### PR TITLE
test(crew-companion): make tick recovery deterministic

### DIFF
--- a/src/kiro_crew/apps/builtins/crew_companion/tests/test_store.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/tests/test_store.py
@@ -388,16 +388,25 @@ class TestLifecycle:
         s.load()
         calls = {"n": 0}
 
+        class ScriptedStop:
+            def __init__(self) -> None:
+                self.waits = 0
+
+            def wait(self, _timeout: float) -> bool:
+                self.waits += 1
+                return self.waits > 2
+
         def boom() -> None:
             calls["n"] += 1
             raise RuntimeError("tick exploded")
 
+        scripted_stop = ScriptedStop()
+        monkeypatch.setattr(s, "_stop", scripted_stop)
         monkeypatch.setattr(s, "tick", boom)
-        s.start()
-        # The loop waits TICK_SECONDS before the first call; give it two chances.
-        time_mod.sleep(2.5)
-        s.stop()
-        assert calls["n"] >= 2, f"loop stopped after {calls['n']} call(s)"
+        s._run()
+
+        assert calls["n"] == 2
+        assert scripted_stop.waits == 3
 
 
 class TestPetPosition:


### PR DESCRIPTION
## Problem

The Crew Companion lifecycle test verifies that one throwing tick does not silently stop the reminder loop.

The test currently starts a background thread, sleeps for 2.5 seconds, and expects at least two ticks from a one-second interval. On a loaded Windows runner, thread scheduling can produce only one tick before the fixed sleep ends, even though the loop correctly catches the exception and continues.

This makes the test depend on host scheduling rather than the recovery behavior it is intended to verify.

## Change

Replace the real thread and wall-clock wait with a scripted stop event:

- allow exactly two loop iterations;
- make both ticks raise;
- exit on the third stop check;
- assert that both failures were survived.

The existing start/stop idempotence test continues to cover the threaded lifecycle. Production behavior is unchanged.

## Validation

- 289 Crew Companion tests passed with 8 workers
- isort and flake8 passed
- mutation verification confirmed the test fails when the production exception boundary is removed
- Screenshots: N/A — test-only backend change
