### PR TITLE
chore(version): bump dev base to 0.3.0, unbreak two frontend tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.2.0"
+version = "0.3.0"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, desktop app, or messaging channels like Slack and Discord"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 
 class _LazyShutdownEvent:

--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kirocrew-electron-mac",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kirocrew-electron-mac",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "electron-store": "^8.2.0",
         "electron-updater": "^6.8.9"

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-electron-mac",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "main": "main.js",
   "scripts": {

--- a/website/src/test/UseMeetingSessionCoverage.test.tsx
+++ b/website/src/test/UseMeetingSessionCoverage.test.tsx
@@ -147,12 +147,27 @@ beforeEach(() => {
   apiMocks.meeting.mockResolvedValue({ meta: meta(), live: null })
   apiMocks.outputs.mockResolvedValue({ outputs: {}, tasks: [] })
   for (const key of [
-    'start', 'setStatus', 'stop', 'mute', 'toggleAgent', 'dispatch', 'message',
+    'start', 'setStatus', 'stop', 'mute', 'toggleAgent', 'message',
     'resetAgents', 'attachments', 'addTask', 'updateTask', 'deleteTask', 'fileTask',
     'reviewTask',
   ] as const) {
     apiMocks[key].mockResolvedValue({})
   }
+  // `dispatch` is deliberately absent from the list above: it is the one mutation
+  // whose response the hook READS, so it needs its real DispatchResponse shape
+  // rather than a bare {}. Broadcast's success path commits `response.segment`
+  // into the transcript cache, and a shapeless stub throws inside onSuccess,
+  // which react-query then reports as a failed broadcast.
+  apiMocks.dispatch.mockResolvedValue({
+    dispatched: 1,
+    text: 'please summarize',
+    segment: {
+      id: 'seg-1',
+      timestamp: '2026-01-01T00:00:00Z',
+      source: 'typed',
+      text: 'please summarize',
+    },
+  })
 })
 
 afterEach(() => {
@@ -483,6 +498,10 @@ describe('useMeetingSession lifecycle actions', () => {
       i18nT('apps.meetings.session.broadcastSent'),
       { type: 'info' },
     )
+    // Assert the commit directly. Without this, the success path is only pinned
+    // indirectly: a throw inside it would suppress the notify above, so the test
+    // would fail for the wrong stated reason instead of naming the real one.
+    expect(view.result.current.transcript.map(segment => segment.id)).toContain('seg-1')
   })
 
   it('messages one agent directly', async () => {

--- a/website/src/test/UseWebSocketCoverage.test.tsx
+++ b/website/src/test/UseWebSocketCoverage.test.tsx
@@ -471,6 +471,11 @@ describe('useWebSocket frame router', () => {
       ws.simulateMessage({ type: 'chat_message', data: { slot: ACTIVE, role: 'user', content: 'go', ts: '2024-01-01T00:00:00Z' } })
     })
     expect(chat().slotStatusDetail[ACTIVE]?.kind).toBe('thinking')
+    // The recency bump is buffered per slot and flushed once per animation frame,
+    // so it is not observable until a frame runs. This harness hands rAF a queue
+    // that nothing drains on its own — driving it is what makes the assertion read
+    // the flushed value rather than the pre-flush undefined.
+    act(() => { const pending = rafCbs; rafCbs = []; pending.forEach(cb => cb(0)) })
     expect(dash().slots[0].last_ts).toBe('2024-01-01T00:00:00Z')
   })
 


### PR DESCRIPTION
## Problem

`v0.2.0` was promoted to stable today (bare tag on the rc.8 commit
`1fad2cad3`), but the in-code base version on `main` is still `0.2.0`.

`nightly.yml` reads `__version__` from `src/kiro_crew/__init__.py` and derives
both release stamps from it. So tonight's nightly, cut from `main` at 06:00 UTC,
would stamp `0.2.0-nightly.<date>t<time>` (semver, for the Electron app and the
S3 build path) and `0.2.0.dev<stamp>` (PEP 440, for the wheel).

## Why it matters

Both of those sort **below** the `0.2.0` that just shipped, because SemVer
demotes a prerelease beneath its own release. A client tracking nightly would
be offered tonight's build as a **downgrade** from stable `0.2.0`, and
`allowDowngrade=true` in `website/electron/auto-update.js` means the updater
would present it rather than ignore it.

This is the same defect PR #1656 corrected after `v0.1.3` shipped against a
`0.1.2` base, and PR #687 corrected after `v0.1.1` shipped against `0.1.0`.

## Fix (symptom → root cause → change)

- **Symptom**: a nightly cut from `main` would advertise a version that sorts
  under released stable.
- **Root cause**: the in-code base is the *next* release's number, and it was
  never advanced when `0.2.0` stopped being "next" and became "shipped".
- **Change**: bump the base to `0.3.0` in all four manifests that carry it, so
  nightlies read as previews of the next minor and sort above `0.2.0`.

Kept as a bare `X.Y.Z` rather than `0.3.0.dev0`: `nightly.yml` needs a bare base
to build valid semver and PEP 440 strings from it, and CONTRIBUTING.md requires
it. A tagged release overrides all three manifests at build time, so this value
governs only **untagged** builds — nightly and local/source installs.

### Files

| File | Field | Why |
|---|---|---|
| `src/kiro_crew/__init__.py` | `__version__` | the source of truth |
| `pyproject.toml` | `[project] version` | what the wheel carries |
| `website/electron/package.json` | `version` | the updater's version compare |
| `website/electron/package-lock.json` | root + `""` entry | kept in lockstep, or `npm ci` fails on the mismatch |

CONTRIBUTING.md's table names the first three; the lock file is the fourth that
PR #1656 also updated. The third `0.2.0` in the lock file is the
`chromium-pickle-js` dependency pin and is deliberately untouched.

No tag is created by this change, and `CHANGELOG.md` is intentionally not
touched: a changelog section asserts a release, and this is not one. The newest
section stays `## [0.2.0] — 2026-08-09` for the version that actually shipped.

## Tests

No new tests. The behavior is already pinned by
`test/test_nightly_version_contract.py`, which asserts every property of the
derived nightly stamp, and `test/test_config_meta_stamp.py`, which compares
against `__version__` dynamically rather than a literal. No test hardcodes an
expected `0.2.0` from `__init__` (`test/test_kiro_crew.py` asserts truthiness
only), so nothing needed updating.

## Manual verification

- Derivation check: base `0.3.0` yields `0.3.0-nightly.20260811t060000` and
  `0.3.0.dev20260811060000`, both sorting above `0.2.0`.
- **Lock file validated by npm, not by hand**: `npm install --package-lock-only`
  in `website/electron` produced **no diff** against the edit, and a subsequent
  `npm ci` succeeded leaving the lock unchanged — npm writes exactly these two
  lines.
- Backend: 41,269 passed. The 49 failures are a pre-existing macOS host
  baseline: the same files on unmodified `origin/main` fail identically
  (47 in the same set), and the three that differed reproduce byte-identically
  on base when run outside the xdist shard.
- Frontend: 14,403 passed, `npm run build` clean. The suite is flaky on this
  host under load (three identical runs gave 0, 1, then 2 failures); the one
  named failure asserts a theme color and contains no version reference.
- isort, flake8, black clean. `mypy` reports 3 pre-existing errors in
  `src/kiro_crew/hooks.py` on `os.{list,get,set}xattr`, which do not exist on
  darwin — that file is untouched and CI runs Linux.

## Screenshots

N/A — no user-visible UI change. The only surface that reflects this value is
the Releases archive, which shows a `0.3.0` row for a source install; that is
inherent to the bare-`X.Y.Z` base CONTRIBUTING.md mandates and was equally true
after #1656 and #687.


---

## Also in this PR: two tests that fail on `main`

`Frontend Tests` and its downstream `Coverage Gate` were red on the first
revision of this PR, and **not because of the version bump**. I checked out
pristine `origin/main`, `__version__` still `0.2.0`, zero modifications, and both
tests failed there identically. Bisected to two independent semantic merge races,
where each side was green when tested and only the combination breaks:

| Broken test | Broken by |
|---|---|
| `UseWebSocketCoverage.test.tsx > marks a thinking status and re-ranks recency…` | `6057951d3` — perf(chat): coalesce slot activity bumps into one dispatch per frame (#2631) |
| `UseMeetingSessionCoverage.test.tsx > broadcasts to the listening agents as chat` | `07308c857` — feat: persist and display meeting transcripts (#2425) |

Both test files were added hours earlier (#2640 and `c93aac02b`) and were green
then. The breakage blocks **every** PR rebased past `6057951d3`, not just this one.

**Both fixes are test-side. The production code is correct in each case:**

- **`UseWebSocketCoverage`** read `slots[0].last_ts` immediately after a
  `chat_message`. #2631 deliberately buffers that bump per slot and flushes once
  per animation frame — it ships with its own 317-line suite pinning exactly that
  (`useWebSocket.slotActivityCoalesce.test.ts`). This file's `beforeEach` stubs
  `requestAnimationFrame` into a queue that nothing drains, so the read landed
  before the flush and saw `undefined`. The test now drives the pending frame,
  matching how the coalescing suite does it. **The assertion is byte-identical** —
  nothing was loosened, no timeout, no retry.
- **`UseMeetingSessionCoverage`** blanket-stubbed every mutation with
  `mockResolvedValue({})`. Broadcast is the one mutation whose response the hook
  reads: since #2425 its success path commits `response.segment` into the
  transcript cache, so the shapeless stub threw inside `onSuccess` and react-query
  reported the broadcast as **failed** (`"Could not reach the agents."` instead of
  `"Sent to the listening agents."`). The `dispatch` mock now carries the real
  `DispatchResponse` shape. A bare `{}` was never valid against that interface; it
  only survived because nothing read the field before #2425.

Neither is a flake fix: both failed deterministically, and neither repair uses a
rerun, a longer sleep, or a weakened assertion.

### Extra hardening from local review

- `dispatch` is now **excluded** from the bare-`{}` loop rather than assigned twice.
  The dead assignment stated the opposite contract seven lines from the real one,
  so relocating or dropping the override would have silently restored this exact
  failure with nothing to catch it (the mocks are untyped, so `tsc` would not).
- The broadcast test now asserts the transcript commit directly
  (`transcript` contains `seg-1`) instead of relying on `notify` firing. I proved
  the assertion is not vacuous by mutating the fixture id and watching it fail
  with `expected [ 'seg-WRONG' ] to include 'seg-1'`, then restoring it.

### Verification

- Both files pass twice consecutively; all 23 sibling websocket and meetings
  suites pass, including #2631's own coalescing suite
- Full frontend suite: **954 files, 15,277 tests, 0 failures**; `tsc -b` and
  `npm run build` clean

### Scope note

This lands two logical changes in one commit because the repo requires
single-commit PRs. The cleaner sequence would have been to land the test repairs
alone first, then rebase the bump onto green. Flagging it explicitly so a
reviewer can push back if they would rather see it split.
