### PR TITLE
feat(mcp): dashboard-control MCP server for the sidebar folder tree

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -33,6 +33,7 @@
         "notify_override_expiry": true,
         "bot_name": "",
         "conductor_skill": false,
+        "dashboard_control": false,
         "tool_search": true,
         "session_sharing": true,
         "max_subagents": 0,
@@ -394,6 +395,20 @@
       "tags": [],
       "label": "Conductor Skill",
       "help": "Enable agent delegation — loads conductor skill with agent roster.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
+    },
+    {
+      "path": "agent.dashboard_control",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Dashboard Control",
+      "help": "Let the agent reorganize your dashboard — the sidebar folder tree and which sessions sit in it — through the kirocrew-dashboard MCP server. OFF by default and the server advertises no tools while off, so a session that never needs it spends no context on it. Takes effect on the next session (tool lists are read once at session start).",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": false

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -347,6 +347,7 @@ Managed servers, registered by `agent._MANAGED_MCP_SERVERS` and installed into
 | `kirocrew-cron` | `kirocrew mcp-cron` (`mcp_cron.py`) | `cron_add`, `cron_list`, `cron_update`, `cron_remove`, `cron_remove_all`, `cron_pause`, `cron_resume`, `cron_trigger` |
 | `kirocrew-core` | `kirocrew mcp-core` (`mcp_core.py`) | spawn/subagent, learn, task, messaging, artifact, workflow, knowledge and session-directive tools (see below) |
 | `kirocrew-computer` | `kirocrew mcp-computer` (`mcp_computer.py`) | `computer_list_apps`, `computer_get_state`, `computer_click`, `computer_drag`, `computer_type_text`, `computer_press_key`, `computer_set_value`, `computer_scroll`, `computer_perform_action`, `computer_end_turn` |
+| `kirocrew-dashboard` | `kirocrew mcp-dashboard` (`mcp_dashboard.py`) | `chat_folder_tree`, `chat_folder_create`, `chat_folder_move`, `chat_folder_move_session` |
 
 CLI commands and their MCP twins:
 
@@ -406,6 +407,61 @@ rewrites slash-containing keys to kiro-safe aliases and
 `browser.setup.converge_playwright_servers()` folds every Playwright-proxy entry onto the one
 canonical key, keyed by resolved launch target, so a legacy slash-free key
 re-injected from `~/.kiro/crew/mcp.json` cannot spawn a second backend.
+
+## What belongs in `kirocrew-core`, and what does not
+
+`kirocrew-core` is the surface EVERY session carries. kiro-cli reads `tools/list`
+once per session, so a tool listed there spends context in every request of every
+session for as long as the session lives — whether or not that session will ever
+use it. With `agent.tool_search` on (the default) Kiro Crew forces kiro's deferral
+always-on, so the per-request cost is a name plus a description rather than a full
+JSON schema; it is smaller, not zero, and it scales with the tool count.
+
+That makes the placement question a real one rather than a matter of taste:
+
+- **Core** is for capabilities a session may need *without being asked* —
+  subagents, messaging, memory, artifacts, session-bound directives.
+- **Its own server** is for a capability the user opts into on purpose. Give it
+  the `kirocrew-computer` / `kirocrew-dashboard` shape: registered
+  unconditionally, but `tools/list` returns `[]` and every call refuses until the
+  feature's enable is on. A user who never turns it on pays nothing, which an
+  always-refusing tool in core cannot achieve — it still ships its description
+  every turn.
+
+**A load switch is not a permission — decide which one you are building.** Two
+different jobs get confused because both look like a boolean:
+
+- **Context economy.** "Do not spend every request advertising tools this session
+  will not use." `config.json` is the right home. It does not matter that an
+  auto-approved agent shell can write it: the worst an agent achieves by flipping
+  its own load switch is paying for its own context. `agent.dashboard_control` is
+  this kind.
+- **Authorization.** "The user has granted reach the agent does not otherwise
+  have." `config.json` is the WRONG home — `security.py` spells out why, and the
+  keystone leaves (`computer_use.json`, `browser-mode-enabled`, the Ops Mission
+  Control mode) exist because each grants something outside Kiro Crew (desktop
+  input synthesis, the operator's logged-in browser, writes against production
+  incident tooling) or is the security floor itself. One of those moved out of
+  agent-writable config after review found exactly this mistake.
+
+The test is blast radius, not wording: ask what the agent gains that it did not
+already have. Folder tools grant no new read (`list_sessions` already returns every
+session's title and key) and cannot delete, so they are a load switch. Driving or
+stopping another session is not, and would need a keystone leaf rather than another
+config bool. Ratchet the set riding a load switch so the next capability cannot
+inherit a gate that was never meant to authorize anything.
+
+Per-agent scoping composes on top and needs no new mechanism: an agent spec's own
+`mcpServers` map decides which agents see a server at all
+(`agent_discovery.py`), so a server can be handed to an orchestrator-class agent
+without every agent inheriting it.
+
+Adding a managed server is a **parity tax** — the name must appear in
+`agent._MANAGED_MCP_SERVERS`, `mcp_discovery._MANAGED_SERVER_SUBCOMMANDS` and
+`_MANAGED_SERVER_TOOL_MODULES`, `mcp_cleanup.KIROCREW_BIN_MCP_SERVERS`,
+`onboarding_import._MANAGED_MCP_NAMES`, and the hidden `cli.py` subcommand.
+`test_computer_use_registration.py` asserts those registries are the same set, so
+a half-registered server fails the suite rather than shipping.
 
 ### The one deliberate exception
 

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -454,6 +454,19 @@ _MANAGED_MCP_SERVERS: dict[str, dict] = {
     # reached for it. For a tool that can click in an already-authenticated
     # application that would be a complete gate bypass.
     "kirocrew-computer": {"invocation_fn": lambda: _kirocrew_mcp_invocation("mcp-computer")},
+    # Dashboard control (sidebar folder tree + which sessions sit in it).
+    # Registered unconditionally for the same reason as kirocrew-computer: its
+    # stdio server returns an EMPTY tools/list while ``agent.dashboard_control``
+    # is off, so a feature nobody asked for costs the model no context and needs
+    # no per-server ``enabled_fn`` here. Kept OUT of kirocrew-core on purpose —
+    # core is the surface every session carries, and reorganizing the dashboard
+    # is an occasional, deliberate user request, not an always-on capability.
+    #
+    # No ``autoApprove`` key, for the same reason the computer server has none:
+    # an autoApproved MCP tool is approved inside kiro-cli and never reaches
+    # ``hooks.on_tool_call``, so the deny floor and governance ceiling would be
+    # bypassed for tools that write to the user's session layout.
+    "kirocrew-dashboard": {"invocation_fn": lambda: _kirocrew_mcp_invocation("mcp-dashboard")},
 }
 
 

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1769,6 +1769,10 @@ Examples:
     # fail-closed governance gate and all accessibility work live.
     sub.add_parser("mcp-computer", help=argparse.SUPPRESS)
 
+    # mcp-dashboard (MCP server — spawned by the agent backend, not user-facing).
+    # Advertises no tools until agent.dashboard_control is on.
+    sub.add_parser("mcp-dashboard", help=argparse.SUPPRESS)
+
     # Builtin app MCP servers (spawned by the agent backend, not user-facing)
     for _bname in _BUILTIN_NAMES:
         sub.add_parser(f"mcp-{_bname}", help=argparse.SUPPRESS)
@@ -2254,6 +2258,11 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         from kiro_crew.mcp_computer import run_mcp_server as run_mcp_computer_server
 
         run_mcp_computer_server()
+    elif args.command == "mcp-dashboard":
+        # Loaded through importlib in the branch, like the builtin-app servers
+        # below: `kirocrew gateway` boots through this module, and a default-off
+        # optional subsystem must not be imported to start it.
+        importlib.import_module("kiro_crew.mcp_dashboard").run_mcp_server()
     elif args.command.startswith("mcp-") and args.command[4:] in _BUILTIN_NAMES:
         _mod = importlib.import_module(f"kiro_crew.apps.builtins.{args.command[4:]}.mcp_server")
         _mod.run_mcp_server()

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1000,6 +1000,19 @@ class AgentConfig:
             "Enable agent delegation — loads conductor skill with agent roster.",
         ),
     )
+    dashboard_control: bool = field(
+        default=False,
+        metadata=_meta(
+            "Dashboard Control",
+            "Load the agent's sidebar-folder tools — read the tree, create "
+            "folders, move them, and file a live session into one. OFF by "
+            "default and the server advertises no tools while off, so a session "
+            "that never needs it spends no context on it. This is a load switch, "
+            "not a permission: the tools rearrange layout, read nothing the agent "
+            "cannot already read, and delete nothing. Takes effect on the next "
+            "session (tool lists are read once at session start).",
+        ),
+    )
     tool_search: bool = field(
         default=True,
         metadata=_meta(
@@ -5185,6 +5198,7 @@ class KiroCrewConfig:
                 yolo_duration=_normalize_yolo_duration(agent_data.get("yolo_duration")),
                 notify_override_expiry=agent_data.get("notify_override_expiry", True),
                 conductor_skill=agent_data.get("conductor_skill", False),
+                dashboard_control=_safe_bool(agent_data.get("dashboard_control"), False),
                 tool_search=bool(agent_data.get("tool_search", True)),
                 session_sharing=bool(agent_data.get("session_sharing", True)),
                 max_subagents=agent_data.get("max_subagents", 0),

--- a/src/kiro_crew/dashboard/chat_folders.py
+++ b/src/kiro_crew/dashboard/chat_folders.py
@@ -184,6 +184,20 @@ async def _unhide_folder(state: DashboardState, folder_id: str) -> bool:
     return await state.mutate_folders(_clear)
 
 
+def _audit_origin(request: web.Request) -> str:
+    """SEL ``source`` for a folder mutation: ``"mcp"`` for a tool, else ``"dashboard"``.
+
+    These endpoints are now driven by BOTH the browser and the
+    ``chat_folder_*`` MCP tools (``/api/chat`` is a mixed-internal path), and an
+    audit line that labels every write ``dashboard`` cannot answer "did I move
+    that session, or did the agent?". Same header test as
+    ``handlers/artifacts.py`` uses for artifact lifecycle events — the header is
+    already validated by the token-auth middleware, so its presence is a
+    trustworthy origin marker rather than a claim from the body.
+    """
+    return "mcp" if request.headers.get("X-Internal-Secret") is not None else "dashboard"
+
+
 async def api_chat_folders(request: web.Request) -> web.Response:
     """GET /api/chat/folders — list all project folders (with archived-session counts)."""
     state: DashboardState = request.app["state"]
@@ -295,8 +309,8 @@ async def api_chat_folder_create(request: web.Request) -> web.Response:
         )
     state.push_slots_update()
     sel().log_api_access(
-        caller="dashboard", operation="chat.folder_create",
-        outcome="allowed", source="dashboard", resources=str(folder["id"]),
+        caller=_audit_origin(request), operation="chat.folder_create",
+        outcome="allowed", source=_audit_origin(request), resources=str(folder["id"]),
     )
     return web.json_response(folder, status=201)
 
@@ -424,8 +438,8 @@ async def api_chat_folder_update(request: web.Request) -> web.Response:
         )
     state.push_slots_update()
     sel().log_api_access(
-        caller="dashboard", operation="chat.folder_update",
-        outcome="allowed", source="dashboard", resources=fid,
+        caller=_audit_origin(request), operation="chat.folder_update",
+        outcome="allowed", source=_audit_origin(request), resources=fid,
     )
     return web.json_response(folder)
 
@@ -485,8 +499,8 @@ async def api_chat_folder_delete(request: web.Request) -> web.Response:
         raise
     state.push_slots_update()
     sel().log_api_access(
-        caller="dashboard", operation="chat.folder_delete",
-        outcome="allowed", source="dashboard", resources=fid,
+        caller=_audit_origin(request), operation="chat.folder_delete",
+        outcome="allowed", source=_audit_origin(request), resources=fid,
     )
     return web.json_response({"ok": True})
 
@@ -523,8 +537,8 @@ async def api_chat_slot_folder(request: web.Request) -> web.Response:
     await save_slot_off_loop(state, slot, force=True)
     state.push_slots_update()
     sel().log_api_access(
-        caller="dashboard", operation="chat.slot_folder",
-        outcome="allowed", source="dashboard", resources=name,
+        caller=_audit_origin(request), operation="chat.slot_folder",
+        outcome="allowed", source=_audit_origin(request), resources=name,
     )
     return web.json_response({"ok": True, "folder_id": slot.folder_id})
 

--- a/src/kiro_crew/mcp_cleanup.py
+++ b/src/kiro_crew/mcp_cleanup.py
@@ -25,7 +25,12 @@ _KIRO_MCP_JSON = Path.home() / ".kiro" / "settings" / "mcp.json"
 # Only these are affected by install-method path changes.
 # Ordered tuple (not a set) so consumers that iterate — e.g. `kirocrew
 # doctor`'s MCP probe — get a deterministic order.
-KIROCREW_BIN_MCP_SERVERS = ("kirocrew-cron", "kirocrew-core", "kirocrew-computer")
+KIROCREW_BIN_MCP_SERVERS = (
+    "kirocrew-cron",
+    "kirocrew-core",
+    "kirocrew-computer",
+    "kirocrew-dashboard",
+)
 
 # MeshClaw was the predecessor of KiroCrew. The rename left these managed
 # server entries — pointing at now-dead MeshClaw build paths — behind in the

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -1,0 +1,652 @@
+"""The dashboard-control MCP server — the agent's hands on the dashboard's own
+organization surfaces.
+
+Deliberately NOT part of ``kirocrew-core``. Core is the tool surface EVERY
+session carries, and kiro-cli reads ``tools/list`` once per session, so anything
+listed there spends context in every request of every session forever — whether
+or not the user ever wants it. Reorganizing the sidebar is something a user asks
+for on purpose, occasionally; it does not belong in the always-on surface.
+
+So this is its own server with the ``kirocrew-computer`` shape: registered
+unconditionally, but ``tools/list`` returns ``[]`` and every call refuses while
+``agent.dashboard_control`` is off. A user who never turns it on pays nothing,
+and the core agent stays simple. Per-agent scoping composes on top of the
+toggle — an agent spec's own ``mcpServers`` map decides which agents see this
+server at all.
+
+What it controls today is the chat (sidebar) folder tree: read it, create a
+folder, reparent a folder, and file a live session into one. Create and move
+only — no delete and no rename, so nothing here can lose a conversation. Every
+tool is a thin proxy over the dashboard's existing endpoints (loopback +
+``X-Internal-Secret``); the endpoints keep owning every tree invariant, and the
+gateway audits each write with ``source=mcp`` so the log can tell an agent's
+move from the user's own.
+
+What `agent.dashboard_control` is, and is not: it is a **load switch for context
+economy**, not an authorization boundary. Off means the tools are not advertised,
+so a session that will never reorganize anything spends nothing on them. It is
+deliberately NOT a consent control, and nothing here relies on it being
+unforgeable — it lives in ``config.json``, which an auto-approved agent shell can
+write.
+
+That is sound only because the blast radius behind it needs no authorization:
+these tools grant no read the agent does not already have (``list_sessions`` in
+``kirocrew-core`` is always available and already returns every session's title
+and key), they cannot delete a folder or a conversation, and the worst outcome is
+a sidebar the user has to tidy. Contrast the keystone leaves in ``security.py``
+(``computer_use.json``, ``browser-mode-enabled``, the Ops Mission Control mode):
+each grants reach OUTSIDE Kiro Crew — desktop input synthesis, the operator's
+logged-in browser, writes against production incident tooling — or is the
+security floor itself, and each is therefore stored where the agent cannot write.
+
+The rule that follows, and the reason the tool set is ratcheted in
+``test_mcp_dashboard_registration.py``: a capability whose blast radius DOES
+require authorization must not ride this switch. It needs its own keystone leaf,
+not another entry in a config bool. Session control (driving or stopping another
+session) is that shape.
+
+Identity posture: these tools use the NON-strict session resolver (inherited
+from the ``mcp_core`` request helpers). The header is ATTRIBUTION here, not
+authorization — the endpoints authorize on the internal secret, and the session
+a move targets is named explicitly by slot key, never derived from the caller's
+identity. The strict resolver would fail closed in sandboxed sessions without
+protecting anything, since no effect here reads the header.
+"""
+
+from __future__ import annotations
+
+import logging
+import re as _re
+from typing import Any
+from urllib.parse import quote
+
+from kiro_crew.config.loader import KiroCrewConfig
+
+# Same cross-module reuse as ``mcp_computer``: the authenticated loopback client
+# to the gateway lives in ``mcp_core``. Importing it costs 341ms/40MB in this
+# process (measured) — under ``mcp_computer``'s own import cost, because
+# mcp_core's heavy dependencies are function-local.
+from kiro_crew.mcp_core import _get, _patch, _post, _resolve_session_key
+from kiro_crew.mcp_shared import call_tool_with_logging, run_mcp_stdio_loop
+from kiro_crew.platform import redact_via_context as redact
+from kiro_crew.validation import (
+    CHAT_FOLDER_CREATE_SCHEMA,
+    CHAT_FOLDER_MOVE_SCHEMA,
+    CHAT_FOLDER_MOVE_SESSION_SCHEMA,
+    CHAT_FOLDER_TREE_SCHEMA,
+    MCP_DASHBOARD_SCHEMAS,
+    validate_tool_args,
+)
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "kirocrew-dashboard"
+SERVER_VERSION = "1.0.0"
+
+_DISABLED_NOTICE = (
+    "Error: dashboard control is off. Turn on Settings -> Agent -> Dashboard "
+    "Control, then start a new session (tool lists are read once at session "
+    "start)."
+)
+
+
+def is_enabled() -> bool:
+    """True when ``agent.dashboard_control`` is on.
+
+    Fail-CLOSED on any config read error: an unreadable config means "not proven
+    on", which hides the tools rather than exposing dashboard writes by accident.
+    """
+    try:
+        return bool(KiroCrewConfig.load().agent.dashboard_control)
+    except Exception:
+        logger.debug("dashboard_control probe failed; treating as off", exc_info=True)
+        return False
+
+
+def _tool_definitions() -> list[dict[str, Any]]:
+    """The tool surface this server advertises when enabled."""
+    return [
+        {
+            "name": "chat_folder_tree",
+            "description": (
+                "Show the user's SIDEBAR folder tree — the folders they organize "
+                "their chat sessions in — with the live sessions filed in each one. "
+                "Returns per folder: id, human path, project directory, default "
+                "agent, and how many archived (history) sessions are filed there; "
+                "then one line per live session (slot key + title) nested under it, "
+                "and an '(unfiled)' group for sessions at the top level. Use this to "
+                "get folder ids/paths and session keys before calling "
+                "chat_folder_create / chat_folder_move / chat_folder_move_session, "
+                "or when the user asks what their tree looks like. This is the "
+                "folder-shaped view; list_sessions is the flat newest-first one."
+            ),
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "chat_folder_create",
+            "description": (
+                "Create a sidebar folder (or subfolder) for chat sessions. "
+                "``parent`` accepts a folder id OR a '/'-separated human path from "
+                "chat_folder_tree; missing path segments are created too (mkdir -p). "
+                "Omit ``parent`` (or pass 'root') for a top-level folder. Creating a "
+                "folder never moves anything — file sessions into it with "
+                "chat_folder_move_session."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": (
+                            "Folder name (max 100 chars). Cannot contain '/' — that "
+                            "would render like a nested path and be unaddressable."
+                        ),
+                    },
+                    "parent": {
+                        "type": "string",
+                        "description": "Parent folder id or human path. Omit / 'root' for top level.",
+                    },
+                },
+                "required": ["name"],
+            },
+        },
+        {
+            "name": "chat_folder_move",
+            "description": (
+                "Reparent a sidebar folder — nest it under another folder, or move it "
+                "back to the top level. Moves the folder with everything in it "
+                "(sessions and subfolders travel with it); nothing is deleted. "
+                "Cycle-guarded: a folder cannot become its own descendant. "
+                "``folder`` and ``new_parent`` are each a folder id or human path; "
+                "omit ``new_parent`` (or pass 'root') for the top level."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "folder": {"type": "string", "description": "Folder to move (id or path)."},
+                    "new_parent": {
+                        "type": "string",
+                        "description": "Destination parent folder (id or path). Omit / 'root' for top level.",
+                    },
+                },
+                "required": ["folder"],
+            },
+        },
+        {
+            "name": "chat_folder_move_session",
+            "description": (
+                "File a LIVE chat session into a sidebar folder, or unfile it to the "
+                "top level (omit ``folder`` / pass 'root'). ``session`` is a slot key "
+                "or 'dashboard:<slot>' session key from chat_folder_tree, or a "
+                "session's exact title when that title is unique. ``folder`` is a "
+                "folder id or human path — the folder must already exist "
+                "(chat_folder_create makes one). Metadata only: the session keeps its "
+                "transcript, model, and any running turn. ARCHIVED (history) sessions "
+                "cannot be moved — revive one into the sidebar first, then call this."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "session": {
+                        "type": "string",
+                        "description": "Slot key, 'dashboard:<slot>' session key, or exact unique session title.",
+                    },
+                    "folder": {
+                        "type": "string",
+                        "description": "Destination folder id or human path. Omit / 'root' to unfile.",
+                    },
+                },
+                "required": ["session"],
+            },
+        },
+    ]
+
+
+def _list_tools() -> list[dict[str, Any]]:
+    """Tool definitions, or ``[]`` while ``agent.dashboard_control`` is off.
+
+    Hiding the tools beats advertising four that always refuse: kiro-cli caches
+    ``tools/list`` for the session, so a disabled feature would otherwise cost
+    context in every request and invite retry loops.
+    """
+    if not is_enabled():
+        return []
+    return _tool_definitions()
+
+
+def _get_rows(path: str) -> tuple[list[dict], str | None]:
+    """GET a gateway endpoint whose success body is a JSON **array**.
+
+    ``_get`` is written for object bodies and signals failure with
+    ``{"error": ...}``, so an array endpoint (``/api/chat/folders``,
+    ``/api/chat/slots``) needs the two shapes split apart. Returns
+    ``(rows, None)`` on success and ``([], error)`` otherwise. A body that is
+    neither an array nor an error object is reported as an error rather than
+    read as empty: "the tree is empty" and "the endpoint is broken" must not
+    render identically.
+    """
+    payload: object = _get(path)
+    if isinstance(payload, list):
+        return [r for r in payload if isinstance(r, dict)], None
+    if isinstance(payload, dict):
+        err = payload.get("error")
+        if err:
+            return [], str(err)
+    return [], f"unexpected response shape from {path}"
+
+
+# Sidebar folder ids are minted as ``uuid.uuid4().hex[:12]``
+# (``chat_folders.api_chat_folder_create``), so an id-shaped reference is
+# recognizable and must never be auto-created as a folder NAME.
+_CHAT_FOLDER_ID_RE = _re.compile(r"[0-9a-f]{12}")
+
+
+def _chat_folder_paths(folders: list[dict]) -> dict[str, str]:
+    """Map each sidebar folder id to its ``parent/child`` human path.
+
+    Chat folders persist only ``parent_id`` (unlike artifact folders, whose
+    store computes ``path`` server-side), so the path is derived here. Walks
+    parents with a visited-set guard so a pre-existing cycle in
+    ``folders.json`` — which ``_is_descendant`` in ``chat_folders.py`` also
+    defends against — cannot hang the tool.
+    """
+    by_id = {str(f.get("id") or ""): f for f in folders if f.get("id")}
+    paths: dict[str, str] = {}
+    for fid in by_id:
+        segments: list[str] = []
+        seen: set[str] = set()
+        cur = fid
+        while cur and cur in by_id and cur not in seen:
+            seen.add(cur)
+            segments.append(str(by_id[cur].get("name") or "?"))
+            cur = str(by_id[cur].get("parent_id") or "")
+        paths[fid] = "/".join(reversed(segments))
+    return paths
+
+
+def _chat_folder_children(folders: list[dict], parent_id: str, name: str) -> list[dict]:
+    """Every DIRECT child of ``parent_id`` whose name equals ``name`` (case-insensitive).
+
+    Chat folder names are not unique within a parent — the sidebar happily holds
+    two folders called ``0811`` under the same parent — so a path segment can be
+    genuinely ambiguous. Returning the whole match list is what keeps the two
+    callers honest: taking the first match would patch an arbitrary sibling, or
+    file a session into whichever duplicate happened to be created first.
+    """
+    target = str(name).strip().lower()
+    return [
+        f
+        for f in folders
+        if str(f.get("parent_id") or "") == parent_id
+        and str(f.get("name", "")).strip().lower() == target
+    ]
+
+
+def _ambiguous_segment_error(seg: str, matches: list[dict]) -> str:
+    """Refusal naming the duplicate folders, so the caller can pick one by id."""
+    ids = ", ".join(str(m.get("id") or "?") for m in matches)
+    return (
+        f"{len(matches)} folders named {redact(seg)} share the same parent "
+        f"({ids}) — pass the folder id instead of a path"
+    )
+
+
+def _resolve_chat_folder_ref(
+    ref: str, folders: list[dict], *, create_missing: bool
+) -> tuple[str, list[str], str | None]:
+    """Resolve a sidebar-folder reference to a folder id. THE resolution chokepoint.
+
+    Every tool addresses a folder through here, so create, move and move-session
+    can never disagree about what a reference means. Returns
+    ``(folder_id, created_names, error)``; ``""`` = top level (empty ref or
+    ``"root"``). ``created_names`` is returned even alongside an error so a
+    partial mkdir -p is reported rather than silently left behind.
+
+    Three things a chat-folder reference can mean, in order:
+
+    * **An id.** Unambiguous. An id-shaped ref that does not exist is a lookup
+      failure even when ``create_missing`` — ids are minted server-side, so
+      creating a folder literally named after the hex id is never what a caller
+      meant.
+    * **A full human path.** A folder NAME may itself contain ``/`` (the
+      sidebar permits it), so ``A/B`` can be one folder named ``A/B`` as well as
+      ``B`` inside ``A``, and the tree renders both identically. Both readings
+      are computed; when they disagree, or when either is itself duplicated, the
+      reference is refused rather than resolved to whichever came first.
+    * **A path to walk**, segment by segment, creating what is missing when
+      ``create_missing``.
+
+    Pure apart from the creation leg: the caller already holds the folder list,
+    and re-fetching per reference would let the tree shift between the two
+    lookups of a single move.
+    """
+    ref = str(ref or "").strip()
+    if not ref or ref.lower() == "root":
+        return "", [], None
+    if any(str(f.get("id") or "") == ref for f in folders):
+        return ref, [], None
+    if _CHAT_FOLDER_ID_RE.fullmatch(ref):
+        return "", [], f"folder not found: {redact(ref)}"
+
+    # Reading 2: a folder whose own name (or ancestry) renders to exactly this path.
+    paths = _chat_folder_paths(folders)
+    exact = sorted(fid for fid, p in paths.items() if p.strip().lower() == ref.lower())
+    if len(exact) > 1:
+        return "", [], (
+            f"{len(exact)} folders render the same path {redact(ref)} "
+            f"({', '.join(exact)}) — pass the folder id instead of a path"
+        )
+
+    # Reading 3: walk the segments. When the exact reading already resolved, the
+    # walk runs resolve-only — there is nothing to create, and creating before
+    # the two readings are compared would mutate the tree on a reference we are
+    # about to refuse.
+    walked, created, walk_err = _walk_chat_folder_segments(
+        ref, folders, create_missing=create_missing and not exact
+    )
+    if walk_err:
+        return "", created, walk_err
+
+    if exact and walked and walked != exact[0]:
+        return "", [], (
+            f"{redact(ref)} is ambiguous: it is both a folder's own name "
+            f"({exact[0]}) and a nested path ({walked}) — pass the folder id"
+        )
+    if exact:
+        return exact[0], [], None
+    if walked:
+        return walked, created, None
+    if not create_missing:
+        return "", [], f"folder not found: {redact(ref)}"
+    # create_missing with nothing walked means every segment was created and the
+    # walk returned the leaf, so this is unreachable via the tools; keep the
+    # refusal rather than returning the library root by accident.
+    return "", created, f"folder not found: {redact(ref)}"
+
+
+def _walk_chat_folder_segments(
+    ref: str, folders: list[dict], *, create_missing: bool
+) -> tuple[str, list[str], str | None]:
+    """Walk a ``/``-separated path segment by segment. ONE walk, two modes.
+
+    Returns ``(folder_id, created_names, error)``; ``folder_id`` is ``""`` when a
+    segment is missing and ``create_missing`` is false. Duplicate siblings are
+    refused in BOTH modes — resolving to the first match would act on an
+    arbitrary folder, and creating under it would bury the new folder in
+    whichever duplicate happened to come first.
+
+    ``folders`` is appended in place for each created row so a later path render
+    sees it. Created names come back even alongside an error, so a partial
+    mkdir -p is reported rather than silently left behind.
+    """
+    walked = ""
+    parent = ""
+    created: list[str] = []
+    for seg in [s.strip() for s in ref.split("/") if s.strip()]:
+        matches = _chat_folder_children(folders, parent, seg)
+        if len(matches) > 1:
+            return "", created, _ambiguous_segment_error(seg, matches)
+        if matches:
+            walked = str(matches[0].get("id") or "")
+            parent = walked
+            continue
+        if not create_missing:
+            return "", created, None
+        # The name is agent-authored and lands in durable state the sidebar
+        # re-renders on every visit, so it gets the egress pass BEFORE the write
+        # (same reason issue-radar findings are redacted before they persist).
+        made = _post("/api/chat/folders", {"name": redact(seg), "parent_id": parent})
+        if made.get("error"):
+            return "", created, str(made["error"])
+        folders.append(made)
+        created.append(str(made.get("name") or seg))
+        walked = str(made.get("id") or "")
+        parent = walked
+    return walked, created, None
+
+
+def _resolve_chat_folder_id(ref: str, folders: list[dict]) -> tuple[str, str | None]:
+    """Resolve an EXISTING sidebar folder (id or human path) to its id."""
+    fid, _created, err = _resolve_chat_folder_ref(ref, folders, create_missing=False)
+    return fid, err
+
+
+def _ensure_chat_folder_path(ref: str, folders: list[dict]) -> tuple[str, list[str], str | None]:
+    """Resolve a parent-folder reference, creating missing segments (mkdir -p)."""
+    return _resolve_chat_folder_ref(ref, folders, create_missing=True)
+
+
+def _resolve_chat_slot_key(ref: str, slots: list[dict]) -> tuple[str, str | None]:
+    """Resolve a session reference to the slot key the folder endpoint takes.
+
+    Accepts the slot key itself, a ``dashboard:<slot>`` session key (what
+    ``search_chat_history`` and the session tools hand out), or a session's
+    exact title when that title is unique. Title matching is exact and
+    case-insensitive — never a substring — so an ambiguous or partial name
+    fails loudly with the candidate keys instead of filing the wrong session.
+    """
+    ref = str(ref or "").strip()
+    if not ref:
+        return "", "session required"
+    explicit_key = ref.lower().startswith("dashboard:")
+    bare = ref[len("dashboard:") :] if explicit_key else ref
+    by_key = {str(s.get("key") or ""): s for s in slots if s.get("key")}
+    titled = [
+        str(s.get("key") or "")
+        for s in slots
+        if str(s.get("title") or "").strip().lower() == ref.lower()
+    ]
+    if bare in by_key:
+        # A tab can be TITLED with another session's key, so a bare reference can
+        # match one session by key and a different one by title. Preferring the
+        # key silently would file the wrong session; the ``dashboard:`` prefix is
+        # the caller's way to say "this is a key".
+        rivals = [k for k in titled if k != bare]
+        if rivals and not explicit_key:
+            return "", (
+                f"{redact(ref)} is one session's key and another's title "
+                f"({', '.join([bare] + rivals)}) — prefix with 'dashboard:' to "
+                "select the key, or pass the other session's key"
+            )
+        return bare, None
+    if explicit_key:
+        # ``dashboard:`` asserted a key, and no slot has it. Falling through to
+        # title matching would honour the opposite of what the caller said and
+        # could file a session that merely happens to be TITLED with that key.
+        return "", (
+            f"no live session has the key {redact(bare)} — call chat_folder_tree "
+            "for slot keys. An ARCHIVED session cannot be moved: revive it into "
+            "the sidebar first"
+        )
+    if len(titled) == 1:
+        return titled[0], None
+    if len(titled) > 1:
+        return "", (
+            f"{len(titled)} live sessions share the title {redact(ref)} "
+            f"({', '.join(titled)}) — pass the slot key instead"
+        )
+    return "", (
+        f"no live session matches {redact(ref)} — call chat_folder_tree for slot "
+        "keys. An ARCHIVED session cannot be moved: revive it into the sidebar first"
+    )
+
+
+def _validate_args(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Validate tool arguments against schema. Returns cleaned args."""
+    schema = MCP_DASHBOARD_SCHEMAS.get(name)
+    if schema:
+        return validate_tool_args(args, schema)
+    return args
+
+
+def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
+    """Dispatch one validated tool call.
+
+    The enable is re-checked here, not only in ``_list_tools``: a session that
+    cached a non-empty list before the user turned the feature off must not keep
+    writing to the sidebar.
+    """
+    if not is_enabled():
+        return _DISABLED_NOTICE
+
+    if name == "chat_folder_tree":
+        validate_tool_args(args, CHAT_FOLDER_TREE_SCHEMA)
+        chat_folders, folders_err = _get_rows("/api/chat/folders")
+        if folders_err:
+            return f"Error: {folders_err}"
+        chat_slots, slots_err = _get_rows("/api/chat/slots")
+        if slots_err:
+            return f"Error: {slots_err}"
+        tree_paths = _chat_folder_paths(chat_folders)
+        # Group live sessions by folder up front so an id that no longer has a
+        # folder row (a slot pointing at a deleted folder) still surfaces under
+        # "(unfiled)" instead of vanishing from the tree.
+        known_ids = set(tree_paths)
+        by_folder: dict[str, list[dict]] = {}
+        for slot_row in chat_slots:
+            fid = str(slot_row.get("folder_id") or "")
+            by_folder.setdefault(fid if fid in known_ids else "", []).append(slot_row)
+
+        def _session_line(row: dict, indent: str) -> str:
+            bits = []
+            if row.get("running"):
+                bits.append("running")
+            if row.get("pinned"):
+                bits.append("pinned")
+            if row.get("app"):
+                bits.append(f"app:{row['app']}")
+            suffix = f"  [{', '.join(bits)}]" if bits else ""
+            title = str(row.get("title") or "(untitled)")
+            return f"{indent}· {row.get('key', '?')}  {title}{suffix}"
+
+        tree_lines = [
+            f"\U0001f5c2\ufe0f Sidebar folder tree — {len(chat_folders)} folder"
+            f"{'' if len(chat_folders) == 1 else 's'}, {len(chat_slots)} live session"
+            f"{'' if len(chat_slots) == 1 else 's'}:"
+        ]
+        for fid, fpath in sorted(tree_paths.items(), key=lambda kv: kv[1].lower()):
+            row = next((f for f in chat_folders if str(f.get("id")) == fid), {})
+            depth = fpath.count("/")
+            meta_bits = []
+            if row.get("project_dir"):
+                meta_bits.append(f"project={row['project_dir']}")
+            if row.get("default_agent"):
+                meta_bits.append(f"agent={row['default_agent']}")
+            archived = int(row.get("history_count") or 0)
+            if archived:
+                meta_bits.append(f"{archived} archived")
+            if row.get("hidden"):
+                meta_bits.append("hidden")
+            meta = f"  ({' · '.join(meta_bits)})" if meta_bits else ""
+            tree_lines.append(f"{'  ' * depth}{fid}  {fpath}{meta}")
+            for slot_row in by_folder.get(fid, []):
+                tree_lines.append(_session_line(slot_row, "  " * depth + "  "))
+        unfiled = by_folder.get("", [])
+        if unfiled:
+            tree_lines.append("(unfiled — top level)")
+            for slot_row in unfiled:
+                tree_lines.append(_session_line(slot_row, "  "))
+        if not chat_folders and not chat_slots:
+            return "No sidebar folders and no live sessions."
+        return redact("\n".join(tree_lines))
+
+    if name == "chat_folder_create":
+        args = validate_tool_args(args, CHAT_FOLDER_CREATE_SCHEMA)
+        # A '/' in a NAME is what makes a rendered path ambiguous (a folder named
+        # "A/B" renders exactly like B inside A). The resolver refuses that
+        # ambiguity; this tool must not manufacture more of it. The sidebar keeps
+        # its freedom — a human can still name a folder anything.
+        if "/" in str(args["name"]):
+            return (
+                "Error: a folder name cannot contain '/' — it would render "
+                "identically to a nested path and become unaddressable by path. "
+                "Create the parent and child separately, or use a different name."
+            )
+        chat_folders, folders_err = _get_rows("/api/chat/folders")
+        if folders_err:
+            return f"Error: {folders_err}"
+        # mkdir -p over the parent path: resolve as far as the tree already
+        # goes, then create each missing segment.
+        parent_id, created_segments, parent_err = _ensure_chat_folder_path(
+            str(args.get("parent") or ""), chat_folders
+        )
+        made_note = (
+            f" (created parent path: {'/'.join(created_segments)})" if created_segments else ""
+        )
+        if parent_err:
+            return redact(f"Error: {parent_err}{made_note}")
+        # Agent-authored name landing in durable, re-rendered state — redact
+        # before the write, like the created parent segments above.
+        body = {"name": redact(args["name"]), "parent_id": parent_id}
+        d = _post("/api/chat/folders", body)
+        if d.get("error"):
+            return redact(f"Error: {d['error']}{made_note}")
+        chat_folders.append(d)
+        new_id = str(d.get("id") or "?")
+        new_path = _chat_folder_paths(chat_folders).get(new_id) or str(d.get("name") or "?")
+        return redact(f"Created folder `{new_path}` (id={new_id}).{made_note}")
+
+    if name == "chat_folder_move":
+        args = validate_tool_args(args, CHAT_FOLDER_MOVE_SCHEMA)
+        chat_folders, folders_err = _get_rows("/api/chat/folders")
+        if folders_err:
+            return f"Error: {folders_err}"
+        fld_id, fld_err = _resolve_chat_folder_id(args["folder"], chat_folders)
+        if fld_err:
+            return f"Error: {fld_err}"
+        if not fld_id:
+            return "Error: 'root' is not a folder — name the folder to move."
+        dest_id, dest_err = _resolve_chat_folder_id(args.get("new_parent") or "", chat_folders)
+        if dest_err:
+            return f"Error: {dest_err}"
+        d = _patch(f"/api/chat/folders/{fld_id}", {"parent_id": dest_id})
+        if d.get("error"):
+            # The endpoint owns the cycle guard (a folder cannot move into its
+            # own descendant) — surface its verdict rather than re-deriving it.
+            return f"Error: {d['error']}"
+        moved: list[dict] = [f for f in chat_folders if str(f.get("id")) != fld_id]
+        moved.append({**d, "id": fld_id})
+        dest_path = _chat_folder_paths(moved).get(fld_id) or "(top level)"
+        return redact(f"Moved folder (id={fld_id}) to `{dest_path}`.")
+
+    if name == "chat_folder_move_session":
+        args = validate_tool_args(args, CHAT_FOLDER_MOVE_SESSION_SCHEMA)
+        chat_folders, folders_err = _get_rows("/api/chat/folders")
+        if folders_err:
+            return f"Error: {folders_err}"
+        fld_id, fld_err = _resolve_chat_folder_id(args.get("folder") or "", chat_folders)
+        if fld_err:
+            return f"Error: {fld_err}"
+        chat_slots, slots_err = _get_rows("/api/chat/slots")
+        if slots_err:
+            return f"Error: {slots_err}"
+        slot_key, slot_err = _resolve_chat_slot_key(args["session"], chat_slots)
+        if slot_err:
+            # The refusal echoes candidate slot keys, and a slot key can be a
+            # folded human name — redact like every other egress here.
+            return redact(f"Error: {slot_err}")
+        d = _patch(f"/api/chat/slots/{quote(slot_key, safe='')}/folder", {"folder_id": fld_id})
+        if d.get("error"):
+            return f"Error: {d['error']}"
+        if not fld_id:
+            return redact(f"Unfiled session `{slot_key}` to the top level.")
+        folder_label = _chat_folder_paths(chat_folders).get(fld_id, fld_id)
+        return redact(f"Moved session `{slot_key}` into `{folder_label}` (id={fld_id}).")
+    return f"Error: unknown tool '{name}'"
+
+
+def _call_tool(name: str, raw_args: dict[str, Any]) -> str:
+    """Guarded entry point — schema validation and SEL audit live in the wrapper."""
+    return call_tool_with_logging(
+        name,
+        raw_args,
+        _validate_args,
+        _call_tool_inner,
+        session_key=_resolve_session_key() or SERVER_NAME,
+        downstream_service=SERVER_NAME,
+    )
+
+
+def run_mcp_server() -> None:
+    """Run the MCP stdio server — reads JSON-RPC from stdin, writes to stdout."""
+    run_mcp_stdio_loop(SERVER_NAME, SERVER_VERSION, _list_tools, _call_tool)

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -650,6 +650,7 @@ _MANAGED_SERVER_SUBCOMMANDS = {
     "kirocrew-core": "mcp-core",
     "kirocrew-cron": "mcp-cron",
     "kirocrew-computer": "mcp-computer",
+    "kirocrew-dashboard": "mcp-dashboard",
 }
 _MANAGED_SERVER_NAMES = set(_MANAGED_SERVER_SUBCOMMANDS)
 
@@ -660,6 +661,7 @@ _MANAGED_SERVER_TOOL_MODULES = {
     "kirocrew-core": "kiro_crew.mcp_core",
     "kirocrew-cron": "kiro_crew.mcp_cron",
     "kirocrew-computer": "kiro_crew.mcp_computer",
+    "kirocrew-dashboard": "kiro_crew.mcp_dashboard",
 }
 
 

--- a/src/kiro_crew/onboarding_import.py
+++ b/src/kiro_crew/onboarding_import.py
@@ -332,6 +332,7 @@ _MANAGED_MCP_NAMES = frozenset(
         "kirocrew-core",
         "kirocrew-cron",
         "kirocrew-computer",
+        "kirocrew-dashboard",
         "meshclaw-core",
         "meshclaw-cron",
         "meshclaw-computer",

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -802,6 +802,11 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         "knowledge/ingestion.py",
         "mcp_core.py",
         "mcp_cron.py",
+        # Same class as mcp_core.py: an MCP stdio server redacts tool RESULTS and
+        # agent-authored names before they are persisted or returned, but the
+        # egress boundary itself is the transport the result crosses, not this
+        # module.
+        "mcp_dashboard.py",
         "mcp_discovery.py",
         "mcp_gateway/backend.py",
         "workflows/agent_exec.py",
@@ -1087,6 +1092,7 @@ _SCHEMA_REGISTRY_NAMES: tuple[str, ...] = (
     "MCP_CORE_SCHEMAS",
     "MCP_CRON_SCHEMAS",
     "MCP_COMPUTER_SCHEMAS",
+    "MCP_DASHBOARD_SCHEMAS",
 )
 
 

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -1709,6 +1709,42 @@ ARTIFACT_FOLDER_DELETE_SCHEMA = ToolSchema(
     ],
 )
 
+# Chat (sidebar) folders. Same reference model as the artifact folders above —
+# a folder is addressed by id OR by a ``/``-separated human path — so the two
+# bounds are shared. Folder names cap at 100 chars server-side
+# (chat_folders.api_chat_folder_create truncates); reject longer input here
+# instead of silently filing the session under a truncated name.
+CHAT_FOLDER_TREE_SCHEMA = ToolSchema(
+    tool_name="chat_folder_tree",
+    fields=[],
+)
+
+CHAT_FOLDER_CREATE_SCHEMA = ToolSchema(
+    tool_name="chat_folder_create",
+    fields=[
+        FieldSpec("name", str, required=True, max_len=_ARTIFACT_FOLDER_NAME_MAX),
+        FieldSpec("parent", str, max_len=_ARTIFACT_FOLDER_REF_MAX),
+    ],
+)
+
+CHAT_FOLDER_MOVE_SCHEMA = ToolSchema(
+    tool_name="chat_folder_move",
+    fields=[
+        FieldSpec("folder", str, required=True, max_len=_ARTIFACT_FOLDER_REF_MAX),
+        FieldSpec("new_parent", str, max_len=_ARTIFACT_FOLDER_REF_MAX),
+    ],
+)
+
+CHAT_FOLDER_MOVE_SESSION_SCHEMA = ToolSchema(
+    tool_name="chat_folder_move_session",
+    fields=[
+        # A session reference is a slot key, a ``dashboard:`` session key, or an
+        # exact session title — none share a charset, so only bound the length.
+        FieldSpec("session", str, required=True, max_len=512),
+        FieldSpec("folder", str, max_len=_ARTIFACT_FOLDER_REF_MAX),
+    ],
+)
+
 ARTIFACT_MOVE_SCHEMA = ToolSchema(
     tool_name="artifact_move",
     fields=[
@@ -2528,6 +2564,21 @@ def _cu_coord_field(name: str, *, required: bool = False) -> FieldSpec:
         max_val=_cu_types.MAX_SCREEN_COORD,
     )
 
+
+# ── Tool Schemas (MCP Dashboard — server ``kirocrew-dashboard``) ──
+#
+# Registered separately from MCP_CORE_SCHEMAS because the dashboard-control tools
+# ship in their own MCP server: core is the always-present surface, and a
+# capability the user opts into does not belong in every session's context. The
+# registry must exist for the same reason the core one does — call_tool_with_logging
+# routes validation through it, and a tool absent from its server's registry has
+# its args passed through raw.
+MCP_DASHBOARD_SCHEMAS: dict[str, ToolSchema] = {
+    "chat_folder_tree": CHAT_FOLDER_TREE_SCHEMA,
+    "chat_folder_create": CHAT_FOLDER_CREATE_SCHEMA,
+    "chat_folder_move": CHAT_FOLDER_MOVE_SCHEMA,
+    "chat_folder_move_session": CHAT_FOLDER_MOVE_SESSION_SCHEMA,
+}
 
 MCP_COMPUTER_SCHEMAS: dict[str, ToolSchema] = {
     _cu_types.TOOL_LIST_APPS: ToolSchema(tool_name=_cu_types.TOOL_LIST_APPS, fields=[]),

--- a/test/test_chat_folder_audit_origin.py
+++ b/test/test_chat_folder_audit_origin.py
@@ -1,0 +1,105 @@
+"""The folder endpoints must audit WHO moved a session — agent or human.
+
+``/api/chat/folders`` and ``/api/chat/slots/{slot}/folder`` are now driven by
+both the browser and the ``chat_folder_*`` MCP tools. An audit line that labels
+every write ``dashboard`` cannot answer "did I file that session, or did the
+agent?", which is the whole point of auditing a mutation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_folder_app, _make_state
+
+
+class _RecordingSel:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def log_api_access(self, **kw: Any) -> None:
+        self.events.append(kw)
+
+    def __getattr__(self, _name: str) -> Any:  # pragma: no cover - unused legs
+        return lambda *a, **k: None
+
+
+@pytest.fixture
+def recorded(monkeypatch: Any) -> _RecordingSel:
+    rec = _RecordingSel()
+    monkeypatch.setattr("kiro_crew.dashboard.chat_folders.sel", lambda: rec)
+    return rec
+
+
+async def _client(state: Any) -> TestClient:
+    client = TestClient(TestServer(_make_folder_app(state)))
+    await client.start_server()
+    return client
+
+
+class TestFolderAuditOrigin:
+    @pytest.mark.asyncio
+    async def test_browser_create_is_audited_as_dashboard(
+        self, tmp_path: Any, monkeypatch: Any, recorded: _RecordingSel
+    ) -> None:
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        client = await _client(state)
+        try:
+            resp = await client.post("/api/chat/folders", json={"name": "Browser"})
+            assert resp.status == 201
+        finally:
+            await client.close()
+        event = next(e for e in recorded.events if e["operation"] == "chat.folder_create")
+        assert event["source"] == "dashboard"
+        assert event["caller"] == "dashboard"
+
+    @pytest.mark.asyncio
+    async def test_mcp_create_is_audited_as_mcp(
+        self, tmp_path: Any, monkeypatch: Any, recorded: _RecordingSel
+    ) -> None:
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        client = await _client(state)
+        try:
+            resp = await client.post(
+                "/api/chat/folders",
+                json={"name": "Agent"},
+                headers={"X-Internal-Secret": "s3cret"},
+            )
+            assert resp.status == 201
+        finally:
+            await client.close()
+        event = next(e for e in recorded.events if e["operation"] == "chat.folder_create")
+        assert event["source"] == "mcp"
+        assert event["caller"] == "mcp"
+
+    @pytest.mark.asyncio
+    async def test_mcp_session_move_is_audited_as_mcp(
+        self, tmp_path: Any, monkeypatch: Any, recorded: _RecordingSel
+    ) -> None:
+        """The mutation Raymond most needs attributed: who re-filed the session."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("myslot")
+        slot.append("user", "hello")
+        slot.drain()
+        state._folders = [
+            {"id": "f1", "name": "Test", "order": 0, "collapsed": False, "parent_id": ""}
+        ]
+        client = await _client(state)
+        try:
+            resp = await client.patch(
+                "/api/chat/slots/myslot/folder",
+                json={"folder_id": "f1"},
+                headers={"X-Internal-Secret": "s3cret"},
+            )
+            assert resp.status == 200
+        finally:
+            await client.close()
+        event = next(e for e in recorded.events if e["operation"] == "chat.slot_folder")
+        assert event["source"] == "mcp"
+        assert event["caller"] == "mcp"
+        assert event["resources"] == "myslot"

--- a/test/test_mcp_dashboard_folders.py
+++ b/test/test_mcp_dashboard_folders.py
@@ -1,0 +1,730 @@
+"""Tests for the chat (sidebar) folder tools on the kirocrew-dashboard server.
+
+Covers dispatch for ``chat_folder_tree/create/move/move_session`` — schema
+validation, path→id resolution, mkdir -p, session-reference resolution, HTTP
+call shape, and result formatting. The HTTP helpers are patched; the endpoints
+themselves are tested by ``test_folder_store_writer.py`` and
+``test_dashboard_chat.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.mcp_dashboard import _call_tool_inner, _list_tools, is_enabled
+from kiro_crew.validation import ValidationError
+
+# Representative GET /api/chat/folders body — a bare JSON array (no envelope),
+# each row carrying only parent_id (the human path is derived client-side).
+_FOLDERS = [
+    {"id": "aaaaaaaaaaaa", "name": "kirocrew", "parent_id": "", "history_count": 3},
+    {"id": "bbbbbbbbbbbb", "name": "0811", "parent_id": "aaaaaaaaaaaa", "history_count": 0},
+    {"id": "cccccccccccc", "name": "Travel", "parent_id": "", "history_count": 0},
+]
+
+_SLOTS = [
+    {"key": "chat-1-100", "title": "Backup M1", "folder_id": "aaaaaaaaaaaa", "running": True},
+    {"key": "chat-2-200", "title": "Folder MCP", "folder_id": "bbbbbbbbbbbb"},
+    {"key": "chat-3-300", "title": "Scratch", "folder_id": ""},
+]
+
+
+@pytest.fixture(autouse=True)
+def _dashboard_control_on(monkeypatch: Any) -> None:
+    """These tests exercise the tools, so the feature gate is held open.
+
+    The gate's own behaviour is covered by TestEnableGate, which does NOT use
+    this fixture's effect (it patches is_enabled to return False).
+    """
+    monkeypatch.setattr("kiro_crew.mcp_dashboard.is_enabled", lambda: True)
+
+
+def _rows(path: str) -> list[dict]:
+    """Stand in for the two array endpoints the tools read."""
+    if path == "/api/chat/folders":
+        return [dict(f) for f in _FOLDERS]
+    if path == "/api/chat/slots":
+        return [dict(s) for s in _SLOTS]
+    raise AssertionError(f"unexpected GET {path}")
+
+
+class TestFolderTree:
+    def test_renders_paths_sessions_and_unfiled(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows):
+            out = _call_tool_inner("chat_folder_tree", {})
+        # Derived human path, not just the leaf name.
+        assert "kirocrew/0811" in out
+        # Sessions nest under their folder, with the slot key the move tool takes.
+        assert "chat-2-200" in out and "Folder MCP" in out
+        assert "running" in out  # live state surfaces
+        assert "3 archived" in out  # history_count is reported, not hidden
+        assert "(unfiled" in out and "chat-3-300" in out
+        assert "3 folders, 3 live sessions" in out
+
+    def test_slot_pointing_at_unknown_folder_falls_back_to_unfiled(self) -> None:
+        """A dangling folder_id must not make the session disappear."""
+        orphan = [{"key": "chat-9-900", "title": "Orphan", "folder_id": "deadbeefdead"}]
+
+        def _get(path: str) -> list[dict]:
+            return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else orphan
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get):
+            out = _call_tool_inner("chat_folder_tree", {})
+        assert "(unfiled" in out and "chat-9-900" in out
+
+    def test_empty_tree(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", return_value=[]):
+            out = _call_tool_inner("chat_folder_tree", {})
+        assert "No sidebar folders and no live sessions." == out
+
+    def test_folder_endpoint_error_is_not_reported_as_empty(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", return_value={"error": "Token required"}):
+            out = _call_tool_inner("chat_folder_tree", {})
+        assert out.startswith("Error:") and "Token required" in out
+
+    def test_unexpected_body_shape_is_an_error(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", return_value={"folders": []}):
+            out = _call_tool_inner("chat_folder_tree", {})
+        assert out.startswith("Error:") and "unexpected response shape" in out
+
+
+class TestFolderCreate:
+    def test_creates_subfolder_under_existing_parent_path(self) -> None:
+        made = {"id": "dddddddddddd", "name": "0812", "parent_id": "aaaaaaaaaaaa"}
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._post", return_value=made
+        ) as mock_post:
+            out = _call_tool_inner("chat_folder_create", {"name": "0812", "parent": "kirocrew"})
+        path, body = mock_post.call_args.args
+        assert path == "/api/chat/folders"
+        assert body == {"name": "0812", "parent_id": "aaaaaaaaaaaa"}
+        assert "kirocrew/0812" in out and "dddddddddddd" in out
+
+    def test_accepts_parent_by_id(self) -> None:
+        made = {"id": "dddddddddddd", "name": "x", "parent_id": "bbbbbbbbbbbb"}
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._post", return_value=made
+        ) as mock_post:
+            _call_tool_inner("chat_folder_create", {"name": "x", "parent": "bbbbbbbbbbbb"})
+        assert mock_post.call_args.args[1]["parent_id"] == "bbbbbbbbbbbb"
+
+    def test_top_level_when_parent_omitted(self) -> None:
+        made = {"id": "eeeeeeeeeeee", "name": "Solo", "parent_id": ""}
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._post", return_value=made
+        ) as mock_post:
+            _call_tool_inner("chat_folder_create", {"name": "Solo"})
+        assert mock_post.call_args.args[1] == {"name": "Solo", "parent_id": ""}
+
+    def test_mkdir_p_creates_missing_parent_segments(self) -> None:
+        posts: list[dict] = []
+
+        def _post(path: str, body: dict, **kw: object) -> dict:
+            posts.append(body)
+            return {
+                "id": f"new{len(posts):09d}",
+                "name": body["name"],
+                "parent_id": body["parent_id"],
+            }
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._post", side_effect=_post
+        ):
+            out = _call_tool_inner(
+                "chat_folder_create", {"name": "week1", "parent": "kirocrew/2026/august"}
+            )
+        # "kirocrew" exists; "2026" and "august" are created, then the leaf.
+        assert [p["name"] for p in posts] == ["2026", "august", "week1"]
+        assert posts[0]["parent_id"] == "aaaaaaaaaaaa"
+        # Each created segment becomes the next one's parent — the walk threads
+        # the freshly minted id through instead of restarting at the top level.
+        assert posts[1]["parent_id"] == "new000000001"
+        assert posts[2]["parent_id"] == "new000000002"
+        assert "created parent path: 2026/august" in out
+
+    def test_partial_mkdir_p_reports_what_was_created(self) -> None:
+        calls: list[dict] = []
+
+        def _post(path: str, body: dict, **kw: object) -> dict:
+            calls.append(body)
+            if len(calls) == 1:
+                return {"id": "new000000001", "name": body["name"], "parent_id": ""}
+            return {"error": "name required"}
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._post", side_effect=_post
+        ):
+            out = _call_tool_inner("chat_folder_create", {"name": "leaf", "parent": "new/deeper"})
+        assert out.startswith("Error:")
+        assert "created parent path: new" in out
+
+    def test_stale_id_reference_is_not_created_as_a_folder_name(self) -> None:
+        """An id-shaped parent that does not exist is a lookup failure.
+
+        Treating it as a path segment would create a folder literally named
+        after the hex id.
+        """
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._post"
+        ) as mock_post:
+            out = _call_tool_inner(
+                "chat_folder_create", {"name": "x", "parent": "0123456789ab"}
+            )
+        assert out.startswith("Error:") and "folder not found" in out
+        mock_post.assert_not_called()
+
+    def test_name_is_required(self) -> None:
+        # Raised inside the tool and converted to a clean "Error: ..." string by
+        # call_tool_with_logging's outer guard (the schema is registered in
+        # validation.TOOL_SCHEMAS precisely so that guard runs).
+        with pytest.raises(ValidationError):
+            _call_tool_inner("chat_folder_create", {"parent": "kirocrew"})
+
+
+class TestAmbiguousFolderPaths:
+    """Folder names are not unique within a parent, so a path can be ambiguous.
+
+    Taking the first match would create under — or move into — an arbitrary
+    sibling, which is a silent wrong-placement rather than a visible failure.
+    """
+
+    # Two folders named "0811" under the same parent, as the sidebar allows.
+    DUPES = [
+        {"id": "aaaaaaaaaaaa", "name": "kirocrew", "parent_id": ""},
+        {"id": "bbbbbbbbbbbb", "name": "0811", "parent_id": "aaaaaaaaaaaa"},
+        {"id": "cccccccccccc", "name": "0811", "parent_id": "aaaaaaaaaaaa"},
+    ]
+
+    def _get(self, path: str) -> list[dict]:
+        if path == "/api/chat/folders":
+            return [dict(f) for f in self.DUPES]
+        return [{"key": "chat-1-100", "title": "S", "folder_id": ""}]
+
+    def test_create_refuses_an_ambiguous_parent_path(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._get), patch(
+            "kiro_crew.mcp_dashboard._post"
+        ) as mock_post:
+            out = _call_tool_inner(
+                "chat_folder_create", {"name": "x", "parent": "kirocrew/0811"}
+            )
+        assert out.startswith("Error:")
+        assert "bbbbbbbbbbbb" in out and "cccccccccccc" in out
+        mock_post.assert_not_called()
+
+    def test_move_refuses_an_ambiguous_destination_path(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._get), patch(
+            "kiro_crew.mcp_dashboard._patch"
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move", {"folder": "kirocrew", "new_parent": "kirocrew/0811"}
+            )
+        assert out.startswith("Error:") and "pass the folder id" in out
+        mock_patch.assert_not_called()
+
+    def test_session_move_refuses_an_ambiguous_destination_path(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._get), patch(
+            "kiro_crew.mcp_dashboard._patch"
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session",
+                {"session": "chat-1-100", "folder": "kirocrew/0811"},
+            )
+        assert out.startswith("Error:")
+        mock_patch.assert_not_called()
+
+    def test_an_id_still_addresses_one_of_the_duplicates(self) -> None:
+        """The refusal must leave a way through: the id is unambiguous."""
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._get), patch(
+            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session",
+                {"session": "chat-1-100", "folder": "cccccccccccc"},
+            )
+        assert not out.startswith("Error:")
+        assert mock_patch.call_args.args[1] == {"folder_id": "cccccccccccc"}
+
+    def test_mkdir_p_does_not_add_a_third_duplicate_sibling(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._get), patch(
+            "kiro_crew.mcp_dashboard._post"
+        ) as mock_post:
+            out = _call_tool_inner(
+                "chat_folder_create", {"name": "leaf", "parent": "kirocrew/0811/deeper"}
+            )
+        # Ambiguity found mid-walk (not at the final segment), so this is the
+        # segment refusal — it must name both duplicates.
+        assert out.startswith("Error:") and "share the same parent" in out
+        assert "bbbbbbbbbbbb" in out and "cccccccccccc" in out
+        mock_post.assert_not_called()
+
+
+class TestSlashBearingFolderNames:
+    """A folder NAME may contain '/', so a rendered path has two readings.
+
+    The sidebar permits a folder literally named ``A/B``, which renders exactly
+    like ``B`` nested inside ``A``. Resolving the agent's own displayed path to
+    the nested pair would act on a different folder than the one it read.
+    """
+
+    LITERAL = [{"id": "aaaaaaaaaaaa", "name": "A/B", "parent_id": ""}]
+    BOTH = [
+        {"id": "aaaaaaaaaaaa", "name": "A/B", "parent_id": ""},
+        {"id": "bbbbbbbbbbbb", "name": "A", "parent_id": ""},
+        {"id": "cccccccccccc", "name": "B", "parent_id": "bbbbbbbbbbbb"},
+    ]
+
+    @staticmethod
+    def _getter(folders: list[dict]) -> Any:
+        def _get(path: str) -> list[dict]:
+            if path == "/api/chat/folders":
+                return [dict(f) for f in folders]
+            return [{"key": "chat-1-100", "title": "S", "folder_id": ""}]
+
+        return _get
+
+    def test_the_literal_folder_wins_when_no_nested_pair_exists(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(self.LITERAL)), patch(
+            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session", {"session": "chat-1-100", "folder": "A/B"}
+            )
+        assert not out.startswith("Error:")
+        assert mock_patch.call_args.args[1] == {"folder_id": "aaaaaaaaaaaa"}
+
+    def test_create_under_a_literal_slash_name_does_not_build_a_nested_pair(self) -> None:
+        made = {"id": "dddddddddddd", "name": "leaf", "parent_id": "aaaaaaaaaaaa"}
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(self.LITERAL)), patch(
+            "kiro_crew.mcp_dashboard._post", return_value=made
+        ) as mock_post:
+            _call_tool_inner("chat_folder_create", {"name": "leaf", "parent": "A/B"})
+        # Exactly one POST: the leaf. No "A" and no "B" were manufactured.
+        assert mock_post.call_count == 1
+        assert mock_post.call_args.args[1] == {"name": "leaf", "parent_id": "aaaaaaaaaaaa"}
+
+    def test_collision_between_the_two_readings_is_refused(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(self.BOTH)), patch(
+            "kiro_crew.mcp_dashboard._patch"
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session", {"session": "chat-1-100", "folder": "A/B"}
+            )
+        assert out.startswith("Error:") and "render the same path" in out
+        # Both candidate ids are named so the caller can choose one.
+        assert "aaaaaaaaaaaa" in out and "cccccccccccc" in out
+        mock_patch.assert_not_called()
+
+    def test_a_reading_divergence_that_survives_the_path_render_is_refused(self) -> None:
+        """The two readings can differ without rendering the same path.
+
+        A leading space inside the nested name makes the pair render ``A/ B``
+        while the literal folder renders ``A/B``, so the duplicate-path check
+        passes and the walk-vs-exact disagreement (the walk strips each segment)
+        is the only thing left to catch it.
+        """
+        padded = [
+            {"id": "aaaaaaaaaaaa", "name": "A/B", "parent_id": ""},
+            {"id": "bbbbbbbbbbbb", "name": "A", "parent_id": ""},
+            {"id": "cccccccccccc", "name": " B", "parent_id": "bbbbbbbbbbbb"},
+        ]
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(padded)), patch(
+            "kiro_crew.mcp_dashboard._patch"
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session", {"session": "chat-1-100", "folder": "A/B"}
+            )
+        assert out.startswith("Error:") and "ambiguous" in out
+        assert "aaaaaaaaaaaa" in out and "cccccccccccc" in out
+        mock_patch.assert_not_called()
+
+    def test_an_id_resolves_either_way(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(self.BOTH)), patch(
+            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session",
+                {"session": "chat-1-100", "folder": "cccccccccccc"},
+            )
+        assert not out.startswith("Error:")
+        assert mock_patch.call_args.args[1] == {"folder_id": "cccccccccccc"}
+
+    def test_the_agent_cannot_mint_a_new_slash_bearing_name(self) -> None:
+        """The tool refuses to grow the ambiguity its resolver exists to refuse.
+
+        The sidebar keeps its freedom — a human may still name a folder ``A/B``;
+        this only stops the agent adding more unaddressable-by-path names.
+        """
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._post"
+        ) as mock_post:
+            out = _call_tool_inner("chat_folder_create", {"name": "Projects/Web"})
+        assert out.startswith("Error:") and "cannot contain '/'" in out
+        mock_post.assert_not_called()
+
+
+class TestFolderNameRedaction:
+    """A folder name is agent-authored and the sidebar re-renders it forever.
+
+    Persisting a credential the agent quoted into a name would re-display it on
+    every visit, so the name takes the egress pass BEFORE the write.
+    """
+
+    LEAKY = "AKIAIOSFODNN7EXAMPLE"
+
+    def test_leaf_name_is_redacted_before_the_write(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._post",
+            return_value={"id": "dddddddddddd", "name": "x", "parent_id": ""},
+        ) as mock_post:
+            _call_tool_inner("chat_folder_create", {"name": self.LEAKY})
+        assert self.LEAKY not in mock_post.call_args.args[1]["name"]
+
+    def test_created_parent_segments_are_redacted_before_the_write(self) -> None:
+        posts: list[dict] = []
+
+        def _post(path: str, body: dict, **kw: object) -> dict:
+            posts.append(body)
+            return {
+                "id": f"new{len(posts):09d}",
+                "name": body["name"],
+                "parent_id": body["parent_id"],
+            }
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._post", side_effect=_post
+        ):
+            out = _call_tool_inner(
+                "chat_folder_create", {"name": "leaf", "parent": f"kirocrew/{self.LEAKY}"}
+            )
+        assert all(self.LEAKY not in p["name"] for p in posts)
+        assert self.LEAKY not in out
+
+
+class TestFolderMove:
+    def test_reparents_by_path(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._patch",
+            return_value={"id": "cccccccccccc", "name": "Travel", "parent_id": "aaaaaaaaaaaa"},
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move", {"folder": "Travel", "new_parent": "kirocrew"}
+            )
+        path, body = mock_patch.call_args.args
+        assert path == "/api/chat/folders/cccccccccccc"
+        assert body == {"parent_id": "aaaaaaaaaaaa"}
+        assert "kirocrew/Travel" in out
+
+    def test_move_to_root(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._patch",
+            return_value={"id": "bbbbbbbbbbbb", "name": "0811", "parent_id": ""},
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move", {"folder": "kirocrew/0811", "new_parent": "root"}
+            )
+        assert mock_patch.call_args.args[1] == {"parent_id": ""}
+        assert "0811" in out
+
+    def test_root_is_not_a_movable_subject(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._patch"
+        ) as mock_patch:
+            out = _call_tool_inner("chat_folder_move", {"folder": "root"})
+        assert out.startswith("Error:")
+        mock_patch.assert_not_called()
+
+    def test_cycle_verdict_comes_from_the_endpoint(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._patch",
+            return_value={"error": "cannot move a folder into its own descendant"},
+        ):
+            out = _call_tool_inner(
+                "chat_folder_move", {"folder": "kirocrew", "new_parent": "kirocrew/0811"}
+            )
+        assert out.startswith("Error:") and "own descendant" in out
+
+    def test_unknown_folder_errors(self) -> None:
+        """Move RESOLVES a folder; it must never create one on the way."""
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._post"
+        ) as mock_post, patch("kiro_crew.mcp_dashboard._patch") as mock_patch:
+            out = _call_tool_inner("chat_folder_move", {"folder": "Nope/Missing"})
+        assert out.startswith("Error:") and "folder not found" in out
+        mock_post.assert_not_called()
+        mock_patch.assert_not_called()
+
+    def test_resolve_only_walk_refuses_a_mid_path_duplicate(self) -> None:
+        """Ambiguity below the addressed path is refused in resolve mode too."""
+        dupes = [
+            {"id": "aaaaaaaaaaaa", "name": "kirocrew", "parent_id": ""},
+            {"id": "bbbbbbbbbbbb", "name": "0811", "parent_id": "aaaaaaaaaaaa"},
+            {"id": "cccccccccccc", "name": "0811", "parent_id": "aaaaaaaaaaaa"},
+        ]
+
+        def _get(path: str) -> list[dict]:
+            return [dict(f) for f in dupes] if path == "/api/chat/folders" else []
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
+            "kiro_crew.mcp_dashboard._post"
+        ) as mock_post, patch("kiro_crew.mcp_dashboard._patch") as mock_patch:
+            out = _call_tool_inner("chat_folder_move", {"folder": "kirocrew/0811/deeper"})
+        assert out.startswith("Error:") and "share the same parent" in out
+        assert "bbbbbbbbbbbb" in out and "cccccccccccc" in out
+        mock_post.assert_not_called()
+        mock_patch.assert_not_called()
+
+
+class TestFolderMoveSession:
+    def test_moves_by_slot_key_into_a_path(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True, "folder_id": "bbbbbbbbbbbb"}
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session",
+                {"session": "chat-3-300", "folder": "kirocrew/0811"},
+            )
+        path, body = mock_patch.call_args.args
+        assert path == "/api/chat/slots/chat-3-300/folder"
+        assert body == {"folder_id": "bbbbbbbbbbbb"}
+        assert "kirocrew/0811" in out
+
+    def test_accepts_a_dashboard_session_key(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
+        ) as mock_patch:
+            _call_tool_inner(
+                "chat_folder_move_session",
+                {"session": "dashboard:chat-1-100", "folder": "Travel"},
+            )
+        assert mock_patch.call_args.args[0] == "/api/chat/slots/chat-1-100/folder"
+
+    def test_accepts_an_exact_unique_title(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
+        ) as mock_patch:
+            _call_tool_inner(
+                "chat_folder_move_session", {"session": "folder mcp", "folder": "Travel"}
+            )
+        assert mock_patch.call_args.args[0] == "/api/chat/slots/chat-2-200/folder"
+
+    def test_ambiguous_title_refuses_rather_than_guessing(self) -> None:
+        dupes = [
+            {"key": "chat-1-100", "title": "Same", "folder_id": ""},
+            {"key": "chat-2-200", "title": "Same", "folder_id": ""},
+        ]
+
+        def _get(path: str) -> list[dict]:
+            return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else dupes
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
+            "kiro_crew.mcp_dashboard._patch"
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session", {"session": "Same", "folder": "Travel"}
+            )
+        assert out.startswith("Error:") and "chat-1-100" in out and "chat-2-200" in out
+        mock_patch.assert_not_called()
+
+    def test_partial_title_is_not_a_match(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._patch"
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session", {"session": "Folder", "folder": "Travel"}
+            )
+        assert out.startswith("Error:")
+        mock_patch.assert_not_called()
+
+    def test_unknown_session_names_the_archived_limitation(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows):
+            out = _call_tool_inner(
+                "chat_folder_move_session", {"session": "chat-nope-1", "folder": "Travel"}
+            )
+        assert out.startswith("Error:") and "ARCHIVED" in out
+
+    def test_an_explicit_key_never_falls_through_to_title_matching(self) -> None:
+        """`dashboard:` asserts a KEY, so an absent key must not resolve by title.
+
+        Honouring the title here would file a session the caller did not name,
+        which is the opposite of what the prefix says.
+        """
+        rows = [
+            {"key": "chat-1-100", "title": "dashboard:chat-9-999", "folder_id": ""},
+            {"key": "chat-2-200", "title": "Other", "folder_id": ""},
+        ]
+
+        def _get(path: str) -> list[dict]:
+            return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else rows
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
+            "kiro_crew.mcp_dashboard._patch"
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session",
+                {"session": "dashboard:chat-9-999", "folder": "Travel"},
+            )
+        assert out.startswith("Error:") and "no live session has the key" in out
+        mock_patch.assert_not_called()
+
+    def test_a_key_that_is_also_another_session_title_is_refused(self) -> None:
+        """One session's key can be another session's title — that is ambiguous."""
+        rows = [
+            {"key": "chat-1-100", "title": "Real one", "folder_id": ""},
+            {"key": "chat-2-200", "title": "chat-1-100", "folder_id": ""},
+        ]
+
+        def _get(path: str) -> list[dict]:
+            return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else rows
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
+            "kiro_crew.mcp_dashboard._patch"
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session", {"session": "chat-1-100", "folder": "Travel"}
+            )
+        assert out.startswith("Error:")
+        assert "chat-1-100" in out and "chat-2-200" in out
+        mock_patch.assert_not_called()
+
+    def test_the_dashboard_prefix_selects_the_key_through_that_collision(self) -> None:
+        rows = [
+            {"key": "chat-1-100", "title": "Real one", "folder_id": ""},
+            {"key": "chat-2-200", "title": "chat-1-100", "folder_id": ""},
+        ]
+
+        def _get(path: str) -> list[dict]:
+            return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else rows
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
+            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session",
+                {"session": "dashboard:chat-1-100", "folder": "Travel"},
+            )
+        assert not out.startswith("Error:")
+        assert mock_patch.call_args.args[0] == "/api/chat/slots/chat-1-100/folder"
+
+    def test_unfile_to_top_level(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True, "folder_id": ""}
+        ) as mock_patch:
+            out = _call_tool_inner("chat_folder_move_session", {"session": "chat-1-100"})
+        assert mock_patch.call_args.args[1] == {"folder_id": ""}
+        assert "top level" in out
+
+    def test_unknown_destination_folder_never_reaches_the_endpoint(self) -> None:
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
+            "kiro_crew.mcp_dashboard._patch"
+        ) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move_session", {"session": "chat-1-100", "folder": "Nope"}
+            )
+        assert out.startswith("Error:") and "folder not found" in out
+        mock_patch.assert_not_called()
+
+    def test_slot_key_is_url_quoted(self) -> None:
+        """A slot key can be a folded human name; it must not break the path."""
+        odd = [{"key": "Artifact: My Doc", "title": "Doc", "folder_id": ""}]
+
+        def _get(path: str) -> list[dict]:
+            return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else odd
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
+            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
+        ) as mock_patch:
+            _call_tool_inner(
+                "chat_folder_move_session", {"session": "Artifact: My Doc", "folder": "Travel"}
+            )
+        assert mock_patch.call_args.args[0] == "/api/chat/slots/Artifact%3A%20My%20Doc/folder"
+
+    def test_unfile_result_is_redacted(self) -> None:
+        """A slot key is a folded human name — it can carry a pasted credential.
+
+        Every other return in these tools goes through redact(); the unfile leg
+        echoes the key verbatim, so it needs the same pass or a secret reaches
+        the model and the tool-result audit.
+        """
+        leaky = "AKIAIOSFODNN7EXAMPLE"
+        rows = [{"key": leaky, "title": "Leaky", "folder_id": "aaaaaaaaaaaa"}]
+
+        def _get(path: str) -> list[dict]:
+            return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else rows
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
+            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True, "folder_id": ""}
+        ):
+            out = _call_tool_inner("chat_folder_move_session", {"session": leaky})
+        assert leaky not in out
+        assert "top level" in out
+
+    def test_ambiguous_session_refusal_is_redacted(self) -> None:
+        """The refusal lists candidate slot keys — those need redaction too."""
+        leaky = "AKIAIOSFODNN7EXAMPLE"
+        rows = [
+            {"key": leaky, "title": "Same", "folder_id": ""},
+            {"key": "chat-2-200", "title": "Same", "folder_id": ""},
+        ]
+
+        def _get(path: str) -> list[dict]:
+            return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else rows
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get):
+            out = _call_tool_inner(
+                "chat_folder_move_session", {"session": "Same", "folder": "Travel"}
+            )
+        assert out.startswith("Error:")
+        assert leaky not in out
+
+
+class TestEnableGate:
+    """The server must be silent AND inert until the user opts in.
+
+    Silent so a session that never wants dashboard control spends no context on
+    it; inert because kiro-cli caches tools/list per session, so a session that
+    cached a live list before the toggle went off must not keep writing.
+    """
+
+    def test_tools_are_hidden_while_disabled(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr("kiro_crew.mcp_dashboard.is_enabled", lambda: False)
+        assert _list_tools() == []
+
+    def test_tools_are_advertised_once_enabled(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr("kiro_crew.mcp_dashboard.is_enabled", lambda: True)
+        names = {t["name"] for t in _list_tools()}
+        assert names == {
+            "chat_folder_tree",
+            "chat_folder_create",
+            "chat_folder_move",
+            "chat_folder_move_session",
+        }
+
+    def test_a_call_refuses_while_disabled_and_touches_no_endpoint(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setattr("kiro_crew.mcp_dashboard.is_enabled", lambda: False)
+        with patch("kiro_crew.mcp_dashboard._get") as mock_get, patch(
+            "kiro_crew.mcp_dashboard._patch"
+        ) as mock_patch:
+            out = _call_tool_inner("chat_folder_move_session", {"session": "chat-1-100"})
+        assert out.startswith("Error:") and "Dashboard Control" in out
+        mock_get.assert_not_called()
+        mock_patch.assert_not_called()
+
+    def test_an_unreadable_config_fails_closed(self, monkeypatch: Any) -> None:
+        """A config that will not load means "not proven on", not "assume on"."""
+
+        def _boom() -> Any:
+            raise OSError("config unreadable")
+
+        # The module-level autouse fixture holds the gate open by patching the
+        # module attribute; put the REAL implementation back so this test
+        # exercises it. The top-level import above still binds the original
+        # function object, unaffected by that patch.
+        monkeypatch.setattr("kiro_crew.mcp_dashboard.is_enabled", is_enabled)
+        monkeypatch.setattr("kiro_crew.mcp_dashboard.KiroCrewConfig.load", staticmethod(_boom))
+        assert is_enabled() is False
+        assert _list_tools() == []

--- a/test/test_mcp_dashboard_registration.py
+++ b/test/test_mcp_dashboard_registration.py
@@ -1,0 +1,147 @@
+"""Managed-MCP registration for ``kirocrew-dashboard``, and why it is its own server.
+
+The dashboard-control tools are deliberately NOT in ``kirocrew-core``. Core is the
+surface every session carries and kiro-cli reads ``tools/list`` once per session,
+so a capability the user opts into occasionally would otherwise spend context in
+every request of every session. Two properties encode that decision and must not
+regress:
+
+* **The server advertises NOTHING while ``agent.dashboard_control`` is off** — the
+  only shape that costs a non-user literally zero context (an always-refusing
+  tool still ships its description every turn).
+* **The managed spec carries NO ``autoApprove`` key.** An autoApproved MCP tool is
+  approved inside kiro-cli and never reaches ``hooks.on_tool_call``, so the deny
+  floor and governance ceiling would be bypassed for tools that rewrite the
+  user's session layout.
+
+The registry assertions mirror ``test_computer_use_registration.py``: a managed
+server has to be named in several places, and a half-registered server is the
+failure mode that test was written to prevent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from kiro_crew import agent, mcp_cleanup, mcp_discovery, onboarding_import
+from kiro_crew.config.loader import KiroCrewConfig
+
+DASH_SERVER = "kirocrew-dashboard"
+DASH_SUBCOMMAND = "mcp-dashboard"
+
+
+class TestRegistryParity:
+    def test_named_in_every_managed_registry(self) -> None:
+        assert DASH_SERVER in agent._MANAGED_MCP_SERVERS
+        assert DASH_SERVER in mcp_cleanup.KIROCREW_BIN_MCP_SERVERS
+        assert mcp_discovery._MANAGED_SERVER_SUBCOMMANDS.get(DASH_SERVER) == DASH_SUBCOMMAND
+        assert DASH_SERVER in mcp_discovery._MANAGED_SERVER_NAMES
+        assert DASH_SERVER in onboarding_import._MANAGED_MCP_NAMES
+
+    def test_tool_module_is_mapped_for_in_process_listing(self) -> None:
+        """Discovery reads tool names in-process; an unmapped server lists zero."""
+        assert (
+            mcp_discovery._MANAGED_SERVER_TOOL_MODULES.get(DASH_SERVER)
+            == "kiro_crew.mcp_dashboard"
+        )
+
+    def test_spec_carries_no_auto_approve(self) -> None:
+        assert "autoApprove" not in agent._MANAGED_MCP_SERVERS[DASH_SERVER]
+
+    def test_server_key_is_slash_free(self) -> None:
+        """A slash in the key would be rewritten by the alias normalization pass."""
+        assert "/" not in DASH_SERVER and "\\" not in DASH_SERVER
+
+
+class TestTheDefaultIsSilent:
+    """A fresh install must not spend context on a feature nobody asked for."""
+
+    def test_config_default_is_off(self) -> None:
+        assert KiroCrewConfig().agent.dashboard_control is False
+
+    def test_a_non_bool_config_value_does_not_enable_it(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        """`"dashboard_control": "false"` must not read as True.
+
+        A truthy STRING is the classic fail-open on a gate: `bool("false")` is
+        True. The field loads through `_safe_bool`, so any non-bool degrades to
+        the default and a hand-edited or script-written config cannot silently
+        grant folder writes.
+        """
+        import json
+
+        monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+        cfg_file = tmp_path / "config.json"
+        for bad in ("false", "true", "0", 1, ["yes"]):
+            cfg_file.write_text(
+                json.dumps({"agent": {"dashboard_control": bad}}), encoding="utf-8"
+            )
+            cfg = KiroCrewConfig.load()
+            assert cfg.agent.dashboard_control is False, f"{bad!r} enabled the gate"
+
+    def test_a_real_true_still_enables_it(self, tmp_path: Any, monkeypatch: Any) -> None:
+        import json
+
+        monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+        (tmp_path / "config.json").write_text(
+            json.dumps({"agent": {"dashboard_control": True}}), encoding="utf-8"
+        )
+        assert KiroCrewConfig.load().agent.dashboard_control is True
+
+    def test_tools_list_is_empty_on_a_default_install(self) -> None:
+        from kiro_crew import mcp_dashboard
+
+        with patch.object(mcp_dashboard.KiroCrewConfig, "load", staticmethod(KiroCrewConfig)):
+            assert mcp_dashboard.is_enabled() is False
+            assert mcp_dashboard._list_tools() == []
+
+    def test_the_toggle_is_what_reveals_the_tools(self) -> None:
+        from kiro_crew import mcp_dashboard
+
+        cfg = KiroCrewConfig()
+        cfg.agent.dashboard_control = True
+        with patch.object(mcp_dashboard.KiroCrewConfig, "load", staticmethod(lambda: cfg)):
+            assert mcp_dashboard.is_enabled() is True
+            assert len(mcp_dashboard._list_tools()) == 4
+
+
+class TestWhatThisEnableAuthorizes:
+    """Nothing needing AUTHORIZATION may ride this load switch.
+
+    `agent.dashboard_control` lives in `config.json`, which an auto-approved agent
+    shell can write, so it is a context-economy switch and not a consent control.
+    That is sound for the current tools — they grant no read the agent lacks
+    (`list_sessions` in core already returns every session's title and key) and
+    delete nothing. It stops being sound the moment a capability with real blast
+    radius is added here: that one needs its own keystone leaf, the way
+    `computer_use.json` and `browser-mode-enabled` do.
+
+    This ratchet pins the set riding the switch, so adding such a capability fails
+    until the author picks the right storage for its gate rather than inheriting
+    one that was never meant to authorize anything.
+    """
+
+    FOLDER_TOOLS = {
+        "chat_folder_tree",
+        "chat_folder_create",
+        "chat_folder_move",
+        "chat_folder_move_session",
+    }
+
+    def test_the_enable_covers_exactly_the_folder_tools(self) -> None:
+        from kiro_crew import mcp_dashboard
+
+        assert {t["name"] for t in mcp_dashboard._tool_definitions()} == self.FOLDER_TOOLS
+
+    def test_no_session_driving_tool_rides_this_enable(self) -> None:
+        """A tool that messages/stops another session needs its own gate."""
+        from kiro_crew import mcp_dashboard
+
+        names = {t["name"] for t in mcp_dashboard._tool_definitions()}
+        forbidden = {n for n in names if "message" in n or "stop" in n or "steer" in n}
+        assert not forbidden, (
+            f"{sorted(forbidden)} drive another session but would ride the "
+            "folder-organization enable — give that class its own switch"
+        )

--- a/test/test_perf_boot_path.py
+++ b/test/test_perf_boot_path.py
@@ -586,3 +586,33 @@ class TestChannelPresetsReadIsCached:
 
         resp = await handlers_channel.api_channel_presets(MagicMock())
         assert json.loads(resp.body)["presets"] == [{"id": "b"}, {"id": "c"}]
+
+
+# ── Optional MCP servers stay off the CLI import graph ─────────────────────
+
+
+class TestOptionalMcpServersAreNotImportedByTheCli:
+    """`kirocrew gateway` boots through ``cli``, so a module-scope import of an
+    optional, default-OFF subsystem runs on every gateway start and every other
+    command that will never dispatch to it. Each MCP server module is therefore
+    loaded inside its own dispatch branch.
+
+    An in-process ``sys.modules`` check cannot see this — pytest has already
+    imported the package — so the assertion runs in a clean interpreter.
+    """
+
+    def test_importing_cli_does_not_pull_the_mcp_server_modules(self) -> None:
+        got = _probe(
+            "import json, sys\n"
+            "import kiro_crew.cli\n"
+            "print(json.dumps({\n"
+            "    'dashboard': 'kiro_crew.mcp_dashboard' in sys.modules,\n"
+            "    'computer': 'kiro_crew.mcp_computer' in sys.modules,\n"
+            "}))\n"
+        )
+        assert got["dashboard"] is False, (
+            "kiro_crew.mcp_dashboard is imported at cli module scope — move it "
+            "into the mcp-dashboard dispatch branch (importlib) so a "
+            "default-disabled server costs gateway boot nothing"
+        )
+        assert got["computer"] is False


### PR DESCRIPTION
## 1. What is the problem?

The agent can read its own session list (`list_sessions`, `search_chat_history`) but it cannot touch the structure the user actually organizes work in: the sidebar folder tree. Every folder operation is browser-only — `GET/POST /api/chat/folders`, `PATCH /api/chat/folders/{id}`, `PATCH /api/chat/slots/{slot}/folder`. So "make a subfolder for today's work and move these three sessions into it" produces instructions instead of the change.

There is also no read that answers *what does my tree look like, and which sessions sit where*: `list_sessions` is flat and newest-first with no folder dimension, and the folders endpoint returns folders with no sessions.

A second problem surfaced while reviewing where these tools should live, and it is the more consequential one: **`kirocrew-core` has 69 tools and no principle for what belongs there.** Core is the surface every session carries, and kiro-cli reads `tools/list` once per session, so anything listed there spends context in every request of every session — whether or not that session will ever use it.

## 2. Why this issue matters to the user

Folders are how a heavy KiroCrew user keeps 30+ concurrent sessions navigable, and they go stale exactly when work is busiest — the moment the user is least willing to stop and file things by hand. The agent is already in the conversation that belongs in a folder; it just had no way to put it there.

The placement half matters to every user, including those who never want this feature. `agent.tool_search` is on by default and KiroCrew forces kiro's deferral always-on, so a core tool costs a name plus a description per request rather than a full JSON schema — smaller than it sounds, but not zero, and it scales with the tool count. A capability the user opts into occasionally should not tax every session forever.

The audit log had a related blind spot: these endpoints hardcoded `source="dashboard"`, so once an agent could drive them the log could not answer "did I move that session, or did the agent?".

## 3. How our fix solves it

**A new `kirocrew-dashboard` MCP server**, not four more tools in core. It takes the shape `kirocrew-computer` already proved: registered unconditionally, but `tools/list` returns `[]` and every call refuses while the new `agent.dashboard_control` config is off. A user who never turns it on pays **nothing** — which an always-refusing tool in core cannot achieve, because it still ships its description every turn. Per-agent scoping composes on top and needed no new mechanism: an agent spec's own `mcpServers` map already decides which agents see a server (`agent_discovery.py`).

**What that switch is, and is not.** `agent.dashboard_control` is a **load switch for context economy, not a permission.** It lives in `config.json`, which an auto-approved agent shell can write, and nothing here relies on it being unforgeable. That is sound because of what sits behind it: these tools grant no read the agent does not already have (`list_sessions` in `kirocrew-core` is always available and already returns every session's title and key), they cannot delete a folder or a conversation, and the worst outcome is a sidebar the user has to tidy — so an agent that flips its own load switch has bought itself context, not reach.

The keystone leaves in `security.py` are the other kind: `computer_use.json`, `browser-mode-enabled` and the Ops Mission Control mode each grant something OUTSIDE Kiro Crew (desktop input synthesis, the operator's logged-in browser, writes against production incident tooling) or are the security floor itself, which is why they are stored where the agent cannot write. A capability with that blast radius must not ride this switch — it needs its own keystone leaf. Session control is that shape, and `test_mcp_dashboard_registration.py` ratchets the tool set riding the switch so it cannot be inherited by accident. The distinction is now written into `docs/architecture/mcp.md`, because deciding which of the two you are building is the part that is easy to get wrong.

| Tool | Endpoint | Behaviour |
|---|---|---|
| `chat_folder_tree` | `GET /api/chat/folders` + `GET /api/chat/slots` | one line per folder (id, human path, project dir, default agent, archived count) with its live sessions nested underneath, plus an `(unfiled)` group |
| `chat_folder_create` | `POST /api/chat/folders` | `parent` is a folder id OR a `/`-path; missing segments are created (mkdir -p) |
| `chat_folder_move` | `PATCH /api/chat/folders/{id}` | reparent a folder, or move it to the top level |
| `chat_folder_move_session` | `PATCH /api/chat/slots/{slot}/folder` | file a live session into a folder, or unfile it |

Chain from the symptom to the design choices:

- **One resolution chokepoint, three readings, ambiguity always refused.** Every tool addresses a folder through `_resolve_chat_folder_ref()`, so create / move / move-session can never disagree about what a reference means. A reference is an **id** (unambiguous; an id-shaped ref that does not exist is a lookup failure, never a folder to create), a **full rendered path**, or a **path to walk**. A folder NAME may itself contain `/` — the sidebar permits it — so `A/B` can be one folder named `A/B` as well as `B` inside `A`, and the tree renders both identically. Both readings are computed and compared: duplicates on either side, or a disagreement between them, is refused with the candidate ids rather than resolved to whichever came first. The segment walk is a single function with a `create_missing` mode, so its duplicate-sibling guard is reachable and tested in both modes.
- **A reference that matches one session by key and another by title is refused.** A tab can be titled with another session's key, so preferring the key silently would file the wrong session. `dashboard:<slot>` is the caller's way to say "this is a key" and resolves through the collision.
- **Agent-authored folder names take the egress pass before the write.** A folder name lands in durable state the sidebar re-renders on every visit, so the leaf name and every created path segment are redacted before the POST — the same reason issue-radar findings are redacted before they persist. Every tool return goes through `redact()` too, since a slot key is a folded human name.
- **The endpoints keep owning every tree invariant.** The cycle guard (a folder cannot move into its own descendant) lives in `api_chat_folder_update` under the store lock; the tool surfaces that verdict rather than re-deriving it, so two concurrent reparents cannot slip a cycle past a tool-side check.
- **Audit origin.** The four folder endpoints derive `caller`/`source` from the presence of the (already middleware-validated) `X-Internal-Secret` header, the same test `handlers/artifacts.py` uses for artifact lifecycle events.

### Deliberately out of scope

- **No delete and no rename tool.** Create and move only. Folder deletion unfiles every session in it and is the one folder operation with a blast radius; #2769 tracks an empty-folder-only delete, which closes the create-without-undo gap at near-zero risk.
- **Archived (history) sessions cannot be moved.** No endpoint rewrites a history row's `folder_id` — only a live slot's. The tree reports the per-folder archived count and the move tool says to revive the session first, rather than pretending to file it.

## 4. What tests we did

- `test/test_mcp_dashboard_folders.py` — 46 tests over tool dispatch: path derivation and nesting, unfiled group, dangling `folder_id`, empty tree, endpoint error not rendered as empty, unexpected body shape, parent by id / path / omitted, mkdir -p segment threading, partial mkdir -p reporting, stale-id rejection, reparent + move-to-root + root-is-not-a-subject, cycle verdict passthrough, duplicate siblings, slash-bearing folder names (4 cases), name redaction, and the full session-reference matrix (slot key, `dashboard:` key, exact title, ambiguous title, partial title, key/title collision, unknown, unfile, URL quoting).
- `test/test_mcp_dashboard_registration.py` — the managed-server parity ratchet for this server (named in every registry, tool module mapped for in-process listing, no `autoApprove` key, slash-free key) plus the default-is-silent properties (config default off, `tools/list` empty on a default install, the toggle is what reveals the tools).
- `test/test_chat_folder_audit_origin.py` — 3 tests driving the real endpoints through an aiohttp test server: a browser create audits as `dashboard`, an internal-secret create as `mcp`, and an agent session move as `mcp` with the slot in `resources`.
- **Mutation-verified 24/24.** The 20 behavioural mutants (ambiguity refusals, mkdir -p nesting, redaction, session-reference resolution, URL quoting, audit origin) were re-run after the move to the new module and all still fail their paired test; 4 new gate mutants cover it: advertising tools while disabled, a cached list still writing after the toggle goes off, an unreadable config failing OPEN, and the config shipping ON by default.
- The existing ratchets caught two half-finished pieces of this change rather than me finding them: `test_computer_use_registration.py` failed until `kirocrew-dashboard` was in every managed registry, and `test_security_posture.py` failed until the new schema registry and the new module's redactor call sites were declared.
- Gates: `isort`, `flake8`, `mypy` (878 files) clean; `docs-lint` clean. Full backend suite: the failure set is unchanged from base — PATH-sensitive `gh`/system-binary probes, `unshare(CLONE_NEWUSER)` EPERM, xdist cap, and `test_interactive_reject` (already-filed flake #2851, which passes in isolation and here only tripped a 300s timeout under host saturation). Zero frontend files touched.

## 5. Any other suggestions on the work

- **This gives the dashboard-control class a home.** Session control (#2435) belongs on this server rather than in core, and the session title / session tag tools people have asked for now have somewhere to go — the answer becomes "not in core" instead of "no".
- Adding a managed server is a **parity tax** (six registries plus the hidden CLI subcommand). That is now written down in `docs/architecture/mcp.md` alongside the core-vs-own-server rule, so the next author does not rediscover it from a failing test.
- `chat_folder_tree` reads `GET /api/chat/slots`, which serializes the full slot payload. Check status is already excluded for internal-secret callers, but a lightweight projection would be cheaper if the tool turns out to be called often.
- The loopback HTTP client the tools use still lives in `mcp_core`; this server imports it, exactly as `mcp_computer` does. Measured cost of that import in the new process is 341ms/40MB — under `mcp_computer`'s own 494ms — because mcp_core's heavy dependencies are function-local. Extracting the client into a shared module is a reasonable follow-up but would have put a 41-call-site refactor of core inside this PR.

Closes #2761

