### PR TITLE
fix(messaging): stop a renderer close failure from wedging a conversation

### DIFF
--- a/src/kiro_crew/messaging/renderer.py
+++ b/src/kiro_crew/messaging/renderer.py
@@ -200,6 +200,30 @@ class Renderer(ABC):
         """Called once before the provider stream begins. Default no-op."""
         return None
 
+    async def close(self) -> None:
+        """Release whatever the renderer opened for this turn. Default no-op.
+
+        Declared here because the shared pipeline's ``finally`` awaits it
+        (``messaging/dispatch.py``) — before this existed, that await reached
+        through an ``Any`` for a method the contract never mentioned, so a
+        channel could change its signature without anything noticing. Telegram
+        did: its override takes an extra optional ``failure_reason``, which is a
+        legal widening of this contract and stays a channel-local concern until
+        the pipeline has a reason to carry one.
+
+        Two rules for implementers:
+
+        * It runs in a ``finally`` and is BEST-EFFORT. A caller must never let a
+          failure here skip the session release — see the guard in
+          ``drive_turn``, and note that the semaphore is keyed by SESSION, so a
+          lost release wedges every later message in that conversation rather
+          than only this turn.
+        * It must tolerate being called when the turn never really started
+          (``get_or_create`` can raise before the semaphore is held), so
+          finalizing a placeholder that does not exist is not an error.
+        """
+        return None
+
     @abstractmethod
     async def on_text_chunk(self, text: str) -> None:
         """Render a streamed assistant text chunk."""

--- a/src/kiro_crew/slack/transport_dispatch.py
+++ b/src/kiro_crew/slack/transport_dispatch.py
@@ -687,7 +687,20 @@ async def handle_message_transport(
         # Guarantee renderer teardown even if TurnDriver.run() raised before
         # on_done: cancels the 30s tool-elapsed timer so it can't survive the
         # turn and keep hitting append_task against a dead stream.
+        #
+        # Teardown is best-effort and must NEVER prevent the release below: the
+        # semaphore is keyed by SESSION, so a close() that raises here would
+        # wedge every later message in that conversation (and its queue drain)
+        # until the gateway restarts, not merely lose this turn. Same guard as
+        # Discord's dispatcher and the shared pipeline.
         if renderer is not None:
-            await renderer.close()
+            try:
+                await renderer.close()
+            except Exception:
+                logger.warning(
+                    "Slack: renderer.close failed session=%s",
+                    session_key,
+                    exc_info=True,
+                )
         if _acquired:
             sessions.release(session_key)

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -485,7 +485,24 @@ class TelegramDispatcher:
             # Always finalize the placeholder (no perma-"🤔 …"), even if
             # get_or_create raised before the semaphore was held. Only release
             # the semaphore if we actually acquired it.
-            await renderer.close(failure_reason=failure_reason)
+            #
+            # ``close()`` is best-effort and must NEVER prevent the three steps
+            # after it. A renderer that fails to finalize -- a malformed
+            # Telegram response, a socket dropped mid-edit -- would otherwise
+            # skip ALL of them: the session semaphore is never given back (and
+            # because it is keyed by SESSION, every later message in that
+            # conversation blocks forever and the queue never drains), the
+            # ``_active_renderers`` entry leaks, and the attachment temp files
+            # stay on disk. Discord and the shared pipeline both already guard
+            # this; Telegram was the remaining copy that did not.
+            try:
+                await renderer.close(failure_reason=failure_reason)
+            except Exception:
+                logger.warning(
+                    "Telegram: renderer.close failed session=%s",
+                    session_key,
+                    exc_info=True,
+                )
             self._active_renderers.pop(session_key, None)
             if _acquired:
                 self.sessions.release(session_key)

--- a/test/test_close_guard_parity.py
+++ b/test/test_close_guard_parity.py
@@ -1,0 +1,181 @@
+"""Every dispatcher's ``finally`` must survive a renderer that fails to close.
+
+``renderer.close()`` runs in the ``finally`` of a turn, ahead of the session
+release. If it raises and the call is unguarded, the release never happens --
+and because the semaphore is keyed by SESSION, that does not merely lose one
+turn: every later message in that conversation blocks forever and its queue
+never drains. The channel looks permanently busy until the gateway restarts.
+
+The shared pipeline (``messaging/dispatch.py``) and Discord both guard this
+already; Telegram and Slack did not, which is what these tests pin. Telegram is
+the worst case of the three because two more steps sit after its ``close()`` --
+the ``_active_renderers`` pop and the attachment temp-file cleanup -- so an
+unguarded raise leaked three things, not one.
+
+``TestRatchet`` is the part that makes this un-forgettable: it reads every
+dispatcher's source and fails if a ``renderer.close()`` is not inside a ``try``.
+A new channel that copies the old shape fails here rather than in production.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+
+import kiro_crew.messaging.dispatch as _pipeline
+from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_TEXT_CHUNK, STOP_REASON_END_TURN
+from kiro_crew.slack import transport_dispatch as slack_dispatch
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+_tg = importlib.import_module("test_telegram")
+_golden = importlib.import_module("test_slack_golden_transcript")
+
+
+class _CountingSessions(_golden.FakeSessions):
+    """Slack's FakeSessions.release() records nothing; count it here."""
+
+    def __init__(self, provider) -> None:
+        super().__init__(provider)
+        self.released: list = []
+
+    def release(self, session_key):
+        self.released.append(session_key)
+        return None
+
+
+class TestSlack:
+    def test_release_survives_a_close_failure(self, monkeypatch) -> None:
+        """Pre-fix this leaked the semaphore for the whole conversation."""
+        monkeypatch.setattr(slack_dispatch, "_get_default_agent", lambda: "")
+        monkeypatch.setattr(slack_dispatch, "_hydrate_thread_overrides", lambda *a, **k: None)
+        monkeypatch.setattr(slack_dispatch, "_hydrate_conv_flags", lambda *a, **k: None)
+        monkeypatch.setattr(slack_dispatch, "_thread_agents", {})
+
+        real_renderer = slack_dispatch.SlackRenderer
+
+        class _ExplodingRenderer(real_renderer):  # type: ignore[misc,valid-type]
+            async def close(self):  # noqa: D102
+                raise RuntimeError("slack renderer finalization failed")
+
+        monkeypatch.setattr(slack_dispatch, "SlackRenderer", _ExplodingRenderer)
+
+        provider = _golden.ScriptedProvider(
+            [
+                _golden.make_event(EVENT_TEXT_CHUNK, text="hi"),
+                _golden.make_event(EVENT_COMPLETE, stop_reason=STOP_REASON_END_TURN),
+            ]
+        )
+        sessions = _CountingSessions(provider)
+
+        # Must not raise: a finalization failure is not a turn failure.
+        asyncio.run(
+            slack_dispatch.handle_message_transport(
+                slack=_golden.RecordingSlackClient(),
+                sessions=sessions,
+                channel="C1",
+                text="hello",
+                thread_ts=None,
+                msg_ts="1700000000.000100",
+                user_id="U_OWNER",
+                context_builder=None,
+                conversation_log=None,
+            )
+        )
+
+        assert sessions.released, (
+            "Slack did not release the session after renderer.close() raised -- "
+            "that conversation is now permanently busy"
+        )
+
+
+class TestTelegram:
+    def test_release_and_cleanup_survive_a_close_failure(self, monkeypatch) -> None:
+        """Three steps sit after telegram's close(); all three must still run."""
+        d, cli, sess = _tg._dispatcher({7})
+
+        real_renderer = _tg.TelegramRenderer
+
+        class _ExplodingRenderer(real_renderer):  # type: ignore[misc,valid-type]
+            async def close(self, failure_reason: str | None = None):  # noqa: D102
+                raise RuntimeError("telegram renderer finalization failed")
+
+        import kiro_crew.telegram.transport_dispatch as tg_dispatch
+
+        monkeypatch.setattr(tg_dispatch, "TelegramRenderer", _ExplodingRenderer)
+
+        cleaned: list = []
+        monkeypatch.setattr(tg_dispatch, "cleanup_attachments", lambda paths: cleaned.append(paths))
+
+        msg = _tg.InboundMessage(
+            channel_type="telegram",
+            user_id="7",
+            conversation_id="7",
+            text="hello",
+        )
+
+        # Must not raise.
+        asyncio.run(d.handle_message(msg))
+
+        assert sess.released, (
+            "Telegram did not release the session after close() raised -- the "
+            "conversation is permanently busy"
+        )
+        assert cleaned, (
+            "Telegram skipped cleanup_attachments after close() raised -- "
+            "attachment temp files leak on every failed finalization"
+        )
+
+
+def _close_calls_are_guarded(path: Path) -> list[int]:
+    """Return the line numbers of ``renderer.close()`` calls NOT inside a try.
+
+    Source-level rather than behavioural on purpose: the point is to catch a
+    NEW channel that never got a test, and a parametrised behavioural test
+    cannot be written for a dispatcher that does not exist yet.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    guarded: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Try):
+            for stmt in node.body:
+                for inner in ast.walk(stmt):
+                    if isinstance(inner, ast.Call):
+                        guarded.add(inner.lineno)
+
+    unguarded: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "close":
+            continue
+        target = func.value
+        if not (isinstance(target, ast.Name) and target.id == "renderer"):
+            continue
+        if node.lineno not in guarded:
+            unguarded.append(node.lineno)
+    return unguarded
+
+
+class TestRatchet:
+    def test_no_dispatcher_awaits_close_unguarded(self) -> None:
+        pkg = Path(_pipeline.__file__).resolve().parent.parent
+        targets = [pkg / "messaging" / "dispatch.py"] + sorted(
+            pkg.glob("*/transport_dispatch.py")
+        )
+        assert len(targets) >= 5, f"expected the dispatcher set, found {targets}"
+
+        offenders = {
+            str(p.relative_to(pkg)): lines
+            for p in targets
+            if (lines := _close_calls_are_guarded(p))
+        }
+        assert not offenders, (
+            "these dispatchers await renderer.close() outside a try, so a "
+            "finalization failure skips the session release and wedges the "
+            f"conversation: {offenders}"
+        )


### PR DESCRIPTION
`renderer.close()` runs in a turn's `finally`, ahead of the session release.
Telegram and Slack awaited it unguarded, so a close that raised skipped
everything after it -- and because the semaphore is keyed by SESSION, that does
not lose one turn: every later message in that conversation blocks forever and
its queue never drains, until the gateway restarts. The raise also escapes the
dispatcher entirely, surfacing as an unhandled task exception on a turn that had
already delivered its reply.

Telegram was the worst of the two: three steps sit after its `close()`, so an
unguarded raise leaked the session semaphore, the `_active_renderers` entry, and
the attachment temp files.

The shared pipeline (`messaging/dispatch.py`) and Discord already guard this --
this brings the two remaining hand-written copies to the same shape, and adds the
mechanism that stops the next channel from re-introducing it.

- telegram/transport_dispatch.py: guard `close()`; pop, release and
  `cleanup_attachments` now always run.
- slack/transport_dispatch.py: guard `close()`; release now always runs.
- messaging/renderer.py: declare `close()` on the `Renderer` ABC. It was never
  declared, yet `drive_turn`'s `finally` awaits it through an `Any`, so a channel
  could change its signature with nothing noticing -- Telegram's override takes
  an extra optional `failure_reason` (a legal widening) and no type check saw the
  divergence. Declared as a documented default no-op rather than
  `@abstractmethod` so existing renderers and test fakes keep working; the
  docstring states the two rules implementers depend on (best-effort, and safe to
  call when the turn never started).
- test/test_close_guard_parity.py: behavioural regression per channel plus a
  `TestRatchet` that parses every dispatcher and fails on a `renderer.close()`
  outside a `try`. The ratchet is the un-forgettable part: a new channel that
  copies the old shape fails there instead of in production.

Red-proof: reverting both guards fails all three tests, with the RuntimeError
escaping the dispatcher in the two behavioural cases.

Found by an adversarial cross-vendor review panel (claude-opus-5, gpt-5.6-sol,
deepseek-3.2, glm-5) red-teaming an architecture claim about the shared turn
pipeline. One member flagged the Telegram site; auditing every `close()` call
site turned up the Slack one as well.
