### PR TITLE
fix(chat): keep streaming follow armed when a shrink clamps scrollTop

### DIFF
--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -807,6 +807,23 @@ export function useVirtualChat<T>(
       } else if (!isSelfScroll(el.scrollTop, lastWriteTopRef.current)) {
         lastUserScrollAtRef.current = performance.now()
         stickRef.current = stickAfterUserScroll(atBottom, followOutput)
+        // A scroll we did not write that leaves us EXACTLY at the bottom was the
+        // layout engine's: the browser clamps scrollTop when a shrinking
+        // scrollHeight drops the maximum below it, and a spacer re-estimate does
+        // the same. Re-baseline the self-scroll reference to where we now are —
+        // otherwise it keeps pointing at our last write, and the next pin
+        // evaluation reads that gap as a user scroll-up, releasing follow for the
+        // rest of the turn with only a manual scroll back to the bottom able to
+        // re-arm it.
+        //
+        // The test is the CLAMP — distance within SELF_SCROLL_EPSILON — and NOT
+        // the 100px `atBottom` UI band. A real 3-100px scroll-up also keeps
+        // `stick` armed via stickAfterUserScroll, so re-baselining across that
+        // band would erase the only evidence evaluateAutoPin has of it and yank
+        // the user back to the bottom on the next append.
+        const clampedAtBottom =
+          geom.scrollHeight - (geom.scrollTop + geom.clientHeight) <= SELF_SCROLL_EPSILON
+        if (stickRef.current && clampedAtBottom) lastWriteTopRef.current = el.scrollTop
       }
       if (!scrollRafScheduledRef.current) {
         scrollRafScheduledRef.current = true
@@ -947,6 +964,17 @@ export function useVirtualChat<T>(
       }
     })
     resizeObserverRef.current = ro
+    // Back-fill rows that registered before this observer existed. Row ref
+    // callbacks run in the COMMIT phase, this effect runs after paint, so any
+    // row mounted in the same commit reached `measureRef` while
+    // `resizeObserverRef` was still null and its `ro?.observe` was a no-op.
+    // `measureRef` returns a STABLE per-index callback (so a row that stays
+    // mounted never churns observe/unobserve), which means React will not
+    // re-invoke it — without this pass such a row is never measured again and
+    // its streaming growth never reaches the follow pin. `elIndexRef` holds
+    // exactly the currently-mounted rows (the null-element branch deletes on
+    // unmount), so iterating it cannot resurrect a detached node.
+    for (const el of elIndexRef.current.keys()) ro.observe(el)
     return () => {
       ro.disconnect()
       // Cancel a frame queued by the last resize so it can't fire a

--- a/website/src/test/useVirtualChat.layoutShrink.test.tsx
+++ b/website/src/test/useVirtualChat.layoutShrink.test.tsx
@@ -1,0 +1,134 @@
+// Feature: chat-virtualizer — a layout-driven scrollTop drop must not disarm
+// follow, while a scroll that lands away from the bottom still must.
+//
+// Reproduces a captured production sequence. Mid-turn the content shrank 227px
+// and the browser clamped scrollTop by the same 227px, leaving the viewport
+// still exactly at the bottom. That clamp dispatches a `scroll` event which is
+// NOT a self-scroll (it lands 227px from the value we wrote), so the handler
+// ran — but it left the self-scroll reference pointing at our last write. The
+// next pin evaluation therefore read a 227px gap as a user scroll-up, released
+// follow, and never pinned again: scrollTop sat frozen for 20s while content
+// grew, and only a manual scroll back to the bottom re-armed it.
+//
+// jsdom has no layout engine, so scroll geometry is faked on a detached scroller
+// passed via `externalScrollerRef`, and the pin is driven through the append
+// layout effect (an itemCount increase) rather than a ResizeObserver — the same
+// technique the integration suite uses. Neither case dispatches an input event:
+// the discriminator is WHERE the scroll lands, not what caused it, which is what
+// keeps keyboard scrolling and wheels over widget iframes working (their events
+// never reach this element).
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { type RefObject } from 'react'
+
+import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
+import type { UseVirtualChatOptions } from '../hooks/virtualizer/types'
+
+interface Geom { scrollTop: number; scrollHeight: number; clientHeight: number }
+
+/** A detached div with controllable, mutable scroll geometry. */
+function makeScroller(initial: Geom) {
+  const el = document.createElement('div')
+  const state: Geom = { ...initial }
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    get: () => state.scrollTop,
+    set: (v: number) => { state.scrollTop = v },
+  })
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => state.scrollHeight })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => state.clientHeight })
+  ;(el as unknown as { scrollTo: (o: { top: number }) => void }).scrollTo = (o) => { state.scrollTop = o.top }
+  return { el, state }
+}
+
+interface Item { id: string }
+const getKey = (it: Item) => it.id
+const mkItems = (n: number): Item[] => Array.from({ length: n }, (_, i) => ({ id: `m${i}` }))
+
+// The captured numbers: pinned at 10318 of an 11462 scrollHeight over a 1144
+// viewport, then a 227px shrink with a matching clamp, then growth to 11441.
+const CH = 1144
+const START_SH = 11462
+const BOTTOM = START_SH - CH        // 10318 — where the pin lands
+const SHRUNK_SH = 11235
+const CLAMPED = SHRUNK_SH - CH      // 10091 — still exactly at the bottom
+const GROWN_SH = 11441
+const GROWN_BOTTOM = GROWN_SH - CH  // 10297 — where follow should land
+// GROWN_SH is below START_SH, so replaying the capture is a net 21px shrink.
+// The in-band scroll-up case needs genuine growth instead, or positions within
+// 21px of the old bottom sit past the new maximum and would be clamped anyway.
+const GROWN_TRUE_SH = START_SH + 200
+
+function mount(items: Item[], sessionId: string) {
+  const { el, state } = makeScroller({ scrollTop: 0, scrollHeight: START_SH, clientHeight: CH })
+  const ref: RefObject<HTMLDivElement | null> = { current: el }
+  const initialProps: UseVirtualChatOptions<Item> = { items, sessionId, getKey, externalScrollerRef: ref }
+  const view = renderHook((p: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(p), { initialProps })
+  return { el, state, view, ref }
+}
+
+describe('useVirtualChat: a clamp at the bottom vs a scroll away from it', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('keeps following when a content shrink clamps scrollTop at the bottom', () => {
+    const { el, state, view, ref } = mount(mkItems(5), 'layout-clamp')
+    expect(el.scrollTop).toBe(BOTTOM)
+
+    // The layout engine's doing: content shrinks, the browser clamps scrollTop
+    // by the same amount and dispatches a scroll. The viewport is still at the
+    // bottom, so this must re-baseline rather than look like a scroll-up.
+    act(() => {
+      state.scrollHeight = SHRUNK_SH
+      state.scrollTop = CLAMPED
+      el.dispatchEvent(new Event('scroll'))
+    })
+
+    // Streaming resumes: a row appends and content grows past the clamp.
+    act(() => {
+      state.scrollHeight = GROWN_SH
+      view.rerender({ items: mkItems(6), sessionId: 'layout-clamp', getKey, externalScrollerRef: ref })
+    })
+
+    expect(el.scrollTop).toBe(GROWN_BOTTOM)
+  })
+
+  it.each([3, 50, 100])('does not yank back a %ipx scroll-up inside the bottom band', (up) => {
+    const { el, state, view, ref } = mount(mkItems(5), `small-nudge-${up}`)
+    expect(el.scrollTop).toBe(BOTTOM)
+
+    // Inside the 100px `atBottom` UI band, so `stickAfterUserScroll` keeps stick
+    // armed and the only thing holding the position is evaluateAutoPin's
+    // scroll-up guard. Re-baselining on that band instead of on the clamp erases
+    // it and the next append pins to the bottom — the regression this locks out.
+    // 3px is the smallest move that clears SELF_SCROLL_EPSILON and so is the
+    // first that reaches this branch at all.
+    act(() => { state.scrollTop = BOTTOM - up; el.dispatchEvent(new Event('scroll')) })
+
+    act(() => {
+      state.scrollHeight = GROWN_TRUE_SH
+      view.rerender({ items: mkItems(6), sessionId: `small-nudge-${up}`, getKey, externalScrollerRef: ref })
+    })
+
+    expect(el.scrollTop).toBe(BOTTOM - up)
+  })
+
+  it('still releases follow for a scroll that lands away from the bottom', () => {
+    const { el, state, view, ref } = mount(mkItems(5), 'scroll-away')
+    expect(el.scrollTop).toBe(BOTTOM)
+
+    // Away from the bottom by far more than bottomThreshold. No input event is
+    // dispatched: a keyboard scroll or a wheel over a widget iframe produces
+    // exactly this — a scroll event on the scroller and nothing else — and it
+    // must still release follow.
+    act(() => { state.scrollTop = 4000; el.dispatchEvent(new Event('scroll')) })
+
+    act(() => {
+      state.scrollHeight = GROWN_SH
+      view.rerender({ items: mkItems(6), sessionId: 'scroll-away', getKey, externalScrollerRef: ref })
+    })
+
+    // Position preserved — no yank back to the bottom.
+    expect(el.scrollTop).toBe(4000)
+  })
+})

--- a/website/src/test/useVirtualChat.observerBackfill.test.tsx
+++ b/website/src/test/useVirtualChat.observerBackfill.test.tsx
@@ -1,0 +1,103 @@
+// Feature: chat-virtualizer — the ResizeObserver must observe rows that were
+// already mounted when it was created.
+//
+// Row ref callbacks (`measureRef`) attach during the COMMIT phase; the shared
+// ResizeObserver is created in a PASSIVE effect, which React runs after paint.
+// Any row whose ref attached before that effect ran therefore called
+// `ro?.observe` on a null observer. `measureRef` deliberately returns a
+// STABLE per-index callback (so a row that stays mounted is never re-invoked
+// and never churns observe/unobserve), which means such a row is never
+// observed again for as long as it stays mounted — its streaming growth never
+// reaches the observer, and follow silently stops working.
+//
+// The other suites in this directory leave `ResizeObserver` undefined so the
+// RO path cannot perturb their pin assertions; this one installs a recording
+// stub precisely to assert on the registration itself, and removes it again.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { useRef, type RefObject } from 'react'
+
+import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
+
+/** ResizeObserver stub that records which elements are under observation. */
+class RecordingResizeObserver {
+  static instances: RecordingResizeObserver[] = []
+  readonly observed = new Set<Element>()
+  constructor(readonly cb: ResizeObserverCallback) {
+    RecordingResizeObserver.instances.push(this)
+  }
+  observe(el: Element) { this.observed.add(el) }
+  unobserve(el: Element) { this.observed.delete(el) }
+  disconnect() { this.observed.clear() }
+}
+
+interface Item { id: string }
+const getKey = (it: Item) => it.id
+const mkItems = (n: number): Item[] => Array.from({ length: n }, (_, i) => ({ id: `m${i}` }))
+
+/**
+ * Renders rows exactly as ChatPage does — `measureRef(index)` on each mounted
+ * row — so the refs attach in the same commit that mounts the list, before the
+ * hook's passive effects run.
+ */
+function Harness({ items }: { items: Item[] }) {
+  const scrollerRef = useRef<HTMLDivElement>(null)
+  const virt = useVirtualChat<Item>({
+    items,
+    sessionId: 'observer-backfill',
+    getKey,
+    externalScrollerRef: scrollerRef as RefObject<HTMLDivElement | null>,
+  })
+  return (
+    <div ref={scrollerRef}>
+      {virt.virtualItems.map((vi) =>
+        vi.mounted ? (
+          <div key={vi.key} ref={virt.measureRef(vi.index)} data-row={vi.index} />
+        ) : null,
+      )}
+    </div>
+  )
+}
+
+describe('useVirtualChat: ResizeObserver registration', () => {
+  const original = globalThis.ResizeObserver
+
+  beforeEach(() => {
+    localStorage.clear()
+    RecordingResizeObserver.instances.length = 0
+    globalThis.ResizeObserver = RecordingResizeObserver as unknown as typeof ResizeObserver
+  })
+
+  afterEach(() => {
+    globalThis.ResizeObserver = original
+  })
+
+  it('observes rows that mounted before the observer was created', () => {
+    const { container } = render(<Harness items={mkItems(4)} />)
+
+    const rows = Array.from(container.querySelectorAll('[data-row]'))
+    expect(rows.length).toBeGreaterThan(0)
+
+    expect(RecordingResizeObserver.instances).toHaveLength(1)
+    const ro = RecordingResizeObserver.instances[0]
+
+    // Every row present at mount must be under observation. Without the
+    // back-fill these rows registered against a null observer and stay
+    // unobserved forever, so their growth never fires the follow pin.
+    for (const row of rows) expect(ro.observed.has(row)).toBe(true)
+  })
+
+  it('drops a row from observation when it unmounts', () => {
+    const { container, rerender } = render(<Harness items={mkItems(4)} />)
+    const ro = RecordingResizeObserver.instances[0]
+    const firstRow = container.querySelector('[data-row]')!
+    expect(ro.observed.has(firstRow)).toBe(true)
+
+    // An empty transcript unmounts every row. The back-fill must not resurrect
+    // a detached node on a later pass.
+    act(() => { rerender(<Harness items={[]} />) })
+
+    expect(ro.observed.has(firstRow)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

Mid-turn, chat auto-follow stops. The viewport freezes while the response keeps
streaming below the fold, and it stays frozen after the turn ends — only
scrolling back to the bottom by hand re-arms it. A captured trace shows
`scrollTop` pinned at 10091 for 21.8 seconds while `scrollHeight` climbed
11235 → 11475 and distance-from-bottom walked 0 → 278.

## Why it matters

The newest text is what a chat is for. When follow dies the user reads a stale
frame and has to chase the stream by hand, on every affected turn, with no
feedback about why. It is intermittent, which makes it read as flakiness rather
than a bug.

## Fix (symptom → root cause → change)

The trace shows `scrollTop` **never decreases**, so nothing was scrolling the
user up. The break instant is a content shrink that the browser clamps:

```
1549006  scroll  10318  11462  1144  0    <- last successful pin
1549097  scroll  10091  11235  1144  0    <- content -227, scrollTop clamped -227, still at bottom
1551790  tick    10091  11441  1144  206  <- scrollHeight grows, scrollTop unchanged: follow is gone
```

That clamp dispatches a `scroll` event which is **not** a self-scroll (it lands
227px from the value we wrote), so the passive handler ran — but it only updated
`stick`. `lastWriteTopRef` kept pointing at 10318 while the element sat at 10091,
so the next `evaluateAutoPin` read that 227px gap as a user scroll-up, released
`stick`, and never pinned again. The only path that re-arms `stick` is a user
scroll landing at the bottom, which is why it never self-healed.

Change: in the non-self-scroll branch, when the scroll leaves the viewport
**clamped at the bottom** (distance within `SELF_SCROLL_EPSILON`), re-baseline
`lastWriteTopRef` to the current position. The following growth then measures
against 10091 and pins to 10297 as it should.

The gate is the clamp, deliberately **not** the 100px `atBottom` UI band: a real
3-100px scroll-up also keeps `stick` armed via `stickAfterUserScroll`, so
re-baselining across that band would erase the only evidence `evaluateAutoPin`
has of it and yank the user back to the bottom. A clamp lands at distance 0; a
scroll-up lands at distance > 0. Because the discriminator is *where* the scroll
lands rather than what caused it, release keeps working for every input path,
including keyboard scrolling and wheels over widget iframes whose events never
reach this element.

Also included: the shared `ResizeObserver` now back-fills rows already registered
in `elIndexRef` when it is created. Row ref callbacks run in the commit phase and
the observer is created in a passive effect, so a row mounted in the same commit
called `ro?.observe` on a null observer; `measureRef` returns a stable per-index
callback, so React never re-invokes it and that row was never measured again.

## Tests

- `useVirtualChat.layoutShrink.test.tsx` — replays the captured sequence with its
  real numbers. Case 1: the shrink-clamp must keep following and pin to 10297.
  Cases 2-4: a 3px, 50px and 100px scroll-up must each hold position across a
  later append. Case 5: a scroll to 4000 must release follow. Reverting the gate
  to `atBottom` fails all three band cases; removing the re-baseline entirely
  fails case 1. Neither the clamp case nor the release case is vacuous — each
  passes while the other fails under the respective mutation.
- `useVirtualChat.observerBackfill.test.tsx` — rows present at mount must be under
  observation, and must drop out on unmount. Both fail without the back-fill.

No existing test was modified.

## Manual verification

The root cause was identified from a live instrumented capture on the dashboard
(the trace quoted above), not from reading alone. The fix itself is verified by
unit tests plus an independent sweep of the 3-100px band at 11 positions and 37
device-pixel-ratio combinations, confirming the clamp gate and
`evaluateAutoPin`'s DPR-aware epsilon cannot disagree reachably.

## Screenshots

N/A — no visual surface changes. The behaviour is scroll position over time,
which a still frame cannot show; the captured `scrollTop` / `scrollHeight` trace
above is the evidence a screenshot would otherwise stand in for.
