### PR TITLE
fix(chat): restore the turn deadline by value, not by ContextVar token

### DIFF
--- a/src/kiro_crew/dashboard/turn_dispatch.py
+++ b/src/kiro_crew/dashboard/turn_dispatch.py
@@ -298,10 +298,22 @@ async def _bounded_turn(coro: "Coroutine[Any, Any, Any]", timeout_secs: float) -
     # Published so anything running INSIDE the turn can size its own waits
     # against the budget that is actually left, rather than against the
     # full-length ceiling. Set before the task is created so the task's context
-    # copy carries it; reset in the finally so a direct `await _bounded_turn(...)`
-    # cannot leak a spent deadline into the caller's context and starve the next
-    # turn dispatched there.
-    deadline_token = _TURN_DEADLINE.set(loop.time() + timeout_secs)
+    # copy carries it; restored in the finally so a direct
+    # `await _bounded_turn(...)` cannot leak a spent deadline into the caller's
+    # context and starve the next turn dispatched there.
+    #
+    # Save-and-restore rather than a Token, because this coroutine's `finally`
+    # does not always run in the context that entered it. An abandoned wrapper
+    # — a gateway shutdown that closes the loop with a turn still pending, a
+    # coroutine never awaited — is finalized by the GARBAGE COLLECTOR, which
+    # throws GeneratorExit in from whatever context happens to be current.
+    # `Token.reset` refuses that with `ValueError: ... was created in a
+    # different Context`, and because it raises inside `__del__` the failure is
+    # unraisable: it cannot be caught by the caller and is only printed. `set`
+    # has no such affinity — restoring into a foreign context writes a value
+    # that context is about to discard, which is precisely the no-op wanted.
+    previous_deadline = _TURN_DEADLINE.get()
+    _TURN_DEADLINE.set(loop.time() + timeout_secs)
     task: "asyncio.Task[Any]" = asyncio.ensure_future(coro)
     handle = loop.call_later(timeout_secs, _on_deadline)
     try:
@@ -322,7 +334,7 @@ async def _bounded_turn(coro: "Coroutine[Any, Any, Any]", timeout_secs: float) -
         return result
     finally:
         handle.cancel()
-        _TURN_DEADLINE.reset(deadline_token)
+        _TURN_DEADLINE.set(previous_deadline)
         if not task.done():
             # The wrapper itself was cancelled; don't orphan the turn.
             task.cancel()

--- a/test/test_turn_deadline_contextvar.py
+++ b/test/test_turn_deadline_contextvar.py
@@ -1,0 +1,141 @@
+"""``_bounded_turn`` must survive being finalized outside its own context.
+
+The wrapper publishes the turn's deadline on a ``ContextVar`` so anything
+running inside the turn can size its waits against the budget that is actually
+left. Restoring that with a ``Token`` assumes the ``finally`` runs in the
+context that entered the ``try`` — and for an ABANDONED wrapper it does not.
+
+A gateway shutdown that closes the loop with a turn still pending, or a
+coroutine that is never awaited, leaves the coroutine object to the garbage
+collector, which throws ``GeneratorExit`` in from whatever context is current
+when it runs. ``Token.reset`` refuses that with ``ValueError: ... was created in
+a different Context``, and because it raises inside ``__del__`` it is
+*unraisable*: no caller can catch it, it is only printed. Under pytest each one
+becomes a ``PytestUnraisableExceptionWarning``, and enough of them take an xdist
+worker down with them.
+
+``ContextVar.set`` has no such affinity, so save-and-restore is correct in both
+directions: it restores properly on the normal path, and a restore that lands in
+a foreign context during finalization writes to a context that is about to be
+discarded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+
+import pytest
+
+from kiro_crew.dashboard.turn_dispatch import _TURN_DEADLINE, _bounded_turn
+
+
+async def _never() -> None:
+    await asyncio.Event().wait()
+
+
+def _step_into_the_turn(wrapper):
+    """Advance *wrapper* past the deadline publish, to its first suspension."""
+    wrapper.send(None)
+
+
+class TestFinalizationOutsideTheOwningContext:
+    @pytest.mark.asyncio
+    async def test_closing_an_abandoned_wrapper_from_another_context_is_quiet(self):
+        """The exact shape the collector produces, made deterministic.
+
+        Stepped far enough to publish the deadline in THIS context, then closed
+        from a different ``contextvars.Context`` — which is what a GC pass
+        running on an unrelated stack does.
+        """
+        wrapper = _bounded_turn(_never(), timeout_secs=30.0)
+        _step_into_the_turn(wrapper)
+
+        foreign = contextvars.copy_context()
+        try:
+            foreign.run(wrapper.close)  # must not raise
+        finally:
+            await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_an_abandoned_dispatched_turn_leaves_the_caller_clean(self):
+        """Production shape: ``spawn_guarded_turn`` dispatches the wrapper as a
+        TASK, so its publish and its restore both happen in the task's own
+        context copy. Cancelling and dropping it must raise nothing and must
+        leave the dispatching context untouched — the next turn dispatched here
+        would otherwise inherit a budget that is already spent."""
+        assert _TURN_DEADLINE.get() is None
+
+        task = asyncio.ensure_future(_bounded_turn(_never(), timeout_secs=30.0))
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert _TURN_DEADLINE.get() is None
+
+    @pytest.mark.asyncio
+    async def test_closing_in_the_owning_context_still_works(self):
+        """The ordinary abandonment, for symmetry: same coroutine, closed where
+        it was started."""
+        wrapper = _bounded_turn(_never(), timeout_secs=30.0)
+        _step_into_the_turn(wrapper)
+
+        wrapper.close()
+        await asyncio.sleep(0)
+
+        assert _TURN_DEADLINE.get() is None
+
+
+class TestTheDeadlineContractIsUnchanged:
+    @pytest.mark.asyncio
+    async def test_the_deadline_is_published_for_the_turn(self):
+        """What the ContextVar exists for: code inside the turn can read it."""
+        seen: list[float | None] = []
+
+        async def _observe() -> str:
+            seen.append(_TURN_DEADLINE.get())
+            return "done"
+
+        result = await _bounded_turn(_observe(), timeout_secs=30.0)
+
+        assert result == "done"
+        assert seen and seen[0] is not None
+
+    @pytest.mark.asyncio
+    async def test_a_completed_turn_does_not_leak_its_deadline(self):
+        """A direct ``await _bounded_turn(...)`` shares the caller's context, so
+        a spent deadline left behind would starve the next turn dispatched
+        there."""
+        assert _TURN_DEADLINE.get() is None
+
+        await _bounded_turn(asyncio.sleep(0), timeout_secs=30.0)
+
+        assert _TURN_DEADLINE.get() is None
+
+    @pytest.mark.asyncio
+    async def test_a_nested_wrapper_restores_the_outer_turns_deadline(self):
+        """Save-and-restore must put back what was there, not merely clear.
+
+        A bare ``set(None)`` would pass the leak test above while silently
+        blanking an enclosing turn's budget.
+        """
+        outer_seen: list[float | None] = []
+
+        async def _outer() -> None:
+            published = _TURN_DEADLINE.get()
+            assert published is not None
+            await _bounded_turn(asyncio.sleep(0), timeout_secs=5.0)
+            outer_seen.append(_TURN_DEADLINE.get())
+            assert _TURN_DEADLINE.get() == published
+
+        await _bounded_turn(_outer(), timeout_secs=30.0)
+
+        assert outer_seen and outer_seen[0] is not None
+        assert _TURN_DEADLINE.get() is None
+
+    @pytest.mark.asyncio
+    async def test_the_ceiling_still_fires(self):
+        """The wrapper's actual job, unchanged by the restore mechanism."""
+        with pytest.raises(TimeoutError):
+            await _bounded_turn(_never(), timeout_secs=0.01)


### PR DESCRIPTION
Fixes #2837.

## Problem / Motivation

`_bounded_turn` publishes the turn's deadline on a `ContextVar` and restores it with a `Token`:

```python
deadline_token = _TURN_DEADLINE.set(loop.time() + timeout_secs)
...
finally:
    _TURN_DEADLINE.reset(deadline_token)
```

That assumes the `finally` runs in the context that entered the `try`. For an **abandoned** wrapper it does not. A gateway shutdown that closes the loop with a turn still pending, or a coroutine that is never awaited, leaves the coroutine object to the **garbage collector**, which throws `GeneratorExit` in from whatever context happens to be current when it runs. `Token.reset` refuses that:

```
Exception ignored in: <coroutine object _bounded_turn at 0x...>
  File "...\turn_dispatch.py", line 325, in _bounded_turn
    _TURN_DEADLINE.reset(deadline_token)
ValueError: <Token var=<ContextVar name='kirocrew_turn_deadline' ...>> was created in a different Context
```

Because it raises inside `__del__` the failure is **unraisable** — no caller can catch it, it is only printed. Under pytest each one becomes a `PytestUnraisableExceptionWarning`, and enough of them take the xdist worker down with them, which is how this surfaces as `Backend Tests (Windows) shard 1` failing on unrelated PRs.

## Why it matters

The unraisable exception is thrown from a GC finalizer, so it cannot be caught by
the code that caused it. Enough of them crash the xdist worker outright, which is
what makes this a production defect rather than noise: any abandoned bounded turn
leaks a broken `ContextVar` token, and the failure surfaces far away from its
cause with no stack pointing back.

## What changed

Save and restore the value instead of holding a token:

```python
previous_deadline = _TURN_DEADLINE.get()
_TURN_DEADLINE.set(loop.time() + timeout_secs)
...
finally:
    _TURN_DEADLINE.set(previous_deadline)
```

`ContextVar.set` has no context affinity, so this is correct in both directions: it restores properly on the normal path, and a restore that lands in a foreign context during finalization writes into a context that is about to be discarded — precisely the no-op wanted.

Saving the **previous value** rather than clearing matters: a bare `set(None)` would pass a leak test while silently blanking an enclosing turn's budget. There is a test for exactly that.

## Why this is a production bug, not only a test-infrastructure one

The unraisable `ValueError` is raised on every abandoned turn wrapper — a shutdown with turns in flight is the ordinary case. It is invisible in production only because nothing is watching `sys.unraisablehook` there; pytest is what makes it loud. The deadline itself is also left wrong in the finalizing context, which is the thing `_turn_budget_remaining` reads to size in-turn waits.

## Reproduction

`test/test_turn_deadline_contextvar.py` makes the GC shape deterministic: step the wrapper past the publish, then close it from a different `contextvars.Context` — which is what a collector running on an unrelated stack does.

**1 failed / 6 passed on `24a6f8ee5` → 7 passed.** The single fail-before is the exact CI `ValueError`; the other six are the preservation contract and already pass on main:

- the deadline is published to code running inside the turn;
- a completed turn does not leak its deadline into the caller's context;
- a **nested** wrapper restores the outer turn's deadline rather than blanking it;
- the ceiling still fires;
- an abandoned *dispatched* turn (the `spawn_guarded_turn` shape, its own task context) leaves the dispatching context clean;
- closing in the owning context still works.

## Tests

Windows 11 26200 / py3.10.6.

- `test_turn_deadline_contextvar.py` — 1 failed / 6 passed before, 7 passed after.
- With `test_turn_dispatch.py`, `test_turn_teardown_release.py`, `test_dashboard_approval.py`, `test_dashboard_approval_window.py`, `test_dashboard_chat.py`, run on the **exact base and on this branch with the identical selection** and compared by failing-node set: **base 4 failed / 663 passed; branch 3 failed / 664 passed.** The one node that disappears is this PR's fail-before; the remaining three are `test_dashboard_approval.py` failures present on base under the same selection and unrelated to this change. `FIX_ONLY = ∅`.
- `flake8`, `isort`, `git diff --check` clean; `mypy` reports nothing in `turn_dispatch.py`. `black` wants to reformat one pre-existing line in this file that the change does not touch, so it is left alone.

## Note on the CI symptom

I triaged this from three job logs before writing any code: the base commit `24a6f8ee5`'s own push CI fails Windows shard 1 on this same single node (`worker 'gw0' crashed`), as do PRs #2594 and #2842 (`gw1`). The crash is not caused by any of them, which is the point of #2837 — and matches the report of it hitting #2823 and #2735 too.

Fixing the unraisable removes the crash source. I have not tried to make `test_interactive_reject` itself more robust; if it still proves unstable for an unrelated reason, that is a separate change.

