### PR TITLE
feat(skills): builtin theme-pack-authoring skill

### DIFF
--- a/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
+++ b/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: theme-pack-authoring
+description: Build, validate, and install Kiro Crew theme packs -- pack anatomy, the 43-variable palette, role-tagged fonts, the overrides.css allowlist (what installs vs what actually renders), and the install-verify cycle. Use when the user wants to create or edit a theme pack.
+triggers: theme pack, custom theme, theme.json, variables.json, overrides.css, install theme, theme font, dashboard theme, build a theme
+---
+
+# Kiro Crew theme-pack authoring
+
+House rules for building theme packs. The authoritative contract is
+[`website/docs/theming-contract.md`](https://github.com/kirodotdev/KiroCrew/blob/main/website/docs/theming-contract.md);
+this skill is the task-oriented digest, plus the traps that cost real
+debugging time.
+
+## Pack anatomy
+
+```
+my-theme/
+├── theme.json          # manifest: slug, name, emoji, level, formatVersion, fonts[]
+├── variables.json      # dark + light palettes (43 allowlisted CSS vars)
+├── readme.md           # optional; attribution and notes
+├── styles/
+│   ├── overrides.css   # optional; scoped structural CSS (see allowlist below)
+│   └── fonts/          # .woff2 / .ttf files, max 6 faces, 512 KB each
+└── LICENSE.txt         # validates as meta, is NOT copied into the install
+```
+
+Levels: **0** = colors only. **1** = + fonts, branding, overrides.css. **2** = +
+overlays/topbar/audio/persona. Declare the lowest level that covers the payload —
+a level-0 pack shipping a font is refused.
+
+## theme.json — complete working example
+
+```json
+{
+  "slug": "my-theme",
+  "name": "My Theme",
+  "emoji": "🎨",
+  "level": 1,
+  "formatVersion": 1,
+  "fonts": [
+    { "family": "My Sans", "file": "my-sans-400.woff2", "weight": 400, "role": "sans" },
+    { "family": "My Sans", "file": "my-sans-500.woff2", "weight": 500, "role": "sans" },
+    { "family": "My Sans", "file": "my-sans-600.woff2", "weight": 600, "role": "sans" },
+    { "family": "My Mono", "file": "my-mono-400.woff2", "weight": 400, "role": "mono" }
+  ]
+}
+```
+
+## Fonts — the role system (the ONLY supported route)
+
+- Each face carries `role: "sans"` or `"mono"`. Absent role = `sans`.
+- `sans` faces feed the **Sans** Font Family option; `mono` faces feed **Mono**
+  AND code surfaces (code blocks, inline code, diffs) under every option.
+- **System always stays the OS font** — a pack cannot reach it. Unfilled roles
+  fall back to Kiro Crew's own stacks.
+- Max **6 faces across both roles**; pick weights deliberately. The UI uses
+  400/500/600/700; with 3 sans slots ship 400/500/600 (`font-bold` resolves to
+  600, acceptable; 400/500/700 makes the many semibold elements render heavy).
+- CJK/Devanagari/Bengali fallbacks are wired automatically — the generated
+  stacks carry the script-fallback aliases. Latin-only faces are fine.
+- **Never set fonts in overrides.css.** `--font-body`, `--mono`, the
+  `--theme-font-*` tokens, or `font`/`font-family` on `body`/`html`/`*`/`:root`
+  are rejected at install and dropped at runtime (CSS-escape evasions included).
+  A `font-family` on ONE allowlisted surface (e.g. `.topbar`) is fine.
+- Ship the font's license file in the pack source (OFL/Apache/MIT).
+- KNOWN TRAP: a wrong role *string* (e.g. `"monospace"`) silently coerces to
+  `sans` — the mono face lands on the Sans option.
+
+## variables.json — the palette
+
+Two blocks, `dark` and `light`, each holding up to **43 allowlisted variables**.
+Required minimum per block: `--bg`, `--text`, `--accent`. Unknown keys are
+REJECTED (install fails), so do not invent variables; the allowlist is
+`_THEME_CSS_VARS` in `src/kiro_crew/dashboard/theme_validate.py`.
+
+- To clone a built-in theme's palette, transcribe its block from
+  `website/src/index.css` (e.g. `[data-theme="kiro-dark"]`), keeping only
+  allowlisted vars.
+- Five commonly-wanted vars are NOT in the allowlist: `--accent-fg` and the four
+  `--json-*` highlight colors. Patch them via overrides.css on the pack's own
+  scoped body selector — legal (not a font, `body` is allowlisted):
+
+```css
+[data-theme="custom-my-theme-dark"] body {
+  --accent-fg: #ffffff;
+  --json-key: #b07fff; --json-str: #7ee787; --json-num: #c19aff; --json-bool: #f94359;
+}
+```
+
+## overrides.css — what installs is NOT what renders
+
+Two different filters run, and they disagree by design:
+
+- **Install** = denylist. Refuses known-bad: `@import`, external `url()`,
+  `expression()`, font pins, `display:none`, viewport-covering `position:fixed`,
+  `z-index` > 9999, selectors touching `iframe`/`script`/`.token`/`[data-auth]`.
+- **Runtime** = allowlist, the real boundary. Only rules targeting these
+  surfaces survive; EVERYTHING else is silently dropped at apply time:
+  `body` (and `body::before/::after`), `button.primary`, `.topbar`, `.sidebar`,
+  `.chat-container`, `.message-bubble`, `.input-area`, `.code-block`.
+  No descendant/child/sibling combinators, no ids, no attribute selectors
+  (one leading `[data-theme="…"]` scoping prefix is allowed and stripped).
+
+Consequence: a rule can pass install and never render. The browser console
+lists any rules the runtime dropped from the active theme (`[theme]
+overrides.css: dropped …`), and builds with the Settings notice show the same
+list under the theme selector in Settings → Display. If a rule you wrote has no
+effect, check there BEFORE suspecting specificity.
+
+## Validate and install
+
+**Install IS the validator.** Install via Settings → Display → Install theme
+(local folder path or a `github.com` repo URL). A refusal message names exactly
+what to change; re-install overwrites, which is the update path. Iterate by
+editing the pack source and re-installing — do not hand-edit the installed copy
+under the data directory, which bypasses validation.
+
+In a Kiro Crew dev checkout, `_validate_theme_dir(pack_dir, installing=True)`
+from `kiro_crew.dashboard.theme_validate` runs the same check programmatically.
+
+## Verify like you mean it
+
+- Toggle a built-in theme vs your pack on the same screen — an A/B flip beats
+  memory.
+- Check: the chat transcript (body face), small accent badges (bold weight), a
+  message with inline code and a link, a JSON payload (the `--json-*` patch),
+  primary buttons (`--accent-fg`), Sans/Mono/System switching in Settings, and
+  the dropped-rules notice staying absent.

--- a/test/test_theme_authoring_skill.py
+++ b/test/test_theme_authoring_skill.py
@@ -1,0 +1,83 @@
+"""The theme-pack-authoring skill's restated contract facts must track the code.
+
+The skill is a distributed digest of the theming contract: it is synced into
+every user's skills directory, so any enumeration it restates (variable count,
+runtime surface allowlist, font caps) becomes what agents worldwide believe.
+Restated counts go stale silently — the same failure mode AGENTS.md pins its
+denied-rule count for — so every number and list the skill hardcodes is
+asserted here against the owning constants in ``theme_validate.py`` and
+``themeCss.ts``. When an allowlist changes, this test fails and points at the
+skill line to update, instead of every theme author hitting the silent
+drop this skill exists to prevent.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from kiro_crew.dashboard.theme_validate import (
+    _THEME_CSS_VARS,
+    _THEME_MAX_FONTS,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILL = ROOT / "src" / "kiro_crew" / "builtin_skills" / "theme-pack-authoring" / "SKILL.md"
+THEME_CSS_TS = ROOT / "website" / "src" / "hooks" / "themeCss.ts"
+
+
+def _skill_text() -> str:
+    return SKILL.read_text(encoding="utf-8")
+
+
+def _frontend_allowed_classes() -> set[str]:
+    """The runtime scoper's surface allowlist, parsed from its owning constant."""
+    src = THEME_CSS_TS.read_text(encoding="utf-8")
+    m = re.search(r"_ALLOWED_CLASSES = new Set\(\[(.*?)\]\)", src, re.S)
+    assert m, "themeCss.ts no longer defines _ALLOWED_CLASSES — update this test AND the skill"
+    return set(re.findall(r"'([^']+)'", m.group(1)))
+
+
+def test_variable_count_matches_validator() -> None:
+    """The '43-variable palette' claim tracks _THEME_CSS_VARS."""
+    n = len(_THEME_CSS_VARS)
+    text = _skill_text()
+    assert f"{n} allowlisted variables" in text and f"{n}-variable palette" in text, (
+        f"theme_validate._THEME_CSS_VARS now has {n} entries; update the counts in "
+        f"{SKILL.relative_to(ROOT)}"
+    )
+
+
+def test_font_cap_matches_validator() -> None:
+    """'max 6 faces' tracks _THEME_MAX_FONTS."""
+    assert f"max {_THEME_MAX_FONTS} faces" in _skill_text().replace("**", ""), (
+        f"theme_validate._THEME_MAX_FONTS is now {_THEME_MAX_FONTS}; update the cap in "
+        f"{SKILL.relative_to(ROOT)}"
+    )
+
+
+def test_surface_allowlist_matches_runtime_scoper() -> None:
+    """Every class surface the scoper allows is named in the skill, and the skill
+    names no class surface the scoper does not allow.
+
+    ``body`` / ``button.primary`` are element-level allowances handled separately
+    in themeCss.ts; the class list is the part that drifts.
+    """
+    text = _skill_text()
+    allowed = _frontend_allowed_classes()
+    for cls in allowed:
+        assert f"`.{cls}`" in text, (
+            f"scoper allows .{cls} but the skill does not list it; update "
+            f"{SKILL.relative_to(ROOT)}"
+        )
+    # The skill's overrides.css section must not name class surfaces beyond the
+    # scoper's set (plus the element-level body/button.primary allowances and
+    # the classes it cites as explicitly forbidden, e.g. `.token`).
+    src = THEME_CSS_TS.read_text(encoding="utf-8")
+    fm = re.search(r"_FORBIDDEN_CLASSES = new Set\(\[(.*?)\]\)", src, re.S)
+    forbidden = set(re.findall(r"'([^']+)'", fm.group(1))) if fm else set()
+    section = text.split("## overrides.css", 1)[1].split("## ", 1)[0]
+    named = set(re.findall(r"`\.([a-z-]+)`", section))
+    assert named <= allowed | forbidden, (
+        f"skill names surfaces the scoper does not allow: {sorted(named - allowed - forbidden)}"
+    )


### PR DESCRIPTION
## Problem

Theme packs have an authoring contract (`website/docs/theming-contract.md`) but no skill, so every agent session that builds a pack re-derives the format from docs and validator source — and reliably trips the same traps: fonts pinned in `overrides.css` (the documented anti-pattern), invented `variables.json` keys (install refuses unknown vars), and rules that pass install but never render (the install-denylist / runtime-allowlist split).

## Why it matters

Theme packs are a third-party surface — installable from a GitHub URL — and the authoring loop's failure modes are silent by design (graceful degradation at a security boundary). A skill that front-loads the boundaries turns each of those debugging sessions into following a checklist, for every Kiro Crew user's agent, not just sessions that happen to have the history.

## Fix

One stateless builtin skill at `src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md`, synced to users by `_ensure_builtin_skills` like the existing sixteen. Content is the task-oriented digest of the theming contract: pack anatomy, a complete role-tagged `theme.json`, palette rules including the allowlist-gap patch for `--accent-fg`/`--json-*`, the install-vs-runtime filter split with the exact 10-surface allowlist, install-as-validator iteration, and a verification checklist. Where the skill and the contract disagree, the contract governs — the skill links it as the authority.

## Tests

`test/test_theme_authoring_skill.py` (new, per Design Review): drift-guards every enumeration the skill restates against the owning constants — the palette variable count vs `_THEME_CSS_VARS`, the font cap vs `_THEME_MAX_FONTS`, and the runtime surface list vs `_ALLOWED_CLASSES`/`_FORBIDDEN_CLASSES` in `themeCss.ts` (both directions: every allowed class is named, no non-allowed class is taught). When an allowlist changes, the failure names the skill line to update. The suites that scan `builtin_skills/` also pass with the skill present: `test_brand_name_gate.py` + `test_skills.py` (210 tests locally).

## Manual verification

The skill body was authored from a real pack-building session (a full font-carrying L1 pack built, validated against `_validate_theme_dir`, installed, and iterated), so each gotcha it lists was hit in practice, not speculated.

## Screenshots

N/A — no UI change.

Related: #2883 (Settings notice for scoper-dropped rules; the skill references the console diagnostic unconditionally and the Settings notice conditionally, so neither PR depends on the other's merge order).
