### PR TITLE
fix(channels): record resolved agent in session metadata on channel transport writes

### DIFF
--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -467,6 +467,7 @@ class DiscordDispatcher:
                     accumulated,
                     is_new_own_session,
                     mirrored,
+                    agent=agent,
                 )
             except Exception:
                 logger.warning(
@@ -1129,6 +1130,7 @@ class DiscordDispatcher:
         reply_text: str,
         is_new: bool,
         mirrored: bool = False,
+        agent: str | None = None,
     ) -> None:
         """Record the turn to conversation_log (dashboard visibility + restart).
 
@@ -1139,13 +1141,13 @@ class DiscordDispatcher:
         if self.conv_log is None:
             return
         if mirrored:
-            self.conv_log.append_if_absent(session_key, "user", user_text)
+            self.conv_log.append_if_absent(session_key, "user", user_text, agent=agent)
             if reply_text:
-                self.conv_log.append_if_absent(session_key, "assistant", reply_text)
+                self.conv_log.append_if_absent(session_key, "assistant", reply_text, agent=agent)
         else:
-            self.conv_log.append(session_key, "user", user_text)
+            self.conv_log.append(session_key, "user", user_text, agent=agent)
             if reply_text:
-                self.conv_log.append(session_key, "assistant", reply_text)
+                self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "Discord"
             self.conv_log.set_title(session_key, title)

--- a/src/kiro_crew/slack/transport_dispatch.py
+++ b/src/kiro_crew/slack/transport_dispatch.py
@@ -214,6 +214,21 @@ async def handle_message_transport(
     _hydrate_thread_overrides(session_key, conversation_log)
     _hydrate_conv_flags(sessions, session_key)
 
+    # Resolve the agent early so ALL persist paths can forward it — including
+    # the hook auto-reply below, whose write CREATES the session file when a
+    # hook answers the first message in a thread (the metadata header records
+    # the agent only on the creating append, so a missed site pins the session
+    # to "default" forever). Mirrors native handle_message, which resolves
+    # _agent right after hydration for exactly this reason. Re-resolved again
+    # at session acquisition below, after the late ownership re-resolution can
+    # move session_key.
+    _agent = (
+        _thread_agents.get(session_key)
+        or agent_override
+        or _get_default_agent()
+        or _DEFAULT_KIROCREW_AGENT
+    )
+
     # Entry marker: lets operators confirm the NEW transport path handled a
     # message (grep gateway.log for "transport_dispatch: handling"). Fires for
     # every message including the status/ping shortcuts below.
@@ -243,6 +258,7 @@ async def handle_message_transport(
                     hook_result.text,
                     source_thread=session_key,
                     source_user=user_id,
+                    agent=_agent,
                 )
             return
 
@@ -378,7 +394,10 @@ async def handle_message_transport(
             # renderer and driver hold, so re-pointing it here is sufficient.
             decider.session_key = session_key
 
-        # Resolve the kiro-cli agent. Thread override (set via !agent), then the
+        # Re-resolve the kiro-cli agent: the early resolution above serves the
+        # pre-acquisition persist paths (hook auto-reply), but the ownership
+        # re-resolution just above can move session_key, and a !agent override
+        # may have landed since. Thread override (set via !agent), then the
         # per-channel override (slack.channels.<id>.agent), then the configured
         # default win; otherwise fall back to the canonical "kirocrew" agent so
         # the session loads kirocrew-core (spawn_run) rather than kiro-cli's bare
@@ -466,6 +485,12 @@ async def handle_message_transport(
                     text,
                     source_thread=session_key,
                     source_user=user_id,
+                    # This is the write that creates the session file, and the
+                    # metadata header records the agent only when the creating
+                    # append supplies it — omit it and the dashboard forever
+                    # shows this session as "default" even though the turn ran
+                    # under ``_agent`` (see ConversationLog.append docstring).
+                    agent=_agent,
                 )
                 _logged_user_turn = True
             except Exception:
@@ -571,6 +596,7 @@ async def handle_message_transport(
                             final_text,
                             source_thread=session_key,
                             source_user=user_id,
+                            agent=_agent,
                         )
                         return _log.last_row_ts(session_key)
 
@@ -583,6 +609,12 @@ async def handle_message_transport(
                     final_text,
                     source_thread=session_key,
                     source_user=user_id,
+                    # This branch runs exactly when the user-turn receipt write
+                    # failed, so THIS write is the one that creates the session
+                    # file — without the agent the metadata header pins the
+                    # session to "default" forever (same reasoning as the
+                    # receipt write above).
+                    agent=_agent,
                 )
             _stamped_turn = True
             # The asker is the conversation that RAN this turn. Resolving the
@@ -691,6 +723,7 @@ async def handle_message_transport(
                             accumulated,
                             source_thread=session_key,
                             source_user=user_id,
+                            agent=_agent,
                         )
                 else:
                     await save_conversation_turn_off_loop(
@@ -700,6 +733,7 @@ async def handle_message_transport(
                         accumulated,
                         source_thread=session_key,
                         source_user=user_id,
+                        agent=_agent,
                     )
                 await _refresh_dashboard_tab(session_key)
         except Exception:

--- a/src/kiro_crew/teams/transport_dispatch.py
+++ b/src/kiro_crew/teams/transport_dispatch.py
@@ -164,7 +164,7 @@ class TeamsDispatcher:
                 approval_mode=self.approval_mode,
                 decider=None,  # Teams can't render approve/deny buttons (MVP)
                 persist=lambda user_text, reply, is_new: self._persist_turn(
-                    session_key, user_text, reply, is_new
+                    session_key, user_text, reply, is_new, agent
                 ),
                 notice=lambda sk, provider: self._maybe_notice(inbound, sk, provider),
                 audit_caller=f"teams:{email}",
@@ -232,14 +232,19 @@ class TeamsDispatcher:
         )
 
     def _persist_turn(
-        self, session_key: str, user_text: str, reply_text: str, is_new: bool
+        self,
+        session_key: str,
+        user_text: str,
+        reply_text: str,
+        is_new: bool,
+        agent: str | None = None,
     ) -> None:
         """Record the turn to conversation_log (dashboard visibility + restart)."""
         if self.conv_log is None:
             return
-        self.conv_log.append(session_key, "user", user_text)
+        self.conv_log.append(session_key, "user", user_text, agent=agent)
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text)
+            self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "Teams"
             self.conv_log.set_title(session_key, title)

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -504,7 +504,7 @@ class TelegramDispatcher:
             # fall through to the except and re-record the successful turn). ──
             self.sessions.record_success(session_key)
             try:
-                await asyncio.to_thread(self._persist_turn, session_key, text, accumulated, is_new)
+                await asyncio.to_thread(self._persist_turn, session_key, text, accumulated, is_new, agent)
             except Exception:
                 logger.warning(
                     "Telegram: persist_turn failed session=%s", session_key, exc_info=True
@@ -1547,14 +1547,19 @@ class TelegramDispatcher:
         await self._reply(chat_id, reply, thread=self._route_thread(route))
 
     def _persist_turn(
-        self, session_key: str, user_text: str, reply_text: str, is_new: bool
+        self,
+        session_key: str,
+        user_text: str,
+        reply_text: str,
+        is_new: bool,
+        agent: str | None = None,
     ) -> None:
         """Record the turn to conversation_log (dashboard visibility + restart)."""
         if self.conv_log is None:
             return
-        self.conv_log.append(session_key, "user", user_text)
+        self.conv_log.append(session_key, "user", user_text, agent=agent)
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text)
+            self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "Telegram"
             self.conv_log.set_title(session_key, title)

--- a/src/kiro_crew/webex/transport_dispatch.py
+++ b/src/kiro_crew/webex/transport_dispatch.py
@@ -157,7 +157,7 @@ class WebexDispatcher:
                 approval_mode=self.approval_mode,
                 decider=None,  # Webex can't render approve/deny buttons
                 persist=lambda user_text, reply, is_new: self._persist_turn(
-                    session_key, user_text, reply, is_new
+                    session_key, user_text, reply, is_new, agent
                 ),
                 notice=lambda sk, provider: self._maybe_notice(inbound, sk, provider),
                 audit_caller=f"webex:{email}",
@@ -226,14 +226,19 @@ class WebexDispatcher:
         )
 
     def _persist_turn(
-        self, session_key: str, user_text: str, reply_text: str, is_new: bool
+        self,
+        session_key: str,
+        user_text: str,
+        reply_text: str,
+        is_new: bool,
+        agent: str | None = None,
     ) -> None:
         """Record the turn to conversation_log (dashboard visibility + restart)."""
         if self.conv_log is None:
             return
-        self.conv_log.append(session_key, "user", user_text)
+        self.conv_log.append(session_key, "user", user_text, agent=agent)
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text)
+            self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "Webex"
             self.conv_log.set_title(session_key, title)

--- a/src/kiro_crew/wecom/transport_dispatch.py
+++ b/src/kiro_crew/wecom/transport_dispatch.py
@@ -171,7 +171,7 @@ class WeComDispatcher:
                 approval_mode=self.approval_mode,
                 decider=None,  # WeCom can't render approve/deny buttons
                 persist=lambda user_text, reply, is_new: self._persist_turn(
-                    session_key, user_text, reply, is_new
+                    session_key, user_text, reply, is_new, agent
                 ),
                 notice=lambda sk, provider: self._maybe_notice(inbound, sk, provider),
                 audit_caller=f"wecom:{userid}",
@@ -246,14 +246,19 @@ class WeComDispatcher:
         )
 
     def _persist_turn(
-        self, session_key: str, user_text: str, reply_text: str, is_new: bool
+        self,
+        session_key: str,
+        user_text: str,
+        reply_text: str,
+        is_new: bool,
+        agent: str | None = None,
     ) -> None:
         """Record the turn to conversation_log (dashboard visibility + restart)."""
         if self.conv_log is None:
             return
-        self.conv_log.append(session_key, "user", user_text)
+        self.conv_log.append(session_key, "user", user_text, agent=agent)
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text)
+            self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "WeCom"
             self.conv_log.set_title(session_key, title)

--- a/src/kiro_crew/weixin/transport_dispatch.py
+++ b/src/kiro_crew/weixin/transport_dispatch.py
@@ -248,7 +248,7 @@ class WeixinDispatcher:
                 approval_mode=self.approval_mode,
                 decider=None,  # iLink can't render approve/deny buttons
                 persist=lambda user_text, reply, is_new: self._persist_turn(
-                    session_key, user_text, reply, is_new
+                    session_key, user_text, reply, is_new, agent
                 ),
                 after_persist=self._surface_own_session,
                 notice=lambda sk, provider: self._maybe_notice(user_id, sk, provider),
@@ -324,14 +324,19 @@ class WeixinDispatcher:
         )
 
     def _persist_turn(
-        self, session_key: str, user_text: str, reply_text: str, is_new: bool
+        self,
+        session_key: str,
+        user_text: str,
+        reply_text: str,
+        is_new: bool,
+        agent: str | None = None,
     ) -> None:
         """Record the turn to conversation_log (dashboard visibility + restart)."""
         if self.conv_log is None:
             return
-        self.conv_log.append(session_key, "user", user_text)
+        self.conv_log.append(session_key, "user", user_text, agent=agent)
         if reply_text:
-            self.conv_log.append(session_key, "assistant", reply_text)
+            self.conv_log.append(session_key, "assistant", reply_text, agent=agent)
         if is_new:
             title = (user_text or "").strip().replace("\n", " ")[:40] or "WeChat"
             self.conv_log.set_title(session_key, title)

--- a/test/test_channel_persist_agent_metadata.py
+++ b/test/test_channel_persist_agent_metadata.py
@@ -1,0 +1,68 @@
+"""Every channel transport's ``_persist_turn`` must record the resolved agent.
+
+``ConversationLog.append`` records the agent in the session file's metadata
+header only when the file-creating write supplies it — omit it and the
+dashboard lists the session as the "default" agent forever, and Discord's
+``_persisted_agent`` resume path reads back "" (falling back to the channel
+agent even when the session was created under an override).
+
+Pre-fix, every channel transport omitted ``agent=`` on its persist writes
+(#2890). The Slack path has its own end-to-end lock in
+``test_slack_transport_dispatch.py``; this file locks the shared
+``_persist_turn`` shape used by the other six channels, calling the unbound
+method with a minimal stand-in so no channel client needs to be constructed.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from kiro_crew.history import ConversationLog
+
+_CHANNELS = [
+    ("telegram", "kiro_crew.telegram.transport_dispatch"),
+    ("teams", "kiro_crew.teams.transport_dispatch"),
+    ("webex", "kiro_crew.webex.transport_dispatch"),
+    ("wecom", "kiro_crew.wecom.transport_dispatch"),
+    ("weixin", "kiro_crew.weixin.transport_dispatch"),
+    ("discord", "kiro_crew.discord.transport_dispatch"),
+]
+
+
+def _dispatcher_class(module):
+    """The class in *module* that defines ``_persist_turn``."""
+    for obj in vars(module).values():
+        if isinstance(obj, type) and "_persist_turn" in vars(obj):
+            return obj
+    raise AssertionError(f"no _persist_turn owner in {module.__name__}")
+
+
+@pytest.mark.parametrize("channel,mod_name", _CHANNELS)
+def test_persist_turn_records_agent_in_session_metadata(channel, mod_name, tmp_path):
+    module = __import__(mod_name, fromlist=["_"])
+    cls = _dispatcher_class(module)
+    log = ConversationLog(base_dir=tmp_path)
+    host = SimpleNamespace(conv_log=log)
+
+    key = f"{channel}:agent-metadata-test"
+    cls._persist_turn(host, key, "hello", "world", True, agent="sales-agent")
+
+    listed = log.list_sessions()
+    assert listed, f"{channel}: _persist_turn should persist a session file"
+    assert listed[0].get("agent") == "sales-agent", (
+        f"{channel}: session metadata must carry the agent the turn ran under"
+    )
+
+
+@pytest.mark.parametrize("channel,mod_name", _CHANNELS)
+def test_persist_turn_without_agent_still_writes(channel, mod_name, tmp_path):
+    """The kwarg is optional — legacy/edge call paths keep working."""
+    module = __import__(mod_name, fromlist=["_"])
+    cls = _dispatcher_class(module)
+    log = ConversationLog(base_dir=tmp_path)
+    host = SimpleNamespace(conv_log=log)
+
+    cls._persist_turn(host, f"{channel}:no-agent", "hello", "world", False)
+    assert log.list_sessions(), f"{channel}: turn must still persist without agent"

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -277,7 +277,7 @@ class _ConversationLog:
             rows = [row for row in rows if row.get("role") in roles]
         return rows[-max_messages:]
 
-    def append(self, key: str, role: str, content: str) -> None:
+    def append(self, key: str, role: str, content: str, agent: str | None = None) -> None:
         self.messages.setdefault(key, []).append({"role": role, "content": content})
 
     def set_title(self, key: str, title: str) -> None:

--- a/test/test_slack_transport_dispatch.py
+++ b/test/test_slack_transport_dispatch.py
@@ -771,3 +771,155 @@ class TestHydrationBeforeHook:
         assert saved == []
         assert _handler.is_thread_incognito(canonical_key(_MSG_TS)) is True
         _handler._thread_incognito.pop(canonical_key(_MSG_TS), None)
+
+
+class TestConversationLogAgentMetadata:
+    """The transport's user-turn write creates the session file — its metadata
+    header records the agent only when that creating append supplies it.
+    Pre-fix, the dashboard listed every Slack-spawned session as the "default"
+    agent even though the turn ran under the resolved agent (issue: agent chip
+    shows "default" for Slack sessions)."""
+
+    def test_transport_turn_records_agent_in_session_metadata(self, monkeypatch, tmp_path):
+        from kiro_crew.history import ConversationLog
+
+        monkeypatch.setattr(transport_dispatch, "_get_default_agent", lambda: "sales-agent")
+        monkeypatch.setattr(transport_dispatch, "_hydrate_thread_overrides", lambda *a, **k: None)
+        monkeypatch.setattr(transport_dispatch, "_hydrate_conv_flags", lambda *a, **k: None)
+        monkeypatch.setattr(transport_dispatch, "_thread_agents", {})
+
+        slack = RecordingSlackClient()
+        provider = ScriptedProvider(
+            [
+                make_event(EVENT_TEXT_CHUNK, text="hi"),
+                make_event(EVENT_COMPLETE, stop_reason=STOP_REASON_END_TURN),
+            ]
+        )
+        sessions = _CapturingSessions(provider)
+        log = ConversationLog(base_dir=tmp_path)
+
+        asyncio.run(
+            transport_dispatch.handle_message_transport(
+                slack=slack,
+                sessions=sessions,
+                channel="C1",
+                text="hello",
+                thread_ts=None,
+                msg_ts=_MSG_TS,
+                user_id="U_OWNER",
+                context_builder=None,
+                conversation_log=log,
+                agent_override=None,
+            )
+        )
+
+        listed = log.list_sessions()
+        assert listed, "transport turn should have persisted a session file"
+        # The session the dashboard lists must carry the agent the turn ran
+        # under — not fall back to "default" because the header omitted it.
+        assert listed[0].get("agent") == "sales-agent"
+
+    def test_options_stamp_fallback_records_agent_when_receipt_write_failed(
+        self, monkeypatch, tmp_path
+    ):
+        """The options-stamp fallback write is file-creating exactly when the
+        user-turn receipt write failed — it must supply the agent for the same
+        reason the receipt write does, or the session is pinned to "default"."""
+        from kiro_crew.history import ConversationLog
+
+        monkeypatch.setattr(transport_dispatch, "_get_default_agent", lambda: "sales-agent")
+        monkeypatch.setattr(transport_dispatch, "_hydrate_thread_overrides", lambda *a, **k: None)
+        monkeypatch.setattr(transport_dispatch, "_hydrate_conv_flags", lambda *a, **k: None)
+        monkeypatch.setattr(transport_dispatch, "_thread_agents", {})
+
+        slack = RecordingSlackClient()
+        provider = ScriptedProvider(
+            [
+                # An [OPTIONS:] trailer makes the renderer invoke stamp_options,
+                # routing persistence through _persist_and_stamp.
+                make_event(EVENT_TEXT_CHUNK, text="Pick one.\n\n[OPTIONS: A | B]"),
+                make_event(EVENT_COMPLETE, stop_reason=STOP_REASON_END_TURN),
+            ]
+        )
+        sessions = _CapturingSessions(provider)
+        log = ConversationLog(base_dir=tmp_path)
+
+        # Fail the FIRST append (the user-turn receipt) so the stamp fallback
+        # becomes the write that creates the session file.
+        real_append = log.append
+        state = {"failed": False}
+
+        def _flaky_append(*args, **kwargs):
+            if not state["failed"]:
+                state["failed"] = True
+                raise OSError("simulated receipt-write failure")
+            return real_append(*args, **kwargs)
+
+        monkeypatch.setattr(log, "append", _flaky_append)
+
+        asyncio.run(
+            transport_dispatch.handle_message_transport(
+                slack=slack,
+                sessions=sessions,
+                channel="C1",
+                text="hello",
+                thread_ts=None,
+                msg_ts=_MSG_TS,
+                user_id="U_OWNER",
+                context_builder=None,
+                conversation_log=log,
+                agent_override=None,
+            )
+        )
+
+        listed = log.list_sessions()
+        assert listed, "options-stamp fallback should have persisted a session file"
+        assert listed[0].get("agent") == "sales-agent"
+
+    def test_hook_reply_write_records_agent_in_session_metadata(self, monkeypatch, tmp_path):
+        """A hook-answered FIRST message is the write that creates the session
+        file — it runs before session acquisition, so the agent must be
+        resolved early (native handler parity) or the session is pinned to
+        "default" forever."""
+        from kiro_crew.history import ConversationLog
+        from kiro_crew.hooks import HookResult
+
+        monkeypatch.setattr(transport_dispatch, "_get_default_agent", lambda: "sales-agent")
+        monkeypatch.setattr(transport_dispatch, "_hydrate_thread_overrides", lambda *a, **k: None)
+        monkeypatch.setattr(transport_dispatch, "_hydrate_conv_flags", lambda *a, **k: None)
+        monkeypatch.setattr(transport_dispatch, "_thread_agents", {})
+
+        slack = RecordingSlackClient()
+        sessions = _CapturingSessions(self._noop_provider())
+        cb = _CapturingCtxBuilder(hook_result=HookResult.reply("canned answer"))
+        log = ConversationLog(base_dir=tmp_path)
+
+        asyncio.run(
+            transport_dispatch.handle_message_transport(
+                slack=slack,
+                sessions=sessions,
+                channel="C1",
+                text="ping",
+                thread_ts=None,
+                msg_ts=_MSG_TS,
+                user_id="U_OWNER",
+                context_builder=cb,
+                conversation_log=log,
+                agent_override=None,
+            )
+        )
+
+        # The hook short-circuited the turn — no LLM session was spawned.
+        assert sessions.agents == []
+        listed = log.list_sessions()
+        assert listed, "hook auto-reply should have persisted a session file"
+        assert listed[0].get("agent") == "sales-agent"
+
+    @staticmethod
+    def _noop_provider():
+        return ScriptedProvider(
+            [
+                make_event(EVENT_TEXT_CHUNK, text="hi"),
+                make_event(EVENT_COMPLETE, stop_reason=STOP_REASON_END_TURN),
+            ]
+        )

--- a/test/test_teams_dispatch.py
+++ b/test/test_teams_dispatch.py
@@ -140,7 +140,7 @@ class FakeConvLog:
         self.appended: list[tuple[str, str, str]] = []
         self.titles: dict[str, str] = {}
 
-    def append(self, key, role, text) -> None:
+    def append(self, key, role, text, agent=None) -> None:
         self.appended.append((key, role, text))
 
     def set_title(self, key, title) -> None:

--- a/test/test_webex_dispatch.py
+++ b/test/test_webex_dispatch.py
@@ -157,7 +157,7 @@ class FakeConvLog:
         self.appended: list[tuple[str, str, str]] = []
         self.titles: dict[str, str] = {}
 
-    def append(self, key, role, text) -> None:
+    def append(self, key, role, text, agent=None) -> None:
         self.appended.append((key, role, text))
 
     def set_title(self, key, title) -> None:

--- a/test/test_wecom_dispatch.py
+++ b/test/test_wecom_dispatch.py
@@ -152,7 +152,7 @@ class FakeConvLog:
         self.appended: list[tuple[str, str, str]] = []
         self.titles: dict[str, str] = {}
 
-    def append(self, key, role, text) -> None:
+    def append(self, key, role, text, agent=None) -> None:
         self.appended.append((key, role, text))
 
     def set_title(self, key, title) -> None:

--- a/test/test_weixin_dispatch.py
+++ b/test/test_weixin_dispatch.py
@@ -575,7 +575,7 @@ def test_delivery_failure_is_not_recorded_as_success(tmp_path):
             raise RuntimeError("ilink send timeout")
 
     class Log:
-        def append(self, key, role, text):
+        def append(self, key, role, text, agent=None):
             rows.append((role, text))
 
         def set_title(self, key, title):
@@ -599,7 +599,7 @@ def test_persist_turn_writes_user_and_assistant_rows(tmp_path):
             self.rows: list[tuple[str, str]] = []
             self.title = ""
 
-        def append(self, key, role, text):
+        def append(self, key, role, text, agent=None):
             self.rows.append((role, text))
 
         def set_title(self, key, title):


### PR DESCRIPTION
Fixes #2890

## Problem / Motivation

Sessions spawned from any messaging channel (Slack, Telegram, Teams, Webex, WeCom, WeiXin, Discord) always show the **default** agent chip in the dashboard session list and composer footer — even when the turn actually ran under a thread override, a per-channel agent, or `agent.default_agent`. Discord is also affected functionally: its `_persisted_agent` resume path reads back "" for sessions its own transport created, silently falling back to the channel agent.

## Why it matters

Anyone running a non-default agent as their channel default cannot tell which agent owns a session from the dashboard — every channel session claims `default`. Worse than cosmetic on Discord, where session resume can silently pick a different agent than the one the session was created under. Dashboard-created sessions record the agent correctly, so the two sit inconsistently side by side.

## What changed (motivation → approach → change)

Observed symptom: channel sessions list no `agent` in `GET /api/sessions`. Root cause: every channel transport resolves the agent and passes it to `sessions.get_or_create` (runtime is correct), but none passed it to the conversation-log writes — and the user-turn receipt write is what **creates the session file**, whose metadata header records the agent only when the creating append supplies it (`ConversationLog.append` contract). Change: pass the already-resolved agent at every transport persist site. Slack passes `agent=_agent` at all six of its persist sites: the user receipt, the assistant reply, both branches of the whole-turn fallback, both branches of the options-stamp persist pair (whose fallback creates the session file exactly when the receipt write failed), and the hook auto-reply write. The hook write runs before session acquisition, so the agent is now resolved early — right after hydration, mirroring native `handle_message` — and re-resolved at acquisition (ownership re-resolution can move `session_key` mid-flight). The other six channels' `_persist_turn` gains an optional `agent` parameter (default `None` keeps any legacy call path working) with every call site passing the handler's resolved agent. All sinks (`append`, `append_if_absent`, `save_conversation_turn_off_loop`) already accepted the kwarg — no changes to `history.py`. Alternative considered: a choke-point that stamps agent metadata at session acquisition and backfills existing files — proposed in #2890 as a follow-up since it touches shared machinery and changes behavior for existing session files.

## Tests

- `test/test_slack_transport_dispatch.py::TestConversationLogAgentMetadata` — end-to-end transport turn against a real `ConversationLog`: locks that the session metadata header carries the resolved agent (red pre-fix: `None == 'sales-agent'`).
- `test/test_channel_persist_agent_metadata.py` (new) — parametrized across the six `_persist_turn` channels: (a) agent recorded in session metadata, (b) kwarg remains optional. Red pre-fix (6 failures), green post-fix.
- Existing channel-suite fakes updated to accept the kwarg. Full affected suites local: **457 passed** (slack, telegram, teams, webex, wecom, weixin, discord dispatch/session suites + new file) on the rebased head.

## Manual verification

Verified on a live gateway (Slack Socket Mode): with `agent.default_agent` set to a non-default agent, a fresh Slack DM session now lists that agent in `GET /api/sessions` and the dashboard chip; pre-fix the same flow showed `default`. Other channels exercised via the parametrized unit path only — same shared `_persist_turn` shape.

## Screenshots / video

N/A — no UI component changes; the dashboard chip simply renders the now-present metadata field.
