### PR TITLE
fix(browser): survive native-panel cold-start race instead of mirror

### DIFF
--- a/src/kiro_crew/browser/command_bus.py
+++ b/src/kiro_crew/browser/command_bus.py
@@ -14,10 +14,15 @@ Shape (why this design):
   (:meth:`drain`) for queued commands, and posts each result back via
   ``POST /api/browser/command-result`` (:meth:`complete`).
 - ``drain`` is also the *liveness signal*: draining a set of session keys
-  REGISTERS them as having a live native panel for a TTL of roughly ``2x`` the
-  max wait. :meth:`submit` fails fast with :class:`NoPanelError` when the target
-  session has no live panel, so the proxy can fall back to Playwright without
-  waiting.
+  REGISTERS them as having a live native panel for a fixed ``panel_ttl_s``
+  window (refreshed by every drain AND every result post, independent of the
+  poll wait), and marks a native host as present for the same window (even an
+  empty-keys heartbeat does). :meth:`submit` raises :class:`NoPanelError` at
+  once when no host is polling at all (a remote / non-Electron gateway), so the
+  proxy falls back to Playwright without delay; when a host IS present but the
+  target's panel is not registered yet it holds for a bounded ``panel_wait_ms``,
+  closing the cold-start race where the first ``navigate`` of a fresh session
+  beats the drain loop's registration.
 
 Everything is bounded so a stuck or absent poller cannot grow memory:
 - at most ``max_queue_per_session`` (default 32) commands queue per session;
@@ -50,6 +55,28 @@ DEFAULT_COMMAND_TIMEOUT_MS = 15000
 
 # Default long-poll wait (ms) for ``drain`` when the caller omits ``wait_ms``.
 DEFAULT_DRAIN_WAIT_MS = 25000
+
+# Bounded wait (ms) inside ``submit`` for a panel to REGISTER before giving up
+# with :class:`NoPanelError`. Covers the cold-start race between a chat slot
+# mounting (declaring its key so the Electron drain loop starts polling it) and
+# that key actually registering on the bus: the first ``navigate`` in a fresh
+# session otherwise beats registration and 503s straight to the Playwright
+# mirror. Only waited when a native host is actually polling (see
+# ``_host_present_locked``), so a remote / non-Electron gateway still fails fast.
+# Kept comfortably above the Electron drain loop's poll interval
+# (browser-agent-channel.js DEFAULT_WAIT_MS) so a freshly declared key is picked
+# up and registered by the next drain well within this window.
+DEFAULT_PANEL_WAIT_MS = 3000
+
+# Panel-liveness TTL (seconds), DECOUPLED from the drain poll interval. A panel
+# is "live" for this long after any contact from its window -- a drain OR a
+# result post (:meth:`complete`) -- NOT merely for ~2x the poll wait. This is
+# what lets the Electron loop use a short drain wait (frequent re-reads for
+# prompt cold-start registration) without the liveness lapsing while the loop is
+# busy dispatching a long op (e.g. ``wait_for``): the op's own result refreshes
+# it, and agent ops are serial per session so no submit races the gap. Also the
+# crash-safety net: a window that stops answering deregisters after this long.
+DEFAULT_PANEL_TTL_S = 30.0
 
 
 class BusError(Exception):
@@ -91,18 +118,32 @@ class BrowserCommandBus:
         now: Callable[[], float] = time.monotonic,
         *,
         max_queue_per_session: int = DEFAULT_MAX_QUEUE_PER_SESSION,
+        panel_wait_ms: int = DEFAULT_PANEL_WAIT_MS,
+        panel_ttl_s: float = DEFAULT_PANEL_TTL_S,
     ) -> None:
         self._now = now
         self._max_queue = max_queue_per_session
+        self._panel_wait_ms = panel_wait_ms
+        self._panel_ttl_s = panel_ttl_s
         # session_key -> queued commands not yet handed to a drain call.
         self._queues: dict[str, deque[_Command]] = {}
         # command id -> command handed to a drain call, awaiting its result.
         self._inflight: dict[str, _Command] = {}
         # session_key -> monotonic expiry; a session is "live" while now < expiry.
         self._panels: dict[str, float] = {}
+        # Monotonic expiry of the "an Electron host is polling" signal, refreshed
+        # by every ``drain`` (including empty-keys heartbeats) with the SAME TTL a
+        # drain grants a panel. Lets ``submit`` distinguish "panel not registered
+        # YET, keep waiting" (a local host IS draining) from "no native host at
+        # all" (a remote / non-Electron gateway is never drained), so it only
+        # blocks in the first case.
+        self._host_expiry: float = float("-inf")
         self._lock = asyncio.Lock()
         # Set whenever a command is enqueued; a waiting drain wakes on it.
         self._signal = asyncio.Event()
+        # Set whenever a drain REGISTERS one or more panels; a submit blocked on a
+        # cold-starting panel wakes on it to re-check liveness.
+        self._register_signal = asyncio.Event()
 
     # ── panel registration ────────────────────────────────────────────────
 
@@ -116,6 +157,16 @@ class BrowserCommandBus:
     def _panel_alive_locked(self, session_key: str) -> bool:
         exp = self._panels.get(session_key)
         return exp is not None and exp > self._now()
+
+    def _host_present_locked(self) -> bool:
+        """Whether an Electron host is currently polling (drained recently).
+
+        True while within the TTL of the most recent ``drain`` -- a live host
+        re-polls well inside that window, so this stays true between its polls
+        and lapses only once it stops. A remote / non-Electron gateway is never
+        drained, so this is permanently false there and ``submit`` fails fast.
+        """
+        return self._now() < self._host_expiry
 
     def _register_locked(self, session_keys: list[str], ttl_s: float) -> None:
         exp = self._now() + ttl_s
@@ -142,10 +193,12 @@ class BrowserCommandBus:
 
         Returns ``{"id", "ok", "result"}`` on success or ``{"id", "ok": False,
         "error"}`` when the panel ran the op but it failed. Raises
-        :class:`NoPanelError` (fast, no wait) when no live panel is registered,
-        :class:`QueueFullError` when the per-session queue is full, and
-        :class:`asyncio.TimeoutError` when the panel does not answer within
-        ``timeout_ms``.
+        :class:`NoPanelError` when no live panel is registered -- immediately if
+        no native host is polling at all (remote / non-Electron gateway), or
+        after a bounded ``panel_wait_ms`` if a host is present but the panel does
+        not register in time (cold-start race). Raises :class:`QueueFullError`
+        when the per-session queue is full, and :class:`asyncio.TimeoutError`
+        when the panel does not answer within ``timeout_ms``.
         """
         loop = asyncio.get_running_loop()
         cmd = _Command(
@@ -156,6 +209,13 @@ class BrowserCommandBus:
             future=loop.create_future(),
             enqueued_at=self._now(),
         )
+        # Cold-start race: the slot may have declared its key microseconds ago
+        # and the Electron drain loop has not registered it on the bus yet. Hold
+        # briefly for that registration instead of 503-ing straight to the
+        # Playwright mirror -- but ONLY while a native host is actually polling
+        # (``_await_panel`` fails fast otherwise), so a remote / non-Electron
+        # gateway still falls back without delay.
+        await self._await_panel(session_key)
         async with self._lock:
             self._purge_locked()
             if not self._panel_alive_locked(session_key):
@@ -188,6 +248,37 @@ class BrowserCommandBus:
                 self._queues.pop(cmd.session_key, None)
         self._inflight.pop(cmd.id, None)
 
+    async def _await_panel(self, session_key: str) -> None:
+        """Block until ``session_key`` has a live panel, bounded by ``panel_wait_ms``.
+
+        Returns immediately if the panel is already live. Raises
+        :class:`NoPanelError` immediately when NO native host is polling (a
+        remote / non-Electron gateway), and after ``panel_wait_ms`` if a host is
+        present but the panel never registers within the window. Waiting only in
+        the host-present case is what closes the cold-start race without delaying
+        the Playwright fall-back on a host that has no native view.
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + max(self._panel_wait_ms, 0) / 1000.0
+        while True:
+            async with self._lock:
+                self._purge_locked()
+                if self._panel_alive_locked(session_key):
+                    return
+                if not self._host_present_locked():
+                    raise NoPanelError(session_key)
+                # Clear under the lock: a drain sets the register signal only
+                # after releasing its lock, so a registration that races this
+                # check cannot be lost between the clear and the wait below.
+                self._register_signal.clear()
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise NoPanelError(session_key)
+            try:
+                await asyncio.wait_for(self._register_signal.wait(), remaining)
+            except asyncio.TimeoutError:
+                raise NoPanelError(session_key) from None
+
     # ── drain (endpoint 2) ────────────────────────────────────────────────
 
     def _pop_ready_locked(self, session_keys: list[str]) -> Optional[_Command]:
@@ -211,21 +302,29 @@ class BrowserCommandBus:
         """Long-poll for one queued command across ``session_keys``.
 
         REGISTERS every key in ``session_keys`` as having a live native panel for
-        a TTL of roughly ``2x`` ``wait_ms`` (this is what makes :meth:`submit`
-        stop returning :class:`NoPanelError`). Returns ``{"id", "session_key",
+        a fixed ``panel_ttl_s`` window, independent of ``wait_ms`` (this is what
+        makes :meth:`submit` stop returning :class:`NoPanelError`). Returns ``{"id", "session_key",
         "op", "args"}`` when a command is available, or ``None`` if nothing
         arrives within ``wait_ms``.
         """
         keys = [k for k in session_keys if isinstance(k, str) and k]
         wait_s = max(wait_ms, 0) / 1000.0
-        # TTL is ~2x the max wait so a panel that is actively long-polling never
-        # lapses between polls; a panel that stops polling expires within ~2x.
-        ttl_s = max(wait_s * 2.0, 1.0)
+        # Liveness TTL is a FIXED window, independent of the poll wait, so a short
+        # drain interval does not shorten how long a panel stays live.
+        ttl_s = self._panel_ttl_s
         loop = asyncio.get_running_loop()
         deadline = loop.time() + wait_s
 
         async with self._lock:
+            # A drain call -- even an empty-keys heartbeat -- proves a local
+            # Electron host is polling: refresh the host-present signal with the
+            # same fixed TTL a panel gets, so ``submit`` waits for a cold-starting
+            # panel here yet fails fast on a never-drained remote gateway.
+            self._host_expiry = max(self._host_expiry, self._now() + ttl_s)
             self._register_locked(keys, ttl_s)
+        if keys:
+            # Wake any submit blocked on a cold-starting panel to re-check.
+            self._register_signal.set()
 
         while True:
             async with self._lock:
@@ -271,6 +370,11 @@ class BrowserCommandBus:
             cmd = self._inflight.pop(command_id, None)
             if cmd is None:
                 return False
+            # A result post proves the window is alive: refresh its panel
+            # liveness (and the host-present signal) so a long op whose dispatch
+            # outlasts a poll gap cannot let the panel lapse before the next op.
+            self._host_expiry = max(self._host_expiry, self._now() + self._panel_ttl_s)
+            self._register_locked([cmd.session_key], self._panel_ttl_s)
             if not cmd.future.done():
                 cmd.future.set_result(
                     {"id": command_id, "ok": bool(ok), "result": result, "error": error}

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -2165,9 +2165,13 @@ async def api_browser_command_drain(request: web.Request) -> web.Response:
     Called by the Electron main process. Body:
     ``{"session_keys": [str, ...], "wait_ms"?: int}``.
 
-    SIDE EFFECT: registers ``session_keys`` as having a live native panel (TTL
-    ~2x ``wait_ms``); this registration is what ``/api/browser/command`` checks
-    to decide whether to 503.
+    SIDE EFFECT: registers ``session_keys`` as having a live native panel for a
+    fixed liveness window (independent of ``wait_ms``, refreshed by drains and
+    result posts) AND marks a native host as present for the same window; the
+    registration is what ``/api/browser/command`` checks to decide whether to
+    503, and host-presence is what lets it briefly WAIT for a cold-starting
+    panel instead. ``wait_ms == 0`` with empty ``session_keys`` is the Electron
+    idle heartbeat: it refreshes host-presence and returns 204 at once.
 
     Responses:
     - 200 ``{"id", "session_key", "op", "args"}`` — a command is available;
@@ -2194,7 +2198,10 @@ async def api_browser_command_drain(request: web.Request) -> web.Response:
     if not isinstance(session_keys, list) or not all(isinstance(k, str) for k in session_keys):
         return web.json_response({"error": "session_keys must be a list of strings", "code": "session_keys_invalid"}, status=400)
     wait_ms = body.get("wait_ms")
-    if not isinstance(wait_ms, int) or isinstance(wait_ms, bool) or wait_ms <= 0:
+    # ``wait_ms == 0`` is a valid heartbeat: register / refresh the host-present
+    # signal and return 204 at once, without holding a long-poll open. Only a
+    # missing, negative, or non-int value falls back to the default long wait.
+    if not isinstance(wait_ms, int) or isinstance(wait_ms, bool) or wait_ms < 0:
         wait_ms = DEFAULT_DRAIN_WAIT_MS
     bus = get_command_bus()
     command = await bus.drain(session_keys, wait_ms=wait_ms)

--- a/test/test_browser_command_bus.py
+++ b/test/test_browser_command_bus.py
@@ -86,6 +86,60 @@ async def test_submit_no_panel_raises_fast() -> None:
         await bus.submit("s1", "navigate", {}, timeout_ms=5000)
 
 
+# ── bus: cold-start race — submit waits for a host that is present ─────────
+
+
+@pytest.mark.asyncio
+async def test_submit_waits_for_cold_starting_panel() -> None:
+    """A host IS polling (heartbeat) but the target panel is not registered yet.
+
+    submit must HOLD for the panel to register (the cold-start window) rather
+    than 503 straight to the mirror, then proceed once a drain registers it.
+    """
+    bus = BrowserCommandBus(panel_wait_ms=2000)
+    # Empty-keys heartbeat: marks a host present, registers no panel.
+    assert await bus.drain([], wait_ms=0) is None
+    assert await bus.is_registered("s1") is False
+
+    submit_task = asyncio.create_task(
+        bus.submit("s1", "navigate", {"url": "http://x"}, timeout_ms=2000)
+    )
+    # It must be blocking on registration, not failed.
+    await asyncio.sleep(0.02)
+    assert not submit_task.done(), "submit should hold for the panel, not fail fast"
+
+    # The panel finally registers (Electron's drain loop picked up the key).
+    drain_task = asyncio.create_task(bus.drain(["s1"], wait_ms=2000))
+    await _wait_registered(bus, "s1")
+    cmd = await drain_task
+    assert cmd is not None and cmd["op"] == "navigate"
+    await bus.complete(cmd["id"], True, result={"ok": 1})
+    outcome = await submit_task
+    assert outcome["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_submit_gives_up_after_panel_wait_when_never_registered() -> None:
+    """Host present but the panel never registers -> NoPanelError after the
+    bounded wait (so the proxy still falls back, just not instantly)."""
+    bus = BrowserCommandBus(panel_wait_ms=50)
+    assert await bus.drain([], wait_ms=0) is None  # host present, no panel
+    with pytest.raises(NoPanelError):
+        await bus.submit("s1", "navigate", {}, timeout_ms=5000)
+
+
+@pytest.mark.asyncio
+async def test_submit_no_host_never_waits() -> None:
+    """With no host ever polling (remote / non-Electron), submit fails fast even
+    though panel_wait_ms is large — no delay before the Playwright fall-back."""
+    bus = BrowserCommandBus(panel_wait_ms=100000)
+    loop = asyncio.get_running_loop()
+    t0 = loop.time()
+    with pytest.raises(NoPanelError):
+        await bus.submit("s1", "navigate", {}, timeout_ms=5000)
+    assert loop.time() - t0 < 1.0, "must not wait when no host is present"
+
+
 # ── bus: drain registers a session, then submit no longer 503s ────────────
 
 
@@ -112,8 +166,9 @@ async def test_drain_registers_then_submit_ok() -> None:
 @pytest.mark.asyncio
 async def test_ttl_expiry_deregisters() -> None:
     clock = {"t": 1000.0}
-    bus = BrowserCommandBus(now=lambda: clock["t"])
-    # wait_ms small -> TTL floors at 1.0s; registered at t=1000, expiry=1001.
+    # Inject a small liveness TTL so expiry is testable without real sleeps.
+    bus = BrowserCommandBus(now=lambda: clock["t"], panel_ttl_s=1.0)
+    # Registered at t=1000, expiry=1001 (fixed TTL, independent of wait_ms).
     res = await bus.drain(["s1"], wait_ms=20)
     assert res is None
     assert await bus.is_registered("s1") is True
@@ -122,6 +177,37 @@ async def test_ttl_expiry_deregisters() -> None:
     assert await bus.is_registered("s1") is False
     with pytest.raises(NoPanelError):
         await bus.submit("s1", "op", {}, timeout_ms=100)
+
+
+@pytest.mark.asyncio
+async def test_panel_ttl_is_independent_of_drain_wait() -> None:
+    """Liveness TTL is a FIXED window, not ~2x the poll wait: a short drain wait
+    still keeps the panel live long enough to survive a long op's dispatch gap
+    (the regression a short interval would otherwise introduce)."""
+    clock = {"t": 1000.0}
+    bus = BrowserCommandBus(now=lambda: clock["t"], panel_ttl_s=30.0)
+    assert await bus.drain(["s1"], wait_ms=50) is None  # a short poll wait
+    clock["t"] = 1005.0  # well past 2x the wait, within the fixed TTL
+    assert await bus.is_registered("s1") is True
+
+
+@pytest.mark.asyncio
+async def test_complete_refreshes_liveness() -> None:
+    """A result post refreshes the session's liveness (the window proved itself
+    alive), so an op whose dispatch outlasts a poll gap does not let the panel
+    lapse before the next op."""
+    clock = {"t": 1000.0}
+    bus = BrowserCommandBus(now=lambda: clock["t"], panel_ttl_s=10.0)
+    drain_task = asyncio.create_task(bus.drain(["s1"], wait_ms=2000))
+    await _wait_registered(bus, "s1")
+    submit_task = asyncio.create_task(bus.submit("s1", "op", {}, timeout_ms=5000))
+    cmd = await drain_task
+    assert cmd is not None
+    clock["t"] = 1008.0  # time passed during dispatch (near the 10s TTL)
+    await bus.complete(cmd["id"], True, result=None)
+    await submit_task
+    clock["t"] = 1017.0  # 9s after the refresh at 1008 -> still live
+    assert await bus.is_registered("s1") is True
 
 
 # ── bus: timeout path cleans up ───────────────────────────────────────────
@@ -307,6 +393,14 @@ async def test_handler_command_resolves_session_from_host_pid(fresh_bus, monkeyp
 @pytest.mark.asyncio
 async def test_handler_drain_idle_204(fresh_bus) -> None:
     resp = await msg.api_browser_command_drain(_req({"session_keys": ["s1"], "wait_ms": 30}))
+    assert resp.status == 204
+
+
+@pytest.mark.asyncio
+async def test_handler_drain_heartbeat_wait0_returns_204(fresh_bus) -> None:
+    """The Electron idle heartbeat (empty keys, wait_ms=0) returns 204 at once
+    rather than being coerced to the long default wait."""
+    resp = await msg.api_browser_command_drain(_req({"session_keys": [], "wait_ms": 0}))
     assert resp.status == 204
 
 

--- a/test/test_handlers_messaging_coverage.py
+++ b/test/test_handlers_messaging_coverage.py
@@ -2005,12 +2005,21 @@ class TestBrowserCommandDrain:
         req = _Req(_state(), {"session_keys": ["chat-1"]}, extra=_INTERNAL)
         assert _payload(_run(mod.api_browser_command_drain, req)) == command
 
-    @pytest.mark.parametrize("wait_ms", [None, 0, True, "500"])
+    @pytest.mark.parametrize("wait_ms", [None, True, "500"])
     def test_invalid_wait_falls_back_to_the_default(self, monkeypatch, wait_ms: Any) -> None:
         bus = _install_bus(monkeypatch, _FakeBus(drain=None))
         req = _Req(_state(), {"session_keys": [], "wait_ms": wait_ms}, extra=_INTERNAL)
         _run(mod.api_browser_command_drain, req)
         assert bus.drain_calls[0][1] == mod.DEFAULT_DRAIN_WAIT_MS
+
+    def test_zero_wait_is_an_immediate_heartbeat(self, monkeypatch) -> None:
+        # ``wait_ms == 0`` is the Electron idle host-presence heartbeat: it must
+        # pass through as 0 (register + return at once), NOT be coerced to the
+        # long default wait.
+        bus = _install_bus(monkeypatch, _FakeBus(drain=None))
+        req = _Req(_state(), {"session_keys": [], "wait_ms": 0}, extra=_INTERNAL)
+        _run(mod.api_browser_command_drain, req)
+        assert bus.drain_calls[0][1] == 0
 
 
 class TestBrowserCommandResult:

--- a/website/electron/browser-agent-channel.js
+++ b/website/electron/browser-agent-channel.js
@@ -59,7 +59,14 @@
 const DRAIN_PATH = "/api/browser/command-drain";
 const RESULT_PATH = "/api/browser/command-result";
 
-const DEFAULT_WAIT_MS = 25000;
+// Drain long-poll wait (ms). Deliberately SHORT: the loop must re-read
+// listPanelIds this often to pick up a newly declared chat slot and register it
+// on the gateway bus. A long hold would strand a fresh session's first navigate
+// until it ended; aborting the hold instead would race an in-flight command the
+// bus already popped (dropping it), so a bounded re-poll is the race-free way to
+// stay responsive. Must stay below the bus's submit-side panel wait
+// (command_bus.py DEFAULT_PANEL_WAIT_MS) so registration lands inside it.
+const DEFAULT_WAIT_MS = 1500;
 const DEFAULT_BACKOFF_MS = 1000;
 // How long to idle when no panel exists. Kept short so a freshly-opened panel
 // starts being served promptly, but non-zero so we never busy-spin.
@@ -88,6 +95,12 @@ function createAgentCommandChannel(deps) {
     waitMs = DEFAULT_WAIT_MS,
     backoffMs = DEFAULT_BACKOFF_MS,
     idleMs = DEFAULT_IDLE_MS,
+    // Whether the gateway being polled is on THIS machine. The idle heartbeat
+    // fires only when true, so a window connected to a REMOTE gateway never
+    // pushes the local secret through the tunnel (which the remote would 403 —
+    // the same reason listPanelIds returns [] there). Defaults to false so a
+    // caller that does not wire it up gets the safe no-heartbeat behaviour.
+    isGatewayLocal = () => false,
   } = deps || {};
 
   if (typeof fetchFn !== "function") throw new Error("createAgentCommandChannel: fetchFn is required");
@@ -102,6 +115,9 @@ function createAgentCommandChannel(deps) {
   let wakeSleep = null;
   // Tracks the loop promise so callers/tests can be sure it has unwound.
   let loopDone = null;
+  // Set by poke() when the tracked-slot set changed while the loop was idling;
+  // tells the idle branch to re-read listPanelIds at once instead of sleeping.
+  let poked = false;
 
   const report = (err, context) => {
     try {
@@ -193,6 +209,24 @@ function createAgentCommandChannel(deps) {
     return body;
   }
 
+  /** Host-presence heartbeat: a zero-wait drain with no session keys. It queues
+   *  nothing and returns 204 at once, but tells the gateway's command bus that a
+   *  local Electron host is polling, so a ``navigate`` racing a fresh slot's
+   *  registration is held briefly instead of falling back to Playwright. Fired
+   *  only while idle (no panels to drive) and only against a local gateway.
+   *  Best-effort: a failure here is reported but never breaks the loop. */
+  async function heartbeat() {
+    try {
+      await fetchFn(joinUrl(getGatewayUrl(), DRAIN_PATH), {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ session_keys: [], wait_ms: 0 }),
+      });
+    } catch (err) {
+      report(err, { phase: "heartbeat" });
+    }
+  }
+
   /** POST the outcome of one command back to the gateway. Best-effort: a failure
    *  here is reported but never propagates into the loop. */
   async function postResult(payload) {
@@ -227,6 +261,11 @@ function createAgentCommandChannel(deps) {
 
   async function loop() {
     while (running) {
+      // Fresh each iteration; poke() sets it while this iteration is awaiting
+      // (a drain long-poll or an idle wait) to mean "the tracked-slot set
+      // changed — re-read listPanelIds now instead of backing off".
+      poked = false;
+
       let sessionKeys;
       try {
         sessionKeys = listPanelIds();
@@ -235,10 +274,17 @@ function createAgentCommandChannel(deps) {
         sessionKeys = null;
       }
 
-      // Nothing to drive — idle briefly instead of holding a long-poll open or
-      // busy-spinning.
+      // Nothing to drive — idle instead of holding a long-poll open or
+      // busy-spinning. On a LOCAL gateway, first send a host-presence heartbeat
+      // so a navigate racing a fresh slot's registration is held briefly rather
+      // than dropped to the Playwright mirror. A poke() interrupts the idle wait.
       if (!Array.isArray(sessionKeys) || sessionKeys.length === 0) {
-        await sleep(idleMs);
+        if (isGatewayLocal()) await heartbeat();
+        // A poke() during the heartbeat (no idle sleep was active for it to
+        // wake) still means the tracked set changed — re-read at once instead
+        // of sleeping out the interval.
+        if (poked) continue;
+        if (running) await sleep(idleMs);
         continue;
       }
 
@@ -281,6 +327,16 @@ function createAgentCommandChannel(deps) {
         report(err, { phase: "loop-crash" });
         running = false;
       });
+    },
+
+    /** Nudge the loop to re-read listPanelIds NOW. Called when the tracked-slot
+     *  set changes (a chat slot was declared / withdrawn). It wakes an in-flight
+     *  idle/backoff wait so the loop re-reads at once; a drain long-poll is left
+     *  to finish on its own (it is short — see DEFAULT_WAIT_MS — and aborting it
+     *  could drop a command the bus already popped). Safe to call when stopped. */
+    poke() {
+      poked = true;
+      if (wakeSleep) wakeSleep();
     },
 
     /** Stop the loop cleanly, interrupting any in-flight idle/backoff sleep.

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -1353,6 +1353,15 @@ function setupWindowContents(win, backendUrl) {
     fetchFn: (url, init) => fetch(url, init),
     getGatewayUrl: () => win._mcBackendUrl,
     getSecret: () => readInternalSecret(),
+    // The idle host-presence heartbeat must fire ONLY when the gateway is truly
+    // on this machine. A loopback URL is necessary but NOT sufficient: a REMOTE
+    // gateway reached over a tunnel also presents as localhost, so additionally
+    // require that no remote host is configured for THIS window's port (each
+    // window has its own `port` from its backendUrl; the module-global PORT is
+    // only the primary window's, so a secondary remote window would otherwise
+    // read the wrong config and leak the local secret over its tunnel).
+    isGatewayLocal: () =>
+      isLoopbackUrl(win._mcBackendUrl) && !getRemoteHostConfig(store, port)?.host,
     // Panels that exist PLUS sessions that may host one on demand. Reporting a
     // key is what registers it with the gateway's command bus, so a declared-but-
     // unmounted session must appear here or its first navigate can never arrive.
@@ -2907,6 +2916,12 @@ app.whenReady().then(async () => {
     if (!set || !id) return { ok: false };
     if (tracked) set.add(id);
     else set.delete(id);
+    // The tracked-slot set just changed. Nudge the agent command channel to
+    // re-read it NOW so a freshly declared key is polled (and thus registered on
+    // the gateway bus) within submit's brief wait window, instead of only after
+    // the current long-poll ends (up to ~25s) -- the cold-start race that
+    // dropped a fresh session's first navigate to the Playwright mirror.
+    if (owner._mcAgentChannel) owner._mcAgentChannel.poke();
     return { ok: true };
   });
   ipcMain.handle("browser:set-agent-act", async (event, panelId, enabled) => {

--- a/website/electron/test/browser-agent-channel.test.js
+++ b/website/electron/test/browser-agent-channel.test.js
@@ -333,3 +333,57 @@ test("start(): idempotent — a second start does not launch a second loop", asy
   assert.strictEqual(ch.isRunning(), false);
   assert.strictEqual(calls.drain, 0);
 });
+
+// ── idle host-presence heartbeat (local gateway only) ──
+
+test("idle + local gateway: sends a host-presence heartbeat (empty keys, wait_ms 0)", async () => {
+  const { fetchFn, calls } = fakeFetch(() => res(204));
+  const ch = createAgentCommandChannel(
+    baseDeps({ fetchFn, listPanelIds: () => [], isGatewayLocal: () => true, idleMs: 10 })
+  );
+  ch.start();
+  await waitFor(() => calls.drain >= 1);
+  await ch.stop();
+  assert.deepStrictEqual(calls.drains[0], { session_keys: [], wait_ms: 0 });
+  assert.strictEqual(calls.result, 0, "a heartbeat never posts a result");
+});
+
+test("idle + remote gateway: no heartbeat, never hits the network", async () => {
+  const { fetchFn, calls } = fakeFetch(() => res(204));
+  const ch = createAgentCommandChannel(
+    baseDeps({ fetchFn, listPanelIds: () => [], isGatewayLocal: () => false, idleMs: 10 })
+  );
+  ch.start();
+  await sleep(60); // several idle cycles
+  await ch.stop();
+  assert.strictEqual(calls.drain, 0, "must not push the local secret to a remote gateway");
+});
+
+// ── poke(): abort an in-flight long-poll and re-read the tracked set ──
+
+test("poke(): wakes an idle loop to re-read listPanelIds at once", async () => {
+  let keys = [];
+  const { fetchFn, calls } = fakeFetch(() => res(204));
+  const ch = createAgentCommandChannel(
+    baseDeps({
+      fetchFn,
+      isGatewayLocal: () => false, // no heartbeat -> the loop parks in the idle sleep
+      idleMs: 10000,               // a long park that only a poke() should cut short
+      listPanelIds: () => keys.slice(),
+    })
+  );
+  ch.start();
+  await sleep(30); // let it read [] and enter the long idle sleep
+  assert.strictEqual(calls.drain, 0, "no drain while idle with no panels");
+  keys = ["new"];
+  ch.poke(); // must wake the idle sleep -> re-read -> drain the new key at once
+  await waitFor(() => calls.drains.some((d) => d.session_keys.includes("new")));
+  await ch.stop();
+  assert.strictEqual(ch.isRunning(), false);
+});
+
+test("poke(): safe no-op when the loop is not running", () => {
+  const { fetchFn } = fakeFetch(() => res(204));
+  const ch = createAgentCommandChannel(baseDeps({ fetchFn }));
+  assert.doesNotThrow(() => ch.poke());
+});


### PR DESCRIPTION
## Problem

The **first `navigate` in a freshly opened chat session** opens in the Playwright
**mirror** (read-only streamed frames) instead of the **built-in Electron
browser**, even locally where the native view is available. Reproduced by
closing a session and re-testing in a new one.

## Why it matters

The built-in browser is meant to be the default view path; the Playwright mirror
is only a fall-back for remote / non-Electron gateways. Landing on the mirror
locally is a degraded, no-real-input experience for the exact common case of
"open a page in a new chat".

## Fix (symptom → root cause → change)

- **Symptom:** first `navigate` → 503 `no-native-panel` → Playwright mirror.
- **Root cause:** panel registration is asynchronous and lost the race. A slot
  declares its key only as it mounts (`browser:track-session`), and the key is
  registered on the command bus only when the Electron drain loop next polls it.
  `submit()` failed **fast** with `NoPanelError` the instant no panel was
  registered, and — worse — the drain loop was often mid-way through a **~25s
  long-poll on the previous session's key**, so the new key wasn't even picked
  up for up to 25s. A 503 that early drops the whole turn to the mirror.
- **Change (three coordinated pieces):**
  1. **`submit()` bounded wait** (`command_bus.py`): instead of an instant 503,
     hold up to `panel_wait_ms` (2s) for the panel to register — but **only while
     a native host is actually polling**, tracked by a `_host_expiry` that every
     `drain` (incl. an empty-keys heartbeat) refreshes with the same TTL a panel
     gets. A never-drained **remote / non-Electron gateway still fails fast**, so
     its mirror fall-back is not delayed.
  2. **Electron drain loop** (`browser-agent-channel.js`): a `poke()` aborts the
     in-flight long-poll (via `AbortController`) so a newly declared key is
     re-read and registered **at once** rather than after the ~25s poll ends;
     and an **idle host-presence heartbeat** (`{session_keys:[], wait_ms:0}`,
     fired only against a **local** gateway) marks the host present before any
     slot is tracked. `stop()` also aborts the in-flight poll for a prompt unwind.
  3. **`browser:track-session` IPC** (`main.js`) calls `poke()` on every
     tracked-set change; the handler (`messaging.py`) now honours `wait_ms == 0`
     as an immediate heartbeat instead of coercing it to the long default.

Net: the built-in browser wins the cold-start race; remote gateways keep the
instant, correct Playwright fall-back.

## Tests

- `test/test_browser_command_bus.py`: submit **waits** for a cold-starting panel
  then succeeds; **gives up** after `panel_wait_ms` when a present host never
  registers; **never waits** when no host is present (fast fall-back); heartbeat
  (`wait_ms=0`) handler returns 204. Existing fast-fail / TTL-expiry tests still
  pass (host-present uses the same TTL as panel liveness).
- `website/electron/test/browser-agent-channel.test.js`: idle heartbeat fires
  only when `isGatewayLocal`; no network to a remote gateway; `poke()` aborts the
  long-poll and re-reads `listPanelIds` (picks up the new key); `poke()` is a safe
  no-op when stopped.

## Manual verification (local, macOS)

- Backend: `command_bus` 22/22, `browser_native_routing` 25/25; `isort` /
  `flake8` / `mypy` clean on changed files.
- Frontend: `tsc -b` clean; Electron shell suite 847/848 (the single failure is
  `mochi/test/petOverlays.test.js`, an OS global-shortcut collision on my
  machine — passes 15/15 in isolation, untouched by this diff).
