### PR TITLE
feat: make artifact viewer header bar sticky while scrolling

### DIFF
--- a/website/src/pages/ArtifactDetailPage.tsx
+++ b/website/src/pages/ArtifactDetailPage.tsx
@@ -1339,7 +1339,9 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
     const msg = detailQuery.error instanceof Error ? detailQuery.error.message : String(detailQuery.error)
     return (
       <>
-        <PageHeader title={i18nT('pages.artifactDetailPage.artifact')} subtitle={slug} />
+        <div className="sticky top-0 z-10 bg-bg border-b border-border">
+          <PageHeader title={i18nT('pages.artifactDetailPage.artifact')} subtitle={slug} />
+        </div>
         <div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0">
           <Card>
             <div className="flex items-start gap-3">
@@ -1381,35 +1383,35 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
 
   return (
     <>
-      <PageHeader
-        title={renaming ? (
-          <Input
-            autoFocus
-            value={nameDraft}
-            aria-label={i18nT('pages.artifactDetailPage.artifact_name')}
-            onChange={(e) => setNameDraft(e.target.value)}
-            onBlur={commitRename}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') { e.preventDefault(); void commitRename() }
-              else if (e.key === 'Escape') { e.preventDefault(); setRenaming(false) }
-            }}
-            className="px-2 py-0.5 text-2xl font-bold tracking-tight text-text-strong w-full max-w-[36rem]"
-          />
-        ) : (
-          <Btn
-            ref={titleButtonRef}
-            onClick={startRenaming}
-            title={i18nT('pages.artifactDetailPage.rename_this_artifact')}
-            className="group gap-2 bg-transparent border-none p-0 text-2xl font-bold tracking-tight text-text-strong cursor-text hover:bg-transparent hover:border-none"
-          >
-            {artifact.name}
-            <Pencil size={14} className="text-muted opacity-0 group-hover:opacity-100 transition-opacity shrink-0" aria-hidden="true" />
-          </Btn>
-        )}
-        subtitle={i18nT('pages.artifactDetailPage.artifact_slug', { slug: artifact.slug })}
-      />
-      <div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0">
-        <div className="flex flex-wrap items-center gap-2 mb-4">
+      <div className="sticky top-0 z-10 bg-bg border-b border-border">
+        <PageHeader
+          title={renaming ? (
+            <Input
+              autoFocus
+              value={nameDraft}
+              aria-label={i18nT('pages.artifactDetailPage.artifact_name')}
+              onChange={(e) => setNameDraft(e.target.value)}
+              onBlur={commitRename}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') { e.preventDefault(); void commitRename() }
+                else if (e.key === 'Escape') { e.preventDefault(); setRenaming(false) }
+              }}
+              className="px-2 py-0.5 text-2xl font-bold tracking-tight text-text-strong w-full max-w-[36rem]"
+            />
+          ) : (
+            <Btn
+              ref={titleButtonRef}
+              onClick={startRenaming}
+              title={i18nT('pages.artifactDetailPage.rename_this_artifact')}
+              className="group gap-2 bg-transparent border-none p-0 text-2xl font-bold tracking-tight text-text-strong cursor-text hover:bg-transparent hover:border-none"
+            >
+              {artifact.name}
+              <Pencil size={14} className="text-muted opacity-0 group-hover:opacity-100 transition-opacity shrink-0" aria-hidden="true" />
+            </Btn>
+          )}
+          subtitle={i18nT('pages.artifactDetailPage.artifact_slug', { slug: artifact.slug })}
+        />
+        <div className="px-6 py-2 flex flex-wrap items-center gap-2">
           {!popout && (
             <Btn onClick={() => {
               if (dirty && !window.confirm(i18nT('pages.artifactDetailPage.discard_unsaved_changes'))) return
@@ -1691,7 +1693,9 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
             </Btn>
           </span>
         </div>
+      </div>
 
+      <div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0">
         {artifact.description && (
           <div className="mb-3 text-sm text-muted italic">{artifact.description}</div>
         )}

--- a/website/src/pages/RemoteArtifactDetailPage.tsx
+++ b/website/src/pages/RemoteArtifactDetailPage.tsx
@@ -262,7 +262,14 @@ export default function RemoteArtifactDetailPage() {
     const msg = detailQuery.error instanceof Error ? detailQuery.error.message : i18nT('pages.remoteArtifactDetailPage.failed_to_load_remote_artifact')
     return (
       <>
-        <PageHeader title={i18nT('pages.remoteArtifactDetailPage.remote_artifact')} subtitle={externalId} />
+        <div className="sticky top-0 z-10 bg-bg border-b border-border">
+          <PageHeader title={i18nT('pages.remoteArtifactDetailPage.remote_artifact')} subtitle={externalId} />
+          <div className="px-6 py-2 flex flex-wrap items-center gap-2">
+            <Btn onClick={() => navigate('/artifacts')} className="flex items-center gap-1">
+              <ArrowLeft size={13} /> {i18nT('pages.remoteArtifactDetailPage.back')}
+            </Btn>
+          </div>
+        </div>
         <div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0">
           <Card>
             <div className="flex items-start gap-3">
@@ -288,9 +295,9 @@ export default function RemoteArtifactDetailPage() {
 
   return (
     <>
-      <PageHeader title={title} subtitle={i18nT('pages.remoteArtifactDetailPage.remote_artifact_2', { provider })} />
-      <div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0">
-        <div className="flex flex-wrap items-center gap-2 mb-4">
+      <div className="sticky top-0 z-10 bg-bg border-b border-border">
+        <PageHeader title={title} subtitle={i18nT('pages.remoteArtifactDetailPage.remote_artifact_2', { provider })} />
+        <div className="px-6 py-2 flex flex-wrap items-center gap-2">
           <Btn onClick={() => navigate('/artifacts')} className="flex items-center gap-1">
             <ArrowLeft size={13} /> {i18nT('pages.remoteArtifactDetailPage.back')}
           </Btn>
@@ -335,6 +342,8 @@ export default function RemoteArtifactDetailPage() {
             </Btn>
           </span>
         </div>
+      </div>
+      <div className="px-6 pb-8 overflow-y-auto flex-1 min-h-0">
 
         {art.summary && <div className="mb-3 text-sm text-muted italic">{art.summary}</div>}
         {forkError && (

--- a/website/src/test/ArtifactDetailPage.stickyHeader.test.tsx
+++ b/website/src/test/ArtifactDetailPage.stickyHeader.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { Routes, Route } from 'react-router-dom'
+import ArtifactDetailPage from '../pages/ArtifactDetailPage'
+import { renderWithProviders } from './helpers'
+import { api } from '../api/client'
+import type { Artifact } from '../types'
+
+vi.mock('../api/client')
+vi.mock('../pages/ChatPage', () => ({
+  default: () => <div data-testid="chat-page" />,
+  PREFILL_STORAGE_KEY: 'kirocrew_prefill',
+}))
+
+const mkArtifact = (overrides: Partial<Artifact> = {}): Artifact => ({
+  slug: 'cr-queue',
+  name: 'CR Queue',
+  kind: 'widget',
+  source: 'chat',
+  description: 'Hourly CR snapshot',
+  tags: ['ops', 'cr'],
+  version: 2,
+  created_at: '2026-05-21T22:00:00.000000+00:00',
+  updated_at: '2026-05-21T22:30:00.000000+00:00',
+  content: '<div>CR Queue widget body</div>',
+  ...overrides,
+})
+
+function renderRoute() {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/artifacts/:slug" element={<ArtifactDetailPage />} />
+      <Route path="/artifacts" element={<div>library page</div>} />
+    </Routes>,
+    { route: '/artifacts/cr-queue' },
+  )
+}
+
+describe('ArtifactDetailPage — sticky header', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    vi.mocked(api).artifactEvents = vi.fn().mockResolvedValue({ slug: 'cr-queue', events: [] })
+    vi.mocked(api).artifactComments = vi.fn().mockResolvedValue({ comments: [] })
+    vi.mocked(api).chatSlots = vi.fn().mockResolvedValue([])
+    vi.mocked(api).artifact = vi.fn().mockResolvedValue(mkArtifact())
+    vi.mocked(api).artifactVersions = vi.fn().mockResolvedValue({ slug: 'cr-queue', versions: [1, 2] })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('toolbar container has sticky positioning', async () => {
+    renderRoute()
+    await waitFor(() => expect(screen.getByText('CR Queue')).toBeInTheDocument())
+    const backBtn = screen.getByRole('button', { name: /Back/ })
+    // Walk up from the Back button to find the toolbar container with sticky class
+    let el: HTMLElement | null = backBtn.parentElement
+    let foundSticky = false
+    while (el) {
+      if (el.className && el.className.includes('sticky')) {
+        foundSticky = true
+        break
+      }
+      el = el.parentElement
+    }
+    expect(foundSticky).toBe(true)
+  })
+
+  it('Back button is NOT inside the scrollable area', async () => {
+    renderRoute()
+    await waitFor(() => expect(screen.getByText('CR Queue')).toBeInTheDocument())
+    const backBtn = screen.getByRole('button', { name: /Back/ })
+    // The Back button must not be nested inside an overflow-y-auto container
+    const scrollParent = backBtn.closest('.overflow-y-auto')
+    expect(scrollParent).toBeNull()
+  })
+
+  it('toolbar and scrollable content area are siblings', async () => {
+    renderRoute()
+    await waitFor(() => expect(screen.getByText('CR Queue')).toBeInTheDocument())
+    const backBtn = screen.getByRole('button', { name: /Back/ })
+    // Find the sticky toolbar container (ancestor of Back button with 'sticky')
+    let toolbar: HTMLElement | null = backBtn.parentElement
+    while (toolbar && !toolbar.className?.includes('sticky')) {
+      toolbar = toolbar.parentElement
+    }
+    expect(toolbar).not.toBeNull()
+
+    // The scrollable content area should be a sibling of the toolbar
+    const parent = toolbar!.parentElement!
+    const children = Array.from(parent.children)
+    const scrollableChild = children.find(
+      (child) => child.className?.includes('overflow-y-auto'),
+    )
+    expect(scrollableChild).toBeDefined()
+    expect(children).toContain(toolbar)
+    expect(children).toContain(scrollableChild)
+    // They must be distinct (toolbar ≠ scrollable)
+    expect(toolbar).not.toBe(scrollableChild)
+  })
+})


### PR DESCRIPTION
## Problem

The artifact viewer's top navigation bar (back button, type selector, tags, and action toolbar) scrolls out of view when reading long content. Users have to scroll all the way back to the top to navigate away or access toolbar actions.

## Why it matters

Basic document-viewer usability — when deep in a long artifact, the toolbar should always be reachable. Scrolling to the top every time is friction that compounds across every reading session, for both markdown/text artifacts and HTML widget artifacts.

## Fix

**Symptom:** Header disappears on scroll.
**Root cause:** The toolbar lives inside the `overflow-y-auto` scrollable container, so it participates in the scroll.
**Change:** Move the `PageHeader` + toolbar row outside the scrollable area and wrap them in a `sticky top-0 z-10 bg-bg border-b border-border` container. The scrollable div now contains only the body content.

Applied to both:
- `ArtifactDetailPage.tsx` — the full-page artifact viewer (markdown, text, widget, HTML)
- `RemoteArtifactDetailPage.tsx` — the read-only remote artifact viewer

## Tests

- **New:** `ArtifactDetailPage.stickyHeader.test.tsx` — 3 tests verifying:
  - The toolbar container has `sticky` in its className
  - The Back button is NOT inside an `overflow-y-auto` ancestor
  - The sticky toolbar and scrollable content area are direct siblings
- **Existing:** All 225 existing tests across 8 ArtifactDetailPage test files pass with zero regressions.

## Manual verification

TypeScript compiles clean (`tsc --noEmit` passes). The DOM restructuring preserves all existing functionality — the toolbar buttons, rename, tags, type selector, folder chip, star, and all action buttons remain functional.

## Screenshots

N/A — this is a CSS positioning change (`position: sticky`) with no visual difference at rest. The change is only observable during scroll interaction (the toolbar stays fixed instead of scrolling away), which cannot be demonstrated in a still screenshot.

Closes #2776
