### PR TITLE
fix(instances): make the remote-pane title bar draggable

### DIFF
--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -341,17 +341,26 @@ export default [
               //      flagged, so it lands in the baseline. Accepted: a false positive
               //      costs one baseline entry, a false negative hides copy forever.
               '^(?![a-z]+(?: [a-z]+)+$)[\\s\\-a-z0-9:/\\[\\]().%#]+$',
-              // CSS ATTRIBUTE SELECTORS, e.g. `[role="dialog"],[data-x]` — a
-              // comma-joined list of bracketed attribute selectors, as passed to
-              // querySelector. The Tailwind/class shape above cannot cover these:
-              // its char class forbids `=`, `"` and `,`, which is exactly what an
-              // attribute selector is made of. Such constants live at module level
-              // under an ALL-CAPS name, so `i18n-strict` looks inside them.
+              // CSS SELECTOR LISTS, e.g. `[role="dialog"],[data-x]` or
+              // `a,button,[tabindex]` — a comma-joined list of type selectors and
+              // bracketed attribute selectors, as passed to querySelector. The
+              // Tailwind/class shape above cannot cover these: its char class forbids
+              // `=`, `"` and `,`, which is exactly what an attribute selector is made
+              // of. Such constants live at module level under an ALL-CAPS name, so
+              // `i18n-strict` looks inside them.
               //
-              // Deliberately anchored and total: the WHOLE string must be
-              // bracketed selectors, so prose cannot match (prose has no square
-              // brackets), and a sentence merely containing one is still flagged.
-              '^\\[[a-z\\-]+(?:[~|^$*]?=(?:"[^"]*"|\'[^\']*\'))?\\](?:\\s*,\\s*\\[[a-z\\-]+(?:[~|^$*]?=(?:"[^"]*"|\'[^\']*\'))?\\])*$',
+              // A bare type selector is admitted only alongside a bracketed one: the
+              // leading lookahead requires at least one `[` in the WHOLE string, and
+              // that is what keeps this entry from becoming a general "lowercase words
+              // joined by commas" exemption. Without it `'save,delete'` would match,
+              // and `\s*,\s*` permits a space, so `'save, delete'` would too. A
+              // sentence merely containing a bracket still fails, because every member
+              // must match end to end and a prose member carries spaces.
+              //
+              // Known false negative, stated: a comma-joined list of lowercase words
+              // that also holds a bracketed term is exempt. Copy does not take that
+              // shape — a bracket in copy sits inside a phrase, not as a list member.
+              '^(?=[^\\[]*\\[)(?:[a-z][a-z0-9]*|\\[[a-z\\-]+(?:[~|^$*]?=(?:"[^"]*"|\'[^\']*\'))?\\])(?:\\s*,\\s*(?:[a-z][a-z0-9]*|\\[[a-z\\-]+(?:[~|^$*]?=(?:"[^"]*"|\'[^\']*\'))?\\]))*$',
               // Identifiers, paths, URLs, mime types, storage keys.
               // camelCase identifiers only. A plain lowercase word must NOT be excluded
               // here: `saved`, `active` and `done` are all real UI copy, and a pattern of

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -69,6 +69,7 @@ import KiroCrewNavBridge from './components/KiroCrewNavBridge'
 import InstanceTabBar from './components/InstanceTabBar'
 import InstancesViewport from './components/InstancesViewport'
 import EmbeddedHostBridge from './components/EmbeddedHostBridge'
+import EmbeddedDragRegionReporter from './components/EmbeddedDragRegionReporter'
 import EmbedTabStrip from './components/EmbedTabStrip'
 import DeveloperPage from './pages/DeveloperPage'
 import SchedulePage from './pages/SchedulePage'
@@ -1705,6 +1706,10 @@ export default function App() {
       {/* Embedded remote panes receive their switcher model from the parent via
           this bridge (option B) — no-op in the top-level dashboard. */}
       <EmbeddedHostBridge />
+      {/* Embedded remote panes report their header's control-free gaps up to the
+          Electron host so it can make the pane title bar draggable — no-op in
+          the top-level dashboard and under a browser host. */}
+      <EmbeddedDragRegionReporter />
       <div className="flex-1 min-h-0 relative">
       {/* Local pane: the native dashboard. Hidden (not unmounted) while a remote
           instance tab is active, so local state/websocket survive the switch. */}

--- a/website/src/components/EmbeddedDragRegionReporter.tsx
+++ b/website/src/components/EmbeddedDragRegionReporter.tsx
@@ -1,0 +1,89 @@
+/**
+ * EmbeddedDragRegionReporter — the embedded (remote-pane) reporter that lets the
+ * Electron host make the pane's title bar draggable.
+ *
+ * A remote pane is a cross-origin <iframe>; the host's injected drag region and
+ * its `no-drag` blanket cover only the host's main frame (the whole iframe is
+ * `no-drag`), and draggable regions do not descend into a subframe. So neither
+ * side can make the pane's header move the window on its own. This reporter
+ * measures the header's control-free gaps and relays them up; the host
+ * (InstancesViewport) re-adds `-webkit-app-region: drag` in exactly those gaps.
+ *
+ * Runs only when this SPA is an embedded pane AND its host is an Electron window
+ * (relayed via the host model) — a browser host has no native window to drag, so
+ * there is nothing to report. No-op everywhere else.
+ */
+import { useEffect } from 'react'
+import { useAppSelector } from '../store'
+import { isEmbeddedPane } from '../lib/embedded'
+import { computeHeaderDragGaps } from '../lib/dragGaps'
+
+export default function EmbeddedDragRegionReporter() {
+  // The host model tells the pane whether its host is an Electron window; only
+  // then is a draggable title bar meaningful.
+  const hostElectron = useAppSelector(s => !!s.instances.host?.electron)
+
+  useEffect(() => {
+    if (!isEmbeddedPane() || !hostElectron) return
+    const parent = window.parent
+    if (!parent || parent === window) return
+
+    let lastJson = ''
+    let raf = 0
+    const post = () => {
+      raf = 0
+      const header = document.querySelector('header.topbar-glass')
+      // Skip while the pane is not laid out (hidden/inactive): a zero-width band
+      // yields no gaps, and posting stale geometry for an off-screen pane is
+      // pointless (the host only reads the active pane's gaps).
+      if (!header || window.innerWidth === 0) return
+      const gaps = computeHeaderDragGaps(header, window.innerWidth)
+      const json = JSON.stringify(gaps)
+      if (json === lastJson) return
+      lastJson = json
+      try {
+        // The host validates our loopback ORIGIN (resolveTunnelOrigin), so the
+        // wildcard target is safe and matches the sibling mc-embedded-ready ping.
+        // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+        parent.postMessage({ type: 'mc-drag-gaps', v: 1, gaps }, '*')
+      } catch {
+        /* parent gone / mid-navigation — the next change reposts */
+      }
+    }
+    // Coalesce bursts (a metrics tick + a theme change in one frame) into one
+    // measurement.
+    const schedule = () => {
+      if (raf) return
+      raf = window.requestAnimationFrame(post)
+    }
+
+    const header = document.querySelector('header.topbar-glass')
+    // Header-scoped observers only — cheap, and they catch every reflow that
+    // moves a control: window/zoom resize, a badge widening a cluster (header
+    // stays the same size, so a header-only ResizeObserver would miss it), a
+    // theme swap, and the pane going visible (0 -> full width fires the RO).
+    const ro = new ResizeObserver(schedule)
+    const mo = new MutationObserver(schedule)
+    if (header) {
+      ro.observe(header)
+      for (const c of Array.from(header.children)) ro.observe(c)
+      mo.observe(header, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['class', 'style'],
+      })
+    }
+    window.addEventListener('resize', schedule)
+    schedule()
+
+    return () => {
+      if (raf) window.cancelAnimationFrame(raf)
+      ro.disconnect()
+      mo.disconnect()
+      window.removeEventListener('resize', schedule)
+    }
+  }, [hostElectron])
+
+  return null
+}

--- a/website/src/components/InstancesViewport.tsx
+++ b/website/src/components/InstancesViewport.tsx
@@ -38,9 +38,10 @@ import { useAppDispatch, useAppSelector } from '../store'
 import { removeWarm, setActiveId, setPaneReady, setUnread, setWarm } from '../store/instancesSlice'
 import InstanceTabBar, { visibleInstanceTabs } from './InstanceTabBar'
 import { resolveTunnelOrigin } from '../lib/tunnelOrigin'
-import { TRAFFIC_LIGHT_INSET_PX } from '../lib/electron'
+import { TRAFFIC_LIGHT_INSET_PX, WIN_CAPTION_OVERLAY_WIDTH } from '../lib/electron'
 import { isEmbeddedPane } from '../lib/embedded'
-import { isElectron } from '../lib/electron'
+import { isElectron, isWinElectron } from '../lib/electron'
+import type { DragGap } from '../lib/dragGaps'
 
 import { i18nT } from '../i18n/t'
 // Refresh the embedded token once elapsed reaches this fraction of its TTL
@@ -77,6 +78,11 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   // Panes whose embedded SPA has announced readiness for their CURRENT src.
   // Tests preload partial slices, so tolerate a missing map.
   const ready = useAppSelector(s => s.instances.ready) ?? {}
+
+  // Per-instance header drag gaps relayed up by each embedded pane
+  // (mc-drag-gaps). Only the ACTIVE pane's gaps are rendered, but they are
+  // keyed by id so a background pane's report is retained for an instant switch.
+  const [dragGaps, setDragGaps] = useState<Record<string, DragGap[]>>({})
 
   // Embedded instance panes never host nested panes (single-level by design),
   // so skip the poll and render nothing — see isEmbeddedPane / InstanceTabBar.
@@ -158,6 +164,20 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     portToIdRef.current = m
   }, [warm])
 
+  // Drop relayed drag gaps for panes that are no longer warm, so the map cannot
+  // grow without bound and a re-warmed pane starts from its own fresh report.
+  useEffect(() => {
+    setDragGaps(prev => {
+      const next: Record<string, DragGap[]> = {}
+      let changed = false
+      for (const id of Object.keys(prev)) {
+        if (warm[id]) next[id] = prev[id]
+        else changed = true
+      }
+      return changed ? next : prev
+    })
+  }, [warm])
+
   useEffect(() => {
     const onMessage = (e: MessageEvent) => {
       const id = resolveTunnelOrigin(e.origin, portToIdRef.current)
@@ -195,6 +215,24 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         // (drives the loading overlay + load watchdog below).
         dispatch(setPaneReady(id))
         postModelToRef.current(id)
+      } else if (data.type === 'mc-drag-gaps') {
+        // The embedded pane relays the control-free spans of its header so the
+        // host can re-add `-webkit-app-region: drag` there (the blanket marks
+        // the whole iframe no-drag). Sanitize: finite, positive-width spans
+        // only, capped so a malformed/hostile pane can't flood the render.
+        const raw = Array.isArray((data as { gaps?: unknown }).gaps)
+          ? ((data as { gaps: unknown[] }).gaps)
+          : []
+        const gaps: DragGap[] = []
+        for (const g of raw) {
+          if (!g || typeof g !== 'object') continue
+          const x = Number((g as { x?: unknown }).x)
+          const w = Number((g as { w?: unknown }).w)
+          if (!Number.isFinite(x) || !Number.isFinite(w) || x < 0 || w <= 0) continue
+          gaps.push({ x, w })
+          if (gaps.length >= 32) break
+        }
+        setDragGaps(prev => ({ ...prev, [id]: gaps }))
       }
     }
     window.addEventListener('message', onMessage)
@@ -432,6 +470,26 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
           style={{ display: id === activeId ? 'block' : 'none' }}
         />
       ))}
+      {/* Draggable title-bar strips for the active remote pane. Rendered AFTER
+          the iframe so they follow it in DOM order — Electron collects
+          draggable regions in document order, so a `drag` strip here re-adds
+          drag over the gap that the blanket `iframe` no-drag rule subtracted.
+          Only while the pane's own header is actually on screen (not the
+          loading/error overlays, which carry their own interactive tab strip).
+          Each strip sits in a control-free gap the pane measured, so it never
+          swallows a header button's clicks. */}
+      {isElectron && activeId && !showPanel && !showLoading && !!warm[activeId] && activeReady &&
+        (dragGaps[activeId] ?? []).map((g, i) => {
+          // On Windows, stay clear of the native titleBarOverlay caption buttons
+          // (right edge); the pane can't know the host is Windows, so clip here.
+          const rightBound = isWinElectron
+            ? Math.max(0, window.innerWidth - WIN_CAPTION_OVERLAY_WIDTH)
+            : Number.POSITIVE_INFINITY
+          const left = g.x
+          const width = Math.min(g.x + g.w, rightBound) - left
+          if (width < 1) return null
+          return <div key={`drag-${i}`} aria-hidden className="host-drag-strip" style={{ left, width }} />
+        })}
       {showLoading && activeId && (
         <div className="absolute inset-0 flex flex-col bg-bg">
           {/* Same escape hatch as the error panel: while this overlay is up the

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1575,6 +1575,16 @@ button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
    chips are clickable, hoverable, and drag-reorderable. Ignored in browsers. */
 .side-panel-strip,.side-panel-strip *{-webkit-app-region:no-drag}
 
+/* Draggable title-bar strips laid over a remote-instance pane. The pane is a
+   cross-origin iframe, so the host's injected #electron-drag-bar can't reach
+   into it and the blanket marks the whole iframe no-drag — the pane's header
+   can't move the window. InstancesViewport renders these strips (positioned by
+   the gaps the pane reports) AFTER the iframe, so they re-add a drag region in
+   the pane header's control-free gaps. pointer-events:none so the strip never
+   intercepts a click; app-region drag is honored regardless. Ignored in
+   browsers (no native window). */
+.host-drag-strip{position:absolute;top:0;height:42px;-webkit-app-region:drag;pointer-events:none;z-index:2}
+
 /* Scrollbar-free scroll container (used by the side panel tab strip — the
    strip scrolls horizontally but a visible scrollbar under the chips reads
    as clutter). Referenced before Tailwind ever defined it; real rules here. */

--- a/website/src/lib/dragGaps.ts
+++ b/website/src/lib/dragGaps.ts
@@ -1,0 +1,72 @@
+/**
+ * Header drag-gap geometry — the horizontal spans of the 42px title-bar band
+ * that carry NO interactive control, so an Electron host can mark exactly those
+ * as `-webkit-app-region: drag`.
+ *
+ * Why this exists: a remote-instance pane is a cross-origin <iframe>. Electron's
+ * injected drag bar and its `no-drag` blanket only apply to the host's MAIN
+ * frame, and the whole iframe is in that blanket — so the host subtracts the
+ * entire top band and the pane's header cannot move the window. Draggable
+ * regions do not descend into a subframe, so the pane cannot mark itself
+ * draggable either. The fix relays this geometry to the host, which re-adds
+ * drag ONLY in the gaps between the pane's own controls.
+ *
+ * The result is failure-safe by construction: each control's box is grown
+ * outward by CONTROL_PAD_PX before it is excluded, so a stale or rounded
+ * measurement can only shrink a gap (a small non-draggable sliver), never let a
+ * drag strip straddle a control and swallow its clicks.
+ */
+export interface DragGap {
+  /** Left edge in viewport pixels. */
+  x: number
+  /** Width in pixels. */
+  w: number
+}
+
+/**
+ * Interactive controls that must stay clickable. Mirrors the `no-drag` blanket
+ * injected by electron/main.js so the pane's draggable area matches the local
+ * header's exactly. `iframe` is omitted — the header carries none.
+ */
+const INTERACTIVE_SEL = 'a,button,input,select,textarea,[role="button"],[tabindex]'
+/** Outward padding on each control box; the safety margin that keeps gaps off controls. */
+const CONTROL_PAD_PX = 6
+/** Gaps narrower than this are dropped: not worth a region, and rounding-risky. */
+const MIN_GAP_PX = 10
+
+/**
+ * Compute the drag gaps of `header` within the `[0, bandWidth]` viewport band.
+ * Returns an empty list when the header is not laid out (hidden pane) or the
+ * band has no width.
+ */
+export function computeHeaderDragGaps(header: Element, bandWidth: number): DragGap[] {
+  const width = Math.max(0, Math.floor(bandWidth))
+  if (width === 0) return []
+  const controls = Array.from(header.querySelectorAll(INTERACTIVE_SEL)) as HTMLElement[]
+  const blocked: Array<[number, number]> = []
+  for (const el of controls) {
+    const r = el.getBoundingClientRect()
+    // Skip controls with no box (display:none, or a not-yet-laid-out pane).
+    if (r.width <= 0 || r.height <= 0) continue
+    const left = Math.max(0, Math.floor(r.left - CONTROL_PAD_PX))
+    const right = Math.min(width, Math.ceil(r.right + CONTROL_PAD_PX))
+    if (right > left) blocked.push([left, right])
+  }
+  // Merge overlapping / touching blocked intervals so the complement is clean.
+  blocked.sort((a, b) => a[0] - b[0])
+  const merged: Array<[number, number]> = []
+  for (const [l, r] of blocked) {
+    const last = merged[merged.length - 1]
+    if (last && l <= last[1]) last[1] = Math.max(last[1], r)
+    else merged.push([l, r])
+  }
+  // The complement within [0, width] is the set of drag gaps.
+  const gaps: DragGap[] = []
+  let cursor = 0
+  for (const [l, r] of merged) {
+    if (l - cursor >= MIN_GAP_PX) gaps.push({ x: cursor, w: l - cursor })
+    cursor = Math.max(cursor, r)
+  }
+  if (width - cursor >= MIN_GAP_PX) gaps.push({ x: cursor, w: width - cursor })
+  return gaps
+}

--- a/website/src/test/dragGaps.test.ts
+++ b/website/src/test/dragGaps.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for computeHeaderDragGaps — the control-free spans of the header band
+ * that a remote pane relays so the Electron host can re-add a window-drag
+ * region there. The key invariant is failure-safety: each control is padded
+ * outward before exclusion, so a gap can only ever shrink off a control, never
+ * straddle one.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+
+import { computeHeaderDragGaps } from '../lib/dragGaps'
+
+type Span = { left: number; right: number; height?: number }
+
+function stubRect(el: HTMLElement, { left, right, height = 42 }: Span) {
+  el.getBoundingClientRect = () =>
+    ({ width: right - left, height, top: 0, left, right, bottom: height, x: left, y: 0, toJSON: () => ({}) }) as DOMRect
+}
+
+function mountHeader(controls: Span[]): HTMLElement {
+  const header = document.createElement('header')
+  header.className = 'topbar-glass'
+  for (const c of controls) {
+    const btn = document.createElement('button')
+    stubRect(btn, c)
+    header.appendChild(btn)
+  }
+  document.body.appendChild(header)
+  return header
+}
+
+afterEach(() => {
+  document.querySelectorAll('header.topbar-glass').forEach(h => h.remove())
+})
+
+describe('computeHeaderDragGaps', () => {
+  it('returns the whole band as one gap when the header has no controls', () => {
+    const header = mountHeader([])
+    expect(computeHeaderDragGaps(header, 1000)).toEqual([{ x: 0, w: 1000 }])
+  })
+
+  it('returns [] for a zero-width band', () => {
+    const header = mountHeader([{ left: 100, right: 200 }])
+    expect(computeHeaderDragGaps(header, 0)).toEqual([])
+  })
+
+  it('leaves a gap on each side of a centered control (padded off it)', () => {
+    const header = mountHeader([{ left: 400, right: 600 }])
+    // control padded outward by 6 -> blocked [394, 606]
+    expect(computeHeaderDragGaps(header, 1000)).toEqual([
+      { x: 0, w: 394 },
+      { x: 606, w: 394 },
+    ])
+  })
+
+  it('merges overlapping controls into one blocked span', () => {
+    const header = mountHeader([
+      { left: 100, right: 300 },
+      { left: 250, right: 400 },
+    ])
+    // padded + merged -> [94, 406]
+    expect(computeHeaderDragGaps(header, 1000)).toEqual([
+      { x: 0, w: 94 },
+      { x: 406, w: 594 },
+    ])
+  })
+
+  it('drops a gap narrower than the minimum between two controls', () => {
+    // A padded right = 106, B padded left = 111 -> a 5px middle gap, dropped.
+    const header = mountHeader([
+      { left: 40, right: 100 },
+      { left: 117, right: 300 },
+    ])
+    const gaps = computeHeaderDragGaps(header, 1000)
+    // No sliver gap around x≈106; only the wide leading + trailing gaps survive.
+    expect(gaps.some(g => g.x > 0 && g.x < 306)).toBe(false)
+    expect(gaps).toEqual([
+      { x: 0, w: 34 },
+      { x: 306, w: 694 },
+    ])
+  })
+
+  it('ignores controls with no box (hidden / not laid out)', () => {
+    const header = mountHeader([{ left: 400, right: 600, height: 0 }])
+    expect(computeHeaderDragGaps(header, 1000)).toEqual([{ x: 0, w: 1000 }])
+  })
+
+  it('clamps a control that overflows the band edges', () => {
+    const header = mountHeader([{ left: -20, right: 995 }])
+    // padded [<=0, >=1000] -> whole band blocked, no gap wide enough remains.
+    expect(computeHeaderDragGaps(header, 1000)).toEqual([])
+  })
+})

--- a/website/src/test/i18nLintExemptions.test.ts
+++ b/website/src/test/i18nLintExemptions.test.ts
@@ -175,6 +175,35 @@ describe('paths, routes and URLs are exempt', () => {
   })
 })
 
+describe('CSS selector lists are exempt', () => {
+  it('stays quiet on a list mixing type and attribute selectors', async () => {
+    // Real site: `INTERACTIVE_SEL` in lib/dragGaps.ts, handed to
+    // `header.querySelectorAll`. Translating it would stop the drag-gap
+    // measurement finding any control, which silently widens a drag region over
+    // a button and swallows its clicks.
+    expect(await lint(
+      `export const PROBE = ['a,button,input,select,textarea,[role="button"],[tabindex]']`,
+    )).toEqual([])
+  })
+
+  it('stays quiet on an all-bracketed list', async () => {
+    // The narrower form this shape grew out of; it must keep matching.
+    expect(await lint(`export const PROBE = ['[role="dialog"],[data-x]']`)).toEqual([])
+  })
+
+  it('still reports comma-joined words with no bracket', async () => {
+    // The bracket requirement is the whole tightness argument: without it this
+    // entry would become a general "lowercase words joined by commas" exemption.
+    expect(await lint(`export const PROBE = ['save,delete']`)).toHaveLength(1)
+  })
+
+  it('still reports a sentence that merely contains a bracket', async () => {
+    // Every member must match end to end, and a prose member carries spaces.
+    const messages = await lint(`export const PROBE = ['Select an item [optional]']`)
+    expect(messages).toHaveLength(1)
+  })
+})
+
 describe('string comparison is a position exemption', () => {
   it('stays quiet on a literal compared with startsWith', async () => {
     // The argument is the value being compared AGAINST, so the call cannot


### PR DESCRIPTION
## Problem
In the desktop app, switching to a **Remote Crew** (remote-instance) tab makes the top 42px title bar un-draggable — the window can no longer be moved by dragging the pane's header. The local tab is fine.

## Why it matters
The remote pane fills the whole window top-to-bottom, so a user on a remote instance loses the ability to move the window from the header — the primary title-bar affordance is dead for the entire time they are on a remote tab.

## Fix (symptom → root cause → change)
- **Symptom:** header not draggable over a remote pane.
- **Root cause:** the drag region is injected by `electron/main.js` into the host's **main frame** only (`#electron-drag-bar` + a `no-drag` blanket that includes `iframe`). A remote pane is a full-bleed **cross-origin `<iframe>`**, so the blanket subtracts the entire 42px band; and draggable regions do not descend into a subframe, so the pane cannot mark itself draggable either.
- **Change (additive, in the gaps):**
  - New `EmbeddedDragRegionReporter` (mounted only in an embedded pane whose host is Electron) measures the header's **control-free gaps** and relays them up over the existing origin-validated `postMessage` channel as `mc-drag-gaps`.
  - `InstancesViewport` sanitizes and stores the gaps per instance, and renders narrow `-webkit-app-region: drag` strips at those spans **after** the iframe in DOM order — Electron collects draggable regions in document order, so a strip placed after the iframe re-adds drag exactly where the iframe's `no-drag` removed it.
  - Pure geometry lives in `lib/dragGaps.ts`. Each control is padded **outward** before exclusion, so a stale/rounded measurement can only shrink a gap (a small non-draggable sliver), never straddle a control and swallow its clicks. Strips are `pointer-events: none` and only render over the active, ready pane (never the loading/error overlays, which carry their own interactive tab strip). Windows caption overlay is clipped on the right.
  - The selector the pane measures with is a CSS selector living in an ALL-CAPS module constant, which is where the strict i18n lint looks inside. The existing CSS-selector exemption in `eslint.i18n.config.js` admitted only lists made **entirely** of bracketed attribute selectors, so a list mixing type selectors with them was reported as untranslated copy. That exemption now covers a full selector list, gated by a leading lookahead requiring at least one bracket in the whole string so it cannot decay into a general "lowercase words joined by commas" exemption.

No changes to `electron/main.js` — the fix rides entirely in the web bundle, so an already-installed desktop app picks it up as soon as its gateway serves the new SPA.

## Tests
- `website/src/test/dragGaps.test.ts` (7 cases): empty header → whole band draggable; zero-width band → none; centered control padded on both sides; overlapping controls merged; sub-minimum gap dropped; hidden (zero-box) control skipped; out-of-band control clamped.
- `website/src/test/i18nLintExemptions.test.ts` (4 cases, linted through the real strict config): the mixed type+attribute list is exempt; the all-bracketed form still is; a comma-joined pair with no bracket is still reported; a sentence merely containing a bracket is still reported. Falsified by reverting the widened pattern — only the mixed-list case goes red, so each case guards its own property rather than riding on the others.
- The failing CI gate reproduced locally and cleared: `I18N_BASE_REF=origin/main node scripts/check-i18n-strings.mjs` → `[added-lines] 0`, `[vs-base] 0`.
- Full frontend suite green: `tsc -b`, `eslint src/ --max-warnings 1116`, `vitest run` (971 files, 15575 passed). Backend untouched, so no Python gate applies.

## Manual verification
Confirmed by hand on the desktop app (host = local Mac gateway, pane = a remote dev-dsk instance, both serving this build): switched to the remote instance tab, dragged the header gaps and the window moved, and search / notifications / settings stayed clickable (not swallowed by the drag region). Unit tests cover the gap geometry; this manual pass covers the OS-level drag that automation cannot.

## Screenshots
N/A — no visible UI change; the strips are invisible (`pointer-events: none`, transparent).
