### PR TITLE
fix: promote app manifest crons into scheduler store on CLI enable

### DIFF
--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -1414,7 +1414,12 @@ async def register_app_crons_with_service(app_name: str, cron_service: Any) -> l
                 )
                 continue
         try:
-            await sdk.add_job_async(
+            # Atomic add-if-absent: the name check and the append happen under
+            # one store lock (fresh _sync first), so a CLI enable racing the
+            # gateway's own registration cannot persist duplicate jobs. The
+            # existing_names snapshot above remains only a cheap fast path to
+            # skip vetting for jobs already seen; this call is the authority.
+            job = await sdk.add_job_if_absent_async(
                 name=name,
                 message=d.get("message", ""),
                 every_secs=d.get("every"),  # JSON "every" → Python "every_secs"
@@ -1428,6 +1433,10 @@ async def register_app_crons_with_service(app_name: str, cron_service: Any) -> l
                 silent=bool(d.get("silent", False)),
                 enabled=bool(d.get("enabled", True)),
             )
+            if job is None:
+                # Lost the race (or already present): another registrar
+                # persisted this name first. Correct outcome — not "new".
+                continue
             newly_registered.append(name)
             sel().log_api_access(
                 caller="app_bridge",

--- a/src/kiro_crew/apps/cron_sdk.py
+++ b/src/kiro_crew/apps/cron_sdk.py
@@ -298,6 +298,45 @@ class CronSDK:
         self._audit_add(job)
         return job
 
+    async def add_job_if_absent_async(
+        self,
+        name: str,
+        message: str,
+        *,
+        every_secs: int | None = None,
+        cron_expr: str | None = None,
+        agent: str = "",
+        command: str = "",
+        script: str = "",
+        agent_sequence: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        persistent_session: bool = True,
+        silent: bool = False,
+        enabled: bool = True,
+    ) -> Any:
+        """Atomic add-if-absent by job name; returns None when already present.
+
+        Routes through ``CronService.add_job_if_absent``, whose existence check
+        and append happen under ONE store file lock after a fresh ``_sync()`` —
+        so two concurrent registrars (e.g. a CLI enable racing gateway boot)
+        cannot both snapshot the name as absent and persist duplicates. The
+        bounded lock spin runs in a worker thread, keeping on-loop callers safe.
+        """
+        self._vet_command_script(name, command, script)
+        job = await self._cron.add_job_if_absent_async(
+            lambda existing, n=name: existing.name == n,
+            **self._add_job_kwargs(
+                name, message,
+                every_secs=every_secs, cron_expr=cron_expr, agent=agent,
+                command=command, script=script, agent_sequence=agent_sequence,
+                env=env, persistent_session=persistent_session, silent=silent,
+                enabled=enabled,
+            ),
+        )
+        if job is not None:
+            self._audit_add(job)
+        return job
+
     def _audit_add(self, job: Any) -> None:
         sel().log_api_access(
             caller=f"app:{self._app_name}",

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -27,6 +27,7 @@ from kiro_crew.apps.bridges import (
     deregister_app,
     deregister_app_crons_from_service,
     register_app,
+    register_app_crons_with_service,
 )
 from kiro_crew.apps.manager import (
     disable_app,
@@ -527,6 +528,48 @@ def _cleanup_app_crons_from_scheduler(app_name: str) -> int:
     return removed
 
 
+def _register_app_crons_to_scheduler(app_name: str) -> list[str]:
+    """Promote the enabled app's cron definitions into the shared scheduler store.
+
+    Mirrors ``_cleanup_app_crons_from_scheduler`` for the enable direction: the
+    HTTP enable route promotes app crons into the running CronService via
+    ``hooks_integration.on_app_enable``, but the CLI runs in a separate process
+    with no handle on the gateway's service — so without a store write here, an
+    app enabled from the CLI has its crons lie dormant until the next gateway
+    restart. Writing through a store-backed CronService closes that gap: the
+    running gateway's timer tick re-syncs ``crons.json`` by content digest at
+    least every ``_TIMER_POLL_SECS``, picking up externally-added jobs by
+    design. ``register_app_crons_with_service`` applies the same trust gate and
+    command/script vetting as the gateway paths and is idempotent (jobs already
+    present by name are skipped). Returns the newly registered job names.
+    """
+    svc = CronService(base_dir=config_dir())
+    svc._load()
+    try:
+        # register_app_crons_with_service is async (routes through the async
+        # CronSDK mutators). The CLI is a loop-less process, so drive it with a
+        # one-shot event loop. No scheduler is running here, so nothing is armed.
+        registered = asyncio.run(register_app_crons_with_service(app_name, svc))
+        sel().log_api_access(
+            caller="cli",
+            operation="app_crons_register",
+            outcome="completed",
+            resources=f"app={app_name} crons={registered}",
+        )
+    except Exception as exc:
+        sel().log_api_access(
+            caller="cli",
+            operation="app_crons_register",
+            outcome="failed",
+            resources=app_name,
+            error=str(exc),
+        )
+        raise
+    if registered:
+        print(f"  registered {len(registered)} cron job(s) with scheduler")
+    return registered
+
+
 def _run_app_mcp_server(app_name: str) -> None:
     """Run the named app's stdio MCP server in this process.
 
@@ -603,6 +646,7 @@ def _handle_app(args: argparse.Namespace) -> None:
                 print(f"   Agents registered: {len(reg.agents)}")
             if reg.skills:
                 print(f"   Skills registered: {len(reg.skills)}")
+            _register_app_crons_to_scheduler(args.name)
         else:
             print(f"❌ {result.error}", file=sys.stderr)
             sys.exit(1)

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -1231,14 +1231,57 @@ class CronService:
     ) -> CronJob | None:
         """Build and persist a job only when no current store entry matches."""
         job = self._build_job(**kwargs)
+        if not self._persist_add_if_absent_locked(predicate, job):
+            return None
+        self._arm_timer()
+        return job
+
+    async def add_job_if_absent_async(
+        self,
+        predicate: Callable[[CronJob], bool],
+        **kwargs: Any,
+    ) -> CronJob | None:
+        """Event-loop-native :meth:`add_job_if_absent`.
+
+        Mirrors :meth:`add_job_async`: the job is built on-loop, the
+        lock/sync/check/append/save core runs in a worker thread so the
+        bounded ``_file_lock`` spin never parks the gateway loop, and timer
+        arming stays on-loop. The absence check and the append happen under
+        ONE store lock after a fresh ``_sync()``, so two concurrent
+        registrars (e.g. a CLI enable racing gateway boot) cannot both
+        observe the name as absent and persist duplicates. Returns None when
+        a matching job already exists.
+        """
+        job = self._build_job(**kwargs)
+        persisted = await asyncio.to_thread(
+            self._persist_add_if_absent_locked, predicate, job
+        )
+        if not persisted:
+            return None
+        self._arm_timer()
+        logger.info("Added cron job '%s' (%s) [if-absent]", job.name, job.id)
+        return job
+
+    def _persist_add_if_absent_locked(
+        self,
+        predicate: Callable[[CronJob], bool],
+        job: CronJob,
+    ) -> bool:
+        """Lock/reload/check/append/save — the atomic add-if-absent disk core.
+
+        Like :meth:`_persist_add_locked` (no timer work, thread-safe, raises
+        :class:`CronStoreBusy` on sustained contention) but the existence
+        check happens INSIDE the same lock, after ``_sync()`` refreshed the
+        in-memory view — closing the snapshot-then-append TOCTOU. Returns
+        False when an existing job matches ``predicate``.
+        """
         with self._file_lock():
             self._sync()
             if any(predicate(existing) for existing in self._jobs):
-                return None
+                return False
             self._jobs.append(job)
             self._save()
-        self._arm_timer()
-        return job
+        return True
 
     def _build_job(
         self,

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -536,13 +536,13 @@ class TestCronRegistration:
         try:
             loop_thread = threading.get_ident()
             persist_threads: list[int] = []
-            orig_persist = svc._persist_add_locked
+            orig_persist = svc._persist_add_if_absent_locked
 
-            def _track(job):  # type: ignore[no-untyped-def]
+            def _track(predicate, job):  # type: ignore[no-untyped-def]
                 persist_threads.append(threading.get_ident())
-                return orig_persist(job)
+                return orig_persist(predicate, job)
 
-            svc._persist_add_locked = _track  # type: ignore[method-assign, assignment]
+            svc._persist_add_if_absent_locked = _track  # type: ignore[method-assign, assignment]
 
             registered = await register_app_crons_with_service("test-app", svc)
             assert "test-app/refresh" in registered
@@ -1248,7 +1248,7 @@ class TestCronServiceBridge:
             result = _run(register_app_crons_with_service("test-app", MagicMock()))
 
         assert result == []
-        mock_sdk.add_job_async.assert_not_called()
+        mock_sdk.add_job_if_absent_async.assert_not_called()
 
     def test_boot_explicit_allow_registers_third_party_crons(self, tmp_path, app_env, monkeypatch):
         from unittest.mock import MagicMock, patch
@@ -1267,13 +1267,13 @@ class TestCronServiceBridge:
         )
         mock_sdk = MagicMock()
         mock_sdk.list_jobs.return_value = []
-        mock_sdk.add_job_async = AsyncMock(return_value=MagicMock(id="job-id"))
+        mock_sdk.add_job_if_absent_async = AsyncMock(return_value=MagicMock(id="job-id"))
 
         with patch("kiro_crew.apps.bridges.CronSDK", return_value=mock_sdk):
             result = _run(register_app_crons_with_service("test-app", MagicMock()))
 
         assert result == ["test-app/refresh"]
-        mock_sdk.add_job_async.assert_awaited_once()
+        mock_sdk.add_job_if_absent_async.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_boot_disarms_persisted_denied_app_crons_before_timer_start(
@@ -1461,13 +1461,13 @@ class TestCronServiceBridge:
         mock_cron_service = MagicMock()
         mock_sdk = MagicMock()
         mock_sdk.list_jobs.return_value = []
-        mock_sdk.add_job_async = AsyncMock(return_value=MagicMock(id="abc123"))
+        mock_sdk.add_job_if_absent_async = AsyncMock(return_value=MagicMock(id="abc123"))
 
         with patch("kiro_crew.apps.bridges.CronSDK", return_value=mock_sdk):
             result = _run(register_app_crons_with_service("test-app", mock_cron_service))
 
         assert result == ["test-app/refresh"]
-        mock_sdk.add_job_async.assert_called_once_with(
+        mock_sdk.add_job_if_absent_async.assert_called_once_with(
             name="test-app/refresh",
             message="do stuff",
             every_secs=600,
@@ -1504,13 +1504,13 @@ class TestCronServiceBridge:
         mock_cron_service = MagicMock()
         mock_sdk = MagicMock()
         mock_sdk.list_jobs.return_value = []
-        mock_sdk.add_job_async = AsyncMock(return_value=MagicMock(id="abc123"))
+        mock_sdk.add_job_if_absent_async = AsyncMock(return_value=MagicMock(id="abc123"))
 
         with patch("kiro_crew.apps.bridges.CronSDK", return_value=mock_sdk):
             result = _run(register_app_crons_with_service("test-app", mock_cron_service))
 
         assert result == ["test-app/nightly-run"]
-        assert mock_sdk.add_job_async.call_args.kwargs["enabled"] is False
+        assert mock_sdk.add_job_if_absent_async.call_args.kwargs["enabled"] is False
 
     def test_legacy_defs_without_enabled_default_active(self, tmp_path, app_env, monkeypatch):
         """Pre-existing app-crons.json without the enabled key registers active."""
@@ -1532,12 +1532,12 @@ class TestCronServiceBridge:
         mock_cron_service = MagicMock()
         mock_sdk = MagicMock()
         mock_sdk.list_jobs.return_value = []
-        mock_sdk.add_job_async = AsyncMock(return_value=MagicMock(id="abc123"))
+        mock_sdk.add_job_if_absent_async = AsyncMock(return_value=MagicMock(id="abc123"))
 
         with patch("kiro_crew.apps.bridges.CronSDK", return_value=mock_sdk):
             _run(register_app_crons_with_service("test-app", mock_cron_service))
 
-        assert mock_sdk.add_job_async.call_args.kwargs["enabled"] is True
+        assert mock_sdk.add_job_if_absent_async.call_args.kwargs["enabled"] is True
 
     def test_startup_skips_existing_disabled_job(self, tmp_path, app_env, monkeypatch):
         """Gateway-startup re-registration must not re-add (and thus re-pause)
@@ -1576,7 +1576,7 @@ class TestCronServiceBridge:
             result = _run(register_app_crons_with_service("test-app", mock_cron_service))
 
         assert result == []
-        mock_sdk.add_job_async.assert_not_called()
+        mock_sdk.add_job_if_absent_async.assert_not_called()
         # The existing job's state is untouched — no duplicate, no re-pause.
         assert existing.enabled is False
         assert existing.user_paused is True
@@ -1608,13 +1608,13 @@ class TestCronServiceBridge:
         mock_cron_service = MagicMock()
         mock_sdk = MagicMock()
         mock_sdk.list_jobs.return_value = []
-        mock_sdk.add_job_async = AsyncMock(return_value=MagicMock(id="cmd123"))
+        mock_sdk.add_job_if_absent_async = AsyncMock(return_value=MagicMock(id="cmd123"))
 
         with patch("kiro_crew.apps.bridges.CronSDK", return_value=mock_sdk):
             result = _run(register_app_crons_with_service("test-app", mock_cron_service))
 
         assert result == ["test-app/collect"]
-        mock_sdk.add_job_async.assert_called_once_with(
+        mock_sdk.add_job_if_absent_async.assert_called_once_with(
             name="test-app/collect",
             message="",
             every_secs=60,
@@ -1652,7 +1652,7 @@ class TestCronServiceBridge:
             result = _run(register_app_crons_with_service("test-app", mock_cron_service))
 
         assert result == []
-        mock_sdk.add_job_async.assert_not_called()
+        mock_sdk.add_job_if_absent_async.assert_not_called()
 
     def test_rejects_invalid_script_path(self, tmp_path, app_env, monkeypatch):
         """Scripts outside ~/.kirocrew/crons/ are rejected at registration."""
@@ -1677,7 +1677,7 @@ class TestCronServiceBridge:
             result = _run(register_app_crons_with_service("test-app", mock_cron_service))
 
         assert result == []
-        mock_sdk.add_job_async.assert_not_called()
+        mock_sdk.add_job_if_absent_async.assert_not_called()
 
     def test_idempotent_skips_existing(self, tmp_path, app_env, monkeypatch):
         from unittest.mock import MagicMock, patch
@@ -1697,7 +1697,7 @@ class TestCronServiceBridge:
             result = _run(register_app_crons_with_service("test-app", mock_cron_service))
 
         assert result == []
-        mock_sdk.add_job_async.assert_not_called()
+        mock_sdk.add_job_if_absent_async.assert_not_called()
 
     def test_returns_empty_when_no_cron_service(self, tmp_path, app_env):
         from kiro_crew.apps.bridges import register_app_crons_with_service
@@ -1727,7 +1727,7 @@ class TestCronServiceBridge:
         mock_cron_service = MagicMock()
         mock_sdk = MagicMock()
         mock_sdk.list_jobs.return_value = []
-        mock_sdk.add_job_async = AsyncMock(return_value=MagicMock(id="x"))
+        mock_sdk.add_job_if_absent_async = AsyncMock(return_value=MagicMock(id="x"))
 
         with patch("kiro_crew.apps.bridges.CronSDK", return_value=mock_sdk):
             result = _run(register_app_crons_with_service("test-app", mock_cron_service))
@@ -1787,14 +1787,14 @@ class TestCronServiceBridge:
         mock_sdk = MagicMock()
         mock_sdk.list_jobs.return_value = []
         # First call raises, second succeeds
-        mock_sdk.add_job_async = AsyncMock(side_effect=[RuntimeError("boom"), MagicMock(id="ok")])
+        mock_sdk.add_job_if_absent_async = AsyncMock(side_effect=[RuntimeError("boom"), MagicMock(id="ok")])
 
         with patch("kiro_crew.apps.bridges.CronSDK", return_value=mock_sdk):
             result = _run(register_app_crons_with_service("test-app", mock_cron_service))
 
         # Failed entry skipped, good entry registered
         assert result == ["test-app/good"]
-        assert mock_sdk.add_job_async.call_count == 2
+        assert mock_sdk.add_job_if_absent_async.call_count == 2
 
 
 class TestCronServiceDeregister:

--- a/test/test_app_cli.py
+++ b/test/test_app_cli.py
@@ -12,7 +12,7 @@ from kiro_crew.apps.manager import APP_MANIFEST_FILENAME, install_app
 # ---------------------------------------------------------------------------
 
 
-def _make_app_source(tmp_path, name="cli-test-app"):
+def _make_app_source(tmp_path, name="cli-test-app", crons=None):
     src = tmp_path / "source" / name
     src.mkdir(parents=True)
     manifest = {
@@ -24,6 +24,8 @@ def _make_app_source(tmp_path, name="cli-test-app"):
         "agents": ["agents/test-agent.json"],
         "skills": ["skills/test-skill"],
     }
+    if crons is not None:
+        manifest["crons"] = crons
     (src / APP_MANIFEST_FILENAME).write_text(json.dumps(manifest, indent=2))
     (src / "agents").mkdir()
     (src / "agents" / "test-agent.json").write_text('{"name": "test-agent"}')
@@ -164,3 +166,119 @@ class TestHandleApp:
         _handle_app(ns)
         captured = capsys.readouterr()
         assert "Usage" in captured.out
+
+
+class TestEnableRegistersCrons:
+    """CLI `app enable` must promote manifest crons into the scheduler store.
+
+    The HTTP enable route promotes app crons into the running CronService via
+    ``hooks_integration.on_app_enable``; the CLI runs in a separate process, so
+    it must write the jobs through the shared on-disk store instead (the
+    gateway's timer tick re-syncs the store by content digest and picks up
+    externally-added jobs). Without that write, an app enabled from the CLI
+    has its crons lie dormant until the next gateway restart.
+    """
+
+    CRONS = [{"name": "poller", "every": 900, "message": "poll things", "silent": True}]
+
+    def _store_job_names(self):
+        from kiro_crew.config import config_dir
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=config_dir())
+        return [j.name for j in svc.list_jobs(include_disabled=True)]
+
+    def _enable(self):
+        import argparse
+
+        from kiro_crew.cli import _handle_app
+
+        ns = argparse.Namespace(app_action="enable", name="cli-test-app")
+        _handle_app(ns)
+
+    def test_enable_registers_manifest_crons_in_store(self, tmp_path, app_env):
+        src = _make_app_source(tmp_path, crons=self.CRONS)
+        install_app(src)
+
+        assert self._store_job_names() == []  # nothing before enable
+        self._enable()
+
+        names = self._store_job_names()
+        assert names == ["cli-test-app/poller"]
+
+        # Ownership tag must match what disable-side cleanup removes by.
+        from kiro_crew.config import config_dir
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=config_dir())
+        job = svc.list_jobs(include_disabled=True)[0]
+        assert job.created_by == "app:cli-test-app"
+
+    def test_enable_twice_is_idempotent(self, tmp_path, app_env):
+        src = _make_app_source(tmp_path, crons=self.CRONS)
+        install_app(src)
+
+        self._enable()
+        self._enable()
+
+        assert self._store_job_names() == ["cli-test-app/poller"]
+
+    def test_concurrent_registration_persists_single_job(self, tmp_path, app_env):
+        """Two registrars with stale absent-snapshots must not persist duplicates.
+
+        Reproduces the CLI-enable-vs-gateway-boot race at the primitive the
+        bridge now routes through: two store-backed services both see the name
+        absent, then add concurrently. ``add_job_if_absent_async`` (name check
+        + append under one store lock) must let exactly one win — with the old
+        snapshot-then-``add_job_async`` path this persists two jobs.
+        """
+        import asyncio
+
+        from kiro_crew.apps.cron_sdk import CronSDK
+        from kiro_crew.config import config_dir
+        from kiro_crew.cron import CronService
+
+        async def _race() -> list:
+            # Two independent store-backed services, as in separate processes;
+            # both snapshot the store before either has appended.
+            svc_a = CronService(base_dir=config_dir())
+            svc_a._load()
+            svc_b = CronService(base_dir=config_dir())
+            svc_b._load()
+            return await asyncio.gather(
+                CronSDK("cli-test-app", svc_a).add_job_if_absent_async(
+                    "cli-test-app/poller", "poll things", every_secs=900
+                ),
+                CronSDK("cli-test-app", svc_b).add_job_if_absent_async(
+                    "cli-test-app/poller", "poll things", every_secs=900
+                ),
+            )
+
+        results = asyncio.run(_race())
+
+        assert self._store_job_names() == ["cli-test-app/poller"]
+        # Exactly one registrar won; the loser observed the existing job.
+        assert sorted(r is None for r in results) == [False, True]
+
+    def test_disable_removes_registered_crons(self, tmp_path, app_env):
+        import argparse
+
+        from kiro_crew.cli import _handle_app
+
+        src = _make_app_source(tmp_path, crons=self.CRONS)
+        install_app(src)
+        self._enable()
+        assert self._store_job_names() == ["cli-test-app/poller"]
+
+        ns = argparse.Namespace(app_action="disable", name="cli-test-app")
+        _handle_app(ns)
+
+        assert self._store_job_names() == []
+
+    def test_enable_without_crons_registers_nothing(self, tmp_path, app_env):
+        src = _make_app_source(tmp_path)  # no crons in manifest
+        install_app(src)
+
+        self._enable()
+
+        assert self._store_job_names() == []

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -562,6 +562,13 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # ``asyncio.run`` sites below (cli_doctor.py::_doctor, workflows
         # server.py::handle_run).
         "cli_commands.py::_cleanup_app_crons_from_scheduler",
+        # NOT a subprocess spawn: the AST heuristic matches ``asyncio.run`` (attr
+        # ``run`` on base ``asyncio``), used to drive the async
+        # ``register_app_crons_with_service`` coroutine from the loop-less CLI
+        # enable path — the exact enable-direction mirror of
+        # ``_cleanup_app_crons_from_scheduler`` above. No child process is
+        # created; the sole input is the operator-typed app name.
+        "cli_commands.py::_register_app_crons_to_scheduler",
         "cli_doctor.py::_doctor",
         "cli_doctor.py::_doctor_mcp_tools",
         # Read-only diagnostic: `loginctl show-user <user> -p Linger --value`,


### PR DESCRIPTION
## Problem

`kirocrew app enable` (CLI) enables an app and registers its agents/skills, but never promotes the app's manifest-declared crons into the shared cron store. Scheduler promotion only happens on two paths:

- the dashboard HTTP enable route (`hooks_integration.on_app_enable` → `register_app_crons_with_service`), which has a handle on the running gateway's `CronService`, and
- gateway boot, which re-registers crons for every enabled app.

So an app enabled from the CLI while the gateway is running has its crons lie **dormant until the next gateway restart** — silently: the CLI prints the enable success, the manifest file (`app-crons.json`) is written, but no job ever fires.

The disable direction already handles this: CLI `disable`/`uninstall` calls `_cleanup_app_crons_from_scheduler`, which writes the removal through a store-backed `CronService` instance. The enable direction simply has no counterpart — an asymmetry, not a design constraint.

Observed in the field (log evidence, sanitized): an app with an every-15-minutes cron was installed and enabled via CLI at 22:09; its output file was last refreshed at 22:20 (a manual run), the job never appeared in `crons.json`, and the gateway — up since the previous day — would not have picked it up until its next restart.

```
22:09:11 WARNING kiro_crew.apps.manager [PID <cli>]: Removing orphaned partial install at .../apps/<app>
   (install/enable ran in a CLI process; no cron-registration line ever follows,
    and the shared crons.json contains no job owned by app:<app>)
```

## Why writing through the store is safe

Cross-process pickup is already a documented design guarantee of `CronService`: the gateway's timer always wakes within `_TIMER_POLL_SECS` (30s) and `_sync()`s the store by content digest, explicitly "to _sync() externally-added jobs" (`cron.py::_effective_delay`). The disable-side CLI cleanup relies on the same shared-store mechanics today.

## Fix

Add `_register_app_crons_to_scheduler(app_name)` in `cli_commands.py`, mirroring `_cleanup_app_crons_from_scheduler`: instantiate a store-backed `CronService(base_dir=config_dir())`, drive the existing async `register_app_crons_with_service` with a one-shot event loop, and audit the outcome. Call it from the CLI `enable` action after `register_app` (which writes `app-crons.json`, the definitions the bridge loads).

No new policy surface: `register_app_crons_with_service` applies the same central execution-admission gate (`cron_register`) and the same command/script vetting as the gateway paths, and is idempotent (jobs already present by name are skipped, so a CLI enable racing a gateway-side registration cannot duplicate). Ownership tagging (`created_by="app:<name>"`) is unchanged, so existing disable/uninstall cleanup and the boot orphan-disarm keep working.

## Tests

New `TestEnableRegistersCrons` in `test/test_app_cli.py` (mutation-verified — 3 of 4 fail without the fix):

- CLI enable registers manifest crons in the store with the correct `created_by` owner tag
- enabling twice is idempotent (no duplicates)
- CLI disable removes what CLI enable registered
- an app without manifest crons registers nothing

Results: 11/11 `test_app_cli.py`; 336 passed across the neighborhood (`test_app_cli`, `test_app_bridges`, `test_app_manager`, `test_app_execution`, `test_cron`); isort/flake8/mypy clean on touched files.