### PR TITLE
fix(slack): evict a thread's prior owner when relinking (#2794)

### DIFF
--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -387,16 +387,70 @@ class SessionMap:
             if isinstance(sid := entry.get("sid"), str) and sid
         }
 
+    @staticmethod
+    def _is_self_derived(key: str, thread_ts: str) -> bool:
+        """True when *key* derives from *thread_ts* itself (``slack:<ts>``).
+
+        Mirrors the predicate in ``_rebuild_thread_index``: a self-derived
+        claimant is the fork (or a self-link) and holds a contested thread
+        only when nothing else claims it.
+        """
+        return is_channel_session_key(key) and key.endswith(thread_ts)
+
+    def _evict_rival_claimants(self, key: str, thread_ts: str) -> list[str]:
+        """Clear the Slack link fields of every OTHER entry claiming *thread_ts*.
+
+        Returns the evicted keys. Only link fields are cleared (entry and
+        ``sid`` preserved, mirroring ``clear_slack_link``); the caller owns the
+        reverse-index write and the ``_save()``. A self-derived claimant — a
+        channel key whose ts IS the thread — never evicts: the load-time
+        tie-break in ``_rebuild_thread_index`` awards a contested thread to the
+        non-derived session, and stripping that owner's fields here would leave
+        the heal with nothing to restore.
+        """
+        if self._is_self_derived(key, thread_ts):
+            return []
+        evicted: list[str] = []
+        for other_key, other_entry in self._data.items():
+            if other_key != key and other_entry.get("slack_thread_ts") == thread_ts:
+                other_entry.pop("slack_thread_ts", None)
+                other_entry.pop("slack_channel_id", None)
+                evicted.append(other_key)
+        if evicted:
+            logger.info(
+                "Slack thread %s reassigned to session %s from %s",
+                thread_ts,
+                key,
+                ", ".join(evicted),
+            )
+        return evicted
+
     def set_slack_link(self, key: str, thread_ts: str, channel_id: str | None) -> None:
-        """Link a session to a Slack thread. Creates entry if needed."""
+        """Link a session to a Slack thread. Creates entry if needed.
+
+        A thread has at most one owner: a non-derived claim evicts every other
+        entry claiming *thread_ts* (see :meth:`_evict_rival_claimants`), and the
+        eviction lands in the same ``_save()`` as the new claim so a crash
+        between the two cannot persist a two-owner map. A self-derived claim
+        never evicts — the load-time tie-break resolves that contest instead.
+        An empty *thread_ts* is the clear sentinel and neither evicts anyone
+        nor enters the reverse index.
+        """
         key = canonical_key(key)
         entry = self._data.get(key)
+        evicted = self._evict_rival_claimants(key, thread_ts) if thread_ts else []
         if entry:
             if (
                 entry.get("slack_thread_ts") == thread_ts
                 and entry.get("slack_channel_id") == channel_id
             ):
-                self._thread_to_session.setdefault(thread_ts, key)
+                if thread_ts:
+                    if evicted:
+                        self._thread_to_session[thread_ts] = key
+                    else:
+                        self._thread_to_session.setdefault(thread_ts, key)
+                if evicted:
+                    self._save()
                 return
             old_ts = entry.get("slack_thread_ts")
             if old_ts and old_ts != thread_ts:
@@ -409,7 +463,15 @@ class SessionMap:
                 "slack_thread_ts": thread_ts,
                 "slack_channel_id": channel_id,
             }
-        self._thread_to_session[thread_ts] = key
+        if thread_ts:
+            # Same policy as the tie-break: a self-derived claim never
+            # displaces a live owner from the reverse index — it routes the
+            # thread only when nothing else claims it. A non-derived claim
+            # (which just swept its rivals) takes the index outright.
+            if self._is_self_derived(key, thread_ts):
+                self._thread_to_session.setdefault(thread_ts, key)
+            else:
+                self._thread_to_session[thread_ts] = key
         self._save()
 
     def get_slack_link(self, key: str) -> tuple[str | None, str | None]:

--- a/test/test_session_map_unlink.py
+++ b/test/test_session_map_unlink.py
@@ -127,3 +127,163 @@ class TestClearSlackLink:
 
         assert session_map.clear_slack_link("dash:1") is True
         assert session_map.get_slack_link("dash:1") == (None, None)
+
+
+class TestSetSlackLinkEvictsPriorOwner:
+    """Relinking a thread to a new session must strip the prior owner's link.
+
+    Before the eviction, a second link of the same thread_ts to a different
+    key rewrote the reverse index but left the loser's ``slack_thread_ts`` /
+    ``slack_channel_id`` in place — two entries claimed one thread, and the
+    inconsistency was persisted.
+    """
+
+    def test_prior_owner_link_fields_are_cleared(self, session_map):
+        session_map.set("dash:a", "sid-a", provider="claude_code")
+        session_map.set("dash:b", "sid-b", provider="claude_code")
+        session_map.set_slack_link("dash:a", "ts-1", "C-1")
+
+        session_map.set_slack_link("dash:b", "ts-1", "C-1")
+
+        # Loser keeps its entry and sid, but no longer claims the thread.
+        assert session_map.get_slack_link("dash:a") == (None, None)
+        assert session_map.get("dash:a") == "sid-a"
+        # Winner owns the thread in both directions.
+        assert session_map.get_slack_link("dash:b") == ("ts-1", "C-1")
+        assert session_map.get_session_for_thread("ts-1") == "dash:b"
+
+    def test_single_owner_invariant_survives_reload(self, tmp_path):
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            sm = SessionMap()
+            sm.set("dash:a", "sid-a", provider="claude_code")
+            sm.set("dash:b", "sid-b", provider="claude_code")
+            sm.set_slack_link("dash:a", "ts-1", "C-1")
+            sm.set_slack_link("dash:b", "ts-1", "C-1")
+
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            sm2 = SessionMap()
+            assert sm2.get_slack_link("dash:a") == (None, None)
+            assert sm2.get("dash:a") == "sid-a"
+            assert sm2.get_slack_link("dash:b") == ("ts-1", "C-1")
+            assert sm2.get_session_for_thread("ts-1") == "dash:b"
+
+    def test_same_key_same_thread_is_idempotent(self, session_map):
+        session_map.set("dash:a", "sid-a", provider="claude_code")
+        session_map.set_slack_link("dash:a", "ts-1", "C-1")
+        with patch.object(session_map, "_save") as mock_save:
+            session_map.set_slack_link("dash:a", "ts-1", "C-1")
+            mock_save.assert_not_called()
+
+        assert session_map.get_slack_link("dash:a") == ("ts-1", "C-1")
+        assert session_map.get_session_for_thread("ts-1") == "dash:a"
+
+    def test_same_key_new_thread_still_evicts_old_index(self, session_map):
+        session_map.set("dash:a", "sid-a", provider="claude_code")
+        session_map.set_slack_link("dash:a", "ts-1", "C-1")
+
+        session_map.set_slack_link("dash:a", "ts-2", "C-1")
+
+        assert session_map.get_session_for_thread("ts-1") is None
+        assert session_map.get_session_for_thread("ts-2") == "dash:a"
+        assert session_map.get_slack_link("dash:a") == ("ts-2", "C-1")
+
+    def test_eviction_and_claim_land_in_one_save(self, session_map):
+        session_map.set("dash:a", "sid-a", provider="claude_code")
+        session_map.set("dash:b", "sid-b", provider="claude_code")
+        session_map.set_slack_link("dash:a", "ts-1", "C-1")
+        with patch.object(session_map, "_save") as mock_save:
+            session_map.set_slack_link("dash:b", "ts-1", "C-1")
+            assert mock_save.call_count == 1
+
+    def test_prior_owner_missing_entry_is_tolerated(self, session_map):
+        """A dangling reverse-index entry (no backing _data entry) must not crash."""
+        session_map.set("dash:b", "sid-b", provider="claude_code")
+        session_map._thread_to_session["ts-1"] = "dash:ghost"
+
+        session_map.set_slack_link("dash:b", "ts-1", "C-1")
+
+        assert session_map.get_session_for_thread("ts-1") == "dash:b"
+        assert session_map.get_slack_link("dash:b") == ("ts-1", "C-1")
+
+    def test_clear_sentinel_empty_ts_never_evicts(self, session_map, caplog):
+        """set_slack_link(key, "", "") is the displaced-slot clear sentinel.
+
+        It must not evict whoever a stale "" index entry names, must not
+        sweep other displaced entries (which carry ts="" themselves), must
+        not log a phantom reassignment of thread "", and "" must not enter
+        the reverse index.
+        """
+        session_map.set("dash:a", "sid-a", provider="claude_code")
+        session_map.set("dash:b", "sid-b", provider="claude_code")
+        session_map.set("dash:c", "sid-c", provider="claude_code")
+        session_map._thread_to_session[""] = "dash:a"
+        session_map.set_slack_link("dash:a", "ts-2", "C-1")
+        # dash:b was displaced earlier: its entry carries the "" sentinel.
+        session_map.set_slack_link("dash:b", "", "")
+
+        with caplog.at_level("INFO", logger="kiro_crew.session_map"):
+            session_map.set_slack_link("dash:c", "", "")
+
+        assert session_map.get_slack_link("dash:a") == ("ts-2", "C-1")
+        assert session_map.get_session_for_thread("ts-2") == "dash:a"
+        assert session_map.get_session_for_thread("") != "dash:c"
+        # The other displaced entry is not swept by a fellow clear.
+        assert session_map.get_slack_link("dash:b") == ("", "")
+        assert "reassigned" not in caplog.text
+
+    def test_self_derived_claim_does_not_strip_the_owner(self, session_map):
+        """A slack:<ts> self-link must not evict the non-derived owner.
+
+        Neither the owner's fields (the load-time tie-break needs them to
+        heal) nor its live reverse-index routing: a self-link lands mid-turn
+        on the native path while the dashboard owner is live, and stealing
+        the index would route later replies to the fork.
+        """
+        session_map.set("dash:a", "sid-a", provider="claude_code")
+        session_map.set_slack_link("dash:a", "ts-1", "C-1")
+
+        session_map.set_slack_link("slack:ts-1", "ts-1", "C-1")
+
+        assert session_map.get_slack_link("dash:a") == ("ts-1", "C-1")
+        assert session_map.get_session_for_thread("ts-1") == "dash:a"
+
+    def test_self_derived_claim_routes_when_unclaimed(self, session_map):
+        """A lone self-link still enters the reverse index."""
+        session_map.set_slack_link("slack:ts-9", "ts-9", "C-1")
+        assert session_map.get_session_for_thread("ts-9") == "slack:ts-9"
+
+    def test_all_rival_claimants_are_swept(self, session_map):
+        """A legacy map can hold several claimants; a new claim clears them all."""
+        for k in ("dash:a", "dash:b", "dash:c"):
+            session_map.set(k, f"sid-{k[-1]}", provider="claude_code")
+            session_map._data[k]["slack_thread_ts"] = "ts-1"
+            session_map._data[k]["slack_channel_id"] = "C-1"
+        session_map._rebuild_thread_index()
+
+        session_map.set_slack_link("dash:new", "ts-1", "C-1")
+
+        for k in ("dash:a", "dash:b", "dash:c"):
+            assert session_map.get_slack_link(k) == (None, None)
+        assert session_map.get_session_for_thread("ts-1") == "dash:new"
+
+    def test_fast_path_still_sweeps_hidden_rivals(self, session_map):
+        """Re-linking a key whose own fields already match must still clear a
+        rival entry left behind by a pre-fix map."""
+        session_map.set("dash:a", "sid-a", provider="claude_code")
+        session_map.set("dash:b", "sid-b", provider="claude_code")
+        session_map.set_slack_link("dash:b", "ts-1", "C-1")
+        # Simulate a legacy two-claimant map: dash:a also carries the fields.
+        session_map._data["dash:a"]["slack_thread_ts"] = "ts-1"
+        session_map._data["dash:a"]["slack_channel_id"] = "C-1"
+
+        session_map.set_slack_link("dash:b", "ts-1", "C-1")
+
+        assert session_map.get_slack_link("dash:a") == (None, None)
+        assert session_map.get_session_for_thread("ts-1") == "dash:b"
+
+    def test_reassignment_log_only_fires_on_a_real_eviction(self, session_map, caplog):
+        session_map.set("dash:b", "sid-b", provider="claude_code")
+        session_map._thread_to_session["ts-1"] = "dash:ghost"
+        with caplog.at_level("INFO", logger="kiro_crew.session_map"):
+            session_map.set_slack_link("dash:b", "ts-1", "C-1")
+        assert "reassigned" not in caplog.text

--- a/test/test_slack_thread_session_binding.py
+++ b/test/test_slack_thread_session_binding.py
@@ -297,9 +297,20 @@ def test_a_link_created_mid_turn_is_not_clobbered(monkeypatch):
 
 
 def _corrupted_map(session_map, first, second):
-    """Two entries claiming one thread, written in the given order."""
+    """Two entries claiming one thread, written in the given order.
+
+    Writes the corruption directly into ``_data``: ``set_slack_link`` now
+    evicts a thread's prior owner, so it can no longer produce the
+    two-owner state this healing path exists for. The state still occurs
+    in the wild in maps persisted before that eviction existed, which is
+    exactly what these tests simulate.
+    """
     for key in (first, second):
-        session_map.set_slack_link(key, _THREAD_TS, _CHANNEL)
+        key = canonical_key(key)
+        entry = session_map._data.setdefault(key, {"sid": ""})
+        entry["slack_thread_ts"] = _THREAD_TS
+        entry["slack_channel_id"] = _CHANNEL
+    session_map._save()
     session_map._rebuild_thread_index()
     return session_map
 


### PR DESCRIPTION
## Problem

A Slack thread linked to a dashboard session can be silently taken by a second linking attempt. `SessionMap.set_slack_link()` rewrote the `_thread_to_session` reverse index unconditionally but never cleared the prior owner's `slack_thread_ts` / `slack_channel_id`, so after a re-link two entries claimed one thread. The loser had no indication its link was taken, kept its stale fields, and — because the map is persisted — the inconsistency survived restarts.

Closes #2794

## Why it matters

The losing session keeps believing it mirrors to the thread while inbound replies route only to the new owner. The corruption is durable: every restart reloads a map where per-entry fields and the reverse index disagree, and on legacy maps repeated reassignments accumulate claimants indefinitely.

## Fix (symptoms → root cause → change)

Symptom: two entries claim one thread after a re-link. Root cause: the claim path updated the reverse index without evicting the prior owner's per-entry fields. Change: a new `_evict_rival_claimants()` sweeps the link fields from **every** other entry claiming the thread (entry and `sid` preserved, mirroring `clear_slack_link`'s invariant), inside the same mutation and the same `_save()` as the new claim, so a crash cannot persist a two-owner map. The sweep runs before the same-key fast path so a legacy hidden claimant is cleared even when the caller's own fields already match.

Two guards scope the eviction:

- **A self-derived `slack:<ts>` claim never evicts and never displaces a live owner from the reverse index** (it enters the index only via `setdefault`, mirroring the tie-break). The load-time tie-break in `_rebuild_thread_index` awards a contested thread to the non-derived session and needs the loser's fields intact to heal; the native handler's privacy-modifier path still self-links unconditionally mid-turn, so an unguarded eviction or index overwrite would have destroyed the dashboard owner's link or routing.
- **The empty-thread clear sentinel (`set_slack_link(key, "", "")`, used by the dashboard's displaced-slot path) neither evicts anyone nor enters the reverse index.** Previously a stale `""` index entry could cause an unrelated session's live link to be stripped.

The reassignment is logged at info level (thread ts + both keys only), and only when an eviction actually happened.

`_corrupted_map` in the thread-binding tests now writes the two-owner state directly (with `canonical_key`), since `set_slack_link` can no longer produce it — the healing tie-break it exercises exists precisely for maps persisted before this fix.

## Tests

New `TestSetSlackLinkEvictsPriorOwner` class (11 tests) in `test/test_session_map_unlink.py`:

- prior owner's fields cleared; entry + `sid` survive; winner owns both directions
- single-owner invariant survives a reload from disk (the durability half of the bug)
- same-key/same-thread re-link is idempotent (no save); same-key/new-thread still evicts the old index entry
- eviction + claim land in exactly one `_save()`
- multi-claimant legacy maps are fully swept; the fast path sweeps hidden rivals
- the `""` clear sentinel never evicts, never pollutes the index, never logs
- a self-derived claim cannot strip the non-derived owner
- a dangling reverse-index entry is tolerated; the log fires only on a real eviction

All four new branches were mutation-probed (guard disabled → named tests fail; restored → green).

## Manual verification

N/A — unit coverage sufficient: the defect and fix are fully observable through `SessionMap`'s public API plus a disk reload, both exercised by the tests.

## Screenshots

N/A — backend-only change, no UI surface.
