### PR TITLE
fix(apps): close the trailing-newline hole in three kebab-case gates

### DIFF
--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -817,7 +817,11 @@ class NotificationsConfig:
             if not ch.id:
                 errors.append("notifications.channels: channel missing required field: id")
                 continue
-            if not KEBAB_RE.match(ch.id):
+            # fullmatch, not match: KEBAB_RE ends in `$`, which also matches
+            # just before a trailing newline, so `match` accepts an id with one
+            # trailing. The id is joined into a channel name ("<app>.<id>") and
+            # used as a subscription key, so the newline survives into both.
+            if not KEBAB_RE.fullmatch(ch.id):
                 errors.append(f"notifications.channels: channel id must be kebab-case: {ch.id!r}")
             if ch.id in seen:
                 errors.append(f"notifications.channels: duplicate channel id: {ch.id!r}")

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -1103,7 +1103,7 @@ def _read_external_registry_cache(
             if not isinstance(entry, dict):
                 continue
             entry_name = entry.get("name")
-            if not isinstance(entry_name, str) or not KEBAB_RE.match(entry_name):
+            if not isinstance(entry_name, str) or not KEBAB_RE.fullmatch(entry_name):
                 logger.warning(
                     "Dropping cached external registry %s entry with invalid "
                     "name %r (must be lowercase kebab-case)",
@@ -1340,7 +1340,7 @@ async def _fetch_and_cache_external_registry(reg) -> list[dict[str, Any]] | None
     valid_entries: list[dict[str, Any]] = []
     for entry in entries:
         entry_name = entry.get("name")
-        if not isinstance(entry_name, str) or not KEBAB_RE.match(entry_name):
+        if not isinstance(entry_name, str) or not KEBAB_RE.fullmatch(entry_name):
             logger.warning(
                 "Dropping external registry %s entry with invalid name %r "
                 "(must be lowercase kebab-case)",

--- a/test/test_kebab_gates_reject_trailing_newline.py
+++ b/test/test_kebab_gates_reject_trailing_newline.py
@@ -1,0 +1,118 @@
+"""``KEBAB_RE`` only carries its grammar under ``fullmatch``.
+
+The pattern ends in ``$``, which in Python matches at the true end of the string
+**and** immediately before a trailing newline. So ``KEBAB_RE.match("alerts\\n")``
+succeeds, and every gate written as ``if not KEBAB_RE.match(value)`` admits a
+value with a trailing newline while reporting it as valid kebab-case.
+
+Three gates were written that way, and each hands the value straight on:
+
+- an app's notification channel id, joined into ``"<app>.<id>"`` and used as a
+  subscription key;
+- the cached external-registry entry name;
+- the fetched external-registry entry name.
+
+``install_receipt._valid_slug`` already used ``fullmatch`` and is the
+reference for the shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.apps.install_receipt import _valid_slug
+from kiro_crew.apps.manifest import KEBAB_RE, NotificationsConfig
+
+#: Values whose only defect is a trailing newline: `$` lets them through `match`.
+NEWLINE_VALUES = ["alerts\n", "build-done\n", "a\n"]
+
+
+def test_the_pattern_itself_is_why_fullmatch_is_required():
+    """Source of truth for the whole file. If this ever fails because the shared
+    pattern was re-anchored with ``\\Z``, the gates below are belt-and-braces and
+    this file can be simplified."""
+    assert KEBAB_RE.match("alerts\n"), "match still accepts a trailing newline"
+    assert not KEBAB_RE.fullmatch("alerts\n"), "fullmatch is what rejects it"
+    assert KEBAB_RE.fullmatch("alerts"), "an ordinary id is unaffected"
+
+
+class TestNotificationChannelId:
+    @pytest.mark.parametrize("bad_id", NEWLINE_VALUES)
+    def test_a_trailing_newline_is_not_kebab_case(self, bad_id):
+        cfg = NotificationsConfig.from_dict(
+            {"channels": [{"id": bad_id, "name": "Alerts", "label": "Alerts"}]}
+        )
+        errors = cfg.validate()
+        assert any("kebab-case" in e for e in errors), (bad_id, errors)
+
+    def test_an_ordinary_channel_id_still_validates(self):
+        cfg = NotificationsConfig.from_dict(
+            {"channels": [{"id": "build-done", "name": "Build", "label": "Build done"}]}
+        )
+        assert cfg.validate() == []
+
+    def test_a_genuinely_non_kebab_id_is_still_rejected(self):
+        """Preservation: the existing contract is unchanged for everything that
+        was already refused."""
+        cfg = NotificationsConfig.from_dict(
+            {"channels": [{"id": "Not_Kebab", "name": "X", "label": "X"}]}
+        )
+        assert any("kebab-case" in e for e in cfg.validate())
+
+
+class TestRegistryEntryNames:
+    """The registry gates drop an entry whose name is not kebab-case, and their
+    own comment says why it matters: the name flows to ``app_source_dir(name)``
+    and a failed clone calls ``shutil.rmtree`` on that path. A trailing newline
+    let the name past the filter that exists to stop exactly that.
+    """
+
+    def _entry(self, name):
+        return {"name": name, "version": "1.0.0", "displayName": "X", "description": "d"}
+
+    @pytest.mark.parametrize("bad_name", ["evil-app\n", "demo\n"])
+    def test_a_cached_entry_with_a_trailing_newline_is_dropped(
+        self, bad_name, tmp_path, monkeypatch
+    ):
+        from kiro_crew.apps import registry
+
+        monkeypatch.setattr(registry, "_manifest_cache_dir", lambda: tmp_path)
+        registry._write_external_registry_cache("acme", [self._entry(bad_name)])
+
+        kept = registry._read_external_registry_cache("acme", ignore_ttl=True) or []
+
+        assert [e["name"] for e in kept] == [], f"{bad_name!r} survived the name gate"
+
+    def test_an_ordinary_cached_entry_is_kept(self, tmp_path, monkeypatch):
+        """Preservation: the gate refuses a malformed name, not entries."""
+        from kiro_crew.apps import registry
+
+        monkeypatch.setattr(registry, "_manifest_cache_dir", lambda: tmp_path)
+        registry._write_external_registry_cache("acme", [self._entry("good-app")])
+
+        kept = registry._read_external_registry_cache("acme", ignore_ttl=True) or []
+
+        assert [e["name"] for e in kept] == ["good-app"]
+
+    def test_neither_registry_gate_uses_bare_match(self):
+        """Source guard for the fetch path.
+
+        The fetch gate lives inside an async function that performs network I/O,
+        so it is not reachable from a unit test without mocking the transport —
+        but it is the same one-line check as the cache gate, and the two must not
+        drift apart. Pins both instead of testing one and hoping.
+        """
+        import inspect
+
+        from kiro_crew.apps import registry
+
+        src = inspect.getsource(registry)
+        assert "KEBAB_RE.match(" not in src, "a registry name gate still uses bare match()"
+        assert src.count("KEBAB_RE.fullmatch(") == 2, "expected exactly two registry name gates"
+
+
+def test_install_receipt_slug_was_already_correct():
+    """The reference implementation, pinned so the three gates above now agree
+    with it rather than each carrying their own answer."""
+    assert not _valid_slug("demo\n")
+    assert _valid_slug("demo")


### PR DESCRIPTION
## Problem / Motivation

`KEBAB_RE` ends in `$`, which in Python matches at the true end of the string
**and** immediately before a trailing newline. So `KEBAB_RE.match("alerts\n")`
succeeds, and any gate written as `if not KEBAB_RE.match(value)` admits a value
with a trailing newline while reporting it as valid kebab-case.

Three gates were written that way, and each hands the value straight on:

| gate | where the value goes next | before | after |
|---|---|---|---|
| notification channel id (`NotificationsConfig.validate`) | joined into `"<app>.<id>"`, used as a subscription key | `"alerts\n"` accepted | rejected |
| cached external-registry entry name (`_read_external_registry_cache`) | `app_source_dir(name)` | `"evil-app\n"` kept | dropped |
| fetched external-registry entry name (`_fetch_and_cache_external_registry`) | same | `"evil-app\n"` kept | dropped |

`install_receipt._valid_slug` already used `fullmatch` and is the reference for
the correct shape.

## Why it matters

The registry gates' own comment states their purpose: the entry name reaches
`app_source_dir(name)` and, on a failed clone, `_git_clone_or_pull` calls
`shutil.rmtree(dest)` on that path — the filter exists specifically to keep a
malformed name away from a filesystem operation. A trailing newline walked past
it and was then re-admitted on every cached read, which is the path the comment
says exists so a tampered cache "can never reintroduce" an unsafe name.

The channel id is lower-severity but the same class: the newline is carried into
a channel name and a subscription key, and the validator reports the id as
well-formed.

## What changed (motivation → approach → change)

All three gates now use `KEBAB_RE.fullmatch`.

**The shared pattern is deliberately left alone.** Re-anchoring `KEBAB_RE` with
`\Z` would fix all of these in one line, but it silently retightens every other
consumer of that pattern in the same change. The gates are what were wrong; each
one is corrected where it is used, which keeps the blast radius equal to the
defect.

## Tests

New file `test/test_kebab_gates_reject_trailing_newline.py`.

**Fail-before / pass-after** (6 fail on `origin/main`):

- `TestNotificationChannelId::test_a_trailing_newline_is_not_kebab_case` —
  `alerts\n`, `build-done\n`, `a\n`.
- `TestRegistryEntryNames::test_a_cached_entry_with_a_trailing_newline_is_dropped`
  — `evil-app\n`, `demo\n`, driven through a real write/read of the registry
  cache with the cache dir pointed at `tmp_path`, so it exercises the gate rather
  than the regex.
- `TestRegistryEntryNames::test_neither_registry_gate_uses_bare_match` — a source
  guard. The fetch gate sits inside an async function that performs network I/O
  and is not reachable from a unit test without mocking the transport, but it is
  the same one-line check as the cache gate and the two must not drift. This pins
  both rather than testing one and hoping.

**Preservation guards** (pass before and after): an ordinary channel id still
validates, a genuinely non-kebab id (`Not_Kebab`) is still rejected, an ordinary
registry entry is still kept, and `_valid_slug` still behaves as before.

`test_the_pattern_itself_is_why_fullmatch_is_required` documents the root cause
and doubles as a tripwire: if the shared pattern is ever re-anchored with `\Z`,
it fails and says so, at which point these gates become belt-and-braces.

## Manual verification

- 296 passed / 10 skipped across the new file plus `test_app_manifest.py`,
  `test_apps_registry.py`, `test_install_receipt.py`, `test_notifications_push.py`
  and `test_app_manager.py`.
- `flake8`, `isort`, `git diff --check` and
  `BRAND_BASE_REF=origin/main scripts/check_brand_name.py` clean. `mypy` reports
  only a pre-existing `os.killpg` attr-defined error at `registry.py:3252`, an
  untouched line that fires only when mypy runs on Windows.

## Scope

Three call sites and a test file. Found while scoping #2590, which fixes the
same class of bug at the **app-name** gate (`app_name_error`) and is deliberately
limited to it. The two PRs touch different lines of `manifest.py`; whichever
lands second may need a trivial rebase. No shared constant, no behaviour change
for any value that was already valid.

## Related Issues

No existing issue — found by auditing every `KEBAB_RE` consumer while narrowing
the scope of #2590. Filing an issue first would only have restated this diff.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes for valid input
- [x] No secrets, credentials, or internal references in the diff
