### PR TITLE
docs(autosde): cap a button row at two, overflow the rest

### DIFF
--- a/website/AUTOSDE.yaml
+++ b/website/AUTOSDE.yaml
@@ -171,6 +171,72 @@ custom-rules:
       )}
       ```
 
+  - id: max-two-buttons-per-row
+    blocking: true
+    file-patterns:
+      - "src/**/*.tsx"
+    rule: |
+      A row of buttons holds AT MOST 2. The third action and everything after it
+      goes into an overflow `DropdownMenu` (kebab / "More"), or leaves the row.
+
+      Why: peer buttons side by side carry no ranking, so three or more force a
+      read-every-label scan before the user can click anything, and the row is
+      the first thing to break under width pressure — the dashboard sidebar, a
+      split pane, and a table cell all clip or wrap it instead of degrading.
+      Two buttons still read as primary + secondary at a glance.
+
+      Counts toward the 2 — every action control that is a sibling in the same
+      horizontal group, labeled or icon-only: `Btn`, `SendBtn`, shadcn `Button`,
+      raw `<button>`, an icon button, a link styled as a button. A
+      `DropdownMenu` trigger counts as ONE regardless of how many items it
+      holds, so the overflow is always the cheapest way back under the cap.
+
+      Does NOT count:
+      - A segmented single-choice control (view mode, time range, tab-like
+        toggles) — one control expressing one setting, not N actions.
+      - Pagination arrows, and a text field's own affordances (clear, reveal,
+        submit-inside-the-field).
+      - Controls in a genuinely different row or a separated region — the cap is
+        per visual group, not per component.
+
+      Applies to what the diff ADDS. A row that already carries 3+ on the base
+      branch is grandfathered, but must not grow: adding a fourth is a
+      violation, and the fix is to collapse the row, never to widen it or let it
+      wrap onto a second line.
+
+      The established overflow pattern in this codebase is
+      `src/components/CronRowActions.tsx` (row actions) and
+      `src/components/SessionActionsMenu.tsx` (per-item menu). Copy those rather
+      than inventing a new one, and keep the icon-button label rules
+      (`icon-buttons-need-labels`) on the trigger.
+
+      Bad:
+      ```tsx
+      <div className="flex items-center gap-2">
+        <Btn onClick={onRun}>Run</Btn>
+        <Btn onClick={onPause}>Pause</Btn>
+        <Btn onClick={onDuplicate}>Duplicate</Btn>
+        <Btn danger onClick={onDelete}>Delete</Btn>
+      </div>
+      ```
+
+      Good:
+      ```tsx
+      <div className="flex items-center gap-2">
+        <Btn primary onClick={onRun}>Run</Btn>
+        <Btn onClick={onPause}>Pause</Btn>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Btn aria-label="More actions"><MoreVertical size={14} aria-hidden /></Btn>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={onDuplicate}>Duplicate</DropdownMenuItem>
+            <DropdownMenuItem onSelect={onDelete}>Delete</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      ```
+
   - id: use-react-query
     blocking: false
     file-patterns:


### PR DESCRIPTION
## What

Adds one blocking rule to the frontend AutoSDE ruleset: `max-two-buttons-per-row`.

A horizontal group of buttons holds at most 2. The third action and beyond move
into an overflow `DropdownMenu` (which counts as one control) or leave the row.

## Why

Peer buttons side by side carry no ranking, so three or more force a
read-every-label scan before the user can click anything. The row is also the
first thing to break under width pressure — the sidebar, a split pane, and a
table cell all clip or wrap it rather than degrading. Two buttons still read as
primary plus secondary at a glance.

## Scope, kept narrow so it is enforceable

Counts toward the cap: any sibling action control in the same horizontal group
(`Btn`, `SendBtn`, shadcn `Button`, raw `button`, icon button, link styled as a
button). A `DropdownMenu` trigger counts as one.

Does not count: segmented single-choice controls (view mode, time range),
pagination arrows, a text field's own affordances, and controls in a genuinely
separate row or region.

Rows that already exceed the cap on the base branch are grandfathered but may
not grow, and the fix is always to collapse the row, never to widen it or let it
wrap.

The rule points at the existing overflow precedents in this repo
(`CronRowActions.tsx`, `SessionActionsMenu.tsx`) so it prescribes a pattern that
already ships here.

## Verification

`website/AUTOSDE.yaml` is the only file changed. Parsed with `yaml.safe_load`;
rule ids unique, shape matches its siblings (`blocking` bool, non-empty
`file-patterns`, non-empty `rule`).
