### PR TITLE
test(website): give the broadcast spec a real dispatch response

### DIFF
--- a/website/src/test/UseMeetingSessionCoverage.test.tsx
+++ b/website/src/test/UseMeetingSessionCoverage.test.tsx
@@ -471,6 +471,18 @@ describe('useMeetingSession lifecycle actions', () => {
   })
 
   it('broadcasts to the listening agents as chat', async () => {
+    // The segment is load-bearing: the source commits it into the transcript
+    // cache, so a response without one routes the mutation into onError.
+    apiMocks.dispatch.mockResolvedValueOnce({
+      dispatched: 2,
+      text: 'please summarize',
+      segment: {
+        id: 'broadcast-1',
+        timestamp: '2026-01-01T00:00:00Z',
+        source: 'typed',
+        text: 'please summarize',
+      },
+    })
     const view = await mountLoaded()
 
     await act(async () => {


### PR DESCRIPTION
## What

`UseMeetingSessionCoverage.test.tsx` pins the broadcast success path to a specific notice — `broadcastSent` at level `info`. That test currently fails on `main` with `broadcastFailed` at level `error`.

The broadcast mutation commits the dispatched line into the transcript cache before notifying, reading `segment` off the response. `DispatchResponse` declares `segment: TranscriptSegment` non-optional and `dispatch` is typed `post<DispatchResponse>`, so the source is entitled to read it unguarded. The spec's shared mock resolves every api call to a bare `{}`, so `segment` arrived `undefined` and the transcript merge threw on `segment.id`. React Query treats a throw inside `onSuccess` as a failed mutation, which is why the success path emitted the failure notice.

Confirmed by instrumenting the mutation's `onError`: `TypeError: Cannot read properties of undefined (reading 'id') at mergeTranscriptSegments`.

The spec is the stale side, not the source, so this fixes the mock rather than adding a guard the types say is unnecessary.

## The change

One file, test-only. Gives that one test a dispatch response shaped like the real one, scoped with `mockResolvedValueOnce` so the table-driven failure case still rejects and still fails for its own reason — verified by making `dispatch` resolve with a valid segment in that row and watching it fail, so its green depends on the rejection rather than on this mock.

The notify assertion is untouched: it still pins both the message and the level rather than merely that `notify` was called.

## Test results

- The single test: passes (was failing).
- The whole file: 56/56.
- Full frontend suite: 15276 passed, 1 failed.

## The remaining failure is not this one

`main` is red on **two** independent frontend tests. This PR fixes one of them. The other is `UseWebSocketCoverage.test.tsx:474` (`last_ts`), which is already fixed by open PR #2712 and is unrelated to this change.

A fork PR's base must be a branch in the base repo, so this cannot be stacked onto #2712's branch. `Frontend Tests` will therefore report that one failure here regardless. This PR goes green on rebase once #2712 lands.
