### PR TITLE
refactor(chat-sdk): make transcript row rendering a registry

### DIFF
--- a/docs/app-kit/api-reference.md
+++ b/docs/app-kit/api-reference.md
@@ -140,6 +140,92 @@ lives in a component is only available to surfaces that render that component, w
 transcript print raw marker text. `website/src/test/chatProtocolBoundary.test.ts` asserts that, and
 also that no other non-test source defines the markers a second time.
 
+## Chat Transcript Rendering
+
+`ChatMessageList` renders a transcript. Which component draws a given row is a **registry** keyed by
+the message's `role`, so you add a row type or replace one instead of forking the list.
+
+```jsx
+import { ChatMessageList } from '@kirocrew/app-sdk'
+
+<ChatMessageList messages={messages} running={running} />
+```
+
+That renders the built-in rows. To change one, pass `renderers`.
+
+### Adding a row the transcript does not draw
+
+Four roles are deliberately undrawn — `thinking`, `system`, `done` and `queued` — because the
+dashboard shows them through other affordances. `file` is undrawn too. Claim one and it is yours:
+
+```jsx
+const renderers = [{
+  id: 'queued-card',
+  roles: ['queued'],
+  render: (m, ctx) => ctx.row(<div className="queued">{m.content}</div>),
+}]
+
+<ChatMessageList messages={messages} running={running} renderers={renderers} />
+```
+
+### Replacing a built-in row
+
+Reuse the built-in's `id`:
+
+```jsx
+const renderers = [{
+  id: 'error',                       // replaces the built-in error row
+  roles: ['error'],
+  render: (m, ctx) => ctx.row(<MyErrorCard text={m.content} />),
+}]
+```
+
+Import `defaultMessageRenderers` if you need to read what the built-ins do, and `resolveRenderer` /
+`mergeRenderers` if you are composing a registry yourself rather than handing one to
+`ChatMessageList`.
+
+### What a renderer is handed
+
+| Field | Purpose |
+|---|---|
+| `index`, `messages` | position and the whole transcript, for a row that must look ahead |
+| `running` | whether the session is producing output |
+| `key` | the row's stable React key |
+| `wrapper(children, isUser)` | bubble layout; `isUser` right-aligns |
+| `row(children, tight)` | full-width layout for cards, pills and banners |
+| `onFileOpen` | open a path, when the host supports it |
+| `autoDeniedIds` | tool calls a policy or hook blocked |
+| `renderTool` | the host's tool row, if it passed one |
+
+Two rules the registry relies on:
+
+- **Shape beats role.** Resolution is first-match, and your entries sit between the two built-ins
+  recognised by message *shape* — a stop event and a sub-agent completion, which claim `'*'` and gate
+  on a `match` predicate — and the role-keyed ones. This matters because a stop event reaches the
+  transcript as role `system`, which is also a role you are invited to claim: were a role claim
+  allowed to outrank a `kind` check, claiming `system` would swallow the stop card and pressing Stop
+  would draw your row instead. A role claim cannot know about `kind`, so it does not outrank one.
+  Replacing a shape-matched row is still possible and stays explicit — reuse its `id`.
+- **Returning `null` is different from not claiming a role.** An entry that exists and draws nothing
+  says "no row by design"; no entry at all says "nothing handles this". Both look identical on
+  screen, so `website/src/test/messageRenderers.test.ts` pins which is which.
+
+### Exports
+
+| Export | Kind | Purpose |
+|---|---|---|
+| `ChatMessageList` | component | the transcript |
+| `defaultMessageRenderers` | value | the built-in registry, in resolution order |
+| `mergeRenderers(extra)` | function | shape-matched defaults, then host entries, then the rest |
+| `resolveRenderer(message, renderers)` | function | first entry that claims the message |
+| `ToolCallPill` | component | the store-free tool row the default registry uses |
+| `MessageRenderer` | type | `{ id, roles, match?, render }` |
+| `MessageRenderContext` | type | what `render` is handed |
+
+The registry takes no store and no router dependency, and reads live state only through the context
+it is handed — an app runs outside the dashboard's React root and has no store to select from. A row
+that genuinely needs live app state is supplied by the host as an entry.
+
 ## Gateway API Surface
 
 The sections below document the canonical Gateway API surface as exposed by the

--- a/docs/app-kit/getting-started.md
+++ b/docs/app-kit/getting-started.md
@@ -192,6 +192,11 @@ choices and steer acknowledgements inline in its prose (`[OPTIONS: a | b]`,
 Types: `ParsedOptions`, `FollowUpDerivation`, `ChatMessage`. React-free, so it also works in a worker
 or a test. Worked examples: [api-reference.md](api-reference.md#chat-marker-protocol).
 
+To render a transcript rather than parse one, `ChatMessageList` draws it and its row
+**registry** lets you add a row type or replace one without forking the list — including the
+roles the dashboard leaves undrawn. See
+[api-reference.md](api-reference.md#chat-transcript-rendering).
+
 ## Shared UI Components
 
 Available in `@kirocrew/app-sdk/ui`:

--- a/skills/kirocrew-app-dev/SKILL.md
+++ b/skills/kirocrew-app-dev/SKILL.md
@@ -360,10 +360,13 @@ _jsx('button', {
 - `react/jsx-runtime` (_jsx, _jsxs, Fragment)
 - `react-dom`
 - `@kirocrew/app-sdk` — hooks (`useAppApi`, `useAppEvents`, `useTheme`, `useAppInfo`,
-  `useNavigate`, `useNotify`, `useNavBadge`, `useChatLauncher`), the `ChatEmbed` /
-  `ChatPanel` components, and the chat **marker protocol** (`parseOptions`,
+  `useNavigate`, `useNotify`, `useNavBadge`, `useChatLauncher`, `useChatSession`), the
+  `ChatEmbed` / `ChatPanel` / `ChatMessageList` components, the transcript's row
+  **registry** (`defaultMessageRenderers`, `mergeRenderers`, `resolveRenderer`,
+  `ToolCallPill`), and the chat **marker protocol** (`parseOptions`,
   `deriveFollowUpOptions`, `extractSteeringAcks`, `stripPartialOptionMarker`). The protocol
-  is React-free, so a worker or a plain function can use it too — see
+  is React-free, so a worker or a plain function can use it too. The registry is how you add
+  a transcript row type or replace one instead of hand-rolling a message list — see
   `docs/app-kit/api-reference.md`.
 
 ### Interactive Elements (Chat Launch)

--- a/website/public/vendor/kirocrew-app-sdk.mjs
+++ b/website/public/vendor/kirocrew-app-sdk.mjs
@@ -7,4 +7,7 @@ export const {
   // Marker protocol. Naming an export the host does not provide is a load-time failure for the
   // whole app, so this list is checked against the protocol barrel by chatProtocolBoundary.test.ts.
   parseOptions, deriveFollowUpOptions, extractSteeringAcks, stripPartialOptionMarker,
+  // Chat surfaces and the transcript row registry.
+  useChatSession, ChatPanel, ChatEmbed, ChatMessageList,
+  defaultMessageRenderers, mergeRenderers, resolveRenderer, ToolCallPill,
 } = m

--- a/website/src/app-sdk/ChatMessageList.tsx
+++ b/website/src/app-sdk/ChatMessageList.tsx
@@ -8,24 +8,17 @@
  * ChatEmbed wraps this in a simple scrollable div.
  */
 import React, { useMemo, useCallback, memo } from 'react'
-import { Clock, LoaderCircle, CircleSlash, CircleAlert, CircleDot, Lock, PanelRight } from 'lucide-react'
-import { i18nT } from '../i18n/t'
-import { extractToolFilePath } from '../utils/toolFilePath'
-import { isSafePath } from '../utils/safePath'
-import AssistantMessage, { type TurnStats } from '../pages/chat/AssistantMessage'
-import UserMessage from '../pages/chat/UserMessage'
 import CollapsibleToolGroup from '../pages/chat/CollapsibleToolGroup'
 import TurnBlock from '../pages/chat/TurnBlock'
-import { renderMcpOAuthMessage } from '../pages/chat/McpOAuthBanner'
-import SubagentCompletionCard from '../pages/chat/SubagentCompletionCard'
 import { isSubagentCompletionMessage } from '../pages/chat/subagentCompletion'
-import MarkdownRenderer from '../components/MarkdownRenderer'
-import MessageErrorBoundary from '../components/MessageErrorBoundary'
-import PastedChip from '../components/PastedChip'
-import { type PasteBlock, findTokenRanges, recollapsePastes } from '../utils/pasteTokens'
+import {
+  type MessageRenderer,
+  type MessageRenderContext,
+  mergeRenderers,
+  resolveRenderer,
+} from './messageRenderers'
 import type { ChatMessage } from '../types'
 import type { TurnItem, DisplayItem } from '../pages/chat/types'
-import { fmtMessageTime, fmtMessageTimeFull } from '../pages/chat/messageTime'
 
 // ── Types ──
 
@@ -45,145 +38,18 @@ export interface ChatMessageListProps {
    *  SDK; the dashboard host passes its `connections_ui` flag. Default renders
    *  every banner, which is correct for any surface with no cards. */
   hideCardOwnedOAuth?: boolean
+  /** Extra renderer entries, searched before the built-ins. An entry reusing a
+   *  built-in id replaces it; one claiming an undrawn role adds a row type. */
+  renderers?: readonly MessageRenderer[]
 }
 
 // ── Stable helpers (outside component) ──
 
-function renderUserContent(content: string, meta: Record<string, unknown> | undefined): React.ReactNode {
-  // History load re-serves the fully-EXPANDED paste content alongside
-  // meta.pastes. Handing a large paste (hundreds of KB / tens of thousands of
-  // lines) straight to MarkdownRenderer parses + lays it out on the main thread
-  // and freezes the tab. Re-collapse the message's own blocks back to
-  // `[ Paste #N ]` chips so only the small token text is rendered. Mirrors
-  // ChatPage.renderUserContentInner; kept minimal here to stay Redux-free.
-  const pastes = (meta?.pastes as PasteBlock[] | undefined) || []
-  if (pastes.length) {
-    let text = content
-    let ranges = findTokenRanges(text, pastes)
-    if (!ranges.length) {
-      const collapsed = recollapsePastes(content, pastes)
-      if (collapsed !== content) { text = collapsed; ranges = findTokenRanges(text, pastes) }
-    }
-    if (ranges.length) {
-      const out: React.ReactNode[] = []
-      let last = 0
-      ranges.forEach((r, i) => {
-        const trimStart = text[r.start - 1] === '\n' ? r.start - 1 : r.start
-        const trimEnd = text[r.end] === '\n' ? r.end + 1 : r.end
-        if (trimStart > last) {
-          const seg = text.slice(last, trimStart)
-          if (seg) out.push(<span key={`t${i}`} style={{ whiteSpace: 'pre-wrap' }}>{seg}</span>)
-        }
-        out.push(<PastedChip key={`p${i}-${r.block.id}`} block={r.block} />)
-        last = trimEnd
-      })
-      if (last < text.length) {
-        const seg = text.slice(last)
-        if (seg) out.push(<span key="tend" style={{ whiteSpace: 'pre-wrap' }}>{seg}</span>)
-      }
-      return <MessageErrorBoundary rawContent={text}>{out}</MessageErrorBoundary>
-    }
-  }
-  return <MessageErrorBoundary rawContent={content}><MarkdownRenderer content={content} /></MessageErrorBoundary>
-}
-
 const GROUPABLE = new Set(['thinking', 'permission'])
-
-/**
- * Delegates to the shared footer formatter so an embedded app's transcript reads
- * IDENTICALLY to the main chat's. This was a second, hardcoded copy that never
- * printed a year at all — so an app showing a message from a previous year dated
- * it to the current one. `fmtMessageTime` elides the year only when it is safe.
- */
-function formatTs(ts?: string): string | undefined {
-  if (!ts) return undefined
-  return fmtMessageTime(ts) || undefined
-}
 
 function msgKey(m: ChatMessage, i: number): string {
   return (m.ts || '') + '-' + i + '-' + m.role
 }
-
-// ── ToolCallPill (prop-driven, no Redux) ──
-
-const ToolCallPill = memo(function ToolCallPill({ message, running, onFileOpen, autoDenied }: { message: ChatMessage; running: boolean; onFileOpen?: (path: string) => void; autoDenied?: boolean }) {
-  const [expanded, setExpanded] = React.useState(false)
-  const isDone = message.role === 'tool_result'
-  const isRejected = message.meta?.resolved === 'rejected'
-  const hasPendingPerm = message.role === 'permission' && !message.meta?.resolved
-
-  // Prefer the backend-stamped purpose ("Add teams_data dict guard…") over the
-  // raw command, matching the main chat. The raw label is the fallback, and is
-  // no longer hard-truncated to 80 chars — CSS truncation keeps one line without
-  // destroying the text for the expanded panel or the file probe.
-  const rawLabel = (message.content || '').replace(/^🔧\s*/, '').split('\n')[0]
-  const purpose = typeof message.meta?.purpose === 'string' ? message.meta.purpose : ''
-  const label = purpose || rawLabel || message.role
-
-  // Status icon + colour mirror ToolCallLine so an embedded transcript reads
-  // with the same visual grammar as a main session: spinner while running,
-  // green dot when done, amber alert for auto-denied (policy/hook block —
-  // detected by the HOST from the hidden 🚫 sibling message and passed in,
-  // since this pill only ever renders the visible 🔧 message), red slash when
-  // user-rejected, amber lock when awaiting approval. Previously EVERY state
-  // showed one accent-purple spinning wrench, so a finished call was
-  // indistinguishable from an in-flight one.
-  const isAutoDenied = !isRejected && !!autoDenied
-  // Auto-denied is TERMINAL even though the 🔧 message never becomes a
-  // tool_result (isDone) — the gate blocked the call, nothing further runs —
-  // so it must escape both the loader icon and the spin animation.
-  const Icon = isRejected ? CircleSlash : isAutoDenied ? CircleAlert : isDone ? CircleDot : hasPendingPerm ? Lock : LoaderCircle
-  const tone = isRejected
-    ? 'text-danger bg-danger-subtle'
-    : isAutoDenied
-      ? 'text-warn bg-warn-subtle'
-      : isDone
-        ? 'text-ok bg-ok/5'
-        : hasPendingPerm
-          ? 'text-warn bg-warn-subtle'
-          : 'text-accent bg-accent/5'
-  // Animate ONLY while the session is actually running. A tool call left
-  // un-terminated by a dropped turn used to spin forever, so an idle transcript
-  // still looked busy — the loading state has to reflect the session, not just
-  // the message role.
-  const iconClass = !isDone && !hasPendingPerm && !isRejected && !isAutoDenied && running ? 'animate-spin' : ''
-
-  // File affordance: same pure helpers the main chat uses (no store needed).
-  const filePath = React.useMemo(() => {
-    const src = typeof message.meta?.input_preview === 'string' ? message.meta.input_preview : rawLabel
-    const p = extractToolFilePath(src)
-    return p && isSafePath(p) ? p : null
-  }, [message.meta?.input_preview, rawLabel])
-
-  return (
-    <div className="animate-scale-in flex items-center gap-1.5 flex-wrap">
-      <button
-        onClick={() => setExpanded(e => !e)}
-        aria-expanded={expanded}
-        className={`inline-flex items-center gap-1 text-[13px] font-mono px-2 py-0.5 rounded-md cursor-pointer transition-all max-w-[min(600px,90%)] hover:brightness-110 ${tone}`}
-      >
-        <Icon size={12} className={iconClass} />
-        <span className="truncate">{label}</span>
-      </button>
-      {filePath && onFileOpen && (
-        <button
-          onClick={() => onFileOpen(filePath)}
-          title={i18nT('appSdk.chatMessageList.open_path', { path: filePath })}
-          aria-label={i18nT('appSdk.chatMessageList.open_path', { path: filePath })}
-          className="inline-flex items-center gap-1 text-[12px] font-mono px-1.5 py-0.5 rounded-md border border-border text-muted cursor-pointer hover:text-text hover:border-border-strong transition-all"
-        >
-          {filePath.split('/').pop()}
-          <PanelRight size={11} />
-        </button>
-      )}
-      {expanded && message.content && (
-        <pre className="w-full text-[11px] font-mono text-muted bg-bg-elevated rounded-md p-2 mt-1 ml-4 max-h-40 overflow-auto whitespace-pre-wrap break-all border border-border">
-          {purpose && rawLabel && purpose !== rawLabel ? rawLabel + '\n\n' + message.content : message.content}
-        </pre>
-      )}
-    </div>
-  )
-})
 
 // ── Main component ──
 
@@ -195,6 +61,7 @@ const ChatMessageList = memo(function ChatMessageList({
   onFileOpen,
   renderTool,
   hideCardOwnedOAuth = false,
+  renderers,
 }: ChatMessageListProps) {
 
   // Phase 1: Build raw items — skip permissions, group thinking
@@ -267,7 +134,10 @@ const ChatMessageList = memo(function ChatMessageList({
     return ids
   }, [messages])
 
-  // Render a single message by role
+  // Resolve each row through the registry. Host entries are searched first, so
+  // the same lookup serves a plain embed and a store-connected dashboard.
+  const activeRenderers = useMemo(() => mergeRenderers(renderers), [renderers])
+
   const renderMessage = useCallback((m: ChatMessage, i: number) => {
     const key = msgKey(m, i)
     const wrapper = (children: React.ReactNode, isUser = false) => (
@@ -279,131 +149,30 @@ const ChatMessageList = memo(function ChatMessageList({
         </div>
       </div>
     )
+    const row = (children: React.ReactNode, tight = false) => (
+      <div key={key} className={`px-5 mx-auto w-full ${tight ? 'py-0.5' : 'py-1'}`} style={{ maxWidth: `var(--mc-content-width, ${contentWidth})` }}>
+        {children}
+      </div>
+    )
 
-    if (m.kind === 'stop_event' || m.meta?.kind === 'stop_event') {
-      return (
-        <div key={key} className="px-5 mx-auto w-full py-1" style={{ maxWidth: `var(--mc-content-width, ${contentWidth})` }}>
-          <div className="text-danger text-[13px] font-mono px-3 py-2 rounded-md bg-danger-subtle inline-flex items-center gap-1.5">
-            {m.content}
-          </div>
-        </div>
-      )
+    const entry = resolveRenderer(m, activeRenderers)
+    if (!entry) return null
+
+    const ctx: MessageRenderContext = {
+      index: i,
+      messages,
+      running,
+      key,
+      onFileOpen,
+      hideCardOwnedOAuth,
+      autoDeniedIds,
+      renderTool,
+      wrapper,
+      row,
     }
+    return entry.render(m, ctx)
+  }, [messages, running, contentWidth, onFileOpen, renderTool, autoDeniedIds, hideCardOwnedOAuth, activeRenderers])
 
-    if (isSubagentCompletionMessage(m)) {
-      return (
-        <SubagentCompletionCard
-          key={key}
-          message={m}
-          onFileOpen={onFileOpen}
-          disclosureKey={key}
-        />
-      )
-    }
-
-    if (m.role === 'user') {
-      return wrapper(
-        <UserMessage content={m.content} meta={m.meta} timestamp={formatTs(m.ts)} timestampTitle={fmtMessageTimeFull(m.ts)} renderContent={renderUserContent} />,
-        true
-      )
-    }
-
-    if (m.role === 'assistant' || m.role === 'streaming') {
-      const isStreaming = m.role === 'streaming'
-      let showFooter = false
-      if (!isStreaming) {
-        let nextRelevant = false
-        for (let j = i + 1; j < messages.length; j++) {
-          if (messages[j].role === 'user') { showFooter = true; nextRelevant = true; break }
-          if (messages[j].role === 'assistant' || messages[j].role === 'streaming') { nextRelevant = true; break }
-        }
-        if (!nextRelevant) showFooter = !running
-      }
-      return wrapper(
-        <div className="flex flex-col gap-0">
-          <AssistantMessage
-            content={m.content}
-            isStreaming={isStreaming}
-            timestamp={formatTs(m.ts)}
-            timestampTitle={fmtMessageTimeFull(m.ts)}
-            showFooter={showFooter}
-            slotRunning={running}
-            onFileOpen={onFileOpen}
-            variants={m.variants}
-            variantIdx={m.variant_idx}
-            turnStats={(m.meta as Record<string, unknown> | undefined)?.turn_stats as TurnStats | undefined}
-          />
-        </div>
-      )
-    }
-
-    if (m.role === 'tool' && m.content?.startsWith('🔧')) {
-      const tcid = m.meta?.tool_call_id as string | undefined
-      return (
-        <div key={key} className="px-5 mx-auto w-full py-0.5" style={{ maxWidth: `var(--mc-content-width, ${contentWidth})` }}>
-          {renderTool ? renderTool(m) : <ToolCallPill message={m} running={running} onFileOpen={onFileOpen} autoDenied={!!tcid && autoDeniedIds.has(tcid)} />}
-        </div>
-      )
-    }
-
-    if (m.role === 'tool_call' || m.role === 'tool_result') {
-      return (
-        <div key={key} className="px-5 mx-auto w-full py-0.5" style={{ maxWidth: `var(--mc-content-width, ${contentWidth})` }}>
-          {renderTool ? renderTool(m) : <ToolCallPill message={m} running={running} onFileOpen={onFileOpen} />}
-        </div>
-      )
-    }
-
-    if (m.role === 'inject') {
-      const cronLabel = (m.meta?.cronLabel as string) || ''
-      const cleanContent = cronLabel
-        ? m.content.replace(/^\[Cron notification from ".*"\]\n/, '').replace(/\n\[End of cron notification\]$/, '')
-        : m.content
-      return wrapper(
-        <>
-          {cronLabel && <span className="text-muted text-[11px] font-medium px-1 mb-0.5"><Clock size={11} className="inline mr-0.5" />{cronLabel}</span>}
-          <div className="msg-content px-3.5 py-2.5 text-sm leading-relaxed whitespace-pre-wrap rounded-lg bg-warning-subtle text-fg border border-warning/30 rounded-bl-[4px] overflow-hidden min-w-0" style={{ overflowWrap: 'anywhere', wordBreak: 'break-word' }}>
-            <MessageErrorBoundary rawContent={cleanContent}><MarkdownRenderer content={cleanContent} /></MessageErrorBoundary>
-          </div>
-        </>
-      )
-    }
-
-    if (m.role === 'error') {
-      return (
-        <div key={key} className="px-5 mx-auto w-full py-1" style={{ maxWidth: `var(--mc-content-width, ${contentWidth})` }}>
-          <div className="bg-danger-subtle text-danger text-[13px] px-3 py-2 rounded-md border border-danger/15 self-center animate-scale-in">
-            {m.content}
-          </div>
-        </div>
-      )
-    }
-
-    if (m.role === 'notice') {
-      return (
-        <div key={key} className="px-5 mx-auto w-full py-1" style={{ maxWidth: `var(--mc-content-width, ${contentWidth})` }}>
-          <div className="bg-card text-muted text-[13px] px-3 py-2 rounded-md border border-border self-center animate-scale-in">
-            {m.content}
-          </div>
-        </div>
-      )
-    }
-
-    if (m.role === 'thinking' || m.role === 'system' || m.role === 'done' || m.role === 'queued') return null
-    if (m.role === 'file') return null // TODO: file download links
-
-    if (m.role === 'mcp_oauth') {
-      const banner = renderMcpOAuthMessage(m, hideCardOwnedOAuth)
-      if (!banner) return null
-      return (
-        <div key={key} className="px-5 mx-auto w-full py-1" style={{ maxWidth: `var(--mc-content-width, ${contentWidth})` }}>
-          {banner}
-        </div>
-      )
-    }
-
-    return null
-  }, [messages, running, contentWidth, onFileOpen, renderTool, autoDeniedIds, hideCardOwnedOAuth])
 
   // Render a TurnItem (single or group)
   const renderItem = useCallback((item: TurnItem, _i: number) => {

--- a/website/src/app-sdk/index.ts
+++ b/website/src/app-sdk/index.ts
@@ -308,3 +308,12 @@ export { default as ChatPanel } from './ChatPanel'
 export * from './protocol'
 export { default as ChatEmbed } from './ChatEmbed'
 export { default as ChatMessageList } from './ChatMessageList'
+// The transcript's row registry, so an app can add a row type or replace one
+// instead of forking the message list.
+export {
+  defaultMessageRenderers,
+  mergeRenderers,
+  resolveRenderer,
+  ToolCallPill,
+} from './messageRenderers'
+export type { MessageRenderer, MessageRenderContext } from './messageRenderers'

--- a/website/src/app-sdk/messageRenderers.tsx
+++ b/website/src/app-sdk/messageRenderers.tsx
@@ -1,0 +1,388 @@
+/**
+ * Message renderer registry — the role → renderer mapping for a chat transcript.
+ *
+ * Rendering policy lives here as DATA rather than as control flow inside
+ * ChatMessageList, so a surface can add a row type (a queued card, a file chip)
+ * or replace one (its own approval UI, its own tool row) without forking the
+ * transcript. A host passes extra entries; they win over the defaults.
+ *
+ * This module must stay free of any store, router, or `pages/`-level import: the
+ * consumers that most need a shared transcript run outside the dashboard's React
+ * root and have no Redux store at all, so a renderer that reaches for a selector
+ * is unusable to them. Anything that genuinely needs live app state is supplied
+ * BY the host as a registry entry instead.
+ */
+import React, { memo } from 'react'
+import { Clock, LoaderCircle, CircleSlash, CircleAlert, CircleDot, Lock, PanelRight } from 'lucide-react'
+import { i18nT } from '../i18n/t'
+import { extractToolFilePath } from '../utils/toolFilePath'
+import { isSafePath } from '../utils/safePath'
+import AssistantMessage, { type TurnStats } from '../pages/chat/AssistantMessage'
+import UserMessage from '../pages/chat/UserMessage'
+import { renderMcpOAuthMessage } from '../pages/chat/McpOAuthBanner'
+import SubagentCompletionCard from '../pages/chat/SubagentCompletionCard'
+import { isSubagentCompletionMessage } from '../pages/chat/subagentCompletion'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+import MessageErrorBoundary from '../components/MessageErrorBoundary'
+import PastedChip from '../components/PastedChip'
+import { type PasteBlock, findTokenRanges, recollapsePastes } from '../utils/pasteTokens'
+import type { ChatMessage } from '../types'
+import { fmtMessageTime, fmtMessageTimeFull } from '../pages/chat/messageTime'
+
+/** Everything a renderer may read. Passed per row so entries stay pure functions. */
+export interface MessageRenderContext {
+  /** Index of this message in `messages`. Needed by rows that look ahead. */
+  index: number
+  /** The whole transcript. The assistant footer rule depends on what follows. */
+  messages: ChatMessage[]
+  /** Whether the session is currently producing output. */
+  running: boolean
+  /** Stable React key the list computed for this row. */
+  key: string
+  onFileOpen?: (path: string, opts?: { line?: number; endLine?: number }) => void
+  /** Drop mcp_oauth banners a Connections card already owns. */
+  hideCardOwnedOAuth: boolean
+  /** tool_call_ids whose call a policy or hook blocked. */
+  autoDeniedIds: Set<string>
+  /** Host-injected tool row, kept as a shorthand for replacing the tool entries. */
+  renderTool?: (message: ChatMessage) => React.ReactNode
+  /** Bubble layout used by conversational rows. `isUser` right-aligns. */
+  wrapper: (children: React.ReactNode, isUser?: boolean) => React.ReactNode
+  /** Full-width row layout used by cards, pills and banners. */
+  row: (children: React.ReactNode, tight?: boolean) => React.ReactNode
+}
+
+export interface MessageRenderer {
+  /** Stable identity. A host entry with the same id replaces the default. */
+  id: string
+  /** Roles this entry claims. `'*'` considers every role, gated by `match`. */
+  roles: readonly string[]
+  /** Extra guard, for the roles whose rendering depends on message content. */
+  match?: (m: ChatMessage) => boolean
+  /** Returning null draws nothing. That an ENTRY EXISTS is what separates a
+   *  deliberately undrawn role from one no renderer claims. */
+  render: (m: ChatMessage, ctx: MessageRenderContext) => React.ReactNode
+}
+
+function renderUserContent(content: string, meta: Record<string, unknown> | undefined): React.ReactNode {
+  // History load re-serves the fully-EXPANDED paste content alongside
+  // meta.pastes. Handing a large paste (hundreds of KB / tens of thousands of
+  // lines) straight to MarkdownRenderer parses + lays it out on the main thread
+  // and freezes the tab. Re-collapse the message's own blocks back to
+  // `[ Paste #N ]` chips so only the small token text is rendered.
+  const pastes = (meta?.pastes as PasteBlock[] | undefined) || []
+  if (pastes.length) {
+    let text = content
+    let ranges = findTokenRanges(text, pastes)
+    if (!ranges.length) {
+      const collapsed = recollapsePastes(content, pastes)
+      if (collapsed !== content) { text = collapsed; ranges = findTokenRanges(text, pastes) }
+    }
+    if (ranges.length) {
+      const out: React.ReactNode[] = []
+      let last = 0
+      ranges.forEach((r, i) => {
+        const trimStart = text[r.start - 1] === '\n' ? r.start - 1 : r.start
+        const trimEnd = text[r.end] === '\n' ? r.end + 1 : r.end
+        if (trimStart > last) {
+          const seg = text.slice(last, trimStart)
+          if (seg) out.push(<span key={`t${i}`} style={{ whiteSpace: 'pre-wrap' }}>{seg}</span>)
+        }
+        out.push(<PastedChip key={`p${i}-${r.block.id}`} block={r.block} />)
+        last = trimEnd
+      })
+      if (last < text.length) {
+        const seg = text.slice(last)
+        if (seg) out.push(<span key="tend" style={{ whiteSpace: 'pre-wrap' }}>{seg}</span>)
+      }
+      return <MessageErrorBoundary rawContent={text}>{out}</MessageErrorBoundary>
+    }
+  }
+  return <MessageErrorBoundary rawContent={content}><MarkdownRenderer content={content} /></MessageErrorBoundary>
+}
+
+/**
+ * Delegates to the shared footer formatter so an embedded app's transcript reads
+ * IDENTICALLY to the main chat's. `fmtMessageTime` elides the year only when it
+ * is safe, so a message from a previous year is never dated to the current one.
+ */
+function formatTs(ts?: string): string | undefined {
+  if (!ts) return undefined
+  return fmtMessageTime(ts) || undefined
+}
+
+/** Prop-driven tool row. The store-connected variant is a host entry. */
+export const ToolCallPill = memo(function ToolCallPill({ message, running, onFileOpen, autoDenied }: { message: ChatMessage; running: boolean; onFileOpen?: (path: string) => void; autoDenied?: boolean }) {
+  const [expanded, setExpanded] = React.useState(false)
+  const isDone = message.role === 'tool_result'
+  const isRejected = message.meta?.resolved === 'rejected'
+  const hasPendingPerm = message.role === 'permission' && !message.meta?.resolved
+
+  // Prefer the backend-stamped purpose ("Add teams_data dict guard…") over the
+  // raw command, matching the main chat. The raw label is the fallback, and is
+  // not hard-truncated — CSS truncation keeps one line without destroying the
+  // text for the expanded panel or the file probe.
+  const rawLabel = (message.content || '').replace(/^🔧\s*/, '').split('\n')[0]
+  const purpose = typeof message.meta?.purpose === 'string' ? message.meta.purpose : ''
+  const label = purpose || rawLabel || message.role
+
+  // Status icon + colour mirror the store-connected tool row so an embedded
+  // transcript reads with the same visual grammar as a main session: spinner
+  // while running, green dot when done, amber alert for auto-denied (a policy or
+  // hook block, detected by the HOST from the hidden 🚫 sibling message and
+  // passed in, since this pill only ever renders the visible 🔧 message), red
+  // slash when user-rejected, amber lock when awaiting approval.
+  const isAutoDenied = !isRejected && !!autoDenied
+  // Auto-denied is TERMINAL even though the 🔧 message never becomes a
+  // tool_result (isDone) — the gate blocked the call, nothing further runs —
+  // so it must escape both the loader icon and the spin animation.
+  const Icon = isRejected ? CircleSlash : isAutoDenied ? CircleAlert : isDone ? CircleDot : hasPendingPerm ? Lock : LoaderCircle
+  const tone = isRejected
+    ? 'text-danger bg-danger-subtle'
+    : isAutoDenied
+      ? 'text-warn bg-warn-subtle'
+      : isDone
+        ? 'text-ok bg-ok/5'
+        : hasPendingPerm
+          ? 'text-warn bg-warn-subtle'
+          : 'text-accent bg-accent/5'
+  // Animate ONLY while the session is actually running, so a tool call left
+  // un-terminated by a dropped turn does not spin forever and make an idle
+  // transcript look busy — the loading state reflects the session, not the role.
+  const iconClass = !isDone && !hasPendingPerm && !isRejected && !isAutoDenied && running ? 'animate-spin' : ''
+
+  // File affordance: same pure helpers the main chat uses (no store needed).
+  const filePath = React.useMemo(() => {
+    const src = typeof message.meta?.input_preview === 'string' ? message.meta.input_preview : rawLabel
+    const p = extractToolFilePath(src)
+    return p && isSafePath(p) ? p : null
+  }, [message.meta?.input_preview, rawLabel])
+
+  return (
+    <div className="animate-scale-in flex items-center gap-1.5 flex-wrap">
+      <button
+        onClick={() => setExpanded(e => !e)}
+        aria-expanded={expanded}
+        className={`inline-flex items-center gap-1 text-[13px] font-mono px-2 py-0.5 rounded-md cursor-pointer transition-all max-w-[min(600px,90%)] hover:brightness-110 ${tone}`}
+      >
+        <Icon size={12} className={iconClass} />
+        <span className="truncate">{label}</span>
+      </button>
+      {filePath && onFileOpen && (
+        <button
+          onClick={() => onFileOpen(filePath)}
+          title={i18nT('appSdk.chatMessageList.open_path', { path: filePath })}
+          aria-label={i18nT('appSdk.chatMessageList.open_path', { path: filePath })}
+          className="inline-flex items-center gap-1 text-[12px] font-mono px-1.5 py-0.5 rounded-md border border-border text-muted cursor-pointer hover:text-text hover:border-border-strong transition-all"
+        >
+          {filePath.split('/').pop()}
+          <PanelRight size={11} />
+        </button>
+      )}
+      {expanded && message.content && (
+        <pre className="w-full text-[11px] font-mono text-muted bg-bg-elevated rounded-md p-2 mt-1 ml-4 max-h-40 overflow-auto whitespace-pre-wrap break-all border border-border">
+          {purpose && rawLabel && purpose !== rawLabel ? rawLabel + '\n\n' + message.content : message.content}
+        </pre>
+      )}
+    </div>
+  )
+})
+
+function toolRow(m: ChatMessage, ctx: MessageRenderContext, autoDenied?: boolean): React.ReactNode {
+  return ctx.row(
+    ctx.renderTool
+      ? ctx.renderTool(m)
+      : <ToolCallPill message={m} running={ctx.running} onFileOpen={ctx.onFileOpen} autoDenied={autoDenied} />,
+    true,
+  )
+}
+
+/**
+ * The built-in registry, in resolution order. A stop event and a sub-agent
+ * completion are recognised by shape rather than by role, so they claim `'*'`
+ * and gate on `match`; they come first for that reason.
+ */
+export const defaultMessageRenderers: readonly MessageRenderer[] = [
+  {
+    id: 'stop_event',
+    roles: ['*'],
+    match: m => m.kind === 'stop_event' || m.meta?.kind === 'stop_event',
+    render: (m, ctx) => ctx.row(
+      <div className="text-danger text-[13px] font-mono px-3 py-2 rounded-md bg-danger-subtle inline-flex items-center gap-1.5">
+        {m.content}
+      </div>,
+    ),
+  },
+  {
+    id: 'subagent_completion',
+    roles: ['*'],
+    match: isSubagentCompletionMessage,
+    render: (m, ctx) => (
+      <SubagentCompletionCard
+        key={ctx.key}
+        message={m}
+        onFileOpen={ctx.onFileOpen}
+        disclosureKey={ctx.key}
+      />
+    ),
+  },
+  {
+    id: 'user',
+    roles: ['user'],
+    render: (m, ctx) => ctx.wrapper(
+      <UserMessage
+        content={m.content}
+        meta={m.meta}
+        timestamp={formatTs(m.ts)}
+        timestampTitle={fmtMessageTimeFull(m.ts)}
+        renderContent={renderUserContent}
+      />,
+      true,
+    ),
+  },
+  {
+    id: 'assistant',
+    roles: ['assistant', 'streaming'],
+    render: (m, ctx) => {
+      const isStreaming = m.role === 'streaming'
+      // The footer belongs to a FINISHED reply. It shows once the turn is over,
+      // which is either because another user or assistant row follows, or
+      // because nothing follows and the session has gone idle.
+      let showFooter = false
+      if (!isStreaming) {
+        let nextRelevant = false
+        for (let j = ctx.index + 1; j < ctx.messages.length; j++) {
+          if (ctx.messages[j].role === 'user') { showFooter = true; nextRelevant = true; break }
+          if (ctx.messages[j].role === 'assistant' || ctx.messages[j].role === 'streaming') { nextRelevant = true; break }
+        }
+        if (!nextRelevant) showFooter = !ctx.running
+      }
+      return ctx.wrapper(
+        <div className="flex flex-col gap-0">
+          <AssistantMessage
+            content={m.content}
+            isStreaming={isStreaming}
+            timestamp={formatTs(m.ts)}
+            timestampTitle={fmtMessageTimeFull(m.ts)}
+            showFooter={showFooter}
+            slotRunning={ctx.running}
+            onFileOpen={ctx.onFileOpen}
+            variants={m.variants}
+            variantIdx={m.variant_idx}
+            turnStats={(m.meta as Record<string, unknown> | undefined)?.turn_stats as TurnStats | undefined}
+          />
+        </div>,
+      )
+    },
+  },
+  {
+    id: 'tool',
+    roles: ['tool'],
+    // A tool role also carries the hidden 🚫 deny sibling, which is read for the
+    // auto-denied flag and never drawn.
+    match: m => !!m.content?.startsWith('🔧'),
+    render: (m, ctx) => {
+      const tcid = m.meta?.tool_call_id as string | undefined
+      return toolRow(m, ctx, !!tcid && ctx.autoDeniedIds.has(tcid))
+    },
+  },
+  {
+    id: 'tool_lifecycle',
+    roles: ['tool_call', 'tool_result'],
+    render: (m, ctx) => toolRow(m, ctx),
+  },
+  {
+    id: 'inject',
+    roles: ['inject'],
+    render: (m, ctx) => {
+      const cronLabel = (m.meta?.cronLabel as string) || ''
+      const cleanContent = cronLabel
+        ? m.content.replace(/^\[Cron notification from ".*"\]\n/, '').replace(/\n\[End of cron notification\]$/, '')
+        : m.content
+      return ctx.wrapper(
+        <>
+          {cronLabel && <span className="text-muted text-[11px] font-medium px-1 mb-0.5"><Clock size={11} className="inline mr-0.5" />{cronLabel}</span>}
+          <div className="msg-content px-3.5 py-2.5 text-sm leading-relaxed whitespace-pre-wrap rounded-lg bg-warning-subtle text-fg border border-warning/30 rounded-bl-[4px] overflow-hidden min-w-0" style={{ overflowWrap: 'anywhere', wordBreak: 'break-word' }}>
+            <MessageErrorBoundary rawContent={cleanContent}><MarkdownRenderer content={cleanContent} /></MessageErrorBoundary>
+          </div>
+        </>,
+      )
+    },
+  },
+  {
+    id: 'error',
+    roles: ['error'],
+    render: (m, ctx) => ctx.row(
+      <div className="bg-danger-subtle text-danger text-[13px] px-3 py-2 rounded-md border border-danger/15 self-center animate-scale-in">
+        {m.content}
+      </div>,
+    ),
+  },
+  {
+    id: 'notice',
+    roles: ['notice'],
+    render: (m, ctx) => ctx.row(
+      <div className="bg-card text-muted text-[13px] px-3 py-2 rounded-md border border-border self-center animate-scale-in">
+        {m.content}
+      </div>,
+    ),
+  },
+  {
+    // Grouped and lifecycle-only roles have no row of their own: a thinking or
+    // permission message is displayed by the group's own summary UI, and
+    // system/done/queued carry state rather than something to read here.
+    id: 'undrawn',
+    roles: ['thinking', 'system', 'done', 'queued'],
+    render: () => null,
+  },
+  {
+    // TODO: file download links
+    id: 'file',
+    roles: ['file'],
+    render: () => null,
+  },
+  {
+    id: 'mcp_oauth',
+    roles: ['mcp_oauth'],
+    render: (m, ctx) => {
+      const banner = renderMcpOAuthMessage(m, ctx.hideCardOwnedOAuth)
+      if (!banner) return null
+      return ctx.row(banner)
+    },
+  },
+]
+
+/**
+ * First entry that claims the role and passes its guard. Host entries are
+ * searched before the defaults, so replacing a row is a matter of reusing its
+ * id — or claiming a role the defaults leave undrawn.
+ */
+export function resolveRenderer(
+  m: ChatMessage,
+  renderers: readonly MessageRenderer[],
+): MessageRenderer | undefined {
+  return renderers.find(r =>
+    (r.roles.includes('*') || r.roles.includes(m.role)) && (!r.match || r.match(m)),
+  )
+}
+
+/**
+ * Host entries sit between the SHAPE-matched defaults and the role-keyed ones.
+ *
+ * A shape-matched entry recognises a message by what it IS (`kind`), not by the
+ * role carrying it — a stop event travels as role `system`, so a host claiming
+ * `system` would otherwise swallow the stop card and Stop would draw the host's
+ * row instead. A role claim cannot know about kind, so it must not outrank a
+ * kind check. Overriding a shape-matched row stays possible, and stays explicit:
+ * reuse its id.
+ */
+export function mergeRenderers(
+  extra: readonly MessageRenderer[] | undefined,
+): readonly MessageRenderer[] {
+  if (!extra?.length) return defaultMessageRenderers
+  const overridden = new Set(extra.map(r => r.id))
+  const kept = defaultMessageRenderers.filter(r => !overridden.has(r.id))
+  const shapeMatched = kept.filter(r => r.roles.includes('*'))
+  const roleKeyed = kept.filter(r => !r.roles.includes('*'))
+  return [...shapeMatched, ...extra, ...roleKeyed]
+}

--- a/website/src/test/chatProtocolBoundary.test.ts
+++ b/website/src/test/chatProtocolBoundary.test.ts
@@ -98,15 +98,21 @@ describe('the protocol surface apps import', () => {
     // instantiate the module, so an app importing it does not load. Two hand-written lists cannot
     // be kept in agreement by review alone.
     const stub = read(resolve(SRC, '..', 'public', 'vendor', 'kirocrew-app-sdk.mjs'))
-    const barrel = read(join(PROTOCOL, 'index.ts'))
-    // Value exports only — `export type` lines vanish at runtime and need no stub entry.
-    const values = [...barrel.matchAll(/^export \{([^}]+)\}/gm)]
-      .flatMap(m => m[1].split(','))
-      .map(s => s.trim())
-      .filter(Boolean)
-    expect(values.length).toBeGreaterThan(0)
+    // BOTH barrels: scoping this to the protocol barrel is what let four chat
+    // exports sit in the app surface with no stub entry, each one a load-time
+    // failure for any app that imported it.
+    const barrels = [read(join(PROTOCOL, 'index.ts')), read(join(SRC, 'app-sdk', 'index.ts'))]
+    // Value exports only — `export type` lines vanish at runtime and need no
+    // stub entry, and `export type {…}` must not be mistaken for a value block.
+    const values = barrels.flatMap(barrel => [
+      ...[...barrel.matchAll(/^export \{([^}]+)\}/gm)]
+        .flatMap(m => m[1].split(','))
+        .map(s => s.trim().replace(/^default as /, '')),
+      ...[...barrel.matchAll(/^export (?:async )?function (\w+)/gm)].map(m => m[1]),
+    ]).filter(Boolean)
+    expect(values.length).toBeGreaterThan(10)
     const missing = values.filter(name => !new RegExp(`\\b${name}\\b`).test(stub))
-    expect(missing, 'vendor stub must re-export every protocol value').toEqual([])
+    expect(missing, 'vendor stub must re-export every value the app surface exports').toEqual([])
   })
 
   it('parses correctly even after the shared regex has been left mid-string', async () => {

--- a/website/src/test/messageRenderers.test.ts
+++ b/website/src/test/messageRenderers.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Registry contract for transcript rendering.
+ *
+ * Three things are pinned here that a type checker cannot see:
+ *  - every role the old hardcoded chain handled still resolves to an entry, and
+ *    the deliberately-undrawn ones resolve to an entry that draws nothing (as
+ *    opposed to falling off the end of the registry, which would look identical
+ *    on screen and hide the regression);
+ *  - a host can replace a row by id and claim an undrawn role, which is the
+ *    whole reason the mapping became data;
+ *  - the registry module takes no store or router dependency, because the
+ *    consumers that most need a shared transcript run outside the dashboard's
+ *    React root and have no store to select from.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { ChatMessage } from '../types'
+import {
+  defaultMessageRenderers,
+  mergeRenderers,
+  resolveRenderer,
+  type MessageRenderer,
+} from '../app-sdk/messageRenderers'
+
+const msg = (role: string, over: Partial<ChatMessage> = {}): ChatMessage =>
+  ({ role, content: '', cls: '', ...over }) as ChatMessage
+
+/** The registry entry id the old chain's branch for this message became. */
+function idFor(m: ChatMessage): string | undefined {
+  return resolveRenderer(m, defaultMessageRenderers)?.id
+}
+
+describe('default registry reproduces the old role chain', () => {
+  it('routes each role to the branch that used to handle it', () => {
+    expect(idFor(msg('user'))).toBe('user')
+    expect(idFor(msg('assistant'))).toBe('assistant')
+    expect(idFor(msg('streaming'))).toBe('assistant')
+    expect(idFor(msg('tool_call'))).toBe('tool_lifecycle')
+    expect(idFor(msg('tool_result'))).toBe('tool_lifecycle')
+    expect(idFor(msg('inject'))).toBe('inject')
+    expect(idFor(msg('error'))).toBe('error')
+    expect(idFor(msg('notice'))).toBe('notice')
+    expect(idFor(msg('mcp_oauth'))).toBe('mcp_oauth')
+  })
+
+  it('claims a tool row only when it is the visible 🔧 message', () => {
+    // The hidden 🚫 sibling is read for the auto-denied flag and never drawn, so
+    // it must NOT resolve to the tool row.
+    expect(idFor(msg('tool', { content: '🔧 grep' }))).toBe('tool')
+    expect(idFor(msg('tool', { content: '🚫 denied by policy' }))).toBeUndefined()
+    expect(idFor(msg('tool', { content: 'plain text' }))).toBeUndefined()
+  })
+
+  it('recognises a stop event by shape, whatever role carries it', () => {
+    expect(idFor(msg('assistant', { kind: 'stop_event' }))).toBe('stop_event')
+    expect(idFor(msg('notice', { meta: { kind: 'stop_event' } }))).toBe('stop_event')
+    // Shape-based entries are searched first, so a stop event never falls
+    // through to the row its role would otherwise pick.
+    expect(idFor(msg('notice'))).toBe('notice')
+  })
+
+  it('draws nothing for the undrawn roles, but still CLAIMS them', () => {
+    // A grouped or lifecycle-only role has no row of its own. Both facts matter:
+    // an entry exists (so deleting it is caught here), and it renders null.
+    for (const role of ['thinking', 'system', 'done', 'queued']) {
+      const entry = resolveRenderer(msg(role), defaultMessageRenderers)
+      expect(entry?.id, role).toBe('undrawn')
+      expect(entry!.render(msg(role), {} as never), role).toBeNull()
+    }
+    const file = resolveRenderer(msg('file'), defaultMessageRenderers)
+    expect(file?.id).toBe('file')
+    expect(file!.render(msg('file'), {} as never)).toBeNull()
+  })
+
+  it('leaves an unknown role unclaimed', () => {
+    expect(idFor(msg('some_future_role'))).toBeUndefined()
+  })
+
+  it('gives every entry a unique id, so an override cannot be ambiguous', () => {
+    const ids = defaultMessageRenderers.map(r => r.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
+describe('host entries', () => {
+  const custom: MessageRenderer = { id: 'user', roles: ['user'], render: () => 'replaced' }
+
+  it('replaces a built-in row by reusing its id', () => {
+    const merged = mergeRenderers([custom])
+    expect(resolveRenderer(msg('user'), merged)).toBe(custom)
+    // Replacing one row must not drop the rest.
+    expect(merged.filter(r => r.id === 'user')).toHaveLength(1)
+    expect(merged.length).toBe(defaultMessageRenderers.length)
+    expect(resolveRenderer(msg('error'), merged)?.id).toBe('error')
+  })
+
+  it('can claim a role the defaults leave undrawn', () => {
+    const queued: MessageRenderer = { id: 'queued-card', roles: ['queued'], render: () => 'card' }
+    const merged = mergeRenderers([queued])
+    expect(resolveRenderer(msg('queued'), merged)).toBe(queued)
+    // The default undrawn entry is still there for the roles it kept.
+    expect(resolveRenderer(msg('thinking'), merged)?.id).toBe('undrawn')
+  })
+
+  it('is the identity for an empty or absent list', () => {
+    expect(mergeRenderers(undefined)).toBe(defaultMessageRenderers)
+    expect(mergeRenderers([])).toBe(defaultMessageRenderers)
+  })
+
+  it('cannot outrank a shape-matched default by claiming the role it travels on', () => {
+    // A stop event reaches the transcript as role `system` (the backend appends
+    // it that way) and is recognised by `kind`. `system` is also one of the
+    // roles the defaults leave undrawn, so it is exactly what a host is invited
+    // to claim — and claiming it must NOT swallow the stop card.
+    const hostSystem: MessageRenderer = { id: 'system-note', roles: ['system'], render: () => 'host' }
+    const merged = mergeRenderers([hostSystem])
+
+    const stop = msg('system', { kind: 'stop_event' })
+    expect(resolveRenderer(stop, merged)?.id).toBe('stop_event')
+    // A plain system row is still the host's.
+    expect(resolveRenderer(msg('system'), merged)).toBe(hostSystem)
+  })
+
+  it('still lets a host replace a shape-matched row, explicitly, by id', () => {
+    const ownStop: MessageRenderer = { id: 'stop_event', roles: ['*'], match: () => true, render: () => 'mine' }
+    const merged = mergeRenderers([ownStop])
+    expect(resolveRenderer(msg('system', { kind: 'stop_event' }), merged)).toBe(ownStop)
+  })
+})
+
+describe('renderTool stays a supported shorthand', () => {
+  it('is preferred by both tool entries when the host supplies one', () => {
+    const seen: string[] = []
+    const ctx = {
+      running: false,
+      autoDeniedIds: new Set<string>(),
+      renderTool: (m: ChatMessage) => { seen.push(m.role); return 'host-tool' },
+      row: (children: unknown) => children,
+    }
+    const tool = msg('tool', { content: '🔧 grep' })
+    const call = msg('tool_call')
+    expect(resolveRenderer(tool, defaultMessageRenderers)!.render(tool, ctx as never)).toBe('host-tool')
+    expect(resolveRenderer(call, defaultMessageRenderers)!.render(call, ctx as never)).toBe('host-tool')
+    expect(seen).toEqual(['tool', 'tool_call'])
+  })
+})
+
+describe('registry stays usable without a store', () => {
+  // Asserted against SOURCE TEXT: tsconfig.app.json excludes src/test, so a
+  // type-level lock written here would never be checked by tsc at all.
+  const src = readFileSync(
+    join(__dirname, '..', 'app-sdk', 'messageRenderers.tsx'),
+    'utf8',
+  )
+
+  it('imports no store and no router', () => {
+    const imports = src.split('\n').filter(l => /^\s*import\b/.test(l))
+    expect(imports.length).toBeGreaterThan(5)
+    for (const line of imports) {
+      expect(line, line).not.toMatch(/from '[^']*\/store/)
+      expect(line, line).not.toMatch(/from 'react-redux'/)
+      expect(line, line).not.toMatch(/from 'react-router/)
+    }
+  })
+
+  it('reads live app state only through the context it is handed', () => {
+    expect(src).not.toMatch(/useAppSelector|useAppDispatch|useSelector\(/)
+  })
+})


### PR DESCRIPTION
## What is the problem?

`website/src/app-sdk/ChatMessageList.tsx` decided how to draw every transcript row with a hardcoded `role` if-chain. It had 13 branches and exactly one extension point — a `renderTool` prop — so a surface that needed a row the chain did not draw could not add one.

Two surfaces already gave up and forked the transcript rather than extend it:

- `website/src/pages/ChannelPage.tsx` (717 lines) hand-rolls its own message bubbles because it needs per-participant identity, and along the way does not parse the agent's `[OPTIONS: …]` marker at all — an agent-offered choice reaches the user as raw, unclickable text.
- `website/src/apps/mochi/src/renderer/ChatPanel.tsx` (2118 lines) hand-rolls its own transcript, drops every `tool` row (`RENDERABLE_ROLES` is `user`/`assistant`/`error`), and carries a private option-marker regex at line 1947 that misses the CJK bracket variants, the trailing markdown-link close, the single-vs-multi distinction, and partial-marker stripping while streaming.

Four roles (`thinking`, `system`, `done`, `queued`) resolve to nothing, and `file` returns null under a `// TODO`, so a queued-message card or a file chip was not addable either. `permission` rows are folded into the collapsible group, which is why an app embed still cannot substitute its own approval UI — the remaining half of #510.

## Why this issue matters to the user

Every surface that cannot extend the chain grows its own transcript, and the copies drift in ways users feel. Channels silently swallow the choices an agent offers. The mochi panel shows no tool activity and parses markers with a regex that fails on real input. #2722/#2723 moved that marker protocol into one React-free module precisely so no second copy would exist; a private copy is exactly the defect class that work eliminated, and it survives because forking was easier than extending.

## How our fix solves it — symptom to root cause to change

Symptom: surfaces fork the transcript. Root cause: rendering policy was welded in as control flow, so the only way to extend it was another prop — and each new prop served only the caller who asked. Change: make the role → renderer mapping **data**.

- `website/src/app-sdk/messageRenderers.tsx` holds the registry. Each entry declares an `id`, the `roles` it claims, an optional `match` guard for the branches that depended on message content, and a `render`.
- Resolution is first-match. The two shape-based branches (a stop event, a sub-agent completion) claim `'*'` and gate on `match`, and stay first — a stop event must never fall through to the row its role would otherwise pick.
- The built-ins reproduce the old chain branch for branch, so existing consumers render identically. The deliberately undrawn roles keep an entry that renders null: that an entry EXISTS is what separates "no row by design" from "nothing claimed this role", and the tests hold both facts.
- A host passes `renderers`. Reusing a built-in `id` replaces that row; claiming an undrawn role adds one. `renderTool` stays supported as the shorthand for replacing the tool rows.
- The layer takes no store or router dependency. mochi has no Redux store and runs in a separate React root, so a registry that reached for a selector would be unusable to the consumer that most needs it. The nine transcript components that do read `chatSlice` remain host-supplied entries, exactly as the dashboard passes `ToolCallLine` through `renderTool` today.

### Making the surface reachable, and guarding the whole of it

A registry nobody can import is not an extension point. The `app-sdk` barrel now exports
`defaultMessageRenderers`, `mergeRenderers`, `resolveRenderer`, `ToolCallPill` and the two types.

That exposed a live defect in the same list. `@kirocrew/app-sdk` resolves through
`website/public/vendor/kirocrew-app-sdk.mjs`, a hand-written named-export stub. The barrel already
exported `ChatMessageList`, `ChatEmbed`, `ChatPanel` and `useChatSession`; the stub named **none** of
them. A named export the host does not provide makes the browser fail to instantiate the module, so
an app importing any one of those four did not merely lose a component — it failed to load. The stub
now lists them alongside the registry.

The reason they stayed missing is that the drift ratchet added with the protocol layer only read the
*protocol* barrel, so the component exports were never compared against anything. It now reads both
barrels and understands the `export function` and `default as` forms. Verified by mutation: dropping
`ChatMessageList`, dropping `useChatSession`, or dropping the registry names from the stub each fails
the test (3/3 caught).

This part is slightly wider than the registry itself, and deliberately so: shipping a public SDK
surface that no app can import would be shipping a claim that is not true.

### Docs

- `docs/app-kit/api-reference.md` — a Chat Transcript Rendering section: how to add a row for a role
  the dashboard leaves undrawn, how to replace a built-in row by reusing its id, the full context a
  renderer is handed, the two rules the registry relies on (first-match order, and `null` meaning
  something different from an absent entry), and the export table.
- `docs/app-kit/getting-started.md` — a pointer next to the existing marker-protocol pointer, for
  someone who wants to render a transcript rather than parse one.
- `skills/kirocrew-app-dev/SKILL.md` — the "Available Imports" list is what an app author reads to
  learn what exists; it now names the registry, `ChatMessageList` and `useChatSession`.

This change is deliberately behaviour-neutral and consumer-neutral: no surface is migrated here. Each migration is a separate change with its own user-visible outcome.

## What tests we did

`website/src/test/messageRenderers.test.ts` — 12 tests, and each one was mutation-verified (7/7 mutants caught):

- Every role the old chain handled resolves to the entry that used to handle it, and an unknown role resolves to nothing.
- The tool row is claimed only for the visible `🔧` message; the hidden `🚫` deny sibling (read for the auto-denied flag, never drawn) is not.
- A stop event is recognised by shape whatever role carries it, and a plain `notice` still resolves to `notice`.
- The undrawn roles resolve to an entry that renders null — deleting that entry fails the test rather than silently changing nothing on screen.
- Host entries: replacing by id keeps the rest of the registry intact, claiming an undrawn role wins, and an empty list is the identity.
- `renderTool` is preferred by both tool entries when supplied.
- Boundary: the registry imports no store and no router and never calls a selector. Asserted against source text — `tsconfig.app.json` excludes `src/test`, so a type-level lock written in a test would never be checked at all.

Mutants caught: dropping the undrawn entry; moving the stop-event entry out of first position; removing the `🔧` guard; keeping a shadowed default when a host overrides by id; ignoring the `'*'` wildcard; ignoring the host tool renderer; adding a store import.

Gates: `npx tsc -b` clean; `npm run i18n:check` and `npm run i18n:render` pass; full `vitest run` shows 996 files / 16341 tests pass with `I18N_BASE_REF` pinned to the merge base.

## Manual verification

N/A — behaviour-neutral by construction and covered by the existing `ChatMessageList` / `ChatEmbed` suites (66 tests) plus the new registry contract. No visual change, so no screenshots.

Two honest notes on the local run:

- The full `vitest` run exits 1 on an unhandled error unrelated to this diff: a stray `setTimeout(() => setCopied(false), 1500)` in `website/src/pages/knowledge/helpers.ts:35` fires after `KnowledgeListView.test.tsx` tears down. That file has zero import relationship to anything here and passes in isolation (19 tests, exit 0). I did not get a clean-base full-suite run to prove it pre-existing, so I am reporting it as unproven rather than asserting it.
- `npm run i18n:render` failed once with `/chat rendered nothing in 15s`, then passed on three consecutive re-runs, and passes on the clean base. That looks like the gate's own 15s render budget under host load rather than anything in this change.

## Any other suggestions on the work

The migrations this unblocks are each worth their own change, and each is a real user-visible fix rather than a refactor:

- Wire the shared protocol into mochi and `ChannelPage` — deletes the private regex and makes agent-offered choices clickable in channels.
- Render approval cards inside an app embed (#510's remaining half).
- The composer is a separate layer: `website/src/components/ChatInput.tsx` has 90 props, of which 52 are pure presentation and 38 need host-owned state. Worth its own issue.

Closes #2918. Part of the chat SDK work tracked in #2722.

