### PR TITLE
ci: gate the 10x macos-15 desktop build behind macOS-packaging paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,53 @@ jobs:
           name: wheel
           path: dist/*.whl
 
+  # Resolve which desktop platforms a PR builds. Linux (both arches) ALWAYS
+  # builds -- it is comparatively cheap and catches cross-platform bundle
+  # breakage, and cannot be cross-compiled. The macos-15 leg bills at ~10x and
+  # its UNIQUE coverage is macOS packaging (DMG, universal/Rosetta, mac
+  # electron-builder), so on a pull_request it builds only when a macOS-
+  # packaging input changed; push / release events always build it. The release
+  # lane (build-desktop.yml) still ships every platform unconditionally.
+  desktop-matrix:
+    name: Resolve desktop matrix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      os: ${{ steps.compute.outputs.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            desktop:
+              - 'website/electron/**'
+              - 'website/package.json'
+              - 'website/package-lock.json'
+              - 'build-desktop.sh'
+              - 'Makefile'
+              - 'pyproject.toml'
+              - 'setup.cfg'
+              - '.github/workflows/build.yml'
+              - '.github/workflows/build-desktop.yml'
+      - id: compute
+        env:
+          IS_PR: ${{ github.event_name == 'pull_request' }}
+          DESKTOP_CHANGED: ${{ steps.filter.outputs.desktop }}
+        run: |
+          # Linux legs are unconditional; macos-15 only when a packaging-relevant
+          # path changed on a PR (always on push / non-PR events).
+          if [ "$IS_PR" != "true" ] || [ "$DESKTOP_CHANGED" = "true" ]; then
+            echo 'os=["macos-15","ubuntu-22.04","ubuntu-22.04-arm"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'os=["ubuntu-22.04","ubuntu-22.04-arm"]' >> "$GITHUB_OUTPUT"
+          fi
+
   build-desktop:
+    needs: [desktop-matrix]
     name: Build Desktop (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     # macOS bills at 10x, so an unbounded hang here is the costliest in the repo.
@@ -87,12 +133,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Both Linux arches, so every SHIPPED desktop platform is gated on a PR.
-        # Linux cannot be cross-compiled (build-desktop.sh RUNS the interpreter it
-        # provisions), so arm64 needs its own runner or it is only ever exercised
-        # by a nightly -- i.e. discovered broken after it ships. Must stay in step
-        # with build-desktop.yml's release matrix.
-        os: [macos-15, ubuntu-22.04, ubuntu-22.04-arm]
+        # Resolved by the desktop-matrix job: both Linux arches always (Linux
+        # cannot be cross-compiled -- build-desktop.sh RUNS the interpreter it
+        # provisions -- so each arch needs its own runner), plus macos-15 when a
+        # macOS-packaging input changed or on any non-PR event. build-desktop.yml
+        # stays the release matrix that ships every platform unconditionally.
+        os: ${{ fromJSON(needs.desktop-matrix.outputs.os) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/test/test_publish_feed_contract.py
+++ b/test/test_publish_feed_contract.py
@@ -257,31 +257,53 @@ def test_linux_lane_verifies_artifact_architecture_before_publishing() -> None:
     )
 
 
-def test_pr_and_release_desktop_matrices_cover_the_same_platforms() -> None:
-    """The PR gate must build every platform the release lane ships.
+def test_pr_desktop_matrix_gates_macos_but_never_linux() -> None:
+    """PR desktop-build coverage policy.
 
-    ``build.yml`` is what runs on a PR; ``build-desktop.yml`` is what nightly and
-    release call. If the PR matrix is narrower, the missing platform is only ever
-    exercised AFTER it ships — which is how an unbuildable arch reaches users.
-    Linux in particular cannot be cross-compiled (``build-desktop.sh`` runs the
-    interpreter it provisions), so each arch needs its own runner in both places.
+    Linux (both arches) builds on EVERY PR -- it is comparatively cheap and
+    cannot be cross-compiled, so a broken arch must be caught before merge, not
+    only at nightly. The macos-15 leg bills at ~10x and its unique coverage is
+    macOS packaging, so on a PR it builds only when a macOS-packaging input
+    changed (the ``desktop-matrix`` job's paths filter); push / release always
+    build it. The release lane (``build-desktop.yml``) still ships every
+    platform unconditionally, so nothing macOS ever reaches users unbuilt.
     """
     pr = yaml.safe_load((WORKFLOWS / "build.yml").read_text(encoding="utf-8"))
     release = yaml.safe_load((WORKFLOWS / "build-desktop.yml").read_text(encoding="utf-8"))
 
-    pr_os = set(pr["jobs"]["build-desktop"]["strategy"]["matrix"]["os"])
+    # The release lane still ships every platform, macOS included.
     release_os = {
         entry["os"] for entry in release["jobs"]["build-desktop"]["strategy"]["matrix"]["include"]
     }
-    assert release_os <= pr_os, (
-        "build.yml's desktop matrix must cover every platform build-desktop.yml "
-        f"ships; missing from the PR gate: {sorted(release_os - pr_os)}"
-    )
-    # Both Linux arches are shipped platforms, so name them explicitly: a future
-    # edit that drops one from BOTH files would still satisfy the subset check.
-    for required in ("ubuntu-22.04", "ubuntu-22.04-arm"):
+    for required in ("macos-15", "ubuntu-22.04", "ubuntu-22.04-arm"):
         assert required in release_os, f"{required} must stay in the release desktop matrix"
-        assert required in pr_os, f"{required} must stay in the PR desktop matrix"
+
+    # The PR desktop matrix is resolved dynamically by the desktop-matrix job.
+    jobs = pr["jobs"]
+    assert "desktop-matrix" in jobs, (
+        "build.yml must resolve the desktop matrix via a desktop-matrix job so "
+        "macos-15 can be gated"
+    )
+    compute = next(
+        (s for s in jobs["desktop-matrix"]["steps"] if s.get("id") == "compute"), None
+    )
+    assert compute is not None, "desktop-matrix must have a `compute` step emitting os="
+    os_lines = [ln for ln in compute["run"].splitlines() if "os=[" in ln]
+    assert os_lines, "the compute step must emit at least one os= matrix list"
+
+    # Linux is UNCONDITIONAL: both arches appear in every branch the script emits.
+    for ln in os_lines:
+        assert '"ubuntu-22.04"' in ln and '"ubuntu-22.04-arm"' in ln, (
+            f"both Linux arches must be in every PR desktop matrix branch: {ln}"
+        )
+    # macOS is GATED: it must be buildable (packaging-relevant PR / push) but must
+    # NOT appear in every branch, or the 10x build still runs on every PR.
+    with_mac = [ln for ln in os_lines if '"macos-15"' in ln]
+    assert with_mac, "macos-15 must still build on packaging-relevant PRs and pushes"
+    assert len(with_mac) < len(os_lines), (
+        "macos-15 must be gated -- at least one branch (a non-packaging PR) must "
+        "omit it, or the 10x macOS build still runs on every PR"
+    )
 
 
 def test_pr_linux_desktop_artifacts_are_arch_qualified() -> None:


### PR DESCRIPTION
## Problem

The **macos-15 desktop build ran on every pull request**. GitHub's macOS runners are scarce and bill at ~10×, so it queued for tens of minutes and became the **critical-path bottleneck** of the PR gate — even for PRs that cannot affect the macOS build (pure backend logic, frontend React, docs).

## Why it matters

Every PR — including ones with no macOS-packaging impact — waited on the macOS runner queue before `PR Readiness` could go green, slowing the entire review loop (each review round re-paid the queue).

## Fix (symptom → root cause → change)

- **Symptom:** `Build / Build Desktop (macos-15) (pull_request)` sits `QUEUED` for a long time on nearly every PR.
- **Root cause:** `build.yml`'s `build-desktop` job used a **static** matrix `os: [macos-15, ubuntu-22.04, ubuntu-22.04-arm]`, so the 10× macOS leg ran unconditionally.
- **Change:** a new `desktop-matrix` job resolves the matrix dynamically. **Linux (both arches) always builds** (cheap, not cross-compilable, catches cross-platform bundle breakage). **macos-15 builds only when a macOS-packaging input changed** on a PR — `website/electron/**`, `website/package[-lock].json`, `build-desktop.sh`, `Makefile`, `pyproject.toml`/`setup.cfg`, and the build workflows themselves — and **always on push / non-PR events**. Its unique coverage is macOS packaging, so a PR touching none of those cannot break it in a way the Linux legs won't already catch.
- **Scope guardrail:** `build-desktop.yml` (nightly + release) is **unchanged** and still ships every platform unconditionally, so nothing macOS ever reaches users unbuilt.
- **Readiness:** unaffected — `PR Readiness` aggregates the `build.yml` **workflow** conclusion, which stays green when the macos-15 leg is simply absent from the matrix (no per-job required context is configured on `main`).

## Tests

Rewrote `test_pr_and_release_desktop_matrices_cover_the_same_platforms` → `test_pr_desktop_matrix_gates_macos_but_never_linux`, encoding the new policy: the release lane still ships macos-15 + both Linux arches; the PR `desktop-matrix` compute step emits **both Linux arches in every branch** (unconditional) while **macos-15 appears in some but not all branches** (gated). `test_workflow_permissions.py` still passes (the new job declares minimal `contents: read` + `pull-requests: read`, needed by the paths filter).

## Manual verification

- `build.yml` parses; `desktop-matrix` present, `build-desktop` gains `needs: [desktop-matrix]`, matrix is `${{ fromJSON(needs.desktop-matrix.outputs.os) }}`.
- `test_publish_feed_contract.py` + `test_workflow_permissions.py`: **35 passed**.
- Self-consistent: this PR edits `build.yml`, which is in the `desktop` filter, so macos-15 **does** build for this PR (re-validating the packaging change).

Follow-up (not in scope): the `Gateway Tests (macOS)` job could be similarly gated, but it guards a security-critical peer-identity primitive, so that's a separate, carefully-scoped change.
