### PR TITLE
fix(docker): prevent load_credentials from re-injecting scrubbed environ

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -104,6 +104,10 @@ for KEY in $CRED_KEYS; do
 done
 
 # ── 2. Sandbox posture (first run only) ──────────────────────────────────
+# Signal to the gateway's load_credentials() that credentials were
+# deliberately scrubbed from the process environ and must NOT be
+# re-injected (which would leak into /proc/<pid>/environ).
+export _KIROCREW_CREDS_SCRUBBED=1
 # By this point the resolver above has already run the product's legacy-home
 # migration if one was pending, so $CONFIG is authoritative: present means
 # operator-owned state (never rewrite), absent means genuine first run.

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -6060,9 +6060,17 @@ class KiroCrewConfig:
         # via Popen's default env=os.environ.copy() — even when their view of
         # ~/.kiro/crew/.env is a bind-mounted empty file. setdefault() preserves
         # any value the caller already set explicitly.
-        for k, v in creds.items():
-            if v:
-                os.environ.setdefault(k, v)
+        #
+        # EXCEPTION: when the Docker entrypoint has deliberately scrubbed
+        # credentials from the process environ (setting _KIROCREW_CREDS_SCRUBBED=1),
+        # re-injecting them here would leak into /proc/<pid>/environ — the exact
+        # attack surface the entrypoint closed. In that case, children that need
+        # credentials get them via their own .env read or via an explicit env=
+        # kwarg on Popen (the sandbox and ACP spawners already do this).
+        if not os.environ.get("_KIROCREW_CREDS_SCRUBBED"):
+            for k, v in creds.items():
+                if v:
+                    os.environ.setdefault(k, v)
 
         return creds
 


### PR DESCRIPTION
## Summary

Fixes the Docker smoke test credential-scrub assertion failure that blocks all PRs touching `core.py`, `server.py`, or `origin.py`.

Closes #2804

## Root cause

The Docker entrypoint deliberately scrubs channel credentials from the process environ:
```
unset SLACK_BOT_TOKEN  # moves to .env, scrubs from environ
```

But `load_credentials()` in `config/loader.py` then reads `.env` and calls:
```python
os.environ.setdefault(k, v)  # re-injects the scrubbed credential!
```

This puts the credential BACK into `/proc/<pid>/environ`, defeating the entrypoint's scrub and failing the smoke test assertion.

## Fix

- **`docker/entrypoint.sh`**: Sets `_KIROCREW_CREDS_SCRUBBED=1` after the credential scrub loop completes.
- **`src/kiro_crew/config/loader.py`**: `load_credentials()` checks this marker and skips the `os.environ.setdefault()` propagation when set.

Non-Docker hosts (no marker) continue working exactly as before — credentials from `.env` are still propagated into environ for child process inheritance via `Popen(env=os.environ.copy())`.

## Testing

- The Docker smoke test (`docker-smoke.yml`) will pass: the gateway's environ no longer contains scrubbed credentials.
- Non-Docker: `_KIROCREW_CREDS_SCRUBBED` is never set outside the Docker entrypoint, so the existing propagation path is unchanged.