### PR TITLE
fix(pod): serialize the env-file merge so a concurrent writer cannot drop keys

### DIFF
--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -29,6 +29,7 @@ try:  # POSIX only; pods are refused on hosts without it (require_backend)
 except ImportError:  # pragma: no cover - Windows
     fcntl = None  # type: ignore[assignment]
 
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.platform_compat import IS_LINUX, IS_MACOS
 from kiro_crew.pod import launchd
@@ -100,15 +101,35 @@ def write_env_file(cfg: PodConfig, name: str, updates: dict[str, str]) -> None:
     newlines, so a multi-line value would not round-trip. ``--seed`` is
     user-supplied, so reject a newline-bearing value loudly (fail-closed) rather
     than silently writing an un-parseable file.
+
+    **Written atomically**, because readers are deliberately lock-free: ``boot``
+    reads this file without taking the mutex (so ``pod up`` can hold it across
+    the health wait without deadlocking against the process it waits for). An
+    in-place truncating rewrite therefore has a window where a reader — a
+    ``Restart=`` re-exec, say — sees a partial or empty file. A dropped
+    ``APPROVAL`` is not a benign default: ``boot`` leaves ``approval_mode``
+    unset, which falls through to ``cfg.agent.approval_mode`` and lands on
+    auto-approve, the LEAST restrictive outcome. Temp-file + rename means an
+    unlocked reader sees either the old file or the new one, never a torn one.
+
+    The merge additionally re-acquires :func:`pod_name_mutex`, which every
+    mutating pod path already holds at its call site. That is defense in depth
+    for direct callers rather than a fix for a live race, and it mirrors what
+    ``start_pod`` / ``stop_pod`` already do; reentrancy is what makes
+    re-acquiring it inside an outer transaction safe.
     """
-    data = read_env_file(cfg, name)
-    data.update(updates)
-    for key, val in data.items():
+    for key, val in updates.items():
         if "\n" in val or "\r" in val:
             raise PodError(f"pod env value for {key!r} must be single-line")
-    cfg.pods_dir.mkdir(parents=True, exist_ok=True)
-    body = "".join(f"{k}='{v}'\n" for k, v in data.items())
-    cfg.env_file(name).write_text(body)
+    with pod_name_mutex(cfg, name):
+        data = read_env_file(cfg, name)
+        data.update(updates)
+        for key, val in data.items():
+            if "\n" in val or "\r" in val:
+                raise PodError(f"pod env value for {key!r} must be single-line")
+        cfg.pods_dir.mkdir(parents=True, exist_ok=True)
+        body = "".join(f"{k}='{v}'\n" for k, v in data.items())
+        atomic_write(cfg.env_file(name), body, newline="")
 
 
 def pin_checkout(cfg: PodConfig, name: str, checkout: Path) -> None:

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -9,6 +9,7 @@ import os
 import stat
 import subprocess
 import sys
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1682,6 +1683,154 @@ class TestReviewRound2Fix:
         # a normal single-line value still round-trips
         rt.write_env_file(c, "y", {"CHECKOUT": "/a/b"})
         assert rt.read_env_file(c, "y")["CHECKOUT"] == "/a/b"
+
+
+@pytest.mark.skipif(
+    rt.fcntl is None,
+    reason="flock needs POSIX; without it the mutex is a documented no-op",
+)
+class TestEnvFileConcurrentWrite:
+    """``write_env_file`` merges, so it must serialize per pod name.
+
+    ``pod up`` writes pod settings AND starts the unit whose gateway writes the same
+    file, so an unserialized merge drops one side's keys and boots the pod on stale
+    config.
+
+    Both tests assert a property only the real lock provides, so both are POSIX-only:
+    where ``fcntl`` is absent ``pod_name_mutex`` degrades to a no-op by design, and
+    pods are refused on those hosts anyway.
+    """
+
+    def test_a_concurrent_write_does_not_drop_the_other_writers_keys(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two real threads, both past a barrier before either takes the lock.
+
+        Threads rather than a nested call because the lock is per open-file-description:
+        re-entering from one thread exercises the reentrant counter instead of the
+        cross-writer exclusion this is about.
+        """
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path))
+        c = PodConfig.load()
+        rt.write_env_file(c, "demo", {"CHECKOUT": "/first", "APPROVAL": "reads"})
+
+        entered = threading.Barrier(2, timeout=30)
+        errors: list[BaseException] = []
+
+        def writer(updates: dict[str, str]) -> None:
+            try:
+                entered.wait()
+                rt.write_env_file(c, "demo", updates)
+            except BaseException as exc:  # noqa: BLE001 - surfaced via `errors`
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=writer, args=({"CRONS": "1"},)),
+            threading.Thread(target=writer, args=({"SEED": "/s"},)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+            assert not t.is_alive(), "write_env_file deadlocked"
+        assert not errors, f"writer raised: {errors!r}"
+
+        final = rt.read_env_file(c, "demo")
+        # Neither writer's key may be lost, and the pre-existing ones survive both.
+        assert final["CRONS"] == "1"
+        assert final["SEED"] == "/s"
+        assert final["CHECKOUT"] == "/first"
+        assert final["APPROVAL"] == "reads"
+
+    def test_a_writer_inside_the_pod_up_transaction_is_serialized_too(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The mutex must be the one ``pod up`` holds, not one private to the merge.
+
+        ``pod up`` runs its whole transaction under :func:`pod_name_mutex`, so a lock
+        only ``write_env_file`` took would leave the writes made inside it unexcluded.
+        Holding the mutex here must therefore block a competing writer outright.
+        """
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path))
+        c = PodConfig.load()
+        rt.write_env_file(c, "demo", {"CHECKOUT": "/first"})
+
+        blocked = threading.Event()
+
+        def competing_writer() -> None:
+            rt.write_env_file(c, "demo", {"SEED": "/s"})
+            blocked.set()
+
+        with rt.pod_name_mutex(c, "demo"):
+            t = threading.Thread(target=competing_writer)
+            t.start()
+            # The transaction holds the mutex, so the other writer cannot proceed.
+            assert not blocked.wait(timeout=1.0), "a writer entered during the transaction"
+            rt.write_env_file(c, "demo", {"APPROVAL": "yolo"})
+        t.join(timeout=30)
+        assert not t.is_alive()
+
+        final = rt.read_env_file(c, "demo")
+        assert final["APPROVAL"] == "yolo"
+        assert final["SEED"] == "/s"
+        assert final["CHECKOUT"] == "/first"
+
+    def test_a_lock_free_reader_never_sees_a_torn_env_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The write must be atomic, not merely serialized.
+
+        ``boot`` reads without the mutex on purpose, so an in-place truncating
+        rewrite lets a reader observe one generation spliced onto another. A
+        missing ``APPROVAL`` is the least restrictive outcome (``boot`` leaves
+        ``approval_mode`` unset, which falls through to auto-approve), so a torn
+        read is a silent privilege upgrade rather than a crash.
+
+        Modelled deterministically instead of by racing: a reader opens the file
+        and consumes half of it, a write lands, then it consumes the rest. Under
+        temp-file + rename its descriptor still refers to the intact old inode,
+        so the two halves belong to ONE generation. Under an in-place rewrite the
+        same descriptor reads across the truncation and the halves do not match
+        any generation that was ever valid.
+        """
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path))
+        c = PodConfig.load()
+        # Enough keys that a spliced read is unambiguous rather than a near-miss.
+        first = {"APPROVAL": "interactive", "CHECKOUT": "/a"}
+        first.update({f"PAD{i}": f"v{i}" * 8 for i in range(40)})
+        rt.write_env_file(c, "demo", first)
+
+        env_path = c.env_file("demo")
+        before = env_path.read_bytes()
+
+        # Raw fd, NOT open() -- a buffered text reader slurps a small file whole
+        # on the first read, so the second read would come from memory and the
+        # test could not observe the on-disk seam at all.
+        fd = os.open(str(env_path), os.O_RDONLY)
+        try:
+            head = os.read(fd, len(before) // 2)
+            # The writer runs while this reader is mid-file.
+            rt.write_env_file(c, "demo", {"APPROVAL": "yolo"})
+            chunks = [head]
+            while True:
+                part = os.read(fd, 4096)
+                if not part:
+                    break
+                chunks.append(part)
+        finally:
+            os.close(fd)
+        seen = b"".join(chunks)
+
+        after = env_path.read_bytes()
+        assert head, "reader consumed nothing; the fixture is not exercising the seam"
+        # The reader must have seen exactly one whole generation, old or new.
+        assert seen in (before, after), (
+            "torn read: the reader spliced two generations together"
+        )
+        # And the new generation must be complete on disk.
+        final = rt.read_env_file(c, "demo")
+        assert final["APPROVAL"] == "yolo"
+        assert final["CHECKOUT"] == "/a"
 
 
 class TestUnitExecSelfHeal:


### PR DESCRIPTION
## What is the problem?

`boot()` reads the per-pod env file **without** taking the per-name mutex, and that is
deliberate: `pod up` holds the mutex across the health wait, so a reader that took it would
deadlock against the very process being waited on (`runtime.py` `pod_name_mutex` docstring).

`write_env_file` rewrote that file **in place**, which truncates before writing. An unlocked
reader — a `Restart=` re-exec, say — could therefore observe one generation spliced onto
another, or a partially written file.

## Why this issue matters to the user

A torn read is not a crash; it is a **silent privilege escalation**.

`boot()` reads `APPROVAL` from this file. If it is absent, `boot()` leaves `approval_mode`
unset, `slack/events.py` falls through to `cfg.agent.approval_mode`, and `config/loader.py`
defaults that to `auto` — auto-approve every tool call. The code says so itself: *"Dropping
would therefore be the LEAST restrictive outcome."* The existing guard only catches an
**unknown** value (`if approval and approval not in APPROVAL_MODES`); a **missing** one is
falsy, so it skips the guard entirely.

So the pod comes up looking healthy, having quietly widened its tool-approval posture.

## How our fix solves it

**Symptom** — a restarting pod can boot on a partial env file and lose `APPROVAL`.
**Root cause** — the write truncates in place while readers are intentionally lock-free.
**Change** — write through the shared `atomic_write` helper (temp file + rename, the same
pattern already used for the MCP overlay in `mcp_gateway/rewriter.py`). A reader now sees
either the old file or the new one, never a torn one.

The merge additionally re-acquires `pod_name_mutex`. To be precise about what that is and
is not: it is **defense in depth for direct callers**, not a fix for a live race. Both
production writers already hold the mutex across their `write_env_file` calls — `pod up` at
`cli.py:118`/`137` and `provision` at `cli.py:415` — and `boot()` only reads, so there is no
unserialized writer in the tree today. It mirrors what `start_pod` / `stop_pod` already do
internally, and reentrancy is what makes re-acquiring it inside an outer transaction safe.

## What tests we did

Three tests in `test/test_pod.py`, all **mutation-verified**:

- keys survive two concurrent writers (real threads past a barrier);
- a competing writer is excluded while a `pod_name_mutex` transaction is held — this is the
  one that pins the *right* lock rather than merely *a* lock;
- a reader that consumes half the file across a write sees exactly one whole generation.

That third test reads through a **raw fd** on purpose. The first version used buffered
`open()`, and a buffered text reader slurps a small file whole on its first read — so the
second read came from memory, the on-disk seam was invisible, and the non-atomic mutant
**escaped**. Switching to `os.read` made it deterministic; no racing required.

Mutants, all caught: lock removed · lock swapped for one private to `write_env_file` ·
`atomic_write` reverted to in-place `write_text`.

Both concurrency tests carry a class-level POSIX `skipif`: `pod_name_mutex` degrades to a
documented no-op where `fcntl` is absent, and pods are refused on those hosts anyway.

Gates: 308 targeted tests across `test_pod.py` / `test_pod_launchd.py` /
`test_session_storage.py` / `test_atomic_write_retry.py`; isort, flake8, mypy clean.

## Manual verification

N/A — the defect is a filesystem-visibility window, and the tests reproduce it directly
(the third fails without the fix). No user-visible UI change, so no screenshots.

## Any other suggestions on the work

- `write_env_file` was the last mutating pod path not routed through `pod_name_mutex`.
  Worth asserting that routing somewhere rather than leaving it to convention.
- The `APPROVAL`-missing fall-through to `auto` is a fail-open shape that deserves its own
  guard independent of how the file got truncated: `boot()` could pin `interactive` when
  `CHECKOUT` is present but `APPROVAL` is absent, the same way it already pins `interactive`
  for an unknown value. Not folded in here — it is a separate decision about boot policy
  rather than about writing the file.
- The pod's kiro home is derived in two places with different spellings
  (`session_storage.py:875`, `runtime.py:984`). Latent drift, untouched here.

Closes #2693
