### PR TITLE
perf(chat): throttle block parsing while a message streams

### DIFF
--- a/website/src/hooks/useBlockAssembler.ts
+++ b/website/src/hooks/useBlockAssembler.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState, useRef, useEffect } from 'react'
 import type { ContentBlock } from '../types'
 
 const FENCE_OPEN = /^(`{3,})(\w*)\s*$/
@@ -325,11 +325,73 @@ export function parseBlocks(raw: string, streaming: boolean): ContentBlock[] {
   return blocks
 }
 
+const THROTTLE_MS = 100
+
+/** Shared empty result so the streaming path allocates nothing per render. */
+const NO_BLOCKS: ContentBlock[] = []
+
 /**
  * Hook that parses raw message text into content blocks.
  * During streaming, unclosed fences or widgets produce provisional blocks.
  * On completion (streaming=false), does a clean full reparse.
+ *
+ * Perf: while streaming, the timer below is the ONLY caller of parseBlocks.
+ * That is what bounds the work, which is otherwise quadratic in response
+ * length because every chunk (~60/s) re-parses the whole accumulated string,
+ * along with the GC pressure from the discarded intermediates. The eager parse
+ * is gated off for the duration of the stream and resumes the moment streaming
+ * ends, so the final output is identical to an unthrottled parse.
  */
 export function useBlockAssembler(rawText: string, streaming: boolean): ContentBlock[] {
-  return useMemo(() => parseBlocks(rawText, streaming), [rawText, streaming])
+  // Gated on !streaming: during a stream this must not parse, or the throttle
+  // below would only be deferring work the render had already paid for.
+  const immediateBlocks = useMemo(
+    () => (streaming ? NO_BLOCKS : parseBlocks(rawText, false)),
+    [rawText, streaming],
+  )
+
+  // Gated too: the early return below never reads this when !streaming, so a
+  // completed message would otherwise pay a second full parse for nothing.
+  const [throttledBlocks, setThrottledBlocks] = useState<ContentBlock[]>(() =>
+    streaming ? parseBlocks(rawText, true) : NO_BLOCKS,
+  )
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const latestTextRef = useRef(rawText)
+
+  // In an effect, not in render: a render React discards must not move the ref
+  // the timer reads, or the timer would parse text from an abandoned render.
+  useEffect(() => {
+    latestTextRef.current = rawText
+  }, [rawText])
+
+  useEffect(() => {
+    if (!streaming) {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+      // Primes the snapshot so a later stream resumes from the current parse.
+      setThrottledBlocks(immediateBlocks)
+      return
+    }
+    if (timerRef.current === null) {
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        setThrottledBlocks(parseBlocks(latestTextRef.current, true))
+      }, THROTTLE_MS)
+    }
+  }, [rawText, streaming, immediateBlocks])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [])
+
+  // This early return, not any effect, is what makes the final render exact.
+  if (!streaming) return immediateBlocks
+  return throttledBlocks
 }

--- a/website/src/test/streamingFlashRepro.test.tsx
+++ b/website/src/test/streamingFlashRepro.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import MarkdownRenderer from '../components/MarkdownRenderer'
 
 /**
@@ -66,7 +66,7 @@ describe('streaming flash regression', () => {
     expect(ftWords(container).length).toBeLessThanOrEqual(32)
   })
 
-  it('PREMISE: completing an inline `code` token still remounts already-visible spans', () => {
+  it('PREMISE: completing an inline `code` token still remounts already-visible spans', async () => {
     // This documents that the remount is inherent to react-markdown — the fix
     // makes it harmless rather than preventing it.
     const { container, rerender } = render(
@@ -75,6 +75,9 @@ describe('streaming flash regression', () => {
     const before = ftWords(container)
     expect(before.length).toBeGreaterThan(0)
     rerender(<MarkdownRenderer content={'see `code` and more here'} {...STREAM} />)
+    // Block parsing is throttled while streaming, so the restructure lands on
+    // the next parse tick rather than in this render.
+    await waitFor(() => expect(container.querySelector('code')).not.toBeNull())
     const after = ftWords(container)
     const remounted = before.filter(n => !after.includes(n))
     // eslint-disable-next-line no-console
@@ -82,7 +85,7 @@ describe('streaming flash regression', () => {
     expect(remounted.length).toBeGreaterThan(0)
   })
 
-  it('FIX: a token completing WITHIN the edge does not re-fade already-visible text (opacity is position-stable)', () => {
+  it('FIX: a token completing WITHIN the edge does not re-fade already-visible text (opacity is position-stable)', async () => {
     // Unclosed backtick renders literally; the tail "and more text here" is all
     // ft-word spans. Closing the backtick turns `code` into <code>, remounting
     // the trailing spans (see PREMISE). The trailing text and its distance to
@@ -94,6 +97,9 @@ describe('streaming flash regression', () => {
     const before = tailOpacities(container)
 
     rerender(<MarkdownRenderer content={'see `code` and more text here'} {...STREAM} />)
+    // Same wait as PREMISE: without it the throttle would leave the subtree
+    // unchanged and this guard would pass with no remount to survive.
+    await waitFor(() => expect(container.querySelector('code')).not.toBeNull())
     const after = tailOpacities(container)
 
     // The visible trailing text "and more text here" (18 chars) is unchanged and

--- a/website/src/test/useBlockAssembler.throttle.test.ts
+++ b/website/src/test/useBlockAssembler.throttle.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useBlockAssembler, parseBlocks } from '../hooks/useBlockAssembler'
+import type { ContentBlock } from '../types'
+
+// Mirrors THROTTLE_MS in the hook. Every wait below goes through fake timers,
+// so no assertion depends on wall-clock progress or host load.
+const THROTTLE_MS = 100
+
+// An export spy cannot see the hook's intra-module call. parseBlocks opens with
+// one `raw.split('\n')`, so counting that on a marked input counts real parses.
+type SplitFn = typeof String.prototype.split
+const realSplit: SplitFn = String.prototype.split
+const MARK = 'prk-marked-input'
+
+function countParsesOf(prefix: string): () => number {
+  let n = 0
+  const patched = function (this: string, ...args: Parameters<SplitFn>): string[] {
+    if (args[0] === '\n' && this.startsWith(prefix)) n += 1
+    return realSplit.apply(this, args)
+  }
+  String.prototype.split = patched as unknown as SplitFn
+  return () => n
+}
+
+describe('useBlockAssembler streaming throttle', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => {
+    String.prototype.split = realSplit
+    vi.useRealTimers()
+  })
+
+  it('parses at most once per throttle window while streaming, not once per chunk', () => {
+    const chunks = [1, 2, 3, 4, 5, 6].map(n => `${MARK} chunk ${'x'.repeat(n)}`)
+    const parses = countParsesOf(MARK)
+
+    const { rerender } = renderHook(
+      ({ text }) => useBlockAssembler(text, true),
+      { initialProps: { text: chunks[0] } },
+    )
+    const afterMount = parses()
+    expect(afterMount).toBe(1)
+
+    for (const text of chunks.slice(1)) rerender({ text })
+    // Five further chunks arrived inside one window and none of them parsed.
+    expect(parses()).toBe(afterMount)
+
+    act(() => { vi.advanceTimersByTime(THROTTLE_MS) })
+    expect(parses()).toBe(afterMount + 1)
+
+    // A second window costs exactly one more parse, however many chunks land.
+    rerender({ text: `${MARK} chunk next` })
+    rerender({ text: `${MARK} chunk next+1` })
+    expect(parses()).toBe(afterMount + 1)
+    act(() => { vi.advanceTimersByTime(THROTTLE_MS) })
+    expect(parses()).toBe(afterMount + 2)
+  })
+
+  it('returns a stable reference across renders inside one window', () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useBlockAssembler(text, true),
+      { initialProps: { text: 'alpha' } },
+    )
+    const first = result.current
+    rerender({ text: 'alpha beta' })
+    rerender({ text: 'alpha beta gamma' })
+    expect(result.current).toBe(first)
+  })
+
+  it('holds the stale parse inside a window and lands an exact parse when streaming ends', () => {
+    const opening = 'intro\n```js\nconst x = 1'
+    const closed = 'intro\n```js\nconst x = 1\n```\noutro'
+
+    const { result, rerender } = renderHook(
+      ({ text, streaming }) => useBlockAssembler(text, streaming),
+      { initialProps: { text: opening, streaming: true } },
+    )
+    act(() => { vi.advanceTimersByTime(THROTTLE_MS) })
+    expect(result.current).toEqual(parseBlocks(opening, true))
+
+    rerender({ text: closed, streaming: true })
+    // Pins that the throttle defers: a settled result is identical either way,
+    // so only the moment of the write separates throttled from unthrottled.
+    expect(result.current).toEqual(parseBlocks(opening, true))
+    expect(result.current).not.toEqual(parseBlocks(closed, true))
+
+    rerender({ text: closed, streaming: false })
+    expect(result.current).toEqual(parseBlocks(closed, false))
+  })
+
+  it('final output is identical to an unthrottled parse for representative inputs', () => {
+    const inputs = [
+      'Hello **world**',
+      '```js\nconst x = 1\n```',
+      'before\n```python\ndef foo():\n  pass\n```\nafter',
+      '```\n@@ -1,3 +1,4 @@\n-old\n+new\n```',
+      '```mermaid\ngraph TD\nA-->B\n```',
+      'text\n<mcwidget title="T" slug="foo">body</mcwidget>\nafter',
+      'lead\n```markdown\nnested ```py\nx\n```\n```\ntail',
+    ]
+
+    for (const full of inputs) {
+      const half = full.slice(0, Math.max(1, Math.floor(full.length / 2)))
+      const { result, rerender } = renderHook(
+        ({ text, streaming }) => useBlockAssembler(text, streaming),
+        { initialProps: { text: half, streaming: true } },
+      )
+      rerender({ text: full, streaming: true })
+      act(() => { vi.advanceTimersByTime(THROTTLE_MS) })
+      rerender({ text: full, streaming: false })
+      expect(result.current).toEqual(parseBlocks(full, false))
+    }
+  })
+
+  it('does not parse after unmount', () => {
+    const parses = countParsesOf(MARK)
+    const { rerender, unmount } = renderHook(
+      ({ text }) => useBlockAssembler(text, true),
+      { initialProps: { text: `${MARK} one` } },
+    )
+    rerender({ text: `${MARK} one two` })
+    const before = parses()
+
+    unmount()
+    act(() => { vi.advanceTimersByTime(THROTTLE_MS * 5) })
+    expect(parses()).toBe(before)
+  })
+
+  it('lands the exact parse in the same render streaming ends, not a commit later', () => {
+    const opening = 'intro\n```js\nconst x = 1'
+    const closed = 'intro\n```js\nconst x = 1\n```\noutro'
+    // Recorded during render: result.current would let a stale first render
+    // hide behind the effect-driven re-render act() flushes, a visible flash.
+    const rendered: ContentBlock[][] = []
+
+    const { rerender } = renderHook(
+      ({ text, streaming }) => {
+        const blocks = useBlockAssembler(text, streaming)
+        rendered.push(blocks)
+        return blocks
+      },
+      { initialProps: { text: opening, streaming: true } },
+    )
+    act(() => { vi.advanceTimersByTime(THROTTLE_MS) })
+    rerender({ text: closed, streaming: true })
+
+    const firstAfterEnd = rendered.length
+    rerender({ text: closed, streaming: false })
+    expect(rendered[firstAfterEnd]).toEqual(parseBlocks(closed, false))
+  })
+})


### PR DESCRIPTION
## Problem

`useBlockAssembler` parsed on every render:

```ts
return useMemo(() => parseBlocks(rawText, streaming), [rawText, streaming])
```

`rawText` grows with each streamed chunk (~60/s) and the memo re-parses the whole accumulated string every time, so total parse work over a response is quadratic in its length, plus GC pressure from the discarded intermediates. `MarkdownRenderer` calls this hook, so it is on the path for every streaming message.

## Fix

Parsing is driven by a ~100ms timer while streaming, and the eager parse is gated off for the duration. The gate is the load-bearing half: without it the timer would only be deferring work the render had already paid for. Streaming renders reuse a shared empty result, so the gated path allocates nothing per frame and stays referentially stable for downstream memo consumers. When streaming ends, an unconditional parse runs in the same render, so the final output is identical to an unthrottled parse and there is no one-commit lag showing stale content.

No client-side timing figure is claimed. The justification is the removed asymptotic work, not a measured frame or latency delta.

## Tests

New `useBlockAssembler.throttle.test.ts`, 6 cases on fake timers so nothing depends on wall-clock progress or CI load.

Parse counting needed care. An export spy cannot see the hook's intra-module call to `parseBlocks`, and counting distinct output identities is only ever a lower bound on parses. `parseBlocks` opens with exactly one `raw.split('\n')`, so the test counts that split on a marked input and gets a true count of parse entries.

Each of the four sabotages below is caught by exactly one case, and the sets are disjoint:

| Sabotage | Result |
| --- | --- |
| Ungate the eager parse (parse every render) | call-count case fails, `expected 2 to be 1` |
| Drop the final unconditional parse | exactness cases fail on deep-equality |
| Return the throttled snapshot instead of the exact one at stream end | same-render case fails |
| Remove the unmount timer cleanup | no-parse-after-unmount case fails |

The third row is why that case exists. Removing the early return alone initially passed everything: the effect that primes the snapshot, plus the re-render `act()` flushes, made the settled value correct either way. The case now records values during render, so it observes the pre-effect render and sees the stale first frame. The stale-window assertion plays the same role in the other direction — a settled result is identical throttled or not, so only the moment of the write distinguishes them.

The parse counter is positive-controlled: it reads 1 after mount and rises with the ungate sabotage, so it is measuring rather than stuck at zero.

## Adjacent test update

`streamingFlashRepro.test.tsx` guards the streaming-flash regression by completing an inline `` `code` `` token mid-stream and asserting that already-visible spans remount, then that their position-derived opacity is unchanged across the remount. With the throttle, the completing token no longer restructures the subtree in the same render, so that file went red on the PREMISE case and its FIX case started passing with no remount to be robust against. Both now wait for the throttled reparse before asserting. The remount count (5) and compared opacity window (18 chars) are unchanged from before this change, and the file still passes with the hook change reverted, so the guard is neither weakened nor coupled to it.

## Out of scope

Two adjacent ideas are deliberately not here. Wrapping the turn component in `memo()` does nothing until its caller hoists `renderItem` to a stable identity — the caller declares it in its render body, so prop identity changes every render and the comparator never hits; it belongs with that caller change. Narrowing the streaming-glow promoted layer to cut paint cost is a compositing concern, not a parsing one. Either one here would make this two changes under one title.
