### PR TITLE
fix: preserve Piper WAV MIME during dashboard playback

### DIFF
--- a/src/kiro_crew/dashboard/chat_voice.py
+++ b/src/kiro_crew/dashboard/chat_voice.py
@@ -265,11 +265,17 @@ async def _synthesize_nonstreaming(
             audio_b64 = base64.b64encode(f.read()).decode()
         state.broadcast_ws(
             "voice_chunk",
-            {"slot": slot_key, "index": 0, "sentence": text, "audio": audio_b64},
+            {
+                "slot": slot_key,
+                "index": 0,
+                "sentence": text,
+                "audio": audio_b64,
+                "audioMime": "audio/wav",
+            },
         )
         state.broadcast_ws(
             "voice_complete",
-            {"slot": slot_key, "audio": audio_b64, "chunks": 1},
+            {"slot": slot_key, "audio": audio_b64, "chunks": 1, "audioMime": "audio/wav"},
         )
         return web.json_response({"ok": True, "chunks": 1})
     except Exception as exc:

--- a/test/test_chat_voice.py
+++ b/test/test_chat_voice.py
@@ -266,6 +266,8 @@ class TestVoiceConfig:
         assert streaming_called is False  # Polly path NOT used for Piper
         kinds = [c.args[0] for c in state.broadcast_ws.call_args_list]
         assert "voice_chunk" in kinds and "voice_complete" in kinds
+        payloads = [c.args[1] for c in state.broadcast_ws.call_args_list]
+        assert all(payload["audioMime"] == "audio/wav" for payload in payloads)
 
     @pytest.mark.asyncio
     async def test_put_config_invalid_json(self, tmp_path, monkeypatch):

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -1415,11 +1415,11 @@ export function useWebSocket() {
             if (voiceMutedRef.current) break
             if (data.slot !== store.getState().chat.activeSlot) break
             // Queue and play audio chunks as they arrive
-            const b64 = (data as { audio: string }).audio
+            const { audio: b64, audioMime } = data as { audio: string; audioMime?: string }
             if (b64) {
               try {
                 const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0))
-                const blob = new Blob([bytes], { type: 'audio/mpeg' })
+                const blob = new Blob([bytes], { type: audioMime === 'audio/wav' ? 'audio/wav' : 'audio/mpeg' })
                 const url = URL.createObjectURL(blob)
                 voiceQueueRef.current.push(url)
                 dispatch(setVoicePlaying(true))

--- a/website/src/test/UseWebSocketCoverage.test.tsx
+++ b/website/src/test/UseWebSocketCoverage.test.tsx
@@ -979,6 +979,26 @@ describe('useWebSocket frame router', () => {
     expect(chat().voicePlaying).toBe(false)
   })
 
+  it('uses the WAV MIME type supplied with a local voice chunk', async () => {
+    const blobs: Blob[] = []
+    URL.createObjectURL = vi.fn((blob: Blob) => {
+      blobs.push(blob)
+      return 'blob:voice-wav'
+    })
+    vi.stubGlobal('Audio', MockAudio)
+    const { ws } = mount()
+
+    await act(async () => {
+      ws.simulateMessage({
+        type: 'voice_chunk',
+        data: { slot: ACTIVE, audio: btoa('wav'), audioMime: 'audio/wav' },
+      })
+    })
+
+    expect(blobs).toHaveLength(1)
+    expect(blobs[0].type).toBe('audio/wav')
+  })
+
   it('advances past a chunk whose audio element errors', async () => {
     vi.stubGlobal('Audio', MockAudio)
     const { ws } = mount()


### PR DESCRIPTION
## Problem / Motivation

Local Piper synthesis returns WAV bytes, but the voice WebSocket events omit their container type and the dashboard assumes every chunk is MPEG.

## Why it matters

A browser can reject or misdecode the completed local-voice reply when its declared MIME type disagrees with the audio bytes.

## What changed

- Send `audioMime: audio/wav` with Piper `voice_chunk` and `voice_complete` events.
- Create the playback Blob using that WAV MIME type while retaining the MPEG fallback for existing providers.
- Add backend and browser regression coverage.

## Tests

- `python -m pytest -q test/test_chat_voice.py` — 20 passed
- `npx vitest run src/test/UseWebSocketCoverage.test.tsx` — 98 passed
- `npx tsc -b`
- `npm run build`