### PR TITLE
chore: list todo-ledger in the app registry

### DIFF
--- a/src/kiro_crew/apps/app-registry.json
+++ b/src/kiro_crew/apps/app-registry.json
@@ -4,5 +4,11 @@
     "gitUrl": "https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app",
     "repo": "https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app",
     "branch": "main"
+  },
+  {
+    "name": "todo-ledger",
+    "gitUrl": "https://github.com/qihang-dai/todo-ledger",
+    "repo": "https://github.com/qihang-dai/todo-ledger",
+    "branch": "release"
   }
 ]


### PR DESCRIPTION
Adds **todo-ledger** — shared markdown todo lists that humans edit in the dashboard and agent sessions claim + complete concurrently.

Repo: https://github.com/qihang-dai/todo-ledger (branch `release`)

This is the App-shaped landing of RFC #2641, per maintainer routing in the contributors channel (interface features belong in Kiro Crew Apps, not core — core PR #2663 was closed accordingly).

**What the app ships:** `app.json` manifest; in-process backend routes over a flock-guarded markdown store (CAS versioning, exact-line toggle guards, atomic multi-item claims so parallel sessions never double-work); a zero-dependency CLI for agent access; a skill + pickup SOP; an optional shipped-disabled pickup cron; and a React dashboard page (interactive GFM checkboxes, claim chips, CAS conflict banners).

Dogfooded on a live instance: one session creates items, a second session claims them atomically (visible as claim markers in the markdown) and completes them with staleness-guarded transitions.