### PR TITLE
docs(mcp-gateway): correct the apps gate precedence for pooling-off

### DIFF
--- a/src/kiro_crew/mcp_gateway/backend.py
+++ b/src/kiro_crew/mcp_gateway/backend.py
@@ -313,9 +313,12 @@ def _mcp_apps_enabled() -> bool:
        environment.
     3. ``KIROCREW_MCP_APPS`` on -> enabled (explicit override for tests and the
        e2e harness), having cleared the opt-out above.
-    4. Otherwise ``mcp_gateway.enabled`` — the broker must be running, because
-       the render and callback paths live inside it, so ``apps_enabled`` alone
-       can never grant the feature.
+    4. Otherwise ``apps_enabled`` alone is enough. Deliberately NOT gated on
+       ``mcp_gateway.enabled``: that switch decides whether a backend may be
+       SHARED, not whether a stub exists, and the stub carries the app-call
+       relay either way. With pooling off each connection gets a private backend
+       that is still addressable by ``storage_digest``, so both the render and
+       the callback resolve -- see ``test_apps_enabled_alone_is_enough``.
 
     ``apps_enabled`` defaults True when absent, so step 2 fires only on a value
     an operator actually wrote: "not configured" is not an opt-out.


### PR DESCRIPTION
## 1. What is the problem?

`_mcp_apps_enabled`'s docstring still describes the pre-decoupling precedence.
Step 4 of its numbered list states the opposite of what the same function does 29
lines below it:

Docstring, before this change:

> 4. Otherwise `mcp_gateway.enabled` — the broker must be running, because the
>    render and callback paths live inside it, so `apps_enabled` alone can never
>    grant the feature.

The code:

```python
    # Deliberately NOT gated on ``gw.enabled``: pooling decides whether backends
    # are shared, not whether the stub exists. The stub carries the app-call
    # relay either way.
    return True
```

The behaviour is already pinned by
`test/test_mcp_gateway_apps_switch.py::test_apps_enabled_alone_is_enough`, so the
docstring was the only thing left carrying the stale claim.

## 2. Why this issue matters to the user

This is the function every other caller reasons about when deciding whether MCP
Apps is available. A reader who trusts the numbered list — rather than reading
past it to the return statement — concludes MCP Apps requires the pooling switch,
which is precisely the coupling that was removed. That wrong mental model leads
an operator to enable shared backends they do not want purely to get app
rendering, and it makes the honest configuration (pooling off, apps on) look
unsupported.

## 3. How our fix solves it

Rewrites step 4 to state the actual rule and, more usefully, the reason behind it:
`enabled` decides whether a backend may be **shared**, not whether a stub
**exists**. The stub is the addressing layer and carries the app-call relay
either way; with pooling off each connection gets a private backend that is still
addressable by `storage_digest`, so both the render and the callback resolve. The
sentence now points at the test that pins the cell, so the next reader can
confirm the claim instead of trusting a comment.

Docs-only — no behaviour change, no test changes.

## 4. What tests we did

- `pytest test/ -k "mcp_gateway_apps or apps_switch or apps_capability or apps_spool"` — **99 passed**
- `isort --check-only`, `flake8`, `mypy` on the touched file — all clean
- Confirmed against the merged code on a throwaway pod booted in the shape the
  docstring previously called impossible (`mcp_gateway.enabled = false`,
  `apps_enabled = true`, empty allowlist): the broker starts, all 6 stdio servers
  get a stub with zero marked poolable, and an end-to-end run through a real
  child process produced a spool record whose `pool_digest` equals the producing
  private backend's `storage_digest`, with `pool.get_by_digest` resolving that
  backend and the app-only tool executing on the callback. A replayed callback
  with a wrong secret was rejected.

## 5. Any other suggestions on the work

The same stale claim also reaches users through the UI —
`mcp_apps_needs_gateway` ("Takes effect once the shared MCP gateway above is
on") and `mcp_apps_no_poolable_servers` ("No MCP servers are poolable yet, so
nothing can render"), rendered from
`website/src/pages/settings/SharedMcpGatewayToggle.tsx`. Both are already being
removed by open PR #2650, so this PR deliberately leaves the frontend and the
locale files alone rather than having two PRs rewrite the same strings. #2650's
own `backend.py` hunks are at lines ~510 and ~1441 and do not overlap this one.

Separately worth considering: no single test joins the two halves of the
app-callback path — `test_mcp_apps_e2e.py` drives a real child process but builds
its `Backend` bare (never registered in a pool, so `get_by_digest` is never
exercised), while `test_mcp_gateway_exclusive_backend.py` exercises
`acquire_exclusive`/`get_by_digest` with `MagicMock` processes (so no spool record
is ever produced). The ad-hoc test written to verify this PR's claim covers that
seam and could be worth landing as a real test.

Fixes #2772
