### PR TITLE
test: make app backend spawn tests deterministic

### DIFF
--- a/test/test_app_backend.py
+++ b/test/test_app_backend.py
@@ -410,6 +410,14 @@ def _slow_never_owns(port, pid):
     return False
 
 
+def _frozen_spawn_time() -> SimpleNamespace:
+    """Keep poll-count scenarios independent of host wall-clock scheduling."""
+    return SimpleNamespace(
+        monotonic=lambda: 0.0,
+        sleep=lambda _seconds: None,
+    )
+
+
 class TestBootSpawnLatency:
     def test_survival_check_exits_early_for_a_healthy_child(self, monkeypatch):
         """A living child must not cost the full survival window.
@@ -449,7 +457,9 @@ class TestBootSpawnLatency:
         """
         import kiro_crew.apps.backend as bmod
 
-        monkeypatch.setattr(bmod.time, "sleep", lambda s: None)
+        monkeypatch.setattr(bmod, "time", _frozen_spawn_time())
+        monkeypatch.setattr(bmod.platform_compat, "listening_pid_tool_available", lambda: True)
+        monkeypatch.setattr(bmod, "_port_is_listening", lambda port: True)
         monkeypatch.setattr(bmod, "_spawn_owns_listener", lambda port, pid: False)
 
         class _DiesLate:
@@ -474,8 +484,10 @@ class TestBootSpawnLatency:
         """
         import kiro_crew.apps.backend as bmod
 
-        monkeypatch.setattr(bmod.time, "sleep", lambda s: None)
+        monkeypatch.setattr(bmod, "time", _frozen_spawn_time())
         # Something is listening, but it is not our child (nor its descendant).
+        monkeypatch.setattr(bmod.platform_compat, "listening_pid_tool_available", lambda: True)
+        monkeypatch.setattr(bmod, "_port_is_listening", lambda port: True)
         monkeypatch.setattr(bmod, "_listening_pids", lambda port: [99999])
         monkeypatch.setattr(bmod, "_pid_is_self_or_descendant_of", lambda pid, ancestor: False)
 
@@ -500,20 +512,29 @@ class TestBootSpawnLatency:
         """
         import kiro_crew.apps.backend as bmod
 
-        monkeypatch.setattr(bmod.time, "sleep", lambda s: None)
+        monkeypatch.setattr(bmod, "time", _frozen_spawn_time())
+        monkeypatch.setattr(bmod.platform_compat, "listening_pid_tool_available", lambda: True)
+        monkeypatch.setattr(bmod, "_port_is_listening", lambda port: True)
         monkeypatch.setattr(bmod, "_listening_pids", lambda port: [4243])
         monkeypatch.setattr(
-            bmod, "_pid_is_self_or_descendant_of",
+            bmod,
+            "_pid_is_self_or_descendant_of",
             lambda pid, ancestor: pid == 4243 and ancestor == 4242,
         )
 
-        class _Alive:
+        class _DiesAfterBind:
             pid = 4242
 
-            def poll(self) -> None:
-                return None
+            def __init__(self) -> None:
+                self.calls = 0
 
-        assert bmod._survived_spawn(_Alive(), 9100) is True
+            def poll(self):
+                self.calls += 1
+                return None if self.calls == 1 else 1
+
+        proc = _DiesAfterBind()
+        assert bmod._survived_spawn(proc, 9100) is True
+        assert proc.calls == 1
 
     def test_failure_path_never_exceeds_the_original_budget(self):
         """The ownership probe must not stretch the wait it is embedded in.


### PR DESCRIPTION
## Problem

Two app-backend spawn tests can fail intermittently on a loaded runner:

- `test_early_exit_requires_our_own_child_to_own_the_listener`
- `test_survival_check_still_detects_a_late_exit`

The failure appeared in the Windows backend shard for #2450 even though that PR
does not touch the app-backend implementation or these tests.

## Why it matters

These false failures block otherwise healthy PRs at PR Readiness and prevent
downstream automated reviews from running.

## Fix (symptoms → root cause → change)

The tests replaced `time.sleep` with a no-op but left `time.monotonic` connected
to the real 1.6-second production deadline. On a loaded runner, real wall-clock
time could therefore expire before the fake process reached its scripted exit,
making the helper report survival.

This change gives those tests a module-local frozen clock that controls both
sleep and monotonic time. It also pins the listener-tool preconditions and makes
the descendant-ownership case assert success on the first process poll, so the
test cannot pass through the deadline fallback.

Production timeout and retry behavior are unchanged.

## Tests

- `python -m pytest -q test/test_app_backend.py` — 52 passed with 8 workers
- the three affected spawn tests passed in three consecutive runs
- `isort --check-only src/kiro_crew test`
- `flake8 src/kiro_crew test`
- `npm --prefix website run build`
- docs lint, brand check, and pre-push single-commit/fresh-base gate
- two independent local review-contract passes found no issues

## Manual verification

N/A — this is a deterministic test-only change with no runtime or UI behavior
change.
