### PR TITLE
fix(pod): serialize write_env_file under pod_name_mutex

### DIFF
--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -96,19 +96,25 @@ def read_env_file(cfg: PodConfig, name: str) -> dict[str, str]:
 def write_env_file(cfg: PodConfig, name: str, updates: dict[str, str]) -> None:
     """Merge *updates* into the pod's env file, preserving existing keys.
 
+    The read-modify-write is serialized under :func:`pod_name_mutex` so that
+    concurrent writers (e.g. ``pod up`` racing the boot it starts) cannot lose
+    each other's keys.  The mutex is reentrant, so callers that already hold it
+    — the ``pod up`` transaction itself — do not deadlock.
+
     Values MUST be single-line: the ``KEY='value'`` format does not escape
     newlines, so a multi-line value would not round-trip. ``--seed`` is
     user-supplied, so reject a newline-bearing value loudly (fail-closed) rather
     than silently writing an un-parseable file.
     """
-    data = read_env_file(cfg, name)
-    data.update(updates)
-    for key, val in data.items():
-        if "\n" in val or "\r" in val:
-            raise PodError(f"pod env value for {key!r} must be single-line")
-    cfg.pods_dir.mkdir(parents=True, exist_ok=True)
-    body = "".join(f"{k}='{v}'\n" for k, v in data.items())
-    cfg.env_file(name).write_text(body)
+    with pod_name_mutex(cfg, name):
+        data = read_env_file(cfg, name)
+        data.update(updates)
+        for key, val in data.items():
+            if "\n" in val or "\r" in val:
+                raise PodError(f"pod env value for {key!r} must be single-line")
+        cfg.pods_dir.mkdir(parents=True, exist_ok=True)
+        body = "".join(f"{k}='{v}'\n" for k, v in data.items())
+        cfg.env_file(name).write_text(body)
 
 
 def pin_checkout(cfg: PodConfig, name: str, checkout: Path) -> None:

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -197,6 +197,18 @@ class TestEnvFileAndPin:
         rt.pin_checkout(c, "x", Path("/abs/co"))
         assert rt.read_env_file(c, "x")["CHECKOUT"] == "/abs/co"
 
+    def test_write_env_file_reentrant_under_mutex(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """write_env_file acquires pod_name_mutex internally; calling it while
+        already holding the mutex must not deadlock (reentrancy)."""
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path))
+        c = PodConfig.load()
+        with rt.pod_name_mutex(c, "x"):
+            rt.write_env_file(c, "x", {"A": "1"})
+            rt.write_env_file(c, "x", {"B": "2"})
+        assert rt.read_env_file(c, "x") == {"A": "1", "B": "2"}
+
 
 class TestWorktreeResolution:
     """Git-native: a friendly name → checkout via pinned CHECKOUT, else git, else


### PR DESCRIPTION
## Problem

`write_env_file` performs an unserialized read-modify-write on the pod's env file. Two concurrent callers (e.g. `pod up` racing the boot it starts, or two `pod up` invocations for the same name) can interleave inside the read → update → write window and lose one side's keys.

## Fix

Wrap the entire merge in `pod_name_mutex(cfg, name)`. The mutex is reentrant (per-thread counter on top of `flock`), so callers that already hold it — the `pod up` transaction itself — do not deadlock.

This is the fix suggested in the issue: `pod_name_mutex` is already the correct chokepoint because every other mutating pod path routes through it, and a lock private to `write_env_file` would not exclude the writers that hold the transaction-level mutex.

## Tests

Added `test_write_env_file_reentrant_under_mutex`: calls `write_env_file` twice while already holding `pod_name_mutex` for the same name, verifying both writes succeed (reentrancy) and both keys are present (serialized merge).

Existing tests in `TestEnvFileAndPin` continue to pass — they now exercise the locked path transparently.

Closes #2693