### PR TITLE
fix(chat): refuse a linked session binding on an app-scoped slot

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -1025,6 +1025,24 @@ second form hits the dedup guard). When normalization changes the name, the
 original pretty form is preserved as the slot's initial title
 (redaction-scrubbed, non-pinned so auto-title can still override).
 
+**App-owned slot binding isolation:** `linked_session_key` is session authority,
+not display metadata: chat routes authorize an app against the slot owner and
+then run the turn on the slot's effective session. An app-owned slot therefore
+never carries a linked channel or cron session. The slot attribute refuses the
+binding at the shared mutation boundary (factory arguments, channel-name
+inference, restore, and background injectors all pass through it), emits a
+best-effort SEL denial, and leaves the slot on its own `dashboard:` session. The
+refused key remains as an authorization-only claim, separate from the live route:
+app gates therefore keep refusing the quarantined slot instead of treating the
+failed mutation as an ordinary unbound slot, and note content stamped before the
+attempt is dropped at its late drain/save seams. The claim never selects a
+provider or transcript and is not serialized as a live binding; assigning an
+explicit empty binding clears it.
+Restore also refuses to infer `channel_origin` from a legacy linked key when the
+same persisted row is app-owned, so an upgrade disarms both the live binding and
+the transcript provenance written by an older vulnerable build. Unscoped
+dashboard/channel slots keep the historical auto-bind and restore behavior.
+
 ## Slack Thread Linking
 
 Sessions can be linked to Slack threads via `SessionMap` fields

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -3518,6 +3518,13 @@ def _app_cancel_denied(
         reason = (
             "app cannot access unscoped slots" if not slot._app else "app does not own this slot"
         )
+    elif getattr(slot, "linked_session_claim", ""):
+        # A refused binding is deliberately absent from ``target_key`` so no
+        # operation can route to it. It still quarantines the slot for app
+        # authorization; otherwise rejection would be indistinguishable from a
+        # genuinely unbound app slot and this destructive action would return
+        # success against a different session than the attempted binding named.
+        reason = "app does not own the session this slot is linked to"
     elif target_key != _history_key_for(slot.key):
         reason = "app does not own the session this slot is linked to"
     else:
@@ -9933,7 +9940,7 @@ def _check_slot_app_ownership(
             error="app does not own this slot",
         )
         return _slot_not_found()
-    if effective_session_key(slot) != _history_key_for(slot.key):
+    if getattr(slot, "linked_session_claim", ""):
         sel().log_api_access(
             caller=request_app,
             operation=operation,

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -32,7 +32,7 @@ from kiro_crew.dashboard.chat_utils import (
     _normalize_model,
     _redact_meta_for_role,
     _sync_dashboard_slots,
-    effective_session_key,
+    note_authorization_session_key,
     slot_history_key,
     slot_transcript_key,
 )
@@ -896,8 +896,14 @@ def _rehydrate_slot_from_history(
             # A legacy channel transcript carrying neither marker is surfaced by
             # ``channel_slot_reconciler`` instead, which sets the flag -- and the
             # first save then persists it, so later boots need no inference.
+            # ``linked_session_key`` is a legacy provenance inference. It must
+            # not fire for an app-owned row: such a row records a binding the
+            # slot boundary now refuses, and inferring provenance from it would
+            # restore the same transcript authority through ``slot_history_key``.
+            # Explicit persisted provenance remains authoritative.
             channel_origin=(
-                bool(meta.get("channel_origin")) or bool(meta.get("linked_session_key"))
+                bool(meta.get("channel_origin"))
+                or (bool(meta.get("linked_session_key")) and not meta.get("app"))
             ),
             # Restore the persisted origin. Re-deriving it here would relabel
             # every rehydrated slot on restart, so a cron slot would come back
@@ -2712,19 +2718,24 @@ def _save_slot_to_history(
     # drain drops it from the live window on the event loop.
     #
     # Authorization and the write target must come from ONE observation of the
-    # routing. Both keys derive from ``slot.linked_session_key``, which the event
-    # loop rebinds with no running gate, so reading it per row -- or again when
-    # the write target is resolved -- authorizes rows against one session and
-    # then writes the file of another. Snapshot-then-confirm with the same
-    # bounded retry this function already uses for the window pair. The two keys
+    # routing. The write target derives from ``slot.linked_session_key`` while
+    # the authorization key also includes a refused app-slot binding claim. The
+    # event loop can mutate either with no running gate, so reading them per row
+    # -- or again when the write target is resolved -- authorizes rows against
+    # one session and then writes the file of another. Snapshot-then-confirm with
+    # the same bounded retry this function already uses for the window pair. The two keys
     # stay DISTINCT: collapsing them would send a channel-born slot the
     # dashboard could not bind to the phantom file ``slot_history_key`` exists
     # to avoid.
     for _ in range(_FLUSH_SNAPSHOT_RETRIES):
         routing = getattr(slot, "linked_session_key", "")
-        note_auth_key = effective_session_key(slot)
+        authorization_claim = getattr(slot, "linked_session_claim", "")
+        note_auth_key = note_authorization_session_key(slot)
         history_key = slot_history_key(slot)
-        if getattr(slot, "linked_session_key", "") == routing:
+        if (
+            getattr(slot, "linked_session_key", "") == routing
+            and getattr(slot, "linked_session_claim", "") == authorization_claim
+        ):
             break
     if expected_history_key is not None and history_key != expected_history_key:
         # The caller authorized a write against a specific transcript and the

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -783,6 +783,22 @@ def subagents_attached(
     return bool(running is None or running or queued or inflight)
 
 
+def note_authorization_session_key(slot: _ChatSlot) -> str:
+    """The session identity stamped note content must still match at delivery.
+
+    A refused binding on an app-owned slot never becomes routing authority, so
+    :func:`effective_session_key` correctly keeps returning the slot's own
+    dashboard session. The refusal is still a routing-identity change for
+    authorization: treating it as an ordinary empty binding would let note
+    content accepted before the attempt survive and reach a later prompt.
+
+    This helper is for authorization comparisons only. It must never select a
+    provider, transcript, approval policy, or any other session-owned resource.
+    """
+    claim = getattr(slot, "linked_session_claim", "")
+    return claim or _history_key_for(slot.key)
+
+
 def slack_options_slot(state: DashboardState, session_key: str) -> _ChatSlot | None:
     """The slot holding *session_key*'s Slack OPTIONS state, if one exists.
 

--- a/src/kiro_crew/dashboard/slot_buffers.py
+++ b/src/kiro_crew/dashboard/slot_buffers.py
@@ -667,9 +667,9 @@ class SlotBufferCoordinator:
         logger: logging.Logger,
     ) -> int:
         # Local import avoids a module cycle: chat_utils imports the state facade.
-        from kiro_crew.dashboard.chat_utils import effective_session_key
+        from kiro_crew.dashboard.chat_utils import note_authorization_session_key
 
-        live_session = effective_session_key(slot)
+        live_session = note_authorization_session_key(slot)
         kept_context = [
             entry
             for entry in slot._pending_context
@@ -725,11 +725,11 @@ class SlotBufferCoordinator:
         """
         if not slot._deferred_notes:
             return 0
-        from kiro_crew.dashboard.chat_utils import effective_session_key
+        from kiro_crew.dashboard.chat_utils import note_authorization_session_key
 
         held = slot._deferred_notes[:]
         slot._deferred_notes.clear()
-        live_session = effective_session_key(slot)
+        live_session = note_authorization_session_key(slot)
         written = 0
         for index, note in enumerate(held):
             authorized_session = note.get("session")

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3365,7 +3365,8 @@ class _ChatSlot:
         "_frozen_prefix_cache",
         "_pending_rewrite",
         "_file_changes",
-        "linked_session_key",
+        "_linked_session_key",
+        "_refused_linked_session_key",
         # Remote-execution binding: this slot lives in the LOCAL list and local
         # history, but its turns run on a connected peer crew. See
         # ``dashboard/remote_relay.py``.
@@ -3973,7 +3974,12 @@ class _ChatSlot:
         self._file_changes: list[dict[str, str]] = (
             []
         )  # [{path, content}] before-snapshots accumulated per turn for file-chip diffs
-        self.linked_session_key: str = ""  # when set, _run_chat uses this as session key
+        self._linked_session_key: str = ""  # when set, _run_chat uses this as session key
+        # A refused app-slot binding is not routing authority, but forgetting it
+        # would make authorization treat the attempted rebind as if it never
+        # happened. Keep it separately so downstream gates and stamped-note
+        # checks fail closed without exposing the foreign session to a turn.
+        self._refused_linked_session_key: str = ""
         # Where the turn CURRENTLY in flight actually started, as opposed to
         # where the slot would route a new one. The two diverge whenever the
         # routing above is reassigned on a live slot — a cron injection binds an
@@ -4132,6 +4138,65 @@ class _ChatSlot:
             # impossible and a missed bump can only cause an extra (harmless)
             # flush, never a skipped one.
             self._dirty_gen += 1
+
+    @property
+    def linked_session_key(self) -> str:
+        """The session this slot's conversation actually runs on, if any.
+
+        A binding is authority: app routes authorize against ``_app`` and then
+        address ``effective_session_key(slot)``. Slot ownership does not imply
+        ownership of a channel or cron session, so an app-owned slot may not
+        carry a binding.
+
+        Keep the rule at the attribute boundary because bindings are assigned
+        by the slot factory, restore paths, and background injectors. This also
+        disarms app-owned rows persisted by an older vulnerable build when
+        those rows are restored after an upgrade.
+        """
+        return self._linked_session_key
+
+    @linked_session_key.setter
+    def linked_session_key(self, value: str) -> None:
+        if value and getattr(self, "_app", ""):
+            # Refuse without raising: one poisoned legacy tab must not abort an
+            # otherwise healthy restore. The app keeps its own dashboard
+            # conversation and loses only authority it was never granted.
+            logger.warning(
+                "refusing session binding on app-scoped slot %r (app=%r)",
+                getattr(self, "key", ""),
+                self._app,
+            )
+            try:
+                sel().log_api_access(
+                    caller=self._app,
+                    operation="slot_session_bind",
+                    outcome="denied",
+                    source="app_isolation",
+                    resources=f"slot={getattr(self, 'key', '')}",
+                    error="app-scoped slots cannot carry a linked session binding",
+                )
+            except Exception:  # noqa: BLE001
+                # The audit is best-effort; the refusal itself is the control.
+                logger.debug("SEL write for a refused slot binding failed", exc_info=True)
+            # Preserve the denied claim separately from the live route. If it
+            # vanished into the empty-string fallback, downstream app gates
+            # would authorize reset/note/context against the dashboard session
+            # and already-stamped note content would survive the rebind attempt.
+            self._refused_linked_session_key = value
+            return
+        self._refused_linked_session_key = ""
+        self._linked_session_key = value
+
+    @property
+    def linked_session_claim(self) -> str:
+        """The accepted or refused binding relevant to authorization.
+
+        This value must never be used for routing or persistence. A refused
+        binding is retained only so a later operation cannot reinterpret the
+        slot as safely unbound, and so content stamped before a rebind attempt
+        is discarded at its late delivery seams.
+        """
+        return self._refused_linked_session_key or self._linked_session_key
 
     @property
     def _plan_stage_count(self) -> int:
@@ -6418,6 +6483,11 @@ class DashboardState:
         reads the persisted link off the slot's effective session key, so a
         binding applied later would hydrate against the wrong key and leave a
         channel-born tab looking unlinked.
+
+        A channel-shaped *name* also resolves a binding for an unscoped caller.
+        An app-owned slot takes no binding through either route; the
+        :attr:`_ChatSlot.linked_session_key` property enforces that invariant
+        across explicit assignment and legacy restore as well.
         """
         existing, creation = _registry_for(self).prepare_creation(
             self,
@@ -6509,7 +6579,7 @@ class DashboardState:
             slot.channel_origin = True
         if linked_session_key:
             slot.linked_session_key = linked_session_key
-        elif self.sessions:
+        elif self.sessions and not app:
             # No caller-supplied binding, but a channel-stem name means this slot
             # displays a conversation that runs on the channel's own session.
             # Resolving it HERE rather than in each caller is what makes the
@@ -6523,6 +6593,10 @@ class DashboardState:
             # only a real channel key may become a binding, so a malformed map
             # answer leaves the slot unbound (a supported state) rather than
             # routing the user's replies to a session no channel reads.
+            #
+            # Skip inference for an app-owned slot. The property above is the
+            # security boundary; this guard avoids a session-map lookup and an
+            # expected refusal for the common app creation path.
             if is_channel_session_key(name):
                 resolved = self.sessions.channel_key_for_stem(name)
                 if isinstance(resolved, str) and is_channel_session_key(resolved):

--- a/test/test_app_slot_channel_autobind.py
+++ b/test/test_app_slot_channel_autobind.py
@@ -1,0 +1,238 @@
+"""App-owned chat slots cannot acquire another surface's session authority."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+SLACK_KEY = "slack:1785370133.085469"
+SLACK_STEM = "slack_1785370133.085469"
+DISCORD_KEY = "discord:kirocrew:direct:123456"
+DISCORD_STEM = "discord_kirocrew_direct_123456"
+APP = "issue-radar"
+
+
+@pytest.fixture
+def state(tmp_path):
+    """A real state with channel lookup controlled by the test."""
+    from chat_test_helpers import _make_state
+
+    st = _make_state(tmp_path)
+    st.sessions.channel_key_for_stem.side_effect = lambda stem: (
+        SLACK_KEY if stem == SLACK_STEM else DISCORD_KEY if stem == DISCORD_STEM else ""
+    )
+    st.sessions.get_slack_link.return_value = (None, None)
+    return st
+
+
+@pytest.mark.parametrize("name", [SLACK_STEM, SLACK_KEY, DISCORD_STEM])
+def test_app_owned_channel_shaped_slot_stays_on_its_dashboard_session(state, name):
+    from kiro_crew.dashboard.chat_utils import effective_session_key
+
+    slot = state.get_or_create_slot(name, app=APP)
+
+    assert slot._app == APP
+    assert slot.linked_session_key == ""
+    assert slot.to_dict()["linked_session_key"] == ""
+    assert effective_session_key(slot) == f"dashboard:{slot.key}"
+
+
+def test_app_creation_skips_channel_lookup(state):
+    state.get_or_create_slot(SLACK_STEM, app=APP)
+
+    state.sessions.channel_key_for_stem.assert_not_called()
+
+
+def test_dashboard_channel_slot_keeps_legacy_autobind(state):
+    from kiro_crew.dashboard.chat_utils import effective_session_key
+
+    slot = state.get_or_create_slot(SLACK_STEM)
+
+    assert slot.linked_session_key == SLACK_KEY
+    assert effective_session_key(slot) == SLACK_KEY
+
+
+def test_existing_dashboard_channel_slot_is_not_taken_over_by_app(state):
+    original = state.get_or_create_slot(SLACK_STEM)
+
+    same = state.get_or_create_slot(SLACK_STEM, app=APP)
+
+    assert same is original
+    assert same._app == ""
+    assert same.linked_session_key == SLACK_KEY
+
+
+def test_explicit_and_late_bindings_are_refused_with_sel(state):
+    from kiro_crew.dashboard.chat_utils import effective_session_key
+
+    with patch("kiro_crew.dashboard.state.sel") as sel_factory:
+        explicit = state.get_or_create_slot("app-explicit", app=APP, linked_session_key=SLACK_KEY)
+        late = state.get_or_create_slot("app-late", app=APP)
+        late.linked_session_key = "cron:nightly"
+
+    assert explicit.linked_session_key == ""
+    assert late.linked_session_key == ""
+    assert explicit.linked_session_claim == SLACK_KEY
+    assert late.linked_session_claim == "cron:nightly"
+    assert effective_session_key(explicit) == "dashboard:app-explicit"
+    assert effective_session_key(late) == "dashboard:app-late"
+    late.linked_session_key = ""
+    assert late.linked_session_claim == ""
+    assert sel_factory.return_value.log_api_access.call_count == 2
+    sel_factory.return_value.log_api_access.assert_any_call(
+        caller=APP,
+        operation="slot_session_bind",
+        outcome="denied",
+        source="app_isolation",
+        resources="slot=app-explicit",
+        error="app-scoped slots cannot carry a linked session binding",
+    )
+
+
+def test_sel_failure_does_not_turn_refusal_into_restore_failure(state):
+    slot = state.get_or_create_slot("app-slot", app=APP)
+
+    with patch("kiro_crew.dashboard.state.sel", side_effect=RuntimeError("audit offline")):
+        slot.linked_session_key = SLACK_KEY
+
+    assert slot.linked_session_key == ""
+
+
+def test_unscoped_slot_can_still_be_bound_after_creation(state):
+    slot = state.get_or_create_slot("cron-nightly")
+
+    slot.linked_session_key = "cron:nightly"
+
+    assert slot.linked_session_key == "cron:nightly"
+
+
+def test_upgrade_disarms_poisoned_app_metadata(tmp_path, monkeypatch):
+    from chat_test_helpers import _make_state
+
+    from kiro_crew.dashboard.chat_persistence import (
+        _save_slot_to_history,
+        restore_open_slots,
+    )
+    from kiro_crew.dashboard.chat_utils import effective_session_key
+
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    original = _make_state(tmp_path / "sessions")
+    slot = original.get_or_create_slot(SLACK_STEM, app=APP)
+    # Reproduce data written by the vulnerable build without going through the
+    # new mutation boundary.
+    slot._linked_session_key = SLACK_KEY
+    slot.append("user", "hello", "msg msg-u")
+    _save_slot_to_history(original, slot, force=True)
+    original._persist_open_slots()
+
+    meta = original.conversation_log.get_metadata(SLACK_KEY)
+    assert meta["app"] == APP
+    assert meta["linked_session_key"] == SLACK_KEY
+
+    restarted = _make_state(tmp_path / "sessions")
+    restarted.sessions.channel_key_for_stem.side_effect = lambda stem: (
+        SLACK_KEY if stem == SLACK_STEM else ""
+    )
+    restore_open_slots(restarted)
+
+    revived = restarted._slots[SLACK_STEM]
+    assert revived._app == APP
+    assert revived.linked_session_key == ""
+    assert revived.channel_origin is False
+    assert effective_session_key(revived) == f"dashboard:{SLACK_STEM}"
+
+
+def test_explicit_channel_origin_survives_refused_legacy_binding(tmp_path, monkeypatch):
+    from chat_test_helpers import _make_state
+
+    from kiro_crew.dashboard.chat_persistence import (
+        _save_slot_to_history,
+        restore_open_slots,
+    )
+
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    original = _make_state(tmp_path / "sessions")
+    slot = original.get_or_create_slot(SLACK_STEM, app=APP, channel_origin=True)
+    slot._linked_session_key = SLACK_KEY
+    slot.append("user", "hello", "msg msg-u")
+    _save_slot_to_history(original, slot, force=True)
+    original._persist_open_slots()
+
+    restarted = _make_state(tmp_path / "sessions")
+    restore_open_slots(restarted)
+
+    revived = restarted._slots[SLACK_STEM]
+    assert revived.linked_session_key == ""
+    assert revived.channel_origin is True
+
+
+def test_unscoped_channel_metadata_still_restores_bound(tmp_path, monkeypatch):
+    from chat_test_helpers import _make_state
+
+    from kiro_crew.dashboard.chat_persistence import (
+        _save_slot_to_history,
+        restore_open_slots,
+    )
+
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    original = _make_state(tmp_path / "sessions")
+    slot = original.get_or_create_slot(
+        SLACK_STEM, linked_session_key=SLACK_KEY, channel_origin=True
+    )
+    slot.append("user", "hello", "msg msg-u")
+    _save_slot_to_history(original, slot, force=True)
+    original._persist_open_slots()
+
+    restarted = _make_state(tmp_path / "sessions")
+    restore_open_slots(restarted)
+
+    revived = restarted._slots[SLACK_STEM]
+    assert revived.linked_session_key == SLACK_KEY
+    assert revived.channel_origin is True
+
+
+def _chat_app(state, app_identity: str = "") -> web.Application:
+    @web.middleware
+    async def identity(request: web.Request, handler: Any) -> web.StreamResponse:
+        if app_identity:
+            request["app"] = app_identity
+        return await handler(request)
+
+    from kiro_crew.dashboard.chat_handlers import api_chat
+
+    app = web.Application(middlewares=[identity])
+    app["state"] = state
+    app.router.add_post("/api/chat", api_chat)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_app_chat_route_does_not_dispatch_on_channel_session(state):
+    from kiro_crew.dashboard.chat_utils import effective_session_key
+
+    with patch("kiro_crew.dashboard.chat_handlers.spawn_guarded_turn") as spawn:
+        spawn.return_value = MagicMock()
+        async with TestClient(TestServer(_chat_app(state, APP))) as client:
+            response = await client.post("/api/chat", json={"slot": SLACK_STEM, "message": "hello"})
+
+    assert response.status == 200
+    slot = state._slots[SLACK_STEM]
+    assert effective_session_key(slot) == f"dashboard:{SLACK_STEM}"
+    assert slot.linked_session_key == ""
+
+
+@pytest.mark.asyncio
+async def test_dashboard_chat_route_keeps_channel_dispatch(state):
+    from kiro_crew.dashboard.chat_utils import effective_session_key
+
+    with patch("kiro_crew.dashboard.chat_handlers.spawn_guarded_turn") as spawn:
+        spawn.return_value = MagicMock()
+        async with TestClient(TestServer(_chat_app(state))) as client:
+            response = await client.post("/api/chat", json={"slot": SLACK_STEM, "message": "hello"})
+
+    assert response.status == 200
+    assert effective_session_key(state._slots[SLACK_STEM]) == SLACK_KEY


### PR DESCRIPTION
## Problem / Motivation

A slot's `linked_session_key` is session authority. App routes authorize against `slot._app`, then dispatch on `effective_session_key(slot)`. Before this change, an app could request a channel-shaped slot name and receive an app-owned slot bound to a channel session it did not own.

The invariant established here is stronger than blocking name inference: **an app-scoped slot cannot carry a linked-session binding at all.** That covers explicit arguments, bindings applied after creation, poisoned metadata written by an older build, and authorization rechecks after an await.

## Why it matters

This closes a cross-surface authorization path. Slot ownership must not imply authority over a Slack, Discord, cron, or other session merely because the app chose a matching slot name or restored stale metadata.

## What changed

- `linked_session_key` is a property with a shared mutation boundary. A non-empty binding on an app-owned slot is refused and audited without aborting slot creation or restore.
- A refused binding is retained separately as an authorization-only `linked_session_claim`; it never becomes the effective route, transcript target, provider key, or serialized live binding.
- Reset, note, and context authorization treat both accepted and refused claims as foreign and return the same 404 as a missing slot.
- Immediate/deferred note delivery, pending-context drain, and save snapshots compare the authorization claim again at their late-use seams, dropping content accepted before a refused rebind attempt rather than delivering it to a different session.
- Explicitly clearing the binding clears the refused claim.
- Channel-shaped name inference is skipped for app-owned slots.
- Restore honors explicit `channel_origin`, but no longer infers channel provenance from a refused legacy linked key on an app-owned row.
- Dashboard-owned channel tabs and unscoped cron/workflow late binding keep their existing behavior.
- The invariant and upgrade behavior are documented in `docs/system-specs/modules/session.md`.

The rule lives at the attribute boundary because bindings are assigned by the factory, restore paths, cron/workflow injectors, and other late-binding callers. A per-call-site guard would leave the next assignment path as a bypass.

## Verification

- Focused security and compatibility set: **18 passed**, including the four failures exposed by the previous CI run.
- Related `state`, `gateway app-kit`, and chat-handler files: **168 passed**.
- Expanded cron/channel/chat-utility set: **259 passed**.
- Five key security cases repeated serially ten times: **50/50 passed**.
- Mypy: **1167 source files, 0 issues**.
- Flake8, isort, Black baseline, subprocess-encoding, docs-lint, brand, and changed-source diff gates passed.
- After the final rebase onto current `main`, the focused 18 tests and static gates passed again.

No flaky failure was hidden with a retry, sleep, or longer timeout. A separate Windows SEL test failure observed in CI is being fixed at its own shared lock boundary and is not mixed into this security PR.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** This is a backend authorization, routing, persistence, and test change; it does not alter rendered UI.
