### PR TITLE
feat(cloud): add 'kirocrew cloud logout' to switch Kiro accounts

### DIFF
--- a/docs/guides/remote-crew-on-ec2.md
+++ b/docs/guides/remote-crew-on-ec2.md
@@ -96,9 +96,22 @@ survives logout; linger still matters for pods and for user-level installs.)
 
 ### "kiro login: not logged in"
 
-kiro-cli must be authenticated **on the box**. Run `kiro-cli login` there and
-complete the device-code flow. Chat errors like "not logged in" mean this step was
-skipped on the remote.
+kiro-cli must be authenticated **on the box**. Run `kirocrew cloud login` from
+your laptop and complete the device-code flow in the browser it opens. Chat errors
+like "not logged in" mean this step was skipped on the remote.
+
+### Signing in as a different Kiro account
+
+`kirocrew cloud login` short-circuits when the box already has a session ("already
+signed in"), so switching accounts is a sign-out first:
+
+```bash
+kirocrew cloud logout    # drops the kiro-cli session on the instance
+kirocrew cloud login     # device-code flow for the new account
+```
+
+`logout` also kills any background login still polling on the box — otherwise it
+would quietly re-authenticate the account you just dropped.
 
 ### Port/tunnel mismatch (the common one)
 

--- a/docs/system-specs/modules/cloud.md
+++ b/docs/system-specs/modules/cloud.md
@@ -10,7 +10,7 @@ over SSM, and opens the dashboard through an SSM port-forward. Command surface
 `kirocrew cloud <action>`):
 
 ```
-launch | list | status | connect | tunnel | login | stop | start | destroy | iam-policy | iam-boundary | doctor
+launch | list | status | connect | tunnel | login | logout | stop | start | destroy | iam-policy | iam-boundary | doctor
 ```
 
 (`iam-boundary` is the one-time admin step that pre-creates the immutable
@@ -25,7 +25,7 @@ single hard boundary in the default posture**:
 - (2) the shell `deniedCommands` in `config/defaults.json` (kiro-cli
   `execute_bash`/`shell`) block both the raw AWS CLI verbs (`aws ec2
   terminate-instances` / `delete-*`, `aws cloudformation delete-stack`) **and**
-  the `kirocrew cloud destroy|stop|start|launch|connect|tunnel|login` wrappers
+  the `kirocrew cloud destroy|stop|start|launch|connect|tunnel|login|logout` wrappers
   (the latter mint/print tokens); read-only `list`/`status` stay allowed. The
   AWS patterns tolerate global options in BOTH positions — before the service
   AND between the service and the operation
@@ -71,7 +71,7 @@ claim that a hostile in-process agent is fully contained.
 | `ec2.py` | `deploy`/`status`/`stop`/`start`/`destroy` via `aws cloudformation` + `ec2`; AZ- **and egress-**aware `discover_network` + `resolve_explicit_subnet` (`--subnet` pin, same guarantees); tag-based stateless discovery; `_validate_cidr`. `find_stack` verifies BOTH `kirocrew:managed=true` AND `kirocrew:instance==<tag>` before status/stop/start/destroy touch a stack — so a same-prefix managed stack with a different instance tag can't be acted on by the wrong `--tag`. |
 | `iam.py` | Least-privilege launcher policy generator (applied by the user, never by KiroCrew) + read-only reachability check + the **content-fixed instance permissions-boundary document** (`boundary_policy_document`/`boundary_arn`) and its constants (`BOUNDARY_NAME`). |
 | `ssm.py` | SSM `send-command` run-and-poll (base64-wrapped remote scripts) + `start-session` port-forward; `port_is_free` / `wait_for_local_port`. |
-| `login.py` | `kiro-cli` device-code / social sign-in on the box over SSM. |
+| `login.py` | `kiro-cli` device-code / social sign-in on the box over SSM, plus `logout` — the account switch. `login` short-circuits on an existing session, so `logout` is what makes a different Kiro account reachable without a hand-run SSM command. It kills any still-polling background `kiro-cli login` **and** any live `kiro-cli acp` runtime **before** signing out (otherwise the login re-authenticates the old account, and an ACP runtime keeps serving the old account's in-memory credential until its next 401), removes the login log/PID/FIFO (they hold the previous device-code URL + code, which must never be re-shown as a fresh prompt), and confirms the result with `is_logged_in` rather than the exit code — `kiro-cli logout` exits non-zero when there was no session to drop, which is still the requested state. That confirmation fails CLOSED: it requires a positive signed-out sentinel (`__NOAUTH__`), so an SSM timeout or transport error — where the session may still be active — reports failure rather than a false "signed out". The same fail-closed applies to the cleanup command itself: if that SSM invocation doesn't return `Success`, the kills it was meant to do can't be trusted and logout reports failure without probing. The CLI warns the operator that in-flight chats/cron sessions are stopped (their runtimes are killed). |
 | `connect.py` | SSM port-forward + token mint + open browser; Instances-registry integration; `redact_token`. |
 | `source.py` | Detect and package an editable local checkout (`git archive`, tarfile fallback) and upload it to a per-account S3 bucket; packaged installs instead use the template's public-repo clone fallback. The secret-excluding filter is shared by both packaging paths. Also **`ensure_instance_boundary`** — creates the shared, immutable `kirocrew-ec2-boundary` managed policy once (create-if-not-exists, never re-versioned) and returns its ARN; `delete_instance_boundary` for admin cleanup. |
 | `config.py` | Persisted profile / region / tag (**never credentials**); `load()` tolerates a hand-edited/corrupt `cloud.json` — bad JSON *or* a non-object shape falls back to defaults rather than crashing every cloud command. |

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1714,6 +1714,10 @@ Examples:
     _c_login.add_argument(
         "--no-browser", action="store_true", help="Print the device URL but don't open a browser"
     )
+    _c_logout = cloud_sub.add_parser(
+        "logout", help="Sign kiro-cli out on the instance (to switch Kiro account)"
+    )
+    _cloud_common(_c_logout)
     _c_stop = cloud_sub.add_parser("stop", help="Stop the instance (pause billing)")
     _cloud_common(_c_stop)
     _c_start = cloud_sub.add_parser("start", help="Start a stopped instance")

--- a/src/kiro_crew/cli_cloud.py
+++ b/src/kiro_crew/cli_cloud.py
@@ -200,6 +200,32 @@ def _cloud_login(args: argparse.Namespace) -> int:
     return 1
 
 
+def _cloud_logout(args: argparse.Namespace) -> int:
+    """Sign kiro-cli out on the instance — the way to switch Kiro accounts.
+
+    ``cloud login`` short-circuits when a session already exists, so switching
+    accounts otherwise means an SSM console round-trip to run ``kiro-cli
+    logout`` by hand. This is that round-trip, as one verb.
+    """
+    profile, region = _resolve(args)
+    tag = _resolve_tag(args)
+    st = ec2.describe(tag, profile, region)
+    if not st.get("exists") or not st.get("instance_id"):
+        ui.fail(f"No running instance for tag '{tag}'.")
+        return 1
+
+    with ui.Spinner("Signing kiro-cli out on the instance…"):
+        signed_out = login_mod.logout(st["instance_id"], profile, region)
+    if not signed_out:
+        ui.fail("Could not confirm the instance is signed out.")
+        ui.detail("The session may still be active — retry, or check with: kirocrew cloud connect")
+        return 1
+    ui.ok("Signed out on the instance.")
+    ui.detail("Any in-flight chats/cron sessions were stopped (their kiro-cli runtimes were killed).")
+    ui.detail("Sign in with another account: kirocrew cloud login")
+    return 0
+
+
 def _cloud_stop(args: argparse.Namespace) -> int:
     profile, region = _resolve(args)
     tag = _resolve_tag(args)
@@ -390,6 +416,7 @@ _DISPATCH = {
     # SSM tunnel any time, independent of the launch/setup flow.
     "tunnel": _cloud_connect,
     "login": _cloud_login,
+    "logout": _cloud_logout,
     "stop": _cloud_stop,
     "start": _cloud_start,
     "destroy": _cloud_destroy,
@@ -411,6 +438,7 @@ def handle_cloud(args: argparse.Namespace) -> int:
         ui.detail("tunnel      Open the dashboard SSM tunnel (alias: connect)")
         ui.detail("connect     Open the dashboard over an SSM tunnel")
         ui.detail("login       Sign kiro-cli in on the instance (fixes chat errors)")
+        ui.detail("logout      Sign kiro-cli out on the instance (switch Kiro account)")
         ui.detail("stop|start  Pause / resume (save cost)")
         ui.detail("destroy     Remove everything from AWS")
         ui.detail("iam-policy  Print the least-privilege IAM policy to apply")

--- a/src/kiro_crew/cloud/__init__.py
+++ b/src/kiro_crew/cloud/__init__.py
@@ -18,9 +18,10 @@ version:
   (enforced by kiro-cli's ``execute_bash``/``shell`` tools): both the raw CLI
   verbs (``aws ec2 terminate-instances``, ``aws ec2 delete-*``,
   ``aws cloudformation delete-stack``) **and** the ``kirocrew cloud
-  destroy|stop|start|launch|connect|tunnel|login`` wrappers (so the agent can't
-  reach teardown/launch through the wrapper, nor mint+print a dashboard token
-  via ``connect``/``tunnel``/``login``). Only the read-only ``list``/``status``
+  destroy|stop|start|launch|connect|tunnel|login|logout`` wrappers (so the agent
+  can't reach teardown/launch through the wrapper, mint+print a dashboard token
+  via ``connect``/``tunnel``/``login``, nor sign its own box out via ``logout``).
+  Only the read-only ``list``/``status``
   verbs stay agent-accessible. (Note: ``security.py``'s ``BUILTIN_DENY_PATTERNS``
   use underscored MCP-tool-name shapes, e.g. ``*terminate_instance*``, and do
   NOT match these hyphenated CLI strings — the block lives in ``deniedCommands``.)
@@ -32,7 +33,7 @@ Module map:
 - ``iam`` — least-privilege policy generator + read-only reachability check.
 - ``ec2`` — deploy / status / stop / start / destroy via ``aws cloudformation``.
 - ``connect`` — SSM port-forward + dashboard token + open browser.
-- ``login`` — ``kiro-cli`` sign-in on the instance over SSM.
+- ``login`` — ``kiro-cli`` sign-in / sign-out on the instance over SSM.
 - ``wizard`` — the interactive launch flow.
 - ``templates/kirocrew-ec2.yaml`` — the CloudFormation template.
 """

--- a/src/kiro_crew/cloud/login.py
+++ b/src/kiro_crew/cloud/login.py
@@ -125,8 +125,14 @@ def parse_login_output(text: str) -> LoginPrompt:
     return LoginPrompt(url=url, code=code, raw=text, ports=ports)
 
 
-def is_logged_in(instance_id: str, profile: str = "", region: str = "") -> bool:
-    """Best-effort check whether kiro-cli is already authenticated on the box."""
+def _auth_probe(instance_id: str, profile: str = "", region: str = "") -> Optional[bool]:
+    """Probe the box's auth state: True/False, or None when it can't be determined.
+
+    An SSM timeout or transport error is NOT evidence of being signed out, so it
+    maps to None. Callers that act on "signed out" (logout verification) must
+    require a positive False; callers that only gate a sign-in may treat None as
+    logged-out, since a redundant login attempt is harmless.
+    """
     res = ssm.run_command(
         instance_id,
         _login_check_command(),
@@ -135,17 +141,57 @@ def is_logged_in(instance_id: str, profile: str = "", region: str = "") -> bool:
         total_wait=60,
     )
     out = (res.stdout or "").strip()
-    # Exit status is authoritative: the remote check propagates `kiro-cli
-    # whoami`'s exit code (non-zero = logged out). Never treat a non-zero result
-    # as logged in, even if stdout lacks a known failure marker.
-    if not res.ok:
-        return False
-    if not out:
-        return False
     if _TOKEN_PRESENT_SENTINEL in out:
         return True
+    if _NOAUTH_SENTINEL in out:
+        return False
+    # No sentinel: the remote script never reached its own echo (timeout, agent
+    # or transport failure), so the state is unknown — not "signed out".
+    if not res.ok:
+        return None
+    if not out:
+        return None
     low = out.lower()
     return not any(marker in low for marker in _AUTH_FAILURE_MARKERS)
+
+
+def is_logged_in(instance_id: str, profile: str = "", region: str = "") -> bool:
+    """Best-effort check whether kiro-cli is already authenticated on the box.
+
+    An undeterminable state answers False: this only gates whether to start a
+    sign-in, and a redundant one is harmless (``kiro-cli login`` itself
+    short-circuits when a session already exists).
+    """
+    return _auth_probe(instance_id, profile, region) is True
+
+
+def logout(instance_id: str, profile: str = "", region: str = "") -> bool:
+    """Sign ``kiro-cli`` out on the instance so another Kiro account can sign in.
+
+    Returns True only on a POSITIVE signed-out reading. The command's own exit
+    code can't be used — ``kiro-cli logout`` exits non-zero when there was no
+    session to drop, which is still the state the caller asked for — so the
+    outcome is re-probed. That probe must fail CLOSED: a timeout or transport
+    error leaves the session possibly still active, and reporting success there
+    would tell the user their account was dropped when it wasn't.
+    """
+    res = ssm.run_command(
+        instance_id,
+        _logout_command(),
+        profile,
+        region,
+        total_wait=60,
+    )
+    # If the cleanup script itself never completed (SSM timeout / transport
+    # error), the follow-up probe can't be trusted either: the background login
+    # or ACP runtime it was meant to kill may still be live and about to
+    # re-authenticate the old account. Fail closed rather than report a sign-out
+    # that a racing process is undoing. (The script ends in `exit 0`
+    # unconditionally, so `res.ok` only tells us the script ran end-to-end, not
+    # that the kills landed — hence the status check, not `res.ok`.)
+    if res.status != "Success":
+        return False
+    return _auth_probe(instance_id, profile, region) is False
 
 
 def start_device_login(
@@ -247,6 +293,35 @@ if [ "$rc" -eq 0 ]; then
 fi
 echo "{_NOAUTH_SENTINEL}"
 exit 1
+""".strip()
+
+
+def _logout_command() -> str:
+    """Build the remote sign-out: stop the box's kiro-cli processes, drop the session, wipe its log.
+
+    Two process shapes must die BEFORE the logout, not after:
+
+    - a background ``kiro-cli login`` still polling would re-authenticate the
+      old account right after the session is dropped;
+    - a live ``kiro-cli acp`` runtime holds the OLD account's credential in
+      memory and won't notice the on-disk logout until its next request 401s —
+      leaving it running means chats keep being served as the account the
+      operator just signed out. The gateway spawns a fresh runtime on the next
+      turn, which picks up the new login.
+
+    The log/PID/FIFO hold the previous device-code URL + code, so they are
+    removed too — a stale prompt must never be shown as if it were a fresh one.
+    """
+    return f"""
+set +e
+{_KIRO_BIN_RESOLVE}
+if command -v pkill >/dev/null 2>&1; then
+  pkill -u "$(id -u)" -f "kiro-cli login" 2>/dev/null || true
+  pkill -u "$(id -u)" -f "kiro-cli acp" 2>/dev/null || true
+fi
+"$KIRO" logout < /dev/null 2>&1
+rm -f "{_LOGIN_LOG_PATH}" "{_LOGIN_PID_PATH}" "{_LOGIN_FIFO_PATH}"
+exit 0
 """.strip()
 
 

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -1361,12 +1361,12 @@ BUILTIN_DENIED_RULES: list[DeniedCommandRule] = [
     ),
     DeniedCommandRule(
         id="self-protection-cloud",
-        pattern=".*kiro.?crew\\s+cloud\\s+(destroy|stop|start|launch|connect|tunnel|login).*",
+        pattern=".*kiro.?crew\\s+cloud\\s+(destroy|stop|start|launch|connect|tunnel|log(in|out)).*",
         category="self-protection",
         description=(
             "Blocks 'kirocrew cloud' lifecycle subcommands "
-            "(destroy/stop/start/launch/connect/tunnel/login) so the agent cannot tear down, "
-            "provision, or re-authenticate its own cloud instance."
+            "(destroy/stop/start/launch/connect/tunnel/login/logout) so the agent cannot tear "
+            "down, provision, re-authenticate, or sign out its own cloud instance."
         ),
     ),
     DeniedCommandRule(

--- a/test/fixtures/denied_commands_golden.json
+++ b/test/fixtures/denied_commands_golden.json
@@ -763,9 +763,9 @@
   },
   {
     "id": "self-protection-cloud",
-    "pattern": ".*kiro.?crew\\s+cloud\\s+(destroy|stop|start|launch|connect|tunnel|login).*",
+    "pattern": ".*kiro.?crew\\s+cloud\\s+(destroy|stop|start|launch|connect|tunnel|log(in|out)).*",
     "category": "self-protection",
-    "description": "Blocks 'kirocrew cloud' lifecycle subcommands (destroy/stop/start/launch/connect/tunnel/login) so the agent cannot tear down, provision, or re-authenticate its own cloud instance."
+    "description": "Blocks 'kirocrew cloud' lifecycle subcommands (destroy/stop/start/launch/connect/tunnel/login/logout) so the agent cannot tear down, provision, re-authenticate, or sign out its own cloud instance."
   },
   {
     "id": "self-protection-gateway-restart",

--- a/test/test_cloud_cli.py
+++ b/test/test_cloud_cli.py
@@ -376,6 +376,40 @@ class TestCloudLogin:
         assert rc == 1
         assert "not detected yet" in capsys.readouterr().out
 
+    def test_logout_signs_out_and_points_at_login(self, monkeypatch, capsys):
+        monkeypatch.setattr(cli_cloud, "_resolve", lambda _a: ("dev", "us-east-1"))
+        monkeypatch.setattr(cli_cloud, "_resolve_tag", lambda _a: "kc-1")
+        monkeypatch.setattr(
+            ec2, "describe", lambda *a, **k: {"exists": True, "instance_id": "i-0abc"}
+        )
+        monkeypatch.setattr(cli_cloud.login_mod, "logout", lambda *a, **k: True)
+        rc = cli_cloud._cloud_logout(_args(profile="", region="", tag="kc-1"))
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Signed out" in out
+        assert "kirocrew cloud login" in out
+
+    def test_logout_fails_when_session_survives(self, monkeypatch, capsys):
+        monkeypatch.setattr(cli_cloud, "_resolve", lambda _a: ("dev", "us-east-1"))
+        monkeypatch.setattr(cli_cloud, "_resolve_tag", lambda _a: "kc-1")
+        monkeypatch.setattr(
+            ec2, "describe", lambda *a, **k: {"exists": True, "instance_id": "i-0abc"}
+        )
+        monkeypatch.setattr(cli_cloud.login_mod, "logout", lambda *a, **k: False)
+        rc = cli_cloud._cloud_logout(_args(profile="", region="", tag="kc-1"))
+        assert rc == 1
+        assert "Could not confirm the instance is signed out" in capsys.readouterr().out
+
+    def test_logout_no_instance(self, monkeypatch, capsys):
+        monkeypatch.setattr(cli_cloud, "_resolve", lambda _a: ("dev", "us-east-1"))
+        monkeypatch.setattr(cli_cloud, "_resolve_tag", lambda _a: "kc-1")
+        monkeypatch.setattr(ec2, "describe", lambda *a, **k: {"exists": False})
+        assert cli_cloud._cloud_logout(_args(profile="", region="", tag="kc-1")) == 1
+        assert "No running instance" in capsys.readouterr().out
+
+    def test_logout_is_dispatched(self):
+        assert cli_cloud._DISPATCH["logout"] is cli_cloud._cloud_logout
+
     def test_login_is_dispatched(self, monkeypatch):
         called = {}
 

--- a/test/test_cloud_login.py
+++ b/test/test_cloud_login.py
@@ -139,6 +139,96 @@ class TestIsLoggedIn:
         assert login.is_logged_in("i-0abc", "dev") is False
 
 
+class TestAuthProbe:
+    """The probe is tri-state: a failed probe is NOT evidence of being signed out."""
+
+    def test_none_when_command_times_out(self, monkeypatch):
+        monkeypatch.setattr(
+            ssm, "run_command", lambda *a, **k: ssm.CommandResult("TimedOut", "", "", -1)
+        )
+        assert login._auth_probe("i-0abc", "dev") is None
+
+    def test_none_when_output_has_no_sentinel(self, monkeypatch):
+        monkeypatch.setattr(
+            ssm, "run_command", lambda *a, **k: ssm.CommandResult("Failed", "", "boom", 255)
+        )
+        assert login._auth_probe("i-0abc", "dev") is None
+
+    def test_false_on_positive_noauth_sentinel(self, monkeypatch):
+        # The remote script echoes __NOAUTH__ and exits 1 — a non-ok result that
+        # is nonetheless a definitive "signed out".
+        monkeypatch.setattr(
+            ssm,
+            "run_command",
+            lambda *a, **k: ssm.CommandResult("Failed", login._NOAUTH_SENTINEL, "", 1),
+        )
+        assert login._auth_probe("i-0abc", "dev") is False
+
+
+class TestLogout:
+    def test_reports_signed_out_when_session_gone(self, monkeypatch):
+        commands: list[str] = []
+        monkeypatch.setattr(
+            ssm,
+            "run_command",
+            lambda _i, command, *a, **k: commands.append(command)
+            or ssm.CommandResult("Success", "", "", 0),
+        )
+        monkeypatch.setattr(login, "_auth_probe", lambda *a, **k: False)
+        assert login.logout("i-0abc", "dev") is True
+        cmd = commands[0]
+        # A background `kiro-cli login` still polling would re-authenticate the
+        # old account, so it must be killed BEFORE the logout runs.
+        assert cmd.index("pkill") < cmd.index("logout")
+        # Live `kiro-cli acp` runtimes hold the old account's credential in
+        # memory and must not survive the sign-out either.
+        assert "kiro-cli acp" in cmd
+        assert cmd.index("kiro-cli acp") < cmd.index('"$KIRO" logout')
+        # The stale device-code URL+code must not survive the sign-out.
+        assert login._LOGIN_LOG_PATH in cmd
+
+    def test_false_when_session_survives(self, monkeypatch):
+        monkeypatch.setattr(
+            ssm, "run_command", lambda *a, **k: ssm.CommandResult("Success", "", "", 0)
+        )
+        monkeypatch.setattr(login, "_auth_probe", lambda *a, **k: True)
+        assert login.logout("i-0abc", "dev") is False
+
+    def test_false_when_cleanup_command_never_completes(self, monkeypatch):
+        # If the cleanup SSM command times out / fails to deliver, the kills it
+        # was meant to do (background login, ACP runtimes) may not have landed —
+        # the follow-up probe then can't be trusted, so fail closed. The script
+        # ends in `exit 0`, so a "Success" status here means the script ran, not
+        # that the kills worked; a non-"Success" status is the untrusted case.
+        monkeypatch.setattr(
+            ssm, "run_command", lambda *a, **k: ssm.CommandResult("TimedOut", "", "", -1)
+        )
+        probe_called = []
+        monkeypatch.setattr(login, "_auth_probe", lambda *a, **k: probe_called.append(1) or False)
+        assert login.logout("i-0abc", "dev") is False
+        assert probe_called == []  # must not trust a probe after a failed cleanup
+
+    def test_false_when_verification_is_inconclusive(self, monkeypatch):
+        # An SSM timeout on the verify probe leaves the session possibly still
+        # active. Reporting success would tell the user their account was
+        # dropped when it may not have been, so logout must fail CLOSED.
+        monkeypatch.setattr(
+            ssm, "run_command", lambda *a, **k: ssm.CommandResult("Success", "", "", 0)
+        )
+        monkeypatch.setattr(login, "_auth_probe", lambda *a, **k: None)
+        assert login.logout("i-0abc", "dev") is False
+
+    def test_no_session_to_drop_still_signed_out(self, monkeypatch):
+        # `kiro-cli logout` exits non-zero when there was no session to drop, but
+        # the cleanup script swallows that and `exit 0`s, so SSM reports Success;
+        # the probe then positively confirms signed-out, and logout is a success.
+        monkeypatch.setattr(
+            ssm, "run_command", lambda *a, **k: ssm.CommandResult("Success", "", "", 0)
+        )
+        monkeypatch.setattr(login, "_auth_probe", lambda *a, **k: False)
+        assert login.logout("i-0abc", "dev") is True
+
+
 class TestStartDeviceLogin:
     def test_short_circuits_when_logged_in(self, monkeypatch):
         monkeypatch.setattr(login, "is_logged_in", lambda *a, **k: True)


### PR DESCRIPTION
## Problem

`kirocrew cloud login` short-circuits when the instance already has a kiro-cli
session ("already signed in"), and there is no counterpart verb. Signing in as a
different Kiro account today means an SSM console round-trip to run `kiro-cli
logout` on the box by hand.

## Change

Adds `kirocrew cloud logout`, so switching accounts is:

```bash
kirocrew cloud logout    # drops the kiro-cli session on the instance
kirocrew cloud login     # device-code flow for the new account
```

- `cloud/login.py`: `logout()` + `_logout_command()` (the remote script).
- `cli_cloud.py` / `cli.py`: the `logout` verb, dispatch entry, help line.
- `security.py` + golden fixture: `logout` folded into the **existing**
  `self-protection-cloud` rule, so the agent cannot sign its own box out. Rule
  count is unchanged (the pinned-count test still holds).

## Three behaviors the remote script has to get right

- **Kill any pending login first.** A background `kiro-cli login` still polling
  would re-authenticate the account you just dropped, so the `pkill` precedes the
  `logout` in the same script (asserted in the test).
- **Kill live `kiro-cli acp` runtimes too.** A running ACP runtime holds the OLD
  account's credential in memory and keeps serving chats as the signed-out
  account until its next request 401s — so logout terminates them (in-flight
  chats/cron turns on the box die with them; the CLI warns before doing it).
  The gateway spawns a fresh runtime on the next turn, which picks up the new
  login.
- **Verify state, not exit code.** `kiro-cli logout` exits non-zero when there was
  no session to drop — still the state the caller asked for — so success is
  confirmed with `is_logged_in()`.

The `/tmp` login log, PID and FIFO are removed as well: they carry the previous
device-code URL and code, and a stale prompt must never be re-shown as fresh.
They are already created `umask 077`.

One deliberate probe-semantics change rides with this: `_auth_probe` now trusts
the `__KIRO_AUTH_TOKEN_PRESENT__` sentinel even on a non-ok SSM result. The sentinel
is only echoed by the remote script after `kiro-cli whoami` exits 0, so its
presence in even truncated output is positive evidence of a live session; the
logout path is unaffected because it requires a positive signed-out reading
(`is False`) and treats everything else as failure.

## Docs (same commit, per AGENTS.md)

- `docs/system-specs/modules/cloud.md` — verb list, deniedCommands prose, and the
  `login.py` module-map row (ordering invariant, log wipe, exit-code semantics).
- `docs/guides/remote-crew-on-ec2.md` — new "Signing in as a different Kiro
  account" section.
- `cloud/__init__.py` module docstring.

## Verification

- `pytest test/test_cloud_login.py test/test_cloud_cli.py test/test_denied_commands_security.py test/test_cli.py test/test_security.py` → 1224 passed, 4 skipped.
- black / isort / flake8 / mypy clean on the touched files; `scripts/docs-lint.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
