### PR TITLE
fix(chat): count the frozen prefix's durable rows for absolute cursors

### DIFF
--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -60,7 +60,7 @@ import weakref
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.dashboard.channel_folders import lookup_channel_folder
-from kiro_crew.dashboard.state import _normalize_slot_key
+from kiro_crew.dashboard.state import _normalize_slot_key, durable_row_count
 from kiro_crew.history import carry_provenance
 from kiro_crew.messaging.link import channel_namespace_of, is_channel_session_key
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -372,7 +372,9 @@ def _rebuild_window(slot: "_ChatSlot", messages: list[dict[str, Any]]) -> None:
     """
     slot.messages.clear()
     slot._pending.clear()
-    slot._disk_older_count = max(0, len(messages) - _RESTORE_WINDOW)
+    older = messages[:-_RESTORE_WINDOW] if len(messages) > _RESTORE_WINDOW else []
+    slot._disk_older_count = len(older)
+    slot._disk_older_durable_count = durable_row_count(older)
     for msg in messages[-_RESTORE_WINDOW:]:
         role = msg.get("role", "assistant")
         cls = msg.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -71,6 +71,7 @@ from kiro_crew.dashboard.state import (
     _ChatSlot,
     _mark_permission_resolved,
     _normalize_slot_key,
+    durable_row_count,
     parse_cls_meta,
 )
 from kiro_crew.dashboard.turn_dispatch import spawn_guarded_turn
@@ -3158,8 +3159,11 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
     disk_total = len(all_messages)
     max_resume = 500
     messages = all_messages[-max_resume:] if disk_total > max_resume else all_messages
-    # Stable count of messages older than what we loaded into memory
-    slot._disk_older_count = max(0, disk_total - len(messages))
+    # Stable count of messages older than what we loaded into memory, plus the
+    # durable-only count absolute cursors index from.
+    older_rows = all_messages[: disk_total - len(messages)]
+    slot._disk_older_count = len(older_rows)
+    slot._disk_older_durable_count = durable_row_count(older_rows)
     for m in messages:
         role = m.get("role", "assistant")
         cls = "msg msg-u" if role == "user" else "msg msg-a"

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -24,7 +24,13 @@ from kiro_crew.dashboard.chat_utils import (
     slot_history_key,
     slot_transcript_key,
 )
-from kiro_crew.dashboard.state import DashboardState, _ChatSlot, _normalize_slot_key
+from kiro_crew.dashboard.state import (
+    TRANSIENT_ROLES,
+    DashboardState,
+    _ChatSlot,
+    _normalize_slot_key,
+    durable_row_count,
+)
 from kiro_crew.effort import EFFORT_LEVELS, EFFORT_VALUES
 from kiro_crew.history import (
     SLOT_OWNED_META_KEYS,
@@ -644,8 +650,11 @@ def _rehydrate_slot_from_history(
             )
         # Only the recent window is loaded into memory; older on-disk lines become
         # the FROZEN PREFIX that saves never rewrite. _disk_older_count must
-        # therefore count those older lines so the save model preserves them.
-        slot._disk_older_count = max(0, len(messages) - 500)
+        # therefore count those older lines so the save model preserves them, and
+        # the durable counter alongside it is what absolute cursors index from.
+        older = messages[:-500] if len(messages) > 500 else []
+        slot._disk_older_count = len(older)
+        slot._disk_older_durable_count = durable_row_count(older)
         for m in messages[-500:]:
             role = m.get("role", "assistant")
             cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
@@ -967,7 +976,9 @@ def _restore_recent_sessions_steps(
             )
         slot._tab_id = tab_id
         messages = state.conversation_log.read_messages_chained(key)
-        slot._disk_older_count = max(0, len(messages) - 500)
+        older = messages[:-500] if len(messages) > 500 else []
+        slot._disk_older_count = len(older)
+        slot._disk_older_durable_count = durable_row_count(older)
         for m in messages[-500:]:
             role = m.get("role", "assistant")
             cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
@@ -1143,12 +1154,6 @@ def _build_message_entry(m: dict) -> dict | None:
     if isinstance(m.get("meta"), dict):
         entry["meta"] = _redact_meta_for_role(role, m["meta"])
     return entry
-
-
-# Transient/streaming roles that are never persisted (mirrors
-# ``_build_message_entry``). A window-region disk line carrying one of these is
-# not a real message and is never treated as a cross-process append to preserve.
-_TRANSIENT_ROLES = frozenset({"chunk", "done", "streaming", "queued", "permission"})
 
 
 def _foreign_tail_ts(foreign_lines: list[str]) -> str | None:
@@ -1396,7 +1401,7 @@ def _frozen_prefix_and_foreign_appends(
         if not isinstance(entry, dict) or entry.get("_type") == "metadata":
             continue
         role = entry.get("role")
-        if role is None or role in _TRANSIENT_ROLES:
+        if role is None or role in TRANSIENT_ROLES:
             continue
         norm = ln if ln.endswith("\n") else ln + "\n"
         disk_msgs.append((norm, entry.get("ts"), role, entry.get("content", "")))

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -462,11 +462,39 @@ def stuck_turn_notice(parked_secs: float) -> str:
 
 _MAX_SLOT_MESSAGES = 10000  # Keep all messages — virtual scrolling handles performance
 
+#: Transient/streaming roles that are not real messages. They ARE written to
+#: disk — the reconciliation read skips them, which is only necessary because
+#: they are there — so they occupy on-disk lines while contributing no durable
+#: message. Owned here rather than in ``chat_persistence`` because the live trim
+#: below needs them and persistence already imports this module; the reverse
+#: import would be a cycle.
+TRANSIENT_ROLES = frozenset({"chunk", "done", "streaming", "queued", "permission"})
+
 #: Roles that exist only on the wire: appended so a reader/flush can see them,
-#: never broadcast as a `chat_message` and never persisted (the mirror of
-#: ``chat_persistence._TRANSIENT_ROLES`` minus the rows that ARE broadcast).
+#: never broadcast as a `chat_message` and never persisted (``TRANSIENT_ROLES``
+#: minus the rows that ARE broadcast).
 #: They get no ``meta.mid`` — see ``_ChatSlot.append``.
 _WIRE_ONLY_ROLES = frozenset({"chunk", "done", "streaming"})
+
+
+def durable_row_count(rows: list[dict]) -> int:
+    """How many of *rows* are durable messages rather than transient artifacts.
+
+    ``_disk_older_count`` counts every on-disk line folded into the frozen
+    prefix, transient ones included, because it exists to protect the prefix the
+    save model must not rewrite — for that job the raw line count is correct. It
+    is the wrong base for an ABSOLUTE MESSAGE POSITION: a cursor of
+    ``_disk_older_count + <index over durable rows>`` gains one place of skew per
+    trimmed transient row, so a consumer paging from a position it was handed
+    earlier is served a durable message it already has.
+
+    One definition, so the two counters cannot disagree about what durable means.
+    Defaults a missing role to ``assistant``, matching ``_build_message_entry``,
+    rather than dropping the row.
+    """
+    return sum(1 for r in rows if r.get("role", "assistant") not in TRANSIENT_ROLES)
+
+
 _MAX_SOURCE_LINKS_PER_SLOT = 64
 # How many source links each slot payload actually serializes (the sidebar
 # renders at most this many chips). Shared with the periodic check-status
@@ -923,6 +951,7 @@ class _ChatSlot:
         "_tab_id",
         "_channel_window_mtime",
         "_disk_older_count",
+        "_disk_older_durable_count",
         "_disk_window_len",
         "_disk_tail_ts",
         "_frozen_prefix_cache",
@@ -1198,6 +1227,13 @@ class _ChatSlot:
         self._disk_older_count: int = (
             0  # count of disk messages OLDER than in-memory window (stable, set at restore/resume)
         )
+        # The same frozen prefix counted as DURABLE rows only. _disk_older_count
+        # includes transient rows (chunk/done/streaming/queued/permission), which
+        # are written to disk but skipped on read-back — so it is the right base
+        # for the save model and the wrong one for an absolute message position.
+        # A cursor built on it shifts by one for every trimmed transient row and
+        # re-serves a durable message the consumer already has.
+        self._disk_older_durable_count: int = 0
         # Count of in-memory window messages the LAST save persisted to disk
         # (the on-disk window region). Trimming may only fold a leading window
         # message into the frozen prefix once it is known to be on disk; this
@@ -1513,6 +1549,9 @@ class _ChatSlot:
         # Trim old messages to bound memory usage
         if len(self.messages) > _MAX_SLOT_MESSAGES:
             excess = len(self.messages) - _MAX_SLOT_MESSAGES
+            # Captured before the delete: crediting the durable counter needs to
+            # know WHICH rows joined the prefix, not just how many.
+            trimmed = self.messages[:excess]
             del self.messages[:excess]
             self._resumed_count = max(0, self._resumed_count - excess)
             # A trimmed leading window message may only join the frozen prefix
@@ -1522,6 +1561,10 @@ class _ChatSlot:
             # as on-disk, which would have stranded those turns.
             persisted_trim = min(excess, self._disk_window_len)
             self._disk_older_count += persisted_trim
+            # Same subset, counted by the other semantics. Both counters must
+            # move on EVERY frozen-prefix mutation or absolute cursors drift
+            # away from the prefix they index into.
+            self._disk_older_durable_count += durable_row_count(trimmed[:persisted_trim])
             self._disk_window_len = max(0, self._disk_window_len - excess)
             if persisted_trim < excess:
                 logger.warning(

--- a/test/test_durable_prefix_count.py
+++ b/test/test_durable_prefix_count.py
@@ -1,0 +1,150 @@
+"""Absolute message cursors need a durable-only count of the frozen prefix.
+
+``_disk_older_count`` counts every trimmed on-disk line. Transient rows
+(``chunk``/``done``/``streaming``/``queued``/``permission``) are written to disk
+but skipped on read-back, so as soon as one is trimmed that counter advances with
+no durable row behind it. A cursor of ``_disk_older_count + <durable index>``
+then names a row the consumer already received.
+
+``_disk_older_durable_count`` counts the same prefix, durable rows only.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.dashboard.state import (
+    _MAX_SLOT_MESSAGES,
+    TRANSIENT_ROLES,
+    _ChatSlot,
+    durable_row_count,
+)
+
+
+def _rows(*roles: str) -> list[dict]:
+    return [{"role": r, "content": f"{r}-{i}"} for i, r in enumerate(roles)]
+
+
+class TestDurableRowCount:
+    def test_transient_rows_do_not_count(self):
+        rows = _rows("user", "chunk", "assistant", "done", "streaming", "user")
+        assert durable_row_count(rows) == 3
+        assert len(rows) == 6, "the raw count is what _disk_older_count would use"
+
+    @pytest.mark.parametrize("role", sorted(TRANSIENT_ROLES))
+    def test_every_transient_role_is_excluded(self, role):
+        """Pinned against the set itself so a new transient role cannot be added
+        without either being counted here or failing this test."""
+        assert durable_row_count(_rows(role)) == 0
+
+    def test_durable_roles_count(self):
+        assert durable_row_count(_rows("user", "assistant", "system")) == 3
+
+    def test_a_row_with_no_role_counts_as_durable(self):
+        """``_build_message_entry`` defaults a missing role to ``assistant``, so
+        the count must default the same way rather than silently dropping it."""
+        assert durable_row_count([{"content": "x"}]) == 1
+
+    def test_empty_prefix(self):
+        assert durable_row_count([]) == 0
+
+
+class TestCursorSkew:
+    """The defect itself, stated as arithmetic over one concrete history."""
+
+    def test_a_trimmed_transient_row_shifts_a_raw_cursor_but_not_a_durable_one(self):
+        # A history whose frozen prefix holds 2 durable rows and 1 transient one.
+        prefix = _rows("user", "chunk", "assistant")
+        window = _rows("user", "assistant")
+
+        disk_older_count = len(prefix)
+        disk_older_durable_count = durable_row_count(prefix)
+
+        # A consumer paging over DURABLE rows asks for "the row after the 2 I
+        # already read from the prefix" — i.e. durable index 0 of the window.
+        durable_index_of_first_window_row = 0
+
+        skewed = disk_older_count + durable_index_of_first_window_row
+        correct = disk_older_durable_count + durable_index_of_first_window_row
+
+        # Absolute positions over the durable-only view of the whole history:
+        # [user, assistant] from the prefix, then [user, assistant] from the window.
+        durable_history = [r for r in prefix + window if r["role"] not in TRANSIENT_ROLES]
+
+        assert durable_history[correct]["content"] == window[0]["content"]
+        assert skewed == correct + 1, "one trimmed transient row, one position of skew"
+        assert durable_history[skewed]["content"] != window[0]["content"], (
+            "the skewed cursor skips a row the consumer never saw"
+        )
+
+    def test_no_transient_rows_means_the_two_counters_agree(self):
+        """Control: the skew appears only because transient rows are on disk."""
+        prefix = _rows("user", "assistant", "user")
+        assert durable_row_count(prefix) == len(prefix)
+
+
+class TestLiveTrimAdvancesBothCounters:
+    """The frozen prefix also grows at runtime, not only at restore.
+
+    ``_ChatSlot.append`` trims the window past ``_MAX_SLOT_MESSAGES`` and credits
+    ``_disk_older_count``. The real invariant is not "every restore site sets
+    both counters" but **every frozen-prefix mutation advances both, each by its
+    own semantics** — an increment site that moves only the raw counter reopens
+    exactly the skew this exists to close.
+    """
+
+    def _slot_at_cap(self, *, disk_window_len: int) -> _ChatSlot:
+        slot = _ChatSlot(key="trim-slot")
+        slot.messages = [
+            {"role": "user", "content": f"m{i}"} for i in range(_MAX_SLOT_MESSAGES)
+        ]
+        slot._disk_window_len = disk_window_len
+        slot._disk_older_count = 0
+        slot._disk_older_durable_count = 0
+        return slot
+
+    def test_a_trim_credits_durable_rows_only(self):
+        """Prefix gains 3 lines but only 2 durable messages."""
+        slot = self._slot_at_cap(disk_window_len=_MAX_SLOT_MESSAGES)
+        # Make the three rows that will be trimmed durable, transient, durable.
+        slot.messages[0] = {"role": "user", "content": "a"}
+        slot.messages[1] = {"role": "chunk", "content": "partial"}
+        slot.messages[2] = {"role": "assistant", "content": "b"}
+
+        for _ in range(3):
+            slot.append("user", "new", "msg msg-u", broadcast=False)
+
+        assert slot._disk_older_count == 3
+        assert slot._disk_older_durable_count == 2
+
+    def test_unpersisted_overflow_enters_neither_counter(self):
+        """Only the persisted subset joins the frozen prefix.
+
+        With 5 rows leaving memory but only 3 on disk, the last 2 are gone from
+        the window and were never flushed — crediting them to either counter
+        would claim history that cannot be read back.
+        """
+        slot = self._slot_at_cap(disk_window_len=3)
+        # First 3 (the persisted ones) are durable, transient, durable.
+        slot.messages[0] = {"role": "user", "content": "a"}
+        slot.messages[1] = {"role": "queued", "content": "waiting"}
+        slot.messages[2] = {"role": "assistant", "content": "b"}
+        # The 2 that overflow unpersisted are durable, and must NOT be counted.
+        slot.messages[3] = {"role": "user", "content": "c"}
+        slot.messages[4] = {"role": "assistant", "content": "d"}
+
+        for _ in range(5):
+            slot.append("user", "new", "msg msg-u", broadcast=False)
+
+        assert slot._disk_older_count == 3, "raw counter credits only the persisted subset"
+        assert slot._disk_older_durable_count == 2, "durable counter, same subset"
+
+    def test_with_no_transient_rows_both_counters_move_together(self):
+        """Control: the two diverge only because transient rows occupy lines."""
+        slot = self._slot_at_cap(disk_window_len=_MAX_SLOT_MESSAGES)
+
+        for _ in range(4):
+            slot.append("user", "new", "msg msg-u", broadcast=False)
+
+        assert slot._disk_older_count == 4
+        assert slot._disk_older_durable_count == 4

--- a/test/test_one_conversation_one_session.py
+++ b/test/test_one_conversation_one_session.py
@@ -172,6 +172,38 @@ class TestA3FullHistoryIsReachable:
         # detail endpoint cannot reassemble it.
         assert slot._disk_older_count + len(slot.messages) == 700
 
+    def test_the_frozen_prefix_also_reports_a_durable_only_count(self, state, log):
+        """``_disk_older_count`` counts trimmed transient rows too, so it cannot
+        serve as the base for an absolute message position. The durable-only
+        counter beside it can.
+
+        Transient rows are written to disk but skipped on read-back, so without
+        the second counter a cursor gains one position of skew per trimmed
+        transient row and re-serves a durable message the consumer already had.
+        """
+        # 700 durable turns with 3 transient rows interleaved into the region
+        # that will be trimmed into the frozen prefix.
+        rows = _turns(700)
+        transient = [
+            {"role": "chunk", "content": "partial", "ts": "2026-08-01T10:00:01"},
+            {"role": "streaming", "content": "partial", "ts": "2026-08-01T10:00:02"},
+            {"role": "queued", "content": "waiting", "ts": "2026-08-01T10:00:03"},
+        ]
+        rows[10:10] = transient
+        _write_transcript(Path(log._dir), SLACK_STEM, rows)
+
+        slot = surface_channel_session(
+            state, {"key": SLACK_STEM, "modified": 100.0}, {}, log.read_messages(SLACK_STEM),
+            session_key=SLACK_KEY,
+        )
+        assert slot is not None
+        # The raw counter still accounts for every trimmed LINE — the save model
+        # depends on that and must not change.
+        assert slot._disk_older_count + len(slot.messages) == len(rows)
+        # The durable counter excludes exactly the three transient rows, all of
+        # which fall inside the trimmed prefix.
+        assert slot._disk_older_durable_count == slot._disk_older_count - len(transient)
+
 
 class TestA4TheTabStaysCurrent:
     """A4 — a channel turn after the tab opened appears in the tab."""


### PR DESCRIPTION
## Problem / Motivation

There is no counter for how many **durable** rows have been trimmed into a slot's
frozen prefix, so no absolute message position can be computed once trimming
starts.

`_disk_older_count` counts every trimmed on-disk line. Transient roles —
`chunk`, `done`, `streaming`, `queued`, `permission` — **are** written to disk and
are skipped only on read-back, which is precisely why the reconciliation pass
filters them. So the counter advances with no durable row behind it as soon as a
transient row is trimmed:

| frozen prefix (trimmed) | `_disk_older_count` | durable rows in prefix | skew |
|---|---|---|---|
| `user`, `assistant` | 2 | 2 | 0 |
| `user`, `chunk`, `assistant` | 3 | 2 | **1** |

A cursor of `_disk_older_count + <index over durable rows>` therefore names a row
one place further on than intended, and a consumer paging from a position it was
handed earlier is served a durable message it already has.

## Why it matters

Absolute, stable positions are what any paging or polling consumer needs. Today
the only available base counter cannot provide them once trimming starts, so a
consumer must either duplicate rows or refuse to paginate.

Session control chose to refuse: `session_read_message` answers `409
cursor_unavailable` for a `since` read once `_disk_older_count > 0`, and omits
`next_since` in favour of `cursor_exact: false`. The in-memory window is 10,000
rows so only a long-lived session reaches it — but a long-lived session is
exactly the one worth polling, so the limitation lands where it hurts most.

## What changed (motivation → approach → change)

**Root cause.** One counter is being asked to do two jobs. As the frozen-prefix
marker it must count *lines*, because that is what the save model must not
rewrite. As a cursor base it must count *messages*. Those numbers diverge exactly
when a transient row is trimmed.

**Change.** `_disk_older_durable_count` is maintained beside `_disk_older_count`,
over the same prefix, counting durable rows only. `_disk_older_count` keeps its
current meaning and value — nothing that depends on the save model changes.

`durable_row_count()` is a single helper next to `TRANSIENT_ROLES` so the two
counters cannot drift on what "durable" means. It defaults a missing role to
`assistant`, matching `_build_message_entry`, rather than silently dropping the
row.

**The invariant is not "every restore site sets both counters".** It is that
**every frozen-prefix mutation advances both, each by its own semantics.** A
mutation that moved only the raw counter would reopen exactly the skew this
closes. There are five, and the issue named two:

| site | kind | |
|---|---|---|
| `chat_persistence._rehydrate_slot_from_history` | assign | establishes the prefix |
| `chat_persistence` restore-by-key | assign | establishes the prefix |
| `channel_slots` channel restore | assign | establishes the prefix |
| `chat_handlers` History resume | assign | establishes the prefix |
| **`_ChatSlot.append` live trim** | **increment** | **grows the prefix at runtime** |

The four assign sites each derive the prefix slice once and set both counters
from it. The fifth is the one that is easy to miss because it does not assign:
past `_MAX_SLOT_MESSAGES` the window is trimmed and `_disk_older_count +=
persisted_trim`.

**The live trim needs the rows, not just the count.** It now captures
`trimmed = self.messages[:excess]` before the delete. Only the *persisted*
subset joins the frozen prefix: with `excess` rows leaving memory and
`_disk_window_len` of them known to be on disk, `trimmed[:persisted_trim]` is
what is credited, and the unpersisted overflow enters **neither** counter rather
than claiming history that cannot be read back. That boundary
(`excess > _disk_window_len`) has its own regression test.

**Where the shared vocabulary lives.** `TRANSIENT_ROLES` and
`durable_row_count` moved to `state.py`. The live trim needs them and
`chat_persistence` already imports `state`, so the reverse import is a cycle —
this keeps one definition rather than two that drift, without adding a module
for one helper.

**No consumer is switched over here.** This adds the counter the fix needs.
Changing what `chat_backfill`, `chat_rewind` and session control index from
belongs to the changes that own those surfaces — the issue flags a suspected
same-root skew in backfill and rewind that it had not audited, and auditing them
properly is its own piece of work rather than something to fold in here.

## Tests

**Fail-before / pass-after** —
`test_one_conversation_one_session.py::TestA3FullHistoryIsReachable::test_the_frozen_prefix_also_reports_a_durable_only_count`
fails on `origin/main` (the attribute does not exist) and passes after. It drives
the **real** channel restore path with a 703-row transcript — 700 durable turns
with 3 transient rows interleaved into the region that gets trimmed — and asserts
both that `_disk_older_count + len(window)` still equals the whole conversation
and that the durable counter is exactly 3 lower.

**Live-trim regressions** (`TestLiveTrimAdvancesBothCounters`) — fail when only
the trim credit is removed from the current tree, which isolates the missed
mutation site:

- `test_a_trim_credits_durable_rows_only` — prefix gains 3 lines, 2 durable.
- `test_unpersisted_overflow_enters_neither_counter` — 5 rows leave memory, only
  3 were flushed; raw counter +3 not +5, durable +2, the 2 unpersisted durable
  rows counted nowhere.
- `test_with_no_transient_rows_both_counters_move_together` — control.

**New unit file** `test/test_durable_prefix_count.py`:

- `TestDurableRowCount` — transient rows excluded; every member of
  `TRANSIENT_ROLES` parametrized, so adding a transient role without considering
  this count fails here; durable roles counted; a role-less row counts as durable;
  empty prefix.
- `TestCursorSkew` — states the defect as arithmetic over one concrete history:
  the raw-counter cursor lands on a row the consumer never saw, the durable-counter
  cursor lands on the right one, and the two differ by exactly the number of
  trimmed transient rows. Includes a control showing the counters agree when no
  transient row was trimmed, so the skew is attributed to the right cause.

## Manual verification

- `test_durable_prefix_count.py`, `test_one_conversation_one_session.py`,
  `test_chat_backfill.py`, `test_dashboard_chat.py`,
  `test_dashboard_chat_rewind.py`, `test_message_provenance.py`,
  `test_chat_slot_interrupt.py`, `test_stop_handler_idempotent.py` → **690
  passed, 1 skipped, 0 failed**.
- `flake8`, `isort`, `mypy` (chat_persistence, channel_slots, state),
  `git diff --check`, `BRAND_BASE_REF=origin/main scripts/check_brand_name.py` —
  all clean.
- Import direction verified: `chat_persistence` imports `state` and `state` does
  not import `chat_persistence`, so owning the vocabulary in `state` is
  cycle-free and every consumer imports it at module scope.
- No spec change: the counter is internal slot state, and the documented
  frozen-prefix contract is unchanged.

## Scope

Adds one counter and its helper. `_disk_older_count`'s meaning, value and every
existing consumer are untouched, so the save model and the frozen-prefix
guarantee are unaffected.

## Related Issues

Fixes #2474

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, internal slot state
- [x] No secrets, credentials, or internal references in the diff
