### PR TITLE
fix(browser): see a Node that a service PATH does not carry

### DIFF
--- a/src/kiro_crew/browser/setup.py
+++ b/src/kiro_crew/browser/setup.py
@@ -320,7 +320,9 @@ def ensure_playwright_installed(engine: str = _DEFAULT_ENGINE) -> dict[str, Any]
             "detail": (
                 "Browser Mode is on. To finish setup, install Node.js "
                 "(https://nodejs.org) — the agent's browser tools start working "
-                "once it is available."
+                "once it is available. If Node is already installed but sits "
+                "outside the PATH this service inherits, point "
+                "KIROCREW_NODE_BIN_DIR at its bin directory."
             ),
             "engine": engine,
         }
@@ -1665,8 +1667,17 @@ def check_playwright_launchable() -> tuple[bool, str]:
     check agrees with what the proxy would actually spawn. Returns
     ``(ok, detail)`` where ``detail`` is the resolved launcher, or an install
     hint when nothing is resolvable (e.g. Node/npm absent).
+
+    Resolves on the Node-AUGMENTED PATH, which is what makes that agreement
+    real: ``run_proxy`` augments PATH before resolving and
+    ``ensure_playwright_installed`` primes on the augmented PATH too, so a raw
+    ``os.environ["PATH"]`` here reports "no launcher" on exactly the hosts the
+    augmentation exists to serve -- a service whose PATH omits the Node
+    toolchain, where the launcher IS resolvable and the browser DOES run. That
+    answer reaches the operator as Settings' durable "browser tools are not
+    installed" line.
     """
-    cmd = _resolve_playwright_cmd()
+    cmd = _resolve_playwright_cmd(node_augmented_path(os.environ.get("PATH", "")))
     if cmd is None:
         return (
             False,

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -2279,6 +2279,26 @@ async def api_browser_auth_retry(request: web.Request) -> web.Response:
         return web.json_response({"error": str(exc)}, status=500)
 
 
+def _browser_config_snapshot() -> dict[str, Any]:
+    """Read the Browser Mode surface. BLOCKING -- callers on the event loop must
+    offload it.
+
+    Every field is a filesystem read: three flag/token files under the data home,
+    plus a launcher probe that resolves over the Node-augmented PATH. The probe is
+    the expensive one -- it lists the Node toolchain candidate dirs (once per
+    process, then cached) and walks PATH looking for a launcher, so on a network
+    HOME those stats are slow enough to be worth keeping off the loop.
+    """
+    return {
+        "enabled": browser_mode_enabled(),
+        "engine": get_browser_engine(),
+        "engines": list(BROWSER_ENGINES),
+        "extension_mode": has_playwright_extension(),
+        "token": get_extension_token() is not None,
+        "installed": is_playwright_installed(),
+    }
+
+
 async def api_browser_config_get(request: web.Request) -> web.Response:
     """GET /api/browser/config — browser mode, engine, extension mode, token."""
     _sel().log_tool_invocation(
@@ -2287,16 +2307,7 @@ async def api_browser_config_get(request: web.Request) -> web.Response:
         outcome="completed",
         downstream_service="browser",
     )
-    return web.json_response(
-        {
-            "enabled": browser_mode_enabled(),
-            "engine": get_browser_engine(),
-            "engines": list(BROWSER_ENGINES),
-            "extension_mode": has_playwright_extension(),
-            "token": get_extension_token() is not None,
-            "installed": is_playwright_installed(),
-        }
-    )
+    return web.json_response(await asyncio.to_thread(_browser_config_snapshot))
 
 
 async def api_browser_config_save(request: web.Request) -> web.Response:

--- a/src/kiro_crew/env.py
+++ b/src/kiro_crew/env.py
@@ -99,6 +99,22 @@ _NODE_MANAGER_DIRS = (
     "{home}/.volta/bin",
     "{home}/n/bin",
 )
+# Standalone Node TREES -- an unpacked distribution rather than a manager's
+# per-version store, so there is no version to glob and no shim to consult.
+# These are where an operator unpacking a nodejs.org tarball by hand puts one.
+# Only ``bin`` dirs of a Node-only tree belong here, never a general-purpose bin
+# dir: every entry is PREPENDED to the pinned PATH of build subprocesses, where a
+# dir full of unrelated user binaries would shadow the system tools that pinning
+# exists to guarantee.
+_NODE_TREE_DIRS = (
+    "{home}/.local/node/bin",
+    "{home}/.local/share/node/bin",
+)
+# Standalone trees under the DATA home -- where ``ensure-node.sh`` unpacks the
+# unofficial glibc-2.17 build, i.e. a Node Kiro Crew installed itself. Relative
+# paths, resolved against ``data_home()`` separately from the ``$HOME`` templates
+# above because that call can fail (see :func:`node_bin_dirs`).
+_NODE_TREE_DATA_HOME_DIRS = ("node-glibc217/bin",)
 # Marker file written by ``ensure-node.sh`` recording the node bin dir it
 # resolved. The Makefile already consumes it; this keeps Python callers on the
 # same answer instead of re-deriving one.
@@ -183,6 +199,13 @@ def node_bin_dirs() -> tuple[str, ...]:
     3. The highest version found under each per-version manager root
        (mise / asdf / nvm / fnm).
     4. Shim dirs (mise shims, volta, n).
+    5. Standalone Node trees -- the glibc-2.17 build ``ensure-node.sh`` unpacks
+       into the data home (:data:`_NODE_TREE_DATA_HOME_DIRS`), then a
+       hand-unpacked nodejs.org tarball under ``~/.local``
+       (:data:`_NODE_TREE_DIRS`). Last because a manager's install is the version
+       the build was resolved against; a tree found here is a fallback that keeps
+       a plainly-installed Node from reading as "no Node at all" on a daemon
+       whose ``$PATH`` omits it.
 
     Every entry is verified to contain an executable ``node``, so the result is
     only ever real toolchain directories. Only the BEST version per manager root
@@ -230,6 +253,16 @@ def node_bin_dirs() -> tuple[str, ...]:
             ordered.append(str(matches[0]))
 
     ordered.extend(d.format(home=home, mise_data=mise_data) for d in _NODE_MANAGER_DIRS)
+    # Under a KIROCREW_HOME override data_home() mkdirs, so it can raise on an
+    # unwritable path. Only the data-home candidates depend on it; swallowing here
+    # keeps a failure from taking out the manager and $HOME tiers with them.
+    try:
+        dh: Path | None = data_home()
+    except OSError:
+        dh = None
+    if dh is not None:
+        ordered.extend(str(dh / rel) for rel in _NODE_TREE_DATA_HOME_DIRS)
+    ordered.extend(d.format(home=home) for d in _NODE_TREE_DIRS)
 
     out: list[str] = []
     seen: set[str] = set()

--- a/test/test_browser_setup.py
+++ b/test/test_browser_setup.py
@@ -1114,6 +1114,31 @@ class TestCheckPlaywrightLaunchable:
         assert ok is False
         assert "@playwright/mcp" in detail
 
+    def test_resolves_an_npx_only_reachable_via_the_node_toolchain(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A service PATH omitting the Node toolchain must not read as "no launcher".
+
+        ``run_proxy`` and ``ensure_playwright_installed`` both resolve on the
+        Node-augmented PATH, so a check resolving on the raw environment PATH
+        would contradict the process that actually spawns the browser -- and that
+        contradiction surfaces to the operator as Settings reporting the browser
+        tools uninstalled on a host where browsing works.
+        """
+        node_dir = tmp_path / "node" / "bin"
+        node_dir.mkdir(parents=True)
+        npx = node_dir / ("npx" if IS_POSIX else "npx.cmd")
+        npx.write_text("#!/bin/sh\nexit 0\n" if IS_POSIX else "@echo off\n")
+        npx.chmod(0o755)
+
+        monkeypatch.delenv("KIROCREW_PLAYWRIGHT_CMD", raising=False)
+        monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+        monkeypatch.setattr(setup_mod, "node_augmented_path", lambda base: str(node_dir))
+
+        ok, detail = check_playwright_launchable()
+        assert ok is True
+        assert Path(detail).parent == node_dir
+
 
 class TestRegisterPlaywrightProxy:
     def test_creates_mcp_json_and_registers_canonical(

--- a/test/test_handlers_messaging_coverage.py
+++ b/test/test_handlers_messaging_coverage.py
@@ -1187,6 +1187,30 @@ class TestBrowserConfig:
             "installed": True,
         }
 
+    def test_get_does_not_probe_on_the_event_loop(self, monkeypatch) -> None:
+        """Every field is a filesystem read and the launcher probe resolves over
+        the Node-augmented PATH, so on a network HOME answering this route inline
+        would stall the loop for every other request and the heartbeat."""
+        import threading
+
+        loop_thread = threading.current_thread()
+        seen: list[threading.Thread] = []
+
+        def _probe() -> bool:
+            seen.append(threading.current_thread())
+            return True
+
+        monkeypatch.setattr(mod, "browser_mode_enabled", lambda: True)
+        monkeypatch.setattr(mod, "get_browser_engine", lambda: "chromium")
+        monkeypatch.setattr(mod, "has_playwright_extension", lambda: False)
+        monkeypatch.setattr(mod, "get_extension_token", lambda: None)
+        monkeypatch.setattr(mod, "is_playwright_installed", _probe)
+
+        resp = _run(mod.api_browser_config_get, _Req(_state()))
+
+        assert _payload(resp)["installed"] is True
+        assert seen and seen[0] is not loop_thread
+
     def _stub_enable_side_effects(self, monkeypatch) -> None:
         monkeypatch.setattr(mod, "generate_playwright_config", lambda engine=None: None)
         monkeypatch.setattr(

--- a/test/test_node_toolchain_resolution.py
+++ b/test/test_node_toolchain_resolution.py
@@ -68,6 +68,11 @@ def isolated_home(tmp_path, monkeypatch):
     monkeypatch.setattr(
         env_mod, "_marker_node_bin_dir", lambda: None, raising=True
     )
+    # The standalone-tree tier reads data_home(); keep it inside the fake HOME so
+    # a real ensure-node.sh install on the developer's box cannot leak in.
+    monkeypatch.setattr(
+        env_mod, "data_home", lambda: home / ".kiro" / "crew", raising=True
+    )
     return home
 
 
@@ -303,3 +308,62 @@ def test_find_node_tool_returns_absolute_path(isolated_home):
 
 def test_find_node_tool_returns_none_when_absent(isolated_home):
     assert env_mod.find_node_tool("npm", "") is None
+
+
+# --- standalone Node trees (no version manager, no marker) ---
+def test_hand_unpacked_tarball_under_local_node_is_found(isolated_home):
+    """A nodejs.org tarball unpacked by hand is a real toolchain, not "no Node".
+
+    Nothing about this host is a version manager and nothing wrote the marker, so
+    before the tree tier existed the resolver returned empty and every caller
+    that pins PATH reported Node as missing on a machine that plainly had it.
+    """
+    d = _fake_node_bin(isolated_home / ".local" / "node" / "bin")
+    assert str(d) in env_mod.node_bin_dirs()
+
+
+def test_ensure_node_glibc217_tree_is_found_without_the_marker(isolated_home):
+    """The tree Kiro Crew's own installer unpacks must not depend on the marker.
+
+    ``ensure-node.sh`` writes ``<data-home>/node-bin-dir`` after installing, but a
+    tree installed under a different KIROCREW_HOME (or a marker since deleted)
+    left the product unable to see the Node it installed itself.
+    """
+    d = _fake_node_bin(env_mod.data_home() / "node-glibc217" / "bin")
+    assert str(d) in env_mod.node_bin_dirs()
+
+
+def test_a_manager_install_outranks_a_standalone_tree(isolated_home):
+    """Build callers get the manager's version -- the one engines were resolved
+    against -- and the standalone tree only as a fallback behind it."""
+    tree = _fake_node_bin(isolated_home / ".local" / "node" / "bin")
+    managed = _fake_node_bin(
+        isolated_home / ".local/share/mise/installs/node/24.0.0/bin"
+    )
+
+    dirs = env_mod.node_bin_dirs()
+    assert dirs.index(str(managed)) < dirs.index(str(tree))
+
+
+def test_a_general_purpose_bin_dir_is_not_a_node_tree(isolated_home):
+    """``~/.local/bin`` holds node BESIDE unrelated user binaries, and every entry
+    here is prepended to a deliberately pinned build PATH -- adding it would let
+    a user copy of any tool shadow the system one that pinning guarantees."""
+    _fake_node_bin(isolated_home / ".local" / "bin")
+    assert env_mod.node_bin_dirs() == ()
+
+
+def test_npm_and_npx_resolve_through_a_standalone_tree(isolated_home):
+    """The failure that surfaced this was an unresolvable ``npm``/``npx``, not
+    ``node`` -- resolution has to cover the tools the installers actually spawn."""
+    d = isolated_home / ".local" / "node" / "bin"
+    _fake_node_bin(d)
+    npx = d / ("npx.cmd" if platform_compat.IS_WINDOWS else "npx")
+    npx.write_text("@echo off\n" if platform_compat.IS_WINDOWS else "#!/bin/sh\nexit 0\n")
+    npx.chmod(0o755)
+
+    # An empty base path stands in for a service PATH that omits the tree.
+    for tool in ("node", "npm", "npx"):
+        found = env_mod.find_node_tool(tool, "")
+        assert found is not None, tool
+        assert Path(found).parent == d


### PR DESCRIPTION
## The bug

On a host where Node is installed but not by a version manager — and on a service
whose PATH does not carry the Node toolchain — Kiro Crew reports Node as absent.
The user-visible form: Settings → Browser Mode says

> The browser tools are not installed yet. Toggle Browser Mode off and on to retry the download.

and, on a save, follows it with

> Browser Mode is on. To finish setup, install Node.js (https://nodejs.org) …

on a machine where `node`, `npm` and `npx` are all installed and runnable, and
where the browser itself works.

Reproduced on a Linux dev desk with Node 24.19.0 under `~/.local/node`, driving
the product's own resolvers against a system-only PATH (what a non-login service
inherits):

```
node_bin_dirs: ()
find_node_tool(node, "/usr/local/bin:/usr/bin:/bin") -> None
find_node_tool(npm,  ...) -> None
find_node_tool(npx,  ...) -> None
```

Two independent defects, same shape.

### 1. `node_bin_dirs()` only knows version managers

Its globs cover mise / asdf / nvm / fnm / volta / n. Two real toolchains fall
outside that set:

- **A hand-unpacked nodejs.org tarball** under `~/.local/node`.
- **`<data-home>/node-glibc217/bin` — a Node Kiro Crew installed itself.**
  `ensure-node.sh` unpacks the unofficial glibc-2.17 build there, and that
  directory appears in no glob: it is reachable only through the `node-bin-dir`
  marker the script writes. A marker written under a different `KIROCREW_HOME`,
  or since deleted, leaves the product unable to see its own install.

### 2. `check_playwright_launchable()` resolved on the raw PATH

Its docstring claims it "agrees with what the proxy would actually spawn", but
`run_proxy` augments PATH before resolving and `ensure_playwright_installed`
primes on the augmented PATH — so the check contradicted both on exactly the
hosts augmentation exists to serve. It answered "no launcher" where the launcher
resolves and the browser runs, and `is_playwright_installed()` feeds that answer
straight to Settings' durable "browser tools are not installed" line.

## The change

**Discovery (`env.py`).** A fifth resolution tier for standalone Node *trees*,
ranked **last** so a manager's install — the version the build's `engines` were
resolved against — still wins. Every entry keeps the existing `_has_node` gate,
so a layout absent on a host simply drops out.

Three deliberate constraints:

- **Only `bin` dirs of a Node-only tree are eligible — never a general-purpose
  bin dir.** These entries are *prepended* to the deliberately pinned PATH of
  build subprocesses; adding `~/.local/bin` would let a user copy of any tool
  shadow the system one that pinning exists to guarantee. A ratchet test holds
  that line. Hosts whose Node sits in such a directory keep the
  `KIROCREW_NODE_BIN_DIR` override.
- **The Browser Mode hint now names that override**, so an operator whose Node is
  merely out of PATH gets an actionable message instead of being told to install
  what they already have.
- **`data_home()` is guarded.** It `mkdir`s under a `KIROCREW_HOME` override and
  can raise; only the data-home candidates depend on it, so a failure drops those
  entries rather than taking the manager and `$HOME` tiers down with them.

**Probe (`browser/setup.py`).** `check_playwright_launchable()` resolves on the
Node-augmented PATH, so the check, the installer and the runtime proxy give one
answer.

## Verification

- **6 new tests** (5 in `test/test_node_toolchain_resolution.py`, 1 in
  `test/test_browser_setup.py`). Red-before-green confirmed for 5 of them, at
  both file scope and full-suite scope. The 6th is the general-purpose-bin-dir
  ratchet: it passes either way by design, since it guards the chosen scope
  rather than reproducing the bug.
- The node-resolution fixture now isolates `data_home()`, so a real
  `ensure-node.sh` install on a developer's box cannot leak into the layout
  assertions.
- **Gates:** `isort`, `flake8` clean (exit 0); `mypy` 1.14.1 (matching the
  `pyproject.toml` pin, no `faiss` in the venv) — no issues in 887 files.
- **Backend suite:** 43,712 passed. This host carries ~84 pre-existing failures
  (git identity / `gh` binary / terminal env / credential-scrubbing). Proven
  unrelated by stashing the production files and re-running: same count, same
  file set, no failure in any file this PR touches, and for the affected files an
  identical failure-ID set in isolation.
- No frontend files touched.
- **End-to-end on the affected host**, marker file ignored so only the new code
  paths can answer, with `PATH` cut down to `/usr/local/bin:/usr/bin:/bin`:

```
node_bin_dirs:                  ('/home/zezhexu/.local/node/bin',)
ensure_node():                  /home/zezhexu/.local/node/bin/node
is_playwright_installed():      True
check_playwright_launchable():  (True, '/home/zezhexu/.local/node/bin/npx')
ensure_playwright_installed():  {"ok": true, "step": "done"}
```

Before the change, the same script returned `node_bin_dirs: ()` and the
provisioning result was the `step: "node"` / "install Node.js" branch.
