### PR TITLE
fix: give the whoami probe its own budget covering an IdP round trip (#1581)

### DIFF
--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -111,6 +111,20 @@ def legacy_idle_operation() -> dict[str, str]:
 _MAX_CAPTURED_OUTPUT = 64 * 1024
 _MAX_VISIBLE_DETAIL = 4_000
 _PROBE_TIMEOUT_SECS = 10
+# The identity probe's own budget, deliberately separate from
+# _PROBE_TIMEOUT_SECS. ``whoami`` is not a local read: when the cached token has
+# expired, Kiro CLI refreshes an OIDC token against the organization's IdP —
+# for IAM Identity Center users that network round trip measures 12–20 seconds,
+# so a probe killed at the shared 10-second ceiling reports a fully signed-in
+# CLI as ``authenticated=False`` and wedges the first-run gate. The budget is
+# NOT applied to ``--version``: that probe is the FIRST execution of an unknown
+# candidate and must stay on a short leash, so a genuinely missing or hung
+# binary is still reported quickly rather than blocking the gate for the full
+# identity budget. Sized to cover the observed refresh with headroom, while the
+# in-flight latch in :meth:`KiroPrerequisiteService.snapshot` keeps the gate's
+# machine polls answering from cached state instead of queueing behind a probe
+# this long.
+_IDENTITY_PROBE_TIMEOUT_SECS = 30
 _PROBE_CACHE_SECS = 2.0
 # Floor between HOST probes driven by the status endpoint, however many callers
 # ask. The first-run gate polls with ``refresh=1`` every 5s while it blocks the
@@ -1681,7 +1695,9 @@ class KiroPrerequisiteService:
         supported way to re-probe on demand.
 
         ``coalesce=True`` additionally floors the probe at
-        :data:`_FORCED_PROBE_FLOOR_SECS`. It is for the MACHINE-driven force — the
+        :data:`_FORCED_PROBE_FLOOR_SECS`, and serves the latched answer without
+        waiting when a probe is already in flight. It is for the MACHINE-driven
+        force — the
         blocking gate's auto-poll, which every open tab runs independently — so N
         tabs collapse onto one probe per interval instead of multiplying the
         spawns. A human-driven force (Check again) passes ``coalesce=False`` and
@@ -1692,6 +1708,18 @@ class KiroPrerequisiteService:
         """
 
         if force and coalesce and self._clock() - self._last_probe_at < _FORCED_PROBE_FLOOR_SECS:
+            force = False
+        if force and coalesce and self._has_probed and self._probe_lock.locked():
+            # A probe is already in flight and a latched answer exists. The
+            # machine poll must not queue behind ``_probe_lock`` here: the
+            # identity probe can legitimately run for
+            # _IDENTITY_PROBE_TIMEOUT_SECS (an IdP token refresh), and every
+            # open tab polls every few seconds, so queueing would hang each
+            # poll for the probe's whole remaining duration — a frozen gate,
+            # exactly what the floor exists to prevent. Serving the latched
+            # answer keeps the pane live; the in-flight probe refreshes it for
+            # the next poll. A human Check again keeps queueing: it promised a
+            # fresh answer, and it runs its own probe after the winner.
             force = False
         if force:
             # ``force=not coalesce`` is what actually coalesces a BURST. The floor
@@ -2077,7 +2105,13 @@ class KiroPrerequisiteService:
                 executable,
                 ["whoami"],
                 base_env=_identity_probe_env(self._environ, self._probe_environment),
-                timeout_secs=_PROBE_TIMEOUT_SECS,
+                # The identity budget, not the shared probe ceiling: ``whoami``
+                # may refresh an OIDC token against an organization IdP (see
+                # _IDENTITY_PROBE_TIMEOUT_SECS). By the time this runs, the same
+                # binary already answered ``--version`` inside the short budget,
+                # so the extra headroom is never spent on a missing or hung
+                # candidate.
+                timeout_secs=_IDENTITY_PROBE_TIMEOUT_SECS,
                 isolate_home=isolate_home,
             )
         except asyncio.CancelledError:

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -3939,6 +3939,129 @@ class TestKiroCrewNeverSetsUpKiroCli:
             assert not hasattr(KiroPrerequisiteService, method), method
 
     @pytest.mark.asyncio
+    async def test_identity_probe_gets_idp_budget_and_version_stays_short(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # whoami may refresh an OIDC token against an organization IdP (IAM
+        # Identity Center), a 12-20s round trip, so it carries its own budget.
+        # --version is the FIRST execution of an unknown candidate and must
+        # keep the short leash, or a missing/hung binary blocks the gate for
+        # the full identity budget.
+        executable = tmp_path / ".local" / "bin" / "kiro-cli"
+        _make_executable(executable)
+        runtime = _FakeRuntime(executable)
+        runtime.authenticated = True
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": str(executable.parent)},
+            home=tmp_path,
+            process_runner=runtime.run,
+            audit_writer=_no_audit,
+        )
+        await service.snapshot(force=True)
+
+        budgets = {
+            tuple(args): kwargs["timeout_secs"]
+            for (_, args), kwargs in zip(runtime.calls, runtime.kwargs)
+        }
+        assert budgets[("--version",)] == prerequisite_module._PROBE_TIMEOUT_SECS
+        assert budgets[("whoami",)] == prerequisite_module._IDENTITY_PROBE_TIMEOUT_SECS
+        assert (
+            prerequisite_module._IDENTITY_PROBE_TIMEOUT_SECS
+            > prerequisite_module._PROBE_TIMEOUT_SECS
+        )
+
+    @pytest.mark.asyncio
+    async def test_slow_idp_whoami_inside_new_budget_resolves_authenticated(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # A whoami that needs longer than the old shared ceiling but fits the
+        # identity budget must resolve as authenticated. The runner times out
+        # iff the granted budget cannot cover an Identity Center token refresh
+        # (measured at 12-20s), which is exactly what the real subprocess does.
+        executable = tmp_path / ".local" / "bin" / "kiro-cli"
+        _make_executable(executable)
+        idp_refresh_secs = 20.0
+
+        async def run(command: str, args: list[str], **kwargs: Any) -> ProcessResult:
+            del command
+            if args == ["--version"]:
+                return ProcessResult(ok=True)
+            if args == ["whoami"]:
+                if kwargs["timeout_secs"] <= idp_refresh_secs:
+                    return ProcessResult(ok=False, timed_out=True, error="process timed out")
+                return ProcessResult(ok=True)
+            return ProcessResult(ok=False)
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": str(executable.parent)},
+            home=tmp_path,
+            process_runner=run,
+            audit_writer=_no_audit,
+        )
+        status = await service.snapshot(force=True)
+        assert status["authenticated"] is True
+        assert status["ready"] is True
+
+    @pytest.mark.asyncio
+    async def test_auto_poll_serves_latched_state_while_slow_probe_runs(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # The identity probe can legitimately run for the full IdP budget. A
+        # machine poll arriving mid-probe must answer immediately from the
+        # latched state — queueing behind _probe_lock would freeze the gate's
+        # pane for the probe's remaining duration, in every open tab.
+        executable = tmp_path / ".local" / "bin" / "kiro-cli"
+        _make_executable(executable)
+        probe_entered = asyncio.Event()
+        release_probe = asyncio.Event()
+        slow = {"active": False}
+        calls: list[list[str]] = []
+        clock = {"now": 1_000.0}
+
+        async def run(command: str, args: list[str], **kwargs: Any) -> ProcessResult:
+            del command, kwargs
+            calls.append(args)
+            if slow["active"] and args == ["whoami"]:
+                probe_entered.set()
+                await release_probe.wait()
+            return ProcessResult(ok=True)
+
+        service = KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": str(executable.parent)},
+            home=tmp_path,
+            process_runner=run,
+            audit_writer=_no_audit,
+            clock=lambda: clock["now"],
+        )
+        # Latch a fast, healthy answer first.
+        first = await service.snapshot(force=True)
+        assert first["ready"] is True
+
+        # Past the floor, a slow probe starts and hangs inside whoami.
+        clock["now"] += prerequisite_module._FORCED_PROBE_FLOOR_SECS + 1
+        slow["active"] = True
+        in_flight = asyncio.create_task(service.snapshot(force=True, coalesce=True))
+        await asyncio.wait_for(probe_entered.wait(), timeout=2)
+
+        # Machine polls answer promptly from the latch, spawning nothing.
+        spawns_before = len(calls)
+        polled = await asyncio.wait_for(
+            service.snapshot(force=True, coalesce=True), timeout=1
+        )
+        assert polled["ready"] is True
+        assert len(calls) == spawns_before
+
+        release_probe.set()
+        await asyncio.wait_for(in_flight, timeout=2)
+
+    @pytest.mark.asyncio
     async def test_auto_poll_is_coalesced_but_check_again_always_probes(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary

The kiro-prerequisite identity probe shared the 10-second `_PROBE_TIMEOUT_SECS` ceiling with the cheap `--version` probe. For IAM Identity Center (SSO) users, `whoami` must refresh an OIDC token against the organization's IdP when the cached token has expired — a network round trip the reporter measured at 12–20 seconds — so the probe was killed mid-refresh and reported a fully signed-in CLI as `authenticated: false`. The dashboard stayed stuck on the "Sign in to Kiro" setup screen indefinitely while `kiro-cli whoami` succeeded in the user's own shell.

## Changes

- **New `_IDENTITY_PROBE_TIMEOUT_SECS = 30`**, used only by the identity/`whoami` probe. `--version` deliberately keeps the short 10s leash: it is the FIRST execution of an unknown candidate, and widening every probe would make a genuinely missing or hung binary block the gate for the full identity budget.
- **Gate stays responsive while a slow probe runs**: coalesced machine polls (`?refresh=auto`, one per open tab every 5s) now serve the latched answer immediately when a probe is already in flight, instead of queueing behind `_probe_lock` for the probe's whole remaining duration (up to ~40s with the new budget). A human **Check again** keeps queueing — it promised a fresh answer. The existing probe cache (`_PROBE_CACHE_SECS`) and inter-probe floor (`_FORCED_PROBE_FLOOR_SECS`) still collapse N tabs onto one probe; both existing coalescing tests pass unchanged.
- `verified_ready` (the gate for irreversible actions) is untouched: it still probes fresh and fails closed.

## Security posture

The timeout increase applies to the same fixed `whoami` argv, in the same sandbox posture, with the same env allowlist — no new privilege surface. The in-flight branch only ever serves a LATCHED answer a real probe produced; it never grants readiness.

## Tests

- `test_identity_probe_gets_idp_budget_and_version_stays_short` — pins whoami's budget to `_IDENTITY_PROBE_TIMEOUT_SECS`, `--version`'s to `_PROBE_TIMEOUT_SECS`, and the ordering between them.
- `test_slow_idp_whoami_inside_new_budget_resolves_authenticated` — a whoami needing 12–20s (times out iff the granted budget cannot cover it) resolves `authenticated=True`. **Fails on unmodified main** (verified).
- `test_auto_poll_serves_latched_state_while_slow_probe_runs` — a machine poll arriving while a probe hangs inside whoami answers promptly from the latch, spawning nothing.
- Full backend gates green: isort, flake8, mypy (877 files), pytest (41k+ passed; unrelated host-environment failures reproduce identically on unmodified main). Brand gate clean.

Pre-push review: spawn_run was governance-barred in this run (kirocrew-core MCP absent); a contract-driven self-review against both reviewer charters was performed in its place — no Critical/High findings. Server-side review bots remain the real gate.

Note: sibling issue #2648 edits the same file for a different root cause; rebased onto fresh `origin/main` before opening — the sibling has not landed, no collision.

Closes #1581
