### PR TITLE
perf(dashboard): memoise the persisted-message entry builder

### DIFF
--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
 import re
+import threading
 import time
 import uuid
-from collections import deque
+from collections import OrderedDict, deque
 from collections.abc import Iterator, Mapping
 
 from kiro_crew import model_registry
@@ -1101,7 +1103,143 @@ def _archive_dropped_lines(
     _archive_lines(history_key, dropped, reason="compact", base=base)
 
 
+# Memoisation for :func:`_build_message_entry`. ``_save_slot_to_history``
+# re-serializes the WHOLE in-memory window on every flush (see the comment inside
+# the uncached builder), so each save re-runs redaction over every message in the
+# window -- including the overwhelming majority that have not changed since the
+# previous flush. Redaction is the expensive part: two passes over the content,
+# the same two passes again over EACH variant, plus a meta pass.
+#
+# The key is a content hash of the WHOLE message rather than an identity or a
+# field subset, which is what makes invalidation automatic and total: the slot
+# mutates messages in place (a stop event resolving, a file-change chip landing,
+# a banner completing), and any such edit changes the digest, so the next call
+# misses and recomputes instead of serving a stale entry. There is deliberately
+# no explicit invalidation hook to forget.
+#
+# Bound sizing: a save re-serializes one slot's entire window, so the live
+# working set is roughly ``active_slots x window_size`` and the failure mode past
+# the bound is a cliff rather than a slope -- each save walks its window in
+# order, so with several slots taking turns the LRU evicts each window just
+# before its next save and the hit rate collapses to zero instead of degrading.
+# The entry bound is therefore chosen to hold several concurrent slot windows.
+#
+# The flush site skips the cache for a window longer than the entry bound, which
+# closes that cliff for ONE oversized window and nothing more. Several slots
+# whose COMBINED windows exceed the bound each stay under it individually, so
+# they take the cached path and hit the same zero-hit cliff unguarded. That is
+# accepted rather than fixed: detecting it needs a live view across slots, while
+# the cost of being wrong is only the key derivation on a miss.
+#
+# The entry count alone does NOT bound memory, because an entry is as large as
+# its message: a cache full of megabyte-sized messages would retain gigabytes.
+# That retention outlives the slot, since the entry holds the SAME content string
+# object as the message rather than a copy, so a closed slot's window can be
+# freed while the cache keeps its content alive. Hence two further bounds: a
+# per-entry ceiling above which an entry is computed but never stored (so one
+# huge message cannot evict the whole cache), and a total-byte ceiling evicted
+# alongside the entry count. Worst-case retention is the lesser of
+# ``_ENTRY_CACHE_MAX x _ENTRY_MAX_CACHEABLE_BYTES`` and ``_ENTRY_CACHE_MAX_BYTES``.
+#
+# Size is measured as the length of the key payload, which the front door has
+# already built for hashing, so it costs nothing extra. It measures the input
+# rather than the built entry, but the entry is derived from it and the two track
+# each other within a small factor -- accurate enough for a memory ceiling.
+#
+# Two properties work in our favour: entries are content-keyed, so two slots
+# holding identical message content share one entry; and a cached ``None`` (a
+# transient role) is a legitimate value, so membership -- not truthiness -- is
+# what distinguishes a hit from a miss.
+_ENTRY_CACHE_MAX = 4096
+_ENTRY_CACHE_MAX_BYTES = 32 * 1024 * 1024
+_ENTRY_MAX_CACHEABLE_BYTES = 256 * 1024
+_entry_cache_lock = threading.Lock()
+_entry_cache: OrderedDict[str, tuple[dict | None, int]] = OrderedDict()
+_entry_cache_bytes = 0
+
+
+def _approx_window_payload_bytes(window: list[dict]) -> int:
+    """Cheap LOWER BOUND on what a window would serialize to, in bytes.
+
+    Sums only string ``content`` on each message and on its variants, ignoring
+    keys, meta and JSON escaping, and never serializes anything -- serializing to
+    measure would pay the very cost the caller is deciding whether to avoid.
+
+    Being a lower bound is what makes it safe to gate on: an estimate above the
+    ceiling proves the real payload is above it too, so the bypass it triggers is
+    always justified, while an underestimate merely forgoes the bypass and pays
+    the hashing cost. Either way correctness is unaffected -- only throughput.
+    """
+    total = 0
+    for m in window:
+        content = m.get("content")
+        if isinstance(content, str):
+            total += len(content)
+        variants = m.get("variants")
+        if isinstance(variants, list):
+            for v in variants:
+                if isinstance(v, dict):
+                    vc = v.get("content")
+                    if isinstance(vc, str):
+                        total += len(vc)
+    return total
+
+
 def _build_message_entry(m: dict) -> dict | None:
+    """Memoised front door to :func:`_build_message_entry_uncached`.
+
+    The cached value is the POST-redaction entry, never the raw input, so a hit
+    can never hand a caller unredacted bytes -- that property is the one whose
+    failure would be a security regression rather than a missed optimisation.
+
+    The returned dict is the cached object itself, not a copy: every current
+    caller treats the entry as read-only (it is serialized with ``json.dumps``
+    and read for ordering keys), and copying on every hit would give back the
+    cost the cache exists to avoid. A future caller that mutates an entry in
+    place would need to copy first.
+    """
+    global _entry_cache_bytes
+    try:
+        payload = json.dumps(m, sort_keys=True, default=str)
+    except Exception:
+        # An unserializable message must still persist; fall back to computing it.
+        return _build_message_entry_uncached(m)
+    key = hashlib.sha256(payload.encode()).hexdigest()
+    size = len(payload)
+    with _entry_cache_lock:
+        if key in _entry_cache:
+            _entry_cache.move_to_end(key)
+            return _entry_cache[key][0]
+    entry = _build_message_entry_uncached(m)
+    if size > _ENTRY_MAX_CACHEABLE_BYTES:
+        return entry
+    # Refuse to STORE a pairing whose key and entry may describe different states.
+    # The flush thread shares message dicts with the event loop, so a variant
+    # switch landing between the two reads above would file the new entry under
+    # the old state's key; because a switch restores content AND ts from the
+    # stored variant, switching back reproduces that key exactly and would serve
+    # the wrong variant. Re-reading m here costs one dump on a miss only.
+    try:
+        if json.dumps(m, sort_keys=True, default=str) != payload:
+            return entry
+    except Exception:
+        return entry
+    with _entry_cache_lock:
+        previous = _entry_cache.pop(key, None)
+        if previous is not None:
+            _entry_cache_bytes -= previous[1]
+        _entry_cache[key] = (entry, size)
+        _entry_cache_bytes += size
+        while _entry_cache and (
+            len(_entry_cache) > _ENTRY_CACHE_MAX
+            or _entry_cache_bytes > _ENTRY_CACHE_MAX_BYTES
+        ):
+            _, (_evicted_entry, evicted_size) = _entry_cache.popitem(last=False)
+            _entry_cache_bytes -= evicted_size
+    return entry
+
+
+def _build_message_entry_uncached(m: dict) -> dict | None:
     """Build one persisted JSONL message dict from an in-memory slot message.
 
     Returns None for transient roles that are never persisted. Applies the
@@ -1756,8 +1894,23 @@ def _save_slot_to_history(
             # foreign lines so a concurrent cross-process append (landed between
             # this save's pre-lock ``window`` snapshot and the lock) is preserved
             # rather than clobbered by the meta+frozen+window replace.
+            # A window longer than the entry cache cannot hit it: this save walks
+            # the window in order, so the LRU evicts each entry before the next
+            # save reaches it again. Building such a window through the cache
+            # would pay the key-hashing cost for a guaranteed 0% hit rate, so the
+            # largest windows -- where flush cost hurts most -- go uncached. A
+            # window whose payload exceeds the BYTE ceiling self-evicts the same
+            # way at a far smaller message count, so it is gated too, on a cheap
+            # lower-bound estimate rather than on a measurement that would itself
+            # cost what the bypass saves.
+            build_entry = (
+                _build_message_entry_uncached
+                if len(window) > _ENTRY_CACHE_MAX
+                or _approx_window_payload_bytes(window) > _ENTRY_CACHE_MAX_BYTES
+                else _build_message_entry
+            )
             window_entries = [
-                e for m in window if (e := _build_message_entry(m)) is not None
+                e for m in window if (e := build_entry(m)) is not None
             ]
             window_lines = [json.dumps(e) + "\n" for e in window_entries]
             frozen_prefix, foreign_lines, dedup_dropped = (

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -591,6 +591,38 @@ def _isolate_kiro_window_cache():
 
 
 @pytest.fixture(autouse=True)
+def _isolate_message_entry_cache():
+    """Give every test an EMPTY ``chat_persistence`` persisted-entry cache.
+
+    The memoised message-entry builder keeps a process-global cache keyed on a
+    content hash of the whole message, so two tests using the same message
+    content share an entry. That is harmless while the builder is pure, and a
+    silent trap the moment a test makes it impure: a test that monkeypatches
+    ``chat_persistence.redact_credentials`` (or the uncached builder) and reuses
+    content another test already cached is served the earlier, pre-patch entry.
+    The assertion then passes against a value the patched code never produced —
+    worst of all for a redaction test, which would go green having seen the
+    redacted entry it was written to prove absent.
+
+    Lives here rather than in the memoisation test module because the hazard runs
+    the other way: the module that pollutes the cache is not the one that
+    misreads it.
+
+    The byte counter is part of the same state, so resetting only the dict would
+    leave the memory ceiling mis-accounted and evict a healthy cache.
+    """
+    from kiro_crew.dashboard import chat_persistence as _cp
+
+    _cp._entry_cache.clear()
+    _cp._entry_cache_bytes = 0
+    try:
+        yield
+    finally:
+        _cp._entry_cache.clear()
+        _cp._entry_cache_bytes = 0
+
+
+@pytest.fixture(autouse=True)
 def _reset_options_control_state():
     """Clear the per-message OPTIONS registries between tests.
 

--- a/test/test_message_entry_memoisation.py
+++ b/test/test_message_entry_memoisation.py
@@ -1,0 +1,468 @@
+"""Memoisation of the persisted-message entry builder.
+
+The save path re-serialises the whole in-memory window on every flush, so
+redaction re-runs for messages that have not changed. The builder is therefore
+split into a content-keyed cache in front of an unchanged implementation.
+
+Four properties matter, and they fail for different reasons:
+
+  equivalence  -- the cached result must equal what the UNCACHED function
+                  computes, not merely equal itself on a second call. Asserting
+                  self-consistency would pass with a key derived from ``id(m)``;
+                  asserting against the uncached function is what catches a
+                  broken key derivation.
+  invalidation -- the slot mutates messages in place (a stop event resolving, a
+                  banner completing), and there is no explicit invalidation
+                  hook, so a changed message MUST produce a changed key.
+  redaction    -- the cached value must be the post-redaction entry. This is the
+                  one property whose failure is a security regression rather
+                  than a missed optimisation.
+  transient    -- roles that build no entry cache a legitimate ``None``, so a
+                  ``None`` hit must not be re-treated as a miss.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard import chat_persistence
+from kiro_crew.dashboard.chat_persistence import (
+    _build_message_entry,
+    _build_message_entry_uncached,
+    _entry_cache,
+)
+
+# Shapes verified against the live detector rather than assumed: each of these
+# is redacted by ``redact_credentials``. Kept in one place so a detector change
+# surfaces as one failure.
+AWS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
+AWS_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+BEARER = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abcdefghij.klmnopqrst"
+TOKEN = "ghp_16C7e42F292c6912E7710c838347Ae178B4a"
+SECRETS = (AWS_KEY_ID, AWS_SECRET, BEARER, TOKEN)
+
+TRANSIENT_ROLES = ("chunk", "done", "streaming", "queued", "permission")
+
+# The cache and its byte counter are reset between tests by the autouse
+# ``_isolate_message_entry_cache`` fixture in conftest, which covers every module
+# rather than only this one -- the module that pollutes the cache is not
+# necessarily the one that misreads it.
+
+
+def _corpus() -> list[dict]:
+    """Mixed roles, with and without variants/meta, plus every secret shape."""
+    return [
+        {"role": "assistant", "content": f"key {AWS_KEY_ID} here", "ts": "t1"},
+        {"role": "user", "content": "just typing", "ts": "t2"},
+        {"role": "system", "content": f"auth {BEARER}", "ts": "t3", "cls": "msg"},
+        {
+            "role": "tool",
+            "content": f"secret {AWS_SECRET}",
+            "ts": "t4",
+            "meta": {"mid": "m-4", "note": f"token {TOKEN}"},
+        },
+        {
+            "role": "assistant",
+            "content": "with variants",
+            "ts": "t5",
+            "variants": [
+                {"content": f"v1 {AWS_KEY_ID}", "model": "m1"},
+                {"content": f"v2 {TOKEN}", "model": "m2"},
+            ],
+            "variant_idx": 0,
+        },
+        *({"role": r, "content": "transient", "ts": f"t-{r}"} for r in TRANSIENT_ROLES),
+    ]
+
+
+# ── 1. equivalence: cached == uncached, asserted against the uncached function ─
+
+
+@pytest.mark.parametrize("message", _corpus(), ids=lambda m: m["role"] + "-" + m["ts"])
+def test_cached_entry_equals_the_uncached_computation(message: dict) -> None:
+    expected = _build_message_entry_uncached(dict(message))
+    assert _build_message_entry(message) == expected
+
+
+def test_cached_entry_equals_uncached_across_the_whole_corpus() -> None:
+    """Whole-window form: this is the shape the save path actually drives."""
+    corpus = _corpus()
+    expected = [_build_message_entry_uncached(dict(m)) for m in corpus]
+    assert [_build_message_entry(m) for m in corpus] == expected
+    # Second pass is served from cache and must still agree.
+    assert [_build_message_entry(m) for m in corpus] == expected
+
+
+def test_a_repeat_call_is_served_from_the_cache() -> None:
+    """Without this the suite could pass with the cache never being consulted,
+    making every other assertion here vacuous."""
+    m = {"role": "assistant", "content": "hello", "ts": "t"}
+    first = _build_message_entry(m)
+    assert len(_entry_cache) == 1
+    assert _build_message_entry(m) is first  # same object -> genuine hit
+
+
+# ── 2. invalidation: in-place mutation must re-run the build ──────────────────
+
+
+def test_in_place_content_mutation_invalidates() -> None:
+    m = {"role": "assistant", "content": "before", "ts": "t"}
+    assert _build_message_entry(m)["content"] == "before"
+    m["content"] = "after"
+    assert _build_message_entry(m)["content"] == "after"
+
+
+def test_in_place_meta_mutation_invalidates() -> None:
+    """Meta is where the in-place edits actually happen (a stop event resolving,
+    a file-change chip landing), so keying on content alone would serve stale."""
+    m = {"role": "assistant", "content": "same", "ts": "t", "meta": {"mid": "m-1"}}
+    _build_message_entry(m)
+    m["meta"]["stopped"] = True
+    assert _build_message_entry(m)["meta"].get("stopped") is True
+
+
+def test_in_place_variant_mutation_invalidates() -> None:
+    m = {
+        "role": "assistant",
+        "content": "c",
+        "ts": "t",
+        "variants": [{"content": "one", "model": "m1"}],
+        "variant_idx": 0,
+    }
+    _build_message_entry(m)
+    m["variants"].append({"content": "two", "model": "m2"})
+    entry = _build_message_entry(m)
+    assert [v["content"] for v in entry["variants"]] == ["one", "two"]
+
+
+def test_mutation_matches_a_freshly_computed_entry() -> None:
+    """Stronger than "changed": the post-mutation entry must equal what the
+    uncached function computes for the mutated message."""
+    m = {"role": "assistant", "content": f"first {AWS_KEY_ID}", "ts": "t"}
+    _build_message_entry(m)
+    m["content"] = f"second {TOKEN}"
+    assert _build_message_entry(m) == _build_message_entry_uncached(dict(m))
+
+
+# ── 3. redaction: the cached value is the redacted entry (security gate) ──────
+
+
+def _flatten(entry: dict | None) -> str:
+    """Every string anywhere in the entry, so a secret cannot hide in a variant
+    or in meta."""
+    if entry is None:
+        return ""
+    import json
+
+    return json.dumps(entry, default=str)
+
+
+@pytest.mark.parametrize("role", ["assistant", "system", "tool"])
+@pytest.mark.parametrize("secret", SECRETS)
+def test_cached_value_is_redacted_not_raw(role: str, secret: str) -> None:
+    m = {"role": role, "content": f"here it is {secret}", "ts": "t", "cls": "msg"}
+    first = _build_message_entry(m)
+    assert secret not in _flatten(first)
+    # And the cached read is redacted too -- the property that would fail if the
+    # raw input were stored instead of the built entry.
+    assert secret not in _flatten(_build_message_entry(m))
+
+
+@pytest.mark.parametrize("secret", SECRETS)
+def test_secrets_in_variants_and_meta_are_redacted_through_the_cache(
+    secret: str,
+) -> None:
+    m = {
+        "role": "assistant",
+        "content": "clean",
+        "ts": "t",
+        "variants": [{"content": f"leak {secret}", "model": "m1"}],
+        "variant_idx": 0,
+        "meta": {"mid": "m-1", "tool_input": f"leak {secret}"},
+    }
+    _build_message_entry(m)
+    assert secret not in _flatten(_build_message_entry(m))
+
+
+def test_no_secret_survives_anywhere_in_the_cached_corpus() -> None:
+    """Sweep: after building the whole corpus, no secret shape may appear in any
+    cached value."""
+    for m in _corpus():
+        _build_message_entry(m)
+    blob = "".join(_flatten(v) for v, _size in _entry_cache.values())
+    for secret in SECRETS:
+        assert secret not in blob
+
+
+# ── 4. transient roles: a cached None is a value, not a miss ──────────────────
+
+
+@pytest.mark.parametrize("role", TRANSIENT_ROLES)
+def test_transient_roles_return_none_through_the_cache(role: str) -> None:
+    m = {"role": role, "content": "x", "ts": "t"}
+    assert _build_message_entry(m) is None
+    assert _build_message_entry(m) is None
+
+
+@pytest.mark.parametrize("role", TRANSIENT_ROLES)
+def test_a_cached_none_is_a_hit_not_a_miss(role: str) -> None:
+    """A ``None`` hit must be distinguished by MEMBERSHIP, not truthiness. Keyed
+    on truthiness the entry would be rebuilt on every call and the cache would
+    silently do nothing for these roles."""
+    m = {"role": role, "content": "x", "ts": "t"}
+    _build_message_entry(m)
+    assert len(_entry_cache) == 1
+    key = next(iter(_entry_cache))
+    assert _entry_cache[key][0] is None
+    _build_message_entry(m)
+    assert len(_entry_cache) == 1  # no duplicate insert -> it was a hit
+
+
+def test_transient_none_agrees_with_the_uncached_function() -> None:
+    for role in TRANSIENT_ROLES:
+        m = {"role": role, "content": "x", "ts": "t"}
+        assert _build_message_entry(m) == _build_message_entry_uncached(dict(m))
+
+
+# ── bounds: entry count, total bytes, and per-entry rejection ─────────────────
+
+
+def test_cache_is_bounded_by_entry_count() -> None:
+    for i in range(chat_persistence._ENTRY_CACHE_MAX + 50):
+        _build_message_entry({"role": "assistant", "content": f"m{i}", "ts": f"t{i}"})
+    assert len(_entry_cache) == chat_persistence._ENTRY_CACHE_MAX
+
+
+def test_byte_counter_tracks_the_stored_entries() -> None:
+    """The counter is what enforces the memory ceiling, so it must equal the sum
+    of the stored sizes -- a counter that drifts upward would evict a healthy
+    cache down to nothing, and one that drifts downward stops bounding at all."""
+    for i in range(50):
+        _build_message_entry({"role": "assistant", "content": f"m{i}" * 10, "ts": f"t{i}"})
+    assert chat_persistence._entry_cache_bytes == sum(s for _e, s in _entry_cache.values())
+
+
+def test_a_concurrent_double_insert_does_not_inflate_the_byte_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two threads can both MISS on the same key -- the hit-check releases the
+    lock before the build -- and both then insert. The insert must replace rather
+    than add, or the counter would double-count and evict a healthy cache.
+
+    A plain repeated call cannot test this: the second call returns early on the
+    hit and never reaches the insert. The barrier is what holds both threads past
+    the hit-check so the race is deterministic rather than incidental.
+    """
+    m = {"role": "assistant", "content": "raced", "ts": "t"}
+    barrier = threading.Barrier(2)
+    real = chat_persistence._build_message_entry_uncached
+
+    def blocking_build(msg: dict):
+        barrier.wait(timeout=10)
+        return real(msg)
+
+    monkeypatch.setattr(chat_persistence, "_build_message_entry_uncached", blocking_build)
+    threads = [threading.Thread(target=_build_message_entry, args=(m,)) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+        assert not t.is_alive()
+
+    assert len(_entry_cache) == 1
+    assert chat_persistence._entry_cache_bytes == sum(s for _e, s in _entry_cache.values())
+
+
+def test_total_byte_ceiling_evicts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bounding entries alone does not bound memory: an entry is as large as its
+    message. With a low byte ceiling the cache must evict on bytes even though
+    the entry count is nowhere near its own bound."""
+    monkeypatch.setattr(chat_persistence, "_ENTRY_CACHE_MAX_BYTES", 4000)
+    for i in range(40):
+        _build_message_entry({"role": "assistant", "content": "x" * 500, "ts": f"t{i}"})
+    assert len(_entry_cache) < 40
+    assert chat_persistence._entry_cache_bytes <= 4000
+
+
+def test_an_oversized_entry_is_returned_but_not_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One huge message must not be allowed to evict the whole cache, so it is
+    computed and returned without being stored."""
+    monkeypatch.setattr(chat_persistence, "_ENTRY_MAX_CACHEABLE_BYTES", 1000)
+    small = {"role": "assistant", "content": "small", "ts": "t1"}
+    _build_message_entry(small)
+    assert len(_entry_cache) == 1
+    huge = {"role": "assistant", "content": "y" * 5000, "ts": "t2"}
+    entry = _build_message_entry(huge)
+    assert entry == _build_message_entry_uncached(dict(huge))
+    assert len(_entry_cache) == 1  # the small one survives; the huge one is absent
+
+
+def test_an_oversized_entry_is_still_redacted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The uncacheable path must not become a redaction bypass."""
+    monkeypatch.setattr(chat_persistence, "_ENTRY_MAX_CACHEABLE_BYTES", 100)
+    entry = _build_message_entry(
+        {"role": "assistant", "content": f"{'p' * 500} {AWS_KEY_ID}", "ts": "t"}
+    )
+    assert AWS_KEY_ID not in _flatten(entry)
+
+
+# ── flush site: a window past the bound cannot hit, so it goes uncached ───────
+
+
+def test_a_window_longer_than_the_bound_bypasses_the_cache(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Such a window evicts itself before the next save reaches it, so routing it
+    through the cache would pay the hashing cost for a guaranteed 0% hit rate."""
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    monkeypatch.setattr(chat_persistence, "_ENTRY_CACHE_MAX", 3)
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("s1")
+    for i in range(5):
+        slot.append("assistant", f"message {i}")
+    slot.drain()
+    _entry_cache.clear()
+
+    _save_slot_to_history(state, slot, closed=True)
+
+    assert len(_entry_cache) == 0
+
+
+def test_a_window_within_the_bound_still_uses_the_cache(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Control for the bypass: without this, the test above would pass even if
+    the cache were never populated by a save at all."""
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    monkeypatch.setattr(chat_persistence, "_ENTRY_CACHE_MAX", 100)
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("s1")
+    for i in range(5):
+        slot.append("assistant", f"message {i}")
+    slot.drain()
+    _entry_cache.clear()
+
+    _save_slot_to_history(state, slot, closed=True)
+
+    assert len(_entry_cache) > 0
+
+
+# ── a mutation racing the build must not be cached ────────────────────────────
+
+
+def test_a_mutation_during_the_build_is_not_cached() -> None:
+    """The key is read before the build, so a mutation between them would file the
+    new entry under the old state's key.
+
+    The flush thread shares message dicts with the event loop, so a variant switch
+    can land in that gap. Storing the pair is what makes it durable: a switch
+    restores content AND ts from the stored variant, so switching back reproduces
+    the old key exactly and would be served the other variant's entry.
+    """
+    real = _build_message_entry_uncached
+    m = {"role": "assistant", "content": "variant A", "ts": "t1", "variant_idx": 0}
+
+    def mutating(msg: dict) -> dict | None:
+        msg["content"] = "variant B"
+        msg["variant_idx"] = 1
+        return real(msg)
+
+    chat_persistence._build_message_entry_uncached = mutating  # type: ignore[assignment]
+    try:
+        entry = _build_message_entry(m)
+    finally:
+        chat_persistence._build_message_entry_uncached = real  # type: ignore[assignment]
+
+    assert entry is not None
+    assert entry["content"] == "variant B"
+    assert len(_entry_cache) == 0
+    assert chat_persistence._entry_cache_bytes == 0
+
+
+def test_switching_back_after_a_racing_mutation_recomputes() -> None:
+    """The observable harm the refusal prevents: the wrong variant persisted.
+
+    Without the refusal the first call leaves ``{key(A): entry(B)}`` behind, so
+    reverting to A hits that pair and writes B to the transcript while the UI
+    shows A -- and unlike the pre-existing torn write, it does not self-correct.
+    """
+    real = _build_message_entry_uncached
+    m = {"role": "assistant", "content": "variant A", "ts": "t1", "variant_idx": 0}
+
+    def mutating(msg: dict) -> dict | None:
+        msg["content"] = "variant B"
+        msg["variant_idx"] = 1
+        return real(msg)
+
+    chat_persistence._build_message_entry_uncached = mutating  # type: ignore[assignment]
+    try:
+        _build_message_entry(m)
+    finally:
+        chat_persistence._build_message_entry_uncached = real  # type: ignore[assignment]
+
+    m["content"] = "variant A"
+    m["variant_idx"] = 0
+    assert _build_message_entry(m)["content"] == "variant A"  # type: ignore[index]
+
+
+# ── flush site: a window past the BYTE ceiling also cannot hit ────────────────
+
+
+def test_the_window_payload_estimate_is_a_lower_bound() -> None:
+    """Gating on it is only sound because it under-counts: an estimate above the
+    ceiling proves the real payload is above it too."""
+    window = [
+        {
+            "role": "assistant",
+            "content": "x" * 100,
+            "ts": "t1",
+            "variants": [{"content": "y" * 50}],
+        }
+    ]
+    estimate = chat_persistence._approx_window_payload_bytes(window)
+    actual = sum(len(json.dumps(m, sort_keys=True, default=str)) for m in window)
+
+    assert estimate == 150
+    assert estimate <= actual
+
+
+def test_a_window_past_the_byte_ceiling_bypasses_the_cache(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Such a window self-evicts through the byte ceiling at a message count well
+    under the entry bound, so it hits 0% while still paying to hash every byte.
+
+    The message count stays under ``_ENTRY_CACHE_MAX`` and each message stays
+    under the per-entry cap, so neither of the other two bypasses can account for
+    an empty cache here.
+    """
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    monkeypatch.setattr(chat_persistence, "_ENTRY_CACHE_MAX", 100)
+    monkeypatch.setattr(chat_persistence, "_ENTRY_CACHE_MAX_BYTES", 1000)
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("s1")
+    for i in range(5):
+        slot.append("assistant", f"{i}" + "z" * 500)
+    slot.drain()
+    _entry_cache.clear()
+
+    _save_slot_to_history(state, slot, closed=True)
+
+    assert len(slot.messages) <= chat_persistence._ENTRY_CACHE_MAX
+    assert all(
+        len(m.get("content") or "") < chat_persistence._ENTRY_MAX_CACHEABLE_BYTES
+        for m in slot.messages
+    )
+    assert len(_entry_cache) == 0


### PR DESCRIPTION
## What

`_build_message_entry` is split into a bounded cache in front of an unchanged implementation, now named `_build_message_entry_uncached`. The body of that function is unchanged byte for byte — the rename is a pure move, so the whole behavioural surface of this PR is the new front door plus a three-line guard at the flush site.

## Why

`_save_slot_to_history` re-serialises the whole in-memory window on every flush; its own comment says so ("re-serializes the WHOLE in-memory window on every flush, so this is the write-back boundary"). So on each save, every message in the window runs, for non-`user` roles: `redact_exfiltration_urls`, `redact_credentials`, that same pair again for **each** variant, and `_redact_meta_for_role` on meta. Repeated flushes redo all of it for messages that have not changed since the previous save.

The key is a content hash of the whole message (`sha256` over `json.dumps(m, sort_keys=True, default=str)`). That is what makes invalidation automatic and total: the slot mutates messages in place — a stop event resolving, a file-change chip landing, a banner completing — and any such edit changes the digest, so the next call misses and recomputes rather than serving a stale entry. There is deliberately no explicit invalidation hook to forget.

The cached value is the **post-redaction entry**, never the raw input, so a hit cannot hand a caller unredacted bytes.

## Bounds, and the memory ceiling

Three bounds, because an entry count alone does **not** bound memory — an entry is as large as its message, and the retention outlives the slot: the entry holds the *same content string object* as the message rather than a copy, so a closed slot's window can be freed while the cache keeps its content alive.

| bound | value | role |
| ---------------------------- | -------: | ------------------------------------------- |
| `_ENTRY_CACHE_MAX`           |     4096 | entry count; sized to hold several windows   |
| `_ENTRY_CACHE_MAX_BYTES`     |   32 MiB | total ceiling, evicted alongside the count   |
| `_ENTRY_MAX_CACHEABLE_BYTES` |  256 KiB | per-entry; above this an entry is computed but never stored |

Worst-case retention is the lesser of `4096 x 256 KiB` and `32 MiB`, so **32 MiB**. Measured, in the scenario that matters — messages dropped, cache retaining:

| message size | entries kept | cache retains |
| ------------ | -----------: | ------------: |
| 500 char     |          400 |       0.33 MB |
| 10 KB        |         2000 |      14.68 MB |
| 100 KB       |          447 |      33.79 MB |
| 1 MB         |            0 |       0.00 MB |

The per-entry ceiling is what keeps one huge message from evicting the whole cache. Its cost is a deliberate tradeoff: a message above 256 KiB never caches, so it pays the key derivation and gets no benefit. Bounded memory is worth more than a large-message speedup.

Size is measured as the length of the key payload the front door has already built for hashing, so it costs nothing extra. It measures the input rather than the built entry, but the two track each other within a few percent — accurate enough for a memory ceiling.

## Measurement

The cache is not free: key derivation serialises and hashes the whole message on every call, hit or miss. So this was measured rather than assumed, on 400-message corpora with the cache cleared before each cached run so pass 1 is all misses.

**The realistic case is a large, robust win: about 10x faster** (uncached 1201ms, cached 120ms across 20 passes over a 400-message mixed-role window, median of 5 interleaved runs). Before the post-build re-read described below it measured 11.9x, reproduced three times independently at 12.0x, 11.4x and 11.9x. The separation far exceeds run-to-run variance either way, so the win stands.

Two smaller claims I will not quote precisely, because the machine I measured on was heavily loaded (load average 58-71 on 16 cores) and run-to-run spread reached 3.2x:

- **A user-heavy window is a real regression, and an earlier claim in this section was wrong.** It previously reported 1.24x and 1.29x *faster* and called that no measurable regression; those runs were taken on a heavily loaded host and do not survive a quieter one. On a user-only corpus the cached path is **3x to 12x slower on this step** — 0.19x at 20-character content, 0.17x at 200, 0.08x at 2000 — because `user` messages skip redaction, so the uncached build stays flat at about 0.73us while hashing scales with content length. In absolute terms that is 0.73us rising to 3.8-9.3us per message, against roughly 135us saved per message in the mixed case, so the net stays strongly positive for any window containing assistant turns. A role-based bypass would remove it entirely and is deliberately not in this change.
- **A single cold pass with no reuse at all** is **slower**, and that direction is certain by construction rather than by measurement: on a pure miss the cached path does everything the uncached path does, plus `json.dumps` and `sha256`. It measured about 12% slower on a quieter run (59.4ms to 67.5ms for one pass over 400 messages), up from 3.6% before the post-build re-read added a second serialization on a miss. Small, but real, and it is the one case this change makes worse.

## The cliff, and why the largest windows now bypass the cache

The failure mode past the entry bound is a **cliff, not a slope**: each save walks its window in order, so with several slots taking turns the LRU evicts each window just before its next save. Measured, and sharp — with four slots and 400-message windows (working set 1600), the hit rate is **0.0% at a bound of 1599 and 75.0% at 1600** (75% being the maximum achievable, since the first round is necessarily all misses).

That has a direct consequence, and thanks to the design-review comment for pointing at it: a window longer than the bound has a *guaranteed* 0% hit rate while still paying the full hashing cost. So the flush site now builds such a window through `_build_message_entry_uncached` directly. Without that guard the one slot this PR made strictly slower would have been the documented `_MAX_SLOT_MESSAGES` maximum of 10000 — precisely where flush cost hurts most. A window whose *payload* exceeds the byte ceiling self-evicts in the same way at a far smaller message count, so it is gated too, on a cheap lower-bound estimate that sums only string `content` on each message and its variants. Being a lower bound is what makes gating on it sound: an estimate above the ceiling proves the real payload is above it, while an underestimate merely forgoes the bypass — so being wrong costs throughput and never correctness.

### Concurrency: a torn key/entry pair is built but never stored

The flush thread and the event loop share message dicts — `window = list(slot.messages)` copies the list, not the dicts — so a mutation can land between the key derivation and the build. Filing that pair would put the new entry under the *old* state's key. That matters because switching variants restores `content` **and** `ts` from the stored variant, so switching back reproduces the old key byte for byte and would be served the other variant's entry, persisting the wrong one; and unlike the pre-existing torn read, a cached pair does not self-correct on the next flush. The front door therefore re-reads the message after building and stores only if it is unchanged, so a torn pair is still used for that one flush (as before this change) but is never persisted. Two tests cover it, and with the check removed they fail with `assert 1 == 0` and `assert 'variant B' == 'variant A'` respectively.

That guard closes the cliff for one oversized window and nothing more, and the follow-up design-review comment was right to ask that the code say so: several slots whose *combined* windows exceed the bound each stay under it individually, take the cached path, and hit the same zero-hit cliff unguarded. That regime is accepted rather than fixed — detecting it needs a live view across slots, while the cost of being wrong is only the key derivation on a miss — and the bound-sizing comment now names it so the next reader does not read the bypass as covering both.

One caveat for future callers: a hit returns the cached dict itself, not a copy. Every current caller treats the entry as read-only — it is serialised with `json.dumps` and read for ordering keys — and copying on every hit would give back the cost the cache exists to avoid. A caller that wants to mutate an entry in place would need to copy first. This is noted in the docstring.

## Tests

`test/test_message_entry_memoisation.py`, 52 cases:

1. **Equivalence** — asserted against `_build_message_entry_uncached` directly, not against a second call of the memoised function. Self-consistency would pass with a key derived from `id(m)`; comparing to the uncached computation is what catches a broken key derivation.
2. **Invalidation** — in-place mutation of content, of meta, and of variants each produce the freshly computed entry.
3. **Redaction** — the security gate. The cached value must be the redacted output, and no raw secret shape may appear anywhere in it, including inside variants and meta. An oversized (uncacheable) entry is asserted redacted too, so that path cannot become a redaction bypass.
4. **Transient roles** — the five roles that build no entry cache a legitimate `None`, distinguished by membership rather than truthiness so a `None` hit is not mistaken for a miss.
5. **Bounds** — entry count, total-byte eviction, per-entry rejection, and byte-counter accuracy.
6. **Flush-site bypass** — a window past the bound populates nothing, with a within-bound control proving the test would fail if a save never populated the cache at all.

Cache isolation lives in the shared `conftest.py` as an autouse fixture rather than in this test module, because the hazard runs the other way round: the module that pollutes the process-global cache is not the one that misreads it. A test that patches `redact_credentials` and reuses content another module already cached would otherwise be served the earlier, pre-patch entry — worst of all for a redaction test, which would go green having seen the very redacted entry it was written to prove absent. Neutering that fixture fails 7 cases, so it is load-bearing rather than decorative.

Secret shapes in the redaction test were verified against the live detector rather than assumed: AWS access key id, AWS secret key, a Bearer/JWT string and a token shape are all redacted. Plaintext `password=` and bare base64 are **not** caught by `redact_credentials`, so asserting on those would test the detector rather than this cache, and they are deliberately excluded.

**Negative controls**, each run and each confirmed to fail the intended tests:

| sabotage | result |
| ------------------------------------------- | -------------------- |
| key derived from a constant                 | 6 failed, 39 passed  |
| key derived from `id(m)`                    | 5 failed, 40 passed  |
| cache the raw input instead of the entry    | 29 failed, 16 passed |
| drop the per-entry rejection                | 1 failed             |
| drop the total-byte ceiling                 | 1 failed             |
| stop subtracting bytes on eviction          | 1 failed             |
| remove the flush-site bypass                | 1 failed             |
| re-insert adds instead of replaces          | 1 failed             |
| unsabotaged                                 | 52 passed            |

Two of those are worth naming. Caching the raw input fails the redaction test with the literal secret present in the cached value, which is exactly the failure that gate exists to catch. And the last one initially did **not** fail — the test was vacuous, because a repeated identical call returns early on the cache hit and never reaches the insert at all. The replace-not-add bookkeeping actually guards a *concurrent* double-insert (the hit-check releases the lock before the build, so two threads can both miss the same key), so the test was rewritten with a barrier that holds both threads past the hit-check. Only then did the control fire.

## Suite

The affected surface is the 26 test files that reference `chat_persistence`, run in both states: **1710 passed** with the base version of the file and the 25 pre-existing files, **1762 passed** with this change and all 26. 1710 + 52 new = 1762, so no pre-existing test changed status. `isort`, `flake8` and `mypy` (884 source files) are clean.

## Not included

One tidy-up was considered and left out. `_build_message_entry_uncached` still spells the five transient roles inline while the module defines the same five as `_TRANSIENT_ROLES`, whose comment says it mirrors this function. Reusing the frozenset would remove that duplication, but it means editing the body — and keeping the body byte-for-byte identical is the cheapest thing a reviewer can verify about this diff, since it makes the rename provably a pure move. Happy to fold it in if you would rather have it here than as a follow-up.

