### PR TITLE
test(website): repair two stale specs that keep Frontend Tests red on main

### DIFF
--- a/website/src/test/UseMeetingSessionCoverage.test.tsx
+++ b/website/src/test/UseMeetingSessionCoverage.test.tsx
@@ -153,6 +153,20 @@ beforeEach(() => {
   ] as const) {
     apiMocks[key].mockResolvedValue({})
   }
+  // dispatch's response is READ, not merely awaited: the success path commits
+  // response.segment into the transcript cache, and DispatchResponse.segment is
+  // non-optional. A bare {} makes that commit throw, so the mutation lands in
+  // onError and reports a failure that never happened.
+  apiMocks.dispatch.mockResolvedValue({
+    dispatched: 1,
+    text: 'dispatched text',
+    segment: {
+      id: 'seg-1',
+      timestamp: '2026-08-10T00:00:00Z',
+      source: 'typed',
+      text: 'dispatched text',
+    },
+  })
 })
 
 afterEach(() => {

--- a/website/src/test/UseWebSocketCoverage.test.tsx
+++ b/website/src/test/UseWebSocketCoverage.test.tsx
@@ -199,6 +199,13 @@ describe('useWebSocket frame router', () => {
       createElement(QueryClientProvider, { client: qc }, children))
   }
 
+  /** Run every frame queued on the stubbed requestAnimationFrame. Coalesced
+   *  work (streaming chunks, slot recency) lands here, not on the event. */
+  function runFrames() {
+    const pending = rafCbs.splice(0)
+    act(() => { pending.forEach(cb => cb(performance.now())) })
+  }
+
   function mount() {
     const hook = renderHook(() => useWebSocket(), { wrapper })
     const ws = WS_INSTANCES[0]
@@ -470,7 +477,12 @@ describe('useWebSocket frame router', () => {
     act(() => {
       ws.simulateMessage({ type: 'chat_message', data: { slot: ACTIVE, role: 'user', content: 'go', ts: '2024-01-01T00:00:00Z' } })
     })
+    // Status is dispatched per event, so it is observable immediately.
     expect(chat().slotStatusDetail[ACTIVE]?.kind).toBe('thinking')
+    // Recency is coalesced into one dispatch per frame, so it lands at the
+    // flush. Asserting before it reads the store one frame too early.
+    expect(dash().slots[0].last_ts).toBeUndefined()
+    runFrames()
     expect(dash().slots[0].last_ts).toBe('2024-01-01T00:00:00Z')
   })
 


### PR DESCRIPTION
## What is the problem?

`Frontend Tests` fails on a pristine `main`, so **every PR inherits a red `Frontend Tests` plus a red `Coverage Gate`** regardless of its own diff. Two separate specs are stale:

**1. `UseWebSocketCoverage.test.tsx` — slot recency** (blocks any PR, including backend-only ones)

```
FAIL useWebSocket frame router > marks a thinking status and re-ranks recency when a user message arrives
AssertionError: expected undefined to be '2024-01-01T00:00:00Z'
```

**2. `UseMeetingSessionCoverage.test.tsx` — meetings broadcast** (blocks any PR with a frontend-touching diff)

```
FAIL useMeetingSession lifecycle actions > broadcasts to the listening agents as chat
-   "Sent to the listening agents."  { "type": "info" }
+   "Could not reach the agents."    { "type": "error" }
```

Both are the same shape — two independently-green merges landing hours apart, touching different files, so git reported no conflict and neither PR's suite covered the other's:

| merged (UTC-7) | PRs | collision |
|---|---|---|
| 08-10 14:46 / 17:21 | #2640 added the recency assertion · #2631 coalesced the dispatch it reads | #2705 |
| — | a coverage spec's blanket mock · #2425 made dispatch's response carry a segment | #2719 |

Reproduced on a clean checkout of `main` at `f4d3327a7`; main's own run `31448947165` shows `Frontend Tests` + `Coverage Gate` failing.

## Why this issue matters to the user

No user-facing behaviour is wrong, and that is what makes it expensive. A false red lands on unrelated PRs and costs each author a diagnosis, because the failing spec has nothing to do with their diff — the natural first move is to suspect your own change. It also drags `Coverage Gate` down with it: that gate fails closed on `frontend-test=failure` even when `coverage-combine` succeeded, so one stale assertion becomes two reds and a red `PR Readiness`.

The second one hid longer than the first. CI reduces the frontend suite to 108 cross-surface specs on a **backend-only** diff, and the meetings spec is not in that set — so it has not run in CI since #2425 landed, including on `main`'s own pushes.

## How our fix solves it

**Recency — the assertion moves, not the implementation.**

1. The assertion reads `slots[0].last_ts` in the same tick as the frame.
2. After #2631 that write happens at a `requestAnimationFrame` flush, not on the event.
3. The harness stubs `requestAnimationFrame` into a `rafCbs` array nothing drains, so the flush never runs.

The deferral is the **intended contract**: #2631's own first case is named `does not bump last_ts synchronously on each event` and asserts `undefined` before running frames. Dispatching recency back on the event to satisfy #2640 would fail that test. So this adds `runFrames()` — same name and shape as the helper already in `useWebSocket.slotActivityCoalesce.test.ts` — and splits the case so the halves cannot silently drift back together: **status** is per-event and stays asserted synchronously, **recency** is asserted `undefined` first and again after the flush. Asserting the intermediate `undefined` pins *which* half is coalesced, so a later change to either dispatch path fails loudly instead of passing for the wrong reason.

**Broadcast — the mock moves, not the hook.**

The spec mocks every endpoint with a blanket `mockResolvedValue({})`. #2425 made the success path commit `response.segment` into the transcript cache. `DispatchResponse.segment` is **non-optional** in `api.ts`, so the unguarded read matches the declared contract and the server always sends one — but a bare `{}` makes `commitTranscriptSegment(undefined)` throw, the mutation lands in `onError`, and the spec sees a failure that never happened.

So the hook is right and the mock is stale: `dispatch` now resolves a full `DispatchResponse`. The blanket `{}` stays for every other endpoint, and the failure-path cases already override with `mockRejectedValue`, so they are unaffected.

Test-only, two files, +26 lines. **No production code touched** — deliberately, since in both cases the production side matches its own stated contract.

## What tests we did

- Each spec with its sibling suite: `UseWebSocketCoverage` + `useWebSocket.slotActivityCoalesce` → **99 passed**; `UseMeetingSessionCoverage` → **56 passed**. The first pairing matters most: it proves the fix does not weaken the suite that asserts the opposite timing.
- **Both repairs mutation-verified**: removing the frame drain fails the recency case; reverting the mock to `{}` fails the broadcast case.
- `npx tsc -b` clean.
- Confirmed the recency assertion is genuinely reachable rather than guarded away: `slotFixture` sets no `last_ts`, so the flush's never-move-backwards guard (`if (current && Date.parse(current) > Date.parse(ts)) continue`) does not suppress the bump.

One caveat, stated plainly: I could not produce a clean **full**-suite run locally. My own full run saturated the host (load average 66) and reported 60 failures across 6 files — a set completely disjoint from the earlier run's 2, and **all 6 files pass when re-run in isolation**. So that run is not usable evidence in either direction; CI is the real verdict here.

## Any other suggestions on the work

**`main` gets no reliable per-commit verdict, which is why combination-only breaks keep landing.** From `ci.yml`'s own comment:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
# main does not, so let an in-flight run finish instead of killing it.
# This does NOT produce a verdict per commit. The group still permits one
# pending run, and GitHub evicts that pending run when a newer one queues
# ... main gets periodic verdicts instead of none.
```

With a ~19 min run and a ~1.4 min median merge gap, most `main` commits are never verified. Counting #2481 (isort), this is the third and fourth instance of the pattern.

**A stale-but-green verdict can also carry a merge.** #2677's `Frontend Tests` ran 23:01–23:17Z and it merged at 01:08Z — its green predates #2631 (00:21Z) by two hours, so it merged without ever having tested the tree it landed on.

Both observations are about the gate, not about any author, and neither is addressed here — flagging them because two independent breakages in one evening is a signal about the mechanism rather than about luck.

Fixes #2705
Fixes #2719
