### PR TITLE
perf(ci): shard the frontend test suite across 4 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,7 +678,7 @@ jobs:
     name: Coverage Gate
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [coverage-combine, frontend-test, backend-test, changes]
+    needs: [coverage-combine, frontend-test, frontend-coverage-merge, backend-test, changes]
     # Single source of truth for the floors -- referenced by the check steps,
     # their names, and the summary table so the three can never drift apart.
     #
@@ -718,11 +718,12 @@ jobs:
         env:
           CC: ${{ needs.coverage-combine.result }}
           FE: ${{ needs.frontend-test.result }}
+          FCM: ${{ needs.frontend-coverage-merge.result }}
           BE: ${{ needs.backend-test.result }}
           ONLY_BACKEND: ${{ needs.changes.outputs.only_backend }}
           ONLY_FRONTEND: ${{ needs.changes.outputs.only_frontend }}
         run: |
-          echo "coverage-combine=$CC  frontend-test=$FE  backend-test=$BE  only_backend=$ONLY_BACKEND  only_frontend=$ONLY_FRONTEND"
+          echo "coverage-combine=$CC  frontend-test=$FE  frontend-coverage-merge=$FCM  backend-test=$BE  only_backend=$ONLY_BACKEND  only_frontend=$ONLY_FRONTEND"
           # Empty flags mean the surface-detection job never reported (it failed
           # or was cancelled) -- its verdict can't be trusted, so fail closed.
           if [ -z "$ONLY_BACKEND" ] || [ -z "$ONLY_FRONTEND" ]; then
@@ -736,6 +737,21 @@ jobs:
           # signal, masking a failed reduced backend suite.
           if [ "$FE" != "success" ]; then
             echo "::error::frontend-test=$FE -- failing closed."
+            exit 1
+          fi
+          # Frontend coverage lane: frontend-coverage-merge unions the shard
+          # blobs into the coverage-frontend artifact. Required to succeed,
+          # EXCEPT on a backend-only diff where the frontend suite ran as a
+          # coverage-free subset and the merge job is skipped by design.
+          # Anything else (failure, cancellation, dependency-skip, or a run that
+          # happened when it shouldn't have) fails closed.
+          if [ "$ONLY_BACKEND" = "true" ]; then
+            if [ "$FCM" != "skipped" ]; then
+              echo "::error::frontend-coverage-merge=$FCM but this run was backend-only (expected exactly 'skipped') -- inconsistent."
+              exit 1
+            fi
+          elif [ "$FCM" != "success" ]; then
+            echo "::error::frontend-coverage-merge=$FCM -- failing closed."
             exit 1
           fi
           if [ "$BE" != "success" ]; then
@@ -997,8 +1013,22 @@ jobs:
     name: Frontend Tests
     needs: [changes]
     runs-on: ubuntu-latest
-    # vitest + coverage is the longest ubuntu job (~23 min observed max).
-    timeout-minutes: 50
+    # Per-shard budget. The whole suite was ~23 min on one runner; split four
+    # ways each shard is well under this, and a hung shard fails fast.
+    timeout-minutes: 25
+    strategy:
+      # Don't cancel sibling shards when one fails -- we want the full failure
+      # picture across the suite, not just the first shard to break.
+      fail-fast: false
+      matrix:
+        # vitest splits by TEST FILE (not test case) across shards. 4 shards
+        # cuts the ~950-file suite roughly fourfold and confines a fork-worker
+        # crash to one shard instead of reddening the whole job. To change the
+        # count, edit this list AND SHARD_COUNT together -- mind the ~20
+        # concurrent-job ceiling for public repos.
+        shard: [1, 2, 3, 4]
+    env:
+      SHARD_COUNT: 4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -1045,7 +1075,7 @@ jobs:
           echo "reduced=true" >> "$GITHUB_OUTPUT"
           echo "Reduced scope: $(wc -l < "$TARGETS_FILE") cross-surface spec(s)."
 
-      - name: Unit tests
+      - name: Unit tests (shard ${{ matrix.shard }}/${{ env.SHARD_COUNT }})
         working-directory: website
         env:
           # Two vitest gates are DIFF-SCOPED rather than baseline-scoped —
@@ -1069,24 +1099,88 @@ jobs:
           if [ "$REDUCED" = "true" ]; then
             # Subset run (backend-only diff): coverage of a subset is not
             # comparable to the repo floor, so it is not collected and the
-            # Coverage Gate skips the frontend lane for this run.
+            # Coverage Gate skips the frontend lane for this run. Still sharded
+            # and blob-reported so the merge job produces one unified result.
             TARGETS=()
             while IFS= read -r line; do line=${line%$'\r'}; if [ -n "$line" ]; then TARGETS+=("$line"); fi; done < "$TARGETS_FILE"
-            npx vitest run "${TARGETS[@]}"
+            # Still sharded so the matrix step is uniform; a target set smaller
+            # than SHARD_COUNT leaves some shards with no files, so
+            # --passWithNoTests keeps an empty shard green (a legitimately empty
+            # slice, not a lost suite).
+            npx vitest run --reporter=blob --passWithNoTests \
+              --shard=${{ matrix.shard }}/"$SHARD_COUNT" "${TARGETS[@]}"
           else
-            npx vitest run --coverage
+            # --reporter=blob stores results + per-shard coverage under
+            # website/.vitest-reports/; the frontend-coverage-merge job stitches
+            # the four shards back into one report and the merged cobertura the
+            # Coverage Gate reads. Coverage is emitted per shard so the merge
+            # can union it -- a single shard covers only the files it ran.
+            npx vitest run --coverage --reporter=blob \
+              --shard=${{ matrix.shard }}/"$SHARD_COUNT"
           fi
 
-      - name: Upload coverage
-        if: steps.scope.outputs.reduced != 'true'
+      - name: Upload shard blob report
+        # Always upload (even a failed shard) so the merge job can render the
+        # full picture; skipped only if the run itself was cancelled. The blob
+        # carries this shard's results AND its coverage data; the merge job
+        # unions them. .vitest-reports is a dot dir -> include-hidden-files.
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: frontend-blob-${{ matrix.shard }}
+          path: website/.vitest-reports/*
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
+
+  frontend-coverage-merge:
+    name: Frontend Coverage Merge
+    needs: [frontend-test, changes]
+    # Runs whenever the sharded run collected coverage -- any diff that is not
+    # backend-only. (A backend-only diff runs the frontend suite as a
+    # coverage-free subset, so there is nothing to merge and the Coverage Gate
+    # skips the frontend lane.) `!cancelled()` lets it still stitch a report
+    # when a shard failed, so the failure surfaces in one place.
+    if: ${{ !cancelled() && needs.changes.outputs.only_backend != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        working-directory: website
+        run: npm ci --no-audit --no-fund
+
+      - name: Download shard blob reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: website/.vitest-reports
+          pattern: frontend-blob-*
+          merge-multiple: true
+
+      - name: Merge reports and coverage
+        working-directory: website
+        # --merge-reports stitches the per-shard blobs back into one result set
+        # WITHOUT re-running tests; --coverage unions the per-shard coverage and
+        # re-emits the configured reporters (cobertura/lcov) under
+        # build/coverage/ -- the exact path + artifact name the Coverage Gate
+        # already consumes. A failed shard makes this exit non-zero, surfacing
+        # the failure here too.
+        run: npx vitest --merge-reports --coverage
+
+      - name: Upload merged coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-frontend
           # vitest's reportsDirectory is website/build/coverage (see
-          # vite.config.ts) -- NOT website/coverage. Uploading the wrong dir
-          # produced an empty artifact, which is why the Coverage Gate used to
-          # re-run vitest instead of consuming this. Fail loudly if the
-          # cobertura report is ever missing again.
+          # vite.config.ts). Fail loudly if the cobertura report is missing so a
+          # broken merge can never hand the Coverage Gate an empty artifact.
           path: website/build/coverage/
           if-no-files-found: error
 


### PR DESCRIPTION
## Problem
`frontend-test` runs the entire ~950-file vitest suite as **one unsharded** `npx vitest run --coverage` job (~16–23 min). It is the slowest ubuntu lane in CI and a single point of failure: because it's one job, a single fork-worker crash — or any single failing shard-worth of tests — reds the whole job, and Coverage Gate + PR Readiness go red downstream. `backend-test` has long been sharded; frontend was the lone outlier.

## Why it matters
Every PR pays the full serial FE time, and the whole FE signal collapses on one localized failure. Sharding cuts wall-clock ~4× and confines a failure/crash to one shard, so re-runs (and the blast radius) shrink dramatically.

## Fix (symptoms → root cause → change)
- **Symptom:** slow, all-or-nothing FE test lane.
- **Root cause:** the suite runs on a single runner with no sharding, so there's no parallelism across machines and no failure isolation.
- **Change:** shard with vitest's native `--shard` + `--reporter=blob` (the official vitest CI recipe, and the same shape as the existing backend matrix):
  - `frontend-test` becomes a `fail-fast: false` matrix `shard: [1,2,3,4]` (`SHARD_COUNT: 4`). Each shard runs `npx vitest run --coverage --reporter=blob --shard=i/4`, uploading its blob (`.vitest-reports/*`, hidden-files included) as `frontend-blob-<shard>`.
  - New **`frontend-coverage-merge`** job downloads the four blobs and runs `npx vitest --merge-reports --coverage`, which stitches the results back together **without re-running tests** and unions the per-shard coverage into the same `build/coverage/` cobertura report under the same **`coverage-frontend`** artifact the Coverage Gate already consumes.
  - **Coverage Gate** is unchanged except it now `needs` the merge job and fails closed if it isn't `success` (or isn't exactly `skipped` on a backend-only diff) — mirroring the existing `coverage-combine` handling.
  - Reduced (backend-only-diff) runs stay sharded with `--passWithNoTests`, so a cross-surface target set smaller than the shard count can't fail an empty slice.

Duration-balanced sharding (a `pytest-split`-style recorded-timings file, like backend's `.test_durations`) is intentionally **deferred** — vitest's native `--shard` is count-balanced, which is a big win with zero new tooling to maintain; time-balancing can layer on later.

## Tests
No unit tests — this is CI workflow config. Verified the mechanism end-to-end locally against the real suite:
- `--shard=1/4 --coverage --reporter=blob` runs in **61s** locally (vs ~16–23 min for the full unsharded suite) and writes `blob-1-4.json`.
- `vitest --merge-reports --coverage` reconstitutes `build/coverage/cobertura-coverage.xml` (proven with multiple shard blobs; single-shard line-rate 0.41 → unions upward across all four).
- Empty-shard case (`--shard=4/4` over a 2-file target set) exits **0** with `--passWithNoTests` and still writes a blob.
- `ci.yml` parses as valid YAML; job graph confirmed (matrix, merge `needs`/`if`, Coverage Gate `needs`).

## Manual verification
The real proof is this PR's own CI run: four `Frontend Tests (n)` shards → `Frontend Coverage Merge` → `Coverage Gate` consuming the merged `coverage-frontend`. **One thing to watch:** if branch protection lists a literal `Frontend Tests` required check, the matrix renames the check runs to `Frontend Tests (1..4)` — this is the same transition `backend-test` already made, so it should be workflow-level, but flagging it for the maintainer.

## Screenshots
N/A — no user-visible UI change.
