### PR TITLE
fix: hold the MCP init drain open until the first server reports (#2627)

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -206,15 +206,33 @@ Step 5 drains MCP server init notifications (both after `session/load` and
 `_mcp_notifications` instead of discarding them. `_drain_notifications()`
 processes buffered notifications first, then reads any remaining from stdout.
 
-The multiplexed `AcpRuntime` has the same guarantee for session-scoped OAuth
-requests even though it cannot register the session queue until `session/new`
+The multiplexed `AcpRuntime` has the same guarantee for session-scoped init
+frames even though it cannot register the session queue until `session/new`
 or `session/load` returns the session id. While either request is in flight, the
-runtime stages matching `_kiro.dev/mcp/oauth_request` notifications in a bounded
-buffer, transfers them into the new handle's queue once the id is known, and
-`AcpSessionHandle.drain_init()` retains them for
-`pop_pending_oauth_requests()`. Staging is cleared when the last concurrent init
+runtime stages matching `_kiro.dev/mcp/oauth_request`,
+`_kiro.dev/mcp/server_initialized`, and `_kiro.dev/mcp/server_init_failure`
+notifications in a bounded buffer and transfers them into the new handle's
+queue once the id is known. `AcpSessionHandle.drain_init()` retains OAuth
+requests for `pop_pending_oauth_requests()`; the registration frames are what
+arm its idle shortcut (below). Staging is cleared when the last concurrent init
 finishes, including failure paths, so a stale approval URL cannot leak into a
 later session.
+
+`drain_init()`'s idle shortcut means "quiet **after** the servers reported",
+not "quiet, therefore done": until the first MCP registration frame
+(`server_initialized` / `server_init_failure` / `oauth_request`) is observed,
+queue silence is treated as a server still booting — an npx-based stdio server
+spends seconds on npm resolution plus a Node boot before emitting anything —
+and the drain keeps waiting, bounded by `_MCP_DRAIN_NO_REPORT_CEILING`. Once a
+report has been seen it allows up to `_MCP_DRAIN_DURATION` more and exits
+after `_MCP_DRAIN_IDLE_EXIT` of silence, so warm sessions (whose registration
+frames were staged during `session/new`) arm immediately and pay no extra
+latency. A session with no MCP servers at all is the one case that pays the
+full no-report ceiling; a runtime whose agent is KNOWN to be MCP-free — the
+`kirocrew-lite` background runtime, whose config Kiro Crew itself writes with
+an empty `mcpServers` map — opts out via
+`AcpRuntime(expect_mcp_reports=False)`, which passes a zero ceiling and keeps
+the idle shortcut active from the start (the pre-ceiling behavior).
 
 ## Key APIs
 

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -49,6 +49,8 @@ from kiro_crew.acp.session_handle import (
 from kiro_crew.acp.types import (
     ACP_CLIENT_CAPABILITIES,
     METHOD_MCP_OAUTH_REQUEST,
+    METHOD_MCP_SERVER_INIT_FAILURE,
+    METHOD_MCP_SERVER_INITIALIZED,
     METHOD_SESSION_LOAD,
     METHOD_SESSION_NEW,
     METHOD_SESSION_TERMINATE,
@@ -474,6 +476,7 @@ class AcpRuntime:
         max_age_secs: float = _DEFAULT_MAX_AGE_SECS,
         max_rss_mb: float = _DEFAULT_MAX_RSS_MB,
         model: str | None = None,
+        expect_mcp_reports: bool = True,
     ):
         if work_dir:
             self._work_dir = Path(work_dir)
@@ -498,6 +501,13 @@ class AcpRuntime:
             str(mcp_gateway_settings_mcp_json) if mcp_gateway_settings_mcp_json else None
         )
         self._mcp_gateway_socket = str(mcp_gateway_socket) if mcp_gateway_socket else None
+        # Whether sessions on this runtime should hold drain_init() open for
+        # slow MCP servers (the no-report ceiling). A runtime whose agent is
+        # KNOWN to have zero MCP servers — the kirocrew-lite background runtime,
+        # whose config Kiro Crew itself writes with an empty mcpServers map —
+        # opts out so hot one-liner paths (chat titles, suggestions, STT
+        # endpointing) don't pay a full ceiling wait that can never be armed.
+        self._expect_mcp_reports = expect_mcp_reports
         self._sandbox_cleanup: str | None = None
 
         # Recycling thresholds — see _is_stale(). Long-lived multiplexed
@@ -1090,12 +1100,19 @@ class AcpRuntime:
                     queue = self._session_queues.get(session_id)
                     if queue is not None:
                         await queue.put(msg)
-                    elif self._session_inits_in_flight and msg.is_method(
-                        METHOD_MCP_OAUTH_REQUEST
+                    elif self._session_inits_in_flight and (
+                        msg.is_method(METHOD_MCP_OAUTH_REQUEST)
+                        or msg.is_method(METHOD_MCP_SERVER_INITIALIZED)
+                        or msg.is_method(METHOD_MCP_SERVER_INIT_FAILURE)
                     ):
-                        # session/new can emit OAuth before its response. The
-                        # response is what gives create_session the id needed to
-                        # register this queue, so retain the frame until then.
+                        # session/new can emit OAuth and MCP registration frames
+                        # before its response. The response is what gives
+                        # create_session the id needed to register this queue,
+                        # so retain the frames until then. Registration frames
+                        # matter beyond logging: drain_init() arms its idle
+                        # shortcut on the first one, so dropping them here would
+                        # make every warm session look report-less and pay the
+                        # full no-report ceiling.
                         self._pending_init_notifications.append(msg)
                     else:
                         # Counted, not logged per frame: this is the measured
@@ -1418,6 +1435,7 @@ class AcpRuntime:
         # Populate state from session/new response (configOptions, available models)
         handle.store_session_config(resp)
 
+        mode_switched = False
         # Set agent mode if specified. If set_mode raises, no handle is returned
         # to the caller, so terminate the session we just created above —
         # session/new already succeeded so the session exists in kiro-cli; a
@@ -1442,6 +1460,14 @@ class AcpRuntime:
             except Exception:
                 await self.terminate_session(session_id)
                 raise
+            # Whether set_mode actually SWITCHED modes: the servers that
+            # initialized during session/new belong to the mode kiro-cli
+            # started the session on. If the requested agent differs, those
+            # staged registration frames describe the pre-switch roster and
+            # must not arm the drain's idle shortcut while the switched-to
+            # agent's own servers may still be booting.
+            _ids, _current, _adv = parse_session_modes(resp)
+            mode_switched = bool(_current) and agent != _current
         elif agent:
             _ids, _current, _adv = parse_session_modes(resp)
             await self.terminate_session(session_id)
@@ -1455,8 +1481,15 @@ class AcpRuntime:
 
         # Drain MCP-server-init / oauth / config notifications before the first
         # prompt so they don't race into the first turn (parity with
-        # AcpClient._drain_notifications). Best-effort, bounded (~1s).
-        await handle.drain_init()
+        # AcpClient._drain_notifications). Best-effort, bounded: exits shortly
+        # after the servers report, or at the no-report ceiling if none do.
+        # A runtime declared MCP-free skips the ceiling — nothing can arm it.
+        # After a real mode SWITCH, reports staged during session/new describe
+        # the pre-switch roster, so they must not arm the idle shortcut.
+        if self._expect_mcp_reports:
+            await handle.drain_init(ignore_queued_reports=mode_switched)
+        else:
+            await handle.drain_init(no_report_ceiling=0.0)
 
         logger.info("Created session %s on runtime PID %d", session_id, self._pid or 0)
         return handle
@@ -1523,6 +1556,7 @@ class AcpRuntime:
         )
         handle.store_session_config(resp)
 
+        mode_switched = False
         # Activate the agent (mirrors AcpClient step 4 — set_mode applies to a
         # resumed session too, not just fresh ones). If set_mode raises, the
         # caller falls back to create_session() (a fresh sid + its own queue),
@@ -1539,6 +1573,10 @@ class AcpRuntime:
             except Exception:
                 await self.terminate_session(resume_sid)
                 raise
+            # See create_session: after a real mode switch, registration frames
+            # staged during session/load describe the pre-switch roster.
+            _ids, _current, _adv = parse_session_modes(resp)
+            mode_switched = bool(_current) and agent != _current
         elif agent:
             # Guard (A) — see create_session. A resumed session always echoes a
             # `modes` list (checked above), so an absent agent means its config
@@ -1557,8 +1595,12 @@ class AcpRuntime:
         # Drain MCP-init / oauth / config notifications before the first prompt
         # (parity with AcpClient). Transcript-replay frames were already dropped
         # before the queue was registered above, so only genuine init frames
-        # remain to drain here.
-        await handle.drain_init()
+        # remain to drain here. MCP-free runtimes skip the no-report ceiling.
+        # After a real mode SWITCH, staged reports are pre-switch — don't arm.
+        if self._expect_mcp_reports:
+            await handle.drain_init(ignore_queued_reports=mode_switched)
+        else:
+            await handle.drain_init(no_report_ceiling=0.0)
 
         logger.info("Resumed session %s on runtime PID %d", resume_sid, self._pid or 0)
         return handle

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -243,6 +243,27 @@ _POST_COMPACTION_METADATA_GRACE_SECS = 5.0
 # are processed before the first prompt, instead of racing into the first turn.
 _MCP_DRAIN_DURATION = 1.0
 _MCP_DRAIN_IDLE_EXIT = 0.25
+# Hard ceiling while NO MCP server has reported yet. The idle shortcut is only
+# meaningful once reporting has begun — before the first registration frame,
+# queue silence just means the server is still booting (an npx-based stdio
+# server spends seconds on npm resolution plus a Node boot before emitting
+# anything), so the drain keeps waiting up to this ceiling instead. Sized to
+# cover a realistic npx cold start (npm resolve + Node boot, observed 1-6s)
+# while bounding the cost for a session whose agent config has no MCP servers
+# at all — the one case that pays the full ceiling, since nothing ever arms
+# the idle exit. Sessions with fast servers are unaffected: their registration
+# frames are staged during session/new and arm the idle exit immediately.
+_MCP_DRAIN_NO_REPORT_CEILING = 6.0
+# Notification actions that count as "an MCP server reported in" for the
+# drain's arming logic. OAuth requests count: a server that asks for OAuth has
+# booted and reached its auth step, which is the same liveness signal.
+_MCP_DRAIN_REPORT_ACTIONS = frozenset(
+    {
+        "mcp_server_initialized",
+        "mcp_server_init_failure",
+        "mcp_oauth_request",
+    }
+)
 _SENTINEL = object()
 
 
@@ -1945,29 +1966,70 @@ class AcpSessionHandle:
         self,
         duration: float = _MCP_DRAIN_DURATION,
         idle_exit: float = _MCP_DRAIN_IDLE_EXIT,
+        no_report_ceiling: float | None = None,
+        ignore_queued_reports: bool = False,
     ) -> None:
         """Drain MCP-init / oauth / config frames from the queue after set_mode.
 
         Parity with AcpClient._drain_notifications. During session setup there is
         no in-flight prompt, so every frame on this session's queue is an
         init-time notification. Draining them here keeps them out of the first
-        turn's event stream and gives MCP servers a brief window to report in
-        before the first prompt races ahead. Bounded by ``duration`` with early
-        exit after ``idle_exit`` seconds of silence. ``config_option_update``
-        frames refresh cached configOptions; OAuth requests remain drainable via
+        turn's event stream and gives MCP servers a window to report in before
+        the first prompt races ahead.
+
+        The idle shortcut means "quiet AFTER the servers reported", not "quiet,
+        therefore done": until the first MCP registration frame (initialized /
+        init_failure / oauth_request) is observed, queue silence is treated as a
+        server still booting and the drain keeps waiting, bounded by
+        ``no_report_ceiling`` (defaults to ``_MCP_DRAIN_NO_REPORT_CEILING``,
+        resolved at call time so tests can shrink the module constant). Once a
+        report has been seen, the drain allows up to ``duration`` more and exits
+        after ``idle_exit`` seconds of silence, so warm sessions — whose
+        registration frames were staged during session/new — arm immediately and
+        pay no extra latency. ``config_option_update`` frames refresh cached
+        configOptions; OAuth requests remain drainable via
         ``pop_pending_oauth_requests``; everything else is logged/discarded.
         Best-effort — never raises.
+
+        ``ignore_queued_reports``: registration frames already sitting on the
+        queue when the drain starts describe the roster that initialized during
+        ``session/new`` — for a session whose mode was then SWITCHED via
+        ``set_mode``, that is the PRE-switch agent's roster, and the
+        switched-to agent's own servers may still be booting. Passing True
+        keeps that stale backlog from arming the idle shortcut (the frames are
+        still drained and processed normally); only a report observed after
+        the pre-drain backlog is exhausted counts as the active agent's.
         """
-        deadline = time.monotonic() + duration
+        if no_report_ceiling is None:
+            no_report_ceiling = _MCP_DRAIN_NO_REPORT_CEILING
+        start = time.monotonic()
+        deadline = start + duration
+        hard_deadline = start + max(duration, no_report_ceiling)
+        # A nonpositive ceiling means "do not hold for a first report" — the
+        # caller knows no MCP server can register (MCP-free runtime). The idle
+        # shortcut is then active from the start, i.e. the pre-fix behavior.
+        reported = no_report_ceiling <= 0.0
+        stale_backlog = ignore_queued_reports and not self._queue.empty()
         drained = 0
-        while time.monotonic() < deadline:
-            remaining = deadline - time.monotonic()
+        while True:
+            now = time.monotonic()
+            limit = deadline if reported else hard_deadline
+            if now >= limit:
+                break
+            remaining = limit - now
+            if stale_backlog and self._queue.empty():
+                # The pre-drain backlog is exhausted; anything from here on
+                # arrived after set_mode and speaks for the ACTIVE agent.
+                stale_backlog = False
             try:
                 msg = await asyncio.wait_for(
-                    self._queue.get(), timeout=min(remaining, idle_exit)
+                    self._queue.get(),
+                    timeout=min(remaining, idle_exit) if reported else remaining,
                 )
             except asyncio.TimeoutError:
-                break  # queue went quiet — MCP servers done reporting
+                # Armed: queue went quiet after reporting — servers are done.
+                # Unarmed: the no-report ceiling elapsed with nothing to show.
+                break
             if msg is None:
                 # Runtime died during init — re-poison so the next consumer sees it.
                 await self._queue.put(None)
@@ -1975,6 +2037,11 @@ class AcpSessionHandle:
             drained += 1
             try:
                 action = classify_notification(msg)
+                if not reported and not stale_backlog and action in _MCP_DRAIN_REPORT_ACTIONS:
+                    # First server report: arm the idle shortcut and give the
+                    # remaining servers up to ``duration`` from this point.
+                    reported = True
+                    deadline = time.monotonic() + duration
                 if action == "update":
                     params = msg.params or {}
                     update = params.get("update") or {}

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -1149,6 +1149,13 @@ class SessionManager:
                     runtime = AcpRuntime(
                         agent="kirocrew-lite",
                         sandbox_mode=getattr(self._cfg.agent, "sandbox", "auto"),
+                        # kirocrew-lite's config is written by Kiro Crew itself
+                        # with an empty mcpServers map, so no MCP server can
+                        # ever report on this runtime. Opting out keeps hot
+                        # one-liner paths (chat titles, suggestions, STT
+                        # endpointing) from holding drain_init() open for a
+                        # first report that cannot arrive.
+                        expect_mcp_reports=False,
                     )
                     await runtime.spawn()
                     self._bg_runtime = runtime

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -51,8 +51,24 @@ from kiro_crew.acp.types import (
     JsonRpcMessage,
 )
 
-
 # ── Harness ──
+
+
+@pytest.fixture(autouse=True)
+def _fast_no_report_ceiling(monkeypatch):
+    """Shrink drain_init()'s no-report ceiling for every test in this module.
+
+    Many tests drive the real create_session()/load_session() path against a
+    fake backend that never emits MCP registration frames; at the production
+    ceiling each would stall drain_init() for seconds. drain_init() resolves
+    the module constant at call time precisely so this patch takes effect.
+    Tests that exercise the ceiling itself pass an explicit value instead.
+    """
+    import kiro_crew.acp.session_handle as sh
+
+    monkeypatch.setattr(sh, "_MCP_DRAIN_NO_REPORT_CEILING", 0.05, raising=False)
+
+
 def _make_runtime():
     """An initialized AcpRuntime wired to a fake subprocess.
 
@@ -3683,6 +3699,226 @@ async def test_drain_init_repoisons_on_dead_runtime():
     q["sA"].put_nowait(None)
     await handle.drain_init(duration=0.5, idle_exit=0.05)
     assert q["sA"].get_nowait() is None  # sentinel preserved
+
+
+def _mcp_initialized_frame(session_id: str, server: str) -> JsonRpcMessage:
+    return JsonRpcMessage.from_dict(
+        {
+            "method": "_kiro.dev/mcp/server_initialized",
+            "params": {"sessionId": session_id, "serverName": server},
+        }
+    )
+
+
+def _metadata_frame(session_id: str) -> JsonRpcMessage:
+    return JsonRpcMessage.from_dict(
+        {
+            "method": "_kiro.dev/metadata",
+            "params": {"sessionId": session_id, "contextUsagePercentage": 1.0},
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_drain_init_waits_past_idle_window_for_first_mcp_report(monkeypatch):
+    """#2627: the idle shortcut is not eligible before the first MCP
+    registration frame. A server that stays silent past the idle window and
+    THEN reports is still observed — non-MCP frames (metadata) that arrive
+    immediately after set_mode must not arm the shortcut either."""
+    import kiro_crew.acp.session_handle as sh
+
+    monkeypatch.setattr(sh, "_MCP_DRAIN_NO_REPORT_CEILING", 5.0, raising=False)
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    # A non-MCP frame is already queued (kiro-cli emits metadata right after
+    # set_mode); it must be consumed without arming the idle exit.
+    q["sA"].put_nowait(_metadata_frame("sA"))
+
+    async def _late_report() -> None:
+        # Many idle windows of silence before the server finally reports.
+        await asyncio.sleep(0.15)
+        q["sA"].put_nowait(_mcp_initialized_frame("sA", "slow-npx"))
+
+    feeder = asyncio.create_task(_late_report())
+    try:
+        await handle.drain_init(duration=0.2, idle_exit=0.01)
+    finally:
+        await feeder
+    # The late report was drained rather than left to race into the first turn.
+    assert q["sA"].empty()
+
+
+@pytest.mark.asyncio
+async def test_drain_init_no_reports_returns_at_ceiling():
+    """#2627: a drain that never sees an MCP report returns at the no-report
+    ceiling instead of hanging (bounded even when servers are dead or absent)."""
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    q["sA"].put_nowait(_metadata_frame("sA"))  # non-MCP traffic doesn't extend it
+    # The outer wait_for is the hang guard: generous vs the 0.2s ceiling so a
+    # loaded shard can't flake it, tiny vs a genuine unbounded wait.
+    await asyncio.wait_for(
+        handle.drain_init(duration=0.05, idle_exit=0.01, no_report_ceiling=0.2),
+        timeout=5.0,
+    )
+    assert q["sA"].empty()
+
+
+@pytest.mark.asyncio
+async def test_drain_init_idle_exit_stays_prompt_after_first_report():
+    """#2627: once a report has been seen, a subsequent idle gap still exits
+    promptly — the warm path must not degrade into full-ceiling waits. The
+    ceilings are deliberately huge relative to the outer bound, so completing
+    inside it proves the idle shortcut (not a ceiling) ended the drain."""
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    q["sA"].put_nowait(_mcp_initialized_frame("sA", "fast-server"))
+    await asyncio.wait_for(
+        handle.drain_init(duration=30.0, idle_exit=0.02, no_report_ceiling=30.0),
+        timeout=5.0,
+    )
+    assert q["sA"].empty()
+
+
+@pytest.mark.asyncio
+async def test_drain_init_zero_ceiling_keeps_idle_exit_active_from_start():
+    """#2627: no_report_ceiling=0.0 (MCP-free runtime opt-out) restores the
+    pre-fix behavior — idle exit is active before any report, so an empty
+    queue exits after one idle window instead of holding for a first report."""
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    q["sA"].put_nowait(_metadata_frame("sA"))
+    # duration is deliberately huge relative to the outer bound: completing
+    # inside it proves the idle shortcut ended the drain despite zero reports.
+    await asyncio.wait_for(
+        handle.drain_init(duration=30.0, idle_exit=0.02, no_report_ceiling=0.0),
+        timeout=5.0,
+    )
+    assert q["sA"].empty()
+
+
+@pytest.mark.asyncio
+async def test_mcp_free_runtime_skips_no_report_ceiling(monkeypatch):
+    """#2627: a runtime constructed with expect_mcp_reports=False passes the
+    zero ceiling to drain_init, so its sessions never hold for a report."""
+    rt = AcpRuntime(work_dir="/tmp", expect_mcp_reports=False)
+    rt._initialized = True
+    proc = MagicMock()
+    proc.returncode = None
+    proc.pid = 4242
+    rt._process = proc
+    rt._pid = 4242
+
+    async def _fake_send(method, params):
+        if method == METHOD_SESSION_NEW:
+            return {"sessionId": "sid-lite"}
+        return {}
+
+    monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+    seen: dict = {}
+    orig = AcpSessionHandle.drain_init
+
+    async def _spy(self, *args, **kwargs):
+        seen.update(kwargs)
+        await orig(self, *args, **kwargs)
+
+    with patch.object(AcpSessionHandle, "drain_init", _spy):
+        await rt.create_session(cwd="/w", agent="kirocrew-lite", mcp_servers=[])
+    assert seen.get("no_report_ceiling") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_drain_init_ignores_pre_switch_reports_still_waits_for_new_agent(monkeypatch):
+    """#2627 (review): on a shared runtime, session/new initializes the
+    PARENT mode's servers; their staged registration frames must not arm the
+    idle shortcut for a session that was then mode-SWITCHED — the switched-to
+    agent's own slow server, reporting after set_mode, must still be observed."""
+    import kiro_crew.acp.session_handle as sh
+
+    monkeypatch.setattr(sh, "_MCP_DRAIN_NO_REPORT_CEILING", 5.0, raising=False)
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    # Staged during session/new: the pre-switch agent's roster.
+    q["sA"].put_nowait(_mcp_initialized_frame("sA", "parent-mode-server"))
+    q["sA"].put_nowait(_metadata_frame("sA"))
+
+    async def _late_report() -> None:
+        # The switched-to agent's server reports well past the idle window.
+        await asyncio.sleep(0.15)
+        q["sA"].put_nowait(_mcp_initialized_frame("sA", "subagent-slow-npx"))
+
+    feeder = asyncio.create_task(_late_report())
+    try:
+        await handle.drain_init(duration=0.2, idle_exit=0.01, ignore_queued_reports=True)
+    finally:
+        await feeder
+    # Without the stale-backlog gate, the staged parent report arms the idle
+    # exit and the drain returns before the late report — leaving it queued.
+    assert q["sA"].empty()
+
+
+@pytest.mark.asyncio
+async def test_reader_retains_mcp_registration_frames_during_init():
+    """#2627: server_initialized / init_failure emitted before the session/new
+    response are staged (like OAuth) and handed to the new session's queue, so
+    drain_init() sees warm servers' reports and arms its idle shortcut."""
+    rt, reader, _ = _make_runtime()
+    task = asyncio.create_task(rt._reader_loop())
+    try:
+
+        async def _fake_send(method, params):
+            if method == METHOD_SESSION_NEW:
+                # Frames arrive while session/new is in flight — before the
+                # queue can be registered under the not-yet-known session id.
+                _feed(
+                    reader,
+                    {
+                        "method": "_kiro.dev/mcp/server_initialized",
+                        "params": {"sessionId": "sid-warm", "serverName": "core"},
+                    },
+                )
+                _feed(
+                    reader,
+                    {
+                        "method": "_kiro.dev/mcp/server_init_failure",
+                        "params": {"sessionId": "sid-warm", "serverName": "broken"},
+                    },
+                )
+                await asyncio.sleep(0.05)  # let the reader route them
+                return {"sessionId": "sid-warm"}
+            return {}
+
+        with patch.object(rt, "_send_and_await", _fake_send):
+            with patch.object(
+                AcpSessionHandle, "drain_init", AsyncMock()
+            ) as mock_drain:
+                handle = await rt.create_session(cwd="/w", agent="kirocrew", mcp_servers=[])
+        assert handle.session_id == "sid-warm"
+        mock_drain.assert_awaited_once()
+        # Both registration frames were transferred into the session queue
+        # (this is what drain_init would consume to arm its idle shortcut).
+        methods = []
+        while not handle._queue.empty():
+            frame = handle._queue.get_nowait()
+            assert frame is not None
+            methods.append(frame.method)
+        assert methods == [
+            "_kiro.dev/mcp/server_initialized",
+            "_kiro.dev/mcp/server_init_failure",
+        ]
+        # Staging area was emptied by the transfer.
+        assert not rt._pending_init_notifications
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
 
 def test_backfill_context_window_from_pct(monkeypatch):


### PR DESCRIPTION
## Summary

`AcpSessionHandle.drain_init()`'s idle shortcut treated 250 ms of queue silence as "MCP servers done reporting". A slow-starting stdio server (an `npx`-based server spends seconds on npm resolution plus a Node boot before emitting anything) was still unregistered when the shortcut fired, so the first prompt raced ahead and tool calls returned `MCP_UNAVAILABLE` on the first turn.

The idle shortcut now means "quiet **after** the servers reported":

- **Arm-on-first-report.** The idle exit is not eligible until the first MCP registration frame (`server_initialized` / `server_init_failure` / `oauth_request`) is observed. Until then the drain waits up to a new `_MCP_DRAIN_NO_REPORT_CEILING` (6.0 s — covers a realistic npx cold start, observed 1–6 s in live probes against kiro-cli) instead of one silent 250 ms window. Once armed, up to `_MCP_DRAIN_DURATION` (1.0 s, unchanged) more with the `_MCP_DRAIN_IDLE_EXIT` (0.25 s, unchanged) shortcut — the post-report path is exactly as cheap as before.
- **Warm-path retention.** Live probes show warm servers register **before** `session/new` returns, and the reader previously dropped those frames (only OAuth was staged). The init-window retention now also stages `server_initialized` / `server_init_failure` and hands them to the new session's queue, so warm sessions arm the idle shortcut immediately and spend no longer in `drain_init()` than today.
- **MCP-free opt-out.** `AcpRuntime(expect_mcp_reports=False)` passes a zero ceiling (idle shortcut active from the start — the pre-fix behavior). The `kirocrew-lite` background runtime opts out: its config is written by Kiro Crew itself with an empty `mcpServers` map, and it backs hot per-call one-liner paths (chat titles, suggestions, STT endpointing) that must not hold 6 s for a report that cannot arrive.

**Known residual (accepted by design):** with a mixed roster (fast servers plus one slow one), the first fast report arms the idle shortcut and the drain may still exit before the slowest server registers. The drain cannot know the roster size (agent-config servers are loaded on the kiro-cli side), and holding every session open for the slowest possible server would regress all warm starts.

`duration` / `idle_exit` stay injectable and all existing callers work unchanged; the new `no_report_ceiling` defaults to the module constant resolved at call time so tests can shrink it globally. No user-facing config added; `mcp_gateway/*` untouched.

## Testing

- New tests (all verified to **fail on unmodified code**):
  - a server silent past the idle window that then reports is still observed (plus: non-MCP frames like `metadata` do not arm the shortcut),
  - a drain with no reports returns at the hard ceiling instead of hanging,
  - once a report is seen, a subsequent idle gap still exits promptly (outer `wait_for` bound, no wall-clock assertions),
  - the reader stages `server_initialized` / `server_init_failure` during `session/new` and transfers them to the session queue,
  - `no_report_ceiling=0.0` restores pre-fix behavior; the MCP-free runtime passes it through.
- Timing driven via injectable params + a patchable module constant; an autouse fixture shrinks the ceiling for the module so existing fake-backend tests don't stall.
- Live E2E against real kiro-cli 2.16.2: warm session drains 44 init frames and exits promptly; injected slow (6 s) server's registration observed by the drain; timeline probes confirmed warm servers register before `session/new` returns and `commands/available` + `metadata` arrive immediately post-`set_mode`.
- Local gates: isort / flake8 / mypy clean; full suite 40 765 passed — 90 failures are pre-existing host-env issues (no `gh` CLI in sandbox, no user namespaces), reproduced identically with this change stashed; ACP/session modules 100% green.
- Pre-push review-fleet spawn was unavailable in this run (governance bar); a contract-driven self-review against both reviewer charters was performed instead and found + fixed one High (the `kirocrew-lite` hot-path ceiling, above). Server-side review bots remain the gate.

Closes #2627
