### PR TITLE
feat(backup): restore into live state, and redact what leaves the host

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -238,7 +238,6 @@ src/kiro_crew/dashboard/handlers/side.py
 src/kiro_crew/dashboard/handlers/source_providers.py
 src/kiro_crew/dashboard/handlers/sso_login.py
 src/kiro_crew/dashboard/handlers/steering.py
-src/kiro_crew/dashboard/handlers/taskrunner.py
 src/kiro_crew/dashboard/handlers/terminal.py
 src/kiro_crew/dashboard/handlers/themes.py
 src/kiro_crew/dashboard/handlers/tunnel.py
@@ -246,7 +245,6 @@ src/kiro_crew/dashboard/handlers/webapp_preview.py
 src/kiro_crew/dashboard/handlers/weixin_qr.py
 src/kiro_crew/dashboard/handlers_channel.py
 src/kiro_crew/dashboard/handlers_cloud.py
-src/kiro_crew/dashboard/handlers_instances.py
 src/kiro_crew/dashboard/loop_watchdog.py
 src/kiro_crew/dashboard/port_reclaim.py
 src/kiro_crew/dashboard/routes/skills.py
@@ -298,7 +296,6 @@ src/kiro_crew/history.py
 src/kiro_crew/hooks.py
 src/kiro_crew/image_artifacts.py
 src/kiro_crew/imaging.py
-src/kiro_crew/instances/ssh_tunnel_manager.py
 src/kiro_crew/kiro_prerequisite.py
 src/kiro_crew/knowledge/agent_fetch.py
 src/kiro_crew/knowledge/agent_source.py
@@ -354,7 +351,6 @@ src/kiro_crew/mcp_tools/control.py
 src/kiro_crew/mcp_tools/knowledge.py
 src/kiro_crew/mcp_tools/skills.py
 src/kiro_crew/mcp_tools/spawn.py
-src/kiro_crew/mcp_tools/workflows.py
 src/kiro_crew/mcp_utils.py
 src/kiro_crew/messaging/link.py
 src/kiro_crew/metrics/http_metrics.py
@@ -401,9 +397,6 @@ src/kiro_crew/slack/sessions_view.py
 src/kiro_crew/subagent_persistence.py
 src/kiro_crew/subagent_scale.py
 src/kiro_crew/suggestions.py
-src/kiro_crew/task_models.py
-src/kiro_crew/task_planner.py
-src/kiro_crew/taskrunner.py
 src/kiro_crew/testing/channel_fixtures.py
 src/kiro_crew/testing/fake_acp_backend.py
 src/kiro_crew/tips.py
@@ -414,8 +407,6 @@ src/kiro_crew/webhooks.py
 src/kiro_crew/weixin/client.py
 src/kiro_crew/workflows/agent_exec.py
 src/kiro_crew/workflows/context.py
-src/kiro_crew/workflows/runner.py
-src/kiro_crew/workflows/service.py
 test/conftest.py
 test/fake_mcp_app_server.py
 test/metrics/test_context_occupancy.py
@@ -672,7 +663,6 @@ test/test_dashboard_worktree_coverage.py
 test/test_dashboard_ws_offloop_fanout.py
 test/test_dashboard_ws_task_tracking.py
 test/test_dashboard_yolo_startup.py
-test/test_decompose_yaml.py
 test/test_deferred_disposition_ratchet.py
 test/test_delete_message.py
 test/test_denied_commands_api.py
@@ -790,7 +780,6 @@ test/test_handlers_channel_presets.py
 test/test_handlers_files_upload.py
 test/test_handlers_mcp_coverage.py
 test/test_handlers_memory_coverage.py
-test/test_handlers_taskrunner_coverage.py
 test/test_heartbeat_atomic_merge.py
 test/test_heartbeat_cycle_recycle.py
 test/test_heartbeat_prompt_deliver.py
@@ -816,7 +805,6 @@ test/test_installer_distro.py
 test/test_installer_node_floor.py
 test/test_installer_shim_and_cleanup.py
 test/test_instance_credential_pairing.py
-test/test_instances.py
 test/test_instances_search_federation.py
 test/test_interactions_shortcut.py
 test/test_ios_simulator_preview_skill.py
@@ -891,7 +879,6 @@ test/test_mcp_caller.py
 test/test_mcp_core.py
 test/test_mcp_core_arg_crash.py
 test/test_mcp_core_audit_e.py
-test/test_mcp_core_coverage.py
 test/test_mcp_core_more_coverage.py
 test/test_mcp_core_set_project.py
 test/test_mcp_core_spawn_sub_agents.py
@@ -950,7 +937,6 @@ test/test_meetings_dictionary.py
 test/test_meetings_providers.py
 test/test_meetings_routes.py
 test/test_meetings_session.py
-test/test_members.py
 test/test_memory_benchmark_workflow.py
 test/test_memory_selfheal.py
 test/test_merge_queued_messages.py
@@ -1198,7 +1184,6 @@ test/test_tailnet_e2e.py
 test/test_tailnet_origin.py
 test/test_tailnet_serve.py
 test/test_tailnet_session_url.py
-test/test_taskrunner.py
 test/test_taskrunner_atomic_persistence.py
 test/test_taskrunner_autoapprove.py
 test/test_taskrunner_coverage.py

--- a/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
@@ -43,6 +43,7 @@ import threading
 from pathlib import Path
 from typing import Any, Optional
 
+from kiro_crew import snapshot
 from kiro_crew.apps.builtins.aws_control.backend import storage
 from kiro_crew.apps.manager import app_data_dir
 from kiro_crew.atomic_write import atomic_write
@@ -244,13 +245,27 @@ def run_snapshot_backup(account: str, profile: str, region: str, bucket: str) ->
         if not archives:
             raise RuntimeError("snapshot build produced no archive")
         archive = archives[-1]
+        # The bytes that LEAVE are redacted when the operator has opted in; the local
+        # bundle is never touched. This is the one part of an off-host backup the app does
+        # not own: the bucket, its hardening, the consent grant and the transport are all
+        # here, but rewriting the payload is the snapshot format's own business, so the
+        # snapshot module owns it and this is where it attaches.
+        #
+        # Deliberately BEFORE `_authorize_upload` and the push: a redaction that cannot be
+        # completed must stop the upload rather than fall through to sending the bundle
+        # unredacted, and `RedactionFailed` carries the reason (an unprovable payload
+        # database, a file that is not text, an unreadable switch) for the caller to
+        # surface. `tmp` is this function's own directory and is removed with it, so the
+        # redacted copy never outlives the push.
+        redacted = snapshot.prepare_redacted_copy(archive, Path(tmp), list(snapshot.COMPONENTS))
+        payload = redacted or archive
         # snapshot_main names by second-resolution timestamp; a racing pair
         # would collide on the key, so the pushed key carries its own
         # entropy (the _stamp shape) rather than trusting the file name.
         key = f"snapshots/kirocrew-snapshot-{_stamp()}.tar.gz"
         _authorize_upload(account, profile, region)
-        storage.put_file(profile, region, bucket, "backup", key, str(archive), account=account)
-        return _record_run(account, KIND_SNAPSHOT, key, archive.stat().st_size)
+        storage.put_file(profile, region, bucket, "backup", key, str(payload), account=account)
+        return _record_run(account, KIND_SNAPSHOT, key, payload.stat().st_size)
 
 
 #: ``O_NOFOLLOW`` refuses to open a symlink at all, which is what makes the

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1369,6 +1369,29 @@ Examples:
             "MANIFEST.json records that it was staged unpinned."
         ),
     )
+    snap_parser.add_argument(
+        "--components",
+        default=None,
+        help="Comma-separated components to include (default: all); see restore --list-components",
+    )
+    snap_parser.add_argument(
+        "--purpose",
+        default="backup",
+        choices=("backup", "share"),
+        help=(
+            "backup = restoring onto a host you control, keeps credential-bearing "
+            "components (the default, and the only one that produces a bundle today); "
+            "share = leaves your control, so it carries only components certified free "
+            "of credential material — no component is certified yet, so this currently "
+            "refuses rather than emitting a bundle that has not been checked"
+        ),
+    )
+
+    # Retired, and defined only so it fails with a pointer instead of a bare argparse
+    # error. Dropping it entirely would still fail loudly ("unrecognized arguments"), but
+    # an operator whose muscle memory or old cron line still says `--to s3://bucket/prefix`
+    # is better served by being told where that capability went than by exit 2.
+    snap_parser.add_argument("--to", default=None, help=argparse.SUPPRESS)
 
     rest_parser = cli_help.add_command(sub, "restore")
     rest_parser.add_argument("snapshot", nargs="?", help="Path to snapshot .tar.gz")

--- a/src/kiro_crew/docs/snapshot-and-restore.md
+++ b/src/kiro_crew/docs/snapshot-and-restore.md
@@ -12,6 +12,7 @@ want a routine backup, schedule the command yourself.
 ```bash
 kirocrew snapshot                                     # write to ~/.kiro/crew/snapshots
 kirocrew snapshot ~/my-snapshots --keep 3             # custom dir, prune to 3
+kirocrew snapshot --components memory                 # just memory, ~20 MB
 kirocrew snapshot --list                              # list existing snapshots
 kirocrew restore snapshot.tar.gz                      # auto-detects replace vs merge
 kirocrew restore snapshot.tar.gz --components memory,crons
@@ -28,13 +29,19 @@ gateway on that port is not this instance.
 
 | Component | Files |
 |-----------|-------|
-| memory | `memory.db`, `memory_index.db` |
+| memory | `memory.db`, `memory_index.db`, `workspace/memory/`, `workspace/knowledge/` |
 | crons | `crons.json` |
 | config | `config.json`, `session_map.json`, `hooks.json`, `project_dir`, `workspace_dir` |
 | skills | `skills/` directory |
 | workspace | `workspace/`, `plan_memory/` directories |
 | notifications | `notifications.jsonl` |
 | security | `telemetry_salt` |
+
+`memory` is self-contained: it names the markdown half of memory (preferences,
+projects, history) and the knowledge base explicitly, so `--components memory`
+restores your recall without also restoring every unrelated working file in
+`workspace/`. Selections may overlap — asking for both `memory` and `workspace`
+stages the shared paths once.
 
 `workspace/hygiene_data/` and `workspace/insert_facts*.py` are excluded: they are
 large and regenerable.
@@ -44,22 +51,205 @@ from every snapshot, and is regenerated on the restoring host. That keeps each
 machine's audit-log signatures bound to the machine that wrote them, so a copied
 snapshot cannot be used to forge audit entries elsewhere.
 
-### Options
+## Purpose: backup vs share
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `OUTPUT_DIR` | `~/.kiro/crew/snapshots` (or `snapshot_dir` in config) | Where to write the tarball |
-| `--keep N` | 7 | Prune the output dir to the N most recent snapshots |
-| `--list` | | List existing snapshots and exit |
+Every bundle records why it exists, and each component declares whether it is safe to
+hand to another person.
 
-The tarball is written to a temporary name and renamed into place only once it is
-complete, so an interrupted run cannot leave a half-written archive that looks
-like a valid backup. It is then locked down to owner-only permissions before the
-command reports success.
+| Purpose | Meaning | Today |
+|---------|---------|-------|
+| `backup` (default) | Restoring onto a host you control | Everything selected rides; the LOCAL archive is unredacted — that is the point |
+| `share` | Leaving your control | **Refused for every component** |
 
-Before copying the memory database, Kiro Crew flushes its write-ahead log. If the
-gateway holds the lock it prints a warning and proceeds anyway: the SQLite backup
-API still produces a consistent point-in-time copy that includes committed data.
+## What leaves the host, and what redaction is for
+
+The local archive and the off-host copy are the same bytes unless you ask otherwise.
+
+What protects the uploaded bundle is the destination, not a rewrite: the bucket is created
+private and every upload re-asserts the whole set before sending a byte — all four
+public-access blocks, default encryption, ACLs disabled via `BucketOwnerEnforced`,
+versioning, no bucket policy at all, and the object write pinned to the expected owner
+account. Any of those missing or unreadable refuses the upload. The audience for the
+uploaded copy is therefore the same as the audience for your local disk: you.
+
+On top of that you can opt IN to rewriting the copy that leaves, by writing
+`{"redact_uploads": true}` to `redaction.json` inside your backup directory. Then both
+mandatory outbound redactors run over the throwaway copy, and `config.json`'s token plus
+anything credential-shaped in a note or a memory row is replaced with an inert tag.
+
+It is off by default because it is not free. Replacing a credential is a variable-length
+edit, so any file whose structure depends on byte offsets — an archive, a PDF, most binary
+container formats — comes out the other side invalid. Paying that to re-protect a copy only
+you can read is the wrong default. Turn it on when the bucket's audience is genuinely wider
+than you believe, or when you want the off-host copy to be inert on principle.
+
+One pass runs only here. The shared redactors also run over live model output and tool
+results, where rewriting something that merely resembles a key corrupts what you are
+reading, so they recognise specific vendor formats and specific field names. That leaves
+real shapes uncovered — a bot token whose format they have no pattern for, or your own
+`api_key = "…"` with an opaque value. This copy is a throwaway on its way off the host and
+your complete archive stays local, so the egress pass can afford to be broader: it also
+replaces any long quoted value assigned to a credential-ish field name, and any bearer
+token shaped as three dot-separated segments. That is the same trade the over-reach note
+below describes, made deliberately in the one place where the cost is one note's text
+rather than a corrupted answer.
+
+Two consequences worth knowing before you turn it on:
+
+- **Restoring a redacted off-host copy gives you working memory and inert credentials.** The
+  shape is complete and the databases are valid; the fields that authenticate are not.
+  Re-enter them after restoring. The restore prints what was redacted, so you are told
+  rather than left to discover it.
+- **Redaction is pattern-based, so it can over-reach.** A note holding something that
+  merely looks like a key can lose that text in the off-host copy. The local archive is
+  unaffected, and the per-path replacement counts are printed at upload and again at
+  restore so you can judge whether a count looks wrong.
+
+Databases are redacted value by value through SQL rather than over their bytes. That is
+not a stylistic choice: the redactors substitute a tag, so they change length, and
+rewriting a SQLite file's bytes produces a file SQLite cannot open — which the restore
+path would then correctly refuse as corrupt.
+
+Search indexes and files whose only purpose is to be secret are left out of the
+outbound copy entirely rather than blanked, because an inert key present in the bundle
+is indistinguishable from a rotated one. Restore already reports an absent index and
+what to rebuild. Those files are matched by their **exact position** in the bundle, not
+by name: your workspace may hold a `telemetry_salt` or a `memory_index.db` of your own,
+and leaving out a file that merely shares a name with one of the product's would be
+losing your data, not protecting it.
+
+Values are redacted on what they hold rather than on the column's declared type, so a
+credential stored as binary is rewritten too. Bytes make the round trip through a
+byte-preserving codec and are only written back when something actually matched, so
+embeddings and other genuine blobs come out identical.
+
+A database's **schema** is checked as well as its rows. A key can be written into a column
+default, a view's body or a trigger, and none of those are values any row scan reaches.
+Schema text also cannot be rewritten the way a value can — changing it means rebuilding the
+object — so a database in that state is one this pass cannot clean, and the upload is
+refused either way. Nothing is deleted to make an upload possible: `memory.db` and the
+Knowledge Library are what the backup exists to carry, so sending the bundle without one
+of them would report success and restore nothing.
+
+Rows are scanned to a **fixpoint**, not once. An update fires the database's own triggers,
+and a trigger can copy the pre-update value into a table the scan has already cleaned, so a
+single pass can leave a credential behind in a place it already visited. Each pass reports
+its own replacements and the scan stops when a pass changes nothing. A database that keeps
+moving is one that cannot be shown clean, so the upload is refused and the database is
+named rather than removed.
+
+The **manifest** is redacted too, after it is stamped — it is the one file guaranteed to be
+in the upload, and the stamp itself writes paths and error text into it. It is checked to
+still parse afterwards, because a manifest that does not is a bundle that cannot be
+restored.
+
+Whether a file is text is decided by **decoding** it, not by its name — a workspace holds
+whatever you put there, and a suffix list would classify your `.py`, `.csv` or
+extension-less notes as opaque. A file that genuinely does not decode (an image, an
+archive) cannot be shown free of credentials, so the **upload is refused** and those
+files are named. They are not removed: a restore that reports success while quietly
+lacking your own files is worse than an upload that stops and tells you. Narrow the
+selection with `--components`, or turn redaction off for that run. A `.db` that is not
+a database the product ships is treated the same way, and so is a database the product
+DOES ship: whichever it is, the file is kept and the upload refuses, naming it and why.
+Your local snapshot is complete and unaffected in every one of these cases.
+
+Turning it on is a file, not a setting in `config.json`, and that placement is the point.
+`config.json` is readable and writable by the agent, so a switch living there could be
+flipped by the agent itself. The fence matters in BOTH directions now: an agent that could
+turn this on could corrupt your off-host copy, and one that could turn it off could publish
+a credential into the bucket. The backup directory is already fenced for the same reason its
+destination record is — neither the agent's file tools nor any shell form can read or write
+it. Only you can.
+
+Four cases, and none of them is a silent guess:
+
+- **No file** — off. The default, and it needs no file.
+- **`{"redact_uploads": true}`** — on.
+- **`{"redact_uploads": false}`** — off, written down explicitly, which is allowed.
+- **Anything else** — a file that parses to neither, an unreadable one, or `"true"` as a
+  string. The upload refuses and names the file. You wrote it on purpose, so guessing off
+  would ignore a request to scrub and guessing on would rewrite files you may not have
+  meant to touch. Your local snapshot is already written and is unaffected.
+
+If redaction is on and cannot be completed, the upload is refused; it never falls back to
+sending the unredacted bundle.
+
+`--purpose share` currently refuses whatever you select, and that is deliberate rather
+than unfinished. Whether a component is safe to share is a question about its
+**content**, not its shape: a workspace file, a skill, a cron's `env` map, a
+notification body or a lesson you pasted a token into can each carry a credential, and
+staging cannot tell. Marking components share-safe one at a time was tried during
+review and guessed wrong twice, so nothing claims it until the redaction work behind
+it exists. The purpose, the per-component declaration and the refusal are all live, so
+the first certified component only has to change its own declaration.
+
+For now, use `--purpose backup` — restoring onto a host you control is what this
+feature is for. The bundle's manifest records the purpose and each component's
+declaration, so a reader of a bundle can tell which they are holding.
+
+A component added without a policy declaration is refused at staging rather than
+defaulting to permissive, so a new component cannot inherit a permissive value by
+omission.
+
+## Off-host copies
+
+A snapshot written only to `~/.kiro/crew/snapshots` does not survive losing the machine,
+which is the whole point of backing up. Getting it off the host is not this module's job:
+the **AWS Control** app owns the destination and everything that protects it. It creates
+one private drive bucket per account, re-asserts the whole posture on every write (public
+access blocked, default encryption, ACLs disabled, object ownership enforced, versioning
+on), routes every call through a single audited `aws` chokepoint, takes consent through the
+existing AWS-usage grant, and runs the nightly schedule. Set it up and read its state from
+that app's console; there is no destination flag here any more.
+
+What stays here is the one thing a hardened destination does not do: **rewriting the bytes
+that leave**. A private bucket still holds whatever was put into it, and a bundle restored
+somewhere else carries every secret the original held.
+
+### The redaction switch
+
+Redacting the outbound copy is opt-in, and the switch lives at
+`<data home>/backup/redaction.json`:
+
+```json
+{"redact_uploads": true}
+```
+
+It is **off by default**, deliberately. Substituting a placeholder changes a value's
+length, and any payload whose format depends on byte offsets is invalidated by that. So
+turning this on trades exact fidelity for a safer copy, which is a call to make rather than
+a default to inherit.
+
+No file means off, and that is the common case. If the file IS there, the value must be
+exactly `true` or `false`: a `"true"` string or a `1` makes the upload refuse and name the
+file rather than guess which way you meant it, because resolving it either way would decide
+on your behalf whether your files get rewritten.
+
+When it is on:
+
+- Only the OUTBOUND copy is rewritten. The local archive is never touched: it sits on the
+  machine that already holds these secrets, and redacting it would damage the only copy
+  that restores complete.
+- Databases are rewritten value-by-value through SQL rather than over their bytes, and
+  every outbound database is rebuilt afterwards so no old value survives in page slack.
+- A pass that cannot complete **refuses the send**. "Could not redact" never falls through
+  to "send it unredacted", so a redaction failure costs you that upload, not your secrets.
+- Content that cannot be proven safe is refused rather than shipped: a file whose bytes are
+  opaque, a database that fails its integrity check, a text container that declares its own
+  extents, or a database whose triggers keep reintroducing the values the scan just removed.
+
+The agent cannot reach this file. It is fenced at the same level as the command deny list
+and the computer-use enable, for reading as well as writing -- flipping it off is the
+attack, and reading it tells an attacker whether the store is currently being scrubbed.
+
+### Restoring a bundle that came from off-host
+
+`kirocrew restore` takes a **local path**. An `s3://` argument is refused, with a message
+telling you to fetch the bundle through the AWS Control app first and then restore the file
+it hands back. That app deliberately lands a fetched archive in its own restore directory
+and returns the path rather than hot-swapping it under a running gateway: restoring into
+live state is this module's job, and it needs the gateway stopped (below).
 
 ## Restore
 
@@ -92,6 +282,26 @@ printed, so a wrong-snapshot restore is recoverable.
 So a merge never destroys anything on the receiving machine. If you want the
 snapshot to win, use `--mode replace`.
 
+#### Known limitation: the knowledge database is not row-merged
+
+`workspace/knowledge/knowledge.db` follows the file rule above rather than the
+row-level rule that `memory.db` gets. If the receiving machine already has a
+knowledge database, a merge **keeps that one and does not import the snapshot's
+rows**. The restore says so on the spot rather than reporting a silent success.
+
+The reason is that combining two knowledge libraries is not a copy: that database
+carries a full-text index plus foreign keys spanning its `sources`, `items`,
+`mentions` and `source_locations` tables, so a correct merge has to remap keys,
+rebuild the derived index, and first decide what makes two documents the same
+document across two machines. `memory.db` gets row-level merging because that
+merge is written per table for its own schema.
+
+Until the same is written for the knowledge schema, the two ways to move a
+knowledge library are:
+
+- `--mode replace`, which takes the snapshot's knowledge database whole; or
+- restore onto a machine that has no knowledge database yet, where nothing is
+  being merged and the snapshot's copy lands directly.
 ### Options
 
 | Flag | Description |
@@ -106,10 +316,25 @@ After a restore, run `kirocrew restart` so the gateway picks up the new state.
 
 ### Integrity check
 
-A restore runs an integrity check on the memory database and exits non-zero if it
-fails, so a corrupted archive is a loud failure rather than a quietly broken
-memory. If the full-text index (`memory_index.db`) is missing you get a warning:
-search keeps working, but the index needs to rebuild first.
+In `replace` mode every database the snapshot carries is checked **before any live
+state is touched** — `memory.db`, `memory_index.db`, and
+`workspace/knowledge/knowledge.db`. A snapshot whose database is unreadable or
+fails its integrity check is refused with a non-zero exit and nothing is
+replaced, so a corrupt archive cannot leave the data home sitting on it. This
+matters most for a bundle fetched from S3, which is untrusted input regardless of
+whose bucket held it.
+
+Other `.db` files inside a restored folder are only checked when they open as a
+database at all, so a file that was never SQLite — a Windows `Thumbs.db`, say —
+does not block a restore.
+
+`merge` mode validates its own source before importing rows and skips a component
+whose incoming database is unsound, rather than failing the whole command: a merge
+cannot corrupt the receiving database, because it copies rows out of the incoming
+one instead of putting it in place.
+
+If the full-text index (`memory_index.db`) is missing you get a warning: search
+keeps working, but the index needs to rebuild first.
 
 ## Security
 
@@ -129,7 +354,8 @@ the way out.
 
 ## Scheduling your own backups
 
-There is no built-in backup schedule. To get one, add a cron job that runs the
-command, for example by asking the agent to schedule `kirocrew snapshot --keep 7`
-daily. Verify it afterwards with `kirocrew snapshot --list`: an unverified backup
-job is the same as no backup.
+`kirocrew snapshot` runs only when something runs it. OFF-HOST backups are scheduled
+by the AWS Control app, which drives a nightly run of its own. For a LOCAL-only
+schedule, add a cron job that runs the command -- for example by asking the agent to
+schedule `kirocrew snapshot --keep 7` daily. Verify it afterwards with
+`kirocrew snapshot --list`: an unverified backup job is the same as no backup.

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -5011,6 +5011,21 @@ _CREW_SECRET_LEAVES: list[str] = [
     # gateway's own startup reader opens it directly rather than through this
     # gate, so both keep working.
     "live_target.json",
+    # Holds `backup/redaction.json`, the switch that decides whether a bundle
+    # leaving this machine is redacted first. An agent that could write it would
+    # turn redaction off and every later upload would carry the operator's
+    # secrets verbatim; an agent that could read it learns whether the memory
+    # store is currently being scrubbed. Flipping it is the attack and reading it
+    # is reconnaissance, so this needs read AND write protection, not just write.
+    #
+    # The DIRECTORY is classified, not just the leaf inside it. Naming only the
+    # leaf leaves the container writable, and a writable container is the same
+    # hole one level up: replace `backup/` with a symlink and the protected leaf
+    # now resolves somewhere unprotected, where the switch can be rewritten at
+    # will. Restore's rollback copies live at `pre-restore-<ts>/`, not here, so
+    # nothing legitimate is shut out, and the product's own reader opens the file
+    # directly rather than through this gate.
+    "backup",
     # The computer-use primary enable ({enabled, allowed_apps, extra_denied_apps}).
     # Same class of control as ``denied_commands.json`` directly above, and here
     # for the same reason: flipping ``enabled`` grants full desktop observation

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -143,6 +143,40 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "passes are idempotent.",
     ),
     (
+        "Off-host backup uploads (opt-in)",
+        "snapshot_redact.py",
+        "The copy of a backup bundle that leaves the machine for object storage. The "
+        "destination is not this module's business: the AWS Control app owns the bucket, "
+        "its hardening, the consent grant and the transport, and refuses to send at all "
+        "if that posture is missing or unreadable. What lives here is the one thing a "
+        "hardened destination does not do -- rewriting the bytes that leave -- because a "
+        "private bucket still holds whatever was put in it, and the operator's own "
+        "account is not the only place a restored bundle can end up. An operator opts IN "
+        "to rewriting the outbound copy through the credential + exfiltration-URL chain; "
+        "it is OFF by default because substituting a tag changes length, which "
+        "invalidates any format that depends on byte offsets. When it is on, databases "
+        "are rewritten value-by-value through SQL rather than over their bytes, and every "
+        "outbound database is rebuilt so no old value survives in page slack. A pass that "
+        "cannot complete refuses the send rather than falling through to an unredacted "
+        "one. The LOCAL archive is never redacted either way: it does not cross the "
+        "boundary, and rewriting it would damage the only copy that restores complete.",
+    ),
+    (
+        "Off-host backup pushes (the boundary itself)",
+        "apps/builtins/aws_control/backend/backup.py",
+        "Where a bundle actually leaves the machine. This module runs no scanner itself: "
+        "the only redaction it performs is the call into `snapshot.prepare_redacted_copy`, "
+        "which runs the full credential + exfiltration-URL chain in `snapshot_redact.py` "
+        "(the row above). It is named here anyway because the call ORDER is the control -- "
+        "redaction runs before the upload is authorized and before any bytes reach the "
+        "transport, so a redaction that raises stops the push instead of letting it "
+        "proceed unredacted, and this module pushes whatever the seam returns: the "
+        "redacted copy when the operator opted in, the original when they did not. "
+        "Reversing those two steps would leave the guarantee intact on paper while "
+        "sending the secrets anyway, which is why the boundary gets its own row rather "
+        "than being left implicit in the module that computes the copy.",
+    ),
+    (
         "Session intent summaries",
         "session_summary.py",
         "Intent-summary payloads persisted to the `.intents` sidecar and served by "
@@ -1098,6 +1132,12 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
 # catches an omission.
 NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
     {
+        # Drives the backup redaction pass and reports what it did, but applies no
+        # redactor itself: the outbound bytes are rewritten in `snapshot_redact.py`,
+        # which is the registered sink. What matches the call-site scan here are the
+        # orchestration and reporting names (`_redacted_upload_copy`,
+        # `_report_redaction`, `_report_redacted_bundle`).
+        "snapshot.py",
         # Inbound / gate-side: redacts what comes IN or what a gate logs, not what
         # goes out to a human.
         "context.py",

--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib
 import json
 import os
 import re
@@ -13,10 +14,16 @@ import stat as _stat
 import tarfile
 import tempfile
 from contextlib import closing
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import TYPE_CHECKING, Any, Callable
 
 from kiro_crew import pinned_fs, platform_compat
+
+if TYPE_CHECKING:
+    from kiro_crew import snapshot_redact
 
 try:
     import pysqlite3 as sqlite3
@@ -28,7 +35,6 @@ try:
 except Exception:  # pragma: no cover - optional during early/standalone import
     _DASHBOARD_PORT = int(os.environ.get("KIROCREW_PORT", 5476))
 
-VALID_COMPONENTS = ("memory", "crons", "config", "skills", "workspace", "notifications", "security")
 
 # Files that must always have 0o600 permissions in snapshots and on restore.
 SECURITY_SENSITIVE_FILES: frozenset = frozenset({"sel_hmac.key", "telemetry_salt"})
@@ -52,6 +58,93 @@ _TELEMETRY_SALT_BYTES = 32
 # file, so a root beacon file is never staged in the first place. The
 # id-cloning hazard is closed by that non-selection, not by a basename filter.
 NEVER_SNAPSHOT_FILES: frozenset = frozenset({"sel_hmac.key"})
+
+
+def _redactor() -> Any:
+    """The outbound redaction pass, imported on first use.
+
+    `snapshot` is on the gateway's boot path, so importing the redaction code here would
+    put it there too -- and a gateway never redacts anything. Resolved when a command that
+    actually prepares an outbound copy asks for it, so `kirocrew gateway` reaches
+    readiness without loading it. A ratchet compares the boot module set against the base
+    branch's.
+    """
+    return importlib.import_module("kiro_crew.snapshot_redact")
+
+
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]")
+
+
+def _escape_one(ch: str) -> str:
+    """Render one stripped character in a form that cannot be re-interpreted.
+
+    Two widths, because a single `\\xNN` spelling would be a lie for a code point above
+    0xFF: `\\x202e` reads as `\\x20` followed by a literal `2e`, which is exactly the kind
+    of ambiguous output this function exists to prevent.
+    """
+    code = ord(ch)
+    return f"\\x{code:02x}" if code < 0x100 else f"\\u{code:04x}"
+
+
+def _safe_name(value: object, default: str = "unknown", limit: int = 300) -> str:
+    """Render a name that came out of an ARCHIVE printable.
+
+    Tar member names, manifest keys and archive root directories are all chosen by
+    whoever wrote the bundle. Printing one raw means the terminal INTERPRETS whatever
+    escape sequences it holds: the cursor moves, lines get overwritten, and a hostile
+    archive can dress itself up as a different, expected one -- right above the prompt
+    where the operator decides whether to restore it. Two of these sites print while
+    REJECTING a hostile entry, so the raw name there is precisely the attacker's payload.
+
+    The escaping itself used to live beside the off-host destination code, because its
+    first caller printed S3 object keys. That destination is now the AWS Control app's,
+    and what is left to escape is a name out of an untrusted archive -- so the helper
+    lives with its remaining caller and its reason is stated in those terms. The length
+    is capped so one very long name cannot flood the view.
+    """
+    cleaned = _CONTROL_CHARS.sub(lambda m: _escape_one(m.group()), str(value if value else default))
+    if len(cleaned) > limit:
+        cleaned = cleaned[:limit] + "…(truncated)"
+    return cleaned
+
+
+def _rejection_recording_filter(
+    rejected: list[str],
+) -> "Callable[..., tarfile.TarInfo | None]":
+    """`_data_filter`, plus a record of every entry it DROPPED for a structural reason.
+
+    Extraction prints a warning and drops a rejected entry, then extraction continues -- so a
+    bundle can arrive at the restore missing part of its payload while the manifest still
+    declares it. In replace mode that is destructive rather than merely incomplete: the memory
+    trees are cleared unconditionally (a tree the archive lacks must not be kept) and nothing
+    replaces the one that was dropped.
+
+    This is the ONLY layer where the two cases are distinguishable. Measured: at the mutation
+    phase a rejected link and an archive that never carried the tree are byte for byte the same
+    state -- the staged tree is simply absent -- so the prescribed check there ("clear only when
+    the source is a directory") cannot tell them apart, and it would revert the unconditional
+    clear that a documented defect required. Extraction, by contrast, knows.
+
+    A `NEVER_SNAPSHOT_FILES` drop is NOT recorded: those are deliberate and expected. Nor is a
+    rejection anywhere OUTSIDE a tree that replace clears -- and that limit is the point.
+    `test_symlink_filtered_out` states the contract for those: a hostile entry injected into an
+    otherwise sound bundle is dropped and the restore SUCCEEDS (`assert ret == 0`). Refusing on
+    any rejection at all was the prescribed shape and breaks three of those tests. What makes the
+    cleared trees different is that dropping an entry there converts into DELETION of the
+    operator's own tree, rather than merely into an absence.
+    """
+    cleared_trees = {"workspace", "plan_memory", "skills"}
+
+    def _f(info: tarfile.TarInfo, dest: str = "") -> tarfile.TarInfo | None:
+        kept = _data_filter(info, dest)
+        if kept is None and PurePosixPath(info.name).name not in NEVER_SNAPSHOT_FILES:
+            # Entries are `<bundle-root>/<tree>/...`; the tree is what decides.
+            parts = PurePosixPath(info.name).parts
+            if len(parts) > 1 and parts[1] in cleared_trees:
+                rejected.append(_safe_name(info.name))
+        return kept
+
+    return _f
 
 
 def _data_filter(info: tarfile.TarInfo, _dest: str = "") -> tarfile.TarInfo | None:
@@ -84,11 +177,11 @@ def _data_filter(info: tarfile.TarInfo, _dest: str = "") -> tarfile.TarInfo | No
             or bool(PureWindowsPath(name).drive)
         )
     if traversal:
-        print(f"⚠️  Rejecting path traversal entry: {info.name}")
+        print(f"⚠️  Rejecting path traversal entry: {_safe_name(info.name)}")
         return None
     # Reject symlinks and hardlinks
     if info.issym() or info.islnk():
-        print(f"⚠️  Rejecting symlink/hardlink entry: {info.name}")
+        print(f"⚠️  Rejecting symlink/hardlink entry: {_safe_name(info.name)}")
         return None
     # Never ship these — each must be regenerated on the restoring host.
     basename = PurePosixPath(info.name).name
@@ -146,23 +239,230 @@ def _audit(event_type: str, resources: str) -> None:
         logging.getLogger(__name__).warning("SEL audit event '%s' failed: %s", event_type, e)
 
 
-CORE_FILES: dict[str, tuple[str, ...]] = {
-    "memory": ("memory.db", "memory_index.db"),
-    "crons": ("crons.json",),
-    "config": ("config.json", "session_map.json", "hooks.json", "project_dir", "workspace_dir"),
-    "notifications": ("notifications.jsonl",),
-    "security": ("telemetry_salt",),  # sel_hmac.key excluded — regenerated on restore
+class Purpose(str, Enum):
+    """Why a bundle exists. Decides which components may ride in it.
+
+    A bundle's purpose is not cosmetic: ``BACKUP`` restores onto a replacement host
+    the operator already controls, so it wants the credentials that make recovery
+    turnkey. ``SHARE`` leaves the operator's control, so a component that carries
+    credential material must not ride in one. Recording the purpose in the manifest
+    is what lets a reader of a bundle know which of the two they are holding.
+    """
+
+    BACKUP = "backup"
+    SHARE = "share"
+
+
+class SecretPolicy(str, Enum):
+    """A component's declaration about the credential material it carries.
+
+    Every component must declare one. There is deliberately no default: a component
+    added without a declaration is refused at staging (see :func:`resolve_components`)
+    rather than inheriting whichever value happens to be permissive.
+
+    ``UNRESOLVED`` means nobody has established that the component is safe to hand to
+    another person. It rides a ``BACKUP`` bundle unchanged and is refused outright in
+    a ``SHARE`` bundle.
+
+    ``SHARE_SAFE`` means someone has, and **no component claims it today**. That is
+    not an oversight. Whether a component is safe to share is a question about
+    CONTENT, not structure: a workspace file, a skill, a cron's ``env`` map, a
+    notification body or a pasted lesson can each contain a token, and staging cannot
+    tell. Two components were flipped from a guessed-safe value to ``UNRESOLVED``
+    during review of this change, one at a time, before the pattern was obvious. The
+    value is kept so the seam has both sides and the gate stays exercised; the first
+    genuinely certified component will arrive with the redaction work that earns it.
+    """
+
+    SHARE_SAFE = "share-safe"
+    UNRESOLVED = "unresolved"
+
+
+@dataclass(frozen=True)
+class ComponentSpec:
+    """What one component stages, and its credential declaration.
+
+    ``files`` are data-home-relative files copied individually; ``trees`` are
+    data-home-relative directories copied wholesale. A ``.db`` file in ``files`` is
+    copied through the SQLite backup API rather than the filesystem, so a live
+    gateway holding the database open still yields a consistent copy.
+    """
+
+    policy: SecretPolicy
+    help: str
+    files: tuple[str, ...] = ()
+    trees: tuple[str, ...] = ()
+
+
+# The single source of truth for what a bundle can contain. Both the staging path
+# and the restore path read this, so a component cannot be stageable but
+# unrestorable (or the reverse) without the mismatch being visible here.
+COMPONENTS: dict[str, ComponentSpec] = {
+    # Self-contained on purpose: lessons and semantic/episodic recall live in the two
+    # databases, but the markdown half of memory lives under workspace/. Naming those
+    # trees here means restoring memory does not require restoring the whole
+    # workspace, which on a real install is two orders of magnitude larger.
+    "memory": ComponentSpec(
+        # UNRESOLVED like every other component: a lesson or a note can contain a
+        # token somebody pasted, and staging cannot tell. Memory is NOT redacted in a
+        # backup -- that is the whole point of backing it up -- this declaration only
+        # governs whether it may ride a bundle that leaves the operator's control.
+        policy=SecretPolicy.UNRESOLVED,
+        help=(
+            "memory.db, memory_index.db (semantic, episodic, lessons), "
+            "workspace/memory/ (preferences, projects, history), workspace/knowledge/ "
+            "(files; the knowledge database is replaced, not row-merged)"
+        ),
+        files=("memory.db", "memory_index.db"),
+        trees=("workspace/memory", "workspace/knowledge"),
+    ),
+    "crons": ComponentSpec(
+        # `CronJob.env` is a persisted dict of per-job environment variables
+        # (cron.py), so a job passing an API token carries it in crons.json.
+        policy=SecretPolicy.UNRESOLVED,
+        help="crons.json (scheduled jobs)",
+        files=("crons.json",),
+    ),
+    "config": ComponentSpec(
+        policy=SecretPolicy.UNRESOLVED,
+        help="config.json, session_map.json, hooks.json, project_dir, workspace_dir",
+        files=("config.json", "session_map.json", "hooks.json", "project_dir", "workspace_dir"),
+    ),
+    "skills": ComponentSpec(
+        policy=SecretPolicy.UNRESOLVED,
+        help="skills/ directory",
+        trees=("skills",),
+    ),
+    "workspace": ComponentSpec(
+        policy=SecretPolicy.UNRESOLVED,
+        help="workspace/, plan_memory/ directories",
+        trees=("workspace", "plan_memory"),
+    ),
+    "notifications": ComponentSpec(
+        policy=SecretPolicy.UNRESOLVED,
+        help="notifications.jsonl (notification history)",
+        files=("notifications.jsonl",),
+    ),
+    "security": ComponentSpec(
+        policy=SecretPolicy.UNRESOLVED,
+        help="telemetry_salt (sel_hmac.key excluded — regenerated on restore)",
+        files=("telemetry_salt",),
+    ),
 }
 
-COMPONENT_HELP = {
-    "memory": "memory.db, memory_index.db (semantic, episodic, knowledge graph)",
-    "crons": "crons.json (scheduled jobs)",
-    "config": "config.json, session_map.json, hooks.json, project_dir, workspace_dir",
-    "skills": "skills/ directory",
-    "workspace": "workspace/, plan_memory/ directories",
-    "notifications": "notifications.jsonl (notification history)",
-    "security": "telemetry_salt (sel_hmac.key excluded — regenerated on restore)",
+
+class ComponentRefused(Exception):
+    """A requested component cannot ride a bundle of the requested purpose."""
+
+
+def resolve_components(requested: list[str] | None, purpose: Purpose) -> list[str]:
+    """Return the component names to stage, or raise :class:`ComponentRefused`.
+
+    ``None`` means every component. The two refusals are the seam's whole point:
+    an unknown name never silently stages nothing, and an ``UNRESOLVED`` component
+    never rides a ``SHARE`` bundle just because nobody wrote the policy down.
+
+    Duplicates are collapsed, ORDER PRESERVED. ``--components config,config`` used to reach
+    the staging pass twice for one component, and the second pass hit the exclusive create
+    the pinned primitives make -- an uncaught ``FileExistsError`` traceback rather than a
+    snapshot. A repeated name is a typo, not a request to stage anything twice, so the
+    honest reading is to collapse it rather than to refuse the run.
+    """
+    names = list(COMPONENTS) if requested is None else list(dict.fromkeys(requested))
+    unknown = [c for c in names if c not in COMPONENTS]
+    if unknown:
+        raise ComponentRefused(
+            f"unknown component(s): {', '.join(sorted(unknown))} "
+            f"(known: {', '.join(sorted(COMPONENTS))})"
+        )
+    if purpose is Purpose.SHARE:
+        blocked = [c for c in names if COMPONENTS[c].policy is SecretPolicy.UNRESOLVED]
+        if blocked:
+            raise ComponentRefused(
+                f"component(s) {', '.join(sorted(blocked))} have no share-safe policy, "
+                f"so they cannot ride a '{Purpose.SHARE.value}' bundle. Whether a "
+                f"component is safe to hand to someone else is a question about its "
+                f"CONTENT — a workspace file, a skill, a cron's env map or a pasted "
+                f"lesson can each hold a token — and no component is certified yet. "
+                f"Use --purpose {Purpose.BACKUP.value} to back up onto a host you "
+                f"control."
+            )
+    return names
+
+
+# Derived views, kept because callers and tests read them as the component tables.
+CORE_FILES: dict[str, tuple[str, ...]] = {
+    name: spec.files for name, spec in COMPONENTS.items() if spec.files
 }
+
+# Every core-file name, flattened across components. DERIVED, never hand-listed: recovery
+# uses it to tell "this run would have created a regular FILE here" from "something else's
+# directory is standing at that name", and a hand-kept copy of the list would drift from the
+# component specs exactly when a new component is added -- which is when the distinction
+# matters most.
+CORE_FILES_FLAT: frozenset[str] = frozenset(f for files in CORE_FILES.values() for f in files)
+
+# Core files that are DERIVED: regenerable from the payload they index, and dropped from an
+# off-host bundle by the redaction pass for exactly that reason. Replace has to answer for
+# the consequence -- see `_drop_derived_indexes_absent_from_bundle`.
+#
+# Duplicated from `snapshot_redact._DERIVED_INDEXES` rather than imported: that module is
+# loaded LAZILY here (`_redact_module()`), and an eager import for one frozenset would pull
+# it into the boot path that `test_perf_boot_path.py` guards. A test asserts the two sets
+# agree, so a future divergence fails loudly instead of silently restoring a stale index.
+_DERIVED_INDEXES: frozenset[str] = frozenset({"memory_index.db"})
+
+
+# Component files whose consumers read a JSON OBJECT and degrade silently when they do
+# not get one. `crons.json` is the sharpest case: its loader wraps `json.loads` in a
+# `try` and falls back to "no jobs", and even a well-formed JSON *array* takes the
+# `isinstance(data, dict) else []` branch — so a corrupt file discards every scheduled
+# job while the restore reports success.
+#
+# Listed rather than derived, because "ends in .json" is not the property that matters:
+# what matters is that a consumer treats an unreadable file as empty instead of as an
+# error. A component file added here is validated before it can be installed.
+COMPONENT_JSON_OBJECTS: frozenset[str] = frozenset(
+    {
+        "crons.json",
+        "config.json",
+        "session_map.json",
+        "hooks.json",
+    }
+)
+
+# Keys inside those files whose value must be a LIST OF OBJECTS, because a reader iterates
+# the list and reads fields off each entry. An object at the top level is necessary and not
+# sufficient: `{"jobs": ["x"]}` is a valid object whose consumer reaches `.get` on a `str`
+# and raises halfway through a merge, with live state already partly changed.
+_JSON_OBJECT_LISTS: dict[str, tuple[str, ...]] = {
+    "crons.json": ("jobs",),
+}
+
+# The tree counterpart of CORE_FILES. Derived from the same specs so a component that
+# gains a tree is covered by everything keyed on this without a second edit.
+COMPONENT_TREES: dict[str, tuple[str, ...]] = {
+    name: spec.trees for name, spec in COMPONENTS.items() if spec.trees
+}
+
+# Databases this product owns that live INSIDE a component tree rather than at the top
+# level. Paths are relative to a bundle root, POSIX-separated.
+#
+# They cannot be derived from `ComponentSpec.files`, which names only top-level files, so
+# they are listed. The list is what separates "our database, broken bundle" from "a `.db`
+# the operator happens to keep in their own folder": everything here is validated as
+# strictly as `memory.db`, and everything else under a tree is only checked when it opens
+# as a database at all. A product database added under a tree and left off this list is
+# validated leniently, which is the failure this comment exists to prevent.
+PRODUCT_TREE_DATABASES: frozenset[str] = frozenset(
+    {
+        "workspace/knowledge/knowledge.db",
+    }
+)
+
+COMPONENT_HELP = {name: spec.help for name, spec in COMPONENTS.items()}
+
+VALID_COMPONENTS: tuple[str, ...] = tuple(COMPONENTS)
 
 
 def _mc_dir() -> Path:
@@ -173,6 +473,261 @@ def _mc_dir() -> Path:
     from kiro_crew.config.loader import config_dir
 
     return config_dir()
+
+
+# SQLite sidecars are excluded from every staged tree. They describe the SOURCE
+# database's in-flight transaction state; shipping them next to a consistent backup
+# copy would invite the restoring host to replay a journal that does not match it.
+#
+# Not redundant with _restage_databases, though it looks that way: re-opening a
+# staged database makes SQLite discard the copied sidecars as a side effect, so for a
+# real database either mechanism alone appears to work. This glob is what covers the
+# case _restage_databases SKIPS — a file named .db that SQLite cannot open, whose
+# stray sidecars would otherwise ride.
+_DB_SIDECAR_GLOBS = ("*.db-wal", "*.db-shm", "*.db-journal", "*.sqlite3-wal", "*.sqlite3-shm")
+
+# Suffixes treated as SQLite databases when found inside a staged tree.
+_DB_SUFFIXES = (".db", ".sqlite", ".sqlite3")
+
+
+class DatabaseCopyFailed(Exception):
+    """A readable database could not be copied consistently.
+
+    Carries the source path so the command boundary can name the file. Raised rather
+    than absorbed because the staged copy at that point is a raw byte copy without its
+    WAL sidecars — shipping it would put a torn database in a bundle that reports
+    success — and typed rather than bare so the failure exits with a message instead of
+    a traceback.
+    """
+
+    def __init__(self, path: Path, cause: Exception) -> None:
+        super().__init__(f"{path}: {cause}")
+        self.path = path
+
+
+def _chain_is_link_free(root: Path, rel_parts: tuple[str, ...]) -> bool:
+    """Is every component of *rel_parts* under *root* a real directory, not a link?
+
+    Walked with descriptors: each directory is opened relative to the previous one with
+    ``O_NOFOLLOW``, so a component that is a link -- or one swapped for a link while this
+    pass runs -- fails its own open instead of redirecting the walk. The final component is
+    the file itself and is checked as a regular file through its pinned parent.
+
+    This exists because verifying a path and then RE-WALKING it by name are two different
+    resolutions of the same string: the second can land somewhere the first never inspected.
+    ``resolve()`` and a late ``realpath()`` are both that second walk.
+
+    Requires descriptor pinning, and SAYS SO rather than pretending: where the platform
+    cannot open relative to a directory descriptor (``os.open`` absent from
+    ``os.supports_dir_fd``, or no ``O_NOFOLLOW`` -- which is Windows), this returns True and
+    the caller proceeds on the by-name screening the loop already did, the file being a
+    regular file and not a link or reparse point. That is weaker, and it is the same
+    degradation the rest of this module applies through ``_staging_is_pinned``. Returning
+    False instead would refuse every database on that platform, turning a hardening into an
+    outage.
+
+    The first version omitted that gate and passed ``dir_fd`` unconditionally, which is not
+    merely weaker on Windows -- ``os.open`` RAISES ``NotImplementedError`` there, so the pass
+    crashed. ``supports_pinned_walk`` exists for exactly this.
+    """
+    if not pinned_fs.supports_pinned_walk():
+        return True
+    fd = pinned_fs.open_dir_pinned(root, what="database source root")
+    try:
+        for part in rel_parts[:-1]:
+            try:
+                nxt = os.open(part, _dir_flags_nofollow(), dir_fd=fd)
+            except OSError:
+                return False  # a link, or gone: either way this file is not reachable safely
+            os.close(fd)
+            fd = nxt
+        return pinned_fs.is_regular_at(fd, rel_parts[-1])
+    except pinned_fs.PinnedPathRefusal:
+        return False
+    finally:
+        os.close(fd)
+
+
+def _dir_flags_nofollow() -> int:
+    """``O_RDONLY|O_DIRECTORY|O_NOFOLLOW``, with the flags that only exist on some platforms
+    added when present."""
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    return flags | getattr(os, "O_CLOEXEC", 0)
+
+
+def _restage_databases(src_dir: Path, dst_dir: Path) -> None:
+    """Re-copy every SQLite database under *src_dir* through the backup API.
+
+    The plain tree copy already placed a byte copy there; this replaces it with a
+    consistent one. Done as a second pass rather than by filtering the tree walk, so
+    the copy logic stays in one place and a database newly appearing in a tree is
+    covered without anyone remembering to register it.
+
+    A file whose suffix says database but which SQLite cannot open is left as the byte
+    copy already made: a non-database that happens to be named ``.db`` is still the
+    operator's file and must ride the bundle.
+
+    A database the tree copy did NOT stage is left alone. This pass exists to REPLACE a
+    byte copy with a consistent one, so a destination that does not already hold that byte
+    copy means the walk deliberately declined the source -- a hardlink alias, a symlink, a
+    non-regular entry -- and recreating it here from the source inode would reinstate
+    exactly what the walk refused. Reproduced before this guard existed: a `.db` hardlinked
+    to a database outside the component tree was skipped as `not_regular` and then rebuilt
+    by this pass, putting the external database's rows in the bundle. Checking the PARENT
+    directory is not enough, because the parent exists for every sibling that copied fine.
+    """
+    for src in sorted(src_dir.rglob("*")):
+        if not src.is_file() or src.is_symlink() or src.suffix not in _DB_SUFFIXES:
+            continue
+        dst = dst_dir / src.relative_to(src_dir)
+        # `lstat`, not `exists()`: the latter follows a link, so a link planted at the
+        # destination name would answer for its target and be treated as a staged copy.
+        try:
+            dst_st = dst.lstat()
+        except OSError:
+            continue
+        if not _stat.S_ISREG(dst_st.st_mode):
+            continue
+        # The chain from the source root down to this file is verified COMPONENT BY
+        # COMPONENT through descriptors, each opened `O_NOFOLLOW`, so a directory that is a
+        # link -- or one swapped for a link while this pass runs -- is refused where it is
+        # opened rather than silently traversed.
+        #
+        # `src.resolve()` was wrong here, and so was resolving the parent late: both re-walk
+        # every ancestor BY NAME after the loop screened the file, so a swapped ancestor
+        # redirects the open at a database this pass never inspected -- someone else's, whose
+        # rows then ride in the bundle under an innocuous name. Review's finding; this is the
+        # construction `open_dir_pinned` uses, for the same reason.
+        #
+        # Once no component is a link, the path AS GIVEN names the file that was verified, so
+        # the URI is built from it without resolving anything. What this does NOT close,
+        # stated rather than implied: SQLite's API takes a PATH, not a descriptor, so SQLite
+        # re-resolves the name itself, and a same-uid swap in the window between this check
+        # and that open is not detectable here -- a post-hoc identity re-check is defeated by
+        # swapping back. Closing that needs a descriptor-taking VFS, which is a change to how
+        # this module opens every database: main's own snapshot module opens SQLite by name
+        # in six places, including the structurally identical creation-side copy.
+        if not _chain_is_link_free(src_dir, src.relative_to(src_dir).parts):
+            continue
+        # `as_uri()` percent-escapes the path. Interpolating it raw meant a POSIX
+        # filename containing `?` or `#` was parsed as the start of the URI's query or
+        # fragment, truncating the path — so the copy would open a DIFFERENT database
+        # and store it under the requested name. Built ONCE and reused by both the probe
+        # and the copy: two spellings of the same URI is how one of them drifts.
+        ro_uri = f"{src.absolute().as_uri()}?mode=ro"
+        # Two different failures hide behind sqlite3.Error here, and treating them
+        # alike is unsafe. If the file is not a database at all, the plain byte copy
+        # already staged is exactly right. If it IS a database and the backup call
+        # failed -- an exclusive writer, an I/O error -- the staged copy is a raw
+        # snapshot of the file WITHOUT its WAL sidecars, which this module deliberately
+        # excludes, so the bundle would carry a torn database and report success.
+        #
+        # They are told apart by probing readability separately from copying, rather
+        # than by inspecting the error: `sqlite_errorname` is 3.11+ and this package
+        # supports 3.10, and matching on message text would break with any SQLite
+        # wording change.
+        try:
+            with closing(sqlite3.connect(ro_uri, uri=True)) as probe:
+                probe.execute("PRAGMA schema_version").fetchone()
+        except sqlite3.DatabaseError as e:
+            # Only a POSITIVELY identified non-database keeps the plain copy. The broad
+            # form was wrong in the dangerous direction: "database is locked" is also a
+            # DatabaseError, so an exclusive writer made the probe report "not a
+            # database" and the raw byte copy -- taken WITHOUT its WAL sidecars, which
+            # this module excludes -- shipped as if it were consistent.
+            #
+            # `sqlite_errorname` is 3.11+ and this package supports 3.10, so it is read
+            # defensively and the message is the documented fallback. Either way the
+            # DEFAULT is to raise: an error this code cannot classify is not evidence
+            # that the file is safe to copy byte-for-byte.
+            name = getattr(e, "sqlite_errorname", "")
+            not_a_database = name == "SQLITE_NOTADB" or (
+                not name and "not a database" in str(e).lower()
+            )
+            if not not_a_database:
+                raise DatabaseCopyFailed(src, e) from e
+            print(
+                f"⚠️  {_safe_name(src.name)} is not a readable SQLite database "
+                "— copied as a plain file"
+            )
+            continue
+        with (
+            closing(sqlite3.connect(ro_uri, uri=True)) as src_conn,
+            closing(sqlite3.connect(str(dst))) as dst_conn,
+        ):
+            # The file is a readable database, so a failure here means the consistent
+            # copy did not happen and the staged file is a raw copy WITHOUT its WAL
+            # sidecars. Absorbing that would ship a torn database, so it is raised --
+            # but as a typed error naming the file, so the command boundary can report
+            # which database failed instead of exiting on a traceback.
+            try:
+                src_conn.backup(dst_conn)
+            except sqlite3.Error as e:
+                raise DatabaseCopyFailed(src, e) from e
+
+
+def safe_tree_root(root: Path, *, what: str, home: Path | None = None) -> Path | None:
+    """Return *root* if it is the declared tree AND staying inside the data home.
+
+    THE chokepoint for component tree roots. Three separate sites touch them — the
+    staging walk, the replace pass and the merge pass — and each was found to
+    dereference a link independently, so the check lives here once.
+
+    Two INDEPENDENT properties are required, and neither implies the other:
+
+    **Containment** — the fully resolved path is a strict descendant of the resolved
+    home. This answers "can a read or write through this root land outside the
+    directory we are allowed to touch". Checking whether the node itself is a link
+    does not answer it: a link nested under the root, or an ancestor of it, escapes
+    while every individual node looks ordinary. ``Path.resolve()`` follows every link
+    in the path, so the comparison covers roots, ancestors, descendants and Windows
+    junctions at once. Equality with the home is refused, not allowed: a link like
+    ``workspace/memory -> ..`` resolves to the home itself, which would make the
+    "component tree" the whole home and sweep ``.env`` and ``sel_hmac.key`` into an
+    archive meant to carry memory. No declared component tree is ever the home.
+
+    **Identity** — no path segment from the home down to the root is a link. This
+    answers a different question: "is this the tree the component declared". A link
+    that redirects to another subtree INSIDE the home satisfies containment perfectly
+    — ``workspace/memory -> ../apps`` resolves to a strict descendant — while
+    silently changing WHICH data is archived. Because these bundles are uploaded, a
+    redirect is an exfiltration primitive, not a mix-up: the archive would carry
+    whatever the link points at under the name of the component that was asked for.
+    Containment cannot see this, because nothing left the home.
+    """
+    base = (home or _mc_dir()).resolve()
+    try:
+        resolved = root.resolve()
+    except OSError as e:  # broken link, ELOOP, permission on an ancestor
+        print(f"⚠️  Skipping unresolvable {what} ({e}): {root}")
+        return None
+    if base not in resolved.parents:
+        print(f"⚠️  Skipping {what} that resolves outside {base}: {root} -> {resolved}")
+        return None
+    # Identity. Walk the segments BELOW the home only: the home itself is allowed to
+    # sit behind a link (a real one often does), and resolving it once already accounted
+    # for that. Climbing stops as soon as a parent resolves to the home, so a link above
+    # the home is never mistaken for a redirect within it.
+    probe = root.absolute()
+    while True:
+        if platform_compat.is_link_or_junction(probe):
+            print(
+                f"⚠️  Skipping {what} that is reached through a link: {probe}. "
+                "A component tree must be the declared directory, not a redirect to "
+                "another one — the archive is uploaded, so a redirect would ship "
+                "whatever the link points at."
+            )
+            return None
+        parent = probe.parent
+        if parent == probe:
+            break
+        try:
+            if parent.resolve() == base:
+                break
+        except OSError:
+            break
+        probe = parent
+    return root
 
 
 def _fsize(p: Path) -> int:
@@ -191,6 +746,229 @@ def _list_components() -> None:
     for k, v in COMPONENT_HELP.items():
         print(f"  {k:16s} {v}")
     print("\nCombine with commas: --components memory,crons,skills")
+
+
+class RollbackIncomplete(OSError):
+    """The restore failed AND putting the previous state back did not fully succeed.
+
+    Distinct from the restore failure itself, because the two need opposite messages: one
+    says "you are back where you started", the other says "some of your previous state is
+    only in the rollback directory now". Reporting the first when the second is true is
+    the worst of the three outcomes -- the operator stops looking.
+    """
+
+    def __init__(self, cause: BaseException, failed: list[str], backup: "Path") -> None:
+        self.cause = cause
+        self.failed = failed
+        self.backup = backup
+        super().__init__(str(cause))
+
+
+class UnsafeComponentRoot(Exception):
+    """A selected component's tree root does not resolve inside the data home.
+
+    Raised rather than skipped: a bundle whose manifest claims a component it could not
+    read is a backup that lies about its contents, which is worse than a refusal.
+    """
+
+
+def _report_unredacted_upload() -> None:
+    """Say plainly what an operator gets by turning redaction off."""
+    print(
+        "⚠️  Redaction is DISABLED by the switch in your backup directory, so this upload "
+        "carries credential material in plaintext."
+    )
+    print(
+        "   That is what makes the off-host copy restore complete. The bucket was "
+        "verified private at setup and every write asserts your account owns it, but "
+        "anyone who can read the bucket can read your credentials — treat it as secret."
+    )
+
+
+def _report_unresolved_payload(selected: list[str]) -> None:
+    """Name the components in this bundle that carry uncertified credential material.
+
+    A backup is NOT redacted, and that is deliberate: it goes to a destination the
+    operator provisioned in their own account, and stripping a credential out of a backup
+    produces an archive that cannot restore a working install — the token is part of the
+    state being protected. The `SHARE` purpose is where content leaves the operator's
+    control, and it refuses every component today precisely because no component has been
+    certified safe to hand to someone else.
+
+    What that reasoning does NOT cover is an operator who does not know what is in the
+    bundle. A backup with no `--components` stages everything, which includes the config
+    file holding a bot token in plaintext. So the bundle's credential-bearing contents are
+    named on the way out. The operator keeps the un-redacted backup they need, and learns
+    what they are sending without having to read the component table to find out.
+    """
+    riding = [name for name in selected if COMPONENTS[name].policy is SecretPolicy.UNRESOLVED]
+    if not riding:
+        return
+    print(f"ℹ️  Riding this bundle, uncertified for sharing: {', '.join(sorted(riding))}.")
+    print(
+        "   `config` carries credentials in plaintext at rest. Whether the copy that "
+        "leaves this host still does is reported below; the bundle on local disk always "
+        "does, so treat it as secret and narrow it with --components if you do not need "
+        "all of it."
+    )
+
+
+class RedactionFailed(RuntimeError):
+    """Redaction could not be completed, so there is nothing safe to upload.
+
+    A `RuntimeError` on purpose, and not narrowable back to `Exception`. The off-host
+    caller is the AWS Control app's backup route, whose error contract is already
+    `AWSError -> aws_failed` and `RuntimeError -> backup_failed`; as a plain `Exception`
+    this refusal escaped both and surfaced as an HTTP 500 with no machine-readable code, so
+    an operator saw a crash where the product had actually made a correct safety decision.
+    Verified before widening that nothing on the snapshot, redaction or app-backup path
+    catches `RuntimeError`, so this cannot be swallowed into "send it unredacted" -- which
+    would be far worse than the 500 it replaces.
+    """
+
+
+def _redacted_upload_copy(
+    outfile: Path, workdir: Path
+) -> "tuple[Path, snapshot_redact.RedactionReport] | None":
+    """Build a redacted archive to upload in place of *outfile*.
+
+    Returns ``None`` only when redaction is deliberately DISABLED by config — the one case
+    where sending the original is the intended behaviour. Every failure raises
+    `RedactionFailed` instead, because "could not redact" must never fall through to
+    "upload it unredacted": that would turn a broken bundle into a credential leak.
+
+    The local bundle is never touched. It sits on the machine that already holds these
+    secrets, so redacting it would destroy the only copy that restores complete and buy
+    nothing — the boundary worth defending is the one the upload crosses.
+    """
+    try:
+        redact = _redactor().outbound_redaction_enabled()
+    except _redactor().RedactionSwitchUnreadable as e:
+        # The operator wrote this file on purpose and we cannot tell which way. Neither
+        # silent answer is honest -- off ignores a request to scrub, on rewrites files they
+        # may not have meant to touch -- so refuse the UPLOAD and name the file. The local
+        # bundle is already written and is unaffected.
+        raise RedactionFailed(
+            f"{e}.\n"
+            "   Refusing to upload rather than guess whether your files should be "
+            "rewritten. Fix the file (or delete it to leave redaction off), then re-run."
+        ) from e
+    if not redact:
+        return None
+
+    stage = workdir / "redacted"
+    try:
+        with tarfile.open(outfile) as tf:
+            _refuse_oversized_archive(tf)
+            try:
+                tf.extractall(path=str(stage), filter=_data_filter)  # nosec B202
+            except TypeError:
+                # Python < 3.11.4 has no `filter` parameter, so the same manual member
+                # screen the restore path uses applies here. Without it the keyword is an
+                # uncaught TypeError -- not caught by the clause below, which lists only
+                # archive and I/O failures -- so the off-host path crashed on those
+                # interpreters while the local snapshot had already been written.
+                members = [m for m in tf.getmembers() if _data_filter(m) is not None]
+                tf.extractall(path=str(stage), members=members)  # nosec B202
+    except (tarfile.TarError, OSError, EOFError, _ArchiveTooLarge) as e:
+        raise RedactionFailed(f"could not read the bundle back to redact it ({e})") from e
+    roots = [d for d in stage.iterdir() if d.is_dir()] if stage.is_dir() else []
+    if len(roots) != 1:
+        raise RedactionFailed(f"expected one bundle root to redact, found {len(roots)}")
+
+    try:
+        report = _redactor().redact_bundle_for_egress(roots[0])
+    except _redactor().PayloadDatabaseUnprovable as e:
+        shown = ", ".join(_safe_name(x) for x in sorted(e.details))
+        raise RedactionFailed(
+            f"the database this backup exists to carry cannot be shown free of "
+            f"credentials: {shown}. It was NOT removed — uploading the remainder would "
+            "report success and restore nothing. Your local snapshot is complete and "
+            "unaffected. Re-run `kirocrew snapshot` once the database is readable, or "
+            "turn the switch off in your backup directory to upload the bundle complete and "
+            "unredacted"
+        ) from e
+    except _redactor().OpaqueFilesPresent as e:
+        shown = ", ".join(_safe_name(p) for p in sorted(e.paths)[:10])
+        more = "" if len(e.paths) <= 10 else f" (+{len(e.paths) - 10} more)"
+        raise RedactionFailed(
+            f"{len(e.paths)} file(s) are not text, so they cannot be shown free of "
+            f"credentials: {shown}{more}. They were NOT removed — a restore that "
+            "silently lacks your own files is worse than an upload that stops. Narrow "
+            "the selection with --components, or turn redaction off in your backup directory to "
+            "upload the bundle complete and unredacted"
+        ) from e
+    except (OSError, ValueError) as e:
+        # Any failure inside the pass means the copy cannot be proven clean. Letting it
+        # out as a traceback would be indistinguishable from a crash, and the branch that
+        # decides what to upload would never run — so it becomes a refusal like the rest.
+        raise RedactionFailed(f"the redaction pass failed ({e})") from e
+    redacted = workdir / f"{outfile.stem}.redacted.tar.gz"
+    try:
+        with tarfile.open(redacted, "w:gz") as tf:
+            tf.add(str(roots[0]), arcname=roots[0].name)
+        # The workdir is locked to the owner before any child is created (see the caller),
+        # and this archive is STREAMED -- routing it through atomic_write would mean holding
+        # a multi-gigabyte bundle in memory to pass as `content`. So this is the re-assert,
+        # not the protection.
+        rd = str(redacted)
+        platform_compat.restrict_to_owner(rd)  # lockdown-ok: re-assert, owner-only workdir
+    except OSError as e:
+        raise RedactionFailed(f"could not write the redacted archive ({e})") from e
+    return redacted, report
+
+
+def _report_redaction(report: "snapshot_redact.RedactionReport") -> None:
+    """Say what left the host in what state, per path, so it can be judged not trusted.
+
+    Every path here is BUNDLE-DERIVED -- a workspace filename the operator (or anything
+    writing to their home) chose, or an archive member name. Printing one raw lets it
+    repaint the very report the operator is reading to decide whether to trust the upload,
+    so each goes through `_safe_name` at this single point rather than at each `print`.
+    """
+    print(f"🛡️  Redacted the outbound copy ({report.total} replacement(s)).")
+    for rel, n in sorted(report.replacements.items()):
+        print(f"     {_safe_name(rel)}: {n}")
+    if report.dropped:
+        shown = ", ".join(_safe_name(d) for d in sorted(report.dropped))
+        print(f"     dropped entirely: {shown}")
+    if report.skipped_unreadable:
+        shown = ", ".join(_safe_name(s) for s in sorted(report.skipped_unreadable))
+        print(f"     could not be proven clean, so removed: {shown}")
+    print(
+        "     The LOCAL archive is unredacted and still restores complete. Restoring the "
+        "off-host copy gives you working memory with inert credentials — re-enter them."
+    )
+
+
+def prepare_redacted_copy(outfile: Path, workdir: Path, selected: list[str]) -> Path | None:
+    """Produce a redacted copy of *outfile* for a caller that is about to send it off-host.
+
+    Returns the redacted archive's path, or ``None`` when the operator has not opted in --
+    in which case the caller sends *outfile* itself. Raises `RedactionFailed` when the
+    pass cannot complete, because "could not redact" must never fall through to "send it
+    unredacted".
+
+    This is the seam the off-host path consumes. It deliberately knows nothing about a
+    destination: the bucket, its hardening, the consent grant and the transport all belong
+    to the AWS Control app, which owns one drive bucket per account and routes every call
+    through the deploy engine's `run_aws` chokepoint. What is left here is the one thing
+    that app does not do -- rewriting the bytes that leave -- and it is kept here because
+    it is the snapshot format's own business, not the transport's.
+
+    *workdir* must be a directory the caller controls and removes; the redacted copy is
+    written inside it. The LOCAL bundle is never touched: it sits on the machine that
+    already holds these secrets, so redacting it would destroy the only copy that restores
+    complete and buy nothing.
+    """
+    _report_unresolved_payload(selected)
+    prepared = _redacted_upload_copy(outfile, workdir)
+    if prepared is None:
+        _report_unredacted_upload()
+        return None
+    payload, report = prepared
+    _report_redaction(report)
+    return payload
 
 
 def _terminal_safe(value: object) -> str:
@@ -414,14 +1192,263 @@ def _copy_tree_no_overwrite(src: Path, dst: Path, *, allow_unpinned: bool = Fals
 # ── Snapshot ──────────────────────────────────────────────────────────────────
 
 
-def _build_snapshot(mc: Path, out: Path, name: str, *, allow_unpinned: bool = False) -> Path:
+class ManifestUnreadable(Exception):
+    """A bundle's manifest exists but cannot be trusted to say what it carries."""
+
+
+class _ArchiveTooLarge(Exception):
+    """An archive declares more content than a memory bundle can justify."""
+
+
+class SourceComponentUnsound(Exception):
+    """An incoming component in a bundle is unsound, so nothing may be restored from it.
+
+    Covers both kinds of unsoundness this path can detect before mutating: a database
+    that fails its integrity check, and a component JSON whose reader would treat it as
+    empty. Both share one boundary handler because both mean the same thing to the
+    operator — the bundle cannot be applied — and neither should surface as a traceback.
+
+    Raised before any live state moves, because the point of the check is that it still
+    costs nothing to decline.
+    """
+
+
+# Generous next to a real memory bundle (megabytes, a few thousand members) and still
+# far below what would fill a disk. Both bounds are needed: total size alone misses an
+# archive whose damage is a huge member COUNT, and count alone misses one member that
+# declares a terabyte.
+_MAX_ARCHIVE_MEMBERS = 200_000
+_MAX_ARCHIVE_BYTES = 4 * 1024 * 1024 * 1024
+
+
+def _refuse_oversized_archive(probe: tarfile.TarFile) -> None:
+    """Refuse an archive that would not fit, before anything is extracted.
+
+    A compressed archive can declare orders of magnitude more content than it occupies,
+    so size on disk says nothing about what extraction would write. The check has to run
+    against the member headers, and it has to run BEFORE ``extractall``: once extraction
+    starts, the damage is already on the filesystem.
+
+    Applied on every path that reads an archive — staging a bundle for upload, a bundle
+    fetched from object storage, and a local bundle handed to `restore`. A local file is
+    not trustworthy by virtue of being local; it can be hostile or simply wrong.
+
+    Members are walked one at a time rather than through ``getmembers()``, because
+    materialising the whole index is itself the denial of service an archive with
+    millions of members performs. Bailing on the member that crosses the bound means the
+    work is bounded by the bound, not by what the archive claims.
+    """
+    total = 0
+    count = 0
+    while (member := probe.next()) is not None:
+        count += 1
+        if count > _MAX_ARCHIVE_MEMBERS:
+            raise _ArchiveTooLarge(
+                f"This archive declares more than {_MAX_ARCHIVE_MEMBERS:,} "
+                "entries, which no memory bundle produces"
+            )
+        # Only regular files carry payload; a directory or link header declares a size
+        # that extraction never writes, so counting those would refuse honest archives.
+        if member.isfile():
+            total += max(member.size, 0)
+            if total > _MAX_ARCHIVE_BYTES:
+                raise _ArchiveTooLarge(
+                    "This archive declares more than "
+                    f"{_MAX_ARCHIVE_BYTES // (1024 ** 3)} GiB of uncompressed content, "
+                    "which no memory bundle produces"
+                )
+
+
+def _manifest_components(snap: Path) -> list[str] | None:
+    """Return the component names a bundle's manifest says it carries.
+
+    ``None`` means "this bundle predates the component map", which is the signal to
+    keep the historical all-components behaviour — such a bundle really did hold every
+    component. That fallback is reserved for a manifest that is READABLE and simply
+    has no map; a manifest that cannot be parsed raises :class:`ManifestUnreadable`
+    instead, because "we could not read it" must never resolve to the most destructive
+    interpretation available.
+
+    Names not in :data:`COMPONENTS` are dropped: the manifest travels with the bundle,
+    so a restore must not act on a name this build cannot resolve. The remaining list
+    is returned even when EMPTY — that means "declares components, none understood
+    here", which must restore nothing.
+    """
+    mf = snap / "MANIFEST.json"
+    if not mf.is_file():
+        return None
+    try:
+        manifest = json.loads(mf.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as e:
+        raise ManifestUnreadable(f"MANIFEST.json is present but unreadable: {e}") from e
+    if not isinstance(manifest, dict):
+        raise ManifestUnreadable("MANIFEST.json is not an object")
+    comps = manifest.get("components")
+    if comps is None:
+        return None
+    if not isinstance(comps, dict):
+        raise ManifestUnreadable(f"MANIFEST.json 'components' is {type(comps).__name__}, not a map")
+    known = [c for c in comps if c in COMPONENTS]
+    dropped = sorted(set(comps) - set(known))
+    if dropped:
+        print(
+            "⚠️  Manifest names unknown component(s), ignoring: "
+            + ", ".join(_safe_name(d) for d in dropped)
+        )
+    return known
+
+
+def _trees_absent_from_bundle(snap: Path, names: list[str], mc: Path) -> list[str]:
+    """Return the declared trees of *names* that *snap* lacks while *mc* HAS them.
+
+    Split from the per-component check because the two answer different questions, and
+    conflating them is what let live data go. Per COMPONENT, presence is "any declared path
+    is there", which is right: a home that never wrote ``memory_index.db`` produces a memory
+    bundle with only ``memory.db``, and demanding every file would refuse a sound bundle.
+    Per TREE under ``--mode replace`` that leniency is destructive, because
+    :func:`_replace_tree_root` clears the destination BEFORE it knows whether the archive
+    has a replacement -- so one present file makes the whole component look carried while
+    an absent tree is cleared from live state and the restore reports success.
+
+    Both halves of the condition are load-bearing, and requiring only the first was wrong:
+    a home that never used a tree produces a bundle without it, so "the archive lacks this
+    tree" alone refuses sound bundles. What makes it a LOSS is live state to lose. Naming
+    the live side keeps the refusal to exactly the case where clearing destroys something.
+
+    Deliberately not applied to a complete bundle: there, a tree the archive lacks is a
+    tree the source genuinely did not have, so clearing it is the point of replace. Only a
+    bundle that ASSERTS it is partial while carrying no component map cannot tell those two
+    apart, and that is the one case this speaks for.
+    """
+    absent = []
+    for name in names:
+        for tree in COMPONENTS[name].trees:
+            d = mc / tree
+            # Through the chokepoint like every other tree-root site. A live root that
+            # redirects elsewhere, or escapes the home, is not the tree this component
+            # declared, so it must not count as state worth refusing to protect -- and
+            # deciding that from `is_dir()` alone would follow the link.
+            if safe_tree_root(d, what="destination root", home=mc) is None:
+                continue
+            if not (snap / tree).is_dir() and d.is_dir():
+                absent.append(tree)
+    return absent
+
+
+def _components_absent_from_bundle(snap: Path, names: list[str]) -> list[str]:
+    """Return the *names* whose declared paths are all missing from *snap*.
+
+    The manifest is normally what answers "does this bundle carry X", and a
+    bundle that declares a component map is checked against it. This is the
+    fallback for the one shape that has no map to check: a root marked partial
+    whose manifest predates (or omits) the component list.
+
+    Naming a component is not evidence the bundle holds it. Replace mode moves
+    each live core file aside before it knows whether the archive has a
+    replacement, and clears a component tree whether or not the archive carries
+    one -- so an operator who names a component the bundle never held loses that
+    component and is told the restore succeeded.
+
+    Presence is "any declared path is there", not "all of them". A component
+    legitimately ships without every file: a home that never wrote
+    ``memory_index.db`` produces a memory bundle with only ``memory.db``, and
+    requiring both would refuse a sound bundle.
+    """
+    absent = []
+    for name in names:
+        spec = COMPONENTS[name]
+        carried = any((snap / f).is_file() for f in spec.files) or any(
+            (snap / t).is_dir() for t in spec.trees
+        )
+        if not carried:
+            absent.append(name)
+    return absent
+
+
+def _report_redacted_bundle(snap: Path) -> None:
+    """Tell the operator up front that this bundle's credentials are inert.
+
+    A redacted bundle is structurally sound — the databases open, the JSON parses, the
+    trees are complete — so nothing downstream refuses it, and that is deliberate. What it
+    is NOT is a bundle you can restore and walk away from: the fields that authenticate
+    have been replaced. Saying so here is the difference between an operator who re-enters
+    a token and one who spends an evening debugging a bot that will never connect.
+    """
+    mf = snap / "MANIFEST.json"
+    if not mf.is_file():
+        return
+    try:
+        data = json.loads(mf.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    info = data.get("redaction") if isinstance(data, dict) else None
+    if not isinstance(info, dict) or not info.get("redacted"):
+        return
+
+    print("🛡️  This bundle was REDACTED before it left its host.")
+    reps = info.get("replacements")
+    if isinstance(reps, dict) and reps:
+        total = sum(v for v in reps.values() if isinstance(v, int))
+        print(f"   {total} value(s) were replaced across {len(reps)} path(s):")
+        for rel, n in sorted(reps.items())[:12]:
+            # BOTH halves come out of a manifest this host did not write, so both are
+            # escaped. Filtering non-integers while SUMMING does not make the count safe
+            # to PRINT: a crafted value here is what repaints the report the operator is
+            # reading to decide whether the upload can be trusted.
+            print(f"     {_safe_name(rel)}: {_safe_name(str(n))}")
+    dropped = info.get("dropped")
+    if isinstance(dropped, list) and dropped:
+        print(
+            "   Left out entirely: " + ", ".join(_safe_name(d) for d in sorted(map(str, dropped)))
+        )
+    rebuild = info.get("indexes_needing_rebuild")
+    if isinstance(rebuild, list) and rebuild:
+        print(
+            "   Search index(es) absent and will need rebuilding: "
+            + ", ".join(_safe_name(d) for d in sorted(map(str, rebuild)))
+        )
+    print(
+        "   Your memory and settings restore normally; anything that AUTHENTICATES does "
+        "not. Re-enter those credentials after restoring."
+    )
+
+
+def _build_snapshot(
+    mc: Path,
+    out: Path,
+    name: str,
+    *,
+    selected: list[str] | None = None,
+    purpose: Purpose = Purpose.BACKUP,
+    root_name: str | None = None,
+    allow_unpinned: bool = False,
+) -> Path:
     """Stage the data home into a temporary tree and publish it as one tarball.
 
     Extracted from ``snapshot_main`` so the staging pass has a boundary a refusal can
     be contained at: everything in here either produces a finished archive or raises,
     and the caller turns a :class:`kiro_crew.pinned_fs.PinnedPathRefusal` into an exit
     code rather than a traceback.
+
+    *selected* names the components to stage and *purpose* what the bundle is for; both
+    are resolved by the caller so this function never has to decide policy. Staging is
+    per-component rather than over one flat file table, which is what makes
+    ``--components memory`` a complete memory backup instead of a subset of one.
+
+    They DEFAULT rather than being required, because callers that predate the component
+    seam ask for a whole-home archive and should keep getting one: an omitted *selected*
+    means every component, which is what ``snapshot`` without ``--components`` has always
+    produced. Making them mandatory broke those callers with a TypeError instead.
+
+    *name* names the TARBALL and *root_name* the directory inside it, and they are two
+    parameters rather than one because a selective bundle marks only the inner directory.
+    Collapsing them renamed the tarball too, and ``--list``, pruning and ``--keep`` all
+    glob ``kirocrew-snapshot-*.tar.gz`` -- so every partial bundle became invisible to
+    rotation and accumulated without bound. Defaults to *name* for a complete bundle.
     """
+    arcname = root_name or name
+    if selected is None:
+        selected = list(COMPONENTS)
     # Decided BEFORE anything is staged, not per-tree. An earlier revision gated
     # inside _copytree_safe only, so a data home with core files and no trees staged
     # them on a platform that cannot pin without ever consulting the opt-in -- the
@@ -447,9 +1474,21 @@ def _build_snapshot(mc: Path, out: Path, name: str, *, allow_unpinned: bool = Fa
         _report_skip(reason, path)
 
     with tempfile.TemporaryDirectory() as work:
-        stage = Path(work) / name
-        for d in ("workspace", "skills", "plan_memory"):
-            (stage / d).mkdir(parents=True, exist_ok=True)
+        # Locked down as a DIRECTORY before anything is staged into it. This tree holds the
+        # operator's whole data home in the clear while the archive is built, and Windows
+        # inherits the parent DACL rather than honouring a mode, so the POSIX 0700 mkdtemp
+        # gives is not the guarantee on every platform this runs on.
+        platform_compat.restrict_dir_to_owner(work)
+        stage = Path(work) / arcname
+        # Unconditionally, before any component runs. A file-only selection whose files
+        # are all absent (a fresh home with `--components crons`) stages nothing, and the
+        # manifest write below would then fail on a missing directory -- an empty bundle
+        # is a valid outcome, a crash is not.
+        #
+        # Only the ROOT is created. A tree's own directory is created by the staging
+        # primitive, which refuses a destination name that already exists in a tree it
+        # made -- so pre-creating them here is what made the overlap collide.
+        stage.mkdir(parents=True, exist_ok=True)
 
         # Core files. Copied through the pinned primitive rather than shutil.copy2:
         # copy2 dereferences a hardlink into ordinary-looking regular bytes, and the
@@ -466,8 +1505,8 @@ def _build_snapshot(mc: Path, out: Path, name: str, *, allow_unpinned: bool = Fa
         # to reach it.
         mc_fd = pinned_fs.open_dir_pinned(mc, what="data home") if pinned else None
         try:
-            for files in CORE_FILES.values():
-                for f in files:
+            for comp in selected:
+                for f in COMPONENTS[comp].files:
                     src = mc / f
                     if mc_fd is not None:
                         # Asked through the descriptor. `is_regular_at` lstats relative to
@@ -503,6 +1542,10 @@ def _build_snapshot(mc: Path, out: Path, name: str, *, allow_unpinned: bool = Fa
                             _record_skip(pinned_fs.SKIP_SYMLINK, str(src))
                             continue
                     if f.endswith(".db"):
+                        # A component file may sit under a subdirectory
+                        # (`workspace/knowledge/knowledge.db`), so the parent is created
+                        # per file rather than assumed from the component's tree roots.
+                        (stage / f).parent.mkdir(parents=True, exist_ok=True)
                         # DATABASES ARE OUT OF SCOPE for this change, deliberately, and
                         # this is main's behaviour unchanged.
                         #
@@ -521,8 +1564,16 @@ def _build_snapshot(mc: Path, out: Path, name: str, *, allow_unpinned: bool = Fa
                             closing(sqlite3.connect(str(src))) as src_conn,
                             closing(sqlite3.connect(str(stage / f))) as dst_conn,
                         ):
-                            src_conn.backup(dst_conn)
+                            # Same contract as the tree path: a failed consistent copy is
+                            # reported by name at the command boundary, never absorbed and
+                            # never a traceback. A silently-skipped database would upload a
+                            # bundle that restores an incomplete memory.
+                            try:
+                                src_conn.backup(dst_conn)
+                            except sqlite3.Error as e:
+                                raise DatabaseCopyFailed(src, e) from e
                     elif mc_fd is not None:
+                        (stage / f).parent.mkdir(parents=True, exist_ok=True)
                         pinned_fs.copy_file_pinned(
                             str(src),
                             str(stage / f),
@@ -536,49 +1587,91 @@ def _build_snapshot(mc: Path, out: Path, name: str, *, allow_unpinned: bool = Fa
             if mc_fd is not None:
                 os.close(mc_fd)
 
-        # Workspace (exclude hygiene_data, insert_facts*.py)
-        if (mc / "workspace").is_dir():
+        # Trees. Selections overlap by design -- `memory` names workspace/memory while
+        # `workspace` names the whole tree -- so the pairs are collected first and a tree
+        # already covered by an ANCESTOR in the same selection is dropped.
+        #
+        # An earlier revision staged the overlap twice and relied on the second write being
+        # identical to the first. That worked against a `shutil.copytree(dirs_exist_ok=True)`
+        # and does NOT work here: the shared staging primitive refuses a destination name
+        # that already exists in a tree this operation created, because it cannot tell a
+        # directory it made from a link someone planted. Not copying the same bytes twice is
+        # the better answer anyway.
+        wanted_trees: list[tuple[str, str]] = []
+        for comp in selected:
+            for tree in COMPONENTS[comp].trees:
+                # Guarded HERE, while collecting, rather than in the staging loop below.
+                # An unsafe root must FAIL the snapshot, not be skipped: skipping produced
+                # the worst possible artefact -- a bundle whose manifest declares `memory`
+                # while the markdown trees are silently absent, so the operator believes
+                # they are covered and only finds out when they try to recover. A backup
+                # that lies about its contents is worse than no backup.
+                #
+                # safe_tree_root returns None only for an unsafe or unresolvable root -- a
+                # root that simply does not exist yet is fine -- so this cannot fire on a
+                # fresh data home.
+                if safe_tree_root(mc / tree, what="component root", home=mc) is None:
+                    raise UnsafeComponentRoot(
+                        f"component {comp!r} names the tree {tree!r}, which does not "
+                        f"resolve inside the data home. Refusing to write a bundle that "
+                        f"would claim to contain {comp!r} without it -- inspect that path "
+                        f"(it is usually a symlink) and re-run."
+                    )
+                wanted_trees.append((comp, tree))
+        covered = {t for _, t in wanted_trees}
+        staged_trees = [
+            (comp, tree)
+            for comp, tree in wanted_trees
+            if not any(
+                other != tree and PurePosixPath(tree).is_relative_to(PurePosixPath(other))
+                for other in covered
+            )
+        ]
+        for comp, tree in staged_trees:
+            src_dir = mc / tree
+            dst_dir = stage / tree
+            if not src_dir.is_dir():
+                continue
+            dst_dir.parent.mkdir(parents=True, exist_ok=True)
             _copytree_safe(
-                mc / "workspace",
-                stage / "workspace",
+                src_dir,
+                dst_dir,
                 allow_unpinned=allow_unpinned,
                 on_skip=_record_skip,
-                ignore=shutil.ignore_patterns("hygiene_data", "insert_facts*.py"),
+                ignore=shutil.ignore_patterns(
+                    "hygiene_data", "insert_facts*.py", *_DB_SIDECAR_GLOBS
+                ),
             )
-
-        # Plan memory
-        if (mc / "plan_memory").is_dir():
-            _copytree_safe(
-                mc / "plan_memory",
-                stage / "plan_memory",
-                allow_unpinned=allow_unpinned,
-                on_skip=_record_skip,
-            )
-
-        # Skills
-        if (mc / "skills").is_dir():
-            _copytree_safe(
-                mc / "skills",
-                stage / "skills",
-                allow_unpinned=allow_unpinned,
-                on_skip=_record_skip,
-            )
+            # A tree can contain a LIVE SQLite database (workspace/knowledge holds
+            # knowledge.db, whose WAL is routinely megabytes). A filesystem copy
+            # reads the db and its sidecars at different instants, so a concurrent
+            # write yields a restored database missing committed rows or corrupt
+            # outright. Re-copy each one through the backup API, which takes a
+            # consistent snapshot, and leave the -wal/-shm out entirely: they
+            # describe the source's transaction state, not the copy's.
+            _restage_databases(src_dir, dst_dir)
 
         # Manifest
         ws_files = sum(1 for _ in (stage / "workspace").rglob("*") if _.is_file())
         pm_files = sum(1 for _ in (stage / "plan_memory").rglob("*") if _.is_file())
-        sk_count = sum(1 for _ in (stage / "skills").iterdir() if _.is_dir())
+        sk_dir = stage / "skills"
+        sk_count = sum(1 for _ in sk_dir.iterdir() if _.is_dir()) if sk_dir.is_dir() else 0
         # Recorded so a reader can tell how the archive was built. "unpinned" means
         # the trees were walked by name, which an ancestor swap during staging could
         # have redirected. Someone deciding whether to trust this archive needs that
         # on the record rather than in the memory of whoever ran the command.
         staging_mode = "pinned" if pinned else "unpinned"
         manifest = {
-            "version": 2,
+            "version": 3,
             "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "hostname": socket.gethostname(),
             "user": os.environ.get("USER", "unknown"),
             "kirocrew_dir": str(mc),
+            "purpose": purpose.value,
+            # Which components rode, and what each declared about credential material.
+            # A reader of the bundle can answer "is this safe to hand to someone"
+            # from the manifest instead of inferring it from the file list.
+            "components": {c: COMPONENTS[c].policy.value for c in selected},
             "staging": staging_mode,
             "skipped": skipped,
             "contents": {
@@ -592,7 +1685,7 @@ def _build_snapshot(mc: Path, out: Path, name: str, *, allow_unpinned: bool = Fa
                 "skill_count": sk_count,
             },
         }
-        (stage / "MANIFEST.json").write_text(json.dumps(manifest, indent=2))
+        (stage / "MANIFEST.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
         if staging_mode == "unpinned":
             print(
                 "⚠️  Staged by path name (--allow-unpinned-staging): this platform "
@@ -606,7 +1699,7 @@ def _build_snapshot(mc: Path, out: Path, name: str, *, allow_unpinned: bool = Fa
         tmp_tar = outfile.with_suffix(".tar.gz.tmp")
         try:
             with tarfile.open(str(tmp_tar), "w:gz") as tar:
-                tar.add(str(stage), arcname=name, filter=_data_filter)
+                tar.add(str(stage), arcname=arcname, filter=_data_filter)
             # Lock the archive down BEFORE it is published. Carried over from main's
             # #5317 during the rebase: this block was extracted out of snapshot_main
             # into this function, and main had meanwhile moved the lockdown to before
@@ -655,12 +1748,26 @@ def snapshot_main(
                 "The archive's MANIFEST.json records that it was staged unpinned."
             ),
         )
+        p.add_argument("--components", default=None)
+        p.add_argument("--purpose", default=Purpose.BACKUP.value)
+        p.add_argument("--to", default=None, help=argparse.SUPPRESS)
         parsed = p.parse_args(argv)
     args = parsed
     allow_unpinned = bool(getattr(args, "allow_unpinned", False))
 
     if args.keep <= 0:
         print(f"❌ --keep value must be a positive integer, got: {args.keep}")
+        return 1
+
+    # `--to s3://…` never worked, and the off-host destination it was replaced by is now
+    # the AWS Control app's. Kept as an explicit refusal rather than dropped, because
+    # silently accepting it would write the bundle into a local directory named `s3:`.
+    if getattr(args, "to", None):
+        print(
+            f"❌ --to is no longer accepted (you passed {args.to!r}).\n"
+            f"   This command writes a local bundle. To keep a copy off-host, open the\n"
+            f"   AWS Control app's Backup section, which owns the bucket and the push."
+        )
         return 1
 
     out = Path(args.output_dir or _default_snapshot_dir())
@@ -680,7 +1787,59 @@ def snapshot_main(
 
     mc = _mc_dir()
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    # Resolve the seam before doing any work: a refusal here must cost nothing and
+    # must not leave a half-written bundle behind.
+    try:
+        purpose = Purpose(getattr(args, "purpose", None) or Purpose.BACKUP.value)
+    except ValueError:
+        print(
+            f"❌ Unknown --purpose: {args.purpose} "
+            f"(known: {', '.join(p.value for p in Purpose)})"
+        )
+        return 1
+    supplied = getattr(args, "components", None)
+    requested = [c.strip() for c in supplied.split(",") if c.strip()] if supplied else None
+    if supplied and not requested:
+        # `--components ,` parses to no names. Treating that as "no selection" is the
+        # dangerous reading: it would produce a bundle carrying nothing but a manifest,
+        # report success, and then `--keep` would count that empty bundle as the newest
+        # backup and prune a real one. An explicit flag that names nothing is a mistake
+        # in the invocation, so it fails before anything is written.
+        print(
+            f"❌ --components was given as {supplied!r}, which names no components.\n"
+            "   Refusing rather than writing an empty bundle that retention would "
+            "count as a backup.\n"
+        )
+        _list_components()
+        return 1
+    try:
+        selected = resolve_components(requested, purpose)
+    except ComponentRefused as e:
+        print(f"❌ {e}")
+        return 1
+
+    # A SELECTIVE bundle gets a root directory name that older restores refuse.
+    #
+    # This is the one guard available against a hazard that cannot be fixed in the
+    # consumer, because the consumer has already shipped: a released `kirocrew restore`
+    # never reads the manifest's component map, and `_backup_and_copy` moves each live
+    # core file out before checking whether the archive has a replacement. Point an old
+    # restore at a memory-only bundle and it relocates `crons.json`, `config.json`, the
+    # notifications store and the security files -- including `sel_hmac.key` -- into
+    # `pre-restore-<ts>/`, then prints a tick for each one.
+    #
+    # What the released code DOES do is require the extracted root to start with
+    # `kirocrew-snapshot-`, and print "Invalid snapshot format" and exit 1 otherwise --
+    # before touching anything. So naming a partial bundle's root differently converts
+    # silent data relocation into a clean refusal on every version already in the wild.
+    #
+    # The TARBALL keeps the familiar name: `--list`, pruning and `--keep` all glob
+    # `kirocrew-snapshot-*.tar.gz`, and a partial bundle still needs to be found and
+    # rotated by them. Only the directory inside it carries the marker.
+    complete = set(selected) == set(COMPONENTS)
     name = f"kirocrew-snapshot-{ts}"
+    root_name = name if complete else f"kirocrew-partial-{ts}"
 
     # Pre-flight size estimate
     if mc.is_dir():
@@ -703,7 +1862,15 @@ def snapshot_main(
             )
 
     try:
-        outfile = _build_snapshot(mc, out, name, allow_unpinned=allow_unpinned)
+        outfile = _build_snapshot(
+            mc,
+            out,
+            name,
+            selected=selected,
+            purpose=purpose,
+            root_name=root_name,
+            allow_unpinned=allow_unpinned,
+        )
     except pinned_fs.PinnedPathRefusal as exc:
         # A refusal is a decision this command made on purpose. A traceback would
         # read like a crash and bury the sentence saying what to do about it.
@@ -715,20 +1882,59 @@ def snapshot_main(
         _audit("snapshot_rejected", f"reason=unpinnable_staging detail={exc}")
         print(f"❌ {exc}")
         return 1
+    except UnsafeComponentRoot as e:
+        # Raised before the archive was published, so this is a clean refusal rather than
+        # a crash. Reported as one, for the same reason as the refusal above.
+        _audit("snapshot_rejected", f"reason=unsafe_component_root detail={e}")
+        print(f"❌ {e}")
+        return 1
+    except DatabaseCopyFailed as e:
+        # A database that could not be copied consistently means the bundle would restore
+        # incomplete memory. Refusing is the only honest answer: a bundle reported as
+        # created is a bundle the operator will rely on.
+        _audit("snapshot_rejected", f"reason=database_copy_failed detail={e}")
+        print(f"❌ {e}")
+        print("   No bundle was written. Stop the gateway and re-run.")
+        return 1
 
     sz = outfile.stat().st_size
     human = f"{sz // 1024}K" if sz < 1024 * 1024 else f"{sz / 1024 / 1024:.1f}M"
+
+    # The bound belongs at CREATION, not only on the paths that move a bundle around. A
+    # bundle past it cannot be restored by this tool, so reporting success would promise a
+    # backup that does not exist -- and the prune below would then delete older bundles that
+    # DO restore in favour of one that never will. Checked before both.
+    try:
+        with tarfile.open(outfile) as probe:
+            _refuse_oversized_archive(probe)
+    except _ArchiveTooLarge as e:
+        print(f"❌ {e}.")
+        print(
+            f"   The archive is written at {outfile}, and nothing was pruned -- but this "
+            "tool cannot restore it. Narrow it with --components, then delete this one."
+        )
+        _audit("snapshot_rejected", f"{outfile} ({human}): {e}")
+        return 1
+    except (tarfile.TarError, OSError, EOFError) as e:
+        print(f"❌ The archive just written could not be read back ({e}).")
+        print(f"   Left in place at {outfile}; nothing was pruned.")
+        _audit("snapshot_rejected", f"{outfile} ({human}): unreadable: {e}")
+        return 1
+
     print(f"✅ Snapshot created: {outfile} ({human})")
 
     _audit("snapshot_created", f"{outfile} ({human})")
 
-    # Prune
+    # Prune. This runs even when the upload failed, because --keep is a promise about
+    # local disk and a persistently failing destination must not turn a daily backup
+    # into an unbounded pile of bundles -- the disk fills, and then the snapshot that
+    # would have worked cannot be written either.
     snaps = sorted(
         out.glob("kirocrew-snapshot-*.tar.gz"), key=lambda x: x.stat().st_mtime, reverse=True
     )
     for old in snaps[args.keep :]:
         old.unlink()
-        print(f"🗑  Pruned: {old.name}")
+        print(f"🗑  Pruned: {_safe_name(old.name)}")
 
     remaining = len(list(out.glob("kirocrew-snapshot-*.tar.gz")))
     print(f"📦 Snapshots in {out}: {remaining} (keep={args.keep})")
@@ -743,7 +1949,7 @@ def _print_manifest(snap: Path) -> None:
     if not mf.is_file():
         return
     try:
-        m = json.loads(mf.read_text())
+        m = json.loads(mf.read_text(encoding="utf-8"))
         print("📋 Snapshot info:")
         # Every string below comes out of an archive the caller supplied, so all of them
         # go through _terminal_safe. Review named the omission list this change added;
@@ -758,6 +1964,15 @@ def _print_manifest(snap: Path) -> None:
             f"@{_terminal_safe(m.get('hostname', 'unknown'))}"
         )
         c = m.get("contents", {})
+        # Absent in bundles written before the purpose seam existed. Say so rather than
+        # printing a default, so an old bundle is never read as a declared one.
+        print(f"  Purpose: {_safe_name(m.get('purpose'), 'undeclared (pre-seam bundle)')}")
+        comps = m.get("components")
+        if isinstance(comps, dict) and comps:
+            rendered = ", ".join(
+                f"{_safe_name(k, '?')} [{_safe_name(v, '?')}]" for k, v in sorted(comps.items())
+            )
+            print(f"  Components: {rendered}")
         print(f"  Memory DB: {c.get('memory_db', 0) // 1024} KB")
         print(f"  Crons: {c.get('crons_json', 0) // 1024} KB")
         print(f"  Workspace files: {c.get('workspace_files', 0)}")
@@ -797,9 +2012,14 @@ def _validate_identifier(name: str) -> str:
 
 
 def _merge_memory(src_db: Path, dst_db: Path) -> None:
-    # Integrity check on source DB before ATTACH
+    # Integrity check on source DB before ATTACH.
+    #
+    # `closing`, not a bare `with sqlite3.connect(...)`: a connection used as a context
+    # manager commits or rolls back the TRANSACTION and leaves the connection OPEN. The
+    # handle it kept on src_db made the caller's extraction temp dir undeletable on
+    # Windows, which is how this surfaced.
     try:
-        with sqlite3.connect(str(src_db)) as check_conn:
+        with closing(sqlite3.connect(str(src_db))) as check_conn:
             result = check_conn.execute("PRAGMA integrity_check;").fetchone()[0]
         if result != "ok":
             print(f"  ⚠️  Source DB integrity check failed: {result} — skipping merge")
@@ -898,6 +2118,8 @@ def _usable_cron_shape(parsed: object, path: Path) -> bool:
 
 
 def _merge_crons(src_path: Path, dst_path: Path) -> None:
+    # Cron job names are operator-authored text and routinely non-ASCII, so the
+    # locale codepage is the wrong decoder for this file on any host.
     try:
         src = json.loads(src_path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
@@ -919,7 +2141,7 @@ def _merge_crons(src_path: Path, dst_path: Path) -> None:
         job["id"] = hashlib.md5(f"{name}-imported".encode(), usedforsecurity=False).hexdigest()[:8]
         dst.setdefault("jobs", []).append(job)
         imported += 1
-    dst_path.write_text(json.dumps(dst, indent=2))
+    dst_path.write_text(json.dumps(dst, indent=2), encoding="utf-8")
     total = len(src.get("jobs", []))
     print(f"  Cron jobs imported: {imported} (skipped {total - imported} duplicates)")
 
@@ -947,9 +2169,25 @@ def _merge_notifications(src_path: Path, dst_path: Path) -> None:
 
 
 def _backup_and_copy(
-    mc: Path, backup: Path, snap: Path, component: str, *, allow_unpinned: bool = False
+    mc: Path,
+    backup: Path,
+    snap: Path,
+    component: str,
+    *,
+    allow_unpinned: bool = False,
+    installed: set[str] | None = None,
 ) -> None:
     """Move the live core files aside, then restore the archive's, destination pinned.
+
+    *installed*, when given, is the rollback ledger, and this function is the ONLY place
+    that may add a core file to it: a name goes in immediately before that file's own first
+    mutation and never before, because the recovery leg reads membership as "this run
+    reached this path". The caller used to add every file the component DECLARES up front,
+    which is a different set -- a bundle may legitimately carry only some of them, and the
+    loops below SKIP the rest. Recovery then saw a file with no saved copy that was
+    nonetheless "installed", concluded the restore had created it, and deleted the
+    operator's untouched file. Recording per file is what makes membership mean what the
+    recovery leg already documents it to mean.
 
     The restore side used to compose ``mc / f`` and hand it to ``shutil.copy2``, so
     the destination was reached by name every time. Two consequences, both real: a
@@ -974,6 +2212,11 @@ def _backup_and_copy(
                 if (snap / f).exists():
                     print(f"⚠️  Skipping symlinked file from snapshot: {snap / f}")
                 continue
+            # Past the skip, so this file WILL be mutated. Recorded now, before the move
+            # below, so a crash mid-write still leaves the name known to have been reached
+            # -- and, just as importantly, a file skipped above is never recorded at all.
+            if installed is not None:
+                installed.add(f)
             live = mc / f
             if live.is_symlink() or pinned_fs.is_reparse_point(live):
                 print(f"⚠️  Moving symlinked core file aside during backup: {live}")
@@ -1037,6 +2280,12 @@ def _backup_and_copy(
                     # destination-ownership check.
                     if not pinned_fs.is_regular_at(src_fd, f):
                         continue
+                    # Same point as the fallback branch: past the skip, so this file is
+                    # about to be mutated and is recorded BEFORE the move. A file the
+                    # bundle does not carry never reaches here, so recovery correctly reads
+                    # it as never touched and leaves it alone.
+                    if installed is not None:
+                        installed.add(f)
                     # A symlink at a core file's name is MOVED aside like any other
                     # occupant, not skipped. The old code skipped the move and then let
                     # the copy write through the very link it had just declined to
@@ -1212,23 +2461,428 @@ def _backup_tree_or_refuse(src: Path, dst: Path, *, allow_unpinned: bool = False
     )
 
 
+def _refuse_unsafe_destination_roots(mc: Path, components: list[str] | None) -> None:
+    """Refuse before touching anything if a selected component's tree root is unsafe.
+
+    Hoisted ahead of every mutation on purpose. Checking inside the per-tree loops was
+    too late in the worst way: `_backup_and_copy` has already swapped the databases by
+    then, so skipping an unsafe markdown tree left memory split between two versions —
+    and the command still reported success. A partial restore reported as complete is
+    the same lie as a partial backup reported as complete.
+
+    Both restore modes call this. Merge is additive and destroys nothing, but a merge
+    that silently omits a tree is still a merge that claims to have imported it.
+    """
+    offenders = []
+    for comp in COMPONENTS:
+        if not _want(components, comp):
+            continue
+        for tree in COMPONENTS[comp].trees:
+            d = mc / tree
+            if safe_tree_root(d, what="destination root", home=mc) is None:
+                offenders.append(f"{comp}:{tree}")
+    if offenders:
+        raise UnsafeComponentRoot(
+            "these destination trees do not resolve inside the data home: "
+            + ", ".join(offenders)
+            + ". Nothing has been changed. Inspect those paths (usually a symlink) "
+            "and re-run — restoring past them would leave memory split between the "
+            "old and new versions while reporting success."
+        )
+
+
+def _refuse_corrupt_source_databases(
+    snap: Path,
+    components: list[str] | None,
+    *,
+    mc_for_merge: Path | None,
+) -> None:
+    """Refuse a bundle whose incoming components are unsound, BEFORE any live state moves.
+
+    Validation has to precede mutation, and for this path that is not a stylistic
+    preference. Putting the incoming file where the live one was and only then checking it
+    can report that the home is now sitting on a corrupt database, which is the outcome the
+    check exists to prevent. A bundle arriving over the network from object storage is
+    untrusted input no matter whose bucket held it, so it is validated at the point where
+    refusing is still free.
+
+    **The condition is "does this restore read or install the file", not "is this replace
+    mode".** Replace installs everything it carries, so *mc_for_merge* is ``None`` and
+    every declared entry is checked. Merge is per-file, because merge is not one behaviour:
+    it installs some files, parses others in place, and leaves the rest alone — see
+    `_merge_reads` for the three cases and why a single destination-existence test was the
+    wrong proxy for all of them.
+
+    Every incoming database for the SELECTED components is checked, not just the largest
+    or the first.
+
+    Unreadable counts as unsound. Tolerating a file named `.db` that SQLite cannot open
+    is right when *creating* a snapshot (the operator's home is the source of truth and
+    the file is copied verbatim), and wrong when consuming one: there the file is about
+    to BECOME the operator's memory.
+    """
+
+    def _merge_reads(rel: str) -> bool:
+        """Whether MERGE reads or installs *rel*, so validation has to cover it.
+
+        A single "is the destination missing" test was a proxy, and it was wrong in two
+        places, both of which merge genuinely consumes:
+
+        * `crons.json` is PARSED when a local one exists (`_merge_crons` json-loads both
+          sides) and copied when it does not. Either way merge reads it, so a malformed
+          file is never harmless — skipping it because the destination exists is what let
+          an unparseable file reach an unguarded `json.loads`.
+        * `memory_index.db` is copied alongside `memory.db` exactly when the live
+          `memory.db` is ABSENT, whatever the index's own destination looks like. Keying on
+          the index's own path let a corrupt index overwrite a healthy one.
+
+        Everything else is installed only where its own destination is missing.
+        """
+        assert mc_for_merge is not None
+        if rel == "crons.json":
+            return True
+        if rel == "memory_index.db":
+            return not (mc_for_merge / "memory.db").exists()
+        return not (mc_for_merge / rel).exists()
+
+    def _will_install(rel: str) -> bool:
+        if mc_for_merge is None:
+            return True  # replace installs everything the bundle carries
+        return _merge_reads(rel)
+
+    for component, files in CORE_FILES.items():
+        if not _want(components, component):
+            continue
+        for name in files:
+            src = snap / name
+            if not src.exists() and not platform_compat.is_link_or_junction(src):
+                continue  # absent from a selective bundle; nothing to validate
+            if not _will_install(name):
+                continue
+            # "Not a file" is NOT the same as "not there". A directory (or a symlink)
+            # occupying a declared file's name would otherwise read as absent, skip every
+            # check below, and then let replace move the operator's live copy aside and
+            # report success having restored nothing in its place.
+            if not src.is_file() or platform_compat.is_link_or_junction(src):
+                raise SourceComponentUnsound(
+                    f"{name} in this snapshot is not a regular file.\n"
+                    "   Refusing to restore: a declared component file that is a "
+                    "directory or a link cannot replace the live one."
+                )
+            if name.endswith((".db", ".sqlite3")):
+                _refuse_unless_sound(src, name, strict=True)
+            elif name in COMPONENT_JSON_OBJECTS:
+                # "Will this file reach a consumer?" -- not "is this a replace?". Merge
+                # installs after all when the destination is ABSENT: the per-component
+                # branch merges only `if dst.is_file()`, and its sibling `else` copies the
+                # bundle's file in verbatim with no validation. An absent destination is the
+                # FRESH MACHINE case, which is the scenario a backup exists for, so the one
+                # path that skipped this check was the likeliest one to need it.
+                #
+                # Reproduced: a well-formed JSON ARRAY in the bundle, no live `crons.json`,
+                # merge -> copied verbatim, rc=0, reported success -- and the cron loader's
+                # `isinstance(data, dict) else []` branch then reports zero jobs. Every
+                # schedule silently gone, nothing raised, nothing retried.
+                will_install = mc_for_merge is None or not (mc_for_merge / name).is_file()
+                _refuse_unless_json_object(src, name, installed=will_install)
+
+    # Component TREES carry databases too, and a tree is copied wholesale: the knowledge
+    # store lives at `workspace/knowledge/knowledge.db`, inside a tree the memory
+    # component declares. Checking only the top-level declared files leaves exactly the
+    # same hole one directory down.
+    #
+    # Strictness is per PATH, not per location. A database this product owns is strict
+    # wherever it lives: `workspace/knowledge/knowledge.db` is as much ours as
+    # `memory.db`, so an unopenable one is a broken bundle, not an operator's stray file.
+    # Leniency exists only for the INCIDENTAL contents of a tree, where a `.db` that is
+    # not SQLite is ordinary — a Windows `Thumbs.db` is on this product's own ignore list
+    # — and refusing those would block restores over files that were never databases.
+    for component, trees in COMPONENT_TREES.items():
+        if not _want(components, component):
+            continue
+        for tree in trees:
+            root = snap / tree
+            if not root.exists() and not platform_compat.is_link_or_junction(root):
+                continue  # absent from a selective bundle; nothing to validate
+            if not root.is_dir() or platform_compat.is_link_or_junction(root):
+                raise SourceComponentUnsound(
+                    f"{tree} in this snapshot is not a directory.\n"
+                    "   Refusing to restore: a declared component tree that is a file "
+                    "or a link cannot replace the live one."
+                )
+            for src in sorted(root.rglob("*")):
+                # Sidecars (`.db-wal`, `.db-shm`) do not match these suffixes, so they
+                # need no separate exclusion.
+                if not src.is_file() or not src.name.endswith((".db", ".sqlite3")):
+                    continue
+                rel = src.relative_to(snap).as_posix()
+                if not _will_install(rel):
+                    continue
+                _refuse_unless_sound(src, rel, strict=rel in PRODUCT_TREE_DATABASES)
+
+
+def _report_unmerged_databases(src_tree: Path, dst_tree: Path, tree: str) -> None:
+    """Say when merge is about to KEEP a product database rather than merge it.
+
+    Merge copies trees without overwriting, which is right for markdown: a local file that
+    is newer than the bundle's must survive. Applied to one of our own databases it means
+    the incoming rows are silently dropped — the operator asked to merge their knowledge
+    library and got a success message that imported none of it.
+
+    Merging those rows for real is not a copy. `knowledge.db` carries an FTS5 index plus
+    foreign keys spanning `sources`, `items`, `mentions` and `source_locations`, so a
+    correct merge has to remap keys, rebuild the derived index, and first decide what makes
+    two documents the same document. `_merge_memory` is a hand-built per-table merge for
+    exactly that reason, and there is no equivalent here yet.
+
+    Until there is, the honest thing is to name it. Silence is what turns a known
+    limitation into apparent data loss.
+    """
+    for rel in sorted(PRODUCT_TREE_DATABASES):
+        prefix = f"{tree}/"
+        if not rel.startswith(prefix):
+            continue
+        leaf = rel[len(prefix) :]
+        if (src_tree / leaf).is_file() and (dst_tree / leaf).is_file():
+            print(
+                f"  ⚠️  {rel}: kept the existing database; the bundle's copy was NOT "
+                "merged into it.\n"
+                "      Merge mode does not combine this database's rows. To take the "
+                "bundle's copy instead, use --mode replace."
+            )
+
+
+def _refuse_unless_json_object(src: Path, label: str, *, installed: bool) -> None:
+    """Raise unless *src* parses as a JSON object.
+
+    A database is not the only thing a restore can install broken. The consumers of these
+    files treat an unreadable one as an EMPTY one — `crons.json`'s loader falls back to
+    "no jobs" on both a parse error and a well-formed array — so installing a corrupt file
+    silently discards the operator's content while the restore reports success. Silent
+    emptiness is the worst failure available here: nothing raises, so nothing is retried.
+
+    *installed* is what separates the two hazards, because only one of them is silent.
+    Replace INSTALLS this file, so an unparseable one reaches the consumer and reads as
+    empty — refusing is the only way the operator hears about it. Merge USUALLY does not
+    install it: when a live copy exists, the per-component merger reads the bundle's copy,
+    reports a file it cannot parse, and returns without writing live state, so the content
+    is neither lost nor lost quietly. Refusing there would turn one unreadable component
+    into a failed restore of every other one, which is the opposite of what an off-host
+    backup is for.
+
+    "Usually" is load-bearing, and this docstring used to say "never". Merge's per-component
+    branch merges only `if dst.is_file()`; its sibling `else` copies the bundle's file in
+    VERBATIM. So an absent destination -- the fresh-machine case, which is the scenario a
+    backup exists for -- does install, and was the one path skipping this check. The caller
+    therefore decides *installed* from "will this reach a consumer", not from "is this a
+    replace". Reproduced before the fix: a well-formed JSON array, no live `crons.json`,
+    merge copied it verbatim and reported success, and the cron loader then read zero jobs.
+
+    Only structure is checked, not schema. Parsing proves the file survived transport and
+    is the shape its consumer branches on; asserting field-level schema here would
+    duplicate each consumer's own validation and refuse bundles those consumers accept.
+
+    The shape checks below are gated on *installed* too, matching the parse branch,
+    because the merger itself now guards the merge path: `_merge_crons` runs
+    `_usable_cron_shape` over BOTH sides and returns without writing when either is
+    misshapen, and that guard is a superset of this one -- it also rejects a non-string
+    job name and a lone surrogate inside one.
+    """
+    try:
+        parsed = json.loads(src.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        if not installed:
+            return
+        raise SourceComponentUnsound(
+            f"{label} in this snapshot could not be read as JSON ({e}).\n"
+            "   Refusing to restore it over live state: its reader treats an unreadable "
+            "file as an empty one, so this would discard content silently."
+        ) from e
+    # Everything past here is an INSTALL-path check, in ONE place rather than a gate per
+    # branch, so a check added later cannot forget to carry the condition.
+    #
+    # The merge path is guarded by the merger: `_merge_crons` runs `_usable_cron_shape`
+    # over BOTH sides and returns without writing when either is misshapen, and that guard
+    # is a superset of these -- it also rejects a non-string job name and a lone surrogate
+    # inside one. An earlier revision ran the shape checks in both modes on the grounds
+    # that a merger's guard caught only a file it could not PARSE, so `{"jobs": ["x"]}`
+    # would flow past it; that is no longer true, so refusing on the merge path would only
+    # turn one misshapen component into a failed restore of every other one.
+    #
+    # The install path has no such guard -- it copies the file in and the consumer reads an
+    # unusable one as empty -- so here this refusal is the only thing between a misshapen
+    # bundle and silently discarded jobs.
+    if not installed:
+        return
+    if not isinstance(parsed, dict):
+        raise SourceComponentUnsound(
+            f"{label} in this snapshot is a JSON {type(parsed).__name__}, not an "
+            "object.\n"
+            "   Refusing to restore it over live state: its reader expects an object and "
+            "treats anything else as empty."
+        )
+    # An object at the top is necessary and not sufficient: the readers iterate a named
+    # list and call `.get` on each entry, so a `jobs` that is not a list of objects
+    # reaches attribute access on a `str` and raises mid-restore.
+    for key in _JSON_OBJECT_LISTS.get(src.name, ()):
+        if key not in parsed:
+            continue
+        entries = parsed[key]
+        if not isinstance(entries, list):
+            raise SourceComponentUnsound(
+                f"{label} in this snapshot has '{key}' as a JSON "
+                f"{type(entries).__name__}, not a list.\n"
+                "   Refusing to restore it over live state: its reader iterates that "
+                "key and would fail partway through."
+            )
+        for i, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                raise SourceComponentUnsound(
+                    f"{label} in this snapshot has '{key}[{i}]' as a JSON "
+                    f"{type(entry).__name__}, not an object.\n"
+                    "   Refusing to restore it over live state: its reader reads fields "
+                    "off each entry and would fail partway through."
+                )
+
+
+def _refuse_unless_sound(src: Path, label: str, *, strict: bool) -> None:
+    """Raise unless *src* is a sound SQLite database.
+
+    *strict* decides what an unopenable file means: a refusal for a database this product
+    declares by name, and nothing at all for a `.db` found inside an operator's own tree,
+    which may legitimately not be SQLite.
+    """
+    # SQLite treats a ZERO-BYTE file as a valid, empty database: it opens, and
+    # `integrity_check` answers `ok`. So the check below cannot see the difference between
+    # a healthy database and a snapshot that captured nothing, and replace mode would
+    # install empty memory over live memory and report success. Size is the only place
+    # that distinction is visible, so it is read before the file is opened.
+    try:
+        if src.stat().st_size == 0:
+            raise SourceComponentUnsound(
+                f"{label} in this snapshot is EMPTY (zero bytes). SQLite opens such a "
+                "file as a valid empty database, so this would replace your live data "
+                "with nothing and report success.\n"
+                "   Refusing to restore it. Take a fresh snapshot."
+            )
+    except OSError as e:
+        if not strict:
+            return
+        raise SourceComponentUnsound(
+            f"{label} in this snapshot could not be read ({e}).\n"
+            "   Refusing to restore it over live state."
+        )
+    try:
+        with closing(sqlite3.connect(str(src))) as conn:
+            result = conn.execute("PRAGMA integrity_check;").fetchone()[0]
+    except sqlite3.Error as e:
+        if not strict:
+            return  # not a database; not this code's business
+        raise SourceComponentUnsound(
+            f"{label} in this snapshot: integrity check failed — it cannot be "
+            f"opened as a database ({e}).\n"
+            "   Refusing to restore it over live state."
+        ) from e
+    if result != "ok":
+        raise SourceComponentUnsound(
+            f"{label} in this snapshot: integrity check failed ({result}).\n"
+            "   Refusing to restore it over live state."
+        )
+
+
+def _allocate_rollback_dir(mc: Path) -> Path:
+    """Create a rollback directory that is this restore's alone.
+
+    The timestamp is second-granular, so two restores inside one second would otherwise
+    share a directory. That is not a naming nicety: the tree saves below refuse to write
+    into an existing destination on purpose — one rollback set holding files from two
+    restores rolls back to neither generation — so a shared directory turned the second
+    restore into an uncaught `FileExistsError` instead of a clean refusal.
+
+    `mkdir` without `exist_ok` is the allocation: it is atomic, so the winner of a race
+    gets the name and the loser moves to the next suffix rather than both proceeding.
+    """
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    for attempt in range(1, 64):
+        name = f"pre-restore-{ts}" if attempt == 1 else f"pre-restore-{ts}-{attempt}"
+        candidate = mc / name
+        try:
+            candidate.mkdir()
+        except FileExistsError:
+            continue
+        return candidate
+    raise SourceComponentUnsound(
+        f"could not allocate a rollback directory under {mc} — "
+        f"'pre-restore-{ts}' and 63 suffixed variants all exist.\n"
+        "   Refusing to restore without somewhere to save the current state."
+    )
+
+
 def _do_replace(
     snap: Path, mc: Path, components: list[str] | None, *, allow_unpinned: bool = False
 ) -> None:
-    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    backup = mc / f"pre-restore-{ts}"
-    backup.mkdir(exist_ok=True)
+    """Replace the selected components, with a complete rollback set taken first.
+
+    Two phases, and the boundary between them is the whole design. Phase one copies every
+    tree this run will mutate into a fresh rollback directory and mutates nothing; phase
+    two performs every mutation. A refusal in phase one therefore aborts with the data home
+    untouched, and a failure in phase two can be reverted from a rollback set that is known
+    to be complete -- the ordering an earlier revision got wrong by running the core-file
+    swap loop first, which aborted with the new databases live and the old trees live.
+    """
+    # Before anything is created or copied: a destination tree root that does not resolve
+    # inside the data home would have the restore write outside it.
+    _refuse_unsafe_destination_roots(mc, components)
+    backup = _allocate_rollback_dir(mc)
     print("🔄 Replace mode — backing up current state...")
 
-    # The ENTIRE rollback set is completed before the first live mutation. A tree
-    # backup can refuse (its fatal skip reporter raises on an entry it cannot
-    # copy, e.g. a hardlink alias or a symlink), and refusing is only safe
-    # while nothing has been swapped yet: the previous ordering ran the core-file
-    # swap loop first, so a tree-backup refusal aborted with the new databases
-    # live and the old trees live -- mixed state, with a rollback set missing the
-    # very trees the abort was protecting. Same
-    # complete-validation-before-first-mutation ordering the unsafe-root check
-    # already follows, applied to the rollback copy (issue #2844, failure mode 3).
+    # `memory` names workspace/memory and workspace/knowledge. Selecting it ALONE must
+    # save and replace just those subtrees; when `workspace` is also selected its own pass
+    # covers them, and doing both would save the INCOMING memory over the saved original.
+    mem_roots: list[tuple[str, Path]] = []
+    if _want(components, "memory") and not _want(components, "workspace"):
+        unsafe_now = []
+        for tree in COMPONENTS["memory"].trees:
+            d = mc / tree
+            if safe_tree_root(d, what="destination root", home=mc) is None:
+                # REFUSED, not skipped. `_refuse_unsafe_destination_roots` already cleared
+                # this exact set moments ago, so a root that fails here failed AFTER that
+                # check -- something moved under us mid-run. This used to `continue`, which
+                # dropped the tree from `mem_roots` entirely: it was then neither saved nor
+                # restored, and the run still printed "Replace complete." Reproduced by
+                # letting the preflight pass and swapping `workspace` for an external link
+                # immediately after -- both memory trees were silently dropped and the
+                # command exited 0, so an operator restoring after losing a machine would
+                # believe memory came back when only the databases had. That is the very
+                # lie the hoisted preflight was written to end, surviving in the one site
+                # the hoist did not convert. Safe to raise here: this runs before phase
+                # one, so no live state has been mutated yet.
+                unsafe_now.append(f"memory:{tree}")
+            else:
+                mem_roots.append((tree, d))
+        if unsafe_now:
+            raise UnsafeComponentRoot(
+                "these destination trees stopped resolving inside the data home after the "
+                "pre-flight check passed: " + ", ".join(unsafe_now) + ". Nothing has been "
+                "changed. A path that was safe moments ago and is not now was replaced "
+                "mid-run (usually a symlink), so restoring past it would leave memory "
+                "split between the old and new versions while reporting success."
+            )
+
+    # ── Phase one: the rollback set. No live state is mutated in this block. ──
+    #
+    # `_backup_tree_or_refuse` reports a skipped entry as FATAL, so a tree that cannot be
+    # copied whole raises here rather than being rmtree'd later with an incomplete backup.
+    for tree, d in mem_roots:
+        if d.is_dir():
+            # `tree` is NESTED (`workspace/memory`), so the rollback destination's parent
+            # does not exist in a freshly-allocated backup dir. The pinned primitive pins
+            # an existing parent chain and does not create one -- callers create their own
+            # tree roots -- so without this the copy fails with FileNotFoundError on the
+            # intermediate component. The single-level trees below are unaffected because
+            # their parent IS the backup dir.
+            (backup / tree).parent.mkdir(parents=True, exist_ok=True)
+            _backup_tree_or_refuse(d, backup / tree, allow_unpinned=allow_unpinned)
     if _want(components, "workspace"):
         for dirname in ("workspace", "plan_memory"):
             d = mc / dirname
@@ -1239,16 +2893,175 @@ def _do_replace(
         if sk.is_dir():
             _backup_tree_or_refuse(sk, backup / "skills", allow_unpinned=allow_unpinned)
 
+    # Every relative path phase two can write. Recovery needs it because a target that did
+    # not exist before the restore has nothing saved for it, so putting saved entries back
+    # would leave that creation standing.
+    targets: list[str] = []
     for comp in ("memory", "crons", "config", "notifications", "security"):
         if _want(components, comp):
-            _backup_and_copy(mc, backup, snap, comp, allow_unpinned=allow_unpinned)
+            targets.extend(COMPONENTS[comp].files)
+    if _want(components, "workspace"):
+        targets.extend(("workspace", "plan_memory"))
+    if _want(components, "skills"):
+        targets.append("skills")
+    targets.extend(tree for tree, _ in mem_roots)
+
+    # Grows as phase two touches each target; recovery reads it to tell a creation from a
+    # target the phase never reached.
+    installed: set[str] = set()
+    try:
+        _do_replace_mutations(
+            snap, mc, backup, components, mem_roots, installed, allow_unpinned=allow_unpinned
+        )
+    except BaseException as e:
+        # `BaseException`, not `Exception`, and deliberately wider than the three named
+        # classes this used to catch. `PinnedPathRefusal` was added here because it fires
+        # MID-mutation and leaving it out left live state half replaced; `KeyboardInterrupt`
+        # has exactly that property and is not an `Exception` at all, so it walked past this
+        # handler entirely. Reproduced: a Ctrl-C after the memory component was replaced left
+        # `memory.db` holding the archive's copy and `crons.json` still the live one, with no
+        # rollback attempted. A restore is the one operation where an interrupt must not be
+        # taken at face value -- the operator's own state is mid-swap.
+        #
+        # The exception is always re-raised, so an interrupt still terminates the command and
+        # `SystemExit` still exits; what changes is that the previous state is put back first.
+        # A second interrupt DURING the rollback cannot be defended against here, and the
+        # rollback directory is what answers for it.
+        #
+        # Phase one is deliberately outside this try: a refusal there happens before any
+        # mutation, so there is nothing to roll back and the clean refusal is the answer.
+        failed = _restore_everything_from_rollback(
+            backup, mc, targets, installed, allow_unpinned=allow_unpinned
+        )
+        if failed:
+            # The revert is part of the outcome, not a side effect of it. Re-raising the
+            # original error alone would let the caller summarise this as "you are back
+            # where you started", which is the one thing that must not be said when some
+            # of the previous state now exists only in the rollback directory.
+            raise RollbackIncomplete(e, failed, backup) from e
+        raise
+
+    try:
+        backup.rmdir()
+    except OSError:
+        print(f"  Previous state saved to: {backup}/")
+    print("✅ Replace complete.")
+
+
+def _component_payload_absent(snap: Path, component: str) -> bool:
+    """Does *snap* carry nothing this component could actually restore?
+
+    Declared-but-hollow is the shape this answers: the manifest says a component rode, and the
+    bundle holds none of its data. Replace then clears the live state for it -- memory trees
+    are cleared unconditionally, and a derived index is now removed too -- with nothing to put
+    back, which is a partial erasure rather than a restore.
+
+    A DERIVED index is not payload. A bundle carrying only `memory_index.db` has no memory to
+    restore, and counting it would let precisely the reproduced case through.
+
+    Files AND trees both count, so a component whose data is a directory is not called hollow
+    just because it keeps no flat file. Derived from `COMPONENTS` / `CORE_FILES`, never a
+    hand-written list: a component gaining a file later must not silently start passing this
+    check on the strength of a stale enumeration.
+    """
+    spec = COMPONENTS.get(component)
+    if spec is None:
+        return False  # not a component this function knows how to judge; do not refuse on it
+    for rel in getattr(spec, "files", ()) or ():
+        if rel in _DERIVED_INDEXES:
+            continue
+        if (snap / rel).exists():
+            return False
+    for rel in getattr(spec, "trees", ()) or ():
+        if (snap / rel).exists():
+            return False
+    return True
+
+
+def _drop_derived_indexes_absent_from_bundle(
+    snap: Path, mc: Path, backup: Path, installed: set[str]
+) -> None:
+    """Remove a live derived index the archive does not carry, saving it first.
+
+    Replace means the destination ends up matching the archive. The memory-TREE loop already
+    says so and clears unconditionally for it; a derived index is a FILE and never got the
+    same treatment, so `_backup_and_copy` skipped it (`(snap / f).is_file()` is false) and
+    left the live one in place. The result is the restored payload indexed by the PREVIOUS
+    one: searches answer from memory that was just replaced.
+
+    That gap is reachable precisely because the redaction pass DROPS `memory_index.db` from an
+    off-host bundle -- so a redacted bundle is the ordinary way to arrive here, not an exotic
+    one. The comment justifying that drop pointed at restore "telling the operator to rebuild
+    it", which is true only when the live index is absent too: the warning tests the file
+    after the restore, and a surviving stale index means no warning is printed at all.
+
+    Removing it is what makes the absence real, so the existing warning fires and the index is
+    rebuilt from the restored payload. Scoped to derived indexes ON PURPOSE -- a missing
+    payload database is a different question with a different answer (refuse, not delete), and
+    it is answered elsewhere.
+    """
+    for rel in sorted(_DERIVED_INDEXES):
+        if (snap / rel).is_file():
+            continue  # the archive carries it; the ordinary copy path applies
+        live = mc / rel
+        if not (live.is_file() or live.is_symlink() or platform_compat.is_link_or_junction(live)):
+            continue
+        # Recorded immediately before the move, never earlier: the recovery leg reads
+        # membership as "this run reached this path", and the move below IS the save it
+        # needs. Adding the name before a save is known is what let recovery delete an
+        # occupant it had never saved.
+        installed.add(rel)
+        if platform_compat.is_link_or_junction(live) and not live.is_symlink():
+            # A junction is a directory reparse point; `shutil.move` on it is not the
+            # pairing this repo uses. Remove the link itself -- there is nothing to save,
+            # because the link's target is not ours and stays where it is.
+            platform_compat.unlink_link_or_junction(live)
+        else:
+            shutil.move(str(live), str(backup / rel))
+        print(f"  ↩️  {rel} is not in the archive — moved aside so it can be rebuilt")
+
+
+def _do_replace_mutations(
+    snap: Path,
+    mc: Path,
+    backup: Path,
+    components: list[str] | None,
+    mem_roots: list[tuple[str, Path]],
+    installed: set[str],
+    *,
+    allow_unpinned: bool = False,
+) -> None:
+    """Every mutation replace mode performs, so one handler can revert all of them.
+
+    *installed* accumulates every declared path this run begins writing, and is recorded
+    BEFORE the write rather than after, so a target interrupted mid-write is still known
+    to have been reached. Recovery needs that: a file is saved by moving it aside at the
+    moment of its own mutation, so "nothing saved" is ambiguous until you know whether the
+    phase ever got there.
+
+    A memory tree is CLEARED unconditionally and refilled only when the archive carries it,
+    because replace means the destination ends up matching the archive. Do not read
+    `_trees_absent_from_bundle` as covering that: it refuses only bundles with no component
+    map, and a v3 bundle may legitimately declare `memory` without carrying every tree of it.
+    """
+    for comp in ("memory", "crons", "config", "notifications", "security"):
+        if _want(components, comp):
+            _backup_and_copy(
+                mc, backup, snap, comp, allow_unpinned=allow_unpinned, installed=installed
+            )
             print(f"  ✅ {comp}")
+
+    if _want(components, "memory"):
+        # After the copy, not before: the loop above is what installs the index when the
+        # archive HAS it, and this only has to answer for the case where it does not.
+        _drop_derived_indexes_absent_from_bundle(snap, mc, backup, installed)
 
     if _want(components, "workspace"):
         for dirname in ("workspace", "plan_memory"):
             d = mc / dirname
             sd = snap / dirname
             if sd.is_dir():
+                installed.add(dirname)
                 if d.is_dir():
                     shutil.rmtree(str(d))
                 # rmtree just removed the live tree, so a skipped source entry here means
@@ -1257,7 +3070,6 @@ def _do_replace(
                 # `must_create` is what makes the removal mean something. Without it the
                 # walk accepted a root recreated between the rmtree and the copy, so files
                 # the archive does not contain survived a REPLACE that reported success.
-                # Review found it; this is the only caller that knows it removed the tree.
                 _copytree_safe(
                     sd,
                     d,
@@ -1271,6 +3083,7 @@ def _do_replace(
         sk = mc / "skills"
         snap_sk = snap / "skills"
         if snap_sk.is_dir():
+            installed.add("skills")
             if sk.is_dir():
                 shutil.rmtree(str(sk))
             _copytree_safe(
@@ -1284,16 +3097,251 @@ def _do_replace(
             )
         print("  ✅ skills")
 
-    try:
-        backup.rmdir()
-    except OSError:
-        print(f"  Previous state saved to: {backup}/")
-    print("✅ Replace complete.")
+    # Scoped to memory's own subtrees, and skipped entirely when `workspace` is selected:
+    # that pass has already replaced these paths, and repeating the work here would save
+    # the INCOMING memory over the saved original.
+    for tree, d in mem_roots:
+        sd = snap / tree
+        # CLEARED UNCONDITIONALLY, then filled only if the archive carries the tree.
+        # Clearing only when the archive had it meant a bundle without, say,
+        # `workspace/knowledge` left the destination's own knowledge tree in place, so a
+        # "replace" produced restored memory mixed with stale notes and still reported
+        # success. Replace means the destination ends up matching the archive; a tree the
+        # archive does not have is a tree the destination must not keep. The rollback copy
+        # was taken in phase one, before any database was swapped, so the removed state is
+        # still recoverable.
+        #
+        # `_trees_absent_from_bundle` does NOT cover this: it only refuses bundles carrying
+        # no component map, which is the escape hatch for pre-seam archives. A v3 bundle
+        # declares `memory` and legitimately may not carry every tree of it, and this is
+        # the branch that has to answer for that.
+        if d.is_dir() or platform_compat.is_link_or_junction(d):
+            installed.add(tree)
+            if platform_compat.is_link_or_junction(d):
+                # `unlink_link_or_junction`, not `Path.unlink`. Detecting with
+                # `is_link_or_junction` and removing with plain unlink is the mispairing that
+                # helper's own docstring warns against: a Windows junction is a DIRECTORY
+                # reparse point, so `unlink` raises on it and the tree is never cleared --
+                # the replace then fails mid-flight on a platform where this is the ordinary
+                # shape of a linked tree.
+                platform_compat.unlink_link_or_junction(d)
+            else:
+                shutil.rmtree(str(d))
+        if sd.is_dir():
+            installed.add(tree)
+            # Nested destination, same reason as the rollback save: the pinned primitive
+            # requires the parent chain to exist and creates only the final directory. A
+            # home that has no `workspace/` at all is the ordinary case for a restore onto
+            # a fresh machine, which is exactly what this component is for.
+            d.parent.mkdir(parents=True, exist_ok=True)
+            _copytree_safe(
+                sd,
+                d,
+                allow_unpinned=allow_unpinned,
+                must_create=True,
+                on_skip=pinned_fs.fatal_skip_reporter(f"restore of {tree!r}"),
+            )
+    if mem_roots:
+        print("  ✅ memory trees")
+
+
+def _restore_everything_from_rollback(
+    backup: Path, mc: Path, targets: list[str], installed: set[str], *, allow_unpinned: bool = False
+) -> list[str]:
+    """Undo the mutation phase, target by target, using *targets* as the granularity.
+
+    The recovery half of replace-mode atomicity. Undoing the whole saved set returns the
+    data home to one coherent generation regardless of how far the pass got. Recovering
+    only the item that failed is what leaves memory half-old and half-new.
+
+    **Granularity is the invariant, and it is exactly *targets*.** Every entry is a
+    declared relative path, and recovery touches nothing else. Walking the rollback
+    DIRECTORY instead looks equivalent and is not: memory's trees are nested
+    (``workspace/memory``), so ``backup`` contains a partial ``workspace/`` holding only
+    those subtrees. Treating that directory as one unit clears the live ``workspace``
+    whole and puts the partial copy back — deleting unrelated workspace data the restore
+    never touched. Restoring `workspace/memory` restores `workspace/memory`.
+
+    Three cases per target, and the third is why *installed* exists:
+
+    * **Saved** — put it back, clearing only that path.
+    * **Not saved, and this run installed it** — it did not exist before, so the copy the
+      restore created is REMOVED. That is what "no pre-restore state" restores to.
+    * **Not saved, and this run never reached it** — LEFT ALONE. Absence of a saved copy
+      does not mean absence of prior state: a file is saved by MOVING it aside at the
+      moment of its own mutation, so a failure partway through the phase leaves every
+      later target untouched and unsaved. Removing those deletes the operator's own data
+      that this restore never so much as opened, which is the opposite of recovery.
+
+    Best-effort per target, and it says so per target: a recovery that aborts on its
+    first problem strands the rest, and by this point the operator's own data is what is
+    at stake. Whatever cannot be undone is named, and this function never deletes the
+    rollback directory.
+    """
+    if not backup.is_dir():
+        print(f"⚠️  No rollback directory at {backup}; nothing to put back.")
+        # Reported as a failed revert, not as success with a warning: the caller's summary
+        # line is what the operator acts on, and "put back" would be false here.
+        return list(sorted(set(targets)))
+    print(f"↩️  Restoring the previous state from {backup} ...")
+    failed: list[str] = []
+    for rel in sorted(set(targets)):
+        saved = backup / rel
+        target = mc / rel
+        try:
+            if platform_compat.is_link_or_junction(saved):
+                # FIRST, because both tests below DEREFERENCE. A core file that was a
+                # relative symlink stops resolving the moment it is moved into the rollback
+                # directory, so `is_dir()` and `is_file()` are both false and the saved link
+                # matched no branch at all: the replacement at the live name was deleted as
+                # an undone creation, the link stayed in the rollback directory, and the
+                # recovery reported success. Reproduced -- the live name ended up not
+                # existing at all.
+                #
+                # The directory branch below says the rollback directory is "links-free by
+                # construction". That is true of TREES, which `_backup_tree_or_refuse` saves
+                # with a fatal skip reporter. Core FILES are saved by `_backup_and_copy`,
+                # which deliberately MOVES a symlinked core file aside and prints that it
+                # did -- so a link here is a state this code creates on purpose, and the
+                # claim was being applied to an input it was never about.
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if platform_compat.is_link_or_junction(target):
+                    platform_compat.unlink_link_or_junction(target)
+                elif target.is_dir():
+                    shutil.rmtree(str(target))
+                elif target.exists():
+                    target.unlink()
+                # MOVED back rather than copied, unlike the two branches below. The save
+                # moved the link itself, so the rollback holds the only copy; and a move is
+                # the one operation that also reinstates a Windows junction, whose target
+                # cannot be read portably. Moving a link moves the LINK, never its target.
+                shutil.move(str(saved), str(target))
+            elif saved.is_dir():
+                # Clearing the live root before refilling it. A root that passed
+                # containment can still BE a link -- one pointing elsewhere inside the
+                # data home resolves within it -- and rmtree raises on a link, which at
+                # this point would strand the recovery. Remove a link as a link and
+                # reserve rmtree for real directories.
+                #
+                # Through `unlink_link_or_junction`, because a Windows junction is a
+                # directory reparse point that `Path.unlink` cannot remove: recovery would
+                # raise here and leave the operator's prior state stranded, which is the
+                # one outcome this whole function exists to prevent.
+                if platform_compat.is_link_or_junction(target):
+                    platform_compat.unlink_link_or_junction(target)
+                elif target.is_dir():
+                    shutil.rmtree(str(target))
+                target.parent.mkdir(parents=True, exist_ok=True)
+                # The plain staging copy is lossless HERE, which it would not have been
+                # for the save. `_backup_tree_or_refuse` reports a skipped entry as fatal,
+                # so a TREE containing a link never reaches the rollback directory at all
+                # -- whatever `backup` holds for a tree is links-free by construction, and
+                # there is nothing for a link-preserving copy to preserve on the way back.
+                #
+                # Scoped to trees deliberately. This used to read as a claim about the whole
+                # rollback directory, which is false: core FILES are saved by a different
+                # function that MOVES a symlink aside on purpose, and reading the claim that
+                # broadly is what left the saved-link case with no branch to match.
+                _copytree_safe(
+                    saved,
+                    target,
+                    # The operator's opt-in has to reach HERE, not just the forward path.
+                    # Without it this copy took the default and refused on a platform with
+                    # no directory descriptors -- so an operator who passed
+                    # `--allow-unpinned-staging` got a replace that was allowed to MUTATE
+                    # live state and a rollback that then refused to put it back. The safety
+                    # net became the one thing that would not run, at the only moment it
+                    # matters. Found by a test that could not be fixed from the test side
+                    # because this function had no way to be told.
+                    allow_unpinned=allow_unpinned,
+                    must_create=True,
+                    on_skip=pinned_fs.fatal_skip_reporter(f"rollback of {rel!r}"),
+                )
+            elif saved.is_file():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                # Routed through the pinned primitive, not `shutil.copy2`. copy2 opens the
+                # destination BY NAME and FOLLOWS a link sitting there, so a link planted at
+                # a core file's name between the save and this recovery would send the
+                # restored bytes to whatever it points at. The directory branch above
+                # already refuses a link; this is the same hazard in the sibling branch, and
+                # recovery is the worst place to have it -- it runs precisely when the
+                # operator's state is already half-replaced.
+                #
+                # An existing destination is REPLACED here, unlike the merge path: this is
+                # putting back what the restore moved aside, so `skip_existing` would leave
+                # the failed generation in place. `copy_file_pinned` opens
+                # O_CREAT|O_EXCL|O_NOFOLLOW, so the old name is removed first and a link at
+                # that name is refused rather than followed.
+                if platform_compat.is_link_or_junction(target):
+                    platform_compat.unlink_link_or_junction(target)
+                elif target.is_file():
+                    target.unlink()
+                pinned_fs.copy_file_pinned(
+                    str(saved),
+                    str(target),
+                    on_skip=pinned_fs.fatal_skip_reporter(f"rollback of {rel!r}"),
+                )
+            elif rel in installed and (
+                target.exists() or platform_compat.is_link_or_junction(target)
+            ):
+                # Nothing saved, so the only justification for deleting is that this run
+                # created it. `rel in installed` is NOT that evidence: the name is recorded
+                # BEFORE the save is known to have happened (deliberately -- a crash
+                # mid-write must still leave it known to have been reached), and the save
+                # only actually happens on two branches, a symlink or a regular file. A core
+                # file's path occupied by a DIRECTORY matches neither, so nothing is saved
+                # and the name is recorded anyway.
+                #
+                # Reproduced: with a directory at `crons.json` holding operator data,
+                # recovery deleted the directory and its contents, reported an empty failure
+                # list, and printed "Previous state restored." Data loss announced as a
+                # successful recovery.
+                #
+                # So the type is the evidence. A core file entry is one this run would have
+                # created as a regular FILE; a directory standing there is something else's,
+                # and deleting it is unrecoverable while leaving it is not. Recorded as a
+                # failure so the operator is told rather than silently obeyed.
+                if target.is_dir() and not platform_compat.is_link_or_junction(target):
+                    if rel in CORE_FILES_FLAT:
+                        failed.append(
+                            f"{rel} (a directory is standing where this component's FILE "
+                            "belongs, and no copy of it was saved -- refusing to delete it, "
+                            "because nothing here proves this run created it)"
+                        )
+                        continue
+                    shutil.rmtree(str(target))
+                else:
+                    # Covers a link or junction as well as a plain file, so it goes through
+                    # the helper: `Path.unlink` cannot remove a Windows junction, and the
+                    # helper falls through to `unlink` for an ordinary file anyway.
+                    platform_compat.unlink_link_or_junction(target)
+        # `PinnedPathRefusal` alongside OSError, and NOT an OSError itself: recovery now
+        # restores through the pinned primitives with a fatal reporter, so one target it
+        # cannot put back raises a refusal. Recorded per target like any other failure --
+        # aborting the loop here would strand every remaining target, which is the opposite
+        # of recovery, and by this point the data at stake is the operator's own.
+        except (OSError, pinned_fs.PinnedPathRefusal) as e:
+            failed.append(f"{rel} ({e})")
+    if failed:
+        print("⚠️  Could not undo these: " + ", ".join(failed))
+        print(
+            f"   The saved copies are still in {backup} — recover them by hand before "
+            "re-running."
+        )
+    else:
+        print("↩️  Previous state restored.")
+    return failed
 
 
 def _do_merge(
     snap: Path, mc: Path, components: list[str] | None, *, allow_unpinned: bool = False
 ) -> None:
+    # BOTH restore modes refuse an unsafe destination tree root up front, and merge needs
+    # it for the same reason replace does: a merge that silently omits a tree is still a
+    # merge that claims to have imported it. Skipping the tree and returning 0 is the worst
+    # available outcome -- the operator is told the import succeeded while the notes they
+    # were importing are not there.
+    _refuse_unsafe_destination_roots(mc, components)
     # Asked once, at entry, BEFORE any mutation. The core-file copies below run before
     # any tree call, so gating inside the tree helpers meant a merge on a platform that
     # cannot pin wrote memory.db, crons.json and the security files first and only then
@@ -1312,6 +3360,38 @@ def _do_merge(
         else:
             _merge_memory(snap / "memory.db", mc / "memory.db")
         print("  ✅ memory")
+
+    # The markdown half of memory (preferences, projects, history, knowledge). Named
+    # by the memory component so restoring memory does not require the whole
+    # workspace; no-overwrite so a merge never clobbers newer local files.
+    if _want(components, "memory"):
+        for tree in COMPONENTS["memory"].trees:
+            sd = snap / tree
+            if sd.is_dir():
+                dd = mc / tree
+                # RE-CHECKED here, not only in the pre-flight at the top of this function.
+                # The pre-flight clears the same set moments earlier, so a root that fails
+                # now failed AFTER it -- something moved under us mid-run. Replace already
+                # refuses that; merge did not, and the gap was reachable: with `workspace`
+                # swapped for an external link straight after the pre-flight, this loop's
+                # `mkdir(parents=True)` created the tree THROUGH the link and the copy wrote
+                # the operator's memory files into an attacker-chosen directory outside the
+                # data home -- four of them, with the run printing "Merge complete."
+                #
+                # The per-file screens cannot see it: each final component is a fresh regular
+                # file, and a by-name open does not check its ancestors. Refusing on the root
+                # is what closes it. Merge is additive, so a component already merged stays
+                # merged -- nothing is destroyed by stopping here, unlike carrying on.
+                if safe_tree_root(dd, what="destination root", home=mc) is None:
+                    raise UnsafeComponentRoot(
+                        f"memory:{tree} stopped resolving inside the data home after the "
+                        "pre-flight check passed. A path that was safe moments ago and is "
+                        "not now was replaced mid-run (usually a symlink); merging past it "
+                        "would write this component outside the data home."
+                    )
+                dd.mkdir(parents=True, exist_ok=True)
+                _report_unmerged_databases(sd, dd, tree)
+                _copy_tree_no_overwrite(sd, dd, allow_unpinned=allow_unpinned)
 
     if _want(components, "crons"):
         sc, dc = snap / "crons.json", mc / "crons.json"
@@ -1423,6 +3503,30 @@ def restore_main(argv: list[str] | None = None, *, parsed: argparse.Namespace | 
         print("❌ Gateway is running. Stop it first (kirocrew stop) or use --force.")
         return 1
 
+    # An s3:// argument is refused, not fetched: the drive bucket, the consent grant and
+    # the transport are the AWS Control app's, and its restore deliberately lands the
+    # archive in a staging folder rather than hot-swapping live state. Everything below
+    # therefore operates on a LOCAL path -- and still treats it as untrusted input, since
+    # a bundle that arrived from object storage is untrusted regardless of whose bucket it
+    # came from. The extraction filter, the archive bound and the source-database
+    # integrity refusal are that validation, and all three run BEFORE any live state
+    # moves; the destination integrity check further down reports on the result and is not
+    # what makes a bundle safe to apply.
+    if str(args.snapshot).startswith("s3://"):
+        # Fetching is the AWS Control app's job now: it owns the drive bucket, the
+        # consent grant and the transport, and its restore deliberately lands the
+        # archive in a staging folder rather than hot-swapping live state. This command
+        # then restores from that local path. Refused explicitly rather than treated as
+        # a filename, which would look for a directory named `s3:`.
+        #
+        # Escaped before printing: this is caller-supplied text on its way to a terminal.
+        print(
+            f"❌ Cannot fetch {_safe_name(str(args.snapshot))} directly.\n"
+            "   Download it from the AWS Control app's Backup section first, then pass\n"
+            "   the local path to this command."
+        )
+        return 1
+
     snap_path = Path(args.snapshot)
     if not snap_path.is_file():
         print(f"❌ File not found: {snap_path}")
@@ -1431,37 +3535,278 @@ def restore_main(argv: list[str] | None = None, *, parsed: argparse.Namespace | 
     # Parse components
     components: list[str] | None = None
     if args.components:
-        components = [c.strip() for c in args.components.split(",")]
-        for c in components:
-            if c not in VALID_COMPONENTS:
-                print(f"❌ Unknown component: {c}\n")
-                _list_components()
-                return 1
+        requested = [c.strip() for c in args.components.split(",") if c.strip()]
+        if not requested:
+            # Same reasoning as the snapshot side: an explicit flag that names nothing
+            # is an invocation mistake. Reading it as "restore no components" would
+            # print success while touching nothing, which is worse than refusing.
+            print(
+                f"❌ --components was given as {args.components!r}, which names no "
+                "components. Refusing rather than reporting a restore that did "
+                "nothing.\n"
+            )
+            _list_components()
+            return 1
+        # Restore reads whatever the bundle holds, so the purpose gate does not apply
+        # here — only the unknown-name refusal does.
+        try:
+            components = resolve_components(requested, Purpose.BACKUP)
+        except ComponentRefused as e:
+            print(f"❌ {e}\n")
+            _list_components()
+            return 1
 
     mc = _mc_dir()
     mode = args.mode or ("merge" if (mc / "memory.db").is_file() else "replace")
 
     with tempfile.TemporaryDirectory() as work_str:
         work = Path(work_str)
+        # Same reasoning as the staging side: the extracted bundle sits here in the clear
+        # before it is installed, so the directory is locked to the owner cross-platform
+        # before any member is written into it.
+        platform_compat.restrict_dir_to_owner(work)
 
         # Security checks are enforced inside _data_filter (no TOCTOU gap)
-        with tarfile.open(str(snap_path), "r:gz") as tar:
-            try:
-                tar.extractall(work, filter=_data_filter)
-            except TypeError:
-                # Python < 3.11.4: filter param not supported, apply manually
-                members = [m for m in tar.getmembers() if _data_filter(m) is not None]
-                tar.extractall(work, members=members)
+        #
+        # Listing an archive and extracting it are different operations, so the download
+        # probe passing does not mean this will: conflicting members (a file and a
+        # directory claiming one name) or a stream that ends mid-member raise here, not
+        # there. A refusal has to read as a refusal — every other rejection on this path
+        # reports and exits 1 rather than surfacing a traceback.
+        try:
+            with tarfile.open(str(snap_path), "r:gz") as tar:
+                # The bound belongs on EVERY path that reads an archive, not just the
+                # ones that crossed a network. A local bundle can be hostile or simply
+                # wrong, and on Python < 3.11.4 the fallback below calls `getmembers()`,
+                # which materialises every entry — so an archive declaring millions of
+                # them exhausts memory before a single file is written.
+                _refuse_oversized_archive(tar)
+                rejected_entries: list[str] = []
+                _filter = _rejection_recording_filter(rejected_entries)
+                try:
+                    tar.extractall(work, filter=_filter)
+                except TypeError:
+                    # Python < 3.11.4: filter param not supported, apply manually
+                    members = [m for m in tar.getmembers() if _filter(m) is not None]
+                    tar.extractall(work, members=members)
+                if rejected_entries:
+                    # A bundle whose entries were dropped is not the bundle its manifest
+                    # describes, and replace CLEARS live state for a component before asking
+                    # whether the archive can refill it. Reproduced: an archive holding the
+                    # memory tree as a link has that entry rejected, the staged tree is then
+                    # absent, the live tree is cleared unconditionally, and the command reports
+                    # success. Refusing here rather than in the mutation phase because this is
+                    # the only layer that can tell a rejected entry from an archive that never
+                    # carried it -- by then the two are the same state.
+                    print(
+                        "❌ This archive contains "
+                        f"{len(rejected_entries)} entr{'ies' if len(rejected_entries) > 1 else 'y'} "
+                        "that cannot be extracted safely "
+                        f"({', '.join(sorted(rejected_entries)[:3])}"
+                        f"{', ...' if len(rejected_entries) > 3 else ''}). Restoring it would "
+                        "apply an incomplete bundle and, in replace mode, clear live state the "
+                        "archive cannot put back.\n   Nothing was restored."
+                    )
+                    _audit(
+                        "state_restore_rejected",
+                        f"reason=unsafe_archive_entries from={snap_path.name}",
+                    )
+                    return 1
+        except _ArchiveTooLarge as e:
+            _audit(
+                "state_restore_rejected",
+                f"reason=archive_too_large from={snap_path.name}",
+            )
+            print(f"❌ {e}.\n   Nothing was restored.")
+            return 1
+        except (tarfile.TarError, OSError, EOFError) as e:
+            _audit(
+                "state_restore_rejected",
+                f"reason=extraction_failed from={snap_path.name}",
+            )
+            print(f"❌ This snapshot could not be extracted ({e}).\n   Nothing was restored.")
+            return 1
 
+        # Both roots: `kirocrew-snapshot-` for a complete bundle and
+        # `kirocrew-partial-` for a selective one. The second name exists so that
+        # released versions, which require the first, refuse a partial bundle instead of
+        # relocating the components it does not carry. This version reads the manifest,
+        # so it can consume either.
         snap_dirs = [
-            d for d in work.iterdir() if d.is_dir() and d.name.startswith("kirocrew-snapshot-")
+            d
+            for d in work.iterdir()
+            if d.is_dir()
+            and (d.name.startswith("kirocrew-snapshot-") or d.name.startswith("kirocrew-partial-"))
         ]
         if not snap_dirs:
             print("❌ Invalid snapshot format")
             return 1
+        if len(snap_dirs) > 1:
+            # Picking the first was arbitrary: two roots in one archive means the
+            # selection about to drive `replace` is a coin toss, and replace deletes.
+            print(
+                "❌ This archive contains more than one snapshot root "
+                f"({', '.join(sorted(_safe_name(d.name) for d in snap_dirs))}). Refusing rather "
+                "than guessing which one to restore."
+            )
+            _audit("state_restore_rejected", f"reason=multiple_roots from={snap_path.name}")
+            return 1
         snap = snap_dirs[0]
+        partial_root = snap.name.startswith("kirocrew-partial-")
 
         _print_manifest(snap)
+        _report_redacted_bundle(snap)
+        try:
+            declared = _manifest_components(snap)
+        except ManifestUnreadable as e:
+            print(f"❌ {e}")
+            print(
+                "   Refusing to guess what this bundle contains. A manifest this "
+                "version cannot parse may mean a corrupt archive, so an explicit "
+                "--components does not override it."
+            )
+            _audit("state_restore_rejected", f"reason=manifest_unreadable from={snap_path.name}")
+            return 1
+        if partial_root and declared is None and components is None:
+            # The root name ASSERTS the bundle is selective, and the manifest is what
+            # says which components it carries. A partial root with no component map is
+            # a contradiction, and resolving it the permissive way is the worst option:
+            # `declared is None` falls through to all-components below, so replace mode
+            # would displace live components this bundle never held while reporting
+            # success. Only a COMPLETE bundle may omit the map (pre-v3 archives did,
+            # and for them all-components is correct because they held everything).
+            #
+            # Gated on `components is None` because an explicit selection is
+            # checked against the bundle's actual contents below instead. Naming
+            # the components is not on its own evidence the bundle holds them, so
+            # the escape hatch this message offers is honoured by that check, not
+            # by trusting the operator's list.
+            print(
+                "❌ This archive is marked partial but carries no component map, so "
+                "there is no way to tell what it holds.\n"
+                "   Refusing: restoring it as if it were complete would move live "
+                "components it never contained.\n"
+                "   Pass --components explicitly if you know what it carries."
+            )
+            _audit(
+                "state_restore_rejected",
+                f"reason=partial_without_manifest from={snap_path.name}",
+            )
+            return 1
+        if components is None:
+            # A selective bundle must not be restored as if it held everything. With
+            # components unset, _want() answers True for every component, so a
+            # memory-only bundle taken through `--mode replace` would rmtree the live
+            # workspace and put back only the memory subtrees it carries — deleting
+            # unrelated state the bundle never had.
+            #
+            # The manifest records what actually rode (v3+), so that is the default,
+            # INCLUDING when it resolves to an empty set. A pre-v3 bundle has no map
+            # (declared is None) and keeps the old all-components behaviour, which is
+            # correct for it — it did hold everything.
+            if declared is not None:
+                # A DECLARED component the bundle carries no payload for is refused, for the
+                # same reason the explicit-selection branch below refuses one: replace clears
+                # live state for a component and then has nothing to put back. The two
+                # branches had different answers to the same question, and only the explicit
+                # one was guarded.
+                #
+                # Reproduced, and the product itself writes the bundle: a snapshot of a home
+                # with no memory payload declares `memory` anyway, and restoring it with
+                # replace onto a home that HAS memory cleared the memory trees and removed the
+                # derived index while `memory.db` survived -- the database kept, the notes
+                # indexed against it gone. A partial erasure is worse than either extreme.
+                #
+                # A DERIVED index does not count as payload: a bundle carrying only
+                # `memory_index.db` still has no memory to restore, and treating it as payload
+                # would let exactly the reproduced case through.
+                hollow = [c for c in declared if _component_payload_absent(snap, c)]
+                if hollow:
+                    print(
+                        "❌ This bundle declares "
+                        f"{', '.join(sorted(hollow))} but carries no data for "
+                        f"{'them' if len(hollow) > 1 else 'it'}. Restoring would clear the "
+                        "live state for those components with nothing to put back. Refusing "
+                        "rather than partially erasing what is there."
+                    )
+                    _audit(
+                        "state_restore_rejected",
+                        f"reason=declared_without_payload from={snap_path.name}",
+                    )
+                    return 1
+                components = declared
+                print(
+                    "🔧 Components (from bundle manifest): "
+                    f"{','.join(components) if components else '(none)'}"
+                )
+        elif declared is not None:
+            # An explicit selection the bundle does not contain is a refusal, not a
+            # no-op: replace mode would move the live files of that component out to
+            # the rollback dir and have nothing to put back.
+            # Membership in the declaration is NOT enough, and testing only that is what left
+            # the destructive case reachable from this side: a bundle can declare `memory` and
+            # carry none of it, so `--components memory` passed a guard written for exactly
+            # this situation. Reproduced -- the live memory trees were cleared and the command
+            # then failed for an unrelated reason, so even the exit code did not give it away.
+            # Both branches ask the same question now; guarding one of them with a stronger
+            # test than the other is the whole defect.
+            absent = [
+                c for c in components if c not in declared or _component_payload_absent(snap, c)
+            ]
+            if absent:
+                print(
+                    f"❌ This bundle does not contain: {', '.join(sorted(absent))}\n"
+                    f"   It carries: {', '.join(declared) if declared else '(nothing)'}"
+                )
+                return 1
+        elif partial_root:
+            # A partial root with no component map, which the guard above lets
+            # through so an operator who knows the contents can name them. What
+            # they named still has to be there: the same refusal as the branch
+            # above, decided by what the archive holds because there is no map to
+            # decide it from.
+            absent = _components_absent_from_bundle(snap, components)
+            if absent:
+                print(
+                    f"❌ This bundle does not contain: {', '.join(sorted(absent))}\n"
+                    "   Its manifest carries no component map, so this is read from "
+                    "the archive's contents.\n"
+                    "   Refusing: replace mode would move that component's live files "
+                    "aside with nothing to put back."
+                )
+                _audit(
+                    "state_restore_rejected",
+                    f"reason=named_component_absent from={snap_path.name}",
+                )
+                return 1
+            # The component is carried, but "carried" is any ONE declared path, and
+            # replace clears a component's directories before it knows whether the
+            # archive has a replacement. So a bundle holding just `memory.db` satisfied
+            # the check above while `workspace/memory` was absent, and replace cleared it
+            # from live state and reported success.
+            #
+            # Only replace, and only a tree live state actually HAS. Merge clears nothing,
+            # so the hatch stays usable there; and a tree live state lacks has nothing to
+            # lose, which is what keeps this from refusing a sound bundle taken from a
+            # home that never used that tree.
+            if mode == "replace":
+                absent_trees = _trees_absent_from_bundle(snap, components, mc)
+                if absent_trees:
+                    print(
+                        "❌ This bundle carries no component map and is missing "
+                        f"{', '.join(absent_trees)}, which live state HAS.\n"
+                        "   Refusing: --mode replace clears a component's directories "
+                        "before copying, so this would delete live state the archive "
+                        "cannot put back. Naming the component does not establish that "
+                        "the archive holds every part of it.\n"
+                        "   Use --mode merge, which clears nothing, or a bundle that "
+                        "carries a component map."
+                    )
+                    _audit(
+                        "state_restore_rejected",
+                        f"reason=partial_replace_absent_tree from={snap_path.name}",
+                    )
+                    return 1
         if components:
             print(f"🔧 Components: {','.join(components)}")
 
@@ -1470,10 +3815,28 @@ def restore_main(argv: list[str] | None = None, *, parsed: argparse.Namespace | 
             print("Files in snapshot:")
             for f in sorted(snap.rglob("*")):
                 if f.is_file():
-                    print(f"  {f.relative_to(snap)}")
+                    # Archive-derived, and a dry run is exactly when the operator is
+                    # reading the list to decide whether to proceed.
+                    print(f"  {_safe_name(f.relative_to(snap).as_posix())}")
             return 0
 
         mc.mkdir(parents=True, exist_ok=True)
+        try:
+            # Replace installs everything it carries; merge installs only what the
+            # destination is missing. Both are validated for exactly what they will put in
+            # place, so neither mode can install a database it never checked.
+            _refuse_corrupt_source_databases(
+                snap,
+                components,
+                mc_for_merge=None if mode == "replace" else mc,
+            )
+        except SourceComponentUnsound as e:
+            _audit(
+                "state_restore_rejected",
+                f"reason=source_integrity_check_failed from={snap_path.name}",
+            )
+            print(f"❌ {e}")
+            return 1
         # Contained here rather than allowed to propagate: a refusal is a decision
         # this command made on purpose, and a traceback would read like a crash and
         # bury the one sentence saying what to do about it.
@@ -1488,11 +3851,69 @@ def restore_main(argv: list[str] | None = None, *, parsed: argparse.Namespace | 
             _audit("state_restore_rejected", f"reason=unpinnable_staging detail={exc}")
             print(f"❌ {exc}")
             return 1
+        except UnsafeComponentRoot as e:
+            # Raised before anything was written, so this is a clean refusal. Report it
+            # as one rather than letting a traceback out -- the same contract every other
+            # refusal on this path already follows.
+            print(f"❌ {e}")
+            return 1
+        except SourceComponentUnsound as e:
+            # `_allocate_rollback_dir` raises this when every candidate name for the current
+            # timestamp is taken. Rare, and still a refusal rather than a crash: it happens
+            # before any mutation, so the data home is untouched and the operator needs a
+            # sentence rather than a stack trace. The pre-flight validator raises the same
+            # type and is caught above; this handler covers the execution boundary, which
+            # had no catch for it at all.
+            _audit(
+                "state_restore_rejected",
+                f"reason=rollback_dir_unavailable from={snap_path.name}",
+            )
+            print(f"❌ {e}")
+            return 1
+        except RollbackIncomplete as e:
+            # Said first and said plainly: the operator's next action depends on it.
+            print(f"❌ The restore failed partway through: {e.cause}")
+            print(
+                "   Putting your previous state back did NOT fully succeed. Some of it "
+                f"exists only in {_safe_name(str(e.backup))} now:"
+            )
+            for item in e.failed[:10]:
+                print(f"     {_safe_name(item)}")
+            if len(e.failed) > 10:
+                print(f"     (+{len(e.failed) - 10} more)")
+            print(
+                "   Recover those by hand BEFORE re-running, or the next restore's "
+                "rollback set will be taken from this half-reverted state."
+            )
+            _audit(
+                "state_restore_rejected",
+                f"reason=rollback_incomplete from={snap_path.name}: {e.cause}",
+            )
+            return 1
+        except (OSError, DatabaseCopyFailed) as e:
+            # A full disk, a read-only filesystem, or a file another process holds open
+            # fails MID-mutation, which is a different answer from the refusals above:
+            # `_do_replace` has already put the whole saved set back and re-raised. So the
+            # home is on its pre-restore generation and the operator needs to be told that
+            # much -- a traceback says a restore blew up without saying what state they are
+            # now in, which is the one thing they need to know before retrying.
+            print(f"❌ The restore failed partway through: {e}")
+            print("   Your previous state was put back; nothing from the bundle remains.")
+            _audit(
+                "state_restore_rejected",
+                f"reason=io_failure from={snap_path.name}: {e}",
+            )
+            return 1
 
     # Integrity check
     if _want(components, "memory") and (mc / "memory.db").is_file():
         try:
-            with sqlite3.connect(str(mc / "memory.db")) as conn:
+            # `closing`, not a bare `with sqlite3.connect(...)`: the connection's own
+            # context manager ends the TRANSACTION and leaves the handle open. Windows
+            # refuses to move or replace a file that still has one, so a leak here makes
+            # the NEXT restore in the same process fail on the database this one just
+            # installed -- and leaves the restored file held open either way.
+            with closing(sqlite3.connect(str(mc / "memory.db"))) as conn:
                 result = conn.execute("PRAGMA integrity_check;").fetchone()[0]
         except Exception as e:
             result = str(e)

--- a/src/kiro_crew/snapshot_redact.py
+++ b/src/kiro_crew/snapshot_redact.py
@@ -1,0 +1,1235 @@
+"""Neutralise credential material in a bundle that is about to leave the host.
+
+An off-host copy crosses a trust boundary the local archive does not: it lands in object
+storage, and every principal that can read the bucket can read it. This module rewrites a
+STAGED COPY of a bundle so the bytes that leave carry no usable credentials, and it is the
+only place in the backup path that does so.
+
+**It is lossy on purpose, and the loss is the point.** A redacted bundle restores to a
+working shape but not to a working credential: the token field is present and inert, so the
+operator re-enters it rather than discovering an empty file. That tradeoff is a deliberate
+product decision, and `backup.redact_uploads` exists to reverse it for an operator who
+would rather have a bundle that restores complete.
+
+Two properties make the difference between a redacted bundle and a broken one:
+
+* **Structure survives.** The redactors substitute a tag for a match, so they CHANGE
+  LENGTH. Running them over the bytes of a SQLite file does not produce a database with
+  dead credentials, it produces a file SQLite cannot open — which the restore path then
+  correctly refuses as corrupt. Databases are therefore redacted through SQL, value by
+  value, so what is written back is still a database.
+* **The bundle says so.** The manifest records that this copy was redacted and what was
+  touched, so a restore can tell the operator their credentials are inert instead of
+  letting them find out when something fails to authenticate.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from contextlib import closing
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator
+
+from kiro_crew.config.loader import config_dir
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+try:  # pragma: no cover - exercised by whichever binding is installed
+    import pysqlite3 as sqlite3  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover
+    import sqlite3  # type: ignore[no-redef]
+
+# Suffixes read as text. Everything else is either a database (handled through SQL) or
+# opaque bytes, and guessing at an unknown binary format is how a bundle gets corrupted.
+# Whether a file is text is decided by DECODING it, not by its name. A workspace holds
+# whatever the operator put there — source files, csv, html, notes with no extension — and
+# a suffix allowlist silently classified all of those as opaque.
+
+# Files whose whole purpose is to be secret. There is no redacted form of a key that is
+# still the key, so they are DROPPED from an outbound copy rather than blanked: a present
+# but inert HMAC key would be indistinguishable from a rotated one.
+# Bundle-RELATIVE paths, not basenames. A workspace holds whatever the operator put
+# there, so matching on a bare name would delete their own `telemetry_salt` or
+# `memory_index.db` from the off-host copy and make a restore quietly incomplete. These
+# are the product's own files, and the product puts them at the bundle root.
+_DROP_ENTIRELY = frozenset({"telemetry_salt", "sel_hmac.key"})
+
+# Derived indexes. An FTS index mirrors content that is itself being redacted, so redacting
+# it row by row would leave the index disagreeing with the table it indexes. Restore already
+# handles an absent index by telling the operator to rebuild it, so absence is the honest
+# state and the existing path carries it.
+_DERIVED_INDEXES = frozenset({"memory_index.db"})
+
+# Databases the product itself ships, by bundle-relative path. Only these may be DROPPED
+# when they cannot be proven redacted: their absence is a state restore already reports.
+# Any other `.db` is the operator's, so an unprovable one refuses the upload instead.
+# A settled database needs two passes (one to clean, one to prove nothing moved). The
+# rest of the budget is for chained triggers; past it, the database is not settling.
+_MAX_SETTLE_PASSES = 10
+
+_PRODUCT_DATABASES = frozenset({"memory.db", "workspace/knowledge/knowledge.db"})
+
+
+class _SchemaCarriesCredential(Exception):
+    """A credential sits in the schema itself, where no value rewrite can reach it.
+
+    Rows can be rewritten in place. DDL cannot: changing it means rebuilding the object
+    or enabling `writable_schema`, which risks leaving a file SQLite will not open. So a
+    database in this state is one the pass cannot clean, and it is handled as such.
+    """
+
+
+class _Unprovable(Exception):
+    """A file that is not the product's own and cannot be proven free of credentials."""
+
+
+class _PayloadUnprovable(Exception):
+    """A database this backup exists to carry, which cannot be proven clean."""
+
+
+class OpaqueFilesPresent(Exception):
+    """Files that are not text, so the pass cannot show them free of credentials.
+
+    Raised instead of deleting them: an operator's own file missing from a restore that
+    reported success is worse than an upload that refuses and says which files to deal
+    with. Public because the upload path reports it to the operator.
+    """
+
+    def __init__(self, paths: list[str]) -> None:
+        self.paths = paths
+        super().__init__(", ".join(paths))
+
+
+class PayloadDatabaseUnprovable(Exception):
+    """A database the backup EXISTS to carry cannot be shown free of credentials.
+
+    Separate from `OpaqueFilesPresent` because the trade is not the operator's to make
+    here: deleting `memory.db` and uploading the remainder produces an off-host copy that
+    reports success and restores nothing, which is discovered only when the machine it
+    came from is gone. Refusing names the database instead, and the local archive is
+    untouched either way. Public because the upload path reports it to the operator.
+    """
+
+    def __init__(self, paths: list[str], details: list[str] | None = None) -> None:
+        self.paths = paths
+        # WHY each one could not be proven clean, not just which. A refusal the operator
+        # cannot act on is a dead end: corruption, an unaddressable table and a schema
+        # that carries the credential need different responses.
+        self.details = details or list(paths)
+        super().__init__(", ".join(self.details))
+
+
+class _FileUnreadable(OSError):
+    """A file that cannot be read at all, so nothing about it can be established.
+
+    An `OSError` so the upload path's IO handler reports it as a refusal instead of
+    letting it escape as a traceback -- the pass cannot prove a file it never read.
+    """
+
+
+class _TableNotInspectable(Exception):
+    """A table this pass cannot read row-by-row, so its database cannot be cleared."""
+
+
+@dataclass
+class RedactionReport:
+    """What the pass changed, so the operator can judge it rather than trust it."""
+
+    replacements: dict[str, int] = field(default_factory=dict)
+    dropped: list[str] = field(default_factory=list)
+    rebuilt_indexes: list[str] = field(default_factory=list)
+    skipped_unreadable: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return sum(self.replacements.values())
+
+    def as_manifest_entry(self) -> dict[str, object]:
+        return {
+            "redacted": True,
+            "replacements": dict(sorted(self.replacements.items())),
+            "dropped": sorted(self.dropped),
+            "indexes_needing_rebuild": sorted(self.rebuilt_indexes),
+            "skipped_unreadable": sorted(self.skipped_unreadable),
+        }
+
+
+# Credentials the shared redactors do not recognise, closed HERE rather than by widening
+# them. Those run over live model output and tool results, where a false positive corrupts
+# what the operator is reading; this pass runs over a throwaway copy on its way off the
+# host, where a false positive costs one note's content and the complete local archive is
+# untouched. So the two boundaries can afford different thresholds, and this is the one
+# that can afford to guess.
+#
+# The shapes below are the ones the shared set misses. Two are vendor formats it has no
+# pattern for. The third is the general case its assignment rule only half-covers: that
+# rule fires on specific NAMES with vendor-shaped values, so `aws_secret_access_key = "…"`
+# is caught while `bot_token = "…"` with an opaque value is not -- a name list only ever
+# holds the names someone thought of, and an operator's own notes hold the rest.
+_SENSITIVE_FIELD = (
+    r"(?:api[-_ ]?key|secret[-_ ]?key|access[-_ ]?key|private[-_ ]?key|client[-_ ]?secret"
+    r"|bot[-_ ]?token|auth[-_ ]?token|access[-_ ]?token|refresh[-_ ]?token|session[-_ ]?key"
+    r"|signing[-_ ]?key|passwd|password|passphrase|credential|secret|token)"
+)
+
+# A quoted value long enough to be a real secret. The floor keeps `"password": ""` and
+# obvious placeholders from being rewritten, which would make a diff of the outbound copy
+# unreadable without protecting anything.
+_MIN_SECRET_LEN = 12
+
+# The value class excludes whitespace, and the replacement tag contains a space, so a value
+# this pass has already replaced cannot match again. That is what makes re-running it a
+# no-op, which the row scan depends on: it repeats until a pass changes nothing, so a rule
+# that rewrote its own output would never settle and would refuse every database. The
+# property is pinned by a test rather than left to whoever next edits the tag.
+
+_STRUCTURED_CREDENTIAL = re.compile(
+    # `"token": "value"` (JSON) and `token = "value"` / `token: value` (config, YAML).
+    rf'(?i)(["\']?{_SENSITIVE_FIELD}["\']?\s*[:=]\s*)'
+    rf'(["\']?)([^\s"\',}}\]]{{{_MIN_SECRET_LEN},}})(\2)'
+)
+
+# Three base64url segments with a dot between them: Discord bot tokens and JWTs both.
+# Both ARE bearer credentials, so matching both is the intent, not collateral.
+_DOTTED_BEARER = re.compile(r"\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{25,}\b")
+
+_TAG = "[REDACTED: credential]"
+
+
+def _scrub_unrecognised(text: str) -> tuple[str, int]:
+    """The shapes the shared redactors do not match. Returns (cleaned, replacements)."""
+    hits = 0
+
+    def _field(m: "re.Match[str]") -> str:
+        nonlocal hits
+        hits += 1
+        return f"{m.group(1)}{m.group(2)}{_TAG}{m.group(4)}"
+
+    cleaned, _ = _STRUCTURED_CREDENTIAL.subn(_field, text)
+
+    def _bearer(m: "re.Match[str]") -> str:
+        nonlocal hits
+        hits += 1
+        return _TAG
+
+    cleaned = _DOTTED_BEARER.sub(_bearer, cleaned)
+    return cleaned, hits
+
+
+def redaction_switch_path() -> "Path":
+    """Where the outbound-redaction opt-in lives: inside the keystone backup directory.
+
+    NOT in ``config.json``. That file is agent-readable and agent-WRITABLE -- an
+    auto-approved shell can write it, which is why this repo already keeps its other
+    security ceilings (the deny list, the computer-use enable) out of it. The backup
+    directory is already fenced on account of the DESTINATION record, and the switch that
+    decides what the uploader does with an operator's files belongs behind the same fence.
+
+    The fence is kept even though redaction is no longer the security boundary, because it
+    now decides whether the uploader REWRITES the operator's files, and an agent that could
+    flip it on could corrupt an off-host copy just as surely as one flipping it off could
+    publish a credential.
+
+    It lives in this module rather than beside the uploader because the switch belongs with
+    the thing it switches, and because this module is already a registered redaction sink.
+
+    Absent means no rewriting, which is the common case and needs no file. The operator
+    writes it out of band; no agent tool or shell form can.
+    """
+    return config_dir() / "backup" / "redaction.json"
+
+
+class RedactionSwitchUnreadable(Exception):
+    """The switch file exists but its contents cannot be read as a decision."""
+
+
+def outbound_redaction_enabled() -> bool:
+    """True only when the operator has explicitly opted IN.
+
+    Off by default. What guards the bundle is that the destination is owner-only and
+    re-verified at every upload -- every public-access block, default encryption, ACLs
+    disabled, versioning, no bucket policy, and the object write pinned to the expected
+    owner. Redaction sits on top of that, and it is not free: it REWRITES the operator's
+    files, and a credential replacement is a variable-length edit, so any format whose
+    structure depends on byte offsets comes out the other side invalid. Paying that by
+    default to re-protect a copy only the owner can read is the wrong trade.
+
+    Four cases, none of them a silent misreading:
+
+    * absent -- off. The common case, and the reason the default needs no file.
+    * exactly ``true`` -- on.
+    * exactly ``false`` -- off, and saying so explicitly is allowed.
+    * present but unreadable, the wrong shape, or some other value -- neither. The operator
+      wrote this file on purpose, so both silent answers betray something they configured:
+      off ignores a request to scrub, on rewrites files they may not have meant to touch.
+      Raising here makes the upload refuse and name the file instead of guessing.
+    """
+    path = redaction_switch_path()
+    if not path.is_file():
+        return False
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as e:
+        raise RedactionSwitchUnreadable(f"{path} could not be read as JSON ({e})") from e
+    if not isinstance(raw, dict):
+        raise RedactionSwitchUnreadable(f"{path} holds a JSON {type(raw).__name__}, not an object")
+    value = raw.get("redact_uploads")
+    if value is True:
+        return True
+    if value is False or value is None:
+        # An ABSENT key is not an attempt to set the switch, so the default applies and the
+        # default is off -- redaction is opt-IN, and off is the fail-safe direction here
+        # (no rewriting means no chance of corrupting the off-host copy; the destination is
+        # owner-only either way). Review asked for this to raise, on the grounds that the
+        # refusal contract covers "anything not exactly true or false". It does not: the
+        # refusal below is for a value that IS set and cannot be interpreted -- `"true"`,
+        # `1` -- where the operator plainly tried to set the switch and resolving it either
+        # way would override their intent. Nothing was attempted here.
+        return False
+    # A string "true" or a 1 is a config mistake. Resolving it either way silently would
+    # decide, on the operator's behalf, whether their files get rewritten.
+    raise RedactionSwitchUnreadable(
+        f"{path} sets redact_uploads to {value!r}; it must be true or false"
+    )
+
+
+def _scrub(text: str) -> tuple[str, int]:
+    """Both mandatory outbound redactors, in the order the rest of the repo applies them.
+
+    The shared pair runs first so its warnings stay the primary signal; the egress-only
+    pass then closes the shapes it does not recognise.
+    """
+    cleaned, cred_warnings = redact_credentials(text)
+    cleaned, url_warnings = redact_exfiltration_urls(cleaned)
+    cleaned, extra = _scrub_unrecognised(cleaned)
+    return cleaned, len(cred_warnings) + len(url_warnings) + extra
+
+
+# A text file that records its own extents cannot survive a variable-length rewrite: the
+# declaration keeps its old number while everything it describes moves. Keyed on the two
+# ways such a declaration is spelled rather than on file types, so it covers PDF, WARC,
+# HTTP archives, MIME multipart and mbox without a per-format entry for each.
+_EXTENT_DECLARATIONS = ("startxref", "content-length:")
+
+# How much text this pass will hold at once. `read_text` plus the scrubbed copy plus the
+# intermediate each redactor returns means several multiples of the file are live at the
+# same time, so an archive-sized member takes the process down before anything is uploaded.
+# A refusal names the file and keeps the local archive intact, which is recoverable; an
+# OOM mid-pass is not.
+_MAX_REDACTABLE_TEXT_BYTES = 64 * 1024 * 1024
+
+
+def _declares_its_own_extents(text: str) -> bool:
+    """Does *text* record a byte length or offset that a rewrite would invalidate?"""
+    lowered = text.lower()
+    return any(marker in lowered for marker in _EXTENT_DECLARATIONS)
+
+
+_WIDE_ENCODINGS = ("utf-16-le", "utf-16-be", "utf-32-le", "utf-32-be")
+
+
+def _carries_wide_encoded_credential(raw: bytes) -> bool:
+    """Does *raw* hold a credential once read as a WIDE encoding?
+
+    The scanners match ASCII, so text stored two or four bytes per character hides a credential
+    from them completely: UTF-16LE `AKIA...` is `A\\x00K\\x00I\\x00A\\x00...`, and nothing matches
+    across the NULs. Both callers previously decoded in a way that preserved that spacing --
+    the file path read UTF-8 (NUL is a legal codepoint, so the read SUCCEEDS) and the column path
+    decodes latin-1 -- so each returned zero hits and reported the data clean.
+
+    UTF-32 is here because covering only UTF-16 does not close it: a UTF-32LE credential read as
+    UTF-16LE is still NUL-separated, so it survives a UTF-16-only scan exactly as it survived the
+    original one.
+
+    A hit here can only ever REFUSE, never rewrite: the real encoding is a guess, and a
+    replacement of a different length shifts every byte after it. Used as a detector for that
+    reason, returning a bool rather than a cleaned copy.
+    """
+    for encoding in _WIDE_ENCODINGS:
+        try:
+            wide = raw.decode(encoding)
+        except (UnicodeDecodeError, LookupError, ValueError):
+            continue
+        if _scrub(wide)[1]:
+            return True
+    return False
+
+
+def _is_text_shaped(raw: bytes) -> bool:
+    """Is *raw* safe to rewrite with a replacement of a DIFFERENT length?
+
+    The same two questions `_redact_text_file` asks of a file, asked of one column value,
+    and deliberately the same answer: decodable as UTF-8 and free of NUL. Neither is proof
+    that nothing depends on byte position -- it is the same bet the file path already makes,
+    and the bet is what lets the feature clean plain text at all. What it does exclude is
+    every shape that is structurally binary, which is where the corruption was measured.
+    """
+    if b"\x00" in raw:
+        return False
+    try:
+        raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def _redact_text_file(path: Path, report: RedactionReport, rel: str) -> bool:
+    """Redact *path* as UTF-8 text. Returns False when it cannot be rewritten as text.
+
+    A `UnicodeDecodeError` is the answer to "is this text", not a failure: the caller
+    refuses the upload for those rather than removing the file.
+
+    Decoding is necessary evidence of text and not sufficient. NUL is a legal code point,
+    so a NUL-padded binary whose other bytes are ASCII decodes cleanly -- a tar of text
+    files is exactly that shape. Replacing a credential is a VARIABLE-LENGTH edit, so
+    rewriting such a file moves every following byte and the structure is destroyed; the
+    operator restores a file that is no longer a valid archive.
+
+    Gated on `hits` rather than on NUL alone, because the hazard lives only on the branch
+    that WRITES. A NUL-bearing file with no credential in it is never rewritten, so it is
+    handed over byte-for-byte and refusing it would cost an upload for a corruption that
+    cannot occur. What is refused is the pair: content this pass would have to rewrite,
+    in a file it cannot rewrite safely.
+
+    The NUL test alone does not cover every offset-dependent container, and what is left was
+    MEASURED rather than reasoned about: of ZIP, gzip, PNG, tar and a Flate-stream PDF, all
+    five are already refused here, each being either not UTF-8 or NUL-bearing.
+
+    That measurement was then over-read. It established which BINARY containers reach this
+    branch and was written up as naming the one shape that does -- an uncompressed ASCII PDF.
+    Review supplied the counterexample: a text WARC is UTF-8, NUL-free, and declares
+    `Content-Length` for every record, so a variable-length edit leaves each length stale and
+    every later record unreadable. Measuring one family and generalising to all of them is
+    the same error this branch keeps making.
+
+    So the test is the MECHANISM, not the format: a text file that declares its own extents
+    internally cannot survive a variable-length rewrite, whatever it is called. `startxref`
+    covers PDF's cross-reference offsets (keyed on the mechanism rather than on `%PDF-`), and
+    `Content-Length` covers WARC, HTTP archives, MIME multipart and mbox in one rule. That is
+    a list of ways to declare an extent rather than a list of file types, which is what makes
+    it stop growing per format.
+
+    Residual, stated rather than implied: a container that declares extents in some other
+    spelling is still rewritten. The cost of the rule is also real and accepted -- an HTTP
+    debug log that contains both a credential and `Content-Length` headers is refused rather
+    than cleaned, because its structure cannot be told from a real archive's here, and
+    refusing an upload is recoverable while corrupting one is not.
+    """
+    try:
+        # Checked BEFORE the read, which is the only place it helps. `read_text` plus the
+        # scrubbed copy plus each redactor's intermediate hold several multiples of the file
+        # at once, so an archive-sized member exhausts memory and the process dies with
+        # nothing uploaded. Refusing names the file and leaves the local archive intact.
+        if path.stat().st_size > _MAX_REDACTABLE_TEXT_BYTES:
+            raise _FileUnreadable(
+                f"{rel}: {path.stat().st_size} bytes is larger than this pass can hold in "
+                f"memory ({_MAX_REDACTABLE_TEXT_BYTES}); refusing rather than risking an "
+                "out-of-memory kill mid-upload"
+            )
+        original = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return False
+    except OSError as e:
+        raise _FileUnreadable(f"{rel}: {e}") from e
+    # A NUL in decoded text means the scanners cannot be trusted on this file: no credential
+    # pattern can match across the NULs, so `hits == 0` is evidence of nothing.
+    #
+    # Reproduced with UTF-16LE and no BOM. Those bytes decode as valid UTF-8 -- NUL is a legal
+    # codepoint -- so the read succeeds, the text reads `A\x00K\x00I\x00A...`, `_scrub` returns
+    # 0 hits, and the file was reported handled while the credential rode out intact. The NUL
+    # check that would have caught it sat one branch too deep, inside `if hits:`, where it only
+    # ever guarded against CORRUPTING a NUL-bearing file that did match.
+    #
+    # Treating every NUL-bearing file as opaque was the prescribed remedy and is WRONG -- it was
+    # measured against `test_a_nul_bearing_file_with_no_credential_still_rides`, which plants an
+    # ordinary tar inside the workspace and asserts it rides. A workspace routinely holds binary
+    # blobs, so that rule refuses real backups over files that carry nothing.
+    #
+    # So the wide-encoding INTERPRETATIONS are scanned instead, and only a credential actually
+    # found there refuses. A hit cannot be rewritten -- the file's real encoding is unknown and a
+    # replacement of a different length would shift every byte after it -- so `opaque` is the
+    # honest outcome, which refuses the upload and names the file. UTF-32 is covered as well as
+    # UTF-16: a UTF-32LE credential read as UTF-16LE is STILL NUL-separated, so a UTF-16-only
+    # scan misses it exactly as the original scan did.
+    if "\x00" in original and _carries_wide_encoded_credential(
+        original.encode("utf-8", errors="surrogatepass")
+    ):
+        return False
+    cleaned, hits = _scrub(original)
+    if hits:
+        if "\x00" in original:
+            # Kept as well as the pre-scan above: that one answers "can this file hide a
+            # credential from the scan", this one answers "can this file be rewritten at all".
+            return False
+        if _declares_its_own_extents(original):
+            return False
+        path.write_text(cleaned, encoding="utf-8")
+        report.replacements[rel] = report.replacements.get(rel, 0) + hits
+    return True
+
+
+# The pure index internals. `_content` is deliberately NOT here: for a standard fts5 table
+# it holds the indexed PLAINTEXT and has a rowid, so it must be scanned like any other
+# table. These four hold only index structure and are regenerated by the rebuild.
+_FTS_INDEX_SUFFIXES = ("data", "idx", "docsize", "config")
+
+
+def _fts_layout(conn: "sqlite3.Connection") -> tuple[list[str], set[str]]:
+    """The FTS virtual tables, and the tables the row scan must not touch.
+
+    Shadow tables are FTS5's private storage. Two of them (`_config`, `_idx`) are
+    `WITHOUT ROWID`, so a row scan cannot address them — and refusing the database on that
+    basis would delete every knowledge library from the outbound copy, which is how a
+    fail-closed rule turns into data loss.
+
+    They are also DERIVED: `_data`, `_idx` and `_docsize` hold the inverted index, so a
+    credential survives there as index structure even after the text it came from is
+    cleaned. Skipping them is therefore not enough on its own — the index is REBUILT from
+    the redacted content afterwards, which is what actually removes the term.
+
+    That reasoning holds only while a content table EXISTS to rebuild from. A contentless
+    index (`content=''`) has none, so the skip would leave its storage the only copy of the
+    text and nothing would ever examine it. Those refuse the upload instead: the rule was
+    justified for one of this path's two shapes and is false for the other.
+
+    Identified positively from each virtual table's own name, not by pattern-matching
+    every table that happens to end in `_idx`.
+    """
+    fts: list[str] = []
+    contentless: list[str] = []
+    for name, sql in conn.execute(
+        "SELECT name, sql FROM sqlite_schema WHERE type='table'"
+    ).fetchall():
+        # Case-INSENSITIVE, because SQLite stores DDL verbatim and its own documentation
+        # writes `USING FTS5(...)`. This used to fold only the all-lowercase spelling
+        # (`"USING fts" in sql.replace("using fts", "USING fts")`), so a table created the
+        # documented way was not recognised as full-text at all: its `WITHOUT ROWID` shadow
+        # tables were then scanned as ordinary ones and the pager's `SELECT MAX(<handle>)`
+        # raised `no such column: rowid`, refusing the ENTIRE backup of a sound database.
+        # Reproduced both spellings -- lowercase passed, uppercase refused -- so this was a
+        # legitimate backup lost to a spelling. The contentless probe below is lowered with
+        # it, for the same reason.
+        lowered = sql.lower() if sql else ""
+        if "using fts" in lowered:
+            fts.append(name)
+            # `content=''` is a CONTENTLESS index: there is no content table, so the
+            # storage tables are not derived from anything and the rebuild below has no
+            # source to regenerate them from. The whole justification for skipping them --
+            # cleaned text plus a rebuild removes the term -- is false for this shape, and
+            # a credential in that storage would ride the bundle unexamined.
+            #
+            # Measured, not assumed: an AWS access key is a separator-free alphanumeric run,
+            # so FTS5 stores it as ONE token rather than splitting it, the scanner matches
+            # that shape, and it survived a full pass with `replacements={}`.
+            if re.search(r"content\s*=\s*(''|\"\")", lowered):
+                contentless.append(name)
+    if contentless:
+        # Refused rather than scanned. Cleaning FTS5's private storage in place is not
+        # something this pass can do correctly -- the format is SQLite's, not ours -- and
+        # dropping the database would delete the operator's memory from the off-host copy.
+        # A payload that cannot be proven clean refuses the upload, which is the same rule
+        # the rest of this module already follows.
+        raise _TableNotInspectable(
+            "contentless FTS5 index(es) " + ", ".join(sorted(contentless)) + ": their tokens "
+            "live only in FTS storage, which has no content table to be cleaned and rebuilt "
+            "from, so this pass cannot prove them free of credentials"
+        )
+    skip = {f"{v}_{suffix}" for v in fts for suffix in _FTS_INDEX_SUFFIXES}
+    # The virtual tables themselves are skipped too. Writing through one is REFUSED for an
+    # external-content table (`content=items`), which is the shape this product actually
+    # uses, and redundant for a standard one whose text is in `_content`. Redacting the
+    # table that owns the text and rebuilding from it works for both, with no dependence
+    # on which table the scan reaches first.
+    skip.update(fts)
+    return fts, skip
+
+
+def _refuse_credential_in_schema(conn: sqlite3.Connection, rel: str) -> None:
+    """A row scan never sees the DDL, and a credential can be written into it.
+
+    A column DEFAULT, a VIEW's select list and a TRIGGER body are all stored as schema
+    text, so a key placed in any of them survives a pass that only rewrites values.
+    """
+    for (sql,) in conn.execute("SELECT sql FROM sqlite_schema WHERE sql IS NOT NULL").fetchall():
+        _, hits = _scrub(str(sql))
+        if hits:
+            raise _SchemaCarriesCredential(rel)
+
+
+def _quote_ident(name: str) -> str:
+    """Return *name* as a SQLite quoted identifier, safe to interpolate.
+
+    Wrapping an identifier in double quotes is not enough on its own: SQLite ends the
+    identifier at the first unescaped quote, so a column named `x" FROM other --` closes
+    the quote and the rest becomes syntax. The scanned tables and columns are read from
+    each database's OWN schema, and this pass deliberately opens databases it does not
+    own — an operator's tree can hold an imported `.db` whose identifiers were chosen by
+    whoever built it — so the names reaching these statements are not this product's to
+    assume well-formed. A rewritten SELECT reads a different table, so the pass reports a
+    clean scan of rows it never examined and the credential it exists to remove ships.
+
+    SQLite escapes an embedded double quote by doubling it, which is what this does. It is
+    NOT a validity check: an identifier this product does not recognise is still perfectly
+    legal SQLite, and refusing it would refuse databases the operator can legitimately
+    hold. Quoting makes any name mean itself, which is the property the callers need.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
+# SQLite's row id answers to three names, and a DECLARED column may take any of them.
+# Ordered by how likely a schema is to have taken the name for itself.
+_ROWID_ALIASES = ("rowid", "_rowid_", "oid")
+
+
+def _rowid_alias(cols: list[str]) -> str:
+    """Return a row-id alias *cols* does not shadow, or refuse the table.
+
+    `rowid` is this pass's update handle, and it is not a reserved word: a table may
+    declare a column called `rowid`, and then `rowid` in a statement means THAT COLUMN.
+    The read still succeeds and the UPDATE still applies, so nothing raises -- it just
+    matches on the wrong thing. Where the shadowing column holds duplicate values, one
+    row's replacement is written to every row sharing its value, so redacting a single
+    credential silently overwrites unrelated rows. That is data loss inflicted by the
+    component whose purpose is to protect the copy, and it lands in the archive that
+    exists because the original may be gone.
+
+    Shadowing is checked case-insensitively because SQLite identifiers are: a column
+    named `RowID` shadows `rowid` just as completely as a lowercase one.
+
+    Only tables that shadow ALL THREE aliases are refused, which keeps a database that
+    merely happens to have a `rowid` column redactable. Refusal reuses this module's
+    existing rule for a table it cannot read row-by-row -- the DATABASE is dropped and
+    the upload refuses -- because a table that cannot be updated by a known-unique
+    handle cannot be shown free of credentials either, and skipping it would upload the
+    very rows this pass exists to clean.
+    """
+    taken = {c.casefold() for c in cols}
+    for alias in _ROWID_ALIASES:
+        if alias not in taken:
+            return alias
+    raise _TableNotInspectable(
+        "every row-id alias (" + ", ".join(_ROWID_ALIASES) + ") is shadowed by a declared "
+        "column, leaving no unique handle to update rows by"
+    )
+
+
+# Each `DELETE FROM <table>` in a trigger body, so the exemption can be decided per
+# DELETE rather than per trigger. Quoting styles sqlite accepts are all stripped, because a
+# target spelled `"docs_content"` must match the plain name the schema reports.
+_DELETE_TARGET_RE = re.compile(r"delete\s+from\s+[\"'`\[]?([A-Za-z0-9_]+)")
+
+# A write that can DESTROY an existing row without saying `DELETE`. `INSERT OR REPLACE`
+# and `REPLACE INTO` both delete the conflicting row and insert in its place, so a trigger
+# whose body only ever "writes" can still lose a row this pass never looked at.
+_REPLACING_WRITE_RE = re.compile(r"\b(?:insert\s+or\s+replace|replace\s+into)\b")
+
+# A trigger body's own `UPDATE` overwrites the PREVIOUS values of every row it matches, in
+# the same way a `DELETE` removes the row: the fixpoint can observe a settled database but
+# cannot restore a value that is gone. Distinguished from a body that only INSERTs -- an
+# inserted copy is exactly what the fixpoint exists to clean on the next pass, which is why
+# `INSERT INTO audit VALUES(OLD.body)` stays allowed while `UPDATE audit SET ...` does not.
+_UPDATE_TARGET_RE = re.compile(r"\bupdate\s+(?:or\s+\w+\s+)?[\"'`\[]?([A-Za-z0-9_]+)")
+
+
+# Rows held in memory at once while scanning a table. Bounded so a large table cannot take
+# the process down mid-pass; large enough that the extra SELECTs are not the cost.
+_ROW_PAGE = 500
+
+
+def _paged_rows(
+    conn: "sqlite3.Connection", table: str, handle: str, quoted: str
+) -> "Iterator[tuple]":
+    """Yield the rows *table* held when this pass began, a page at a time, ordered by *handle*.
+
+    The caller UPDATEs rows as it consumes them, which is why this pages on `handle > ?`
+    instead of streaming a single cursor: a scan interleaved with writes to the same table
+    has undefined results in SQLite. Each page is read whole before the caller touches it,
+    and an UPDATE never changes the handle, so the next page stays disjoint and complete.
+
+    An UPDATE can still make the table GROW, which is the case a page cursor alone does not
+    survive. An `AFTER UPDATE` trigger that INSERTs -- copying the pre-update value into a
+    new row -- hands every cleaned row back as a fresh one with a higher handle, so `handle
+    > last` finds work forever and a single pass never terminates. The caller's fixpoint cap
+    counts PASSES, so it never gets to fire: the divergence is inside the pass it is
+    counting. The ceiling below is what makes each pass finite -- rows that appear mid-pass
+    are beyond it and belong to the NEXT pass, which reports them as replacements, so a
+    trigger that keeps reintroducing values is refused by the pass cap instead of hanging.
+    """
+    try:
+        top = conn.execute(f"SELECT MAX({handle}) FROM {_quote_ident(table)}").fetchone()
+    except sqlite3.DatabaseError as e:
+        raise _TableNotInspectable(f"{table}: {e}") from e
+    ceiling = top[0] if top else None
+    if ceiling is None:
+        return  # empty table: nothing this pass is responsible for
+    # NO sentinel lower bound. This used to start at `last = -1` and always select
+    # `handle > ?`, which silently skipped every row with a rowid <= -1 -- and SQLite lets
+    # you set an explicit negative INTEGER PRIMARY KEY, so a credential sitting at rowid
+    # -5 was never scanned and shipped in the redacted copy while the report still claimed
+    # a successful replacement. Picking a smaller sentinel does not fix it either: the
+    # range includes -2**63, so any floor at all can be the row that is missed. The first
+    # page therefore has no floor, and only subsequent pages carry one.
+    last: object = None
+    while True:
+        if last is None:
+            sql = (
+                f"SELECT {handle}, {quoted} FROM {_quote_ident(table)} "
+                f"WHERE {handle} <= ? ORDER BY {handle} LIMIT ?"
+            )
+            params: tuple = (ceiling, _ROW_PAGE)
+        else:
+            sql = (
+                f"SELECT {handle}, {quoted} FROM {_quote_ident(table)} "
+                f"WHERE {handle} > ? AND {handle} <= ? ORDER BY {handle} LIMIT ?"
+            )
+            params = (last, ceiling, _ROW_PAGE)
+        try:
+            page = conn.execute(sql, params).fetchall()
+        except sqlite3.DatabaseError as e:
+            raise _TableNotInspectable(f"{table}: {e}") from e
+        if not page:
+            return
+        last = page[-1][0]
+        yield from page
+
+
+def _refuse_generated_columns_with_credentials(
+    conn: "sqlite3.Connection", table: str, generated: list[str], rel: str
+) -> None:
+    """Refuse the database when a GENERATED column's value carries a credential.
+
+    Only when it actually does. A generated column is ordinary in most schemas, so refusing
+    every table that has one would turn this hardening into an outage -- the same trade the
+    trigger refusal gets wrong when it is widened. The values are read and put through the
+    same two scanners the row pass uses, and only a real match refuses.
+
+    Read as a STREAM, not with `fetchall()`. A generated column can span as many rows as its
+    table, and materialising all of them to answer an all-or-nothing question is how a backup
+    turns into an OOM kill. The row pass already pages for the same reason; this one does not
+    even need a page window, because it stops at the first match.
+
+    BYTES are scanned, not skipped. sqlite stores plain UTF-8 text as a BLOB routinely, so an
+    `isinstance(value, str)` filter would walk straight past a credential in a byte-valued
+    generated column. Unlike the row pass there is no text-shaped/structured split to make
+    here: that distinction exists to decide whether a value can be safely REWRITTEN, and a
+    generated column is read-only, so every hit ends the same way -- refuse.
+    """
+    quoted = ", ".join(_quote_ident(c) for c in generated)
+    try:
+        cursor = conn.execute(f"SELECT {quoted} FROM {_quote_ident(table)}")
+        for row in cursor:
+            for value in row:
+                if isinstance(value, (bytes, bytearray)):
+                    text = bytes(value).decode("utf-8", errors="replace")
+                elif isinstance(value, str):
+                    text = value
+                else:
+                    continue
+                if not text:
+                    continue
+                _scrubbed, hits = _scrub(text)
+                if hits:
+                    raise _SchemaCarriesCredential(
+                        f"{rel}: table {table!r} has a GENERATED column among "
+                        f"{', '.join(sorted(generated))} whose value carries a credential. A "
+                        "generated column is derived and read-only, so it cannot be rewritten "
+                        "in place -- refusing the upload rather than sending it. The local "
+                        "archive is unaffected."
+                    )
+    except sqlite3.DatabaseError as e:
+        # Unreadable is the same position as uninspectable elsewhere in this pass.
+        raise _TableNotInspectable(f"{table}: {e}") from e
+
+
+def _refuse_update_triggers_that_destroy_rows(
+    conn: "sqlite3.Connection", rel: str, fts_names: set[str]
+) -> None:
+    """Refuse a database whose UPDATE triggers DELETE rows.
+
+    The fixpoint scan below handles one thing a trigger does, and does it provably: copy a
+    pre-update value somewhere the pass has already been, which the next pass then cleans.
+    It cannot handle the other thing. A trigger that DELETES runs once, settles immediately,
+    and the fixpoint sees a quiet database -- the rows are simply gone from the copy that
+    leaves. Reproduced: an `AFTER UPDATE` trigger removed both rows of an unrelated table
+    while the pass reported success.
+
+    Scoped to DELETE deliberately, and NARROWER than the prescription that produced it.
+    Review asked for every non-FTS UPDATE trigger to be refused; that would throw away the
+    fixpoint, which is a deliberate, tested capability for exactly the copy-the-value case --
+    and it would refuse the product's own external-content full-text index, which is
+    MAINTAINED by update triggers. A trigger that only writes values is the schema doing
+    what it says, and any credential it propagates is what the fixpoint is for.
+
+    An FTS-maintenance trigger is exempt only for the deletions that ARE that maintenance:
+    every `DELETE FROM` in its body must target FTS storage. The first version of this
+    exempted the whole trigger as soon as any FTS name appeared anywhere in it, so a trigger
+    that maintains the index AND deletes unrelated rows was waved through -- review's
+    finding, and the same mistake this refusal exists to correct: a rule justified for one of
+    a thing's statements, applied to all of them.
+
+    The residual, stated rather than implied, and NARROWER than it was: `INSERT OR REPLACE`
+    and `REPLACE INTO` used to be named here as uncaught, and they are now refused -- they
+    are spellings a body either contains or does not, so text bounds them honestly. An
+    `UPDATE` aimed at a table OTHER than the trigger's own is refused for the same reason:
+    it overwrites rows this pass is not rewriting, so their prior values are gone from the
+    copy that leaves, and the fixpoint can observe a settled database but never restore them.
+
+    What genuinely remains: an `UPDATE` on the trigger's OWN table with no row bound can
+    still overwrite other rows of that table. It stays allowed because the shape it cannot be
+    told apart from by text -- a mirror column maintained by
+    `UPDATE t SET mirror = NEW.body WHERE id = NEW.id` -- is ordinary, and the fixpoint
+    provably cleans it. Separating those two needs the statement's effects.
+
+    That is why the refusal keys on the TARGET rather than on the body containing an `UPDATE`
+    at all. Both broader rules were measured and rejected: refusing every non-FTS
+    UPDATE-writing trigger discards the fixpoint entirely (three tests in this suite assert
+    the value-writing cases it handles -- a trigger propagating a credential is CLEANED by
+    the next pass, not shipped) and refuses the product's own external-content index, whose
+    maintenance is exactly such a trigger; refusing every body containing an `UPDATE` then
+    fails the mirror-column case above. The trade is deliberate: cleaning a propagated value
+    serves the operator, refusing to back up at all does not.
+    """
+    suspects: list[str] = []
+    for name, tbl_name, sql in conn.execute(
+        "SELECT name, tbl_name, sql FROM sqlite_schema WHERE type='trigger'"
+    ).fetchall():
+        body = (sql or "").lower()
+        header, _, actions = body.partition("begin")
+        if "update" not in header:
+            continue  # not fired by what this pass does
+        targets = _DELETE_TARGET_RE.findall(actions)
+        # An `UPDATE` inside the body overwrites the PRIOR values of every row it matches, and
+        # the fixpoint can observe a settled database but never restore a value that is gone --
+        # the same reason a `DELETE` is refused. Reproduced twice, and the two cases need
+        # different treatment, which is why this is not one flat rule:
+        #
+        #   * FOREIGN target (`UPDATE unrelated SET note='CLOBBERED'`): reaches rows this pass
+        #     is not rewriting at all. Refused.
+        #   * OWN table, UNBOUND (`UPDATE items SET note='CLOBBERED'`): no row bound, so it
+        #     rewrites every row of the table it fires on. Refused.
+        #   * OWN table, bound to the triggering row (`UPDATE t SET mirror = NEW.body WHERE
+        #     id = NEW.id`): a mirror column. Ordinary shape, and the fixpoint provably cleans
+        #     the propagated value. ALLOWED -- refusing it discards the fixpoint, which three
+        #     tests in this suite assert, and refusing every non-FTS UPDATE-writing trigger
+        #     additionally refuses the product's own external-content index.
+        #
+        # "References NEW or OLD" is the bound, and it is a spelling rather than an effect, so
+        # text carries it honestly. Residual, stated: a statement can reference NEW and still
+        # touch other rows deliberately (`WHERE id != NEW.id`). That is an adversarial
+        # construction; the accidental corrupting trigger is the unbound form, now refused.
+        for stmt in actions.split(";"):
+            for target in _UPDATE_TARGET_RE.findall(stmt):
+                if target == (tbl_name or "").lower() and re.search(r"\b(?:new|old)\.", stmt):
+                    continue  # bound to the row this pass is already rewriting
+                targets.append(target)
+        if not targets:
+            # A body with no `DELETE` can still destroy a row: `INSERT OR REPLACE` and
+            # `REPLACE INTO` delete the conflicting row and insert in its place. Reproduced
+            # both forms clobbering a row in an unrelated table that this pass never looked
+            # at, so they are refused for the same reason an explicit DELETE is -- the
+            # fixpoint can observe a settled database, never undo a row that is gone.
+            #
+            # Text is a legitimate bound for THESE TWO because they are spellings, not
+            # effects: a body either contains one or it does not. That is why this is narrow
+            # enough to keep, unlike refusing every non-FTS UPDATE trigger -- measured twice,
+            # and it discards the fixpoint plus the product's own full-text index. Verified
+            # this guard discriminates: both REPLACE forms refuse, while a plain
+            # value-copying trigger still goes through the fixpoint and is cleaned.
+            if _REPLACING_WRITE_RE.search(actions):
+                suspects.append(name)
+            continue  # writes values only: the fixpoint's case
+        if all(t in fts_names for t in targets):
+            continue  # every deletion is index maintenance, rebuilt after this pass anyway
+        suspects.append(name)
+    if suspects:
+        raise _TableNotInspectable(
+            f"{rel} has UPDATE trigger(s) that DELETE or OVERWRITE rows and are not full-text "
+            f"maintenance ({', '.join(sorted(suspects))}). Redacting runs UPDATE statements, "
+            "so these fire and the deletion is permanent in the copy that leaves -- the "
+            "fixpoint scan cannot undo it, only observe a settled database. Refusing the "
+            "upload; the local archive is unaffected."
+        )
+
+
+def _redact_database(path: Path, report: RedactionReport, rel: str, *, product: bool) -> None:
+    """Rewrite credential-bearing VALUES in place, leaving a valid database behind.
+
+    Every column is read and the decision is made on the VALUE's type, not the column's
+    declared one. SQLite affinity is advisory — a column declared `BLOB`, or declared with
+    no type at all, holds a Python `str` perfectly well — so filtering on the declaration
+    would skip exactly the places a credential is least expected and most likely to sit.
+    A value is written back only when it changed, so an untouched database keeps its pages.
+    """
+    try:
+        with closing(sqlite3.connect(str(path))) as conn:
+            _refuse_credential_in_schema(conn, rel)
+            fts_tables, skip_tables = _fts_layout(conn)
+            # BEFORE any UPDATE runs: a trigger's effects cannot be undone once fired.
+            _refuse_update_triggers_that_destroy_rows(conn, rel, set(fts_tables) | skip_tables)
+            tables = [
+                r[0]
+                for r in conn.execute(
+                    # `sqlite_schema` is the current name for the schema table, and the
+                    # one this codebase already queries elsewhere.
+                    "SELECT name FROM sqlite_schema WHERE type='table' "
+                    "AND name NOT LIKE 'sqlite_%'"
+                ).fetchall()
+            ]
+            hits = 0
+            # Scanned to a FIXPOINT rather than once. An UPDATE fires this database's
+            # triggers, and a trigger can copy the pre-update value somewhere the scan
+            # has already been — so one pass can leave a credential behind in a table it
+            # already cleaned. Each pass reports its own replacements; zero means nothing
+            # moved and the database is settled. Refusing all triggers instead would
+            # reject the product's own full-text schema, which is maintained by them.
+            for _ in range(_MAX_SETTLE_PASSES):
+                pass_hits = 0
+                for table in tables:
+                    if table in skip_tables:
+                        # FTS5's private storage: derived from the content table, regenerated
+                        # by the rebuild below. Two of these have no rowid, so scanning them
+                        # is impossible as well as pointless.
+                        continue
+                    cols = [
+                        r[1]
+                        for r in conn.execute(
+                            f"PRAGMA table_info({_quote_ident(table)})"
+                        ).fetchall()
+                    ]
+                    # GENERATED columns are invisible to `table_info` and READ-ONLY, so they
+                    # can be neither scanned by the loop below nor rewritten by its UPDATE.
+                    # Two existing guards already cover most of the exposure -- the schema
+                    # scan refuses a credential written as a literal in the generation
+                    # expression, and a STORED column is recomputed when its source is
+                    # updated, so redacting the source propagates -- but neither covers a
+                    # credential ASSEMBLED across columns. Reproduced: `a='AKIA'`,
+                    # `b='IOSFODNN7EXAMPLE'`, `joined AS (a || b) STORED`. No single value
+                    # matches, the DDL holds no credential, nothing refused, and the
+                    # generated column materialised the whole key into the outbound copy.
+                    #
+                    # Refused rather than redacted, because there is no way to redact it: the
+                    # column is derived, so the only honest answer is to stop the upload and
+                    # name the table. Scoped to hidden flags 2 and 3 (VIRTUAL and STORED
+                    # generated) so a virtual table's own hidden columns -- flag 1, which is
+                    # what an FTS table presents -- are untouched and full-text backups keep
+                    # working.
+                    generated = [
+                        r[1]
+                        for r in conn.execute(
+                            f"PRAGMA table_xinfo({_quote_ident(table)})"
+                        ).fetchall()
+                        if len(r) > 6 and r[6] in (2, 3)
+                    ]
+                    if generated:
+                        _refuse_generated_columns_with_credentials(conn, table, generated, rel)
+                    if not cols:
+                        # No enumerable columns means no way to read the table's values, which
+                        # is the same position as a missing rowid: uninspectable, so refused.
+                        raise _TableNotInspectable(f"{table}: no readable columns")
+                    quoted = ", ".join(_quote_ident(c) for c in cols)
+                    # The row id is the update handle. A `WITHOUT ROWID` table has none and
+                    # raises below — and a table this pass cannot inspect cannot be shown free
+                    # of credentials, so the DATABASE is dropped rather than the table skipped.
+                    # Skipping would upload the very rows the pass exists to clean, which is
+                    # the one outcome this module must never produce. A table that DECLARES a
+                    # column named `rowid` is the quieter version of the same problem: the
+                    # handle still resolves, just to the wrong thing, so the alias is chosen
+                    # per table and the SELECT and the UPDATE must use the SAME one.
+                    handle = _rowid_alias(cols)
+                    # PAGED, not `fetchall()`. Materialising a whole table held every row in
+                    # memory at once, so a large table took the process down before anything
+                    # was uploaded -- review's finding, the same hazard as reading an
+                    # archive-sized file whole.
+                    #
+                    # A generator paging on `handle > ?` rather than one streamed cursor,
+                    # because this loop UPDATEs the table it is reading and a live scan
+                    # interleaved with writes has undefined results in SQLite. Each page is
+                    # fully read before its rows are updated, and an UPDATE never changes the
+                    # handle, so the next page's `handle > last` is still disjoint and
+                    # complete.
+                    for row in _paged_rows(conn, table, handle, quoted):
+                        handle_value, values = row[0], row[1:]
+                        changes: dict[str, str | bytes] = {}
+                        for col, value in zip(cols, values):
+                            if not value:
+                                continue
+                            cleaned: str | bytes
+                            if isinstance(value, str):
+                                cleaned, n = _scrub(value)
+                                # The same hazard the FILE path refuses, at row scope. A
+                                # TEXT value carrying NUL is binary wearing a text type, so
+                                # a variable-length replacement shifts everything after the
+                                # hit inside a value whose structure depends on position.
+                                if n and "\x00" in value:
+                                    raise _TableNotInspectable(
+                                        f"{table}.{col}: a NUL-bearing text value carries a "
+                                        "credential, and replacing it would shift every "
+                                        "following byte of a value whose layout depends on "
+                                        "position. Refusing rather than rewriting it."
+                                    )
+                            elif isinstance(value, (bytes, bytearray)):
+                                # A column's declared type does not decide what it holds, so a
+                                # credential can arrive as bytes. latin-1 maps every byte to a
+                                # codepoint and back without loss, so the patterns (ASCII) match
+                                # inside binary too and a value with no hit is never rewritten —
+                                # which is what keeps embeddings and other real blobs intact.
+                                text, n = _scrub(bytes(value).decode("latin-1"))
+                                cleaned = text.encode("latin-1")
+                                if not n and _carries_wide_encoded_credential(bytes(value)):
+                                    # latin-1 preserves a wide encoding's NUL spacing, so the
+                                    # miss above is not evidence of a clean value: a UTF-16 or
+                                    # UTF-32 BLOB hides an ASCII credential from the scanners
+                                    # completely. Refused rather than rewritten, for the reason
+                                    # spelled out just below -- replacement is variable-length,
+                                    # and here the value's real encoding is a guess on top of
+                                    # that.
+                                    raise _TableNotInspectable(
+                                        f"{table}.{col}: a byte-valued field carries a "
+                                        "credential encoded two or four bytes per character. "
+                                        "The scanners cannot rewrite it -- the value's real "
+                                        "encoding is unknown and a replacement of a different "
+                                        "length would shift every byte after it. Refusing the "
+                                        "upload; the local archive is unaffected."
+                                    )
+                                # A HIT is a different question from a miss, and the sentence
+                                # above only answers the miss. Replacement is VARIABLE-LENGTH,
+                                # so rewriting a byte value moves every byte after the hit:
+                                # a length prefix then describes the wrong extent and every
+                                # following field is read at the wrong offset. Measured on a
+                                # length-prefixed record -- the prefix still said 46 while the
+                                # payload had become 48, and the trailing field came back
+                                # shifted.
+                                #
+                                # The test is the FILE path's test, deliberately: text-shaped
+                                # bytes are rewritten, structured bytes are refused. A blanket
+                                # refusal for every byte column was the prescribed remedy and
+                                # is wrong -- sqlite stores plain UTF-8 text as a BLOB all the
+                                # time, that case has no offsets to invalidate, and refusing it
+                                # would turn a credential this pass can safely remove into a
+                                # refused upload. Refusing is for bytes whose layout depends on
+                                # position, which is the same pair the file path refuses:
+                                # content that must be rewritten, in a container that cannot be
+                                # rewritten safely.
+                                #
+                                # Repair is not on the table for the structured case: what the
+                                # bytes MEAN is unknown, so no length fix-up can be trusted.
+                                if n and not _is_text_shaped(bytes(value)):
+                                    raise _TableNotInspectable(
+                                        f"{table}.{col}: a byte-valued field carries a "
+                                        "credential and is not text -- replacing it would "
+                                        "change the value's length and shift every byte after "
+                                        "it, and the bytes' meaning is unknown, so it cannot "
+                                        "be repaired. Refusing the upload instead of shipping "
+                                        "a corrupted copy. The local archive is unaffected."
+                                    )
+                            else:
+                                continue  # numbers and NULL carry no credential text
+                            if n:
+                                changes[col] = cleaned
+                                pass_hits += n
+                        if changes:
+                            assignments = ", ".join(f"{_quote_ident(c)} = ?" for c in changes)
+                            conn.execute(
+                                f"UPDATE {_quote_ident(table)} SET {assignments} "
+                                f"WHERE {handle} = ?",
+                                (*changes.values(), handle_value),
+                            )
+                hits += pass_hits
+                if not pass_hits:
+                    break
+            else:
+                # Still moving after the cap: a trigger is feeding the scan faster than
+                # it cleans. Unprovable, so it is handled as such rather than shipped.
+                raise _TableNotInspectable(
+                    "redaction did not settle; a trigger keeps reintroducing values"
+                )
+            # REBUILD every identified index UNCONDITIONALLY, for the same reason the
+            # VACUUM below is unconditional: reading every live row clean does not make the
+            # index clean. An external-content FTS table keeps its OWN tokenized copy and
+            # does not auto-sync, so a base table that has moved on leaves the index holding
+            # text no live row contains. The scan then finds `hits == 0` -- correctly, there
+            # is nothing in the rows -- and gating the rebuild on `hits` skipped the one case
+            # where the index is the ONLY copy.
+            #
+            # Reproduced: base row updated to drop the credential without syncing the index,
+            # `hits == 0`, no refusal, and the egress copy still answered
+            # `docs_fts MATCH '<key>'` with a hit afterwards. VACUUM does not help here --
+            # it repacks live content and never re-tokenizes, and the stale doclist IS live
+            # content of the shadow table.
+            #
+            # Safe to do unconditionally because a CONTENTLESS index -- the one shape with no
+            # content table to rebuild from -- is refused before this point, so every name in
+            # `fts_tables` has a source.
+            for virtual in fts_tables:
+                conn.execute(
+                    f"INSERT INTO {_quote_ident(virtual)}({_quote_ident(virtual)}) "
+                    f"VALUES('rebuild')"
+                )
+            conn.commit()
+            if hits:
+                report.replacements[rel] = report.replacements.get(rel, 0) + hits
+                if fts_tables:
+                    # Itemised only when the rebuild accompanied a real replacement, which is
+                    # what this manifest field tells the operator about. The unconditional
+                    # pass above is hygiene on the throwaway egress copy, like the VACUUM,
+                    # which is likewise not itemised.
+                    report.rebuilt_indexes.extend(f"{rel}:{v}" for v in fts_tables)
+            # REWRITE the file UNCONDITIONALLY, because reading every row clean does not
+            # make the FILE clean. SQLite does not erase what it stops using: an UPDATE
+            # leaves the old cell in the page's unused space, and a DELETE leaves the whole
+            # row in a free page. So a credential the operator deleted from their memory
+            # last week is still plaintext in the file, and the scan above finds nothing to
+            # replace precisely because no live row holds it. Gating the rebuild on `hits`
+            # would protect only the rows this pass rewrote and leave that case intact --
+            # the same mistake as trusting the rows over the bytes.
+            #
+            # `VACUUM` rebuilds the database from its live content, so the freed bytes are
+            # not carried over. Row VALUES are untouched, which keeps stored embeddings
+            # exactly as they were. Safe because this is the throwaway egress copy, never
+            # the operator's own archive.
+            conn.commit()
+            conn.execute("VACUUM")
+    except (sqlite3.DatabaseError, _TableNotInspectable, _SchemaCarriesCredential) as e:
+        # Shipping it is never an option: a database this pass cannot read end to end
+        # cannot be proven redacted, whether the cause is corruption or a table it cannot
+        # address. Neither is DELETING it and uploading the rest. `memory.db` is the
+        # payload this backup exists to carry, so a bundle without it reports success and
+        # restores nothing — and the only files dropped by name here are ones that are
+        # pure secret or rebuildable, which a payload database is neither. So both cases
+        # refuse and name the file; what differs is only the wording, because one is the
+        # operator's own file and one is ours. The local archive is unaffected by either.
+        report.skipped_unreadable.append(f"{rel} ({e})")
+        if product:
+            raise _PayloadUnprovable(rel) from e
+        raise _Unprovable(rel) from e
+
+
+def redact_bundle_for_egress(stage: Path) -> RedactionReport:
+    """Redact a staged bundle IN PLACE. *stage* must be a throwaway copy, never the original.
+
+    Walks the staged tree rather than a declared file list: what leaves the host is exactly
+    what is on disk here, so the walk and the payload cannot disagree.
+    """
+    report = RedactionReport()
+    opaque: list[str] = []
+    unprovable_payload: list[str] = []
+    # Directory members carry names too, and the archive stores them. A directory holding
+    # files is already covered by those files' own paths, but an EMPTY one is a member no
+    # file names -- so scanning only files let a credential written into a directory name
+    # ride out in the archive's member list while every byte of content was clean. The
+    # reason the file loop refuses on a path is not a property of files; it is a property
+    # of member names.
+    for directory in sorted(p for p in stage.rglob("*") if p.is_dir()):
+        rel = directory.relative_to(stage).as_posix()
+        if _scrub(rel)[1]:
+            opaque.append(rel)
+    for path in sorted(p for p in stage.rglob("*") if p.is_file()):
+        rel = path.relative_to(stage).as_posix()
+        if _scrub(rel)[1]:
+            # The archive stores its member names, so a credential written into a PATH
+            # leaves the host even when every byte of content is clean. Renaming is not
+            # the answer — the restore would then produce a file the operator never had —
+            # so the upload refuses and names it.
+            opaque.append(rel)
+            continue
+        if rel == "MANIFEST.json":
+            # The ROOT manifest only. The caller rewrites that one once the report is
+            # known, which is why skipping it here is safe; nothing rewrites a file that
+            # merely shares its name. Matching on the basename would exempt every
+            # `MANIFEST.json` anywhere in the bundle -- `workspace/` is copied wholesale,
+            # so an operator's own tree can carry one -- and an exempted file is neither
+            # scrubbed nor refused, so its contents would reach the destination verbatim.
+            continue
+        if rel in _DROP_ENTIRELY:
+            path.unlink()
+            report.dropped.append(rel)
+            continue
+        if rel in _DERIVED_INDEXES:
+            path.unlink()
+            report.dropped.append(rel)
+            report.rebuilt_indexes.append(rel)
+            continue
+        if path.suffix == ".db":
+            try:
+                _redact_database(path, report, rel, product=rel in _PRODUCT_DATABASES)
+            except _PayloadUnprovable:
+                # Never deleted: an off-host copy missing the memory it was taken for is
+                # the failure this whole path exists to prevent.
+                unprovable_payload.append(rel)
+            except _Unprovable:
+                # Not a product database and not provably clean — commonly a `.db` that
+                # is not SQLite at all. Refused rather than removed, for the same reason
+                # an opaque file is.
+                opaque.append(rel)
+            continue
+        if _redact_text_file(path, report, rel):
+            continue
+        # Genuinely not text: the redactors work on strings, so this file cannot be shown
+        # free of credentials. It is neither redacted nor deleted — deleting an operator's
+        # file would make a restore quietly incomplete, so the UPLOAD is refused and the
+        # file is named, leaving the choice with the person whose data it is.
+        opaque.append(rel)
+    if unprovable_payload:
+        # Raised before the opaque list: this one says the backup has no contents, which
+        # is the more important thing for the operator to read first.
+        raise PayloadDatabaseUnprovable(
+            unprovable_payload,
+            [s for s in report.skipped_unreadable if s.split(" (", 1)[0] in unprovable_payload],
+        )
+    if opaque:
+        # Reported together so the operator sees the whole list, not the first offender.
+        raise OpaqueFilesPresent(opaque)
+    _stamp_manifest(stage, report)
+    # LAST, because the stamp itself writes paths and error text into the manifest. The
+    # manifest is the one file guaranteed to leave the host, so leaving it unscanned put
+    # the only certain payload outside the pass.
+    _redact_manifest(stage, report)
+    return report
+
+
+def _redact_manifest(stage: Path, report: RedactionReport) -> None:
+    """Scrub the manifest after it is stamped, and prove it is still readable.
+
+    The replacement tag carries no quote or backslash, so a scrubbed JSON string stays
+    valid — but that is a property of the tag, not a guarantee, so it is checked instead
+    of assumed. A manifest that no longer parses would make the bundle unrestorable.
+    """
+    mf = stage / "MANIFEST.json"
+    if not mf.is_file():
+        return
+    try:
+        original = mf.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        raise _Unprovable(f"MANIFEST.json: {e}") from e
+    cleaned, hits = _scrub(original)
+    if not hits:
+        return
+    try:
+        json.loads(cleaned)
+    except ValueError as e:
+        raise _Unprovable(f"MANIFEST.json would not survive redaction: {e}") from e
+    mf.write_text(cleaned, encoding="utf-8")
+    report.replacements["MANIFEST.json"] = report.replacements.get("MANIFEST.json", 0) + hits
+
+
+def _stamp_manifest(stage: Path, report: RedactionReport) -> None:
+    """Record the redaction in the manifest so a restore can say what it is holding."""
+    mf = stage / "MANIFEST.json"
+    if not mf.is_file():
+        return
+    try:
+        data = json.loads(mf.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    if not isinstance(data, dict):
+        return
+    data["redaction"] = report.as_manifest_entry()
+    mf.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def stage_redacted_copy(source_stage: Path, dest: Path) -> RedactionReport:
+    """Copy *source_stage* to *dest* and redact the copy, never the original."""
+    shutil.copytree(source_stage, dest)
+    return redact_bundle_for_egress(dest)

--- a/test/test_pinned_staging.py
+++ b/test/test_pinned_staging.py
@@ -922,10 +922,23 @@ def test_the_replace_path_refuses_a_root_recreated_after_its_own_rmtree(
 
     monkeypatch.setattr(snapshot.shutil, "rmtree", _rmtree_then_recreate)
 
-    with pytest.raises(pinned_fs.PinnedPathRefusal) as excinfo:
+    # The refusal must SURFACE with its message intact -- that message is what proves
+    # `must_create=True` reached the call site, which is this test's whole point.
+    #
+    # It may arrive wrapped. A refusal mid-mutation now triggers the phase-two rollback, and
+    # this test's own `rmtree` patch sabotages the recovery leg too (it recreates the root the
+    # recovery is about to refill), so recovery legitimately cannot complete and the refusal
+    # is re-raised as its `cause`. Accepting either form keeps the wiring assertion exactly as
+    # strong -- the message is still required -- without asserting that a mid-mutation refusal
+    # must SKIP the rollback, which would be the opposite of correct.
+    with pytest.raises((pinned_fs.PinnedPathRefusal, snapshot.RollbackIncomplete)) as excinfo:
         snapshot._do_replace(snap, mc, ["workspace"], **UNPINNED_OK)
 
-    assert "already exists" in str(excinfo.value), f"unclear refusal: {excinfo.value}"
+    refusal = getattr(excinfo.value, "cause", excinfo.value)
+    assert isinstance(
+        refusal, pinned_fs.PinnedPathRefusal
+    ), f"not a pin refusal: {type(refusal).__name__}: {refusal}"
+    assert "already exists" in str(refusal), f"unclear refusal: {refusal}"
     assert not (live / "from-archive.txt").exists(), (
         "the archive was staged into a root somebody else recreated, so a replace would "
         "have reported success with foreign files still in place"

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -18,6 +18,31 @@ from kiro_crew.snapshot import restore_main, snapshot_main
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
+def unpinnable_argv() -> list[str]:
+    """``--allow-unpinned-staging``, but ONLY where the platform cannot pin a tree walk.
+
+    ``_staging_is_pinned`` refuses rather than falling back when there are no directory
+    descriptors, which is deliberate: a by-name walk is the mechanism whose failure closed
+    two pull requests, so the weaker mode is never something the tool picks on the
+    operator's behalf. A test that drives snapshot or restore therefore has to say the same
+    thing an operator on such a platform has to say, or it dies at the refusal instead of
+    reaching its own subject -- which is what left the whole snapshot suite red on Windows.
+
+    Returned CONDITIONALLY, never unconditionally. Passing the flag everywhere would move
+    Linux onto the by-name traversal too and quietly delete this suite's coverage of the
+    pinned path, which is the path that actually ships. Where pinning works this is empty
+    and nothing changes.
+
+    Not for a test whose SUBJECT is the pinned guarantee itself (an ancestor swap being
+    refused, a nested symlink not being copied). That guarantee does not exist on a
+    platform without descriptors, so such a test skips there rather than asserting a
+    promise the platform cannot keep.
+    """
+    from kiro_crew import pinned_fs
+
+    return [] if pinned_fs.supports_pinned_tree_walk() else ["--allow-unpinned-staging"]
+
+
 @pytest.fixture(autouse=True)
 def _no_gateway(monkeypatch):
     """Prevent gateway-running check from blocking restore in tests.
@@ -32,11 +57,18 @@ def _setup_fake_kirocrew(d: Path) -> None:
     """Create a realistic fake ~/.kirocrew directory."""
     for sub in (
         "workspace/memory/history",
+        "workspace/knowledge",
         "workspace/hygiene_data",
         "skills/my-skill",
         "plan_memory",
     ):
         (d / sub).mkdir(parents=True, exist_ok=True)
+
+    # The markdown half of memory, which the `memory` component claims alongside the
+    # databases so restoring memory does not require the whole workspace.
+    (d / "workspace/memory/preferences.md").write_text("- prefers terse answers\n")
+    (d / "workspace/memory/projects.md").write_text("# Active Projects\n")
+    (d / "workspace/knowledge/kb.sqlite3").write_bytes(b"SQLite format 3\x00stub")
 
     # memory.db with all tables
     conn = sqlite3.connect(str(d / "memory.db"))
@@ -106,8 +138,15 @@ def _setup_fake_kirocrew(d: Path) -> None:
 
 
 def _make_snapshot(src: Path, out: Path, extra_args: list[str] | None = None) -> Path:
-    """Create a snapshot and return the tarball path. Caller must set KIROCREW_HOME."""
-    args = [str(out)] + (extra_args or [])
+    """Create a snapshot and return the tarball path. Caller must set KIROCREW_HOME.
+
+    ``unpinnable_argv()`` is appended, not optional: on a platform with no directory
+    descriptors ``_staging_is_pinned`` refuses instead of falling back, so without it every
+    consumer of this helper dies in the helper itself and reports as a fixture ERROR rather
+    than as its own subject failing. Empty where pinning works, so Linux still exercises the
+    pinned path.
+    """
+    args = [str(out)] + (extra_args or []) + unpinnable_argv()
     snapshot_main(args)
     tarballs = sorted(
         out.glob("kirocrew-snapshot-*.tar.gz"), key=lambda p: p.stat().st_mtime, reverse=True
@@ -151,7 +190,20 @@ class TestSnapshot:
         assert (snap / "skills/my-skill/SKILL.md").is_file()
         assert not (snap / "workspace/hygiene_data/week1.json").exists()
         m = json.loads((snap / "MANIFEST.json").read_text(encoding="utf-8"))
-        assert m["version"] == 2
+        assert m["version"] == 3
+        # v3 is additive over v2 — every v2 key is still present, so a restore built
+        # before the purpose seam reads a v3 bundle correctly instead of refusing it.
+        for v2_key in (
+            "created_at",
+            "hostname",
+            "user",
+            "kirocrew_dir",
+            "contents",
+        ):
+            assert v2_key in m, v2_key
+        assert m["purpose"] == "backup"
+        assert m["components"]["memory"] == "unresolved"
+        assert m["components"]["config"] == "unresolved"
 
     def test_db_content_survives(self, env):
         _, _, tarball, tmp_path = env
@@ -189,7 +241,7 @@ class TestSnapshot:
         for i in range(3):
             (out2 / f"kirocrew-snapshot-2026010{i}T000000Z.tar.gz").write_text("fake")
         monkeypatch.setenv("KIROCREW_HOME", str(src))
-        snapshot_main([str(out2), "--keep", "2"])
+        snapshot_main([str(out2), "--keep", "2"] + unpinnable_argv())
         total = len(list(out2.glob("kirocrew-snapshot-*.tar.gz")))
         assert total == 2
 
@@ -233,7 +285,7 @@ class TestRestoreReplace:
         fresh = tmp_path / "fresh5"
         fresh.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(fresh))
-        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"] + unpinnable_argv())
         assert ret == 0
         assert (fresh / "memory.db").is_file()
         assert (fresh / "crons.json").is_file()
@@ -254,7 +306,7 @@ class TestRestoreReplace:
         _setup_fake_kirocrew(existing)
         (existing / "workspace/original.md").write_text("original")
         monkeypatch.setenv("KIROCREW_HOME", str(existing))
-        restore_main([str(tarball), "--mode", "replace", "--force"])
+        restore_main([str(tarball), "--mode", "replace", "--force"] + unpinnable_argv())
         backups = [
             d for d in existing.iterdir() if d.is_dir() and d.name.startswith("pre-restore-")
         ]
@@ -275,7 +327,7 @@ class TestRestoreReplace:
         _setup_fake_kirocrew(existing)
         (existing / "workspace/local_only.md").write_text("local-only-file")
         monkeypatch.setenv("KIROCREW_HOME", str(existing))
-        restore_main([str(tarball), "--mode", "replace", "--force"])
+        restore_main([str(tarball), "--mode", "replace", "--force"] + unpinnable_argv())
         backups = [
             d for d in existing.iterdir() if d.is_dir() and d.name.startswith("pre-restore-")
         ]
@@ -340,7 +392,7 @@ class TestRestoreMerge:
         conn.commit()
         conn.close()
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
         assert ret == 0
         conn = sqlite3.connect(str(dst / "memory.db"))
         val = conn.execute(
@@ -360,7 +412,7 @@ class TestRestoreMerge:
         _setup_fake_kirocrew(dst)
         before = len(json.loads((dst / "crons.json").read_text(encoding="utf-8"))["jobs"])
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
         assert ret == 0
         after = len(json.loads((dst / "crons.json").read_text(encoding="utf-8"))["jobs"])
         assert before == after
@@ -374,7 +426,7 @@ class TestRestoreMerge:
         d["jobs"][0]["name"] = "different-job"
         (dst / "crons.json").write_text(json.dumps(d))
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        restore_main([str(tarball), "--mode", "merge", "--force"])
+        restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
         count = len(json.loads((dst / "crons.json").read_text(encoding="utf-8"))["jobs"])
         assert count == 2
 
@@ -389,7 +441,10 @@ class TestRestoreMerge:
         before = (dst / "crons.json").read_bytes()
 
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        ret = restore_main([str(tarball), "--mode", "merge", "--components", "crons", "--force"])
+        ret = restore_main(
+            [str(tarball), "--mode", "merge", "--components", "crons", "--force"]
+            + unpinnable_argv()
+        )
 
         assert ret == 0
         assert (dst / "crons.json").read_bytes() == before
@@ -407,7 +462,10 @@ class TestRestoreMerge:
         (dst / "crons.json").write_bytes(malformed)
 
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        ret = restore_main([str(tarball), "--mode", "merge", "--components", "crons", "--force"])
+        ret = restore_main(
+            [str(tarball), "--mode", "merge", "--components", "crons", "--force"]
+            + unpinnable_argv()
+        )
 
         assert ret == 0
         assert (dst / "crons.json").read_bytes() == malformed
@@ -422,7 +480,7 @@ class TestRestoreMerge:
         _setup_fake_kirocrew(dst)
         (dst / "workspace/doc.md").write_text("local version")
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
         assert ret == 0
         assert (dst / "workspace/doc.md").read_text(encoding="utf-8") == "local version"
 
@@ -439,7 +497,7 @@ class TestRestoreMerge:
         conn.commit()
         conn.close()
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
         assert ret == 0
         conn = sqlite3.connect(str(dst / "memory.db"))
         assert conn.execute("SELECT count(*) FROM episodic_memories").fetchone()[0] == 3
@@ -453,7 +511,7 @@ class TestRestoreMerge:
         dst = tmp_path / "dst13"
         _setup_fake_kirocrew(dst)
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        restore_main([str(tarball), "--mode", "merge", "--force"])
+        restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
         assert "Semantic Memory imported: 0" in capsys.readouterr().out
 
     def test_merge_import_count_one_new(self, env, capsys, monkeypatch):
@@ -466,7 +524,7 @@ class TestRestoreMerge:
         conn.commit()
         conn.close()
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        restore_main([str(tarball), "--mode", "merge", "--force"])
+        restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
         assert "Semantic Memory imported: 1" in capsys.readouterr().out
 
     def test_merge_notifications(self, env, monkeypatch):
@@ -476,7 +534,7 @@ class TestRestoreMerge:
         _setup_fake_kirocrew(dst)
         (dst / "notifications.jsonl").write_text('{"ts":"2026-02-01","msg":"local"}\n')
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        restore_main([str(tarball), "--mode", "merge", "--force"])
+        restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
         lines = (dst / "notifications.jsonl").read_text(encoding="utf-8").strip().split("\n")
         assert len(lines) == 2
 
@@ -487,7 +545,7 @@ class TestRestoreMerge:
         _setup_fake_kirocrew(dst)
         (dst / "plan_memory/local_plan.json").write_text("local plan")
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
         assert ret == 0
         assert (dst / "plan_memory/plan1.json").is_file()
         assert (dst / "plan_memory/local_plan.json").read_text(encoding="utf-8") == "local plan"
@@ -507,7 +565,7 @@ class TestRestoreMerge:
         (dst / "telemetry_salt").unlink()
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
 
-        assert restore_main([str(tarball), "--mode", "merge", "--force"]) == 0
+        assert restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv()) == 0
         assert (dst / "telemetry_salt").is_file()
 
     def test_merge_refuses_a_crons_file_that_is_not_an_object(self, env, capsys, monkeypatch):
@@ -518,7 +576,7 @@ class TestRestoreMerge:
         (dst / "crons.json").write_text('["not", "a", "cron file"]', encoding="utf-8")
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
 
-        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
 
         assert ret == 0
         assert "skipping" in capsys.readouterr().out.lower()
@@ -544,7 +602,7 @@ class TestRestoreMerge:
         (dst / "crons.json").write_text(body, encoding="utf-8")
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
 
-        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
 
         assert ret == 0
         assert "skipping" in capsys.readouterr().out.lower()
@@ -565,7 +623,7 @@ class TestRestoreMerge:
         keep = (dst / "crons.json").read_text(encoding="utf-8")
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
 
-        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
 
         assert ret == 0
         assert "skipping" in capsys.readouterr().out.lower()
@@ -579,7 +637,7 @@ class TestRestoreMerge:
         (dst / "crons.json").write_text('{"version": 1}', encoding="utf-8")
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
 
-        assert restore_main([str(tarball), "--mode", "merge", "--force"]) == 0
+        assert restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv()) == 0
 
         merged = json.loads((dst / "crons.json").read_text(encoding="utf-8"))
         assert len(merged["jobs"]) == 1
@@ -594,7 +652,7 @@ class TestRestoreMerge:
         (dst / "crons.json").write_text(json.dumps(d))
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
 
-        restore_main([str(tarball), "--mode", "merge", "--force"])
+        restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
 
         assert len(json.loads((dst / "crons.json").read_text(encoding="utf-8"))["jobs"]) == 2
 
@@ -605,7 +663,7 @@ class TestRestoreMerge:
         _setup_fake_kirocrew(dst)
         (dst / "telemetry_salt").unlink()
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        restore_main([str(tarball), "--mode", "merge", "--force"])
+        restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
         assert (dst / "telemetry_salt").is_file()
         assert "telemetry_salt: restored" in capsys.readouterr().out
 
@@ -615,7 +673,10 @@ class TestRestoreMerge:
         fresh = tmp_path / "fresh26"
         fresh.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(fresh))
-        restore_main([str(tarball), "--mode", "merge", "--components", "memory", "--force"])
+        restore_main(
+            [str(tarball), "--mode", "merge", "--components", "memory", "--force"]
+            + unpinnable_argv()
+        )
         assert (fresh / "memory.db").is_file()
         assert "copied" in capsys.readouterr().out
 
@@ -627,7 +688,10 @@ class TestRestoreMerge:
         # Same ts as snapshot
         (dst / "notifications.jsonl").write_text('{"ts":"2026-01-01","msg":"test"}\n')
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        restore_main([str(tarball), "--mode", "merge", "--components", "notifications", "--force"])
+        restore_main(
+            [str(tarball), "--mode", "merge", "--components", "notifications", "--force"]
+            + unpinnable_argv()
+        )
         lines = (dst / "notifications.jsonl").read_text(encoding="utf-8").strip().split("\n")
         assert len(lines) == 1
         assert "Notifications imported: 0" in capsys.readouterr().out
@@ -667,7 +731,10 @@ class TestComponents:
         fresh = tmp_path / "fresh19"
         fresh.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(fresh))
-        restore_main([str(tarball), "--mode", "replace", "--components", "memory", "--force"])
+        restore_main(
+            [str(tarball), "--mode", "replace", "--components", "memory", "--force"]
+            + unpinnable_argv()
+        )
         assert (fresh / "memory.db").is_file()
         assert not (fresh / "crons.json").exists()
         assert not (fresh / "config.json").exists()
@@ -680,7 +747,10 @@ class TestComponents:
         fresh = tmp_path / "fresh20"
         fresh.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(fresh))
-        restore_main([str(tarball), "--mode", "replace", "--components", "crons,skills", "--force"])
+        restore_main(
+            [str(tarball), "--mode", "replace", "--components", "crons,skills", "--force"]
+            + unpinnable_argv()
+        )
         assert (fresh / "crons.json").is_file()
         assert (fresh / "skills/my-skill/SKILL.md").is_file()
         assert not (fresh / "memory.db").exists()
@@ -693,7 +763,10 @@ class TestComponents:
         _setup_fake_kirocrew(dst)
         (dst / "crons.json").unlink()
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        restore_main([str(tarball), "--mode", "merge", "--components", "crons", "--force"])
+        restore_main(
+            [str(tarball), "--mode", "merge", "--components", "crons", "--force"]
+            + unpinnable_argv()
+        )
         assert (dst / "crons.json").is_file()
         conn = sqlite3.connect(str(dst / "memory.db"))
         assert conn.execute("SELECT count(*) FROM semantic_memory").fetchone()[0] == 2
@@ -705,7 +778,12 @@ class TestComponents:
         monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
         ret = restore_main([str(tarball), "--components", "bogus", "--force"])
         assert ret == 1
-        assert "Unknown component: bogus" in capsys.readouterr().out
+        out = capsys.readouterr().out
+        # The refusal must name the offending component and the known set, so the
+        # operator can fix the invocation without reading the source.
+        assert "unknown component" in out.lower()
+        assert "bogus" in out
+        assert "memory" in out
 
     def test_all_components(self, env, monkeypatch):
         """TEST 23"""
@@ -713,7 +791,7 @@ class TestComponents:
         fresh = tmp_path / "fresh23"
         fresh.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(fresh))
-        restore_main([str(tarball), "--mode", "replace", "--force"])
+        restore_main([str(tarball), "--mode", "replace", "--force"] + unpinnable_argv())
         assert (fresh / "memory.db").is_file()
         assert (fresh / "crons.json").is_file()
         assert (fresh / "config.json").is_file()
@@ -729,7 +807,7 @@ class TestIntegrity:
         fresh = tmp_path / "fresh17"
         fresh.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(fresh))
-        restore_main([str(tarball), "--mode", "replace", "--force"])
+        restore_main([str(tarball), "--mode", "replace", "--force"] + unpinnable_argv())
         assert "integrity: OK" in capsys.readouterr().out
 
     def test_fts_missing_warning(self, env, capsys, monkeypatch):
@@ -738,12 +816,18 @@ class TestIntegrity:
         fresh = tmp_path / "fresh31"
         fresh.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(fresh))
-        restore_main([str(tarball), "--mode", "replace", "--components", "memory", "--force"])
+        restore_main(
+            [str(tarball), "--mode", "replace", "--components", "memory", "--force"]
+            + unpinnable_argv()
+        )
         capsys.readouterr()  # discard first call's output
         # Remove index db
         (fresh / "memory_index.db").unlink(missing_ok=True)
         # Re-run merge to trigger warning
-        restore_main([str(tarball), "--mode", "merge", "--components", "memory", "--force"])
+        restore_main(
+            [str(tarball), "--mode", "merge", "--components", "memory", "--force"]
+            + unpinnable_argv()
+        )
         assert "memory_index.db is missing" in capsys.readouterr().out
 
 
@@ -784,7 +868,7 @@ class TestSecurity:
         fresh = tmp_path / "fresh30"
         fresh.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(fresh))
-        ret = restore_main([str(evil_tar), "--mode", "replace", "--force"])
+        ret = restore_main([str(evil_tar), "--mode", "replace", "--force"] + unpinnable_argv())
         # Symlink is filtered out by _data_filter, restore succeeds
         assert ret == 0
         assert not (fresh / "evil_link").exists()
@@ -811,7 +895,7 @@ class TestSecurity:
         fresh = tmp_path / "fresh_traversal"
         fresh.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(fresh))
-        ret = restore_main([str(evil_tar), "--mode", "replace", "--force"])
+        ret = restore_main([str(evil_tar), "--mode", "replace", "--force"] + unpinnable_argv())
         # Traversal entry filtered out, restore proceeds
         assert ret == 0
         # Verify no "passwd" file anywhere under restore dir
@@ -832,7 +916,7 @@ class TestSecurity:
         fresh = tmp_path / "fresh_abspath"
         fresh.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(fresh))
-        ret = restore_main([str(evil_tar), "--mode", "replace", "--force"])
+        ret = restore_main([str(evil_tar), "--mode", "replace", "--force"] + unpinnable_argv())
         assert ret == 0
         assert not any(p.name == "passwd" for p in fresh.rglob("*"))
 
@@ -851,7 +935,7 @@ class TestSecurity:
         fresh = tmp_path / "fresh_hardlink"
         fresh.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(fresh))
-        ret = restore_main([str(evil_tar), "--mode", "replace", "--force"])
+        ret = restore_main([str(evil_tar), "--mode", "replace", "--force"] + unpinnable_argv())
         assert ret == 0
         assert not (fresh / "evil").exists()
 
@@ -883,7 +967,12 @@ class TestParsedNamespace:
         src, _, _, tmp_path = env
         out = tmp_path / "out_parsed"
         monkeypatch.setenv("KIROCREW_HOME", str(src))
-        ns = argparse.Namespace(output_dir=str(out), keep=7, list_snapshots=False)
+        ns = argparse.Namespace(
+            output_dir=str(out),
+            keep=7,
+            list_snapshots=False,
+            allow_unpinned=bool(unpinnable_argv()),
+        )
         ret = snapshot_main(parsed=ns)
         assert ret == 0
         assert list(out.glob("kirocrew-snapshot-*.tar.gz"))
@@ -900,6 +989,7 @@ class TestParsedNamespace:
             components=None,
             list_components=False,
             force=True,
+            allow_unpinned=bool(unpinnable_argv()),
         )
         ret = restore_main(parsed=ns)
         assert ret == 0
@@ -921,7 +1011,7 @@ class TestSchemaIncompatibleMerge:
         conn.commit()
         conn.close()
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
         assert ret == 0
         out = capsys.readouterr().out
         assert "Semantic Memory imported" in out
@@ -950,7 +1040,7 @@ class TestCorruptSourceDB:
         dst = tmp_path / "dst_corrupt_src"
         _setup_fake_kirocrew(dst)
         monkeypatch.setenv("KIROCREW_HOME", str(dst))
-        ret = restore_main([str(corrupt_tar), "--mode", "merge", "--force"])
+        ret = restore_main([str(corrupt_tar), "--mode", "merge", "--force"] + unpinnable_argv())
         assert ret == 0
         out_text = capsys.readouterr().out
         assert "Source DB" in out_text or "Merge complete" in out_text
@@ -975,7 +1065,7 @@ class TestGatewayRunningRefusal:
         fresh.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(fresh))
         monkeypatch.setenv("KIROCREW_ASSUME_GATEWAY_RUNNING", "1")
-        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"] + unpinnable_argv())
         assert ret == 0
 
 
@@ -986,7 +1076,7 @@ class TestEmptyKirocrewDir:
         empty.mkdir()
         out = tmp_path / "empty_out"
         monkeypatch.setenv("KIROCREW_HOME", str(empty))
-        ret = snapshot_main([str(out)])
+        ret = snapshot_main([str(out)] + unpinnable_argv())
         assert ret == 0
         assert list(out.glob("kirocrew-snapshot-*.tar.gz"))
 
@@ -998,12 +1088,12 @@ class TestConcurrentSnapshot:
         out = tmp_path / "concurrent_out"
         out.mkdir()
         monkeypatch.setenv("KIROCREW_HOME", str(src))
-        snapshot_main([str(out)])
+        snapshot_main([str(out)] + unpinnable_argv())
         # Ensure different timestamp by creating a second one
         import time
 
         time.sleep(1.1)
-        snapshot_main([str(out)])
+        snapshot_main([str(out)] + unpinnable_argv())
         tarballs = list(out.glob("kirocrew-snapshot-*.tar.gz"))
         assert len(tarballs) == 2
         assert tarballs[0].name != tarballs[1].name
@@ -1041,7 +1131,7 @@ class TestTheArchiveIsLockedDownBeforeItIsPublished:
             return real(path)
 
         monkeypatch.setattr("kiro_crew.platform_compat.restrict_to_owner", _recording)
-        snapshot_main([str(out)])
+        snapshot_main([str(out)] + unpinnable_argv())
 
         published = sorted(out.glob("kirocrew-snapshot-*.tar.gz"))
         assert published, "no snapshot was produced"
@@ -1065,7 +1155,7 @@ class TestTheArchiveIsLockedDownBeforeItIsPublished:
         )
 
         with pytest.raises(OSError):
-            snapshot_main([str(out)])
+            snapshot_main([str(out)] + unpinnable_argv())
 
         assert not list(
             out.glob("kirocrew-snapshot-*.tar.gz")
@@ -1079,7 +1169,7 @@ class TestTheArchiveIsLockedDownBeforeItIsPublished:
         _setup_fake_kirocrew(src)
         monkeypatch.setenv("KIROCREW_HOME", str(src))
 
-        snapshot_main([str(out)])
+        snapshot_main([str(out)] + unpinnable_argv())
         tarball = sorted(out.glob("kirocrew-snapshot-*.tar.gz"))[0]
         assert tarball.is_file()
         if os.name == "posix":
@@ -1112,7 +1202,7 @@ class TestMergeRestoreLocksBeforePublish:
             return real(path)
 
         monkeypatch.setattr(snapshot_mod.platform_compat, "restrict_to_owner", _recording)
-        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=True)
+        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=bool(unpinnable_argv()))
 
         assert dest.is_file()
         assert dest.read_bytes() == self._SALT
@@ -1133,7 +1223,7 @@ class TestMergeRestoreLocksBeforePublish:
             "restrict_to_owner",
             lambda path: (_ for _ in ()).throw(OSError("icacls: transient failure")),
         )
-        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=True)
+        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=bool(unpinnable_argv()))
 
         assert not (home / "telemetry_salt").exists()
         assert not list(home.glob("*.tmp"))
@@ -1159,7 +1249,7 @@ class TestMergeRestoreLocksBeforePublish:
         snap.mkdir()
         home.mkdir()
         (snap / "telemetry_salt").write_bytes(b"x" * 33)
-        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=True)
+        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=bool(unpinnable_argv()))
         assert not (home / "telemetry_salt").exists()
 
     def test_a_dest_created_before_link_is_not_clobbered(self, tmp_path, monkeypatch):
@@ -1187,7 +1277,7 @@ class TestMergeRestoreLocksBeforePublish:
             raise OSError("Invalid cross-device link")
 
         monkeypatch.setattr(snapshot_mod.os, "link", _link)
-        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=True)
+        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=bool(unpinnable_argv()))
         assert not (home / "telemetry_salt").exists()
 
     def test_a_failed_close_does_not_abort_merge(self, tmp_path, monkeypatch):
@@ -1209,5 +1299,5 @@ class TestMergeRestoreLocksBeforePublish:
             raise OSError("close: delayed writeback")
 
         monkeypatch.setattr(snapshot_mod.os, "close", _close)
-        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=True)
+        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=bool(unpinnable_argv()))
         assert not (home / "telemetry_salt").exists()

--- a/test/test_snapshot_archive_bound.py
+++ b/test/test_snapshot_archive_bound.py
@@ -1,0 +1,93 @@
+"""Tests for the archive-size bound that refuses an archive too large to be safe.
+
+A compressed archive can declare orders of magnitude more content than it occupies, so
+the bytes it holds say nothing about what extraction would write. The bound runs on the
+member headers before `extractall`.
+"""
+
+from __future__ import annotations
+
+import tarfile
+
+import pytest
+
+from kiro_crew import snapshot as snap
+
+
+def _info(name: str, size: int, *, kind: str = "file") -> tarfile.TarInfo:
+    """A REAL TarInfo, so isfile()/size behave as production sees them."""
+    ti = tarfile.TarInfo(name)
+    ti.size = size
+    ti.type = {"file": tarfile.REGTYPE, "dir": tarfile.DIRTYPE, "link": tarfile.SYMTYPE}[kind]
+    return ti
+
+
+class _Walker:
+    """Stands in for TarFile's member cursor only -- `next()` is the real API used."""
+
+    def __init__(self, members):
+        self._it = iter(members)
+
+    def next(self):  # noqa: A003 - mirrors tarfile.TarFile.next
+        return next(self._it, None)
+
+
+class TestTheBoundRefusesWhatWouldNotFit:
+    def test_too_many_members_is_refused(self):
+        members = [_info(f"f{i}", 1) for i in range(snap._MAX_ARCHIVE_MEMBERS + 1)]
+        with pytest.raises(snap._ArchiveTooLarge) as e:
+            snap._refuse_oversized_archive(_Walker(members))
+        assert "entries" in str(e.value)
+
+    def test_too_many_declared_bytes_is_refused(self):
+        members = [_info("huge", snap._MAX_ARCHIVE_BYTES + 1)]
+        with pytest.raises(snap._ArchiveTooLarge) as e:
+            snap._refuse_oversized_archive(_Walker(members))
+        assert "GiB" in str(e.value)
+
+    def test_the_bound_is_a_sum_not_a_per_member_check(self):
+        """A bomb split across many honest-looking members must still be refused."""
+        each = snap._MAX_ARCHIVE_BYTES // 4
+        members = [_info(f"p{i}", each) for i in range(5)]
+        with pytest.raises(snap._ArchiveTooLarge):
+            snap._refuse_oversized_archive(_Walker(members))
+
+    def test_a_normal_bundle_passes(self):
+        members = [_info("kirocrew-snapshot-x/MANIFEST.json", 200)] + [
+            _info(f"kirocrew-snapshot-x/f{i}", 4096) for i in range(50)
+        ]
+        snap._refuse_oversized_archive(_Walker(members))  # no raise
+
+    def test_directory_and_link_headers_do_not_count_toward_the_size(self):
+        """Their declared size is never written, so counting them would refuse
+        honest archives."""
+        members = [
+            _info("d", snap._MAX_ARCHIVE_BYTES, kind="dir"),
+            _info("l", snap._MAX_ARCHIVE_BYTES, kind="link"),
+            _info("real", 10),
+        ]
+        snap._refuse_oversized_archive(_Walker(members))  # no raise
+
+    def test_a_negative_declared_size_cannot_reduce_the_total(self):
+        members = [
+            _info("neg", -(snap._MAX_ARCHIVE_BYTES)),
+            _info("big", snap._MAX_ARCHIVE_BYTES + 1),
+        ]
+        with pytest.raises(snap._ArchiveTooLarge):
+            snap._refuse_oversized_archive(_Walker(members))
+
+    def test_the_walk_stops_at_the_member_that_crosses_the_bound(self):
+        """Bounded work, not work proportional to what the archive claims."""
+        seen = 0
+
+        def gen():
+            nonlocal seen
+            for i in range(snap._MAX_ARCHIVE_MEMBERS * 10):
+                seen += 1
+                yield _info(f"f{i}", 1)
+
+        with pytest.raises(snap._ArchiveTooLarge):
+            snap._refuse_oversized_archive(_Walker(gen()))
+        assert (
+            seen <= snap._MAX_ARCHIVE_MEMBERS + 1
+        ), f"walked {seen} members; the bound must stop the walk"

--- a/test/test_snapshot_cycle11_fixes.py
+++ b/test/test_snapshot_cycle11_fixes.py
@@ -1,0 +1,89 @@
+"""Two ways a credential reached the destination unscrubbed: an exemption matched by
+basename, and a SQL identifier that closed its own quote.
+
+Both are the same shape -- a rule written for one specific thing, applied to everything
+that merely resembles it -- and both end with the pass reporting a clean scan of bytes it
+never examined.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kiro_crew import snapshot_redact as redact
+
+KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _stage(tmp_path: Path) -> Path:
+    stage = tmp_path / "bundle"
+    stage.mkdir()
+    (stage / "MANIFEST.json").write_text(json.dumps({"components": {}}), encoding="utf-8")
+    return stage
+
+
+def _ddl_quoted(name: str) -> str:
+    """Quote *name* for DDL, escaping by hand rather than through the code under test."""
+    return '"' + name.replace('"', '""') + '"'
+
+
+class TestOnlyTheRootManifestIsExempt:
+    """The manifest branch is for the ONE manifest this pass rewrites with its report."""
+
+    def test_a_nested_manifest_does_not_ride_out_unscrubbed(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        nested = stage / "workspace" / "MANIFEST.json"
+        nested.parent.mkdir(parents=True)
+        nested.write_text(json.dumps({"note": f"key={KEY}"}), encoding="utf-8")
+
+        redact.redact_bundle_for_egress(stage)
+
+        assert KEY not in nested.read_text(encoding="utf-8")
+
+    def test_the_root_manifest_takes_the_manifest_branch(self, tmp_path: Path) -> None:
+        """It is rewritten with the report, which is why it is not scrubbed as content."""
+        stage = _stage(tmp_path)
+        root = stage / "MANIFEST.json"
+
+        redact.redact_bundle_for_egress(stage)
+
+        assert "redaction" in json.loads(root.read_text(encoding="utf-8"))
+
+
+class TestAnIdentifierCannotRewriteTheScan:
+    """Identifiers come from each database's own schema, not from this product."""
+
+    def test_a_column_name_that_closes_its_quote_still_gets_scanned(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        hostile = _ddl_quoted('body" FROM decoy --')
+        with redact.sqlite3.connect(str(db)) as conn:
+            conn.execute(f"CREATE TABLE items(id INTEGER PRIMARY KEY, {hostile} TEXT)")
+            conn.execute(f"INSERT INTO items({hostile}) VALUES(?)", (f"key={KEY}",))
+            conn.execute("CREATE TABLE decoy(body TEXT)")
+            conn.execute("INSERT INTO decoy(body) VALUES('nothing secret')")
+            conn.commit()
+        conn.close()
+
+        redact.redact_bundle_for_egress(stage)
+
+        assert KEY.encode("utf-8") not in db.read_bytes()
+
+    def test_a_table_name_that_closes_its_quote_still_gets_scanned(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        hostile = _ddl_quoted('items" ; --')
+        with redact.sqlite3.connect(str(db)) as conn:
+            conn.execute(f"CREATE TABLE {hostile}(id INTEGER PRIMARY KEY, body TEXT)")
+            conn.execute(f"INSERT INTO {hostile}(body) VALUES(?)", (f"key={KEY}",))
+            conn.commit()
+        conn.close()
+
+        redact.redact_bundle_for_egress(stage)
+
+        assert KEY.encode("utf-8") not in db.read_bytes()
+
+    def test_quoting_doubles_an_embedded_quote_and_leaves_a_plain_name_alone(self) -> None:
+        assert redact._quote_ident("body") == '"body"'
+        assert redact._quote_ident('a"b') == '"a""b"'

--- a/test/test_snapshot_cycle12_fixes.py
+++ b/test/test_snapshot_cycle12_fixes.py
@@ -1,0 +1,105 @@
+"""Two more places a rule justified for one member kind was applied as if that kind were
+the only one: the archive's member-name scan skipped directories, and replace's per-file
+presence evidence was accepted for a component's directories.
+"""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+from kiro_crew import snapshot_redact as redact
+
+KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _stage(tmp_path: Path) -> Path:
+    stage = tmp_path / "bundle"
+    stage.mkdir()
+    (stage / "MANIFEST.json").write_text(json.dumps({"components": {}}), encoding="utf-8")
+    return stage
+
+
+class TestADirectoryNameIsAMemberName:
+    """The archive stores directory members, so their names leave the host too."""
+
+    def test_an_empty_directory_named_after_a_credential_is_refused(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        (stage / "workspace" / f"key={KEY}").mkdir(parents=True)
+
+        with pytest.raises(redact.OpaqueFilesPresent) as e:
+            redact.redact_bundle_for_egress(stage)
+
+        assert KEY in str(e.value), str(e.value)
+
+    def test_a_clean_directory_tree_still_passes(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        (stage / "workspace" / "notes").mkdir(parents=True)
+
+        redact.redact_bundle_for_egress(stage)
+
+
+class TestReplaceWillNotClearATreeTheBundleLacks:
+    """Per-component presence is `any declared path`; replace clears whole directories."""
+
+    @pytest.fixture
+    def home(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        (home / "workspace" / "memory").mkdir(parents=True)
+        (home / "workspace" / "memory" / "keep.md").write_text("mine", encoding="utf-8")
+        (home / "memory.db").write_bytes(b"")
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        return home
+
+    def _partial_bundle(self, tmp_path: Path) -> Path:
+        """A partial bundle carrying memory.db and NEITHER of memory's trees."""
+        payload = tmp_path / "kirocrew-partial-20260101T000000Z"
+        payload.mkdir(parents=True)
+        conn = snap.sqlite3.connect(str(payload / "memory.db"))
+        conn.execute("CREATE TABLE semantic_memory (key, value_json)")
+        conn.commit()
+        conn.close()
+        payload.joinpath("MANIFEST.json").write_text(json.dumps({"version": 3}), encoding="utf-8")
+        bundle = tmp_path / "partial.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+        return bundle
+
+    def test_the_live_tree_survives(self, home, tmp_path, capsys) -> None:
+        """The point of the refusal: without it, replace clears this and refills nothing."""
+        bundle = self._partial_bundle(tmp_path)
+
+        snap.restore_main([str(bundle), "--mode", "replace", "--force", "--components", "memory"])
+
+        assert (home / "workspace" / "memory" / "keep.md").is_file(), capsys.readouterr().out
+
+    def test_replace_refuses_and_keeps_the_live_tree(self, home, tmp_path, capsys) -> None:
+        bundle = self._partial_bundle(tmp_path)
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "workspace/memory" in out, out
+        assert (home / "workspace" / "memory" / "keep.md").is_file(), "live tree was cleared"
+
+    def test_merge_still_accepts_it_because_merge_clears_nothing(
+        self, home, tmp_path, capsys
+    ) -> None:
+        bundle = self._partial_bundle(tmp_path)
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "merge", "--force", "--components", "memory"]
+            + unpinnable_argv()
+        )
+
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert (home / "workspace" / "memory" / "keep.md").is_file(), out

--- a/test/test_snapshot_cycle14_fixes.py
+++ b/test/test_snapshot_cycle14_fixes.py
@@ -1,0 +1,140 @@
+"""Decoding as UTF-8 is necessary evidence of text, not sufficient.
+
+NUL is a legal code point, so a NUL-padded binary whose other bytes are ASCII decodes
+cleanly -- a tar of text files is exactly that shape. Replacing a credential is a
+variable-length edit, so rewriting one moves every following byte and the operator restores
+something that is no longer a valid archive.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import snapshot_redact as redact
+
+KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _stage(tmp_path: Path) -> Path:
+    stage = tmp_path / "bundle"
+    stage.mkdir()
+    (stage / "MANIFEST.json").write_text(json.dumps({"components": {}}), encoding="utf-8")
+    return stage
+
+
+def _tar_of_text(payload: str) -> bytes:
+    """A real tar carrying one text member: mostly ASCII, NUL-padded, UTF-8 decodable."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        data = payload.encode("utf-8")
+        info = tarfile.TarInfo("notes.txt")
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+class TestTheFilterKeywordHasAFallbackAtEverySite:
+    """`filter=` landed in 3.11.4, and this repo supports 3.10."""
+
+    def test_the_redaction_extract_falls_back_like_the_restore_extract(self) -> None:
+        import ast
+
+        src = Path(__import__("kiro_crew.snapshot", fromlist=["x"]).__file__)
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+        unguarded: list[int] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "extractall"):
+                continue
+            if not any(kw.arg == "filter" for kw in node.keywords):
+                continue
+            # Walk up is not available on an ast node, so re-scan: the call must sit inside
+            # a Try whose handlers name TypeError.
+            guarded = False
+            for outer in ast.walk(tree):
+                if not isinstance(outer, ast.Try):
+                    continue
+                if node not in list(ast.walk(outer)):
+                    continue
+                for handler in outer.handlers:
+                    names = (
+                        [handler.type.id]
+                        if isinstance(handler.type, ast.Name)
+                        else [
+                            e.id
+                            for e in getattr(handler.type, "elts", [])
+                            if isinstance(e, ast.Name)
+                        ]
+                    )
+                    if "TypeError" in names:
+                        guarded = True
+            if not guarded:
+                unguarded.append(node.lineno)
+        assert unguarded == [], (
+            f"extractall(filter=...) at line(s) {unguarded} has no TypeError fallback -- "
+            f"an uncaught TypeError on Python < 3.11.4"
+        )
+
+
+class TestANulBearingFileIsNotRewritten:
+    def test_the_fixture_really_is_utf8_decodable_and_nul_padded(self) -> None:
+        """Otherwise the tests below would pass for the wrong reason."""
+        raw = _tar_of_text(f"token={KEY}")
+        assert b"\x00" in raw
+        raw.decode("utf-8")  # must not raise
+
+    def test_a_credential_inside_it_refuses_the_upload_instead_of_corrupting_it(
+        self, tmp_path: Path
+    ) -> None:
+        stage = _stage(tmp_path)
+        archive = stage / "workspace" / "export.tar"
+        archive.parent.mkdir(parents=True)
+        raw = _tar_of_text(f"token={KEY}")
+        archive.write_bytes(raw)
+
+        with pytest.raises(redact.OpaqueFilesPresent):
+            redact.redact_bundle_for_egress(stage)
+
+        assert archive.read_bytes() == raw, "the archive was rewritten in place"
+
+    def test_it_is_still_a_readable_tar_afterwards(self, tmp_path: Path) -> None:
+        """The corruption stated directly, rather than as a byte comparison."""
+        stage = _stage(tmp_path)
+        archive = stage / "workspace" / "export.tar"
+        archive.parent.mkdir(parents=True)
+        archive.write_bytes(_tar_of_text(f"token={KEY}"))
+
+        with pytest.raises(redact.OpaqueFilesPresent):
+            redact.redact_bundle_for_egress(stage)
+
+        with tarfile.open(archive, mode="r") as tf:
+            assert [m.name for m in tf.getmembers()] == ["notes.txt"]
+
+    def test_a_nul_bearing_file_with_no_credential_still_rides(self, tmp_path: Path) -> None:
+        """The hazard is on the WRITE branch, so refusing this one would cost an upload."""
+        stage = _stage(tmp_path)
+        archive = stage / "workspace" / "clean.tar"
+        archive.parent.mkdir(parents=True)
+        raw = _tar_of_text("nothing secret in here")
+        archive.write_bytes(raw)
+
+        redact.redact_bundle_for_egress(stage)
+
+        assert archive.read_bytes() == raw
+
+    def test_ordinary_text_is_still_redacted_in_place(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        note = stage / "workspace" / "note.md"
+        note.parent.mkdir(parents=True)
+        note.write_text(f"token={KEY}\n", encoding="utf-8")
+
+        redact.redact_bundle_for_egress(stage)
+
+        assert KEY not in note.read_text(encoding="utf-8")

--- a/test/test_snapshot_cycle2_fixes.py
+++ b/test/test_snapshot_cycle2_fixes.py
@@ -1,0 +1,160 @@
+"""Tests for the cycle-2 review findings.
+
+Each one pins a property whose absence was a real exposure, not a style point.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tarfile
+
+import pytest
+from test_snapshot import _setup_fake_kirocrew, unpinnable_argv
+
+from kiro_crew import pinned_fs, platform_compat
+from kiro_crew import snapshot as snap
+
+
+class TestAnUnsafeTreeRootFailsTheSnapshot:
+    """Superseded contract, and the change is a strengthening.
+
+    This class previously asserted that an unsafe root was SKIPPED and left nothing in
+    the bundle. Skipping was still wrong: the manifest went on declaring the component,
+    so the artefact claimed to contain memory it had silently omitted, and the operator
+    only found out when they tried to recover. A backup that lies about its contents is
+    worse than a refusal, so an unsafe root now fails the snapshot.
+    """
+
+    def test_a_symlinked_component_root_refuses_the_snapshot(self, tmp_path, monkeypatch, capsys):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        _setup_fake_kirocrew(home)
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "loot.md").write_text("SHOULD NOT BE STAGED")
+        target = home / "workspace" / "memory"
+        if target.is_dir():
+            shutil.rmtree(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            target.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("cannot create a directory symlink on this platform")
+
+        out = tmp_path / "out"
+        rc = snap.snapshot_main([str(out), "--components", "memory"])
+        assert rc != 0, "an unsafe root produced a 'successful' backup"
+        printed = capsys.readouterr().out
+        assert "Refusing" in printed or "refus" in printed.lower()
+        # And no bundle claiming `memory` was left behind.
+        assert list(out.glob("kirocrew-snapshot-*.tar.gz")) == []
+
+    def test_the_guard_still_stages_a_legitimate_tree(self, tmp_path, monkeypatch):
+        """The refusal must not turn a valid tree into a failure."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        _setup_fake_kirocrew(home)
+        md = home / "workspace" / "memory"
+        md.mkdir(parents=True, exist_ok=True)
+        (md / "preferences.md").write_text("keep me")
+
+        out = tmp_path / "out"
+        assert snap.snapshot_main([str(out), "--components", "memory", *unpinnable_argv()]) == 0
+        with tarfile.open(next(out.glob("kirocrew-snapshot-*.tar.gz"))) as tf:
+            names = tf.getnames()
+        assert any(n.endswith("workspace/memory/preferences.md") for n in names)
+
+
+class TestNestedLinksCannotSmuggleFilesIntoABundle:
+    def test_the_tree_walkers_use_a_junction_aware_screen(self):
+        """`os.path.islink` returns False for a Windows directory junction, so a junction
+        nested inside a component tree must be caught by a reparse-aware check or it is
+        copied THROUGH -- pulling whatever it targets into the bundle and then to S3.
+
+        M1 retarget: staging routes through `pinned_fs`. The pinned tree walk
+        (`stage_tree_pinned`) screens each entry by `lstat`/`fstat` on a descriptor -- a
+        reparse point is not `S_ISREG`/a real dir there -- and the declared by-name
+        fallback in `_copytree_safe` uses `pinned_fs.is_reparse_point`, which reports a
+        junction where `islink` does not. This pins that the junction-aware screen is what
+        both staging paths rely on, rather than the removed `is_link_or_junction` helper.
+        """
+        import inspect
+
+        copytree = inspect.getsource(snap._copytree_safe)
+        assert "is_reparse_point" in copytree, (
+            "the by-name staging fallback dropped the reparse-aware screen, so a Windows "
+            "junction would be followed"
+        )
+        # The bare name-based `islink` must not be the ONLY screen (it misses junctions).
+        # It may still appear alongside is_reparse_point in the fallback's OR-guard.
+        prim = inspect.getsource(pinned_fs.stage_tree_pinned)
+        assert (
+            "on_skip" in prim and "SKIP_SYMLINK" in prim
+        ), "the pinned tree walk no longer reports a skipped link/junction"
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="_copytree_safe refuses without dir_fd; the nested-symlink screen this pins "
+        "is the descriptor-pinned tree walk, which does not exist on a platform lacking "
+        "os.supports_dir_fd, so there is no such guarantee here to assert",
+    )
+    def test_a_nested_symlink_is_not_copied(self, tmp_path):
+        src = tmp_path / "src"
+        (src / "sub").mkdir(parents=True)
+        (src / "sub" / "real.md").write_text("keep me")
+        secret_dir = tmp_path / "secrets"
+        secret_dir.mkdir()
+        (secret_dir / "creds").write_text("SECRET")
+        try:
+            (src / "sub" / "link").symlink_to(secret_dir, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("this platform does not allow creating a directory symlink here")
+
+        dst = tmp_path / "dst"
+        snap._copytree_safe(src, dst)
+        assert (dst / "sub" / "real.md").is_file()
+        assert not (dst / "sub" / "link").exists()
+        assert "SECRET" not in "".join(p.read_text() for p in dst.rglob("*") if p.is_file())
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="both walkers (_copytree_safe / _copy_tree_no_overwrite) refuse without "
+        "dir_fd; the agreement this pins is a property of the descriptor-pinned tree walk, "
+        "which does not exist on a platform lacking os.supports_dir_fd",
+    )
+    def test_both_walkers_agree(self, tmp_path):
+        """The two tree walkers are used on the same data at different phases, so a
+        link rejected by one and followed by the other is a hole."""
+        src = tmp_path / "s"
+        (src / "d").mkdir(parents=True)
+        (src / "d" / "f.md").write_text("x")
+        target = tmp_path / "t"
+        target.mkdir()
+        (target / "leak").write_text("LEAK")
+        try:
+            (src / "d" / "l").symlink_to(target, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("cannot create a directory symlink on this platform")
+
+        a = tmp_path / "a"
+        snap._copytree_safe(src, a)
+        b = tmp_path / "b"
+        b.mkdir()
+        snap._copy_tree_no_overwrite(src, b)
+        for root in (a, b):
+            assert not (root / "d" / "l").exists(), f"{root} followed the link"
+
+    def test_the_predicate_itself_reports_a_plain_symlink(self, tmp_path):
+        f = tmp_path / "f"
+        f.write_text("x")
+        link = tmp_path / "l"
+        try:
+            link.symlink_to(f)
+        except (OSError, NotImplementedError):
+            pytest.skip("cannot create a symlink on this platform")
+        assert platform_compat.is_link_or_junction(link)
+        assert not platform_compat.is_link_or_junction(f)

--- a/test/test_snapshot_cycle2b_fixes.py
+++ b/test/test_snapshot_cycle2b_fixes.py
@@ -1,0 +1,310 @@
+"""Tests for the cycle-2 review finding: a partial root must carry a component map.
+
+The `kirocrew-partial-` root exists so released versions refuse a selective bundle.
+This version accepts it -- and that acceptance created a new hole: `declared is None`
+falls through to all-components behaviour, which is correct for a pre-v3 COMPLETE
+archive and exactly wrong for a partial one.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tarfile
+
+import pytest
+from test_snapshot import _setup_fake_kirocrew, unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    d = tmp_path / "home"
+    d.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(d))
+    _setup_fake_kirocrew(d)
+    return d
+
+
+def _archive(tmp_path, roots: dict[str, dict | None]) -> "object":
+    """Build an archive with the given roots. Value is the manifest, or None for none."""
+    stage = tmp_path / "stage"
+    stage.mkdir(exist_ok=True)
+    for name, manifest in roots.items():
+        root = stage / name
+        (root / "workspace" / "memory").mkdir(parents=True, exist_ok=True)
+        (root / "workspace" / "memory" / "preferences.md").write_text("from the bundle")
+        if manifest is not None:
+            (root / "MANIFEST.json").write_text(json.dumps(manifest))
+    out = tmp_path / "bundle.tar.gz"
+    with tarfile.open(out, "w:gz") as tf:
+        for name in roots:
+            tf.add(str(stage / name), arcname=name)
+    return out
+
+
+class TestAPartialRootWithoutAComponentMapIsRefused:
+    def test_it_refuses_rather_than_restoring_everything(self, home, tmp_path, capsys):
+        bundle = _archive(tmp_path, {"kirocrew-partial-20260101T000000Z": None})
+        rc = snap.restore_main([str(bundle), "--mode", "replace", "--force"])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "marked partial but carries no component map" in out
+
+    def test_the_live_tree_is_untouched_by_that_refusal(self, home, tmp_path):
+        md = home / "workspace" / "memory"
+        (md / "preferences.md").write_text("live state")
+        bundle = _archive(tmp_path, {"kirocrew-partial-20260101T000000Z": None})
+        assert snap.restore_main([str(bundle), "--mode", "replace", "--force"]) == 1
+        assert (md / "preferences.md").read_text() == "live state"
+
+    def test_an_explicit_components_flag_still_lets_it_through(self, home, tmp_path):
+        """The refusal is about guessing, not about the bundle being unusable.
+
+        Replace is the destructive direction, so the hatch is shown here on a live home
+        with nothing to lose: the bundle omits `workspace/knowledge` and so does live
+        state, and a tree neither side has cannot be cleared out from under anyone. The
+        case where live DOES hold a tree the bundle omits is refused, and merge -- which
+        clears nothing -- accepts it either way; both are pinned in cycle12.
+        """
+        md = home / "workspace" / "memory"
+        (md / "preferences.md").write_text("live state")
+        shutil.rmtree(home / "workspace" / "knowledge", ignore_errors=True)
+        bundle = _archive(tmp_path, {"kirocrew-partial-20260101T000000Z": None})
+        rc = snap.restore_main(
+            [
+                str(bundle),
+                "--mode",
+                "replace",
+                "--force",
+                "--components",
+                "memory",
+                *unpinnable_argv(),
+            ]
+        )
+        assert rc == 0
+        assert (md / "preferences.md").read_text() == "from the bundle"
+
+
+def _archive_without_memory(tmp_path, name: str) -> "object":
+    """A partial root with no component map that carries only `crons.json`."""
+    stage = tmp_path / "stage-nomem"
+    stage.mkdir(exist_ok=True)
+    root = stage / name
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "crons.json").write_text(json.dumps({"jobs": []}))
+    out = tmp_path / "bundle-nomem.tar.gz"
+    with tarfile.open(out, "w:gz") as tf:
+        tf.add(str(root), arcname=name)
+    return out
+
+
+class TestANamedComponentTheBundleDoesNotCarryIsRefused:
+    """The escape hatch is honoured by checking the archive, not by trusting the list.
+
+    Naming a component is an assertion, not evidence. Replace mode moves each live
+    core file aside before it knows whether the archive has a replacement, and clears
+    a component tree whether or not the archive carries one -- so without this check
+    the operator loses the component and is told the restore succeeded.
+    """
+
+    def test_it_refuses_instead_of_reporting_success(self, home, tmp_path, capsys):
+        bundle = _archive_without_memory(tmp_path, "kirocrew-partial-20260101T000000Z")
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "does not contain: memory" in out
+        assert "carries no component map" in out
+
+    def test_the_live_databases_and_trees_survive(self, home, tmp_path):
+        (home / "workspace" / "memory" / "preferences.md").write_text("live state")
+        bundle = _archive_without_memory(tmp_path, "kirocrew-partial-20260101T000000Z")
+        assert (
+            snap.restore_main(
+                [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+            )
+            == 1
+        )
+        assert (home / "memory.db").is_file()
+        assert (home / "workspace" / "memory" / "preferences.md").read_text() == "live state"
+        assert (home / "workspace" / "knowledge").is_dir()
+
+    def test_nothing_is_moved_into_a_rollback_directory(self, home, tmp_path):
+        bundle = _archive_without_memory(tmp_path, "kirocrew-partial-20260101T000000Z")
+        snap.restore_main([str(bundle), "--mode", "replace", "--force", "--components", "memory"])
+        assert list(home.glob("pre-restore-*")) == []
+
+    def test_the_refusal_is_audited_with_its_own_reason(self, home, tmp_path, monkeypatch):
+        """A refusal that leaves no security event is one nobody can review later.
+
+        The reason is asserted, not just the presence of an event: every rejection on
+        this path audits, so a shared or wrong reason makes them indistinguishable.
+        """
+        events: list[tuple[str, str]] = []
+        monkeypatch.setattr(snap, "_audit", lambda et, res: events.append((et, res)))
+        bundle = _archive_without_memory(tmp_path, "kirocrew-partial-20260101T000000Z")
+        snap.restore_main([str(bundle), "--mode", "replace", "--force", "--components", "memory"])
+        assert any(
+            et == "state_restore_rejected" and "reason=named_component_absent" in res
+            for et, res in events
+        ), events
+
+    def test_a_component_present_only_as_a_file_counts_as_carried(self, home, tmp_path):
+        """Presence is ANY declared path, not all of them.
+
+        `crons` declares one file and no trees, so the bundle above carries it. A
+        rule demanding every declared path would refuse a sound bundle -- a home
+        that never wrote `memory_index.db` ships memory with only `memory.db`.
+        """
+        bundle = _archive_without_memory(tmp_path, "kirocrew-partial-20260101T000000Z")
+        rc = snap.restore_main(
+            [
+                str(bundle),
+                "--mode",
+                "replace",
+                "--force",
+                "--components",
+                "crons",
+                *unpinnable_argv(),
+            ]
+        )
+        assert rc == 0
+
+    def test_a_component_present_only_as_a_tree_counts_as_carried(self, home, tmp_path):
+        """`_archive` writes workspace/memory but neither memory database."""
+        bundle = _archive(tmp_path, {"kirocrew-partial-20260101T000000Z": None})
+        assert (
+            snap._components_absent_from_bundle(_extract_root(bundle, tmp_path), ["memory"]) == []
+        )
+
+    def test_a_declared_map_still_decides_when_there_is_one(self, home, tmp_path):
+        """This check is the fallback for a missing map, and must not shadow it.
+
+        The manifest is authoritative when present: a bundle whose map omits a
+        component is refused on the map even though the archive happens to hold the
+        files, because the map is what the bundle says it carries.
+        """
+        bundle = _archive(
+            tmp_path,
+            {
+                "kirocrew-partial-20260101T000000Z": {
+                    "version": 3,
+                    "components": {"crons": "unresolved"},
+                }
+            },
+        )
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+        assert rc == 1
+
+
+def _extract_root(bundle, tmp_path):
+    """Return the bundle's single root directory, extracted."""
+    dest = tmp_path / "extracted"
+    dest.mkdir(exist_ok=True)
+    with tarfile.open(bundle) as tf:
+        tf.extractall(dest, filter=snap._data_filter)  # nosec B202
+    return next(d for d in dest.iterdir() if d.is_dir())
+
+    def test_a_partial_root_WITH_a_map_is_accepted(self, home, tmp_path):
+        bundle = _archive(
+            tmp_path,
+            {
+                "kirocrew-partial-20260101T000000Z": {
+                    "version": 3,
+                    "components": {"memory": "UNRESOLVED"},
+                }
+            },
+        )
+        md = home / "workspace" / "memory"
+        (md / "preferences.md").write_text("live state")
+        assert snap.restore_main([str(bundle), "--mode", "replace", "--force"]) == 0
+        assert (md / "preferences.md").read_text() == "from the bundle"
+
+    def test_a_complete_root_without_a_map_is_still_accepted(self, home, tmp_path):
+        """Pre-v3 complete archives legitimately have no map, and for them
+        all-components is the correct reading."""
+        bundle = _archive(tmp_path, {"kirocrew-snapshot-20260101T000000Z": None})
+        assert snap.restore_main([str(bundle), "--mode", "replace", "--force"]) == 0
+
+
+class TestTwoRootsAreRefusedRatherThanGuessed:
+    def test_more_than_one_root_refuses(self, home, tmp_path, capsys):
+        bundle = _archive(
+            tmp_path,
+            {
+                "kirocrew-snapshot-20260101T000000Z": {"version": 3, "components": {}},
+                "kirocrew-partial-20260101T000001Z": {"version": 3, "components": {}},
+            },
+        )
+        rc = snap.restore_main([str(bundle), "--mode", "replace", "--force"])
+        assert rc == 1
+        assert "more than one snapshot root" in capsys.readouterr().out
+
+    def test_the_refusal_names_both_roots(self, home, tmp_path, capsys):
+        bundle = _archive(
+            tmp_path,
+            {
+                "kirocrew-snapshot-20260101T000000Z": {"version": 3, "components": {}},
+                "kirocrew-partial-20260101T000001Z": {"version": 3, "components": {}},
+            },
+        )
+        snap.restore_main([str(bundle), "--mode", "replace", "--force"])
+        out = capsys.readouterr().out
+        assert "kirocrew-snapshot-20260101T000000Z" in out
+        assert "kirocrew-partial-20260101T000001Z" in out
+
+
+class TestTextIOPinsUtf8:
+    """JSON is UTF-8 by specification. A `read_text()` with no encoding decodes with
+    the platform's locale codepage, so on a Windows host a control file holding any
+    non-ASCII byte is refused as unreadable instead of honoured. This is not
+    hypothetical: the encoding-less form shipped here and reddened two Windows shards.
+    Asserted on the source so the check runs on every platform, not only the one that
+    would fail.
+    """
+
+    def test_no_text_io_in_the_backup_path_omits_an_encoding(self):
+        """Checked with the AST, not a regex: the call can span lines and its
+        arguments can contain nested calls with their own parentheses, both of
+        which defeat line-oriented matching. A regex version of this test let a
+        `write_text(payload)` mutant survive.
+
+        Scans the modules the off-host path is actually made of now: the snapshot
+        format, the redaction pass that rewrites what leaves (which reads the
+        opt-in switch as JSON, the exact shape this defect hit), and the app module
+        that performs the push.
+        """
+        import ast
+        import pathlib
+
+        import kiro_crew.snapshot as sn
+        import kiro_crew.snapshot_redact as sr
+        from kiro_crew.apps.builtins.aws_control.backend import backup as app_backup
+
+        offenders = []
+        for mod in (sn, sr, app_backup):
+            path = pathlib.Path(mod.__file__)
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                if not isinstance(fn, ast.Attribute):
+                    continue
+                if fn.attr not in ("read_text", "write_text"):
+                    continue
+                if any(kw.arg == "encoding" for kw in node.keywords):
+                    continue
+                offenders.append(f"{path.name}:{node.lineno} .{fn.attr}()")
+
+        assert not offenders, (
+            "text I/O without an explicit encoding: "
+            + ", ".join(offenders)
+            + ". Pin encoding='utf-8' — the default is the platform locale codepage, "
+            "so these break on a Windows host for any non-ASCII content."
+        )

--- a/test/test_snapshot_cycle3_fixes.py
+++ b/test/test_snapshot_cycle3_fixes.py
@@ -1,0 +1,208 @@
+"""Tests for the cycle-3 review findings.
+
+The surviving cases are restore-side partial-state defects: a tree the archive lacks
+was left behind, and a rollback directory was merged with another restore's.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tarfile
+from datetime import datetime, timezone
+
+from test_snapshot import _setup_fake_kirocrew, unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+def _peek(bundle, tmp_path):
+    """Unpack a bundle so a test can assert on what it actually contains."""
+    dest = tmp_path / "peek"
+    if not dest.is_dir():
+        dest.mkdir()
+        with tarfile.open(bundle) as tf:
+            tf.extractall(dest)
+    return next(p for p in dest.iterdir() if p.is_dir())
+
+
+def _home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(home))
+    _setup_fake_kirocrew(home)
+    return home
+
+
+class TestReplaceDoesNotKeepATreeTheArchiveLacks:
+    """A bundle without `workspace/knowledge` used to leave the destination's own
+    knowledge tree in place, so a "replace" produced restored memory mixed with stale
+    notes — and reported success. Replace means the destination matches the archive."""
+
+    def test_a_tree_absent_from_the_bundle_is_removed(self, tmp_path, monkeypatch):
+        home = _home(tmp_path, monkeypatch)
+        md = home / "workspace" / "memory"
+        md.mkdir(parents=True, exist_ok=True)
+        (md / "preferences.md").write_text("original")
+        # The fixture ships a knowledge tree; remove it so the bundle genuinely
+        # cannot carry one. Without this the case under test does not exist.
+        shutil.rmtree(home / "workspace" / "knowledge")
+        out = tmp_path / "out"
+        assert snap.snapshot_main([str(out), "--components", "memory", *unpinnable_argv()]) == 0
+        bundle = next(out.glob("kirocrew-snapshot-*.tar.gz"))
+        assert not (
+            _peek(bundle, tmp_path) / "workspace" / "knowledge"
+        ).exists(), "the bundle carries a knowledge tree, so this test proves nothing"
+
+        # The destination has since grown one.
+        kd = home / "workspace" / "knowledge"
+        kd.mkdir(parents=True, exist_ok=True)
+        (kd / "stale.md").write_text("not in the bundle")
+
+        assert (
+            snap.restore_main(
+                [
+                    str(bundle),
+                    "--mode",
+                    "replace",
+                    "--force",
+                    "--components",
+                    "memory",
+                    *unpinnable_argv(),
+                ]
+            )
+            == 0
+        )
+        assert not (
+            kd / "stale.md"
+        ).exists(), "a tree the bundle does not carry survived a replace restore"
+        assert (md / "preferences.md").read_text() == "original"
+
+    def test_the_removed_tree_is_still_in_the_rollback_copy(self, tmp_path, monkeypatch):
+        """Clearing is only defensible because the state is recoverable."""
+        home = _home(tmp_path, monkeypatch)
+        md = home / "workspace" / "memory"
+        md.mkdir(parents=True, exist_ok=True)
+        (md / "preferences.md").write_text("original")
+        shutil.rmtree(home / "workspace" / "knowledge")
+        out = tmp_path / "out"
+        assert snap.snapshot_main([str(out), "--components", "memory", *unpinnable_argv()]) == 0
+        bundle = next(out.glob("kirocrew-snapshot-*.tar.gz"))
+
+        kd = home / "workspace" / "knowledge"
+        kd.mkdir(parents=True, exist_ok=True)
+        (kd / "stale.md").write_text("not in the bundle")
+
+        assert (
+            snap.restore_main(
+                [
+                    str(bundle),
+                    "--mode",
+                    "replace",
+                    "--force",
+                    "--components",
+                    "memory",
+                    *unpinnable_argv(),
+                ]
+            )
+            == 0
+        )
+        saved = list(home.glob("pre-restore-*/workspace/knowledge/stale.md"))
+        assert saved and saved[0].read_text() == "not in the bundle"
+
+    def test_a_bundle_that_has_the_tree_still_replaces_it(self, tmp_path, monkeypatch):
+        home = _home(tmp_path, monkeypatch)
+        md = home / "workspace" / "memory"
+        md.mkdir(parents=True, exist_ok=True)
+        (md / "preferences.md").write_text("original")
+        kd = home / "workspace" / "knowledge"
+        kd.mkdir(parents=True, exist_ok=True)
+        (kd / "note.md").write_text("from the bundle")
+        out = tmp_path / "out"
+        assert snap.snapshot_main([str(out), "--components", "memory", *unpinnable_argv()]) == 0
+        bundle = next(out.glob("kirocrew-snapshot-*.tar.gz"))
+
+        (kd / "note.md").write_text("changed since the backup")
+        assert (
+            snap.restore_main(
+                [
+                    str(bundle),
+                    "--mode",
+                    "replace",
+                    "--force",
+                    "--components",
+                    "memory",
+                    *unpinnable_argv(),
+                ]
+            )
+            == 0
+        )
+        assert (kd / "note.md").read_text() == "from the bundle"
+
+
+class TestTwoRestoresInOneSecondKeepSeparateRollbackSets:
+    """The rollback directory name is second-granular, so two restores inside one second
+    resolve to the same name. One directory holding two pre-restore states would roll back
+    to neither, so each restore gets its own — allocated, not merged, and not crashed."""
+
+    def test_the_second_restore_gets_its_own_rollback_set(self, tmp_path, monkeypatch):
+        home = _home(tmp_path, monkeypatch)
+        md = home / "workspace" / "memory"
+        md.mkdir(parents=True, exist_ok=True)
+        (md / "preferences.md").write_text("original")
+        out = tmp_path / "out"
+        assert snap.snapshot_main([str(out), "--components", "memory", *unpinnable_argv()]) == 0
+        bundle = next(out.glob("kirocrew-snapshot-*.tar.gz"))
+
+        frozen = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        class _Frozen:
+            @staticmethod
+            def now(tz=None):
+                return frozen
+
+        monkeypatch.setattr(snap, "datetime", _Frozen)
+
+        (md / "preferences.md").write_text("live state A")
+        assert (
+            snap.restore_main(
+                [
+                    str(bundle),
+                    "--mode",
+                    "replace",
+                    "--force",
+                    "--components",
+                    "memory",
+                    *unpinnable_argv(),
+                ]
+            )
+            == 0
+        )
+        assert (md / "preferences.md").read_text() == "original"
+
+        # Second restore in the SAME frozen second. Earlier this raised an uncaught
+        # FileExistsError; a collision has to be resolved, not thrown, because a crash is
+        # not the clean abort it was described as.
+        (md / "preferences.md").write_text("live state B")
+        assert (
+            snap.restore_main(
+                [
+                    str(bundle),
+                    "--mode",
+                    "replace",
+                    "--force",
+                    "--components",
+                    "memory",
+                    *unpinnable_argv(),
+                ]
+            )
+            == 0
+        )
+
+        saved = sorted(p.name for p in home.glob("pre-restore-*"))
+        assert len(saved) == 2, f"each restore needs its own rollback set: {saved}"
+        # And neither set holds the other's state: A was saved by the first restore, B by
+        # the second, so the two directories differ in content.
+        contents = {
+            (home / name / "workspace" / "memory" / "preferences.md").read_text() for name in saved
+        }
+        assert contents == {"live state A", "live state B"}, contents

--- a/test/test_snapshot_cycle4_fixes.py
+++ b/test/test_snapshot_cycle4_fixes.py
@@ -1,0 +1,93 @@
+"""Tests for the cycle-4 review findings.
+
+Two independent defects that still live in the product: terminal escape sequences
+reaching stdout from an untrusted manifest, and an explicit component list naming
+nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import tarfile
+
+import pytest
+from test_snapshot import _setup_fake_kirocrew, unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    d = tmp_path / "home"
+    d.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(d))
+    _setup_fake_kirocrew(d)
+    return d
+
+
+class TestManifestOutputCannotDriveTheTerminal:
+    def test_escape_sequences_in_manifest_fields_are_neutralised(self, tmp_path, capsys):
+        snapdir = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        snapdir.mkdir()
+        hostile = "\x1b[2J\x1b[Hrestored OK"
+        (snapdir / "MANIFEST.json").write_text(
+            json.dumps(
+                {
+                    "created_at": hostile,
+                    "user": hostile,
+                    "hostname": hostile,
+                    "purpose": hostile,
+                    "components": {hostile: hostile},
+                }
+            ),
+            encoding="utf-8",
+        )
+        snap._print_manifest(snapdir)
+        out = capsys.readouterr().out
+        assert "\x1b" not in out, "an escape sequence from the manifest reached stdout"
+
+    def test_ordinary_fields_still_render(self, tmp_path, capsys):
+        snapdir = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        snapdir.mkdir()
+        (snapdir / "MANIFEST.json").write_text(
+            json.dumps({"created_at": "2026-01-01", "purpose": "backup"}),
+            encoding="utf-8",
+        )
+        snap._print_manifest(snapdir)
+        out = capsys.readouterr().out
+        assert "2026-01-01" in out and "backup" in out
+
+
+class TestAnExplicitButEmptyComponentListIsRefused:
+    def test_snapshot_refuses_and_writes_nothing(self, home, tmp_path, capsys):
+        out = tmp_path / "out"
+        rc = snap.snapshot_main([str(out), "--components", ","])
+        assert rc == 1
+        assert "names no components" in capsys.readouterr().out
+        assert not list(out.glob("*.tar.gz")) if out.exists() else True
+
+    def test_snapshot_refusal_precedes_any_pruning(self, home, tmp_path):
+        """The damage was retention counting an empty bundle as the newest backup."""
+        out = tmp_path / "out"
+        out.mkdir()
+        existing = out / "kirocrew-snapshot-20260101T000000Z.tar.gz"
+        with tarfile.open(existing, "w:gz") as tf:
+            payload = tmp_path / "p"
+            payload.mkdir()
+            tf.add(str(payload), arcname="kirocrew-snapshot-20260101T000000Z")
+        assert snap.snapshot_main([str(out), "--components", ",", "--keep", "1"]) == 1
+        assert existing.is_file(), "a refused run must not prune a real backup"
+
+    def test_restore_refuses_rather_than_reporting_a_no_op(self, home, tmp_path, capsys):
+        bundle = tmp_path / "b.tar.gz"
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        payload.mkdir()
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+        rc = snap.restore_main([str(bundle), "--components", " , ", "--force"])
+        assert rc == 1
+        assert "names no components" in capsys.readouterr().out
+
+    def test_a_real_selection_still_works(self, home, tmp_path):
+        out = tmp_path / "out"
+        assert snap.snapshot_main([str(out), "--components", "memory", *unpinnable_argv()]) == 0

--- a/test/test_snapshot_cycle5_fixes.py
+++ b/test/test_snapshot_cycle5_fixes.py
@@ -1,0 +1,221 @@
+"""Tests for the cycle-5 review findings.
+
+What survives here is restore-side behaviour the off-host removal did not touch: rollback
+recovery clearing a linked live root as a link, the merge refusing to write outside the
+data home, and the archive probe admitting a good bundle.
+"""
+
+from __future__ import annotations
+
+import os
+import tarfile
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+class TestAContainedLinkRootDoesNotHalfRestore:
+    """A live tree root can pass containment and still be a LINK.
+
+    A symlink pointing somewhere else *inside* the data home resolves within it, so the
+    containment predicate allows it -- and `shutil.rmtree` then refuses a symlink with
+    OSError. In the current design a link root reached by REPLACE/MERGE is refused up
+    front by `_refuse_unsafe_destination_roots` (pinned in cycle9), so the one place that
+    still clears a possibly-linked live root is rollback recovery
+    (`_restore_everything_from_rollback`): it removes the live target before refilling it
+    from the saved copy. If that clearing followed the link -- or rmtree'd it and raised --
+    the recovery would strand itself (worst outcome) and delete data outside the home.
+    The old standalone `_clear_tree_root` helper is gone; its link-as-link property lives
+    here, so these tests drive recovery directly.
+    """
+
+    def test_recovery_removes_a_linked_live_root_as_a_link(self, tmp_path):
+        """The saved copy is put back, and the link target OUTSIDE the home is untouched."""
+        backup = tmp_path / "rollback"
+        (backup / "skills").mkdir(parents=True)
+        (backup / "skills" / "saved.md").write_text("saved")
+        home = tmp_path / "home"
+        home.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "keep.md").write_text("must survive")
+        link = home / "skills"
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("cannot create a directory symlink on this platform")
+
+        failed = snap._restore_everything_from_rollback(
+            backup, home, ["skills"], {"skills"}, allow_unpinned=bool(unpinnable_argv())
+        )
+
+        assert failed == [], f"recovery could not clear the linked root: {failed}"
+        assert not link.is_symlink(), "the link survived instead of being removed as a link"
+        assert (outside / "keep.md").is_file(), "clearing the link deleted the target"
+        assert (home / "skills" / "saved.md").read_text() == "saved", "saved copy not put back"
+
+    def test_recovery_still_removes_a_real_directory_root(self, tmp_path):
+        """A real live directory is cleared before the saved copy replaces it."""
+        backup = tmp_path / "rollback"
+        (backup / "skills").mkdir(parents=True)
+        (backup / "skills" / "saved.md").write_text("saved")
+        home = tmp_path / "home"
+        (home / "skills" / "sub").mkdir(parents=True)
+        (home / "skills" / "sub" / "stale.md").write_text("stale")
+
+        failed = snap._restore_everything_from_rollback(
+            backup, home, ["skills"], {"skills"}, allow_unpinned=bool(unpinnable_argv())
+        )
+
+        assert failed == [], failed
+        assert not (home / "skills" / "sub" / "stale.md").exists(), "the stale live tree survived"
+        assert (home / "skills" / "saved.md").read_text() == "saved"
+
+    def test_recovery_does_not_raise_when_the_live_root_is_missing(self, tmp_path):
+        """No pre-existing live tree, but a saved copy -- recovery creates it, no crash."""
+        backup = tmp_path / "rollback"
+        (backup / "skills").mkdir(parents=True)
+        (backup / "skills" / "saved.md").write_text("saved")
+        home = tmp_path / "home"
+        home.mkdir()  # no `skills` under it
+
+        failed = snap._restore_everything_from_rollback(
+            backup, home, ["skills"], {"skills"}, allow_unpinned=bool(unpinnable_argv())
+        )
+
+        assert failed == [], failed
+        assert (home / "skills" / "saved.md").read_text() == "saved"
+
+    def test_recovery_clears_a_linked_root_as_a_link_before_rmtree(self):
+        """Structural: the naive `if target.is_dir(): shutil.rmtree(target)` is wrong for a
+        link, because `is_dir()` follows it and rmtree then raises on the symlink. Every site
+        in recovery that clears a possibly-linked live target must therefore remove a link AS
+        a link before it can reach an rmtree.
+
+        Checked PER SITE rather than by first-occurrence order. Recovery has more than one
+        clearing site now (a saved link is reinstated ahead of the dereferencing branches),
+        and an ordering assertion over the whole function cannot express "each one is
+        guarded" -- worse, it was blind in the direction that matters: a SECOND, unguarded
+        rmtree added later still satisfied it, because only the FIRST occurrence of each
+        string was ever looked at.
+        """
+        import inspect
+
+        recovery = inspect.getsource(snap._restore_everything_from_rollback)
+        raw = recovery.splitlines()
+        sites = [i for i, ln in enumerate(raw) if ln.strip() == "shutil.rmtree(str(target))"]
+        assert sites, "recovery no longer clears a live directory target at all"
+
+        def _indent(line: str) -> int:
+            return len(line) - len(line.lstrip())
+
+        for i in sites:
+            # The gate is the nearest ENCLOSING `if`/`elif` -- the closest preceding line at
+            # STRICTLY SMALLER indentation that opens one -- not `raw[i - 1]`. A one-line
+            # window was the original locator and it is the same fragility this test warns
+            # about further down: it reads whatever statement happens to sit directly above,
+            # so inserting any statement between the guard and the rmtree (a nested refusal
+            # that `continue`s, say) made the assertion report the site as ungated when the
+            # rmtree was still inside the guard's own block. Indentation answers "what
+            # actually controls this line", which is the claim.
+            site_indent = _indent(raw[i])
+            gate = ""
+            for j in range(i - 1, -1, -1):
+                if not raw[j].strip():
+                    continue
+                if _indent(raw[j]) < site_indent and raw[j].strip().startswith(("if ", "elif ")):
+                    gate = raw[j]
+                    break
+            assert gate, f"the rmtree at line {i} is not inside any if/elif at all"
+            assert "target.is_dir()" in gate, (
+                f"an rmtree of the live target at line {i} is not gated on the target being "
+                f"a directory at all -- found {gate.strip()!r}"
+            )
+            if "is_link_or_junction(target)" in gate:
+                continue  # self-guarded: `is_dir() and not is_link_or_junction(...)`
+            # Otherwise this must be an `elif` whose CHAIN HEAD excludes a link. The head is
+            # the nearest preceding line at the SAME indentation opening with `if` -- found
+            # by indentation rather than by a fixed line window, because a window lets an
+            # unrelated link check a few lines up vouch for an unguarded site, which is how
+            # this assertion first passed against a deliberately broken version.
+            assert gate.strip().startswith("elif "), (
+                f"the rmtree at line {i} is gated by {gate.strip()!r}, which neither excludes "
+                "a link itself nor continues a chain that does"
+            )
+            depth = _indent(gate)
+            head = None
+            for j in range(i - 2, -1, -1):
+                if not raw[j].strip():
+                    continue
+                if _indent(raw[j]) < depth:
+                    break  # left the block without finding the chain head
+                if _indent(raw[j]) == depth and raw[j].strip().startswith("if "):
+                    head = raw[j]
+                    break
+            assert head is not None and "is_link_or_junction(target)" in head, (
+                f"the rmtree at line {i} can be reached for a LINK: its chain head is "
+                f"{(head.strip() if head else None)!r}, which does not test for one, so "
+                "rmtree would raise on the symlink and strand the whole recovery"
+            )
+
+
+class TestTheMergeCannotWriteOutsideTheDataHome:
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="_copy_tree_no_overwrite refuses without dir_fd; the not-following of a "
+        "nested destination link is a guarantee of the descriptor-pinned merge walk, "
+        "which does not exist on a platform lacking os.supports_dir_fd",
+    )
+    def test_a_nested_destination_link_is_not_followed(self, tmp_path):
+        """safe_tree_root validates the destination ROOT, but the merge walks below it
+        and the write target is the dangerous end: a nested link under the destination
+        would deposit restored files wherever it aimed."""
+        home = tmp_path / "home"
+        (home / "workspace" / "memory").mkdir(parents=True)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        dest = home / "workspace" / "memory"
+        try:
+            (dest / "history").symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("cannot create a directory symlink on this platform")
+
+        src = tmp_path / "snap" / "workspace" / "memory"
+        (src / "history").mkdir(parents=True)
+        (src / "history" / "leak.md").write_text("must not escape")
+        (src / "keep.md").write_text("fine")
+
+        snap._copy_tree_no_overwrite(src, dest)
+
+        assert (dest / "keep.md").is_file(), "the legitimate file should still merge"
+        assert not (outside / "leak.md").exists(), "the merge wrote outside the data home"
+
+    def test_a_fresh_temporary_tree_still_merges(self, tmp_path):
+        """No planted link, so nothing to refuse: the ordinary merge path still copies.
+
+        (Was `test_without_a_home_the_check_is_skipped`: the old `home` parameter is gone
+        -- containment is now enforced unconditionally inside the descriptor-pinned
+        primitive rather than gated on a home argument -- so this only pins that a clean
+        merge keeps working.)
+        """
+        src = tmp_path / "s"
+        src.mkdir()
+        (src / "f.md").write_text("x")
+        dst = tmp_path / "d"
+        dst.mkdir()
+        snap._copy_tree_no_overwrite(src, dst, allow_unpinned=bool(unpinnable_argv()))
+        assert (dst / "f.md").is_file()
+
+
+class TestTheArchiveProbeAcceptsAGoodBundle:
+    def test_a_valid_archive_passes_the_probe(self, tmp_path):
+        """The guard must not reject bundles it is meant to admit."""
+        good = tmp_path / "good.tar.gz"
+        payload = tmp_path / "f.txt"
+        payload.write_text("hi")
+        with tarfile.open(good, "w:gz") as tf:
+            tf.add(payload, arcname="f.txt")
+        with tarfile.open(good) as tf:
+            assert [m.name for m in tf.getmembers()] == ["f.txt"]

--- a/test/test_snapshot_cycle5c_fixes.py
+++ b/test/test_snapshot_cycle5c_fixes.py
@@ -1,0 +1,540 @@
+"""Tests for the cycle-5 review findings.
+
+Two defects that shared one shape: a failure was absorbed into a success. A failed
+database copy warned and continued, and a failed tree copy left the tree deleted and
+exited zero.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tarfile
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+from test_snapshot import _setup_fake_kirocrew, unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    d = tmp_path / "home"
+    d.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(d))
+    _setup_fake_kirocrew(d)
+    return d
+
+
+def _sound_db_bytes(path):
+    """A real SQLite database, since replace mode now refuses an unsound incoming one.
+
+    These tests exercise rollback, not validation, so the bundle they feed in has to get
+    past the pre-flight to reach the code under test.
+    """
+    with sqlite3.connect(str(path)) as c:
+        c.execute("CREATE TABLE t (v TEXT)")
+        c.execute("INSERT INTO t VALUES ('incoming')")
+    return path.read_bytes()
+
+
+class TestAFailedDatabaseCopyIsNotSilentlyDowngraded:
+    def _db(self, path):
+        with sqlite3.connect(str(path)) as c:
+            c.execute("CREATE TABLE t (v TEXT)")
+            c.execute("INSERT INTO t VALUES ('real')")
+        return path
+
+    def _staged_pair(self, tmp_path):
+        """Mirror production: the tree copy already placed a byte copy at dst, so dst is
+        itself a valid database before _restage_databases replaces it."""
+        import shutil
+
+        src, dst = tmp_path / "s", tmp_path / "d"
+        src.mkdir()
+        dst.mkdir()
+        self._db(src / "memory.db")
+        shutil.copy2(src / "memory.db", dst / "memory.db")
+        return src, dst
+
+    def test_a_non_database_file_keeps_the_plain_copy(self, tmp_path, capsys):
+        src, dst = tmp_path / "s", tmp_path / "d"
+        src.mkdir()
+        dst.mkdir()
+        (src / "notes.db").write_text("this is not a database", encoding="utf-8")
+        (dst / "notes.db").write_text("this is not a database", encoding="utf-8")
+        snap._restage_databases(src, dst)
+        assert "not a readable SQLite database" in capsys.readouterr().out
+        assert (dst / "notes.db").read_text(encoding="utf-8") == "this is not a database"
+
+    def test_a_real_database_is_copied_consistently(self, tmp_path):
+        src, dst = self._staged_pair(tmp_path)
+        snap._restage_databases(src, dst)
+        with closing(sqlite3.connect(str(dst / "memory.db"))) as c:
+            assert c.execute("SELECT v FROM t").fetchone()[0] == "real"
+
+    def _break_backup(self, monkeypatch, message):
+        """`sqlite3.Connection` is immutable, so the failure is injected at the
+        `connect` seam the module actually calls.
+
+        The exception class comes from ``snap.sqlite3``, NOT this file's ``import
+        sqlite3``: the package binds a different DB-API implementation, so an error
+        built from the stdlib module is not caught by production's ``except
+        sqlite3.Error`` at all. A first version of these tests did exactly that and
+        passed against a mutant that swallowed the failure -- the error escaped for the
+        wrong reason.
+        """
+        prod = snap.sqlite3
+        real_connect = prod.connect
+        exc = prod.OperationalError(message)
+
+        class _NoBackup:
+            def __init__(self, conn):
+                self._conn = conn
+
+            def __getattr__(self, name):
+                return getattr(self._conn, name)
+
+            def backup(self, *a, **kw):
+                raise exc
+
+        monkeypatch.setattr(prod, "connect", lambda *a, **kw: _NoBackup(real_connect(*a, **kw)))
+
+    def test_a_failed_backup_on_a_real_database_propagates(self, tmp_path, monkeypatch):
+        """The dangerous case: readable database, failing copy. The staged file is a raw
+        byte copy without its WAL sidecars, so success here would ship a torn database.
+        """
+        src, dst = self._staged_pair(tmp_path)
+        self._break_backup(monkeypatch, "database is locked")
+        with pytest.raises(snap.DatabaseCopyFailed) as e:
+            snap._restage_databases(src, dst)
+        assert e.value.path.name == "memory.db", "the error must name the file"
+
+    def test_the_probe_does_not_mask_a_backup_failure_as_a_plain_file(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Guards the specific regression: catching every sqlite3.Error again."""
+        src, dst = self._staged_pair(tmp_path)
+        self._break_backup(monkeypatch, "disk I/O error")
+        with pytest.raises(snap.DatabaseCopyFailed):
+            snap._restage_databases(src, dst)
+        assert "not a readable SQLite database" not in capsys.readouterr().out
+
+    def test_the_command_reports_it_instead_of_crashing(self, home, tmp_path, monkeypatch, capsys):
+        """Propagating is right, but the operator must get a message and a nonzero exit,
+        not a traceback: `snapshot` is a command, and a traceback reads as a crash the
+        operator would retry rather than act on."""
+        db = home / "workspace" / "knowledge" / "knowledge.db"
+        db.parent.mkdir(parents=True, exist_ok=True)
+        with closing(snap.sqlite3.connect(str(db))) as c:
+            c.execute("CREATE TABLE t (v TEXT)")
+        self._break_backup(monkeypatch, "database is locked")
+
+        rc = snap.snapshot_main(
+            [str(tmp_path / "out"), "--components", "memory", *unpinnable_argv()]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        # Core files are staged before trees, so memory.db is the one that fails first.
+        # Both paths raise the same typed error -- there were two `backup()` call sites
+        # and wrapping only the tree one left this path exiting on a traceback.
+        assert "memory.db" in out, "the failing database must be named"
+        assert "No bundle was written" in out
+        assert (
+            not list((tmp_path / "out").glob("*.tar.gz")) if (tmp_path / "out").exists() else True
+        )
+
+    def test_a_locked_database_raises_instead_of_being_called_a_plain_file(self, tmp_path, capsys):
+        """The dangerous misclassification: "database is locked" is a DatabaseError too,
+        so a broad probe reported a live, healthy database as "not a database" and
+        shipped the raw byte copy without its WAL.
+
+        Uses a real exclusive transaction rather than a stub, because the whole point is
+        which error SQLite actually raises.
+        """
+        src, dst = self._staged_pair(tmp_path)
+        holder = snap.sqlite3.connect(str(src / "memory.db"))
+        try:
+            holder.execute("BEGIN EXCLUSIVE")
+            holder.execute("INSERT INTO t VALUES ('held')")
+            with pytest.raises(snap.DatabaseCopyFailed) as e:
+                snap._restage_databases(src, dst)
+            assert e.value.path.name == "memory.db"
+            assert "not a readable SQLite database" not in capsys.readouterr().out
+        finally:
+            holder.close()
+
+    def test_a_genuine_non_database_is_still_identified_positively(self, tmp_path, capsys):
+        """The other direction: tightening must not turn a real non-database into a
+        hard failure."""
+        src, dst = tmp_path / "s", tmp_path / "d"
+        src.mkdir()
+        dst.mkdir()
+        (src / "notes.db").write_text("plainly not a database", encoding="utf-8")
+        (dst / "notes.db").write_text("plainly not a database", encoding="utf-8")
+        snap._restage_databases(src, dst)
+        assert "not a readable SQLite database" in capsys.readouterr().out
+
+    def test_both_database_copy_sites_raise_the_typed_error(self):
+        """Structural: core files and trees are separate `backup()` call sites, and only
+        one was wrapped at first -- the other exited on a traceback. The readability
+        PROBE is a third raiser: anything it cannot positively classify as
+        not-a-database must raise rather than fall through to the plain-file path."""
+        import inspect
+        import re
+
+        src = inspect.getsource(snap)
+        calls = len(re.findall(r"src_conn\.backup\(dst_conn\)", src))
+        wrapped = len(re.findall(r"raise DatabaseCopyFailed\(src, e\) from e", src))
+        assert calls >= 2, "expected both the core-file and tree copy sites"
+        assert wrapped >= calls, (
+            f"{calls} backup call sites but only {wrapped} raise the typed error; an "
+            "unwrapped site exits the command on a traceback"
+        )
+        # The probe must fail closed. `SQLITE_BUSY` (a locked database) is a
+        # DatabaseError too, so continuing on anything unclassified ships a raw copy
+        # without its WAL as if it were consistent.
+        probe_src = inspect.getsource(snap._restage_databases)
+        assert (
+            "SQLITE_NOTADB" in probe_src
+        ), "the probe must identify not-a-database positively, not by exception class"
+        assert probe_src.index("if not not_a_database:") < probe_src.index(
+            "is not a readable SQLite database"
+        ), "the raise must precede the plain-file fall-through"
+
+    def test_the_module_under_test_and_this_file_agree_on_the_driver(self):
+        """Pins the reason the tests above use snap.sqlite3: if the package ever binds
+        the stdlib module, these tests keep working, and if it binds another one they
+        still exercise the real except clause."""
+        assert hasattr(snap.sqlite3, "Error") and hasattr(snap.sqlite3, "OperationalError")
+        assert issubclass(snap.sqlite3.OperationalError, snap.sqlite3.Error)
+
+
+class TestAFailedTreeReplacementPutsTheTreeBack:
+    def test_the_whole_rollback_set_is_restored_not_just_the_failing_tree(
+        self, home, tmp_path, monkeypatch, capsys
+    ):
+        """The unit of atomicity is the restore, not one tree.
+
+        Recovering only the tree that failed leaves every EARLIER tree replaced and the
+        databases already swapped -- memory split across two restore generations, which
+        is the state a rollback exists to prevent. So the assertion is on the whole set:
+        the database content and the tree content both come back.
+        """
+        tree_root = home / "workspace"
+        marker = tree_root / "memory" / "keep.md"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("live content", encoding="utf-8")
+        live_db = home / "memory.db"
+        live_db.write_bytes(b"LIVE DATABASE")
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        (payload / "workspace" / "memory").mkdir(parents=True)
+        (payload / "workspace" / "memory" / "new.md").write_text("x", encoding="utf-8")
+        (payload / "memory.db").write_bytes(_sound_db_bytes(tmp_path / "in1_1.db"))
+        bundle = tmp_path / "b.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        real = snap._copytree_safe
+
+        def flaky(src, dst, **kw):
+            # Fail the incoming copy into the live root; the rollback save and the
+            # recovery copies must both go through.
+            if Path(dst) == tree_root and "kirocrew-snapshot-" in str(src):
+                raise OSError("No space left on device")
+            return real(src, dst, **kw)
+
+        monkeypatch.setattr(snap, "_copytree_safe", flaky)
+        rc = snap.restore_main([str(bundle), "--mode", "replace", "--force", *unpinnable_argv()])
+        assert rc == 1
+        out = capsys.readouterr().out
+
+        assert "Restoring the previous state" in out, out
+        assert marker.is_file(), "the live tree was not put back"
+        assert marker.read_text(encoding="utf-8") == "live content"
+        assert (
+            live_db.read_bytes() == b"LIVE DATABASE"
+        ), "the database stayed on the incoming generation while the tree rolled back"
+
+    def test_the_rollback_directory_is_kept_when_recovery_itself_fails(
+        self, home, tmp_path, monkeypatch, capsys
+    ):
+        """If recovery cannot put something back, it must name it and leave the saved
+        copy in place -- by that point the operator's own data is what is at stake."""
+        backup = home / "pre-restore-test"
+        (backup / "workspace").mkdir(parents=True)
+        (backup / "workspace" / "saved.md").write_text("saved", encoding="utf-8")
+
+        def refuse(src, dst, **kw):
+            raise OSError("Read-only file system")
+
+        # Recovery now restores with `_copytree_safe` (the save refuses a tree with a
+        # link, so the rollback set is links-free and needs no link-preserving copy), so
+        # that is where a failure has to be injected to reach this path.
+        monkeypatch.setattr(snap, "_copytree_safe", refuse)
+        snap._restore_everything_from_rollback(
+            backup, home, ["workspace"], {"workspace"}, allow_unpinned=bool(unpinnable_argv())
+        )
+        out = capsys.readouterr().out
+        assert "Could not undo these" in out, out
+        assert "workspace" in out
+        assert backup.is_dir(), "the rollback directory must survive a failed recovery"
+
+    def test_a_target_the_restore_created_is_removed_by_recovery(
+        self, home, tmp_path, monkeypatch, capsys
+    ):
+        """Restoring saved entries is not enough. A target that did NOT exist before the
+        restore has nothing saved for it, so the copy the restore created would survive
+        the rollback and leave the home carrying half of the incoming generation.
+
+        The mutation order is workspace then skills, so workspace is the creation and
+        skills is the step made to fail -- a creation must precede the failure for the
+        hazard to exist at all.
+        """
+        import shutil as _shutil
+
+        for name in ("workspace", "plan_memory"):
+            p = home / name
+            if p.exists():
+                _shutil.rmtree(p)
+        live_ws = home / "workspace"
+        assert not live_ws.exists(), "premise: no pre-restore workspace tree"
+        (home / "skills").mkdir(parents=True, exist_ok=True)
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        (payload / "workspace" / "memory").mkdir(parents=True)
+        (payload / "workspace" / "memory" / "new.md").write_text("y", encoding="utf-8")
+        (payload / "skills" / "incoming").mkdir(parents=True)
+        (payload / "skills" / "incoming" / "SKILL.md").write_text("x", encoding="utf-8")
+        bundle = tmp_path / "b.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        real = snap._copytree_safe
+
+        def flaky(src, dst, **kw):
+            if Path(dst) == home / "skills" and "kirocrew-snapshot-" in str(src):
+                raise OSError("No space left on device")
+            return real(src, dst, **kw)
+
+        monkeypatch.setattr(snap, "_copytree_safe", flaky)
+        rc = snap.restore_main(
+            [
+                str(bundle),
+                "--mode",
+                "replace",
+                "--force",
+                "--components",
+                "workspace,skills",
+                *unpinnable_argv(),
+            ]
+        )
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Restoring the previous state" in out, out
+        assert not live_ws.exists(), (
+            "recovery left behind a workspace tree the restore created; the home is now "
+            "on two generations at once"
+        )
+
+    def test_a_target_that_existed_is_restored_not_removed(self, home, capsys):
+        """The other direction: an entry WITH pre-restore state must come back, not be
+        deleted as if it were a creation."""
+        backup = home / "pre-restore-x"
+        (backup / "skills" / "mine").mkdir(parents=True)
+        (backup / "skills" / "mine" / "SKILL.md").write_text("saved", encoding="utf-8")
+        snap._restore_everything_from_rollback(
+            backup, home, ["skills"], {"skills"}, allow_unpinned=bool(unpinnable_argv())
+        )
+        assert (home / "skills" / "mine" / "SKILL.md").read_text(encoding="utf-8") == "saved"
+
+    def test_memory_only_recovery_does_not_clear_sibling_workspace_data(
+        self, home, tmp_path, monkeypatch, capsys
+    ):
+        """Granularity is the invariant. Memory's trees are NESTED under workspace, so
+        the rollback directory holds a partial `workspace/` containing only those
+        subtrees. Recovering at directory granularity clears the live `workspace` whole
+        and puts the partial copy back, deleting sibling data the restore never touched.
+        """
+        memory_tree = home / "workspace" / "memory"
+        memory_tree.mkdir(parents=True, exist_ok=True)
+        (memory_tree / "mine.md").write_text("memory content", encoding="utf-8")
+        sibling = home / "workspace" / "unrelated"
+        sibling.mkdir(parents=True, exist_ok=True)
+        (sibling / "notes.md").write_text("NOT PART OF MEMORY", encoding="utf-8")
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        (payload / "workspace" / "memory").mkdir(parents=True)
+        (payload / "workspace" / "memory" / "new.md").write_text("x", encoding="utf-8")
+        (payload / "memory.db").write_bytes(_sound_db_bytes(tmp_path / "in2.db"))
+        bundle = tmp_path / "b.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        real = snap._copytree_safe
+
+        def flaky(src, dst, **kw):
+            if Path(dst) == memory_tree and "kirocrew-snapshot-" in str(src):
+                raise OSError("No space left on device")
+            return real(src, dst, **kw)
+
+        monkeypatch.setattr(snap, "_copytree_safe", flaky)
+        rc = snap.restore_main(
+            [
+                str(bundle),
+                "--mode",
+                "replace",
+                "--force",
+                "--components",
+                "memory",
+                *unpinnable_argv(),
+            ]
+        )
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Restoring the previous state" in out, out
+        assert (sibling / "notes.md").is_file(), (
+            "recovery deleted unrelated workspace data by treating backup/workspace as "
+            "a single target"
+        )
+        assert (sibling / "notes.md").read_text(encoding="utf-8") == "NOT PART OF MEMORY"
+        assert (memory_tree / "mine.md").read_text(encoding="utf-8") == "memory content"
+
+    def test_recovery_touches_only_declared_targets(self):
+        """Structural: recovery must iterate the target list, not the rollback tree."""
+        import inspect
+
+        src = inspect.getsource(snap._restore_everything_from_rollback)
+        assert "for rel in sorted(set(targets))" in src
+        assert "backup.iterdir()" not in src, (
+            "iterating the rollback directory reintroduces directory granularity, which "
+            "clears a live parent when only nested subtrees were saved"
+        )
+
+    def test_a_missing_rollback_directory_is_reported_not_crashed(self, home, capsys):
+        snap._restore_everything_from_rollback(
+            home / "nope", home, ["workspace"], set(), allow_unpinned=bool(unpinnable_argv())
+        )
+        assert "No rollback directory" in capsys.readouterr().out
+
+    def test_a_failed_rollback_SAVE_leaves_live_data_untouched(
+        self, home, tmp_path, monkeypatch, capsys
+    ):
+        """An INCOMPLETE rollback set is worse than none.
+
+        The tree saves used to happen inside the mutation phase, so a save that failed
+        partway raised into the recovery handler -- which then cleared the intact live
+        tree and put the PARTIAL copy back, destroying data nothing had touched. Saves
+        now complete before anything mutates, so a save failure aborts with the data
+        home unchanged and recovery never runs.
+        """
+        live = home / "workspace" / "memory"
+        live.mkdir(parents=True, exist_ok=True)
+        (live / "precious.md").write_text("must survive", encoding="utf-8")
+        live_db = home / "memory.db"
+        live_db.write_bytes(b"LIVE DATABASE")
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        (payload / "workspace" / "memory").mkdir(parents=True)
+        (payload / "workspace" / "memory" / "new.md").write_text("x", encoding="utf-8")
+        (payload / "memory.db").write_bytes(_sound_db_bytes(tmp_path / "in1_2.db"))
+        bundle = tmp_path / "b.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        real = snap._copytree_safe
+
+        def fail_the_save(src, dst, **kw):
+            # The SAVE direction: copying the live tree INTO the rollback directory. The
+            # save now routes through `_backup_tree_or_refuse` -> `_copytree_safe` (a tree
+            # with a link is refused, not preserved), so failing the save means failing
+            # the `_copytree_safe` call whose destination is under `pre-restore-`.
+            if "pre-restore-" in str(dst):
+                raise OSError("Input/output error")
+            return real(src, dst, **kw)
+
+        monkeypatch.setattr(snap, "_copytree_safe", fail_the_save)
+        rc = snap.restore_main([str(bundle), "--mode", "replace", "--force"])
+        assert rc == 1
+        out = capsys.readouterr().out
+
+        assert "Restoring the previous state" not in out, (
+            "recovery ran on an incomplete rollback set: " + out
+        )
+        assert (live / "precious.md").read_text(encoding="utf-8") == "must survive"
+        assert live_db.read_bytes() == b"LIVE DATABASE"
+
+    def test_the_skills_tree_is_also_rolled_back(self, home, tmp_path, monkeypatch, capsys):
+        """Each tree needs its own coverage: a mutant that deleted only the SKILLS
+        rollback save survived while workspace was covered."""
+        live_skill = home / "skills" / "mine" / "SKILL.md"
+        live_skill.parent.mkdir(parents=True, exist_ok=True)
+        live_skill.write_text("my skill", encoding="utf-8")
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        (payload / "skills" / "other").mkdir(parents=True)
+        (payload / "skills" / "other" / "SKILL.md").write_text("x", encoding="utf-8")
+        bundle = tmp_path / "sk.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        real = snap._copytree_safe
+
+        def flaky(src, dst, **kw):
+            # Fail only the incoming copy into the live skills tree.
+            if Path(dst) == home / "skills" and "kirocrew-snapshot-" in str(src):
+                raise OSError("No space left on device")
+            return real(src, dst, **kw)
+
+        monkeypatch.setattr(snap, "_copytree_safe", flaky)
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "skills"]
+        )
+        assert rc == 1
+        assert live_skill.is_file(), "the live skills tree was not put back"
+        assert live_skill.read_text(encoding="utf-8") == "my skill"
+
+    def test_every_tree_save_precedes_the_mutation_phase(self):
+        """Structural: a save left inside the mutation phase re-opens the data-loss
+        path, and the failure only shows on an unreadable file.
+
+        The save primitive is now `_backup_tree_or_refuse` (fatal skip reporter, so an
+        incomplete rollback set is refused rather than written); it must live in
+        `_do_replace`'s phase one and never in `_do_replace_mutations`.
+        """
+        import inspect
+
+        muts = inspect.getsource(snap._do_replace_mutations)
+        # No SAVE of a live tree into the rollback directory may happen in the mutation
+        # phase, by any copier.
+        for saving in ("backup / dirname)", 'backup / "skills")', "backup / tree)"):
+            for copier in ("_backup_tree_or_refuse", "_copytree_safe", "_copytree_rollback"):
+                assert f"{copier}(d, {saving}" not in muts
+                assert f"{copier}(sk, {saving}" not in muts
+        assert (
+            "dirs_exist_ok=True" not in muts
+        ), "a rollback save with dirs_exist_ok blends two pre-restore states"
+        setup = inspect.getsource(snap._do_replace)
+        assert setup.index("_backup_tree_or_refuse(d, backup / dirname") < setup.index(
+            "_do_replace_mutations("
+        ), "the workspace rollback save must complete before any mutation"
+
+    def test_a_successful_replace_is_unaffected(self, home, tmp_path):
+        live = home / "workspace" / "memory"
+        live.mkdir(parents=True, exist_ok=True)
+        (live / "old.md").write_text("old", encoding="utf-8")
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        (payload / "workspace" / "memory").mkdir(parents=True)
+        (payload / "workspace" / "memory" / "new.md").write_text("new", encoding="utf-8")
+        bundle = tmp_path / "ok.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        assert (
+            snap.restore_main([str(bundle), "--mode", "replace", "--force", *unpinnable_argv()])
+            == 0
+        )
+        assert (live / "new.md").read_text(encoding="utf-8") == "new"

--- a/test/test_snapshot_cycle5d_fixes.py
+++ b/test/test_snapshot_cycle5d_fixes.py
@@ -1,0 +1,318 @@
+"""A bundle's incoming databases are validated BEFORE any live state moves.
+
+Replace mode swaps the live database for the incoming one, so a check that runs after
+the swap can only report that the home is now sitting on a corrupt database. Bundles
+arriving from object storage are untrusted input, which is what makes the ordering load
+bearing rather than tidy.
+"""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+def _make_bundle(tmp_path: Path, memory_db: bytes, *, name: str = "memory.db") -> Path:
+    payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+    payload.mkdir(parents=True, exist_ok=True)
+    (payload / name).write_bytes(memory_db)
+    manifest = payload / "MANIFEST.json"
+    manifest.write_text('{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8")
+    bundle = tmp_path / "bundle.tar.gz"
+    with tarfile.open(bundle, "w:gz") as tf:
+        tf.add(str(payload), arcname=payload.name)
+    return bundle
+
+
+def _real_db(path: Path) -> bytes:
+    conn = snap.sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE t (a INTEGER)")
+    conn.execute("INSERT INTO t VALUES (1)")
+    conn.commit()
+    conn.close()
+    return path.read_bytes()
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setattr(snap, "_mc_dir", lambda: h)
+    monkeypatch.setattr(snap, "_is_gateway_running", lambda: False)
+    return h
+
+
+class TestAnUnsoundIncomingDatabaseIsRefusedBeforeMutation:
+    def test_an_unreadable_incoming_database_leaves_live_memory_untouched(
+        self, home, tmp_path, capsys
+    ):
+        live = home / "memory.db"
+        live.write_bytes(_real_db(tmp_path / "live.db"))
+        before = live.read_bytes()
+        bundle = _make_bundle(tmp_path, b"this is not a database at all")
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "cannot be opened as a database" in out, out
+        assert (
+            live.read_bytes() == before
+        ), "live memory was replaced before the incoming database was validated"
+
+    def test_a_corrupt_incoming_database_is_refused(self, home, tmp_path, capsys):
+        live = home / "memory.db"
+        live.write_bytes(_real_db(tmp_path / "live2.db"))
+        before = live.read_bytes()
+
+        good = _real_db(tmp_path / "src.db")
+        # Valid header, damaged pages: opens as a database, fails integrity_check.
+        corrupt = bytearray(good)
+        for off in range(100, min(len(corrupt), 3000)):
+            corrupt[off] = 0xFF
+        bundle = _make_bundle(tmp_path, bytes(corrupt))
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "integrity check failed" in out, out
+        assert live.read_bytes() == before
+
+    def test_a_sound_bundle_still_restores(self, home, tmp_path, capsys):
+        (home / "memory.db").write_bytes(_real_db(tmp_path / "old.db"))
+        incoming = _real_db(tmp_path / "new.db")
+        bundle = _make_bundle(tmp_path, incoming)
+
+        rc = snap.restore_main(
+            [
+                str(bundle),
+                "--mode",
+                "replace",
+                "--force",
+                "--components",
+                "memory",
+                *unpinnable_argv(),
+            ]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert (home / "memory.db").is_file()
+
+    def test_a_database_that_opens_but_fails_integrity_is_refused(self, home, tmp_path, capsys):
+        """The distinct branch: page-level damage behind an intact header.
+
+        SQLite opens this file happily, so nothing short of `PRAGMA integrity_check`
+        catches it. Asserting only "refused somehow" would pass on the unopenable path
+        and leave this branch untested.
+        """
+        live = home / "memory.db"
+        live.write_bytes(_real_db(tmp_path / "live2.db"))
+        before = live.read_bytes()
+
+        big = tmp_path / "big.db"
+        conn = snap.sqlite3.connect(str(big))
+        conn.execute("CREATE TABLE t (a INTEGER, b TEXT)")
+        conn.executemany("INSERT INTO t VALUES (?, ?)", [(i, "x" * 200) for i in range(400)])
+        conn.execute("CREATE INDEX idx_b ON t(b)")
+        conn.commit()
+        conn.close()
+        raw = bytearray(big.read_bytes())
+        assert len(raw) > 8192, "need several pages for page-level damage"
+        # Leave page 1 (header + schema) intact and zero page 2, which is measured to
+        # open cleanly and fail integrity_check with a btreeInitPage error.
+        for off in range(4096, 8192):
+            raw[off] = 0x00
+        candidate = tmp_path / "candidate.db"
+        candidate.write_bytes(bytes(raw))
+        c = snap.sqlite3.connect(str(candidate))
+        res = c.execute("PRAGMA integrity_check;").fetchone()[0]
+        c.close()
+        assert res != "ok", "fixture no longer models an opens-but-corrupt database"
+
+        bundle = _make_bundle(tmp_path, bytes(raw))
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "integrity check failed" in out, out
+        assert "cannot be opened" not in out, (
+            "this file DOES open; it must be caught by integrity_check, not by the "
+            "unopenable branch"
+        )
+        assert live.read_bytes() == before
+
+    def test_a_second_declared_database_is_also_checked(self, home, tmp_path, capsys):
+        """memory declares two databases; checking only the first leaves a hole."""
+        live = home / "memory.db"
+        live.write_bytes(_real_db(tmp_path / "live3.db"))
+        before = live.read_bytes()
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        payload.mkdir(parents=True, exist_ok=True)
+        (payload / "memory.db").write_bytes(_real_db(tmp_path / "sound.db"))
+        (payload / "memory_index.db").write_bytes(b"not a database either")
+        (payload / "MANIFEST.json").write_text(
+            '{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8"
+        )
+        bundle = tmp_path / "second.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "memory_index.db" in out, out
+        assert live.read_bytes() == before
+
+    def test_a_corrupt_database_inside_a_component_tree_is_refused(self, home, tmp_path, capsys):
+        """The knowledge store lives INSIDE a declared tree, and trees copy wholesale.
+
+        Validating only the top-level declared files leaves the same hole one directory
+        down.
+        """
+        live = home / "memory.db"
+        live.write_bytes(_real_db(tmp_path / "live4.db"))
+        before = live.read_bytes()
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        kdir = payload / "workspace" / "knowledge"
+        kdir.mkdir(parents=True)
+        (payload / "memory.db").write_bytes(_real_db(tmp_path / "sound2.db"))
+        # Opens as a database, fails integrity_check.
+        good = _real_db(tmp_path / "k.db")
+        raw = bytearray(good)
+        conn = snap.sqlite3.connect(str(tmp_path / "kbig.db"))
+        conn.execute("CREATE TABLE t (a INTEGER, b TEXT)")
+        conn.executemany("INSERT INTO t VALUES (?, ?)", [(i, "y" * 200) for i in range(400)])
+        conn.execute("CREATE INDEX idx ON t(b)")
+        conn.commit()
+        conn.close()
+        raw = bytearray((tmp_path / "kbig.db").read_bytes())
+        for off in range(4096, 8192):
+            raw[off] = 0x00
+        (kdir / "knowledge.db").write_bytes(bytes(raw))
+        (payload / "MANIFEST.json").write_text(
+            '{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8"
+        )
+        bundle = tmp_path / "tree.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "knowledge.db" in out, out
+        assert live.read_bytes() == before
+
+    def test_a_non_database_file_inside_a_tree_does_not_block_a_restore(
+        self, home, tmp_path, capsys
+    ):
+        """A `.db` inside the operator's own tree may simply not be SQLite.
+
+        A Windows `Thumbs.db` is on this product's own ignore list, so refusing every
+        unopenable `.db` under a tree would block restores over files that were never
+        databases.
+        """
+        (home / "memory.db").write_bytes(_real_db(tmp_path / "live5.db"))
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        kdir = payload / "workspace" / "knowledge"
+        kdir.mkdir(parents=True)
+        (payload / "memory.db").write_bytes(_real_db(tmp_path / "sound3.db"))
+        (kdir / "Thumbs.db").write_bytes(b"\x00\x01 windows thumbnail cache, not sqlite")
+        (payload / "MANIFEST.json").write_text(
+            '{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8"
+        )
+        bundle = tmp_path / "thumbs.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        rc = snap.restore_main(
+            [
+                str(bundle),
+                "--mode",
+                "replace",
+                "--force",
+                "--components",
+                "memory",
+                *unpinnable_argv(),
+            ]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert (home / "workspace" / "knowledge" / "Thumbs.db").is_file()
+
+
+class TestAnUnextractableBundleIsARefusalNotATraceback:
+    def test_a_readable_archive_that_cannot_be_extracted_is_refused(
+        self, home, tmp_path, capsys, monkeypatch
+    ):
+        """Listing an archive and extracting it are different operations.
+
+        The download probe passing does not mean extraction will, and a refusal has to
+        read as a refusal rather than a traceback.
+        """
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        payload.mkdir(parents=True)
+        (payload / "memory.db").write_bytes(_real_db(tmp_path / "ok.db"))
+        bundle = tmp_path / "ok.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        real = tarfile.TarFile.extractall
+
+        def boom(self, *a, **kw):
+            raise OSError("Not a directory")
+
+        monkeypatch.setattr(tarfile.TarFile, "extractall", boom)
+        rc = snap.restore_main([str(bundle), "--mode", "replace", "--force"])
+        out = capsys.readouterr().out
+        monkeypatch.setattr(tarfile.TarFile, "extractall", real)
+        assert rc == 1, out
+        assert "could not be extracted" in out, out
+        assert "Nothing was restored" in out, out
+
+
+class TestEveryDeclaredDatabaseIsCovered:
+    def test_every_declared_database_is_checked_not_just_the_first(self):
+        """The finding named one database; the check must cover all of them."""
+        dbs = [
+            name
+            for files in snap.CORE_FILES.values()
+            for name in files
+            if name.endswith((".db", ".sqlite3"))
+        ]
+        assert len(dbs) >= 2, dbs
+        import inspect
+
+        src = inspect.getsource(snap._refuse_corrupt_source_databases)
+        assert (
+            "for name in files" in src
+        ), "the pre-flight must iterate every declared database file"
+        assert "break" not in src, "stopping early would skip a later database"
+
+    def test_the_refusal_precedes_the_mutation_call(self):
+        """Structural: ordering is the property, so pin it in the source.
+
+        The mutation entrypoints now carry an `allow_unpinned` argument, so match the
+        call by its leading `(snap, mc, components` rather than a hardcoded closing paren.
+        """
+        import inspect
+
+        src = inspect.getsource(snap.restore_main)
+        pre = src.index("_refuse_corrupt_source_databases(")
+        assert pre < src.index("_do_replace(snap, mc, components")
+        assert pre < src.index("_do_merge(snap, mc, components")

--- a/test/test_snapshot_cycle5e_fixes.py
+++ b/test/test_snapshot_cycle5e_fixes.py
@@ -1,0 +1,157 @@
+"""Our own tree databases are strict on restore.
+
+A database this product owns (`memory.db`, `knowledge.db`) that cannot be opened is a bad
+bundle, not an incidental file: restoring it would replace a healthy local copy with a
+torn one. An incidental non-database in the same tree stays lenient, and merge says out
+loud when it keeps the local copy rather than importing the incoming one.
+"""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+def _real_db(path: Path) -> bytes:
+    conn = snap.sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE t (a INTEGER)")
+    conn.execute("INSERT INTO t VALUES (1)")
+    conn.commit()
+    conn.close()
+    return path.read_bytes()
+
+
+class TestOurOwnDatabasesInsideATreeAreStrict:
+    @pytest.fixture
+    def home(self, tmp_path, monkeypatch):
+        h = tmp_path / "home"
+        h.mkdir()
+        monkeypatch.setattr(snap, "_mc_dir", lambda: h)
+        monkeypatch.setattr(snap, "_is_gateway_running", lambda: False)
+        return h
+
+    def _bundle(self, tmp_path, knowledge_bytes: bytes, name: str) -> Path:
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        kdir = payload / "workspace" / "knowledge"
+        kdir.mkdir(parents=True, exist_ok=True)
+        (payload / "memory.db").write_bytes(_real_db(tmp_path / f"sound-{name}.db"))
+        (kdir / name).write_bytes(knowledge_bytes)
+        (payload / "MANIFEST.json").write_text(
+            '{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8"
+        )
+        bundle = tmp_path / f"{name}.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+        return bundle
+
+    def test_an_unopenable_knowledge_database_is_refused(self, home, tmp_path, capsys):
+        """`knowledge.db` is as much ours as `memory.db`, so unopenable is a bad bundle."""
+        live = home / "memory.db"
+        live.write_bytes(_real_db(tmp_path / "live.db"))
+        before = live.read_bytes()
+
+        bundle = self._bundle(tmp_path, b"torn, not a database", "knowledge.db")
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "knowledge.db" in out and "integrity check failed" in out, out
+        assert live.read_bytes() == before
+
+    def test_an_incidental_non_database_in_the_same_tree_is_still_allowed(
+        self, home, tmp_path, capsys
+    ):
+        """Leniency has to survive for files that were never databases."""
+        (home / "memory.db").write_bytes(_real_db(tmp_path / "live2.db"))
+        bundle = self._bundle(tmp_path, b"\x00 windows thumbnail cache", "Thumbs.db")
+        rc = snap.restore_main(
+            [
+                str(bundle),
+                "--mode",
+                "replace",
+                "--force",
+                "--components",
+                "memory",
+                *unpinnable_argv(),
+            ]
+        )
+        assert rc == 0, capsys.readouterr().out
+
+    def test_merge_says_when_it_keeps_an_existing_knowledge_database(self, home, tmp_path, capsys):
+        """Merge legitimately keeps the local file; going silent is what misleads.
+
+        The operator asked to merge their knowledge library. Reporting success while
+        importing none of it reads as data loss, so the skip is stated outright.
+        """
+        kdir = home / "workspace" / "knowledge"
+        kdir.mkdir(parents=True)
+        local = _real_db(tmp_path / "local-knowledge.db")
+        (kdir / "knowledge.db").write_bytes(local)
+        (home / "memory.db").write_bytes(_real_db(tmp_path / "live3.db"))
+
+        bundle = self._bundle(
+            tmp_path, _real_db(tmp_path / "incoming-knowledge.db"), "knowledge.db"
+        )
+        rc = snap.restore_main(
+            [
+                str(bundle),
+                "--mode",
+                "merge",
+                "--force",
+                "--components",
+                "memory",
+                *unpinnable_argv(),
+            ]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert "workspace/knowledge/knowledge.db" in out, out
+        assert "NOT merged" in out, out
+        assert (
+            kdir / "knowledge.db"
+        ).read_bytes() == local, "merge must keep the local database, not clobber it"
+
+    def test_the_component_help_does_not_promise_a_row_merge(self):
+        help_text = snap.COMPONENTS["memory"].help
+        assert "workspace/knowledge/" in help_text
+        assert "not row-merged" in help_text, (
+            "the help advertises the knowledge tree, so it must not imply its database "
+            "rows are merged"
+        )
+
+    def test_the_limitation_is_documented_where_merge_is_explained(self):
+        """A limitation that ships as documentation has to stay true to the code.
+
+        The risk of choosing "document it" over "fix it" is that the two drift, so the
+        doc claim and the runtime warning are pinned together.
+        """
+        doc = (Path(snap.__file__).parent / "docs" / "snapshot-and-restore.md").read_text(
+            encoding="utf-8"
+        )
+        assert "not row-merged" in doc, "the merge limitation is not documented"
+        assert "workspace/knowledge/knowledge.db" in doc
+        # The doc promises the restore says so on the spot; that promise is the warning.
+        import inspect
+
+        src = inspect.getsource(snap._report_unmerged_databases)
+        assert (
+            "NOT " in src and "--mode replace" in src
+        ), "the doc says the restore reports the skip and names --mode replace"
+
+    def test_the_declared_set_is_not_empty_and_is_tree_relative(self):
+        assert snap.PRODUCT_TREE_DATABASES, "the strict set must not be empty"
+        for rel in snap.PRODUCT_TREE_DATABASES:
+            assert "/" in rel, f"{rel} is not inside a tree"
+            assert not rel.startswith("/"), rel
+            covered = any(
+                rel.startswith(f"{tree}/")
+                for trees in snap.COMPONENT_TREES.values()
+                for tree in trees
+            )
+            assert covered, f"{rel} is not under any declared component tree"

--- a/test/test_snapshot_cycle5f_fixes.py
+++ b/test/test_snapshot_cycle5f_fixes.py
@@ -1,0 +1,203 @@
+"""Validation follows what a restore will INSTALL, and the archive bound covers local files.
+
+Two scoping errors of the same shape: a rule was justified for one of a path's behaviours
+and then applied as if the path had only that behaviour.
+
+* Merge has two behaviours -- row-merge when the destination exists, plain file copy when it
+  does not. "Merge cannot corrupt the destination" is true only of the first.
+* The archive bound was applied to upload and download. A local bundle handed to `restore`
+  is a third path, and being local does not make a file trustworthy.
+"""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+def _real_db(path: Path) -> bytes:
+    conn = snap.sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE t (a INTEGER)")
+    conn.execute("INSERT INTO t VALUES (1)")
+    conn.commit()
+    conn.close()
+    return path.read_bytes()
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setattr(snap, "_mc_dir", lambda: h)
+    monkeypatch.setattr(snap, "_is_gateway_running", lambda: False)
+    return h
+
+
+def _bundle(tmp_path, memory_bytes: bytes, *, knowledge: bytes | None = None) -> Path:
+    payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+    payload.mkdir(parents=True, exist_ok=True)
+    (payload / "memory.db").write_bytes(memory_bytes)
+    if knowledge is not None:
+        kdir = payload / "workspace" / "knowledge"
+        kdir.mkdir(parents=True, exist_ok=True)
+        (kdir / "knowledge.db").write_bytes(knowledge)
+    (payload / "MANIFEST.json").write_text(
+        '{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8"
+    )
+    bundle = tmp_path / "b.tar.gz"
+    with tarfile.open(bundle, "w:gz") as tf:
+        tf.add(str(payload), arcname=payload.name)
+    return bundle
+
+
+class TestMergeValidatesWhatItWillInstall:
+    def test_merge_into_a_home_without_the_database_refuses_a_corrupt_one(
+        self, home, tmp_path, capsys
+    ):
+        """With no local memory.db, merge COPIES the incoming file -- exactly replace's act.
+
+        The "merge copies rows out, so it cannot corrupt the destination" argument does not
+        reach this branch.
+        """
+        assert not (home / "memory.db").exists()
+        bundle = _bundle(tmp_path, b"not a database at all")
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "merge", "--force", "--components", "memory"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "integrity check failed" in out, out
+        assert not (
+            home / "memory.db"
+        ).exists(), "merge installed an unvalidated database because the destination was absent"
+
+    def test_merge_keeps_skipping_when_the_destination_exists(self, home, tmp_path, capsys):
+        """The row-merge branch must stay skip-and-continue, not become a refusal."""
+        local = _real_db(tmp_path / "local.db")
+        (home / "memory.db").write_bytes(local)
+        bundle = _bundle(tmp_path, b"corrupt incoming")
+
+        rc = snap.restore_main(
+            [
+                str(bundle),
+                "--mode",
+                "merge",
+                "--force",
+                "--components",
+                "memory",
+                *unpinnable_argv(),
+            ]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert (home / "memory.db").read_bytes() == local
+
+    def test_a_tree_database_is_validated_only_when_merge_would_install_it(
+        self, home, tmp_path, capsys
+    ):
+        """Same rule one directory down: absent destination means it gets installed."""
+        (home / "memory.db").write_bytes(_real_db(tmp_path / "l2.db"))
+        assert not (home / "workspace" / "knowledge" / "knowledge.db").exists()
+        bundle = _bundle(
+            tmp_path,
+            _real_db(tmp_path / "sound.db"),
+            knowledge=b"torn knowledge database",
+        )
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "merge", "--force", "--components", "memory"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "knowledge.db" in out, out
+        assert not (home / "workspace" / "knowledge" / "knowledge.db").exists()
+
+    def test_a_tree_database_that_already_exists_locally_is_still_skipped(
+        self, home, tmp_path, capsys
+    ):
+        """The mirror case: merge keeps the local knowledge database and does not refuse.
+
+        Without this, validating every tree database unconditionally would look correct.
+        """
+        (home / "memory.db").write_bytes(_real_db(tmp_path / "l3.db"))
+        kdir = home / "workspace" / "knowledge"
+        kdir.mkdir(parents=True)
+        local = _real_db(tmp_path / "local-k.db")
+        (kdir / "knowledge.db").write_bytes(local)
+
+        bundle = _bundle(
+            tmp_path,
+            _real_db(tmp_path / "sound2.db"),
+            knowledge=b"torn knowledge database",
+        )
+        rc = snap.restore_main(
+            [
+                str(bundle),
+                "--mode",
+                "merge",
+                "--force",
+                "--components",
+                "memory",
+                *unpinnable_argv(),
+            ]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert (
+            kdir / "knowledge.db"
+        ).read_bytes() == local, "merge must keep the local knowledge database"
+
+
+class TestTheArchiveBoundCoversALocalBundle:
+    def test_a_local_archive_declaring_too_many_entries_is_refused(
+        self, home, tmp_path, capsys, monkeypatch
+    ):
+        """Local is not a trust boundary, and on 3.10 the fallback materialises members."""
+        monkeypatch.setattr(snap, "_MAX_ARCHIVE_MEMBERS", 12)
+        bundle = tmp_path / "many.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            root = tarfile.TarInfo("kirocrew-snapshot-20260101T000000Z")
+            root.type = tarfile.DIRTYPE
+            tf.addfile(root)
+            for i in range(40):
+                info = tarfile.TarInfo(f"kirocrew-snapshot-20260101T000000Z/f{i}.txt")
+                info.size = 0
+                tf.addfile(info)
+
+        rc = snap.restore_main([str(bundle), "--mode", "replace", "--force"])
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "declares more than" in out, out
+        assert "Nothing was restored" in out, out
+
+    def test_the_bound_runs_before_extraction_on_the_local_path(self):
+        """Ordering is the property: after extractall the damage is already written.
+
+        Located by the CALL, not by its argument list. Pinning the exact spelling
+        `filter=_data_filter` made this fail when the restore path started passing a
+        rejection-recording wrapper instead -- a rename, with the ordering it exists to prove
+        entirely intact. `extractall(work` still identifies the site, and the assertion is
+        unchanged.
+        """
+        import inspect
+        import re as _re
+
+        src = inspect.getsource(snap.restore_main)
+        bound = src.index("_refuse_oversized_archive(tar)")
+        extract = _re.search(r"\.extractall\(\s*work", src)
+        assert extract, "the local extraction site moved; retarget this locator"
+        assert bound < extract.start()
+
+    def test_the_message_does_not_claim_the_archive_was_downloaded(self):
+        import inspect
+
+        src = inspect.getsource(snap._refuse_oversized_archive)
+        assert (
+            "downloaded archive" not in src
+        ), "the bound now covers local bundles, so the message must not say downloaded"

--- a/test/test_snapshot_cycle5g_fixes.py
+++ b/test/test_snapshot_cycle5g_fixes.py
@@ -1,0 +1,197 @@
+"""Non-database components are validated too, and an un-redacted backup says what it
+carries.
+
+Two gaps that share a root: a rule was implemented for the case that prompted it and not
+for the others it applies to equally. Databases were validated but component JSON was not.
+A backup is deliberately un-redacted, but nothing told the operator what that includes.
+"""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+def _real_db(path: Path) -> bytes:
+    conn = snap.sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE t (a INTEGER)")
+    conn.commit()
+    conn.close()
+    return path.read_bytes()
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setattr(snap, "_mc_dir", lambda: h)
+    monkeypatch.setattr(snap, "_is_gateway_running", lambda: False)
+    return h
+
+
+def _bundle(tmp_path, crons: bytes, name: str = "b") -> Path:
+    payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+    payload.mkdir(parents=True, exist_ok=True)
+    (payload / "crons.json").write_bytes(crons)
+    (payload / "MANIFEST.json").write_text(
+        '{"version": 3, "components": {"crons": "unresolved"}}', encoding="utf-8"
+    )
+    bundle = tmp_path / f"{name}.tar.gz"
+    with tarfile.open(bundle, "w:gz") as tf:
+        tf.add(str(payload), arcname=payload.name)
+    return bundle
+
+
+class TestComponentJsonIsValidatedBeforeInstall:
+    def test_an_unparseable_crons_file_is_refused(self, home, tmp_path, capsys):
+        """Its reader treats an unreadable file as no jobs, so this would discard silently."""
+        bundle = _bundle(tmp_path, b"{ this is not json", name="broken")
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "crons"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "crons.json" in out and "could not be read as JSON" in out, out
+        assert not (home / "crons.json").exists()
+
+    def test_a_json_array_is_refused_because_the_reader_expects_an_object(
+        self, home, tmp_path, capsys
+    ):
+        """Well-formed JSON is not enough: an array takes the reader's empty branch."""
+        bundle = _bundle(tmp_path, b'[{"id": "a"}]', name="array")
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "crons"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "not an" in out and "object" in out, out
+        assert not (home / "crons.json").exists()
+
+    def test_a_sound_crons_file_still_restores(self, home, tmp_path, capsys):
+        bundle = _bundle(tmp_path, b'{"jobs": []}', name="ok")
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "crons"]
+            + unpinnable_argv()
+        )
+        assert rc == 0, capsys.readouterr().out
+        assert (home / "crons.json").is_file()
+
+    def test_merge_skips_a_crons_file_of_the_wrong_shape_rather_than_installing_it(
+        self, home, tmp_path
+    ):
+        """A crons file that parses into the wrong shape must never reach the merge reader.
+
+        Superseded mechanism: an earlier revision pre-flighted this in
+        `_refuse_corrupt_source_databases` and raised `SourceComponentUnsound`. The M1
+        base guards it on the merge side -- `_usable_cron_shape` classifies the shape and
+        `_merge_crons` skips an unusable file and continues.
+
+        That hand-off is conditional, and this test used to assert it unconditionally. The
+        merger only runs when a live copy EXISTS (`if dst.is_file(): _merge_crons(...)`); the
+        sibling `else` copies the bundle's file in verbatim, with no shape guard anywhere
+        downstream. So the pre-flight may stand aside only for the case whose guard is real,
+        and must refuse when it is the thing that installs -- both directions are asserted
+        below rather than the one that happened to hold.
+        """
+        # An existing destination: the merger's own guard covers it, so the pre-flight
+        # stands aside and one unreadable component does not fail every other one.
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        payload.mkdir(parents=True)
+        (payload / "crons.json").write_text('{"jobs": ["x"]}', encoding="utf-8")
+        (home / "crons.json").write_text('{"jobs": []}', encoding="utf-8")
+        snap._refuse_corrupt_source_databases(payload, ["crons"], mc_for_merge=home)
+
+        # An ABSENT destination: merge copies verbatim, nothing downstream checks the shape,
+        # so standing aside would install it. The pre-flight has to refuse here.
+        (home / "crons.json").unlink()
+        with pytest.raises(snap.SourceComponentUnsound):
+            snap._refuse_corrupt_source_databases(payload, ["crons"], mc_for_merge=home)
+        (home / "crons.json").write_text('{"jobs": []}', encoding="utf-8")
+
+        # ...and it is the reader's shape guard that rejects it before any field access.
+        import json as _json
+
+        assert (
+            snap._usable_cron_shape(_json.loads('{"jobs": ["x"]}'), payload / "crons.json") is False
+        )
+        assert (
+            snap._usable_cron_shape(_json.loads('{"jobs": {"a": 1}}'), payload / "crons.json")
+            is False
+        )
+
+        # Unparseable JSON is still the pre-flight's to refuse (an object reader can't
+        # even reach), so it stands aside for the merger there too.
+        (payload / "crons.json").write_bytes(b"{ broken")
+        snap._refuse_corrupt_source_databases(payload, ["crons"], mc_for_merge=home)
+
+    def test_merge_validates_the_index_when_a_missing_memory_db_drags_it_along(
+        self, home, tmp_path
+    ):
+        """`memory_index.db` is copied whenever the live `memory.db` is absent.
+
+        Keying validation on the index's OWN destination let a corrupt index overwrite a
+        healthy one, because the copy is triggered by the other file's absence.
+        """
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        payload.mkdir(parents=True)
+        (payload / "memory.db").write_bytes(_real_db(tmp_path / "sound.db"))
+        (payload / "memory_index.db").write_bytes(b"corrupt index")
+
+        # A healthy local index exists, but no local memory.db -> both get copied.
+        (home / "memory_index.db").write_bytes(_real_db(tmp_path / "localidx.db"))
+        assert not (home / "memory.db").exists()
+        with pytest.raises(snap.SourceComponentUnsound):
+            snap._refuse_corrupt_source_databases(payload, ["memory"], mc_for_merge=home)
+
+        # With a local memory.db present, merge copies neither, so the index is left alone.
+        (home / "memory.db").write_bytes(_real_db(tmp_path / "localmem.db"))
+        snap._refuse_corrupt_source_databases(payload, ["memory"], mc_for_merge=home)
+
+    def test_the_declared_set_covers_the_readers_that_fail_empty(self):
+        for name in snap.COMPONENT_JSON_OBJECTS:
+            assert name.endswith(".json"), name
+        declared = {f for files in snap.CORE_FILES.values() for f in files}
+        assert (
+            snap.COMPONENT_JSON_OBJECTS <= declared
+        ), "every entry must be a real component file, or it is never checked"
+        assert "crons.json" in snap.COMPONENT_JSON_OBJECTS
+
+
+class TestAnUnredactedBackupSaysWhatItCarries:
+    def test_it_names_the_uncertified_components(self, capsys):
+        snap._report_unresolved_payload(["memory", "config"])
+        out = capsys.readouterr().out
+        assert "uncertified for sharing" in out.lower(), out
+        assert "config" in out and "memory" in out, out
+
+    def test_it_does_not_claim_a_redaction_state_it_no_longer_owns(self, capsys):
+        """Whether the OUTBOUND copy is redacted is decided later and reported there.
+
+        This notice runs before the outbound copy is even produced, so asserting "NOT
+        redacted" here would state the outcome of a decision that has not been made --
+        and it was wrong the moment redaction became the default.
+        """
+        snap._report_unresolved_payload(["memory", "config"])
+        out = capsys.readouterr().out
+        assert "NOT redacted" not in out, out
+        # It must still be honest about the copy it CAN speak for: the local one.
+        assert "local disk" in out, out
+
+    def test_it_stays_quiet_when_nothing_uncertified_rides(self, capsys, monkeypatch):
+        snap._report_unresolved_payload([])
+        assert capsys.readouterr().out == ""
+
+    def test_it_runs_before_the_outbound_copy_is_produced(self):
+        import inspect
+
+        src = inspect.getsource(snap.prepare_redacted_copy)
+        assert src.index("_report_unresolved_payload(") < src.index("_redacted_upload_copy(")
+
+    def test_no_component_is_certified_share_safe_yet(self):
+        """The disclosure's premise: nothing has been cleared for another person's hands."""
+        assert all(spec.policy is snap.SecretPolicy.UNRESOLVED for spec in snap.COMPONENTS.values())

--- a/test/test_snapshot_cycle5h_fixes.py
+++ b/test/test_snapshot_cycle5h_fixes.py
@@ -1,0 +1,155 @@
+"""Absent is not the same as wrong-type, and a rollback directory belongs to one restore.
+
+Both defects come from a `continue` or a reused name standing in for a decision: an entry
+of the wrong type read as "not there" and skipped every check; a second-granular rollback
+name read as "mine" and collided with the previous restore's saved state.
+"""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+def _real_db(path: Path) -> bytes:
+    conn = snap.sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE t (a INTEGER)")
+    conn.commit()
+    conn.close()
+    return path.read_bytes()
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setattr(snap, "_mc_dir", lambda: h)
+    monkeypatch.setattr(snap, "_is_gateway_running", lambda: False)
+    return h
+
+
+class TestAWrongTypeEntryIsRefusedNotSkipped:
+    def test_a_directory_named_like_a_declared_file_is_refused(self, home, tmp_path, capsys):
+        """Otherwise it reads as absent: replace moves live memory aside and restores none."""
+        live = home / "memory.db"
+        live.write_bytes(_real_db(tmp_path / "live.db"))
+        before = live.read_bytes()
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        (payload / "memory.db").mkdir(parents=True)  # a DIRECTORY with a file's name
+        (payload / "MANIFEST.json").write_text(
+            '{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8"
+        )
+        bundle = tmp_path / "dirfile.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "not a regular file" in out, out
+        assert live.read_bytes() == before, "live memory was moved for a bundle that "
+        "could never restore it"
+
+    def test_a_file_named_like_a_declared_tree_is_refused(self, home, tmp_path, capsys):
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        (payload / "workspace").mkdir(parents=True)
+        (payload / "workspace" / "knowledge").write_text("not a dir", encoding="utf-8")
+        (payload / "memory.db").write_bytes(_real_db(tmp_path / "sound.db"))
+        (payload / "MANIFEST.json").write_text(
+            '{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8"
+        )
+        bundle = tmp_path / "filetree.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "not a directory" in out, out
+
+    def test_a_genuinely_absent_entry_still_skips(self, home, tmp_path, capsys):
+        """The refusal must not turn a selective bundle into an error."""
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        payload.mkdir(parents=True)
+        (payload / "memory.db").write_bytes(_real_db(tmp_path / "s2.db"))
+        # memory_index.db and the trees are simply not in this bundle.
+        (payload / "MANIFEST.json").write_text(
+            '{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8"
+        )
+        bundle = tmp_path / "partial.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+            + unpinnable_argv()
+        )
+        assert rc == 0, capsys.readouterr().out
+
+
+class TestTheRollbackDirectoryBelongsToOneRestore:
+    def test_a_second_allocation_in_the_same_second_gets_its_own_directory(self, home):
+        """Two restores inside one UTC second must not share a rollback set."""
+        first = snap._allocate_rollback_dir(home)
+        second = snap._allocate_rollback_dir(home)
+        assert first != second, "the second restore reused the first's rollback directory"
+        assert first.is_dir() and second.is_dir()
+        assert second.name.startswith(
+            first.name
+        ), f"the suffixed name should stay recognisable: {second.name}"
+
+    def test_the_operator_readable_stem_is_kept(self, home):
+        got = snap._allocate_rollback_dir(home)
+        assert got.name.startswith("pre-restore-"), got.name
+
+    def test_allocation_refuses_rather_than_crashing_when_exhausted(self, home, monkeypatch):
+        """A refusal names the problem; an uncaught FileExistsError does not."""
+
+        def always_taken(self, *a, **kw):
+            raise FileExistsError(str(self))
+
+        monkeypatch.setattr(Path, "mkdir", always_taken)
+        with pytest.raises(snap.SourceComponentUnsound) as e:
+            snap._allocate_rollback_dir(home)
+        assert "rollback directory" in str(e.value)
+
+    def test_two_restores_in_one_second_both_complete(self, home, tmp_path, capsys):
+        """End to end: the second restore must not die on the first's rollback path."""
+        (home / "memory.db").write_bytes(_real_db(tmp_path / "live2.db"))
+        mem = home / "workspace" / "memory"
+        mem.mkdir(parents=True)
+        (mem / "note.md").write_text("local", encoding="utf-8")
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        (payload / "workspace" / "memory").mkdir(parents=True)
+        (payload / "workspace" / "memory" / "in.md").write_text("in", encoding="utf-8")
+        (payload / "memory.db").write_bytes(_real_db(tmp_path / "in2.db"))
+        (payload / "MANIFEST.json").write_text(
+            '{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8"
+        )
+        bundle = tmp_path / "twice.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        argv = [
+            str(bundle),
+            "--mode",
+            "replace",
+            "--force",
+            "--components",
+            "memory",
+        ] + unpinnable_argv()
+        assert snap.restore_main(argv) == 0, capsys.readouterr().out
+        assert snap.restore_main(argv) == 0, capsys.readouterr().out
+        saved = sorted(p.name for p in home.glob("pre-restore-*"))
+        assert len(saved) >= 2, f"each restore needs its own rollback set: {saved}"

--- a/test/test_snapshot_cycle5i_fixes.py
+++ b/test/test_snapshot_cycle5i_fixes.py
@@ -1,0 +1,99 @@
+"""A snapshot this tool cannot restore is not a success, and must not prune what can be.
+
+The archive bound was applied to several of the paths that read an archive but not to
+creation, and creation is the worst one to miss: `snapshot` reported success AND pruned
+older bundles, so a workspace past the bound traded restorable backups for one that never
+restores.
+"""
+
+from __future__ import annotations
+
+import tarfile
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    (h / "workspace" / "memory").mkdir(parents=True)
+    (h / "workspace" / "memory" / "note.md").write_text("x", encoding="utf-8")
+    monkeypatch.setattr(snap, "_mc_dir", lambda: h)
+    return h
+
+
+class TestANewArchiveIsBoundedBeforeSuccessAndPrune:
+    def test_an_oversized_new_archive_is_refused(self, home, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(snap, "_MAX_ARCHIVE_MEMBERS", 2)
+        out = tmp_path / "out"
+        rc = snap.snapshot_main([str(out), "--components", "memory"] + unpinnable_argv())
+        captured = capsys.readouterr().out
+        assert rc == 1, captured
+        assert "declares more than" in captured, captured
+
+    def test_nothing_is_pruned_when_the_new_archive_is_refused(
+        self, home, tmp_path, monkeypatch, capsys
+    ):
+        """The prune is the damaging half: it deletes bundles that DO restore."""
+        out = tmp_path / "out"
+        out.mkdir()
+        # Two older bundles that must survive a refused run.
+        for name in (
+            "kirocrew-snapshot-20250101T000000Z.tar.gz",
+            "kirocrew-snapshot-20250102T000000Z.tar.gz",
+        ):
+            (out / name).write_bytes(b"older bundle")
+        before = sorted(p.name for p in out.glob("kirocrew-snapshot-*.tar.gz"))
+
+        monkeypatch.setattr(snap, "_MAX_ARCHIVE_MEMBERS", 2)
+        rc = snap.snapshot_main(
+            [str(out), "--components", "memory", "--keep", "1"] + unpinnable_argv()
+        )
+        captured = capsys.readouterr().out
+        assert rc == 1, captured
+        assert "nothing was pruned" in captured.lower(), captured
+
+        after = sorted(p.name for p in out.glob("kirocrew-snapshot-*.tar.gz"))
+        assert set(before) <= set(
+            after
+        ), f"a refused snapshot pruned restorable bundles: {before} -> {after}"
+
+    def test_a_normal_snapshot_still_succeeds(self, home, tmp_path, capsys):
+        out = tmp_path / "out"
+        rc = snap.snapshot_main([str(out), "--components", "memory"] + unpinnable_argv())
+        assert rc == 0, capsys.readouterr().out
+        # A memory-only (selective) bundle is named `kirocrew-partial-*`; a complete one
+        # keeps `kirocrew-snapshot-*`. Match either — the property is that a bundle was
+        # written, not which prefix it carries.
+        assert list(out.glob("kirocrew-*.tar.gz"))
+
+    def test_the_bound_runs_before_the_success_line_and_the_prune(self):
+        """Ordering is the property: success and prune both follow the check."""
+        import inspect
+
+        src = inspect.getsource(snap.snapshot_main)
+        bound = src.index("_refuse_oversized_archive(probe)")
+        assert bound < src.index("Snapshot created:")
+        assert bound < src.index("Pruned:")
+
+    def test_every_archive_reader_applies_the_bound(self):
+        """Every path that opens an archive applies the same bound.
+
+        Counting occurrences of the name would count its own ``def`` line, so a
+        threshold of N silently passes with N-1 real callers. Assert instead
+        that each function that opens an archive contains the call: creating a
+        bundle, restoring one, and producing the redacted outbound copy. A new
+        archive reader that skips the bound has to be added here to stay green.
+        """
+        import inspect
+
+        readers = ("snapshot_main", "restore_main", "_redacted_upload_copy")
+        for name in readers:
+            body = inspect.getsource(getattr(snap, name))
+            assert (
+                "_refuse_oversized_archive(" in body
+            ), f"{name} opens an archive without applying the member bound"
+        assert tarfile  # the fixtures above build real archives

--- a/test/test_snapshot_cycle5j_fixes.py
+++ b/test/test_snapshot_cycle5j_fixes.py
@@ -1,0 +1,233 @@
+"""A failed restore reports the state it left behind, and holds no handle open.
+
+Two defects with one shape: the operator is told less than they need. A traceback out of
+the mutation phase does not say whether the home is on the old generation or a half-applied
+new one, and a leaked database handle makes the next restore fail on Windows for a reason
+that has nothing to do with the bundle.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tarfile
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+def _real_db(path: Path) -> bytes:
+    conn = snap.sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE t (a INTEGER)")
+    conn.commit()
+    conn.close()
+    return path.read_bytes()
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setattr(snap, "_mc_dir", lambda: h)
+    monkeypatch.setattr(snap, "_is_gateway_running", lambda: False)
+    return h
+
+
+def _bundle(tmp_path: Path) -> Path:
+    payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+    payload.mkdir(parents=True)
+    (payload / "memory.db").write_bytes(_real_db(tmp_path / "in.db"))
+    (payload / "MANIFEST.json").write_text(
+        '{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8"
+    )
+    bundle = tmp_path / "b.tar.gz"
+    with tarfile.open(bundle, "w:gz") as tf:
+        tf.add(str(payload), arcname=payload.name)
+    return bundle
+
+
+class TestAMidMutationIoFailureIsReportedNotRaised:
+    def test_an_os_error_becomes_a_refusal_that_names_the_state(
+        self, home, tmp_path, monkeypatch, capsys
+    ):
+        (home / "memory.db").write_bytes(_real_db(tmp_path / "live.db"))
+        bundle = _bundle(tmp_path)
+
+        def boom(*_a, **_k):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(snap, "_do_replace_mutations", boom)
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "failed partway through" in out, out
+        assert "previous state was put back" in out.lower(), out
+        assert "Traceback" not in out
+
+    def test_an_untouched_target_survives_a_failure_in_an_earlier_one(
+        self, home, tmp_path, monkeypatch, capsys
+    ):
+        """Recovery must not delete what the phase never reached.
+
+        A file is saved by MOVING it aside at the moment of its own mutation, so when the
+        phase dies partway through, later targets have no saved copy AND still hold the
+        operator's original. Reading "no saved copy" as "did not exist" deletes them.
+
+        The failure is injected on the copy of `memory.db` -- the FIRST core file the
+        phase mutates -- so `crons` is a genuinely later target the loop never reaches.
+        (The move-aside now goes through pinned descriptors rather than `shutil.move`, so
+        the old `shutil.move` hook no longer intercepts it; failing the copy of an earlier
+        target is the current-shape way to leave a later one untouched.)
+        """
+        original = _real_db(tmp_path / "live.db")
+        (home / "memory.db").write_bytes(original)
+        (home / "crons.json").write_text('{"jobs": [{"id": "mine"}]}', encoding="utf-8")
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        payload.mkdir(parents=True)
+        (payload / "memory.db").write_bytes(_real_db(tmp_path / "in.db"))
+        (payload / "crons.json").write_text('{"jobs": []}', encoding="utf-8")
+        (payload / "MANIFEST.json").write_text(
+            '{"version": 3, "components": {"memory": "unresolved",' ' "crons": "unresolved"}}',
+            encoding="utf-8",
+        )
+        bundle = tmp_path / "two.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        # Fail the phase during memory (its first mutation), before crons is touched at
+        # all. copy_file_pinned is the copy step on BOTH the pinned and by-name paths, so
+        # this fires regardless of platform.
+        #
+        # Scoped to copies OUT OF THE BUNDLE: recovery now uses the same pinned primitive
+        # (a bare copy2 there followed a link planted at the target name), so an unscoped
+        # stub would also break the put-back and the test would be asserting that recovery
+        # fails rather than that it works. A copy whose source is under `pre-restore-` is
+        # the recovery leg and passes through.
+        real_copy = snap.pinned_fs.copy_file_pinned
+
+        def fail_on_memory_db(src, *a, **k):
+            if "pre-restore-" not in str(src) and (
+                "memory.db" in str(src) or k.get("name") == "memory.db"
+            ):
+                raise OSError(30, "Read-only file system")
+            return real_copy(src, *a, **k)
+
+        monkeypatch.setattr(snap.pinned_fs, "copy_file_pinned", fail_on_memory_db)
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory,crons"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert (home / "crons.json").is_file(), "recovery deleted a file the restore never touched"
+        assert "mine" in (home / "crons.json").read_text(
+            encoding="utf-8"
+        ), "the operator's own crons were replaced or lost"
+        assert (home / "memory.db").read_bytes() == original
+
+
+class TestTheIntegrityCheckLeavesNoOpenHandle:
+    def test_the_restored_database_can_be_replaced_afterwards(self, home, tmp_path, capsys):
+        """A held handle is invisible on POSIX and fatal on Windows -- assert the close.
+
+        Replacing the file is the portable way to observe it: Windows raises
+        PermissionError while a handle is open, and on POSIX the assertion below still
+        pins that the connection was closed.
+        """
+        (home / "memory.db").write_bytes(_real_db(tmp_path / "live.db"))
+        rc = snap.restore_main(
+            [str(_bundle(tmp_path)), "--mode", "replace", "--force", "--components", "memory"]
+            + unpinnable_argv()
+        )
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert "integrity: OK" in out, out
+
+        # Would raise PermissionError on Windows if the check leaked its connection.
+        moved = tmp_path / "moved.db"
+        (home / "memory.db").replace(moved)
+        assert moved.is_file()
+
+    def test_a_core_file_the_restore_created_is_removed_by_recovery(
+        self, home, tmp_path, monkeypatch, capsys
+    ):
+        """The other half of the same rule: a creation IS undone.
+
+        `crons.json` does not exist before the restore, so the copy this run installed has
+        no pre-restore state to return to and must go. Distinguishing this from the
+        untouched case above is the whole point of tracking what the phase installed.
+        """
+        (home / "config.json").write_text('{"mine": true}', encoding="utf-8")
+        assert not (home / "crons.json").exists(), "premise: no pre-restore crons"
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        payload.mkdir(parents=True)
+        (payload / "crons.json").write_text('{"jobs": []}', encoding="utf-8")
+        (payload / "config.json").write_text('{"incoming": true}', encoding="utf-8")
+        (payload / "MANIFEST.json").write_text(
+            '{"version": 3, "components": {"crons": "unresolved",' ' "config": "unresolved"}}',
+            encoding="utf-8",
+        )
+        bundle = tmp_path / "created.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        # crons installs first and is a creation; config then fails before being saved.
+        # The move-aside is descriptor-pinned now, so the old `shutil.move` hook no longer
+        # intercepts the restore; failing the copy of `config.json` is the current-shape
+        # way to make config fail AFTER crons was fully created. copy_file_pinned is the
+        # copy on both platforms.
+        #
+        # Scoped to copies OUT OF THE BUNDLE, because recovery uses the same primitive now:
+        # a copy whose source is under `pre-restore-` is the put-back leg and must succeed,
+        # or this test would assert recovery fails instead of asserting it undoes the
+        # creation.
+        real_copy = snap.pinned_fs.copy_file_pinned
+
+        def fail_on_config(src, *a, **k):
+            if "pre-restore-" not in str(src) and (
+                "config.json" in str(src) or k.get("name") == "config.json"
+            ):
+                raise OSError(30, "Read-only file system")
+            return real_copy(src, *a, **k)
+
+        monkeypatch.setattr(snap.pinned_fs, "copy_file_pinned", fail_on_config)
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "crons,config"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert not (
+            home / "crons.json"
+        ).exists(), "a file this restore created was left standing after recovery"
+        assert (home / "config.json").read_text(
+            encoding="utf-8"
+        ) == '{"mine": true}', "the untouched file was replaced or removed"
+
+    def test_the_integrity_check_uses_closing(self):
+        """The connection's own context manager ends the transaction, not the handle."""
+        import inspect
+
+        src = inspect.getsource(snap.restore_main)
+        i = src.index("PRAGMA integrity_check")
+        window = src[max(0, i - 400) : i]
+        assert (
+            "closing(sqlite3.connect" in window
+        ), "the integrity check must close its connection, not just its transaction"
+
+    def test_no_bare_connection_context_manager_remains(self):
+        """`with sqlite3.connect(...)` anywhere in this module leaks a handle."""
+        import re
+
+        source = Path(snap.__file__).read_text(encoding="utf-8")
+        code = [ln for ln in source.splitlines() if not ln.lstrip().startswith("#")]
+        bare = [ln.strip() for ln in code if re.search(r"with\s+sqlite3\.connect\(", ln)]
+        assert bare == [], f"bare connection context managers leak handles: {bare}"
+        assert sqlite3  # the fixtures build real databases

--- a/test/test_snapshot_cycle5k_fixes.py
+++ b/test/test_snapshot_cycle5k_fixes.py
@@ -1,0 +1,137 @@
+"""Names that came out of an archive are escaped before they reach the terminal.
+
+An untrusted archive supplies its own member names, manifest keys and root directory
+names. Two of the sites print while REJECTING a hostile entry, so the raw value there is
+the payload itself.
+"""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import snapshot as snap
+
+# A cursor-up plus carriage return: enough to overwrite the line printed above it.
+EVIL = "\x1b[1A\rinnocent-looking"
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setattr(snap, "_mc_dir", lambda: h)
+    monkeypatch.setattr(snap, "_is_gateway_running", lambda: False)
+    return h
+
+
+class TestTarMemberNamesAreEscaped:
+    def test_a_traversal_rejection_does_not_print_the_raw_name(self, capsys):
+        info = tarfile.TarInfo(name=f"../{EVIL}")
+        assert snap._data_filter(info) is None
+        out = capsys.readouterr().out
+        assert "\x1b" not in out, "the rejected member's escape sequence reached the terminal"
+        assert "\\x1b" in out, out
+
+    def test_a_symlink_rejection_does_not_print_the_raw_name(self, capsys):
+        info = tarfile.TarInfo(name=f"payload/{EVIL}")
+        info.type = tarfile.SYMTYPE
+        assert snap._data_filter(info) is None
+        out = capsys.readouterr().out
+        assert "\x1b" not in out, "the rejected symlink's escape sequence reached the terminal"
+
+
+class TestManifestDerivedNamesAreEscaped:
+    def test_an_unknown_component_key_is_escaped(self, tmp_path, capsys):
+        payload = tmp_path / "snap"
+        payload.mkdir()
+        (payload / "MANIFEST.json").write_text(
+            json.dumps({"version": 3, "components": {"memory": "unresolved", EVIL: "x"}}),
+            encoding="utf-8",
+        )
+        known = snap._manifest_components(payload)
+        out = capsys.readouterr().out
+        assert "memory" in known
+        assert "\x1b" not in out, "a hostile manifest key reached the terminal raw"
+        assert "\\x1b" in out, out
+
+    def test_the_manifest_summary_escapes_its_fields(self, tmp_path, capsys):
+        payload = tmp_path / "snap"
+        payload.mkdir()
+        (payload / "MANIFEST.json").write_text(
+            json.dumps(
+                {
+                    "version": 3,
+                    "created_at": EVIL,
+                    "user": EVIL,
+                    "hostname": EVIL,
+                    "components": {EVIL: EVIL},
+                }
+            ),
+            encoding="utf-8",
+        )
+        snap._print_manifest(payload)
+        out = capsys.readouterr().out
+        assert "\x1b" not in out, "a manifest field reached the terminal raw"
+
+
+class TestArchiveRootNamesAreEscaped:
+    def test_two_roots_are_named_without_their_escapes(self, home, tmp_path, capsys):
+        """The ambiguity refusal names what it found, so it must escape those names.
+
+        The roots are written as tar METADATA rather than as real directories. That is
+        both the portable form -- Windows rejects control characters in a filename
+        outright, so the escape could never exist on disk there -- and the honest one: a
+        hostile root name reaches us inside an archive someone else wrote, which is
+        exactly the surface being tested.
+        """
+        bundle = tmp_path / "two-roots.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            for name in (f"kirocrew-snapshot-{EVIL}", "kirocrew-snapshot-20260101T000000Z"):
+                info = tarfile.TarInfo(name=name)
+                info.type = tarfile.DIRTYPE
+                info.mode = 0o755
+                tf.addfile(info)
+
+        rc = snap.restore_main([str(bundle), "--mode", "replace", "--force"])
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "\x1b" not in out, "an archive root name reached the terminal raw"
+
+
+class TestTheRuleCoversEveryArchiveDerivedPrint:
+    def test_no_site_prints_a_raw_member_or_manifest_name(self):
+        """A new print of archive-derived text must go through the helper.
+
+        Pinned structurally because the vulnerable sites are spread across the tar
+        filter, the manifest reader and the root-selection refusal -- three places that
+        do not otherwise look alike, which is how two of them were missed.
+        """
+        source = Path(snap.__file__).read_text(encoding="utf-8")
+        assert "{info.name}" not in source, "a tar member name is interpolated without _safe_name"
+        assert "', '.join(dropped)" not in source, "manifest keys are joined without _safe_name"
+        assert (
+            "sorted(d.name for d in snap_dirs)" not in source
+        ), "archive root names are joined without _safe_name"
+
+    def test_the_helper_escapes_control_bytes_and_keeps_printable_text(self):
+        """The escaping property itself, asserted directly on `_safe_name`.
+
+        This used to compare `_safe_name` against a shared sanitiser that lived beside the
+        off-host destination code; that helper is gone and the escaping now lives inside
+        `_safe_name`. The property is unchanged: every control byte is rendered as a
+        visible `\\xNN` escape so it cannot drive the terminal, while ordinary printable
+        text is left intact and an empty value falls back.
+        """
+        got = snap._safe_name(EVIL)
+        # No raw control byte survives -- neither the cursor-up escape nor the CR.
+        assert "\x1b" not in got and "\r" not in got, got
+        # Each is rendered as its visible \xNN form instead.
+        assert "\\x1b" in got, got
+        assert "\\x0d" in got, got
+        # The printable remainder is untouched.
+        assert "innocent-looking" in got, got
+        assert snap._safe_name("", "fallback") == "fallback"

--- a/test/test_snapshot_cycle5l_fixes.py
+++ b/test/test_snapshot_cycle5l_fixes.py
@@ -1,0 +1,1134 @@
+"""A table the pass cannot read fails CLOSED, and validation matches what readers need.
+
+Both are the same mistake in different places: a branch that could not do its job chose to
+continue rather than refuse. The redaction pass exists to keep credentials off the wire, so
+"could not inspect this table" cannot mean "ship it".
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+import os
+import shutil
+import tarfile
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+from kiro_crew import snapshot_redact as redact
+
+TOKEN = "8412345678:AAH9xSECRETtokenvalue_here12345"
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setattr(snap, "_mc_dir", lambda: h)
+    monkeypatch.setattr(snap, "_is_gateway_running", lambda: False)
+    return h
+
+
+class TestATableThatCannotBeInspectedRefusesTheUpload:
+    def test_a_without_rowid_table_is_not_silently_skipped(self, tmp_path):
+        """`WITHOUT ROWID` has no rowid handle -- the database must go, not the table."""
+        db = tmp_path / "memory.db"
+        conn = redact.sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE norowid (k TEXT PRIMARY KEY, v TEXT) WITHOUT ROWID")
+        conn.execute("INSERT INTO norowid VALUES (?, ?)", ("aws", f"token {TOKEN}"))
+        conn.commit()
+        conn.close()
+
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        (db).replace(stage / "memory.db")
+        (stage / "MANIFEST.json").write_text(
+            json.dumps({"version": 3, "components": {"memory": "unresolved"}}),
+            encoding="utf-8",
+        )
+
+        # Refused, not dropped: deleting the database this backup exists to carry and
+        # uploading the remainder yields an off-host copy that reports success and
+        # restores nothing, discovered only once the machine it came from is gone.
+        with pytest.raises(redact.PayloadDatabaseUnprovable) as e:
+            redact.redact_bundle_for_egress(stage)
+        assert "memory.db" in e.value.paths
+        assert (
+            stage / "memory.db"
+        ).exists(), "the payload was deleted instead of the upload being refused"
+        assert any("memory.db" in d for d in e.value.details), e.value.details
+
+    def test_an_ordinary_table_is_still_redacted_in_place(self, tmp_path):
+        """The refusal must not swallow the normal path."""
+        db = tmp_path / "memory.db"
+        conn = redact.sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE ok (k, v)")
+        conn.execute("INSERT INTO ok VALUES (?, ?)", ("aws", f"token {TOKEN}"))
+        conn.commit()
+        conn.close()
+
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        db.replace(stage / "memory.db")
+        report = redact.redact_bundle_for_egress(stage)
+
+        assert (stage / "memory.db").is_file(), "an inspectable database was dropped"
+        assert report.replacements.get("memory.db"), report.replacements
+        conn = redact.sqlite3.connect(str(stage / "memory.db"))
+        assert conn.execute("PRAGMA integrity_check;").fetchone()[0] == "ok"
+        assert TOKEN not in conn.execute("SELECT v FROM ok").fetchone()[0]
+        conn.close()
+
+    def test_no_branch_skips_a_table_it_could_not_read(self):
+        """A table that cannot be read must refuse; a DERIVED one may be skipped.
+
+        Pinned as two properties rather than a ban on `continue`, because the FTS shadow
+        tables are legitimately skipped -- they are regenerated from the content table, so
+        skipping them is part of redacting rather than a hole in it. What must never come
+        back is turning an unreadable table into a silent pass.
+        """
+        import inspect
+
+        src = inspect.getsource(redact._redact_database)
+        assert (
+            "except sqlite3.DatabaseError:\n                    continue" not in src
+        ), "an unreadable table is skipped instead of refusing the database"
+        # Asserted as the STATES that must refuse, not as a count of occurrences in one
+        # function. The count broke the moment the paged row read was extracted into a helper
+        # -- the refusal had moved, not disappeared -- which is a refactor, not a regression.
+        # Naming each state also says WHICH one went missing when this fails.
+        source = src + inspect.getsource(redact._paged_rows)
+        for state, fragment in (
+            ("a table with no readable columns", "no readable columns"),
+            ("a database that never settles", "did not settle"),
+            ("a NUL-bearing text value", "NUL-bearing text value"),
+            ("a byte-valued field that is not text", "byte-valued field carries a"),
+            ("a table that cannot be read at all", "{table}: {e}"),
+        ):
+            assert fragment in source, (
+                f"the refusal for {state} is gone; every state this pass cannot prove clean "
+                "must refuse rather than skip"
+            )
+        assert (
+            "if table in skip_tables:" in src
+        ), "only positively-identified derived tables may be skipped"
+
+    def test_an_fts_database_survives_and_loses_the_credential(self, tmp_path):
+        """The fail-closed rule must not delete the Knowledge Library.
+
+        FTS5 keeps two `WITHOUT ROWID` shadow tables, so refusing on that basis would drop
+        every knowledge database from the outbound copy. Redacting the content and
+        rebuilding the index is what removes the term: the inverted index holds it as
+        index structure, so a redacted content table with a stale index still answers a
+        search for the credential.
+        """
+        key = "ghp_" + "C" * 36
+        stage = tmp_path / "stage"
+        (stage / "workspace" / "knowledge").mkdir(parents=True)
+        db = stage / "workspace" / "knowledge" / "knowledge.db"
+
+        conn = redact.sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, title, content)")
+        conn.execute("CREATE VIRTUAL TABLE items_fts USING fts5(title, content)")
+        conn.execute("INSERT INTO items (title, content) VALUES (?, ?)", ("n", f"key {key} here"))
+        conn.execute(
+            "INSERT INTO items_fts (rowid, title, content) VALUES (?, ?, ?)",
+            (1, "n", f"key {key} here"),
+        )
+        conn.commit()
+        conn.close()
+
+        assert key.encode() in db.read_bytes(), "premise: the key is in the file"
+        report = redact.redact_bundle_for_egress(stage)
+
+        assert db.is_file(), f"the knowledge database was deleted: {report.dropped}"
+        assert (
+            key.encode() not in db.read_bytes()
+        ), "the credential survived in the file, most likely in the inverted index"
+
+        conn = redact.sqlite3.connect(str(db))
+        assert conn.execute("PRAGMA integrity_check;").fetchone()[0] == "ok"
+        assert conn.execute("SELECT count(*) FROM items").fetchone()[0] == 1
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM items_fts WHERE items_fts MATCH ?", (key,)
+            ).fetchone()[0]
+            == 0
+        ), "the index still matches the redacted credential"
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM items_fts WHERE items_fts MATCH ?", ("here",)
+            ).fetchone()[0]
+            == 1
+        ), "redaction broke ordinary search"
+        conn.close()
+
+    def test_a_contentless_fts_index_refuses_the_upload(self, tmp_path):
+        """A contentless index has no content table, so the skip-and-rebuild rule is false.
+
+        The FTS storage tables are skipped because they are DERIVED: cleaning the content
+        table and rebuilding the index is what removes the term. `content=''` has no content
+        table at all, so its tokens live ONLY in that storage -- skipping it means nothing
+        ever examines them and nothing regenerates them from a cleaned source.
+
+        Measured before this guard existed: an AWS access key is a separator-free
+        alphanumeric run, so FTS5 stores it as one token instead of splitting it, the scanner
+        matches that shape, and a full pass reported `replacements={}` while the token sat in
+        the file. Lowercasing by the tokenizer is not a control -- an `sk`-style or hex key is
+        lowercase to begin with.
+        """
+        db = tmp_path / "memory.db"
+        conn = redact.sqlite3.connect(str(db))
+        conn.execute("CREATE VIRTUAL TABLE notes USING fts5(body, content='')")
+        conn.execute("INSERT INTO notes(rowid, body) VALUES (1, ?)", (f"key {TOKEN} here",))
+        conn.commit()
+        conn.close()
+
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        db.replace(stage / "memory.db")
+
+        with pytest.raises(redact.PayloadDatabaseUnprovable) as e:
+            redact.redact_bundle_for_egress(stage)
+        assert "memory.db" in e.value.paths
+        assert any("contentless" in d for d in e.value.details), e.value.details
+        # Refused, not deleted: dropping the database this backup exists to carry would
+        # turn a provable-cleanliness problem into data loss.
+        assert (stage / "memory.db").exists()
+
+    def test_an_external_content_fts_database_is_redacted_and_kept(self, tmp_path):
+        """The shape this product actually uses: `content=items, content_rowid=id`.
+
+        With external content there is no `_content` shadow table and the virtual table is
+        READ-ONLY for content, so the term can only leave the index by rebuilding it from
+        the redacted base table. A fixture using a standard fts5 table passes without the
+        rebuild for the wrong reason -- writing through the virtual table happens to fix
+        both halves there -- which is why this case is pinned separately.
+        """
+        key = "ghp_" + "E" * 36
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        db = stage / "knowledge.db"
+
+        conn = redact.sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, title, content, tags)")
+        conn.execute(
+            "CREATE VIRTUAL TABLE items_fts USING fts5("
+            "title, content, tags, content=items, content_rowid=id)"
+        )
+        conn.execute(
+            "INSERT INTO items (title, content, tags) VALUES (?, ?, ?)",
+            ("n", f"k {key} z", "t"),
+        )
+        conn.execute("INSERT INTO items_fts(items_fts) VALUES('rebuild')")
+        conn.commit()
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM items_fts WHERE items_fts MATCH ?", (key,)
+            ).fetchone()[0]
+            == 1
+        ), "premise: the index matches the key"
+        conn.close()
+
+        report = redact.redact_bundle_for_egress(stage)
+        assert db.is_file(), f"the knowledge database was deleted: {report.dropped}"
+        assert (
+            key.encode() not in db.read_bytes()
+        ), "the credential survived in the index -- the rebuild did not run"
+
+        conn = redact.sqlite3.connect(str(db))
+        assert conn.execute("PRAGMA integrity_check;").fetchone()[0] == "ok"
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM items_fts WHERE items_fts MATCH ?", (key,)
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM items_fts WHERE items_fts MATCH ?", ("z",)
+            ).fetchone()[0]
+            == 1
+        ), "redaction broke ordinary search"
+        conn.close()
+
+    def test_an_unrecognised_rowidless_table_still_refuses(self, tmp_path):
+        """The exemption is for identified FTS shadow storage, not for rowid-less tables."""
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        db = stage / "memory.db"
+        conn = redact.sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE odd (k TEXT PRIMARY KEY, v TEXT) WITHOUT ROWID")
+        conn.execute("INSERT INTO odd VALUES ('a', 'b')")
+        conn.commit()
+        conn.close()
+
+        # Refused, not dropped: deleting the database this backup exists to carry and
+        # uploading the remainder yields an off-host copy that reports success and
+        # restores nothing, discovered only once the machine it came from is gone.
+        with pytest.raises(redact.PayloadDatabaseUnprovable) as e:
+            redact.redact_bundle_for_egress(stage)
+        assert "memory.db" in e.value.paths, "a rowid-less table outside FTS was silently skipped"
+        assert db.exists()
+
+
+class TestADeclaredRowidColumnDoesNotBecomeTheUpdateHandle:
+    """`rowid` is not reserved, so a schema can take the name -- and then `WHERE rowid = ?`
+    matches that COLUMN. Nothing raises; the write just lands on every row sharing the
+    value. A pass that exists to protect the off-host copy must not corrupt it."""
+
+    def _staged(self, tmp_path, schema, rows):
+        db = tmp_path / "memory.db"
+        conn = redact.sqlite3.connect(str(db))
+        conn.execute(schema)
+        conn.executemany(f"INSERT INTO shadow VALUES ({', '.join('?' * len(rows[0]))})", rows)
+        conn.commit()
+        conn.close()
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        db.replace(stage / "memory.db")
+        return stage
+
+    def test_a_shadowed_rowid_does_not_clobber_sibling_rows(self, tmp_path):
+        """The regression: two rows share the shadowing value, only one holds a credential."""
+        stage = self._staged(
+            tmp_path,
+            'CREATE TABLE shadow ("rowid" TEXT, secret TEXT)',
+            [("dup", f"token {TOKEN}"), ("dup", "keep-me"), ("other", "keep-me-too")],
+        )
+        report = redact.redact_bundle_for_egress(stage)
+
+        assert report.replacements.get("memory.db"), report.replacements
+        conn = redact.sqlite3.connect(str(stage / "memory.db"))
+        got = dict(
+            (i, v)
+            for i, (v,) in enumerate(conn.execute("SELECT secret FROM shadow ORDER BY _rowid_"))
+        )
+        conn.close()
+        assert TOKEN not in got[0], "the credential was not removed"
+        assert got[1] == "keep-me", f"an unrelated row was overwritten: {got[1]!r}"
+        assert got[2] == "keep-me-too", f"an unrelated row was overwritten: {got[2]!r}"
+
+    def test_the_shadowing_column_is_itself_still_scanned(self, tmp_path):
+        """It is a column like any other -- a credential inside it must still go."""
+        stage = self._staged(
+            tmp_path,
+            'CREATE TABLE shadow ("rowid" TEXT, v TEXT)',
+            [(f"token {TOKEN}", "x")],
+        )
+        redact.redact_bundle_for_egress(stage)
+
+        conn = redact.sqlite3.connect(str(stage / "memory.db"))
+        held = conn.execute('SELECT "rowid" FROM shadow').fetchone()[0]
+        conn.close()
+        assert TOKEN not in held, "the shadowing column was skipped instead of scanned"
+
+    def test_a_table_shadowing_every_alias_refuses_the_upload(self, tmp_path):
+        """No unique handle left, so this is the WITHOUT ROWID case: the database goes."""
+        stage = self._staged(
+            tmp_path,
+            'CREATE TABLE shadow ("rowid" TEXT, "_rowid_" TEXT, "oid" TEXT, v TEXT)',
+            [("a", "b", "c", f"token {TOKEN}")],
+        )
+        with pytest.raises(redact.PayloadDatabaseUnprovable) as e:
+            redact.redact_bundle_for_egress(stage)
+        assert "memory.db" in e.value.paths
+        assert (
+            stage / "memory.db"
+        ).exists(), "the payload was deleted instead of the upload being refused"
+
+    def test_shadowing_is_detected_regardless_of_case(self, tmp_path):
+        """SQLite identifiers are case-insensitive, so `RowID` shadows `rowid` completely."""
+        stage = self._staged(
+            tmp_path,
+            'CREATE TABLE shadow ("RowID" TEXT, secret TEXT)',
+            [("dup", f"token {TOKEN}"), ("dup", "keep-me")],
+        )
+        redact.redact_bundle_for_egress(stage)
+
+        conn = redact.sqlite3.connect(str(stage / "memory.db"))
+        rows = [v for (v,) in conn.execute("SELECT secret FROM shadow ORDER BY _rowid_")]
+        conn.close()
+        assert TOKEN not in rows[0]
+        assert rows[1] == "keep-me", f"case-different shadowing was missed: {rows[1]!r}"
+
+    def test_the_alias_resolver_prefers_rowid_and_refuses_only_when_exhausted(self):
+        """Unit-level, so the ordering is pinned without building four databases."""
+        assert redact._rowid_alias(["a", "b"]) == "rowid"
+        assert redact._rowid_alias(["rowid"]) == "_rowid_"
+        assert redact._rowid_alias(["rowid", "_rowid_"]) == "oid"
+        assert redact._rowid_alias(["RowID", "_ROWID_"]) == "oid"
+        with pytest.raises(redact._TableNotInspectable):
+            redact._rowid_alias(["rowid", "_rowid_", "oid"])
+
+    def test_the_select_and_the_update_cannot_drift_apart(self):
+        """Two statements, one handle. If a future edit hardcodes either, the pass writes
+        by a different key than it read by -- the corruption returns silently."""
+        src = Path(redact.__file__).read_text(encoding="utf-8")
+        body = src[src.index("def _redact_database") :]
+        assert "WHERE rowid = ?" not in body, "the UPDATE hardcodes rowid again"
+        assert "SELECT rowid," not in body, "the SELECT hardcodes rowid again"
+        # The SELECT now lives in the paging helper, so counting `{handle}` in one function
+        # no longer expresses the property -- and the property itself got STRONGER: the alias
+        # is computed once in `_redact_database` and PASSED to the helper, so the two
+        # statements cannot drift by construction rather than by convention. Asserted as
+        # that: the helper takes the handle as a parameter and interpolates it, and the caller
+        # hands it the same variable the UPDATE uses.
+        paged = inspect.getsource(redact._paged_rows)
+        assert "handle: str" in paged, "the paging helper no longer receives the handle"
+        assert "{handle}" in paged, "the SELECT stopped interpolating the passed handle"
+        assert "_paged_rows(conn, table, handle, quoted)" in body, (
+            "the caller must pass the SAME `handle` local that the UPDATE interpolates, or "
+            "the read and the write can key on different columns again"
+        )
+        assert "{handle}" in body, "the UPDATE stopped interpolating the handle"
+
+
+class TestTheRollbackLedgerRecordsWhatWasTouchedNotWhatWasDeclared:
+    """`installed` decides whether recovery DELETES a file, so it must mean "reached".
+
+    It was populated with every file the component DECLARES, before the copy loop ran. A
+    bundle may legitimately carry only some of them and the loop skips the rest, so those
+    files were never backed up and never written -- yet recovery saw "installed, no saved
+    copy, target exists", concluded the restore had created them, and deleted the operator's
+    own untouched files while reporting a successful rollback.
+
+    Both halves are asserted here, because a fix that only stops the deletion could do it by
+    breaking the legitimate undo.
+    """
+
+    def _bundle_for_config(self, tmp_path, carried):
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        payload.mkdir(parents=True)
+        for name in carried:
+            (payload / name).write_text("FROM ARCHIVE", encoding="utf-8")
+        (payload / "MANIFEST.json").write_text(
+            json.dumps({"version": 3, "components": {"config": "unresolved"}}), encoding="utf-8"
+        )
+        bundle = tmp_path / "b.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+        return bundle
+
+    def test_a_file_the_bundle_omits_is_not_deleted_by_the_rollback(self, home, tmp_path):
+        declared = list(snap.CORE_FILES["config"])
+        carried, omitted = declared[:1], declared[1:]
+        assert omitted, "this test needs a component with more than one core file"
+        for name in declared:
+            (home / name).write_text(f"OPERATOR DATA {name}", encoding="utf-8")
+
+        installed: set[str] = set()
+        backup = tmp_path / "pre-restore-probe"
+        backup.mkdir()
+        payload = tmp_path / "payload"
+        payload.mkdir()
+        for name in carried:
+            (payload / name).write_text("FROM ARCHIVE", encoding="utf-8")
+
+        snap._do_replace_mutations(
+            payload, home, backup, ["config"], [], installed, allow_unpinned=True
+        )
+        assert installed == set(carried), (
+            "the ledger recorded files the copy loop skipped: "
+            f"{sorted(installed - set(carried))}"
+        )
+
+        failed = snap._restore_everything_from_rollback(
+            backup, home, declared, installed, allow_unpinned=bool(unpinnable_argv())
+        )
+        assert failed == [], failed
+        for name in omitted:
+            live = home / name
+            assert live.is_file(), f"rollback deleted {name!r}, which this run never touched"
+            assert live.read_text(encoding="utf-8") == f"OPERATOR DATA {name}"
+
+    def test_a_file_this_run_really_created_is_still_undone(self, home, tmp_path):
+        """The other half: the legitimate undo must survive the fix.
+
+        `hooks.json` is absent live and present in the bundle, so the restore CREATES it.
+        Recovery has no saved copy to put back and must remove the creation -- that is what
+        "no pre-restore state" restores to. A fix that simply stopped recording would leave
+        this file behind and silently keep a file the operator never had.
+        """
+        created = "hooks.json"
+        assert not (home / created).exists()
+
+        installed: set[str] = set()
+        backup = tmp_path / "pre-restore-probe"
+        backup.mkdir()
+        payload = tmp_path / "payload"
+        payload.mkdir()
+        (payload / created).write_text("FROM ARCHIVE", encoding="utf-8")
+
+        snap._do_replace_mutations(
+            payload, home, backup, ["config"], [], installed, allow_unpinned=True
+        )
+        assert (home / created).is_file(), "the restore did not create the file"
+        assert created in installed
+
+        failed = snap._restore_everything_from_rollback(
+            backup,
+            home,
+            list(snap.CORE_FILES["config"]),
+            installed,
+            allow_unpinned=bool(unpinnable_argv()),
+        )
+        assert failed == [], failed
+        assert not (
+            home / created
+        ).exists(), "a file this run created was left behind by the rollback"
+
+
+class TestAPinnedRefusalMidMutationStillRollsBack:
+    """A refusal is not an OSError, and the rollback handler must still see it.
+
+    The mutation phase reaches the pinned primitives, which REFUSE rather than raise
+    OSError: `must_create=True` rejects a root recreated after its own rmtree, and a fatal
+    skip reporter rejects a file it cannot copy whole. Both fire mid-mutation. If the
+    handler only names OSError, the one failure class phase-two rollback exists for walks
+    past it and leaves live state half replaced.
+    """
+
+    def test_a_refusal_during_the_mutation_phase_triggers_recovery(
+        self, home, tmp_path, capsys, monkeypatch
+    ):
+        # `home` is the fixture that points `snap._mc_dir` at an isolated directory. Without
+        # it this test passes VACUOUSLY: the restore writes into the ambient data home while
+        # the assertions inspect an untouched tmp tree, so "ORIGINAL survived" is true because
+        # nothing ever ran. Caught by mutation-testing the handler and seeing green.
+        (home / "workspace" / "memory").mkdir(parents=True)
+        (home / "workspace" / "memory" / "keep.md").write_text("ORIGINAL", encoding="utf-8")
+        # A REAL database on both sides: the pre-flight refuses an unopenable payload
+        # database before the mutation phase, so a byte-string stand-in would never let this
+        # invariant be reached.
+        live = redact.sqlite3.connect(str(home / "memory.db"))
+        live.execute("CREATE TABLE t(v TEXT)")
+        live.execute("INSERT INTO t VALUES ('LIVE')")
+        live.commit()
+        live.close()
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        (payload / "workspace" / "memory").mkdir(parents=True)
+        (payload / "workspace" / "memory" / "keep.md").write_text("INCOMING", encoding="utf-8")
+        # Both of memory's declared trees, or the pre-flight refuses the bundle for lacking
+        # one the live home has -- a refusal that would fire before the mutation phase and so
+        # would not exercise this invariant at all.
+        (payload / "workspace" / "knowledge").mkdir(parents=True)
+        (payload / "workspace" / "knowledge" / "note.md").write_text("kb", encoding="utf-8")
+        incoming = redact.sqlite3.connect(str(payload / "memory.db"))
+        incoming.execute("CREATE TABLE t(v TEXT)")
+        incoming.execute("INSERT INTO t VALUES ('INCOMING')")
+        incoming.commit()
+        incoming.close()
+        (payload / "MANIFEST.json").write_text(
+            json.dumps({"version": 3, "components": {"memory": "unresolved"}}), encoding="utf-8"
+        )
+        bundle = tmp_path / "b.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        # A refusal, not an OSError, raised from inside the mutation phase. Scoped to copies
+        # out of the bundle so the recovery leg still works.
+        real = snap.pinned_fs.copy_file_pinned
+
+        def refuse_the_incoming_db(src, *a, **k):
+            if "pre-restore-" not in str(src) and "memory.db" in str(src):
+                raise snap.pinned_fs.PinnedPathRefusal("refusing: simulated pin failure")
+            return real(src, *a, **k)
+
+        monkeypatch.setattr(snap.pinned_fs, "copy_file_pinned", refuse_the_incoming_db)
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+        )
+        out = capsys.readouterr().out
+
+        assert "Replace mode" in out, f"the restore never reached the mutation phase: {out}"
+        assert rc == 1, out
+        assert "Traceback" not in out, out
+        # The point of the invariant: recovery RAN and put the original back.
+        assert (home / "workspace" / "memory" / "keep.md").read_text(
+            encoding="utf-8"
+        ) == "ORIGINAL", "a mid-mutation refusal skipped the rollback"
+        back = redact.sqlite3.connect(str(home / "memory.db"))
+        rows = [r[0] for r in back.execute("SELECT v FROM t")]
+        back.close()
+        assert rows == ["LIVE"], f"the live database was not put back: {rows}"
+
+
+class TestARewriteNeverLandsInAContainerThatRecordsItsOwnExtents:
+    """The guard is the MECHANISM, not the file type.
+
+    An earlier version keyed on `%PDF-` and its comment claimed measurement had shown the
+    ASCII PDF to be the one text container that reaches the rewrite. That measurement covered
+    BINARY containers (ZIP, gzip, PNG, tar, Flate-PDF, all already refused by the NUL test)
+    and was over-read into a claim about all of them. A text WARC is the counterexample:
+    UTF-8, NUL-free, and every record declares its own `Content-Length`.
+    """
+
+    def test_a_warc_is_refused_rather_than_shifted(self, tmp_path):
+        warc = tmp_path / "crawl.warc"
+        body = "key=AKIAIOSFODNN7EXAMPLE\r\n"
+        warc.write_text(
+            "WARC/1.0\r\nWARC-Type: response\r\n" f"Content-Length: {len(body)}\r\n\r\n{body}\r\n",
+            encoding="utf-8",
+        )
+        before = warc.read_bytes()
+
+        handled = redact._redact_text_file(warc, redact.RedactionReport(), "crawl.warc")
+
+        assert handled is False, "the WARC was accepted as plain text and rewritten"
+        assert warc.read_bytes() == before
+
+    def test_a_pdf_is_still_refused_by_its_offset_table(self, tmp_path):
+        """The PDF case must survive the switch from magic to mechanism."""
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_text(
+            "%PDF-1.4\ncred AKIAIOSFODNN7EXAMPLE\nxref\n0 2\nstartxref\n9\n%%EOF\n",
+            encoding="utf-8",
+        )
+        before = pdf.read_bytes()
+
+        handled = redact._redact_text_file(pdf, redact.RedactionReport(), "doc.pdf")
+
+        assert handled is False
+        assert pdf.read_bytes() == before
+
+    def test_ordinary_text_is_still_redacted(self, tmp_path):
+        note = tmp_path / "note.md"
+        note.write_text("my key is AKIAIOSFODNN7EXAMPLE\nnext line\n", encoding="utf-8")
+
+        assert redact._redact_text_file(note, redact.RedactionReport(), "note.md") is True
+        body = note.read_text(encoding="utf-8")
+        assert "AKIAIOSFODNN7EXAMPLE" not in body
+        assert "next line" in body
+
+    def test_a_file_too_large_to_hold_is_refused_before_being_read(self, tmp_path, monkeypatch):
+        """Refused on its SIZE, before `read_text` -- the only point where it helps.
+
+        `read_text` plus the scrubbed copy plus each redactor's intermediate hold several
+        multiples of the file at once, so an archive-sized member ends the process with
+        nothing uploaded.
+        """
+        big = tmp_path / "huge.log"
+        big.write_text("key=AKIAIOSFODNN7EXAMPLE\n", encoding="utf-8")
+        monkeypatch.setattr(redact, "_MAX_REDACTABLE_TEXT_BYTES", 4)
+        opened = {"count": 0}
+        real_read = type(big).read_text
+
+        def counting_read(self, *a, **k):
+            opened["count"] += 1
+            return real_read(self, *a, **k)
+
+        monkeypatch.setattr(type(big), "read_text", counting_read)
+
+        with pytest.raises(redact._FileUnreadable):
+            redact._redact_text_file(big, redact.RedactionReport(), "huge.log")
+        assert opened["count"] == 0, "the file was read before its size was checked"
+
+
+class TestAnFtsTriggerIsExemptOnlyForTheDeletionsThatAreMaintenance:
+    """The exemption is per DELETE, not per trigger.
+
+    The first version waved a whole trigger through as soon as any FTS name appeared anywhere
+    in it, so a trigger that maintains the index AND deletes unrelated rows was exempt -- a
+    rule justified for one of a thing's statements, applied to all of them.
+    """
+
+    def _db(self, path, trigger_body):
+        conn = redact.sqlite3.connect(str(path))
+        conn.executescript(f"""
+            CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);
+            CREATE TABLE audit(id INTEGER PRIMARY KEY, note TEXT);
+            CREATE VIRTUAL TABLE notes_fts USING fts5(body);
+            INSERT INTO notes(body) VALUES ('key=AKIAIOSFODNN7EXAMPLE');
+            INSERT INTO audit(note) VALUES ('row the operator needs');
+            CREATE TRIGGER t AFTER UPDATE ON notes BEGIN {trigger_body} END;
+            """)
+        conn.commit()
+        conn.close()
+
+    def test_a_trigger_that_maintains_fts_and_also_deletes_elsewhere_refuses(self, tmp_path):
+        db = tmp_path / "memory.db"
+        self._db(
+            db,
+            "DELETE FROM notes_fts WHERE rowid = OLD.id; DELETE FROM audit;",
+        )
+
+        with pytest.raises(redact._PayloadUnprovable):
+            redact._redact_database(db, redact.RedactionReport(), "memory.db", product=True)
+
+        conn = redact.sqlite3.connect(str(db))
+        rows = conn.execute("SELECT count(*) FROM audit").fetchone()[0]
+        conn.close()
+        assert rows == 1, "the unrelated table was emptied despite the refusal"
+
+    def test_a_trigger_whose_only_deletion_is_fts_maintenance_still_rides(self, tmp_path):
+        """The must-still-work half: a full-text index is kept in step by deleting its rows.
+
+        A plain (not external-content) fts5 table is used deliberately: `DELETE FROM` is legal
+        there, whereas on an external-content table the sync idiom is
+        `INSERT INTO t(t, rowid, ...) VALUES('delete', ...)` and a raw DELETE corrupts the
+        index -- which is what the first version of this test did, and sqlite said so.
+        """
+        db = tmp_path / "memory.db"
+        self._db(db, "DELETE FROM notes_fts WHERE rowid = OLD.id;")
+
+        redact._redact_database(db, redact.RedactionReport(), "memory.db", product=True)
+
+        conn = redact.sqlite3.connect(str(db))
+        body = conn.execute("SELECT body FROM notes").fetchone()[0]
+        audit = conn.execute("SELECT count(*) FROM audit").fetchone()[0]
+        conn.close()
+        assert "AKIA" not in body, "the credential survived"
+        assert audit == 1
+
+
+class TestATriggerThatDeletesRowsRefusesTheUpload:
+    """The fixpoint scan proves credentials do not survive. It proves nothing about rows.
+
+    A trigger that copies a pre-update value is cleaned by the next pass -- that is what the
+    fixpoint is for and it stays. A trigger that DELETES runs once and settles immediately,
+    so the fixpoint sees a quiet database while the rows are gone from the copy that leaves.
+    """
+
+    def _db(self, path, trigger_body):
+        conn = redact.sqlite3.connect(str(path))
+        conn.executescript(f"""
+            CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);
+            CREATE TABLE audit(id INTEGER PRIMARY KEY, note TEXT);
+            INSERT INTO notes(body) VALUES ('key=AKIAIOSFODNN7EXAMPLE');
+            INSERT INTO audit(note) VALUES ('row the operator needs');
+            CREATE TRIGGER t AFTER UPDATE ON notes BEGIN {trigger_body} END;
+            """)
+        conn.commit()
+        conn.close()
+
+    def test_a_deleting_trigger_refuses_and_the_rows_survive(self, tmp_path):
+        db = tmp_path / "memory.db"
+        self._db(db, "DELETE FROM audit;")
+
+        with pytest.raises(redact._PayloadUnprovable):
+            redact._redact_database(db, redact.RedactionReport(), "memory.db", product=True)
+
+        conn = redact.sqlite3.connect(str(db))
+        rows = conn.execute("SELECT count(*) FROM audit").fetchone()[0]
+        conn.close()
+        assert rows == 1, "the trigger fired and deleted the operator's row despite refusing"
+
+    def test_a_trigger_that_only_writes_values_is_still_handled_by_the_fixpoint(self, tmp_path):
+        """The must-still-work half, and the reason this refusal is narrower than prescribed.
+
+        Refusing every non-FTS UPDATE trigger would discard the fixpoint, which handles this
+        case provably -- and would refuse an external-content full-text index, which is
+        MAINTAINED by update triggers.
+        """
+        db = tmp_path / "memory.db"
+        self._db(db, "INSERT INTO audit(note) VALUES (OLD.body);")
+
+        redact._redact_database(db, redact.RedactionReport(), "memory.db", product=True)
+
+        conn = redact.sqlite3.connect(str(db))
+        leaked = [
+            r[0]
+            for r in conn.execute("SELECT note FROM audit UNION ALL SELECT body FROM notes")
+            if "AKIA" in (r[0] or "")
+        ]
+        conn.close()
+        assert leaked == [], f"the fixpoint left a credential behind: {leaked}"
+
+
+class TestTheDatabaseRestageChecksAndOpensTheSameFile:
+    """The screening and the SQLite open must not be two independent path walks.
+
+    `src.resolve()` re-walked every ancestor after the loop had screened the file by name,
+    so a swapped ancestor could redirect the open at a database the screen never inspected.
+    The parent chain is resolved once and pinned, the final name is checked THROUGH that
+    pinned parent, and the URI is built from the same resolved chain.
+    """
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="the swapped-ancestor defence is _chain_is_link_free opening each ancestor "
+        "through a directory descriptor (O_NOFOLLOW); os.supports_dir_fd is empty on "
+        "Windows, so this pinned redirect-refusal guarantee does not exist to assert here",
+    )
+    def test_a_swapped_ancestor_cannot_redirect_the_open(self, tmp_path, monkeypatch):
+        """The swap is INJECTED mid-loop, because a statically-planted link proves nothing.
+
+        `rglob` does not descend a symlinked directory, so a link placed before the pass runs
+        is never enumerated and the test passes no matter what the code does -- the first
+        version of this test was exactly that, and a mutant restoring `src.resolve()` sailed
+        through it. The real claim is about a swap AFTER the file was enumerated and screened,
+        so the swap is performed from inside the chain check, on its first call.
+        """
+        real = tmp_path / "live"
+        (real / "workspace").mkdir(parents=True)
+        db = real / "workspace" / "notes.db"
+        conn = redact.sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE t(v TEXT)")
+        conn.execute("INSERT INTO t VALUES ('MINE')")
+        conn.commit()
+        conn.close()
+
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        conn = redact.sqlite3.connect(str(outside / "notes.db"))
+        conn.execute("CREATE TABLE t(v TEXT)")
+        conn.execute("INSERT INTO t VALUES ('EXTERNAL-SECRET')")
+        conn.commit()
+        conn.close()
+
+        stage = tmp_path / "stage"
+        (stage / "workspace").mkdir(parents=True)
+        shutil.copy2(str(db), str(stage / "workspace" / "notes.db"))
+
+        real_check = snap._chain_is_link_free
+        swapped = {"done": False}
+
+        def swap_then_check(root, rel_parts):
+            if not swapped["done"]:
+                swapped["done"] = True
+                shutil.rmtree(str(real / "workspace"))
+                (real / "workspace").symlink_to(outside, target_is_directory=True)
+            return real_check(root, rel_parts)
+
+        monkeypatch.setattr(snap, "_chain_is_link_free", swap_then_check)
+        snap._restage_databases(real, stage)
+        assert swapped["done"], "the swap never fired; the test proves nothing"
+
+        staged = stage / "workspace" / "notes.db"
+        conn = redact.sqlite3.connect(str(staged))
+        rows = [r[0] for r in conn.execute("SELECT v FROM t")]
+        conn.close()
+        assert "EXTERNAL-SECRET" not in rows, (
+            "the restage followed a swapped ancestor and copied an external database "
+            f"into the bundle: {rows}"
+        )
+
+    def test_a_platform_without_dir_fd_still_restages(self, tmp_path, monkeypatch):
+        """Windows, simulated the way this repo already simulates it.
+
+        `os.supports_dir_fd` is EMPTY on Windows, so `os.open(..., dir_fd=fd)` raises
+        `NotImplementedError` there -- not "works but weaker". The first version of the chain
+        check passed `dir_fd` unconditionally and took the whole database pass down on
+        Windows; `pinned_fs.supports_pinned_walk()` exists for exactly this and was not
+        consulted. Both halves are simulated here: the capability report is emptied AND
+        `os.open` refuses a `dir_fd`, so a missing gate fails rather than silently passing on
+        a platform that happens to support it.
+        """
+        real = tmp_path / "live"
+        real.mkdir()
+        db = real / "notes.db"
+        conn = redact.sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE t(v TEXT)")
+        conn.execute("INSERT INTO t VALUES ('MINE')")
+        conn.commit()
+        conn.close()
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        shutil.copy2(str(db), str(stage / "notes.db"))
+
+        monkeypatch.setattr(snap.pinned_fs.os, "supports_dir_fd", set())
+        real_open = snap.os.open
+        # Scoped to THIS pass, not the process: pytest's own tmp_path teardown uses
+        # `os.open(..., dir_fd=)` on Linux, so an unconditional stub errors in teardown and
+        # the simulation would be testing the harness instead of the code.
+        active = {"on": True}
+
+        def refuse_dir_fd(path, flags, mode=0o777, *, dir_fd=None):
+            if dir_fd is not None and active["on"]:
+                raise NotImplementedError("dir_fd is unavailable on this platform")
+            return (
+                real_open(path, flags, mode)
+                if dir_fd is None
+                else real_open(path, flags, mode, dir_fd=dir_fd)
+            )
+
+        monkeypatch.setattr(snap.os, "open", refuse_dir_fd)
+
+        try:
+            snap._restage_databases(real, stage)
+        finally:
+            active["on"] = False
+
+        conn = redact.sqlite3.connect(str(stage / "notes.db"))
+        rows = [r[0] for r in conn.execute("SELECT v FROM t")]
+        conn.close()
+        assert rows == ["MINE"], f"the restage did not survive a platform without dir_fd: {rows}"
+
+    def test_an_ordinary_database_is_still_restaged(self, tmp_path):
+        """The screening must not become a blanket refusal."""
+        real = tmp_path / "live"
+        real.mkdir()
+        db = real / "notes.db"
+        conn = redact.sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE t(v TEXT)")
+        conn.execute("INSERT INTO t VALUES ('MINE')")
+        conn.commit()
+        conn.close()
+
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        # The staged copy is a real (possibly torn) filesystem copy -- that is what this
+        # pass exists to replace with a consistent one, so a non-database placeholder here
+        # would be testing a state the pass never sees.
+        shutil.copy2(str(db), str(stage / "notes.db"))
+        conn = redact.sqlite3.connect(str(real / "notes.db"))
+        conn.execute("INSERT INTO t VALUES ('ADDED-AFTER-THE-COPY')")
+        conn.commit()
+        conn.close()
+
+        snap._restage_databases(real, stage)
+
+        conn = redact.sqlite3.connect(str(stage / "notes.db"))
+        rows = [r[0] for r in conn.execute("SELECT v FROM t")]
+        conn.close()
+        assert rows == ["MINE", "ADDED-AFTER-THE-COPY"], f"the database was not restaged: {rows}"
+
+
+class TestASavedCoreFileLinkIsPutBackAsALink:
+    """`_backup_and_copy` MOVES a symlinked core file aside, so a link in the rollback
+    directory is a state this code creates on purpose.
+
+    Recovery tested `saved.is_dir()` then `saved.is_file()`, both of which dereference. A
+    relative link stops resolving once it sits in the rollback directory, so it matched
+    neither branch: the replacement at the live name was deleted as an undone creation, the
+    link stayed behind in the rollback directory, and the recovery reported success.
+    """
+
+    def test_a_relative_symlink_survives_the_round_trip(self, home, tmp_path):
+        (home / "real-crons.json").write_text('{"jobs": [{"name": "mine"}]}', encoding="utf-8")
+        (home / "crons.json").symlink_to("real-crons.json")
+
+        backup = tmp_path / "pre-restore-probe"
+        backup.mkdir()
+        # Exactly what the backup pass does with a symlinked core file: move the LINK.
+        shutil.move(str(home / "crons.json"), str(backup / "crons.json"))
+        saved = backup / "crons.json"
+        # The two branch tests are both false here -- that is the whole defect.
+        assert saved.is_symlink() and not saved.is_file() and not saved.is_dir()
+        # The restore wrote its own replacement before something later failed.
+        (home / "crons.json").write_text('{"jobs": [{"name": "from-archive"}]}', encoding="utf-8")
+
+        failed = snap._restore_everything_from_rollback(
+            backup, home, ["crons.json"], {"crons.json"}, allow_unpinned=bool(unpinnable_argv())
+        )
+
+        assert failed == [], failed
+        live = home / "crons.json"
+        assert live.is_symlink(), "the saved link was not put back as a link"
+        assert str(live.readlink()) == "real-crons.json", "the link target changed"
+        assert json.loads(live.read_text(encoding="utf-8"))["jobs"][0]["name"] == "mine"
+
+    def test_a_saved_regular_file_still_comes_back(self, home, tmp_path):
+        """The ordinary case must not be captured by the new link branch."""
+        backup = tmp_path / "pre-restore-probe"
+        backup.mkdir()
+        (backup / "crons.json").write_text('{"jobs": [{"name": "mine"}]}', encoding="utf-8")
+        (home / "crons.json").write_text('{"jobs": [{"name": "from-archive"}]}', encoding="utf-8")
+
+        failed = snap._restore_everything_from_rollback(
+            backup, home, ["crons.json"], {"crons.json"}, allow_unpinned=bool(unpinnable_argv())
+        )
+
+        assert failed == [], failed
+        live = home / "crons.json"
+        assert not live.is_symlink()
+        assert json.loads(live.read_text(encoding="utf-8"))["jobs"][0]["name"] == "mine"
+
+
+class TestAVariableLengthReplacementNeverRidesInAnOffsetDependentPayload:
+    """Redaction substitutes text of a DIFFERENT length, so it may only rewrite bytes whose
+    meaning does not depend on position.
+
+    The file path already refused a NUL-bearing file for exactly this reason. Two places had
+    no equivalent guard: a byte-valued database column, and a text-shaped container whose
+    own layout records byte offsets. Both shipped a corrupted off-host copy and reported it
+    clean, which on a backup is the worst available outcome.
+    """
+
+    def test_a_blob_carrying_a_credential_refuses_instead_of_being_rewritten(self, tmp_path):
+        import struct
+
+        db = tmp_path / "memory.db"
+        payload = b"attachment holding AKIAIOSFODNN7EXAMPLE inside"
+        # A length prefix that DESCRIBES the payload: the shape of every serialised record,
+        # and what a shifted payload destroys.
+        blob = struct.pack("<I", len(payload)) + payload + struct.pack("<I", 0xAABBCCDD)
+        conn = redact.sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE attachments(id INTEGER PRIMARY KEY, body BLOB)")
+        conn.execute("INSERT INTO attachments(body) VALUES (?)", (blob,))
+        conn.commit()
+        conn.close()
+
+        with pytest.raises(redact._PayloadUnprovable):
+            redact._redact_database(db, redact.RedactionReport(), "memory.db", product=True)
+
+        # Refusing means nothing is uploaded, so the staged bytes are left exactly as they
+        # were. The check that matters is that they were not SILENTLY rewritten.
+        conn = redact.sqlite3.connect(str(db))
+        after = bytes(conn.execute("SELECT body FROM attachments").fetchone()[0])
+        conn.close()
+        assert after == blob, "the blob was rewritten despite the refusal"
+
+    def test_a_blob_with_no_credential_still_rides(self, tmp_path):
+        """The refusal must key off a HIT, not off the column being binary.
+
+        Embeddings and thumbnails are the normal contents of a byte column. Refusing every
+        database that merely HAS one would replace the feature with an unconditional refusal
+        -- the same failure mode measured for the refuse-on-length-change remedy.
+        """
+        import struct
+
+        db = tmp_path / "memory.db"
+        clean = struct.pack("<I", 8) + b"embeddin" + struct.pack("<I", 0x11223344)
+        conn = redact.sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, body BLOB)")
+        conn.execute("INSERT INTO t(body) VALUES (?)", (clean,))
+        conn.commit()
+        conn.close()
+
+        redact._redact_database(db, redact.RedactionReport(), "memory.db", product=True)
+
+        conn = redact.sqlite3.connect(str(db))
+        after = bytes(conn.execute("SELECT body FROM t").fetchone()[0])
+        conn.close()
+        assert after == clean
+
+    def test_an_ascii_pdf_is_refused_rather_than_shifted(self, tmp_path):
+        """Measured to be the ONE offset-dependent container that reaches the rewrite.
+
+        ZIP, gzip, PNG, tar and a Flate-stream PDF are all already refused by the NUL guard
+        -- each is either not UTF-8 or carries NUL. An uncompressed ASCII PDF is neither,
+        and its `xref` holds byte offsets that a variable-length edit invalidates.
+        """
+        pdf = tmp_path / "doc.pdf"
+        body = b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\ncred AKIAIOSFODNN7EXAMPLE\n"
+        pdf.write_bytes(body + b"xref\n0 2\n0000000009 00000 n \nstartxref\n9\n%%EOF\n")
+        before = pdf.read_bytes()
+
+        handled = redact._redact_text_file(pdf, redact.RedactionReport(), "doc.pdf")
+
+        assert handled is False, "the PDF was accepted as plain text and rewritten"
+        assert pdf.read_bytes() == before, "the PDF was modified"
+
+    def test_an_ordinary_text_file_is_still_redacted(self, tmp_path):
+        """The feature has to keep working: plain text has no offsets to invalidate."""
+        note = tmp_path / "note.md"
+        note.write_text("my key is AKIAIOSFODNN7EXAMPLE\nnext line\n", encoding="utf-8")
+
+        handled = redact._redact_text_file(note, redact.RedactionReport(), "note.md")
+
+        assert handled is True
+        body = note.read_text(encoding="utf-8")
+        assert "AKIAIOSFODNN7EXAMPLE" not in body
+        assert "next line" in body
+
+
+class TestCronValidationMatchesWhatTheReaderNeeds:
+    """A malformed cron shape must never reach the merge reader's field access.
+
+    Superseded mechanism: an earlier revision pre-flighted the shape in
+    `_refuse_corrupt_source_databases` and raised `SourceComponentUnsound`. The M1 base
+    guards this on the MERGE side instead -- `_usable_cron_shape` classifies the shape and
+    `_merge_crons` SKIPS an unusable one and continues, so the reader never calls `.get`
+    on a str or iterates a non-list. The property (a bad entry is never handed to the
+    reader) is unchanged; where it is enforced moved, so these pin `_usable_cron_shape`
+    and the merge-skips-and-continues behaviour.
+    """
+
+    def test_a_jobs_list_of_strings_is_rejected_by_the_shape_guard(self, home, tmp_path) -> None:
+        """`{"jobs": ["x"]}` is a valid object whose reader would call `.get` on a str."""
+        import json as _json
+
+        parsed = _json.loads('{"jobs": ["x"]}')
+        assert (
+            snap._usable_cron_shape(parsed, tmp_path / "crons.json") is False
+        ), "a job that is not an object must be rejected before the reader touches it"
+
+    def test_a_jobs_value_that_is_not_a_list_is_rejected_by_the_shape_guard(
+        self, home, tmp_path
+    ) -> None:
+        import json as _json
+
+        parsed = _json.loads('{"jobs": {"a": 1}}')
+        assert (
+            snap._usable_cron_shape(parsed, tmp_path / "crons.json") is False
+        ), "a jobs value that is not a list must be rejected"
+
+    def test_a_well_formed_crons_shape_still_passes(self, home, tmp_path) -> None:
+        import json as _json
+
+        parsed = _json.loads('{"jobs": [{"name": "a"}, {"name": "b"}]}')
+        assert snap._usable_cron_shape(parsed, tmp_path / "crons.json") is True
+
+    def test_an_absent_jobs_key_is_not_invented(self, home, tmp_path) -> None:
+        """A missing `jobs` key keeps its meaning of "no jobs" -- usable, not rejected."""
+        import json as _json
+
+        parsed = _json.loads('{"other": 1}')
+        assert snap._usable_cron_shape(parsed, tmp_path / "crons.json") is True
+
+    def test_the_merge_reader_never_sees_a_bad_entry(self, home, tmp_path, capsys):
+        """End to end: a malformed jobs list is skipped and live crons are left intact.
+
+        The merge does not crash and does not corrupt the operator's crons -- it skips the
+        unusable file and reports the rest complete, which is the M1 skip-and-continue
+        contract (not the old whole-restore refusal).
+        """
+        (home / "crons.json").write_text('{"jobs": [{"name": "mine"}]}', encoding="utf-8")
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        payload.mkdir(parents=True)
+        (payload / "crons.json").write_text('{"jobs": ["x"]}', encoding="utf-8")
+        (payload / "MANIFEST.json").write_text(
+            json.dumps({"version": 3, "components": {"crons": "unresolved"}}),
+            encoding="utf-8",
+        )
+        bundle = tmp_path / "b.tar.gz"
+        with tarfile.open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "merge", "--force", "--components", "crons"] + unpinnable_argv()
+        )
+        out = capsys.readouterr().out
+        # 0, not 1: the merger SKIPS an unusable crons file and carries on with the rest of
+        # the restore. Asserted rather than left implicit, because the return code is exactly
+        # what this contract changed -- an earlier revision refused the whole restore here,
+        # which turned one misshapen component into a failed restore of every other one.
+        assert rc == 0, out
+        assert "Traceback" not in out, out
+        assert '{"jobs": [{"name": "mine"}]}' == (home / "crons.json").read_text(
+            encoding="utf-8"
+        ), "live crons were modified despite the incoming file being unusable"
+
+
+class TestTheUploadPathDoesNotConsultConfigAtAll:
+    def test_the_switch_is_read_through_the_redactor_not_the_config(self):
+        """Stronger than the import-placement rule this replaces.
+
+        That rule pinned WHERE the config import sat, to stop a hoist-back. The upload path
+        no longer reads config at all: the redaction opt-out moved behind the keystone fence
+        on the backup directory, because a switch in agent-writable `config.json` is one the
+        agent can flip to publish live credentials through a sanctioned path. So the thing
+        worth pinning is that no config read comes back here in any form.
+        """
+        import inspect
+
+        src = inspect.getsource(snap._redacted_upload_copy)
+        assert "outbound_redaction_enabled()" in src
+        assert "KiroCrewConfig" not in src, "a config read came back to the upload path"
+        assert "from kiro_crew.config.loader import" not in src
+        assert not hasattr(
+            snap, "KiroCrewConfig"
+        ), "the module-scope config import is unused now and must not linger"
+
+    def test_the_schema_query_uses_the_current_table_name(self):
+        """The codebase already queries `sqlite_schema`; this module matches it."""
+        source = Path(redact.__file__).read_text(encoding="utf-8")
+        assert "sqlite_schema" in source, source[:0]
+        assert argparse  # namespace kept meaningful for the upload-path callers above

--- a/test/test_snapshot_cycle5m_fixes.py
+++ b/test/test_snapshot_cycle5m_fixes.py
@@ -1,0 +1,293 @@
+"""Redaction must read what a value holds, and must not delete files it does not own."""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import snapshot as snap
+from kiro_crew import snapshot_redact as redact
+
+KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _stage(tmp_path: Path) -> Path:
+    stage = tmp_path / "bundle"
+    stage.mkdir()
+    (stage / "MANIFEST.json").write_text(json.dumps({"components": {}}), encoding="utf-8")
+    return stage
+
+
+def _db(path: Path, body: object, vec: bytes | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with redact.sqlite3.connect(str(path)) as conn:
+        conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, body TEXT, vec BLOB)")
+        conn.execute("INSERT INTO items(body, vec) VALUES(?, ?)", (body, vec))
+        conn.commit()
+    conn.close()
+
+
+class TestAByteValuedCredentialIsRedacted:
+    """A column's declared type does not decide what it holds."""
+
+    def test_a_credential_stored_as_bytes_leaves_no_trace_in_the_file(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        _db(db, f"key={KEY}".encode("utf-8"))
+
+        redact.redact_bundle_for_egress(stage)
+
+        assert KEY.encode("utf-8") not in db.read_bytes()
+
+    def test_the_value_keeps_its_type_so_readers_still_see_bytes(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        _db(db, f"key={KEY}".encode("utf-8"))
+
+        redact.redact_bundle_for_egress(stage)
+
+        with redact.sqlite3.connect(str(db)) as conn:
+            body = conn.execute("SELECT body FROM items").fetchone()[0]
+        conn.close()
+        assert isinstance(body, bytes)
+        assert KEY not in body.decode("latin-1")
+
+    def test_a_real_binary_blob_survives_byte_for_byte(self, tmp_path: Path) -> None:
+        """Embeddings are blobs. Redacting must not rewrite one that holds no credential."""
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        embedding = struct.pack("<8f", *[0.125 * i for i in range(8)])
+        _db(db, f"key={KEY}", embedding)
+
+        redact.redact_bundle_for_egress(stage)
+
+        with redact.sqlite3.connect(str(db)) as conn:
+            vec = conn.execute("SELECT vec FROM items").fetchone()[0]
+            assert conn.execute("PRAGMA integrity_check;").fetchone()[0] == "ok"
+        conn.close()
+        assert vec == embedding
+
+    def test_binary_around_a_credential_refuses_instead_of_shifting_it(
+        self, tmp_path: Path
+    ) -> None:
+        """This used to assert the blob was REWRITTEN with its surrounding bytes intact.
+
+        Both assertions it made were true and neither could see the defect: replacement is
+        variable-length, so the head and tail bytes were still present and still at the two
+        ends while everything between them had MOVED. A length prefix or an offset table in
+        such a value is silently invalidated, and the corrupted database went off-host
+        reported as clean. Structurally binary values are refused now.
+        """
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        head, tail = b"\xff\xfe\x80", b"\x00\x81\xff"
+        blob = head + KEY.encode("ascii") + tail
+        _db(db, "x", blob)
+
+        with pytest.raises(redact.PayloadDatabaseUnprovable):
+            redact.redact_bundle_for_egress(stage)
+
+        with redact.sqlite3.connect(str(db)) as conn:
+            vec = bytes(conn.execute("SELECT vec FROM items").fetchone()[0])
+        conn.close()
+        assert vec == blob, "the value was rewritten despite the refusal"
+
+    def test_non_ascii_text_stored_as_bytes_is_still_redacted_byte_exactly(
+        self, tmp_path: Path
+    ) -> None:
+        """The codec claim, moved to the branch that still rewrites.
+
+        Only a byte-preserving codec can round-trip a value that is not pure ASCII: the
+        patterns are ASCII, so latin-1 lets them match inside the bytes while every other
+        byte comes back unchanged. This value is text-shaped -- valid UTF-8, no NUL -- so it
+        is rewritten rather than refused, and the non-ASCII text around the credential has
+        to survive exactly.
+        """
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        head = "backup note: ".encode("utf-8") + b"\xc3\xa9\xc3\xa8"
+        tail = b"\xc3\xbc" + " end".encode("utf-8")
+        _db(db, "x", head + KEY.encode("ascii") + tail)
+
+        redact.redact_bundle_for_egress(stage)
+
+        with redact.sqlite3.connect(str(db)) as conn:
+            vec = bytes(conn.execute("SELECT vec FROM items").fetchone()[0])
+        conn.close()
+        assert KEY.encode("ascii") not in vec
+        assert vec.startswith(head), "leading non-ASCII text was re-encoded"
+        assert vec.endswith(tail), "trailing non-ASCII text was re-encoded"
+
+
+class TestTheOperatorsOwnFilesAreNotDeleted:
+    """The special names are the product's, at the product's paths — not anyone's basename."""
+
+    def test_a_workspace_file_sharing_a_secrets_name_survives(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        mine = stage / "workspace" / "projects" / "telemetry_salt"
+        mine.parent.mkdir(parents=True)
+        mine.write_text("my own notes\n", encoding="utf-8")
+
+        redact.redact_bundle_for_egress(stage)
+
+        assert mine.is_file()
+
+    def test_a_db_that_is_not_sqlite_is_refused_not_removed(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        mine = stage / "workspace" / "projects" / "notes.db"
+        mine.parent.mkdir(parents=True)
+        mine.write_bytes(b"\xff\xfe not sqlite \x00")
+
+        with pytest.raises(redact.OpaqueFilesPresent) as caught:
+            redact.redact_bundle_for_egress(stage)
+
+        assert "workspace/projects/notes.db" in caught.value.paths
+        assert mine.is_file(), "an operator's file must never be deleted to protect them"
+
+    def test_a_workspace_file_named_like_the_derived_index_survives(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        mine = stage / "workspace" / "projects" / "memory_index.db"
+        mine.parent.mkdir(parents=True)
+        mine.write_bytes(b"\xff\xfe mine \x00")
+
+        with pytest.raises(redact.OpaqueFilesPresent):
+            redact.redact_bundle_for_egress(stage)
+
+        assert mine.is_file()
+
+
+class TestTheProductsOwnFilesStillGo:
+    """Narrowing the match must not stop the real secret files from being dropped."""
+
+    def test_the_root_secret_and_derived_index_are_still_dropped(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        (stage / "telemetry_salt").write_text("real\n", encoding="utf-8")
+        idx = stage / "memory_index.db"
+        _db(idx, "x")
+
+        report = redact.redact_bundle_for_egress(stage)
+
+        assert not (stage / "telemetry_salt").exists()
+        assert not idx.exists()
+        assert "telemetry_salt" in report.dropped
+        assert "memory_index.db" in report.rebuilt_indexes
+
+    def test_an_unreadable_product_database_refuses_the_upload(self, tmp_path: Path) -> None:
+        """Refused rather than dropped.
+
+        A database this pass cannot prove clean is REFUSED, not deleted. Removing it
+        and uploading the remainder produces an off-host copy that reports success
+        and restores nothing -- the failure the feature exists to prevent -- so what
+        this pins is that the upload stops and the file survives to be dealt with.
+        """
+        stage = _stage(tmp_path)
+        db = stage / "workspace" / "knowledge" / "knowledge.db"
+        db.parent.mkdir(parents=True)
+        db.write_bytes(b"\xff\xfe not sqlite \x00")
+
+        with pytest.raises(redact.PayloadDatabaseUnprovable) as e:
+            redact.redact_bundle_for_egress(stage)
+
+        assert "workspace/knowledge/knowledge.db" in e.value.paths
+        assert db.exists()
+
+
+class TestTheSchemaTextIsScannedToo:
+    """A row scan never sees the DDL, and a credential can be written into it."""
+
+    @pytest.mark.parametrize(
+        "ddl",
+        [
+            pytest.param(f"CREATE TABLE t(x TEXT DEFAULT '{KEY}')", id="column-default"),
+            pytest.param(f"CREATE VIEW v AS SELECT '{KEY}' AS leaked", id="view-body"),
+            pytest.param(
+                "CREATE TRIGGER tr AFTER INSERT ON t BEGIN " f"UPDATE t SET x='{KEY}'; END",
+                id="trigger-body",
+            ),
+        ],
+    )
+    def test_a_credential_in_the_schema_stops_the_product_database(
+        self, tmp_path: Path, ddl: str
+    ) -> None:
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        with redact.sqlite3.connect(str(db)) as conn:
+            conn.execute("CREATE TABLE t(x TEXT)")
+            if not ddl.startswith("CREATE TABLE t("):
+                conn.execute(ddl)
+            else:
+                conn.execute("DROP TABLE t")
+                conn.execute(ddl)
+            conn.commit()
+        conn.close()
+
+        with pytest.raises(redact.PayloadDatabaseUnprovable) as e:
+            redact.redact_bundle_for_egress(stage)
+
+        assert "memory.db" in e.value.paths
+        assert db.exists(), "the payload was deleted instead of the upload being refused"
+
+    def test_an_operator_database_is_refused_and_kept(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        mine = stage / "workspace" / "projects" / "mine.db"
+        mine.parent.mkdir(parents=True)
+        with redact.sqlite3.connect(str(mine)) as conn:
+            conn.execute(f"CREATE TABLE t(x TEXT DEFAULT '{KEY}')")
+            conn.commit()
+        conn.close()
+
+        with pytest.raises(redact.OpaqueFilesPresent) as caught:
+            redact.redact_bundle_for_egress(stage)
+
+        assert "workspace/projects/mine.db" in caught.value.paths
+        assert mine.is_file()
+
+    def test_the_products_own_schema_does_not_trip_the_scan(self, tmp_path: Path) -> None:
+        """The guard against a refusal that would reject every real upload.
+
+        The product's databases carry FTS triggers and virtual-table DDL. If any of that
+        matched, this rule would drop the very databases the backup exists to carry.
+        """
+        stage = _stage(tmp_path)
+        db = stage / "workspace" / "knowledge" / "knowledge.db"
+        db.parent.mkdir(parents=True)
+        with redact.sqlite3.connect(str(db)) as conn:
+            conn.executescript("""
+                CREATE TABLE items(rowid INTEGER PRIMARY KEY, body TEXT);
+                CREATE VIRTUAL TABLE items_fts
+                  USING fts5(body, content=items, content_rowid=rowid);
+                CREATE TRIGGER items_ai AFTER INSERT ON items BEGIN
+                  INSERT INTO items_fts(rowid, body) VALUES (new.rowid, new.body);
+                END;
+                """)
+            conn.execute("INSERT INTO items(body) VALUES(?)", (f"key {KEY} here",))
+            conn.commit()
+        conn.close()
+
+        report = redact.redact_bundle_for_egress(stage)
+
+        assert db.is_file(), "a normal product database was dropped"
+        assert report.dropped == []
+        assert KEY.encode("ascii") not in db.read_bytes()
+        with redact.sqlite3.connect(str(db)) as conn:
+            assert conn.execute("PRAGMA integrity_check;").fetchone()[0] == "ok"
+            assert conn.execute("SELECT count(*) FROM items").fetchone()[0] == 1
+        conn.close()
+
+
+class TestTheProductPathSetCannotGoStale:
+    def test_it_matches_the_databases_the_snapshot_actually_declares(self) -> None:
+        declared = {"memory.db"} | set(snap.PRODUCT_TREE_DATABASES)
+        assert set(redact._PRODUCT_DATABASES) == declared
+
+    def test_the_special_files_are_matched_by_path_not_basename(self) -> None:
+        src = Path(redact.__file__).read_text(encoding="utf-8")
+        for group in ("_DROP_ENTIRELY", "_DERIVED_INDEXES"):
+            assert f"rel in {group}" in src
+            assert f"name in {group}" not in src, (
+                f"{group} matched on a basename would delete an operator file that "
+                "merely shares the name"
+            )

--- a/test/test_snapshot_cycle5n_fixes.py
+++ b/test/test_snapshot_cycle5n_fixes.py
@@ -1,0 +1,150 @@
+"""A rollback copy must be faithful; an archive's member names must be clean too."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+from kiro_crew import snapshot_redact as redact
+
+KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _tree_with_nested_link(tmp_path: Path) -> Path:
+    live = tmp_path / "workspace"
+    (live / "sub").mkdir(parents=True)
+    (live / "sub" / "real.md").write_text("mine\n", encoding="utf-8")
+    (live / "sub" / "pointer.md").symlink_to(live / "sub" / "real.md")
+    return live
+
+
+class TestARollbackSaveRefusesATreeWithALink:
+    """A rollback set must never hold a link — so the SAVE refuses one, up front.
+
+    The premise changed with the descriptor-pinned staging module. The rollback copy
+    used to PRESERVE links (a link the copy dropped was a link recovery deleted). Now
+    the save (`_backup_tree_or_refuse`) reports a skipped entry as FATAL, so a tree
+    containing a link is REFUSED before any incomplete rollback set is written — and
+    because the save happens in phase one, before any live mutation, the refusal leaves
+    the data home untouched. The consequence is that nothing in a rollback directory can
+    contain a link, so the RESTORE no longer needs a link-preserving copy: it uses
+    `_copytree_safe`, and there is nothing for it to preserve on the way back.
+    """
+
+    def test_a_nested_link_makes_the_save_refuse(self, tmp_path: Path) -> None:
+        live = _tree_with_nested_link(tmp_path)
+        backup = tmp_path / "backup" / "workspace"
+        backup.parent.mkdir(parents=True)
+
+        with pytest.raises(snap.pinned_fs.PinnedPathRefusal):
+            snap._backup_tree_or_refuse(live, backup)
+
+    def test_the_link_is_not_followed_when_the_save_refuses(self, tmp_path: Path) -> None:
+        """Refusing must not mean dereferencing: nothing outside the tree may be read."""
+        outside = tmp_path / "outside-secret"
+        outside.write_text("not part of the tree\n", encoding="utf-8")
+        live = tmp_path / "workspace"
+        live.mkdir()
+        (live / "escape").symlink_to(outside)
+        backup = tmp_path / "backup" / "workspace"
+        backup.parent.mkdir(parents=True)
+
+        with pytest.raises(snap.pinned_fs.PinnedPathRefusal):
+            snap._backup_tree_or_refuse(live, backup)
+
+        # The refusal read the link's own name, never its target's contents.
+        copied = backup / "escape"
+        assert not copied.is_file() or "not part of the tree" not in copied.read_text(
+            encoding="utf-8"
+        )
+
+    def test_the_egress_copy_still_drops_links(self, tmp_path: Path) -> None:
+        """The staging change must not relax the copy that feeds the uploaded bundle.
+
+        `_copytree_safe` now delegates to the descriptor-pinned primitive, whose
+        documented contract is that the caller creates the destination's parent -- so
+        `out.parent` is made first, then the copy runs and must still drop the link.
+        """
+        live = _tree_with_nested_link(tmp_path)
+        out = tmp_path / "egress" / "workspace"
+        out.parent.mkdir(parents=True)
+
+        snap._copytree_safe(live, out, allow_unpinned=bool(unpinnable_argv()))
+
+        assert (out / "sub" / "real.md").is_file()
+        assert not (out / "sub" / "pointer.md").exists(), "a link reached the bundle"
+
+    def test_the_rollback_restore_uses_the_ordinary_staging_copy(self) -> None:
+        """BOTH directions of the round-trip route through `_copytree_safe`.
+
+        The save refuses any tree with a link, so whatever lands in the rollback
+        directory is links-free by construction and the recovery copy has nothing to
+        preserve. Inverts the earlier guard, which forbade `_copytree_safe` on the
+        rollback path back when a bespoke link-preserving copy lived there: the property
+        now is that the recovery copy IS `_copytree_safe`, and that the save that feeds
+        it is the fatal-reporter refusal rather than a silent link-dropping copy.
+        """
+        setup = inspect.getsource(snap._do_replace)
+        recovery = inspect.getsource(snap._restore_everything_from_rollback)
+
+        # The save that feeds the rollback set must refuse, not silently drop links.
+        assert "_backup_tree_or_refuse(" in setup, (
+            "the rollback save no longer refuses a tree with a link; an incomplete "
+            "rollback set could be written and then rmtree'd over"
+        )
+        # The recovery copy is the ordinary staging copy, deliberately.
+        assert "_copytree_safe(" in recovery, (
+            "recovery must restore with _copytree_safe now that the save guarantees the "
+            "rollback set holds no links"
+        )
+        # The deleted link-preserving helper must not reappear on either half.
+        assert "_copytree_rollback" not in setup + recovery, (
+            "the link-preserving rollback copy was removed; its premise (a saved link to "
+            "recreate) no longer exists because the save refuses links"
+        )
+
+    def test_the_refusal_type_is_contained_by_restore(self) -> None:
+        """restore_main catches this refusal and turns it into a clean rc=1.
+
+        The old helper raised a bespoke OSError subclass so restore's IO handling would
+        report it. The save now raises `PinnedPathRefusal`, which `restore_main` catches
+        explicitly (alongside `UnsafeComponentRoot`), so an incomplete-rollback refusal
+        still becomes a reported refusal rather than a traceback.
+        """
+        restore_src = inspect.getsource(snap.restore_main)
+        assert "except pinned_fs.PinnedPathRefusal" in restore_src
+
+
+class TestArchiveMemberNamesAreScanned:
+    def test_a_credential_in_a_filename_refuses_the_upload(self, tmp_path: Path) -> None:
+        """Contents can be spotless while the tar's member name carries the key."""
+        stage = tmp_path / "bundle"
+        stage.mkdir()
+        (stage / "MANIFEST.json").write_text(json.dumps({"components": {}}), encoding="utf-8")
+        bad = stage / "workspace" / f"creds-{KEY}.md"
+        bad.parent.mkdir(parents=True)
+        bad.write_text("contents are clean\n", encoding="utf-8")
+
+        with pytest.raises(redact.OpaqueFilesPresent) as caught:
+            redact.redact_bundle_for_egress(stage)
+
+        assert any(KEY in p for p in caught.value.paths)
+        assert bad.is_file(), "an operator's file must not be deleted for its name"
+
+    def test_an_ordinary_name_is_untouched(self, tmp_path: Path) -> None:
+        stage = tmp_path / "bundle"
+        stage.mkdir()
+        (stage / "MANIFEST.json").write_text(json.dumps({"components": {}}), encoding="utf-8")
+        ok = stage / "workspace" / "notes.md"
+        ok.parent.mkdir(parents=True)
+        ok.write_text("nothing to see\n", encoding="utf-8")
+
+        report = redact.redact_bundle_for_egress(stage)
+
+        assert ok.is_file()
+        assert report.dropped == []

--- a/test/test_snapshot_cycle5o_fixes.py
+++ b/test/test_snapshot_cycle5o_fixes.py
@@ -1,0 +1,171 @@
+"""The manifest leaves the host too, and an UPDATE can put back what it just removed."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import snapshot_redact as redact
+
+KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _stage(tmp_path: Path, manifest: dict | None = None) -> Path:
+    stage = tmp_path / "bundle"
+    stage.mkdir()
+    (stage / "MANIFEST.json").write_text(
+        json.dumps(manifest if manifest is not None else {"components": {}}),
+        encoding="utf-8",
+    )
+    return stage
+
+
+class TestTheManifestIsRedactedToo:
+    """It is the one file guaranteed to be in the upload."""
+
+    def test_a_credential_in_the_manifest_does_not_leave(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path, {"components": {}, "home": f"/home/{KEY}/crew"})
+
+        redact.redact_bundle_for_egress(stage)
+
+        assert KEY not in (stage / "MANIFEST.json").read_text(encoding="utf-8")
+
+    def test_it_stays_valid_json_so_the_bundle_stays_restorable(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path, {"components": {"memory": "ok"}, "note": f"k={KEY}"})
+
+        redact.redact_bundle_for_egress(stage)
+
+        data = json.loads((stage / "MANIFEST.json").read_text(encoding="utf-8"))
+        assert data["components"] == {"memory": "ok"}
+
+    def test_the_scan_runs_after_the_stamp_so_it_covers_what_the_stamp_wrote(
+        self, tmp_path: Path
+    ) -> None:
+        """The stamp writes paths and error text, so scanning before it would miss them."""
+        import inspect
+
+        src = inspect.getsource(redact.redact_bundle_for_egress)
+        assert src.index("_stamp_manifest(") < src.index("_redact_manifest(")
+
+    def test_the_replacement_is_reported(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path, {"components": {}, "home": f"/home/{KEY}/crew"})
+
+        report = redact.redact_bundle_for_egress(stage)
+
+        assert report.replacements.get("MANIFEST.json")
+
+    def test_a_scrub_that_would_break_the_json_refuses(self, tmp_path: Path, monkeypatch) -> None:
+        """Today's tag keeps the JSON valid; the guard is what makes that a checked fact.
+
+        No real input can break it, because the replacement carries no quote or backslash.
+        So the guard is exercised where it is decided -- by substituting a replacement that
+        does -- rather than left as an assertion nothing runs.
+        """
+        stage = _stage(tmp_path, {"components": {}, "home": f"/home/{KEY}/crew"})
+        monkeypatch.setattr(
+            redact, "_scrub", lambda text: (text.replace(KEY, '"'), 1) if KEY in text else (text, 0)
+        )
+
+        try:
+            redact.redact_bundle_for_egress(stage)
+        except Exception as e:  # the private refusal type is an implementation detail
+            assert "MANIFEST.json" in str(e)
+        else:
+            raise AssertionError("an unparseable manifest was written")
+
+        assert json.loads((stage / "MANIFEST.json").read_text(encoding="utf-8"))
+
+
+class TestATriggerCannotPutBackWhatWasRemoved:
+    def test_a_trigger_copying_the_old_value_is_still_cleaned(self, tmp_path: Path) -> None:
+        """One pass cleans `items`; the trigger then refills `audit`, already scanned."""
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        with redact.sqlite3.connect(str(db)) as conn:
+            conn.executescript("""
+                CREATE TABLE audit(note TEXT);
+                CREATE TABLE items(id INTEGER PRIMARY KEY, body TEXT);
+                CREATE TRIGGER keep_old AFTER UPDATE ON items BEGIN
+                  INSERT INTO audit(note) VALUES (OLD.body);
+                END;
+                """)
+            conn.execute("INSERT INTO items(body) VALUES(?)", (f"secret {KEY} here",))
+            conn.commit()
+        conn.close()
+
+        redact.redact_bundle_for_egress(stage)
+
+        assert db.is_file(), "a settling database must still ship"
+        assert KEY.encode("ascii") not in db.read_bytes()
+
+    def test_a_database_that_never_settles_is_refused(self, tmp_path: Path) -> None:
+        """The trigger names no credential, so only the value scan can see the loop."""
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        with redact.sqlite3.connect(str(db)) as conn:
+            conn.executescript("""
+                CREATE TABLE t(id INTEGER PRIMARY KEY, body TEXT);
+                CREATE TRIGGER never AFTER UPDATE ON t BEGIN
+                  INSERT INTO t(body) VALUES (OLD.body);
+                END;
+                """)
+            conn.execute("INSERT INTO t(body) VALUES(?)", (f"{KEY} start",))
+            conn.commit()
+        conn.close()
+
+        with pytest.raises(redact.PayloadDatabaseUnprovable) as e:
+            redact.redact_bundle_for_egress(stage)
+
+        assert "memory.db" in e.value.paths
+        assert db.exists(), "the payload was deleted instead of the upload being refused"
+        # The reason travels with the refusal, so the operator learns WHY it stopped.
+        assert any("did not settle" in d for d in e.value.details)
+
+    def test_the_products_own_fts_triggers_do_not_trip_it(self, tmp_path: Path) -> None:
+        """The guard against a fixpoint rule that refuses every real backup.
+
+        The product's search schema is maintained BY triggers, including on UPDATE. If
+        those counted as non-settling, this rule would drop the databases the backup
+        exists to carry.
+        """
+        stage = _stage(tmp_path)
+        db = stage / "workspace" / "knowledge" / "knowledge.db"
+        db.parent.mkdir(parents=True)
+        with redact.sqlite3.connect(str(db)) as conn:
+            conn.executescript("""
+                CREATE TABLE items(rowid INTEGER PRIMARY KEY, body TEXT);
+                CREATE VIRTUAL TABLE items_fts
+                  USING fts5(body, content=items, content_rowid=rowid);
+                CREATE TRIGGER items_ai AFTER INSERT ON items BEGIN
+                  INSERT INTO items_fts(rowid, body) VALUES (new.rowid, new.body);
+                END;
+                CREATE TRIGGER items_au AFTER UPDATE ON items BEGIN
+                  INSERT INTO items_fts(items_fts, rowid, body)
+                    VALUES('delete', old.rowid, old.body);
+                  INSERT INTO items_fts(rowid, body) VALUES (new.rowid, new.body);
+                END;
+                """)
+            conn.execute("INSERT INTO items(body) VALUES(?)", (f"key {KEY} here",))
+            conn.commit()
+        conn.close()
+
+        report = redact.redact_bundle_for_egress(stage)
+
+        assert db.is_file(), "a normal product database was dropped"
+        assert report.dropped == []
+        assert KEY.encode("ascii") not in db.read_bytes()
+        with redact.sqlite3.connect(str(db)) as conn:
+            assert conn.execute("PRAGMA integrity_check;").fetchone()[0] == "ok"
+            found = conn.execute(
+                "SELECT count(*) FROM items_fts WHERE items_fts MATCH ?", (KEY,)
+            ).fetchone()[0]
+            assert found == 0, "the index still answers a search for the credential"
+            assert (
+                conn.execute(
+                    "SELECT count(*) FROM items_fts WHERE items_fts MATCH 'key'"
+                ).fetchone()[0]
+                == 1
+            ), "ordinary search stopped working"
+        conn.close()

--- a/test/test_snapshot_cycle5q_fixes.py
+++ b/test/test_snapshot_cycle5q_fixes.py
@@ -1,0 +1,152 @@
+"""A merge never overwrites, never follows a link into the destination, and a URL is
+escaped before printing.
+
+Retargeted for M1: `_copy_tree_no_overwrite` no longer stages a `.partial` file and
+publishes it with `os.link` -- that design was proven exploitable and removed (see
+`pinned_fs.copy_file_pinned`'s docstring). It now writes each file straight to its final
+name with `O_CREAT|O_EXCL|O_NOFOLLOW`, so the properties below are asserted against that
+primitive's observable behaviour rather than the deleted staging mechanism.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import pinned_fs
+from kiro_crew import snapshot as snap
+
+
+class TestAFailedMergeCopyLeavesNoTruncatedTarget:
+    """The merge skips existing targets, so a target it wrote must be the real bytes."""
+
+    def test_a_failed_write_does_not_masquerade_as_a_completed_merge(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If a per-file copy raises, the merge must not report success over the gap.
+
+        The exclusive-create write has no publish step to interrupt, so the failure the
+        old `.partial` design guarded against is gone; what still matters is that a copy
+        error propagates rather than being swallowed, so nothing downstream treats the
+        absent file as merged. Once the transient condition clears, a retry completes.
+        """
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "memory.md").write_text("the real content\n", encoding="utf-8")
+        dst = tmp_path / "dst"
+        dst.mkdir()
+
+        real = pinned_fs.copy_file_pinned
+        calls = {"n": 0}
+
+        def flaky(*a, **kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError(28, "No space left on device")
+            return real(*a, **kw)
+
+        monkeypatch.setattr(snap.pinned_fs, "copy_file_pinned", flaky)
+        with pytest.raises(OSError):
+            snap._copy_tree_no_overwrite(src, dst, allow_unpinned=bool(unpinnable_argv()))
+
+        # The retry, once the disk is fine, completes properly and the target holds the
+        # real bytes -- not a truncated remnant of the failed attempt.
+        monkeypatch.setattr(snap.pinned_fs, "copy_file_pinned", real)
+        snap._copy_tree_no_overwrite(src, dst, allow_unpinned=bool(unpinnable_argv()))
+        assert (dst / "memory.md").read_text(encoding="utf-8") == "the real content\n"
+
+    def test_an_existing_target_is_still_not_overwritten(self, tmp_path: Path) -> None:
+        """No-overwrite is the promise: a target already present is left as-is."""
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "keep.md").write_text("from the bundle\n", encoding="utf-8")
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        (dst / "keep.md").write_text("mine, already here\n", encoding="utf-8")
+
+        snap._copy_tree_no_overwrite(src, dst, allow_unpinned=bool(unpinnable_argv()))
+
+        assert (dst / "keep.md").read_text(encoding="utf-8") == "mine, already here\n"
+
+    def test_the_write_is_exclusive_create_not_an_unconditional_rename(self) -> None:
+        """Atomicity must not be bought with an overwriting publish.
+
+        An `os.replace` (or an `os.link` publish of a `.partial`) is atomic AND
+        unconditional, so it would trade a truncated file for a destroyed one in a mode
+        whose whole contract is that it adds only what is missing. The primitive instead
+        opens the destination `O_CREAT|O_EXCL`, which refuses when the target exists, so
+        this pins the exclusive create and the absence of an unconditional publish.
+        """
+        code = "\n".join(
+            line
+            for line in inspect.getsource(snap._copy_tree_no_overwrite).splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        assert "skip_existing=True" in code, "the merge write is not the no-overwrite form"
+        assert "os.replace(" not in code, "an unconditional rename can destroy live data"
+        assert "os.link(" not in code, "the exploitable link-publish design must not return"
+        prim = inspect.getsource(pinned_fs.copy_file_pinned)
+        assert "O_EXCL" in prim, "the destination is not created exclusively"
+
+
+class TestTheMergeDoesNotWriteThroughALink:
+    """Making the write refuse a present target must not open a way to escape the tree."""
+
+    def test_it_does_not_write_through_a_link_planted_at_the_target_name(
+        self, tmp_path: Path
+    ) -> None:
+        """A destination name pre-occupied by a LINK must not have bytes written through it.
+
+        `O_NOFOLLOW` on the exclusive create refuses the link outright rather than
+        following it to whatever it points at outside the tree.
+        """
+        outside = tmp_path / "outside.txt"
+        outside.write_text("must not be overwritten\n", encoding="utf-8")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "note.md").write_text("from the bundle\n", encoding="utf-8")
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        (dst / "note.md").symlink_to(outside)
+
+        snap._copy_tree_no_overwrite(src, dst, allow_unpinned=bool(unpinnable_argv()))
+
+        assert (
+            outside.read_text(encoding="utf-8") == "must not be overwritten\n"
+        ), "the merge write followed a link and left the destination tree"
+
+    def test_no_scratch_file_survives_a_successful_merge(self, tmp_path: Path) -> None:
+        """The write is direct-to-final, so a completed merge leaves only the real files."""
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "a.md").write_text("x\n", encoding="utf-8")
+        dst = tmp_path / "dst"
+        dst.mkdir()
+
+        snap._copy_tree_no_overwrite(src, dst, allow_unpinned=bool(unpinnable_argv()))
+
+        assert sorted(p.name for p in dst.iterdir()) == ["a.md"]
+
+
+class TestTheDownloadBannerIsEscaped:
+    def test_a_control_byte_in_the_url_does_not_reach_the_terminal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """It is printed before the URL has been validated, so it is escaped first."""
+        hostile = "s3://bucket/\x1b[2Jkey.tar.gz"
+
+        monkeypatch.setattr(snap, "_default_snapshot_dir", lambda: str(tmp_path))
+        rc = snap.restore_main([hostile, "--force"])
+
+        out = capsys.readouterr().out
+        assert "\x1b" not in out, "a raw escape sequence reached the terminal"
+        assert rc != 0 or "Downloading" in out
+
+    def test_the_banner_routes_through_the_escaper(self) -> None:
+        src = inspect.getsource(snap.restore_main)
+        assert (
+            "_safe_name(str(args.snapshot))" in src
+        ), "the caller-supplied snapshot argument is printed unescaped"

--- a/test/test_snapshot_cycle5r_fixes.py
+++ b/test/test_snapshot_cycle5r_fixes.py
@@ -1,0 +1,123 @@
+"""A rollback is a round-trip, and an empty file is not a healthy database."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+class TestRecoveryRefusesToSaveATreeItCannotCopyWhole:
+    """The rollback SAVE is `_backup_tree_or_refuse`, and it must refuse a link.
+
+    Superseded contract: the old `_copytree_rollback` preserved a symlink so a
+    save-then-restore round trip kept it. That helper is gone. Replace mode runs
+    `rmtree` on the live tree AFTER the save, so a symlink the save cannot faithfully copy
+    is a file the restore would delete with nothing to put back. `_backup_tree_or_refuse`
+    therefore reports a skipped link as FATAL and REFUSES the whole save before any
+    mutation, rather than making a partial backup. Refusing is the stronger guarantee, so
+    this pins the refusal -- not the old preservation.
+    """
+
+    def test_a_tree_with_a_link_is_refused_rather_than_partially_backed_up(
+        self, tmp_path: Path
+    ) -> None:
+        live = tmp_path / "home" / "workspace"
+        (live / "sub").mkdir(parents=True)
+        (live / "sub" / "real.md").write_text("mine\n", encoding="utf-8")
+        (live / "sub" / "pointer.md").symlink_to(live / "sub" / "real.md")
+
+        backup = tmp_path / "rollback"
+        backup.mkdir(parents=True)
+        saved = backup / "workspace"
+        with pytest.raises(snap.pinned_fs.PinnedPathRefusal):
+            snap._backup_tree_or_refuse(live, saved)
+
+        # And the live tree is untouched -- the refusal arrives before any delete.
+        assert (live / "sub" / "real.md").is_file()
+        assert (live / "sub" / "pointer.md").is_symlink()
+
+    def test_an_ordinary_tree_is_backed_up_faithfully(self, tmp_path: Path) -> None:
+        """The refusal must not turn a link-free tree into a failure."""
+        live = tmp_path / "home" / "workspace"
+        (live / "sub").mkdir(parents=True)
+        (live / "sub" / "real.md").write_text("mine\n", encoding="utf-8")
+
+        backup = tmp_path / "rollback"
+        backup.mkdir(parents=True)
+        saved = backup / "workspace"
+        snap._backup_tree_or_refuse(live, saved, allow_unpinned=bool(unpinnable_argv()))
+        assert (saved / "sub" / "real.md").read_text(encoding="utf-8") == "mine\n"
+
+
+class TestAnEmptyDatabaseIsRefused:
+    """SQLite opens a zero-byte file as a valid empty database and calls it `ok`."""
+
+    def test_sqlite_really_does_call_an_empty_file_healthy(self, tmp_path: Path) -> None:
+        """The premise, pinned -- if this ever stops being true the guard can go."""
+        empty = tmp_path / "empty.db"
+        empty.touch()
+
+        with snap.closing(snap.sqlite3.connect(str(empty))) as conn:
+            assert conn.execute("PRAGMA integrity_check;").fetchone()[0] == "ok"
+
+    def test_a_zero_byte_product_database_is_refused(self, tmp_path: Path) -> None:
+        empty = tmp_path / "memory.db"
+        empty.touch()
+
+        with pytest.raises(snap.SourceComponentUnsound) as caught:
+            snap._refuse_unless_sound(empty, "memory.db", strict=True)
+
+        message = str(caught.value)
+        assert "EMPTY" in message
+        assert "report success" in message, "the refusal does not say what it prevents"
+
+    def test_a_real_database_still_passes(self, tmp_path: Path) -> None:
+        good = tmp_path / "memory.db"
+        with snap.closing(snap.sqlite3.connect(str(good))) as conn:
+            conn.execute("CREATE TABLE t(x TEXT)")
+            conn.commit()
+
+        snap._refuse_unless_sound(good, "memory.db", strict=True)
+
+    def test_the_size_check_precedes_the_open(self) -> None:
+        import inspect
+
+        src = inspect.getsource(snap._refuse_unless_sound)
+        assert src.index("st_size == 0") < src.index(
+            "sqlite3.connect("
+        ), "opening first means the empty case is already judged healthy"
+
+    def test_a_product_database_whose_size_cannot_be_read_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unreadable is not the same as fine -- for a declared database it is a refusal."""
+        db = tmp_path / "memory.db"
+        db.touch()
+
+        def cannot_stat(self, *a, **kw):
+            raise OSError("Input/output error")
+
+        monkeypatch.setattr(Path, "stat", cannot_stat)
+
+        with pytest.raises(snap.SourceComponentUnsound) as caught:
+            snap._refuse_unless_sound(db, "memory.db", strict=True)
+
+        assert "could not be read" in str(caught.value)
+
+    def test_a_non_product_db_whose_size_cannot_be_read_is_left_alone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A `.db` in the operator's own tree is not this code's business either way."""
+        db = tmp_path / "theirs.db"
+        db.touch()
+
+        def cannot_stat(self, *a, **kw):
+            raise OSError("Input/output error")
+
+        monkeypatch.setattr(Path, "stat", cannot_stat)
+
+        snap._refuse_unless_sound(db, "theirs.db", strict=False)

--- a/test/test_snapshot_cycle5t_fixes.py
+++ b/test/test_snapshot_cycle5t_fixes.py
@@ -1,0 +1,41 @@
+"""Bundle-derived paths reach a terminal in the report too, not just in the archive."""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+from kiro_crew import snapshot as snap
+from kiro_crew import snapshot_redact as redact
+
+HOSTILE = "workspace/ev\x1b[2Jil.md"
+
+
+class TestTheRedactionReportIsEscaped:
+    def test_a_hostile_path_cannot_repaint_the_report(self, capsys) -> None:
+        """The report is what the operator reads to judge the upload, so it is a target."""
+        report = redact.RedactionReport()
+        report.replacements[HOSTILE] = 3
+        report.dropped.append(HOSTILE)
+        report.skipped_unreadable.append(f"{HOSTILE} (unreadable)")
+
+        snap._report_redaction(report)
+
+        out = capsys.readouterr().out
+        assert "\x1b" not in out, "an escape sequence from a filename reached the terminal"
+        assert "il.md" in out, "the path was escaped into uselessness"
+
+    def test_every_path_in_the_report_goes_through_the_escaper(self) -> None:
+        """Structural, because the three lists are three chances to forget one."""
+        src = inspect.getsource(snap._report_redaction)
+        bare = re.findall(r"\{(?!_safe_name)(rel|d|s)\}", src)
+        assert bare == [], f"a report path is printed unescaped: {bare}"
+        assert (
+            src.count("_safe_name(") == 3
+        ), "each of replacements / dropped / skipped_unreadable must be escaped"
+
+    def test_the_dry_run_listing_is_escaped_too(self) -> None:
+        src = inspect.getsource(snap.restore_main)
+        assert (
+            "_safe_name(f.relative_to(snap).as_posix())" in src
+        ), "the dry-run list prints archive-derived paths raw"

--- a/test/test_snapshot_cycle5u_fixes.py
+++ b/test/test_snapshot_cycle5u_fixes.py
@@ -1,0 +1,146 @@
+"""A redacted row is not enough: the FILE must not carry the credential either."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kiro_crew import snapshot_redact as redact
+
+KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _stage(tmp_path: Path) -> Path:
+    stage = tmp_path / "bundle"
+    stage.mkdir()
+    (stage / "MANIFEST.json").write_text(json.dumps({"components": {}}), encoding="utf-8")
+    return stage
+
+
+def _realistic_db(path: Path) -> None:
+    """Several rows, only one carrying the secret -- the shape a real memory store has.
+
+    A single-row fixture hides the defect: rewriting the only cell happens to overwrite
+    the same bytes. With neighbours present the old cell content stays in the page's
+    unused space.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with redact.sqlite3.connect(str(path)) as conn:
+        conn.execute("CREATE TABLE semantic(id INTEGER PRIMARY KEY, key TEXT, value TEXT)")
+        conn.executemany(
+            "INSERT INTO semantic(key, value) VALUES(?, ?)",
+            [
+                ("project.terrace", "Sydney property platform"),
+                ("aws.prod", f"account key {KEY}"),
+                ("pref.lang", "Chinese for discussion, English for code"),
+            ],
+        )
+        conn.commit()
+    conn.close()
+
+
+class TestTheRedactedFileCarriesNoCredential:
+    def test_the_plaintext_is_gone_from_the_bytes_not_just_the_rows(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        _realistic_db(db)
+        assert KEY.encode("ascii") in db.read_bytes(), "fixture did not plant the secret"
+
+        redact.redact_bundle_for_egress(stage)
+
+        assert KEY.encode("ascii") not in db.read_bytes(), (
+            "every row reads redacted but the credential is still greppable in the file "
+            "that leaves the host"
+        )
+
+    def test_the_rows_and_the_database_survive_the_rebuild(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        _realistic_db(db)
+
+        redact.redact_bundle_for_egress(stage)
+
+        with redact.sqlite3.connect(str(db)) as conn:
+            assert conn.execute("PRAGMA integrity_check;").fetchone()[0] == "ok"
+            rows = dict(conn.execute("SELECT key, value FROM semantic").fetchall())
+        conn.close()
+        assert rows["project.terrace"] == "Sydney property platform"
+        assert rows["pref.lang"] == "Chinese for discussion, English for code"
+        assert KEY not in rows["aws.prod"]
+        assert "REDACTED" in rows["aws.prod"]
+
+    def test_a_credential_the_operator_already_deleted_does_not_ship(self, tmp_path: Path) -> None:
+        """The scan finds nothing to replace, and that is exactly why this leaks.
+
+        A DELETE does not erase the row -- SQLite frees the page and keeps the bytes. No
+        live row holds the credential, so a pass that only rewrites live rows reports zero
+        replacements and uploads the plaintext of a memory the operator believes is gone.
+        """
+        stage = _stage(tmp_path)
+        db = stage / "memory.db"
+        db.parent.mkdir(parents=True, exist_ok=True)
+        with redact.sqlite3.connect(str(db)) as conn:
+            conn.execute("CREATE TABLE semantic(id INTEGER PRIMARY KEY, key TEXT, value TEXT)")
+            conn.executemany(
+                "INSERT INTO semantic(key, value) VALUES(?, ?)",
+                [(f"note.{i}", f"harmless content number {i}") for i in range(40)],
+            )
+            conn.execute("INSERT INTO semantic(key, value) VALUES(?, ?)", ("aws.old", f"key {KEY}"))
+            conn.commit()
+            conn.execute("DELETE FROM semantic WHERE key = 'aws.old'")
+            conn.commit()
+        conn.close()
+        assert KEY.encode("ascii") in db.read_bytes(), "fixture did not leave a freed page"
+
+        report = redact.redact_bundle_for_egress(stage)
+
+        assert report.total == 0, "no live row holds it -- there is nothing to replace"
+        assert (
+            KEY.encode("ascii") not in db.read_bytes()
+        ), "a credential the operator deleted is still plaintext in the uploaded copy"
+
+    def test_the_surviving_rows_are_untouched_by_the_rebuild(self, tmp_path: Path) -> None:
+        stage = _stage(tmp_path)
+        db = stage / "clean.db"
+        with redact.sqlite3.connect(str(db)) as conn:
+            conn.execute("CREATE TABLE t(x TEXT, v BLOB)")
+            conn.execute("INSERT INTO t(x, v) VALUES('nothing secret here', ?)", (b"\x00\x01\x02",))
+            conn.commit()
+        conn.close()
+
+        redact.redact_bundle_for_egress(stage)
+
+        with redact.sqlite3.connect(str(db)) as conn:
+            assert conn.execute("PRAGMA integrity_check;").fetchone()[0] == "ok"
+            # Values survive verbatim -- this is what keeps stored embeddings usable.
+            assert conn.execute("SELECT x, v FROM t").fetchall() == [
+                ("nothing secret here", b"\x00\x01\x02")
+            ]
+        conn.close()
+
+    def test_the_rebuild_is_not_conditional_on_a_replacement(self) -> None:
+        """Gating it on `hits` is the defect: it protects only the rows this pass rewrote."""
+        import inspect
+        import textwrap
+
+        src = textwrap.dedent(inspect.getsource(redact._redact_database))
+        lines = [ln for ln in src.splitlines() if ln.strip()]
+        vacuum = next(i for i, ln in enumerate(lines) if 'conn.execute("VACUUM")' in ln)
+        indent = len(lines[vacuum]) - len(lines[vacuum].lstrip())
+        enclosing = [
+            ln.strip()
+            for ln in lines[:vacuum]
+            if (len(ln) - len(ln.lstrip())) < indent and ln.strip().endswith(":")
+        ]
+        assert not any(
+            "if hits" in ln or "if pass_hits" in ln for ln in enclosing
+        ), f"the rebuild is gated on a replacement having happened: {enclosing[-3:]}"
+
+    def test_the_rebuild_runs_after_the_content_is_clean(self) -> None:
+        import inspect
+
+        src = inspect.getsource(redact._redact_database)
+        assert 'conn.execute("VACUUM")' in src
+        assert src.index("UPDATE") < src.index(
+            'conn.execute("VACUUM")'
+        ), "rebuilding before the rows are cleaned would preserve the old bytes"

--- a/test/test_snapshot_cycle5v_fixes.py
+++ b/test/test_snapshot_cycle5v_fixes.py
@@ -1,0 +1,64 @@
+"""The download report is built from an untrusted manifest, so every value is escaped."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import io
+import json
+import textwrap
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from kiro_crew import snapshot as snap
+
+ESC = chr(27)
+PAYLOAD = f"{ESC}[2J{ESC}[1;1HRESTORE SUCCEEDED -- nothing was redacted"
+
+
+class TestTheDownloadReportCannotBeRepainted:
+    """The manifest comes from the downloaded bundle, so every value in it is untrusted."""
+
+    def _bundle(self, tmp_path: Path, replacements: object) -> Path:
+        (tmp_path / "MANIFEST.json").write_text(
+            json.dumps({"redaction": {"redacted": True, "replacements": replacements}}),
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    def _report(self, d: Path) -> str:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            snap._report_redacted_bundle(d)
+        return buf.getvalue()
+
+    def test_a_crafted_replacement_count_cannot_emit_terminal_controls(
+        self, tmp_path: Path
+    ) -> None:
+        """Filtering non-integers while SUMMING does not make the count safe to PRINT."""
+        out = self._report(self._bundle(tmp_path, {"memory.db": PAYLOAD}))
+        assert ESC not in out
+        assert "RESTORE SUCCEEDED" in out, "the value is still shown, just inert"
+
+    def test_a_crafted_path_cannot_emit_terminal_controls(self, tmp_path: Path) -> None:
+        out = self._report(self._bundle(tmp_path, {PAYLOAD: 3}))
+        assert ESC not in out
+
+    def test_every_interpolation_in_the_report_is_escaped_or_computed_here(self) -> None:
+        """Guards the class rather than the instance: a new raw field fails this."""
+        tree = ast.parse(textwrap.dedent(inspect.getsource(snap._report_redacted_bundle)))
+        allowed_bare = {"total", "len(reps)"}
+        raw: list[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FormattedValue):
+                continue
+            src = ast.unparse(node.value)
+            if src in allowed_bare:
+                continue
+            if (
+                isinstance(node.value, ast.Call)
+                and getattr(node.value.func, "id", "") == "_safe_name"
+            ):
+                continue
+            raw.append(src)
+        assert not raw, f"manifest-derived values printed without escaping: {raw}"

--- a/test/test_snapshot_cycle5w_fixes.py
+++ b/test/test_snapshot_cycle5w_fixes.py
@@ -1,0 +1,185 @@
+"""Two promises that were kept for one of their reasons only."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import pinned_fs
+from kiro_crew import snapshot as snap
+from kiro_crew import snapshot_redact as redact
+
+KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+class TestMergeNeverOverwrites:
+    """`merge` adds what is missing. Exclusive creation is the promise, not a hint.
+
+    Retargeted for M1: the merge no longer has a `copy2` + `os.link`/`os.replace` publish
+    with a separate no-hard-link fallback -- `_merge_exclusive_copy` is gone. Every file
+    now goes through `pinned_fs.copy_file_pinned(..., skip_existing=True)`, whose
+    destination is created `O_CREAT|O_EXCL|O_NOFOLLOW`, so "it did not exist" and "this
+    call created it" are one statement and there is no window to race.
+    """
+
+    def _tree(self, tmp_path: Path) -> tuple[Path, Path]:
+        src = tmp_path / "from-backup"
+        dst = tmp_path / "home"
+        (src / "workspace").mkdir(parents=True)
+        (dst / "workspace").mkdir(parents=True)
+        (src / "workspace" / "notes.md").write_text("FROM THE BACKUP\n", encoding="utf-8")
+        return src, dst
+
+    def test_a_missing_file_is_merged_in(self, tmp_path: Path) -> None:
+        src, dst = self._tree(tmp_path)
+        snap._copy_tree_no_overwrite(src, dst, allow_unpinned=bool(unpinnable_argv()))
+        assert (dst / "workspace" / "notes.md").read_text(encoding="utf-8") == ("FROM THE BACKUP\n")
+
+    def test_an_existing_file_is_left_alone(self, tmp_path: Path) -> None:
+        src, dst = self._tree(tmp_path)
+        target = dst / "workspace" / "notes.md"
+        target.write_text("THE OPERATOR'S WORK\n", encoding="utf-8")
+        snap._copy_tree_no_overwrite(src, dst, allow_unpinned=bool(unpinnable_argv()))
+        assert target.read_text(encoding="utf-8") == "THE OPERATOR'S WORK\n"
+
+    def test_a_target_that_appears_before_the_write_is_still_not_overwritten(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The window between deciding and writing is the whole finding.
+
+        The old `os.replace`/`os.link` publish could destroy whatever arrived in that
+        window. The exclusive create refuses it instead. This drives the real primitive:
+        `copy_file_pinned` is wrapped so the target is created by a racing writer AFTER
+        the merge decides to copy it but BEFORE the exclusive open runs -- the winner's
+        bytes must survive.
+        """
+        src, dst = self._tree(tmp_path)
+        target = dst / "workspace" / "notes.md"
+        real = snap.pinned_fs.copy_file_pinned
+
+        def create_then_copy(*a, **kw):
+            # Someone else publishes the target in the pre-write window.
+            if not target.exists():
+                target.write_text("ARRIVED MID-MERGE\n", encoding="utf-8")
+            return real(*a, **kw)
+
+        monkeypatch.setattr(snap.pinned_fs, "copy_file_pinned", create_then_copy)
+        snap._copy_tree_no_overwrite(src, dst, allow_unpinned=bool(unpinnable_argv()))
+        assert target.read_text(encoding="utf-8") == "ARRIVED MID-MERGE\n", (
+            "the exclusive create was not honoured -- a file that appeared before the "
+            "write was overwritten"
+        )
+
+    def test_no_scratch_file_is_left_behind(self, tmp_path: Path) -> None:
+        src, dst = self._tree(tmp_path)
+        (dst / "workspace" / "notes.md").write_text("THE OPERATOR'S WORK\n", encoding="utf-8")
+        snap._copy_tree_no_overwrite(src, dst, allow_unpinned=bool(unpinnable_argv()))
+        # Direct-to-final writes: no `.merge-*` or `.partial` remnant of the old publish.
+        leftovers = [
+            p.name
+            for p in (dst / "workspace").iterdir()
+            if p.name.startswith((".merge-", ".partial", ".")) and p.name != "notes.md"
+        ]
+        assert leftovers == [], leftovers
+
+    def test_the_merge_write_is_exclusive_create_not_a_publish(self) -> None:
+        code = "\n".join(
+            line
+            for line in inspect.getsource(snap._copy_tree_no_overwrite).splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        assert "skip_existing=True" in code, "the merge no longer requests the no-overwrite form"
+        assert "os.replace" not in code, "an unconditional rename cannot keep no-overwrite"
+        assert "os.link" not in code, "the exploitable link-publish design must not return"
+        prim = inspect.getsource(pinned_fs.copy_file_pinned)
+        assert "O_EXCL" in prim, "the destination is not created exclusively"
+
+
+class TestAnEmptiedBackupIsRefused:
+    """Dropping the payload and uploading the rest reports success and restores nothing."""
+
+    def _stage(self, tmp_path: Path) -> Path:
+        stage = tmp_path / "bundle"
+        stage.mkdir()
+        (stage / "MANIFEST.json").write_text(json.dumps({"components": {}}), encoding="utf-8")
+        (stage / "workspace").mkdir()
+        (stage / "workspace" / "notes.md").write_text("real memory\n", encoding="utf-8")
+        return stage
+
+    def _unprovable_db(self, path: Path) -> None:
+        """A credential in the SCHEMA -- rows can be rewritten, DDL cannot."""
+        with sqlite3.connect(str(path)) as conn:
+            conn.execute(
+                f"CREATE TABLE semantic(id INTEGER PRIMARY KEY, value TEXT DEFAULT '{KEY}')"
+            )
+            conn.execute("INSERT INTO semantic(id) VALUES(1)")
+            conn.commit()
+        conn.close()
+
+    @pytest.mark.parametrize("rel", sorted(redact._PRODUCT_DATABASES))
+    def test_every_payload_database_refuses_rather_than_being_dropped(
+        self, tmp_path: Path, rel: str
+    ) -> None:
+        stage = self._stage(tmp_path)
+        db = stage / rel
+        db.parent.mkdir(parents=True, exist_ok=True)
+        self._unprovable_db(db)
+
+        with pytest.raises(redact.PayloadDatabaseUnprovable) as e:
+            redact.redact_bundle_for_egress(stage)
+
+        assert rel in e.value.paths
+        assert db.exists(), "the payload was deleted instead of the upload being refused"
+
+    def test_the_operators_own_database_still_refuses_too(self, tmp_path: Path) -> None:
+        stage = self._stage(tmp_path)
+        db = stage / "workspace" / "their-own.db"
+        self._unprovable_db(db)
+        with pytest.raises(redact.OpaqueFilesPresent):
+            redact.redact_bundle_for_egress(stage)
+        assert db.exists()
+
+    def test_files_dropped_by_name_are_still_dropped(self, tmp_path: Path) -> None:
+        """Only pure-secret and rebuildable files are removed, and that still happens."""
+        stage = self._stage(tmp_path)
+        assert redact._DERIVED_INDEXES or redact._DROP_ENTIRELY
+        rel = sorted(redact._DROP_ENTIRELY)[0]
+        target = stage / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"secret-material")
+
+        report = redact.redact_bundle_for_egress(stage)
+
+        assert rel in report.dropped
+        assert not target.exists()
+
+    def test_a_payload_database_is_never_unlinked_by_the_pass(self) -> None:
+        src = inspect.getsource(redact._redact_database)
+        assert "unlink" not in src, "the pass must not delete a database it cannot prove clean"
+
+    def test_the_upload_reports_the_refusal_instead_of_crashing(self) -> None:
+        """A bare raise would surface as a traceback, indistinguishable from a crash."""
+        src = inspect.getsource(snap)
+        assert "PayloadDatabaseUnprovable" in src
+        idx = src.index("PayloadDatabaseUnprovable as e")
+        assert "RedactionFailed" in src[idx : idx + 900]
+
+
+def test_the_merge_primitive_uses_exclusive_creation() -> None:
+    """The no-overwrite guarantee now lives in the shared primitive, not a merge helper.
+
+    `_merge_exclusive_copy` was removed; `copy_file_pinned` creates the destination
+    `O_CREAT|O_EXCL` and, on failure, empties the entry it holds a descriptor to rather
+    than unlinking a name -- so a half-written target cannot masquerade as already-merged
+    and cannot delete a concurrent writer's file.
+    """
+    src = inspect.getsource(pinned_fs.copy_file_pinned)
+    assert "O_EXCL" in src
+    assert "skip_existing" in src, "the no-overwrite mode is not offered by the primitive"
+    assert os.O_EXCL  # the flag exists on every supported platform

--- a/test/test_snapshot_cycle5x_fixes.py
+++ b/test/test_snapshot_cycle5x_fixes.py
@@ -1,0 +1,207 @@
+"""A revert that did not happen, and credential shapes the guarantee did not cover."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+from kiro_crew import snapshot_redact as redact
+
+
+class TestAFailedRevertIsNotReportedAsSuccess:
+    """The summary line is what the operator acts on, so it must not overstate."""
+
+    def test_recovery_reports_which_targets_it_could_not_put_back(self, tmp_path: Path) -> None:
+        backup = tmp_path / "rollback"
+        backup.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+        (backup / "workspace").mkdir()
+        (backup / "workspace" / "note.md").write_text("saved\n", encoding="utf-8")
+
+        failed = snap._restore_everything_from_rollback(
+            backup, home, ["workspace"], {"workspace"}, allow_unpinned=bool(unpinnable_argv())
+        )
+        assert failed == [], "a clean revert reported failures"
+        assert (home / "workspace" / "note.md").read_text(encoding="utf-8") == "saved\n"
+
+    def test_a_missing_rollback_directory_is_a_failed_revert(self, tmp_path: Path) -> None:
+        """Nothing to put back is not the same as everything put back."""
+        home = tmp_path / "home"
+        home.mkdir()
+        failed = snap._restore_everything_from_rollback(
+            home / "absent", home, ["workspace", "skills"], set()
+        )
+        assert sorted(failed) == ["skills", "workspace"]
+
+    def test_a_target_that_cannot_be_put_back_is_returned(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        backup = tmp_path / "rollback"
+        (backup / "workspace").mkdir(parents=True)
+        (backup / "workspace" / "note.md").write_text("saved\n", encoding="utf-8")
+        home = tmp_path / "home"
+        home.mkdir()
+
+        def refuse(*a, **k):
+            raise OSError(28, "No space left on device")
+
+        # Recovery restores a saved DIRECTORY through _copytree_safe now (the standalone
+        # _copytree_rollback helper is gone); make that copy refuse.
+        monkeypatch.setattr(snap, "_copytree_safe", refuse)
+        failed = snap._restore_everything_from_rollback(backup, home, ["workspace"], {"workspace"})
+        assert failed and "workspace" in failed[0]
+        assert "No space left" in failed[0]
+
+    def test_the_incomplete_signal_carries_what_the_operator_needs(self) -> None:
+        cause = OSError(28, "No space left on device")
+        e = snap.RollbackIncomplete(cause, ["workspace (denied)"], Path("/tmp/rb"))
+        assert e.cause is cause
+        assert e.failed == ["workspace (denied)"]
+        assert e.backup == Path("/tmp/rb")
+        # Still an OSError, so no existing handler on this path stops catching it.
+        assert isinstance(e, OSError)
+
+    def test_a_partial_revert_is_raised_rather_than_swallowed(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Driven for real: the mutation fails, and putting things back fails too."""
+        home = tmp_path / "home"
+        (home / "workspace").mkdir(parents=True)
+        snapdir = tmp_path / "bundle"
+        snapdir.mkdir()
+
+        def blow_up(*a, **k):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(snap, "_do_replace_mutations", blow_up)
+        monkeypatch.setattr(
+            snap, "_restore_everything_from_rollback", lambda *a, **k: ["workspace (denied)"]
+        )
+        monkeypatch.setattr(snap, "_refuse_unsafe_destination_roots", lambda *a, **k: None)
+
+        with pytest.raises(snap.RollbackIncomplete) as e:
+            snap._do_replace(snapdir, home, ["workspace"], allow_unpinned=bool(unpinnable_argv()))
+        assert e.value.failed == ["workspace (denied)"]
+        assert isinstance(e.value.cause, OSError)
+
+    def test_a_clean_revert_still_raises_the_original_failure(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The other branch: the restore failed but the revert worked, so say that."""
+        home = tmp_path / "home"
+        (home / "workspace").mkdir(parents=True)
+        snapdir = tmp_path / "bundle"
+        snapdir.mkdir()
+
+        def blow_up(*a, **k):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(snap, "_do_replace_mutations", blow_up)
+        monkeypatch.setattr(snap, "_restore_everything_from_rollback", lambda *a, **k: [])
+        monkeypatch.setattr(snap, "_refuse_unsafe_destination_roots", lambda *a, **k: None)
+
+        with pytest.raises(OSError) as e:
+            snap._do_replace(snapdir, home, ["workspace"], allow_unpinned=bool(unpinnable_argv()))
+        assert not isinstance(e.value, snap.RollbackIncomplete)
+
+    def test_the_success_wording_is_not_printed_unconditionally(self) -> None:
+        """The claim and the case it is true in must be in the same branch."""
+        src = inspect.getsource(snap)
+        claim = "Your previous state was put back"
+        assert claim in src
+        # The honest branch must exist and must be the one handling a partial revert.
+        assert "did NOT fully succeed" in src
+        assert src.index("except RollbackIncomplete") < src.index(claim), (
+            "the partial-revert handler must be matched BEFORE the blanket OSError one, "
+            "or the reassuring message wins"
+        )
+
+
+class TestTheOutboundScrubCoversWhatItClaims:
+    # Assembled at runtime, never written as one literal: GitHub's own push protection
+    # recognises this shape as a Discord bot token and blocks the push. That is the
+    # clearest possible evidence the shape is a real credential format worth redacting,
+    # and it is also why a fixture must not spell one out.
+    _DOTTED = ".".join(
+        ("MTIzNDU2Nzg5MDEyMzQ1Njc4", "Gh1j2K", "l3M4n5O6p7Q8r9S0t1U2v3W4x5Y6z7A8b9C")
+    )
+
+    def test_a_dotted_bearer_token_is_removed(self) -> None:
+        cleaned, hits = redact._scrub(self._DOTTED)
+        assert hits > 0
+        assert cleaned == "[REDACTED: credential]"
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            '{"api_key": "' + "k" * 40 + '"}',
+            '{"password": "hunter2-correct-horse-battery"}',
+            'bot_token = "' + "z" * 46 + '"',
+            "client_secret: " + "q" * 32,
+        ],
+    )
+    def test_a_shape_the_shared_redactors_miss_is_still_removed(self, shape: str) -> None:
+        cleaned, hits = redact._scrub(shape)
+        assert hits > 0, "no replacement was recorded"
+        assert "REDACTED" in cleaned
+        secret = max(shape.replace('"', " ").replace(":", " ").split(), key=len)
+        assert secret not in cleaned
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            '{"version": 3, "components": {"memory": "unresolved"}}',
+            "The token budget per turn is about 13k, mostly fixed overhead.",
+            '{"password": ""}',
+            '{"password": "changeme"}',
+            '{"path": "workspace/memory/notes.md"}',
+            "kiro_crew.snapshot_redact.redact_bundle_for_egress",
+            '{"created_at": "2026-08-14T10:00:00Z"}',
+            "CREATE TABLE semantic(id INTEGER PRIMARY KEY, key TEXT, value TEXT)",
+        ],
+    )
+    def test_ordinary_content_is_left_exactly_as_it_was(self, content: str) -> None:
+        """Over-reach here silently empties an operator's notes out of their backup."""
+        cleaned, hits = redact._scrub(content)
+        assert cleaned == content
+        assert hits == 0
+
+    def test_a_redacted_json_document_still_parses(self) -> None:
+        """The tag carries no quote or backslash, and that is checked, not assumed."""
+        doc = json.dumps({"telegram": {"bot_token": "8123456789:AAF" + "x" * 32}})
+        cleaned, hits = redact._scrub(doc)
+        assert hits > 0
+        assert json.loads(cleaned) == {"telegram": {"bot_token": "[REDACTED: credential]"}}
+
+    def test_an_already_redacted_value_is_not_redacted_twice(self) -> None:
+        once, _ = redact._scrub('{"api_key": "' + "k" * 40 + '"}')
+        twice, hits = redact._scrub(once)
+        assert twice == once
+        assert hits == 0, "a second pass must settle, or the fixpoint loop never terminates"
+
+    def test_the_tag_cannot_be_matched_as_a_value(self) -> None:
+        """This is WHY re-running settles, so it is pinned rather than left implicit.
+
+        The row scan repeats until a pass changes nothing. A rule that rewrote its own
+        replacement would never settle, and a non-settling database is refused -- so
+        editing the tag into something the value class accepts would refuse every backup.
+        """
+        assert " " in redact._TAG, "the tag must contain whitespace, which the value class excludes"
+        assert not redact._STRUCTURED_CREDENTIAL.search(f'{{"api_key": "{redact._TAG}"}}')
+
+    def test_the_egress_pass_runs_after_the_shared_pair(self) -> None:
+        """The shared warnings stay the primary signal; this only closes what they miss."""
+        src = inspect.getsource(redact._scrub)
+        assert src.index("redact_credentials(") < src.index("_scrub_unrecognised(")
+        assert src.index("redact_exfiltration_urls(") < src.index("_scrub_unrecognised(")
+
+    def test_the_shared_redactors_are_not_widened_by_this_pass(self) -> None:
+        """Those run over live output, where a false positive corrupts what is read."""
+        src = inspect.getsource(redact)
+        assert "_SENSITIVE_FIELD" in src, "the extra shapes belong to the egress module"

--- a/test/test_snapshot_cycle5y_fixes.py
+++ b/test/test_snapshot_cycle5y_fixes.py
@@ -1,0 +1,153 @@
+"""The redaction opt-out is a ceiling, so it does not live where the agent can write."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import security
+from kiro_crew import snapshot as snap
+from kiro_crew import snapshot_redact as redact
+from kiro_crew.config.loader import KiroCrewConfig
+
+
+@pytest.fixture()
+def home(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    return tmp_path
+
+
+class TestTheSwitchIsBeyondTheAgentsReach:
+    def test_it_lives_inside_the_fenced_backup_directory(self, home: Path) -> None:
+        switch = redact.redaction_switch_path()
+        assert switch.parent.name == "backup", switch
+        # The fence classifies the DIRECTORY, so the leaf inherits it by living there.
+        assert switch.parent.parent == home
+        assert switch.name == "redaction.json"
+
+    def test_the_file_gate_refuses_it(self, home: Path) -> None:
+        """The layer that holds on every platform: containment, not pattern matching."""
+        assert security.is_sensitive_path(str(redact.redaction_switch_path()))
+
+    @pytest.mark.skipif(
+        os.name != "posix",
+        reason=(
+            "The shell-form scan does not recognise a drive-letter data home, so it fires "
+            "for no fenced file at all on Windows -- not this one, and not the deny list "
+            "or the computer-use enable either. That is a limit of the shared scanner, "
+            "proven by the companion test below, and asserting it here would claim "
+            "protection the platform does not give."
+        ),
+    )
+    @pytest.mark.parametrize("verb", ["cat {p}", "echo x > {p}", "tee {p}", "rm {p}"])
+    def test_every_shell_form_refuses_it(self, home: Path, verb: str) -> None:
+        """A read-only fence is not enough: flipping it is the attack, reading it is recon."""
+        cmd = verb.format(p=redact.redaction_switch_path())
+        assert security.is_sensitive_bash_command(cmd), cmd
+
+    def test_the_shell_scan_treats_this_file_exactly_like_the_other_ceilings(
+        self, home: Path
+    ) -> None:
+        """Pins the SHAPE of the coverage rather than one platform's answer.
+
+        Whatever the shell scan does with the data home it is given, it must do the same
+        for this switch as for the deny list and the computer-use enable. That keeps the
+        skip above honest -- it records a shared-scanner limit rather than a hole specific
+        to this file -- and it fails if this switch ever becomes the odd one out.
+        """
+        cfg = redact.redaction_switch_path().parent.parent
+        peers = [cfg / "denied_commands.json", cfg / "computer_use.json"]
+        mine = redact.redaction_switch_path()
+        verdicts = {
+            str(p): bool(security.is_sensitive_bash_command(f"cat {p}")) for p in [*peers, mine]
+        }
+        assert len(set(verdicts.values())) == 1, verdicts
+
+    def test_it_is_not_a_config_field(self) -> None:
+        """Two places to turn it off means the agent-writable one decides.
+
+        The repo already keeps its other ceilings (the deny list, the computer-use enable)
+        out of `config.json` for exactly this reason, and states that the config section
+        must carry no enable field so there is only one place the thing can be switched.
+        """
+        assert not hasattr(KiroCrewConfig, "redact_backup_uploads")
+        assert "redact_backup_uploads" not in inspect.getsource(snap)
+
+
+class TestTheDefaultNeedsNoFile:
+    """Redaction is opt-IN. The owner-only destination is what guards the bundle."""
+
+    def _write(self, home: Path, payload: str) -> None:
+        switch = redact.redaction_switch_path()
+        switch.parent.mkdir(parents=True, exist_ok=True)
+        switch.write_text(payload, encoding="utf-8")
+
+    def test_absent_means_no_rewriting(self, home: Path) -> None:
+        assert redact.outbound_redaction_enabled() is False
+
+    def test_an_explicit_opt_in_is_honoured(self, home: Path) -> None:
+        self._write(home, json.dumps({"redact_uploads": True}))
+        assert redact.outbound_redaction_enabled() is True
+
+    def test_an_explicit_off_is_allowed_to_be_written_down(self, home: Path) -> None:
+        self._write(home, json.dumps({"redact_uploads": False}))
+        assert redact.outbound_redaction_enabled() is False
+
+    def test_a_key_the_operator_did_not_set_is_off_not_an_error(self, home: Path) -> None:
+        """An unrelated key is a file that simply does not opt in."""
+        self._write(home, json.dumps({"other": True}))
+        assert redact.outbound_redaction_enabled() is False
+        self._write(home, json.dumps({}))
+        assert redact.outbound_redaction_enabled() is False
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "not json at all",
+            "",
+            "[]",
+            json.dumps({"redact_uploads": "true"}),
+            json.dumps({"redact_uploads": 1}),
+            json.dumps({"redact_uploads": "false"}),
+            json.dumps({"redact_uploads": 0}),
+        ],
+    )
+    def test_a_file_that_states_neither_raises_rather_than_guessing(
+        self, home: Path, payload: str
+    ) -> None:
+        """The operator wrote this on purpose; both silent answers betray a choice.
+
+        Off would ignore a request to scrub, on would rewrite files they may not have meant
+        to touch, so the upload refuses and names the file instead.
+        """
+        self._write(home, payload)
+        with pytest.raises(redact.RedactionSwitchUnreadable):
+            redact.outbound_redaction_enabled()
+
+    def test_an_unreadable_file_raises_rather_than_defaulting(
+        self, home: Path, monkeypatch
+    ) -> None:
+        self._write(home, json.dumps({"redact_uploads": True}))
+
+        def deny(*a, **k):
+            raise OSError(13, "Permission denied")
+
+        monkeypatch.setattr(Path, "read_text", deny)
+        with pytest.raises(redact.RedactionSwitchUnreadable):
+            redact.outbound_redaction_enabled()
+
+    def test_the_upload_asks_the_switch_not_the_config(self) -> None:
+        src = inspect.getsource(snap._redacted_upload_copy)
+        assert "outbound_redaction_enabled()" in src
+        assert "KiroCrewConfig" not in src
+
+    def test_an_unreadable_switch_refuses_the_upload(self, home: Path, monkeypatch) -> None:
+        """Not a silent default in either direction: the upload stops and names the file."""
+        self._write(home, "not json at all")
+        src = inspect.getsource(snap._redacted_upload_copy)
+        assert "RedactionSwitchUnreadable" in src
+        assert "redact = True" not in src, "the old fail-closed default must be gone"

--- a/test/test_snapshot_cycle7_fixes.py
+++ b/test/test_snapshot_cycle7_fixes.py
@@ -1,0 +1,108 @@
+"""Tests for the cycle-7 review findings.
+
+What survives here is the restore-side behaviour the off-host removal did not touch: the
+merge pass refusing to write through a broken destination link, and the archive-name
+escaping that keeps a hostile bundle from driving the operator's terminal.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from test_snapshot import unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+class TestABrokenDestinationLinkDoesNotAbortAMerge:
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="'refused not climbed past' is the descriptor-pinned destination walk "
+        "opening each ancestor by fd; the by-name fallback this platform is forced onto "
+        "runs mkdir(parents=True) straight over the dangling link and aborts with "
+        "FileExistsError, so the not-climbed-past guarantee does not exist without dir_fd",
+    )
+    def test_a_dangling_link_target_is_refused_not_climbed_past(self, tmp_path):
+        """`exists()` FOLLOWS links, so a broken symlink answers False and an ancestor
+        climb steps straight past it — then mkdir(parents=True) meets the dangling link
+        and raises FileExistsError, after the databases have already been replaced."""
+        home = tmp_path / "home"
+        dst = home / "workspace" / "memory"
+        dst.mkdir(parents=True)
+        try:
+            (dst / "history").symlink_to(tmp_path / "does-not-exist", target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("cannot create a symlink on this platform")
+
+        src = tmp_path / "snap" / "workspace" / "memory"
+        (src / "history").mkdir(parents=True)
+        (src / "history" / "note.md").write_text("incoming")
+        (src / "top.md").write_text("fine")
+
+        # Must not raise. `_copy_tree_no_overwrite` no longer takes a `home` argument:
+        # the destination chain is pinned descriptor-by-descriptor by the shared
+        # primitive, so containment is enforced by the pinned walk rather than by a
+        # home passed in here.
+        snap._copy_tree_no_overwrite(src, dst)
+        assert (dst / "top.md").is_file(), "the merge aborted instead of skipping"
+        assert not (tmp_path / "does-not-exist").exists(), "it wrote through the link"
+
+    def test_a_healthy_nested_directory_still_merges(self, tmp_path):
+        home = tmp_path / "home"
+        dst = home / "workspace" / "memory"
+        (dst / "history").mkdir(parents=True)
+        src = tmp_path / "snap" / "workspace" / "memory"
+        (src / "history").mkdir(parents=True)
+        (src / "history" / "note.md").write_text("incoming")
+        snap._copy_tree_no_overwrite(src, dst, allow_unpinned=bool(unpinnable_argv()))
+        assert (dst / "history" / "note.md").is_file()
+
+
+class TestArchiveNamesAreSanitizedBeforeReachingATerminal:
+    """A restore prints names that came out of an untrusted archive, so the escaping
+    that used to guard S3 object keys now guards manifest fields and member names, as
+    the body of ``snap._safe_name``."""
+
+    def test_control_bytes_are_escaped(self):
+        raw = "backups/host/\x1b[2Jsnap.tar.gz"
+        out = snap._safe_name(raw)
+        assert "\x1b" not in out
+        assert "\\x1b" in out
+        assert "snap.tar.gz" in out, "the value should stay recognisable"
+
+    def test_a_long_name_is_capped(self):
+        out = snap._safe_name("a" * 5000)
+        assert len(out) < 400
+        assert "truncated" in out
+
+    def test_ordinary_names_are_untouched(self):
+        key = "backups/workstation/kirocrew-snapshot-20260811T000000Z.tar.gz"
+        assert snap._safe_name(key) == key
+
+    def test_bidi_overrides_are_escaped(self):
+        """A glyphless reordering control survives a control-BYTE filter untouched.
+
+        U+202E renders the tail that follows it reversed, so the name the operator reads
+        is not the name they would be restoring.
+        """
+        raw = "backups/host/\u202egz.rat.pans/live"
+        out = snap._safe_name(raw)
+        assert "\u202e" not in out
+        assert "\\u202e" in out
+        assert "backups/host/" in out, "the value should stay recognisable"
+
+    def test_every_embedding_override_and_isolate_is_escaped(self):
+        for ch in "\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069":
+            out = snap._safe_name(f"backups/host/{ch}snap.tar.gz")
+            assert ch not in out, f"U+{ord(ch):04X} reached the terminal"
+
+    def test_a_code_point_above_ff_is_not_spelled_as_a_byte(self):
+        """`\\x202e` would read as `\\x20` plus a literal `2e` -- ambiguous output."""
+        out = snap._safe_name("\u202e")
+        assert out == "\\u202e"
+
+    def test_right_to_left_marks_are_kept(self):
+        """LRM/RLM appear in genuine right-to-left names and cannot rewrite a line alone."""
+        key = "backups/host/\u200fnotes.tar.gz"
+        assert snap._safe_name(key) == key

--- a/test/test_snapshot_cycle8_fixes.py
+++ b/test/test_snapshot_cycle8_fixes.py
@@ -1,0 +1,156 @@
+"""Tests for the cycle-8 review findings.
+
+What survives here is restore-side behaviour the off-host removal did not touch: replace
+mode taking a complete rollback copy before it swaps any database, and the archive-name
+escaping that keeps a forged newline or tab from faking listing lines.
+"""
+
+from __future__ import annotations
+
+from test_snapshot import _setup_fake_kirocrew, unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+class TestNamesCannotForgeListingLines:
+    def test_a_newline_in_a_name_is_escaped(self):
+        """The first version of the sanitizer excluded tab and newline as "harmless
+        whitespace". A newline lets a name print FORGED lines, so the operator sees
+        entries that do not exist."""
+        out = snap._safe_name("backups/h/a.tar.gz\nbackups/h/fake.tar.gz")
+        assert "\n" not in out
+        assert "\\x0a" in out
+
+    def test_a_tab_is_escaped(self):
+        out = snap._safe_name("backups/h/a\tb.tar.gz")
+        assert "\t" not in out
+        assert "\\x09" in out
+
+
+class TestReplaceSavesEveryTreeBeforeReplacingAny:
+    def test_the_rollback_copy_is_taken_before_any_database_is_swapped(self):
+        """Backing up and replacing tree-by-tree meant a failure partway through left
+        some trees replaced and no rollback copy of the rest — with the databases already
+        swapped. Half old, half new, and no complete copy of either.
+
+        The current design splits this into two phases across two functions: `_do_replace`
+        takes the WHOLE rollback set (every `_backup_tree_or_refuse`) before it calls
+        `_do_replace_mutations`, and only then does the mutation function swap databases
+        (`_backup_and_copy`) and replace trees (`rmtree` + `_copytree_safe(..., must_create=`).
+        So the ordering claim spans both, and both are read.
+        """
+        import inspect
+
+        setup = inspect.getsource(snap._do_replace)
+        muts = inspect.getsource(snap._do_replace_mutations)
+        # Phase one: every tree is saved via _backup_tree_or_refuse BEFORE the mutation
+        # phase begins. The last save must still precede the handoff.
+        save_at = setup.rindex("_backup_tree_or_refuse(")
+        guard_at = setup.index("_do_replace_mutations(")
+        assert save_at < guard_at, "a tree is saved after the mutation phase has already started"
+        # Phase two: the database swap precedes the tree replacement, so an rmtree failure
+        # cannot strand the databases in the new generation with no rollback of the trees.
+        #
+        # The locator is the function NAME, not a spelling of its argument list. Pinning the
+        # arguments made this assertion fail on any signature change -- which is noise, not a
+        # regression, since the claim being made here is purely about ORDER.
+        swap_at = muts.index("_backup_and_copy(")
+        replace_at = muts.index("_copytree_safe(")
+        assert swap_at < replace_at, "the tree replace pass moved ahead of the database swap"
+        # And the recovery is wired to the whole saved set, not to one tree.
+        #
+        # Checked by reading that call's ARGUMENTS for the whole-set names, not by matching a
+        # spelling of the whole call. This assertion used to pin
+        # `_restore_everything_from_rollback(backup, mc, targets, installed)` verbatim, which
+        # is the exact mistake the comment above warns about -- threading the operator's
+        # unpinned opt-in into recovery reflowed the call across lines and broke it, with
+        # nothing about the claim having changed. What must hold is that recovery is handed
+        # the declared target list and the installed set, so that is what is read.
+        call_at = setup.index("_restore_everything_from_rollback(")
+        args = setup[call_at : setup.index(")", call_at)]
+        assert "targets" in args, f"recovery is not handed the declared target list: {args!r}"
+        assert "installed" in args, f"recovery is not handed the installed set: {args!r}"
+
+    def test_a_failed_tree_replace_still_leaves_a_complete_rollback_copy(
+        self, tmp_path, monkeypatch
+    ):
+        """The behavioural half: if the replace pass dies, the ORIGINAL tree must be
+        recoverable even though the databases have already moved.
+
+        Built without `snapshot_main` (a manual `kirocrew-snapshot-` payload) so the
+        rollback property is exercised directly, and the tree-replace failure is injected
+        at `shutil.rmtree` -- the current mechanism `_do_replace_mutations` uses to clear a
+        live tree before refilling it (the old `_clear_tree_root` helper is gone). Because
+        phase one takes the whole rollback set before phase two mutates anything, the saved
+        copy holds the state that was live before the restore even when phase two dies.
+        """
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        _setup_fake_kirocrew(home)
+        md = home / "workspace" / "memory"
+        md.mkdir(parents=True, exist_ok=True)
+        (md / "preferences.md").write_text("changed since the backup")
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        (payload / "workspace" / "memory").mkdir(parents=True)
+        (payload / "workspace" / "memory" / "preferences.md").write_text("from the bundle")
+        (payload / "MANIFEST.json").write_text(
+            '{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8"
+        )
+        bundle = tmp_path / "b.tar.gz"
+        with __import__("tarfile").open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        # Fail the live-tree clear that phase two performs, AFTER phase one has already
+        # saved the rollback copy.
+        real_rmtree = snap.shutil.rmtree
+
+        def boom(path, *a, **k):
+            if "workspace/memory" in str(path).replace("\\", "/"):
+                raise OSError("disk full partway through the replace")
+            return real_rmtree(path, *a, **k)
+
+        monkeypatch.setattr(snap.shutil, "rmtree", boom)
+        try:
+            snap.restore_main(
+                [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+                + unpinnable_argv()
+            )
+        except OSError:
+            pass
+        finally:
+            monkeypatch.setattr(snap.shutil, "rmtree", real_rmtree)
+
+        saved = list(home.glob("pre-restore-*/workspace/memory/preferences.md"))
+        assert saved, "no rollback copy of the tree was taken before the swap"
+        assert (
+            saved[0].read_text() == "changed since the backup"
+        ), "the rollback copy does not hold the state that was live before the restore"
+
+    def test_a_normal_replace_still_works(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        _setup_fake_kirocrew(home)
+        md = home / "workspace" / "memory"
+        md.mkdir(parents=True, exist_ok=True)
+        (md / "preferences.md").write_text("original")
+
+        payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+        (payload / "workspace" / "memory").mkdir(parents=True)
+        (payload / "workspace" / "memory" / "preferences.md").write_text("original")
+        (payload / "MANIFEST.json").write_text(
+            '{"version": 3, "components": {"memory": "unresolved"}}', encoding="utf-8"
+        )
+        bundle = tmp_path / "b.tar.gz"
+        with __import__("tarfile").open(bundle, "w:gz") as tf:
+            tf.add(str(payload), arcname=payload.name)
+
+        (md / "preferences.md").write_text("changed since the backup")
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+            + unpinnable_argv()
+        )
+        assert rc == 0
+        assert (md / "preferences.md").read_text() == "original"

--- a/test/test_snapshot_cycle8b_fixes.py
+++ b/test/test_snapshot_cycle8b_fixes.py
@@ -1,0 +1,217 @@
+"""Tests for the cycle-8 review findings.
+
+Both are cases where a guard admitted the worst input as if it were safe: a component
+root that resolves to the data home ITSELF passed the containment check, and a selective
+bundle was indistinguishable to an older restore from a complete one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tarfile
+
+import pytest
+from test_snapshot import _setup_fake_kirocrew, unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    d = tmp_path / "home"
+    d.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(d))
+    _setup_fake_kirocrew(d)
+    return d
+
+
+class TestARootResolvingToTheHomeItselfIsRefused:
+    """`workspace/memory -> ..` resolves to the data home. The old predicate allowed
+    `resolved == base`, so the "component tree" became the whole home and staging swept
+    `.env`, `config.json` and `sel_hmac.key` into an archive meant to carry memory."""
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+    def test_a_link_to_the_home_is_refused(self, home):
+        target = home / "workspace" / "memory"
+        import shutil
+
+        shutil.rmtree(target)
+        target.symlink_to("..", target_is_directory=True)
+        assert snap.safe_tree_root(target, what="component root") is None
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+    def test_the_home_itself_is_refused_directly(self, home):
+        assert snap.safe_tree_root(home, what="component root") is None
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+    def test_secrets_do_not_reach_the_archive_through_such_a_link(self, home, tmp_path):
+        """The consequence, asserted end to end rather than at the predicate."""
+        (home / ".env").write_text("TELEGRAM_TOKEN=should-never-be-archived\n")
+        import shutil
+
+        target = home / "workspace" / "memory"
+        shutil.rmtree(target)
+        target.symlink_to("..", target_is_directory=True)
+
+        out = tmp_path / "out"
+        snap.snapshot_main([str(out), "--components", "memory"])
+        bundles = list(out.glob("*.tar.gz"))
+        if not bundles:
+            return  # refused outright, which is also acceptable
+        with tarfile.open(bundles[0]) as tf:
+            names = tf.getnames()
+        assert not any(
+            n.endswith("/.env") for n in names
+        ), "the data home's .env reached the archive through a link root"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+    def test_a_link_redirecting_INSIDE_the_home_is_refused(self, home):
+        """Containment is necessary and not sufficient.
+
+        A link to another subtree inside the home passes containment — it resolves to a
+        strict descendant — while changing WHICH tree is archived. Since bundles are
+        uploaded, that ships the link's target under the name of the component that was
+        asked for. An earlier revision of this file asserted the opposite, on the
+        reasoning that "the predicate is containment, not is-this-a-link". That was
+        wrong: containment answers whether a read can escape the home, not whether this
+        is the tree the component declared, and only the second question stops a
+        redirect. Nothing legitimate is lost -- a link aimed at a bigger disk points
+        OUTSIDE the home and containment already refuses it, so the only links
+        containment ever admitted were in-home redirects, which have no honest use.
+        """
+        other = home / "workspace" / "elsewhere"
+        other.mkdir(parents=True)
+        import shutil
+
+        target = home / "workspace" / "knowledge"
+        shutil.rmtree(target)
+        target.symlink_to(other, target_is_directory=True)
+        assert snap.safe_tree_root(target, what="component root") is None
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+    def test_a_link_ABOVE_the_home_does_not_make_every_root_unsafe(self, tmp_path):
+        """The other direction, which is the real risk in tightening this.
+
+        A data home routinely sits behind a link (a home directory on a mounted volume,
+        for one). The identity walk must stop at the home, or every component tree on
+        such a host would be refused and the feature would be dead there.
+        """
+        real = tmp_path / "real-home"
+        (real / "workspace" / "memory").mkdir(parents=True)
+        linked = tmp_path / "linked-home"
+        linked.symlink_to(real, target_is_directory=True)
+
+        root = linked / "workspace" / "memory"
+        assert snap.safe_tree_root(root, what="component root", home=linked) == root
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+    def test_a_link_at_an_INTERMEDIATE_segment_below_the_home_is_refused(self, home):
+        """The redirect does not have to be the root itself."""
+        other = home / "otherplace"
+        (other / "memory").mkdir(parents=True)
+        import shutil
+
+        shutil.rmtree(home / "workspace")
+        (home / "workspace").symlink_to(other, target_is_directory=True)
+        assert snap.safe_tree_root(home / "workspace" / "memory", what="component root") is None
+
+    def test_a_plain_directory_root_is_still_accepted(self, home):
+        """Guards the tightening from refusing the ordinary case."""
+        root = home / "workspace" / "memory"
+        root.mkdir(parents=True, exist_ok=True)
+        assert snap.safe_tree_root(root, what="component root") == root
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+    def test_a_redirected_root_does_not_ship_another_subtree_in_a_real_archive(
+        self, home, tmp_path
+    ):
+        """The predicate returning None is not the property that matters; what matters
+        is that the bytes never reach a bundle that gets uploaded."""
+        import shutil
+
+        secrets = home / "apps"
+        secrets.mkdir(parents=True, exist_ok=True)
+        (secrets / ".app_secret").write_text("SHOULD NEVER BE ARCHIVED", encoding="utf-8")
+
+        memory = home / "workspace" / "memory"
+        if memory.exists():
+            shutil.rmtree(memory)
+        memory.symlink_to(secrets, target_is_directory=True)
+
+        out = tmp_path / "out"
+        snap.snapshot_main([str(out), "--components", "memory"])
+        bundles = list(out.glob("*.tar.gz"))
+        if not bundles:
+            return  # refused outright, also acceptable
+        with tarfile.open(bundles[0]) as tf:
+            names = tf.getnames()
+            bodies = [(tf.extractfile(n).read() if tf.extractfile(n) else b"") for n in names]
+        assert not any(n.endswith(".app_secret") for n in names), names
+        assert not any(
+            b"SHOULD NEVER BE ARCHIVED" in b for b in bodies
+        ), "the link target's content reached the archive under the memory component"
+
+
+class TestASelectiveBundleIsRefusedByOlderRestores:
+    """A released restore never reads the manifest's component map and moves each live
+    core file out before checking the archive has a replacement. It DOES require the
+    extracted root to start with `kirocrew-snapshot-`, so a different name turns silent
+    data relocation into a clean refusal on versions already in the wild."""
+
+    def _root_of(self, bundle, tmp_path, tag):
+        work = tmp_path / f"x-{tag}"
+        work.mkdir()
+        with tarfile.open(bundle) as tf:
+            tf.extractall(work)
+        return next(d for d in work.iterdir() if d.is_dir()).name
+
+    def test_a_selective_bundle_root_is_named_partial(self, home, tmp_path):
+        out = tmp_path / "out"
+        assert snap.snapshot_main([str(out), "--components", "memory"] + unpinnable_argv()) == 0
+        bundle = next(out.glob("*.tar.gz"))
+        root = self._root_of(bundle, tmp_path, "sel")
+        assert root.startswith("kirocrew-partial-"), root
+        assert not root.startswith("kirocrew-snapshot-")
+
+    def test_a_complete_bundle_keeps_the_original_root(self, home, tmp_path):
+        out = tmp_path / "out"
+        assert snap.snapshot_main([str(out)] + unpinnable_argv()) == 0
+        bundle = next(out.glob("*.tar.gz"))
+        root = self._root_of(bundle, tmp_path, "full")
+        assert root.startswith("kirocrew-snapshot-"), root
+
+    def test_the_tarball_name_is_unchanged_so_listing_and_pruning_still_work(self, home, tmp_path):
+        """Only the inner root carries the marker; rotation globs the tarball name."""
+        out = tmp_path / "out"
+        assert snap.snapshot_main([str(out), "--components", "memory"] + unpinnable_argv()) == 0
+        assert list(
+            out.glob("kirocrew-snapshot-*.tar.gz")
+        ), "a partial bundle became invisible to --list and pruning"
+
+    def test_this_version_still_restores_a_partial_bundle(self, home, tmp_path):
+        md = home / "workspace" / "memory"
+        (md / "preferences.md").write_text("original")
+        out = tmp_path / "out"
+        assert snap.snapshot_main([str(out), "--components", "memory"] + unpinnable_argv()) == 0
+        bundle = next(out.glob("*.tar.gz"))
+        (md / "preferences.md").write_text("changed")
+        rc = snap.restore_main(
+            [str(bundle), "--mode", "replace", "--force", "--components", "memory"]
+            + unpinnable_argv()
+        )
+        assert rc == 0
+        assert (md / "preferences.md").read_text() == "original"
+
+    def test_the_manifest_still_records_the_component_map(self, home, tmp_path):
+        out = tmp_path / "out"
+        assert snap.snapshot_main([str(out), "--components", "memory"] + unpinnable_argv()) == 0
+        bundle = next(out.glob("*.tar.gz"))
+        work = tmp_path / "man"
+        work.mkdir()
+        with tarfile.open(bundle) as tf:
+            tf.extractall(work)
+        root = next(d for d in work.iterdir() if d.is_dir())
+        man = json.loads((root / "MANIFEST.json").read_text())
+        assert man["version"] == 3
+        assert "memory" in man["components"]

--- a/test/test_snapshot_cycle9_fixes.py
+++ b/test/test_snapshot_cycle9_fixes.py
@@ -1,0 +1,120 @@
+"""Tests for the cycle-9 review findings.
+
+The surviving finding: the RESTORE side kept skipping an unsafe tree instead of
+refusing before any mutation, leaving state split between two versions while the
+command reported success.
+"""
+
+from __future__ import annotations
+
+import pytest
+from test_snapshot import _setup_fake_kirocrew, unpinnable_argv
+
+from kiro_crew import snapshot as snap
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    return tmp_path
+
+
+class TestAnUnsafeDestinationRootRefusesBeforeAnyMutation:
+    """The staging side was fixed last cycle; the RESTORE side kept skipping.
+
+    `_backup_and_copy` swaps the databases before the tree loops run, so skipping an
+    unsafe markdown tree left memory split between two versions — and the command
+    reported success. Validation is now hoisted ahead of every mutation.
+    """
+
+    def _bundle(self, tmp_path, monkeypatch):
+        home = tmp_path / "src"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        _setup_fake_kirocrew(home)
+        md = home / "workspace" / "memory"
+        md.mkdir(parents=True, exist_ok=True)
+        (md / "preferences.md").write_text("from the bundle")
+        out = tmp_path / "out"
+        assert snap.snapshot_main([str(out), "--components", "memory"] + unpinnable_argv()) == 0
+        return next(out.glob("kirocrew-snapshot-*.tar.gz"))
+
+    def _linked_dest(self, tmp_path, name: str, tree: str):
+        """A seeded data home whose *tree* root is a symlink pointing outside it.
+
+        Order matters: seed FIRST, then replace the real directory with the link.
+        Creating the link first makes the seeding write straight through it, which is a
+        fixture bug that quietly invalidates the assertion about the outside directory.
+        """
+        import shutil
+
+        dest = tmp_path / name
+        dest.mkdir()
+        _setup_fake_kirocrew(dest)
+        outside = tmp_path / f"outside-{name}"
+        outside.mkdir()
+        target = dest / tree
+        if target.is_dir():
+            shutil.rmtree(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.symlink_to(outside, target_is_directory=True)
+        return dest, outside
+
+    def test_replace_refuses_before_replacing_the_databases(self, tmp_path, monkeypatch):
+        bundle = self._bundle(tmp_path, monkeypatch)
+        try:
+            dest, _outside = self._linked_dest(tmp_path, "dest", "workspace/memory")
+        except (OSError, NotImplementedError):
+            pytest.skip("cannot create a directory symlink on this platform")
+        original = (dest / "memory.db").read_bytes() if (dest / "memory.db").is_file() else None
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+
+        rc = snap.restore_main(
+            [str(bundle), "--components", "memory", "--mode", "replace", "--force"]
+        )
+        assert rc == 1
+        # The database was NOT swapped, and no rollback directory was created.
+        if original is not None:
+            assert (dest / "memory.db").read_bytes() == original
+        assert list(dest.glob("pre-restore-*")) == []
+
+    def test_merge_refuses_too(self, tmp_path, monkeypatch):
+        bundle = self._bundle(tmp_path, monkeypatch)
+        try:
+            dest, outside = self._linked_dest(tmp_path, "dest2", "workspace/knowledge")
+        except (OSError, NotImplementedError):
+            pytest.skip("cannot create a directory symlink on this platform")
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+        rc = snap.restore_main(
+            [str(bundle), "--components", "memory", "--mode", "merge", "--force"]
+        )
+        assert rc == 1
+        assert list(outside.iterdir()) == []
+
+    def test_a_clean_destination_still_restores(self, tmp_path, monkeypatch):
+        """The refusal must not fire on an ordinary home."""
+        bundle = self._bundle(tmp_path, monkeypatch)
+        dest = tmp_path / "clean"
+        dest.mkdir()
+        _setup_fake_kirocrew(dest)
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+        assert (
+            snap.restore_main(
+                [str(bundle), "--components", "memory", "--mode", "replace", "--force"]
+                + unpinnable_argv()
+            )
+            == 0
+        )
+        assert (dest / "workspace" / "memory" / "preferences.md").read_text() == ("from the bundle")
+
+    def test_the_refusal_is_a_message_not_a_traceback(self, tmp_path, monkeypatch, capsys):
+        bundle = self._bundle(tmp_path, monkeypatch)
+        try:
+            dest, _outside = self._linked_dest(tmp_path, "dest3", "workspace/memory")
+        except (OSError, NotImplementedError):
+            pytest.skip("cannot create a directory symlink on this platform")
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+        snap.restore_main([str(bundle), "--components", "memory", "--mode", "replace", "--force"])
+        out = capsys.readouterr().out
+        assert "do not resolve inside the data home" in out
+        assert "Nothing has been changed" in out

--- a/test/test_snapshot_invariants.py
+++ b/test/test_snapshot_invariants.py
@@ -1,0 +1,277 @@
+"""Tests for the structural fixes made after the same defect class recurred.
+
+The symlinked-tree-root invariant had been patched instance-by-instance across three
+sites. These assert the invariant, and where possible assert it STRUCTURALLY so a new
+instance cannot appear quietly.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+from test_snapshot import _setup_fake_kirocrew, unpinnable_argv
+
+from kiro_crew.snapshot import restore_main, snapshot_main
+
+SNAPSHOT_SRC = Path(__file__).resolve().parents[1] / "src/kiro_crew/snapshot.py"
+
+
+@pytest.fixture
+def src(tmp_path, monkeypatch):
+    d = tmp_path / "src"
+    _setup_fake_kirocrew(d)
+    monkeypatch.setenv("KIROCREW_HOME", str(d))
+    return d
+
+
+def _make_memory_db(path: Path) -> None:
+    """A minimal but REAL memory.db, so merge takes its normal path."""
+    import sqlite3
+
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.executescript("""
+            CREATE TABLE semantic_memory (key TEXT PRIMARY KEY, value_json TEXT NOT NULL,
+                confidence REAL DEFAULT 0.5, source TEXT NOT NULL, created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL, is_deleted INTEGER DEFAULT 0, embedding BLOB);
+            CREATE TABLE episodic_memories (id TEXT PRIMARY KEY, conversation_id TEXT,
+                text TEXT NOT NULL, embedding BLOB, tags TEXT DEFAULT '[]',
+                importance REAL DEFAULT 0.5, created_at TEXT NOT NULL,
+                last_accessed_at TEXT, is_deleted INTEGER DEFAULT 0);
+            """)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestMergeReleasesItsSourceHandles:
+    """`with sqlite3.connect(...)` commits the TRANSACTION and leaves the connection
+    OPEN — a long-standing Python gotcha. The handle it kept on the extracted
+    memory.db made the caller's extraction temp dir undeletable on Windows, which is
+    how it surfaced.
+
+    Asserted on the source, because the leak is invisible on POSIX: an open handle
+    does not prevent unlink there, so a functional test would pass either way and
+    prove nothing.
+    """
+
+    def test_the_integrity_check_connection_is_closed(self):
+        src = (Path(__file__).resolve().parents[1] / "src/kiro_crew/snapshot.py").read_text(
+            encoding="utf-8"
+        )
+        body = src.split("def _merge_memory(")[1].split("\ndef ")[0]
+        assert "closing(sqlite3.connect(str(src_db)))" in body, (
+            "the integrity-check connection must be wrapped in closing(); a bare "
+            "`with sqlite3.connect(...)` leaves it open and holds the source file"
+        )
+        assert "with sqlite3.connect(str(src_db))" not in body
+
+
+def _snapshot(out: Path, extra: list[str]) -> Path:
+    # A selective bundle is named `kirocrew-partial-*` (an older restore refuses it
+    # rather than relocating the core files it lacks); a complete one keeps
+    # `kirocrew-snapshot-*`. Match both.
+    assert snapshot_main([str(out)] + extra + unpinnable_argv()) == 0
+    return sorted(out.glob("kirocrew-*.tar.gz"))[-1]
+
+
+class TestEveryTreeRootSiteUsesTheChokepoint:
+    """Structural: a new site iterating a component's trees must use safe_tree_root.
+
+    The symlink class was found three times in three different sites. Counting call
+    sites is crude but it is the property that actually failed: each site had been
+    written without the check, independently.
+    """
+
+    def test_each_trees_loop_is_guarded(self):
+        tree = ast.parse(SNAPSHOT_SRC.read_text(encoding="utf-8"))
+        # A loop is guarded either by calling the chokepoint itself, or by sitting in a
+        # function that already REFUSED every unsafe root before the loop runs. The second
+        # form is not a loophole: `_refuse_unsafe_destination_roots` iterates the same
+        # `.trees` and raises, so reaching the loop proves the roots resolved inside the
+        # home. Requiring the call inside every loop would force a redundant re-check whose
+        # only effect is to satisfy this test.
+        hoisted: set[str] = set()
+        for fn in ast.walk(tree):
+            if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+                "_refuse_unsafe_destination_roots" in ast.dump(fn)
+            ):
+                hoisted.add(fn.name)
+
+        def _enclosing(node: ast.AST) -> str | None:
+            for fn in ast.walk(tree):
+                if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)) and any(
+                    n is node for n in ast.walk(fn)
+                ):
+                    return fn.name
+            return None
+
+        unguarded: list[int] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.For):
+                continue
+            # `for tree in <...>.trees:`
+            it = node.iter
+            if not (isinstance(it, ast.Attribute) and it.attr == "trees"):
+                continue
+            body = ast.dump(ast.Module(body=node.body, type_ignores=[]))
+            if "safe_tree_root" in body:
+                continue
+            if _enclosing(node) in hoisted:
+                continue
+            unguarded.append(node.lineno)
+        assert unguarded == [], (
+            f"trees loop(s) at line(s) {unguarded} neither call safe_tree_root nor sit in "
+            f"a function that refused unsafe roots first -- a symlinked root would be "
+            f"dereferenced"
+        )
+
+    def test_the_chokepoint_admits_paths_inside_the_home_and_refuses_escapes(self, tmp_path):
+        """Containment of the RESOLVED path, not 'is this node a link'.
+
+        Checking the node was tried first and missed a link nested under the root or
+        in one of its ancestors — every individual node the loop inspects looks
+        ordinary while the write still lands outside.
+        """
+        from kiro_crew.snapshot import safe_tree_root
+
+        home = tmp_path / "home"
+        (home / "workspace").mkdir(parents=True)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        inside = home / "workspace" / "memory"
+        inside.mkdir()
+        assert safe_tree_root(inside, what="x", home=home) == inside
+
+        # 1. the root itself is a link out
+        root_link = home / "workspace" / "linked"
+        root_link.symlink_to(outside, target_is_directory=True)
+        assert safe_tree_root(root_link, what="x", home=home) is None
+
+        # 2. an ANCESTOR is a link out — the node itself is an ordinary directory
+        anc = home / "workspace" / "viaparent"
+        anc.symlink_to(outside, target_is_directory=True)
+        (outside / "child").mkdir()
+        assert safe_tree_root(anc / "child", what="x", home=home) is None
+
+        # 3. a path that does not exist yet but resolves inside is fine
+        assert safe_tree_root(home / "workspace" / "new", what="x", home=home) is not None
+
+    def test_merge_does_not_write_through_a_linked_destination_root(
+        self, src, tmp_path, monkeypatch
+    ):
+        """The third site: merge mode. Files must not land outside the data home."""
+        tarball = _snapshot(tmp_path / "out", ["--components", "memory"])
+
+        dest = tmp_path / "dest"
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (dest / "workspace").mkdir(parents=True)
+        (dest / "workspace/knowledge").symlink_to(outside, target_is_directory=True)
+        # A REAL database, so merge mode takes the ATTACH path rather than the
+        # "source unreadable, skipping" shortcut an empty file would trigger.
+        _make_memory_db(dest / "memory.db")
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+
+        rc = restore_main([str(tarball), "--components", "memory", "--mode", "merge", "--force"])
+        assert list(outside.iterdir()) == [], "merge wrote through a symlinked root"
+        # And it refuses rather than reporting a merge it did not fully perform. Merge
+        # destroys nothing, but a merge that silently omits a tree still claims to have
+        # imported it.
+        assert rc == 1, "merge reported success while skipping a tree"
+
+
+class TestManifestDrivenRestoreEdges:
+    def test_an_unknown_only_manifest_restores_nothing(self, tmp_path):
+        """An empty resolved set must not collapse into 'restore everything'."""
+        from kiro_crew.snapshot import _manifest_components
+
+        snap = tmp_path / "future"
+        snap.mkdir()
+        (snap / "MANIFEST.json").write_text(json.dumps({"components": {"quantum": "unresolved"}}))
+        assert _manifest_components(snap) == []
+
+    def test_a_pre_manifest_bundle_still_means_everything(self, tmp_path):
+        from kiro_crew.snapshot import _manifest_components
+
+        snap = tmp_path / "old"
+        snap.mkdir()
+        (snap / "MANIFEST.json").write_text(json.dumps({"version": 2}))
+        assert _manifest_components(snap) is None
+
+    def test_requesting_a_component_the_bundle_lacks_is_refused(
+        self, src, tmp_path, monkeypatch, capsys
+    ):
+        """Replace would move the live files out with nothing to put back."""
+        tarball = _snapshot(tmp_path / "out", ["--components", "memory"])
+
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        (dest / "config.json").write_text('{"keep": true}')
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+
+        rc = restore_main([str(tarball), "--components", "config", "--mode", "replace", "--force"])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "does not contain" in out and "config" in out
+        assert json.loads((dest / "config.json").read_text()) == {"keep": True}
+
+
+class TestUnreadableManifestRefuses:
+    """'We could not read it' must never resolve to the most destructive reading."""
+
+    def test_a_malformed_manifest_raises_rather_than_defaulting(self, tmp_path):
+        from kiro_crew.snapshot import ManifestUnreadable, _manifest_components
+
+        snap = tmp_path / "broken"
+        snap.mkdir()
+        (snap / "MANIFEST.json").write_text("{not json at all")
+        with pytest.raises(ManifestUnreadable):
+            _manifest_components(snap)
+
+    def test_a_components_key_of_the_wrong_type_raises(self, tmp_path):
+        from kiro_crew.snapshot import ManifestUnreadable, _manifest_components
+
+        snap = tmp_path / "weird"
+        snap.mkdir()
+        (snap / "MANIFEST.json").write_text(json.dumps({"components": ["memory"]}))
+        with pytest.raises(ManifestUnreadable):
+            _manifest_components(snap)
+
+    def test_restore_refuses_a_bundle_with_a_malformed_manifest(
+        self, src, tmp_path, monkeypatch, capsys
+    ):
+        """Falling back to all-components would displace live state in replace mode."""
+        import tarfile
+
+        tarball = _snapshot(tmp_path / "out", ["--components", "memory"])
+
+        # Rewrite the bundle with a corrupt manifest.
+        work = tmp_path / "rebuild"
+        work.mkdir()
+        with tarfile.open(str(tarball)) as t:
+            t.extractall(work, filter=lambda m, _d="": m)
+        inner = next(
+            d
+            for d in work.iterdir()
+            if d.name.startswith(("kirocrew-snapshot-", "kirocrew-partial-"))
+        )
+        (inner / "MANIFEST.json").write_text("{corrupt")
+        broken = tmp_path / "broken.tar.gz"
+        with tarfile.open(str(broken), "w:gz") as t:
+            t.add(str(inner), arcname=inner.name)
+
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        keep = dest / "config.json"
+        keep.write_text('{"keep": true}')
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+
+        rc = restore_main([str(broken), "--mode", "replace", "--force"])
+        assert rc == 1
+        assert "unreadable" in capsys.readouterr().out
+        assert json.loads(keep.read_text()) == {"keep": True}

--- a/test/test_snapshot_manifest_and_links.py
+++ b/test/test_snapshot_manifest_and_links.py
@@ -1,0 +1,177 @@
+"""Tests for the four defects the review found on `181c09d4b`."""
+
+from __future__ import annotations
+
+import json
+import os
+import tarfile
+from pathlib import Path
+
+import pytest
+from test_snapshot import _setup_fake_kirocrew, unpinnable_argv
+
+from kiro_crew.snapshot import restore_main, snapshot_main
+
+
+def _tagset(pairs: dict[str, str]) -> str:
+    return json.dumps({"TagSet": [{"Key": k, "Value": v} for k, v in pairs.items()]})
+
+
+@pytest.fixture
+def src(tmp_path, monkeypatch):
+    d = tmp_path / "src"
+    _setup_fake_kirocrew(d)
+    monkeypatch.setenv("KIROCREW_HOME", str(d))
+    return d
+
+
+def _extract(tarball: Path, into: Path) -> Path:
+    into.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(str(tarball)) as t:
+        t.extractall(into, filter=lambda m, _d="": m)
+    return next(
+        d for d in into.iterdir() if d.name.startswith(("kirocrew-snapshot-", "kirocrew-partial-"))
+    )
+
+
+def _snapshot(out: Path, extra: list[str]) -> Path:
+    # A selective bundle is now named `kirocrew-partial-*` so an older restore refuses
+    # it rather than silently relocating the core files it lacks; a complete one keeps
+    # the `kirocrew-snapshot-*` name. Match both so this helper works for either.
+    assert snapshot_main([str(out)] + extra + unpinnable_argv()) == 0
+    return sorted(out.glob("kirocrew-*.tar.gz"))[-1]
+
+
+class TestSymlinkedTreeRootsAreRefused:
+    """`is_dir()` follows a link, so a linked component root would export its target."""
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="the 'symlinked root resolves outside and is not followed into the bundle' "
+        "guarantee is enforced by the descriptor-pinned staging walk; without dir_fd "
+        "staging refuses up front (PinnedPathRefusal) before that guarantee can be asserted",
+    )
+    def test_a_linked_component_root_is_not_followed_into_the_bundle(self, src, tmp_path, capsys):
+        secret_dir = tmp_path / "outside"
+        secret_dir.mkdir()
+        (secret_dir / "id_rsa").write_text("PRIVATE KEY\n")
+
+        target = src / "workspace/knowledge"
+        for p in sorted(target.rglob("*"), reverse=True):
+            p.unlink() if p.is_file() else p.rmdir()
+        target.rmdir()
+        target.symlink_to(secret_dir, target_is_directory=True)
+
+        # The snapshot now REFUSES rather than quietly omitting the tree: a manifest
+        # that still declares `memory` while the tree is missing is a backup that lies
+        # about its contents. The link is of course still not followed.
+        out = tmp_path / "out"
+        rc = snapshot_main([str(out), "--components", "memory"])
+        assert rc != 0, "a symlinked component root produced a 'successful' backup"
+        assert list(out.glob("kirocrew-snapshot-*.tar.gz")) == []
+        printed = capsys.readouterr().out
+        assert "resolves outside" in printed
+        assert "PRIVATE KEY" not in printed
+
+    def test_replace_restore_refuses_a_linked_destination_root(self, src, tmp_path, monkeypatch):
+        tarball = _snapshot(tmp_path / "out", ["--components", "memory"])
+
+        dest = tmp_path / "dest"
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        (outside / "keepme.txt").write_text("not ours to delete\n")
+        (dest / "workspace").mkdir(parents=True)
+        (dest / "workspace/memory").symlink_to(outside, target_is_directory=True)
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+
+        # Strengthened contract. This previously asserted a SUCCESSFUL restore that
+        # merely left the link alone — but the databases were replaced before the tree
+        # loop reached the link, so "success" meant memory split between the old and new
+        # versions with no warning. The refusal now happens before any mutation.
+        rc = restore_main([str(tarball), "--components", "memory", "--mode", "replace", "--force"])
+        assert rc == 1, "a linked destination root produced a 'successful' restore"
+        assert (outside / "keepme.txt").read_text() == "not ours to delete\n"
+        assert (dest / "workspace/memory").is_symlink()
+        # Refused BEFORE mutation: no rollback directory was even created.
+        assert list(dest.glob("pre-restore-*")) == []
+
+
+class TestRestoreHonoursTheBundleManifest:
+    """A selective bundle must not be restored as if it held everything."""
+
+    def test_a_memory_only_bundle_does_not_displace_the_workspace(self, src, tmp_path, monkeypatch):
+        tarball = _snapshot(tmp_path / "out", ["--components", "memory"])
+
+        dest = tmp_path / "dest"
+        (dest / "workspace").mkdir(parents=True)
+        unrelated = dest / "workspace/my-notes.md"
+        unrelated.write_text("months of work\n")
+        (dest / "skills").mkdir()
+        (dest / "skills/mine").mkdir()
+        (dest / "skills/mine/SKILL.md").write_text("my skill\n")
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+
+        # No --components: the bundle's manifest is the source of truth.
+        assert restore_main([str(tarball), "--mode", "replace", "--force"] + unpinnable_argv()) == 0
+
+        assert (
+            unrelated.read_text() == "months of work\n"
+        ), "an unrelated workspace file was displaced by a memory-only bundle"
+        assert (dest / "skills/mine/SKILL.md").read_text() == "my skill\n"
+        assert (dest / "workspace/memory/preferences.md").is_file()
+
+    def test_the_defaulted_component_set_is_reported(self, src, tmp_path, monkeypatch, capsys):
+        tarball = _snapshot(tmp_path / "out", ["--components", "memory"])
+        dest = tmp_path / "dest2"
+        dest.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+        assert restore_main([str(tarball), "--mode", "replace", "--force"] + unpinnable_argv()) == 0
+        out = capsys.readouterr().out
+        assert "from bundle manifest" in out
+        assert "memory" in out
+
+    def test_an_explicit_components_flag_still_wins(self, src, tmp_path, monkeypatch):
+        tarball = _snapshot(tmp_path / "out", [])  # full bundle
+        dest = tmp_path / "dest3"
+        dest.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+        assert (
+            restore_main(
+                [str(tarball), "--components", "crons", "--mode", "replace", "--force"]
+                + unpinnable_argv()
+            )
+            == 0
+        )
+        assert (dest / "crons.json").is_file()
+        # memory was in the bundle but not requested.
+        assert not (dest / "memory.db").exists()
+
+    def test_a_full_bundle_still_restores_everything(self, src, tmp_path, monkeypatch):
+        tarball = _snapshot(tmp_path / "out", [])
+        dest = tmp_path / "dest4"
+        dest.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+        assert restore_main([str(tarball), "--mode", "replace", "--force"] + unpinnable_argv()) == 0
+        assert (dest / "memory.db").is_file()
+        assert (dest / "crons.json").is_file()
+        assert (dest / "skills/my-skill/SKILL.md").is_file()
+
+    def test_a_manifest_naming_an_unknown_component_drops_it(self, src, tmp_path, monkeypatch):
+        """A bundle from a newer build must not steer this one into an unknown name."""
+        from kiro_crew.snapshot import _manifest_components
+
+        snap = tmp_path / "fakesnap"
+        snap.mkdir()
+        (snap / "MANIFEST.json").write_text(
+            json.dumps({"components": {"memory": "no-redaction", "quantum": "no-redaction"}})
+        )
+        assert _manifest_components(snap) == ["memory"]
+
+    def test_a_pre_manifest_bundle_keeps_all_components(self, tmp_path):
+        """No component map (a pre-v3 bundle) means it really did hold everything."""
+        from kiro_crew.snapshot import _manifest_components
+
+        snap = tmp_path / "old"
+        snap.mkdir()
+        (snap / "MANIFEST.json").write_text(json.dumps({"version": 2, "contents": {}}))
+        assert _manifest_components(snap) is None

--- a/test/test_snapshot_name_escaping_contract.py
+++ b/test/test_snapshot_name_escaping_contract.py
@@ -1,0 +1,59 @@
+"""A name printed from disk goes through the terminal escaper, at every site.
+
+Three rounds fixed this one site at a time -- a manifest count beside an escaped path, the
+bidi controls, and now a staging warning -- so this pins the RULE structurally as well as
+behaviourally: no `print` in the backup modules interpolates a `.name` raw.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from kiro_crew import snapshot as snap
+
+SRC = Path(snap.__file__).parent
+MODULES = ("snapshot.py", "snapshot_redact.py", "snapshot_remote.py", "backup_cli.py")
+
+
+class TestNoPrintInterpolatesARawName:
+    def test_every_name_print_goes_through_the_escaper(self) -> None:
+        offenders: list[str] = []
+        pattern = re.compile(r"\{[A-Za-z_][A-Za-z0-9_.]*\.name\}")
+        for module in MODULES:
+            path = SRC / module
+            if not path.is_file():
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "print"
+                ):
+                    continue
+                rendered = ast.dump(node)
+                if "_safe_name" in rendered or "safe_for_terminal" in rendered:
+                    continue
+                # Reconstruct the f-string's literal text to spot a bare `{x.name}`.
+                literal = "".join(
+                    v.value
+                    for v in ast.walk(node)
+                    if isinstance(v, ast.Constant) and isinstance(v.value, str)
+                )
+                joined = literal + " ".join(
+                    ast.unparse(v) for v in ast.walk(node) if isinstance(v, ast.Attribute)
+                )
+                if pattern.search(ast.unparse(node)) or re.search(r"\.name\b", joined):
+                    if ".name" in ast.unparse(node):
+                        offenders.append(f"{module}:{node.lineno}")
+        assert offenders == [], (
+            f"print site(s) {offenders} interpolate a name without _safe_name -- a "
+            f"hostile filename would reach the terminal raw"
+        )
+
+    def test_the_escaper_still_neutralises_an_escape_sequence(self) -> None:
+        """Behavioural half: the structural walk above proves routing, not effect."""
+        assert "\x1b" not in snap._safe_name("\x1b[2Kfake.db")
+        assert "\u202e" not in snap._safe_name("\u202egnp.db")

--- a/test/test_snapshot_purpose.py
+++ b/test/test_snapshot_purpose.py
@@ -1,0 +1,283 @@
+"""Tests for the bundle purpose seam and the self-contained memory component.
+
+The seam's value is entirely in its refusals, so each one is asserted directly
+rather than inferred from a successful run: an unknown component name, and a
+component that carries credential material riding a bundle meant to be shared.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tarfile
+from pathlib import Path
+
+import pytest
+from test_snapshot import _setup_fake_kirocrew, unpinnable_argv
+
+from kiro_crew.snapshot import (
+    COMPONENTS,
+    ComponentRefused,
+    Purpose,
+    SecretPolicy,
+    resolve_components,
+    restore_main,
+    snapshot_main,
+)
+
+
+def _snapshot(out: Path, extra: list[str]) -> Path:
+    assert snapshot_main([str(out)] + extra + unpinnable_argv()) == 0
+    tars = sorted(out.glob("kirocrew-snapshot-*.tar.gz"), key=lambda p: p.stat().st_mtime)
+    assert tars
+    return tars[-1]
+
+
+def _extract(tarball: Path, into: Path) -> Path:
+    into.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(str(tarball)) as tar:
+        tar.extractall(into, filter=lambda t, _d="": t)
+    # A selective bundle's root is `kirocrew-partial-`, which is how released
+    # restores are made to refuse it; both are valid to this version.
+    snaps = [
+        d for d in into.iterdir() if d.name.startswith(("kirocrew-snapshot-", "kirocrew-partial-"))
+    ]
+    assert snaps
+    return snaps[0]
+
+
+@pytest.fixture
+def src(tmp_path, monkeypatch):
+    d = tmp_path / "src"
+    _setup_fake_kirocrew(d)
+    monkeypatch.setenv("KIROCREW_HOME", str(d))
+    return d
+
+
+class TestPolicyDeclarations:
+    def test_every_component_declares_a_policy(self):
+        """The seam is only load-bearing if no component can skip the declaration.
+
+        A new component added without one must not fall through to a permissive
+        default — the dataclass has no default for ``policy``, so construction
+        fails, and this asserts the invariant the registry relies on.
+        """
+        for name, spec in COMPONENTS.items():
+            assert isinstance(spec.policy, SecretPolicy), name
+
+    def test_component_spec_cannot_be_built_without_a_policy(self):
+        from kiro_crew.snapshot import ComponentSpec
+
+        with pytest.raises(TypeError):
+            ComponentSpec(help="no policy declared")  # type: ignore[call-arg]
+
+    def test_credential_bearing_components_are_marked_unresolved(self):
+        """Components that can carry credential material; the policy is undecided.
+
+        Fail closed until it is decided: they ride a backup unchanged and are
+        refused outright in a share bundle. `crons` is here because `CronJob.env`
+        is a persisted dict of per-job environment variables, so a job passing an
+        API token to a command carries that token in crons.json.
+        """
+        assert COMPONENTS["config"].policy is SecretPolicy.UNRESOLVED
+        assert COMPONENTS["security"].policy is SecretPolicy.UNRESOLVED
+        assert COMPONENTS["crons"].policy is SecretPolicy.UNRESOLVED
+
+    def test_no_component_claims_to_be_share_safe(self):
+        """Whether a component is safe to share is a CONTENT question.
+
+        A workspace file, a skill, a cron's env map or a pasted lesson can each hold
+        a token, and staging cannot tell. Guessing per component was tried and two
+        guesses were wrong, so nothing is certified until the redaction work exists.
+        This is the assertion that stops the guessing from creeping back.
+        """
+        guessed_safe = [
+            name for name, spec in COMPONENTS.items() if spec.policy is SecretPolicy.SHARE_SAFE
+        ]
+        assert (
+            guessed_safe == []
+        ), f"{guessed_safe} claim SHARE_SAFE without content redaction behind it"
+
+
+class TestResolveComponents:
+    def test_unknown_name_is_refused_not_silently_dropped(self):
+        with pytest.raises(ComponentRefused) as e:
+            resolve_components(["memory", "bogus"], Purpose.BACKUP)
+        assert "bogus" in str(e.value)
+
+    def test_share_refuses_an_unresolved_component(self):
+        with pytest.raises(ComponentRefused) as e:
+            resolve_components(["memory", "config"], Purpose.SHARE)
+        msg = str(e.value)
+        assert "config" in msg
+        # The refusal has to say how to proceed, or it just blocks the operator.
+        assert "--purpose backup" in msg or "--components" in msg
+
+    def test_share_refuses_every_component_today(self):
+        """The gate is live and nothing is certified, so share refuses each one.
+
+        Asserted per component rather than once, so certifying one later fails here
+        and forces this expectation to be revisited deliberately.
+        """
+        for name in COMPONENTS:
+            with pytest.raises(ComponentRefused) as e:
+                resolve_components([name], Purpose.SHARE)
+            assert "no share-safe policy" in str(e.value)
+
+    def test_the_share_refusal_explains_that_it_is_a_content_question(self):
+        with pytest.raises(ComponentRefused) as e:
+            resolve_components(["memory"], Purpose.SHARE)
+        msg = str(e.value)
+        assert "CONTENT" in msg
+        assert "--purpose backup" in msg, "the refusal must say how to proceed"
+
+    def test_backup_allows_everything(self):
+        assert resolve_components(None, Purpose.BACKUP) == list(COMPONENTS)
+
+    def test_a_full_share_bundle_is_refused_while_any_policy_is_unresolved(self):
+        """`--purpose share` with no `--components` must not quietly ship config."""
+        with pytest.raises(ComponentRefused):
+            resolve_components(None, Purpose.SHARE)
+
+
+class TestSelectiveStaging:
+    def test_memory_only_bundle_omits_other_components(self, src, tmp_path):
+        snap = _extract(_snapshot(tmp_path / "out", ["--components", "memory"]), tmp_path / "x1")
+        assert (snap / "memory.db").is_file()
+        # Not selected, so not staged. This is what makes a memory bundle 22 MB
+        # instead of the whole data home.
+        assert not (snap / "config.json").exists()
+        assert not (snap / "crons.json").exists()
+        assert not (snap / "skills").exists()
+
+    def test_memory_component_is_self_contained(self, src, tmp_path):
+        """Both halves of memory ride: the databases and the markdown files.
+
+        Before the memory component named these trees they reached a bundle only
+        through the whole-`workspace` component, so restoring memory meant
+        restoring every unrelated working file too.
+        """
+        snap = _extract(_snapshot(tmp_path / "out", ["--components", "memory"]), tmp_path / "x2")
+        assert (snap / "workspace/memory/preferences.md").is_file()
+        assert (snap / "workspace/memory/projects.md").is_file()
+        assert (snap / "workspace/memory/history/2026-01-01.md").is_file()
+        assert (snap / "workspace/knowledge/kb.sqlite3").is_file()
+        # Memory does NOT drag the rest of the workspace in.
+        assert not (snap / "workspace/doc.md").exists()
+        assert not (snap / "plan_memory").exists()
+
+    def test_manifest_records_purpose_and_declared_policies(self, src, tmp_path):
+        snap = _extract(
+            _snapshot(tmp_path / "out", ["--components", "memory,crons"]), tmp_path / "x3"
+        )
+        m = json.loads((snap / "MANIFEST.json").read_text(encoding="utf-8"))
+        assert m["purpose"] == "backup"
+        # crons rides a BACKUP unchanged, and its declaration says why a share
+        # bundle would refuse it.
+        assert m["components"] == {"memory": "unresolved", "crons": "unresolved"}
+
+    def test_a_share_bundle_refuses_crons(self, src, tmp_path, capsys):
+        out = tmp_path / "out"
+        assert snapshot_main([str(out), "--components", "crons", "--purpose", "share"]) == 1
+        assert "crons" in capsys.readouterr().out
+        assert not list(out.glob("kirocrew-snapshot-*.tar.gz"))
+
+    def test_a_file_only_component_with_nothing_to_stage_still_produces_a_bundle(
+        self, src, tmp_path
+    ):
+        """An empty selection is a valid outcome; a crash is not.
+
+        `crons` names only files, so a home without crons.json stages nothing --
+        which used to leave the staging dir uncreated and fail the manifest write.
+        """
+        (src / "crons.json").unlink(missing_ok=True)
+        snap = _extract(_snapshot(tmp_path / "out", ["--components", "crons"]), tmp_path / "x5")
+        m = json.loads((snap / "MANIFEST.json").read_text(encoding="utf-8"))
+        assert m["components"] == {"crons": "unresolved"}
+        assert not (snap / "crons.json").exists()
+
+    def test_share_produces_no_bundle_while_nothing_is_certified(self, src, tmp_path, capsys):
+        """`--purpose share` is wired end to end and refuses, writing nothing."""
+        out = tmp_path / "out"
+        assert snapshot_main([str(out), "--components", "memory", "--purpose", "share"]) == 1
+        assert "no share-safe policy" in capsys.readouterr().out
+        assert not list(out.glob("kirocrew-snapshot-*.tar.gz"))
+
+    def test_share_of_a_credential_bearing_component_fails_and_writes_nothing(
+        self, src, tmp_path, capsys
+    ):
+        out = tmp_path / "out"
+        assert snapshot_main([str(out), "--components", "config", "--purpose", "share"]) == 1
+        assert "config" in capsys.readouterr().out
+        # A refusal must cost nothing — no partial bundle left behind.
+        assert not list(out.glob("kirocrew-snapshot-*.tar.gz"))
+
+    def test_unknown_purpose_is_refused(self, src, tmp_path, capsys):
+        out = tmp_path / "out"
+        assert snapshot_main([str(out), "--purpose", "sideways"]) == 1
+        assert "sideways" in capsys.readouterr().out
+        assert not list(out.glob("kirocrew-snapshot-*.tar.gz"))
+
+
+class TestMemoryRoundTrip:
+    def test_memory_only_restore_reproduces_both_halves(self, src, tmp_path, monkeypatch):
+        """The M1 exit criterion: a memory bundle restored onto an empty home brings
+        back every semantic key, episodic row and the markdown files — without the
+        workspace component."""
+        tarball = _snapshot(tmp_path / "out", ["--components", "memory"])
+
+        src_conn = sqlite3.connect(str(src / "memory.db"))
+        want_semantic = src_conn.execute("SELECT count(*) FROM semantic_memory").fetchone()[0]
+        want_episodic = src_conn.execute("SELECT count(*) FROM episodic_memories").fetchone()[0]
+        src_conn.close()
+        assert want_semantic > 0 and want_episodic > 0
+
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+        assert (
+            restore_main(
+                [str(tarball), "--components", "memory", "--mode", "replace", "--force"]
+                + unpinnable_argv()
+            )
+            == 0
+        )
+
+        assert (dest / "memory.db").is_file()
+        dest_conn = sqlite3.connect(str(dest / "memory.db"))
+        assert (
+            dest_conn.execute("SELECT count(*) FROM semantic_memory").fetchone()[0] == want_semantic
+        )
+        assert (
+            dest_conn.execute("SELECT count(*) FROM episodic_memories").fetchone()[0]
+            == want_episodic
+        )
+        dest_conn.close()
+
+        assert (dest / "workspace/memory/preferences.md").read_text() == (
+            src / "workspace/memory/preferences.md"
+        ).read_text()
+        assert (dest / "workspace/memory/history/2026-01-01.md").is_file()
+        assert (dest / "workspace/knowledge/kb.sqlite3").is_file()
+
+    def test_memory_restore_leaves_the_rest_of_the_workspace_alone(
+        self, src, tmp_path, monkeypatch
+    ):
+        """Restoring memory in replace mode must not rmtree the whole workspace."""
+        tarball = _snapshot(tmp_path / "out", ["--components", "memory"])
+
+        dest = tmp_path / "dest2"
+        (dest / "workspace").mkdir(parents=True)
+        keep = dest / "workspace" / "unrelated.md"
+        keep.write_text("local work, not in the bundle\n")
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+
+        assert (
+            restore_main(
+                [str(tarball), "--components", "memory", "--mode", "replace", "--force"]
+                + unpinnable_argv()
+            )
+            == 0
+        )
+        assert keep.read_text() == "local work, not in the bundle\n"
+        assert (dest / "workspace/memory/preferences.md").is_file()

--- a/test/test_snapshot_redaction.py
+++ b/test/test_snapshot_redaction.py
@@ -1,0 +1,919 @@
+"""The copy that leaves the host is redacted; the copy on local disk is not.
+
+The boundary is the copy that crosses off-host, not the archive. A local bundle sits on
+the machine that already holds these secrets, so redacting it would destroy the only copy
+that restores complete and buy nothing. What crosses the boundary is a separate, redacted
+copy, produced by ``snapshot.prepare_redacted_copy`` -- the seam an off-host sender
+consumes. The destination itself (bucket, hardening, consent, transport) belongs to the
+AWS Control app; what stays here is rewriting the bytes that leave.
+"""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import snapshot as snap
+from kiro_crew import snapshot_redact
+
+
+def _real_db(path: Path, secret: str | None = None) -> bytes:
+    conn = snap.sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE semantic_memory (key, value_json)")
+    conn.execute("INSERT INTO semantic_memory VALUES (?, ?)", ("note", secret or "nothing secret"))
+    conn.commit()
+    conn.close()
+    return path.read_bytes()
+
+
+TOKEN = "8412345678:AAH9xSECRETtokenvalue_here12345"
+
+
+@pytest.fixture(autouse=True)
+def opted_in(monkeypatch):
+    """Outbound redaction is OFF by default, so these tests must ask for it.
+
+    Redaction is an opt-in the operator sets, so a test of the redaction PASS has to turn
+    it on the way an operator would. `TestTheOptOut` patches this same function in its own
+    bodies, which runs after this fixture and therefore still wins.
+    """
+    monkeypatch.setattr(snapshot_redact, "outbound_redaction_enabled", lambda: True)
+
+
+@pytest.fixture
+def bundle(tmp_path):
+    """A written archive carrying a bot token in config and a key inside memory."""
+    payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+    payload.mkdir(parents=True)
+    (payload / "config.json").write_text(
+        json.dumps({"telegram": {"bot_token": TOKEN}}), encoding="utf-8"
+    )
+    (payload / "memory.db").write_bytes(
+        _real_db(tmp_path / "src.db", f"my key is ghp_{'A' * 36} ok")
+    )
+    (payload / "memory_index.db").write_bytes(_real_db(tmp_path / "idx.db"))
+    (payload / "MANIFEST.json").write_text(
+        json.dumps({"version": 3, "components": {"memory": "unresolved"}}),
+        encoding="utf-8",
+    )
+    out = tmp_path / "kirocrew-snapshot-20260101T000000Z.tar.gz"
+    with tarfile.open(out, "w:gz") as tf:
+        tf.add(str(payload), arcname=payload.name)
+    return out
+
+
+@pytest.fixture
+def workdir(tmp_path):
+    """A caller-owned directory the redacted copy is written inside."""
+    d = tmp_path / "work"
+    d.mkdir()
+    return d
+
+
+def _prepare(bundle: Path, workdir: Path):
+    """Drive redaction through the surviving seam and return the redacted copy's path."""
+    return snap.prepare_redacted_copy(bundle, workdir, ["memory"])
+
+
+def _read_member(archive: Path, suffix: str) -> bytes:
+    with tarfile.open(archive) as tf:
+        for m in tf.getmembers():
+            if m.name.endswith(suffix):
+                f = tf.extractfile(m)
+                assert f is not None
+                return f.read()
+    raise AssertionError(f"{suffix} not found in {archive}")
+
+
+def _member_names(archive: Path) -> list[str]:
+    with tarfile.open(archive) as tf:
+        return tf.getnames()
+
+
+def _bundle_with(tmp_path: Path, extra: dict[str, bytes]) -> Path:
+    """A minimal valid bundle carrying *extra* entries alongside a real manifest."""
+    payload = tmp_path / "kirocrew-snapshot-20260101T000000Z"
+    payload.mkdir(parents=True)
+    (payload / "MANIFEST.json").write_text(
+        json.dumps({"version": 3, "components": {"memory": "unresolved"}}), encoding="utf-8"
+    )
+    (payload / "memory.db").write_bytes(_real_db(tmp_path / "m.db"))
+    for name, data in extra.items():
+        target = payload / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    out = tmp_path / "kirocrew-snapshot-20260101T000000Z.tar.gz"
+    with tarfile.open(out, "w:gz") as tf:
+        tf.add(str(payload), arcname=payload.name)
+    return out
+
+
+class TestTheOutboundCopyIsRedacted:
+    def test_the_token_does_not_leave_the_host(self, bundle, workdir, capsys):
+        redacted = _prepare(bundle, workdir)
+        out = capsys.readouterr().out
+        assert redacted is not None, out
+        assert TOKEN not in _read_member(redacted, "config.json").decode("utf-8")
+
+    def test_a_key_pasted_into_memory_does_not_leave_either(self, bundle, workdir, capsys):
+        redacted = _prepare(bundle, workdir)
+        assert redacted is not None, capsys.readouterr().out
+        assert b"ghp_" + b"A" * 36 not in _read_member(redacted, "memory.db")
+
+    def test_the_redacted_database_is_still_a_database(self, bundle, workdir, tmp_path, capsys):
+        """The whole reason redaction goes through SQL instead of over the bytes."""
+        redacted = _prepare(bundle, workdir)
+        assert redacted is not None, capsys.readouterr().out
+        restored = tmp_path / "roundtrip.db"
+        restored.write_bytes(_read_member(redacted, "memory.db"))
+        conn = snap.sqlite3.connect(str(restored))
+        assert conn.execute("PRAGMA integrity_check;").fetchone()[0] == "ok"
+        assert conn.execute("SELECT count(*) FROM semantic_memory").fetchone()[0] == 1
+        conn.close()
+
+    def test_the_local_bundle_is_left_unredacted(self, bundle, workdir, capsys):
+        redacted = _prepare(bundle, workdir)
+        assert redacted is not None, capsys.readouterr().out
+        assert TOKEN in _read_member(bundle, "config.json").decode(
+            "utf-8"
+        ), "the local archive was modified -- it must stay restorable"
+
+    def test_the_redacted_copy_lives_in_the_caller_workdir(self, bundle, workdir, capsys):
+        """The seam writes the copy inside the directory the caller controls and removes."""
+        redacted = _prepare(bundle, workdir)
+        assert redacted is not None, capsys.readouterr().out
+        assert workdir in redacted.parents, redacted
+        assert redacted != bundle
+
+    def test_it_reports_what_it_changed(self, bundle, workdir, capsys):
+        _prepare(bundle, workdir)
+        out = capsys.readouterr().out
+        assert "Redacted the outbound copy" in out, out
+        assert "config.json" in out, out
+        assert "still restores complete" in out, out
+
+
+class TestRedactionFailureRefusesRatherThanLeaking:
+    def test_a_pass_that_cannot_run_prepares_nothing(self, bundle, workdir, monkeypatch):
+        """An IO failure inside the pass is a refusal, not a traceback or a silent pass.
+
+        A traceback would leave the operator unable to tell a crash from a leak, and
+        "could not redact" must never fall through to "send it unredacted".
+        """
+
+        def boom(*_a, **_k):
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(snapshot_redact, "redact_bundle_for_egress", boom)
+        with pytest.raises(snap.RedactionFailed) as e:
+            _prepare(bundle, workdir)
+        assert "no space left on device" in str(e.value)
+
+    def test_an_unreadable_bundle_refuses_with_a_reason(self, tmp_path, workdir):
+        """Refused before redaction is even reached, by the re-read guard.
+
+        Asserted as a refusal rather than a message, because which guard catches it is an
+        ordering detail; that nothing usable is produced is the property.
+        """
+        broken = tmp_path / "kirocrew-snapshot-20260101T000000Z.tar.gz"
+        broken.write_bytes(b"not a tarball")
+        with pytest.raises(snap.RedactionFailed):
+            _prepare(broken, workdir)
+
+
+class TestTheOptOut:
+    def test_disabling_redaction_prepares_no_copy_so_the_original_is_sent(
+        self, bundle, workdir, monkeypatch, capsys
+    ):
+        # The opt-out is not a config field: it lives behind the keystone fence on the
+        # backup directory, because a switch the agent can write is a switch the agent can
+        # use to publish plaintext credentials through a sanctioned path.
+        monkeypatch.setattr(snapshot_redact, "outbound_redaction_enabled", lambda: False)
+        redacted = _prepare(bundle, workdir)
+        out = capsys.readouterr().out
+        assert redacted is None, out
+        assert "Redaction is DISABLED" in out, out
+        # None means the caller sends the ORIGINAL bundle -- which is unredacted.
+        assert TOKEN in _read_member(bundle, "config.json").decode(
+            "utf-8"
+        ), "the opt-out must leave the complete bundle to be sent"
+
+    def test_an_unreadable_app_config_does_not_change_the_switch(
+        self, bundle, workdir, monkeypatch, capsys
+    ):
+        """The switch is its own fenced file, not a field in the app config.
+
+        So a config that cannot be read says nothing about redaction either way: with the
+        operator opted in, the pass still runs.
+        """
+        from kiro_crew.config import loader as cfg_loader
+
+        def boom(*a, **k):
+            raise OSError("config unreadable")
+
+        monkeypatch.setattr(cfg_loader.KiroCrewConfig, "load", staticmethod(boom))
+        redacted = _prepare(bundle, workdir)
+        assert redacted is not None, capsys.readouterr().out
+        assert TOKEN not in _read_member(redacted, "config.json").decode("utf-8")
+
+
+class TestNothingUnprovableLeavesTheHost:
+    """Anything that cannot be shown redacted is removed, not shipped hoping it is fine."""
+
+    def test_secret_only_files_are_left_out(self, tmp_path, workdir, capsys):
+        out = _bundle_with(tmp_path, {"telemetry_salt": b"saltvalue", "sel_hmac.key": b"k"})
+        redacted = _prepare(out, workdir)
+        assert redacted is not None, capsys.readouterr().out
+        names = _member_names(redacted)
+        assert not any(n.endswith("telemetry_salt") for n in names), names
+        assert not any(n.endswith("sel_hmac.key") for n in names), names
+
+    def test_an_ordinary_source_file_is_redacted_not_deleted(self, tmp_path, workdir, capsys):
+        """A workspace holds arbitrary files; an unlisted suffix is not a reason to drop one.
+
+        `tool.py` is text. Deciding by suffix classified it as opaque and removed it, so an
+        off-host restore reported success while permanently lacking the operator's file.
+        """
+        out = _bundle_with(
+            tmp_path,
+            {
+                "workspace/project/tool.py": f'TOKEN = "{TOKEN}"\nprint("hi")\n'.encode(),
+                "workspace/data/rows.csv": b"a,b\n1,2\n",
+                "workspace/page.html": b"<p>ok</p>",
+            },
+        )
+        redacted = _prepare(out, workdir)
+        assert redacted is not None, capsys.readouterr().out
+        names = _member_names(redacted)
+        for keep in ("tool.py", "rows.csv", "page.html"):
+            assert any(n.endswith(keep) for n in names), f"{keep} was dropped: {names}"
+        # And it was actually redacted, not merely kept.
+        assert TOKEN not in _read_member(redacted, "tool.py").decode("utf-8")
+
+    def test_a_file_that_cannot_be_read_refuses_rather_than_passing(
+        self, tmp_path, workdir, monkeypatch
+    ):
+        """Unreadable is not the same as clean, and it must not escape as a traceback.
+
+        Patched rather than produced with permissions, because a mode-000 file is still
+        readable by its owner on Windows -- the branch would go untested exactly where the
+        platform differs.
+        """
+        out = _bundle_with(tmp_path, {"workspace/notes.md": b"hello"})
+        real_read = Path.read_text
+
+        def fail_on_notes(self, *a, **k):
+            if self.name == "notes.md":
+                raise OSError(5, "Input/output error")
+            return real_read(self, *a, **k)
+
+        monkeypatch.setattr(Path, "read_text", fail_on_notes)
+        with pytest.raises(snap.RedactionFailed) as e:
+            _prepare(out, workdir)
+        assert "Traceback" not in str(e.value)
+
+    def test_the_unreadable_signal_is_an_io_error(self):
+        """So the upload path's IO handler reports it instead of letting it escape."""
+        assert issubclass(snapshot_redact._FileUnreadable, OSError)
+
+    def test_a_genuinely_opaque_file_refuses_and_is_kept(self, tmp_path, workdir, capsys):
+        """Not text -> cannot be shown clean. Refuse; do not quietly drop the file.
+
+        The bytes here are undecodable on purpose: a NUL-filled file IS valid UTF-8, so
+        "looks binary" is not the test -- decoding is.
+        """
+        png = b"\x89PNG\r\n\x1a\n\xff\xd8\xff\xe0binary"
+        out = _bundle_with(tmp_path, {"workspace/shot.png": png})
+        with pytest.raises(snap.RedactionFailed) as e:
+            _prepare(out, workdir)
+        text = str(e.value)
+        assert "not text" in text, text
+        assert "shot.png" in text, text
+        assert "NOT removed" in text, text
+        # The local bundle is untouched, so the operator still holds the complete copy.
+        assert any(n.endswith("shot.png") for n in _member_names(out))
+
+    def test_a_corrupt_product_database_refuses_rather_than_shipping_without_it(
+        self, tmp_path, workdir
+    ):
+        """Dropping the payload IS shipping a broken backup, so this refuses instead.
+
+        This asserted that an unprovable product database was removed and the remainder
+        sent. That produces an off-host copy which reports success and restores nothing,
+        discovered only once the machine it came from is gone -- the exact failure the
+        feature exists to prevent. The database the backup carries is not a file that may
+        be silently omitted, so the copy is refused and names it, and the complete local
+        archive is left untouched.
+        """
+        out = _bundle_with(
+            tmp_path, {"workspace/knowledge/knowledge.db": b"this is not a database"}
+        )
+        with pytest.raises(snap.RedactionFailed) as e:
+            _prepare(out, workdir)
+        assert "knowledge.db" in str(e.value)
+
+    def test_a_corrupt_database_the_product_does_not_own_refuses(self, tmp_path, workdir):
+        """Deleting an operator's file to protect them from it is not a trade to make."""
+        out = _bundle_with(tmp_path, {"workspace/projects/notes.db": b"not a database"})
+        with pytest.raises(snap.RedactionFailed) as e:
+            _prepare(out, workdir)
+        assert "notes.db" in str(e.value)
+
+    def test_the_redacted_manifest_records_the_redaction(self, bundle, workdir, capsys):
+        """Restore's warning depends on this stamp, so the redaction pass must write it."""
+        redacted = _prepare(bundle, workdir)
+        assert redacted is not None, capsys.readouterr().out
+        mf = json.loads(_read_member(redacted, "MANIFEST.json").decode("utf-8"))
+        assert mf.get("redaction", {}).get("redacted") is True, mf
+        assert mf["redaction"]["replacements"], mf
+
+    def test_a_redaction_failure_prepares_nothing(self, tmp_path, workdir):
+        """Two roots is a state the pass refuses -- and a refusal must not produce a copy."""
+        stage = tmp_path / "two"
+        for name in ("kirocrew-snapshot-20260101T000000Z", "kirocrew-snapshot-other"):
+            (stage / name).mkdir(parents=True)
+        out = tmp_path / "kirocrew-snapshot-20260101T000000Z.tar.gz"
+        with tarfile.open(out, "w:gz") as tf:
+            for child in sorted(stage.iterdir()):
+                tf.add(str(child), arcname=child.name)
+
+        with pytest.raises(snap.RedactionFailed):
+            _prepare(out, workdir)
+
+
+class TestRestoreAnnouncesARedactedBundle:
+    def test_it_says_the_credentials_are_inert(self, tmp_path, capsys):
+        payload = tmp_path / "snap"
+        payload.mkdir()
+        (payload / "MANIFEST.json").write_text(
+            json.dumps(
+                {
+                    "version": 3,
+                    "components": {"memory": "unresolved"},
+                    "redaction": {
+                        "redacted": True,
+                        "replacements": {"config.json": 1},
+                        "dropped": ["telemetry_salt"],
+                        "indexes_needing_rebuild": ["memory_index.db"],
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        snap._report_redacted_bundle(payload)
+        out = capsys.readouterr().out
+        assert "REDACTED before it left its host" in out, out
+        assert "config.json: 1" in out, out
+        assert "Re-enter those credentials" in out, out
+        assert "rebuilding" in out, out
+
+    def test_it_stays_quiet_for_an_ordinary_bundle(self, tmp_path, capsys):
+        payload = tmp_path / "snap"
+        payload.mkdir()
+        (payload / "MANIFEST.json").write_text(
+            json.dumps({"version": 3, "components": {"memory": "unresolved"}}),
+            encoding="utf-8",
+        )
+        snap._report_redacted_bundle(payload)
+        assert capsys.readouterr().out == ""
+
+
+class TestNoRowidIsBelowTheScan:
+    """Every row is scanned, whatever its rowid -- including negative ones.
+
+    The pager used to open with `last = -1` and always select `handle > ?`, so any row whose
+    rowid was <= -1 was never yielded and its credential shipped in the "redacted" copy
+    while the report still claimed a successful replacement. SQLite lets you set an explicit
+    negative INTEGER PRIMARY KEY, so nothing exotic is needed to land there.
+
+    The INT64 minimum is included deliberately: it is the row that any FIXED sentinel floor
+    would still miss, so it is what distinguishes the actual fix (no floor on the first
+    page) from merely lowering the old one.
+    """
+
+    TOKEN = "AKIAIOSFODNN7EXAMPLE"
+
+    def _staged(self, tmp_path):
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        db = stage / "memory.db"
+        conn = snap.sqlite3.connect(str(db))
+        conn.executescript("CREATE TABLE t(id INTEGER PRIMARY KEY, body TEXT);")
+        for rid, label in (
+            (5, "positive"),
+            (-1, "minus-one"),
+            (-5, "negative"),
+            (-(2**63), "int64min"),
+        ):
+            conn.execute("INSERT INTO t(id, body) VALUES(?, ?)", (rid, f"{label} {self.TOKEN}"))
+        conn.commit()
+        conn.close()
+        return stage, db
+
+    def test_a_credential_at_a_negative_rowid_is_still_redacted(self, tmp_path):
+        stage, db = self._staged(tmp_path)
+        snapshot_redact.redact_bundle_for_egress(stage)
+
+        conn = snap.sqlite3.connect(str(db))
+        rows = conn.execute("SELECT id, body FROM t").fetchall()
+        conn.close()
+
+        assert len(rows) == 4, "the pass must not drop rows"
+        kept = [rid for rid, body in rows if self.TOKEN in (body or "")]
+        assert not kept, f"rowid(s) {kept} shipped the credential unredacted"
+
+    def test_the_report_counts_every_row_it_changed(self, tmp_path):
+        """A count that omits the skipped rows is how the bypass stayed invisible."""
+        stage, _ = self._staged(tmp_path)
+        report = snapshot_redact.redact_bundle_for_egress(stage)
+        assert report.replacements.get("memory.db") == 4, report.replacements
+
+
+class TestAWriteOnlyTriggerThatReplacesARowIsRefused:
+    """A body with no `DELETE` can still destroy a row, and those forms are refused.
+
+    `INSERT OR REPLACE` and `REPLACE INTO` delete the conflicting row and insert in its
+    place. The refusal looked only for `DELETE FROM`, so a trigger whose body only ever
+    "writes" could clobber a row in a table this pass never looked at -- and the fixpoint
+    can observe a settled database, never bring back a row that is gone.
+
+    Both directions are asserted, because a guard that fires on everything is as wrong as
+    one that fires on nothing: the two REPLACE spellings refuse, and a plain value-copying
+    trigger still goes through the fixpoint and gets cleaned. Refusing every non-FTS UPDATE
+    trigger was measured twice and rejected -- it discards the fixpoint and refuses the
+    product's own external-content index -- so the narrowness here is the point.
+    """
+
+    TOKEN = "AKIAIOSFODNN7EXAMPLE"
+
+    def _staged(self, tmp_path, schema: str, *, with_other: bool):
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        db = stage / "memory.db"
+        conn = snap.sqlite3.connect(str(db))
+        conn.executescript(schema)
+        if with_other:
+            conn.execute("INSERT INTO other(id, keep) VALUES(1, 'operator data')")
+        conn.execute("INSERT INTO t(id, body) VALUES(1, ?)", (f"secret {self.TOKEN}",))
+        conn.commit()
+        conn.close()
+        return stage, db
+
+    def test_insert_or_replace_in_an_update_trigger_refuses(self, tmp_path):
+        stage, _ = self._staged(
+            tmp_path,
+            """
+            CREATE TABLE t(id INTEGER PRIMARY KEY, body TEXT);
+            CREATE TABLE other(id INTEGER PRIMARY KEY, keep TEXT);
+            CREATE TRIGGER clobber AFTER UPDATE ON t BEGIN
+              INSERT OR REPLACE INTO other(id, keep) VALUES (1, 'stomped');
+            END;
+            """,
+            with_other=True,
+        )
+        with pytest.raises(snapshot_redact.PayloadDatabaseUnprovable):
+            snapshot_redact.redact_bundle_for_egress(stage)
+
+    def test_replace_into_in_an_update_trigger_refuses(self, tmp_path):
+        stage, _ = self._staged(
+            tmp_path,
+            """
+            CREATE TABLE t(id INTEGER PRIMARY KEY, body TEXT);
+            CREATE TABLE other(id INTEGER PRIMARY KEY, keep TEXT);
+            CREATE TRIGGER clobber AFTER UPDATE ON t BEGIN
+              REPLACE INTO other(id, keep) VALUES (1, 'stomped');
+            END;
+            """,
+            with_other=True,
+        )
+        with pytest.raises(snapshot_redact.PayloadDatabaseUnprovable):
+            snapshot_redact.redact_bundle_for_egress(stage)
+
+    def test_a_plain_value_writing_trigger_is_still_cleaned_not_refused(self, tmp_path):
+        """The discrimination half. Refusing this would discard the fixpoint."""
+        stage, db = self._staged(
+            tmp_path,
+            """
+            CREATE TABLE t(id INTEGER PRIMARY KEY, body TEXT, mirror TEXT);
+            CREATE TRIGGER copyval AFTER UPDATE ON t BEGIN
+              UPDATE t SET mirror = NEW.body WHERE id = NEW.id;
+            END;
+            """,
+            with_other=False,
+        )
+        snapshot_redact.redact_bundle_for_egress(stage)
+        conn = snap.sqlite3.connect(str(db))
+        body = conn.execute("SELECT body FROM t WHERE id=1").fetchone()[0]
+        conn.close()
+        assert self.TOKEN not in body, "the fixpoint no longer cleans a value-writing trigger"
+
+
+class TestFtsDetectionIsCaseInsensitive:
+    """SQLite stores DDL verbatim, and its own docs write `USING FTS5(...)`.
+
+    The detector folded only the all-lowercase spelling, so a table created the documented
+    way was not recognised as full-text: its `WITHOUT ROWID` shadow tables were scanned as
+    ordinary ones and the pager's `SELECT MAX(<handle>)` raised `no such column: rowid`,
+    refusing the ENTIRE backup of a sound database. A legitimate backup lost to a spelling.
+
+    Both halves are pinned: the uppercase table now redacts, AND the contentless refusal
+    still fires for an uppercase declaration -- a case fix that quietly stopped recognising
+    `content=''` would trade a false refusal for a real leak.
+    """
+
+    TOKEN = "AKIAIOSFODNN7EXAMPLE"
+
+    def _staged(self, tmp_path, ddl: str):
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        db = stage / "memory.db"
+        conn = snap.sqlite3.connect(str(db))
+        conn.executescript(ddl)
+        conn.execute("INSERT INTO docs(id, body) VALUES(1, ?)", (f"secret {self.TOKEN}",))
+        conn.commit()
+        conn.close()
+        return stage, db
+
+    def test_an_uppercase_fts5_table_does_not_refuse_a_sound_database(self, tmp_path):
+        stage, db = self._staged(
+            tmp_path,
+            """
+            CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT);
+            CREATE VIRTUAL TABLE docs_fts USING FTS5(body, content='docs', content_rowid='id');
+            """,
+        )
+        snapshot_redact.redact_bundle_for_egress(stage)
+        conn = snap.sqlite3.connect(str(db))
+        body = conn.execute("SELECT body FROM docs WHERE id=1").fetchone()[0]
+        conn.close()
+        assert self.TOKEN not in body
+
+    def test_a_contentless_index_is_still_refused_when_declared_uppercase(self, tmp_path):
+        """The half a naive case fix would lose."""
+        stage, _ = self._staged(
+            tmp_path,
+            """
+            CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT);
+            CREATE VIRTUAL TABLE docs_fts USING FTS5(body, CONTENT='');
+            """,
+        )
+        with pytest.raises(snapshot_redact.PayloadDatabaseUnprovable):
+            snapshot_redact.redact_bundle_for_egress(stage)
+
+
+class TestAGeneratedColumnCannotCarryACredentialOffHost:
+    """`PRAGMA table_info` omits GENERATED columns, and they are read-only.
+
+    So the row pass can neither see nor rewrite one. Two existing guards cover most of the
+    exposure -- the schema scan refuses a credential written as a literal in the generation
+    expression, and a STORED column is recomputed when its source is updated -- but neither
+    covers a credential ASSEMBLED across columns: no single value matches, the DDL holds
+    nothing, and the generated column materialises the whole key.
+
+    Reproduced before the fix with `a='AKIA'`, `b='IOSFODNN7EXAMPLE'` and
+    `joined AS (a || b) STORED`: nothing refused, and the outbound copy carried the key.
+
+    Refused rather than redacted, because a derived column cannot be rewritten in place. The
+    discrimination is asserted too: a generated column with nothing sensitive must NOT refuse,
+    and an FTS table -- whose own columns present as hidden flag 1 rather than 2 or 3 -- must
+    keep working, or this hardening becomes an outage for every full-text backup.
+    """
+
+    HEAD = "AKIA"
+    TAIL = "IOSFODNN7EXAMPLE"
+
+    def _staged(self, tmp_path, ddl: str, rows: list[tuple]):
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        conn.executescript(ddl)
+        for row in rows:
+            conn.execute(f"INSERT INTO t VALUES({', '.join('?' * len(row))})", row)
+        conn.commit()
+        conn.close()
+        return stage
+
+    _GEN = (
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b TEXT, "
+        "joined TEXT GENERATED ALWAYS AS (a || b) STORED);"
+    )
+
+    def test_a_credential_assembled_across_columns_refuses_the_upload(self, tmp_path):
+        stage = self._staged(tmp_path, self._GEN, [(1, self.HEAD, self.TAIL)])
+        with pytest.raises(snapshot_redact.PayloadDatabaseUnprovable) as e:
+            snapshot_redact.redact_bundle_for_egress(stage)
+        assert "GENERATED column" in str(e.value)
+
+    def test_a_generated_column_with_nothing_sensitive_is_not_refused(self, tmp_path):
+        """The discrimination half: refusing every generated column would be an outage."""
+        stage = self._staged(tmp_path, self._GEN, [(1, "hello", "world")])
+        snapshot_redact.redact_bundle_for_egress(stage)
+
+    def test_a_bytes_valued_generated_column_is_scanned_too(self, tmp_path):
+        """`isinstance(value, str)` alone would walk straight past this one.
+
+        The form matters. `a || b` over blobs yields TEXT, so that shape is caught by a
+        str-only filter anyway; `CAST(... AS BLOB)` genuinely stores bytes -- verified by
+        `typeof()` reporting `blob` and the driver handing back a `bytes` -- which is what
+        makes the bytes branch reachable rather than merely defensive.
+        """
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        conn.executescript(
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b TEXT, "
+            "joined BLOB GENERATED ALWAYS AS (CAST(a || b AS BLOB)) STORED);"
+        )
+        conn.execute("INSERT INTO t(id, a, b) VALUES(1, ?, ?)", (self.HEAD, self.TAIL))
+        conn.commit()
+        kind = conn.execute("SELECT typeof(joined) FROM t").fetchone()[0]
+        conn.close()
+        assert kind == "blob", f"probe no longer stores bytes ({kind}) -- retarget this test"
+
+        with pytest.raises(snapshot_redact.PayloadDatabaseUnprovable):
+            snapshot_redact.redact_bundle_for_egress(stage)
+
+    def test_an_fts_table_is_untouched_by_the_generated_column_check(self, tmp_path):
+        """FTS columns present as hidden flag 1, not 2 or 3, so they must not be swept in."""
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        conn.executescript("""
+            CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT);
+            CREATE VIRTUAL TABLE docs_fts USING fts5(body, content='docs', content_rowid='id');
+            """)
+        conn.execute("INSERT INTO docs(id, body) VALUES(1, ?)", (f"secret {self.HEAD}{self.TAIL}",))
+        conn.commit()
+        conn.close()
+        snapshot_redact.redact_bundle_for_egress(stage)
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        body = conn.execute("SELECT body FROM docs WHERE id=1").fetchone()[0]
+        conn.close()
+        assert self.HEAD + self.TAIL not in body
+
+
+class TestAStaleFtsIndexIsRebuiltEvenWithNoRowHits:
+    """The FTS rebuild used to be gated on `hits`, which cannot see this case.
+
+    An external-content FTS index keeps its own tokenized copy and does NOT auto-sync, so a
+    base table can move on and leave the index holding text no live row contains. The row scan
+    then reports `hits == 0` -- correctly, the rows are clean -- and a rebuild gated on that
+    never runs. VACUUM does not save it either: VACUUM repacks live content and never
+    re-tokenizes, and the stale doclist IS live content of the shadow table.
+
+    Reproduced before the fix: base row updated to drop the credential without syncing the
+    index, no refusal, and the egress copy still answered a MATCH for the key afterwards.
+
+    Asserted through a QUERY, and on the lowercased form in the bytes, because FTS5's default
+    tokenizer lowercases terms -- checking only the credential's own casing reports a clean
+    file for a database that still answers a search for it.
+    """
+
+    HEAD = "AKIA"
+    TAIL = "IOSFODNN7EXAMPLE"
+
+    def _staged(self, tmp_path, *, go_stale: bool):
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        conn.executescript("""
+            CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT);
+            CREATE VIRTUAL TABLE docs_fts USING fts5(body, content='docs', content_rowid='id');
+            """)
+        conn.execute(
+            "INSERT INTO docs(id, body) VALUES(1, ?)", (f"key {self.HEAD}{self.TAIL} here",)
+        )
+        conn.execute("INSERT INTO docs_fts(docs_fts) VALUES('rebuild')")
+        conn.commit()
+        if go_stale:
+            # The base table moves on without the index -- the ordinary external-content
+            # situation, with no trigger here to sync it.
+            conn.execute("UPDATE docs SET body = 'key redacted here' WHERE id = 1")
+            conn.commit()
+        conn.close()
+        return stage
+
+    def _searchable(self, stage) -> int:
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        try:
+            return conn.execute(
+                "SELECT count(*) FROM docs_fts WHERE docs_fts MATCH ?",
+                (self.HEAD + self.TAIL,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+    def test_a_stale_index_is_cleaned_even_though_no_row_matched(self, tmp_path):
+        stage = self._staged(tmp_path, go_stale=True)
+        assert self._searchable(stage) == 1, "probe did not create a stale index"
+
+        snapshot_redact.redact_bundle_for_egress(stage)
+
+        assert self._searchable(stage) == 0, "stale index still answers a search for the key"
+        raw = (stage / "memory.db").read_bytes()
+        assert (self.HEAD + self.TAIL).lower().encode() not in raw
+
+    def test_the_ordinary_case_still_works(self, tmp_path):
+        stage = self._staged(tmp_path, go_stale=False)
+        snapshot_redact.redact_bundle_for_egress(stage)
+        assert self._searchable(stage) == 0
+
+
+class TestATriggerOverwritingAnotherTableIsRefused:
+    """The redaction's own UPDATE can fire a trigger that overwrites UNRELATED rows.
+
+    Not a credential-survival problem -- a data-loss one, which is why the earlier trigger
+    measurements do not answer it. `UPDATE unrelated SET note='CLOBBERED'` runs when this pass
+    rewrites a value, and the operator's row reads 'CLOBBERED' in the copy that is uploaded
+    and later RESTORED. The fixpoint can observe a settled database; it cannot restore a value
+    that is gone.
+
+    Refused by TARGET, and the scope is the whole point. Two broader rules were measured and
+    fail: refusing every non-FTS UPDATE-writing trigger discards the fixpoint and the
+    product's own FTS index, and refusing any body containing an `UPDATE` breaks a mirror
+    column, which is ordinary and provably cleaned. The three tests below are the shapes that
+    must stay allowed; without them this class would read as a licence to widen the rule.
+    """
+
+    KEY = "AKIA" + "IOSFODNN7EXAMPLE"
+
+    def _run(self, tmp_path, ddl: str, insert_body: str = "items"):
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        conn.executescript(ddl)
+        conn.execute(f"INSERT INTO {insert_body}(body) VALUES(?)", (f"key {self.KEY} here",))
+        conn.commit()
+        conn.close()
+        return stage
+
+    def test_an_update_to_another_table_refuses(self, tmp_path):
+        stage = self._run(
+            tmp_path,
+            """
+            CREATE TABLE items(id INTEGER PRIMARY KEY, body TEXT);
+            CREATE TABLE unrelated(id INTEGER PRIMARY KEY, note TEXT);
+            INSERT INTO unrelated(id, note) VALUES(1, 'the operator''s own note');
+            CREATE TRIGGER clobber AFTER UPDATE ON items BEGIN
+              UPDATE unrelated SET note = 'CLOBBERED';
+            END;
+            """,
+        )
+        with pytest.raises(snapshot_redact.PayloadDatabaseUnprovable):
+            snapshot_redact.redact_bundle_for_egress(stage)
+        # Refused BEFORE the damage, not after: the note must still be the operator's.
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        note = conn.execute("SELECT note FROM unrelated WHERE id=1").fetchone()[0]
+        conn.close()
+        assert note == "the operator's own note"
+
+    def test_an_unbound_update_on_its_own_table_refuses(self, tmp_path):
+        """The residual the previous rule left open, now closed.
+
+        `UPDATE items SET note='CLOBBERED'` names the trigger's own table, so a rule keyed only
+        on the target let it through -- and with no row bound it rewrites EVERY row of the table
+        it fires on. Distinguished from the mirror column below by whether the statement is
+        bound to the triggering row at all, not by which table it names.
+        """
+        stage = self._run(
+            tmp_path,
+            """
+            CREATE TABLE items(id INTEGER PRIMARY KEY, body TEXT, note TEXT);
+            CREATE TRIGGER clobber_self AFTER UPDATE ON items BEGIN
+              UPDATE items SET note = 'CLOBBERED';
+            END;
+            """,
+        )
+        with pytest.raises(snapshot_redact.PayloadDatabaseUnprovable):
+            snapshot_redact.redact_bundle_for_egress(stage)
+
+    def test_a_mirror_column_on_its_own_table_is_still_allowed(self, tmp_path):
+        """Ordinary shape, and the fixpoint cleans it -- refusing it would be an outage."""
+        stage = self._run(
+            tmp_path,
+            """
+            CREATE TABLE items(id INTEGER PRIMARY KEY, body TEXT, mirror TEXT);
+            CREATE TRIGGER copyval AFTER UPDATE ON items BEGIN
+              UPDATE items SET mirror = NEW.body WHERE id = NEW.id;
+            END;
+            """,
+        )
+        snapshot_redact.redact_bundle_for_egress(stage)
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        body = conn.execute("SELECT body FROM items WHERE id=1").fetchone()[0]
+        conn.close()
+        assert self.KEY not in body
+
+    def test_an_insert_of_a_copy_is_still_allowed(self, tmp_path):
+        """An inserted copy is what the fixpoint exists for; only overwrites are refused."""
+        stage = self._run(
+            tmp_path,
+            """
+            CREATE TABLE items(id INTEGER PRIMARY KEY, body TEXT);
+            CREATE TABLE audit(note TEXT);
+            CREATE TRIGGER keep_old AFTER UPDATE ON items BEGIN
+              INSERT INTO audit(note) VALUES (OLD.body);
+            END;
+            """,
+        )
+        snapshot_redact.redact_bundle_for_egress(stage)
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        rows = conn.execute("SELECT note FROM audit").fetchall()
+        conn.close()
+        assert all(self.KEY not in (r[0] or "") for r in rows)
+
+
+class TestAWideEncodedCredentialCannotRideOutUnscanned:
+    """UTF-16LE with no BOM decodes as valid UTF-8, because NUL is a legal codepoint.
+
+    So the read succeeds, the text reads `A\\x00K\\x00I\\x00A...`, and no credential pattern can
+    match across the NULs. `_scrub` returns 0 hits and the file is reported handled while the
+    credential rides out intact. The NUL check that would have caught it sat inside `if hits:`,
+    where it only ever guarded against CORRUPTING a NUL-bearing file that did match.
+
+    Treating every NUL-bearing file as opaque was the prescribed remedy and is wrong: a workspace
+    routinely holds binary blobs, and `test_a_nul_bearing_file_with_no_credential_still_rides`
+    asserts an ordinary tar rides. Scanning the wide-encoding interpretations closes the bypass
+    without refusing files that carry nothing -- both halves are asserted below.
+    """
+
+    KEY = "AKIA" + "IOSFODNN7EXAMPLE"
+
+    def _stage(self, tmp_path):
+        stage = tmp_path / "stage"
+        (stage / "workspace").mkdir(parents=True)
+        return stage
+
+    def test_a_utf16le_credential_refuses_the_upload(self, tmp_path):
+        stage = self._stage(tmp_path)
+        f = stage / "workspace" / "notes.md"
+        f.write_bytes(f"my key is {self.KEY} keep safe".encode("utf-16-le"))
+        # The premise: nothing in this file matches as plain ASCII.
+        assert self.KEY.encode() not in f.read_bytes()
+
+        with pytest.raises(snapshot_redact.OpaqueFilesPresent):
+            snapshot_redact.redact_bundle_for_egress(stage)
+
+    def test_a_utf16be_credential_refuses_too(self, tmp_path):
+        stage = self._stage(tmp_path)
+        f = stage / "workspace" / "notes.md"
+        f.write_bytes(f"my key is {self.KEY} keep safe".encode("utf-16-be"))
+        with pytest.raises(snapshot_redact.OpaqueFilesPresent):
+            snapshot_redact.redact_bundle_for_egress(stage)
+
+    def test_a_utf32le_credential_refuses_too(self, tmp_path):
+        """UTF-16 coverage alone does not close this.
+
+        Read as UTF-16LE, a UTF-32LE credential is STILL NUL-separated -- `A\\x00` then `\\x00\\x00`
+        -- so it survived the UTF-16-only scan exactly as it survived the original one.
+        """
+        stage = self._stage(tmp_path)
+        f = stage / "workspace" / "notes.md"
+        f.write_bytes(f"my key is {self.KEY} keep safe".encode("utf-32-le"))
+        with pytest.raises(snapshot_redact.OpaqueFilesPresent):
+            snapshot_redact.redact_bundle_for_egress(stage)
+
+    def test_a_wide_encoded_blob_column_refuses(self, tmp_path):
+        """The column path had the same hole for the same reason.
+
+        It decodes latin-1, which is lossless byte-to-codepoint and therefore PRESERVES the NUL
+        spacing, so its zero-hit result was not evidence of a clean value.
+        """
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB)")
+        conn.execute("INSERT INTO t(id, v) VALUES(1, ?)", (self.KEY.encode("utf-16-le"),))
+        conn.commit()
+        conn.close()
+        with pytest.raises(snapshot_redact.PayloadDatabaseUnprovable):
+            snapshot_redact.redact_bundle_for_egress(stage)
+
+    def test_a_plain_ascii_credential_in_a_column_is_still_redacted(self, tmp_path):
+        """The discrimination half for the column path: refuse only what cannot be rewritten."""
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        conn.execute("INSERT INTO t(id, v) VALUES(1, ?)", (f"key {self.KEY} here",))
+        conn.commit()
+        conn.close()
+
+        snapshot_redact.redact_bundle_for_egress(stage)
+
+        conn = snap.sqlite3.connect(str(stage / "memory.db"))
+        got = conn.execute("SELECT v FROM t WHERE id=1").fetchone()[0]
+        conn.close()
+        assert self.KEY not in got
+
+    def test_a_nul_bearing_file_with_no_credential_is_untouched(self, tmp_path):
+        """The discrimination half -- refusing this would cost a legitimate upload."""
+        stage = self._stage(tmp_path)
+        f = stage / "workspace" / "blob.bin"
+        raw = b"\x00\x01binary\x00payload\x00nothing secret\x00"
+        f.write_bytes(raw)
+        snapshot_redact.redact_bundle_for_egress(stage)
+        assert f.read_bytes() == raw

--- a/test/test_snapshot_review_fixes.py
+++ b/test/test_snapshot_review_fixes.py
@@ -1,0 +1,633 @@
+"""Tests for the review findings on the first M1 SHA.
+
+Each one asserts the consequence, not the mechanism: what state would have been
+destroyed, or what would have escaped, if the fix were not there.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import tarfile
+from pathlib import Path
+
+import pytest
+from test_snapshot import _setup_fake_kirocrew, unpinnable_argv
+
+from kiro_crew import snapshot as snap_mod
+from kiro_crew.snapshot import restore_main, snapshot_main
+
+
+@pytest.fixture
+def src(tmp_path, monkeypatch):
+    d = tmp_path / "src"
+    _setup_fake_kirocrew(d)
+    monkeypatch.setenv("KIROCREW_HOME", str(d))
+    return d
+
+
+class TestReplaceKeepsARecoverableRollback:
+    """Restoring memory+workspace must not overwrite its own rollback copy."""
+
+    def test_the_original_memory_is_recoverable_after_a_full_replace(
+        self, src, tmp_path, monkeypatch
+    ):
+        # Bundle carries INCOMING content.
+        (src / "workspace/memory/preferences.md").write_text("incoming prefs\n")
+        out = tmp_path / "out"
+        assert snapshot_main([str(out)] + unpinnable_argv()) == 0
+        tars = sorted(out.glob("kirocrew-snapshot-*.tar.gz"))
+        assert tars
+
+        # Destination holds DIFFERENT, original content.
+        dest = tmp_path / "dest"
+        (dest / "workspace/memory").mkdir(parents=True)
+        (dest / "workspace/memory/preferences.md").write_text("ORIGINAL prefs\n")
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+
+        assert (
+            restore_main([str(tars[-1]), "--mode", "replace", "--force"] + unpinnable_argv()) == 0
+        )
+
+        # Live state is the incoming copy.
+        assert (dest / "workspace/memory/preferences.md").read_text() == "incoming prefs\n"
+
+        # And the pre-restore original is still recoverable from the rollback dir.
+        saved = list(dest.glob("pre-restore-*/workspace/memory/preferences.md"))
+        assert saved, "no rollback copy was kept"
+        assert (
+            saved[0].read_text() == "ORIGINAL prefs\n"
+        ), "the rollback copy was overwritten with incoming data"
+
+
+class TestLiveDatabasesAreStagedConsistently:
+    """A SQLite database inside a staged tree gets the backup API, not a byte copy."""
+
+    def _stage(self, src: Path, out: Path) -> Path:
+        assert snapshot_main([str(out), "--components", "memory"] + unpinnable_argv()) == 0
+        tar = sorted(out.glob("kirocrew-snapshot-*.tar.gz"))[-1]
+        extract = out / "x"
+        extract.mkdir(exist_ok=True)
+        with tarfile.open(str(tar)) as t:
+            t.extractall(extract, filter=lambda m, _d="": m)
+        return next(
+            d
+            for d in extract.iterdir()
+            if d.name.startswith(("kirocrew-snapshot-", "kirocrew-partial-"))
+        )
+
+    def test_a_knowledge_database_survives_with_its_rows(self, src, tmp_path):
+        kb = src / "workspace/knowledge/knowledge.db"
+        conn = sqlite3.connect(str(kb))
+        conn.execute("CREATE TABLE facts (id INTEGER PRIMARY KEY, body TEXT)")
+        conn.executemany("INSERT INTO facts (body) VALUES (?)", [("a",), ("b",), ("c",)])
+        conn.commit()
+        conn.close()
+
+        snap = self._stage(src, tmp_path / "out")
+        staged = snap / "workspace/knowledge/knowledge.db"
+        assert staged.is_file()
+        c = sqlite3.connect(str(staged))
+        assert c.execute("SELECT count(*) FROM facts").fetchone()[0] == 3
+        c.close()
+
+    def test_wal_and_shm_sidecars_are_not_staged(self, src, tmp_path):
+        """They describe the source's transaction state, not the copy's.
+
+        Asserted on a `.db` that SQLite CANNOT open, because that is the only case
+        where the glob is the thing doing the work: for a real database, re-opening
+        the staged copy makes SQLite discard the copied sidecars as a side effect, so
+        a test using a real database passes either way and proves nothing.
+        """
+        kdir = src / "workspace/knowledge"
+        (kdir / "notes.db").write_bytes(b"not a database")
+        (kdir / "notes.db-wal").write_bytes(b"stale journal")
+        (kdir / "notes.db-shm").write_bytes(b"stale shm")
+
+        snap = self._stage(src, tmp_path / "out")
+        staged = snap / "workspace/knowledge"
+        assert (staged / "notes.db").is_file(), "the operator's file must still ride"
+        assert not (staged / "notes.db-wal").exists(), "a WAL sidecar rode the bundle"
+        assert not (staged / "notes.db-shm").exists(), "a SHM sidecar rode the bundle"
+
+    def test_a_real_databases_sidecars_also_stay_out(self, src, tmp_path):
+        kb = src / "workspace/knowledge/knowledge.db"
+        conn = sqlite3.connect(str(kb))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE facts (id INTEGER PRIMARY KEY, body TEXT)")
+        conn.execute("INSERT INTO facts (body) VALUES ('uncheckpointed')")
+        conn.commit()
+        # Leave the connection OPEN so -wal / -shm exist on disk while we snapshot.
+        assert (src / "workspace/knowledge/knowledge.db-wal").exists()
+        try:
+            snap = self._stage(src, tmp_path / "out")
+            kdir = snap / "workspace/knowledge"
+            assert not list(kdir.glob("knowledge.db-*"))
+            # The committed row still arrives: the backup API checkpointed it.
+            c = sqlite3.connect(str(kdir / "knowledge.db"))
+            assert c.execute("SELECT count(*) FROM facts").fetchone()[0] == 1
+            c.close()
+        finally:
+            conn.close()
+
+    def test_a_non_database_named_db_still_rides(self, src, tmp_path, capsys):
+        """A .db file that is not SQLite is the operator's file — keep the byte copy."""
+        decoy = src / "workspace/knowledge/notes.db"
+        decoy.write_bytes(b"not a database at all")
+        snap = self._stage(src, tmp_path / "out")
+        assert (snap / "workspace/knowledge/notes.db").read_bytes() == b"not a database at all"
+
+    def test_a_hardlinked_database_the_walk_skipped_is_not_rebuilt(self, tmp_path):
+        """The consistency pass must not undo the walk's hardlink rejection.
+
+        The staging walk refuses a hardlink alias because the second link can point at a
+        file outside the component tree, and copying it would put content the tree does not
+        own into the bundle. That refusal is recorded as a SKIP and staging continues -- so
+        a second pass that rebuilds databases from the SOURCE, keyed only on the source
+        walk, reinstates precisely what was refused.
+
+        Reproduced before the guard existed: a `.db` hardlinked to a database outside the
+        tree was skipped as `not_regular`, then rebuilt here, and its rows rode the bundle.
+        """
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        secret = outside / "secret.db"
+        conn = sqlite3.connect(str(secret))
+        conn.execute("CREATE TABLE t(v TEXT)")
+        conn.execute("INSERT INTO t VALUES ('EXTERNAL')")
+        conn.commit()
+        conn.close()
+
+        tree = tmp_path / "live" / "knowledge"
+        tree.mkdir(parents=True)
+        (tree / "kb.db").hardlink_to(secret)
+        stage = tmp_path / "stage" / "knowledge"
+        stage.parent.mkdir(parents=True)
+
+        skips: list[str] = []
+        snap_mod._copytree_safe(
+            tree,
+            stage,
+            allow_unpinned=bool(unpinnable_argv()),
+            on_skip=lambda reason, _p: skips.append(reason),
+        )
+        assert skips, "the walk did not refuse the hardlink alias, so this proves nothing"
+        assert not (stage / "kb.db").exists()
+
+        snap_mod._restage_databases(tree, stage)
+        assert not (
+            stage / "kb.db"
+        ).exists(), "the consistency pass rebuilt a database the walk deliberately skipped"
+
+    def test_an_ordinary_database_is_still_restaged_consistently(self, tmp_path):
+        """The guard must not cost the pass its actual job."""
+        tree = tmp_path / "live" / "knowledge"
+        tree.mkdir(parents=True)
+        conn = sqlite3.connect(str(tree / "kb.db"))
+        conn.execute("CREATE TABLE t(v TEXT)")
+        conn.execute("INSERT INTO t VALUES ('MINE')")
+        conn.commit()
+        conn.close()
+        stage = tmp_path / "stage" / "knowledge"
+        stage.parent.mkdir(parents=True)
+
+        snap_mod._copytree_safe(tree, stage, allow_unpinned=bool(unpinnable_argv()))
+        assert (stage / "kb.db").is_file()
+        snap_mod._restage_databases(tree, stage)
+
+        c = sqlite3.connect(str(stage / "kb.db"))
+        assert [r[0] for r in c.execute("SELECT v FROM t")] == ["MINE"]
+        c.close()
+
+
+class TestADestinationRootSwappedAfterPreflightRefuses:
+    """A replace that loses a memory tree mid-run must refuse, not report success.
+
+    ``_refuse_unsafe_destination_roots`` is hoisted ahead of every mutation, and its own
+    docstring gives the reason: checking inside the per-tree loop was too late, because
+    skipping an unsafe tree left memory split between two versions while the command still
+    reported success. One site kept the old behaviour -- the ``mem_roots`` build
+    ``continue``d past a root that failed the very same check -- so a root that went bad
+    AFTER the pre-flight was dropped from the set entirely, neither saved nor restored,
+    and the run still printed "Replace complete."
+
+    The swap is injected from INSIDE a wrapper around the pre-flight rather than planted
+    beforehand. Planting it first only proves the pre-flight works, which it does and which
+    is not this test's subject. The wrapper's fire count is asserted first, because a
+    monkeypatch that silently never ran would make every assertion after it vacuous.
+    """
+
+    def test_it_refuses_instead_of_reporting_a_complete_replace(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        import os
+        import shutil
+
+        outside = tmp_path / "outside"
+        (outside / "victim").mkdir(parents=True)
+        (outside / "victim" / "precious.txt").write_text("survives\n", encoding="utf-8")
+
+        source = tmp_path / "source"
+        _setup_fake_kirocrew(source)
+        monkeypatch.setenv("KIROCREW_HOME", str(source))
+        outdir = tmp_path / "snaps"
+        assert snapshot_main([str(outdir), "--components", "memory"] + unpinnable_argv()) == 0
+        bundle = sorted(outdir.glob("*.tar.gz"))[0]
+
+        home = tmp_path / "home"
+        _setup_fake_kirocrew(home)
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+
+        real = snap_mod._refuse_unsafe_destination_roots
+        fired: list[bool] = []
+
+        def _preflight_then_swap(mc, components):
+            real(mc, components)
+            shutil.rmtree(home / "workspace")
+            os.symlink(str(outside / "victim"), str(home / "workspace"))
+            fired.append(True)
+
+        monkeypatch.setattr(snap_mod, "_refuse_unsafe_destination_roots", _preflight_then_swap)
+        capsys.readouterr()
+
+        rc = restore_main([str(bundle), "--mode", "replace", "--force"] + unpinnable_argv())
+        out = capsys.readouterr().out
+
+        assert fired, "the mid-run swap never fired -- every assertion below would be vacuous"
+        assert "Replace mode" in out, "never reached the phase under test"
+        assert rc != 0, "a replace that lost both memory trees reported success"
+        assert "stopped resolving inside the data home" in out
+        assert "Replace complete" not in out
+        assert (outside / "victim" / "precious.txt").read_text(encoding="utf-8") == "survives\n"
+
+
+class TestRollbackWillNotDeleteWhatItNeverSaved:
+    """Recovery must not delete an occupant it cannot prove this run created.
+
+    `installed` records a core file BEFORE the save is known to have happened -- deliberately,
+    so a crash mid-write still leaves the name known to have been reached. But the save only
+    happens on two branches, a symlink or a regular file. A core file's path occupied by a
+    DIRECTORY matches neither, so nothing is saved while the name is recorded anyway, and
+    recovery's "nothing saved AND this run put it here" branch then had no evidence for the
+    second half of its own claim.
+
+    Reproduced before the fix: a directory at `crons.json` holding operator data was deleted
+    with its contents, the failure list came back empty, and the run printed "Previous state
+    restored." Data loss announced as a successful recovery, which is the one thing recovery
+    must never say.
+    """
+
+    def test_a_pre_existing_directory_at_a_core_file_name_is_kept_and_reported(self, tmp_path):
+        home = tmp_path / "home"
+        _setup_fake_kirocrew(home)
+        backup = tmp_path / "pre-restore"
+        backup.mkdir()
+
+        occupant = home / "crons.json"
+        if occupant.exists() or occupant.is_symlink():
+            occupant.unlink()
+        occupant.mkdir()
+        (occupant / "operator-data.txt").write_text("predates this run\n", encoding="utf-8")
+
+        # Exactly the state the backup pass leaves: recorded as reached, nothing saved.
+        assert not (backup / "crons.json").exists()
+
+        failed = snap_mod._restore_everything_from_rollback(
+            backup, home, ["crons.json"], {"crons.json"}
+        )
+
+        assert (occupant / "operator-data.txt").read_text(
+            encoding="utf-8"
+        ) == "predates this run\n", "recovery deleted data it never saved a copy of"
+        assert occupant.is_dir()
+        assert failed, "the refusal has to be reported, not silently skipped"
+        assert "crons.json" in failed[0]
+
+    def test_the_flat_core_file_set_is_derived_from_the_component_specs(self):
+        """A hand-kept copy would drift exactly when a component is added."""
+        expected = {f for files in snap_mod.CORE_FILES.values() for f in files}
+        assert set(snap_mod.CORE_FILES_FLAT) == expected
+        assert "crons.json" in snap_mod.CORE_FILES_FLAT
+
+
+class TestMergeRefusesADestinationRootSwappedAfterPreflight:
+    """Merge must refuse a root that stopped resolving inside the home, not write through it.
+
+    `_do_merge` calls the same pre-flight as replace and then had NO use-time re-check before
+    `dd.mkdir(parents=True)` and the copy. Reproduced: with `workspace` replaced by an
+    external symlink immediately after the pre-flight, merge created the tree THROUGH the link
+    and wrote four of the operator's memory files into a directory outside the data home --
+    and printed "Merge complete."
+
+    The per-file screens cannot catch this. Each final component is a fresh regular file, and
+    a by-name open does not examine its ancestors, so `O_NOFOLLOW` per file is satisfied while
+    the whole tree lands somewhere else. Refusing on the ROOT is what closes it.
+
+    The swap is injected from inside a wrapper around the pre-flight; planting it beforehand
+    would only prove the pre-flight works, which is not this test's subject. The wrapper's
+    fire count is asserted first, or every assertion after it is vacuous.
+    """
+
+    def test_it_refuses_instead_of_merging_outside_the_data_home(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        import os
+        import shutil
+
+        outside = tmp_path / "outside"
+        (outside / "victim").mkdir(parents=True)
+        (outside / "victim" / "precious.txt").write_text("survives\n", encoding="utf-8")
+
+        source = tmp_path / "source"
+        _setup_fake_kirocrew(source)
+        monkeypatch.setenv("KIROCREW_HOME", str(source))
+        outdir = tmp_path / "snaps"
+        assert snapshot_main([str(outdir), "--components", "memory"] + unpinnable_argv()) == 0
+        bundle = sorted(outdir.glob("*.tar.gz"))[0]
+
+        home = tmp_path / "home"
+        _setup_fake_kirocrew(home)
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+
+        real = snap_mod._refuse_unsafe_destination_roots
+        fired: list[bool] = []
+
+        def _preflight_then_swap(mc, components):
+            real(mc, components)
+            shutil.rmtree(home / "workspace")
+            os.symlink(str(outside / "victim"), str(home / "workspace"))
+            fired.append(True)
+
+        monkeypatch.setattr(snap_mod, "_refuse_unsafe_destination_roots", _preflight_then_swap)
+        capsys.readouterr()
+
+        # The flag matters for the SUBJECT, not just for getting past staging: without it,
+        # a platform with no directory descriptors would refuse this merge for the PINNING
+        # reason and `rc != 0` below would pass for the wrong reason -- green while proving
+        # nothing about the destination-root check this test exists for.
+        rc = restore_main([str(bundle), "--mode", "merge", "--force"] + unpinnable_argv())
+        out = capsys.readouterr().out
+
+        assert fired, "the mid-run swap never fired -- every assertion below would be vacuous"
+        assert rc != 0, "merge reported success while writing outside the data home"
+        assert "stopped resolving inside the data home" in out
+        assert "Merge complete" not in out
+
+        strays = [
+            p.relative_to(outside)
+            for p in outside.rglob("*")
+            if p.is_file() and p.name != "precious.txt"
+        ]
+        assert not strays, f"merge wrote outside the data home: {strays}"
+        assert (outside / "victim" / "precious.txt").read_text(encoding="utf-8") == "survives\n"
+
+
+class TestReplaceDoesNotKeepAnIndexTheArchiveOmits:
+    """A derived index the archive does not carry must not survive a REPLACE.
+
+    `_backup_and_copy` skips a core file the bundle lacks -- correct for its own job, since
+    it has nothing to install -- so the live `memory_index.db` stayed put while `memory.db`
+    was replaced underneath it. The restore then ends with new memory and an index built from
+    the old, and searches answer from memory that is gone.
+
+    Reachable by the ORDINARY route, which is what makes it worth a test: the redaction pass
+    drops `memory_index.db` from an off-host bundle by design, so every restore from a
+    redacted bundle takes this path. The "restore warns about a missing index" argument that
+    justified the drop does not cover it -- that warning tests the file AFTER the restore, and
+    a surviving stale index means it never fires.
+
+    The memory-TREE loop already stated the rule ("a tree the archive does not have is a tree
+    the destination must not keep"); this is the same rule for a file.
+    """
+
+    def test_the_stale_index_is_removed_and_kept_for_rollback(self, tmp_path):
+        mc = tmp_path / "home"
+        mc.mkdir()
+        (mc / "memory.db").write_bytes(b"OLD-MEMORY")
+        (mc / "memory_index.db").write_bytes(b"INDEX-OF-OLD-MEMORY")
+
+        snap = tmp_path / "snap"
+        snap.mkdir()
+        (snap / "memory.db").write_bytes(b"NEW-MEMORY")  # no index, as redaction leaves it
+
+        backup = tmp_path / "rollback"
+        backup.mkdir()
+        installed: set[str] = set()
+
+        snap_mod._do_replace_mutations(
+            snap,
+            mc,
+            backup,
+            ["memory"],
+            [],
+            installed,
+            allow_unpinned=bool(unpinnable_argv()),
+        )
+
+        assert (mc / "memory.db").read_bytes() == b"NEW-MEMORY"
+        assert not (mc / "memory_index.db").exists(), "stale index survived the replace"
+        # Removed, not destroyed -- and recorded, so recovery knows this run reached it.
+        assert (backup / "memory_index.db").read_bytes() == b"INDEX-OF-OLD-MEMORY"
+        assert "memory_index.db" in installed
+
+    def test_an_index_the_archive_carries_is_installed_not_dropped(self, tmp_path):
+        """The discrimination half: this must not turn into "always delete the index"."""
+        mc = tmp_path / "home"
+        mc.mkdir()
+        (mc / "memory.db").write_bytes(b"OLD-MEMORY")
+        (mc / "memory_index.db").write_bytes(b"INDEX-OF-OLD-MEMORY")
+
+        snap = tmp_path / "snap"
+        snap.mkdir()
+        (snap / "memory.db").write_bytes(b"NEW-MEMORY")
+        (snap / "memory_index.db").write_bytes(b"INDEX-OF-NEW-MEMORY")
+
+        backup = tmp_path / "rollback"
+        backup.mkdir()
+        snap_mod._do_replace_mutations(
+            snap,
+            mc,
+            backup,
+            ["memory"],
+            [],
+            set(),
+            allow_unpinned=bool(unpinnable_argv()),
+        )
+        assert (mc / "memory_index.db").read_bytes() == b"INDEX-OF-NEW-MEMORY"
+
+    def test_the_two_derived_index_sets_agree(self):
+        """The restore side cannot import the redaction side's set, so pin the agreement.
+
+        `snapshot_redact` is loaded lazily to keep it out of the boot path, so the name is
+        duplicated rather than imported. A divergence would mean the redaction pass drops an
+        index that replace then leaves stale -- silently. This fails instead.
+        """
+        from kiro_crew import snapshot_redact
+
+        assert snap_mod._DERIVED_INDEXES == snapshot_redact._DERIVED_INDEXES
+
+
+class TestAnInterruptDuringReplaceStillRollsBack:
+    """A Ctrl-C mid-replace must not leave live state half swapped.
+
+    The handler used to catch `(OSError, DatabaseCopyFailed, PinnedPathRefusal)`.
+    `KeyboardInterrupt` is a `BaseException` and matches none of them, so it propagated past
+    the rollback entirely -- and its own comment already gave the reason `PinnedPathRefusal`
+    had to be in that tuple: it fires MID-mutation, so omitting it left live state half
+    replaced. An interrupt has exactly that property.
+
+    Reproduced: a Ctrl-C after the memory component was replaced left `memory.db` holding the
+    archive's copy and `crons.json` still live, with no rollback attempted.
+
+    Both halves are asserted, because rolling back is only half the requirement -- the
+    interrupt must still terminate the command rather than be swallowed into a success.
+    """
+
+    def _home(self, tmp_path):
+        mc = tmp_path / "home"
+        mc.mkdir()
+        (mc / "memory.db").write_bytes(b"LIVE-MEMORY")
+        (mc / "crons.json").write_text("[]")
+        snap = tmp_path / "snap"
+        snap.mkdir()
+        (snap / "memory.db").write_bytes(b"ARCHIVE-MEMORY")
+        (snap / "crons.json").write_text('[{"from": "archive"}]')
+        return mc, snap
+
+    def test_the_previous_state_is_restored_and_the_interrupt_propagates(
+        self, tmp_path, monkeypatch
+    ):
+        mc, snap = self._home(tmp_path)
+        real = snap_mod._do_replace_mutations
+        fired = {"n": 0}
+
+        def interrupting(sd, home, backup, components, mem_roots, installed, **kw):
+            # Replace the memory component for real, so "partially replaced" is observable,
+            # then interrupt where the next component would begin.
+            real(sd, home, backup, ["memory"], mem_roots, installed, **kw)
+            fired["n"] += 1
+            raise KeyboardInterrupt("operator pressed Ctrl-C")
+
+        monkeypatch.setattr(snap_mod, "_do_replace_mutations", interrupting)
+
+        with pytest.raises(KeyboardInterrupt):
+            snap_mod._do_replace(snap, mc, None, allow_unpinned=bool(unpinnable_argv()))
+
+        assert fired["n"] == 1, "the injected interrupt never fired -- test proves nothing"
+        assert (mc / "memory.db").read_bytes() == b"LIVE-MEMORY", "rollback did not run"
+
+
+class TestABundleDeclaringAComponentItDoesNotCarryIsRefused:
+    """Declared-but-hollow: the manifest says a component rode, the bundle holds none of it.
+
+    Replace then clears the live state for that component with nothing to put back. Measured
+    end to end rather than on the mutation phase, because the guard is at the decision point --
+    calling `_do_replace_mutations` directly bypasses it and would report the old behaviour.
+
+    Two facts made this worth refusing rather than tolerating. The PRODUCT writes such a bundle:
+    a snapshot of a home with no memory payload declares `memory` anyway. And the damage is a
+    PARTIAL erasure, which is worse than either extreme -- the memory trees are cleared
+    unconditionally and the derived index is removed, while `memory.db` survives because the
+    bundle has no copy to install. The database is kept and the notes indexed against it are not.
+
+    The explicit-selection branch already refused this exact situation, with the rationale that
+    replace "would move the live files of that component out to the rollback dir and have
+    nothing to put back". Only the manifest-derived branch was missing the check.
+    """
+
+    def test_a_hollow_memory_declaration_refuses_instead_of_erasing(
+        self, src, tmp_path, monkeypatch
+    ):
+        # A home with the memory component present but no memory payload at all.
+        for name in ("memory.db", "memory_index.db"):
+            if (src / name).exists():
+                (src / name).unlink()
+        for tree in ("workspace", "plan_memory"):
+            if (src / tree).is_dir():
+                shutil.rmtree(src / tree)
+
+        out = tmp_path / "out"
+        assert snapshot_main([str(out)] + unpinnable_argv()) == 0
+        tars = sorted(out.glob("kirocrew-snapshot-*.tar.gz"))
+        assert tars
+
+        # A destination that DOES have memory, so a partial erasure would be observable.
+        dest = tmp_path / "dest"
+        (dest / "workspace" / "memory").mkdir(parents=True)
+        (dest / "workspace" / "memory" / "note.md").write_text("the operator's note\n")
+        (dest / "memory.db").write_bytes(b"LIVE-MEMORY")
+        (dest / "memory_index.db").write_bytes(b"LIVE-INDEX")
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+
+        rc = restore_main([str(tars[-1]), "--mode", "replace", "--force"] + unpinnable_argv())
+        assert rc == 1, "a bundle carrying no memory payload was accepted"
+
+        # Nothing touched: the refusal has to happen BEFORE any clearing, not after.
+        assert (dest / "workspace" / "memory" / "note.md").read_text() == "the operator's note\n"
+        assert (dest / "memory.db").read_bytes() == b"LIVE-MEMORY"
+        assert (dest / "memory_index.db").read_bytes() == b"LIVE-INDEX"
+
+    def test_an_explicit_selection_of_a_hollow_component_also_refuses(
+        self, src, tmp_path, monkeypatch
+    ):
+        """The mirror of the case above, and the half I missed when I fixed it.
+
+        The explicit-selection branch tested `c not in declared` -- membership in the
+        declaration, not whether any payload rode. So `--components memory` on a hollow bundle
+        passed the guard that exists for exactly this situation: `memory` IS declared, so
+        nothing looked absent, and replace went on to clear the live trees and index.
+
+        Both branches now ask the same question. Guarding one of them with a stronger test than
+        the other is what left this reachable.
+
+        The return code alone would NOT have caught it. Reproducing this showed `rc == 1`
+        already -- not from a refusal but from the memory.db integrity check failing later, by
+        which point the operator's notes were gone. So the load-bearing assertion is that the
+        note SURVIVES, and the destination gets a real database to keep the integrity check
+        from deciding the outcome.
+        """
+        for name in ("memory.db", "memory_index.db"):
+            if (src / name).exists():
+                (src / name).unlink()
+        for tree in ("workspace", "plan_memory"):
+            if (src / tree).is_dir():
+                shutil.rmtree(src / tree)
+
+        out = tmp_path / "out"
+        assert snapshot_main([str(out)] + unpinnable_argv()) == 0
+        tars = sorted(out.glob("kirocrew-snapshot-*.tar.gz"))
+
+        dest = tmp_path / "dest3"
+        (dest / "workspace" / "memory").mkdir(parents=True)
+        (dest / "workspace" / "memory" / "note.md").write_text("the operator's note\n")
+        conn = sqlite3.connect(str(dest / "memory.db"))
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, body TEXT)")
+        conn.commit()
+        conn.close()
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+
+        rc = restore_main(
+            [str(tars[-1]), "--mode", "replace", "--force", "--components", "memory"]
+            + unpinnable_argv()
+        )
+        # The property that matters: nothing was cleared. Checked FIRST because a non-zero rc
+        # can arrive from a later failure that says nothing about whether the guard fired.
+        assert (
+            dest / "workspace" / "memory" / "note.md"
+        ).read_text() == "the operator's note\n", "live memory was cleared before anything refused"
+        assert rc == 1, "an explicit selection of a component with no payload was accepted"
+
+    def test_a_bundle_that_does_carry_memory_still_restores(self, src, tmp_path, monkeypatch):
+        """The discrimination half: this must not refuse an ordinary bundle."""
+        (src / "workspace/memory/preferences.md").write_text("incoming prefs\n")
+        out = tmp_path / "out"
+        assert snapshot_main([str(out)] + unpinnable_argv()) == 0
+        tars = sorted(out.glob("kirocrew-snapshot-*.tar.gz"))
+
+        dest = tmp_path / "dest2"
+        (dest / "workspace" / "memory").mkdir(parents=True)
+        monkeypatch.setenv("KIROCREW_HOME", str(dest))
+        assert (
+            restore_main([str(tars[-1]), "--mode", "replace", "--force"] + unpinnable_argv()) == 0
+        )
+        assert (dest / "workspace/memory/preferences.md").read_text() == "incoming prefs\n"

--- a/test/test_snapshot_sqlite_uri.py
+++ b/test/test_snapshot_sqlite_uri.py
@@ -1,0 +1,69 @@
+"""A database whose filename contains `?` must still be copied correctly.
+
+Interpolating the path into a `file:` URI made everything after a `?` read as the URI's
+query string, so the path was truncated and a DIFFERENT database was opened — then
+stored under the name of the one that was asked for. Silent, and the bundle looks fine.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import closing
+
+import pytest
+
+from kiro_crew import snapshot
+
+
+def _make_db(path, marker: str) -> None:
+    with closing(sqlite3.connect(str(path))) as c:
+        c.execute("CREATE TABLE t (who TEXT)")
+        c.execute("INSERT INTO t VALUES (?)", (marker,))
+        c.commit()
+
+
+def _read(path) -> list[str]:
+    with closing(sqlite3.connect(str(path))) as c:
+        return [r[0] for r in c.execute("SELECT who FROM t")]
+
+
+@pytest.mark.skipif(not hasattr(sqlite3.Connection, "backup"), reason="needs the SQLite backup API")
+class TestAQuestionMarkInTheFilenameDoesNotRedirectTheCopy:
+    def _stage(self, tmp_path, name: str):
+        src_dir = tmp_path / "src"
+        dst_dir = tmp_path / "dst"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        # A truncated path would resolve to this decoy instead.
+        _make_db(src_dir / "memory", "decoy")
+        _make_db(src_dir / name, "wanted")
+        # _restage_databases only rewrites a staged file that already exists.
+        (dst_dir / name).write_bytes(b"")
+        return src_dir, dst_dir
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="Windows forbids `?` in a filename, so the case cannot be constructed",
+    )
+    def test_the_requested_database_is_the_one_copied(self, tmp_path):
+        name = "memory?snapshot=1.db"
+        src_dir, dst_dir = self._stage(tmp_path, name)
+        snapshot._restage_databases(src_dir, dst_dir)
+        assert _read(dst_dir / name) == [
+            "wanted"
+        ], "the copy opened a different database than the one requested"
+
+    def test_a_hash_in_the_filename_is_also_safe(self, tmp_path):
+        # `#` is legal on both platforms, so this case carries the invariant on
+        # Windows where the `?` case above cannot exist.
+        name = "memory#1.db"
+        src_dir, dst_dir = self._stage(tmp_path, name)
+        snapshot._restage_databases(src_dir, dst_dir)
+        assert _read(dst_dir / name) == ["wanted"]
+
+    def test_an_ordinary_name_still_works(self, tmp_path):
+        name = "plain.db"
+        src_dir, dst_dir = self._stage(tmp_path, name)
+        snapshot._restage_databases(src_dir, dst_dir)
+        assert _read(dst_dir / name) == ["wanted"]


### PR DESCRIPTION
## 1. What is the problem?

A Kiro Crew operator's memory, lessons, and session history live on one machine. Losing
that machine loses them. Two pieces are needed to make a backup actually useful, and
neither existed:

**Restoring is not the same as downloading.** Having an archive is not having your agent
back. Live state has to be replaced or merged with the gateway stopped, databases have to
be staged rather than copied over an open handle, saved symlinks have to be reinstated as
links, and a failure partway through must leave the machine as it was rather than half
restored. Nothing did that.

**A backup that leaves the host carries every secret it holds.** A snapshot is a faithful
copy, which is what makes it a good backup and a bad thing to put in object storage. The
AWS Control app now creates a private drive bucket and pushes to it, but a private bucket
still holds whatever was put into it, and a bundle restored elsewhere carries the original's
tokens verbatim. Nothing rewrote the bytes on their way out.

Scope note: this PR used to include the destination, its hardening, the consent grant, the
transport, session backups and the schedule. PR #5517 (AWS Control) shipped all of that, so
those parts were deleted here rather than merged twice.

## 2. Why this issue matters to the user

Without restore, a backup is a file you cannot use on the day you need it -- and the day you
need it is the day the machine is gone, which is the worst time to discover the archive only
half applies.

Without outbound redaction, turning on off-host backup silently ships your credentials. The
push path exists now, so this is live exposure rather than a hypothetical: whatever is in
the memory store leaves the machine on a nightly schedule.

## 3. How our fix solves it

**Restore into live state.** `kirocrew restore` takes a local archive and applies it with
`--mode replace` or `--mode merge`. Replace is two-phase: every declared tree is backed up
into a rollback directory BEFORE any is removed, so a failure on the third tree cannot leave
the first two gone. The rollback ledger records per file inside the copy loop rather than
from the declared set -- an earlier version recorded the intent, and a failure then printed
"Previous state restored." with an empty failure list while four config files were actually
deleted. Databases are only replaced when an existing regular file is there to replace, a
saved symlink is reinstated as a link before any branch that would dereference it, and
`PinnedPathRefusal` is caught in both rollback handlers because it subclasses `Exception`,
not `OSError`. An `s3://` argument is refused rather than treated as a filename, pointing
the operator at the app that owns fetching.

**Redact what leaves.** `snapshot_redact.py` rewrites the outbound copy through the repo's
credential and exfiltration-URL scanners. The design constraint is that it must never
degrade into shipping unredacted: a pass that cannot complete raises, and the caller treats
that as a refusal to send. Content that cannot be proven safe is refused rather than
scrubbed-and-hoped: bytes that are not text-shaped, a database that fails its integrity
check, a text container that declares its own extents (`startxref`, `content-length:` --
one rule covering PDF, WARC, HTTP archives, MIME multipart and mbox rather than a per-format
list), and a database whose triggers keep reintroducing values the scan just removed.
Databases are rewritten value-by-value through SQL and then rebuilt, so no old value
survives in page slack. Row reads are paged, text is capped at 64 MiB before being read, and
the local archive is never touched -- it lives on the machine that already holds these
secrets, and rewriting it would damage the only copy that restores complete.

**Wired into the push, in the order that makes it a control.** `prepare_redacted_copy` is a
destination-free seam: it takes a finished tarball and returns a redacted copy, or `None`
when the operator has not opted in. The app's `run_snapshot_backup` calls it BEFORE
authorizing the upload and before handing bytes to the transport, so a redaction that raises
stops the push. Reversing those two steps would leave the guarantee intact on paper while
sending the secrets anyway, which is why the app module is registered as its own redaction
sink in the security posture rather than left implicit.

**The switch is beyond the agent's reach.** Redaction is opt-in via
`<data home>/backup/redaction.json`, and that directory is classified sensitive for reading
as well as writing. Flipping it off is the attack; reading it tells an attacker whether the
store is currently being scrubbed. The DIRECTORY is classified, not just the leaf, because a
writable container is the same hole one level up -- replace it with a symlink and the
protected leaf resolves somewhere unprotected.

## 4. What tests we did

673 tests across the snapshot, redaction, staging and posture suites; all hard gates green
(subprocess-encoding, black, isort, flake8, mypy over 1127 files).

Findings are mutation-verified rather than assumed. Two worth naming because both were
mine:

- The redaction tests were repointed onto the new seam when `_upload_bundle` was deleted.
  To prove that rewrite was not vacuous, `prepare_redacted_copy` was mutated to hand back
  the unredacted original: 16 of 21 tests turned red. They detect unredacted egress.
- A structural ratchet asserted "every archive reader applies the member bound" by counting
  occurrences of the function name -- which counted its own `def` line, so a threshold of
  four passed with three real callers. It now asserts the call is present inside each reader
  by name, so a new reader that skips the bound has to be added here to stay green.

Two defects were found by verification rather than by the tests passing:

- Removing the now-obsolete destination record from the sensitive-path list also un-fenced
  `backup/redaction.json`, which lives in the same directory. Six tests caught it. The entry
  is restored with a rationale describing its live occupant instead of the deleted one.
- `test_a_database_that_never_settles_is_refused` did not fail, it HUNG, which is why it
  read as a suite timeout. The paged row reader advanced on `handle > last` and its comment
  asserted an UPDATE never changes the handle -- but the trigger under test INSERTS, so new
  rows kept appearing above the cursor and a single pass never terminated. The fixpoint cap
  counts passes, so it never got to fire. Each pass is now bounded by the maximum handle at
  its start; rows that appear mid-pass belong to the next one, which reports them, so a
  trigger that keeps reintroducing values is refused by the pass cap instead of hanging.

## 5. Any other suggestions on the work

**No scope question after all -- I withdrew one.** An earlier version of this description
offered to split `security.py` out, calling it +88/-68 of new shell/parameter scanner
logic. That was a misreading: those regexes exist on the merge base and the diff only
reformatted them. First Principles caught it. The file is now reverted to base with only
the one substantive change re-applied on top -- +15/-0, the `"backup"` sensitive-path entry
that fences the redaction switch, which belongs in this PR. The `.github/black-baseline.txt`
line went with the reformat and that file is out of the diff entirely.

**Still unverified end to end.** The redaction hook and the restore path have not been
exercised against a real push. The transport is the app's now, so what remains to verify
live is this PR's two halves rather than bucket provisioning.

**A gap the posture registry does not model.** The app's backup module is an egress boundary
that DELEGATES redaction to a registered sink. The registry has a slot for "runs a scanner"
and an allowlist named for non-egress modules, but none for "egress boundary that delegates",
so the row states the delegation in prose. Worth a shape the registry can check.
