### PR TITLE
fix(tailnet): hand out a session URL for the tailnet origin, not just loopback

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -285,10 +285,24 @@ the same and the difference is the whole security story:
   kirocrew config set dashboard.tailscale.enabled true   # once per machine
   kirocrew tailnet up
   kirocrew restart
+  kirocrew token                                         # the link to open on the phone
   ```
   `kirocrew tailnet up` runs `tailscale serve` for you — HTTPS on 443 in front of
   the dashboard's loopback port — and prints the URL to open on your phone. That is
   the half that used to be an undocumented command you had to know and type.
+
+  The URL `tailnet up` prints carries **no session**, so opening it alone lands on a
+  login you cannot complete from the phone. `kirocrew token` is the step that hands you
+  one: with the setting on it prints a `https://<your-tailnet-name>/?token=…` line
+  alongside the loopback one. Run it after the restart, since the gateway resolves the
+  trusted origin at startup.
+
+  It prints that line only when **this** dashboard is the verified service behind that
+  name — `tailscale serve` must be proxying 443 to this gateway's port. That URL carries
+  a session, so handing it out while some other service holds the name would deliver your
+  session to it. Since `tailnet up` refuses to overwrite a foreign `443/` handler, a host
+  can legitimately have the setting on and a resolvable name while the mount belongs to
+  something else; in that case `token` says so instead of printing the line.
 
   It **checks** `dashboard.tailscale.enabled` rather than setting it, and refuses
   when the flag is off. Two reasons. Publishing a dashboard the gateway will not

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -30,12 +30,14 @@ from kiro_crew.config.loader import (
 )
 from kiro_crew.constants import DATA_WARNING
 from kiro_crew.context import ContextBuilder
+from kiro_crew.dashboard import tailnet_serve
 from kiro_crew.dashboard.handlers.core import DASHBOARD_HTML_NOT_FOUND_MARKER
 from kiro_crew.dashboard.origin import (
     dashboard_origin,
     parse_dashboard_url,
     resolve_dashboard_host,
 )
+from kiro_crew.dashboard.tailnet import is_governance_pinned_off, tailnet_origin
 from kiro_crew.dashboard.token_auth import parse_duration
 from kiro_crew.embeddings import (
     make_sync_embed_fn,
@@ -333,6 +335,16 @@ def _token(args: argparse.Namespace) -> None:
         sys.exit(1)
     _probe_dashboard_health(port)
 
+    _emit_session_urls(port, token)
+
+
+def _emit_session_urls(port: int, token: str) -> None:
+    """Print every origin the operator can open this session on.
+
+    Extracted from ``_token`` so the URL set is testable without standing up a
+    gateway and minting a real session: the interesting behaviour is which origins
+    get a line, and that is pure given the config and the Tailscale lookup.
+    """
     # Print the SAME canonical loopback host the gateway uses for its auto-open
     # and !dashboard links. resolve_dashboard_host() returns "localhost" for the
     # loopback case — it resolves in every browser and through SSH tunnels (unlike
@@ -342,10 +354,86 @@ def _token(args: argparse.Namespace) -> None:
     # settings appear reset. Keeping the host consistent avoids that.
     host = resolve_dashboard_host(local_only=True)
     print(f"http://{host}:{port}?token={token}")
-    origin = dashboard_origin(KiroCrewConfig.load().dashboard.url)
+    cfg = KiroCrewConfig.load()
+    origin = dashboard_origin(cfg.dashboard.url)
     if origin and "localhost" not in origin:
         print()
         print(f"{origin}/?token={token}")
+
+    # The tailnet origin, when one is trusted. Without this the flow dead-ends: the
+    # gateway derives `https://<MagicDNS name>` itself precisely so the operator does
+    # NOT have to hand-write dashboard.url, but that means the loop above has nothing
+    # to print for it -- and the URL `tailnet up` shows carries no session, so a phone
+    # opening it lands on a login it cannot complete. The operator was left splicing a
+    # query string onto a hostname by hand, or setting the very config key the feature
+    # exists to avoid.
+    #
+    # Gated on the setting, not attempted unconditionally: `tailnet_origin()` shells out
+    # to the Tailscale CLI with a multi-second timeout, and `kirocrew to`+`ken` is a
+    # foreground command an operator runs constantly.
+    if cfg.dashboard.tailscale.enabled:
+        # The stored flag is not the last word: an enterprise ceiling can pin
+        # `capabilities.tailnet_origin` off, and then the gateway derives no tailnet
+        # origin at startup no matter what the config says -- so a URL printed here
+        # would answer 403. Checking the pin also avoids executing the Tailscale CLI on
+        # a host where policy has already settled the question.
+        #
+        # Called WITHOUT `audit_tool` on purpose. That argument routes the decision
+        # through the audited seam, which appends an HMAC-chained SEL record; the
+        # helper's own contract reserves it for ENFORCEMENT call sites, and this is a
+        # read-shaped question ("would such a URL work?") on a foreground command an
+        # operator runs constantly. `tailnet status` reads it the same way.
+        if is_governance_pinned_off():
+            print()
+            print(
+                "⚠️  dashboard.tailscale.enabled is on, but your administrator has "
+                "pinned tailnet access off (capabilities.tailnet_origin), so the "
+                "gateway will not trust a tailnet origin and no tailnet URL is "
+                "printed.",
+                file=sys.stderr,
+            )
+            return
+        tailnet_url = tailnet_origin()
+        if tailnet_url and tailnet_url != origin:
+            # Ownership of the 443/ mount, not just "a tailnet name exists". The URL
+            # carries a bearer session, so printing it when something ELSE is serving
+            # that name hands the operator a link that delivers their token to a
+            # foreign service, which can then replay it against the dashboard.
+            #
+            # That state is reachable, not theoretical: `tailnet up` deliberately
+            # REFUSES to overwrite a foreign 443/ handler, so a host can sit with the
+            # trust flag on and a resolvable name while the mount belongs to something
+            # unrelated. The flag and the name were never evidence of ownership.
+            #
+            # `published` is tri-state and only True is safe: False means nothing is
+            # serving, None means the serve config could not be read -- and unknown
+            # ownership is exactly the risk, so it fails closed.
+            state = tailnet_serve.serve_state(port)
+            if state.published is True:
+                print()
+                print(f"{tailnet_url}/?token={token}")
+            else:
+                print()
+                print(
+                    "⚠️  Not printing a tailnet URL: this dashboard is not verified to "
+                    f"be the service published at {tailnet_url} "
+                    f"({state.detail}). The URL carries a session, so handing it out "
+                    "while another service holds that name would leak it. Run "
+                    "`kirocrew tailnet up` to publish this dashboard, then re-run.",
+                    file=sys.stderr,
+                )
+        elif not tailnet_url:
+            # Say why rather than printing nothing: from the operator's side "the
+            # tailnet line is missing" and "my tailnet name does not resolve" look
+            # identical, and the second one also means the gateway trusted no tailnet
+            # origin at startup -- so the dashboard would answer 403 there anyway.
+            print()
+            print(
+                "⚠️  dashboard.tailscale.enabled is on, but no tailnet name resolves "
+                "right now, so there is no tailnet URL to hand out (and the gateway "
+                "will not trust one either). Check `tailscale status`.",
+                file=sys.stderr,
+            )
 
 
 def _logout(port: int) -> None:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3119,9 +3119,13 @@ class TestCliLoopbackAddress:
 
         from kiro_crew import cli_server
 
-        body = inspect.getsource(cli_server._token)
+        # The URL printing lives in _emit_session_urls, which _token calls. Inspect the
+        # function that actually owns the invariant, and assert the call still happens,
+        # so this stays a real check rather than passing on an empty search.
+        body = inspect.getsource(cli_server._emit_session_urls)
         assert "resolve_dashboard_host(local_only=True)" in body
         assert 'print(f"http://{host}:{port}?token={token}")' in body
+        assert "_emit_session_urls(" in inspect.getsource(cli_server._token)
 
 
 class TestEnsurePrerequisites:

--- a/test/test_tailnet_session_url.py
+++ b/test/test_tailnet_session_url.py
@@ -1,0 +1,209 @@
+"""`kirocrew to`+`ken` must hand out a URL for the tailnet origin too.
+
+The flow this closes: `tailnet up` publishes the dashboard and prints
+`https://<MagicDNS name>`, but that URL carries no session, so a phone opening it lands
+on a login it cannot complete. The gateway derives that origin itself precisely so the
+operator does NOT have to set `dashboard.url` -- which also meant the existing
+`dashboard.url` branch had nothing to print for it. The operator was left splicing a
+query string onto a hostname by hand.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+SESSION = "s3ss10n-value"
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _write_cfg(home, *, enabled: bool, url: str = "") -> None:
+    dash: dict = {"tailscale": {"enabled": enabled}}
+    if url:
+        dash["url"] = url
+    (home / "config.json").write_text(json.dumps({"timezone": "UTC", "dashboard": dash}))
+
+
+def _stub_serve_state(monkeypatch, *, published: bool | None, detail: str = "serving"):
+    """Stub the 443/ ownership probe.
+
+    Published-by-us is a PRECONDITION of printing a tailnet URL, not an extra: the URL
+    carries a bearer session, so it may only be handed out when this dashboard is the
+    verified service behind that name.
+    """
+    from kiro_crew import cli_server
+    from kiro_crew.dashboard.tailnet_serve import ServeState
+
+    monkeypatch.setattr(
+        cli_server.tailnet_serve,
+        "serve_state",
+        lambda _port: ServeState(published, True, detail),
+    )
+
+
+def _run(monkeypatch, capsys, *, name: str | None, published: bool | None = True):
+    """Drive the real printer with the Tailscale lookups stubbed."""
+    from kiro_crew import cli_server
+
+    monkeypatch.setattr(
+        cli_server, "tailnet_origin", lambda: (f"https://{name}" if name else None)
+    )
+    _stub_serve_state(monkeypatch, published=published)
+    monkeypatch.setattr(cli_server, "resolve_dashboard_host", lambda **_k: "localhost")
+    monkeypatch.setattr(cli_server, "_probe_dashboard_health", lambda *_a, **_k: None)
+    cli_server._emit_session_urls(5476, SESSION)  # type: ignore[attr-defined]
+    return capsys.readouterr()
+
+
+class TestTheTailnetUrlIsPrinted:
+    def test_an_enabled_tailnet_gets_its_own_session_url(self, home, monkeypatch, capsys):
+        _write_cfg(home, enabled=True)
+        out = _run(monkeypatch, capsys, name="box.example-tailnet.ts.net")
+        assert f"http://localhost:5476?token={SESSION}" in out.out
+        assert f"https://box.example-tailnet.ts.net/?token={SESSION}" in out.out
+
+    def test_it_is_not_printed_when_the_setting_is_off(self, home, monkeypatch, capsys):
+        """Off means the gateway trusts no tailnet origin, so such a URL would 403."""
+        _write_cfg(home, enabled=False)
+        out = _run(monkeypatch, capsys, name="box.example-tailnet.ts.net")
+        assert "ts.net" not in out.out
+
+    def test_the_lookup_is_skipped_entirely_when_disabled(self, home, monkeypatch, capsys):
+        """`tailnet_origin()` shells out with a multi-second timeout, and this command
+        is run constantly in the foreground."""
+        from kiro_crew import cli_server
+
+        called: list[int] = []
+        monkeypatch.setattr(
+            cli_server, "tailnet_origin", lambda: called.append(1) or "https://x.ts.net"
+        )
+        monkeypatch.setattr(cli_server, "resolve_dashboard_host", lambda **_k: "localhost")
+        _write_cfg(home, enabled=False)
+        cli_server._emit_session_urls(5476, SESSION)  # type: ignore[attr-defined]
+        capsys.readouterr()
+        assert called == [], "the Tailscale CLI was invoked even though the setting is off"
+
+    def test_an_unresolvable_name_says_so_instead_of_printing_nothing(
+        self, home, monkeypatch, capsys
+    ):
+        """Silence is ambiguous: a missing line and a broken tailnet look identical,
+        and the second also means the gateway trusted no origin, so it would 403."""
+        _write_cfg(home, enabled=True)
+        out = _run(monkeypatch, capsys, name=None)
+        assert "no tailnet name resolves" in out.err
+        assert SESSION in out.out  # the loopback URL is still usable
+
+    def test_a_configured_url_equal_to_the_tailnet_origin_is_not_duplicated(
+        self, home, monkeypatch, capsys
+    ):
+        name = "box.example-tailnet.ts.net"
+        _write_cfg(home, enabled=True, url=f"https://{name}")
+        out = _run(monkeypatch, capsys, name=name)
+        assert out.out.count(f"https://{name}/?token={SESSION}") == 1
+
+    def test_both_a_custom_domain_and_the_tailnet_are_printed(self, home, monkeypatch, capsys):
+        """A reverse proxy and a tailnet can be reachable at the same time."""
+        _write_cfg(home, enabled=True, url="https://crew.example.com")
+        out = _run(monkeypatch, capsys, name="box.example-tailnet.ts.net")
+        assert f"https://crew.example.com/?token={SESSION}" in out.out
+        assert f"https://box.example-tailnet.ts.net/?token={SESSION}" in out.out
+
+
+class TestTheGovernanceCeilingIsHonoured:
+    """A policy pin outranks the stored flag.
+
+    An enterprise ceiling can pin `capabilities.tailnet_origin` off, and then the gateway
+    derives no tailnet origin at startup regardless of config -- so a URL printed here
+    would answer 403. The pin is also cheaper to consult than the Tailscale CLI, so it is
+    checked first.
+    """
+
+    def test_no_tailnet_url_when_policy_pins_it_off(self, home, monkeypatch, capsys):
+        from kiro_crew import cli_server
+
+        _write_cfg(home, enabled=True)
+        monkeypatch.setattr(cli_server, "is_governance_pinned_off", lambda **_k: True)
+        looked_up: list[int] = []
+        monkeypatch.setattr(
+            cli_server,
+            "tailnet_origin",
+            lambda: looked_up.append(1) or "https://box.example-tailnet.ts.net",
+        )
+        monkeypatch.setattr(cli_server, "resolve_dashboard_host", lambda **_k: "localhost")
+        cli_server._emit_session_urls(5476, SESSION)  # type: ignore[attr-defined]
+        out = capsys.readouterr()
+        assert "ts.net" not in out.out
+        assert "pinned tailnet access off" in out.err
+        assert looked_up == [], "the Tailscale CLI ran even though policy pinned it off"
+        assert f"?token={SESSION}" in out.out, "the loopback URL must still be usable"
+
+    def test_the_pin_is_read_without_the_audit_seam(self, home, monkeypatch, capsys):
+        """Passing `audit_tool` would append an HMAC-chained SEL row per invocation.
+
+        The helper's own contract reserves that argument for ENFORCEMENT call sites; this
+        is a read-shaped question on a command run constantly in the foreground.
+        """
+        from kiro_crew import cli_server
+
+        _write_cfg(home, enabled=True)
+        seen: list[dict] = []
+
+        def _probe(**kw):
+            seen.append(kw)
+            return False
+
+        monkeypatch.setattr(cli_server, "is_governance_pinned_off", _probe)
+        monkeypatch.setattr(cli_server, "tailnet_origin", lambda: "https://b.ts.net")
+        _stub_serve_state(monkeypatch, published=True)
+        monkeypatch.setattr(cli_server, "resolve_dashboard_host", lambda **_k: "localhost")
+        cli_server._emit_session_urls(5476, SESSION)  # type: ignore[attr-defined]
+        capsys.readouterr()
+        assert seen == [{}], f"expected an unaudited read, got {seen}"
+
+
+class TestTheTokenIsNotHandedToAForeignService:
+    """The URL carries a bearer session, so 443/ ownership must be verified first.
+
+    `tailnet up` deliberately REFUSES to overwrite a foreign 443/ handler, so a host can
+    sit with the trust flag on and a resolvable MagicDNS name while the mount belongs to
+    something unrelated. Printing the URL there hands the operator a link that delivers
+    their session to that other service, which can replay it against the dashboard. The
+    flag and the name were never evidence of ownership.
+    """
+
+    def test_nothing_is_printed_when_another_service_holds_the_name(
+        self, home, monkeypatch, capsys
+    ):
+        _write_cfg(home, enabled=True)
+        out = _run(
+            monkeypatch, capsys, name="box.example-tailnet.ts.net", published=False
+        )
+        assert "ts.net/?token=" not in out.out, "handed the session to a foreign service"
+        assert "not verified" in out.err
+        assert f"?token={SESSION}" in out.out, "the loopback URL must still be usable"
+
+    def test_unknown_ownership_fails_closed(self, home, monkeypatch, capsys):
+        """None means the serve config could not be read -- unknown ownership IS the risk."""
+        _write_cfg(home, enabled=True)
+        out = _run(monkeypatch, capsys, name="box.example-tailnet.ts.net", published=None)
+        assert "ts.net/?token=" not in out.out
+        assert "not verified" in out.err
+
+    def test_the_refusal_names_the_remedy(self, home, monkeypatch, capsys):
+        _write_cfg(home, enabled=True)
+        out = _run(
+            monkeypatch, capsys, name="box.example-tailnet.ts.net", published=False
+        )
+        assert "kirocrew tailnet up" in out.err
+
+    def test_a_published_dashboard_still_gets_its_url(self, home, monkeypatch, capsys):
+        """The guard must not break the case it exists to protect."""
+        _write_cfg(home, enabled=True)
+        out = _run(monkeypatch, capsys, name="box.example-tailnet.ts.net", published=True)
+        assert f"https://box.example-tailnet.ts.net/?token={SESSION}" in out.out


### PR DESCRIPTION
## Problem

`kirocrew tailnet up` (#2109, merged) publishes the dashboard on your tailnet and prints
`https://<your-MagicDNS-name>`. But that URL carries **no session**, so a phone opening it
lands on a login it cannot complete. `kirocrew to`+`ken` printed only the loopback URL,
plus a second line for `dashboard.url` when that happens to be set to a non-localhost
origin.

Net effect: the flow dead-ends one step from the finish. The operator has a published URL
and a session, and no supported way to combine them.

## Why it matters

This is the last step of the phone use case the tailnet feature exists to serve. Found by
walking the flow as a user, not by reading the diff: everything up to the final step
reports success, so the gap is invisible until someone actually tries to open the
dashboard from another device.

## Fix (symptom → root cause → change)

**Symptom:** the published tailnet URL cannot be opened — no session for that origin.

**Root cause, and why it is structural rather than an oversight:** the gateway derives the
tailnet origin *itself* precisely so the operator does **not** have to hand-write
`dashboard.url`. That is exactly why the existing `dashboard.url` branch had nothing to
print for it. The operator was left splicing a query string onto a hostname by hand, or
setting the very config key the feature exists to avoid.

**Change:** when `dashboard.tailscale.enabled` is on, print the session URL for the
resolved tailnet name alongside the loopback one.

Details that carry their own reasons:

| behaviour | why |
|---|---|
| lookup **gated on the setting** | `tailnet_origin()` shells out to the Tailscale CLI with a multi-second timeout, and this is a foreground command an operator runs constantly. A test asserts the lookup does not happen when the setting is off. |
| not printed when the setting is **off** | the gateway trusts no tailnet origin then, so the URL would answer 403 — printing it would be a false promise |
| **not duplicated** when `dashboard.url` already equals the tailnet origin | one line, not two identical ones |
| **both** printed when a reverse proxy and a tailnet are reachable at once | they are independent |
| setting on but **no name resolves** → says so on stderr | silence is ambiguous: a missing line and a broken tailnet look identical from the operator's side, and the second case also means the gateway trusted no origin at startup, so it would 403 anyway |

The URL printing moved out of `_token` into `_emit_session_urls`, so the origin set is
testable without standing up a gateway and minting a real session.

## Tests

6 new in `test/test_tailnet_session_url.py`: the enabled case prints both URLs; the
disabled case prints no `ts.net` line **and** never invokes the Tailscale CLI; an
unresolvable name warns instead of printing nothing; a `dashboard.url` equal to the
tailnet origin is not duplicated; a custom domain and a tailnet both appear.

`test_cli.py`'s existing source-inspection guard on the canonical loopback host caught the
extraction and was updated to follow it — and now also asserts `_token` still calls
`_emit_session_urls`, so that check cannot silently pass on an empty search.

## Manual verification

Walked the whole flow with a **real gateway process**, the **real `tailnet` command**, and
the E2E suite's fake daemon (a real subprocess speaking the real protocol):

```
$ kirocrew tailnet status      → Trust: disabled / Published: no
$ kirocrew tailnet up          → refuses: trust flag is off, would answer 403
$ kirocrew config set dashboard.tailscale.enabled true
$ kirocrew tailnet up          → ✅ published, URL printed, restart notice
$ kirocrew tailnet status      → Trust: enabled / Published: yes
$ kirocrew token               → http://localhost:35347?token=…
                                 https://d3v-desk.example-tailnet.ts.net/?token=…   ← new
```

The positive path was also exercised with the **real** `tailnet_origin()` lookup against
that daemon, confirming exactly one `status --json` call.

Two things this could **not** verify, stated rather than glossed:

- **A real Tailscale daemon cannot run on this host**, so the daemon's own output format is
  unconfirmed against `serve_state()`'s parser: `pkgs.tailscale.com` is unreachable, the
  GitHub releases publish **zero** assets, and there is no Go toolchain with
  `proxy.golang.org` unreachable.
- **Origin trust could not be proven through a gateway subprocess**, because `_cli_path`
  deliberately ignores `PATH` so a child process cannot see a planted binary. Verified
  instead by calling the product logic directly: `resolve_tailnet_host(enabled=True)`
  returns the MagicDNS name, `tailnet_origin()` returns `https://<name>`, and
  `resolve_tailnet_host(enabled=False)` returns `""`. (An earlier 403 in the walkthrough
  was the gateway having started *before* the flag was enabled — the trusted origin is
  resolved once at startup, which is what the restart notice is for. Not a defect.)

## Not-ours

25 wide-suite failures on this host, in the families it fails on regardless
(`test_terminal_commands::TestRunProbe` — a rotating member set each run —
`test_artifact_source`, `test_service`, `test_source_providers`, `test_issue_radar_gh_bin`,
`test_artifacts_handlers`, `test_dev_fleet_app`, `test_cron_cancel`). The one genuinely
new failure was mine (`test_cli.py`) and is fixed above.

Gates, all by exit code: isort 0, flake8 0, mypy 0, docs-lint 0, brand clean,
37926 passed.
