### PR TITLE
test: pin the clock in ChatSidebar date-bucket tests (#2919)

### DIFF
--- a/website/src/test/ChatSidebar.flatView.test.tsx
+++ b/website/src/test/ChatSidebar.flatView.test.tsx
@@ -124,7 +124,24 @@ function renderSidebar(slots: any[] = SLOTS, folders: ChatFolder[] = FOLDERS) {
 }
 
 beforeEach(() => localStorage.clear())
-afterEach(() => vi.clearAllMocks())
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.useRealTimers()
+})
+
+/** Pin the clock for date-bucket tests (issue #2919). Fakes ONLY `Date` so
+ *  real timers keep driving RTL and promises, and pins the instant to LOCAL
+ *  midday — the farthest point from both midnight edges in any timezone — so
+ *  a `daysAgo(n)` fixture lands in its intended calendar bucket regardless of
+ *  timezone or time of day (a raw `now - offset` slides across local midnight
+ *  when the suite runs just after 00:00, which put the 60s-ago row under a
+ *  "Yesterday" header). Mid-January avoids DST transitions in the lookback. */
+function pinClock() {
+  vi.useFakeTimers({ toFake: ['Date'] })
+  const pin = new Date(2026, 0, 15, 12, 0, 0) // local midday, not 12:00Z
+  vi.setSystemTime(pin)
+  return (daysAgo: number) => new Date(pin.getTime() - daysAgo * 86400_000).toISOString()
+}
 
 describe('chat sidebar — flat view (explode chats out of folders)', () => {
   it('is off by default: folder tree renders, no flat lane', () => {
@@ -186,11 +203,11 @@ describe('chat sidebar — flat view (explode chats out of folders)', () => {
 
   it('renders date segment headers on date sorts; pinned rows stay above without a header', () => {
     safeSetItem('mc-sidebar-flat-view', '1')
-    const iso = (secsAgo: number) => new Date(Date.now() - secsAgo * 1000).toISOString()
+    const iso = pinClock()
     const slots = [
-      { key: 'k-pin', title: 'Pinned old', messages: 1, running: false, last_ts: iso(40 * 86400), pinned: true },
-      { key: 'k-today', title: 'Fresh one', messages: 1, running: false, folder_id: 'f1', last_ts: iso(60) },
-      { key: 'k-week', title: 'Three days ago', messages: 1, running: false, folder_id: 'f2', last_ts: iso(3 * 86400) },
+      { key: 'k-pin', title: 'Pinned old', messages: 1, running: false, last_ts: iso(40), pinned: true },
+      { key: 'k-today', title: 'Fresh one', messages: 1, running: false, folder_id: 'f1', last_ts: iso(0) },
+      { key: 'k-week', title: 'Three days ago', messages: 1, running: false, folder_id: 'f2', last_ts: iso(3) },
     ]
     const { getByTestId } = renderSidebar(slots)
     const lane = getByTestId('flat-view-lane')
@@ -204,10 +221,10 @@ describe('chat sidebar — flat view (explode chats out of folders)', () => {
   it('hides date segment headers on non-date sorts', () => {
     safeSetItem('mc-sidebar-flat-view', '1')
     safeSetItem('mc-session-sort', 'name-asc')
-    const iso = (secsAgo: number) => new Date(Date.now() - secsAgo * 1000).toISOString()
+    const iso = pinClock()
     const slots = [
-      { key: 'k-b', title: 'Bravo', messages: 1, running: false, folder_id: 'f1', last_ts: iso(60) },
-      { key: 'k-a', title: 'Alpha row', messages: 1, running: false, folder_id: 'f2', last_ts: iso(3 * 86400) },
+      { key: 'k-b', title: 'Bravo', messages: 1, running: false, folder_id: 'f1', last_ts: iso(0) },
+      { key: 'k-a', title: 'Alpha row', messages: 1, running: false, folder_id: 'f2', last_ts: iso(3) },
     ]
     const { getByTestId } = renderSidebar(slots)
     const lane = getByTestId('flat-view-lane')

--- a/website/src/test/ChatSidebarCoverage.test.tsx
+++ b/website/src/test/ChatSidebarCoverage.test.tsx
@@ -360,7 +360,21 @@ describe('ChatSidebar — header menu view + tag entries', () => {
 })
 
 describe('ChatSidebar — Older Sessions pane', () => {
-  const daysAgo = (n: number) => Math.floor((Date.now() - n * 86400_000) / 1000)
+  // Pin the clock for the date-bucket assertions (issue #2919): a raw
+  // `Date.now() - n days` fixture slides across local midnight when the suite
+  // runs just after 00:00, moving the `daysAgo(1)` row from Yesterday into
+  // Last 7 Days. The pin is LOCAL midday — the farthest point from both
+  // midnight edges in any timezone — and fixtures are built here at
+  // collection time from the PIN constant, not the faked clock (the
+  // beforeEach below only pins what the component reads at render). Faking
+  // ONLY `Date` leaves real timers driving waitFor/promises. Mid-January
+  // avoids DST transitions inside the lookback window.
+  const PIN = new Date(2026, 0, 15, 12, 0, 0) // local midday, not 12:00Z
+  const daysAgo = (n: number) => Math.floor((PIN.getTime() - n * 86400_000) / 1000)
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(PIN)
+  })
   const HISTORY: TestHistoryItem[] = [
     { key: 'h1', title: 'Fresh history', modified: daysAgo(0), agent: 'builder' },
     { key: 'h2', title: 'Yesterday history', modified: daysAgo(1) },


### PR DESCRIPTION
Closes #2919

## What

Both `ChatSidebar` date-bucket test surfaces built fixture timestamps by subtracting offsets from the live wall clock (`Date.now()`), then asserted calendar-bucket header labels (`Today` / `Yesterday` / `Last 7 Days` / …). Calendar buckets are computed from local-midnight boundaries (`dateSegment()` in `ChatSidebar.tsx`), so a run starting just after local midnight slid the "60 seconds ago" row into `Yesterday` and failed the exact-sequence assertion — a verdict that depended on the time of day, carrying no information about the change under review.

This pins the clock instead of sampling it (the `seed nondeterministic input` class in `docs/system-specs/common/testing-conventions.md`):

- **`ChatSidebar.flatView.test.tsx`** — new `pinClock()` helper: `vi.useFakeTimers({ toFake: ['Date'] })` + `vi.setSystemTime` pinned to **local midday** (`new Date(2026, 0, 15, 12, 0, 0)`), returning a `daysAgo → ISO` fixture helper. Both date-segment tests use it; `afterEach` gains `vi.useRealTimers()`. The exact-sequence assertion is untouched.
- **`ChatSidebarCoverage.test.tsx`** — `daysAgo()` now derives from the same local-midday `PIN` constant (fixtures here are built at describe-collection time, so they must use the constant, not the faked clock), and a describe-scoped `beforeEach` pins the render-time clock to the same instant. The file's existing `afterEach` already restores real timers.

Zero production code changed.

### Design notes

- **`toFake: ['Date']` only** — real timers keep driving RTL `waitFor`, promises, and the 250 ms debounced search in the coverage file's async tests. A full fake-timer install is exactly what would have starved those paths.
- **Local midday, not `12:00Z`** — the worker TZ is pinned to UTC by `vite.config.ts` (`test.env.TZ`), but the fixtures must not rely on that: a `12:00Z` pin re-derived to local noon leaves the anchor up to 11 h in the future on UTC-11 hosts if anyone ever lifts the TZ pin. `new Date(2026, 0, 15, 12, 0, 0)` is local midday by construction — ~12 h from both midnight edges in every zone. (Raised as an advisory by the pre-push Opus review; applied.)
- **Mid-January pin** avoids DST transitions inside the 40-day lookback.
- **No shared helper** — the two files need different fixture shapes (ISO string vs epoch seconds) and different install points (per-test vs collection-time constant + `beforeEach`); two inline setups read more clearly than one abstraction (spec: minimal surface area wins).
- **Root-cause note**: the reporter's "Australia/Sydney morning" observation is consistent with the UTC worker clock — `test.env.TZ = 'UTC'` in `vite.config.ts` means Sydney mornings are UTC just-after-midnight, which is precisely the failure window.

## Fail-before / pass-after evidence

**Fail before** (unmodified tests, ambient worker clock pinned to `2026-08-12T00:00:30Z`, i.e. 30 s past midnight in the worker TZ):

```
FAIL  src/test/ChatSidebar.flatView.test.tsx > … > renders date segment headers on date sorts; pinned rows stay above without a header
AssertionError: expected [ 'k-pin', 'H:Yesterday', …(3) ] to deeply equal [ 'k-pin', 'H:Today', 'k-today', …(2) ]
```

(the exact diff reported in #2919; the coverage file's date-segment test fails the same way under the pin)

**Pass after** — both files, 39/39, under every combination tried:

| Scenario | Result |
|---|---|
| `TZ=UTC` | 39/39 ✅ |
| `TZ=Australia/Sydney` (UTC+10) | 39/39 ✅ |
| `TZ=Pacific/Kiritimati` (UTC+14) | 39/39 ✅ |
| `TZ=Pacific/Midway` (UTC-11) | 39/39 ✅ |
| `TZ=America/Los_Angeles` (UTC-8) | 39/39 ✅ |
| Ambient clock 00:00:30 local (worker TZ) | 39/39 ✅ |
| Kiritimati + ambient 00:00:30 local | 39/39 ✅ |
| Midway + ambient 00:00:30 local | 39/39 ✅ |

(TZ variation applied via a temporary local override of the config's `test.env.TZ`; not part of this change.)

## Full-suite verification

- `npx tsc -b` — clean
- `npx vitest run` — 995 files, 16,329 passed | 2 expected fail | 3 skipped; no other test depended on these files' real-clock behavior. (One pre-existing unhandled-error teardown race in lottie-web via an unrelated avatar test file appears under full-suite load on unmodified main too.)
- Backend gates: isort / flake8 / mypy clean; pytest failures on this dev host are all environmental (sandbox backend unavailable, `/tmp` uid, `KIROCREW_PORT` leak) and reproduce on unmodified main — this diff touches only the two frontend test files.

## Pre-push review

- GPT 5.6 Sol: **PASS**, zero findings (verified fake-Date-only leaves async paths live, no collection/render drift, teardown correct, no weakened assertions).
- Opus 5: **PASS**, zero blocking; 2 advisories — local-midday pin (applied, see design notes) and shared-helper extraction (declined per the spec's minimal-surface rule, rationale above).

Tests are the deliverable; no UI surface changed, no screenshots required.
