### PR TITLE
fix(cli): don't conflate missing FAISS accelerator with nothing indexed

### DIFF
--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -1418,7 +1418,11 @@ def _memory_cmd(args: argparse.Namespace) -> None:
             print(
                 f"  Episodic: {stats['episodic_active']} active, {stats['episodic_deleted']} deleted"
             )
-            print(f"  FAISS index: {stats['faiss_index_size']} vectors")
+            print(f"  Embedded: {stats['embedded_count']}/{stats['episodic_active']}")
+            if stats["faiss_available"]:
+                print(f"  FAISS accelerator: {stats['faiss_index_size']} vectors indexed")
+            else:
+                print("  FAISS accelerator: not installed — stdlib cosine fallback (exact)")
             print(f"  Audit events: {stats['events_count']}")
 
         elif action == "audit":

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -1768,6 +1768,10 @@ class VectorMemoryStore:
             "events_count": row[4],
             "faiss_index_size": faiss_size,
             "embedded_count": row[5],
+            # The FAISS index is an optional in-RAM accelerator (needs both
+            # faiss and numpy); without it, retrieval falls back to an exact
+            # stdlib cosine scan over the same stored embeddings.
+            "faiss_available": _HAS_FAISS and _HAS_NUMPY,
         }
 
     # ── Episodic Helpers ──

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -1341,10 +1341,35 @@ class TestMemoryCli:
                 "episodic_deleted": 2,
                 "faiss_index_size": 10,
                 "events_count": 4,
+                "embedded_count": 7,
+                "faiss_available": True,
             }
             cc._memory_cmd(_ns(mem_action="stats"))
         out = capsys.readouterr().out
-        assert "Semantic: 3 active, 1 deleted" in out and "FAISS index: 10 vectors" in out
+        assert "Semantic: 3 active, 1 deleted" in out
+        assert "Embedded: 7/7" in out
+        assert "FAISS accelerator: 10 vectors indexed" in out
+
+    def test_stats_without_faiss_reports_fallback_not_zero_vectors(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """No accelerator must not read as "nothing indexed" when embeddings exist."""
+        with _MemHarness() as h:
+            h.store.memory_stats.return_value = {
+                "semantic_active": 3,
+                "semantic_deleted": 1,
+                "episodic_active": 228,
+                "episodic_deleted": 2,
+                "faiss_index_size": 0,
+                "events_count": 4,
+                "embedded_count": 228,
+                "faiss_available": False,
+            }
+            cc._memory_cmd(_ns(mem_action="stats"))
+        out = capsys.readouterr().out
+        assert "Embedded: 228/228" in out
+        assert "FAISS accelerator: not installed — stdlib cosine fallback (exact)" in out
+        assert "0 vectors" not in out
 
     def test_audit_with_and_without_findings(self, capsys: pytest.CaptureFixture[str]) -> None:
         with _MemHarness(), patch("kiro_crew.cli_commands.scan_memory", return_value=[]):

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -786,6 +786,9 @@ class TestMemoryStats:
         assert stats["semantic_active"] == 1
         assert stats["episodic_active"] == 1
         assert stats["faiss_index_size"] == 0  # no FAISS without numpy/faiss
+        # Availability of the optional accelerator is reported separately so
+        # callers can distinguish "not installed" from "nothing indexed".
+        assert isinstance(stats["faiss_available"], bool)
 
 
 class TestStemWords:


### PR DESCRIPTION
## Problem

`kirocrew memory stats` prints:

```
  FAISS index: 0 vectors
```

on a store where every episodic memory is fully embedded and retrieval works correctly. `faiss-cpu` is an optional accelerator (deliberately not a dependency — `kirocrew doctor` itself reports it as "not installed (optional)"); when it isn't importable, the in-RAM index is always empty and the line reads as "nothing is indexed". The stats dict already computes `embedded_count` — the CLI just never printed it. This output sent a real investigation chasing a data-loss scenario that didn't exist: the stored embeddings were 228/228 healthy and the stdlib exact-cosine fallback returns results identical to `faiss.IndexFlatIP`.

## Fix

- `VectorMemoryStore.memory_stats()` now also reports `faiss_available` (faiss + numpy importable), so callers can distinguish "accelerator not installed" from "nothing indexed". Purely additive for the dashboard stats endpoint.
- `kirocrew memory stats` now prints the embedded coverage and an honest accelerator line:

```
  Semantic: 12 active, 1 deleted
  Episodic: 228 active, 3 deleted
  Embedded: 228/228
  FAISS accelerator: not installed — stdlib cosine fallback (exact)
  Audit events: 512
```

With faiss installed it prints `FAISS accelerator: N vectors indexed` instead.

## Tests

- Updated the store-level `memory_stats` test to pin the new `faiss_available` key.
- Updated the CLI stats test for the accelerator-present branch and added a regression test for the accelerator-absent branch asserting the misleading `0 vectors` string is gone while embedded coverage is shown.
- Ran the four touched-suite files (524 passed), plus isort, flake8, and CI-parity mypy — all green.
