### PR TITLE
fix(sidebar): render pending PR checks as a static dot, not a spinner

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -2500,7 +2500,12 @@ function ChatSidebar({
                       {link.state === 'closed' && <span className="capitalize text-danger">{link.state}</span>}
                       {/* CI status is moot once the PR is terminal (merged or closed) —
                           the lifecycle glyph is the terminal signal. */}
-                      {showsChipCi(link.state) && link.ci === 'running' && <Loader2 className="lucide-inline shrink-0 animate-spin" aria-label={i18nT('pages.chatSidebar.checks_running')} />}
+                      {/* Pending CI is a STATIC amber dot (the provider's own pending
+                          convention), never a spinner: an animated glyph on a session
+                          card reads as "the agent is working on this session", which is
+                          a stronger claim than "this PR's checks haven't finished".
+                          Motion on the card stays reserved for session activity. */}
+                      {showsChipCi(link.state) && link.ci === 'running' && <Circle className="lucide-inline shrink-0 text-warn scale-75" fill="currentColor" strokeWidth={0} aria-label={i18nT('pages.chatSidebar.checks_running')} />}
                       {showsChipCi(link.state) && link.ci === 'passed' && <Check className="lucide-inline shrink-0 text-ok" aria-label={i18nT('pages.chatSidebar.checks_passed')} />}
                       {showsChipCi(link.state) && link.ci === 'failed' && <X className="lucide-inline shrink-0 text-danger" aria-label={i18nT('pages.chatSidebar.checks_failed')} />}
                     </a>

--- a/website/src/test/ChatSidebar.sourceLinkChip.test.tsx
+++ b/website/src/test/ChatSidebar.sourceLinkChip.test.tsx
@@ -310,4 +310,18 @@ describe('ChatSidebar – terminal PR chips suppress CI', () => {
     expect(chipEl.querySelector('[aria-label="Checks passed"]')).toBeNull()
     expect(chipEl.querySelector('[aria-label="Checks failed"]')).toBeNull()
   })
+
+  /**
+   * The pending-CI glyph must be STATIC. An animated spinner on a session card
+   * reads as "the agent is working on this session" — users conflated PR check
+   * status with session activity. Motion on the card is reserved for session
+   * activity; PR-pending is a still amber dot (the provider's own convention).
+   */
+  it('renders pending CI as a static glyph, not a spinner', () => {
+    renderSidebar({ rows: stateRows() })
+    const glyph = spinner(995)
+    expect(glyph).not.toBeNull()
+    expect(glyph!.classList.contains('animate-spin')).toBe(false)
+    expect(glyph!.className.baseVal ?? glyph!.className).not.toMatch(/animate/)
+  })
 })


### PR DESCRIPTION
## Problem

The sidebar session-card PR chip shows an animated `Loader2` spinner while the PR's checks are pending. On a session card, an animated glyph reads as **"the agent is working on this session"** — a much stronger claim than "this PR's CI hasn't finished". In practice a user glanced at a quiet session, saw two spinning circles next to its PR chips, and concluded the session was actively working when it was idle; only the PRs' checks were pending.

Two different signals were sharing one visual language:
- **Session activity** (agent running) — animated indicators
- **PR check status** (external CI state) — should be state, not motion

## Fix

Pending CI on the chip is now a **static amber dot** — the same pending convention GitHub itself uses (amber dot / hollow circle), using the existing `--warn` token. The `aria-label="Checks running"`, the passed ✓ / failed ✗ glyphs, and the terminal-state suppression rule (`showsChipCi`) are all unchanged. Motion on session cards stays reserved for actual session activity.

A regression test pins the contract: the pending-CI glyph must carry no animation class, so a spinner can't silently return.

## Visual proof

Session "Babysit Open KiroCrew PRs" is idle in both shots; its two PRs have pending checks.

| Before (spinner reads as agent activity) | After (static amber dot = pending checks) |
|---|---|
| ![before](https://raw.githubusercontent.com/rubencu/KiroCrew/assets/chip-ci-static-dot/chip-before.png) | ![after](https://raw.githubusercontent.com/rubencu/KiroCrew/assets/chip-ci-static-dot/chip-after.png) |

## Tested

- `tsc --noEmit` clean
- `vitest` ChatSidebar.sourceLinkChip + issueChip suites: 20/20 pass (incl. new static-glyph regression test)
- `eslint` on touched files: 0 errors
- Headless Playwright before/after capture of the real component (above)