### PR TITLE
feat(terminal): open bottom-panel terminals in the selected session's project directory

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -8,7 +8,7 @@ import { fetchSlots, sseStatus, setUpdateProgress, setEnabledAppIds, changeAppro
 // before `getBuiltinSurfaces()` is invoked below to compute `NAV_ITEMS`.
 import './surfaces/builtins'
 import { getBuiltinSurfaces, getBuiltinSurface, selectSurfaceBadgeCount, selectSurfaceActivityCount, selectAllSurfacesAttention, surfaceLabel, surfacePreviewEnabled } from './surfaces/registry'
-import { createSlot, appendMessage, setSlotRunning, switchSlot } from './store/chatSlice'
+import { createSlot, appendMessage, setSlotRunning, switchSlot, selectActiveSlotProject } from './store/chatSlice'
 import { setNavIntentHandler as setArtifactNavIntentHandler } from './utils/artifactPopout'
 import { applyNavIntentInMain } from './utils/navIntent'
 import { installSoftNavigate } from './utils/errorReport'
@@ -894,6 +894,9 @@ export default function App() {
   // every mousemove during a grip-drag, and a primitive snapshot lets
   // useSyncExternalStore's Object.is check skip those re-renders of App.
   const bottomTerminalOpen = useBottomTerminalOpen()
+  // Selected session's project directory: a terminal opened from the nav row
+  // starts there (server default when no session is selected or it has none).
+  const activeSlotProject = useAppSelector(selectActiveSlotProject)
   const navigate = useNavigate()
 
   // Main-dashboard role for the artifact popout nav-intent handshake: perform
@@ -2378,7 +2381,7 @@ export default function App() {
                   /* While popped out: focus only (a refused programmatic
                      focus is a harmless no-op). Explicit re-dock lives in the
                      TerminalDetachedBar below -- never a timing heuristic. */
-                  onClickOverride={() => { if (terminalPoppedOut) focusTerminalPopout(); else toggleBottomTerminal() }}
+                  onClickOverride={() => { if (terminalPoppedOut) focusTerminalPopout(); else toggleBottomTerminal(activeSlotProject) }}
                 />
               )}
               <div>{renderNavRow(cap)}</div>

--- a/website/src/components/BottomTerminalPanel.tsx
+++ b/website/src/components/BottomTerminalPanel.tsx
@@ -8,7 +8,7 @@ import CliPanel, { disposeTerminalSession, useDeleteTerminalSession } from './Cl
 import { useTerminalTitle, disposeTerminalConnection } from '../utils/terminalRegistry'
 import { usePanelTabs } from '../hooks/usePanelTabs'
 import { useAppSelector, useAppDispatch } from '../store'
-import { openActivityPanel } from '../store/chatSlice'
+import { openActivityPanel, selectActiveSlotProject } from '../store/chatSlice'
 import { openPopout as openTerminalPopout, isPopoutOpen as isTerminalPopoutOpen, focusPopout as focusTerminalPopout, bringBack as bringBackTerminalPopout, returnSelfToMain } from '../utils/terminalPopout'
 import {
   useBottomTerminal, addTab, removeTab, setActiveTab, setTabsOrder,
@@ -96,6 +96,9 @@ export function TerminalTabsView({ variant }: { variant: 'dock' | 'popout' }) {
   // Move-to-chat is only offered while the user is actually ON the chat page
   // with a slot active
   const activeSlot = useAppSelector(s => s.chat.activeSlot)
+  // New tabs spawn in the selected session's project directory when one is
+  // set; otherwise the backend's default cwd applies.
+  const activeSlotProject = useAppSelector(selectActiveSlotProject)
   const chatTabs = usePanelTabs(activeSlot)
   const dispatch = useAppDispatch()
   const location = useLocation()
@@ -177,7 +180,7 @@ export function TerminalTabsView({ variant }: { variant: 'dock' | 'popout' }) {
         {/* + opens a new terminal tab instantly (no menu). */}
         <button
           className="flex items-center justify-center w-7 h-7 rounded-md text-muted hover:text-text hover:bg-bg-hover transition-colors bg-transparent border-none cursor-pointer shrink-0 disabled:opacity-40 disabled:cursor-not-allowed"
-          onClick={() => addTab()}
+          onClick={() => addTab(activeSlotProject)}
           disabled={atCap}
           title={atCap ? i18nT('components.bottomTerminalPanel.maximum_terminals', { n: MAX_TERMINALS }) : i18nT('components.bottomTerminalPanel.new_terminal')}
           aria-label={i18nT('components.bottomTerminalPanel.new_terminal')}

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1406,6 +1406,16 @@ const CONTINUE_SCAN_SKIP = new Set(['queued', 'tool_call', 'tool_result', 'injec
  * An empty transcript returns false, which keeps a brand-new chat's send button
  * disabled exactly as it is today.
  */
+/** Project directory of the ACTIVE chat session's slot, or undefined when no
+ *  session is selected or the selected session has no project set. Used by the
+ *  bottom terminal panel so a freshly opened terminal starts in the selected
+ *  session's working tree instead of the server default. */
+export const selectActiveSlotProject = (state: RootState): string | undefined => {
+  const key = state.chat.activeSlot
+  if (!key) return undefined
+  return state.dashboard.slots.find((sl) => sl.key === key)?.project || undefined
+}
+
 export const selectContinuable = (state: RootState): boolean => {
   const c = state.chat
   if (c.slotRunning || c.slotStopping || c.pendingTurnSlot) return false

--- a/website/src/test/BottomTerminalPanel.cwd.test.tsx
+++ b/website/src/test/BottomTerminalPanel.cwd.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Bottom terminal panel — new terminals open in the SELECTED session's
+ * workspace/project directory (issue #2832).
+ *
+ * Pins the two halves of the behavior:
+ *
+ * 1. `selectActiveSlotProject` resolves the active chat slot's project
+ *    directory (and yields undefined when no session is selected, or the
+ *    selected session has no project — the "fall back to the server default"
+ *    contract).
+ * 2. The panel's "+" (new terminal) button threads that directory into the
+ *    minted tab's `cwd`, which is what the WS layer sends as `?cwd=` — and
+ *    omits it when no session is selected, so the backend default applies.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders, createTestStore } from './helpers'
+import { TerminalTabsView } from '../components/BottomTerminalPanel'
+import { __resetBottomTerminal, openBottomTerminal, useBottomTerminal } from '../hooks/useBottomTerminal'
+import { selectActiveSlotProject } from '../store/chatSlice'
+import { renderHook } from '@testing-library/react'
+import type { RootState } from '../store'
+
+vi.mock('../components/CliPanel', () => ({
+  default: ({ sessionId }: { sessionId: string }) => <div data-testid={`cli-${sessionId}`} />,
+  disposeTerminalSession: vi.fn(),
+  useDeleteTerminalSession: () => ({ mutate: vi.fn() }),
+}))
+vi.mock('../utils/terminalRegistry', () => ({
+  useTerminalTitle: () => '',
+  disposeTerminalConnection: vi.fn(),
+}))
+vi.mock('../utils/terminalPopout', () => ({
+  openPopout: vi.fn(),
+  isPopoutOpen: vi.fn(() => true),
+  focusPopout: vi.fn(),
+  bringBack: vi.fn(),
+  returnSelfToMain: vi.fn(),
+}))
+vi.mock('../hooks/usePanelTabs', () => ({
+  usePanelTabs: () => ({ adoptTerminal: vi.fn() }),
+}))
+
+beforeEach(() => {
+  __resetBottomTerminal()
+  vi.clearAllMocks()
+})
+afterEach(() => {
+  __resetBottomTerminal()
+})
+
+/** Store whose active slot is `key` and whose dashboard slot list carries the
+ *  given project (undefined = session without a project directory). */
+function storeWith(key: string | null, project?: string) {
+  const store = createTestStore()
+  const base = store.getState() as RootState
+  return createTestStore({
+    chat: { ...base.chat, activeSlot: key },
+    dashboard: {
+      ...base.dashboard,
+      slots: key ? [{ key, messages: 0, running: false, project }] : [],
+    },
+  } as Partial<RootState>)
+}
+
+describe('selectActiveSlotProject', () => {
+  it('returns the active slot project directory', () => {
+    const store = storeWith('s1', '/repos/my-app')
+    expect(selectActiveSlotProject(store.getState() as RootState)).toBe('/repos/my-app')
+  })
+
+  it('returns undefined when no session is selected', () => {
+    const store = storeWith(null)
+    expect(selectActiveSlotProject(store.getState() as RootState)).toBeUndefined()
+  })
+
+  it('returns undefined when the selected session has no project (empty string too)', () => {
+    const store = storeWith('s1', '')
+    expect(selectActiveSlotProject(store.getState() as RootState)).toBeUndefined()
+  })
+
+  it('returns undefined when the active slot is not in the slot list', () => {
+    const store = storeWith('missing')
+    const state = store.getState() as RootState
+    expect(selectActiveSlotProject({
+      ...state,
+      dashboard: { ...state.dashboard, slots: [] },
+    } as RootState)).toBeUndefined()
+  })
+})
+
+describe('TerminalTabsView "+" button — new tab cwd', () => {
+  it('mints the new tab with the selected session project as cwd', async () => {
+    openBottomTerminal() // first tab, no cwd (panel opened before selection)
+    const store = storeWith('s1', '/repos/my-app')
+    renderWithProviders(<TerminalTabsView variant="dock" />, { store })
+
+    await userEvent.click(screen.getByRole('button', { name: 'New terminal' }))
+
+    const { result } = renderHook(() => useBottomTerminal())
+    const tabs = result.current.tabs
+    expect(tabs).toHaveLength(2)
+    expect(tabs[1].cwd).toBe('/repos/my-app')
+  })
+
+  it('mints the new tab without a cwd when no session is selected (server default)', async () => {
+    openBottomTerminal()
+    const store = storeWith(null)
+    renderWithProviders(<TerminalTabsView variant="dock" />, { store })
+
+    await userEvent.click(screen.getByRole('button', { name: 'New terminal' }))
+
+    const { result } = renderHook(() => useBottomTerminal())
+    const tabs = result.current.tabs
+    expect(tabs).toHaveLength(2)
+    expect(tabs[1].cwd).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

New terminals opened from the **sidebar nav toggle** and the **bottom panel's + button** now start in the **selected session's project directory**, falling back to the server default when no session is selected or the session has no project set.

Closes #2832

## Changes

- `website/src/store/chatSlice.ts`: new `selectActiveSlotProject` selector (active `chat.activeSlot` x `dashboard.slots` project).
- `website/src/App.tsx`: the terminal nav row passes it to `toggleBottomTerminal(...)`.
- `website/src/components/BottomTerminalPanel.tsx`: the panel's + button passes it to `addTab(...)`.
- No backend change: the tab `cwd` already flows to the PTY spawn via the WS `?cwd=` param and `_resolve_cwd` (client-requested dir wins, `$HOME` fallback). The chat side panel already passed its `projectDir`; this extends the same behavior to the app-wide bottom panel.

## Tested

- New test file `BottomTerminalPanel.cwd.test.tsx` (6 tests): selector contract (active project, no session, empty project, missing slot) + the + button minting a tab with/without cwd.
- Full frontend gates green locally: `tsc -b`, vitest 15,447 passed (962 files), eslint ratchet (0 errors), `i18n:check` OK, jscpd 0 clones, Electron suite 858/858.
- Frontend-only change; backend suite untouched.

## Notes

- Related: #1142 (per-project quick actions, external terminal) is complementary — this PR only changes the integrated panel's default cwd.
