### PR TITLE
test(dashboard): stop approval answerers racing the stream

### DIFF
--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 from contextlib import contextmanager
 from pathlib import Path
@@ -102,13 +103,7 @@ async def _drive_hook_blocked_turn(
     if approve_prompt:
 
         async def _answer() -> None:
-            for _ in range(600):
-                fut = slot._approval_futures.get("req-1")
-                if fut is not None:
-                    if not fut.done():
-                        fut.set_result("approved")
-                    return
-                await asyncio.sleep(0.01)
+            await _answer_approval(slot, "req-1", "approved")
 
         approver = asyncio.get_event_loop().create_task(_answer())
 
@@ -186,6 +181,46 @@ def _tool_messages(slot: _ChatSlot) -> list[dict]:
     return [m for m in slot.messages if m.get("role") in ("tool", "permission")]
 
 
+# How long an answerer waits for the turn to register its approval future. The
+# product parks on that future for the MINIMUM of `approval_timeout_for()` and
+# `tool_approval_timeout_secs()` — 600s by default — which is LONGER than CI's
+# `--timeout=180`, so a poke that misses does not fail the test: pytest-timeout
+# hard-kills the xdist worker and the run reports `worker 'gwN' crashed`,
+# naming an arbitrary in-flight test and discarding the real cause. Waiting for
+# the future to EXIST instead of sleeping a fixed interval removes that race;
+# the deadline exists only so a future that never appears surfaces as the named
+# assertion below rather than as a killed worker.
+_ANSWER_WAIT_SECS = 30.0
+_ANSWER_POLL_SECS = 0.01
+
+
+async def _answer_approval(
+    owner: object, request_id: str, outcome: str, *, timeout: float = _ANSWER_WAIT_SECS
+) -> None:
+    """Resolve *owner*'s approval future for *request_id* once the turn registers it.
+
+    Stands in for a user clicking Approve/Reject. The future is created inside
+    ``_run_chat`` when the permission event is processed, so an answerer that
+    pokes at a fixed offset races the stream: on a loaded runner the event can
+    arrive after the poke, leaving the turn parked on an approval nobody will
+    ever answer.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        fut = owner._approval_futures.get(request_id)  # type: ignore[attr-defined]
+        if fut is not None:
+            if not fut.done():
+                fut.set_result(outcome)
+            return
+        assert loop.time() < deadline, (
+            f"approval future {request_id!r} was never registered within "
+            f"{timeout:.0f}s — the turn never reached its permission event, so "
+            f"there was nothing to answer"
+        )
+        await asyncio.sleep(_ANSWER_POLL_SECS)
+
+
 def _context_builder(hook_result: ToolHookResult = ToolHookResult.allow()) -> MagicMock:
     cb = MagicMock()
     cb.hooks.on_tool_call.return_value = hook_result
@@ -220,17 +255,12 @@ class TestApprovalModes:
         slot = _make_slot()
         _set_stream(client, [_permission_event(), _complete_event()])
 
-        # Poll for the future rather than sleeping a fixed 0.05s and hoping the chat
-        # has registered it by then, and keep a handle so the helper is cancelled
-        # instead of being GC'd mid-flight during a later test.
-        async def _auto_approve():
-            for _ in range(600):
-                fut = slot._approval_futures.get("req-1")
-                if fut is not None:
-                    if not fut.done():
-                        fut.set_result("approved")
-                    return
-                await asyncio.sleep(0.01)
+        # Answer via the shared helper, which waits for the future to EXIST
+        # rather than sleeping a fixed interval and hoping the chat registered
+        # it by then, and keep a handle so the answerer is cancelled instead of
+        # being GC'd mid-flight during a later test.
+        async def _auto_approve() -> None:
+            await _answer_approval(slot, "req-1", "approved")
 
         approver = asyncio.get_event_loop().create_task(_auto_approve())
 
@@ -464,16 +494,14 @@ class TestApprovalModes:
         slot = _make_slot()
         _set_stream(client, [_permission_event(), _complete_event()])
 
-        async def _auto_reject():
-            await asyncio.sleep(0.05)
-            fut = slot._approval_futures.get("req-1")
-            if fut and not fut.done():
-                fut.set_result("rejected")
+        async def _auto_reject() -> None:
+            await _answer_approval(slot, "req-1", "rejected")
 
-        asyncio.get_event_loop().create_task(_auto_reject())
+        rejecter = asyncio.get_event_loop().create_task(_auto_reject())
 
         with _patch_stats():
             await _run_chat(state, slot, "hello")
+        await _drain(rejecter)
 
         client.reject_tool.assert_called_once()
 
@@ -484,14 +512,8 @@ class TestApprovalModes:
         slot = _make_slot()
         _set_stream(client, [_permission_event(), _complete_event()])
 
-        async def _auto_approve():
-            for _ in range(600):
-                fut = slot._approval_futures.get("req-1")
-                if fut is not None:
-                    if not fut.done():
-                        fut.set_result("approved")
-                    return
-                await asyncio.sleep(0.01)
+        async def _auto_approve() -> None:
+            await _answer_approval(slot, "req-1", "approved")
 
         approver = asyncio.get_event_loop().create_task(_auto_approve())
 
@@ -657,16 +679,14 @@ class TestBatchRejection:
         evt2.tool_call_id = "tc-2"
         _set_stream(client, [evt1, evt2, _complete_event()])
 
-        async def _reject_first():
-            await asyncio.sleep(0.05)
-            fut = slot._approval_futures.get("req-1")
-            if fut and not fut.done():
-                fut.set_result("rejected")
+        async def _reject_first() -> None:
+            await _answer_approval(slot, "req-1", "rejected")
 
-        asyncio.get_event_loop().create_task(_reject_first())
+        rejecter = asyncio.get_event_loop().create_task(_reject_first())
 
         with _patch_stats():
             await _run_chat(state, slot, "hello")
+        await _drain(rejecter)
 
         # First tool rejected interactively, second auto-rejected
         client.reject_tool.assert_any_call("req-1")
@@ -1036,18 +1056,16 @@ class TestInteractiveDenyDoesNotTriggerRecovery:
         client.stream = MagicMock(side_effect=_stream)
 
         # Simulate the user clicking Reject after a short delay.
-        async def _auto_reject():
-            await asyncio.sleep(0.05)
-            fut = slot._approval_futures.get("req-1")
-            if fut and not fut.done():
-                fut.set_result("rejected")
+        async def _auto_reject() -> None:
+            await _answer_approval(slot, "req-1", "rejected")
 
-        asyncio.get_running_loop().create_task(_auto_reject())
+        rejecter = asyncio.get_running_loop().create_task(_auto_reject())
 
         with _patch_stats():
             await _run_chat(state, slot, "hello")
             if slot.task:
                 await slot.task
+        await _drain(rejecter)
 
         # The key assertion: no recovery continuation was injected.
         assert not any(
@@ -1292,13 +1310,7 @@ async def _drive_deny_turn(
     if approve_prompt:
 
         async def _answer() -> None:
-            for _ in range(600):
-                fut = slot._approval_futures.get("req-1")
-                if fut is not None:
-                    if not fut.done():
-                        fut.set_result("approved")
-                    return
-                await asyncio.sleep(0.01)
+            await _answer_approval(slot, "req-1", "approved")
 
         approver = asyncio.get_event_loop().create_task(_answer())
 
@@ -1509,3 +1521,81 @@ class TestDenyRowTitleRedaction:
         # Each deny shape is rendered in exactly one place — its helper.
         assert source.count('f"🚫 {title} (invalid: {error})"') == 1
         assert source.count('f"🚫 {title} (hook error)"') == 1
+
+
+class TestApprovalAnswerersDoNotRaceTheStream:
+    """No answerer may wait on the clock instead of on the approval future.
+
+    An answerer that sleeps a fixed interval and then reads
+    ``_approval_futures`` once is racing the provider stream: when the
+    permission event arrives after the poke, the future is registered with
+    nobody left to answer it, and the turn parks on
+    ``asyncio.wait_for(fut, timeout=...)`` for the whole approval window.
+
+    That window (600s by default) outlives CI's ``--timeout=180``, so the test
+    does not fail — pytest-timeout hard-kills the xdist worker and the run
+    reports ``worker 'gwN' crashed while running <whatever was in flight>``,
+    naming an arbitrary test and discarding the real cause.
+
+    These are source ratchets, not behavioral tests, because the racy shape
+    passes every assertion on an idle machine — only load reveals it, and only
+    as somebody else's crashed worker.
+    """
+
+    @staticmethod
+    def _functions():
+        tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                yield node
+
+    @staticmethod
+    def _calls(fn, *, attr, on=None):
+        """Calls of ``<...>.attr(...)`` inside *fn*, optionally on ``<...>.on``."""
+        out = []
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.Call):
+                continue
+            f = node.func
+            if not isinstance(f, ast.Attribute) or f.attr != attr:
+                continue
+            if on is not None:
+                base = f.value
+                if not (isinstance(base, ast.Attribute) and base.attr == on):
+                    continue
+            out.append(node)
+        return out
+
+    def test_only_the_shared_helper_waits_for_an_approval_future(self):
+        """A function touching _approval_futures must not also sleep."""
+        offenders = []
+        for fn in self._functions():
+            if fn.name == "_answer_approval":
+                continue  # the one place allowed to wait, and it polls
+            touches = any(
+                isinstance(n, ast.Attribute) and n.attr == "_approval_futures"
+                for n in ast.walk(fn)
+            )
+            if not touches:
+                continue
+            if self._calls(fn, attr="sleep"):
+                offenders.append(f"{fn.name} (line {fn.lineno})")
+        assert not offenders, (
+            "these functions wait on the clock before touching an approval "
+            "future, which races the stream and surfaces as a crashed xdist "
+            "worker -- await _answer_approval() instead: " + ", ".join(offenders)
+        )
+
+    def test_answerers_do_not_hand_roll_the_future_lookup(self):
+        """Only _answer_approval may .get() an approval future to answer it."""
+        offenders = [
+            f"{fn.name} (line {fn.lineno})"
+            for fn in self._functions()
+            if fn.name != "_answer_approval"
+            and self._calls(fn, attr="get", on="_approval_futures")
+        ]
+        assert not offenders, (
+            "these functions look up an approval future themselves instead of "
+            "reusing _answer_approval, so the wait discipline has to be "
+            "re-derived at each site: " + ", ".join(offenders)
+        )


### PR DESCRIPTION
## Problem

`Backend Tests (Windows) (1)` went red **on main** at `24a6f8ee5` (run
`31468584779` attempt 1, job `93707753968`) with:

```
worker 'gw0' crashed while running
'test/test_dashboard_approval.py::TestApprovalModes::test_interactive_reject@serial'
```

It is not a crash. The job log carries a pytest-timeout dump — `+++ Timeout +++`,
`timeout: 180.0s`, `timeout method: thread` — and its MainThread stack has **zero
repo frames**; the loop is parked with nothing left to run:

```
_pytest/python.py:166         result = testfunction(**testargs)
pytest_asyncio/plugin.py:478  _loop.run_until_complete(task)
asyncio/base_events.py:1961   event_list = self._selector.select(timeout)
asyncio/windows_events.py:774 GetQueuedCompletionStatus(self._iocp, ms)
```

pytest-timeout's `thread` method dumps every thread stack and hard-kills the
process, so xdist reports `[gw0] node down: Not properly terminated` →
`replacing crashed worker gw0` → `worker 'gw0' crashed while running <whatever
was in flight>`. The test name in that message is incidental.

## Root cause

Three answerers in this file poked the approval future at a fixed offset:

```python
async def _auto_reject():
    await asyncio.sleep(0.05)
    fut = slot._approval_futures.get("req-1")   # one shot
    if fut and not fut.done():
        fut.set_result("rejected")
```

The future is created inside `_run_chat` when the permission event is processed
(`chat_runner.py:5208`). When the stream takes longer than 0.05s to deliver its
first event, the poke finds `None`, returns, and the turn parks on
`asyncio.wait_for(fut, timeout=_approval_window)` where `_approval_window =
min(approval_timeout_for(slot), tool_approval_timeout_secs())` — **600s** by
default (`chat_runner.py:5298-5313`).

**600s > CI's `--timeout=180`, and that inequality is what destroys the
diagnostic.** The test cannot fail on its own assertion, because the worker is
killed 420s before the product would have given up. A wall-clock race is
therefore reported as a crash, with no traceback, attributed to an arbitrary
test — which is why it has been read as unexplainable and pre-existing.

Windows only loses the race more often (4 workers, slower first event). The
mechanism is not platform-specific and reproduces on Linux.

## Fix

One `_answer_approval()` helper that waits for the future to **exist** rather
than sleeping a fixed interval, used by all seven answerers in the file.

Four of those seven already polled correctly and now route through the same
helper. One of them already carried this comment:

> Poll for the future rather than sleeping a fixed 0.05s and hoping the chat has
> registered it by then

So the rule was diagnosed and written down at one site, and the three siblings
were left behind — the same shape as #2688 and #2736. Consolidating to one
implementation is what stops the next answerer re-deriving it.

**Nothing is skipped and no threshold is loosened.** The helper's 30s deadline is
not a widened timeout: `0.05s` was a synchronisation guess, not a bound on
product behaviour. The deadline exists so that a future which never appears
surfaces as a named assertion —

```
approval future 'req-1' was never registered within 30s — the turn never
reached its permission event, so there was nothing to answer
```

— instead of a killed worker. The two fire-and-forget answerer tasks now keep a
handle and are drained, matching the sibling that already did.

Two AST source ratchets keep the shape from returning: no function touching
`_approval_futures` may call `sleep`, and only the helper may `.get()` a future
in order to answer it. They are ratchets rather than behavioral tests because
the racy shape passes every assertion on an idle machine — only load reveals it,
and only as somebody else's crashed worker.

## Tests

Red before green, on Linux, at main `24a6f8ee5`. A throwaway plugin (**not
committed**) delayed only the *first* stream event, standing in for runner
latency; no product code and no assertion was touched.

| | injection | result |
|---|---|---|
| before | 0.30s | **reproduces the CI signature verbatim** — `worker 'gw0' crashed while running ...test_interactive_reject@serial`, all 3 sites, `xdist: maximum crashed workers reached: 2` |
| after | 0.30s | 3 passed |
| after | 3.0s (60x the old poke) | 62 passed |
| after | none | 62 passed; `-n 4 --dist loadgroup` 62 passed |

- Both ratchets proven able to fail: reintroducing the fixed-sleep shape at one
  site fails both (`2 failed`).
- `792 passed` across all seven test files that touch `_approval_futures`.
- `flake8` exit 0, `isort` exit 0 — exit codes read explicitly, not tailed.

## Independent corroboration

The same test appears as `worker 'gw1' crashed` twice on #2763, where it was
reported as pre-existing and unrelated to that branch. That reading was correct,
and it is consistent with this cause: a race, not a regression.

## Not in scope

- The product waiting 600s for an approval while CI's per-test ceiling is 180s
  is the reason an unanswered approval presents as a crashed worker rather than
  a test failure. Changing the approval window is a product decision, so this PR
  only removes the test-side race that reaches it.
- An AST scan of the whole test tree finds 4 further functions that sleep before
  reading a future registry (`test_ask_question_roundtrip.py:63`,
  `test_dashboard_chat.py:711`, `test_orphaned_approval_card.py:145`,
  `test_stt_endpointing.py:238`). That scan is **over-inclusive** — it also
  matches correct polling loops, and the one I checked
  (`test_ask_question_roundtrip.py`) polls properly and is bounded. Listed as
  candidates to check, not as defects.
