### PR TITLE
fix: resolve MCP callback port via marker and export bound port

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -523,15 +523,29 @@ Each step checks if the tool is already installed and skips if present.
 
 `kirocrew token` / `status` / `logout` / `stop` / `restart` must find the port
 the gateway is actually bound to. `cli_server.resolve_client_port()` resolves it
-in this order, first hit wins:
+in this order, first hit wins. The MCP stdio servers (`mcp_core` /
+`mcp_computer`) resolve their gateway API base through the same helper —
+lazily, on the first gateway call, and cached for the process lifetime — so a
+loopback callback and a client CLI command always agree on which gateway they
+are talking to:
 
 1. An explicit `--port N` flag (`0` counts — the check is `is not None`).
-2. `KIROCREW_PORT`, when it parses as an int.
-3. A port **explicitly written** in `dashboard.url`. A portless URL
+2. `KIROCREW_PORT`, when it parses as an int. Deliberately above the bound
+   export: an explicitly-set `KIROCREW_PORT` is how a caller retargets a
+   child at a DIFFERENT gateway — `pod exec` builds a client env with
+   `KIROCREW_PORT=<pod-port>` while the inherited `KIROCREW_BOUND_PORT`
+   still names the spawning live gateway, and the bound value outranking it
+   would walk pod `token`/`status`/`logout` into the live plane.
+   (`build_pod_env` additionally scrubs `KIROCREW_BOUND_PORT` outright.)
+3. `KIROCREW_BOUND_PORT`, when it parses as an int — the port the parent
+   gateway actually bound, exported once its TCP site is listening
+   (`dashboard.server._export_bound_port`). Never persisted —
+   `service_environment()` deliberately does not capture it.
+4. A port **explicitly written** in `dashboard.url`. A portless URL
    (`http://my.host`) is *not* a port choice: `parse_dashboard_url()`
    substitutes `5476` for the server's benefit, so the client re-splits the URL
    and only accepts the port when it was actually named.
-4. The sole **gateway-owned run-marker**. A running gateway records
+5. The sole **gateway-owned run-marker**. A running gateway records
    `<data-home>/run/gateway-<port>.bin` (see
    `kiro_crew.instances.run_marker`, written for the SSH token-mint), so its
    filename already advertises the port. A client with nothing configured reads
@@ -572,9 +586,9 @@ in this order, first hit wins:
    - **Ambiguity** — with several gateways up there is no basis to pick one, so
      the step refuses, prints the candidate ports and the `--port` /
      `KIROCREW_PORT` hint to stderr, and falls through.
-5. `_DEFAULT_PORT` (`5476`).
+6. `_DEFAULT_PORT` (`5476`).
 
-Step 4 is what makes a single gateway started on a non-default port
+Steps 3 and 5 are what make a single gateway started on a non-default port
 (`kirocrew gateway --port 6776`) reachable from a bare `kirocrew token` with
 zero configuration; before it existed, the client hit a dead 5476 while the
 marker naming the live gateway sat unread. Config-load, URL-parse (including a

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -1140,6 +1140,19 @@ The `dashboard.url` field controls where the dashboard is reachable. From it, th
 
 A **malformed** `dashboard.url` (e.g. an unterminated IPv6 literal `http://[::1` or a non-numeric port `http://host:notaport`) does **not** abort startup: `parse_dashboard_url` degrades to the defaults (`""` host, port `5476`) and logs a warning, so a single typo in the config can never take the gateway down on boot. `KIROCREW_PORT` still overrides the port regardless.
 
+Once the dashboard's TCP site is listening, the gateway **exports the
+actually-bound port as `KIROCREW_BOUND_PORT`** into its own environment, so
+every child it spawns (kiro-cli sessions and their MCP stdio servers) inherits
+the truth instead of re-deriving a guess from `dashboard.url` — a portless URL
+would otherwise collapse to the default port in the child even when the
+gateway is bound elsewhere (including `--port auto`, where the OS assigns the
+port and no config field ever names it). It is a **distinct variable from
+`KIROCREW_PORT`** on purpose: `KIROCREW_PORT` means operator intent and is
+persisted by `service_environment()` into unit files, while
+`KIROCREW_BOUND_PORT` is ephemeral observed truth that must never be frozen
+into persistent config. Clients read it via `cli_server.resolve_client_port`,
+one precedence step below the operator override.
+
 ## Model Resolution Chain
 
 When `agent.model` is `"auto"` (default):

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -226,42 +226,77 @@ def resolve_client_port(cli_port: int | None) -> int:
     Resolution order:
 
     1. Explicit ``--port`` CLI flag if the user passed one (``cli_port`` is not ``None``).
-    2. ``KIROCREW_PORT`` env var if set to a valid integer.
-    3. Port explicitly named by ``dashboard.url`` in the config file
+    2. ``KIROCREW_PORT`` env var if set to a valid integer. Deliberately ABOVE
+       the bound-port export: an explicitly-set ``KIROCREW_PORT`` is how a
+       caller retargets a child at a DIFFERENT gateway — ``pod exec`` builds a
+       client env with ``KIROCREW_PORT=<pod-port>`` precisely so the command
+       reaches the pod, while the inherited ``KIROCREW_BOUND_PORT`` still
+       names the spawning LIVE gateway. Ranking the bound value higher would
+       walk pod ``token``/``status``/``logout`` (and the local secret they
+       carry) into the live gateway — a cross-plane isolation break.
+    3. ``KIROCREW_BOUND_PORT`` env var if set to a valid integer — the port the
+       parent gateway ACTUALLY bound, exported once its TCP site is listening
+       (``dashboard.server._export_bound_port``). Below the operator override
+       (see above); above config because a bound fact from the live parent
+       beats a guess re-derived from a portless ``dashboard.url``.
+    4. Port explicitly named by ``dashboard.url`` in the config file
        (``<data-home>/config.json``), when it parses.
-    4. The sole gateway-owned run-marker (``<data-home>/run/gateway-<port>.bin``)
+    5. The sole gateway-owned run-marker (``<data-home>/run/gateway-<port>.bin``)
        — see :func:`_marker_port`. Skipped when no marker's port is held by a
        verified gateway process, and refused (with a stderr hint) when several
        are.
-    5. ``_DEFAULT_PORT`` (5476) as the final fallback.
+    6. ``_DEFAULT_PORT`` (5476) as the final fallback.
 
-    Steps 1-3 match the server-side ``parse_dashboard_url()`` logic so that
-    ``kirocrew token`` / ``status`` / ``logout`` / ``stop`` all hit the same
-    port the gateway is actually bound to when the user has configured a
+    Steps 1, 2 and 4 match the server-side ``parse_dashboard_url()`` logic so
+    that ``kirocrew token`` / ``status`` / ``logout`` / ``stop`` all hit the
+    same port the gateway is actually bound to when the user has configured a
     non-default ``dashboard.url`` (for example a dev instance on 6777 or an
-    alternative prod port like 7778). Step 4 covers the case where nothing was
-    configured at all but a gateway is up on a non-default port (e.g. started
-    with ``kirocrew gateway --port 6776``): the running gateway's own marker is
-    better evidence than the 5476 default.
+    alternative prod port like 7778). Steps 3 and 5 cover the case where
+    nothing was configured at all but a gateway is up on a non-default port
+    (e.g. started with ``kirocrew gateway --port 6776``): the parent's own
+    export, or the running gateway's marker, is better evidence than the 5476
+    default.
+    """
+    port, _ = resolve_client_port_ex(cli_port)
+    return port
+
+
+def resolve_client_port_ex(cli_port: int | None) -> tuple[int, bool]:
+    """Like :func:`resolve_client_port`, also reporting HOW the port resolved.
+
+    The second element is ``True`` when the port came from positive evidence
+    (an explicit flag, an env var, a configured port, or a verified
+    run-marker) and ``False`` when resolution fell through to
+    ``_DEFAULT_PORT``. Callers that cache a resolution for the process
+    lifetime need the distinction: a fall-through only proves nothing was
+    discoverable *at that instant* — during gateway boot the run-marker may
+    not be written yet — so pinning it would freeze the weakest outcome
+    forever, while every positive source is stable for the process lifetime.
     """
     if cli_port is not None:
-        return cli_port
+        return cli_port, True
     env_port = os.environ.get("KIROCREW_PORT")
     if env_port:
         try:
-            return int(env_port)
+            return int(env_port), True
         except ValueError:
-            # Fall through to config/marker/default — main() validates this
-            # early, but guard here too in case the helper is reached via
+            # Fall through to bound/config/marker/default — main() validates
+            # this early, but guard here too in case the helper is reached via
             # another path.
+            pass
+    bound_port = os.environ.get("KIROCREW_BOUND_PORT")
+    if bound_port:
+        try:
+            return int(bound_port), True
+        except ValueError:
             pass
     cfg_port = _config_url_port()
     if cfg_port:
-        return cfg_port
+        return cfg_port, True
     discovered = _marker_port()
     if discovered:
-        return discovered
-    return _DEFAULT_PORT
+        return discovered, True
+    return _DEFAULT_PORT, False
 
 
 def _probe_dashboard_health(port: int) -> None:

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1223,6 +1223,51 @@ def _register_mcp_routes(app: web.Application) -> None:
     )
 
 
+def _export_bound_port(runner: web.AppRunner, port: int) -> None:
+    """Advertise the actually-bound dashboard port to child processes.
+
+    Sets ``KIROCREW_BOUND_PORT`` in this process's environment once the TCP
+    site is listening, so everything the gateway spawns (kiro-cli sessions and
+    the MCP stdio servers they start) inherits the port that is really bound
+    instead of re-deriving a guess from ``dashboard.url``. A portless URL makes
+    ``parse_dashboard_url`` substitute the default port — right for the server
+    (it must bind something), wrong for a child aiming a loopback callback at
+    a gateway that may be bound elsewhere.
+
+    Deliberately a DISTINCT variable from ``KIROCREW_PORT``: that one means
+    "operator-declared port" everywhere else — ``service_environment()`` bakes
+    it into persistent unit files, and config code reads it as intent — so
+    writing bound truth into it would let a ``--port auto`` ephemeral port be
+    frozen into a service install run from a gateway-descended shell, and
+    would leak between tests through the process environment.
+    ``KIROCREW_BOUND_PORT`` carries ephemeral truth only: consumed by
+    ``cli_server.resolve_client_port`` one step below the operator override,
+    never persisted.
+
+    *port* is ``0`` for an OS-assigned ephemeral bind (``--port auto``); the
+    real port is then read back from the runner's bound addresses (only the
+    TCP site is on the runner when this runs — the unix site is added after).
+    Best-effort: when no TCP address is readable the environment is left
+    untouched, which is exactly the pre-export behavior.
+    """
+    bound = port
+    if not bound:
+        for addr in runner.addresses:
+            # TCP socknames are (host, port[, flowinfo, scope_id]) tuples; a
+            # unix socket's would be a bare str path.
+            if isinstance(addr, (tuple, list)) and len(addr) >= 2 and isinstance(addr[1], int):
+                bound = addr[1]
+                break
+    if bound:
+        os.environ["KIROCREW_BOUND_PORT"] = str(bound)
+        logger.debug("Exported KIROCREW_BOUND_PORT=%d for child processes", bound)
+    else:
+        logger.warning(
+            "Could not read the bound dashboard port; child processes will "
+            "re-derive it from config and the run-marker"
+        )
+
+
 async def _start_site(
     site: web.TCPSite,
     port: int,
@@ -3505,6 +3550,9 @@ async def start_dashboard(
     await runner.setup()
     site = web.TCPSite(runner, bind_address_for(local_only), port)
     await _start_site(site, port)
+    # Export the port this gateway ACTUALLY bound so child processes resolve
+    # loopback callbacks against the truth, not a re-derived config guess.
+    _export_bound_port(runner, port)
     # Additional kernel-verifiable transport for the internal API (POSIX only;
     # degrades to TCP-only on any failure — see _start_unix_site).
     _unix_socket_holder["path"] = await _start_unix_site(runner, port)
@@ -4079,6 +4127,9 @@ async def start_api_server(
     bind_addr = bind_address_for(local_only)
     site = web.TCPSite(runner, bind_addr, port)
     await _start_site(site, port)
+    # Export the actually-bound port for child processes (parity with
+    # start_dashboard — headless gateways spawn the same MCP stdio children).
+    _export_bound_port(runner, port)
     # Additional kernel-verifiable transport for the internal API (parity with
     # start_dashboard; POSIX only, degrades to TCP-only on any failure).
     _unix_socket_holder["path"] = await _start_unix_site(runner, port)

--- a/src/kiro_crew/mcp_computer.py
+++ b/src/kiro_crew/mcp_computer.py
@@ -96,7 +96,7 @@ from kiro_crew.computer_use.types import (
 )
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.mcp_core import (
-    _API,
+    _api_base,
     _http_error_body,
     _internal_secret,
     _resolve_session_key_strict,
@@ -643,7 +643,7 @@ def _invoke(session_key: str, name: str, args: dict[str, Any]) -> dict[str, Any]
         {"tool": name, "args": args, "session_key": session_key, "agent": "", "app": ""}
     ).encode()
     request = urllib.request.Request(
-        f"{_API}{INVOKE_PATH}",
+        f"{_api_base()}{INVOKE_PATH}",
         data=body,
         headers={
             "Content-Type": "application/json",
@@ -653,7 +653,7 @@ def _invoke(session_key: str, name: str, args: dict[str, Any]) -> dict[str, Any]
         method="POST",
     )
     try:
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_API from dashboard.url config) + a fixed internal path; never agent-controlled  # noqa: E501
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_api_base() from config/run-marker) + a fixed internal path; never agent-controlled  # noqa: E501
         with loopback_urlopen(request, timeout=INVOKE_TIMEOUT_SECS) as response:
             decoded = json.loads(response.read())
     except urllib.error.HTTPError as exc:

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -48,7 +48,7 @@ from kiro_crew.config.loader import (
     resolve_agent_bindings,
 )
 from kiro_crew.context_management import COMPLETION_KEEP_DEFAULT_CHARS, summarize_result
-from kiro_crew.dashboard.origin import dashboard_socket_path, parse_dashboard_url
+from kiro_crew.dashboard.origin import dashboard_socket_path
 from kiro_crew.history import _SEARCH_SCAN_WINDOW as SEARCH_SCAN_WINDOW
 from kiro_crew.history import INCOGNITO_MEMORY_MODES, ConversationLog, search_query_tokens
 from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes
@@ -141,41 +141,114 @@ from kiro_crew.validation import (
 )
 
 
-def _resolve_api_base() -> str:
-    """Resolve the gateway API base URL from ``dashboard.url`` config."""
-    cfg = KiroCrewConfig.load()
-    _host, port = parse_dashboard_url(cfg.dashboard.url)
-    return f"http://localhost:{port}"
+def _resolve_api_port() -> tuple[int, bool]:
+    """Resolve the gateway API port a callback should aim at.
+
+    Delegates to :func:`kiro_crew.cli_server.resolve_client_port`, the same
+    precedence every client CLI command applies: ``KIROCREW_PORT``, then a
+    port **explicitly written** in ``dashboard.url``, then the sole
+    gateway-owned run-marker, then the documented default. The marker step is
+    what keeps a portless ``dashboard.url`` from collapsing to the default
+    port while a live gateway is bound elsewhere — ``parse_dashboard_url``
+    substitutes the default for the *server's* benefit (it must bind
+    something), which is exactly the wrong guess for a client callback.
+
+    The import is lazy on purpose: ``cli_server`` fans out into CLI-only
+    dependencies this stdio server otherwise never loads, and paying that once
+    on the first gateway call keeps the hot MCP-stdio import path lean.
+
+    Returns ``(port, positive)`` — ``positive`` is ``False`` when resolution
+    fell through to the default with no evidence behind it.
+    """
+    from kiro_crew.cli_server import resolve_client_port_ex
+
+    return resolve_client_port_ex(None)
 
 
-_API = _resolve_api_base()
+# Lazily-resolved caches for the gateway API port, base URL, and unix-socket
+# path. ``None`` means "not resolved yet"; the getters below fill them on
+# first use (tests may pre-seed any of them with a concrete value).
+# Deliberately NOT computed at import: resolution reads config and the
+# gateway's live run-marker, both of which can change between process start
+# and the first gateway call — an import-time snapshot froze a wrong guess
+# for the whole process lifetime. The URL and the socket path both derive
+# from the single ``_API_PORT`` resolution, so the two transports can never
+# name different gateways.
+_API_PORT: int | None = None
+_API: str | None = None
+_API_UNIX_SOCKET: str | None = None
 
 
-def _resolve_api_unix_socket() -> str:
+def _api_port() -> int:
+    """Gateway API port, resolved on first use; cached only on evidence.
+
+    A resolution that fell through to the default port is returned but NOT
+    cached: it only proves nothing was discoverable at that instant. During
+    gateway boot a broker-descended server can race the asynchronous
+    run-marker write — pinning that fall-through would freeze the wrong port
+    for the process lifetime, with restart as the only recovery. The next
+    call re-resolves and picks the marker up once it exists. Every positive
+    source (env, explicit config, verified marker) is stable, so those are
+    cached as before.
+    """
+    global _API_PORT
+    if _API_PORT is None:
+        port, positive = _resolve_api_port()
+        if not positive:
+            return port
+        _API_PORT = port
+    return _API_PORT
+
+
+def _api_base() -> str:
+    """Gateway API base URL, resolved on first use and cached.
+
+    Pinned to the IPv4 literal ``127.0.0.1`` rather than ``localhost``: these
+    requests carry ``X-Internal-Secret``, and a hostname lookup could resolve
+    to ``::1`` where a different (possibly foreign) process may be listening —
+    the gateway itself binds IPv4 loopback. Mirrors ``cli_server._CLI_LOOPBACK``.
+    """
+    global _API
+    if _API is None:
+        base = f"http://127.0.0.1:{_api_port()}"
+        if _API_PORT is None:
+            # Port resolution fell through to the default — do not pin a URL
+            # built on no evidence (see _api_port).
+            return base
+        _API = base
+    return _API
+
+
+def _api_unix_socket() -> str:
     """Path of the gateway's internal-API unix socket (may not exist yet).
 
-    Preferred transport for every ``_API`` request: connecting through it lets
-    the gateway kernel-verify (``SO_PEERCRED`` + /proc ancestry) that this
-    process actually belongs to the session its ``X-Session-Key`` header
+    Preferred transport for every gateway API request: connecting through it
+    lets the gateway kernel-verify (``SO_PEERCRED`` + /proc ancestry) that
+    this process actually belongs to the session its ``X-Session-Key`` header
     declares, instead of taking the header on faith. ``loopback_urlopen``
     checks existence per call and falls back to TCP when the file is absent
     (Windows, older gateway, bind failure) or nobody answers on it, so
-    resolving the path once at import — mirroring ``_API`` — is safe.
+    caching the path after the first resolution — mirroring ``_api_base`` —
+    is safe. Derived from the same cached ``_api_port`` resolution as the API
+    base so both transports always aim at the same gateway.
     """
-    try:
-        cfg = KiroCrewConfig.load()
-        _host, port = parse_dashboard_url(cfg.dashboard.url)
-        return str(dashboard_socket_path(port))
-    except Exception:
-        return ""
-
-
-_API_UNIX_SOCKET = _resolve_api_unix_socket()
+    global _API_UNIX_SOCKET
+    if _API_UNIX_SOCKET is None:
+        try:
+            path = str(dashboard_socket_path(_api_port()))
+        except Exception:
+            _API_UNIX_SOCKET = ""
+            return _API_UNIX_SOCKET
+        if _API_PORT is None:
+            # Same no-evidence rule as _api_base: usable now, not pinned.
+            return path
+        _API_UNIX_SOCKET = path
+    return _API_UNIX_SOCKET
 
 
 def _api_urlopen(req: urllib.request.Request | str, timeout: float):
-    """``loopback_urlopen`` against ``_API`` with the unix-socket preference."""
-    return loopback_urlopen(req, timeout=timeout, unix_socket_path=_API_UNIX_SOCKET or None)
+    """``loopback_urlopen`` against the API base with the unix-socket preference."""
+    return loopback_urlopen(req, timeout=timeout, unix_socket_path=_api_unix_socket() or None)
 
 
 # How often a sleeping `wait` polls /api/session-keepalive.
@@ -3158,13 +3231,13 @@ def _post(path: str, body: dict | None = None, *, timeout: float = 30) -> dict:
     if sk:
         headers["X-Session-Key"] = sk
     req = urllib.request.Request(
-        f"{_API}{path}",
+        f"{_api_base()}{path}",
         data=data,
         headers=headers,
         method="POST",
     )
     try:
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_API from dashboard.url config) + a fixed internal path; never user-controlled  # noqa: E501
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_api_base() from config/run-marker) + a fixed internal path; never user-controlled  # noqa: E501
         with _api_urlopen(req, timeout=timeout) as resp:
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
@@ -3248,7 +3321,7 @@ def _get(path: str, session_key: str | None = None) -> dict:
     if sk:
         headers["X-Session-Key"] = sk
     req = urllib.request.Request(
-        f"{_API}{path}",
+        f"{_api_base()}{path}",
         headers=headers,
     )
     try:
@@ -3270,13 +3343,13 @@ def _patch(path: str, body: dict | None = None) -> dict:
     if sk:
         headers["X-Session-Key"] = sk
     req = urllib.request.Request(
-        f"{_API}{path}",
+        f"{_api_base()}{path}",
         data=data,
         headers=headers,
         method="PATCH",
     )
     try:
-        # _API is the hardcoded loopback dashboard base and `path` is a code
+        # _api_base() is the loopback dashboard base and `path` is a code
         # literal — never attacker-controlled, so no file:// scheme risk.
         with _api_urlopen(req, timeout=30) as resp:  # nosemgrep  # noqa: E501
             return json.loads(resp.read())
@@ -3308,13 +3381,13 @@ def _put(path: str, body: dict | None = None, session_key: str | None = None) ->
     if sk:
         headers["X-Session-Key"] = sk
     req = urllib.request.Request(
-        f"{_API}{path}",
+        f"{_api_base()}{path}",
         data=data,
         headers=headers,
         method="PUT",
     )
     try:
-        # _API is the hardcoded loopback dashboard base and `path` is a code
+        # _api_base() is the loopback dashboard base and `path` is a code
         # literal — never attacker-controlled, so no file:// scheme risk.
         with _api_urlopen(req, timeout=30) as resp:  # nosemgrep  # noqa: E501
             return json.loads(resp.read())
@@ -3336,7 +3409,7 @@ def _delete(path: str, body: dict | None = None) -> dict:
     if data:
         headers["Content-Type"] = "application/json"
     req = urllib.request.Request(
-        f"{_API}{path}",
+        f"{_api_base()}{path}",
         data=data,
         headers=headers,
         method="DELETE",
@@ -5085,7 +5158,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                     os.unlink(tmp)
                     raise
         # Resolve webhook URL
-        parsed = urlparse(_API)
+        parsed = urlparse(_api_base())
         base = f"{parsed.scheme}://{parsed.hostname}"
         if parsed.port:
             base += f":{parsed.port}"
@@ -5661,7 +5734,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         if sk:
             headers["X-Session-Key"] = sk
         req = urllib.request.Request(
-            f"{_API}/api/artifacts/{slug}", data=data, headers=headers, method="PATCH"
+            f"{_api_base()}/api/artifacts/{slug}", data=data, headers=headers, method="PATCH"
         )
         try:
             with _api_urlopen(req, timeout=30) as http_resp:
@@ -5723,7 +5796,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         if sk:
             headers["X-Session-Key"] = sk
         req = urllib.request.Request(
-            f"{_API}/api/artifacts/{slug}", data=data, headers=headers, method="PATCH"
+            f"{_api_base()}/api/artifacts/{slug}", data=data, headers=headers, method="PATCH"
         )
         try:
             with _api_urlopen(req, timeout=30) as http_resp:

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -1030,6 +1030,12 @@ def build_pod_env(cfg: PodConfig, home_dir: Path, port: int, checkout: Path) -> 
         or (k.endswith("_TOKEN") and not k.startswith("AWS_"))
     ]:
         env.pop(key, None)
+    # Cross-plane guard: a gateway-descended caller inherits the LIVE
+    # gateway's KIROCREW_BOUND_PORT (dashboard.server._export_bound_port).
+    # Inside a pod env it would name the wrong plane — the pod's own
+    # KIROCREW_PORT above is the target — so drop it unconditionally rather
+    # than rely on resolution precedence alone.
+    env.pop("KIROCREW_BOUND_PORT", None)
     return env
 
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -6587,19 +6587,32 @@ class GatewayOrchestrator:
         self._init_task_runner()
         if not self._no_dashboard:
             await self._init_dashboard()
-            # Record this gateway's own kirocrew launcher, keyed by the port it
-            # serves, so a remote token-mint execs THIS install's venv instead of
-            # a stale ~/.local/bin/kirocrew that may point at an uninstalled
-            # worktree. See kiro_crew.instances.run_marker.
-            try:
-                from kiro_crew.instances import run_marker
-
-                if self._dashboard_port:
-                    run_marker.write_marker(self._dashboard_port)
-            except Exception:
-                logger.debug("Gateway run-marker write skipped", exc_info=True)
         else:
             await self._init_api_server()
+        # Record this gateway's own kirocrew launcher, keyed by the port it
+        # serves, so a remote token-mint execs THIS install's venv instead of
+        # a stale ~/.local/bin/kirocrew that may point at an uninstalled
+        # worktree. See kiro_crew.instances.run_marker. Written for headless
+        # API-only gateways too: the marker's filename is what lets a client
+        # or MCP child discover a non-default port when neither KIROCREW_PORT
+        # nor dashboard.url names one. Dispatched as a tracked background
+        # task, never awaited: write_marker does atomic file writes plus a
+        # prune scan over prior runs' markers, so on a slow filesystem an
+        # await here would gate READY on file-count-scaled maintenance. The
+        # marker is best-effort discovery metadata — nothing at boot depends
+        # on it, and write_marker never raises. The guard keeps startup alive
+        # even when dashboard init was skipped and no port was ever resolved.
+        try:
+            from kiro_crew.instances import run_marker
+
+            if self._dashboard_port:
+                _marker_task = asyncio.create_task(
+                    asyncio.to_thread(run_marker.write_marker, self._dashboard_port)
+                )
+                self._background_tasks.add(_marker_task)
+                _marker_task.add_done_callback(self._background_tasks.discard)
+        except Exception:
+            logger.debug("Gateway run-marker write skipped", exc_info=True)
 
         # Publish the MCP-gateway broker + apply callbacks onto
         # DashboardState now that it exists (the broker started earlier).

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -546,6 +546,12 @@ def _isolate_kirocrew_home(_isolation_dirs, monkeypatch):
     home = _isolation_dirs("kirocrew-home")
     monkeypatch.setenv("KIROCREW_HOME", str(home))
     monkeypatch.delenv("KIROCREW_PROJECT_DIR", raising=False)
+    # ``_export_bound_port`` writes KIROCREW_BOUND_PORT into the real process
+    # environment when a test boots a dashboard/API server. Under xdist a
+    # worker runs many tests in one process, so a port exported by one test
+    # would leak into every later test's port resolution. Clear it per test;
+    # a test that wants it sets it via monkeypatch (which still wins).
+    monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
     monkeypatch.setattr("kiro_crew.config.paths._resolved_home", None)
 
 

--- a/test/test_mcp_api_port_resolution.py
+++ b/test/test_mcp_api_port_resolution.py
@@ -1,0 +1,207 @@
+"""Gateway port resolution for MCP callbacks.
+
+Two halves of one defect:
+
+* ``mcp_core`` derived its API base from ``dashboard.url`` alone at import
+  time, so a portless URL collapsed to the default port even while a live
+  gateway advertised itself elsewhere via its run-marker — every loopback
+  callback then aimed at a port the gateway never bound.
+* The gateway never exported the port it actually bound, so child processes
+  had nothing better than that guess to inherit.
+
+These tests lock in the fix: ``mcp_core`` resolves lazily through
+``cli_server.resolve_client_port`` (env → explicit config port → live
+run-marker → default), and the dashboard server exports ``KIROCREW_BOUND_PORT``
+once its TCP site is listening.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import kiro_crew.mcp_core as mcp_core
+from kiro_crew.dashboard.server import _export_bound_port
+
+
+@pytest.fixture(autouse=True)
+def _fresh_caches(monkeypatch: pytest.MonkeyPatch):
+    """Reset the lazy caches and neutralise ambient env for every test.
+
+    ``_API`` / ``_API_UNIX_SOCKET`` memoise the first resolution for the
+    process lifetime; the suite runs many tests in one process, so each test
+    must start unresolved. ``KIROCREW_PORT`` is deleted because a dev box (or
+    a gateway-spawned test run) may carry it, and it sits above every other
+    resolution step.
+    """
+    monkeypatch.setattr(mcp_core, "_API_PORT", None)
+    monkeypatch.setattr(mcp_core, "_API", None)
+    monkeypatch.setattr(mcp_core, "_API_UNIX_SOCKET", None)
+    monkeypatch.delenv("KIROCREW_PORT", raising=False)
+    monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+
+
+def _cfg(url: object):
+    cfg = MagicMock()
+    cfg.dashboard.url = url
+    return patch("kiro_crew.cli_server.KiroCrewConfig.load", return_value=cfg)
+
+
+def _markers(ports: list[int]):
+    return patch("kiro_crew.cli_server.run_marker.marker_ports", return_value=ports)
+
+
+def _owned(ports: list[int]):
+    """Pretend a verified Kiro Crew gateway listens on each of *ports*."""
+    return patch("kiro_crew.cli_server._gateway_owns_port", side_effect=lambda p: p in set(ports))
+
+
+class TestApiBaseResolution:
+    """``mcp_core._api_base`` — the resolver every gateway callback uses."""
+
+    def test_portless_url_prefers_live_marker(self):
+        """The bug: portless ``dashboard.url``, no env, gateway live on 6776.
+
+        ``parse_dashboard_url`` substitutes the default port for a portless
+        URL; taking that as the answer aims every MCP callback at a port the
+        gateway never bound. The live run-marker is the better evidence.
+        """
+        with _cfg("http://my.host.example"), _markers([6776]), _owned([6776]):
+            assert mcp_core._api_base() == "http://127.0.0.1:6776"
+
+    def test_explicit_config_port_beats_marker(self):
+        """A port the user wrote down is a decision; discovery must yield."""
+        with _cfg("http://127.0.0.1:7778"), _markers([6776]), _owned([6776]):
+            assert mcp_core._api_base() == "http://127.0.0.1:7778"
+
+    def test_dead_pid_marker_is_ignored(self, monkeypatch: pytest.MonkeyPatch):
+        """A marker whose recorded pid no longer holds the port is discarded.
+
+        A crashed gateway leaves its marker and pid sidecar behind
+        (``clear_marker`` only runs on graceful shutdown). The ownership check
+        requires the recorded pid to be among the port's live listeners, so a
+        dead pid fails it and resolution lands on the documented default
+        rather than a port nobody answers on. Exercises the real
+        ``_gateway_owns_port`` chain (only the marker file reads and the
+        listener lookup are stubbed).
+        """
+        monkeypatch.setattr("kiro_crew.cli_server.run_marker.read_pid", lambda port: 999999999)
+        # A dead pid holds no sockets — the listener set for the port is empty.
+        monkeypatch.setattr(
+            "kiro_crew.cli_server.platform_compat.find_listening_pids", lambda port: []
+        )
+        with _cfg(""), _markers([6776]):
+            assert mcp_core._api_base() == "http://127.0.0.1:5476"
+
+    def test_env_var_beats_marker(self, monkeypatch: pytest.MonkeyPatch):
+        """The exported ``KIROCREW_PORT`` (gateway truth) sits above discovery."""
+        monkeypatch.setenv("KIROCREW_PORT", "6777")
+        with _cfg(""), _markers([6776]), _owned([6776]):
+            assert mcp_core._api_base() == "http://127.0.0.1:6777"
+
+    def test_default_fallthrough_is_not_pinned(self):
+        """A resolution with no evidence behind it must not be cached.
+
+        During gateway boot a broker-descended MCP server can resolve before
+        the asynchronous run-marker write lands; nothing is discoverable at
+        that instant and resolution falls through to the default. Pinning
+        that would freeze the wrong port for the process lifetime — the next
+        call must re-resolve and pick up the marker once it exists.
+        """
+        with _cfg(""), _markers([]):
+            assert mcp_core._api_base() == "http://127.0.0.1:5476"
+        assert mcp_core._API_PORT is None  # nothing pinned
+        assert mcp_core._API is None
+        # The marker appears (gateway finished booting) — same process now
+        # resolves the real port without a restart.
+        with _cfg(""), _markers([6776]), _owned([6776]):
+            assert mcp_core._api_base() == "http://127.0.0.1:6776"
+        assert mcp_core._API_PORT == 6776  # positive evidence IS pinned
+
+    def test_unix_socket_not_pinned_on_default_fallthrough(self):
+        """The socket path follows the same no-evidence rule as the URL."""
+        with _cfg(""), _markers([]):
+            assert mcp_core._api_unix_socket().endswith("dashboard-5476.sock")
+        assert mcp_core._API_UNIX_SOCKET is None
+        with _cfg(""), _markers([6776]), _owned([6776]):
+            assert mcp_core._api_unix_socket().endswith("dashboard-6776.sock")
+
+    def test_resolution_is_lazy_and_cached(self):
+        """First call resolves, later calls reuse the cache (no re-discovery)."""
+        with _cfg(""), _markers([6776]) as markers, _owned([6776]):
+            assert mcp_core._api_base() == "http://127.0.0.1:6776"
+            assert mcp_core._api_base() == "http://127.0.0.1:6776"
+            assert markers.call_count == 1
+
+    def test_preseeded_cache_is_respected(self, monkeypatch: pytest.MonkeyPatch):
+        """A pre-seeded ``_API`` (the test seam) short-circuits resolution."""
+        monkeypatch.setattr(mcp_core, "_API", "http://127.0.0.1:1")
+        with _markers([6776]) as markers:
+            assert mcp_core._api_base() == "http://127.0.0.1:1"
+            markers.assert_not_called()
+
+    def test_unix_socket_path_follows_the_same_port(self):
+        """Both transports must aim at the same gateway.
+
+        The unix-socket path is derived from the same resolution as the TCP
+        base; deriving it from raw config again would reintroduce the split
+        this fix removes (TCP at the marker port, socket at the default).
+        """
+        with _cfg("http://my.host.example"), _markers([6776]), _owned([6776]):
+            assert mcp_core._api_unix_socket().endswith("dashboard-6776.sock")
+
+    def test_bound_port_beats_marker_and_config_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The parent gateway's exported bound port is observed truth."""
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "7891")
+        with _cfg("http://my.host.example"), _markers([6776]), _owned([6776]):
+            assert mcp_core._api_base() == "http://127.0.0.1:7891"
+
+    def test_operator_port_beats_bound_port(self, monkeypatch: pytest.MonkeyPatch):
+        """An explicit KIROCREW_PORT is how a caller retargets a child at a
+        DIFFERENT gateway: pod exec builds a client env with
+        KIROCREW_PORT=<pod-port> while the inherited KIROCREW_BOUND_PORT still
+        names the spawning LIVE gateway. If the bound value outranked it, pod
+        token/status/logout would walk their credentials into the live
+        gateway — a cross-plane isolation break."""
+        monkeypatch.setenv("KIROCREW_PORT", "7891")
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "5476")
+        with _cfg(""), _markers([]):
+            assert mcp_core._api_base() == "http://127.0.0.1:7891"
+
+
+class _StubRunner:
+    def __init__(self, addresses: list[object]):
+        self.addresses = addresses
+
+
+class TestExportBoundPort:
+    """``dashboard.server._export_bound_port`` — the gateway-side half."""
+
+    def test_explicit_port_is_exported(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+        _export_bound_port(_StubRunner([("127.0.0.1", 6776)]), 6776)
+        assert os.environ["KIROCREW_BOUND_PORT"] == "6776"
+        monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+
+    def test_ephemeral_bind_reads_port_back_from_runner(self, monkeypatch: pytest.MonkeyPatch):
+        """``--port auto`` requests port 0; the OS-assigned port is the truth."""
+        monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+        _export_bound_port(_StubRunner([("127.0.0.1", 54321)]), 0)
+        assert os.environ["KIROCREW_BOUND_PORT"] == "54321"
+        monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+
+    def test_no_readable_address_leaves_env_untouched(self, monkeypatch: pytest.MonkeyPatch):
+        """Best-effort: an unreadable address list must not export garbage."""
+        monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+        _export_bound_port(_StubRunner(["/tmp/some.sock"]), 0)
+        assert "KIROCREW_BOUND_PORT" not in os.environ
+
+    def test_export_overwrites_stale_env(self, monkeypatch: pytest.MonkeyPatch):
+        """The bound port is the truth even when an older value is inherited."""
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "1111")
+        _export_bound_port(_StubRunner([]), 6776)
+        assert os.environ["KIROCREW_BOUND_PORT"] == "6776"

--- a/test/test_mcp_computer.py
+++ b/test/test_mcp_computer.py
@@ -2255,7 +2255,9 @@ class TestTheInvokeCallIsNeverProxied:
             for key in self.PROXY_ENV_KEYS:
                 monkeypatch.delenv(key, raising=False)
             monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{proxy_port}")
-            monkeypatch.setattr(mcp_computer, "_API", f"http://127.0.0.1:{gateway_port}")
+            monkeypatch.setattr(
+                mcp_computer, "_api_base", lambda: f"http://127.0.0.1:{gateway_port}"
+            )
             monkeypatch.setattr(mcp_computer, "_internal_secret", lambda: self.CANARY)
 
             decoded = mcp_computer._invoke("dashboard:main", TOOL_LIST_APPS, {})
@@ -2287,7 +2289,9 @@ class TestTheInvokeCallIsNeverProxied:
                 monkeypatch.delenv(key, raising=False)
             monkeypatch.setenv("http_proxy", f"http://127.0.0.1:{proxy_port}")
             monkeypatch.setenv("no_proxy", "localhost")
-            monkeypatch.setattr(mcp_computer, "_API", f"http://127.0.0.1:{gateway_port}")
+            monkeypatch.setattr(
+                mcp_computer, "_api_base", lambda: f"http://127.0.0.1:{gateway_port}"
+            )
             monkeypatch.setattr(mcp_computer, "_internal_secret", lambda: self.CANARY)
 
             mcp_computer._invoke("dashboard:main", TOOL_LIST_APPS, {})

--- a/test/test_pod_self_contained.py
+++ b/test/test_pod_self_contained.py
@@ -64,6 +64,25 @@ def test_pod_env_puts_the_checkout_venv_ahead_of_the_global_shim_dir(tmp_path):
     assert entries.index(venv_bin) < entries.index(shim_dir)
 
 
+def test_pod_env_scrubs_the_live_gateways_bound_port(tmp_path, monkeypatch):
+    """KIROCREW_BOUND_PORT must never cross the pod boundary.
+
+    A gateway-descended caller (an agent bash turn) inherits the LIVE
+    gateway's bound-port export. Inside a pod env it names the wrong plane —
+    the pod's own KIROCREW_PORT is the target — and resolve_client_port reads
+    it as a fallback, so leaving it in would let pod client commands aim at
+    the live gateway if precedence ever changed. Scrubbed unconditionally.
+    """
+    monkeypatch.setenv("KIROCREW_BOUND_PORT", "5476")
+    cfg = _pod_cfg(tmp_path)
+    checkout = _provisioned_checkout(tmp_path)
+
+    env = rt.build_pod_env(cfg, tmp_path / "home", 7900, checkout)
+
+    assert "KIROCREW_BOUND_PORT" not in env
+    assert env["KIROCREW_PORT"] == "7900"
+
+
 def test_pod_env_still_isolates_home_and_port(tmp_path):
     """The PATH change must not disturb the existing isolation keys."""
     cfg = _pod_cfg(tmp_path)


### PR DESCRIPTION
## What is the problem?

MCP callbacks connect to a gateway port that may never have been bound. `mcp_core._resolve_api_base()` derived the gateway API base from `dashboard.url` alone: when that URL carries no explicit port and `KIROCREW_PORT` is unset, `parse_dashboard_url` substitutes the default 5476 — a substitution that exists for the *server's* benefit (it must bind something) but is exactly the wrong guess for a client callback. Two issues report the same defect from different sides: the gateway never exports the port it actually bound (#2659), and the resolver never consults the run-marker that `cli_server` already uses for exactly this fallback (#2893). `_API` was also evaluated at module import, so a corrected config could not take effect without restarting the process.

## Why this issue matters to the user

Every KiroCrew tool that round-trips through the gateway (`spawn_run`, `learn_add`, artifacts, monitors, computer-use) rides this URL. On any gateway not on 5476 — a pod, `--port N`, `--port auto`, or a multi-instance box — those tools fail with connection-refused, or worse, talk to a *different* gateway that happens to hold 5476. The failure looks like random MCP tool breakage with no log line tying it to port resolution.

## How our fix solves it

Symptom → root cause → change:

- **Symptom:** callbacks aim at 5476 while the gateway listens elsewhere.
- **Root cause:** the resolver trusted a default that encodes no information, computed once at import, and the gateway never published the truth.
- **Change (fix at the resolver, not at each caller):**
  1. `mcp_core` now resolves lazily through `cli_server.resolve_client_port(None)` — the same precedence every client CLI command applies: `KIROCREW_PORT` → a port **explicitly written** in `dashboard.url` → the sole **gateway-owned run-marker** (pid-verified, fails closed) → the default. One cached `_API_PORT` feeds both the TCP base URL and the unix-socket path, so the two transports can never name different gateways. The base URL is pinned to the IPv4 literal `127.0.0.1` (previously `localhost`) — a deliberate security-relevant change: these requests carry `X-Internal-Secret`, a hostname lookup could resolve to `::1` where a different process may listen, and the gateway binds IPv4 loopback (mirrors `cli_server._CLI_LOOPBACK`). A resolution that falls through to the default port with no evidence (env/config/marker) behind it is served but never cached, so a broker-descended server that races the asynchronous run-marker write picks up the real port on its next call instead of freezing 5476 for the process lifetime. `mcp_computer` consumes the same getter.
  2. The dashboard server exports the **actually-bound** port as `KIROCREW_BOUND_PORT` (a distinct variable from `KIROCREW_PORT`, which means operator intent and is persisted into service unit files; the new variable is ephemeral observed truth, read by `resolve_client_port` one step below the operator override) once its TCP site is listening (`_export_bound_port`, in both `start_dashboard` and `start_api_server`), so every child the gateway spawns inherits the truth — including `--port auto`, where the OS-assigned port is read back from the runner's addresses.
  3. The gateway **run-marker is now written in headless API-only mode too**, so marker discovery also covers children spawned before the export (e.g. the MCP broker) on POSIX.

Docs updated in the same commit: `docs/system-specs/modules/cli.md` (mcp_core/mcp_computer as `resolve_client_port` consumers) and `docs/system-specs/modules/config.md` (the bound-port export).

## What tests we did

- New `test/test_mcp_api_port_resolution.py` (11 tests): portless `dashboard.url` + live marker resolves to the marker's port; an explicit port in `dashboard.url` still wins; a marker whose recorded PID is dead is ignored (real `_gateway_owns_port` chain); env beats marker; resolution is lazy + cached; pre-seeded cache test seam respected; unix-socket path follows the same port; export of explicit/ephemeral ports; unreadable-address no-op; stale-env overwrite.
- **Mutation-verified (4/4 caught):** resolver hardcoded to default; env export dropped; socket derives from raw default; ephemeral readback dropped.
- Updated the two proxy-leak tests in `test/test_mcp_computer.py` to pin the new getter (they patched the removed `_API` alias).
- 1,217 targeted tests green across the 9 affected/adjacent files (`test_mcp_api_port_resolution`, `test_mcp_computer`, `test_dashboard_peer_auth`, `test_cli`, `test_instances`, `test_dashboard_server_coverage`, `test_slack_gateway*`, `test_tailnet_cli`); isort/flake8/mypy clean.
- Two model-pinned local review passes ran pre-push; all Critical/High findings fixed (stale test patch target, shared port cache, export observability, headless marker write).

## Any other suggestions on the work

Deferred, with reasoning:

- **`cli_server` import weight:** `mcp_core` lazily imports `cli_server` (first gateway call only). Extracting the ~40-line resolution chain into a leaf module would drop that cost; kept out of this PR to avoid churning `cli_server`'s security-sensitive, separately-tested discovery functions.
- **Broker start order:** the MCP broker starts before the dashboard binds, so broker-inherited environments predate the export. POSIX children recover via the run-marker at first use (lazy resolution); Windows broker children keep pre-fix behavior (marker discovery deliberately denies on non-POSIX). Reordering gateway boot is out of scope here.

Closes #2893
Closes #2929
Closes #2659
