### PR TITLE
fix: finish Make Live via detached kirocrew restart when no manager is drivable (#2566)

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -34,7 +34,7 @@ verification. Route names below are relative to that prefix.
 
 | Route | Description |
 |-------|-------------|
-| `/apps/dev-fleet/api/health` | Liveness + gateway **start identity**: `{status, start_id}`. `start_id` is the live unit's `ExecMainStartTimestampMonotonic` (or `null` when unavailable); the dashboard polls it to detect the NEW process after a restart (see Action narration). Served on the proxied `/api/` namespace because the gateway only forwards `/apps/dev-fleet/api/*` to the backend. (The bare `/health` carries the same body but is HMAC-exempt and reached only by the gateway's own internal liveness poll.) |
+| `/apps/dev-fleet/api/health` | Liveness + gateway **start identity**: `{status, start_id}`. `start_id` is the live unit's `ExecMainStartTimestampMonotonic` (launchd: job PID; foreground last resort: run-marker pid; `null` when unavailable); the dashboard polls it to detect the NEW process after a restart (see Action narration). Served on the proxied `/api/` namespace because the gateway only forwards `/apps/dev-fleet/api/*` to the backend. (The bare `/health` carries the same body but is HMAC-exempt and reached only by the gateway's own internal liveness poll.) |
 | `/apps/dev-fleet/api/fleet` | Lightweight worktree + pod list (polled every 12s). `?fresh=1` forces cache bypass. |
 | `/apps/dev-fleet/api/worktree?name=` | Lazy per-branch detail: PR, commits, disk usage |
 | `/apps/dev-fleet/api/pod/logs?name=&n=` | Pod journal tail (recent N lines, default 120) |
@@ -314,7 +314,11 @@ scheduling the restart and hands it to the frontend:
 
 - **Identity is manager-specific.** systemd uses
   `ExecMainStartTimestampMonotonic`; launchd uses the loaded job PID. Both change
-  when the replacement main process starts.
+  when the replacement main process starts. On a host with NO drivable manager
+  (the foreground last resort below) the identity is the pid the gateway records
+  in its `run/gateway-<port>.pid` sidecar — written before readiness is
+  published, rewritten by the replacement, and consumed by the same
+  changed-identity comparison unchanged.
 - The current identity is reported by extending the existing **`/health`**
   surface (`{status, start_id}`). Because the gateway proxies only
   `/apps/dev-fleet/api/*` to the backend, the same handler is registered at
@@ -504,7 +508,7 @@ On a `write_failed` / `restart_failed` refusal the response includes
 `rolled_back: true|false` — whether the pre-cutover pointer state (prior
 content, or absence) was successfully restored on disk.
 
-### Two outcomes: automatic vs staged-only
+### Three outcomes: automatic, foreground last resort, staged-only
 
 The cutover writes the pointer on every platform. What differs is whether Dev
 Fleet can also bounce the gateway:
@@ -515,10 +519,33 @@ Fleet can also bounce the gateway:
   on Linux, bounded graceful `launchctl stop` on macOS), sets the
   `_MAKE_LIVE_COMMITTED` latch, and returns `start_id` for the restart handshake.
   The next gateway process reads the pointer and execs into the target checkout.
-- **Staged only** (`can_restart = False`): no drivable service manager is
-  available (system unit via `kirocrew service install`, macOS without a launchd
-  agent or with a legacy restart contract, terminal-launched gateway, or another
-  unsupported manager). The pointer is still
+- **Foreground last resort**: when the manager probe reports one of
+  `no_systemd` / `no_user_unit` / `no_launchd` / `no_agent` — nothing to drive at
+  all, e.g. a terminal-launched gateway on a host whose per-user systemd cannot
+  be used — `gateway_service.ForegroundBackend` finishes the cutover by
+  establishing a **detached `kirocrew restart --port <port>`** (new session, so
+  it survives the gateway it kills), reusing the CLI's whole kill-and-respawn
+  path instead of reimplementing it. Selection is strictly
+  systemd > launchd > foreground, POSIX-only, and requires: an UNCONFINED
+  backend (no `KIROCREW_SANDBOX_ACTIVE` marker, not inside
+  `kirocrew-agents.slice` — a replacement spawned from inside the sandbox or
+  cgroup scope would inherit that confinement for the gateway's whole life);
+  exactly ONE run-marker whose recorded pid is alive; and the marker's own
+  recorded `kirocrew` launcher (keystone-fenced `run/` dir — there is
+  deliberately NO `PATH` fallback, which an agent-planted `~/.local/bin/kirocrew`
+  could poison). The mis-set-up manager codes (`user_unit_inactive`,
+  `agent_not_indirected`, `agent_restart_contract_outdated`,
+  `live_program_missing`) keep their named remedies and are never bounced
+  behind the manager's back. On success the response looks exactly like an
+  automatic cutover (`start_id` = pre-restart marker pid, latch set). **Fail
+  safe:** the backend never signals any process itself — if any requirement
+  above fails or the detached spawn cannot be established, nothing has been
+  killed and the request degrades to the staged-only outcome below, pointer
+  intact.
+- **Staged only** (`can_restart = False`, no usable foreground gateway): no
+  drivable service manager is available (system unit via `kirocrew service
+  install`, macOS without a launchd agent or with a legacy restart contract, or
+  another unsupported manager). The pointer is still
   written and the cutover is reported as a success carrying `staged_only: true`,
   plus `manual_restart` (the shell command that finishes it) and a human-readable
   `notice`. The latch is deliberately NOT set — no restart is pending, so a

--- a/src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
@@ -57,15 +57,26 @@ launchd analogue of systemd's ``no_user_unit``: installed, but not controllable
 this way, and actionable rather than a silent false success. An indirected agent
 with the legacy restart contract reports ``agent_restart_contract_outdated``. A
 loaded agent whose launcher has been deleted is reported as ``live_program_missing``.
+
+Hosts where NEITHER manager can be driven (:data:`FOREGROUND_ELIGIBLE`) get one
+last resort: :class:`ForegroundBackend`, which hands the bounce to a detached
+``kirocrew restart`` instead of a service manager. Strictly ordered
+systemd > launchd > foreground, and fail-safe by construction — it never
+signals anything itself, so a failed spawn leaves the running gateway
+untouched and the operator keeps the manual-restart advisory.
 """
 
 from __future__ import annotations
 
 import os
 import re
+import subprocess
 import uuid
 from pathlib import Path
-from typing import Awaitable, Callable, Protocol
+from typing import IO, Awaitable, Callable, Protocol
+
+from kiro_crew import platform_compat
+from kiro_crew.config.paths import config_dir
 
 # service.* is import-safe on every platform (it only touches launchctl/systemctl
 # when called) and never imports apps.*, so there is no cycle to dodge here.
@@ -550,6 +561,297 @@ class LaunchdBackend:
             return True
         except OSError:
             return False
+
+
+# --- foreground (last resort) --------------------------------------------------
+
+#: Eligibility codes under which the foreground backend may be attempted: the
+#: primary manager reported "nothing here to drive" at all. Deliberately
+#: EXCLUDES the codes where a manager exists but is mis-set-up
+#: (``user_unit_inactive``, ``agent_not_indirected``,
+#: ``agent_restart_contract_outdated``, ``live_program_missing``): those hosts
+#: have a named remedy, and a foreground kill-and-respawn behind the manager's
+#: back would leave the manager's view of its own job wrong.
+FOREGROUND_ELIGIBLE = frozenset(
+    {"no_systemd", "no_user_unit", "no_launchd", "no_agent"}
+)
+
+#: ``(port) -> pid | None`` — the pid sidecar the gateway writes beside its
+#: run-marker (see :mod:`kiro_crew.instances.run_marker`).
+ReadPid = Callable[[int], "int | None"]
+#: ``(port) -> launcher path | None`` — the run-marker's recorded launcher.
+ReadLauncher = Callable[[int], "str | None"]
+#: ``() -> [port, ...]`` — ports named by run-markers on disk.
+MarkerPorts = Callable[[], "list[int]"]
+#: ``(pid) -> bool`` — liveness probe (``platform_compat.pid_exists``).
+PidExists = Callable[[int], bool]
+#: ``(argv) -> None`` — establish a DETACHED process running *argv*, raising
+#: ``OSError`` when it cannot be established. The seam the tests inject a fake
+#: through; the real one is :func:`default_detached_spawn`.
+DetachedSpawn = Callable[[list[str]], None]
+
+
+#: ``() -> reason | None`` — is THIS process confined in a way a spawned
+#: replacement gateway would inherit? See :func:`default_confinement`.
+Confinement = Callable[[], "str | None"]
+
+
+def default_confinement() -> "str | None":
+    """Why a process spawned from here would inherit confinement, or ``None``.
+
+    The app backend this code runs in is spawned by the gateway through
+    ``wrap_argv`` (+ ``cgroup_scope_argv``): on a sandbox-capable host it lives
+    inside a user/mount namespace (or macOS seatbelt) and the
+    ``kirocrew-agents.slice`` cgroup scope. Namespaces and cgroups are
+    INHERITED by children regardless of ``start_new_session``, so a
+    ``kirocrew restart`` spawned from here would produce a replacement gateway
+    that (a) sees the sandbox's altered filesystem view forever, (b) carries an
+    agent-sized ``MemoryMax``/``TasksMax`` ceiling for the whole gateway, and
+    (c) — because ``cli.main()`` clears the inherited ``KIROCREW_SANDBOX_ACTIVE``
+    marker — re-wraps its own agent spawns in a NESTED sandbox that may fail.
+    Worse, the detached child shares the backend's scope, so a scope kill
+    mid-restart could strand the host with NO gateway.
+
+    Detection is deny-by-default on the two purpose-built signals:
+
+    * ``KIROCREW_SANDBOX_ACTIVE`` — exported only by the namespace launcher /
+      seatbelt env prefix, i.e. only ever present INSIDE the sandbox.
+    * ``kirocrew-agents.slice`` in ``/proc/self/cgroup`` — the transient scope
+      ``cgroup_scope_argv`` places every backend in (Linux only; the file does
+      not exist elsewhere and an unreadable file is treated as unconfined,
+      matching hosts where the scope probe failed and no scope was applied).
+    """
+    if os.environ.get("KIROCREW_SANDBOX_ACTIVE"):
+        return "the Dev Fleet backend runs inside the Kiro Crew OS sandbox"
+    try:
+        cgroup = Path("/proc/self/cgroup").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if "kirocrew-agents.slice" in cgroup:
+        return "the Dev Fleet backend runs inside the kirocrew-agents cgroup scope"
+    return None
+
+
+def default_detached_spawn(argv: list[str]) -> None:
+    """Spawn *argv* detached from this process (new session / own group).
+
+    The command must OUTLIVE us — it is ``kirocrew restart``, which kills the
+    gateway that (transitively) owns this backend — so it gets its own session
+    on POSIX (immune to our SIGHUP/SIGTERM propagation and to the gateway's
+    process-group teardown of app backends) and a detached console-less group
+    on Windows, mirroring ``cli_server._spawn_detached_gateway``. Output goes
+    to the same ``gateway.log`` the ``logs`` command tails, falling back to
+    ``DEVNULL`` when the log cannot be opened (a restart must not be refused
+    over a diagnostics file).
+
+    Raises ``OSError`` when the process cannot be established; the caller
+    treats that as "no replacement path exists" and falls back to the manual
+    advisory WITHOUT having signalled anything.
+    """
+    stdout: "IO[str] | int"
+    try:
+        log_path = config_dir() / "gateway.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        stdout = open(log_path, "a", encoding="utf-8")  # noqa: SIM115 — closed below
+    except OSError:
+        stdout = subprocess.DEVNULL
+    # argv is a validated launcher + fixed arguments (never LLM- or
+    # request-derived), same trust class as the systemd-run invocation the
+    # managed path issues.
+    try:
+        subprocess.Popen(  # noqa: S603
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout,
+            stderr=subprocess.STDOUT,
+            close_fds=True,
+            cwd=str(Path.home()),
+            start_new_session=platform_compat.IS_POSIX,
+            creationflags=(
+                platform_compat.DETACHED_PROCESS | platform_compat.CREATE_NEW_PROCESS_GROUP
+            ),
+        )
+    finally:
+        # Unlike cli_server's short-lived CLI process, this runs inside the
+        # long-lived app backend: the child holds its own duplicate of the fd
+        # after Popen, so the parent's copy must be closed on BOTH outcomes or
+        # every attempt (notably the failing ones, where the backend lives on)
+        # leaks a handle.
+        if not isinstance(stdout, int):
+            stdout.close()
+
+
+class ForegroundBackend:
+    """LAST-RESORT restart for a gateway that no service manager owns.
+
+    On a host where neither systemd nor launchd can be driven (see
+    :data:`FOREGROUND_ELIGIBLE`) the gateway is just a foreground/detached
+    process, and Make Live used to stage the live-target pointer and stop —
+    telling the operator to run ``kirocrew restart`` themselves. This backend
+    performs exactly that command FOR them, detached so it survives the death
+    of the gateway it bounces, and otherwise reuses the CLI's whole
+    kill-and-respawn path (lsof+SIGTERM the incumbent, wait, spawn a detached
+    replacement that reads the staged pointer, poll ``/api/ready``) rather than
+    reimplementing any of it.
+
+    Selection ordering is strictly systemd > launchd > foreground: callers only
+    construct this after the platform backend reported one of the
+    :data:`FOREGROUND_ELIGIBLE` codes, so no host that works today changes
+    behaviour.
+
+    **Identity.** There is no ``ExecMainStartTimestampMonotonic`` here, so
+    ``start_id`` is the pid the gateway records in its ``run/gateway-<port>.pid``
+    sidecar (written before readiness is published, cleared/rewritten by the
+    replacement) — the same identity ``kirocrew restart`` itself waits on, and
+    an opaque changes-on-replacement token exactly like the launchd PID the
+    dashboard handshake already consumes.
+
+    **Locating the gateway.** A gateway is a singleton per data home
+    (``gateway.lock``), and it prunes other ports' markers at startup, so the
+    run-markers normally name exactly one port. This backend requires exactly
+    ONE marker whose recorded pid is alive; zero (no gateway / no marker) or
+    several (stale crash leftovers that could make ``--port`` ambiguous) make it
+    report unavailable and the caller keeps the manual advisory.
+
+    **FAIL SAFE.** This class never signals any process itself. Its only
+    mutation is establishing the detached ``kirocrew restart``; when the binary
+    cannot be resolved or the spawn fails, nothing has been killed and the
+    running gateway is untouched — a failed restart that leaves no gateway is
+    far worse than the manual-advisory status quo.
+
+    **Confinement gate.** The Dev Fleet backend usually runs inside the
+    gateway-applied OS sandbox and ``kirocrew-agents.slice`` cgroup scope,
+    both of which a spawned replacement would inherit (see
+    :func:`default_confinement`). When confinement is detected this backend
+    reports unavailable and never spawns; only an unconfined backend (sandbox
+    off/unavailable on this host) may perform the foreground restart.
+    """
+
+    kind = "foreground"
+
+    def __init__(self, *, marker_ports: MarkerPorts, read_pid: ReadPid,
+                 read_launcher: ReadLauncher, pid_exists: PidExists,
+                 spawn: DetachedSpawn = default_detached_spawn,
+                 confinement: Confinement = default_confinement,
+                 ) -> None:
+        self._marker_ports = marker_ports
+        self._read_pid = read_pid
+        self._read_launcher = read_launcher
+        self._pid_exists = pid_exists
+        self._spawn = spawn
+        self._confinement = confinement
+
+    # -- discovery --
+    def _locate(self) -> "tuple[int, int] | None":
+        """``(port, pid)`` of the single live foreground gateway, or ``None``.
+
+        A marker is not proof of liveness (a crash leaves it behind), so only
+        markers whose recorded pid still exists count. Ambiguity — more than one
+        live (port, pid) — returns ``None`` rather than guessing which gateway
+        to bounce.
+        """
+        live: list[tuple[int, int]] = []
+        for port in self._marker_ports():
+            pid = self._read_pid(port)
+            if pid is not None and self._pid_exists(pid):
+                live.append((port, pid))
+        return live[0] if len(live) == 1 else None
+
+    @staticmethod
+    def _usable_launcher(path: "str | None") -> "str | None":
+        """*path* when it is an absolute, executable ``kirocrew`` file."""
+        if not path:
+            return None
+        p = Path(path)
+        # Basename check mirrors cli_server._own_console_script: a restart must
+        # exec the entry point it claims to be, never whatever an odd marker or
+        # PATH entry happens to name. .stem so a Windows ``kirocrew.exe`` would
+        # also pass, though callers currently construct this backend POSIX-only.
+        if p.stem != "kirocrew" or not p.is_absolute():
+            return None
+        try:
+            if p.is_file() and os.access(p, os.X_OK):
+                return str(p)
+        except OSError:
+            return None
+        return None
+
+    def _resolve_binary(self, port: int) -> "str | None":
+        """The ``kirocrew`` launcher to run the restart with, or ``None``.
+
+        ONLY the run-marker's recorded launcher — written by the running
+        gateway about ITSELF into the keystone-fenced ``run/`` dir (0600 inside
+        0700, on the sensitive-path floor), so the restart respawns the same
+        install/edition being replaced and the path is one no agent file tool
+        can have planted. A ``shutil.which("kirocrew")`` fallback is
+        deliberately ABSENT: ``PATH`` for this backend includes user-writable
+        directories (``~/.local/bin``), so an agent-planted impostor could be
+        executed by an operator's Make Live click. A host whose marker records
+        no launcher (a source-tree ``python -m kiro_crew`` launch) keeps the
+        manual advisory — never a guessed or PATH-trusted binary.
+        """
+        return self._usable_launcher(self._read_launcher(port))
+
+    # -- protocol subset (status / identity / restart / plan) --
+    async def status(self) -> str:
+        """``ok`` when a restart can actually be attempted on this host."""
+        if self._confinement() is not None:
+            return "backend_confined"
+        located = self._locate()
+        if located is None:
+            return "no_foreground_gateway"
+        if self._resolve_binary(located[0]) is None:
+            return "no_kirocrew_binary"
+        return STATUS_OK
+
+    async def start_id(self) -> "str | None":
+        """The recorded gateway pid, or ``None`` (callers degrade, never wait)."""
+        located = self._locate()
+        return None if located is None else str(located[1])
+
+    async def restart_detached(self) -> "tuple[bool, str]":
+        """Establish a detached ``kirocrew restart``. ``(ok, error)``.
+
+        Re-resolves rather than trusting an earlier ``status()``: the gateway
+        (and its marker) can change between the probe and the act. On ANY
+        failure nothing has been signalled — the incumbent keeps running and
+        the caller keeps the manual advisory.
+        """
+        confined = self._confinement()
+        if confined is not None:
+            # A replacement spawned from inside the sandbox/cgroup scope would
+            # inherit that confinement for the gateway's whole lifetime — and a
+            # scope kill mid-restart could strand the host with no gateway.
+            return False, confined
+        located = self._locate()
+        if located is None:
+            return False, "no single live foreground gateway to restart"
+        port, _pid = located
+        kcbin = self._resolve_binary(port)
+        if kcbin is None:
+            return False, "kirocrew binary could not be resolved"
+        # --port pins the restart to the gateway the marker names, exactly as
+        # cli_server passes the resolved port to its own detached spawn — the
+        # child must not re-resolve and disagree.
+        try:
+            self._spawn([kcbin, "restart", "--port", str(port)])
+        except OSError as exc:
+            return False, f"could not establish detached restart: {exc}"[:200]
+        return True, ""
+
+    def plan(self, worktree: Path, kcbin: Path) -> dict:
+        """Describe — without mutating anything — how the restart would run."""
+        located = self._locate()
+        port = located[0] if located is not None else None
+        resolved = self._resolve_binary(port) if port is not None else None
+        return {
+            "restart_backend": "foreground",
+            "restart_command": (
+                f"{resolved} restart --port {port}"
+                if resolved is not None and port is not None
+                else "kirocrew restart"
+            ),
+        }
 
 
 # --- selection ---------------------------------------------------------------

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -54,6 +54,7 @@ from kiro_crew import frontend, hooks, platform_compat
 from kiro_crew.apps.builtins.dev_fleet import gateway_service
 from kiro_crew.env import find_node_tool, node_bin_dirs
 from kiro_crew.executors import subprocess_executor
+from kiro_crew.instances import run_marker
 from kiro_crew.sandbox import (
     RLIMIT_PROFILE_BUILD,
     create_subprocess_limited,
@@ -4022,6 +4023,29 @@ def _gateway_backend() -> "gateway_service.GatewayServiceBackend | None":
     )
 
 
+def _foreground_backend() -> "gateway_service.ForegroundBackend | None":
+    """The last-resort foreground restart backend, or ``None`` off-POSIX.
+
+    Constructed per call for the same reason as :func:`_gateway_backend`, and
+    ``sys.platform`` is read through this module's globals so the tests that
+    patch ``server.sys`` keep controlling it. POSIX-only: the detach mechanism
+    is a new session standing in for ``systemd-run --collect``, and the hosts
+    this exists for (no drivable systemd/launchd) are Linux and macOS; Windows
+    keeps the manual-restart advisory. Whether a restart can actually be
+    attempted is the backend's ``status()``, not this constructor — callers
+    must gate on both :data:`gateway_service.FOREGROUND_ELIGIBLE` and
+    ``status() == ok``.
+    """
+    if sys.platform not in ("linux", "darwin"):
+        return None
+    return gateway_service.ForegroundBackend(
+        marker_ports=run_marker.marker_ports,
+        read_pid=run_marker.read_pid,
+        read_launcher=run_marker.read_launcher,
+        pid_exists=platform_compat.pid_exists,
+    )
+
+
 async def _gateway_service_reason() -> str | None:
     """Human-readable reason the gateway service cannot be driven, or ``None``.
 
@@ -4086,7 +4110,26 @@ async def _gateway_start_id() -> str | None:
     ``_restart_gateway`` / ``_make_live`` actually bounce (pod or live).
     """
     svc = _gateway_backend()
-    return None if svc is None else await svc.start_id()
+    sid = None if svc is None else await svc.start_id()
+    if sid is not None:
+        return sid
+    # Foreground fallback: on a host where no manager can be driven the
+    # handshake still needs an identity that changes when the replacement
+    # starts, or a foreground cutover could never be observed to complete. The
+    # run-marker pid stands in (see ForegroundBackend). Gated on the same
+    # eligibility codes as the foreground restart itself so that a host with a
+    # mis-set-up manager (which this app refuses to bounce) does not start
+    # advertising an identity for a restart path that will never run.
+    if _foreground_eligible(await _live_user_unit_status()):
+        fg = _foreground_backend()
+        if fg is not None:
+            return await fg.start_id()
+    return None
+
+
+def _foreground_eligible(status: str) -> bool:
+    """True when *status* permits the foreground last resort."""
+    return status in gateway_service.FOREGROUND_ELIGIBLE
 
 
 async def _restart_gateway() -> dict:
@@ -4391,25 +4434,32 @@ def _manual_restart_command() -> str:
 
 
 def _make_live_plan(worktree: Path, kcbin: Path, *,
-                    svc: "gateway_service.GatewayServiceBackend | None") -> dict:
+                    svc: "gateway_service.GatewayServiceBackend | None",
+                    foreground: "gateway_service.ForegroundBackend | None" = None,
+                    ) -> dict:
     """Describe — without mutating anything — what making *worktree* live does.
 
     Validates the target the same way the real cutover does, so a dry run
     reports an unusable worktree instead of promising a cutover that would then
     be refused. When the service is drivable the backend's own plan is folded in,
-    because the cutover restages that definition too.
+    because the cutover restages that definition too. *foreground* is the
+    last-resort restart that will be ATTEMPTED when no manager is drivable
+    (see ``_make_live``): a dry run must report that restart as automatic, or
+    the preview would promise a manual step the real call then performs itself.
     """
     live_target.validate(str(worktree))
     plan: dict = {
         "mechanism": "live-target pointer",
         "pointer_path": str(live_target.pointer_path()),
         "exec": str(kcbin),
-        "restart": "automatic" if svc is not None else "manual",
+        "restart": "automatic" if (svc is not None or foreground is not None) else "manual",
     }
-    if svc is None:
-        plan["manual_restart"] = _manual_restart_command()
-    else:
+    if svc is not None:
         plan.update(svc.plan(worktree, kcbin))
+    elif foreground is not None:
+        plan.update(foreground.plan(worktree, kcbin))
+    else:
+        plan["manual_restart"] = _manual_restart_command()
     return plan
 
 
@@ -4474,6 +4524,17 @@ async def _make_live(path: str, dry_run: bool = False) -> dict:
     svc = _gateway_backend()
     unit_status = await _live_user_unit_status()
     can_restart = svc is not None and unit_status == "ok"
+    # LAST RESORT (strictly systemd > launchd > foreground): when no manager is
+    # drivable at all, a detached `kirocrew restart` can still finish the
+    # cutover (see gateway_service.ForegroundBackend). Probed ONCE per request,
+    # mirroring can_restart, so the plan and the act cannot disagree. Only the
+    # FOREGROUND_ELIGIBLE codes qualify — a mis-set-up manager keeps its named
+    # remedy instead of being bounced behind its back.
+    foreground: "gateway_service.ForegroundBackend | None" = None
+    if not can_restart and _foreground_eligible(unit_status):
+        fg = _foreground_backend()
+        if fg is not None and await fg.status() == gateway_service.STATUS_OK:
+            foreground = fg
 
     live = await _live_worktree_path()
     same_as_running = live is not None and _same_path(str(real), live)
@@ -4635,7 +4696,8 @@ async def _make_live(path: str, dry_run: bool = False) -> dict:
         )}
 
     try:
-        plan = _make_live_plan(real, kcbin, svc=svc if can_restart else None)
+        plan = _make_live_plan(real, kcbin, svc=svc if can_restart else None,
+                               foreground=foreground)
     except live_target.InvalidTarget as exc:
         return {"ok": False, "code": "unsafe_path", "error": (
             "refusing make-live: the worktree path cannot be used as a live "
@@ -4746,15 +4808,42 @@ async def _make_live(path: str, dry_run: bool = False) -> dict:
                     "rolled_back": await _unwind(),
                     "error": _redact(str(exc))}
 
-        # Nothing bounces the gateway on this host, so the cutover is STAGED and
-        # the operator finishes it. Reported as a success with the exact command,
-        # not a failure: the pointer is written and correct, and the next start
-        # of the gateway — however it happens — comes up on the new target.
-        # Deliberately NOT latched as committed: no restart is pending, so a
-        # subsequent cutover to a different worktree must stay allowed.
+        # Nothing MANAGED bounces the gateway on this host. When the foreground
+        # last resort is usable it finishes the cutover below; otherwise the
+        # cutover is STAGED and the operator finishes it — reported as a success
+        # with the exact command, not a failure: the pointer is written and
+        # correct, and the next start of the gateway — however it happens —
+        # comes up on the new target. The staged-only outcome is deliberately
+        # NOT latched as committed: no restart is pending, so a subsequent
+        # cutover to a different worktree must stay allowed.
         if not can_restart:
             _LIVE_WORKTREE = None
             _LIVE_CHECK_AT = 0.0
+            if foreground is not None:
+                # Capture identity BEFORE establishing the restart, mirroring
+                # the drivable path: the detached bounce can tear this process
+                # down at any moment after the spawn.
+                start_id = await foreground.start_id()
+                restarted, fg_err = await foreground.restart_detached()
+                if restarted:
+                    # A restart IS pending now — latch exactly as the drivable
+                    # path does, so no further cutover mutates the pointer
+                    # while the detached `kirocrew restart` is acting on it.
+                    _MAKE_LIVE_COMMITTED = True
+                    return {"ok": True, "cutover": True, "target": str(real),
+                            "plan": plan, "start_id": start_id}
+                # FAIL SAFE: the spawn was never established, so nothing has
+                # been signalled and the gateway is untouched. The pointer
+                # stays staged (it is written and correct) and the operator
+                # gets the exact status-quo advisory. Rolling the pointer back
+                # here would be strictly worse: it would turn "finish with one
+                # command" into "start over".
+                logger.warning(
+                    "foreground restart could not be established (%s); "
+                    "falling back to the manual-restart advisory", fg_err,
+                )
+                plan = {**plan, "restart": "manual",
+                        "manual_restart": _manual_restart_command()}
             return {"ok": True, "cutover": True, "staged_only": True,
                     "target": str(real), "plan": plan,
                     "manual_restart": _manual_restart_command(),

--- a/src/kiro_crew/instances/run_marker.py
+++ b/src/kiro_crew/instances/run_marker.py
@@ -121,6 +121,31 @@ def read_pid(port: int) -> int | None:
     return pid if pid > 0 else None
 
 
+def read_launcher(port: int) -> str | None:
+    """Launcher path recorded by the gateway serving *port*, or ``None``.
+
+    The marker's *contents* — the absolute path to the running gateway's own
+    ``kirocrew`` launcher (see :func:`write_marker`), or ``None`` when the
+    marker is absent, unreadable, or empty (a source-tree ``python -m
+    kiro_crew`` launch records no launcher). Same trust argument as
+    :func:`read_pid`: the file is written ``0600`` inside the keystone-fenced
+    ``0700`` ``run/`` dir, so only the gateway itself can have planted it.
+    Callers that exec the result must still validate it the way mint's shell
+    clause does (an existing executable file).
+
+    Read-only: never creates ``run/`` (unlike :func:`marker_path`, whose
+    ``_run_dir`` materialises the directory).
+    """
+    try:
+        raw = (config_dir() / "run" / f"{_MARKER_PREFIX}{int(port)}{_MARKER_SUFFIX}").read_text(
+            encoding="utf-8"
+        )
+    except (OSError, ValueError):
+        return None
+    raw = raw.strip()
+    return raw or None
+
+
 def marker_ports() -> list[int]:
     """Ports named by the run-markers currently on disk, ascending.
 

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -7429,3 +7429,304 @@ async def test_dirty_unmerged_message_does_not_promise_force_override():
     assert "use force to override" not in result["error"]
     # Should mention uncommitted changes
     assert "uncommitted changes" in result["error"]
+
+
+# =============================================================================
+# Foreground last-resort restart (issue #2566)
+# =============================================================================
+
+def _mk_kcbin(tmp_path: Path, name: str = "kirocrew") -> Path:
+    """An executable file that passes ForegroundBackend's launcher validation."""
+    d = tmp_path / "bin"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / name
+    p.write_text("#!/bin/sh\n")
+    p.chmod(0o755)
+    return p
+
+
+def _fg(tmp_path: Path, *, port: int = 7777, pid: int = 4242,
+        launcher: "str | None" = None, alive: bool = True, spawn=None,
+        ports: "list[int] | None" = None, pids: "dict[int, int] | None" = None,
+        confined: "str | None" = None):
+    """A ForegroundBackend wired to fakes. Returns (backend, spawned_argvs)."""
+    from kiro_crew.apps.builtins.dev_fleet import gateway_service as gs
+
+    spawned: list[list[str]] = []
+
+    def default_spawn(argv):
+        spawned.append(list(argv))
+
+    marker_ports = ports if ports is not None else [port]
+    pid_by_port = pids if pids is not None else {port: pid}
+    backend = gs.ForegroundBackend(
+        marker_ports=lambda: list(marker_ports),
+        read_pid=lambda p: pid_by_port.get(p),
+        read_launcher=lambda p: launcher,
+        pid_exists=lambda p: alive,
+        spawn=spawn if spawn is not None else default_spawn,
+        confinement=lambda: confined,
+    )
+    return backend, spawned
+
+
+@pytest.mark.asyncio
+async def test_foreground_backend_ok_and_start_id(tmp_path):
+    """Single live marker + resolvable binary -> ok; start_id is the marker pid."""
+    kc = _mk_kcbin(tmp_path)
+    fg, _ = _fg(tmp_path, launcher=str(kc))
+    assert await fg.status() == "ok"
+    assert await fg.start_id() == "4242"
+
+
+@pytest.mark.asyncio
+async def test_foreground_backend_unavailable_cases(tmp_path):
+    """No marker, dead pid, or ambiguous markers -> unavailable, start_id None."""
+    kc = _mk_kcbin(tmp_path)
+    # No marker at all.
+    fg, _ = _fg(tmp_path, ports=[], pids={}, launcher=str(kc))
+    assert await fg.status() == "no_foreground_gateway"
+    assert await fg.start_id() is None
+    # Marker whose pid is dead (crash leftover).
+    fg, _ = _fg(tmp_path, alive=False, launcher=str(kc))
+    assert await fg.status() == "no_foreground_gateway"
+    # Two live markers: ambiguous, never guess which gateway to bounce.
+    fg, _ = _fg(tmp_path, ports=[7777, 7778], pids={7777: 1, 7778: 2},
+                launcher=str(kc))
+    assert await fg.status() == "no_foreground_gateway"
+    assert await fg.start_id() is None
+
+
+@pytest.mark.asyncio
+async def test_foreground_backend_binary_resolution(tmp_path):
+    """ONLY the keystone-fenced marker launcher is trusted — no PATH fallback
+    (an agent can plant a `kirocrew` in ~/.local/bin); invalid recorded
+    launchers are refused rather than guessed around."""
+    kc = _mk_kcbin(tmp_path)
+    # Marker launcher used, verbatim.
+    fg, spawned = _fg(tmp_path, launcher=str(kc))
+    ok, err = await fg.restart_detached()
+    assert ok and spawned[0][0] == str(kc)
+    # No recorded launcher (source-tree launch, empty marker): refuse — the
+    # PATH fallback is deliberately absent.
+    fg, spawned = _fg(tmp_path, launcher=None)
+    assert await fg.status() == "no_kirocrew_binary"
+    ok, err = await fg.restart_detached()
+    assert not ok and "resolved" in err and spawned == []
+    # A launcher that is not basenamed kirocrew is refused even when executable
+    # (the _own_console_script rule: exec the entry point it claims to be).
+    impostor = _mk_kcbin(tmp_path / "i", name="systemctl")
+    fg, _ = _fg(tmp_path, launcher=str(impostor))
+    assert await fg.status() == "no_kirocrew_binary"
+    # A non-executable launcher is refused: it could stop the gateway but never
+    # start the replacement.
+    limp = _mk_kcbin(tmp_path / "n")
+    limp.chmod(0o644)
+    fg, _ = _fg(tmp_path, launcher=str(limp))
+    assert await fg.status() == "no_kirocrew_binary"
+    # A relative recorded path is refused (never resolved against a cwd).
+    fg, _ = _fg(tmp_path, launcher="bin/kirocrew")
+    assert await fg.status() == "no_kirocrew_binary"
+
+
+@pytest.mark.asyncio
+async def test_foreground_backend_refuses_when_confined(tmp_path):
+    """A confined backend (OS sandbox / agents cgroup scope) never spawns: the
+    replacement would inherit the confinement for the gateway's whole life."""
+    kc = _mk_kcbin(tmp_path)
+    fg, spawned = _fg(tmp_path, launcher=str(kc),
+                      confined="the Dev Fleet backend runs inside the sandbox")
+    assert await fg.status() == "backend_confined"
+    ok, err = await fg.restart_detached()
+    assert not ok and "sandbox" in err
+    assert spawned == []
+
+
+def test_default_confinement_detects_sandbox_marker(monkeypatch):
+    """KIROCREW_SANDBOX_ACTIVE — the launcher-exported in-sandbox marker — is
+    detected as confinement (checked before the cgroup read, so this is
+    deterministic on any host)."""
+    from kiro_crew.apps.builtins.dev_fleet import gateway_service as gs
+
+    monkeypatch.setenv("KIROCREW_SANDBOX_ACTIVE", "1")
+    reason = gs.default_confinement()
+    assert reason is not None and "sandbox" in reason
+
+
+@pytest.mark.asyncio
+async def test_foreground_restart_detached_pins_port(tmp_path):
+    """The detached command is `<bin> restart --port <marker port>`."""
+    kc = _mk_kcbin(tmp_path)
+    fg, spawned = _fg(tmp_path, port=6776, pid=99, launcher=str(kc))
+    ok, err = await fg.restart_detached()
+    assert ok and err == ""
+    assert spawned == [[str(kc), "restart", "--port", "6776"]]
+
+
+@pytest.mark.asyncio
+async def test_foreground_spawn_failure_signals_nothing(tmp_path, monkeypatch):
+    """A spawn that cannot be established returns (False, why) and the backend
+    never signals any process — the incumbent gateway must stay untouched."""
+    kc = _mk_kcbin(tmp_path)
+
+    def bad_spawn(argv):
+        raise OSError("resource temporarily unavailable")
+
+    kills: list = []
+    monkeypatch.setattr(os, "kill", lambda *a: kills.append(a))
+    fg, _ = _fg(tmp_path, launcher=str(kc), spawn=bad_spawn)
+    ok, err = await fg.restart_detached()
+    assert not ok and "resource temporarily unavailable" in err
+    assert kills == []
+
+
+@pytest.mark.asyncio
+async def test_make_live_foreground_last_resort_cutover(monkeypatch, tmp_path):
+    """When no manager is drivable but a single live foreground gateway exists,
+    make-live finishes the cutover itself: pointer written, detached
+    `kirocrew restart` established, start_id (the pre-restart pid) returned,
+    and the committed latch set exactly as on a drivable host."""
+    kc = _mk_kcbin(tmp_path)
+    for status in ("no_systemd", "no_user_unit", "no_launchd", "no_agent"):
+        wt = _mk_make_live_wt(tmp_path / status, venv=True, dist=True)
+        ptr_dir = tmp_path / "ptr" / status
+        _stub_make_live(monkeypatch, wt, unit_status=status, pointer_dir=ptr_dir)
+        monkeypatch.setattr(mod, "_MAKE_LIVE_COMMITTED", False, raising=False)
+        fg, spawned = _fg(tmp_path, port=7777, pid=31337, launcher=str(kc))
+        monkeypatch.setattr(mod, "_foreground_backend", lambda fg=fg: fg)
+
+        res = await mod._make_live(str(wt), dry_run=False)
+        assert res["ok"] is True and res["cutover"] is True, f"{status}: {res}"
+        assert "staged_only" not in res
+        assert res["start_id"] == "31337"
+        assert spawned == [[str(kc), "restart", "--port", "7777"]]
+        # Pointer written with the target.
+        data = json.loads((ptr_dir / "live_target.json").read_text())
+        assert Path(data["checkout"]).resolve() == wt.resolve()
+        # A restart IS pending: latched like the drivable path.
+        assert mod._MAKE_LIVE_COMMITTED is True
+
+
+@pytest.mark.asyncio
+async def test_make_live_foreground_is_strictly_last_resort(monkeypatch, tmp_path):
+    """Ordering is systemd > launchd > foreground: on a drivable host — or one
+    whose manager exists but is mis-set-up (named-remedy codes) — the
+    foreground backend is never even constructed."""
+    factory = MagicMock()
+    monkeypatch.setattr(mod, "_foreground_backend", factory)
+    # Drivable systemd host: full managed cutover, no foreground.
+    wt = _mk_make_live_wt(tmp_path / "ok", venv=True, dist=True)
+    _stub_make_live(monkeypatch, wt, unit_status="ok",
+                    pointer_dir=tmp_path / "ptr-ok")
+    monkeypatch.setattr(mod, "_MAKE_LIVE_COMMITTED", False, raising=False)
+    res = await mod._make_live(str(wt), dry_run=False)
+    assert res["ok"] is True and "staged_only" not in res
+    factory.assert_not_called()
+    # Mis-set-up managers keep their named remedy; foreground must not bounce
+    # a gateway behind a manager's back.
+    for status in ("user_unit_inactive", "agent_not_indirected",
+                   "agent_restart_contract_outdated", "live_program_missing"):
+        wt = _mk_make_live_wt(tmp_path / status, venv=True, dist=True)
+        _stub_make_live(monkeypatch, wt, unit_status=status,
+                        pointer_dir=tmp_path / f"ptr-{status}")
+        monkeypatch.setattr(mod, "_MAKE_LIVE_COMMITTED", False, raising=False)
+        res = await mod._make_live(str(wt), dry_run=False)
+        assert res["ok"] is True and res["staged_only"] is True, f"{status}: {res}"
+        factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_make_live_foreground_spawn_failure_keeps_advisory(monkeypatch, tmp_path):
+    """FAIL SAFE: when the detached spawn cannot be established the running
+    gateway is untouched, the pointer STAYS staged, the committed latch is not
+    set, and the response is the status-quo manual advisory."""
+    kc = _mk_kcbin(tmp_path)
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    ptr_dir = tmp_path / "ptr"
+    _stub_make_live(monkeypatch, wt, unit_status="no_systemd", pointer_dir=ptr_dir)
+    monkeypatch.setattr(mod, "_MAKE_LIVE_COMMITTED", False, raising=False)
+
+    def bad_spawn(argv):
+        raise OSError("spawn refused")
+
+    fg, _ = _fg(tmp_path, launcher=str(kc), spawn=bad_spawn)
+    monkeypatch.setattr(mod, "_foreground_backend", lambda: fg)
+
+    res = await mod._make_live(str(wt), dry_run=False)
+    assert res["ok"] is True and res["staged_only"] is True
+    assert res["manual_restart"]
+    assert res["manual_restart"] in res["notice"]
+    # The plan must not keep promising an automatic restart that failed.
+    assert res["plan"]["restart"] == "manual"
+    # Pointer written and KEPT: "finish with one command", not "start over".
+    data = json.loads((ptr_dir / "live_target.json").read_text())
+    assert Path(data["checkout"]).resolve() == wt.resolve()
+    # No restart pending -> not latched; a re-point must stay allowed.
+    assert mod._MAKE_LIVE_COMMITTED is False
+
+
+@pytest.mark.asyncio
+async def test_make_live_foreground_unavailable_keeps_advisory(monkeypatch, tmp_path):
+    """Eligible codes without a usable foreground gateway (no/ambiguous marker,
+    unresolvable binary, confined backend) keep the pre-existing staged_only
+    behaviour."""
+    kc = _mk_kcbin(tmp_path)
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    ptr_dir = tmp_path / "ptr"
+    for label, fg_kwargs in (
+        ("no_marker", dict(ports=[], pids={}, launcher=None)),
+        ("confined", dict(launcher=str(kc), confined="backend is sandboxed")),
+    ):
+        _stub_make_live(monkeypatch, wt, unit_status="no_systemd",
+                        pointer_dir=ptr_dir / label)
+        monkeypatch.setattr(mod, "_MAKE_LIVE_COMMITTED", False, raising=False)
+        fg, spawned = _fg(tmp_path, **fg_kwargs)
+        monkeypatch.setattr(mod, "_foreground_backend", lambda fg=fg: fg)
+
+        res = await mod._make_live(str(wt), dry_run=False)
+        assert res["ok"] is True and res["staged_only"] is True, f"{label}: {res}"
+        assert res["manual_restart"] in res["notice"]
+        assert spawned == []
+        assert mod._MAKE_LIVE_COMMITTED is False
+
+
+@pytest.mark.asyncio
+async def test_make_live_foreground_dry_run_plan(monkeypatch, tmp_path):
+    """A dry run on a foreground-capable host reports the restart as automatic
+    with the exact command — and mutates nothing, spawns nothing."""
+    kc = _mk_kcbin(tmp_path)
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    ptr_dir = tmp_path / "ptr"
+    _stub_make_live(monkeypatch, wt, unit_status="no_systemd", pointer_dir=ptr_dir)
+    fg, spawned = _fg(tmp_path, port=7777, pid=1, launcher=str(kc))
+    monkeypatch.setattr(mod, "_foreground_backend", lambda: fg)
+
+    res = await mod._make_live(str(wt), dry_run=True)
+    assert res["ok"] is True and res["dry_run"] is True
+    plan = res["plan"]
+    assert plan["restart"] == "automatic"
+    assert plan["restart_backend"] == "foreground"
+    assert plan["restart_command"] == f"{kc} restart --port 7777"
+    assert spawned == []
+    assert not (ptr_dir / "live_target.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_gateway_start_id_foreground_fallback(monkeypatch, tmp_path):
+    """On an eligible host the health handshake identity is the marker pid, so
+    the dashboard can observe a foreground cutover complete; on an ineligible
+    host it stays None (degrade, never wait forever)."""
+    kc = _mk_kcbin(tmp_path)
+    fg, _ = _fg(tmp_path, pid=8080, launcher=str(kc))
+    monkeypatch.setattr(mod, "_foreground_backend", lambda: fg)
+    with patch.object(mod, "sys", MagicMock(platform="linux")), \
+         patch.object(mod, "shutil",
+                      MagicMock(which=MagicMock(return_value=None))):
+        # No systemctl at all -> primary yields None -> foreground pid.
+        assert await mod._gateway_start_id() == "8080"
+    with patch.object(mod, "_live_user_unit_status", new_callable=AsyncMock,
+                      return_value="user_unit_inactive"), \
+         patch.object(mod, "sys", MagicMock(platform="linux")), \
+         patch.object(mod, "shutil",
+                      MagicMock(which=MagicMock(return_value=None))):
+        assert await mod._gateway_start_id() is None

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -702,6 +702,24 @@ class TestRunMarkerDiscovery:
         (d / "gateway-6776.pid").write_text(" 4242 \n", encoding="utf-8")
         assert run_marker.read_pid(6776) == 4242
 
+    def test_read_launcher_reads_marker_content(self, tmp_path, monkeypatch):
+        """read_launcher returns the recorded path, None for absent/empty, and
+        never creates run/ (read-only, like read_pid)."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        from kiro_crew.instances import run_marker
+
+        assert run_marker.read_launcher(6776) is None  # absent
+        assert not (tmp_path / "run").exists()  # read never materialises run/
+        d = tmp_path / "run"
+        d.mkdir(parents=True, exist_ok=True)
+        # Empty marker: a source-tree launch records no launcher (port-only).
+        (d / "gateway-6776.bin").write_text("", encoding="utf-8")
+        assert run_marker.read_launcher(6776) is None
+        (d / "gateway-6776.bin").write_text("  \n", encoding="utf-8")
+        assert run_marker.read_launcher(6776) is None
+        (d / "gateway-6776.bin").write_text("/opt/venv/bin/kirocrew\n", encoding="utf-8")
+        assert run_marker.read_launcher(6776) == "/opt/venv/bin/kirocrew"
+
     def test_write_prunes_markers_from_earlier_runs(self, tmp_path, monkeypatch):
         """A gateway is a singleton per home, so markers naming other ports are
         crash residue. Left alone they cost every client command an extra

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -506,6 +506,15 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # git rev-parse at startup, no agent input, no sandbox needed).
         "apps/builtins/dev_fleet/server.py::_resolve_primary_checkout",
         "apps/builtins/dev_fleet/server.py::worker",
+        # Foreground last-resort restart (Make Live on hosts with no drivable
+        # service manager): a detached `kirocrew restart --port <marker port>`,
+        # fixed argv whose binary is validated (basenamed kirocrew, absolute,
+        # executable) from the gateway's own keystone-fenced run-marker or
+        # shutil.which — never agent input. Deliberately NOT sandboxed for the
+        # same reason as cli_server.py::_spawn_detached_gateway above: the child
+        # must outlive and REPLACE the gateway (kill + respawn + own session),
+        # which a scoped/sandboxed child cannot do.
+        "apps/builtins/dev_fleet/gateway_service.py::default_detached_spawn",
         # (apps/dependencies.py::_run_aim removed — App Kit capability deps now
         # resolve through the CapabilityManager seam, so the resolver spawns no
         # subprocess at all and needs no allowlist entry.)


### PR DESCRIPTION
## Summary

On hosts where neither systemd nor launchd can be driven (`no_systemd` / `no_user_unit` / `no_launchd` / `no_agent` — e.g. an Amazon Linux 2 cloud desktop with systemd 219, no per-user manager, and broken sudo), Dev Fleet's Make Live staged the live-target pointer correctly but could not restart, telling the operator to run `kirocrew restart` themselves. The feature did nothing useful on exactly those hosts.

This adds `gateway_service.ForegroundBackend` as a strict LAST RESORT (ordering systemd > launchd > foreground, asserted in a test): it finishes the cutover by establishing a **detached** `kirocrew restart --port <marker port>` — reusing the CLI's whole kill-and-respawn path (lsof+SIGTERM, wait, detached respawn that reads the staged pointer, `/api/ready` poll) instead of reimplementing it.

## Design

- **Selection**: only when the manager probe reports one of the four FOREGROUND_ELIGIBLE codes. Mis-set-up manager codes (`user_unit_inactive`, `agent_not_indirected`, `agent_restart_contract_outdated`, `live_program_missing`) keep their named remedies and are never bounced behind the manager's back. POSIX-only.
- **Locating the gateway**: requires exactly ONE run-marker (`run/gateway-<port>.pid`) whose recorded pid is alive — a gateway is a singleton per data home, so ambiguity means stale crash residue and the backend refuses rather than guessing which gateway to bounce.
- **Binary resolution**: the run-marker's recorded launcher first (written by the running gateway about itself — the `_own_console_script` rationale, so the restart respawns the same install/edition), then `shutil.which("kirocrew")`; both validated (absolute, executable, basenamed kirocrew). Unresolvable = advisory, never a guessed path.
- **start_id**: the marker pid — an opaque changes-on-replacement token the existing dashboard reconnect handshake consumes unchanged (same class as the launchd job PID). `_gateway_start_id()` falls back to it only on eligible hosts so the health poll can observe the foreground cutover complete.
- **FAIL SAFE**: the backend never signals any process itself; its only mutation is establishing the detached spawn. Binary unresolvable or spawn failure ⇒ the running gateway is untouched, the pointer STAYS staged, and the response is the exact status-quo `staged_only` advisory (latch not set). Covered by tests.
- **Detach**: new session (POSIX) via a constructor-injected spawner seam — the fake the verification constraint requires; the default mirrors `cli_server._spawn_detached_gateway`.

## Testing

- 12 new tests, all verified failing on unmodified code: backend unit tests (ok/start_id, unavailable cases, binary resolution incl. impostor-basename and non-executable refusal, port-pinned argv, spawn-failure-signals-nothing with an `os.kill` recorder) and make-live flow tests (4-code cutover parametrization with latch+pointer+start_id assertions, strict last-resort ordering incl. drivable + all 4 named-remedy codes, spawn-failure advisory preservation, unavailable-foreground advisory, dry-run plan honesty, `_gateway_start_id` fallback/ineligible).
- Per the spec's verification constraint the restart is never exercised against a live gateway — everything runs against the injected fake spawner.
- Full local gates: isort / flake8 / mypy clean, 40,582 backend tests passed (75 pre-existing host-env failures proven unrelated via an unmodified-tree baseline diff; the one real ratchet hit — spawn-audit — is allowlisted with justification mirroring `cli_server._spawn_detached_gateway`).
- Docs updated in the same commit: `docs/system-specs/modules/dev-fleet.md` (three-outcome cutover section, handshake identity, route table).

No frontend changes: a foreground success returns the same `{ok, cutover, start_id}` shape as an automatic cutover and rides the existing handshake; failure returns the existing `staged_only` shape.

Closes #2566
