### PR TITLE
perf(chat): animate the streaming shimmer on the compositor

### DIFF
--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1270,8 +1270,13 @@ button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
 
 /* ── Streaming highlight (shimmer sweep on trailing words) ── */
 .streaming-glow{background:linear-gradient(90deg,transparent 0%,var(--accent-glow) 40%,var(--accent-glow) 100%);border-radius:2px;padding:0 8px 0 2px;margin:0 -2px;position:relative;overflow:hidden}
-.streaming-glow::before{content:'';position:absolute;inset:0;border-radius:inherit;background:linear-gradient(90deg,transparent 25%,color-mix(in srgb,var(--accent) 50%,transparent) 50%,transparent 75%);background-size:250% 100%;animation:stream-sweep 2.5s ease-in-out infinite;-webkit-mask:linear-gradient(90deg,transparent 0%,black 40%,black 100%);mask:linear-gradient(90deg,transparent 0%,black 40%,black 100%)}
-@keyframes stream-sweep{0%{background-position:150% 0}100%{background-position:-50% 0}}
+/* Animates transform (compositable) rather than background-position, which repaints every
+   frame. The layer stays the size of the box: the gradient is transparent across its outer
+   quarters, so a 25% translate never carries anything visible past the box edge and no
+   clipping is needed -- which matters because this is an inline span that can wrap.
+   `alternate` reverses each cycle so the loop has no restart jump. */
+.streaming-glow::before{content:'';position:absolute;inset:0;border-radius:inherit;background:linear-gradient(90deg,transparent 25%,color-mix(in srgb,var(--accent) 50%,transparent) 50%,transparent 75%);will-change:transform;animation:stream-sweep 2.5s ease-in-out infinite alternate;-webkit-mask:linear-gradient(90deg,transparent 0%,black 40%,black 100%);mask:linear-gradient(90deg,transparent 0%,black 40%,black 100%)}
+@keyframes stream-sweep{0%{transform:translateX(-25%)}100%{transform:translateX(25%)}}
 
 /* ── Streaming caret ──
    Blinking cursor appended after a streaming assistant message. Rendered


### PR DESCRIPTION
## What

`.streaming-glow`'s shimmer animated `background-position`, which is not a compositable property, so every frame of a 2.5s infinite loop repainted on the main thread — while a response is streaming and the main thread is already the contended resource.

It now animates `transform: translateX`.

## How it stays inside its box

The pseudo-element keeps the size of its box (`inset:0`) and the existing gradient, which is transparent across its outer quarters. A ±25% translate therefore never carries anything visible past the box edge, so **no clipping is involved and the parent rule is untouched**.

That constraint is load-bearing rather than incidental. This highlight is an inline `<span>` that can wrap, and an over-wide layer cannot be contained on one: `overflow` is ignored on inline non-replaced boxes, and `clip-path` on a fragmented inline clips away every line fragment after the first — measured in both Chromium and Firefox, the span's own text disappears. An earlier revision of this PR did exactly that; this one needs no clip at all.

## Motion change — stated, not claimed as parity

This is **not** motion-equivalent to the old sweep, and the earlier description was wrong to frame it that way. Upstream's band entered and exited the box, giving a brighten/dim envelope. This one slides within the box at near-constant brightness, and `animation-direction: alternate` reverses each cycle, which is what removes the restart jump.

Measured by freezing the animation at fixed phases and taking the mean grey of the span (Chromium / Firefox where both were run):

| | upstream | this revision |
|---|---|---|
| loop seam, cycle end vs start | 0.38 / 0.34 | 0.67 / 0.70 — and `alternate` removes the restart entirely |
| brightness outside the box | 0.00 | 0.00 / 0.00 |
| two-line wrap, text intact | 31.61 / 30.51 | 30.29 / 29.86 |
| centroid travel inside the box | 4.5% | 23.2% / 23.2% |

The last row is worth a note, because a single metric misleads here: mean brightness over the box measures total light, not spatial distribution, so a band sliding inside the box holds brightness nearly constant while still moving. The centroid is what shows the travel.

Under `prefers-reduced-motion` this settles at the same level as its own animated appearance, so there is no static bright band.

## Verification

No test asserts these rules — `stream-sweep` appears only at its use site and its definition, and only the class *name* is referenced elsewhere. The suite is therefore unaffected, and a green run says nothing about this change either way.

Checked in Chromium and Firefox. **Safari is untested by me** rather than passing, so the WebKit part of the `AGENTS.md` requirement is unverified.

No timing figure is claimed: the change rests on which property is animated, not on a measured frame delta.
