### PR TITLE
feat(desktop): add Keep on Top toggle to the View menu (#2732)

### DIFF
--- a/website/electron/app-menu.js
+++ b/website/electron/app-menu.js
@@ -26,6 +26,8 @@ function buildMenuTemplate(deps) {
     zoomActualSize,
     zoomIn,
     zoomOut,
+    alwaysOnTop, // initial checked state for Keep on Top (restored preference)
+    toggleAlwaysOnTop,
     openNewConnectionWindow,
     renameCurrentWindow,
     promptRemoteHost,
@@ -80,6 +82,17 @@ function buildMenuTemplate(deps) {
         { label: "Zoom Out", accelerator: "CmdOrCtrl+-", click: zoomOut },
         { type: "separator" },
         { role: "togglefullscreen" },
+        // Checkable, no accelerator: there is no cross-platform convention for
+        // always-on-top, and inventing one risks colliding with an existing
+        // binding. `checked` seeds from the restored preference; main.js
+        // reconciles it with the window's ACTUAL state after every toggle.
+        {
+          label: "Keep on Top",
+          type: "checkbox",
+          id: "keep-on-top",
+          checked: !!alwaysOnTop,
+          click: toggleAlwaysOnTop,
+        },
         { type: "separator" },
         {
           label: "Toggle Developer Tools",

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -1576,6 +1576,15 @@ function windowForWebContents(wc) {
   return null;
 }
 
+// Persist the main window's state (geometry + fullscreen + Keep on Top) to the
+// store. Module-level so both createWindow()'s geometry listeners and the View
+// menu's Keep on Top toggle can trigger a save. No-op while mainWindow is
+// absent/destroyed (captureWindowState returns null).
+function persistMainWindowState() {
+  const s = captureWindowState(mainWindow);
+  if (s) store.set("windowState", s);
+}
+
 function createWindow() {
   // Restore the saved geometry so quitting from native fullscreen (or any size)
   // comes back correctly. Without this the window is always rebuilt at the
@@ -1628,6 +1637,10 @@ function createWindow() {
   // fullscreen when we quit in fullscreen. The width/height above become the
   // normal frame to return to on exit.
   if (state.fullScreen) opts.fullscreen = true;
+  // Restore the Keep on Top preference (View menu checkbox). Constructor
+  // option, not a post-create setAlwaysOnTop(), so the window never flashes
+  // at normal z-order first.
+  if (state.alwaysOnTop) opts.alwaysOnTop = true;
   if (typeof state.x === "number" && typeof state.y === "number") {
     opts.x = state.x;
     opts.y = state.y;
@@ -1640,10 +1653,7 @@ function createWindow() {
   // keeps the last good size + fullscreen flag. captureWindowState() uses
   // getNormalBounds(), so we store the restore size, never the fullscreen frame.
   let saveTimer = null;
-  const persist = () => {
-    const s = captureWindowState(mainWindow);
-    if (s) store.set("windowState", s);
-  };
+  const persist = persistMainWindowState;
   const persistDebounced = () => {
     if (saveTimer) clearTimeout(saveTimer);
     saveTimer = setTimeout(persist, 400);
@@ -2695,10 +2705,16 @@ app.whenReady().then(async () => {
   // from the dock/tray-only state; surfaces the window before navigating.
   // `_mcView` marks every window that hosts a dashboard (setupWindowContents),
   // which skips modal prompt BrowserWindows that have no SPA to navigate.
-  const openSettingsPage = (tab) => {
-    const win = [BaseWindow.getFocusedWindow(), mainWindow].find(
+  // Resolve the dashboard WINDOW (not WebContents): the focused one, falling
+  // back to the main window so menu items still work from the dock/tray-only
+  // state. `_mcView` marks every window that hosts a dashboard
+  // (setupWindowContents), which skips modal prompt BrowserWindows.
+  const focusedDashboardWindow = () =>
+    [BaseWindow.getFocusedWindow(), mainWindow].find(
       (w) => w && !w.isDestroyed() && w._mcView
     );
+  const openSettingsPage = (tab) => {
+    const win = focusedDashboardWindow();
     if (!win) return;
     if (win.isMinimized()) win.restore();
     win.show();
@@ -2707,6 +2723,21 @@ app.whenReady().then(async () => {
     if (wc && !wc.isDestroyed()) {
       wc.send("navigate", tab ? `/settings?tab=${tab}` : "/settings");
     }
+  };
+  // View > Keep on Top: flip always-on-top on the focused dashboard window,
+  // then reconcile the checkbox with the window's ACTUAL state (read back) so
+  // the checkmark cannot drift if the platform refuses or another code path
+  // changes it. Persisted so the pinned window survives a relaunch.
+  const toggleAlwaysOnTop = () => {
+    const win = focusedDashboardWindow();
+    if (!win) return;
+    try {
+      win.setAlwaysOnTop(!win.isAlwaysOnTop());
+      const menu = Menu.getApplicationMenu();
+      const item = menu && menu.getMenuItemById("keep-on-top");
+      if (item) item.checked = win.isAlwaysOnTop();
+    } catch { /* window mid-teardown */ }
+    persistMainWindowState();
   };
   const appMenu = Menu.buildFromTemplate(
     buildMenuTemplate({
@@ -2720,6 +2751,10 @@ app.whenReady().then(async () => {
       zoomActualSize: zoomItem((wc) => wc.setZoomFactor(1)),
       zoomIn: zoomItem((wc) => wc.setZoomFactor(stepZoomFactor(wc.getZoomFactor(), +1))),
       zoomOut: zoomItem((wc) => wc.setZoomFactor(stepZoomFactor(wc.getZoomFactor(), -1))),
+      // Menu is built before createWindow(), so seed the checkbox from the
+      // same persisted state createWindow() restores from.
+      alwaysOnTop: !!(store.get("windowState") || {}).alwaysOnTop,
+      toggleAlwaysOnTop,
       openNewConnectionWindow: () => openNewConnectionWindow(),
       renameCurrentWindow: () => renameCurrentWindow(),
       promptRemoteHost: () => promptRemoteHost(),

--- a/website/electron/test/app-menu.test.js
+++ b/website/electron/test/app-menu.test.js
@@ -17,6 +17,8 @@ function makeDeps(overrides = {}) {
     zoomActualSize: record("zoomActualSize"),
     zoomIn: record("zoomIn"),
     zoomOut: record("zoomOut"),
+    alwaysOnTop: false,
+    toggleAlwaysOnTop: record("toggleAlwaysOnTop"),
     openNewConnectionWindow: record("openNewConnectionWindow"),
     renameCurrentWindow: record("renameCurrentWindow"),
     promptRemoteHost: record("promptRemoteHost"),
@@ -119,6 +121,25 @@ for (const isMac of [true, false]) {
     assert.strictEqual(item.accelerator, "CmdOrCtrl+Shift+I");
   });
 
+  test(`${os}: View has a Keep on Top checkbox whose checked mirrors the injected value`, () => {
+    for (const alwaysOnTop of [true, false]) {
+      const { deps } = makeDeps({ isMac, alwaysOnTop });
+      const view = buildMenuTemplate(deps).find((i) => i.label === "View");
+      const item = view.submenu.find((i) => i.label === "Keep on Top");
+      assert.ok(item, "Keep on Top present in the View submenu");
+      assert.strictEqual(item.type, "checkbox");
+      assert.strictEqual(item.id, "keep-on-top");
+      assert.strictEqual(item.checked, alwaysOnTop, `checked follows alwaysOnTop=${alwaysOnTop}`);
+      assert.strictEqual(item.accelerator, undefined, "deliberately ships no accelerator");
+    }
+  });
+
+  test(`${os}: Keep on Top click invokes the injected toggle`, () => {
+    const { deps, calls } = makeDeps({ isMac });
+    findItem(buildMenuTemplate(deps), (i) => i.label === "Keep on Top").click();
+    assert.deepStrictEqual(calls, ["toggleAlwaysOnTop"]);
+  });
+
   test(`${os}: Settings… and About clicks invoke the injected actions`, () => {
     const { deps, calls } = makeDeps({ isMac });
     const template = buildMenuTemplate(deps);
@@ -136,6 +157,7 @@ for (const isMac of [true, false]) {
       "Actual Size",
       "Zoom In",
       "Zoom Out",
+      "Keep on Top",
       "Toggle Developer Tools",
       "New Connection Window…",
       "Rename Window…",
@@ -151,6 +173,7 @@ for (const isMac of [true, false]) {
       "zoomActualSize",
       "zoomIn",
       "zoomOut",
+      "toggleAlwaysOnTop",
       "toggleDevTools",
       "openNewConnectionWindow",
       "renameCurrentWindow",

--- a/website/electron/test/window-state.test.js
+++ b/website/electron/test/window-state.test.js
@@ -92,6 +92,38 @@ test("fullScreen is coerced to a boolean", () => {
   assert.strictEqual(sanitizeWindowState({ width: 1000, height: 700 }, OPTS).fullScreen, false);
 });
 
+// ── sanitizeWindowState: Keep on Top carry-through ──
+
+test("alwaysOnTop flag round-trips with bounds intact", () => {
+  const s = sanitizeWindowState({ x: 10, y: 10, width: 1000, height: 700, alwaysOnTop: true }, OPTS);
+  assert.strictEqual(s.alwaysOnTop, true);
+  assert.strictEqual(s.width, 1000);
+});
+
+test("legacy saved state without the alwaysOnTop key -> false", () => {
+  assert.strictEqual(sanitizeWindowState({ width: 1000, height: 700 }, OPTS).alwaysOnTop, false);
+  assert.strictEqual(sanitizeWindowState(undefined, OPTS).alwaysOnTop, false);
+  // Coerced to a boolean, like fullScreen.
+  assert.strictEqual(sanitizeWindowState({ width: 1000, height: 700, alwaysOnTop: 1 }, OPTS).alwaysOnTop, true);
+});
+
+test("captureWindowState reads isAlwaysOnTop; absent method -> false", () => {
+  const s = captureWindowState(fakeWin({ normal: { x: 1, y: 2, width: 900, height: 700 }, alwaysOnTop: true }));
+  assert.strictEqual(s.alwaysOnTop, true);
+  const bare = {
+    isDestroyed: () => false,
+    isFullScreen: () => false,
+    getNormalBounds: () => ({ x: 0, y: 0, width: 900, height: 700 }),
+  };
+  assert.strictEqual(captureWindowState(bare).alwaysOnTop, false);
+});
+
+test("round-trip: a pinned window restores pinned", () => {
+  const win = fakeWin({ normal: { x: 100, y: 80, width: 1100, height: 760 }, alwaysOnTop: true });
+  const restored = sanitizeWindowState(captureWindowState(win), OPTS);
+  assert.strictEqual(restored.alwaysOnTop, true);
+});
+
 // ── isVisibleOn ──
 
 test("isVisibleOn: window mostly on a second display is visible", () => {
@@ -106,10 +138,11 @@ test("isVisibleOn: only a sliver on-screen is NOT visible", () => {
 
 // ── captureWindowState ──
 
-function fakeWin({ normal, fullScreen = false, destroyed = false }) {
+function fakeWin({ normal, fullScreen = false, alwaysOnTop = false, destroyed = false }) {
   return {
     isDestroyed: () => destroyed,
     isFullScreen: () => fullScreen,
+    isAlwaysOnTop: () => alwaysOnTop,
     getNormalBounds: () => normal,
     // getBounds intentionally returns a different (fullscreen) frame to prove
     // captureWindowState prefers getNormalBounds.
@@ -120,7 +153,7 @@ function fakeWin({ normal, fullScreen = false, destroyed = false }) {
 test("captureWindowState uses getNormalBounds, not the fullscreen frame", () => {
   const win = fakeWin({ normal: { x: 12, y: 34, width: 1000, height: 700 }, fullScreen: true });
   const s = captureWindowState(win);
-  assert.deepStrictEqual(s, { x: 12, y: 34, width: 1000, height: 700, fullScreen: true });
+  assert.deepStrictEqual(s, { x: 12, y: 34, width: 1000, height: 700, fullScreen: true, alwaysOnTop: false });
 });
 
 test("captureWindowState returns null for a destroyed window", () => {

--- a/website/electron/window-state.js
+++ b/website/electron/window-state.js
@@ -66,6 +66,8 @@ function sanitizeWindowState(saved, opts = {}) {
   const displays = Array.isArray(opts.displays) ? opts.displays : [];
 
   const fullScreen = !!(saved && saved.fullScreen);
+  // Legacy saved states predate the key; !! coerces missing/odd values to false.
+  const alwaysOnTop = !!(saved && saved.alwaysOnTop);
 
   let width = isFiniteNum(saved && saved.width) ? saved.width : null;
   let height = isFiniteNum(saved && saved.height) ? saved.height : null;
@@ -76,7 +78,7 @@ function sanitizeWindowState(saved, opts = {}) {
     height = defaults.height;
   }
 
-  const result = { width, height, fullScreen };
+  const result = { width, height, fullScreen, alwaysOnTop };
 
   const x = isFiniteNum(saved && saved.x) ? saved.x : null;
   const y = isFiniteNum(saved && saved.y) ? saved.y : null;
@@ -101,6 +103,7 @@ function sanitizeWindowState(saved, opts = {}) {
 function captureWindowState(win) {
   if (!win || (typeof win.isDestroyed === "function" && win.isDestroyed())) return null;
   const fullScreen = typeof win.isFullScreen === "function" ? win.isFullScreen() : false;
+  const alwaysOnTop = typeof win.isAlwaysOnTop === "function" ? win.isAlwaysOnTop() : false;
   const b =
     (typeof win.getNormalBounds === "function"
       ? win.getNormalBounds()
@@ -108,7 +111,7 @@ function captureWindowState(win) {
         ? win.getBounds()
         : null) || {};
   if (!isFiniteNum(b.width) || !isFiniteNum(b.height)) return null;
-  return { x: b.x, y: b.y, width: b.width, height: b.height, fullScreen };
+  return { x: b.x, y: b.y, width: b.width, height: b.height, fullScreen, alwaysOnTop };
 }
 
 module.exports = {


### PR DESCRIPTION
Closes #2732

## What

Adds a checkable **Keep on Top** item to the desktop app's View menu on every platform (macOS, Windows, Linux), backed by `BrowserWindow.setAlwaysOnTop()`, with the preference persisted across relaunches.

## How

- **`website/electron/app-menu.js`** — new checkbox entry next to `togglefullscreen`, pure data + injected `alwaysOnTop` / `toggleAlwaysOnTop` deps (no electron import, matching the file's contract). Deliberately ships **no accelerator**: there is no cross-platform convention for always-on-top, and inventing a binding risks collisions.
- **`website/electron/main.js`** — `toggleAlwaysOnTop` targets the focused **dashboard** window via a shared `focusedDashboardWindow()` helper (extracted from the Settings/About `_mcView` resolution, so there is one resolution, not two). After flipping it reconciles the menu item's `checked` with the window's **actual** `isAlwaysOnTop()` read-back, so the checkmark cannot drift if the platform refuses. The whole flip+reconcile is guarded like neighboring handlers (window mid-teardown). Restore path: `alwaysOnTop` becomes a constructor option in `createWindow()` (no z-order flash). Persist path: the `persist` closure is hoisted to module-level `persistMainWindowState()` shared by the geometry listeners and the toggle.
- **`website/electron/window-state.js`** — the `windowState` blob (the module that already owns window persistence, per its exports contract) round-trips a new `alwaysOnTop` boolean: `captureWindowState` reads `isAlwaysOnTop()`, `sanitizeWindowState` coerces with `!!` so **legacy saved states lacking the key restore to `false`**.

Menu build order note: the app menu is built before `createWindow()`, so the checkbox seeds from the same persisted store value `createWindow()` restores from, not from a live window.

## Cross-platform

The item lives in the shared View template, so Windows and Linux get it by construction; nothing in it is darwin-gated. `setAlwaysOnTop`/`isAlwaysOnTop` are supported on all three platforms.

## Tests

- `app-menu.test.js`: checkbox present in View with `type: "checkbox"`, `id: "keep-on-top"`, `checked` mirrors the injected value (both truth values), no accelerator, click invokes the injected toggle; new deps added to `makeDeps`; item added to the shared click-order assertion. Runs on both platform shapes.
- `window-state.test.js`: `alwaysOnTop` round-trip (capture → sanitize), legacy state without the key → `false`, boolean coercion, absent `isAlwaysOnTop` method → `false`, pinned-window round-trip.
- **Fail-before verified**: 11 of the new assertions fail on unmodified sources, 39/39 pass with the change.
- Full electron suite: 858/858 pass (`npm test` in `website/electron`, as CI runs it).
- Website gates: `npx tsc -b` clean, `vitest run` 954 files / 15277 tests green, jscpd 0 clones.

## Screenshots

No renderer/SPA change — this is a native OS menu item, which Playwright/screenshot tooling cannot capture and the dashboard web UI does not render. The screenshot requirement therefore does not apply to this PR.

## Pre-push review

`spawn_run` was absent from the session's MCP registry (known intermittent symptom, #2502), so the two model-pinned pre-push reviewers could not be spawned. A contract-driven self-review against both charters (codex-review: correctness/security/cross-OS; claude-review + AUTOSDE: blocking-rule hits) was performed instead; it produced one hardening fix (the checked-state reconcile moved inside the teardown guard). The server-side review bots on this PR remain the authoritative gate.
