### PR TITLE
fix: export KIROCREW_PORT after port bind for child-process discovery

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -3509,6 +3509,14 @@ async def start_dashboard(
     # degrades to TCP-only on any failure — see _start_unix_site).
     _unix_socket_holder["path"] = await _start_unix_site(runner, port)
 
+    # Port bind succeeded — export the port so child processes (sandboxes,
+    # mcp-core, kiro-cli sessions) can discover it via env instead of parsing
+    # dashboard.url (which may be a portless URL behind a reverse proxy or
+    # custom domain).  Without this, _resolve_api_base() in mcp_core.py falls
+    # to _DEFAULT_PORT when the URL has no explicit port and KIROCREW_PORT is
+    # unset, breaking spawn_run and all other mcp-core → gateway HTTP calls.
+    os.environ["KIROCREW_PORT"] = str(port)
+
     # Port bind succeeded — now safe to write the secret file. Offloaded:
     # _write_secret_file does blocking fs I/O (os.open/os.close and, on Windows,
     # an icacls subprocess via restrict_to_owner), so it must not run on the
@@ -4082,6 +4090,10 @@ async def start_api_server(
     # Additional kernel-verifiable transport for the internal API (parity with
     # start_dashboard; POSIX only, degrades to TCP-only on any failure).
     _unix_socket_holder["path"] = await _start_unix_site(runner, port)
+
+    # Port bind succeeded — export for child-process discovery (parity with
+    # start_dashboard; see the comment there for the full rationale).
+    os.environ["KIROCREW_PORT"] = str(port)
 
     # Port bind succeeded — now safe to persist the secret file (parity with
     # start_dashboard: write deferred so a failed bind can't poison it).


### PR DESCRIPTION
## Problem

When `dashboard.url` is configured as a URL with no explicit port (e.g. behind a reverse proxy, custom domain, or any URL where the port is implicit), child processes spawned by the gateway (sandboxes, mcp-core MCP servers, kiro-cli sessions) cannot discover the actual gateway port. `mcp_core._resolve_api_base()` calls `parse_dashboard_url()` which resolves to `_DEFAULT_PORT = 5476` when the URL has no port and `KIROCREW_PORT` is unset.

This breaks:
- `spawn_run` / `spawn_sub_agents` (subagent spawning)
- All other mcp-core → gateway HTTP calls (`_post()`)
- `kirocrew status` (same resolution path)

The unix socket path (`dashboard-5476.sock`) also resolves wrong, so both transport paths fail with Connection refused.

## Why it matters

Subagent spawning is a core capability. Any user running the gateway on a non-default port via `--port` with a portless `dashboard.url` loses all subagent functionality silently.

## Fix

Export `os.environ["KIROCREW_PORT"] = str(port)` immediately after the TCP site binds successfully, in both `start_dashboard()` and `start_api_server()`. Every child process inherits this via the existing `KIROCREW_PORT` env-var override in `parse_dashboard_url()`.

The export is placed **after** `_start_site()` and `_start_unix_site()` succeed — so a failed bind never poisons the env — and **before** the secret-file write and all subsequent child-spawning code paths.

## Tests

Added `test/test_gateway_port_env_export.py` with 4 tests:
1. Structural: verifies both gateway start functions contain the export
2. `parse_dashboard_url` honors `KIROCREW_PORT` for portless URLs
3. Falls to `_DEFAULT_PORT` without the env var (the bug condition)
4. `KIROCREW_PORT` overrides even explicit URL ports (existing behavior preserved)

## Manual verification

N/A — unit coverage sufficient. The fix is a single `os.environ` assignment at an already-proven code point (between port-bind success and secret-file write).

## Related

Fixes https://github.com/kirodotdev/KiroCrew/issues/2893