### PR TITLE
fix(dashboard): stop Columns popover rendering behind table rows

### DIFF
--- a/website/src/pages/system/SessionsTab.tsx
+++ b/website/src/pages/system/SessionsTab.tsx
@@ -358,7 +358,7 @@ export default function SessionsTab({ planeStateRef }: Props) {
           onChange={e => setFilter(e.currentTarget.value)}
           className="w-[150px]"
         />
-        <div className="relative ml-auto">
+        <div className="relative ml-auto z-30">
           <Btn
             ref={pickerBtnRef}
             type="button"


### PR DESCRIPTION
## Problem

The Columns picker in System → Sessions renders behind the table rows. The popover's positioning parent (`<div class="relative ml-auto">`) has no explicit z-index, while the table wrapper (`<div class="relative w-full overflow-x-auto">`) creates a stacking context that paints above it due to later DOM order.

## Fix

Add `z-30` to the popover's positioning parent so it stacks above the table wrapper.

## Testing

Opened Sessions tab, clicked Columns — popover now renders above the table.

Closes #2806