### PR TITLE
fix: forward proxy environment to the kiro-cli setup probes (#2648)

### DIFF
--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -938,9 +938,17 @@ remain in memory and execute through the fixed system interpreter's standard
 input, closing the validation/execution replacement window. The unsandboxed
 official installer receives a system-only `PATH`. Explicit login
 inherits only the allowlisted user-path, UI/device-flow, TLS, and proxy values;
-passive probes receive a narrower environment that excludes proxy credentials
-and desktop-session IPC as well as ambient cloud, Slack, SSH-agent, and
-application credentials. The one deliberate *credential* exception is Kiro CLI's
+passive probes receive a narrower environment that carries TLS trust and, on
+hosts that need it, desktop-session IPC, while excluding ambient cloud, Slack,
+SSH-agent, and application credentials. Proxy configuration (both case
+spellings, since matching is exact on POSIX and HTTP stacks disagree on which
+case they honour) joins only the `whoami` identity stage: a proxy-only host is
+exactly where `whoami` must still reach the IdP, but a proxy URL can embed
+credentials, and `--version` is the first execution of an unvalidated
+candidate that needs no network — so the version stage stays proxy-free and
+the exposure delta is confined to a candidate that already passed the version
+gate, reaching the same resolved binary an ACP session already runs with the
+full inherited environment. The one deliberate *credential* exception is Kiro CLI's
 OWN model credential (`KIRO_API_KEY`, `_IDENTITY_PROBE_ENV_KEYS`), forwarded to the
 `whoami` identity probe only: the CLI reports an API-key session as signed in only
 when it can see that variable, so filtering it out reports a host that ACP

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -241,6 +241,40 @@ _PROBE_ENV_KEYS = frozenset(
 # presence of this variable must never become a shortcut that skips the probe.
 _IDENTITY_PROBE_ENV_KEYS = frozenset({"KIRO_API_KEY"})
 
+# Proxy configuration, forwarded to the ``whoami`` identity probe only.
+#
+# On a host that reaches the network only through an HTTP proxy, ``whoami``
+# must talk to the IdP the same way the user's own shell does — filtered out,
+# the child cannot connect, the probe answers "Not logged in", and the setup
+# gate latches unauthenticated on a host where sign-in actually works. Both
+# case spellings are listed because matching is exact on POSIX and the HTTP
+# stacks disagree on which case they honour (curl-family reads the lowercase
+# names, Rust/Python stacks read either), so forwarding only one case
+# reproduces the bug on half of hosts. ALL_PROXY is included deliberately: a
+# SOCKS-only host sets it INSTEAD of the scheme-specific pair, and curl and
+# reqwest both honour it as the fallback, so omitting it keeps the exact same
+# defect for that host class.
+#
+# These are kept OUT of :data:`_PROBE_ENV_KEYS` for the same reason as the
+# credential above: a proxy URL can embed credentials, and ``--version`` is
+# the FIRST execution of a candidate that has not yet answered anything — and
+# nothing about resolving a version needs the network. ``whoami`` runs only
+# after ``--version`` succeeds, against the same resolved binary an ACP
+# session already runs with the full inherited environment, so the exposure
+# delta is confined to a candidate that has already passed the version gate.
+_IDENTITY_PROXY_ENV_KEYS = frozenset(
+    {
+        "ALL_PROXY",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "all_proxy",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    }
+)
+
 
 @dataclass
 class ProcessResult:
@@ -850,7 +884,15 @@ def _allowlisted_env(
 
 
 def _probe_env(environ: MutableMapping[str, str], search_path: str) -> dict[str, str]:
-    """Build a non-interactive probe environment without proxy or desktop IPC."""
+    """Build a non-interactive probe environment from the fixed allowlist.
+
+    Network-reachability configuration (TLS trust, the session bus where a CLI
+    build needs it) passes through; proxy settings join only the ``whoami``
+    stage via :func:`_identity_probe_env`, because a proxy URL can embed
+    credentials and ``--version`` executes a candidate that has not yet
+    answered anything. Ambient credentials (cloud, Slack, SSH agent,
+    application secrets) never pass.
+    """
 
     result = _allowlisted_env(environ, _PROBE_ENV_KEYS)
     result["PATH"] = search_path
@@ -862,14 +904,16 @@ def _probe_env(environ: MutableMapping[str, str], search_path: str) -> dict[str,
 def _identity_probe_env(
     environ: MutableMapping[str, str], probe_environment: dict[str, str]
 ) -> dict[str, str]:
-    """Add Kiro CLI's own credential env to a probe environment.
+    """Add Kiro CLI's own credential and proxy env to a probe environment.
 
     Separate from :func:`_probe_env` so only the identity probe carries the
-    credential; see :data:`_IDENTITY_PROBE_ENV_KEYS` for why ``whoami`` needs it
-    and why ``--version`` must not get it.
+    credential and the (possibly credentialed) proxy configuration; see
+    :data:`_IDENTITY_PROBE_ENV_KEYS` and :data:`_IDENTITY_PROXY_ENV_KEYS` for
+    why ``whoami`` needs them and why ``--version`` must not get them.
     """
 
     result = dict(probe_environment)
+    result.update(_allowlisted_env(environ, _IDENTITY_PROXY_ENV_KEYS))
     result.update(_allowlisted_env(environ, _IDENTITY_PROBE_ENV_KEYS))
     return result
 

--- a/test/test_env_allowlist_consolidation.py
+++ b/test/test_env_allowlist_consolidation.py
@@ -21,12 +21,13 @@ These tests pin two things:
    real Windows ``os.environ`` yields — which is exactly why the shared fold
    admits the same set there.
 
-``kiro_prerequisite`` passes two different allowlists through the shared matcher:
+``kiro_prerequisite`` passes three different allowlists through the shared matcher:
 ``_PROBE_ENV_KEYS`` for the credential-free ``--version`` probe, and
-``_IDENTITY_PROBE_ENV_KEYS`` for the ``whoami`` identity probe, which names Kiro
-CLI's own credential. Both are pinned, and the credential one additionally pins
-WHAT it admits — one name, admitted by no other site — because a fold that
-widened there would forward more than the carve-out names.
+``_IDENTITY_PROBE_ENV_KEYS`` plus ``_IDENTITY_PROXY_ENV_KEYS`` for the ``whoami``
+identity probe, which names Kiro CLI's own credential and the host's (possibly
+credentialed) proxy configuration. All are pinned, and the credential one
+additionally pins WHAT it admits — one name, admitted by no other site — because
+a fold that widened there would forward more than the carve-out names.
 """
 
 from __future__ import annotations
@@ -218,6 +219,7 @@ class TestCallSiteParity:
         for allowed in (
             registry._SAFE_ENV_KEYS,
             kiro_prerequisite._PROBE_ENV_KEYS,
+            kiro_prerequisite._IDENTITY_PROXY_ENV_KEYS,
             dev_fleet_server._SAFE_ENV_KEYS,
             gh_profile._MEASURE_ENV_PASSTHROUGH,
             source_providers._PROVIDER_BASE_ENV_KEYS,
@@ -287,6 +289,7 @@ class TestCallSiteParity:
             registry._SAFE_ENV_KEYS,
             kiro_prerequisite._PROBE_ENV_KEYS,
             kiro_prerequisite._IDENTITY_PROBE_ENV_KEYS,
+            kiro_prerequisite._IDENTITY_PROXY_ENV_KEYS,
             dev_fleet_server._SAFE_ENV_KEYS,
             gh_profile._MEASURE_ENV_PASSTHROUGH,
             source_providers._PROVIDER_BASE_ENV_KEYS,

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -115,6 +115,59 @@ async def _wait_for_operation(service: KiroPrerequisiteService) -> None:
 
 
 class TestKiroPrerequisiteHelpers:
+    @pytest.mark.parametrize("windows", [True, False], ids=["windows", "posix"])
+    def test_identity_env_forwards_proxy_configuration_and_refuses_secrets(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        windows: bool,
+    ) -> None:
+        """A proxy-only host's ``whoami`` reaches the IdP the way the user's shell does.
+
+        Every spelling of the proxy set passes through the IDENTITY probe env —
+        matching is exact on POSIX and the HTTP stacks disagree on which case
+        they honour — while a non-allowlisted variable is still refused, so the
+        allowlist does not silently widen into a passthrough. The
+        ``--version``/``whoami`` split stays intact: the base probe environment
+        carries neither the CLI's own credential nor the (possibly
+        credentialed) proxy configuration, because ``--version`` is the first
+        execution of an unvalidated candidate and needs no network.
+        """
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
+        proxies = {
+            "ALL_PROXY": "socks5://proxy.example:1080",
+            "HTTP_PROXY": "http://proxy.example:3128",
+            "HTTPS_PROXY": "http://user:pass@proxy.example:3128",
+            "NO_PROXY": "localhost,127.0.0.1",
+            "all_proxy": "socks5://proxy.example:1080",
+            "http_proxy": "http://proxy.example:3128",
+            "https_proxy": "http://user:pass@proxy.example:3128",
+            "no_proxy": "localhost,127.0.0.1",
+        }
+        secrets = {
+            "AWS_SECRET_ACCESS_KEY": "secret",
+            "GITHUB_TOKEN": "ghp_secret",
+            "SSH_AUTH_SOCK": "/tmp/agent.sock",
+        }
+        environ = {"HOME": "/home/u", **proxies, **secrets}
+
+        version_env = prerequisite_module._probe_env(environ, "/probe/search/path")
+        identity_env = prerequisite_module._identity_probe_env(environ, version_env)
+
+        # The unvalidated --version candidate never sees proxy configuration.
+        for name in proxies:
+            assert name not in version_env
+        # whoami gets the full proxy set, values intact.
+        for name, value in proxies.items():
+            assert identity_env[name] == value
+        # Non-allowlisted variables stay refused in both environments.
+        for name in secrets:
+            assert name not in version_env
+            assert name not in identity_env
+        # _probe_env pins PATH to the caller's search path regardless of the
+        # allowlist admitting the host PATH.
+        assert version_env["PATH"] == "/probe/search/path"
+        assert identity_env["PATH"] == "/probe/search/path"
+
     def test_binary_digest_rejects_oversized_candidate(
         self,
         tmp_path: Path,
@@ -1384,15 +1437,27 @@ class TestKiroPrerequisiteWorkflow:
                     str(tmp_path / ".local" / "share" / "kiro-cli"),
                     str(tmp_path / ".local" / "share" / "amazon-q"),
                 )
+                # Proxy configuration never reaches the unvalidated --version
+                # candidate (a proxy URL can embed credentials); it joins only
+                # the whoami stage below. Desktop IPC beyond the session bus
+                # stays excluded.
                 assert "HTTPS_PROXY" not in runtime.kwargs[index]["env"]
                 assert "DISPLAY" not in runtime.kwargs[index]["env"]
-                # The session bus IS forwarded now — some CLI builds connect to
+                # The session bus IS forwarded — some CLI builds connect to
                 # the D-Bus secret-service keyring even at --version (AL2023).
-                # Other desktop IPC / proxy vars stay excluded.
                 assert (
                     runtime.kwargs[index]["env"].get("DBUS_SESSION_BUS_ADDRESS")
                     == "unix:path=/tmp/bus"
                 )
+            if call[1] == ["whoami"]:
+                # A proxy-only host is exactly where whoami must reach the IdP
+                # the way the user's shell does, so the identity stage carries
+                # the proxy configuration the version stage withheld.
+                assert (
+                    runtime.kwargs[index]["env"].get("HTTPS_PROXY")
+                    == "http://secret@proxy.example:8443"
+                )
+                assert "DISPLAY" not in runtime.kwargs[index]["env"]
 
     @pytest.mark.asyncio
     async def test_probe_does_not_spawn_when_invoked_audit_fails(


### PR DESCRIPTION
## Problem

On a host that reaches the network only through an HTTP proxy, the dashboard setup gate never detects that kiro-cli is already signed in, and "Check again" does not help, so setup blocks forever.

The identity probe builds its child environment from the `_PROBE_ENV_KEYS` allowlist in `src/kiro_crew/kiro_prerequisite.py`, which carried no proxy variables. `_allowlisted_env()` therefore stripped them, the probe child could not reach the IdP, `whoami` failed, and the gate latched "not authenticated" even though the same command succeeds in the user's own shell.

## Fix

Add the proxy set as a new `_IDENTITY_PROXY_ENV_KEYS` constant, forwarded by `_identity_probe_env()` to the `whoami` identity stage only:

- `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `ALL_PROXY` and their lowercase spellings. Both cases are listed because allowlist matching is exact on POSIX and the HTTP stacks disagree on which case they honour (curl-family reads the lowercase names; Rust/Python stacks read either), so forwarding only one case reproduces the bug on half of hosts.
- `ALL_PROXY` is included deliberately: a SOCKS-only host sets it INSTEAD of the scheme-specific pair, and curl and reqwest both honour it as the fallback, so omitting it keeps the exact same defect for that host class. It also matches the repo's own canonical proxy quartet (`github_runner.GH_ENV_PASSTHROUGH`, messaging clients).
- The `--version` stage stays proxy-free for the same reason it stays credential-free (the `KIRO_API_KEY` precedent): a proxy URL can embed credentials, and `--version` is the first execution of an unvalidated candidate that needs no network. The exposure delta is confined to a candidate that already passed the version gate — the same resolved kiro-cli an ACP session already runs with the full inherited environment. This addresses the GPT round-2 blocking finding.
- `_IDENTITY_PROBE_ENV_KEYS` semantics are unchanged.

`docs/system-specs/modules/security.md` is updated in the same commit to document the two-stage posture. Probe SEL events never carry the environment.

## Tests

- New `test_identity_env_forwards_proxy_configuration_and_refuses_secrets` (windows + posix arms): asserts all 8 proxy spellings are absent from the `--version` env, present with their values in the `whoami` identity env, non-allowlisted variables (`AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `SSH_AUTH_SOCK`) refused in both, and `PATH` stays pinned to the caller's search path. Verified failing before the fix.
- `test_probe_has_paired_audit_events_and_hides_crew_homes` extended: the `--version` spawn asserts `HTTPS_PROXY` absent (as before), and the `whoami` spawn now asserts the proxy value is forwarded.
- `_IDENTITY_PROXY_ENV_KEYS` joins the env-allowlist consolidation secret-refusal claims.

Local gates: isort, flake8, mypy, pytest (full suite; the handful of failures are pre-existing host-environment issues — identical failure set without this change), docs-lint, brand gate.

Note: issue #1581 edits the same file for a different root cause; rebased onto fresh `origin/main` before each push — no collision at this time.

Closes #2648
