### PR TITLE
docs(install): scope kirocrew.env to v0.2.0+ units and teach the systemd drop-in (#2658)

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,10 @@ KIROCREW_PORT=5477 kirocrew service install
 ```
 
 To change it later without reinstalling, edit `/etc/kirocrew/kirocrew.env`
-(created by `service install`) and run `sudo systemctl restart kirocrew`.
+(created by `service install`) and run `sudo systemctl restart kirocrew`. Units
+installed by releases before v0.2.0 lack the `EnvironmentFile=` directive that
+reads this file — re-run `kirocrew service install` or use a systemd drop-in;
+see [the install guide](docs/guides/install.md#setting-the-service-port).
 
 The desktop app can use this local Gateway or connect to a remote one. For an
 always-on VPS, home server, or cloud VM in your account, follow the

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -408,6 +408,47 @@ example by a local crew you also run on this host — there is one
 `kirocrew.service` unit, so re-running `service install` updates it in place
 rather than creating a second service).
 
+**The `EnvironmentFile=` directive only exists in units written by v0.2.0 or
+later.** Upgrading the package never rewrites an already-installed unit, so a
+unit installed by an older release (v0.1.3 and earlier) silently ignores
+`/etc/kirocrew/kirocrew.env` — editing it changes nothing. Check which kind you
+have:
+
+```bash
+grep EnvironmentFile /etc/systemd/system/kirocrew.service
+```
+
+No output means the directive is missing. Either re-run `kirocrew service
+install` (it rewrites the unit in place, keeping the same service), or set
+variables with a [systemd drop-in](#setting-other-environment-variables-systemd-drop-in),
+which works on any unit version.
+
+### Setting other environment variables (systemd drop-in)
+
+For variables the seeded overrides file does not cover — proxy settings are the
+common case — use a systemd drop-in. Drop-ins are systemd's own override
+mechanism: they apply to the unit no matter which release wrote it, and they
+survive reinstalls, `service install` re-runs, and even
+`kirocrew service uninstall` (which removes the unit but never touches
+`/etc/systemd/system/kirocrew.service.d/`).
+
+```bash
+sudo mkdir -p /etc/systemd/system/kirocrew.service.d
+sudo tee /etc/systemd/system/kirocrew.service.d/proxy.conf > /dev/null <<'EOF'
+[Service]
+Environment="HTTPS_PROXY=http://proxy.example.com:3128"
+Environment="HTTP_PROXY=http://proxy.example.com:3128"
+Environment="NO_PROXY=localhost,127.0.0.1"
+EOF
+sudo systemctl daemon-reload
+sudo systemctl restart kirocrew
+```
+
+A new or edited drop-in is not picked up until `systemctl daemon-reload` runs —
+restarting alone is not enough. Verify what the unit resolved to with
+`systemctl cat kirocrew` (drop-ins are printed below the unit) or
+`systemctl show kirocrew --property=Environment`.
+
 For remote hosts, see [remote-and-mobile.md](remote-and-mobile.md).
 
 ## Linux: the agent sandbox and unprivileged user namespaces
@@ -581,7 +622,7 @@ Always start with `kirocrew doctor`.
 
 ### `AcpTimeoutError: ACP prompt timed out`
 
-The `kiro-cli` backend did not answer in time. Four common causes:
+The `kiro-cli` backend did not answer in time. Five common causes:
 
 1. **`kiro-cli` is not installed.** The gateway raises
    `kiro-cli not found in PATH`. Install it, or use the dashboard's
@@ -598,6 +639,18 @@ The `kiro-cli` backend did not answer in time. Four common causes:
    seconds is treated as finished, and a dispatched tool that returns nothing at
    all for 10 minutes is treated as a dead stall and the agent is killed to
    recover the slot.
+5. **The host needs a proxy and the service does not have one.** On a
+   corporate network, `kiro-cli` must reach its backend through your proxy. A
+   systemd service inherits none of your shell's `HTTPS_PROXY`/`HTTP_PROXY`
+   exports, so a gateway that works when run from your terminal can still time
+   out as a service. Set the proxy variables on the unit with a
+   [systemd drop-in](#setting-other-environment-variables-systemd-drop-in),
+   then `sudo systemctl daemon-reload && sudo systemctl restart kirocrew`.
+   Agent sessions inherit the service environment, so this fixes them. One
+   known gap: the first-run setup gate's login probe currently filters proxy
+   variables out even when the unit carries them, so it can stay stuck on
+   "Sign in to Kiro CLI" on a proxied host — that is
+   [issue #2648](https://github.com/kirodotdev/KiroCrew/issues/2648).
 
 ### Memory or knowledge search returns nothing
 


### PR DESCRIPTION
## What

Fixes the `install.md` claim that `/etc/kirocrew/kirocrew.env` "is read by the unit via `EnvironmentFile=`" — true only for units written by v0.2.0+ (#2097 added the directive), and a package upgrade never rewrites an installed unit, so on a v0.1.3 unit (the reporter's case) editing that file silently does nothing.

- **`docs/guides/install.md` (Setting the service port):** scope the `EnvironmentFile=` claim to units written by v0.2.0 or later, and give a one-line `grep` self-check plus the two remedies (re-run `kirocrew service install`, or use a drop-in).
- **New section — Setting other environment variables (systemd drop-in):** concrete `proxy.conf` example, `systemctl daemon-reload` + restart (a drop-in is not picked up without the reload), and verification via `systemctl cat` / `systemctl show`. Drop-ins work on any unit version and survive reinstalls and `service uninstall` (verified against `uninstall()` in `service/linux.py`, which removes only the unit and the untouched env-file seed).
- **`AcpTimeoutError` troubleshooting:** new cause 5 — a proxied host whose service has no proxy variables. Points at the drop-in section, and is honest about the known gap: the first-run setup gate's login probe filters proxy variables out of its env (`_PROBE_ENV_KEYS` in `kiro_prerequisite.py`), which is open as #2648.
- **`README.md`:** the same claim qualified with a pointer to the guide.

Docs-only; no behavioural change.

## Why not add `EnvironmentFile=` to the unit instead

Current main already emits it (`service/linux.py` since #2097). The defect lives only in the docs' unqualified claim as read by users on older units; teaching the drop-in covers every unit version without touching install behaviour.

## Testing

- `python3 scripts/docs_lint.py --test && ./scripts/docs-lint.sh` — pass (validates the new internal anchors)
- `scripts/check_brand_name.py` (diff-scoped) — pass
- `./scripts/scrub-lint.sh --no-history` — pass
- `isort` / `flake8` / `mypy` — pass (unchanged code)
- Full `pytest`: 41425 passed; the 99 fails + 2 errors are host-environmental on this sandboxed runner (SandboxUnavailableError with `KIROCREW_SANDBOX_ACTIVE` set, uid-65534-mapped fs breaking root-ownership assertions, AF_UNIX path length, no `gh` on probe PATH) and reproduce on unmodified main; none touch docs.

Facts verified against the repo/API: #2097 patch adds the directive; `v0.1.3` tree has zero `EnvironmentFile` matches; `39a3db4` is an ancestor of `v0.2.0`; `uninstall()` never touches `/etc/systemd/system/kirocrew.service.d/`.

## Review

`spawn_run` was unavailable this session (kirocrew-core tools absent, #2502 symptom), so a contract-driven self-review ran against both reviewer charters. One finding, fixed before push: cause 5 originally implied the drop-in also fixes the setup gate, but the gate's probe strips proxy vars (#2648) — the text now states that gap explicitly. No AUTOSDE rule covers markdown files.

Closes #2658
