### PR TITLE
fix(mcp-gateway): size the stub handshake budget for a contended host

### DIFF
--- a/src/kiro_crew/docs/troubleshooting.md
+++ b/src/kiro_crew/docs/troubleshooting.md
@@ -61,6 +61,31 @@ The doctor also runs a live handshake probe against each managed server and
 prints the child's stderr tail on failure, which is usually where the real cause
 (an import error, a bad path) shows up.
 
+### MCP servers stop sharing a pooled backend
+
+With the shared MCP gateway enabled (`mcp_gateway.enabled`), each session reaches
+a server through a small stub that registers with the gateway daemon. If that
+registration does not complete in time the stub starts its own copy of the server
+instead: the session keeps working, but it no longer shares a backend, and the
+only signal is one record in `$KIROCREW_HOME/logs/stub_fallback.jsonl` (default
+`~/.kiro/crew/logs/stub_fallback.jsonl`) whose `reason` is `handshake_timeout`.
+
+```bash
+grep -c handshake_timeout ~/.kiro/crew/logs/stub_fallback.jsonl
+```
+
+The budget covers only the local connect-and-register with the daemon, so a slow
+MCP server cannot spend it — a saturated host or a stalled gateway can.
+
+- **Default:** 10 seconds
+- **Env override:** `KIROCREW_MCP_HANDSHAKE_TIMEOUT_SECS`, greater than 0 and
+  under 300. A value that is not a number, or outside that range, is ignored and
+  the default applies.
+
+Raise it if those records cluster while heavy local builds or test runs are
+saturating the machine. An absent or refused socket fails immediately and is
+unaffected by this setting.
+
 ### Dashboard not loading
 
 ```bash

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -41,7 +41,35 @@ from kiro_crew.mcp_gateway.pool import READ_BUFFER_LIMIT_BYTES, PoolKey
 
 logger = logging.getLogger(__name__)
 
-_HANDSHAKE_TIMEOUT_SECS = 3.0
+#: Budget for the whole of :func:`handshake` — connect, write Register, read the
+#: gateway's reply. That is local IPC with gatewayd only; the target server's own
+#: startup happens later and inside gatewayd, so a slow ``npx`` or a remote
+#: endpoint can never spend this budget.
+#:
+#: Only ONE condition can reach it: a gateway that is listening but slow to
+#: answer, i.e. a stalled loop or a CPU-starved host. Every other refusal shape
+#: (socket absent, connect refused, rejected, malformed reply) raises inside
+#: ``handshake`` and returns immediately without consuming the budget — so a
+#: generous value costs nothing on the paths users actually hit, and is paid only
+#: where waiting is the correct answer.
+#:
+#: Sized generously because expiry is self-amplifying: the stub degrades to a
+#: per-session ``execvpe``, which spawns a backend that pooling would have
+#: shared, so the extra processes add load to the contended host that caused the
+#: stall in the first place.
+#:
+#: What bounds raising it further is the MCP client's own ``initialize`` budget:
+#: the real server is not exec'd until this expires, so a value approaching that
+#: budget trades a lost pool for a dropped server.
+_HANDSHAKE_TIMEOUT_SECS = 10.0
+
+#: Seconds, overriding :data:`_HANDSHAKE_TIMEOUT_SECS`.
+_HANDSHAKE_TIMEOUT_ENV = "KIROCREW_MCP_HANDSHAKE_TIMEOUT_SECS"
+
+#: Exclusive upper bound on an accepted override. Bounds a typo (``600`` for
+#: ``6.00``) that would otherwise hang session startup for minutes waiting on a
+#: gateway that is never going to answer.
+_HANDSHAKE_TIMEOUT_MAX_SECS = 300.0
 
 # --- Bridge liveness (ping-while-outstanding) constants ---------------------
 # Interval between successive stub→gateway liveness pings while at least one
@@ -510,6 +538,48 @@ class FallbackRequestedError(Exception):
     def __init__(self, reason: str) -> None:
         super().__init__(reason)
         self.reason = reason
+
+
+def _handshake_timeout_secs() -> float:
+    """Resolve the :func:`handshake` budget, honouring the env override.
+
+    Read from the environment rather than ``config.json`` to stay inside the
+    import budget this module's own docstring declares (stdlib + pool +
+    mcp_caller), and because this is a stub-process diagnostic knob rather than a
+    product setting -- the same shape as ``KIROCREW_MCP_LOG`` and
+    ``KIROCREW_MCP_SOCKET``. The pool and backend tunables that do carry config
+    keys are resolved inside the gateway daemon, which loads config regardless.
+
+    A malformed, non-positive, or absurd value yields the default instead of
+    raising. The stub's contract is to always degrade to a per-session exec, and
+    an override typo that killed it here would do so *before* ``fallback_exec``
+    can run — the same trap the logging-level guard in ``_amain`` exists for.
+    """
+    raw = os.environ.get(_HANDSHAKE_TIMEOUT_ENV)
+    if not raw:
+        return _HANDSHAKE_TIMEOUT_SECS
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "ignoring unparseable %s=%r; using %ss",
+            _HANDSHAKE_TIMEOUT_ENV,
+            raw,
+            _HANDSHAKE_TIMEOUT_SECS,
+        )
+        return _HANDSHAKE_TIMEOUT_SECS
+    # Chained comparison also rejects NaN (every comparison against it is false)
+    # and both infinities, neither of which is a usable wait_for timeout.
+    if not 0.0 < value < _HANDSHAKE_TIMEOUT_MAX_SECS:
+        logger.warning(
+            "ignoring out-of-range %s=%r (want 0 < secs < %s); using %ss",
+            _HANDSHAKE_TIMEOUT_ENV,
+            raw,
+            _HANDSHAKE_TIMEOUT_MAX_SECS,
+            _HANDSHAKE_TIMEOUT_SECS,
+        )
+        return _HANDSHAKE_TIMEOUT_SECS
+    return value
 
 
 async def handshake(
@@ -1096,7 +1166,7 @@ async def _amain(argv: Optional[list[str]] = None) -> int:
     try:
         reader, writer, stub_uuid, registered = await asyncio.wait_for(
             handshake(args.socket, payload),
-            timeout=_HANDSHAKE_TIMEOUT_SECS,
+            timeout=_handshake_timeout_secs(),
         )
     except asyncio.TimeoutError:
         log_fallback("handshake_timeout", payload["stub_uuid"], pool_label, args)

--- a/test/test_mcp_gateway_stub_handshake_timeout.py
+++ b/test/test_mcp_gateway_stub_handshake_timeout.py
@@ -1,0 +1,172 @@
+"""The stub's handshake budget: where it applies, and that a bad override cannot kill it.
+
+``handshake`` covers connect + Register + the gateway's reply -- local IPC with
+gatewayd, nothing more. The target server's own startup happens later and inside
+the daemon, so no slow backend can spend this budget; the only condition that
+reaches it is a gateway listening but slow to answer under host contention. Every
+other refusal shape raises inside ``handshake`` and returns without waiting,
+which is what makes a generous default free on the paths users actually hit --
+asserted below so that reasoning stays true rather than remaining a comment.
+
+Expiry costs pooling rather than correctness (the stub degrades to a per-session
+``execvpe``), and it is silent apart from one ``stub_fallback.jsonl`` line. That
+combination is why a regression here would not surface as a bug report: sessions
+would simply stop sharing backends, adding load to the host whose load caused the
+stall.
+
+Named ``test_mcp_gateway_stub_*`` deliberately -- that is the prefix the macOS
+job's glob selects, matching the sibling stub suites. Under another name this
+coverage would silently be Linux-and-Windows-only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+
+import pytest
+
+from kiro_crew.mcp_gateway import stub, transport
+
+
+def _register_payload() -> dict[str, Any]:
+    """The minimum Register frame ``handshake`` needs; it only reads ``stub_uuid``."""
+    return {"type": "register", "stub_uuid": "handshake-timeout-probe"}
+
+
+async def _serve(handler: Any, sock_dir: Any) -> tuple[Any, Any]:
+    sock = sock_dir / "gw.sock"
+    transport.prepare_dir(sock)
+    server = await transport.serve(sock, handler, limit=1 << 16)
+    return server, sock
+
+
+def test_default_budget_absorbs_a_contended_host(monkeypatch) -> None:
+    """Unset override yields a budget sized for a stalled gateway, not a fast one.
+
+    The floor is the point of the test. A budget in the low single digits is
+    within reach of ordinary local-IPC scheduling delay on a loaded host, and
+    every expiry silently drops a session out of the pool.
+    """
+    monkeypatch.delenv(stub._HANDSHAKE_TIMEOUT_ENV, raising=False)
+    assert stub._handshake_timeout_secs() >= 10.0
+
+
+def test_override_is_honoured(monkeypatch) -> None:
+    monkeypatch.setenv(stub._HANDSHAKE_TIMEOUT_ENV, "42.5")
+    assert stub._handshake_timeout_secs() == 42.5
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "soon",          # not a number
+        "",              # set but empty
+        "0",             # wait_for(0) would defeat pooling outright
+        "-1",            # negative
+        "nan",           # every comparison false
+        "inf",           # not a usable deadline
+        "300",           # at the exclusive bound
+        "1e9",           # typo that would hang startup for years
+    ],
+)
+def test_unusable_override_yields_the_default(monkeypatch, raw: str) -> None:
+    """A bad override must degrade to the default, never raise.
+
+    An exception here would escape ``_amain``'s ``wait_for`` call *before*
+    ``fallback_exec`` runs, breaking the always-degrade-to-per-session guarantee
+    -- the same trap the logging-level guard exists for. So the property under
+    test is "returns the default", not merely "does not crash".
+    """
+    monkeypatch.delenv(stub._HANDSHAKE_TIMEOUT_ENV, raising=False)
+    monkeypatch.setenv(stub._HANDSHAKE_TIMEOUT_ENV, raw)
+    assert stub._handshake_timeout_secs() == stub._HANDSHAKE_TIMEOUT_SECS
+
+
+@pytest.mark.asyncio
+async def test_refusals_do_not_consume_the_budget(short_sock_dir) -> None:
+    """An absent gateway returns immediately, so a large budget is free.
+
+    This is the load-bearing half of sizing the default generously: if the
+    common refusal shapes waited out the timeout, raising it would slow every
+    session that starts while the gateway is down.
+    """
+    missing = short_sock_dir / "absent.sock"
+    started = asyncio.get_running_loop().time()
+    with pytest.raises(stub.FallbackRequestedError):
+        await stub.handshake(str(missing), _register_payload())
+    elapsed = asyncio.get_running_loop().time() - started
+    assert elapsed < 1.0, f"connect refusal waited {elapsed:.2f}s instead of failing fast"
+
+
+@pytest.mark.asyncio
+async def test_amain_degrades_using_the_resolved_budget(
+    short_sock_dir, monkeypatch, tmp_path
+) -> None:
+    """The real call site consults the resolver, and expiry reaches fallback.
+
+    Drives ``_amain`` rather than ``handshake`` directly: the budget is applied
+    by the ``wait_for`` in ``_amain``, so testing ``handshake`` alone would leave
+    the wiring unpinned. The endpoint accepts and then says nothing, which is the
+    one shape that can actually reach the timeout.
+    """
+    accepted = asyncio.Event()
+    held: list[Any] = []
+
+    def on_connect(_reader: Any, writer: Any) -> None:
+        # Accept, read nothing, reply never. Keep a reference so the transport is
+        # not closed by garbage collection, which would turn this into an EOF
+        # (a different, already-covered fallback branch).
+        accepted.set()
+        held.append(writer)
+
+    server, sock = await _serve(on_connect, short_sock_dir)
+
+    # A tiny override keeps the test fast AND proves the resolver governs the
+    # wait: at the default this would sit here for ten seconds.
+    monkeypatch.setenv(stub._HANDSHAKE_TIMEOUT_ENV, "0.2")
+
+    reasons: list[str] = []
+    monkeypatch.setattr(
+        stub, "log_fallback", lambda reason, *a, **k: reasons.append(reason)
+    )
+    execs: list[Any] = []
+    # execvpe never returns in production; a recording no-op lets _amain finish.
+    monkeypatch.setattr(stub, "fallback_exec", lambda args: execs.append(args))
+
+    argv = [
+        "--server", "probe",
+        "--agent", "kirocrew",
+        "--target-command", sys.executable,
+        "--work-dir", str(tmp_path),
+        "--socket", str(sock),
+    ]
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    try:
+        rc = await asyncio.wait_for(stub._amain(argv), timeout=30)
+    finally:
+        elapsed = loop.time() - started
+        for writer in held:
+            writer.close()
+        server.close()
+        await server.wait_closed()
+
+    assert accepted.is_set(), "the endpoint never accepted, so nothing was tested"
+    assert reasons == ["handshake_timeout"], reasons
+    assert execs, "timeout did not reach fallback_exec; the session would have died"
+    assert rc == 1
+    # Bounds the wiring, not the clock: a call site that read the module constant
+    # instead of calling the resolver would still land on handshake_timeout here,
+    # just at the default budget. Only the elapsed time distinguishes the two.
+    #
+    # Derived from the constant rather than an absolute number because the
+    # measured window is all of _amain -- including build_register_payload's
+    # /proc walk and target-binary hashing -- and an absolute ceiling on an
+    # instrumented run is a known flake class (coverage runs on one Python
+    # version only). Half the default still fails an unwired call site, which
+    # waits the full budget.
+    assert elapsed < stub._HANDSHAKE_TIMEOUT_SECS / 2, (
+        f"waited {elapsed:.2f}s for a 0.2s budget — the override was not applied"
+    )


### PR DESCRIPTION
## Problem

With the shared MCP gateway enabled, a session reaches an MCP server through a stub
process that registers with the gateway daemon over a unix socket. That handshake had
a fixed 3-second budget and no way to change it. When it expires the stub falls back
to `execvpe`-ing the real backend per session: the session keeps working, but it no
longer shares a pooled backend, and the only trace is one record in
`$KIROCREW_HOME/logs/stub_fallback.jsonl` with `"reason": "handshake_timeout"`.

## Why it matters

The degradation is silent and self-amplifying. Losing the pool spawns a backend that
would otherwise have been shared, so the extra processes add load to the same host
whose load caused the stall — and nothing surfaces to the user, because correctness is
preserved. Measured local contention on a 16-core dev host reaches load 27 with gate
runs at ~318% CPU, which is exactly the regime where a 3s budget for local IPC is thin.

## Fix (symptom → root cause → change)

**Symptom:** sessions intermittently stop sharing pooled MCP backends under load.

**Root cause:** `_HANDSHAKE_TIMEOUT_SECS = 3.0` wrapped `handshake()` with no override.
That budget covers *only* connect + write Register + read the gateway's reply — local
IPC with gatewayd. The target server's own startup happens later and inside the daemon,
so no slow `npx` or remote endpoint can spend it; the one condition that reaches it is a
gateway that is listening but slow to answer.

**Change:** default raised to 10s, plus a `KIROCREW_MCP_HANDSHAKE_TIMEOUT_SECS` env
override resolved by `_handshake_timeout_secs()`.

Raising it is close to free because every other refusal shape — socket absent, connect
refused, `rejected`, malformed reply — raises inside `handshake()` and returns without
consuming the budget, so the longer wait is paid only where waiting is the correct
answer. A test pins that fast-fail property so the reasoning cannot rot.

The override is an env var rather than a config key to stay inside the import budget
this module's docstring declares, and because it is a stub-process diagnostic knob
rather than a product setting — the same shape as `KIROCREW_MCP_LOG` and
`KIROCREW_MCP_SOCKET`. The pool/backend tunables that *do* carry config keys
(`read_buffer_limit_bytes`, `response_spill_threshold_bytes`) are resolved inside the
gateway daemon, which loads config regardless.

A malformed, non-positive, or absurd value yields the default rather than raising: the
stub's contract is to always degrade to a per-session exec, and an override typo that
threw here would do so *before* `fallback_exec` runs.

## Tests

`test/test_mcp_gateway_stub_handshake_timeout.py` (new, 12 cases). Named
`test_mcp_gateway_stub_*` so the macOS job's glob selects it, matching the sibling stub
suites.

- `test_default_budget_absorbs_a_contended_host` — pins the default floor.
- `test_override_is_honoured` — a valid override is used verbatim.
- `test_unusable_override_yields_the_default` — parametrized over unparseable, empty,
  `0`, negative, `nan`, `inf`, the exclusive `300` bound, and `1e9`. The asserted
  property is *returns the default*, not merely "does not raise", because a raise would
  break the always-degrade-to-per-session guarantee.
- `test_refusals_do_not_consume_the_budget` — an absent socket fails fast. This is the
  load-bearing half of sizing the default generously.
- `test_amain_degrades_using_the_resolved_budget` — drives `_amain` against an endpoint
  that accepts and never replies, so the timeout is reached through the real call site
  rather than a direct `handshake()` call. Bounds elapsed time against the constant, so
  a call site that bypassed the resolver fails here.

Revert-verified: three separate mutations (tighten the default, bypass the resolver at
the call site, delete the range guard) each break their matching test, with pytest
confirmed to have executed in every run.

## Manual verification

N/A — unit coverage is sufficient for a timeout-resolution change, and the code path is
exercised end-to-end through `_amain` against a real socket endpoint.

Not reproduced in the field: this install runs with `mcp_gateway.enabled: false`
(the default), so no `stub_fallback.jsonl` exists and the timer never executes here. The
sizing is reasoned from the code paths plus measured host contention, not from a captured
`handshake_timeout` record. Confirming the win would mean enabling the gateway on a pod,
saturating the host with a gate run, and comparing fallback counts at 3s vs 10s.

One thing not observable from this repo: kiro-cli's own `initialize` budget. The real
server is not exec'd until this timeout expires, so a value approaching that budget
would trade a lost pool for a dropped server. That bound is documented next to the
constant; 10s sits well under this repo's own 30s probe budget.

## Screenshots

N/A — no user-visible UI change.
