### PR TITLE
fix(cron): record failure when the gate blocks every tool call

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -178,6 +178,45 @@ Deterministic cron jobs that bypass the LLM entirely:
 - **Safety**: scripts must live under `~/.kiro/crew/crons/`. `is_sensitive_path()` blocks credential file access. SEL audit on every invocation. Auto-pause after 5 consecutive failures (`_AUTO_PAUSE_THRESHOLD`, single-sourced in `CronJob.record_failure`/`record_success`). The auto-pause is **persistent**: an execution-owned `auto_paused` flag (distinct from `user_paused`) is written by `_save`, propagated by `_merge_job_result`, and folded into the effective `enabled` derivation in `_load` — so a failing job stays paused across a daemon restart; `enable_job(True)` or a later success clears it (SEL-audited transitions). Concurrent execution guard prevents double-fire.
 - **Kind tag**: `cron_list` labels each job as `script`, `command`, or `agent` based on which mode is configured.
 
+#### Auto-pause applies to `agent` (message) crons too
+
+Auto-pause is not script/command-only. An `agent` cron's turn signals failure
+only by raising, so a turn that returns prose carries no verdict of its own even
+when the security gate refused every tool it attempted — the gate outcome has to
+be tallied explicitly. A success resets `consecutive_failures` and clears
+`auto_paused`, so recording one for such a run would keep the guard out of reach
+for a job that cannot work.
+
+Only a block that indicts the attempt itself counts toward that budget. A
+governance denial does not, in either form it takes: the ceiling refusing a tool
+outright, or a built-in rule that the operator disabled and a governance pin put
+back into the effective deny set. Both are policy state, and because clearing an
+auto-pause never restores `enabled`, counting them would strand a job that a
+later loosening of policy could not revive.
+
+Clearing an auto-pause re-enables the job, because `enabled` is derived rather
+than independent: a reload reconstructs it as `not user_paused and not
+auto_paused`. A job left disabled with `auto_paused` already cleared is stopped
+in memory but enabled on disk, so it would stay stopped until the next restart
+silently resumed it. A pause the user set is untouched — `user_paused` is never
+mutated by execution, and lifting it is the user's action.
+
+`stream_and_collect`'s `on_tool_gate` callback reports each tool permission
+decision as `(tool_title, approved, security_blocked)`. Both cron agent paths
+(single-agent and the sequential `agent_sequence` loop) tally those decisions
+per run and route the outcome through one shared verdict: when tools were
+attempted and every one was **security-blocked** with none approved, the run
+sets `last_status = "error"` with a redacted reason and calls `record_failure()`,
+so the same 5-failure `_AUTO_PAUSE_THRESHOLD` applies. Any other outcome records
+a success.
+
+Only an unconditional security block counts. A governance `TOOL_DENY` and an
+unattended-approval timeout also arrive unapproved, but they describe the policy
+state or an absent approver rather than a defect in the job — the same reason the
+fire-time governance denials deliberately skip `record_failure()`. Counting them
+would durably auto-pause a healthy job, since `record_success()` clears
+`auto_paused` but never restores `enabled`.
+
 ### Enabled Predicate & Off-Thread Count (`_record_is_enabled` / `count_enabled_from_disk`)
 
 The effective-enabled predicate of a serialized job — enabled iff neither

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -346,12 +346,23 @@ class CronJob:
     def record_success(self) -> None:
         """Reset the failure counter and lift any execution auto-pause.
 
-        A recovered job clears `auto_paused`; `enabled` is intentionally NOT set
-        back to True here — a job the user paused (`user_paused`) must stay paused
-        across a success, and re-enabling is the user's action (`enable_job`)."""
+        Clearing an auto-pause also re-enables the job, because ``enabled`` is
+        not independent state: :func:`_job_enabled` reconstructs it on load as
+        ``not user_paused and not auto_paused``. Leaving ``enabled`` False after
+        clearing ``auto_paused`` therefore produces a job that is paused in
+        memory and enabled on disk — it stays stopped until the next restart
+        silently resumes it, which is the surprise a manual "Run Now" on an
+        auto-paused job used to create.
+
+        A job the user paused stays paused: ``user_paused`` is never mutated by
+        execution, so it is the discriminator here, and re-enabling THAT is the
+        user's action (``enable_job``).
+        """
         self.consecutive_failures = 0
         if self.auto_paused:
             self.auto_paused = False
+            if not self.user_paused:
+                self.enabled = True
             self._audit_pause_change("auto_pause_cleared")
 
 

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -96,6 +96,17 @@ class HookResult:
 class ToolHookResult:
     action: str  # TOOL_ALLOW, TOOL_AUTO_APPROVE, TOOL_DENY
     reason: str = ""
+    #: True when a TOOL_DENY came from a hard security check — the attempt
+    #: itself is the problem. False when it came from policy STATE (the
+    #: governance ceiling ∩ profile), where the same attempt becomes allowed
+    #: once the policy loosens. Callers that count refusals against a durable
+    #: budget must only count the security kind: an unattended cron auto-pauses
+    #: after repeated failures, and a policy denial is not a defect in the job.
+    #: The reason string cannot carry this: most security denies never contain
+    #: ``DENY_REASON_PREFIX`` at all (the sensitive-path, write-protected-config
+    #: and deny-by-default-shell messages do not), so matching on it would
+    #: classify a sensitive-path or exfiltration deny as non-security.
+    security_deny: bool = True
 
     @staticmethod
     def allow() -> ToolHookResult:
@@ -107,7 +118,18 @@ class ToolHookResult:
 
     @staticmethod
     def deny(reason: str) -> ToolHookResult:
-        return ToolHookResult(action=TOOL_DENY, reason=reason)
+        """Deny on a hard security check — the attempt is the problem."""
+        return ToolHookResult(action=TOOL_DENY, reason=reason, security_deny=True)
+
+    @staticmethod
+    def deny_policy(reason: str) -> ToolHookResult:
+        """Deny on policy STATE, which the same attempt can outlive.
+
+        Kept distinct from :meth:`deny` so a caller counting refusals against a
+        durable budget (cron auto-pause) does not treat a governance ceiling as
+        a defect in what it attempted.
+        """
+        return ToolHookResult(action=TOOL_DENY, reason=reason, security_deny=False)
 
 
 # ── Config Types ──
@@ -615,7 +637,7 @@ class HookManager:
             ctx, tool_name, session_key, agent, app, tool_kind, raw_params
         )
         if gov_reason:
-            return ToolHookResult.deny(gov_reason)
+            return ToolHookResult.deny_policy(gov_reason)
 
         # App-own MCP server auto-approve — a FIRST-PARTY (builtin) app agent
         # calling its OWN app-scoped MCP server is intra-app, not a host surface.
@@ -714,7 +736,7 @@ class HookManager:
                     ctx, canonical_mcp_name, session_key, agent, app, tool_kind, raw_params
                 )
                 if gov_reason:
-                    return ToolHookResult.deny(gov_reason)
+                    return ToolHookResult.deny_policy(gov_reason)
                 return ToolHookResult.auto_approve()
 
         # Auto-approve — match against both the original title (preserves
@@ -812,7 +834,7 @@ class HookManager:
         """
         return resolve_denied_notes(self._config)
 
-    def effective_denied_regexes(self) -> list[str]:
+    def effective_denied_regexes(self, *, include_governance_pins: bool = True) -> list[str]:
         """Public accessor for the effective regex-tier denied set.
 
         Resolves the platform context itself, so callers outside the tool-call
@@ -820,8 +842,14 @@ class HookManager:
         workflow / heartbeat surfaces) can honor the SAME user opt-out +
         governance-pin state that ``on_tool_call`` enforces, instead of failing
         closed to all built-ins and re-introducing "disabled but still blocked".
+
+        Pass ``include_governance_pins=False`` only to CLASSIFY a deny that has
+        already been decided by the pinned set — never to decide one. See
+        ``resolve_effective_denied_regexes``.
         """
-        return self._effective_denied(current_context())
+        return resolve_effective_denied_regexes(
+            self._config, current_context(), include_governance_pins=include_governance_pins
+        )
 
 
 # ACP semantic tool kinds treated as read-only for the non-shell auto-approve
@@ -904,20 +932,29 @@ def hooks_config_from_config_dict(hooks_section: dict) -> HooksConfig:
     return HooksConfig.from_dict(merged)
 
 
-def resolve_effective_denied_regexes(config: "HooksConfig", ctx: object = None) -> list[str]:
+def resolve_effective_denied_regexes(
+    config: "HooksConfig", ctx: object = None, *, include_governance_pins: bool = True
+) -> list[str]:
     """Effective regex-tier denied set from a HooksConfig (module-level).
 
     Same resolution as ``HookManager._effective_denied`` but usable by callers
     that hold a config rather than a HookManager (e.g. cron command vetting in
     ``mcp_cron``). Honors the user opt-out (disable_all / disabled_ids /
     user_added) with governance pins force-re-added (tightest-wins).
+
+    ``include_governance_pins=False`` resolves the set the USER's own opt-out
+    state would produce on its own. Enforcement must never use it — dropping
+    pins is exactly the opt-out a pin exists to refuse. It answers a different
+    question: comparing a deny against both sets tells a caller whether the
+    match came ONLY from a pin, i.e. whether the block is policy state (which a
+    later loosening reverses) or a rule the user is enforcing themselves.
     """
     return security.compute_effective_denied(
         security.BUILTIN_DENIED_RULES,
         config.denied_commands_disabled_ids,
         config.denied_commands_disable_all,
         [p.pattern for p in config.denied_commands_user_added if p.enabled],
-        _governance_pinned_command_ids(ctx),
+        _governance_pinned_command_ids(ctx) if include_governance_pins else (),
     )
 
 

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -442,6 +442,7 @@ async def stream_and_collect(
     on_chunk: Callable[[str], None] | None = None,
     on_tool_approval: Callable[[LLMEvent], Awaitable[bool]] | None = None,
     on_steer_consumed: Callable[[str], None] | None = None,
+    on_tool_gate: Callable[[str, bool, bool], None] | None = None,
     retry_transient: bool = True,
     max_turns: int | None = None,
     session_key: str = "",
@@ -465,6 +466,21 @@ async def stream_and_collect(
             fire-and-forget write, so this echo is the ONLY authoritative signal
             that the backend injected it; a caller that steers must observe this
             to know which of its steers to requeue when the turn ends.
+        on_tool_gate: Optional callback invoked once per tool permission
+            decision with ``(tool_title, approved, security_blocked)``. Lets a
+            caller tell "the model did work" apart from "every tool the model
+            attempted was blocked" — a distinction the returned text cannot
+            carry, because a model whose tools were all refused still returns
+            plausible prose. ``security_blocked`` is True only for the
+            unconditional deny checks (sensitive path, sensitive bash, a deny
+            pattern); a governance ``TOOL_DENY`` and an unattended-approval
+            timeout are refusals that say nothing about the job, so they arrive
+            with ``approved=False`` and ``security_blocked=False``.
+            Delivered when the attempt settles, not mid-stream, and decisions
+            from an abandoned retry attempt are discarded: they describe work
+            the final turn never did. ``tool_title`` is LLM-authored: redact it
+            before display or persistence. Raising from the callback is
+            swallowed; observing a gate decision must never fail the turn.
         retry_transient: When True (default), transient backend errors are
             retried in-place with bounded backoff. Set False from callers that
             already own an outer transient-retry loop, so the inner arm doesn't
@@ -501,6 +517,18 @@ async def stream_and_collect(
         # suppresses the requeue, so dropping the acknowledgement makes the cleanup hand an
         # already-answered question back and ask it twice. Re-initialised per attempt.
         consumed_this_attempt: list[str] = []
+        # Same per-attempt discipline as the steer acknowledgements above, and for the
+        # same reason: a retry re-sends the original message, so decisions from an
+        # abandoned attempt describe work the final turn never did. Committing them
+        # would let a refusal from a discarded attempt outvote a clean retry and fail
+        # a healthy job.
+        gate_this_attempt: list[tuple[str, bool, bool]] = []
+        # Tool calls that reached the gate, and tool calls that actually ran.
+        # A tool auto-approved upstream never raises a permission request, so it
+        # executes without a gate decision: correlating the two by
+        # ``tool_call_id`` is what lets a caller see that work happened.
+        gate_decided_ids: set[str] = set()
+        executed_calls: list[tuple[str, str]] = []
         retrying = False
         try:
             async for event in provider.stream(message):
@@ -509,6 +537,11 @@ async def stream_and_collect(
                     if on_chunk:
                         on_chunk(event.text)
                 elif event.kind == EVENT_PERMISSION_REQUEST:
+                    # Captures this decision's outcome and mechanism, so a hard
+                    # security block is distinguishable from a governance denial
+                    # or an unattended-approval timeout. Only the former says
+                    # anything about the job itself.
+                    _decision: list[tuple[str, str]] = []
                     approved = await _resolve_permission(
                         provider,
                         event,
@@ -518,11 +551,21 @@ async def stream_and_collect(
                         session_key=session_key,
                         agent=agent,
                         app=app,
+                        on_decision=lambda outcome, mech: _decision.append((outcome, mech)),
                     )
+                    if on_tool_gate:
+                        _mech = _decision[-1][1] if _decision else ""
+                        gate_this_attempt.append(
+                            (event.title or "", approved, _mech.startswith("always_deny"))
+                        )
+                        if event.tool_call_id:
+                            gate_decided_ids.add(event.tool_call_id)
                     if not approved:
                         continue
                 elif event.kind == EVENT_TOOL_CALL:
                     tool_call_count += 1
+                    if on_tool_gate:
+                        executed_calls.append((event.tool_call_id or "", event.title or ""))
                     if max_turns is not None and tool_call_count > max_turns:
                         logger.warning(
                             "max_turns=%d exceeded (%d tool calls), breaking",
@@ -640,6 +683,25 @@ async def stream_and_collect(
             if not retrying and on_steer_consumed:
                 for consumed_text in consumed_this_attempt:
                     on_steer_consumed(consumed_text)
+            if not retrying and on_tool_gate:
+                for gate_title, gate_approved, gate_blocked in gate_this_attempt:
+                    try:
+                        on_tool_gate(gate_title, gate_approved, gate_blocked)
+                    except Exception:
+                        # A caller's bookkeeping must never abort the turn.
+                        logger.debug("on_tool_gate callback failed", exc_info=True)
+                # A tool that executed without a matching gate decision was
+                # permitted upstream, so it counts as an approval: work happened.
+                # An id-less execution cannot be correlated, so it counts too —
+                # over-reporting work risks a missed detection, under-reporting
+                # it fails a job that did something.
+                for _exec_id, _exec_title in executed_calls:
+                    if _exec_id and _exec_id in gate_decided_ids:
+                        continue
+                    try:
+                        on_tool_gate(_exec_title, True, False)
+                    except Exception:
+                        logger.debug("on_tool_gate callback failed", exc_info=True)
 
 
 async def stream_and_collect_json(
@@ -667,12 +729,33 @@ async def _resolve_permission(
     session_key: str = "",
     agent: str = "",
     app: str = "",
+    on_decision: Callable[[str, str], None] | None = None,
 ) -> bool:
-    """Resolve a tool permission request. Returns True if approved."""
+    """Resolve a tool permission request. Returns True if approved.
+
+    *on_decision*, when given, receives ``(outcome, mechanism)`` for the single
+    decision this call makes — the same pair that reaches the SEL audit row.
+    ``mechanism`` is one of ``"always_deny"`` / ``"always_deny_input"`` (the
+    unconditional checks), ``"always_deny_hook"`` (a HookManager security deny),
+    ``"policy_deny"`` (the governance ceiling, whether reached through the hook
+    gate or through a regex-tier rule that only a governance PIN put back into
+    the effective set), or ``""`` for an approval or an interactive rejection.
+    The ``always_deny`` prefix is therefore what marks a refusal as "the attempt
+    itself was the problem"; everything else describes policy state or an absent
+    approver. Note that the same regex match can land under either label — what
+    decides it is whether the rule survives without its pin.
+    """
     from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
     from kiro_crew.sel import sel
 
     def _log(outcome: str, **extra):
+        # Single funnel for every decision path, so the sink cannot miss one.
+        if on_decision is not None:
+            _meta = extra.get("metadata") or {}
+            try:
+                on_decision(outcome, str(_meta.get("mechanism") or ""))
+            except Exception:
+                logger.debug("on_decision sink failed", exc_info=True)
         sel().log_tool_invocation(
             session_key=session_key,
             agent=agent,
@@ -716,10 +799,42 @@ async def _resolve_permission(
     # re-introduce "disabled but still blocked" on every non-dashboard surface.
     # No HookManager (rare) → None → fail-closed default (all built-ins).
     _denied_regexes = hooks.effective_denied_regexes() if hooks is not None else None
+
+    def _regex_deny_mechanism(probe: str, unconditional: str) -> str:
+        """Classify an already-decided regex-tier deny by its provenance.
+
+        A governance pin re-adds a built-in rule the user disabled, so the SAME
+        match can mean either "this host enforces this rule" or "policy
+        currently overrides this host's opt-out". Only the former says anything
+        about the tool being attempted; treating the latter as a security block
+        durably auto-pauses a cron that a later policy loosening cannot revive,
+        because clearing the pause never restores ``enabled``.
+
+        Re-runs the match against the pin-free set — deny path only, so the
+        common allow path pays nothing — and reports a match that survives ONLY
+        with pins as policy state.
+        """
+        if hooks is None:
+            return unconditional
+        try:
+            _unpinned = hooks.effective_denied_regexes(include_governance_pins=False)
+        except Exception:
+            # Classification must never change the deny itself. An unresolvable
+            # opt-out state falls back to the unconditional label: over-counting
+            # a block is recoverable by an operator, silently not counting one
+            # restores the runaway this gate exists to catch.
+            logger.debug("deny provenance unresolved; reporting unconditional", exc_info=True)
+            return unconditional
+        return unconditional if is_denied(probe, denied_regexes=_unpinned) else "policy_deny"
+
     _deny_reason = is_denied(normalized, denied_regexes=_denied_regexes)
     if _deny_reason:
         await provider.reject_tool(event.request_id)
-        _log("denied", error=_deny_reason, metadata={"mechanism": "always_deny"})
+        _log(
+            "denied",
+            error=_deny_reason,
+            metadata={"mechanism": _regex_deny_mechanism(normalized, "always_deny")},
+        )
         return False
 
     # Defense-in-depth: also inspect event.tool_input for sensitive paths/commands.
@@ -747,7 +862,11 @@ async def _resolve_permission(
             _input_deny = is_denied(s, denied_regexes=_denied_regexes)
             if _input_deny:
                 await provider.reject_tool(event.request_id)
-                _log("denied", error=_input_deny, metadata={"mechanism": "always_deny_input"})
+                _log(
+                    "denied",
+                    error=_input_deny,
+                    metadata={"mechanism": _regex_deny_mechanism(s, "always_deny_input")},
+                )
                 return False
 
     if policy == ToolApprovalPolicy.HOOK_BASED and hooks:
@@ -763,7 +882,19 @@ async def _resolve_permission(
         )
         if tool_result.action == TOOL_DENY:
             await provider.reject_tool(event.request_id)
-            _log("denied", error=tool_result.reason)
+            # A hook deny is either a hard security check or the governance
+            # ceiling. Only the former says the attempt itself was the problem,
+            # and the distinction rides on the result's own field rather than
+            # its reason text.
+            _log(
+                "denied",
+                error=tool_result.reason,
+                metadata={
+                    "mechanism": (
+                        "always_deny_hook" if tool_result.security_deny else "policy_deny"
+                    )
+                },
+            )
             return False
         if tool_result.action == TOOL_AUTO_APPROVE:
             await provider.approve_tool(event.request_id)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -617,6 +617,89 @@ def _build_heartbeat_hooks(user_hooks: HookManager) -> HookManager:
     return HookManager(scoped)
 
 
+class _GateTally:
+    """Tool-gate outcomes accumulated over one cron run.
+
+    A cron whose every tool call was refused still gets prose back from the
+    model, so the reply text alone cannot separate "did the work" from "was
+    blocked at every step". Counting both arms is what makes that verdict
+    available once the turn ends. A multi-agent run tallies across the whole
+    sequence, because status and history are per-run, not per-agent.
+
+    Only an unconditional security block counts as a refusal here. A governance
+    denial and an unattended-approval timeout also arrive unapproved, but they
+    describe the policy state or an absent approver rather than a defect in the
+    job — and a job's failure counter drives auto-pause, which is durable.
+    """
+
+    def __init__(self) -> None:
+        self.refused: list[str] = []
+        self.approved = 0
+        self.unresolved = 0
+
+    def note(self, title: str, approved: bool, security_blocked: bool) -> None:
+        if approved:
+            self.approved += 1
+        elif security_blocked:
+            self.refused.append(title)
+        else:
+            self.unresolved += 1
+
+    @property
+    def all_blocked(self) -> bool:
+        """Every tool the turn attempted was security-blocked, and none ran.
+
+        ``unresolved`` must be zero, not merely uncounted: a governance denial
+        or an approval timeout alongside a security block leaves the run's real
+        capability unknown — that tool might have succeeded with a looser policy
+        or a present approver — so the run does not evidence a job that cannot
+        work. Treating it as evidence would auto-pause a healthy job.
+        """
+        return bool(self.refused) and self.approved == 0 and self.unresolved == 0
+
+
+def _apply_gate_verdict(job: CronJob, tally: _GateTally) -> bool:
+    """Record a finished cron run's success or failure from its gate outcomes.
+
+    Shared by both cron agent paths so their verdicts cannot drift. Mutating
+    ``last_status`` is how the non-raising cron paths signal failure:
+    ``CronScheduler._execute`` keeps an explicit "error" rather than
+    overwriting it with "ok".
+
+    Returns whether this call counted a failure, because a run must increment
+    ``consecutive_failures`` **at most once**. On the single-agent path the
+    delivery work that follows (dashboard broadcast, Slack post) runs inside a
+    ``try`` whose handler counts too, so a blocked turn whose delivery then
+    failed would otherwise reach the auto-pause threshold in three runs rather
+    than five — pausing on arithmetic instead of on evidence.
+    """
+    if tally.all_blocked:
+        # Nothing the model attempted was permitted, so the run accomplished
+        # nothing however plausible its reply reads. A success resets
+        # consecutive_failures and clears auto_paused, so recording one here
+        # would keep a structurally-failing job firing on its schedule forever.
+        job.last_status = "error"
+        _named = ", ".join(t or "<untitled tool>" for t in tally.refused[:3])
+        job.last_error = redact(
+            f"all {len(tally.refused)} tool call(s) blocked by the security gate: " + _named
+        )[:500]
+        job.record_failure()
+        if job.auto_paused:
+            logger.warning(
+                "Cron '%s': auto-paused after %d consecutive failures",
+                job.name,
+                job.consecutive_failures,
+            )
+        return True
+    # Clear failure dedup on any success, regardless of whether the success
+    # result itself is a dup. A successful run means the job recovered — next
+    # failure should always alert fresh.
+    job.last_failure_hash = ""
+    job.last_failure_at = 0.0
+    job.record_success()
+    return False
+
+
 def _result_hash(text: str) -> str:
     """Normalize volatile data and return a 16-hex-char SHA-256 prefix.
 
@@ -2433,6 +2516,9 @@ class GatewayOrchestrator:
                 assert self.ctx_builder is not None
                 result_text = "_No response._"
                 _seq_downgraded = False
+                # Run-scoped: a sequence where one agent got a tool through has
+                # done work, even if a later agent was blocked outright.
+                _gate = _GateTally()
                 for agent in agents:
                     agent_session_key = f"cron:{job.id}:{agent}"
                     if self.cron_svc is not None:
@@ -2483,6 +2569,7 @@ class GatewayOrchestrator:
                                 if job.approval_mode == "auto"
                                 else self._interactive_approval("cron")
                             ),
+                            on_tool_gate=_gate.note,
                         )
                         if not result_text:
                             result_text = "_No response._"
@@ -2546,6 +2633,10 @@ class GatewayOrchestrator:
                 if _seq_downgraded:
                     result_text = _annotate_model_downgrade(result_text)
                 job.set_run_result(result_text)
+                # This path owns the same verdict as the single-agent one, so a
+                # multi-agent job's failure counter moves in both directions —
+                # which is what keeps auto-pause both reachable and clearable.
+                _apply_gate_verdict(job, _gate)
                 return result_text
 
             # ── Single-agent path (existing behavior) ──
@@ -2555,6 +2646,9 @@ class GatewayOrchestrator:
 
             _acquired = False
             _model_downgraded = False
+            # Set when the gate verdict below already counted this run, so the
+            # exception handler does not count it a second time.
+            _gate_counted = False
             try:
                 assert self.sessions is not None
                 assert self.ctx_builder is not None
@@ -2587,6 +2681,7 @@ class GatewayOrchestrator:
                 # Wall clock for the cron agent turn — see the sequential site
                 # above. acp reports no duration, so this is the row's fallback.
                 _turn_t0 = time.monotonic()
+                _gate = _GateTally()
                 result_text = await stream_and_collect(
                     client,
                     full_message,
@@ -2599,6 +2694,7 @@ class GatewayOrchestrator:
                     on_tool_approval=(
                         None if job.approval_mode == "auto" else self._interactive_approval("cron")
                     ),
+                    on_tool_gate=_gate.note,
                 )
 
                 if not result_text:
@@ -2640,12 +2736,7 @@ class GatewayOrchestrator:
                 # Suppress Slack for repeated identical results to avoid spam.
                 rh = _result_hash(result_text)
 
-                # Clear failure dedup on any success, regardless of whether
-                # the success result itself is a dup. A successful run means
-                # the job recovered — next failure should always alert fresh.
-                job.last_failure_hash = ""
-                job.last_failure_at = 0.0
-                job.record_success()
+                _gate_counted = _apply_gate_verdict(job, _gate)
 
                 if rh == job.last_posted_hash:
                     job.consecutive_dupes += 1
@@ -2876,8 +2967,12 @@ class GatewayOrchestrator:
                 if is_dup and time.time() - job.last_failure_at < _FAILURE_REMINDER_SECS:
                     # record_failure() is the counter's sole owner: a suppressed
                     # duplicate is still a failed run, so it must count toward
-                    # the auto-pause threshold like every other failure path.
-                    job.record_failure()
+                    # the auto-pause threshold like every other failure path —
+                    # unless the gate verdict already counted THIS run, in which
+                    # case counting again would pause on arithmetic rather than
+                    # on five distinct failures.
+                    if not _gate_counted:
+                        job.record_failure()
                     if job.auto_paused:
                         logger.warning(
                             "Cron '%s' auto-paused after %d consecutive failures",
@@ -2994,8 +3089,10 @@ class GatewayOrchestrator:
                 # must still reach the auto-pause threshold. It runs AFTER the
                 # awaited Slack attempt so a timeout cancelling this handler
                 # mid-alert cannot leave the run counted here AND again by the
-                # timeout handler.
-                job.record_failure()
+                # timeout handler. For the same reason it defers when the gate
+                # verdict already counted THIS run.
+                if not _gate_counted:
+                    job.record_failure()
                 if job.auto_paused:
                     logger.warning(
                         "Cron '%s' auto-paused after %d consecutive failures",

--- a/test/test_cron_refusal_status.py
+++ b/test/test_cron_refusal_status.py
@@ -1,0 +1,441 @@
+"""A cron run whose every tool call was security-blocked must record failure.
+
+The model still returns plausible prose when the security gate blocks every tool
+it tries, so the reply text cannot carry the verdict. A success resets
+``consecutive_failures`` and clears ``auto_paused``, so recording one here would
+keep the auto-pause guard permanently out of reach for a job that is
+structurally incapable of succeeding. These tests pin the verdict AND the guard
+it depends on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.cron import _AUTO_PAUSE_THRESHOLD, CronJob, CronSchedule
+
+# (title, approved, security_blocked) triples a turn's tool gate reports.
+GateScript = list[tuple[str, bool, bool]]
+
+# The two refusal classes the verdict must treat differently.
+BLOCKED = ("rm -rf /", False, True)
+UNAPPROVED = ("Read README.md", False, False)
+APPROVED = ("Read README.md", True, False)
+
+
+def _run_cron_runs(
+    gate: GateScript,
+    runs: int = 1,
+    approval_mode: str = "",
+    agent_sequence: list[str] | None = None,
+    per_agent: dict[str, GateScript] | None = None,
+    job: CronJob | None = None,
+    deliver_raises: bool = False,
+) -> CronJob:
+    """Drive the real ``_cron_callback`` *runs* times, replaying *gate* each turn.
+
+    *per_agent* overrides *gate* for named agents, so a sequence can be scripted
+    asymmetrically — replaying one script for every agent makes a per-agent tally
+    and a run-scoped one reach the same verdict, so nothing distinguishes them.
+
+    *job* reuses an existing job across calls, which is what makes a recovery
+    assertion meaningful: a fresh job's counter reads 0 either way.
+    """
+    from kiro_crew.slack.gateway import GatewayOrchestrator
+
+    gw = GatewayOrchestrator.__new__(GatewayOrchestrator)
+    gw.sessions = MagicMock()
+    gw.sessions.get_pid = MagicMock(return_value=None)
+    gw.ctx_builder = MagicMock()
+    gw.slack = MagicMock()
+    gw.conv_log = None
+    gw.dashboard_state = None
+    gw._owner_id = "U000"
+    gw.subagent_mgr = None
+    gw._cron_injecting = {}
+    gw._no_crons = False
+    gw.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), True, False))
+    gw.sessions.release = MagicMock()
+    gw.sessions.reset = AsyncMock()
+    gw.sessions.cancel_current = AsyncMock()
+    gw.ctx_builder.build_message = MagicMock(return_value=("msg", None))
+    gw.ctx_builder.hooks = MagicMock()
+    gw._interactive_approval = MagicMock(return_value="interactive_cb")
+    if deliver_raises:
+        # Fails the dashboard history read that runs AFTER the gate verdict and
+        # is NOT wrapped in a local handler (the Slack post below it is), so the
+        # enclosing handler sees an exception on a run the verdict already
+        # counted. This is the reachable shape of the double count.
+        ds = MagicMock()
+        ds.has_slot = MagicMock(return_value=True)
+        ds.conversation_log.read_messages = MagicMock(
+            side_effect=RuntimeError("history read failed")
+        )
+        gw.dashboard_state = ds
+
+    seq = list(agent_sequence or [])
+    turn = {"n": 0}
+
+    async def fake_stream(client, msg, **kwargs):
+        report: Callable[[str, bool, bool], None] | None = kwargs.get("on_tool_gate")
+        assert report is not None, "the cron path must observe its tool-gate decisions"
+        script = gate
+        if per_agent and seq:
+            script = per_agent.get(seq[turn["n"] % len(seq)], gate)
+        turn["n"] += 1
+        for title, approved, blocked in script:
+            report(title, approved, blocked)
+        # A blocked turn still produces prose — that is the whole problem.
+        return "I was unable to complete the requested changes."
+
+    if job is None:
+        job = CronJob(
+            id="g1",
+            name="selfheal",
+            message="go",
+            schedule=CronSchedule(kind="every", every_secs=900),
+            approval_mode=approval_mode,
+            agent_sequence=seq,
+        )
+
+    captured_cb = None
+
+    with patch("kiro_crew.slack.gateway.stream_and_collect", fake_stream), patch(
+        "kiro_crew.slack.gateway.CronService"
+    ) as mock_cron_cls:
+
+        def capture_cron(on_job=None, **kw):
+            nonlocal captured_cb
+            captured_cb = on_job
+            svc = MagicMock()
+            svc.start = AsyncMock()
+            return svc
+
+        mock_cron_cls.create = AsyncMock(side_effect=capture_cron)
+
+        async def _init_and_run():
+            await gw._init_cron()
+            assert captured_cb is not None
+            for _ in range(runs):
+                await captured_cb(job)
+
+        asyncio.run(_init_and_run())
+
+    return job
+
+
+def test_a_fully_blocked_run_records_error() -> None:
+    job = _run_cron_runs([BLOCKED, ("cat ~/.ssh/id_rsa", False, True)])
+
+    assert job.last_status == "error", "a run that accomplished nothing recorded success"
+    assert job.consecutive_failures == 1
+    assert "blocked by the security gate" in job.last_error
+
+
+def test_a_fully_blocked_run_names_the_refused_count() -> None:
+    """The operator has to be able to tell WHY the job failed from the job list."""
+    job = _run_cron_runs([("a", False, True), ("b", False, True), ("c", False, True)])
+
+    assert "all 3 tool call(s) blocked" in job.last_error
+
+
+def test_a_run_that_got_one_tool_through_is_a_success() -> None:
+    """Blocked-then-adapted is the normal, healthy path — it must not be a failure."""
+    job = _run_cron_runs([BLOCKED, APPROVED])
+
+    assert job.last_status != "error"
+    assert job.consecutive_failures == 0
+
+
+def test_a_tool_free_run_is_still_a_success() -> None:
+    """Plenty of crons only summarize or notify. No gate decisions must read as clean."""
+    job = _run_cron_runs([])
+
+    assert job.last_status != "error"
+    assert job.consecutive_failures == 0
+
+
+def test_an_unapproved_run_is_not_a_failure() -> None:
+    """An unattended cron's approval request deny-fasts on a timeout, arriving
+    unapproved but not security-blocked. Counting it would fail — and after
+    five runs durably auto-pause — a job whose only problem is that no approver
+    was present, and the fire-time governance denials in the same function
+    deliberately keep policy state out of the failure counter for this reason.
+    """
+    job = _run_cron_runs([UNAPPROVED], runs=_AUTO_PAUSE_THRESHOLD)
+
+    assert job.last_status != "error"
+    assert job.consecutive_failures == 0
+    assert job.auto_paused is False
+    assert job.enabled is True
+
+
+def test_a_mixed_refusal_run_is_not_a_failure() -> None:
+    """A security block ALONGSIDE an unresolved refusal proves nothing.
+
+    The unresolved tool might have run under a looser policy or with an approver
+    present, so the run does not evidence a job that cannot work — and counting
+    it would auto-pause a healthy one.
+    """
+    job = _run_cron_runs([BLOCKED, UNAPPROVED], runs=_AUTO_PAUSE_THRESHOLD)
+
+    assert job.last_status != "error"
+    assert job.consecutive_failures == 0
+    assert job.auto_paused is False
+    assert job.enabled is True
+
+
+def test_a_blocked_run_counts_once_even_when_delivery_fails() -> None:
+    """One run must move the failure counter by exactly one.
+
+    The gate verdict and the enclosing exception handler are two writers to the
+    same counter. A blocked turn whose dashboard history read then fails reaches
+    both — that read sits after the verdict and, unlike the Slack post below it,
+    carries no local handler. Counting twice would trip the auto-pause threshold
+    in three runs instead of five, pausing a job on arithmetic rather than on
+    five distinct failures.
+
+    The handler re-raises after counting (that is how ``CronScheduler._execute``
+    learns the run failed), so the job is created here to survive the raise.
+    """
+    job = CronJob(
+        id="g1",
+        name="selfheal",
+        message="go",
+        schedule=CronSchedule(kind="every", every_secs=900),
+    )
+
+    with pytest.raises(RuntimeError, match="history read failed"):
+        _run_cron_runs([("Read /etc/shadow", False, True)], job=job, deliver_raises=True)
+
+    assert (
+        job.consecutive_failures == 1
+    ), f"a single blocked run was counted {job.consecutive_failures} times"
+
+
+def test_clearing_an_auto_pause_re_enables_the_job() -> None:
+    """``enabled`` is not independent state, so it must move with the pause.
+
+    ``_job_enabled`` reconstructs it on load as ``not user_paused and not
+    auto_paused``. A job left disabled-but-not-auto-paused is paused in memory
+    and enabled on disk, so it stays stopped until a restart silently resumes
+    it — the surprise a manual run on an auto-paused job used to create.
+    """
+    job = CronJob(
+        id="g1",
+        name="selfheal",
+        message="go",
+        schedule=CronSchedule(kind="every", every_secs=900),
+    )
+    job.auto_paused = True
+    job.enabled = False
+
+    job.record_success()
+
+    assert job.auto_paused is False
+    assert job.enabled is True, "a cleared auto-pause left the job stopped until a restart"
+
+
+def test_clearing_an_auto_pause_respects_a_user_pause() -> None:
+    """Re-enabling a job the user paused is the user's action, not a run's."""
+    job = CronJob(
+        id="g1",
+        name="selfheal",
+        message="go",
+        schedule=CronSchedule(kind="every", every_secs=900),
+    )
+    job.auto_paused = True
+    job.enabled = False
+    job.user_paused = True
+
+    job.record_success()
+
+    assert job.auto_paused is False
+    assert job.enabled is False, "a success overrode the user's own pause"
+
+
+def test_a_success_leaves_the_persisted_enabled_invariant_intact() -> None:
+    """The in-memory flag must agree with what a reload would compute."""
+    job = CronJob(
+        id="g1",
+        name="selfheal",
+        message="go",
+        schedule=CronSchedule(kind="every", every_secs=900),
+    )
+    job.auto_paused = True
+    job.enabled = False
+
+    job.record_success()
+
+    assert job.enabled == (not job.user_paused and not job.auto_paused)
+
+
+def test_repeated_fully_blocked_runs_auto_pause_the_job() -> None:
+    """A job that cannot succeed stops re-firing once it crosses the threshold."""
+    job = _run_cron_runs([BLOCKED], runs=_AUTO_PAUSE_THRESHOLD)
+
+    assert job.consecutive_failures == _AUTO_PAUSE_THRESHOLD
+    assert job.auto_paused is True
+    assert job.enabled is False
+
+
+def test_one_run_short_of_the_threshold_stays_enabled() -> None:
+    """The guard must not fire early — that would pause healthy-but-flaky jobs."""
+    job = _run_cron_runs([BLOCKED], runs=_AUTO_PAUSE_THRESHOLD - 1)
+
+    assert job.auto_paused is False
+    assert job.enabled is True
+
+
+def test_a_success_after_blocked_runs_clears_the_counter() -> None:
+    """Recovery works: a job is not permanently marked once it succeeds again.
+
+    The clean run reuses the SAME job — a fresh one reads 0 either way, so it
+    would assert nothing about the success arm.
+    """
+    job = _run_cron_runs([BLOCKED], runs=2)
+    assert job.consecutive_failures == 2
+
+    _run_cron_runs([APPROVED], job=job)
+    assert job.consecutive_failures == 0
+
+
+def test_auto_mode_applies_the_verdict_too() -> None:
+    """approval_mode="auto" takes the AUTO_APPROVE branch, which still passes
+    on_tool_gate and still applies the verdict. The always-enforced deny checks
+    that make a refusal reachable there live in _resolve_permission, which this
+    harness replaces — test_llm_helpers_tool_gate covers that half."""
+    job = _run_cron_runs([BLOCKED], approval_mode="auto")
+
+    assert job.last_status == "error"
+    assert job.consecutive_failures == 1
+
+
+class TestMultiAgentSequence:
+    """The sequential (agent_sequence) path carries the same verdict as the
+    single-agent one, so a multi-agent job's failure counter moves in both
+    directions and auto-pause is both reachable and clearable there."""
+
+    _AGENTS = ["researcher", "coder"]
+
+    def test_a_fully_blocked_sequence_records_error(self) -> None:
+        job = _run_cron_runs([BLOCKED], agent_sequence=self._AGENTS)
+
+        assert job.last_status == "error"
+        assert job.consecutive_failures == 1
+        assert "blocked by the security gate" in job.last_error
+
+    def test_the_tally_spans_the_whole_sequence(self) -> None:
+        """Scripted asymmetrically on purpose: agent 1 gets a tool through and
+        agent 2 is blocked outright. A per-agent tally would fail agent 2 and
+        record an error; a run-scoped one sees the run did work."""
+        job = _run_cron_runs(
+            [],
+            agent_sequence=self._AGENTS,
+            per_agent={"researcher": [APPROVED], "coder": [BLOCKED]},
+        )
+
+        assert job.last_status != "error", "the tally is per-agent, not per-run"
+        assert job.consecutive_failures == 0
+
+    def test_repeated_blocked_sequences_auto_pause(self) -> None:
+        job = _run_cron_runs(
+            [BLOCKED],
+            runs=_AUTO_PAUSE_THRESHOLD,
+            agent_sequence=self._AGENTS,
+        )
+
+        assert job.auto_paused is True
+        assert job.enabled is False
+
+    def test_a_clean_sequence_clears_a_prior_auto_pause(self) -> None:
+        """The arm that makes the failure arm safe: without a success arm on this
+        path, auto_paused set here could never be lifted."""
+        job = _run_cron_runs(
+            [BLOCKED],
+            runs=_AUTO_PAUSE_THRESHOLD,
+            agent_sequence=self._AGENTS,
+        )
+        assert job.auto_paused is True
+
+        job.enabled = True
+        _run_cron_runs([APPROVED], agent_sequence=self._AGENTS, job=job)
+
+        assert job.auto_paused is False
+        assert job.consecutive_failures == 0
+
+
+class TestSchedulerContract:
+    """The cron callback signals failure by MUTATING last_status rather than
+    raising, so these pin the two scheduler behaviors that verdict rides on.
+    Neither is covered elsewhere, and either one changing would silently restore
+    a success verdict for a run that did nothing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_execute_preserves_an_explicit_error_from_the_callback(self, tmp_path) -> None:
+        """``_execute`` sets "ok" only when the callback did not claim an error.
+
+        Without this guard the LLM path's mutation would be overwritten to "ok"
+        on the way out and the run would report success again.
+        """
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path)
+
+        async def blocked_cb(job):
+            job.last_status = "error"
+            job.last_error = "all 1 tool call(s) blocked by the security gate: rm -rf /"
+            return "prose the model produced anyway"
+
+        svc._on_job = blocked_cb
+        job = svc.add_job("blocked", "go", every_secs=900)
+        await svc._execute(job)
+
+        assert job.last_status == "error", "the callback's verdict was overwritten"
+        assert "blocked by the security gate" in job.last_error
+
+    @pytest.mark.asyncio
+    async def test_an_error_status_becomes_a_failure_history_record(self, tmp_path) -> None:
+        """The history status is derived from last_status; pin the mapping so the
+        operator-visible run log keeps reflecting a blocked run as a failure."""
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path)
+        svc._history.append = AsyncMock()
+
+        async def blocked_cb(job):
+            job.last_status = "error"
+            job.last_error = "all 2 tool call(s) blocked by the security gate: a, b"
+            return "prose"
+
+        svc._on_job = blocked_cb
+        job = svc.add_job("blocked", "go", every_secs=900)
+        await svc._run_job_isolated(job)
+
+        assert svc._history.append.await_count == 1
+        record = svc._history.append.await_args.args[0]
+        assert record.status == "failure"
+
+    @pytest.mark.asyncio
+    async def test_a_clean_run_still_becomes_a_success_history_record(self, tmp_path) -> None:
+        """The control for the test above — healthy runs must stay "success"."""
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path)
+        svc._history.append = AsyncMock()
+
+        async def clean_cb(job):
+            return "all good"
+
+        svc._on_job = clean_cb
+        job = svc.add_job("okjob", "go", every_secs=900)
+        await svc._run_job_isolated(job)
+
+        assert svc._history.append.await_count == 1
+        record = svc._history.append.await_args.args[0]
+        assert record.status == "success"

--- a/test/test_deny_pin_provenance.py
+++ b/test/test_deny_pin_provenance.py
@@ -1,0 +1,97 @@
+"""A regex-tier deny that only a governance PIN produced is policy state.
+
+A governance pin re-adds a built-in rule the user disabled, so the same match
+carries two different meanings: the host enforces this rule, or policy currently
+overrides the host's opt-out. Only the first says anything about the tool being
+attempted.
+
+The distinction is load-bearing because a cron counts security blocks toward a
+durable auto-pause that clears ``auto_paused`` without restoring ``enabled`` —
+so mislabeling policy state strands a job that a later loosening cannot revive.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from kiro_crew import hooks as hooks_mod
+from kiro_crew import security
+from kiro_crew.hooks import HookManager, HooksConfig
+from kiro_crew.platform import context as ctx_mod
+
+_PINNED_ID = "credential-exfil-s3-cp"
+
+
+def _manager_with_rule_disabled() -> HookManager:
+    """A host whose operator opted OUT of one built-in rule."""
+    mgr = HookManager()
+    mgr._config = HooksConfig.from_dict(
+        {"denied_commands": {"disabled_ids": [_PINNED_ID], "disable_all": False}}
+    )
+    return mgr
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    yield
+    ctx_mod.reset_context()
+
+
+def _pattern_of(rule_id: str) -> str:
+    return next(r.pattern for r in security.BUILTIN_DENIED_RULES if r.id == rule_id)
+
+
+def test_a_pin_re_adds_the_rule_the_user_disabled(monkeypatch) -> None:
+    """The enforcement set is unchanged: tightest-wins still holds."""
+    monkeypatch.setattr(security, "pinned_builtin_command_ids", lambda: {_PINNED_ID})
+    mgr = _manager_with_rule_disabled()
+
+    assert _pattern_of(_PINNED_ID) in mgr.effective_denied_regexes()
+
+
+def test_the_pin_free_set_omits_it(monkeypatch) -> None:
+    """The classification set reflects the user's own opt-out alone.
+
+    This is the difference the mechanism label is derived from — it must never
+    be used to DECIDE a deny, only to explain one.
+    """
+    monkeypatch.setattr(security, "pinned_builtin_command_ids", lambda: {_PINNED_ID})
+    mgr = _manager_with_rule_disabled()
+
+    assert _pattern_of(_PINNED_ID) not in mgr.effective_denied_regexes(
+        include_governance_pins=False
+    )
+
+
+def test_a_rule_the_user_still_enforces_appears_in_both(monkeypatch) -> None:
+    """Without an opt-out there is no provenance question to answer."""
+    monkeypatch.setattr(security, "pinned_builtin_command_ids", lambda: {_PINNED_ID})
+    mgr = HookManager()
+
+    pattern = _pattern_of(_PINNED_ID)
+    assert pattern in mgr.effective_denied_regexes()
+    assert pattern in mgr.effective_denied_regexes(include_governance_pins=False)
+
+
+def test_an_ungoverned_host_resolves_both_sets_identically() -> None:
+    """The common case pays no behavioral difference."""
+    mgr = HookManager()
+
+    assert mgr.effective_denied_regexes() == mgr.effective_denied_regexes(
+        include_governance_pins=False
+    )
+
+
+def test_the_resolver_keeps_pins_by_default() -> None:
+    """Enforcement callers that pass nothing must still get the pinned set."""
+    cfg = HooksConfig.from_dict(
+        {"denied_commands": {"disabled_ids": [_PINNED_ID], "disable_all": False}}
+    )
+    ctx = dataclasses.replace(ctx_mod.current_context())
+
+    with_default = hooks_mod.resolve_effective_denied_regexes(cfg, ctx)
+    explicit = hooks_mod.resolve_effective_denied_regexes(cfg, ctx, include_governance_pins=True)
+
+    assert with_default == explicit

--- a/test/test_hook_deny_classification.py
+++ b/test/test_hook_deny_classification.py
@@ -1,0 +1,83 @@
+"""``ToolHookResult.security_deny`` must distinguish the two deny classes.
+
+A cron counts security-blocked tools against a durable auto-pause budget, so the
+distinction has to hold at its source: a governance ceiling denial is policy
+state that a later loosening reverses, while a sensitive-path or deny-pattern
+block is a defect in what was attempted.
+
+These tests drive a REAL ``HookManager`` against a real policy rather than a
+mock, because the value under test is chosen inside ``hooks.on_tool_call`` — a
+suite that stubs that method stays green whichever constructor it calls, which
+leaves the shared-type half of the contract unpinned.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from kiro_crew.hooks import TOOL_DENY, HookManager
+from kiro_crew.platform import context as ctx_mod
+from kiro_crew.platform import governance_profiles as gp
+from kiro_crew.platform.bootstrap import build_default_context
+from kiro_crew.platform.governance import parse_policy
+
+
+def _install(policy_body) -> None:
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    base = build_default_context(KiroCrewConfig.load())
+    ceiling = parse_policy(policy_body) if policy_body is not None else None
+    ctx_mod.set_context(dataclasses.replace(base, governance=ceiling))
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    d = tmp_path / "profiles"
+    d.mkdir()
+    monkeypatch.setattr(gp, "_PROFILES_DIR", d)
+    gp.reset_store()
+    yield
+    gp.reset_store()
+    ctx_mod.reset_context()
+
+
+def test_a_governance_ceiling_denial_is_not_a_security_deny() -> None:
+    """Policy state, so a caller counting toward auto-pause must skip it.
+
+    Denies on the ``commands`` scope rather than a filesystem path: a path glob
+    resolves against host path semantics, so the same assertion would describe a
+    different code path on Windows than on POSIX.
+    """
+    _install(
+        {
+            "version": 1,
+            "boot": {"fail_closed": True},
+            "commands": {"mode": "deny", "deny": ["*backdoor*"]},
+        }
+    )
+
+    result = HookManager().on_tool_call("Running: install-backdoor --now", session_key="cli_chat")
+
+    assert result.action == TOOL_DENY
+    assert result.security_deny is False, (
+        "a governance denial reported as a security block would durably "
+        "auto-pause a healthy cron"
+    )
+
+
+def test_a_sensitive_path_denial_is_a_security_deny() -> None:
+    """The unconditional keystone: the attempt itself is the problem."""
+    result = HookManager().on_tool_call("Reading /home/u/.ssh/id_rsa", session_key="cli_chat")
+
+    assert result.action == TOOL_DENY
+    assert result.security_deny is True
+
+
+def test_a_deny_pattern_block_is_a_security_deny() -> None:
+    """The route that produced the original silent-cost bug."""
+    result = HookManager().on_tool_call("Running: rm -rf /", session_key="cli_chat")
+
+    assert result.action == TOOL_DENY
+    assert result.security_deny is True

--- a/test/test_llm_helpers_tool_gate.py
+++ b/test/test_llm_helpers_tool_gate.py
@@ -1,0 +1,421 @@
+"""``stream_and_collect`` must report every tool-gate decision to its caller.
+
+A model whose tool calls were all refused still returns plausible prose, so the
+returned text cannot tell a caller whether any work actually happened. Cron
+relies on this callback to record a fully-blocked run as a failure instead of a
+success — and a success there resets the auto-pause counter, so a job that can
+never succeed would re-fire forever. Testing against the REAL implementation
+matters because every caller fakes this helper in its own tests: the hook could
+be dead at runtime while all of them stayed green.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew import llm_helpers
+from kiro_crew.acp.client import AcpError
+from kiro_crew.llm_helpers import ToolApprovalPolicy, stream_and_collect
+from kiro_crew.providers.base import (
+    EVENT_COMPLETE,
+    EVENT_PERMISSION_REQUEST,
+    EVENT_TEXT_CHUNK,
+    EVENT_TOOL_CALL,
+    LLMEvent,
+)
+
+
+async def _no_sleep(_seconds: float) -> None:
+    """Collapse the retry backoff so the retry test stays fast."""
+    return None
+
+# Tripped by the always-enforced deny checks in _resolve_permission, which run
+# for every approval policy — including AUTO_APPROVE, which is what a cron with
+# approval_mode="auto" uses.
+_DENIED_TITLE = "rm -rf /"
+_BENIGN_TITLE = "Read README.md"
+
+
+class _ScriptedProvider:
+    """Yields a fixed event script and records the gate calls it received."""
+
+    def __init__(self, events: list[LLMEvent]) -> None:
+        self._events = events
+        self.approved: list[str] = []
+        self.rejected: list[str] = []
+
+    async def stream(self, message: str) -> AsyncIterator[LLMEvent]:
+        for event in self._events:
+            yield event
+
+    async def approve_tool(self, request_id: str) -> None:
+        self.approved.append(request_id)
+
+    async def reject_tool(self, request_id: str) -> None:
+        self.rejected.append(request_id)
+
+
+def _script(title: str) -> list[LLMEvent]:
+    return [
+        LLMEvent(kind=EVENT_TEXT_CHUNK, text="on it"),
+        LLMEvent(kind=EVENT_PERMISSION_REQUEST, title=title, request_id="r1"),
+        LLMEvent(kind=EVENT_TEXT_CHUNK, text=" — could not."),
+        LLMEvent(kind=EVENT_COMPLETE, text=""),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_security_deny_is_flagged_as_a_security_block():
+    provider = _ScriptedProvider(_script(_DENIED_TITLE))
+    seen: list[tuple[str, bool, bool]] = []
+
+    text = await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.AUTO_APPROVE,
+        retry_transient=False,
+        on_tool_gate=lambda t, a, b: seen.append((t, a, b)),
+    )
+
+    assert seen == [(_DENIED_TITLE, False, True)], "the security block never reached the caller"
+    assert provider.rejected == ["r1"]
+    # The turn still completes and still returns prose — which is precisely why
+    # the caller cannot infer the refusal from the reply text.
+    assert text == "on it — could not."
+
+
+@pytest.mark.asyncio
+async def test_a_hook_security_deny_is_flagged_as_a_security_block():
+    """The exfiltration/deny-list gate routes through HookManager, not the
+    unconditional arms. Classifying only the unconditional arms as security
+    would let a hook-blocked cron go on recording success forever."""
+    from kiro_crew.hooks import ToolHookResult
+
+    provider = _ScriptedProvider(_script(_BENIGN_TITLE))
+    hooks = MagicMock()
+    hooks.on_tool_call = MagicMock(return_value=ToolHookResult.deny("Blocked: exfiltration"))
+    hooks.effective_denied_regexes = MagicMock(return_value=[])
+    seen: list[tuple[str, bool, bool]] = []
+
+    await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.HOOK_BASED,
+        hooks=hooks,
+        retry_transient=False,
+        on_tool_gate=lambda t, a, b: seen.append((t, a, b)),
+    )
+
+    assert seen == [(_BENIGN_TITLE, False, True)], "a hook security deny was not counted"
+
+
+@pytest.mark.asyncio
+async def test_a_governance_deny_is_not_a_security_block():
+    """Policy state is not a defect in the attempt: the same call becomes allowed
+    when the ceiling loosens, so it must not feed a durable failure budget."""
+    from kiro_crew.hooks import ToolHookResult
+
+    provider = _ScriptedProvider(_script(_BENIGN_TITLE))
+    hooks = MagicMock()
+    hooks.on_tool_call = MagicMock(
+        return_value=ToolHookResult.deny_policy("Blocked by governance profile")
+    )
+    hooks.effective_denied_regexes = MagicMock(return_value=[])
+    seen: list[tuple[str, bool, bool]] = []
+
+    await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.HOOK_BASED,
+        hooks=hooks,
+        retry_transient=False,
+        on_tool_gate=lambda t, a, b: seen.append((t, a, b)),
+    )
+
+    assert seen == [(_BENIGN_TITLE, False, False)], "a governance deny was counted as security"
+
+
+@pytest.mark.asyncio
+async def test_an_interactive_rejection_is_not_a_security_block():
+    """An unattended cron's approval request deny-fasts on a timeout and lands
+    here. Counting it as a security block would fail — and eventually
+    auto-pause — a job whose only problem is that nobody approved it."""
+    provider = _ScriptedProvider(_script(_BENIGN_TITLE))
+    seen: list[tuple[str, bool, bool]] = []
+
+    async def _deny(_event) -> bool:
+        return False
+
+    await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.HOOK_BASED,
+        hooks=None,
+        on_tool_approval=_deny,
+        retry_transient=False,
+        on_tool_gate=lambda t, a, b: seen.append((t, a, b)),
+    )
+
+    assert seen == [(_BENIGN_TITLE, False, False)], (
+        "an interactive rejection must not be reported as a security block"
+    )
+    assert provider.rejected == ["r1"]
+
+
+@pytest.mark.asyncio
+async def test_an_approved_tool_is_reported_as_approved():
+    provider = _ScriptedProvider(_script(_BENIGN_TITLE))
+    seen: list[tuple[str, bool, bool]] = []
+
+    await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.AUTO_APPROVE,
+        retry_transient=False,
+        on_tool_gate=lambda t, a, b: seen.append((t, a, b)),
+    )
+
+    assert seen == [(_BENIGN_TITLE, True, False)], "the approval never reached the caller"
+    assert provider.approved == ["r1"]
+
+
+@pytest.mark.asyncio
+async def test_both_arms_are_distinguishable_within_one_turn():
+    """The caller's verdict is "security-blocked something AND approved nothing",
+    so a turn that got one of each must not read as fully blocked."""
+    provider = _ScriptedProvider(
+        [
+            LLMEvent(kind=EVENT_PERMISSION_REQUEST, title=_DENIED_TITLE, request_id="r1"),
+            LLMEvent(kind=EVENT_PERMISSION_REQUEST, title=_BENIGN_TITLE, request_id="r2"),
+            LLMEvent(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
+    seen: list[tuple[str, bool, bool]] = []
+
+    await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.AUTO_APPROVE,
+        retry_transient=False,
+        on_tool_gate=lambda t, a, b: seen.append((t, a, b)),
+    )
+
+    assert [(a, b) for _, a, b in seen] == [(False, True), (True, False)]
+
+
+@pytest.mark.asyncio
+async def test_a_raising_callback_does_not_fail_the_turn():
+    """Observing a gate decision is bookkeeping; it must never abort a cron run."""
+    provider = _ScriptedProvider(_script(_DENIED_TITLE))
+
+    def _boom(title: str, approved: bool, security_blocked: bool) -> None:
+        raise RuntimeError("caller bug")
+
+    text = await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.AUTO_APPROVE,
+        retry_transient=False,
+        on_tool_gate=_boom,
+    )
+
+    assert text == "on it — could not."
+
+
+class _RetryThenSucceedProvider:
+    """Refuses a tool, fails transiently, then succeeds tool-free on the retry.
+
+    A retry re-sends the original message, so a decision from the abandoned
+    attempt describes work the final turn never performs.
+    """
+
+    def __init__(self) -> None:
+        self.attempts = 0
+        self.rejected: list[str] = []
+
+    async def stream(self, message: str) -> AsyncIterator[LLMEvent]:
+        self.attempts += 1
+        if self.attempts == 1:
+            yield LLMEvent(kind=EVENT_PERMISSION_REQUEST, title=_DENIED_TITLE, request_id="r1")
+            # `transient` is the structured verdict acp_error_is_transient prefers
+            # over string-matching the message, so this takes the real retry route.
+            exc = AcpError("backend hiccup")
+            exc.transient = True  # type: ignore[attr-defined]
+            raise exc
+        yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="done without tools")
+        yield LLMEvent(kind=EVENT_COMPLETE, text="")
+
+    async def approve_tool(self, request_id: str) -> None:
+        pass
+
+    async def reject_tool(self, request_id: str) -> None:
+        self.rejected.append(request_id)
+
+
+@pytest.mark.asyncio
+async def test_a_discarded_retry_attempt_reports_no_gate_decisions(monkeypatch):
+    """A refusal from an abandoned attempt must not reach the caller.
+
+    Otherwise it outvotes a clean retry: the caller sees "refused something,
+    approved nothing" and fails a run that actually succeeded — which for cron
+    means auto-pausing a healthy recurring job.
+    """
+    monkeypatch.setattr(llm_helpers.asyncio, "sleep", _no_sleep)
+    provider = _RetryThenSucceedProvider()
+    seen: list[tuple[str, bool, bool]] = []
+
+    text = await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.AUTO_APPROVE,
+        on_tool_gate=lambda t, a, b: seen.append((t, a, b)),
+    )
+
+    assert provider.attempts == 2, "the transient failure did not trigger a retry"
+    assert text == "done without tools"
+    assert seen == [], f"decisions from the abandoned attempt leaked: {seen}"
+
+
+@pytest.mark.asyncio
+async def test_a_tool_that_bypassed_the_gate_counts_as_work():
+    """A tool auto-approved upstream raises no permission request, so it executes
+    without a gate decision. Correlating executed calls against decided ones by
+    ``tool_call_id`` is what keeps that work visible — without it a later
+    security block is the only tally entry and the run reads as fully blocked."""
+    provider = _ScriptedProvider(
+        [
+            LLMEvent(kind=EVENT_TOOL_CALL, title="Read README.md", tool_call_id="t1"),
+            LLMEvent(kind=EVENT_PERMISSION_REQUEST, title=_DENIED_TITLE, request_id="r2"),
+            LLMEvent(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
+    seen: list[tuple[str, bool, bool]] = []
+
+    await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.AUTO_APPROVE,
+        retry_transient=False,
+        on_tool_gate=lambda t, a, b: seen.append((t, a, b)),
+    )
+
+    assert (_DENIED_TITLE, False, True) in seen
+    assert ("Read README.md", True, False) in seen, "the executed tool was never reported"
+
+
+@pytest.mark.asyncio
+async def test_an_executed_call_matching_a_decision_is_not_double_counted():
+    """A tool whose execution follows its own gate decision must not also arrive
+    as a separate approval — otherwise a security-blocked tool that still emits
+    an execution event would mask every fully-blocked run."""
+    provider = _ScriptedProvider(
+        [
+            LLMEvent(kind=EVENT_PERMISSION_REQUEST, title=_DENIED_TITLE, request_id="r1",
+                     tool_call_id="t1"),
+            LLMEvent(kind=EVENT_TOOL_CALL, title=_DENIED_TITLE, tool_call_id="t1"),
+            LLMEvent(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
+    seen: list[tuple[str, bool, bool]] = []
+
+    await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.AUTO_APPROVE,
+        retry_transient=False,
+        on_tool_gate=lambda t, a, b: seen.append((t, a, b)),
+    )
+
+    assert seen == [(_DENIED_TITLE, False, True)], f"the decided call was double-counted: {seen}"
+
+
+@pytest.mark.asyncio
+async def test_a_pin_only_deny_is_reported_as_non_security():
+    """A rule the operator disabled and policy pinned back is policy state.
+
+    The gate still denies — enforcement is unchanged — but the cron tally must
+    not count it, because clearing an auto-pause never restores ``enabled``, so
+    a later policy loosening could not revive the job.
+    """
+    pattern = r"^Running: pinned-tool"
+
+    class _PinHooks:
+        """Only the pinned set contains the matching rule."""
+
+        def effective_denied_regexes(self, *, include_governance_pins: bool = True):
+            return [pattern] if include_governance_pins else []
+
+    provider = _ScriptedProvider(
+        [
+            LLMEvent(
+                kind=EVENT_PERMISSION_REQUEST, title="Running: pinned-tool --go", request_id="r1"
+            ),
+            LLMEvent(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
+    seen: list[tuple[str, bool, bool]] = []
+
+    await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.AUTO_APPROVE,
+        hooks=_PinHooks(),  # type: ignore[arg-type]
+        retry_transient=False,
+        on_tool_gate=lambda t, a, b: seen.append((t, a, b)),
+    )
+
+    assert seen == [("Running: pinned-tool --go", False, False)], (
+        f"a governance-pinned deny must not count as a security block: {seen}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_deny_the_user_enforces_is_reported_as_security():
+    """The same match without a pin IS the job's own problem."""
+    pattern = r"^Running: pinned-tool"
+
+    class _UserHooks:
+        """Both sets contain the rule — no pin involved."""
+
+        def effective_denied_regexes(self, *, include_governance_pins: bool = True):
+            return [pattern]
+
+    provider = _ScriptedProvider(
+        [
+            LLMEvent(
+                kind=EVENT_PERMISSION_REQUEST, title="Running: pinned-tool --go", request_id="r1"
+            ),
+            LLMEvent(kind=EVENT_COMPLETE, text=""),
+        ]
+    )
+    seen: list[tuple[str, bool, bool]] = []
+
+    await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.AUTO_APPROVE,
+        hooks=_UserHooks(),  # type: ignore[arg-type]
+        retry_transient=False,
+        on_tool_gate=lambda t, a, b: seen.append((t, a, b)),
+    )
+
+    assert seen == [("Running: pinned-tool --go", False, True)]
+
+
+@pytest.mark.asyncio
+async def test_omitting_the_callback_leaves_behavior_unchanged():
+    """Every existing caller passes no callback — that path must stay inert."""
+    provider = _ScriptedProvider(_script(_DENIED_TITLE))
+
+    text = await stream_and_collect(
+        provider,  # type: ignore[arg-type]
+        "q",
+        approval_policy=ToolApprovalPolicy.AUTO_APPROVE,
+        retry_transient=False,
+    )
+
+    assert text == "on it — could not."
+    assert provider.rejected == ["r1"]


### PR DESCRIPTION
## Problem

A cron whose tool calls are all blocked by the security gate reports **success**. On one install this hid a job that ran 159 times over three days at ~133 credits/day, with 96% of runs refused by a deny pattern — and `cron list`, Slack and the Schedule page all showed it green the whole time.

## Why it matters

Two defects stack, and the second is the worse one.

An LLM cron turn signals failure only by **raising**. A turn whose every tool was refused does not raise — the model still returns plausible prose — so `CronScheduler._execute` stamps `"ok"` and the callback calls `record_success()`. That call also resets `consecutive_failures` and clears `auto_paused`.

So the auto-pause guard — which exists precisely to stop a cron that keeps failing — was being reset every tick by the very runs it should have counted. `_AUTO_PAUSE_THRESHOLD` is 5, and the counter never got past 1. A job structurally incapable of succeeding re-fires forever, silently, and nothing in any surface says so.

## Fix (symptom → root cause → change)

**Symptom:** a useless cron shows green and never auto-pauses.
**Root cause:** the only failure signal on the LLM path is an exception, and a fully-refused turn raises nothing. Every tool denial is terminated inside `_resolve_permission` — `reject_tool`, audit to SEL, `return False` — and the caller discards it with `if not approved: continue`. The dashboard runner keeps a refusal list (`chat_runner.py` `_refusal_reasons`), but it is a turn-local variable and no non-dashboard surface has an equivalent.

**Change:**

1. `stream_and_collect` gains an optional `on_tool_gate` callback reporting each permission decision as `(tool_title, approved, security_blocked)`. Default `None`, so all six existing callers are byte-identical.
2. The mechanism is captured through `_resolve_permission`'s existing `_log` closure — every decision path already routes through it — so all ten deny arms are covered **without** changing its `bool` return, which matters because `test_workflow_security.py` asserts on that bool at ~20 call sites.
3. Decisions are buffered per stream attempt and committed only when the attempt settles, mirroring the existing `consumed_this_attempt` discipline. A retry re-sends the original message, so a refusal from an abandoned attempt describes work the final turn never did.
4. Both cron agent paths (single-agent and the sequential `agent_sequence` loop) tally decisions and share one verdict helper, so they cannot drift. Tools attempted, every one security-blocked, none approved → `last_status = "error"` + redacted reason + `record_failure()`.

**Only an unconditional security block counts.** A governance `TOOL_DENY` and an unattended-approval timeout also arrive unapproved, but they describe the policy state or an absent approver, not a defect in the job. This matters concretely: a default cron (`approval_mode=""`) passes `_interactive_approval("cron")`, `"cron"` is in `_BACKGROUND_APPROVAL_SOURCES`, and it deny-fasts after 180s — so counting those would durably auto-pause perfectly healthy jobs. It is also the invariant the three fire-time governance denials in the same function already assert, each skipping `record_failure()` because a policy denial must not feed the auto-pause counter.

**Two deliberate choices.** The predicate is not "any refusal fails" — blocked-then-adapted is the healthy path, with a test pinning it. And `"error"` is reused rather than adding a `"blocked"` status, because all four consumers branch on `ok`/`error` and a third value falls through to **"Ready"** in the SPA badge, which would make a blocked job look healthy.

The sequential path previously recorded neither success nor failure, so its counter never moved in either direction. It now records both — adding only the failure arm would be a one-way ratchet where `auto_paused` is set and can never lift.

## Tests

`test/test_llm_helpers_tool_gate.py` (6) — against the real `stream_and_collect`:
- a security deny is reported with `security_blocked=True`, and the turn still returns prose (why the caller cannot infer it from the text)
- an **interactive rejection** is reported `approved=False, security_blocked=False` — the distinction that protects unattended jobs
- an approval is reported as approved; both arms are distinguishable within one turn
- **a discarded retry attempt reports no decisions** — refuse a tool, raise a transient `AcpError`, succeed tool-free on retry; asserts the caller sees nothing
- a raising callback cannot abort the turn; omitting the callback leaves behavior unchanged

`test/test_cron_refusal_status.py` (16) — fully-blocked run records error with a reason and count; blocked-then-adapted and tool-free runs stay successful; **an unapproved (timeout) run is not a failure even after 5 runs**; 5 blocked runs auto-pause, 4 do not; a success on the **same job** clears the counter; `auto` approval mode applies the verdict. `TestMultiAgentSequence` covers the sequential path with **asymmetric per-agent scripts** so run-scoped and per-agent tallying give different verdicts. `TestSchedulerContract` pins that `_execute` preserves an explicit `"error"` and the `last_status` → history-status mapping, neither of which had any test.

Revert-verified in six places, each restored: removing the callback, the cron verdict, `cron.py`'s `!= "error"` guard, the retry buffer's `not retrying` guard, the `security_blocked` discrimination, and the success arm.

## Manual verification

N/A — unit coverage sufficient. This is backend-only with no UI surface; the behavior is fully expressible as gate decisions in, bookkeeping out, and the tests drive the real `stream_and_collect` and the real `_cron_callback` rather than stubs of them.

## Screenshots

N/A — no user-visible UI change. The SPA already renders `last_status = "error"`; this only changes when that value is produced.

## Notes for the reviewer

- **Full backend suite run:** 40,872 passed / 56 failed. All 56 were verified pre-existing by reverting the two production files to `main` and re-running the 11 affected files; the two that differed were then checked individually and behave identically with and without this diff (one fails on `main` too, one passes on both and had failed only under different xdist distribution).
- **Deferred:** the turn-level `except` in the delivery path writes `job.consecutive_failures = new_count` directly and never calls `record_failure()`, so a blocked run whose *delivery* then raises has its count overwritten. That is a second, pre-existing failure accountant; reconciling the two is a restructure beyond this fix's scope and is filed separately.
