### PR TITLE
perf(frontend): cap vitest fork workers + heap to stop OOM job failures

### DIFF
--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -458,6 +458,19 @@ export default defineConfig({
     setupFiles: './integration/setup.ts',
     css: true,
     pool: 'forks',  // More stable than threads on ARM64 build fleet (avoids ERR_IPC_CHANNEL_CLOSED)
+    // Bound fork memory. Without a cap, vitest spawns one worker per core
+    // (os.availableParallelism); on a high-core fleet the aggregate RSS of that
+    // many full Node heaps — each retaining v8 coverage maps + happy-dom DOM
+    // state across the ~950 files it touches — exceeds host RAM under
+    // ``--coverage``. The kernel then OOM-kills a worker, which vitest surfaces
+    // as "Worker exited unexpectedly" (1 unhandled error → the job fails) even
+    // though every test passed. maxWorkers caps concurrency regardless of core
+    // count, and the per-worker --max-old-space-size gives each fork a heap
+    // ceiling that fails a genuine leak loudly instead of dragging the host down.
+    // (Vitest 4 pool rework: these are top-level, not poolOptions; minWorkers
+    // was removed — only maxWorkers has effect.)
+    maxWorkers: 4,
+    execArgv: ['--max-old-space-size=4096'],
     // Default 5s is too tight for tests that ``await import(...)`` inside the
     // body: under a full concurrent forks run the collect phase can starve the
     // dynamic import past 5s and it times out. 15s gives headroom for
@@ -466,6 +479,11 @@ export default defineConfig({
     include: ['integration/**/*.test.{ts,tsx}', 'src/**/*.test.{ts,tsx}'],
     onConsoleLog: (log) =>
       !log.includes('was not wrapped in act(') &&
+      // TipCard's useTipTrigger issues tipsStatus/tipsNext queries; the 232
+      // tests that vi.mock('../api/client') without stubbing those two fields
+      // leave queryFn undefined, so React Query logs "No queryFn was passed"
+      // ~44x per file. Pure noise — the component under test is never TipCard.
+      !log.includes('No queryFn was passed') &&
       // Insurance for the defense-in-depth path above: if a widget iframe
       // <script>/page load ever reaches happy-dom's disable-loading settings
       // (rather than being answered by the msw fallback first), happy-dom logs a


### PR DESCRIPTION
## Problem
The frontend CI test job (`frontend-test` in `.github/workflows/ci.yml`) intermittently fails with **all tests passing**. The failure is `Worker exited unexpectedly` — vitest counts a crashed worker as 1 unhandled error, so the job exits 1. `main` itself flakes on this; a re-run clears it. Coverage Gate and PR Readiness go red downstream, so a spurious crash blocks unrelated PRs.

Separately, the suite logs ~44 `No queryFn was passed to your queries` warnings **per test file** (720 lines on a single ChatPage test) — pure noise that buries real output.

## Why it matters
A base-wide infra flake that reds every PR's readiness is a recurring tax: contributors re-run CI, mistrust the signal, and lose ~16 min per spurious cycle. The log noise makes triaging genuine failures harder.

## Fix (symptoms → root cause → change)
- **Symptom:** worker crash under `--coverage`, only on the full run, only sometimes.
- **Root cause:** `pool:'forks'` with **no worker cap and no heap ceiling**. vitest spawns one fork per core (`os.availableParallelism`); each fork is a full Node heap retaining v8 coverage maps + happy-dom DOM state across the ~950 files it touches. On a high-core runner the aggregate RSS exceeds host RAM → the kernel OOM-kills a fork → `Worker exited unexpectedly`.
- **Change:** bound fork memory in `website/vite.config.ts` with top-level **`maxWorkers: 4`** (caps concurrency regardless of core count) and **`execArgv: ['--max-old-space-size=4096']`** (per-worker heap ceiling — a genuine leak now fails loudly instead of dragging the host down). Uses the Vitest 4 pool-rework shape (top-level, not `poolOptions`; `minWorkers` was removed and has no effect).
- **Noise:** add `!log.includes('No queryFn was passed')` to the existing `onConsoleLog` chain. Chosen over a global mock because 232 tests fully replace the `../api/client` module, so a global stub wouldn't reach them; the console filter covers all uniformly. Tradeoff: it also hides a genuine missing-`queryFn` bug — acceptable since the component under test is never TipCard.

Sharding the suite for wall-clock (duration-balanced, like `backend-test`) is deliberately a **separate follow-up PR**; this PR is the minimal root-cause fix for the spurious red.

## Tests
No new tests — this is test-infra config. Verified behavior directly:
- `npx vitest run` slice passes with **zero** Vitest-4 `poolOptions` deprecation warnings (the naive `poolOptions.forks` shape warned; the top-level shape is clean).
- `npx tsc -b` green.
- Noise filter proven by before/after on `ChatPage.sendDuringDictation.test.tsx`: **720** `No queryFn` lines without the filter → **0** with it.

## Manual verification
Config-only change; full-suite crash is load-dependent and can't be deterministically reproduced locally, but the memory-bound is the documented root cause and `maxWorkers` provably caps fork count. CI on this PR exercises the real full `--coverage` run.

## Screenshots
N/A — no user-visible UI change.
