### PR TITLE
fix(chat): authorize History resume against the conversation it loads

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1137,
+    "missing_code": 1135,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1722,
+  "_compliant": 1769,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -37,7 +37,7 @@
       "missing_code": 19
     },
     "dashboard/chat_handlers.py": {
-      "missing_code": 48
+      "missing_code": 46
     },
     "dashboard/chat_mirror.py": {
       "missing_code": 7

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -8389,7 +8389,7 @@ async def _live_slot_resume_response(
                     resources=f"slot={existing.key}",
                     error="app cannot access unscoped slots",
                 )
-                return web.json_response({"error": "not found"}, status=404)
+                return _slot_not_found()
             elif request_app != existing._app:
                 sel().log_api_access(
                     caller=request_app,
@@ -8399,7 +8399,7 @@ async def _live_slot_resume_response(
                     resources=f"slot={existing.key}",
                     error="app does not own this slot",
                 )
-                return web.json_response({"error": "not found"}, status=404)
+                return _slot_not_found()
         # Reconcile: if disk grew beyond what the in-memory window covers,
         # append the missing tail so a page refresh self-heals (#4373).
         await _reconcile_slot_window(state, existing)
@@ -8519,6 +8519,43 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
     # app token, otherwise leaves it untagged, which is invisible to cross-slot
     # scopes) rather than claiming USER on a conversation we cannot attribute.
     meta = state.conversation_log.get_metadata(history_key)
+
+    # ── App Kit §5.2 on the CONVERSATION, EARLY refusal ─────────────────────
+    # `history_key` is `body["key"]`, caller-supplied and not required to match
+    # the slot name in the URL, so it names an arbitrary conversation until
+    # something says otherwise. The `existing` branch above can authorize
+    # against `existing._app` because that slot predates the request; here the
+    # only slot is the one this request is about to create with the caller's own
+    # identity, so checking it would let the claim stand as its own evidence.
+    # `meta["app"]` is the durable owner: the slot save is authoritative for it
+    # (`history.SLOT_OWNED_META_KEYS`) and both restore paths rebuild
+    # `slot._app` from it.
+    #
+    # Deny-by-default, and absence is a real answer rather than a gap: because
+    # `app` is a slot-owned key, an unscoped conversation's save OMITS it, which
+    # states "no app owns this" instead of "unknown". A transcript that does not
+    # exist also has no `app`, so a foreign conversation and a missing one take
+    # this same branch and are answered identically — no probing the history
+    # namespace for keys that exist. `_slot_not_found` is the same single-sourced
+    # 404 every other slot refusal returns, so these cannot drift into an oracle.
+    #
+    # Placed here for the same reason the member early refusal below is:
+    # ``_unhide_folder`` and ``clear_closed`` further down write durable state,
+    # and a resume that is going to be refused must not edit the very transcript
+    # the caller may not touch. Ahead of the member checks too, so a foreign
+    # member thread answers 404 rather than a 409 that would name it as one. The
+    # late twin before the slot is created re-validates the post-await snapshot.
+    request_app = request.get("app", "")
+    if request_app and meta.get("app") != request_app:
+        sel().log_api_access(
+            caller=request_app,
+            operation="slot_resume",
+            outcome="denied",
+            source="app_isolation",
+            resources=f"history={history_key}",
+            error="app does not own this conversation",
+        )
+        return _slot_not_found()
 
     # ── Member-thread EARLY refusal, before any persistent mutation ────────
     # ``_unhide_folder`` and ``clear_closed`` below write durable state. A
@@ -8831,9 +8868,29 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
             status=409,
         )
 
+    # ── App Kit §5.2 on the CONVERSATION, LATE barrier ──────────────────────
+    # The early twin ran on the PRE-await snapshot, which is what keeps a
+    # refusal free of the durable mutations above. This one is the authoritative
+    # one: it re-validates against the post-await `meta` the guards just rebound,
+    # and it is the last thing before `get_or_create_slot` publishes anything. A
+    # delete/recreate landing inside the transcript read or the binding await
+    # replaces the metadata line, so ownership earned by the old snapshot says
+    # nothing about the transcript this request is about to adopt. Same
+    # deny-by-default rule and the same single-sourced 404 as the early twin.
+    if request_app and meta.get("app") != request_app:
+        sel().log_api_access(
+            caller=request_app,
+            operation="slot_resume",
+            outcome="denied",
+            source="app_isolation",
+            resources=f"history={history_key}",
+            error="app does not own this conversation (late barrier)",
+        )
+        return _slot_not_found()
+
     slot = state.get_or_create_slot(
         name,
-        app=request.get("app", ""),
+        app=request_app,
         # The BINDING is the pin's authority on a member key — not the
         # transcript's own metadata (the guard above verified identity
         # structurally; metadata lives in the same operator-editable file it

--- a/test/test_resume_history_ownership.py
+++ b/test/test_resume_history_ownership.py
@@ -1,0 +1,316 @@
+"""Who may hydrate a persisted conversation through History resume?
+
+``api_chat_slot_resume`` has two branches. When a live slot already exists it
+applies the App Kit §5.2 ownership check against that slot before returning
+anything. When it does not, it used to go straight to::
+
+    slot = state.get_or_create_slot(name, app=request.get("app", ""), ...)
+    meta = state.conversation_log.get_metadata(history_key)
+    all_messages = state.conversation_log.read_messages_chained(history_key)
+
+``history_key`` is ``body["key"]`` — caller-supplied, and not required to match
+the slot name in the URL — so it names an arbitrary conversation. The only slot
+on that path is the one the request just created carrying the caller's own
+identity, so authorizing against it lets the claim stand as its own evidence.
+
+The authority is the transcript's persisted owner. ``meta["app"]`` is written by
+the slot save, is one of ``history.SLOT_OWNED_META_KEYS`` (so its ABSENCE is the
+positive statement "no app owns this", not a gap), and both restore paths
+already rebuild ``slot._app`` from it.
+
+Distinct from the session-binding boundary in #2783: that one governs which
+LIVE SESSION a slot may acquire authority over, this one governs which PERSISTED
+TRANSCRIPT a caller may read and adopt.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_state
+
+APP_A = "issue-radar"
+APP_B = "spec-builder"
+
+SLACK_KEY = "slack:1785370133.085469"
+DASHBOARD_KEY = "dashboard:chat-7-1785300000"
+APP_B_KEY = "dashboard:spec-builder-99"
+APP_A_KEY = "dashboard:issue-radar-5"
+MISSING_KEY = "dashboard:no-such-conversation"
+
+SECRET = "board minutes: acquisition price is 4.2M"
+
+#: What a caller who may not read a conversation is told, byte for byte. It must
+#: also be what a conversation that does not exist answers, or the difference is
+#: an oracle for enumerating history keys.
+REFUSED_BODY = {"error": "not found", "code": "slot_not_found"}
+
+
+def _write_transcript(state, key: str, meta: dict[str, Any]) -> None:
+    """Persist a session the way the history layer stores one."""
+    from kiro_crew.history import _safe_key
+
+    log = state.conversation_log
+    path = log._path(_safe_key(key))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps({"_type": "metadata", "created_at": "2026-08-01T10:00:00", **meta})]
+    lines.append(json.dumps({"role": "user", "content": SECRET, "ts": "2026-08-01T10:00:01"}))
+    lines.append(json.dumps({"role": "assistant", "content": "noted", "ts": "2026-08-01T10:00:02"}))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    log._invalidate_cache(key)
+
+
+def _resume_app(state, app_identity: str | None) -> web.Application:
+    """The real resume route, with the auth middleware's app stamp."""
+    from kiro_crew.dashboard.chat_handlers import api_chat_slot_resume
+
+    middlewares = []
+    if app_identity is not None:
+
+        @web.middleware
+        async def _identity(request: web.Request, handler: Any) -> web.StreamResponse:
+            request["app"] = app_identity
+            return await handler(request)
+
+        middlewares.append(_identity)
+    app = web.Application(middlewares=middlewares)
+    app["state"] = state
+    app.router.add_post("/api/chat/slots/{slot}/resume", api_chat_slot_resume)
+    return app
+
+
+async def _resume(state, app_identity, slot_name: str, history_key: str):
+    async with TestClient(TestServer(_resume_app(state, app_identity))) as client:
+        resp = await client.post(f"/api/chat/slots/{slot_name}/resume", json={"key": history_key})
+        return resp.status, await resp.json()
+
+
+def _contents(body: dict) -> list[str]:
+    return [m.get("content", "") for m in body.get("messages", [])]
+
+
+class TestAnAppCannotHydrateAForeignConversation:
+    """The slot name is not the authority; the transcript's owner is."""
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_dashboard_users_conversation(self, tmp_path):
+        """The broad case: no channel shape, no app owner — the kind every user
+        has dozens of. Note the slot name is unrelated to the history key."""
+        state = _make_state(tmp_path)
+        _write_transcript(state, DASHBOARD_KEY, {"title": "Board notes"})
+
+        status, body = await _resume(state, APP_A, "app-a-scratch", DASHBOARD_KEY)
+
+        assert status == 404, body
+        assert SECRET not in _contents(body)
+
+    @pytest.mark.asyncio
+    async def test_another_apps_conversation(self, tmp_path):
+        state = _make_state(tmp_path)
+        _write_transcript(state, APP_B_KEY, {"title": "B's work", "app": APP_B})
+
+        status, body = await _resume(state, APP_A, "app-a-scratch", APP_B_KEY)
+
+        assert status == 404, body
+        assert SECRET not in _contents(body)
+
+    @pytest.mark.asyncio
+    async def test_a_channel_conversation(self, tmp_path):
+        state = _make_state(tmp_path)
+        _write_transcript(state, SLACK_KEY, {"title": "#exec thread", "channel_origin": True})
+
+        status, body = await _resume(state, APP_A, "app-a-scratch", SLACK_KEY)
+
+        assert status == 404, body
+        assert SECRET not in _contents(body)
+
+    @pytest.mark.asyncio
+    async def test_missing_ownership_metadata_is_deny_by_default(self, tmp_path):
+        """``app`` is a slot-owned key, so an unscoped save OMITS it.
+
+        Absence therefore means "no app owns this", not "unknown" — an app
+        caller is refused rather than admitted on a gap.
+        """
+        state = _make_state(tmp_path)
+        _write_transcript(state, DASHBOARD_KEY, {})
+
+        status, body = await _resume(state, APP_A, "app-a-scratch", DASHBOARD_KEY)
+
+        assert status == 404, body
+        assert SECRET not in _contents(body)
+
+
+class TestARefusalIsNotAnExistenceOracle:
+    @pytest.mark.asyncio
+    async def test_a_foreign_conversation_answers_exactly_like_a_missing_one(self, tmp_path):
+        """If these two differ in any externally visible way, an app can walk
+        the history namespace for keys that exist."""
+        state = _make_state(tmp_path)
+        _write_transcript(state, APP_B_KEY, {"title": "B's work", "app": APP_B})
+
+        foreign_status, foreign_body = await _resume(state, APP_A, "probe", APP_B_KEY)
+        missing_status, missing_body = await _resume(state, APP_A, "probe", MISSING_KEY)
+
+        assert foreign_status == missing_status == 404
+        assert foreign_body == missing_body == REFUSED_BODY
+
+    @pytest.mark.asyncio
+    async def test_the_refusal_matches_the_existing_slot_branchs_refusal(self, tmp_path):
+        """Both §5.2 refusals on this route must read the same to a caller."""
+        state = _make_state(tmp_path)
+        _write_transcript(state, APP_B_KEY, {"title": "B's work", "app": APP_B})
+        # A live slot owned by B, addressed by its own name.
+        state.get_or_create_slot("spec-builder-99", app=APP_B)
+
+        existing_status, existing_body = await _resume(state, APP_A, "spec-builder-99", APP_B_KEY)
+        create_status, create_body = await _resume(state, APP_A, "app-a-scratch", APP_B_KEY)
+
+        assert existing_status == create_status == 404
+        assert existing_body == create_body == REFUSED_BODY
+
+
+class TestARefusalHasNoSideEffects:
+    @pytest.mark.asyncio
+    async def test_no_slot_is_created_and_nothing_is_hydrated(self, tmp_path):
+        """A denial that still creates the slot hands the app a foothold: the
+        tab exists, it is app-owned, and the next request finds it on the
+        already-exists branch."""
+        state = _make_state(tmp_path)
+        _write_transcript(
+            state,
+            APP_B_KEY,
+            {
+                "title": "B's work",
+                "app": APP_B,
+                "agent": "researcher",
+                "model": "x",
+                "pinned": True,
+            },
+        )
+        before = dict(state._slots)
+
+        status, _ = await _resume(state, APP_A, "app-a-scratch", APP_B_KEY)
+
+        assert status == 404
+        assert state._slots == before, "the refused resume left a slot behind"
+        assert "app-a-scratch" not in state._slots
+
+    @pytest.mark.asyncio
+    async def test_the_apps_own_slots_are_untouched(self, tmp_path):
+        """Nothing restored from the foreign transcript may land anywhere — not
+        a title, agent, model, pin, or channel provenance.
+
+        The URL names a slot that does not exist, so the request takes the
+        creation branch; the app's real tab is a bystander and must stay one.
+        """
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+
+        state = _make_state(tmp_path)
+        _write_transcript(
+            state,
+            SLACK_KEY,
+            {"title": "#exec thread", "channel_origin": True, "agent": "researcher"},
+        )
+        own = state.get_or_create_slot("app-a-worker", app=APP_A)
+        own.title = "A's own tab"
+
+        def _snapshot():
+            return (
+                own.title,
+                own.agent,
+                own.model,
+                own.pinned,
+                own.linked_session_key,
+                getattr(own, "channel_origin", False),
+                len(own.messages),
+                own._dirty,
+                sorted(state._slots),
+                sorted(state._restricted_keys),
+            )
+
+        before = _snapshot()
+
+        status, _ = await _resume(state, APP_A, "app-a-scratch", SLACK_KEY)
+
+        assert status == 404
+        assert _snapshot() == before, "the refused resume mutated slot state"
+        assert effective_session_key(own) == "dashboard:app-a-worker"
+
+    @pytest.mark.asyncio
+    async def test_the_foreign_transcript_is_not_rewritten(self, tmp_path):
+        """Resume clears a ``closed`` flag on the history it loads. A refused
+        one must not be edited at all."""
+        from kiro_crew.history import _safe_key
+
+        state = _make_state(tmp_path)
+        _write_transcript(state, APP_B_KEY, {"title": "B's work", "app": APP_B, "closed": True})
+        path = state.conversation_log._path(_safe_key(APP_B_KEY))
+        before = path.read_bytes()
+
+        status, _ = await _resume(state, APP_A, "app-a-scratch", APP_B_KEY)
+
+        assert status == 404
+        assert path.read_bytes() == before, "the refused resume rewrote the transcript"
+
+
+class TestWhatMustKeepWorking:
+    @pytest.mark.asyncio
+    async def test_an_app_resumes_its_own_conversation(self, tmp_path):
+        state = _make_state(tmp_path)
+        _write_transcript(state, APP_A_KEY, {"title": "A's work", "app": APP_A})
+
+        status, body = await _resume(state, APP_A, "issue-radar-5", APP_A_KEY)
+
+        assert status == 200, body
+        assert SECRET in _contents(body)
+
+    @pytest.mark.asyncio
+    async def test_a_dashboard_user_resumes_a_channel_conversation(self, tmp_path):
+        """No app scope — History resume keeps working, channels included."""
+        state = _make_state(tmp_path)
+        _write_transcript(state, SLACK_KEY, {"title": "#exec thread", "channel_origin": True})
+
+        status, body = await _resume(state, None, "slack_1785370133.085469", SLACK_KEY)
+
+        assert status == 200, body
+        assert SECRET in _contents(body)
+
+    @pytest.mark.asyncio
+    async def test_a_dashboard_user_resumes_an_app_owned_conversation(self, tmp_path):
+        """The guard is scoped to app callers; an operator still sees everything
+        their History pane lists."""
+        state = _make_state(tmp_path)
+        _write_transcript(state, APP_B_KEY, {"title": "B's work", "app": APP_B})
+
+        status, body = await _resume(state, None, "spec-builder-99", APP_B_KEY)
+
+        assert status == 200, body
+        assert SECRET in _contents(body)
+
+    @pytest.mark.asyncio
+    async def test_a_dashboard_user_resumes_an_ordinary_conversation(self, tmp_path):
+        state = _make_state(tmp_path)
+        _write_transcript(state, DASHBOARD_KEY, {"title": "Board notes"})
+
+        status, body = await _resume(state, None, "chat-7-1785300000", DASHBOARD_KEY)
+
+        assert status == 200, body
+        assert SECRET in _contents(body)
+
+    @pytest.mark.asyncio
+    async def test_the_existing_slot_branch_still_serves_the_owner(self, tmp_path):
+        """The other branch is unchanged: an app with a live slot it owns still
+        gets it back."""
+        state = _make_state(tmp_path)
+        _write_transcript(state, APP_A_KEY, {"title": "A's work", "app": APP_A})
+        live = state.get_or_create_slot("issue-radar-5", app=APP_A)
+        live.append("user", "already here", "msg msg-u")
+
+        status, body = await _resume(state, APP_A, "issue-radar-5", APP_A_KEY)
+
+        assert status == 200, body
+        assert "already here" in _contents(body)


### PR DESCRIPTION
## Problem / Motivation

`POST /api/chat/slots/{slot}/resume` has two branches, and only one of them authorizes.

When a live slot already exists, the App Kit §5.2 check runs against that slot before anything is returned. When it does not — which is the ordinary History case, a conversation with no open tab — the handler went straight to:

```python
slot = state.get_or_create_slot(name, app=request.get("app", ""), ...)
meta = state.conversation_log.get_metadata(history_key)
all_messages = state.conversation_log.read_messages_chained(history_key)
```

`history_key` is `body["key"]` — caller-supplied, and **not required to match the slot name in the URL**. So it names an arbitrary conversation, and nothing on that path compares the caller against that conversation's owner. The only slot in scope is the one the request just created carrying the caller's own identity, so authorizing against it would let the claim stand as its own evidence.

On `24a6f8ee5`, an app token can read any persisted conversation this way:

| requested history | result before |
|---|---|
| `dashboard:chat-7-…` — an ordinary dashboard user's conversation | `200`, full transcript |
| `dashboard:spec-builder-99` — `meta["app"] == "spec-builder"` | `200`, full transcript |
| `slack:1785370133.085469` — a Slack thread | `200`, full transcript |

In every case the URL slot was `app-a-scratch`, unrelated to the key — so this is not about channel-shaped names. It is also not read-only: the transcript is hydrated into a new app-owned slot, which then owns that conversation's messages, its title, agent, model and folder, and clears its `closed` flag on the way in.

## Why it matters

This is an authorization bypass, not a cosmetic gap. An app token that owns a
scratch slot can name **any** conversation key in the request body and receive the
full transcript back: a dashboard user's private chat, another app's conversation,
or a Slack thread. The slot in the URL never has to be related to the key that is
read, so no naming convention limits the blast radius.

`/resume` is the only reader of a persisted conversation that ignored
`meta["app"]`; every other restore path already treats it as authoritative.

## What changed

Authorize against the persisted conversation, before a slot exists:

```python
meta = state.conversation_log.get_metadata(history_key)
request_app = request.get("app", "")
if request_app and meta.get("app") != request_app:
    ...  # SEL app_isolation denial, then the shared 404
```

**`meta["app"]` is the durable owner.** It is written by the slot save (`chat_persistence.py:1669`), it is one of `history.SLOT_OWNED_META_KEYS`, and both restore paths already rebuild `slot._app` from it (`chat_persistence.py:485`/`:559` and `:869`/`:917`). Resume was the only reader of a persisted conversation that ignored it.

**Absence is an answer, not a gap.** Because `app` is a slot-owned key, an unscoped conversation's save deliberately *omits* it — that states "no app owns this", not "unknown". Deny-by-default for app callers therefore follows the writer's own contract rather than guessing about legacy rows.

**One metadata read.** It moved above `get_or_create_slot` and the same dict already fed the title/agent/model/folder restoration below, so authorization and hydration decide from one snapshot rather than two reads.

**A refusal is not an existence oracle.** A transcript that does not exist also has no `app`, so a foreign conversation and a missing one take the same branch and are answered identically — no probing the history namespace for keys that exist. The two pre-existing §5.2 denials on this route gained the same `code` so all three bodies stay byte-identical; per AGENTS.md a new non-2xx body must carry a machine-readable `code`, and giving it only to the new one would itself have been the oracle. `error-code-baseline.json` regenerated for those three (`dashboard/chat_handlers.py` 76 → 74).

Dashboard callers have no app scope and are untouched.

## Relationship to #2783 — adjacent, not overlapping

- **#2783** governs which **live session** a slot may acquire authority over (`linked_session_key`).
- **This** governs which **persisted transcript** a caller may read and adopt.

They are independent: even with no session binding at all, an app that can hydrate another conversation's messages has already crossed the isolation boundary. Neither fix makes the other unnecessary.

## Tests — `test/test_resume_history_ownership.py`

Behaviour-level, through the real handler with the auth middleware's app stamp. **9 failed / 5 passed against `24a6f8ee5`; 14 passed after.**

*Refused* — an ordinary dashboard conversation, another app's conversation, a channel conversation, and a conversation with no ownership metadata (deny-by-default).

*Not an oracle* — a foreign conversation answers with the same status and the same JSON body as a nonexistent one; and the create-branch refusal is identical to the existing-slot branch's.

*No side effects on refusal* — no slot is created; no existing slot is mutated (title, agent, model, pin, `linked_session_key`, `channel_origin`, message count, dirty flag, the slot table and the restricted-key set are all snapshot-compared); and the foreign transcript is not rewritten, which the `closed`-flag clear would otherwise do.

*Preserved, all passing before the change* — an app resumes its own conversation; a dashboard caller resumes a channel conversation, an app-owned one, and an ordinary one; and the existing-slot branch still serves its owner.

## Verification

Windows 11 26200 / py3.10.6.

- `test_resume_history_ownership.py` — 9 failed / 5 passed before, 14 passed after.
- Run against the **exact base** and against this branch, comparing failing node
  sets rather than counts: `test_error_code_contract.py`, `test_dashboard_chat.py`,
  `test_open_slots_persistence.py`, `test_session_restore.py`,
  `test_rehydrate_async.py`, `test_channel_slots.py`,
  `test_one_conversation_one_session.py`, `test_trusted_apps_api.py`,
  `test_slot_detail_full_history.py` plus the new file — **base: 9 failed, 860
  passed, 2 skipped; branch: 869 passed, 2 skipped, 0 failed.** Every one of the
  9 base failures is in the new file, so the delta across 869 tests is exactly
  the security coverage this PR adds and nothing else moved.
- `flake8`, `isort` and `git diff --check` clean; `mypy` reports nothing in `chat_handlers.py`.
- No spec change: `docs/app-kit/` documents no resume contract, and the route's own §5.2 comments are the existing statement of the rule this extends.

