### PR TITLE
perf(chat): skip the dispatch for a repeated identical slots frame

### DIFF
--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -138,6 +138,8 @@ export function useWebSocket() {
   const reconnectingRef = useRef(false)  // suppress markSlotUnread during reconnect catch-up
   const lastVersionRef = useRef<string | null>(null)
   const lastGitlabHostsGenRef = useRef<number | null>(null)
+  const lastSlotsRawRef = useRef<string | null>(null)
+  const lastSlotsArrayRef = useRef<ChatSlot[] | null>(null)
   const voiceQueueRef = useRef<string[]>([])
   const voicePlayingRef = useRef(false)
   const activeAudioRef = useRef<HTMLAudioElement | null>(null)
@@ -414,6 +416,9 @@ export function useWebSocket() {
       // gateway, so after a restart an equal number can mean a different
       // allowlist. Clearing it makes the next generation frame refetch.
       lastGitlabHostsGenRef.current = null
+      // Forget the last raw slots frame too, so a reconnect whose first frame
+      // repeats the last one before it cannot swallow that first frame.
+      lastSlotsRawRef.current = null
       // Cache auto-speak preference
       api.voiceConfig().then(c => { autoSpeakRef.current = !!c.autoSpeak }).catch(() => {})
       if (wasConnectedRef.current) {
@@ -508,7 +513,14 @@ export function useWebSocket() {
             break
           }
           case 'slots': {
+            // An identical repeat carries identical values for every arm below, but
+            // only while no other writer (fetchSlots) has since replaced the list.
+            const raw = e.data as string
+            if (raw === lastSlotsRawRef.current
+                && store.getState().dashboard.slots === lastSlotsArrayRef.current) break
+            lastSlotsRawRef.current = raw
             dispatch(sseSlots(data as ChatSlot[]))
+            lastSlotsArrayRef.current = store.getState().dashboard.slots
             if (msg.yolo !== undefined) {
               dispatch(sseStatus({ yolo: msg.yolo } as StatusData))
             }

--- a/website/src/test/useWebSocket.slotsFrameDedupe.test.ts
+++ b/website/src/test/useWebSocket.slotsFrameDedupe.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The gateway re-broadcasts the whole slot list on any change, so a client
+ * receives `slots` frames byte-identical to the previous one. The hook skips an
+ * identical repeat, but only while no other writer has replaced the list since.
+ *
+ * Four controls. The middle two exist because a dedupe that never passes
+ * anything through is indistinguishable from a working one if only the dedup
+ * case is tested; the last pins the store-identity half of the guard, without
+ * which a late `fetchSlots` snapshot wins permanently.
+ *
+ * Deliberately the SINGLETON store: useWebSocket dispatches via useAppDispatch()
+ * but reads slots off the imported singleton, so a separate Provider store would
+ * let reads and writes diverge and every control below would pass vacuously.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { store as globalStore } from '../store'
+import { sseSlots, fetchSlots } from '../store/dashboardSlice'
+import type { ChatSlot } from '../types'
+import { useWebSocket } from '../hooks/useWebSocket'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() {
+    WS_INSTANCES.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+describe('useWebSocket slots frame dedupe', () => {
+  let dispatchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    globalStore.dispatch(sseSlots([]))
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => {
+    dispatchSpy?.mockRestore()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  function wrapper({ children }: { children: React.ReactNode }) {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return createElement(Provider, { store: globalStore },
+      createElement(QueryClientProvider, { client: qc }, children),
+    )
+  }
+
+  /** Mount, open the socket, and start counting sseSlots dispatches from zero.
+   *  The spy must precede mount: useAppDispatch() captures store.dispatch once. */
+  function mountOpened() {
+    dispatchSpy = vi.spyOn(globalStore, 'dispatch')
+    renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    dispatchSpy.mockClear()
+    return ws
+  }
+
+  const slotsDispatches = () =>
+    dispatchSpy.mock.calls.filter(([a]) => (a as { type?: string })?.type === sseSlots.type).length
+
+  const frame = (title: string) => ({
+    type: 'slots',
+    data: [{ key: 'slot-a', title, agent: 'kirocrew' }],
+  })
+
+  const title = () => globalStore.getState().dashboard.slots[0]?.title
+
+  it('dispatches once for two byte-identical consecutive frames', () => {
+    const ws = mountOpened()
+
+    act(() => { ws.simulateMessage(frame('session')) })
+    expect(slotsDispatches()).toBe(1)
+
+    act(() => { ws.simulateMessage(frame('session')) })
+    expect(slotsDispatches()).toBe(1)
+  })
+
+  it('dispatches twice when the second frame differs', () => {
+    const ws = mountOpened()
+
+    act(() => { ws.simulateMessage(frame('session')) })
+    act(() => { ws.simulateMessage(frame('renamed')) })
+
+    expect(slotsDispatches()).toBe(2)
+    expect(title()).toBe('renamed')
+  })
+
+  it('dispatches twice when a reconnect separates two identical frames', () => {
+    vi.useFakeTimers()
+    const ws1 = mountOpened()
+    act(() => { ws1.simulateMessage(frame('session')) })
+    expect(slotsDispatches()).toBe(1)
+
+    act(() => { ws1.onclose?.(new CloseEvent('close')) })
+    act(() => { vi.advanceTimersByTime(2000) })
+    const ws2 = WS_INSTANCES[1]
+    act(() => { ws2.simulateOpen() })
+    act(() => { ws2.simulateMessage(frame('session')) })
+
+    expect(slotsDispatches()).toBe(2)
+  })
+
+  it('re-applies an identical frame after a late fetchSlots snapshot overwrote it', () => {
+    const ws = mountOpened()
+    act(() => { ws.simulateMessage(frame('session')) })
+    expect(title()).toBe('session')
+
+    // An in-flight fetchSlots resolves after the frame and replaces the list —
+    // the ordering the reconnect path already documents as expected.
+    const stale = [{ key: 'slot-a', title: 'from-http', agent: 'kirocrew' }] as ChatSlot[]
+    act(() => { globalStore.dispatch(fetchSlots.fulfilled(stale, 'req-1', undefined as never)) })
+    expect(title()).toBe('from-http')
+
+    act(() => { ws.simulateMessage(frame('session')) })
+    expect(slotsDispatches()).toBe(2)
+    expect(title()).toBe('session')
+  })
+
+  it('dispatches the first frame of a reconnect even while the refetch is still pending', async () => {
+    // Isolates the onopen reset. With the refetch unresolved the slot list is
+    // untouched, so the store-identity half of the guard cannot carry this case.
+    const { api } = await import('../api/client')
+    vi.mocked(api.chatSlots).mockReturnValue(new Promise(() => {}) as never)
+
+    vi.useFakeTimers()
+    const ws1 = mountOpened()
+    act(() => { ws1.simulateMessage(frame('session')) })
+    expect(slotsDispatches()).toBe(1)
+
+    act(() => { ws1.onclose?.(new CloseEvent('close')) })
+    act(() => { vi.advanceTimersByTime(2000) })
+    const ws2 = WS_INSTANCES[1]
+    act(() => { ws2.simulateOpen() })
+    act(() => { ws2.simulateMessage(frame('session')) })
+
+    expect(slotsDispatches()).toBe(2)
+  })
+})


### PR DESCRIPTION
## What

`case 'slots'` in `useWebSocket.ts` dispatched unconditionally. The gateway re-broadcasts the whole slot list on any change, so a client receives frames that are byte-identical to the previous one. Each still costs a `JSON.parse`, a Redux dispatch and a store notify, and reference equality cannot short-circuit anything downstream because `JSON.parse` always yields fresh objects.

The raw frame string is now kept in a ref and an identical repeat is skipped — but only while the store still holds the list that frame produced.

## Why the guard checks the store, not just the wire

Comparing the wire alone is not enough, and the first revision of this PR got that wrong. `fetchSlots.fulfilled` assigns `state.slots` wholesale, so a snapshot that resolves *after* a frame replaces what the frame put there. A wire-only dedupe then suppresses the repeat that would have corrected it, and the older snapshot stays in place indefinitely.

That ordering is not exotic — it is the one this file already documents. The reconnect path's own comment notes that "the WS replay backlog flushes faster than the fetchSlots HTTP round-trip resolves", and `fetchSlots` is dispatched from four places, including a 5-second interval in `WorldsPopout`.

So the skip also requires that `store.getState().dashboard.slots` is still the array our last frame produced. That is a reference comparison, not a deep one, so it stays cheap; any other writer replacing the list makes the next frame dispatch normally.

## Why skipping the rest of the case is sound

The `break` skips more than the `sseSlots` dispatch — the same case also handles `msg.yolo`, `msg.channelTrusted`, and the GitLab-hosts allowlist generation. Within a connection that is the point: a byte-identical frame carries identical values for all of them, so `yolo` and `channelTrusted` would re-dispatch what the store already has, and the generation compare would find `prevGen === msg.gitlabHostsGeneration` and not invalidate.

## Why the ref is cleared on connect

The allowlist generation is process-local to the gateway, so after a restart an equal number can mean a different allowlist — which is why the existing code treats the *first generation frame of each connection* as "unknown, refetch". If the first frame after a reconnect happened to be byte-identical to the last frame before the disconnect, the dedupe would break early and silently defeat that rule. `lastSlotsRawRef.current = null` is therefore set in `ws.onopen`, alongside the existing `lastGitlabHostsGenRef.current = null` that exists for the same reason.

## Tests

`website/src/test/useWebSocket.slotsFrameDedupe.test.ts`, five controls. They run against the **singleton** store, because the hook dispatches via `useAppDispatch()` but reads slots off the imported singleton — a separate Provider store would let reads and writes diverge and every control would pass vacuously. `useWebSocket.slotActivityCoalesce.test.ts` documents the same constraint.

| Control | Expectation |
|---|---|
| Two byte-identical consecutive frames        | `sseSlots` dispatched **once** |
| Two frames that differ                       | dispatched **twice** |
| Reconnect between two identical frames       | dispatched **twice** |
| Late `fetchSlots` snapshot, then identical frame | dispatched **twice**, list restored |
| First frame of a reconnect, refetch still pending | dispatched **twice** |

Each was broken deliberately and confirmed to fail:

- removing the guard fails control 1 only
- making the dedupe always fire fails all five, plus both `useWebSocketGitlabHosts` cases
- reverting to a wire-only guard fails control 4 only — that is the defect above, reproduced
- removing the `onopen` reset fails controls 3 and 5, plus the pre-existing `useWebSocketGitlabHosts` case "invalidates after a reconnect even when the generation is unchanged"

The last two resets were initially both present and neither was detectable, because either one alone falsifies a conjunct. Only one is needed, so only one is kept, and its removal is now caught.

Full website suite: 1028 files, 17131 passed, 2 expected-fail, 3 skipped, no failures.

## Scope

Only `case 'slots'` is touched. The rAF coalescing in this same file buffers different message types (`chat_message`, `chat_chunk`, `chat_done`) and does not overlap.

No measured client-side rendering delta is claimed. The justification is the work removed per duplicate frame — one parse plus dispatch plus store notify.
