### PR TITLE
feat(crew): give each member its own space and an activity log

### DIFF
--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -1754,19 +1754,19 @@ class ContextBuilder:
         if not is_custom:
             ws_name = workspace or "default"
             ws_path = workspace_dir_for(ws_name)
+            # Deliberately does NOT advertise scope="workspace" for lessons. That
+            # scope no longer reaches a prompt (see the lessons block above), so
+            # telling the agent to use it would make it save corrections that
+            # silently never apply — the exact failure the unwire removes.
             parts.append(
                 "[WORKSPACE IDENTITY]\n"
                 f"You are operating in workspace: {ws_name}\n"
                 f"Workspace path: {ws_path}\n"
-                "A workspace is an isolated context with its own memory (preferences, "
-                "projects, daily history) and files. Different workspaces have different "
-                "memory — what you learn in one workspace stays in that workspace.\n\n"
-                "Lessons have two scopes (use learn_add tool to save):\n"
-                "- scope=global (default): shared across ALL workspaces. "
-                "Use for universal preferences (e.g. 'always use dark mode').\n"
-                f"- scope=workspace: only visible in this workspace ({ws_name}). "
-                "Use for project-specific rules "
-                "(e.g. 'this repo uses pytest-asyncio strict mode').\n"
+                "A workspace is a shared space holding your knowledge base, "
+                "preferences, project notes, daily history and files.\n\n"
+                "Lessons saved with the learn_add tool apply across all "
+                "workspaces. Use them for durable corrections and preferences, "
+                "not for one-off facts.\n"
                 "[End of workspace identity]\n\n"
             )
 
@@ -1924,8 +1924,22 @@ class ContextBuilder:
                     skills_ctx = skills_ctx[: caps.skills] + "\n...[skills truncated]\n"
                 parts.append(skills_ctx)
 
-        # Lessons: merge global + workspace-scoped — inject for ALL agents
-        # (skipped for temporary sessions)
+        # Lessons: global only — injected for ALL agents (skipped for temporary
+        # sessions).
+        #
+        # Workspace-scoped lessons are deliberately NOT merged here. The scope
+        # dates from when a workspace WAS a project, so "workspace lessons" meant
+        # "this project's rules"; project identity now lives on the session
+        # (``slot.project``), leaving the scope with nothing to anchor to. The
+        # merge it replaced was also unreachable in practice: it required
+        # ``workspace != "default"`` while every member resolves to ``default``,
+        # so a lesson saved with ``scope="workspace"`` reported success and then
+        # never reached a prompt. Removing the read keeps that silent failure
+        # from looking like a working feature.
+        #
+        # ``LessonStore`` and ``get_lessons_for`` are intentionally left intact:
+        # the per-member memory work re-targets the write side onto them, so the
+        # store is dormant here, not dead.
         lessons_ctx = ""
         if not blocks_reads and _group_included(context_groups, CONTEXT_GROUP_LESSONS):
             # One query, not two: get_lessons_context() already returns "" when the
@@ -1935,19 +1949,6 @@ class ContextBuilder:
             lessons_ctx = memory.vector_store.get_lessons_context() if memory.vector_store else ""
             if not lessons_ctx:
                 lessons_ctx = self.lessons.get_context()
-            # Merge workspace-scoped lessons if workspace differs from default
-            if workspace and workspace != "default":
-                ws_lessons = self.get_lessons_for(workspace)
-                ws_ctx = ws_lessons.get_context()
-                if ws_ctx and lessons_ctx:
-                    # Append workspace lessons inside the same block
-                    lessons_ctx = (
-                        lessons_ctx.rstrip().removesuffix("[End of learned corrections]").rstrip()
-                        + "\n"
-                        + ws_ctx.split("]", 1)[-1].lstrip()
-                    )
-                elif ws_ctx:
-                    lessons_ctx = ws_ctx
             if lessons_ctx:
                 if len(lessons_ctx) > caps.lessons:
                     over = len(lessons_ctx) - caps.lessons

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -162,6 +162,7 @@ from kiro_crew.llm_helpers import (
     transient_retry_delay,
 )
 from kiro_crew.mcp_discovery import kirocrew_managed_names
+from kiro_crew.members import record_activity
 from kiro_crew.messaging.identity import publish_turn_identity
 from kiro_crew.messaging.link import SLACK_NAMESPACE, telemetry_channel_of
 from kiro_crew.messaging.renderer import chunk_text
@@ -3614,6 +3615,26 @@ async def _run_chat(
             reasoning_effort_override=slot.reasoning_effort or None,
         )
         _acquired = True
+        # Member activity pointer — once per SESSION, not per turn: the log
+        # answers "which sessions did this member take part in", so a per-turn
+        # append would inflate every count taken from it. `slot.agent` is the
+        # member the human picked; `kiro_agent` is the template it resolved to,
+        # and only the member identity is recorded.
+        #
+        # Offloaded: this opens and appends to a file, and `_run_chat` shares the
+        # single gateway event loop with every other session — matching the
+        # to_thread offloads used for the other file IO in this function.
+        # record_activity is total, so no guard is needed here.
+        if is_new and slot.agent:
+            await asyncio.to_thread(
+                record_activity,
+                slot.agent,
+                session_key,
+                slot.memory_mode or "",
+                project=slot.project or "",
+                via="chat",
+                dedupe_session=True,
+            )
         # Publish the live inner AcpClient onto the slot so a concurrent request
         # (the dashboard steer handler) can reach the running session's client
         # to inject a mid-turn steer. Cleared in the finally below.

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -64,6 +64,7 @@ from kiro_crew.mcp_shared import (
     is_tool_cancelled,
     run_mcp_stdio_loop,
 )
+from kiro_crew.members import record_activity
 from kiro_crew.messaging.link import is_legacy_slack_key, legacy_key
 from kiro_crew.platform import redact_via_context as redact
 from kiro_crew.security import (
@@ -3800,6 +3801,31 @@ def _do_select_crew(crew: str) -> str:
             ensure_ascii=False,
         )
     b = resolve_agent_bindings(cfg, crew)
+    # Routing-decision pointer. This is the one place a member's identity is
+    # unambiguous on the delegation path: `spawn_run`'s `agent` is validated
+    # against the installed TEMPLATES, so by the time a sub-agent starts the
+    # member it came from can no longer be recovered (two members may share one
+    # template). Recording at bind time sidesteps that.
+    #
+    # It records the DECISION, not an execution — binding a crew does not oblige
+    # the model to delegate to it. That is the signal trigger generation wants
+    # (what the router believes belongs to whom), but it means these entries are
+    # intent. A `via="spawn"` execution entry is deliberately left for when the
+    # spawn path carries member identity.
+    #
+    # The caller's memory mode is resolved HERE rather than defaulted: this log
+    # outlives session pruning, so recording a no-trace session's key would
+    # durably defeat the mode. An unreadable session degrades to the private
+    # spelling so the failure mode is "skip the entry", never "log a private
+    # session". No try/except around the write itself: record_activity is total
+    # and reports failure by returning False, which matters because this module
+    # keeps no logger.
+    _sk = _resolve_session_key()
+    try:
+        _mode = str(ConversationLog().get_metadata(_sk).get("memory_mode", "") or "")
+    except Exception:
+        _mode = "incognito"
+    record_activity(crew, _sk, _mode, via="select_crew")
     return json.dumps(
         {
             "crew": crew,

--- a/src/kiro_crew/members.py
+++ b/src/kiro_crew/members.py
@@ -1,0 +1,245 @@
+"""Per-crew-member space: ``$KIROCREW_HOME/members/<slug>/``.
+
+A crew member is the same agent running with different context, so its space
+holds what belongs to that member alone rather than to the user as a whole. The
+first occupant is ``activity.jsonl`` — pointers to the sessions the member took
+part in, which is the signal trigger generation reads.
+
+The directory name is a **slug**: stable, immutable, and path-safe. A member's
+display name is editable independently, so a rename never has to move files.
+This mirrors the artifact store's ``artifacts/<slug>/`` layout, and reuses its
+:func:`~kiro_crew.artifacts.slugify` so both surfaces normalize names the same
+way.
+
+Activity entries are pointers by design: they carry the session key, not a copy
+of what happened. Details are read back from the session itself, so the log
+cannot drift from the transcript — and it survives session pruning, which is why
+frequency counts taken from it stay stable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from kiro_crew.artifacts import slugify
+from kiro_crew.config.paths import data_home
+
+logger = logging.getLogger(__name__)
+
+#: Directory under the data home holding one subdirectory per crew member.
+MEMBERS_DIR_NAME = "members"
+
+#: Append-only pointer log inside a member's directory.
+ACTIVITY_FILE_NAME = "activity.jsonl"
+
+# Same shape the artifact store enforces for its slugs: lowercase letters,
+# digits and hyphens, 1-80 chars, no leading or trailing hyphen. Kept here as a
+# local constant rather than imported because it is a private name there; the
+# artifact store remains the source of truth for the spelling.
+_SLUG_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,78}[a-z0-9])?\Z")
+
+#: The ONLY mode whose sessions may be recorded. An allowlist, not a denylist of
+#: no-trace modes: a mode that is missing, empty (metadata not yet flushed for a
+#: brand-new session) or simply unrecognized would pass a denylist and durably
+#: record a private session key in a log that outlives session pruning. Failing
+#: closed costs at most a missing entry in an advisory log.
+_TRACEABLE_MEMORY_MODES = frozenset({"persistent"})
+
+
+class MemberSlugError(ValueError):
+    """Raised when a member slug is unusable or cannot be allocated."""
+
+
+def members_root() -> Path:
+    """Root directory for member spaces.
+
+    Uses :func:`data_home` rather than :func:`config_dir`: this is reached from
+    request and chat paths, and ``config_dir`` re-runs start-of-process
+    maintenance (including a destructive leftover sweep) on every call.
+    """
+    return data_home() / MEMBERS_DIR_NAME
+
+
+def validate_slug(slug: str) -> str:
+    """Return *slug* unchanged when it is well-formed, else raise.
+
+    The pattern admits no ``/``, ``.`` or whitespace, so a validated slug cannot
+    traverse out of :func:`members_root` on its own. :func:`member_dir` still
+    re-checks containment, because validation and use are separated by a call
+    boundary a future caller could bypass.
+    """
+    if not isinstance(slug, str) or not _SLUG_RE.match(slug):
+        raise MemberSlugError(f"invalid member slug {slug!r}: must match {_SLUG_RE.pattern}")
+    return slug
+
+
+def slug_for_name(name: str) -> str:
+    """Derive a candidate slug from a free-form member name.
+
+    Not guaranteed unique: slugification is lossy, so two distinct member names
+    can map to one slug. :func:`record_activity` stores the exact name in each
+    entry so attribution survives that. Falls back to
+    ``"member"`` when the name has no slug-safe characters, so a name written
+    entirely in punctuation still yields something addressable.
+    """
+    base = slugify(name)
+    # slugify falls back to its own module's noun; ours should read as a member.
+    if base == "artifact":
+        base = "member"
+    return validate_slug(base)
+
+
+def member_dir(slug: str) -> Path:
+    """Absolute path to one member's directory, containment-checked.
+
+    Does NOT create the directory; :func:`record_activity` creates it on demand.
+    """
+    validate_slug(slug)
+    root = members_root().resolve()
+    target = (root / slug).resolve()
+    # Defence in depth behind validate_slug: a symlinked root, or a future
+    # caller that skipped validation, must not land outside the members root.
+    if target != root and root not in target.parents:
+        raise MemberSlugError(f"member slug {slug!r} escapes {root}")
+    return target
+
+
+def record_activity(
+    member: str,
+    session_key: str,
+    memory_mode: str,
+    *,
+    project: str = "",
+    via: str = "",
+    dedupe_session: bool = False,
+) -> bool:
+    """Append one pointer entry to a member's activity log.
+
+    Takes the member's NAME and derives the slug internally, so callers need no
+    try/except: every failure path — a name that yields no usable slug, a
+    read-only home, a torn write — is handled here and reported ``False``. This
+    is best-effort by contract; a logging failure must never break the turn that
+    triggered it, and one call site (``mcp_core``) has no logger of its own.
+
+    ``memory_mode`` is REQUIRED and positional, not an opt-in keyword: it gates
+    whether the session may be recorded at all, and a caller that simply forgot
+    it would durably log a private session. It is matched against an allowlist
+    (:data:`_TRACEABLE_MEMORY_MODES`), so an absent, empty or unrecognized mode
+    skips the write rather than passing through.
+
+    ``dedupe_session`` suppresses a repeat entry for a member/session pair. The
+    chat site needs it because its ``is_new`` flag tracks the PROVIDER session,
+    not the conversation: a dead provider cold-starts the same conversation with
+    ``is_new=True`` again, which would append the same pointer twice and inflate
+    the counts this log exists to feed. Routing decisions are NOT deduped — each
+    ``select_crew`` bind is a distinct event even for one session.
+
+    ``via`` records HOW the member was chosen, because the two call sites mean
+    different things and a mixed log cannot be read apart afterwards:
+
+    * ``"chat"`` — the human picked this member for the session.
+    * ``"select_crew"`` — the orchestrator judged this member fits the task.
+
+    A ``select_crew`` entry records the routing *decision*, not an execution:
+    binding a crew does not oblige the model to delegate to it. That is the
+    useful signal for trigger generation (what the router believes belongs to
+    whom), but it means these counts are intent, not runs.
+
+    Blocking file IO: call via ``asyncio.to_thread`` from async code.
+    """
+    if not member or not session_key:
+        return False
+    if memory_mode.strip().lower() not in _TRACEABLE_MEMORY_MODES:
+        return False
+    # The exact member name travels IN the record rather than being implied by
+    # the directory. Slugification is lossy, so two distinct member names can
+    # map to one slug ("Review_Agent" and "review-agent") and share a log;
+    # carrying the name keeps per-member attribution recoverable in that case,
+    # which the frequency signal downstream depends on.
+    #
+    # The session pointer is named for what it MEANS, not just what it holds.
+    # A routing decision is recorded in the session that made it — the parent —
+    # while the member itself runs in a different (sub-agent) session that does
+    # not exist yet at bind time. Filing both under one `session` key would let
+    # a consumer counting "sessions this member took part in" count a session
+    # the member never ran in. Distinct keys make that misread impossible
+    # instead of leaving it to the consumer to notice `via`.
+    entry = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "member": member,
+    }
+    if via == "select_crew":
+        entry["decided_in"] = session_key
+    else:
+        entry["session"] = session_key
+    if project:
+        entry["project"] = project
+    if via:
+        entry["via"] = via
+    try:
+        slug = slug_for_name(member)
+        path = member_dir(slug)
+        if dedupe_session and any(
+            # Matched on BOTH fields: a colliding slug means one file can hold
+            # two members, so session alone would suppress the wrong entry.
+            # Only participation entries carry `session`, which is also the only
+            # kind deduped — routing decisions are distinct events.
+            r.get("session") == session_key and r.get("member") == member
+            for r in read_activity(slug)
+        ):
+            return False
+        path.mkdir(parents=True, exist_ok=True)
+        # Newline on BOTH sides. The trailing one is ordinary JSONL framing; the
+        # LEADING one is what survives a torn write. A record appended straight
+        # after an interrupted write would otherwise be glued to that fragment,
+        # losing BOTH to one unparseable line — and a leading newline alone is
+        # not enough either, because the newest record would then carry no
+        # terminator and be absorbed by whatever came next. read_activity skips
+        # the blank lines this produces.
+        line = "\n" + json.dumps(entry, ensure_ascii=False) + "\n"
+        # No fsync: this is an advisory pointer log, and a durability barrier is
+        # a blocking kernel syscall that would stall the shared event loop for
+        # every concurrent session. Losing the final entry to a crash is
+        # acceptable; stalling the gateway is not.
+        with open(path / ACTIVITY_FILE_NAME, "a", encoding="utf-8") as fh:
+            fh.write(line)
+        return True
+    except Exception:
+        logger.debug("member activity log write failed for %r", member, exc_info=True)
+        return False
+
+
+def read_activity(slug: str, limit: int = 0) -> list[dict]:
+    """Return a member's activity entries, oldest first.
+
+    Malformed lines are skipped rather than raising: the log is append-only from
+    multiple processes, and one torn line must not make the whole history
+    unreadable. ``limit`` > 0 returns only the most recent N.
+    """
+    try:
+        path = member_dir(slug) / ACTIVITY_FILE_NAME
+    except MemberSlugError:
+        return []
+    if not path.is_file():
+        return []
+    out: list[dict] = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except (ValueError, TypeError):
+                    continue
+                if isinstance(row, dict):
+                    out.append(row)
+    except OSError:
+        logger.debug("member activity log read failed for %r", slug, exc_info=True)
+        return []
+    return out[-limit:] if limit > 0 else out

--- a/test/test_members.py
+++ b/test/test_members.py
@@ -1,0 +1,257 @@
+"""Tests for the per-crew-member space (``$KIROCREW_HOME/members/<slug>/``).
+
+``KIROCREW_HOME`` is pinned to a per-test tmp dir by the autouse
+``_isolate_kirocrew_home`` fixture, so every path here resolves under tmp.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kiro_crew.members import (
+    ACTIVITY_FILE_NAME,
+    MemberSlugError,
+    member_dir,
+    members_root,
+    read_activity,
+    record_activity,
+    slug_for_name,
+    validate_slug,
+)
+
+
+class TestSlugForName:
+    def test_normalizes_spaces_and_case(self):
+        assert slug_for_name("Code Review") == "code-review"
+
+    def test_strips_accents_to_ascii(self):
+        assert slug_for_name("Café Crew") == "cafe-crew"
+
+    def test_collapses_punctuation_runs_to_single_hyphen(self):
+        assert slug_for_name("PR   triage!!! (fast)") == "pr-triage-fast"
+
+    def test_punctuation_only_name_falls_back_to_member(self):
+        # Not "artifact": the fallback noun must read as a member, since the
+        # shared slugify() belongs to the artifact store.
+        assert slug_for_name("!!!") == "member"
+
+    def test_result_always_satisfies_the_slug_pattern(self):
+        for name in ("Code Review", "Café Crew", "!!!", "a" * 200, "-leading", "trailing-"):
+            validate_slug(slug_for_name(name))
+
+    def test_long_name_is_truncated_without_trailing_hyphen(self):
+        slug = slug_for_name("x" * 100)
+        assert len(slug) <= 80
+        assert not slug.endswith("-")
+
+
+class TestValidateSlug:
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "Has-Upper",
+            "has space",
+            "has/slash",
+            "has.dot",
+            "..",
+            "-leading",
+            "trailing-",
+            "a" * 81,
+        ],
+    )
+    def test_rejects_unsafe_or_malformed(self, bad):
+        with pytest.raises(MemberSlugError):
+            validate_slug(bad)
+
+    @pytest.mark.parametrize("good", ["a", "1", "code-review", "a" * 80])
+    def test_accepts_well_formed(self, good):
+        assert validate_slug(good) == good
+
+    def test_rejects_non_string(self):
+        with pytest.raises(MemberSlugError):
+            validate_slug(None)  # type: ignore[arg-type]
+
+
+class TestMemberDir:
+    def test_resolves_under_members_root(self):
+        assert member_dir("code-review").parent == members_root().resolve()
+
+    def test_does_not_create_the_directory(self):
+        assert not member_dir("code-review").exists()
+
+    @pytest.mark.parametrize("attempt", ["../escape", "..", "a/../../b", "/etc"])
+    def test_refuses_traversal_shaped_names(self, attempt):
+        # The slug pattern is the primary defence; this asserts the boundary
+        # holds rather than trusting the caller to have validated first.
+        with pytest.raises(MemberSlugError):
+            member_dir(attempt)
+
+
+class TestRecordActivity:
+    def test_writes_a_pointer_entry(self):
+        assert record_activity("Code Review", "dashboard_chat-1", "persistent", project="/repo", via="chat")
+        rows = read_activity("code-review")
+        assert len(rows) == 1
+        assert rows[0]["session"] == "dashboard_chat-1"
+        assert rows[0]["project"] == "/repo"
+        assert rows[0]["via"] == "chat"
+        assert rows[0]["ts"].endswith("Z")
+
+    def test_entry_carries_the_exact_member_name(self):
+        # Slugification is lossy, so the directory alone cannot identify the
+        # member; attribution has to survive two names sharing one slug.
+        record_activity("Review_Agent", "s1", "persistent")
+        assert read_activity("review-agent")[0]["member"] == "Review_Agent"
+
+    def test_colliding_names_stay_attributable(self):
+        record_activity("Review_Agent", "s1", "persistent")
+        record_activity("review-agent", "s2", "persistent")
+        rows = read_activity("review-agent")
+        assert [(r["member"], r["session"]) for r in rows] == [
+            ("Review_Agent", "s1"),
+            ("review-agent", "s2"),
+        ]
+
+    def test_entry_carries_no_content_only_pointers(self):
+        record_activity("Code Review", "dashboard_chat-1", "persistent", project="/repo", via="chat")
+        assert set(read_activity("code-review")[0]) == {"ts", "member", "session", "project", "via"}
+
+    def test_appends_rather_than_overwrites(self):
+        record_activity("M", "s1", "persistent", via="chat")
+        record_activity("M", "s2", "persistent", via="chat")
+        assert [r["session"] for r in read_activity("m")] == ["s1", "s2"]
+
+    def test_creates_the_member_directory_on_demand(self):
+        record_activity("Brand New", "s1", "persistent")
+        assert (member_dir("brand-new") / ACTIVITY_FILE_NAME).is_file()
+
+    def test_omits_empty_optional_fields(self):
+        record_activity("M", "s1", "persistent")
+        assert set(read_activity("m")[0]) == {"ts", "member", "session"}
+
+    @pytest.mark.parametrize("mode", ["incognito", "temporary", "INCOGNITO", " temporary "])
+    def test_no_trace_modes_write_nothing(self, mode):
+        assert record_activity("M", "s1", mode) is False
+        assert read_activity("m") == []
+
+    @pytest.mark.parametrize("mode", ["", "   ", "unknown", "Persistent-ish", "PERSISTENT_v2"])
+    def test_unrecognized_mode_fails_closed(self, mode):
+        # Allowlist, not denylist: a brand-new session whose metadata has not
+        # flushed yet reports an empty mode, and that must not be treated as
+        # traceable just because it is not spelled "incognito".
+        assert record_activity("M", "s1", mode) is False
+        assert read_activity("m") == []
+
+    def test_persistent_mode_still_writes(self):
+        assert record_activity("M", "s1", "persistent") is True
+
+    @pytest.mark.parametrize("mode", ["PERSISTENT", " persistent "])
+    def test_persistent_match_is_case_and_space_insensitive(self, mode):
+        assert record_activity("M", "s1", mode) is True
+
+    def test_dedupe_suppresses_a_repeat_session_pointer(self):
+        # The chat site's `is_new` tracks the PROVIDER session, so a dead
+        # provider cold-starting the same conversation would append twice and
+        # inflate the counts this log feeds.
+        assert record_activity("M", "s1", "persistent", via="chat", dedupe_session=True) is True
+        assert record_activity("M", "s1", "persistent", via="chat", dedupe_session=True) is False
+        assert len(read_activity("m")) == 1
+
+    def test_dedupe_still_allows_a_different_session(self):
+        record_activity("M", "s1", "persistent", dedupe_session=True)
+        assert record_activity("M", "s2", "persistent", dedupe_session=True) is True
+        assert [r["session"] for r in read_activity("m")] == ["s1", "s2"]
+
+    def test_dedupe_is_per_member_not_per_file(self):
+        # Colliding slugs share one file; dedupe must key on member AND session
+        # or one member's entry would suppress the other's.
+        record_activity("Review_Agent", "s1", "persistent", dedupe_session=True)
+        assert record_activity("review-agent", "s1", "persistent", dedupe_session=True) is True
+        assert len(read_activity("review-agent")) == 2
+
+    def test_routing_decisions_are_not_deduped(self):
+        # Each select_crew bind is a distinct event even within one session.
+        record_activity("M", "s1", "persistent", via="select_crew")
+        record_activity("M", "s1", "persistent", via="select_crew")
+        assert len(read_activity("m")) == 2
+
+    def test_routing_decision_uses_a_distinct_session_field(self):
+        # A decision is recorded in the session that MADE it (the parent); the
+        # member runs elsewhere. Filing it under `session` would let a consumer
+        # count a session the member never ran in.
+        record_activity("M", "parent-1", "persistent", via="select_crew")
+        row = read_activity("m")[0]
+        assert row["decided_in"] == "parent-1"
+        assert "session" not in row
+
+    def test_participation_and_decisions_are_countable_apart(self):
+        record_activity("M", "chat-1", "persistent", via="chat")
+        record_activity("M", "parent-1", "persistent", via="select_crew")
+        rows = read_activity("m")
+        assert [r["session"] for r in rows if "session" in r] == ["chat-1"]
+        assert [r["decided_in"] for r in rows if "decided_in" in r] == ["parent-1"]
+
+    def test_memory_mode_cannot_be_omitted(self):
+        # Required positionally so a caller cannot silently log a private
+        # session by forgetting an opt-in keyword.
+        with pytest.raises(TypeError):
+            record_activity("M", "s1")  # type: ignore[call-arg]
+
+    @pytest.mark.parametrize("member,session", [("", "s1"), ("M", ""), ("", "")])
+    def test_requires_both_member_and_session(self, member, session):
+        assert record_activity(member, session, "persistent") is False
+
+    def test_does_not_fsync(self, monkeypatch):
+        # A durability barrier is a blocking kernel syscall; this log is
+        # advisory and one call site shares the gateway event loop.
+        calls = []
+        monkeypatch.setattr("os.fsync", lambda fd: calls.append(fd))
+        record_activity("M", "s1", "persistent")
+        assert calls == []
+
+    def test_reports_failure_instead_of_raising(self, monkeypatch):
+        # Total by contract: the call sites have no guard, and one of them
+        # (mcp_core) has no logger, so a raise here would surface as a tool error.
+        monkeypatch.setattr("kiro_crew.members.member_dir", lambda _s: (_ for _ in ()).throw(OSError("boom")))
+        assert record_activity("M", "s1", "persistent") is False
+
+
+class TestReadActivity:
+    def test_missing_member_reads_empty(self):
+        assert read_activity("never-existed") == []
+
+    def test_invalid_slug_reads_empty_rather_than_raising(self):
+        assert read_activity("../escape") == []
+
+    def test_torn_fragment_does_not_swallow_the_next_record(self):
+        # A write interrupted before its newline leaves a fragment on the last
+        # line. The next record must not be glued onto it, or BOTH are lost.
+        record_activity("M", "s1", "persistent")
+        path = member_dir("m") / ACTIVITY_FILE_NAME
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write('{"ts":"x","session":"torn"')  # no newline: torn write
+        record_activity("M", "s2", "persistent")
+        assert [r["session"] for r in read_activity("m")] == ["s1", "s2"]
+
+    def test_skips_torn_lines_and_keeps_the_rest(self):
+        record_activity("M", "s1", "persistent")
+        path = member_dir("m") / ACTIVITY_FILE_NAME
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write("\n{not valid json\n")
+        record_activity("M", "s2", "persistent")
+        assert [r["session"] for r in read_activity("m")] == ["s1", "s2"]
+
+    def test_skips_non_object_rows(self):
+        record_activity("M", "s1", "persistent")
+        path = member_dir("m") / ACTIVITY_FILE_NAME
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write("\n" + json.dumps(["not", "a", "dict"]))
+        assert len(read_activity("m")) == 1
+
+    def test_limit_returns_the_most_recent(self):
+        for i in range(5):
+            record_activity("M", f"s{i}", "persistent")
+        assert [r["session"] for r in read_activity("m", limit=2)] == ["s3", "s4"]


### PR DESCRIPTION
## What

Gives each crew member its own directory and starts recording which sessions it took part in. Also unwires workspace-scoped lessons from the read path, which could not reach a prompt.

A crew member is intentionally the *same* agent run with different context — not a specialist with its own prompt and tools. So this PR is about giving a member somewhere to keep what belongs to it alone, not about changing what it can do.

### `$KIROCREW_HOME/members/<slug>/`

The directory name is a slug derived from the member's name, reusing the artifact store's `slugify()` so both surfaces normalize names identically. `activity.jsonl` is the first occupant; future additions (triggers, permissions, notes) have a home now without re-litigating where they go.

**Slug collisions are handled by carrying identity in the record, not by allocating unique directories.** Slugification is lossy, so two distinct member names (`Review_Agent` and `review-agent`) map to one slug and share one directory and log. Rather than add a collision-resolving allocator with no caller, every entry carries the **exact member name**, so per-member attribution stays correct even when a directory is shared. A persisted name→slug binding belongs with the member-create path, not here.

### Activity entries are pointers, not copies

```json
{"ts":"2026-08-11T07:37:19Z","member":"Code Review","session":"dashboard_chat-42","project":"/repo","via":"chat"}
{"ts":"2026-08-11T07:41:02Z","member":"Code Review","decided_in":"dashboard_chat-42","via":"select_crew"}
```

Each entry carries a session key, so details are read back from the session itself and the log cannot drift from the transcript. It also **survives session pruning**, which is what keeps frequency counts stable — the reason for a separate log rather than scanning session metadata for `agent == <member>`.

Two write points, with **distinct field names** so the two cannot be conflated:

| `via` | Field | Meaning |
|---|---|---|
| `chat` | `session` | the human picked this member, and it ran in that session |
| `select_crew` | `decided_in` | the orchestrator judged this member fits — recorded in the session that *made the decision* |

**Why `select_crew` and not spawn.** `spawn_run`'s `agent` is validated against the installed *templates*, so by the time a sub-agent starts, the member it came from can no longer be recovered — two members may share one template. `select_crew` is the one point on the routing path where member identity is unambiguous.

The cost, stated plainly: a `select_crew` entry records the routing **decision**, not an execution. Binding a crew does not oblige the model to delegate to it, and the member runs in a different session that does not exist at bind time — hence `decided_in` rather than `session`, so a consumer counting participation cannot accidentally count it. A `via="spawn"` execution entry is left for when the spawn path carries member identity.

Three guards:
- **Memory mode is an allowlist** (`{"persistent"}`), not a denylist. A brand-new session whose metadata has not flushed reports an empty mode; a denylist would pass it and durably log a private session in a log that outlives pruning. `memory_mode` is a required positional parameter so a caller cannot omit it.
- **Chat entries dedupe** on member + session. `is_new` tracks the *provider* session, not the conversation, so a dead provider cold-starting the same conversation would otherwise append the same pointer twice and inflate the counts this log feeds. Routing decisions are not deduped — each bind is a distinct event.
- **No `fsync`**, and the chat call is offloaded via `asyncio.to_thread`. A durability barrier is a blocking kernel syscall and `_run_chat` shares the single gateway loop; losing the last entry to a crash is acceptable, stalling the gateway is not.

Records are framed with a newline on **both** sides. A write interrupted before its newline leaves a fragment; a following record appended straight onto it would be glued to that fragment and lose both to one unparseable line. A leading newline alone is insufficient — the newest record would then carry no terminator and be absorbed by whatever came next.

### Unwiring workspace-scoped lessons (read path)

That scope dates from when a workspace *was* a project, so "workspace lessons" meant "this project's rules". Project identity now lives on the session, leaving the scope with nothing to anchor to.

It was also unreachable in practice: the read required `workspace != "default"` while every member resolves to `default`, so a lesson saved with `scope="workspace"` returned `Saved lesson (workspace): …` and then never reached a prompt. That is worse than dead code — it looked like a working feature.

The workspace identity block no longer advertises the scope either; keeping that instruction while removing the read would have actively *caused* the silent failure on every turn.

`LessonStore` and `get_lessons_for` are left intact — the per-member memory work re-targets the write side onto them, so the store is dormant here, not dead.

**Known incomplete:** the `learn_add` tool schema still offers `scope="workspace"` and its handler still reports success. See the disposition thread — Design Review has asked for this to be closed in this PR, and it is the one open question on the change.

## Why

Crew has never actually run: every member has empty triggers, so the routing roster is always empty and delegation never fires. Fixing that needs a signal for what each member is actually used for, and there is nowhere to record it today. This is that foundation.

## Tests

`test/test_members.py` covers slug derivation (accents, punctuation-only fallback, truncation, pattern invariant), slug rejection (uppercase, whitespace, `/`, `.`, `..`, leading/trailing hyphen, over-length), containment (traversal-shaped names refused), the activity log (pointer-only fields, exact-name attribution under a slug collision, append semantics, the mode allowlist across 10 spellings, dedupe keyed on member+session, routing decisions not deduped, `decided_in` vs `session` separation, no `fsync`, returns `False` instead of raising), and tolerant reads (a deliberate torn fragment between two records, non-object rows, `limit`).

## Manual verification

N/A — unit coverage is sufficient for a file-append helper and two call sites; there is no user-visible surface in this change.

## Screenshots

N/A — no user-visible UI change.

## Not in this PR

- Sub-agent **execution** records (`via="spawn"`) — needs the spawn path to carry member identity
- Per-member memory — separate in-flight refactor
- Auto-generating triggers or members — the phases this unblocks
