### PR TITLE
fix(security): move $HOME expansion after shlex tokenization

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -7493,28 +7493,34 @@ def normalize_shell_command(cmd: str) -> list[str]:
     if not cmd or not cmd.strip():
         return []
 
-    # Pre-process: expand $HOME/${HOME} BEFORE shlex splitting so that
-    # expansion happens even inside quoted strings that shlex won't expand.
-    home = os.path.expanduser("~")
-    # Replace via a FUNCTION, not a string template: on Windows the home path
-    # is ``C:\Users\<name>``, and ``re.sub`` parses a str replacement as a
-    # template eagerly -- ``\U`` is an invalid escape, so a string replacement
-    # raises ``re.error`` for EVERY input on that platform, not just ones
-    # containing ``$HOME``.  A callable is substituted literally.
-    preprocessed = _HOME_VAR_RE.sub(lambda _m: home, cmd)
+    # NOTE: $HOME expansion happens AFTER tokenization (in the per-token loop
+    # below), NOT here.  The previous pre-shlex expansion inserted the raw home
+    # path (e.g. ``C:\Users\name`` on Windows) into the command string before
+    # shlex.split(posix=True), which then consumed the backslashes as escape
+    # characters — mangling the path so is_sensitive_path() could not match it.
+    # Moving expansion to per-token mirrors how tilde (``~``) is already
+    # handled: shlex strips quotes and produces a literal ``$HOME/...`` token,
+    # which the loop then expands safely without backslash reinterpretation.
 
     # Tokenize using POSIX shlex — handles quoting, escaping, etc.
     try:
-        tokens = shlex.split(preprocessed, posix=True)
+        tokens = shlex.split(cmd, posix=True)
     except ValueError:
         # Unbalanced quotes or other parse errors — fall back to basic split.
-        tokens = preprocessed.split()
+        tokens = cmd.split()
         tokens = [t.strip("\"'\\") for t in tokens]
 
+    home = os.path.expanduser("~")
     resolved: list[str] = []
     for token in tokens:
         # Strip empty-string concatenation artifacts: ca""t -> cat, g''it -> git
         token = _EMPTY_QUOTE_RE.sub("", token)
+
+        # Expand $HOME/${HOME} per-token (after shlex, so Windows backslashes
+        # in the expanded path are never reinterpreted as escape characters).
+        # Uses a callable replacement to avoid re.error on Windows where the
+        # home path contains ``\U`` which re.sub parses as a template escape.
+        token = _HOME_VAR_RE.sub(lambda _m: home, token)
 
         # Expand tilde (shlex doesn't do tilde expansion)
         if token.startswith("~"):

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -1082,13 +1082,13 @@ class TestSelfProtectionFloorIsAdditive:
         from kiro_crew.security import normalize_shell_command
 
         monkeypatch.setattr(_os.path, "expanduser", lambda _p: r"C:\Users\runneradmin")
-        # The guard is that this RETURNS rather than raising.  (POSIX ``shlex``
-        # then eats the backslashes, which is pre-existing behaviour for Windows
-        # paths and not what this test is about.)
+        # The guard is that this RETURNS rather than raising.
         assert normalize_shell_command(f"{_PK} {_NAME}") == [_PK, _NAME]
+        # $HOME expansion now happens AFTER shlex tokenization, so the Windows
+        # home path backslashes are preserved (not eaten by shlex).
         expanded = normalize_shell_command("ls $HOME/x")
         assert expanded[0] == "ls"
-        assert "usersrunneradmin" in expanded[1].lower().replace("\\", "")
+        assert r"C:\Users\runneradmin" in expanded[1] or "C:\\Users\\runneradmin" in expanded[1]
 
 
 class TestInterpreterArgvLiteralMint:

--- a/test/test_governance_self_protection.py
+++ b/test/test_governance_self_protection.py
@@ -9,7 +9,6 @@ files are on the sensitive-path floor (read + write blocked at every surface via
 from __future__ import annotations
 
 import os
-import sys
 
 import pytest
 
@@ -131,22 +130,10 @@ def test_benign_write_verbs_not_overblocked():
 # therefore turned the keystone fence off for every write verb on a default
 # install. These pin the two spellings to the SAME verdict.
 #
-# The ``$HOME`` spelling is POSIX-only here, and NOT because the gate is
-# POSIX-only: ``normalize_shell_command`` substitutes ``$HOME`` BEFORE
-# ``shlex.split(posix=True)``, so on Windows the expansion inserts
-# ``C:\Users\<name>`` and shlex then consumes those backslashes as escapes
-# (``C:Usersrunneradmin/.kiro/crew/…``). The token no longer names any real
-# path, so the normalizer resolves nothing. That is a separate defect in the
-# tokenizer, on the pre-existing read path as much as this one; asserting it
-# here would pin a guarantee this change does not make.
-_HOME_VAR_SPELLING = pytest.param(
-    "$HOME/.kiro/crew/./live_target.json",
-    marks=pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="normalize_shell_command expands $HOME before shlex, which eats the "
-        "backslashes of a Windows home",
-    ),
-)
+# The ``$HOME`` spelling works on all platforms: normalize_shell_command()
+# expands ``$HOME`` per-token AFTER shlex.split(), so Windows backslashes in
+# the expanded path are never reinterpreted as escape characters.
+_HOME_VAR_SPELLING = "$HOME/.kiro/crew/./live_target.json"
 
 _KEYSTONE_SPELLINGS = (
     "~/.kiro/crew/live_target.json",
@@ -240,6 +227,26 @@ def test_attached_redirections_benign_not_overblocked():
         "cat <<EOF",  # heredoc delimiter, not a path
     ):
         assert security.is_sensitive_bash_command(cmd) is None, cmd
+
+
+def test_home_var_expansion_survives_windows_backslashes(monkeypatch):
+    """$HOME expansion must not be defeated by Windows backslash home paths.
+
+    The fix: $HOME is expanded per-token AFTER shlex.split, so backslashes in
+    the expanded path are never reinterpreted as escape characters by shlex."""
+    import os as _os
+
+    from kiro_crew.security import normalize_shell_command
+
+    win_home = r"C:\Users\runneradmin"
+    monkeypatch.setattr(_os.path, "expanduser", lambda _p: win_home)
+
+    tokens = normalize_shell_command("cat $HOME/.kiro/crew/live_target.json")
+    assert tokens[0] == "cat"
+    # The path must contain the FULL Windows home (backslashes intact),
+    # not the mangled 'C:Usersrunneradmin' that shlex would produce.
+    assert win_home in tokens[1], f"Expected {win_home!r} in {tokens[1]!r}"
+    assert ".kiro/crew/live_target.json" in tokens[1]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`normalize_shell_command()` expanded `$HOME` before `shlex.split(posix=True)`. On Windows, the expanded path (`C:\Users\<name>`) contained backslashes that shlex interpreted as escape characters, mangling the token into garbage (`C:Usersrunneradmin/.kiro/crew/...`) so `is_sensitive_path()` could not match it.

## Why it matters

This defeats the **entire normalizer second-pass on Windows** — both the read and write paths — for any `$HOME`-spelled credential access. The threat model this defends against (`_CREW_SECRET_LEAVES`) is prompt injection via untrusted content, where the injected command may use `$HOME` rather than `~` to name a keystone file.

## Fix (symptoms → root cause → change)

- **Symptom**: `echo x > $HOME/.kiro/crew/./live_target.json` returns None on Windows
- **Root cause**: Pre-shlex expansion inserts `C:\Users\name` into the raw command string; `shlex.split(posix=True)` then consumes backslashes as escape chars
- **Change**: Move `_HOME_VAR_RE.sub()` from pre-tokenization to the per-token loop (after shlex), mirroring how `~` expansion already works. shlex produces a literal `$HOME/...` token which the loop then expands safely.

## Tests

- Removed the `skipif(win32)` mark from `_HOME_VAR_SPELLING` parametrization — now runs on all platforms
- Updated `test_home_expansion_tolerates_a_backslash_home` to assert correct (preserved) backslash path
- Added `test_home_var_expansion_survives_windows_backslashes` — monkeypatches expanduser to a Windows path and verifies the full path survives tokenization intact
- 1045 tests pass across governance + security + denied-commands suites

## Attribution

Reported by Akash Vishwakarma (@joyboy5477) as Finding 2 in the normalizer security report.