### PR TITLE
fix(build): install the pinned dev group into make-built venvs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ backend:
 	# prebuilt wheel instead. No-op where the newest deps already have a usable
 	# wheel (macOS, AL2023).
 	KIROCREW_SKIP_FRONTEND=1 $(PIP) install --prefer-binary -e ".[dev]"
+	# CI parity: also install the PEP 735 dev dependency-group (pins
+	# jsonschema so the config-validation guard tests actually run).
+	$(PIP) install --group dev
 	bash packaging/resign-macos-libs.sh $(VENV)/bin/python
 
 test: build

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,7 +122,8 @@ desktop =
 # makes a local `make build` venv disagree with CI (black 26 reformats ~680
 # files that black 24 accepts). Bump these in lockstep with pyproject.toml.
 dev =
-    pytest>=8,<9
+    # Ceiling admits pytest 9 (CI dev-group pins pytest==9.0.3 and proves it works).
+    pytest>=8,<10
     pytest-cov>=4,<7
     pytest-asyncio>=0.21
     pytest-xdist>=3


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 2 related changes:
- **Install the pinned dev group into make-built venvs**
- **PR 2709: retitle lowercase scope, drop jsonschema fallback, align pytest ceiling**

## Changes and rationale

### Install the pinned dev group into make-built venvs
**Problem:** Two divergent dev-dependency lists leave `make build` venvs missing `jsonschema==4.26.0`: CI installs the PEP 735 dependency GROUP: `pip install -e ".[voice]" --group dev` (pyproject.toml `[dependency-groups] dev`, which pins jsonschema==4.26.0 with an explicit comment: it is declared "so those guards actually run" because `kiro_crew.config.validation` imports jsonschema behind try/except and pytest scores the resulting skips as passes). The Makefile `backend` target installs only the setup.cfg dev EXTRA (`pip…
**Why it matters:** `make test` is the documented build-from-source path. A dev-tooling split that makes the same tree pass CI and fail locally wastes every contributor's first debugging session, and until PR 2390 lands it silently disables 11 security-ish validation guard tests on those hosts.
**Tests:** From a clean checkout: `make build`, then `.venv/bin/python -c "import jsonschema"` succeeds and `.venv/bin/python -m pytest test/test_mcp_gateway_apps_switch.py -o addopts="" -p no:cacheprovider` passes with the validator tests RUNNING (not skipped). `make build` remains idempotent (second run succeeds).
**Review focus:** backend

### PR 2709: retitle lowercase scope, drop jsonschema fallback, align pytest ceiling
**Review focus:** pr-maintenance

## Review map

| Change | Primary files |
|---|---|
| Install the pinned dev group into make-built venvs | `Makefile` |
| PR 2709: retitle lowercase scope, drop jsonschema fallback, align pytest ceiling | `Makefile`<br>`setup.cfg` |

## Commits
- [`1c048d0`](https://github.com/kirodotdev/KiroCrew/pull/2709/commits/1c048d0620126547f5e6dcabe705a42698e453b6) fix(build): install the pinned dev group into make-built venvs

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (2 files, +5/-1)</summary>

- `Makefile` (+3/-0)
- `setup.cfg` (+2/-1)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->