### PR TITLE
docs(token-auth): correct the link-consumption spec; annotate two safe yaml.load sites

### DIFF
--- a/docs/system-specs/features/dashboard-token-auth.md
+++ b/docs/system-specs/features/dashboard-token-auth.md
@@ -132,7 +132,11 @@ def check_token_ip(token: str, ip: str) -> bool: ...
 def mark_consumed(token: str) -> None: ...
 def is_consumed(token: str) -> bool: ...
 def try_consume(token: str) -> bool: ...
-    # Atomically check-and-consume (prevents TOCTOU race)
+    # Atomically check-and-consume (prevents TOCTOU race).
+    # NOT WIRED INTO THE MIDDLEWARE LINK PATH — see "Link re-exchange is
+    # deliberately allowed" below. These are a working primitive with unit
+    # coverage and no production caller; do not assume presenting a link twice
+    # is refused because they exist.
 
 def revoke_all_sessions() -> None: ...
     # Clears all nonces, IP bindings, and consumed tokens AND bumps the
@@ -169,10 +173,38 @@ Request flow:
 3. Extract token from `?token=` query param or `mc_token_{port}` cookie
 4. Validate signature + expiry (link window for query param, session_exp for cookie)
 5. Check IP binding
-6. Check consumption state — if consumed token re-clicked and browser has valid cookie, redirect to strip token from URL
-7. On first query-param use: bind IP, mark consumed, set cookie with `max_age` derived from `session_exp`
-8. Log to SEL
-9. Return 403 with JSON for `/api/*`, HTML for pages — **except** non-API `GET`/`HEAD` navigations, which are served the public SPA shell (see below)
+6. On query-param use: mint a SEPARATE session token, bind it to the peer key, add the link token's own nonce to the persisted denylist so the link string can never be presented as a cookie, and set `mc_token_{port}` with `max_age` derived from `session_exp`
+7. Log to SEL
+8. Return 403 with JSON for `/api/*`, HTML for pages — **except** non-API `GET`/`HEAD` navigations, which are served the public SPA shell (see below)
+
+#### Link re-exchange is deliberately allowed (the link is not single-use)
+
+Presenting the same `?token=` link more than once inside its 5-minute window
+**succeeds**, and each presentation re-exchanges for a fresh session cookie bound
+to the presenting peer. This is a deliberate design choice, not a missing control:
+remote-instance iframes re-derive `/?token=` on navigation, and self-nudge polling
+re-opens the same URL, so refusing the second presentation would break both.
+
+What the exchange *does* guarantee is that the link never becomes the long-lived
+credential. The cookie is a separate token with its own nonce, and the link's
+nonce is added to `RevokedNonceStore` at exchange, so a link captured from Slack,
+a log, or browser history cannot be replayed as `mc_token_{port}` on the cookie
+path (`use_session_exp=True`, which does consult the denylist). The link path
+(`use_session_exp=False`) does not consult it, which is what keeps re-navigation
+working.
+
+The residual exposure is therefore bounded by the 5-minute window: an observer who
+sees the URL inside that window can exchange it for their own session, pinned to
+their own peer. Two consequences follow, and both are accepted:
+
+- The window — not single-use — is the bound on link replay.
+- Deployments that need identity as a second factor must put one in front of the
+  origin (for example an alias-scoped tunnel allowlist), because the link alone is
+  a bearer credential for those 5 minutes.
+
+Making the link single-use is a live option, but it is a **behaviour change with
+known breakage** (iframe re-navigation, self-nudge polling) and needs an owner
+decision, not a silent tightening. `try_consume` is the primitive it would use.
 
 #### Liveness / readiness probes (rec #6)
 
@@ -530,7 +562,8 @@ Note: Loopback access (127.0.0.1) is always trusted for both token auth and CSRF
 | Expired token (link window or session) | 403 | JSON for `/api/*`, HTML for pages |
 | Invalid HMAC signature | 403 | JSON for `/api/*`, HTML for pages |
 | IP mismatch | 403 | JSON for `/api/*`, HTML + SEL log |
-| Consumed token re-click (browser has cookie) | 302 | Redirect to strip token from URL |
+| Link re-presented inside its 5-minute window | 200 | Allowed by design — re-exchanges for a fresh session cookie bound to the presenting peer (see *Link re-exchange is deliberately allowed*) |
+| Link string presented as the `mc_token_{port}` cookie | 403 | Rejected: its nonce is on the persisted denylist from the moment of exchange |
 | Consumed token from different client | 403 | JSON for `/api/*`, HTML for pages |
 | Malformed token (can't decode) | 403 | JSON for `/api/*`, HTML for pages |
 | Invalid duration in `!dashboard` | N/A | Slack usage message |

--- a/test/test_deploy_cwe770_throttle_waf.py
+++ b/test/test_deploy_cwe770_throttle_waf.py
@@ -46,7 +46,7 @@ _TagTolerantLoader.add_multi_constructor(None, _construct_intrinsic)
 
 
 def _load(text):
-    return yaml.load(text, Loader=_TagTolerantLoader)
+    return yaml.load(text, Loader=_TagTolerantLoader)  # noqa: S506 — tag-blind CFN parse
 
 
 class TestPartAApiGwThrottling:

--- a/test/test_deploy_round29_fixes.py
+++ b/test/test_deploy_round29_fixes.py
@@ -176,7 +176,7 @@ def _load_cfn_yaml(path: Path) -> dict:
     )
 
     with open(path) as f:
-        return yaml.load(f, Loader=CfnLoader)
+        return yaml.load(f, Loader=CfnLoader)  # noqa: S506 — tag-blind CFN parse
 
 
 class TestF3IdentitySourceList:


### PR DESCRIPTION
docs(token-auth): correct the link-consumption spec; annotate two safe yaml.load sites

## Problem

Two AppSec findings against the internal distribution of this codebase pointed at
things in this repo. Neither turned out to be a code vulnerability, but one is a
real spec/implementation divergence that caused a reviewer to file a control gap
that does not exist.

**1. `dashboard-token-auth.md` documents a single-use link token that is not
implemented.** The spec's request-flow steps said "Check consumption state" and
"On first query-param use: bind IP, mark consumed", and the error table promised a
302 for a re-clicked consumed token. The middleware does none of that:
`try_consume` / `mark_consumed` / `is_consumed` have unit coverage and **zero
production call sites**, so a reader (or an AppSec reviewer) reasonably concludes
the control is wired when it is not. Reviewer conclusion, verbatim: "close the two
controls the package's own `dashboard-token-auth.md` documents but does not
implement".

**2. Bandit B506 fires on `yaml.load` calls that are already safe.** Six of eight
call sites carry `# noqa: S506`; two do not, so a scanner keeps re-reporting them
and the finding keeps reappearing on every branch.

## Why it matters

A spec that over-claims a security control is worse than one that documents a
known gap. It costs reviewer time re-deriving actual behaviour from source, and it
invites a "fix" that would break working flows — which is exactly the risk here:
wiring `try_consume` into the link path would break remote-instance iframes that
re-derive `/?token=` on navigation and self-nudge polling that re-opens the same
URL. The middleware's own comments already explain that re-exchange is deliberate;
only the spec disagreed.

For the scanner findings, an un-annotated safe call site is recurring toil: the
finding is filed, triaged as a false positive, closed, and filed again on the next
branch scan.

## Fix (symptoms → root cause → change)

Symptom: reviewer files "single-use consumption is unwired". Root cause: the spec
describes a design the middleware deliberately does not implement, and the dead
primitive's presence corroborates the wrong reading. Change: correct the spec to
describe real behaviour, and say plainly at the API that it is not wired.

- Request flow steps 6–7 now describe what the middleware actually does: mint a
  separate session token, bind it to the peer key, denylist the link token's own
  nonce, set the cookie.
- New section **"Link re-exchange is deliberately allowed (the link is not
  single-use)"** records the choice, the two flows that depend on it, what the
  exchange *does* guarantee (the link can never be replayed as the cookie, because
  its nonce is denylisted at exchange), and the residual exposure — bounded by the
  5-minute window rather than by consumption. It also states the two accepted
  consequences, including that a deployment needing identity as a second factor
  must put one in front of the origin.
- The consumption API in the spec's signature block is marked NOT WIRED, so the
  next reader does not repeat the inference.
- Error table: replaced the fictional "consumed token re-click → 302" row with the
  two rows that are real — link re-presented inside its window → 200 by design,
  and link string presented as the cookie → 403 from the denylist.

Making the link genuinely single-use remains a live option; the spec now frames it
as a behaviour change with named breakage that needs an owner decision, rather
than as a missing control. No code behaviour is changed by this PR.

Symptom: B506 re-reported on two files. Root cause: missing suppression on two of
eight otherwise-annotated call sites. Change: added `# noqa: S506 — tag-blind CFN
parse` to `test/test_deploy_round29_fixes.py` and
`test/test_deploy_cwe770_throttle_waf.py`, matching the existing convention in
`test_deploy_web_iam.py` and `test_deploy_round35_fixes.py`.

Both loaders (`CfnLoader`, `_TagTolerantLoader`) subclass `yaml.SafeLoader`; they
exist because CloudFormation fixtures use custom tags (`!Ref`, `!GetAtt`, `!Sub`)
that plain `yaml.safe_load` rejects with `ConstructorError`. Worth recording for
the next reader of that finding: the sole production call site
(`onboarding_import.py`) uses `_NoAliasSafeLoader`, which is *stricter* than
`safe_load` — it also rejects aliases to block billion-laughs expansion — so
"replace with `yaml.safe_load`" would be a security regression there.

## Tests

No new tests: the yaml change is two comments, and the token-auth change is
documentation of existing behaviour. Existing coverage confirms nothing moved:

- `test/test_deploy_round29_fixes.py` + `test/test_deploy_cwe770_throttle_waf.py`
  — 18 passed.
- `test/test_token_auth.py` — 243 passed (including the consumption-primitive
  tests, which keep passing because the primitive itself is untouched).
- `flake8` clean on both touched test files.

## Manual verification

N/A — unit coverage is sufficient. The spec claims were verified against source
rather than by running the flow: `grep` for `try_consume`/`mark_consumed` across
`src/` returns only their own definitions in `dashboard/token_auth.py` plus the
unrelated refresh-token subsystem (`refresh_tokens.py` / `auth_refresh.py`), which
is what establishes that the dashboard link path never calls them.
