### PR TITLE
perf(dashboard): read slot state at keypress time, not by subscribing

### DIFF
--- a/website/src/hooks/useKeyboardShortcuts.ts
+++ b/website/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useAppDispatch, useAppSelector } from '../store'
+import { useAppDispatch, useAppStore } from '../store'
 import { switchSlot, deleteSlot, openActivityToTab } from '../store/chatSlice'
 import { loadChatConfig } from '../pages/chat/ChatSettings'
 import { reportSeamCollision } from '../apps/seamCollision'
@@ -449,9 +449,7 @@ interface UseKeyboardShortcutsOpts {
 export function useKeyboardShortcuts({ onToggleShortcutsModal, onNewChat, onCycleAgent, onCyclePrevAgent, onCycleReasoningEffort, onCyclePrevReasoningEffort, onCycleApprovalMode, onCyclePrevApprovalMode, onCycleModel, onCyclePrevModel, disabled }: UseKeyboardShortcutsOpts) {
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
-  const slots = useAppSelector(s => s.dashboard.slots)
-  const activeSlot = useAppSelector(s => s.chat.activeSlot)
-  const slotHistory = useAppSelector(s => s.chat.slotHistory)
+  const appStore = useAppStore()
   const mruIndexRef = useRef(-1)
   // Set true right after a char-producing Alt shortcut (Alt+`) fires inside a
   // text field. On macOS those combos are dead keys (Option+` = grave accent),
@@ -498,6 +496,8 @@ export function useKeyboardShortcuts({ onToggleShortcutsModal, onNewChat, onCycl
   const handler = useCallback((e: KeyboardEvent) => {
     const tag = (e.target as HTMLElement)?.tagName
     const isInput = tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement)?.isContentEditable
+    // Read at keypress time; subscribing re-renders the root on every slots frame.
+    const { dashboard: { slots }, chat: { activeSlot, slotHistory } } = appStore.getState()
 
     // On Mac (when Ctrl+digit mode enabled), Ctrl+digit switches chats.
     // Check for that first, before the Alt-based gate.
@@ -685,7 +685,7 @@ export function useKeyboardShortcuts({ onToggleShortcutsModal, onNewChat, onCycl
       navigate(panelMap[code])
       return
     }
-  }, [dispatch, navigate, slots, activeSlot, slotHistory, onToggleShortcutsModal, onNewChat, onCycleAgent, onCyclePrevAgent, onCycleReasoningEffort, onCyclePrevReasoningEffort, onCycleApprovalMode, onCyclePrevApprovalMode, onCycleModel, onCyclePrevModel, disabled, enabled, ctrlDigits])
+  }, [dispatch, navigate, appStore, onToggleShortcutsModal, onNewChat, onCycleAgent, onCyclePrevAgent, onCycleReasoningEffort, onCyclePrevReasoningEffort, onCycleApprovalMode, onCyclePrevApprovalMode, onCycleModel, onCyclePrevModel, disabled, enabled, ctrlDigits])
 
   useEffect(() => {
     document.addEventListener('keydown', handler)

--- a/website/src/store/index.ts
+++ b/website/src/store/index.ts
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch, useSelector, useStore } from 'react-redux'
 import dashboardReducer from './dashboardSlice'
 import notificationsReducer from './notificationsSlice'
 import chatReducer from './chatSlice'
@@ -16,5 +16,7 @@ export const store = configureStore({
 
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch
+export type AppStore = typeof store
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>()
 export const useAppSelector = useSelector.withTypes<RootState>()
+export const useAppStore = useStore.withTypes<AppStore>()

--- a/website/src/test/App.rootSelectorScope.test.tsx
+++ b/website/src/test/App.rootSelectorScope.test.tsx
@@ -10,8 +10,8 @@
  * per-render counter. A `<Profiler>` counts subtree commits instead, which a child that
  * legitimately subscribes would be indistinguishable from.
  *
- * A slots frame is deliberately not asserted: `useKeyboardShortcuts`, called from the
- * root's own body, selects `dashboard.slots` independently, so it re-renders either way.
+ * A slots frame is asserted too, and is the high-frequency case: `sseSlots` assigns a new
+ * array on every websocket frame, so a reference-equality subscription re-renders forever.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { act, cleanup, screen, waitFor } from '@testing-library/react'
@@ -196,5 +196,20 @@ describe('App root store subscription scope', () => {
 
     expect(delta).toBeGreaterThan(0)
     expect(store.getState().dashboard.updateProgress).toEqual({ step: 'download', detail: 'fetching' })
+  })
+
+  it('does not re-render the root on a slots frame', async () => {
+    const { store } = await mountSettled()
+
+    // Control: nothing is dispatched, so a non-zero count here is background work.
+    expect(await rendersDuring(() => {})).toBe(0)
+
+    // `sseSlots` assigns a new array and rebuilds `slotHistory`, so both go reference-unequal.
+    const delta = await rendersDuring(() => {
+      store.dispatch(sseSlots([slot('chat-1-1', 2), slot('chat-1-2', 0)]))
+    })
+
+    expect(store.getState().dashboard.slots).toHaveLength(2)
+    expect(delta).toBe(0)
   })
 })


### PR DESCRIPTION
## What

`useKeyboardShortcuts` is called from the app root's own body, and it selected three things with `useAppSelector`: `dashboard.slots`, `chat.activeSlot` and `chat.slotHistory`. Because the hook runs in the root's body, those subscriptions belong to the root — so a store change to any of them re-renders the whole root.

All three are read only inside the keydown handler. Nothing reads them during render, and no `useMemo`/`useEffect` dependency needs them. So the hook now takes the store via `useStore()` and reads the three values at keypress time instead of subscribing.

## Why it re-rendered the root

`sseSlots` assigns a brand-new array (`state.slots = action.payload`), and slots frames arrive continuously over the websocket, so `dashboard.slots` is reference-unequal on every frame. `useAppSelector` is `useSelector` with reference equality, so the root re-rendered on every frame even though nothing it displays changed.

`chat.slotHistory` is a second trigger on the same frame, which is easy to miss: the `sseSlots` case in the chat slice ends with `state.slotHistory = (state.slotHistory ?? []).filter(...)`, and `.filter()` always returns a new array. Narrowing only `slots` would therefore not have moved the render count — both subscriptions had to go.

`chat.activeSlot` is not a slots-frame trigger (the reducer only adds it to a local set, never assigns it), but it is read in the same handler, so it moved with the other two rather than being left as the sole remaining subscription.

Secondary effect: the handler's `useCallback` listed all three as dependencies, so its identity changed on every frame and the `useEffect` below it removed and re-added the `document` keydown listener each time. With them gone, the listener is registered once.

## Render counts

Counting renders of `App` itself, on a slots frame:

| | renders |
| --- | --- |
| before this change | 1 |
| after this change | 0 |

Both measured by running the same new assertion against unchanged and changed production code. Against unchanged code it fails with `expected 1 to be +0`; with the change it passes at 0. The no-dispatch control in the same test passes at 0 in both directions, so the 1 is the dispatch rather than unsettled mount work.

No latency, frame-rate or CPU numbers are claimed — render counts are what was measured.

## The test

`App.rootSelectorScope.test.tsx` already counted renders of the root by wrapping `useTerminalPoppedOut`, which the root calls exactly once, unconditionally, and which is imported nowhere else — an exact per-render counter. Its header previously recorded the slots case as deliberately unassertable, naming this hook as the reason; this change flips that and asserts it.

The new case dispatches a real `sseSlots` frame that differs in both content and length, asserts the store actually took it (`slots` has length 2, so the dispatch is not a no-op), and asserts the root render delta is 0.

## `useStore()` rather than importing the store

`App.tsx` already reads `store.getState().dashboard.slots` in shortcut-adjacent callbacks using the module singleton, so reading at handler time matches the neighbouring code. But the singleton is the wrong store under test: the test helpers build a fresh store per test, and `useKeyboardShortcuts.test.tsx` seeds slots into that store and passes it through the `Provider`. A singleton read would see an empty store and break every slot-switching assertion in that file.

`useStore()` reads the store from React context, so it is the singleton in the app and the test store under test. It is added as a typed `useAppStore` next to the existing `useAppDispatch`/`useAppSelector`. `shallowEqual` would not have worked here — it compares the array too, and that array is exactly what changes.

## Checks

- Full frontend suite before: 970 files, 15564 passed, 2 expected fail, 3 skipped (15569 total).
- Full frontend suite after: 970 files, 15565 passed, 2 expected fail, 3 skipped (15570 total). The delta is exactly the one test case added here.
- 7 shortcut-related files re-run together (156 tests, all passing), so shortcut behaviour is unchanged.
- `tsc -b --force` clean. (`npm run typecheck` is `tsc --noEmit`, which does not build the project references and so checks nothing — the build form was used instead.)
- `eslint src` — 0 errors; the three changed files produce no output at all, including no `react-hooks/exhaustive-deps` warning on the reduced dependency list.
- Repo scrub self-test passes (all six planted markers detected), then the scrub itself passes.
