### PR TITLE
fix: add Windows kiro-cli auth store to credential candidates (#2782)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
@@ -134,9 +134,25 @@ _JSON_TOKEN_READ_IDS = (
 # exactly this path.
 # ``~/.local/share`` is not a sensitive credential path, so this read is a direct
 # read-only sqlite open. auth_kv holds a JSON blob per key.
+#
+# The entries are deliberately UNGUARDED by ``sys.platform``: every candidate is
+# existence-checked before it is opened, so a path that cannot exist on the
+# running OS is inert, and a platform-independent module constant is what lets
+# tests patch the tuple without becoming host-dependent.
+#
+# The Windows entry is the fixed default Roaming location, NOT resolved from
+# ``%APPDATA%``. Membership here is a trust claim (``from_cli_store=True``)
+# that rests on agent file tools being unable to write the store, and that
+# fence (``_SENSITIVE_HOME_DIRS``) is home-anchored at exactly this path — so
+# an APPDATA-resolved location either equals this entry or falls outside the
+# fence and must not be trusted. A redirected Roaming profile therefore keeps
+# the text-scrape fallback rather than gaining a forgeable trusted path; the
+# same posture as the Linux entry, which does not follow ``XDG_DATA_HOME``
+# redirection either.
 _CLI_SQLITE_DBS = (
     Path.home() / ".local" / "share" / "kiro-cli" / "data.sqlite3",
     Path.home() / "Library" / "Application Support" / "kiro-cli" / "data.sqlite3",
+    Path.home() / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3",
 )
 
 # Auth stores belonging to OTHER products (amazon-q). Readable, and often the same

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -4121,6 +4121,12 @@ _SENSITIVE_HOME_DIRS: list[str] = [
     ".local/share/amazon-q",
     "Library/Application Support/kiro-cli",
     "Library/Application Support/amazon-q",
+    # Windows layout of the same stores (%APPDATA% defaults to
+    # ~/AppData/Roaming). This matcher is home-anchored, so a Roaming profile
+    # redirected outside the home directory is not covered — the default
+    # location is what agent file tools can reach by a fixed relative path.
+    "AppData/Roaming/kiro-cli",
+    "AppData/Roaming/amazon-q",
 ]
 
 # ── KiroCrew's own data-home secrets & governance trust-root ──
@@ -4559,6 +4565,80 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         # ``marker.exists()``) is caught, not just the exact-leaf forms.
         rf"{home_alts}/(?:{wp_prefixes})/(?:{wp_leaves})(?:/|\s|$|['\"])"
     )
+    # Windows-native spellings of the same fenced dirs, matched in the RAW
+    # command text. POSIX shlex consumes unquoted backslashes during
+    # tokenization, and an embedded interpreter script
+    # (``python -c "open(r'C:\\Users\\u\\.aws\\credentials')"``) never
+    # tokenizes into a path at all — so this raw pass, which already catches
+    # embedded scripts for the POSIX spellings above, is the only layer that
+    # can see a native spelling. Anchors: the resolved home literal (on
+    # Windows it contains backslashes), a generic drive-letter home with
+    # either separator, a UNC prefix, ``%USERPROFILE%``, and ``~``/``$HOME``.
+    # Entry-internal separators accept both slashes; naming a fenced dir is
+    # itself the signal (same fail-safe posture as the branches above), so
+    # over-matching an odd mixed-separator spelling is the safe direction.
+    win_sep = r"[\\/]"
+    # Generalized separator: a plain separator, optionally preceded by any
+    # chain of canonical no-ops — single-dot segments (``\.``) and same-level
+    # down-up excursions (``\X\..``). This is what makes traversal spellings
+    # that re-enter the same location match
+    # (``AppData\Roaming\..\Roaming\kiro-cli``: the excursion consumes
+    # ``Roaming\..`` and the literal segment matches the re-entry). A
+    # multi-level ``..`` chain can over-match a path that actually ends
+    # elsewhere — the safe direction for this gate, which blocks on naming
+    # alone. The name run is length-capped to bound backtracking.
+    win_gsep = rf"(?:{win_sep}(?:\.|[^\\/\s'\"]{{1,64}}{win_sep}\.\.))*{win_sep}"
+    win_dirs_pattern = "|".join(
+        win_gsep.join(re.escape(part) for part in d.split("/"))
+        for d in _SENSITIVE_HOME_DIRS
+    )
+    generic_win_home = rf"[A-Za-z]:{win_sep}(?:Users|home){win_sep}[^\\/\s'\"]+"
+    unc_prefix = r"\\\\[^\s'\"]+"
+    # cmd.exe and PowerShell spellings of the profile variable both anchor a
+    # home-relative fenced path. The cmd.exe form tolerates expansion
+    # modifiers (``%USERPROFILE:~0%``, ``%USERPROFILE:a=b%``), and the
+    # PowerShell form is accepted braced (``${env:USERPROFILE}``) or bare —
+    # all expand to the same location. HOMEDRIVE+HOMEPATH concatenated (either
+    # shell's spelling) is the same home by definition.
+    userprofile = (
+        r"(?:%USERPROFILE(?::[^%\s]*)?%"
+        rf"|{re.escape('$env:USERPROFILE')}"
+        rf"|{re.escape('${env:USERPROFILE}')}"
+        r"|%HOMEDRIVE(?::[^%\s]*)?%%HOMEPATH(?::[^%\s]*)?%"
+        rf"|{re.escape('$env:HOMEDRIVE$env:HOMEPATH')}"
+        rf"|{re.escape('${env:HOMEDRIVE}${env:HOMEPATH}')})"
+    )
+    win_home_alts = (
+        f"(?:{home}|{generic_win_home}|{unc_prefix}|{userprofile}|{tilde}|{home_var})"
+    )
+    # Between the anchor and the fenced remainder, accept the same
+    # canonical-no-op chains (``\.\``, ``\X\..\``): they are equivalent to a
+    # plain separator, so ``%APPDATA%\.\kiro-cli\data.sqlite3`` and
+    # ``...\AppData\Roaming\..\Roaming\kiro-cli\...`` still name the store.
+    win_sensitive_path = (
+        rf"{win_home_alts}{win_gsep}(?:{win_dirs_pattern})(?:{win_sep}|\s|$|['\"])"
+    )
+    # ``%APPDATA%`` already points INTO ``AppData\Roaming``, so a spelling like
+    # ``%APPDATA%\kiro-cli\data.sqlite3`` names a fenced store WITHOUT the
+    # ``AppData\Roaming`` text the branch above anchors on. Map the variable
+    # directly onto that prefix: entries under ``AppData/Roaming/`` are matched
+    # by their remainder.
+    appdata_var = (
+        r"(?:%APPDATA(?::[^%\s]*)?%"
+        rf"|{re.escape('$env:APPDATA')}"
+        rf"|{re.escape('${env:APPDATA}')})"
+    )
+    appdata_remainders = "|".join(
+        win_gsep.join(re.escape(part) for part in d.split("/")[2:])
+        for d in _SENSITIVE_HOME_DIRS
+        if d.startswith("AppData/Roaming/")
+    )
+    # ``%APPDATA%`` ends in ``Roaming`` by definition, so ``\..\Roaming``
+    # right after it is a canonical no-op specific to this anchor.
+    appdata_sensitive_path = (
+        rf"{appdata_var}(?:{win_sep}\.\.{win_sep}Roaming)*"
+        rf"{win_gsep}(?:{appdata_remainders})(?:{win_sep}|\s|$|['\"])"
+    )
     return re.compile(
         # (1) verb/redirect-anchored, OR (2) verb-independent: the sensitive path
         # appears anywhere as a token.  The token anchor accepts start-of-string
@@ -4573,7 +4653,13 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         rf"(?:(?:{_READ_CMDS}.*|{_WRITE_CMDS}.*|{_SCRIPT_OPEN}.*|.*[<>|]\s*)"
         rf"{sensitive_path}"
         rf"|(?:^|.*[\s'\"=:,;]){sensitive_path}"
-        rf"|(?:^|.*[\s'\"=:,;]){write_protected_path})",
+        rf"|(?:^|.*[\s'\"=:,;]){write_protected_path}"
+        # (4) Windows-native spelling, verb-independent (same token anchor):
+        # covers quoted backslash paths AND embedded-script literals that the
+        # tokenizing passes cannot see. (5) the %APPDATA% alias of the fenced
+        # Roaming stores.
+        rf"|(?:^|.*[\s'\"=:,;]){win_sensitive_path}"
+        rf"|(?:^|.*[\s'\"=:,;]){appdata_sensitive_path})",
         re.IGNORECASE,
     )
 
@@ -4981,8 +5067,16 @@ _EXTRACT_INTO_TRUST_ROOT_RE = re.compile(
 # the CREATION verbs (``ln``, ``cp -s``/``--symbolic-link``) when any token
 # names a sensitive dir via dot-slash traversal.
 _SENSITIVE_SEGMENT_ALT = "|".join(re.escape(d) for d in _SENSITIVE_HOME_DIRS)
+# Same alternation with either separator accepted between segments, so the
+# Windows-native relative spelling (``..\..\.aws\credentials``) is caught by
+# the traversal matcher below alongside the POSIX one. Forward-slash-only
+# entries still match (the class includes ``/``), so this strictly widens.
+_SENSITIVE_SEGMENT_ALT_ANYSEP = "|".join(
+    r"[\\/]".join(re.escape(part) for part in d.split("/"))
+    for d in _SENSITIVE_HOME_DIRS
+)
 _RELATIVE_SENSITIVE_RE = re.compile(
-    rf"(?:^|[\s'\"=:,;])(?:\.\.?/)+(?:{_SENSITIVE_SEGMENT_ALT})(?:/|\s|$|['\"])",
+    rf"(?:^|[\s'\"=:,;])(?:\.\.?[\\/])+(?:{_SENSITIVE_SEGMENT_ALT_ANYSEP})(?:[\\/]|\s|$|['\"])",
     re.IGNORECASE,
 )
 
@@ -7729,6 +7823,27 @@ def resolve_command_paths(tokens: list[str]) -> list[str]:
     return resolved
 
 
+# Drive-letter absolute path (``C:\...`` or ``C:/...``). Anchored to a single
+# ASCII letter + colon + separator so ``key:value`` option tokens do not match.
+_WIN_DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+def _win_anchor_roots() -> tuple[str, ...]:
+    """Roots whose drive/share anchor Windows-native path recognition.
+
+    The user home, and — when set — ``KIROCREW_HOME``: the keystone leaves are
+    re-anchored under it (see ``_home_dir_targets_uncached``) and it may
+    legitimately live on another drive, so a token on that drive must still be
+    routed to ``is_sensitive_path()``. Lexical only: no ``resolve()``, so no
+    filesystem or network is touched deciding whether to recognize a token.
+    """
+    roots = [str(Path.home())]
+    crew_env = os.environ.get("KIROCREW_HOME")
+    if crew_env:
+        roots.append(os.path.expanduser(crew_env))
+    return tuple(roots)
+
+
 def _is_path_like(token: str) -> bool:
     """Heuristic: does this token look like a filesystem path?"""
     if not token:
@@ -7741,6 +7856,47 @@ def _is_path_like(token: str) -> bool:
         return True
     # Relative with explicit directory prefix
     if token.startswith("./") or token.startswith("../"):
+        return True
+    # Windows-native shapes. The shell tool runs on native Windows, where the
+    # sensitive-path fence compares casefolded ``os.sep``-joined targets — a
+    # backslash spelling must reach ``is_sensitive_path()`` through the
+    # normalizer pass, or every fenced dir is reachable through the shell gate
+    # on Windows hosts. A match on the drive (or UNC share) holding one of the
+    # ``_win_anchor_roots()`` — the user home, and ``KIROCREW_HOME`` when set —
+    # is recognized directly; anything else FALLS THROUGH to
+    # the generic checks below rather than being rejected here. That keeps two
+    # properties at once: a forward-slash spelling on another drive
+    # (``D:/kirocrew/security_policy.json`` under a cross-drive
+    # ``KIROCREW_HOME``) stays path-like exactly as it was before these shapes
+    # were recognized, so the keystone fence is not narrowed — while a
+    # pure-backslash foreign-drive token gains no NEW recognition, since
+    # probing it would only feed ``os.path.realpath`` a disconnected mapped
+    # drive or dead UNC host (a synchronous network stall on the caller).
+    if _WIN_DRIVE_PATH_RE.match(token):
+        token_drive = token[:2].casefold()
+        for root in _win_anchor_roots():
+            if (
+                len(root) >= 3
+                and root[1] == ":"
+                and root[2] in "\\/"
+                and token_drive == root[:2].casefold()
+            ):
+                return True
+    elif token.startswith("\\\\"):
+        token_cf = token.casefold()
+        for root in _win_anchor_roots():
+            if not root.startswith("\\\\"):
+                continue
+            # Compare the ``\\server\share`` prefix (first four ``\``-split
+            # parts: '', '', server, share) at a path-segment boundary, so a
+            # share that merely shares a name prefix (``\\srv\homes-dead``)
+            # is not probed.
+            share = "\\".join(root.casefold().split("\\")[:4])
+            if token_cf == share or token_cf.startswith((share + "\\", share + "/")):
+                return True
+    # Backslash-relative traversal resolves against the CWD (local, no
+    # network), so it stays unconditional.
+    if token.startswith(".\\") or token.startswith("..\\"):
         return True
     # Contains path separator and has directory component (not a flag)
     if "/" in token and not token.startswith("-"):

--- a/test/test_kiro_usage_api.py
+++ b/test/test_kiro_usage_api.py
@@ -9,6 +9,7 @@ import ssl
 import urllib.error
 import urllib.request
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -391,6 +392,71 @@ class TestLoadBearerToken:
              patch.object(api, "_CLI_SQLITE_DBS", (db,)), \
              patch.object(api, "_OTHER_SQLITE_DBS", ()):
             assert api._load_bearer_token() == "idp-tok"
+
+
+class TestWindowsCliStore:
+    """kiro-cli on Windows keeps the same auth store under ``%APPDATA%\\kiro-cli``
+    (``~/AppData/Roaming/kiro-cli`` by default).
+
+    Absent from ``_CLI_SQLITE_DBS``, a Windows host's only candidate was the
+    JSON SSO cache (``from_cli_store=False``), which can never satisfy the
+    provenance path -- so whenever the ARN anchor also failed, every candidate
+    was rejected and the credit pill silently disappeared.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_arn_cache(self):
+        api._PROFILE_ARN_CACHE.clear()
+        api._PROFILE_NAME_CACHE.clear()
+        yield
+        api._PROFILE_ARN_CACHE.clear()
+        api._PROFILE_NAME_CACHE.clear()
+
+    def test_windows_store_is_a_default_candidate(self):
+        # The FIXED default Roaming location, not %APPDATA%-resolved: the
+        # sensitive-path fence that makes membership a trust claim is
+        # home-anchored at exactly this path, so an APPDATA-resolved location
+        # either equals it or falls outside the fence and must not be trusted.
+        expected = Path.home() / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
+        assert expected in api._CLI_SQLITE_DBS
+
+    def test_windows_store_token_is_trusted_without_arn(self, tmp_path):
+        # End-to-end: a token read out of a Windows-layout store carries
+        # from_cli_store=True, so the provenance path accepts it when whoami
+        # reports no profile ARN -- exactly the case that failed with "all 1
+        # candidate credential(s) failed" before the store was a candidate.
+        db = tmp_path / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
+        db.parent.mkdir(parents=True)
+        con = sqlite3.connect(str(db))
+        con.execute("CREATE TABLE auth_kv (key TEXT PRIMARY KEY, value TEXT)")
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        con.execute(
+            "INSERT INTO auth_kv VALUES (?, ?)",
+            ("kirocli:odic:token",
+             json.dumps({"access_token": "win-tok", "expires_at": future})),
+        )
+        con.commit()
+        con.close()
+
+        usage_body = {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 7.0, "usageLimit": 100.0}]}
+
+        def fake_post(token, target, payload):
+            if target == api._TARGET_LIST_PROFILES:
+                return _resp(200, {"profiles": []})
+            return _resp(200, usage_body)
+
+        with patch("kiro_crew.hooks.safe_read_file_internal", return_value=None), \
+             patch("kiro_crew.hooks.emit_internal_read_audit", return_value=True), \
+             patch.object(api, "_CLI_SQLITE_DBS", (db,)), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()), \
+             patch.object(api, "_post", side_effect=fake_post):
+            cands = api._candidate_tokens()
+            assert [c.token for c in cands] == ["win-tok"]
+            assert cands[0].from_cli_store is True
+            out = api.fetch_usage_limits(expected_arn=None)
+        assert out is not None
+        assert out["credits_used"] == 7.0
 
 
 class TestPostSecurityControls:
@@ -1010,7 +1076,7 @@ class TestTokenStoreSensitivePath:
 
         from kiro_crew.security import is_sensitive_path
         home = Path.home()
-        for base in (".local/share", "Library/Application Support"):
+        for base in (".local/share", "Library/Application Support", "AppData/Roaming"):
             for app in ("kiro-cli", "amazon-q"):
                 # The DB and its WAL/SHM/journal sidecars must all be sensitive.
                 assert is_sensitive_path(str(home / base / app / "data.sqlite3"))

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -3668,6 +3668,186 @@ class TestIsSensitiveBashCommand:
         assert canonicalize_ip("8.8.8.8") == "8.8.8.8"
 
 
+class TestWindowsPathShapes:
+    """Native Windows path spellings must be recognized as path-like so the
+    normalizer pass routes them through is_sensitive_path() -- on Windows
+    hosts the fence targets are os.sep-joined, and a backslash spelling that
+    never reaches the check would leave every fenced dir shell-reachable.
+    Recognition is limited lexically to the drive/share holding Path.home():
+    every fenced target lives under home, and a foreign-drive token would only
+    feed realpath a disconnected mapped drive or dead UNC host (a synchronous
+    network stall on the permission gate)."""
+
+    def test_home_drive_paths_are_path_like(self) -> None:
+        from unittest.mock import patch
+
+        with patch.object(security.Path, "home", return_value=Path("C:\\Users\\u")):
+            assert security._is_path_like("C:\\Users\\u\\.aws\\credentials")
+            assert security._is_path_like("c:/Users/u/.aws/credentials")
+
+    def test_foreign_drive_and_unc_are_not_probed(self, monkeypatch) -> None:
+        # A pure-backslash token on another drive/share gains no NEW
+        # recognition; treating it as path-like would only cost a realpath
+        # probe of a possibly-dead network target.
+        from unittest.mock import patch
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        with patch.object(security.Path, "home", return_value=Path("C:\\Users\\u")):
+            assert not security._is_path_like("Z:\\stale\\mapped\\drive")
+            assert not security._is_path_like("\\\\dead-server\\share\\x")
+
+    def test_cross_drive_forward_slash_token_stays_path_like(self) -> None:
+        # KIROCREW_HOME may legitimately live on another drive, and its
+        # keystone leaves are re-anchored there. A forward-slash spelling was
+        # path-like via the generic "/" branch before drive shapes were
+        # recognized -- the foreign-drive check must FALL THROUGH to it, not
+        # intercept it, or the governance ceiling on that drive becomes
+        # shell-reachable.
+        from unittest.mock import patch
+
+        with patch.object(security.Path, "home", return_value=Path("C:\\Users\\u")):
+            assert security._is_path_like("D:/kirocrew/security_policy.json")
+
+    def test_kirocrew_home_drive_anchors_backslash_recognition(self, monkeypatch) -> None:
+        # A BACKSLASH spelling under a cross-drive KIROCREW_HOME must also be
+        # recognized: the keystone leaves are re-anchored under that root, so
+        # its drive is an anchor alongside the user home's.
+        from unittest.mock import patch
+
+        monkeypatch.setenv("KIROCREW_HOME", "D:\\crew")
+        with patch.object(security.Path, "home", return_value=Path("C:\\Users\\u")):
+            assert security._is_path_like("D:\\crew\\security_policy.json")
+            # Drives matching NEITHER root stay unrecognized (no realpath probe).
+            assert not security._is_path_like("Z:\\stale\\mapped\\drive")
+
+    def test_unc_home_share_is_path_like(self, monkeypatch) -> None:
+        from unittest.mock import patch
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        with patch.object(
+            security.Path, "home", return_value=Path("\\\\srv\\homes\\u")
+        ):
+            assert security._is_path_like("\\\\srv\\homes\\u\\.aws\\credentials")
+            assert not security._is_path_like("\\\\other\\share\\x")
+            # A share that merely extends the name past the segment boundary
+            # is a DIFFERENT share -- probing it would realpath a possibly
+            # dead SMB target.
+            assert not security._is_path_like("\\\\srv\\homes-dead\\share\\x")
+
+    def test_backslash_relative_is_path_like(self) -> None:
+        assert security._is_path_like(".\\x\\y")
+        assert security._is_path_like("..\\x\\y")
+
+    def test_drive_shapes_are_inert_on_posix_homes(self, monkeypatch) -> None:
+        # With a POSIX home and no drive-lettered KIROCREW_HOME, no anchor
+        # root has a drive, so drive/UNC tokens are not path-like at all --
+        # no behavior change for POSIX workflows. (KIROCREW_HOME must be
+        # cleared: on Windows CI it is a drive-lettered path and a legitimate
+        # anchor root.)
+        from unittest.mock import patch
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        with patch.object(security.Path, "home", return_value=Path("/home/u")):
+            assert not security._is_path_like("C:\\Users\\u\\.aws\\credentials")
+            assert not security._is_path_like("\\\\server\\share\\x")
+
+    def test_non_path_tokens_stay_non_path_like(self) -> None:
+        # ``key:value`` option tokens and URLs must not become path-like --
+        # the drive-letter form requires a separator right after the colon.
+        assert not security._is_path_like("key:value")
+        assert not security._is_path_like("C:no-separator")
+        assert not security._is_path_like("https://x.example/a")
+
+    def test_native_spelling_is_blocked_in_raw_text_on_any_host(self) -> None:
+        # The raw regex pass sees the command BEFORE tokenization, so it is
+        # the only layer that can catch an embedded interpreter script or a
+        # quoted native spelling -- and it is host-independent, so these must
+        # block everywhere, not just on Windows runners.
+        cmds = [
+            "python -c \"open(r'C:\\Users\\u\\AppData\\Roaming\\kiro-cli\\data.sqlite3','w')\"",
+            "python -c \"open(r'C:\\Users\\u\\.aws\\credentials')\"",
+            "type 'C:\\Users\\u\\.ssh\\id_rsa'",
+            "cat '%USERPROFILE%\\.aws\\credentials'",
+            "type '\\\\srv\\homes\\u\\.ssh\\id_rsa'",
+            "type 'C:/Users/u/.aws/credentials'",
+            # PowerShell spelling of the profile variable.
+            "Get-Content '$env:USERPROFILE\\.aws\\credentials'",
+            # cmd.exe expansion-modifier spelling.
+            "type '%USERPROFILE:~0%\\.ssh\\id_rsa'",
+            # Braced PowerShell spelling.
+            "Get-Content '${env:USERPROFILE}\\.aws\\credentials'",
+            # HOMEDRIVE+HOMEPATH concatenation is the same home by definition.
+            'Get-Content "$env:HOMEDRIVE$env:HOMEPATH\\AppData\\Roaming\\kiro-cli\\data.sqlite3"',
+            "type '%HOMEDRIVE%%HOMEPATH%\\.ssh\\id_rsa'",
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_appdata_alias_of_fenced_store_is_blocked(self) -> None:
+        # %APPDATA% points INTO AppData\Roaming, so this spelling names the
+        # store without the AppData\Roaming text the home-anchored branch
+        # matches on -- it needs its own alias branch.
+        cmds = [
+            'del "%APPDATA%\\kiro-cli\\data.sqlite3"',
+            "type '%APPDATA%\\amazon-q\\data.sqlite3'",
+            "cat '%APPDATA%/kiro-cli/data.sqlite3'",
+            'del "$env:APPDATA\\kiro-cli\\data.sqlite3"',
+            # Single-dot segments are canonical-equivalent to their absence.
+            'cmd /c copy /Y evil.sqlite "%APPDATA%\\.\\kiro-cli\\data.sqlite3"',
+            # cmd.exe expansion modifiers resolve to the same location.
+            'cmd /c copy "%APPDATA:~0%\\kiro-cli\\data.sqlite3" .\\loot.db',
+            # Braced PowerShell spelling.
+            'del "${env:APPDATA}\\kiro-cli\\data.sqlite3"',
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+        # Other %APPDATA% content stays allowed.
+        assert is_sensitive_bash_command('type "%APPDATA%\\SomeApp\\config.json"') is None
+
+    def test_backslash_relative_traversal_is_blocked(self) -> None:
+        assert is_sensitive_bash_command("type ..\\..\\.aws\\credentials") is not None
+        assert (
+            is_sensitive_bash_command(
+                "type ..\\..\\AppData\\Roaming\\kiro-cli\\data.sqlite3"
+            )
+            is not None
+        )
+        # The POSIX spelling keeps matching through the widened alternation.
+        assert is_sensitive_bash_command("dd if=../../.aws/credentials") is not None
+
+    def test_benign_native_spellings_stay_allowed(self) -> None:
+        assert is_sensitive_bash_command("type 'C:\\Users\\u\\project\\readme.md'") is None
+        assert (
+            is_sensitive_bash_command("python -c \"open(r'C:\\temp\\x.txt')\"") is None
+        )
+
+    def test_down_up_traversal_reentry_is_blocked(self) -> None:
+        # A same-level excursion (X\..) is a canonical no-op, so a spelling
+        # that re-enters the fenced location still names it.
+        cmds = [
+            (
+                "python -c \"open(r'C:\\Users\\u\\AppData\\Roaming\\..\\Roaming"
+                "\\kiro-cli\\data.sqlite3','w')\""
+            ),
+            "type 'C:\\Users\\u\\.aws\\..\\.aws\\credentials'",
+            'del "%APPDATA%\\..\\Roaming\\kiro-cli\\data.sqlite3"',
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    @pytest.mark.skipif(
+        os.name != "nt",
+        reason="fence targets are os.sep-joined; the match is only real on Windows",
+    )
+    def test_backslash_spelling_of_fenced_dirs_is_blocked_on_windows(self) -> None:
+        # Single quotes keep the backslashes literal through POSIX shlex, so
+        # the token reaches is_sensitive_path() in its native spelling.
+        home = str(Path.home())
+        for fenced in (".aws\\credentials", "AppData\\Roaming\\kiro-cli\\data.sqlite3"):
+            cmd = f"type '{home}\\{fenced}'"
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+
 class TestDeniedCommandsKeystone:
     """The denied-command opt-out file is a KEYSTONE trust root.
 


### PR DESCRIPTION
Closes #2782

## Problem

On Windows the dashboard credit-usage pill silently disappears. `_CLI_SQLITE_DBS` in `kiro_usage_api.py` lists only the Linux and macOS locations of kiro-cli's SQLite auth store; kiro-cli on Windows keeps the same database at `%APPDATA%\kiro-cli\data.sqlite3`. `_candidate_tokens()` is the only producer of `from_cli_store=True` and sets it exclusively for tokens read from that tuple, so a Windows host's only candidate is the JSON SSO cache (`from_cli_store=False`). That flag is a trust claim: without it, a candidate is usable only when a matching profile ARN independently proves ownership. When the ARN anchor also fails, every candidate is rejected and `fetch_usage_limits` degrades to the disabled-by-default text scrape, matching the reporter's log line ("all 1 candidate credential(s) failed; last: no candidate credential proved it belongs to the signed-in profile").

## Fix

- Add the fixed default Roaming location `~/AppData/Roaming/kiro-cli/data.sqlite3` to `_CLI_SQLITE_DBS`, deliberately **not** resolved from `%APPDATA%`. Membership in the tuple is a trust claim (`from_cli_store=True`) that rests on agent file tools being unable to write the store, and that fence (`_SENSITIVE_HOME_DIRS`) is home-anchored at exactly the default path — so an `%APPDATA%`-resolved location either equals the static entry or falls outside the fence and must not be trusted. Honoring the env var adds zero trustworthy coverage while adding attack surface (env-influenced junction/UNC targets) and import-time filesystem resolution; both were raised as blocking findings by the GPT review bot (rounds 1 and 2) and are eliminated by the static path, which is pure path arithmetic identical in character to the two existing entries. This deviates from the issue/spec suggestion to resolve `%APPDATA%`; the deviation and its rationale are stated here per the spec's own escape hatch (prefer safety at the consumption site over blind env resolution).
- The tuple stays UNGUARDED by `sys.platform`, matching the existing entries. Rationale: every candidate path is existence-checked before it is opened, so a path that cannot exist on the running OS is inert, and a platform-independent module-level constant is what lets the existing tests patch `_CLI_SQLITE_DBS` directly (this file's tests patch it in 14 places). An import-time platform guard would make the constant differ per host and make those tests platform-dependent.
- Extend the raw-text sensitive regex (`_build_sensitive_regex`) with a Windows-native branch: quoted backslash paths and **embedded interpreter scripts** (`python -c "open(r'C:\\Users\\u\\...')"`) never survive POSIX tokenization as path tokens, so the raw pass — which already catches embedded scripts for POSIX spellings — is the only layer that can see a native spelling. Anchored to the resolved home literal, generic drive-letter homes, UNC prefixes, `%USERPROFILE%`, and `~`/`$HOME`; host-independent, so it blocks everywhere, not only on Windows runners (GPT rounds 3-5).
- Harden the shell gate's path recognition (`security._is_path_like`) with native Windows shapes: drive-letter absolute (`C:\` / `C:/`), UNC (`\\server\share`), and backslash-relative traversal. Raised by GPT review round 3: on a Windows host the fence targets are `os.sep`-joined, but a backslash spelling never reached `is_sensitive_path()` because the normalizer pass only recognized forward-slash tokens — leaving every fenced dir (pre-existing `~/.aws`, `~/.ssh`, the keystone — not just the new entry) reachable through the shell gate on Windows. Recognition is limited lexically to the drive/share holding `Path.home()` — every fenced target lives under home, and a foreign-drive token would only feed `realpath` a disconnected mapped drive or dead UNC host, a synchronous network stall on the permission gate (GPT round 4 finding, fixed as suggested). The unit tests cover the shape recognition everywhere; a `skipif(os.name != "nt")` test asserts the end-to-end block on the Windows CI shards.
- Classify `AppData/Roaming/kiro-cli` and `AppData/Roaming/amazon-q` in `security._SENSITIVE_HOME_DIRS`. This is a deliberate, minimal companion change, not scope creep: the module documents that the trusted store is sensitive-classified so agent file tools cannot reach it — that unreachability is the premise that makes `from_cli_store=True` a provenance proof. Adding a trusted path without the matching classification would let an agent file-write a fake DB at a fixed relative path and forge provenance on Windows hosts.

Known residual (documented in code comments): a redirected Roaming profile (%APPDATA% pointing elsewhere) is not followed — those hosts keep the pre-fix behavior (pill falls back to the text scrape) rather than gaining a forgeable trusted path. This mirrors the pre-existing posture on Linux, where the tuple hardcodes `~/.local/share` and does not follow `XDG_DATA_HOME` redirection either.

## Tests

New `TestWindowsCliStore` (2 tests) + Windows layout added to the existing `TestTokenStoreSensitivePath` loop:

- the fixed Windows store path is a member of the default `_CLI_SQLITE_DBS`
- end-to-end: a token read from a Windows-layout store carries `from_cli_store=True` and is accepted by `fetch_usage_limits(expected_arn=None)` via the provenance path — exactly the case that previously failed
- `is_sensitive_path` covers the Windows store dirs and their WAL sidecars

**Fail-before verified**: with `src/` reverted to origin/main, the membership and sensitive-classification tests fail; with the fix applied, the full `test_kiro_usage_api.py` file passes (80 tests). The end-to-end provenance test passes on main by construction (it patches `_CLI_SQLITE_DBS` per the file's established pattern — the defect was membership, which the membership test locks).

## Gates

- isort, flake8 (changed files clean; repo-wide findings are pre-existing local-plugin noise), mypy (no errors in changed files), brand-name gate
- Full pytest: 42,127 passed; 77 failures are pre-existing on this host (no-userns sandbox environment), verified identical on the unmodified tree
- Pre-push review: spawn_run unavailable in this session (known symptom); contract-driven self-review against both reviewer charters performed, 0 blocking findings — server-side review bots are the authoritative gate
