### PR TITLE
fix(memory): select injected lessons by relevance, not recency

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -494,7 +494,7 @@ User-taught corrections ("always do X", "never do Y"). Single write path through
 
 **Migration**: `migrate_from_markdown()` reads `lessons.jsonl` and writes each entry as `lesson.*` semantic key with `source=migration, confidence=0.9`. User-explicit lessons (confidence 1.0) can't be overwritten by migration.
 
-Categories: `tool`, `preference`, `knowledge`. Injected as a `[Learned corrections]` block, at most 50 lessons (`get_lessons(limit=50)` in the vector path, `_MAX_LESSONS_IN_CONTEXT = 50` in the JSONL path). The JSONL store itself retains `_MAX_LESSONS_TOTAL = 200` and prunes oldest-first beyond that, so "50 in context" and "200 on disk" are different numbers.
+Categories: `tool`, `preference`, `knowledge`. Injected as a `[Learned corrections]` block. The vector path ranks lessons by hybrid relevance to the incoming request and fills the caller's character budget, stating in the block how many of the stored lessons are shown and how many are omitted; the JSONL path caps at `_MAX_LESSONS_IN_CONTEXT = 50`. The JSONL store itself retains `_MAX_LESSONS_TOTAL = 200` and prunes oldest-first beyond that, so what reaches the context and what sits on disk are different numbers.
 
 ### Conflict resolution: which layer wins
 

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -1608,6 +1608,7 @@ class ContextBuilder:
         exclude_last_n: int = 0,
         model_window: int | None = None,
         context_groups: frozenset[str] | None = None,
+        query_text: str = "",
     ) -> str:
         """Build context for a new session (memory + skills + history).
 
@@ -1946,7 +1947,11 @@ class ContextBuilder:
             # store holds no lessons, so a separate get_lessons() existence probe
             # would be a duplicate SELECT * over the same rows (embedding blobs
             # included) whose only use is an emptiness check.
-            lessons_ctx = memory.vector_store.get_lessons_context() if memory.vector_store else ""
+            lessons_ctx = (
+                memory.vector_store.get_lessons_context(query_text=query_text, cap=caps.lessons)
+                if memory.vector_store
+                else ""
+            )
             if not lessons_ctx:
                 lessons_ctx = self.lessons.get_context()
             if lessons_ctx:
@@ -2130,6 +2135,7 @@ class ContextBuilder:
                 exclude_last_n=exclude_last_n,
                 model_window=model_window,
                 context_groups=context_groups,
+                query_text=text,
             )
             if session_ctx:
                 # Scrub forgeable boundary markers from the UNTRUSTED content in

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -132,6 +132,24 @@ _MMR_MAX_POOL = 1000
 _SEMANTIC_VECTOR_WEIGHT = 0.6  # weight for vector score in hybrid semantic retrieval
 _SEMANTIC_KEYWORD_WEIGHT = 0.4  # weight for keyword score in hybrid semantic retrieval
 
+
+def _keyword_score(raw_overlap: int) -> float:
+    """Normalize a raw keyword-overlap count to [0, 1]."""
+    return min(raw_overlap / 10.0, 1.0) if raw_overlap > 0 else 0.0
+
+
+def _hybrid_score(keyword: float, vector: float) -> float:
+    """Merge keyword and vector scores, degrading to keyword-only without a vector.
+
+    Shared by every hybrid retrieval path so the weighting cannot drift between
+    them; each caller still chooses which text it matches and where its vector
+    comes from, because those differ legitimately.
+    """
+    if vector > 0:
+        return _SEMANTIC_VECTOR_WEIGHT * vector + _SEMANTIC_KEYWORD_WEIGHT * keyword
+    return keyword
+
+
 # snowballstemmer's pure-Python stemmers keep the word being stemmed as
 # mutable instance state (set_current() -> _stem() -> get_current()), so a
 # single shared instance is NOT thread-safe: concurrent context builds
@@ -987,8 +1005,7 @@ class VectorMemoryStore:
                 key_overlap = len(query_words & key_words)
                 val_overlap = len(query_words & val_words)
                 kw_raw = key_overlap * 3 + val_overlap
-                # Normalize keyword score to [0, 1]
-                kw_score = min(kw_raw / 10.0, 1.0) if kw_raw > 0 else 0.0
+                kw_score = _keyword_score(kw_raw)
 
                 # Vector score (when embeddings available)
                 vec_score = 0.0
@@ -998,13 +1015,7 @@ class VectorMemoryStore:
                     if entry_emb:
                         vec_score = max(0.0, self._cosine_sim(query_embedding, entry_emb))
 
-                # Hybrid merge
-                if query_embedding is not None and vec_score > 0:
-                    score = (
-                        _SEMANTIC_VECTOR_WEIGHT * vec_score + _SEMANTIC_KEYWORD_WEIGHT * kw_score
-                    )
-                else:
-                    score = kw_score
+                score = _hybrid_score(kw_score, vec_score)
 
                 if score > 0:
                     scored_rows.append((score, dict(r)))
@@ -2273,21 +2284,98 @@ class VectorMemoryStore:
                 deleted = True
         return deleted
 
-    def get_lessons_context(self) -> str:
-        """Format lessons for prompt injection."""
-        lessons = self.get_lessons(limit=50)
-        if not lessons:
-            return ""
-        lines = [
-            "[Learned corrections — user-taught rules from past mistakes.\n"
-            "ALWAYS follow these. They override default behavior.]"
+    def get_lessons_context(self, query_text: str = "", cap: int = 0) -> str:
+        """Format lessons for prompt injection, most relevant first.
+
+        Lessons are ranked against *query_text* using the same hybrid
+        vector + keyword score as :meth:`get_semantic_context`, then emitted
+        until *cap* characters are used. Ranking is relevance-only — neither
+        ``source`` nor ``confidence`` contributes — so an unrelated user-taught
+        rule cannot displace a relevant inferred one.
+
+        Args:
+            query_text: Request to rank against. Empty keeps recency order.
+            cap: Character budget for the rendered block. 0 means unbounded.
+        """
+        entries = [
+            (row, text)
+            for row in self.get_lessons()
+            if (text := _lesson_display_text(json.loads(row["value_json"])))
         ]
-        for e in lessons:
-            text = _lesson_display_text(json.loads(e["value_json"]))
-            if text:
-                lines.append(f"- {text}")
-        lines.append("[End of learned corrections]\n")
-        return "\n".join(lines)
+        if not entries:
+            return ""
+        total = len(entries)
+        ranked = self._rank_lessons(entries, query_text) if query_text else entries
+        order = "most relevant" if query_text else "most recent"
+
+        def render(rows: list[tuple[dict, str]]) -> str:
+            header = (
+                "[Learned corrections — user-taught rules from past mistakes.\n"
+                "ALWAYS follow these. They override default behavior."
+            )
+            if len(rows) < total:
+                header += (
+                    f"\nShowing {len(rows)} of {total} lessons, {order} first; "
+                    f"{total - len(rows)} omitted."
+                )
+            body = "\n".join(f"- {text}" for _, text in rows)
+            return f"{header}]\n{body}\n[End of learned corrections]\n"
+
+        if not cap:
+            return render(ranked)
+
+        selected: list[tuple[dict, str]] = []
+        used = 0
+        for entry in ranked:
+            size = len(entry[1]) + 3  # "- " prefix and newline
+            if selected and used + size > cap:
+                # Skip rather than stop: one long lesson high in the ranking
+                # must not discard every shorter one behind it that still fits.
+                continue
+            selected.append(entry)
+            used += size
+        # The header grows with the counts it reports, so trim to fit rather
+        # than reserving a guessed margin. At least one lesson is always kept.
+        while len(selected) > 1 and len(render(selected)) > cap:
+            selected.pop()
+        return render(selected)
+
+    def _rank_lessons(
+        self, entries: list[tuple[dict, str]], query_text: str
+    ) -> list[tuple[dict, str]]:
+        """Order *entries* by hybrid relevance to *query_text*, most relevant first.
+
+        Stored ``embedding`` blobs are reused, so this costs one embed for the
+        query rather than one per lesson. The sort is stable and *entries*
+        arrives newest-first, so equal scores keep recency order and a query
+        that matches nothing degrades to plain recency.
+        """
+        query_words = _stem_words(set(re.findall(r"\w+", query_text.lower())))
+        query_emb = self._try_embed(query_text) if self.embed_fn else None
+        scored: list[tuple[float, tuple[dict, str]]] = []
+        for entry in entries:
+            row, text = entry
+            # Only the rendered text is matched. A lesson key is
+            # ``lesson.<md5hash>``, which carries no words, so there is no key
+            # term to weight here the way get_semantic_context() weights its own.
+            overlap = len(query_words & _stem_words(set(re.findall(r"\w+", text.lower()))))
+            score = _hybrid_score(
+                _keyword_score(overlap), self._stored_similarity(row, query_emb)
+            )
+            scored.append((score, entry))
+        scored.sort(key=lambda pair: -pair[0])
+        return [entry for _, entry in scored]
+
+    def _stored_similarity(self, entry: dict, query_emb: list[float] | None) -> float:
+        """Cosine similarity between *query_emb* and a row's stored embedding."""
+        blob = entry.get("embedding")
+        if query_emb is None or not isinstance(blob, bytes) or len(blob) < 4:
+            return 0.0
+        try:
+            stored = struct.unpack(f"{len(blob) // 4}f", blob)
+        except struct.error:
+            return 0.0
+        return max(0.0, self._cosine_sim(query_emb, list(stored)))
 
     # ── Migration & Import ──
 
@@ -3018,7 +3106,7 @@ class VectorMemoryStore:
         """Preview what would be injected into context (for debugging)."""
         semantic = self.get_semantic_context(query_text=query_text)
         episodic = self.get_episodic_context(query_text=query_text)
-        lessons = self.get_lessons_context()
+        lessons = self.get_lessons_context(query_text=query_text)
         return {
             "semantic_chars": len(semantic),
             "episodic_chars": len(episodic),

--- a/test/test_lesson_ranking.py
+++ b/test/test_lesson_ranking.py
@@ -1,0 +1,190 @@
+"""Tests for relevance-ranked lesson injection via ``get_lessons_context``."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.vector_memory import VectorMemoryStore
+
+# Deliberately share no significant words, so write_lesson's topic-overlap
+# dedup keeps all of them and each test controls the ordering it exercises.
+TABS = "Prefer tabs over spaces in Makefiles"
+MIGRATION = "Run the database migration before deploying"
+FORCE_PUSH = "Never force push to a shared branch"
+DIGEST = "Pin container images by digest rather than tag"
+CERTIFICATE = "Rotate the signing certificate every ninety days"
+ALL_RULES = (TABS, MIGRATION, FORCE_PUSH, DIGEST, CERTIFICATE)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Iterator[VectorMemoryStore]:
+    memory = VectorMemoryStore(db_path=tmp_path / "mem.db")
+    memory.init()
+    yield memory
+    memory.close()
+
+
+def shown(block: str) -> list[str]:
+    """The lesson bodies rendered in *block*, in order."""
+    return [line[2:] for line in block.splitlines() if line.startswith("- ")]
+
+
+class TestRelevanceOrdering:
+    def test_relevant_lesson_outranks_newer_ones(self, store: VectorMemoryStore) -> None:
+        """Keyword overlap wins over write order."""
+        for rule in (MIGRATION, FORCE_PUSH, TABS):
+            store.write_lesson(rule)
+
+        block = store.get_lessons_context(query_text="how do I run a database migration")
+
+        assert shown(block)[0] == MIGRATION
+
+    def test_order_is_labelled_when_lessons_are_omitted(self, store: VectorMemoryStore) -> None:
+        """The scope line names the ordering so a truncated block is unambiguous."""
+        for rule in ALL_RULES:
+            store.write_lesson(rule)
+
+        ranked = store.get_lessons_context(query_text=MIGRATION, cap=250)
+        recent = store.get_lessons_context(cap=250)
+
+        assert "most relevant first" in ranked
+        assert "most recent first" in recent
+
+    def test_unmatched_query_falls_back_to_recency(self, store: VectorMemoryStore) -> None:
+        """A query matching nothing leaves the newest-first order intact."""
+        store.write_lesson(TABS)
+        store.write_lesson(MIGRATION)
+
+        block = store.get_lessons_context(query_text="unrelated zebra xylophone")
+
+        assert shown(block) == [MIGRATION, TABS]
+
+    def test_no_query_keeps_recency_order(self, store: VectorMemoryStore) -> None:
+        store.write_lesson(TABS)
+        store.write_lesson(MIGRATION)
+
+        block = store.get_lessons_context()
+
+        assert shown(block) == [MIGRATION, TABS]
+        assert "most recent first" not in block  # nothing omitted, so no scope line
+
+
+class TestCharacterBudget:
+    def test_unbounded_cap_shows_every_lesson(self, store: VectorMemoryStore) -> None:
+        for rule in ALL_RULES:
+            store.write_lesson(rule)
+
+        block = store.get_lessons_context()
+
+        assert len(shown(block)) == len(ALL_RULES)
+        assert "omitted" not in block
+
+    def test_cap_is_respected_and_omissions_reported(self, store: VectorMemoryStore) -> None:
+        for rule in ALL_RULES:
+            store.write_lesson(rule)
+
+        block = store.get_lessons_context(cap=250)
+
+        assert len(block) <= 250
+        assert 0 < len(shown(block)) < len(ALL_RULES)
+        assert f"of {len(ALL_RULES)} lessons" in block
+        assert "omitted." in block
+
+    def test_one_lesson_survives_an_unmeetable_cap(self, store: VectorMemoryStore) -> None:
+        """A cap smaller than any single lesson still yields the top-ranked one."""
+        store.write_lesson(TABS)
+        store.write_lesson(MIGRATION)
+
+        block = store.get_lessons_context(query_text=MIGRATION, cap=1)
+
+        assert shown(block) == [MIGRATION]
+
+    def test_a_lesson_too_long_to_fit_does_not_discard_shorter_ones(
+        self, store: VectorMemoryStore
+    ) -> None:
+        """An oversized lesson is skipped, not treated as the end of the budget.
+
+        Stopping at the first lesson that does not fit would throw away every
+        shorter lesson ranked behind it, wasting the remaining budget. The
+        oversized rule is written second of three so it lands in the MIDDLE of
+        the recency order, which is the only arrangement where skipping and
+        stopping differ.
+        """
+        oversized = "Avoid " + "verbosity " * 60
+        store.write_lesson(MIGRATION)  # ranked last
+        store.write_lesson(oversized)  # ranked middle, cannot fit
+        store.write_lesson(TABS)  # ranked first, fits
+
+        block = store.get_lessons_context(cap=500)
+
+        assert shown(block) == [TABS, MIGRATION]
+        assert oversized not in shown(block)
+
+    def test_empty_store_yields_nothing(self, store: VectorMemoryStore) -> None:
+        assert store.get_lessons_context(query_text="anything", cap=1000) == ""
+
+
+class TestVectorScoring:
+    def test_query_is_embedded_once_and_row_vectors_reused(self, store: VectorMemoryStore) -> None:
+        """Ranking reads stored embeddings instead of re-embedding each lesson."""
+        vectors = {MIGRATION: [1.0, 0.0, 0.0], TABS: [0.0, 1.0, 0.0]}
+        embedded: list[str] = []
+
+        def embed(text: str) -> list[float]:
+            embedded.append(text)
+            return vectors.get(text, [0.0, 0.0, 1.0])
+
+        store.embed_fn = embed
+        store.write_lesson(TABS)
+        store.write_lesson(MIGRATION)
+        embedded.clear()
+
+        block = store.get_lessons_context(query_text=MIGRATION)
+
+        assert embedded == [MIGRATION]
+        assert shown(block)[0] == MIGRATION
+
+    def test_missing_row_embedding_degrades_to_keywords(self, store: VectorMemoryStore) -> None:
+        """A lesson stored without a vector is still ranked on keyword overlap."""
+        store.write_lesson(MIGRATION)
+        store.write_lesson(TABS)
+        store.embed_fn = lambda text: [1.0, 0.0, 0.0]
+
+        block = store.get_lessons_context(query_text="database migration deploying")
+
+        assert shown(block)[0] == MIGRATION
+
+
+class TestImportedLessonShapes:
+    """Imported lessons are stored as a mapping, not a string (see #2656)."""
+
+    def test_mapping_lesson_renders_as_its_rule_and_ranks(
+        self, store: VectorMemoryStore
+    ) -> None:
+        store.write_lesson(TABS)
+        store.set_semantic(
+            "lesson.imported01",
+            {"rule": MIGRATION, "category": "knowledge", "negative": None},
+            1.0,
+            "user_explicit",
+        )
+
+        block = store.get_lessons_context(query_text="database migration deploying")
+
+        assert shown(block)[0] == MIGRATION
+        assert "'rule'" not in block
+
+    def test_unrenderable_lesson_is_excluded_from_the_counts(
+        self, store: VectorMemoryStore
+    ) -> None:
+        """A shape with no rule is skipped, so it cannot be reported as omitted."""
+        store.write_lesson(TABS)
+        store.set_semantic("lesson.imported02", {"category": "knowledge"}, 1.0, "user_explicit")
+
+        block = store.get_lessons_context()
+
+        assert shown(block) == [TABS]
+        assert "omitted" not in block

--- a/test/test_subagent_context_groups.py
+++ b/test/test_subagent_context_groups.py
@@ -186,7 +186,7 @@ class TestEpisodicMemoryGate:
         store._vector_store = SimpleNamespace(
             get_episodic_context=lambda query_text, cap: "[EPISODIC-SENTINEL]",
             get_semantic_context=lambda query_text, cap: "",
-            get_lessons_context=lambda: "",
+            get_lessons_context=lambda query_text, cap: "",
         )
         return builder
 


### PR DESCRIPTION
## Problem

`VectorMemoryStore.get_lessons_context()` selected lessons with
`ORDER BY updated_at DESC LIMIT 50`.

Two problems follow from that:

1. **Most of the store is dropped.** The lesson store grows without bound. Past
   50 lessons, the majority are excluded from every session, and which 50
   survive depends only on when they were taught.
2. **The character budget went partly unused.** `context.py` allocates
   `caps.lessons` characters to this block, but the row cap ignored it. On a
   store I measured, 50 lessons filled 26,955 of a 37,250-character budget —
   roughly 16 more lessons would have fit while lessons just past the cutoff
   were discarded.

The practical effect is that a rule stated once decays out of context within
days and is then violated. The only way to keep a lesson alive was to re-teach
it, which is why long-lived lessons accumulate "confirmed again" restatements.

The omission was also silent. The truncation notice in `context.py` fires on the
*character* cap, which the 50-row block never reached, so nothing indicated that
most of the store was missing.

## Change

Rank lessons against the incoming request using the same hybrid
vector + keyword score `get_semantic_context()` already uses, then fill to the
caller's character budget instead of a row count. The injected set becomes the
most relevant N that fit.

- `get_lessons_context(query_text="", cap=0)` — ranks and fills to `cap`.
  Defaults preserve the previous no-argument behaviour for existing callers.
- `build_session_context(..., query_text="")` threads the request text through;
  `build_message()` passes the message it already has.
- `get_context_preview()` now previews the ranking for its own query.

Three properties worth calling out:

**Ranking is relevance-only.** Neither `source` nor `confidence` is weighted, so
an unrelated user-taught rule cannot displace a relevant one that consolidation
inferred.

**One embed per call, not one per lesson.** Lesson rows already carry
`embedding` blobs (`_backfill_lesson_embeddings` keeps them populated), so
ranking reads stored vectors and embeds only the query.

**Ordering degrades safely.** Every lesson stays a candidate at score 0 and
`get_lessons()` returns them newest-first, so a query that matches nothing
reproduces the previous recency order. The block never contains fewer lessons
than before.

The rendered block now states its scope, e.g.
`Showing 61 of 275 lessons, most relevant first; 214 omitted.`

## Scope note

Relevance ranking helps topically-related lessons and does not help universal
preconditions — a rule like "always create a fresh workspace before starting a
task" carries no topical content by design, so it scores low against any
specific request. Addressing that needs an explicit always-inject mechanism and
is deliberately left out of this change.

## Tests

New `test/test_lesson_ranking.py` covers relevance ordering, recency fallback
for an unmatched query, the character budget and its reported omissions, keeping
one lesson under an unmeetable cap, the empty store, single-embed reuse of
stored vectors, and keyword-only degradation when a row has no vector.

`test/test_subagent_context_groups.py` has a one-line change: its stubbed vector
store used `get_lessons_context=lambda: ""` while the sibling stubs already took
`(query_text, cap)`. The stub now matches the real signature.

## Verification

- `flake8 src/kiro_crew test` — clean
- `isort --check-only src/kiro_crew test` — clean
- `mypy src/kiro_crew/vector_memory.py src/kiro_crew/context.py` — clean
- `scripts/scrub-lint.sh --no-history` — clean
- 1147 tests pass across the memory, context, lesson, onboarding, and
  subagent-context-group suites

Two failures in `TestEmbeddingDimPlumbing` were present before this change on a
clean tree; they come from an incomplete local dependency install (this
environment cannot build numpy or Pillow from source), not from this change.

## Related Issues

Fixes #2912
