### PR TITLE
fix(dashboard): validate and bound slot-detail query params

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -769,8 +769,14 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
     """GET /api/chat/slots/{slot} — message history for a slot.
 
     Query params:
-      - ``limit``: max messages to return (optional; if omitted, returns ALL messages from disk)
-      - ``before``: return messages before this index (legacy pagination, still supported)
+      - ``limit``: max messages to return (optional; if omitted, returns ALL messages from disk).
+        Clamped to 1..500. A value below 1 is rejected rather than clamped up, because
+        no caller asking for 0 wanted exactly one message.
+      - ``before``: return messages before this index (legacy pagination, still supported).
+        ``before=0`` is valid and yields an empty page.
+
+    Either param being a non-integer is a 400; both used to raise out of the
+    handler and surface as a 500.
 
     By default (no limit), reads the full chained history from disk across
     gateway restarts. Pagination params are retained for backwards compatibility.
@@ -782,23 +788,46 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
         return web.json_response({"error": "not found"}, status=404)
 
     limit_raw = request.query.get("limit")
-    before = request.query.get("before")
+    before_raw = request.query.get("before")
+
+    # Both params arrive as strings and were converted at their point of use, so a
+    # non-integer escaped as a ValueError and the client saw a 500 for what is
+    # plainly a bad request. The branch below still keys off the RAW values, so
+    # routing is unchanged.
+    try:
+        limit = min(int(limit_raw or "200"), 500)
+        before = int(before_raw) if before_raw is not None else None
+    except ValueError:
+        return web.json_response(
+            {"error": "limit and before must be integers", "code": "invalid_query_params"},
+            status=400,
+        )
+    # Clamped above but not below, limit=0 made `start == end`: an empty page
+    # reporting has_more true, which paginates forever.
+    if limit < 1:
+        return web.json_response(
+            {"error": "limit must be >= 1", "code": "limit_out_of_range"}, status=400
+        )
 
     # No limit → load ALL messages (chained across gateway restarts).
     # In-memory slot.messages is authoritative for the current session.
     # _disk_older_count gates whether to read disk AND provides the stable
     # slice boundary (set at restore/resume, never drifts with new messages).
-    if limit_raw is None and before is None:
+    if limit_raw is None and before_raw is None:
         mem_msgs = list(slot.messages)
         if slot._disk_older_count > 0 and state.conversation_log:
             history_key = slot_history_key(slot)
             try:
-                disk_msgs = state.conversation_log.read_messages_chained(history_key)
+                disk_msgs = await asyncio.to_thread(
+                    state.conversation_log.read_messages_chained, history_key
+                )
             except Exception:
                 logger.warning("read_messages_chained failed for %s", history_key, exc_info=True)
                 disk_msgs = []
             older = disk_msgs[: slot._disk_older_count] if disk_msgs else []
-            messages = older + mem_msgs
+            # Re-read the tail after the await: that suspension point lets a message
+            # land mid-read, and the client replaces its list with this response.
+            messages = older + list(slot.messages)
         else:
             messages = mem_msgs
         total = len(messages)
@@ -806,11 +835,12 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
     else:
         # Legacy pagination path (retained for programmatic callers).
         # Always reads from chained disk history; no in-memory offset math.
-        limit = min(int(limit_raw or "200"), 500)
         history_key = slot_history_key(slot)
         try:
             all_msgs = (
-                state.conversation_log.read_messages_chained(history_key)
+                await asyncio.to_thread(
+                    state.conversation_log.read_messages_chained, history_key
+                )
                 if state.conversation_log
                 else []
             )
@@ -828,7 +858,7 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
             all_msgs = list(all_msgs) + list(slot.messages[-unflushed:])
         total = len(all_msgs)
         if before is not None:
-            end = max(0, min(int(before), total))
+            end = max(0, min(before, total))
         else:
             end = total
         start = max(0, end - limit)

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import re
+import threading
 import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -973,6 +974,175 @@ class TestSlotDetailPagination:
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.get("/api/chat/slots/nonexistent")
             assert resp.status == 404
+
+    async def _slot_with_history(self, tmp_path, monkeypatch, name, count=10):
+        """A slot with *count* messages on disk and in memory."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot(name)
+        for i in range(count):
+            state.conversation_log.append(f"dashboard:{name}", "user", f"msg {i}")
+            slot.append("user", f"msg {i}")
+        slot.drain()
+        return state
+
+    @pytest.mark.asyncio
+    async def test_non_integer_limit_is_a_bad_request(self, tmp_path, monkeypatch):
+        """A junk limit is the client's mistake, so it must not surface as a 500."""
+        state = await self._slot_with_history(tmp_path, monkeypatch, "badlimit")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/badlimit?limit=abc")
+            assert resp.status == 400
+            body = await resp.json()
+            assert "limit" in body["error"]
+            assert body["code"] == "invalid_query_params"
+
+    @pytest.mark.asyncio
+    async def test_non_integer_before_is_a_bad_request(self, tmp_path, monkeypatch):
+        state = await self._slot_with_history(tmp_path, monkeypatch, "badbefore")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/badbefore?before=xyz")
+            assert resp.status == 400
+            body = await resp.json()
+            assert "before" in body["error"]
+            assert body["code"] == "invalid_query_params"
+
+    @pytest.mark.asyncio
+    async def test_limit_below_one_is_rejected_not_clamped_up(self, tmp_path, monkeypatch):
+        """limit=0 used to return an empty page reporting has_more true — forever."""
+        state = await self._slot_with_history(tmp_path, monkeypatch, "zerolimit")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            for bad in ("0", "-1", "-5"):
+                resp = await client.get(f"/api/chat/slots/zerolimit?limit={bad}")
+                assert resp.status == 400, f"limit={bad} should be rejected"
+                body = await resp.json()
+                assert "messages" not in body
+                assert body["code"] == "limit_out_of_range"
+
+    @pytest.mark.asyncio
+    async def test_before_zero_remains_valid(self, tmp_path, monkeypatch):
+        """A real caller sends before=0 on first page, so it must not be rejected."""
+        state = await self._slot_with_history(tmp_path, monkeypatch, "beforezero")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/beforezero?limit=5&before=0")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["messages"] == []
+            assert data["has_more"] is False
+
+    @pytest.mark.asyncio
+    async def test_bounded_request_still_returns_the_same_page(self, tmp_path, monkeypatch):
+        """Regression guard: threading the disk read must not alter the result."""
+        state = await self._slot_with_history(tmp_path, monkeypatch, "bounded", count=30)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/bounded?limit=10")
+            data = await resp.json()
+            assert data["total"] == 30
+            assert len(data["messages"]) == 10
+            assert data["messages"][0]["content"] == "msg 20"
+            assert data["messages"][-1]["content"] == "msg 29"
+            assert data["has_more"] is True
+
+    @pytest.mark.asyncio
+    async def test_cursor_branch_reads_disk_off_the_loop_thread(self, tmp_path, monkeypatch):
+        """The read must not run on the loop thread that serves every other request.
+
+        Asserts only that the call executed on a different thread. It does not
+        measure loop latency, so it cannot prove the loop was never blocked for
+        some other reason — but it does fail if the ``to_thread`` hop is removed.
+        """
+        state = await self._slot_with_history(tmp_path, monkeypatch, "offloop")
+        log = state.conversation_log
+        real = log.read_messages_chained
+        seen: list[int] = []
+
+        def recording(key):
+            seen.append(threading.get_ident())
+            return real(key)
+
+        monkeypatch.setattr(log, "read_messages_chained", recording)
+        loop_thread = threading.get_ident()
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/offloop?limit=5")
+            assert resp.status == 200
+        assert seen, "read_messages_chained was never called"
+        assert loop_thread not in seen
+
+    @pytest.mark.asyncio
+    async def test_unlimited_branch_returns_whole_history_off_the_loop_thread(
+        self, tmp_path, monkeypatch
+    ):
+        """The no-limit branch reassembles disk+memory and still claims has_more false."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("whole")
+        log = state.conversation_log
+        for i in range(10):
+            log.append("dashboard:whole", "user", f"msg {i}")
+        for i in range(6, 10):
+            slot.append("user", f"msg {i}")
+        slot.drain()
+        slot._disk_older_count = 6
+
+        real = log.read_messages_chained
+        seen: list[int] = []
+
+        def recording(key):
+            seen.append(threading.get_ident())
+            return real(key)
+
+        monkeypatch.setattr(log, "read_messages_chained", recording)
+        loop_thread = threading.get_ident()
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/whole")
+            assert resp.status == 200
+            data = await resp.json()
+        assert [m["content"] for m in data["messages"]] == [f"msg {i}" for i in range(10)]
+        assert data["total"] == 10
+        assert data["has_more"] is False
+        assert seen, "read_messages_chained was never called"
+        assert loop_thread not in seen
+
+    @pytest.mark.asyncio
+    async def test_message_arriving_during_the_disk_read_is_not_dropped(
+        self, tmp_path, monkeypatch
+    ):
+        """The awaited read is a suspension point, so the tail is re-read after it.
+
+        The client replaces its message list with this response, so a message that
+        lands mid-read must not be silently absent. Appending from inside the
+        patched read reproduces exactly that window deterministically.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("midread")
+        log = state.conversation_log
+        for i in range(10):
+            log.append("dashboard:midread", "user", f"msg {i}")
+        for i in range(6, 10):
+            slot.append("user", f"msg {i}")
+        slot.drain()
+        slot._disk_older_count = 6
+
+        real = log.read_messages_chained
+
+        def appends_while_reading(key):
+            result = real(key)
+            slot.append("assistant", "arrived mid-read")
+            slot.drain()
+            return result
+
+        monkeypatch.setattr(log, "read_messages_chained", appends_while_reading)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/midread")
+            assert resp.status == 200
+            data = await resp.json()
+        contents = [m["content"] for m in data["messages"]]
+        assert "arrived mid-read" in contents, "message that landed during the await was dropped"
+        assert contents == [f"msg {i}" for i in range(10)] + ["arrived mid-read"]
 
 
 # ── History persistence and disk fallback ──


### PR DESCRIPTION
Three small, independent hygiene fixes to `api_chat_slot_detail` in `src/kiro_crew/dashboard/chat_handlers.py`. **This does not change which messages the endpoint returns, and does not touch `has_more` or `total` semantics on any branch** — it is query-parameter hygiene plus moving two disk reads off the event loop. That framing should make it reviewable in one pass.

## 1. A non-integer `limit` or `before` returned 500, now returns 400

Both params were read as raw strings and converted at their point of use, so `?limit=abc` or `?before=xyz` raised `ValueError` out of the handler and the client saw a 500 for what is plainly a malformed request. Both are now parsed up front inside a `try`, and a `ValueError` returns a 400.

Verified against the unmodified base before fixing: both produced `500` with `ValueError: invalid literal for int() with base 10: 'abc'` / `'xyz'` in the server log.

## 2. `limit` had no lower bound, so `limit=0` returned an empty page claiming more existed

The clamp was upper-bound only. Tracing `limit=0` through the cursor branch, `start = max(0, end - limit)` becomes `start = end`, so the slice is empty while `has_more = start > 0` is true whenever `end > 0`. A client paging on `has_more` would get an empty page and a promise of more, forever. `limit=-5` behaves the same way.

**I chose to reject `limit < 1` with a 400 rather than clamp it up to 1**, folding it into the same validation block as fix 1. Reasons, in order of weight:

- **An in-repo caller decides it.** `website/src/api/client.ts` builds the query with `if (limit) p.set('limit', String(limit))` — a *falsy* guard. `limit=0` is therefore never put on the wire by any frontend caller; the param is omitted entirely and the request routes to the unlimited branch. So the "an existing caller passing 0 would suddenly get a 400" objection has no in-repo blast radius. Every in-repo caller that does pass a limit passes a positive one (`100` from the store's older-history fetch, `THREAD_VIEW_MESSAGES * 3` from the scene-interaction hook, `50` in an API client test).
- **The upper clamp and a lower clamp are not symmetric.** Clamping a request for 10,000 down to 500 *preserves* the caller's intent — they asked for as much as possible and got as much as the server will give. Clamping 0 or -5 up to 1 *invents* an intent: nobody asking for zero messages wanted exactly one. A 400 is the truthful answer.
- Rejecting keeps one validation block, one error path, and one line of docstring rather than two different behaviours for two kinds of bad input.

Note that `before=0` **is** reachable from a real caller (the store passes its oldest-index state, which initialises to 0) and remains valid — only non-integers are rejected there. There is a test pinning that specifically, because it would be an easy thing to break while tightening `limit`.

## 3. Two full chained-history disk reads ran on the event loop

`api_chat_slot_detail` is `async def` but called `read_messages_chained(...)` synchronously in both branches, reading a session's entire chained transcript off disk on the single loop that also serves every other request and agent turn. Both are now wrapped in `await asyncio.to_thread(...)`, each keeping its existing `try`/`except` and warning log unchanged, with the exception still caught around the awaited call.

This idiom is already native to this module — it had 7 `asyncio.to_thread` call sites before this change, including `await asyncio.to_thread(state.ensure_context_snapshots_loaded)` in the helper immediately above this handler — so this follows the established shape rather than introducing an executor. It is also the same principle as previous work in this repo moving blocking filesystem scans off the event loop.

Because that `await` is a suspension point, the unlimited branch now re-reads the in-memory tail **after** the disk read rather than reusing a snapshot taken before it. Otherwise a message landing during the read would be absent from a response the client treats as authoritative, replacing its list and (for an approval request) removing the approval UI until timeout. The pagination branch already had this property — it reads `mem_len`, `disk_len` and the unflushed tail after the await, with no yield between them — so this brings the unlimited branch in line rather than inventing a new pattern. A test reproduces the window deterministically by appending from inside the patched read; reverting the re-read makes it fail.

For the record, that staleness window is not created by this change: the response dict already `await`s `_context_snapshot_fields(...)` *after* `prepared` is fixed, so an await always sat between the message snapshot and the response. This change widens the window and then closes the part of it that it widened.

## Error codes

The two new 400s return `{"error": "<prose>", "code": "<lower_snake_id>"}` (`invalid_query_params`, `limit_out_of_range`), matching this module's existing convention (`slot_not_found`, `folder_not_found`, `invalid_json`). The repo's error-code contract test caught the first version of this change for returning prose alone, on the grounds that the dashboard renders `res.error` verbatim into a localized UI so an un-coded sentence is untranslatable by construction. Both codes are asserted by the new tests.

## Tests

Extended the existing `TestSlotDetailPagination` class in `test/test_dashboard_chat.py` rather than adding a new file — it already owns this endpoint's `has_more` behaviour. 7 new cases; the class goes 4 → 11, all passing.

Coverage: non-integer `limit` and `before` each return 400 with the expected code; `limit=0`, `-1` and `-5` are rejected; `before=0` still returns 200; a normal bounded request returns the same page and the same `has_more` as before (the regression guard for fix 3); and the unlimited branch still reassembles the whole history with `has_more` false.

### Negative controls

Each fix was reverted in turn to confirm the tests actually fail:

| Reverted | Result |
| --- | --- |
| the 400 guard | both parse tests fail, `assert 500 == 400` |
| the lower clamp | `limit=0` test fails, "limit=0 should be rejected" |
| the cursor-branch `to_thread` | off-loop test fails |
| the unlimited-branch `to_thread` | off-loop test fails |

**On the threading tests specifically, and what they do not prove.** I expected the `to_thread` hop to be untestable at unit level and it turned out not to be: each test wraps `read_messages_chained` to record `threading.get_ident()` and asserts the loop thread's id is absent from what was recorded. Removing the hop makes the ids match and the assertion fails, so a revert is caught. But this only proves *the call executed on a non-loop thread*. It measures no latency and makes no liveness claim, so it would not detect some other blocking call added to the same handler later. It is a structural assertion about where this one call ran, not a guarantee that the loop is never blocked.

Both defects in fixes 1 and 2 were also reproduced against unmodified code before any fix was written, so the failures being repaired here were observed rather than inferred.
