### PR TITLE
fix(pod): serialize write_env_file with pod_name_mutex

### DIFF
--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -100,15 +100,20 @@ def write_env_file(cfg: PodConfig, name: str, updates: dict[str, str]) -> None:
     newlines, so a multi-line value would not round-trip. ``--seed`` is
     user-supplied, so reject a newline-bearing value loudly (fail-closed) rather
     than silently writing an un-parseable file.
+
+    The read-modify-write is wrapped in :func:`pod_name_mutex` so concurrent
+    writers (e.g. ``pod up`` racing the boot it starts) cannot lose each other's
+    keys.
     """
-    data = read_env_file(cfg, name)
-    data.update(updates)
-    for key, val in data.items():
-        if "\n" in val or "\r" in val:
-            raise PodError(f"pod env value for {key!r} must be single-line")
-    cfg.pods_dir.mkdir(parents=True, exist_ok=True)
-    body = "".join(f"{k}='{v}'\n" for k, v in data.items())
-    cfg.env_file(name).write_text(body)
+    with pod_name_mutex(cfg, name):
+        data = read_env_file(cfg, name)
+        data.update(updates)
+        for key, val in data.items():
+            if "\n" in val or "\r" in val:
+                raise PodError(f"pod env value for {key!r} must be single-line")
+        cfg.pods_dir.mkdir(parents=True, exist_ok=True)
+        body = "".join(f"{k}='{v}'\n" for k, v in data.items())
+        cfg.env_file(name).write_text(body)
 
 
 def pin_checkout(cfg: PodConfig, name: str, checkout: Path) -> None:


### PR DESCRIPTION
## Problem

`write_env_file` performs a read-modify-write without holding any lock. When `pod up` writes settings (`CHECKOUT`, `APPROVAL`, `SEED`) and the booting gateway concurrently writes to the same env file, both read the same (or empty) state, and the last writer wins — the first writer's keys are silently lost.

This is not hypothetical: `pod up` starts the unit and writes to the env file, and the boot it triggers writes to the same file — so the two writers overlap by construction on every `pod up`.

## Fix

Wrap the entire read-merge-write critical section in `pod_name_mutex(cfg, name)`, which already exists as the per-pod-name reentrant `flock`. Callers like `start_pod` and `stop_pod` that already hold the mutex won't deadlock — the lock is reentrant (thread-local refcount).

## Testing

Existing tests pass. The race is timing-dependent and not practically testable without injecting delays, but the serialization guarantee is structural: all writers now go through the same exclusive lock.

Closes #2693