### PR TITLE
fix(sidebar): count goal-loop sessions in the In progress filter

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -384,6 +384,11 @@ interface Slot {
   // Derived (not a payload field), like `unread`: true when the slot's last
   // activity falls inside `RECENT_WINDOW_MS`. Computed in `enrichedSlots`.
   recent?: boolean
+  // Derived: the RAW per-turn flag, preserved before `running` is widened to
+  // the "in progress" notion (live workflow run / active goal loop) for the
+  // session filter. Subtitle logic reads this to tell mid-turn from idle —
+  // an idle-between-cycles loop must show its last message, not "Thinking…".
+  midTurn?: boolean
   tags?: string[]
   forked_from?: string | null
   source_links?: Array<{
@@ -1053,11 +1058,18 @@ function ChatSidebar({
       // A slot with a live dynamic-workflow run counts as running so the
       // "In progress" filter (and its count) surfaces it, even though the
       // parent turn has ended while the run executes in the background.
-      return { ...s, running: s.running || !!workflowActive[s.key], unread: unreadSet.has(s.key), recent }
+      // An active goal loop (auto-nudge) counts too: a looping session idles
+      // between cycles with running=false, but it is still mid-mission — its
+      // row shows "Loop N/M", so dropping it from "In progress" undercounts.
+      // Own-property read, matching the row renderer: the store normalizes
+      // writes through `safeKey`, so a bare index read could resolve a
+      // `__proto__`-like key to a truthy `Object.prototype`.
+      const looping = Object.prototype.hasOwnProperty.call(goalLoops ?? {}, s.key)
+      return { ...s, running: s.running || !!workflowActive[s.key] || looping, midTurn: s.running, unread: unreadSet.has(s.key), recent }
     })
     // `recentTick` is an intentional dep: it forces recency to re-evaluate on
     // the heartbeat above so idle sessions age out of the Recent filter.
-  }, [slots, unreadSet, recentWindowMs, recentTick, workflowActive]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [slots, unreadSet, recentWindowMs, recentTick, workflowActive, goalLoops]) // eslint-disable-line react-hooks/exhaustive-deps
   const filterCounts = useMemo(() => {
     const counts = {} as Record<SessionFilterKey, number>
     for (const filterDef of SESSION_FILTERS) counts[filterDef.key] = enrichedSlots.filter(slot => slot[filterDef.key]).length
@@ -2161,11 +2173,14 @@ function ChatSidebar({
     // loop line's trailing detail. This is why the loop branch can outrank the
     // working signals below without swallowing them: live workflow/subagent/tool
     // status still shows, and between cycles it falls back to the last message.
+    // Reads `midTurn` (the raw turn flag), NOT `running`: enrichment widens
+    // `running` to include this very loop, and an idle-between-cycles row must
+    // say "Loop 7/24 · <last message>", not "Loop 7/24 · Thinking…".
     const goalLoopDetail = wfActive
       ? wfActive.label
       : subagentCount > 0
         ? subagentLabel
-        : s.running
+        : s.midTurn
           ? slotStatusText(slotStatusDetail[s.key], simplifiedToolNames, uiLang)
           : (s.last_message || '')
     const ci = s.color_index != null && s.color_index >= 0 && s.color_index < paletteColors.length ? s.color_index : null

--- a/website/src/test/ChatSidebar.goalLoop.test.tsx
+++ b/website/src/test/ChatSidebar.goalLoop.test.tsx
@@ -8,7 +8,8 @@
  * Progress comes from chat.goalLoops, keyed by the BARE slot key (autonudge.py
  * `binding_key_for` strips the `dashboard:` prefix). Presence in the map IS
  * "looping": inactive loops are dropped on the way into the store, so a loop
- * that hit max_cycles leaves no residue here.
+ * that hit max_cycles leaves no residue here. An actively-looping slot also
+ * counts as "In progress" for the session filter, like a live workflow run.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render } from '@testing-library/react'
@@ -176,5 +177,23 @@ describe('chat sidebar — goal-loop progress subtitle', () => {
     expect(queryByTitle(UNREAD_DOT_TITLE)).toBeTruthy()
     expect(getByText('final answer')).toBeTruthy()
     expect(queryByText(/^Loop/)).toBeNull()
+  })
+
+  it('a looping slot passes the "In progress" session filter despite running=false', () => {
+    // A loop spends its idle gaps with running=false (turn ended, waiting for
+    // the next nudge). The row still says "Loop N/M", so the filter — and its
+    // count — must keep surfacing it, mirroring the dynamic-workflow rule.
+    // Pre-activate the filter via its persisted toggle (read at mount).
+    localStorage.setItem('mc-session-running-only', '1')
+    const slots = [
+      { key: 'k-loop', title: 'loop session', running: false, messages: 5 },
+      { key: 'k-idle', title: 'idle session', running: false, messages: 2 },
+    ]
+    const { getByText, queryByText } = renderSidebar(
+      slots,
+      { goalLoops: { 'k-loop': { cycle_count: 10, max_cycles: 40 } } },
+    )
+    expect(getByText('loop session')).toBeTruthy() // kept: active loop counts as in-progress
+    expect(queryByText('idle session')).toBeNull() // filtered out: genuinely idle
   })
 })


### PR DESCRIPTION
## Problem

The sidebar's **In progress** filter (and its count) misses sessions running an active goal loop (auto-nudge). A looping session spends its idle gaps between cycles with `running=false` — the turn has ended and the loop is waiting for the next nudge — so it drops out of the filter even though its row shows **Loop N/M** and the session is clearly mid-mission.

Observed on a live dashboard: two sessions showing `Loop 14/30` and `Loop 10/40`, filter menu says **In progress (1)** — only the one that happened to be mid-turn at that instant was counted.

## Fix

`enrichedSlots` already widens the derived `running` flag for slots with a live dynamic-workflow run, precisely so the In progress filter surfaces background work (`running: s.running || !!workflowActive[s.key]`). This PR applies the same rule to active goal loops: presence in `chat.goalLoops` counts as in progress (the store only holds ACTIVE loops — stopped/capped loops are dropped on the way in).

The raw per-turn flag is preserved as a derived `midTurn` field, because the loop row's trailing detail uses it to distinguish mid-turn (`Loop 7/24 · Reading x.py`) from idle-between-cycles (`Loop 7/24 · <last message>`). Without that split, the widened flag degraded idle loop rows to `Loop 7/24 · Thinking…` — caught by the existing goal-loop subtitle test during development.

## Tests

- New: `a looping slot passes the "In progress" session filter despite running=false` in `ChatSidebar.goalLoop.test.tsx`, mirroring the existing workflow-run filter test in `ChatSidebar.workflowRunning.test.tsx`.
- Existing goal-loop subtitle tests pin the `midTurn` split (idle loop keeps its last message).
- Full frontend suite: 954 files / 15,278 tests green. `tsc --noEmit` and `eslint` clean.

## Visual proof

Fixture: three sessions — two in active goal loops (`Loop 14/30` idle between cycles, `Loop 10/40` mid-turn) and one plain idle session. Captured from the sidebar rendered at the merge-base (before) and at this PR's head (after), headless Chromium.

| Before (main) | After (this PR) |
|--------|-------|
| ![before: In progress (1) despite two looping sessions](https://raw.githubusercontent.com/rubencu/KiroCrew/assets/pr-2755/pr2755-before.png) | ![after: In progress (2)](https://raw.githubusercontent.com/rubencu/KiroCrew/assets/pr-2755/pr2755-after.png) |

The idle-between-cycles loop (`Loop 14/30`) is missing from the count on main and included with this fix; the count matches the two visibly-looping rows.
