### PR TITLE
test(website): clear the unhandled window error from DevFleetPage toasts

### DIFF
--- a/website/src/test/DevFleetPageCoverage.test.tsx
+++ b/website/src/test/DevFleetPageCoverage.test.tsx
@@ -52,6 +52,26 @@ function renderPage() {
   return renderWithProviders(<DevFleetPage />, { route: '/dev-fleet' })
 }
 
+// DevFleetPage's ToastHost schedules a 4s (7s for errors) window.setTimeout to
+// auto-dismiss each toast, and its effect cleanup only drops the listener -- it
+// never clears those timers. Every test here that raises a toast therefore
+// leaves a pending callback that calls setToasts long after the test ends; once
+// vitest tears the environment down, that callback hits a torn-down global and
+// throws "ReferenceError: window is not defined" as an UNHANDLED error. Vitest
+// reports every test as passing and still exits non-zero, so this fails CI
+// without failing a test.
+//
+// Fake timers keep those callbacks off the real clock and clearAllTimers drops
+// the pending ones at teardown. `shouldAdvanceTime` keeps the clock moving on
+// its own so waitFor and the polling effects behave as they do with real timers.
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+})
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
 /** Wait for the first paint of the fleet table. */
 async function waitForRow(name: string) {
   await waitFor(() => expect(screen.getByText(name)).toBeInTheDocument(), { timeout: 4000 })


### PR DESCRIPTION
## What

One file, 20 lines: fences the toast timers in `DevFleetPageCoverage.test.tsx` so the suite stops emitting unhandled errors.

`DevFleetPage`'s `ToastHost` schedules a 4s (7s for errors) `window.setTimeout` to auto-dismiss each toast, but its effect cleanup only removes the listener — it never clears the timers. Every test that raises a toast leaves a pending callback that calls `setToasts` after the test ends. When vitest tears the environment down, that callback reaches a torn-down global:

```
ReferenceError: window is not defined
  at getCurrentEventPriority (react-dom.development.js:10993)
  at Timeout._onTimeout (src/pages/DevFleetPage.tsx:534)
```

A full-suite run counted **4** of these.

## Why it matters

This is the worst shape of CI failure: **every test reports passing and the run still exits non-zero.** The job goes red with nothing in the test summary to point at. I only found it because a coverage run exited 1 with `990 passed / 0 failed`, and vitest emits no coverage report at all on a non-zero exit — so the failure was silently costing whole runs.

## Approach

Auto-advancing fake timers (`shouldAdvanceTime: true`) plus `clearAllTimers()` at teardown. The clock still moves on its own, so `waitFor` and the polling effects behave exactly as they did on real timers; no assertion changed.

## Scope note

**The leak in `ToastHost` is a genuine product defect and is deliberately left unfixed here** — this PR is tests only. It deserves its own change: the same pattern drops a state update on a real unmounted component, not just in tests.

## Why this PR shrank

It was opened to add 21 coverage files taking the frontend lane from 80.22% to 83.35%. Those files reached main independently while this was in flight, so the rebase correctly reduced the diff to just this fix. The coverage work is already on main; **the frontend lane sits at ~83.35%, still short of the 85% target by ~1,137 statements.**

## Verification

- `vitest run src/test/DevFleetPageCoverage.test.tsx`: exit 0, 54 tests pass, no unhandled errors
- `tsc --noEmit`: exit 0
- `eslint src/ --max-warnings 1116` (CI's own threshold): exit 0
- `jscpd .`: 0 clones
- Exit codes checked explicitly rather than read off piped output
