### PR TITLE
fix(acp): send client name under clientInfo.name in AcpRuntime handshake

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -783,8 +783,13 @@ class AcpRuntime:
             init_resp = await self._send_and_await(
                 "initialize",
                 {
-                    "clientName": CLIENT_NAME,
-                    "clientVersion": CLIENT_VERSION,
+                    # kiro-cli reads the driving client name from `clientInfo.name`
+                    # (agent/acp/acp_agent.rs: `if let Some(info) = request.client_info`),
+                    # NOT from a flat `clientName` key. Sending it flat left every
+                    # AcpRuntime-driven session (the primary kiro-cli path) unnamed in
+                    # telemetry — bucketed as "(none)" instead of "kirocrew". Nest it to
+                    # match AcpClient and be picked up for acpClientName attribution.
+                    "clientInfo": {"name": CLIENT_NAME, "version": CLIENT_VERSION},
                     "protocolVersion": PROTOCOL_VERSION,
                     "clientCapabilities": ACP_CLIENT_CAPABILITIES,
                 },

--- a/test/test_acp_client_capabilities.py
+++ b/test/test_acp_client_capabilities.py
@@ -42,3 +42,22 @@ def test_both_acp_transports_send_capabilities() -> None:
         # is cp1252 on the Windows CI shards, and these files contain non-ASCII
         # (em dashes / arrows) in their comments.
         assert "ACP_CLIENT_CAPABILITIES" in src.read_text(encoding="utf-8"), rel
+
+
+def test_both_acp_transports_send_client_info_name() -> None:
+    """Both transports must declare the client name under `clientInfo.name`.
+
+    kiro-cli reads the driving ACP client name from the initialize request's
+    `clientInfo.name` (agent/acp/acp_agent.rs: `if let Some(info) =
+    request.client_info`). A flat top-level `clientName` key is ignored, which
+    leaves the session unnamed in telemetry (bucketed as "(none)" instead of
+    "kirocrew"). AcpRuntime previously sent the flat key; this locks in the
+    nested form on BOTH transports. Asserted on source because neither params
+    dict is reachable without spawning a real agent subprocess.
+    """
+    for rel in ("src/kiro_crew/acp/client.py", "src/kiro_crew/acp/runtime.py"):
+        src = Path(__file__).resolve().parents[1] / rel
+        text = src.read_text(encoding="utf-8")
+        assert '"clientInfo": {"name": CLIENT_NAME' in text, rel
+        # The flat key kiro-cli ignores must not come back.
+        assert '"clientName": CLIENT_NAME' not in text, rel


### PR DESCRIPTION
## Problem

kiro-cli attributes ACP traffic to a client name taken from the initialize request's **`clientInfo.name`**. Its ACP agent only reads that nested field:

```rust
// kiro-cli agent/acp/acp_agent.rs
async move |request: InitializeRequest, request_cx, _cx| {
    if let Some(info) = request.client_info {
        let _ = session_tx.initialize(info.name, info.version).await;
    }
    ...
```

KiroCrew has two ACP drivers. `AcpClient` sends the name correctly nested; `AcpRuntime` sent it under a **flat top-level `clientName`** key, which kiro-cli ignores:

- `AcpClient` (correct) — `src/kiro_crew/acp/client.py`: `"clientInfo": {"name": CLIENT_NAME, "version": CLIENT_VERSION}`
- `AcpRuntime` (buggy) — `src/kiro_crew/acp/runtime.py`: `"clientName": CLIENT_NAME, "clientVersion": CLIENT_VERSION`

`AcpProvider` routes **every non-Claude (kiro-cli) backend through `AcpRuntime`** (`src/kiro_crew/providers/acp.py`): main interactive/channel sessions, the background "lite" session, sub-agent spawns, the Code Review Sage worker pool, and all cron/monitor/workflow/remote-crew sessions. So the driving client name never reached kiro-cli on the primary path — those turns were recorded with **no `acpClientName`** and bucketed as `(none)` in telemetry instead of `kirocrew`. The only path that reported correctly is the Knowledge pool (it uses `AcpClient`), which is why adoption reports show a small non-zero `kirocrew` bucket next to a very large `(none)` bucket.

## Why it matters

This makes Kiro Crew adoption look far smaller than it is: the vast majority of kirocrew turns and installs are misattributed to the unnamed `(none)` ACP bucket, which simultaneously understates `kirocrew` and inflates `(none)`/"Others" in any report keyed on `acpClientName` (e.g. `metadata.kirocli_acpClientName` in the telemetry ES cluster).

## Fix

Nest the name under `clientInfo` in `AcpRuntime`'s initialize params, matching `AcpClient`:

```python
"clientInfo": {"name": CLIENT_NAME, "version": CLIENT_VERSION},
```

`CLIENT_NAME = "kirocrew"`. This moves the main interactive, background, sub-agent, Sage-pool, and cron/monitor/workflow/remote sessions out of `(none)` and into `kirocrew`. No other initialize field changes (`protocolVersion`, `clientCapabilities` unchanged).

## Tests

Adds a source-level regression test in `test/test_acp_client_capabilities.py` (the existing home for handshake-shape assertions, since neither params dict is reachable without spawning a real agent subprocess): asserts BOTH transports send `clientInfo.name` and that neither reintroduces the flat `clientName` key.

- `python3 -m py_compile` on both changed files — clean.
- Verified the new assertions hold against source (both files nest `clientInfo.name`; flat `clientName` is gone).
- Full pytest / isort / flake8 / mypy gate deferred to CI.

## Manual verification

Not yet exercised end-to-end against a live kiro-cli telemetry pipeline. The change only alters the JSON key under which the already-sent name/version travel, to the exact shape kiro-cli parses; behavior of the initialize handshake is otherwise unchanged (protocol version and capabilities untouched).

## Related

The reporting-side fixes for the same investigation are in kiro-team/kiro-cli#3971 (correct install-count aggregation + turn fan-out visibility). This PR fixes the root cause at the source: the misattribution that produced the low `kirocrew` counts that PR could only document.
