### PR TITLE
test(website): flush the coalesced recency write before asserting it

### DIFF
--- a/website/src/test/UseWebSocketCoverage.test.tsx
+++ b/website/src/test/UseWebSocketCoverage.test.tsx
@@ -471,6 +471,8 @@ describe('useWebSocket frame router', () => {
       ws.simulateMessage({ type: 'chat_message', data: { slot: ACTIVE, role: 'user', content: 'go', ts: '2024-01-01T00:00:00Z' } })
     })
     expect(chat().slotStatusDetail[ACTIVE]?.kind).toBe('thinking')
+    // last_ts is coalesced to one dispatch per frame, so drain the rAF queue.
+    act(() => { rafCbs.splice(0).forEach(cb => cb(0)) })
     expect(dash().slots[0].last_ts).toBe('2024-01-01T00:00:00Z')
   })
 


### PR DESCRIPTION
`main` is currently red on `website/src/test/UseWebSocketCoverage.test.tsx`. This is a one-line test-file fix.

## Why it is red

Two independently-green PRs collided, and nothing re-ran the frontend suite on the merge result:

- `9a5ffea0` (#2640) added `useWebSocket frame router > marks a thinking status and re-ranks recency when a user message arrives`, which asserts `slots[0].last_ts` immediately after a `chat_message` frame.
- `6057951d` (#2631) then moved that write behind a once-per-animation-frame flush (`scheduleSlotActivityFlush` / `flushSlotActivity` in `website/src/hooks/useWebSocket.ts`).

`9a5ffea0` is an ancestor of `6057951d`, but #2631's Frontend Tests ran before the test existed, so neither run could see the other. On the merged tip the assertion reads `undefined`.

## Why the test is the stale side, not the code

The coalescing is deliberate and documented, and it ships 11 cases of its own in `website/src/test/useWebSocket.slotActivityCoalesce.test.ts`. The old assertion was pinning *synchronous dispatch* — the implementation detail #2631 changed on purpose. The user-visible effect is that sidebar recency updates one animation frame (~16ms) later, which is the point of the change.

## The change

Drain the already-stubbed animation-frame queue before the assertion, using the idiom this file already uses elsewhere (`rafCbs` is stubbed in `beforeEach` and drained in two later tests). `splice(0)` rather than `rafCbs[0]` because the chunk coalescer also queues frames, so draining only the first entry could leave the activity flush pending.

The `toBe('2024-01-01T00:00:00Z')` assertion is unchanged — it still pins the value, not merely its presence.

## Verification

| scope | result |
| ----- | ------ |
| target test before the fix | fails: `expected undefined to be '2024-01-01T00:00:00Z'` |
| target test after | 1 passed |
| whole file after | 88 passed (88) |

One unrelated failure remains in the full frontend suite, in `website/src/test/UseMeetingSessionCoverage.test.tsx > broadcasts to the listening agents as chat`. It reproduces identically with this branch's change stashed away, so it is independent of this PR and is deliberately left alone rather than folded in. Local runs are on node 22; CI pins node 24, so this PR's own CI run is the cheapest way to tell whether it is a real second regression on `main` or node-version-specific.

## Why this is worth landing ahead of other frontend work

`main` currently fails two frontend tests, so **every** frontend PR — from anyone — inherits both failures and cannot go green. Measured at `f4d3327a` by running the two files directly rather than reading run states:

```
Test Files  2 failed (2)
Tests       2 failed | 142 passed (144)
```

This PR clears one of the two. The other is `website/src/test/UseMeetingSessionCoverage.test.tsx > broadcasts to the listening agents as chat`, which is unrelated to this change and is being reported separately; it is the sole reason this PR's own `Frontend Tests` job is red. The same job shows `✓ src/test/UseWebSocketCoverage.test.tsx (88 tests)`, so the fix here is verified on CI's node 24, not just locally.
