### PR TITLE
fix(dashboard): run blocking directory and replay scans off the event loop

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -3535,7 +3535,12 @@ async def _run_chat(
                 # and the periodic flush_loop may have already written it to
                 # disk during the kiro-cli cold spawn (~5s flush vs ≥15s spawn).
                 # Scale the replay budget to the model window (client is live here).
-                compressed = build_session_replay(
+                # Offloaded: resolving this chat's tab id globs and opens every
+                # session file sharing it to rebuild an index, then reads each
+                # chained file in full — unbounded file IO on the hottest path in
+                # the gateway, where it would block every other request.
+                compressed = await asyncio.to_thread(
+                    build_session_replay,
                     state.context_builder.conversation_log,
                     session_key,
                     exclude_last_n=1,

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -2185,6 +2185,63 @@ async def api_file_diff(request: web.Request) -> web.Response:
     return web.json_response(result)
 
 
+def _browse_dirs_sync(base: str, skip: set[str]) -> list[dict]:
+    """Walk *base* one level deep and return its visible subdirectories.
+
+    Blocking, and unboundedly so: *base* is caller-chosen and defaults to ``$HOME``,
+    so the scan is as large as that directory, and every surviving entry additionally
+    pays an ``is_sensitive_path`` call that resolves several paths of its own. Run via
+    ``asyncio.to_thread`` so one large directory cannot hold the sole event loop for
+    the duration of the listing.
+    """
+    dirs: list[dict] = []
+    try:
+        for entry in sorted(os.scandir(base), key=lambda e: e.name.lower()):
+            if entry.is_dir(follow_symlinks=True) and entry.name not in skip and not entry.name.startswith("."):
+                # Resolve symlinks before the sensitivity check — a symlink in
+                # a benign dir pointing at ~/.aws would otherwise pass through.
+                if is_sensitive_path(os.path.realpath(entry.path)):
+                    continue
+                dirs.append({"name": entry.name, "path": entry.path})
+    except PermissionError:
+        pass
+    return dirs
+
+
+def _browse_files_sync(base: str, skip: set[str]) -> tuple[list[dict], list[dict]]:
+    """Walk *base* one level deep and return its ``(dirs, files)`` entries.
+
+    The sibling of :func:`_browse_dirs_sync` and blocking for the same reasons, plus a
+    ``stat`` per entry for the mtime the browser sorts on. Offloaded the same way.
+    """
+    dirs: list[dict] = []
+    files: list[dict] = []
+    try:
+        # Sort: dirs before files, then alphabetical
+        for entry in sorted(os.scandir(base), key=lambda e: (not e.is_dir(follow_symlinks=True), e.name.lower())):
+            if entry.name.startswith("."):
+                continue
+            # Resolve symlinks before the sensitivity check — a symlink in a
+            # benign dir pointing at ~/.aws would otherwise pass through.
+            if is_sensitive_path(os.path.realpath(entry.path)):
+                continue
+            # Capture mtime so the activity-panel browser can offer a
+            # sort-by-date option; fall back to 0 on a race (entry removed
+            # mid-scan) so one unstattable entry never breaks the listing.
+            try:
+                mtime = int(entry.stat(follow_symlinks=True).st_mtime)
+            except OSError:
+                mtime = 0
+            if entry.is_dir(follow_symlinks=True):
+                if entry.name not in skip:
+                    dirs.append({"name": entry.name, "path": entry.path, "mtime": mtime})
+            elif entry.is_file(follow_symlinks=True):
+                files.append({"name": entry.name, "path": entry.path, "mtime": mtime})
+    except PermissionError:
+        pass
+    return dirs, files
+
+
 async def api_browse_dirs(request: web.Request) -> web.Response:
     """GET /api/browse-dirs?path=... — list subdirectories for directory browser."""
     import os  # noqa: F811
@@ -2200,17 +2257,7 @@ async def api_browse_dirs(request: web.Request) -> web.Response:
         _sel().log_api_access(caller=caller, operation="browse_dirs", outcome="denied", resources=base, error="sensitive path")
         return web.json_response({"error": "Access denied"}, status=403)
     skip = {".git", "node_modules", "__pycache__", ".cache", ".venv", "venv", "env", ".kirocrew", ".kiro", ".aim"}
-    dirs: list[dict] = []
-    try:
-        for entry in sorted(os.scandir(base), key=lambda e: e.name.lower()):
-            if entry.is_dir(follow_symlinks=True) and entry.name not in skip and not entry.name.startswith("."):
-                # Resolve symlinks before the sensitivity check — a symlink in
-                # a benign dir pointing at ~/.aws would otherwise pass through.
-                if is_sensitive_path(os.path.realpath(entry.path)):
-                    continue
-                dirs.append({"name": entry.name, "path": entry.path})
-    except PermissionError:
-        pass
+    dirs = await asyncio.to_thread(_browse_dirs_sync, base, skip)
     _sel().log_api_access(caller=caller, operation="browse_dirs", outcome="allowed", resources=base)
     return web.json_response({"path": base, "parent": os.path.dirname(base), "dirs": dirs})
 
@@ -2470,31 +2517,7 @@ async def api_browse_files(request: web.Request) -> web.Response:
         _sel().log_api_access(caller=caller, operation="browse_files", outcome="denied", resources=base, error="sensitive path")
         return web.json_response({"error": "Access denied"}, status=403)
     skip = {".git", "node_modules", "__pycache__", ".cache", ".venv", "venv", "env", ".kirocrew", ".kiro", ".aim", "build", "dist", ".next"}
-    dirs: list[dict] = []
-    files: list[dict] = []
-    try:
-        # Sort: dirs before files, then alphabetical
-        for entry in sorted(os.scandir(base), key=lambda e: (not e.is_dir(follow_symlinks=True), e.name.lower())):
-            if entry.name.startswith("."):
-                continue
-            # Resolve symlinks before the sensitivity check — a symlink in a
-            # benign dir pointing at ~/.aws would otherwise pass through.
-            if is_sensitive_path(os.path.realpath(entry.path)):
-                continue
-            # Capture mtime so the activity-panel browser can offer a
-            # sort-by-date option; fall back to 0 on a race (entry removed
-            # mid-scan) so one unstattable entry never breaks the listing.
-            try:
-                mtime = int(entry.stat(follow_symlinks=True).st_mtime)
-            except OSError:
-                mtime = 0
-            if entry.is_dir(follow_symlinks=True):
-                if entry.name not in skip:
-                    dirs.append({"name": entry.name, "path": entry.path, "mtime": mtime})
-            elif entry.is_file(follow_symlinks=True):
-                files.append({"name": entry.name, "path": entry.path, "mtime": mtime})
-    except PermissionError:
-        pass
+    dirs, files = await asyncio.to_thread(_browse_files_sync, base, skip)
     _sel().log_api_access(caller=caller, operation="browse_files", outcome="allowed", resources=base)
     return web.json_response({"path": base, "parent": os.path.dirname(base), "dirs": dirs, "files": files})
 

--- a/test/test_browse_dirs.py
+++ b/test/test_browse_dirs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,6 +10,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from kiro_crew.dashboard.handlers import api_browse_dirs
+from kiro_crew.dashboard.handlers.files import _browse_dirs_sync
 
 
 def _make_app() -> web.Application:
@@ -98,3 +100,29 @@ class TestBrowseDirs:
                 assert data["dirs"] == []
         finally:
             restricted.chmod(0o755)
+
+    @pytest.mark.asyncio
+    async def test_scan_does_not_run_on_the_event_loop(self, tmp_path, mock_sel):
+        """The directory walk must execute off the loop thread.
+
+        Moving a scan into a thread preserves behaviour exactly, so no assertion on
+        the response body can tell the offload from an inline walk — a plain revert
+        keeps every other test in this file green. Record the thread the scan really
+        runs on and compare it against the loop's own thread instead.
+        """
+        (tmp_path / "alpha").mkdir()
+        loop_thread = threading.get_ident()
+        ran_on: list[int] = []
+
+        def spy(base: str, skip: set[str]) -> list[dict]:
+            ran_on.append(threading.get_ident())
+            return _browse_dirs_sync(base, skip)
+
+        with patch("kiro_crew.dashboard.handlers.files._browse_dirs_sync", spy):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get(f"/api/browse-dirs?path={tmp_path}")
+                assert resp.status == 200
+                names = {d["name"] for d in (await resp.json())["dirs"]}
+                assert names == {"alpha"}
+        assert ran_on, "the scan helper was never called"
+        assert ran_on[0] != loop_thread

--- a/test/test_browse_files.py
+++ b/test/test_browse_files.py
@@ -9,6 +9,7 @@ paths (added).
 from __future__ import annotations
 
 import os
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,6 +17,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from kiro_crew.dashboard.handlers import api_browse_files
+from kiro_crew.dashboard.handlers.files import _browse_files_sync
 
 
 def _make_app() -> web.Application:
@@ -213,3 +215,25 @@ class TestBrowseFiles:
                 data = await resp.json()
                 entry = next(e for e in data["files"] if e["name"] == "racey.md")
                 assert entry["mtime"] == 0
+
+    @pytest.mark.asyncio
+    async def test_scan_does_not_run_on_the_event_loop(self, tmp_path, mock_sel):
+        """The walk must execute off the loop thread — see the sibling dirs test."""
+        (tmp_path / "alpha").mkdir()
+        (tmp_path / "readme.md").write_text("hello")
+        loop_thread = threading.get_ident()
+        ran_on: list[int] = []
+
+        def spy(base: str, skip: set[str]) -> tuple[list[dict], list[dict]]:
+            ran_on.append(threading.get_ident())
+            return _browse_files_sync(base, skip)
+
+        with patch("kiro_crew.dashboard.handlers.files._browse_files_sync", spy):
+            async with TestClient(TestServer(_make_app())) as client:
+                resp = await client.get(f"/api/browse-files?path={tmp_path}")
+                assert resp.status == 200
+                data = await resp.json()
+                assert {d["name"] for d in data["dirs"]} == {"alpha"}
+                assert {f["name"] for f in data["files"]} == {"readme.md"}
+        assert ran_on, "the scan helper was never called"
+        assert ran_on[0] != loop_thread


### PR DESCRIPTION
## What

Three request paths did unbounded filesystem work synchronously on the single asyncio loop, so each one blocked every other request for its duration. All three now run via `asyncio.to_thread`, which is the idiom already used throughout both files.

| Path | Blocking work |
| --- | --- |
| `api_browse_dirs` | inline `os.scandir` walk over a caller-chosen directory that defaults to `$HOME`, plus an `is_sensitive_path` call per surviving entry that resolves several paths of its own |
| `api_browse_files` | the same walk with a different sort key, plus a `stat` per entry for the mtime the browser sorts on |
| session replay in the turn runner | resolves a chat's tab id by globbing and opening every session file sharing it to rebuild an index, then reads each chained file in full |

The two scans move into `_browse_dirs_sync` and `_browse_files_sync` unchanged, including the `PermissionError` handling that makes an unreadable directory return an empty listing. No behaviour change is intended.

`api_browse_files` is included because it carries the identical defect 270 lines below its sibling in the same file; fixing one and not the other seemed worse than one slightly wider diff. Happy to split it out if you would rather review them separately.

## Tests

`test_browse_dirs.py` and `test_browse_files.py` already drive both endpoints end-to-end through `TestServer`, and they stay green — but that is weak evidence for an offload, which is behaviour-preserving by construction. Removing the `await` and calling the helpers synchronously leaves all 19 existing tests passing, so nothing in the suite could tell the fix from a no-op.

Each endpoint therefore gains one test that records the thread the scan really runs on and asserts it is not the loop thread. With the offload reverted, exactly those two fail while the other 19 still pass. No sleeps and no duration assertions.

The replay call site has no equivalent guard — reaching it needs the full turn-runner harness.

## Verification

- `pytest test/test_browse_dirs.py test/test_browse_files.py` — 21 passed
- wider sweep over the other `handlers/files.py` consumers (`api_file_diff`, `file_download`, `reveal_path`, `project_git`, `file_search_dirs`, `history_race`) — 117 passed
- `isort --check-only` and `flake8` clean on all four files; `mypy src/kiro_crew` clean
- as a control that the moved code is genuinely covered, dropping the `skip` filter from the helper is caught by `test_skips_hidden_and_excluded`
