### PR TITLE
fix(chat): keep the follow-up toggle correct across rapid clicks

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -3475,6 +3475,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // what gets sent. Cleared whenever the options list changes (new assistant
   // message) or the active chat switches — both signal a fresh turn.
   const [followUpPicked, setFollowUpPicked] = useState<Set<string>>(() => new Set())
+  // Read by the option handler instead of the state: two clicks landing before a
+  // re-render would both see the same set and both take the append branch.
+  const followUpPickedRef = useRef(followUpPicked); followUpPickedRef.current = followUpPicked
   const followUpOptionsKey = followUpOptions.join('\x00')
   useEffect(() => { setFollowUpPicked(new Set()) }, [followUpOptionsKey, activeSlot])
   const { data: dashCfg } = useQuery<{ quick_send?: boolean; session_grid?: boolean; link_previews?: boolean }>({ queryKey: ['dashboardConfig'], queryFn: () => api.dashboardConfig(), staleTime: 30_000 })
@@ -6724,12 +6727,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                   return
                 }
                 // One-click: enabled + no shift + not busy + not already in multi-select
-                if (tryQuickSend(o, dashCfg?.quick_send, e.shiftKey, slotRunning, followUpPicked.size, send)) return
+                if (tryQuickSend(o, dashCfg?.quick_send, e.shiftKey, slotRunning, followUpPickedRef.current.size, send)) return
                 // Regular options: toggle. Click unpicked → append + mark; click
                 // picked → try to remove text + unmark (if the user edited the
                 // text so it no longer matches, leave text alone — the chip
                 // still un-highlights for consistency).
-                if (followUpPicked.has(o)) {
+                if (followUpPickedRef.current.has(o)) {
+                  const next = new Set(followUpPickedRef.current); next.delete(o)
+                  followUpPickedRef.current = next
                   setInput(prev => {
                     // Order matters: try leading ", o" first so "opt, opt" + remove
                     // last "opt" doesn't match "opt, " and splice the wrong one.
@@ -6742,10 +6747,12 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                     if (prev === o) return ''
                     return prev  // user edited — leave text, still unmark below
                   })
-                  setFollowUpPicked(prev => { const next = new Set(prev); next.delete(o); return next })
+                  setFollowUpPicked(next)
                 } else {
+                  const next = new Set(followUpPickedRef.current); next.add(o)
+                  followUpPickedRef.current = next
                   setInput(prev => prev.trim() ? prev.trimEnd() + ', ' + o : o)
-                  setFollowUpPicked(prev => new Set(prev).add(o))
+                  setFollowUpPicked(next)
                 }
               }}
               pasteBlocks={pasteBlocks}

--- a/website/src/test/ChatPage.followUpToggle.test.tsx
+++ b/website/src/test/ChatPage.followUpToggle.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Rapid clicks on a follow-up option must toggle, not append twice.
+ *
+ * The handler's add/remove predicate used to read the picked-set from the render
+ * closure, so two clicks landing before a commit both took the append branch.
+ *
+ * These render the real ChatPage and click the real chip, so the shipped handler
+ * runs — a suite that re-implements the handler locally passes with the fix
+ * reverted. The starved-render window comes from advancing the chip's 220ms
+ * debounce for both clicks inside one act(), so React cannot commit between them.
+ * That precondition is asserted below, not assumed.
+ *
+ * Negative control: point the predicate back at `followUpPicked` and four of
+ * these fail with "Deploy, Deploy".
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
+import type { RootState } from '../store'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ThemeProvider } from '../hooks/useTheme'
+import chatReducer from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+
+/** The per-chip single-click debounce in FollowUpBar; one click = one onSelect. */
+const CHIP_DEBOUNCE_MS = 220
+
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: ({ data, itemContent }: { data?: unknown[]; itemContent: (index: number, item: unknown) => ReactNode }) => (
+    <div data-testid="virtuoso">{data?.map((d: unknown, i: number) => <div key={i}>{itemContent(i, d)}</div>)}</div>
+  ),
+}))
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([{ key: 'chat-1', messages: 1, running: false, mode: '', project: '/repo' }]),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0 }),
+    sendChat: vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true }) }),
+    chatHistory: vi.fn().mockResolvedValue({ sessions: [] }),
+    models: vi.fn().mockResolvedValue([]),
+    agents: vi.fn().mockResolvedValue([]),
+    agentDetail: vi.fn().mockResolvedValue({}),
+    workspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    slackChannels: vi.fn().mockResolvedValue([]),
+    spawnList: vi.fn().mockResolvedValue({ agents: [] }),
+    uploadFiles: vi.fn().mockResolvedValue({ paths: [] }),
+    screenshot: vi.fn().mockResolvedValue({ path: null }),
+    setSlotColor: vi.fn().mockResolvedValue({ ok: true }),
+    setSlotFolder: vi.fn().mockResolvedValue({ ok: true }),
+    dashboardConfig: vi.fn().mockResolvedValue({ quick_send: false }),
+  },
+  SEARCH_MIN_CHARS: 2,
+}))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: 'default' }) }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: ({ content }: { content: string }) => <span>{content}</span> }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../components/DetailPanel', () => ({ default: () => null }))
+vi.mock('../hooks/useWebSocket', () => ({ useWebSocket: () => ({ subscribeLogs: () => {} }) }))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+})
+
+import ChatPage from '../pages/ChatPage'
+import { api } from '../api/client'
+
+/** The marker has to close its own line for OPTION_MARKER_RE to match. */
+const ASSISTANT_WITH_OPTIONS = 'Ready to proceed.\n\n[OPTIONS: Deploy | Roll back | Retry]'
+
+function makeStore() {
+  return configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+    preloadedState: {
+      dashboard: {
+        status: null, connected: true,
+        slots: [{ key: 'chat-1', messages: 1, running: false, mode: '', project: '/repo', pending_approval: false, waiting_for_input: false, last_activity_ts: undefined }],
+        unreadSlots: [], refreshTrigger: 0, approvalMode: 'normal',
+        subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      } as unknown as RootState['dashboard'],
+      chat: {
+        activeSlot: 'chat-1', messages: [{ role: 'assistant', content: ASSISTANT_WITH_OPTIONS, cls: '' }],
+        slotRunning: false, slotStopping: false, slotState: 'idle',
+        history: [], historyHasMore: false, pendingInput: null,
+        subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools',
+        slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+        slotStatusDetail: {}, slotContextPct: {}, slotActivity: {}, slotHistory: [],
+        historyOffset: 0, _wsChunkedDuringFetch: false,
+        slotMessages: {}, slotLoading: false,
+        followups: {},
+      } as unknown as RootState['chat'],
+      notifications: { items: [] } as unknown as RootState['notifications'],
+    },
+  })
+}
+
+/** Render with real timers so the queries settle, then hand back to the caller. */
+async function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  await act(async () => {
+    render(
+      <QueryClientProvider client={qc}>
+        <Provider store={makeStore()}>
+          <ThemeProvider>
+            <MemoryRouter><ChatPage /></MemoryRouter>
+          </ThemeProvider>
+        </Provider>
+      </QueryClientProvider>,
+    )
+  })
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Deploy' })).toBeTruthy())
+}
+
+const composer = () => screen.getByLabelText('Message input') as HTMLTextAreaElement
+/** Exact-name match: the send-now segment is a sibling button named "Send now: <option>". */
+const chip = (option: string) => screen.getByRole('button', { name: option })
+
+beforeEach(() => {
+  sessionStorage.clear()
+  localStorage.clear()
+  vi.clearAllMocks()
+  ;(api.dashboardConfig as ReturnType<typeof vi.fn>).mockResolvedValue({ quick_send: false })
+})
+afterEach(() => { vi.useRealTimers() })
+
+/** Fire one debounced chip click and let its onSelect run, without committing. */
+function clickOption(option: string, opts: { shiftKey?: boolean } = {}) {
+  fireEvent.click(chip(option), opts)
+  vi.advanceTimersByTime(CHIP_DEBOUNCE_MS + 10)
+}
+
+describe('ChatPage follow-up option toggle', () => {
+  it('appends the option text on a single click', async () => {
+    await renderPage()
+    vi.useFakeTimers()
+    await act(async () => { clickOption('Deploy') })
+    expect(composer().value).toBe('Deploy')
+  })
+
+  it('toggles off when the second click lands before React commits the first', async () => {
+    // The reported defect: this appended "Deploy, Deploy" because the add/remove
+    // predicate re-read the same uncommitted render state on both clicks.
+    await renderPage()
+    vi.useFakeTimers()
+    await act(async () => {
+      clickOption('Deploy')
+      clickOption('Deploy')
+    })
+    expect(composer().value).toBe('')
+  })
+
+  it('does not commit between those two clicks (control for the case above)', async () => {
+    // Without this, the case above would also pass on the unfixed handler if a
+    // render happened to land between the clicks — the very thing that hid the bug.
+    await renderPage()
+    vi.useFakeTimers()
+    let betweenClicks = 'unobserved'
+    await act(async () => {
+      clickOption('Deploy')
+      betweenClicks = composer().value
+      clickOption('Deploy')
+    })
+    // The single-click case proves a committed first click reads "Deploy", so an
+    // empty value here can only mean no commit had landed when click two ran.
+    expect(betweenClicks).toBe('')
+    expect(composer().value).toBe('')
+  })
+
+  it('still toggles off when a render does land between the clicks', async () => {
+    await renderPage()
+    vi.useFakeTimers()
+    await act(async () => { clickOption('Deploy') })
+    expect(composer().value).toBe('Deploy')
+    await act(async () => { clickOption('Deploy') })
+    expect(composer().value).toBe('')
+  })
+
+  it('accumulates distinct options clicked in one uncommitted window', async () => {
+    await renderPage()
+    vi.useFakeTimers()
+    await act(async () => {
+      clickOption('Deploy')
+      clickOption('Roll back')
+      clickOption('Retry')
+    })
+    expect(composer().value).toBe('Deploy, Roll back, Retry')
+  })
+
+  it('removes a middle option without corrupting its neighbours', async () => {
+    // Exercises the production splice, which tries the leading ", opt" before the
+    // trailing "opt, " so a repeated label cannot splice the wrong occurrence.
+    await renderPage()
+    vi.useFakeTimers()
+    await act(async () => {
+      clickOption('Deploy')
+      clickOption('Roll back')
+      clickOption('Retry')
+    })
+    await act(async () => { clickOption('Roll back') })
+    expect(composer().value).toBe('Deploy, Retry')
+  })
+
+  it('re-adds the option on a third click', async () => {
+    await renderPage()
+    vi.useFakeTimers()
+    await act(async () => {
+      clickOption('Deploy')
+      clickOption('Deploy')
+      clickOption('Deploy')
+    })
+    expect(composer().value).toBe('Deploy')
+  })
+
+  it('does not quick-send a second option while a selection is already open', async () => {
+    // The one-click send path read the same stale set to decide "already in
+    // multi-select", so it sent instead of extending the uncommitted selection.
+    ;(api.dashboardConfig as ReturnType<typeof vi.fn>).mockResolvedValue({ quick_send: true })
+    await renderPage()
+    vi.useFakeTimers()
+    await act(async () => {
+      clickOption('Deploy', { shiftKey: true })
+      clickOption('Roll back')
+    })
+    expect(api.sendChat).not.toHaveBeenCalled()
+    expect(composer().value).toBe('Deploy, Roll back')
+  })
+})


### PR DESCRIPTION
## What's wrong

Clicking the same follow-up option twice in quick succession inserts its text a second time instead of removing it.

Both state updates in the option handler were already written as functional updaters, but the branch that *chooses* between add and remove read the picked-set straight from the render closure:

```ts
if (followUpPicked.has(o)) { /* remove */ } else { /* append */ }
```

Two clicks arriving before a re-render therefore see the same value, and both take the append branch.

## Main-thread lag exposed this, it did not cause it

This is worth stating plainly because it is easy to file as a perf symptom and close. The toggle was only ever correct when a re-render *happened* to land between the two clicks. That is a race the code never actually won on purpose — it just usually got away with it, because a commit normally lands in the gap between two human clicks. When the main thread is busy the commit slides past the second click and the latent defect becomes visible every time. Making rendering faster would hide it again; it would not fix it.

## The fix

The predicate now reads a ref updated synchronously in the handler, so a click observes the previous one regardless of when React re-renders. The next set is computed once per click and used for **both** the ref and the state, so the two cannot disagree.

The one-click send path read the same stale value to decide "is a multi-select already in progress", so it needed the ref too — otherwise a second option clicked inside the same uncommitted window would quick-send instead of extending the selection.

### Why the functional updaters were replaced rather than kept alongside the ref

`setFollowUpPicked(prev => ...)` was doing no work here once the set is computed from the ref: the ref is the freshest value by construction, so `prev` and `followUpPickedRef.current` can only differ if some *other* writer has queued an update. The only other writer is the reset effect keyed on the options list and the active slot, which sets an empty set on a new turn — it does not merge, so a functional updater would not preserve anything against it. Keeping both forms would mean the ref and the state could disagree about what "next" is, which is the failure mode this change exists to remove.

### Why the existing chip debounce does not already cover it

`FollowUpBar`'s chip debounces a single click by ~220ms and bails on `e.detail >= 2`. That collapses two *same-chip* clicks landing inside 220ms into one `onSelect`. The failure mode here is two `onSelect` calls more than 220ms apart with React starved, so the debounce never sees them as one event. The chip layer is unchanged by this PR.

## Tests

New: `website/src/test/ChatPage.followUpToggle.test.tsx` — 8 cases.

This is net-new coverage of this branch. Before it, the only test file touching `onFollowUpSelect` was `ChatInput.test.tsx`, whose two follow-up cases assert that the quick-send title renders and that `onFollowUpSelect` fires once; `FollowUpBar.test.tsx` covers the chip layer (`detail >= 2`, `mousedown` preventDefault). Neither exercises the handler's add/remove branch.

The tests render the real `ChatPage` and click the real chip, so the shipped handler executes. The starved-render window is reproduced by advancing the chip's debounce for both clicks inside one `act()`, so React cannot commit in between — the production shape, without needing a genuinely busy main thread.

The precondition is asserted rather than assumed: one case observes the composer *between* the two clicks and asserts it is still empty, which combined with the single-click case (a committed click reads `Deploy`) proves the second click really did run pre-commit. Without that, the toggle assertions could pass for the unrelated reason that a render landed in between after all — which is exactly what used to hide the bug.

**Negative control.** Reverting the predicate to read `followUpPicked` instead of the ref fails 4 of the 8 cases:

| case | failure against the unfixed handler |
| --- | --- |
| second click before the first commits | `expected 'Deploy, Deploy' to be ''` |
| no commit between the two clicks | `expected 'Deploy, Deploy' to be ''` |
| third click re-adds | `expected 'Deploy, Deploy, Deploy' to be 'Deploy'` |
| no quick-send while a selection is open | `sendChat` called once, expected not at all |

The other 4 pass against the unfixed handler, which is the correct shape: they cover the paths that always worked — a single click, a render landing between clicks, distinct options in one window, and removing a middle option.

That last one also exercises the production removal path, which splices via ordered `indexOf` (trying the leading `", opt"` before the trailing `"opt, "`) so a repeated label cannot splice the wrong occurrence.

## Verification

- `ChatPage.followUpToggle` + `ChatInput` + `FollowUpBar` + `ChatPageFollowup`: 175 passed.
- Full website suite: see the note below on three unrelated failures.
- `npx eslint` on both changed files: 0 errors. The warnings it reports are pre-existing and at unrelated lines.
- Typecheck: `tsc -b` passes. Note that `tsc --noEmit` is vacuous in this project — the root `tsconfig.json` is `{"files": [], "references": [...]}`, so it typechecks 0 files; build mode is what honours the reference. I confirmed `tsc -b` genuinely covers the changed production file by injecting a deliberate type error and watching it fail, then removing it. Test files are excluded from `tsconfig.app.json`, so the new test file is type-stripped by vitest rather than typechecked — that is the existing project setup, not something this PR changes.

## Visual evidence

**Correction, added after merge.** This section previously claimed that a capture cannot distinguish this fix from the unfixed code. That claim is wrong as stated, and I measured it rather than reasoning about it: the defect *is* reproducible in a real browser. Driving the real chip in Chromium with two clicks on the same option 230 ms apart — longer than the chip's 220 ms debounce, so each click is its own `onSelect` — and the main thread at 200x CPU throttle so React cannot commit between them, the unfixed handler leaves the composer at `"Deploy, Deploy"` while the fixed handler leaves it empty. In both runs the composer reads `""` *between* the two clicks, which is what establishes that the first click had not been committed when the second landed rather than assuming it.

The narrower claim that was true is this: a capture at **ordinary click speed** does not discriminate, because a commit lands between the clicks and the old code already behaves correctly. That is the same reason 4 of the 8 new cases pass against the unfixed handler. The throttle is what opens the window, and I should have said so instead of generalising to all captures.

Two honest caveats on that reproduction. It is a race, so the window does not open on every attempt: when the debounce timer is itself delayed past the gap, the second click cancels the first pending timer, only one `onSelect` fires, and the attempt is uninformative rather than passing — attempts have to be repeated until the window opens, selecting on the window opening and never on the outcome. And blocking the main thread does *not* work as a starvation method, because it blocks the debounce timer too and collapses the two clicks into a single selection; CPU throttling is what leaves timers on wall clock while slowing the commit past the gap.

The negative control in the test remains the primary evidence, and it is the part that runs in CI. Reverting the predicate to read the render-closure value instead of the ref fails 4 of the 8 cases:

| case | failure against the unfixed handler |
| --- | --- |
| second click before the first commits | `expected 'Deploy, Deploy' to be ''` |
| no commit between the two clicks | `expected 'Deploy, Deploy' to be ''` |
| third click re-adds | `expected 'Deploy, Deploy, Deploy' to be 'Deploy'` |
| no quick-send while a selection is open | `sendChat` called once, expected not at all |

There is no layout, theme, spacing, or component-appearance delta: no element is added, removed, resized, or restyled. What changed is *when* the text splice runs, which is why the evidence has to be an interaction rather than a still of a surface at rest.

No image is embedded above. The capture was committed locally under `temp-screenshots/followup-toggle/`, but the merge landed before it was pushed, so a raw URL would 404 — rather than link something broken, this section is text-only.
