### PR TITLE
fix: improve notification panel text contrast over busy backgrounds

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -764,7 +764,7 @@ function NotificationsBellButton() {
                 the cards' own backdrop-blur still samples the page). */}
             <div
               aria-hidden="true"
-              className="absolute inset-y-0 -left-20 right-0 -z-10 pointer-events-none bg-black/[.03] [mask-image:linear-gradient(to_right,transparent,black_80px)] [-webkit-mask-image:linear-gradient(to_right,transparent,black_80px)]"
+              className="absolute inset-y-0 -left-20 right-0 -z-10 pointer-events-none bg-black/[.12] backdrop-blur-sm [mask-image:linear-gradient(to_right,transparent,black_80px)] [-webkit-mask-image:linear-gradient(to_right,transparent,black_80px)]"
             />
             <div className="flex-1 min-h-0 px-3 py-2 flex flex-col">
               <NotificationFeed

--- a/website/src/components/notifications/NotificationFeed.tsx
+++ b/website/src/components/notifications/NotificationFeed.tsx
@@ -248,7 +248,7 @@ export default function NotificationFeed({ selectedTs, onSelect, variant = 'pane
           floating card (search above the disclosure); panel mode puts the
           disclosure first, directly on the popover surface. */}
       {mac ? (
-        <div className="notif-material rounded-2xl bg-[color-mix(in_srgb,var(--card)_55%,transparent)] backdrop-blur-2xl backdrop-saturate-150 shadow-[0_8px_24px_rgba(0,0,0,.10),0_1px_3px_rgba(0,0,0,.06)] border border-[color-mix(in_srgb,var(--border)_55%,transparent)] px-2.5 pt-2 pb-1 mb-2 shrink-0">
+        <div className="notif-material rounded-2xl bg-[color-mix(in_srgb,var(--card)_72%,transparent)] backdrop-blur-2xl backdrop-saturate-150 shadow-[0_8px_24px_rgba(0,0,0,.10),0_1px_3px_rgba(0,0,0,.06)] border border-[color-mix(in_srgb,var(--border)_55%,transparent)] px-2.5 pt-2 pb-1 mb-2 shrink-0">
           <div className="flex items-center gap-1.5">
             <div className="flex-1 min-w-0">{header}</div>
             {unread > 0 && (
@@ -301,7 +301,7 @@ export default function NotificationFeed({ selectedTs, onSelect, variant = 'pane
                 // (#1817). Keep the hook on every translucent mac-variant surface.
                 const macCard = silenced
                   ? 'bg-[color-mix(in_srgb,var(--card)_35%,transparent)] backdrop-blur-xl border border-dashed border-[color-mix(in_srgb,var(--border)_70%,transparent)]'
-                  : `bg-[color-mix(in_srgb,var(--card)_55%,transparent)] backdrop-blur-2xl backdrop-saturate-150 shadow-[0_8px_24px_rgba(0,0,0,.10),0_1px_3px_rgba(0,0,0,.06)] ${active ? 'border border-accent bg-accent-subtle' : 'border border-[color-mix(in_srgb,var(--border)_55%,transparent)] hover:bg-[color-mix(in_srgb,var(--card)_70%,transparent)]'}`
+                  : `bg-[color-mix(in_srgb,var(--card)_72%,transparent)] backdrop-blur-2xl backdrop-saturate-150 shadow-[0_8px_24px_rgba(0,0,0,.10),0_1px_3px_rgba(0,0,0,.06)] ${active ? 'border border-accent bg-accent-subtle' : 'border border-[color-mix(in_srgb,var(--border)_55%,transparent)] hover:bg-[color-mix(in_srgb,var(--card)_82%,transparent)]'}`
                 const panelBorder = silenced ? 'border-l-muted' : prio === 'critical' ? 'border-l-danger' : km.borderColor
                 const contentDim = silenced ? 'opacity-50' : (n.acked && !active) || prio === 'passive' ? (mac ? 'opacity-55' : '') : ''
                 const promptChannel = promptTs === n.ts && n.channel && n.source
@@ -413,8 +413,8 @@ export default function NotificationFeed({ selectedTs, onSelect, variant = 'pane
                         stack -- click anywhere on the head to expand. */}
                     {mac && collapsedStack && (
                       <div aria-hidden className="mb-2">
-                        <div className={`notif-material relative z-[1] h-3 -mt-1.5 mx-2 rounded-b-2xl ${silenced ? 'bg-[color-mix(in_srgb,var(--card)_30%,transparent)]' : 'bg-[color-mix(in_srgb,var(--card)_45%,transparent)]'} backdrop-blur-xl border border-t-0 border-[color-mix(in_srgb,var(--border)_45%,transparent)] shadow-[0_4px_12px_rgba(0,0,0,.06)]`} />
-                        <div className="notif-material relative z-0 h-3 -mt-1.5 mx-4 rounded-b-2xl bg-[color-mix(in_srgb,var(--card)_35%,transparent)] backdrop-blur-lg border border-t-0 border-[color-mix(in_srgb,var(--border)_35%,transparent)]" />
+                        <div className={`notif-material relative z-[1] h-3 -mt-1.5 mx-2 rounded-b-2xl ${silenced ? 'bg-[color-mix(in_srgb,var(--card)_30%,transparent)]' : 'bg-[color-mix(in_srgb,var(--card)_58%,transparent)]'} backdrop-blur-xl border border-t-0 border-[color-mix(in_srgb,var(--border)_45%,transparent)] shadow-[0_4px_12px_rgba(0,0,0,.06)]`} />
+                        <div className="notif-material relative z-0 h-3 -mt-1.5 mx-4 rounded-b-2xl bg-[color-mix(in_srgb,var(--card)_45%,transparent)] backdrop-blur-lg border border-t-0 border-[color-mix(in_srgb,var(--border)_35%,transparent)]" />
                       </div>
                     )}
                     {promptChannel && (


### PR DESCRIPTION
## Problem

The Activity Feed notification panel uses glassmorphism (semi-transparent cards with backdrop-blur) that becomes unreadable when the underlying page has colorful or high-contrast content — for example, the Agent Worlds game view.

![notification-panel-contrast-issue](/home/amadsalm/.meshclaw/uploads/b5420517ca364a7e8af72aff23c1b312_notifications-panel-glassy-contrast-issue.png)

The red arrows in the screenshot highlight where text is barely legible due to game pixels bleeding through the 55%-opacity card backgrounds and the nearly-invisible 3% scrim.

## Fix

- **Card backgrounds**: increased fill from `55%` → `72%` opacity (controls card + notification rows)
- **Column scrim**: strengthened from `bg-black/[.03]` → `bg-black/[.12]` with added `backdrop-blur-sm`
- **Hover state**: bumped from `70%` → `82%` to maintain the expected opacity delta
- **Stack deck cards**: raised proportionally (`45%` → `58%`) for consistency

The glassmorphism aesthetic is preserved — cards still show backdrop-blur and remain visually translucent — but the increased fill guarantees readable text against any background content.

## Testing

- Typecheck: `tsc --noEmit` passes
- Lint: no new warnings/errors
- All 45 notification-related tests pass (NotificationFeed phase 3/4, NotificationsPanel, NotificationItem, sheet exit animation)
- Visual: cards remain translucent but text is now consistently readable over colorful backgrounds