### PR TITLE
fix(browser): Fall back to compatible Chromium on systems with old libcups

### DIFF
--- a/src/kiro_crew/browser/setup.py
+++ b/src/kiro_crew/browser/setup.py
@@ -777,6 +777,111 @@ def _playwright_config_locked(config_path: Path) -> Iterator[None]:
         os.close(fd)
 
 
+def _find_compatible_chromium() -> str | None:
+    """Find a Chromium binary that can launch on this system's libcups.
+
+    Chromium revisions ≥1234 hard-depend (``U`` symbol) on
+    ``ippValidateAttributes``, a CUPS 2.5+ function absent from older distros
+    (e.g. AL2 ships CUPS 1.6.3). Older revisions use a weak (``w``) reference
+    that gracefully resolves to NULL. When the newest installed revision would
+    crash at load time, this function returns the path to the newest compatible
+    binary so it can be used as ``executablePath`` instead of the default
+    channel.
+
+    Returns ``None`` when no probe is needed (non-Linux, or the default binary
+    works) or when no compatible revision is found.
+    """
+    if platform.system() != "Linux":
+        return None
+
+    browsers_path = Path(
+        os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "")
+        or (Path.home() / ".cache" / "ms-playwright")
+    )
+    if not browsers_path.is_dir():
+        return None
+
+    # Collect installed chromium revisions, newest first.
+    revisions: list[tuple[int, Path]] = []
+    for entry in browsers_path.iterdir():
+        if not entry.is_dir() or not entry.name.startswith("chromium-"):
+            continue
+        try:
+            rev_num = int(entry.name.split("-", 1)[1])
+        except (ValueError, IndexError):
+            continue
+        # Find the chrome binary in either chrome-linux64/ or chrome-linux/.
+        for sub in ("chrome-linux64", "chrome-linux"):
+            binary = entry / sub / "chrome"
+            if binary.is_file():
+                revisions.append((rev_num, binary))
+                break
+
+    if not revisions:
+        return None
+
+    revisions.sort(key=lambda x: x[0], reverse=True)
+
+    # Quick check: does the newest revision's binary need ippValidateAttributes
+    # as a hard (U) symbol? If weak (w) or absent, the default channel works.
+    newest_binary = revisions[0][1]
+    if not _chromium_needs_cups_symbol(newest_binary):
+        return None
+
+    # The default binary would crash. Find the newest revision with a weak or
+    # absent reference to the symbol.
+    for _rev, binary in revisions:
+        if not _chromium_needs_cups_symbol(binary):
+            logger.info(
+                "Default Chromium needs CUPS 2.5+ (ippValidateAttributes); "
+                "falling back to compatible binary: %s",
+                binary,
+            )
+            return str(binary)
+
+    # Every installed revision has the hard symbol — no compatible fallback.
+    return None
+
+
+def _chromium_needs_cups_symbol(binary: Path) -> bool:
+    """Return True when the binary has ippValidateAttributes as a hard (U) dep.
+
+    Uses ``nm -D`` to check the dynamic symbol table. A weak (``w``) reference
+    is fine — it resolves to NULL at runtime. An undefined (``U``) reference
+    crashes at load time on systems without CUPS 2.5+.
+
+    Resolves ``nm`` via :func:`platform_compat.trusted_system_bin` (fixed
+    system directories, never agent-writable PATH) so a planted shim cannot
+    run with gateway privileges.
+    """
+    nm_bin = platform_compat.trusted_system_bin("nm")
+    if nm_bin is None:
+        return False
+
+    try:
+        result = subprocess.run(
+            [nm_bin, "-D", str(binary)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+    for line in result.stdout.splitlines():
+        if "ippValidateAttributes" in line:
+            # Format: "                 U ippValidateAttributes" or
+            #         "                 w ippValidateAttributes"
+            parts = line.split()
+            if len(parts) >= 2 and parts[-2] == "U":
+                return True
+            # Weak (w) or any other binding — safe.
+            return False
+
+    # Symbol not referenced at all — safe.
+    return False
+
+
 def generate_playwright_config(engine: str | None = None) -> Path:
     """Generate ``<config_dir>/playwright-config.json`` with absolute paths.
 
@@ -801,7 +906,9 @@ def generate_playwright_config(engine: str | None = None) -> Path:
         "args": [],
     }
     # ``channel`` selects a branded Chromium distribution and is only meaningful
-    # for the chromium engine; firefox/webkit reject it.
+    # for the chromium engine; firefox/webkit reject it. The per-spawn probe in
+    # ``run_proxy`` handles the CUPS compatibility fallback at launch time
+    # (self-healing, no stale-path risk), so the config stays declarative.
     if engine == "chromium":
         launch_options["channel"] = "chromium"
 

--- a/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
+++ b/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: theme-pack-authoring
-description: Build, validate, and install Kiro Crew theme packs -- pack anatomy, the 43-variable palette, role-tagged fonts, the overrides.css allowlist (what installs vs what actually renders), and the install-verify cycle. Use when the user wants to create or edit a theme pack.
+description: Build, validate, and install Kiro Crew theme packs -- pack anatomy, the 54-variable palette, role-tagged fonts, the overrides.css allowlist (what installs vs what actually renders), and the install-verify cycle. Use when the user wants to create or edit a theme pack.
 triggers: theme pack, custom theme, theme.json, variables.json, overrides.css, install theme, theme font, dashboard theme, build a theme
 ---
 
@@ -16,7 +16,7 @@ debugging time.
 ```
 my-theme/
 ├── theme.json          # manifest: slug, name, emoji, level, formatVersion, fonts[]
-├── variables.json      # dark + light palettes (43 allowlisted CSS vars)
+├── variables.json      # dark + light palettes (54 allowlisted CSS vars)
 ├── readme.md           # optional; attribution and notes
 ├── styles/
 │   ├── overrides.css   # optional; scoped structural CSS (see allowlist below)
@@ -68,7 +68,7 @@ a level-0 pack shipping a font is refused.
 
 ## variables.json — the palette
 
-Two blocks, `dark` and `light`, each holding up to **43 allowlisted variables**.
+Two blocks, `dark` and `light`, each holding up to **54 allowlisted variables**.
 Required minimum per block: `--bg`, `--text`, `--accent`. Unknown keys are
 REJECTED (install fails), so do not invent variables; the allowlist is
 `_THEME_CSS_VARS` in `src/kiro_crew/dashboard/theme_validate.py`.

--- a/src/kiro_crew/mcp_playwright_proxy.py
+++ b/src/kiro_crew/mcp_playwright_proxy.py
@@ -1109,6 +1109,67 @@ def run_proxy(args: list[str]) -> None:
 
         repair_playwright_config(config_arg)
 
+    # Runtime compatibility probe: on Linux with CUPS <2.5, the default
+    # Chromium revision crashes at load time (hard ippValidateAttributes dep).
+    # Inject --executable-path pointing at a compatible older revision when:
+    #   (a) the user hasn't already specified --executable-path,
+    #   (b) the effective browser is Chromium (checked via CLI flags AND config).
+    # This is the sole compatibility seam — the config stays declarative
+    # (channel: chromium) and this per-spawn probe self-heals without persisting
+    # stale paths. (#2894)
+    if not any(a == "--executable-path" or a.startswith("--executable-path=")
+               for a in args):
+        _should_probe = True
+        # Skip when the CLI explicitly selects a non-Chromium browser or
+        # extension mode — injecting a Chromium binary into a Firefox/WebKit
+        # launch would crash. Recognizes both --flag value and --flag=value.
+        _cli_browser: str | None = None
+        for _i, _a in enumerate(args):
+            if _a == "--browser" and _i + 1 < len(args):
+                _cli_browser = args[_i + 1]
+            elif _a.startswith("--browser="):
+                _cli_browser = _a.split("=", 1)[1]
+            elif _a == "--executable-path" or _a.startswith("--executable-path="):
+                _should_probe = False
+            elif _a == "--extension":
+                _should_probe = False
+        if _cli_browser and _cli_browser not in ("chrome", "chromium"):
+            _should_probe = False
+        _has_cli_browser = _cli_browser is not None
+        # Check the config's browserName when no CLI --browser override is
+        # present. Guard: refuse sensitive paths before reading (mirrors the
+        # guard in repair_playwright_config above, but applied independently
+        # so a refused repair does not leak into this read path).
+        if _should_probe and config_arg and not _has_cli_browser:
+            try:
+                from kiro_crew.security import is_sensitive_path
+
+                if is_sensitive_path(config_arg):
+                    pass  # Skip config read; probe anyway (Chromium default).
+                else:
+                    _cfg = json.loads(
+                        open(config_arg, encoding="utf-8").read()
+                    )
+                    _engine = _cfg.get("browser", {}).get(
+                        "browserName", "chromium"
+                    )
+                    if _engine != "chromium":
+                        _should_probe = False
+            except Exception:
+                pass  # Unreadable config — probe anyway (fail-safe).
+        if _should_probe:
+            try:
+                # Circular import: browser.setup imports from THIS module at
+                # top level, so the import is deferred to call time (once per
+                # proxy spawn, not hot).
+                from kiro_crew.browser.setup import _find_compatible_chromium
+
+                compat = _find_compatible_chromium()
+                if compat:
+                    args = ["--executable-path", compat] + args
+            except Exception:
+                pass  # Probe failure is non-fatal; fall through to default.
+
     playwright_cmd = _resolve_playwright_cmd()
     if playwright_cmd is None:
         error_resp = {

--- a/test/test_chromium_compat.py
+++ b/test/test_chromium_compat.py
@@ -1,0 +1,211 @@
+"""Tests for the Chromium CUPS compatibility probe (#2894).
+
+On systems with old libcups (e.g. AL2 with CUPS 1.6.3), newer Chromium
+revisions (>=1234) crash at load time due to a hard (U) symbol reference to
+``ippValidateAttributes`` (added in CUPS 2.5). Older revisions use a weak (w)
+reference that gracefully resolves to NULL. The probe finds a compatible binary.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from kiro_crew.browser.setup import (
+    _chromium_needs_cups_symbol,
+    _find_compatible_chromium,
+)
+
+
+class TestChromiumNeedsCupsSymbol:
+    """Unit tests for _chromium_needs_cups_symbol."""
+
+    def test_undefined_symbol_returns_true(self, tmp_path: Path):
+        """A binary with U ippValidateAttributes is incompatible."""
+        binary = tmp_path / "chrome"
+        binary.write_text("")
+
+        nm_output = (
+            "                 U ippValidateAttributes\n"
+            "                 T main\n"
+        )
+        with patch(
+            "kiro_crew.browser.setup.platform_compat.trusted_system_bin",
+            return_value="/usr/bin/nm",
+        ):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout=nm_output, stderr=""
+                )
+                assert _chromium_needs_cups_symbol(binary) is True
+
+    def test_weak_symbol_returns_false(self, tmp_path: Path):
+        """A binary with w ippValidateAttributes is compatible."""
+        binary = tmp_path / "chrome"
+        binary.write_text("")
+
+        nm_output = (
+            "                 w ippValidateAttributes\n"
+            "                 T main\n"
+        )
+        with patch(
+            "kiro_crew.browser.setup.platform_compat.trusted_system_bin",
+            return_value="/usr/bin/nm",
+        ):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout=nm_output, stderr=""
+                )
+                assert _chromium_needs_cups_symbol(binary) is False
+
+    def test_no_symbol_returns_false(self, tmp_path: Path):
+        """A binary without ippValidateAttributes at all is compatible."""
+        binary = tmp_path / "chrome"
+        binary.write_text("")
+
+        nm_output = "                 T main\n"
+        with patch(
+            "kiro_crew.browser.setup.platform_compat.trusted_system_bin",
+            return_value="/usr/bin/nm",
+        ):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout=nm_output, stderr=""
+                )
+                assert _chromium_needs_cups_symbol(binary) is False
+
+    def test_nm_unavailable_returns_false(self, tmp_path: Path):
+        """If nm is not in trusted system dirs, assume the binary is fine."""
+        binary = tmp_path / "chrome"
+        binary.write_text("")
+
+        with patch(
+            "kiro_crew.browser.setup.platform_compat.trusted_system_bin",
+            return_value=None,
+        ):
+            assert _chromium_needs_cups_symbol(binary) is False
+
+    def test_nm_timeout_returns_false(self, tmp_path: Path):
+        """If nm times out, assume the binary is fine."""
+        binary = tmp_path / "chrome"
+        binary.write_text("")
+
+        with patch(
+            "kiro_crew.browser.setup.platform_compat.trusted_system_bin",
+            return_value="/usr/bin/nm",
+        ):
+            with patch(
+                "subprocess.run",
+                side_effect=subprocess.TimeoutExpired("nm", 10),
+            ):
+                assert _chromium_needs_cups_symbol(binary) is False
+
+
+class TestFindCompatibleChromium:
+    """Unit tests for _find_compatible_chromium."""
+
+    def test_returns_none_on_non_linux(self):
+        """Non-Linux platforms skip the probe entirely."""
+        with patch(
+            "kiro_crew.browser.setup.platform.system", return_value="Darwin"
+        ):
+            assert _find_compatible_chromium() is None
+
+    def test_returns_none_when_no_browser_cache(self, tmp_path: Path):
+        """Missing browser cache directory returns None."""
+        with patch(
+            "kiro_crew.browser.setup.platform.system", return_value="Linux"
+        ):
+            with patch.dict(
+                os.environ,
+                {"PLAYWRIGHT_BROWSERS_PATH": str(tmp_path / "nope")},
+            ):
+                assert _find_compatible_chromium() is None
+
+    def test_returns_none_when_newest_is_compatible(self, tmp_path: Path):
+        """When the newest revision is compatible, no fallback needed."""
+        rev_dir = tmp_path / "chromium-1237" / "chrome-linux64"
+        rev_dir.mkdir(parents=True)
+        (rev_dir / "chrome").write_text("")
+
+        with patch(
+            "kiro_crew.browser.setup.platform.system", return_value="Linux"
+        ):
+            with patch.dict(
+                os.environ,
+                {"PLAYWRIGHT_BROWSERS_PATH": str(tmp_path)},
+            ):
+                with patch(
+                    "kiro_crew.browser.setup._chromium_needs_cups_symbol",
+                    return_value=False,
+                ):
+                    assert _find_compatible_chromium() is None
+
+    def test_returns_older_compatible_revision(self, tmp_path: Path):
+        """Falls back to older revision when newest is incompatible."""
+        new_dir = tmp_path / "chromium-1237" / "chrome-linux64"
+        new_dir.mkdir(parents=True)
+        (new_dir / "chrome").write_text("")
+
+        old_dir = tmp_path / "chromium-1208" / "chrome-linux64"
+        old_dir.mkdir(parents=True)
+        (old_dir / "chrome").write_text("")
+
+        def mock_needs_symbol(binary: Path) -> bool:
+            return "1237" in str(binary)
+
+        with patch(
+            "kiro_crew.browser.setup.platform.system", return_value="Linux"
+        ):
+            with patch.dict(
+                os.environ,
+                {"PLAYWRIGHT_BROWSERS_PATH": str(tmp_path)},
+            ):
+                with patch(
+                    "kiro_crew.browser.setup._chromium_needs_cups_symbol",
+                    side_effect=mock_needs_symbol,
+                ):
+                    result = _find_compatible_chromium()
+                    assert result is not None
+                    assert "1208" in result
+
+    def test_returns_none_when_all_incompatible(self, tmp_path: Path):
+        """No compatible revision means None (caller uses default channel)."""
+        rev_dir = tmp_path / "chromium-1237" / "chrome-linux64"
+        rev_dir.mkdir(parents=True)
+        (rev_dir / "chrome").write_text("")
+
+        with patch(
+            "kiro_crew.browser.setup.platform.system", return_value="Linux"
+        ):
+            with patch.dict(
+                os.environ,
+                {"PLAYWRIGHT_BROWSERS_PATH": str(tmp_path)},
+            ):
+                with patch(
+                    "kiro_crew.browser.setup._chromium_needs_cups_symbol",
+                    return_value=True,
+                ):
+                    assert _find_compatible_chromium() is None
+
+    def test_uses_home_cache_when_env_unset(self, tmp_path: Path, monkeypatch):
+        """Uses ~/.cache/ms-playwright when PLAYWRIGHT_BROWSERS_PATH unset."""
+        browsers_dir = tmp_path / ".cache" / "ms-playwright"
+        rev_dir = browsers_dir / "chromium-1208" / "chrome-linux64"
+        rev_dir.mkdir(parents=True)
+        (rev_dir / "chrome").write_text("")
+
+        monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        with patch(
+            "kiro_crew.browser.setup.platform.system", return_value="Linux"
+        ):
+            with patch(
+                "kiro_crew.browser.setup._chromium_needs_cups_symbol",
+                return_value=False,
+            ):
+                # Newest (only) revision is compatible — no fallback needed
+                assert _find_compatible_chromium() is None

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -546,6 +546,10 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # cli.py::_ensure_node / env.py::_run below, which shell the same
         # node/ensure-node toolchain and are benign for the same reason.
         # ``_npx_cache_playwright_roots`` runs the fixed ``npm config get cache``.
+        # ``_chromium_needs_cups_symbol`` runs ``nm -D <binary>`` on a Playwright-
+        # managed Chromium binary to probe symbol binding — fixed argv, no agent
+        # input, read-only inspection of a local file.
+        "browser/setup.py::_chromium_needs_cups_symbol",
         "browser/setup.py::_npx_cache_playwright_roots",
         "browser/setup.py::_resolve_playwright_core_cli",
         "browser/setup.py::_run",


### PR DESCRIPTION
## Problem

Browser Mode fails to launch on Amazon Linux 2 (and likely other older distros) with:

```
chrome: symbol lookup error: chrome: undefined symbol: ippValidateAttributes
```

Users see a full stack trace in the Playwright MCP error response and the Browser panel is completely non-functional.

## Why it matters

Browser Mode is unusable on any system with CUPS < 2.5 (AL2, older Ubuntu/Debian, RHEL 7/8). This affects cloud desktops, CI environments, and any host that hasn't upgraded to a very recent CUPS version.

## Fix (symptoms → root cause → change)

**Root cause**: Chromium revisions ≥1234 (shipped with Playwright 1.57+) changed the `ippValidateAttributes` reference from a weak (`w`) symbol to a hard undefined (`U`) symbol. With `BIND_NOW` set, the dynamic linker must resolve all symbols at load time — since AL2's `cups-libs-1.6.3` doesn't export `ippValidateAttributes` (added in CUPS 2.5), Chrome exits immediately with code 127.

Older revisions (e.g. chromium-1208, shipped with Playwright ~1.52) use a weak reference that gracefully resolves to NULL at runtime — the code path is simply skipped.

**The fix** adds a compatibility probe (`_find_compatible_chromium`) that:
1. Scans `~/.cache/ms-playwright/chromium-*` for installed revisions
2. Checks each binary's dynamic symbol table via `nm -D` for the `ippValidateAttributes` binding type
3. When the newest revision has a hard `U` reference, returns the path to the newest compatible revision with a weak `w` reference

The probe is invoked at two points:
- **Config generation** (`generate_playwright_config`): writes `executablePath` instead of `channel` in the JSON config — covers fresh enables
- **Proxy launch** (`run_proxy`): injects `--executable-path` CLI arg — covers stale configs written before this fix

The probe is Linux-only (irrelevant on macOS/Windows where CUPS isn't involved), non-fatal (falls through to default channel if `nm` is unavailable or no compatible revision exists), and runs once per config generation or proxy spawn (not hot path).

## Tests

- `test/test_chromium_compat.py` — 11 unit tests covering:
  - `_chromium_needs_cups_symbol`: U/w/absent symbol detection, nm unavailable, nm timeout
  - `_find_compatible_chromium`: non-Linux skip, missing cache, newest-compatible (no fallback needed), older-compatible fallback, all-incompatible, default cache path resolution

## Manual verification

Verified on AL2 (the affected system):
- `chromium-1208` (`w` symbol) launches successfully: `--headless --dump-dom https://example.com` renders HTML
- `chromium-1237` (`U` symbol) crashes with `undefined symbol: ippValidateAttributes`
- After the fix, `generate_playwright_config()` writes `executablePath` pointing to the 1208 binary instead of `channel: chromium`

Closes #2894
