### PR TITLE
fix(auth): explain revocation counter recovery

### DIFF
--- a/docs/system-specs/features/dashboard-token-auth.md
+++ b/docs/system-specs/features/dashboard-token-auth.md
@@ -271,6 +271,12 @@ Up to `MAX_CONCURRENT_NONCES` (**50**) link nonces are valid simultaneously. Whe
 
 The in-memory `TokenStateManager` (link nonces, IP bindings, consumed set) is cleared on restart, but this does **not** log users out: an established session cookie is validated on the cookie path (`use_session_exp=True`), which needs only a valid HMAC signature (persistent key) + unexpired `session_exp` + a current revocation generation + a nonce not on the persisted denylist — it never consults the in-memory link-nonce set. Revoked-session state is durable: `RevokedNonceStore` persists to `token_revoked_nonces.json` (mode `0600`) and the revocation generation persists to `token_revocation.gen`, so a logged-out cookie stays dead across restarts while a restart alone (generation reloaded unchanged) logs nobody out. Users can revoke a single session via `POST /api/auth/logout` (`revoke_access_cookie()`) or all sessions — access cookies and refresh chains — via `kirocrew logout` (`revoke_all_sessions()`, which bumps the generation both token kinds embed and check).
 
+If `token_revocation.gen` exists but cannot be read as an integer, both token
+validators fail closed until the state is repaired. The gateway warning names
+the exact file and advises deleting only that file to reset revocation state;
+the warning also states the security consequence: resetting the counter can
+re-enable unexpired sessions previously revoked by `kirocrew logout`.
+
 #### App-token scope confinement (CWE-269)
 
 An **app token** (payload carries a non-empty `app` claim, minted by the `X-App-Secret` exchange at `POST /api/apps/<name>/token`) must not have the same reach as a dashboard-user token. `_enforce_app_scope(request, app_name, path)` applies least privilege, **deny-by-default**:

--- a/src/kiro_crew/dashboard/revocation_gen.py
+++ b/src/kiro_crew/dashboard/revocation_gen.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,19 @@ _REVOCATION_FILE = "token_revocation.gen"
 # concurrent first reads / bumps agree on one value.
 _gen: int | None = None
 _gen_lock = threading.Lock()
+
+
+def _warn_unreadable_counter(path: Path, reason: str, *, exc_info: bool = False) -> None:
+    """Log the fail-closed recovery action without hiding its security cost."""
+    logger.warning(  # nosemgrep: python-logger-credential-disclosure
+        "token revocation counter file %s %s; authentication is fail-closed. "
+        "To reset revocation state and restore access, delete only %s "
+        "(this re-enables unexpired sessions revoked by kirocrew logout)",
+        path,
+        reason,
+        path,
+        exc_info=exc_info,
+    )
 
 
 def _load_revocation_gen_or_none() -> int | None:
@@ -51,6 +65,7 @@ def _load_revocation_gen_or_none() -> int | None:
     # a cycle. Matches the config_dir() call sites in token_secret.py.
     from kiro_crew.config.loader import config_dir
 
+    p = Path(_REVOCATION_FILE)
     try:
         p = config_dir() / _REVOCATION_FILE
         try:
@@ -62,15 +77,11 @@ def _load_revocation_gen_or_none() -> int | None:
             # Logs the counter file PATH only, never any token or secret value;
             # the Semgrep rule fires on the credential-adjacent wording in the
             # static message string.
-            logger.warning(  # nosemgrep: python-logger-credential-disclosure
-                "token revocation counter file %s is empty (interrupted write?); "
-                "treating as unreadable",
-                p,
-            )
+            _warn_unreadable_counter(p, "is empty (interrupted write?)")
             return None
         return int(stripped)
     except (OSError, ValueError):
-        logger.warning("could not read token revocation counter", exc_info=True)
+        _warn_unreadable_counter(p, "could not be read", exc_info=True)
         return None
 
 

--- a/test/test_refresh_tokens.py
+++ b/test/test_refresh_tokens.py
@@ -1443,21 +1443,29 @@ def test_tr_u_35_bump_persist_failure_leaves_counter_unchanged(
     assert rg.current_revocation_gen() == 3
 
 
-def test_tr_u_36_empty_counter_file_fails_closed(tmp_path: Path, monkeypatch):
-    """An existing-but-empty counter file is unreadable, not gen 0.
+@pytest.mark.parametrize("contents", ["", "not-an-integer"])
+def test_tr_u_36_unreadable_counter_file_logs_recovery(
+    tmp_path: Path, monkeypatch, caplog, contents: str
+):
+    """An empty or malformed counter is unreadable and explains recovery.
 
-    A write torn by process termination leaves an empty file; interpreting it
-    as 0 would resurrect every revoked session on the next boot. The loader
-    reports it unreadable and validators reject until the state is repaired
-    (or the next successful bump atomically replaces it).
+    Interpreting either form as 0 would resurrect every revoked session on the
+    next boot. The loader reports it unreadable, explains the reset cost, and
+    validators reject until the state is repaired.
     """
     import kiro_crew.dashboard.revocation_gen as rg
 
     monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
-    (tmp_path / rg._REVOCATION_FILE).write_text("", encoding="utf-8")
+    counter = tmp_path / rg._REVOCATION_FILE
+    counter.write_text(contents, encoding="utf-8")
     monkeypatch.setattr(rg, "_gen", None)
 
-    assert rg._load_revocation_gen_or_none() is None
+    with caplog.at_level("WARNING", logger=rg.__name__):
+        assert rg._load_revocation_gen_or_none() is None
+
+    assert str(counter) in caplog.text
+    assert "delete only" in caplog.text
+    assert "re-enables unexpired sessions revoked by kirocrew logout" in caplog.text
 
     token, _cid, _jti, _exp = generate_refresh_token("alice")  # mint degrades to gen 0
     valid, _, reason, _, _, _ = validate_refresh_token(token)


### PR DESCRIPTION
## Problem\n\nWhen the revocation counter file is empty, malformed, or unreadable, authentication correctly fails closed but the warning does not tell operators how to recover safely.\n\n## Why it matters\n\nOperators can be locked out without knowing which file needs attention or that resetting it may restore sessions previously revoked with kirocrew logout.\n\n## Fix\n\n- include the exact counter-file path and a deliberate reset instruction in unreadable-counter warnings\n- explain the security consequence of resetting the counter\n- preserve fail-closed authentication behavior\n- cover empty and malformed counter files in tests\n- document the recovery behavior in the dashboard token-auth specification\n\n## Tests\n\n- 62 refresh-token tests passed\n- Python formatting, import, lint, docs, brand, scrub, vendor, and CloudFormation checks passed\n- website build, TypeScript, ESLint, localization, 15,277 frontend tests, and 850 Electron tests passed\n\n## Manual verification\n\nN/A — behavior is covered through warning-log and authentication assertions.\n\n## Screenshots\n\nN/A — no UI change.\n\nCloses #2393