### PR TITLE
fix(skills): retire skill-review bell notifications when the candidate is consumed

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -196,7 +196,7 @@ from kiro_crew.safety_override import (
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.skill_usage import register_skill_read_observer
-from kiro_crew.skills import SkillsLoader, set_pending_staged_hook
+from kiro_crew.skills import SkillsLoader, set_pending_consumed_hook, set_pending_staged_hook
 from kiro_crew.suggestions import api_suggestions
 from kiro_crew.tips import api_tips_feedback, api_tips_next, api_tips_status
 from kiro_crew.tunnel.setup import setup_tunnel
@@ -2119,6 +2119,44 @@ async def start_dashboard(
                 logger.debug("pending-skill notification failed", exc_info=True)
 
         set_pending_staged_hook(_on_pending_skill_staged)
+
+        def _on_pending_skill_consumed(info: dict) -> None:
+            # Counterpart of the staged hook above: when a candidate leaves the
+            # queue (approved, dismissed, or TTL-pruned — by ANY loader
+            # instance), retire its bell notification instead of leaving an
+            # unread row whose deep link now lands on the "no longer awaiting
+            # review" banner. Same thread contract as staging: the hook fires
+            # from whatever thread consumed the candidate (dashboard handlers
+            # run it on an executor), so marshal onto the gateway loop before
+            # touching the notification log or the WS fanout.
+            try:
+                slug = str(info.get("slug") or "")
+                consumed_at = str(info.get("consumed_at") or "")
+                if not slug or not consumed_at:
+                    return
+
+                def _resolve() -> None:
+                    try:
+                        task = asyncio.ensure_future(
+                            state.resolve_skill_review_notifications(slug, consumed_at)
+                        )
+                        state._background_tasks.add(task)
+                        task.add_done_callback(state._background_tasks.discard)
+                    except Exception:
+                        logger.debug("pending-skill notification resolve failed", exc_info=True)
+
+                if _gw_loop is not None and not _gw_loop.is_closed():
+                    try:
+                        _gw_loop.call_soon_threadsafe(_resolve)
+                    except RuntimeError:  # pragma: no cover - loop closing
+                        pass
+                # Without a loop there is no serving dashboard (sync/embedded
+                # launch): no SSE/WS clients to update and no executor to
+                # persist through, so the row is left as-is.
+            except Exception:
+                logger.debug("pending-skill notification resolve failed", exc_info=True)
+
+        set_pending_consumed_hook(_on_pending_skill_consumed)
     except Exception:
         logger.debug("Could not register pending-skill staged hook", exc_info=True)
 

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3383,6 +3383,52 @@ class DashboardState:
                 return True
         return False
 
+    async def resolve_skill_review_notifications(self, slug: str, consumed_at: str) -> int:
+        """Ack every skill-review notification for a candidate that left the queue.
+
+        Approving, dismissing, or TTL-pruning a pending skill candidate retires
+        the review request the notification exists to surface. Left unread, the
+        row keeps the bell badge lit for something that can no longer be acted
+        on — its deep link lands on the "no longer awaiting review" banner.
+
+        ``consumed_at`` scopes the ack to the candidate GENERATION that was
+        actually consumed: it is stamped by the consumption site BEFORE the
+        pending directory is removed, and staging refuses to overwrite an
+        existing candidate — so a same-slug replacement staged afterwards
+        carries a strictly later ``ts`` and is never touched. Both timestamps
+        come from ``datetime.now(tz=timezone.utc).isoformat()``, so string
+        comparison is chronological. Rows with a missing/foreign ``ts`` and a
+        falsy cutoff are left alone (fail-safe: a stale unread row beats a
+        wrongly-acked actionable one). Matching is on ``channel ==
+        "system.skills"`` — the bus-validated field only the gateway's own
+        skill-review producer can carry (``system`` is a reserved app name) —
+        never on the derived legacy ``kind``, which an app channel named
+        ``<app>.skills`` would collide with. Acks — never deletes — so the feed
+        keeps its history, and broadcasts ``notification_ack`` per row so an
+        open feed updates live. Returns the number of rows acked.
+        """
+        if not slug or not consumed_at:
+            return 0
+        acked_ts: list[str] = []
+        for n in self._notification_log:
+            ts = n.get("ts")
+            if (
+                n.get("channel") == "system.skills"
+                and n.get("slug") == slug
+                and not n.get("acked")
+                and isinstance(ts, str)
+                and ts
+                and ts <= consumed_at
+            ):
+                n["acked"] = True
+                acked_ts.append(ts)
+        if not acked_ts:
+            return 0
+        await self._rewrite_notifications_async()
+        for ts in acked_ts:
+            self.broadcast_ws("notification_ack", {"ts": ts})
+        return len(acked_ts)
+
     async def clear_notifications(self) -> None:
         """Remove all notifications from memory and disk.
 

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -167,6 +167,39 @@ def _emit_pending_staged(payload: dict) -> None:
         logger.debug("pending-staged hook failed", exc_info=True)
 
 
+# Counterpart observer for candidates LEAVING the queue (approved, dismissed,
+# or TTL-pruned). Module-level for the same reason as the staged hook: any
+# loader instance can consume a candidate. The gateway registers a hook that
+# retires the candidate's bell-feed notification — without it, the "awaiting
+# review" row stays unread forever and its deep link lands on the
+# no-longer-awaiting-review banner.
+_PENDING_CONSUMED_HOOK: "Callable[[dict], None] | None" = None
+
+
+def set_pending_consumed_hook(fn: "Callable[[dict], None] | None") -> None:
+    """Register (or clear, with ``None``) the pending-candidate consumed observer.
+
+    Called once at gateway boot. Idempotent — a later call replaces the hook.
+    """
+    global _PENDING_CONSUMED_HOOK
+    _PENDING_CONSUMED_HOOK = fn
+
+
+def _emit_pending_consumed(payload: dict) -> None:
+    """Invoke the pending-consumed hook, swallowing every failure.
+
+    Consumption has already succeeded on disk by the time this runs; a broken
+    observer must never turn a successful approve/dismiss into a failure.
+    """
+    fn = _PENDING_CONSUMED_HOOK
+    if fn is None:
+        return
+    try:
+        fn(payload)
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("pending-consumed hook failed", exc_info=True)
+
+
 # Derived lifecycle states for auto-skills (not persisted — computed from
 # usage recency at lifecycle-run time).
 SKILL_STATE_ACTIVE = "active"
@@ -2526,6 +2559,9 @@ class SkillsLoader:
         # (h) Prune version history to the cap.
         self._prune_versions(versions_dir)
         # (i) Remove the pending candidate.
+        # Captured BEFORE the removal so a same-slug replacement staged after
+        # this instant keeps its notification (see approve_pending_skill).
+        consumed_at = datetime.now(tz=timezone.utc).isoformat()
         shutil.rmtree(src, ignore_errors=True)
         # (j) Audit the approved update.
         sel().log_tool_invocation(
@@ -2546,6 +2582,20 @@ class SkillsLoader:
         logger.info(
             "Approved pending update: %s (v%d -> v%d)", target_name, current_version, new_version
         )
+        # The candidate cleanup above ignores rmtree errors (e.g. a Windows
+        # file lock), so the candidate can survive in the pending queue even
+        # though the update went live. Only report it consumed when the
+        # directory is really gone — otherwise the queue still shows an
+        # actionable review and its notification must stay unread.
+        if not src.exists():
+            _emit_pending_consumed(
+                {
+                    "slug": slug,
+                    "outcome": "approved",
+                    "name": target_name,
+                    "consumed_at": consumed_at,
+                }
+            )
         return target_name
 
     def approve_pending_skill(self, slug: str) -> str | None:
@@ -2621,6 +2671,12 @@ class SkillsLoader:
             )
             return None
         dest.parent.mkdir(parents=True, exist_ok=True)
+        # Cutoff for notification resolution, captured BEFORE the candidate
+        # leaves the pending queue: staging refuses to overwrite an existing
+        # candidate, so a same-slug replacement can only be staged after this
+        # instant — its notification carries a strictly later ``ts`` and must
+        # survive the resolve.
+        consumed_at = datetime.now(tz=timezone.utc).isoformat()
         try:
             shutil.move(str(src), str(dest))
         except OSError:
@@ -2648,6 +2704,9 @@ class SkillsLoader:
                             pass
         self._invalidate_iter_cache()
         logger.info("Approved pending skill: %s", name)
+        _emit_pending_consumed(
+            {"slug": slug, "outcome": "approved", "name": name, "consumed_at": consumed_at}
+        )
         return name
 
     def dismiss_pending_skill(self, slug: str) -> bool:
@@ -2657,8 +2716,14 @@ class SkillsLoader:
         pdir = self._pending_root() / slug
         if not pdir.is_dir():
             return False
+        # Captured BEFORE the removal so a same-slug replacement staged after
+        # this instant keeps its notification (see approve_pending_skill).
+        consumed_at = datetime.now(tz=timezone.utc).isoformat()
         shutil.rmtree(pdir)
         logger.info("Dismissed pending skill: %s", slug)
+        _emit_pending_consumed(
+            {"slug": slug, "outcome": "dismissed", "consumed_at": consumed_at}
+        )
         return True
 
     def prune_pending(self, ttl_days: int, *, now: float | None = None) -> int:

--- a/test/test_notification_skill_resolve.py
+++ b/test/test_notification_skill_resolve.py
@@ -1,0 +1,165 @@
+"""Tests: DashboardState.resolve_skill_review_notifications.
+
+Approving, dismissing, or TTL-pruning a pending skill candidate retires the
+review request its bell notification exists to surface. This method is the
+gateway-side half of the consumed-hook seam (see ``set_pending_consumed_hook``
+in ``kiro_crew.skills``): it acks — never deletes — every matching unread
+skill-review row, persists once, and broadcasts ``notification_ack`` per row so
+an open feed drops the badge live.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.dashboard.state import DashboardState
+
+
+@pytest.fixture()
+def state(monkeypatch, tmp_path):
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    return DashboardState(
+        sessions=MagicMock(count=0),
+        crons=MagicMock(),
+        lessons=MagicMock(),
+        start_time=0.0,
+    )
+
+
+def _skill_note(slug: str, ts: str, *, acked: bool = False) -> dict:
+    # Shape mirrors what the staged hook produces: bus channel system.skills
+    # (with the derived legacy kind) and the meta payload ({slug,
+    # candidate_kind, target}) flat-merged by the bus.
+    note = {
+        "kind": "skills",
+        "channel": "system.skills",
+        "title": "New skill awaiting review",
+        "body": f"**{slug}**",
+        "ts": ts,
+        "slug": slug,
+        "candidate_kind": "new",
+    }
+    if acked:
+        note["acked"] = True
+    return note
+
+
+@pytest.mark.asyncio
+async def test_acks_matching_rows_and_broadcasts(state):
+    state._notification_log = [
+        _skill_note("deploy-helper", "t1"),
+        # Re-surfaced duplicate for the same candidate: both rows must retire.
+        _skill_note("deploy-helper", "t2"),
+        _skill_note("other-skill", "t3"),
+        {"kind": "cron", "title": "Job", "body": "b", "ts": "t4", "slug": "deploy-helper"},
+    ]
+    sent: list[tuple[str, object]] = []
+    state.broadcast_ws = lambda msg_type, data: sent.append((msg_type, data))
+
+    assert await state.resolve_skill_review_notifications("deploy-helper", "t9") == 2
+
+    by_ts = {n["ts"]: n for n in state._notification_log}
+    assert by_ts["t1"]["acked"] is True
+    assert by_ts["t2"]["acked"] is True
+    # A different candidate's row stays unread.
+    assert "acked" not in by_ts["t3"]
+    # A non-skills note that happens to carry a `slug` key is never touched.
+    assert "acked" not in by_ts["t4"]
+    assert sent == [
+        ("notification_ack", {"ts": "t1"}),
+        ("notification_ack", {"ts": "t2"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_already_acked_rows_are_left_alone(state):
+    state._notification_log = [_skill_note("done-skill", "t1", acked=True)]
+    sent: list[tuple[str, object]] = []
+    state.broadcast_ws = lambda msg_type, data: sent.append((msg_type, data))
+
+    # Nothing to do → no rewrite, no broadcast.
+    assert await state.resolve_skill_review_notifications("done-skill", "t9") == 0
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_no_match_is_a_noop(state):
+    state._notification_log = [_skill_note("some-skill", "t1")]
+    assert await state.resolve_skill_review_notifications("unrelated", "t9") == 0
+    assert "acked" not in state._notification_log[0]
+
+
+@pytest.mark.asyncio
+async def test_empty_slug_matches_nothing(state):
+    # A defensive caller with a blank slug must not sweep rows whose slug is
+    # also blank/absent (note.get("slug") would equal "" for neither here,
+    # but the guard makes the contract explicit).
+    state._notification_log = [_skill_note("real-skill", "t1")]
+    assert await state.resolve_skill_review_notifications("", "t9") == 0
+    assert "acked" not in state._notification_log[0]
+
+
+@pytest.mark.asyncio
+async def test_ack_persists_to_disk(state, tmp_path):
+    state._notification_log = [_skill_note("persist-me", "t1")]
+    assert await state.resolve_skill_review_notifications("persist-me", "t9") == 1
+    text = (tmp_path / "notifications.jsonl").read_text(encoding="utf-8")
+    assert '"acked": true' in text
+
+
+@pytest.mark.asyncio
+async def test_replacement_generation_staged_after_cutoff_survives(state):
+    # The consumed_at cutoff is stamped BEFORE the pending dir is removed, and
+    # staging refuses to overwrite an existing candidate — so a same-slug
+    # replacement staged after consumption carries a later ts. Its (actionable)
+    # notification must survive the resolve; only the consumed generation acks.
+    state._notification_log = [
+        _skill_note("deploy-helper", "t1"),  # consumed generation
+        _skill_note("deploy-helper", "t8"),  # replacement, staged after cutoff
+    ]
+    sent: list[tuple[str, object]] = []
+    state.broadcast_ws = lambda msg_type, data: sent.append((msg_type, data))
+
+    assert await state.resolve_skill_review_notifications("deploy-helper", "t5") == 1
+
+    by_ts = {n["ts"]: n for n in state._notification_log}
+    assert by_ts["t1"]["acked"] is True
+    assert "acked" not in by_ts["t8"]
+    assert sent == [("notification_ack", {"ts": "t1"})]
+
+
+@pytest.mark.asyncio
+async def test_empty_cutoff_matches_nothing(state):
+    # A consumption event without a stamp cannot prove which generation it
+    # consumed — fail safe by leaving every row unread.
+    state._notification_log = [_skill_note("some-skill", "t1")]
+    assert await state.resolve_skill_review_notifications("some-skill", "") == 0
+    assert "acked" not in state._notification_log[0]
+
+
+@pytest.mark.asyncio
+async def test_app_channel_note_with_skills_kind_is_never_acked(state):
+    # An app can register a channel like "myapp.skills", whose notes derive the
+    # legacy kind "skills" and may flat-merge their own `slug` meta key. Only
+    # the gateway's own producer can carry channel system.skills ("system" is a
+    # reserved app name), so matching pins the channel — the app's durable
+    # notification must survive a same-slug candidate consumption.
+    app_note = {
+        "kind": "skills",
+        "channel": "myapp.skills",
+        "title": "App item",
+        "body": "b",
+        "ts": "t1",
+        "slug": "deploy-helper",
+    }
+    state._notification_log = [app_note, _skill_note("deploy-helper", "t2")]
+    sent: list[tuple[str, object]] = []
+    state.broadcast_ws = lambda msg_type, data: sent.append((msg_type, data))
+
+    assert await state.resolve_skill_review_notifications("deploy-helper", "t9") == 1
+
+    assert "acked" not in state._notification_log[0]
+    assert state._notification_log[1]["acked"] is True
+    assert sent == [("notification_ack", {"ts": "t2"})]

--- a/test/test_skill_pending_notify.py
+++ b/test/test_skill_pending_notify.py
@@ -1,15 +1,23 @@
-"""Tests for the pending-candidate staged notification hook.
+"""Tests for the pending-candidate staged + consumed notification hooks.
 
-The hook is the Stage-5 notification seam: ``stage_skill_candidate`` fires a
+The hooks are the Stage-5 notification seam: ``stage_skill_candidate`` fires a
 MODULE-level observer (not a per-instance callback) so a candidate staged by ANY
 loader — consolidation's ContextBuilder loader or a per-request dashboard one —
 surfaces to the user. The gateway registers a hook that raises a bell-feed
 notification + broadcasts ``skills.pending_changed``.
+
+The consumed hook is the counterpart for candidates LEAVING the queue
+(approved, dismissed, or TTL-pruned): the gateway registers a hook that
+retires the candidate's bell notification so the badge doesn't stay lit for a
+review that can no longer be acted on.
 """
 
 from __future__ import annotations
 
+import shutil
+import time
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
@@ -24,10 +32,12 @@ def loader(tmp_path):
 
 @pytest.fixture(autouse=True)
 def _clear_hook():
-    """Never leak a hook across tests (it is module-level global state)."""
+    """Never leak a hook across tests (they are module-level global state)."""
     S.set_pending_staged_hook(None)
+    S.set_pending_consumed_hook(None)
     yield
     S.set_pending_staged_hook(None)
+    S.set_pending_consumed_hook(None)
 
 
 def _prov() -> AutoSkillProvenance:
@@ -130,3 +140,107 @@ def test_set_hook_replaces_rather_than_stacks(loader):
     _stage(loader, "cand-replace")
     assert first == []
     assert len(second) == 1
+
+
+# ── consumed hook (approve / dismiss / prune) ──
+
+
+def _payloads_sans_stamp(seen):
+    """Strip (and validate) the consumed_at stamp so payloads compare exactly."""
+    out = []
+    for info in seen:
+        info = dict(info)
+        stamp = info.pop("consumed_at")
+        assert isinstance(stamp, str) and stamp  # ISO-8601 UTC, always present
+        out.append(info)
+    return out
+
+
+def test_consumed_hook_fires_on_approve(loader):
+    _stage(loader, "cand-approve")
+    seen: list[dict] = []
+    S.set_pending_consumed_hook(seen.append)
+    assert loader.approve_pending_skill("cand-approve") == "auto/cand-approve"
+    assert _payloads_sans_stamp(seen) == [
+        {"slug": "cand-approve", "outcome": "approved", "name": "auto/cand-approve"}
+    ]
+
+
+def test_consumed_hook_fires_on_update_approve(loader):
+    _stage(loader, "cand-upd")
+    assert loader.approve_pending_skill("cand-upd") == "auto/cand-upd"
+    _stage(loader, "cand-upd", kind="update", target="auto/cand-upd", base_version=1)
+    seen: list[dict] = []
+    S.set_pending_consumed_hook(seen.append)
+    assert loader.approve_pending_update("cand-upd") == "auto/cand-upd"
+    assert _payloads_sans_stamp(seen) == [{"slug": "cand-upd", "outcome": "approved", "name": "auto/cand-upd"}]
+
+
+def test_consumed_hook_not_fired_when_update_cleanup_leaves_candidate(loader, monkeypatch):
+    # approve_pending_update deletes the candidate with ignore_errors=True
+    # (a Windows file lock can silently defeat it). A surviving candidate is
+    # still an actionable review in the pending queue, so its notification
+    # must NOT be retired.
+    _stage(loader, "cand-locked")
+    assert loader.approve_pending_skill("cand-locked") == "auto/cand-locked"
+    _stage(loader, "cand-locked", kind="update", target="auto/cand-locked", base_version=1)
+    pending_dir = loader._pending_root() / "cand-locked"
+    real_rmtree = shutil.rmtree
+
+    def _locked_rmtree(path, *args, **kwargs):
+        if Path(path) == pending_dir and kwargs.get("ignore_errors"):
+            return  # swallow, like rmtree with a locked file inside
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr("kiro_crew.skills.shutil.rmtree", _locked_rmtree)
+    seen: list[dict] = []
+    S.set_pending_consumed_hook(seen.append)
+    assert loader.approve_pending_update("cand-locked") == "auto/cand-locked"
+    assert pending_dir.is_dir()  # cleanup really was defeated
+    assert seen == []
+
+
+def test_consumed_hook_fires_on_dismiss(loader):
+    _stage(loader, "cand-dismiss")
+    seen: list[dict] = []
+    S.set_pending_consumed_hook(seen.append)
+    assert loader.dismiss_pending_skill("cand-dismiss") is True
+    assert _payloads_sans_stamp(seen) == [{"slug": "cand-dismiss", "outcome": "dismissed"}]
+
+
+def test_consumed_hook_fires_on_ttl_prune(loader):
+    # Pruning routes through dismiss_pending_skill, so the hook covers the
+    # silent-expiry path too — a pruned candidate's notification must not
+    # outlive the candidate any more than a dismissed one's.
+    _stage(loader, "cand-prune")
+    seen: list[dict] = []
+    S.set_pending_consumed_hook(seen.append)
+    assert loader.prune_pending(0, now=time.time() + 60) == 1
+    assert _payloads_sans_stamp(seen) == [{"slug": "cand-prune", "outcome": "dismissed"}]
+
+
+def test_consumed_hook_not_fired_when_nothing_consumed(loader):
+    seen: list[dict] = []
+    S.set_pending_consumed_hook(seen.append)
+    assert loader.approve_pending_skill("no-such-slug") is None
+    assert loader.dismiss_pending_skill("no-such-slug") is False
+    assert seen == []
+
+
+def test_consumed_no_hook_registered_is_a_silent_noop(loader):
+    # CLI processes register nothing — consumption must still succeed.
+    _stage(loader, "cand-cli")
+    assert loader.dismiss_pending_skill("cand-cli") is True
+    assert loader.list_pending_skills() == []
+
+
+def test_consumed_hook_failure_never_breaks_consumption(loader):
+    def boom(_info: dict) -> None:
+        raise RuntimeError("observer exploded")
+
+    S.set_pending_consumed_hook(boom)
+    _stage(loader, "cand-boom2")
+    # The candidate is gone from disk before the hook runs; a broken observer
+    # must not turn that into a failure.
+    assert loader.approve_pending_skill("cand-boom2") == "auto/cand-boom2"
+    assert loader.list_pending_skills() == []


### PR DESCRIPTION
## Problem

Approving or dismissing a pending skill candidate leaves its "awaiting review" bell notification unread forever. The notification's deep link then lands on the "That skill candidate is no longer awaiting review. It was approved or dismissed." banner — the badge stays lit for something that can no longer be acted on. Observed on a live instance: after approving every queued candidate, the bell still showed 2 unread review notifications pointing at consumed candidates.

The staging side already has a notification seam (`set_pending_staged_hook` fires a bell notification when a candidate enters the queue), but nothing fires when a candidate leaves it: the approve/dismiss handlers promote or delete the candidate and never touch the notification log.

## Fix

Mirror the existing staged-hook seam with a consumed hook:

- `skills.py`: add module-level `set_pending_consumed_hook` / `_emit_pending_consumed` (module-level for the same reason as the staged hook — any `SkillsLoader` instance can consume a candidate). Fired from the three consumption sites: `approve_pending_skill`, `approve_pending_update`, and `dismiss_pending_skill` (which also covers TTL pruning via `prune_pending`). Failures are swallowed — consumption has already succeeded on disk.
- `state.py`: add `DashboardState.resolve_skill_review_notifications(slug)` — acks (never deletes) every unread `kind == "skills"` notification whose flat-merged `slug` matches the consumed candidate, persists once, and broadcasts `notification_ack` per row so an open feed and the bell badge update live (the frontend already handles this WS event and computes the badge from unacked rows).
- `server.py`: register the consumed hook next to the staged one, with the same thread contract — the hook fires from executor threads, so the resolve is marshalled onto the gateway loop before touching the log or the WS fanout.

Notifications are acked rather than deleted so the feed keeps its history; already-acked rows are skipped so the rewrite/broadcast only happens when something changed.

## Tests

- `test/test_skill_pending_notify.py`: 8 new consumed-hook tests mirroring the staged-hook suite — fires on approve (new + update), dismiss, and TTL prune; not fired when nothing was consumed; silent no-op with no hook registered; a raising observer never breaks consumption; payload shape pinned.
- `test/test_notification_skill_resolve.py` (new): 5 tests for the resolve method — acks all matching rows including re-surfaced duplicates and broadcasts per row, never touches other candidates' rows or non-skills rows that happen to carry a `slug` key, skips already-acked rows without a rewrite, empty-slug guard, ack persists to disk.

Full backend suite: 42,120 passed; the 87 failures are the pre-existing sandbox-environment baseline on this host (subprocess/socket-sensitive tests, identical on clean main) with no overlap with the files this PR touches. isort, flake8, and mypy (CI-parity venv) all green.
