### PR TITLE
fix(cron): count delivery-path failures toward auto-pause (#2667)

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -248,6 +248,12 @@ class CronJob:
     # is indistinguishable from a run that produced nothing. Reset at the
     # start of every run by _run_job_isolated.
     result_produced: bool = False
+    # Runtime-only, reset by _execute_with_timeout at the start of every run:
+    # True once THIS run's failure has been counted via record_failure(). The
+    # timeout handler consults it so a run that already recorded its failure
+    # (e.g. a delivery-path exception) and then overran its deadline during
+    # cleanup is counted once, not twice.
+    failure_recorded: bool = False
     context_enabled: bool = False
     agent_id: str = ""
     approval_mode: str = ""  # "" (default/hook-based) | "auto" (auto-approve all tools)
@@ -260,7 +266,7 @@ class CronJob:
     last_posted_at: float = 0.0  # epoch when last Slack post was delivered (dedup reminder)
     last_failure_hash: str = ""  # hash of last failure notification (dedup crashes)
     last_failure_at: float = 0.0  # epoch of last failure Slack alert (dedup reminder)
-    consecutive_failures: int = 0  # count of consecutive identical failures (incl. first alert)
+    consecutive_failures: int = 0  # consecutive failed runs (any error); drives auto-pause
     skip_dates: list[str] = field(default_factory=list)  # ISO dates to skip ["2026-04-06"]
     timezone: str = ""  # IANA timezone for skip evaluation
     persistent_session: bool = True  # False → fresh ephemeral session per run
@@ -331,6 +337,7 @@ class CronJob:
         is recorded — mirroring how the effective-enabled derivation reads it back.
         """
         self.consecutive_failures += 1
+        self.failure_recorded = True
         if self.consecutive_failures >= _AUTO_PAUSE_THRESHOLD and not self.auto_paused:
             self.enabled = False
             self.auto_paused = True
@@ -2412,6 +2419,10 @@ class CronService:
     async def _execute_with_timeout(self, job: CronJob) -> None:
         """Execute a job with a timeout guard."""
         timeout = job.timeout_secs if 1 <= job.timeout_secs <= 86400 else _JOB_TIMEOUT_SECS
+        # Fresh run: no failure counted yet. The timeout handler below reads
+        # this to avoid double-counting a run that already recorded its
+        # failure and then overran the deadline during cleanup.
+        job.failure_recorded = False
         try:
             await asyncio.wait_for(self._execute(job), timeout=timeout)
         except asyncio.TimeoutError:
@@ -2429,7 +2440,12 @@ class CronService:
             job.last_run_ts = time.time()
             job.last_failure_hash = ""
             job.last_failure_at = 0.0
-            job.record_failure()
+            # Skip the count when this run already recorded its failure (a
+            # delivery-path exception followed by cleanup overrunning the
+            # deadline): one failed run is one failure, whichever handler
+            # observes it last.
+            if not job.failure_recorded:
+                job.record_failure()
             logger.error("Cron job '%s' timed out after %ds", job.name, timeout)
 
     async def _execute(self, job: CronJob) -> None:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -2874,7 +2874,16 @@ class GatewayOrchestrator:
                 fh = _result_hash(exc_summary)
                 is_dup = fh == job.last_failure_hash
                 if is_dup and time.time() - job.last_failure_at < _FAILURE_REMINDER_SECS:
-                    job.consecutive_failures += 1
+                    # record_failure() is the counter's sole owner: a suppressed
+                    # duplicate is still a failed run, so it must count toward
+                    # the auto-pause threshold like every other failure path.
+                    job.record_failure()
+                    if job.auto_paused:
+                        logger.warning(
+                            "Cron '%s' auto-paused after %d consecutive failures",
+                            job.name,
+                            job.consecutive_failures,
+                        )
                     logger.info(
                         "Cron '%s': duplicate failure #%d — suppressing Slack",
                         job.name,
@@ -2926,9 +2935,6 @@ class GatewayOrchestrator:
                     logger.debug(
                         "Dashboard notify failed in cron failure alert path", exc_info=True
                     )
-                # Compute the count this alert represents (including itself) so
-                # the re-alert message can call out persistence.
-                new_count = job.consecutive_failures + 1 if is_dup else 1
                 # Include the machine hostname so multi-gateway setups (e.g. a
                 # laptop + a cloud desktop both running KiroCrew) can tell which
                 # machine's session failed. This is framework-level: the ❌ DM
@@ -2937,9 +2943,12 @@ class GatewayOrchestrator:
                 # not from inside the cron prompt.
                 host = socket.gethostname().split(".")[0]
                 if is_dup:
+                    # +1: this run's failure is recorded below, after the
+                    # awaited Slack attempt, so the display count must include
+                    # it explicitly.
                     fail_msg = (
                         f"⏰ *Cron: {job.name}* ❌ _Job still failing on {host}"
-                        f" ({new_count} consecutive identical failures)"
+                        f" ({job.consecutive_failures + 1} consecutive failures)"
                         f" — check logs._"
                     )
                 else:
@@ -2950,9 +2959,9 @@ class GatewayOrchestrator:
                 fail_msg, _ = redact_exfiltration_urls(fail_msg)
                 fail_msg, _ = redact_credentials(fail_msg)
                 # Silent jobs still execute but suppress notifications (UI bells
-                # AND Slack DMs). We still log the failure at warning level above,
-                # and consecutive_failures still increments for the SEL event below
-                # — we just skip user-facing noise.
+                # AND Slack DMs). The failure is still logged at warning level
+                # and counted toward auto-pause above — we just skip
+                # user-facing noise.
                 slack_failed = False  # track real delivery exceptions only
                 if self.slack and not job.silent:
 
@@ -2977,14 +2986,31 @@ class GatewayOrchestrator:
                             job.name,
                             exc_info=True,
                         )
+                # record_failure() is the counter's sole owner: it continues an
+                # accumulation another writer (gate verdict, timeout) already
+                # built up instead of restarting at 1, and it is deliberately
+                # NOT gated on the alert's Slack delivery above — the run
+                # failed either way, and a job whose failure alerts also fail
+                # must still reach the auto-pause threshold. It runs AFTER the
+                # awaited Slack attempt so a timeout cancelling this handler
+                # mid-alert cannot leave the run counted here AND again by the
+                # timeout handler.
+                job.record_failure()
+                if job.auto_paused:
+                    logger.warning(
+                        "Cron '%s' auto-paused after %d consecutive failures",
+                        job.name,
+                        job.consecutive_failures,
+                    )
                 # Advance dedup state unless Slack delivery raised. "No channel
                 # available" is treated as a skip (not a failure), so dedup still
                 # advances — otherwise every identical failure re-notifies the
-                # dashboard, which is what dedup is supposed to prevent.
+                # dashboard, which is what dedup is supposed to prevent. Only the
+                # dedup fields are gated here; the failure count was already
+                # recorded above.
                 if not slack_failed:
                     job.last_failure_hash = fh
                     job.last_failure_at = time.time()
-                    job.consecutive_failures = new_count
                     # SEL logging is best-effort — never mask the original
                     # exception if audit logging itself fails.
                     try:

--- a/test/test_cron_dedup.py
+++ b/test/test_cron_dedup.py
@@ -11,7 +11,7 @@ import asyncio
 import socket
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from kiro_crew.cron import CronJob, CronSchedule
+from kiro_crew.cron import _AUTO_PAUSE_THRESHOLD, CronJob, CronSchedule
 from kiro_crew.slack.gateway import _result_hash
 
 
@@ -338,8 +338,10 @@ class TestCronFailureDedup:
         _run_callback_raising(gw, job, ValueError("different"))
         # Different exception → not a dup → fresh alert
         assert gw.slack.post_message.await_count == 2
-        # Counter reset on new alert
-        assert job.consecutive_failures == 1
+        # The counter tracks consecutive failed RUNS, not identical errors:
+        # a distinct new error continues the accumulation toward auto-pause
+        # instead of resetting it to 1.
+        assert job.consecutive_failures == 2
 
     def test_reminder_window_reexpired_realerts(self) -> None:
         gw = _make_gateway()
@@ -386,7 +388,10 @@ class TestCronFailureDedup:
         _run_callback_raising(gw, job, RuntimeError("boom"))
         # Slack delivery failed → dedup state NOT advanced → next run re-alerts
         assert job.last_failure_hash == ""
-        assert job.consecutive_failures == 0
+        # But the run still FAILED: auto-pause accounting is not gated on the
+        # alert being deliverable, or a job whose alerts also fail would never
+        # accumulate toward the threshold.
+        assert job.consecutive_failures == 1
 
     def test_no_channel_still_advances_dedup_state(self) -> None:
         """When Slack is configured but no channel can be resolved, dedup must
@@ -406,6 +411,85 @@ class TestCronFailureDedup:
         # Second identical failure → suppressed (dedup works)
         _run_callback_raising(gw, job, RuntimeError("boom"))
         assert job.consecutive_failures == 2
+
+
+class TestCronDeliveryFailureAutoPause:
+    """Delivery-path failures feed the single failure accountant.
+
+    The turn-level ``except`` in the gateway's cron delivery path must route
+    the counter through ``CronJob.record_failure()`` so a job that fails by
+    raising reaches the auto-pause threshold like every other failure path,
+    and so a count accumulated by another writer (gate verdict, timeout)
+    survives a later raise instead of being reset to 1.
+    """
+
+    def test_repeated_identical_delivery_exceptions_auto_pause(self) -> None:
+        """Auto-pause is reachable purely through repeated delivery exceptions."""
+        gw = _make_gateway()
+        gw.slack.post_message = AsyncMock()
+        job = _make_job()
+        exc = RuntimeError("boom")
+        for _ in range(_AUTO_PAUSE_THRESHOLD):
+            _run_callback_raising(gw, job, exc)
+        assert job.consecutive_failures == _AUTO_PAUSE_THRESHOLD
+        assert job.auto_paused is True
+        assert job.enabled is False
+
+    def test_repeated_distinct_delivery_exceptions_auto_pause(self) -> None:
+        """Distinct errors accumulate too — no reset-to-1 escape from the net."""
+        gw = _make_gateway()
+        gw.slack.post_message = AsyncMock()
+        job = _make_job()
+        for i in range(_AUTO_PAUSE_THRESHOLD):
+            _run_callback_raising(gw, job, RuntimeError(f"boom {i}"))
+        assert job.consecutive_failures == _AUTO_PAUSE_THRESHOLD
+        assert job.auto_paused is True
+        assert job.enabled is False
+
+    def test_accumulated_count_survives_delivery_raise(self) -> None:
+        """A count another writer built up is continued, not clobbered to 1."""
+        gw = _make_gateway()
+        gw.slack.post_message = AsyncMock()
+        job = _make_job()
+        # Prior failures recorded by another owner of the counter (e.g. the
+        # timeout path or the gate-verdict path).
+        for _ in range(3):
+            job.record_failure()
+        assert job.consecutive_failures == 3
+        _run_callback_raising(gw, job, RuntimeError("fresh delivery error"))
+        assert job.consecutive_failures == 4
+        assert job.auto_paused is False
+
+    def test_no_auto_pause_below_threshold(self) -> None:
+        gw = _make_gateway()
+        gw.slack.post_message = AsyncMock()
+        job = _make_job()
+        exc = RuntimeError("boom")
+        for _ in range(_AUTO_PAUSE_THRESHOLD - 1):
+            _run_callback_raising(gw, job, exc)
+        assert job.consecutive_failures == _AUTO_PAUSE_THRESHOLD - 1
+        assert job.auto_paused is False
+        assert job.enabled is True
+
+    def test_failure_recorded_after_alert_await(self) -> None:
+        """The counter moves only after the awaited Slack alert.
+
+        A run timeout cancelling the callback mid-alert must not leave the
+        run counted here AND again by the timeout handler's own
+        record_failure() — so at alert time the counter must still hold the
+        pre-run value.
+        """
+        gw = _make_gateway()
+        job = _make_job()
+        seen: list[int] = []
+
+        async def _capture(channel: str, msg: str) -> None:
+            seen.append(job.consecutive_failures)
+
+        gw.slack.post_message = AsyncMock(side_effect=_capture)
+        _run_callback_raising(gw, job, RuntimeError("boom"))
+        assert job.consecutive_failures == 1
+        assert seen == [0]
 
 
 class TestCronFailurePersistence:

--- a/test/test_cron_timeout_autopause_424.py
+++ b/test/test_cron_timeout_autopause_424.py
@@ -57,3 +57,26 @@ async def test_timeout_clears_failure_dedup_hash(tmp_path, monkeypatch):
     assert job.last_failure_at == 0.0
     # ...but the failure still counted.
     assert job.consecutive_failures == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_after_recorded_failure_counts_once(tmp_path, monkeypatch):
+    """One failed run is one failure, even when two handlers observe it.
+
+    A delivery-path exception records the failure inside the callback; if the
+    run then overruns its deadline during cleanup, the TimeoutError handler
+    must not count the same run a second time.
+    """
+    svc = CronService(base_dir=tmp_path)
+    job = CronJob(id="j3", name="slow", message="hi", timeout_secs=1)
+
+    async def _fail_then_timeout(coro, timeout):
+        coro.close()
+        # The callback counted this run's failure before cleanup overran.
+        job.record_failure()
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(cron_mod.asyncio, "wait_for", _fail_then_timeout)
+    await svc._execute_with_timeout(job)
+    assert job.consecutive_failures == 1
+    assert job.last_status == "error"

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -2100,6 +2100,7 @@ class TestCronFailurePaths:
         job.last_failure_hash = ""
         job.last_failure_at = 0.0
         job.consecutive_failures = 0
+        job.auto_paused = False
         job._acp_retried = False
 
         with patch(
@@ -2114,7 +2115,9 @@ class TestCronFailurePaths:
                         await callback(job)
 
         orch.slack.post_message.assert_awaited()
-        assert job.consecutive_failures == 1
+        # Failure accounting is single-owned by CronJob.record_failure() so the
+        # auto-pause threshold stays reachable from the delivery path.
+        job.record_failure.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_cron_callback_failure_dedup_suppresses(self):
@@ -2165,6 +2168,7 @@ class TestCronFailurePaths:
         job.last_failure_hash = _result_hash("RuntimeError: boom")
         job.last_failure_at = time.time()
         job.consecutive_failures = 1
+        job.auto_paused = False
         job._acp_retried = False
 
         with patch(
@@ -2180,7 +2184,9 @@ class TestCronFailurePaths:
 
         # Slack should NOT be called (suppressed)
         orch.slack.post_message.assert_not_awaited()
-        assert job.consecutive_failures == 2
+        # A suppressed duplicate still counts toward auto-pause via the
+        # counter's single owner.
+        job.record_failure.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_cron_multi_agent_sequence(self):


### PR DESCRIPTION
## Problem

Cron failure accounting had two independent writers of the same counter. `CronJob.record_failure()` increments `consecutive_failures` and auto-pauses at the threshold, and is used by the command path, the script path, and the timeout path (#424). The turn-level `except` in the gateway's cron delivery path instead assigned `job.consecutive_failures` directly — `+= 1` in the dedup-suppress branch, `= 1` in the fresh-alert branch — and never called `record_failure()`.

Two consequences:
- A cron whose failure mode is an exception raised during the LLM delivery turn **never auto-pauses**, no matter how many times it crash-loops: the threshold check lives only in `record_failure()`, which this path skipped.
- A count another writer legitimately accumulated (timeout path, command/script path) was **clobbered back to 1** by the fresh-alert branch on the next delivery-path raise, losing the accumulation toward auto-pause.

## Why it matters

Auto-pause is the safety net against crash-looping jobs. A job stuck in a perpetual delivery-exception loop today runs forever, firing a failure notification (or a suppressed dup) every cycle with no auto-pause — exactly the chronic failure mode the net exists to catch. This is the remaining third writer after #424 fixed the timeout path the same way.

## Fix (symptoms → root cause → change)

Root cause: the counter had no single owner, so the delivery path's direct assignments bypassed the threshold logic entirely. The change gives `CronJob.record_failure()` sole ownership:

- **Dedup-suppress branch** (`gateway.py`): `job.consecutive_failures += 1` → `job.record_failure()`. Same count, but the auto-pause threshold is now reachable. Mirrors the script-path shape (#424): log a warning when the call trips auto-pause.
- **Fresh-alert branch**: the `new_count = ... if is_dup else 1` reset is replaced by `job.record_failure()`. The dedup fields (`last_failure_hash`, `last_failure_at`) stay gated on Slack delivery success exactly as before; only the counter assignment moves out.

### Recorded decisions (per the issue's ask)

1. **A duplicate delivery failure counts as a continuation of the accumulation, not a fresh failure.** A suppressed dup is still a failed run; it increments the streak (this is what the suppress branch already did — the behavior is preserved, now via the single owner).
2. **A distinct new error also continues the accumulation instead of resetting to 1.** `consecutive_failures` means consecutive failed *runs*, not consecutive *identical* errors — which is already the semantic every other writer (command, script, timeout) uses. The re-alert message wording drops "identical" accordingly, and the field's doc comment in `cron.py` is updated to match. Dedup/suppression behavior itself is unchanged: identity still drives *notification* suppression via `last_failure_hash`; it just no longer drives *accounting*.
3. **Counting is not gated on the alert's Slack delivery.** The run failed whether or not the alert about it could be posted; a job whose failure alerts also fail must still reach the auto-pause threshold. Only the dedup fields remain gated (so an undelivered alert retries next run).

The threshold value is untouched.

## Tests

New `TestCronDeliveryFailureAutoPause` in `test/test_cron_dedup.py` (all verified failing on unmodified code):
- `test_repeated_identical_delivery_exceptions_auto_pause` — auto-pause reached purely through repeated delivery exceptions (1 alert + 4 suppressed dups).
- `test_repeated_distinct_delivery_exceptions_auto_pause` — distinct errors accumulate too; no reset-to-1 escape from the net.
- `test_accumulated_count_survives_delivery_raise` — a count built up by another writer (3) is continued (4) by a later delivery raise, not clobbered to 1.
- `test_no_auto_pause_below_threshold` — threshold-1 failures do not pause.

Updated to the unified semantics: `test_different_failure_re_alerts` (counter continues across distinct errors), `test_slack_failure_does_not_advance_dedup_state` (dedup hash still not advanced; the failed run still counts), and the two MagicMock-based `test_slack_gateway.py` tests now pin the `record_failure()` delegation.

## Manual verification

N/A — unit coverage exercises the real callback closure end-to-end through `_init_cron` with real `CronJob` instances; the persistence of `consecutive_failures`/`auto_paused` after a failed run is pre-existing (`_merge_job_result`) and already covered by `test_cron_autopause_persist.py`.

Closes #2667
