### PR TITLE
fix(mcp): reach a gateway started on a non-default port

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -68,6 +68,7 @@ from kiro_crew.port_resolution import (  # noqa: F401
     _marker_port,
     resolve_client_port,
     resolve_client_port_ex,
+    resolve_client_port_src,
 )
 from kiro_crew.preflight import run_preflight_checks
 from kiro_crew.sel import sel

--- a/src/kiro_crew/mcp_computer.py
+++ b/src/kiro_crew/mcp_computer.py
@@ -99,6 +99,8 @@ from kiro_crew.mcp_core import (
     _api_base,
     _http_error_body,
     _internal_secret,
+    _invalidate_api_base,
+    _resolve_api_port,
     _resolve_session_key_strict,
     _session_key_header_error,
 )
@@ -642,25 +644,51 @@ def _invoke(session_key: str, name: str, args: dict[str, Any]) -> dict[str, Any]
     body = json.dumps(
         {"tool": name, "args": args, "session_key": session_key, "agent": "", "app": ""}
     ).encode()
-    request = urllib.request.Request(
-        f"{_api_base()}{INVOKE_PATH}",
-        data=body,
-        headers={
-            "Content-Type": "application/json",
-            "X-Internal-Secret": _internal_secret(),
-            "X-Session-Key": session_key,
-        },
-        method="POST",
-    )
-    try:
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_api_base() from config/run-marker) + a fixed internal path; never agent-controlled  # noqa: E501
+    headers = {
+        "Content-Type": "application/json",
+        "X-Internal-Secret": _internal_secret(),
+        "X-Session-Key": session_key,
+    }
+
+    def _send_once(base: str):
+        request = urllib.request.Request(
+            f"{base}{INVOKE_PATH}", data=body, headers=headers, method="POST"
+        )
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_api_base(): 127.0.0.1 plus a port from config/env or a run-marker whose ownership is re-verified per request) + a fixed internal path; never agent-controlled  # noqa: E501
         with loopback_urlopen(request, timeout=INVOKE_TIMEOUT_SECS) as response:
-            decoded = json.loads(response.read())
+            return json.loads(response.read())
+
+    api_base = _api_base()
+    try:
+        decoded = _send_once(api_base)
     except urllib.error.HTTPError as exc:
         return _http_error_body(exc)
     except urllib.error.URLError as exc:
         detail = str(exc.reason) if isinstance(exc.reason, OSError) else str(exc)
-        return {"error": ERR_GATEWAY_UNREACHABLE.format(detail=detail)}
+        # The resolved base can predate the gateway: its port is recorded only in
+        # the run marker, so a refusal is worth one re-resolution before giving up.
+        if isinstance(exc.reason, (ConnectionRefusedError, socket.gaierror)):
+            _invalidate_api_base()
+            retry_port, retry_source = _resolve_api_port()
+            # A default-source fall-through carries NO evidence: a listener on
+            # the default port could be any local process, and replaying would
+            # hand it the internal secret. Replay only chases positive
+            # evidence of a moved gateway. Same rule as mcp_core._send.
+            retry_base = f"http://127.0.0.1:{retry_port}"
+            if retry_source != "default" and retry_base != api_base:
+                try:
+                    decoded = _send_once(retry_base)
+                except urllib.error.HTTPError as retry_exc:
+                    # The replay REACHED the (moved) gateway and it answered with
+                    # a normal HTTP error — surface the structured body exactly
+                    # like a first-attempt HTTPError, not a stale "unreachable".
+                    return _http_error_body(retry_exc)
+                except Exception:
+                    return {"error": ERR_GATEWAY_UNREACHABLE.format(detail=detail)}
+            else:
+                return {"error": ERR_GATEWAY_UNREACHABLE.format(detail=detail)}
+        else:
+            return {"error": ERR_GATEWAY_UNREACHABLE.format(detail=detail)}
     except (TimeoutError, socket.timeout) as exc:
         return {"error": ERR_GATEWAY_UNREACHABLE.format(detail=f"timed out ({exc})")}
     except Exception as exc:

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -60,7 +60,7 @@ from kiro_crew.mcp_tools import build_tool_list, dispatch
 from kiro_crew.members import record_activity
 from kiro_crew.messaging.link import is_legacy_slack_key, legacy_key
 from kiro_crew.platform import redact_via_context as redact
-from kiro_crew.port_resolution import resolve_client_port_ex
+from kiro_crew.port_resolution import resolve_client_port_src
 from kiro_crew.security import (
     redact_credentials,
     redact_exfiltration_urls,
@@ -90,10 +90,10 @@ _HANDLER_SURFACE = (
 )
 
 
-def _resolve_api_port() -> tuple[int, bool]:
+def _resolve_api_port() -> tuple[int, str]:
     """Resolve the gateway API port a callback should aim at.
 
-    Delegates to :func:`kiro_crew.port_resolution.resolve_client_port_ex`, the
+    Delegates to :func:`kiro_crew.port_resolution.resolve_client_port_src`, the
     same precedence every client CLI command applies: ``KIROCREW_PORT``, then a
     port **explicitly written** in ``dashboard.url``, then the sole
     gateway-owned run-marker, then the documented default. The marker step is
@@ -102,10 +102,20 @@ def _resolve_api_port() -> tuple[int, bool]:
     substitutes the default for the *server's* benefit (it must bind
     something), which is exactly the wrong guess for a client callback.
 
-    Returns ``(port, positive)`` — ``positive`` is ``False`` when resolution
-    fell through to the default with no evidence behind it.
+    Returns ``(port, source)`` — the source string names the chain step that
+    produced the port (``"env"`` / ``"bound"`` / ``"config"`` / ``"marker"`` /
+    ``"default"``), because the caching rule below differs by source.
     """
-    return resolve_client_port_ex(None)
+    return resolve_client_port_src(None)
+
+
+#: Port sources stable for the process lifetime, safe to pin. Deliberately
+#: excludes ``"marker"``: a marker-discovered port is verified at that instant
+#: only — the gateway can exit or move and any local process may then rebind
+#: the port, so every secret-bearing request must re-run the discovery chain
+#: (which re-proves ownership via ``_gateway_owns_port``) instead of trusting
+#: a pinned value. Also excludes ``"default"``, the no-evidence fall-through.
+_STABLE_PORT_SOURCES = frozenset({"cli", "env", "bound", "config"})
 
 
 # Lazily-resolved caches for the gateway API port, base URL, and unix-socket
@@ -123,21 +133,29 @@ _API_UNIX_SOCKET: str | None = None
 
 
 def _api_port() -> int:
-    """Gateway API port, resolved on first use; cached only on evidence.
+    """Gateway API port, resolved on first use; pinned only on stable evidence.
 
-    A resolution that fell through to the default port is returned but NOT
-    cached: it only proves nothing was discoverable at that instant. During
-    gateway boot a broker-descended server can race the asynchronous
-    run-marker write — pinning that fall-through would freeze the wrong port
-    for the process lifetime, with restart as the only recovery. The next
-    call re-resolves and picks the marker up once it exists. Every positive
-    source (env, explicit config, verified marker) is stable, so those are
-    cached as before.
+    Only a *stable* source — env var, exported bound port, or a port the user
+    wrote in ``dashboard.url`` — is cached: those are user decisions that hold
+    for the process lifetime. Two resolutions are returned but NOT cached:
+
+    * The default fall-through: it only proves nothing was discoverable at
+      that instant. During gateway boot a broker-descended server can race
+      the asynchronous run-marker write — pinning that fall-through would
+      freeze the wrong port for the process lifetime, with restart as the
+      only recovery. The next call re-resolves and picks the marker up once
+      it exists.
+    * A **marker-discovered** port: ownership was proven for that instant,
+      not forever. The gateway can exit or move ports, after which any local
+      process — another user's included — may rebind the port; a pinned
+      marker resolution would keep sending the internal secret there. Every
+      call therefore re-runs the discovery chain, whose marker step re-proves
+      ownership (``_gateway_owns_port``) before the port is trusted again.
     """
     global _API_PORT
     if _API_PORT is None:
-        port, positive = _resolve_api_port()
-        if not positive:
+        port, source = _resolve_api_port()
+        if source not in _STABLE_PORT_SOURCES:
             return port
         _API_PORT = port
     return _API_PORT
@@ -192,6 +210,22 @@ def _api_unix_socket() -> str:
 def _api_urlopen(req: urllib.request.Request | str, timeout: float):
     """``loopback_urlopen`` against the API base with the unix-socket preference."""
     return loopback_urlopen(req, timeout=timeout, unix_socket_path=_api_unix_socket() or None)
+
+
+def _invalidate_api_base() -> None:
+    """Forget the pinned port, base and socket path so the next call re-resolves.
+
+    Called when a connection is refused: the pinned base can predate a gateway
+    that has since moved (or a config edit that retargeted it), and the current
+    port is recorded only in the live run-marker. Dropping all three caches
+    together keeps the invariant that both transports derive from one
+    resolution — clearing only the URL would leave the socket path aimed at the
+    old gateway.
+    """
+    global _API_PORT, _API, _API_UNIX_SOCKET
+    _API_PORT = None
+    _API = None
+    _API_UNIX_SOCKET = None
 
 
 # How often a sleeping `wait` polls /api/session-keepalive.
@@ -901,6 +935,101 @@ def _caller_header() -> dict[str, str]:
     return {"X-Internal-Caller": name} if name else {}
 
 
+def _transport_failure(message: str, mark: bool) -> dict:
+    """Error payload for a request whose outcome is unknown.
+
+    ``transport_error`` means acceptance is undetermined — the request may have
+    reached the gateway before the response failed (a read timeout after spawn
+    acceptance, say), so the caller must not declare a definite rejection nor
+    retry on its own. Only spawn_run's batch reconcile consumes it, and it only
+    ever posts, so the flag stays opt-in per verb rather than becoming a new field
+    on every reply.
+    """
+    out: dict[str, object] = {"error": message}
+    if mark:
+        out["transport_error"] = True
+    return out
+
+
+def _send(
+    path: str,
+    *,
+    data: bytes | None = None,
+    headers: dict[str, str],
+    method: str = "GET",
+    timeout: float = 30,
+    mark_transport_error: bool = False,
+) -> dict:
+    """Send one gateway request, re-resolving the base once if it is refused.
+
+    A refused connection usually means the resolved base is stale: the gateway
+    came up, or moved to another port, after this tool server booted, and that
+    port is recorded only in the run marker. The replay runs only when
+    re-resolution actually produced a different base — retrying an unchanged
+    dead port just doubles the caller's latency to reach the identical failure.
+
+    Every verb goes through here. Keeping the replay in one place is what stops
+    PATCH-shaped calls from staying pinned to a base that POST already learned
+    was wrong.
+    """
+
+    def _once(base: str) -> dict:
+        req = urllib.request.Request(f"{base}{path}", data=data, headers=headers, method=method)
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_api_base(): 127.0.0.1 plus a port from config/env or a run-marker whose ownership is re-verified per request) + a fixed internal path; never user-controlled  # noqa: E501
+        with _api_urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read())
+
+    base = _api_base()
+    try:
+        return _once(base)
+    except urllib.error.HTTPError as e:
+        # urlopen raises HTTPError on 4xx/5xx; str(e) is only "HTTP Error 400:
+        # Bad Request" — the structured {"error": ...} body lives in e.read().
+        # Surface it so callers can act on the backend's actual error (e.g.
+        # the learn_add "unknown session" mapping) instead of an opaque code.
+        return _http_error_body(e)
+    except urllib.error.URLError as e:
+        if not isinstance(e.reason, (ConnectionRefusedError, socket.gaierror)):
+            return _transport_failure(str(e), mark_transport_error)
+        _invalidate_api_base()
+        retry_port, retry_source = _resolve_api_port()
+        if retry_source == "default":
+            # Re-resolution produced NO evidence — the default port is an
+            # unverified guess, and a listener there could be any local
+            # process. Replaying would hand it the internal secret and the
+            # request payload; the replay exists to chase POSITIVE evidence
+            # of a moved gateway, so a no-evidence fall-through ends here.
+            return {"error": str(e)}
+        # Build the base from the very resolution whose source was just
+        # checked (same shape as _api_base) — re-resolving again could race a
+        # marker disappearing between the check and the dial.
+        retry_base = f"http://127.0.0.1:{retry_port}"
+        if retry_base == base:
+            # Nothing was ever handed to a live gateway, so this is a definite
+            # rejection: no transport ambiguity to report.
+            return {"error": str(e)}
+        try:
+            return _once(retry_base)
+        except urllib.error.HTTPError as retry_exc:
+            return _http_error_body(retry_exc)
+        except urllib.error.URLError as retry_exc:
+            if isinstance(retry_exc.reason, (ConnectionRefusedError, socket.gaierror)):
+                return {"error": str(e)}
+            return _transport_failure(str(retry_exc), mark_transport_error)
+        except Exception as retry_exc:
+            # The replay reached the gateway and failed afterwards (a read timeout
+            # after a spawn was accepted, say). Acceptance is undetermined, so this
+            # must carry the same ambiguity flag as a first-attempt post-connect
+            # failure — otherwise spawn_run reconciles a still-running member down
+            # and orphans it.
+            return _transport_failure(str(retry_exc), mark_transport_error)
+    except Exception as e:
+        # The request may have reached the gateway before the response failed
+        # (for example, a read timeout after spawn acceptance). Callers must
+        # not present this as a definite rejection or retry automatically.
+        return _transport_failure(str(e), mark_transport_error)
+
+
 def _post(path: str, body: dict | None = None, *, timeout: float = 30) -> dict:
     data = json.dumps(body or {}).encode()
     headers = {
@@ -914,34 +1043,17 @@ def _post(path: str, body: dict | None = None, *, timeout: float = 30) -> dict:
         return {"error": _sk_err}
     if sk:
         headers["X-Session-Key"] = sk
-    req = urllib.request.Request(
-        f"{_api_base()}{path}",
+    # ``transport_error`` is consumed only by spawn_run's batch reconcile: it
+    # means acceptance is unknown, so that member must not be declared lost.
+    # Other _post callers should treat the payload as a normal error.
+    return _send(
+        path,
         data=data,
         headers=headers,
         method="POST",
+        timeout=timeout,
+        mark_transport_error=True,
     )
-    try:
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_api_base() from config/run-marker) + a fixed internal path; never user-controlled  # noqa: E501
-        with _api_urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        # urlopen raises HTTPError on 4xx/5xx; str(e) is only "HTTP Error 400:
-        # Bad Request" — the structured {"error": ...} body lives in e.read().
-        # Surface it so callers can act on the backend's actual error (e.g.
-        # the learn_add "unknown session" mapping) instead of an opaque code.
-        return _http_error_body(e)
-    except urllib.error.URLError as e:
-        if isinstance(e.reason, (ConnectionRefusedError, socket.gaierror)):
-            return {"error": str(e)}
-        # ``transport_error`` is consumed only by spawn_run's batch reconcile:
-        # it means acceptance is unknown, so that member must not be declared
-        # lost. Other _post callers should treat the payload as a normal error.
-        return {"error": str(e), "transport_error": True}
-    except Exception as e:
-        # The request may have reached the gateway before the response failed
-        # (for example, a read timeout after spawn acceptance). Callers must
-        # not present this as a definite rejection or retry automatically.
-        return {"error": str(e), "transport_error": True}
 
 
 def _http_error_body(exc: urllib.error.HTTPError) -> dict:
@@ -1018,17 +1130,7 @@ def _get(path: str, session_key: str | None = None) -> dict:
         return {"error": _sk_err}
     if sk:
         headers["X-Session-Key"] = sk
-    req = urllib.request.Request(
-        f"{_api_base()}{path}",
-        headers=headers,
-    )
-    try:
-        with _api_urlopen(req, timeout=10) as resp:
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        return _http_error_body(e)
-    except Exception as e:
-        return {"error": str(e)}
+    return _send(path, headers=headers, timeout=10)
 
 
 def _patch(path: str, body: dict | None = None, *, session_key: str | None = None) -> dict:
@@ -1051,21 +1153,7 @@ def _patch(path: str, body: dict | None = None, *, session_key: str | None = Non
         return {"error": _sk_err}
     if sk:
         headers["X-Session-Key"] = sk
-    req = urllib.request.Request(
-        f"{_api_base()}{path}",
-        data=data,
-        headers=headers,
-        method="PATCH",
-    )
-    try:
-        # _api_base() is the loopback dashboard base and `path` is a code
-        # literal — never attacker-controlled, so no file:// scheme risk.
-        with _api_urlopen(req, timeout=30) as resp:  # nosemgrep  # noqa: E501
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        return _http_error_body(e)
-    except Exception as e:
-        return {"error": str(e)}
+    return _send(path, data=data, headers=headers, method="PATCH")
 
 
 def _put(path: str, body: dict | None = None, session_key: str | None = None) -> dict:
@@ -1093,21 +1181,7 @@ def _put(path: str, body: dict | None = None, session_key: str | None = None) ->
         return {"error": _sk_err}
     if sk:
         headers["X-Session-Key"] = sk
-    req = urllib.request.Request(
-        f"{_api_base()}{path}",
-        data=data,
-        headers=headers,
-        method="PUT",
-    )
-    try:
-        # _api_base() is the loopback dashboard base and `path` is a code
-        # literal — never attacker-controlled, so no file:// scheme risk.
-        with _api_urlopen(req, timeout=30) as resp:  # nosemgrep  # noqa: E501
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        return _http_error_body(e)
-    except Exception as e:
-        return {"error": str(e)}
+    return _send(path, data=data, headers=headers, method="PUT")
 
 
 def _delete(path: str, body: dict | None = None) -> dict:
@@ -1121,19 +1195,7 @@ def _delete(path: str, body: dict | None = None) -> dict:
         headers["X-Session-Key"] = sk
     if data:
         headers["Content-Type"] = "application/json"
-    req = urllib.request.Request(
-        f"{_api_base()}{path}",
-        data=data,
-        headers=headers,
-        method="DELETE",
-    )
-    try:
-        with _api_urlopen(req, timeout=10) as resp:
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        return _http_error_body(e)
-    except Exception as e:
-        return {"error": str(e)}
+    return _send(path, data=data, headers=headers, method="DELETE", timeout=10)
 
 
 def _autonudge_binding_key(sk: str) -> str | None:

--- a/src/kiro_crew/port_resolution.py
+++ b/src/kiro_crew/port_resolution.py
@@ -269,12 +269,34 @@ def resolve_client_port_ex(cli_port: int | None) -> tuple[int, bool]:
     not be written yet — so pinning it would freeze the weakest outcome
     forever, while every positive source is stable for the process lifetime.
     """
+    port, source = _patchable("resolve_client_port_src")(cli_port)
+    return port, source != "default"
+
+
+def resolve_client_port_src(cli_port: int | None) -> tuple[int, str]:
+    """Like :func:`resolve_client_port`, also reporting WHERE the port came from.
+
+    The second element names the chain step that produced the port: ``"cli"``,
+    ``"env"`` (``KIROCREW_PORT``), ``"bound"`` (``KIROCREW_BOUND_PORT``),
+    ``"config"`` (a port explicitly written in ``dashboard.url``), ``"marker"``
+    (the sole gateway-owned run-marker), or ``"default"`` (the fall-through).
+
+    The distinction :func:`resolve_client_port_ex` cannot make — and the reason
+    this exists — is ``"marker"`` versus the other positive sources. A flag, an
+    env var, or a configured port is a *user decision*, stable for the process
+    lifetime and safe to cache. A marker-discovered port is only *verified at
+    that instant*: the ownership proof says this user's gateway holds the port
+    NOW, not that it always will. A gateway that exits or moves frees the port
+    for any local process to rebind, so a caller about to attach a credential
+    to a request must re-run this chain (re-verifying ownership) rather than
+    trust a cached marker resolution.
+    """
     if cli_port is not None:
-        return cli_port, True
+        return cli_port, "cli"
     env_port = os.environ.get("KIROCREW_PORT")
     if env_port:
         try:
-            return int(env_port), True
+            return int(env_port), "env"
         except ValueError:
             # Fall through to bound/config/marker/default — main() validates
             # this early, but guard here too in case the helper is reached via
@@ -283,16 +305,16 @@ def resolve_client_port_ex(cli_port: int | None) -> tuple[int, bool]:
     bound_port = os.environ.get("KIROCREW_BOUND_PORT")
     if bound_port:
         try:
-            return int(bound_port), True
+            return int(bound_port), "bound"
         except ValueError:
             pass
     cfg_port = _patchable("_config_url_port")()
     if cfg_port:
-        return cfg_port, True
+        return cfg_port, "config"
     discovered = _patchable("_marker_port")()
     if discovered:
-        return discovered, True
-    return _DEFAULT_PORT, False
+        return discovered, "marker"
+    return _DEFAULT_PORT, "default"
 
 
 # Subcommands that launch a long-running Kiro Crew *server* process which

--- a/test/test_mcp_api_base_resolution.py
+++ b/test/test_mcp_api_base_resolution.py
@@ -1,0 +1,288 @@
+"""A refused gateway callback re-resolves its base once and replays.
+
+The port a ``--port``-started gateway is bound to is recorded only in its run
+marker, so an MCP tool server that resolved its base before the gateway came up
+(or before it moved) holds a stale base. These tests lock in the recovery path
+this PR adds: every verb helper routes through ``mcp_core._send``, which on a
+refused connection drops the resolution caches, re-resolves, and replays the
+request exactly once — and only when re-resolution actually produced a
+different base. ``mcp_computer._invoke`` applies the same rule to its one
+request path.
+"""
+
+from __future__ import annotations
+
+import importlib
+import socket
+import urllib.error
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def mcp(monkeypatch: pytest.MonkeyPatch) -> Any:
+    module = importlib.import_module("kiro_crew.mcp_core")
+    monkeypatch.setattr(module, "_API_PORT", None)
+    monkeypatch.setattr(module, "_API", None)
+    monkeypatch.setattr(module, "_API_UNIX_SOCKET", None)
+    monkeypatch.setattr(module, "_internal_secret", lambda: "s")
+    monkeypatch.setattr(module, "_resolve_session_key", lambda: "")
+    monkeypatch.setattr(module, "_session_key_header_error", lambda sk: None)
+    return module
+
+
+def _bases(monkeypatch: pytest.MonkeyPatch, mcp: Any, sequence: list[str]) -> None:
+    """Feed ``_api_base`` a scripted resolution sequence (first attempts)."""
+    it = iter(sequence)
+    last = sequence[-1]
+    monkeypatch.setattr(mcp, "_api_base", lambda: next(it, last))
+
+
+def _retry_resolution(monkeypatch: pytest.MonkeyPatch, mcp: Any, port: int, source: str) -> None:
+    """Script what ``_resolve_api_port`` answers when the replay re-resolves."""
+    monkeypatch.setattr(mcp, "_resolve_api_port", lambda: (port, source))
+
+
+class TestInvalidation:
+    def test_invalidate_drops_all_three_caches(self, mcp: Any, monkeypatch) -> None:
+        """URL, port and socket path must expire together — both transports
+        derive from one resolution, and clearing only the URL would leave the
+        socket aimed at the old gateway."""
+        monkeypatch.setattr(mcp, "_API_PORT", 7788)
+        monkeypatch.setattr(mcp, "_API", "http://127.0.0.1:7788")
+        monkeypatch.setattr(mcp, "_API_UNIX_SOCKET", "/tmp/dashboard-7788.sock")
+        mcp._invalidate_api_base()
+        assert mcp._API_PORT is None
+        assert mcp._API is None
+        assert mcp._API_UNIX_SOCKET is None
+
+
+@pytest.fixture
+def refusing_gateway(mcp: Any, monkeypatch):
+    """First attempt refused on the default port; re-resolution proves 7788."""
+    urls: list[str] = []
+    _bases(monkeypatch, mcp, ["http://127.0.0.1:5476"])
+    _retry_resolution(monkeypatch, mcp, 7788, "marker")
+
+    def fake_open(req, timeout=None):
+        urls.append(req.full_url)
+        if ":5476" in req.full_url:
+            raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+        return _Resp()
+
+    monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+    return mcp, urls
+
+
+class _Resp:
+    def __init__(self, payload: bytes = b'{"ok": true}') -> None:
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+@pytest.mark.parametrize("verb", ["_post", "_get", "_patch", "_put", "_delete"])
+def test_every_verb_rediscovers_and_replays(refusing_gateway, verb: str) -> None:
+    """A stale base must not survive in one verb after another has learned better."""
+    mcp, urls = refusing_gateway
+    call = getattr(mcp, verb)
+    out = call("/api/x") if verb == "_get" else call("/api/x", {"k": "v"})
+    assert out == {"ok": True}
+    assert len(urls) == 2
+    assert ":5476" in urls[0]
+    assert ":7788" in urls[1]
+
+
+def test_no_replay_when_rediscovery_returns_the_same_base(mcp: Any, monkeypatch) -> None:
+    """Retrying an unchanged dead base would only double the latency."""
+    attempts: list[str] = []
+    _bases(monkeypatch, mcp, ["http://127.0.0.1:7788"])
+    _retry_resolution(monkeypatch, mcp, 7788, "marker")
+
+    def fake_open(req, timeout=None):
+        attempts.append(req.full_url)
+        raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+
+    monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+    assert "error" in mcp._post("/api/x", {"k": "v"})
+    assert len(attempts) == 1
+
+
+def test_no_replay_when_rediscovery_falls_through_to_default(mcp: Any, monkeypatch) -> None:
+    """A no-evidence default fall-through must never receive the replay.
+
+    The marker gateway exited after the first resolution; re-resolution finds
+    nothing and falls through to the default port. A listener there is
+    unverified — it could be any local process — and the request carries the
+    internal secret, so the replay is skipped even though the base differs.
+    """
+    attempts: list[str] = []
+    _bases(monkeypatch, mcp, ["http://127.0.0.1:9999"])
+    _retry_resolution(monkeypatch, mcp, 5476, "default")
+
+    def fake_open(req, timeout=None):
+        attempts.append(req.full_url)
+        raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+
+    monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+    out = mcp._post("/api/x", {"k": "v"})
+    assert "error" in out
+    assert "transport_error" not in out
+    assert len(attempts) == 1  # nothing was sent to the unverified default port
+
+
+def test_only_post_reports_transport_error(mcp: Any, monkeypatch) -> None:
+    """``transport_error`` is spawn_run's signal; other verbs keep their shape."""
+    _bases(monkeypatch, mcp, ["http://127.0.0.1:5476"])
+
+    def fake_open(req, timeout=None):
+        raise urllib.error.URLError(socket.timeout("slow"))
+
+    monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+    assert mcp._post("/api/x", {}).get("transport_error") is True
+    assert "transport_error" not in mcp._get("/api/x")
+    assert "transport_error" not in mcp._patch("/api/x", {})
+
+
+def test_replay_that_fails_after_connecting_stays_ambiguous(mcp: Any, monkeypatch) -> None:
+    """A spawn accepted by the rediscovered gateway must not be reported as lost.
+
+    spawn_run reconciles a member down on a definite rejection. If the replay
+    reaches the gateway and only the response read fails, acceptance is
+    undetermined — collapsing that to a plain error orphans a still-running
+    subagent and closes the batch early.
+    """
+    _bases(monkeypatch, mcp, ["http://127.0.0.1:5476"])
+    _retry_resolution(monkeypatch, mcp, 7788, "marker")
+
+    def fake_open(req, timeout=None):
+        if ":5476" in req.full_url:
+            raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+        raise TimeoutError("read timed out after the spawn was accepted")
+
+    monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+    out = mcp._post("/api/spawn", {"tasks": ["x"]})
+    assert out.get("transport_error") is True
+
+
+def test_replay_refused_again_is_a_definite_rejection(mcp: Any, monkeypatch) -> None:
+    """Refused on both bases means nothing was ever accepted."""
+    _bases(monkeypatch, mcp, ["http://127.0.0.1:5476"])
+    _retry_resolution(monkeypatch, mcp, 7788, "marker")
+
+    def fake_open(req, timeout=None):
+        raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+
+    monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+    out = mcp._post("/api/spawn", {"tasks": ["x"]})
+    assert "error" in out
+    assert "transport_error" not in out
+
+
+def test_http_error_on_replay_surfaces_the_backend_body(mcp: Any, monkeypatch) -> None:
+    """A 4xx from the rediscovered gateway must decode like a first-attempt 4xx."""
+    _bases(monkeypatch, mcp, ["http://127.0.0.1:5476"])
+    _retry_resolution(monkeypatch, mcp, 7788, "marker")
+
+    def fake_open(req, timeout=None):
+        if ":5476" in req.full_url:
+            raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+        raise urllib.error.HTTPError(
+            req.full_url, 400, "Bad Request", None, None  # type: ignore[arg-type]
+        )
+
+    monkeypatch.setattr(mcp, "_api_urlopen", fake_open)
+    out = mcp._post("/api/x", {})
+    assert "error" in out
+    assert "transport_error" not in out
+
+
+class TestMcpComputerReplay:
+    """``mcp_computer._invoke`` — the same refused-once-replay rule."""
+
+    @pytest.fixture
+    def computer(self, mcp: Any, monkeypatch) -> Any:
+        module = importlib.import_module("kiro_crew.mcp_computer")
+        monkeypatch.setattr(module, "_internal_secret", lambda: "s")
+        return module
+
+    def test_refusal_rediscovers_and_replays(self, computer: Any, mcp: Any, monkeypatch) -> None:
+        urls: list[str] = []
+        monkeypatch.setattr(computer, "_api_base", lambda: "http://127.0.0.1:5476")
+        monkeypatch.setattr(computer, "_resolve_api_port", lambda: (7788, "marker"))
+
+        def fake_open(req, timeout=None):
+            urls.append(req.full_url)
+            if ":5476" in req.full_url:
+                raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+            return _Resp(b'{"text": "done"}')
+
+        monkeypatch.setattr(computer, "loopback_urlopen", fake_open)
+        out = computer._invoke("dashboard:chat-1", "computer_get_state", {})
+        assert out == {"text": "done"}
+        assert len(urls) == 2
+
+    def test_refusal_with_unchanged_base_is_reported(self, computer: Any, monkeypatch) -> None:
+        attempts: list[str] = []
+        monkeypatch.setattr(computer, "_api_base", lambda: "http://127.0.0.1:7788")
+        monkeypatch.setattr(computer, "_resolve_api_port", lambda: (7788, "marker"))
+
+        def fake_open(req, timeout=None):
+            attempts.append(req.full_url)
+            raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+
+        monkeypatch.setattr(computer, "loopback_urlopen", fake_open)
+        out = computer._invoke("dashboard:chat-1", "computer_get_state", {})
+        assert "error" in out
+        assert len(attempts) == 1
+
+    def test_no_replay_when_rediscovery_falls_through_to_default(
+        self, computer: Any, monkeypatch
+    ) -> None:
+        """Same no-evidence rule as mcp_core._send: an unverified default-port
+        listener must never receive the replayed secret-bearing request."""
+        attempts: list[str] = []
+        monkeypatch.setattr(computer, "_api_base", lambda: "http://127.0.0.1:9999")
+        monkeypatch.setattr(computer, "_resolve_api_port", lambda: (5476, "default"))
+
+        def fake_open(req, timeout=None):
+            attempts.append(req.full_url)
+            raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+
+        monkeypatch.setattr(computer, "loopback_urlopen", fake_open)
+        out = computer._invoke("dashboard:chat-1", "computer_get_state", {})
+        assert "error" in out
+        assert len(attempts) == 1  # nothing was sent to the unverified default port
+
+    def test_http_error_on_replay_surfaces_the_backend_body(
+        self, computer: Any, monkeypatch
+    ) -> None:
+        """A 4xx from the reached moved gateway must decode like a first-attempt
+        4xx, not collapse into a stale 'gateway unreachable: refused'."""
+        import io
+
+        monkeypatch.setattr(computer, "_api_base", lambda: "http://127.0.0.1:5476")
+        monkeypatch.setattr(computer, "_resolve_api_port", lambda: (7788, "marker"))
+
+        def fake_open(req, timeout=None):
+            if ":5476" in req.full_url:
+                raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+            raise urllib.error.HTTPError(
+                req.full_url,
+                400,
+                "Bad Request",
+                None,  # type: ignore[arg-type]
+                io.BytesIO(b'{"error": "unknown session"}'),
+            )
+
+        monkeypatch.setattr(computer, "loopback_urlopen", fake_open)
+        out = computer._invoke("dashboard:chat-1", "computer_get_state", {})
+        assert out == {"error": "unknown session"}

--- a/test/test_mcp_api_port_resolution.py
+++ b/test/test_mcp_api_port_resolution.py
@@ -132,7 +132,30 @@ class TestApiBaseResolution:
         # resolves the real port without a restart.
         with _cfg(""), _markers([6776]), _owned([6776]):
             assert mcp_core._api_base() == "http://127.0.0.1:6776"
-        assert mcp_core._API_PORT == 6776  # positive evidence IS pinned
+        # A marker-discovered port is served but never pinned either: its
+        # ownership proof holds only for the instant it was made, and a freed
+        # port can be rebound by any local process. Requests carrying the
+        # internal secret must re-verify per call (see _api_port).
+        assert mcp_core._API_PORT is None
+
+    def test_marker_port_is_reverified_on_every_call(self):
+        """A marker-discovered port must be re-resolved (re-proving ownership)
+        on every call, not trusted from a cache.
+
+        The gateway can exit or move ports after a resolution; the freed port
+        may be rebound by a different local user's process. A pinned marker
+        resolution would keep aiming secret-bearing requests at it — so the
+        chain (whose marker step runs ``_gateway_owns_port``) must run again
+        for each request.
+        """
+        with _cfg(""), _markers([6776]) as markers, _owned([6776]):
+            assert mcp_core._api_base() == "http://127.0.0.1:6776"
+            assert mcp_core._api_base() == "http://127.0.0.1:6776"
+            assert markers.call_count == 2  # re-resolved, not cached
+        # The gateway moved: ownership of 6776 no longer verifies and the new
+        # marker names 7788 — the very next call follows it.
+        with _cfg(""), _markers([7788]), _owned([7788]):
+            assert mcp_core._api_base() == "http://127.0.0.1:7788"
 
     def test_unix_socket_not_pinned_on_default_fallthrough(self):
         """The socket path follows the same no-evidence rule as the URL."""
@@ -142,12 +165,20 @@ class TestApiBaseResolution:
         with _cfg(""), _markers([6776]), _owned([6776]):
             assert mcp_core._api_unix_socket().endswith("dashboard-6776.sock")
 
-    def test_resolution_is_lazy_and_cached(self):
-        """First call resolves, later calls reuse the cache (no re-discovery)."""
-        with _cfg(""), _markers([6776]) as markers, _owned([6776]):
-            assert mcp_core._api_base() == "http://127.0.0.1:6776"
-            assert mcp_core._api_base() == "http://127.0.0.1:6776"
-            assert markers.call_count == 1
+    def test_resolution_is_lazy_and_cached(self, monkeypatch: pytest.MonkeyPatch):
+        """First call resolves, later calls reuse the cache (no re-discovery).
+
+        Caching applies to STABLE sources only — here the env var, a user
+        decision that holds for the process lifetime. (A marker-discovered
+        port deliberately re-resolves per call; see
+        ``test_marker_port_is_reverified_on_every_call``.)
+        """
+        monkeypatch.setenv("KIROCREW_PORT", "6777")
+        with _cfg(""), _markers([]) as markers:
+            assert mcp_core._api_base() == "http://127.0.0.1:6777"
+            assert mcp_core._api_base() == "http://127.0.0.1:6777"
+            markers.assert_not_called()
+        assert mcp_core._API_PORT == 6777  # stable evidence IS pinned
 
     def test_preseeded_cache_is_respected(self, monkeypatch: pytest.MonkeyPatch):
         """A pre-seeded ``_API`` (the test seam) short-circuits resolution."""


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

Every MCP tool that calls back into the gateway (`file_send`, `learn_add`, artifact writes, `send_message`, cron and spawn control) resolved its base URL once and then trusted it for the process lifetime. On a host whose gateway was started with `kirocrew gateway --port 7788` — a documented flag — a tool server that resolved before the gateway came up (or before it moved) kept aiming at a port nobody was listening on, and every callback failed with `urlopen error [Errno 111] Connection refused`. The failure is silent server-side because the request never arrives. The effective port of a `--port`-started gateway is recorded only in its run marker.

Since this PR was opened, main landed marker-based lazy resolution for the *first* resolution (`port_resolution.py`, via #2927 and #3138), which superseded this PR's original discovery-module extraction. Rebased onto that structure, this PR now carries the two halves main still lacks: **recovery** (a refused connection re-resolves and replays once) and **re-verification** (a marker-discovered port is never pinned).

## Why it matters

Without recovery, a gateway that appears or moves after a tool server booted stays unreachable until every tool server is restarted — on a live host that means agent sessions whose `file_send` / `learn_add` / spawn control silently stop working. Without re-verification, a pinned marker-discovered port outlives its ownership proof: the gateway can exit and any local process — another user's included — can rebind the port, and requests carrying `X-Internal-Secret` would keep being sent there.

## What changed (motivation → approach → change)

Symptom: refused callbacks after a gateway starts late or moves ports. Root cause: each verb helper resolved its base at most once and had no recovery path; and a marker-discovered resolution was cached forever even though its ownership proof holds only for the instant it is made.

- **One `_send` helper for every gateway verb.** `mcp_core._post/_get/_patch/_put/_delete` now route through a single `_send` that, on a refused connection (`ConnectionRefusedError` / `gaierror`), drops the port/base/socket caches (`_invalidate_api_base`), re-resolves, and replays the request exactly once — and only when re-resolution actually produced a different base (retrying an unchanged dead port just doubles the caller's latency). `mcp_computer._invoke` applies the same rule to its request path. Keeping the replay in one place stops PATCH-shaped calls from staying pinned to a base POST already learned was wrong. Per-verb semantics are preserved: timeouts (10s GET/DELETE, 30s POST/PATCH/PUT), `HTTPError` body decoding, and the `transport_error` ambiguity flag that only `_post` sets (spawn_run's batch reconcile depends on it — a replay that reaches the gateway and then fails must stay ambiguous, or a still-running subagent gets reconciled down).
- **A marker-discovered port is re-verified before every secret-bearing request.** `port_resolution` gains `resolve_client_port_src` (the existing chain, also reporting *which step* produced the port; `resolve_client_port_ex` becomes a thin wrapper over it, same contract). `mcp_core._api_port` now pins only stable, user-decided sources (`KIROCREW_PORT` / `KIROCREW_BOUND_PORT` / an explicit `dashboard.url` port). A marker-discovered port is served but never cached: each call re-runs the chain, whose marker step re-proves ownership via `_gateway_owns_port` before the port is trusted again. This closes the window where a pinned marker port could be rebound by a different local user after the gateway moved, with the internal secret still being sent to it.

## Tests

- `test/test_mcp_api_base_resolution.py` (new): every verb (`_post`/`_get`/`_patch`/`_put`/`_delete`) rediscovers and replays on refusal; no replay when rediscovery yields the same base; `transport_error` stays `_post`-only; a replay that fails after connecting stays ambiguous; a replay refused again is a definite rejection; an HTTP 4xx on the replay decodes like a first-attempt 4xx; `_invalidate_api_base` drops all three caches together; `mcp_computer._invoke` replays on refusal and reports an unchanged-base refusal without retrying.
- `test/test_mcp_api_port_resolution.py` (updated): `test_marker_port_is_reverified_on_every_call` (new) locks in per-call re-resolution and that a moved gateway's new marker is followed on the very next call; `test_default_fallthrough_is_not_pinned` now also asserts the marker port is not pinned; `test_resolution_is_lazy_and_cached` asserts caching against a stable source (env), which is the surface the cache now covers.

## Manual verification

N/A — unit coverage sufficient: the refusal/replay and pinning paths are fully exercised with network-mocked tests; full backend suite run locally (55441 passed; the only failures are pre-existing on main in this environment: old `jq`, no Node ≥ 20, host procfs/ssh quirks).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (MCP tool server ↔ gateway transport); no rendered UI is touched.

## Related Issues

Fixes #2659

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: `docs/system-specs/modules/instances.md` does not document the pinning rule; docstrings updated in-code
- [x] No secrets, credentials, or internal references in the diff
