### PR TITLE
refactor(messaging): one mid-turn queue receipt, not two

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -189,8 +189,16 @@ steer/queue/drain machinery, `telegram/transport_dispatch.py` and
 `discord/transport_dispatch.py`; both read the same
 `messaging.queue_mode` (`config/loader.py`, `"steer"` | `"queue"`, anything
 else normalized to `steer`) and both implement the same three primitives
-(`_handle_busy`, `_enqueue_with_receipt` + `_drain_queue`, `_handle_stop`) with
-only the platform call names differing.
+(`_handle_busy`, `_enqueue_with_receipt` + `_drain_queue`, `_handle_stop`).
+
+The **channel-neutral half of the queue receipt is shared**, not duplicated:
+`messaging/queue_receipt.py` owns the receipt registry, the lock, the three
+lifecycle transitions and the receipt body formatting. Each channel reaches it
+through a `ReceiptSurface` whose address is bound at construction, which is why
+the shared module never sees a `chat_id` / `channel_id` / forum thread and
+Telegram's forum routing stays entirely channel-local. `_handle_busy` and
+`_drain_queue` deliberately stay per-channel: they re-enter their own
+`handle_message` and own the per-channel `_active_renderers`.
 
 The remaining channels (Webex, WeCom, Teams, Weixin) implement `_handle_busy`
 as **steer-only**: they fold the message into the running turn and reply with a
@@ -240,7 +248,7 @@ in place:
 ⏳ Queued (2): "what time is it" · "and the weather?"
 ```
 
-The first five items are listed verbatim (`_RECEIPT_MAX_ITEMS`), the rest
+The first five items are listed verbatim (`RECEIPT_MAX_ITEMS`), the rest
 collapse into `…and N more` so a large burst cannot blow the message cap.
 
 **The receipt is EDITED, never deleted.** At the end of the turn it flips to
@@ -249,8 +257,11 @@ Neither dispatcher calls a delete API on it. This is deliberate: the receipt is
 the durable record of what the user asked and how it was routed, so deleting it
 would erase the only evidence that a message was accepted at all.
 
-The enqueue and the receipt create/grow happen together under `_receipt_lock`,
-which the end-of-turn drain also takes across its dequeue plus flip. That is
+The enqueue and the receipt create/grow happen together under
+`ReceiptQueue.lock`, which the end-of-turn drain also takes across its dequeue
+plus flip. The lock is deliberately **caller-held** rather than acquired inside
+each transition (hence the `_locked` suffixes): moving the acquire inside would
+read tidier and silently reintroduce the orphaned-bubble race. That is
 what makes the two race-free: the drain sees either the message queued **with**
 its receipt or neither yet, never a half state that would orphan a bubble.
 `enqueue(..., force=False)` is a no-op once the semaphore is free, so if the
@@ -266,7 +277,7 @@ behind it** are re-enqueued so FIFO order stays exact, the receipt notes
 `+N deferred`, and the drain loops to pump the remainder. Messages arriving
 during the combined turn open a fresh receipt and drain after it.
 
-The combined turn itself runs outside `_receipt_lock`, and the drain replays via
+The combined turn itself runs outside `ReceiptQueue.lock`, and the drain replays via
 `handle_message(..., interpret_commands=False)`. Drained payloads therefore
 bypass both the command intercept and override parsing, so a queued `/new`
 reaches the model as literal text instead of executing on drain.
@@ -296,7 +307,7 @@ ported.
 
 `/stop` (alias `/cancel`; `!stop` / `!cancel` on Discord) aborts the running
 turn, drops every queued message, and finalizes the receipt to `🛑 Cancelled`.
-`clear_queue` and the receipt finalize run together under `_receipt_lock`.
+`clear_queue` and the receipt finalize run together under `ReceiptQueue.lock`.
 
 **Cancel is cooperative before it is fatal.** The dispatchers call
 `provider.cancel(wait_ack_timeout=0)`, which writes an ACP `session/cancel`

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -25,8 +25,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from kiro_crew.discord.attachments import (
     append_attachment_context,
@@ -66,6 +65,12 @@ if TYPE_CHECKING:
     from kiro_crew.history import ConversationLog
     from kiro_crew.session import SessionManager
 
+from kiro_crew.messaging.queue_receipt import STEER_ACK_EMOJI as _STEER_ACK_EMOJI
+from kiro_crew.messaging.queue_receipt import (
+    ReceiptQueue,
+    ReceiptSurface,
+)
+
 logger = logging.getLogger(__name__)
 
 # Canonical kiro-cli agent fallback so Discord sessions load kirocrew-core
@@ -103,44 +108,6 @@ Just send a message to chat. Replies stream in real-time.
 """
 
 
-def _short(text: str, limit: int = 40) -> str:
-    """Collapse whitespace and truncate for compact receipt display."""
-    collapsed = " ".join(text.split())
-    return collapsed if len(collapsed) <= limit else collapsed[: limit - 1] + "…"
-
-
-_RECEIPT_MAX_ITEMS = 5  # verbatim items in a receipt before "…and N more"
-# Instant, no-extra-bubble acknowledgement that a mid-turn steer was accepted
-# and folded into the running turn.
-_STEER_ACK_EMOJI = "🫡"
-
-
-def _receipt_text(
-    texts: list[str],
-    *,
-    answering: bool = False,
-    cancelled: bool = False,
-) -> str:
-    """Render the single collapsing receipt for ``texts`` (order preserved)."""
-    count = len(texts)
-    items = " · ".join(f"“{_short(t)}”" for t in texts[:_RECEIPT_MAX_ITEMS])
-    if count > _RECEIPT_MAX_ITEMS:
-        items += f" · …and {count - _RECEIPT_MAX_ITEMS} more"
-    if cancelled:
-        return f"🛑 Cancelled ({count}): {items}"
-    if answering:
-        return f"▶️ Now answering ({count}): {items}"
-    return f"⏳ Queued ({count}): {items}"
-
-
-@dataclass
-class _QueueReceipt:
-    """The single, in-place receipt bubble tracking messages queued mid-turn."""
-
-    msg_id: str
-    texts: list[str]
-
-
 class DiscordDispatcher:
     """Coordinates Discord turns onto the shared ``TurnDriver``.
 
@@ -173,10 +140,9 @@ class DiscordDispatcher:
         self.approval_mode = approval_mode
         self.client: "DiscordClient | None" = None
         self._conv = ConversationState(seed_fn=self._seed_gen)
-        # session_key -> the single in-place "queued" receipt bubble.
-        self._queue_receipts: dict[str, _QueueReceipt] = {}
-        # Serializes receipt bookkeeping against the end-of-turn drain.
-        self._receipt_lock = asyncio.Lock()
+        # The mid-turn queue receipt + the lock serializing it against the
+        # end-of-turn drain, shared with Telegram via messaging/queue_receipt.py.
+        self._queue = ReceiptQueue()
         # session_key -> the running turn's renderer (for steer chips).
         self._active_renderers: dict[str, DiscordRenderer] = {}
         self._session_resume = DiscordSessionResume(
@@ -560,7 +526,7 @@ class DiscordDispatcher:
                         logger.debug("discord: steer ack reaction failed", exc_info=True)
                 return
         # queue mode (or !queue override, or steer unavailable). Atomic
-        # enqueue + receipt under _receipt_lock — see the Telegram dispatcher.
+        # enqueue + receipt under self._queue.lock — see the Telegram dispatcher.
         if not await self._enqueue_with_receipt(
             session_key,
             channel_id,
@@ -583,7 +549,7 @@ class DiscordDispatcher:
             attachments: list[Any] = []
             remainder: list[tuple[str, str, dict]] = []
             defer_rest = False
-            async with self._receipt_lock:
+            async with self._queue.lock:
                 while True:
                     item = self.sessions.dequeue(session_key)
                     if item is None:
@@ -656,10 +622,10 @@ class DiscordDispatcher:
         attachments: list[Any] | None = None,
     ) -> bool:
         """Atomically enqueue a mid-turn message and create/grow its collapsing
-        receipt, under ``_receipt_lock``. Returns True if queued; False if the
+        receipt, under ``self._queue.lock``. Returns True if queued; False if the
         turn finished in the window (caller runs the message as a fresh turn)."""
         assert self.client is not None
-        async with self._receipt_lock:
+        async with self._queue.lock:
             if not self.sessions.enqueue(
                 session_key,
                 str(time.time()),
@@ -668,25 +634,11 @@ class DiscordDispatcher:
                 attachments=list(attachments or []),
             ):
                 return False
-            receipt_text = text or "[attachment]"
-            receipt = self._queue_receipts.get(session_key)
-            if receipt is None:
-                msg_id = await self.client.send_message(
-                    channel_id, _receipt_text([receipt_text])
-                )
-                if msg_id is not None:
-                    self._queue_receipts[session_key] = _QueueReceipt(
-                        msg_id=msg_id,
-                        texts=[receipt_text],
-                    )
-                return True
-            receipt.texts.append(receipt_text)
-            try:
-                await self.client.edit_message(
-                    channel_id, receipt.msg_id, _receipt_text(receipt.texts)
-                )
-            except Exception:
-                logger.debug("discord: queue receipt grow failed", exc_info=True)
+            # An attachment-only message has no text; show a placeholder rather
+            # than a blank entry in the receipt.
+            await self._queue.create_or_grow_locked(
+                session_key, self._receipt_surface(channel_id), text or "[attachment]"
+            )
             return True
 
     async def _receipt_flip_locked(
@@ -697,32 +649,37 @@ class DiscordDispatcher:
         deferred: int = 0,
     ) -> None:
         """Flip the receipt to a durable "▶️ Now answering" record. Caller MUST
-        hold ``_receipt_lock``."""
+        hold ``self._queue.lock``."""
         assert self.client is not None
-        receipt = self._queue_receipts.pop(session_key, None)
-        if receipt is None:
-            return
-        body = _receipt_text(answered, answering=True)
-        if deferred:
-            body += f" · +{deferred} deferred"
-        try:
-            await self.client.edit_message(channel_id, receipt.msg_id, body)
-        except Exception:
-            logger.debug("discord: queue receipt flip failed", exc_info=True)
+        await self._queue.flip_answering_locked(
+            session_key, self._receipt_surface(channel_id), answered, deferred
+        )
 
     async def _receipt_finish_cancelled_locked(self, session_key: str, channel_id: str) -> None:
         """Finalize the receipt to a "🛑 Cancelled" record, if present. Caller
-        MUST hold ``_receipt_lock``."""
+        MUST hold ``self._queue.lock``."""
         assert self.client is not None
-        receipt = self._queue_receipts.pop(session_key, None)
-        if receipt is None:
-            return
-        try:
-            await self.client.edit_message(
-                channel_id, receipt.msg_id, _receipt_text(receipt.texts, cancelled=True)
-            )
-        except Exception:
-            logger.debug("discord: queue receipt cancel-finalize failed", exc_info=True)
+        await self._queue.finish_cancelled_locked(
+            session_key, self._receipt_surface(channel_id)
+        )
+
+    def _receipt_surface(self, channel_id: str) -> ReceiptSurface:
+        """A receipt surface with this channel's address already bound."""
+        # cast, not assert: mypy does not carry an assert-narrowed local
+        # into the nested class body below, so the closure would still see
+        # ``DiscordClient | None``. The caller path always has a live client.
+        client = cast("DiscordClient", self.client)
+
+        class _Surface:
+            label = "discord"
+
+            async def send_receipt(self, body: str) -> Any | None:
+                return await client.send_message(channel_id, body)
+
+            async def edit_receipt(self, msg_id: Any, body: str) -> None:
+                await client.edit_message(channel_id, msg_id, body)
+
+        return _Surface()
 
     async def _handle_stop(self, user_id: str, channel_id: str, thread_id: str = "") -> None:
         """Hard cancel: abort the in-flight turn and clear everything."""
@@ -742,7 +699,7 @@ class DiscordDispatcher:
                         session_key,
                         exc_info=True,
                     )
-        async with self._receipt_lock:
+        async with self._queue.lock:
             self.sessions.clear_queue(session_key)
             await self._receipt_finish_cancelled_locked(session_key, channel_id)
         await self.client.send_message(

--- a/src/kiro_crew/messaging/queue_receipt.py
+++ b/src/kiro_crew/messaging/queue_receipt.py
@@ -1,0 +1,198 @@
+"""Mid-turn queue receipts — the single collapsing "⏳ Queued (N): …" bubble.
+
+A message that arrives while a turn is running is either folded into that turn
+as a steer or queued for after it. Queued messages get ONE receipt bubble that
+is edited in place as the burst grows, then flipped to a durable record when the
+turn drains it ("▶️ Now answering") or cancelled ("🛑 Cancelled"). Two channels
+grew the same subsystem independently -- Telegram and Discord, ~560 duplicated
+lines -- and this module is the half of it that is genuinely channel-neutral.
+
+What lives here and what does NOT:
+
+* HERE -- the receipt registry, its lock, and the three lifecycle transitions
+  (create/grow, flip-to-answering, finalize-cancelled). These are pure
+  bookkeeping over an opaque message id, and every line of them was identical
+  across the two channels apart from the address type and the send call.
+* NOT here -- ``_handle_busy`` and ``_drain_queue``. They re-enter the channel's
+  own ``handle_message`` (whose signature differs per channel: route/chat_id/
+  thread vs user_id/channel_id/thread_id) and they own the ``_active_renderers``
+  registry. Sharing them would need a ``run_turn`` callback that buys nothing
+  and couples this module to turn execution.
+
+Channels reach the transitions through :class:`ReceiptSurface`, whose address is
+bound at CONSTRUCTION -- so nothing below ever sees a ``chat_id``, a ``thread``
+or a ``channel_id``, which is what let the five address-shaped divergences
+between the two copies collapse to zero.
+
+Dependency direction is ``<channel> -> messaging`` (never the reverse), matching
+``messaging/dispatch.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+#: Verbatim items shown in a receipt before "…and N more". A large mid-turn
+#: burst would otherwise grow the rendered receipt past a channel's message
+#: limit; the count prefix still reflects the true total.
+RECEIPT_MAX_ITEMS = 5
+
+#: Instant, no-extra-bubble acknowledgement that a mid-turn steer was accepted
+#: and folded into the running turn (not merely "seen" — 👀 reads as passive).
+STEER_ACK_EMOJI = "🫡"
+
+
+def short(text: str, limit: int = 40) -> str:
+    """Collapse whitespace and truncate for compact receipt display."""
+    collapsed = " ".join(text.split())
+    return collapsed if len(collapsed) <= limit else collapsed[: limit - 1] + "…"
+
+
+def receipt_text(
+    texts: list[str],
+    *,
+    answering: bool = False,
+    cancelled: bool = False,
+) -> str:
+    """Render the single collapsing receipt for ``texts`` (order preserved).
+
+    Only the first :data:`RECEIPT_MAX_ITEMS` are listed verbatim; the count
+    prefix still reflects the true total.
+    """
+    count = len(texts)
+    items = " · ".join(f"“{short(t)}”" for t in texts[:RECEIPT_MAX_ITEMS])
+    if count > RECEIPT_MAX_ITEMS:
+        items += f" · …and {count - RECEIPT_MAX_ITEMS} more"
+    if cancelled:
+        return f"🛑 Cancelled ({count}): {items}"
+    if answering:
+        return f"▶️ Now answering ({count}): {items}"
+    return f"⏳ Queued ({count}): {items}"
+
+
+@dataclass
+class QueueReceipt:
+    """The single, in-place receipt bubble tracking messages queued mid-turn.
+
+    ``msg_id`` is deliberately opaque (``Any``): Telegram message ids are ints
+    and Discord's are strings, the two are never interleaved in one process, and
+    a generic parameter would add ceremony without catching a real mixup -- the
+    id is only ever handed straight back to the surface that produced it.
+    """
+
+    msg_id: Any
+    texts: list[str] = field(default_factory=list)
+
+
+class ReceiptSurface(Protocol):
+    """One conversation's receipt bubble, with its address already bound.
+
+    Implementations close over whatever addresses their channel needs (Telegram
+    binds ``chat_id`` AND the forum ``thread``; Discord binds ``channel_id``), so
+    forum routing and channel addressing stay entirely channel-local.
+    """
+
+    #: Channel name for log lines only ("telegram" / "discord").
+    label: str
+
+    async def send_receipt(self, body: str) -> Any | None:
+        """Post a new receipt bubble. Returns an opaque message id, or None."""
+
+    async def edit_receipt(self, msg_id: Any, body: str) -> None:
+        """Rewrite the receipt in place. May raise; the queue logs and continues."""
+
+
+class ReceiptQueue:
+    """Owns the per-session receipt registry, its lock, and the transitions.
+
+    The lock is deliberately CALLER-HELD and exposed as :attr:`lock` rather than
+    taken inside each method. Holding it across BOTH the enqueue and the receipt
+    bookkeeping is what makes the subsystem race-free against the end-of-turn
+    drain, which takes the same lock across dequeue + flip: the drain either sees
+    a message queued WITH its receipt or sees neither yet -- never a half state
+    that would orphan a bubble. ``/stop`` holds it across clear_queue + finalize
+    for the same reason. Hiding the lock inside these methods would silently
+    reintroduce that race, which is why the ``_locked`` suffixes stay in the
+    public names: ugly, and load-bearing.
+    """
+
+    def __init__(self) -> None:
+        self._receipts: dict[str, QueueReceipt] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def lock(self) -> asyncio.Lock:
+        """The lock callers MUST hold across compound operations (see class doc)."""
+        return self._lock
+
+    def has_receipt(self, session_key: str) -> bool:
+        """Whether a live receipt exists for this session."""
+        return session_key in self._receipts
+
+    async def create_or_grow_locked(
+        self, session_key: str, surface: ReceiptSurface, display_text: str
+    ) -> None:
+        """Create the receipt, or append to it and edit in place.
+
+        ``display_text`` is what the receipt SHOWS, which is not always the raw
+        message: Discord substitutes "[attachment]" for an attachment-only
+        message so the bubble is not blank. Caller MUST hold :attr:`lock`, and
+        MUST have already enqueued the message under that same hold.
+        """
+        receipt = self._receipts.get(session_key)
+        if receipt is None:
+            msg_id = await surface.send_receipt(receipt_text([display_text]))
+            if msg_id is not None:
+                self._receipts[session_key] = QueueReceipt(msg_id=msg_id, texts=[display_text])
+            return
+        receipt.texts.append(display_text)
+        try:
+            await surface.edit_receipt(receipt.msg_id, receipt_text(receipt.texts))
+        except Exception:
+            logger.debug("%s: queue receipt grow failed", surface.label, exc_info=True)
+
+    async def flip_answering_locked(
+        self,
+        session_key: str,
+        surface: ReceiptSurface,
+        answered: list[str],
+        deferred: int = 0,
+    ) -> None:
+        """Flip the receipt to a durable "▶️ Now answering" record.
+
+        Drops the live entry so the next mid-turn burst opens a fresh receipt.
+        ``answered`` is the subset this turn actually answers (the drain caps it),
+        so a burst past the cap does not overstate the turn; ``deferred`` (>0 only
+        past the cap) is noted so the remainder is not silently implied. Caller
+        MUST hold :attr:`lock` across dequeue + this call.
+        """
+        receipt = self._receipts.pop(session_key, None)
+        if receipt is None:
+            return
+        body = receipt_text(answered, answering=True)
+        if deferred:
+            body += f" · +{deferred} deferred"
+        try:
+            await surface.edit_receipt(receipt.msg_id, body)
+        except Exception:
+            logger.debug("%s: queue receipt flip failed", surface.label, exc_info=True)
+
+    async def finish_cancelled_locked(self, session_key: str, surface: ReceiptSurface) -> None:
+        """Finalize the receipt to a "🛑 Cancelled" record, if present.
+
+        Caller MUST hold :attr:`lock` across clear_queue + this call.
+        """
+        receipt = self._receipts.pop(session_key, None)
+        if receipt is None:
+            return
+        try:
+            await surface.edit_receipt(
+                receipt.msg_id, receipt_text(receipt.texts, cancelled=True)
+            )
+        except Exception:
+            logger.debug("%s: queue receipt cancel-finalize failed", surface.label, exc_info=True)

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -28,7 +28,7 @@ import html
 import logging
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from kiro_crew.acp.client import AcpError
 from kiro_crew.executors import run_in_embed_pool
@@ -73,6 +73,12 @@ if TYPE_CHECKING:
     from kiro_crew.session import SessionManager
     from kiro_crew.telegram.client import TelegramCallback, TelegramClient
 
+from kiro_crew.messaging.queue_receipt import STEER_ACK_EMOJI as _STEER_ACK_EMOJI
+from kiro_crew.messaging.queue_receipt import (
+    ReceiptQueue,
+    ReceiptSurface,
+)
+
 logger = logging.getLogger(__name__)
 
 # Canonical kiro-cli agent fallback so Telegram sessions load kirocrew-core
@@ -93,12 +99,6 @@ _MAX_COLLAPSE = 50
 _MAX_COLLAPSED_ATTACHMENTS = IngestLimits().max_attachments
 
 _HELP_TEXT = build_help_text()
-
-
-def _short(text: str, limit: int = 40) -> str:
-    """Collapse whitespace and truncate for compact receipt display."""
-    collapsed = " ".join(text.split())
-    return collapsed if len(collapsed) <= limit else collapsed[: limit - 1] + "…"
 
 
 # Hard cap for a user-visible failure reason: one short chat message, never a
@@ -136,44 +136,6 @@ def _user_safe_failure_reason(exc: BaseException) -> str | None:
     if len(text) > _FAILURE_REASON_MAX_CHARS:
         text = text[: _FAILURE_REASON_MAX_CHARS - 1].rstrip() + "…"
     return f"⚠️ {text}"
-
-
-_RECEIPT_MAX_ITEMS = 5  # verbatim items shown in a receipt before "…and N more"
-# Instant, no-extra-bubble acknowledgement that a mid-turn steer was accepted
-# and folded into the running turn (not merely "seen" — 👀 read as passive).
-# Must be one of Telegram's allowed reaction emojis (Bot API 7.0+).
-_STEER_ACK_EMOJI = "🫡"
-
-
-def _receipt_text(
-    texts: list[str],
-    *,
-    answering: bool = False,
-    cancelled: bool = False,
-) -> str:
-    """Render the single collapsing receipt for ``texts`` (order preserved).
-
-    Only the first ``_RECEIPT_MAX_ITEMS`` are listed verbatim (a large mid-turn
-    burst otherwise grows the rendered receipt past Telegram's limit); the count
-    prefix still reflects the true total.
-    """
-    count = len(texts)
-    items = " · ".join(f"“{_short(t)}”" for t in texts[:_RECEIPT_MAX_ITEMS])
-    if count > _RECEIPT_MAX_ITEMS:
-        items += f" · …and {count - _RECEIPT_MAX_ITEMS} more"
-    if cancelled:
-        return f"🛑 Cancelled ({count}): {items}"
-    if answering:
-        return f"▶️ Now answering ({count}): {items}"
-    return f"⏳ Queued ({count}): {items}"
-
-
-@dataclass
-class _QueueReceipt:
-    """The single, in-place receipt bubble tracking messages queued mid-turn."""
-
-    msg_id: int
-    texts: list[str]
 
 
 # How long a /model picker stays pressable, and how many pickers are retained.
@@ -228,13 +190,11 @@ class TelegramDispatcher:
         self.approval_mode = approval_mode
         self.client: "TelegramClient | None" = None
         self._conv = ConversationState(seed_fn=self._seed_gen)
-        # session_key -> the single in-place "queued" receipt bubble tracking
-        # messages that arrived mid-turn (collapsed into one record + one turn).
-        self._queue_receipts: dict[str, _QueueReceipt] = {}
-        # Serializes the check-then-send-then-store receipt bookkeeping so a
-        # burst of concurrently-dispatched mid-turn messages can't each post a
-        # fresh bubble and orphan the earlier one.
-        self._receipt_lock = asyncio.Lock()
+        # The mid-turn queue receipt: one in-place "queued" bubble per session,
+        # plus the lock that serializes check-then-send-then-store against the
+        # end-of-turn drain. Both now live in messaging/queue_receipt.py so
+        # Telegram and Discord cannot drift on the lock discipline.
+        self._queue = ReceiptQueue()
         # session_key -> the running turn's renderer, so a concurrent mid-turn
         # steer (handled in a separate _handle_busy task) can hand it the user's
         # typed steer text for the inline "↪️ steered: …" chip. Set on turn
@@ -621,7 +581,7 @@ class TelegramDispatcher:
                         logger.debug("telegram: steer ack reaction failed", exc_info=True)
                 return
         # queue mode (or /queue override, or steer unavailable). Enqueue + receipt
-        # happen atomically under ``_receipt_lock`` (see ``_enqueue_with_receipt``)
+        # happen atomically under ``self._queue.lock`` (see ``_enqueue_with_receipt``)
         # so the end-of-turn drain -- which takes the same lock to dequeue + flip
         # -- cannot interleave between the enqueue and the receipt and orphan a
         # bubble. If the turn finished in the window the message is not queued, so
@@ -646,7 +606,7 @@ class TelegramDispatcher:
         combined turn (order preserved, blank-line joined) and answer them
         together, rather than replaying each as a separate turn.
 
-        The dequeue + receipt flip run together under ``_receipt_lock`` so a
+        The dequeue + receipt flip run together under ``self._queue.lock`` so a
         concurrent mid-turn ``_enqueue_with_receipt`` (which takes the same lock)
         cannot interleave and leave an orphaned receipt. The combined turn itself
         runs OUTSIDE the lock -- messages that arrive during it open a fresh
@@ -662,7 +622,7 @@ class TelegramDispatcher:
             all_attachments: list[Any] = []
             remainder: list[tuple[str, str, dict]] = []
             defer_rest = False
-            async with self._receipt_lock:
+            async with self._queue.lock:
                 # Drain the ENTIRE queue under the lock, then split: the first
                 # _MAX_COLLAPSE messages collapse into this turn; the rest are
                 # re-enqueued IN ORIGINAL ORDER (the queue is now empty, so
@@ -735,6 +695,29 @@ class TelegramDispatcher:
 
     # ── Mid-turn queue receipt (single, in-place, persistent record) ───────
 
+    def _receipt_surface(self, chat_id: int, thread: int | None) -> ReceiptSurface:
+        """A receipt surface with this conversation's address already bound.
+
+        Binding ``chat_id`` AND the forum ``thread`` here is what keeps forum
+        routing out of the shared queue module: it never sees an address at all.
+        """
+        # cast, not assert: mypy does not carry an assert-narrowed local
+        # into the nested class body below, so the closure would still see
+        # ``TelegramClient | None``. The caller path always has a live client.
+        client = cast("TelegramClient", self.client)
+        reply = self._reply
+
+        class _Surface:
+            label = "telegram"
+
+            async def send_receipt(self, body: str) -> Any | None:
+                return await reply(chat_id, body, thread=thread)
+
+            async def edit_receipt(self, msg_id: Any, body: str) -> None:
+                await client.edit_message(chat_id, msg_id, body)
+
+        return _Surface()
+
     async def _enqueue_with_receipt(
         self,
         session_key: str,
@@ -745,7 +728,7 @@ class TelegramDispatcher:
         attachments: list[Any] | None = None,
     ) -> bool:
         """Atomically enqueue a mid-turn message and create/grow its collapsing
-        "⏳ Queued (N): …" receipt, under ``_receipt_lock``.
+        "⏳ Queued (N): …" receipt, under ``self._queue.lock``.
 
         Holding the lock across BOTH the enqueue and the receipt bookkeeping is
         what makes this race-free against the end-of-turn drain (which takes the
@@ -756,25 +739,15 @@ class TelegramDispatcher:
         caller runs the message as a fresh turn instead.
         """
         assert self.client is not None
-        async with self._receipt_lock:
+        async with self._queue.lock:
             if not self.sessions.enqueue(
                 session_key, str(time.time()), text, force=False,
                 attachments=list(attachments or []),
             ):
                 return False
-            receipt = self._queue_receipts.get(session_key)
-            if receipt is None:
-                msg_id = await self._reply(chat_id, _receipt_text([text]), thread=thread)
-                if msg_id is not None:
-                    self._queue_receipts[session_key] = _QueueReceipt(msg_id=msg_id, texts=[text])
-                return True
-            receipt.texts.append(text)
-            try:
-                await self.client.edit_message(
-                    chat_id, receipt.msg_id, _receipt_text(receipt.texts)
-                )
-            except Exception:
-                logger.debug("telegram: queue receipt grow failed", exc_info=True)
+            await self._queue.create_or_grow_locked(
+                session_key, self._receipt_surface(chat_id, thread), text
+            )
             return True
 
     async def _receipt_flip_locked(
@@ -782,7 +755,7 @@ class TelegramDispatcher:
     ) -> None:
         """Flip the receipt to a durable "▶️ Now answering" record and drop the
         live entry so the next mid-turn burst opens a fresh receipt. Caller MUST
-        hold ``_receipt_lock`` (the drain holds it across dequeue + flip).
+        hold ``self._queue.lock`` (the drain holds it across dequeue + flip).
 
         ``answered`` is the subset actually answered by this turn (capped at
         ``_MAX_COLLAPSE``); the count reflects it -- not the full queued list --
@@ -790,30 +763,17 @@ class TelegramDispatcher:
         (>0 only past the cap) is noted so the remainder isn't silently implied.
         """
         assert self.client is not None
-        receipt = self._queue_receipts.pop(session_key, None)
-        if receipt is None:
-            return
-        body = _receipt_text(answered, answering=True)
-        if deferred:
-            body += f" · +{deferred} deferred"
-        try:
-            await self.client.edit_message(chat_id, receipt.msg_id, body)
-        except Exception:
-            logger.debug("telegram: queue receipt flip failed", exc_info=True)
+        await self._queue.flip_answering_locked(
+            session_key, self._receipt_surface(chat_id, None), answered, deferred
+        )
 
     async def _receipt_finish_cancelled_locked(self, session_key: str, chat_id: int) -> None:
         """Finalize the receipt to a "🛑 Cancelled" record, if present. Caller
-        MUST hold ``_receipt_lock`` (/stop holds it across clear_queue + this)."""
+        MUST hold ``self._queue.lock`` (/stop holds it across clear_queue + this)."""
         assert self.client is not None
-        receipt = self._queue_receipts.pop(session_key, None)
-        if receipt is None:
-            return
-        try:
-            await self.client.edit_message(
-                chat_id, receipt.msg_id, _receipt_text(receipt.texts, cancelled=True)
-            )
-        except Exception:
-            logger.debug("telegram: queue receipt cancel-finalize failed", exc_info=True)
+        await self._queue.finish_cancelled_locked(
+            session_key, self._receipt_surface(chat_id, None)
+        )
 
     async def _handle_stop(self, route: tuple[str, str], chat_id: int) -> None:
         """Hard cancel: abort the in-flight turn and clear everything.
@@ -839,7 +799,7 @@ class TelegramDispatcher:
                     logger.warning(
                         "telegram /stop: cancel failed for %s", session_key, exc_info=True
                     )
-        async with self._receipt_lock:
+        async with self._queue.lock:
             self.sessions.clear_queue(session_key)
             await self._receipt_finish_cancelled_locked(session_key, chat_id)
         await self._reply(

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -54,10 +54,10 @@ from kiro_crew.discord.transport import (
 from kiro_crew.discord.transport_dispatch import (
     _STEER_ACK_EMOJI,
     DiscordDispatcher,
-    _receipt_text,
 )
 from kiro_crew.messaging.attachments import cleanup
 from kiro_crew.messaging.link import ChannelLink, legacy_dashboard_mirror_key
+from kiro_crew.messaging.queue_receipt import receipt_text as _receipt_text
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.session_map import ConversationOwnershipConflict
 

--- a/test/test_queue_receipt.py
+++ b/test/test_queue_receipt.py
@@ -1,0 +1,190 @@
+"""The shared mid-turn queue receipt: lifecycle, lock contract, and a ratchet.
+
+Telegram and Discord grew this subsystem independently and kept ~560 duplicated
+lines of it. The channel-neutral half now lives in
+``messaging/queue_receipt.py``; these tests pin the behaviour that used to be
+asserted twice (once per channel, in two files that could drift) and add the
+mechanism that stops a third channel from starting a third copy.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import kiro_crew.messaging.queue_receipt as Q
+from kiro_crew.messaging.queue_receipt import RECEIPT_MAX_ITEMS, ReceiptQueue, receipt_text
+
+
+class _Surface:
+    """Records what a channel would have put on the wire."""
+
+    label = "fake"
+
+    def __init__(self, *, send_id: Any = 7, edit_raises: bool = False) -> None:
+        self._send_id = send_id
+        self.edit_raises = edit_raises
+        self.sent: list[str] = []
+        self.edits: list[tuple[Any, str]] = []
+
+    async def send_receipt(self, body: str) -> Any | None:
+        self.sent.append(body)
+        return self._send_id
+
+    async def edit_receipt(self, msg_id: Any, body: str) -> None:
+        self.edits.append((msg_id, body))
+        if self.edit_raises:
+            raise RuntimeError("edit failed mid-flush")
+
+
+class TestReceiptText:
+    def test_queued_grows_with_the_count(self) -> None:
+        assert receipt_text(["a"]).startswith("⏳ Queued (1):")
+        assert receipt_text(["a", "b"]).startswith("⏳ Queued (2):")
+
+    def test_past_the_cap_the_tail_is_summarised_not_dropped(self) -> None:
+        texts = [f"m{i}" for i in range(RECEIPT_MAX_ITEMS + 3)]
+        out = receipt_text(texts)
+        # The count is the TRUE total even though only the cap is listed.
+        assert f"({len(texts)})" in out
+        assert "…and 3 more" in out
+
+    def test_the_three_states_are_distinguishable(self) -> None:
+        assert "Now answering" in receipt_text(["a"], answering=True)
+        assert "Cancelled" in receipt_text(["a"], cancelled=True)
+
+
+class TestLifecycle:
+    def test_create_then_grow_edits_one_bubble(self) -> None:
+        q, s = ReceiptQueue(), _Surface(send_id=42)
+
+        async def go() -> None:
+            async with q.lock:
+                await q.create_or_grow_locked("s", s, "first")
+                await q.create_or_grow_locked("s", s, "second")
+
+        asyncio.run(go())
+        assert len(s.sent) == 1, "a second message would orphan the first bubble"
+        assert s.edits == [(42, receipt_text(["first", "second"]))]
+
+    def test_flip_drops_the_entry_so_the_next_burst_opens_a_fresh_bubble(self) -> None:
+        q, s = ReceiptQueue(), _Surface()
+
+        async def go() -> None:
+            async with q.lock:
+                await q.create_or_grow_locked("s", s, "a")
+                await q.flip_answering_locked("s", s, ["a"])
+                assert not q.has_receipt("s")
+                await q.create_or_grow_locked("s", s, "b")
+
+        asyncio.run(go())
+        assert len(s.sent) == 2, "post-flip burst must start a NEW receipt"
+
+    def test_deferred_remainder_is_stated_not_implied(self) -> None:
+        q, s = ReceiptQueue(), _Surface()
+
+        async def go() -> None:
+            async with q.lock:
+                await q.create_or_grow_locked("s", s, "a")
+                await q.flip_answering_locked("s", s, ["a"], deferred=4)
+
+        asyncio.run(go())
+        assert "+4 deferred" in s.edits[-1][1]
+
+    def test_cancel_finalises_with_the_full_queued_list(self) -> None:
+        q, s = ReceiptQueue(), _Surface()
+
+        async def go() -> None:
+            async with q.lock:
+                await q.create_or_grow_locked("s", s, "a")
+                await q.create_or_grow_locked("s", s, "b")
+                await q.finish_cancelled_locked("s", s)
+
+        asyncio.run(go())
+        assert "Cancelled (2)" in s.edits[-1][1]
+        assert not q.has_receipt("s")
+
+    def test_a_failing_edit_never_escapes(self) -> None:
+        """Receipt upkeep is cosmetic; it must not fail the turn around it."""
+        q, s = ReceiptQueue(), _Surface(edit_raises=True)
+
+        async def go() -> None:
+            async with q.lock:
+                await q.create_or_grow_locked("s", s, "a")
+                await q.create_or_grow_locked("s", s, "b")  # edit raises
+                await q.flip_answering_locked("s", s, ["a", "b"])  # raises too
+
+        asyncio.run(go())  # must not raise
+
+    def test_a_send_that_returns_no_id_records_no_receipt(self) -> None:
+        """No id means no bubble to edit later -- storing one would 404 forever."""
+        q, s = ReceiptQueue(), _Surface(send_id=None)
+
+        async def go() -> None:
+            async with q.lock:
+                await q.create_or_grow_locked("s", s, "a")
+
+        asyncio.run(go())
+        assert not q.has_receipt("s")
+
+
+class TestLockIsCallerHeld:
+    def test_the_transitions_do_not_take_the_lock_themselves(self) -> None:
+        """The atomicity contract, asserted rather than documented.
+
+        Callers hold the lock ACROSS enqueue+receipt (and dequeue+flip), which is
+        what makes the subsystem race-free against the drain. If a future change
+        moved the acquire inside these methods, this deadlocks -- so the bounded
+        wait is the assertion, not a timeout guard.
+        """
+        q, s = ReceiptQueue(), _Surface()
+
+        async def go() -> None:
+            async with q.lock:
+                await asyncio.wait_for(q.create_or_grow_locked("s", s, "a"), timeout=2)
+                await asyncio.wait_for(q.flip_answering_locked("s", s, ["a"]), timeout=2)
+                await asyncio.wait_for(q.finish_cancelled_locked("s", s), timeout=2)
+
+        asyncio.run(go())
+
+
+def _dispatchers() -> list[Path]:
+    pkg = Path(Q.__file__).resolve().parent.parent
+    found = sorted(pkg.glob("*/transport_dispatch.py"))
+    assert len(found) >= 5, f"expected the dispatcher set, found {found}"
+    return found
+
+
+class TestRatchet:
+    def test_no_channel_keeps_its_own_receipt_registry_or_lock(self) -> None:
+        """A third copy of this subsystem must fail here, not in production."""
+        offenders: dict[str, list[str]] = {}
+        for path in _dispatchers():
+            src = path.read_text(encoding="utf-8")
+            tree = ast.parse(src)
+            names = {
+                node.attr
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Attribute) and node.attr in {
+                    "_queue_receipts",
+                    "_receipt_lock",
+                }
+            }
+            if names:
+                offenders[path.parent.name] = sorted(names)
+        assert not offenders, (
+            "these channels carry a private receipt registry/lock instead of the "
+            f"shared ReceiptQueue, so the lock discipline can drift again: {offenders}"
+        )
+
+    def test_every_channel_with_a_queue_uses_the_shared_one(self) -> None:
+        missing = []
+        for path in _dispatchers():
+            src = path.read_text(encoding="utf-8")
+            if "_enqueue_with_receipt" in src and "ReceiptQueue" not in src:
+                missing.append(path.parent.name)
+        assert not missing, (
+            f"{missing} implement a mid-turn queue without the shared ReceiptQueue"
+        )

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -2672,7 +2672,8 @@ class TestLinkCommand:
 def test_receipt_text_caps_displayed_items() -> None:
     # A large mid-turn burst must not grow the rendered receipt unbounded: only
     # the first _RECEIPT_MAX_ITEMS are listed verbatim; the count stays true.
-    from kiro_crew.telegram.transport_dispatch import _RECEIPT_MAX_ITEMS, _receipt_text
+    from kiro_crew.messaging.queue_receipt import RECEIPT_MAX_ITEMS as _RECEIPT_MAX_ITEMS
+    from kiro_crew.messaging.queue_receipt import receipt_text as _receipt_text
 
     texts = [f"msg number {i}" for i in range(_RECEIPT_MAX_ITEMS + 3)]
     out = _receipt_text(texts)


### PR DESCRIPTION
Telegram and Discord each grew the "⏳ Queued (N): …" mid-turn receipt
independently and kept ~560 duplicated lines of it. The half that is genuinely
channel-neutral now lives in `messaging/queue_receipt.py`; the two channels
reach it through a `ReceiptSurface` whose address is bound at construction.

The point is not the line count -- it is that the lock discipline had two
implementations. Holding the lock across BOTH the enqueue and the receipt
bookkeeping is what makes the subsystem race-free against the end-of-turn drain
(which takes the same lock across dequeue + flip): the drain either sees a
message queued WITH its receipt or sees neither, never a half state that orphans
a bubble. With two copies, a fix to that reasoning lands in one channel. The
`renderer.close()` guard was exactly this shape: Discord had it, Telegram did
not, and the fix had to be made twice.

What moved, and why the divergences vanished
--------------------------------------------
Measured before touching anything: 563 duplicated lines (Telegram 316, Discord
247), of which only 5 were byte-identical -- but the divergences were almost
entirely address-shaped. Exhaustively: the address type (`chat_id: int` plus a
forum `thread` vs `channel_id: str`), the initial send call (`_reply(...,
thread=)` vs `client.send_message`), the edit call's address, Discord's
`"[attachment]"` display fallback, the log prefix, and `msg_id: int` vs `str`.

Binding the address into `ReceiptSurface` at construction removes five of those
six at a stroke: nothing in the shared module ever sees an address, so forum
routing stays entirely channel-local. A `display_text` argument absorbs the
attachment fallback, and `msg_id` is opaque (`Any`) because the two id types are
never interleaved in one process.

What deliberately did NOT move
------------------------------
`_handle_busy` and `_drain_queue` (175 + 121 lines) stay per-channel. They
re-enter the channel's own `handle_message`, whose signature genuinely differs,
and they own `_active_renderers`. Sharing them would need a `run_turn` callback
that buys nothing and couples this module to turn execution. So the extractable
surface was 267 lines, not 563, and the net change is -83 lines -- the win is one
lock discipline, not a smaller repo.

The lock stays CALLER-HELD, exposed as `ReceiptQueue.lock` rather than taken
inside each transition, and the `_locked` suffixes stay in the public names.
Hiding the acquire inside the methods would read tidier and silently reintroduce
the orphaned-bubble race.

Tests
-----
`test/test_queue_receipt.py` pins the behaviour that used to be asserted twice:
create/grow edits ONE bubble, flip drops the entry so the next burst opens a
fresh one, the deferred remainder is stated rather than implied, a send that
returns no id records no receipt, and a failing edit never escapes (receipt
upkeep is cosmetic and must not fail the turn around it).

Two mechanisms beyond the happy path:

- `TestLockIsCallerHeld` asserts the atomicity contract instead of documenting
  it -- the transitions must not acquire the lock themselves, so a future change
  that moved the acquire inside would deadlock here.
- `TestRatchet` parses every dispatcher and fails if a channel carries a private
  `_queue_receipts` / `_receipt_lock`, or implements `_enqueue_with_receipt`
  without the shared `ReceiptQueue`. A third copy fails there, not in
  production.

Red-proof: reverting the grow branch reds 2 lifecycle tests; reintroducing a
private lock in one channel reds the ratchet.

Local gates: 2,719 tests across the telegram / discord / messaging / slack
surface, isort / flake8 / mypy all exit 0. Two defects in my own mechanical
edit were caught by those gates before commit -- an orphaned `@dataclass` left
by the block cut, and a closure that lost mypy's narrowing (fixed with an
explicit `cast`, since an `assert` does not carry into a nested class body).
