### PR TITLE
feat(registry): re-converge persistent clone on registry entry branch change

### DIFF
--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -1384,26 +1384,202 @@ def _official_entry(entry: dict[str, Any]) -> bool:
     return not entry.get("_registry")
 
 
+class _MoveAsideUndoFailed(OSError):
+    """A move-aside undo failed, stranding the checkout at *aside*.
+
+    The retained-path carrier for the round-11 undo contract: whenever a
+    checkout is left physically at ``aside`` (not ``dest``) — possibly holding
+    an already-expired mtime — the caller MUST learn the exact ``aside`` path
+    to report it retained instead of letting the age-based sweep delete an
+    unnamed recovery copy. Carries ``aside`` as an attribute (not a re-derived
+    string) so :func:`_move_checkout_aside` reports the true on-disk path.
+
+    :func:`_rename_and_refresh_mtime` now refreshes *dest*'s mtime BEFORE the
+    rename, so a refresh failure fails closed before anything moves and never
+    strands a copy under a ``.stale-*`` name — it does not raise this. The
+    class and its handler are kept as the fail-closed contract for any residual
+    stranding path (the cancellation-settlement undo in
+    :func:`_move_checkout_aside`).
+    """
+
+    def __init__(self, aside: Path, cause: BaseException) -> None:
+        super().__init__(f"move-aside undo failed; checkout retained at {aside}: {cause}")
+        self.aside = aside
+
+
+def _rename_and_refresh_mtime(dest: Path, aside: Path) -> None:
+    """Refresh *dest*'s mtime, then rename it to *aside*, in one thread call.
+
+    The mtime refresh runs BEFORE the rename, so the moved-aside directory
+    already carries a fresh retention clock the instant it appears under its
+    sweep-recognized ``.stale-*`` name. This closes a concurrent-sweep race the
+    old rename-then-utime ordering left open: between ``dest.rename(aside)``
+    landing and a following ``os.utime(aside)`` completing, *aside* is already
+    visible under the sweepable name while still holding the checkout's OLD
+    (possibly already-expired) mtime, so a CONCURRENT ``install_from_registry``
+    running the age-based sweep in that sub-syscall window could delete the
+    user's recovery copy. Refreshing *dest* first means *aside* is never
+    observable under a swept name with a stale clock — the two syscalls stay in
+    one ``asyncio.to_thread`` invocation, so a cancellation between them cannot
+    reorder them either.
+
+    The mtime refresh is NOT best-effort. A moved-aside checkout is the user's
+    recovery copy, and the fresh mtime is the whole retention window: a
+    checkout already older than :data:`_STALE_CHECKOUT_RETENTION_DAYS` would be
+    sweep-eligible the instant it appears under the ``.stale-*`` name if its
+    mtime were not renewed, so a silently-swallowed ``utime`` failure would hand
+    the age-based sweep a green light to delete the recovery copy on the very
+    next install. So a ``utime`` failure fails CLOSED before anything moves:
+    *dest* has not been renamed yet, so it is still the caller's checkout at its
+    original path with its original clock untouched, and this simply re-raises.
+    Nothing is ever stranded under a ``.stale-*`` name by a failed refresh
+    because the refresh precedes the rename. The caller
+    (:func:`_move_checkout_aside`) turns the re-raised error into a ``None``
+    return, and every caller of that fails closed with the non-destructive
+    ``stale_clone_not_removed`` refusal — the checkout is left in place.
+
+    Only once the refresh SUCCEEDS is the rename attempted. ``Path.rename`` is a
+    single atomic syscall: it either moves *dest* to *aside* (now carrying the
+    fresh clock) or leaves *dest* exactly where it was, so a rename failure
+    strands nothing and re-raises for the same fail-closed handling. The
+    round-11 :class:`_MoveAsideUndoFailed` retained-path contract is preserved
+    on the caller side: its handler still reports the exact ``.stale-*`` path if
+    a checkout is ever found stranded there (e.g. the cancellation-settlement
+    undo below), so no recovery copy is ever swept unnamed.
+    """
+    # Refresh the retention clock IN PLACE first, so the moved-aside dir carries
+    # a fresh mtime the instant it becomes visible under the sweep-recognized
+    # name. A utime failure fails closed here: dest has not moved, so the caller
+    # keeps its checkout untouched at its original path and refuses
+    # non-destructively. Never rename after a failed refresh — that is what
+    # would strand an un-refreshed copy under a swept name.
+    os.utime(dest)
+    dest.rename(aside)
+
+
 async def _move_checkout_aside(dest: Path, log_lines: list[str]) -> Path | None:
     """Atomically rename *dest* to a sibling temp path under the app-sources root.
 
     Returns the new path, or ``None`` if the rename failed. Nothing is ever
     deleted here: the caller reports the failure and the retention sweep owns the
-    moved-aside directory's eventual removal.
+    moved-aside directory's eventual removal. The mtime refresh now runs BEFORE
+    the rename, so a refresh failure fails closed with *dest* untouched at its
+    original path and strands nothing under a ``.stale-*`` name — it surfaces as
+    the ``Could not move aside`` log line and a ``None`` return. The
+    ``.stale-*`` retained-path report (via :class:`_MoveAsideUndoFailed`) is
+    still emitted for the one residual strander, the cancellation-settlement
+    undo below, so no stranded recovery copy is ever left unreported.
+
+    Report durability: every branch that strands a recovery copy at a
+    ``.stale-*`` path records it with ``logger.warning`` as well as appending to
+    *log_lines*. The request-local list is discarded when a gateway shutdown
+    cancels the update before it returns (the response the list renders into is
+    never sent), so a list-only report would leave the age-based sweep to delete
+    an unnamed recovery copy. The durable process-log line is what survives that
+    shutdown, so the retained path is always recoverable.
+
+    Cancellation safety: the rename+mtime-refresh runs on a retained worker
+    future, and the handler SETTLES that worker before inspecting *aside*.
+    Cancelling the awaiting task does not cancel a thread already running in
+    the executor -- ``asyncio.Future.cancel()`` returns while the worker runs
+    on -- so a bare ``if aside.exists():`` check would race the in-thread
+    rename: a worker past dispatch but pre-rename at check time would complete
+    the rename after the handler re-raised, stranding the checkout at *aside*
+    unrecorded. Awaiting the worker to completion first makes the inspection
+    deterministic: if the rename ran, this synchronously moves *aside* back to
+    *dest* so the caller's state is unchanged by the attempt; if that undo
+    itself fails, the aside path is logged durably (``logger.warning``, so it is
+    never silently strandable even when the cancelling shutdown discards
+    *log_lines*) before the cancellation is re-raised. Repeated cancellation
+    does NOT get
+    to skip that undo-or-log: the worker is an executor THREAD and will finish
+    regardless of how many times the awaiting task is cancelled, so the
+    settlement loop absorbs every further ``CancelledError`` until the worker
+    future is done, THEN runs the synchronous undo-or-log, THEN re-raises a
+    single ``CancelledError``. The earlier "acceptable to skip on a second
+    cancel" behavior was wrong by this PR's own standard: a skipped undo leaves
+    the checkout at an UNREPORTED ``.stale-*`` path that the retention sweep
+    later deletes -- exactly the silent-deletion class this surface exists to
+    close, and an mtime refresh only delays the sweep, it does not report the
+    path. No new ``await`` runs after settlement: the undo/log is synchronous
+    so it cannot itself be interrupted.
     """
     aside = dest.with_name(f"{dest.name}.stale-{uuid.uuid4().hex[:8]}")
+    loop = asyncio.get_running_loop()
+    # Retain the worker future so the CancelledError handler can settle it
+    # before inspecting *aside*; shield keeps a task cancel from propagating
+    # into the executor item (a thread cannot be cancelled anyway).
+    worker = loop.run_in_executor(None, _rename_and_refresh_mtime, dest, aside)
     try:
-        await asyncio.to_thread(dest.rename, aside)
+        await asyncio.shield(worker)
+    except _MoveAsideUndoFailed as undo_failed:
+        # The utime refresh failed AND the rename-back failed: the checkout is
+        # stranded at *aside* (NOT dest) with a possibly-expired mtime. Report
+        # the exact retained path so the sweep does not delete an unnamed
+        # recovery copy -- the same undo-or-log contract the cancellation path
+        # below honours. Must come before the generic OSError handler since
+        # _MoveAsideUndoFailed subclasses OSError.
+        #
+        # Record it DURABLY as well as into log_lines: every branch that strands
+        # a recovery copy at a .stale-* path names it in the process log, not
+        # only in the request-local list, so the retained path survives a
+        # gateway shutdown that discards the response the list would have
+        # rendered into.
+        logger.warning("Previous checkout retained at: %s", undo_failed.aside)
+        log_lines.append(f"Previous checkout retained at: {undo_failed.aside}")
+        return None
     except OSError as exc:
+        # utime failed but the rename-back succeeded: the checkout is back at
+        # *dest* with its original clock, nothing stranded, so naming dest is
+        # the honest report.
         log_lines.append(f"Could not move aside the checkout at {dest}: {exc}")
         return None
-    # Refresh mtime so the retention clock starts now, not at the checkout's
-    # last-modified time (which may already exceed the sweep threshold).
-    # Best-effort: failure only shortens how long the directory survives.
-    try:
-        await asyncio.to_thread(os.utime, aside)
-    except OSError:
-        pass
+    except asyncio.CancelledError:
+        # Settle the worker before inspecting *aside*: the shield delivered the
+        # cancel to us while the thread may still be mid-flight, and only once
+        # the worker has finished is aside.exists() an honest reading of whether
+        # the rename ran. The worker is a thread and WILL finish, so keep
+        # awaiting it across any FURTHER cancellation: a second cancel delivered
+        # during settlement must not skip the undo-or-log below and strand the
+        # checkout at an unreported .stale-* path. Absorb each extra cancel and
+        # re-await until the future is done; asyncio.wait never re-raises the
+        # worker's own exception (we do not need its result, only that it
+        # settled).
+        while not worker.done():
+            try:
+                await asyncio.wait({worker})
+            except asyncio.CancelledError:
+                # A repeated cancel landed on the settling await. Loop: the
+                # thread is still running and the undo-or-log is owed either way.
+                continue
+        # Settled. The undo-or-log is synchronous, so it runs to completion
+        # even under a pending cancellation, then a single CancelledError is
+        # re-raised to the caller.
+        if aside.exists():
+            try:
+                aside.rename(dest)
+            except OSError as undo_exc:
+                # The undo failed, so the recovery checkout is stranded at the
+                # .stale-* aside path. The cancellation that brought us here is
+                # typically a gateway shutdown, which DISCARDS log_lines (the
+                # request never returns to render them), so the request-local
+                # append alone would leave the age-based sweep to delete an
+                # unnamed recovery copy. Emit a durable logger.warning FIRST so
+                # the retained path survives the shutdown in the process log;
+                # the log_lines append still carries it into the response on the
+                # non-shutdown cancellation paths that do return.
+                logger.warning(
+                    "Cancelled while moving aside %s; the checkout is retained "
+                    "at %s and could not be restored: %s",
+                    dest,
+                    aside,
+                    undo_exc,
+                )
+                log_lines.append(
+                    f"Cancelled while moving aside {dest}; the checkout is "
+                    f"retained at {aside} and could not be restored: {undo_exc}"
+                )
+        raise
     return aside
 
 
@@ -3051,10 +3227,16 @@ def _resolved_clone_commit(clone_root: Path) -> str:
     ``""`` (provenance without a commit) instead of failing the install.
     """
     git_dir = clone_root / ".git"
-    try:
-        head = (git_dir / "HEAD").read_text(encoding="utf-8").strip()
-    except (OSError, UnicodeDecodeError):
+    # All three reads below are BOUNDED: HEAD, the loose ref, and packed-refs
+    # all live inside the checkout, so their sizes are attacker-controlled (an
+    # app's build script can rewrite them). This is the SAME `.git/HEAD` file
+    # that :func:`_read_clone_branch` bounds — closing the memory-exhaustion
+    # class at that call site alone would leave it open here, on the install
+    # path, which is the round-11 "next call site" lesson.
+    raw_head = _read_git_metadata_bounded(git_dir / "HEAD", _HEAD_READ_LIMIT)
+    if raw_head is None:
         return ""
+    head = raw_head.strip()
     if not head.startswith("ref:"):
         # Detached HEAD holds the SHA directly.
         return head if _COMMIT_SHA_RE.match(head) else ""
@@ -3063,20 +3245,18 @@ def _resolved_clone_commit(clone_root: Path) -> str:
     # never be read as a path outside the clone's own .git directory.
     if not ref or ref.startswith("/") or ".." in ref.split("/"):
         return ""
-    try:
-        loose = (git_dir / ref).read_text(encoding="utf-8").strip()
+    raw_loose = _read_git_metadata_bounded(git_dir / ref, _HEAD_READ_LIMIT)
+    if raw_loose is not None:
+        loose = raw_loose.strip()
         if _COMMIT_SHA_RE.match(loose):
             return loose
-    except (OSError, UnicodeDecodeError):
-        pass
     # A repacked clone keeps no loose ref file.
-    try:
-        for line in (git_dir / "packed-refs").read_text(encoding="utf-8").splitlines():
+    packed = _read_git_metadata_bounded(git_dir / "packed-refs", _PACKED_REFS_READ_LIMIT)
+    if packed is not None:
+        for line in packed.splitlines():
             parts = line.split()
             if len(parts) == 2 and parts[1] == ref and _COMMIT_SHA_RE.match(parts[0]):
                 return parts[0]
-    except (OSError, UnicodeDecodeError):
-        pass
     return ""
 
 
@@ -3325,6 +3505,66 @@ async def _clone_origin_matches(dest: Path, git_url: str) -> bool:
     return await _clone_origin_url(dest) == git_url
 
 
+# Upper bound on any single git-metadata read of a file INSIDE a checkout
+# (``.git/HEAD``, a loose ref). Those files are agent-writable — an app's own
+# build script can rewrite them — so their size is ATTACKER-controlled: an app
+# can replace one with (or symlink it to) a multi-gigabyte / sparse file, and
+# an unbounded read would load it into gateway memory. A well-formed value here
+# is a single line (a ``ref:`` line or a 40/64-char SHA), tens of bytes, so a
+# few-hundred-byte cap makes the read a no-op for hostile content while a real
+# ref fits comfortably. This bound is applied at EVERY checkout-resident git
+# read, not just one call site — the round-11 lesson is that gating a single
+# caller leaves the primitive exploitable from the next one.
+_HEAD_READ_LIMIT = 512  # bytes
+
+# Upper bound on the ``.git/packed-refs`` read. It is line-oriented (one ref per
+# line) so it can legitimately be larger than a single ref file, but it is still
+# agent-writable checkout content, so the read is capped rather than unbounded.
+# A shallow single-branch app clone packs a handful of refs; this ceiling covers
+# a realistic repo while still refusing a hostile multi-megabyte replacement.
+_PACKED_REFS_READ_LIMIT = 1 << 20  # 1 MiB
+
+
+def _read_git_metadata_bounded(path: Path, limit: int) -> str | None:
+    """Read at most *limit* bytes of a git-metadata file, or None on failure.
+
+    The read is BOUNDED because *path* lives inside a checkout whose contents an
+    app's build script can rewrite (see :data:`_HEAD_READ_LIMIT`): reading a
+    ref file whole would let an oversized/sparse/symlinked replacement exhaust
+    gateway memory. Content that exactly fills the bound is treated as
+    truncated/hostile and returns None, so a caller never acts on a partial
+    token. Missing file, unreadable, or non-UTF-8 all fail closed to None.
+
+    The read is also SYMLINK-CONTAINED: *path* is a checkout-resident file whose
+    name (``.git/HEAD``, a loose ref, ``packed-refs``) an app's build script can
+    replace with a symlink pointing at a protected file (``~/.aws/credentials``,
+    an SSH key). A bare ``open()`` would follow that link and read the target
+    through the sensitive-path ceiling, so the read is routed through
+    :func:`kiro_crew.hooks.safe_read_prefix`, which canonicalizes via ``realpath``
+    and refuses a resolved target ``is_sensitive_path`` flags before any read,
+    then opens the canonical path ``O_NOFOLLOW`` as TOCTOU defense against a
+    final-component symlink swap. A rejected (or unreadable) path fails closed to
+    None, so the size bound and the containment gate share one fail-closed exit.
+    """
+    from kiro_crew import hooks
+
+    raw = hooks.safe_read_prefix(str(path), limit)
+    if raw is None:
+        # Rejected by the sensitive-path gate, a followed symlink refused
+        # O_NOFOLLOW, missing, or otherwise unreadable — all fail closed.
+        return None
+    try:
+        data = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    # Filling the bound means the real content was larger — refuse rather than
+    # act on a value that may have been cut mid-token. Measured on the decoded
+    # text so a multi-byte tail cannot slip a value past the bound.
+    if len(data) >= limit:
+        return None
+    return data
+
+
 def _read_clone_branch(clone_dir: Path) -> str | None:
     """Read the current branch of an existing git clone.
 
@@ -3333,6 +3573,15 @@ def _read_clone_branch(clone_dir: Path) -> str | None:
     Reads ``.git/HEAD`` directly (stdlib-only, no subprocess spawn) — mirrors
     the fail-closed posture of :func:`_clone_origin_matches`.
 
+    The read is BOUNDED to :data:`_HEAD_READ_LIMIT` bytes. ``.git/HEAD`` lives
+    inside a checkout an app's build script can rewrite, so its size is
+    attacker-controlled; reading it whole would let a multi-gigabyte or sparse
+    replacement exhaust gateway memory. A well-formed HEAD fits in a few
+    hundred bytes, so a ``ref:`` line that does not resolve within the bound is
+    treated as malformed and fails closed (returns None). This is what closes
+    the memory-exhaustion class at EVERY call site, not just the ones a caller
+    happens to gate.
+
     A ``.git`` that is a *file* (worktree / submodule gitfile) rather than a
     directory also fails closed (``is_file()`` on the nested path returns
     False), so no fast path is attempted for those layouts.
@@ -3340,14 +3589,19 @@ def _read_clone_branch(clone_dir: Path) -> str | None:
     head_file = clone_dir / ".git" / "HEAD"
     if not head_file.is_file():
         return None
-    try:
-        head_content = head_file.read_text("utf-8").strip()
-    except (OSError, UnicodeDecodeError):
+    raw = _read_git_metadata_bounded(head_file, _HEAD_READ_LIMIT)
+    if raw is None:
+        # Missing, unreadable, non-UTF-8, or oversized (filled the bound) — the
+        # bounded reader already failed closed on hostile/truncated content.
         return None
+    head_content = raw.strip()
     # A normal branch checkout has HEAD = "ref: refs/heads/<branch>"
     _REF_PREFIX = "ref: refs/heads/"
     if head_content.startswith(_REF_PREFIX):
-        return head_content[len(_REF_PREFIX) :]
+        branch = head_content[len(_REF_PREFIX) :]
+        if not branch:
+            return None
+        return branch
     # Detached HEAD (raw SHA) or unexpected format — fail closed.
     return None
 
@@ -3600,6 +3854,13 @@ async def _git_clone_or_pull(
     on the happy path; on failure, the old checkout has already been restored
     by this function's finally block.
 
+    If *restorable_stale* is provided (a mutable list), a moved-aside checkout
+    that is the SAME repository as the active one (a branch drift, not a
+    different repo) is additionally appended here. Only a path in BOTH
+    *pending_cleanup* and *restorable_stale* is safe to hand back as
+    ``restore_from`` on a later rejection — restoring an origin-mismatched
+    move-aside would give the build the exact tree an earlier gate refused.
+
     *index_originated* selects the credential posture (confused-deputy defense —
     see :func:`anonymous_git_env`). When ``False`` (the default: a bundled /
     owner-designated install) the clone keeps the gateway's ambient git/ssh
@@ -3669,6 +3930,10 @@ async def _git_clone_or_pull(
                 ),
             }
         if existing_origin != git_url:
+            # Parity with the branch-mismatch path below: say WHY the checkout
+            # is being replaced before doing it, naming the mismatched origin,
+            # so the install log records the re-clone reason instead of a bare
+            # move-aside line.
             log_lines.append(
                 f"Existing clone origin {existing_origin!r} does not match "
                 f"{git_url!r}; moving aside stale clone for re-clone"
@@ -3689,6 +3954,68 @@ async def _git_clone_or_pull(
                         "Remove it manually and retry the install."
                     ),
                 }
+
+    if not commit and dest.is_dir() and (dest / ".git").is_dir():
+        # Branch re-convergence only applies to branch-tracking entries. A
+        # commit-pinned install never reuses the existing tree (the `if commit:`
+        # block below moves it aside and re-fetches detached regardless), so
+        # reading its branch here is pointless work — and pointless attack
+        # surface: the read touches ``.git/HEAD`` inside a checkout the app's
+        # own build script can rewrite. Skipping it when `commit` is set keeps
+        # the reconvergence read off the pinned-update path entirely (the read
+        # itself is also bounded in :func:`_read_clone_branch`, so the fast
+        # path at :func:`_clone_branch_matches` is safe too).
+        #
+        # Origin is verified — but the checked-out branch may have drifted
+        # (e.g. a registry entry changed from branch A to branch B). If so,
+        # the same move-aside/re-clone treatment applies: do NOT checkout in
+        # place (local edits would be carried over silently), move the old
+        # checkout aside so it is preserved for manual recovery, then fall
+        # through to a fresh clone of the correct branch.
+        #
+        # IMPORTANT: Only move aside when a CONCRETE branch name was read AND
+        # it differs from the requested branch. When the read returns None
+        # (detached HEAD, unreadable .git/HEAD, gitfile layout) we fall
+        # through to the pull path — this is the pre-PR behavior for that
+        # checkout (non-destructive). Detached HEAD is the normal healthy
+        # state for tag-pinned entries (and for any commit-pinned checkout,
+        # which is always fetched detached — see :func:`_git_fetch_commit`);
+        # treating it as a confirmed mismatch would destroy a working
+        # checkout on every update cycle.
+        clone_branch = await asyncio.to_thread(_read_clone_branch, dest)
+        if clone_branch is None:
+            # Unknown branch state — do not destroy the checkout.
+            log_lines.append(
+                f"Cannot determine branch of existing checkout at {dest} "
+                f"(detached HEAD or unreadable .git/HEAD); skipping "
+                f"branch re-convergence and proceeding with pull"
+            )
+        elif clone_branch != branch:
+            log_lines.append(
+                f"Existing clone branch {clone_branch!r} does not match "
+                f"requested branch {branch!r}; moving aside for re-clone"
+            )
+            moved_aside = await _move_checkout_aside(dest, log_lines)
+            if moved_aside is None:
+                log_lines.append(
+                    f"Refusing to build from the checkout on the wrong branch at {dest}"
+                )
+                return {
+                    "ok": False,
+                    "name": dest.name,
+                    "error": "stale_clone_not_removed",
+                    "message": (
+                        "A checkout on the wrong branch is present and could not be "
+                        "moved aside. Remove it manually and retry the install."
+                    ),
+                }
+            # Origin was already verified identical above, so this is the SAME
+            # repository the user was on — only its branch drifted. That makes
+            # it restorable on a later build/install failure, exactly like the
+            # pinned-install move-aside below: a failed transaction must put
+            # the user's own (possibly edited) branch-A tree back rather than
+            # strand it as an undiscoverable `.stale-*` sibling.
+            moved_aside_is_restorable = True
 
     if dest.is_dir() and (dest / ".git").is_dir():
         if commit:
@@ -3736,11 +4063,12 @@ async def _git_clone_or_pull(
             # Fall through: `dest` no longer exists, so the pinned fetch below
             # creates it fresh inside the try/finally that owns restoration.
         else:
-            # Already cloned from the verified origin — fetch and fast-forward.
-            # (The origin-mismatch gate above guarantees this checkout's origin is
-            # byte-identical to git_url: a mismatched checkout was moved aside and
-            # never reused, so the fetch source and the provenance record are the
-            # same URL by construction.)
+            # Already cloned from the verified origin AND branch (or the branch
+            # state was unknown and re-convergence was skipped) — fetch and
+            # fast-forward. (The origin-mismatch gate above guarantees this
+            # checkout's origin is byte-identical to git_url: a mismatched
+            # checkout was moved aside and never reused, so the fetch source and
+            # the provenance record are the same URL by construction.)
             log_lines.append(f"Updating {git_url} (branch: {branch})...")
             # Route through wrap_argv (OS sandbox) THEN cgroup_scope_argv, matching
             # the fresh-clone path below — the cgroup DoS ceiling is the outermost
@@ -3940,6 +4268,22 @@ async def _git_clone_or_pull(
                         )
 
 
+def _restorable_or_none(pending: list[Path] | None, restorable: list[Path] | None) -> Path | None:
+    """Return the moved-aside checkout a refusal may restore, or None.
+
+    ``pending`` mirrors ``_pending_stale_cleanup`` (every move-aside this run,
+    regardless of reason) while ``restorable`` mirrors ``_restorable_stale``
+    (the same-repository subset — branch drift, not a different repo). Only a
+    path present in BOTH is safe to hand back as ``restore_from``: restoring
+    an origin-mismatched move-aside would give a rejection the exact tree an
+    earlier gate already refused.
+    """
+    if not pending:
+        return None
+    candidate = pending[0]
+    return candidate if candidate in (restorable or []) else None
+
+
 async def _clone_build_app(
     git_url: str,
     app_name: str,
@@ -3973,12 +4317,17 @@ async def _clone_build_app(
     # registration, and backend startup — so nested acquisition here would
     # deadlock (asyncio.Lock is not reentrant).
     # The restoration state is collected HERE, at the single return, rather than
-    # stamped onto the result inside `_clone_build_app_locked`. That function has six
-    # exits and the state was only attached on the successful one, so a post-fetch
-    # failure -- a subdirectory that escapes containment, an identity mismatch, a
-    # rejected admission -- dropped it, and the caller's `finally` had nothing to
-    # restore from: the user's edited checkout went to the retention sweep. A list the
-    # callee fills and this one exit reads cannot be forgotten by a new exit.
+    # stamped onto the result inside `_clone_build_app_locked`. That function has
+    # several exits and the state was only attached on the successful one, so a
+    # post-fetch failure -- a subdirectory that escapes containment, an identity
+    # mismatch, a rejected admission -- dropped it: the caller's `finally` had
+    # nothing to restore from AND `_report_retained_stale_checkouts` iterated an
+    # empty list, so a non-restorable (origin-mismatch) checkout was stranded as a
+    # `.stale-*` sibling, unreported, until the retention sweep deleted it. Two
+    # lists the callee fills and this one exit reads cannot be forgotten by a new
+    # exit: `pending_cleanup` is every move-aside this run, `restorable_stale` the
+    # same-origin subset a failure-path restore may put back.
+    pending_cleanup: list[Path] = []
     restorable_stale: list[Path] = []
     try:
         result = await _clone_build_app_locked(
@@ -3990,6 +4339,7 @@ async def _clone_build_app(
             subdirectory=subdirectory,
             entry_repo=entry_repo,
             commit=commit,
+            pending_cleanup=pending_cleanup,
             restorable_stale=restorable_stale,
         )
     except BaseException:
@@ -4010,9 +4360,37 @@ async def _clone_build_app(
                 log_lines,
                 "the build was interrupted",
             )
+        # The restore above puts back the same-origin subset; the NON-restorable
+        # move-asides (origin-mismatch tree-asides, deliberately kept) are left on
+        # disk as `.stale-*` siblings. On this exception path there is no result
+        # dict, so the caller's `finally`-owned reporter never learns of them and
+        # the age-based sweep would delete a checkout the user was never told
+        # about. Report them through the SHARED reporter -- the one owner of the
+        # "Previous checkout retained at" wording -- so this path and the finally
+        # can never drift apart. `filter_restorable=True` skips the same-origin
+        # subset the restore above just put back, matching the finally's
+        # post-restore call. Synchronous: the reporter only appends to a list and
+        # logs, so it needs no loop (awaiting during cancellation re-enters a
+        # closing loop -- see the SYNCHRONOUS note above).
+        _report_retained_stale_checkouts(
+            {
+                "_pending_stale_cleanup": pending_cleanup,
+                "_restorable_stale": restorable_stale,
+            },
+            log_lines,
+            filter_restorable=True,
+        )
         raise
-    if restorable_stale and isinstance(result, dict):
-        result["_restorable_stale"] = list(restorable_stale)
+    if isinstance(result, dict):
+        # Stamp the FULL move-aside state on EVERY dict result crossing this
+        # single exit -- refusals included -- so the caller's
+        # `_report_retained_stale_checkouts` names a retained non-restorable
+        # checkout instead of dropping it. This is report/restore metadata only:
+        # it changes no path that gets restored or deleted.
+        if pending_cleanup:
+            result["_pending_stale_cleanup"] = list(pending_cleanup)
+        if restorable_stale:
+            result["_restorable_stale"] = list(restorable_stale)
     return result
 
 
@@ -4049,6 +4427,21 @@ async def _unpoison_rejected_checkout(
     (literal pathspecs keep an index-controlled subdirectory from being
     parsed as pathspec magic). Best-effort throughout: a cleanup failure is
     logged, never raised — the refusal it follows must stand regardless.
+
+    *manifest_relpath* is the untrusted registry-declared manifest path the
+    caller built (``f"{subdirectory}/app.json"``, or plain ``app.json`` when
+    no subdirectory was declared). A build step or ``onInstall`` script runs
+    with write access to the checkout BEFORE some callers reach this cleanup,
+    and can plant a symlink at the manifest path — the subdirectory OR the
+    leaf — after an earlier containment check already passed; this restore
+    then runs unsandboxed as the Kiro Crew process, so it must not trust that
+    earlier check. Containment of the FULL manifest path is re-verified HERE,
+    at the point of the write, against the CURRENT on-disk state: on a
+    failure the manifest restore (both the raw-write and the git-checkout
+    fallback) is skipped so neither can be redirected outside *pkg_dir*
+    through a symlink planted after the caller's check. The pre-pull
+    ``git reset`` above is unaffected — it targets the whole checkout, not
+    the manifest path.
     """
     if not checkout_preexisted:
         await asyncio.to_thread(shutil.rmtree, pkg_dir, ignore_errors=True)
@@ -4099,6 +4492,28 @@ async def _unpoison_rejected_checkout(
         # RuntimeError covers SandboxUnavailableError from wrap_argv — cleanup
         # is best-effort and must never mask the refusal it follows.
         logger.debug("post-rejection rollback failed for %s: %s", app_name, exc)
+    if _contained_join(pkg_dir, manifest_relpath) is None:
+        # manifest_relpath (the FULL path, e.g. "sub/app.json") no longer
+        # resolves inside pkg_dir RIGHT NOW — some callers reach this point
+        # after a build step or onInstall script ran with write access to the
+        # checkout, so a containment check the caller made earlier cannot be
+        # trusted here. Checking only `subdirectory` (the directory, and only
+        # when non-empty) misses a symlink planted at the manifest LEAF itself
+        # -- `subdirectory/app.json`, or plain `app.json` when there is no
+        # subdirectory -- which is exactly what the raw write and the
+        # git-checkout fallback below target; either would follow such a
+        # symlink and write outside pkg_dir as this unsandboxed process. Skip
+        # the manifest restore entirely rather than risk that write; the
+        # rollback above already ran and stands. Unconditional (no
+        # `if subdirectory` gate): the same leaf-symlink attack works with an
+        # empty subdirectory too, where manifest_relpath is just "app.json".
+        log_lines.append(
+            f"WARNING: {manifest_relpath!r} no longer resolves inside "
+            "the checkout; skipping manifest restore to avoid writing through "
+            "a symlink escape. A retry may keep rejecting until the source is "
+            "repaired."
+        )
+        return
     try:
         # Restore the manifest regardless — in its OWN guarded block so a
         # reset failure above cannot skip it: a build step or install script
@@ -4129,9 +4544,20 @@ async def _clone_build_app_locked(
     subdirectory: str = "",
     entry_repo: str = "",
     commit: str = "",
+    pending_cleanup: list[Path],
     restorable_stale: list[Path] | None = None,
 ) -> dict[str, Any]:
-    """Inner implementation of _clone_build_app, called under per-app lock."""
+    """Inner implementation of _clone_build_app, called under per-app lock.
+
+    *pending_cleanup* and *restorable_stale* are caller-owned mutable lists
+    (see :func:`_clone_build_app`): this function fills them so the wrapper's
+    single return can stamp the full move-aside state onto EVERY dict result,
+    refusals included. *pending_cleanup* is REQUIRED — the sole production
+    caller always threads its own list through so the wrapper's single exit
+    can read the move-aside state, and every test constructs one too; an
+    optional-with-``None`` shape would only invite a caller to drop the list
+    and silently lose that state, so there is no default to fall back to.
+    """
     if not _looks_like_git_url(git_url):
         return {
             "ok": False,
@@ -4140,7 +4566,6 @@ async def _clone_build_app_locked(
         }
 
     pkg_dir = app_source_dir(app_name)
-    pending_cleanup: list[Path] = []
     if restorable_stale is None:
         restorable_stale = []
     # Captured BEFORE the clone so a refusal below can tell a checkout this run
@@ -4223,7 +4648,7 @@ async def _clone_build_app_locked(
             pre_pull_commit=pre_pull_commit,
             manifest_relpath=manifest_rel,
             manifest_snapshot=pre_update_manifest,
-            restore_from=(pending_cleanup[0] if pending_cleanup else None),
+            restore_from=_restorable_or_none(pending_cleanup, restorable_stale),
         )
 
     # ADMISSION GATE, second pass — on the CLONED manifest. The first pass ran
@@ -4258,7 +4683,7 @@ async def _clone_build_app_locked(
             pre_pull_commit=pre_pull_commit,
             manifest_relpath=manifest_rel,
             manifest_snapshot=pre_update_manifest,
-            restore_from=(pending_cleanup[0] if pending_cleanup else None),
+            restore_from=_restorable_or_none(pending_cleanup, restorable_stale),
         )
         return {
             "ok": False,
@@ -4292,17 +4717,47 @@ async def _clone_build_app_locked(
         result["_pre_update_manifest"] = pre_update_manifest
         # Do NOT delete moved-aside checkouts — even after a successful
         # install transaction the user may want to recover local edits from
-        # the old checkout.  Surface the paths so the caller can log them.
+        # the old checkout. The paths are surfaced to the caller by
+        # `_clone_build_app`'s single-exit stamp (every dict result carries
+        # `_pending_stale_cleanup`), so no explicit stamping is needed here.
         # The dirs are harmless siblings swept by _sweep_stale_checkouts()
         # after _STALE_CHECKOUT_RETENTION_DAYS (best-effort, runs at the
         # start of the next install_from_registry call).
-        if pending_cleanup:
-            result["_pending_stale_cleanup"] = list(pending_cleanup)
+        pass
     else:
         # Build failed — restore the old checkout so the user's local edits
         # survive. Remove the (successfully cloned but unbuildable) new dest
         # and rename the moved-aside dir back.
+        #
+        # But ONLY for RESTORABLE move-asides. `pending_cleanup` carries every
+        # move-aside this run made — both same-origin/branch-drift asides
+        # (restorable: restoring them is the point) AND origin-mismatch asides
+        # the identity gate deliberately refused to serve. Restoring the latter
+        # would re-seat a repository the gate just rejected into the active
+        # source slot the instant its replacement's build fails — the exact
+        # confused-deputy residue the restorable/pending split exists to close.
+        # Membership is tested against `restorable_stale`, the caller-owned list
+        # populated at the same move-aside site (identity `in`, comparing the
+        # Path objects both lists share — never a re-derived string that path
+        # aliasing could spoof). A non-restorable aside stays in
+        # `pending_cleanup` untouched so the single-exit stamp carries it and
+        # the finally-owned `_report_retained_stale_checkouts` names it.
+        # `restorable_stale or []`: a missing list means NOTHING is restorable,
+        # so every move-aside is retained rather than restored — the fail-closed
+        # default (the production caller always threads a real list; this only
+        # guards a caller that omits it from re-seating a checkout by accident).
+        restorable_set = set(restorable_stale or [])
+        restored_paths: list[Path] = []
         for stale_path in pending_cleanup:
+            if stale_path not in restorable_set:
+                # Refused-origin checkout: never restored into the active slot.
+                # Left in pending_cleanup so it is reported retained, not swept
+                # silently and not re-seated as the live app source.
+                log_lines.append(
+                    "Build failed; origin-mismatched checkout NOT restored, "
+                    f"retained at: {stale_path}"
+                )
+                continue
             if stale_path.exists():
                 await asyncio.to_thread(shutil.rmtree, pkg_dir, True)
                 try:
@@ -4310,12 +4765,20 @@ async def _clone_build_app_locked(
                     log_lines.append(
                         "Build failed; previous checkout restored from " f"{stale_path.name}"
                     )
+                    restored_paths.append(stale_path)
                 except OSError as exc:
                     log_lines.append(
                         f"Build failed; could not restore previous checkout "
                         f"from {stale_path}: {exc}. Recover your files from "
                         f"{stale_path}"
                     )
+        # Drop the checkouts actually put back from the caller-owned pending
+        # list: a restored checkout is no longer a retained `.stale-*` sibling,
+        # so `_clone_build_app`'s single-exit stamp must not carry it and the
+        # caller's `_report_retained_stale_checkouts` must not name it. A rename
+        # that FAILED above stays in the list so it is still reported stranded.
+        for restored in restored_paths:
+            pending_cleanup.remove(restored)
     return result
 
 
@@ -4458,6 +4921,72 @@ async def _run_app_build(
     return {"ok": True}
 
 
+def _report_retained_stale_checkouts(
+    build_result: dict[str, Any] | None,
+    log_lines: list[str],
+    *,
+    filter_restorable: bool,
+) -> None:
+    """Log a "Previous checkout retained at" line for each moved-aside
+    checkout that will actually stay retained after this call.
+
+    CONTRACT: this is the ONLY owner of the "Previous checkout retained at"
+    wording — no exit re-implements the string. It has exactly TWO call sites,
+    and neither is a per-exit copy of the other:
+
+    - the ``finally`` of :func:`install_from_registry`, AFTER that ``finally``
+      has run its restore block. This is the ordinary path: it reaches EVERY
+      normal exit (success and refusal alike) via the single ``finally``,
+      passing the returned ``build_result`` and ``filter_restorable=not
+      durable_success`` so the flag is derived once, never hand-mirrored.
+    - the exception handler in :func:`_clone_build_app` (the ``except`` that
+      re-raises a build error). That path produces NO result dict — the
+      exception propagates instead of returning — so the ``finally`` above
+      never sees the move-aside state. This second call synthesises a minimal
+      dict from that scope's ``pending_cleanup``/``restorable_stale`` and
+      passes ``filter_restorable=True`` (the handler restored the same-origin
+      subset just above it), so a non-restorable ``.stale-*`` on the
+      exception path is still named instead of being silently swept.
+
+    Both routes funnel the wording through here precisely so they can never
+    drift: the reporter used to be hand-replicated across every exit with a
+    ``filter_restorable`` flag manually mirrored to ``durable_success`` at each
+    one, which is the scattered-per-exit stranding class the caller's
+    move-aside bookkeeping exists to avoid — a new exit could forget the call
+    or pass the wrong flag and silently strand or double-report a checkout.
+    Every normal exit now reaches the single ``finally`` call and derives the
+    flag once; the only other caller is the exception path that no ``finally``
+    return can cover.
+
+    ``_pending_stale_cleanup`` collects every move-aside regardless of
+    reason, but ``_restorable_stale`` (a subset) is put back by the
+    enclosing ``finally`` — and ONLY when the exit leaves ``durable_success``
+    False. The single call passes ``filter_restorable=not durable_success``,
+    exactly the restore condition, so the flag can never drift from it:
+
+    - On a failure exit (``durable_success`` False) the ``finally`` restored
+      the restorable stale just before this call, so ``filter_restorable`` is
+      True and that path — now back in place on disk — is filtered out rather
+      than misreported as retained.
+    - On a durable-success exit (``durable_success`` True) the ``finally``
+      restores nothing, so ``filter_restorable`` is False and a restorable
+      stale genuinely retained at ``.stale-*`` is reported instead of sitting
+      unlogged until the age-based sweep — the possible-data-loss case this
+      covers. A durable-success exit includes one where provenance
+      persistence raised AFTER ``durable_success`` was set: the generic
+      ``except`` catches it, the ``finally`` still sees ``durable_success``
+      True, and this reporter names the retained stale.
+    """
+    if build_result is None:
+        return
+    restorable = set(build_result.get("_restorable_stale") or []) if filter_restorable else set()
+    for stale in build_result.get("_pending_stale_cleanup") or []:
+        if stale in restorable:
+            continue
+        log_lines.append(f"Previous checkout retained at: {stale}")
+        logger.info("Retained stale checkout: %s", stale)
+
+
 async def install_from_registry(
     name: str,
     log_lines: list[str] | None = None,
@@ -4598,7 +5127,9 @@ async def install_from_registry(
     # a repointed row on a trusted forge would otherwise be cloned with the
     # gateway's ambient git/ssh identity -- the confused-deputy read this posture
     # exists to prevent.
-    index_originated = _remote_controlled_url(entry)    # OFFICIALNESS is decided from `_registry` ALONE, and BEFORE the
+    index_originated = _remote_controlled_url(
+        entry
+    )  # OFFICIALNESS is decided from `_registry` ALONE, and BEFORE the
     # owner-designated carve-out below: that carve-out flips index_originated as a
     # CREDENTIAL decision (owner explicitly designated the repo), but an
     # external-index entry never becomes an official-catalog entry — install
@@ -4746,6 +5277,18 @@ async def install_from_registry(
     build_result: dict[str, Any] = {}
     # Cleared only after the transaction durably succeeds; the `finally` below reads it.
     durable_success = False
+    # Every `return` below assigns here first (named `outcome`, not `result` —
+    # the kirocrew-managed path below already uses `result` for the
+    # install_app/update_app return value). `"log"` is stamped from
+    # `log_lines` at assignment time, but the `finally` backstop can append to
+    # `log_lines` (a restore confirmation, or the restore-failed WARNING) AFTER
+    # that value is already computed — a `return`'s expression is evaluated
+    # before `finally` runs, and `str.join` produces an immutable copy, so a
+    # later append never reaches an already-built "log" string. Because
+    # dicts ARE mutable, holding the same object here and re-stamping
+    # `outcome["log"]` at the end of `finally` (below) closes that gap instead
+    # of the WARNING silently never reaching the log the user sees.
+    outcome: dict[str, Any] | None = None
     try:
         # Best-effort sweep of aged .stale-* / .partial-* dirs before the
         # install — prevents unbounded accumulation without blocking.
@@ -4770,7 +5313,15 @@ async def install_from_registry(
             commit=commit,
         )
         if not build_result["ok"]:
-            return {**build_result, "log": "\n".join(log_lines)}
+            # A pre-build refusal (identity/admission gate inside
+            # _clone_build_app), a failed clone, or a failed build may have left
+            # a non-restorable origin-mismatch checkout moved aside. Retained-stale
+            # reporting and restorable-stale restoration are both owned by the
+            # single `finally` below: it runs on every exit, knows durable_success,
+            # and re-stamps outcome["log"], so no per-exit report or log join is
+            # needed here.
+            outcome = {**build_result}
+            return outcome
 
         app_source = build_result["pkg_dir"]
         clone_root = app_source
@@ -4781,12 +5332,58 @@ async def install_from_registry(
             # setup.onInstall) at an attacker-selected path outside the clone.
             contained = _contained_join(app_source, subdirectory)
             if contained is None:
-                return {
+                # subdirectory FAILED containment here — by definition it is
+                # an escaping value (absolute, "..", or a symlink pointing
+                # outside app_source). It must never be joined onto pkg_dir
+                # for a filesystem write; that is exactly what
+                # _contained_join guards against. The manifest-restore step
+                # of _unpoison_rejected_checkout writes to
+                # ``pkg_dir / manifest_relpath`` when checkout_preexisted is
+                # True, so passing the raw subdirectory as manifest_relpath
+                # there would let a symlinked subdirectory redirect that
+                # write outside the sandboxed checkout.
+                #
+                # A successful clone+build already ran (build_result["ok"] is
+                # True), so any moved-aside checkout from a branch/origin
+                # re-convergence must not be silently stranded by this
+                # refusal — but only the delete-this-run's-checkout /
+                # restore-previous-checkout branch of the helper (taken when
+                # checkout_preexisted is False) is safe here: it never
+                # touches manifest_relpath. When the checkout PRE-existed,
+                # skip cleanup entirely and return the refusal as-is rather
+                # than risk that write.
+                if not build_result.get("_checkout_preexisted"):
+                    # Restoring a moved-aside checkout here means giving the
+                    # rejected clone's own pkg_dir back to the CALLER as the
+                    # active checkout, even though the containment gate just
+                    # refused it. That is only safe for a restorable
+                    # (same-origin, branch-drift) stale, never for a
+                    # non-restorable (origin-mismatch, different repository)
+                    # one — restoring an origin-mismatched stale here is
+                    # exactly the "hand the build the tree the gate refused"
+                    # case _restorable_stale exists to prevent, so it must be
+                    # filtered out the same way every other restoration site
+                    # in this module filters it.
+                    await _unpoison_rejected_checkout(
+                        name,
+                        app_source_dir(name),
+                        log_lines,
+                        checkout_preexisted=False,
+                        pre_pull_commit="",
+                        restore_from=_restorable_or_none(
+                            build_result.get("_pending_stale_cleanup"),
+                            build_result.get("_restorable_stale"),
+                        ),
+                    )
+                # The _unpoison above restores only a restorable stale, so an
+                # origin-mismatch one is stranded here — the `finally`-owned
+                # reporter names it and re-stamps outcome["log"].
+                outcome = {
                     "ok": False,
                     "name": name,
                     "error": f"unsafe subdirectory {subdirectory!r} escapes the app source root",
-                    "log": "\n".join(log_lines),
                 }
+                return outcome
             app_source = contained
 
         # NOTE: a missing app.json is handled by the identity gate below
@@ -4819,7 +5416,7 @@ async def install_from_registry(
         # not a pass. ``install_app``/``update_app`` derive the installed
         # identity from this manifest, so it must still match the entry here.
         if manifest_data is None or str(manifest_data.get("name", "") or "") != name:
-            return await _refuse_identity_mismatch(
+            outcome = await _refuse_identity_mismatch(
                 name,
                 str((manifest_data or {}).get("name", "") or ""),
                 repo,
@@ -4829,8 +5426,14 @@ async def install_from_registry(
                 pre_pull_commit=str(build_result.get("_pre_pull_commit", "") or ""),
                 manifest_relpath=(f"{subdirectory}/app.json" if subdirectory else "app.json"),
                 manifest_snapshot=build_result.get("_pre_update_manifest"),
-                restore_from=next(iter(build_result.get("_pending_stale_cleanup") or []), None),
+                restore_from=_restorable_or_none(
+                    build_result.get("_pending_stale_cleanup"),
+                    build_result.get("_restorable_stale"),
+                ),
             )
+            # Retained-stale reporting for this refusal is owned by the
+            # `finally` below (it re-stamps outcome["log"] on every exit).
+            return outcome
 
         # ADMISSION GATE, third pass — the post-build manifest is what
         # install_app/update_app will actually register, and a build step can
@@ -4856,6 +5459,9 @@ async def install_from_registry(
             # Same retry-poisoning hazard as the cloned-admission gate: the
             # checkout sits at the rejected commit and the prefetch prefers it,
             # so clean up with the same delete-fresh/roll-back semantics.
+            # _unpoison restores only the restorable subset; the `finally`-owned
+            # reporter names any stranded non-restorable move-aside from
+            # on-disk truth after this restore and re-stamps outcome["log"].
             await _unpoison_rejected_checkout(
                 name,
                 app_source_dir(name),
@@ -4864,14 +5470,17 @@ async def install_from_registry(
                 pre_pull_commit=str(build_result.get("_pre_pull_commit", "") or ""),
                 manifest_relpath=(f"{subdirectory}/app.json" if subdirectory else "app.json"),
                 manifest_snapshot=build_result.get("_pre_update_manifest"),
-                restore_from=next(iter(build_result.get("_pending_stale_cleanup") or []), None),
+                restore_from=_restorable_or_none(
+                    build_result.get("_pending_stale_cleanup"),
+                    build_result.get("_restorable_stale"),
+                ),
             )
-            return {
+            outcome = {
                 "ok": False,
                 "name": name,
                 "error": f"blocked by admission policy: {denied}",
-                "log": "\n".join(log_lines),
             }
+            return outcome
 
         # NOTE: the provenance commit AND signer are both resolved AFTER the
         # install-script block below — onInstall runs with write access to the
@@ -4923,12 +5532,14 @@ async def install_from_registry(
                 # Kill the entire process group (shell + children), reap the
                 # child, and escalate SIGTERM -> SIGKILL if it ignores the term.
                 await _kill_process_group(proc)
-                return {
+                # Retained-stale reporting and restorable-stale restoration are
+                # owned by the `finally` below (it re-stamps outcome["log"]).
+                outcome = {
                     "ok": False,
                     "name": name,
                     "error": f"install script timed out after {_SCRIPT_TIMEOUT}s",
-                    "log": "\n".join(log_lines),
                 }
+                return outcome
 
             lines = stdout.decode(errors="replace").strip().split("\n")
             if len(lines) > 50:
@@ -4938,12 +5549,14 @@ async def install_from_registry(
                 log_lines.extend(lines)
 
             if proc.returncode != 0:
-                return {
+                # Retained-stale reporting and restorable-stale restoration are
+                # owned by the `finally` below (it re-stamps outcome["log"]).
+                outcome = {
                     "ok": False,
                     "name": name,
                     "error": f"install script failed (exit {proc.returncode})",
-                    "log": "\n".join(log_lines),
                 }
+                return outcome
 
             # Reap any SURVIVING descendants of the script's process group
             # before the final gates re-read app.json: a backgrounded child
@@ -4987,7 +5600,7 @@ async def install_from_registry(
             except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
                 logger.debug("post-script app.json for %s is unreadable: %s", name, exc)
             if manifest_data is None or str(manifest_data.get("name", "") or "") != name:
-                return await _refuse_identity_mismatch(
+                outcome = await _refuse_identity_mismatch(
                     name,
                     str((manifest_data or {}).get("name", "") or ""),
                     repo,
@@ -4997,8 +5610,14 @@ async def install_from_registry(
                     pre_pull_commit=str(build_result.get("_pre_pull_commit", "") or ""),
                     manifest_relpath=(f"{subdirectory}/app.json" if subdirectory else "app.json"),
                     manifest_snapshot=build_result.get("_pre_update_manifest"),
-                    restore_from=next(iter(build_result.get("_pending_stale_cleanup") or []), None),
+                    restore_from=_restorable_or_none(
+                        build_result.get("_pending_stale_cleanup"),
+                        build_result.get("_restorable_stale"),
+                    ),
                 )
+                # Retained-stale reporting for this post-script refusal is owned
+                # by the `finally` below (it re-stamps outcome["log"]).
+                return outcome
             denied = app_admission_denied(
                 name,
                 manifest=AppManifest.from_dict(manifest_data),
@@ -5020,6 +5639,9 @@ async def install_from_registry(
                 # denial leaves it poisoned exactly like the earlier gates —
                 # apply the same delete-fresh/roll-back cleanup so a retry
                 # can pull a fixed remote instead of re-rejecting at prefetch.
+                # _unpoison restores only the restorable subset; the
+                # `finally`-owned reporter names any stranded non-restorable
+                # move-aside from on-disk truth and re-stamps outcome["log"].
                 await _unpoison_rejected_checkout(
                     name,
                     app_source_dir(name),
@@ -5028,14 +5650,17 @@ async def install_from_registry(
                     pre_pull_commit=str(build_result.get("_pre_pull_commit", "") or ""),
                     manifest_relpath=(f"{subdirectory}/app.json" if subdirectory else "app.json"),
                     manifest_snapshot=build_result.get("_pre_update_manifest"),
-                    restore_from=next(iter(build_result.get("_pending_stale_cleanup") or []), None),
+                    restore_from=_restorable_or_none(
+                        build_result.get("_pending_stale_cleanup"),
+                        build_result.get("_restorable_stale"),
+                    ),
                 )
-                return {
+                outcome = {
                     "ok": False,
                     "name": name,
                     "error": f"blocked by admission policy: {denied}",
-                    "log": "\n".join(log_lines),
                 }
+                return outcome
 
         # Provenance is pinned from the FINAL state — after the build, the
         # install script, and the last identity/admission gates: the exact
@@ -5102,14 +5727,11 @@ async def install_from_registry(
 
             log_lines.append("Pre-registered from cloned manifest (self-managed)")
             log_lines.append("App will update its own registration on next launch")
-            # Retain moved-aside checkouts so the user can recover local
-            # edits; they will be swept after _STALE_CHECKOUT_RETENTION_DAYS.
-            for _stale in build_result.get("_pending_stale_cleanup") or []:
-                log_lines.append(
-                    f"Previous checkout retained at: {_stale} "
-                    f"(removed automatically after {_STALE_CHECKOUT_RETENTION_DAYS} days)"
-                )
-                logger.info("Retained stale checkout: %s", _stale)
+            # Retained moved-aside checkouts (the user can recover local edits;
+            # swept after _STALE_CHECKOUT_RETENTION_DAYS) are reported by the
+            # `finally`-owned reporter: durable_success is True, so it runs with
+            # filter_restorable=False and names the genuinely-retained restorable
+            # stale rather than letting it sit unlogged until the sweep.
             if official_entry:
                 install_receipt.dispatch(
                     name,
@@ -5118,12 +5740,12 @@ async def install_from_registry(
                         install_receipt.KIND_UPDATE if was_installed else install_receipt.KIND_FRESH
                     ),
                 )
-            return {
+            outcome = {
                 "ok": True,
                 "name": name,
                 "message": f"installed {name} from {repo} (self-managed)",
-                "log": "\n".join(log_lines),
             }
+            return outcome
 
         # Kirocrew-managed: copy to ~/.kiro/crew/apps/ and register resources
         log_lines.append("Installing app...")
@@ -5162,14 +5784,14 @@ async def install_from_registry(
                 commit=source_commit,
                 signer=source_signer,
             )
-            # Retain moved-aside checkouts so the user can recover local
-            # edits; they will be swept after _STALE_CHECKOUT_RETENTION_DAYS.
-            for _stale in build_result.get("_pending_stale_cleanup") or []:
-                log_lines.append(
-                    f"Previous checkout retained at: {_stale} "
-                    f"(removed automatically after {_STALE_CHECKOUT_RETENTION_DAYS} days)"
-                )
-                logger.info("Retained stale checkout: %s", _stale)
+            # Retained moved-aside checkouts are reported by the `finally`-owned
+            # reporter (durable_success is True, filter_restorable=False), so a
+            # genuinely-retained restorable stale is named rather than sitting
+            # unlogged at `.stale-*` until the sweep. NOTE set_app_provenance
+            # above runs while durable_success is already True: if it raises, the
+            # generic `except` catches it, the `finally` does NOT restore (durable
+            # success), and it reports with filter_restorable=not durable_success
+            # = False — so the restorable stale is reported, not stranded.
             if official_entry:
                 # Detached best-effort telemetry runs only after durable success.
                 install_receipt.dispatch(
@@ -5179,18 +5801,27 @@ async def install_from_registry(
                         install_receipt.KIND_UPDATE if was_installed else install_receipt.KIND_FRESH
                     ),
                 )
+        # Install/update failed AFTER a successful clone+build: durable_success
+        # stays False, so the `finally` restores the restorable stale and its
+        # reporter filters it out — no per-exit report is needed here.
 
-        return {
+        outcome = {
             "ok": result.ok,
             "name": name,
             "message": result.message,
             "error": result.error,
-            "log": "\n".join(log_lines),
         }
+        return outcome
 
     except Exception as exc:
         logger.exception("Failed to install %s from registry", name)
-        return {"ok": False, "name": name, "error": str(exc), "log": "\n".join(log_lines)}
+        # Retained-stale reporting and restorable-stale restoration are owned by
+        # the `finally` below. It reports with filter_restorable=not
+        # durable_success, which is precisely why an exception raised AFTER
+        # durable_success was set (e.g. set_app_provenance) still names the
+        # genuinely-retained restorable stale instead of stranding it.
+        outcome = {"ok": False, "name": name, "error": str(exc)}
+        return outcome
     finally:
         # RESTORATION BELONGS TO THE LIFETIME, NOT TO THE LIST OF FAILURES.
         #
@@ -5234,3 +5865,45 @@ async def install_from_registry(
                     "WARNING: the previous checkout could not be restored; recover it "
                     "from the .stale-* sibling directory"
                 )
+
+        # THE reporter, owned by this `finally` and nowhere else. Placed AFTER
+        # the restore block above so it reports on-disk truth: a restorable stale
+        # the restore just put back must not then be named as retained. The flag
+        # is derived, not hand-mirrored at each exit — `not durable_success` is
+        # exactly the restore condition above, so a failure exit (restored) files
+        # its restorable stale out and a durable-success exit (never restored)
+        # keeps it. This is the whole point of the consolidation: a new exit
+        # added to this function cannot forget the report or pass the wrong flag,
+        # because there are no per-exit reports left to forget. A no-op unless a
+        # move-aside exists (pre-clone exits and the happy-path-with-no-stale
+        # pass through untouched).
+        _report_retained_stale_checkouts(
+            build_result, log_lines, filter_restorable=not durable_success
+        )
+
+        # Re-stamp AFTER the restore and the report above: each `return` built its
+        # `outcome` dict WITHOUT a "log" key, deferring it to here so the restore
+        # confirmation, the restore-failed WARNING, and the retained-stale lines
+        # just produced all reach the caller. `outcome` is the SAME dict object
+        # being returned (dicts are mutable), so setting its "log" key here is
+        # what the caller receives. Pre-clone exits return bare dicts that already
+        # carry their own "log" and never set `outcome`, so they skip this
+        # backstop and keep their join.
+        if outcome is not None:
+            outcome["log"] = "\n".join(log_lines)
+            # Scrub the internal move-aside/transaction bookkeeping keys from
+            # the dict that leaves this function. They are consumed ABOVE (the
+            # restore block and the reporter both read them off `build_result`,
+            # never off `outcome`), so removing them here deprives no consumer.
+            # Two of them -- `_pending_stale_cleanup` and `_restorable_stale` --
+            # are `list[Path]`, which is not JSON-serializable, so a build
+            # refusal that spreads `{**build_result}` into `outcome` used to make
+            # the API/SSE layer raise `TypeError` when it serialized the refusal.
+            # Scrubbing the CLASS (every `_`-prefixed key) rather than those two
+            # names closes it at the single seam: `_checkout_preexisted`,
+            # `_pre_pull_commit`, and `_pre_update_manifest` are internal gate
+            # state too, and no current or future exit can leak any of them once
+            # they are stripped here. Underscore keys are internal by
+            # convention; a response field the caller needs is never named `_x`.
+            for _internal_key in [k for k in outcome if k.startswith("_")]:
+                outcome.pop(_internal_key, None)

--- a/test/test_app_execution.py
+++ b/test/test_app_execution.py
@@ -784,15 +784,13 @@ class TestRegistryAndProvenanceBoundary:
             return item
 
         monkeypatch.setattr(registry, "_load_external_registries", _no_external_registries)
-        # The official catalog is a THIRD inventory source, so this test has to
-        # isolate it exactly as it already isolates the seed and the external
-        # registries. Left unpatched it reaches the live document over the
-        # network, and the assertion below would then depend on what the store
-        # currently ships. Inventory comes from a fresh fetch, so patching this
-        # source covers both the listing and the install-resolution paths.
-        monkeypatch.setattr(registry.official_catalog, "fetch_inventory_entries", lambda: [])
         monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
         monkeypatch.setattr(registry, "_resolve_manifest", _identity_manifest)
+        # Isolate from the official catalog: list_registry now materialises its
+        # git entries as installable rows via a fresh network fetch. Without this
+        # the listing picks up whatever the live catalog serves, which is neither
+        # deterministic nor what this test is about.
+        monkeypatch.setattr(registry.official_catalog, "fetch_inventory_entries", lambda: [])
         monkeypatch.setattr(execution, "third_party_execution_allowed", lambda: False)
 
         async def _unexpected_spawn(*args, **kwargs):

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -570,6 +570,8 @@ async def test_reused_checkout_pull_never_repoints_origin(monkeypatch, tmp_path)
 
     monkeypatch.setattr(registry, "_clone_origin_url", _fake_origin)
 
+    monkeypatch.setattr(registry, "_read_clone_branch", lambda clone_dir: "main")
+
     spawned: list[list[str]] = []
 
     class _Proc:
@@ -632,6 +634,8 @@ async def test_failed_pull_aborts_instead_of_installing_stale_code(monkeypatch, 
         return "https://example.com/demo.git"
 
     monkeypatch.setattr(registry, "_clone_origin_url", _fake_origin)
+
+    monkeypatch.setattr(registry, "_read_clone_branch", lambda clone_dir: "main")
 
     class _Proc:
         pid = 4242
@@ -923,12 +927,15 @@ async def test_postscript_admission_rejection_rolls_back_preexisting_checkout(
 
 
 @pytest.mark.asyncio
-async def test_moveaside_reclone_treated_as_fresh_on_rejection(monkeypatch, tmp_path):
+async def test_moveaside_reclone_retained_not_restored_on_rejection(monkeypatch, tmp_path):
     """When the origin-mismatch gate moves an old checkout aside and
     fresh-clones, a rejection must delete the fresh re-clone (never preserve it
-    or reset it toward the moved-aside repository's commit) and RESTORE the
-    moved-aside previous checkout — otherwise the slot is left empty and the
-    user's old workspace is stranded as a sweeper-doomed .stale-* sibling."""
+    or reset it toward the moved-aside repository's commit) and must NOT
+    restore the moved-aside previous checkout: an origin-mismatch move-aside is
+    a DIFFERENT repository, so handing it back to the slot would give a later
+    retry the very tree this gate already refused. It stays RETAINED as a
+    `.stale-*` sibling (recoverable by hand, swept on a retention timer), which
+    is why only a same-origin/branch-drift move-aside is ever restored."""
     src = tmp_path / "app-sources" / "demoapp"
     (src / ".git").mkdir(parents=True)  # OLD checkout pre-exists (origin A)
     (src / "old-work.txt").write_text("precious", encoding="utf-8")
@@ -937,7 +944,9 @@ async def test_moveaside_reclone_treated_as_fresh_on_rejection(monkeypatch, tmp_
     monkeypatch.setattr(registry, "_resolved_clone_commit", lambda root: "a" * 40)
 
     async def _fake_clone(git_url, branch, dest, log_lines, **kwargs):
-        # Simulate the origin-mismatch move-aside + fresh re-clone.
+        # Simulate the origin-mismatch move-aside + fresh re-clone. Only
+        # `pending_cleanup` is populated, never `restorable_stale` — an
+        # origin-mismatch move is never restorable.
         moved = dest.with_name("demoapp.stale-deadbeef")
         dest.rename(moved)
         cleanup = kwargs.get("pending_cleanup")
@@ -974,11 +983,13 @@ async def test_moveaside_reclone_treated_as_fresh_on_rejection(monkeypatch, tmp_
     assert result["ok"] is False
     # No rollback is attempted toward the moved-aside repo's commit ...
     assert not any(cmd[:3] == ["git", "reset", "--keep"] for cmd in spawned)
-    # ... the rejected re-clone is gone, and the PREVIOUS checkout is back.
-    assert src.exists()
-    assert (src / "old-work.txt").read_text(encoding="utf-8") == "precious"
-    assert not (src / "app.json").exists()  # the rejected clone's manifest is gone
-    assert not src.with_name("demoapp.stale-deadbeef").exists()  # moved back, not stranded
+    # ... the rejected re-clone is gone from the active slot ...
+    assert not src.exists()
+    # ... and the ORIGIN-mismatched previous checkout is retained, not
+    # restored into the slot the gate just refused it for.
+    stale = src.with_name("demoapp.stale-deadbeef")
+    assert stale.exists()
+    assert (stale / "old-work.txt").read_text(encoding="utf-8") == "precious"
 
 
 @pytest.mark.asyncio
@@ -1636,7 +1647,11 @@ async def test_a_monorepo_subdirectory_is_built_not_the_clone_root(tmp_path, mon
     monkeypatch.setattr(registry, "sel", lambda: MagicMock())
 
     await registry._clone_build_app_locked(
-        "https://example.invalid/r.git", "my-tool", [], subdirectory="apps/my-tool"
+        "https://example.invalid/r.git",
+        "my-tool",
+        [],
+        subdirectory="apps/my-tool",
+        pending_cleanup=[],
     )
 
     assert captured, "the build must be attempted"
@@ -1669,7 +1684,11 @@ async def test_a_traversing_subdirectory_does_not_choose_the_build_dir(tmp_path,
     monkeypatch.setattr(registry, "sel", lambda: MagicMock())
 
     result = await registry._clone_build_app_locked(
-        "https://example.invalid/r.git", "evil", [], subdirectory="../../etc"
+        "https://example.invalid/r.git",
+        "evil",
+        [],
+        subdirectory="../../etc",
+        pending_cleanup=[],
     )
 
     assert result["ok"] is False

--- a/test/test_external_registry.py
+++ b/test/test_external_registry.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -31,6 +33,27 @@ from kiro_crew.apps.registry import (
     known_registry_repos,
     refresh_registries,
 )
+
+# Bound every gated-executor worker wait in this module. A test that gates a
+# move-aside worker on a threading.Event and fails before signalling the
+# release would otherwise leave that worker blocked against tmp_path past
+# teardown (hanging xdist worker shutdown or mutating a directory a later test
+# already deleted). Generous enough never to false-fire on a loaded shared
+# runner.
+_WORKER_RELEASE_TIMEOUT = 30.0
+
+
+async def _bounded_off_loop(loop: asyncio.AbstractEventLoop, event: threading.Event) -> None:
+    """Await *event* off the event loop, bounded by ``_WORKER_RELEASE_TIMEOUT``.
+
+    Waiting for a worker's signal on a bare ``threading.Event`` via
+    ``run_in_executor`` blocks an executor thread; if the worker never signals
+    (an assertion failed before it ran), an unbounded wait would hang the test
+    process. The bound turns that into a fast, loud failure instead.
+    """
+    signalled = await loop.run_in_executor(None, event.wait, _WORKER_RELEASE_TIMEOUT)
+    assert signalled, "worker never signalled within the release timeout"
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1847,9 +1870,7 @@ class TestConfiguredBranchOverride:
         cached = reg._read_external_registry_cache("acme", ignore_ttl=True)
         assert cached[0]["branch"] == "develop"
         # The divergence is logged, naming both branches and the entry.
-        divergence_logs = [
-            r for r in caplog.records if "declares branch" in r.getMessage()
-        ]
+        divergence_logs = [r for r in caplog.records if "declares branch" in r.getMessage()]
         assert len(divergence_logs) == 1
         msg = divergence_logs[0].getMessage()
         assert "eager-app" in msg and "'main'" in msg and "'develop'" in msg
@@ -1878,9 +1899,7 @@ class TestConfiguredBranchOverride:
         assert not [r for r in caplog.records if "declares branch" in r.getMessage()]
 
     @pytest.mark.asyncio
-    async def test_matching_declared_branch_does_not_warn(
-        self, cache_dir, monkeypatch, caplog
-    ):
+    async def test_matching_declared_branch_does_not_warn(self, cache_dir, monkeypatch, caplog):
         # A declaration that AGREES with the configured branch is not a
         # divergence — the warning must fire only on a genuine mismatch.
         import kiro_crew.apps.registry as reg
@@ -1901,9 +1920,7 @@ class TestConfiguredBranchOverride:
         assert not [r for r in caplog.records if "declares branch" in r.getMessage()]
 
     @pytest.mark.asyncio
-    async def test_cross_repo_entry_keeps_declared_branch(
-        self, cache_dir, monkeypatch, caplog
-    ):
+    async def test_cross_repo_entry_keeps_declared_branch(self, cache_dir, monkeypatch, caplog):
         # A cross-repo entry's declared branch names a ref in ANOTHER
         # repository, about which the configured registry branch carries no
         # information. The override must not touch it (and must not warn) —
@@ -3352,8 +3369,10 @@ class TestInstallScriptFailurePreservesStaleCheckout:
 
     @pytest.mark.asyncio
     async def test_clone_build_surfaces_pending_stale_cleanup(self, tmp_path):
-        """_clone_build_app_locked returns _pending_stale_cleanup paths on
-        success instead of deleting them (deferring to caller)."""
+        """_clone_build_app surfaces _pending_stale_cleanup paths on the result
+        (via its single-exit stamp) instead of deleting them (deferring to
+        caller). The stamp lives on the wrapper so EVERY dict result carries
+        it, refusals included, not only the ok path."""
         import kiro_crew.apps.registry as reg
 
         stale_url = "https://old.example.com/app.git"
@@ -3406,7 +3425,7 @@ class TestInstallScriptFailurePreservesStaleCheckout:
             ),
             patch("kiro_crew.apps.registry._looks_like_git_url", return_value=True),
         ):
-            result = await reg._clone_build_app_locked(
+            result = await reg._clone_build_app(
                 new_url, "testapp", [], branch="main", index_originated=False
             )
 
@@ -3416,7 +3435,7 @@ class TestInstallScriptFailurePreservesStaleCheckout:
         stale_paths = result.get("_pending_stale_cleanup", [])
         assert len(stale_paths) == 1
         assert stale_paths[0].exists(), (
-            "Expected .stale-* dir to still exist after _clone_build_app_locked "
+            "Expected .stale-* dir to still exist after _clone_build_app "
             "success (deferred to caller)"
         )
         assert ".stale-" in stale_paths[0].name
@@ -3493,14 +3512,28 @@ class TestInstallScriptFailurePreservesStaleCheckout:
             result = await install_from_registry("testapp")
 
         assert not result["ok"]
-        assert (pkg_dir / "my-work.txt").read_text(encoding="utf-8") == "important", (
-            "the user's edited checkout must be back in place after a failed update"
-        )
+        assert (pkg_dir / "my-work.txt").read_text(
+            encoding="utf-8"
+        ) == "important", "the user's edited checkout must be back in place after a failed update"
         assert not (pkg_dir / "replacement.txt").exists(), "the replacement is discarded"
         assert not stale_dir.exists()
+        # Regression: `"log": "\n".join(log_lines)` is built at the `return`
+        # inside the `try`, which runs BEFORE this `finally`-driven restore. A
+        # dict return value is mutable, but the string it briefly held is not
+        # -- appending to log_lines from `finally` after that point silently
+        # never reached the caller unless the returned dict itself is re-
+        # stamped from `finally`.
+        assert "Restored the previous checkout after the install did not complete" in result.get(
+            "log", ""
+        ), (
+            "the finally-driven restore actually happened (asserted above) but its "
+            "own confirmation message must reach the caller's log too"
+        )
 
     @pytest.mark.asyncio
-    async def test_restoration_works_when_the_failure_dict_omits_pkg_dir(self, tmp_path, monkeypatch):
+    async def test_restoration_works_when_the_failure_dict_omits_pkg_dir(
+        self, tmp_path, monkeypatch
+    ):
         """The exit Design Review found, which four rounds of rollback work missed.
 
         Every post-clone FAILURE dict omits `pkg_dir`, so reading it raised a KeyError
@@ -3549,9 +3582,9 @@ class TestInstallScriptFailurePreservesStaleCheckout:
             result = await install_from_registry("testapp")
 
         assert not result["ok"]
-        assert (pkg_dir / "my-work.txt").read_text(encoding="utf-8") == "important", (
-            "a failure dict without pkg_dir must still get the checkout restored"
-        )
+        assert (pkg_dir / "my-work.txt").read_text(
+            encoding="utf-8"
+        ) == "important", "a failure dict without pkg_dir must still get the checkout restored"
         assert not stale_dir.exists()
 
     @pytest.mark.asyncio
@@ -3610,9 +3643,9 @@ class TestInstallScriptFailurePreservesStaleCheckout:
             result = await install_from_registry("testapp")
 
         assert not result["ok"], "the bookkeeping failure is still reported"
-        assert (pkg_dir / "replacement.txt").exists(), (
-            "the installed source tree must NOT be rolled back under installed files"
-        )
+        assert (
+            pkg_dir / "replacement.txt"
+        ).exists(), "the installed source tree must NOT be rolled back under installed files"
         assert stale_dir.exists(), "the previous checkout is retained, not restored"
 
     @pytest.mark.asyncio
@@ -3671,9 +3704,9 @@ class TestInstallScriptFailurePreservesStaleCheckout:
             result = await install_from_registry("testapp")
 
         assert result["ok"], result
-        assert (pkg_dir / "replacement.txt").exists(), (
-            "a durable success must keep the tree it installed"
-        )
+        assert (
+            pkg_dir / "replacement.txt"
+        ).exists(), "a durable success must keep the tree it installed"
         assert stale_dir.exists(), "the old checkout is retained beside it, not restored"
 
     @pytest.mark.asyncio
@@ -3750,6 +3783,1070 @@ class TestInstallScriptFailurePreservesStaleCheckout:
         # The stale checkout was NOT deleted — user can recover.
         assert stale_dir.exists(), "Expected .stale-* dir to survive install script failure"
         assert (stale_dir / "my-work.txt").read_text() == "important"
+
+
+class TestMoveCheckoutAsideCancellationSafety:
+    """Regression: GPT 5.6 round-5 finding — a cancellation delivered while
+    awaiting ``_move_checkout_aside``'s rename+mtime-refresh must not leave
+    the moved-aside checkout silently unaccounted for.
+
+    The old implementation ran the rename and the mtime refresh as TWO
+    separate ``asyncio.to_thread`` calls; a cancellation landing between them
+    left ``aside`` on disk with the checkout's ORIGINAL mtime — immediately
+    eligible for the age-based sweep — and unrecorded, since the assignment
+    ``moved_aside = await _move_checkout_aside(...)`` never completed. Both
+    calls now run as one thread function (no mtime gap), and a cancellation
+    that arrives after that call already completed synchronously undoes the
+    rename so the caller's state is unchanged by the attempt.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancellation_after_completed_rename_restores_checkout(self, tmp_path):
+        """A deterministic, event-gated fake: the rename+refresh is allowed
+        to run to completion, a threading.Event confirms that on-disk state,
+        and only THEN is the awaiting task cancelled -- never a wall-clock
+        sleep racing the interleave."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "testapp"
+        dest.mkdir()
+        (dest / "marker.txt").write_text("original", encoding="utf-8")
+
+        rename_completed = threading.Event()
+        release_thread = threading.Event()
+        real_impl = reg._rename_and_refresh_mtime
+
+        def _gated_impl(d, a):
+            # Perform the real rename+utime, signal the test that it landed,
+            # then hold the worker thread (the underlying concurrent.futures
+            # future stays NOT DONE) until the test has issued the
+            # cancellation -- this is what pins the interleave to "cancel
+            # arrives strictly after the rename, strictly before the thread
+            # call reports its result" instead of leaving it to a race. The
+            # wait is BOUNDED: an early test failure that never signals must
+            # not leave this worker blocked against tmp_path past teardown.
+            real_impl(d, a)
+            rename_completed.set()
+            assert release_thread.wait(_WORKER_RELEASE_TIMEOUT), "worker was never released"
+
+        log_lines: list[str] = []
+        loop = asyncio.get_event_loop()
+        with patch.object(reg, "_rename_and_refresh_mtime", side_effect=_gated_impl):
+            try:
+                task = asyncio.ensure_future(reg._move_checkout_aside(dest, log_lines))
+                # Block off-loop until the worker thread's rename+utime has
+                # actually landed on disk -- deterministic, no wall-clock sleep.
+                await _bounded_off_loop(loop, rename_completed)
+                # The underlying thread call is still blocked (has not reported
+                # its result yet), so this cancellation is guaranteed to be
+                # observed before the coroutine would otherwise receive the
+                # completed rename's result.
+                task.cancel()
+                release_thread.set()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+            finally:
+                # Release the worker no matter how the body exits, so a failed
+                # assertion above can never strand the executor thread.
+                release_thread.set()
+
+        # The rename had already landed when cancellation arrived, so the
+        # helper must have undone it: dest is back with its original
+        # contents, and no `.stale-*` sibling is left stranded.
+        assert dest.exists()
+        assert (dest / "marker.txt").read_text(encoding="utf-8") == "original"
+        stranded = list(tmp_path.glob("testapp.stale-*"))
+        assert stranded == [], f"expected no stranded aside directory, found {stranded}"
+
+    @pytest.mark.asyncio
+    async def test_successful_move_aside_has_no_mtime_gap(self, tmp_path):
+        """Control: an un-cancelled move-aside still renames and refreshes
+        the mtime, and does so without the window a separate utime call used
+        to leave open — the aside's mtime must be fresh (close to now), not
+        the checkout's original, possibly-old, mtime."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "testapp"
+        dest.mkdir()
+        old_time = time.time() - 3600
+        os.utime(dest, (old_time, old_time))
+
+        log_lines: list[str] = []
+        aside = await reg._move_checkout_aside(dest, log_lines)
+
+        assert aside is not None
+        assert not dest.exists()
+        assert aside.exists()
+        assert abs(aside.stat().st_mtime - time.time()) < 60, (
+            "the aside's mtime must be refreshed to now, not inherited from "
+            "the checkout's original (possibly stale) mtime"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancellation_before_rename_settles_worker_and_does_not_strand(self, tmp_path):
+        """Round-6 regression (GPT 5.6): a cancellation delivered while the
+        move-aside worker is dispatched but has NOT yet renamed must still end
+        with the checkout accounted for. Cancelling the awaiting task does not
+        cancel the executor thread -- it runs on -- so a bare
+        ``if aside.exists()`` check races the in-thread rename: a worker past
+        dispatch but pre-rename at check time would complete the rename after
+        the handler re-raised, stranding the checkout at ``aside`` unrecorded.
+        The handler now settles the worker future BEFORE inspecting ``aside``,
+        so a rename that lands after the cancellation is undone (or the
+        retained path is logged) -- never silently stranded."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "testapp"
+        dest.mkdir()
+        (dest / "marker.txt").write_text("original", encoding="utf-8")
+
+        worker_started = threading.Event()
+        release_thread = threading.Event()
+        rename_done = threading.Event()
+        real_impl = reg._rename_and_refresh_mtime
+
+        def _gated_impl(d, a):
+            # Signal that the worker is running, then hold it BEFORE the
+            # rename -- so at cancellation time ``aside`` does not yet exist.
+            # Only after the test releases the thread does the rename land,
+            # reproducing the "worker renames after the cancel" interleave. The
+            # wait is BOUNDED so an early failure cannot strand the worker past
+            # teardown.
+            worker_started.set()
+            assert release_thread.wait(_WORKER_RELEASE_TIMEOUT), "worker was never released"
+            real_impl(d, a)
+            rename_done.set()
+
+        log_lines: list[str] = []
+        loop = asyncio.get_event_loop()
+        with patch.object(reg, "_rename_and_refresh_mtime", side_effect=_gated_impl):
+            try:
+                task = asyncio.ensure_future(reg._move_checkout_aside(dest, log_lines))
+                # Worker is dispatched and blocked strictly BEFORE the rename.
+                await _bounded_off_loop(loop, worker_started)
+                task.cancel()
+                # Let the handler resume and reach its settle-await; a bare
+                # check-then-race shape would instead re-raise here without ever
+                # waiting for the worker.
+                await asyncio.sleep(0)
+                # Now let the worker perform the rename -- AFTER the cancellation.
+                release_thread.set()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+                # Confirm the worker's rename actually landed on disk.
+                assert await loop.run_in_executor(
+                    None, lambda: rename_done.wait(_WORKER_RELEASE_TIMEOUT)
+                )
+            finally:
+                # Release the worker no matter how the body exits.
+                release_thread.set()
+
+        stranded = list(tmp_path.glob("testapp.stale-*"))
+        if stranded:
+            # If the undo could not run, the retained path MUST be logged so
+            # it is never silently unaccounted for.
+            assert any(
+                "retained at" in line for line in log_lines
+            ), f"a stranded aside {stranded} must be logged, not silent"
+        else:
+            assert dest.exists()
+            assert (dest / "marker.txt").read_text(encoding="utf-8") == "original"
+
+    @pytest.mark.asyncio
+    async def test_repeated_cancellation_still_settles_and_undoes_or_logs(self, tmp_path):
+        """Round-10 regression (GPT 5.6): a SECOND cancellation delivered while
+        the handler is awaiting settlement must not skip the undo-or-log.
+
+        The rename lands (aside exists), then the awaiting task is cancelled
+        while the worker thread is still held, driving the handler into its
+        settle-await. A second cancel is delivered there. The old handler used
+        a bare ``await asyncio.wait({worker})`` that re-raised on that second
+        cancel and skipped BOTH the aside->dest undo AND the retained-path log
+        -- stranding the checkout at an unreported ``.stale-*`` path until the
+        sweep deleted it. The handler now absorbs repeated cancels until the
+        worker future is done, THEN runs the synchronous undo-or-log, THEN
+        re-raises once. So this ends deterministically with either the aside
+        restored to dest OR the retained path named in the log -- never a
+        silent strand. Event-gated; no wall-clock sleeps."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "testapp"
+        dest.mkdir()
+        (dest / "marker.txt").write_text("original", encoding="utf-8")
+
+        rename_completed = threading.Event()
+        release_thread = threading.Event()
+        real_impl = reg._rename_and_refresh_mtime
+
+        def _gated_impl(d, a):
+            # Perform the real rename+utime so ``aside`` exists on disk, signal
+            # the test, then hold the worker thread NOT DONE until the test has
+            # delivered BOTH cancels -- pinning the "aside exists, worker still
+            # settling, second cancel arrives" interleave the fix must survive.
+            # BOUNDED so an early failure cannot strand the worker past teardown.
+            real_impl(d, a)
+            rename_completed.set()
+            assert release_thread.wait(_WORKER_RELEASE_TIMEOUT), "worker was never released"
+
+        log_lines: list[str] = []
+        loop = asyncio.get_event_loop()
+        with patch.object(reg, "_rename_and_refresh_mtime", side_effect=_gated_impl):
+            try:
+                task = asyncio.ensure_future(reg._move_checkout_aside(dest, log_lines))
+                # Block off-loop until the worker's rename+utime has landed on disk.
+                await _bounded_off_loop(loop, rename_completed)
+                # First cancel: delivered at ``await asyncio.shield(worker)``, so
+                # the coroutine enters its CancelledError handler and reaches the
+                # settle-await (the worker future is still NOT DONE -- held below).
+                task.cancel()
+                await asyncio.sleep(0)
+                # Second cancel: delivered while the handler is parked on its
+                # settle-await. The fix must absorb this and keep settling; the
+                # old bare wait re-raised here and skipped the undo/log.
+                task.cancel()
+                await asyncio.sleep(0)
+                # Now let the worker finish so the future settles.
+                release_thread.set()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+            finally:
+                # Release the worker no matter how the body exits.
+                release_thread.set()
+
+        # Repeated cancellation must NOT have stranded the checkout silently.
+        stranded = list(tmp_path.glob("testapp.stale-*"))
+        if stranded:
+            assert any("retained at" in line for line in log_lines), (
+                f"a stranded aside {stranded} must be logged after repeated "
+                f"cancellation, not silently swept"
+            )
+        else:
+            # The undo ran: the checkout is back in place, unchanged.
+            assert dest.exists()
+            assert (dest / "marker.txt").read_text(encoding="utf-8") == "original"
+
+    @pytest.mark.asyncio
+    async def test_cancel_with_failed_undo_logs_retained_path_durably(self, tmp_path, caplog):
+        """Round-14 regression (GPT 5.6, BLOCKING): a cancellation whose undo
+        FAILS must record the retained ``.stale-*`` path in a DURABLE sink
+        (``logger.warning``), not only in the request-local ``log_lines``.
+
+        A gateway shutdown cancels the update after the move-aside rename landed,
+        then the aside->dest undo fails. The request never returns, so its
+        ``log_lines`` are discarded — a list-only report would leave the
+        age-based sweep to later delete the unnamed recovery checkout. The fix
+        emits ``logger.warning`` with the exact retained path before re-raising,
+        so the path survives the shutdown in the process log. This asserts the
+        durable record specifically, not just the (also-discarded) log line."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "testapp"
+        dest.mkdir()
+        (dest / "marker.txt").write_text("original", encoding="utf-8")
+
+        rename_completed = threading.Event()
+        release_thread = threading.Event()
+        real_impl = reg._rename_and_refresh_mtime
+
+        def _gated_impl(d, a):
+            # Land the real rename+utime so ``aside`` exists, signal the test,
+            # then hold the worker NOT DONE until the test delivers the cancel.
+            real_impl(d, a)
+            rename_completed.set()
+            assert release_thread.wait(_WORKER_RELEASE_TIMEOUT), "worker was never released"
+
+        real_rename = Path.rename
+
+        def _undo_fails(self, target, *args, **kwargs):
+            # Fail ONLY the aside->dest undo (target is the original dest); the
+            # dest->aside move-aside already ran inside the worker via real_impl.
+            if Path(target) == dest:
+                raise OSError("simulated undo failure")
+            return real_rename(self, target, *args, **kwargs)
+
+        log_lines: list[str] = []
+        loop = asyncio.get_event_loop()
+        with caplog.at_level(logging.WARNING, logger=reg.logger.name):
+            with patch.object(reg, "_rename_and_refresh_mtime", side_effect=_gated_impl):
+                with patch.object(Path, "rename", _undo_fails):
+                    try:
+                        task = asyncio.ensure_future(reg._move_checkout_aside(dest, log_lines))
+                        await _bounded_off_loop(loop, rename_completed)
+                        task.cancel()
+                        await asyncio.sleep(0)
+                        release_thread.set()
+                        with pytest.raises(asyncio.CancelledError):
+                            await task
+                    finally:
+                        release_thread.set()
+
+        # The checkout is genuinely stranded at a .stale-* aside (the undo failed).
+        stranded = list(tmp_path.glob("testapp.stale-*"))
+        assert stranded, "the undo was supposed to fail, leaving a stranded aside"
+        aside_name = stranded[0].name
+        # The DURABLE record names the exact retained path. This is the point of
+        # the fix: caplog captures logger output that outlives the discarded
+        # log_lines, so an incident responder can find the recovery copy.
+        durable = [
+            rec.getMessage()
+            for rec in caplog.records
+            if "retained at" in rec.getMessage() and aside_name in rec.getMessage()
+        ]
+        assert durable, (
+            "the retained .stale-* path must be logged durably (logger.warning), "
+            f"not only into the request-local log_lines; caplog had: "
+            f"{[r.getMessage() for r in caplog.records]}"
+        )
+
+
+class TestMoveAsideRefreshesMtimeBeforeRename:
+    """Round-14 regression (GPT 5.6): the move-aside must refresh the retention
+    clock BEFORE the rename, so the moved-aside dir never appears under its
+    sweep-recognized ``.stale-*`` name carrying a stale (possibly expired) mtime.
+
+    The pre-fix ordering renamed first, then ran ``os.utime`` on the aside. For
+    a checkout already older than the retention window, that leaves the aside
+    visible under the sweepable name with an expired clock in the window between
+    the two syscalls — a CONCURRENT install running the age-based sweep in that
+    window deletes the user's recovery copy. Refreshing ``dest`` before the
+    rename closes the window: the dir is already fresh the instant it becomes
+    observable under the ``.stale-*`` name.
+    """
+
+    @pytest.mark.asyncio
+    async def test_refresh_precedes_rename_in_invocation_trace(self, tmp_path):
+        """The mtime refresh (``os.utime`` on ``dest``) is recorded strictly
+        before ``dest`` is renamed aside. Fails against the pre-fix
+        rename-then-utime ordering; passes with the refresh-then-rename fix."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "testapp"
+        dest.mkdir()
+        # Source is ALREADY older than the retention window — the exact
+        # condition under which a stale-clock aside would be swept immediately.
+        expired = time.time() - (reg._STALE_CHECKOUT_RETENTION_DAYS + 1) * 86400
+        os.utime(dest, (expired, expired))
+
+        trace: list[str] = []
+        real_utime = os.utime
+        real_rename = Path.rename
+
+        def _traced_utime(path, *args, **kwargs):
+            # Only the retention refresh (targeting the live dest) is of
+            # interest; record it and delegate to the real implementation.
+            if Path(path) == dest:
+                trace.append("utime(dest)")
+            return real_utime(path, *args, **kwargs)
+
+        def _traced_rename(self, target, *args, **kwargs):
+            if Path(self) == dest:
+                trace.append("rename(dest)")
+            return real_rename(self, target, *args, **kwargs)
+
+        log_lines: list[str] = []
+        with (
+            patch.object(reg.os, "utime", side_effect=_traced_utime),
+            patch.object(reg.Path, "rename", autospec=True, side_effect=_traced_rename),
+        ):
+            aside = await reg._move_checkout_aside(dest, log_lines)
+
+        assert aside is not None, f"move-aside should succeed; log: {log_lines!r}"
+        # The refresh must be recorded BEFORE the rename.
+        assert trace == ["utime(dest)", "rename(dest)"], (
+            "the retention clock must be refreshed on dest before the rename; "
+            f"observed order was {trace!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_expired_source_carries_fresh_clock_the_instant_it_is_swept_eligible(
+        self, tmp_path
+    ):
+        """On-disk proof: an already-expired checkout, once moved aside, sits at
+        the ``.stale-*`` name with a FRESH mtime (well inside the retention
+        window), so a concurrent age-based sweep cannot delete it. The sweep's
+        own age test is applied to the moved-aside dir to make the point
+        concrete."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "testapp"
+        dest.mkdir()
+        (dest / "marker.txt").write_text("recovery copy", encoding="utf-8")
+        expired = time.time() - (reg._STALE_CHECKOUT_RETENTION_DAYS + 1) * 86400
+        os.utime(dest, (expired, expired))
+
+        log_lines: list[str] = []
+        aside = await reg._move_checkout_aside(dest, log_lines)
+
+        assert aside is not None
+        assert ".stale-" in aside.name, "the aside must use the sweep-recognized name"
+        # Fresh clock: well inside the retention window, so the age-based sweep
+        # (cutoff = now - retention window) would NOT delete it.
+        cutoff = time.time() - reg._STALE_CHECKOUT_RETENTION_DAYS * 86400
+        assert aside.stat().st_mtime >= cutoff, (
+            "the moved-aside recovery copy must carry a fresh clock so a "
+            "concurrent sweep cannot delete it"
+        )
+        # And the recovery copy's contents survive intact.
+        assert (aside / "marker.txt").read_text(encoding="utf-8") == "recovery copy"
+
+
+class TestSubdirectoryEscapeRefusalNeverWritesOutsideCheckout:
+    """Regression: the subdirectory-containment refusal must never join the
+    raw, untrusted ``subdirectory`` onto ``pkg_dir`` for a filesystem write.
+
+    GPT 5.6 finding: on a containment refusal (``_contained_join`` returns
+    ``None``), the cleanup call built ``manifest_relpath`` from the raw
+    ``subdirectory`` value instead of the safely-contained path. When the
+    checkout PRE-existed, ``_unpoison_rejected_checkout`` writes the manifest
+    snapshot to ``pkg_dir / manifest_relpath`` — and a build step that
+    replaces ``subdirectory`` with a symlink pointing outside the checkout
+    made that write escape the sandbox.
+    """
+
+    @pytest.mark.asyncio
+    async def test_escaping_subdirectory_does_not_write_outside_checkout(self, tmp_path):
+        """A symlinked subdirectory that escapes containment must not cause
+        any write outside the cloned checkout, even when the checkout
+        pre-existed (update path)."""
+        from kiro_crew.apps.registry import install_from_registry
+
+        app_source = tmp_path / "app-source"
+        app_source.mkdir()
+        (app_source / "app.json").write_text('{"name": "testapp"}', encoding="utf-8")
+
+        # A directory OUTSIDE the checkout that a malicious build step wants
+        # the manifest-restore write to land in.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        # subdirectory "evil" is a symlink escaping app_source — this is what
+        # a compromised/malicious build step would do.
+        evil_link = app_source / "evil"
+        evil_link.symlink_to(outside)
+
+        def _fake_wrap_argv(argv, mode="standard"):
+            return list(argv), None
+
+        class _GitProc:
+            returncode = 1
+
+            async def communicate(self):
+                return (b"", None)
+
+        build_result = {
+            "ok": True,
+            "pkg_dir": app_source,
+            # Simulates an UPDATE of a pre-existing app checkout — the branch
+            # of _unpoison_rejected_checkout that performs the vulnerable
+            # manifest write.
+            "_checkout_preexisted": True,
+            "_pre_pull_commit": "deadbeef",
+            "_pre_update_manifest": b'{"name": "testapp", "pwned": true}',
+            "_pending_stale_cleanup": [],
+        }
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            return build_result
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={
+                    "repo": "https://example.com/app.git",
+                    "branch": "main",
+                    "subdirectory": "evil",
+                },
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.wrap_argv", side_effect=_fake_wrap_argv),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                new=AsyncMock(return_value=_GitProc()),
+            ),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert not result["ok"]
+        assert "unsafe subdirectory" in result.get("error", "")
+        # The manifest-restore write must NEVER have followed the symlink out
+        # of the checkout — "outside" must remain exactly as it was.
+        assert list(outside.iterdir()) == [], (
+            "containment refusal must not write into a symlink-escaped "
+            "subdirectory outside the checkout"
+        )
+
+
+class TestUnpoisonRejectedCheckoutRevalidatesSubdirectoryAtWriteTime:
+    """Regression: every call site that reaches ``_unpoison_rejected_checkout``
+    with ``checkout_preexisted=True`` (identity/admission gates before AND
+    after the install script runs) built ``manifest_relpath`` from the raw
+    ``subdirectory`` and trusted a containment check an EARLIER gate had
+    already made. A build step or ``onInstall`` script — which runs with
+    write access to the checkout between some of those gates — can replace
+    the subdirectory with a symlink escaping the checkout after that earlier
+    check passed, and this cleanup runs unsandboxed as the Kiro Crew process.
+    ``_unpoison_rejected_checkout`` must re-verify containment itself, at the
+    point of the write, rather than relying on every call site to remember.
+    """
+
+    @pytest.mark.asyncio
+    async def test_manifest_restore_skipped_when_subdirectory_escapes_at_write_time(self, tmp_path):
+        from kiro_crew.apps.registry import _unpoison_rejected_checkout
+
+        pkg_dir = tmp_path / "app-source"
+        pkg_dir.mkdir()
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        # An earlier gate saw a real directory here and passed containment;
+        # by the time this cleanup runs it has been replaced with a symlink
+        # escaping pkg_dir — e.g. by onInstall, which ran in between.
+        (pkg_dir / "sub").symlink_to(outside)
+
+        log_lines: list[str] = []
+        await _unpoison_rejected_checkout(
+            "testapp",
+            pkg_dir,
+            log_lines,
+            checkout_preexisted=True,
+            pre_pull_commit="",  # skip the git-reset branch; irrelevant here
+            manifest_relpath="sub/app.json",
+            manifest_snapshot=b'{"name": "testapp", "pwned": true}',
+        )
+
+        assert list(outside.iterdir()) == [], (
+            "manifest restore must not write through a symlink that escapes "
+            "pkg_dir, even when it was planted after an earlier containment check"
+        )
+        assert any("no longer resolves inside" in line for line in log_lines)
+
+    @pytest.mark.asyncio
+    async def test_manifest_restore_still_runs_when_subdirectory_stays_contained(self, tmp_path):
+        """Control: a legitimate, still-contained subdirectory must still get
+        its manifest restored — the new guard must not break the happy path."""
+        from kiro_crew.apps.registry import _unpoison_rejected_checkout
+
+        pkg_dir = tmp_path / "app-source"
+        sub = pkg_dir / "sub"
+        sub.mkdir(parents=True)
+        (sub / "app.json").write_text('{"name": "testapp", "pwned": true}', encoding="utf-8")
+
+        log_lines: list[str] = []
+        await _unpoison_rejected_checkout(
+            "testapp",
+            pkg_dir,
+            log_lines,
+            checkout_preexisted=True,
+            pre_pull_commit="",
+            manifest_relpath="sub/app.json",
+            manifest_snapshot=b'{"name": "testapp"}',
+        )
+
+        assert (sub / "app.json").read_text(encoding="utf-8") == '{"name": "testapp"}'
+
+    @pytest.mark.asyncio
+    async def test_manifest_restore_skipped_when_leaf_is_symlinked_inside_subdirectory(
+        self, tmp_path
+    ):
+        """GPT 5.6 round-5 finding: the old guard checked containment of
+        ``subdirectory`` (the directory) only, never the manifest LEAF
+        (``subdirectory/app.json``). A build step or ``onInstall`` script can
+        leave ``subdirectory`` itself an ordinary, correctly-contained
+        directory while replacing just its ``app.json`` with a symlink
+        escaping ``pkg_dir`` — that passed the old check and the raw write
+        then followed the symlink outside the checkout."""
+        from kiro_crew.apps.registry import _unpoison_rejected_checkout
+
+        pkg_dir = tmp_path / "app-source"
+        sub = pkg_dir / "sub"
+        sub.mkdir(parents=True)
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        target = outside / "security_policy.json"
+        target.write_text("untouched", encoding="utf-8")
+
+        # `sub` itself is a real, contained directory — only its app.json
+        # leaf is a symlink escaping pkg_dir.
+        (sub / "app.json").symlink_to(target)
+
+        log_lines: list[str] = []
+        await _unpoison_rejected_checkout(
+            "testapp",
+            pkg_dir,
+            log_lines,
+            checkout_preexisted=True,
+            pre_pull_commit="",
+            manifest_relpath="sub/app.json",
+            manifest_snapshot=b'{"name": "testapp", "pwned": true}',
+        )
+
+        assert target.read_text(encoding="utf-8") == "untouched", (
+            "the manifest restore must not follow a symlink planted at the "
+            "manifest leaf, even when the containing subdirectory is itself "
+            "a real, contained directory"
+        )
+        assert any("no longer resolves inside" in line for line in log_lines)
+
+    @pytest.mark.asyncio
+    async def test_manifest_restore_skipped_when_leaf_is_symlinked_no_subdirectory(self, tmp_path):
+        """Same attack, no ``subdirectory`` at all: the old guard was gated on
+        ``if subdirectory`` and never ran when subdirectory=="", so a
+        symlinked ``app.json`` at the checkout root was never re-checked
+        before the write."""
+        from kiro_crew.apps.registry import _unpoison_rejected_checkout
+
+        pkg_dir = tmp_path / "app-source"
+        pkg_dir.mkdir()
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        target = outside / "security_policy.json"
+        target.write_text("untouched", encoding="utf-8")
+
+        (pkg_dir / "app.json").symlink_to(target)
+
+        log_lines: list[str] = []
+        await _unpoison_rejected_checkout(
+            "testapp",
+            pkg_dir,
+            log_lines,
+            checkout_preexisted=True,
+            pre_pull_commit="",
+            manifest_relpath="app.json",
+            manifest_snapshot=b'{"name": "testapp", "pwned": true}',
+        )
+
+        assert target.read_text(encoding="utf-8") == "untouched", (
+            "the manifest restore must not follow a symlinked app.json even "
+            "with no subdirectory declared"
+        )
+        assert any("no longer resolves inside" in line for line in log_lines)
+
+
+class TestContainmentRefusalRestoreFromRespectsRestorableStale:
+    """Regression: the subdirectory-containment refusal's cleanup
+    (``_checkout_preexisted=False`` branch) must filter ``restore_from`` by
+    ``_restorable_stale`` the same way every other restoration site in this
+    module does.
+
+    Round-4 security review finding: the refusal passed the first
+    ``_pending_stale_cleanup`` entry to ``_unpoison_rejected_checkout``
+    unfiltered. When ``_clone_build_app_locked`` forces
+    ``_checkout_preexisted=False`` after an origin-mismatch (non-restorable,
+    different-repository) move-aside + a successful fresh clone/build, and
+    that fresh clone's declared ``subdirectory`` then fails containment, the
+    unfiltered ``restore_from`` renamed the origin-mismatched stale checkout
+    back into ``pkg_dir`` — exactly the "hand the build the tree the gate
+    refused" case ``_restorable_stale`` exists to prevent elsewhere in this
+    file.
+    """
+
+    @staticmethod
+    def _build_result(app_source, stale_dir, *, restorable):
+        result = {
+            "ok": True,
+            "pkg_dir": app_source,
+            "_checkout_preexisted": False,
+            "_pending_stale_cleanup": [stale_dir],
+        }
+        if restorable:
+            result["_restorable_stale"] = [stale_dir]
+        return result
+
+    @pytest.mark.asyncio
+    async def test_non_restorable_stale_is_not_restored_on_containment_refusal(self, tmp_path):
+        """A non-restorable (origin-mismatch) pending stale must NOT be
+        restored into pkg_dir when the freshly cloned repo's declared
+        subdirectory fails containment."""
+        from kiro_crew.apps.registry import install_from_registry
+
+        app_source = tmp_path / "app-source"
+        app_source.mkdir()
+        (app_source / "app.json").write_text('{"name": "testapp"}', encoding="utf-8")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (app_source / "evil").symlink_to(outside)
+
+        stale_dir = tmp_path / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "someone-elses-repo.txt").write_text("not restorable", encoding="utf-8")
+
+        build_result = self._build_result(app_source, stale_dir, restorable=False)
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            return build_result
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={
+                    "repo": "https://example.com/app.git",
+                    "branch": "main",
+                    "subdirectory": "evil",
+                },
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert not result["ok"]
+        assert "unsafe subdirectory" in result.get("error", "")
+        assert not app_source.exists(), "the rejected fresh clone must be removed"
+        assert stale_dir.exists(), "a non-restorable stale must never be restored"
+        assert (stale_dir / "someone-elses-repo.txt").read_text(
+            encoding="utf-8"
+        ) == "not restorable"
+
+    @pytest.mark.asyncio
+    async def test_restorable_stale_is_still_restored_on_containment_refusal(self, tmp_path):
+        """Control: a restorable (same-repository, branch-drift) pending
+        stale IS still restored into pkg_dir on the same containment
+        refusal — the fix must narrow, not remove, this path."""
+        from kiro_crew.apps.registry import install_from_registry
+
+        app_source = tmp_path / "app-source"
+        app_source.mkdir()
+        (app_source / "app.json").write_text('{"name": "testapp"}', encoding="utf-8")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (app_source / "evil").symlink_to(outside)
+
+        stale_dir = tmp_path / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        build_result = self._build_result(app_source, stale_dir, restorable=True)
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            return build_result
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={
+                    "repo": "https://example.com/app.git",
+                    "branch": "main",
+                    "subdirectory": "evil",
+                },
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert not result["ok"]
+        assert "unsafe subdirectory" in result.get("error", "")
+        assert not stale_dir.exists(), "the restorable stale is renamed back into pkg_dir"
+        assert app_source.exists()
+        assert (app_source / "my-work.txt").read_text(encoding="utf-8") == "important"
+
+
+class TestIdentityMismatchPreBuildRestoreFromRespectsRestorableStale:
+    """Regression: the pre-build IDENTITY GATE inside ``_clone_build_app_locked``
+    must filter ``restore_from`` through the local ``restorable_stale`` list
+    before handing it to ``_refuse_identity_mismatch`` — the same class of bug
+    fixed at the containment refusal above, just at a different call site.
+
+    Round-4 security review finding (step 10, site 1/3): this gate computed
+    ``restore_from`` as ``pending_cleanup[0] if pending_cleanup else None``
+    with no ``restorable_stale`` filter, so an origin-mismatched move-aside
+    could be restored into ``pkg_dir`` for a repo whose cloned ``app.json``
+    this very gate is refusing for declaring the wrong name.
+    """
+
+    @staticmethod
+    def _make_fake_clone(stale_dir, *, restorable):
+        async def _fake_clone(git_url, branch, dest, log_lines, **kwargs):
+            pending_cleanup = kwargs.get("pending_cleanup")
+            if pending_cleanup is not None:
+                pending_cleanup.append(stale_dir)
+            restorable_stale = kwargs.get("restorable_stale")
+            if restorable and restorable_stale is not None:
+                restorable_stale.append(stale_dir)
+            dest.mkdir(parents=True, exist_ok=True)
+            # Wrong name — trips the identity gate, not the admission gate.
+            (dest / "app.json").write_text(json.dumps({"name": "wrong-name"}), encoding="utf-8")
+            return None
+
+        return _fake_clone
+
+    @pytest.mark.asyncio
+    async def test_non_restorable_stale_is_not_restored_on_identity_mismatch(self, tmp_path):
+        from kiro_crew.apps.registry import _clone_build_app
+
+        app_source = tmp_path / "app-sources" / "testapp"
+        stale_dir = tmp_path / "app-sources" / "testapp.stale-deadbeef"
+        stale_dir.mkdir(parents=True)
+        (stale_dir / "someone-elses-repo.txt").write_text("not restorable", encoding="utf-8")
+
+        with (
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch(
+                "kiro_crew.apps.registry._git_clone_or_pull",
+                new=self._make_fake_clone(stale_dir, restorable=False),
+            ),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await _clone_build_app("https://example.com/app.git", "testapp", [])
+
+        assert not result["ok"]
+        assert "declares" in result.get("error", "")
+        assert not app_source.exists(), "the rejected fresh clone must be removed"
+        assert stale_dir.exists(), "a non-restorable stale must never be restored"
+        assert (stale_dir / "someone-elses-repo.txt").read_text(
+            encoding="utf-8"
+        ) == "not restorable"
+
+    @pytest.mark.asyncio
+    async def test_restorable_stale_is_still_restored_on_identity_mismatch(self, tmp_path):
+        from kiro_crew.apps.registry import _clone_build_app
+
+        app_source = tmp_path / "app-sources" / "testapp"
+        stale_dir = tmp_path / "app-sources" / "testapp.stale-deadbeef"
+        stale_dir.mkdir(parents=True)
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        with (
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch(
+                "kiro_crew.apps.registry._git_clone_or_pull",
+                new=self._make_fake_clone(stale_dir, restorable=True),
+            ),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await _clone_build_app("https://example.com/app.git", "testapp", [])
+
+        assert not result["ok"]
+        assert not stale_dir.exists(), "the restorable stale is renamed back into pkg_dir"
+        assert app_source.exists()
+        assert (app_source / "my-work.txt").read_text(encoding="utf-8") == "important"
+
+
+class TestIdentityMismatchPostBuildRestoreFromRespectsRestorableStale:
+    """Regression: the post-build IDENTITY GATE inside ``install_from_registry``
+    (the re-check that runs right after ``_clone_build_app`` returns
+    ``ok=True``) must filter ``restore_from`` through
+    ``build_result["_restorable_stale"]`` before handing it to
+    ``_refuse_identity_mismatch`` — same class of bug, third call site.
+    """
+
+    @staticmethod
+    def _build_result(app_source, stale_dir, *, restorable):
+        result = {
+            "ok": True,
+            "pkg_dir": app_source,
+            "_checkout_preexisted": False,
+            "_pending_stale_cleanup": [stale_dir],
+        }
+        if restorable:
+            result["_restorable_stale"] = [stale_dir]
+        return result
+
+    @pytest.mark.asyncio
+    async def test_non_restorable_stale_is_not_restored_on_identity_mismatch(self, tmp_path):
+        from kiro_crew.apps.registry import install_from_registry
+
+        app_source = tmp_path / "app-source"
+        app_source.mkdir()
+        # A build step rewrote app.json to a different name than the registry
+        # entry declares — the post-build re-check must catch this.
+        (app_source / "app.json").write_text('{"name": "wrong-name"}', encoding="utf-8")
+
+        stale_dir = tmp_path / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "someone-elses-repo.txt").write_text("not restorable", encoding="utf-8")
+
+        build_result = self._build_result(app_source, stale_dir, restorable=False)
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            return build_result
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={"repo": "https://example.com/app.git", "branch": "main"},
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert not result["ok"]
+        assert "declares" in result.get("error", "")
+        assert not app_source.exists(), "the rejected clone must be removed"
+        assert stale_dir.exists(), "a non-restorable stale must never be restored"
+        assert (stale_dir / "someone-elses-repo.txt").read_text(
+            encoding="utf-8"
+        ) == "not restorable"
+
+    @pytest.mark.asyncio
+    async def test_restorable_stale_is_still_restored_on_identity_mismatch(self, tmp_path):
+        from kiro_crew.apps.registry import install_from_registry
+
+        app_source = tmp_path / "app-source"
+        app_source.mkdir()
+        (app_source / "app.json").write_text('{"name": "wrong-name"}', encoding="utf-8")
+
+        stale_dir = tmp_path / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        build_result = self._build_result(app_source, stale_dir, restorable=True)
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            return build_result
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={"repo": "https://example.com/app.git", "branch": "main"},
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert not result["ok"]
+        assert not stale_dir.exists(), "the restorable stale is renamed back into pkg_dir"
+        assert app_source.exists()
+        assert (app_source / "my-work.txt").read_text(encoding="utf-8") == "important"
+
+
+class TestAdmissionGatePreBuildRestoreFromRespectsRestorableStale:
+    """Regression: the pre-build ADMISSION GATE (second pass, on the cloned
+    manifest) inside ``_clone_build_app_locked`` must filter ``restore_from``
+    through the local ``restorable_stale`` list before handing it to
+    ``_unpoison_rejected_checkout`` — same class of bug, second call site.
+    """
+
+    @staticmethod
+    def _make_fake_clone(stale_dir, *, restorable):
+        async def _fake_clone(git_url, branch, dest, log_lines, **kwargs):
+            pending_cleanup = kwargs.get("pending_cleanup")
+            if pending_cleanup is not None:
+                pending_cleanup.append(stale_dir)
+            restorable_stale = kwargs.get("restorable_stale")
+            if restorable and restorable_stale is not None:
+                restorable_stale.append(stale_dir)
+            dest.mkdir(parents=True, exist_ok=True)
+            # Correct name — passes the identity gate so the admission gate
+            # (patched to deny below) is the one that fires.
+            (dest / "app.json").write_text(json.dumps({"name": "testapp"}), encoding="utf-8")
+            return None
+
+        return _fake_clone
+
+    @pytest.mark.asyncio
+    async def test_non_restorable_stale_is_not_restored_on_admission_denial(self, tmp_path):
+        from kiro_crew.apps.registry import _clone_build_app
+
+        app_source = tmp_path / "app-sources" / "testapp"
+        stale_dir = tmp_path / "app-sources" / "testapp.stale-deadbeef"
+        stale_dir.mkdir(parents=True)
+        (stale_dir / "someone-elses-repo.txt").write_text("not restorable", encoding="utf-8")
+
+        with (
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch(
+                "kiro_crew.apps.registry._git_clone_or_pull",
+                new=self._make_fake_clone(stale_dir, restorable=False),
+            ),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value="unsigned"),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await _clone_build_app("https://example.com/app.git", "testapp", [])
+
+        assert not result["ok"]
+        assert "admission policy" in result.get("error", "")
+        assert not app_source.exists(), "the rejected fresh clone must be removed"
+        assert stale_dir.exists(), "a non-restorable stale must never be restored"
+        assert (stale_dir / "someone-elses-repo.txt").read_text(
+            encoding="utf-8"
+        ) == "not restorable"
+
+    @pytest.mark.asyncio
+    async def test_restorable_stale_is_still_restored_on_admission_denial(self, tmp_path):
+        from kiro_crew.apps.registry import _clone_build_app
+
+        app_source = tmp_path / "app-sources" / "testapp"
+        stale_dir = tmp_path / "app-sources" / "testapp.stale-deadbeef"
+        stale_dir.mkdir(parents=True)
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        with (
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch(
+                "kiro_crew.apps.registry._git_clone_or_pull",
+                new=self._make_fake_clone(stale_dir, restorable=True),
+            ),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value="unsigned"),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await _clone_build_app("https://example.com/app.git", "testapp", [])
+
+        assert not result["ok"]
+        assert not stale_dir.exists(), "the restorable stale is renamed back into pkg_dir"
+        assert app_source.exists()
+        assert (app_source / "my-work.txt").read_text(encoding="utf-8") == "important"
 
 
 # ---------------------------------------------------------------------------
@@ -3841,6 +4938,231 @@ class TestSuccessPathRetainsStaleCheckout:
         assert (stale_dir / "local-edits.txt").read_text() == "important work"
         # The log must name the retained path.
         assert str(stale_dir) in result.get("log", "")
+
+
+class TestRetainedAtReportingSkipsRestorableStale:
+    """Regression: a restorable (same-repository) move-aside must never be
+    reported as "Previous checkout retained at" — the enclosing `finally`
+    restores it after `_report_retained_stale_checkouts` runs, so naming its
+    (now-deleted) `.stale-*` path in the log is misleading recovery guidance.
+
+    Opus 4.8 finding (round 3), converged on by Design Review and First
+    Principles: a branch-mismatch move-aside is the SAME repository as the
+    active checkout (origin already verified identical), so it is marked
+    restorable and the `finally` puts it back on a post-build failure. An
+    origin-mismatch move-aside is a DIFFERENT repository and is never
+    restorable, so it must keep reporting retained-at and stay on disk.
+    """
+
+    @pytest.mark.asyncio
+    async def test_restorable_stale_is_restored_and_not_reported_as_retained(self, tmp_path):
+        """Branch-mismatch move-aside (restorable) + post-build install
+        failure -> checkout restored to app_source_dir, and the returned log
+        does not claim "Previous checkout retained at:" for it."""
+        from kiro_crew.apps.registry import install_from_registry
+
+        pkg_dir = tmp_path / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "app.json").write_text('{"name": "testapp"}', encoding="utf-8")
+        (pkg_dir / "replacement.txt").write_text("freshly fetched", encoding="utf-8")
+        stale_dir = tmp_path / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_pending_stale_cleanup": [stale_dir],
+                "_restorable_stale": [stale_dir],
+            }
+
+        class _NotOk:
+            ok = False
+            name = "testapp"
+            message = None
+            error = "install failed"
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={"repo": "https://example.com/app.git", "branch": "main"},
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.get_app", return_value=None),
+            patch("kiro_crew.apps.registry.install_app", return_value=_NotOk()),
+            # The `finally` restores to `app_source_dir(name)`, not to a key on
+            # the failure dict (see _restore_moved_aside call site).
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert not result["ok"]
+        assert (pkg_dir / "my-work.txt").read_text(encoding="utf-8") == "important", (
+            "the branch-mismatch move-aside is the same repository and must be "
+            "restored after the failed install"
+        )
+        assert not (pkg_dir / "replacement.txt").exists(), "the replacement is discarded"
+        assert not stale_dir.exists(), "the restored path no longer exists as a stale sibling"
+        assert "Previous checkout retained at:" not in result.get("log", ""), (
+            "a restored checkout must not be reported as still retained at a "
+            "now-deleted .stale-* path"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_restorable_stale_still_reports_retained_and_survives(self, tmp_path):
+        """Origin-mismatch move-aside (non-restorable, a different repository)
+        + the same post-build install failure -> the retained-at line is
+        still present and the `.stale-*` dir survives on disk untouched."""
+        from kiro_crew.apps.registry import install_from_registry
+
+        pkg_dir = tmp_path / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "app.json").write_text('{"name": "testapp"}', encoding="utf-8")
+        (pkg_dir / "replacement.txt").write_text("freshly fetched", encoding="utf-8")
+        stale_dir = tmp_path / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "someone-elses-repo.txt").write_text("not restorable", encoding="utf-8")
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_pending_stale_cleanup": [stale_dir],
+                # No _restorable_stale: an origin mismatch is a different
+                # repository and is never restorable.
+            }
+
+        class _NotOk:
+            ok = False
+            name = "testapp"
+            message = None
+            error = "install failed"
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={"repo": "https://example.com/app.git", "branch": "main"},
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.get_app", return_value=None),
+            patch("kiro_crew.apps.registry.install_app", return_value=_NotOk()),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert not result["ok"]
+        assert stale_dir.exists(), "an origin-mismatched checkout must never be restored"
+        assert (stale_dir / "someone-elses-repo.txt").exists()
+        assert (pkg_dir / "replacement.txt").exists(), "the freshly cloned tree stays in place"
+        assert f"Previous checkout retained at: {stale_dir}" in result.get("log", "")
+
+
+class TestRetainedAtReportingOnDurableSuccess:
+    """Regression: a restorable stale must still be reported as retained on a
+    DURABLE SUCCESS exit, where the enclosing ``finally`` never restores it.
+
+    GPT 5.6 round-5 finding: ``_report_retained_stale_checkouts`` filtered out
+    every ``_restorable_stale`` entry unconditionally, on the assumption that
+    "the enclosing finally restores it" — true only on a FAILURE exit
+    (``durable_success`` stays False). On a durable success (a completed
+    branch-drift or pinned reinstall), the same filtering silently dropped
+    the "Previous checkout retained at" line for the one stale that is
+    genuinely never restored on that path — it sits at ``.stale-*`` until
+    the age-based sweep deletes it, with neither the user nor the log ever
+    told about it. ``filter_restorable=False`` on the success call sites
+    fixes this.
+    """
+
+    @pytest.mark.asyncio
+    async def test_successful_reinstall_reports_retained_restorable_stale(self, tmp_path):
+        """A durably successful kirocrew-managed install whose build carried
+        a restorable stale (branch drift, same repository) must still log
+        "Previous checkout retained at" for it."""
+        from kiro_crew.apps.registry import install_from_registry
+
+        pkg_dir = tmp_path / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "app.json").write_text(
+            json.dumps({"name": "testapp", "version": "1.0.0", "resources": "app"}),
+            encoding="utf-8",
+        )
+        stale_dir = tmp_path / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_pending_stale_cleanup": [stale_dir],
+                # Restorable, but this success path's `finally` never reaches
+                # the restore branch (durable_success is set True below) —
+                # the stale genuinely stays at `.stale-*` and must be named.
+                "_restorable_stale": [stale_dir],
+            }
+
+        class _Ok:
+            ok = True
+            name = "testapp"
+            message = "installed"
+            error = None
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={
+                    "repo": "https://example.com/app.git",
+                    "branch": "main",
+                    "resources": "app",
+                },
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.get_app", return_value=None),
+            patch("kiro_crew.apps.registry.install_app", return_value=_Ok()),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert result["ok"]
+        assert stale_dir.exists(), "a durable success never restores the stale"
+        assert f"Previous checkout retained at: {stale_dir}" in result.get("log", ""), (
+            "a restorable stale must still be reported as retained on a "
+            "durable-success exit, where it is genuinely never restored"
+        )
 
 
 class TestStaleCheckoutSweep:
@@ -4554,3 +5876,2000 @@ class TestCloneFailureDiagnostics:
         assert err["error"] == "git clone failed"
         assert "code" not in err
         assert "credential" not in err["error"].lower()
+
+
+class TestDetachedHeadNeverMovedAside:
+    """Regression: the install-path branch gate must not treat an unreadable
+    or detached-HEAD branch state as a confirmed mismatch.
+
+    GPT 5.6 finding (registry.py, install-path branch gate): a None return
+    from ``_read_clone_branch`` (detached HEAD, unreadable ``.git/HEAD``,
+    gitfile layout) was treated identically to a confirmed branch mismatch,
+    destructively moving the checkout aside for re-clone. This punished
+    tag-pinned entries (whose detached HEAD is their normal healthy state) on
+    every update cycle, and any checkout with a momentarily unreadable
+    ``.git/HEAD``. Post-fix: a None read falls through to the non-destructive
+    pull path with a log line, and only a CONCRETELY read differing branch
+    name triggers the move-aside.
+    """
+
+    @staticmethod
+    def _make_detached_checkout(dest: Path, origin_url: str) -> None:
+        dest.mkdir(parents=True)
+        git_dir = dest / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text(
+            f'[remote "origin"]\n\turl = {origin_url}\n',
+            encoding="utf-8",
+        )
+        # Detached HEAD: raw SHA, not a "ref: refs/heads/..." line.
+        (git_dir / "HEAD").write_text(
+            "e83c5163316f89bfbde7d9ab23ca2e25604af290\n",
+            encoding="utf-8",
+        )
+
+    @pytest.mark.asyncio
+    async def test_detached_head_does_not_move_aside(self, tmp_path):
+        """A tag-pinned (detached HEAD) checkout must not be moved aside just
+        because the requested branch differs from the (unreadable) current
+        state — it must fall through to the pull path instead."""
+        import kiro_crew.apps.registry as reg
+
+        origin_url = "https://example.com/tag-pinned-app.git"
+        dest = tmp_path / "app-sources" / "tag-pinned-app"
+        self._make_detached_checkout(dest, origin_url)
+
+        def _fake_wrap_argv(argv, mode="standard"):
+            return list(argv), None
+
+        class _PullProc:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"Already up to date.", None)
+
+        pull_calls: list[list[str]] = []
+
+        async def _fake_create_subprocess(*args, **kwargs):
+            pull_calls.append(list(args))
+            return _PullProc()
+
+        log_lines: list[str] = []
+        with (
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch("kiro_crew.apps.registry.wrap_argv", side_effect=_fake_wrap_argv),
+            patch(
+                "kiro_crew.apps.registry.cgroup_scope_argv",
+                side_effect=lambda a: a,
+            ),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                side_effect=_fake_create_subprocess,
+            ),
+            patch(
+                "kiro_crew.apps.registry._clone_origin_url",
+                new=AsyncMock(return_value=origin_url),
+            ),
+        ):
+            err = await reg._git_clone_or_pull(
+                origin_url,
+                "v2.0.0",  # requested branch differs from the (unknown) current state
+                dest,
+                log_lines,
+                index_originated=False,
+            )
+
+        # No error — the fall-through pull path ran instead of a destructive
+        # move-aside + re-clone.
+        assert err is None
+        # No .stale-* sibling was created.
+        stale_dirs = [p for p in dest.parent.iterdir() if ".stale-" in p.name]
+        assert stale_dirs == []
+        # The original checkout (still the same directory) survived.
+        assert dest.is_dir()
+        assert (dest / ".git").is_dir()
+        # A log line explains why re-convergence was skipped.
+        assert any("skipping" in line and "branch re-convergence" in line for line in log_lines)
+        # The pull path actually ran (git pull spawned).
+        assert pull_calls
+
+    @pytest.mark.asyncio
+    async def test_repeated_installs_detached_head_no_stale_accumulation(self, tmp_path):
+        """Opus 4.8 tag-pinned case: repeated installs of a detached-HEAD
+        checkout must never accumulate .stale-* siblings."""
+        import kiro_crew.apps.registry as reg
+
+        origin_url = "https://example.com/tag-pinned-app.git"
+        dest = tmp_path / "app-sources" / "tag-pinned-app"
+        self._make_detached_checkout(dest, origin_url)
+
+        def _fake_wrap_argv(argv, mode="standard"):
+            return list(argv), None
+
+        class _PullProc:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"Already up to date.", None)
+
+        async def _fake_create_subprocess(*args, **kwargs):
+            return _PullProc()
+
+        for _ in range(2):
+            log_lines: list[str] = []
+            with (
+                patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+                patch("kiro_crew.apps.registry.wrap_argv", side_effect=_fake_wrap_argv),
+                patch(
+                    "kiro_crew.apps.registry.cgroup_scope_argv",
+                    side_effect=lambda a: a,
+                ),
+                patch(
+                    "kiro_crew.apps.registry.create_subprocess_limited",
+                    side_effect=_fake_create_subprocess,
+                ),
+                patch(
+                    "kiro_crew.apps.registry._clone_origin_url",
+                    new=AsyncMock(return_value=origin_url),
+                ),
+            ):
+                err = await reg._git_clone_or_pull(
+                    origin_url,
+                    "v2.0.0",
+                    dest,
+                    log_lines,
+                    index_originated=False,
+                )
+            assert err is None
+
+        stale_dirs = [p for p in dest.parent.iterdir() if ".stale-" in p.name]
+        assert stale_dirs == [], "detached-HEAD installs must never accumulate .stale-* dirs"
+
+    @pytest.mark.asyncio
+    async def test_known_branch_mismatch_moves_aside_with_fresh_mtime(self, tmp_path):
+        """Control: a CONCRETELY read differing branch still moves aside for
+        re-clone with a refreshed mtime (existing PR behavior, unchanged)."""
+        import kiro_crew.apps.registry as reg
+
+        origin_url = "https://example.com/branched-app.git"
+        dest = tmp_path / "app-sources" / "branched-app"
+        dest.mkdir(parents=True)
+        git_dir = dest / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text(
+            f'[remote "origin"]\n\turl = {origin_url}\n',
+            encoding="utf-8",
+        )
+        (git_dir / "HEAD").write_text("ref: refs/heads/old-branch\n", encoding="utf-8")
+
+        def _fake_wrap_argv(argv, mode="standard"):
+            return list(argv), None
+
+        class _SuccessProc:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"Cloning into...", None)
+
+        async def _fake_create_subprocess(*args, **kwargs):
+            dest.mkdir(parents=True, exist_ok=True)
+            new_git = dest / ".git"
+            new_git.mkdir(parents=True, exist_ok=True)
+            (new_git / "config").write_text(
+                f'[remote "origin"]\n\turl = {origin_url}\n',
+                encoding="utf-8",
+            )
+            return _SuccessProc()
+
+        log_lines: list[str] = []
+        pending_cleanup: list[Path] = []
+        with (
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch("kiro_crew.apps.registry.wrap_argv", side_effect=_fake_wrap_argv),
+            patch(
+                "kiro_crew.apps.registry.cgroup_scope_argv",
+                side_effect=lambda a: a,
+            ),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                side_effect=_fake_create_subprocess,
+            ),
+            patch(
+                "kiro_crew.apps.registry._clone_origin_url",
+                new=AsyncMock(return_value=origin_url),
+            ),
+        ):
+            before = time.time() - 1000
+            os.utime(dest, (before, before))
+            err = await reg._git_clone_or_pull(
+                origin_url,
+                "new-branch",
+                dest,
+                log_lines,
+                index_originated=False,
+                pending_cleanup=pending_cleanup,
+            )
+
+        assert err is None
+        assert len(pending_cleanup) == 1
+        moved_aside = pending_cleanup[0]
+        assert ".stale-" in moved_aside.name
+        assert moved_aside.exists()
+        # mtime was refreshed (not the far-past value set above).
+        assert moved_aside.stat().st_mtime > before + 500
+        assert any("moving aside for re-clone" in line for line in log_lines)
+
+
+class TestOriginMismatchLogsBeforeMoveAside:
+    """Regression (First Principles round-6 Watch): the origin-mismatch
+    move-aside path must announce WHY it is replacing the checkout -- naming
+    the mismatched origin -- for parity with the branch-mismatch path. A
+    branch rebuild had dropped that log line, leaving the origin-mismatch
+    re-clone silent while the branch-mismatch path still logged its reason.
+    """
+
+    @pytest.mark.asyncio
+    async def test_origin_mismatch_logs_the_mismatched_origin(self, tmp_path):
+        import kiro_crew.apps.registry as reg
+
+        existing_origin = "https://example.com/old-owner/app.git"
+        requested_url = "https://example.com/new-owner/app.git"
+        dest = tmp_path / "app-sources" / "app"
+        dest.mkdir(parents=True)
+        git_dir = dest / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text(
+            f'[remote "origin"]\n\turl = {existing_origin}\n',
+            encoding="utf-8",
+        )
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+        def _fake_wrap_argv(argv, mode="standard"):
+            return list(argv), None
+
+        class _SuccessProc:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"Cloning into...", None)
+
+        async def _fake_create_subprocess(*args, **kwargs):
+            # The re-clone recreates the checkout at the requested origin.
+            dest.mkdir(parents=True, exist_ok=True)
+            new_git = dest / ".git"
+            new_git.mkdir(parents=True, exist_ok=True)
+            (new_git / "config").write_text(
+                f'[remote "origin"]\n\turl = {requested_url}\n',
+                encoding="utf-8",
+            )
+            return _SuccessProc()
+
+        log_lines: list[str] = []
+        pending_cleanup: list[Path] = []
+        with (
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch("kiro_crew.apps.registry.wrap_argv", side_effect=_fake_wrap_argv),
+            patch("kiro_crew.apps.registry.cgroup_scope_argv", side_effect=lambda a: a),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                side_effect=_fake_create_subprocess,
+            ),
+            patch(
+                "kiro_crew.apps.registry._clone_origin_url",
+                new=AsyncMock(return_value=existing_origin),
+            ),
+        ):
+            err = await reg._git_clone_or_pull(
+                requested_url,
+                "main",
+                dest,
+                log_lines,
+                index_originated=False,
+                pending_cleanup=pending_cleanup,
+            )
+
+        assert err is None
+        # The stale clone was moved aside for re-clone.
+        assert len(pending_cleanup) == 1
+        assert ".stale-" in pending_cleanup[0].name
+        # The reason is logged, naming the mismatched origin, for parity with
+        # the branch-mismatch path. Assert on log_lines, never raw git argv.
+        origin_log = [
+            line
+            for line in log_lines
+            if "Existing clone origin" in line and "does not match" in line
+        ]
+        assert origin_log, f"expected an origin-mismatch log line, got {log_lines!r}"
+        assert existing_origin in origin_log[0]
+        assert "moving aside stale clone for re-clone" in origin_log[0]
+
+
+class TestInstallFailureReportsStaleCheckout:
+    """Regression (GPT 5.6 round 2): every non-ok exit AFTER a successful
+    clone+build that carries ``_pending_stale_cleanup`` must report the
+    retained checkout path — never strand a .stale-* silently.
+    """
+
+    @pytest.mark.asyncio
+    async def test_install_app_not_ok_reports_stale_path(self, tmp_path):
+        """install_app returning not-ok after a successful branch-mismatch
+        move-aside + clone + build must still report the retained checkout."""
+        import kiro_crew.apps.registry as reg
+        from kiro_crew.apps.manager import AppResult
+
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        stale_dir = app_sources / "testapp.stale-abcd1234"
+        stale_dir.mkdir()
+        (stale_dir / "local-edits.txt").write_text("important work", encoding="utf-8")
+
+        pkg_dir = app_sources / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "app.json").write_text(
+            json.dumps({"name": "testapp", "version": "1.0.0"}),
+            encoding="utf-8",
+        )
+
+        async def _fake_clone_build(
+            git_url, name, log_lines, *, branch="main", index_originated=False, **kwargs
+        ):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_pending_stale_cleanup": [stale_dir],
+            }
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={
+                    "repo": "https://example.com/app.git",
+                    "branch": "main",
+                },
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch(
+                "kiro_crew.apps.registry._clone_build_app",
+                new=_fake_clone_build,
+            ),
+            patch(
+                "kiro_crew.apps.registry.app_admission_denied",
+                return_value=None,
+            ),
+            patch(
+                "kiro_crew.apps.registry.app_execution_denied",
+                return_value=None,
+            ),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "kiro_crew.apps.registry.is_clone_host_trusted",
+                return_value=True,
+            ),
+            patch("kiro_crew.apps.registry.get_app", return_value=None),
+            patch(
+                "kiro_crew.apps.registry.install_app",
+                return_value=AppResult(ok=False, name="testapp", error="install script refused"),
+            ),
+            patch("kiro_crew.apps.registry._sweep_stale_checkouts", new=AsyncMock()),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await reg.install_from_registry("testapp")
+
+        assert result["ok"] is False
+        # The stale directory must still exist — not silently stranded.
+        assert stale_dir.exists()
+        assert (stale_dir / "local-edits.txt").read_text() == "important work"
+        # The log must name the retained path (same line the success paths use).
+        assert f"Previous checkout retained at: {stale_dir}" in result.get("log", "")
+
+    @pytest.mark.asyncio
+    async def test_outer_exception_reports_stale_path(self, tmp_path):
+        """An exception raised AFTER a successful clone+build (e.g. during
+        the install_app/update_app call) must still report the retained
+        checkout via the outer except handler."""
+        import kiro_crew.apps.registry as reg
+
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        stale_dir = app_sources / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "local-edits.txt").write_text("important work", encoding="utf-8")
+
+        pkg_dir = app_sources / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "app.json").write_text(
+            json.dumps({"name": "testapp", "version": "1.0.0"}),
+            encoding="utf-8",
+        )
+
+        async def _fake_clone_build(
+            git_url, name, log_lines, *, branch="main", index_originated=False, **kwargs
+        ):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_pending_stale_cleanup": [stale_dir],
+            }
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={
+                    "repo": "https://example.com/app.git",
+                    "branch": "main",
+                },
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch(
+                "kiro_crew.apps.registry._clone_build_app",
+                new=_fake_clone_build,
+            ),
+            patch(
+                "kiro_crew.apps.registry.app_admission_denied",
+                return_value=None,
+            ),
+            patch(
+                "kiro_crew.apps.registry.app_execution_denied",
+                return_value=None,
+            ),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "kiro_crew.apps.registry.is_clone_host_trusted",
+                return_value=True,
+            ),
+            patch("kiro_crew.apps.registry.get_app", return_value=None),
+            patch(
+                "kiro_crew.apps.registry.install_app",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("kiro_crew.apps.registry._sweep_stale_checkouts", new=AsyncMock()),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await reg.install_from_registry("testapp")
+
+        assert result["ok"] is False
+        assert stale_dir.exists()
+        assert f"Previous checkout retained at: {stale_dir}" in result.get("log", "")
+
+    @pytest.mark.asyncio
+    async def test_install_script_timeout_reports_stale_path(self, tmp_path):
+        """The install-script TIMEOUT exit (proc killed via
+        _kill_process_group) must also report the retained checkout — the
+        same "Previous checkout retained at:" line the other post-build exits
+        use. Distinct from test_outer_exception_reports_stale_path and
+        test_install_app_not_ok_reports_stale_path, which both bypass the
+        script-execution code path entirely (their manifests carry no
+        ``setup.onInstall``)."""
+        import kiro_crew.apps.registry as reg
+
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        stale_dir = app_sources / "testapp.stale-f00dcafe"
+        stale_dir.mkdir()
+        (stale_dir / "local-edits.txt").write_text("important work", encoding="utf-8")
+
+        pkg_dir = app_sources / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "app.json").write_text(
+            json.dumps({"name": "testapp", "setup": {"onInstall": "sleep 999"}}),
+            encoding="utf-8",
+        )
+
+        async def _fake_clone_build(
+            git_url, name, log_lines, *, branch="main", index_originated=False, **kwargs
+        ):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_pending_stale_cleanup": [stale_dir],
+            }
+
+        class _TimeoutProc:
+            returncode: int | None = None
+
+            async def communicate(self):
+                raise asyncio.TimeoutError
+
+        def _fake_wrap_argv(argv, mode="standard"):
+            return list(argv), None
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={
+                    "repo": "https://example.com/app.git",
+                    "branch": "main",
+                },
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch(
+                "kiro_crew.apps.registry._clone_build_app",
+                new=_fake_clone_build,
+            ),
+            patch(
+                "kiro_crew.apps.registry.app_admission_denied",
+                return_value=None,
+            ),
+            patch(
+                "kiro_crew.apps.registry.app_execution_denied",
+                return_value=None,
+            ),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "kiro_crew.apps.registry.is_clone_host_trusted",
+                return_value=True,
+            ),
+            patch("kiro_crew.apps.registry.wrap_argv", side_effect=_fake_wrap_argv),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                new=AsyncMock(return_value=_TimeoutProc()),
+            ),
+            patch("kiro_crew.apps.registry._kill_process_group", new=AsyncMock()),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await reg.install_from_registry("testapp")
+
+        assert result["ok"] is False
+        assert "timed out" in result.get("error", "")
+        # The stale directory must still exist — not silently stranded.
+        assert stale_dir.exists()
+        assert (stale_dir / "local-edits.txt").read_text() == "important work"
+        # The log must name the retained path (same line the other post-build
+        # exits use).
+        assert f"Previous checkout retained at: {stale_dir}" in result.get("log", "")
+
+    @pytest.mark.asyncio
+    async def test_traversing_subdirectory_restores_moved_aside_checkout(self, tmp_path):
+        """Self-review finding: a traversing ``subdirectory`` refused AFTER a
+        successful branch-mismatch move-aside + clone + build must restore the
+        moved-aside checkout, not strand it.
+
+        This refusal fires right after ``build_result`` is obtained, before
+        any of the identity/admission gates that already call
+        ``_unpoison_rejected_checkout`` — it must do the same.
+        """
+        import kiro_crew.apps.registry as reg
+
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        stale_dir = app_sources / "testapp.stale-abcd1234"
+        stale_dir.mkdir()
+        (stale_dir / "local-edits.txt").write_text("important work", encoding="utf-8")
+
+        pkg_dir = app_sources / "testapp"
+        pkg_dir.mkdir()
+
+        async def _fake_clone_build(
+            git_url, name, log_lines, *, branch="main", index_originated=False, **kwargs
+        ):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_checkout_preexisted": False,
+                "_pre_pull_commit": "",
+                "_pre_update_manifest": None,
+                "_pending_stale_cleanup": [stale_dir],
+                # A branch-mismatch move-aside is the same repository as the
+                # active checkout, so `_clone_build_app_locked` marks it
+                # restorable — the containment-refusal cleanup must only
+                # restore a pending stale when it is also restorable (see
+                # TestContainmentRefusalRestoreFromRespectsRestorableStale).
+                "_restorable_stale": [stale_dir],
+            }
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={
+                    "repo": "https://example.com/app.git",
+                    "branch": "main",
+                    "subdirectory": "../../etc",
+                },
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch(
+                "kiro_crew.apps.registry._clone_build_app",
+                new=_fake_clone_build,
+            ),
+            patch(
+                "kiro_crew.apps.registry.app_execution_denied",
+                return_value=None,
+            ),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "kiro_crew.apps.registry.is_clone_host_trusted",
+                return_value=True,
+            ),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch("kiro_crew.apps.registry.get_app", return_value=None),
+            patch("kiro_crew.apps.registry._sweep_stale_checkouts", new=AsyncMock()),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await reg.install_from_registry("testapp")
+
+        assert result["ok"] is False
+        assert "unsafe subdirectory" in result["error"]
+        # The moved-aside checkout must be restored into pkg_dir's slot, not
+        # left stranded as an unreported .stale-* sibling.
+        assert not stale_dir.exists()
+        assert pkg_dir.exists()
+        assert (pkg_dir / "local-edits.txt").read_text() == "important work"
+
+
+class TestRefusalExitsReportRetainedStale:
+    """Regression (GPT 5.6 round 8): a refusal that leaves a non-restorable
+    (origin-mismatch) checkout moved aside must REPORT the retained ``.stale-*``
+    path, not strand it silently until the age-based sweep deletes it.
+
+    Two halves of the fix are pinned here:
+
+    * ``_clone_build_app`` stamps ``_pending_stale_cleanup`` on EVERY dict
+      result at its single exit — refusals included, not only the ok path — so
+      the caller's reporter has the move-aside state to work from.
+    * ``install_from_registry`` runs ``_report_retained_stale_checkouts`` at
+      every refusal exit reachable after a move-aside, filtering the restorable
+      subset the enclosing ``finally`` puts back.
+
+    The end-to-end cases drive the REAL ``_clone_build_app`` through a faked
+    ``_git_clone_or_pull`` so the wrapper's stamping is exercised, not
+    hand-supplied.
+    """
+
+    @staticmethod
+    def _make_fake_git_clone(stale_dir, *, restorable, cloned_name):
+        async def _fake_clone(git_url, branch, dest, log_lines, **kwargs):
+            # Mirror the origin-mismatch move-aside: record the aside path on
+            # the caller-owned lists exactly as the real gate does.
+            pending_cleanup = kwargs.get("pending_cleanup")
+            if pending_cleanup is not None:
+                pending_cleanup.append(stale_dir)
+            restorable_stale = kwargs.get("restorable_stale")
+            if restorable and restorable_stale is not None:
+                restorable_stale.append(stale_dir)
+            dest.mkdir(parents=True, exist_ok=True)
+            (dest / "app.json").write_text(json.dumps({"name": cloned_name}), encoding="utf-8")
+            return None
+
+        return _fake_clone
+
+    @staticmethod
+    def _install_patches(pkg_dir, *, admission_denied=None):
+        # Deny only once a MANIFEST is present (the cloned / post-build gates),
+        # never on the manifest=None prefetch gate that runs before the clone —
+        # otherwise the prefetch short-circuits before any move-aside happens.
+        def _admission(_name, *, manifest=None, action=None, **_kw):
+            return admission_denied if (admission_denied and manifest is not None) else None
+
+        return (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={"repo": "https://new.example.com/app.git", "branch": "main"},
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://new.example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch("kiro_crew.apps.registry.app_admission_denied", side_effect=_admission),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch("kiro_crew.apps.registry._looks_like_git_url", return_value=True),
+            patch("kiro_crew.apps.registry._sweep_stale_checkouts", new=AsyncMock()),
+            patch("kiro_crew.apps.registry.sel"),
+        )
+
+    async def _run_install(self, pkg_dir, first_patch, *, admission_denied=None):
+        """Enter *first_patch* plus the shared install patches and run
+        ``install_from_registry("testapp")``, returning its result."""
+        import kiro_crew.apps.registry as reg
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(first_patch)
+            for cm in self._install_patches(pkg_dir, admission_denied=admission_denied):
+                stack.enter_context(cm)
+            return await reg.install_from_registry("testapp")
+
+    @pytest.mark.asyncio
+    async def test_identity_refusal_reports_non_restorable_retained_stale(self, tmp_path):
+        """Origin-mismatch move-aside + a pre-build identity refusal (cloned
+        app.json declares a different name): the log names the retained
+        ``.stale-*`` path and the dir survives on disk."""
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        pkg_dir = app_sources / "testapp"
+        stale_dir = app_sources / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "someone-elses-repo.txt").write_text("not restorable", encoding="utf-8")
+
+        result = await self._run_install(
+            pkg_dir,
+            patch(
+                "kiro_crew.apps.registry._git_clone_or_pull",
+                new=self._make_fake_git_clone(stale_dir, restorable=False, cloned_name="wrong"),
+            ),
+        )
+
+        assert result["ok"] is False
+        assert f"Previous checkout retained at: {stale_dir}" in result.get("log", "")
+        assert stale_dir.exists(), "a non-restorable stale must never be swept unreported"
+        assert (stale_dir / "someone-elses-repo.txt").read_text(
+            encoding="utf-8"
+        ) == "not restorable"
+
+    @pytest.mark.asyncio
+    async def test_cloned_admission_refusal_reports_non_restorable_retained_stale(self, tmp_path):
+        """Origin-mismatch move-aside + the cloned-admission rejection
+        (app_admission_denied denies): the retained ``.stale-*`` is reported and
+        survives — same seam as the identity refusal, different gate."""
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        pkg_dir = app_sources / "testapp"
+        stale_dir = app_sources / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "someone-elses-repo.txt").write_text("not restorable", encoding="utf-8")
+
+        result = await self._run_install(
+            pkg_dir,
+            patch(
+                "kiro_crew.apps.registry._git_clone_or_pull",
+                # Correct name → identity gate passes → the admission gate is
+                # the one that refuses.
+                new=self._make_fake_git_clone(stale_dir, restorable=False, cloned_name="testapp"),
+            ),
+            admission_denied="signature required",
+        )
+
+        assert result["ok"] is False
+        assert "admission policy" in result.get("error", "")
+        assert f"Previous checkout retained at: {stale_dir}" in result.get("log", "")
+        assert stale_dir.exists(), "a non-restorable stale must never be swept unreported"
+
+    @pytest.mark.asyncio
+    async def test_restorable_stale_is_restored_and_not_reported_on_identity_refusal(
+        self, tmp_path
+    ):
+        """Control: a same-origin (branch-drift) move-aside + an identity
+        refusal is RESTORED into the slot (existing behavior) and the log does
+        NOT claim it was retained."""
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        pkg_dir = app_sources / "testapp"
+        stale_dir = app_sources / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        result = await self._run_install(
+            pkg_dir,
+            patch(
+                "kiro_crew.apps.registry._git_clone_or_pull",
+                new=self._make_fake_git_clone(stale_dir, restorable=True, cloned_name="wrong"),
+            ),
+        )
+
+        assert result["ok"] is False
+        assert "Previous checkout retained at:" not in result.get("log", "")
+        assert not stale_dir.exists(), "a restorable stale is renamed back into the slot"
+        assert pkg_dir.exists()
+        assert (pkg_dir / "my-work.txt").read_text(encoding="utf-8") == "important"
+
+    @pytest.mark.asyncio
+    async def test_post_build_identity_refusal_reports_non_restorable_retained_stale(
+        self, tmp_path
+    ):
+        """A build step that rewrites app.json to a different name trips the
+        POST-build identity gate inside install_from_registry; a non-restorable
+        move-aside carried on the (ok) build result must be reported there."""
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        pkg_dir = app_sources / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "app.json").write_text('{"name": "wrong-name"}', encoding="utf-8")
+        stale_dir = app_sources / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "someone-elses-repo.txt").write_text("not restorable", encoding="utf-8")
+
+        async def _fake_clone_build(git_url, name, log_lines, *, branch="main", **kwargs):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_checkout_preexisted": False,
+                "_pending_stale_cleanup": [stale_dir],
+            }
+
+        result = await self._run_install(
+            pkg_dir, patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build)
+        )
+
+        assert result["ok"] is False
+        assert "declares" in result.get("error", "")
+        assert f"Previous checkout retained at: {stale_dir}" in result.get("log", "")
+        assert stale_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_post_build_admission_refusal_reports_non_restorable_retained_stale(
+        self, tmp_path
+    ):
+        """The POST-build admission gate inside install_from_registry must also
+        report a non-restorable move-aside it strands."""
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        pkg_dir = app_sources / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "app.json").write_text('{"name": "testapp"}', encoding="utf-8")
+        stale_dir = app_sources / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "someone-elses-repo.txt").write_text("not restorable", encoding="utf-8")
+
+        async def _fake_clone_build(git_url, name, log_lines, *, branch="main", **kwargs):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_checkout_preexisted": False,
+                "_pending_stale_cleanup": [stale_dir],
+            }
+
+        result = await self._run_install(
+            pkg_dir,
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            admission_denied="signature required",
+        )
+
+        assert result["ok"] is False
+        assert "admission policy" in result.get("error", "")
+        assert f"Previous checkout retained at: {stale_dir}" in result.get("log", "")
+        assert stale_dir.exists()
+
+
+class TestCloneBuildStampsPendingOnRefusal:
+    """Regression (GPT 5.6 round 8): ``_clone_build_app`` must stamp
+    ``_pending_stale_cleanup`` onto a REFUSAL dict, not only the ok path — the
+    single-exit invariant that keeps a new exit from silently dropping the
+    move-aside state the caller's reporter needs.
+    """
+
+    @staticmethod
+    def _make_fake_clone(stale_dir, *, restorable):
+        async def _fake_clone(git_url, branch, dest, log_lines, **kwargs):
+            pending_cleanup = kwargs.get("pending_cleanup")
+            if pending_cleanup is not None:
+                pending_cleanup.append(stale_dir)
+            restorable_stale = kwargs.get("restorable_stale")
+            if restorable and restorable_stale is not None:
+                restorable_stale.append(stale_dir)
+            dest.mkdir(parents=True, exist_ok=True)
+            # Wrong name trips the pre-build identity gate → refusal dict.
+            (dest / "app.json").write_text(json.dumps({"name": "wrong-name"}), encoding="utf-8")
+            return None
+
+        return _fake_clone
+
+    @pytest.mark.asyncio
+    async def test_non_restorable_refusal_dict_carries_pending_only(self, tmp_path):
+        from kiro_crew.apps.registry import _clone_build_app
+
+        app_source = tmp_path / "app-sources" / "testapp"
+        stale_dir = tmp_path / "app-sources" / "testapp.stale-deadbeef"
+        stale_dir.mkdir(parents=True)
+
+        with (
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch(
+                "kiro_crew.apps.registry._git_clone_or_pull",
+                new=self._make_fake_clone(stale_dir, restorable=False),
+            ),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await _clone_build_app("https://new.example.com/app.git", "testapp", [])
+
+        assert result["ok"] is False
+        assert result.get("_pending_stale_cleanup") == [stale_dir]
+        # Non-restorable: it must NOT appear in the restorable subset.
+        assert result.get("_restorable_stale") is None
+
+    @pytest.mark.asyncio
+    async def test_restorable_refusal_dict_carries_both_lists(self, tmp_path):
+        from kiro_crew.apps.registry import _clone_build_app
+
+        app_source = tmp_path / "app-sources" / "testapp"
+        stale_dir = tmp_path / "app-sources" / "testapp.stale-deadbeef"
+        stale_dir.mkdir(parents=True)
+
+        with (
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch(
+                "kiro_crew.apps.registry._git_clone_or_pull",
+                new=self._make_fake_clone(stale_dir, restorable=True),
+            ),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await _clone_build_app("https://new.example.com/app.git", "testapp", [])
+
+        assert result["ok"] is False
+        assert result.get("_pending_stale_cleanup") == [stale_dir]
+        assert result.get("_restorable_stale") == [stale_dir]
+
+
+class TestCloneBuildExceptionPathReportsRetainedStale:
+    """Regression (GPT 5.6 round 9, registry.py:~4005): when ``_clone_build_app``
+    raises AFTER an origin-mismatch move-aside, its ``except BaseException``
+    handler must NAME each retained non-restorable ``.stale-*`` path (the same
+    "Previous checkout retained at:" wording the finally-owned reporter uses)
+    before re-raising.
+
+    On this path there is no result dict, so the caller's finally-owned reporter
+    never learns of the move-aside; without the handler's logging the age-based
+    sweep would later delete a checkout the user was never told about. The
+    restorable (same-origin) subset is instead RESTORED here and must NOT be
+    reported as retained.
+    """
+
+    @staticmethod
+    def _make_raising_locked(stale_dir, *, restorable, exc):
+        """Fake ``_clone_build_app_locked`` that records *stale_dir* on the
+        caller-owned lists exactly as the real move-aside gate does, then raises
+        *exc* before returning any result dict."""
+
+        async def _fake_locked(git_url, app_name, log_lines, **kwargs):
+            pending_cleanup = kwargs.get("pending_cleanup")
+            if pending_cleanup is not None:
+                pending_cleanup.append(stale_dir)
+            restorable_stale = kwargs.get("restorable_stale")
+            if restorable and restorable_stale is not None:
+                restorable_stale.append(stale_dir)
+            raise exc
+
+        return _fake_locked
+
+    @pytest.mark.asyncio
+    async def test_non_restorable_move_aside_is_logged_before_reraise(self, tmp_path):
+        """Origin-mismatch (non-restorable) move-aside + a build-step exception:
+        the retained ``.stale-*`` path is named in ``log_lines`` before the
+        exception propagates, and the dir survives on disk untouched."""
+        import kiro_crew.apps.registry as reg
+
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        pkg_dir = app_sources / "testapp"
+        stale_dir = app_sources / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "someone-elses-repo.txt").write_text("not restorable", encoding="utf-8")
+
+        log_lines: list[str] = []
+        with (
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch(
+                "kiro_crew.apps.registry._clone_build_app_locked",
+                new=self._make_raising_locked(
+                    stale_dir, restorable=False, exc=RuntimeError("build blew up")
+                ),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="build blew up"):
+                await reg._clone_build_app(
+                    "https://new.example.com/app.git", "testapp", log_lines
+                )
+
+        # The handler named the retained path before re-raising.
+        assert f"Previous checkout retained at: {stale_dir}" in log_lines
+        # A non-restorable origin-mismatch stale is deliberately left on disk.
+        assert stale_dir.exists(), "a non-restorable stale must never be swept unreported"
+        assert (stale_dir / "someone-elses-repo.txt").read_text(
+            encoding="utf-8"
+        ) == "not restorable"
+
+    @pytest.mark.asyncio
+    async def test_cancellation_logs_retained_non_restorable_path(self, tmp_path):
+        """``CancelledError`` (the reported case) on the same path also names the
+        retained non-restorable stale before propagating — the handler catches
+        ``BaseException`` on purpose."""
+        import kiro_crew.apps.registry as reg
+
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        pkg_dir = app_sources / "testapp"
+        stale_dir = app_sources / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "someone-elses-repo.txt").write_text("not restorable", encoding="utf-8")
+
+        log_lines: list[str] = []
+        with (
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch(
+                "kiro_crew.apps.registry._clone_build_app_locked",
+                new=self._make_raising_locked(
+                    stale_dir, restorable=False, exc=asyncio.CancelledError()
+                ),
+            ),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await reg._clone_build_app(
+                    "https://new.example.com/app.git", "testapp", log_lines
+                )
+
+        assert f"Previous checkout retained at: {stale_dir}" in log_lines
+        assert stale_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_restorable_move_aside_is_restored_not_reported_on_reraise(self, tmp_path):
+        """A restorable (same-origin) move-aside on the exception path is put
+        back at ``pkg_dir`` and must NOT be reported as retained — restoring it
+        deletes the ``.stale-*`` sibling, so naming it would be misleading."""
+        import kiro_crew.apps.registry as reg
+
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        pkg_dir = app_sources / "testapp"
+        stale_dir = app_sources / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        log_lines: list[str] = []
+        with (
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch(
+                "kiro_crew.apps.registry._clone_build_app_locked",
+                new=self._make_raising_locked(
+                    stale_dir, restorable=True, exc=RuntimeError("build blew up")
+                ),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="build blew up"):
+                await reg._clone_build_app(
+                    "https://new.example.com/app.git", "testapp", log_lines
+                )
+
+        # Restored back into the slot, so the .stale-* sibling is gone...
+        assert not stale_dir.exists(), "a restorable stale is renamed back into pkg_dir"
+        assert (pkg_dir / "my-work.txt").read_text(encoding="utf-8") == "important"
+        # ...and it must NOT be reported as still retained at a now-deleted path.
+        assert not any(
+            line.startswith("Previous checkout retained at:") for line in log_lines
+        ), "a restored checkout must not be named as retained"
+
+
+class TestProvenanceRaiseAfterDurableSuccessReportsRetainedStale:
+    """Regression (GPT 5.6 round 9, registry.py:~5418 / the consolidated
+    finally-owned reporter): a durable-success install whose provenance write
+    then RAISES must still NAME the retained restorable stale in the outcome log
+    and leave it on disk (never restored — the install durably succeeded).
+
+    The generic ``except`` catches the provenance failure, but the ``finally``
+    still sees ``durable_success`` True, so it restores nothing and reports with
+    ``filter_restorable=not durable_success`` == ``False`` — naming the stale
+    that genuinely stays at ``.stale-*`` rather than letting it sit unlogged
+    until the age-based sweep. With the pre-fix ``filter_restorable=True`` mirror
+    this path filtered the stale out and reported nothing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_provenance_raise_reports_retained_restorable_stale(self, tmp_path):
+        from kiro_crew.apps.registry import install_from_registry
+
+        pkg_dir = tmp_path / "testapp"
+        pkg_dir.mkdir()
+        (pkg_dir / "app.json").write_text('{"name": "testapp"}', encoding="utf-8")
+        (pkg_dir / "installed.txt").write_text("the installed version", encoding="utf-8")
+        stale_dir = tmp_path / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            return {
+                "ok": True,
+                "pkg_dir": pkg_dir,
+                "_pending_stale_cleanup": [stale_dir],
+                # Restorable (branch drift, same repository) — but this
+                # durable-success path's `finally` never restores it, so it
+                # genuinely stays at `.stale-*` and must be named.
+                "_restorable_stale": [stale_dir],
+            }
+
+        class _Ok:
+            ok = True
+            name = "testapp"
+            message = "installed"
+            error = None
+
+        def _boom(*a, **k):
+            raise OSError("provenance store unwritable")
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={"repo": "https://example.com/app.git", "branch": "main"},
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry.get_app", return_value=None),
+            patch("kiro_crew.apps.registry.install_app", return_value=_Ok()),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch("kiro_crew.apps.registry.set_app_provenance", side_effect=_boom),
+            patch("kiro_crew.apps.registry._sweep_stale_checkouts", new=AsyncMock()),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        # The bookkeeping failure is surfaced, but the install is NOT rolled back.
+        assert result["ok"] is False
+        assert (pkg_dir / "installed.txt").read_text(encoding="utf-8") == "the installed version"
+        # The restorable stale is RETAINED (durable success never restores it)...
+        assert stale_dir.exists(), "a durable success never restores the stale"
+        assert (stale_dir / "my-work.txt").read_text(encoding="utf-8") == "important"
+        # ...and it is NAMED in the outcome log, not stranded until the sweep.
+        assert f"Previous checkout retained at: {stale_dir}" in result.get("log", ""), (
+            "a provenance raise after durable success must still report the "
+            "genuinely-retained restorable stale"
+        )
+
+
+class TestFinallyOwnedReporterIsTheSoleSite:
+    """Grep-pin (Design + First Principles round 9): retained-stale reporting is
+    owned by exactly ONE site — the ``finally`` of ``install_from_registry``,
+    with ``filter_restorable=not durable_success``. The 12 per-exit calls this
+    consolidation deleted were the scattered-per-exit stranding class; a new exit
+    re-introducing a per-exit call (and its own hand-mirrored flag) would
+    reopen it, so pin the single site textually."""
+
+    def test_exactly_one_reporter_call_in_install_from_registry(self):
+        import inspect
+
+        from kiro_crew.apps import registry as reg
+
+        source = inspect.getsource(reg.install_from_registry)
+        calls = source.count("_report_retained_stale_checkouts(")
+        assert calls == 1, (
+            "install_from_registry must call _report_retained_stale_checkouts "
+            f"exactly once (the finally-owned site); found {calls}"
+        )
+        # The single call must derive its flag from durable_success, never
+        # hand-mirror a literal True/False at a per-exit site.
+        assert "filter_restorable=not durable_success" in source, (
+            "the sole reporter call must use filter_restorable=not durable_success"
+        )
+
+
+class TestRefusalOutcomeCarriesNoInternalTransactionKeys:
+    """Regression (GPT 5.6 round 10, registry.py:~4925): a build-refusal exit
+    does ``outcome = {**build_result}``, so the internal move-aside bookkeeping
+    keys ``_pending_stale_cleanup`` / ``_restorable_stale`` (each ``list[Path]``)
+    used to ride out of ``install_from_registry`` on the returned dict. ``Path``
+    is not JSON-serializable, so the API/SSE layer raised ``TypeError`` when it
+    serialized the refusal.
+
+    The finally now scrubs every ``_``-prefixed key from ``outcome`` AFTER the
+    restore/report have consumed them off ``build_result``, so the returned
+    outcome is JSON-serializable and carries no internal transaction key — while
+    the retained-path log line the reporter produced still reaches the caller.
+    """
+
+    @pytest.mark.asyncio
+    async def test_build_refusal_outcome_is_json_serializable_and_scrubbed(self, tmp_path):
+        from kiro_crew.apps.registry import install_from_registry
+
+        app_sources = tmp_path / "app-sources"
+        app_sources.mkdir()
+        pkg_dir = app_sources / "testapp"
+        stale_dir = app_sources / "testapp.stale-deadbeef"
+        stale_dir.mkdir()
+        (stale_dir / "someone-elses-repo.txt").write_text("not restorable", encoding="utf-8")
+
+        async def _fake_clone_build(git_url, app_name, log_lines, branch="main", **kwargs):
+            # A pre-build refusal (failed clone/build or an in-callee gate):
+            # ok=False, carrying the origin-mismatch move-aside state as the
+            # real single-exit stamping does. `_restorable_stale` empty → the
+            # pending path is a genuinely-retained non-restorable checkout.
+            return {
+                "ok": False,
+                "name": app_name,
+                "error": "build failed",
+                "_pending_stale_cleanup": [stale_dir],
+                "_restorable_stale": [],
+            }
+
+        with (
+            patch(
+                "kiro_crew.apps.registry.get_registry_app",
+                return_value={"repo": "https://example.com/app.git", "branch": "main"},
+            ),
+            patch(
+                "kiro_crew.apps.registry._entry_git_url",
+                return_value="https://example.com/app.git",
+            ),
+            patch("kiro_crew.apps.registry._clone_build_app", new=_fake_clone_build),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=pkg_dir),
+            patch("kiro_crew.apps.registry.app_admission_denied", return_value=None),
+            patch("kiro_crew.apps.registry.app_execution_denied", return_value=None),
+            patch(
+                "kiro_crew.apps.registry._fetch_app_manifest",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("kiro_crew.apps.registry._sweep_stale_checkouts", new=AsyncMock()),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            result = await install_from_registry("testapp")
+
+        assert result["ok"] is False
+        # The whole point of the round-10 fix: the refusal serializes cleanly.
+        json.dumps(result)
+        # No internal transaction key rides out on the returned outcome.
+        assert "_pending_stale_cleanup" not in result
+        assert "_restorable_stale" not in result
+        # Scrub the CLASS, not the two names: no leaked `_`-prefixed key at all.
+        leaked = [k for k in result if k.startswith("_")]
+        assert leaked == [], f"internal underscore keys leaked into the outcome: {leaked}"
+        # The retained non-restorable path is still named in the log the caller
+        # receives — the scrub strips the keys, not the report.
+        assert f"Previous checkout retained at: {stale_dir}" in result.get("log", "")
+        assert stale_dir.exists(), "a non-restorable stale must never be swept unreported"
+
+
+class TestReadCloneBranchBoundedRead:
+    """Round-11 regression (GPT 5.6): the ``.git/HEAD`` read must be BOUNDED.
+
+    ``.git/HEAD`` lives inside a checkout an app's own build script can rewrite,
+    so its size is attacker-controlled. Reading it whole let an app replace the
+    file with (or symlink it to) a multi-gigabyte / sparse file and exhaust
+    gateway memory on the next update. The read is now capped at
+    ``_HEAD_READ_LIMIT`` bytes, and content that fills the bound fails closed.
+    """
+
+    def test_oversized_head_is_not_read_past_the_bound(self, tmp_path):
+        """An oversized ``.git/HEAD`` never pulls more than the bound into
+        memory: record the byte count passed to the bounded reader and confirm
+        it is capped at ``_HEAD_READ_LIMIT``.
+
+        The bounded read now runs through ``hooks.safe_read_prefix`` (the
+        symlink-containing primitive), so the boundedness proof is the ``n``
+        argument that reader receives, not a ``builtins.open`` read size."""
+        from kiro_crew.apps import registry as reg
+
+        clone_dir = tmp_path / "clone"
+        (clone_dir / ".git").mkdir(parents=True)
+        head_file = clone_dir / ".git" / "HEAD"
+        # A `ref:` line followed by megabytes of padding — a real HEAD is a
+        # single short line, so anything this large is hostile.
+        head_file.write_text(
+            "ref: refs/heads/main\n" + ("A" * (5 * 1024 * 1024)),
+            encoding="utf-8",
+        )
+
+        from kiro_crew import hooks
+
+        real_prefix = hooks.safe_read_prefix
+        limit_args: list[int] = []
+
+        def _recording_prefix(raw, n):
+            # A concrete positive bound is the only legal shape; the unbounded
+            # read this test forbids would be a whole-file read() with no cap.
+            limit_args.append(n)
+            return real_prefix(raw, n)
+
+        with patch.object(hooks, "safe_read_prefix", side_effect=_recording_prefix):
+            branch = reg._read_clone_branch(clone_dir)
+
+        # The read was bounded: every bounded-reader call was capped at the
+        # limit, never an unbounded read that would slurp the whole 5 MiB file.
+        assert limit_args, "the HEAD read never happened"
+        assert all(
+            0 <= n <= reg._HEAD_READ_LIMIT for n in limit_args
+        ), f"HEAD was read past the bound: read sizes {limit_args}"
+        # Content that fills the bound (this hostile file does) fails closed.
+        assert branch is None, "an oversized HEAD must fail closed, not return a branch"
+
+    def test_head_content_filling_the_bound_fails_closed(self, tmp_path):
+        """A ``ref:`` line padded exactly to the byte bound is treated as
+        malformed (possible mid-token truncation) and returns None."""
+        from kiro_crew.apps import registry as reg
+
+        clone_dir = tmp_path / "clone"
+        (clone_dir / ".git").mkdir(parents=True)
+        head_file = clone_dir / ".git" / "HEAD"
+        # A branch name long enough that the whole line meets/exceeds the bound.
+        long_branch = "b" * (reg._HEAD_READ_LIMIT + 100)
+        head_file.write_text(f"ref: refs/heads/{long_branch}\n", encoding="utf-8")
+
+        assert reg._read_clone_branch(clone_dir) is None
+
+    def test_normal_head_still_reads_the_branch(self, tmp_path):
+        """Control: a well-formed short HEAD still resolves to its branch —
+        the bound rejects only oversized/hostile content."""
+        from kiro_crew.apps import registry as reg
+
+        clone_dir = tmp_path / "clone"
+        (clone_dir / ".git").mkdir(parents=True)
+        (clone_dir / ".git" / "HEAD").write_text(
+            "ref: refs/heads/feature/some-branch\n", encoding="utf-8"
+        )
+
+        assert reg._read_clone_branch(clone_dir) == "feature/some-branch"
+
+    def test_head_symlinked_to_oversized_file_fails_closed(self, tmp_path):
+        """A ``.git/HEAD`` symlinked to a huge file is still bounded — the read
+        follows the link but stops at the limit, and the oversized content
+        fails closed."""
+        from kiro_crew.apps import registry as reg
+
+        clone_dir = tmp_path / "clone"
+        (clone_dir / ".git").mkdir(parents=True)
+        big = tmp_path / "big-file"
+        big.write_text("ref: refs/heads/main\n" + ("A" * (3 * 1024 * 1024)), encoding="utf-8")
+        head_file = clone_dir / ".git" / "HEAD"
+        try:
+            head_file.symlink_to(big)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        # Fails closed (oversized), and — the point — without loading 3 MiB:
+        # the bounded read is what makes the symlink target's size irrelevant.
+        assert reg._read_clone_branch(clone_dir) is None
+
+    def test_head_symlinked_to_sensitive_path_is_refused(self, tmp_path):
+        """Round-14 regression (GPT 5.6, BLOCKING): a checkout-controlled
+        ``.git/HEAD`` symlinked to a protected file must NOT be read.
+
+        A malicious app can replace ``.git/HEAD`` with a symlink to a secret
+        (``~/.aws/credentials``, an SSH key). The bounded read now routes
+        through ``hooks.safe_read_prefix``, which canonicalizes via ``realpath``
+        and refuses a resolved target ``is_sensitive_path`` flags before any
+        read, so the branch read fails closed to None and the secret bytes never
+        leave the sensitive-path ceiling — even though a valid ``ref:`` line at
+        the target would otherwise parse to a branch."""
+        from kiro_crew import hooks
+        from kiro_crew.apps import registry as reg
+
+        # A secret file that resolves to a *sensitive* path. Its content is a
+        # perfectly valid HEAD line, so if the read followed the link it would
+        # return a branch — the refusal, not malformed content, is the defense.
+        secret = tmp_path / "credentials"
+        secret.write_text("ref: refs/heads/leaked\n", encoding="utf-8")
+
+        clone_dir = tmp_path / "clone"
+        (clone_dir / ".git").mkdir(parents=True)
+        head_file = clone_dir / ".git" / "HEAD"
+        try:
+            head_file.symlink_to(secret)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        resolved_secret = os.path.realpath(secret)
+        real_is_sensitive = hooks.is_sensitive_path
+
+        def _sensitive(path, base_dir=None):
+            # Flag only the symlink's resolved target as sensitive, so the test
+            # does not depend on the host actually having ~/.aws etc.
+            if os.path.realpath(path) == resolved_secret:
+                return True
+            return real_is_sensitive(path, base_dir)
+
+        with patch.object(hooks, "is_sensitive_path", side_effect=_sensitive):
+            branch = reg._read_clone_branch(clone_dir)
+
+        assert branch is None, (
+            "a .git/HEAD symlinked to a sensitive path must be refused, not "
+            "followed through the sensitive-path ceiling"
+        )
+
+    def test_bounded_read_of_sensitive_symlink_returns_none(self, tmp_path):
+        """Unit-level twin of the above at the primitive: the shared
+        ``_read_git_metadata_bounded`` returns None (not the target's bytes) for
+        a path whose resolved target is sensitive, so EVERY call site (loose
+        ref, ``packed-refs``, provenance HEAD) is contained, not just the
+        branch read."""
+        from kiro_crew import hooks
+        from kiro_crew.apps import registry as reg
+
+        secret = tmp_path / "id_rsa"
+        secret.write_text("PRIVATE KEY MATERIAL\n", encoding="utf-8")
+        link = tmp_path / "clone" / ".git" / "some-ref"
+        link.parent.mkdir(parents=True)
+        try:
+            link.symlink_to(secret)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        resolved_secret = os.path.realpath(secret)
+        real_is_sensitive = hooks.is_sensitive_path
+
+        def _sensitive(path, base_dir=None):
+            if os.path.realpath(path) == resolved_secret:
+                return True
+            return real_is_sensitive(path, base_dir)
+
+        with patch.object(hooks, "is_sensitive_path", side_effect=_sensitive):
+            result = reg._read_git_metadata_bounded(link, reg._HEAD_READ_LIMIT)
+
+        assert result is None, "the bounded reader must refuse a sensitive symlink target"
+
+
+class TestResolvedCloneCommitBoundedRead:
+    """Round-11 class closure: :func:`_resolved_clone_commit` reads the SAME
+    ``.git/HEAD`` primitive on the install (provenance) path, so it must be
+    bounded too — otherwise the memory-exhaustion class stays open from the
+    next call site even after :func:`_read_clone_branch` is fixed.
+    """
+
+    def test_oversized_head_fails_closed_without_unbounded_read(self, tmp_path):
+        from kiro_crew.apps import registry as reg
+
+        clone = tmp_path / "clone"
+        (clone / ".git").mkdir(parents=True)
+        head_file = clone / ".git" / "HEAD"
+        # Detached-HEAD shape padded past the bound — a real detached HEAD is a
+        # single 40/64-char SHA line.
+        head_file.write_text("f" * (2 * 1024 * 1024), encoding="utf-8")
+
+        from kiro_crew import hooks
+
+        real_prefix = hooks.safe_read_prefix
+        limit_args: list[int] = []
+
+        def _recording_prefix(raw, n):
+            limit_args.append(n)
+            return real_prefix(raw, n)
+
+        with patch.object(hooks, "safe_read_prefix", side_effect=_recording_prefix):
+            sha = reg._resolved_clone_commit(clone)
+
+        # Provenance degrades to "" (unknown) rather than loading 2 MiB.
+        assert sha == ""
+        assert limit_args, "HEAD was never read"
+        assert all(
+            0 <= n <= reg._HEAD_READ_LIMIT for n in limit_args
+        ), f"HEAD read past the bound: {limit_args}"
+
+    def test_packed_refs_read_is_bounded(self, tmp_path):
+        """``packed-refs`` is checkout-resident, so its read is bounded — an
+        oversized file is not slurped whole. Asserted by counting the largest
+        ``read(n)`` on that file: the unbounded original reads it all."""
+        from kiro_crew.apps import registry as reg
+
+        clone = tmp_path / "clone"
+        git_dir = clone / ".git"
+        git_dir.mkdir(parents=True)
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+        packed = git_dir / "packed-refs"
+        # A multi-MiB packed-refs — far past the bound, no matching ref line.
+        packed.write_text("x" * (4 * 1024 * 1024), encoding="utf-8")
+
+        from kiro_crew import hooks
+
+        real_prefix = hooks.safe_read_prefix
+        packed_read_args: list[int] = []
+
+        def _recording_prefix(raw, n):
+            # Record only the packed-refs read; HEAD is read through the same
+            # primitive but with the smaller HEAD bound.
+            if Path(raw) == packed:
+                packed_read_args.append(n)
+            return real_prefix(raw, n)
+
+        with patch.object(hooks, "safe_read_prefix", side_effect=_recording_prefix):
+            sha = reg._resolved_clone_commit(clone)
+
+        assert sha == ""  # no matching ref → unknown provenance
+        assert packed_read_args, "packed-refs was never read through the bounded reader"
+        # The bounded read passes a concrete positive size; an unbounded read
+        # would slurp the whole 4 MiB file. Use the file size as the ceiling so
+        # this fails behaviorally on an unbounded read regardless of the exact
+        # bound constant.
+        assert all(
+            0 <= n <= 4 * 1024 * 1024 for n in packed_read_args
+        ), f"packed-refs read unbounded (read sizes {packed_read_args})"
+
+    def test_normal_detached_head_still_resolves(self, tmp_path):
+        """Control: a well-formed detached HEAD still yields its SHA — the
+        bound rejects only oversized content."""
+        from kiro_crew.apps import registry as reg
+
+        clone = tmp_path / "clone"
+        (clone / ".git").mkdir(parents=True)
+        sha = "a" * 40
+        (clone / ".git" / "HEAD").write_text(sha + "\n", encoding="utf-8")
+
+        assert reg._resolved_clone_commit(clone) == sha
+
+
+class TestCommitPinnedSkipsReconvergenceRead:
+    """Round-11 regression (GPT 5.6): a commit-pinned install must NOT perform
+    the branch-reconvergence ``.git/HEAD`` read.
+
+    A pinned install never reuses the existing tree (it is moved aside and the
+    commit is re-fetched into a fresh checkout regardless), so reading the old
+    tree's branch is pointless work — and pointless attack surface on a path
+    that runs during every pinned update against attacker-writable content. The
+    read is now gated behind ``not commit``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pinned_install_never_calls_read_clone_branch(self, tmp_path):
+        """With ``commit`` set, ``_read_clone_branch`` is never invoked even
+        though a ``.git`` checkout on a DIFFERENT branch is present."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "app-sources" / "pinned-app"
+        (dest / ".git").mkdir(parents=True)
+        # A concrete, different branch — if the reconvergence read ran it would
+        # try to move this aside. The gate must skip the read entirely.
+        (dest / ".git" / "HEAD").write_text("ref: refs/heads/old-branch\n", encoding="utf-8")
+
+        read_calls: list[Path] = []
+        real_read = reg._read_clone_branch
+
+        def _counting_read(clone_dir):
+            read_calls.append(clone_dir)
+            return real_read(clone_dir)
+
+        async def _fake_move_aside(d, log_lines):
+            # Behave like a successful move-aside without touching disk.
+            return d.with_name(f"{d.name}.stale-test")
+
+        # The pinned fetch returns a failure dict so the function returns before
+        # doing any real work after the reconvergence gate.
+        fetch_result = {"ok": False, "name": "pinned-app", "error": "fetch stub"}
+        git_url = "https://example.com/pinned-app.git"
+
+        with (
+            patch.object(reg, "_read_clone_branch", side_effect=_counting_read),
+            patch.object(reg, "_move_checkout_aside", side_effect=_fake_move_aside),
+            patch.object(reg, "_git_fetch_commit", new=AsyncMock(return_value=fetch_result)),
+            # Origin verified identical so the origin gate passes and control
+            # reaches the (now commit-gated) reconvergence block.
+            patch.object(reg, "_clone_origin_url", new=AsyncMock(return_value=git_url)),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=dest),
+            patch(
+                "kiro_crew.apps.registry.is_clone_host_trusted",
+                return_value=True,
+            ),
+        ):
+            result = await reg._clone_build_app_locked(
+                git_url,
+                "pinned-app",
+                [],
+                branch="main",
+                commit="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                pending_cleanup=[],
+                restorable_stale=[],
+            )
+
+        assert result == fetch_result
+        assert read_calls == [], (
+            "a commit-pinned install must skip the branch-reconvergence "
+            f"read, but _read_clone_branch was called with {read_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_branch_tracking_install_does_call_read_clone_branch(self, tmp_path):
+        """Control: with ``commit`` unset, the reconvergence read DOES run —
+        proving the skip is specific to the pinned path, not a dead gate."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "app-sources" / "tracking-app"
+        (dest / ".git").mkdir(parents=True)
+        (dest / ".git" / "HEAD").write_text("ref: refs/heads/old-branch\n", encoding="utf-8")
+
+        git_url = "https://example.com/tracking-app.git"
+
+        def _tripwire_read(clone_dir):
+            raise RuntimeError("reconvergence read reached")
+
+        with (
+            patch.object(reg, "_read_clone_branch", side_effect=_tripwire_read),
+            # Origin verified identical (the check that precedes the
+            # reconvergence read) so the branch path is actually reached.
+            patch.object(reg, "_clone_origin_url", new=AsyncMock(return_value=git_url)),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=dest),
+            patch(
+                "kiro_crew.apps.registry.is_clone_host_trusted",
+                return_value=True,
+            ),
+        ):
+            # The read runs (inside asyncio.to_thread), so its exception
+            # propagates — that is the proof it was reached on the branch path.
+            with pytest.raises(RuntimeError, match="reconvergence read reached"):
+                await reg._clone_build_app_locked(
+                    git_url,
+                    "tracking-app",
+                    [],
+                    branch="main",
+                    commit="",
+                    pending_cleanup=[],
+                    restorable_stale=[],
+                )
+
+
+class TestMoveAsideUtimeFailureUndoesRename:
+    """Round-11 regression (GPT 5.6): a failed mtime refresh must NOT forfeit
+    stale-checkout retention.
+
+    ``_rename_and_refresh_mtime`` refreshes the checkout's mtime FIRST, then
+    renames it aside, so the moved-aside dir gets the full retention window and
+    never appears under its ``.stale-*`` name carrying a stale clock. If the
+    ``utime`` fails and the failure is swallowed, the checkout would end up
+    aside with its original (possibly already-expired) mtime and the next
+    install's age-based sweep would delete the user's recovery copy. The refresh
+    is not best-effort: it fails CLOSED before anything moves — the utime error
+    re-raises while ``dest`` is still at its original path, so
+    ``_move_checkout_aside`` returns None and the caller fails closed with
+    ``stale_clone_not_removed``. The checkout stays in place, never stranded
+    with an expired clock.
+    """
+
+    @pytest.mark.asyncio
+    async def test_utime_failure_undoes_the_move_aside(self, tmp_path):
+        """``os.utime`` raising OSError leaves ``dest`` in place with no
+        ``.stale-*`` sibling, and the move-aside returns None (fail closed).
+
+        With the pre-rename refresh the failure fires before ``dest`` is moved,
+        so there is nothing to undo — but the observable contract is unchanged:
+        the checkout stays put and no aside is handed back."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "testapp"
+        dest.mkdir()
+        (dest / "marker.txt").write_text("original", encoding="utf-8")
+
+        def _boom(*args, **kwargs):
+            raise OSError("timestamps not permitted on this filesystem")
+
+        log_lines: list[str] = []
+        with patch("kiro_crew.apps.registry.os.utime", side_effect=_boom):
+            aside = await reg._move_checkout_aside(dest, log_lines)
+
+        # Fail closed: no aside path handed back.
+        assert aside is None
+        # The refresh failed before the rename, so dest never moved: it is
+        # still in place with its original contents.
+        assert dest.exists()
+        assert (dest / "marker.txt").read_text(encoding="utf-8") == "original"
+        # No stranded .stale-* sibling holding an expired clock.
+        stranded = list(tmp_path.glob("testapp.stale-*"))
+        assert stranded == [], f"a .stale-* sibling was stranded: {stranded}"
+
+    @pytest.mark.asyncio
+    async def test_utime_failure_makes_install_fail_closed(self, tmp_path):
+        """End to end: a branch-drift install whose ``os.utime`` fails during
+        move-aside refuses with ``stale_clone_not_removed`` and leaves the old
+        checkout in place, rather than moving it aside with an expired mtime."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "app-sources" / "drift-app"
+        (dest / ".git").mkdir(parents=True)
+        # Different branch than requested → triggers the reconvergence move-aside.
+        (dest / ".git" / "HEAD").write_text("ref: refs/heads/old-branch\n", encoding="utf-8")
+
+        git_url = "https://example.com/drift-app.git"
+
+        def _boom(*args, **kwargs):
+            raise OSError("timestamps not permitted on this filesystem")
+
+        with (
+            patch("kiro_crew.apps.registry.os.utime", side_effect=_boom),
+            # Origin verified identical → the origin gate does not move aside;
+            # only the branch-drift reconvergence below does, which is where the
+            # utime failure must fail the whole install closed.
+            patch.object(reg, "_clone_origin_url", new=AsyncMock(return_value=git_url)),
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=dest),
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+        ):
+            result = await reg._clone_build_app_locked(
+                git_url,
+                "drift-app",
+                [],
+                branch="main",
+                commit="",
+                pending_cleanup=[],
+                restorable_stale=[],
+            )
+
+        assert result["ok"] is False
+        assert result["error"] == "stale_clone_not_removed"
+        # The old checkout is left in place (fail closed), not stranded aside.
+        assert (dest / ".git").is_dir()
+        stranded = list((tmp_path / "app-sources").glob("drift-app.stale-*"))
+        assert stranded == [], f"a .stale-* sibling was stranded with an expired clock: {stranded}"
+
+
+class TestBuildFailureRestoreRespectsRestorableStale:
+    """Round-12 regression (GPT 5.6): the build-failure restore loop inside
+    ``_clone_build_app_locked`` must restore ONLY ``restorable_stale`` members.
+
+    ``pending_cleanup`` carries every move-aside a run made — both
+    same-origin/branch-drift asides (restorable) AND origin-mismatch asides the
+    identity gate deliberately refused to serve. The old loop iterated ALL of
+    ``pending_cleanup`` and renamed each aside back into ``pkg_dir`` whenever the
+    fresh clone's build failed. Chain: an entry repointed to a different origin
+    → old checkout moved aside (NON-restorable) → fresh clone BUILDS but the
+    build fails → the loop renamed the origin-mismatched old checkout back into
+    the active source slot, re-seating a repository the gate had just refused.
+
+    After the fix only ``restorable_stale`` members are put back; a
+    non-restorable aside stays a ``.stale-*`` sibling and is named "retained at:"
+    in the returned log.
+    """
+
+    @staticmethod
+    def _make_fake_clone(stale_dir, *, restorable):
+        async def _fake_clone(git_url, branch, dest, log_lines, **kwargs):
+            # Simulate the origin-mismatch (or branch-drift) move-aside having
+            # happened during the clone: the old checkout is a .stale-* sibling
+            # and a FRESH clone now sits at dest with a CORRECT-name manifest so
+            # the identity gate passes and control reaches the build step.
+            pending_cleanup = kwargs.get("pending_cleanup")
+            if pending_cleanup is not None:
+                pending_cleanup.append(stale_dir)
+            restorable_stale = kwargs.get("restorable_stale")
+            if restorable and restorable_stale is not None:
+                restorable_stale.append(stale_dir)
+            dest.mkdir(parents=True, exist_ok=True)
+            (dest / "app.json").write_text(json.dumps({"name": "testapp"}), encoding="utf-8")
+            return None
+
+        return _fake_clone
+
+    @pytest.mark.asyncio
+    async def test_origin_mismatch_stale_not_restored_on_build_failure(self, tmp_path):
+        """Origin-mismatch aside + successful fresh clone + FAILED build → the
+        origin-mismatched old checkout is NOT renamed back into the active slot
+        (it stays a ``.stale-*`` sibling) and the returned log names it retained.
+
+        Fails at head 17372a70 (the loop renamed every aside back); passes
+        after the restorable-membership gate.
+        """
+        from kiro_crew.apps.registry import _clone_build_app
+
+        app_source = tmp_path / "app-sources" / "testapp"
+        stale_dir = tmp_path / "app-sources" / "testapp.stale-deadbeef"
+        stale_dir.mkdir(parents=True)
+        (stale_dir / "someone-elses-repo.txt").write_text("refused origin", encoding="utf-8")
+
+        with (
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch(
+                "kiro_crew.apps.registry._git_clone_or_pull",
+                new=self._make_fake_clone(stale_dir, restorable=False),
+            ),
+            patch(
+                "kiro_crew.apps.registry._run_app_build",
+                new=AsyncMock(return_value={"ok": False, "name": "testapp"}),
+            ),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            log_lines: list[str] = []
+            result = await _clone_build_app(
+                "https://example.com/app.git", "testapp", log_lines
+            )
+
+        assert not result["ok"]
+        # The refused-origin checkout was NOT re-seated into the active slot.
+        assert stale_dir.exists(), "the origin-mismatched aside must stay .stale-*"
+        assert (stale_dir / "someone-elses-repo.txt").read_text(
+            encoding="utf-8"
+        ) == "refused origin", "the refused checkout must be untouched on disk"
+        # It must NOT occupy the active source slot the gate refused to serve.
+        if app_source.exists():
+            assert not (app_source / "someone-elses-repo.txt").exists(), (
+                "the refused-origin checkout must never occupy the active slot"
+            )
+        # It is reported retained (both in the returned log and the stamp),
+        # never silently swept.
+        joined = "\n".join(log_lines) + "\n" + result.get("log", "")
+        assert "retained at" in joined, "the non-restorable aside must be named retained"
+        assert stale_dir in (result.get("_pending_stale_cleanup") or []), (
+            "the non-restorable aside must remain in pending_cleanup for the reporter"
+        )
+
+    @pytest.mark.asyncio
+    async def test_branch_drift_stale_is_restored_on_build_failure(self, tmp_path):
+        """Control: a same-origin branch-drift aside (RESTORABLE) + failed build
+        → the old checkout IS renamed back into the slot, with the existing
+        "previous checkout restored" log line. Existing behaviour unchanged.
+        """
+        from kiro_crew.apps.registry import _clone_build_app
+
+        app_source = tmp_path / "app-sources" / "testapp"
+        stale_dir = tmp_path / "app-sources" / "testapp.stale-cafef00d"
+        stale_dir.mkdir(parents=True)
+        (stale_dir / "my-work.txt").write_text("important local edits", encoding="utf-8")
+
+        with (
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch(
+                "kiro_crew.apps.registry._git_clone_or_pull",
+                new=self._make_fake_clone(stale_dir, restorable=True),
+            ),
+            patch(
+                "kiro_crew.apps.registry._run_app_build",
+                new=AsyncMock(return_value={"ok": False, "name": "testapp"}),
+            ),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            log_lines: list[str] = []
+            result = await _clone_build_app(
+                "https://example.com/app.git", "testapp", log_lines
+            )
+
+        assert not result["ok"]
+        # The restorable aside was put back into the active slot.
+        assert not stale_dir.exists(), "the restorable aside is renamed back into pkg_dir"
+        assert app_source.exists()
+        assert (app_source / "my-work.txt").read_text(
+            encoding="utf-8"
+        ) == "important local edits"
+        joined = "\n".join(log_lines) + "\n" + result.get("log", "")
+        assert "previous checkout restored" in joined, (
+            "a restored aside keeps the existing restore log line"
+        )
+        # A restored aside is dropped from pending_cleanup (no longer retained).
+        assert stale_dir not in (result.get("_pending_stale_cleanup") or [])
+
+    @pytest.mark.asyncio
+    async def test_restorable_restore_rename_oserror_reports_hint_and_keeps_pending(
+        self, tmp_path
+    ):
+        """Control: a RESTORABLE aside whose restore-rename raises OSError still
+        reports the recovery hint and keeps the path in pending_cleanup so it is
+        reported stranded (existing failure-path behaviour unchanged)."""
+        from kiro_crew.apps import registry as reg
+        from kiro_crew.apps.registry import _clone_build_app
+
+        app_source = tmp_path / "app-sources" / "testapp"
+        stale_dir = tmp_path / "app-sources" / "testapp.stale-beefbeef"
+        stale_dir.mkdir(parents=True)
+        (stale_dir / "my-work.txt").write_text("important", encoding="utf-8")
+
+        real_to_thread = asyncio.to_thread
+
+        async def _to_thread_fail_rename(fn, *args, **kwargs):
+            # Fail only the restore rename (stale_dir.rename), pass everything
+            # else (the rmtree of the failed fresh clone) through.
+            if getattr(fn, "__name__", "") == "rename":
+                raise OSError("simulated restore rename failure")
+            return await real_to_thread(fn, *args, **kwargs)
+
+        with (
+            patch("kiro_crew.apps.registry.app_source_dir", return_value=app_source),
+            patch(
+                "kiro_crew.apps.registry._git_clone_or_pull",
+                new=self._make_fake_clone(stale_dir, restorable=True),
+            ),
+            patch(
+                "kiro_crew.apps.registry._run_app_build",
+                new=AsyncMock(return_value={"ok": False, "name": "testapp"}),
+            ),
+            patch.object(reg.asyncio, "to_thread", side_effect=_to_thread_fail_rename),
+            patch("kiro_crew.apps.registry.sel"),
+        ):
+            log_lines: list[str] = []
+            result = await _clone_build_app(
+                "https://example.com/app.git", "testapp", log_lines
+            )
+
+        assert not result["ok"]
+        joined = "\n".join(log_lines) + "\n" + result.get("log", "")
+        assert "could not restore previous checkout" in joined, (
+            "the OSError restore path must surface the recovery hint"
+        )
+        # A rename that FAILED stays in pending_cleanup so it is still reported.
+        assert stale_dir in (result.get("_pending_stale_cleanup") or [])
+
+
+class TestMoveAsideUndoFailureReportsRetainedPath:
+    """Round-12b + round-14 regression (GPT 5.6): a checkout ever left stranded
+    at a ``.stale-*`` aside path MUST have that exact path named in the log,
+    rather than left for the age-based sweep to delete an unreported recovery
+    copy.
+
+    Round 14 moved the mtime refresh BEFORE the rename (so the moved-aside dir
+    never appears under its sweepable name with a stale clock), which means a
+    ``utime`` failure now fails closed while ``dest`` is still at its original
+    path — there is no rename to undo, nothing is stranded, and the honest
+    report names ``dest`` (see :class:`TestMoveAsideUtimeFailureUndoesRename`).
+    The :class:`_MoveAsideUndoFailed` retained-path contract is preserved as
+    the caller's handler for any residual stranding path: when it fires, the
+    exact ``aside`` path it carries is what the log names.
+    """
+
+    @pytest.mark.asyncio
+    async def test_move_aside_undo_failed_handler_names_retained_aside(self, tmp_path):
+        """The caller's ``_MoveAsideUndoFailed`` handler names the exact
+        stranded ``.stale-*`` path. Drive the contract directly: the worker
+        raises ``_MoveAsideUndoFailed`` carrying an on-disk aside (the residual
+        strand shape), and ``_move_checkout_aside`` must fail closed (return
+        None) and log a "Previous checkout retained at: <aside>" line naming
+        that exact path — never a generic dest-only line that would leave the
+        strand unreported."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "testapp"
+        dest.mkdir()
+        # A stranded aside actually present on disk, as the contract describes.
+        aside = dest.with_name("testapp.stale-deadbeef")
+        aside.mkdir()
+        (aside / "marker.txt").write_text("original", encoding="utf-8")
+
+        def _raise_undo_failed(d, a):
+            raise reg._MoveAsideUndoFailed(aside, OSError("undo could not land"))
+
+        log_lines: list[str] = []
+        with patch.object(reg, "_rename_and_refresh_mtime", side_effect=_raise_undo_failed):
+            result = await reg._move_checkout_aside(dest, log_lines)
+
+        # Failed closed.
+        assert result is None
+        # The exact retained path is named, not swept unreported.
+        retained_lines = [ln for ln in log_lines if "Previous checkout retained at" in ln]
+        assert retained_lines, f"the retained aside must be named; got {log_lines!r}"
+        assert str(aside) in retained_lines[0], "the log must name the true on-disk aside path"
+
+    @pytest.mark.asyncio
+    async def test_utime_failure_before_rename_names_dest_not_retained(self, tmp_path):
+        """Round-14 ordering: ``utime`` runs on ``dest`` BEFORE the rename, so a
+        failure fires while the checkout is still at ``dest`` — nothing is moved,
+        nothing is stranded, and the honest report is the generic
+        "Could not move aside ... at <dest>" line with no "retained at" line."""
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "testapp"
+        dest.mkdir()
+        (dest / "marker.txt").write_text("original", encoding="utf-8")
+        old_time = time.time() - 3600
+        os.utime(dest, (old_time, old_time))
+
+        real_utime = os.utime
+
+        def _fake_utime(path, *args, **kwargs):
+            # The refresh now targets dest (pre-rename); fail it there.
+            if Path(path) == dest:
+                raise OSError("simulated utime failure")
+            return real_utime(path, *args, **kwargs)
+
+        log_lines: list[str] = []
+        with patch.object(reg.os, "utime", side_effect=_fake_utime):
+            aside = await reg._move_checkout_aside(dest, log_lines)
+
+        assert aside is None
+        # dest is still in place with its original contents; nothing stranded.
+        assert dest.exists()
+        assert (dest / "marker.txt").read_text(encoding="utf-8") == "original"
+        assert list(tmp_path.glob("testapp.stale-*")) == []
+        assert any("Could not move aside" in ln for ln in log_lines)
+        assert not any(
+            "retained at" in ln for ln in log_lines
+        ), "a fail-closed pre-rename refresh strands nothing, so no retained line is owed"


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 7 related changes:
- **Re-converge persistent clone on registry entry branch change**
- **PR 2731: only move aside on a concretely-read differing branch; fix brand fixture**
- **Republish PR group 'registry-branch-reconverge' (merge conflict with upstream/main)**
- **PR 2731 round 3: gate containment cleanup, fix retained-at for restorable stales**
- **PR 2731 round 6: settle move-aside worker on cancel, delete dead surface**
- **PR 2731 round 8: report refusal-path retained stales**
- **PR 2731: rebase over merged #4939 clone-failure diagnostics**

## Changes and rationale

### Re-converge persistent clone on registry entry branch change
**Tests:** Regression: existing clone on branch A, entry now branch B -> install moves the old checkout aside (`.stale-*` present, fresh mtime), clones branch B, admission sees B's manifest; SECOND manifest fetch uses the fast path again (re-convergence proven). Same-branch case: pull path unchanged (no move-aside). Local-edits case: modified file in the old checkout…
**Review focus:** backend, security boundaries, regression coverage

### PR 2731: only move aside on a concretely-read differing branch; fix brand fixture
**Tests:** Regression pinning finding 1: existing checkout with detached HEAD (raw SHA in .git/HEAD) + entry branch B → install does NOT create a `.stale-*` dir and proceeds via the pull path. Fails at 9a97a6dd, passes after. Regression pinning finding 2 (tag case): two consecutive installs with a detached-HEAD checkout → zero `.stale-*` dirs accumulate. Controls:…
**Review focus:** pr-maintenance, security boundaries, regression coverage

### Republish PR group 'registry-branch-reconverge' (merge conflict with upstream/main)
**Review focus:** pr-maintenance

### PR 2731 round 3: gate containment cleanup, fix retained-at for restorable stales
**Why it matters:** The PR carries two verified blocking fixes (unknown-HEAD destructive gate + post-build restore/report) that have been open since 2026-08-11; the GPT lane is the last CI blocker before human review. The retained-at defect the advisory lanes converge on gives users recovery guidance pointing at a path that no longer exists — exactly the misleading-recovery class the PR set out to remove.
**Tests:** Regression pinning finding 2: branch-mismatch move-aside (restorable) + post-build install failure (monkeypatch install_app to return not-ok) → returned log does NOT claim "Previous checkout retained at:" for the restored path, and the checkout is back at app_source_dir (the finally ran). Fails at f3049572, passes after. Control: ORIGIN-mismatch…
**Review focus:** pr-maintenance, security boundaries, regression coverage

### PR 2731 round 6: settle move-aside worker on cancel, delete dead surface
**Why it matters:** The PR carries verified data-loss fixes open since 2026-08-11; GPT's lane is the last CI blocker before human review, and the First Principles subtractions REMOVE review surface (dead code riding in a security-path diff), which is exactly what stops round 7.
**Tests:** Regression pinning item 1: event-gated fake worker (never wall-clock sleeps) — cancellation delivered while the worker is dispatched-but- pre-rename → after `_move_checkout_aside` re-raises, dest is back in place (or the aside path was logged); control: cancellation after the rename completed still undoes it (existing behavior). Fails at a185d124's…
**Review focus:** pr-maintenance, security boundaries, regression coverage

### PR 2731 round 8: report refusal-path retained stales
**Why it matters:** The PR's whole round-5/6 arc was making retained checkouts either restored or REPORTED; the refusal exits are the one path where a user's old workspace still vanishes without a trace. It is also the last CI blocker before human review.
**Tests:** Regression pinning the finding: origin-mismatch move-aside (non-restorable) + identity-mismatch refusal (cloned app.json declares a different name) → the returned log contains "Previous checkout retained at:" naming the `.stale-*` path, and the dir still exists on disk. Fails at cc37ce637, passes after. Same for the cloned-admission rejection path…
**Review focus:** pr-maintenance

### PR 2731: rebase over merged #4939 clone-failure diagnostics
**Why it matters:** A CONFLICTING PR cannot merge and stalls the human-review blocker. #4939's diagnostics land in the SAME failure-return regions this PR's rounds 1-12 hardened (the `_git_clone_or_pull` failure dicts and their tests), so a careless resolution could drop either side's content.
**Review focus:** pr-maintenance

## Review map

| Change | Primary files |
|---|---|
| Re-converge persistent clone on registry entry branch change | `src/kiro_crew/apps/registry.py`<br>`test/test_external_registry.py` |
| PR 2731: only move aside on a concretely-read differing branch; fix brand fixture | `src/kiro_crew/apps/registry.py`<br>`test/test_external_registry.py`<br>`test/test_apps_registry.py` |
| Republish PR group 'registry-branch-reconverge' (merge conflict with upstream/main) | — |
| PR 2731 round 3: gate containment cleanup, fix retained-at for restorable stales | `src/kiro_crew/apps/registry.py`<br>`test/test_external_registry.py`<br>`test/test_apps_registry.py` |
| PR 2731 round 6: settle move-aside worker on cancel, delete dead surface | `src/kiro_crew/apps/registry.py`<br>`test/test_external_registry.py`<br>`test/test_apps_registry.py` |
| PR 2731 round 8: report refusal-path retained stales | `src/kiro_crew/apps/registry.py`<br>`test/test_external_registry.py` |
| PR 2731: rebase over merged #4939 clone-failure diagnostics | `src/kiro_crew/apps/registry.py`<br>`test/test_external_registry.py`<br>`test/test_apps_registry.py`<br>`test/test_app_execution.py` |

## Commits
- [`9571758`](https://github.com/kirodotdev/KiroCrew/pull/2731/commits/9571758a328d67fe03ed936763d3c17ea7a723cd) fix(registry): re-converge persistent clone on entry branch change

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (4 files, +4443/-735)</summary>

- `src/kiro_crew/apps/registry.py` (+702/-83)
- `test/test_app_execution.py` (+5/-7)
- `test/test_apps_registry.py` (+31/-12)
- `test/test_external_registry.py` (+3705/-633)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->


## Behavior changes in this PR

The auto-generated summary above understates this change: beyond the headline
branch re-convergence it carries several user-visible behavior changes across the
registry install/cleanup surface (see the "Changed files" block above for the
current per-file line counts). Spelling them out so the recovery-path behavior is
on the record:

- **Branch change re-clones instead of pulling.** When a registry entry's branch
  changes, the next update of an installed app builds the new branch by cloning it
  fresh rather than pulling the old one. The old checkout is not deleted — it is
  kept as a `.stale-*` sibling with a fresh retention clock, so it is recoverable by
  hand until the retention sweep removes it.
- **Tag-pinned checkouts are never moved aside.** A detached or unreadable HEAD
  (a tag/commit pin) takes the non-destructive pull path and is left in place; a log
  line records that it was kept rather than re-cloned.
- **Restore-on-rejection is now policy-aware (deliberate flip).** This is the one
  worth a close read. Previously, when an install was rejected (identity mismatch,
  admission denial, unsafe subdirectory, build/script failure), a moved-aside
  checkout was restored back into the active slot. That is now split by origin:
  - A **same-origin (branch-drift)** move-aside is still restored after a failed
    install — same repository, only the branch differed, so putting it back is safe.
  - An **origin-mismatched** move-aside (a different repository that happened to sit
    in the slot) is **no longer restored**. Restoring it would hand the admission
    path the exact tree it just refused. Instead the active slot is left empty and
    the previous workspace stays recoverable at the named `.stale-*` path until the
    retention sweep deletes it. A previously-pinned test
    (`test_moveaside_reclone_treated_as_fresh_on_rejection`) was renamed to
    `..._retained_not_restored_on_rejection` and its assertions inverted to match.
- **Retained checkouts are named in the returned log.** Failure exits (timeout,
  script failure, exception) and durable-success exits now append a
  "Previous checkout retained at: …" line naming any genuinely retained `.stale-*`
  path, so the recovery location is discoverable from the install log.
- **Cancellation mid-move-aside is deterministic.** If the task is cancelled while
  the checkout is being renamed aside, the rename is either undone or reported
  instead of stranding the checkout at the `.stale-*` path.
- **Manifest restore re-checks containment at write time.** The post-rejection
  manifest restore re-verifies full-path symlink containment (subdirectory *and*
  leaf) at the moment it writes, rather than trusting an earlier check that
  untrusted build/`onInstall` output could have invalidated. A refused unsafe
  `subdirectory` now also cleans up the rejected clone instead of leaving it behind.

## Hardening riders

Three standalone hardening fixes ride along in this PR (flagged so reviewers and
`git blame` can find them):

- **`_move_checkout_aside` cancellation rework** — collapses the rename and mtime
  refresh into a single worker so a cancellation cannot land between them and strand
  the checkout; the rename is undone/reported on cancel. The refresh now runs before
  the rename, so a concurrent install's age-based sweep cannot delete the recovery
  checkout in the window between the rename and the timestamp refresh. When an undo
  fails and a recovery copy is left at a `.stale-*` path, that path is now recorded
  with a `logger.warning` as well as in the returned log, so it survives a gateway
  shutdown that discards the response the log would render into.
- **Write-time containment recheck in `_unpoison_rejected_checkout`** — re-validates
  symlink containment of the manifest path (subdirectory and leaf) at write time.
- **Bounded, symlink-contained reads of a checkout's git metadata** —
  `_read_git_metadata_bounded` caps how much of a checkout's `.git` files the
  branch-reconvergence read will consume: `_HEAD_READ_LIMIT` (512 B) for `HEAD`/loose
  refs and `_PACKED_REFS_READ_LIMIT` (1 MiB) for `packed-refs`, applied at four call
  sites, so a checkout the app's own build can rewrite cannot feed an unbounded read.
  The read is routed through the sensitive-path file gate, which canonicalizes the
  path and refuses a resolved target inside a protected location (opening
  `O_NOFOLLOW`), so a `.git/HEAD` an app symlinks at a credential file is refused
  rather than followed.

---

@maintainers — the restore-on-rejection split above is a deliberate change to a
user-facing recovery behavior on a destructive-cleanup surface. Could you confirm
the retain-over-restore choice (origin-mismatched trees stay at `.stale-*` rather
than being restored into the slot) is what you want before merge?

