### PR TITLE
fix(mcp-apps): honor SEP-1865's visibility default for app tool calls

### DIFF
--- a/src/kiro_crew/mcp_gateway/app_call.py
+++ b/src/kiro_crew/mcp_gateway/app_call.py
@@ -11,11 +11,13 @@ gateway side:
    recover ``{server, session_key}``; a caller that cannot name a live spool
    id gets nothing. No server names or session keys are trusted from the
    HTTP layer.
-2. **Visibility enforcement** — the target tool must declare
-   ``_meta.ui.visibility`` including ``"app"`` in the backend's ``tools/list``
-   (fetched FRESH per call — an authorization input is never cached, so a
-   server-side visibility revocation takes effect immediately). Tools without an
-   explicit visibility are model-only per SEP-1865 and are refused.
+2. **Visibility enforcement** — the target tool's ``_meta.ui.visibility`` in the
+   backend's ``tools/list`` must admit the ``"app"`` audience (fetched FRESH per
+   call — an authorization input is never cached, so a server-side visibility
+   revocation takes effect immediately). Per SEP-1865 ``visibility`` defaults to
+   ``["model", "app"]``, so a tool that declares nothing IS app-callable; only an
+   explicit declaration excluding ``"app"``, or one this host cannot parse, is
+   refused.
 3. **Argument validation** — the iframe-controlled ``arguments`` are
    validated against the tool's declared ``inputSchema`` (fail-closed; see
    :func:`kiro_crew.validation.validate_mcp_tool_arguments`) before any
@@ -44,6 +46,7 @@ from typing import Any, Optional
 
 from kiro_crew.mcp_apps_render import load_spool
 from kiro_crew.mcp_caller import CallerContext
+from kiro_crew.mcp_gateway.apps import AUDIENCE_APP, visibility_allows
 from kiro_crew.sel import SecurityEventLog
 from kiro_crew.validation import ValidationError, validate_mcp_tool_arguments
 
@@ -157,15 +160,16 @@ async def _tools_by_name(
 
 
 def _tool_visible_to_app(tool: dict[str, Any]) -> bool:
-    """True iff the tool's ``_meta.ui.visibility`` explicitly includes "app".
+    """True iff an app from this server may call ``tool``.
 
-    Per SEP-1865 a tool with no declared visibility defaults to model-only,
-    so absence of ``_meta.ui.visibility`` is a DENY.
+    SEP-1865: ``visibility`` defaults to ``["model", "app"]`` when omitted, so a
+    tool that declares nothing IS app-callable. Only an explicit declaration
+    that excludes ``"app"`` — or one this host cannot parse — denies.
+
+    Delegates to :func:`visibility_allows`, the same parser the agent-listing
+    filter uses, so the two audiences cannot drift apart.
     """
-    meta = tool.get("_meta")
-    ui = meta.get("ui") if isinstance(meta, dict) else None
-    vis = ui.get("visibility") if isinstance(ui, dict) else None
-    return isinstance(vis, list) and "app" in vis
+    return visibility_allows(tool, AUDIENCE_APP).allowed
 
 
 def _governance_denial(

--- a/src/kiro_crew/mcp_gateway/apps.py
+++ b/src/kiro_crew/mcp_gateway/apps.py
@@ -236,6 +236,115 @@ class WithheldTools(NamedTuple):
         return bool(self.declared or self.unreadable)
 
 
+#: The audiences SEP-1865 defines for ``_meta.ui.visibility``.
+AUDIENCE_MODEL = "model"
+AUDIENCE_APP = "app"
+
+
+class VisibilityVerdict(NamedTuple):
+    """How :func:`visibility_allows` read a tool's ``_meta.ui.visibility``."""
+
+    #: True when this audience may see/call the tool.
+    allowed: bool
+    #: True when the server DID set ``visibility`` but this host could not parse
+    #: it. Distinguishes "the server said no" from "we could not tell", which
+    #: the caller logs differently.
+    unreadable: bool
+
+
+def visibility_allows(tool: Any, audience: str) -> VisibilityVerdict:
+    """Decide whether ``audience`` may reach ``tool`` per its declared visibility.
+
+    ONE parser for BOTH directions — the agent's ``tools/list`` (audience
+    ``"model"``) and an app's ``tools/call`` (audience ``"app"``). They were
+    separate implementations with *opposite* defaults, and the app-side one
+    denied on absence while claiming the spec required it. The spec says the
+    opposite, so the two are now the same function and cannot drift again.
+
+    How each shape of ``visibility`` is read:
+
+    ==========================  ==============================================
+    ``visibility``              Verdict
+    ==========================  ==============================================
+    absent                      ALLOW — spec default is ``["model", "app"]``
+    ``["model", "app"]``        ALLOW for both
+    ``["app"]``                 ALLOW app, DENY model
+    ``["model"]``               ALLOW model, DENY app
+    ``[]``                      DENY both — an explicit empty audience list
+    ``"app"`` (bare string)     read as ``["app"]``
+    present, uninterpretable    DENY both, flagged ``unreadable``
+    ``_meta``/``ui`` = ``null``  ALLOW — a null container is an unset optional
+    ``_meta``/``ui`` not a dict  DENY both, flagged ``unreadable``
+    ==========================  ==============================================
+
+    Only ABSENCE gets the permissive default, and absence is distinguished from
+    malformation at EVERY level, not just the leaf:
+
+    * ``_meta`` missing, or present-and-a-dict with no ``ui`` key, or ``ui``
+      present-and-a-dict with no ``visibility`` key → genuine absence → allow.
+    * ``_meta`` or ``ui`` explicitly ``null`` → also absence. A JSON ``null`` is
+      how serializers spell an unset optional object, and it cannot conceal a
+      declaration, so the reason non-dict containers deny does not apply.
+    * ``_meta`` or ``ui`` present as some OTHER non-dict → the container that
+      would hold the declaration is unreadable, so a visibility may well be in
+      there and we cannot see it → deny, flagged ``unreadable``.
+    * ``visibility`` present but unparseable → deny, flagged ``unreadable``.
+
+    Absence is tested by key presence rather than by value, so an explicit
+    ``"visibility": null`` is a declaration this host cannot read rather than an
+    omission — ``.get()`` cannot tell those apart.
+
+    KNOWN DIVERGENCE, pre-existing and deliberately unchanged here: the C#
+    reference SDK documents ``null`` and ``[]`` on ``visibility`` ITSELF as
+    "visible to both the model and the app by default". This host denies both
+    for those two shapes, as it did before this function existed. The SEP text
+    grants the default to an OMITTED field, and an explicitly empty audience
+    list reads as a deliberate exclusion, so the conservative reading is kept
+    rather than widened as a side effect of an unrelated fix. Worth settling
+    separately — it is a conformance question, not an oversight.
+
+    Bare strings are coerced rather than lumped in with the unreadable values,
+    because the realistic typo for this field is a scalar instead of a
+    one-element list; blanket-denying every malformed value would hide a tool
+    whose author wrote ``"model"`` meaning to expose it.
+
+    Anything present-but-unreadable denies both audiences: it is an attempt to
+    restrict the tool that this host cannot honor, and the errors are not
+    symmetric. Over-denying is loud (the name is logged, the tool is simply
+    absent) while under-denying silently lets a tool run without readable
+    authorization metadata.
+    """
+    if not isinstance(tool, dict):
+        return VisibilityVerdict(False, False)
+    if "_meta" not in tool:
+        # SEP-1865: ``visibility`` defaults to ``["model", "app"]`` when omitted.
+        return VisibilityVerdict(True, False)
+    meta = tool["_meta"]
+    # An explicit ``null`` CONTAINER is absence, not malformation. JSON
+    # serializers routinely emit ``"_meta": null`` for an unset optional
+    # object, and the reason non-dict containers deny — a declaration could be
+    # hiding in there — does not apply to ``null``, which cannot hold one.
+    # Denying it would drop every tool from such a server.
+    if meta is None:
+        return VisibilityVerdict(True, False)
+    if not isinstance(meta, dict):
+        return VisibilityVerdict(False, True)
+    if "ui" not in meta:
+        return VisibilityVerdict(True, False)
+    ui = meta["ui"]
+    if ui is None:
+        return VisibilityVerdict(True, False)
+    if not isinstance(ui, dict):
+        return VisibilityVerdict(False, True)
+    if "visibility" not in ui:
+        return VisibilityVerdict(True, False)
+    raw = ui["visibility"]
+    vis = [raw] if isinstance(raw, str) else raw
+    if not isinstance(vis, list):
+        return VisibilityVerdict(False, True)
+    return VisibilityVerdict(audience in vis, False)
+
+
 def strip_model_hidden_tools(result: dict) -> WithheldTools:
     """Remove tools the agent may not see from a ``tools/list`` result IN PLACE.
 
@@ -244,33 +353,8 @@ def strip_model_hidden_tools(result: dict) -> WithheldTools:
     names split by cause, so the caller can log an unreadable declaration more
     loudly than a well-formed one.
 
-    How each shape of ``visibility`` is read:
-
-    ==========================  ==========================================
-    ``visibility``              Verdict
-    ==========================  ==========================================
-    absent                      KEEP — spec default is ``["model", "app"]``
-    ``["model", ...]``          KEEP
-    ``["app"]`` / ``[]``        DROP — explicit list without "model"
-    ``"model"`` (bare string)   KEEP — read as ``["model"]``
-    ``"app"`` (bare string)     DROP — read as ``["app"]``
-    present, uninterpretable    DROP
-    ==========================  ==========================================
-
-    Only ABSENCE gets the permissive default. A present-but-unreadable value is
-    an attempt to restrict the tool that this host cannot parse, and the two
-    errors are not symmetric: an over-drop is loud (the name is logged and the
-    tool simply does not appear) while a leak silently hands the model a tool
-    the server withheld, which it may then execute.
-
-    Bare strings are coerced rather than lumped in with the unreadable values,
-    because the realistic typo for this field is a scalar instead of a
-    one-element list — and blanket-dropping every malformed value would discard
-    a tool whose author wrote ``"model"`` meaning to expose it.
-
-    Note this is the OPPOSITE default from the app-call direction in
-    :mod:`kiro_crew.mcp_gateway.app_call`, which denies unless ``"app"`` is
-    explicitly present.
+    Every shape of ``visibility`` is read by :func:`visibility_allows`, which
+    the app-call direction shares — see that docstring for the full table.
     """
     tools = result.get("tools")
     if not isinstance(tools, list):
@@ -282,25 +366,13 @@ def strip_model_hidden_tools(result: dict) -> WithheldTools:
         if not isinstance(tool, dict):
             kept.append(tool)
             continue
-        meta = tool.get("_meta")
-        ui = meta.get("ui") if isinstance(meta, dict) else None
-        # Absence is the ONLY permissive case, so it is tested by key presence
-        # rather than by value — an explicit ``"visibility": null`` is a
-        # declaration this host cannot read, not an omission.
-        if not isinstance(ui, dict) or "visibility" not in ui:
+        verdict = visibility_allows(tool, AUDIENCE_MODEL)
+        if verdict.allowed:
             kept.append(tool)
             continue
-        raw = ui["visibility"]
-        vis = [raw] if isinstance(raw, str) else raw
-        if isinstance(vis, list):
-            if "model" in vis:
-                kept.append(tool)
-                continue
-            bucket = declared
-        else:
-            bucket = unreadable
         name = tool.get("name")
-        bucket.append(name if isinstance(name, str) else "<unnamed>")
+        label = name if isinstance(name, str) else "<unnamed>"
+        (unreadable if verdict.unreadable else declared).append(label)
     withheld = WithheldTools(declared, unreadable)
     if withheld:
         result["tools"] = kept

--- a/test/fake_mcp_app_server.py
+++ b/test/fake_mcp_app_server.py
@@ -93,6 +93,14 @@ def main() -> int:
                     "inputSchema": {"type": "object", "properties": {}},
                     "_meta": {"ui": {"visibility": ["app"]}},
                 },
+                {
+                    # Declares NO visibility, which is what the majority of real
+                    # servers do — SEP-1865 defaults it to ["model", "app"], so
+                    # it must be BOTH listed to the agent and callable by an app.
+                    "name": "refresh",
+                    "description": "Undeclared-visibility tool (spec default).",
+                    "inputSchema": {"type": "object", "properties": {}},
+                },
             ]})
         elif method == "tools/call":
             params = msg.get("params") or {}
@@ -111,6 +119,10 @@ def main() -> int:
             elif tool == "save_state":
                 _reply(msg_id, result={
                     "content": [{"type": "text", "text": "state saved"}],
+                })
+            elif tool == "refresh":
+                _reply(msg_id, result={
+                    "content": [{"type": "text", "text": "refreshed"}],
                 })
             else:
                 _reply(msg_id, error={"code": -32602, "message": f"unknown tool {tool!r}"})

--- a/test/test_mcp_apps_call_endpoint.py
+++ b/test/test_mcp_apps_call_endpoint.py
@@ -445,6 +445,85 @@ async def test_app_call_rejects_malformed_frames(apps_flag_on, spool_tmp):
         assert reply["reason"] == want
 
 
+async def test_app_call_allows_tool_with_no_declared_visibility(
+    apps_flag_on, spool_tmp
+):
+    """The bug this PR fixes, against the real fake server.
+
+    ``visibility`` is optional and SEP-1865 defaults it to ``["model", "app"]``,
+    so a server that declares nothing must still accept an app callback. The old
+    gate denied on absence, which broke the spec's Interactive Updates pattern
+    (a rendered app calling a tool to refresh itself) for every default-visibility
+    server — apps rendered but their controls were inert.
+    """
+    live = await _spawn_pooled_server()
+    try:
+        spool_id = _spool_record()
+        frame = {"type": "app-call", "spool_id": spool_id,
+                 "callback_secret": _cbs(spool_id),
+                 "tool": "refresh", "arguments": {}}
+        reply = await handle_app_call(live.pool, frame)
+        assert reply["type"] == "app-result", reply
+        assert reply["result"]["content"][0]["text"] == "refreshed"
+    finally:
+        await live.aclose()
+
+
+async def test_app_call_still_denies_model_only_tool(apps_flag_on, spool_tmp):
+    """Loosening the DEFAULT must not loosen an explicit exclusion."""
+    live = await _spawn_pooled_server()
+    try:
+        from kiro_crew.mcp_gateway import app_call as app_call_mod
+
+        async def _model_only(backend, **_):
+            return {"secret": {"name": "secret",
+                               "inputSchema": {"type": "object", "properties": {}},
+                               "_meta": {"ui": {"visibility": ["model"]}}}}
+
+        spool_id = _spool_record()
+        frame = {"type": "app-call", "spool_id": spool_id,
+                 "callback_secret": _cbs(spool_id),
+                 "tool": "secret", "arguments": {}}
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(app_call_mod, "_tools_by_name", _model_only)
+            reply = await handle_app_call(live.pool, frame)
+        assert reply["type"] == "app-call-rejected"
+        assert reply["reason"] == "tool not app-visible"
+    finally:
+        await live.aclose()
+
+
+async def test_app_call_denies_a_malformed_declaration(apps_flag_on, spool_tmp):
+    """An unreadable declaration must deny on the APP path too.
+
+    The parser bucketed this correctly all along, but nothing drove a malformed
+    declaration through ``handle_app_call``, so the DELEGATION was unpinned: a
+    fail-open of the shape ``v.allowed or v.unreadable`` passed the whole suite.
+    A container this host cannot read may be hiding an exclusion, so admitting
+    it would authorize a call the server may have meant to refuse.
+    """
+    live = await _spawn_pooled_server()
+    try:
+        from kiro_crew.mcp_gateway import app_call as app_call_mod
+
+        async def _unreadable(backend, **_):
+            return {"secret": {"name": "secret",
+                               "inputSchema": {"type": "object", "properties": {}},
+                               "_meta": {"ui": "bad"}}}
+
+        spool_id = _spool_record()
+        frame = {"type": "app-call", "spool_id": spool_id,
+                 "callback_secret": _cbs(spool_id),
+                 "tool": "secret", "arguments": {}}
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(app_call_mod, "_tools_by_name", _unreadable)
+            reply = await handle_app_call(live.pool, frame)
+        assert reply["type"] == "app-call-rejected"
+        assert reply["reason"] == "tool not app-visible"
+    finally:
+        await live.aclose()
+
+
 async def test_app_call_tools_list_is_fetched_fresh_per_call(apps_flag_on, spool_tmp, monkeypatch):
     """Authorization input is never cached: each app call re-fetches
     tools/list, so a server-side visibility revocation takes effect on the
@@ -458,12 +537,15 @@ async def test_app_call_tools_list_is_fetched_fresh_per_call(apps_flag_on, spool
                  "tool": "save_state", "arguments": {}}
         r1 = await handle_app_call(live.pool, frame)
         assert r1["type"] == "app-result"
-        # Simulate the server revoking app visibility: the next tools/list
-        # returns save_state WITHOUT _meta.ui.visibility.
+        # Simulate the server revoking app visibility. The revocation must be an
+        # explicit declaration that EXCLUDES "app" — merely dropping the
+        # visibility key is not a revocation, because SEP-1865 defaults an
+        # undeclared tool to ["model", "app"].
 
         async def _revoked(backend, **_):
             return {"save_state": {"name": "save_state",
-                                   "inputSchema": {"type": "object", "properties": {}}}}
+                                   "inputSchema": {"type": "object", "properties": {}},
+                                   "_meta": {"ui": {"visibility": ["model"]}}}}
 
         monkeypatch.setattr(app_call_mod, "_tools_by_name", _revoked)
         r2 = await handle_app_call(live.pool, frame)

--- a/test/test_mcp_gateway_apps_spool.py
+++ b/test/test_mcp_gateway_apps_spool.py
@@ -32,6 +32,8 @@ import pytest
 from kiro_crew.mcp_caller import CallerContext
 from kiro_crew.mcp_gateway import apps
 from kiro_crew.mcp_gateway.apps import (
+    AUDIENCE_APP,
+    AUDIENCE_MODEL,
     MARKER_PREFIX,
     SCHEMA_VERSION,
     append_marker,
@@ -39,6 +41,7 @@ from kiro_crew.mcp_gateway.apps import (
     spool_dir,
     strip_model_hidden_tools,
     sweep_spool,
+    visibility_allows,
     write_spool,
 )
 from kiro_crew.mcp_gateway.backend import (
@@ -342,6 +345,142 @@ def _tool(name: str, visibility=...) -> dict:
         tool["_meta"] = {"ui": {"visibility": visibility}}
     return tool
 
+
+# --------------------------------------------------------------------------
+# visibility_allows — ONE parser, both audiences
+# --------------------------------------------------------------------------
+
+class TestVisibilityAllows:
+    """SEP-1865 audience semantics, asserted for BOTH directions together.
+
+    The two directions used to be separate implementations with opposite
+    defaults, and the app-side one denied on absence while citing the spec as
+    its reason. Testing them as a table is what keeps them honest.
+    """
+
+    @pytest.mark.parametrize(
+        "vis,model_ok,app_ok",
+        [
+            (...,                  True,  True),   # absent -> spec default
+            (["model", "app"],     True,  True),
+            (["app", "model"],     True,  True),
+            (["model"],            True,  False),
+            (["app"],              False, True),
+            ([],                   False, False),  # explicit empty audience list
+            ("model",              True,  False),  # bare string is coerced
+            ("app",                False, True),
+        ],
+        ids=["absent", "both", "both-reversed", "model-only", "app-only",
+             "empty-list", "bare-model", "bare-app"],
+    )
+    def test_readable_declarations(self, vis, model_ok, app_ok):
+        tool = _tool("t", vis)
+        assert visibility_allows(tool, AUDIENCE_MODEL).allowed is model_ok
+        assert visibility_allows(tool, AUDIENCE_APP).allowed is app_ok
+        assert visibility_allows(tool, AUDIENCE_MODEL).unreadable is False
+        assert visibility_allows(tool, AUDIENCE_APP).unreadable is False
+
+    @pytest.mark.parametrize(
+        "vis",
+        [None, {}, 42, {"app": True}, 0, True],
+        ids=["explicit-null", "empty-dict", "int", "dict", "zero", "bool"],
+    )
+    def test_unreadable_denies_both_audiences(self, vis):
+        """A declaration this host cannot parse denies BOTH sides and is flagged.
+
+        Present-but-unreadable is an attempt to restrict that we cannot honor,
+        so it fails closed in both directions rather than picking a side.
+        """
+        tool = _tool("t", vis)
+        for audience in (AUDIENCE_MODEL, AUDIENCE_APP):
+            verdict = visibility_allows(tool, audience)
+            assert verdict.allowed is False
+            assert verdict.unreadable is True
+
+    def test_absence_is_by_key_not_by_value(self):
+        """``"visibility": null`` is a declaration, not an omission — ``.get()``
+        cannot tell those apart, so presence is tested by key."""
+        assert visibility_allows(_tool("t"), AUDIENCE_APP).allowed is True
+        assert visibility_allows(_tool("t", None), AUDIENCE_APP).allowed is False
+
+    @pytest.mark.parametrize(
+        "tool",
+        [
+            {"name": "t"},                              # no _meta at all
+            {"name": "t", "_meta": {}},                  # _meta dict, no ui
+            {"name": "t", "_meta": {"ui": {}}},          # ui dict, no visibility
+            {"name": "t", "_meta": {"other": 1}},        # unrelated _meta keys
+            {"name": "t", "_meta": {"ui": {"resourceUri": "ui://x"}}},
+        ],
+        ids=["no-meta", "empty-meta", "empty-ui", "unrelated-meta", "ui-without-vis"],
+    )
+    def test_genuine_absence_allows_both(self, tool):
+        """Absence at ANY level is still absence — the spec default applies."""
+        for audience in (AUDIENCE_MODEL, AUDIENCE_APP):
+            verdict = visibility_allows(tool, audience)
+            assert verdict.allowed is True
+            assert verdict.unreadable is False
+
+    @pytest.mark.parametrize(
+        "tool",
+        [
+            {"name": "t", "_meta": "bad"},
+            {"name": "t", "_meta": 42},
+            {"name": "t", "_meta": []},
+            {"name": "t", "_meta": {"ui": "bad"}},
+            {"name": "t", "_meta": {"ui": 42}},
+            {"name": "t", "_meta": {"ui": []}},
+        ],
+        ids=["meta-str", "meta-int", "meta-list", "ui-str", "ui-int", "ui-list"],
+    )
+    def test_malformed_container_denies_both(self, tool):
+        """A present-but-non-dict ``_meta``/``ui`` is NOT absence.
+
+        The container that would hold ``visibility`` is unreadable, so a
+        declaration may well be in there and this host cannot see it. Treating
+        that as absence let a tool run with no readable authorization metadata,
+        which is the same fail-open the leaf-level check already guards against.
+        """
+        for audience in (AUDIENCE_MODEL, AUDIENCE_APP):
+            verdict = visibility_allows(tool, audience)
+            assert verdict.allowed is False
+            assert verdict.unreadable is True
+
+    @pytest.mark.parametrize(
+        "tool",
+        [
+            {"name": "t", "_meta": None},
+            {"name": "t", "_meta": {"ui": None}},
+        ],
+    )
+    def test_null_container_is_absence_not_malformation(self, tool):
+        """A JSON ``null`` container is an unset optional, so the default applies.
+
+        Serializers routinely emit ``"_meta": null`` for an unset optional
+        object. Denying it would withhold EVERY tool from such a server — a
+        worse failure than the deny-on-absence bug this parser exists to fix —
+        and ``null`` cannot conceal a declaration, which is the whole reason a
+        non-dict container denies.
+        """
+        for audience in (AUDIENCE_MODEL, AUDIENCE_APP):
+            verdict = visibility_allows(tool, audience)
+            assert verdict.allowed is True
+            assert verdict.unreadable is False
+
+    def test_non_dict_tool_denies(self):
+        for junk in (None, "tool", 7, []):
+            verdict = visibility_allows(junk, AUDIENCE_APP)
+            assert verdict.allowed is False
+            # Not a metadata problem: there is no tool here to have declared
+            # anything, so this must not be bucketed as an unreadable
+            # declaration. Asserted because the bucketing is otherwise
+            # unobservable and a future caller could rely on it.
+            assert verdict.unreadable is False
+
+
+# --------------------------------------------------------------------------
+# strip_model_hidden_tools
+# --------------------------------------------------------------------------
 
 class TestStripModelHiddenTools:
     def test_drops_app_only_tool(self):


### PR DESCRIPTION
Fixes #2633.

## Problem

`_tool_visible_to_app` denied any tool that did not explicitly declare `_meta.ui.visibility` containing `"app"`, and its docstring justified that with a claim about the spec:

> Per SEP-1865 a tool with no declared visibility defaults to model-only, so absence of `_meta.ui.visibility` is a DENY.

[SEP-1865 Stable 2026-01-26](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx) says the opposite:

```typescript
/** Who can access this tool. Default: ["model", "app"] */
visibility?: Array<"model" | "app">;
```

> `visibility` defaults to `["model", "app"]` if omitted

The default exists *so servers do not have to declare it*. `visibility` is optional and most servers omit it, so the gate refused app callbacks against exactly the servers that follow the spec — breaking the **Interactive Updates** pattern the extension is built around (a rendered app calling a tool to refresh itself, submit a form, re-fetch data). Apps rendered; their controls were inert.

## Change

The two directions were **separate parsers with opposite defaults** — which is how one of them ended up contradicting the spec it cited. They are now one function:

```python
visibility_allows(tool, audience) -> VisibilityVerdict(allowed, unreadable)
```

| `visibility` | model | app |
|---|---|---|
| absent | allow | **allow** ← the fix |
| `["model","app"]` | allow | allow |
| `["app"]` | deny | allow |
| `["model"]` | allow | deny |
| `[]` | deny | deny |
| `"app"` / `"model"` (bare string) | coerced to one-element list | |
| present, uninterpretable | deny (`unreadable`) | deny (`unreadable`) |

Absence is tested by **key presence**, not value, so an explicit `"visibility": null` counts as an unreadable declaration rather than an omission — `.get()` cannot tell those apart. Present-but-unreadable denies both audiences: it is an attempt to restrict that this host cannot honor, and the errors are asymmetric (over-denying is logged and visible; under-denying silently hands out a tool the server withheld).

A **null container** is the one exception, and it matters: `"_meta": null` and `"_meta": {"ui": null}` are how JSON serializers spell an unset optional object, so they count as absence. Treating them as malformation would have withheld *every* tool from such a server — a worse failure than the bug this PR fixes — and `null` cannot conceal a declaration, which is the entire reason a non-dict container denies.

**Known divergence, pre-existing and deliberately not changed here:** the C# reference SDK documents `null` and `[]` on `visibility` *itself* as "visible to both the model and the app by default". This host denies both for those two shapes, exactly as it did before this refactor. The SEP grants the default to an *omitted* field, and an explicitly empty audience list reads as a deliberate exclusion — so the conservative reading is preserved rather than widened as a side effect of an unrelated fix. Worth settling separately; it is a conformance question, not an oversight.

`strip_model_hidden_tools` now delegates to the same helper, so the two audiences cannot drift apart again.

**This tightens the model direction as well, which the earlier revision of this description got wrong.** `main` reads only the leaf, so a tool whose `_meta` or `ui` is present but *not a dict* falls into `not isinstance(ui, dict) → kept` and is exposed to the model:

```python
# origin/main — the container is unreadable, and the tool is KEPT
meta = tool.get("_meta")
ui = meta.get("ui") if isinstance(meta, dict) else None
if not isinstance(ui, dict) or "visibility" not in ui:
    kept.append(tool)
```

A non-dict container may well hold a restriction this host cannot see, so treating it as an omission fails open on exactly the input that signals a problem. `visibility_allows` distinguishes absence from malformation at every level, so that shape now denies both audiences and is reported as `unreadable`. The practical effect on the model direction is narrow — only malformed metadata is affected, never a well-formed declaration or a genuine omission — but it is a behavior change against `main` and not merely a refactor.

## Why this is a narrower loosening than it sounds

Only the **default** moves. An explicit exclusion still denies, and the other four gates on the app-call path are untouched:

1. HMAC `callback_secret` compared against the owner-WS-only secret
2. Exact backend identity by `pool_key.stable_hash()` digest — **cross-server calls remain blocked**, so an app can only ever reach the server that produced it
3. `inputSchema` validation, fail-closed
4. The governance `policy ∩ profile` ceiling — *the same decision applied to model-originated MCP calls*, so an enterprise deny still binds

The principal on both sides is the same server: server X's UI calling server X's tools, where server X authored both. It is not a cross-trust-boundary escalation, which is why the spec makes it the default.

## A third option considered and rejected

The triage comment on #2633 proposed honoring the spec default **only for operator-allowlisted servers**, keeping posture deliberate. I looked at how poolability is actually decided:

```python
is_poolable = entry.get("poolable") is True or name in poolable_servers
```

Both paths are operator-controlled config — `poolable: true` lives in the operator's own MCP entry and is not something a server sets remotely. So the middle option would not separate "operator reviewed" from "not reviewed"; it would draw a line between two places the operator can type the same server name, and produce a two-tier behavior where an app's refresh button works or silently does not depending on which file mentions the server. That is the same silent-inert-app failure this PR fixes, applied to a subset.

Also worth noting: a server must already be poolable for an app to render at all, so every app that exists has passed an operator gate.

## Deliberately NOT in this PR

Design Review's suggestion on #2632 — refuse a *model*-originated `tools/call` for a tool whose visibility omits `"model"` — is **not** here. Re-reading the spec, its only two visibility MUSTs are the `tools/list` filter and the app-side `tools/call` rejection; there is no requirement to police the model direction, and Design Review called it a follow-up. It would touch the hottest path in the gateway (every `tools/call`), so bundling it with an authorization loosening is bad packaging. Worth doing separately.

## A test whose premise was wrong

`test_app_call_tools_list_is_fetched_fresh_per_call` simulated a server revoking app visibility by **dropping the `visibility` key**. Under the corrected semantics that is an omission — i.e. still app-callable — so it was asserting a denial that only held because of the bug. It now revokes with `visibility: ["model"]`, which genuinely excludes the app audience, so the no-cached-authorization property is pinned by a real revocation.

## Verification

- **Revert-verified:** restoring deny-on-absence fails 4 tests, including the end-to-end one.
- New end-to-end test against the real fake server: added a `refresh` tool that declares **no** visibility (modelling the majority of real servers) and asserted an app call to it succeeds. The fake server previously only had explicit-visibility tools, so this gap was untestable.
- New `TestVisibilityAllows` asserts both audiences as one table (8 readable shapes × 2 audiences, 6 unreadable shapes) so a future edit cannot fix one direction and skew the other.
- 215 MCP-apps tests pass · mypy 892 files clean · isort/flake8 clean.
- **Rebased onto current `main` (0 behind) after 116 commits of drift.** The rebase applied without conflict, but `main` had meanwhile reworked `strip_model_hidden_tools`, so the model-direction delta above was re-derived against the new base rather than assumed from the original review round.
- Full backend suite: 42188 passed, 67 pre-existing host-env failures (no OS sandbox backend). Verified pre-existing by reverting both source files to `origin/main` and re-running the failing files: **51 failed / 818 passed either way**, identical.

