### PR TITLE
feat(dev): change-scoped local test gate reusing the CI surface selector

### DIFF
--- a/scripts/local-gate.py
+++ b/scripts/local-gate.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Change-scoped LOCAL test gate: run only the surfaces a diff can affect.
+
+Why this exists
+---------------
+The iteration loop on this repo (review-fix rounds, babysit amends) runs the
+full backend suite for every change -- roughly an hour at 16 workers -- even
+when the diff touches a single frontend file. CI already narrows scope safely
+via ``ci-surface-tests.py`` plus a three-bucket diff classification; this
+script brings the SAME contract to the local gate, so an iteration costs what
+the diff costs, not what the repo costs.
+
+Contract (identical to CI's, fail-open everywhere)
+--------------------------------------------------
+Every changed file lands in exactly ONE bucket, mirroring ci.yml's
+``changes`` job:
+
+- ``frontend``: ``website/**``
+- ``meta``:     ``.github/**``, ``scripts/**``
+- ``backend``:  everything else (a CATCH-ALL -- an unrecognised path counts as
+  backend, so a new file can never silently ride along under a narrowed run)
+
+Narrowing happens only when exactly one of frontend/backend changed and meta
+did not:
+
+- frontend-only diff: full frontend suite + the backend files
+  ``ci-surface-tests.py --surface backend`` could NOT prove single-surface
+- backend-only diff:  full backend suite + the frontend specs
+  ``ci-surface-tests.py --surface frontend`` could NOT prove single-surface
+- anything else (meta touched, both surfaces touched, empty/unreadable diff,
+  selector error): the FULL gate on both surfaces
+
+A heuristic miss therefore costs local time, never a skipped test. The final
+pre-push gate and CI always run full regardless of this script -- this is an
+iteration-loop tool, not a replacement for either.
+
+Usage
+-----
+    scripts/local-gate.py                  # diff against merge-base with origin/main
+    scripts/local-gate.py --base REF       # explicit base ref
+    scripts/local-gate.py --dry-run        # print the plan, run nothing
+    scripts/local-gate.py --full           # force the full gate (both surfaces)
+
+Exit status is the gate's: 0 when every selected command passed, non-zero
+otherwise. ``--dry-run`` exits 0 after printing the plan.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SELECTOR = _REPO_ROOT / "scripts" / "ci-surface-tests.py"
+
+# Bucket rules -- MUST mirror ci.yml's `changes` job filters. test_local_gate.py
+# pins this against the workflow file so drift fails a test instead of shipping.
+_FRONTEND_PREFIXES = ("website/",)
+_META_PREFIXES = (".github/", "scripts/")
+
+
+def classify(paths: list[str]) -> tuple[bool, bool, bool]:
+    """Return (frontend, meta, backend) touched-flags for a changed-file list.
+
+    Backend is the catch-all: any path that is neither frontend nor meta counts
+    as backend, including paths that do not exist yet (adds) or any unexpected
+    shape. There is deliberately NO "unknown" outcome.
+    """
+    frontend = meta = backend = False
+    for raw in paths:
+        p = raw.strip().replace("\\", "/")
+        if not p:
+            continue
+        if p.startswith(_FRONTEND_PREFIXES):
+            frontend = True
+        elif p.startswith(_META_PREFIXES):
+            meta = True
+        else:
+            backend = True
+    return frontend, meta, backend
+
+
+def changed_files(base: str) -> list[str] | None:
+    """Changed paths vs the merge-base with ``base``; None means "cannot tell".
+
+    Includes uncommitted work (staged + unstaged + untracked) -- the local gate
+    verifies the working tree, not just commits. Any git failure returns None,
+    which the caller maps to the full gate (fail-open).
+    """
+    try:
+        merge_base = subprocess.run(
+            ["git", "merge-base", "HEAD", base],
+            cwd=_REPO_ROOT, capture_output=True, text=True, timeout=30,
+        )
+        if merge_base.returncode != 0:
+            return None
+        committed = subprocess.run(
+            ["git", "diff", "--name-only", merge_base.stdout.strip(), "HEAD"],
+            cwd=_REPO_ROOT, capture_output=True, text=True, timeout=30,
+        )
+        working = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=_REPO_ROOT, capture_output=True, text=True, timeout=30,
+        )
+        if committed.returncode != 0 or working.returncode != 0:
+            return None
+    except (OSError, subprocess.SubprocessError):
+        return None
+    paths = [line for line in committed.stdout.splitlines() if line.strip()]
+    for line in working.stdout.splitlines():
+        # porcelain: "XY path" or "XY old -> new" for renames; take the new name.
+        entry = line[3:].split(" -> ")[-1].strip().strip('"')
+        if entry:
+            paths.append(entry)
+    return paths
+
+
+def selector_must_run(surface: str) -> list[str] | None:
+    """Cross-surface must-run files for ``surface``; None means "fall back to full"."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(_SELECTOR), "--surface", surface],
+            cwd=_REPO_ROOT, capture_output=True, text=True, timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+class Plan:
+    """The commands the gate will run, plus the reason it chose them."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        self.commands: list[tuple[str, list[str], Path]] = []
+
+    def add(self, label: str, argv: list[str], cwd: Path) -> None:
+        self.commands.append((label, argv, cwd))
+
+
+def _backend_full(plan: Plan) -> None:
+    plan.add(
+        "backend (full)",
+        [sys.executable, "-m", "pytest", "-q", "-n", "auto", "--dist", "loadgroup"],
+        _REPO_ROOT,
+    )
+
+
+def _frontend_full(plan: Plan) -> None:
+    plan.add("frontend (full)", ["npm", "test"], _REPO_ROOT / "website")
+
+
+def build_plan(args: argparse.Namespace) -> Plan:
+    if args.full:
+        plan = Plan("--full requested")
+        _backend_full(plan)
+        _frontend_full(plan)
+        return plan
+
+    paths = changed_files(args.base)
+    if paths is None:
+        plan = Plan("could not read the diff -- full gate (fail-open)")
+        _backend_full(plan)
+        _frontend_full(plan)
+        return plan
+    if not paths:
+        plan = Plan("no changes vs merge-base -- full gate (fail-open)")
+        _backend_full(plan)
+        _frontend_full(plan)
+        return plan
+
+    frontend, meta, backend = classify(paths)
+
+    if meta or (frontend and backend):
+        plan = Plan(
+            "meta or both surfaces touched -- full gate"
+            f" (frontend={frontend} meta={meta} backend={backend})"
+        )
+        _backend_full(plan)
+        _frontend_full(plan)
+        return plan
+
+    if frontend and not backend:
+        must_run = selector_must_run("backend")
+        if must_run is None:
+            plan = Plan("selector unusable -- full gate (fail-open)")
+            _backend_full(plan)
+            _frontend_full(plan)
+            return plan
+        plan = Plan(f"frontend-only diff -- full frontend + {len(must_run)} backend guard file(s)")
+        _frontend_full(plan)
+        if must_run:
+            plan.add(
+                "backend (cross-surface guards)",
+                [sys.executable, "-m", "pytest", "-q", "-n", "auto", "--dist", "loadgroup",
+                 *must_run],
+                _REPO_ROOT,
+            )
+        return plan
+
+    # backend-only diff
+    must_run = selector_must_run("frontend")
+    if must_run is None:
+        plan = Plan("selector unusable -- full gate (fail-open)")
+        _backend_full(plan)
+        _frontend_full(plan)
+        return plan
+    # The frontend-surface selector also lists website/electron guards; those
+    # belong to the electron job and vitest cannot collect them -- filter, as
+    # CI's frontend-test scope step does.
+    vitest_targets = [p for p in must_run if not p.startswith("website/electron/")]
+    vitest_rel = [p.removeprefix("website/") for p in vitest_targets]
+    plan = Plan(f"backend-only diff -- full backend + {len(vitest_rel)} frontend guard spec(s)")
+    _backend_full(plan)
+    if vitest_rel:
+        plan.add(
+            "frontend (cross-surface guards)",
+            ["npx", "vitest", "run", *vitest_rel],
+            _REPO_ROOT / "website",
+        )
+    return plan
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main",
+                        help="base ref for the diff (default: origin/main)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print the plan without running anything")
+    parser.add_argument("--full", action="store_true",
+                        help="force the full gate on both surfaces")
+    args = parser.parse_args(argv)
+
+    plan = build_plan(args)
+    print(f"local-gate: {plan.reason}", file=sys.stderr)
+    for label, cmd, cwd in plan.commands:
+        print(f"  [{label}] (cwd={cwd.relative_to(_REPO_ROOT) if cwd != _REPO_ROOT else '.'}) "
+              f"{shlex.join(cmd[:8])}{' ...' if len(cmd) > 8 else ''}", file=sys.stderr)
+    if args.dry_run:
+        return 0
+
+    for label, cmd, cwd in plan.commands:
+        print(f"local-gate: running [{label}]", file=sys.stderr)
+        proc = subprocess.run(cmd, cwd=cwd)
+        if proc.returncode != 0:
+            print(f"local-gate: [{label}] FAILED (rc={proc.returncode})", file=sys.stderr)
+            return proc.returncode
+    print("local-gate: all selected gates passed", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_local_gate.py
+++ b/test/test_local_gate.py
@@ -1,0 +1,278 @@
+"""Tests for the change-scoped local gate (``scripts/local-gate.py``).
+
+The gate narrows the LOCAL iteration suite the same way CI narrows its matrix:
+three diff buckets, narrowing only on a provably single-surface diff, full run
+on any doubt. These tests pin the two contracts that make it safe:
+
+1. **Fail-open**: every unreadable/ambiguous input produces the FULL plan.
+2. **CI parity**: the bucket prefixes here are the SAME ones ci.yml's
+   ``changes`` job uses, asserted against the workflow text so the two cannot
+   drift apart silently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "scripts" / "local-gate.py"
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("local_gate", _SCRIPT)
+    assert spec and spec.loader, "could not build an import spec for the gate"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gate():
+    return _load_gate()
+
+
+def _args(**overrides):
+    defaults = {"base": "origin/main", "dry_run": True, "full": False}
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_script_exists(gate) -> None:
+    assert _SCRIPT.is_file()
+
+
+# ---------------------------------------------------------------------------
+# classify(): the three-bucket rules
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("website/src/App.tsx", (True, False, False)),
+        ("website/electron/main.js", (True, False, False)),
+        (".github/workflows/ci.yml", (False, True, False)),
+        ("scripts/local-gate.py", (False, True, False)),
+        ("src/kiro_crew/gateway.py", (False, False, True)),
+        ("test/test_gateway.py", (False, False, True)),
+        ("docs/README.md", (False, False, True)),  # catch-all: unrecognised = backend
+        ("newtoplevel.cfg", (False, False, True)),
+        ("websites/evil.py", (False, False, True)),  # prefix, not substring
+    ],
+)
+def test_classify_buckets(gate, path: str, expected) -> None:
+    assert gate.classify([path]) == expected
+
+
+def test_classify_mixed_diff_sets_both_flags(gate) -> None:
+    frontend, meta, backend = gate.classify(
+        ["website/src/App.tsx", "src/kiro_crew/gateway.py"]
+    )
+    assert frontend and backend and not meta
+
+
+def test_classify_windows_separators(gate) -> None:
+    assert gate.classify(["website\\src\\App.tsx"]) == (True, False, False)
+
+
+def test_classify_ignores_blank_lines(gate) -> None:
+    assert gate.classify(["", "  "]) == (False, False, False)
+
+
+# ---------------------------------------------------------------------------
+# CI parity: the buckets MUST be the ones ci.yml uses
+# ---------------------------------------------------------------------------
+
+def test_bucket_prefixes_match_ci_changes_job(gate) -> None:
+    """The bucket rules must be exactly ci.yml's — in BOTH directions.
+
+    A one-directional substring pin would catch a local prefix missing from
+    ci.yml but not a bucket CI adds (a new frontend tree, a path moved into
+    meta): the local gate would misclassify it into the backend catch-all and
+    skip locally what CI runs. Parse the workflow's ``filters:`` block and
+    assert set equality, so any divergence — either direction — fails here.
+    """
+    yaml = pytest.importorskip("yaml")
+    workflow = yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))
+    filter_step = next(
+        step
+        for step in workflow["jobs"]["changes"]["steps"]
+        if "paths-filter" in str(step.get("uses", ""))
+    )
+    filters = yaml.safe_load(filter_step["with"]["filters"])
+
+    def _prefixes(patterns: list[str]) -> set[str]:
+        # ci.yml expresses buckets as '<prefix>**' globs; anything else in a
+        # bucket the local gate mirrors would need new classify() logic, so
+        # fail loudly rather than approximating.
+        out = set()
+        for pattern in patterns:
+            assert pattern.endswith("**") and not pattern.startswith("!"), (
+                f"ci.yml bucket pattern {pattern!r} is not a plain '<prefix>**' "
+                "glob -- update scripts/local-gate.py classify() to match it, "
+                "then update this parser"
+            )
+            out.add(pattern[:-2])
+        return out
+
+    assert set(gate._FRONTEND_PREFIXES) == _prefixes(filters["frontend"]), (
+        "frontend bucket drifted between scripts/local-gate.py and ci.yml -- "
+        "update _FRONTEND_PREFIXES and ci.yml together"
+    )
+    assert set(gate._META_PREFIXES) == _prefixes(filters["meta"]), (
+        "meta bucket drifted between scripts/local-gate.py and ci.yml -- "
+        "update _META_PREFIXES and ci.yml together"
+    )
+    # The backend bucket must stay the exact complement of the other two:
+    # positive '**' plus a negation for every frontend/meta pattern. A bucket
+    # added to frontend/meta without its matching backend negation would make
+    # some paths land in TWO buckets, breaking "only_X means only X changed".
+    positives = [p for p in filters["backend"] if not p.startswith("!")]
+    negations = {p[1:] for p in filters["backend"] if p.startswith("!")}
+    assert positives == ["**"], (
+        "ci.yml's backend bucket is no longer a pure '**' catch-all -- "
+        "scripts/local-gate.py classify() must be reworked to match"
+    )
+    assert negations == set(filters["frontend"]) | set(filters["meta"]), (
+        "ci.yml's backend negations no longer mirror frontend+meta exactly -- "
+        "re-derive the bucket rules in scripts/local-gate.py"
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_plan(): fail-open on every doubtful input
+# ---------------------------------------------------------------------------
+
+def test_electron_filter_is_still_mirrored_from_ci(gate) -> None:
+    """build_plan() filters ``website/electron/`` guards out of the vitest
+    hand-off the same way ci.yml's frontend-test scope step does. That step is
+    bash, so full structural parity isn't parseable — pin the observable
+    contract instead: the frontend-test job still strips electron specs with
+    ``grep -v '^electron/'`` after re-rooting to cwd=website. If this
+    disappears, CI stopped partitioning electron from vitest specs and the
+    local filter needs a fresh look."""
+    workflow = _CI_WORKFLOW.read_text(encoding="utf-8")
+    assert "frontend-test:" in workflow
+    frontend_job = workflow.split("frontend-test:", 1)[1]
+    # Bound the search to this job: cut at the next top-level job key.
+    next_job = re.search(r"\n  [a-z][a-z0-9-]*:\n", frontend_job)
+    if next_job:
+        frontend_job = frontend_job[: next_job.start()]
+    assert "grep -v '^electron/'" in frontend_job, (
+        "ci.yml's frontend-test job no longer filters electron specs from the "
+        "vitest hand-off -- re-examine the electron filtering in "
+        "scripts/local-gate.py build_plan()"
+    )
+
+
+def _plan_labels(plan) -> list[str]:
+    return [label for label, _cmd, _cwd in plan.commands]
+
+
+def _is_full(plan) -> bool:
+    return _plan_labels(plan) == ["backend (full)", "frontend (full)"]
+
+
+def test_full_flag_forces_full_gate(gate) -> None:
+    assert _is_full(gate.build_plan(_args(full=True)))
+
+
+def test_unreadable_diff_falls_open(gate, monkeypatch) -> None:
+    monkeypatch.setattr(gate, "changed_files", lambda base: None)
+    plan = gate.build_plan(_args())
+    assert _is_full(plan)
+    assert "fail-open" in plan.reason
+
+
+def test_empty_diff_falls_open(gate, monkeypatch) -> None:
+    monkeypatch.setattr(gate, "changed_files", lambda base: [])
+    assert _is_full(gate.build_plan(_args()))
+
+
+def test_meta_diff_runs_full(gate, monkeypatch) -> None:
+    monkeypatch.setattr(gate, "changed_files", lambda base: ["scripts/clean.sh"])
+    assert _is_full(gate.build_plan(_args()))
+
+
+def test_both_surfaces_runs_full(gate, monkeypatch) -> None:
+    monkeypatch.setattr(
+        gate, "changed_files",
+        lambda base: ["website/src/App.tsx", "src/kiro_crew/gateway.py"],
+    )
+    assert _is_full(gate.build_plan(_args()))
+
+
+def test_selector_failure_falls_open(gate, monkeypatch) -> None:
+    monkeypatch.setattr(gate, "changed_files", lambda base: ["website/src/App.tsx"])
+    monkeypatch.setattr(gate, "selector_must_run", lambda surface: None)
+    plan = gate.build_plan(_args())
+    assert _is_full(plan)
+    assert "fail-open" in plan.reason
+
+
+# ---------------------------------------------------------------------------
+# build_plan(): the two narrowed shapes
+# ---------------------------------------------------------------------------
+
+def test_frontend_only_diff_narrows_backend(gate, monkeypatch) -> None:
+    monkeypatch.setattr(gate, "changed_files", lambda base: ["website/src/App.tsx"])
+    monkeypatch.setattr(
+        gate, "selector_must_run",
+        lambda surface: ["test/test_redaction_mirror_parity.py"],
+    )
+    plan = gate.build_plan(_args())
+    labels = _plan_labels(plan)
+    assert labels == ["frontend (full)", "backend (cross-surface guards)"]
+    _label, cmd, _cwd = plan.commands[1]
+    assert cmd[-1] == "test/test_redaction_mirror_parity.py"
+
+
+def test_frontend_only_diff_with_no_guards_runs_frontend_alone(gate, monkeypatch) -> None:
+    monkeypatch.setattr(gate, "changed_files", lambda base: ["website/src/App.tsx"])
+    monkeypatch.setattr(gate, "selector_must_run", lambda surface: [])
+    plan = gate.build_plan(_args())
+    assert _plan_labels(plan) == ["frontend (full)"]
+
+
+def test_backend_only_diff_narrows_frontend(gate, monkeypatch) -> None:
+    monkeypatch.setattr(gate, "changed_files", lambda base: ["src/kiro_crew/gateway.py"])
+    monkeypatch.setattr(
+        gate, "selector_must_run",
+        lambda surface: [
+            "website/src/utils/sanitize.test.ts",
+            "website/electron/permissions.test.js",  # electron job's guard: filtered
+        ],
+    )
+    plan = gate.build_plan(_args())
+    labels = _plan_labels(plan)
+    assert labels == ["backend (full)", "frontend (cross-surface guards)"]
+    _label, cmd, cwd = plan.commands[1]
+    # electron guard filtered out; path re-rooted for cwd=website
+    assert cmd[-1] == "src/utils/sanitize.test.ts"
+    assert not any("electron" in part for part in cmd)
+    assert cwd.name == "website"
+
+
+def test_backend_only_diff_with_no_guards_runs_backend_alone(gate, monkeypatch) -> None:
+    monkeypatch.setattr(gate, "changed_files", lambda base: ["src/kiro_crew/gateway.py"])
+    monkeypatch.setattr(gate, "selector_must_run", lambda surface: [])
+    plan = gate.build_plan(_args())
+    assert _plan_labels(plan) == ["backend (full)"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end dry run against the real repo (no tests executed)
+# ---------------------------------------------------------------------------
+
+def test_dry_run_exits_zero_and_prints_plan(gate, capsys) -> None:
+    rc = gate.main(["--dry-run", "--full"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "local-gate:" in err
+    assert "backend (full)" in err
+    assert "frontend (full)" in err


### PR DESCRIPTION
## What

A change-scoped local test gate: `scripts/local-gate.py` reads the diff against the merge-base with `origin/main` (committed + working tree), classifies it with the same three buckets ci.yml's `changes` job uses (`website/**` = frontend, `.github/**` + `scripts/**` = meta, everything else = backend catch-all), and runs only the surfaces the diff can affect:

- frontend-only diff: full frontend suite + the backend files `ci-surface-tests.py --surface backend` could not prove single-surface (currently 270 of 1240)
- backend-only diff: full backend suite + the unproven frontend guard specs (currently 120 of 931), with `website/electron` guards filtered out the same way CI's frontend-test scope step filters them
- meta touched, both surfaces touched, empty or unreadable diff, or selector error: the full gate on both surfaces

`--dry-run` prints the plan without running anything; `--full` forces the full gate.

## Why

Iteration loops on this repo (review-fix rounds, PR amends) run the full backend suite for every change. On a 16-core host that is about an hour per amend regardless of what changed; a one-file frontend fix pays the same gate as a backend refactor. CI already solved the safe-narrowing problem for its own matrix — the `changes` job plus `scripts/ci-surface-tests.py`, with every doubt falling back to the full run. This reuses that exact machinery locally instead of inventing a second selection heuristic.

The safety posture is unchanged from CI's, and `test/test_local_gate.py` pins it:

- every ambiguous input (meta diff, mixed diff, unreadable diff, selector failure) produces the full plan — asserted per case
- the bucket prefixes are asserted against the ci.yml text itself, so the local gate and CI cannot drift apart silently
- the selector keeps its deny-by-default contract: a heuristic miss costs local time, never a skipped cross-surface guard

This is an iteration-loop tool. The final pre-push gate and CI stay full-suite; nothing in CI consumes this script.

## Testing

- 25 new tests in `test/test_local_gate.py` (classification incl. catch-all and prefix-vs-substring cases, CI-parity pin, all fail-open paths, both narrowed plan shapes, electron filtering and path re-rooting, dry-run end-to-end) — all pass
- `test/test_ci_surface_tests.py` (39 tests) still green — the selector itself is untouched
- flake8, isort, mypy clean on both new files
- live smoke: on this PR's own worktree the gate classifies its diff as meta+backend and correctly plans the full gate
