### PR TITLE
fix(acp): Guard park accounting against None and downgrade unclosed-conn noise

### DIFF
--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -597,9 +597,12 @@ class AcpSessionHandle:
                     # `finally`, not a trailing statement: an abandoned generator
                     # unwinds with GeneratorExit and would otherwise leave
                     # `_parked_since` set forever, which reads from outside as a
-                    # turn parked since the abandonment.
-                    self._parked_total += time.monotonic() - self._parked_since
-                    self._parked_since = None
+                    # turn parked since the abandonment.  Guard against None:
+                    # a turn boundary (line ~517) may reset _parked_since before
+                    # a lingering generator's finally fires on GC.
+                    if self._parked_since is not None:
+                        self._parked_total += time.monotonic() - self._parked_since
+                        self._parked_since = None
         finally:
             if not self._turn_done.is_set():
                 self._turn_done.set()

--- a/src/kiro_crew/crash_guard.py
+++ b/src/kiro_crew/crash_guard.py
@@ -104,8 +104,13 @@ def _asyncio_exception_handler(loop, context) -> None:  # noqa: no-blocking-call
         exc_tuple = (type(exception), exception, exception.__traceback__)
         _write_crash(header, exc_tuple)
     else:
-        logger.error("asyncio unhandled: %s (no exception object)", message)
-        _write_crash(f"ASYNCIO UNHANDLED (no exc): {message}")
+        if message.startswith("Unclosed"):
+            # GC noise from aiohttp sessions dropped without close() — harmless,
+            # not worth a crash.log entry.
+            logger.warning("asyncio unhandled (noise): %s", message)
+        else:
+            logger.error("asyncio unhandled: %s (no exception object)", message)
+            _write_crash(f"ASYNCIO UNHANDLED (no exc): {message}")
 
 
 def install(loop=None) -> None:

--- a/test/test_crash_guard.py
+++ b/test/test_crash_guard.py
@@ -70,3 +70,70 @@ class TestInstallLoopHandler:
         finally:
             loop.close()
         assert crash_guard._CRASH_LOG is None
+
+
+class TestUnclosedConnectionDowngrade:
+    """Unclosed-connection GC noise is downgraded to WARNING, not ERROR."""
+
+    def test_unclosed_connection_logged_at_warning(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+        crash_guard._CRASH_LOG = None
+        loop = asyncio.new_event_loop()
+        try:
+            crash_guard.install_loop_handler(loop)
+        finally:
+            loop.close()
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.crash_guard"):
+            crash_guard._asyncio_exception_handler(
+                loop, {"message": "Unclosed connection"}
+            )
+
+        assert any("noise" in r.message for r in caplog.records)
+        assert all(r.levelno <= logging.WARNING for r in caplog.records)
+        # Must NOT write to crash.log
+        crash_log = tmp_path / "home" / "logs" / "crash.log"
+        assert not crash_log.exists()
+
+    def test_unclosed_client_session_also_downgraded(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+        crash_guard._CRASH_LOG = None
+        loop = asyncio.new_event_loop()
+        try:
+            crash_guard.install_loop_handler(loop)
+        finally:
+            loop.close()
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.crash_guard"):
+            crash_guard._asyncio_exception_handler(
+                loop, {"message": "Unclosed client session"}
+            )
+
+        assert any("noise" in r.message for r in caplog.records)
+        assert all(r.levelno <= logging.WARNING for r in caplog.records)
+
+    def test_non_unclosed_message_still_errors(self, tmp_path, monkeypatch, caplog):
+        """Other no-exception messages must still go to ERROR + crash.log."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+        crash_guard._CRASH_LOG = None
+        loop = asyncio.new_event_loop()
+        try:
+            crash_guard.install_loop_handler(loop)
+        finally:
+            loop.close()
+
+        import logging
+
+        with caplog.at_level(logging.ERROR, logger="kiro_crew.crash_guard"):
+            crash_guard._asyncio_exception_handler(
+                loop, {"message": "Some other problem"}
+            )
+
+        assert any(r.levelno == logging.ERROR for r in caplog.records)
+        crash_log = tmp_path / "home" / "logs" / "crash.log"
+        assert crash_log.exists()
+        assert "Some other problem" in crash_log.read_text()

--- a/test/test_stuck_turn_watchdog.py
+++ b/test/test_stuck_turn_watchdog.py
@@ -139,6 +139,33 @@ async def test_parked_for_secs_reports_a_consumer_holding_an_event():
 
 
 @pytest.mark.asyncio
+async def test_park_finally_survives_none_parked_since():
+    """GeneratorExit when _parked_since is already None must not raise TypeError.
+
+    Regression: if a turn boundary resets _parked_since before a lingering
+    generator is GC'd, the finally block attempted `time.monotonic() - None`,
+    raising TypeError and producing ERROR-level crash_guard log noise.
+    """
+    handle = _make_handle()
+    _feed_on_prompt(handle, _tool_call_frame())
+
+    agen = handle.prompt("hi", timeout=2.0)
+    await agen.__anext__()  # consumer holds the event (parks)
+
+    # Simulate the race: a turn boundary resets park state before GC fires.
+    handle._parked_since = None
+    handle._parked_total = 0.0
+
+    # aclose() triggers GeneratorExit inside the yield -> finally fires.
+    # Before the fix this raised TypeError; now it must be a no-op.
+    await agen.aclose()
+
+    # No crash, park total unchanged (the abandoned park is silently discarded).
+    assert handle._parked_total == 0.0
+    assert handle._parked_since is None
+
+
+@pytest.mark.asyncio
 async def test_park_state_does_not_carry_across_turns():
     """Park state is per-turn. Carrying it would charge the previous turn's
     consumer time to this one, and a permission left unanswered when the last


### PR DESCRIPTION
## Problem

Two sources of ERROR-level log noise on every gateway:

1. **TypeError on GeneratorExit** — when an async generator in `session_handle.py:prompt()` is GC'd (client disconnect, tab close), the `finally` block subtracts `None` from a float because `_parked_since` was already reset by a turn boundary.

2. **Unclosed connection warnings** — asyncio's GC warning for aiohttp sessions that weren't explicitly closed. These carry no exception object and are harmless, but `crash_guard` logs them at ERROR and writes to crash.log, polluting both.

## Fix

1. Guard the subtraction: `if self._parked_since is not None` before the arithmetic in `session_handle.py:601`.
2. Downgrade `Unclosed *` messages to WARNING and skip the crash.log write — they're GC noise, not crashes.

## Tests

- `test_park_finally_survives_none_parked_since` — verifies the finally block handles None gracefully without raising TypeError
- `TestUnclosedConnectionDowngrade` — 3 tests verifying crash_guard routes 'Unclosed' messages to WARNING (not ERROR/crash.log) while preserving ERROR for other messages

## Manual verification

N/A — unit coverage sufficient. The TypeError was observed in production logs and the guard is a straightforward None check.

---
Linked: #2898, #2899