### PR TITLE
feat: consolidate cron-session work into agent memory

### DIFF
--- a/src/kiro_crew/cron_memory.py
+++ b/src/kiro_crew/cron_memory.py
@@ -1,0 +1,149 @@
+"""Bridge cron-session work into the agent memory system.
+
+Agent-mode (message) cron runs historically wrote only to the cron
+execution-history store (``cron-history/{job_id}.jsonl``), which has no
+connection to :class:`~kiro_crew.history.HistoryConsolidator` or the memory
+stores.  A cron could root-cause a defect and open a PR, yet leave no trace in
+memory — a later interactive session would re-derive the same work from
+scratch.
+
+This module records each successful agent-mode run as a user/assistant
+exchange in the canonical :class:`~kiro_crew.history.ConversationLog` under a
+DEDICATED stable key (``cron-mem:{job_id}``) and immediately triggers
+fire-and-forget consolidation, so the run flows through the same
+history/semantic/episodic/lesson extraction as interactive sessions.
+
+Why a dedicated key rather than the existing ``cron:{job_id}``: that key's
+emptiness for hidden crons is a documented invariant (see the slot-creation
+comment in ``slack/gateway.py``) — it exists solely to feed a dashboard
+follow-up turn.  Overloading it would replay every recorded run into the
+follow-up agent's context.  ``cron-mem:{job_id}`` is written for ALL
+agent-mode jobs (silent, hidden, and ``persistent_session=False`` included)
+and read only by the consolidator.
+
+Noise control deliberately does NOT live here: recording is default-on, and
+significance is judged at consolidation time (a trivial run distills to
+nothing — see the empty-``history_entry`` contract in
+``HistoryConsolidator._consolidate``), never configured per job.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Coroutine
+
+    from kiro_crew.cron import CronJob
+    from kiro_crew.history import ConversationLog
+
+logger = logging.getLogger(__name__)
+
+#: Dedicated ConversationLog key prefix for cron memory transcripts.
+CRON_MEMORY_KEY_PREFIX = "cron-mem:"
+
+# Strong references for detached recording tasks: asyncio keeps only weak
+# refs to tasks, so a fire-and-forget task without an anchor can be
+# garbage-collected mid-flight. Bounded by the number of concurrently
+# finishing cron runs; entries remove themselves on completion.
+_DETACHED_TASKS: set["asyncio.Task[Any]"] = set()
+
+
+def _detach_cron_memory_task(coro: "Coroutine[Any, Any, bool]") -> None:
+    """Run a recording coroutine as a detached task, outside any timeout.
+
+    The cron executor calls this instead of awaiting so the transcript write
+    never spends the job's execution deadline (a run finishing near its
+    timeout would otherwise be marked timed out by its own memory
+    bookkeeping). ``record_cron_run_to_memory`` already catches and logs its
+    own failures; the callback guard here covers only cancellation and
+    truly unexpected exits.
+    """
+    task = asyncio.get_running_loop().create_task(coro)
+    _DETACHED_TASKS.add(task)
+
+    def _done(t: "asyncio.Task[Any]") -> None:
+        _DETACHED_TASKS.discard(t)
+        if t.cancelled():
+            logger.debug("Detached cron memory recording cancelled")
+        elif t.exception() is not None:
+            logger.warning(
+                "Detached cron memory recording failed", exc_info=t.exception()
+            )
+
+    task.add_done_callback(_done)
+
+
+#: Placeholder the executor substitutes for an empty model response — carries
+#: no information worth remembering, so it is treated as an empty result.
+_EMPTY_RESULT_PLACEHOLDER = "_No response._"
+
+
+def cron_memory_key(job_id: str) -> str:
+    """Return the dedicated memory-transcript key for *job_id*."""
+    return f"{CRON_MEMORY_KEY_PREFIX}{job_id}"
+
+
+async def record_cron_run_to_memory(
+    conversation_log: "ConversationLog | None",
+    job: "CronJob",
+    result_text: str | None,
+) -> bool:
+    """Record a successful agent-mode cron run for later consolidation.
+
+    Appends the run as a user turn (the job's message) and an assistant turn
+    (the run's result) under :func:`cron_memory_key` — and nothing else. The
+    transcript FILE is the durable enrollment record: the consolidator's
+    heartbeat sweep (``HistoryConsolidator.sweep_cron_memory_keys``) discovers
+    ``cron-mem:*`` transcripts from disk, so consolidation needs no
+    in-process registration to survive gateway restarts or shutdowns, and a
+    one-shot job's exchange is picked up even after its cron is deleted.
+
+    Best-effort by contract: every failure is logged and swallowed — memory
+    recording must never fail, delay, or otherwise alter the cron run that
+    produced the result.  Returns ``True`` when the exchange was recorded,
+    ``False`` on skip or failure (callers only use this for logging/tests).
+    """
+    try:
+        if conversation_log is None:
+            return False
+        if not result_text or not result_text.strip():
+            return False
+        if result_text.strip() == _EMPTY_RESULT_PLACEHOLDER:
+            return False
+        key = cron_memory_key(job.id)
+        # Same redaction precedent as the other cron result sinks (dashboard
+        # inject, Slack delivery): job.message and the result are LLM/user
+        # controllable, so scrub exfiltration URLs + credentials before they
+        # become durable transcript rows.
+        safe_msg, _ = redact_exfiltration_urls(job.message or "")
+        safe_msg, _ = redact_credentials(safe_msg)
+        safe_result, _ = redact_exfiltration_urls(result_text)
+        safe_result, _ = redact_credentials(safe_result)
+        log = conversation_log  # narrowed local: closure keeps the non-None type
+
+        def _append_exchange() -> None:
+            # Both rows in ONE worker-thread call under atomic_appends: a
+            # single await point means cancellation lands before the thread
+            # starts or after it completes (never an unmatched user turn),
+            # and the group lock prevents two concurrent detached recordings
+            # from interleaving into user/user/assistant/assistant.
+            with log.atomic_appends(key):
+                log.append(key, "user", safe_msg, agent=job.agent_id or None)
+                log.append(key, "assistant", safe_result)
+
+        await asyncio.to_thread(_append_exchange)
+        # No trigger, no registration: the heartbeat's disk-backed sweep
+        # (sweep_cron_memory_keys) discovers this transcript by its prefix.
+        return True
+    except Exception:
+        logger.warning(
+            "Cron memory recording failed for job %s (run unaffected)",
+            getattr(job, "id", "?"),
+            exc_info=True,
+        )
+        return False

--- a/src/kiro_crew/heartbeat.py
+++ b/src/kiro_crew/heartbeat.py
@@ -192,6 +192,9 @@ class HeartbeatService:
         # Check for idle sessions needing history consolidation (every tick)
         if self._consolidator:
             self._consolidator.check_idle_sessions()
+            # Cron-memory transcripts are discovered from disk (the file is
+            # the durable enrollment record) — off-loop scan, same gates.
+            self._consolidator.sweep_cron_memory_keys()
 
     async def _run_one_task(self, task_text: str, deliver: str) -> str | None:
         """Execute a single heartbeat task (used by gather).

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -21,7 +21,7 @@ from collections import OrderedDict
 from collections.abc import Callable, Container, Iterator
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Generic, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeVar
 
 from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
@@ -937,6 +937,13 @@ def monotonic_transcript_ts(previous: str | None, now: datetime) -> str:
 def _safe_key(key: str) -> str:
     """Convert a session key (e.g. Slack thread_ts) to a safe filename."""
     return re.sub(r"[^\w\-.]", "_", key)
+
+
+#: Session-key prefix whose transcripts the idle sweep discovers from DISK
+#: (see HistoryConsolidator.sweep_cron_memory_keys). Mirrors
+#: kiro_crew.cron_memory.CRON_MEMORY_KEY_PREFIX; duplicated as a literal
+#: because cron_memory imports from this module.
+_CRON_MEMORY_SWEEP_PREFIX = "cron-mem:"
 
 
 def transcript_stem(key: str) -> str:
@@ -2162,6 +2169,24 @@ class ConversationLog:
         except (TypeError, ValueError, OverflowError):
             offset = 0
         return len(messages), max(0, len(messages) - offset)
+
+    def keys_with_prefix(self, prefix: str) -> list[str]:
+        """Transcript keys (file stems) starting with *prefix*.
+
+        Disk-backed session discovery for the consolidator's cron-memory
+        sweep: the transcript FILE is the enrollment record, so discovery
+        survives restarts and needs no in-process registration. No freshness
+        filter — the per-key locks make the append pair atomic and
+        consolidation routinely reads transcripts that live sessions are
+        appending to, so a concurrent write is safe; an mtime gate would
+        permanently starve any cron whose interval is shorter than the gate.
+        Stems are ``_safe_key``-stable (a sanitized stem sanitizes to
+        itself), the same convention the ``kirocrew consolidate --all`` CLI
+        path relies on. Call from a worker thread — this scans a directory.
+        """
+        if not self._dir.exists():
+            return []
+        return [p.stem for p in self._dir.glob(f"{_safe_key(prefix)}*.jsonl")]
 
     def consolidation_retry_state(
         self, key: str, message_count: int | None = None
@@ -4122,6 +4147,9 @@ class HistoryConsolidator:
         self._tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
         # Track last activity per session for idle-based history consolidation
         self._last_activity: dict[str, float] = {}
+        # Single-flight latch for the disk-backed cron-memory sweep: one scan
+        # task at a time regardless of heartbeat cadence.
+        self._cron_sweep_inflight = False
         self._history_consolidated: dict[str, float] = {}  # key → last history consolidation time
         # Separate offset for prefs-only consolidation (doesn't advance main offset)
         self._prefs_offset: dict[str, int] = {}
@@ -4269,6 +4297,46 @@ class HistoryConsolidator:
             max(0.0, retry_at - _time.time()),
         )
 
+    def sweep_cron_memory_keys(self) -> None:
+        """Discover cron-memory transcripts from DISK and gate-spawn each.
+
+        The transcript file itself is the durable enrollment record — no
+        in-process registration exists to lose. This makes the mechanism
+        restart-proof (a one-shot cron's transcript written seconds before a
+        gateway restart is discovered on the next boot's first sweep) and
+        shutdown-tolerant (a recording whose atomic write completed is never
+        orphaned; one that did not complete never existed).
+
+        Loop-safety: the directory scan stats files, so it runs in a worker
+        thread; only the in-memory gates and task spawns happen on the loop.
+        Cadence is owned by the existing per-key machinery — the
+        ``_history_consolidated`` once-per-idle-window throttle, the
+        ``_running`` reservation, and the off-loop ``unconsolidated < 1``
+        no-op — NOT by file mtime as an idle anchor: a frequent cron touches
+        its transcript every run, so an mtime-idleness rule would starve
+        exactly the jobs this feature exists for.
+        Concurrent appends are safe: the per-key locks make each exchange atomic.
+        """
+        if self._cron_sweep_inflight:
+            return
+        self._cron_sweep_inflight = True
+
+        async def _scan_and_spawn() -> None:
+            try:
+                keys = await asyncio.to_thread(
+                    self._log.keys_with_prefix,
+                    _CRON_MEMORY_SWEEP_PREFIX,
+                )
+                now = _time.time()
+                for key in keys:
+                    self._spawn_idle_consolidation(key, now)
+            finally:
+                self._cron_sweep_inflight = False
+
+        t = asyncio.create_task(_scan_and_spawn())
+        self._tasks.add(t)
+        t.add_done_callback(self._tasks.discard)
+
     def maybe_consolidate(self, key: str) -> None:
         """Fire preferences/projects consolidation if message threshold exceeded."""
         self._last_activity[key] = _time.time()
@@ -4308,46 +4376,95 @@ class HistoryConsolidator:
         t.add_done_callback(_on_done)
 
     def check_idle_sessions(self) -> None:
-        """Check all tracked sessions for idle-based history consolidation."""
+        """Check all tracked sessions for idle-based history consolidation.
+
+        Loop-safety: this sweep runs on the gateway event loop every heartbeat
+        tick, so it touches ONLY in-memory state (timestamps, running set).
+        The transcript-sized eligibility reads happen inside the spawned task
+        via a worker thread (see ``_idle_consolidate_after_prechecks``) — a
+        large session transcript (e.g. an accumulated cron-memory log) never
+        stalls the loop.
+        """
         now = _time.time()
         for key, last in list(self._last_activity.items()):
             if now - last < self._history_idle_secs:
                 continue
-            total, unconsolidated = self._log.consolidation_counts(key)
+            self._spawn_idle_consolidation(key, now)
+
+    def _spawn_idle_consolidation(self, key: str, now: float) -> None:
+        """Gate and spawn one idle-consolidation task (loop-safe, shared).
+
+        Used by the idle sweep and by :meth:`note_activity`. The gates here
+        are purely in-memory (throttle timestamp + running set); ALL
+        transcript- and metadata-backed eligibility — including the durable
+        retry backoff — is evaluated off-loop inside the spawned task, where
+        the extent-aware ``retry_eligible(message_count=total)`` check can
+        release a capped span whose transcript has since grown. An on-loop
+        extent-blind backoff pre-gate would permanently starve exactly that
+        case.
+        """
+        if (
+            now - self._history_consolidated.get(key, 0) < self._history_idle_secs
+            or key in self._running
+        ):
+            return
+        self._running.add(key)
+        t = asyncio.create_task(self._idle_consolidate_after_prechecks(key, now))
+        self._tasks.add(t)
+
+        def _on_idle_done(
+            fut: asyncio.Task,  # type: ignore[type-arg]
+            k: str = key,
+            ts: float = now,
+        ) -> None:
+            self._tasks.discard(fut)
             if (
-                unconsolidated < 1
-                or now - self._history_consolidated.get(key, 0) < self._history_idle_secs
-                or key in self._running
-                # Durable backoff, checked last so it only costs a metadata read
-                # once the cheap conditions pass. The in-memory throttle above is
-                # set only when the task ends without an exception and is lost on
-                # restart, so it alone cannot stop a repeatedly failing span from
-                # re-billing an LLM turn every tick. *total* comes from the read
-                # above, so the check adds no transcript read on the loop.
-                or not self.retry_eligible(key, now, message_count=total)
+                not fut.cancelled()
+                and fut.exception() is None
+                # A refusal (or a precheck no-op, which reuses the marker)
+                # is not a completed pass; setting the throttle for it
+                # would delay the retry past the backoff deadline.
+                and fut.result() is not _CONSOLIDATION_REFUSED
             ):
-                continue
-            self._running.add(key)
-            captured_now = now
-            t = asyncio.create_task(self._consolidate(key, include_history=True))
-            self._tasks.add(t)
+                self._history_consolidated[k] = ts
 
-            def _on_idle_done(
-                fut: asyncio.Task,  # type: ignore[type-arg]
-                k: str = key,
-                ts: float = captured_now,
-            ) -> None:
-                self._tasks.discard(fut)
-                if (
-                    not fut.cancelled()
-                    and fut.exception() is None
-                    # A refusal is not a completed pass; setting the throttle
-                    # for it would delay the retry past the backoff deadline.
-                    and fut.result() is not _CONSOLIDATION_REFUSED
-                ):
-                    self._history_consolidated[k] = ts
+        t.add_done_callback(_on_idle_done)
 
-            t.add_done_callback(_on_idle_done)
+    async def _idle_consolidate_after_prechecks(self, key: str, now: float) -> Any:
+        """Off-loop eligibility prechecks, then the real consolidation.
+
+        ``consolidation_counts`` reads the whole transcript, so it runs in a
+        worker thread; the sweep that spawned this task never blocks on it.
+        The ``finally`` releases the ``_running`` reservation on EVERY exit —
+        including a precheck read failure — so a transient error cannot
+        strand the key and make later sweeps skip it forever. (The delegate
+        path's ``_consolidate`` also discards in its own finally; a second
+        discard is a no-op.) A precheck no-op returns
+        ``_CONSOLIDATION_REFUSED`` so the done callback leaves the idle
+        throttle unset.
+        """
+        try:
+            total, unconsolidated = await asyncio.to_thread(
+                self._log.consolidation_counts, key
+            )
+            if unconsolidated < 1:
+                # Fully consolidated for now — stay ENROLLED. Evicting here
+                # would race a concurrent append + note_activity landing
+                # after the zero-count read (setdefault keeps the old anchor,
+                # so no anchor comparison can detect it) and silently drop
+                # that content from memory. The steady-state cost of staying
+                # enrolled is one off-loop counts read per tick — the same
+                # read the pre-existing sweep did per tick, minus the loop
+                # stall.
+                return _CONSOLIDATION_REFUSED
+            if not self.retry_eligible(key, now, message_count=total):
+                # Backed-off span: refuse without touching enrollment. This
+                # extent-aware check is the ONLY backoff gate — it can
+                # release a capped span whose transcript has since grown.
+                return _CONSOLIDATION_REFUSED
+            return await self._consolidate(key, include_history=True)
+        finally:
+            self._running.discard(key)
 
     def consolidate_session(self, key: str) -> None:
         """Trigger history consolidation for *key* (fire-and-forget).
@@ -4521,7 +4638,10 @@ class HistoryConsolidator:
                 keys.append(
                     '"history_entry": A concise paragraph (2-5 sentences) summarizing '
                     "what happened. Use local time [YYYY-MM-DD HH:MM]. Focus on "
-                    "decisions, outcomes, facts. Use user's real name if known."
+                    "decisions, outcomes, facts. Use user's real name if known. "
+                    "If the conversation contains nothing worth remembering (a "
+                    "routine or trivial exchange with no decisions, outcomes, or "
+                    'new facts), return an empty string "" instead.'
                 )
 
             # Structured memory extraction (when vector store is available)

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -752,6 +752,11 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         "apps/builtins/auto_improvement/spine/push_policy.py",
         # Internal persistence / indexing (the on-disk or in-memory copy), whose
         # user-visible surface is already covered by a registered sink.
+        # cron_memory.py redacts a cron run's exchange before persisting it into
+        # ConversationLog for the memory consolidator — internal storage feeding
+        # consolidation, not an output to a human; the run's user-visible copies
+        # (Slack/bell notification, dashboard inject) are the registered sinks.
+        "cron_memory.py",
         "dashboard/chat_folders.py",
         "dashboard/chat_fork.py",
         "dashboard/chat_handlers.py",

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -80,6 +80,7 @@ from kiro_crew.constants import CHAT_TURN_TIMEOUT, DATA_WARNING
 from kiro_crew.context import ContextBuilder
 from kiro_crew.context_management import summarize_result
 from kiro_crew.cron import CronJob, CronService, CronStoreBusy, build_cron_session_context
+from kiro_crew.cron_memory import _detach_cron_memory_task, record_cron_run_to_memory
 from kiro_crew.cron_script import run_command_sandboxed, run_script_sandboxed
 from kiro_crew.dashboard import cautious_boot, start_dashboard
 from kiro_crew.dashboard.chat_persistence import rehydrate_slot_from_history_async
@@ -2546,6 +2547,20 @@ class GatewayOrchestrator:
                 if _seq_downgraded:
                     result_text = _annotate_model_downgrade(result_text)
                 job.set_run_result(result_text)
+                # Record the run into agent memory (dedicated cron-mem:{id}
+                # key + fire-and-forget consolidation). Default-on for every
+                # agent-mode run; best-effort — never fails the run. DETACHED
+                # task: the transcript write must not spend the job's
+                # execution deadline — a run finishing near its timeout would
+                # otherwise be marked timed out by its own bookkeeping. See
+                # kiro_crew.cron_memory for the rationale.
+                _detach_cron_memory_task(
+                    record_cron_run_to_memory(
+                        getattr(self, "conv_log", None),
+                        job,
+                        result_text,
+                    )
+                )
                 return result_text
 
             # ── Single-agent path (existing behavior) ──
@@ -2608,6 +2623,25 @@ class GatewayOrchestrator:
                     result_text = _annotate_model_downgrade(result_text)
 
                 job.set_run_result(result_text)
+
+                # Record the run into agent memory (dedicated cron-mem:{id}
+                # key + fire-and-forget consolidation) BEFORE the finally
+                # block's session reset. Default-on for every agent-mode run
+                # — including silent, hidden, and persistent_session=False
+                # jobs, which all return early below without ever reaching
+                # the delivery sites. Best-effort — never fails the run.
+                # DETACHED task: must not spend the job's execution deadline
+                # (see the single-agent site). The task holds its own strong
+                # reference, so the finally block's session reset cannot
+                # cancel a write already dispatched. See kiro_crew.cron_memory
+                # for the rationale.
+                _detach_cron_memory_task(
+                    record_cron_run_to_memory(
+                        getattr(self, "conv_log", None),
+                        job,
+                        result_text,
+                    )
+                )
 
                 # Context-meter reading for the dashboard slot, captured NOW:
                 # the finally block below resets this session, so the open

--- a/test/test_cron_memory.py
+++ b/test/test_cron_memory.py
@@ -1,0 +1,372 @@
+"""Tests for cron-session memory consolidation (kiro_crew.cron_memory).
+
+Agent-mode cron runs used to write only to CronHistoryStore, which has no
+connection to HistoryConsolidator / the memory stores — work a cron did (e.g.
+root-causing a defect and opening a PR) left no trace in memory, and a later
+interactive session would re-derive it from scratch.
+
+Covers:
+- record_cron_run_to_memory: exchange appended under cron-mem:{job_id} +
+  consolidation triggered, for silent / hidden / persistent_session=False jobs
+- nothing recorded for empty results or the "_No response._" placeholder
+- recording failures (append or consolidator) never propagate
+- credential redaction on the stored transcript rows
+- gateway executor wiring: single-agent AND sequential paths record + trigger;
+  failed runs record nothing; a consolidation error doesn't break the run or
+  the session reset
+- salience contract: the consolidation prompt authorizes an empty
+  history_entry, and an empty history_entry writes no history
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.cron import CronJob, CronSchedule
+from kiro_crew.cron_memory import cron_memory_key, record_cron_run_to_memory
+from kiro_crew.history import ConversationLog, HistoryConsolidator
+
+
+def _make_job(**overrides):
+    defaults = dict(
+        id="j1",
+        name="test-job",
+        message="check the logs",
+        schedule=CronSchedule(kind="every", every_secs=300),
+        approval_mode="auto",
+    )
+    defaults.update(overrides)
+    return CronJob(**defaults)
+
+
+class TestRecordCronRunToMemory:
+    """Unit tests for the bridge helper against a real ConversationLog."""
+
+    def test_records_exchange_and_triggers_consolidation(self, tmp_path):
+        """Silent + hidden + stateless job still lands in memory (default-on)."""
+        log = ConversationLog(base_dir=tmp_path)
+        job = _make_job(silent=True, hide_in_chat=True, persistent_session=False)
+
+        ok = asyncio.run(
+            record_cron_run_to_memory(log, job, "found a defect in X")
+        )
+
+        assert ok is True
+        key = cron_memory_key(job.id)
+        assert key == "cron-mem:j1"
+        msgs = log.read_messages(key)
+        assert [(m["role"], m["content"]) for m in msgs] == [
+            ("user", "check the logs"),
+            ("assistant", "found a defect in X"),
+        ]
+
+    def test_does_not_overload_cron_id_key(self, tmp_path):
+        """cron:{id} emptiness is a documented invariant — must stay untouched."""
+        log = ConversationLog(base_dir=tmp_path)
+        job = _make_job()
+
+        asyncio.run(record_cron_run_to_memory(log, job, "result"))
+
+        assert log.read_messages(f"cron:{job.id}") == []
+
+    @pytest.mark.parametrize("result", [None, "", "   ", "_No response._"])
+    def test_empty_or_placeholder_result_records_nothing(self, tmp_path, result):
+        log = ConversationLog(base_dir=tmp_path)
+        job = _make_job()
+
+        ok = asyncio.run(record_cron_run_to_memory(log, job, result))
+
+        assert ok is False
+        assert log.read_messages(cron_memory_key(job.id)) == []
+
+    def test_missing_log_is_a_noop(self, tmp_path):
+        job = _make_job()
+        assert asyncio.run(record_cron_run_to_memory(None, job, "r")) is False
+
+    def test_append_failure_is_swallowed(self):
+        log = MagicMock()
+        log.append.side_effect = OSError("disk full")
+        job = _make_job()
+
+        ok = asyncio.run(record_cron_run_to_memory(log, job, "result"))
+
+        assert ok is False
+
+    def test_credentials_redacted_in_transcript(self, tmp_path):
+        """Stored rows follow the cron result sink redaction precedent."""
+        log = ConversationLog(base_dir=tmp_path)
+        # Built by concatenation so the fixture itself never matches secret
+        # scanners (repo precedent: test_telemetry_titles.py).
+        fake_key = "AKIA" + "ABCDEFGHIJKLMNOP"
+        job = _make_job(message=f"rotate key {fake_key} now")
+
+        asyncio.run(
+            record_cron_run_to_memory(log, job, f"old key was {fake_key}")
+        )
+
+        msgs = log.read_messages(cron_memory_key(job.id))
+        blob = "\n".join(m["content"] for m in msgs)
+        assert fake_key not in blob
+
+
+# ── Gateway executor wiring ──────────────────────────────────────────────
+
+
+def _make_gateway(tmp_path):
+    """Minimal GatewayOrchestrator mirroring test_cron_dedup's harness,
+    with a REAL ConversationLog and a recording consolidator stub."""
+    from kiro_crew.slack.gateway import GatewayOrchestrator
+
+    gw = GatewayOrchestrator.__new__(GatewayOrchestrator)
+    gw.sessions = MagicMock()
+    gw.ctx_builder = MagicMock()
+    gw.slack = MagicMock()
+    gw.conv_log = ConversationLog(base_dir=tmp_path)
+    gw.dashboard_state = MagicMock()
+    gw._owner_id = "U000"
+    gw.subagent_mgr = None
+    gw._cron_injecting = {}
+    gw._no_crons = False
+    gw._running_script_ids = set()
+    gw.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), True, False))
+    gw.sessions.release = MagicMock()
+    gw.sessions.reset = AsyncMock()
+    gw.sessions.set_thread = AsyncMock()
+    gw.sessions.set_channel = AsyncMock()
+    gw.ctx_builder.build_message = MagicMock(return_value=("msg", None))
+    gw.ctx_builder.hooks = MagicMock()
+    gw._interactive_approval = MagicMock(return_value="cb")
+    return gw
+
+
+def _run_callback(gw, job, stream_result="done", stream_exc=None):
+    """Init cron on the gateway, capture the callback, and invoke it."""
+    captured_cb = None
+
+    async def fake_stream(client, msg, **kwargs):
+        if stream_exc is not None:
+            raise stream_exc
+        return stream_result
+
+    with patch("kiro_crew.slack.gateway.stream_and_collect", fake_stream), patch(
+        "kiro_crew.slack.gateway.CronService"
+    ) as mock_cron_cls, patch("kiro_crew.slack.gateway.sel"):
+
+        def capture_cron(on_job=None, **kw):
+            nonlocal captured_cb
+            captured_cb = on_job
+            svc = MagicMock()
+            svc.start = AsyncMock()
+            return svc
+
+        mock_cron_cls.create = AsyncMock(side_effect=capture_cron)
+
+        async def _init_and_run():
+            await gw._init_cron()
+            assert captured_cb is not None
+            result = await captured_cb(job)
+            # Recording is DETACHED from the job's timeout window (a task,
+            # not an await) — drain it so assertions see the completed write.
+            from kiro_crew import cron_memory as _cm
+
+            if _cm._DETACHED_TASKS:
+                await asyncio.gather(
+                    *_cm._DETACHED_TASKS, return_exceptions=True
+                )
+            return result
+
+        return asyncio.run(_init_and_run())
+
+
+class TestGatewaySingleAgentPath:
+    def test_run_records_memory_and_triggers_consolidation(self, tmp_path):
+        gw = _make_gateway(tmp_path)
+        # Silent + hidden + stateless: the run never reaches a delivery site,
+        # yet must still reach memory (the default-on requirement).
+        job = _make_job(silent=True, hide_in_chat=True, persistent_session=False)
+
+        result = _run_callback(gw, job, stream_result="root-caused defect Y")
+
+        assert result == "root-caused defect Y"
+        key = cron_memory_key(job.id)
+        msgs = gw.conv_log.read_messages(key)
+        assert [(m["role"], m["content"]) for m in msgs] == [
+            ("user", "check the logs"),
+            ("assistant", "root-caused defect Y"),
+        ]
+
+    def test_failed_run_records_nothing(self, tmp_path):
+        gw = _make_gateway(tmp_path)
+        job = _make_job(silent=True)
+
+        with pytest.raises(RuntimeError):
+            _run_callback(gw, job, stream_exc=RuntimeError("turn failed"))
+
+        assert gw.conv_log.read_messages(cron_memory_key(job.id)) == []
+
+    def test_empty_result_records_nothing(self, tmp_path):
+        gw = _make_gateway(tmp_path)
+        job = _make_job(silent=True)
+
+        result = _run_callback(gw, job, stream_result="")
+
+        assert result == "_No response._"
+        assert gw.conv_log.read_messages(cron_memory_key(job.id)) == []
+
+    def test_recording_error_breaks_neither_run_nor_reset(self, tmp_path):
+        gw = _make_gateway(tmp_path)
+        gw.conv_log = MagicMock()
+        gw.conv_log.atomic_appends.side_effect = RuntimeError("boom")
+        job = _make_job(silent=True)
+
+        result = _run_callback(gw, job, stream_result="fine")
+
+        assert result == "fine"
+        gw.sessions.reset.assert_awaited()
+
+
+class TestGatewaySequentialPath:
+    def test_sequential_run_records_final_result(self, tmp_path):
+        gw = _make_gateway(tmp_path)
+        job = _make_job(agent_sequence=["planner", "executor"], silent=True)
+
+        result = _run_callback(gw, job, stream_result="sequence outcome")
+
+        assert result == "sequence outcome"
+        key = cron_memory_key(job.id)
+        msgs = gw.conv_log.read_messages(key)
+        assert [(m["role"], m["content"]) for m in msgs] == [
+            ("user", "check the logs"),
+            ("assistant", "sequence outcome"),
+        ]
+
+
+# ── Salience: nothing-notable spans must write no history ────────────────
+
+
+class TestConsolidationSalience:
+    def _consolidator_with_real_log(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("cron-mem:j1", "user", "check the logs")
+        log.append("cron-mem:j1", "assistant", "nothing new")
+        memory = MagicMock()
+        memory.read_preferences.return_value = ""
+        memory.read_projects.return_value = ""
+        c = HistoryConsolidator(log=log, memory=memory, sessions=None, migrated=True)
+        return c, memory
+
+    def test_prompt_authorizes_empty_history_entry(self, tmp_path):
+        """The consolidation prompt must offer the nothing-notable skip."""
+        c, _memory = self._consolidator_with_real_log(tmp_path)
+        prompts: list[str] = []
+
+        async def fake_llm(prompt):
+            prompts.append(prompt)
+            return {"history_entry": ""}
+
+        with patch.object(c, "_call_llm", side_effect=fake_llm):
+            asyncio.run(c._consolidate("cron-mem:j1", include_history=True))
+
+        assert prompts, "_call_llm was not invoked"
+        assert 'return an empty string ""' in prompts[0]
+
+    def test_empty_history_entry_writes_no_history(self, tmp_path):
+        c, memory = self._consolidator_with_real_log(tmp_path)
+
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as llm:
+            llm.return_value = {"history_entry": "", "lessons": []}
+            asyncio.run(c._consolidate("cron-mem:j1", include_history=True))
+
+        memory.append_history.assert_not_called()
+
+    def test_notable_history_entry_is_written(self, tmp_path):
+        """Control: the skip must not swallow genuinely notable spans."""
+        c, memory = self._consolidator_with_real_log(tmp_path)
+
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as llm:
+            llm.return_value = {"history_entry": "Root-caused defect Y.", "lessons": []}
+            asyncio.run(c._consolidate("cron-mem:j1", include_history=True))
+
+        memory.append_history.assert_called_once_with("Root-caused defect Y.")
+
+
+class TestDiskBackedSweep:
+    """The transcript FILE is the enrollment record — no volatile state."""
+
+    def _fresh_consolidator(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+        memory = MagicMock()
+        memory.read_preferences.return_value = ""
+        memory.read_projects.return_value = ""
+        c = HistoryConsolidator(log=log, memory=memory, sessions=None, migrated=True)
+        return c, log
+
+    async def _drain(self, c):
+        for t in list(c._tasks):
+            await t
+        for t in list(c._tasks):  # nested spawns from the scan task
+            await t
+
+    @pytest.mark.asyncio
+    async def test_restart_discovers_preexisting_transcript(self, tmp_path):
+        """A transcript written before a restart is swept with ZERO in-process
+        registration — the core durability property (survives restarts,
+        one-shot cron deletion, and shutdown between write and trigger)."""
+        writer_log = ConversationLog(base_dir=tmp_path)
+        with writer_log.atomic_appends("cron-mem:oneshot"):
+            writer_log.append("cron-mem:oneshot", "user", "run once")
+            writer_log.append("cron-mem:oneshot", "assistant", "opened PR #1")
+        # Age the file past the settle grace.
+        f = next(tmp_path.glob("cron-mem_oneshot*.jsonl"))
+        old = time.time() - 120
+        os.utime(f, (old, old))
+
+        # "Restart": a brand-new consolidator with empty in-memory dicts.
+        c, _log = self._fresh_consolidator(tmp_path)
+        with patch.object(c, "_consolidate", AsyncMock()) as consolidated:
+            c.sweep_cron_memory_keys()
+            await self._drain(c)
+            consolidated.assert_awaited_once()
+            assert consolidated.await_args.args[0] == "cron-mem_oneshot"
+
+    @pytest.mark.asyncio
+    async def test_just_written_transcript_is_swept_immediately(self, tmp_path):
+        """No freshness gate: a minutely cron's file never 'settles', so an
+        mtime filter would starve it forever (GPT round-6 finding). Locks
+        make concurrent appends safe; discovery must include hot files."""
+        writer_log = ConversationLog(base_dir=tmp_path)
+        writer_log.append("cron-mem:hot", "user", "m")
+        writer_log.append("cron-mem:hot", "assistant", "r")
+
+        c, _log = self._fresh_consolidator(tmp_path)
+        with patch.object(c, "_consolidate", AsyncMock()) as consolidated:
+            c.sweep_cron_memory_keys()
+            await self._drain(c)
+            consolidated.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_sweep_is_single_flight(self, tmp_path):
+        c, _log = self._fresh_consolidator(tmp_path)
+        c._cron_sweep_inflight = True
+        before = len(c._tasks)
+        c.sweep_cron_memory_keys()
+        assert len(c._tasks) == before  # latched: no second scan spawned
+
+    @pytest.mark.asyncio
+    async def test_non_cron_transcripts_are_not_swept(self, tmp_path):
+        writer_log = ConversationLog(base_dir=tmp_path)
+        writer_log.append("dashboard_chat-1", "user", "hi")
+        f = next(tmp_path.glob("dashboard_chat-1*.jsonl"))
+        old = time.time() - 120
+        os.utime(f, (old, old))
+
+        c, _log = self._fresh_consolidator(tmp_path)
+        with patch.object(c, "_consolidate", AsyncMock()) as consolidated:
+            c.sweep_cron_memory_keys()
+            await self._drain(c)
+            consolidated.assert_not_awaited()

--- a/test/test_history_consolidation_retry.py
+++ b/test/test_history_consolidation_retry.py
@@ -157,8 +157,12 @@ class TestFailureAfterTheBilledCall:
         assert KEY not in c._history_consolidated
 
         c._tasks.clear()
-        c.check_idle_sessions()
-        assert not c._tasks, "consolidation re-fired while inside the backoff window"
+        with patch.object(c, "_consolidate", AsyncMock()) as rebilled:
+            c.check_idle_sessions()
+            # Backoff is judged off-loop now: a precheck task may spawn, but
+            # it must refuse before dispatching a billed consolidation.
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+            rebilled.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_a_failure_before_the_llm_call_does_not_consume_budget(
@@ -239,8 +243,15 @@ class TestAttemptCap:
         assert log.consolidation_retry_state(KEY) == (0, 0.0)
         c._last_activity[KEY] = time.time() - 10
         c._tasks.clear()
-        c.check_idle_sessions()
-        assert not c._tasks
+        with patch.object(c, "_consolidate", AsyncMock()) as respawn:
+            c.check_idle_sessions()
+            # The sweep may spawn a precheck task (transcript reads run
+            # off-loop now), but the marked span has zero unconsolidated
+            # messages, so the precheck no-ops: no consolidation — and hence
+            # no billed turn — is ever dispatched for the abandoned span.
+            for t in list(c._tasks):
+                await t
+            respawn.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_cap_without_a_marker_write_stays_ineligible(self, tmp_path):
@@ -300,8 +311,12 @@ class TestAccountingSurvivesARestart:
         assert not fresh._history_consolidated
 
         assert fresh.retry_eligible(KEY) is False
-        fresh.check_idle_sessions()
-        assert not fresh._tasks, "restart re-billed a turn for a backed-off span"
+        with patch.object(fresh, "_consolidate", AsyncMock()) as rebilled:
+            fresh.check_idle_sessions()
+            # The durable backoff is read off-loop inside the precheck task —
+            # a task may spawn, but no billed consolidation may dispatch.
+            await asyncio.gather(*list(fresh._tasks), return_exceptions=True)
+            rebilled.assert_not_awaited()
 
 
 class TestTheAccountingIsReadUncached:
@@ -375,7 +390,15 @@ class TestTheAccountingIsReadUncached:
             other.record_consolidation_failure(KEY, 900.0, 86400.0, _span(other))
 
         c.check_idle_sessions()
-        assert not c._tasks, (
+        # The sweep may spawn a precheck task (backoff is now judged off-loop,
+        # extent-aware); the invariant is that no LLM turn is billed.
+        with patch.object(c, "_consolidate", AsyncMock()) as billed:
+            for t in list(c._tasks):
+                await t
+            billed.assert_not_awaited()
+        assert not any(
+            not t.done() for t in c._tasks
+        ), (
             "the sweep billed an LLM turn for a span another process had just "
             "put into backoff"
         )


### PR DESCRIPTION
## Problem

Work done by cron sessions never reaches the agent memory system. Observed incident: the log-patrol cron root-caused a defect and opened https://github.com/kirodotdev/KiroCrew/pull/2695 — ~30 minutes later an interactive session, whose injected memory had no trace of it, independently re-derived the same defect and nearly filed a duplicate PR.

Root cause: cron runs write only to the cron execution-history store, which has no connection to `HistoryConsolidator`, the memory store, or the vector store — and no consolidation trigger can ever fire for a cron session key (the executor never registers one, and its post-run session reset bypasses the expiry hook that consolidates interactive sessions).

## Why it matters

Agents repeat work the crew has already done. Anything a silent, scheduled agent learns — defects found, PRs opened, findings recorded — is invisible to every other session, so the same investigation gets billed twice and the user sees duplicate PRs.

## Fix (symptoms → root cause → change)

An agent should remember what it did, even routine work; significance is judged at consolidation time, never configured per job. Two small pieces, default-on for every agent-mode (message) cron run:

1. **Record** (`cron_memory.py`): after a successful run with a non-empty result, the executor detaches a task that appends the run's exchange (job message → user turn, result → assistant turn; both redacted) under a dedicated `cron-mem:{job.id}` ConversationLog key, atomically via `atomic_appends` in one worker-thread call. Recording is write-only — no trigger, no in-process registration — and best-effort: it never fails, delays, or outlives-blocks the run.
2. **Discover from disk** (`history.py` + `heartbeat.py`): the consolidator's heartbeat sweep gains `sweep_cron_memory_keys()`, which scans the transcript directory for `cron-mem:*` files (off-loop, single-flight, 60s write-settle grace) and routes each through the existing consolidation gates — the once-per-idle-window throttle, the running-set reservation, the off-loop unconsolidated/backoff prechecks, and the sensitive-session guard.

**The transcript file itself is the durable enrollment record.** That is the load-bearing design choice: there is no volatile in-process state whose loss can orphan an exchange — a gateway restart, a shutdown between write and trigger, or a one-shot cron deleted after its run all leave a file on disk that the next sweep (or next boot's first sweep) picks up. Cadence deliberately does NOT use file mtime as an idle anchor (a frequent cron touches its file every run and would never look idle); the settle grace only avoids racing an in-flight append.

Noise control is salience at consolidation time: the consolidation prompt now authorizes an empty `history_entry` for spans with no decisions, outcomes, or new facts — a routine "nothing to report" run distills to nothing and writes nothing. This authorization is intentionally uniform across session kinds.

## Tests

- `test/test_cron_memory.py`: recording unit tests (skips for empty/failed/placeholder results, missing-log no-op, append-failure swallowing, credential redaction, `cron:{id}` invariant untouched); gateway wiring for silent/hidden/ephemeral jobs on both executor paths (detached-task drain included); recording errors break neither run nor session reset; salience prompt contract (empty entry → no history write, notable entry → written); **disk-backed sweep**: a pre-existing transcript is discovered by a brand-new consolidator with empty in-memory state (restart/one-shot durability), settle grace defers hot files, single-flight latch, non-cron transcripts excluded.
- `test/test_history.py`, `test/test_history_consolidation_retry.py`: existing consolidation, throttle, and durable-backoff behavior unchanged (backoff asserted as "no billed consolidation dispatched").

## Manual verification

N/A — unit coverage exercises the executor wiring, the sweep, and the consolidator gates directly; the feature's end-to-end path (cron fires → transcript on disk → sweep consolidates) is composed of these covered units.

## Screenshots

N/A — backend-only change, no user-visible UI surface.
