### PR TITLE
fix(system): Columns popover clipped behind table in Sessions tab

### DIFF
--- a/website/src/pages/system/SessionsTab.tsx
+++ b/website/src/pages/system/SessionsTab.tsx
@@ -8,6 +8,7 @@
  * grouping, and aggregation come from `@tanstack/react-table`.
  */
 import { type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -325,7 +326,7 @@ export default function SessionsTab({ planeStateRef }: Props) {
   }, [])
 
   return (
-    <Card className="mb-6 overflow-hidden">
+    <Card className="mb-6">
       {/* Stale-data notice. Shown when a poll has failed but a previous payload is
           still on screen: the rows below are real, just not current, and saying so
           is what lets the user trust them without mistaking them for live. */}
@@ -370,12 +371,18 @@ export default function SessionsTab({ planeStateRef }: Props) {
             <Columns3 size={13} aria-hidden="true" className="lucide-inline" />
             {i18nT('pages.sessionsTab.columns')}
           </Btn>
-          {pickerOpen && (
+          {pickerOpen && pickerBtnRef.current && createPortal(
             <div
               ref={pickerRef}
               role="dialog"
               aria-label={i18nT('pages.sessionsTab.columns')}
-              className="absolute right-0 z-20 mt-1 min-w-40 rounded border border-border bg-bg-elevated p-1.5 shadow-lg"
+              className="min-w-40 rounded border border-border bg-bg-elevated p-1.5 shadow-lg"
+              style={{
+                position: 'fixed',
+                zIndex: 9999,
+                top: pickerBtnRef.current.getBoundingClientRect().bottom + 4,
+                right: window.innerWidth - pickerBtnRef.current.getBoundingClientRect().right,
+              }}
             >
               {hideable.map(col => (
                 <label key={col.id} className="flex items-center gap-2 px-1.5 py-1 text-[12px] cursor-pointer">
@@ -392,11 +399,13 @@ export default function SessionsTab({ planeStateRef }: Props) {
                   {i18nT('pages.sessionsTab.done')}
                 </Btn>
               </div>
-            </div>
+            </div>,
+            document.body,
           )}
         </div>
       </div>
 
+      <div className="overflow-hidden rounded-b-lg">
       {isPending ? (
         // "No active sessions" is a claim about the machine, and during the first
         // fetch it is one we cannot make — a slow or failing endpoint made the page
@@ -645,6 +654,7 @@ export default function SessionsTab({ planeStateRef }: Props) {
         )}
       </div>
       )}
+      </div>
     </Card>
   )
 }


### PR DESCRIPTION
## Summary

Fix the Columns picker popover on the System > Sessions tab being rendered behind/clipped by the table rows.

## Problem

Two layered CSS issues caused the popover to be invisible:

1. The `Table` component's wrapper (`<div className="relative w-full overflow-x-auto">`) created a stacking context that painted over the toolbar's popover — no z-index on the popover's parent could overcome this within the same overflow container.
2. The Card's `animate-rise` CSS animation (`transform: translateY(0)`) made the Card a containing block for `position: fixed` descendants, preventing the standard escape-hatch from `overflow: hidden` clipping.

## Fix

Render the Columns picker via `createPortal` into `document.body` with `position: fixed` and coordinates derived from the button's bounding rect. This fully escapes the Card's stacking/overflow/transform context. Also removed the now-unnecessary `overflow-hidden` from the Card (table content is wrapped in its own `overflow-hidden rounded-b-lg` container for corner clipping).

## After

![Columns popover rendering fully above table](https://github.com/RohanK6/KiroCrew/raw/f78b84666d578896f9edbced2d3a771dd4f0a92f/columns-popover-fix-after.png)

## Testing

- All 45 SessionsTab + SystemPage tests pass
- TypeScript clean
- ESLint clean (only pre-existing warnings)
- Frontend build passes

Fixes #2806
