### PR TITLE
fix(tips): stop advertising double-tap Shift as if it were on by default

### DIFF
--- a/src/kiro_crew/data/tips_curated.json
+++ b/src/kiro_crew/data/tips_curated.json
@@ -15,10 +15,11 @@
       "id": "command-palette",
       "feature": "Command Palette",
       "title": "Jump anywhere with ⌘K",
-      "body": "Press **⌘K** (**Ctrl+K**), or double-tap **Shift**, to open Search Everywhere — sessions, pages, skills, prompts, artifacts, settings, and runnable actions in one box.",
+      "body": "Press **⌘K** (**Ctrl+K**) to open Search Everywhere — sessions, pages, skills, prompts, artifacts, settings, and runnable actions in one box. Prefer the IntelliJ-style double-tap **Shift**? Turn it on in **Settings › Shortcuts**.",
       "why": "",
       "doc": "",
-      "cta_prompt": ""
+      "cta_prompt": "",
+      "action": { "kind": "route", "label": "Open Shortcuts settings", "route": "/settings?tab=shortcuts" }
     },
     {
       "id": "steer-or-queue",

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -1616,13 +1616,14 @@ class TestCuratedTips:
         for tid in (
             "split-view", "interface-cli-mode", "warm-pool", "mcp-gateway",
             "subagent-parallelism", "zero-token-cron", "dev-fleet", "app-store",
+            "command-palette",
         ):
             action = tips[tid].get("action")
             assert action is not None, f"{tid} should have an action"
             assert _sanitize_tip_action(action) == action, f"{tid} action must be valid"
             assert action["route"].startswith("/")
         # Features with no in-dashboard destination render body only (no button).
-        for tid in ("command-palette", "steer-or-queue", "local-telemetry"):
+        for tid in ("steer-or-queue", "local-telemetry"):
             assert "action" not in tips[tid], f"{tid} must not carry an action"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The curated **Jump anywhere with ⌘K** tip still tells users to *double-tap Shift* to open Search Everywhere:

> Press **⌘K** (**Ctrl+K**), or double-tap **Shift**, to open Search Everywhere — …

But double-Shift has been **opt-in** since the activation default moved to `mod-k` (`DEFAULT_QUICK_SEARCH_CONFIG` in `website/src/lib/quickSearchShortcut.ts`): remote-desktop sessions (RDP/ICA/PCoIP) were found to synthesize spurious repeat Shift events that opened the palette by themselves, so `useCommandPalette` only honors the gesture when `mode === 'double-shift'`. The tip was never updated when the default moved.

Observed exactly as designed to fail: a user reads the tip, double-taps Shift, and nothing happens.

## Fix

- Reword the tip body to lead with ⌘K/Ctrl+K and present double-Shift as the opt-in it is, pointing at **Settings › Shortcuts**.
- Add the `action` route button (`/settings?tab=shortcuts`) — per this file's own convention (its `_comment` header) that tips whose feature has a navigable destination carry a one-click action. Previously the tip described only keyboard gestures, so it had none; now its call-to-action is a Settings row.
- Move `command-palette` from the no-action group to the has-action group in `test_shipped_curated_actions_match_capable_features`.

## Testing

- `test/test_tips.py`: 119 passed (includes the updated capability test and curated-tip validation).
- isort / flake8 clean on the touched test file; mypy reports only 4 pre-existing errors on untouched lines (identical on clean main).
- `tips_curated.json` parses; new body is 229 chars (limit 1000); action validates against `_sanitize_tip_action` (internal route, known kind, label ≤ 40).