### PR TITLE
feat: generate intent-level session summaries behind a flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ in the **same commit** when you change what it documents.
 | `computer_use/` | [computer-use](docs/system-specs/modules/computer-use.md) |
 | `acp/`, kiro-cli transport, providers | [acp-client](docs/system-specs/modules/acp-client.md) + [providers](docs/system-specs/modules/providers.md) |
 | sessions, slots, session keys, PIDs | [session](docs/system-specs/modules/session.md) + [history](docs/system-specs/modules/history.md) |
+| session summaries, the chat summary panel, intent extraction | [session-summary](docs/system-specs/modules/session-summary.md) |
 | memory, embeddings, vectors, lessons, skills, hooks | [memory-skills-hooks](docs/system-specs/modules/memory-skills-hooks.md) |
 | MCP servers or tools (adding, changing, statelessness) | [mcp](docs/architecture/mcp.md) |
 | apps, App Kit, manifests, app agents | [app-kit-platform](docs/system-specs/modules/app-kit-platform.md) + [app-kit/](docs/app-kit/README.md) |

--- a/docs/system-specs/modules/README.md
+++ b/docs/system-specs/modules/README.md
@@ -16,6 +16,7 @@ agent loads only the one it needs.
 | [providers.md](providers.md) | The `LLMProvider` interface and the KiroACP-only provider surface. |
 | [session.md](session.md) | Sessions, slots, session keys, the warm pool, and PID tracking. |
 | [history.md](history.md) | Conversation persistence, JSONL rotation, and transcript search. |
+| [session-summary.md](session-summary.md) | Intent-level session summaries: the sidecar cache, extraction, and the turn-end pass. |
 | [file-search.md](file-search.md) | The `@`-mention file/folder search: index, ranking, `kinds` filter, and the sensitive-path symmetry. |
 | [session-storage.md](session-storage.md) | What sessions cost on disk, and the user-initiated trash that reclaims it. |
 | [config.md](config.md) | The config schema, defaults, loading, and live reload. |

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -12,6 +12,14 @@ writing.
 
 The config module (`kiro_crew/config/loader.py`) loads runtime configuration from `~/.kiro/crew/config.json` using stdlib dataclasses with sensible defaults.
 
+A feature whose section spends tokens on the user's behalf defaults to off and
+documents its knobs in its own spec — `session_summary` is the current example
+(see [session-summary.md](session-summary.md)), following the shape
+`SkillsConfig` established: every field carries `_meta` label/help for the config
+surfaces, out-of-range values are clamped with a warning rather than raising, and
+a malformed section degrades to defaults so a hand-edited file cannot prevent the
+gateway from starting.
+
 ## Data Home Location & Migration
 
 KiroCrew's data root nests **under kiro-cli's own `~/.kiro/` base** so all

--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -40,7 +40,12 @@ workspace-scoped by default (fail-closed via `_caller_workspace`/`_ws_bucket`,
   cost. A new message advances the mtime and invalidates the cache. Because the
   session log is untouched, `list_sessions(summarize=true)` remains a true read of
   conversation history (`get_cached_summary` / `set_cached_summary` in
-  `ConversationLog`). The gateway-side one-liner
+  `ConversationLog`). The intent-level session summary shown in the chat panel
+  uses the same mtime-signature contract but a **separate** sidecar
+  (`sessions/.intents/`), because the two artifacts have independent writers and
+  sharing one file would reintroduce the read-modify-write race the sidecar design
+  avoids — see [session-summary.md](session-summary.md). The gateway-side
+  one-liner
   generation uses the shared `llm_helpers.run_bg_oneliner` helper (the same
   acquire→drive→destroy skeleton as title / link-label / folder-icon generation).
 

--- a/docs/system-specs/modules/session-summary.md
+++ b/docs/system-specs/modules/session-summary.md
@@ -1,0 +1,310 @@
+# Session Summary
+
+## Overview
+
+The session summary is an intent-level description of a chat session, generated
+after a turn completes and rendered in the chat right panel. Its purpose is
+narrow: make **re-entering** a session cheap. A person who kicked off work, got
+pulled away, and came back needs three things — why they asked for this, what
+happened, and what to do next — without re-reading the transcript.
+
+The organizing unit is an **intent**: a goal the person pursued, which can span
+many turns. It is not a per-turn log and not a diff. A session where the person
+pivoted produces several intents.
+
+Off by default. Generating a summary spends tokens on a turn the user did not ask
+to pay for, so the whole subsystem is inert until `session_summary.enabled`.
+
+| Concern | Module |
+|---|---|
+| Config section and its clamps | `config/loader.py` (`SessionSummaryConfig`) |
+| Transcript extraction, payload shaping | `session_summary.py` |
+| Turn-end generation, the prompt | `dashboard/chat_summary.py` |
+| Sidecar cache | `history.py` (`ConversationLog`) |
+| Read endpoint | `dashboard/chat_handlers.py` (`api_chat_slot_summary`) |
+
+## Storage: a sidecar, never the transcript
+
+Summaries live in `~/.kiro/crew/sessions/.intents/<safe_key>.json`, keyed by the
+session's **transcript** key, with the payload shape below plus a `sig` field.
+
+```json
+{"sig": 1760000000.5, "generated_at": 1760000123.1, "user_turns": 7,
+ "last_activity": "2026-08-10T10:00:00+00:00",
+ "intents": [ … ], "constraints": [ … ]}
+```
+
+Three properties of this arrangement are load-bearing:
+
+**The transcript is never rewritten.** A summary write touches only the sidecar.
+The session JSONL's mtime is the cache-validity signature for *every* derived
+artifact and the sort key for `list_sessions`, so a write that advanced it would
+invalidate unrelated caches and reorder the user's session list. Housekeeping
+rewrites (title edits, consolidation, rotation) deliberately restore the previous
+mtime for the same reason — see `history.md`. `test_session_summary_storage.py`
+pins that writing and reading a summary leaves the transcript's bytes and mtime
+untouched.
+
+**`sig` is the session file's mtime.** Any real append advances it and invalidates
+the cache; a metadata-only rewrite does not. This makes staleness exact and free
+to check — one `stat`, no content comparison.
+
+**It is a different file from the one-line summary.** `.summaries/<key>.json`
+holds the on-demand one-line description shown in the sessions list, written by
+`set_cached_summary`, which overwrites the whole file. The two artifacts have
+independent writers and independent triggers, so sharing a file would have them
+clobbering each other — exactly the read-modify-write race the sidecar design
+exists to avoid.
+
+Both sidecars are reaped by `delete_session`, which is contractually a permanent
+removal: a deleted session must leave no orphaned model-generated text on disk.
+
+**The write is guarded against resurrecting a delete.** Generation holds no lock
+while the model call is in flight (it can take tens of seconds), so a permanent
+`delete_session` can complete in that window — removing the transcript and both
+sidecars. `set_cached_intent_summary` therefore takes `_locked(key)` and writes
+only if the transcript still exists with the exact signature the generation
+started from; otherwise it refuses (returns `False`) and the generator discards
+the payload without pushing a WS update or advancing its turn mark. The same
+check drops a summary a mid-generation append has already made stale, rather
+than storing it as the latest word.
+
+### Keyed on the transcript key, not the slot key
+
+The cache is keyed by `slot_history_key(slot)`. That differs from `slot.key` for a
+channel-born slot the dashboard could not bind, and keying on the slot key would
+stat a file no read path addresses — the summary would be written to a phantom
+transcript and the panel would never find it. Generator and endpoint resolve the
+same key for this reason.
+
+## Payload shape
+
+Each intent carries:
+
+| Field | Meaning |
+|---|---|
+| `title` | The goal, short, in the person's terms |
+| `ranges` | **List** of `[first_user_turn, last_user_turn]` pairs |
+| `status` | `active` \| `completed` \| `abandoned` — about the work |
+| `verified` | `true` \| `false` \| `null` — about the result, independent of status |
+| `state` | Derived single word the panel renders |
+| `last_touched_turn` | Highest turn in `ranges`; the panel's sort key |
+| `origin_turn` | The turn that triggered this intent, or `null` |
+| `initial_intent` | Why the work started |
+| `progress` | A runbook of what is true now, not a history |
+| `next_steps` | `{what, why, expect}` — the summarizer's inferences |
+
+**`ranges` is a list, and ranges may overlap.** An intent can go dormant and
+resume days later, and one intent can sit inside another's span (a question asked
+mid-intent whose answer becomes part of the work). A single interval cannot
+express either, and forcing them apart would misdescribe the session.
+
+**Status has two axes because they disagree in the cases that matter.** Work whose
+discussion ended while the goal was never reached — diagnosed but never fixed,
+merged but never run — is exactly what a person forgets. `status: completed` with
+`verified: false` says that; one field cannot. `derive_state()` collapses the two
+into the single word the panel shows, so both surfaces agree by construction:
+
+| status | verified | state |
+|---|---|---|
+| `abandoned` | any | `dropped` |
+| `completed` | `false` | `needs-you` |
+| `completed` | `true` / `null` | `done` |
+| `active` | any | `in-progress` |
+
+`constraints` is session-level, not per-intent: recurring operational facts about
+how this project has to be run (a required build flag, a step that must follow a
+change, a name the user corrected). Capped by `max_constraints`, default 5 — a
+long list stops being read. Durable cross-session preferences belong in
+**lessons**, not here; this field is scoped to the session's project.
+
+## Extraction: what the model actually reads
+
+`extract_turns()` reduces raw transcript records to a bounded input:
+
+- **`role` and `content` only.** Every other field is ignored, notably the `meta`
+  blob on assistant rows — in one real 15.6 MB session, message content totalled
+  602 KB and `meta` was the other 14.65 MB. Ignoring it rather than excerpting it
+  is the single largest saving available.
+- **Tool and error rows are dropped.** The assistant has already distilled them.
+- **User messages whole, assistant messages excerpted** head-and-tail at
+  `assistant_excerpt_chars` (default 400). Intent lives in the user's messages,
+  which are small; progress lives in the assistant's, which are not.
+
+Measured against three real sessions, this reads roughly 1% of a transcript's
+bytes.
+
+### Mechanically detectable traps live here
+
+Two transcript shapes reliably produce a wrong summary and are both detectable
+without judgement, so they are labelled in extraction rather than left to the
+prompt:
+
+- **Automation posting under `role: "user"`** — cron notifications, subagent
+  completion events, auto-nudge cycles, tool refusals, restored webhook context.
+  These are flagged `injected`, excluded from the user-turn count, and rendered
+  as `[automation, not the user]`. Counting one invents a goal the person never
+  had.
+- **A verbatim resend** of the previous user message is marked `repeat_of`. A
+  resend looks identical to insistence, and reading it as insistence produces
+  "the user asked repeatedly, so it was ignored" for a request that already
+  succeeded.
+
+An oversized user paste (a stack trace, a log dump) is capped so one paste cannot
+crowd out the session; intent survives truncation.
+
+## Generation
+
+Dispatched from `_finish_queue_cycle` in `dashboard/chat_runner.py` — the post-turn
+hub, alongside auto-titling — as a background task. Not from `hooks.py`: the
+`Stop` hook event is script/config-driven and fires only for dashboard turns, and
+shipped behavior does not belong on a user-extension seam.
+
+`_should_summarize()` returns a **skip reason string** rather than a boolean, so a
+declined pass is auditable in logs; a feature that silently declines to run is
+indistinguishable from one that is broken.
+
+| Reason | Cause |
+|---|---|
+| `disabled` | The flag is off — the common case, and it costs nothing |
+| `in_flight` | A pass for this slot is already running |
+| `memory_mode` | Incognito or temporary: no derived artifact from this conversation (mirrors `history.INCOGNITO_MEMORY_MODES` — a temporary transcript is discarded, so a persisted summary would outlive it) |
+| `stop_reason:<r>` | The turn did not cleanly end |
+| `too_few_turns` | Below `min_user_turns` |
+| `cadence` | Fewer than `regenerate_after_turns` since the last pass |
+
+**Only a clean `end_turn` qualifies — and the marker is fail-closed.** Timeout,
+cancel-unacked, tool-stall and stale-recover all describe a turn that was cut
+short; summarizing one would present interrupted work as concluded. Because
+`_finish_queue_cycle` does not receive the stop reason, it is recorded on the slot
+at `EVENT_COMPLETE` (`slot._last_stop_reason`) — and **cleared at turn start**, so
+a turn that dies before `EVENT_COMPLETE` (ACP crash, auth expiry, transport drop)
+leaves an empty marker rather than the previous turn's stale `end_turn`. The gate
+requires the marker to equal `end_turn` exactly; empty means "this turn never
+finished" and skips as `stop_reason:missing`.
+
+**Input is the full on-disk transcript, not `slot.messages`.** A restored slot
+keeps only the most recent 500 messages in memory (`chat_persistence` caps the
+restore), so summarizing the in-memory tail of a long session would regenerate
+from a truncated view and overwrite the sidecar — earlier intents would silently
+vanish from the panel. The generator reads `read_messages_chained()` off the event
+loop; the cheap slot-level gates (disabled, unclean stop) run first so the common
+skip cases cost no disk IO, and `extract_turns` still bounds what the model reads.
+
+**An unchanged transcript costs nothing.** Before any model call the pass checks
+the sidecar; a valid signature means the stored summary is already exactly right.
+This is what makes the summary stable rather than a live feed — a property of the
+cache, not something the UI has to enforce.
+
+The model comes from `AgentConfig.resolve_model("background")`; the role never
+inherits `agent.model`, so unattended summarization cannot ride the interactive
+flagship. Every failure path is swallowed and logged: a lost summary must never
+surface as a failed turn, and the previous cached summary stays valid.
+
+On success, `push_session_summary()` broadcasts `{"_type": "session_summary"}` so
+the panel invalidates immediately rather than polling.
+
+### The prompt's trap list is tested
+
+The judgement traps cannot be detected in code, so the prompt names each one, and
+`test_session_summary_generate.py` asserts the prompt still mentions them. A later
+trim of the prompt fails a test instead of quietly degrading every summary:
+retractions supersede the claim they retract; option lines are offers that were
+mostly declined, not requests; merged is not verified; a feasibility question is
+not a work order; facts go stale inside one session; a compaction is not a topic
+boundary; the session title describes only its beginning.
+
+The prompt also ranks the boundary signals: commits and merges punctuate a session
+more reliably than any phrasing, timestamps separate a daily routine from a failed
+retry, and a user correction is the highest-value signal per character in the file.
+
+## Endpoint
+
+```
+GET /api/chat/slots/{slot}/summary
+```
+
+Read-only, and deliberately so: it never triggers generation. A panel that
+generated on open would spend tokens on every look and reward refreshing — the
+behavior the feature exists to remove.
+
+| Response | Meaning |
+|---|---|
+| `200` | `{enabled, stale, intents, constraints, generated_at, user_turns, last_activity}` |
+| `200` with `enabled: false` | Feature off; the panel explains itself rather than erroring |
+| `404` `{"code": "slot_not_found"}` | Unknown slot, or a slot the calling app does not own |
+
+`stale: true` means a summary exists but the transcript has moved on. The stored
+payload is still returned: an empty panel reads as "this is broken" while a stale
+one reads as "not regenerated yet", which is the truth. `read_intent_summary()` is
+the non-strict accessor for this; `get_cached_intent_summary()` is the strict one
+the generator uses.
+
+The flag gates the READ as well as the write. Turning the feature off has to stop
+serving summaries, not merely stop producing them — otherwise a sidecar written
+during an earlier opt-in keeps being returned after opt-out, which is the opposite
+of what the switch promises.
+
+Reads are subject to App Kit §5.2 ownership isolation (mirroring
+`api_chat_slot_delete`): a summary is derived conversation content, so a slot
+merely existing must not make it readable. An app token may read only slots that
+app created, never an unscoped slot; a dashboard user (explicit empty
+`request["app"]`) is unaffected. A denied read answers `404`, not `403`, so a
+foreign slot is indistinguishable from a missing one (anti-enumeration, CWE-204);
+the true reason is recorded via SEL.
+
+## Redaction
+
+The payload is model output derived from transcript text, so anything the user
+pasted into the conversation — a token, a key, a beacon URL — can be reproduced
+inside it. `normalize_payload()` therefore runs the whole payload through the
+standard `redact_credentials` + `redact_exfiltration_urls` chain before it is
+returned, recursively: the payload nests (intents → next_steps → strings) and a
+top-level-only pass would leave every field the panel actually renders unredacted.
+
+Redaction sits in normalization rather than at the write site so that every path
+into the sidecar is covered by construction, and at write time rather than render
+time because the sidecar is durable — a secret written once would be served on
+every subsequent open.
+
+## Configuration
+
+`session_summary` in `config.json`. All knobs exist so cost can be reduced without
+losing the feature.
+
+| Key | Default | Purpose |
+|---|---|---|
+| `enabled` | `false` | Top-level switch; the subsystem is inert while off |
+| `min_user_turns` | `2` | A one-exchange session has no intent structure |
+| `regenerate_after_turns` | `1` | Turns between rebuilds; raise to trade freshness for tokens |
+| `max_intents` | `8` | Oldest-touched are trimmed; the panel collapses them anyway |
+| `max_constraints` | `5` | Project notes; `0` suppresses the section |
+| `assistant_excerpt_chars` | `400` | Head/tail kept per assistant message |
+
+Out-of-range values are clamped with a warning rather than raising, and a
+malformed section degrades to defaults, so a hand-edited `config.json` cannot
+prevent the gateway from starting.
+
+## Scope in this release
+
+Dashboard sessions only. The generator hangs off the dashboard turn-end hub, so
+Slack, cron, webhook and task-runner turns do not produce summaries. Reaching
+them means threading the flag through the same four call sites
+`skills.auto_create_from_sessions` uses (`cli.py`, `cli_server.py`,
+`dashboard/server.py`, `slack/gateway.py`). This is a deliberate cut, not an
+oversight.
+
+No governance capability scope. Nothing enforces one, and a scope is a data-only
+addition later; if one is ever added it must be registered inline in
+`SCOPE_CATALOG`, never lazily from a feature package, because
+`load_security_policy()` runs at boot before feature imports.
+
+## Tests
+
+| File | Covers |
+|---|---|
+| `test_session_summary_config.py` | Defaults, clamping, disk parsing, malformed sections |
+| `test_session_summary_extract.py` | Role filtering, `meta` ignored, excerpting, the two mechanical traps |
+| `test_session_summary_storage.py` | Sidecar round-trip, invalidation, transcript-untouched, delete reaping |
+| `test_session_summary_generate.py` | Gating, caching, failure containment, prompt trap coverage |
+| `test_session_summary_api.py` | Status codes, error `code`, stale flag, never-generates |

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -163,6 +163,7 @@ _KNOWN_CONFIG_SECTIONS: frozenset = frozenset(
         "knowledge",
         "heartbeat",
         "skills",
+        "session_summary",
         "telemetry",
         "snapshot_dir",
         "timezone",
@@ -2738,6 +2739,97 @@ class SkillsConfig:
 
 
 @dataclass
+class SessionSummaryConfig:
+    """Intent-level session summaries shown in the chat right panel.
+
+    Summarizing spends tokens on a turn the user did not ask to pay for, so every
+    field defaults to off/conservative and the feature is inert until ``enabled``.
+    """
+
+    enabled: bool = field(
+        default=False,
+        metadata=_meta(
+            "Session Summaries",
+            "When true, summarize each session by intent after a turn completes so "
+            "the chat right panel can show what the session is about, what has "
+            "happened, and what to do next. Costs tokens on turns that change the "
+            "session; an unchanged session is served from cache for free. Disabled "
+            "by default; enable in Settings.",
+        ),
+    )
+    min_user_turns: int = field(
+        default=2,
+        metadata=_meta(
+            "Minimum User Turns",
+            "Skip summarization until the session has at least this many user "
+            "messages (>=1). A one-exchange session has no intent structure worth "
+            "extracting, and the session title already covers it.",
+        ),
+    )
+    regenerate_after_turns: int = field(
+        default=1,
+        metadata=_meta(
+            "Regenerate Every N Turns",
+            "How many completed turns must pass before the summary is rebuilt "
+            "(>=1). 1 keeps the panel current at the cost of one pass per turn; "
+            "raise it to trade freshness for tokens. A cached summary whose "
+            "session has not changed is never rebuilt regardless of this value.",
+        ),
+    )
+    max_intents: int = field(
+        default=8,
+        metadata=_meta(
+            "Maximum Intents",
+            "Upper bound on intents kept per session (>=1). Beyond this the oldest "
+            "closed intents are dropped, since the panel collapses them anyway.",
+        ),
+    )
+    max_constraints: int = field(
+        default=5,
+        metadata=_meta(
+            "Maximum Project Notes",
+            "Upper bound on session-level operational notes -- the recurring facts "
+            "about how this project is run (>=0). Kept small on purpose: a long "
+            "list stops being read, and durable cross-session preferences belong "
+            "in lessons rather than here.",
+        ),
+    )
+    assistant_excerpt_chars: int = field(
+        default=400,
+        metadata=_meta(
+            "Assistant Excerpt Size",
+            "Characters kept from each end of an assistant message when building "
+            "the summarization input (>=80). User messages are always included in "
+            "full -- they carry intent and are small -- while assistant output is "
+            "excerpted because it holds the progress detail but dominates the "
+            "transcript.",
+        ),
+    )
+
+    def __post_init__(self) -> None:
+        if self.min_user_turns < 1:
+            logger.warning("min_user_turns %d < 1, using 1", self.min_user_turns)
+            object.__setattr__(self, "min_user_turns", 1)
+        if self.regenerate_after_turns < 1:
+            logger.warning(
+                "regenerate_after_turns %d < 1, using 1", self.regenerate_after_turns
+            )
+            object.__setattr__(self, "regenerate_after_turns", 1)
+        if self.max_intents < 1:
+            logger.warning("max_intents %d < 1, using 1", self.max_intents)
+            object.__setattr__(self, "max_intents", 1)
+        if self.max_constraints < 0:
+            logger.warning("max_constraints %d < 0, using 0", self.max_constraints)
+            object.__setattr__(self, "max_constraints", 0)
+        if self.assistant_excerpt_chars < 80:
+            logger.warning(
+                "assistant_excerpt_chars %d < 80, using 80",
+                self.assistant_excerpt_chars,
+            )
+            object.__setattr__(self, "assistant_excerpt_chars", 80)
+
+
+@dataclass
 class TelemetryConfig:
     """Metrics telemetry settings (Wave 0 trunk).
 
@@ -4729,6 +4821,13 @@ class KiroCrewConfig:
         default_factory=SkillsConfig,
         metadata=_meta("Skills", "Skill loading and matching configuration."),
     )
+    session_summary: SessionSummaryConfig = field(
+        default_factory=SessionSummaryConfig,
+        metadata=_meta(
+            "Session Summary",
+            "Intent-level session summaries for the chat right panel. Off by default.",
+        ),
+    )
     telemetry: TelemetryConfig = field(
         default_factory=TelemetryConfig,
         metadata=_meta(
@@ -5078,6 +5177,9 @@ class KiroCrewConfig:
         skills_data = data.get("skills", {})
         if not isinstance(skills_data, dict):
             skills_data = {}
+        session_summary_data = data.get("session_summary", {})
+        if not isinstance(session_summary_data, dict):
+            session_summary_data = {}
         messaging_data = data.get("messaging", {})
         if not isinstance(messaging_data, dict):
             messaging_data = {}
@@ -5812,6 +5914,19 @@ class KiroCrewConfig:
                     p for p in _safe_list(skills_data.get("extra_paths")) if isinstance(p, str)
                 ],
             ),
+            session_summary=SessionSummaryConfig(
+                enabled=bool(session_summary_data.get("enabled", False)),
+                min_user_turns=_safe_int(
+                    session_summary_data.get("min_user_turns", 2), 2),
+                regenerate_after_turns=_safe_int(
+                    session_summary_data.get("regenerate_after_turns", 1), 1),
+                max_intents=_safe_int(
+                    session_summary_data.get("max_intents", 8), 8),
+                max_constraints=_safe_int(
+                    session_summary_data.get("max_constraints", 5), 5),
+                assistant_excerpt_chars=_safe_int(
+                    session_summary_data.get("assistant_excerpt_chars", 400), 400),
+            ),
             slack_channels={
                 ch_id: ChannelConfig.from_dict(ch_data)
                 for ch_id, ch_data in (
@@ -5917,6 +6032,7 @@ class KiroCrewConfig:
             "knowledge": asdict(self.knowledge),
             "heartbeat": asdict(self.heartbeat),
             "skills": asdict(self.skills),
+            "session_summary": asdict(self.session_summary),
             "telemetry": asdict(self.telemetry),
             "snapshot_dir": self.snapshot_dir,
             "timezone": self.timezone,

--- a/src/kiro_crew/dashboard/chat.py
+++ b/src/kiro_crew/dashboard/chat.py
@@ -63,6 +63,7 @@ from kiro_crew.dashboard.chat_handlers import (  # noqa: F401
     api_chat_slot_reasoning_effort,
     api_chat_slot_resume,
     api_chat_slot_stop,
+    api_chat_slot_summary,
     api_chat_slot_workspace,
     api_chat_slots,
     api_chat_slots_cleanup,

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -765,6 +765,68 @@ async def _context_snapshot_fields_inner(
     )
 
 
+async def api_chat_slot_summary(request: web.Request) -> web.Response:
+    """GET /api/chat/slots/{slot}/summary — intent summary for the panel.
+
+    Read-only: it never triggers generation. Summaries are produced at turn end
+    by the background pass, deliberately, so that opening the panel cannot spend
+    tokens and repeated opening cannot turn into a refresh loop.
+
+    Responses:
+      - 200 with ``{enabled, generated_at, stale, intents, constraints, ...}``
+      - 200 with ``intents: []`` and ``enabled: false`` when the feature is off,
+        so the panel can render an explanatory empty state rather than an error
+      - 404 ``slot_not_found`` for an unknown slot, or for a slot an app caller
+        does not own (App Kit §5.2 isolation; 404 not 403 for anti-enumeration)
+    """
+    state: DashboardState = request.app["state"]
+    name = request.match_info["slot"]
+    slot = state._slots.get(name)
+    if not slot:
+        return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
+
+    # App ownership check (App Kit §5.2), mirroring api_chat_slot_delete: a
+    # summary is derived conversation content, so a slot merely existing must
+    # not make it readable. Dashboard users carry an explicit empty request_app
+    # and are unaffected; an app token may only read summaries for slots it
+    # created, never for unscoped slots.
+    request_app = request.get("app", "")
+    if request_app and (not slot._app or slot._app != request_app):
+        sel().log_api_access(
+            caller=request_app,
+            operation="slot_summary_read",
+            outcome="denied",
+            source="app_isolation",
+            resources=f"slot={name}",
+            error="app does not own this slot",
+        )
+        return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
+
+    cfg = await asyncio.to_thread(KiroCrewConfig.load)
+    enabled = bool(cfg.session_summary.enabled)
+
+    payload: dict | None = None
+    stale = False
+    log = state.conversation_log
+    # Gate the cache read on the flag as well: turning the feature off has to
+    # stop serving summaries, not just stop producing them, or a sidecar written
+    # during an earlier opt-in keeps being returned after opt-out.
+    if enabled and log is not None:
+        history_key = slot_history_key(slot)
+        payload, stale = await asyncio.to_thread(log.read_intent_summary, history_key)
+
+    body: dict = {
+        "enabled": enabled,
+        "stale": stale,
+        "intents": (payload or {}).get("intents", []),
+        "constraints": (payload or {}).get("constraints", []),
+        "generated_at": (payload or {}).get("generated_at"),
+        "user_turns": (payload or {}).get("user_turns"),
+        "last_activity": (payload or {}).get("last_activity"),
+    }
+    return web.json_response(body)
+
+
 async def api_chat_slot_detail(request: web.Request) -> web.Response:
     """GET /api/chat/slots/{slot} — message history for a slot.
 

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -60,6 +60,7 @@ from kiro_crew.context_management import (
     validate_plan_format,
 )
 from kiro_crew.dashboard.chat_persistence import _build_history_prefix, save_slot_off_loop
+from kiro_crew.dashboard.chat_summary import generate_session_summary
 from kiro_crew.dashboard.chat_title import (
     _extract_and_redact_plan_metadata,
     _maybe_auto_title,
@@ -3064,6 +3065,13 @@ def _finish_queue_cycle(state: DashboardState, slot: _ChatSlot) -> None:
         state._background_tasks.add(refresh_task)
         refresh_task.add_done_callback(state._background_tasks.discard)
 
+    # Intent summary for the chat summary panel. Self-guarding: the common case
+    # (feature disabled) returns before any work, and an unchanged transcript is
+    # served from the sidecar cache without a model call.
+    summary_task = asyncio.create_task(generate_session_summary(state, slot))
+    state._background_tasks.add(summary_task)
+    summary_task.add_done_callback(state._background_tasks.discard)
+
 
 def _emit_ttft_metric(t0: float, session_key: str, *, is_new: bool, resumed: bool) -> None:
     """Emit the user-message → first-visible-token latency histogram.
@@ -4181,6 +4189,12 @@ async def _run_chat(
             await _deliver_cross_surface_user_message(state, session_key, _user_msg_for_mirror)
 
         _stop_reason = ""
+        # Cleared at turn START so post-turn consumers never read the PREVIOUS
+        # turn's value: a turn that dies before EVENT_COMPLETE (ACP crash, auth
+        # expiry, transport drop) never reaches the assignment below, and a
+        # stale "end_turn" from the last successful turn would make the failed
+        # turn look cleanly finished (e.g. to the session-summary gate).
+        slot._last_stop_reason = ""
         # Tool-stall metadata forwarded by the ACP watchdog on its terminal
         # event (title / redacted command / evidence) — feeds the dedicated
         # tool-stall recovery nudge below.
@@ -5666,6 +5680,10 @@ async def _run_chat(
                     elapsed_ms=_turn_elapsed_ms,
                 )
                 _stop_reason = event.stop_reason
+                # Recorded on the slot so post-turn consumers reached later
+                # (which do not receive the event) can tell a turn that really
+                # finished from one cut short by a timeout, cancel or stall.
+                slot._last_stop_reason = _stop_reason or ""
                 if _stop_reason == STOP_REASON_TOOL_STALL:
                     _stall_tool_title = event.title
                     _stall_command = event.tool_input

--- a/src/kiro_crew/dashboard/chat_summary.py
+++ b/src/kiro_crew/dashboard/chat_summary.py
@@ -1,0 +1,318 @@
+"""Generate intent-level session summaries after a turn completes.
+
+The pass runs on the shared background session, off the turn's critical path,
+and is best-effort throughout: every failure path leaves the previous cached
+summary in place rather than replacing it with something worse. Nothing here
+raises into the caller.
+
+The prompt carries an explicit trap list. Each entry is a transcript shape that
+produced a confidently wrong summary when this was prototyped against real
+sessions -- not a hypothetical. The mechanically detectable ones (automation
+posting under the user role, verbatim resends) are already labelled by
+:mod:`kiro_crew.session_summary` before the model sees them; the rest are
+judgement calls the prompt has to name.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from kiro_crew.acp.types import STOP_REASON_END_TURN
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.dashboard.chat_utils import slot_history_key
+from kiro_crew.llm_helpers import run_bg_oneliner
+from kiro_crew.session_summary import (
+    count_user_turns,
+    extract_turns,
+    last_activity_ts,
+    normalize_payload,
+    render_input,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+logger = logging.getLogger(__name__)
+
+# Role used to pick the model. Summarization is unattended background work, so
+# it must not ride the interactive chat flagship on every turn.
+_SUMMARY_ROLE = "background"
+
+# Memory modes that forbid deriving durable artifacts from the conversation.
+# Mirrors history.INCOGNITO_MEMORY_MODES: a temporary session's transcript is
+# discarded, so persisting a summary of it to the .intents sidecar would leave
+# conversation content on disk after the conversation itself is gone.
+_NO_DERIVED_ARTIFACT_MODES = frozenset({"incognito", "temporary"})
+
+_PROMPT = """\
+Summarize this chat session by INTENT, for a panel whose only job is to make \
+returning to the session cheap.
+
+An INTENT is a goal the person was pursuing. It can span many turns. It is NOT \
+one message, and it is NOT a topic label. A session with a pivot has several \
+intents. Turn numbers below refer to the USER turn numbers shown in the \
+transcript.
+
+Return ONLY a JSON object, no prose around it, in exactly this shape:
+
+{
+  "intents": [
+    {
+      "title": "short goal, in the person's terms",
+      "ranges": [[first_user_turn, last_user_turn]],
+      "status": "active" | "completed" | "abandoned",
+      "verified": true | false | null,
+      "origin_turn": <user turn that triggered this intent, or null>,
+      "initial_intent": "why the work started, stated as the person would",
+      "progress": ["what is actually true now", "..."],
+      "next_steps": [
+        {"what": "the action", "why": "why it matters", "expect": "what happens if they do it"}
+      ]
+    }
+  ],
+  "constraints": ["how this project has to be run -- recurring operational facts"]
+}
+
+FIELD RULES
+
+- "ranges" is a LIST. Use several when an intent went dormant and resumed. \
+Ranges may overlap another intent's: an intent pursued inside a longer one is \
+real, and forcing them apart would misdescribe the session.
+- "status" is about the WORK: active if it is still being pursued, completed if \
+it was carried to an end, abandoned if it was dropped.
+- "verified" is about the RESULT, and is independent of status. false means the \
+outcome was never actually confirmed -- shipped but never looked at, diagnosed \
+but never fixed, merged but never run. null means confirmation does not apply. \
+This distinction is the single most useful thing in the summary: work whose \
+discussion ended while the goal was never reached is exactly what a person \
+forgets.
+- "progress" is a RUNBOOK, not a history. Say what is true now and what is \
+known to work, not a turn-by-turn replay. Length is inversely proportional to \
+value here; a long progress list is a worse summary.
+- "next_steps" are YOUR inferences, and will be shown as such. Only include \
+steps that are genuinely open. An intent that needs nothing gets an empty list.
+- "constraints" are session-scoped operational facts about this project -- the \
+things the person would otherwise re-learn the hard way (a required flag, a \
+step that has to happen after a change, a name they corrected you on). Not \
+general preferences. At most a handful, or leave it empty.
+
+BOUNDARY SIGNALS, most reliable first
+
+- A commit, merge, or PR being opened punctuates a session more reliably than \
+any phrasing.
+- Timestamps separate a routine that is re-run daily from a request that failed \
+and was retried. A message repeated across days is a routine.
+- A correction from the person ("no", "revert that", "that broke it") is the \
+highest-value signal per character in the whole transcript. Weight it heavily \
+and never summarize away a correction.
+
+TRAPS -- each of these has produced a wrong summary before
+
+1. A row labelled "[automation, not the user]" is not the person. Never treat \
+it as intent, and never create an intent for it.
+2. A row labelled as a resend is not insistence and not evidence that the \
+request was ignored. The first attempt usually succeeded.
+3. A later message can RETRACT an earlier one ("I was wrong", "revert this -- \
+it broke my notes"). The retraction is the truth. Never report a feature that \
+was withdrawn, or a bug that was walked back, as current.
+4. Lines offering the person choices are options they were given, and mostly \
+DECLINED. Never read an offer as something the person asked for.
+5. Work being merged is not work being verified. If the transcript shows \
+something shipped without being run or seen, that intent is completed with \
+"verified": false.
+6. A question is not a work order. "How hard would it be to..." or "do not \
+change anything yet" is not an intent -- if a question caused the next goal, \
+record it as that intent's "origin_turn" instead.
+7. Facts go stale inside one session: a version, size, path or count stated \
+early may have changed by the end. Prefer the latest statement.
+8. A context reset or compaction mid-session is not a topic boundary.
+9. The session's own title covers only its beginning and is often wrong about \
+the whole. Do not anchor on it.
+
+TRANSCRIPT
+
+"""
+
+
+def _should_summarize(cfg: KiroCrewConfig, slot: Any, user_turns: int | None) -> str:
+    """Return "" when a summary should be generated, else the reason to skip.
+
+    Returning a reason rather than a bool keeps the decision auditable in logs:
+    a feature that silently declines to run is indistinguishable from one that
+    is broken.
+
+    Pass ``user_turns=None`` to run only the cheap slot-level gates -- the
+    generator does that before reading the transcript from disk, so the common
+    skip cases (disabled, unclean stop) cost no IO.
+    """
+    if not cfg.session_summary.enabled:
+        return "disabled"
+    if getattr(slot, "_summary_in_flight", False):
+        return "in_flight"
+    if getattr(slot, "memory_mode", "") in _NO_DERIVED_ARTIFACT_MODES:
+        return "memory_mode"
+    # Require EXACTLY a clean end_turn. The marker is cleared at turn start,
+    # so an empty value means the turn never reached EVENT_COMPLETE (ACP
+    # failure, transport drop) -- summarizing that transcript would cache an
+    # incomplete turn as if it finished.
+    stop = getattr(slot, "_last_stop_reason", "") or ""
+    if stop != STOP_REASON_END_TURN:
+        return f"stop_reason:{stop or 'missing'}"
+    if user_turns is None:
+        return ""
+    if user_turns < cfg.session_summary.min_user_turns:
+        return "too_few_turns"
+    mark = getattr(slot, "_summary_turn_mark", 0) or 0
+    if mark and user_turns - mark < cfg.session_summary.regenerate_after_turns:
+        return "cadence"
+    return ""
+
+
+def _parse_reply(text: str) -> object:
+    """Pull a JSON object out of a model reply, tolerating fenced output."""
+    raw = (text or "").strip()
+    if not raw:
+        return None
+    if raw.startswith("```"):
+        # Strip a fence and any language tag, then the trailing fence.
+        raw = raw.split("\n", 1)[-1]
+        if raw.rstrip().endswith("```"):
+            raw = raw.rstrip()[: -len("```")]
+    start, end = raw.find("{"), raw.rfind("}")
+    if start == -1 or end <= start:
+        return None
+    try:
+        return json.loads(raw[start : end + 1])
+    except json.JSONDecodeError:
+        logger.debug("Session summary: reply was not valid JSON")
+        return None
+
+
+async def generate_session_summary(
+    state: DashboardState,
+    slot: _ChatSlot,
+    *,
+    cfg: KiroCrewConfig | None = None,
+) -> bool:
+    """Generate and cache an intent summary for *slot*. Never raises.
+
+    Returns True when a new summary was stored. The in-flight guard is taken
+    before the first await so a fast follow-up turn cannot start a second pass
+    over the same transcript.
+    """
+    log = state.conversation_log
+    if log is None:
+        return False
+    # Off-loop: KiroCrewConfig.load() stats and reads config files, and this
+    # coroutine runs on the gateway's single event loop. Tests pass cfg in
+    # directly to keep the decision path free of file IO.
+    if cfg is None:
+        cfg = await asyncio.to_thread(KiroCrewConfig.load)
+    # The TRANSCRIPT key, not the slot key. They differ for a channel-born slot
+    # the dashboard could not bind, and keying the sidecar on the slot key would
+    # stat a file no read path addresses -- the summary would be written to a
+    # phantom transcript and the panel would never find it.
+    key = slot_history_key(slot)
+
+    # Cheap slot-level gates BEFORE touching the transcript: the common cases
+    # (feature disabled, unclean stop) must cost no disk IO.
+    skip = _should_summarize(cfg, slot, None)
+    if skip:
+        logger.debug("Session summary skipped for %s: %s", key, skip)
+        return False
+
+    # Capture the cache signature BEFORE reading the transcript. The signature
+    # must be at least as old as the snapshot it stamps: any append landing
+    # after this point advances the mtime, so the write guard in
+    # ``set_cached_intent_summary`` refuses the then-stale payload. Captured
+    # the other way around, an append between the read and the capture would
+    # pair old records with the new mtime and store an incomplete summary that
+    # the cache then serves as fresh.
+    sig = await asyncio.to_thread(log.session_mtime, key)
+    if sig is None:
+        # No transcript on disk yet means nothing to key a cache entry on.
+        return False
+
+    # Read the FULL chained transcript from disk, not ``slot.messages``: a
+    # restored slot keeps only the most recent 500 messages in memory
+    # (chat_persistence caps the restore), so summarizing the in-memory tail of
+    # a long session would regenerate from a truncated view and overwrite the
+    # sidecar -- earlier intents would silently vanish from the panel. Disk is
+    # the same source the history endpoint serves, and extract_turns bounds
+    # what the model actually reads.
+    records = await asyncio.to_thread(log.read_messages_chained, key)
+    turns = extract_turns(
+        records,
+        assistant_excerpt_chars=cfg.session_summary.assistant_excerpt_chars,
+    )
+    user_turns = count_user_turns(turns)
+
+    skip = _should_summarize(cfg, slot, user_turns)
+    if skip:
+        logger.debug("Session summary skipped for %s: %s", key, skip)
+        return False
+
+    slot._summary_in_flight = True
+    try:
+        cached = await asyncio.to_thread(log.get_cached_intent_summary, key)
+        if cached is not None:
+            # The transcript has not changed since the last pass, so the stored
+            # summary is still exactly right and the pass would cost tokens for
+            # an identical result.
+            slot._summary_turn_mark = user_turns
+            return False
+
+        prompt = _PROMPT + render_input(turns)
+        model = cfg.agent.resolve_model(_SUMMARY_ROLE)
+        text = await run_bg_oneliner(
+            state.sessions,
+            prompt,
+            model=model,
+            sel_source="session_summary",
+        )
+        payload = normalize_payload(
+            _parse_reply(text),
+            max_intents=cfg.session_summary.max_intents,
+            max_constraints=cfg.session_summary.max_constraints,
+        )
+        if payload is None:
+            logger.info("Session summary: no usable intents for %s", key)
+            return False
+
+        payload["generated_at"] = time.time()
+        payload["user_turns"] = user_turns
+        payload["last_activity"] = last_activity_ts(turns)
+        stored = await asyncio.to_thread(log.set_cached_intent_summary, key, payload, sig)
+        if not stored:
+            # The transcript was deleted or changed while the model call was in
+            # flight; the write was refused so a permanent delete stays deleted.
+            # Don't push a WS update for a summary that was never stored, and
+            # don't advance the turn mark -- the next turn should retry.
+            logger.info("Session summary discarded for %s: transcript gone or moved", key)
+            return False
+        slot._summary_turn_mark = user_turns
+        logger.info(
+            "Session summary stored for %s (%d intents, %d user turns)",
+            key,
+            len(payload["intents"]),
+            user_turns,
+        )
+        # Notify with the SLOT key, not the transcript key used for storage.
+        # Two identifiers for two purposes: the sidecar is keyed to the
+        # transcript file, while a UI notification has to carry the identifier
+        # the dashboard addresses slots by (the same one push_slot_title uses).
+        # Sending the transcript key here would broadcast an id no client has a
+        # cache entry for, so the panel would silently never refresh.
+        state.push_session_summary(slot.key)
+        return True
+    except Exception:
+        # A summary is a convenience. Losing one must never surface as a failed
+        # turn, and the previous cached summary stays valid.
+        logger.warning("Session summary generation failed for %s", key, exc_info=True)
+        return False
+    finally:
+        slot._summary_in_flight = False

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2588,6 +2588,7 @@ async def start_dashboard(
     # ``/api/chat/slots/{slot}`` POST would otherwise shadow this path.
     app.router.add_post("/api/chat/slots/import", session_transfer.api_chat_slot_import)
     app.router.add_get("/api/chat/slots/{slot}", chat.api_chat_slot_detail)
+    app.router.add_get("/api/chat/slots/{slot}/summary", chat.api_chat_slot_summary)
     app.router.add_post("/api/chat/slots/{slot}/stop", chat.api_chat_slot_stop)
     app.router.add_post("/api/chat/slots/{slot}/interrupt", chat.api_chat_slot_interrupt)
     app.router.add_post("/api/chat/slots/{slot}/end-wait", chat.api_chat_slot_end_wait)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -859,6 +859,9 @@ class _ChatSlot:
         "_auto_tagged",
         "_title_in_flight",
         "_title_retry_pending",
+        "_summary_in_flight",
+        "_summary_turn_mark",
+        "_last_stop_reason",
         "_artifact",
         "_channel_folder_filed",
         "_resumed_count",
@@ -1012,6 +1015,18 @@ class _ChatSlot:
         self._title_in_flight: bool = False
         # Records a chat_done retry that arrived during the on-send attempt.
         self._title_retry_pending: bool = False
+        # Excludes concurrent session-summary generations for this slot. A
+        # summary pass outlives the turn that triggered it, so a fast follow-up
+        # turn would otherwise start a second pass over the same transcript.
+        self._summary_in_flight: bool = False
+        # User-turn count at the last successful summary, so the configured
+        # regeneration cadence can be honored without re-reading the sidecar.
+        self._summary_turn_mark: int = 0
+        # Stop reason of the most recently completed turn. Recorded because a
+        # turn that ended on a timeout, cancel or tool stall did not really
+        # finish, and deriving anything from it would describe work that was
+        # interrupted mid-flight as if it had concluded.
+        self._last_stop_reason: str = ""
         # Artifact companion binding: set when this slot is a
         # companion chat session for an artifact (slug). At most one
         # non-archived slot per slug by convention — the frontend flow
@@ -4743,6 +4758,17 @@ class DashboardState:
         self._broadcast({"_type": "slot_title", "key": key, "title": title})
         if full:
             self.push_slots_update()
+
+    def push_session_summary(self, key: str) -> None:
+        """Broadcast that a session's intent summary was regenerated.
+
+        Lets the summary panel invalidate immediately instead of polling, which
+        matters because the summary is deliberately a pull-friendly artifact: a
+        panel that polled would reintroduce the checking loop the feature exists
+        to remove. Fire-and-forget — the client's own staleness window remains
+        the safety net if the event is missed.
+        """
+        self._broadcast({"_type": "session_summary", "key": key})
 
     def push_artifact_update(self, slug: str, version: int, *, deleted: bool = False) -> None:
         """Broadcast an artifact content change to all connected clients.

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -1733,6 +1733,93 @@ class ConversationLog:
             json.dumps({"sig": sig, "summary": summary}),
         )
 
+    def _intent_summary_cache_path(self, key: str) -> Path:
+        """Sidecar path for a session's cached intent-structured summary.
+
+        Deliberately a different file from :meth:`_summary_cache_path`: the
+        one-line summary and the intent summary have independent writers and
+        independent triggers, and sharing one file would reintroduce the
+        read-modify-write race the sidecar design exists to avoid.
+        """
+        return self._dir / ".intents" / f"{_safe_key(key)}.json"
+
+    def get_cached_intent_summary(self, key: str) -> dict | None:
+        """Return the cached intent summary payload for *key* if still valid.
+
+        Same mtime-signature contract as :meth:`get_cached_summary`: any real
+        append advances the session file's mtime and invalidates the cache,
+        while metadata-only rewrites preserve it. Returns the whole payload so
+        the caller can read ``generated_at`` for display.
+        """
+        try:
+            raw = self._intent_summary_cache_path(key).read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict) or not isinstance(data.get("intents"), list):
+            return None
+        sig = self.session_mtime(key)
+        if sig is None or data.get("sig") != sig:
+            return None
+        return data
+
+    def read_intent_summary(self, key: str) -> tuple[dict | None, bool]:
+        """Return ``(payload, stale)`` for a session's intent summary.
+
+        Unlike :meth:`get_cached_intent_summary`, this does not discard a
+        payload whose signature no longer matches — it reports it as stale
+        instead. The panel prefers showing the last known summary marked as
+        out of date over showing nothing, because an empty panel reads as
+        "this feature is broken" while a stale one reads as "not regenerated
+        yet", which is the truth.
+        """
+        try:
+            raw = self._intent_summary_cache_path(key).read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError):
+            return None, False
+        if not isinstance(data, dict) or not isinstance(data.get("intents"), list):
+            return None, False
+        sig = self.session_mtime(key)
+        return data, not (sig is not None and data.get("sig") == sig)
+
+    def set_cached_intent_summary(self, key: str, payload: dict, sig: float) -> bool:
+        """Persist a derived intent summary *payload* to its sidecar cache.
+
+        Writes only the sidecar, never the session JSONL, so generating a
+        summary cannot clobber the transcript or advance its mtime (which would
+        both invalidate every other derived cache and reorder ``list_sessions``).
+
+        The write happens under ``_locked`` and only if the transcript still
+        exists with the *same* signature the generation started from. Generation
+        holds no lock while the model call is in flight (it can take tens of
+        seconds), so a permanent :meth:`delete_session` can complete in that
+        window -- removing the transcript AND this sidecar. An unconditional
+        write here would then recreate the sidecar, resurrecting deleted
+        conversation data after the user was told it was gone. The sig equality
+        check also drops a summary that a mid-generation append has already made
+        stale, rather than storing it as the latest word.
+
+        Returns True when the payload was written, False when it was refused
+        (transcript deleted or changed, or the lock could not be acquired).
+        Callers run this off the event loop (``asyncio.to_thread``) because
+        ``_locked`` blocks.
+        """
+        try:
+            with self._locked(key):
+                if _safe_mtime(self._path(key)) != sig:
+                    return False
+                atomic_write(
+                    self._intent_summary_cache_path(key),
+                    json.dumps({**payload, "sig": sig}),
+                )
+                return True
+        except HistoryLockTimeout:
+            logger.warning(
+                "set_cached_intent_summary: lock timeout, not writing key=%s", key
+            )
+            return False
+
     def append(
         self,
         key: str,
@@ -3091,6 +3178,10 @@ class ConversationLog:
                 # safe, and a failure here must not fail the primary delete.
                 try:
                     self._summary_cache_path(key).unlink(missing_ok=True)
+                except OSError:
+                    pass
+                try:
+                    self._intent_summary_cache_path(key).unlink(missing_ok=True)
                 except OSError:
                     pass
         except HistoryLockTimeout:

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -105,6 +105,16 @@ class PostureControl:
 # Where a sink runs only ONE of the two scanners, its detail text says so.
 _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
     (
+        "Session intent summaries",
+        "session_summary.py",
+        "Intent-summary payloads persisted to the `.intents` sidecar and served by "
+        "`GET /api/chat/slots/{slot}/summary`. The payload is model output derived "
+        "from transcript text, so a secret or beacon URL pasted into the chat can be "
+        "reproduced inside it; `normalize_payload` runs the whole nested payload "
+        "through the credential + exfiltration-URL chain before the write, because "
+        "the sidecar is durable and read straight back to the panel.",
+    ),
+    (
         "Session storage inventory",
         "dashboard/handlers/session_storage.py",
         "A session's title and its first message, served by "

--- a/src/kiro_crew/session_summary.py
+++ b/src/kiro_crew/session_summary.py
@@ -1,0 +1,425 @@
+"""Transcript extraction and payload shaping for intent-level session summaries.
+
+Two jobs, both deliberately free of any model call so they can be tested
+directly:
+
+* :func:`extract_turns` turns raw transcript records into the bounded input a
+  summarization pass reads.
+* :func:`normalize_payload` validates and clamps whatever the model returns
+  before it reaches the sidecar cache, so a malformed generation degrades to a
+  smaller valid summary instead of poisoning the panel.
+
+Why the input is shaped the way it is: a session transcript is dominated by
+assistant records and their tool payloads, while intent lives almost entirely in
+the (small) user messages. Reading ``role``/``content`` only, keeping user text
+whole and excerpting assistant text, reproduces the shape that worked when the
+prompt was prototyped against real sessions -- around 1% of a transcript's bytes
+-- and drops tool output entirely, which added nothing.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+logger = logging.getLogger(__name__)
+
+# Roles worth reading. Tool rows carry display titles and raw payloads that the
+# assistant has already distilled, and error rows duplicate content that shows
+# up in the following assistant turn.
+_READ_ROLES = frozenset({"user", "assistant"})
+
+# A record can carry role "user" without a human having typed it: automation
+# injects cron notifications, subagent completions, auto-nudge cycles, tool
+# refusals and restored webhook context under that role. Counting one as intent
+# invents a goal the user never had, so they are marked and excluded from the
+# intent signal while staying visible as context.
+_INJECTED_PREFIXES = (
+    "[cron notification",
+    "[subagent completion event]",
+    "[subagent batch completion event]",
+    "[auto-nudge cycle",
+    "[tool refusal",
+    "[tool stall",
+    "=== restored context",
+    "[system]",
+)
+
+# A pasted stack trace or log dump under role "user" is not a goal either, but
+# it is only recognizable by shape. Cap user text so one paste cannot crowd out
+# the rest of the session; intent survives truncation, volume does not help.
+_MAX_USER_CHARS = 4000
+
+
+@dataclass
+class TranscriptTurn:
+    """One transcript row, reduced to what a summarization pass needs."""
+
+    index: int
+    """1-based position among the rows that were kept."""
+
+    role: str
+    text: str
+    ts: str | None = None
+
+    user_turn: int | None = None
+    """1-based index among user turns, or None for assistant rows.
+
+    Intent ranges are expressed in user turns because that is the unit a person
+    recognizes when they read the summary back.
+    """
+
+    injected: bool = False
+    """True when this row came from automation rather than the person."""
+
+    repeat_of: int | None = None
+    """Set when this row repeats the previous user row verbatim.
+
+    A resend looks identical to insistence in a raw transcript, and reading it
+    as insistence produces "the user asked repeatedly, so it was ignored" for a
+    request that already succeeded.
+    """
+
+    truncated: bool = False
+
+
+def _excerpt(text: str, keep_each_end: int) -> str:
+    """Keep the head and tail of *text*, marking the elision.
+
+    Assistant messages open with the outcome and close with what was offered
+    next, so both ends carry signal while the middle is usually a diff or a
+    listing.
+    """
+    if len(text) <= keep_each_end * 2:
+        return text
+    dropped = len(text) - keep_each_end * 2
+    head, tail = text[:keep_each_end], text[-keep_each_end:]
+    return f"{head}\n[... {dropped} characters omitted ...]\n{tail}"
+
+
+def _is_injected(text: str) -> bool:
+    head = text.lstrip().lower()
+    return any(head.startswith(p) for p in _INJECTED_PREFIXES)
+
+
+def extract_turns(
+    records: list[dict],
+    *,
+    assistant_excerpt_chars: int = 400,
+    max_user_chars: int = _MAX_USER_CHARS,
+) -> list[TranscriptTurn]:
+    """Reduce raw transcript *records* to the rows a summarization pass reads.
+
+    Reads ``role``, ``content`` and ``ts`` only. Every other field -- notably the
+    ``meta`` blob on assistant rows, which can be most of a transcript's bytes --
+    is ignored rather than excerpted, because none of it reaches the model.
+    """
+    turns: list[TranscriptTurn] = []
+    user_count = 0
+    last_user_text: str | None = None
+    last_user_index: int | None = None
+
+    for rec in records:
+        if not isinstance(rec, dict):
+            continue
+        role = rec.get("role")
+        if role not in _READ_ROLES:
+            continue
+        content = rec.get("content")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        ts = rec.get("ts") if isinstance(rec.get("ts"), str) else None
+
+        if role == "user":
+            injected = _is_injected(content)
+            text = content if len(content) <= max_user_chars else content[:max_user_chars]
+            truncated = len(content) > max_user_chars
+            repeat_of = None
+            if not injected:
+                user_count += 1
+                normalized = " ".join(text.split())
+                if last_user_text is not None and normalized == last_user_text:
+                    repeat_of = last_user_index
+                last_user_text = normalized
+                last_user_index = user_count
+            turns.append(
+                TranscriptTurn(
+                    index=len(turns) + 1,
+                    role="user",
+                    text=text,
+                    ts=ts,
+                    user_turn=None if injected else user_count,
+                    injected=injected,
+                    repeat_of=repeat_of,
+                    truncated=truncated,
+                )
+            )
+            continue
+
+        excerpt = _excerpt(content, assistant_excerpt_chars)
+        turns.append(
+            TranscriptTurn(
+                index=len(turns) + 1,
+                role="assistant",
+                text=excerpt,
+                ts=ts,
+                truncated=excerpt != content,
+            )
+        )
+
+    return turns
+
+
+def count_user_turns(turns: list[TranscriptTurn]) -> int:
+    """Number of genuine user turns, excluding automation injections."""
+    return sum(1 for t in turns if t.role == "user" and not t.injected)
+
+
+def last_activity_ts(turns: list[TranscriptTurn]) -> str | None:
+    """Timestamp of the most recent row that carries one."""
+    for turn in reversed(turns):
+        if turn.ts:
+            return turn.ts
+    return None
+
+
+def render_input(turns: list[TranscriptTurn]) -> str:
+    """Render *turns* as the text block a summarization pass reads.
+
+    Annotations are inline and explicit -- an injected row and a resend are
+    labelled rather than silently dropped, so the pass can see the shape of the
+    conversation without being misled by it.
+    """
+    lines: list[str] = []
+    for turn in turns:
+        if turn.role == "user":
+            if turn.injected:
+                lines.append("[automation, not the user]")
+                lines.append(turn.text)
+            else:
+                label = f"USER (turn {turn.user_turn})"
+                if turn.repeat_of is not None:
+                    label += f" [resend of turn {turn.repeat_of}, not a new request]"
+                if turn.ts:
+                    label += f" [{turn.ts}]"
+                lines.append(label)
+                lines.append(turn.text)
+        else:
+            lines.append("ASSISTANT [excerpt]" if turn.truncated else "ASSISTANT")
+            lines.append(turn.text)
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+# ---------------------------------------------------------------------------
+# Payload shaping
+# ---------------------------------------------------------------------------
+
+_PROGRESS_STATES = frozenset({"active", "completed", "abandoned"})
+
+STATE_DONE = "done"
+STATE_NEEDS_YOU = "needs-you"
+STATE_IN_PROGRESS = "in-progress"
+STATE_DROPPED = "dropped"
+
+
+def derive_state(status: str, verified: bool | None) -> str:
+    """Collapse the two status axes into the single word the panel shows.
+
+    Progress and verification are stored separately because they disagree in the
+    cases that matter most on re-entry: work whose discussion ended while the
+    goal was never actually reached ("answered but not fixed", "merged but never
+    looked at"). One field cannot express that, and a summary that renders such
+    an intent as finished actively helps the reader forget it.
+    """
+    if status == "abandoned":
+        return STATE_DROPPED
+    if status == "completed":
+        return STATE_NEEDS_YOU if verified is False else STATE_DONE
+    return STATE_IN_PROGRESS
+
+
+@dataclass
+class NextStep:
+    what: str
+    why: str = ""
+    expect: str = ""
+
+
+@dataclass
+class Intent:
+    title: str
+    initial_intent: str = ""
+    progress: list[str] = field(default_factory=list)
+    next_steps: list[NextStep] = field(default_factory=list)
+    ranges: list[list[int]] = field(default_factory=list)
+    status: str = "active"
+    verified: bool | None = None
+    origin_turn: int | None = None
+
+    @property
+    def last_touched_turn(self) -> int:
+        """Highest user turn this intent covers -- what the panel sorts on.
+
+        Derived rather than stored: ranges are the source of truth, and a
+        separate field could disagree with them.
+        """
+        return max((r[-1] for r in self.ranges if r), default=0)
+
+    @property
+    def state(self) -> str:
+        return derive_state(self.status, self.verified)
+
+
+def _coerce_ranges(raw: object) -> list[list[int]]:
+    """Accept a list of turn ranges; drop anything that is not a real range.
+
+    Ranges are a list rather than one interval because an intent can go dormant
+    and resume, and because one intent can sit inside another's span. Overlap is
+    allowed on purpose -- rejecting it would force a lie about what happened.
+    """
+    out: list[list[int]] = []
+    if not isinstance(raw, list):
+        return out
+    for item in raw:
+        if isinstance(item, (list, tuple)) and len(item) == 2:
+            start, end = item
+            if isinstance(start, int) and isinstance(end, int) and start >= 1 and end >= start:
+                out.append([start, end])
+        elif isinstance(item, int) and item >= 1:
+            out.append([item, item])
+    return out
+
+
+def _coerce_next_steps(raw: object) -> list[NextStep]:
+    out: list[NextStep] = []
+    if not isinstance(raw, list):
+        return out
+    for item in raw:
+        if isinstance(item, str) and item.strip():
+            out.append(NextStep(what=item.strip()))
+        elif isinstance(item, dict):
+            what = item.get("what")
+            if isinstance(what, str) and what.strip():
+                out.append(
+                    NextStep(
+                        what=what.strip(),
+                        why=str(item.get("why") or "").strip(),
+                        expect=str(item.get("expect") or "").strip(),
+                    )
+                )
+    return out
+
+
+def _coerce_intent(raw: object) -> Intent | None:
+    if not isinstance(raw, dict):
+        return None
+    title = raw.get("title")
+    if not isinstance(title, str) or not title.strip():
+        return None
+    status = raw.get("status")
+    if status not in _PROGRESS_STATES:
+        status = "active"
+    verified = raw.get("verified")
+    if not isinstance(verified, bool):
+        verified = None
+    origin = raw.get("origin_turn")
+    origin_turn = origin if isinstance(origin, int) and origin >= 1 else None
+    raw_progress = raw.get("progress")
+    progress: list[str] = []
+    if isinstance(raw_progress, list):
+        progress = [p.strip() for p in raw_progress if isinstance(p, str) and p.strip()]
+    return Intent(
+        title=title.strip(),
+        initial_intent=str(raw.get("initial_intent") or "").strip(),
+        progress=progress,
+        next_steps=_coerce_next_steps(raw.get("next_steps")),
+        ranges=_coerce_ranges(raw.get("ranges")),
+        status=status,
+        verified=verified,
+        origin_turn=origin_turn,
+    )
+
+
+def redact_payload(value: Any) -> Any:
+    """Recursively redact credentials and exfiltration URLs in a summary payload.
+
+    The payload is model output derived from transcript text, so any secret or
+    beacon URL that appeared in the conversation can be reproduced inside it.
+    The sidecar is read straight back to the dashboard, so redaction has to
+    happen before the write, not at render time -- the same
+    ``redact_credentials`` + ``redact_exfiltration_urls`` chain every other
+    LLM-controlled value in this codebase is put through before it is cached.
+
+    Recursive because the payload is nested (intents -> next_steps -> strings);
+    a single top-level pass would leave every field the panel actually renders
+    unredacted.
+    """
+    if isinstance(value, str):
+        cleaned, _ = redact_credentials(value)
+        cleaned, _ = redact_exfiltration_urls(cleaned)
+        return cleaned
+    if isinstance(value, list):
+        return [redact_payload(v) for v in value]
+    if isinstance(value, dict):
+        return {k: redact_payload(v) for k, v in value.items()}
+    return value
+
+
+def normalize_payload(
+    raw: object,
+    *,
+    max_intents: int = 8,
+    max_constraints: int = 5,
+) -> dict | None:
+    """Validate and clamp a generated summary into the stored payload shape.
+
+    Returns None when nothing usable survives, so the caller keeps the previous
+    cached summary rather than replacing it with an empty one. Intents are
+    ordered most-recently-touched first, which is the order the panel renders
+    and therefore the order the payload should already be in.
+    """
+    if not isinstance(raw, dict):
+        return None
+    intents = [i for i in (_coerce_intent(x) for x in raw.get("intents", []) or []) if i]
+    if not intents:
+        return None
+    intents.sort(key=lambda i: i.last_touched_turn, reverse=True)
+    if len(intents) > max_intents:
+        # Trim from the tail: those are the oldest-touched, which the panel
+        # collapses to a single line anyway.
+        intents = intents[:max_intents]
+
+    constraints_raw = raw.get("constraints")
+    constraints: list[str] = []
+    if isinstance(constraints_raw, list):
+        for c in constraints_raw:
+            if isinstance(c, str) and c.strip():
+                constraints.append(c.strip())
+    constraints = constraints[:max_constraints]
+
+    return redact_payload(
+        {
+            "intents": [
+                {
+                    "title": i.title,
+                    "initial_intent": i.initial_intent,
+                    "progress": i.progress,
+                    "next_steps": [
+                        {"what": s.what, "why": s.why, "expect": s.expect} for s in i.next_steps
+                    ],
+                    "ranges": i.ranges,
+                    "status": i.status,
+                    "verified": i.verified,
+                    "state": i.state,
+                    "last_touched_turn": i.last_touched_turn,
+                    "origin_turn": i.origin_turn,
+                }
+                for i in intents
+            ],
+            "constraints": constraints,
+        }
+    )

--- a/test/test_session_summary_api.py
+++ b/test/test_session_summary_api.py
@@ -1,0 +1,266 @@
+"""Tests for GET /api/chat/slots/{slot}/summary.
+
+The endpoint is deliberately read-only: opening the panel must never spend
+tokens, so these assert it serves the cache and nothing more.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_state
+
+from kiro_crew.config.loader import KiroCrewConfig, SessionSummaryConfig
+from kiro_crew.dashboard import chat_handlers
+from kiro_crew.dashboard.chat import api_chat_slot_summary
+from kiro_crew.dashboard.chat_utils import slot_history_key
+from kiro_crew.dashboard.state import _ChatSlot
+
+pytestmark = pytest.mark.asyncio
+
+
+def _payload(title="set up auth"):
+    return {
+        "intents": [
+            {
+                "title": title,
+                "ranges": [[1, 2]],
+                "status": "completed",
+                "verified": False,
+                "state": "needs-you",
+                "last_touched_turn": 2,
+            }
+        ],
+        "constraints": ["restart the worker after a config change"],
+        "generated_at": 1_760_000_000.0,
+        "user_turns": 2,
+        "last_activity": "2026-08-10T10:00:00+00:00",
+    }
+
+
+def _make_app(state) -> web.Application:
+    app = web.Application()
+    app["state"] = state
+    app.router.add_get("/api/chat/slots/{slot}/summary", api_chat_slot_summary)
+    return app
+
+
+def _pin_flag(monkeypatch, enabled: bool) -> None:
+    def _load():
+        cfg = KiroCrewConfig()
+        cfg.session_summary = SessionSummaryConfig(enabled=enabled)
+        return cfg
+
+    monkeypatch.setattr(chat_handlers.KiroCrewConfig, "load", staticmethod(_load))
+
+
+class TestSummaryEndpoint:
+    async def test_unknown_slot_is_404_with_a_machine_readable_code(self, tmp_path, monkeypatch):
+        _pin_flag(monkeypatch, True)
+        state = _make_state(tmp_path)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/nope/summary")
+            assert resp.status == 404
+            assert (await resp.json())["code"] == "slot_not_found"
+
+    async def test_a_slot_with_no_summary_returns_empty_not_an_error(self, tmp_path, monkeypatch):
+        _pin_flag(monkeypatch, True)
+        state = _make_state(tmp_path)
+        state._slots["s1"] = _ChatSlot("s1")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/s1/summary")
+            assert resp.status == 200
+            body = await resp.json()
+            assert body["intents"] == []
+            assert body["generated_at"] is None
+            assert body["stale"] is False
+
+    async def test_serves_a_fresh_cached_summary(self, tmp_path, monkeypatch):
+        _pin_flag(monkeypatch, True)
+        state = _make_state(tmp_path)
+        slot = _ChatSlot("s1")
+        state._slots[slot.key] = slot
+        hkey = slot_history_key(slot)
+        log = state.conversation_log
+        log.append(hkey, "user", "hello")
+        log.set_cached_intent_summary(hkey, _payload(), log.session_mtime(hkey))
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            body = await (await client.get("/api/chat/slots/s1/summary")).json()
+        assert body["stale"] is False
+        assert body["intents"][0]["title"] == "set up auth"
+        assert body["intents"][0]["state"] == "needs-you"
+        assert body["constraints"] == ["restart the worker after a config change"]
+        assert body["generated_at"] == 1_760_000_000.0
+        assert body["user_turns"] == 2
+
+    async def test_a_stale_summary_is_served_and_flagged(self, tmp_path, monkeypatch):
+        """Better a summary marked out of date than an empty panel."""
+        _pin_flag(monkeypatch, True)
+        state = _make_state(tmp_path)
+        slot = _ChatSlot("s1")
+        state._slots[slot.key] = slot
+        hkey = slot_history_key(slot)
+        log = state.conversation_log
+        log.append(hkey, "user", "hello")
+        log.set_cached_intent_summary(hkey, _payload(), log.session_mtime(hkey))
+        log.append(hkey, "user", "a newer turn")
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            body = await (await client.get("/api/chat/slots/s1/summary")).json()
+        assert body["stale"] is True
+        assert body["intents"][0]["title"] == "set up auth"
+
+    async def test_reports_the_feature_flag_so_the_panel_can_explain_itself(
+        self, tmp_path, monkeypatch
+    ):
+        _pin_flag(monkeypatch, False)
+        state = _make_state(tmp_path)
+        state._slots["s1"] = _ChatSlot("s1")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/s1/summary")
+            assert resp.status == 200
+            assert (await resp.json())["enabled"] is False
+
+    async def test_a_corrupt_sidecar_degrades_to_empty(self, tmp_path, monkeypatch):
+        _pin_flag(monkeypatch, True)
+        state = _make_state(tmp_path)
+        slot = _ChatSlot("s1")
+        state._slots[slot.key] = slot
+        hkey = slot_history_key(slot)
+        log = state.conversation_log
+        log.append(hkey, "user", "hello")
+        path = log._intent_summary_cache_path(hkey)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{broken", encoding="utf-8")
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/s1/summary")
+            assert resp.status == 200
+            assert (await resp.json())["intents"] == []
+
+    async def test_the_endpoint_never_generates(self, tmp_path, monkeypatch):
+        """Opening the panel must not spend tokens."""
+        from kiro_crew.dashboard import chat_summary
+
+        called: list[int] = []
+
+        async def fake(*a, **k):
+            called.append(1)
+            return ""
+
+        monkeypatch.setattr(chat_summary, "run_bg_oneliner", fake)
+        _pin_flag(monkeypatch, True)
+        state = _make_state(tmp_path)
+        state._slots["s1"] = _ChatSlot("s1")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            await client.get("/api/chat/slots/s1/summary")
+        assert called == []
+
+    async def test_disabling_the_flag_stops_serving_an_earlier_summary(
+        self, tmp_path, monkeypatch
+    ):
+        """Opting out has to stop serving, not just stop producing."""
+        _pin_flag(monkeypatch, False)
+        state = _make_state(tmp_path)
+        slot = _ChatSlot("s1")
+        state._slots[slot.key] = slot
+        hkey = slot_history_key(slot)
+        log = state.conversation_log
+        log.append(hkey, "user", "hello")
+        log.set_cached_intent_summary(hkey, _payload(), log.session_mtime(hkey))
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            body = await (await client.get("/api/chat/slots/s1/summary")).json()
+        assert body["enabled"] is False
+        assert body["intents"] == []
+        assert body["constraints"] == []
+        assert body["generated_at"] is None
+
+
+class TestSummaryAppIsolation:
+    """App Kit §5.2: a summary is conversation content, not public metadata."""
+
+    @staticmethod
+    def _app_client_app(state, caller: str) -> web.Application:
+        app = _make_app(state)
+
+        @web.middleware
+        async def inject_app(request, handler):
+            request["app"] = caller
+            return await handler(request)
+
+        app.middlewares.insert(0, inject_app)
+        return app
+
+    async def test_a_foreign_app_cannot_read_another_apps_summary(
+        self, tmp_path, monkeypatch
+    ):
+        mock_sel = MagicMock()
+        monkeypatch.setattr(chat_handlers, "sel", lambda: mock_sel)
+        _pin_flag(monkeypatch, True)
+        state = _make_state(tmp_path)
+        slot = _ChatSlot("s1")
+        slot._app = "app-B"
+        state._slots[slot.key] = slot
+        hkey = slot_history_key(slot)
+        log = state.conversation_log
+        log.append(hkey, "user", "hello")
+        log.set_cached_intent_summary(hkey, _payload(), log.session_mtime(hkey))
+
+        async with TestClient(TestServer(self._app_client_app(state, "app-A"))) as client:
+            resp = await client.get("/api/chat/slots/s1/summary")
+            # 404, not 403: a foreign slot must be indistinguishable from a
+            # missing one (anti-enumeration). True reason lands in SEL.
+            assert resp.status == 404
+            assert (await resp.json())["code"] == "slot_not_found"
+
+        denied = [
+            c for c in mock_sel.log_api_access.call_args_list if c[1].get("outcome") == "denied"
+        ]
+        assert len(denied) == 1
+        assert denied[0][1]["source"] == "app_isolation"
+
+    async def test_an_app_cannot_read_an_unscoped_slots_summary(self, tmp_path, monkeypatch):
+        mock_sel = MagicMock()
+        monkeypatch.setattr(chat_handlers, "sel", lambda: mock_sel)
+        _pin_flag(monkeypatch, True)
+        state = _make_state(tmp_path)
+        state._slots["s1"] = _ChatSlot("s1")  # _app stays empty
+
+        async with TestClient(TestServer(self._app_client_app(state, "app-A"))) as client:
+            assert (await client.get("/api/chat/slots/s1/summary")).status == 404
+
+    async def test_the_owning_app_still_reads_its_own_summary(self, tmp_path, monkeypatch):
+        _pin_flag(monkeypatch, True)
+        state = _make_state(tmp_path)
+        slot = _ChatSlot("s1")
+        slot._app = "app-A"
+        state._slots[slot.key] = slot
+        hkey = slot_history_key(slot)
+        log = state.conversation_log
+        log.append(hkey, "user", "hello")
+        log.set_cached_intent_summary(hkey, _payload(), log.session_mtime(hkey))
+
+        async with TestClient(TestServer(self._app_client_app(state, "app-A"))) as client:
+            body = await (await client.get("/api/chat/slots/s1/summary")).json()
+        assert body["intents"][0]["title"] == "set up auth"
+
+    async def test_a_dashboard_user_reads_an_app_owned_summary(self, tmp_path, monkeypatch):
+        """An explicit empty request_app is the dashboard user and bypasses the check."""
+        _pin_flag(monkeypatch, True)
+        state = _make_state(tmp_path)
+        slot = _ChatSlot("s1")
+        slot._app = "app-B"
+        state._slots[slot.key] = slot
+        hkey = slot_history_key(slot)
+        log = state.conversation_log
+        log.append(hkey, "user", "hello")
+        log.set_cached_intent_summary(hkey, _payload(), log.session_mtime(hkey))
+
+        async with TestClient(TestServer(self._app_client_app(state, ""))) as client:
+            body = await (await client.get("/api/chat/slots/s1/summary")).json()
+        assert body["intents"][0]["title"] == "set up auth"

--- a/test/test_session_summary_config.py
+++ b/test/test_session_summary_config.py
@@ -1,0 +1,139 @@
+"""Tests for the session-summary config section.
+
+The feature spends tokens on a turn the user did not ask to pay for, so the
+defaults matter as much as the parsing: a fresh install must be inert, and a
+malformed section must degrade to defaults rather than raising during load.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+from kiro_crew.config import loader as L
+from kiro_crew.config.loader import KiroCrewConfig, SessionSummaryConfig
+
+# Sentinel for "the section is absent from config.json entirely", which is a
+# different case from an empty dict.
+_ABSENT = object()
+
+
+class TestSessionSummaryDefaults:
+    def test_disabled_on_a_fresh_config(self):
+        """Merging PR 1 must change nothing for anyone until the flag flips."""
+        assert KiroCrewConfig().session_summary.enabled is False
+
+    def test_documented_defaults(self):
+        cfg = SessionSummaryConfig()
+        assert cfg.min_user_turns == 2
+        assert cfg.regenerate_after_turns == 1
+        assert cfg.max_intents == 8
+        assert cfg.max_constraints == 5
+        assert cfg.assistant_excerpt_chars == 400
+
+    def test_every_field_carries_ui_metadata(self):
+        """Config surfaces render label/help from field metadata."""
+        for f in SessionSummaryConfig.__dataclass_fields__.values():
+            meta = f.metadata.get("x-meta") or f.metadata
+            assert meta, f"{f.name} has no metadata"
+
+
+class TestSessionSummaryClamping:
+    def test_below_range_values_are_clamped_not_raised(self):
+        cfg = SessionSummaryConfig(
+            min_user_turns=0,
+            regenerate_after_turns=0,
+            max_intents=0,
+            max_constraints=-3,
+            assistant_excerpt_chars=10,
+        )
+        assert cfg.min_user_turns == 1
+        assert cfg.regenerate_after_turns == 1
+        assert cfg.max_intents == 1
+        assert cfg.max_constraints == 0
+        assert cfg.assistant_excerpt_chars == 80
+
+    def test_zero_constraints_is_allowed(self):
+        """Suppressing project notes entirely is a legitimate choice, not an error."""
+        assert SessionSummaryConfig(max_constraints=0).max_constraints == 0
+
+    def test_in_range_values_are_untouched(self):
+        cfg = SessionSummaryConfig(
+            min_user_turns=4,
+            regenerate_after_turns=3,
+            max_intents=12,
+            max_constraints=2,
+            assistant_excerpt_chars=800,
+        )
+        assert asdict(cfg) == {
+            "enabled": False,
+            "min_user_turns": 4,
+            "regenerate_after_turns": 3,
+            "max_intents": 12,
+            "max_constraints": 2,
+            "assistant_excerpt_chars": 800,
+        }
+
+
+class TestSessionSummaryParsing:
+    """The section is parsed by ``KiroCrewConfig.load()``, which reads config.json."""
+
+    @staticmethod
+    def _load(tmp_path, monkeypatch, section):
+        cfgp = tmp_path / "config.json"
+        payload = {"agent": {"provider": "acp"}}
+        if section is not _ABSENT:
+            payload["session_summary"] = section
+        cfgp.write_text(json.dumps(payload))
+        monkeypatch.setattr(L, "config_path", lambda: cfgp)
+        monkeypatch.setattr(L, "config_dir", lambda: tmp_path)
+        monkeypatch.setattr(L, "config_local_path", lambda: tmp_path / "config.local.json")
+        return KiroCrewConfig.load()
+
+    def test_load_reads_the_section(self, tmp_path, monkeypatch):
+        cfg = self._load(tmp_path, monkeypatch, {"enabled": True, "max_intents": 3})
+        assert cfg.session_summary.enabled is True
+        assert cfg.session_summary.max_intents == 3
+
+    def test_absent_section_yields_defaults(self, tmp_path, monkeypatch):
+        cfg = self._load(tmp_path, monkeypatch, _ABSENT)
+        assert cfg.session_summary == SessionSummaryConfig()
+
+    def test_non_dict_section_degrades_to_defaults(self, tmp_path, monkeypatch):
+        """A hand-edited config.json must not break gateway start."""
+        for junk in ("nope", 7, [], None):
+            cfg = self._load(tmp_path, monkeypatch, junk)
+            assert cfg.session_summary == SessionSummaryConfig()
+
+    def test_non_numeric_values_fall_back_to_defaults(self, tmp_path, monkeypatch):
+        cfg = self._load(
+            tmp_path, monkeypatch, {"max_intents": "lots", "assistant_excerpt_chars": None}
+        )
+        assert cfg.session_summary.max_intents == 8
+        assert cfg.session_summary.assistant_excerpt_chars == 400
+
+    def test_out_of_range_values_from_disk_are_clamped(self, tmp_path, monkeypatch):
+        cfg = self._load(tmp_path, monkeypatch, {"max_intents": 0, "min_user_turns": -5})
+        assert cfg.session_summary.max_intents == 1
+        assert cfg.session_summary.min_user_turns == 1
+
+    def test_section_is_serialized_so_save_round_trips(self):
+        assert "session_summary" in KiroCrewConfig().to_dict()
+
+    def test_round_trips_through_to_dict(self, tmp_path, monkeypatch):
+        cfg = self._load(tmp_path, monkeypatch, {"enabled": True, "regenerate_after_turns": 5})
+        assert cfg.to_dict()["session_summary"] == asdict(cfg.session_summary)
+
+    def test_section_is_known_not_an_unknown_passthrough(self, tmp_path, monkeypatch):
+        """A known section must be parsed, not captured as an edition extra."""
+        cfg = self._load(tmp_path, monkeypatch, {"enabled": True})
+        assert isinstance(cfg.session_summary, SessionSummaryConfig)
+        assert "session_summary" not in cfg._extra_sections
+
+    def test_section_is_registered_in_the_config_schema(self):
+        """Config surfaces (CLI, baseline) enumerate SCHEMA_REGISTRY."""
+        from kiro_crew.config import schema
+
+        paths = {e.path for e in schema.SCHEMA_REGISTRY}
+        assert "session_summary" in paths
+        assert "session_summary.enabled" in paths

--- a/test/test_session_summary_extract.py
+++ b/test/test_session_summary_extract.py
@@ -1,0 +1,347 @@
+"""Tests for session-summary transcript extraction and payload shaping.
+
+The trap fixtures here are the load-bearing part. Each one is a shape that
+produced a confidently wrong summary when the prompt was prototyped against real
+transcripts, and each is now caught mechanically rather than left to the model's
+judgement.
+"""
+
+from __future__ import annotations
+
+import json
+
+from kiro_crew.session_summary import (
+    STATE_DONE,
+    STATE_DROPPED,
+    STATE_IN_PROGRESS,
+    STATE_NEEDS_YOU,
+    count_user_turns,
+    derive_state,
+    extract_turns,
+    last_activity_ts,
+    normalize_payload,
+    render_input,
+)
+
+
+def _rec(role, content, ts=None, **extra):
+    rec = {"role": role, "content": content}
+    if ts:
+        rec["ts"] = ts
+    rec.update(extra)
+    return rec
+
+
+class TestExtractionReadsOnlyWhatItNeeds:
+    def test_tool_and_error_rows_are_dropped(self):
+        turns = extract_turns(
+            [
+                _rec("user", "do the thing"),
+                _rec("tool", "ran a command"),
+                _rec("error", "boom"),
+                _rec("assistant", "done"),
+            ]
+        )
+        assert [t.role for t in turns] == ["user", "assistant"]
+
+    def test_meta_blob_is_ignored_not_excerpted(self):
+        """``meta`` can be most of a transcript's bytes and never reaches the model."""
+        big = "x" * 100_000
+        turns = extract_turns([_rec("assistant", "short answer", meta={"payload": big})])
+        assert turns[0].text == "short answer"
+        assert big not in render_input(turns)
+
+    def test_blank_and_malformed_rows_are_skipped(self):
+        turns = extract_turns(["not a dict", {}, _rec("user", "   "), _rec("user", "real")])
+        assert len(turns) == 1
+        assert turns[0].text == "real"
+
+    def test_user_text_is_kept_whole(self):
+        text = "a" * 500
+        turns = extract_turns([_rec("user", text)], assistant_excerpt_chars=10)
+        assert turns[0].text == text
+        assert turns[0].truncated is False
+
+    def test_assistant_text_is_excerpted_from_both_ends(self):
+        text = "HEAD" + ("m" * 5000) + "TAIL"
+        turns = extract_turns([_rec("assistant", text)], assistant_excerpt_chars=50)
+        assert turns[0].text.startswith("HEAD")
+        assert turns[0].text.endswith("TAIL")
+        assert turns[0].truncated is True
+        assert len(turns[0].text) < len(text)
+
+    def test_short_assistant_text_is_not_marked_truncated(self):
+        turns = extract_turns([_rec("assistant", "brief")], assistant_excerpt_chars=400)
+        assert turns[0].truncated is False
+
+    def test_a_huge_user_paste_is_capped(self):
+        turns = extract_turns([_rec("user", "z" * 20_000)], max_user_chars=100)
+        assert len(turns[0].text) == 100
+        assert turns[0].truncated is True
+
+
+class TestTrapAutomationUnderUserRole:
+    """Automation posts under role "user"; counting it invents a goal."""
+
+    def test_injected_rows_are_flagged_and_not_counted(self):
+        turns = extract_turns(
+            [
+                _rec("user", "real request"),
+                _rec("user", "[Subagent completion event] Agent X completed"),
+                _rec("user", "[Cron notification from \"nightly\"] ran"),
+                _rec("user", "[Tool refusal -- automatic recovery] blocked"),
+                _rec("user", "=== Restored Context (from prior session) ==="),
+            ]
+        )
+        assert count_user_turns(turns) == 1
+        assert [t.injected for t in turns] == [False, True, True, True, True]
+
+    def test_injected_rows_do_not_consume_user_turn_numbers(self):
+        turns = extract_turns(
+            [
+                _rec("user", "first"),
+                _rec("user", "[auto-nudge cycle 3]"),
+                _rec("user", "second"),
+            ]
+        )
+        numbered = [t.user_turn for t in turns if not t.injected]
+        assert numbered == [1, 2]
+
+    def test_render_labels_automation_explicitly(self):
+        turns = extract_turns([_rec("user", "[Subagent completion event] done")])
+        assert "[automation, not the user]" in render_input(turns)
+
+    def test_detection_is_case_insensitive_and_tolerates_leading_space(self):
+        turns = extract_turns([_rec("user", "  [SUBAGENT COMPLETION EVENT] x")])
+        assert turns[0].injected is True
+
+
+class TestTrapResends:
+    """A resent message is not insistence, and not evidence of being ignored."""
+
+    def test_verbatim_repeat_is_marked(self):
+        turns = extract_turns([_rec("user", "make a build"), _rec("user", "make a build")])
+        assert turns[0].repeat_of is None
+        assert turns[1].repeat_of == 1
+
+    def test_whitespace_only_difference_still_counts_as_a_repeat(self):
+        turns = extract_turns([_rec("user", "make a build"), _rec("user", "make  a\nbuild")])
+        assert turns[1].repeat_of == 1
+
+    def test_a_genuinely_different_message_is_not_marked(self):
+        turns = extract_turns([_rec("user", "make a build"), _rec("user", "now ship it")])
+        assert turns[1].repeat_of is None
+
+    def test_render_labels_the_resend_so_it_is_not_read_as_a_new_request(self):
+        turns = extract_turns([_rec("user", "same"), _rec("user", "same")])
+        assert "resend of turn 1, not a new request" in render_input(turns)
+
+
+class TestTimestampsAndCounts:
+    def test_last_activity_uses_the_most_recent_row_with_a_timestamp(self):
+        turns = extract_turns(
+            [
+                _rec("user", "a", ts="2026-08-01T10:00:00+00:00"),
+                _rec("assistant", "b", ts="2026-08-02T10:00:00+00:00"),
+                _rec("user", "c"),
+            ]
+        )
+        assert last_activity_ts(turns) == "2026-08-02T10:00:00+00:00"
+
+    def test_no_timestamps_yields_none(self):
+        assert last_activity_ts(extract_turns([_rec("user", "a")])) is None
+
+    def test_user_turn_numbers_appear_in_the_rendered_input(self):
+        turns = extract_turns([_rec("user", "one"), _rec("assistant", "x"), _rec("user", "two")])
+        rendered = render_input(turns)
+        assert "USER (turn 1)" in rendered
+        assert "USER (turn 2)" in rendered
+
+
+class TestDerivedState:
+    def test_completed_but_unverified_needs_you(self):
+        """The prototype's sharpest case: discussion ended, goal never reached."""
+        assert derive_state("completed", False) == STATE_NEEDS_YOU
+
+    def test_completed_and_verified_is_done(self):
+        assert derive_state("completed", True) == STATE_DONE
+
+    def test_completed_with_verification_not_applicable_is_done(self):
+        assert derive_state("completed", None) == STATE_DONE
+
+    def test_active_is_in_progress_regardless_of_verification(self):
+        assert derive_state("active", None) == STATE_IN_PROGRESS
+        assert derive_state("active", False) == STATE_IN_PROGRESS
+
+    def test_abandoned_is_dropped(self):
+        assert derive_state("abandoned", False) == STATE_DROPPED
+
+
+class TestNormalizePayload:
+    def test_orders_intents_most_recently_touched_first(self):
+        payload = normalize_payload(
+            {
+                "intents": [
+                    {"title": "old", "ranges": [[1, 4]]},
+                    {"title": "newest", "ranges": [[20, 25]]},
+                    {"title": "middle", "ranges": [[10, 12]]},
+                ]
+            }
+        )
+        assert [i["title"] for i in payload["intents"]] == ["newest", "middle", "old"]
+
+    def test_ranges_may_be_multiple_and_overlapping(self):
+        """Dormancy plus resumption, and one intent inside another's span."""
+        payload = normalize_payload(
+            {"intents": [{"title": "resumed", "ranges": [[1, 14], [77, 100]]}]}
+        )
+        intent = payload["intents"][0]
+        assert intent["ranges"] == [[1, 14], [77, 100]]
+        assert intent["last_touched_turn"] == 100
+
+    def test_a_bare_integer_range_is_accepted_as_a_single_turn(self):
+        payload = normalize_payload({"intents": [{"title": "t", "ranges": [7]}]})
+        assert payload["intents"][0]["ranges"] == [[7, 7]]
+
+    def test_malformed_ranges_are_dropped_not_fatal(self):
+        payload = normalize_payload(
+            {"intents": [{"title": "t", "ranges": [[5, 2], ["a", "b"], [0, 3], [2, 4]]}]}
+        )
+        assert payload["intents"][0]["ranges"] == [[2, 4]]
+
+    def test_intents_are_capped(self):
+        raw = {"intents": [{"title": f"i{n}", "ranges": [[n, n]]} for n in range(1, 21)]}
+        payload = normalize_payload(raw, max_intents=3)
+        assert len(payload["intents"]) == 3
+        # The cap keeps the most recently touched, not the first generated.
+        assert [i["title"] for i in payload["intents"]] == ["i20", "i19", "i18"]
+
+    def test_constraints_are_capped_and_cleaned(self):
+        payload = normalize_payload(
+            {
+                "intents": [{"title": "t", "ranges": [[1, 1]]}],
+                "constraints": ["  a  ", "", "b", "c", "d", "e", "f"],
+            },
+            max_constraints=3,
+        )
+        assert payload["constraints"] == ["a", "b", "c"]
+
+    def test_zero_constraints_cap_suppresses_the_section(self):
+        payload = normalize_payload(
+            {"intents": [{"title": "t", "ranges": [[1, 1]]}], "constraints": ["a"]},
+            max_constraints=0,
+        )
+        assert payload["constraints"] == []
+
+    def test_next_steps_accept_strings_and_objects(self):
+        payload = normalize_payload(
+            {
+                "intents": [
+                    {
+                        "title": "t",
+                        "ranges": [[1, 1]],
+                        "next_steps": [
+                            "bare string",
+                            {"what": "structured", "why": "because", "expect": "this"},
+                            {"why": "no what -- dropped"},
+                        ],
+                    }
+                ]
+            }
+        )
+        steps = payload["intents"][0]["next_steps"]
+        assert [s["what"] for s in steps] == ["bare string", "structured"]
+        assert steps[1]["why"] == "because"
+
+    def test_unknown_status_falls_back_to_active(self):
+        payload = normalize_payload(
+            {"intents": [{"title": "t", "ranges": [[1, 1]], "status": "nonsense"}]}
+        )
+        assert payload["intents"][0]["status"] == "active"
+        assert payload["intents"][0]["state"] == STATE_IN_PROGRESS
+
+    def test_state_is_stored_so_both_surfaces_agree(self):
+        payload = normalize_payload(
+            {
+                "intents": [
+                    {"title": "t", "ranges": [[1, 1]], "status": "completed", "verified": False}
+                ]
+            }
+        )
+        assert payload["intents"][0]["state"] == STATE_NEEDS_YOU
+
+    def test_origin_turn_is_kept_when_plausible(self):
+        payload = normalize_payload(
+            {"intents": [{"title": "t", "ranges": [[23, 76]], "origin_turn": 20}]}
+        )
+        assert payload["intents"][0]["origin_turn"] == 20
+
+    def test_implausible_origin_turn_is_dropped(self):
+        payload = normalize_payload(
+            {"intents": [{"title": "t", "ranges": [[1, 2]], "origin_turn": 0}]}
+        )
+        assert payload["intents"][0]["origin_turn"] is None
+
+    def test_untitled_intents_are_dropped(self):
+        payload = normalize_payload(
+            {"intents": [{"ranges": [[1, 2]]}, {"title": "   "}, {"title": "keep"}]}
+        )
+        assert [i["title"] for i in payload["intents"]] == ["keep"]
+
+    def test_nothing_usable_returns_none_so_the_cache_is_left_alone(self):
+        assert normalize_payload({"intents": []}) is None
+        assert normalize_payload({"intents": "nope"}) is None
+        assert normalize_payload("not a dict") is None
+        assert normalize_payload(None) is None
+
+
+class TestPayloadRedaction:
+    """The payload is LLM output derived from the transcript, so it can echo a
+    secret the user pasted. Redaction happens before the sidecar write, because
+    the sidecar is read straight back to the panel."""
+
+    def test_a_credential_in_a_title_is_redacted(self):
+        payload = normalize_payload(
+            {"intents": [{"title": "rotate ghp_abcdefghijklmnopqrstuvwxyz0123456789"}]}
+        )
+        assert "ghp_abcdefghijklmnopqrstuvwxyz0123456789" not in payload["intents"][0]["title"]
+
+    def test_redaction_reaches_nested_fields(self):
+        secret = "ghp_abcdefghijklmnopqrstuvwxyz0123456789"
+        payload = normalize_payload(
+            {
+                "intents": [
+                    {
+                        "title": "t",
+                        "initial_intent": f"use {secret}",
+                        "progress": [f"exported {secret}"],
+                        "next_steps": [
+                            {"what": f"revoke {secret}", "why": f"{secret} leaked", "expect": "ok"}
+                        ],
+                    }
+                ],
+                "constraints": [f"never log {secret}"],
+            }
+        )
+        assert secret not in json.dumps(payload)
+
+    def test_ordinary_text_is_left_alone(self):
+        payload = normalize_payload(
+            {
+                "intents": [{"title": "set up auth", "progress": ["ran the test suite"]}],
+                "constraints": ["restart the worker after a config change"],
+            }
+        )
+        assert payload["intents"][0]["title"] == "set up auth"
+        assert payload["intents"][0]["progress"] == ["ran the test suite"]
+        assert payload["constraints"] == ["restart the worker after a config change"]
+
+    def test_non_string_fields_survive_untouched(self):
+        payload = normalize_payload(
+            {"intents": [{"title": "t", "ranges": [[1, 4]], "verified": True, "origin_turn": 2}]}
+        )
+        intent = payload["intents"][0]
+        assert intent["ranges"] == [[1, 4]]
+        assert intent["verified"] is True
+        assert intent["origin_turn"] == 2
+        assert intent["last_touched_turn"] == 4

--- a/test/test_session_summary_generate.py
+++ b/test/test_session_summary_generate.py
@@ -1,0 +1,394 @@
+"""Tests for the session-summary generator.
+
+No real model is ever called: ``run_bg_oneliner`` is patched at the module
+boundary, so these assert the gating, the caching, the failure containment and
+the trap wiring rather than any model behavior.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kiro_crew.config.loader import KiroCrewConfig, SessionSummaryConfig
+from kiro_crew.dashboard import chat_summary
+from kiro_crew.dashboard.chat_utils import slot_history_key
+from kiro_crew.dashboard.state import _ChatSlot
+from kiro_crew.history import ConversationLog
+
+
+def _make_slot(messages=None, memory_mode="default"):
+    """A real _ChatSlot: the generator resolves its transcript key, which a
+    stand-in object cannot answer for."""
+    slot = _ChatSlot("s1")
+    slot.messages = messages if messages is not None else []
+    slot.memory_mode = memory_mode
+    slot._last_stop_reason = "end_turn"
+    return slot
+
+
+def _write_transcript(log, hkey, messages):
+    """Persist *messages* to the on-disk transcript the generator reads.
+
+    The generator deliberately reads the full chained history from disk (a
+    restored slot keeps only the most recent 500 messages in memory), so tests
+    must stage their fixture turns in the log, not on ``slot.messages``.
+    """
+    for m in messages:
+        log.append(hkey, m["role"], m["content"])
+
+
+class _FakeState:
+    def __init__(self, log):
+        self.conversation_log = log
+        self.sessions = object()
+        self.pushed: list[str] = []
+        self.hkey = ""
+
+    def push_session_summary(self, key):
+        self.pushed.append(key)
+
+
+def _cfg(**overrides):
+    cfg = KiroCrewConfig()
+    cfg.session_summary = SessionSummaryConfig(**{"enabled": True, **overrides})
+    return cfg
+
+
+def _turns(n=3):
+    out = []
+    for i in range(n):
+        out.append({"role": "user", "content": f"request {i}"})
+        out.append({"role": "assistant", "content": f"reply {i}"})
+    return out
+
+
+_GOOD_REPLY = json.dumps(
+    {
+        "intents": [
+            {
+                "title": "set up auth",
+                "ranges": [[1, 3]],
+                "status": "completed",
+                "verified": False,
+                "initial_intent": "wire up login",
+                "progress": ["login works locally"],
+                "next_steps": [{"what": "try it in staging", "why": "never run there"}],
+            }
+        ],
+        "constraints": ["restart the worker after a config change"],
+    }
+)
+
+
+@pytest.fixture
+def env(tmp_path):
+    log = ConversationLog(base_dir=tmp_path)
+    slot = _make_slot(_turns())
+    state = _FakeState(log)
+    state.hkey = slot_history_key(slot)
+    _write_transcript(log, state.hkey, _turns())
+    return state, slot
+
+
+def _stub_llm(monkeypatch, reply, calls=None):
+    async def fake(*args, **kwargs):
+        if calls is not None:
+            calls.append(kwargs.get("model"))
+        return reply
+
+    monkeypatch.setattr(chat_summary, "run_bg_oneliner", fake)
+
+
+class TestGating:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_disabled_returns_false_without_calling_the_model(self, env, monkeypatch):
+        state, slot = env
+        called = []
+        _stub_llm(monkeypatch, _GOOD_REPLY, called)
+        ok = await chat_summary.generate_session_summary(state, slot, cfg=KiroCrewConfig())
+        assert ok is False
+        assert called == []
+
+    async def test_enabled_generates_and_caches(self, env, monkeypatch):
+        state, slot = env
+        _stub_llm(monkeypatch, _GOOD_REPLY)
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is True
+        cached = state.conversation_log.get_cached_intent_summary(state.hkey)
+        assert cached["intents"][0]["title"] == "set up auth"
+        assert cached["constraints"] == ["restart the worker after a config change"]
+
+    async def test_incognito_is_refused_before_any_model_call(self, env, monkeypatch):
+        state, slot = env
+        slot.memory_mode = "incognito"
+        called = []
+        _stub_llm(monkeypatch, _GOOD_REPLY, called)
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is False
+        assert called == []
+
+    async def test_temporary_is_refused_before_any_model_call(self, env, monkeypatch):
+        """A temporary session's transcript is discarded; persisting a summary
+        of it would leave conversation content on disk after the conversation
+        itself is gone (mirrors history.INCOGNITO_MEMORY_MODES)."""
+        state, slot = env
+        slot.memory_mode = "temporary"
+        called = []
+        _stub_llm(monkeypatch, _GOOD_REPLY, called)
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is False
+        assert called == []
+        assert state.conversation_log.get_cached_intent_summary(state.hkey) is None
+
+    async def test_an_unclean_stop_reason_skips(self, env, monkeypatch):
+        """A turn cut short by a timeout or stall did not really finish."""
+        state, slot = env
+        called = []
+        _stub_llm(monkeypatch, _GOOD_REPLY, called)
+        for reason in ("timeout", "tool_stall", "error: cancel unacked", "stale_recover"):
+            slot._last_stop_reason = reason
+            assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is False
+        assert called == []
+
+    async def test_a_missing_stop_reason_skips(self, env, monkeypatch):
+        """The marker is cleared at turn start, so empty means the turn never
+        reached EVENT_COMPLETE (ACP failure, transport drop) -- summarizing
+        would cache an incomplete turn as if it finished cleanly."""
+        state, slot = env
+        slot._last_stop_reason = ""
+        called = []
+        _stub_llm(monkeypatch, _GOOD_REPLY, called)
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is False
+        assert called == []
+
+    async def test_summarizes_the_full_disk_transcript_not_the_memory_tail(
+        self, env, monkeypatch
+    ):
+        """A restored slot keeps only the most recent messages in memory;
+        generation must read the full transcript from disk or earlier intents
+        vanish from the regenerated summary."""
+        state, slot = env
+        # Disk carries an early request the in-memory tail no longer holds.
+        slot.messages = [{"role": "user", "content": "request 2"}]
+        prompts: list[str] = []
+
+        async def fake(_sessions, prompt, **kwargs):
+            prompts.append(prompt)
+            return _GOOD_REPLY
+
+        monkeypatch.setattr(chat_summary, "run_bg_oneliner", fake)
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is True
+        assert "request 0" in prompts[0]  # only on disk, not in slot.messages
+
+    async def test_an_append_during_the_transcript_read_refuses_the_write(
+        self, env, monkeypatch
+    ):
+        """The signature is captured BEFORE the transcript read, so a message
+        landing during the read advances the mtime past the captured sig and
+        the write guard refuses the payload -- an incomplete summary must never
+        be stored and served as fresh."""
+        state, slot = env
+        log = state.conversation_log
+        real_read = log.read_messages_chained
+
+        def racing_read(key):
+            records = real_read(key)
+            # A concurrent turn appends while generation is reading.
+            log.append(key, "user", "landed mid-read")
+            return records
+
+        monkeypatch.setattr(log, "read_messages_chained", racing_read)
+        _stub_llm(monkeypatch, _GOOD_REPLY)
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is False
+        assert log.get_cached_intent_summary(state.hkey) is None
+
+    async def test_too_few_user_turns_skips(self, env, monkeypatch):
+        state, slot = env
+        log = state.conversation_log
+        log.delete_session(state.hkey)
+        _write_transcript(log, state.hkey, [{"role": "user", "content": "just one"}])
+        called = []
+        _stub_llm(monkeypatch, _GOOD_REPLY, called)
+        ok = await chat_summary.generate_session_summary(state, slot, cfg=_cfg(min_user_turns=2))
+        assert ok is False
+        assert called == []
+
+    async def test_in_flight_guard_blocks_a_second_pass(self, env, monkeypatch):
+        state, slot = env
+        slot._summary_in_flight = True
+        called = []
+        _stub_llm(monkeypatch, _GOOD_REPLY, called)
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is False
+        assert called == []
+
+    async def test_cadence_skips_until_enough_turns_pass(self, env, monkeypatch):
+        state, slot = env
+        slot._summary_turn_mark = 3
+        called = []
+        _stub_llm(monkeypatch, _GOOD_REPLY, called)
+        ok = await chat_summary.generate_session_summary(
+            state, slot, cfg=_cfg(regenerate_after_turns=5)
+        )
+        assert ok is False
+        assert called == []
+
+    async def test_automation_rows_do_not_count_toward_the_turn_minimum(self, env, monkeypatch):
+        state, slot = env
+        log = state.conversation_log
+        log.delete_session(state.hkey)
+        _write_transcript(
+            log,
+            state.hkey,
+            [
+                {"role": "user", "content": "real ask"},
+                {"role": "user", "content": "[Subagent completion event] done"},
+                {"role": "user", "content": '[Cron notification from "x"] fired'},
+            ],
+        )
+        called = []
+        _stub_llm(monkeypatch, _GOOD_REPLY, called)
+        ok = await chat_summary.generate_session_summary(state, slot, cfg=_cfg(min_user_turns=2))
+        assert ok is False
+        assert called == []
+
+
+class TestCaching:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_an_unchanged_transcript_is_not_regenerated(self, env, monkeypatch):
+        state, slot = env
+        called = []
+        _stub_llm(monkeypatch, _GOOD_REPLY, called)
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is True
+        assert len(called) == 1
+        # Second pass: the sidecar signature still matches, so no model call.
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is False
+        assert len(called) == 1
+
+    async def test_a_new_message_makes_it_regenerate(self, env, monkeypatch):
+        state, slot = env
+        called = []
+        _stub_llm(monkeypatch, _GOOD_REPLY, called)
+        await chat_summary.generate_session_summary(state, slot, cfg=_cfg())
+        state.conversation_log.append(state.hkey, "user", "another")
+        slot._summary_turn_mark = 0
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is True
+        assert len(called) == 2
+
+    async def test_a_successful_pass_pushes_to_the_client(self, env, monkeypatch):
+        state, slot = env
+        _stub_llm(monkeypatch, _GOOD_REPLY)
+        await chat_summary.generate_session_summary(state, slot, cfg=_cfg())
+        # The SLOT key, not the transcript key the sidecar is stored under: the
+        # dashboard addresses slots by slot key, so broadcasting the transcript
+        # key would name an id no client holds a cache entry for.
+        assert state.pushed == [slot.key]
+        assert state.pushed != [state.hkey]
+
+    async def test_stored_payload_carries_display_metadata(self, env, monkeypatch):
+        state, slot = env
+        _stub_llm(monkeypatch, _GOOD_REPLY)
+        await chat_summary.generate_session_summary(state, slot, cfg=_cfg())
+        cached = state.conversation_log.get_cached_intent_summary(state.hkey)
+        assert cached["generated_at"] > 0
+        assert cached["user_turns"] == 3
+
+
+class TestFailureContainment:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_a_model_error_is_swallowed(self, env, monkeypatch):
+        state, slot = env
+
+        async def boom(*a, **k):
+            raise RuntimeError("provider exploded")
+
+        monkeypatch.setattr(chat_summary, "run_bg_oneliner", boom)
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is False
+        assert slot._summary_in_flight is False
+
+    async def test_unparseable_reply_leaves_no_cache_entry(self, env, monkeypatch):
+        state, slot = env
+        _stub_llm(monkeypatch, "I'm afraid I can't do that")
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is False
+        assert state.conversation_log.get_cached_intent_summary(state.hkey) is None
+
+    async def test_empty_intents_do_not_replace_a_good_summary(self, env, monkeypatch):
+        state, slot = env
+        _stub_llm(monkeypatch, _GOOD_REPLY)
+        await chat_summary.generate_session_summary(state, slot, cfg=_cfg())
+        state.conversation_log.append(state.hkey, "user", "more")
+        slot._summary_turn_mark = 0
+        _stub_llm(monkeypatch, json.dumps({"intents": []}))
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is False
+
+    async def test_the_guard_is_released_on_every_path(self, env, monkeypatch):
+        state, slot = env
+        _stub_llm(monkeypatch, "garbage")
+        await chat_summary.generate_session_summary(state, slot, cfg=_cfg())
+        assert slot._summary_in_flight is False
+
+
+class TestReplyParsing:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_a_fenced_json_block_is_accepted(self, env, monkeypatch):
+        state, slot = env
+        _stub_llm(monkeypatch, f"```json\n{_GOOD_REPLY}\n```")
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is True
+
+    async def test_prose_around_the_object_is_tolerated(self, env, monkeypatch):
+        state, slot = env
+        _stub_llm(monkeypatch, f"Here you go:\n{_GOOD_REPLY}\nHope that helps.")
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is True
+
+    async def test_caps_from_config_are_applied_to_the_reply(self, env, monkeypatch):
+        state, slot = env
+        many = {
+            "intents": [
+                {"title": f"i{n}", "ranges": [[n, n]], "status": "active"} for n in range(1, 10)
+            ],
+            "constraints": ["a", "b", "c", "d", "e", "f"],
+        }
+        _stub_llm(monkeypatch, json.dumps(many))
+        await chat_summary.generate_session_summary(
+            state, slot, cfg=_cfg(max_intents=2, max_constraints=1)
+        )
+        cached = state.conversation_log.get_cached_intent_summary(state.hkey)
+        assert len(cached["intents"]) == 2
+        assert len(cached["constraints"]) == 1
+
+
+class TestPromptCarriesTheTraps:
+    """The prompt is the only place the judgement traps are enforced."""
+
+    def test_every_judgement_trap_is_named(self):
+        p = chat_summary._PROMPT
+        for phrase in (
+            "automation, not the user",
+            "resend",
+            "RETRACT",
+            "DECLINED",
+            "merged is not work being verified",
+            "not a work order",
+            "stale",
+            "compaction",
+            "title",
+        ):
+            assert phrase.lower() in p.lower(), f"prompt does not mention {phrase!r}"
+
+    def test_boundary_signals_are_named(self):
+        p = chat_summary._PROMPT.lower()
+        assert "commit" in p and "merge" in p
+        assert "timestamp" in p
+        assert "correction" in p
+
+    def test_progress_is_specified_as_a_runbook(self):
+        assert "RUNBOOK" in chat_summary._PROMPT
+
+    def test_next_steps_are_specified_as_inferences(self):
+        assert "inferences" in chat_summary._PROMPT
+
+    def test_the_two_status_axes_are_explained(self):
+        p = chat_summary._PROMPT
+        assert '"verified"' in p and "independent of status" in p

--- a/test/test_session_summary_storage.py
+++ b/test/test_session_summary_storage.py
@@ -1,0 +1,175 @@
+"""Tests for the intent-summary sidecar cache in ConversationLog.
+
+The load-bearing invariant is that writing a summary must not touch the session
+JSONL. The transcript's mtime is the cache-validity signature for every derived
+artifact and the sort key for the sessions list, so a summary write that advanced
+it would invalidate unrelated caches and reorder the user's session list.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kiro_crew.history import ConversationLog
+
+
+@pytest.fixture
+def log(tmp_path):
+    return ConversationLog(base_dir=tmp_path)
+
+
+def _payload(title="do the thing"):
+    return {
+        "intents": [
+            {
+                "title": title,
+                "ranges": [[1, 2]],
+                "status": "active",
+                "state": "in-progress",
+                "last_touched_turn": 2,
+            }
+        ],
+        "constraints": ["build with the flag set"],
+    }
+
+
+class TestIntentSummarySidecar:
+    def test_round_trips(self, log):
+        log.append("s1", "user", "hello")
+        sig = log.session_mtime("s1")
+        log.set_cached_intent_summary("s1", _payload(), sig)
+        got = log.get_cached_intent_summary("s1")
+        assert got is not None
+        assert got["intents"][0]["title"] == "do the thing"
+        assert got["constraints"] == ["build with the flag set"]
+
+    def test_missing_cache_returns_none(self, log):
+        log.append("s1", "user", "hello")
+        assert log.get_cached_intent_summary("s1") is None
+
+    def test_a_new_message_invalidates_the_cache(self, log):
+        log.append("s1", "user", "hello")
+        log.set_cached_intent_summary("s1", _payload(), log.session_mtime("s1"))
+        assert log.get_cached_intent_summary("s1") is not None
+        log.append("s1", "user", "another turn")
+        assert log.get_cached_intent_summary("s1") is None
+
+    def test_a_stale_signature_is_rejected(self, log):
+        log.append("s1", "user", "hello")
+        log.set_cached_intent_summary("s1", _payload(), 1.0)
+        assert log.get_cached_intent_summary("s1") is None
+
+    def test_corrupt_sidecar_degrades_to_a_miss(self, log):
+        log.append("s1", "user", "hello")
+        path = log._intent_summary_cache_path("s1")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+        assert log.get_cached_intent_summary("s1") is None
+
+    def test_payload_without_intents_is_rejected(self, log):
+        log.append("s1", "user", "hello")
+        sig = log.session_mtime("s1")
+        path = log._intent_summary_cache_path("s1")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"sig": sig, "constraints": []}), encoding="utf-8")
+        assert log.get_cached_intent_summary("s1") is None
+
+    def test_uses_a_separate_file_from_the_one_line_summary(self, log):
+        """Independent writers must not share a file, or they clobber each other."""
+        log.append("s1", "user", "hello")
+        sig = log.session_mtime("s1")
+        log.set_cached_summary("s1", "a one-line summary", sig)
+        log.set_cached_intent_summary("s1", _payload(), sig)
+        assert log.get_cached_summary("s1") == "a one-line summary"
+        assert log.get_cached_intent_summary("s1") is not None
+        assert log._summary_cache_path("s1") != log._intent_summary_cache_path("s1")
+
+    def test_writing_one_does_not_clobber_the_other(self, log):
+        log.append("s1", "user", "hello")
+        sig = log.session_mtime("s1")
+        log.set_cached_intent_summary("s1", _payload(), sig)
+        log.set_cached_summary("s1", "one-liner", sig)
+        assert log.get_cached_intent_summary("s1") is not None
+
+    def test_sessions_are_isolated_from_each_other(self, log):
+        log.append("s1", "user", "hello")
+        log.append("s2", "user", "hello")
+        log.set_cached_intent_summary("s1", _payload("first"), log.session_mtime("s1"))
+        assert log.get_cached_intent_summary("s2") is None
+        assert log.get_cached_intent_summary("s1")["intents"][0]["title"] == "first"
+
+    def test_a_key_needing_folding_is_handled(self, log):
+        key = "dashboard/chat:weird key"
+        log.append(key, "user", "hello")
+        log.set_cached_intent_summary(key, _payload(), log.session_mtime(key))
+        assert log.get_cached_intent_summary(key) is not None
+
+
+class TestTranscriptIsNeverTouched:
+    def test_writing_a_summary_does_not_change_the_session_file(self, log):
+        log.append("s1", "user", "hello")
+        path = log._path("s1")
+        before_bytes = path.read_bytes()
+        before_mtime = log.session_mtime("s1")
+
+        log.set_cached_intent_summary("s1", _payload(), before_mtime)
+
+        assert path.read_bytes() == before_bytes
+        assert log.session_mtime("s1") == before_mtime
+
+    def test_reading_a_summary_does_not_change_the_session_file(self, log):
+        log.append("s1", "user", "hello")
+        sig = log.session_mtime("s1")
+        log.set_cached_intent_summary("s1", _payload(), sig)
+        log.get_cached_intent_summary("s1")
+        assert log.session_mtime("s1") == sig
+
+    def test_the_sidecar_lives_outside_the_sessions_transcript_names(self, log):
+        log.append("s1", "user", "hello")
+        sidecar = log._intent_summary_cache_path("s1")
+        assert sidecar != log._path("s1")
+        assert sidecar.parent.name == ".intents"
+
+
+class TestDeleteSessionReapsTheSidecar:
+    def test_delete_removes_the_intent_sidecar(self, log):
+        log.append("s1", "user", "hello")
+        log.set_cached_intent_summary("s1", _payload(), log.session_mtime("s1"))
+        sidecar = log._intent_summary_cache_path("s1")
+        assert sidecar.exists()
+
+        log.delete_session("s1")
+
+        assert not sidecar.exists()
+
+    def test_delete_still_succeeds_when_no_sidecar_exists(self, log):
+        log.append("s1", "user", "hello")
+        assert log.delete_session("s1") is True
+
+
+class TestWriteGuard:
+    """The write is refused unless the transcript still exists with the same
+    signature the generation started from -- a permanent delete completing
+    while a model call is in flight must stay deleted."""
+
+    def test_a_successful_write_reports_true(self, log):
+        log.append("s1", "user", "hello")
+        assert log.set_cached_intent_summary("s1", _payload(), log.session_mtime("s1")) is True
+
+    def test_a_delete_during_generation_is_not_resurrected(self, log):
+        log.append("s1", "user", "hello")
+        sig = log.session_mtime("s1")  # generation captured this, then awaited
+        log.delete_session("s1")  # permanent delete lands mid-flight
+
+        assert log.set_cached_intent_summary("s1", _payload(), sig) is False
+        assert not log._intent_summary_cache_path("s1").exists()
+
+    def test_an_append_during_generation_refuses_the_stale_payload(self, log):
+        log.append("s1", "user", "hello")
+        sig = log.session_mtime("s1")
+        log.append("s1", "user", "a newer turn")  # transcript moved on
+
+        assert log.set_cached_intent_summary("s1", _payload(), sig) is False
+        assert log.get_cached_intent_summary("s1") is None


### PR DESCRIPTION
## Problem

Returning to an agent session is expensive. When a turn finishes, the only way to
work out where things stand is to re-read the transcript — and the transcript is
the wrong shape for the question. A person coming back needs three things: why
they asked for this, what actually happened, and what to do next. A per-turn log
answers none of them directly, and a raw diff answers them worse.

## Why it matters

Parallel agent sessions reduce the *execution* burden but increase the
*re-entry* burden, and re-entry is the harder half. The agent decides when it is
"ready", so the interruption is not chosen by the person; with several sessions
live, those re-entry points stack up. Work whose discussion ended while the goal
was never actually reached — diagnosed but never fixed, merged but never run — is
exactly what gets silently dropped.

## Fix (symptom → root cause → change)

**Symptom:** no cheap way to see what a session is about or what it needs.
**Root cause:** nothing derives a goal-level view; the transcript is the only
artifact, and it is organised by turn rather than by intent.
**Change:** generate an intent-level summary after a turn completes and serve it
over an API for the panel that follows in a later PR.

A summary describes the session as one or more **intents** — a goal the person
pursued, which can span many turns — each with what they asked for, where it
stands, and suggested next steps. Not a per-turn log.

This PR is **backend only** and **off by default**.

### Off by default, and genuinely inert

`session_summary.enabled` defaults to `false` and is the generator's first
check, so merging this changes nothing for anyone who does not opt in: no
tokens, no added turn latency, nothing written to disk. Five further skip
conditions sit behind it (pass already running, incognito session, unclean turn
end, too few turns, cadence not reached). `_should_summarize()` returns a skip
*reason string* rather than a boolean so every skip is logged with its cause — a
feature that silently declines to run is indistinguishable from one that is
broken.

Enable with `kirocrew config set session_summary.enabled true`. A Settings
toggle arrives with PR 3; the panel arrives with PR 2.

### Storage: a sidecar, never the transcript

Summaries land in `sessions/.intents/<safe_key>.json`, reusing the
mtime-signature contract already used for the one-line session summary — but in
a **separate file**. The two artifacts have independent writers and independent
triggers, and `set_cached_summary` overwrites its whole file, so sharing one
would have them clobbering each other: precisely the read-modify-write race the
sidecar design exists to avoid. A test asserts each survives the other's write.

The transcript is never rewritten. Its mtime is the cache-validity signature for
every derived artifact and the sort key for `list_sessions`, so a write that
advanced it would invalidate unrelated caches and reorder the user's session
list. A regression test pins that a summary write leaves the transcript's bytes
and mtime untouched.

The cache is keyed on `slot_history_key(slot)`, **not** `slot.key`. Those differ
for a channel-born slot the dashboard could not bind; keying on the slot key
would stat a file no read path addresses, so the summary would land on a phantom
transcript and the panel would never find it. This was a real bug in an earlier
revision, caught by the endpoint tests.

### Extraction: ~1% of a transcript

Reads `role` + `content` only. The `meta` blob on assistant rows can be most of
a transcript's bytes — in one real session, 602 KB of message content against
14.65 MB of `meta` — so it is ignored rather than excerpted. Tool rows are
dropped because the assistant has already distilled them. User messages are kept
whole (they carry intent and are small); assistant messages are excerpted
head-and-tail.

### Four traps handled mechanically, the rest in the prompt

Transcript shapes that reliably produce a *confidently wrong* summary, each
verified against real sessions:

- **Automation posting under `role: "user"`** — cron notifications, subagent
  completion events, auto-nudge cycles, tool refusals, restored webhook context.
  Flagged and excluded from the intent count; counting one invents a goal the
  person never had.
- **A verbatim resend** is marked as a resend. Read as insistence, it produces
  "the user asked repeatedly, so it was ignored" for a request that already
  succeeded.
- **An oversized paste** is capped so one stack trace cannot crowd out a session.
- **`meta`** is never fed to the model.

The judgement traps cannot be detected in code, so the prompt names each one —
retractions supersede what they retract, option lines are offers that were mostly
*declined*, merged is not verified, a feasibility question is not a work order,
facts go stale within one session, a compaction is not a topic boundary, the
session title describes only its beginning. A test asserts the prompt still names
them, so a later trim fails a test instead of quietly degrading every summary.

### Generation: turn-end, clean turns only, cached

Hangs off the existing post-turn hub in `chat_runner`, alongside auto-titling —
not `hooks.py`, whose `Stop` event is script-driven and dashboard-only, and is
not where shipped behavior belongs. Only a clean `end_turn` qualifies: timeout,
cancel-unacked, tool-stall and stale-recover all describe a turn that was cut
short, and summarizing one would present interrupted work as concluded. Since
`_finish_queue_cycle` never receives the stop reason, it is recorded on the slot
at `EVENT_COMPLETE`.

An unchanged transcript is served from cache with no model call. That is what
makes the summary stable rather than a live feed — a property of the cache, not
something the UI has to enforce. The model comes from
`AgentConfig.resolve_model("background")`, so unattended summarization never
rides the interactive flagship. Every failure path is logged and swallowed: a
lost summary must not surface as a failed turn, and the previous cached summary
stays valid.

### Two status axes

Progress (`active` / `completed` / `abandoned`) and verification
(`true` / `false` / `null`) are stored separately because they disagree in the
cases that matter most on re-entry. `completed` + `verified: false` says
"the discussion ended but the goal was never reached"; one field cannot.
`derive_state()` collapses them into the single word the panel renders, so both
surfaces agree by construction.

### Endpoint

`GET /api/chat/slots/{slot}/summary` — read-only, and it **never triggers
generation**: a panel that spent tokens on open would recreate the checking loop
this feature exists to remove. Returns `200` with `enabled: false` when the flag
is off, so the panel can render an explanatory empty state rather than an error.
A stale summary is served *and flagged* rather than withheld — an empty panel
reads as "broken", a stale one reads as "not regenerated yet", which is the truth.

## Tests

98 new tests across five files.

| File | Locks in |
|---|---|
| `test_session_summary_config.py` (15) | Default-off, clamping, disk parsing, malformed section degrades to defaults, schema registration |
| `test_session_summary_extract.py` (37) | Role filtering, `meta` ignored not excerpted, excerpting, and the four mechanical traps |
| `test_session_summary_storage.py` (15) | Sidecar round-trip, mtime invalidation, **transcript bytes and mtime untouched**, separate-file non-clobber, delete reaps the sidecar |
| `test_session_summary_generate.py` (24) | Every skip condition, cache-hit means no model call, failure containment, guard released on all paths, **prompt still names all nine traps** |
| `test_session_summary_api.py` (7) | Status codes, machine-readable `code`, stale flag, `enabled: false` shape, never-generates |

No real model is called anywhere: `run_bg_oneliner` is patched at the module
boundary.

## Manual verification

N/A for this PR — it ships no user-visible surface, and the paths that would be
exercised by hand (sidecar round-trip, cache invalidation, endpoint shapes, every
gating branch) are covered by the tests above. The summarization *prompt* was
separately prototyped against three real transcripts of different shapes (135,
49 and 24 user turns) before implementation; that exercise is what produced the
trap list and the two-axis status design.

Local gates on the pushed commit: `pytest` (full suite, 4 shards: 41,405 passed;
139 pre-existing environment failures verified identical on clean `main` by
stashing and re-running), `isort`, `flake8`, `mypy`, `docs-lint`, `scrub-lint`,
brand gate.

## Screenshots

N/A — backend only, no user-visible UI. The panel and its screenshots come with
PR 2.

## Notes for review

- **`config-baseline.json` is deliberately not regenerated.** Regenerating adds
  506 lines for this change's 7 new keys, because the committed file was already
  ~499 lines stale on `main`. Nothing reads it (no CI job; `test_config_baseline.py`
  regenerates to a temp path), so refreshing it belongs in its own hygiene PR
  rather than buried here.
- **`black` was not run.** `ci.yml` has `black --check` explicitly disabled and
  `main` is not black-clean; running it would have added ~119 lines of unrelated
  reformatting to this diff. The additions are flake8-clean at the 100-char limit.
- **Scope is dashboard sessions only**, stated in the spec as a deliberate cut.
  Slack, cron, webhook and task-runner turns would need the flag threaded through
  the same four call sites `skills.auto_create_from_sessions` uses.
- **No governance capability scope.** Nothing enforces one and a scope is a
  data-only addition later; if added it must be registered inline in
  `SCOPE_CATALOG`, never lazily from a feature package.

Spec: `docs/system-specs/modules/session-summary.md`.
