### PR TITLE
fix: scope Docker creds-scrub skip to credential keys only (#2827)

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -6064,13 +6064,20 @@ class KiroCrewConfig:
         # EXCEPTION: when the Docker entrypoint has deliberately scrubbed
         # credentials from the process environ (setting _KIROCREW_CREDS_SCRUBBED=1),
         # re-injecting them here would leak into /proc/<pid>/environ — the exact
-        # attack surface the entrypoint closed. In that case, children that need
-        # credentials get them via their own .env read or via an explicit env=
-        # kwarg on Popen (the sandbox and ACP spawners already do this).
-        if not os.environ.get("_KIROCREW_CREDS_SCRUBBED"):
-            for k, v in creds.items():
-                if v:
-                    os.environ.setdefault(k, v)
+        # attack surface the entrypoint closed. The scrub covers only credential
+        # keys, so the skip is scoped to _CREDENTIAL_KEYS: every other .env entry
+        # (operator-added settings such as proxy or feature variables) still
+        # propagates so children behave identically in and out of Docker.
+        # Children that need the withheld credentials get them via their own
+        # .env read or via an explicit env= kwarg on Popen (the sandbox and ACP
+        # spawners already do this).
+        scrubbed = bool(os.environ.get("_KIROCREW_CREDS_SCRUBBED"))
+        for k, v in creds.items():
+            if not v:
+                continue
+            if scrubbed and k in _CREDENTIAL_KEYS:
+                continue
+            os.environ.setdefault(k, v)
 
         return creds
 

--- a/test/test_review_fixes.py
+++ b/test/test_review_fixes.py
@@ -366,6 +366,91 @@ class TestLoadCredentialsEnvPropagation:
         assert creds["SLACK_BOT_TOKEN"] == "xoxb-from-parent"
         assert os.environ["SLACK_BOT_TOKEN"] == "xoxb-from-parent"
 
+    def test_scrubbed_marker_withholds_only_credential_keys(
+        self, tmp_path: object, monkeypatch
+    ) -> None:
+        """With _KIROCREW_CREDS_SCRUBBED set (Docker entrypoint), credential
+        keys stay out of os.environ while non-credential .env entries still
+        propagate to spawned children."""
+        import os
+        from pathlib import Path
+
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        monkeypatch.setenv("_KIROCREW_CREDS_SCRUBBED", "1")
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("KC_TEST_PROXY_SETTING", raising=False)
+
+        tmp = Path(str(tmp_path))
+        env_file = tmp / ".env"
+        env_file.write_text(
+            "SLACK_BOT_TOKEN=xoxb-placeholder\n" "KC_TEST_PROXY_SETTING=proxy-value\n"
+        )
+        env_file.chmod(0o600)
+
+        try:
+            with patch("kiro_crew.config.loader.env_path", return_value=env_file):
+                cfg = KiroCrewConfig.__new__(KiroCrewConfig)
+                creds = cfg.load_credentials()
+
+            # The returned creds dict still carries both entries…
+            assert creds["SLACK_BOT_TOKEN"] == "xoxb-placeholder"
+            assert creds["KC_TEST_PROXY_SETTING"] == "proxy-value"
+            # …but only the non-credential key reaches the process environ:
+            # re-injecting a scrubbed credential would leak it back into
+            # /proc/<pid>/environ.
+            assert "SLACK_BOT_TOKEN" not in os.environ
+            assert os.environ.get("KC_TEST_PROXY_SETTING") == "proxy-value"
+        finally:
+            os.environ.pop("KC_TEST_PROXY_SETTING", None)
+
+    def test_scrubbed_marker_withholds_every_credential_key(
+        self, tmp_path: object, monkeypatch
+    ) -> None:
+        """The skip covers the full _CREDENTIAL_KEYS tuple, not just the subset
+        the entrypoint scrubs today — withholding is the safe direction."""
+        import os
+        from pathlib import Path
+
+        from kiro_crew.config.loader import _CREDENTIAL_KEYS, KiroCrewConfig
+
+        monkeypatch.setenv("_KIROCREW_CREDS_SCRUBBED", "1")
+        for key in _CREDENTIAL_KEYS:
+            monkeypatch.delenv(key, raising=False)
+
+        # Hardcoded literal so no expression derived from the credential-key
+        # tuple flows into a file write; the assertion below keeps the fixture
+        # from drifting out of sync with _CREDENTIAL_KEYS.
+        fixture_keys = (
+            "SLACK_APP_TOKEN",
+            "SLACK_BOT_TOKEN",
+            "KIROCREW_OWNER_ID",
+            "WECOM_BOT_ID",
+            "WECOM_SECRET",
+            "TELEGRAM_BOT_TOKEN",
+            "DISCORD_BOT_TOKEN",
+            "WEBEX_BOT_TOKEN",
+            "MICROSOFT_APP_ID",
+            "MICROSOFT_APP_PASSWORD",
+            "MICROSOFT_APP_TENANT_ID",
+            "WEIXIN_TOKEN",
+        )
+        assert set(fixture_keys) == set(_CREDENTIAL_KEYS)
+
+        tmp = Path(str(tmp_path))
+        env_file = tmp / ".env"
+        env_file.write_text(
+            "".join(f"{key}=placeholder-value\n" for key in fixture_keys)
+        )
+        env_file.chmod(0o600)
+
+        with patch("kiro_crew.config.loader.env_path", return_value=env_file):
+            cfg = KiroCrewConfig.__new__(KiroCrewConfig)
+            cfg.load_credentials()
+
+        for key in _CREDENTIAL_KEYS:
+            assert key not in os.environ
+
 
 class TestYoloFromConfigGuard:
     """Tests for config-sourced safety override.


### PR DESCRIPTION
## What is the problem?

In Docker, every non-credential `.env` entry is silently dropped from the process environment. The `_KIROCREW_CREDS_SCRUBBED` guard in `load_credentials()` (`src/kiro_crew/config/loader.py`) wraps the ENTIRE propagation loop, but the `.env` parser puts every `KEY=VALUE` pair into the `creds` dict — not just credentials — and the Docker entrypoint only scrubs credential keys.

## Why this issue matters to the user

An operator who adds a non-credential setting to `.env` (a proxy variable, a feature flag) gets it applied on bare-metal installs but silently ignored inside Docker: spawned children (sandboxed agents, MCP servers, cron subprocesses) never see it. Same config file, different behavior, no error anywhere.

## How our fix solves it

Symptom: non-credential `.env` entries vanish in Docker → mechanism: the scrubbed-marker guard skips the whole `creds` loop, though the entrypoint's scrub (the reason the guard exists) only covers credential keys → change: narrow the skip to keys in `_CREDENTIAL_KEYS`. When the marker is set, credential keys are withheld (re-injecting them would leak back into `/proc/<pid>/environ` — the exact surface the entrypoint closed); every other key keeps its `setdefault`, restoring parity with non-Docker hosts.

`_CREDENTIAL_KEYS` (12 keys) is a strict superset of what the entrypoint scrubs today (8 keys), so the narrowing errs toward withholding — the safe direction.

## What tests we did

- `test_scrubbed_marker_withholds_only_credential_keys` — with the marker set, a credential key stays out of `os.environ` while a non-credential key propagates (fails on the pre-fix code).
- `test_scrubbed_marker_withholds_every_credential_key` — all 12 `_CREDENTIAL_KEYS` are withheld, locking in superset coverage.
- Mutation-verified: reverting to the whole-loop skip and deleting the scrubbed check are each caught by the new tests (2/2 mutants).
- Full local gates: isort ✓, flake8 (CI pin 7.1.0) ✓, mypy ✓ (4 pre-existing base errors in `transcribe.py`/`cloudwatch.py`, A/B-verified on origin/main), pytest with baseline diff against origin/main: 0 regressions.

## Any other suggestions on the work

Review surfaced one adjacent pre-existing defect, out of this PR's scope: the entrypoint's scrub list has drifted from `_CREDENTIAL_KEYS` (8 vs 12 keys), so the 4 unlisted keys passed via `docker run -e` are never scrubbed at all. Filed as #2921 with a suggested derive-from-product fix. A second advisory observation — operator secrets not named in `_CREDENTIAL_KEYS` now propagate again in Docker — is the deliberate outcome: it is exactly the pre-guard behavior on every non-Docker host, and the entrypoint never scrubbed those keys in the first place.

Closes #2827
