### PR TITLE
fix(tests): secret-shaped parametrize IDs leak into derived artifacts

### DIFF
--- a/test/test_handlers_messaging_coverage.py
+++ b/test/test_handlers_messaging_coverage.py
@@ -1338,6 +1338,10 @@ class TestHelpers:
             ("abcdefgh", "••••efgh"),
             ("ab", "••••"),
         ],
+        # Safe display labels: without them pytest embeds the token-shaped
+        # value in the test ID, which then lands in derived artifacts
+        # (.test_durations, junit XML) and trips GitHub push protection.
+        ids=["empty", "slack-token", "generic", "too-short"],
     )
     def test_mask_secret(self, value: str, expected: str) -> None:
         assert mod._mask_secret(value) == expected

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -209,6 +209,13 @@ class TestRedactCredentials:
     # the intended token (the redaction test is unchanged). The split keeps any
     # single source literal from being a complete provider token, so GitHub
     # push-protection / secret scanners don't flag these synthetic fixtures.
+    #
+    # The explicit ``ids=`` labels exist for the same reason one level up:
+    # without them pytest derives each test ID from the REASSEMBLED value, and
+    # the full key-shaped string then lands verbatim in every derived artifact
+    # (.test_durations, junit XML, CI logs). Push protection rejects any branch
+    # carrying such an artifact — that is what kept the Update Test Durations
+    # workflow from ever landing its PR. Keep these labels secret-shape-free.
     @pytest.mark.parametrize(
         "secret",
         [
@@ -228,6 +235,22 @@ class TestRedactCredentials:
             "dop_v1_" "abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrst",  # DigitalOcean
             "GOCSPX-" "abcdefghijklmnopqrstuvwx",  # Google OAuth
         ],
+        ids=[
+            "github-classic-pat",
+            "github-oauth",
+            "github-fine-grained-pat",
+            "gitlab-pat",
+            "stripe-live",
+            "stripe-test",
+            "stripe-restricted",
+            "sendgrid",
+            "openai-project",
+            "anthropic",
+            "npm-token",
+            "pypi-token",
+            "digitalocean",
+            "google-oauth",
+        ],
     )
     def test_redacts_third_party_credentials(self, secret: str) -> None:
         text = f"KEY={secret}"
@@ -245,6 +268,9 @@ class TestRedactCredentials:
             "sk_live_" "51HG7aBcDeFgHiJkLmNoPqRsTuVwXyZ",  # Stripe live
             "xoxb-" "1234567890-abcdefghijklmnop",  # Slack bot token
         ],
+        # Safe display labels: pytest would otherwise derive the ID from the
+        # reassembled token — see the note on the parametrize above.
+        ids=["github-classic-pat", "anthropic", "openai-project", "stripe-live", "slack-bot"],
     )
     def test_warning_does_not_leak_secret_prefix(self, secret: str) -> None:
         """The warnings list must carry NO secret bytes — only length metadata.


### PR DESCRIPTION
## What

Adds explicit `ids=` labels to the three `pytest.mark.parametrize` sites whose fixtures are synthetic provider credentials (`test/test_security.py` ×2, `test/test_handlers_messaging_coverage.py` ×1). The fixture values are unchanged — only the display IDs pytest derives from them are replaced with provider-name labels (`stripe-live`, `github-classic-pat`, ...).

## Why

The fixtures are deliberately written as split string literals so no source line contains a complete provider token — the comment above them says exactly that, and it works: the scanner never flags the source. But pytest derives each parametrized test ID from the *reassembled* runtime value, so the complete key-shaped string (`sk_live_51HG7a...`, `ghp_ABCD...`, `xoxb-1234...`) appears verbatim in every derived artifact: `.test_durations`, junit XML, CI logs. The protection applied to the source does not survive into the artifacts.

Concrete consequence: the `Update Test Durations` workflow (`.github/workflows/test-durations.yml`) runs the suite with `--store-durations` and pushes a branch with the refreshed file — and that push is declined by GitHub push protection as a repository rule violation, flagging Stripe live/restricted key patterns at `.test_durations:32017/32020/32035`. Reproduced today via `workflow_dispatch` on a fork ([failed run](https://github.com/rubencu/KiroCrew/actions/runs/31505771639)); the same failure explains why no `.test_durations` file has ever landed despite ci.yml being written to consume one ("With a committed .test_durations file the split is balanced by *recorded time*"). Until this fix, pytest-split shards are balanced by test count, not duration.

## Testing

- `test/test_security.py` + `test/test_handlers_messaging_coverage.py`: 755 passed locally
- flake8 / isort clean on both files
- Collection sweep: `pytest --collect-only -q` over `test/` and `src/kiro_crew/apps/builtins` grepped for all 14 provider token shapes — 0 hits after the change (50 before)
- A comment on each site explains why the labels must stay secret-shape-free, so a future fixture addition doesn't silently regress this
