### PR TITLE
fix(doctor): honest sandbox verdict from an unconfined shell (#2652)

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -7,15 +7,17 @@ import json
 import logging
 import os
 import platform as _plat
+import shlex
 import shutil
 import subprocess
 import sys
+import textwrap
 import urllib.error
 import urllib.request
 from pathlib import Path
 
 from kiro_crew import __version__ as _mc_version
-from kiro_crew import diagnostics, platform_compat
+from kiro_crew import diagnostics, platform_compat, sandbox
 from kiro_crew.acp.client import KIRO_CLI_BIN
 from kiro_crew.agent import AGENT_FILENAME
 from kiro_crew.atomic_write import atomic_write
@@ -61,6 +63,8 @@ from kiro_crew.platform import (
 from kiro_crew.platform.governance import CU_MCP_SERVER, may_skip_gate_now
 from kiro_crew.sandbox import warm_backend
 from kiro_crew.sel import sel
+from kiro_crew.service import apparmor
+from kiro_crew.service import linux as service_linux
 from kiro_crew.session_pid_sig import signing_health
 from kiro_crew.transcribe import _find_whisper, ensure_ffmpeg_in_path
 
@@ -382,6 +386,184 @@ def _doctor_trust_root() -> None:
         "key file, or"
     )
     print("               restart the gateway if another process relocated it.")
+
+
+_INDENT = "               "
+
+
+def _print_wrapped(text: str) -> None:
+    """Print ``text`` wrapped to the doctor's detail indent."""
+    for line in textwrap.wrap(text, width=80):
+        print(f"{_INDENT}{line}")
+
+
+def _process_apparmor_confinement() -> str:
+    """AppArmor confinement label of THIS process, ``""`` when unreadable.
+
+    Reads the kernel's own answer, e.g. ``unconfined`` or
+    ``kirocrew-userns (enforce)``. The per-LSM path is tried first; the bare
+    ``attr/current`` covers older kernels (where it may also carry an SELinux
+    context — which is fine, since callers only compare against a profile name).
+    """
+    for attr in ("/proc/self/attr/apparmor/current", "/proc/self/attr/current"):
+        try:
+            raw = Path(attr).read_text(encoding="utf-8")
+        except OSError:
+            continue
+        return raw.replace("\x00", "").strip()
+    return ""
+
+
+def _service_unit_applies_profile(unit_path: Path, profile_name: str) -> bool:
+    """True when the installed systemd unit transitions the service into the profile.
+
+    The unit is rendered with ``AppArmorProfile=-<name>`` (the leading dash keeps
+    the unit startable while the profile is temporarily unloaded); the dashless
+    form is accepted too so a hand-edited unit still counts.
+    """
+    try:
+        text = unit_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("AppArmorProfile="):
+            value = stripped.split("=", 1)[1].strip().lstrip("-")
+            if value == profile_name:
+                return True
+    return False
+
+
+def _doctor_sandbox_apparmor(reason: str, issues: list[str]) -> None:
+    """Verdict for the Ubuntu AppArmor userns-restriction denial (EPERM on NEWNS).
+
+    Three honest verdicts, decided from real signals rather than the happy path:
+
+    * profile absent → broken, with the install command;
+    * profile installed but nothing applies it, or the probe failed even though
+      THIS process is confined by the profile → broken, with the repair command;
+    * profile installed, the service unit applies it, and this process is
+      unconfined → the probe's failure says nothing about the service, so the
+      verdict is "cannot be verified from this shell" plus how to verify — NOT
+      a claim that the sandbox works, and NOT counted as an issue.
+    """
+    if not apparmor.PROFILE_PATH.is_file():
+        print(f"  backend:     ❌ none — {reason}")
+        _print_wrapped(
+            f"This host restricts unprivileged user namespaces and the "
+            f"{apparmor.PROFILE_NAME} AppArmor profile is not installed, so no context "
+            f"on this host can build the sandbox. Run `kirocrew service install` to "
+            f"install the profile and confine the gateway service with it."
+        )
+        issues.append("sandbox: AppArmor profile not installed")
+        return
+
+    confinement = _process_apparmor_confinement()
+    if confinement and confinement.split(" ")[0] == apparmor.PROFILE_NAME:
+        # The one context that SHOULD be able to build the sandbox refused to:
+        # this is a genuine fault, not a vantage-point artifact.
+        print(f"  backend:     ❌ broken — {reason}")
+        _print_wrapped(
+            f"This process already runs confined by {apparmor.PROFILE_NAME}, which "
+            f"should grant user namespaces, yet the probe still failed. Re-run "
+            f"`kirocrew service install` to re-render and reload the profile."
+        )
+        issues.append("sandbox: probe failed under the AppArmor profile")
+        return
+
+    if not _service_unit_applies_profile(service_linux.UNIT_PATH, apparmor.PROFILE_NAME):
+        print(f"  backend:     ❌ none — {reason}")
+        _print_wrapped(
+            f"The {apparmor.PROFILE_NAME} AppArmor profile is installed, but no systemd "
+            f"unit applies it, so nothing on this host runs confined by it. Run "
+            f"`kirocrew service install` to (re)install the gateway service with the "
+            f"profile applied."
+        )
+        issues.append("sandbox: AppArmor profile installed but not applied")
+        return
+
+    # Unverifiable from here — deliberately NOT an issue, and deliberately NOT a
+    # success claim either.
+    print("  backend:     ⏭  cannot be verified from this shell")
+    _print_wrapped(
+        f"The {apparmor.PROFILE_NAME} AppArmor profile is installed and the gateway "
+        f"service unit is configured to run under it, but this shell is unconfined "
+        f"and aa_change_onexec() into a named profile is not permitted for an "
+        f"unconfined user — so this probe cannot succeed here no matter how healthy "
+        f"the service's sandbox is. To verify the sandbox in the confined context "
+        f"the service uses, run:"
+    )
+    # The interpreter path is quoted for the shell: the recipe is meant to be
+    # pasted, so an install path containing spaces or shell metacharacters must
+    # arrive as one argument, not execute.
+    quoted_python = shlex.quote(sys.executable)
+    print(f"{_INDENT}  sudo systemd-run --pipe --unit=kirocrew-sandbox-test \\")
+    print(f"{_INDENT}    --property=AppArmorProfile=-{apparmor.PROFILE_NAME} \\")
+    print(f"{_INDENT}    --uid=$(id -u) --gid=$(id -g) \\")
+    print(f'{_INDENT}    {quoted_python} -c "import kiro_crew.sandbox as sb; \\')
+    print(f'{_INDENT}      sb.reset_backend(); print(sb.detect_backend())"')
+    _print_wrapped("A healthy sandbox prints: namespace")
+
+
+def _doctor_sandbox(issues: list[str]) -> None:
+    """Render the ``Sandbox`` section — an honest verdict about the agent sandbox.
+
+    The hard rule: report only what THIS process can observe.
+    :func:`sandbox.detect_backend` answers for the probing process, not for the
+    gateway service — on a host that restricts unprivileged user namespaces the
+    profile is applied by systemd to the SERVICE, so from an interactive shell
+    the probe fails with EPERM no matter how healthy the service's sandbox is.
+    Reporting that failure as the sandbox being broken is a false negative; the
+    fix must not swing to the false positive of claiming the sandbox works when
+    all that is known is that it cannot be checked from here.
+    """
+    print("\nSandbox")
+    try:
+        # ONE probe decision: ``unavailable_kind()`` probes internally and
+        # returns "" for a working backend. Probing twice (a detect_backend
+        # read followed by a classifying call) would let a transient failure
+        # heal between the two reads and report a now-working backend as
+        # broken.
+        kind = sandbox.unavailable_kind()
+    except Exception as exc:  # noqa: BLE001 — doctor must survive a broken probe
+        print(f"  backend:     ⚠️  could not probe ({exc})")
+        return
+    if not kind:
+        # The probe just succeeded, so this read serves the cached positive
+        # result rather than probing again.
+        print(f"  backend:     ✅ {sandbox.detect_backend()}")
+        return
+
+    reason = sandbox.unavailable_reason() or "no probe detail recorded"
+    if kind == "transient":
+        print("  backend:     ⚠️  probe failed transiently — not cached; the next spawn re-probes")
+        print(f"{_INDENT}({reason})")
+        return
+    if kind == "foreign_sandbox":
+        print("  backend:     ⚠️  an outer sandbox already confines this process")
+        _print_wrapped(
+            "Kiro Crew cannot nest its own sandbox inside it. Launch the gateway "
+            "outside that sandbox to hand isolation back to Kiro Crew's own profile."
+        )
+        return
+
+    remedy = sandbox.unavailable_remedy()
+    if remedy == sandbox.REMEDY_APPARMOR_USERNS:
+        _doctor_sandbox_apparmor(reason, issues)
+        return
+    if sys.platform.startswith("linux"):
+        # A permanent, named kernel refusal (user.max_user_namespaces=0, a kernel
+        # without CONFIG_USER_NS, ...) — genuinely broken, with the mechanism's
+        # own guidance when the probe identified one.
+        print(f"  backend:     ❌ none — {reason}")
+        guidance = sandbox.remedy_guidance(remedy)
+        if guidance:
+            _print_wrapped(guidance)
+        issues.append("sandbox backend")
+        return
+    # Platforms with no OS-level backend to offer (Windows; macOS builds without
+    # sandbox-exec) — a fact about the platform, not a fault of this install.
+    print("  backend:     ⏭  no OS-level sandbox backend on this platform")
 
 
 def _linger_enabled(user: str) -> bool | None:
@@ -734,6 +916,11 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
 
     # ── Pods (systemd --user session bus) ──
     _doctor_pod_session_bus(issues)
+
+    # ── Sandbox ──
+    # Ahead of MCP Tools: the probes below spawn through the sandbox chokepoint,
+    # so this verdict is the context for any probe failure they report.
+    _doctor_sandbox(issues)
 
     # ── MCP Tools ──
     print("\nMCP Tools")

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -359,6 +359,30 @@ def unavailable_remedy() -> str:
     return _last_unshare_failure[2]
 
 
+def unavailable_reason() -> str:
+    """Public: technical reason for the most recent sandbox probe failure.
+
+    Names the failing step verbatim (e.g. ``"unshare(CLONE_NEWNS) failed with
+    errno 1 (EPERM)"``), so a diagnostic surface can show the kernel's answer
+    rather than a paraphrase. ``""`` when the last probe succeeded or none has
+    run. Sibling accessor to :func:`unavailable_remedy`, reading the same
+    recorded failure so the two can never describe different probes.
+    """
+    if _last_unshare_failure is None:
+        return ""
+    return _last_unshare_failure[1]
+
+
+def remedy_guidance(remedy: str) -> str:
+    """Public: mechanism-specific guidance for a ``REMEDY_*`` token (``""`` if none).
+
+    The stable cross-module entry point for :data:`_LINUX_REMEDY_GUIDANCE`, so
+    diagnostic surfaces (doctor, dashboard) render the one shared remedy text
+    for a mechanism instead of maintaining a drifting copy.
+    """
+    return _linux_remedy_guidance(remedy)
+
+
 def _close_probe_fds(*fds: int) -> None:
     """Close probe pipe fds, tolerating an already-closed one. Never raises.
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -118,6 +118,17 @@ class TestDoctor:
         monkeypatch.setattr(_doc, "_load_llama_class", lambda: object)
         monkeypatch.setattr(_doc, "model_file_present", lambda path=None: False)
 
+    @pytest.fixture(autouse=True)
+    def _hermetic_sandbox(self, monkeypatch):
+        """Pin the Sandbox section host-independently: a CI runner can restrict
+        user namespaces with no profile installed, which is a genuine issue on
+        that HOST (doctor exits 1 for it) but not the subject of these tests."""
+        import kiro_crew.cli_doctor as _doc
+
+        monkeypatch.setattr(
+            _doc.sandbox, "detect_backend", lambda config_mode="auto": "namespace"
+        )
+
     def test_doctor_with_kiro(self, tmp_path):
         agent_file = tmp_path / "kirocrew.json"
         # A minimally healthy agent config so doctor walks the whole MCP

--- a/test/test_doctor_sandbox_verdict.py
+++ b/test/test_doctor_sandbox_verdict.py
@@ -1,0 +1,229 @@
+"""`kirocrew doctor` Sandbox section — honest verdicts from an unconfined shell.
+
+The probe (`sandbox.detect_backend`) answers for the PROBING process, not for
+the gateway service. On a host that restricts unprivileged user namespaces the
+kirocrew-userns AppArmor profile is applied by systemd to the service, and
+``aa_change_onexec()`` into a named profile is not permitted for an ordinary
+unconfined user — so from an interactive shell the probe fails with EPERM no
+matter how healthy the service's sandbox is.
+
+These tests pin the line the fix must hold: stop the false negative WITHOUT
+starting a false positive.
+
+* profile installed + service unit applies it + shell unconfined →
+  "cannot be verified from this shell" (never "works"), and NOT an issue;
+* the probe failing while THIS process is confined by the profile → broken;
+* profile absent → broken, naming the install command.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import cli_doctor, sandbox
+from kiro_crew.service import apparmor
+from kiro_crew.service import linux as service_linux
+
+
+def _arm_apparmor_denial(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the probe signals read as the Ubuntu userns-restriction denial."""
+    monkeypatch.setattr(sandbox, "detect_backend", lambda config_mode="auto": "none")
+    monkeypatch.setattr(sandbox, "unavailable_kind", lambda: "no_backend")
+    monkeypatch.setattr(
+        sandbox,
+        "unavailable_reason",
+        lambda: "unshare(CLONE_NEWNS) failed with errno 1 (EPERM)",
+    )
+    monkeypatch.setattr(
+        sandbox, "unavailable_remedy", lambda: sandbox.REMEDY_APPARMOR_USERNS
+    )
+
+
+def _install_profile(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    profile = tmp_path / apparmor.PROFILE_NAME
+    profile.write_text("profile kirocrew-userns flags=(unconfined) {}\n", encoding="utf-8")
+    monkeypatch.setattr(apparmor, "PROFILE_PATH", profile)
+
+
+def _install_unit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, applies_profile: bool
+) -> None:
+    unit = tmp_path / "kirocrew.service"
+    directive = (
+        f"AppArmorProfile=-{apparmor.PROFILE_NAME}\n" if applies_profile else ""
+    )
+    unit.write_text(
+        f"[Service]\n{directive}ExecStart=/usr/bin/true\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(service_linux, "UNIT_PATH", unit)
+
+
+class TestUnverifiableFromShell:
+    """Profile installed, service confined, shell unconfined → no false negative."""
+
+    def test_reports_unverifiable_not_broken_and_not_an_issue(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+    ) -> None:
+        _arm_apparmor_denial(monkeypatch)
+        _install_profile(monkeypatch, tmp_path)
+        _install_unit(monkeypatch, tmp_path, applies_profile=True)
+        monkeypatch.setattr(cli_doctor, "_process_apparmor_confinement", lambda: "unconfined")
+
+        issues: list[str] = []
+        cli_doctor._doctor_sandbox(issues)
+
+        out = capsys.readouterr().out
+        assert "cannot be verified from this shell" in out
+        assert "❌" not in out
+        assert issues == []
+
+    def test_does_not_claim_the_sandbox_works(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+    ) -> None:
+        # The no-false-positive half of the line: unverifiable must never render
+        # as the success verdict a working probe gets.
+        _arm_apparmor_denial(monkeypatch)
+        _install_profile(monkeypatch, tmp_path)
+        _install_unit(monkeypatch, tmp_path, applies_profile=True)
+        monkeypatch.setattr(cli_doctor, "_process_apparmor_confinement", lambda: "unconfined")
+
+        cli_doctor._doctor_sandbox([])
+
+        out = capsys.readouterr().out
+        assert "✅" not in out
+
+    def test_names_the_systemd_run_verification_recipe(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+    ) -> None:
+        _arm_apparmor_denial(monkeypatch)
+        _install_profile(monkeypatch, tmp_path)
+        _install_unit(monkeypatch, tmp_path, applies_profile=True)
+        monkeypatch.setattr(cli_doctor, "_process_apparmor_confinement", lambda: "unconfined")
+
+        cli_doctor._doctor_sandbox([])
+
+        out = capsys.readouterr().out
+        assert "systemd-run" in out
+        assert f"AppArmorProfile=-{apparmor.PROFILE_NAME}" in out
+
+
+class TestGenuinelyBroken:
+    """A real fault must still read as broken — no swing to false positives."""
+
+    def test_probe_failure_while_confined_by_the_profile_is_broken(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+    ) -> None:
+        # The confined context is the one place the probe SHOULD succeed; a
+        # failure there is a verdict about the sandbox, not the vantage point.
+        _arm_apparmor_denial(monkeypatch)
+        _install_profile(monkeypatch, tmp_path)
+        _install_unit(monkeypatch, tmp_path, applies_profile=True)
+        monkeypatch.setattr(
+            cli_doctor,
+            "_process_apparmor_confinement",
+            lambda: f"{apparmor.PROFILE_NAME} (enforce)",
+        )
+
+        issues: list[str] = []
+        cli_doctor._doctor_sandbox(issues)
+
+        out = capsys.readouterr().out
+        assert "❌" in out
+        assert "cannot be verified" not in out
+        assert issues, "a genuine fault must be counted as an issue"
+
+    def test_profile_installed_but_nothing_applies_it_is_broken(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+    ) -> None:
+        # An inert profile is not a confined service: claiming "unverifiable"
+        # here would be the false positive the fix must not introduce.
+        _arm_apparmor_denial(monkeypatch)
+        _install_profile(monkeypatch, tmp_path)
+        _install_unit(monkeypatch, tmp_path, applies_profile=False)
+        monkeypatch.setattr(cli_doctor, "_process_apparmor_confinement", lambda: "unconfined")
+
+        issues: list[str] = []
+        cli_doctor._doctor_sandbox(issues)
+
+        out = capsys.readouterr().out
+        assert "❌" in out
+        assert "cannot be verified from this shell" not in out
+        assert issues
+
+
+class TestProfileAbsent:
+    """A host with no profile installed at all must still be told so."""
+
+    def test_reports_broken_and_names_the_install_command(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+    ) -> None:
+        _arm_apparmor_denial(monkeypatch)
+        monkeypatch.setattr(apparmor, "PROFILE_PATH", tmp_path / "absent-profile")
+        monkeypatch.setattr(cli_doctor, "_process_apparmor_confinement", lambda: "unconfined")
+
+        issues: list[str] = []
+        cli_doctor._doctor_sandbox(issues)
+
+        out = capsys.readouterr().out
+        assert "❌" in out
+        assert "not installed" in out
+        assert "kirocrew service install" in out
+        assert "cannot be verified from this shell" not in out
+        assert issues
+
+
+class TestNonFaultStates:
+    """States that are not a fault of this install stay out of the issue list."""
+
+    def test_working_backend_is_a_plain_success(
+        self, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        monkeypatch.setattr(sandbox, "detect_backend", lambda config_mode="auto": "namespace")
+
+        issues: list[str] = []
+        cli_doctor._doctor_sandbox(issues)
+
+        out = capsys.readouterr().out
+        assert "✅ namespace" in out
+        assert issues == []
+
+    def test_transient_failure_is_not_an_issue(
+        self, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        monkeypatch.setattr(sandbox, "detect_backend", lambda config_mode="auto": "none")
+        monkeypatch.setattr(sandbox, "unavailable_kind", lambda: "transient")
+        monkeypatch.setattr(sandbox, "unavailable_reason", lambda: "fork failed with EAGAIN")
+
+        issues: list[str] = []
+        cli_doctor._doctor_sandbox(issues)
+
+        out = capsys.readouterr().out
+        assert "transiently" in out
+        assert "❌" not in out
+        assert issues == []
+
+
+class TestUnitDirectiveParsing:
+    """`_service_unit_applies_profile` reads the real directive forms."""
+
+    def test_dashed_directive_matches(self, tmp_path: Path) -> None:
+        unit = tmp_path / "u.service"
+        unit.write_text(f"AppArmorProfile=-{apparmor.PROFILE_NAME}\n", encoding="utf-8")
+        assert cli_doctor._service_unit_applies_profile(unit, apparmor.PROFILE_NAME)
+
+    def test_dashless_directive_matches(self, tmp_path: Path) -> None:
+        unit = tmp_path / "u.service"
+        unit.write_text(f"AppArmorProfile={apparmor.PROFILE_NAME}\n", encoding="utf-8")
+        assert cli_doctor._service_unit_applies_profile(unit, apparmor.PROFILE_NAME)
+
+    def test_other_profile_does_not_match(self, tmp_path: Path) -> None:
+        unit = tmp_path / "u.service"
+        unit.write_text("AppArmorProfile=-something-else\n", encoding="utf-8")
+        assert not cli_doctor._service_unit_applies_profile(unit, apparmor.PROFILE_NAME)
+
+    def test_missing_unit_does_not_match(self, tmp_path: Path) -> None:
+        assert not cli_doctor._service_unit_applies_profile(
+            tmp_path / "missing.service", apparmor.PROFILE_NAME
+        )

--- a/test/test_sandbox_remedy.py
+++ b/test/test_sandbox_remedy.py
@@ -166,6 +166,29 @@ class TestRemedyRecording:
         sb.reset_backend()
         assert sb.unavailable_remedy() == ""
 
+    def test_unavailable_reason_reads_the_same_recorded_failure(self) -> None:
+        # Sibling accessor: reason and remedy come from ONE recorded tuple, so a
+        # diagnostic surface can never pair failure A's text with failure B's fix.
+        sb._record_probe_failure(
+            False,
+            "unshare(CLONE_NEWNS) failed with errno 1 (EPERM)",
+            sb.REMEDY_APPARMOR_USERNS,
+        )
+        assert sb.unavailable_reason() == "unshare(CLONE_NEWNS) failed with errno 1 (EPERM)"
+
+    def test_unavailable_reason_is_empty_when_the_last_probe_succeeded(self) -> None:
+        sb._record_probe_failure(False, "x", sb.REMEDY_APPARMOR_USERNS)
+        sb._last_unshare_failure = None
+        assert sb.unavailable_reason() == ""
+
+    def test_remedy_guidance_is_the_shared_guidance_text(self) -> None:
+        # The public accessor must serve the one shared prose table, so doctor
+        # and the dashboard can never drift from the mechanism's own guidance.
+        assert sb.remedy_guidance(sb.REMEDY_APPARMOR_USERNS) == sb._linux_remedy_guidance(
+            sb.REMEDY_APPARMOR_USERNS
+        )
+        assert sb.remedy_guidance("not-a-token") == ""
+
     def test_a_deferred_on_loop_probe_reports_no_remedy(self) -> None:
         """The synthetic on-loop transient describes no host mechanism.
 


### PR DESCRIPTION
## Problem

`kirocrew doctor` reported the sandbox as broken on hosts where the service's sandbox is perfectly healthy. The probe (`sandbox.detect_backend()`) answers for the **probing process**, not for the gateway service: on a host that restricts unprivileged user namespaces (Ubuntu >= 23.10), the `kirocrew-userns` AppArmor profile is applied by systemd to the **service**, and `aa_change_onexec()` into a named profile is not permitted for an ordinary unconfined user. From an interactive shell the probe therefore fails with `unshare(CLONE_NEWNS) EPERM` no matter how healthy the service's sandbox is — and doctor reported the shell's answer as if it were the service's. Prior fixes in this misreporting family: #1139, #1137.

## Fix

Add a **Sandbox** section to `kirocrew doctor` that reports only what the probing process can actually observe, deciding among the verdicts from real signals — is the profile installed (`/etc/apparmor.d/kirocrew-userns`), is THIS process confined (`/proc/self/attr/apparmor/current`), does the installed systemd unit apply the profile (`AppArmorProfile=` directive) — never by assuming the happy path:

| Signals | Verdict |
|---|---|
| backend probe succeeds | ✅ backend name |
| profile installed + unit applies it + this shell unconfined | ⏭ **cannot be verified from this shell** + the `systemd-run --property=AppArmorProfile=-kirocrew-userns` verification recipe (never a success claim; not counted as an issue) |
| probe fails while THIS process is confined by the profile | ❌ broken (issue) |
| profile installed but no unit applies it | ❌ broken — inert profile (issue) |
| profile absent | ❌ broken — names `kirocrew service install` (issue) |
| other permanent Linux refusal | ❌ + mechanism guidance from the shared remedy table (issue) |
| transient probe failure | ⚠️ not cached, re-probes (not an issue) |
| non-Linux host with no backend | ⏭ platform fact, not a fault |

The line held strictly: the false negative is gone **without** introducing a false positive — the unverifiable verdict explicitly says the sandbox cannot be checked from here and how to check it, and every genuinely broken state still reads as broken.

`sandbox.py` gains two public accessors (`unavailable_reason()`, `remedy_guidance()`) so doctor reads the recorded probe failure and the shared mechanism guidance through stable entry points instead of private state. This also makes `docs/guides/install.md`'s existing claim ("`kirocrew doctor` reports the same verdict") true.

## Tests

- `test/test_doctor_sandbox_verdict.py` (new): all three spec verdicts — unverifiable-from-shell (not broken, not an issue, no success claim, names the systemd-run recipe), genuinely broken (confined-yet-failing, and inert-profile), profile absent (names the install command) — plus working-backend, transient, and unit-directive parsing cases (12 tests).
- `test/test_sandbox_remedy.py`: accessor tests for `unavailable_reason()` / `remedy_guidance()` (3 tests).
- Local gates green: isort, flake8, mypy (877 files), targeted pytest 113 passed. Full-suite run on this host shows only pre-existing host artifacts (also failing on pristine `main`).

Closes #2652
