### PR TITLE
test(website): use restorable spies for URL.createObjectURL stubs

### DIFF
--- a/website/src/test/ArtifactDetailPage.test.tsx
+++ b/website/src/test/ArtifactDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { screen, waitFor, fireEvent } from '@testing-library/react'
 import { Routes, Route, useNavigate } from 'react-router-dom'
 import ArtifactDetailPage from '../pages/ArtifactDetailPage'
@@ -64,13 +64,10 @@ async function versionRowLabels() {
 describe('ArtifactDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // jsdom needs URL.createObjectURL for blob iframes
-    if (!URL.createObjectURL) {
-      // @ts-expect-error stub
-      URL.createObjectURL = vi.fn().mockReturnValue('blob:test')
-      // @ts-expect-error stub
-      URL.revokeObjectURL = vi.fn()
-    }
+    // Spy rather than assign: only a spy lands in the registry that
+    // vi.restoreAllMocks() can undo. The env provides both natively.
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     // Default events response so the events query never throws "undefined".
     // Individual tests can override this with .mockResolvedValueOnce when
     // they need a specific event log.
@@ -90,6 +87,10 @@ describe('ArtifactDetailPage', () => {
     // ends — an unhandled rejection that fails the run (`Errors: N errors`)
     // while every test still reports as passing.
     vi.mocked(api).chatSlots = vi.fn().mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('renders artifact metadata and iframe', async () => {

--- a/website/src/test/WidgetFrame.test.tsx
+++ b/website/src/test/WidgetFrame.test.tsx
@@ -59,8 +59,8 @@ beforeEach(() => {
       }
     }
   } as typeof Blob
-  URL.createObjectURL = vi.fn().mockReturnValue('blob:test-widget')
-  URL.revokeObjectURL = vi.fn()
+  vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test-widget')
+  vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
 
   // Jest-dom inherits the real CSSOM, so spy on getComputedStyle to inject a
   // deterministic set of custom properties. The parent app's useTheme applies
@@ -283,8 +283,8 @@ describe('WidgetFrame openInNewTab', () => {
       if (typeof parts[0] === 'string') wrapper = parts[0] as string
       return new realBlob(parts, opts)
     })
-    URL.createObjectURL = vi.fn().mockReturnValue('blob:test')
-    URL.revokeObjectURL = vi.fn()
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     vi.spyOn(window, 'open').mockReturnValue(null)
 
     const btn = container.querySelector('button[aria-label="Open in new tab"]') as HTMLButtonElement
@@ -302,8 +302,8 @@ describe('WidgetFrame openInNewTab', () => {
       mimeType = opts?.type ?? ''
       return new realBlob(args[0] as BlobPart[], opts)
     })
-    URL.createObjectURL = vi.fn().mockReturnValue('blob:test')
-    URL.revokeObjectURL = vi.fn()
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     vi.spyOn(window, 'open').mockReturnValue(null)
 
     const btn = container.querySelector('button[aria-label="Open in new tab"]') as HTMLButtonElement


### PR DESCRIPTION
## What

Two test files stubbed `URL.createObjectURL` / `URL.revokeObjectURL` by **direct property assignment** — four sites, eight statements. `vi.restoreAllMocks()` cannot undo a direct assignment, so each stub outlives the test that installed it. This converts them to `vi.spyOn`, which lands in the registry that `restoreAllMocks()` can actually clean up.

Test-only change. No production code touched.

## Why — the rule is already stated in this repo

`website/src/test/WidgetFrame.test.tsx` already documents exactly this hazard, in its own comment on the neighbouring `matchMedia` stub:

> Unconditional — don't inherit a prior test's stub, since matchMedia is a direct property assignment (not a spy) and `vi.restoreAllMocks()` can't undo it.

This applies that same rule to the two sites that still assign directly. The `matchMedia` stub itself is left alone (out of scope).

## Scope — what this does and does not fix

This is **test hygiene**. It fixes no user-visible bug and no currently-failing test. The honest claim is narrower: today nothing escapes a test file only because Vitest's `isolate: true` default rebuilds the environment per file, so suite correctness rests silently on a config default that a future performance change could flip. After this change the stubs restore on their own.

No performance claim is attached to this.

## The `ArtifactDetailPage` guard — a deliberate semantic change

`ArtifactDetailPage.test.tsx` guarded its stub:

```ts
if (!URL.createObjectURL) {
  // @ts-expect-error stub
  URL.createObjectURL = vi.fn().mockReturnValue('blob:test')
  ...
}
```

`spyOn` requires the property to exist, so converting is not a like-for-like swap and deserves a straight answer: **that branch was dead code.** The test environment supplies `URL.createObjectURL` natively, so the condition was always false and the stub never installed — those tests were quietly exercising the real implementation, never the intended `'blob:test'` double. Measured directly: a probe asserting the guard's own condition (`Boolean(URL.createObjectURL)`) is true passed, and the value returned before any local stub is the environment's native `blob:nodedata:<uuid>`, not `'blob:test'`.

So the conversion drops the dead branch and makes the double real for the first time, and `spyOn`'s existence requirement is satisfied by the same environment that made the guard dead. Both `@ts-expect-error` directives go with the assignments they covered.

That file had no `afterEach` at all, so one was added to restore its spies. (`WidgetFrame.test.tsx` already has one; it was not touched, and no second hook was added.) Adding a shared restore there is safe: all five pre-existing `vi.spyOn` calls in the file sit inside individual `it()` bodies and already call `mockRestore()` themselves, so no suite-level spy gets torn down under a later test.

## Verification

- **Negative control (the point of the exercise).** A green suite after a hygiene change is also what a no-op produces, so the leak was made to reproduce on demand. A temporary detector file, with no `beforeEach` of its own, was run after `WidgetFrame.test.tsx` in the same worker under `--no-isolate --fileParallelism=false`:
  - with the spies: detector sees the native `blob:nodedata:<uuid>` — **passes**.
  - reverting a **single** site to a direct assignment: detector sees `blob:test-widget`, i.e. the stub escaped its file — **fails** with `expected 'blob:test-widget' to match /^blob:nodedata:/`.
  - `WidgetFrame`'s own 35 tests pass in **both** runs, which is precisely why this is latent rather than currently-breaking.
  The detector was temporary and is not part of this PR.
- **Target suites:** `ArtifactDetailPage` + `WidgetFrame` — 88 passed before, 88 passed after.
- **Full website suite:** 921 files / 14329 passed / 2 expected-fail / 3 skipped — identical before and after (baseline taken by stashing this change and re-running).
- **eslint** on both files: 0 errors (3 pre-existing `no-explicit-any` warnings, unchanged in count from the base commit).

One note for maintainers, unrelated to this change: `npm run typecheck` does not cover test files at all. Root `tsconfig.json` is `{"files": [], "references": [...]}`, so `tsc --noEmit` compiles **0 files**, and `tsconfig.app.json` excludes `src/test` and `**/*.test.tsx`. Happy to open a separate issue if that is not already known.
