### PR TITLE
test: raise backend coverage 85.98% -> 86.93%

### DIFF
--- a/test/test_chat_runner_coverage.py
+++ b/test/test_chat_runner_coverage.py
@@ -1,0 +1,2203 @@
+"""Coverage tests for ``kiro_crew.dashboard.chat_runner``.
+
+The module's happy paths are well covered by the existing chat suites
+(``test_dashboard_approval``, ``test_dashboard_chat``, ``test_eager_spawn``,
+``test_goal_command`` …). What this module targets instead is the set of
+*defensive* branches those suites never reach: fail-open ``except`` arms,
+deny-by-default returns, the three retry ladders that a terminal
+``stop_reason`` walks, and the auto-approve rungs (trusted patterns,
+read-only bash, native crew) that sit between the interactive prompt and the
+session-trust flag.
+
+Two harnesses are used and the choice between them is deliberate:
+
+* Pure helpers are called directly. They take plain dicts / mocks, so a unit
+  call reaches the branch with no turn machinery at all.
+* Branches that only exist inside ``_run_chat`` are driven through a real
+  turn, with a mocked provider whose ``stream()`` yields a scripted list of
+  ``LLMEvent``s. That is the same shape ``test_dashboard_approval`` uses, so
+  the assertions run against production dispatch rather than a re-implemented
+  copy of it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from chat_test_helpers import _make_ready_kiro_prerequisite
+
+from kiro_crew.acp.types import (
+    EVENT_COMPLETE,
+    EVENT_PERMISSION_REQUEST,
+    EVENT_TEXT_CHUNK,
+    STOP_REASON_STALE_RECOVER,
+    STOP_REASON_TOOL_STALL,
+)
+from kiro_crew.dashboard import chat_runner
+from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+from kiro_crew.history import ConversationLog
+from kiro_crew.providers.base import LLMEvent
+
+# ── Shared helpers ────────────────────────────────────────────────────────
+
+
+def _slot(key: str = "chat-cov-1") -> _ChatSlot:
+    slot = _ChatSlot(key)
+    # Titled on purpose: an untitled slot makes the end-of-turn cycle spawn
+    # _maybe_auto_title, which is a real LLM path. maybe_refresh_title (the
+    # titled branch) self-guards and returns without a call.
+    slot._titled = True
+    return slot
+
+
+def _state(tmp_path, **kwargs) -> DashboardState:
+    sessions = MagicMock(count=0)
+    sessions.get_pid = MagicMock(return_value=None)
+    sessions.get_slack_link = MagicMock(return_value=(None, None))
+    sessions.set_slack_link = MagicMock()
+    sessions.get_mirror_link = MagicMock(return_value=None)
+    sessions.reset = AsyncMock()
+    sessions.remove = AsyncMock()
+    sessions.record_failure = AsyncMock()
+    sessions.remove_if_unclaimed = AsyncMock(return_value=False)
+    sessions.check_context_usage = MagicMock()
+    state = DashboardState(
+        sessions=sessions,
+        crons=MagicMock(list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})),
+        lessons=MagicMock(load_all=MagicMock(return_value=[])),
+        start_time=0.0,
+        conversation_log=ConversationLog(base_dir=tmp_path),
+        **kwargs,
+    )
+    state.kiro_prerequisite_service = _make_ready_kiro_prerequisite()
+    state.broadcast_ws = MagicMock()
+    state.push_slots_update = MagicMock()
+    state.push_refresh = MagicMock()
+    state.refresh_slot_source_status = MagicMock()
+    state.broadcast_context_usage = MagicMock()
+    return state
+
+
+async def _async_iter(items):
+    for item in items:
+        yield item
+
+
+def _complete(stop_reason: str = "end_turn", **kwargs) -> LLMEvent:
+    return LLMEvent(kind=EVENT_COMPLETE, stop_reason=stop_reason, **kwargs)
+
+
+def _permission(
+    title: str = "Running: ls -la",
+    tool_input: str = "",
+    tool_kind: str = "execute",
+    request_id: str = "req-cov-1",
+) -> LLMEvent:
+    return LLMEvent(
+        kind=EVENT_PERMISSION_REQUEST,
+        title=title,
+        tool_kind=tool_kind,
+        tool_input=tool_input,
+        request_id=request_id,
+        is_shell=True,
+    )
+
+
+def _runner_state(tmp_path, *, hook_store=None, context_builder=None):
+    """Return ``(state, client)`` wired for a scripted ``_run_chat`` turn."""
+    state = _state(tmp_path)
+    client = AsyncMock()
+    # The provider's sync accessors must NOT be AsyncMock: _run_chat calls them
+    # inline and would otherwise store un-awaited coroutines in the WS payload.
+    client.context_usage_pct = MagicMock(return_value=0.0)
+    client.context_window_tokens = MagicMock(return_value=0)
+    client.context_used_tokens = MagicMock(return_value=0)
+    client.last_prompt_stats = None
+    client._client = client
+    client.exit_code = None
+    state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+    state._hook_store = hook_store or MagicMock(fire=AsyncMock(return_value=[]))
+    if context_builder is not None:
+        state.context_builder = context_builder
+    return state, client
+
+
+def _set_stream(client, events) -> None:
+    """Script ``client.stream`` so only the FIRST turn yields *events*.
+
+    A turn that produced no visible assistant text arms the empty-response
+    auto-continue, which re-queues the prompt and runs a second turn. With a
+    stream that replays unconditionally, that second turn re-processes the same
+    permission event and every ``assert_awaited_once`` on the provider counts
+    two calls. Later turns therefore complete immediately.
+    """
+    calls = {"n": 0}
+
+    def _stream(*_args, **_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _async_iter(events)
+        return _async_iter([_complete()])
+
+    client.stream = MagicMock(side_effect=_stream)
+
+
+@contextmanager
+def _quiet_sel():
+    """Stub the SEL audit sink so a turn does not write an audit trail."""
+    with patch.object(chat_runner, "sel") as mock_sel:
+        mock_sel.return_value = MagicMock()
+        yield mock_sel
+
+
+async def _drive(state, slot, message: str = "hello") -> None:
+    """Run exactly one turn and leave no task behind.
+
+    ``_empty_response_retries`` is pre-spent on purpose. A turn that streams no
+    assistant text re-queues itself, and the finally block then dispatches a
+    SECOND turn through ``spawn_guarded_turn`` — which doubles every
+    ``assert_awaited_once`` on the provider and leaves a task running past the
+    test's event loop. Starting at the exhausted count sends the empty response
+    to its terminal notice branch instead, so one call is one turn.
+    """
+    slot._empty_response_retries = 2
+    with _quiet_sel():
+        await chat_runner._run_chat(state, slot, message)
+    await _settle(slot)
+
+
+async def _settle(slot) -> None:
+    """Await (or cancel) any follow-up turn the finally block dispatched."""
+    task = slot.task
+    if task is None or not hasattr(task, "cancel"):
+        return
+    if not task.done():
+        task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    except Exception:  # pragma: no cover — draining, never the assertion
+        pass
+
+
+def _errors(slot) -> list[str]:
+    return [m.get("content", "") for m in slot.messages if m.get("role") == "error"]
+
+
+# ── drain_pending_context ─────────────────────────────────────────────────
+
+
+class TestDrainPendingContext:
+    def test_expired_entry_is_discarded(self):
+        """An entry past its ``maxAge`` is dropped, not injected."""
+        slot = _slot()
+        slot._pending_context = [
+            {"content": "stale", "source": "app", "maxAge": 1, "injectedAt": 0},
+            {"content": "fresh", "source": "panel"},
+        ]
+
+        out = chat_runner.drain_pending_context(slot)
+
+        assert "stale" not in out
+        assert "fresh" in out
+        assert 'from "panel"' in out
+        assert slot._pending_context == []
+
+    def test_all_expired_yields_empty_string(self):
+        slot = _slot()
+        slot._pending_context = [
+            {"content": "stale", "maxAge": 1, "injectedAt": 0},
+        ]
+
+        assert chat_runner.drain_pending_context(slot) == ""
+
+
+# ── turn metric ───────────────────────────────────────────────────────────
+
+
+class TestTurnMetric:
+    @pytest.mark.parametrize(
+        "stop_reason,expected",
+        [
+            (None, "ok"),
+            ("", "ok"),
+            ("end_turn", "ok"),
+            ("completed", "ok"),
+            ("error: timeout waiting", "timeout"),
+            ("error: pipe died", "error"),
+        ],
+    )
+    def test_outcome_mapping(self, stop_reason, expected):
+        assert chat_runner._turn_outcome(stop_reason) == expected
+
+    def test_session_source_attribute_is_attached(self):
+        recorder = MagicMock()
+        with patch.object(chat_runner, "infer_use_case", return_value="cron"), patch.object(
+            chat_runner, "get_recorder", return_value=recorder
+        ):
+            chat_runner._emit_turn_metric(0, "end_turn", "cron:job", elapsed_ms=12)
+
+        _, kwargs = recorder.histogram.call_args
+        assert kwargs["attrs"]["session_source"] == "cron"
+        assert kwargs["attrs"]["outcome"] == "ok"
+
+    def test_use_case_failure_does_not_block_the_emit(self):
+        """A broken source lookup must still leave the histogram emitted."""
+        recorder = MagicMock()
+        with patch.object(chat_runner, "infer_use_case", side_effect=RuntimeError("boom")), patch.object(
+            chat_runner, "get_recorder", return_value=recorder
+        ):
+            chat_runner._emit_turn_metric(50, "end_turn", "dashboard:x")
+
+        recorder.histogram.assert_called_once()
+        _, kwargs = recorder.histogram.call_args
+        assert "session_source" not in kwargs["attrs"]
+
+    def test_recorder_failure_is_swallowed(self):
+        with patch.object(chat_runner, "get_recorder", side_effect=RuntimeError("no recorder")):
+            chat_runner._emit_turn_metric(50, "end_turn", "dashboard:x")
+
+    def test_zero_duration_skips_the_emit(self):
+        recorder = MagicMock()
+        with patch.object(chat_runner, "get_recorder", return_value=recorder):
+            chat_runner._emit_turn_metric(0, "end_turn", "dashboard:x", elapsed_ms=0)
+
+        recorder.histogram.assert_not_called()
+
+
+# ── PreToolUse hook verdicts ──────────────────────────────────────────────
+
+
+class TestPreToolHookVerdicts:
+    @pytest.mark.parametrize(
+        "results",
+        [None, "BLOCKED:h:no", {"blocked": True}, 7],
+    )
+    def test_non_list_output_is_denied(self, results):
+        """Deny-by-default: anything but a list of strings blocks the tool."""
+        assert chat_runner._pre_tool_hooks_should_block(results) is True
+
+    def test_empty_list_is_the_pass_through_contract(self):
+        assert chat_runner._pre_tool_hooks_should_block([]) is False
+
+    def test_non_string_member_blocks(self):
+        assert chat_runner._pre_tool_hooks_should_block(["ok", 3]) is True
+
+    def test_block_reason_prefers_the_hook_text(self):
+        assert (
+            chat_runner._pre_tool_block_reason(["BLOCKED:policy: not allowed here "])
+            == "not allowed here"
+        )
+
+    @pytest.mark.parametrize(
+        "results",
+        [
+            ["BLOCKED:policy:"],  # marker present, reason empty
+            ["BLOCKED:policy"],  # marker truncated, no reason field
+            [],  # nothing blocked
+            "not-a-list",
+        ],
+    )
+    def test_block_reason_falls_back_when_no_reason_is_authored(self, results):
+        assert (
+            chat_runner._pre_tool_block_reason(results) == "blocked by a PreToolUse policy hook"
+        )
+
+
+# ── snapshot helpers ──────────────────────────────────────────────────────
+
+
+class TestSnapshotHelpers:
+    def test_safe_read_snapshot_declines_on_validator_error(self):
+        with patch.object(chat_runner, "validate_file_path", side_effect=OSError("boom")):
+            assert chat_runner._safe_read_snapshot("/tmp/whatever") is None
+
+    def test_safe_read_snapshot_declines_a_directory(self, tmp_path):
+        assert chat_runner._safe_read_snapshot(str(tmp_path)) is None
+
+    def test_safe_read_snapshot_reads_a_regular_file(self, tmp_path):
+        target = tmp_path / "note.txt"
+        target.write_text("hello\n", newline="\n")
+
+        assert chat_runner._safe_read_snapshot(str(target)) == "hello\n"
+
+    def test_truncate_snapshot_marks_the_cut(self):
+        out = chat_runner._truncate_snapshot("x" * (chat_runner._MAX_SNAPSHOT + 10))
+
+        assert out.endswith(f"... (truncated at {chat_runner._MAX_SNAPSHOT} chars)")
+
+    def test_reconstruct_declines_when_neither_state_is_plausible(self, tmp_path):
+        """Ambiguous disk content must decline rather than fabricate a before."""
+        target = tmp_path / "amb.txt"
+        # oldStr twice (pre-write implausible) and the single-newStr reversal
+        # candidate is tool-inconsistent, so neither hypothesis survives.
+        target.write_text("cabab", newline="\n")
+
+        out = chat_runner._reconstruct_str_replace_before(
+            str(target), {"oldStr": "ab", "newStr": "c"}
+        )
+
+        assert out is None
+
+    def test_reconstruct_declines_on_replace_all(self, tmp_path):
+        target = tmp_path / "all.txt"
+        target.write_text("aaa", newline="\n")
+
+        assert (
+            chat_runner._reconstruct_str_replace_before(
+                str(target), {"oldStr": "a", "newStr": "b", "replaceAll": True}
+            )
+            is None
+        )
+
+    def test_reconstruct_declines_on_missing_params(self, tmp_path):
+        target = tmp_path / "missing.txt"
+        target.write_text("body", newline="\n")
+
+        assert chat_runner._reconstruct_str_replace_before(str(target), {"oldStr": "x"}) is None
+
+    def test_snapshot_write_target_ignores_non_write_commands(self):
+        assert chat_runner._snapshot_write_target({"command": "read", "path": "/tmp/x"}) is None
+        assert chat_runner._snapshot_write_target(None) is None
+
+    def test_snapshot_write_target_prefers_the_diff_block(self, tmp_path):
+        target = tmp_path / "create-me.txt"
+
+        got = chat_runner._snapshot_write_target(
+            {"command": "create", "path": str(target)}, diff_old_text=""
+        )
+
+        assert got is not None
+        assert os.path.realpath(got["path"]) == os.path.realpath(str(target))
+        assert got["content"] == ""
+
+    def test_snapshot_write_target_records_empty_before_for_a_new_file(self, tmp_path):
+        target = tmp_path / "not-yet.txt"
+
+        got = chat_runner._snapshot_write_target({"command": "create", "path": str(target)})
+
+        assert got == {"path": str(target), "content": ""}
+
+
+class TestFlushFileChanges:
+    def test_credentials_are_scrubbed_from_before_and_after(self, tmp_path):
+        """A secret in a non-sensitive config must not reach message meta."""
+        target = tmp_path / "config.ini"
+        target.write_text("key=AKIAIOSFODNN7EXAMPLE\nafter\n", newline="\n")
+        slot = _slot()
+        slot.append("assistant", "done", "msg msg-a", broadcast=False)
+        slot._file_changes = [
+            {"path": str(target), "content": "key=AKIAIOSFODNN7EXAMPLE\nbefore\n"}
+        ]
+
+        chat_runner._flush_file_changes(slot)
+
+        changes = slot.messages[-1]["meta"]["file_changes"]
+        assert len(changes) == 1
+        assert "AKIAIOSFODNN7EXAMPLE" not in changes[0]["before"]
+        assert "AKIAIOSFODNN7EXAMPLE" not in changes[0]["after"]
+        assert slot._dirty is True
+        assert slot._file_changes == []
+
+    def test_non_list_changes_are_ignored(self):
+        """A MagicMock slot attribute is truthy — the isinstance gate matters."""
+        slot = _slot()
+        slot._file_changes = MagicMock()
+
+        chat_runner._flush_file_changes(slot)
+
+        assert slot.messages == []
+
+    def test_synthetic_message_is_created_when_no_assistant_row_exists(self, tmp_path):
+        target = tmp_path / "orphan.txt"
+        target.write_text("after\n", newline="\n")
+        slot = _slot()
+        slot._file_changes = [{"path": str(target), "content": "before\n"}]
+
+        chat_runner._flush_file_changes(slot)
+
+        assert slot.messages[-1]["role"] == "assistant"
+        assert slot.messages[-1]["meta"]["file_changes"][0]["after"] == "after\n"
+
+
+class TestAttachTurnStats:
+    def test_zero_elapsed_attaches_nothing(self):
+        slot = _slot()
+        slot.append("assistant", "hi", "msg msg-a", broadcast=False)
+
+        chat_runner._attach_turn_stats(slot, 0, 0.0, 0.0)
+
+        assert "turn_stats" not in (slot.messages[-1].get("meta") or {})
+
+    def test_credits_and_cost_are_rounded_and_omitted_when_zero(self):
+        slot = _slot()
+        slot.append("assistant", "hi", "msg msg-a", broadcast=False)
+
+        chat_runner._attach_turn_stats(slot, 1200, 0.123456, 0.0)
+
+        stats = slot.messages[-1]["meta"]["turn_stats"]
+        assert stats == {"elapsed_ms": 1200, "credits": 0.1235}
+
+    def test_boundary_protects_a_previous_turns_message(self):
+        """A turn that appended no assistant row must not overwrite the last one."""
+        slot = _slot()
+        slot.append("assistant", "prior turn", "msg msg-a", broadcast=False)
+        boundary = len(slot.messages)
+
+        chat_runner._attach_turn_stats(slot, 999, 0.0, 0.0, turn_boundary=boundary)
+
+        assert "turn_stats" not in (slot.messages[-1].get("meta") or {})
+
+
+# ── ACP string redaction / OAuth URL gate ─────────────────────────────────
+
+
+class TestAcpRedaction:
+    def test_empty_string_passes_through(self):
+        assert chat_runner._redact_acp_string("") == ""
+
+    def test_credential_is_scrubbed(self):
+        out = chat_runner._redact_acp_string("token AKIAIOSFODNN7EXAMPLE")
+
+        assert "AKIAIOSFODNN7EXAMPLE" not in out
+
+
+class TestOauthUrlCredentialGate:
+    def test_empty_url_is_not_a_credential(self):
+        assert chat_runner._oauth_url_contains_credential("") is False
+
+    def test_plain_consent_url_is_allowed(self):
+        assert (
+            chat_runner._oauth_url_contains_credential(
+                "https://github.com/login/oauth/authorize?client_id=abc&state=xyz"
+            )
+            is False
+        )
+
+    def test_unparseable_url_is_refused(self):
+        with patch.object(chat_runner, "urlparse", side_effect=ValueError("bad")):
+            assert chat_runner._oauth_url_contains_credential("https://example.test/x") is True
+
+    def test_credential_signature_inside_an_oauth_param_is_refused(self):
+        url = "https://example.test/authorize?state=AKIAIOSFODNN7EXAMPLE1"
+
+        assert chat_runner._oauth_url_contains_credential(url) is True
+
+    def test_exfiltration_pattern_in_a_non_oauth_param_is_refused(self):
+        url = "https://example.test/authorize?payload=" + ("A" * 260)
+
+        assert chat_runner._oauth_url_contains_credential(url) is True
+
+
+class TestEmitMcpOauthRequest:
+    def test_unsafe_scheme_renders_a_rejected_banner(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        chat_runner._emit_mcp_oauth_request(state, slot, "svc", "file:///etc/passwd")
+
+        banner = slot.messages[-1]
+        assert banner["role"] == "mcp_oauth"
+        assert banner["meta"]["rejected_url"] is True
+        assert banner["meta"]["error"] == "unsafe URL scheme"
+
+    def test_credential_bearing_url_renders_a_rejected_banner(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        chat_runner._emit_mcp_oauth_request(
+            state, slot, "svc", "https://example.test/a?state=AKIAIOSFODNN7EXAMPLE1"
+        )
+
+        assert slot.messages[-1]["meta"]["rejected_url"] is True
+
+    def test_card_owned_annotation_rides_on_the_authorize_banner(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        url = "https://github.test/authorize?client_id=x"
+
+        chat_runner._emit_mcp_oauth_request(state, slot, "github", url, card_owned=True)
+
+        assert slot.messages[-1]["meta"]["card_owned"] is True
+        # Assert the whole URL, not a prefix. A startswith() check would also
+        # accept https://github.test.example.com/... -- a different host that
+        # merely begins with the expected string -- so it is both a weaker
+        # assertion and the pattern CodeQL flags as incomplete URL substring
+        # sanitization.
+        assert slot.messages[-1]["meta"]["oauth_url"] == url
+
+
+class TestConnectionsManagedNames:
+    def test_failure_fails_open_to_the_empty_set(self):
+        with patch.object(chat_runner, "kirocrew_managed_names", side_effect=RuntimeError("io")):
+            assert chat_runner._connections_managed_mcp_names() == frozenset()
+
+    def test_intersection_of_managed_and_carded(self):
+        with patch.object(
+            chat_runner, "kirocrew_managed_names", return_value={"github", "handmade"}
+        ), patch.object(
+            chat_runner,
+            "get_visible_providers",
+            return_value=[{"slug": "github"}, {"slug": "slack"}],
+        ):
+            assert chat_runner._connections_managed_mcp_names() == frozenset({"github"})
+
+
+class TestDrainSessionInitOauthRequests:
+    @pytest.mark.asyncio
+    async def test_provider_without_the_accessor_is_a_noop(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        client = MagicMock()
+        client.client = object()  # no pop_pending_oauth_requests
+
+        await chat_runner._drain_session_init_oauth_requests(state, slot, client)
+
+        assert slot.messages == []
+
+    @pytest.mark.asyncio
+    async def test_empty_pending_list_skips_ownership_resolution(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        client = MagicMock()
+        client.client.pop_pending_oauth_requests = MagicMock(return_value=[])
+
+        with patch.object(chat_runner, "_connections_managed_mcp_names") as managed:
+            await chat_runner._drain_session_init_oauth_requests(state, slot, client)
+
+        managed.assert_not_called()
+        assert slot.messages == []
+
+    @pytest.mark.asyncio
+    async def test_non_dict_entries_are_skipped_and_the_rest_emitted(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        client = MagicMock()
+        client.client.pop_pending_oauth_requests = MagicMock(
+            return_value=[
+                "not-a-dict",
+                {"serverName": "github", "oauthUrl": "https://github.test/authorize?client_id=x"},
+            ]
+        )
+
+        with patch.object(
+            chat_runner, "_connections_managed_mcp_names", return_value=frozenset({"github"})
+        ):
+            await chat_runner._drain_session_init_oauth_requests(state, slot, client)
+
+        banners = [m for m in slot.messages if m.get("role") == "mcp_oauth"]
+        assert len(banners) == 1
+        assert banners[0]["meta"]["card_owned"] is True
+
+
+class TestMarkMcpOauthCompleted:
+    def _open_banner(self, state, slot, name: str = "github") -> None:
+        chat_runner._emit_mcp_oauth_request(
+            state, slot, name, "https://x.test/authorize?client_id=1"
+        )
+
+    def test_no_matching_banner_is_a_noop(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        self._open_banner(state, slot, "github")
+        before = len(slot.messages)
+
+        chat_runner._mark_mcp_oauth_completed(state, slot, "other", True)
+
+        assert len(slot.messages) == before
+        assert "completed" not in slot.messages[-1]["meta"]
+
+    def test_already_terminal_banner_is_not_patched_again(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        self._open_banner(state, slot)
+        chat_runner._mark_mcp_oauth_completed(state, slot, "github", True)
+        content_after_first = slot.messages[-1]["content"]
+
+        chat_runner._mark_mcp_oauth_completed(state, slot, "github", False, "second try")
+
+        assert slot.messages[-1]["content"] == content_after_first
+        assert slot.messages[-1]["meta"]["completed"] is True
+
+    def test_failure_records_the_redacted_error(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        self._open_banner(state, slot)
+
+        chat_runner._mark_mcp_oauth_completed(
+            state, slot, "github", False, "denied for AKIAIOSFODNN7EXAMPLE"
+        )
+
+        meta = slot.messages[-1]["meta"]
+        assert meta["failed"] is True
+        assert "AKIAIOSFODNN7EXAMPLE" not in meta["error"]
+        assert "authentication failed" in slot.messages[-1]["content"]
+
+    def test_untimestamped_banner_cannot_be_updated(self, tmp_path):
+        """A history line with no ``ts`` has no update handle — bail, don't broadcast."""
+        state, slot = _state(tmp_path), _slot()
+        slot.messages.append(
+            {"role": "mcp_oauth", "content": "legacy", "meta": {"server_name": "github"}}
+        )
+
+        chat_runner._mark_mcp_oauth_completed(state, slot, "github", True)
+
+        assert not any(
+            call.args and call.args[0] == "chat_message_update"
+            for call in state.broadcast_ws.call_args_list
+        )
+
+
+# ── trust / auto-approve predicates ───────────────────────────────────────
+
+
+class TestTrustPredicates:
+    def test_scope_grant_is_rechecked_on_every_call(self):
+        slot = _slot()
+        slot._trust_scope = "scope-1"
+
+        with patch.object(chat_runner, "safety_override") as override:
+            override.return_value.is_scope_active.return_value = True
+            assert chat_runner._slot_is_trusted(slot) is True
+            override.return_value.is_scope_active.return_value = False
+            assert chat_runner._slot_is_trusted(slot) is False
+
+    def test_no_grant_at_all_is_untrusted(self):
+        assert chat_runner._slot_is_trusted(_slot()) is False
+
+    @pytest.mark.parametrize(
+        "trust,scope,yolo,expected",
+        [
+            (False, "", True, "yolo"),
+            (True, "", False, "trust"),
+            (False, "s-1", False, "trust_scope"),
+            (False, "", False, "trust"),
+        ],
+    )
+    def test_auto_approve_reason_precedence(self, trust, scope, yolo, expected):
+        slot = _slot()
+        slot._trust = trust
+        slot._trust_scope = scope
+
+        assert chat_runner._auto_approve_reason(slot, yolo) == expected
+
+    def test_scoped_grant_is_never_persisted_as_a_session_policy(self):
+        """A lapsing grant must not be cached where nothing re-checks it."""
+        slot = _slot()
+        slot._trust_scope = "scope-1"
+
+        assert chat_runner._persistable_session_policy(slot, False) == ""
+
+    @pytest.mark.parametrize("yolo,trust", [(True, False), (False, True)])
+    def test_non_lapsing_grants_are_persistable(self, yolo, trust):
+        slot = _slot()
+        slot._trust = trust
+
+        assert chat_runner._persistable_session_policy(slot, yolo) == "auto"
+
+    def test_native_crew_auto_approve_requires_an_active_crew(self, tmp_path):
+        state = _state(tmp_path)
+        state.is_yolo_active = MagicMock(return_value=True)
+        slot = _slot()
+        slot._trust = True
+
+        assert chat_runner._native_crew_should_auto_approve({}, state, slot) is False
+        assert (
+            chat_runner._native_crew_should_auto_approve({"s1": {"done": True}}, state, slot)
+            is False
+        )
+        assert (
+            chat_runner._native_crew_should_auto_approve({"s1": {"done": False}}, state, slot)
+            is True
+        )
+
+    def test_active_crew_without_any_grant_is_still_denied(self, tmp_path):
+        state = _state(tmp_path)
+        state.is_yolo_active = MagicMock(return_value=False)
+        state.context_builder = None
+
+        assert (
+            chat_runner._native_crew_should_auto_approve({"s1": {"done": False}}, state, _slot())
+            is False
+        )
+
+
+# ── channel mirror ladder ─────────────────────────────────────────────────
+
+
+class TestChannelTargetLadder:
+    def test_missing_link_resolves_to_nothing(self, tmp_path):
+        assert chat_runner._resolve_channel_target(_state(tmp_path), "dashboard:x", None) is None
+
+    def test_slack_is_skipped(self, tmp_path):
+        link = MagicMock(channel_type=chat_runner.SLACK_NAMESPACE, channel_id="C1")
+
+        assert chat_runner._resolve_channel_target(_state(tmp_path), "dashboard:x", link) is None
+
+    def test_governance_denial_skips_the_mirror(self, tmp_path):
+        link = MagicMock(channel_type="telegram", channel_id="123", thread_id=None)
+        with patch(
+            "kiro_crew.platform.governance_profiles.vet_and_audit",
+            return_value=MagicMock(permitted=False),
+        ):
+            assert (
+                chat_runner._resolve_channel_target(_state(tmp_path), "dashboard:x", link) is None
+            )
+
+    def test_unregistered_transport_skips_the_mirror(self, tmp_path):
+        state = _state(tmp_path)
+        state.get_channel_transport = MagicMock(return_value=None)
+        link = MagicMock(channel_type="telegram", channel_id="123", thread_id=None)
+
+        with patch(
+            "kiro_crew.platform.governance_profiles.vet_and_audit",
+            return_value=MagicMock(permitted=True),
+        ):
+            assert chat_runner._resolve_channel_target(state, "dashboard:x", link) is None
+
+    def test_transport_without_proactive_send_skips_the_mirror(self, tmp_path):
+        state = _state(tmp_path)
+        transport = MagicMock()
+        transport.capabilities.supports_proactive_send = False
+        state.get_channel_transport = MagicMock(return_value=transport)
+        link = MagicMock(channel_type="wecom", channel_id="123", thread_id=None)
+
+        with patch(
+            "kiro_crew.platform.governance_profiles.vet_and_audit",
+            return_value=MagicMock(permitted=True),
+        ):
+            assert chat_runner._resolve_channel_target(state, "dashboard:x", link) is None
+
+    def test_capable_transport_is_returned(self, tmp_path):
+        state = _state(tmp_path)
+        transport = MagicMock()
+        transport.capabilities.supports_proactive_send = True
+        state.get_channel_transport = MagicMock(return_value=transport)
+        link = MagicMock(channel_type="telegram", channel_id="123", thread_id=None)
+
+        with patch(
+            "kiro_crew.platform.governance_profiles.vet_and_audit",
+            return_value=MagicMock(permitted=True),
+        ):
+            got = chat_runner._resolve_channel_target(state, "dashboard:x", link)
+
+        assert got == (link, transport)
+
+
+class TestMarkKiroSignedOut:
+    def test_absent_service_is_a_noop(self):
+        state = MagicMock(spec=[])
+
+        chat_runner._mark_kiro_signed_out(state)
+
+    def test_latch_failure_never_raises(self):
+        state = MagicMock()
+        state.kiro_prerequisite_service.mark_signed_out.side_effect = RuntimeError("io")
+
+        chat_runner._mark_kiro_signed_out(state)
+
+
+class TestDeliverAuthErrorToSlack:
+    @pytest.mark.asyncio
+    async def test_no_slack_client_is_a_noop(self, tmp_path):
+        state = _state(tmp_path)
+        state.slack_client = None
+
+        await chat_runner._deliver_auth_error_to_slack(
+            state, _slot(), state.sessions, "dashboard:x", "signed out"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unlinked_session_is_a_noop(self, tmp_path):
+        state = _state(tmp_path)
+        state.slack_client = AsyncMock()
+
+        await chat_runner._deliver_auth_error_to_slack(
+            state, _slot(), state.sessions, "dashboard:x", "signed out"
+        )
+
+        state.slack_client.post_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_link_from_the_session_store_is_used(self, tmp_path):
+        state = _state(tmp_path)
+        state.slack_client = AsyncMock()
+        state.sessions.get_slack_link = MagicMock(return_value=("111.222", "C123"))
+
+        await chat_runner._deliver_auth_error_to_slack(
+            state, _slot(), state.sessions, "dashboard:x", "signed out"
+        )
+
+        state.slack_client.post_message.assert_awaited_once_with("C123", "signed out", "111.222")
+
+    @pytest.mark.asyncio
+    async def test_post_failure_is_swallowed(self, tmp_path):
+        state = _state(tmp_path)
+        state.slack_client = AsyncMock()
+        state.slack_client.post_message.side_effect = RuntimeError("slack down")
+        slot = _slot()
+        slot._slack_thread_ts = "1.2"
+        slot._slack_channel = "C1"
+
+        await chat_runner._deliver_auth_error_to_slack(
+            state, slot, state.sessions, "dashboard:x", "signed out"
+        )
+
+
+class TestCrossSurfaceReply:
+    @pytest.mark.asyncio
+    async def test_empty_text_is_not_mirrored(self, tmp_path):
+        state = _state(tmp_path)
+
+        with patch.object(chat_runner, "_resolve_mirror_target") as resolve:
+            await chat_runner._deliver_cross_surface_reply(state, "dashboard:x", "")
+
+        resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reply_is_chunked_per_transport_limit(self, tmp_path):
+        state = _state(tmp_path)
+        transport = AsyncMock()
+        transport.capabilities.max_message_chars = 10
+        link = MagicMock(channel_id="123", thread_id=None, channel_type="telegram")
+
+        with patch.object(chat_runner, "_resolve_mirror_target", return_value=(link, transport)):
+            await chat_runner._deliver_cross_surface_reply(state, "dashboard:x", "ab " * 20)
+
+        assert transport.send_message.await_count > 1
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_never_disrupts_the_turn(self, tmp_path):
+        state = _state(tmp_path)
+        transport = AsyncMock()
+        transport.capabilities.max_message_chars = 4096
+        transport.send_message.side_effect = RuntimeError("offline")
+        link = MagicMock(channel_id="123", thread_id=None, channel_type="telegram")
+
+        with patch.object(chat_runner, "_resolve_mirror_target", return_value=(link, transport)):
+            await chat_runner._deliver_cross_surface_reply(state, "dashboard:x", "hello")
+
+
+class TestPrepareMirrorMsg:
+    def test_truncates_then_redacts(self):
+        out = chat_runner._prepare_mirror_msg("x" * 900)
+
+        assert len(out) <= 500
+
+    def test_none_becomes_empty(self):
+        assert chat_runner._prepare_mirror_msg("") == ""
+
+
+# ── segment flush / widget registration ───────────────────────────────────
+
+
+class TestFlushSegment:
+    def test_pending_variants_are_attached_and_broadcast(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot._pending_variants = [{"content": "older draft", "ts": "1"}, "not-a-dict"]
+
+        chat_runner._flush_segment(state, slot, "newest draft")
+
+        last = slot.messages[-1]
+        assert last["variant_idx"] == 1
+        assert [v["content"] for v in last["variants"]] == ["older draft", "newest draft"]
+        assert slot._pending_variants == []
+        assert any(
+            call.args[0] == "chat_variant_switch" for call in state.broadcast_ws.call_args_list
+        )
+
+    def test_credentials_in_the_segment_are_redacted(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        chat_runner._flush_segment(state, slot, "secret AKIAIOSFODNN7EXAMPLE here")
+
+        assert "AKIAIOSFODNN7EXAMPLE" not in slot.messages[-1]["content"]
+
+    def test_trailing_stop_event_is_replaced_below_the_segment(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot.append("chunk", "partial", "chunk", broadcast=False)
+        slot.append("stop", "", json.dumps({"kind": "stop_event"}), broadcast=False)
+
+        chat_runner._flush_segment(state, slot, "final text")
+
+        assert [m.get("role") for m in slot.messages] == ["assistant", "stop"]
+
+    def test_unparseable_cls_is_not_a_stop_event(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot.append("chunk", "partial", "not json", broadcast=False)
+
+        chat_runner._flush_segment(state, slot, "final text")
+
+        assert [m.get("role") for m in slot.messages] == ["assistant"]
+
+
+class TestScheduleWidgetRegistration:
+    def test_empty_text_registers_nothing(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        with patch.object(chat_runner.asyncio, "create_task") as create:
+            chat_runner._schedule_widget_registration(state, slot, "", "1")
+
+        create.assert_not_called()
+
+    def test_restricted_session_never_registers(self, tmp_path):
+        """Incognito slots are denied artifact writes at the HTTP gate too."""
+        state, slot = _state(tmp_path), _slot()
+        slot.memory_mode = "temporary"
+        assert slot.is_restricted is True
+
+        with patch.object(chat_runner.asyncio, "create_task") as create:
+            chat_runner._schedule_widget_registration(state, slot, "<mcwidget>x</mcwidget>", "1")
+
+        create.assert_not_called()
+
+    def test_no_running_loop_skips_registration(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        with patch.object(chat_runner.asyncio, "create_task") as create:
+            chat_runner._schedule_widget_registration(state, slot, "<mcwidget>x</mcwidget>", "1")
+
+        create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_widget_and_image_each_schedule_one_task(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        with patch.object(
+            chat_runner, "register_widgets_off_loop", new=AsyncMock()
+        ) as widgets, patch.object(
+            chat_runner, "register_images_off_loop", new=AsyncMock()
+        ) as images:
+            chat_runner._schedule_widget_registration(
+                state, slot, "<mcwidget>x</mcwidget> ![a](/tmp/a.png)", "1"
+            )
+            await asyncio.sleep(0)
+
+            assert widgets.await_count == 1
+            assert images.await_count == 1
+
+
+# ── prompt / skill expansion ──────────────────────────────────────────────
+
+
+class TestExpandPromptMention:
+    def test_message_without_a_mention_is_untouched(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        assert chat_runner._expand_prompt_mention("plain text", state, slot) == (
+            "plain text",
+            "not_found",
+        )
+
+    def test_lookup_failure_is_reported_as_not_found(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        with patch.object(chat_runner, "_find_prompt", side_effect=RuntimeError("io")):
+            assert chat_runner._expand_prompt_mention("@sop", state, slot) == ("@sop", "not_found")
+
+    def test_sensitive_path_is_blocked(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        with patch.object(
+            chat_runner, "_find_prompt", return_value={"path": "/home/u/.aws/credentials"}
+        ), patch.object(chat_runner, "is_sensitive_path", return_value=True):
+            assert chat_runner._expand_prompt_mention("@sop", state, slot) == ("@sop", "blocked")
+
+    def test_oversized_prompt_is_refused(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        big = tmp_path / "big.md"
+        big.write_text("y" * (chat_runner.MAX_PROMPT_BYTES + 1), newline="\n")
+
+        with patch.object(
+            chat_runner, "_find_prompt", return_value={"path": str(big), "fullName": "big"}
+        ), patch.object(chat_runner, "is_sensitive_path", return_value=False):
+            assert chat_runner._expand_prompt_mention("@big", state, slot) == ("@big", "too_large")
+
+    def test_unreadable_prompt_is_not_found(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        missing = tmp_path / "gone.md"
+
+        with patch.object(
+            chat_runner, "_find_prompt", return_value={"path": str(missing), "fullName": "gone"}
+        ), patch.object(chat_runner, "is_sensitive_path", return_value=False):
+            assert chat_runner._expand_prompt_mention("@gone", state, slot) == (
+                "@gone",
+                "not_found",
+            )
+
+    def test_resolved_prompt_carries_user_text_and_a_chip(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        sop = tmp_path / "sop.md"
+        sop.write_text("Do the thing\n", newline="\n")
+
+        with patch.object(
+            chat_runner, "_find_prompt", return_value={"path": str(sop), "fullName": "sop"}
+        ), patch.object(chat_runner, "is_sensitive_path", return_value=False):
+            expanded, status = chat_runner._expand_prompt_mention("@sop extra ask", state, slot)
+
+        assert status == "ok"
+        assert "Do the thing" in expanded
+        assert "extra ask" in expanded
+        assert slot.messages[-1]["role"] == "system"
+
+
+class TestExpandDollarSkills:
+    def test_no_dollar_token_is_untouched(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        assert chat_runner._expand_dollar_skills("plain", state, slot, "dashboard:x") == (
+            "plain",
+            0,
+        )
+
+    def test_resolution_failure_is_audited_and_swallowed(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        skills = MagicMock()
+        skills.resolve_dollar_skills.side_effect = RuntimeError("bad glob")
+
+        with patch.object(chat_runner, "_get_skills", return_value=skills), _quiet_sel() as sel:
+            out = chat_runner._expand_dollar_skills("$broken", state, slot, "dashboard:x")
+
+        assert out == ("$broken", 0)
+        assert sel.return_value.log_tool_invocation.call_args.kwargs["outcome"] == "error"
+
+    def test_unknown_candidate_is_audited_as_not_found(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        skills = MagicMock()
+        skills.resolve_dollar_skills.return_value = []
+        skills.has_dollar_candidate.return_value = True
+
+        with patch.object(chat_runner, "_get_skills", return_value=skills), _quiet_sel() as sel:
+            out = chat_runner._expand_dollar_skills("$nope", state, slot, "dashboard:x")
+
+        assert out == ("$nope", 0)
+        assert sel.return_value.log_tool_invocation.call_args.kwargs["outcome"] == "not_found"
+
+    def test_resolved_skill_body_is_appended_and_redacted(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        skills = MagicMock()
+        skills.resolve_dollar_skills.return_value = [
+            ("$deploy", "deploy", "step one AKIAIOSFODNN7EXAMPLE")
+        ]
+
+        with patch.object(chat_runner, "_get_skills", return_value=skills):
+            expanded, count = chat_runner._expand_dollar_skills(
+                "run $deploy", state, slot, "dashboard:x"
+            )
+
+        assert count == 1
+        assert "[Skill: deploy]" in expanded
+        assert "AKIAIOSFODNN7EXAMPLE" not in expanded
+        assert slot.messages[-1]["role"] == "system"
+
+
+# ── requeue suppression / pending reset ───────────────────────────────────
+
+
+class TestRequeueSuppression:
+    @pytest.mark.parametrize(
+        "stop_state,expected", [("idle", False), ("soft_pending", True), ("killing", True)]
+    )
+    def test_stop_in_progress_suppresses_requeue(self, stop_state, expected):
+        slot = _slot()
+        slot._stop_state = stop_state
+
+        assert chat_runner._should_suppress_requeue(slot) is expected
+
+
+class TestConsumePendingReset:
+    @pytest.mark.asyncio
+    async def test_no_pending_key_is_a_noop(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        await chat_runner._consume_pending_reset(state, slot)
+
+        state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_successful_reset_clears_the_flag(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot._pending_reset_history_key = "dashboard:chat-cov-1"
+
+        await chat_runner._consume_pending_reset(state, slot)
+
+        state.sessions.reset.assert_awaited_once_with("dashboard:chat-cov-1")
+        assert slot._pending_reset_history_key is None
+
+    @pytest.mark.asyncio
+    async def test_a_key_queued_during_the_await_is_not_clobbered(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot._pending_reset_history_key = "old-key"
+
+        async def _reset(_key):
+            slot._pending_reset_history_key = "newer-key"
+
+        state.sessions.reset = AsyncMock(side_effect=_reset)
+
+        await chat_runner._consume_pending_reset(state, slot)
+
+        assert slot._pending_reset_history_key == "newer-key"
+
+    @pytest.mark.asyncio
+    async def test_reset_failure_leaves_the_flag_armed(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot._pending_reset_history_key = "old-key"
+        state.sessions.reset = AsyncMock(side_effect=RuntimeError("no session"))
+
+        await chat_runner._consume_pending_reset(state, slot)
+
+        assert slot._pending_reset_history_key == "old-key"
+
+
+# ── eager spawn / resume prefetch ─────────────────────────────────────────
+
+
+class TestScheduleEagerSpawn:
+    def test_disabled_config_returns_no_task(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        cfg = MagicMock()
+        cfg.session.eager_spawn = False
+
+        with patch.object(chat_runner.KiroCrewConfig, "load", return_value=cfg):
+            assert chat_runner.schedule_eager_spawn(state, slot) is None
+
+    def test_config_load_failure_returns_no_task(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        with patch.object(
+            chat_runner.KiroCrewConfig, "load", side_effect=RuntimeError("bad toml")
+        ):
+            assert chat_runner.schedule_eager_spawn(state, slot) is None
+
+    @pytest.mark.asyncio
+    async def test_a_newer_signal_cancels_the_pending_task(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        cfg = MagicMock()
+        cfg.session.eager_spawn = True
+
+        with patch.object(chat_runner.KiroCrewConfig, "load", return_value=cfg), patch.object(
+            chat_runner, "_eager_spawn", new=AsyncMock()
+        ):
+            first = chat_runner.schedule_eager_spawn(state, slot)
+            second = chat_runner.schedule_eager_spawn(state, slot)
+            await asyncio.sleep(0)
+
+        assert first is not None and second is not None
+        assert first.cancelled() or first.done()
+        second.cancel()
+
+
+class TestCapArmedPrefetches:
+    @pytest.mark.asyncio
+    async def test_eviction_failure_still_drops_the_registry_entry(self, tmp_path):
+        state = _state(tmp_path)
+        state.sessions.remove_if_unclaimed = AsyncMock(side_effect=RuntimeError("shutdown hung"))
+        chat_runner._armed_prefetches.clear()
+        try:
+            for i in range(chat_runner._RESUME_PREFETCH_MAX_LIVE + 1):
+                await chat_runner._cap_armed_prefetches(state.sessions, f"key-{i}")
+
+            assert len(chat_runner._armed_prefetches) == chat_runner._RESUME_PREFETCH_MAX_LIVE
+            assert "key-0" not in chat_runner._armed_prefetches
+        finally:
+            chat_runner._armed_prefetches.clear()
+
+    @pytest.mark.asyncio
+    async def test_rearming_moves_a_key_to_newest(self, tmp_path):
+        state = _state(tmp_path)
+        state.sessions.remove_if_unclaimed = AsyncMock(return_value=True)
+        chat_runner._armed_prefetches.clear()
+        try:
+            for i in range(chat_runner._RESUME_PREFETCH_MAX_LIVE):
+                await chat_runner._cap_armed_prefetches(state.sessions, f"key-{i}")
+            await chat_runner._cap_armed_prefetches(state.sessions, "key-0")
+            await chat_runner._cap_armed_prefetches(state.sessions, "newest")
+
+            assert "key-0" in chat_runner._armed_prefetches
+            assert "key-1" not in chat_runner._armed_prefetches
+        finally:
+            chat_runner._armed_prefetches.clear()
+
+
+class TestPrefetchTtl:
+    @pytest.mark.asyncio
+    async def test_replaced_slot_owner_keeps_the_session(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        state.get_slot = MagicMock(return_value=_slot("other"))
+
+        with patch.object(chat_runner.asyncio, "sleep", new=AsyncMock()):
+            await chat_runner._prefetch_ttl(state, slot, "dashboard:chat-cov-1")
+
+        state.sessions.remove_if_unclaimed.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_running_turn_claims_the_session(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        state.get_slot = MagicMock(return_value=slot)
+        slot.task = MagicMock(done=MagicMock(return_value=False))
+
+        with patch.object(chat_runner.asyncio, "sleep", new=AsyncMock()):
+            await chat_runner._prefetch_ttl(state, slot, "dashboard:chat-cov-1")
+
+        state.sessions.remove_if_unclaimed.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_deleted_slot_still_tears_down_a_linked_session(self, tmp_path):
+        """A channel-born slot's prefetch key is not the slot-derived one."""
+        state, slot = _state(tmp_path), _slot()
+        state.get_slot = MagicMock(return_value=None)
+        state.sessions.remove_if_unclaimed = AsyncMock(return_value=True)
+
+        with patch.object(chat_runner.asyncio, "sleep", new=AsyncMock()):
+            await chat_runner._prefetch_ttl(state, slot, "telegram:123")
+
+        state.sessions.remove_if_unclaimed.assert_awaited_once_with("telegram:123")
+
+    @pytest.mark.asyncio
+    async def test_cancellation_propagates(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        with patch.object(
+            chat_runner.asyncio, "sleep", new=AsyncMock(side_effect=asyncio.CancelledError)
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await chat_runner._prefetch_ttl(state, slot, "dashboard:chat-cov-1")
+
+    @pytest.mark.asyncio
+    async def test_unexpected_failure_is_logged_not_raised(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        state.get_slot = MagicMock(side_effect=RuntimeError("map gone"))
+
+        with patch.object(chat_runner.asyncio, "sleep", new=AsyncMock()):
+            await chat_runner._prefetch_ttl(state, slot, "dashboard:chat-cov-1")
+
+    @pytest.mark.asyncio
+    async def test_scheduling_cancels_the_previous_timer(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        with patch.object(chat_runner, "_prefetch_ttl", new=AsyncMock()):
+            chat_runner._schedule_prefetch_ttl(state, slot, "k1")
+            first = slot._prefetch_ttl_task
+            chat_runner._schedule_prefetch_ttl(state, slot, "k2")
+            second = slot._prefetch_ttl_task
+            await asyncio.sleep(0)
+
+        assert first is not second
+        assert first.cancelled() or first.done()
+        second.cancel()
+
+
+# ── steer settle / requeue ────────────────────────────────────────────────
+
+
+class TestSteerLifecycle:
+    def test_settle_is_a_noop_without_pending_steers(self):
+        slot = _slot()
+
+        chat_runner._settle_consumed_steers(slot, "anything")
+
+        assert slot._pending_steers == []
+
+    def test_settle_delegates_to_the_shared_rules(self):
+        slot = _slot()
+        slot._pending_steers = ["a", "b"]
+
+        with patch.object(chat_runner, "settle_consumed_steers", return_value=["b"]) as settle:
+            chat_runner._settle_consumed_steers(slot, "a")
+
+        assert slot._pending_steers == ["b"]
+        assert settle.call_args.kwargs["settle_all_on_empty"] is True
+
+    def test_requeue_is_a_noop_without_pending_steers(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        chat_runner._requeue_unconsumed_steers(state, slot)
+
+        assert slot._queue == []
+
+    def test_unconsumed_steers_requeue_at_the_head_in_order(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot.queue_append("already queued")
+        slot._pending_steers = ["first steer", "second steer"]
+
+        chat_runner._requeue_unconsumed_steers(state, slot)
+
+        assert [entry["content"] for entry in slot._queue] == [
+            "first steer",
+            "second steer",
+            "already queued",
+        ]
+        assert slot._pending_steers == []
+
+    def test_broadcast_failure_still_leaves_the_steer_queued(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot._pending_steers = ["steer me"]
+        state.broadcast_ws = MagicMock(side_effect=RuntimeError("ws closed"))
+
+        chat_runner._requeue_unconsumed_steers(state, slot)
+
+        assert [entry["content"] for entry in slot._queue] == ["steer me"]
+
+
+# ── queue drain / synthesis ───────────────────────────────────────────────
+
+
+class TestStartNextQueuedTurn:
+    @pytest.mark.asyncio
+    async def test_empty_queue_starts_nothing(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        assert await chat_runner._start_next_queued_turn(state, slot) is False
+
+    @pytest.mark.asyncio
+    async def test_config_failure_falls_back_to_sequential_dequeue(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot.queue_append("one")
+        slot.queue_append("two")
+        state.subagents = None
+
+        with patch.object(
+            chat_runner.KiroCrewConfig, "load", side_effect=RuntimeError("bad toml")
+        ), patch.object(chat_runner, "spawn_guarded_turn", return_value=MagicMock()) as spawn, patch.object(
+            chat_runner, "_run_chat", return_value=MagicMock()
+        ):
+            assert await chat_runner._start_next_queued_turn(state, slot) is True
+
+        assert spawn.call_count == 1
+        assert len(slot._queue) == 1
+
+    @pytest.mark.asyncio
+    async def test_running_subagents_hold_user_messages_back(self, tmp_path):
+        """With a fan-out in flight only a system injection may drain."""
+        state, slot = _state(tmp_path), _slot()
+        slot.queue_append("a user message")
+        state.subagents = MagicMock(running_agents_for=MagicMock(return_value=["agent-1"]))
+
+        assert await chat_runner._start_next_queued_turn(state, slot) is False
+        assert len(slot._queue) == 1
+
+    @pytest.mark.asyncio
+    async def test_reset_notice_is_emitted_for_a_stopping_slot(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot.queue_append("next please")
+        slot._stopping = True
+        state.subagents = None
+
+        with patch.object(
+            chat_runner, "spawn_guarded_turn", return_value=MagicMock()
+        ), patch.object(chat_runner, "_run_chat", return_value=MagicMock()):
+            assert await chat_runner._start_next_queued_turn(state, slot) is True
+
+        assert any("Session reset" in err for err in _errors(slot))
+        assert slot._stopping is False
+
+
+class TestRunPendingSynthesis:
+    @pytest.mark.asyncio
+    async def test_unarmed_synthesis_just_finishes_the_cycle(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot._pending_synthesis = False
+        slot._synthesis_inflight = True
+
+        with patch.object(chat_runner, "_finish_queue_cycle") as finish:
+            await chat_runner._run_pending_synthesis(state, slot)
+
+        finish.assert_called_once()
+        assert slot._synthesis_inflight is False
+
+    @pytest.mark.asyncio
+    async def test_a_queued_message_takes_priority_over_synthesis(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot._pending_synthesis = True
+        slot.queue_append("queued work")
+
+        with patch.object(
+            chat_runner, "_start_next_queued_turn", new=AsyncMock(return_value=True)
+        ) as start:
+            await chat_runner._run_pending_synthesis(state, slot)
+
+        start.assert_awaited_once()
+        assert slot._pending_synthesis is True
+
+    @pytest.mark.asyncio
+    async def test_running_agents_defer_synthesis(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot._pending_synthesis = True
+        state.subagents = MagicMock(running_agents_for=MagicMock(return_value=["a"]))
+
+        with patch.object(chat_runner, "_finish_queue_cycle") as finish:
+            await chat_runner._run_pending_synthesis(state, slot)
+
+        finish.assert_called_once()
+        assert slot._pending_synthesis is True
+
+    @pytest.mark.asyncio
+    async def test_synthesis_timeout_is_swallowed(self, tmp_path):
+        """The ceiling already rendered a card; re-raising would go unretrieved."""
+        state, slot = _state(tmp_path), _slot()
+        slot._pending_synthesis = True
+        state.subagents = MagicMock(running_agents_for=MagicMock(return_value=[]))
+
+        async def _boom():
+            raise asyncio.TimeoutError
+
+        with patch.object(
+            chat_runner, "spawn_guarded_turn", return_value=asyncio.ensure_future(_boom())
+        ), patch.object(chat_runner, "_run_chat", return_value=MagicMock()):
+            await chat_runner._run_pending_synthesis(state, slot)
+
+        assert slot._pending_synthesis is False
+        assert slot._synthesis_inflight is False
+
+
+class TestFinishQueueCycle:
+    @pytest.mark.asyncio
+    async def test_eligible_synthesis_is_started_instead_of_going_idle(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        slot._pending_synthesis = True
+        state.subagents = MagicMock(running_agents_for=MagicMock(return_value=[]))
+
+        with patch.object(chat_runner, "_run_pending_synthesis", new=AsyncMock()):
+            chat_runner._finish_queue_cycle(state, slot)
+            await asyncio.sleep(0)
+
+        assert slot._synthesis_inflight is True
+        assert not any(m.get("role") == "done" for m in slot.messages)
+        if slot.task is not None:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_idle_cycle_emits_done_and_refreshes_the_sidebar(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        with patch.object(chat_runner, "maybe_refresh_title", new=AsyncMock()):
+            chat_runner._finish_queue_cycle(state, slot)
+            await asyncio.sleep(0)
+
+        assert slot.messages[-1]["role"] == "done"
+        assert slot.task is None
+        state.refresh_slot_source_status.assert_called_once_with(slot.key)
+        state.broadcast_ws.assert_any_call("chat_done", {"slot": slot.key})
+
+
+class TestTtftMetric:
+    def test_emission_failure_is_swallowed(self):
+        with patch("kiro_crew.metrics.provider.get_recorder", side_effect=RuntimeError("down")):
+            chat_runner._emit_ttft_metric(0.0, "dashboard:x", is_new=True, resumed=False)
+
+    def test_attributes_split_cold_and_resumed_populations(self):
+        recorder = MagicMock()
+        with patch("kiro_crew.metrics.provider.get_recorder", return_value=recorder):
+            chat_runner._emit_ttft_metric(0.0, "dashboard:x", is_new=True, resumed=True)
+
+        attrs = recorder.histogram.call_args.kwargs["attrs"]
+        assert attrs["first_turn"] is True
+        assert attrs["resumed"] is True
+
+
+# ── native subagent cards ─────────────────────────────────────────────────
+
+
+class TestNativeSubagentCards:
+    def test_non_list_payload_is_ignored(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        tracker: dict = {}
+
+        chat_runner._native_subagent_sync(state, slot, "not-a-list", tracker)
+
+        assert tracker == {}
+
+    def test_entry_without_a_task_is_marked_done_immediately(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        tracker: dict = {}
+
+        chat_runner._native_subagent_sync(
+            state, slot, [{"sessionId": "s1", "role": "worker"}], tracker
+        )
+
+        assert tracker["s1"]["done"] is True
+        assert tracker["s1"]["task"] == ""
+
+    def test_terminal_status_completes_the_card_with_a_redacted_error(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        tracker: dict = {}
+        entry = {"sessionId": "s2", "role": "worker", "initialQuery": "do it"}
+
+        chat_runner._native_subagent_sync(state, slot, [entry], tracker)
+        entry["status"] = {"type": "failed", "message": "boom AKIAIOSFODNN7EXAMPLE"}
+        chat_runner._native_subagent_sync(state, slot, [entry], tracker)
+
+        assert tracker["s2"]["done"] is True
+        assert "AKIAIOSFODNN7EXAMPLE" not in tracker["s2"]["error"]
+
+    def test_status_message_surfaces_as_the_current_tool(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        tracker: dict = {}
+        entry = {"sessionId": "s3", "initialQuery": "do it"}
+
+        chat_runner._native_subagent_sync(state, slot, [entry], tracker)
+        entry["status"] = {"type": "working", "message": "reading files"}
+        chat_runner._native_subagent_sync(state, slot, [entry], tracker)
+
+        assert tracker["s3"]["last_tool"] == "reading files"
+        assert any(call.args[0] == "subagent_tool" for call in state.broadcast_ws.call_args_list)
+
+    def test_unreported_stale_card_is_auto_closed(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        tracker: dict = {
+            "gone": {
+                "id": "native:gone",
+                "started": 0.0,
+                "done": False,
+                "agent": "worker",
+                "task": "stalled work",
+                "last_activity": 0.0,
+            }
+        }
+
+        chat_runner._native_subagent_sync(state, slot, [], tracker)
+
+        assert tracker["gone"]["done"] is True
+        assert tracker["gone"]["error"] == "timed out (no activity)"
+
+    def test_close_all_completes_open_cards_without_an_error(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+        tracker = {"open": {"started": 0.0, "done": False, "task": "t", "agent": "a"}}
+
+        chat_runner._native_subagent_close_all(state, slot, tracker)
+
+        assert tracker["open"]["done"] is True
+        assert tracker["open"]["error"] is None
+
+    def test_card_registry_round_trip(self, tmp_path):
+        state = _state(tmp_path)
+
+        chat_runner._register_native_card(state, "native:x", "chat-1", "sid-1")
+        assert state._native_cards["native:x"]["session_id"] == "sid-1"
+
+        chat_runner._unregister_native_card(state, "native:x")
+        assert "native:x" not in state._native_cards
+
+    def test_unregister_without_a_registry_is_a_noop(self, tmp_path):
+        state = _state(tmp_path)
+        if hasattr(state, "_native_cards"):
+            del state._native_cards
+
+        chat_runner._unregister_native_card(state, "native:x")
+
+    def test_terminal_records_are_bounded_by_keep_and_ttl(self):
+        now = 1000.0
+        tracker = {
+            "fresh": {"id": "native:fresh", "done": True, "done_at": now - 1},
+            "older": {"id": "native:older", "done": True, "done_at": now - 2},
+            "expired": {"id": "native:expired", "done": True, "done_at": now - 10_000},
+            "running": {"id": "native:running", "done": False, "done_at": now},
+            "unidentified": {"done": True, "done_at": now},
+        }
+
+        kept = chat_runner._retain_terminal_native(tracker, keep=1, ttl_secs=100.0, now=now)
+
+        assert list(kept) == ["fresh"]
+
+    def test_native_output_collapses_to_the_newest_tail(self):
+        buf: list[str] = []
+        total = chat_runner._append_native_output(buf, "a" * 50, 0, cap=10, hard=20)
+
+        assert total == 10
+        assert buf == ["a" * 10]
+
+    def test_done_result_marks_a_truncated_feed(self):
+        out = chat_runner._native_done_result(["z" * (chat_runner.NATIVE_SUBAGENT_DONE_RESULT_CAP + 5)])
+
+        assert out.startswith(chat_runner.NATIVE_SUBAGENT_DONE_TRUNC_MARKER)
+
+    def test_card_feed_redacts_before_the_broadcast(self):
+        feed = chat_runner._native_card_feed({"native:x": ["AKIAIOSFODNN7EXAMPLE"]}, "native:x")
+
+        assert "AKIAIOSFODNN7EXAMPLE" not in feed
+
+    def test_empty_card_feed_is_empty(self):
+        assert chat_runner._native_card_feed(None, "native:x") == ""
+
+
+# ── command parsing helpers ───────────────────────────────────────────────
+
+
+class TestCommandParsing:
+    def test_quoted_separators_are_masked_and_restored(self):
+        masked, restore = chat_runner._mask_quoted_separators('grep "a|b" f && wc -l')
+
+        assert "|" not in masked.split("&&")[0].replace("&&", "")
+        assert list(restore.values()) == ["|"]
+
+    def test_command_substitution_is_denied_by_default(self):
+        assert chat_runner._matches_trusted_pattern("Running: echo $(whoami)", {"echo*"}) is None
+
+    def test_every_segment_must_match_for_a_chained_command(self):
+        assert chat_runner._matches_trusted_pattern("Running: ls | rm -rf x", {"ls*"}) is None
+
+    def test_all_matching_segments_return_joined_patterns(self):
+        matched = chat_runner._matches_trusted_pattern("Running: ls | wc -l", {"ls*", "wc*"})
+
+        assert matched is not None
+        assert matched.count(",") == 1
+
+    def test_redirect_forms_are_not_treated_as_separators(self):
+        assert chat_runner._matches_trusted_pattern("Running: ls 2>&1", {"ls*"}) is not None
+
+    def test_base_command_extraction_dedups_across_segments(self):
+        assert chat_runner._extract_base_command("Running: cat a | wc -l | cat b") == "cat,wc"
+
+    def test_full_command_strips_the_display_prefix(self):
+        assert chat_runner._extract_full_command("Running: ls -la") == "ls -la"
+
+
+# ── model backfill / pin guards ───────────────────────────────────────────
+
+
+class TestModelBackfill:
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            ("global.anthropic.claude-opus-4-8[1m]", True),
+            ("us.anthropic.claude-sonnet-4-6", True),
+            ("claude-opus-4.7", False),
+            ("deepseek-3.2", False),
+        ],
+    )
+    def test_bedrock_profile_detection(self, model, expected):
+        assert chat_runner._is_bedrock_profile_id(model) is expected
+
+    def test_missing_provider_model_backfills_nothing(self):
+        client = MagicMock()
+        client.client._model = ""
+
+        assert chat_runner._backfill_canonical_model(client, "kiro") == ""
+
+    def test_auto_sentinel_is_skipped(self):
+        client = MagicMock()
+        client.client._model = "auto"
+
+        assert chat_runner._backfill_canonical_model(client, "kiro") == ""
+
+    def test_profile_id_is_dropped_off_the_claude_code_path(self):
+        """Caching a resolved profile id would pin the slot to one region."""
+        client = MagicMock()
+        client.client._model = "global.anthropic.claude-opus-4-8[1m]"
+
+        assert chat_runner._backfill_canonical_model(client, "kiro") == ""
+
+    def test_portable_alias_is_kept(self):
+        client = MagicMock()
+        client.client._model = "deepseek-3.2"
+
+        with patch.object(
+            chat_runner.model_registry, "canonicalize_for_provider", return_value="deepseek-3.2"
+        ):
+            assert chat_runner._backfill_canonical_model(client, "kiro") == "deepseek-3.2"
+
+
+class TestPinnedModelWithheld:
+    @pytest.mark.parametrize("model,provider", [("", "kiro"), ("auto", "kiro"), ("x", "claude_code")])
+    def test_unpinnable_combinations_are_never_withheld(self, model, provider):
+        assert chat_runner._pinned_model_withheld(MagicMock(), model, provider) is False
+
+    def test_claude_backend_is_exempt(self):
+        client = MagicMock()
+        client.is_claude_backend = True
+
+        assert chat_runner._pinned_model_withheld(client, "claude-opus-5", "kiro") is False
+
+    def test_provider_without_an_advertiser_leaves_the_pin_alone(self):
+        client = MagicMock()
+        client.is_claude_backend = False
+        client.available_models = "not-callable"
+
+        assert chat_runner._pinned_model_withheld(client, "claude-opus-5", "kiro") is False
+
+    def test_advertiser_failure_fails_open(self):
+        client = MagicMock()
+        client.is_claude_backend = False
+        client.available_models = MagicMock(side_effect=RuntimeError("no session"))
+
+        assert chat_runner._pinned_model_withheld(client, "claude-opus-5", "kiro") is False
+
+    def test_unadvertised_pin_is_reported_as_withheld(self):
+        client = MagicMock()
+        client.is_claude_backend = False
+        client.available_models = MagicMock(return_value=[{"modelId": "claude-sonnet-4.6"}])
+
+        with patch.object(chat_runner, "advertised_model_ids", return_value={"claude-sonnet-4.6"}):
+            assert chat_runner._pinned_model_withheld(client, "claude-opus-5", "kiro") is True
+
+
+class TestContextUsagePayload:
+    def test_missing_counts_emit_a_reset_frame(self):
+        """A bare {slot, pct} frame would strand stale token counts on the ring."""
+        client = MagicMock()
+        client.context_usage_pct = MagicMock(return_value=44.44)
+        client.context_window_tokens = MagicMock(return_value=0)
+
+        payload = chat_runner._context_usage_payload("chat-1", client)
+
+        assert payload == {"slot": "chat-1", "pct": 44.4, "reset": True}
+
+    def test_real_counts_ship_the_pair(self):
+        client = MagicMock()
+        client.context_usage_pct = MagicMock(return_value=10.0)
+        client.context_window_tokens = MagicMock(return_value=200_000)
+        client.context_used_tokens = MagicMock(return_value=20_000)
+
+        payload = chat_runner._context_usage_payload("chat-1", client)
+
+        assert payload["used_tokens"] == 20_000
+        assert payload["window_tokens"] == 200_000
+        assert "reset" not in payload
+
+    def test_zero_used_still_emits_a_reset_frame(self):
+        client = MagicMock()
+        client.context_usage_pct = MagicMock(return_value=0.0)
+        client.context_window_tokens = MagicMock(return_value=200_000)
+        client.context_used_tokens = MagicMock(return_value=0)
+
+        assert chat_runner._context_usage_payload("chat-1", client)["reset"] is True
+
+
+# ── _run_chat: local commands ─────────────────────────────────────────────
+
+
+class TestRunChatLocalCommands:
+    @pytest.mark.asyncio
+    async def test_blocked_slash_command_never_acquires_a_session(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        blocked = sorted(chat_runner._BLOCKED_SLASH_COMMANDS)[0]
+
+        await _drive(state, slot, blocked)
+
+        state.sessions.get_or_create.assert_not_awaited()
+        assert any("not available in the dashboard" in m.get("content", "") for m in slot.messages)
+        assert slot.messages[-1]["role"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_goal_command_is_handled_locally(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+
+        with patch.object(chat_runner, "_handle_goal_command", new=AsyncMock()) as handler:
+            await _drive(state, slot, "/goal ship the thing")
+
+        handler.assert_awaited_once()
+        state.sessions.get_or_create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_prompts_get_blocked_path_reports_a_sensitive_path(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+
+        with patch.object(
+            chat_runner, "_expand_prompt_mention", return_value=("@secret", "blocked")
+        ):
+            await _drive(state, slot, "/prompts get secret")
+
+        assert any("sensitive path" in m.get("content", "") for m in slot.messages)
+        state.sessions.get_or_create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_prompts_get_too_large_path_reports_the_limit(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+
+        with patch.object(
+            chat_runner, "_expand_prompt_mention", return_value=("@big", "too_large")
+        ):
+            await _drive(state, slot, "/prompts get big")
+
+        assert any("exceeds size limit" in m.get("content", "") for m in slot.messages)
+
+    @pytest.mark.asyncio
+    async def test_prompts_get_missing_prompt_reports_not_found(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+
+        with patch.object(
+            chat_runner, "_expand_prompt_mention", return_value=("@nope", "not_found")
+        ):
+            await _drive(state, slot, "/prompts get nope")
+
+        assert any("not found" in m.get("content", "") for m in slot.messages)
+
+    @pytest.mark.asyncio
+    async def test_prompts_listing_with_none_available(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+
+        with patch.object(chat_runner, "_list_aim_prompts", return_value=[]):
+            await _drive(state, slot, "/prompts")
+
+        assert any("No prompts found" in m.get("content", "") for m in slot.messages)
+
+    @pytest.mark.asyncio
+    async def test_prompts_listing_groups_by_source(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        prompts = [
+            {"fullName": "a", "description": "first", "source": "aim"},
+            {"fullName": "b", "description": "", "source": "team"},
+        ]
+
+        with patch.object(chat_runner, "_list_aim_prompts", return_value=prompts):
+            await _drive(state, slot, "/prompts list")
+
+        body = "\n".join(m.get("content", "") for m in slot.messages)
+        assert "User Prompts (team)" in body
+        assert "`@a` — first" in body
+
+    @pytest.mark.asyncio
+    async def test_prompts_listing_survives_a_walk_failure(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+
+        with patch.object(chat_runner, "_list_aim_prompts", side_effect=OSError("bad root")):
+            await _drive(state, slot, "/prompts")
+
+        assert any("No prompts found" in m.get("content", "") for m in slot.messages)
+
+
+# ── _run_chat: recovery ladders ───────────────────────────────────────────
+
+
+class TestRunChatRecoveryLadders:
+    @pytest.mark.asyncio
+    async def test_stale_recover_requeues_a_continuation(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        _set_stream(client, [_complete(STOP_REASON_STALE_RECOVER)])
+
+        with patch.object(chat_runner, "_start_next_queued_turn", new=AsyncMock(return_value=True)):
+            await _drive(state, slot)
+
+        assert slot._stale_recovery_retries == 1
+        assert any("Recovering a stalled turn" in err for err in _errors(slot))
+
+    @pytest.mark.asyncio
+    async def test_stale_recover_budget_exhaustion_asks_for_a_new_chat(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot._stale_recovery_retries = 3
+        _set_stream(client, [_complete(STOP_REASON_STALE_RECOVER)])
+
+        await _drive(state, slot)
+
+        assert any("start a new chat" in err for err in _errors(slot))
+
+    @pytest.mark.asyncio
+    async def test_nested_stale_recover_surfaces_a_retry_notice(self, tmp_path):
+        """depth>0 resets the session but must not re-queue — it still reports."""
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        _set_stream(client, [_complete(STOP_REASON_STALE_RECOVER)])
+
+        with _quiet_sel():
+            await chat_runner._run_chat(state, slot, "hello", _prompt_depth=1)
+        await _settle(slot)
+
+        assert any("please retry" in err for err in _errors(slot))
+        assert slot._queue == []
+
+    @pytest.mark.asyncio
+    async def test_tool_stall_recovery_names_the_stalled_tool(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        _set_stream(
+            client,
+            [
+                _complete(
+                    STOP_REASON_TOOL_STALL,
+                    title="Running: tail -f app.log",
+                    tool_input="tail -f app.log",
+                    text="idle_secs=900 stuck_input",
+                )
+            ],
+        )
+
+        with patch.object(chat_runner, "_start_next_queued_turn", new=AsyncMock(return_value=True)):
+            await _drive(state, slot)
+
+        assert slot._tool_stall_retries == 1
+        assert any("Tool appeared stalled" in err for err in _errors(slot))
+
+    @pytest.mark.asyncio
+    async def test_tool_stall_budget_exhaustion_asks_for_a_new_chat(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot._tool_stall_retries = 3
+        _set_stream(client, [_complete(STOP_REASON_TOOL_STALL, text="idle_secs=60")])
+
+        await _drive(state, slot)
+
+        assert any("start a new chat" in err for err in _errors(slot))
+
+    @pytest.mark.asyncio
+    async def test_nested_tool_stall_surfaces_a_retry_notice(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        _set_stream(client, [_complete(STOP_REASON_TOOL_STALL, text="idle_secs=60")])
+
+        with _quiet_sel():
+            await chat_runner._run_chat(state, slot, "hello", _prompt_depth=1)
+        await _settle(slot)
+
+        assert any("please retry" in err for err in _errors(slot))
+        assert slot._queue == []
+
+    @pytest.mark.asyncio
+    async def test_pipe_death_requeues_and_reports_the_exit_code(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        client.exit_code = 137
+        slot = _slot()
+        _set_stream(client, [_complete("error: pipe closed")])
+
+        with patch.object(chat_runner, "_start_next_queued_turn", new=AsyncMock(return_value=True)):
+            await _drive(state, slot)
+
+        assert slot._acp_pipe_death_retries == 1
+        assert any("exit 137" in err for err in _errors(slot))
+
+    @pytest.mark.asyncio
+    async def test_pipe_death_budget_exhaustion_asks_for_a_new_chat(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot._acp_pipe_death_retries = 3
+        _set_stream(client, [_complete("error: pipe closed")])
+
+        await _drive(state, slot)
+
+        assert any("start a new chat" in err for err in _errors(slot))
+
+    @pytest.mark.asyncio
+    async def test_nested_pipe_death_surfaces_a_retry_notice(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        _set_stream(client, [_complete("error: pipe closed")])
+
+        with _quiet_sel():
+            await chat_runner._run_chat(state, slot, "hello", _prompt_depth=1)
+        await _settle(slot)
+
+        assert any("please retry" in err for err in _errors(slot))
+        assert slot._queue == []
+
+
+# ── _run_chat: auto-approve rungs ─────────────────────────────────────────
+
+
+class TestRunChatAutoApproveRungs:
+    @pytest.mark.asyncio
+    async def test_trusted_pattern_auto_approves_a_matching_command(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot._trusted_patterns = {"ls*"}
+        _set_stream(
+            client,
+            [
+                _permission(tool_input=json.dumps({"command": "ls -la"})),
+                _complete(),
+            ],
+        )
+
+        await _drive(state, slot)
+
+        client.approve_tool.assert_awaited_once_with("req-cov-1")
+        assert any(
+            m.get("role") == "tool" and m.get("content", "").startswith("🔧")
+            for m in slot.messages
+        )
+
+    @pytest.mark.asyncio
+    async def test_trusted_pattern_rejects_an_invalid_tool_name(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot._trusted_patterns = {"ls*"}
+        _set_stream(
+            client,
+            [
+                _permission(tool_input=json.dumps({"command": "ls -la"})),
+                _complete(),
+            ],
+        )
+
+        with patch.object(
+            chat_runner, "_validate_tool_name", side_effect=ValueError("name too long")
+        ):
+            await _drive(state, slot)
+
+        client.reject_tool.assert_awaited_once_with("req-cov-1")
+        assert any("invalid: name too long" in m.get("content", "") for m in slot.messages)
+
+    @pytest.mark.asyncio
+    async def test_unrecognised_tool_input_skips_pattern_matching(self, tmp_path):
+        """Deny-by-default: a non-bash tool_input must not reach fnmatch."""
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot._trusted_patterns = {"*"}
+        slot._trust = True  # falls through to the trust rung instead
+        _set_stream(client, [_permission(tool_input="{}"), _complete()])
+
+        with patch.object(chat_runner, "_matches_trusted_pattern") as matcher:
+            await _drive(state, slot)
+
+        matcher.assert_not_called()
+        client.approve_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_trust_reads_auto_approves_a_read_only_command(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot._trust_reads = True
+        _set_stream(
+            client,
+            [_permission(tool_input=json.dumps({"command": "cat README.md"})), _complete()],
+        )
+
+        await _drive(state, slot)
+
+        client.approve_tool.assert_awaited_once_with("req-cov-1")
+
+    @pytest.mark.asyncio
+    async def test_trust_reads_rejects_an_invalid_tool_name(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot._trust_reads = True
+        _set_stream(
+            client,
+            [_permission(tool_input=json.dumps({"command": "cat README.md"})), _complete()],
+        )
+
+        with patch.object(chat_runner, "_validate_tool_name", side_effect=ValueError("bad name")):
+            await _drive(state, slot)
+
+        client.reject_tool.assert_awaited_once_with("req-cov-1")
+
+
+class TestRunChatApprovalWindow:
+    @pytest.mark.asyncio
+    async def test_no_remaining_budget_declines_without_waiting(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        _set_stream(client, [_permission(), _complete()])
+
+        with patch.object(chat_runner, "tool_approval_timeout_secs", return_value=0.0):
+            await _drive(state, slot)
+
+        client.reject_tool.assert_awaited_once_with("req-cov-1")
+        assert _errors(slot)
+
+    @pytest.mark.asyncio
+    async def test_unanswered_prompt_times_out_and_names_the_cause(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        _set_stream(client, [_permission(), _complete()])
+
+        with patch.object(chat_runner, "tool_approval_timeout_secs", return_value=0.01):
+            await _drive(state, slot)
+
+        client.reject_tool.assert_awaited_once_with("req-cov-1")
+        assert slot._approval_futures == {}
+
+    @pytest.mark.asyncio
+    async def test_unattended_slot_is_told_to_ask_instead_of_retrying(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot._app = "worker-app"
+        slot._human_seen = False
+        assert slot.unattended is True
+        _set_stream(client, [_permission(), _complete()])
+
+        with patch.object(chat_runner, "tool_approval_timeout_secs", return_value=0.01):
+            await _drive(state, slot)
+
+        assert any(
+            "running unattended" in m.get("content", "")
+            for m in slot.messages
+            if m.get("role") == "assistant"
+        )
+
+
+# ── _run_chat: plan gate ──────────────────────────────────────────────────
+
+
+class TestRunChatPlanGate:
+    @pytest.mark.asyncio
+    async def test_valid_plan_arms_the_option_gate(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot.mode = "orchestrator"
+        plan = (
+            "📋 Plan for: ship it\n"
+            "Stage 1: build\n"
+            "Stage 2: verify\n"
+            "[OPTION: Go | Go All | Cancel]"
+        )
+        _set_stream(client, [LLMEvent(kind=EVENT_TEXT_CHUNK, text=plan), _complete()])
+
+        await _drive(state, slot)
+
+        assert slot._stage_titles
+
+    @pytest.mark.asyncio
+    async def test_invalid_plan_is_stripped_when_the_rephrase_fails(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot.mode = "orchestrator"
+        _set_stream(
+            client,
+            [LLMEvent(kind=EVENT_TEXT_CHUNK, text="📋 Plan for: x\nno stages here"), _complete()],
+        )
+
+        with patch.object(chat_runner, "_rephrase_plan_lite", new=AsyncMock(return_value="")):
+            await _drive(state, slot)
+
+        assert not slot._stage_titles
+
+    @pytest.mark.asyncio
+    async def test_plan_like_text_is_reformatted_by_the_rephrase_pass(self, tmp_path):
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot.mode = "orchestrator"
+        good = (
+            "📋 Plan for: ship it\n"
+            "Stage 1: build\n"
+            "Stage 2: verify\n"
+            "[OPTION: Go | Go All | Cancel]"
+        )
+        _set_stream(
+            client,
+            [
+                LLMEvent(kind=EVENT_TEXT_CHUNK, text="Step 1: build\nStep 2: verify\n"),
+                _complete(),
+            ],
+        )
+
+        with patch.object(chat_runner, "looks_like_plan", return_value=True), patch.object(
+            chat_runner, "_rephrase_plan_lite", new=AsyncMock(return_value=good)
+        ):
+            await _drive(state, slot)
+
+        assert slot._stage_titles
+
+    @pytest.mark.asyncio
+    async def test_stage_execution_turn_never_arms_a_plan(self, tmp_path):
+        """A stage turn whose output looks like a plan must not re-arm the gate."""
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot.mode = "orchestrator"
+        slot._in_stage_execution = True
+        plan = (
+            "📋 Plan for: ship it\n"
+            "Stage 1: build\n"
+            "Stage 2: verify\n"
+            "[OPTION: Go | Go All | Cancel]"
+        )
+        _set_stream(client, [LLMEvent(kind=EVENT_TEXT_CHUNK, text=plan), _complete()])
+
+        await _drive(state, slot)
+
+        assert not slot._stage_titles

--- a/test/test_dashboard_handlers_core_coverage.py
+++ b/test/test_dashboard_handlers_core_coverage.py
@@ -1,0 +1,1340 @@
+"""Coverage for ``dashboard/handlers/core.py`` error branches and cold paths.
+
+Targets the parts of the module the rest of the suite never reaches: the STT
+prerequisite/install/transcribe surface, the SEL + security read endpoints,
+the agent-settings PUT validators, the loopback-gated local endpoints
+(token / logout), the app-secret exchange, and the session sub-agent routes.
+
+Style follows ``test_api_health.py`` (direct handler calls against a
+``MagicMock(spec=web.Request)``) and ``test_config_patch.py`` (real aiohttp
+``TestClient`` when the handler needs a genuine request body or streaming
+response). Every write lands under the autouse-isolated ``KIROCREW_HOME``
+from ``conftest.py``; nothing here touches the network or spawns a process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import platform
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.config.loader import (
+    MAX_SUBAGENTS_FIXED_FLOOR,
+    SUBAGENT_AUTO_MAX_CEILING,
+    SUBAGENT_MAX_TURNS_CEILING,
+    config_path,
+)
+from kiro_crew.dashboard.handlers import core as core_mod
+
+# ── shared helpers ───────────────────────────────────────────────────────
+
+
+def _req(
+    *,
+    remote: str = "127.0.0.1",
+    headers: dict | None = None,
+    query: dict | None = None,
+    app: dict | None = None,
+    match_info: dict | None = None,
+    user: str | None = "dashboard",
+) -> web.Request:
+    """A stub request carrying only what these handlers read."""
+    req = MagicMock(spec=web.Request)
+    req.remote = remote
+    req.headers = headers or {}
+    req.query = query or {}
+    req.app = app if app is not None else {}
+    req.match_info = match_info or {}
+    req.get = lambda key, default=None: (user if key == "user" else default)
+    return req
+
+
+@pytest.fixture
+def fake_sel(monkeypatch) -> MagicMock:
+    """Swap the audited SEL seam for a recorder.
+
+    ``core._sel()`` late-binds through the handlers package, so patching the
+    package attribute is what the handler observes.
+    """
+    recorder = MagicMock()
+    monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: recorder)
+    return recorder
+
+
+@pytest.fixture
+def seeded_config() -> Path:
+    """Write a minimal config into the isolated home and return its path."""
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"agent": {"approval_mode": "auto"}}) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return path
+
+
+@pytest.fixture
+def stt_status(monkeypatch):
+    """Restore the module-level install-status global after each test."""
+    saved = dict(core_mod._stt_install_status)
+    yield
+    core_mod._stt_install_status = saved
+
+
+# ── Page + static assets ─────────────────────────────────────────────────
+
+
+class TestPageAndAssets:
+    @pytest.mark.asyncio
+    async def test_index_falls_back_when_bundle_missing(self, monkeypatch, tmp_path) -> None:
+        """A stale/unbuilt install serves the static guidance page, not a 500."""
+        monkeypatch.setattr(core_mod, "_DIST_INDEX", tmp_path / "nope" / "index.html")
+        resp = await core_mod.index(_req())
+        assert resp.status == 200
+        assert core_mod.DASHBOARD_HTML_NOT_FOUND_MARKER in resp.text
+        # SECURITY CONTRACT: the cold-start body is served unauthenticated, so
+        # it must stay static — no request/session state may leak into it.
+        assert "127.0.0.1" not in resp.text
+
+    @pytest.mark.asyncio
+    async def test_index_serves_built_bundle(self, monkeypatch, tmp_path) -> None:
+        index = tmp_path / "index.html"
+        index.write_text("<html>spa</html>", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(core_mod, "_DIST_INDEX", index)
+        resp = await core_mod.index(_req())
+        assert resp.text == "<html>spa</html>"
+        assert resp.content_type == "text/html"
+
+    @pytest.mark.asyncio
+    async def test_branding_defaults_to_product_name(self) -> None:
+        resp = await core_mod.api_branding(_req())
+        body = json.loads(resp.body)
+        assert body == {"bot_name": "Kiro Crew", "avatar": "/logo.png"}
+
+    @pytest.mark.asyncio
+    async def test_logo_refuses_sensitive_avatar_path(self, monkeypatch) -> None:
+        """A configured avatar pointing at a credential path is 404, never served."""
+        cfg = SimpleNamespace(dashboard=SimpleNamespace(avatar="/home/u/.ssh/id_rsa"))
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.KiroCrewConfig",
+            SimpleNamespace(load=lambda: cfg),
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.is_sensitive_path", lambda _p: True
+        )
+        resp = await core_mod.logo(_req())
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_logo_serves_validated_custom_avatar(self, monkeypatch, tmp_path) -> None:
+        avatar = tmp_path / "avatar.png"
+        avatar.write_bytes(b"png")
+        cfg = SimpleNamespace(dashboard=SimpleNamespace(avatar=str(avatar)))
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.KiroCrewConfig",
+            SimpleNamespace(load=lambda: cfg),
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.is_sensitive_path", lambda _p: False
+        )
+        monkeypatch.setattr(
+            "kiro_crew.hooks.validate_file_path", lambda p: str(avatar) if p else None
+        )
+        resp = await core_mod.logo(_req())
+        assert isinstance(resp, web.FileResponse)
+
+    @pytest.mark.asyncio
+    async def test_logo_prefers_nightly_variant_on_nightly_build(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Nightly builds serve the night-sky logo so the in-app identity
+        matches the nightly desktop shell."""
+        (tmp_path / "kirocrew-logo.png").write_bytes(b"day")
+        nightly = tmp_path / "kirocrew-logo-nightly.png"
+        nightly.write_bytes(b"night")
+        cfg = SimpleNamespace(dashboard=SimpleNamespace(avatar=""))
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.KiroCrewConfig",
+            SimpleNamespace(load=lambda: cfg),
+        )
+        monkeypatch.setattr("kiro_crew.dashboard.handlers._STATIC_DIR", tmp_path)
+        monkeypatch.setattr("kiro_crew.__version__", "9.9.9-nightly.20260812")
+        resp = await core_mod.logo(_req())
+        assert isinstance(resp, web.FileResponse)
+        assert os.path.realpath(resp._path) == os.path.realpath(nightly)
+
+    @pytest.mark.asyncio
+    async def test_logo_404_when_no_asset_exists(self, monkeypatch, tmp_path) -> None:
+        cfg = SimpleNamespace(dashboard=SimpleNamespace(avatar=""))
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.KiroCrewConfig",
+            SimpleNamespace(load=lambda: cfg),
+        )
+        monkeypatch.setattr("kiro_crew.dashboard.handlers._STATIC_DIR", tmp_path / "empty")
+        monkeypatch.setattr("kiro_crew.__version__", "9.9.9")
+        resp = await core_mod.logo(_req())
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_pwa_file_serves_dist_child(self, monkeypatch, tmp_path) -> None:
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        (dist / "manifest.webmanifest").write_text("{}", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(core_mod, "_DIST_DIR", dist)
+        resp = await core_mod.pwa_file(_req(match_info={"name": "manifest.webmanifest"}))
+        assert isinstance(resp, web.FileResponse)
+
+    @pytest.mark.asyncio
+    async def test_pwa_file_404_for_missing_name(self, monkeypatch, tmp_path) -> None:
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        monkeypatch.setattr(core_mod, "_DIST_DIR", dist)
+        with pytest.raises(web.HTTPNotFound):
+            await core_mod.pwa_file(_req(match_info={"name": "absent.js"}))
+
+
+# ── STT capability probes ────────────────────────────────────────────────
+
+
+class TestAppleSiliconProbe:
+    def test_non_darwin_is_never_apple_silicon(self, monkeypatch) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        assert core_mod._is_apple_silicon() is False
+
+    def test_native_arm64_short_circuits(self, monkeypatch) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(platform, "machine", lambda: "arm64")
+        assert core_mod._is_apple_silicon() is True
+
+    def test_rosetta_falls_back_to_sysctl(self, monkeypatch) -> None:
+        """Under Rosetta ``platform.machine()`` lies, so the hardware sysctl is
+        the authority."""
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(stdout="1\n", returncode=0),
+        )
+        assert core_mod._is_apple_silicon() is True
+
+    def test_sysctl_failure_is_not_apple_silicon(self, monkeypatch) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+
+        def _boom(*_a, **_k):
+            raise OSError("no sysctl")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+        assert core_mod._is_apple_silicon() is False
+
+
+class TestSttProviders:
+    def test_mlx_hidden_off_apple_silicon(self, monkeypatch) -> None:
+        monkeypatch.setattr(core_mod, "_is_apple_silicon", lambda: False)
+        monkeypatch.setattr(
+            "kiro_crew.apple_speech.availability",
+            lambda: SimpleNamespace(ok=True),
+        )
+        providers = core_mod._stt_providers()
+        assert "mlx" not in providers
+        assert "whisper" in providers
+
+    def test_apple_hidden_when_framework_unavailable(self, monkeypatch) -> None:
+        monkeypatch.setattr(core_mod, "_is_apple_silicon", lambda: True)
+        monkeypatch.setattr(
+            "kiro_crew.apple_speech.availability",
+            lambda: SimpleNamespace(ok=False),
+        )
+        providers = core_mod._stt_providers()
+        assert "apple" not in providers
+        assert "mlx" in providers
+
+
+class TestSttPrereqCommands:
+    @pytest.fixture(autouse=True)
+    def _no_ffmpeg_probe(self, monkeypatch):
+        monkeypatch.setattr(core_mod, "ensure_ffmpeg_in_path", lambda: None)
+
+    def test_mlx_off_apple_silicon_has_no_prereqs(self, monkeypatch) -> None:
+        monkeypatch.setattr(core_mod, "_is_apple_silicon", lambda: False)
+        monkeypatch.setattr(core_mod.shutil, "which", lambda _n: None)
+        assert core_mod._stt_prereq_commands("mlx") == []
+
+    def test_mlx_needs_only_homebrew(self, monkeypatch) -> None:
+        """The Install button bootstraps everything except Homebrew itself."""
+        monkeypatch.setattr(core_mod, "_is_apple_silicon", lambda: True)
+        monkeypatch.setattr(core_mod.shutil, "which", lambda _n: None)
+        monkeypatch.setattr(core_mod, "find_brew", lambda: None)
+        cmds = core_mod._stt_prereq_commands("mlx")
+        assert len(cmds) == 1
+        assert "install.sh" in cmds[0]
+
+    def test_mlx_with_homebrew_present_is_clean(self, monkeypatch) -> None:
+        monkeypatch.setattr(core_mod, "_is_apple_silicon", lambda: True)
+        monkeypatch.setattr(core_mod.shutil, "which", lambda _n: None)
+        monkeypatch.setattr(core_mod, "find_brew", lambda: "/opt/homebrew/bin/brew")
+        assert core_mod._stt_prereq_commands("mlx") == []
+
+    def test_darwin_lists_license_brew_and_packages(self, monkeypatch) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(core_mod.shutil, "which", lambda _n: None)
+        monkeypatch.setattr(core_mod, "find_brew", lambda: None)
+        monkeypatch.setattr(core_mod, "_find_suitable_python", lambda: None)
+
+        def _no_xcrun(*_a, **_k):
+            raise FileNotFoundError("xcrun")
+
+        monkeypatch.setattr(subprocess, "run", _no_xcrun)
+        cmds = core_mod._stt_prereq_commands()
+        assert any("xcodebuild -license" in c for c in cmds)
+        assert any("install.sh" in c for c in cmds)
+        assert any(c.startswith("brew install ") and "ffmpeg" in c for c in cmds)
+
+    def test_darwin_fully_provisioned_has_no_prereqs(self, monkeypatch) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(core_mod.shutil, "which", lambda _n: "/usr/bin/" + _n)
+        monkeypatch.setattr(core_mod, "find_brew", lambda: "/opt/homebrew/bin/brew")
+        monkeypatch.setattr(core_mod, "_find_suitable_python", lambda: "/usr/bin/python3")
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0, stdout="")
+        )
+        assert core_mod._stt_prereq_commands() == []
+
+    def test_debian_uses_apt_get(self, monkeypatch) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(core_mod, "_is_al2023", lambda: False)
+        monkeypatch.setattr(core_mod, "_find_suitable_python", lambda: None)
+        monkeypatch.setattr(
+            core_mod.shutil,
+            "which",
+            lambda n: "/usr/bin/apt-get" if n == "apt-get" else None,
+        )
+        cmds = core_mod._stt_prereq_commands()
+        assert any("apt-get install -y python3" in c for c in cmds)
+        assert any(c == "sudo apt-get install -y ffmpeg" for c in cmds)
+
+    def test_al2023_uses_dnf_and_ffmpeg_build_script(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(core_mod, "_is_al2023", lambda: True)
+        monkeypatch.setattr(core_mod, "_find_suitable_python", lambda: None)
+        monkeypatch.setattr(core_mod.shutil, "which", lambda _n: None)
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        (scripts / "build-ffmpeg.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        cmds = core_mod._stt_prereq_commands()
+        assert any("dnf install -y python3.11" in c for c in cmds)
+        assert any("build-ffmpeg.sh" in c for c in cmds)
+
+    def test_al2_without_build_script_points_at_upstream(self, monkeypatch) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(core_mod, "_is_al2023", lambda: False)
+        monkeypatch.setattr(core_mod, "_find_suitable_python", lambda: "/usr/bin/python3")
+        monkeypatch.setattr(core_mod.shutil, "which", lambda _n: None)
+        monkeypatch.delenv("KIROCREW_PROJECT_DIR", raising=False)
+        cmds = core_mod._stt_prereq_commands()
+        assert cmds == ["echo 'Build ffmpeg from source: https://ffmpeg.org/releases/'"]
+
+
+class TestAl2023Detection:
+    def test_release_file_naming_2023(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            core_mod,
+            "Path",
+            lambda _p: SimpleNamespace(read_text=lambda **_k: "Amazon Linux release 2023"),
+        )
+        assert core_mod._is_al2023() is True
+
+    def test_unreadable_release_file_is_false(self, monkeypatch) -> None:
+        def _raise(**_k):
+            raise OSError("no such file")
+
+        monkeypatch.setattr(core_mod, "Path", lambda _p: SimpleNamespace(read_text=_raise))
+        assert core_mod._is_al2023() is False
+
+
+class TestFindSuitablePython:
+    """The reject predicate must SKIP an unusable interpreter, never abort."""
+
+    @staticmethod
+    def _capture(monkeypatch):
+        captured: dict = {}
+
+        def _fake(reject=None):
+            captured["reject"] = reject
+            return "/usr/bin/python3"
+
+        monkeypatch.setattr(
+            "kiro_crew.platform_compat.find_python_interpreter", _fake
+        )
+        assert core_mod._find_suitable_python() == "/usr/bin/python3"
+        return captured["reject"]
+
+    def test_free_threaded_build_is_rejected(self, monkeypatch) -> None:
+        reject = self._capture(monkeypatch)
+        monkeypatch.setattr(
+            subprocess,
+            "check_output",
+            lambda *a, **k: "3.14.0 free-threading build",
+        )
+        assert reject("/usr/bin/python3.14t") is True
+
+    def test_interpreter_with_pip_is_accepted(self, monkeypatch) -> None:
+        reject = self._capture(monkeypatch)
+        monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: "3.12.1 (main)")
+        assert reject("/usr/bin/python3.12") is False
+
+    def test_missing_pip_is_rejected(self, monkeypatch) -> None:
+        reject = self._capture(monkeypatch)
+
+        def _fake(args, **_k):
+            if "pip" in args:
+                raise subprocess.CalledProcessError(1, args)
+            return "3.12.1 (main)"
+
+        monkeypatch.setattr(subprocess, "check_output", _fake)
+        assert reject("/usr/bin/python3.12") is True
+
+    def test_unspawnable_interpreter_is_rejected(self, monkeypatch) -> None:
+        def _boom(*_a, **_k):
+            raise OSError("exec format error")
+
+        reject = self._capture(monkeypatch)
+        monkeypatch.setattr(subprocess, "check_output", _boom)
+        assert reject("/usr/bin/broken") is True
+
+
+class TestInstallScript:
+    def test_path_prelude_defers_to_brew_shellenv(self) -> None:
+        prelude = core_mod._stt_install_path_prelude()
+        assert "brew shellenv" in prelude
+        assert "export PATH" in prelude
+
+    def test_mlx_script_installs_via_pipx(self) -> None:
+        script = core_mod._build_stt_install_script("mlx")
+        assert "pipx install --force mlx-whisper" in script
+        assert "openai-whisper" not in script
+
+    def test_default_script_prefers_brew_then_pip_user(self) -> None:
+        script = core_mod._build_stt_install_script()
+        assert "brew install openai-whisper" in script
+        # The pip fallback must target a SYSTEM python with --user, never the
+        # gateway venv (which is replaced on every upgrade).
+        assert "--user" in script
+        assert "--only-binary" in script
+
+
+# ── STT config endpoint ─────────────────────────────────────────────────
+
+
+def _stt_app() -> web.Application:
+    app = web.Application()
+    app.router.add_route("*", "/api/config/stt", core_mod.api_stt_config)
+    return app
+
+
+class TestSttConfigEndpoint:
+    @pytest.fixture(autouse=True)
+    def _quiet_probes(self, monkeypatch):
+        monkeypatch.setattr(core_mod, "_stt_prereq_commands", lambda _p: [])
+        monkeypatch.setattr(core_mod, "is_available", lambda _cfg: False)
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_malformed_body(self, seeded_config) -> None:
+        async with TestClient(TestServer(_stt_app())) as client:
+            resp = await client.put("/api/config/stt", data=b"not json")
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "invalid JSON"
+
+    @pytest.mark.asyncio
+    async def test_put_fails_loud_on_corrupt_config(self, seeded_config) -> None:
+        """A corrupt config must NOT be silently rebuilt from {} — that would
+        durably clobber every unrelated user setting."""
+        seeded_config.write_text("{ this is not json", encoding="utf-8", newline="\n")
+        async with TestClient(TestServer(_stt_app())) as client:
+            resp = await client.put("/api/config/stt", json={"enabled": True})
+            assert resp.status == 500
+            assert (await resp.json())["error"] == "failed to read config file"
+        # The unparseable bytes are left exactly as they were.
+        assert seeded_config.read_text(encoding="utf-8") == "{ this is not json"
+
+    @pytest.mark.asyncio
+    async def test_put_persists_recognised_fields_only(self, seeded_config) -> None:
+        async with TestClient(TestServer(_stt_app())) as client:
+            resp = await client.put(
+                "/api/config/stt",
+                json={
+                    "enabled": True,
+                    "provider": "whisper",
+                    "model": "turbo",
+                    "mlx_model": "mlx-community/whisper-large-v3-turbo",
+                    "transcribe_region": "us-west-2",
+                    "transcribe_profile": "default",
+                    "language_code": "en-US",
+                    "streaming": True,
+                    "endpointing": False,
+                    "dictation_panel": True,
+                    "provider_bogus": "ignored",
+                },
+            )
+            assert resp.status == 200
+        stt = json.loads(seeded_config.read_text(encoding="utf-8"))["stt"]
+        assert stt["enabled"] is True
+        assert stt["provider"] == "whisper"
+        assert stt["model"] == "turbo"
+        assert stt["transcribe_region"] == "us-west-2"
+        assert stt["language_code"] == "en-US"
+        assert stt["streaming"] is True
+        assert stt["endpointing"] is False
+        assert stt["dictation_panel"] is True
+        assert "provider_bogus" not in stt
+        # The pre-existing unrelated section survived the read-modify-write.
+        agent = json.loads(seeded_config.read_text(encoding="utf-8"))["agent"]
+        assert agent["approval_mode"] == "auto"
+
+    @pytest.mark.asyncio
+    async def test_put_ignores_unknown_enum_values(self, seeded_config) -> None:
+        async with TestClient(TestServer(_stt_app())) as client:
+            resp = await client.put(
+                "/api/config/stt",
+                json={"provider": "not-a-provider", "model": "not-a-model"},
+            )
+            assert resp.status == 200
+        stt = json.loads(seeded_config.read_text(encoding="utf-8"))["stt"]
+        assert stt.get("provider") != "not-a-provider"
+        assert stt.get("model") != "not-a-model"
+
+    @pytest.mark.asyncio
+    async def test_get_advertises_capabilities(self, seeded_config) -> None:
+        async with TestClient(TestServer(_stt_app())) as client:
+            resp = await client.get("/api/config/stt")
+            assert resp.status == 200
+            body = await resp.json()
+        # Streaming capability is served from the backend's own set so the
+        # Settings UI gates on a CAPABILITY rather than a provider name.
+        assert body["streaming_providers"] == ["transcribe", "apple"]
+        assert body["models"] == {"turbo": "~1.6 GB"}
+        assert body["language_codes"][0] == "en-US"
+        assert body["available"] is False
+        assert body["prereqs"] == []
+        assert body["install_step"] in ("idle", "done", "error")
+
+
+# ── STT install endpoint ────────────────────────────────────────────────
+
+
+def _proc(lines: list[bytes], returncode: int = 0) -> MagicMock:
+    proc = MagicMock()
+    proc.stdout = SimpleNamespace(readline=AsyncMock(side_effect=[*lines, b""]))
+    proc.wait = AsyncMock(return_value=returncode)
+    proc.communicate = AsyncMock(return_value=(b"", b""))
+    proc.returncode = returncode
+    return proc
+
+
+class TestSttInstall:
+    @pytest.mark.asyncio
+    async def test_concurrent_install_is_refused(self, fake_sel, stt_status) -> None:
+        core_mod._stt_install_status = {
+            "step": "installing_ffmpeg",
+            "detail": "",
+            "error": "",
+        }
+        resp = await core_mod.api_stt_install(_req())
+        assert resp.status == 409
+        assert "already in progress" in json.loads(resp.body)["error"]
+        assert fake_sel.log_api_access.call_args.kwargs["outcome"] == "denied"
+
+    @pytest.mark.asyncio
+    async def test_successful_install_walks_the_progress_steps(
+        self, monkeypatch, fake_sel, stt_status
+    ) -> None:
+        core_mod._stt_install_status = {"step": "idle", "detail": "", "error": ""}
+        lines = [
+            b"Checking Xcode tools\n",
+            b"Installing Homebrew\n",
+            b"Installing ffmpeg\n",
+            b"Installing openai-whisper\n",
+            b"Installing mlx-whisper\n",
+            b"No suitable python3 found\n",
+            b"Using: /usr/bin/python3\n",
+            b"ERROR: recoverable hiccup\n",
+            b"Done.\n",
+        ]
+
+        async def _spawn(*_a, **_k):
+            return _proc(lines)
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
+        resp = await core_mod.api_stt_install(_req())
+        assert resp.status == 200
+        assert json.loads(resp.body)["ok"] is True
+        assert core_mod._stt_install_status["step"] == "done"
+        assert fake_sel.log_api_access.call_args.kwargs["outcome"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_failed_install_reports_tail_of_output(
+        self, monkeypatch, fake_sel, stt_status
+    ) -> None:
+        core_mod._stt_install_status = {"step": "idle", "detail": "", "error": ""}
+
+        async def _spawn(*_a, **_k):
+            return _proc([b"boom\n"], returncode=1)
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
+        resp = await core_mod.api_stt_install(_req())
+        assert resp.status == 500
+        body = json.loads(resp.body)
+        assert body["ok"] is False
+        assert "boom" in body["error"]
+        assert core_mod._stt_install_status["step"] == "error"
+        assert fake_sel.log_api_access.call_args.kwargs["outcome"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_install_timeout_kills_the_child(
+        self, monkeypatch, fake_sel, stt_status
+    ) -> None:
+        core_mod._stt_install_status = {"step": "idle", "detail": "", "error": ""}
+        proc = MagicMock()
+        proc.stdout = SimpleNamespace(readline=AsyncMock(side_effect=asyncio.TimeoutError))
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        async def _spawn(*_a, **_k):
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
+        resp = await core_mod.api_stt_install(_req())
+        assert resp.status == 500
+        assert json.loads(resp.body)["error"] == "Install timed out"
+        proc.kill.assert_called_once()
+        assert core_mod._stt_install_status["step"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_missing_shell_is_reported_not_raised(
+        self, monkeypatch, fake_sel, stt_status
+    ) -> None:
+        core_mod._stt_install_status = {"step": "idle", "detail": "", "error": ""}
+
+        async def _spawn(*_a, **_k):
+            raise FileNotFoundError("bash")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
+        resp = await core_mod.api_stt_install(_req())
+        assert resp.status == 500
+        assert json.loads(resp.body)["error"] == "bash not found"
+        assert core_mod._stt_install_status["error"] == "bash not found"
+
+
+# ── STT transcribe endpoint ─────────────────────────────────────────────
+
+
+def _multipart_req(field) -> web.Request:
+    reader = SimpleNamespace(next=AsyncMock(return_value=field))
+    req = _req()
+    req.multipart = AsyncMock(return_value=reader)
+    return req
+
+
+class TestSttTranscribe:
+    @pytest.mark.asyncio
+    async def test_unavailable_backend_is_503(self, monkeypatch) -> None:
+        monkeypatch.setattr("kiro_crew.transcribe.is_available", lambda *_a: False)
+        resp = await core_mod.api_stt_transcribe(_req())
+        assert resp.status == 503
+        assert json.loads(resp.body)["error"] == "STT not available"
+
+    @pytest.mark.asyncio
+    async def test_missing_audio_field_is_400(self, monkeypatch) -> None:
+        monkeypatch.setattr("kiro_crew.transcribe.is_available", lambda *_a: True)
+        resp = await core_mod.api_stt_transcribe(_multipart_req(None))
+        assert resp.status == 400
+        assert json.loads(resp.body)["error"] == "missing audio field"
+
+    @pytest.mark.asyncio
+    async def test_wrong_field_name_is_400(self, monkeypatch) -> None:
+        monkeypatch.setattr("kiro_crew.transcribe.is_available", lambda *_a: True)
+        field = SimpleNamespace(name="video", filename="x.webm", read_chunk=AsyncMock())
+        resp = await core_mod.api_stt_transcribe(_multipart_req(field))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_oversized_upload_is_413(self, monkeypatch) -> None:
+        monkeypatch.setattr("kiro_crew.transcribe.is_available", lambda *_a: True)
+        field = SimpleNamespace(
+            name="audio",
+            filename="recording.mp4",
+            read_chunk=AsyncMock(return_value=b"0" * (25 * 1024 * 1024 + 1)),
+        )
+        resp = await core_mod.api_stt_transcribe(_multipart_req(field))
+        assert resp.status == 413
+        assert json.loads(resp.body)["error"] == "audio too large"
+
+    @pytest.mark.asyncio
+    async def test_transcript_is_returned_and_redacted(self, monkeypatch) -> None:
+        monkeypatch.setattr("kiro_crew.transcribe.is_available", lambda *_a: True)
+        monkeypatch.setattr(
+            "kiro_crew.transcribe.transcribe_audio",
+            AsyncMock(return_value="hello from the meeting"),
+        )
+        field = SimpleNamespace(
+            name="audio",
+            filename="recording.ogg",
+            read_chunk=AsyncMock(side_effect=[b"audio-bytes", b""]),
+        )
+        resp = await core_mod.api_stt_transcribe(_multipart_req(field))
+        assert resp.status == 200
+        assert json.loads(resp.body)["text"] == "hello from the meeting"
+
+    @pytest.mark.asyncio
+    async def test_backend_failure_is_a_generic_500(self, monkeypatch) -> None:
+        monkeypatch.setattr("kiro_crew.transcribe.is_available", lambda *_a: True)
+        monkeypatch.setattr(
+            "kiro_crew.transcribe.transcribe_audio",
+            AsyncMock(side_effect=RuntimeError("whisper exploded")),
+        )
+        field = SimpleNamespace(
+            name="audio",
+            filename="recording.webm",
+            read_chunk=AsyncMock(side_effect=[b"x", b""]),
+        )
+        resp = await core_mod.api_stt_transcribe(_multipart_req(field))
+        assert resp.status == 500
+        # The internal exception text must not reach the client.
+        body = json.loads(resp.body)
+        assert body["error"] == "transcription failed"
+        assert "whisper exploded" not in json.dumps(body)
+
+
+# ── Security event log + posture ────────────────────────────────────────
+
+
+class TestSelEndpoints:
+    @pytest.mark.asyncio
+    async def test_events_uses_default_limit(self, fake_sel) -> None:
+        fake_sel.recent.return_value = [{"event": "a"}]
+        resp = await core_mod.api_sel_events(_req())
+        assert json.loads(resp.body) == {"events": [{"event": "a"}], "count": 1}
+        assert fake_sel.recent.call_args.kwargs["limit"] == 100
+
+    @pytest.mark.asyncio
+    async def test_events_caps_limit_at_1000(self, fake_sel) -> None:
+        fake_sel.recent.return_value = []
+        await core_mod.api_sel_events(_req(query={"limit": "99999"}))
+        assert fake_sel.recent.call_args.kwargs["limit"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_events_falls_back_on_unparsable_limit(self, fake_sel) -> None:
+        fake_sel.recent.return_value = []
+        await core_mod.api_sel_events(_req(query={"limit": "many"}))
+        assert fake_sel.recent.call_args.kwargs["limit"] == 100
+
+    @pytest.mark.asyncio
+    async def test_verify_reports_intact_chain(self, fake_sel) -> None:
+        fake_sel.verify_integrity.return_value = (7, 7)
+        body = json.loads((await core_mod.api_sel_verify(_req())).body)
+        assert body == {"total": 7, "valid": 7, "integrity": "ok", "tampered": 0}
+
+    @pytest.mark.asyncio
+    async def test_verify_reports_tampering(self, fake_sel) -> None:
+        fake_sel.verify_integrity.return_value = (7, 5)
+        body = json.loads((await core_mod.api_sel_verify(_req())).body)
+        assert body["integrity"] == "compromised"
+        assert body["tampered"] == 2
+
+
+class TestSecurityStats:
+    @pytest.mark.asyncio
+    async def test_counts_are_derived_from_the_posture_registry(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.security.build_denied_commands_snapshot_async",
+            AsyncMock(return_value={"effective_count": 42}),
+        )
+        monkeypatch.setattr(
+            core_mod,
+            "posture_counts_async",
+            AsyncMock(
+                return_value={
+                    "suspicious_patterns": 3,
+                    "tool_schemas": 4,
+                    "redaction_paths": 5,
+                }
+            ),
+        )
+        body = json.loads((await core_mod.api_security_stats(_req())).body)
+        assert body == {
+            "denied_commands": 42,
+            "suspicious_patterns": 3,
+            "tool_schemas": 4,
+            "redaction_paths": 5,
+        }
+
+    @pytest.mark.asyncio
+    async def test_denied_count_failure_degrades_to_zero(self, monkeypatch) -> None:
+        """An unreadable denylist must not take the whole stats endpoint down."""
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.security.build_denied_commands_snapshot_async",
+            AsyncMock(side_effect=OSError("unreadable")),
+        )
+        monkeypatch.setattr(core_mod, "posture_counts_async", AsyncMock(return_value={}))
+        body = json.loads((await core_mod.api_security_stats(_req())).body)
+        assert body["denied_commands"] == 0
+        assert body["suspicious_patterns"] is None
+
+
+# ── Agent settings PUT (/api/config/kirocrew) ───────────────────────────
+
+
+def _agent_cfg_app() -> web.Application:
+    app = web.Application()
+    app.router.add_route("*", "/api/config/kirocrew", core_mod.api_kirocrew_config)
+    return app
+
+
+async def _put_agent(client, settings: dict):
+    return await client.put("/api/config/kirocrew", json={"agent": settings})
+
+
+class TestAgentSettingsPut:
+    @pytest.mark.asyncio
+    async def test_malformed_body_is_denied_and_audited(self, seeded_config, fake_sel) -> None:
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await client.put("/api/config/kirocrew", data=b"{{{")
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "invalid JSON"
+        assert fake_sel.log_api_access.call_args.kwargs["outcome"] == "denied"
+
+    @pytest.mark.asyncio
+    async def test_missing_agent_object_is_denied(self, seeded_config, fake_sel) -> None:
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await client.put("/api/config/kirocrew", json={"agent": "nope"})
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "agent must be an object"
+
+    @pytest.mark.asyncio
+    async def test_corrupt_config_is_500_not_a_silent_reset(
+        self, seeded_config, fake_sel
+    ) -> None:
+        seeded_config.write_text("<<not json>>", encoding="utf-8", newline="\n")
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(client, {"subagent_max_turns": 5})
+            assert resp.status == 500
+            assert (await resp.json())["error"] == "config.json is corrupt"
+        assert seeded_config.read_text(encoding="utf-8") == "<<not json>>"
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_turns_is_denied(self, seeded_config, fake_sel) -> None:
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(
+                client, {"subagent_max_turns": SUBAGENT_MAX_TURNS_CEILING + 1}
+            )
+            assert resp.status == 400
+            assert "between 1 and" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_boolean_is_not_an_integer(self, seeded_config, fake_sel) -> None:
+        """``True`` is an ``int`` subclass in Python — the validator must still
+        refuse it, or a JSON ``true`` would silently persist as 1."""
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(client, {"subagent_max_turns": True})
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_auto_max_above_ceiling_is_denied(self, seeded_config, fake_sel) -> None:
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(
+                client, {"subagent_auto_max": SUBAGENT_AUTO_MAX_CEILING + 1}
+            )
+            assert resp.status == 400
+            assert "subagent_auto_max must be an integer" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_same_request_ceiling_raise_cannot_widen_the_pin(
+        self, seeded_config, fake_sel
+    ) -> None:
+        """Deny-by-default: ``{subagent_auto_max: N, max_subagents: N}`` must not
+        let one request raise the ceiling and immediately spend it."""
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(
+                client,
+                {
+                    "subagent_auto_max": SUBAGENT_AUTO_MAX_CEILING,
+                    "max_subagents": SUBAGENT_AUTO_MAX_CEILING,
+                },
+            )
+            assert resp.status == 400
+            assert "max_subagents must be 0 (auto)" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_corrupt_persisted_ceiling_is_clamped(self, seeded_config, fake_sel) -> None:
+        """A hand-edited ceiling must not be trusted to widen the bound."""
+        seeded_config.write_text(
+            json.dumps({"agent": {"subagent_auto_max": 9999}}),
+            encoding="utf-8",
+            newline="\n",
+        )
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(client, {"max_subagents": 9999})
+            assert resp.status == 400
+            error = (await resp.json())["error"]
+            assert f"and {SUBAGENT_AUTO_MAX_CEILING}" in error
+
+    @pytest.mark.asyncio
+    async def test_fixed_pin_below_floor_is_denied(self, seeded_config, fake_sel) -> None:
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(client, {"max_subagents": MAX_SUBAGENTS_FIXED_FLOOR - 1})
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_auto_sentinel_is_accepted(self, seeded_config, fake_sel) -> None:
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(client, {"max_subagents": 0})
+            assert resp.status == 200
+            assert (await resp.json())["restart_required"] is True
+        assert json.loads(seeded_config.read_text(encoding="utf-8"))["agent"][
+            "max_subagents"
+        ] == 0
+
+    @pytest.mark.asyncio
+    async def test_non_boolean_toggle_is_denied(self, seeded_config, fake_sel) -> None:
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(client, {"conductor_skill": "yes"})
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "conductor_skill must be a boolean"
+
+    @pytest.mark.asyncio
+    async def test_empty_settings_is_denied(self, seeded_config, fake_sel) -> None:
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(client, {"unknown_key": 1})
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "no recognized settings provided"
+
+    @pytest.mark.asyncio
+    async def test_resent_unchanged_value_does_not_ask_for_a_restart(
+        self, seeded_config, fake_sel
+    ) -> None:
+        """The dashboard sends all settings on every save, so "was applied" is
+        not "was changed" — the restart hint has to stay trustworthy."""
+        seeded_config.write_text(
+            json.dumps({"agent": {"subagent_max_turns": 9}}),
+            encoding="utf-8",
+            newline="\n",
+        )
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(client, {"subagent_max_turns": 9})
+            assert resp.status == 200
+            assert (await resp.json()) == {"ok": True, "restart_required": False}
+
+    @pytest.mark.asyncio
+    async def test_conductor_enable_regenerates_the_skill(
+        self, seeded_config, fake_sel, monkeypatch
+    ) -> None:
+        regen = MagicMock()
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.agents._regen_conductor", regen)
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(client, {"conductor_skill": True})
+            assert resp.status == 200
+            # A conductor-only save is applied in-request, so no restart hint.
+            assert (await resp.json())["restart_required"] is False
+        regen.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_conductor_disable_removes_the_skill_file(
+        self, seeded_config, fake_sel, tmp_path
+    ) -> None:
+        from kiro_crew.skills import SkillsLoader
+
+        skill = SkillsLoader()._dir / "conductor" / "SKILL.md"
+        skill.parent.mkdir(parents=True, exist_ok=True)
+        skill.write_text("# conductor\n", encoding="utf-8", newline="\n")
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(client, {"conductor_skill": False})
+            assert resp.status == 200
+        assert not skill.exists()
+
+    @pytest.mark.asyncio
+    async def test_get_drops_edition_contributed_sections(self, seeded_config) -> None:
+        """Unknown top-level sections exist only for the save round-trip; the
+        browser-facing view must omit them so an edition secret cannot leak."""
+        seeded_config.write_text(
+            json.dumps({"agent": {}, "some_edition": {"api_key": "s3cret"}}),
+            encoding="utf-8",
+            newline="\n",
+        )
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            body = await (await client.get("/api/config/kirocrew")).json()
+        assert "some_edition" not in body
+        assert "s3cret" not in json.dumps(body)
+        assert "agent" in body
+
+
+# ── PATCH validators not reachable through the editable-field table ─────
+
+
+class TestPatchGuards:
+    @pytest.mark.asyncio
+    async def test_moved_field_names_its_replacement_endpoint(
+        self, seeded_config, fake_sel
+    ) -> None:
+        """A dead end ("not editable") becomes a next step for fields whose
+        side effects the generic write cannot reproduce."""
+        app = web.Application()
+        app.router.add_patch("/api/config/kirocrew", core_mod.api_kirocrew_config_patch)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.patch(
+                "/api/config/kirocrew",
+                json={"path": "agent.apps_allow_third_party", "value": False},
+            )
+            assert resp.status == 400
+            assert "trusted-apps/allow-all" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_field_is_refused(self, seeded_config, fake_sel) -> None:
+        app = web.Application()
+        app.router.add_patch("/api/config/kirocrew", core_mod.api_kirocrew_config_patch)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.patch(
+                "/api/config/kirocrew", json={"path": "agent.nope", "value": 1}
+            )
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "field not editable: agent.nope"
+
+
+class TestAdvertisedModelGuards:
+    def test_unknown_when_no_session_has_initialised(self) -> None:
+        assert core_mod._active_advertised_ids(_req(app={})) is None
+
+    def test_provider_without_a_model_getter_is_skipped(self) -> None:
+        state = SimpleNamespace(
+            sessions=SimpleNamespace(active_providers=lambda: [SimpleNamespace()])
+        )
+        assert core_mod._active_advertised_ids(_req(app={"state": state})) is None
+
+    def test_raising_getter_does_not_propagate(self) -> None:
+        def _boom():
+            raise RuntimeError("provider is mid-restart")
+
+        state = SimpleNamespace(
+            sessions=SimpleNamespace(
+                active_providers=lambda: [SimpleNamespace(available_models=_boom)]
+            )
+        )
+        assert core_mod._active_advertised_ids(_req(app={"state": state})) is None
+
+    def test_first_provider_with_ids_wins(self) -> None:
+        state = SimpleNamespace(
+            sessions=SimpleNamespace(
+                active_providers=lambda: [
+                    SimpleNamespace(available_models=lambda: []),
+                    SimpleNamespace(
+                        available_models=lambda: [{"modelId": "claude-sonnet-4.6"}]
+                    ),
+                ]
+            )
+        )
+        ids = core_mod._active_advertised_ids(_req(app={"state": state}))
+        assert ids == ["claude-sonnet-4.6"]
+
+    @pytest.mark.parametrize("value", ["", "auto"])
+    def test_defer_values_always_allowed(self, value) -> None:
+        assert core_mod._validate_role_model(value, _req()) is None
+
+    def test_provider_rejection_is_surfaced(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers._model_rejected_reason",
+            lambda _v: "display-only key",
+        )
+        assert core_mod._validate_role_model("fable-5-1m", _req()) == "display-only key"
+
+    def test_unknown_entitlement_does_not_accuse(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers._model_rejected_reason", lambda _v: None
+        )
+        assert core_mod._validate_role_model("some-model", _req(app={})) is None
+
+    def test_unentitled_model_lists_usable_alternatives(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers._model_rejected_reason", lambda _v: None
+        )
+        state = SimpleNamespace(
+            sessions=SimpleNamespace(
+                active_providers=lambda: [
+                    SimpleNamespace(available_models=lambda: [{"modelId": "allowed-1"}])
+                ]
+            )
+        )
+        reason = core_mod._validate_role_model("denied-1", _req(app={"state": state}))
+        assert reason is not None
+        assert "allowed-1" in reason
+
+    def test_pool_agent_values_include_the_clear_sentinel(self) -> None:
+        assert "" in core_mod._agent_values()
+
+
+# ── Loopback + local-secret gated endpoints ─────────────────────────────
+
+
+class TestLocalToken:
+    @pytest.mark.asyncio
+    async def test_non_loopback_is_refused(self, monkeypatch, fake_sel) -> None:
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.is_loopback", lambda _r: False)
+        resp = await core_mod.api_token_local(_req(remote="203.0.113.9"))
+        assert resp.status == 403
+        assert json.loads(resp.body)["error"] == "loopback only"
+        assert fake_sel.log_api_access.call_args.kwargs["resources"] == "non-loopback"
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_secret_is_503(self, monkeypatch, fake_sel) -> None:
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.is_loopback", lambda _r: True)
+        resp = await core_mod.api_token_local(_req(app={}))
+        assert resp.status == 503
+        assert json.loads(resp.body)["error"] == "not available"
+
+    @pytest.mark.asyncio
+    async def test_wrong_secret_is_refused(self, monkeypatch, fake_sel) -> None:
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.is_loopback", lambda _r: True)
+        resp = await core_mod.api_token_local(
+            _req(app={"local_secret": "right"}, headers={"X-Local-Secret": "wrong"})
+        )
+        assert resp.status == 403
+        assert json.loads(resp.body)["error"] == "invalid secret"
+
+    @pytest.mark.asyncio
+    async def test_missing_secret_header_is_refused(self, monkeypatch, fake_sel) -> None:
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.is_loopback", lambda _r: True)
+        resp = await core_mod.api_token_local(_req(app={"local_secret": "right"}))
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_issues_credential_with_requested_ttl_and_embed_claim(
+        self, monkeypatch, fake_sel
+    ) -> None:
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.is_loopback", lambda _r: True)
+        minted: dict = {}
+
+        def _generate(owner, ttl_seconds=0, extra=None):
+            minted.update({"owner": owner, "ttl": ttl_seconds, "extra": extra})
+            return "issued-value"
+
+        monkeypatch.setattr(core_mod, "generate_token", _generate)
+        resp = await core_mod.api_token_local(
+            _req(
+                app={"local_secret": "right", "state": SimpleNamespace(owner_id="owner-1")},
+                headers={"X-Local-Secret": "right"},
+                query={"ttl": "2h", "embed_parent_port": "5476"},
+            )
+        )
+        assert resp.status == 200
+        assert json.loads(resp.body)["expires_in"] == 7200
+        assert minted["owner"] == "owner-1"
+        assert minted["extra"] == {"embed_parent_port": "5476"}
+
+    @pytest.mark.asyncio
+    async def test_bad_embed_port_is_dropped(self, monkeypatch, fake_sel) -> None:
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.is_loopback", lambda _r: True)
+        minted: dict = {}
+
+        def _generate(owner, ttl_seconds=0, extra=None):
+            minted["extra"] = extra
+            return "issued-value"
+
+        monkeypatch.setattr(core_mod, "generate_token", _generate)
+        resp = await core_mod.api_token_local(
+            _req(
+                app={"local_secret": "right"},
+                headers={"X-Local-Secret": "right"},
+                query={"ttl": "not-a-duration", "embed_parent_port": "99999"},
+            )
+        )
+        assert resp.status == 200
+        assert minted["extra"] is None
+
+
+class TestLogout:
+    @pytest.mark.asyncio
+    async def test_non_loopback_is_refused(self, monkeypatch, fake_sel) -> None:
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.is_loopback", lambda _r: False)
+        resp = await core_mod.api_logout(_req(remote="203.0.113.9"))
+        assert resp.status == 403
+        assert json.loads(resp.body)["error"] == "loopback only"
+
+    @pytest.mark.asyncio
+    async def test_wrong_secret_is_refused(self, monkeypatch, fake_sel) -> None:
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.is_loopback", lambda _r: True)
+        resp = await core_mod.api_logout(
+            _req(app={"local_secret": "right"}, headers={"X-Local-Secret": "wrong"})
+        )
+        assert resp.status == 403
+        assert json.loads(resp.body)["error"] == "invalid secret"
+
+    @pytest.mark.asyncio
+    async def test_revocation_persist_failure_reports_a_coded_error(
+        self, monkeypatch, fake_sel
+    ) -> None:
+        """Fail-closed: an unpersisted revocation must never report success."""
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.is_loopback", lambda _r: True)
+
+        def _boom():
+            raise OSError("read-only trust dir")
+
+        monkeypatch.setattr("kiro_crew.dashboard.token_auth.revoke_all_sessions", _boom)
+        resp = await core_mod.api_logout(
+            _req(app={"local_secret": "right"}, headers={"X-Local-Secret": "right"})
+        )
+        assert resp.status == 500
+        body = json.loads(resp.body)
+        assert body["code"] == "revocation_persist_failed"
+        assert "logout not completed" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_successful_revocation_is_audited(self, monkeypatch, fake_sel) -> None:
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.is_loopback", lambda _r: True)
+        revoke = MagicMock()
+        monkeypatch.setattr("kiro_crew.dashboard.token_auth.revoke_all_sessions", revoke)
+        resp = await core_mod.api_logout(
+            _req(app={"local_secret": "right"}, headers={"X-Local-Secret": "right"})
+        )
+        assert resp.status == 200
+        assert json.loads(resp.body) == {"ok": True}
+        revoke.assert_called_once()
+        assert fake_sel.log_api_access.call_args.kwargs["outcome"] == "success"
+
+
+class TestAppSecretExchange:
+    @pytest.fixture
+    def app_sel(self, monkeypatch) -> MagicMock:
+        recorder = MagicMock()
+        monkeypatch.setattr("kiro_crew.sel.sel", lambda: recorder)
+        return recorder
+
+    @pytest.mark.asyncio
+    async def test_missing_header_is_refused(self, app_sel) -> None:
+        resp = await core_mod.api_app_token(_req(match_info={"name": "meetings"}))
+        assert resp.status == 403
+        assert json.loads(resp.body)["error"] == "missing X-App-Secret header"
+        assert app_sel.log_api_access.call_args.kwargs["outcome"] == "denied"
+
+    @pytest.mark.asyncio
+    async def test_invalid_secret_is_refused(self, app_sel, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.token_auth.validate_app_secret", lambda *_a: False
+        )
+        resp = await core_mod.api_app_token(
+            _req(match_info={"name": "meetings"}, headers={"X-App-Secret": "nope"})
+        )
+        assert resp.status == 403
+        assert json.loads(resp.body)["error"] == "invalid secret"
+
+    @pytest.mark.asyncio
+    async def test_valid_secret_mints_an_app_scoped_credential(
+        self, app_sel, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.token_auth.validate_app_secret", lambda *_a: True
+        )
+        seen: dict = {}
+
+        def _generate(name, app=None):
+            seen.update({"name": name, "app": app})
+            return "app-scoped-value"
+
+        monkeypatch.setattr("kiro_crew.dashboard.token_auth.generate_token", _generate)
+        resp = await core_mod.api_app_token(
+            _req(match_info={"name": "meetings"}, headers={"X-App-Secret": "ok"})
+        )
+        assert resp.status == 200
+        # The app identity must be IN the payload so downstream middleware can
+        # extract a verified app name rather than trusting a header.
+        assert seen == {"name": "meetings", "app": "meetings"}
+        assert app_sel.log_api_access.call_args.kwargs["outcome"] == "granted"
+
+
+# ── Session sub-agent routes ────────────────────────────────────────────
+
+
+class TestSessionAgentRoutes:
+    @pytest.mark.asyncio
+    async def test_list_returns_workspace_results(self, monkeypatch, fake_sel) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.session_workspace.list_results",
+            lambda _s: [{"agent_id": "a1", "bytes": 12}],
+        )
+        resp = await core_mod.api_session_agents_list(_req(match_info={"id": "s1"}))
+        assert json.loads(resp.body) == {"results": [{"agent_id": "a1", "bytes": 12}]}
+        assert fake_sel.log_api_access.call_args.kwargs["resources"] == "s1"
+
+    @pytest.mark.asyncio
+    async def test_missing_result_is_404(self, monkeypatch, fake_sel) -> None:
+        monkeypatch.setattr("kiro_crew.session_workspace.read_result", lambda *_a: "")
+        resp = await core_mod.api_session_agent_result(
+            _req(match_info={"id": "s1", "agent_id": "a1"})
+        )
+        assert resp.status == 404
+        assert json.loads(resp.body)["error"] == "not found"
+
+    @pytest.mark.asyncio
+    async def test_result_is_returned_after_redaction(self, monkeypatch, fake_sel) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.session_workspace.read_result", lambda *_a: "finished the audit"
+        )
+        resp = await core_mod.api_session_agent_result(
+            _req(match_info={"id": "s1", "agent_id": "a1"})
+        )
+        body = json.loads(resp.body)
+        assert body == {"agent_id": "a1", "content": "finished the audit"}
+
+    @pytest.mark.asyncio
+    async def test_stream_emits_the_tail_then_a_done_event(
+        self, monkeypatch, fake_sel, tmp_path
+    ) -> None:
+        result = tmp_path / "agent-a1.md"
+        result.write_text("partial output\n", encoding="utf-8", newline="\n")
+        monkeypatch.setattr("kiro_crew.session_workspace.result_path", lambda *_a: result)
+
+        app = web.Application()
+        app["state"] = SimpleNamespace(
+            subagents=SimpleNamespace(get=lambda _a: SimpleNamespace(done=True))
+        )
+        app.router.add_get(
+            "/api/sessions/{id}/agents/{agent_id}/stream", core_mod.api_session_agent_stream
+        )
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/api/sessions/s1/agents/a1/stream")
+            assert resp.status == 200
+            assert resp.headers["Content-Type"].startswith("text/event-stream")
+            text = await resp.text()
+        assert "partial output" in text
+        assert "event: done" in text
+
+    @pytest.mark.asyncio
+    async def test_stream_stops_when_the_client_disconnects(
+        self, monkeypatch, fake_sel
+    ) -> None:
+        """A reset peer must end the loop, not spin for the full 20 minutes."""
+
+        def _reset(**_k):
+            raise ConnectionResetError("peer went away")
+
+        monkeypatch.setattr(
+            "kiro_crew.session_workspace.result_path",
+            lambda *_a: SimpleNamespace(exists=lambda: True, read_text=_reset),
+        )
+        app = web.Application()
+        app["state"] = SimpleNamespace(subagents=None)
+        app.router.add_get(
+            "/api/sessions/{id}/agents/{agent_id}/stream", core_mod.api_session_agent_stream
+        )
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/api/sessions/s1/agents/a1/stream")
+            assert resp.status == 200
+            assert await resp.text() == ""

--- a/test/test_dashboard_server_startup_coverage.py
+++ b/test/test_dashboard_server_startup_coverage.py
@@ -1,0 +1,541 @@
+"""Coverage tests for ``kiro_crew.dashboard.server``'s startup path.
+
+Sibling of ``test_dashboard_server_coverage.py``, which pins the module's
+extracted *helpers*. What was left uncovered is the one thing no helper test can
+reach: the body of :func:`~kiro_crew.dashboard.server.start_dashboard` itself —
+the app factory that wires every route, middleware and lifecycle hook the
+gateway serves. Nothing asserted here is reachable from a helper, because the
+wiring order and the hook/middleware inventory only exist inside that function.
+
+The listener is never bound. ``start_dashboard`` builds
+``web.TCPSite(runner, addr, port)`` and binds it inside ``_start_site``;
+constructing the site is inert, so stubbing ``_start_site`` means no host port
+is opened. That is the pattern the sibling module established for
+``start_api_server`` — AUTOSDE ``no-test-side-effects`` is ``blocking: true`` and
+an ephemeral ``port=0`` would not exempt a real bind.
+
+Everything else that reaches outside the process is replaced rather than
+tolerated: app-backend launches, the builtin-app registration sweep, the Kiro
+prerequisite probe, the Playwright registration migration (which writes the
+operator's REAL ``~/.kiro/settings/mcp.json``, outside ``KIROCREW_HOME``), the
+terminal reaper (shells out to ``ps``) and the MCP probe. ``KIROCREW_HOME`` is
+pinned to ``tmp_path`` by ``test/conftest.py``, so the state files the startup
+writes stay inside the test's own directory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import os
+import socket
+import stat
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard import server as srv
+
+requires_unix_socket = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"),
+    reason="unix sockets are POSIX-only; Windows has no AF_UNIX bind for aiohttp",
+)
+
+
+# ── _remove_stale_unix_socket ───────────────────────────────────────────
+#
+# The pre-bind self-heal. It is the one filesystem unlink on the startup path
+# that runs against a path an operator can have replaced, so each arm is a
+# distinct safety decision rather than a variation on one.
+
+
+class TestRemoveStaleUnixSocket:
+    def test_absent_path_is_not_an_error(self, tmp_path: Path) -> None:
+        """A missing socket file is the normal first-boot case, not a failure."""
+        srv._remove_stale_unix_socket(tmp_path / "never-existed.sock")
+
+    def test_a_regular_file_is_left_in_place(self, tmp_path: Path, caplog) -> None:
+        """Only a socket inode may be removed.
+
+        Anything else at the path is someone else's file: unlinking it would
+        make a mis-pointed config path silently destroy operator data, so the
+        bind is allowed to fail instead.
+        """
+        victim = tmp_path / "not-a-socket"
+        victim.write_text("operator data", encoding="utf-8", newline="\n")
+
+        with caplog.at_level("WARNING", logger=srv.logger.name):
+            srv._remove_stale_unix_socket(victim)
+
+        assert victim.read_text(encoding="utf-8") == "operator data"
+        assert "is not a socket" in caplog.text
+
+    def test_a_directory_is_left_in_place(self, tmp_path: Path) -> None:
+        """A directory is not a socket either — and unlink would raise on it."""
+        victim = tmp_path / "dir-in-the-way"
+        victim.mkdir()
+
+        srv._remove_stale_unix_socket(victim)
+
+        assert victim.is_dir()
+
+    @requires_unix_socket
+    def test_a_real_stale_socket_is_unlinked(self, tmp_path: Path) -> None:
+        """The arm that lets a restart rebind: a real socket inode is removed.
+
+        Asserted against a real ``AF_UNIX`` inode rather than a mocked
+        ``os.stat``, because the whole decision is ``S_ISSOCK`` on the real
+        mode bits.
+        """
+        path = tmp_path / "stale.sock"
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.bind(str(path))
+            assert stat.S_ISSOCK(os.stat(path).st_mode)
+
+            srv._remove_stale_unix_socket(path)
+        finally:
+            sock.close()
+
+        assert not path.exists()
+
+    @requires_unix_socket
+    def test_an_unlink_failure_is_logged_and_swallowed(
+        self, tmp_path: Path, monkeypatch, caplog
+    ) -> None:
+        """A refused unlink must degrade to TCP-only, not abort startup.
+
+        The unlink can fail on a read-only or permission-restricted data home;
+        raising here would take the whole gateway down over an optional
+        transport.
+        """
+        path = tmp_path / "stale.sock"
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.bind(str(path))
+            monkeypatch.setattr(
+                Path,
+                "unlink",
+                lambda _self, **_kw: (_ for _ in ()).throw(
+                    OSError(errno.EACCES, "permission denied")
+                ),
+            )
+
+            with caplog.at_level("WARNING", logger=srv.logger.name):
+                srv._remove_stale_unix_socket(path)
+        finally:
+            sock.close()
+
+        assert "could not remove stale dashboard socket" in caplog.text
+
+
+# ── _register_unix_socket_cleanup ───────────────────────────────────────
+
+
+class TestRegisterUnixSocketCleanup:
+    """The holder is read LAZILY at shutdown, which is the whole point.
+
+    The hook must be registered before ``runner.setup()`` freezes the signal
+    lists, but the socket path only becomes known after the site starts — so a
+    hook that captured the value eagerly would always see ``None``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_socket_means_nothing_is_removed(self) -> None:
+        """Windows and every degraded-to-TCP boot land here."""
+        app = web.Application()
+        holder: dict[str, Path | None] = {"path": None}
+        srv._register_unix_socket_cleanup(app, holder)
+        removed: list[Path] = []
+
+        async with TestClient(TestServer(app)):
+            pass
+
+        assert removed == []
+
+    @requires_unix_socket
+    @pytest.mark.asyncio
+    async def test_the_socket_named_after_registration_is_removed(
+        self, tmp_path: Path
+    ) -> None:
+        """A clean shutdown must not leave a socket file behind.
+
+        Each stale file costs the next client a refused connect before its TCP
+        fallback, so this is the difference between a clean restart and one that
+        looks broken to every internal caller.
+        """
+        path = tmp_path / "dash.sock"
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.bind(str(path))
+        sock.close()
+        app = web.Application()
+        holder: dict[str, Path | None] = {"path": None}
+
+        srv._register_unix_socket_cleanup(app, holder)
+        # Only now is the path known — exactly the ordering the lazy read exists
+        # for.
+        holder["path"] = path
+
+        async with TestClient(TestServer(app)):
+            assert path.exists()
+
+        assert not path.exists()
+
+
+# ── start_dashboard ─────────────────────────────────────────────────────
+
+
+def _neutralise_outside_process_work(monkeypatch) -> dict[str, Any]:
+    """Replace every startup step that reaches outside this process.
+
+    Returns the spies, so a test can assert a step ran without the step itself
+    launching anything. Grouped in one helper because omitting any single entry
+    does not fail the test — it silently spawns a real subprocess, writes the
+    operator's real config, or shells out to ``ps``, which is the shape of side
+    effect AUTOSDE ``no-test-side-effects`` is blocking on.
+    """
+    import kiro_crew.apps.dev_mode as dev_mode
+    import kiro_crew.kiro_prerequisite as kiro_prereq
+
+    spies: dict[str, Any] = {
+        # Spawns a real backend process per enabled app.
+        "start_enabled_app_backends": MagicMock(return_value=[]),
+        # Writes into the apps dir and re-materialises builtin manifests.
+        "register_builtin_apps": MagicMock(),
+        # Rewrites the operator's REAL ~/.kiro/settings/mcp.json — the one step
+        # here whose target is outside KIROCREW_HOME.
+        "_migrate_playwright_to_proxy": MagicMock(),
+        "cleanup_migrated_builtin": MagicMock(),
+        "on_gateway_startup": AsyncMock(),
+        "on_gateway_shutdown": AsyncMock(),
+    }
+    for name, spy in spies.items():
+        monkeypatch.setattr(srv, name, spy)
+
+    # Probes Kiro readiness by spawning sandboxed CLI subprocesses.
+    prereq = MagicMock()
+    prereq.close = AsyncMock()
+    monkeypatch.setattr(kiro_prereq, "KiroPrerequisiteService", MagicMock(return_value=prereq))
+    spies["kiro_prerequisite"] = prereq
+
+    # A filesystem watcher on the apps tree.
+    monkeypatch.setattr(dev_mode, "init_dev_mode_watcher", AsyncMock())
+    monkeypatch.setattr(dev_mode, "stop_dev_mode_watcher", AsyncMock())
+
+    # Background pollers: the terminal reaper shells out to ``ps``, the MCP
+    # probe launches every configured MCP server, and the title poller drives
+    # live PTYs. All three are fire-and-forget tasks, so a real one would
+    # outlive the test.
+    async def _noop() -> None:
+        return None
+
+    for name in ("_bg_mcp_probe", "reap_orphaned_terminals", "poll_terminal_titles"):
+        monkeypatch.setattr(srv.handlers, name, MagicMock(side_effect=lambda *_a, **_k: _noop()))
+
+    return spies
+
+
+async def _start_dashboard(tmp_path: Path, monkeypatch, **kwargs: Any) -> Any:
+    """Run the real ``start_dashboard`` without binding a listener.
+
+    ``_start_site`` is the only bind on the path, so stubbing it is what keeps
+    this from starting a service; everything else runs for real against the
+    ``tmp_path`` data home. Returns ``(runner, state, spies)``.
+    """
+    import kiro_crew.config.loader as _loader
+    import kiro_crew.dashboard.state as _st
+
+    monkeypatch.setattr(srv, "data_home", lambda: tmp_path)
+    monkeypatch.setattr(_st, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(_loader, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(srv, "_start_site", AsyncMock())
+    # POSIX-only extra transport; irrelevant to the wiring under test and it
+    # would bind a real socket in the data home.
+    monkeypatch.setattr(srv, "_start_unix_site", AsyncMock(return_value=None))
+    spies = _neutralise_outside_process_work(monkeypatch)
+
+    sessions = MagicMock(count=0)
+    sessions.remove = AsyncMock()
+    sessions.get_pid = MagicMock(return_value=None)
+    sessions.any_active_turn = MagicMock(return_value=False)
+    runner, state = await srv.start_dashboard(
+        sessions=sessions,
+        crons=MagicMock(
+            list_jobs=MagicMock(return_value=[]),
+            list_jobs_async=AsyncMock(return_value=[]),
+            status=MagicMock(return_value={}),
+        ),
+        lessons=MagicMock(load_all=MagicMock(return_value=[])),
+        port=0,
+        **kwargs,
+    )
+    return runner, state, spies
+
+
+@asynccontextmanager
+async def _dashboard(tmp_path: Path, monkeypatch, **kwargs: Any) -> Any:
+    """A fully wired dashboard app, torn down through the real cleanup path.
+
+    An ``async with`` helper rather than an ``@pytest_asyncio.fixture``, by this
+    suite's convention (the pinned pytest-asyncio does not collect async
+    generator fixtures declared with plain ``@pytest.fixture``).
+
+    The teardown is not incidental: ``runner.cleanup()`` dispatches every
+    ``on_cleanup`` hook the startup registered, so the hooks are exercised as
+    well as counted.
+
+    The task sweep afterwards is this harness's own hygiene, not a product
+    contract. Four perpetual loops the startup creates — the loop heartbeat, the
+    channel-slot reconciler, the state flush loop and the chat sweeper — have no
+    cleanup hook, because in production the process exits at shutdown. In a test
+    they would outlive the case and be reported against whichever one runs next,
+    so they are cancelled here.
+    """
+    runner, state, spies = await _start_dashboard(tmp_path, monkeypatch, **kwargs)
+    try:
+        yield runner, state, spies
+    finally:
+        await runner.cleanup()
+        await _cancel_stray_tasks()
+
+
+async def _cancel_stray_tasks() -> None:
+    """Cancel every task other than the caller's own, then await them."""
+    stray = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    for task in stray:
+        task.cancel()
+    if stray:
+        await asyncio.gather(*stray, return_exceptions=True)
+
+
+class TestStartDashboardWiring:
+    @pytest.mark.asyncio
+    async def test_the_app_is_wired_and_reports_ready(self, tmp_path, monkeypatch) -> None:
+        """Readiness is published at the boot-to-ready boundary, last.
+
+        ``state.ready`` is the flag the desktop app waits on, so it must be true
+        only once every startup step above it has completed.
+        """
+        async with _dashboard(tmp_path, monkeypatch) as (runner, state, _spies):
+            assert state.ready is True
+            assert runner.app["state"] is state
+            assert runner.app["port"] == 0
+
+    @pytest.mark.asyncio
+    async def test_the_mcp_and_dashboard_routes_are_both_mounted(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The dashboard serves the MCP surface as well as its own routes.
+
+        A missing MCP route here is invisible in a browser and breaks every MCP
+        tool call, so the inventory is asserted rather than inferred from the
+        shared ``_register_mcp_routes`` helper being called.
+        """
+        async with _dashboard(tmp_path, monkeypatch) as (runner, _state, _spies):
+            routes = {
+                (route.method, route.resource.canonical)
+                for route in runner.app.router.routes()
+                if route.resource is not None
+            }
+
+        for expected in (
+            ("POST", "/api/spawn"),
+            ("GET", "/api/crons"),
+            ("POST", "/api/send-message"),
+            ("GET", "/api/notifications"),
+            ("GET", "/api/status"),
+            ("GET", "/api/ws"),
+        ):
+            assert expected in routes, f"missing route: {expected}"
+
+    @pytest.mark.asyncio
+    async def test_the_middleware_chain_is_ordered_outermost_first(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Ordering is a security property, not a style choice.
+
+        The ``Host`` barrier must run OUTSIDE the audit middleware: aiohttp runs
+        middlewares outermost-first, and a rebinding attempt refused inside the
+        audit layer would 403 without ever being recorded (which is why
+        ``_audit_denied`` exists at all).
+        """
+        async with _dashboard(tmp_path, monkeypatch) as (runner, _state, _spies):
+            names = [
+                getattr(mw, "__name__", type(mw).__name__) for mw in runner.app.middlewares
+            ]
+
+        assert "host_validation_middleware" in names
+        assert "sel_audit_middleware" in names
+        assert names.index("host_validation_middleware") < names.index("sel_audit_middleware")
+
+    @pytest.mark.asyncio
+    async def test_a_disallowed_host_is_refused_by_the_real_chain(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """DNS-rebinding barrier, through the app's own middleware stack.
+
+        Driven in-process (``TestServer``) rather than against the production
+        listener: the same middlewares are installed on the app, and no host
+        port is bound.
+        """
+        async with _dashboard(tmp_path, monkeypatch) as (runner, _state, _spies):
+            async with TestClient(TestServer(runner.app)) as client:
+                resp = await client.get("/api/status", headers={"Host": "evil.example.com"})
+                assert resp.status == 403
+                assert "Host header not allowed" in await resp.text()
+
+    @pytest.mark.asyncio
+    async def test_security_headers_are_applied_to_a_real_response(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The header middleware is wired, not merely defined.
+
+        Checked on a real response because ``_apply_security_headers`` is
+        reached through the middleware chain — a header set on a helper nobody
+        calls protects nothing.
+        """
+        async with _dashboard(tmp_path, monkeypatch) as (runner, _state, _spies):
+            async with TestClient(TestServer(runner.app)) as client:
+                resp = await client.get("/api/status")
+                csp = resp.headers["Content-Security-Policy"]
+                assert "frame-ancestors 'self'" in csp
+                assert resp.headers["X-Content-Type-Options"] == "nosniff"
+                assert resp.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_hooks_are_registered_by_name(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Every long-lived subsystem must have a teardown hook.
+
+        Selected BY NAME: the lists are appended to as subsystems are added, so a
+        positional assertion silently repoints at whatever landed last.
+
+        The tunnel hook's *relative* position is asserted, because being ahead of
+        the others is its documented contract — ``on_cleanup`` runs in
+        registration order under a hard shutdown deadline, and a tunnel hook
+        queued behind the instances teardown (which waits on SSH children that
+        may ignore SIGTERM) can be starved, leaving the tunnel running after a
+        clean Ctrl+C. Index 0 belongs to aiohttp's own ``CleanupContext``, which
+        every ``web.Application`` registers in its constructor, so first-among-
+        product-hooks is the strongest true claim here.
+        """
+        async with _dashboard(tmp_path, monkeypatch) as (runner, _state, _spies):
+            cleanup = [hook.__name__ for hook in runner.app.on_cleanup]
+            startup = [hook.__name__ for hook in runner.app.on_startup]
+
+        later_hooks = (
+            "_instances_shutdown",
+            "_prevent_sleep_shutdown",
+            "_status_sink_shutdown",
+            "_contrib_shutdown",
+            "_kiro_prerequisite_shutdown",
+            "_watchdog_shutdown",
+            "_unlink_unix_socket",
+        )
+        for name in ("_tunnel_shutdown", *later_hooks):
+            assert name in cleanup, f"missing on_cleanup hook: {name}"
+        tunnel_at = cleanup.index("_tunnel_shutdown")
+        for name in later_hooks:
+            assert tunnel_at < cleanup.index(name), f"{name} would starve the tunnel teardown"
+        for name in ("_instances_startup", "_contrib_startup", "_hooks_startup"):
+            assert name in startup, f"missing on_startup hook: {name}"
+
+    @pytest.mark.asyncio
+    async def test_a_cross_origin_post_is_refused(self, tmp_path, monkeypatch) -> None:
+        """The CSRF barrier is installed on the real chain.
+
+        A state-changing request from a page the operator merely visited must not
+        reach a handler: loopback is not a trust boundary, so the Origin check is
+        what stands between any local web page and the gateway's own API.
+        """
+        async with _dashboard(tmp_path, monkeypatch) as (runner, _state, _spies):
+            async with TestClient(TestServer(runner.app)) as client:
+                resp = await client.post(
+                    "/api/notifications/clear",
+                    json={},
+                    headers={"Origin": "https://evil.example.com"},
+                )
+                assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_a_configured_url_joins_the_csrf_origin_set(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A published URL widens the CSRF allowlist — but only behind token auth.
+
+        The widening is guarded by an explicit re-check that the token-auth
+        middleware is installed, because ``dashboard.url`` means the dashboard is
+        reachable by something other than a loopback browser; widening the origin
+        set without authentication would accept state-changing requests from that
+        origin unauthenticated.
+        """
+        url = "http://dash.example.com:5476"
+        async with _dashboard(
+            tmp_path, monkeypatch, dashboard_url=url, local_only=False
+        ) as (runner, _state, _spies):
+            assert any(getattr(mw, "_is_token_auth", False) for mw in runner.app.middlewares)
+            assert url in runner.app["allowed_origins"]
+
+    @pytest.mark.asyncio
+    async def test_the_playwright_migration_never_touches_the_real_settings(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The migration is scheduled as a background task, so it must be awaited.
+
+        It rewrites ``~/.kiro/settings/mcp.json`` — the operator's real file,
+        outside ``KIROCREW_HOME`` — so this test's value is proving the stub is
+        what ran. Without the stub the suite would silently edit the developer's
+        machine.
+        """
+        runner, _state, spies = await _start_dashboard(tmp_path, monkeypatch)
+        try:
+            # The migration runs in a task created during startup; yield until
+            # the loop has drained it.
+            for _ in range(50):
+                if spies["_migrate_playwright_to_proxy"].called:
+                    break
+                await asyncio.sleep(0)
+        finally:
+            await runner.cleanup()
+            await _cancel_stray_tasks()
+
+        assert spies["_migrate_playwright_to_proxy"].called
+
+    @pytest.mark.asyncio
+    async def test_cleanup_stops_the_tunnel_it_never_started(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """No manager is built when the tunnel is disabled, so the provider is
+        stopped directly.
+
+        The on-demand link path provisions a tunnel straight on the provider and
+        never constructs a manager, so a hook that bailed out on
+        ``state.tunnel_manager is None`` left exactly the orphan it exists to
+        prevent.
+        """
+        provider = SimpleNamespace(stop=AsyncMock(), enabled=lambda: False)
+        monkeypatch.setattr(
+            srv,
+            "current_context",
+            lambda: SimpleNamespace(
+                tunnel=provider,
+                telemetry=SimpleNamespace(record_event=lambda *_a, **_k: None),
+                dashboard=SimpleNamespace(
+                    start_services=AsyncMock(), stop_services=AsyncMock()
+                ),
+            ),
+        )
+
+        runner, state, _spies = await _start_dashboard(tmp_path, monkeypatch)
+        assert state.tunnel_manager is None
+        await runner.cleanup()
+        await _cancel_stray_tasks()
+
+        provider.stop.assert_awaited()

--- a/test/test_deploy_handlers_coverage.py
+++ b/test/test_deploy_handlers_coverage.py
@@ -1,0 +1,1566 @@
+"""Coverage tests for ``kiro_crew.deploy.handlers`` error/refusal branches.
+
+Focus is the paths the existing deploy suites never reach: the redaction
+helpers, ``_scan_tree`` fail-closed findings, ``_stage_tree_safe`` rejections,
+the ``_do_deploy``/``_do_recall``/``_do_destroy`` refusal returns, the profile
+control-plane 400/404s, ``_expire_manifest_best_effort``'s "unreachable"
+ladder, the teardown preconditions and the pending-confirm guards.
+
+Everything is stubbed at the ``engine.run_aws`` / store boundary -- no AWS
+call, no network, no real subprocess, and every filesystem write lands under
+``tmp_path``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kiro_crew.deploy import engine, handlers
+from kiro_crew.deploy import profiles as profiles_mod
+
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only symlink/permission semantics (reduced Windows backend scope)",
+)
+
+
+@pytest.fixture(autouse=True)
+def _force_posix_shell(monkeypatch):
+    """Neutralise the handlers' module-local ``os.name == "nt"`` platform gate.
+
+    Patches a handlers-module-local ``os`` proxy (never the global ``os.name``)
+    so pathlib keeps selecting real platform behaviour on a Windows runner.
+    """
+
+    class _PosixNameOs:
+        name = "posix"
+
+        def __getattr__(self, attr):  # pragma: no cover - trivial delegation
+            return getattr(os, attr)
+
+    monkeypatch.setattr(handlers, "os", _PosixNameOs())
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(tmp_path: Path, monkeypatch):
+    """Redirect every deploy-module config_dir() and KIROCREW_HOME to tmp_path."""
+    import kiro_crew.deploy as _deploy_pkg
+    from kiro_crew.deploy import pending as _pending_mod
+
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr(handlers, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(profiles_mod, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(_pending_mod, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(_deploy_pkg, "config_dir", lambda: tmp_path)
+    return tmp_path
+
+
+class _NonRestrictedState:
+    """Minimal dashboard state that passes ``_deny_restricted``."""
+
+    _restricted_keys: set = set()
+    _slots: dict = {}
+
+
+class _FakeReq:
+    """Request double with a non-restricted app state installed."""
+
+    def __init__(self, body=None, *, match_info=None, query=None, headers=None):
+        self._body = {} if body is None else body
+        self.headers = headers if headers is not None else {"X-Session-Key": "dashboard:ui"}
+        self.app = {"state": _NonRestrictedState()}
+        self.match_info = match_info or {}
+        self.query = query or {}
+        self.rel_url = SimpleNamespace(query=self.query)
+
+    async def json(self):
+        if isinstance(self._body, str):
+            raise json.JSONDecodeError("bad", self._body, 0)
+        return self._body
+
+    async def read(self):
+        if isinstance(self._body, str):
+            return self._body.encode()
+        return json.dumps(self._body).encode()
+
+
+def _payload(resp):
+    return json.loads(resp.body.decode())
+
+
+def _aws_router(routes, default=(0, "", "")):
+    """Build a ``run_aws`` stub dispatching on a substring of the joined argv."""
+
+    def _run_aws(argv, profile="", timeout=15, *a, **kw):
+        joined = " ".join(str(x) for x in argv)
+        for needle, result in routes:
+            if needle in joined:
+                return result
+        return default
+
+    return _run_aws
+
+
+_BASE_OUTPUTS = json.dumps([{"OutputKey": "BucketName", "OutputValue": "base-bucket"}])
+
+
+def _deny_stat(monkeypatch, filename: str) -> None:
+    """Make ``Path.stat`` fail for one file while ``is_file`` still says True.
+
+    ``Path.is_file`` is implemented on top of ``Path.stat``, so patching only
+    ``stat`` makes the walker's ``is_file()`` raise instead of reaching the
+    handler's own ``stat`` call site. Patch both.
+    """
+    real_stat = Path.stat
+    real_is_file = Path.is_file
+
+    def _stat(self, *a, **kw):
+        if self.name == filename:
+            raise OSError("stat denied")
+        return real_stat(self, *a, **kw)
+
+    def _is_file(self, *a, **kw):
+        if self.name == filename:
+            return True
+        return real_is_file(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "stat", _stat)
+    monkeypatch.setattr(Path, "is_file", _is_file)
+
+
+# --- redaction / small helpers ---------------------------------------------
+
+
+class TestHelpers:
+    def test_redact_pending_entries_recurses_one_level(self):
+        out = handlers._redact_pending_entries([
+            {"site_id": "s", "nested": {"a": "plain", "b": 3}, "n": 7, "empty": ""},
+        ])
+        assert out[0]["nested"] == {"a": "plain", "b": 3}
+        assert out[0]["n"] == 7
+        assert out[0]["empty"] == ""
+
+    def test_redact_profile_fields_keeps_non_strings(self):
+        out = handlers._redact_profile_fields([{"name": "p", "n": 1, "blank": ""}])
+        assert out == [{"name": "p", "n": 1, "blank": ""}]
+
+    def test_sanitize_response_walks_lists_and_scalars(self):
+        assert handlers._sanitize_response([{"a": ["x"]}, 5, None]) == [{"a": ["x"]}, 5, None]
+
+    def test_data_dir_under_config_dir(self, tmp_path: Path):
+        assert handlers._data_dir() == tmp_path / "deploy"
+
+    def test_safe_resolve_falls_back_on_oserror(self):
+        class _Boom:
+            def resolve(self):
+                raise OSError("nope")
+
+        boom = _Boom()
+        assert handlers._safe_resolve(boom) is boom
+
+    def test_reaper_remediation_omits_empty_flags(self):
+        assert handlers._reaper_remediation("", "") == "install-reaper.sh"
+        assert "--profile p" in handlers._reaper_remediation("p", "us-west-2")
+
+    def test_safe_site_id_strips_and_truncates(self):
+        assert handlers._safe_site_id("  My Site!!  ") == "my-site"
+        assert len(handlers._safe_site_id("a" * 200)) == handlers._SITE_ID_MAX
+
+    def test_load_config_with_empty_registry(self):
+        assert handlers._load_config() == {
+            "profile": "", "region": handlers.DEFAULT_REGION}
+
+    def test_save_config_updates_existing_entry_region(self):
+        handlers._save_config("p", "us-west-2")
+        handlers._save_config("p", "eu-west-1")
+        assert handlers._load_config() == {"profile": "p", "region": "eu-west-1"}
+
+    def test_save_config_empty_profile_clears_default(self):
+        handlers._save_config("p", "us-west-2")
+        handlers._save_config("", "")
+        assert handlers._load_config()["profile"] == ""
+
+
+class TestAllowedLocalRoots:
+    def test_config_load_failure_degrades_to_fallback(self, monkeypatch, tmp_path: Path):
+        from kiro_crew.config import loader as loader_mod
+
+        class _Boom:
+            @staticmethod
+            def load():
+                raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr(loader_mod, "KiroCrewConfig", _Boom)
+        (tmp_path / "workspace").mkdir()
+        roots = handlers._allowed_local_roots()
+        # config_dir()/workspace is always allowed, even with no usable config.
+        assert any(os.path.realpath(str(r)) == os.path.realpath(str(tmp_path / "workspace"))
+                   for r in roots)
+
+    def test_configured_roots_are_included(self, monkeypatch, tmp_path: Path):
+        from kiro_crew.config import loader as loader_mod
+
+        allowed = tmp_path / "cfgroot"
+        allowed.mkdir()
+        cfg = SimpleNamespace(
+            agent=SimpleNamespace(subagent_cwd_allowed_roots=[str(allowed), "/nonexistent-xyz"]),
+            workspaces={},
+        )
+        monkeypatch.setattr(loader_mod, "KiroCrewConfig", SimpleNamespace(load=lambda: cfg))
+        roots = handlers._allowed_local_roots()
+        assert any(os.path.realpath(str(r)) == os.path.realpath(str(allowed)) for r in roots)
+
+    def test_registered_workspaces_are_included(self, monkeypatch, tmp_path: Path):
+        from kiro_crew.config import loader as loader_mod
+
+        ws = tmp_path / "ws1"
+        ws.mkdir()
+        cfg = SimpleNamespace(
+            agent=SimpleNamespace(subagent_cwd_allowed_roots=[str(tmp_path)]),
+            workspaces={"w": SimpleNamespace(dir=str(ws))},
+        )
+        monkeypatch.setattr(loader_mod, "KiroCrewConfig", SimpleNamespace(load=lambda: cfg))
+        roots = handlers._allowed_local_roots()
+        real = {os.path.realpath(str(r)) for r in roots}
+        assert os.path.realpath(str(ws)) in real
+
+    def test_staging_root_failure_is_swallowed(self, monkeypatch, tmp_path: Path):
+        def _boom():
+            raise OSError("no staging")
+
+        monkeypatch.setattr(handlers, "_staging_root", _boom)
+        assert isinstance(handlers._allowed_local_roots(), list)
+
+
+# --- scan / staging --------------------------------------------------------
+
+
+class TestScanTree:
+    def test_large_file_becomes_unscanned_finding(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(handlers, "_SCAN_SIZE_LIMIT", 8)
+        src = tmp_path / "site"
+        src.mkdir()
+        (src / "sub").mkdir()
+        (src / "big.bin").write_bytes(b"0123456789")
+        findings, size = handlers._scan_tree(src)
+        kinds = {f.kind for f in findings}
+        assert "unscanned-large-file" in kinds
+        assert size == 10
+
+    def test_hook_denied_file_is_a_credential_finding(self, tmp_path: Path, monkeypatch):
+        from kiro_crew import hooks as hooks_mod
+
+        src = tmp_path / "site"
+        src.mkdir()
+        (src / "index.html").write_text("<p>hi</p>", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(hooks_mod, "safe_read_file_bytes", lambda *a, **kw: None)
+        findings, _size = handlers._scan_tree(src)
+        assert [f.kind for f in findings] == ["hook-denied"]
+
+    def test_unstattable_file_becomes_unreadable_finding(self, tmp_path: Path, monkeypatch):
+        src = tmp_path / "site"
+        src.mkdir()
+        (src / "index.html").write_text("<p>hi</p>", encoding="utf-8", newline="\n")
+        _deny_stat(monkeypatch, "index.html")
+        findings, size = handlers._scan_tree(src)
+        assert [f.kind for f in findings] == ["unreadable-file"]
+        assert size == 0
+
+    @_POSIX_ONLY
+    def test_symlink_escape_is_reported_and_never_read(self, tmp_path: Path):
+        outside = tmp_path / "outside.txt"
+        outside.write_text("secret", encoding="utf-8", newline="\n")
+        src = tmp_path / "site"
+        src.mkdir()
+        os.symlink(str(outside), str(src / "link.txt"))
+        findings, _size = handlers._scan_tree(src)
+        assert "symlink-escape" in {f.kind for f in findings}
+
+    def test_dir_contains_sensitive_detects_child(self, tmp_path: Path, monkeypatch):
+        src = tmp_path / "site"
+        src.mkdir()
+        child = src / "creds"
+        child.write_text("x", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(
+            handlers, "is_sensitive_path",
+            lambda p: os.path.basename(str(p)) == "creds")
+        assert handlers._dir_contains_sensitive(src, src) is True
+
+    def test_compute_tree_size_global_ignores_stat_errors(self, tmp_path: Path, monkeypatch):
+        src = tmp_path / "site"
+        src.mkdir()
+        (src / "a.txt").write_text("abc", encoding="utf-8", newline="\n")
+        _deny_stat(monkeypatch, "a.txt")
+        assert handlers._compute_tree_size_global(src) == 0
+
+    def test_compute_content_digest_ignores_unreadable_files(self, tmp_path: Path, monkeypatch):
+        src = tmp_path / "site"
+        src.mkdir()
+        (src / "a.txt").write_text("abc", encoding="utf-8", newline="\n")
+        real_read = Path.read_bytes
+
+        def _read(self, *a, **kw):
+            if self.name == "a.txt":
+                raise OSError("denied")
+            return real_read(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "read_bytes", _read)
+        empty = handlers._compute_content_digest(str(tmp_path / "site"))
+        assert isinstance(empty, str) and len(empty) == 64
+
+    def test_stage_artifact_html_refuses_webapp_kind(self):
+        with pytest.raises(ValueError, match="webapp artifacts"):
+            handlers._stage_artifact_html("webapp", "summary", "app")
+
+
+class TestStageTreeSafe:
+    @_POSIX_ONLY
+    def test_symlinked_directory_blocks_staging(self, tmp_path: Path):
+        src = tmp_path / "site"
+        src.mkdir()
+        real_dir = tmp_path / "elsewhere"
+        real_dir.mkdir()
+        os.symlink(str(real_dir), str(src / "linkdir"))
+        with pytest.raises(RuntimeError, match="symlinked directory"):
+            handlers._stage_tree_safe(src, tmp_path / "stage")
+
+    def test_unstattable_file_blocks_staging(self, tmp_path: Path, monkeypatch):
+        src = tmp_path / "site"
+        src.mkdir()
+        (src / "a.txt").write_text("x", encoding="utf-8", newline="\n")
+        real_lstat = os.lstat
+
+        def _lstat(path, *a, **kw):
+            if str(path).endswith("a.txt"):
+                raise OSError("stat denied")
+            return real_lstat(path, *a, **kw)
+
+        monkeypatch.setattr(os, "lstat", _lstat)
+        with pytest.raises(RuntimeError, match="hardlink-in-tree: cannot stat"):
+            handlers._stage_tree_safe(src, tmp_path / "stage")
+
+    def test_hook_refusal_blocks_staging(self, tmp_path: Path, monkeypatch):
+        from kiro_crew import hooks as hooks_mod
+
+        src = tmp_path / "site"
+        src.mkdir()
+        (src / "a.txt").write_text("x", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(
+            hooks_mod, "safe_read_file_bytes_nolink", lambda *a, **kw: None)
+        with pytest.raises(RuntimeError, match="staging-read-blocked"):
+            handlers._stage_tree_safe(src, tmp_path / "stage")
+
+    def test_too_large_file_blocks_staging(self, tmp_path: Path, monkeypatch):
+        from kiro_crew import hooks as hooks_mod
+
+        src = tmp_path / "site"
+        src.mkdir()
+        (src / "a.txt").write_text("x", encoding="utf-8", newline="\n")
+
+        def _raise(*a, **kw):
+            raise hooks_mod.FileTooLargeError("over the per-file cap")
+
+        monkeypatch.setattr(hooks_mod, "safe_read_file_bytes_nolink", _raise)
+        with pytest.raises(RuntimeError, match="file-too-large"):
+            handlers._stage_tree_safe(src, tmp_path / "stage")
+
+    @_POSIX_ONLY
+    def test_staging_root_rejects_symlink(self, tmp_path: Path, monkeypatch):
+        real = tmp_path / "real-staging"
+        real.mkdir()
+        link_parent = tmp_path / "cfg"
+        link_parent.mkdir()
+        os.symlink(str(real), str(link_parent / "deploy-staging"))
+        monkeypatch.setattr(handlers, "config_dir", lambda: link_parent)
+        with pytest.raises(RuntimeError, match="symlink"):
+            handlers._staging_root()
+
+
+# --- _do_deploy refusal ladder ---------------------------------------------
+
+
+@pytest.fixture
+def _site(tmp_path: Path, monkeypatch):
+    """An allow-listed source directory holding one clean page."""
+    src = tmp_path / "site"
+    src.mkdir()
+    (src / "index.html").write_text("<h1>hi</h1>", encoding="utf-8", newline="\n")
+    monkeypatch.setattr(handlers, "_allowed_local_roots", lambda: [tmp_path])
+    return src
+
+
+class TestDoDeployRefusals:
+    # Every test below hands `_do_deploy` a real filesystem path as local_dir.
+    # That field is charset-validated against
+    #     _LOCAL_DIR_RE = ^[A-Za-z0-9 _\-./~]+$
+    # which admits POSIX path characters only. A native Windows absolute path
+    # (``C:\Users\runneradmin\...``) contains ':' and '\', so validation refuses
+    # it with "invalid local_dir: local_dir: invalid format" BEFORE any of the
+    # branches these tests target is reached -- the refusal short-circuits, and
+    # a test aimed at, say, the ttl_hours range then sees the local_dir error
+    # instead of its own.
+    #
+    # That is a PRODUCT defect, not a test artefact: deploy cannot accept any
+    # local directory on Windows. Widening a charset allowlist that guards a
+    # path flowing into an `aws s3 sync` subprocess is a security-relevant
+    # change and does not belong in a tests-only change, so it is reported
+    # rather than fixed here. These tests are POSIX-only until it is fixed;
+    # they will start covering Windows for free once the pattern accepts
+    # native paths.
+    pytestmark = pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="deploy's _LOCAL_DIR_RE rejects native Windows paths (product defect)",
+    )
+
+    @pytest.mark.asyncio
+    async def test_missing_site_id(self):
+        handlers._save_config("p", "us-west-2")
+        status, payload = await handlers._do_deploy({"local_dir": "/tmp"})
+        assert status == 400 and payload["error"] == "site_id is required"
+
+    @pytest.mark.asyncio
+    async def test_unregistered_profile_is_refused(self):
+        handlers._save_config("p", "us-west-2")
+        status, payload = await handlers._do_deploy({"site_id": "s", "profile": "ghost"})
+        assert status == 400 and "not registered" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_profile_charset_is_refused(self):
+        handlers._save_config("p", "us-west-2")
+        status, payload = await handlers._do_deploy({"site_id": "s", "profile": "a;rm -rf"})
+        assert status == 400 and "invalid profile" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_no_source_supplied(self):
+        handlers._save_config("p", "us-west-2")
+        status, payload = await handlers._do_deploy({"site_id": "s"})
+        assert status == 400 and payload["error"] == "provide artifact_slug or local_dir"
+
+    @pytest.mark.asyncio
+    async def test_both_sources_supplied(self, tmp_path: Path):
+        handlers._save_config("p", "us-west-2")
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "artifact_slug": "a1", "local_dir": str(tmp_path)})
+        assert status == 400 and "exactly one" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_artifact_slug(self):
+        handlers._save_config("p", "us-west-2")
+        status, payload = await handlers._do_deploy({"site_id": "s", "artifact_slug": "-bad!"})
+        assert status == 400 and "invalid artifact_slug" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_artifact_store_unavailable(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(handlers, "_HAS_ARTIFACTS", False)
+        status, payload = await handlers._do_deploy({"site_id": "s", "artifact_slug": "a1"})
+        assert status == 500 and payload["error"] == "artifact store unavailable"
+
+    @pytest.mark.asyncio
+    async def test_invalid_local_dir_charset(self):
+        handlers._save_config("p", "us-west-2")
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": "/tmp/$(whoami)"})
+        assert status == 400 and "invalid local_dir" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_relative_local_dir(self):
+        handlers._save_config("p", "us-west-2")
+        status, payload = await handlers._do_deploy({"site_id": "s", "local_dir": "site/public"})
+        assert status == 400 and payload["error"] == "local_dir must be an absolute path"
+
+    @pytest.mark.asyncio
+    async def test_local_dir_not_a_directory(self, tmp_path: Path):
+        handlers._save_config("p", "us-west-2")
+        f = tmp_path / "a.txt"
+        f.write_text("x", encoding="utf-8", newline="\n")
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(f)})
+        assert status == 400 and "local_dir not found" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_local_dir_outside_allowed_roots(self, tmp_path: Path, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        monkeypatch.setattr(handlers, "_allowed_local_roots", lambda: [tmp_path / "only"])
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(outside)})
+        assert status == 400 and "must resolve within" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_sensitive_local_dir_is_refused(self, _site, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(handlers, "_dir_contains_sensitive", lambda *a: True)
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site)})
+        assert status == 400 and "sensitive credential path" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_tagged_staging_rejection_becomes_409(self, _site, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+
+        def _boom():
+            raise RuntimeError("hardlink-in-tree: a.txt has nlink=2 — deploy blocked")
+
+        monkeypatch.setattr(handlers, "_staging_root", _boom)
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site)})
+        assert status == 409
+        assert payload["blocked"] is True and payload["credential"] is True
+        assert "hardlink-in-tree" in payload["message"]
+
+    @pytest.mark.asyncio
+    async def test_untagged_staging_error_is_not_swallowed(self, _site, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+
+        def _boom():
+            raise RuntimeError("disk on fire")
+
+        monkeypatch.setattr(handlers, "_staging_root", _boom)
+        with pytest.raises(RuntimeError, match="disk on fire"):
+            await handlers._do_deploy({"site_id": "s", "local_dir": str(_site)})
+
+    @pytest.mark.asyncio
+    async def test_scan_failure_cleans_staging_and_propagates(self, _site, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+
+        def _boom(_src):
+            raise ValueError("scanner exploded")
+
+        monkeypatch.setattr(handlers, "_scan_tree", _boom)
+        with pytest.raises(ValueError, match="scanner exploded"):
+            await handlers._do_deploy({"site_id": "s", "local_dir": str(_site)})
+
+    @pytest.mark.asyncio
+    async def test_overridable_findings_block_without_override(self, _site, monkeypatch):
+        from kiro_crew.deploy.scan import Finding
+
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(
+            handlers, "_scan_tree",
+            lambda _src: ([Finding(kind="internal-host", snippet="host", line=1,
+                                   severity="info")], 11))
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site)})
+        assert status == 409 and payload["count"] == 1
+        assert payload["content_digest"] and payload["profile"] == "p"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("raw,needle", [
+        (True, "got bool"),
+        (12.5, "not float"),
+        ("12", "got str"),
+        (-1, "non-negative"),
+        (9000, "0-8760"),
+    ])
+    async def test_ttl_hours_validation(self, _site, raw, needle):
+        handlers._save_config("p", "us-west-2")
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site), "ttl_hours": raw})
+        assert status == 400 and needle in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_base_stack_blocks_finite_ttl(self, _site, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "run_aws", _aws_router([], default=(1, "", "no stack")))
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site), "confirm": True})
+        assert status == 409
+        assert payload["remediation"].startswith("install-reaper.sh")
+
+    @pytest.mark.asyncio
+    async def test_base_stack_parse_error_is_swallowed(self, _site, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(
+            engine, "run_aws", _aws_router([("describe-stacks", (0, "not-json", ""))]))
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site), "confirm": True})
+        assert status == 409 and "reaper base stack" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_reaper_stack_blocks_finite_ttl(self, _site, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "run_aws", _aws_router([
+            ("kirocrew-deploy-base", (0, _BASE_OUTPUTS, "")),
+            ("kirocrew-deploy-reaper", (1, "", "missing")),
+        ]))
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site), "confirm": True})
+        assert status == 409 and "kirocrew-deploy-reaper" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_reaper_probe_exception_blocks_finite_ttl(self, _site, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+
+        def _run_aws(argv, *a, **kw):
+            joined = " ".join(str(x) for x in argv)
+            if "kirocrew-deploy-reaper" in joined:
+                raise OSError("aws missing")
+            return (0, _BASE_OUTPUTS, "")
+
+        monkeypatch.setattr(engine, "run_aws", _run_aws)
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site), "confirm": True})
+        assert status == 409 and "kirocrew-deploy-reaper" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_stale_preview_digest_is_refused(self, _site, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "run_aws", _aws_router([
+            ("kirocrew-deploy-base", (0, _BASE_OUTPUTS, "")),
+        ]))
+        status, payload = await handlers._do_deploy({
+            "site_id": "s", "local_dir": str(_site), "confirm": True,
+            "expected_content_digest": "deadbeef",
+        })
+        assert status == 409 and payload["code"] == "stale_preview"
+
+    @pytest.mark.asyncio
+    async def test_aws_error_becomes_502(self, _site, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "run_aws", _aws_router([
+            ("kirocrew-deploy-base", (0, _BASE_OUTPUTS, "")),
+        ]))
+
+        def _deploy(*a, **kw):
+            raise engine.AWSError("AccessDenied on s3:PutObject",
+                                  missing_statement="s3:PutObject")
+
+        monkeypatch.setattr(engine, "deploy", _deploy)
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site), "confirm": True, "ttl_hours": 0})
+        assert status == 502 and payload["missing_statement"] == "s3:PutObject"
+
+
+class TestDoDeployManifestFailure:
+    # POSIX-only for the same reason as TestDoDeployRefusals: these tests pass a
+    # real filesystem path as local_dir, and deploy's _LOCAL_DIR_RE admits only
+    # POSIX path characters, so a native Windows path is refused before the
+    # manifest branch under test is reached. Product defect, reported not fixed.
+    pytestmark = pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="deploy's _LOCAL_DIR_RE rejects native Windows paths (product defect)",
+    )
+
+    """The TTL manifest is the reaper's only input -- a failed write must not
+    leave a finite-TTL deploy live and reported as successful."""
+
+    def _arm(self, monkeypatch, *, manifest_rc=1, manifest_raises=False):
+        handlers._save_config("p", "us-west-2")
+
+        def _run_aws(argv, *a, **kw):
+            joined = " ".join(str(x) for x in argv)
+            if "kirocrew-deploy-base" in joined:
+                return (0, _BASE_OUTPUTS, "")
+            if joined.startswith("s3 cp"):
+                if manifest_raises:
+                    raise OSError("aws cli gone")
+                return (manifest_rc, "", "denied")
+            return (0, "CREATE_COMPLETE", "")
+
+        monkeypatch.setattr(engine, "run_aws", _run_aws)
+        monkeypatch.setattr(engine, "deploy", lambda *a, **kw: {
+            "url": "https://d1.cloudfront.net/s/", "bucket": "site-bucket",
+            "distribution_id": "D1", "oac_id": "O1"})
+
+    @pytest.mark.asyncio
+    async def test_finite_ttl_manifest_failure_rolls_back(self, _site, monkeypatch):
+        self._arm(monkeypatch)
+        recalled = []
+        monkeypatch.setattr(engine, "recall",
+                            lambda slug, *a, **kw: recalled.append(slug))
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site), "confirm": True, "ttl_hours": 24})
+        assert status == 502 and payload["rolled_back"] is True
+        assert recalled == ["s"]
+
+    @pytest.mark.asyncio
+    async def test_rollback_failure_is_reported_not_raised(self, _site, monkeypatch):
+        self._arm(monkeypatch)
+
+        def _recall(*a, **kw):
+            raise engine.AWSError("cannot empty bucket")
+
+        monkeypatch.setattr(engine, "recall", _recall)
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site), "confirm": True, "ttl_hours": 24})
+        assert status == 502 and payload["rolled_back"] is False
+
+    @pytest.mark.asyncio
+    async def test_manifest_write_exception_counts_as_failure(self, _site, monkeypatch):
+        self._arm(monkeypatch, manifest_raises=True)
+        monkeypatch.setattr(engine, "recall", lambda *a, **kw: None)
+        status, _payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site), "confirm": True, "ttl_hours": 24})
+        assert status == 502
+
+    @pytest.mark.asyncio
+    async def test_persistent_deploy_only_warns(self, _site, monkeypatch):
+        self._arm(monkeypatch)
+        status, payload = await handlers._do_deploy(
+            {"site_id": "s", "local_dir": str(_site), "confirm": True, "ttl_hours": 0})
+        assert status == 200
+        assert "TTL manifest upload failed" in payload["warning"]
+
+
+# --- recall / destroy / list ------------------------------------------------
+
+
+class TestRecallDestroy:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("fn", ["_do_recall", "_do_destroy"])
+    async def test_unresolvable_profile(self, fn):
+        status, payload = await getattr(handlers, fn)({"site_id": "s"})
+        assert status == 400 and "not configured" in payload["error"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("fn", ["_do_recall", "_do_destroy"])
+    async def test_missing_site_id(self, fn):
+        handlers._save_config("p", "us-west-2")
+        status, payload = await getattr(handlers, fn)({})
+        assert status == 400 and payload["error"] == "site_id is required"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("fn", ["_do_recall", "_do_destroy"])
+    async def test_preview_unknown_site_is_404(self, fn, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "find_site_by_tag", lambda *a, **kw: {})
+        status, payload = await getattr(handlers, fn)({"site_id": "s"})
+        assert status == 404 and payload["error"] == "no site 's'"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("fn", ["_do_recall", "_do_destroy"])
+    async def test_confirm_against_vanished_site_is_404(self, fn, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "find_site_by_tag", lambda *a, **kw: {})
+        status, payload = await getattr(handlers, fn)(
+            {"site_id": "s", "confirm": True, "expected_distribution_id": "D1"})
+        assert status == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("fn", ["_do_recall", "_do_destroy"])
+    async def test_recreated_resources_refuse_stale_confirm(self, fn, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "find_site_by_tag",
+                            lambda *a, **kw: {"distribution_id": "D2", "bucket": "b2"})
+        status, payload = await getattr(handlers, fn)({
+            "site_id": "s", "confirm": True,
+            "expected_distribution_id": "D1", "expected_bucket": "b1",
+        })
+        assert status == 409 and "changed since preview" in payload["error"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("fn,verb", [("_do_recall", "recall"), ("_do_destroy", "destroy")])
+    async def test_aws_error_becomes_502(self, fn, verb, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+
+        def _boom(*a, **kw):
+            raise engine.AWSError("AccessDenied", missing_statement="s3:DeleteObject")
+
+        monkeypatch.setattr(engine, verb, _boom)
+        status, payload = await getattr(handlers, fn)({"site_id": "s", "confirm": True})
+        assert status == 502 and payload["missing_statement"] == "s3:DeleteObject"
+
+    @pytest.mark.asyncio
+    async def test_destroy_preview_names_the_resources(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "find_site_by_tag",
+                            lambda *a, **kw: {"distribution_id": "D1", "bucket": "b1"})
+        status, payload = await handlers._do_destroy({"site_id": "s"})
+        assert status == 200 and payload["destructive"] is True
+        assert "b1" in payload["message"] and "D1" in payload["message"]
+
+
+class TestDoList:
+    @pytest.mark.asyncio
+    async def test_windows_returns_structured_unsupported(self, monkeypatch):
+        class _NtOs:
+            name = "nt"
+
+            def __getattr__(self, attr):  # pragma: no cover - delegation
+                return getattr(os, attr)
+
+        monkeypatch.setattr(handlers, "os", _NtOs())
+        status, payload = await handlers._do_list()
+        assert status == 200 and payload["configured"] is False
+        assert "not supported on Windows" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_registry(self):
+        status, payload = await handlers._do_list()
+        assert status == 200 and payload == {"sites": [], "configured": False}
+
+    @pytest.mark.asyncio
+    async def test_per_profile_failure_degrades_to_warning(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+
+        def _boom(*a, **kw):
+            raise KeyError("region")
+
+        monkeypatch.setattr(engine, "list_sites", _boom)
+        status, payload = await handlers._do_list()
+        assert status == 200 and payload["sites"] == []
+        assert payload["profile_errors"] and "p:" in payload["profile_errors"][0]
+
+    @pytest.mark.asyncio
+    async def test_aws_error_degrades_to_warning(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+
+        def _boom(*a, **kw):
+            raise engine.AWSError("expired credentials")
+
+        monkeypatch.setattr(engine, "list_sites", _boom)
+        _status, payload = await handlers._do_list()
+        assert "expired credentials" in payload["profile_errors"][0]
+
+    @pytest.mark.asyncio
+    async def test_sites_are_deduped_by_distribution_id(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        handlers._save_config("q", "us-west-2")
+        monkeypatch.setattr(
+            engine, "list_sites",
+            lambda *a, **kw: [{"site_id": "s", "distribution_id": "D1"}])
+        _status, payload = await handlers._do_list()
+        assert len(payload["sites"]) == 1
+
+
+# --- aiohttp adapters -------------------------------------------------------
+
+
+class TestAdapters:
+    @pytest.mark.asyncio
+    async def test_json_body_tolerates_invalid_json(self):
+        assert await handlers._json_body(_FakeReq("not json")) == {}
+
+    @pytest.mark.asyncio
+    async def test_json_body_rejects_non_object(self):
+        assert await handlers._json_body(_FakeReq([1, 2])) == {}
+
+    @pytest.mark.asyncio
+    async def test_get_config_returns_registry_default(self):
+        handlers._save_config("p", "eu-west-1")
+        resp = await handlers._handle_get_config(_FakeReq())
+        assert _payload(resp) == {"profile": "p", "region": "eu-west-1"}
+
+    @pytest.mark.asyncio
+    async def test_deny_restricted_without_app_context(self):
+        req = _FakeReq()
+        req.app = None
+        resp = await handlers._handle_put_config(req)
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_deny_restricted_without_dashboard_state(self):
+        req = _FakeReq()
+        req.app = {}
+        resp = await handlers._handle_put_config(req)
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_internal_secret_caller_is_denied(self):
+        req = _FakeReq(headers={"X-Internal-Secret": "s"})
+        resp = await handlers._handle_recall(req)
+        assert resp.status == 403
+        assert "internal-secret callers" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_strip_confirm_for_internal_removes_both_flags(self):
+        req = _FakeReq(headers={"X-Internal-Secret": "s"})
+        out = handlers._strip_confirm_for_internal(
+            req, {"confirm": True, "override_scan": True, "site_id": "s"})
+        assert out == {"site_id": "s"}
+
+    @pytest.mark.asyncio
+    async def test_recall_adapter_serializes_payload(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "find_site_by_tag", lambda *a, **kw: {})
+        resp = await handlers._handle_recall(_FakeReq({"site_id": "s"}))
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_destroy_adapter_serializes_payload(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "find_site_by_tag", lambda *a, **kw: {})
+        resp = await handlers._handle_destroy(_FakeReq({"site_id": "s"}))
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_list_adapter(self):
+        resp = await handlers._handle_list(_FakeReq())
+        assert resp.status == 200 and _payload(resp)["configured"] is False
+
+    @pytest.mark.asyncio
+    async def test_iam_policy_rejects_unknown_tier(self):
+        resp = await handlers._handle_iam_policy(_FakeReq(query={"tier": "serverless"}))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_iam_policy_static_tier(self):
+        resp = await handlers._handle_iam_policy(_FakeReq(query={}))
+        body = _payload(resp)
+        assert "policy" in body and "boundary_policy" not in body
+
+    @pytest.mark.asyncio
+    async def test_iam_policy_fullstack_adds_boundary(self):
+        resp = await handlers._handle_iam_policy(
+            _FakeReq(query={"tier": "fullstack", "custom_domain": "true"}))
+        body = _payload(resp)
+        assert body["boundary_policy_name"] and json.loads(body["boundary_policy"])
+
+    @pytest.mark.asyncio
+    async def test_verify_rejects_unresolvable_profile(self):
+        resp = await handlers._handle_verify(_FakeReq({"profile": "ghost"}))
+        assert resp.status == 400 and _payload(resp)["reachable"] is False
+
+    @pytest.mark.asyncio
+    async def test_verify_backfills_account_on_success(self, monkeypatch):
+        from kiro_crew.deploy import iam as iam_mod
+
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(iam_mod, "reachability_check",
+                            lambda profile: {"reachable": True, "account": "111122223333"})
+        resp = await handlers._handle_verify(_FakeReq({}))
+        assert _payload(resp)["profile"] == "p"
+        reg = profiles_mod.load_registry()
+        entry = profiles_mod.get_entry(reg, "p")
+        assert entry["account"] == "111122223333" and entry["verified_at"]
+
+    @pytest.mark.asyncio
+    async def test_verify_unreachable_skips_backfill(self, monkeypatch):
+        from kiro_crew.deploy import iam as iam_mod
+
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(iam_mod, "reachability_check",
+                            lambda profile: {"reachable": False, "error": "expired"})
+        resp = await handlers._handle_verify(_FakeReq({}))
+        assert _payload(resp)["reachable"] is False
+        assert profiles_mod.get_entry(profiles_mod.load_registry(), "p")["account"] == ""
+
+    @pytest.mark.asyncio
+    async def test_verify_is_blocked_on_windows(self, monkeypatch):
+        class _NtOs:
+            name = "nt"
+
+            def __getattr__(self, attr):  # pragma: no cover - delegation
+                return getattr(os, attr)
+
+        monkeypatch.setattr(handlers, "os", _NtOs())
+        resp = await handlers._handle_verify(_FakeReq({}))
+        assert resp.status == 400 and _payload(resp)["reachable"] is False
+
+    @pytest.mark.asyncio
+    async def test_pricing_rejects_unresolvable_profile(self):
+        resp = await handlers._handle_pricing(_FakeReq(query={"profile": "ghost"}))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_pricing_returns_unit_prices(self, monkeypatch):
+        from kiro_crew.deploy import pricing as pricing_mod
+
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(
+            pricing_mod, "get_unit_prices",
+            lambda profile, region: SimpleNamespace(
+                to_dict=lambda: {"source": "fallback", "s3_storage_gb_month": 0.023}))
+        resp = await handlers._handle_pricing(_FakeReq(query={}))
+        body = _payload(resp)
+        assert body["region"] == "us-west-2"
+        assert body["prices"]["source"] == "fallback"
+
+
+class TestProfilesControlPlane:
+    @pytest.mark.asyncio
+    async def test_get_lists_registry_and_discovered(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(profiles_mod, "discover_aws_profiles", lambda: ["p", "other"])
+        body = _payload(await handlers._handle_profiles_get(_FakeReq()))
+        assert body["default"] == "p" and body["available"] == ["other"]
+
+    @pytest.mark.asyncio
+    async def test_post_rejects_empty_name(self):
+        resp = await handlers._handle_profiles_post(_FakeReq({"name": ""}))
+        assert resp.status == 400 and "must not be empty" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_post_rejects_invalid_region(self):
+        resp = await handlers._handle_profiles_post(
+            _FakeReq({"name": "p", "region": "not a region!"}))
+        assert resp.status == 400 and "invalid profile" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_post_surfaces_create_failure(self, monkeypatch):
+        monkeypatch.setattr(profiles_mod, "create_aws_profile",
+                            lambda *a, **kw: "aws configure set failed")
+        resp = await handlers._handle_profiles_post(
+            _FakeReq({"name": "p", "create": True}))
+        assert resp.status == 400 and "configure set failed" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_post_registers_and_defaults(self, monkeypatch):
+        monkeypatch.setattr(profiles_mod, "create_aws_profile", lambda *a, **kw: "")
+        resp = await handlers._handle_profiles_post(
+            _FakeReq({"name": "p", "create": True, "default": True}))
+        assert _payload(resp)["default"] == "p"
+
+    @pytest.mark.asyncio
+    async def test_post_refuses_when_registry_is_full(self, monkeypatch):
+        full = {"profiles": [profiles_mod.make_entry(f"p{i}", "us-west-2")
+                             for i in range(50)], "default": "p0"}
+        monkeypatch.setattr(profiles_mod, "load_registry", lambda: full)
+        resp = await handlers._handle_profiles_post(_FakeReq({"name": "new"}))
+        assert resp.status == 400 and "registry is full" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_invalid_name(self):
+        resp = await handlers._handle_profiles_put(
+            _FakeReq({}, match_info={"name": "bad name;"}))
+        assert resp.status == 400 and "invalid profile name" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_invalid_region(self):
+        handlers._save_config("p", "us-west-2")
+        resp = await handlers._handle_profiles_put(
+            _FakeReq({"region": "bad region!"}, match_info={"name": "p"}))
+        assert resp.status == 400 and "invalid region" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_put_unknown_profile_is_404(self):
+        resp = await handlers._handle_profiles_put(
+            _FakeReq({}, match_info={"name": "ghost"}))
+        assert resp.status == 404 and "not registered" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_put_updates_note_and_default(self):
+        handlers._save_config("p", "us-west-2")
+        handlers._save_config("q", "us-west-2")
+        resp = await handlers._handle_profiles_put(
+            _FakeReq({"note": "n" * 400, "default": True, "region": "eu-west-1"},
+                     match_info={"name": "p"}))
+        body = _payload(resp)
+        assert body["default"] == "p"
+        entry = next(e for e in body["profiles"] if e["name"] == "p")
+        assert len(entry["note"]) == 256 and entry["region"] == "eu-west-1"
+
+    @pytest.mark.asyncio
+    async def test_delete_rejects_invalid_name(self):
+        resp = await handlers._handle_profiles_delete(
+            _FakeReq(match_info={"name": "bad;name"}))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_delete_unknown_profile_is_404(self):
+        resp = await handlers._handle_profiles_delete(
+            _FakeReq(match_info={"name": "ghost"}))
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_reassigns_the_default(self):
+        handlers._save_config("q", "us-west-2")
+        handlers._save_config("p", "us-west-2")
+        resp = await handlers._handle_profiles_delete(
+            _FakeReq(match_info={"name": "p"}))
+        assert _payload(resp)["default"] == "q"
+
+
+# --- manifest expiry --------------------------------------------------------
+
+
+def _art(profile="p", region="us-west-2", dist_id="D1", slug="app", meta=True):
+    target = SimpleNamespace(profile=profile, region=region, distribution_id=dist_id)
+    metadata = SimpleNamespace(deploy_target=target) if meta else None
+    return SimpleNamespace(slug=slug, kind="webapp", webapp_metadata=metadata)
+
+
+class TestExpireManifest:
+    @pytest.mark.asyncio
+    async def test_no_metadata_is_skipped(self):
+        assert await handlers._expire_manifest_best_effort(_art(meta=False)) == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_missing_slug_is_skipped(self):
+        assert await handlers._expire_manifest_best_effort(_art(slug="")) == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_no_recorded_profile_is_skipped(self):
+        assert await handlers._expire_manifest_best_effort(_art(profile="")) == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_unregistered_profile_is_unreachable(self):
+        assert await handlers._expire_manifest_best_effort(_art()) == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_invalid_region_is_unreachable(self):
+        handlers._save_config("p", "us-west-2")
+        art = _art(region="not a region!")
+        assert await handlers._expire_manifest_best_effort(art) == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_base_stack_read_failure_is_unreachable(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "run_aws", _aws_router([], default=(1, "", "err")))
+        assert await handlers._expire_manifest_best_effort(_art()) == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_base_stack_exception_is_unreachable(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+
+        def _boom(*a, **kw):
+            raise OSError("aws missing")
+
+        monkeypatch.setattr(engine, "run_aws", _boom)
+        assert await handlers._expire_manifest_best_effort(_art()) == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_missing_bucket_output_is_unreachable(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "run_aws", _aws_router(
+            [("describe-stacks", (0, json.dumps([{"OutputKey": "X", "OutputValue": "y"}]), ""))]))
+        assert await handlers._expire_manifest_best_effort(_art()) == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_manifest_fails_closed(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(engine, "run_aws", _aws_router([
+            ("describe-stacks", (0, _BASE_OUTPUTS, "")),
+        ], default=(1, "", "no such key")))
+        assert await handlers._expire_manifest_best_effort(_art()) == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_manifest_read_exception_fails_closed(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+
+        def _run_aws(argv, *a, **kw):
+            joined = " ".join(str(x) for x in argv)
+            if "describe-stacks" in joined:
+                return (0, _BASE_OUTPUTS, "")
+            raise OSError("network down")
+
+        monkeypatch.setattr(engine, "run_aws", _run_aws)
+        assert await handlers._expire_manifest_best_effort(_art()) == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_distribution_id_mismatch_refuses(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        other = json.dumps({"slug": "app", "distribution_id": "SOMEONE-ELSE"})
+        monkeypatch.setattr(engine, "run_aws", _aws_router([
+            ("describe-stacks", (0, _BASE_OUTPUTS, "")),
+            (".kirocrew-deploy.json -", (0, other, "")),
+        ]))
+        assert await handlers._expire_manifest_best_effort(_art()) == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_put_failure_is_unreachable(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        mine = json.dumps({"slug": "app", "distribution_id": "D1", "arch": "engine"})
+
+        def _run_aws(argv, *a, **kw):
+            joined = " ".join(str(x) for x in argv)
+            if "describe-stacks" in joined:
+                return (0, _BASE_OUTPUTS, "")
+            if joined.endswith(".kirocrew-deploy.json - --region us-west-2"):
+                return (0, mine, "")
+            return (1, "", "AccessDenied")
+
+        monkeypatch.setattr(engine, "run_aws", _run_aws)
+        assert await handlers._expire_manifest_best_effort(_art()) == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_put_exception_is_unreachable(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        mine = json.dumps({"slug": "app", "distribution_id": "D1"})
+        calls = {"n": 0}
+
+        def _run_aws(argv, *a, **kw):
+            joined = " ".join(str(x) for x in argv)
+            if "describe-stacks" in joined:
+                return (0, _BASE_OUTPUTS, "")
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return (0, mine, "")
+            raise OSError("aws vanished")
+
+        monkeypatch.setattr(engine, "run_aws", _run_aws)
+        assert await handlers._expire_manifest_best_effort(_art()) == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_success_patches_only_the_expiry_fields(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        mine = json.dumps({
+            "slug": "app", "distribution_id": "D1", "arch": "engine",
+            "bucket": "site-bucket", "oac_id": "O1", "ttl_hours": "72",
+            "persistent": False, "unknown_field": "kept",
+        })
+        written: list[str] = []
+
+        def _run_aws(argv, *a, **kw):
+            joined = " ".join(str(x) for x in argv)
+            if "describe-stacks" in joined:
+                return (0, _BASE_OUTPUTS, "")
+            if joined.endswith("- --region us-west-2"):
+                return (0, mine, "")
+            written.append(Path(argv[2]).read_text(encoding="utf-8"))
+            return (0, "", "")
+
+        monkeypatch.setattr(engine, "run_aws", _run_aws)
+        assert await handlers._expire_manifest_best_effort(_art()) == "expired-now"
+        doc = json.loads(written[0])
+        assert doc["arch"] == "engine" and doc["unknown_field"] == "kept"
+        assert doc["oac_id"] == "O1" and doc["persistent"] is False
+        assert doc["ttl_hours"] == "0" and doc["expires_at"]
+
+
+# --- teardown ---------------------------------------------------------------
+
+
+class _FakeStore:
+    def __init__(self, art=None, *, get_exc=None, expire_exc=None):
+        self._art = art
+        self._get_exc = get_exc
+        self._expire_exc = expire_exc
+
+    def get(self, _slug):
+        if self._get_exc is not None:
+            raise self._get_exc
+        return self._art
+
+    def mark_webapp_expired(self, _slug):
+        if self._expire_exc is not None:
+            raise self._expire_exc
+        return self._art
+
+
+class TestTeardown:
+    @pytest.mark.asyncio
+    async def test_blocked_on_windows(self, monkeypatch):
+        class _NtOs:
+            name = "nt"
+
+            def __getattr__(self, attr):  # pragma: no cover - delegation
+                return getattr(os, attr)
+
+        monkeypatch.setattr(handlers, "os", _NtOs())
+        resp = await handlers._handle_teardown(
+            _FakeReq({"confirm": True}, match_info={"slug": "app"}))
+        assert resp.status == 400 and "POSIX shell" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_artifacts_module_unavailable(self, monkeypatch):
+        monkeypatch.setattr(handlers, "_HAS_ARTIFACTS", False)
+        resp = await handlers._handle_teardown(
+            _FakeReq({"confirm": True}, match_info={"slug": "app"}))
+        assert resp.status == 500
+
+    @pytest.mark.asyncio
+    async def test_unparseable_body_fails_the_confirm_gate(self):
+        resp = await handlers._handle_teardown(
+            _FakeReq("}{", match_info={"slug": "app"}))
+        assert resp.status == 400 and "confirm=true required" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_artifact_is_404(self, monkeypatch):
+        exc = handlers.ArtifactNotFoundError("no artifact 'app'")
+        monkeypatch.setattr(handlers, "get_default_store",
+                            lambda: _FakeStore(get_exc=exc))
+        resp = await handlers._handle_teardown(
+            _FakeReq({"confirm": True}, match_info={"slug": "app"}))
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_store_error_is_500(self, monkeypatch):
+        exc = handlers.ArtifactError("store corrupt")
+        monkeypatch.setattr(handlers, "get_default_store",
+                            lambda: _FakeStore(get_exc=exc))
+        resp = await handlers._handle_teardown(
+            _FakeReq({"confirm": True}, match_info={"slug": "app"}))
+        assert resp.status == 500
+
+    @pytest.mark.asyncio
+    async def test_non_webapp_artifact_is_refused(self, monkeypatch):
+        art = SimpleNamespace(slug="app", kind="html", webapp_metadata=None)
+        monkeypatch.setattr(handlers, "get_default_store", lambda: _FakeStore(art))
+        resp = await handlers._handle_teardown(
+            _FakeReq({"confirm": True}, match_info={"slug": "app"}))
+        assert resp.status == 400 and _payload(resp)["error"] == "not a webapp artifact"
+
+    @pytest.mark.asyncio
+    async def test_unregistered_metadata_profile_is_refused(self, monkeypatch):
+        monkeypatch.setattr(handlers, "get_default_store",
+                            lambda: _FakeStore(_art(profile="ghost")))
+        resp = await handlers._handle_teardown(
+            _FakeReq({"confirm": True}, match_info={"slug": "app"}))
+        assert resp.status == 409 and "unregistered profile" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_metadata_region_is_refused(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(handlers, "get_default_store",
+                            lambda: _FakeStore(_art(region="bad region!")))
+        resp = await handlers._handle_teardown(
+            _FakeReq({"confirm": True}, match_info={"slug": "app"}))
+        assert resp.status == 409 and "invalid region" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_reaper_is_refused(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(handlers, "get_default_store", lambda: _FakeStore(_art()))
+        monkeypatch.setattr(engine, "run_aws", _aws_router([], default=(1, "", "no stack")))
+        resp = await handlers._handle_teardown(
+            _FakeReq({"confirm": True}, match_info={"slug": "app"}))
+        assert resp.status == 409 and _payload(resp)["reaper_missing"] is True
+
+    @pytest.mark.asyncio
+    async def test_unreachable_manifest_is_retryable(self, monkeypatch):
+        handlers._save_config("p", "us-west-2")
+        monkeypatch.setattr(handlers, "get_default_store", lambda: _FakeStore(_art()))
+        monkeypatch.setattr(handlers, "_check_reaper_installed", lambda *a: True)
+
+        async def _unreachable(_art_obj):
+            return "unreachable"
+
+        monkeypatch.setattr(handlers, "_expire_manifest_best_effort", _unreachable)
+        resp = await handlers._handle_teardown(
+            _FakeReq({"confirm": True}, match_info={"slug": "app"}))
+        assert resp.status == 502 and _payload(resp)["retry"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("exc_name,status", [
+        ("ArtifactNotFoundError", 404),
+        ("ArtifactValidationError", 400),
+        ("ArtifactError", 500),
+    ])
+    async def test_tombstone_failures_surface(self, monkeypatch, exc_name, status):
+        exc = getattr(handlers, exc_name)("boom")
+        art = SimpleNamespace(slug="app", kind="webapp", webapp_metadata=None)
+        monkeypatch.setattr(handlers, "get_default_store",
+                            lambda: _FakeStore(art, expire_exc=exc))
+
+        async def _skipped(_art_obj):
+            return "skipped"
+
+        monkeypatch.setattr(handlers, "_expire_manifest_best_effort", _skipped)
+        resp = await handlers._handle_teardown(
+            _FakeReq({"confirm": True}, match_info={"slug": "app"}))
+        assert resp.status == status
+
+    def test_check_reaper_installed_maps_rc_to_bool(self, monkeypatch):
+        monkeypatch.setattr(engine, "run_aws", _aws_router([], default=(0, "", "")))
+        assert handlers._check_reaper_installed("p", "us-west-2") is True
+        monkeypatch.setattr(engine, "run_aws", _aws_router([], default=(255, "", "err")))
+        assert handlers._check_reaper_installed("p", "us-west-2") is False
+
+
+# --- pending confirmations --------------------------------------------------
+
+
+class TestPending:
+    # POSIX-only for the same reason as TestDoDeployRefusals: these tests pass a
+    # real filesystem path as local_dir, and deploy's _LOCAL_DIR_RE admits only
+    # POSIX path characters, so a native Windows path is refused before the
+    # pending-deploy branch under test is reached. Product defect, reported not
+    # fixed.
+    pytestmark = pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="deploy's _LOCAL_DIR_RE rejects native Windows paths (product defect)",
+    )
+
+    @pytest.mark.asyncio
+    async def test_list_redacts_entries(self):
+        from kiro_crew.deploy.pending import add_pending
+
+        add_pending({"site_id": "s", "profile": "p"})
+        body = _payload(await handlers._handle_pending_list(_FakeReq()))
+        assert body["pending"][0]["site_id"] == "s"
+
+    @pytest.mark.asyncio
+    async def test_confirm_unknown_entry_is_409(self):
+        resp = await handlers._handle_pending_confirm(
+            _FakeReq({}, match_info={"id": "nope"}))
+        assert resp.status == 409
+
+    @pytest.mark.asyncio
+    async def test_confirm_refuses_on_profile_drift(self):
+        from kiro_crew.deploy.pending import add_pending
+
+        handlers._save_config("p", "us-west-2")
+        entry = add_pending({"site_id": "s", "profile": "p", "region": "eu-west-1"})
+        resp = await handlers._handle_pending_confirm(
+            _FakeReq({}, match_info={"id": entry["id"]}))
+        assert resp.status == 409 and "profile changed since preview" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_confirm_refuses_when_local_dir_vanished(self, tmp_path: Path):
+        from kiro_crew.deploy.pending import add_pending, list_pending
+
+        handlers._save_config("p", "us-west-2")
+        entry = add_pending({
+            "site_id": "s", "profile": "p", "region": "us-west-2",
+            "local_dir": str(tmp_path / "gone"), "content_digest": "abc",
+        })
+        resp = await handlers._handle_pending_confirm(
+            _FakeReq({}, match_info={"id": entry["id"]}))
+        assert resp.status == 409 and "no longer exists" in _payload(resp)["error"]
+        # The entry is put back so the user can retry after fixing the path.
+        assert [e["id"] for e in list_pending()] == [entry["id"]]
+
+    @pytest.mark.asyncio
+    async def test_confirm_refuses_dir_outside_allowed_roots(self, tmp_path: Path, monkeypatch):
+        from kiro_crew.deploy.pending import add_pending
+
+        handlers._save_config("p", "us-west-2")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        monkeypatch.setattr(handlers, "_allowed_local_roots", lambda: [tmp_path / "only"])
+        entry = add_pending({
+            "site_id": "s", "profile": "p", "region": "us-west-2",
+            "local_dir": str(outside), "content_digest": "abc",
+        })
+        resp = await handlers._handle_pending_confirm(
+            _FakeReq({}, match_info={"id": entry["id"]}))
+        assert resp.status == 409 and "outside allowed roots" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_confirm_refuses_sensitive_dir(self, tmp_path: Path, monkeypatch):
+        from kiro_crew.deploy.pending import add_pending
+
+        handlers._save_config("p", "us-west-2")
+        src = tmp_path / "site"
+        src.mkdir()
+        monkeypatch.setattr(handlers, "_allowed_local_roots", lambda: [tmp_path])
+        monkeypatch.setattr(handlers, "_dir_contains_sensitive", lambda *a: True)
+        entry = add_pending({
+            "site_id": "s", "profile": "p", "region": "us-west-2",
+            "local_dir": str(src), "content_digest": "abc",
+        })
+        resp = await handlers._handle_pending_confirm(
+            _FakeReq({}, match_info={"id": entry["id"]}))
+        assert resp.status == 409 and "sensitive paths" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_confirm_refuses_oversized_tree(self, tmp_path: Path, monkeypatch):
+        from kiro_crew.deploy.pending import add_pending
+
+        handlers._save_config("p", "us-west-2")
+        src = tmp_path / "site"
+        src.mkdir()
+        monkeypatch.setattr(handlers, "_allowed_local_roots", lambda: [tmp_path])
+        monkeypatch.setattr(handlers, "_compute_tree_size_global",
+                            lambda _p: 300 * 1024 * 1024)
+        entry = add_pending({
+            "site_id": "s", "profile": "p", "region": "us-west-2",
+            "local_dir": str(src), "content_digest": "abc",
+        })
+        resp = await handlers._handle_pending_confirm(
+            _FakeReq({}, match_info={"id": entry["id"]}))
+        assert resp.status == 409 and "exceeds 200 MiB" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_confirm_refuses_edited_artifact(self, monkeypatch):
+        from kiro_crew.deploy.pending import add_pending
+
+        handlers._save_config("p", "us-west-2")
+        art = SimpleNamespace(kind="html", content="<p>changed</p>", name="a")
+        monkeypatch.setattr(handlers, "get_default_store", lambda: _FakeStore(art))
+        entry = add_pending({
+            "site_id": "s", "profile": "p", "region": "us-west-2",
+            "artifact_slug": "a1", "content_digest": "digest-at-preview",
+        })
+        resp = await handlers._handle_pending_confirm(
+            _FakeReq({}, match_info={"id": entry["id"]}))
+        assert resp.status == 409 and "content changed since preview" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_confirm_tolerates_unstageable_artifact(self, monkeypatch):
+        from kiro_crew.deploy.pending import add_pending
+
+        handlers._save_config("p", "us-west-2")
+        exc = handlers.ArtifactNotFoundError("deleted")
+        monkeypatch.setattr(handlers, "get_default_store",
+                            lambda: _FakeStore(get_exc=exc))
+        entry = add_pending({
+            "site_id": "s", "profile": "p", "region": "us-west-2",
+            "artifact_slug": "a1", "content_digest": "digest-at-preview",
+        })
+        resp = await handlers._handle_pending_confirm(
+            _FakeReq({}, match_info={"id": entry["id"]}))
+        # Digest check declines to judge; _do_deploy reports the missing artifact.
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_confirm_carries_human_override_scan(self, monkeypatch, tmp_path: Path):
+        from kiro_crew.deploy.pending import add_pending
+
+        handlers._save_config("p", "us-west-2")
+        seen: dict = {}
+
+        async def _fake_deploy(params):
+            seen.update(params)
+            return 200, {"url": "https://d1.cloudfront.net/s/"}
+
+        monkeypatch.setattr(handlers, "_do_deploy", _fake_deploy)
+        entry = add_pending({
+            "site_id": "s", "profile": "p", "region": "us-west-2",
+            "local_dir": str(tmp_path), "ttl_hours": 24,
+            "override_scan_required": True,
+        })
+        resp = await handlers._handle_pending_confirm(
+            _FakeReq({"override_scan": True}, match_info={"id": entry["id"]}))
+        assert resp.status == 200
+        assert seen["override_scan"] is True and seen["confirm"] is True
+        assert seen["expected_profile"] == "p" and seen["ttl_hours"] == 24
+
+    @pytest.mark.asyncio
+    async def test_failed_confirm_readds_the_entry(self, monkeypatch, tmp_path: Path):
+        from kiro_crew.deploy.pending import add_pending, list_pending
+
+        handlers._save_config("p", "us-west-2")
+
+        async def _fake_deploy(_params):
+            return 502, {"error": "AccessDenied"}
+
+        monkeypatch.setattr(handlers, "_do_deploy", _fake_deploy)
+        entry = add_pending({
+            "site_id": "s", "profile": "p", "region": "us-west-2",
+            "artifact_slug": "a1",
+        })
+        resp = await handlers._handle_pending_confirm(
+            _FakeReq({}, match_info={"id": entry["id"]}))
+        assert resp.status == 502
+        assert [e["id"] for e in list_pending()] == [entry["id"]]
+
+    @pytest.mark.asyncio
+    async def test_dismiss_rejects_internal_secret_callers(self):
+        req = _FakeReq({}, match_info={"id": "x"}, headers={"X-Internal-Secret": "s"})
+        resp = await handlers._handle_pending_dismiss(req)
+        # The @_internal_denied decorator answers first, so the message is the
+        # generic one; the handler's own inner guard never runs on this path.
+        assert resp.status == 403
+        assert "internal-secret callers" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_dismiss_inner_guard_is_defence_in_depth(self):
+        # The decorator shadows this branch in production, so exercise the
+        # undecorated function to prove the second gate is still fail-closed.
+        req = _FakeReq({}, match_info={"id": "x"}, headers={"X-Internal-Secret": "s"})
+        resp = await handlers._handle_pending_dismiss.__wrapped__(req)
+        assert resp.status == 403 and "MCP callers" in _payload(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_dismiss_unknown_entry_is_404(self):
+        resp = await handlers._handle_pending_dismiss(
+            _FakeReq({}, match_info={"id": "nope"}))
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_dismiss_removes_the_entry(self):
+        from kiro_crew.deploy.pending import add_pending, list_pending
+
+        entry = add_pending({"site_id": "s"})
+        resp = await handlers._handle_pending_dismiss(
+            _FakeReq({}, match_info={"id": entry["id"]}))
+        assert resp.status == 200 and list_pending() == []

--- a/test/test_dev_fleet_server_coverage.py
+++ b/test/test_dev_fleet_server_coverage.py
@@ -1,0 +1,1780 @@
+"""Coverage-focused tests for the Dev Fleet standalone backend.
+
+Targets uncovered helper branches, pod-guard refusals, request-handler
+validation, the audit decorator's non-success paths, and the lifecycle
+hooks of ``kiro_crew.apps.builtins.dev_fleet.server``.
+
+Everything is injected: no real git, no real subprocess, no network, and no
+writes outside ``tmp_path``. Where the module reads its config home the
+loader's ``config_dir`` is patched, so nothing touches the real one.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+import kiro_crew.apps.builtins.dev_fleet.server as mod
+from kiro_crew.apps.builtins.dev_fleet import gateway_service
+
+# The launchd label derivation imports the pod launchd module for its label
+# prefix; on a host where that optional module is unavailable the function
+# falls back to the live label and the pod branch cannot be observed.
+_LAUNCHD_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="launchd live-program layout is POSIX-only",
+)
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+class _CapturingSel:
+    """Minimal SEL stand-in that records every audit call."""
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    def log_tool_invocation(self, **kw) -> None:
+        self.events.append(kw)
+
+
+def _sel_capture(monkeypatch) -> _CapturingSel:
+    sink = _CapturingSel()
+    monkeypatch.setattr(mod, "_sel", lambda: sink)
+    return sink
+
+
+def _json_request(payload: dict) -> MagicMock:
+    """A request double shaped like the one the audit decorator expects."""
+    raw = json.dumps(payload).encode()
+    request = MagicMock()
+    request.read = AsyncMock(return_value=raw)
+    request.json = AsyncMock(return_value=payload)
+    request.content_length = len(raw)
+    request.can_read_body = True
+    return request
+
+
+def _raw_request(raw: bytes, *, json_error: Exception | None = None) -> MagicMock:
+    request = MagicMock()
+    request.read = AsyncMock(return_value=raw)
+    if json_error is not None:
+        request.json = AsyncMock(side_effect=json_error)
+    else:
+        try:
+            request.json = AsyncMock(return_value=json.loads(raw or b"{}"))
+        except ValueError as exc:
+            request.json = AsyncMock(side_effect=exc)
+    request.content_length = len(raw)
+    request.can_read_body = True
+    return request
+
+
+def _same(a: str, b: str) -> bool:
+    """Path equality that survives Windows 8.3 short paths and /tmp symlinks."""
+    return os.path.realpath(a) == os.path.realpath(b)
+
+
+@pytest.fixture(autouse=True)
+def _pin_module_state(monkeypatch):
+    """Neutralise the module's cached globals so tests never share state."""
+    monkeypatch.setattr(mod, "_UPSTREAM_REMOTE", "origin")
+    monkeypatch.setattr(mod, "_HTML_BASE", None)
+    monkeypatch.setattr(mod, "_PR_CACHE", {})
+    monkeypatch.setattr(mod, "_FALLBACK_REPOS", [])
+    monkeypatch.setattr(mod, "_WT_LOCKS", {})
+    monkeypatch.setattr(mod, "_PROVISION_INFLIGHT", {})
+    monkeypatch.setattr(mod, "_RUNS", {})
+    monkeypatch.setattr(mod, "_BUILD_PATH_CACHE", "/usr/bin")
+    monkeypatch.setattr(mod, "_warm_build_path", AsyncMock())
+    monkeypatch.setattr(mod, "_pod_env", lambda: {})
+
+
+# --------------------------------------------------------------------------
+# _load_dev_fleet_cfg
+# --------------------------------------------------------------------------
+def test_load_dev_fleet_cfg_overlay_wins(monkeypatch, tmp_path):
+    """config.local.json overlays config.json for the dev_fleet section."""
+    (tmp_path / "config.json").write_text(
+        json.dumps({"dev_fleet": {"a": 1, "keep": "yes"}}), encoding="utf-8", newline="\n"
+    )
+    (tmp_path / "config.local.json").write_text(
+        json.dumps({"dev_fleet": {"a": 2, "b": 3}}), encoding="utf-8", newline="\n"
+    )
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+
+    assert mod._load_dev_fleet_cfg() == {"a": 2, "keep": "yes", "b": 3}
+
+
+def test_load_dev_fleet_cfg_ignores_unusable_files(monkeypatch, tmp_path):
+    """Invalid JSON and a non-dict dev_fleet value are skipped, never raised."""
+    (tmp_path / "config.json").write_text("{not json", encoding="utf-8", newline="\n")
+    (tmp_path / "config.local.json").write_text(
+        json.dumps({"dev_fleet": "nope"}), encoding="utf-8", newline="\n"
+    )
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+
+    assert mod._load_dev_fleet_cfg() == {}
+
+
+def test_load_dev_fleet_cfg_config_dir_failure_is_empty(monkeypatch):
+    """A config home that cannot be resolved yields {} rather than an error."""
+    def _boom():
+        raise RuntimeError("no home")
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", _boom)
+    assert mod._load_dev_fleet_cfg() == {}
+
+
+# --------------------------------------------------------------------------
+# _launchd_live_worktree
+# --------------------------------------------------------------------------
+@_LAUNCHD_ONLY
+def test_launchd_live_worktree_missing_launcher_is_none(monkeypatch, tmp_path):
+    missing = tmp_path / "absent" / "live-gateway"
+    monkeypatch.setattr(
+        gateway_service.LaunchdBackend, "live_program", staticmethod(lambda: missing)
+    )
+    assert mod._launchd_live_worktree() is None
+
+
+@_LAUNCHD_ONLY
+@pytest.mark.parametrize(
+    "script",
+    [
+        "#!/bin/sh\nexport FOO=1\n",  # no exec line at all
+        "#!/bin/sh\nexec '/usr/local/bin/kirocrew' gateway\n",  # not a venv binary
+    ],
+)
+def test_launchd_live_worktree_unusable_exec_is_none(monkeypatch, tmp_path, script):
+    launcher = tmp_path / "live-gateway"
+    launcher.write_text(script, encoding="utf-8", newline="\n")
+    monkeypatch.setattr(
+        gateway_service.LaunchdBackend, "live_program", staticmethod(lambda: launcher)
+    )
+    assert mod._launchd_live_worktree() is None
+
+
+@_LAUNCHD_ONLY
+def test_launchd_live_worktree_resolves_checkout(monkeypatch, tmp_path):
+    """A venv binary in the exec line resolves to its checkout grandparent."""
+    checkout = tmp_path / "kirocrew-wt-alpha"
+    kcbin = checkout / ".venv" / "bin" / "kirocrew"
+    kcbin.parent.mkdir(parents=True)
+    kcbin.write_text("", encoding="utf-8", newline="\n")
+    launcher = tmp_path / "live-gateway"
+    launcher.write_text(f"#!/bin/sh\nexec '{kcbin}' gateway\n", encoding="utf-8", newline="\n")
+    monkeypatch.setattr(
+        gateway_service.LaunchdBackend, "live_program", staticmethod(lambda: launcher)
+    )
+
+    resolved = mod._launchd_live_worktree()
+    assert resolved is not None
+    assert _same(resolved, str(checkout))
+
+
+# --------------------------------------------------------------------------
+# _load_fallback_repos
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_load_fallback_repos_collects_ancestor_remotes(monkeypatch):
+    """A remote whose base is an ancestor of upstream becomes a fallback repo."""
+    async def fake_run(cmd, **kw):
+        if cmd[-1] == "remote":
+            return 0, "origin\nfork\nstale\n", ""
+        if "--is-ancestor" in cmd:
+            return (0 if "fork/main" in cmd else 1), "", ""
+        if "get-url" in cmd:
+            return 0, "git@github.com:someone/kirocrew.git\n", ""
+        return 1, "", "unexpected"
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run)
+    await mod._load_fallback_repos()
+    assert mod._FALLBACK_REPOS == ["someone/kirocrew"]
+
+
+@pytest.mark.asyncio
+async def test_load_fallback_repos_empty_when_remote_listing_fails(monkeypatch):
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(1, "", "boom")))
+    await mod._load_fallback_repos()
+    assert mod._FALLBACK_REPOS == []
+
+
+# --------------------------------------------------------------------------
+# PR cache + html base
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_pr_status_cached_skips_base_branch(monkeypatch):
+    fetch = AsyncMock(return_value={"state": "OPEN"})
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+    assert await mod._pr_status_cached(mod.BASE_BRANCH) is None
+    assert await mod._pr_status_cached("") is None
+    fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_merged_entry_is_terminal(monkeypatch):
+    """A MERGED entry is served regardless of age — no refetch."""
+    fetch = AsyncMock(return_value={"state": "OPEN"})
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+    monkeypatch.setattr(mod, "_PR_CACHE", {"feat": {"data": {"state": "MERGED"}, "ts": 0.0}})
+
+    assert (await mod._pr_status_cached("feat"))["state"] == "MERGED"
+    fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_stale_closed_entry_refetches(monkeypatch):
+    """A CLOSED entry can be reopened, so it expires on the normal TTL."""
+    fetch = AsyncMock(return_value={"state": "OPEN"})
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+    monkeypatch.setattr(mod, "_PR_CACHE", {"feat": {"data": {"state": "CLOSED"}, "ts": 0.0}})
+
+    assert (await mod._pr_status_cached("feat"))["state"] == "OPEN"
+    fetch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_fresh_entry_is_served(monkeypatch):
+    fetch = AsyncMock(return_value={"state": "MERGED"})
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+    monkeypatch.setattr(
+        mod, "_PR_CACHE", {"feat": {"data": {"state": "OPEN"}, "ts": time.time()}}
+    )
+
+    assert (await mod._pr_status_cached("feat"))["state"] == "OPEN"
+    fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_html_repo_base_from_remote_url(monkeypatch):
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "git@github.com:o/r.git\n", "")))
+    assert await mod._html_repo_base() == "https://github.com/o/r"
+
+
+@pytest.mark.asyncio
+async def test_html_repo_base_falls_back_to_owner_repo(monkeypatch):
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(1, "", "no remote")))
+    monkeypatch.setattr(mod, "_get_owner_repo", AsyncMock(return_value="o/r"))
+    assert await mod._html_repo_base() == "https://github.com/o/r"
+
+
+@pytest.mark.asyncio
+async def test_html_repo_base_cached_value_short_circuits(monkeypatch):
+    run = AsyncMock(return_value=(0, "", ""))
+    monkeypatch.setattr(mod, "_run_cmd", run)
+    monkeypatch.setattr(mod, "_HTML_BASE", "https://example.invalid/o/r")
+    assert await mod._html_repo_base() == "https://example.invalid/o/r"
+    run.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------
+# _read_pin_strict
+# --------------------------------------------------------------------------
+def _pin_cfg(tmp_path: Path, text: str | None) -> SimpleNamespace:
+    pods = tmp_path / "pods"
+    pods.mkdir(exist_ok=True)
+    env_path = pods / "feat.env"
+    if text is not None:
+        env_path.write_text(text, encoding="utf-8", newline="\n")
+    return SimpleNamespace(pods_dir=pods, env_file=lambda name: env_path)
+
+
+def test_read_pin_strict_no_env_file_is_unpinned(tmp_path):
+    cfg = _pin_cfg(tmp_path, None)
+    assert mod._read_pin_strict(cfg, "feat") == (False, None)
+
+
+def test_read_pin_strict_refused_read_raises(monkeypatch, tmp_path):
+    """A hooks-gate refusal is a DENY, never 'unpinned'."""
+    cfg = _pin_cfg(tmp_path, "CHECKOUT=/x\n")
+    monkeypatch.setattr(mod.hooks, "safe_read_file_bytes_nolink", lambda *a, **k: None)
+    with pytest.raises(OSError, match="refused by hooks read gate"):
+        mod._read_pin_strict(cfg, "feat")
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ("# a comment\nnovalue\nCHECKOUT='/repo/wt'\n", (True, "/repo/wt")),
+        ('OTHER=1\nCHECKOUT="/repo/wt"\n', (True, "/repo/wt")),
+        ("CHECKOUT=\n", (True, None)),
+        ("OTHER=1\n", (True, None)),
+    ],
+)
+def test_read_pin_strict_parses_checkout(monkeypatch, tmp_path, body, expected):
+    cfg = _pin_cfg(tmp_path, body)
+    monkeypatch.setattr(
+        mod.hooks, "safe_read_file_bytes_nolink", lambda *a, **k: body.encode()
+    )
+    assert mod._read_pin_strict(cfg, "feat") == expected
+
+
+# --------------------------------------------------------------------------
+# _pod_checkout_guard
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_pod_guard_unknown_worktree(monkeypatch):
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=(None, None)))
+    assert "unknown worktree" in (await mod._pod_checkout_guard("ghost") or "")
+
+
+@pytest.mark.asyncio
+async def test_pod_guard_no_pod_subsystem_allows(monkeypatch):
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=({"path": "/w"}, None)))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: None)
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", False)
+    assert await mod._pod_checkout_guard("feat") is None
+
+
+@pytest.mark.asyncio
+async def test_pod_guard_unloadable_config_denies(monkeypatch):
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=({"path": "/w"}, None)))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: None)
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+    assert await mod._pod_checkout_guard("feat") == (
+        "cannot load pod configuration to verify pod identity"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pod_guard_unreadable_pin_denies(monkeypatch):
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=({"path": "/w"}, None)))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+
+    def _boom(cfg, name):
+        raise OSError("pin unreadable")
+
+    monkeypatch.setattr(mod, "_read_pin_strict", _boom)
+    assert "cannot verify pod checkout pin" in (await mod._pod_checkout_guard("feat") or "")
+
+
+@pytest.mark.asyncio
+async def test_pod_guard_active_pod_without_pin_denies(monkeypatch):
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=({"path": "/w"}, None)))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+    monkeypatch.setattr(mod, "_read_pin_strict", lambda cfg, name: (False, None))
+    monkeypatch.setattr(
+        mod, "rt", SimpleNamespace(active_names=lambda cfg: {"feat"}), raising=False
+    )
+    assert "unattributable pod identity" in (await mod._pod_checkout_guard("feat") or "")
+
+
+@pytest.mark.asyncio
+async def test_pod_guard_inactive_pod_without_pin_allows(monkeypatch):
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=({"path": "/w"}, None)))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+    monkeypatch.setattr(mod, "_read_pin_strict", lambda cfg, name: (False, None))
+    monkeypatch.setattr(mod, "rt", SimpleNamespace(active_names=lambda cfg: set()), raising=False)
+    assert await mod._pod_checkout_guard("feat") is None
+
+
+@pytest.mark.asyncio
+async def test_pod_guard_active_names_failure_denies(monkeypatch):
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=({"path": "/w"}, None)))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+    monkeypatch.setattr(mod, "_read_pin_strict", lambda cfg, name: (False, None))
+
+    def _boom(cfg):
+        raise RuntimeError("systemctl gone")
+
+    monkeypatch.setattr(mod, "rt", SimpleNamespace(active_names=_boom), raising=False)
+    assert "cannot verify active pods" in (await mod._pod_checkout_guard("feat") or "")
+
+
+@pytest.mark.asyncio
+async def test_pod_guard_pin_without_checkout_denies(monkeypatch):
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=({"path": "/w"}, None)))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+    monkeypatch.setattr(mod, "_read_pin_strict", lambda cfg, name: (True, None))
+    assert "ambiguous pod identity" in (await mod._pod_checkout_guard("feat") or "")
+
+
+@pytest.mark.asyncio
+async def test_pod_guard_foreign_checkout_denies(monkeypatch, tmp_path):
+    mine = tmp_path / "mine"
+    theirs = tmp_path / "theirs"
+    mine.mkdir()
+    theirs.mkdir()
+    monkeypatch.setattr(
+        mod, "_find_worktree", AsyncMock(return_value=({"path": str(mine)}, None))
+    )
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+    monkeypatch.setattr(mod, "_read_pin_strict", lambda cfg, name: (True, str(theirs)))
+    assert "cross-repository pod operation" in (await mod._pod_checkout_guard("feat") or "")
+
+
+@pytest.mark.asyncio
+async def test_pod_guard_matching_checkout_allows(monkeypatch, tmp_path):
+    mine = tmp_path / "mine"
+    mine.mkdir()
+    monkeypatch.setattr(
+        mod, "_find_worktree", AsyncMock(return_value=({"path": str(mine)}, None))
+    )
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+    monkeypatch.setattr(mod, "_read_pin_strict", lambda cfg, name: (True, str(mine)))
+    assert await mod._pod_checkout_guard("feat") is None
+
+
+# --------------------------------------------------------------------------
+# pod operations
+# --------------------------------------------------------------------------
+@pytest.fixture
+def allow_pod(monkeypatch):
+    """Pod guard passes and pod state verification is opt-in per test."""
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: None)
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", False)
+
+
+@pytest.mark.asyncio
+async def test_pod_up_refused_by_guard(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value="nope"))
+    assert await mod._pod_up("feat") == {"ok": False, "error": "nope"}
+
+
+@pytest.mark.asyncio
+async def test_pod_up_cli_failure_is_reported(monkeypatch, allow_pod):
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(1, "", "boom")))
+    assert await mod._pod_up("feat") == {"ok": False, "error": "boom"}
+
+
+@pytest.mark.asyncio
+async def test_pod_up_non_json_output_still_ok(monkeypatch, allow_pod):
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "not json", "")))
+    assert await mod._pod_up("feat") == {"ok": True, "output": "not json"}
+
+
+@pytest.mark.asyncio
+async def test_pod_up_json_output_is_merged(monkeypatch, allow_pod):
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, '{"port": 9999}', "")))
+    assert await mod._pod_up("feat") == {"ok": True, "port": 9999}
+
+
+@pytest.mark.asyncio
+async def test_pod_up_inactive_after_start_fails_closed(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "{}", "")))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+    monkeypatch.setattr(mod, "rt", SimpleNamespace(active_names=lambda cfg: set()), raising=False)
+    assert await mod._pod_up("feat") == {"ok": False, "error": "pod not active after start"}
+
+
+@pytest.mark.asyncio
+async def test_pod_up_unverifiable_start_fails_closed(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "{}", "")))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+
+    def _boom(cfg):
+        raise RuntimeError("no bus")
+
+    monkeypatch.setattr(mod, "rt", SimpleNamespace(active_names=_boom), raising=False)
+    res = await mod._pod_up("feat")
+    assert res["ok"] is False
+    assert "cannot verify pod start" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_pod_down_refused_by_guard(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value="denied"))
+    assert await mod._pod_down("feat") == {"ok": False, "error": "denied"}
+
+
+@pytest.mark.asyncio
+async def test_pod_down_cli_failure_is_reported(monkeypatch, allow_pod):
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(2, "out", "")))
+    assert await mod._pod_down("feat") == {"ok": False, "error": "out"}
+
+
+@pytest.mark.asyncio
+async def test_pod_down_still_active_fails_closed(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "", "")))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+    monkeypatch.setattr(
+        mod, "rt", SimpleNamespace(active_names=lambda cfg: {"feat"}), raising=False
+    )
+    assert await mod._pod_down("feat") == {
+        "ok": False, "error": "pod still active after shutdown",
+    }
+
+
+@pytest.mark.asyncio
+async def test_pod_down_unverifiable_shutdown_fails_closed(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "", "")))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+
+    def _boom(cfg):
+        raise RuntimeError("no bus")
+
+    monkeypatch.setattr(mod, "rt", SimpleNamespace(active_names=_boom), raising=False)
+    res = await mod._pod_down("feat")
+    assert res["ok"] is False
+    assert "cannot verify pod shutdown" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_pod_down_success(monkeypatch, allow_pod):
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "", "")))
+    assert await mod._pod_down("feat") == {"ok": True, "error": None}
+
+
+@pytest.mark.asyncio
+async def test_pod_restart_stops_on_failed_shutdown(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_down", AsyncMock(return_value={"ok": False, "error": "stuck"}))
+    up = AsyncMock(return_value={"ok": True})
+    monkeypatch.setattr(mod, "_pod_up", up)
+
+    res = await mod._pod_restart("feat")
+    assert res == {"ok": False, "error": "pod shutdown failed: stuck"}
+    up.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pod_restart_starts_after_clean_shutdown(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_down", AsyncMock(return_value={"ok": True, "error": None}))
+    monkeypatch.setattr(mod, "_pod_up", AsyncMock(return_value={"ok": True, "port": 1}))
+    assert await mod._pod_restart("feat") == {"ok": True, "port": 1}
+
+
+@pytest.mark.asyncio
+async def test_pod_token_refused_by_guard(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value="denied"))
+    assert await mod._pod_token("feat") == {"ok": False, "error": "denied"}
+
+
+@pytest.mark.asyncio
+async def test_pod_token_without_config(monkeypatch, allow_pod):
+    assert await mod._pod_token("feat") == {"ok": False, "error": "PodConfig unavailable"}
+
+
+@pytest.mark.asyncio
+async def test_pod_token_mints_url(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        mod, "rt",
+        SimpleNamespace(
+            mint_token=lambda cfg, name, ttl: "SECRET",
+            derive_port=lambda cfg, name: 9123,
+        ),
+        raising=False,
+    )
+    res = await mod._pod_token("feat")
+    assert res["ok"] is True
+    assert res["url"].endswith("9123/?token=SECRET")
+
+
+@pytest.mark.asyncio
+async def test_pod_token_reports_mint_failure(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+
+    def _boom(cfg, name, ttl):
+        raise RuntimeError("keyring locked")
+
+    monkeypatch.setattr(mod, "rt", SimpleNamespace(mint_token=_boom), raising=False)
+    assert await mod._pod_token("feat") == {"ok": False, "error": "keyring locked"}
+
+
+@pytest.mark.asyncio
+async def test_pod_logs_refused_by_guard(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value="denied"))
+    assert await mod._pod_logs("feat") == {"ok": False, "error": "denied"}
+
+
+@pytest.mark.asyncio
+async def test_pod_logs_without_config(monkeypatch, allow_pod):
+    assert await mod._pod_logs("feat") == {"ok": False, "error": "PodConfig unavailable"}
+
+
+@pytest.mark.asyncio
+async def test_pod_logs_returns_redacted_journal(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        mod, "rt",
+        SimpleNamespace(recent_journal=lambda cfg, name, n: f"lines={n}"),
+        raising=False,
+    )
+    assert await mod._pod_logs("feat", 7) == {"ok": True, "logs": "lines=7"}
+
+
+@pytest.mark.asyncio
+async def test_pod_provision_refused_by_guard(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value="denied"))
+    assert await mod._pod_provision("feat") == {"ok": False, "error": "denied"}
+
+
+@pytest.mark.asyncio
+async def test_pod_provision_single_flights_running_build(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_PROVISION_INFLIGHT", {"feat": "run-1"})
+    monkeypatch.setattr(mod, "_RUNS", {"run-1": {"status": "running"}})
+    start = AsyncMock(return_value="run-2")
+    monkeypatch.setattr(mod, "_start_run", start)
+
+    assert await mod._pod_provision("feat") == {
+        "ok": False, "error": "provision already running", "run_id": "run-1",
+    }
+    start.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pod_provision_starts_run_and_records_it(monkeypatch):
+    monkeypatch.setattr(mod, "_pod_checkout_guard", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_PROVISION_INFLIGHT", {"feat": "run-0"})
+    monkeypatch.setattr(mod, "_RUNS", {"run-0": {"status": "done"}})
+    monkeypatch.setattr(
+        mod, "sandboxed_spawn_argv", lambda argv, tier, env=None: (list(argv), {}, None)
+    )
+    monkeypatch.setattr(mod, "_start_run", AsyncMock(return_value="run-9"))
+
+    assert await mod._pod_provision("feat") == {"ok": True, "run_id": "run-9"}
+    assert mod._PROVISION_INFLIGHT["feat"] == "run-9"
+
+
+# --------------------------------------------------------------------------
+# _disk
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_disk_in_progress_returns_snapshot(monkeypatch):
+    monkeypatch.setattr(mod, "_DISK", {"status": "computing", "total_mb": None, "per": {}})
+    assert (await mod._disk())["status"] == "computing"
+
+
+@pytest.mark.asyncio
+async def test_disk_done_snapshot_resets_to_idle(monkeypatch):
+    monkeypatch.setattr(mod, "_DISK", {"status": "done", "total_mb": 42, "per": {"a": 42}})
+    snap = await mod._disk()
+    assert snap["total_mb"] == 42
+    assert mod._DISK["status"] == "idle"
+
+
+@pytest.mark.asyncio
+async def test_disk_idle_starts_background_aggregation(monkeypatch):
+    monkeypatch.setattr(mod, "_DISK", {"status": "idle", "total_mb": None, "per": {}})
+    monkeypatch.setattr(
+        mod, "_discover_worktrees",
+        AsyncMock(return_value=[{"path": "/repo/wt-a"}, {"path": "/repo/wt-b"}]),
+    )
+
+    async def fake_run(cmd, **kw):
+        return (0, "12\t" + cmd[-1], "") if cmd[-1].endswith("wt-a") else (1, "", "err")
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run)
+
+    assert await mod._disk() == {"status": "computing", "total_mb": None, "per": {}}
+    for _ in range(50):
+        if mod._DISK["status"] == "done":
+            break
+        await asyncio.sleep(0.01)
+    assert mod._DISK["per"] == {"wt-a": 12}
+    assert mod._DISK["total_mb"] == 12
+
+
+@pytest.mark.asyncio
+async def test_disk_aggregation_failure_reports_unknown(monkeypatch):
+    monkeypatch.setattr(mod, "_DISK", {"status": "idle", "total_mb": None, "per": {}})
+    monkeypatch.setattr(mod, "_discover_worktrees", AsyncMock(side_effect=RuntimeError("git")))
+
+    await mod._disk()
+    for _ in range(50):
+        if mod._DISK["status"] == "done":
+            break
+        await asyncio.sleep(0.01)
+    assert mod._DISK == {"status": "done", "total_mb": None, "per": {}}
+
+
+# --------------------------------------------------------------------------
+# rebase
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_rebase_unknown_worktree(monkeypatch):
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=(None, "gone")))
+    assert await mod._rebase("feat") == {"ok": False, "error": "gone"}
+
+
+@pytest.mark.asyncio
+async def test_rebase_refuses_main_checkout(monkeypatch):
+    monkeypatch.setattr(
+        mod, "_find_worktree", AsyncMock(return_value=({"path": "/r", "is_main": True}, None))
+    )
+    assert await mod._rebase("main") == {
+        "ok": False, "error": "refusing to rebase the main checkout",
+    }
+
+
+@pytest.mark.asyncio
+async def test_rebase_rejects_concurrent_run(monkeypatch):
+    lock = asyncio.Lock()
+    await lock.acquire()
+    try:
+        monkeypatch.setattr(mod, "_WT_LOCKS", {"feat": lock})
+        monkeypatch.setattr(
+            mod, "_find_worktree", AsyncMock(return_value=({"path": "/r"}, None))
+        )
+        assert await mod._rebase("feat") == {
+            "ok": False, "error": "rebase already running for this worktree",
+        }
+    finally:
+        lock.release()
+
+
+@pytest.mark.asyncio
+async def test_rebase_locked_unverifiable_state(monkeypatch):
+    monkeypatch.setattr(mod, "_git", AsyncMock(return_value=None))
+    assert await mod._rebase_locked({"path": "/r"}) == {
+        "ok": False, "error": "cannot verify worktree state (git status failed)",
+    }
+
+
+@pytest.mark.asyncio
+async def test_rebase_locked_refuses_dirty_worktree(monkeypatch):
+    monkeypatch.setattr(mod, "_git", AsyncMock(return_value=" M file.py"))
+    assert await mod._rebase_locked({"path": "/r"}) == {
+        "ok": False, "error": "worktree has uncommitted changes",
+    }
+
+
+@pytest.mark.asyncio
+async def test_rebase_locked_fetch_failure(monkeypatch):
+    async def fake_git(path, *args, **kw):
+        return "" if args[0] == "status" else None
+
+    monkeypatch.setattr(mod, "_git", fake_git)
+    res = await mod._rebase_locked({"path": "/r"})
+    assert res["ok"] is False
+    assert res["error"] == "git fetch origin main failed"
+
+
+@pytest.mark.asyncio
+async def test_rebase_locked_success(monkeypatch):
+    async def fake_git(path, *args, **kw):
+        return "" if args[0] == "status" else "ok"
+
+    monkeypatch.setattr(mod, "_git", fake_git)
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "", "")))
+    monkeypatch.setattr(
+        mod, "_git_info", AsyncMock(return_value={"head": "abc1234", "behind": 0})
+    )
+    assert await mod._rebase_locked({"path": "/r"}) == {
+        "ok": True, "rebased": True, "head": "abc1234", "behind": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_rebase_locked_conflict_aborted(monkeypatch):
+    async def fake_git(path, *args, **kw):
+        return "" if args[0] == "status" else "ok"
+
+    monkeypatch.setattr(mod, "_git", fake_git)
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(1, "CONFLICT", "in f.py")))
+    res = await mod._rebase_locked({"path": "/r"})
+    assert res["ok"] is False and res["conflict"] is True
+    assert "aborted" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_rebase_locked_conflict_with_failed_abort(monkeypatch):
+    """A failed --abort must never be reported as 'aborted'."""
+    async def fake_git(path, *args, **kw):
+        if args[0] == "status":
+            return ""
+        if args[0] == "rebase":
+            return None
+        return "ok"
+
+    monkeypatch.setattr(mod, "_git", fake_git)
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(1, "CONFLICT", "")))
+    res = await mod._rebase_locked({"path": "/r"})
+    assert res["conflict"] is True
+    assert "manual recovery required" in res["error"]
+
+
+# --------------------------------------------------------------------------
+# prune verdicts
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_prunable_dirty_check_failure(monkeypatch):
+    monkeypatch.setattr(mod, "_pr_status_cached", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_own_commits_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(mod, "_real_dirty", AsyncMock(return_value=None))
+    v = await mod._prunable("/nope/missing", "feat")
+    assert v == {**v, "ok": False, "code": "dirty_check_failed"}
+    assert v["age_h"] is None
+
+
+@pytest.mark.asyncio
+async def test_prunable_merged_but_dirty(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "_pr_status_cached", AsyncMock(return_value={"state": "MERGED"}))
+    monkeypatch.setattr(mod, "_own_commits_count", AsyncMock(return_value=1))
+    monkeypatch.setattr(mod, "_real_dirty", AsyncMock(return_value=True))
+    assert (await mod._prunable(str(tmp_path), "feat"))["code"] == "merged_dirty"
+
+
+@pytest.mark.asyncio
+async def test_prunable_merged_unverified_when_oid_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "_pr_status_cached", AsyncMock(return_value={"state": "MERGED"}))
+    monkeypatch.setattr(mod, "_own_commits_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(mod, "_real_dirty", AsyncMock(return_value=False))
+    monkeypatch.setattr(mod, "_git", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_fetch_pr_head_oid", AsyncMock(return_value=None))
+    assert (await mod._prunable(str(tmp_path), "feat"))["code"] == "merged_unverified"
+
+
+@pytest.mark.asyncio
+async def test_prunable_merged_with_new_commits(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "_pr_status_cached", AsyncMock(return_value={"state": "MERGED"}))
+    monkeypatch.setattr(mod, "_own_commits_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(mod, "_real_dirty", AsyncMock(return_value=False))
+    monkeypatch.setattr(mod, "_git", AsyncMock(return_value="aaa"))
+    monkeypatch.setattr(mod, "_fetch_pr_head_oid", AsyncMock(return_value="bbb"))
+    monkeypatch.setattr(mod, "_head_contained_in_pr", AsyncMock(return_value=False))
+    assert (await mod._prunable(str(tmp_path), "feat"))["code"] == "merged_new_commits"
+
+
+@pytest.mark.asyncio
+async def test_prunable_merged_clean_is_candidate(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "_pr_status_cached", AsyncMock(return_value={"state": "MERGED"}))
+    monkeypatch.setattr(mod, "_own_commits_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(mod, "_real_dirty", AsyncMock(return_value=False))
+    monkeypatch.setattr(mod, "_git", AsyncMock(return_value="aaa"))
+    monkeypatch.setattr(mod, "_fetch_pr_head_oid", AsyncMock(return_value="aaa"))
+    monkeypatch.setattr(mod, "_head_contained_in_pr", AsyncMock(return_value=True))
+    v = await mod._prunable(str(tmp_path), "feat")
+    assert v["ok"] is True and v["code"] == "merged"
+
+
+@pytest.mark.asyncio
+async def test_prunable_fresh_empty_worktree_is_kept(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "_pr_status_cached", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_own_commits_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(mod, "_real_dirty", AsyncMock(return_value=False))
+    v = await mod._prunable(str(tmp_path), "feat")
+    assert v["ok"] is False and v["code"] == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_prunable_active_worktree_is_kept(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "_pr_status_cached", AsyncMock(return_value={"state": "OPEN"}))
+    monkeypatch.setattr(mod, "_own_commits_count", AsyncMock(return_value=3))
+    monkeypatch.setattr(mod, "_real_dirty", AsyncMock(return_value=False))
+    assert (await mod._prunable(str(tmp_path), "feat"))["code"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_prune_candidates_splits_and_skips_main(monkeypatch):
+    monkeypatch.setattr(
+        mod, "_discover_worktrees",
+        AsyncMock(return_value=[
+            {"path": "/r", "is_main": True},
+            {"path": "/r/wt-a", "branch": "a"},
+            {"path": "/r/wt-b", "branch": "b"},
+        ]),
+    )
+
+    async def fake_prunable(path, branch):
+        ok = branch == "a"
+        return {"ok": ok, "code": "merged" if ok else "active"}
+
+    monkeypatch.setattr(mod, "_prunable", fake_prunable)
+    out = await mod._prune_candidates()
+    assert out["scanned"] == 2
+    assert [c["name"] for c in out["candidates"]] == ["wt-a"]
+    assert [k["name"] for k in out["kept"]] == ["wt-b"]
+
+
+# --------------------------------------------------------------------------
+# fleet cache helpers
+# --------------------------------------------------------------------------
+def test_drop_worktrees_ignores_malformed_payload():
+    assert mod._drop_worktrees({"worktrees": "nope"}, {"x"}) == {"worktrees": "nope"}
+
+
+def test_drop_worktrees_returns_same_object_when_nothing_matches():
+    data = {"worktrees": [{"name": "a"}]}
+    assert mod._drop_worktrees(data, {"z"}) is data
+
+
+def test_drop_worktrees_copies_without_named_rows():
+    data = {"worktrees": [{"name": "a"}, {"name": "b"}], "other": 1}
+    out = mod._drop_worktrees(data, {"a"})
+    assert out["worktrees"] == [{"name": "b"}]
+    assert out["other"] == 1
+    assert data["worktrees"] == [{"name": "a"}, {"name": "b"}]
+
+
+@pytest.mark.asyncio
+async def test_log_fleet_rebuild_failure_ignores_cancellation():
+    async def _never():
+        await asyncio.sleep(30)
+
+    task = asyncio.create_task(_never())
+    await asyncio.sleep(0)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    mod._log_fleet_rebuild_failure(task)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_log_fleet_rebuild_failure_warns_on_exception(caplog):
+    async def _boom():
+        raise RuntimeError("rebuild died")
+
+    task = asyncio.create_task(_boom())
+    try:
+        await task
+    except RuntimeError:
+        pass
+    with caplog.at_level("WARNING", logger=mod.logger.name):
+        mod._log_fleet_rebuild_failure(task)
+    assert "rebuild died" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# GET handlers
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_fleet_handler_reports_discovery_error(monkeypatch):
+    monkeypatch.setattr(mod, "_fleet_cached", AsyncMock(side_effect=RuntimeError("no git")))
+    resp = await mod.api_dev_fleet_fleet(make_mocked_request("GET", "/api/fleet"))
+    assert json.loads(resp.text) == {"worktrees": [], "error": "no git"}
+
+
+@pytest.mark.asyncio
+async def test_fleet_handler_fresh_bypasses_cache(monkeypatch):
+    refresh = AsyncMock(return_value={"worktrees": [{"name": "a"}]})
+    monkeypatch.setattr(mod, "_fleet_refresh", refresh)
+    monkeypatch.setattr(mod, "_fleet_cached", AsyncMock(return_value={"worktrees": []}))
+    resp = await mod.api_dev_fleet_fleet(make_mocked_request("GET", "/api/fleet?fresh=1"))
+    assert json.loads(resp.text)["worktrees"] == [{"name": "a"}]
+    refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_worktree_handler_requires_name():
+    resp = await mod.api_dev_fleet_worktree(make_mocked_request("GET", "/api/worktree"))
+    assert resp.status == 400
+    assert "missing 'name'" in json.loads(resp.text)["error"]
+
+
+@pytest.mark.asyncio
+async def test_worktree_handler_rejects_unknown_name(monkeypatch):
+    monkeypatch.setattr(mod, "_valid_worktree_names", AsyncMock(return_value={"other"}))
+    resp = await mod.api_dev_fleet_worktree(make_mocked_request("GET", "/api/worktree?name=x"))
+    assert resp.status == 400
+    assert "unknown worktree" in json.loads(resp.text)["error"]
+
+
+@pytest.mark.asyncio
+async def test_worktree_handler_returns_detail(monkeypatch):
+    monkeypatch.setattr(mod, "_valid_worktree_names", AsyncMock(return_value={"x"}))
+    monkeypatch.setattr(mod, "_worktree_detail", AsyncMock(return_value={"name": "x"}))
+    resp = await mod.api_dev_fleet_worktree(make_mocked_request("GET", "/api/worktree?name=x"))
+    assert json.loads(resp.text) == {"name": "x"}
+
+
+@pytest.mark.asyncio
+async def test_pod_logs_handler_requires_name():
+    resp = await mod.api_dev_fleet_pod_logs(make_mocked_request("GET", "/api/pod/logs"))
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_pod_logs_handler_rejects_unknown_name(monkeypatch):
+    monkeypatch.setattr(mod, "_valid_worktree_names", AsyncMock(return_value=set()))
+    resp = await mod.api_dev_fleet_pod_logs(make_mocked_request("GET", "/api/pod/logs?name=x"))
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("query", "expected_n"),
+    [("", 120), ("&n=notanint", 120), ("&n=0", 1), ("&n=99999", 1000), ("&n=25", 25)],
+)
+async def test_pod_logs_handler_clamps_line_count(monkeypatch, query, expected_n):
+    monkeypatch.setattr(mod, "_valid_worktree_names", AsyncMock(return_value={"x"}))
+    seen: list[int] = []
+
+    async def fake_logs(name, n):
+        seen.append(n)
+        return {"ok": True, "logs": ""}
+
+    monkeypatch.setattr(mod, "_pod_logs", fake_logs)
+    await mod.api_dev_fleet_pod_logs(
+        make_mocked_request("GET", f"/api/pod/logs?name=x{query}")
+    )
+    assert seen == [expected_n]
+
+
+@pytest.mark.asyncio
+async def test_run_handler_requires_id():
+    resp = await mod.api_dev_fleet_run(make_mocked_request("GET", "/api/run"))
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_run_handler_unknown_id_is_404(monkeypatch):
+    monkeypatch.setattr(mod, "_RUNS", {})
+    resp = await mod.api_dev_fleet_run(make_mocked_request("GET", "/api/run?id=nope"))
+    assert resp.status == 404
+
+
+@pytest.mark.asyncio
+async def test_run_handler_tails_and_redacts_output(monkeypatch):
+    lines = [f"line {i}" for i in range(80)]
+    monkeypatch.setattr(mod, "_RUNS", {"r1": {"status": "running", "output": lines}})
+    resp = await mod.api_dev_fleet_run(make_mocked_request("GET", "/api/run?id=r1"))
+    payload = json.loads(resp.text)
+    assert len(payload["output"]) == 60
+    assert payload["output"][0] == "line 20"
+
+
+@pytest.mark.asyncio
+async def test_prune_and_disk_handlers_pass_through(monkeypatch):
+    monkeypatch.setattr(mod, "_prune_candidates", AsyncMock(return_value={"ok": True}))
+    monkeypatch.setattr(mod, "_prune_status", AsyncMock(return_value={"running": False}))
+    monkeypatch.setattr(mod, "_disk", AsyncMock(return_value={"status": "idle"}))
+
+    r1 = await mod.api_dev_fleet_prune_candidates(
+        make_mocked_request("GET", "/api/prune-candidates")
+    )
+    r2 = await mod.api_dev_fleet_prune_status(make_mocked_request("GET", "/api/prune-status"))
+    r3 = await mod.api_dev_fleet_disk(make_mocked_request("GET", "/api/disk"))
+    assert json.loads(r1.text) == {"ok": True}
+    assert json.loads(r2.text) == {"running": False}
+    assert json.loads(r3.text) == {"status": "idle"}
+
+
+# --------------------------------------------------------------------------
+# _json_body + POST handler validation
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_json_body_rejects_invalid_json():
+    body, err = await mod._json_body(_raw_request(b"{oops", json_error=ValueError("bad")))
+    assert body is None and err is not None and err.status == 400
+
+
+@pytest.mark.asyncio
+async def test_json_body_rejects_non_object():
+    body, err = await mod._json_body(_raw_request(b"[1, 2]"))
+    assert body is None and err is not None
+    assert "must be an object" in json.loads(err.text)["error"]
+
+
+@pytest.mark.asyncio
+async def test_json_body_empty_request_is_empty_dict():
+    request = MagicMock()
+    request.content_length = 0
+    body, err = await mod._json_body(request)
+    assert body == {} and err is None
+
+
+@pytest.mark.asyncio
+async def test_worktree_remove_handler_rejects_non_bool_force(monkeypatch):
+    _sel_capture(monkeypatch)
+    monkeypatch.setattr(mod, "_valid_worktree_names", AsyncMock(return_value={"feat"}))
+    resp = await mod.api_dev_fleet_worktree_remove(
+        _json_request({"name": "feat", "force": "yes"})
+    )
+    assert resp.status == 400
+    assert "force must be a boolean" in json.loads(resp.text)["error"]
+
+
+@pytest.mark.asyncio
+async def test_worktree_remove_handler_forwards_force(monkeypatch):
+    _sel_capture(monkeypatch)
+    monkeypatch.setattr(mod, "_valid_worktree_names", AsyncMock(return_value={"feat"}))
+    remove = AsyncMock(return_value={"ok": True})
+    monkeypatch.setattr(mod, "_worktree_remove", remove)
+
+    resp = await mod.api_dev_fleet_worktree_remove(_json_request({"name": "feat", "force": True}))
+    assert resp.status == 200
+    remove.assert_awaited_once_with("feat", True)
+
+
+@pytest.mark.asyncio
+async def test_prune_run_handler_rejects_invalid_json(monkeypatch):
+    _sel_capture(monkeypatch)
+    resp = await mod.api_dev_fleet_prune_run(_raw_request(b"{", json_error=ValueError("bad")))
+    assert resp.status == 400
+    assert json.loads(resp.text)["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_prune_run_handler_rejects_non_object_body(monkeypatch):
+    _sel_capture(monkeypatch)
+    resp = await mod.api_dev_fleet_prune_run(_raw_request(b"[]"))
+    assert resp.status == 400
+    assert "must be an object" in json.loads(resp.text)["error"]
+
+
+@pytest.mark.asyncio
+async def test_prune_run_handler_rejects_non_string_names(monkeypatch):
+    _sel_capture(monkeypatch)
+    resp = await mod.api_dev_fleet_prune_run(_json_request({"names": ["a", 7]}))
+    assert resp.status == 400
+    assert "list of strings" in json.loads(resp.text)["error"]
+
+
+@pytest.mark.asyncio
+async def test_prune_run_handler_rejects_when_no_name_is_valid(monkeypatch):
+    _sel_capture(monkeypatch)
+    monkeypatch.setattr(mod, "_valid_worktree_names", AsyncMock(return_value={"other"}))
+    resp = await mod.api_dev_fleet_prune_run(_json_request({"names": ["ghost"]}))
+    assert resp.status == 400
+    assert json.loads(resp.text)["error"] == "no valid names"
+
+
+@pytest.mark.asyncio
+async def test_prune_run_handler_filters_to_valid_names(monkeypatch):
+    _sel_capture(monkeypatch)
+    monkeypatch.setattr(mod, "_valid_worktree_names", AsyncMock(return_value={"a"}))
+    run = AsyncMock(return_value={"ok": True})
+    monkeypatch.setattr(mod, "_prune_run", run)
+
+    resp = await mod.api_dev_fleet_prune_run(_json_request({"names": ["a", "ghost"]}))
+    assert resp.status == 200
+    run.assert_awaited_once_with(["a"])
+
+
+@pytest.mark.asyncio
+async def test_pod_name_action_rejects_empty_name(monkeypatch):
+    _sel_capture(monkeypatch)
+    resp = await mod.api_dev_fleet_pod_up(_json_request({"name": ""}))
+    assert resp.status == 400
+    assert "non-empty string" in json.loads(resp.text)["error"]
+
+
+@pytest.mark.asyncio
+async def test_pod_name_action_rejects_ambiguous_basename(monkeypatch):
+    """_find_worktree, not set membership, is the validator (collision safety)."""
+    _sel_capture(monkeypatch)
+    monkeypatch.setattr(
+        mod, "_find_worktree", AsyncMock(return_value=(None, "ambiguous name 'feat'"))
+    )
+    resp = await mod.api_dev_fleet_pod_restart(_json_request({"name": "feat"}))
+    assert resp.status == 400
+    assert json.loads(resp.text)["error"] == "ambiguous name 'feat'"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler_name", "action_name"),
+    [
+        ("api_dev_fleet_pod_up", "_pod_up"),
+        ("api_dev_fleet_pod_down", "_pod_down"),
+        ("api_dev_fleet_pod_restart", "_pod_restart"),
+        ("api_dev_fleet_pod_token", "_pod_token"),
+        ("api_dev_fleet_pod_provision", "_pod_provision"),
+        ("api_dev_fleet_rebase", "_rebase"),
+    ],
+)
+async def test_pod_handlers_dispatch_to_their_action(monkeypatch, handler_name, action_name):
+    _sel_capture(monkeypatch)
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=({"path": "/w"}, None)))
+    action = AsyncMock(return_value={"ok": True, "via": action_name})
+    monkeypatch.setattr(mod, action_name, action)
+
+    resp = await getattr(mod, handler_name)(_json_request({"name": "feat"}))
+    assert json.loads(resp.text) == {"ok": True, "via": action_name}
+    action.assert_awaited_once_with("feat")
+
+
+@pytest.mark.asyncio
+async def test_sync_handler_maps_already_running_to_409(monkeypatch):
+    _sel_capture(monkeypatch)
+    monkeypatch.setattr(
+        mod, "_sync", AsyncMock(return_value={"ok": False, "error": "sync already running"})
+    )
+    request = MagicMock()
+    request.content_length = 0
+    request.can_read_body = False
+    resp = await mod.api_dev_fleet_sync(request)
+    assert resp.status == 409
+
+
+@pytest.mark.asyncio
+async def test_sync_handler_success_is_200(monkeypatch):
+    _sel_capture(monkeypatch)
+    monkeypatch.setattr(mod, "_sync", AsyncMock(return_value={"ok": True}))
+    request = MagicMock()
+    request.content_length = 0
+    request.can_read_body = False
+    resp = await mod.api_dev_fleet_sync(request)
+    assert resp.status == 200
+
+
+# --------------------------------------------------------------------------
+# make-live handler
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_make_live_handler_requires_path(monkeypatch):
+    _sel_capture(monkeypatch)
+    resp = await mod.api_dev_fleet_make_live(_json_request({"path": ""}))
+    assert resp.status == 400
+    assert "non-empty string" in json.loads(resp.text)["error"]
+
+
+@pytest.mark.asyncio
+async def test_make_live_handler_rejects_non_bool_dry_run(monkeypatch):
+    _sel_capture(monkeypatch)
+    resp = await mod.api_dev_fleet_make_live(_json_request({"path": "/w", "dry_run": "1"}))
+    assert resp.status == 400
+    assert "dry_run must be a boolean" in json.loads(resp.text)["error"]
+
+
+@pytest.mark.asyncio
+async def test_make_live_handler_forwards_dry_run(monkeypatch):
+    sink = _sel_capture(monkeypatch)
+    make_live = AsyncMock(return_value={"ok": True, "dry_run": True})
+    monkeypatch.setattr(mod, "_make_live", make_live)
+
+    resp = await mod.api_dev_fleet_make_live(_json_request({"path": "/w", "dry_run": True}))
+    assert resp.status == 200
+    make_live.assert_awaited_once_with("/w", True)
+    assert sink.events[0]["resources"] == "/w"
+
+
+# --------------------------------------------------------------------------
+# _audited
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_audited_bodyless_request_has_empty_target(monkeypatch):
+    sink = _sel_capture(monkeypatch)
+
+    @mod._audited("probe")
+    async def handler(request):
+        return web.json_response({"ok": True})
+
+    request = MagicMock()
+    request.content_length = 0
+    request.can_read_body = False
+    await handler(request)
+    assert sink.events[0]["resources"] == ""
+    assert sink.events[0]["outcome"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_audited_joins_list_target(monkeypatch):
+    sink = _sel_capture(monkeypatch)
+
+    @mod._audited("probe")
+    async def handler(request):
+        return web.json_response({"ok": True})
+
+    await handler(_json_request({"names": ["a", "b", "c"]}))
+    assert sink.events[0]["resources"] == "a,b,c"
+
+
+@pytest.mark.asyncio
+async def test_audited_ignores_unparsable_body(monkeypatch):
+    sink = _sel_capture(monkeypatch)
+
+    @mod._audited("probe")
+    async def handler(request):
+        return web.json_response({"ok": True})
+
+    await handler(_raw_request(b"not json at all"))
+    assert sink.events[0]["resources"] == ""
+
+
+@pytest.mark.asyncio
+async def test_audited_non_dict_body_has_empty_target(monkeypatch):
+    sink = _sel_capture(monkeypatch)
+
+    @mod._audited("probe")
+    async def handler(request):
+        return web.json_response({"ok": True})
+
+    await handler(_raw_request(b"[1,2,3]"))
+    assert sink.events[0]["resources"] == ""
+
+
+@pytest.mark.asyncio
+async def test_audited_read_failure_does_not_break_handler(monkeypatch):
+    sink = _sel_capture(monkeypatch)
+
+    @mod._audited("probe")
+    async def handler(request):
+        return web.json_response({"ok": True})
+
+    request = MagicMock()
+    request.content_length = 5
+    request.can_read_body = True
+    request.read = AsyncMock(side_effect=RuntimeError("stream gone"))
+    await handler(request)
+    assert sink.events[0]["resources"] == ""
+
+
+@pytest.mark.asyncio
+async def test_audited_handler_exception_is_audited_and_reraised(monkeypatch):
+    sink = _sel_capture(monkeypatch)
+
+    @mod._audited("probe")
+    async def handler(request):
+        raise KeyError("kaboom")
+
+    with pytest.raises(KeyError):
+        await handler(_json_request({"name": "feat"}))
+    assert sink.events[0]["outcome"] == "failure"
+    assert sink.events[0]["error"] == "KeyError"
+
+
+@pytest.mark.asyncio
+async def test_audited_server_error_is_failure(monkeypatch):
+    sink = _sel_capture(monkeypatch)
+
+    @mod._audited("probe")
+    async def handler(request):
+        return web.json_response({"error": "internal"}, status=500)
+
+    await handler(_json_request({"name": "feat"}))
+    assert sink.events[0]["outcome"] == "failure"
+    assert sink.events[0]["error"] == "internal"
+
+
+@pytest.mark.asyncio
+async def test_audited_non_json_response_still_audits_success(monkeypatch):
+    sink = _sel_capture(monkeypatch)
+
+    @mod._audited("probe")
+    async def handler(request):
+        return web.Response(text="plain body")
+
+    await handler(_json_request({"name": "feat"}))
+    assert sink.events[0]["outcome"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_audited_non_dict_json_response_is_success(monkeypatch):
+    sink = _sel_capture(monkeypatch)
+
+    @mod._audited("probe")
+    async def handler(request):
+        return web.json_response([1, 2])
+
+    await handler(_json_request({"name": "feat"}))
+    assert sink.events[0]["outcome"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_audited_error_free_denial_falls_back_to_status(monkeypatch):
+    sink = _sel_capture(monkeypatch)
+
+    @mod._audited("probe")
+    async def handler(request):
+        return web.json_response({}, status=403)
+
+    await handler(_json_request({"name": "feat"}))
+    assert sink.events[0]["outcome"] == "denied"
+    assert sink.events[0]["error"] == "http_403"
+
+
+@pytest.mark.asyncio
+async def test_audited_preserves_handler_identity():
+    async def original(request):
+        """Docstring stays."""
+        return web.json_response({})
+
+    wrapped = mod._audited("probe")(original)
+    assert wrapped.__name__ == "original"
+    assert wrapped.__doc__ == "Docstring stays."
+
+
+# --------------------------------------------------------------------------
+# HMAC middleware denials
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_hmac_health_path_is_exempt(monkeypatch):
+    called: list[bool] = []
+
+    async def handler(request):
+        called.append(True)
+        return web.json_response({"status": "ok"})
+
+    await mod.hmac_proxy_middleware(make_mocked_request("GET", "/health"), handler)
+    assert called == [True]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("headers", "secret", "reason"),
+    [
+        ({}, "", "no app secret configured"),
+        ({}, "s3cr3t", "missing X-KiroCrew-Proxy header"),
+        ({"X-KiroCrew-Proxy": "nocolon"}, "s3cr3t", "malformed X-KiroCrew-Proxy header"),
+        ({"X-KiroCrew-Proxy": "abc:sig"}, "s3cr3t", "invalid timestamp in proxy header"),
+        ({"X-KiroCrew-Proxy": "1:sig"}, "s3cr3t", "proxy signature expired"),
+    ],
+)
+async def test_hmac_denials(monkeypatch, headers, secret, reason):
+    sink = _sel_capture(monkeypatch)
+    monkeypatch.setattr(mod, "_load_app_secret", lambda: secret)
+
+    async def handler(request):  # pragma: no cover - must never run
+        raise AssertionError("handler must not be reached")
+
+    request = make_mocked_request("GET", "/api/fleet", headers=headers)
+    resp = await mod.hmac_proxy_middleware(request, handler)
+    assert resp.status == 401
+    assert reason in json.loads(resp.text)["error"]
+    assert sink.events[0]["outcome"] == "denied"
+    assert sink.events[0]["tool_name"] == "dev-fleet:proxy-hmac"
+
+
+@pytest.mark.asyncio
+async def test_hmac_denial_survives_audit_sink_failure(monkeypatch, caplog):
+    """A broken SEL sink must never mask the 401."""
+    def _boom():
+        raise RuntimeError("sel down")
+
+    monkeypatch.setattr(mod, "_sel", _boom)
+    monkeypatch.setattr(mod, "_load_app_secret", lambda: "s3cr3t")
+
+    async def handler(request):  # pragma: no cover - must never run
+        raise AssertionError("handler must not be reached")
+
+    with caplog.at_level("WARNING", logger=mod.logger.name):
+        resp = await mod.hmac_proxy_middleware(
+            make_mocked_request("GET", "/api/fleet"), handler
+        )
+    assert resp.status == 401
+    assert "SEL emit failed" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# gateway identity helpers
+# --------------------------------------------------------------------------
+def test_gateway_unit_name_defaults_to_live_unit(monkeypatch, tmp_path):
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path / "home")
+    assert mod._gateway_unit_name() == mod._LIVE_GATEWAY_UNIT
+
+
+def test_gateway_unit_name_uses_pod_instance(monkeypatch, tmp_path):
+    home = tmp_path / ".kirocrew-pods" / "feat"
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: home)
+    assert mod._gateway_unit_name() == "kirocrew-pod@feat.service"
+
+
+def test_gateway_unit_name_falls_back_when_home_unresolvable(monkeypatch):
+    def _boom():
+        raise RuntimeError("no home")
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", _boom)
+    assert mod._gateway_unit_name() == mod._LIVE_GATEWAY_UNIT
+
+
+def test_gateway_label_defaults_to_live_agent(monkeypatch, tmp_path):
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path / "home")
+    assert mod._gateway_label() == mod._LIVE_GATEWAY_LABEL
+
+
+def test_gateway_label_uses_pod_agent(monkeypatch, tmp_path):
+    launchd = pytest.importorskip("kiro_crew.pod.launchd")
+    pod_config = pytest.importorskip("kiro_crew.pod.config")
+    home = tmp_path / ".kirocrew-pods" / "feat"
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: home)
+    monkeypatch.delenv("KIROCREW_POD_UNIT_PREFIX", raising=False)
+    expected = f"{launchd.LABEL_PREFIX}.{pod_config.DEFAULT_UNIT_PREFIX}.feat"
+    assert mod._gateway_label() == expected
+
+
+def test_gateway_label_honours_unit_prefix_override(monkeypatch, tmp_path):
+    launchd = pytest.importorskip("kiro_crew.pod.launchd")
+    home = tmp_path / ".kirocrew-pods" / "feat"
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: home)
+    monkeypatch.setenv("KIROCREW_POD_UNIT_PREFIX", "altplane")
+    assert mod._gateway_label() == f"{launchd.LABEL_PREFIX}.altplane.feat"
+
+
+@pytest.mark.parametrize(
+    ("home_parts", "expected"),
+    [((".kirocrew-pods", "feat"), True), (("home", "kirocrew"), False)],
+)
+def test_in_pod_detection(monkeypatch, tmp_path, home_parts, expected):
+    monkeypatch.setattr(
+        "kiro_crew.config.loader.config_dir", lambda: tmp_path.joinpath(*home_parts)
+    )
+    assert mod._in_pod() is expected
+
+
+def test_in_pod_is_none_when_home_unresolvable(monkeypatch):
+    def _boom():
+        raise RuntimeError("no home")
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", _boom)
+    assert mod._in_pod() is None
+
+
+def test_foreground_backend_is_none_off_posix(monkeypatch):
+    monkeypatch.setattr(mod.sys, "platform", "win32")
+    assert mod._foreground_backend() is None
+
+
+# --------------------------------------------------------------------------
+# drop-in rollback + path selector
+# --------------------------------------------------------------------------
+def test_restore_dropin_deletes_when_there_was_none(tmp_path):
+    dropin = tmp_path / "make-live.conf"
+    dropin.write_text("[Service]\n", encoding="utf-8", newline="\n")
+    assert mod._restore_dropin(dropin, None) is True
+    assert not dropin.exists()
+
+
+def test_restore_dropin_rewrites_prior_content(tmp_path):
+    dropin = tmp_path / "make-live.conf"
+    dropin.write_text("new\n", encoding="utf-8", newline="\n")
+    assert mod._restore_dropin(dropin, "prior\n") is True
+    assert dropin.read_text(encoding="utf-8") == "prior\n"
+
+
+def test_restore_dropin_reports_failure(monkeypatch, tmp_path):
+    def _boom(path, content):
+        raise OSError("read-only fs")
+
+    monkeypatch.setattr(gateway_service, "atomic_write_text", _boom)
+    assert mod._restore_dropin(tmp_path / "make-live.conf", "prior") is False
+
+
+@pytest.mark.asyncio
+async def test_find_worktree_by_path_requires_path():
+    wt, err = await mod._find_worktree_by_path("")
+    assert wt is None
+    assert err is not None and "non-empty string" in err
+
+
+@pytest.mark.asyncio
+async def test_find_worktree_by_path_unknown_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "_discover_worktrees", AsyncMock(return_value=[]))
+    wt, err = await mod._find_worktree_by_path(str(tmp_path / "nope"))
+    assert wt is None
+    assert err is not None and "not a known worktree" in err
+
+
+@pytest.mark.asyncio
+async def test_find_worktree_by_path_matches_known_worktree(monkeypatch, tmp_path):
+    wanted = tmp_path / "kirocrew-wt-alpha"
+    wanted.mkdir()
+    monkeypatch.setattr(
+        mod, "_discover_worktrees",
+        AsyncMock(return_value=[{"path": str(tmp_path / "other")}, {"path": str(wanted)}]),
+    )
+    wt, err = await mod._find_worktree_by_path(str(wanted))
+    assert err is None
+    assert wt is not None and _same(wt["path"], str(wanted))
+
+
+# --------------------------------------------------------------------------
+# lifecycle
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_cleanup_kills_runs_and_cancels_workers(monkeypatch):
+    async def _never():
+        await asyncio.sleep(30)
+
+    run_task = asyncio.create_task(_never())
+    refresher = asyncio.create_task(_never())
+    await asyncio.sleep(0)
+
+    proc = MagicMock()
+    proc.returncode = None
+    proc.pid = 4242
+    kill_tree = AsyncMock()
+    monkeypatch.setattr(mod, "_kill_tree", kill_tree)
+    monkeypatch.setattr(mod, "_ACTIVE_RUNS", {"r1": (run_task, proc)})
+    monkeypatch.setattr(mod, "_refresher_task", refresher)
+    monkeypatch.setattr(mod, "_warm_task", None)
+    monkeypatch.setattr(mod, "_reaper_task", None)
+
+    await mod.dev_fleet_cleanup(MagicMock())
+
+    kill_tree.assert_awaited_once_with(4242)
+    proc.kill.assert_called_once()
+    assert mod._ACTIVE_RUNS == {}
+    assert run_task.cancelled() or run_task.done()
+    assert refresher.cancelled() or refresher.done()
+    assert mod._refresher_task is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_tolerates_already_dead_process(monkeypatch):
+    async def _never():
+        await asyncio.sleep(30)
+
+    run_task = asyncio.create_task(_never())
+    await asyncio.sleep(0)
+
+    proc = MagicMock()
+    proc.returncode = None
+    proc.pid = 77
+    proc.kill.side_effect = ProcessLookupError
+    monkeypatch.setattr(mod, "_kill_tree", AsyncMock())
+    monkeypatch.setattr(mod, "_ACTIVE_RUNS", {"r1": (run_task, proc)})
+    monkeypatch.setattr(mod, "_refresher_task", None)
+    monkeypatch.setattr(mod, "_warm_task", None)
+    monkeypatch.setattr(mod, "_reaper_task", None)
+
+    await mod.dev_fleet_cleanup(MagicMock())
+    assert mod._ACTIVE_RUNS == {}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_skips_finished_process(monkeypatch):
+    async def _done():
+        return None
+
+    run_task = asyncio.create_task(_done())
+    await run_task
+
+    proc = MagicMock()
+    proc.returncode = 0
+    kill_tree = AsyncMock()
+    monkeypatch.setattr(mod, "_kill_tree", kill_tree)
+    monkeypatch.setattr(mod, "_ACTIVE_RUNS", {"r1": (run_task, proc)})
+    monkeypatch.setattr(mod, "_refresher_task", None)
+    monkeypatch.setattr(mod, "_warm_task", None)
+    monkeypatch.setattr(mod, "_reaper_task", None)
+
+    await mod.dev_fleet_cleanup(MagicMock())
+    kill_tree.assert_not_awaited()
+    proc.kill.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# app factory + entry point
+# --------------------------------------------------------------------------
+def test_create_app_registers_lifecycle_hooks_by_name():
+    app = mod.create_app()
+    startup_names = [getattr(h, "__name__", "") for h in app.on_startup]
+    cleanup_names = [getattr(h, "__name__", "") for h in app.on_cleanup]
+    assert "dev_fleet_startup" in startup_names
+    assert "dev_fleet_cleanup" in cleanup_names
+
+
+def test_create_app_exposes_health_on_both_paths():
+    app = mod.create_app()
+    paths = {
+        r.resource.canonical
+        for r in app.router.routes()
+        if r.resource is not None
+    }
+    assert {"/health", "/api/health"} <= paths
+    assert "/api/make-live" in paths
+
+
+def test_main_runs_the_app_on_loopback(monkeypatch):
+    seen: dict = {}
+
+    def fake_run_app(app, host=None, port=None, print=None):
+        seen.update({"app": app, "host": host, "port": port})
+
+    monkeypatch.setattr(mod.web, "run_app", fake_run_app)
+    assert mod.main() == 0
+    assert seen["host"] == "127.0.0.1"
+    assert seen["port"] == mod.PORT
+
+
+# --------------------------------------------------------------------------
+# worktree detail
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_worktree_detail_unknown_name(monkeypatch):
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=(None, "gone")))
+    assert await mod._worktree_detail("ghost") == {"error": "gone"}
+
+
+@pytest.mark.asyncio
+async def test_worktree_detail_includes_pod_state_and_design_docs(monkeypatch, tmp_path):
+    wt = {"path": str(tmp_path), "branch": "feat", "is_main": False}
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=(wt, None)))
+    monkeypatch.setattr(
+        mod, "_git_info",
+        AsyncMock(return_value={
+            "branch": "feat", "head": "abc1234", "dirty": False,
+            "ahead": 0, "behind": 0, "last_updated_at": None,
+        }),
+    )
+    monkeypatch.setattr(mod, "_pr_status_cached", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_own_commits_count", AsyncMock(return_value=1))
+    monkeypatch.setattr(mod, "_context_cached", AsyncMock(return_value={}))
+
+    async def fake_git(path, *args, **kw):
+        if args[0] == "log":
+            return "abc1234\x1ffeat: do a thing\x1f2 hours ago\nmalformed line"
+        if args[0] == "diff":
+            return "docs/design/plan.md\nsrc/app.py\ndocs/design/plan.md\n"
+        return ""
+
+    monkeypatch.setattr(mod, "_git", fake_git)
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "31\t.", "")))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: SimpleNamespace())
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+    name = Path(str(tmp_path)).name
+    monkeypatch.setattr(
+        mod, "rt",
+        SimpleNamespace(
+            active_names=lambda cfg: {name},
+            derive_port=lambda cfg, nm: 9321,
+        ),
+        raising=False,
+    )
+
+    detail = await mod._worktree_detail(name)
+    assert detail["pod_running"] is True
+    assert detail["pod_port"] == 9321
+    assert detail["disk_mb"] == 31
+    assert detail["commits"] == [
+        {"hash": "abc1234", "subject": "feat: do a thing", "when": "2 hours ago"}
+    ]
+    assert detail["design_docs"] == ["docs/design/plan.md"]
+
+
+@pytest.mark.asyncio
+async def test_worktree_detail_survives_pod_probe_failure(monkeypatch, tmp_path):
+    wt = {"path": str(tmp_path), "branch": None, "is_main": True}
+    monkeypatch.setattr(mod, "_find_worktree", AsyncMock(return_value=(wt, None)))
+    monkeypatch.setattr(
+        mod, "_git_info",
+        AsyncMock(return_value={
+            "branch": "main", "head": "abc1234", "dirty": False,
+            "ahead": 0, "behind": 0, "last_updated_at": None,
+        }),
+    )
+    monkeypatch.setattr(mod, "_own_commits_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(mod, "_context_cached", AsyncMock(return_value={}))
+    monkeypatch.setattr(mod, "_git", AsyncMock(return_value=""))
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(1, "", "du failed")))
+    monkeypatch.setattr(mod, "_load_cfg", lambda: None)
+
+    detail = await mod._worktree_detail(Path(str(tmp_path)).name)
+    assert detail["pod_running"] is False
+    assert detail["disk_mb"] is None
+    assert detail["commits"] == []

--- a/test/test_gitlab_client_coverage.py
+++ b/test/test_gitlab_client_coverage.py
@@ -1,0 +1,1541 @@
+"""Unit coverage for Issue Radar's GitLab client (``gitlab_client``).
+
+The module is a function-for-function mirror of ``github_client`` that shells out
+to the user's own ``glab`` CLI, so almost everything worth testing sits between
+two seams: the argv/query a call BUILDS, and the normalization it applies to the
+JSON that comes back. Both are exercised here through a stubbed transport --
+``_glab_run`` is replaced by a router that answers from a table keyed on the API
+path -- so no subprocess is spawned, no network is touched, and the POSIX-only
+binary resolution is only reached by the handful of tests that target it
+directly.
+
+Coverage is deliberately weighted toward the branches a happy-path test never
+sees: pagination (short page, page cap, non-list payload), the error mapping
+(auth marker -> setup error, 403 -> permission error, unparseable JSON -> CLI
+error), the degrade-rather-than-fail paths (label colours, secondary timeline
+streams), and the refusals the module makes on purpose (auto-merge, a
+"request changes" review, an MR open-count probe).
+"""
+
+import json
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from kiro_crew.apps.builtins.issue_radar.backend import gitlab_client as gl
+
+# The autouse isolation fixture stubs ``allowed_hosts``, so the two tests that
+# cover the real reader hold onto it here, before any patching.
+_REAL_ALLOWED_HOSTS = gl.allowed_hosts
+
+# ── test transport ───────────────────────────────────────────────────────────
+
+
+def _proc(stdout: str = "", returncode: int = 0, stderr: str = "") -> SimpleNamespace:
+    """A stand-in for the ``CompletedProcess`` ``_glab_run`` returns."""
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode, args=[])
+
+
+class Router:
+    """Stub for ``_glab_run``: answers from an ordered path table, records calls.
+
+    Each table entry is ``(substring, answer)`` where ``answer`` is either a
+    JSON-able payload (returned as a successful stdout), a ``(returncode, stderr)``
+    tuple (returned as a failure), or a callable taking the router (so a paginated
+    read can answer differently per page).
+    """
+
+    def __init__(self, table):
+        self.table = list(table)
+        self.calls: list[dict] = []
+
+    def __call__(self, argv, *, host, timeout, input_text=None):
+        target = argv[2] if len(argv) > 2 else ""
+        self.calls.append(
+            {"argv": list(argv), "target": target, "host": host,
+             "timeout": timeout, "input": input_text}
+        )
+        for pattern, answer in self.table:
+            if pattern in target:
+                if callable(answer):
+                    answer = answer(self)
+                if isinstance(answer, tuple):
+                    return _proc(returncode=answer[0], stderr=answer[1])
+                if isinstance(answer, str):
+                    return _proc(stdout=answer)
+                return _proc(stdout=json.dumps(answer))
+        return _proc(stdout="{}")
+
+    def targets(self, needle: str = "") -> list[str]:
+        return [c["target"] for c in self.calls if needle in c["target"]]
+
+
+@pytest.fixture
+def route(monkeypatch):
+    """Install a :class:`Router` as the module's only transport."""
+
+    def _install(table):
+        router = Router(table)
+        monkeypatch.setattr(gl, "_glab_run", router)
+        return router
+
+    return _install
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    """No inherited state: KIROCREW_HOME under tmp_path, no cached binary, no SEL."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(gl, "_glab_bin_cache", None)
+    monkeypatch.setattr(gl, "sel", lambda: SimpleNamespace(log_api_access=lambda **kw: None))
+    monkeypatch.setattr(gl, "allowed_hosts", lambda: frozenset({"gitlab.acme.example"}))
+
+
+ISSUE = {
+    "iid": 7,
+    "title": "Broken pipeline",
+    "web_url": "https://gitlab.com/g/p/-/issues/7",
+    "labels": ["bug", "", 3],
+    "user_notes_count": 4,
+    "upvotes": 2,
+    "downvotes": 1,
+    "updated_at": "2026-07-02T00:00:00Z",
+    "created_at": "2026-07-01T00:00:00Z",
+    "state": "opened",
+    "author": {"username": "alice"},
+    "assignees": [{"username": "bob"}, {"nope": 1}],
+    "description": "body text",
+    "discussion_locked": True,
+    "closed_at": None,
+    "closed_by": {"username": "carol"},
+    "milestone": {"title": "v1", "state": "active", "due_date": "2026-08-01"},
+}
+
+MR = {
+    "iid": 12,
+    "title": "Add widget",
+    "web_url": "https://gitlab.com/g/p/-/merge_requests/12",
+    "state": "opened",
+    "work_in_progress": True,
+    "labels": ["bug"],
+    "author": {"username": "alice"},
+    "updated_at": "2026-07-02T00:00:00Z",
+    "created_at": "2026-07-01T00:00:00Z",
+    "closed_at": None,
+    "merged_at": None,
+    "assignees": [{"username": "bob"}],
+    "reviewers": [{"username": "carol"}],
+    "target_branch": "main",
+    "source_branch": "feat/widget",
+    "sha": "abc1234",
+    "description": "why",
+    "head_pipeline": {"status": "running"},
+}
+
+LABELS = [
+    {"name": "bug", "color": "#d9534f", "description": "a defect"},
+    {"name": "chore", "color": "#cccccc"},
+    {"noname": True},
+]
+
+
+# ── URL parsing ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "link",
+    [
+        "",
+        "http://gitlab.com/g/p",
+        "https://user:pw@gitlab.com/g/p",
+        "https://gitlab.com/g",
+        "https://gitlab.com/g/p/../x",
+        "https://gitlab.com/g/p p",
+        "https://gitlab.com/groups/g/p",
+        "https://gitlab.com/api/p",
+        "https://evil.example/g/p",
+        "https://gitlab.com:notaport/g/p",
+        "https://[oops/g/p",
+        "https://gitlab.acme.example:8443/g/p",
+    ],
+)
+def test_parse_rejects_unusable_links(link):
+    with pytest.raises(gl.RepoUrlError):
+        gl.parse_gitlab_repo_url(link)
+
+
+def test_parse_rejects_a_non_string():
+    with pytest.raises(gl.RepoUrlError):
+        gl.parse_gitlab_repo_url(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "link,expected",
+    [
+        ("https://gitlab.com/g/p", ("gitlab.com", "g", "p")),
+        ("https://www.gitlab.com/g/p/", ("gitlab.com", "g", "p")),
+        ("https://gitlab.com/g/sub/p.git", ("gitlab.com", "g/sub", "p")),
+        ("https://gitlab.com/g/p/-/merge_requests/7", ("gitlab.com", "g", "p")),
+        ("https://gitlab.com:443/g/p", ("gitlab.com", "g", "p")),
+        ("  https://gitlab.com/g/p  ", ("gitlab.com", "g", "p")),
+    ],
+)
+def test_parse_accepts_project_urls(link, expected):
+    assert gl.parse_gitlab_repo_url(link) == expected
+
+
+def test_parse_matches_a_self_managed_host_from_the_allowlist():
+    allowed = frozenset({"gitlab.acme.example"})
+    assert gl.parse_gitlab_repo_url(
+        "https://gitlab.acme.example./team/app", allowed_hosts=allowed
+    ) == ("gitlab.acme.example", "team", "app")
+
+
+def test_parse_requires_the_port_to_be_allowlisted_too():
+    allowed = frozenset({"gitlab.acme.example:8443"})
+    assert gl.parse_gitlab_repo_url(
+        "https://gitlab.acme.example:8443/team/app", allowed_hosts=allowed
+    ) == ("gitlab.acme.example:8443", "team", "app")
+
+
+def test_project_path_encodes_the_namespace_separator():
+    assert gl.project_path("g/sub", "p") == "g%2Fsub%2Fp"
+
+
+# ── host resolution, env, allowlist ──────────────────────────────────────────
+
+
+def test_resolve_host_requires_a_host():
+    with pytest.raises(gl.ProviderCliError, match="host is required"):
+        gl._resolve_host("")
+
+
+@pytest.mark.parametrize("host", ["gitlab.com", "WWW.GitLab.com", "gitlab.acme.example."])
+def test_resolve_host_accepts_public_and_allowlisted(host):
+    assert gl._resolve_host(host) in {"gitlab.com", "gitlab.acme.example"}
+
+
+def test_resolve_host_refuses_an_unlisted_host():
+    with pytest.raises(gl.ProviderCliError, match="allowlist"):
+        gl._resolve_host("gitlab.evil.example")
+
+
+def test_allowed_hosts_reads_the_config(monkeypatch):
+    monkeypatch.setattr(
+        gl,
+        "KiroCrewConfig",
+        SimpleNamespace(
+            load=lambda: SimpleNamespace(dashboard=SimpleNamespace(gitlab_hosts=["a.example"]))
+        ),
+    )
+    assert _REAL_ALLOWED_HOSTS() == frozenset({"a.example"})
+
+
+def test_allowed_hosts_fails_closed_on_a_broken_config(monkeypatch):
+    def _boom():
+        raise RuntimeError("unreadable")
+
+    monkeypatch.setattr(gl, "KiroCrewConfig", SimpleNamespace(load=_boom))
+    assert _REAL_ALLOWED_HOSTS() == frozenset()
+
+
+def test_glab_env_pins_the_host_and_drops_the_token_off_gitlab_com(monkeypatch):
+    monkeypatch.setenv("GITLAB_TOKEN", "glpat-xyz")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    env = gl._glab_env("gitlab.acme.example")
+    assert env["GITLAB_HOST"] == "gitlab.acme.example"
+    assert env["GLAB_PAGER"] == "cat"
+    assert env["NO_COLOR"] == "1"
+    assert "GITLAB_TOKEN" not in env
+    assert env["HTTPS_PROXY"] == "http://proxy.example:3128"
+
+
+def test_glab_env_keeps_the_token_for_gitlab_com(monkeypatch):
+    monkeypatch.setenv("GITLAB_TOKEN", "glpat-xyz")
+    assert gl._glab_env("gitlab.com")["GITLAB_TOKEN"] == "glpat-xyz"
+
+
+# ── the spawn chokepoint ─────────────────────────────────────────────────────
+
+
+def test_glab_run_substitutes_the_trusted_binary(monkeypatch):
+    monkeypatch.setattr(gl, "_glab_bin", lambda: "/trusted/bin/glab")
+    seen: dict = {}
+
+    def _run(argv, **kwargs):
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        return _proc(stdout="{}")
+
+    monkeypatch.setattr(gl.subprocess, "run", _run)
+    proc = gl._glab_run(["glab", "api", "user"], host="gitlab.com", timeout=5.0)
+    assert proc.returncode == 0
+    assert seen["argv"] == ["/trusted/bin/glab", "api", "user"]
+    assert seen["kwargs"]["env"]["GITLAB_HOST"] == "gitlab.com"
+    assert seen["kwargs"]["timeout"] == 5.0
+    assert seen["kwargs"]["check"] is False
+
+
+def test_glab_run_maps_a_timeout_to_a_cli_error(monkeypatch):
+    monkeypatch.setattr(gl, "_glab_bin", lambda: "/trusted/bin/glab")
+
+    def _run(argv, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="glab", timeout=5.0)
+
+    monkeypatch.setattr(gl.subprocess, "run", _run)
+    with pytest.raises(gl.ProviderCliError, match="timed out"):
+        gl._glab_run(["glab", "api", "user"], host="gitlab.com", timeout=5.0)
+
+
+def test_glab_run_returns_a_failure_without_raising(monkeypatch):
+    monkeypatch.setattr(gl, "_glab_bin", lambda: "/trusted/bin/glab")
+    monkeypatch.setattr(gl.subprocess, "run", lambda argv, **kw: _proc(returncode=22))
+    assert gl._glab_run(["glab", "api", "user"], host="gitlab.com", timeout=1.0).returncode == 22
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="the POSIX resolution path")
+def test_glab_bin_override_is_validated_and_cached(monkeypatch):
+    from kiro_crew.dashboard.handlers import source_providers
+
+    monkeypatch.setenv("KIROCREW_ISSUE_RADAR_GLAB", "/opt/glab")
+    monkeypatch.setattr(source_providers, "_validate_provider_executable", lambda p: "/opt/glab")
+    assert gl._glab_bin() == "/opt/glab"
+    # Cached: a second call must not re-validate.
+    monkeypatch.setattr(
+        source_providers,
+        "_validate_provider_executable",
+        lambda p: (_ for _ in ()).throw(AssertionError("re-validated")),
+    )
+    assert gl._glab_bin() == "/opt/glab"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="the POSIX resolution path")
+def test_glab_bin_override_failure_is_a_setup_error(monkeypatch):
+    from kiro_crew.dashboard.handlers import source_providers
+
+    monkeypatch.setenv("KIROCREW_ISSUE_RADAR_GLAB", "/opt/glab")
+
+    def _reject(path):
+        raise ValueError("not trusted")
+
+    monkeypatch.setattr(source_providers, "_validate_provider_executable", _reject)
+    with pytest.raises(gl.ProviderSetupError) as excinfo:
+        gl._glab_bin()
+    assert excinfo.value.reason == "not_installed"
+    assert "KIROCREW_ISSUE_RADAR_GLAB" in str(excinfo.value)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="the POSIX resolution path")
+def test_glab_bin_skips_untrusted_candidates_and_reports_the_last_check(monkeypatch, tmp_path):
+    from kiro_crew.dashboard.handlers import source_providers
+
+    monkeypatch.delenv("KIROCREW_ISSUE_RADAR_GLAB", raising=False)
+    present = tmp_path / "glab"
+    present.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n")
+    monkeypatch.setattr(
+        source_providers,
+        "provider_executable_candidates",
+        lambda name: (str(tmp_path / "absent-glab"), str(present)),
+    )
+
+    def _reject(path):
+        raise ValueError("world-writable")
+
+    monkeypatch.setattr(source_providers, "_validate_provider_executable", _reject)
+    with pytest.raises(gl.ProviderSetupError) as excinfo:
+        gl._glab_bin()
+    assert excinfo.value.reason == "not_installed"
+    assert "world-writable" in str(excinfo.value)
+    assert "glab auth login" in str(excinfo.value)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="the POSIX resolution path")
+def test_glab_bin_accepts_the_first_trusted_candidate(monkeypatch, tmp_path):
+    from kiro_crew.dashboard.handlers import source_providers
+
+    monkeypatch.delenv("KIROCREW_ISSUE_RADAR_GLAB", raising=False)
+    present = tmp_path / "glab"
+    present.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n")
+    monkeypatch.setattr(
+        source_providers, "provider_executable_candidates", lambda name: (str(present),)
+    )
+    monkeypatch.setattr(source_providers, "_validate_provider_executable", lambda p: p)
+    assert gl._glab_bin() == str(present)
+
+
+def test_glab_bin_refuses_windows(monkeypatch):
+    monkeypatch.setattr(gl.sys, "platform", "win32")
+    with pytest.raises(gl.ProviderCliError, match="POSIX"):
+        gl._glab_bin()
+
+
+# ── the API layer: pagination and error mapping ──────────────────────────────
+
+
+def test_glab_api_walks_pages_until_a_short_one(route):
+    router = route(
+        [("issues", lambda r: [{"iid": len(r.calls)}] * (100 if len(r.calls) <= 2 else 3))]
+    )
+    out = gl._glab_api("projects/g%2Fp/issues", host="gitlab.com", paginate=True)
+    assert len(out) == 203
+    assert "?page=1&per_page=100" in router.calls[0]["target"]
+    assert "?page=3&per_page=100" in router.calls[2]["target"]
+
+
+def test_glab_api_stops_at_the_page_cap(route, monkeypatch):
+    monkeypatch.setattr(gl, "_PAGE_SIZE", 1)
+    monkeypatch.setattr(gl, "_MAX_PAGES", 3)
+    router = route([("issues", [{"iid": 1}])])
+    out = gl._glab_api("projects/g%2Fp/issues", host="gitlab.com", paginate=True)
+    assert len(out) == 3
+    assert len(router.calls) == 3
+
+
+def test_glab_api_uses_an_ampersand_when_the_path_already_has_a_query(route):
+    router = route([("issues", [])])
+    gl._glab_api("projects/g%2Fp/issues?state=opened", host="gitlab.com", paginate=True)
+    assert "?state=opened&page=1" in router.calls[0]["target"]
+
+
+def test_glab_api_returns_a_non_list_payload_from_a_paginated_read(route):
+    route([("issues", {"message": "nope"})])
+    assert gl._glab_api("projects/g%2Fp/issues", host="gitlab.com", paginate=True) == {
+        "message": "nope"
+    }
+
+
+@pytest.mark.parametrize("paginate,expected", [(False, {}), (True, [])])
+def test_glab_api_treats_empty_output_as_an_empty_payload(route, paginate, expected):
+    route([("user", "   ")])
+    assert gl._glab_api("user", host="gitlab.com", paginate=paginate) == expected
+
+
+def test_glab_api_sends_a_body_on_stdin_with_a_method(route):
+    router = route([("issues/7", {"iid": 7})])
+    gl._glab_api(
+        "projects/g%2Fp/issues/7", host="gitlab.com", method="PUT", body={"state_event": "close"}
+    )
+    call = router.calls[0]
+    assert call["argv"][3:] == ["--method", "PUT", "--input", "-"]
+    assert json.loads(call["input"]) == {"state_event": "close"}
+
+
+def test_glab_api_rejects_unparseable_output(route):
+    route([("user", "not json")])
+    with pytest.raises(gl.ProviderCliError, match="unexpected output"):
+        gl._glab_api("user", host="gitlab.com")
+
+
+def test_glab_api_maps_an_auth_marker_to_a_setup_error(route):
+    route([("user", (1, "run `glab auth login` first"))])
+    with pytest.raises(gl.ProviderSetupError) as excinfo:
+        gl._glab_api("user", host="gitlab.com")
+    assert excinfo.value.reason == "not_authenticated"
+    assert "glab auth login --hostname gitlab.com" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("tail", ["HTTP 403", "Forbidden", "insufficient scope"])
+def test_glab_api_maps_403_to_a_permission_error(route, tail):
+    route([("members", (1, tail))])
+    with pytest.raises(gl.ProviderPermissionError):
+        gl._glab_api("projects/g%2Fp/members/all", host="gitlab.com")
+
+
+def test_glab_api_maps_any_other_failure_to_a_cli_error(route):
+    route([("user", (1, "HTTP 500 boom"))])
+    with pytest.raises(gl.ProviderCliError, match="exit 1"):
+        gl._glab_api("user", host="gitlab.com")
+
+
+# ── normalization helpers ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("opened", "open"), ("locked", "open"), ("closed", "closed"), ("", "open"), (None, "open")],
+)
+def test_norm_state(raw, expected):
+    assert gl._norm_state(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected", [("#d9534f", "d9534f"), ("d9534f", "d9534f"), ("", "888888"), (None, "888888")]
+)
+def test_hex_color(raw, expected):
+    assert gl._hex_color(raw) == expected
+
+
+def test_label_names_drops_non_strings_and_a_non_list():
+    assert gl._label_names(["a", "", 3, None]) == ["a"]
+    assert gl._label_names("nope") == []
+
+
+def test_username_and_usernames_tolerate_junk():
+    assert gl._username({"username": "alice"}) == "alice"
+    assert gl._username({"username": ""}) is None
+    assert gl._username("alice") is None
+    assert gl._usernames([{"username": "a"}, {}, 3]) == ["a"]
+    assert gl._usernames("nope") == []
+
+
+@pytest.mark.parametrize(
+    "level,role",
+    [(50, "admin"), (40, "maintain"), (30, "write"), (20, "triage"), (10, "read"),
+     (5, "read"), ("30", "write"), ("abc", "read"), (None, "read")],
+)
+def test_role_for_access_level(level, role):
+    assert gl._role_for_access_level(level) == role
+
+
+def test_permissions_for_access_level_is_conservative():
+    assert gl._permissions_for_access_level(20) == {
+        "admin": False, "maintain": False, "push": False, "triage": True, "pull": True
+    }
+    assert gl._permissions_for_access_level(50)["admin"] is True
+
+
+def test_access_level_takes_the_best_of_project_and_group():
+    details = {
+        "permissions": {
+            "project_access": {"access_level": 20},
+            "group_access": {"access_level": "40"},
+        }
+    }
+    assert gl._access_level(details) == 40
+    assert gl._access_level({"permissions": {"project_access": {"access_level": "x"}}}) == 0
+    assert gl._access_level({}) == 0
+
+
+def test_rows_and_obj_coerce_junk():
+    assert gl._rows([{"a": 1}, 3, None]) == [{"a": 1}]
+    assert gl._rows("nope") == []
+    assert gl._obj({"a": 1}) == {"a": 1}
+    assert gl._obj(None) == {}
+
+
+def test_norm_issue_maps_gitlab_fields_onto_the_github_vocabulary():
+    row = gl._norm_issue(ISSUE)
+    assert row["number"] == 7
+    assert row["url"] == ISSUE["web_url"]
+    assert row["labels"] == ["bug"]
+    assert row["comments"] == 4
+    assert row["reactions"] == 3
+    assert row["thumbs_up"] == 2
+    assert row["author_association"] is None
+    assert row["state"] == "open"
+    assert row["author"] == "alice"
+    assert row["assignees"] == ["bob"]
+    assert row["body"] == "body text"
+
+
+def test_norm_issue_tolerates_a_bare_payload():
+    row = gl._norm_issue({})
+    assert row["title"] == "" and row["comments"] == 0 and row["reactions"] == 0
+
+
+def test_norm_issue_detail_colours_labels_and_summarizes_reactions():
+    detail = gl._norm_issue_detail(ISSUE, {"bug": {"color": "#ff0000", "description": "d"}})
+    assert detail["labels"] == [{"name": "bug", "color": "ff0000", "description": "d"}]
+    assert detail["locked"] is True
+    assert detail["closed_by"] == "carol"
+    assert detail["state_reason"] is None
+    assert detail["milestone"] == {"title": "v1", "state": "active", "due_on": "2026-08-01"}
+    assert detail["reactions"]["total"] == 3
+    assert detail["reactions"]["plus1"] == 2
+
+
+def test_norm_issue_detail_omits_reactions_and_milestone_when_absent():
+    detail = gl._norm_issue_detail({"iid": 1, "labels": ["bug"]}, {})
+    assert detail["reactions"] is None
+    assert detail["milestone"] is None
+    # An unknown label still renders, with the neutral default colour.
+    assert detail["labels"] == [{"name": "bug", "color": "888888", "description": ""}]
+
+
+def test_shape_labels_drops_nameless_rows():
+    assert gl._shape_labels(LABELS) == [
+        {"name": "bug", "color": "d9534f", "description": "a defect"},
+        {"name": "chore", "color": "cccccc", "description": ""},
+    ]
+
+
+# ── project reads ────────────────────────────────────────────────────────────
+
+
+def test_verify_repo_access_summarizes_the_project(route):
+    route([("projects/", {
+        "path_with_namespace": "g/p",
+        "visibility": "internal",
+        "open_issues_count": 9,
+        "description": "d",
+        "permissions": {"project_access": {"access_level": 40}},
+    })])
+    out = gl.verify_repo_access("g", "p", host="gitlab.com")
+    assert out["full_name"] == "g/p"
+    # internal is not public, so the UI's badge reads private.
+    assert out["private"] is True
+    assert out["open_issues_count"] == 9
+    assert out["permissions"]["maintain"] is True
+
+
+def test_verify_repo_access_falls_back_to_statistics_for_the_count(route):
+    route([("projects/", {
+        "visibility": "public",
+        "statistics": {"open_issues_count": 4},
+        "permissions": {},
+    })])
+    out = gl.verify_repo_access("g", "p", host="gitlab.com")
+    assert out["open_issues_count"] == 4
+    assert out["private"] is False
+    assert out["full_name"] == "g/p"
+
+
+def test_verify_repo_access_raises_on_an_empty_project(route):
+    route([("projects/", {})])
+    with pytest.raises(gl.ProviderCliError, match="could not read"):
+        gl.verify_repo_access("g", "p", host="gitlab.com")
+
+
+def test_get_repo_permissions_returns_the_permission_object(route):
+    route([("projects/", {"permissions": {"project_access": {"access_level": 30}}})])
+    assert gl.get_repo_permissions("g", "p", host="gitlab.com")["push"] is True
+
+
+def test_get_repo_permissions_coerces_a_non_dict(route, monkeypatch):
+    monkeypatch.setattr(gl, "verify_repo_access", lambda *a, **k: {"permissions": None})
+    assert gl.get_repo_permissions("g", "p", host="gitlab.com") == {}
+
+
+def test_list_open_issues_paginates_and_asks_for_every_author(route):
+    router = route([("issues", [ISSUE])])
+    rows = gl.list_open_issues("g", "p", host="gitlab.com")
+    assert [r["number"] for r in rows] == [7]
+    target = router.calls[0]["target"]
+    assert "state=opened" in target and "scope=all" in target
+    assert "order_by=updated_at" in target and "&page=1&" in target
+
+
+def test_list_open_issues_first_page_asks_for_a_full_page_without_paginating(route):
+    router = route([("issues", [ISSUE])])
+    gl.list_open_issues_first_page("g", "p", host="gitlab.com")
+    target = router.calls[0]["target"]
+    assert "per_page=100" in target
+    assert "&page=1&" not in target
+
+
+def test_list_closed_issues_asks_for_the_closed_state(route):
+    router = route([("issues", [dict(ISSUE, state="closed")])])
+    rows = gl.list_closed_issues("g", "p", host="gitlab.com")
+    assert rows[0]["state"] == "closed"
+    assert "state=closed" in router.calls[0]["target"]
+
+
+def test_list_recent_open_issues_orders_by_creation_and_caps_the_limit(route):
+    router = route([("issues", [ISSUE, dict(ISSUE, iid=8)])])
+    rows = gl.list_recent_open_issues("g", "p", limit=1, host="gitlab.com")
+    assert [r["number"] for r in rows] == [7]
+    assert "order_by=created_at" in router.calls[0]["target"]
+    assert "per_page=1" in router.calls[0]["target"]
+
+
+def test_list_recent_open_issues_clamps_an_absurd_limit(route):
+    router = route([("issues", [])])
+    gl.list_recent_open_issues("g", "p", limit=10_000, host="gitlab.com")
+    assert "per_page=100" in router.calls[0]["target"]
+
+
+def test_list_repo_labels_shapes_and_paginates(route):
+    router = route([("labels", LABELS)])
+    assert [lab["name"] for lab in gl.list_repo_labels("g", "p", host="gitlab.com")] == [
+        "bug", "chore"
+    ]
+    assert "?page=1&per_page=100" in router.calls[0]["target"]
+
+
+def test_list_repo_collaborators_uses_inherited_members(route):
+    router = route([("members/all", [
+        {"username": "alice", "access_level": 50},
+        {"username": "bob", "access_level": 20},
+        {"access_level": 30},
+    ])])
+    assert gl.list_repo_collaborators("g", "p", host="gitlab.com") == [
+        {"login": "alice", "role_name": "admin"},
+        {"login": "bob", "role_name": "triage"},
+    ]
+    assert "members/all" in router.calls[0]["target"]
+
+
+def test_derive_members_is_always_empty():
+    assert gl.derive_members([{"author": "alice", "author_association": "MEMBER"}]) == []
+
+
+def test_get_current_login_reads_the_session_user(route):
+    route([("user", {"username": "alice"})])
+    assert gl.get_current_login(host="gitlab.com") == "alice"
+
+
+def test_get_current_login_returns_none_on_a_cli_failure(route):
+    route([("user", (1, "HTTP 500"))])
+    assert gl.get_current_login(host="gitlab.com") is None
+
+
+def test_list_contributed_repos_filters_by_activity_and_shape(route):
+    route([("projects?membership=true", [
+        {"path_with_namespace": "g/p", "last_activity_at": "2099-01-01T00:00:00Z",
+         "visibility": "public", "description": "d"},
+        {"path_with_namespace": "g/old", "last_activity_at": "2000-01-01T00:00:00Z"},
+        {"path_with_namespace": "noslash"},
+    ])])
+    rows, truncated = gl.list_contributed_repos("alice", host="gitlab.com", within_days=30)
+    assert rows == [
+        {"owner": "g", "repo": "p", "pushed_at": "2099-01-01T00:00:00Z",
+         "private": False, "description": "d"}
+    ]
+    assert truncated is False
+
+
+def test_list_contributed_repos_reports_truncation_at_the_page_cap(route, monkeypatch):
+    monkeypatch.setattr(gl, "_PAGE_SIZE", 1)
+    monkeypatch.setattr(gl, "_MAX_PAGES", 1)
+    route([("projects?membership=true", [{"path_with_namespace": "g/p"}])])
+    rows, truncated = gl.list_contributed_repos("alice", host="gitlab.com", within_days=0)
+    assert truncated is True
+    assert rows[0]["private"] is True
+
+
+@pytest.mark.parametrize("window", [0, -1, gl.MAX_WINDOW_DAYS, "abc", None])
+def test_cutoff_iso_is_empty_for_an_unbounded_window(window):
+    assert gl._cutoff_iso(window) == ""
+
+
+def test_cutoff_iso_returns_an_iso_timestamp():
+    assert gl._cutoff_iso(30).startswith("20")
+
+
+def test_get_issue_detail_joins_the_label_colours(route):
+    route([("labels", LABELS), ("issues/7", ISSUE)])
+    detail = gl.get_issue_detail("g", "p", 7, host="gitlab.com")
+    assert detail["labels"] == [{"name": "bug", "color": "d9534f", "description": "a defect"}]
+
+
+def test_get_issue_detail_degrades_when_labels_cannot_be_read(route):
+    route([("labels", (1, "HTTP 500")), ("issues/7", ISSUE)])
+    detail = gl.get_issue_detail("g", "p", 7, host="gitlab.com")
+    assert detail["labels"] == [{"name": "bug", "color": "888888", "description": ""}]
+
+
+def test_get_issue_detail_raises_on_an_empty_issue(route):
+    route([("issues/7", {})])
+    with pytest.raises(gl.ProviderCliError, match="could not read"):
+        gl.get_issue_detail("g", "p", 7, host="gitlab.com")
+
+
+def test_get_issue_detail_coerces_the_number_before_it_reaches_argv(route):
+    router = route([("issues", ISSUE)])
+    with pytest.raises(ValueError):
+        gl.get_issue_detail("g", "p", "7/../secret", host="gitlab.com")  # type: ignore[arg-type]
+    assert router.calls == []
+
+
+# ── reference summary ────────────────────────────────────────────────────────
+
+
+def test_get_ref_summary_is_issue_only_and_colours_its_labels(route):
+    route([("labels", LABELS), ("issues/7", ISSUE)])
+    out = gl.get_ref_summary("g", "p", 7, host="gitlab.com")
+    assert out["is_pr"] is False and out["merged_at"] is None and out["draft"] is False
+    assert out["labels"] == [{"name": "bug", "color": "d9534f"}]
+
+
+def test_get_ref_summary_skips_the_label_call_when_there_are_none(route):
+    router = route([("issues/7", dict(ISSUE, labels=[]))])
+    assert gl.get_ref_summary("g", "p", 7, host="gitlab.com")["labels"] == []
+    assert router.targets("labels") == []
+
+
+def test_get_ref_summary_degrades_when_labels_cannot_be_read(route):
+    route([("labels", (1, "HTTP 500")), ("issues/7", ISSUE)])
+    assert gl.get_ref_summary("g", "p", 7, host="gitlab.com")["labels"] == [
+        {"name": "bug", "color": "888888"}
+    ]
+
+
+def test_get_ref_summary_raises_on_a_missing_issue(route):
+    route([("issues/7", {})])
+    with pytest.raises(gl.ProviderCliError, match="could not read"):
+        gl.get_ref_summary("g", "p", 7, host="")
+
+
+# ── timeline assembly ────────────────────────────────────────────────────────
+
+
+def test_norm_note_keeps_a_human_comment():
+    out = gl._norm_note({"body": "hi", "created_at": "t", "author": {"username": "alice"}})
+    assert out == {
+        "kind": "comment", "actor": "alice", "created_at": "t", "body": "hi",
+        "author_association": None, "reactions": None,
+    }
+
+
+def test_norm_note_drops_an_unrecognized_system_note():
+    assert gl._norm_note({"body": "did something odd", "system": True}) is None
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        ("assigned to @bob", ("assigned", "bob")),
+        ("unassigned @bob", ("unassigned", "bob")),
+        ("assigned to @", ("assigned", None)),
+    ],
+)
+def test_norm_note_parses_assignment(body, expected):
+    out = gl._norm_note({"body": body, "system": True})
+    assert (out["kind"], out["assignee"]) == expected
+
+
+def test_norm_note_parses_a_rename():
+    out = gl._norm_note({"body": "changed title from **old** to **new**", "system": True})
+    assert out["kind"] == "renamed"
+    assert out["rename"] == {"from": "old", "to": "new"}
+
+
+def test_norm_note_reports_an_unparseable_rename_as_unknown():
+    out = gl._norm_note({"body": "changed title from old to new", "system": True})
+    assert out["rename"] == {"from": None, "to": None}
+
+
+@pytest.mark.parametrize(
+    "body,number,is_pr",
+    [
+        ("mentioned in issue #42", 42, False),
+        ("mentioned in merge request !42", 42, True),
+        ("mentioned in issue somewhere", None, False),
+    ],
+)
+def test_norm_note_parses_a_cross_reference(body, number, is_pr):
+    out = gl._norm_note({"body": body, "system": True})
+    assert out["kind"] == "cross-referenced"
+    assert out["source"]["number"] == number
+    assert out["source"]["is_pr"] is is_pr
+
+
+@pytest.mark.parametrize(
+    "body,commit",
+    [("mentioned in commit abc1234", "abc1234"), ("mentioned in commit zz", None)],
+)
+def test_norm_note_parses_a_commit_reference(body, commit):
+    out = gl._norm_note({"body": body, "system": True})
+    assert (out["kind"], out["commit_id"]) == ("referenced", commit)
+
+
+@pytest.mark.parametrize(
+    "body,kind",
+    [("changed milestone to %v1", "milestoned"), ("removed milestone", "demilestoned")],
+)
+def test_norm_note_parses_milestone_changes(body, kind):
+    out = gl._norm_note({"body": body, "system": True})
+    assert (out["kind"], out["milestone"]) == (kind, None)
+
+
+def test_norm_note_drops_a_pattern_that_has_no_handler(monkeypatch):
+    """The tail of ``_norm_note`` is the guard for extending the pattern table.
+
+    Adding a prefix to ``_SYSTEM_NOTE_PATTERNS`` without also adding the branch
+    that shapes it must DROP the note, not emit a half-built entry the UI cannot
+    render. Only reachable by adding such a pattern, which is exactly the mistake
+    it protects against.
+    """
+    monkeypatch.setattr(
+        gl, "_SYSTEM_NOTE_PATTERNS", gl._SYSTEM_NOTE_PATTERNS + (("locked this", "locked"),)
+    )
+    assert gl._norm_note({"body": "locked this issue", "system": True}) is None
+
+
+def test_norm_label_event_maps_add_and_remove():
+    added = gl._norm_label_event(
+        {"action": "add", "user": {"username": "alice"}, "created_at": "t",
+         "label": {"name": "bug", "color": "#ff0000"}},
+        {},
+    )
+    assert added["kind"] == "labeled"
+    assert added["label"] == {"name": "bug", "color": "ff0000"}
+    removed = gl._norm_label_event({"action": "remove", "label": {"name": "bug"}}, {})
+    assert removed["kind"] == "unlabeled"
+
+
+def test_norm_label_event_falls_back_to_the_project_colour():
+    out = gl._norm_label_event(
+        {"action": "add", "label": {"name": "bug"}}, {"bug": {"color": "#00ff00"}}
+    )
+    assert out["label"]["color"] == "00ff00"
+
+
+@pytest.mark.parametrize(
+    "event", [{"action": "moved", "label": {"name": "bug"}}, {"action": "add", "label": {}}]
+)
+def test_norm_label_event_drops_what_it_cannot_render(event):
+    assert gl._norm_label_event(event, {}) is None
+
+
+@pytest.mark.parametrize(
+    "state,kind",
+    [("closed", "closed"), ("reopened", "reopened"), ("opened", "reopened"), ("merged", None)],
+)
+def test_norm_state_event(state, kind):
+    out = gl._norm_state_event({"state": state, "user": {"username": "alice"}})
+    assert (out or {}).get("kind") == kind
+
+
+def test_list_issue_timeline_merges_and_sorts_every_stream(route):
+    route([
+        ("issues/7/notes", [
+            {"body": "second", "created_at": "2026-07-02T00:00:00Z",
+             "author": {"username": "bob"}},
+            {"body": "assigned to @bob", "system": True, "created_at": "2026-07-01T00:00:00Z"},
+        ]),
+        ("resource_label_events", [
+            {"action": "add", "created_at": "2026-07-03T00:00:00Z", "label": {"name": "bug"}}
+        ]),
+        ("resource_state_events", [
+            {"state": "closed", "created_at": "2026-07-04T00:00:00Z"}
+        ]),
+        ("labels", LABELS),
+    ])
+    events = gl.list_issue_timeline("g", "p", 7, host="gitlab.com")
+    assert [e["kind"] for e in events] == ["assigned", "comment", "labeled", "closed"]
+
+
+def test_assemble_timeline_degrades_when_a_secondary_stream_fails(route):
+    route([
+        ("issues/7/notes", [{"body": "hi", "created_at": "t"}]),
+        ("resource_label_events", (1, "HTTP 404")),
+        ("resource_state_events", (1, "HTTP 404")),
+        ("labels", (1, "HTTP 500")),
+    ])
+    events = gl.list_issue_timeline("g", "p", 7, host="gitlab.com")
+    assert [e["kind"] for e in events] == ["comment"]
+
+
+def test_list_pr_timeline_promotes_positioned_notes_to_review_comments(route):
+    route([
+        ("merge_requests/12/notes", [
+            {"body": "nit", "created_at": "2026-07-01T00:00:00Z",
+             "author": {"username": "carol"},
+             "position": {"new_path": "a.py", "new_line": 12}},
+            {"body": "plain", "created_at": "2026-07-02T00:00:00Z"},
+            {"body": "old file", "created_at": "2026-07-03T00:00:00Z",
+             "position": {"old_path": "b.py", "old_line": 3}},
+            {"body": "assigned to @bob", "system": True, "created_at": "2026-07-04T00:00:00Z",
+             "position": {"new_path": "c.py"}},
+        ]),
+        ("resource_label_events", []),
+        ("resource_state_events", []),
+        ("labels", LABELS),
+    ])
+    events = gl.list_pr_timeline("g", "p", 12, host="gitlab.com")
+    kinds = [e["kind"] for e in events]
+    # The positioned notes appear ONCE, as the richer inline entry.
+    assert kinds.count("review_comment") == 2
+    assert kinds.count("comment") == 1
+    inline = next(e for e in events if e["kind"] == "review_comment")
+    assert (inline["path"], inline["line"], inline["actor"]) == ("a.py", 12, "carol")
+    old = [e for e in events if e["kind"] == "review_comment"][1]
+    assert (old["path"], old["line"]) == ("b.py", 3)
+
+
+# ── write operations ─────────────────────────────────────────────────────────
+
+
+def test_add_issue_labels_returns_the_full_shaped_set(route):
+    router = route([("labels", LABELS), ("issues/7", {"labels": ["bug", "chore"]})])
+    out = gl.add_issue_labels("g", "p", 7, ["bug", "chore"], host="gitlab.com")
+    assert out == [
+        {"name": "bug", "color": "d9534f", "description": "a defect"},
+        {"name": "chore", "color": "cccccc", "description": ""},
+    ]
+    put = next(c for c in router.calls if "issues/7" in c["target"])
+    assert json.loads(put["input"]) == {"add_labels": "bug,chore"}
+    assert "--method" in put["argv"] and "PUT" in put["argv"]
+
+
+def test_remove_issue_label_returns_the_remaining_labels(route):
+    router = route([("labels", LABELS), ("issues/7", {"labels": ["chore"]})])
+    out = gl.remove_issue_label("g", "p", 7, "bug", host="gitlab.com")
+    assert [lab["name"] for lab in out] == ["chore"]
+    put = next(c for c in router.calls if "issues/7" in c["target"])
+    assert json.loads(put["input"]) == {"remove_labels": "bug"}
+
+
+def test_resolve_label_details_degrades_to_the_neutral_colour(route):
+    route([("labels", (1, "HTTP 500"))])
+    assert gl._resolve_label_details(
+        "g", "p", ["bug"], host="gitlab.com", timeout=1.0
+    ) == [{"name": "bug", "color": "888888", "description": ""}]
+
+
+@pytest.mark.parametrize(
+    "state,event", [("closed", "close"), ("open", "reopen")]
+)
+def test_set_issue_state_sends_a_state_event(route, state, event):
+    router = route([("issues/7", {"state": "closed" if state == "closed" else "opened"})])
+    out = gl.set_issue_state("g", "p", 7, state, state_reason="completed", host="gitlab.com")
+    assert out["state_reason"] is None
+    assert json.loads(router.calls[0]["input"]) == {"state_event": event}
+
+
+def test_create_label_adds_the_hash_gitlab_requires(route):
+    router = route([("labels", {"name": "bug", "color": "#d9534f", "description": "d"})])
+    out = gl.create_label("g", "p", "bug", "d9534f", "d", host="gitlab.com")
+    assert out == {"name": "bug", "color": "d9534f", "description": "d"}
+    assert json.loads(router.calls[0]["input"])["color"] == "#d9534f"
+
+
+def test_create_label_returns_a_synthetic_row_when_the_response_is_not_a_label(route):
+    route([("labels", [])])
+    assert gl.create_label("g", "p", "bug", host="gitlab.com") == {
+        "name": "bug", "color": "888888", "description": ""
+    }
+
+
+def test_create_label_is_idempotent_on_a_conflict(route):
+    route([
+        ("labels?search=", [{"name": "bug", "color": "#111111", "description": "existing"}]),
+        ("labels", (1, "409 Conflict: label already exists")),
+    ])
+    assert gl.create_label("g", "p", "bug", host="gitlab.com") == {
+        "name": "bug", "color": "111111", "description": "existing"
+    }
+
+
+def test_create_label_synthesizes_a_row_when_the_conflict_lookup_misses(route):
+    route([
+        ("labels?search=", []),
+        ("labels", (1, "409 has already been taken")),
+    ])
+    assert gl.create_label("g", "p", "bug", "abcdef", host="gitlab.com")["color"] == "abcdef"
+
+
+def test_create_label_propagates_a_permission_error(route):
+    route([("labels", (1, "HTTP 403 Forbidden"))])
+    with pytest.raises(gl.ProviderPermissionError):
+        gl.create_label("g", "p", "bug", host="gitlab.com")
+
+
+def test_create_label_propagates_an_unrelated_failure(route):
+    route([("labels", (1, "HTTP 500 boom"))])
+    with pytest.raises(gl.ProviderCliError):
+        gl.create_label("g", "p", "bug", host="gitlab.com")
+
+
+# ── merge requests ───────────────────────────────────────────────────────────
+
+
+def test_norm_pull_maps_branches_votes_and_the_head_commit():
+    row = gl._norm_pull(MR)
+    assert row["number"] == 12
+    assert row["state"] == "open"
+    assert row["draft"] is True  # from work_in_progress
+    assert row["base"] == "main" and row["head"] == "feat/widget"
+    assert row["head_sha"] == "abc1234"
+    assert row["requested_reviewers"] == ["carol"]
+    # The card enrichment rides on the same payload.
+    assert row["checks_state"] == "running"
+    assert row["checks_counts"]["running"] == 1
+    assert row["additions"] is None and row["changed_files"] is None
+
+
+def test_norm_pull_prefers_diff_refs_and_the_explicit_draft_flag():
+    row = gl._norm_pull(dict(MR, draft=False, diff_refs={"head_sha": "deadbee"}))
+    assert row["draft"] is False
+    assert row["head_sha"] == "deadbee"
+
+
+def test_norm_pull_folds_merged_into_closed_but_keeps_merged_at():
+    row = gl._norm_pull(dict(MR, state="merged", merged_at="2026-07-05T00:00:00Z"))
+    assert row["state"] == "closed"
+    assert row["merged_at"] == "2026-07-05T00:00:00Z"
+
+
+def test_list_open_pulls_paginates(route):
+    router = route([("merge_requests", [MR])])
+    assert [r["number"] for r in gl.list_open_pulls("g", "p", host="gitlab.com")] == [12]
+    assert "state=opened" in router.calls[0]["target"]
+    assert "&page=1&" in router.calls[0]["target"]
+
+
+def test_list_open_pulls_first_page_is_one_full_page(route):
+    router = route([("merge_requests", [MR])])
+    gl.list_open_pulls_first_page("g", "p", host="gitlab.com")
+    assert "per_page=100" in router.calls[0]["target"]
+    assert "&page=1&" not in router.calls[0]["target"]
+
+
+def test_list_closed_pulls_asks_for_all_and_keeps_only_non_open(route):
+    router = route([("merge_requests", [
+        MR,
+        dict(MR, iid=13, state="merged", merged_at="2026-07-05T00:00:00Z"),
+        dict(MR, iid=14, state="closed"),
+    ])])
+    rows = gl.list_closed_pulls("g", "p", host="gitlab.com")
+    assert [r["number"] for r in rows] == [13, 14]
+    assert "state=all" in router.calls[0]["target"]
+
+
+def test_get_pr_detail_adds_the_detail_only_fields(route):
+    route([("merge_requests/12", dict(
+        MR,
+        changes_count="20+",
+        commits_count=3,
+        user_notes_count=5,
+        merged_at="2026-07-05T00:00:00Z",
+        detailed_merge_status="mergeable",
+        merged_by={"username": "dave"},
+        merge_when_pipeline_succeeds=True,
+        squash=True,
+        merge_user={"username": "erin"},
+    ))])
+    detail = gl.get_pr_detail("g", "p", 12, host="gitlab.com", resolve_mergeable=False)
+    assert detail["changed_files"] == 20
+    assert detail["commits"] == 3
+    assert detail["comments"] == 5
+    assert detail["merged"] is True
+    assert detail["mergeable"] is True
+    assert detail["mergeable_state"] == "mergeable"
+    assert detail["merged_by"] == "dave"
+    assert detail["auto_merge"] == {"method": "SQUASH", "enabled_by": "erin"}
+
+
+def test_get_pr_detail_reports_unknown_sizes_and_no_auto_merge(route):
+    route([("merge_requests/12", dict(MR, changes_count="many"))])
+    detail = gl.get_pr_detail("g", "p", 12, host="gitlab.com")
+    assert detail["changed_files"] is None
+    assert detail["auto_merge"] is None
+    assert detail["mergeable_state"] == "unknown"
+    assert detail["review_comments"] is None
+
+
+def test_get_pr_detail_raises_on_an_empty_merge_request(route):
+    route([("merge_requests/12", {})])
+    with pytest.raises(gl.ProviderCliError, match="could not read"):
+        gl.get_pr_detail("g", "p", 12, host="gitlab.com")
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ({"detailed_merge_status": "mergeable"}, True),
+        ({"merge_status": "can_be_merged"}, True),
+        ({"detailed_merge_status": "conflict"}, False),
+        ({"merge_status": "checking"}, None),
+        ({}, None),
+    ],
+)
+def test_mergeable_reports_pending_as_unknown(raw, expected):
+    assert gl._mergeable(raw) is expected
+
+
+# ── pipelines as checks ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "status,allow_failure,bucket",
+    [
+        ("failed", False, "failure"),
+        ("failed", True, "other"),
+        ("running", False, "running"),
+        ("waiting_for_resource", False, "running"),
+        ("success", False, "success"),
+        ("canceled", False, "other"),
+        ("manual", False, "other"),
+        ("something-new", False, "other"),
+        ("", False, "other"),
+    ],
+)
+def test_job_bucket(status, allow_failure, bucket):
+    assert gl._job_bucket(status, allow_failure) == bucket
+
+
+def test_norm_job_shapes_a_check_row():
+    row = gl._norm_job({
+        "name": "unit", "status": "failed", "stage": "test", "web_url": "u",
+        "created_at": "c", "started_at": "s", "finished_at": "f",
+    })
+    assert row["status"] == "completed"
+    assert row["conclusion"] == "failure"
+    assert row["bucket"] == "failure"
+    assert row["summary"] == "stage: test"
+    assert row["source"] == "gitlab-ci"
+    assert row["app"] == "GitLab CI"
+    assert row["started_at"] == "s"
+
+
+def test_norm_job_defaults_a_nameless_running_job():
+    row = gl._norm_job({"status": "running", "created_at": "c"})
+    assert row["name"] == "job"
+    assert row["status"] == "in_progress"
+    assert row["conclusion"] is None
+    assert row["summary"] == ""
+    assert row["started_at"] == "c"
+
+
+def test_list_pr_checks_uses_the_newest_pipeline_for_the_sha(route):
+    router = route([
+        ("pipelines/99/jobs", [{"name": "unit", "status": "success"}]),
+        ("pipelines?sha=", [
+            {"id": 98, "created_at": "2026-07-01T00:00:00Z"},
+            {"id": 99, "created_at": "2026-07-02T00:00:00Z"},
+        ]),
+    ])
+    rows = gl.list_pr_checks("g", "p", "abc1234", host="gitlab.com")
+    assert [r["name"] for r in rows] == ["unit"]
+    assert router.targets("pipelines/99/jobs")
+
+
+def test_list_pr_checks_rejects_a_non_sha(route):
+    router = route([])
+    with pytest.raises(gl.ProviderCliError, match="invalid commit sha"):
+        gl.list_pr_checks("g", "p", "abc; rm -rf x", host="gitlab.com")
+    assert router.calls == []
+
+
+def test_list_pr_checks_is_empty_without_a_pipeline(route):
+    route([("pipelines?sha=", [])])
+    assert gl.list_pr_checks("g", "p", "abc1234", host="gitlab.com") == []
+
+
+def test_list_pr_checks_is_empty_when_the_pipeline_has_no_usable_id(route):
+    route([("pipelines?sha=", [{"id": "99"}])])
+    assert gl.list_pr_checks("g", "p", "abc1234", host="gitlab.com") == []
+
+
+def test_summarize_checks_lets_failure_dominate():
+    out = gl.summarize_checks([
+        {"bucket": "success"}, {"bucket": "running"}, {"bucket": "failure"},
+        {"bucket": "invented"}, "not a dict",
+    ])
+    assert out["checks_state"] == "failure"
+    assert out["checks_counts"] == {"failure": 1, "running": 1, "success": 1, "other": 1}
+    assert out["checks_truncated"] is False
+
+
+def test_summarize_checks_reports_no_state_without_checks():
+    assert gl.summarize_checks([])["checks_state"] is None
+
+
+def test_enrich_is_a_no_op_on_gitlab():
+    pulls = [{"number": 1}]
+    assert gl.enrich_pulls("g", "p", pulls, "open", host="gitlab.com") is pulls
+    assert gl.enrich_pulls_by_number("g", "p", pulls, host="gitlab.com") is pulls
+
+
+def test_enrichment_complete_reads_the_same_invariant_as_github():
+    assert gl.enrichment_complete([{"checks_counts": {}}]) is True
+    assert gl.enrichment_complete([{"checks_counts": None}]) is False
+
+
+def test_pipeline_summary_falls_back_to_the_plain_pipeline_key():
+    out = gl._pipeline_summary({"pipeline": {"status": "failed"}})
+    assert out["checks_state"] == "failure"
+    assert out["checks_counts"]["failure"] == 1
+
+
+def test_pipeline_summary_reports_no_state_without_a_pipeline():
+    out = gl._pipeline_summary({})
+    assert out["checks_state"] is None
+    assert out["checks_counts"] == {"failure": 0, "running": 0, "success": 0, "other": 0}
+    # Never 0 for diff size: these rows are persisted, and a zero would read as
+    # a confident "no changes".
+    assert out["additions"] is None and out["deletions"] is None
+
+
+# ── poll probe ───────────────────────────────────────────────────────────────
+
+
+def test_probe_open_list_counts_open_issues_and_the_newest_update(route):
+    route([
+        ("issues_statistics", {"statistics": {"counts": {"opened": 12}}}),
+        ("issues", [{"updated_at": "2026-07-02T00:00:00Z"}]),
+    ])
+    assert gl.probe_open_list("g", "p", "issue", host="gitlab.com") == {
+        "total_count": 12, "top_updated_at": "2026-07-02T00:00:00Z"
+    }
+
+
+def test_probe_open_list_tolerates_an_empty_or_untyped_top_row(route):
+    route([("issues_statistics", {"statistics": {"counts": {"opened": 0}}}), ("issues", [])])
+    assert gl.probe_open_list("g", "p", "issue", host="gitlab.com")["top_updated_at"] is None
+    route([
+        ("issues_statistics", {"statistics": {"counts": {"opened": 1}}}),
+        ("issues", [{"updated_at": 17}]),
+    ])
+    assert gl.probe_open_list("g", "p", "issue", host="gitlab.com")["top_updated_at"] is None
+
+
+def test_probe_open_list_raises_without_a_count(route):
+    route([("issues_statistics", {"statistics": {"counts": {}}})])
+    with pytest.raises(gl.ProviderCliError, match="no open count"):
+        gl.probe_open_list("g", "p", "issue", host="gitlab.com")
+
+
+def test_probe_open_list_refuses_an_unknown_kind(route):
+    router = route([])
+    with pytest.raises(gl.ProviderCliError, match="unsupported probe kind"):
+        gl.probe_open_list("g", "p", "release", host="gitlab.com")
+    assert router.calls == []
+
+
+def test_probe_open_list_refuses_merge_requests_rather_than_approximating(route):
+    router = route([])
+    with pytest.raises(gl.ProviderCliError, match="no cheap open merge-request count"):
+        gl.probe_open_list("g", "p", "pr", host="gitlab.com")
+    assert router.calls == []
+
+
+# ── merge-request search ─────────────────────────────────────────────────────
+
+
+def test_build_pr_search_query_maps_every_person_filter():
+    query = gl.build_pr_search_query(
+        "g", "p", state="merged", author="alice", assignee="bob", review_requested="carol"
+    )
+    assert query == (
+        "state=merged&scope=all&author_username=alice"
+        "&assignee_username=bob&reviewer_username=carol"
+    )
+
+
+@pytest.mark.parametrize("state,gl_state", [("open", "opened"), ("closed", "closed"), ("all", "all")])
+def test_build_pr_search_query_translates_the_state(state, gl_state):
+    query = gl.build_pr_search_query("g", "p", state=state, author="alice")
+    assert query.startswith(f"state={gl_state}&scope=all")
+
+
+def test_build_pr_search_query_rejects_an_unknown_state():
+    with pytest.raises(gl.PrSearchError, match="unsupported state"):
+        gl.build_pr_search_query("g", "p", state="draft", author="alice")
+
+
+def test_build_pr_search_query_rejects_an_invalid_username():
+    with pytest.raises(gl.PrSearchError, match="invalid GitLab username"):
+        gl.build_pr_search_query("g", "p", author="alice&state=all")
+
+
+def test_build_pr_search_query_requires_a_person_filter():
+    with pytest.raises(gl.PrSearchError, match="at least one person filter"):
+        gl.build_pr_search_query("g", "p")
+
+
+def test_search_pulls_honours_the_limit(route):
+    route([("merge_requests", [MR, dict(MR, iid=13)])])
+    rows = gl.search_pulls("g", "p", host="gitlab.com", author="alice", limit=1)
+    assert [r["number"] for r in rows] == [12]
+
+
+def test_search_pulls_clamps_the_limit_to_one_above_the_cap(route):
+    route([("merge_requests", [dict(MR, iid=n) for n in range(5)])])
+    rows = gl.search_pulls("g", "p", host="gitlab.com", author="alice", limit=10_000)
+    assert len(rows) == 5
+
+
+def test_search_pulls_drops_merged_rows_from_a_closed_search(route):
+    router = route([("merge_requests", [
+        dict(MR, iid=13, state="closed"),
+        dict(MR, iid=14, state="merged", merged_at="2026-07-05T00:00:00Z"),
+    ])])
+    rows = gl.search_pulls("g", "p", host="gitlab.com", state="closed", author="alice")
+    assert [r["number"] for r in rows] == [13]
+    assert "state=closed" in router.calls[0]["target"]
+
+
+# ── merge-request actions ────────────────────────────────────────────────────
+
+
+def test_set_pr_state_closes_and_reports_the_draft_flag(route):
+    router = route([("merge_requests/12", {"state": "closed", "work_in_progress": True})])
+    out = gl.set_pr_state("g", "p", 12, "closed", host="gitlab.com")
+    assert out == {"state": "closed", "merged": False, "draft": True}
+    assert json.loads(router.calls[0]["input"]) == {"state_event": "close"}
+
+
+def test_set_pr_state_reopens(route):
+    router = route([("merge_requests/12", {"state": "opened"})])
+    out = gl.set_pr_state("g", "p", 12, "open", host="gitlab.com")
+    assert out["state"] == "open" and out["draft"] is False
+    assert json.loads(router.calls[0]["input"]) == {"state_event": "reopen"}
+
+
+def test_set_pr_state_rejects_an_unknown_state(route):
+    router = route([])
+    with pytest.raises(gl.ProviderCliError, match="invalid MR state"):
+        gl.set_pr_state("g", "p", 12, "merged", host="gitlab.com")
+    assert router.calls == []
+
+
+def test_submit_pr_review_refuses_request_changes(route):
+    router = route([])
+    with pytest.raises(gl.ProviderCliError, match="no 'request changes' review verb"):
+        gl.submit_pr_review("g", "p", 12, "REQUEST_CHANGES", "no", "abc1234", host="gitlab.com")
+    assert router.calls == []
+
+
+def test_submit_pr_review_rejects_an_unknown_event(route):
+    with pytest.raises(gl.ProviderCliError, match="invalid review event"):
+        gl.submit_pr_review("g", "p", 12, "DISMISS", head_sha="abc1234", host="gitlab.com")
+
+
+def test_submit_pr_review_requires_a_body_for_a_comment(route):
+    with pytest.raises(gl.ProviderCliError, match="requires a comment body"):
+        gl.submit_pr_review("g", "p", 12, "COMMENT", "  ", "abc1234", host="gitlab.com")
+
+
+def test_submit_pr_review_requires_the_head_commit(route):
+    with pytest.raises(gl.ProviderCliError, match="refusing to review"):
+        gl.submit_pr_review("g", "p", 12, "APPROVE", head_sha="", host="gitlab.com")
+
+
+def test_submit_pr_review_comment_posts_a_note(route):
+    router = route([("notes", {"id": 5, "created_at": "t"})])
+    out = gl.submit_pr_review("g", "p", 12, "comment", "looks fine", "abc1234", host="gitlab.com")
+    assert out == {"id": None, "state": "COMMENTED", "submitted_at": None}
+    assert "merge_requests/12/notes" in router.calls[0]["target"]
+
+
+def test_submit_pr_review_approves_before_it_posts_the_note(route):
+    router = route([
+        ("approve", {"id": 3, "created_at": "c", "updated_at": "u"}),
+        ("notes", {"id": 5, "created_at": "t"}),
+    ])
+    out = gl.submit_pr_review("g", "p", 12, "APPROVE", "ship it", "abc1234", host="gitlab.com")
+    assert out == {"id": 3, "state": "APPROVED", "submitted_at": "u"}
+    # The approval is idempotent, so it goes FIRST: a retry after a failed note
+    # must not duplicate the prose.
+    assert [t.rsplit("/", 1)[-1] for t in router.targets()] == ["approve", "notes"]
+    assert json.loads(router.calls[0]["input"]) == {"sha": "abc1234"}
+
+
+def test_submit_pr_review_approves_without_a_note(route):
+    router = route([("approve", {"id": 3, "created_at": "c"})])
+    out = gl.submit_pr_review("g", "p", 12, "APPROVE", "", "abc1234", host="gitlab.com")
+    assert out["submitted_at"] == "c"
+    assert router.targets("notes") == []
+
+
+def test_add_note_requires_a_body(route):
+    router = route([])
+    with pytest.raises(gl.ProviderCliError, match="comment needs a body"):
+        gl.add_issue_comment("g", "p", 7, "   ", host="gitlab.com")
+    assert router.calls == []
+
+
+def test_add_issue_comment_and_add_pr_comment_use_separate_collections(route):
+    router = route([("notes", {"id": 5, "created_at": "t"})])
+    assert gl.add_issue_comment("g", "p", 7, "hi", host="gitlab.com") == {
+        "id": 5, "url": None, "created_at": "t"
+    }
+    gl.add_pr_comment("g", "p", 7, "hi", host="gitlab.com")
+    assert "issues/7/notes" in router.calls[0]["target"]
+    assert "merge_requests/7/notes" in router.calls[1]["target"]
+
+
+def test_merge_pull_request_pins_the_squash_flag_and_the_sha(route):
+    router = route([("merge", {"state": "merged", "merge_commit_sha": "feed123"})])
+    out = gl.merge_pull_request("g", "p", 12, "SQUASH", "abc1234", host="gitlab.com")
+    assert out == {"merged": True, "sha": "feed123", "message": ""}
+    assert json.loads(router.calls[0]["input"]) == {"squash": True, "sha": "abc1234"}
+
+
+def test_merge_pull_request_sends_squash_false_explicitly(route):
+    router = route([("merge", {"state": "opened", "merge_error": "conflict"})])
+    out = gl.merge_pull_request("g", "p", 12, "merge", "abc1234", host="gitlab.com")
+    assert out == {"merged": False, "sha": None, "message": "conflict"}
+    assert json.loads(router.calls[0]["input"])["squash"] is False
+
+
+def test_merge_pull_request_refuses_a_method_gitlab_cannot_honour(route):
+    router = route([])
+    with pytest.raises(gl.ProviderCliError, match="invalid merge method"):
+        gl.merge_pull_request("g", "p", 12, "REBASE", "abc1234", host="gitlab.com")
+    assert "REBASE" not in gl.PR_MERGE_METHODS
+    assert router.calls == []
+
+
+def test_merge_pull_request_requires_the_reviewed_commit(route):
+    router = route([])
+    with pytest.raises(gl.ProviderCliError, match="refusing to merge"):
+        gl.merge_pull_request("g", "p", 12, "SQUASH", "nope", host="gitlab.com")
+    assert router.calls == []
+
+
+def test_auto_merge_is_refused_in_both_directions(route):
+    router = route([])
+    with pytest.raises(gl.ProviderCliError, match="no separate auto-merge to arm"):
+        gl.enable_auto_merge("g", "p", 12, host="gitlab.com")
+    with pytest.raises(gl.ProviderCliError, match="not managed from this app"):
+        gl.disable_auto_merge("g", "p", 12, host="gitlab.com")
+    assert router.calls == []
+
+
+# ── pipelines as workflow runs ───────────────────────────────────────────────
+
+
+def test_list_pr_workflow_runs_normalizes_status_and_conclusion(route):
+    route([("pipelines?sha=", [
+        {"id": 1, "status": "running", "iid": 5, "web_url": "u", "source": "push",
+         "created_at": "c"},
+        {"id": 2, "status": "canceled", "name": "nightly"},
+        {"id": 3, "status": "success"},
+        {"id": 4, "status": "skipped"},
+        {"no_id": True},
+        "not a dict",
+    ])])
+    rows = gl.list_pr_workflow_runs("g", "p", "abc1234", host="gitlab.com")
+    by_id = {row["id"]: row for row in rows}
+    assert len(rows) == 4
+    assert by_id[1]["status"] == "running"
+    assert by_id[1]["conclusion"] is None
+    assert by_id[1]["cancellable"] is True and by_id[1]["rerunnable"] is False
+    assert by_id[1]["name"] == "pipeline #5"
+    # GitLab spells it with one l; the shared UI compares the GitHub spelling.
+    assert by_id[2]["conclusion"] == "cancelled"
+    assert by_id[2]["status"] == "completed"
+    assert by_id[2]["rerunnable"] is True
+    assert by_id[3]["conclusion"] == "success" and by_id[3]["rerunnable"] is False
+    assert by_id[4]["conclusion"] == "skipped" and by_id[4]["rerunnable"] is False
+
+
+def test_list_pr_workflow_runs_rejects_a_non_sha(route):
+    router = route([])
+    with pytest.raises(gl.ProviderCliError, match="invalid commit sha"):
+        gl.list_pr_workflow_runs("g", "p", "../etc", host="gitlab.com")
+    assert router.calls == []
+
+
+def test_cancel_workflow_run_posts_to_the_pipeline(route):
+    router = route([("cancel", {})])
+    assert gl.cancel_workflow_run("g", "p", 99, host="gitlab.com") == {
+        "run_id": 99, "cancelled": True
+    }
+    assert "pipelines/99/cancel" in router.calls[0]["target"]
+    assert "POST" in router.calls[0]["argv"]
+
+
+def test_rerun_workflow_run_reports_what_gitlab_actually_does(route):
+    router = route([("retry", {})])
+    out = gl.rerun_workflow_run("g", "p", 99, failed_only=False, host="gitlab.com")
+    # GitLab's /retry only retries failed and canceled jobs, so the answer is what
+    # happened -- not what was asked for.
+    assert out == {"run_id": 99, "rerun": True, "failed_only": True}
+    assert "pipelines/99/retry" in router.calls[0]["target"]
+
+
+# ── module-level parity constants ────────────────────────────────────────────
+
+
+def test_the_historical_gh_aliases_are_the_same_classes():
+    assert gl.GhCliError is gl.ProviderCliError
+    assert gl.GhSetupError is gl.ProviderSetupError
+    assert gl.GhPermissionError is gl.ProviderPermissionError
+    assert gl.PR_REVIEW_EVENTS == ("APPROVE", "COMMENT")

--- a/test/test_history_coverage.py
+++ b/test/test_history_coverage.py
@@ -1,0 +1,1378 @@
+"""Coverage tests for :mod:`kiro_crew.history`.
+
+Targets whole uncovered helpers and error branches rather than the happy paths
+the existing ``test_history*.py`` files already exercise:
+
+- the off-loop persistence wrappers' inline / offloaded failure reporting,
+- pure text helpers (``_content_text``, ``transcript_stems``, the tool-call and
+  sensitive-path scanners),
+- bounded tail readers (``_read_tail_messages``, ``last_message_preview``),
+- ``list_sessions`` metadata fallbacks and canonical-key dedupe,
+- ``clear_closed``'s compare-and-clear guards,
+- the durable consolidation retry accounting (environment failures, bad
+  persisted values) and ``HistoryConsolidator``'s ``_note_*`` bookkeeping,
+- the structured-memory / lesson writers and the two background-session LLM
+  turns (``_dedupe_judge``, ``_merge_skill_update``).
+
+Every test writes only under ``tmp_path``; no network, no subprocess.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew import history as H
+from kiro_crew.history import (
+    _CONSOLIDATION_BACKOFF_BASE_SECS,
+    _CONSOLIDATION_BACKOFF_MAX_SECS,
+    _CONSOLIDATION_MAX_ATTEMPTS,
+    AttemptedSpan,
+    ConversationLog,
+    HistoryConsolidator,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    """Write *text* with LF endings on every platform (Windows would translate)."""
+    path.write_text(text, encoding="utf-8", newline="\n")
+
+
+def _jsonl(*rows: dict) -> str:
+    return "".join(json.dumps(r) + "\n" for r in rows)
+
+
+def _log(tmp_path: Path) -> ConversationLog:
+    return ConversationLog(base_dir=tmp_path)
+
+
+def _consolidator(**kw) -> HistoryConsolidator:
+    kw.setdefault("log", MagicMock())
+    kw.setdefault("memory", MagicMock())
+    return HistoryConsolidator(**kw)
+
+
+# ── off-loop persistence wrappers ──────────────────────────────────────────
+
+
+class TestOffLoopWrappers:
+    """The three ``*_off_loop`` helpers must swallow-and-log inline failures and
+    report offloaded ones through the done-callback."""
+
+    def test_append_off_loop_inline_failure_is_logged(self, caplog) -> None:
+        log = MagicMock()
+        log.append.side_effect = OSError("disk gone")
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            H.append_off_loop(log, "k", "user", "hi", agent="a")
+        assert "inline append failed" in caplog.text
+        log.append.assert_called_once_with("k", "user", "hi", agent="a")
+
+    def test_append_if_absent_off_loop_inline_failure_is_logged(self, caplog) -> None:
+        log = MagicMock()
+        log.append_if_absent.side_effect = OSError("disk gone")
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            H.append_if_absent_off_loop(log, "k", "assistant", "yo")
+        assert "inline append failed" in caplog.text
+
+    def test_update_metadata_off_loop_inline_failure_is_logged(self, caplog) -> None:
+        log = MagicMock()
+        log.update_metadata.side_effect = OSError("disk gone")
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            H.update_metadata_off_loop(log, "k", {"title": "t"})
+        assert "inline update failed" in caplog.text
+
+    def test_off_loop_wrappers_run_inline_when_no_loop(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        H.append_off_loop(log, "k", "user", "one")
+        H.append_if_absent_off_loop(log, "k", "user", "one")  # idempotent → no dup
+        H.append_if_absent_off_loop(log, "k", "assistant", "two")
+        H.update_metadata_off_loop(log, "k", {"title": "T"})
+        assert [m["content"] for m in log._read_messages("k")] == ["one", "two"]
+        assert log.get_metadata("k")["title"] == "T"
+
+    @pytest.mark.asyncio
+    async def test_append_off_loop_offloads_and_reports_failure(self, caplog) -> None:
+        """On a running loop the write is dispatched to an executor, and the
+        done-callback surfaces the exception instead of losing it."""
+        done = asyncio.Event()
+        log = MagicMock()
+        log.append.side_effect = OSError("nope")
+        loop = asyncio.get_running_loop()
+        real_run_in_executor = loop.run_in_executor
+        captured: dict[str, object] = {}
+
+        def _spy(executor, func, *args):
+            fut = real_run_in_executor(executor, func, *args)
+            captured["fut"] = fut
+            fut.add_done_callback(lambda _f: loop.call_soon_threadsafe(done.set))
+            return fut
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            with patch.object(loop, "run_in_executor", _spy):
+                H.append_off_loop(log, "k", "user", "hi")
+            await asyncio.wait_for(done.wait(), timeout=5)
+            await asyncio.sleep(0)
+        assert "offloaded append failed" in caplog.text
+        assert captured["fut"].done()
+
+    @pytest.mark.asyncio
+    async def test_update_metadata_off_loop_offloads_to_executor(
+        self, tmp_path: Path
+    ) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        loop = asyncio.get_running_loop()
+        futures: list[asyncio.Future] = []
+        real_run_in_executor = loop.run_in_executor
+
+        def _spy(executor, func, *args):
+            fut = real_run_in_executor(executor, func, *args)
+            futures.append(fut)
+            return fut
+
+        with patch.object(loop, "run_in_executor", _spy):
+            H.update_metadata_off_loop(log, "k", {"title": "later"})
+        assert futures, "update_metadata_off_loop must dispatch to an executor"
+        await asyncio.wait_for(asyncio.shield(futures[0]), timeout=5)
+        assert _log(tmp_path).get_metadata("k")["title"] == "later"
+
+    @pytest.mark.asyncio
+    async def test_append_if_absent_off_loop_offloads_to_executor(
+        self, tmp_path: Path
+    ) -> None:
+        log = _log(tmp_path)
+        loop = asyncio.get_running_loop()
+        futures: list[asyncio.Future] = []
+        real_run_in_executor = loop.run_in_executor
+
+        def _spy(executor, func, *args):
+            fut = real_run_in_executor(executor, func, *args)
+            futures.append(fut)
+            return fut
+
+        with patch.object(loop, "run_in_executor", _spy):
+            H.append_if_absent_off_loop(log, "k", "user", "durable")
+        assert futures, "append_if_absent_off_loop must dispatch to an executor"
+        await asyncio.wait_for(asyncio.shield(futures[0]), timeout=5)
+        assert [m["content"] for m in _log(tmp_path)._read_messages("k")] == ["durable"]
+
+
+# ── pure helpers ───────────────────────────────────────────────────────────
+
+
+class TestContentText:
+    @pytest.mark.parametrize(
+        "content,expected",
+        [
+            ("  hello  ", "hello"),
+            ([], ""),
+            (["a", "  b  "], "a b"),
+            ([{"type": "text", "text": "block"}], "block"),
+            ([{"type": "text", "text": "   "}], ""),
+            ([{"type": "image"}, {"text": "second"}], "second"),
+            ([{"text": 42}], ""),
+            (["x", {"text": "y"}], "x y"),
+            (None, ""),
+            (17, ""),
+            ({"text": "dicts are not lists"}, ""),
+        ],
+    )
+    def test_content_text(self, content, expected) -> None:
+        assert ConversationLog._content_text(content) == expected
+
+
+class TestTranscriptStems:
+    def test_plain_key_has_one_stem(self) -> None:
+        assert H.transcript_stems("dashboard:chat-1") == (H._safe_key("dashboard:chat-1"),)
+
+    def test_legacy_slack_key_adds_bare_thread_ts(self) -> None:
+        stems = H.transcript_stems("slack:1699999999.000100")
+        assert stems == (
+            H._safe_key("slack:1699999999.000100"),
+            H._safe_key("1699999999.000100"),
+        )
+
+    def test_legacy_stem_is_not_duplicated(self) -> None:
+        with patch.object(H, "legacy_key", return_value="dashboard:chat-1"):
+            assert H.transcript_stems("dashboard:chat-1") == (
+                H._safe_key("dashboard:chat-1"),
+            )
+
+
+class TestToolCallScanners:
+    def test_count_tool_call_messages_counts_each_message_once(self) -> None:
+        messages = [
+            {"role": "assistant", "tools": ["Read"]},
+            {"role": "assistant", "tools": []},  # empty list → not a tool call
+            {"role": "tool", "content": "ran"},
+            {"role": "tool_call", "content": "x", "tools": ["A"]},  # counted once
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "tools": "Read"},  # wrong type → ignored
+        ]
+        assert H._count_tool_call_messages(messages) == 3
+
+    @pytest.mark.parametrize(
+        "messages,expected",
+        [
+            ([{"role": "assistant", "tools": ["fs_read ~/.ssh/id_ed25519"]}], True),
+            ([{"role": "assistant", "tools": [None, 5]}], False),
+            ([{"role": "assistant", "tools": ["Read README.md"]}], False),
+            ([{"role": "tool", "content": "curl http://169.254.169.254/latest"}], True),
+            ([{"role": "tool_result", "content": {"not": "a string"}}], False),
+            ([{"role": "user", "content": "cat ~/.aws/credentials"}], False),
+            ([], False),
+        ],
+    )
+    def test_session_touched_sensitive(self, messages, expected) -> None:
+        assert H._session_touched_sensitive(messages) is expected
+
+
+# ── bounded tail readers ───────────────────────────────────────────────────
+
+
+class TestReadTailMessages:
+    def test_non_positive_max_returns_empty(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        assert log._read_tail_messages(log._path("k"), 0, None) == []
+        assert log._read_tail_messages(log._path("k"), -3, None) == []
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        assert log._read_tail_messages(tmp_path / "nope.jsonl", 5, None) == []
+
+    def test_skips_metadata_blank_and_unparseable_lines(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        path = tmp_path / "k.jsonl"
+        _write(
+            path,
+            _jsonl({"_type": "metadata", "created_at": "x"})
+            + "\n"
+            + "{not json\n"
+            + _jsonl(
+                {"role": "user", "content": "a"},
+                {"role": "assistant", "content": "b"},
+            ),
+        )
+        got = log._read_tail_messages(path, 10, None)
+        assert [m["content"] for m in got] == ["a", "b"]
+
+    def test_role_filter_applies(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        path = tmp_path / "k.jsonl"
+        _write(
+            path,
+            _jsonl(
+                {"role": "user", "content": "u1"},
+                {"role": "assistant", "content": "a1"},
+                {"role": "user", "content": "u2"},
+            ),
+        )
+        got = log._read_tail_messages(path, 5, {"user"})
+        assert [m["content"] for m in got] == ["u1", "u2"]
+
+    def test_window_grows_until_enough_messages(self, tmp_path: Path) -> None:
+        """A file far larger than the initial window still yields the true tail."""
+        log = _log(tmp_path)
+        path = tmp_path / "k.jsonl"
+        rows = [{"role": "user", "content": f"m{i}" + "p" * 400} for i in range(200)]
+        _write(path, _jsonl(*rows))
+        assert path.stat().st_size > log._TAIL_MIN_BYTES
+        got = log._read_tail_messages(path, 40, None)
+        assert len(got) == 40
+        assert got[-1]["content"].startswith("m199")
+
+    def test_open_failure_returns_empty(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        path = log._path("k")
+        with patch("builtins.open", side_effect=OSError("locked")):
+            assert log._read_tail_messages(path, 5, None) == []
+
+
+class TestLastMessagePreview:
+    def test_missing_file(self, tmp_path: Path) -> None:
+        assert _log(tmp_path).last_message_preview("nope") == ""
+
+    def test_metadata_only_file(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(log._path("k"), _jsonl({"_type": "metadata", "created_at": "x"}))
+        assert log.last_message_preview("k") == ""
+
+    def test_returns_newest_message(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "first")
+        log.append("k", "assistant", "second")
+        assert log.last_message_preview("k") == "second"
+
+    def test_structured_content_blocks(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(
+            log._path("k"),
+            _jsonl(
+                {"_type": "metadata"},
+                {"role": "assistant", "content": [{"type": "text", "text": "blocky"}]},
+            ),
+        )
+        assert log.last_message_preview("k") == "blocky"
+
+    def test_skips_unparseable_and_empty_content_rows(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(
+            log._path("k"),
+            _jsonl({"role": "user", "content": "real"})
+            + "{ broken\n"
+            + "\n"
+            + _jsonl({"role": "assistant", "content": ""}),
+        )
+        assert log.last_message_preview("k") == "real"
+
+    def test_truncates_long_preview_with_ellipsis(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "assistant", "abcdefghij" * 40)
+        preview = log.last_message_preview("k")
+        assert preview.endswith("…")
+        assert len(preview) == log._PREVIEW_MAX_CHARS + 1
+
+    def test_retries_with_wider_window(self, tmp_path: Path) -> None:
+        """A single trailing line larger than the first window is only reachable
+        on the 16x retry — the first pass discards it as a partial line."""
+        log = _log(tmp_path)
+        big = "z" * (log._PREVIEW_TAIL_BYTES * 2)
+        _write(
+            log._path("k"),
+            _jsonl({"_type": "metadata"}, {"role": "assistant", "content": big}),
+        )
+        preview = log.last_message_preview("k")
+        assert preview.startswith("z")
+
+    def test_open_failure_returns_empty(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        with patch("builtins.open", side_effect=OSError("locked")):
+            assert log.last_message_preview("k") == ""
+
+    def test_unpreviewable_markdown_yields_empty(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "assistant", "text")
+        with patch("kiro_crew.history.strip_markdown_preview", return_value=""):
+            assert log.last_message_preview("k") == ""
+
+
+# ── list_sessions ──────────────────────────────────────────────────────────
+
+
+class TestListSessions:
+    def test_missing_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert ConversationLog(base_dir=tmp_path / "absent").list_sessions() == []
+
+    def test_metadata_line_supplies_title_agent_folder(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(
+            tmp_path / "s1.jsonl",
+            _jsonl(
+                {
+                    "_type": "metadata",
+                    "created_at": "2026-01-01T00:00:00",
+                    "title": "Titled",
+                    "agent": "kirocrew",
+                    "memory_mode": "ephemeral",
+                    "folder_id": "f1",
+                },
+                {"role": "user", "content": "hi"},
+            ),
+        )
+        (row,) = log.list_sessions()
+        assert row["title"] == "Titled"
+        assert row["agent"] == "kirocrew"
+        assert row["memory_mode"] == "ephemeral"
+        assert row["folder_id"] == "f1"
+        assert row["created"] == "2026-01-01T00:00:00"
+
+    def test_metadata_cache_hit_is_used(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(tmp_path / "s1.jsonl", _jsonl({"_type": "metadata"}))
+        mtime = (tmp_path / "s1.jsonl").stat().st_mtime
+        log._meta_cache["s1"] = (
+            mtime,
+            {
+                "_type": "metadata",
+                "created_at": "cached-at",
+                "title": "cached",
+                "agent": "cached-agent",
+                "memory_mode": "ephemeral",
+                "folder_id": "cf",
+            },
+        )
+        (row,) = log.list_sessions()
+        assert (row["title"], row["agent"], row["created"]) == (
+            "cached",
+            "cached-agent",
+            "cached-at",
+        )
+        assert row["folder_id"] == "cf"
+
+    def test_first_user_message_is_title_fallback(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(
+            tmp_path / "s1.jsonl",
+            _jsonl({"_type": "metadata"})
+            + "\n"
+            + "{ broken\n"
+            + _jsonl(
+                {"role": "assistant", "content": "ignored"},
+                {"role": "user", "content": "from message"},
+            ),
+        )
+        (row,) = log.list_sessions()
+        assert row["title"] == "from message"
+
+    def test_message_cache_supplies_title_fallback(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(tmp_path / "s1.jsonl", _jsonl({"_type": "metadata"}))
+        mtime = (tmp_path / "s1.jsonl").stat().st_mtime
+        log._msg_cache["s1"] = (
+            mtime,
+            [
+                {"role": "assistant", "content": "skip"},
+                {"role": "user", "content": "cached title"},
+            ],
+        )
+        (row,) = log.list_sessions()
+        assert row["title"] == "cached title"
+
+    def test_title_defaults_to_key(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(tmp_path / "s1.jsonl", _jsonl({"_type": "metadata"}))
+        (row,) = log.list_sessions()
+        assert row["title"] == "s1"
+        assert row["memory_mode"] == "persistent"
+
+    def test_stacked_dashboard_prefixes_dedupe_to_newest(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(tmp_path / "dashboard_chat-1.jsonl", _jsonl({"_type": "metadata"}))
+        _write(
+            tmp_path / "dashboard_dashboard_chat-1.jsonl",
+            _jsonl({"_type": "metadata", "title": "newer"}),
+        )
+        import os as _os
+
+        older = tmp_path / "dashboard_chat-1.jsonl"
+        _os.utime(older, (1_600_000_000, 1_600_000_000))
+        rows = log.list_sessions()
+        assert len(rows) == 1
+        assert rows[0]["title"] == "newer"
+
+    def test_stat_failure_skips_file(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(tmp_path / "s1.jsonl", _jsonl({"_type": "metadata"}))
+        real_stat = Path.stat
+
+        def _stat(self, *args, **kwargs):
+            if self.suffix == ".jsonl":
+                raise OSError("gone")
+            return real_stat(self, *args, **kwargs)
+
+        with patch.object(Path, "stat", _stat):
+            assert log.list_sessions() == []
+
+    def test_symlinks_are_skipped(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(tmp_path / "s1.jsonl", _jsonl({"_type": "metadata"}))
+        with patch.object(Path, "is_symlink", return_value=True):
+            assert log.list_sessions() == []
+
+
+# ── clear_closed ───────────────────────────────────────────────────────────
+
+
+class TestClearClosed:
+    def test_missing_file_is_noop(self, tmp_path: Path) -> None:
+        _log(tmp_path).clear_closed("nope")
+
+    def test_empty_file_is_noop(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(log._path("k"), "")
+        log.clear_closed("k")
+
+    def test_unparseable_first_line_is_noop(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(log._path("k"), "{ broken\n")
+        log.clear_closed("k")
+        assert log._path("k").read_text(encoding="utf-8") == "{ broken\n"
+
+    def test_not_flagged_is_noop(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        before = log._path("k").read_text(encoding="utf-8")
+        log.clear_closed("k")
+        assert log._path("k").read_text(encoding="utf-8") == before
+
+    def test_first_line_not_metadata_is_noop(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(log._path("k"), _jsonl({"role": "user", "content": "hi"}))
+        log.clear_closed("k")
+        assert "closed" not in log._path("k").read_text(encoding="utf-8")
+
+    def test_clears_flag_and_stamp(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        log.update_metadata("k", {"closed": True, "closed_at": 100.0})
+        log.clear_closed("k")
+        meta = _log(tmp_path).get_metadata("k")
+        assert "closed" not in meta and "closed_at" not in meta
+
+    def test_compare_and_clear_keeps_newer_close(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        log.update_metadata("k", {"closed": True, "closed_at": 500.0})
+        log.clear_closed("k", only_if_closed_before=400.0)
+        assert _log(tmp_path).get_metadata("k")["closed"] is True
+
+    def test_compare_and_clear_drops_older_close(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        log.update_metadata("k", {"closed": True, "closed_at": 300.0})
+        log.clear_closed("k", only_if_closed_before=400.0)
+        assert "closed" not in _log(tmp_path).get_metadata("k")
+
+    def test_unstamped_flag_falls_back_to_mtime(self, tmp_path: Path) -> None:
+        """No ``closed_at`` → the file mtime approximates the close instant, so a
+        far-future threshold clears and a far-past one keeps."""
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        log.update_metadata("k", {"closed": True})
+        log.clear_closed("k", only_if_closed_before=0.0)
+        assert _log(tmp_path).get_metadata("k")["closed"] is True
+        log.clear_closed("k", only_if_closed_before=4_000_000_000.0)
+        assert "closed" not in _log(tmp_path).get_metadata("k")
+
+    def test_unparseable_closed_at_falls_back_to_mtime(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        log.update_metadata("k", {"closed": True, "closed_at": "not-a-float"})
+        log.clear_closed("k", only_if_closed_before=4_000_000_000.0)
+        assert "closed" not in _log(tmp_path).get_metadata("k")
+
+
+# ── durable consolidation accounting ───────────────────────────────────────
+
+
+class TestConsolidationCounts:
+    def test_unparseable_offset_is_treated_as_zero(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "a")
+        log.append("k", "user", "b")
+        log.update_metadata("k", {"last_consolidated": "bogus"})
+        assert log.consolidation_counts("k") == (2, 2)
+
+    def test_counts_subtract_offset(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        for i in range(4):
+            log.append("k", "user", str(i))
+        log.mark_consolidated("k", 3)
+        assert log.consolidation_counts("k") == (4, 1)
+
+
+class TestRecordEnvironmentFailure:
+    def test_deleted_session_records_nothing(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        assert log.record_consolidation_environment_failure("gone", 900.0, 86400.0) == (
+            0,
+            0.0,
+        )
+
+    def test_increments_and_widens_wait(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        first, at1 = log.record_consolidation_environment_failure(
+            "k", 100.0, 10_000.0, now=1_000.0
+        )
+        second, at2 = log.record_consolidation_environment_failure(
+            "k", 100.0, 10_000.0, now=1_000.0
+        )
+        assert (first, second) == (1, 2)
+        assert at1 == 1_100.0
+        assert at2 == 1_200.0
+        assert log.get_metadata("k")["consolidation_env_failures"] == 2
+
+    def test_wait_is_capped(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        log.update_metadata("k", {"consolidation_env_failures": 40})
+        failures, retry_at = log.record_consolidation_environment_failure(
+            "k", 100.0, 500.0, now=0.0
+        )
+        assert failures == 41
+        assert retry_at == 500.0
+
+    def test_unparseable_counter_restarts_at_one(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        log.update_metadata("k", {"consolidation_env_failures": "wat"})
+        failures, _ = log.record_consolidation_environment_failure(
+            "k", 100.0, 10_000.0, now=0.0
+        )
+        assert failures == 1
+
+
+class TestRetryEligible:
+    def test_refuses_at_attempt_cap(self) -> None:
+        log = MagicMock()
+        log.consolidation_retry_state.return_value = (_CONSOLIDATION_MAX_ATTEMPTS, 0.0)
+        assert _consolidator(log=log).retry_eligible("k", now=1e12) is False
+
+    def test_refuses_before_retry_at(self) -> None:
+        log = MagicMock()
+        log.consolidation_retry_state.return_value = (1, 5_000.0)
+        c = _consolidator(log=log)
+        assert c.retry_eligible("k", now=4_999.0) is False
+        assert c.retry_eligible("k", now=5_000.0) is True
+
+    def test_passes_message_count_through(self) -> None:
+        log = MagicMock()
+        log.consolidation_retry_state.return_value = (0, 0.0)
+        assert _consolidator(log=log).retry_eligible("k", message_count=12) is True
+        log.consolidation_retry_state.assert_called_once_with("k", 12)
+
+
+_SPAN = AttemptedSpan(total=10, generation=2, offset=4)
+
+
+class TestNoteFailedAttempt:
+    @pytest.mark.asyncio
+    async def test_persist_failure_is_logged_and_swallowed(self, caplog) -> None:
+        log = MagicMock()
+        log.record_consolidation_failure.side_effect = OSError("no disk")
+        c = _consolidator(log=log)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            await c._note_failed_attempt("k", _SPAN, "boom")
+        assert "Could not persist consolidation retry state" in caplog.text
+        log.mark_consolidated.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deleted_session_records_nothing(self) -> None:
+        log = MagicMock()
+        log.record_consolidation_failure.return_value = (0, 0.0)
+        c = _consolidator(log=log)
+        await c._note_failed_attempt("k", _SPAN, "boom")
+        log.mark_consolidated.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_below_cap_logs_next_attempt(self, caplog) -> None:
+        log = MagicMock()
+        log.record_consolidation_failure.return_value = (1, 1e12)
+        c = _consolidator(log=log)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            await c._note_failed_attempt("k", _SPAN, "boom")
+        assert "Consolidation attempt 1/" in caplog.text
+        log.mark_consolidated.assert_not_called()
+        assert log.record_consolidation_failure.call_args.args[1:] == (
+            _CONSOLIDATION_BACKOFF_BASE_SECS,
+            _CONSOLIDATION_BACKOFF_MAX_SECS,
+            _SPAN,
+        )
+
+    @pytest.mark.asyncio
+    async def test_at_cap_abandons_span_with_snapshot_identity(self, caplog) -> None:
+        log = MagicMock()
+        log.record_consolidation_failure.return_value = (
+            _CONSOLIDATION_MAX_ATTEMPTS,
+            0.0,
+        )
+        c = _consolidator(log=log)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            await c._note_failed_attempt("k", _SPAN, "boom")
+        assert "Abandoning consolidation" in caplog.text
+        log.mark_consolidated.assert_called_once_with("k", _SPAN.total, _SPAN.generation)
+
+    @pytest.mark.asyncio
+    async def test_marker_write_failure_at_cap_is_logged(self, caplog) -> None:
+        log = MagicMock()
+        log.record_consolidation_failure.return_value = (
+            _CONSOLIDATION_MAX_ATTEMPTS,
+            0.0,
+        )
+        log.mark_consolidated.side_effect = OSError("no disk")
+        c = _consolidator(log=log)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            await c._note_failed_attempt("k", _SPAN, "boom")
+        assert "Could not mark abandoned consolidation" in caplog.text
+
+
+class TestNoteEnvironmentFailure:
+    @pytest.mark.asyncio
+    async def test_persist_failure_is_logged(self, caplog) -> None:
+        log = MagicMock()
+        log.record_consolidation_environment_failure.side_effect = OSError("no disk")
+        c = _consolidator(log=log)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            await c._note_environment_failure("k", "kiro-cli missing")
+        assert "Could not persist consolidation environment backoff" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_deleted_session_is_silent(self, caplog) -> None:
+        log = MagicMock()
+        log.record_consolidation_environment_failure.return_value = (0, 0.0)
+        c = _consolidator(log=log)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            await c._note_environment_failure("k", "gone")
+        assert "could not reach the LLM" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_never_touches_the_attempt_cap(self, caplog) -> None:
+        log = MagicMock()
+        log.record_consolidation_environment_failure.return_value = (3, 1e12)
+        c = _consolidator(log=log)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            await c._note_environment_failure("k", "no session manager")
+        assert "environment failure #3" in caplog.text
+        log.mark_consolidated.assert_not_called()
+        log.record_consolidation_failure.assert_not_called()
+
+
+# ── structured memory + lesson writers ─────────────────────────────────────
+
+
+class TestWriteStructuredMemory:
+    def test_no_vector_store_is_noop(self) -> None:
+        _consolidator()._write_structured_memory({"semantic": [{"key": "a"}]}, "k")
+
+    def test_semantic_write_delete_and_escalation(self, caplog) -> None:
+        vs = MagicMock()
+        vs.set_semantic.return_value = None
+        vs.delete_semantic.return_value = True
+        c = _consolidator(vector_store=vs)
+        result = {
+            "semantic": [
+                {"key": "plain", "value": "v", "confidence": 0.5},
+                {"key": "explicit", "value": "v2", "confidence": 1.0},
+                {"key": "stale", "delete": True},
+                {"no_key": "skipped"},
+                "not a dict",
+            ]
+        }
+        with caplog.at_level(logging.INFO, logger="kiro_crew.history"):
+            c._write_structured_memory(result, "sess")
+        sources = {kw["key"]: kw["source"] for _, kw in vs.set_semantic.call_args_list}
+        assert sources == {"plain": "consolidation:sess", "explicit": "user_explicit"}
+        vs.delete_semantic.assert_called_once_with("stale", "consolidation:sess")
+        assert "2 written, 1 deleted" in caplog.text
+
+    def test_semantic_error_is_not_counted(self, caplog) -> None:
+        vs = MagicMock()
+        vs.set_semantic.return_value = "rejected"
+        c = _consolidator(vector_store=vs)
+        with caplog.at_level(logging.INFO, logger="kiro_crew.history"):
+            c._write_structured_memory({"semantic": [{"key": "a", "value": "b"}]}, "k")
+        assert "Semantic consolidation" not in caplog.text
+
+    def test_semantic_is_capped(self) -> None:
+        vs = MagicMock()
+        vs.set_semantic.return_value = None
+        c = _consolidator(vector_store=vs)
+        items = [{"key": f"k{i}", "value": "v"} for i in range(200)]
+        c._write_structured_memory({"semantic": items}, "k")
+        assert vs.set_semantic.call_count == H._MAX_SEMANTIC_PER_CONSOLIDATION
+
+    def test_episodic_write_and_skips(self, caplog) -> None:
+        vs = MagicMock()
+        vs.write_episodic.return_value = True
+        c = _consolidator(vector_store=vs)
+        result = {
+            "episodic": [
+                {"text": "a thing happened", "tags": ["t"], "importance": 0.9},
+                {"missing": "text"},
+                7,
+            ]
+        }
+        with caplog.at_level(logging.INFO, logger="kiro_crew.history"):
+            c._write_structured_memory(result, "sess")
+        vs.write_episodic.assert_called_once_with(
+            text="a thing happened",
+            conversation_id="sess",
+            tags=["t"],
+            importance=0.9,
+            source="consolidation:sess",
+        )
+        assert "Wrote 1 episodic" in caplog.text
+
+    def test_episodic_failure_is_not_counted(self, caplog) -> None:
+        vs = MagicMock()
+        vs.write_episodic.return_value = False
+        c = _consolidator(vector_store=vs)
+        with caplog.at_level(logging.INFO, logger="kiro_crew.history"):
+            c._write_structured_memory({"episodic": [{"text": "x"}]}, "k")
+        assert "episodic entries from consolidation" not in caplog.text
+
+    def test_episodic_is_capped(self) -> None:
+        vs = MagicMock()
+        vs.write_episodic.return_value = True
+        c = _consolidator(vector_store=vs)
+        items = [{"text": f"t{i}"} for i in range(200)]
+        c._write_structured_memory({"episodic": items}, "k")
+        assert vs.write_episodic.call_count == H._MAX_EPISODIC_PER_CONSOLIDATION
+
+    def test_non_list_sections_are_ignored(self) -> None:
+        vs = MagicMock()
+        c = _consolidator(vector_store=vs)
+        c._write_structured_memory({"semantic": "nope", "episodic": {"a": 1}}, "k")
+        vs.set_semantic.assert_not_called()
+        vs.write_episodic.assert_not_called()
+
+
+class TestSaveLessons:
+    def test_non_list_is_ignored(self) -> None:
+        vs = MagicMock()
+        _consolidator(vector_store=vs)._save_lessons({"rule": "x"})
+        vs.write_lesson.assert_not_called()
+
+    def test_caps_and_warns(self, caplog) -> None:
+        vs = MagicMock()
+        vs.write_lesson.return_value = True
+        c = _consolidator(vector_store=vs)
+        raw = [{"rule": f"r{i}"} for i in range(H._MAX_LESSONS_PER_CONSOLIDATION + 5)]
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+            c._save_lessons(raw)
+        assert "capping to" in caplog.text
+        assert vs.write_lesson.call_count == H._MAX_LESSONS_PER_CONSOLIDATION
+
+    def test_vector_store_path_skips_lesson_store(self, caplog) -> None:
+        vs = MagicMock()
+        vs.write_lesson.side_effect = [True, False]
+        store = MagicMock()
+        c = _consolidator(vector_store=vs, lesson_store=store)
+        with caplog.at_level(logging.INFO, logger="kiro_crew.history"):
+            c._save_lessons(
+                [
+                    {"rule": "one", "category": "style", "negative": "not that"},
+                    {"rule": "two"},
+                    {"no": "rule"},
+                ]
+            )
+        assert vs.write_lesson.call_count == 2
+        store.save.assert_not_called()
+        assert "Extracted 1 lesson(s) from chat (vector store)" in caplog.text
+
+    def test_vector_store_zero_writes_logs_nothing(self, caplog) -> None:
+        vs = MagicMock()
+        vs.write_lesson.return_value = False
+        with caplog.at_level(logging.INFO, logger="kiro_crew.history"):
+            _consolidator(vector_store=vs)._save_lessons([{"rule": "r"}])
+        assert "vector store" not in caplog.text
+
+    def test_no_stores_is_noop(self) -> None:
+        _consolidator()._save_lessons([{"rule": "r"}])
+
+    def test_lesson_store_fallback_saves_lessons(self, caplog) -> None:
+        store = MagicMock()
+        c = _consolidator(lesson_store=store)
+        with caplog.at_level(logging.INFO, logger="kiro_crew.history"):
+            c._save_lessons(
+                [
+                    {"rule": "always X", "category": "workflow", "negative": "never Y"},
+                    {"missing": "rule"},
+                    "not a dict",
+                ]
+            )
+        store.save.assert_called_once()
+        lesson = store.save.call_args.args[0]
+        assert lesson.rule == "always X"
+        assert lesson.category == "workflow"
+        assert lesson.negative == "never Y"
+        assert lesson.ts
+        assert "Extracted 1 lesson(s) from chat" in caplog.text
+
+    def test_lesson_store_defaults_category(self) -> None:
+        store = MagicMock()
+        _consolidator(lesson_store=store)._save_lessons([{"rule": "r"}])
+        assert store.save.call_args.args[0].category == "knowledge"
+
+
+# ── background-session LLM turns ───────────────────────────────────────────
+
+
+def _fake_sessions() -> MagicMock:
+    sessions = MagicMock()
+    sessions.get_or_create = AsyncMock(return_value=(MagicMock(), False, False))
+    sessions.release = MagicMock()
+    sessions.recycle_background = AsyncMock(return_value=None)
+    return sessions
+
+
+class TestDedupeJudge:
+    @pytest.mark.asyncio
+    async def test_no_session_manager_fails_open(self) -> None:
+        assert await _consolidator()._dedupe_judge("p") == ""
+
+    @pytest.mark.asyncio
+    async def test_returns_text_and_releases_session(self) -> None:
+        sessions = _fake_sessions()
+        c = _consolidator(sessions=sessions)
+        with patch(
+            "kiro_crew.history.stream_and_collect", AsyncMock(return_value="DUP")
+        ):
+            assert await c._dedupe_judge("prompt") == "DUP"
+        sessions.release.assert_called_once_with(H.BACKGROUND_KEY)
+        sessions.recycle_background.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_text_becomes_empty_string(self) -> None:
+        sessions = _fake_sessions()
+        c = _consolidator(sessions=sessions)
+        with patch(
+            "kiro_crew.history.stream_and_collect", AsyncMock(return_value=None)
+        ):
+            assert await c._dedupe_judge("prompt") == ""
+
+    @pytest.mark.asyncio
+    async def test_llm_error_fails_open_but_still_releases(self) -> None:
+        sessions = _fake_sessions()
+        c = _consolidator(sessions=sessions)
+        with patch(
+            "kiro_crew.history.stream_and_collect",
+            AsyncMock(side_effect=RuntimeError("provider down")),
+        ):
+            assert await c._dedupe_judge("prompt") == ""
+        sessions.release.assert_called_once_with(H.BACKGROUND_KEY)
+
+    @pytest.mark.asyncio
+    async def test_release_failure_is_swallowed(self) -> None:
+        sessions = _fake_sessions()
+        sessions.release.side_effect = RuntimeError("already released")
+        c = _consolidator(sessions=sessions)
+        with patch(
+            "kiro_crew.history.stream_and_collect", AsyncMock(return_value="NEW")
+        ):
+            assert await c._dedupe_judge("prompt") == "NEW"
+
+
+class TestMergeSkillUpdate:
+    @pytest.mark.asyncio
+    async def test_no_session_manager_returns_none(self) -> None:
+        assert await _consolidator()._merge_skill_update("body", "d", "t", "p") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_merged_body_and_prompts_with_all_inputs(self) -> None:
+        sessions = _fake_sessions()
+        c = _consolidator(sessions=sessions)
+        collector = AsyncMock(return_value="## When to use\nmerged\n")
+        with patch("kiro_crew.history.stream_and_collect", collector):
+            out = await c._merge_skill_update(
+                "EXISTING BODY", "the description", "trig1, trig2", "1. do it"
+            )
+        assert out == "## When to use\nmerged\n"
+        prompt = collector.await_args.args[1]
+        for needle in ("EXISTING BODY", "the description", "trig1, trig2", "1. do it"):
+            assert needle in prompt
+        sessions.release.assert_called_once_with(H.BACKGROUND_KEY)
+        sessions.recycle_background.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_text_returns_none(self) -> None:
+        sessions = _fake_sessions()
+        c = _consolidator(sessions=sessions)
+        with patch("kiro_crew.history.stream_and_collect", AsyncMock(return_value="")):
+            assert await c._merge_skill_update("b", "d", "t", "p") is None
+
+    @pytest.mark.asyncio
+    async def test_llm_error_returns_none_but_still_releases(self) -> None:
+        sessions = _fake_sessions()
+        c = _consolidator(sessions=sessions)
+        with patch(
+            "kiro_crew.history.stream_and_collect",
+            AsyncMock(side_effect=RuntimeError("provider down")),
+        ):
+            assert await c._merge_skill_update("b", "d", "t", "p") is None
+        sessions.release.assert_called_once_with(H.BACKGROUND_KEY)
+
+    @pytest.mark.asyncio
+    async def test_release_failure_is_swallowed(self) -> None:
+        sessions = _fake_sessions()
+        sessions.recycle_background.side_effect = RuntimeError("boom")
+        c = _consolidator(sessions=sessions)
+        with patch("kiro_crew.history.stream_and_collect", AsyncMock(return_value="x")):
+            assert await c._merge_skill_update("b", "d", "t", "p") == "x"
+
+
+# ── compaction rewrite ─────────────────────────────────────────────────────
+
+
+class TestRewriteSession:
+    def test_corrupted_lines_are_archived_not_kept(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "keep")
+        log.append("k", "user", "drop")
+        with log._path("k").open("a", encoding="utf-8", newline="\n") as f:
+            f.write("{ corrupted\n")
+        keep = [m for m in log._read_messages("k") if m["content"] == "keep"]
+        log.rewrite_session("k", keep)
+        assert [m["content"] for m in _log(tmp_path)._read_messages("k")] == ["keep"]
+        archived = list((tmp_path / H.ARCHIVE_DIR_NAME).glob("*.jsonl"))
+        assert archived, "dropped + corrupted lines must be archived"
+        body = archived[0].read_text(encoding="utf-8")
+        assert "drop" in body
+        assert "{ corrupted" in body
+
+    def test_archive_failure_is_logged_not_raised(self, tmp_path: Path, caplog) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "a")
+        log.append("k", "user", "b")
+        keep = log._read_messages("k")[:1]
+        with patch.object(H, "_archive_lines", side_effect=OSError("read-only")):
+            with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+                log.rewrite_session("k", keep)
+        assert "Failed to archive dropped lines" in caplog.text
+        assert [m["content"] for m in _log(tmp_path)._read_messages("k")] == ["a"]
+
+    def test_unowned_metadata_is_carried_through(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "a")
+        log.append("k", "user", "b")
+        log.update_metadata("k", {"title": "mine", "agent": "kirocrew"})
+        keep = log._read_messages("k")[:1]
+        log.rewrite_session("k", keep)
+        meta = _log(tmp_path).get_metadata("k")
+        assert meta["title"] == "mine"
+        assert meta["agent"] == "kirocrew"
+        assert meta["compacted_at"]
+
+    def test_rewrite_preserves_mtime(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "a")
+        log.append("k", "user", "b")
+        import os as _os
+
+        _os.utime(log._path("k"), (1_600_000_000, 1_600_000_000))
+        before = log._path("k").stat().st_mtime
+        log.rewrite_session("k", log._read_messages("k")[:1])
+        assert log._path("k").stat().st_mtime == pytest.approx(before, abs=2)
+
+
+# ── search-text cache budget ───────────────────────────────────────────────
+
+
+class TestSearchTextCache:
+    def _cache(self, max_bytes: int) -> H._SearchTextCache:
+        return H._SearchTextCache(max_bytes, lambda v: int(v), "test")
+
+    def test_retain_drops_dead_keys_and_resets_refusals(self) -> None:
+        cache = self._cache(100)
+        cache["a"] = 10
+        cache["b"] = 20
+        cache["huge"] = 1_000  # refused: over budget
+        assert cache.refused_since_prune() == 1
+        assert cache.retain({"a"}) == 1
+        assert "b" not in cache
+        assert "a" in cache
+        assert cache.refused_since_prune() == 0
+
+    def test_len_pop_clear_and_stats(self) -> None:
+        cache = self._cache(100)
+        cache["a"] = 10
+        cache["b"] = 20
+        assert len(cache) == 2
+        assert cache.pop("a") == 10
+        assert cache.pop("a", 99) == 99
+        stats = cache.stats()
+        assert stats["entries"] == 1
+        assert stats["max_bytes"] == 100
+        cache.clear()
+        assert len(cache) == 0
+        assert cache.stats()["bytes"] == 0
+
+
+# ── span identity for the attempt cap ──────────────────────────────────────
+
+
+class TestAttemptsDescribeCurrentSpan:
+    def _log(self, tmp_path: Path) -> ConversationLog:
+        return _log(tmp_path)
+
+    def test_unstamped_accounting_keeps_the_cap(self, tmp_path: Path) -> None:
+        log = self._log(tmp_path)
+        assert log._attempts_describe_current_span({}, 99) is True
+
+    def test_generation_mismatch_releases_the_cap(self, tmp_path: Path) -> None:
+        log = self._log(tmp_path)
+        meta = {"rotation_generation": 3, "consolidation_attempts_generation": 2}
+        assert log._attempts_describe_current_span(meta, None) is False
+
+    def test_offset_mismatch_releases_the_cap(self, tmp_path: Path) -> None:
+        log = self._log(tmp_path)
+        meta = {"last_consolidated": 7, "consolidation_attempts_offset": 4}
+        assert log._attempts_describe_current_span(meta, None) is False
+
+    def test_unreadable_stamp_keeps_the_cap(self, tmp_path: Path) -> None:
+        log = self._log(tmp_path)
+        meta = {"rotation_generation": 1, "consolidation_attempts_generation": "junk"}
+        assert log._attempts_describe_current_span(meta, None) is True
+
+    def test_growth_past_attempted_extent_releases_the_cap(self, tmp_path: Path) -> None:
+        log = self._log(tmp_path)
+        meta = {"consolidation_attempts_count": 10}
+        assert log._attempts_describe_current_span(meta, 11) is False
+        assert log._attempts_describe_current_span(meta, 10) is True
+        # A shrink is a rotation/compaction, not new content — cap holds.
+        assert log._attempts_describe_current_span(meta, 4) is True
+
+    def test_unreadable_extent_keeps_the_cap(self, tmp_path: Path) -> None:
+        log = self._log(tmp_path)
+        meta = {"consolidation_attempts_count": "junk"}
+        assert log._attempts_describe_current_span(meta, 11) is True
+
+    def test_missing_count_skips_the_extent_test(self, tmp_path: Path) -> None:
+        log = self._log(tmp_path)
+        assert log._attempts_describe_current_span(
+            {"consolidation_attempts_count": 3}, None
+        ) is True
+
+
+# ── metadata write guards ──────────────────────────────────────────────────
+
+
+class TestUpdateMetadataLocked:
+    def test_unparseable_first_line_is_left_untouched(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(log._path("k"), "{ broken\n")
+        log.update_metadata("k", {"title": "T"})
+        assert log._path("k").read_text(encoding="utf-8") == "{ broken\n"
+
+    def test_non_metadata_first_line_is_left_untouched(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(log._path("k"), _jsonl({"role": "user", "content": "hi"}))
+        log.update_metadata("k", {"title": "T"})
+        assert "title" not in log._path("k").read_text(encoding="utf-8")
+
+    def test_upsert_creates_metadata_line(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.update_metadata("fresh", {"agent": "kirocrew"})
+        meta = _log(tmp_path).get_metadata("fresh")
+        assert meta["agent"] == "kirocrew"
+        assert meta["last_consolidated"] == 0
+
+    def test_replace_failure_cleans_up_the_temp_file(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        with patch("os.replace", side_effect=OSError("cross-device")):
+            with pytest.raises(OSError):
+                log.update_metadata("k", {"title": "T"})
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_update_metadata_if_guard_rejects(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        assert log.update_metadata_if("k", {"title": "T"}, lambda m: False) is False
+        assert "title" not in log.get_metadata("k")
+
+    def test_update_metadata_if_guard_accepts(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        assert log.update_metadata_if("k", {"tab_id": "t1"}, lambda m: True) is True
+        assert _log(tmp_path).get_metadata("k")["tab_id"] == "t1"
+
+    def test_update_metadata_if_fails_closed_on_unreadable_record(
+        self, tmp_path: Path
+    ) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        with patch.object(log, "_read_metadata_status", return_value=({}, False)):
+            assert log.update_metadata_if("k", {"title": "T"}, lambda m: True) is False
+
+
+# ── delete_session ─────────────────────────────────────────────────────────
+
+
+class TestDeleteSession:
+    def test_missing_session_returns_false(self, tmp_path: Path) -> None:
+        assert _log(tmp_path).delete_session("nope") is False
+
+    def test_removes_file_and_summary_sidecar(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        log.set_cached_summary("k", "a summary", 1.0)
+        sidecar = log._summary_cache_path("k")
+        assert sidecar.exists()
+        assert log.delete_session("k") is True
+        assert not log._path("k").exists()
+        assert not sidecar.exists()
+
+    def test_unlink_failure_returns_false(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        with patch.object(Path, "unlink", side_effect=OSError("busy")):
+            assert log.delete_session("k") is False
+        assert log._path("k").exists()
+
+    def test_sidecar_unlink_failure_still_deletes(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        real_unlink = Path.unlink
+
+        def _unlink(self, *args, **kwargs):
+            if self.suffix == ".json":
+                raise OSError("busy")
+            return real_unlink(self, *args, **kwargs)
+
+        with patch.object(Path, "unlink", _unlink):
+            assert log.delete_session("k") is True
+
+    def test_lock_timeout_refuses_to_delete(self, tmp_path: Path, caplog) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hi")
+        with patch.object(log, "_locked", side_effect=H.HistoryLockTimeout("wedged")):
+            with caplog.at_level(logging.WARNING, logger="kiro_crew.history"):
+                assert log.delete_session("k") is False
+        assert "lock timeout, not deleting" in caplog.text
+        assert log._path("k").exists()
+
+
+# ── snippet + cross-session reads ──────────────────────────────────────────
+
+
+class TestContentSnippet:
+    def test_empty_query_has_no_snippet(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hello world")
+        assert log._content_snippet("k", "   ") == ""
+
+    def test_no_match_has_no_snippet(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hello world")
+        assert log._content_snippet("k", "absent") == ""
+
+    def test_read_error_has_no_snippet(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "hello world")
+        with patch.object(log, "_snippet_texts", side_effect=OSError("gone")):
+            assert log._content_snippet("k", "hello") == ""
+
+    def test_match_is_centered_and_elided(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", ("pad " * 200) + "needle" + (" pad" * 200))
+        snippet = log._content_snippet("k", "needle")
+        assert "needle" in snippet
+        assert snippet.startswith("…")
+        assert snippet.endswith("…")
+
+    def test_token_fallback_for_multiword_query(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("k", "user", "alpha then something then beta")
+        snippet = log._content_snippet("k", "alpha beta")
+        assert snippet  # the phrase is absent, so a token matched
+
+
+class TestRecentFromSource:
+    def test_missing_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert (
+            ConversationLog(base_dir=tmp_path / "absent").recent_from_source("slack")
+            == []
+        )
+
+    def test_collects_and_excludes(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("slack:a", "user", "from a")
+        log.append("slack:b", "user", "from b")
+        log.append("other:c", "user", "from c")
+        got = log.recent_from_source("slack", exclude_key="slack:b")
+        assert [m["content"] for m in got] == ["from a"]
+        assert all(set(m) == {"role", "content"} for m in got)
+
+    def test_incognito_sessions_are_skipped(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("slack:a", "user", "kept")
+        log.append("slack:b", "user", "hidden")
+        log.update_metadata("slack:b", {"memory_mode": sorted(H.INCOGNITO_MEMORY_MODES)[0]})
+        got = log.recent_from_source("slack")
+        assert [m["content"] for m in got] == ["kept"]
+
+    def test_head_read_failure_skips_the_file(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        log.append("slack:a", "user", "hi")
+        with patch("builtins.open", side_effect=OSError("locked")):
+            assert log.recent_from_source("slack") == []
+
+    def test_max_messages_trims_to_the_newest(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        for i in range(6):
+            log.append("slack:a", "user", f"m{i}")
+        got = log.recent_from_source("slack", max_messages=2)
+        assert [m["content"] for m in got] == ["m4", "m5"]
+
+
+# ── skill-text helpers ─────────────────────────────────────────────────────
+
+
+class TestSkillTextHelpers:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            (None, ""),
+            ("", ""),
+            ("no frontmatter here", ""),
+            ("---\nname: thing\ndescription: d\n---\nbody", "d"),
+            ("---\nname: thing\n---\nbody", ""),
+            ("---\nnovalue\n---\nbody", ""),
+        ],
+    )
+    def test_frontmatter_value(self, text, expected) -> None:
+        assert H._frontmatter_value(text, "description") == expected
+
+    @pytest.mark.parametrize(
+        "live,candidate,expected",
+        [
+            ("a, b", "b, c", "a, b, c"),
+            ("A", "a", "A"),
+            ("", "solo", "solo"),
+            ("  spaced   out ", "", "spaced out"),
+            (",,", ",", ""),
+        ],
+    )
+    def test_merge_trigger_lists(self, live, candidate, expected) -> None:
+        assert H._merge_trigger_lists(live, candidate) == expected
+
+    def test_merge_trigger_lists_caps(self) -> None:
+        live = ", ".join(f"t{i}" for i in range(20))
+        assert H._merge_trigger_lists(live, "extra", cap=3) == "t0, t1, t2"
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            (None, ""),
+            ("---\nname: x\n---\nbody text", "body text"),
+            ("no frontmatter", "no frontmatter"),
+        ],
+    )
+    def test_strip_skill_frontmatter(self, text, expected) -> None:
+        assert H._strip_skill_frontmatter(text) == expected
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("", ""),
+            ("plain body", "plain body"),
+            ("```markdown\nfenced\n```", "fenced"),
+            ("```\nfenced\n```", "fenced"),
+            ("```markdown\nunterminated", "unterminated"),
+            ("```", "```"),  # a lone fence has no body line to unwrap
+        ],
+    )
+    def test_strip_code_fence(self, text, expected) -> None:
+        assert H._strip_code_fence(text) == expected
+
+
+class TestReadMessagesSkipsBlankLines:
+    def test_blank_lines_between_rows_are_ignored(self, tmp_path: Path) -> None:
+        log = _log(tmp_path)
+        _write(
+            log._path("k"),
+            _jsonl({"_type": "metadata"})
+            + "\n\n"
+            + _jsonl({"role": "user", "content": "only"}),
+        )
+        assert [m["content"] for m in log._read_messages("k")] == ["only"]

--- a/test/test_hooks_coverage.py
+++ b/test/test_hooks_coverage.py
@@ -1,0 +1,1874 @@
+"""Coverage tests for ``kiro_crew.hooks``.
+
+Focus is the parts of the module the existing hook suites never reach: the
+descriptor-pinned file helpers (``safe_*``), the internal-read allowlist and its
+SEL-audit gate, the boot-time builtin-app registries, the script-hook store's
+persistence/rollback contract, and script-hook dispatch (registration ordering,
+matcher filtering, and failure isolation).
+
+Everything here is hermetic: no real network, no real subprocess, and every
+filesystem write lands under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import stat as _stat
+import uuid
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import hooks as hooks_mod
+from kiro_crew import security, webhooks
+from kiro_crew.hooks import (
+    HOOK_EVENT_POST_TOOL_USE,
+    HOOK_EVENT_PRE_TOOL_USE,
+    HOOK_EVENT_STOP,
+    HOOK_EVENT_USER_PROMPT_SUBMIT,
+    HOOK_MODIFY,
+    TOOL_ALLOW,
+    TOOL_AUTO_APPROVE,
+    FileTooLargeError,
+    HookManager,
+    HooksConfig,
+    ScriptHook,
+    ScriptHookResult,
+    ScriptHookStore,
+    TransformHook,
+    UserDeniedPattern,
+    _app_owns_mcp_server,
+    _audit_governance,
+    _builtin_app_for_agent,
+    _coerce_bool,
+    _cu_read_only_auto_approve,
+    _emit_internal_read_audit,
+    _fd_real_path,
+    _governance_denial,
+    _governance_pinned_command_ids,
+    _is_access_control_xattr,
+    _is_declared_builtin_mcp_server,
+    _is_first_party_app,
+    _script_hooks_capability_denied,
+    effective_denied_regexes_from_config,
+    emit_internal_read_audit,
+    fire_tool_hooks,
+    get_global_hook_store,
+    hooks_config_from_config_dict,
+    load_denied_commands_state,
+    register_internal_read_path,
+    resolve_denied_notes,
+    run_script_hook,
+    safe_copy_file_nolink,
+    safe_read_file,
+    safe_read_file_bytes,
+    safe_read_file_bytes_nolink,
+    safe_read_file_bytes_with_identity,
+    safe_read_file_internal,
+    safe_read_prefix,
+    safe_write_file_nolink,
+    set_builtin_app_agents,
+    set_builtin_app_mcp_servers,
+    set_builtin_app_names,
+    set_global_hook_store,
+    stat_identity,
+    validate_file_path,
+)
+
+_IS_WINDOWS = platform.system() == "Windows"
+
+
+# ── helpers ──
+
+
+def _write(path: Path, text: str) -> Path:
+    """Write *text* verbatim.
+
+    ``newline="\\n"`` is explicit: the default translates ``\\n`` to ``\\r\\n``
+    on Windows, which breaks the byte-exact assertions below.
+    """
+    path.write_text(text, encoding="utf-8", newline="\n")
+    return path
+
+
+def _same(a: str, b: str) -> bool:
+    """Compare two paths after resolving BOTH sides.
+
+    ``tempfile`` hands back the Windows 8.3 SHORT form while ``realpath``
+    returns the long one, so a raw string compare passes on POSIX and fails
+    only on Windows.
+    """
+    return os.path.realpath(a) == os.path.realpath(b)
+
+
+def _identity(path: Path) -> tuple[int, int]:
+    st = os.stat(path)
+    return (st.st_dev, st.st_ino)
+
+
+def _staged_sibling(directory: Path, base: str) -> bool:
+    """True once ``safe_write_file_nolink`` has staged its temp file for *base*.
+
+    A deterministic marker for "the payload is written and the identity
+    re-checks are next", used instead of counting ``os.stat`` calls -- the
+    screening before staging varies with what the process has already cached.
+    ``Path.iterdir`` uses ``scandir``, so it does not re-enter a patched
+    ``os.stat``.
+    """
+    prefix = f".{base}.kirocrew-"
+    return any(p.name.startswith(prefix) for p in directory.iterdir())
+
+
+def _try_hardlink(src: Path, dst: Path) -> None:
+    """Hardlink *src* to *dst*, skipping the test when the platform refuses."""
+    try:
+        os.link(src, dst)
+    except (OSError, NotImplementedError, AttributeError) as exc:  # pragma: no cover
+        pytest.skip(f"hardlinks unavailable here: {exc}")
+
+
+class _StubDecision:
+    def __init__(self, permitted: bool, reason: str = "") -> None:
+        self.permitted = permitted
+        self.reason = reason
+
+
+@pytest.fixture
+def restore_builtin_registries():
+    """Snapshot/restore the boot-warmed module globals the gate reads."""
+    saved = (
+        hooks_mod._BUILTIN_APP_NAMES,
+        hooks_mod._BUILTIN_APP_MCP_SERVERS,
+        dict(hooks_mod._BUILTIN_APP_AGENTS),
+    )
+    yield
+    hooks_mod._BUILTIN_APP_NAMES = saved[0]
+    hooks_mod._BUILTIN_APP_MCP_SERVERS = saved[1]
+    hooks_mod._BUILTIN_APP_AGENTS = saved[2]
+
+
+@pytest.fixture
+def restore_internal_allowlist():
+    """Snapshot/restore ``_INTERNAL_READ_ALLOWLIST`` around a registration."""
+    saved = dict(hooks_mod._INTERNAL_READ_ALLOWLIST)
+    yield
+    hooks_mod._INTERNAL_READ_ALLOWLIST.clear()
+    hooks_mod._INTERNAL_READ_ALLOWLIST.update(saved)
+
+
+# ── config parsing ──
+
+
+class TestCoerceBool:
+    @pytest.mark.parametrize("raw", ["true", "TRUE", " 1 ", "yes", "on"])
+    def test_truthy_spellings(self, raw):
+        assert _coerce_bool(raw, default=False) is True
+
+    @pytest.mark.parametrize("raw", ["false", "FALSE", "0", "no", "off"])
+    def test_falsey_spellings(self, raw):
+        # Plain bool("false") is True -- the trap this helper exists to close.
+        assert _coerce_bool(raw, default=True) is False
+
+    @pytest.mark.parametrize("raw", [None, 3, [], {}, "maybe"])
+    def test_unrecognised_falls_back_to_default(self, raw):
+        assert _coerce_bool(raw, default=True) is True
+        assert _coerce_bool(raw, default=False) is False
+
+    def test_real_bool_passes_through(self):
+        assert _coerce_bool(True, default=False) is True
+        assert _coerce_bool(False, default=True) is False
+
+
+class TestUserDeniedPattern:
+    def test_missing_id_gets_generated(self):
+        p = UserDeniedPattern.from_dict({"pattern": "rm .*"})
+        assert p.id and len(p.id) == 12
+        assert p.pattern == "rm .*"
+        assert p.enabled is True
+        assert p.note == ""
+
+    def test_malformed_enabled_stays_on(self):
+        # Fail safe: an ambiguous value must keep a deny rule enforcing.
+        assert UserDeniedPattern.from_dict({"pattern": "x", "enabled": "junk"}).enabled is True
+        assert UserDeniedPattern.from_dict({"pattern": "x", "enabled": "off"}).enabled is False
+
+    def test_malformed_note_degrades_to_blank(self):
+        assert UserDeniedPattern.from_dict({"pattern": "x", "note": None}).note == ""
+        assert UserDeniedPattern.from_dict({"pattern": "x", "note": 7}).note == "7"
+
+    def test_round_trip(self):
+        p = UserDeniedPattern(id="abc", pattern="p", enabled=False, note="n")
+        assert p.to_dict() == {"id": "abc", "pattern": "p", "enabled": False, "note": "n"}
+
+
+class TestHooksConfigFromDict:
+    def test_non_dict_input_degrades(self):
+        cfg = HooksConfig.from_dict("not a dict")  # type: ignore[arg-type]
+        assert cfg.auto_replies == []
+        assert cfg.context_rules == []
+
+    def test_scalar_where_list_expected_degrades(self):
+        cfg = HooksConfig.from_dict(
+            {
+                "auto_replies": 1,
+                "transforms": "x",
+                "context_rules": None,
+                "auto_approve_sources": 5,
+                "auto_deny_tools": {"a": 1},
+            }
+        )
+        assert cfg.auto_replies == []
+        assert cfg.transforms == []
+        assert cfg.context_rules == []
+        assert cfg.auto_approve_sources == []
+        assert cfg.auto_deny_tools == []
+
+    def test_non_dict_items_in_lists_are_dropped(self):
+        cfg = HooksConfig.from_dict(
+            {"auto_replies": ["nope", {"pattern": "p", "reply": "r"}, 3]}
+        )
+        assert len(cfg.auto_replies) == 1
+        assert cfg.auto_replies[0].pattern == "p"
+
+    def test_non_string_auto_approve_entries_dropped_and_bundled_merged(self):
+        cfg = HooksConfig.from_dict({"auto_approve_tools": ["mine", 4, None]})
+        assert "mine" in cfg.auto_approve_tools
+        for bundled in hooks_mod._BUNDLED_AUTO_APPROVE_TOOLS:
+            assert bundled in cfg.auto_approve_tools
+        # No duplicates even when the operator listed a bundled pattern too.
+        assert len(cfg.auto_approve_tools) == len(set(cfg.auto_approve_tools))
+
+    def test_subagent_flags_fail_safe_on_junk(self):
+        cfg = HooksConfig.from_dict(
+            {
+                "auto_approve_subagent_spawn": "false",
+                "auto_approve_subagent_tools": "nonsense",
+            }
+        )
+        assert cfg.auto_approve_subagent_spawn is False
+        assert cfg.auto_approve_subagent_tools is False
+
+    def test_denied_commands_junk_degrades_to_no_optout(self):
+        cfg = HooksConfig.from_dict(
+            {"denied_commands": {"user_added": 1, "disabled_ids": "x", "disable_all": "false"}}
+        )
+        assert cfg.denied_commands_user_added == []
+        assert cfg.denied_commands_disabled_ids == []
+        assert cfg.denied_commands_disable_all is False
+
+    def test_denied_commands_non_dict_degrades(self):
+        cfg = HooksConfig.from_dict({"denied_commands": ["nope"]})
+        assert cfg.denied_commands_state() == {
+            "disabled_ids": [],
+            "disable_all": False,
+            "user_added": [],
+        }
+
+    def test_blank_user_patterns_are_dropped(self):
+        cfg = HooksConfig.from_dict(
+            {
+                "denied_commands": {
+                    "user_added": [{"pattern": "  "}, {"pattern": "keep"}, "junk"],
+                    "disabled_ids": ["a", 2, ""],
+                }
+            }
+        )
+        assert [p.pattern for p in cfg.denied_commands_user_added] == ["keep"]
+        assert cfg.denied_commands_disabled_ids == ["a"]
+
+    def test_to_dict_omits_bundled_and_nests_denied(self):
+        cfg = HooksConfig.from_dict({"auto_approve_tools": ["mine"]})
+        out = cfg.to_dict()
+        assert out["auto_approve_tools"] == ["mine"]
+        assert out["denied_commands"] == {
+            "disabled_ids": [],
+            "disable_all": False,
+            "user_added": [],
+        }
+
+
+class TestDeniedCommandsState:
+    def test_load_state_missing_file_is_no_optout(self):
+        assert load_denied_commands_state() == {}
+
+    def test_load_state_reads_keystone(self, tmp_path, monkeypatch):
+        from kiro_crew.config import loader
+
+        keystone = tmp_path / "denied_commands.json"
+        _write(keystone, json.dumps({"disable_all": True}))
+        monkeypatch.setattr(loader, "denied_commands_path", lambda: keystone)
+        assert load_denied_commands_state() == {"disable_all": True}
+
+    def test_load_state_non_object_degrades(self, tmp_path, monkeypatch):
+        from kiro_crew.config import loader
+
+        keystone = _write(tmp_path / "denied_commands.json", "[1, 2]")
+        monkeypatch.setattr(loader, "denied_commands_path", lambda: keystone)
+        assert load_denied_commands_state() == {}
+
+    def test_load_state_corrupt_json_degrades(self, tmp_path, monkeypatch):
+        from kiro_crew.config import loader
+
+        keystone = _write(tmp_path / "denied_commands.json", "{not json")
+        monkeypatch.setattr(loader, "denied_commands_path", lambda: keystone)
+        assert load_denied_commands_state() == {}
+
+    def test_boot_path_ignores_config_json_denied_section(self, monkeypatch):
+        # config.json's own hooks.denied_commands must be discarded: the
+        # keystone file is the sole source for the deny ceiling.
+        monkeypatch.setattr(hooks_mod, "load_denied_commands_state", lambda: {})
+        cfg = hooks_config_from_config_dict(
+            {"denied_commands": {"disable_all": True}, "auto_deny_tools": ["x"]}
+        )
+        assert cfg.denied_commands_disable_all is False
+        assert cfg.auto_deny_tools == ["x"]
+
+    def test_boot_path_tolerates_non_dict_section(self, monkeypatch):
+        monkeypatch.setattr(hooks_mod, "load_denied_commands_state", lambda: {})
+        assert hooks_config_from_config_dict(None).auto_deny_tools == []  # type: ignore[arg-type]
+
+    def test_effective_set_fails_closed_when_load_raises(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("keystone unreadable")
+
+        monkeypatch.setattr(hooks_mod, "load_denied_commands_state", _boom)
+        result = effective_denied_regexes_from_config()
+        expected = security.compute_effective_denied(
+            security.BUILTIN_DENIED_RULES, (), False, (), ()
+        )
+        assert result == expected
+
+    def test_effective_set_from_disk_includes_user_pattern(self, monkeypatch):
+        monkeypatch.setattr(
+            hooks_mod,
+            "load_denied_commands_state",
+            lambda: {"user_added": [{"pattern": "my-own-rule", "enabled": True}]},
+        )
+        assert "my-own-rule" in effective_denied_regexes_from_config()
+
+
+class TestResolveDeniedNotes:
+    def test_only_annotated_enabled_patterns_appear(self):
+        cfg = HooksConfig(
+            denied_commands_user_added=[
+                UserDeniedPattern(id="1", pattern="a", enabled=True, note=" use rg "),
+                UserDeniedPattern(id="2", pattern="b", enabled=True, note="   "),
+                UserDeniedPattern(id="3", pattern="c", enabled=False, note="hidden"),
+                UserDeniedPattern(id="4", pattern="", enabled=True, note="no pattern"),
+            ]
+        )
+        assert resolve_denied_notes(cfg) == {"a": "use rg"}
+
+    def test_note_that_forges_a_refusal_line_is_dropped(self):
+        forged = f"{security.DENY_REASON_MATCH_PREFIX} fabricated"
+        cfg = HooksConfig(
+            denied_commands_user_added=[
+                UserDeniedPattern(id="1", pattern="a", enabled=True, note=forged)
+            ]
+        )
+        # Fail-safe direction: lose the note, keep the pattern.
+        assert resolve_denied_notes(cfg) == {}
+
+
+# ── path validation and reads ──
+
+
+class TestValidateFilePath:
+    def test_blank_is_rejected(self):
+        assert validate_file_path("") is None
+
+    def test_sensitive_is_rejected(self):
+        assert validate_file_path(str(Path.home() / ".aws" / "credentials")) is None
+
+    def test_ordinary_path_is_canonicalized(self, tmp_path):
+        f = _write(tmp_path / "ok.txt", "x")
+        assert _same(validate_file_path(str(f)) or "", str(f))
+
+
+class TestSafeReadFile:
+    def test_reads_text(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "hello\n")
+        assert safe_read_file(str(f)) == "hello\n"
+
+    def test_sensitive_path_refused(self):
+        with pytest.raises(PermissionError, match="sensitive path"):
+            safe_read_file(str(Path.home() / ".ssh" / "id_rsa"))
+
+    def test_missing_file_propagates(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            safe_read_file(str(tmp_path / "nope.txt"))
+
+
+class TestSafeReadFileBytes:
+    def test_reads_bytes(self, tmp_path):
+        f = _write(tmp_path / "a.bin", "abc")
+        assert safe_read_file_bytes(str(f)) == b"abc"
+
+    def test_rejected_path_returns_none(self):
+        assert safe_read_file_bytes("") is None
+        assert safe_read_file_bytes(str(Path.home() / ".aws" / "config")) is None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert safe_read_file_bytes(str(tmp_path / "gone")) is None
+
+    def test_directory_returns_none(self, tmp_path):
+        d = tmp_path / "adir"
+        d.mkdir()
+        # A directory is either EISDIR on open or unreadable on read; both -> None.
+        assert safe_read_file_bytes(str(d)) is None
+
+    def test_oversize_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hooks_mod, "MAX_FILE_BYTES", 4)
+        f = _write(tmp_path / "big.bin", "0123456789")
+        with pytest.raises(FileTooLargeError):
+            safe_read_file_bytes(str(f))
+
+
+class TestSafeReadFileBytesWithIdentity:
+    def test_allowlisted_inode_is_read(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "payload")
+        assert safe_read_file_bytes_with_identity(str(f), {_identity(f)}) == b"payload"
+
+    def test_unlisted_inode_is_refused(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "payload")
+        with pytest.raises(PermissionError, match="not in the authorized set"):
+            safe_read_file_bytes_with_identity(str(f), set())
+
+    def test_rejected_path_returns_none(self, tmp_path):
+        assert safe_read_file_bytes_with_identity("", {(1, 2)}) is None
+        assert safe_read_file_bytes_with_identity(str(tmp_path / "gone"), {(1, 2)}) is None
+
+    def test_symlink_swap_at_final_component_is_refused(self, tmp_path, monkeypatch):
+        # validate_file_path resolves symlinks, so the refusal is reached by
+        # making the post-validation open report ELOOP -- the TOCTOU shape the
+        # O_NOFOLLOW guard exists for.
+        f = _write(tmp_path / "a.txt", "payload")
+        import errno as _errno
+
+        real_open = os.open
+
+        def _eloop(path, flags, *args, **kwargs):
+            if _same(str(path), str(f)):
+                raise OSError(_errno.ELOOP, "symlink swapped in")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(os, "open", _eloop)
+        with pytest.raises(PermissionError, match="refusing to follow symlink"):
+            safe_read_file_bytes_with_identity(str(f), {_identity(f)})
+
+    def test_oversize_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hooks_mod, "MAX_FILE_BYTES", 2)
+        f = _write(tmp_path / "a.txt", "0123456789")
+        with pytest.raises(FileTooLargeError):
+            safe_read_file_bytes_with_identity(str(f), {_identity(f)})
+
+
+class TestStatIdentity:
+    def test_returns_dev_ino(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "x")
+        assert stat_identity(str(f)) == _identity(f)
+
+    def test_missing_or_rejected_returns_none(self, tmp_path):
+        assert stat_identity(str(tmp_path / "gone")) is None
+        assert stat_identity("") is None
+        assert stat_identity(str(Path.home() / ".aws")) is None
+
+
+class TestFdRealPath:
+    def test_resolves_an_open_descriptor(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "x")
+        fd = os.open(str(f), os.O_RDONLY)
+        try:
+            got = _fd_real_path(fd)
+        finally:
+            os.close(fd)
+        # A platform with no supported mechanism fails closed (None); where one
+        # exists it must name the same file.
+        assert got is None or _same(got, str(f))
+
+
+class TestSafeReadPrefix:
+    def test_non_positive_n_short_circuits(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "abcdef")
+        assert safe_read_prefix(str(f), 0) == b""
+        assert safe_read_prefix(str(f), -1) == b""
+
+    def test_reads_only_the_prefix(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "abcdef")
+        assert safe_read_prefix(str(f), 3) == b"abc"
+
+    def test_rejected_or_missing_returns_none(self, tmp_path):
+        assert safe_read_prefix("", 4) is None
+        assert safe_read_prefix(str(tmp_path / "gone"), 4) is None
+        assert safe_read_prefix(str(Path.home() / ".aws" / "config"), 4) is None
+
+
+class TestIsAccessControlXattr:
+    @pytest.mark.parametrize("attr", ["security.selinux", "system.posix_acl_access"])
+    def test_access_control_attrs(self, attr):
+        assert _is_access_control_xattr(attr) is True
+
+    @pytest.mark.parametrize("attr", ["user.comment", "trusted.thing", ""])
+    def test_informational_attrs(self, attr):
+        assert _is_access_control_xattr(attr) is False
+
+
+class TestSafeReadFileBytesNolink:
+    def test_reads_a_plain_file(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "body")
+        assert safe_read_file_bytes_nolink(str(f)) == b"body"
+
+    def test_negative_max_bytes_is_a_programming_error(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "body")
+        with pytest.raises(ValueError, match="non-negative"):
+            safe_read_file_bytes_nolink(str(f), max_bytes=-1)
+
+    def test_hardlinked_inode_refused(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "body")
+        _try_hardlink(f, tmp_path / "b.txt")
+        assert safe_read_file_bytes_nolink(str(f)) is None
+
+    def test_non_regular_refused(self, tmp_path):
+        d = tmp_path / "adir"
+        d.mkdir()
+        assert safe_read_file_bytes_nolink(str(d)) is None
+
+    def test_rejected_and_missing_paths(self, tmp_path):
+        assert safe_read_file_bytes_nolink("") is None
+        assert safe_read_file_bytes_nolink(str(tmp_path / "gone")) is None
+
+    def test_within_root_accepts_a_contained_file(self, tmp_path):
+        root = tmp_path / "root"
+        (root / "sub").mkdir(parents=True)
+        f = _write(root / "sub" / "a.txt", "in")
+        assert safe_read_file_bytes_nolink(str(f), within_root=str(root)) == b"in"
+
+    def test_within_root_refuses_an_escaping_file(self, tmp_path):
+        root = tmp_path / "root"
+        root.mkdir()
+        outside = _write(tmp_path / "outside.txt", "out")
+        assert safe_read_file_bytes_nolink(str(outside), within_root=str(root)) is None
+
+    def test_within_root_fails_closed_when_fd_path_unknown(self, tmp_path, monkeypatch):
+        root = tmp_path / "root"
+        root.mkdir()
+        f = _write(root / "a.txt", "in")
+        monkeypatch.setattr(hooks_mod, "_fd_real_path", lambda fd: None)
+        assert safe_read_file_bytes_nolink(str(f), within_root=str(root)) is None
+
+    def test_oversize_refused_by_default(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "0123456789")
+        with pytest.raises(FileTooLargeError):
+            safe_read_file_bytes_nolink(str(f), max_bytes=4)
+
+    def test_oversize_truncated_when_caller_opts_in(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "0123456789")
+        got = safe_read_file_bytes_nolink(str(f), max_bytes=4, allow_truncate=True)
+        assert got == b"0123"
+
+
+class TestSafeWriteFileNolink:
+    def test_overwrites_an_existing_file(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "old")
+        assert safe_write_file_nolink(str(f), "new body") is True
+        assert f.read_text(encoding="utf-8") == "new body"
+
+    def test_preserves_the_target_mode(self, tmp_path):
+        if _IS_WINDOWS:
+            pytest.skip("POSIX mode bits are not meaningful on Windows")
+        f = _write(tmp_path / "a.txt", "old")
+        os.chmod(f, 0o644)
+        assert safe_write_file_nolink(str(f), "new") is True
+        assert _stat.S_IMODE(os.stat(f).st_mode) == 0o644
+
+    def test_refuses_to_create_a_missing_file(self, tmp_path):
+        target = tmp_path / "gone.txt"
+        assert safe_write_file_nolink(str(target), "x") is False
+        assert not target.exists()
+
+    def test_refuses_a_blank_or_sensitive_path(self):
+        assert safe_write_file_nolink("", "x") is False
+        assert safe_write_file_nolink(str(Path.home() / ".aws" / "credentials"), "x") is False
+
+    def test_refuses_a_hardlinked_target(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "old")
+        _try_hardlink(f, tmp_path / "b.txt")
+        assert safe_write_file_nolink(str(f), "new") is False
+        assert f.read_text(encoding="utf-8") == "old"
+
+    def test_refuses_a_directory(self, tmp_path):
+        d = tmp_path / "adir"
+        d.mkdir()
+        assert safe_write_file_nolink(str(d), "new") is False
+
+    def test_within_root_accepts_a_contained_file(self, tmp_path):
+        root = tmp_path / "root"
+        (root / "sub").mkdir(parents=True)
+        f = _write(root / "sub" / "a.txt", "old")
+        assert safe_write_file_nolink(str(f), "new", within_root=str(root)) is True
+        assert f.read_text(encoding="utf-8") == "new"
+
+    def test_within_root_refuses_an_escaping_file(self, tmp_path):
+        root = tmp_path / "root"
+        root.mkdir()
+        outside = _write(tmp_path / "outside.txt", "old")
+        assert safe_write_file_nolink(str(outside), "new", within_root=str(root)) is False
+        assert outside.read_text(encoding="utf-8") == "old"
+
+    def test_within_root_fails_closed_when_fd_path_unknown(self, tmp_path, monkeypatch):
+        root = tmp_path / "root"
+        root.mkdir()
+        f = _write(root / "a.txt", "old")
+        monkeypatch.setattr(hooks_mod, "_fd_real_path", lambda fd: None)
+        assert safe_write_file_nolink(str(f), "new", within_root=str(root)) is False
+        assert f.read_text(encoding="utf-8") == "old"
+
+    def test_no_staging_file_is_left_behind(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "old")
+        assert safe_write_file_nolink(str(f), "new") is True
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["a.txt"]
+
+    def test_a_target_swapped_after_validation_is_not_clobbered(self, tmp_path, monkeypatch):
+        """A NEW inode at the target name after validation must refuse, not overwrite.
+
+        Both re-checks in the write path (the pinned-parent re-resolve and the
+        last-moment pre-rename stat) compare ``(st_dev, st_ino)`` against the
+        validated identity, so reporting a foreign inode from the first stat of
+        the target exercises the refusal on every platform -- the pinned branch
+        where a directory fd is available, the pre-rename branch where it is not.
+        """
+        f = _write(tmp_path / "a.txt", "old")
+        real_stat = os.stat
+        state = {"fired": False}
+
+        def _swap_after_staging(path, *args, **kwargs):
+            st = real_stat(path, *args, **kwargs)
+            if isinstance(path, int):
+                return st
+            try:
+                name = os.fspath(path)
+            except TypeError:  # pragma: no cover - defensive
+                return st
+            # Keyed on the staged sibling EXISTING rather than on a call count:
+            # the identity re-checks are the only stats of the target that
+            # happen after staging, whatever screening ran before it.
+            if not isinstance(name, str) or os.path.basename(name) != f.name:
+                return st
+            if not _staged_sibling(tmp_path, f.name):
+                return st
+            state["fired"] = True
+
+            class _Other:
+                st_dev = st.st_dev
+                st_ino = st.st_ino + 100000
+                st_mode = st.st_mode
+                st_nlink = 1
+
+            return _Other()
+
+        monkeypatch.setattr(os, "stat", _swap_after_staging)
+        try:
+            assert safe_write_file_nolink(str(f), "new") is False
+        finally:
+            monkeypatch.undo()
+        assert state["fired"] is True
+        assert f.read_text(encoding="utf-8") == "old"
+        # The staged sibling is cleaned up even on the refusal path.
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["a.txt"]
+
+
+class TestSafeCopyFileNolink:
+    def test_copies_into_the_destination_dir(self, tmp_path):
+        src = _write(tmp_path / "src.png", "bytes-here")
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        copied = safe_copy_file_nolink(str(src), str(dest))
+        assert copied is not None
+        assert Path(copied).read_text(encoding="utf-8") == "bytes-here"
+        assert Path(copied).parent == dest
+        assert Path(copied).suffix == ".png"
+
+    def test_copy_is_private(self, tmp_path):
+        if _IS_WINDOWS:
+            pytest.skip("POSIX mode bits are not meaningful on Windows")
+        src = _write(tmp_path / "src.bin", "x")
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        copied = safe_copy_file_nolink(str(src), str(dest))
+        assert copied is not None
+        assert _stat.S_IMODE(os.stat(copied).st_mode) == 0o600
+
+    def test_refuses_a_hardlinked_source(self, tmp_path):
+        src = _write(tmp_path / "src.bin", "x")
+        _try_hardlink(src, tmp_path / "link.bin")
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        assert safe_copy_file_nolink(str(src), str(dest)) is None
+        assert list(dest.iterdir()) == []
+
+    def test_refuses_a_directory_source(self, tmp_path):
+        d = tmp_path / "adir"
+        d.mkdir()
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        assert safe_copy_file_nolink(str(d), str(dest)) is None
+
+    def test_missing_or_rejected_source(self, tmp_path):
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        assert safe_copy_file_nolink("", str(dest)) is None
+        assert safe_copy_file_nolink(str(tmp_path / "gone"), str(dest)) is None
+
+    def test_fails_closed_when_fd_path_unknown(self, tmp_path, monkeypatch):
+        src = _write(tmp_path / "src.bin", "x")
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        monkeypatch.setattr(hooks_mod, "_fd_real_path", lambda fd: None)
+        assert safe_copy_file_nolink(str(src), str(dest)) is None
+
+    def test_unwritable_destination_returns_none(self, tmp_path):
+        src = _write(tmp_path / "src.bin", "x")
+        assert safe_copy_file_nolink(str(src), str(tmp_path / "no-such-dir")) is None
+
+
+# ── internal (audited) reads of sensitive paths ──
+
+
+class TestRegisterInternalReadPath:
+    def test_blank_read_id_refused(self, restore_internal_allowlist):
+        with pytest.raises(ValueError, match="non-empty string"):
+            register_internal_read_path("", ".aws/x.json")
+        with pytest.raises(ValueError, match="non-empty string"):
+            register_internal_read_path(None, ".aws/x.json")  # type: ignore[arg-type]
+
+    def test_repointing_an_existing_id_refused(self, restore_internal_allowlist):
+        with pytest.raises(ValueError, match="refusing to repoint"):
+            register_internal_read_path("kiro_usage_api.sso_token_cli", ".aws/other.json")
+
+    def test_same_id_same_path_is_idempotent(self, restore_internal_allowlist):
+        existing = hooks_mod._INTERNAL_READ_ALLOWLIST["kiro_usage_api.sso_token_cli"]
+        register_internal_read_path("kiro_usage_api.sso_token_cli", existing)
+        assert hooks_mod._INTERNAL_READ_ALLOWLIST["kiro_usage_api.sso_token_cli"] == existing
+
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            "/etc/shadow",
+            "../outside.json",
+            ".aws/../../escape.json",
+        ],
+    )
+    def test_non_relative_or_traversing_paths_refused(self, rel, restore_internal_allowlist):
+        with pytest.raises(ValueError, match="must be relative"):
+            register_internal_read_path("edition.probe", rel)
+
+    def test_non_sensitive_target_refused(self, restore_internal_allowlist):
+        with pytest.raises(ValueError, match="non-sensitive"):
+            register_internal_read_path("edition.probe", "Documents/notes.txt")
+
+    def test_valid_sensitive_registration_lands(self, restore_internal_allowlist):
+        rel = ".aws/sso/cache/edition-probe.json"
+        register_internal_read_path("edition.probe", rel)
+        assert hooks_mod._INTERNAL_READ_ALLOWLIST["edition.probe"] == rel
+
+
+class TestSafeReadFileInternal:
+    def test_unregistered_read_id_is_denied(self):
+        with pytest.raises(PermissionError, match="not in allowlist"):
+            safe_read_file_internal("nope.not_registered")
+
+    def test_allowlist_entry_that_is_no_longer_sensitive_is_denied(self, monkeypatch):
+        # Defense in depth: the carve-out is only valid for a path the shared
+        # file gate otherwise blocks.
+        monkeypatch.setitem(
+            hooks_mod._INTERNAL_READ_ALLOWLIST, "drifted", "Documents/plain.txt"
+        )
+        with pytest.raises(PermissionError, match="non-sensitive"):
+            safe_read_file_internal("drifted")
+
+    def test_missing_file_returns_none_without_reading_anything(self, monkeypatch):
+        rel = f".aws/sso/cache/absent-{uuid.uuid4().hex}.json"
+        monkeypatch.setitem(hooks_mod._INTERNAL_READ_ALLOWLIST, "absent", rel)
+        outcomes: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            hooks_mod,
+            "_emit_internal_read_audit",
+            lambda read_id, outcome: outcomes.append((read_id, outcome)) or True,
+        )
+        assert safe_read_file_internal("absent") is None
+        assert outcomes == [("absent", "missing")]
+
+    def test_unreadable_open_error_returns_none(self, monkeypatch):
+        rel = f".aws/sso/cache/unreadable-{uuid.uuid4().hex}.json"
+        monkeypatch.setitem(hooks_mod._INTERNAL_READ_ALLOWLIST, "unreadable", rel)
+        outcomes: list[str] = []
+        monkeypatch.setattr(
+            hooks_mod,
+            "_emit_internal_read_audit",
+            lambda read_id, outcome: outcomes.append(outcome) or True,
+        )
+        real_open = os.open
+
+        def _eacces(path, flags, *args, **kwargs):
+            if str(path).endswith(os.path.basename(rel)):
+                raise PermissionError("denied")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(os, "open", _eacces)
+        assert safe_read_file_internal("unreadable") is None
+        assert outcomes == ["unreadable"]
+
+    def test_unregistered_read_emits_an_audit_before_raising(self, monkeypatch):
+        seen: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            hooks_mod,
+            "_emit_internal_read_audit",
+            lambda read_id, outcome: seen.append((read_id, outcome)) or True,
+        )
+        with pytest.raises(PermissionError):
+            safe_read_file_internal("also.not_registered")
+        assert seen == [("also.not_registered", "not_allowlisted")]
+
+
+class TestInternalReadAudit:
+    def test_success_is_reported_when_sel_records_it(self, monkeypatch):
+        calls: list[dict] = []
+
+        class _Sel:
+            def log_tool_invocation(self, **kwargs):
+                calls.append(kwargs)
+
+        import kiro_crew.sel as sel_mod
+
+        monkeypatch.setattr(sel_mod, "sel", lambda: _Sel())
+        assert _emit_internal_read_audit("some.read", "success") is True
+        assert calls[0]["outcome"] == "success"
+        # A success gates the return of live credential bytes, so it must be
+        # written synchronously.
+        assert calls[0]["critical"] is True
+
+    def test_non_success_outcome_is_not_critical(self, monkeypatch):
+        calls: list[dict] = []
+
+        class _Sel:
+            def log_tool_invocation(self, **kwargs):
+                calls.append(kwargs)
+
+        import kiro_crew.sel as sel_mod
+
+        monkeypatch.setattr(sel_mod, "sel", lambda: _Sel())
+        assert _emit_internal_read_audit("some.read", "missing") is True
+        assert calls[0]["critical"] is False
+
+    def test_a_raising_sel_reports_failure(self, monkeypatch):
+        class _Sel:
+            def log_tool_invocation(self, **kwargs):
+                raise RuntimeError("sel down")
+
+        import kiro_crew.sel as sel_mod
+
+        monkeypatch.setattr(sel_mod, "sel", lambda: _Sel())
+        assert _emit_internal_read_audit("some.read", "success") is False
+
+    def test_audit_only_wrapper_enforces_its_own_allowlist(self, monkeypatch):
+        calls: list[str] = []
+
+        class _Sel:
+            def log_tool_invocation(self, **kwargs):
+                calls.append(kwargs["outcome"])
+
+        import kiro_crew.sel as sel_mod
+
+        monkeypatch.setattr(sel_mod, "sel", lambda: _Sel())
+        assert emit_internal_read_audit("not.registered", "success") is False
+        assert calls == []
+        registered = next(iter(hooks_mod._AUDIT_ONLY_READ_IDS))
+        assert emit_internal_read_audit(registered, "success") is True
+        assert calls == ["success"]
+
+
+# ── boot-warmed builtin-app registries ──
+
+
+class TestBuiltinAppRegistries:
+    def test_mcp_server_set_is_casefolded_and_junk_dropped(self, restore_builtin_registries):
+        set_builtin_app_mcp_servers(["Meetings:Srv", "", None, 5, "papyrus:tools"])
+        assert _is_declared_builtin_mcp_server("meetings:srv") is True
+        assert _is_declared_builtin_mcp_server("MEETINGS:SRV") is True
+        assert _is_declared_builtin_mcp_server("papyrus:tools") is True
+        assert _is_declared_builtin_mcp_server("meetings:evil") is False
+        assert _is_declared_builtin_mcp_server("") is False
+
+    def test_unwarmed_mcp_set_fails_closed(self, restore_builtin_registries):
+        set_builtin_app_mcp_servers([])
+        assert _is_declared_builtin_mcp_server("meetings:srv") is False
+
+    def test_first_party_lookup_is_casefolded(self, restore_builtin_registries):
+        set_builtin_app_names(["Meetings", "", 7])
+        assert _is_first_party_app("meetings") is True
+        assert _is_first_party_app("MEETINGS") is True
+        assert _is_first_party_app("third-party") is False
+        assert _is_first_party_app("") is False
+
+    def test_agent_map_is_casefolded_and_junk_dropped(self, restore_builtin_registries):
+        set_builtin_app_agents({"Mochi": "mochi", "": "x", "a": "", 3: "y"})
+        assert _builtin_app_for_agent("mochi") == "mochi"
+        assert _builtin_app_for_agent("MOCHI") == "mochi"
+        assert _builtin_app_for_agent("unknown") == ""
+        assert _builtin_app_for_agent("") == ""
+
+    def test_agent_map_replacement_is_idempotent(self, restore_builtin_registries):
+        set_builtin_app_agents({"a": "app-a"})
+        set_builtin_app_agents({"b": "app-b"})
+        assert _builtin_app_for_agent("a") == ""
+        assert _builtin_app_for_agent("b") == "app-b"
+
+    @pytest.mark.parametrize(
+        ("server", "app", "expected"),
+        [
+            ("meetings:srv", "meetings", True),
+            ("Meetings:srv", "MEETINGS", True),
+            ("meetings:srv", "papyrus", False),
+            ("kirocrew-cron", "meetings", False),
+            ("", "meetings", False),
+            ("meetings:srv", "", False),
+        ],
+    )
+    def test_app_owns_mcp_server(self, server, app, expected):
+        assert _app_owns_mcp_server(server, app) is expected
+
+
+class TestComputerUseReadOnlyAutoApprove:
+    def test_a_non_computer_use_title_never_auto_approves(self):
+        assert _cu_read_only_auto_approve("execute_bash") is False
+        assert _cu_read_only_auto_approve("") is False
+
+    def test_enable_state_probe_failure_fails_closed(self, monkeypatch):
+        monkeypatch.setattr(
+            hooks_mod, "computer_use_action_from_title", lambda name: "get_state"
+        )
+        monkeypatch.setattr(
+            hooks_mod, "computer_use_action_classes", lambda action: (hooks_mod.CU_CLASS_OBSERVE,)
+        )
+        import kiro_crew.computer_use as cu
+
+        class _Boom:
+            @staticmethod
+            def is_enabled():
+                raise RuntimeError("keystone unreadable")
+
+        monkeypatch.setattr(cu, "enable_state", _Boom, raising=False)
+        assert _cu_read_only_auto_approve("mcp__kirocrew-computer__computer_get_state") is False
+
+    def test_a_mutating_action_is_not_read_only(self, monkeypatch):
+        monkeypatch.setattr(hooks_mod, "computer_use_action_from_title", lambda name: "click")
+        monkeypatch.setattr(hooks_mod, "computer_use_action_classes", lambda action: ("mutate",))
+        assert _cu_read_only_auto_approve("mcp__kirocrew-computer__computer_click") is False
+
+
+# ── script hook dataclasses ──
+
+
+class TestScriptHookDataclasses:
+    def test_legacy_pattern_field_maps_to_matcher(self):
+        hook = ScriptHook.from_dict({"pattern": "fs_*"})
+        assert hook.matcher == "fs_*"
+
+    def test_matcher_wins_over_legacy_pattern(self):
+        hook = ScriptHook.from_dict({"pattern": "old", "matcher": "new"})
+        assert hook.matcher == "new"
+
+    def test_defaults_are_filled(self):
+        hook = ScriptHook.from_dict({})
+        assert hook.id and hook.event == HOOK_EVENT_USER_PROMPT_SUBMIT
+        assert hook.timeout == 30 and hook.enabled is True
+
+    def test_result_classification(self):
+        blocked = ScriptHookResult(hook_id="a", hook_name="a", event="x", exit_code=2)
+        ok = ScriptHookResult(hook_id="a", hook_name="a", event="x", exit_code=0)
+        failed = ScriptHookResult(hook_id="a", hook_name="a", event="x", exit_code=1)
+        assert blocked.blocked is True and blocked.succeeded is False
+        assert ok.succeeded is True and ok.blocked is False
+        assert failed.succeeded is False and failed.blocked is False
+
+
+# ── script hook store persistence ──
+
+
+class TestScriptHookStorePersistence:
+    def test_foreign_top_level_keys_survive_a_mutation(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _write(path, json.dumps({"webhook-ctx-1": {"note": "resume me"}, "hooks": []}))
+        store = ScriptHookStore(tmp_path)
+        store.create({"name": "h1", "command": "true"})
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        assert on_disk["webhook-ctx-1"] == {"note": "resume me"}
+        assert len(on_disk["hooks"]) == 1
+
+    def test_corrupt_file_is_not_overwritten(self, tmp_path):
+        path = _write(tmp_path / "hooks.json", "{not json")
+        store = ScriptHookStore(tmp_path)  # _load logs and continues
+        assert store.list_all() == []
+        with pytest.raises(webhooks.WebhookStoreUnreadable):
+            store.create({"name": "h1", "command": "true"})
+        # The unreadable file is left for an operator to repair.
+        assert path.read_text(encoding="utf-8") == "{not json"
+
+    def test_a_failed_persist_rolls_back_the_in_memory_set(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create({"name": "h1", "command": "true"})
+        _write(tmp_path / "hooks.json", "{not json")
+        with pytest.raises(webhooks.WebhookStoreUnreadable):
+            store.delete(hook.id)
+        # The delete did not reach disk, so it must not be visible in memory.
+        assert store.get(hook.id) is not None
+
+    def test_toggle_rollback_restores_the_stored_object(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create({"name": "h1", "command": "true", "enabled": True})
+        _write(tmp_path / "hooks.json", "{not json")
+        with pytest.raises(webhooks.WebhookStoreUnreadable):
+            store.toggle(hook.id)
+        # A shallow dict copy would share the ScriptHook and restore nothing.
+        assert store.get(hook.id).enabled is True
+
+    def test_load_reads_hooks_back(self, tmp_path):
+        first = ScriptHookStore(tmp_path)
+        first.create({"id": "keepme", "name": "h1", "command": "true"})
+        second = ScriptHookStore(tmp_path)
+        assert [h.id for h in second.list_all()] == ["keepme"]
+
+    def test_update_rejects_an_unknown_event(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create({"name": "h1", "command": "true"})
+        with pytest.raises(ValueError, match="invalid event"):
+            store.update(hook.id, {"event": "NotAnEvent"})
+
+    @pytest.mark.parametrize("bad", [0, 301, -5, "30", 3.5, None])
+    def test_update_rejects_an_out_of_range_timeout(self, tmp_path, bad):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create({"name": "h1", "command": "true"})
+        with pytest.raises(ValueError, match="timeout must be"):
+            store.update(hook.id, {"timeout": bad})
+
+    def test_update_accepts_the_range_bounds(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create({"name": "h1", "command": "true"})
+        assert store.update(hook.id, {"timeout": 1}).timeout == 1
+        assert store.update(hook.id, {"timeout": 300}).timeout == 300
+
+    def test_a_bool_timeout_is_accepted_as_its_int_value(self, tmp_path):
+        # Documents current behaviour, not an endorsement: bool is a subclass of
+        # int, so ``True`` satisfies the isinstance+range check and lands as a
+        # 1-second timeout. Recorded so a future tightening is a deliberate change.
+        store = ScriptHookStore(tmp_path)
+        hook = store.create({"name": "h1", "command": "true"})
+        assert store.update(hook.id, {"timeout": True}).timeout is True
+
+    def test_update_applies_only_known_fields(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create({"name": "h1", "command": "true"})
+        updated = store.update(
+            hook.id, {"name": "h2", "timeout": 12, "run_count": 999, "unknown": "x"}
+        )
+        assert updated is not None
+        assert updated.name == "h2" and updated.timeout == 12
+        assert updated.run_count == 0
+        assert not hasattr(updated, "unknown")
+
+    def test_mutations_on_a_missing_hook_are_no_ops(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        assert store.update("nope", {"name": "x"}) is None
+        assert store.delete("nope") is False
+        assert store.toggle("nope") is None
+
+    def test_toggle_flips_and_persists(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create({"name": "h1", "command": "true", "enabled": True})
+        assert store.toggle(hook.id).enabled is False
+        assert ScriptHookStore(tmp_path).get(hook.id).enabled is False
+
+    def test_delete_removes_from_disk(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create({"name": "h1", "command": "true"})
+        assert store.delete(hook.id) is True
+        assert ScriptHookStore(tmp_path).list_all() == []
+
+    def test_status_bookkeeping_never_raises_out_of_persist(self, tmp_path, caplog):
+        store = ScriptHookStore(tmp_path)
+        store.create({"name": "h1", "command": "true"})
+        _write(tmp_path / "hooks.json", "{not json")
+        # fire() is awaited from the PreToolUse path, so a corrupt file must not
+        # turn every tool call into a rejection.
+        store._persist_current()
+        assert any("bookkeeping" in r.message for r in caplog.records)
+
+    def test_save_snapshot_writes_the_given_list(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        store._save_snapshot([{"id": "snap", "name": "s", "command": "true"}])
+        on_disk = json.loads((tmp_path / "hooks.json").read_text(encoding="utf-8"))
+        assert [h["id"] for h in on_disk["hooks"]] == ["snap"]
+
+
+class TestGlobalHookStore:
+    def test_set_and_get(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hooks_mod, "_global_script_hook_store", None)
+        assert get_global_hook_store() is None
+        store = ScriptHookStore(tmp_path)
+        set_global_hook_store(store)
+        assert get_global_hook_store() is store
+
+
+# ── script hook governance + dispatch ──
+
+
+class TestScriptHookGovernance:
+    def test_no_opinion_when_governance_permits(self, monkeypatch):
+        import kiro_crew.platform.governance_profiles as gp
+
+        monkeypatch.setattr(
+            gp, "governance_permits", lambda *a, **k: _StubDecision(True), raising=False
+        )
+        assert _script_hooks_capability_denied("slot:1") is None
+
+    def test_denial_reason_is_returned(self, monkeypatch):
+        import kiro_crew.platform.governance_profiles as gp
+
+        monkeypatch.setattr(
+            gp,
+            "governance_permits",
+            lambda *a, **k: _StubDecision(False, "script hooks off"),
+            raising=False,
+        )
+        assert _script_hooks_capability_denied() == "script hooks off"
+
+    def test_a_transient_governance_error_degrades_to_no_opinion(self, monkeypatch):
+        import kiro_crew.platform.governance_profiles as gp
+
+        def _boom(*a, **k):
+            raise RuntimeError("profile store glitch")
+
+        monkeypatch.setattr(gp, "governance_permits", _boom, raising=False)
+        monkeypatch.setattr(gp, "audit_governance_degraded", _boom, raising=False)
+        # A glitch must not wedge every script hook.
+        assert _script_hooks_capability_denied() is None
+
+    def test_composition_error_fails_closed(self, monkeypatch):
+        import kiro_crew.platform.governance_profiles as gp
+        from kiro_crew.platform.context import PlatformCompositionError
+
+        def _boom(*a, **k):
+            raise PlatformCompositionError("cannot compose")
+
+        monkeypatch.setattr(gp, "governance_permits", _boom, raising=False)
+        with pytest.raises(PlatformCompositionError):
+            _script_hooks_capability_denied()
+
+    @pytest.mark.asyncio
+    async def test_a_denied_hook_never_spawns_a_subprocess(self, monkeypatch):
+        monkeypatch.setattr(
+            hooks_mod, "_script_hooks_capability_denied", lambda sk: "capability disabled"
+        )
+
+        def _no_spawn(*a, **k):  # pragma: no cover - must not be reached
+            raise AssertionError("run_script_hook spawned a subprocess despite the deny")
+
+        monkeypatch.setattr(hooks_mod.asyncio, "create_subprocess_shell", _no_spawn)
+        hook = ScriptHook(id="h1", name="blocked-hook", command="echo hi")
+        result = await run_script_hook(hook, "ctx", {"parent_session_key": "slot:1"})
+        assert result.exit_code == 2  # PreToolUse "block tool" convention
+        assert "capability disabled" in result.error
+        assert hook.last_status == "blocked"
+        assert hook.run_count == 1
+
+    @pytest.mark.asyncio
+    async def test_the_deny_audit_never_breaks_the_caller(self, monkeypatch):
+        monkeypatch.setattr(hooks_mod, "_script_hooks_capability_denied", lambda sk: "nope")
+        import kiro_crew.sel as sel_mod
+
+        class _Sel:
+            def log_governance_decision(self, **kwargs):
+                raise RuntimeError("sel down")
+
+        monkeypatch.setattr(sel_mod, "sel", lambda: _Sel())
+        result = await run_script_hook(ScriptHook(id="h1", command="echo hi"))
+        assert result.exit_code == 2
+
+    @pytest.mark.asyncio
+    async def test_session_key_is_taken_from_the_event(self, monkeypatch):
+        seen: list[str] = []
+        monkeypatch.setattr(
+            hooks_mod,
+            "_script_hooks_capability_denied",
+            lambda sk: seen.append(sk) or "denied",
+        )
+        await run_script_hook(ScriptHook(id="h1", command="x"), "", {"session_key": "slot:9"})
+        await run_script_hook(
+            ScriptHook(id="h2", command="x"), "", {"parent_session_key": "slot:7"}
+        )
+        await run_script_hook(ScriptHook(id="h3", command="x"))
+        assert seen == ["slot:9", "slot:7", ""]
+
+
+class TestFireDispatch:
+    """Registration, ordering, matcher filtering, and failure isolation.
+
+    ``run_script_hook`` is replaced so no real subprocess is spawned; the
+    substitute records what it was handed, which is what these assertions are
+    about.
+    """
+
+    @pytest.fixture
+    def recorder(self, monkeypatch):
+        calls: list[tuple[ScriptHook, str, dict]] = []
+
+        async def _fake_run(hook, context="", hook_event=None):
+            calls.append((hook, context, dict(hook_event or {})))
+            # One registered hook failing must not stop the ones after it.
+            exit_code = 1 if hook.name == "boom" else 0
+            return ScriptHookResult(
+                hook_id=hook.id,
+                hook_name=hook.name,
+                event=hook.event,
+                exit_code=exit_code,
+                stderr="failed" if exit_code else "",
+            )
+
+        monkeypatch.setattr(hooks_mod, "run_script_hook", _fake_run)
+        return calls
+
+    @pytest.mark.asyncio
+    async def test_hooks_fire_in_registration_order(self, tmp_path, recorder):
+        store = ScriptHookStore(tmp_path)
+        for name in ("first", "second", "third"):
+            store.create({"name": name, "command": "true", "event": HOOK_EVENT_STOP})
+        results = await store.fire(HOOK_EVENT_STOP, context="done")
+        assert [h.name for h, _c, _e in recorder] == ["first", "second", "third"]
+        assert [r.hook_name for r in results] == ["first", "second", "third"]
+
+    @pytest.mark.asyncio
+    async def test_one_failing_hook_does_not_stop_the_rest(self, tmp_path, recorder):
+        store = ScriptHookStore(tmp_path)
+        for name in ("before", "boom", "after"):
+            store.create({"name": name, "command": "true", "event": HOOK_EVENT_STOP})
+        results = await store.fire(HOOK_EVENT_STOP, context="x")
+        assert [r.hook_name for r in results] == ["before", "boom", "after"]
+        assert [r.exit_code for r in results] == [0, 1, 0]
+
+    @pytest.mark.asyncio
+    async def test_disabled_and_other_event_hooks_are_skipped(self, tmp_path, recorder):
+        store = ScriptHookStore(tmp_path)
+        store.create({"name": "on", "command": "true", "event": HOOK_EVENT_STOP})
+        store.create(
+            {"name": "off", "command": "true", "event": HOOK_EVENT_STOP, "enabled": False}
+        )
+        store.create({"name": "other", "command": "true", "event": HOOK_EVENT_PRE_TOOL_USE})
+        await store.fire(HOOK_EVENT_STOP, context="x")
+        assert [h.name for h, _c, _e in recorder] == ["on"]
+
+    @pytest.mark.asyncio
+    async def test_tool_matcher_filters_by_tool_name(self, tmp_path, recorder):
+        store = ScriptHookStore(tmp_path)
+        store.create(
+            {
+                "name": "fs-only",
+                "command": "true",
+                "event": HOOK_EVENT_PRE_TOOL_USE,
+                "matcher": "fs_*",
+            }
+        )
+        store.create(
+            {
+                "name": "all-tools",
+                "command": "true",
+                "event": HOOK_EVENT_PRE_TOOL_USE,
+                "matcher": "",
+            }
+        )
+        await store.fire(HOOK_EVENT_PRE_TOOL_USE, tool_name="fs_write")
+        assert sorted(h.name for h, _c, _e in recorder) == ["all-tools", "fs-only"]
+        recorder.clear()
+        await store.fire(HOOK_EVENT_PRE_TOOL_USE, tool_name="execute_bash")
+        assert [h.name for h, _c, _e in recorder] == ["all-tools"]
+
+    @pytest.mark.asyncio
+    async def test_post_tool_use_uses_the_tool_matcher_too(self, tmp_path, recorder):
+        store = ScriptHookStore(tmp_path)
+        store.create(
+            {
+                "name": "post",
+                "command": "true",
+                "event": HOOK_EVENT_POST_TOOL_USE,
+                "matcher": "fs_*",
+            }
+        )
+        await store.fire(HOOK_EVENT_POST_TOOL_USE, tool_name="other")
+        assert recorder == []
+        await store.fire(
+            HOOK_EVENT_POST_TOOL_USE, tool_name="fs_read", tool_response={"ok": True}
+        )
+        assert [h.name for h, _c, _e in recorder] == ["post"]
+        assert recorder[0][2]["tool_response"] == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_non_tool_matcher_globs_the_context(self, tmp_path, recorder):
+        store = ScriptHookStore(tmp_path)
+        store.create(
+            {
+                "name": "prompt",
+                "command": "true",
+                "event": HOOK_EVENT_USER_PROMPT_SUBMIT,
+                "matcher": "*deploy*",
+            }
+        )
+        await store.fire(HOOK_EVENT_USER_PROMPT_SUBMIT, context="please DEPLOY now")
+        assert [h.name for h, _c, _e in recorder] == ["prompt"]
+        recorder.clear()
+        await store.fire(HOOK_EVENT_USER_PROMPT_SUBMIT, context="nothing relevant")
+        assert recorder == []
+
+    @pytest.mark.asyncio
+    async def test_prompt_event_carries_the_prompt(self, tmp_path, recorder):
+        store = ScriptHookStore(tmp_path)
+        store.create({"name": "p", "command": "true", "event": HOOK_EVENT_USER_PROMPT_SUBMIT})
+        await store.fire(HOOK_EVENT_USER_PROMPT_SUBMIT, context="hi there")
+        event = recorder[0][2]
+        assert event["prompt"] == "hi there"
+        assert event["hook_event_name"] == HOOK_EVENT_USER_PROMPT_SUBMIT
+        assert "cwd" in event
+
+    @pytest.mark.asyncio
+    async def test_stop_event_always_carries_assistant_text(self, tmp_path, recorder):
+        store = ScriptHookStore(tmp_path)
+        store.create({"name": "s", "command": "true", "event": HOOK_EVENT_STOP})
+        await store.fire(HOOK_EVENT_STOP, context="")
+        # Unconditional, so a hook that always reads it never KeyErrors.
+        assert recorder[0][2]["assistant_text"] == ""
+
+    @pytest.mark.asyncio
+    async def test_attribution_fields_are_forwarded(self, tmp_path, recorder):
+        store = ScriptHookStore(tmp_path)
+        store.create({"name": "t", "command": "true", "event": HOOK_EVENT_PRE_TOOL_USE})
+        await store.fire(
+            HOOK_EVENT_PRE_TOOL_USE,
+            tool_name="fs_read",
+            tool_input={"path": "/tmp/x"},
+            subagent_id="sub-1",
+            parent_session_key="slot:3",
+            agent_role="reviewer",
+        )
+        event = recorder[0][2]
+        assert event["tool_name"] == "fs_read"
+        assert event["tool_input"] == {"path": "/tmp/x"}
+        assert event["subagent_id"] == "sub-1"
+        assert event["parent_session_key"] == "slot:3"
+        assert event["agent_role"] == "reviewer"
+
+    @pytest.mark.asyncio
+    async def test_absent_attribution_fields_are_omitted(self, tmp_path, recorder):
+        store = ScriptHookStore(tmp_path)
+        store.create({"name": "t", "command": "true", "event": HOOK_EVENT_PRE_TOOL_USE})
+        await store.fire(HOOK_EVENT_PRE_TOOL_USE)
+        event = recorder[0][2]
+        for key in ("tool_name", "tool_input", "subagent_id", "parent_session_key", "agent_role"):
+            assert key not in event
+
+    @pytest.mark.asyncio
+    async def test_fire_persists_status_bookkeeping(self, tmp_path, recorder):
+        store = ScriptHookStore(tmp_path)
+        store.create({"id": "h1", "name": "s", "command": "true", "event": HOOK_EVENT_STOP})
+        await store.fire(HOOK_EVENT_STOP, context="x")
+        assert (tmp_path / "hooks.json").exists()
+
+
+class TestFireToolHooks:
+    @pytest.mark.asyncio
+    async def test_a_missing_store_is_a_no_op(self):
+        assert await fire_tool_hooks(None, "Running: ls") is None
+
+    @pytest.mark.asyncio
+    async def test_running_prefix_is_stripped_and_input_parsed(self, tmp_path, monkeypatch):
+        seen: list[dict] = []
+
+        class _Store:
+            async def fire(self, event, **kwargs):
+                seen.append({"event": event, **kwargs})
+                return []
+
+        await fire_tool_hooks(
+            _Store(),  # type: ignore[arg-type]
+            "Running: execute_bash",
+            '{"command": "ls"}',
+            subagent_id="sub-1",
+            parent_session_key="slot:2",
+            agent_role="worker",
+        )
+        assert seen[0]["event"] == HOOK_EVENT_PRE_TOOL_USE
+        assert seen[0]["tool_name"] == "execute_bash"
+        assert seen[0]["tool_input"] == {"command": "ls"}
+        assert seen[0]["subagent_id"] == "sub-1"
+        assert seen[0]["parent_session_key"] == "slot:2"
+        assert seen[0]["agent_role"] == "worker"
+
+    @pytest.mark.asyncio
+    async def test_unparseable_tool_input_degrades_to_none(self):
+        seen: list[dict] = []
+
+        class _Store:
+            async def fire(self, event, **kwargs):
+                seen.append(kwargs)
+                return []
+
+        await fire_tool_hooks(_Store(), "", "{not json")  # type: ignore[arg-type]
+        assert seen[0]["tool_input"] is None
+        assert seen[0]["tool_name"] == ""
+
+    @pytest.mark.asyncio
+    async def test_a_raising_store_is_swallowed(self):
+        class _Store:
+            async def fire(self, event, **kwargs):
+                raise RuntimeError("store on fire")
+
+        # Informational hooks must never break the tool-call notification path.
+        assert await fire_tool_hooks(_Store(), "Running: ls") is None  # type: ignore[arg-type]
+
+
+# ── governance helper fail-soft / fail-closed discipline ──
+
+
+class TestGovernancePinResolution:
+    def test_a_glitch_degrades_to_no_pins(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("policy store glitch")
+
+        monkeypatch.setattr(security, "pinned_builtin_command_ids", _boom)
+        # An empty set, not an exception: a glitch here must not wedge the gate.
+        assert _governance_pinned_command_ids(None) == set()
+
+    def test_composition_error_propagates(self, monkeypatch):
+        from kiro_crew.platform.context import PlatformCompositionError
+
+        def _boom():
+            raise PlatformCompositionError("cannot compose")
+
+        monkeypatch.setattr(security, "pinned_builtin_command_ids", _boom)
+        with pytest.raises(PlatformCompositionError):
+            _governance_pinned_command_ids(None)
+
+
+class TestGovernanceDenial:
+    def test_composition_error_propagates(self, monkeypatch):
+        import kiro_crew.platform.governance_profiles as gp
+        from kiro_crew.platform.context import PlatformCompositionError
+
+        def _boom(*a, **k):
+            raise PlatformCompositionError("cannot compose")
+
+        monkeypatch.setattr(gp, "resolve_active_scope", _boom, raising=False)
+        with pytest.raises(PlatformCompositionError):
+            _governance_denial(object(), "some_tool", "", "", "")
+
+    def test_a_glitch_degrades_to_no_opinion(self, monkeypatch):
+        import kiro_crew.platform.governance_profiles as gp
+
+        def _boom(*a, **k):
+            raise RuntimeError("profile store glitch")
+
+        monkeypatch.setattr(gp, "resolve_active_scope", _boom, raising=False)
+        monkeypatch.setattr(gp, "audit_governance_degraded", _boom, raising=False)
+        assert _governance_denial(object(), "some_tool", "", "", "") is None
+
+    def test_ungoverned_host_is_a_fast_no_op(self, monkeypatch):
+        import kiro_crew.platform.governance_profiles as gp
+
+        monkeypatch.setattr(gp, "resolve_active_scope", lambda *a, **k: None, raising=False)
+
+        class _Ctx:
+            governance = None
+
+        assert _governance_denial(_Ctx(), "some_tool", "", "", "") is None
+
+
+class TestGovernanceAudit:
+    def test_a_raising_sel_never_breaks_the_gate(self, monkeypatch):
+        import kiro_crew.sel as sel_mod
+
+        class _Sel:
+            def log_governance_decision(self, **kwargs):
+                raise RuntimeError("sel down")
+
+        monkeypatch.setattr(sel_mod, "sel", lambda: _Sel())
+        # Returns None rather than propagating -- the audit is best effort.
+        assert _audit_governance("slot:1", "kirocrew", "some_tool", object()) is None
+
+
+# ── extra branches in the file helpers ──
+
+
+class TestSafeReadFileSymlinkRace:
+    def test_eloop_after_canonicalization_is_refused(self, tmp_path, monkeypatch):
+        import errno as _errno
+
+        f = _write(tmp_path / "a.txt", "x")
+        real_open = os.open
+
+        def _eloop(path, flags, *args, **kwargs):
+            if isinstance(path, str) and _same(path, str(f)):
+                raise OSError(_errno.ELOOP, "swapped for a symlink")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(os, "open", _eloop)
+        with pytest.raises(PermissionError, match="refusing to follow symlink"):
+            safe_read_file(str(f))
+
+
+class TestFdPathSensitivityChecks:
+    """The opened inode's real path is re-screened, not just the input name."""
+
+    @staticmethod
+    def _sensitive_on_second_call(monkeypatch):
+        calls = {"n": 0}
+
+        def _probe(path, *args, **kwargs):
+            calls["n"] += 1
+            # First call is validate_file_path's screening of the input name;
+            # the next is the check against the OPENED descriptor's real path.
+            return calls["n"] >= 2
+
+        monkeypatch.setattr(hooks_mod, "is_sensitive_path", _probe)
+        return calls
+
+    def test_read_nolink_refuses_a_sensitive_opened_inode(self, tmp_path, monkeypatch):
+        root = tmp_path / "root"
+        root.mkdir()
+        f = _write(root / "a.txt", "x")
+        self._sensitive_on_second_call(monkeypatch)
+        assert safe_read_file_bytes_nolink(str(f), within_root=str(root)) is None
+
+    def test_copy_refuses_a_sensitive_opened_inode(self, tmp_path, monkeypatch):
+        src = _write(tmp_path / "src.bin", "x")
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        self._sensitive_on_second_call(monkeypatch)
+        assert safe_copy_file_nolink(str(src), str(dest)) is None
+        assert list(dest.iterdir()) == []
+
+    def test_write_refuses_a_sensitive_opened_inode(self, tmp_path, monkeypatch):
+        root = tmp_path / "root"
+        root.mkdir()
+        f = _write(root / "a.txt", "old")
+        self._sensitive_on_second_call(monkeypatch)
+        assert safe_write_file_nolink(str(f), "new", within_root=str(root)) is False
+        assert f.read_text(encoding="utf-8") == "old"
+
+
+class TestSafeCopyFileNolinkStagingFailure:
+    def test_a_failed_stage_write_cleans_up_and_returns_none(self, tmp_path, monkeypatch):
+        import tempfile as _tempfile
+
+        src = _write(tmp_path / "src.bin", "payload")
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        real_mkstemp = _tempfile.mkstemp
+        staged: list[str] = []
+
+        def _stale_fd(*args, **kwargs):
+            fd, path = real_mkstemp(*args, **kwargs)
+            staged.append(path)
+            # A closed descriptor makes the very next os.write raise EBADF,
+            # which is the OSError the cleanup branch exists for.
+            os.close(fd)
+            return fd, path
+
+        monkeypatch.setattr(_tempfile, "mkstemp", _stale_fd)
+        assert safe_copy_file_nolink(str(src), str(dest)) is None
+        assert staged, "the staging file was never created"
+        # The partial copy must not be left behind for a downstream reader.
+        assert list(dest.iterdir()) == []
+
+
+class TestSafeWriteFileNolinkXattrs:
+    """Access controls must survive the atomic replace, or the write refuses."""
+
+    def _require_xattrs(self):
+        if not all(hasattr(os, a) for a in ("listxattr", "getxattr", "setxattr")):
+            pytest.skip("this platform has no extended-attribute API")
+
+    def test_an_unreadable_xattr_set_refuses_the_write(self, tmp_path, monkeypatch):
+        self._require_xattrs()
+        f = _write(tmp_path / "a.txt", "old")
+
+        def _eperm(fd):
+            raise OSError(1, "operation not permitted")
+
+        monkeypatch.setattr(os, "listxattr", _eperm)
+        # Not knowing what would be dropped is a refusal, not a best effort.
+        assert safe_write_file_nolink(str(f), "new") is False
+        assert f.read_text(encoding="utf-8") == "old"
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["a.txt"]
+
+    def test_a_filesystem_without_xattrs_is_not_an_error(self, tmp_path, monkeypatch):
+        self._require_xattrs()
+        import errno as _errno
+
+        f = _write(tmp_path / "a.txt", "old")
+
+        def _unsupported(fd):
+            raise OSError(_errno.ENOTSUP, "not supported")
+
+        monkeypatch.setattr(os, "listxattr", _unsupported)
+        # Nothing on the source to lose, so the write proceeds.
+        assert safe_write_file_nolink(str(f), "new") is True
+        assert f.read_text(encoding="utf-8") == "new"
+
+    def test_an_uncopyable_access_control_attr_refuses_the_write(self, tmp_path, monkeypatch):
+        self._require_xattrs()
+        f = _write(tmp_path / "a.txt", "old")
+        monkeypatch.setattr(os, "listxattr", lambda fd: ["security.selinux"])
+        monkeypatch.setattr(os, "getxattr", lambda fd, attr: b"label")
+
+        def _refuse(fd, attr, value):
+            raise OSError(1, "cannot set")
+
+        monkeypatch.setattr(os, "setxattr", _refuse)
+        assert safe_write_file_nolink(str(f), "new") is False
+        assert f.read_text(encoding="utf-8") == "old"
+
+    def test_an_uncopyable_informational_attr_is_best_effort(self, tmp_path, monkeypatch):
+        self._require_xattrs()
+        f = _write(tmp_path / "a.txt", "old")
+        monkeypatch.setattr(os, "listxattr", lambda fd: ["user.comment"])
+        monkeypatch.setattr(os, "getxattr", lambda fd, attr: b"tag")
+
+        def _refuse(fd, attr, value):
+            raise OSError(1, "cannot set")
+
+        monkeypatch.setattr(os, "setxattr", _refuse)
+        # Losing a tag must not fail every save on a filesystem that cannot
+        # store one.
+        assert safe_write_file_nolink(str(f), "new") is True
+        assert f.read_text(encoding="utf-8") == "new"
+
+
+class TestSafeWriteFileNolinkWithoutDirFd:
+    """The by-name replace branch taken where the POSIX dir-fd APIs are absent.
+
+    Windows has no ``O_DIRECTORY`` / ``dir_fd`` support, so this is the branch it
+    always uses. Clearing ``os.supports_dir_fd`` exercises the same code here.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_dir_fd(self, monkeypatch):
+        monkeypatch.setattr(os, "supports_dir_fd", set())
+
+    def test_the_staged_payload_is_still_renamed_over_the_target(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "old")
+        assert safe_write_file_nolink(str(f), "new") is True
+        assert f.read_text(encoding="utf-8") == "new"
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["a.txt"]
+
+    def test_within_root_still_refuses_an_escaping_parent(self, tmp_path):
+        root = tmp_path / "root"
+        root.mkdir()
+        outside = _write(tmp_path / "outside.txt", "old")
+        assert safe_write_file_nolink(str(outside), "new", within_root=str(root)) is False
+        assert outside.read_text(encoding="utf-8") == "old"
+
+    def test_within_root_accepts_a_contained_parent(self, tmp_path):
+        root = tmp_path / "root"
+        root.mkdir()
+        f = _write(root / "a.txt", "old")
+        assert safe_write_file_nolink(str(f), "new", within_root=str(root)) is True
+        assert f.read_text(encoding="utf-8") == "new"
+
+    def test_a_vanished_target_refuses_before_the_rename(self, tmp_path, monkeypatch):
+        f = _write(tmp_path / "a.txt", "old")
+        real_stat = os.stat
+        state = {"fired": False}
+
+        def _vanish_on_the_recheck(path, *args, **kwargs):
+            if (
+                isinstance(path, str)
+                and os.path.basename(path) == f.name
+                and _staged_sibling(tmp_path, f.name)
+            ):
+                state["fired"] = True
+                raise FileNotFoundError("target moved")
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(os, "stat", _vanish_on_the_recheck)
+        try:
+            assert safe_write_file_nolink(str(f), "new") is False
+        finally:
+            monkeypatch.undo()
+        assert state["fired"] is True
+        assert f.read_text(encoding="utf-8") == "old"
+        # The staged sibling is unlinked by name on the cleanup path.
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["a.txt"]
+
+
+class TestSafeWriteFileNolinkDirFdChecks:
+    def test_an_unverifiable_parent_fails_closed(self, tmp_path, monkeypatch):
+        if not (
+            getattr(os, "O_DIRECTORY", 0)
+            and os.open in getattr(os, "supports_dir_fd", set())
+            and os.rename in getattr(os, "supports_dir_fd", set())
+        ):
+            pytest.skip("this platform has no directory-fd pinning")
+        root = tmp_path / "root"
+        root.mkdir()
+        f = _write(root / "a.txt", "old")
+        real_fd_path = hooks_mod._fd_real_path
+
+        def _files_only(fd):
+            got = real_fd_path(fd)
+            # The file's own check must still pass; only the DIRECTORY handle
+            # becomes unverifiable.
+            if got and os.path.isdir(got):
+                return None
+            return got
+
+        monkeypatch.setattr(hooks_mod, "_fd_real_path", _files_only)
+        assert safe_write_file_nolink(str(f), "new", within_root=str(root)) is False
+        assert f.read_text(encoding="utf-8") == "old"
+
+    def test_an_unstattable_pinned_target_refuses(self, tmp_path, monkeypatch):
+        if not (
+            getattr(os, "O_DIRECTORY", 0)
+            and os.open in getattr(os, "supports_dir_fd", set())
+            and os.rename in getattr(os, "supports_dir_fd", set())
+        ):
+            pytest.skip("this platform has no directory-fd pinning")
+        f = _write(tmp_path / "a.txt", "old")
+        real_stat = os.stat
+
+        def _no_stat_through_dir_fd(path, *args, **kwargs):
+            if "dir_fd" in kwargs and path == f.name:
+                raise FileNotFoundError("gone from the pinned parent")
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(os, "stat", _no_stat_through_dir_fd)
+        try:
+            assert safe_write_file_nolink(str(f), "new") is False
+        finally:
+            monkeypatch.undo()
+        assert f.read_text(encoding="utf-8") == "old"
+
+
+# ── internal read: the remaining outcomes ──
+
+
+class TestSafeReadFileInternalOutcomes:
+    """Exercise the read outcomes against a redirected home directory.
+
+    ``HOME``/``USERPROFILE`` are repointed at ``tmp_path`` so a real file can
+    live at an allowlisted, genuinely sensitive location without touching the
+    operator's own ``~/.aws``.
+    """
+
+    @pytest.fixture
+    def sensitive_home(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        (home / ".aws" / "sso" / "cache").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        rel = ".aws/sso/cache/probe.json"
+        monkeypatch.setitem(hooks_mod._INTERNAL_READ_ALLOWLIST, "probe", rel)
+        target = home / ".aws" / "sso" / "cache" / "probe.json"
+        if not security.is_sensitive_path(str(target)):
+            pytest.skip("home redirection did not take effect for the path gate")
+        return target
+
+    def test_a_successful_read_returns_the_bytes(self, sensitive_home, monkeypatch):
+        _write(sensitive_home, "opaque-value")
+        outcomes: list[str] = []
+        monkeypatch.setattr(
+            hooks_mod,
+            "_emit_internal_read_audit",
+            lambda read_id, outcome: outcomes.append(outcome) or True,
+        )
+        assert safe_read_file_internal("probe") == b"opaque-value"
+        assert outcomes == ["success"]
+
+    def test_a_read_whose_audit_cannot_be_recorded_is_denied(self, sensitive_home, monkeypatch):
+        _write(sensitive_home, "opaque-value")
+        monkeypatch.setattr(
+            hooks_mod, "_emit_internal_read_audit", lambda read_id, outcome: False
+        )
+        # audit-or-deny: the carve-out's validity depends on the audit landing.
+        assert safe_read_file_internal("probe") is None
+
+    def test_a_non_regular_target_is_refused(self, sensitive_home, monkeypatch):
+        sensitive_home.mkdir()
+        outcomes: list[str] = []
+        monkeypatch.setattr(
+            hooks_mod,
+            "_emit_internal_read_audit",
+            lambda read_id, outcome: outcomes.append(outcome) or True,
+        )
+        assert safe_read_file_internal("probe") is None
+        assert outcomes and outcomes[0] in ("not_regular", "unreadable")
+
+    def test_an_oversized_target_is_refused(self, sensitive_home, monkeypatch):
+        _write(sensitive_home, "0123456789")
+        monkeypatch.setattr(hooks_mod, "MAX_FILE_BYTES", 4)
+        outcomes: list[str] = []
+        monkeypatch.setattr(
+            hooks_mod,
+            "_emit_internal_read_audit",
+            lambda read_id, outcome: outcomes.append(outcome) or True,
+        )
+        assert safe_read_file_internal("probe") is None
+        assert outcomes == ["too_large"]
+
+
+# ── message transforms and the read-only auto-approve branch ──
+
+
+class TestMessageTransformSuffix:
+    def test_prefix_and_suffix_are_both_applied(self):
+        cfg = HooksConfig(
+            transforms=[TransformHook(pattern="deploy", prefix="[BEFORE]", suffix="[AFTER]")]
+        )
+        result = HookManager(cfg).on_message("please deploy")
+        assert result.action == HOOK_MODIFY
+        assert result.text == "[BEFORE]\nplease deploy\n[AFTER]"
+
+    def test_suffix_only(self):
+        cfg = HooksConfig(transforms=[TransformHook(pattern="deploy", suffix="[AFTER]")])
+        assert HookManager(cfg).on_message("deploy").text == "deploy\n[AFTER]"
+
+
+class TestReadOnlyKindAutoApprove:
+    @pytest.mark.parametrize("kind", ["read", "fetch", "READ"])
+    def test_a_read_only_kind_auto_approves(self, kind):
+        got = HookManager().on_tool_call("some_tool", tool_kind=kind)
+        assert got.action == TOOL_AUTO_APPROVE
+
+    def test_a_computer_use_observation_never_reaches_its_own_gate(self, monkeypatch):
+        """Documents that the computer-use observation branch is unreachable.
+
+        ``on_tool_call`` returns ``auto_approve`` for every kind in
+        ``_READ_ONLY_TOOL_KINDS`` one branch earlier, so the follow-up condition
+        ``kind in _READ_ONLY_TOOL_KINDS and _cu_read_only_auto_approve(...)``
+        can never be evaluated -- and with it the keystone computer-use
+        enable-state check it carries. Asserted so the dead branch is visible
+        rather than silently trusted.
+        """
+        consulted: list[str] = []
+        monkeypatch.setattr(
+            hooks_mod,
+            "_cu_read_only_auto_approve",
+            lambda name: consulted.append(name) or True,
+        )
+        got = HookManager().on_tool_call(
+            "mcp__kirocrew-computer__computer_get_state", tool_kind="read"
+        )
+        assert got.action == TOOL_AUTO_APPROVE
+        assert consulted == []
+
+    def test_a_mutating_kind_falls_through_to_interactive_approval(self):
+        assert HookManager().on_tool_call("some_tool", tool_kind="edit").action == TOOL_ALLOW
+        assert HookManager().on_tool_call("some_tool", tool_kind="other").action == TOOL_ALLOW

--- a/test/test_session_coverage.py
+++ b/test/test_session_coverage.py
@@ -1,0 +1,996 @@
+"""Coverage for ``kiro_crew.session`` edges the behavioural suites skip.
+
+Three groups, and the seam between them is what this file is for:
+
+* The module-level **probe helpers** (``_provider_has_active_turn`` and its two
+  siblings) are the defensive boundary between the manager and a provider
+  double. Their contract is "anything that is not exactly ``True`` reads as no",
+  which only holds if the missing-attribute, raising, and awaitable-returning
+  shapes are each exercised — an awaitable slipping through is what leaks an
+  un-awaited-coroutine warning into an unrelated test.
+* The **pure resolvers** (``_model_fallback``, ``_session_model``,
+  ``detect_provider_switch``, ``_is_continuable_key``) decide what a session
+  becomes before any process exists, so they are testable without spawning one.
+* The **lifecycle edges** (``remove_if_unclaimed``, ``recycle_heartbeat``,
+  ``_expire_idle``, ``_stuck_turn_check``, ``_send_abort_for_session``) are the
+  refusal branches: each one's job is to decline to act on a session that is
+  busy, persistent, or already claimed. A test that only drives the happy path
+  cannot tell a working guard from an absent one.
+
+Every session here is injected directly into the registry as a ``_Session``
+over a stub provider, so no test starts a real process, writes outside
+``tmp_path``, or opens a socket.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.config import KiroCrewConfig
+from kiro_crew.config.loader import KiroCrewAgentConfig
+from kiro_crew.messaging.link import ChannelLink
+from kiro_crew.session import (
+    _MAX_ORIGIN_LINKS,
+    _STUCK_TURN_REPORT_SECS,
+    BACKGROUND_KEY,
+    HEARTBEAT_KEY,
+    SessionManager,
+    _context_pct_is_unknown,
+    _model_fallback,
+    _provider_has_active_turn,
+    _provider_has_unfinished_turn,
+    _ProviderBgSession,
+    _Session,
+    _session_model,
+    detect_provider_switch,
+)
+
+
+@pytest.fixture
+def cfg():
+    c = KiroCrewConfig()
+    c.session.timeout_secs = 60
+    return c
+
+
+@pytest.fixture
+def mgr(cfg):
+    """A manager with no provider factory — nothing can cold-start by accident."""
+    return SessionManager(cfg)
+
+
+def _stub_provider(**attrs):
+    """A provider double with only the attributes a test names.
+
+    ``MagicMock`` is deliberately avoided for the probe surfaces: an
+    auto-generated ``has_active_turn`` returns a truthy Mock, which would make
+    the drain filters pass for the wrong reason.
+    """
+    base = {
+        "shutdown": AsyncMock(),
+        "context_usage_pct": lambda: 0.0,
+    }
+    base.update(attrs)
+    return SimpleNamespace(**base)
+
+
+def _register(mgr: SessionManager, key: str, **session_kwargs) -> _Session:
+    provider = session_kwargs.pop("provider", None) or _stub_provider()
+    sess = _Session(provider=provider, **session_kwargs)
+    mgr._sessions[key] = sess
+    return sess
+
+
+# ── Probe helpers ────────────────────────────────────────────────────────────
+
+
+class _AwaitableWithoutClose:
+    """Awaitable that exposes no ``close`` — the guard must not assume one."""
+
+    def __await__(self):
+        yield from ()
+
+
+class _AwaitableWithBrokenClose:
+    def __await__(self):
+        yield from ()
+
+    def close(self):
+        raise RuntimeError("close blew up")
+
+
+PROBES = [
+    (_provider_has_active_turn, "has_active_turn"),
+    (_context_pct_is_unknown, "context_usage_unknown"),
+    (_provider_has_unfinished_turn, "has_unfinished_turn"),
+]
+
+
+@pytest.mark.parametrize("probe,attr", PROBES, ids=[a for _, a in PROBES])
+class TestProviderProbeHelpers:
+    """Each probe is a strict opt-in: only an exact ``True`` counts."""
+
+    def test_missing_attribute_reads_as_no(self, probe, attr) -> None:
+        assert probe(SimpleNamespace()) is False
+
+    def test_non_callable_attribute_reads_as_no(self, probe, attr) -> None:
+        """A stub that sets the name to a plain bool must not be called."""
+        assert probe(SimpleNamespace(**{attr: True})) is False
+
+    def test_raising_probe_reads_as_no(self, probe, attr) -> None:
+        def boom():
+            raise RuntimeError("provider is wedged")
+
+        assert probe(SimpleNamespace(**{attr: boom})) is False
+
+    def test_true_is_the_only_yes(self, probe, attr) -> None:
+        assert probe(SimpleNamespace(**{attr: lambda: True})) is True
+
+    def test_truthy_non_bool_is_still_no(self, probe, attr) -> None:
+        """``is True``, not truthiness — a Mock return must not read as yes."""
+        assert probe(SimpleNamespace(**{attr: lambda: MagicMock()})) is False
+
+    def test_coroutine_returning_double_is_closed_not_awaited(self, probe, attr) -> None:
+        """The AsyncMock shape. Left un-closed this emits a RuntimeWarning that
+        surfaces in whichever unrelated test happens to run next."""
+
+        async def _coro():  # pragma: no cover — never awaited, only closed
+            return True
+
+        assert probe(SimpleNamespace(**{attr: _coro})) is False
+
+    def test_awaitable_without_close_reads_as_no(self, probe, attr) -> None:
+        assert probe(SimpleNamespace(**{attr: _AwaitableWithoutClose})) is False
+
+    def test_awaitable_whose_close_raises_reads_as_no(self, probe, attr) -> None:
+        """A double that fails on cleanup must not propagate out of a probe."""
+        assert probe(SimpleNamespace(**{attr: _AwaitableWithBrokenClose})) is False
+
+
+# ── Model resolution ─────────────────────────────────────────────────────────
+
+
+class TestModelFallback:
+    def test_agent_pin_defers_to_native_resolution(self) -> None:
+        """A per-agent pin returns None so the factory reads the agent JSON."""
+        assert _model_fallback("opus", "sonnet") is None
+
+    def test_global_default_applies_when_agent_defers(self) -> None:
+        assert _model_fallback("", "sonnet") == "sonnet"
+
+    def test_sentinel_global_defers(self) -> None:
+        assert _model_fallback("", "auto") is None
+
+    def test_empty_global_defers(self) -> None:
+        assert _model_fallback("", "") is None
+
+
+class TestSessionModel:
+    def test_no_agent_uses_global_default(self, cfg) -> None:
+        cfg.agent.model = "sonnet"
+        assert _session_model(cfg, None) == "sonnet"
+
+    def test_crew_pin_wins_verbatim(self, cfg) -> None:
+        """The factory never sees the crew name, so its pin must be returned
+        as-is rather than left for a lower tier to rediscover."""
+        cfg.agent.model = "sonnet"
+        cfg.agents["research"] = KiroCrewAgentConfig(model="opus")
+        assert _session_model(cfg, "research") == "opus"
+
+    def test_crew_inherit_spelling_is_not_a_pin(self, cfg) -> None:
+        """``auto`` on the crew tier means inherit, not "pin the default"."""
+        cfg.agent.model = "sonnet"
+        cfg.agents["research"] = KiroCrewAgentConfig(model="auto")
+        assert _session_model(cfg, "research") == "sonnet"
+
+    def test_crew_that_defers_continues_on_its_bound_template(self, cfg, monkeypatch) -> None:
+        seen: list[str] = []
+
+        def _resolve(agent: str) -> str:
+            seen.append(agent)
+            return "haiku-from-template"
+
+        cfg.agent.model = "sonnet"
+        cfg.agents["research"] = KiroCrewAgentConfig(model="", kiro_agent="tmpl")
+        monkeypatch.setattr(cfg, "_resolve_named_agent_model", _resolve)
+        # A template pin returns None: the factory resolves the JSON itself.
+        assert _session_model(cfg, "research") is None
+        assert seen == ["tmpl"], "the crew's bound template, not the crew name"
+
+    def test_base_agent_name_skips_the_per_agent_lookup(self, cfg, monkeypatch) -> None:
+        """``kirocrew`` is the built-in template; globbing the agents dir for it
+        would be a disk read with a known-empty answer."""
+        calls: list[str] = []
+        cfg.agent.model = "sonnet"
+        monkeypatch.setattr(
+            cfg,
+            "_resolve_named_agent_model",
+            lambda agent: calls.append(agent) or "",
+        )
+        assert _session_model(cfg, "kirocrew") == "sonnet"
+        assert calls == []
+
+
+# ── Provider-switch detection ────────────────────────────────────────────────
+
+
+def _map_stub(provider: str = "", sid: str | None = None):
+    return SimpleNamespace(get_provider=lambda key: provider, get=lambda key: sid)
+
+
+class TestDetectProviderSwitch:
+    def test_same_provider_is_not_a_switch(self) -> None:
+        assert detect_provider_switch(_map_stub("acp", "sid-1"), "k", "acp") is False
+
+    def test_unset_stored_provider_defaults_to_acp(self) -> None:
+        """An entry written before the provider column existed reads as acp."""
+        assert detect_provider_switch(_map_stub("", "sid-1"), "k", "acp") is False
+
+    def test_different_provider_without_a_stored_sid_is_not_a_switch(self) -> None:
+        """Nothing to discard, so nothing to audit."""
+        assert detect_provider_switch(_map_stub("claude_code", None), "k", "acp") is False
+
+    def test_different_provider_with_a_stored_sid_is_a_switch(self) -> None:
+        with patch("kiro_crew.session.sel") as sel_mock:
+            assert detect_provider_switch(_map_stub("claude_code", "sid-1"), "k", "acp") is True
+        call = sel_mock.return_value.log_tool_invocation.call_args.kwargs
+        assert call["tool_name"] == "provider_switch_detected"
+        assert call["metadata"] == {"stored_provider": "claude_code", "new_provider": "acp"}
+
+
+# ── _Session record ──────────────────────────────────────────────────────────
+
+
+class TestAdoptProvider:
+    def test_transcript_state_is_reset_but_role_state_survives(self) -> None:
+        """Everything reset describes the OLD transcript. ``agent`` and
+        ``approval_policy`` describe the session's role, so they must carry."""
+        old, new = _stub_provider(), _stub_provider()
+        sess = _Session(
+            provider=old,
+            agent="researcher",
+            approval_policy="auto",
+            prompt_count=17,
+            consecutive_failures=3,
+            prev_turn_cancelled=True,
+            provider_switch_replay=True,
+            needs_context_reinjection=True,
+            resumed_armed=True,
+        )
+
+        sess.adopt_provider(new)
+
+        assert sess.provider is new
+        assert sess.prompt_count == 0
+        assert sess.consecutive_failures == 0
+        assert sess.prev_turn_cancelled is False
+        assert sess.provider_switch_replay is False
+        assert sess.needs_context_reinjection is False
+        assert sess.resumed_armed is False, "a replacement is fresh, not resumed"
+        assert sess.agent == "researcher"
+        assert sess.approval_policy == "auto"
+
+
+# ── _ProviderBgSession ───────────────────────────────────────────────────────
+
+
+class _StreamingProvider:
+    def __init__(self, events=("a", "b"), sid="sid-9"):
+        self._events = events
+        self._sid = sid
+        self.rejected: list[object] = []
+
+    @property
+    def session_id(self) -> str:
+        return self._sid
+
+    async def stream(self, message: str):
+        for e in self._events:
+            yield f"{message}:{e}"
+
+    async def reject_tool(self, request_id) -> None:
+        self.rejected.append(request_id)
+
+
+class _SidRaisingProvider(_StreamingProvider):
+    @property
+    def session_id(self) -> str:
+        raise RuntimeError("no native session yet")
+
+
+class TestProviderBgSession:
+    """The non-kiro ``_bg`` adapter. All callers share ONE provider session, so
+    the ``Semaphore(1)`` is the only thing serializing them."""
+
+    def test_session_id_is_read_through(self) -> None:
+        sess = _Session(provider=_StreamingProvider())
+        assert _ProviderBgSession(sess).session_id == "sid-9"
+
+    def test_session_id_swallows_a_provider_error(self) -> None:
+        """Reading the id must never break a caller that only wants to log it."""
+        sess = _Session(provider=_SidRaisingProvider())
+        assert _ProviderBgSession(sess).session_id == ""
+
+    @pytest.mark.asyncio
+    async def test_prompt_holds_the_semaphore_and_releases_on_exhaustion(self) -> None:
+        sess = _Session(provider=_StreamingProvider())
+        handle = _ProviderBgSession(sess)
+
+        seen = []
+        async for event in handle.prompt("hi", timeout=1.0):
+            assert sess.semaphore.locked(), "the turn must hold the shared lock"
+            seen.append(event)
+
+        assert seen == ["hi:a", "hi:b"]
+        assert not sess.semaphore.locked(), "released on generator exhaustion"
+
+    @pytest.mark.asyncio
+    async def test_destroy_releases_the_shared_semaphore_but_keeps_the_session(self) -> None:
+        """The BACKGROUND_KEY session is persistent and shared: destroy must
+        release the turn lock without tearing the provider down."""
+        provider = _StreamingProvider()
+        sess = _Session(provider=provider)
+        handle = _ProviderBgSession(sess)
+        await sess.semaphore.acquire()
+        handle._sem_held = True
+
+        await handle.destroy()
+
+        assert not sess.semaphore.locked()
+        assert sess.provider is provider
+
+    @pytest.mark.asyncio
+    async def test_destroy_is_idempotent_when_no_turn_is_held(self) -> None:
+        """A double release would over-count the semaphore and let two _bg
+        callers into the provider at once."""
+        sess = _Session(provider=_StreamingProvider())
+        handle = _ProviderBgSession(sess)
+
+        await handle.destroy()
+        await handle.destroy()
+
+        assert not sess.semaphore.locked()
+        await sess.semaphore.acquire()
+        assert sess.semaphore.locked(), "the counter was never inflated"
+
+    @pytest.mark.asyncio
+    async def test_reject_tool_delegates_to_the_provider(self) -> None:
+        provider = _StreamingProvider()
+        handle = _ProviderBgSession(_Session(provider=provider))
+        await handle.reject_tool("req-1")
+        assert provider.rejected == ["req-1"]
+
+
+class TestGetBgSessionNonKiro:
+    @pytest.mark.asyncio
+    async def test_non_kiro_backend_gets_the_provider_backed_adapter(self, cfg) -> None:
+        cfg.agent.provider = "claude_code"
+        mgr = SessionManager(cfg)
+        sess = _register(mgr, BACKGROUND_KEY, provider=_StreamingProvider())
+
+        with patch.object(mgr, "_ensure_background", AsyncMock()):
+            handle = await mgr.get_bg_session()
+
+        assert isinstance(handle, _ProviderBgSession)
+        assert handle._sess is sess
+
+    @pytest.mark.asyncio
+    async def test_missing_background_session_is_a_named_error(self, cfg) -> None:
+        """Silently returning None here surfaces much later as an
+        AttributeError inside a chat-title turn."""
+        cfg.agent.provider = "bedrock"
+        mgr = SessionManager(cfg)
+
+        with patch.object(mgr, "_ensure_background", AsyncMock()):
+            with pytest.raises(RuntimeError, match="background session unavailable"):
+                await mgr.get_bg_session()
+
+
+# ── Registry reads ───────────────────────────────────────────────────────────
+
+
+class TestTryAcquire:
+    @pytest.mark.asyncio
+    async def test_unknown_key_is_refused(self, mgr) -> None:
+        assert await mgr.try_acquire("nope") is False
+
+    @pytest.mark.asyncio
+    async def test_busy_session_is_refused(self, mgr) -> None:
+        sess = _register(mgr, "d1")
+        await sess.semaphore.acquire()
+        assert await mgr.try_acquire("d1") is False
+
+    @pytest.mark.asyncio
+    async def test_idle_session_is_taken(self, mgr) -> None:
+        """Every True must be paired with release(), so the semaphore is held
+        on return — that IS the contract."""
+        sess = _register(mgr, "d1")
+        assert await mgr.try_acquire("d1") is True
+        assert sess.semaphore.locked()
+        mgr.release("d1")
+
+
+class TestSessionAgentLookup:
+    def test_unknown_key_is_empty(self, mgr) -> None:
+        assert mgr._get_session_agent("nope") == ""
+
+    def test_agentless_session_is_empty_not_none(self, mgr) -> None:
+        _register(mgr, "d1")
+        assert mgr._get_session_agent("d1") == ""
+
+    def test_agent_is_returned(self, mgr) -> None:
+        _register(mgr, "d1", agent="researcher")
+        assert mgr._get_session_agent("d1") == "researcher"
+
+
+class TestParentRuntimeKwargs:
+    """A companion subagent runtime must inherit the parent's security posture,
+    never spawn as a bare unsandboxed process."""
+
+    def test_unknown_parent_yields_no_kwargs(self, mgr) -> None:
+        assert mgr._parent_runtime_kwargs("nope") == {}
+
+    def test_provider_without_a_client_yields_no_kwargs(self, mgr) -> None:
+        _register(mgr, "d1", provider=_stub_provider())
+        assert mgr._parent_runtime_kwargs("d1") == {}
+
+    def test_posture_is_copied_from_the_private_client(self, mgr) -> None:
+        client = SimpleNamespace(
+            _sandbox_mode="strict",
+            _extra_env={"A": "1"},
+            _mcp_gateway_overlay={"servers": {}},
+            _mcp_gateway_settings_mcp_json="/tmp/mcp.json",
+            _mcp_gateway_socket="/tmp/gw.sock",
+        )
+        _register(mgr, "d1", provider=_stub_provider(client=client))
+
+        assert mgr._parent_runtime_kwargs("d1") == {
+            "sandbox_mode": "strict",
+            "extra_env": {"A": "1"},
+            "mcp_gateway_overlay": {"servers": {}},
+            "mcp_gateway_settings_mcp_json": "/tmp/mcp.json",
+            "mcp_gateway_socket": "/tmp/gw.sock",
+        }
+
+    def test_unset_posture_fields_are_omitted_not_nulled(self, mgr) -> None:
+        """A None must not be forwarded: the runtime would read it as an
+        explicit "no sandbox" rather than "inherit the default"."""
+        client = SimpleNamespace(_sandbox_mode="strict", _extra_env=None)
+        _register(mgr, "d1", provider=_stub_provider(client=client))
+        assert mgr._parent_runtime_kwargs("d1") == {"sandbox_mode": "strict"}
+
+    def test_legacy_underscore_client_attribute_is_honoured(self, mgr) -> None:
+        client = SimpleNamespace(_sandbox_mode="off")
+        provider = _stub_provider()
+        provider._client = client
+        _register(mgr, "d1", provider=provider)
+        assert mgr._parent_runtime_kwargs("d1") == {"sandbox_mode": "off"}
+
+
+class TestSessionSharingEligible:
+    def test_unknown_parent_is_ineligible(self, mgr) -> None:
+        assert mgr.is_session_sharing_eligible("nope") is False
+
+    def test_provider_that_does_not_advertise_the_capability_is_ineligible(self, mgr) -> None:
+        _register(mgr, "d1", provider=_stub_provider())
+        assert mgr.is_session_sharing_eligible("d1") is False
+
+    def test_kiro_backed_provider_is_eligible(self, mgr) -> None:
+        _register(mgr, "d1", provider=_stub_provider(is_session_sharing_eligible=True))
+        assert mgr.is_session_sharing_eligible("d1") is True
+
+
+class TestContinuableKeys:
+    def test_cache_hit_needs_no_disk_read(self, mgr) -> None:
+        mgr._continuable_keys.add("subagent:a")
+        mgr._continuable_fallback = MagicMock(
+            side_effect=AssertionError("must not consult disk")
+        )
+        assert mgr._is_continuable_key("subagent:a") is True
+
+    def test_miss_without_a_fallback_is_stateless(self, mgr) -> None:
+        assert mgr._is_continuable_key("subagent:a") is False
+
+    def test_disk_hit_rewarms_the_cache(self, mgr) -> None:
+        """A gateway restart empties the cache; the disk answer must be
+        promoted so a continuable conversation is not demoted to stateless."""
+        mgr.set_continuable_fallback(lambda folded: folded == "subagent:a")
+
+        assert mgr._is_continuable_key("subagent:a") is True
+        assert "subagent:a" in mgr._continuable_keys
+        assert mgr.is_continuable("subagent:b") is False
+
+    def test_a_broken_fallback_reads_as_stateless(self, mgr) -> None:
+        def boom(folded: str) -> bool:
+            raise OSError("state.json is unreadable")
+
+        mgr.set_continuable_fallback(boom)
+        assert mgr._is_continuable_key("subagent:a") is False
+        assert "subagent:a" not in mgr._continuable_keys
+
+
+# ── Origin links ─────────────────────────────────────────────────────────────
+
+
+class TestOriginLinks:
+    def test_link_round_trips(self, mgr) -> None:
+        link = ChannelLink(channel_type="slack", channel_id="C1", thread_id="1.2")
+        mgr.set_origin_link("slack:1.2", link)
+        assert mgr.get_origin_link("slack:1.2") is link
+
+    def test_unknown_key_has_no_link(self, mgr) -> None:
+        assert mgr.get_origin_link("nope") is None
+
+    def test_the_map_is_bounded_fifo(self, mgr) -> None:
+        """Sessions dropped without reset()/remove() would otherwise grow this
+        map without limit for the life of the gateway."""
+        for i in range(_MAX_ORIGIN_LINKS + 5):
+            mgr.set_origin_link(f"k{i}", ChannelLink(channel_type="slack", channel_id=f"C{i}"))
+
+        assert len(mgr._origin_links) == _MAX_ORIGIN_LINKS
+        assert mgr.get_origin_link("k0") is None, "oldest evicted first"
+        assert mgr.get_origin_link(f"k{_MAX_ORIGIN_LINKS + 4}") is not None
+
+
+# ── Lifecycle refusals ──────────────────────────────────────────────────────
+
+
+class TestRemoveIfUnclaimed:
+    """The TTL backstop for resume prefetch. A speculative session holds
+    kiro-cli's native per-session lock, so an unclaimed one must be released —
+    but a claimed one must survive."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_key_removes_nothing(self, mgr) -> None:
+        assert await mgr.remove_if_unclaimed("nope") is False
+
+    @pytest.mark.asyncio
+    async def test_a_consumed_session_is_kept(self, mgr) -> None:
+        sess = _register(mgr, "dashboard:1", is_new=False)
+        assert await mgr.remove_if_unclaimed("dashboard:1") is False
+        assert mgr._sessions["dashboard:1"] is sess
+        sess.provider.shutdown.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_session_mid_turn_is_kept(self, mgr) -> None:
+        sess = _register(mgr, "dashboard:1", is_new=True)
+        await sess.semaphore.acquire()
+        assert await mgr.remove_if_unclaimed("dashboard:1") is False
+        assert "dashboard:1" in mgr._sessions
+
+    @pytest.mark.asyncio
+    async def test_an_unclaimed_session_is_shut_down_and_forgotten(self, mgr) -> None:
+        sess = _register(mgr, "dashboard:1", is_new=True)
+        mgr._compact_cooldown_until["dashboard:1"] = 123.0
+        mgr.set_origin_link("dashboard:1", ChannelLink(channel_type="dashboard"))
+
+        assert await mgr.remove_if_unclaimed("dashboard:1") is True
+
+        assert "dashboard:1" not in mgr._sessions
+        assert "dashboard:1" not in mgr._compact_cooldown_until
+        assert mgr.get_origin_link("dashboard:1") is None
+        sess.provider.shutdown.assert_awaited_once()
+
+
+class TestRecycleHeartbeat:
+    @pytest.mark.asyncio
+    async def test_no_heartbeat_session_is_a_noop(self, mgr) -> None:
+        await mgr.recycle_heartbeat()
+        assert HEARTBEAT_KEY not in mgr._sessions
+
+    @pytest.mark.asyncio
+    async def test_recycle_is_unconditional(self, mgr) -> None:
+        """Heartbeat's published contract is a fresh context each cycle, so the
+        teardown must not be gated on context usage the way recycle_background
+        is."""
+        sess = _register(mgr, HEARTBEAT_KEY, provider=_stub_provider(context_usage_pct=lambda: 1.0))
+
+        await mgr.recycle_heartbeat()
+
+        assert HEARTBEAT_KEY not in mgr._sessions
+        sess.provider.shutdown.assert_awaited_once()
+
+
+class TestExpireIdle:
+    @pytest.mark.asyncio
+    async def test_persistent_and_channel_sessions_are_never_swept(self, mgr) -> None:
+        for key in (BACKGROUND_KEY, HEARTBEAT_KEY, "channel:slack:C1"):
+            _register(mgr, key, last_used=0.0)
+        with patch.object(mgr, "reset", AsyncMock(return_value=True)) as reset:
+            await mgr._expire_idle(1)
+        reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_turn_in_flight_is_never_idle(self, mgr) -> None:
+        """``last_used`` is bumped once per turn, so a turn running longer than
+        the timeout looks idle to the arithmetic — the semaphore is the guard."""
+        sess = _register(mgr, "dashboard:1", last_used=0.0)
+        await sess.semaphore.acquire()
+        with patch.object(mgr, "reset", AsyncMock(return_value=True)) as reset:
+            await mgr._expire_idle(1)
+        reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_idle_session_is_reset_not_removed(self, mgr) -> None:
+        """reset() preserves the session-map entry so the next open can
+        session/load the transcript back."""
+        _register(mgr, "dashboard:1", last_used=0.0)
+        with patch.object(mgr, "reset", AsyncMock(return_value=True)) as reset:
+            await mgr._expire_idle(1)
+        reset.assert_awaited_once_with("dashboard:1", skip_if_busy=True)
+
+    @pytest.mark.asyncio
+    async def test_an_orphaned_dashboard_session_ignores_the_clock(self, mgr) -> None:
+        """A closed tab is reaped immediately; the slot set is the authority."""
+        _register(mgr, "dashboard:gone")
+        mgr._active_dashboard_slots = {"dashboard:live"}
+        _register(mgr, "dashboard:live")
+
+        with patch.object(mgr, "reset", AsyncMock(return_value=True)) as reset:
+            await mgr._expire_idle(10_000)
+
+        assert [c.args[0] for c in reset.await_args_list] == ["dashboard:gone"]
+
+    @pytest.mark.asyncio
+    async def test_uninitialised_slot_set_orphans_nothing(self, mgr) -> None:
+        """None means "not yet reported", which must not read as "all tabs
+        closed" — that would reap every dashboard session on startup."""
+        _register(mgr, "dashboard:1")
+        assert mgr._active_dashboard_slots is None
+        with patch.object(mgr, "reset", AsyncMock(return_value=True)) as reset:
+            await mgr._expire_idle(10_000)
+        reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_session_that_turns_busy_before_reset_is_left_running(self, mgr) -> None:
+        """The collect->reset window: reset() re-checks atomically and returns
+        False, and the sweep must accept that rather than retry or raise."""
+        _register(mgr, "dashboard:1", last_used=0.0)
+        with patch.object(mgr, "reset", AsyncMock(return_value=False)):
+            await mgr._expire_idle(1)
+        # No exception, and the entry was left for the next pass to reconsider.
+
+    @pytest.mark.asyncio
+    async def test_a_broken_expire_callback_does_not_stop_the_sweep(self, mgr) -> None:
+        _register(mgr, "dashboard:1", last_used=0.0)
+        mgr.on_session_expire = MagicMock(side_effect=RuntimeError("consolidator down"))
+        with patch.object(mgr, "reset", AsyncMock(return_value=True)) as reset:
+            await mgr._expire_idle(1)
+        mgr.on_session_expire.assert_called_once_with("dashboard:1")
+        reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_the_hook_honours_the_disable_gate(self, mgr) -> None:
+        _register(mgr, "dashboard:1", last_used=0.0)
+        mgr._idle_sweep_enabled = False
+        with patch.object(mgr, "_expire_idle", AsyncMock()) as expire:
+            await mgr._expire_idle_hook()
+        expire.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_hook_swallows_a_sweep_crash(self, mgr) -> None:
+        mgr._idle_sweep_enabled = True
+        mgr._idle_timeout = 60
+        with patch.object(mgr, "_expire_idle", AsyncMock(side_effect=RuntimeError("boom"))):
+            await mgr._expire_idle_hook()  # must not propagate into the loop
+
+
+# ── Stuck-turn observer ─────────────────────────────────────────────────────
+
+
+def _parked_provider(parked: float, *, since: object = 1.0, awaiting: bool = False):
+    handle = SimpleNamespace(
+        parked_for_secs=lambda: parked,
+        parked_since=since,
+        awaiting_permission=awaiting,
+    )
+    provider = _stub_provider()
+    provider._handle = handle
+    return provider
+
+
+async def _busy(mgr: SessionManager, key: str, provider) -> _Session:
+    sess = _register(mgr, key, provider=provider)
+    await sess.semaphore.acquire()
+    return sess
+
+
+class TestStuckTurnCheck:
+    """Detection only — the hook reports and never terminates."""
+
+    @pytest.mark.asyncio
+    async def test_an_idle_session_is_not_a_park(self, mgr) -> None:
+        _register(mgr, "d1", provider=_parked_provider(_STUCK_TURN_REPORT_SECS + 10))
+        mgr.on_stuck_turn = MagicMock()
+        await mgr._stuck_turn_check()
+        mgr.on_stuck_turn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_provider_without_a_handle_is_skipped(self, mgr) -> None:
+        await _busy(mgr, "d1", _stub_provider())
+        mgr.on_stuck_turn = MagicMock()
+        await mgr._stuck_turn_check()
+        mgr.on_stuck_turn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_handle_without_the_accessor_is_skipped(self, mgr) -> None:
+        """Duck-typed on the capability, so a transport that lacks it is
+        ignored rather than crashing the cleanup pass."""
+        provider = _stub_provider()
+        provider._handle = SimpleNamespace(parked_for_secs=None)
+        await _busy(mgr, "d1", provider)
+        mgr.on_stuck_turn = MagicMock()
+        await mgr._stuck_turn_check()
+        mgr.on_stuck_turn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_short_park_is_below_the_report_threshold(self, mgr) -> None:
+        await _busy(mgr, "d1", _parked_provider(1.0))
+        mgr.on_stuck_turn = MagicMock()
+        await mgr._stuck_turn_check()
+        mgr.on_stuck_turn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_turn_waiting_for_a_human_is_excluded(self, mgr) -> None:
+        """That wait has its own budget (tool_approval_timeout_secs); reporting
+        it here would put two components on different clocks."""
+        await _busy(
+            mgr, "d1", _parked_provider(_STUCK_TURN_REPORT_SECS + 10, awaiting=True)
+        )
+        mgr.on_stuck_turn = MagicMock()
+        await mgr._stuck_turn_check()
+        mgr.on_stuck_turn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_long_park_is_reported_once_per_park(self, mgr) -> None:
+        parked = _STUCK_TURN_REPORT_SECS + 42
+        await _busy(mgr, "d1", _parked_provider(parked, since=1000.0))
+        mgr.on_stuck_turn = MagicMock()
+
+        await mgr._stuck_turn_check()
+        await mgr._stuck_turn_check()
+
+        mgr.on_stuck_turn.assert_called_once_with("d1", parked)
+        assert mgr._stuck_reported == {"d1": 1000.0}
+
+    @pytest.mark.asyncio
+    async def test_a_new_park_on_the_same_session_reports_afresh(self, mgr) -> None:
+        """Latched on the park's identity, not the session, so a stale entry
+        cannot silence a later stall."""
+        provider = _parked_provider(_STUCK_TURN_REPORT_SECS + 5, since=1000.0)
+        await _busy(mgr, "d1", provider)
+        mgr.on_stuck_turn = MagicMock()
+        await mgr._stuck_turn_check()
+
+        provider._handle.parked_since = 2000.0
+        await mgr._stuck_turn_check()
+
+        assert mgr.on_stuck_turn.call_count == 2
+        assert mgr._stuck_reported == {"d1": 2000.0}
+
+    @pytest.mark.asyncio
+    async def test_a_handle_without_a_park_identity_is_reported_per_tick(self, mgr) -> None:
+        """A missed stall is worse than a repeated line, so a handle exposing
+        the duration but not the instant falls back to the duration."""
+        parked = _STUCK_TURN_REPORT_SECS + 7
+        await _busy(mgr, "d1", _parked_provider(parked, since=None))
+        mgr.on_stuck_turn = MagicMock()
+
+        await mgr._stuck_turn_check()
+        assert mgr._stuck_reported == {"d1": parked}
+        await mgr._stuck_turn_check()
+        mgr.on_stuck_turn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_the_latch_is_dropped_when_the_park_ends(self, mgr) -> None:
+        sess = await _busy(mgr, "d1", _parked_provider(_STUCK_TURN_REPORT_SECS + 5))
+        mgr.on_stuck_turn = MagicMock()
+        await mgr._stuck_turn_check()
+        assert mgr._stuck_reported
+
+        sess.semaphore.release()
+        await mgr._stuck_turn_check()
+
+        assert mgr._stuck_reported == {}
+
+    @pytest.mark.asyncio
+    async def test_a_broken_callback_does_not_break_the_cleanup_pass(self, mgr) -> None:
+        await _busy(mgr, "d1", _parked_provider(_STUCK_TURN_REPORT_SECS + 5))
+        mgr.on_stuck_turn = MagicMock(side_effect=RuntimeError("notifier down"))
+        await mgr._stuck_turn_check()  # an observer must never break its host
+
+    @pytest.mark.asyncio
+    async def test_the_observer_swallows_its_own_crash(self, mgr, caplog) -> None:
+        provider = _stub_provider()
+        provider._handle = SimpleNamespace(
+            parked_for_secs=lambda: "not-a-number",
+            parked_since=1.0,
+            awaiting_permission=False,
+        )
+        await _busy(mgr, "d1", provider)
+        with caplog.at_level(logging.ERROR, logger="kiro_crew.session"):
+            await mgr._stuck_turn_check()
+        assert any("_stuck_turn_check crashed" in r.message for r in caplog.records)
+
+
+# ── Abort push ───────────────────────────────────────────────────────────────
+
+
+class TestSendAbortForSession:
+    @pytest.mark.asyncio
+    async def test_runtime_info_drives_the_abort(self, mgr) -> None:
+        sess = _Session(provider=_stub_provider(runtime_info=lambda: (4242, "/tmp/gw.sock")))
+        with patch("kiro_crew.session.schedule_abort") as abort:
+            await mgr._send_abort_for_session("d1", sess)
+        abort.assert_called_once()
+        assert abort.call_args.args[0] == "/tmp/gw.sock"
+        assert abort.call_args.args[1] == [4242]
+
+    @pytest.mark.asyncio
+    async def test_private_client_fields_are_the_fallback(self, mgr) -> None:
+        """For providers that never overrode runtime_info()."""
+        provider = _stub_provider(runtime_info=lambda: (None, None))
+        provider._client = SimpleNamespace(_pid=99, _mcp_gateway_socket="/tmp/b.sock")
+        with patch("kiro_crew.session.schedule_abort") as abort:
+            await mgr._send_abort_for_session("d1", _Session(provider=provider))
+        assert abort.call_args.args[1] == [99]
+
+    @pytest.mark.asyncio
+    async def test_an_unresolvable_runtime_warns_rather_than_failing_silently(
+        self, mgr, caplog
+    ) -> None:
+        """Visible by default: if provider internals get renamed the abort push
+        stops firing, and a silent skip would hide the regression."""
+        provider = _stub_provider(runtime_info=lambda: (None, None))
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session"):
+            with patch("kiro_crew.session.schedule_abort") as abort:
+                await mgr._send_abort_for_session("d1", _Session(provider=provider))
+        abort.assert_not_called()
+        assert any("abort-push skipped" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_a_reaped_pid_is_not_aborted(self, mgr) -> None:
+        """pid<=1 would target init, not a kiro-cli process."""
+        sess = _Session(provider=_stub_provider(runtime_info=lambda: (1, "/tmp/gw.sock")))
+        with patch("kiro_crew.session.schedule_abort") as abort:
+            await mgr._send_abort_for_session("d1", sess)
+        abort.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_raising_provider_never_blocks_the_kill_path(self, mgr) -> None:
+        def boom():
+            raise RuntimeError("provider is gone")
+
+        sess = _Session(provider=_stub_provider(runtime_info=boom))
+        await mgr._send_abort_for_session("d1", sess)  # best-effort, must not raise
+
+    @pytest.mark.asyncio
+    async def test_a_failing_audit_does_not_block_the_abort(self, mgr) -> None:
+        sess = _Session(provider=_stub_provider(runtime_info=lambda: (7, "/tmp/gw.sock")))
+        with patch("kiro_crew.session.sel", side_effect=RuntimeError("sel down")):
+            with patch("kiro_crew.session.schedule_abort") as abort:
+                await mgr._send_abort_for_session("d1", sess)
+        abort.assert_called_once()
+
+
+# ── Orphan-MCP hook ─────────────────────────────────────────────────────────
+
+
+class TestOrphanMcpHook:
+    @pytest.mark.asyncio
+    async def test_a_sweep_result_is_logged(self, mgr, caplog) -> None:
+        with patch("kiro_crew.session._cleanup_orphaned_mcp_servers", return_value=3):
+            with caplog.at_level(logging.INFO, logger="kiro_crew.session"):
+                await mgr._orphan_mcp_hook()
+        assert any("cleaned 3 orphaned MCP servers" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_a_clean_sweep_logs_nothing(self, mgr, caplog) -> None:
+        with patch("kiro_crew.session._cleanup_orphaned_mcp_servers", return_value=0):
+            with caplog.at_level(logging.INFO, logger="kiro_crew.session"):
+                await mgr._orphan_mcp_hook()
+        assert not any("orphaned MCP servers" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_a_sweep_failure_is_swallowed(self, mgr) -> None:
+        with patch(
+            "kiro_crew.session._cleanup_orphaned_mcp_servers",
+            side_effect=OSError("procfs unreadable"),
+        ):
+            await mgr._orphan_mcp_hook()  # preserves the silent-swallow contract
+
+
+# ── Conversation map seams ──────────────────────────────────────────────────
+
+
+class _MapSpy:
+    def __init__(self, sid: str | None = None, provider: str = "") -> None:
+        self.entries: dict[str, tuple[str, str, str]] = {}
+        self.deleted: list[str] = []
+        self._sid = sid
+        self._provider = provider
+
+    def set(self, key: str, sid: str, *, provider: str = "", cwd: str = "") -> None:
+        self.entries[key] = (sid, provider, cwd)
+
+    def get(self, key: str) -> str | None:
+        return self._sid
+
+    def get_provider(self, key: str) -> str:
+        return self._provider
+
+    def delete(self, key: str) -> None:
+        self.deleted.append(key)
+
+
+class TestConversationMapSeams:
+    def test_seeding_without_a_sid_writes_nothing(self, mgr) -> None:
+        """Retain-by-default: a full-file rewrite per spawn is O(n) churn at
+        wave scale, so an empty sid must not touch the map."""
+        spy = _MapSpy()
+        mgr._session_map = spy
+        mgr.seed_conversation("subagent:a", "")
+        assert spy.entries == {}
+
+    def test_seeding_records_provider_and_cwd(self, mgr) -> None:
+        spy = _MapSpy()
+        mgr._session_map = spy
+        mgr.seed_conversation("subagent:a", "sid-1", provider="acp", cwd="/tmp/wt")
+        assert spy.entries == {"subagent:a": ("sid-1", "acp", "/tmp/wt")}
+
+    def test_forgetting_returns_the_sid_and_clears_the_mark(self, mgr) -> None:
+        mgr._session_map = _MapSpy(sid="sid-1")
+        mgr._continuable_keys.add("subagent:a")
+
+        assert mgr.forget_conversation("subagent:a") == "sid-1"
+
+        assert mgr._session_map.deleted == ["subagent:a"]
+        assert "subagent:a" not in mgr._continuable_keys
+
+    def test_forgetting_an_unmapped_key_returns_none(self, mgr) -> None:
+        mgr._session_map = _MapSpy(sid=None)
+        assert mgr.forget_conversation("subagent:a") is None
+
+    def test_resumable_sid_and_provider_read_through(self, mgr) -> None:
+        mgr._session_map = _MapSpy(sid="sid-1", provider="claude_code")
+        assert mgr.resumable_sid("subagent:a") == "sid-1"
+        assert mgr.conversation_provider("subagent:a") == "claude_code"
+
+
+# ── Registry snapshots ──────────────────────────────────────────────────────
+
+
+class TestRegistrySnapshots:
+    def test_active_providers_lists_every_live_backend(self, mgr) -> None:
+        a = _register(mgr, "d1").provider
+        b = _register(mgr, "d2").provider
+        assert set(map(id, mgr.active_providers())) == {id(a), id(b)}
+
+    def test_any_active_turn_filters_on_the_real_turn_signal(self, mgr) -> None:
+        """A provider that does not implement the probe contributes nothing,
+        rather than a false positive that would keep the host awake."""
+        _register(mgr, "d1", provider=_stub_provider())
+        assert mgr.any_active_turn() is False
+
+        _register(mgr, "d2", provider=_stub_provider(has_active_turn=lambda: True))
+        assert mgr.any_active_turn() is True
+
+    def test_get_pid_reads_the_client(self, mgr) -> None:
+        provider = _stub_provider()
+        provider.client = SimpleNamespace(_pid=555)
+        _register(mgr, "d1", provider=provider)
+        assert mgr.get_pid("d1") == 555
+
+    def test_get_pid_is_none_for_an_unknown_key(self, mgr) -> None:
+        assert mgr.get_pid("nope") is None
+
+    def test_get_pid_is_none_when_the_provider_has_no_client(self, mgr) -> None:
+        _register(mgr, "d1", provider=_stub_provider())
+        assert mgr.get_pid("d1") is None
+
+    def test_get_provider_is_none_for_an_unknown_key(self, mgr) -> None:
+        assert mgr.get_provider("nope") is None

--- a/test/test_slack_gateway_cron_exec_coverage.py
+++ b/test/test_slack_gateway_cron_exec_coverage.py
@@ -1,0 +1,684 @@
+"""Coverage for the Kiro Crew gateway's deterministic cron-execution paths.
+
+``test_slack_gateway.py`` and ``test_cron_gateway_integration.py`` drive the
+LLM (``message``) arm of ``_cron_callback`` thoroughly, but the two
+deterministic arms — ``job.command`` (shell) and ``job.script`` (Python
+callable) — only had their happy paths exercised. Everything reached here was
+uncovered by the whole suite before this file:
+
+* the shared concurrent-execution guard (``_running_script_ids``);
+* command mode: fire-time governance denial, ``cancelled`` status, the
+  empty-output ok/non-ok split, non-ok-with-output, timeout and generic-error
+  arms, plus the best-effort SEL-audit ``except`` around each;
+* script mode: governance denial, ``cancelled`` / ``ok`` / ``skip`` / ``done``
+  / ``report`` / unknown-status dispositions, the auto-paused warning arms of
+  timeout and generic error, and their SEL-audit ``except`` twins;
+* the ``message``-arm fire-time denial audit ``except``;
+* ``_deliver_script_result``'s queued-slot, rehydrate-miss, no-session-key,
+  delivery-failure and ``CronStoreBusy`` deferred-removal branches;
+* the "cron reaper not started" arm of ``_init_cron``;
+* ``_channel_reply_link`` / ``_deliver_channel_reply`` resolution refusals;
+* ``_persist_turn_row``'s best-effort ``except`` and ``_is_read_only_tool``'s
+  no-token guard.
+
+Everything is driven through mocked collaborators: the sandbox runners, the
+governance gate, SEL and the cron service are all patched, so no subprocess, no
+socket and no write outside the per-test ``KIROCREW_HOME`` (pinned by
+``test/conftest.py``) happens. Style and patch seams mirror
+``test_slack_gateway.py`` / ``test_cron_gateway_integration.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.cron import CronJob, CronStoreBusy
+from kiro_crew.slack import gateway as gw
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _make_orchestrator(**kwargs: Any) -> Any:
+    """Build a GatewayOrchestrator with mocked credentials (no Slack tokens).
+
+    Returned as ``Any`` on purpose: every test below swaps real collaborators
+    for mocks, which do not satisfy the declared attribute types.
+    """
+    cfg = KiroCrewConfig()
+    creds = {"KIROCREW_OWNER_ID": "U_OWNER"}
+    with patch.object(cfg, "load_credentials", return_value=creds):
+        return gw.GatewayOrchestrator(
+            cfg,
+            no_dashboard=kwargs.pop("no_dashboard", True),
+            no_crons=kwargs.pop("no_crons", True),
+            no_open=True,
+        )
+
+
+def _mock_dashboard_state() -> MagicMock:
+    ds = MagicMock()
+    ds._slots = {}
+    ds.notify = MagicMock()
+    ds.push_slots_update = MagicMock()
+    ds.push_refresh = MagicMock()
+    ds.get_slot = MagicMock(return_value=None)
+    ds.has_slot = MagicMock(return_value=False)
+    ds.conversation_log = None
+    return ds
+
+
+def _mock_slot(*, running: bool = False) -> MagicMock:
+    slot = MagicMock()
+    slot.running = running
+    slot.queue_append = MagicMock(return_value="q-1")
+    slot.append = MagicMock()
+    slot.task = None
+    return slot
+
+
+def _job(**kwargs: Any) -> CronJob:
+    """A real CronJob, so record_success / record_failure semantics are real."""
+    job = CronJob(
+        id=kwargs.pop("id", "j1"),
+        name=kwargs.pop("name", "nightly probe"),
+        message=kwargs.pop("message", "go"),
+    )
+    for key, value in kwargs.items():
+        setattr(job, key, value)
+    return job
+
+
+def _cron_service_double() -> MagicMock:
+    svc = MagicMock()
+    svc.start = AsyncMock()
+    svc.start_reaper = MagicMock()
+    svc.remove_job_async = AsyncMock(return_value=True)
+    svc.defer_removal = MagicMock()
+    svc.set_refresh_callback = MagicMock()
+    svc.register_active_session_key = MagicMock()
+    svc.clear_active_session_key = MagicMock()
+    svc.get_job = MagicMock(return_value=None)
+    return svc
+
+
+def _blind_sel() -> MagicMock:
+    """A SEL double whose audit write always fails (drives the best-effort arms)."""
+    sel_obj = MagicMock()
+    sel_obj.log_tool_invocation = MagicMock(side_effect=RuntimeError("sel down"))
+    return sel_obj
+
+
+def _sandboxed(result: Any) -> Any:
+    """A sandbox-runner double: returns *result*, or raises it when it is an error.
+
+    The real runners execute inside ``run_in_executor``, so raising here
+    propagates through ``asyncio.wait_for`` exactly as a real failure does —
+    which is what lets the timeout arm be driven without a real wall-clock wait.
+    """
+
+    def _run(*_args: Any, **_kwargs: Any) -> Any:
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    return _run
+
+
+@asynccontextmanager
+async def _cron_cb(
+    orch: Any,
+    *,
+    svc: MagicMock | None = None,
+    gate_reason: str = "",
+    sel_obj: MagicMock | None = None,
+    command_result: Any = None,
+    script_result: Any = None,
+) -> AsyncIterator[Any]:
+    """Run ``_init_cron`` with every collaborator patched and yield ``on_job``.
+
+    The callback resolves ``sel`` / ``vet_job_at_fire_time`` / the sandbox
+    runners from module globals at CALL time, so it must be invoked while these
+    patches are still active — hence a context manager rather than a plain
+    factory.
+    """
+    service = svc if svc is not None else _cron_service_double()
+    captured: dict[str, Any] = {}
+
+    async def _create(**kw: Any) -> MagicMock:
+        captured["on_job"] = kw["on_job"]
+        return service
+
+    _sel = sel_obj if sel_obj is not None else MagicMock()
+    with (
+        patch.object(gw.CronService, "create", AsyncMock(side_effect=_create)),
+        patch.object(gw, "cron_executor", lambda: None),
+        patch.object(gw, "vet_job_at_fire_time", lambda job: gate_reason),
+        patch.object(gw, "sel", lambda: _sel),
+        patch.object(gw, "run_command_sandboxed", _sandboxed(command_result)),
+        patch.object(gw, "run_script_sandboxed", _sandboxed(script_result)),
+        patch.object(
+            gw, "build_cron_session_context", lambda job: (f"cron:{job.id}", job.message)
+        ),
+        patch("kiro_crew.apps.bridges.reconcile_app_crons_for_execution", AsyncMock()),
+    ):
+        await orch._init_cron()
+        assert "on_job" in captured
+        yield captured["on_job"]
+
+
+def _channel_sessions(
+    *,
+    origin: Any = None,
+    mirror: Any = None,
+    stored: Any = "",
+    origin_raises: bool = False,
+    stored_raises: bool = False,
+) -> MagicMock:
+    """A SessionManager double exposing only the link-resolution surface."""
+    sessions = MagicMock()
+    if origin_raises:
+        sessions.get_origin_link = MagicMock(side_effect=RuntimeError("map wedged"))
+    else:
+        sessions.get_origin_link = MagicMock(return_value=origin)
+    sessions.get_mirror_link = MagicMock(return_value=mirror)
+    if stored_raises:
+        sessions.get_channel = MagicMock(side_effect=RuntimeError("map wedged"))
+    else:
+        sessions.get_channel = MagicMock(return_value=stored)
+    return sessions
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Module-level helpers
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestModuleHelpers:
+    """``_persist_turn_row`` and ``_is_read_only_tool`` guard arms."""
+
+    @pytest.mark.asyncio
+    async def test_persist_turn_row_swallows_failure(self):
+        """A usage-row persistence failure never propagates into the caller."""
+        with patch.object(gw, "read_context_tokens", side_effect=RuntimeError("no provider")):
+            await gw._persist_turn_row(
+                object(),
+                "_hb",
+                provider="anthropic",
+                surface="heartbeat",
+                agent_fallback=lambda: "kirocrew",
+                t0=0.0,
+            )
+
+    def test_read_only_tool_rejects_punctuation_only_title(self):
+        """A title that tokenizes to nothing fails closed rather than approving."""
+        assert gw._is_read_only_tool("___") is False
+        assert gw._is_read_only_tool("read") is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Command-mode cron execution
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCronCommandMode:
+    """``_cron_callback``'s ``job.command`` arm."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_run_is_skipped(self):
+        """A job still running is skipped rather than started twice."""
+        orch = _make_orchestrator()
+        job = _job(command="echo hi")
+        orch._running_script_ids.add(job.id)
+        async with _cron_cb(orch, command_result={"status": "ok", "output": "hi"}) as cb:
+            assert await cb(job) is None
+        # The guard must not consume the marker — the in-flight run owns it.
+        assert job.id in orch._running_script_ids
+
+    @pytest.mark.asyncio
+    async def test_fire_time_denial_keeps_job_and_audits(self):
+        """Governance denial marks the run failed without counting a failure."""
+        orch = _make_orchestrator()
+        job = _job(command="printf hi")
+        async with _cron_cb(
+            orch, gate_reason="capabilities.cron denied", sel_obj=_blind_sel()
+        ) as cb:
+            assert await cb(job) is None
+        assert job.last_status == "error"
+        assert job.fire_time_denied is True
+        # A policy denial must never feed the auto-pause counter.
+        assert job.consecutive_failures == 0
+        assert job.id not in orch._running_script_ids
+
+    @pytest.mark.asyncio
+    async def test_cancelled_status_is_not_a_failure(self):
+        """A user cancel leaves the bookkeeping to CronService.cancel()."""
+        orch = _make_orchestrator()
+        job = _job(command="sleep 1")
+        async with _cron_cb(orch, command_result={"status": "cancelled"}) as cb:
+            assert await cb(job) is None
+        assert job.consecutive_failures == 0
+        assert job.last_status is None
+
+    @pytest.mark.asyncio
+    async def test_empty_output_ok_records_success(self):
+        """No output on an ok status is a success with nothing to deliver."""
+        orch = _make_orchestrator()
+        job = _job(command="true", consecutive_failures=2)
+        async with _cron_cb(orch, command_result={"status": "ok", "output": "   "}) as cb:
+            assert await cb(job) is None
+        assert job.last_status == "ok"
+        assert job.consecutive_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_output_non_ok_records_failure(self):
+        """No output on a non-ok status is a failure, and it says why."""
+        orch = _make_orchestrator()
+        job = _job(command="false")
+        async with _cron_cb(orch, command_result={"status": "error", "output": ""}) as cb:
+            assert await cb(job) is None
+        assert job.last_status == "error"
+        assert "non-ok status with no output" in (job.last_error or "")
+        assert job.consecutive_failures == 1
+
+    @pytest.mark.asyncio
+    async def test_non_ok_with_output_delivers_and_counts_failure(self):
+        """Output is still delivered on a non-ok exit, but the run is a failure."""
+        orch = _make_orchestrator()
+        job = _job(command="false")
+        result = {"status": "error", "output": "partial output", "exit_code": 3}
+        async with _cron_cb(orch, sel_obj=_blind_sel(), command_result=result) as cb:
+            assert await cb(job) == "partial output"
+        assert job.last_status == "error"
+        assert "exit_code=3" in (job.last_error or "")
+        assert job.consecutive_failures == 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_records_failure(self):
+        """A sandbox timeout is recorded against the job with its own audit arm."""
+        orch = _make_orchestrator()
+        job = _job(command="sleep 9999", timeout=7)
+        async with _cron_cb(
+            orch, sel_obj=_blind_sel(), command_result=asyncio.TimeoutError()
+        ) as cb:
+            assert await cb(job) is None
+        assert job.last_status == "error"
+        assert job.last_error == "timeout (12s)"
+        assert job.consecutive_failures == 1
+        assert job.id not in orch._running_script_ids
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_records_failure(self):
+        """An unexpected runner error is redacted, truncated and counted."""
+        orch = _make_orchestrator()
+        job = _job(command="printf hi")
+        async with _cron_cb(
+            orch, sel_obj=_blind_sel(), command_result=RuntimeError("x" * 400)
+        ) as cb:
+            assert await cb(job) is None
+        assert job.last_status == "error"
+        assert len(job.last_error or "") <= 200
+        assert job.consecutive_failures == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Script-mode cron execution
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCronScriptMode:
+    """``_cron_callback``'s ``job.script`` arm and its dispositions."""
+
+    @pytest.mark.asyncio
+    async def test_fire_time_denial_keeps_job(self):
+        orch = _make_orchestrator()
+        job = _job(script="probes.py:check")
+        async with _cron_cb(
+            orch, gate_reason="script body rescan denied", sel_obj=_blind_sel()
+        ) as cb:
+            assert await cb(job) is None
+        assert job.fire_time_denied is True
+        assert job.consecutive_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_cancelled_status_is_not_a_failure(self):
+        orch = _make_orchestrator()
+        job = _job(script="probes.py:check")
+        async with _cron_cb(orch, script_result={"status": "cancelled"}) as cb:
+            assert await cb(job) is None
+        assert job.consecutive_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_ok_status_records_success(self):
+        orch = _make_orchestrator()
+        job = _job(script="probes.py:check", consecutive_failures=1)
+        async with _cron_cb(orch, sel_obj=_blind_sel(), script_result={"status": "ok"}) as cb:
+            assert await cb(job) == "ok"
+        assert job.last_status == "ok"
+        assert job.last_result == "ok"
+        assert job.consecutive_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_skip_status_delivers_nothing(self):
+        """A Skip is a deliberate no-op: no result, no status change."""
+        orch = _make_orchestrator()
+        job = _job(script="probes.py:check")
+        async with _cron_cb(orch, sel_obj=_blind_sel(), script_result={"status": "skip"}) as cb:
+            assert await cb(job) is None
+        assert job.last_result is None
+
+    @pytest.mark.asyncio
+    async def test_unknown_status_is_an_error(self):
+        """An unrecognized status raises and lands in the generic error arm."""
+        orch = _make_orchestrator()
+        job = _job(script="probes.py:check")
+        result = {"status": "weird", "error": "bad disposition"}
+        async with _cron_cb(orch, script_result=result) as cb:
+            assert await cb(job) is None
+        assert job.last_status == "error"
+        assert job.last_error == "bad disposition"
+        assert job.consecutive_failures == 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_on_already_paused_job_warns(self):
+        """An auto-paused job's timeout logs the pause without re-auditing it."""
+        orch = _make_orchestrator()
+        job = _job(
+            script="probes.py:check", timeout=3, auto_paused=True, consecutive_failures=5
+        )
+        async with _cron_cb(
+            orch, sel_obj=_blind_sel(), script_result=asyncio.TimeoutError()
+        ) as cb:
+            assert await cb(job) is None
+        assert job.last_error == "timeout (8s)"
+        assert job.auto_paused is True
+        assert job.id not in orch._running_script_ids
+
+    @pytest.mark.asyncio
+    async def test_error_on_already_paused_job_warns(self):
+        orch = _make_orchestrator()
+        job = _job(script="probes.py:check", auto_paused=True, consecutive_failures=5)
+        async with _cron_cb(
+            orch, sel_obj=_blind_sel(), script_result=RuntimeError("callable exploded")
+        ) as cb:
+            assert await cb(job) is None
+        assert job.last_status == "error"
+        assert "callable exploded" in (job.last_error or "")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# _deliver_script_result
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDeliverScriptResult:
+    """Delivery of a Report / Done message back into the originating session."""
+
+    @pytest.mark.asyncio
+    async def test_report_queues_into_a_running_slot(self):
+        """A busy slot gets the notification queued, not dispatched."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        slot = _mock_slot(running=True)
+        orch.dashboard_state.get_slot = MagicMock(return_value=slot)
+        job = _job(script="probes.py:check", session_key="dashboard:chat-1-2")
+        result = {"status": "report", "message": "still red"}
+        async with _cron_cb(orch, script_result=result) as cb:
+            assert await cb(job) == "still red"
+        slot.queue_append.assert_called_once()
+        assert slot.append.call_args[0][0] == "queued"
+        orch.dashboard_state.push_slots_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_report_injects_into_an_idle_slot(self):
+        """An idle slot takes the notification as a real turn."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        slot = _mock_slot(running=False)
+        orch.dashboard_state.get_slot = MagicMock(return_value=slot)
+        job = _job(script="probes.py:check", session_key="dashboard:chat-1-2")
+        turn = MagicMock()
+        result = {"status": "report", "message": "green again"}
+        spawn = MagicMock(return_value=turn)
+        with (
+            patch.object(gw, "spawn_guarded_turn", spawn),
+            patch.object(gw, "_run_chat", MagicMock(return_value=MagicMock())),
+        ):
+            async with _cron_cb(orch, script_result=result) as cb:
+                assert await cb(job) == "green again"
+        spawn.assert_called_once()
+        assert slot.append.call_args[0][0] == "inject"
+        assert slot.task is turn
+
+    @pytest.mark.asyncio
+    async def test_report_falls_back_to_notification_when_no_slot(self):
+        """No live and no rehydratable slot degrades to a bell notification."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        job = _job(script="probes.py:check", session_key="dashboard:chat-gone")
+        result = {"status": "report", "message": "orphaned"}
+        with patch.object(gw, "_rehydrate_slot_from_history", MagicMock(return_value=None)):
+            async with _cron_cb(orch, script_result=result) as cb:
+                assert await cb(job) == "orphaned"
+        orch.dashboard_state.notify.assert_called_once()
+        assert orch.dashboard_state.notify.call_args[0][2] == "orphaned"
+
+    @pytest.mark.asyncio
+    async def test_report_without_session_key_notifies(self):
+        """A job with no originating session still reaches the bell feed."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        job = _job(script="probes.py:check", session_key="")
+        result = {"status": "report", "message": "no session"}
+        async with _cron_cb(orch, script_result=result) as cb:
+            assert await cb(job) == "no session"
+        orch.dashboard_state.notify.assert_called_once()
+        orch.dashboard_state.get_slot.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delivery_failure_does_not_break_the_run(self):
+        """A delivery exception is logged; the run's own verdict still stands."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.dashboard_state.get_slot = MagicMock(side_effect=RuntimeError("slots wedged"))
+        job = _job(script="probes.py:check", session_key="dashboard:chat-1-2")
+        result = {"status": "report", "message": "delivered nowhere"}
+        async with _cron_cb(orch, script_result=result) as cb:
+            assert await cb(job) == "delivered nowhere"
+        assert job.last_status == "ok"
+
+    @pytest.mark.asyncio
+    async def test_done_removes_the_job(self):
+        """A Done disposition delivers and then removes the one-shot job."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        svc = _cron_service_double()
+        job = _job(script="probes.py:check", session_key="")
+        result = {"status": "done", "message": "all clear"}
+        async with _cron_cb(orch, svc=svc, sel_obj=_blind_sel(), script_result=result) as cb:
+            assert await cb(job) == "all clear"
+        svc.remove_job_async.assert_awaited_once_with(job.id)
+
+    @pytest.mark.asyncio
+    async def test_done_defers_removal_when_store_is_busy(self):
+        """A busy store hands the removal to the deferred queue, not a retry."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        svc = _cron_service_double()
+        svc.remove_job_async = AsyncMock(side_effect=CronStoreBusy("locked"))
+        job = _job(script="probes.py:check", session_key="")
+        result = {"status": "done", "message": "finished"}
+        async with _cron_cb(orch, svc=svc, script_result=result) as cb:
+            assert await cb(job) == "finished"
+        svc.defer_removal.assert_called_once_with(job.id)
+
+    @pytest.mark.asyncio
+    async def test_silent_job_delivers_nothing(self):
+        """A silent job's Report reaches neither a slot nor the bell."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        job = _job(script="probes.py:check", session_key="dashboard:chat-1-2", silent=True)
+        result = {"status": "report", "message": "quiet"}
+        async with _cron_cb(orch, script_result=result) as cb:
+            assert await cb(job) == "quiet"
+        orch.dashboard_state.notify.assert_not_called()
+        orch.dashboard_state.get_slot.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# message-mode denial + _init_cron wiring
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCronMessageDenialAndWiring:
+    @pytest.mark.asyncio
+    async def test_message_job_fire_time_denial(self):
+        """An LLM cron denied at fire time never dispatches a turn."""
+        orch = _make_orchestrator()
+        orch.sessions = MagicMock()
+        orch.ctx_builder = MagicMock()
+        job = _job()
+        async with _cron_cb(
+            orch, gate_reason="capabilities.cron off", sel_obj=_blind_sel()
+        ) as cb:
+            assert await cb(job) is None
+        assert job.fire_time_denied is True
+        assert job.consecutive_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_reaper_not_started_without_sessions(self):
+        """Arming the scheduler without a session manager skips the reaper."""
+        orch = _make_orchestrator(no_crons=False)
+        orch.sessions = None
+        svc = _cron_service_double()
+        async with _cron_cb(orch, svc=svc):
+            pass
+        svc.start.assert_awaited_once()
+        svc.start_reaper.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Non-Slack channel reply resolution
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestChannelReplyLink:
+    """``_channel_reply_link``'s resolution ladder and its refusals."""
+
+    def test_slack_and_local_keys_return_none(self):
+        orch = _make_orchestrator()
+        orch.sessions = _channel_sessions()
+        assert orch._channel_reply_link("slack:C1") is None
+        assert orch._channel_reply_link("dashboard:chat-1-2") is None
+
+    def test_no_session_manager_returns_none(self):
+        orch = _make_orchestrator()
+        orch.sessions = None
+        assert orch._channel_reply_link("discord:kirocrew:direct:U9") is None
+
+    def test_link_getter_failure_falls_through_to_stored_channel(self):
+        """A raising link getter degrades to the next rung, it does not propagate."""
+        orch = _make_orchestrator()
+        orch.sessions = _channel_sessions(origin_raises=True, stored="discord:U9")
+        resolved = orch._channel_reply_link("discord:kirocrew:direct:U9")
+        assert resolved is not None
+        link, needs_dm = resolved
+        assert (link.channel_type, link.channel_id, needs_dm) == ("discord", "U9", True)
+
+    def test_stored_channel_lookup_failure_returns_none(self):
+        orch = _make_orchestrator()
+        orch.sessions = _channel_sessions(stored_raises=True)
+        assert orch._channel_reply_link("discord:kirocrew:direct:U9") is None
+
+    def test_no_stored_channel_returns_none(self):
+        orch = _make_orchestrator()
+        orch.sessions = _channel_sessions(stored="")
+        assert orch._channel_reply_link("discord:kirocrew:direct:U9") is None
+
+    @pytest.mark.parametrize(
+        "stored",
+        ["nocolon", "slack:U9", ":U9", "discord:"],
+        ids=["no-separator", "slack-typed", "empty-type", "empty-peer"],
+    )
+    def test_unusable_stored_value_returns_none(self, stored):
+        orch = _make_orchestrator()
+        orch.sessions = _channel_sessions(stored=stored)
+        assert orch._channel_reply_link("discord:kirocrew:direct:U9") is None
+
+    @pytest.mark.parametrize(
+        "stored",
+        ["bogus:U9", "unified:U9"],
+        ids=["unregistered-namespace", "unified-namespace"],
+    )
+    def test_unified_bucket_validates_stored_namespace(self, stored):
+        """A unified DM bucket only accepts a registered non-unified namespace."""
+        orch = _make_orchestrator()
+        orch.sessions = _channel_sessions(stored=stored)
+        assert orch._channel_reply_link("unified:kirocrew:direct:U9") is None
+
+    def test_group_session_never_takes_the_stored_rung(self):
+        """A group key's stored value is the sender, so it must not become a DM."""
+        orch = _make_orchestrator()
+        orch.sessions = _channel_sessions(stored="discord:U9")
+        assert orch._channel_reply_link("discord:kirocrew:group:C1") is None
+
+    def test_origin_link_wins_and_needs_no_dm_resolution(self):
+        orch = _make_orchestrator()
+        origin = gw.ChannelLink("discord", channel_id="C77", thread_id="T1")
+        orch.sessions = _channel_sessions(origin=origin, stored="discord:U9")
+        assert orch._channel_reply_link("discord:kirocrew:direct:U9") == (origin, False)
+
+
+class TestDeliverChannelReply:
+    """``_deliver_channel_reply``'s early refusals."""
+
+    @pytest.mark.asyncio
+    async def test_blank_text_is_not_delivered(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        assert await orch._deliver_channel_reply("discord:kirocrew:direct:U9", "   ") is False
+
+    @pytest.mark.asyncio
+    async def test_no_dashboard_state_is_not_delivered(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = None
+        assert await orch._deliver_channel_reply("discord:kirocrew:direct:U9", "hi") is False
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_key_is_not_delivered(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.sessions = _channel_sessions(stored="")
+        assert await orch._deliver_channel_reply("discord:kirocrew:direct:U9", "hi") is False
+
+    @pytest.mark.asyncio
+    async def test_target_resolution_failure_degrades_to_false(self):
+        """A raising governance ladder degrades the caller, it never propagates."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        link = gw.ChannelLink("discord", channel_id="C77")
+
+        def _boom(*_args: Any, **_kwargs: Any) -> Any:
+            raise RuntimeError("profile dir unreadable")
+
+        with patch.object(gw, "_resolve_channel_target", _boom):
+            delivered = await orch._deliver_channel_reply(
+                "discord:kirocrew:direct:U9", "hi", resolved_link=(link, False)
+            )
+        assert delivered is False
+
+    @pytest.mark.asyncio
+    async def test_no_governed_target_is_not_delivered(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        link = gw.ChannelLink("discord", channel_id="C77")
+        with patch.object(gw, "_resolve_channel_target", MagicMock(return_value=None)):
+            delivered = await orch._deliver_channel_reply(
+                "discord:kirocrew:direct:U9", "hi", resolved_link=(link, False)
+            )
+        assert delivered is False

--- a/test/test_slack_handler_coverage_branches.py
+++ b/test/test_slack_handler_coverage_branches.py
@@ -1,0 +1,736 @@
+"""Failure-branch coverage for :mod:`kiro_crew.slack.handler`.
+
+``test_slack_handler.py`` and ``test_slack_handler_coverage.py`` drive the happy
+paths of the Slack command surface. This module deliberately targets what they
+leave behind: the ``except`` arms that only run when the Slack API, the config
+store, or the SEL audit sink misbehave, plus the early keyword dispatch inside
+``handle_message`` (``status`` / ``sessions`` / ``!compact`` / the
+not-authorized replies).
+
+Everything runs in-process against doubles: no network, no subprocess, and no
+write outside ``tmp_path`` (``config_path`` is redirected per test).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from conftest import MockSlackClient
+from kiro_crew.config.loader import ConfigReadError
+from kiro_crew.providers.base import LLMEvent
+from kiro_crew.slack import handler as h
+
+# ──────────────────────────────────────────────────────────────────────
+# doubles
+# ──────────────────────────────────────────────────────────────────────
+
+
+class FlakySlack(MockSlackClient):
+    """MockSlackClient whose named methods raise instead of recording.
+
+    The handler wraps almost every Slack call in ``try/except`` so a transient
+    API error degrades cosmetics rather than aborting a turn. Those arms are
+    only reachable with a client that actually fails.
+    """
+
+    def __init__(self, *fail: str) -> None:
+        super().__init__()
+        self.fail: set[str] = set(fail)
+
+    async def add_reaction(self, channel, ts, emoji, raise_on_error=False):
+        if "add_reaction" in self.fail:
+            raise RuntimeError("slack add_reaction unavailable")
+        await super().add_reaction(channel, ts, emoji, raise_on_error)
+
+    async def remove_reaction(self, channel, ts, emoji, raise_on_error=False):
+        if "remove_reaction" in self.fail:
+            raise RuntimeError("slack remove_reaction unavailable")
+        await super().remove_reaction(channel, ts, emoji, raise_on_error)
+
+    async def post_message(self, channel, text, thread_ts=None, unfurl_links=None,
+                           unfurl_media=None):
+        if "post_message" in self.fail:
+            raise RuntimeError("slack post_message unavailable")
+        return await super().post_message(channel, text, thread_ts, unfurl_links, unfurl_media)
+
+    async def post_blocks(self, channel, blocks, text, thread_ts=None, unfurl_links=None,
+                          unfurl_media=None):
+        if "post_blocks" in self.fail:
+            raise RuntimeError("slack post_blocks unavailable")
+        return await super().post_blocks(channel, blocks, text, thread_ts, unfurl_links,
+                                         unfurl_media)
+
+
+def _raising_sel(*, method: str) -> MagicMock:
+    """A ``sel()`` factory whose *method* raises, for audit-sink failure arms."""
+    audit = MagicMock()
+    getattr(audit, method).side_effect = RuntimeError("audit sink down")
+    return MagicMock(return_value=audit)
+
+
+async def _drain() -> None:
+    """Let ``asyncio.ensure_future`` callbacks queued by the code under test run."""
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+
+def _texts(slack: MockSlackClient) -> str:
+    return "\n".join(
+        str(a[1].get("text") or "")
+        for a in slack.actions
+        if a[0] in ("post", "update", "blocks", "ephemeral")
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# state hygiene
+# ──────────────────────────────────────────────────────────────────────
+@pytest.fixture(autouse=True)
+def _clean_state():
+    """Reset the module globals these tests touch, before and after."""
+
+    def _reset() -> None:
+        h._titled_threads.clear()
+        # The auto-title lock is a module global created inside whichever event
+        # loop ran first. Reusing one across loops deadlocks, so drop it and let
+        # each test's loop build its own.
+        h._auto_title_lock = None
+        h._thread_agents.clear()
+        h._thread_projects.clear()
+        h._hydrated_sessions.clear()
+        h._thread_temporary.clear()
+        h._thread_incognito.clear()
+        h._pending_approvals.clear()
+        h._linked_approvals.clear()
+        h._trusted_sessions.clear()
+        h._cached_default_agent = None
+        h._dashboard_state = None
+        h._orch_cfg = None
+        h._tracking_channels = set()
+
+    _reset()
+    yield
+    _reset()
+
+
+@pytest.fixture()
+def owner(monkeypatch):
+    monkeypatch.setattr(h, "_owner_id", "U1")
+    return "U1"
+
+
+@pytest.fixture()
+def sessions():
+    """SessionManager double. ``_session_map=None`` keeps flag hydration inert."""
+    sm = MagicMock()
+    sm._session_map = None
+    sm.try_acquire = AsyncMock(return_value=True)
+    sm.has_session = MagicMock(return_value=False)
+    sm.release = MagicMock()
+    sm.destroy = AsyncMock()
+    sm.get_session_for_thread = MagicMock(return_value=None)
+    return sm
+
+
+# ──────────────────────────────────────────────────────────────────────
+# StatusReactionController — Slack API failures and the stall watchdog
+# ──────────────────────────────────────────────────────────────────────
+class TestStatusReactionControllerFailures:
+    """Every reaction call is best-effort; none may propagate."""
+
+    @pytest.mark.asyncio
+    async def test_swap_emoji_swallows_add_and_remove_failures(self):
+        slack = FlakySlack("add_reaction", "remove_reaction")
+        ctrl = h.StatusReactionController(slack, "C1", "1.0")
+        try:
+            # Immediate phase: add_reaction raises inside _swap_emoji.
+            ctrl.set_phase("queued")
+            await _drain()
+            assert ctrl._current_emoji == h._PHASE_EMOJIS["queued"]
+
+            # Debounced phase fired by hand: now there IS an old emoji, so the
+            # remove_reaction failure arm runs too.
+            ctrl.set_phase("coding")
+            ctrl._cancel_debounce()
+            ctrl._fire_debounce()
+            await _drain()
+            assert ctrl._current_emoji == h._PHASE_EMOJIS["coding"]
+        finally:
+            ctrl._cancel_debounce()
+            ctrl._cancel_stall_timers()
+
+    @pytest.mark.asyncio
+    async def test_apply_pending_is_a_noop_once_finalized(self):
+        slack = FlakySlack()
+        ctrl = h.StatusReactionController(slack, "C1", "1.0")
+        ctrl._pending_phase = "coding"
+        ctrl._finalized = True
+        await ctrl._apply_pending()
+        assert ctrl._current_emoji is None
+
+    @pytest.mark.asyncio
+    async def test_stall_emojis_upgrade_and_finalize_despite_failures(self):
+        slack = FlakySlack("add_reaction", "remove_reaction")
+        ctrl = h.StatusReactionController(slack, "C1", "1.0")
+        try:
+            ctrl._on_stall_soft()
+            await _drain()
+            assert ctrl._stall_emoji == h._STALL_EMOJI_SOFT
+
+            # Upgrading soft -> hard removes the previous stall emoji first;
+            # that remove_reaction raises and must be swallowed.
+            ctrl._on_stall_hard()
+            await _drain()
+            assert ctrl._stall_emoji == h._STALL_EMOJI_HARD
+
+            # finalize() clears the stall emoji before the terminal swap.
+            ctrl.finalize(error=True)
+            await _drain()
+            assert ctrl._stall_emoji is None
+            assert ctrl._current_emoji == h._PHASE_EMOJIS["error"]
+        finally:
+            ctrl._cancel_stall_timers()
+
+    @pytest.mark.asyncio
+    async def test_add_stall_emoji_after_finalize_is_dropped(self):
+        slack = FlakySlack()
+        ctrl = h.StatusReactionController(slack, "C1", "1.0")
+        ctrl._finalized = True
+        await ctrl._add_stall_emoji(h._STALL_EMOJI_SOFT)
+        assert ctrl._stall_emoji is None
+
+    @pytest.mark.asyncio
+    async def test_reset_watchdog_clears_stall_emoji_and_swallows_failure(self):
+        slack = FlakySlack("remove_reaction")
+        ctrl = h.StatusReactionController(slack, "C1", "1.0")
+        try:
+            ctrl._stall_emoji = h._STALL_EMOJI_SOFT
+            ctrl._reset_stall_watchdog()
+            await _drain()
+            assert ctrl._stall_emoji is None
+            assert ctrl._stall_soft_handle is not None
+        finally:
+            ctrl._cancel_stall_timers()
+
+    @pytest.mark.asyncio
+    async def test_reset_watchdog_arms_nothing_while_paused(self):
+        slack = FlakySlack()
+        ctrl = h.StatusReactionController(slack, "C1", "1.0")
+        ctrl.pause_stall_watchdog()
+        ctrl._reset_stall_watchdog()
+        assert ctrl._stall_soft_handle is None
+        assert ctrl._stall_hard_handle is None
+        # on_progress() must stay inert while paused.
+        ctrl.on_progress()
+        assert ctrl._stall_soft_handle is None
+
+    @pytest.mark.asyncio
+    async def test_disabled_controller_never_arms_timers(self):
+        slack = FlakySlack()
+        ctrl = h.StatusReactionController(slack, "C1", "1.0", enabled=False)
+        ctrl._reset_stall_watchdog()
+        ctrl.resume_stall_watchdog()
+        ctrl.set_phase("coding")
+        ctrl.finalize()
+        assert ctrl._stall_soft_handle is None
+        assert ctrl._debounce_handle is None
+        assert ctrl._current_emoji is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# config writers — read/write failures must surface as ValueError
+# ──────────────────────────────────────────────────────────────────────
+class TestConfigWriteFailures:
+    """Both writers fail CLOSED: a bad read must never write a {} baseline."""
+
+    @pytest.fixture(autouse=True)
+    def _local_config(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "config.json"
+        cfg.write_text("{}", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(h, "config_path", lambda: cfg)
+        return cfg
+
+    def test_set_default_agent_read_error(self, monkeypatch):
+        def _boom(_path):
+            raise ConfigReadError("config.json is not valid JSON")
+
+        monkeypatch.setattr(h, "read_config_for_update", _boom)
+        with pytest.raises(ValueError, match="Failed to read config"):
+            h._set_default_agent("kirocrew")
+        assert h._cached_default_agent is None
+
+    def test_set_default_agent_write_error(self, monkeypatch):
+        monkeypatch.setattr(h, "read_config_for_update", lambda _p: {})
+
+        def _boom(_path, _data):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(h, "write_config_atomically", _boom)
+        with pytest.raises(ValueError, match="Failed to write config"):
+            h._set_default_agent("kirocrew")
+        # Cache must NOT advance past a failed write.
+        assert h._cached_default_agent is None
+
+    def test_persist_channel_config_read_error(self, monkeypatch):
+        def _boom(_path):
+            raise ConfigReadError("truncated file")
+
+        monkeypatch.setattr(h, "read_config_for_update", _boom)
+        with pytest.raises(ValueError, match="Failed to read config"):
+            h._persist_channel_config("C1", activation="mention")
+
+    def test_persist_channel_config_write_error(self, monkeypatch):
+        monkeypatch.setattr(h, "read_config_for_update", lambda _p: {})
+
+        def _boom(_path, _data):
+            raise OSError("read-only filesystem")
+
+        monkeypatch.setattr(h, "write_config_atomically", _boom)
+        with pytest.raises(ValueError, match="Failed to write config"):
+            h._persist_channel_config("C1", agent="kirocrew")
+
+    def test_persist_channel_config_merges_both_fields(self, monkeypatch):
+        written: dict = {}
+        monkeypatch.setattr(h, "read_config_for_update", lambda _p: {"slack": {"bot": "x"}})
+        monkeypatch.setattr(
+            h, "write_config_atomically", lambda _p, data: written.update(data)
+        )
+        h._persist_channel_config("C9", activation="always", agent="kirocrew")
+        ch = written["slack"]["channels"]["C9"]
+        assert ch == {"activation": "always", "agent": "kirocrew"}
+        # Sibling keys survive the merge.
+        assert written["slack"]["bot"] == "x"
+
+
+class TestSensitivePathRefusal:
+    def test_both_writers_refuse_a_sensitive_config_path(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(h, "config_path", lambda: tmp_path / "config.json")
+        monkeypatch.setattr(h, "is_sensitive_path", lambda _p: True)
+        with pytest.raises(ValueError, match="sensitive path"):
+            h._set_default_agent("kirocrew")
+        with pytest.raises(ValueError, match="sensitive path"):
+            h._persist_channel_config("C1", activation="mention")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# set_yolo_mode — the headless --slack-only startup path
+# ──────────────────────────────────────────────────────────────────────
+class TestSetYoloMode:
+    def test_enabled_grants_a_standing_yolo(self, monkeypatch):
+        calls: list[str] = []
+        monkeypatch.setattr(h, "apply_config_duration", lambda: calls.append("duration"))
+        monkeypatch.setattr(h, "grant_declared_yolo", lambda: calls.append("grant"))
+        h.set_yolo_mode(True)
+        assert calls == ["duration", "grant"]
+
+    def test_disabled_only_applies_the_configured_duration(self, monkeypatch):
+        calls: list[str] = []
+        monkeypatch.setattr(h, "apply_config_duration", lambda: calls.append("duration"))
+        monkeypatch.setattr(h, "grant_declared_yolo", lambda: calls.append("grant"))
+        h.set_yolo_mode(False)
+        assert calls == ["duration"]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# agent-name resolution — project specs, path validation, bad JSON
+# ──────────────────────────────────────────────────────────────────────
+class TestResolveAgentName:
+    def test_project_spec_wins_over_user_level_agents(self, monkeypatch, tmp_path):
+        spec = tmp_path / "reviewer.agent-spec.json"
+        spec.write_text("{}", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(h, "_discover_project_agents", lambda _d: [spec])
+        monkeypatch.setattr(h, "project_agent_name", lambda p: "project-reviewer")
+        assert h._resolve_agent_name("reviewer", str(tmp_path)) == "project-reviewer"
+
+    def test_unsafe_agent_path_resolves_to_none(self, monkeypatch, tmp_path):
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "helper.json").write_text('{"name": "helper"}', encoding="utf-8", newline="\n")
+        monkeypatch.setattr(h, "_discover_project_agents", lambda _d: [])
+        monkeypatch.setattr(h, "kiro_agents_dir", lambda: agents)
+        monkeypatch.setattr(h, "validate_file_path", lambda _s: None)
+        assert h._resolve_agent_name("helper") is None
+
+    def test_unparseable_spec_falls_back_to_the_file_stem(self, monkeypatch, tmp_path):
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "helper.json").write_text("{not json", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(h, "_discover_project_agents", lambda _d: [])
+        monkeypatch.setattr(h, "kiro_agents_dir", lambda: agents)
+        monkeypatch.setattr(h, "validate_file_path", lambda s: s)
+        assert h._resolve_agent_name("helper") == "helper"
+
+
+class TestIterCcAgentNames:
+    def _cc_dir(self, tmp_path: Path) -> Path:
+        agents = tmp_path / "plugin" / "agents"
+        agents.mkdir(parents=True)
+        (agents / "one.md").write_text(
+            "---\nname: reviewer\n---\nbody\n", encoding="utf-8", newline="\n"
+        )
+        return tmp_path
+
+    def test_unreadable_spec_is_skipped(self, monkeypatch, tmp_path):
+        cc = self._cc_dir(tmp_path)
+        monkeypatch.setattr(h, "safe_read_file_bytes", lambda _p: None)
+        assert list(h._iter_cc_agent_names(cc)) == []
+
+    def test_reader_exception_is_swallowed(self, monkeypatch, tmp_path):
+        cc = self._cc_dir(tmp_path)
+
+        def _boom(_p):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(h, "safe_read_file_bytes", _boom)
+        assert list(h._iter_cc_agent_names(cc)) == []
+
+    def test_missing_directory_yields_nothing(self, tmp_path):
+        assert list(h._iter_cc_agent_names(tmp_path / "absent")) == []
+
+    def test_declared_name_is_yielded(self, tmp_path):
+        assert list(h._iter_cc_agent_names(self._cc_dir(tmp_path))) == ["reviewer"]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# !compact — every cosmetic/teardown failure arm
+# ──────────────────────────────────────────────────────────────────────
+def _provider(*, compact_raises: bool = False, result: str = "completed") -> MagicMock:
+    provider = MagicMock()
+    if compact_raises:
+        provider.compact = AsyncMock(side_effect=RuntimeError("transport closed"))
+    else:
+        provider.compact = AsyncMock(return_value=None)
+    summary = "boom" if result == "failed" else ""
+    provider.wait_for_compaction = AsyncMock(return_value={"type": result, "summary": summary})
+    return provider
+
+
+class TestCompactCommandFailureArms:
+    @pytest.mark.asyncio
+    async def test_pre_ui_failure_does_not_abort_compaction(self, sessions):
+        slack = FlakySlack("add_reaction")
+        sessions.get_provider = MagicMock(return_value=_provider())
+        await h._handle_compact_command(slack, sessions, "C1", "t1", "m1", "slack:t1")
+        assert "✅ Context compacted." in _texts(slack)
+        sessions.release.assert_called_once_with("slack:t1")
+
+    @pytest.mark.asyncio
+    async def test_compact_failure_tears_down_even_when_every_cleanup_fails(
+        self, sessions, monkeypatch
+    ):
+        slack = FlakySlack("post_message", "remove_reaction")
+        sessions.get_provider = MagicMock(return_value=_provider(compact_raises=True))
+        sessions.destroy = AsyncMock(side_effect=RuntimeError("registry locked"))
+        await h._handle_compact_command(slack, sessions, "C1", "t1", "m1", "slack:t1")
+        sessions.destroy.assert_awaited_once_with("slack:t1")
+        sessions.release.assert_called_once_with("slack:t1")
+
+    @pytest.mark.asyncio
+    async def test_reporting_and_audit_failures_are_swallowed(self, sessions, monkeypatch):
+        slack = FlakySlack("post_message", "remove_reaction")
+        sessions.get_provider = MagicMock(return_value=_provider())
+        monkeypatch.setattr(h, "sel", _raising_sel(method="log_tool_invocation"))
+        await h._handle_compact_command(slack, sessions, "C1", "t1", "m1", "slack:t1")
+        sessions.release.assert_called_once_with("slack:t1")
+
+    @pytest.mark.asyncio
+    async def test_failed_verdict_reports_the_backend_error(self, sessions):
+        slack = FlakySlack()
+        sessions.get_provider = MagicMock(return_value=_provider(result="failed"))
+        await h._handle_compact_command(slack, sessions, "C1", "t1", "m1", "slack:t1")
+        assert "Compaction failed: boom" in _texts(slack)
+
+    @pytest.mark.asyncio
+    async def test_unknown_verdict_reports_a_timeout(self, sessions):
+        slack = FlakySlack()
+        sessions.get_provider = MagicMock(return_value=_provider(result="pending"))
+        await h._handle_compact_command(slack, sessions, "C1", "t1", "m1", "slack:t1")
+        assert "Compaction timed out." in _texts(slack)
+
+    @pytest.mark.asyncio
+    async def test_busy_session_refuses_instead_of_destroying_it(self, sessions):
+        slack = FlakySlack()
+        sessions.try_acquire = AsyncMock(return_value=False)
+        sessions.has_session = MagicMock(return_value=True)
+        await h._handle_compact_command(slack, sessions, "C1", "t1", "m1", "slack:t1")
+        assert "Still working on your last message" in _texts(slack)
+        sessions.release.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_session_after_acquire(self, sessions):
+        slack = FlakySlack()
+        sessions.get_provider = MagicMock(return_value=None)
+        await h._handle_compact_command(slack, sessions, "C1", "t1", "m1", "slack:t1")
+        assert "No active session to compact." in _texts(slack)
+        sessions.release.assert_called_once_with("slack:t1")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# !unknown — the catch-all that must not fall through to the LLM
+# ──────────────────────────────────────────────────────────────────────
+class TestUnknownBangCommand:
+    @pytest.mark.asyncio
+    async def test_unknown_command_is_answered_not_forwarded(self, sessions, owner):
+        slack = FlakySlack()
+        reply = await h._handle_slash_command(
+            "!definitelynotacommand", slack, sessions, "C1", "t1", "m1", "slack:t1", owner
+        )
+        # "" (not None) is what stops handle_message forwarding to the agent.
+        assert reply == ""
+        assert "Unknown command" in _texts(slack)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# small command helpers — empty-argument early returns
+# ──────────────────────────────────────────────────────────────────────
+class TestCommandHelperEarlyReturns:
+    def test_spawn_with_no_task_declines(self):
+        manager = MagicMock()
+        assert h._do_spawn("", manager) is None
+        manager.spawn.assert_not_called()
+
+    def test_spawn_keyword_without_prefix_declines(self):
+        assert h._handle_spawn_command("summarize this", MagicMock()) is None
+
+    @pytest.mark.asyncio
+    async def test_task_run_with_no_argument_declines(self):
+        runner = MagicMock()
+        out = await h._handle_run_command("task run", runner, FlakySlack(), "C1", "t1")
+        assert out is None
+        out = await h._handle_run_command("task run   ", runner, FlakySlack(), "C1", "t1")
+        assert out is None
+
+    @pytest.mark.asyncio
+    async def test_task_run_missing_spec_file(self, tmp_path):
+        runner = MagicMock()
+        runner.running = False
+        missing = tmp_path / "no-such-spec.yaml"
+        out = await h._handle_run_command(
+            f"task run {missing}", runner, FlakySlack(), "C1", "t1"
+        )
+        assert out is not None and "Spec file not found" in out
+
+    @pytest.mark.asyncio
+    async def test_cron_command_needs_an_action(self):
+        cron = MagicMock()
+        assert await h._handle_cron_command("cron", cron, "C1", "t1") is None
+        assert await h._handle_cron_command("notcron list", cron, "C1", "t1") is None
+        assert await h._handle_cron_command("cron remove", cron, "C1", "t1") is None
+        assert await h._handle_cron_command("cron bogus job1", cron, "C1", "t1") is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# auto-title — manual-title race and conversation-log failure
+# ──────────────────────────────────────────────────────────────────────
+class _TitleClient:
+    """Minimal ACP client double that streams a one-chunk title."""
+
+    def __init__(self, title: str = "Deploy the gateway") -> None:
+        self._title = title
+
+    async def stream(self, _prompt):
+        yield LLMEvent(kind=h.EVENT_TEXT_CHUNK, text=self._title)
+        yield LLMEvent(kind=h.EVENT_COMPLETE)
+
+    async def reject_tool(self, _request_id):  # pragma: no cover - not reached here
+        return None
+
+
+@pytest.fixture()
+def title_sessions():
+    sm = MagicMock()
+    sm.get_or_create = AsyncMock(return_value=(_TitleClient(), None, None))
+    sm.release = MagicMock()
+    return sm
+
+
+class TestAutoTitle:
+    @pytest.mark.asyncio
+    async def test_manual_title_set_mid_stream_wins(self, title_sessions):
+        slack = FlakySlack()
+        h._titled_threads["slack:t1"] = "manual"
+        await h._maybe_auto_title_slack(
+            slack, title_sessions, "C1", "slack:t1", None, "hello", "hi there"
+        )
+        assert not [a for a in slack.actions if a[0] == "set_thread_title"]
+
+    @pytest.mark.asyncio
+    async def test_conversation_log_failure_still_titles_the_thread(self, title_sessions):
+        slack = FlakySlack()
+        log = MagicMock()
+        log.set_title = MagicMock(side_effect=RuntimeError("log locked"))
+        await h._maybe_auto_title_slack(
+            slack, title_sessions, "C1", "slack:t1", log, "hello", "hi there"
+        )
+        titled = [a for a in slack.actions if a[0] == "set_thread_title"]
+        assert titled and titled[0][1]["title"] == "Deploy the gateway"
+        # A log failure must not mark the thread untitled (no retry storm).
+        assert "slack:t1" not in h._titled_threads
+
+    @pytest.mark.asyncio
+    async def test_skip_verdict_allows_a_later_retry(self, title_sessions):
+        slack = FlakySlack()
+        title_sessions.get_or_create = AsyncMock(return_value=(_TitleClient("SKIP"), None, None))
+        h._titled_threads["slack:t1"] = "auto"
+        await h._maybe_auto_title_slack(
+            slack, title_sessions, "C1", "slack:t1", None, "hello", "hi"
+        )
+        assert "slack:t1" not in h._titled_threads
+        assert not [a for a in slack.actions if a[0] == "set_thread_title"]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# handle_message — early keyword dispatch and permission replies
+# ──────────────────────────────────────────────────────────────────────
+async def _msg(slack, sessions, text, *, user="U1", **kw):
+    await h.handle_message(slack, sessions, "C1", text, None, "m1", user, **kw)
+
+
+class TestHandleMessageKeywordDispatch:
+    @pytest.mark.asyncio
+    async def test_linked_thread_intercept_short_circuits(self, sessions, owner, monkeypatch):
+        slack = FlakySlack()
+        monkeypatch.setattr(h, "maybe_route_linked_thread", AsyncMock(return_value=True))
+        await _msg(slack, sessions, "anything at all")
+        assert slack.actions == []
+
+    # NOTE: the bare ``status`` keyword (handler.py:2642) is NOT covered here.
+    # ``handle_message`` re-imports ``current_context`` locally further down its
+    # own body (handler.py:3705), which makes the name local to the whole
+    # function, so the ``status`` branch raises ``UnboundLocalError`` before it
+    # can reply. Covering it would mean asserting the broken behaviour; the
+    # defect is reported instead.
+
+    @pytest.mark.asyncio
+    async def test_sessions_keyword_is_audited_and_rendered(self, sessions, owner, monkeypatch):
+        slack = FlakySlack()
+        called: dict = {}
+
+        async def _fake(cmd_text, _slack, channel, reply_ts, msg_ts, session_key, log,
+                        *, sessions=None):
+            called["session_key"] = session_key
+
+        monkeypatch.setattr(h, "_handle_sessions_command", _fake)
+        await _msg(slack, sessions, "sessions")
+        assert called["session_key"] == h.canonical_key("m1")
+
+    @pytest.mark.asyncio
+    async def test_sessions_keyword_denies_a_non_owner(self, sessions, owner, monkeypatch):
+        slack = FlakySlack()
+        monkeypatch.setattr(h, "_handle_sessions_command", AsyncMock())
+        await _msg(slack, sessions, "sessions", user="U999")
+        assert "Permission denied" in _texts(slack)
+        h._handle_sessions_command.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_compact_keyword_dispatches_for_the_owner(self, sessions, owner, monkeypatch):
+        slack = FlakySlack()
+        monkeypatch.setattr(h, "_handle_compact_command", AsyncMock())
+        await _msg(slack, sessions, "!compact")
+        h._handle_compact_command.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_compact_keyword_denied_for_a_stranger(self, sessions, owner, monkeypatch):
+        slack = FlakySlack()
+        monkeypatch.setattr(h, "_handle_compact_command", AsyncMock())
+        await _msg(slack, sessions, "!compact", user="U999")
+        assert "Not authorized to compact." in _texts(slack)
+        h._handle_compact_command.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_allowed_user_command_denied_for_a_stranger(self, sessions, owner, monkeypatch):
+        slack = FlakySlack()
+        monkeypatch.setattr(h, "_handle_slash_command", AsyncMock(return_value=""))
+        await _msg(slack, sessions, "!dashboard", user="U999")
+        assert "Not authorized." in _texts(slack)
+        h._handle_slash_command.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_owner_only_command_denied_for_a_stranger(self, sessions, owner, monkeypatch):
+        slack = FlakySlack()
+        monkeypatch.setattr(h, "_handle_slash_command", AsyncMock(return_value=""))
+        await _msg(slack, sessions, "!agent kirocrew", user="U999")
+        assert "Owner-only command." in _texts(slack)
+        h._handle_slash_command.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_mention_prefix_is_stripped_before_command_matching(
+        self, sessions, owner, monkeypatch
+    ):
+        slack = FlakySlack()
+        monkeypatch.setattr(h, "_handle_compact_command", AsyncMock())
+        await _msg(slack, sessions, "<@UBOT|kirocrew> !compact")
+        h._handle_compact_command.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_governance_denial_drops_the_message(self, sessions, owner, monkeypatch):
+        slack = FlakySlack()
+        monkeypatch.setattr(h, "channel_inbound_permitted", AsyncMock(return_value=False))
+        await _msg(slack, sessions, "status")
+        assert slack.actions == []
+
+    @pytest.mark.asyncio
+    async def test_hook_auto_reply_answers_without_touching_acp(self, sessions, owner):
+        slack = FlakySlack()
+        builder = MagicMock()
+        builder.hooks.on_message = MagicMock(
+            return_value=MagicMock(action=h.HOOK_REPLY, text="canned answer")
+        )
+        await _msg(slack, sessions, "ping", context_builder=builder)
+        assert "canned answer" in _texts(slack)
+        sessions.get_or_create.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _safe_update / _safe_final_update — Slack edit failures
+# ──────────────────────────────────────────────────────────────────────
+class TestSafeUpdates:
+    @pytest.mark.asyncio
+    async def test_safe_update_truncates_and_swallows_failure(self):
+        class _Boom(MockSlackClient):
+            async def update_message(self, channel, ts, text):
+                raise RuntimeError("message_not_found")
+
+        await h._safe_update(_Boom(), "C1", "1.0", "x" * (h.SLACK_MSG_LIMIT + 50))
+
+    @pytest.mark.asyncio
+    async def test_safe_final_update_swallows_both_edit_and_followup_failures(self):
+        slack = FlakySlack("post_message")
+
+        class _BoomUpdate(FlakySlack):
+            async def update_message(self, channel, ts, text):
+                raise RuntimeError("message_not_found")
+
+        boom = _BoomUpdate("post_message")
+        await h._safe_final_update(boom, "C1", "1.0", "y" * (h.SLACK_MSG_LIMIT * 2), "t1")
+        assert isinstance(slack, FlakySlack)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# agent listing — union across both sources, dedup, hidden variant
+# ──────────────────────────────────────────────────────────────────────
+class TestListAllAgentNames:
+    def test_union_dedups_and_hides_the_internal_variant(self, monkeypatch, tmp_path):
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        for stem in ("alpha", "shared", "kirocrew-lite"):
+            (agents / f"{stem}.json").write_text(
+                json.dumps({"name": stem}), encoding="utf-8", newline="\n"
+            )
+        monkeypatch.setattr(h, "kiro_agents_dir", lambda: agents)
+        monkeypatch.setattr(
+            h, "_iter_cc_agent_names", lambda _d=None: iter(["shared", "beta", "kirocrew-lite"])
+        )
+        out = h._list_all_agent_names()
+        names = [n.strip() for n in out.split(",")]
+        assert names == ["alpha", "shared", "beta"]
+
+    def test_empty_sources_report_none_found(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(h, "kiro_agents_dir", lambda: tmp_path / "absent")
+        monkeypatch.setattr(h, "_iter_cc_agent_names", lambda _d=None: iter([]))
+        assert h._list_all_agent_names() == "(none found)"

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -1,0 +1,1842 @@
+"""Coverage tests for ``kiro_crew.subagent`` helpers and manager bookkeeping.
+
+Focused on the module-level probes (memory / CPU / cgroup readers, env
+parsing, agent + governance vetting) and the ``SubagentManager`` bookkeeping
+surfaces — slot accounting, queue depth, wave submission reconciliation,
+digest-hold release, continuable-conversation retention — none of which need a
+real agent process. Every process boundary is stubbed: no test here launches a
+binary, opens a socket, or writes outside ``tmp_path`` / the autouse isolated
+``KIROCREW_HOME``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+
+import pytest
+
+from kiro_crew import subagent as sa
+from kiro_crew.subagent import SubagentInfo, SubagentManager
+
+# ── Fixtures / builders ───────────────────────────────────────────────────
+
+
+def _sessions() -> MagicMock:
+    """A SessionManager double with the seams this module touches."""
+    sessions = MagicMock()
+    sessions.get_pid = MagicMock(return_value=None)
+    sessions.get_provider = MagicMock(return_value=None)
+    sessions.mark_continuable = MagicMock()
+    sessions.forget_conversation = MagicMock(return_value="")
+    sessions.conversation_provider = MagicMock(return_value="acp")
+    sessions.is_session_sharing_eligible = MagicMock(return_value=True)
+    sessions.release = MagicMock()
+    sessions.reset = AsyncMock()
+    return sessions
+
+
+def _manager(**kwargs: object) -> SubagentManager:
+    """Build a manager with every callback off unless a test wires one."""
+    kwargs.setdefault("sessions", _sessions())
+    kwargs.setdefault("ctx_builder", None)
+    return SubagentManager(**kwargs)  # type: ignore[arg-type]
+
+
+def _info(agent_id: str = "a1", **kwargs: object) -> SubagentInfo:
+    kwargs.setdefault("task", "t")
+    return SubagentInfo(id=agent_id, **kwargs)  # type: ignore[arg-type]
+
+
+# ── _safe_fire ────────────────────────────────────────────────────────────
+
+
+class TestSafeFire:
+    @pytest.mark.asyncio
+    async def test_runs_coroutine_and_drops_ref(self) -> None:
+        seen: list[str] = []
+
+        async def _work() -> None:
+            seen.append("ran")
+
+        sa._safe_fire(_work())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert seen == ["ran"]
+
+    @pytest.mark.asyncio
+    async def test_swallows_exception(self) -> None:
+        async def _boom() -> None:
+            raise RuntimeError("nope")
+
+        sa._safe_fire(_boom())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        # Reaching here without an unretrieved-exception crash is the assertion.
+        assert True
+
+
+# ── _validate_agent ───────────────────────────────────────────────────────
+
+
+class TestValidateAgent:
+    def test_empty_request_is_the_default(self) -> None:
+        assert sa._validate_agent("") == ("", "")
+
+    def test_known_user_agent_accepted(self) -> None:
+        with patch.object(sa, "list_agents", return_value=[SimpleNamespace(name="scout")]):
+            assert sa._validate_agent("scout") == ("scout", "")
+
+    def test_unknown_agent_refused_not_defaulted(self) -> None:
+        with patch.object(sa, "list_agents", return_value=[SimpleNamespace(name="scout")]):
+            name, err = sa._validate_agent("typo")
+        assert name == ""
+        assert "not found" in err
+
+    def test_project_scope_widens_known_set(self, tmp_path: Path) -> None:
+        with (
+            patch.object(sa, "list_agents", return_value=[]),
+            patch.object(sa, "cached_project_agent_names", return_value=frozenset({"local"})),
+        ):
+            assert sa._validate_agent("local", str(tmp_path)) == ("local", "")
+
+    def test_project_scope_cold_cache_refuses(self, tmp_path: Path) -> None:
+        with (
+            patch.object(sa, "list_agents", return_value=[]),
+            patch.object(sa, "cached_project_agent_names", return_value=None),
+        ):
+            name, err = sa._validate_agent("local", str(tmp_path))
+        assert (name, "not found" in err) == ("", True)
+
+
+# ── _vet_spawn_governance ─────────────────────────────────────────────────
+
+
+def _verdict(permitted: bool, reason: str = "") -> SimpleNamespace:
+    return SimpleNamespace(permitted=permitted, reason=reason)
+
+
+class TestVetSpawnGovernance:
+    def test_permitted_returns_none(self) -> None:
+        with patch(
+            "kiro_crew.platform.governance_profiles.governance_permits",
+            return_value=_verdict(True),
+        ):
+            assert sa._vet_spawn_governance("dash:1", "scout") is None
+
+    def test_capability_disabled_returns_reason(self) -> None:
+        with patch(
+            "kiro_crew.platform.governance_profiles.governance_permits",
+            return_value=_verdict(False, "spawn off for this app"),
+        ):
+            assert sa._vet_spawn_governance("dash:1", "", app="notes") == "spawn off for this app"
+
+    def test_agent_scope_denied(self) -> None:
+        calls: list[str] = []
+
+        def _permits(_scope: str, item: str = "", **_kw: object) -> SimpleNamespace:
+            calls.append(item)
+            return _verdict(not item.startswith("agents:"))
+
+        with patch(
+            "kiro_crew.platform.governance_profiles.governance_permits", side_effect=_permits
+        ):
+            reason = sa._vet_spawn_governance("dash:1", "scout")
+        assert reason == "agent 'scout' not permitted by spawn policy"
+        assert "agents:scout" in calls
+
+    def test_composition_error_propagates(self) -> None:
+        from kiro_crew.platform.context import PlatformCompositionError
+
+        with patch(
+            "kiro_crew.platform.governance_profiles.governance_permits",
+            side_effect=PlatformCompositionError("bad platform"),
+        ):
+            with pytest.raises(PlatformCompositionError):
+                sa._vet_spawn_governance("dash:1", "scout")
+
+    def test_other_error_fails_closed_and_audits(self) -> None:
+        audit = MagicMock()
+        with (
+            patch(
+                "kiro_crew.platform.governance_profiles.governance_permits",
+                side_effect=RuntimeError("store down"),
+            ),
+            patch(
+                "kiro_crew.platform.governance_profiles.audit_governance_degraded",
+                audit,
+            ),
+        ):
+            reason = sa._vet_spawn_governance("dash:1", "scout")
+        assert reason is not None
+        assert "fail-closed" in reason
+        assert audit.call_count == 1
+
+    def test_audit_failure_still_fails_closed(self) -> None:
+        with (
+            patch(
+                "kiro_crew.platform.governance_profiles.governance_permits",
+                side_effect=RuntimeError("store down"),
+            ),
+            patch(
+                "kiro_crew.platform.governance_profiles.audit_governance_degraded",
+                side_effect=RuntimeError("audit down"),
+            ),
+        ):
+            assert sa._vet_spawn_governance("dash:1", "scout") is not None
+
+
+# ── _done_result / _timeout_context ───────────────────────────────────────
+
+
+class TestDoneResult:
+    def test_empty_stays_empty(self) -> None:
+        assert sa._done_result("") == ""
+
+    def test_short_text_passes_through(self) -> None:
+        assert sa._done_result("all good") == "all good"
+
+    def test_oversize_truncates_from_the_head(self) -> None:
+        out = sa._done_result("x" * (sa._MAX_DONE_RESULT_LEN + 500))
+        assert out.startswith("…(truncated)\n")
+        assert len(out) == sa._MAX_DONE_RESULT_LEN + len("…(truncated)\n")
+
+
+class TestTimeoutContext:
+    def test_includes_turn_tool_and_elapsed(self) -> None:
+        info = _info(turns=3, max_turns=10, last_tool="read", elapsed=42.0)
+        out = sa._timeout_context(info)
+        assert "turn 3/10" in out
+        assert "last tool: read" in out
+        assert "elapsed: 42s" in out
+
+    def test_elapsed_omitted_when_requested(self) -> None:
+        info = _info(turns=1, max_turns=5)
+        out = sa._timeout_context(info, include_elapsed=False)
+        assert "elapsed" not in out
+        assert "last tool" not in out
+
+    def test_elapsed_falls_back_to_wall_clock(self) -> None:
+        info = _info(turns=1, max_turns=5, started=0.0)
+        assert "elapsed:" in sa._timeout_context(info)
+
+
+# ── env parsing ───────────────────────────────────────────────────────────
+
+
+class TestEnvFloat:
+    def test_absent_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KIROCREW_TEST_FLOAT", raising=False)
+        assert sa._env_float("KIROCREW_TEST_FLOAT", 7.5) == 7.5
+
+    def test_valid_value_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KIROCREW_TEST_FLOAT", "12.25")
+        assert sa._env_float("KIROCREW_TEST_FLOAT", 7.5) == 12.25
+
+    @pytest.mark.parametrize("raw", ["0", "-3", "abc"])
+    def test_invalid_or_nonpositive_falls_back(
+        self, raw: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KIROCREW_TEST_FLOAT", raw)
+        assert sa._env_float("KIROCREW_TEST_FLOAT", 7.5) == 7.5
+
+
+class TestResolveInjectionTimeout:
+    def test_clamped_to_outer_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KIROCREW_INJECTION_TIMEOUT", str(sa._ON_DONE_TIMEOUT * 10))
+        assert sa._resolve_injection_timeout() == sa._ON_DONE_TIMEOUT
+
+    def test_below_cap_kept(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KIROCREW_INJECTION_TIMEOUT", "60")
+        assert sa._resolve_injection_timeout() == 60.0
+
+
+class TestSubagentRolePins:
+    def test_model_pin_returns_normalized_value(self) -> None:
+        cfg = MagicMock()
+        cfg.agent.role_models = {"subagent": " sonnet "}
+        with (
+            patch("kiro_crew.config.loader.KiroCrewConfig.load", return_value=cfg),
+            patch("kiro_crew.config.loader.normalize_agent_model", side_effect=str.strip),
+        ):
+            assert sa._subagent_default_model() == "sonnet"
+
+    def test_model_pin_never_raises(self) -> None:
+        with patch(
+            "kiro_crew.config.loader.KiroCrewConfig.load", side_effect=RuntimeError("no config")
+        ):
+            assert sa._subagent_default_model() == ""
+
+    def test_effort_pin_returns_string(self) -> None:
+        cfg = MagicMock()
+        cfg.agent.role_efforts = {"subagent": "high"}
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load", return_value=cfg):
+            assert sa._subagent_default_effort() == "high"
+
+    def test_effort_pin_rejects_non_string(self) -> None:
+        cfg = MagicMock()
+        cfg.agent.role_efforts = {"subagent": 3}
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load", return_value=cfg):
+            assert sa._subagent_default_effort() == ""
+
+    def test_effort_pin_never_raises(self) -> None:
+        with patch(
+            "kiro_crew.config.loader.KiroCrewConfig.load", side_effect=RuntimeError("no config")
+        ):
+            assert sa._subagent_default_effort() == ""
+
+
+class TestDigestHoldSecs:
+    def test_absent_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KIROCREW_SUBAGENT_DIGEST_HOLD_SECS", raising=False)
+        assert sa._digest_hold_secs() == sa._DEFAULT_DIGEST_HOLD_SECS
+
+    def test_nan_is_malformed_not_a_deadline(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KIROCREW_SUBAGENT_DIGEST_HOLD_SECS", "nan")
+        val = sa._digest_hold_secs()
+        assert not math.isnan(val)
+        assert val == sa._DEFAULT_DIGEST_HOLD_SECS
+
+    @pytest.mark.parametrize("raw", ["0", "-1"])
+    def test_nonpositive_opts_out(self, raw: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KIROCREW_SUBAGENT_DIGEST_HOLD_SECS", raw)
+        assert sa._digest_hold_secs() == 0.0
+
+    def test_clamped_to_hard_deadline(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KIROCREW_SUBAGENT_DIGEST_HOLD_SECS", str(sa._TIMEOUT_SECS * 5))
+        assert sa._digest_hold_secs() == float(sa._TIMEOUT_SECS)
+
+    def test_valid_value_kept(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KIROCREW_SUBAGENT_DIGEST_HOLD_SECS", "45")
+        assert sa._digest_hold_secs() == 45.0
+
+
+# ── memory probes ─────────────────────────────────────────────────────────
+
+
+class TestCheckMemoryAvailable:
+    def test_parses_mem_available(self) -> None:
+        text = "MemTotal:       1000 kB\nMemAvailable:    8388608 kB\n"
+        with patch.object(sa, "safe_read_file", return_value=text):
+            ok, gb = sa.check_memory_available(min_gb=4.0)
+        assert ok is True
+        assert gb == 8.0
+
+    def test_below_threshold_reports_not_ok(self) -> None:
+        text = "MemAvailable:    1048576 kB\n"
+        with patch.object(sa, "safe_read_file", return_value=text):
+            ok, gb = sa.check_memory_available(min_gb=4.0)
+        assert (ok, gb) == (False, 1.0)
+
+    def test_sensitive_path_fails_open(self) -> None:
+        with patch.object(sa, "safe_read_file", side_effect=PermissionError):
+            assert sa.check_memory_available() == (True, -1.0)
+
+    def test_read_error_fails_open(self) -> None:
+        with patch.object(sa, "safe_read_file", side_effect=OSError):
+            assert sa.check_memory_available() == (True, -1.0)
+
+    def test_malformed_line_fails_open(self) -> None:
+        with patch.object(sa, "safe_read_file", return_value="MemAvailable:  notanumber kB\n"):
+            assert sa.check_memory_available() == (True, -1.0)
+
+    def test_missing_key_fails_open(self) -> None:
+        with patch.object(sa, "safe_read_file", return_value="MemTotal: 12 kB\n"):
+            assert sa.check_memory_available() == (True, -1.0)
+
+
+class TestProcRssReaders:
+    def test_single_proc_parses_vmrss(self) -> None:
+        with patch("builtins.open", mock_open(read_data="Name:\tx\nVmRSS:\t 2048 kB\n")):
+            assert sa._single_proc_rss_kb(1234) == 2048
+
+    def test_single_proc_missing_returns_minus_one(self) -> None:
+        with patch("builtins.open", side_effect=OSError):
+            assert sa._single_proc_rss_kb(1234) == -1
+
+    def test_children_listing_unavailable(self) -> None:
+        with patch.object(os, "listdir", side_effect=OSError):
+            assert sa._proc_children(1234) == []
+
+    def test_children_parsed_per_thread(self) -> None:
+        with (
+            patch.object(os, "listdir", return_value=["1234"]),
+            patch("builtins.open", mock_open(read_data="11 12 13")),
+        ):
+            assert sa._proc_children(1234) == [11, 12, 13]
+
+    def test_children_garbage_skipped(self) -> None:
+        with (
+            patch.object(os, "listdir", return_value=["1234"]),
+            patch("builtins.open", mock_open(read_data="not-a-pid")),
+        ):
+            assert sa._proc_children(1234) == []
+
+    def test_subtree_rss_falsy_pid(self) -> None:
+        assert sa._proc_rss_kb(None) == -1
+        assert sa._proc_rss_kb(0) == -1
+
+    def test_subtree_rss_unreadable_parent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa, "_single_proc_rss_kb", lambda _pid: -1)
+        assert sa._proc_rss_kb(99) == -1
+
+    def test_subtree_rss_sums_descendants(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        tree = {1: [2, 3], 2: [4], 3: [], 4: []}
+        monkeypatch.setattr(sa, "_single_proc_rss_kb", lambda pid: 100 * pid)
+        monkeypatch.setattr(sa, "_proc_children", lambda pid: tree.get(pid, []))
+        assert sa._proc_rss_kb(1) == 100 + 200 + 300 + 400
+
+    def test_subtree_rss_ignores_cycles_and_dead_children(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sa, "_single_proc_rss_kb", lambda pid: 100 if pid == 1 else -1)
+        monkeypatch.setattr(sa, "_proc_children", lambda pid: [1, 2] if pid == 1 else [])
+        assert sa._proc_rss_kb(1) == 100
+
+
+class TestReadIntFile:
+    def test_reads_integer(self, tmp_path: Path) -> None:
+        path = tmp_path / "n"
+        path.write_text("4096\n", newline="\n")
+        assert sa._read_int_file(str(path)) == 4096
+
+    def test_max_sentinel_is_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "m"
+        path.write_text("max", newline="\n")
+        assert sa._read_int_file(str(path)) is None
+
+    def test_missing_file_is_none(self, tmp_path: Path) -> None:
+        assert sa._read_int_file(str(tmp_path / "absent")) is None
+
+    def test_garbage_is_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "g"
+        path.write_text("banana", newline="\n")
+        assert sa._read_int_file(str(path)) is None
+
+
+class TestCgroupAvailable:
+    def _reader(self, values: dict[str, int | None]):
+        return lambda path: values.get(path)
+
+    def test_v2_unlimited_sentinel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            sa,
+            "_read_int_file",
+            self._reader({"/sys/fs/cgroup/memory.max": sa._CGROUP_UNLIMITED}),
+        )
+        assert sa._cgroup_available_gb() == -1.0
+
+    def test_v2_headroom(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        gib = 1024**3
+        monkeypatch.setattr(
+            sa,
+            "_read_int_file",
+            self._reader(
+                {
+                    "/sys/fs/cgroup/memory.max": 8 * gib,
+                    "/sys/fs/cgroup/memory.current": 2 * gib,
+                }
+            ),
+        )
+        assert sa._cgroup_available_gb() == pytest.approx(6.0)
+
+    def test_v1_headroom(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        gib = 1024**3
+        monkeypatch.setattr(
+            sa,
+            "_read_int_file",
+            self._reader(
+                {
+                    "/sys/fs/cgroup/memory/memory.limit_in_bytes": 4 * gib,
+                    "/sys/fs/cgroup/memory/memory.usage_in_bytes": 1 * gib,
+                }
+            ),
+        )
+        assert sa._cgroup_available_gb() == pytest.approx(3.0)
+
+    def test_v1_unlimited_sentinel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            sa,
+            "_read_int_file",
+            self._reader({"/sys/fs/cgroup/memory/memory.limit_in_bytes": sa._CGROUP_UNLIMITED}),
+        )
+        assert sa._cgroup_available_gb() == -1.0
+
+    def test_no_controller(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa, "_read_int_file", self._reader({}))
+        assert sa._cgroup_available_gb() == -1.0
+
+    def test_usage_absent_treated_as_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        gib = 1024**3
+        monkeypatch.setattr(
+            sa, "_read_int_file", self._reader({"/sys/fs/cgroup/memory.max": 2 * gib})
+        )
+        assert sa._cgroup_available_gb() == pytest.approx(2.0)
+
+
+class TestAvailableMemoryGb:
+    def test_linux_clamped_by_cgroup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa.platform_compat, "IS_LINUX", True, raising=False)
+        monkeypatch.setattr(sa.platform_compat, "IS_MACOS", False, raising=False)
+        monkeypatch.setattr(sa, "check_memory_available", lambda min_gb=0.0: (True, 16.0))
+        monkeypatch.setattr(sa, "_cgroup_available_gb", lambda: 4.0)
+        assert sa._available_memory_gb() == 4.0
+
+    def test_linux_without_cgroup_uses_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa.platform_compat, "IS_LINUX", True, raising=False)
+        monkeypatch.setattr(sa.platform_compat, "IS_MACOS", False, raising=False)
+        monkeypatch.setattr(sa, "check_memory_available", lambda min_gb=0.0: (True, 9.0))
+        monkeypatch.setattr(sa, "_cgroup_available_gb", lambda: -1.0)
+        assert sa._available_memory_gb() == 9.0
+
+    def test_linux_unreadable_propagates_sentinel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa.platform_compat, "IS_LINUX", True, raising=False)
+        monkeypatch.setattr(sa.platform_compat, "IS_MACOS", False, raising=False)
+        monkeypatch.setattr(sa, "check_memory_available", lambda min_gb=0.0: (True, -1.0))
+        assert sa._available_memory_gb() == -1.0
+
+    def test_macos_branch_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa.platform_compat, "IS_LINUX", False, raising=False)
+        monkeypatch.setattr(sa.platform_compat, "IS_MACOS", True, raising=False)
+        monkeypatch.setattr(sa, "_macos_available_memory_gb", lambda: 3.5)
+        assert sa._available_memory_gb() == 3.5
+
+    def test_unsupported_platform_fails_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa.platform_compat, "IS_LINUX", False, raising=False)
+        monkeypatch.setattr(sa.platform_compat, "IS_MACOS", False, raising=False)
+        assert sa._available_memory_gb() == -1.0
+
+
+class TestMacosAvailableMemory:
+    """Windows has no ``os.sysconf`` at all, so every patch here is
+    ``raising=False`` — the probe's own ``hasattr`` guard is what CI exercises."""
+
+    def test_page_size_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            os, "sysconf", lambda _name: (_ for _ in ()).throw(ValueError), raising=False
+        )
+        assert sa._macos_available_memory_gb() == -1.0
+
+    def test_nonpositive_page_size(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(os, "sysconf", lambda _name: 0, raising=False)
+        assert sa._macos_available_memory_gb() == -1.0
+
+    def test_no_reclaimable_pages(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(os, "sysconf", lambda _name: 4096, raising=False)
+        monkeypatch.setattr(sa, "_macos_vm_reclaimable_pages", lambda: None)
+        assert sa._macos_available_memory_gb() == -1.0
+
+    def test_zero_pages_fails_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(os, "sysconf", lambda _name: 4096, raising=False)
+        monkeypatch.setattr(sa, "_macos_vm_reclaimable_pages", lambda: 0)
+        assert sa._macos_available_memory_gb() == -1.0
+
+    def test_computes_gb_from_pages(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(os, "sysconf", lambda _name: 4096, raising=False)
+        monkeypatch.setattr(sa, "_macos_vm_reclaimable_pages", lambda: 262144)
+        assert sa._macos_available_memory_gb() == pytest.approx(1.0)
+
+
+# ── CPU probes ────────────────────────────────────────────────────────────
+
+
+class TestCpuJiffies:
+    def test_parses_utime_plus_stime(self) -> None:
+        fields = " ".join(str(i) for i in range(3, 30))
+        raw = f"42 (weird name (x)) S {fields}".encode("ascii")
+        # After the final ')' the tokens start at 'S'; utime/stime are indices 11/12.
+        tokens = raw[raw.rindex(b")") + 2 :].split()
+        expected = int(tokens[11]) + int(tokens[12])
+        assert sa._parse_cpu_jiffies(raw) == expected
+
+    @pytest.mark.parametrize("raw", [b"", b"no-parens-here", b"1 (x) S 1 2 3"])
+    def test_malformed_returns_zero(self, raw: bytes) -> None:
+        assert sa._parse_cpu_jiffies(raw) == 0
+
+    def test_proc_cpu_jiffies_missing_pid(self) -> None:
+        with patch("builtins.open", side_effect=OSError):
+            assert sa._proc_cpu_jiffies(1234) == 0
+
+    def test_proc_cpu_jiffies_reads_stat(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa, "_parse_cpu_jiffies", lambda _raw: 77)
+        with patch("builtins.open", mock_open(read_data=b"whatever")):
+            assert sa._proc_cpu_jiffies(1234) == 77
+
+    def test_subtree_sums_descendants(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        tree = {1: [2], 2: [3], 3: []}
+        monkeypatch.setattr(sa, "_proc_cpu_jiffies", lambda pid: pid * 10)
+        monkeypatch.setattr(sa, "_proc_children", lambda pid: tree.get(pid, []))
+        assert sa._subtree_cpu_jiffies(1) == 10 + 20 + 30
+
+    def test_subtree_skips_already_seen(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa, "_proc_cpu_jiffies", lambda pid: 5)
+        monkeypatch.setattr(sa, "_proc_children", lambda pid: [1] if pid == 1 else [])
+        assert sa._subtree_cpu_jiffies(1) == 5
+
+
+# ── validate_cwd / resolve_max_subagents ──────────────────────────────────
+
+
+class TestValidateCwdEdges:
+    def test_resolution_failure_reported(self, tmp_path: Path) -> None:
+        with patch.object(os.path, "realpath", side_effect=OSError("boom")):
+            resolved, err = sa.validate_cwd(str(tmp_path), [str(tmp_path)])
+        assert resolved == ""
+        assert "cwd resolution failed" in err
+
+    def test_realpath_agreement_on_both_sides(self, tmp_path: Path) -> None:
+        # realpath BOTH sides: on Windows tmp_path is the 8.3 short form while
+        # validate_cwd returns the long form, so a raw compare passes only on POSIX.
+        resolved, err = sa.validate_cwd(str(tmp_path), [str(tmp_path)])
+        assert err == ""
+        assert os.path.realpath(resolved) == os.path.realpath(str(tmp_path))
+
+
+class TestResolveMaxSubagents:
+    def test_broken_config_falls_back_to_legacy(self) -> None:
+        cfg = SimpleNamespace(agent=SimpleNamespace())
+        assert sa.resolve_max_subagents(cfg) == sa._LEGACY_DEFAULT_MAX  # type: ignore[arg-type]
+
+    def test_non_numeric_pin_falls_back(self) -> None:
+        cfg = SimpleNamespace(agent=SimpleNamespace(max_subagents="lots"))
+        assert sa.resolve_max_subagents(cfg) == sa._LEGACY_DEFAULT_MAX  # type: ignore[arg-type]
+
+
+# ── SubagentInfo surface ──────────────────────────────────────────────────
+
+
+class TestOutcome:
+    def test_user_stop_is_neutral(self) -> None:
+        assert _info(user_stopped=True, error="ignored").outcome == "stopped"
+
+    def test_error_is_failed(self) -> None:
+        assert _info(error="boom").outcome == "failed"
+
+    def test_clean_is_completed(self) -> None:
+        assert _info().outcome == "completed"
+
+
+class TestContextGroups:
+    def test_all_groups_on(self) -> None:
+        groups = sa._context_groups_of(_info())
+        assert groups == frozenset(
+            {sa.CONTEXT_GROUP_MEMORY, sa.CONTEXT_GROUP_LESSONS, sa.CONTEXT_GROUP_PROJECT}
+        )
+
+    def test_withheld_group_absent(self) -> None:
+        info = _info(include_memory=False)
+        assert sa.CONTEXT_GROUP_MEMORY not in sa._context_groups_of(info)
+
+    def test_field_is_sorted_and_comma_joined(self) -> None:
+        field = sa._context_groups_field(_info(include_project=False))
+        assert field == ",".join(sorted(field.split(",")))
+        assert sa.CONTEXT_GROUP_PROJECT not in field.split(",")
+
+    def test_all_withheld_is_empty_string(self) -> None:
+        info = _info(include_memory=False, include_lessons=False, include_project=False)
+        assert sa._context_groups_field(info) == ""
+
+
+# ── Manager: slot + finalize tokens ───────────────────────────────────────
+
+
+class TestSlotAndFinalizeTokens:
+    def test_slot_released_exactly_once(self) -> None:
+        mgr = _manager()
+        info = _info()
+        assert mgr._release_slot(info) is True
+        assert mgr._release_slot(info) is False
+
+    def test_finalize_claimed_exactly_once(self) -> None:
+        mgr = _manager()
+        info = _info()
+        assert mgr._claim_finalize(info) is True
+        assert mgr._claim_finalize(info) is False
+
+    def test_recovering_withholds_the_claim(self) -> None:
+        mgr = _manager()
+        info = _info()
+        info._recovering = True
+        assert mgr._claim_finalize(info) is False
+        assert info._finalized is False
+
+    def test_supersede_recovery_takes_claim_and_clears_flag(self) -> None:
+        mgr = _manager()
+        info = _info()
+        info._recovering = True
+        assert mgr._claim_finalize(info, supersede_recovery=True) is True
+        assert info._recovering is False
+
+
+class TestCompletionKeepSetter:
+    def test_updates_live_values(self) -> None:
+        mgr = _manager()
+        mgr.update_completion_keep("tail", 1234)
+        assert (mgr._completion_keep, mgr._completion_keep_chars) == ("tail", 1234)
+
+
+class TestApprovalLogging:
+    @pytest.mark.asyncio
+    async def test_approve_logs_auto_when_reason_present(self) -> None:
+        client = AsyncMock()
+        event = SimpleNamespace(title="read", tool_kind="fs")
+        with patch.object(sa, "sel") as sel_mock:
+            await SubagentManager._approve_and_log(
+                client, "req-1", "subagent:a1", event, metadata={"reason": "allowlisted"}
+            )
+        client.approve_tool.assert_awaited_once_with("req-1")
+        assert sel_mock().log_tool_invocation.call_args.kwargs["outcome"] == "auto_approved"
+
+    @pytest.mark.asyncio
+    async def test_approve_logs_plain_without_reason(self) -> None:
+        client = AsyncMock()
+        event = SimpleNamespace(title="read", tool_kind="fs")
+        with patch.object(sa, "sel") as sel_mock:
+            await SubagentManager._approve_and_log(client, 2, "subagent:a1", event)
+        assert sel_mock().log_tool_invocation.call_args.kwargs["outcome"] == "approved"
+
+    @pytest.mark.asyncio
+    async def test_reject_logs_denied_with_error(self) -> None:
+        client = AsyncMock()
+        event = SimpleNamespace(title="write", tool_kind="fs")
+        with patch.object(sa, "sel") as sel_mock:
+            await SubagentManager._reject_and_log(
+                client, 3, "subagent:a1", event, error="policy denied"
+            )
+        client.reject_tool.assert_awaited_once_with(3)
+        assert sel_mock().log_tool_invocation.call_args.kwargs["outcome"] == "denied"
+
+    @pytest.mark.asyncio
+    async def test_reject_logs_rejected_without_error(self) -> None:
+        client = AsyncMock()
+        event = SimpleNamespace(title="write", tool_kind="fs")
+        with patch.object(sa, "sel") as sel_mock:
+            await SubagentManager._reject_and_log(client, 4, "subagent:a1", event)
+        assert sel_mock().log_tool_invocation.call_args.kwargs["outcome"] == "rejected"
+
+
+# ── Manager: orphan / pid helpers ─────────────────────────────────────────
+
+
+class TestPidHelpers:
+    def test_is_pid_alive_delegates_to_platform(self) -> None:
+        with patch.object(sa.platform_compat, "pid_exists", return_value=True) as probe:
+            assert SubagentManager._is_pid_alive(4242) is True
+        probe.assert_called_once_with(4242)
+
+    def test_orphan_check_false_for_missing_proc(self) -> None:
+        with patch.object(os, "stat", side_effect=FileNotFoundError):
+            assert SubagentManager._is_orphan_process(4242, 100.0) is False
+
+    def test_orphan_check_true_when_created_before_spawn(self) -> None:
+        with patch.object(os, "stat", return_value=SimpleNamespace(st_ctime=99.0)):
+            assert SubagentManager._is_orphan_process(4242, 100.0) is True
+
+    def test_orphan_check_false_for_recycled_pid(self) -> None:
+        with patch.object(os, "stat", return_value=SimpleNamespace(st_ctime=500.0)):
+            assert SubagentManager._is_orphan_process(4242, 100.0) is False
+
+    def test_kill_orphan_swallows_missing_process(self) -> None:
+        with patch.object(sa.platform_compat, "kill_pid", side_effect=ProcessLookupError):
+            SubagentManager._kill_orphan_pid(4242)  # must not raise
+
+    def test_kill_orphan_calls_platform_kill(self) -> None:
+        with patch.object(sa.platform_compat, "kill_pid") as kill:
+            SubagentManager._kill_orphan_pid(4242)
+        assert kill.call_args[0][0] == 4242
+
+
+class TestLiveSharedCount:
+    def test_no_pid_counts_as_one(self) -> None:
+        assert _manager()._live_shared_count(None) == 1
+
+    def test_counts_live_sharers_on_the_same_pid(self) -> None:
+        mgr = _manager()
+        for idx in range(3):
+            info = _info(f"s{idx}")
+            info._session_sharing = True
+            info._pid = 777
+            mgr._agents[info.id] = info
+        dead = _info("dead", done=True)
+        dead._session_sharing = True
+        dead._pid = 777
+        mgr._agents["dead"] = dead
+        assert mgr._live_shared_count(777) == 3
+
+    def test_unknown_pid_floors_at_one(self) -> None:
+        assert _manager()._live_shared_count(31337) == 1
+
+
+class TestRecordCost:
+    def test_unsampled_run_records_nothing(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "append_cost_sample") as append:
+            mgr._record_cost(_info())
+        append.assert_not_called()
+
+    def test_sampled_run_appends(self) -> None:
+        mgr = _manager()
+        info = _info(agent="scout")
+        info.peak_rss_gb = 1.5
+        info.peak_cpu_cores = 0.75
+        with patch.object(sa, "append_cost_sample") as append:
+            mgr._record_cost(info)
+        append.assert_called_once_with("scout", 1.5, 0.75)
+
+    def test_store_failure_is_swallowed(self) -> None:
+        mgr = _manager()
+        info = _info()
+        info.peak_rss_gb = 1.0
+        with patch.object(sa, "append_cost_sample", side_effect=OSError):
+            mgr._record_cost(info)  # must not raise
+
+
+class TestSlowCommandRecord:
+    def test_records_redacted_fields(self) -> None:
+        info = _info(last_tool="read /tmp/x", tool_count=4, turns=2)
+        with patch.object(sa, "record_slow_command") as rec:
+            SubagentManager._record_slow_command(info, 300.0)
+        assert rec.call_args.kwargs["idle_secs"] == 300
+
+    def test_write_failure_is_swallowed(self) -> None:
+        with patch.object(sa, "record_slow_command", side_effect=OSError):
+            SubagentManager._record_slow_command(_info(), 1.0)  # must not raise
+
+
+class TestWriteTombstone:
+    def test_failure_is_swallowed(self) -> None:
+        with patch.object(sa, "write_tombstone", side_effect=OSError):
+            SubagentManager._write_tombstone(_info(), "reaped")  # must not raise
+
+    def test_passes_outcome_through(self) -> None:
+        with patch.object(sa, "write_tombstone") as write:
+            SubagentManager._write_tombstone(_info(user_stopped=True), "user_stop")
+        assert write.call_args.kwargs["outcome"] == "stopped"
+
+
+# ── Manager: stall detection ──────────────────────────────────────────────
+
+
+class TestStartupStall:
+    def test_not_yet_executing_is_never_stalled(self) -> None:
+        mgr = _manager(startup_timeout=10)
+        assert mgr._is_startup_stalled(_info(), now=1e9) is False
+
+    def test_runtimeless_past_deadline_is_stalled(self) -> None:
+        mgr = _manager(startup_timeout=10)
+        info = _info()
+        info._exec_started = 100.0
+        assert mgr._is_startup_stalled(info, now=200.0) is True
+
+    def test_agent_with_pid_is_not_stalled(self) -> None:
+        mgr = _manager(startup_timeout=10)
+        info = _info()
+        info._exec_started = 100.0
+        info._pid = 5
+        assert mgr._is_startup_stalled(info, now=200.0) is False
+
+    def test_agent_with_a_turn_is_not_stalled(self) -> None:
+        mgr = _manager(startup_timeout=10)
+        info = _info(turns=1)
+        info._exec_started = 100.0
+        assert mgr._is_startup_stalled(info, now=200.0) is False
+
+
+class TestIdleStall:
+    @pytest.mark.asyncio
+    async def test_prestart_agent_ignored(self) -> None:
+        mgr = _manager(stall_idle_secs=1)
+        info = _info(last_activity=0.0)
+        await mgr._maybe_flag_stall("a1", info, now=1e9)
+        assert info.stalled is False
+
+    @pytest.mark.asyncio
+    async def test_awaiting_approval_is_exempt(self) -> None:
+        mgr = _manager(stall_idle_secs=1)
+        info = _info(turns=1, last_activity=0.0)
+        info._awaiting_approval = True
+        await mgr._maybe_flag_stall("a1", info, now=1e9)
+        assert info.stalled is False
+
+    @pytest.mark.asyncio
+    async def test_two_sweep_confirmation_before_flagging(self) -> None:
+        events: list[tuple[str, dict]] = []
+
+        async def _on_event(etype: str, _info: SubagentInfo, extra: dict) -> None:
+            events.append((etype, extra))
+
+        mgr = _manager(stall_idle_secs=10, on_event=_on_event)
+        info = _info(turns=1, last_activity=0.0)
+        await mgr._maybe_flag_stall("a1", info, now=100.0)
+        assert (info.stalled, info._stall_suspect_at) == (False, 100.0)
+        with patch.object(sa, "record_slow_command"):
+            await mgr._maybe_flag_stall("a1", info, now=200.0)
+        assert info.stalled is True
+        assert events and events[0][0] == "subagent_stalled"
+
+    @pytest.mark.asyncio
+    async def test_event_failure_does_not_break_flagging(self) -> None:
+        async def _on_event(_etype: str, _info: SubagentInfo, _extra: dict) -> None:
+            raise RuntimeError("ws down")
+
+        mgr = _manager(stall_idle_secs=10, on_event=_on_event)
+        info = _info(turns=1, last_activity=0.0)
+        info._stall_suspect_at = 1.0
+        with patch.object(sa, "record_slow_command"):
+            await mgr._maybe_flag_stall("a1", info, now=200.0)
+        assert info.stalled is True
+
+    @pytest.mark.asyncio
+    async def test_already_stalled_agent_not_reflagged(self) -> None:
+        calls: list[str] = []
+
+        async def _on_event(etype: str, _info: SubagentInfo, _extra: dict) -> None:
+            calls.append(etype)
+
+        mgr = _manager(stall_idle_secs=1, on_event=_on_event)
+        info = _info(turns=1, last_activity=0.0, stalled=True)
+        await mgr._maybe_flag_stall("a1", info, now=1e9)
+        assert calls == []
+
+
+# ── Manager: read surfaces ────────────────────────────────────────────────
+
+
+class TestReadSurfaces:
+    def test_running_agents_for_filters_by_parent(self) -> None:
+        mgr = _manager()
+        mgr._agents["a"] = _info("a", parent_session_key="dash:1")
+        mgr._agents["b"] = _info("b", parent_session_key="dash:2")
+        mgr._agents["c"] = _info("c", parent_session_key="dash:1", done=True)
+        rows = mgr.running_agents_for("dash:1")
+        assert [r["id"] for r in rows] == ["a"]
+
+    def test_running_agents_for_redacts_task(self) -> None:
+        mgr = _manager()
+        mgr._agents["a"] = _info(
+            "a", task="use AKIAIOSFODNN7EXAMPLE now", parent_session_key="dash:1"
+        )
+        assert "AKIAIOSFODNN7EXAMPLE" not in mgr.running_agents_for("dash:1")[0]["task"]
+
+    def test_task_memory_rows_reports_sampled_flag(self) -> None:
+        mgr = _manager()
+        fresh = _info("fresh", parent_session_key="dash:1")
+        sampled = _info("sampled", parent_session_key="dash:1")
+        sampled.last_rss_gb = 0.5
+        sampled.peak_rss_gb = 0.75
+        sampled.last_cpu_cores = 1.234
+        mgr._agents.update({"fresh": fresh, "sampled": sampled})
+        rows = {r["id"]: r for r in mgr.task_memory_rows()}
+        assert rows["fresh"]["sampled"] is False
+        assert rows["sampled"]["sampled"] is True
+        assert rows["sampled"]["rss_mb"] == pytest.approx(512.0)
+        assert rows["sampled"]["cpu_cores"] == pytest.approx(1.23)
+
+    def test_task_memory_rows_skips_done_and_queued(self) -> None:
+        mgr = _manager()
+        mgr._agents["done"] = _info("done", done=True)
+        mgr._agents["queued"] = _info("queued", queued=True)
+        assert mgr.task_memory_rows() == []
+
+    def test_get_running_all_and_count(self) -> None:
+        mgr = _manager()
+        live = _info("live")
+        mgr._agents.update({"live": live, "gone": _info("gone", done=True)})
+        assert mgr.get("live") is live
+        assert mgr.get("absent") is None
+        assert [a.id for a in mgr.running] == ["live"]
+        assert len(mgr.all_agents) == 2
+        assert mgr.count == 1
+
+    def test_max_concurrent_and_running_count_properties(self) -> None:
+        mgr = _manager(max_concurrent=7)
+        mgr._running_count = 4
+        assert (mgr.max_concurrent, mgr.running_count) == (7, 4)
+
+
+class TestQueueDepth:
+    def test_depth_counts_only_matching_parent(self) -> None:
+        mgr = _manager()
+        mgr._queue = [
+            {"parent_session_key": "dash:1"},
+            {"parent_session_key": "dash:1"},
+            {"parent_session_key": "dash:2"},
+        ]
+        assert mgr.queued_count_for("dash:1") == 2
+        assert mgr.queued_count_for("dash:9") == 0
+
+    def test_pending_work_sees_queued_agents(self) -> None:
+        mgr = _manager()
+        mgr._queue = [{"parent_session_key": "dash:1"}]
+        assert mgr.has_pending_work_for("dash:1") is True
+
+    def test_pending_work_sees_running_agents(self) -> None:
+        mgr = _manager()
+        mgr._agents["a"] = _info("a", parent_session_key="dash:1")
+        assert mgr.has_pending_work_for("dash:1") is True
+
+    def test_pending_work_false_when_idle(self) -> None:
+        assert _manager().has_pending_work_for("dash:1") is False
+
+    def test_emit_queue_depth_without_loop_is_a_noop(self) -> None:
+        mgr = _manager(on_event=AsyncMock())
+        mgr._emit_queue_depth("dash:1")  # no running loop — advisory event skipped
+
+    @pytest.mark.asyncio
+    async def test_emit_queue_depth_fires_event(self) -> None:
+        seen: list[dict] = []
+
+        async def _on_event(_etype: str, _info: SubagentInfo, extra: dict) -> None:
+            seen.append(extra)
+
+        mgr = _manager(on_event=_on_event)
+        mgr._queue = [{"parent_session_key": "dash:1"}]
+        mgr._emit_queue_depth("dash:1", batch_id="w1")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert seen == [{"queued": 1}]
+
+
+class TestStaggerGate:
+    def test_at_capacity_queues(self) -> None:
+        mgr = _manager(max_concurrent=1)
+        mgr._running_count = 1
+        should_queue, slot_free = mgr._should_stagger_queue(now=1e9)
+        assert (should_queue, slot_free) == (True, False)
+
+    def test_slot_free_but_too_soon_queues(self) -> None:
+        mgr = _manager(max_concurrent=3)
+        mgr._spawn_stagger_secs = 100.0
+        mgr._last_spawn_ts = 1000.0
+        assert mgr._should_stagger_queue(now=1001.0) == (True, True)
+
+    def test_slot_free_and_interval_elapsed_starts(self) -> None:
+        mgr = _manager(max_concurrent=3)
+        mgr._spawn_stagger_secs = 1.0
+        mgr._last_spawn_ts = 1000.0
+        assert mgr._should_stagger_queue(now=2000.0) == (False, True)
+
+
+# ── Manager: injection-failure notice ─────────────────────────────────────
+
+
+class TestNotifyInjectionFailed:
+    def test_parent_without_a_tab_is_skipped(self) -> None:
+        mgr = _manager(on_event=AsyncMock())
+        with patch("kiro_crew.dashboard.chat_utils.dashboard_slot_key", return_value=""):
+            mgr.notify_injection_failed(_info(parent_session_key="cron:1"))
+
+    @pytest.mark.asyncio
+    async def test_queues_failure_for_the_next_turn(self, tmp_path: Path) -> None:
+        seen: list[dict] = []
+
+        async def _on_event(_etype: str, _info: SubagentInfo, extra: dict) -> None:
+            seen.append(extra)
+
+        result = tmp_path / "result.txt"
+        result.write_text("hello", newline="\n")
+        mgr = _manager(on_event=_on_event)
+        info = _info(parent_session_key="dash:1", result_path=str(result))
+        with patch("kiro_crew.dashboard.chat_utils.dashboard_slot_key", return_value="slot-1"):
+            mgr.notify_injection_failed(info)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert seen and seen[0]["slot"] == "slot-1"
+        assert "Result saved at" in seen[0]["failure_msg"]
+
+    @pytest.mark.asyncio
+    async def test_unreadable_result_path_omits_size(self, tmp_path: Path) -> None:
+        seen: list[dict] = []
+
+        async def _on_event(_etype: str, _info: SubagentInfo, extra: dict) -> None:
+            seen.append(extra)
+
+        mgr = _manager(on_event=_on_event)
+        info = _info(parent_session_key="dash:1", result_path=str(tmp_path / "absent.txt"))
+        with patch("kiro_crew.dashboard.chat_utils.dashboard_slot_key", return_value="slot-1"):
+            mgr.notify_injection_failed(info)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert seen and "bytes" not in seen[0]["failure_msg"]
+
+    def test_lookup_failure_is_swallowed(self) -> None:
+        mgr = _manager(on_event=AsyncMock())
+        with patch(
+            "kiro_crew.dashboard.chat_utils.dashboard_slot_key",
+            side_effect=RuntimeError("no dashboard"),
+        ):
+            mgr.notify_injection_failed(_info(parent_session_key="dash:1"))
+
+
+# ── Manager: continuable conversations ────────────────────────────────────
+
+
+class TestConversationBusy:
+    def test_live_run_is_busy(self) -> None:
+        mgr = _manager()
+        mgr._agents["c1"] = _info("c1")
+        busy = mgr._conversation_busy("subagent:c1")
+        assert busy is not None and busy.id == "c1"
+
+    def test_queued_continuation_is_busy(self) -> None:
+        mgr = _manager()
+        mgr._queue = [{"conversation_key": "subagent:c1", "_preassigned_id": "q1"}]
+        busy = mgr._conversation_busy("subagent:c1")
+        assert busy is not None and busy.queued is True
+
+    def test_queued_without_explicit_key_matches_preassigned_id(self) -> None:
+        mgr = _manager()
+        mgr._queue = [{"_preassigned_id": "q1"}]
+        assert mgr._conversation_busy("subagent:q1") is not None
+
+    def test_idle_conversation_is_not_busy(self) -> None:
+        assert _manager()._conversation_busy("subagent:nope") is None
+
+
+class TestKeepRecordedOnDisk:
+    def test_non_subagent_key_short_circuits(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "read_state") as read:
+            assert mgr._keep_recorded_on_disk("dash:1") is False
+        read.assert_not_called()
+
+    def test_keep_true_recorded(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "read_state", return_value={"keep": True}):
+            assert mgr._keep_recorded_on_disk("subagent:c1") is True
+
+    def test_missing_state_is_false(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "read_state", return_value=None):
+            assert mgr._keep_recorded_on_disk("subagent:c1") is False
+
+    def test_read_failure_is_false(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "read_state", side_effect=OSError):
+            assert mgr._keep_recorded_on_disk("subagent:c1") is False
+
+
+class TestPromoteConversation:
+    def test_writes_all_three_retention_surfaces(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "update_state") as update:
+            mgr._promote_conversation("c1", "subagent:c1", last_used=1234.0)
+        update.assert_called_once_with("c1", keep=True)
+        mgr._sessions.mark_continuable.assert_called_once_with("subagent:c1")
+        assert mgr._conversations["subagent:c1"] == 1234.0
+
+    def test_state_write_failure_still_registers(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "update_state", side_effect=OSError):
+            mgr._promote_conversation("c1", "subagent:c1")
+        assert "subagent:c1" in mgr._conversations
+
+
+class TestScanKeepStates:
+    def test_missing_base_dir_returns_empty(self, tmp_path: Path) -> None:
+        mgr = _manager()
+        with patch.object(sa, "_subagents_dir", return_value=tmp_path / "absent"):
+            assert mgr._scan_keep_states() == []
+
+    def test_collects_only_keep_runs(self, tmp_path: Path) -> None:
+        mgr = _manager()
+        (tmp_path / "c1").mkdir()
+        (tmp_path / "c2").mkdir()
+        (tmp_path / "loose.txt").write_text("x", newline="\n")
+        states = {
+            "c1": {
+                "keep": True,
+                "conversation_key": "subagent:c1",
+                "session_id": "sid-1",
+                "provider": "acp",
+                "cwd": str(tmp_path),
+                "updated_at": 42.0,
+            },
+            "c2": {"keep": False},
+        }
+        with (
+            patch.object(sa, "_subagents_dir", return_value=tmp_path),
+            patch.object(sa, "read_state", side_effect=lambda name: states.get(name)),
+        ):
+            rows = mgr._scan_keep_states()
+        assert [r[0] for r in rows] == ["c1"]
+        assert rows[0][2] == "sid-1"
+        assert rows[0][5] == 42.0
+
+    def test_unreadable_entry_is_skipped(self, tmp_path: Path) -> None:
+        mgr = _manager()
+        (tmp_path / "c1").mkdir()
+        with (
+            patch.object(sa, "_subagents_dir", return_value=tmp_path),
+            patch.object(sa, "read_state", side_effect=OSError),
+        ):
+            assert mgr._scan_keep_states() == []
+
+    def test_scan_error_returns_empty(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "_subagents_dir", side_effect=RuntimeError("no home")):
+            assert mgr._scan_keep_states() == []
+
+
+class TestReleaseConversation:
+    def test_busy_conversation_refused(self) -> None:
+        mgr = _manager()
+        mgr._agents["c1"] = _info("c1")
+        ok, detail = mgr.release_conversation("c1")
+        assert ok is False
+        assert "conversation_busy" in detail
+
+    def test_nothing_to_release(self) -> None:
+        mgr = _manager()
+        mgr._sessions.forget_conversation.return_value = ""
+        with patch.object(sa, "update_state"):
+            ok, detail = mgr.release_conversation("c1")
+        assert (ok, detail) == (False, "conversation_gone: nothing to release")
+
+    def test_released_deletes_session_files(self) -> None:
+        mgr = _manager()
+        mgr._conversations["subagent:c1"] = 1.0
+        mgr._sessions.forget_conversation.return_value = "sid-1"
+        with (
+            patch.object(sa, "update_state") as update,
+            patch.object(sa, "_cleanup_session_files_sync") as cleanup,
+        ):
+            ok, detail = mgr.release_conversation("c1")
+        assert (ok, detail) == (True, "released")
+        update.assert_called_once_with("c1", keep=False)
+        cleanup.assert_called_once_with("sid-1", "acp")
+        assert "subagent:c1" not in mgr._conversations
+
+    def test_file_cleanup_failure_still_reports_released(self) -> None:
+        mgr = _manager()
+        mgr._sessions.forget_conversation.return_value = "sid-1"
+        with (
+            patch.object(sa, "update_state"),
+            patch.object(sa, "_cleanup_session_files_sync", side_effect=OSError),
+        ):
+            assert mgr.release_conversation("c1")[0] is True
+
+
+class TestSweepConversations:
+    def test_fresh_conversation_kept(self) -> None:
+        mgr = _manager()
+        mgr._conversations["subagent:c1"] = 1000.0
+        mgr._sweep_conversations(now=1001.0)
+        assert "subagent:c1" in mgr._conversations
+
+    def test_busy_conversation_refreshed_not_released(self) -> None:
+        mgr = _manager()
+        mgr._conversations["subagent:c1"] = 0.0
+        mgr._agents["c1"] = _info("c1")
+        now = float(sa._CONVERSATION_TTL_SECS * 3)
+        mgr._sweep_conversations(now=now)
+        assert mgr._conversations["subagent:c1"] == now
+
+    def test_expired_conversation_released(self) -> None:
+        mgr = _manager()
+        mgr._conversations["subagent:c1"] = 0.0
+        mgr._sessions.forget_conversation.return_value = "sid-1"
+        with (
+            patch.object(sa, "update_state"),
+            patch.object(sa, "_cleanup_session_files_sync"),
+        ):
+            mgr._sweep_conversations(now=float(sa._CONVERSATION_TTL_SECS * 3))
+        assert "subagent:c1" not in mgr._conversations
+
+
+class TestInheritedContextGroups:
+    def test_live_record_wins(self) -> None:
+        mgr = _manager()
+        mgr._agents["c1"] = _info("c1", include_memory=False)
+        assert mgr._inherited_context_groups("c1") == (False, True, True)
+
+    def test_run_predating_the_field_defaults_all_on(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "read_state", return_value={}):
+            assert mgr._inherited_context_groups("c1") == (True, True, True)
+
+    def test_persisted_scope_is_read_back(self) -> None:
+        mgr = _manager()
+        raw = f"{sa.CONTEXT_GROUP_LESSONS},{sa.CONTEXT_GROUP_PROJECT}"
+        with patch.object(sa, "read_state", return_value={"context_groups": raw}):
+            assert mgr._inherited_context_groups("c1") == (False, True, True)
+
+    def test_empty_scope_means_every_group_withheld(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "read_state", return_value={"context_groups": ""}):
+            assert mgr._inherited_context_groups("c1") == (False, False, False)
+
+
+# ── Manager: wave / batch bookkeeping ─────────────────────────────────────
+
+
+class TestBatchMembersPending:
+    def test_no_batch_id_is_never_pending(self) -> None:
+        assert _manager().batch_members_pending("") is False
+
+    def test_submissions_in_flight_are_pending(self) -> None:
+        mgr = _manager()
+        mgr._batch_submitted["w1"] = [1, 3]
+        assert mgr.batch_members_pending("w1") is True
+
+    def test_live_member_is_pending(self) -> None:
+        mgr = _manager()
+        mgr._batch_submitted["w1"] = [2, 2]
+        mgr._agents["a"] = _info("a", batch_id="w1")
+        assert mgr.batch_members_pending("w1") is True
+
+    def test_queued_member_is_pending(self) -> None:
+        mgr = _manager()
+        mgr._batch_submitted["w1"] = [2, 2]
+        mgr._queue = [{"batch_id": "w1"}]
+        assert mgr.batch_members_pending("w1") is True
+
+    def test_closed_wave_not_pending(self) -> None:
+        mgr = _manager()
+        mgr._batch_submitted["w1"] = [2, 2]
+        mgr._agents["a"] = _info("a", batch_id="w1", done=True)
+        assert mgr.batch_members_pending("w1") is False
+
+
+class TestFinalizeBatch:
+    def test_prunes_every_wave_map(self) -> None:
+        mgr = _manager()
+        mgr._seen_batches.add("w1")
+        mgr._batch_submitted["w1"] = [1, 1]
+        mgr._batch_progress_ts["w1"] = 1.0
+        mgr.finalize_batch("w1")
+        assert "w1" not in mgr._seen_batches
+        assert "w1" not in mgr._batch_submitted
+        assert "w1" not in mgr._batch_progress_ts
+
+    def test_empty_id_is_a_noop(self) -> None:
+        mgr = _manager()
+        mgr._seen_batches.add("w1")
+        mgr.finalize_batch("")
+        assert "w1" in mgr._seen_batches
+
+
+class TestRecordLostSubmission:
+    def test_empty_batch_id_is_a_noop(self) -> None:
+        mgr = _manager()
+        mgr.record_lost_submission("", 2, "transport error")
+        assert mgr._batch_submitted == {}
+
+    @pytest.mark.asyncio
+    async def test_counts_submission_and_announces_failure(self) -> None:
+        announced: list[SubagentInfo] = []
+
+        async def _on_done(info: SubagentInfo) -> None:
+            announced.append(info)
+
+        mgr = _manager(on_done=_on_done)
+        with patch.object(sa, "sel"):
+            mgr.record_lost_submission("w1", 3, "POST timed out", parent_session_key="dash:1")
+        await asyncio.gather(*mgr._tasks.values())
+        assert mgr._batch_submitted["w1"][0] == 1
+        assert announced and announced[0].batch_id == "w1"
+        assert announced[0].done is True
+        assert "spawn submission lost" in announced[0].error
+
+    def test_audit_failure_does_not_block_accounting(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "sel", side_effect=RuntimeError("sel down")):
+            mgr.record_lost_submission("w1", 2, "boom")
+        assert mgr._batch_submitted["w1"][0] == 1
+
+    def test_without_completion_consumer_only_accounting_runs(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "sel"):
+            mgr.record_lost_submission("w1", 2, "boom")
+        assert mgr._batch_submitted["w1"] == [1, 2]
+        assert mgr._tasks == {}
+
+    def test_negative_total_is_floored_at_zero(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "sel"):
+            mgr.record_lost_submission("w1", -5, "boom")
+        assert mgr._batch_submitted["w1"][1] == 0
+
+
+class TestSweepStuckWaves:
+    def test_complete_wave_skipped(self) -> None:
+        mgr = _manager()
+        mgr._batch_submitted["w1"] = [2, 2]
+        with patch.object(mgr, "record_lost_submission") as rec:
+            mgr._sweep_stuck_waves(now=1e9)
+        rec.assert_not_called()
+
+    def test_within_grace_window_skipped(self) -> None:
+        mgr = _manager()
+        mgr._batch_submitted["w1"] = [1, 2]
+        mgr._batch_progress_ts["w1"] = 1000.0
+        with patch.object(mgr, "record_lost_submission") as rec:
+            mgr._sweep_stuck_waves(now=1001.0)
+        rec.assert_not_called()
+
+    def test_live_member_defers_reconciliation(self) -> None:
+        mgr = _manager()
+        mgr._batch_submitted["w1"] = [1, 2]
+        mgr._batch_progress_ts["w1"] = 0.0
+        mgr._agents["a"] = _info("a", batch_id="w1")
+        with patch.object(mgr, "record_lost_submission") as rec:
+            mgr._sweep_stuck_waves(now=float(sa._WAVE_STUCK_SECS * 3))
+        rec.assert_not_called()
+
+    def test_queued_member_defers_reconciliation(self) -> None:
+        mgr = _manager()
+        mgr._batch_submitted["w1"] = [1, 2]
+        mgr._batch_progress_ts["w1"] = 0.0
+        mgr._queue = [{"batch_id": "w1"}]
+        with patch.object(mgr, "record_lost_submission") as rec:
+            mgr._sweep_stuck_waves(now=float(sa._WAVE_STUCK_SECS * 3))
+        rec.assert_not_called()
+
+    def test_wedged_wave_reconciled_once(self) -> None:
+        mgr = _manager()
+        mgr._batch_submitted["w1"] = [1, 2]
+        mgr._batch_progress_ts["w1"] = 0.0
+        mgr._agents["a"] = _info("a", batch_id="w1", done=True, parent_session_key="dash:1")
+        with patch.object(mgr, "record_lost_submission") as rec:
+            mgr._sweep_stuck_waves(now=float(sa._WAVE_STUCK_SECS * 3))
+        assert rec.call_count == 1
+        assert rec.call_args.kwargs["parent_session_key"] == "dash:1"
+
+
+class TestSweepDigestHolds:
+    def test_disabled_deadline_is_a_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa, "DIGEST_HOLD_SECS", 0.0)
+        mgr = _manager(on_done=AsyncMock())
+        with patch.object(mgr, "force_digest_flush") as flush:
+            mgr._sweep_digest_holds(now=1e9)
+        flush.assert_not_called()
+
+    def test_no_completion_consumer_is_a_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa, "DIGEST_HOLD_SECS", 10.0)
+        mgr = _manager()
+        with patch.object(mgr, "force_digest_flush") as flush:
+            mgr._sweep_digest_holds(now=1e9)
+        flush.assert_not_called()
+
+    def test_hold_within_window_kept(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa, "DIGEST_HOLD_SECS", 100.0)
+        mgr = _manager(on_done=AsyncMock())
+        held = _info("a", batch_id="w1", batch_total=2)
+        held._digest_held_at = 1000.0
+        mgr._agents["a"] = held
+        with patch.object(mgr, "force_digest_flush") as flush:
+            mgr._sweep_digest_holds(now=1050.0)
+        flush.assert_not_called()
+
+    def test_closing_wave_not_forced(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa, "DIGEST_HOLD_SECS", 10.0)
+        mgr = _manager(on_done=AsyncMock())
+        held = _info("a", batch_id="w1", batch_total=1, done=True)
+        held._digest_held_at = 1.0
+        mgr._agents["a"] = held
+        mgr._batch_submitted["w1"] = [1, 1]
+        with patch.object(mgr, "force_digest_flush") as flush:
+            mgr._sweep_digest_holds(now=1e6)
+        flush.assert_not_called()
+
+    def test_expired_hold_forces_partial_flush(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa, "DIGEST_HOLD_SECS", 10.0)
+        mgr = _manager(on_done=AsyncMock())
+        held = _info("a", batch_id="w1", batch_total=2, done=True, parent_session_key="dash:1")
+        held._digest_held_at = 100.0
+        newer = _info("b", batch_id="w1", batch_total=2, done=True)
+        newer._digest_held_at = 500.0
+        mgr._agents.update({"a": held, "b": newer})
+        mgr._batch_submitted["w1"] = [1, 2]  # still pending
+        with patch.object(mgr, "force_digest_flush") as flush:
+            mgr._sweep_digest_holds(now=1000.0)
+        assert flush.call_count == 1
+        assert flush.call_args[0][0] == "w1"
+        assert flush.call_args[0][1] == "dash:1"
+        assert flush.call_args[0][3] == pytest.approx(900.0)  # oldest hold wins
+
+    def test_unheld_members_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa, "DIGEST_HOLD_SECS", 10.0)
+        mgr = _manager(on_done=AsyncMock())
+        mgr._agents["a"] = _info("a", batch_id="w1")
+        mgr._agents["b"] = _info("b")
+        with patch.object(mgr, "force_digest_flush") as flush:
+            mgr._sweep_digest_holds(now=1e9)
+        flush.assert_not_called()
+
+
+class TestForceDigestFlush:
+    def test_missing_batch_id_is_a_noop(self) -> None:
+        mgr = _manager(on_done=AsyncMock())
+        mgr.force_digest_flush("", "dash:1", 2, 300.0)
+        assert mgr._tasks == {}
+
+    def test_without_completion_consumer_is_a_noop(self) -> None:
+        mgr = _manager()
+        mgr.force_digest_flush("w1", "dash:1", 2, 300.0)
+        assert mgr._tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_announces_flush_only_record(self) -> None:
+        announced: list[SubagentInfo] = []
+
+        async def _on_done(info: SubagentInfo) -> None:
+            announced.append(info)
+
+        mgr = _manager(on_done=_on_done)
+        with patch.object(sa, "sel"):
+            mgr.force_digest_flush("w1", "dash:1", 3, 300.0)
+        await asyncio.gather(*mgr._tasks.values())
+        assert announced and announced[0]._digest_flush_only is True
+        assert announced[0].batch_id == "w1"
+        assert announced[0].batch_total == 3
+
+    @pytest.mark.asyncio
+    async def test_audit_failure_still_schedules(self) -> None:
+        announced: list[SubagentInfo] = []
+
+        async def _on_done(info: SubagentInfo) -> None:
+            announced.append(info)
+
+        mgr = _manager(on_done=_on_done)
+        with patch.object(sa, "sel", side_effect=RuntimeError("sel down")):
+            mgr.force_digest_flush("w1", "dash:1", 1, 1.0)
+        await asyncio.gather(*mgr._tasks.values())
+        assert announced and announced[0].batch_id == "w1"
+
+
+class TestAnnounceDigestFlush:
+    @pytest.mark.asyncio
+    async def test_settles_holds_after_clean_handoff(self) -> None:
+        mgr = _manager(on_done=AsyncMock())
+        info = _info(batch_id="w1")
+        info._digest_settle_ids = ["m1", "m2"]
+        with patch.object(sa, "mark_delivered") as mark:
+            await mgr._announce_digest_flush(info)
+        assert [c[0][0] for c in mark.call_args_list] == ["m1", "m2"]
+        assert info._digest_settle_ids == []
+
+    @pytest.mark.asyncio
+    async def test_routing_failure_leaves_holds_unsettled(self) -> None:
+        mgr = _manager(on_done=AsyncMock(side_effect=RuntimeError("route down")))
+        info = _info(batch_id="w1")
+        info._digest_settle_ids = ["m1"]
+        with patch.object(sa, "mark_delivered") as mark:
+            await mgr._announce_digest_flush(info)
+        mark.assert_not_called()
+        assert info._digest_settle_ids == ["m1"]
+
+    def test_settle_swallows_tombstone_failure(self) -> None:
+        mgr = _manager()
+        info = _info()
+        info._digest_settle_ids = ["m1"]
+        with patch.object(sa, "mark_delivered", side_effect=OSError):
+            mgr._settle_digest_holds(info)
+        assert info._digest_settle_ids == []
+
+
+class TestAnnounceRejection:
+    def test_non_batch_rejection_is_not_announced(self) -> None:
+        mgr = _manager(on_done=AsyncMock())
+        info = _info(done=True, error="rejected")
+        assert mgr._announce_rejection(info) is info
+        assert mgr._tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_batch_rejection_reaches_the_wave(self) -> None:
+        announced: list[SubagentInfo] = []
+
+        async def _on_done(info: SubagentInfo) -> None:
+            announced.append(info)
+
+        mgr = _manager(on_done=_on_done)
+        info = _info(done=True, error="rejected", batch_id="w1")
+        mgr._announce_rejection(info)
+        await asyncio.gather(*mgr._tasks.values())
+        assert announced == [info]
+
+    @pytest.mark.asyncio
+    async def test_safe_announce_swallows_callback_failure(self) -> None:
+        mgr = _manager(on_done=AsyncMock(side_effect=RuntimeError("boom")))
+        await mgr._safe_announce(_info())  # must not raise
+
+
+# ── Manager: session sharing / provider probes ────────────────────────────
+
+
+class TestShouldUseSessionSharing:
+    def test_disabled_by_config(self) -> None:
+        mgr = _manager()
+        cfg = MagicMock()
+        cfg.agent.session_sharing = False
+        with patch("kiro_crew.subagent.KiroCrewConfig.load", return_value=cfg):
+            assert mgr._should_use_session_sharing(_info(parent_session_key="dash:1")) is False
+
+    def test_config_failure_fails_closed(self) -> None:
+        mgr = _manager()
+        with patch("kiro_crew.subagent.KiroCrewConfig.load", side_effect=RuntimeError):
+            assert mgr._should_use_session_sharing(_info(parent_session_key="dash:1")) is False
+
+    @pytest.mark.parametrize(
+        "override",
+        [{"model": "sonnet"}, {"allowed_tools": ["read"]}, {"bare": True}],
+    )
+    def test_cc_specific_spawn_excluded(self, override: dict) -> None:
+        mgr = _manager()
+        cfg = MagicMock()
+        cfg.agent.session_sharing = True
+        info = _info(parent_session_key="dash:1", **override)
+        with patch("kiro_crew.subagent.KiroCrewConfig.load", return_value=cfg):
+            assert mgr._should_use_session_sharing(info) is False
+
+    def test_parentless_spawn_excluded(self) -> None:
+        mgr = _manager()
+        cfg = MagicMock()
+        cfg.agent.session_sharing = True
+        with patch("kiro_crew.subagent.KiroCrewConfig.load", return_value=cfg):
+            assert mgr._should_use_session_sharing(_info()) is False
+
+    def test_eligible_parent_accepted(self) -> None:
+        mgr = _manager()
+        cfg = MagicMock()
+        cfg.agent.session_sharing = True
+        with patch("kiro_crew.subagent.KiroCrewConfig.load", return_value=cfg):
+            assert mgr._should_use_session_sharing(_info(parent_session_key="dash:1")) is True
+
+
+class TestGetParentRuntime:
+    def test_no_provider(self) -> None:
+        mgr = _manager()
+        mgr._sessions.get_provider.return_value = None
+        assert mgr._get_parent_runtime("dash:1") is None
+
+    def test_non_acp_session_provider(self) -> None:
+        mgr = _manager()
+        mgr._sessions.get_provider.return_value = SimpleNamespace(client=object())
+        assert mgr._get_parent_runtime("dash:1") is None
+
+    def test_acp_session_provider_yields_runtime(self) -> None:
+        mgr = _manager()
+        runtime = object()
+        inner = MagicMock(spec=sa.AcpSessionProvider)
+        inner._runtime = runtime
+        mgr._sessions.get_provider.return_value = SimpleNamespace(client=inner)
+        assert mgr._get_parent_runtime("dash:1") is runtime
+
+
+class TestIsCcProvider:
+    def test_delegates_to_backend_probe(self) -> None:
+        with patch("kiro_crew.providers.acp.is_claude_backend", return_value=True):
+            assert SubagentManager._is_cc_provider(object()) is True
+
+    def test_non_claude_backend(self) -> None:
+        with patch("kiro_crew.providers.acp.is_claude_backend", return_value=False):
+            assert SubagentManager._is_cc_provider(object()) is False
+
+
+# ── Manager: intentional cancel contract ──────────────────────────────────
+
+
+class TestCancelTaskIntentionally:
+    @pytest.mark.asyncio
+    async def test_marked_cancel_leaves_recovery_budget(self) -> None:
+        mgr = _manager()
+        info = _info(user_stopped=True)
+
+        async def _sleep() -> None:
+            await asyncio.sleep(3600)
+
+        task = asyncio.ensure_future(_sleep())
+        mgr._cancel_task_intentionally(task, info, reason="user_stop")
+        await asyncio.gather(task, return_exceptions=True)
+        assert task.cancelled() is True
+        assert info._cancel_retry_used is False
+
+    @pytest.mark.asyncio
+    async def test_unmarked_cancel_consumes_recovery_budget(self) -> None:
+        mgr = _manager()
+        info = _info()
+
+        async def _sleep() -> None:
+            await asyncio.sleep(3600)
+
+        task = asyncio.ensure_future(_sleep())
+        mgr._cancel_task_intentionally(task, info, reason="oops")
+        await asyncio.gather(task, return_exceptions=True)
+        assert info._cancel_retry_used is True
+
+    @pytest.mark.asyncio
+    async def test_shutdown_counts_as_a_marker(self) -> None:
+        mgr = _manager()
+        mgr._shutting_down = True
+
+        async def _sleep() -> None:
+            await asyncio.sleep(3600)
+
+        task = asyncio.ensure_future(_sleep())
+        mgr._cancel_task_intentionally(task, None, reason="shutdown")
+        await asyncio.gather(task, return_exceptions=True)
+        assert task.cancelled() is True
+
+
+class TestCancelLookup:
+    @pytest.mark.asyncio
+    async def test_unknown_agent_is_false(self) -> None:
+        assert await _manager().cancel("nope") is False
+
+    @pytest.mark.asyncio
+    async def test_finished_agent_is_false(self) -> None:
+        mgr = _manager()
+        mgr._agents["a"] = _info("a", done=True)
+        assert await mgr.cancel("a") is False
+
+
+# ── Manager: steer / follow-up refusals ───────────────────────────────────
+
+
+class TestSteerRun:
+    @pytest.mark.asyncio
+    async def test_unknown_run(self) -> None:
+        assert await _manager().steer_run("nope", "hi") == (False, "not_found")
+
+    @pytest.mark.asyncio
+    async def test_finished_run_points_at_continue(self) -> None:
+        mgr = _manager()
+        mgr._agents["a"] = _info("a", done=True)
+        ok, detail = await mgr.steer_run("a", "hi")
+        assert ok is False
+        assert detail.startswith("not_running")
+
+    @pytest.mark.asyncio
+    async def test_shared_provider_steer_accepted(self) -> None:
+        mgr = _manager()
+        info = _info("a", parent_session_key="dash:1")
+        info._session_sharing = True
+        info._shared_provider = MagicMock(steer=AsyncMock(return_value=True))
+        mgr._agents["a"] = info
+        with patch.object(sa, "sel"):
+            assert await mgr.steer_run("a", "hi") == (True, "ok")
+
+    @pytest.mark.asyncio
+    async def test_provider_rejection_reported(self) -> None:
+        mgr = _manager()
+        info = _info("a")
+        info._session_sharing = True
+        info._shared_provider = MagicMock(steer=AsyncMock(return_value=False))
+        mgr._agents["a"] = info
+        assert await mgr.steer_run("a", "hi") == (False, "steer rejected by provider")
+
+    @pytest.mark.asyncio
+    async def test_audit_failure_does_not_change_the_verdict(self) -> None:
+        mgr = _manager()
+        info = _info("a")
+        info._session_sharing = True
+        info._shared_provider = MagicMock(steer=AsyncMock(return_value=True))
+        mgr._agents["a"] = info
+        with patch.object(sa, "sel", side_effect=RuntimeError("sel down")):
+            assert await mgr.steer_run("a", "hi") == (True, "ok")
+
+    @pytest.mark.asyncio
+    async def test_startup_grace_returns_typed_refusal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sa, "_STEER_STARTUP_WAIT_SECS", 0.05)
+        monkeypatch.setattr(sa, "_STEER_STARTUP_POLL_SECS", 0.01)
+        mgr = _manager()
+        mgr._agents["a"] = _info("a")
+        ok, detail = await mgr.steer_run("a", "hi")
+        assert ok is False
+        assert detail.startswith("session_starting")
+
+    @pytest.mark.asyncio
+    async def test_run_finishing_during_the_grace_wait_flips_to_not_running(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sa, "_STEER_STARTUP_WAIT_SECS", 1.0)
+        monkeypatch.setattr(sa, "_STEER_STARTUP_POLL_SECS", 0.01)
+        mgr = _manager()
+        info = _info("a")
+        mgr._agents["a"] = info
+
+        async def _finish() -> None:
+            await asyncio.sleep(0.02)
+            info.done = True
+
+        finisher = asyncio.ensure_future(_finish())
+        ok, detail = await mgr.steer_run("a", "hi")
+        await finisher
+        assert ok is False
+        assert detail.startswith("not_running")
+
+
+class TestFollowUpRun:
+    @pytest.mark.asyncio
+    async def test_unknown_run(self) -> None:
+        assert await _manager().follow_up_run("nope", "hi") == (False, "not_found")
+
+    @pytest.mark.asyncio
+    async def test_finished_run_refused(self) -> None:
+        mgr = _manager()
+        mgr._agents["a"] = _info("a", done=True)
+        ok, detail = await mgr.follow_up_run("a", "hi")
+        assert ok is False
+        assert detail.startswith("not_running")
+
+    @pytest.mark.asyncio
+    async def test_shutdown_refuses_rather_than_dropping(self) -> None:
+        mgr = _manager()
+        mgr._agents["a"] = _info("a")
+        mgr._shutting_down = True
+        ok, detail = await mgr.follow_up_run("a", "hi")
+        assert ok is False
+        assert detail.startswith("shutting_down")
+
+    @pytest.mark.asyncio
+    async def test_queued_and_watcher_armed_once(self) -> None:
+        mgr = _manager()
+        info = _info("a")
+        mgr._agents["a"] = info
+        with (
+            patch.object(sa, "sel"),
+            patch.object(mgr, "_arm_followup_watcher") as arm,
+        ):
+            assert await mgr.follow_up_run("a", "first") == (True, "queued")
+            info._followup_watcher = True
+            assert await mgr.follow_up_run("a", "second") == (True, "queued")
+        assert info.pending_followups == ["first", "second"]
+        assert arm.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_audit_failure_does_not_lose_the_message(self) -> None:
+        mgr = _manager()
+        info = _info("a")
+        info._followup_watcher = True
+        mgr._agents["a"] = info
+        with patch.object(sa, "sel", side_effect=RuntimeError("sel down")):
+            assert await mgr.follow_up_run("a", "hi") == (True, "queued")
+        assert info.pending_followups == ["hi"]
+
+    def test_audit_helper_swallows_failure(self) -> None:
+        mgr = _manager()
+        with patch.object(sa, "sel", side_effect=RuntimeError("sel down")):
+            mgr._audit_followup(_info(), "followup_expired")  # must not raise
+
+
+# ── Cross-platform constants ──────────────────────────────────────────────
+
+
+class TestPlatformConstants:
+    def test_clock_ticks_positive_on_every_platform(self) -> None:
+        """``_CLK_TCK`` divides a CPU delta, so a zero/absent value would make
+        the cost sampler raise. Windows has no ``os.sysconf``; the module falls
+        back to 100 there."""
+        assert isinstance(sa._CLK_TCK, int)
+        assert sa._CLK_TCK > 0
+
+    def test_subtree_walk_caps_are_bounded(self) -> None:
+        assert sa._RSS_SUBTREE_MAX_PROCS > 0
+        assert sa._CPU_SUBTREE_MAX_PROCS > 0


### PR DESCRIPTION
## What

Twelve new backend test files, raising the backend lane from **85.98% to 86.93%** (+2,084 statements). First wave of the push toward 90%.

```
before   188,188 / 218,873   85.98%
after    190,272 / 218,873   86.93%
```

Targets were chosen by **uncovered-statement mass**, not by percentage, so the effort lands where the gap actually is:

| Module | Recovered |
|---|---|
| `dashboard/server.py` | +401 |
| `apps/builtins/dev_fleet/server.py` | +280 |
| `apps/builtins/issue_radar/backend/gitlab_client.py` | +256 (every uncovered statement in the file) |
| `dashboard/handlers/core.py` | +228 |
| `deploy/handlers.py` | +205 |
| `history.py` | +177 |
| `chat_runner.py`, `session.py`, `hooks.py`, `subagent.py`, `slack/handler.py`, `slack/gateway.py` | +417 combined |

## How the number was measured

The exact union of this wave's coverage with main's published CI artifact, under CI's own command shape (`--cov=kiro_crew --cov=sage_lib`). Statement coverage is monotonic in the set of tests executed, so the union is what CI reports with these files present — no estimate, and no need to wait on a full-suite run.

Never `--cov=<submodule>`: that splits aiohttp's `web.Application` module identity and manufactures ~100 false failures.

## Verification

- 1,668 tests, all passing, re-verified after rebasing onto current main
- `flake8 -j 1`: exit 0
- `isort --check-only`: exit 0
- Exit codes checked explicitly rather than read off piped output, since error lines print *above* the summary
- No product code touched — tests only

The specs carried the cross-platform traps this repo has hit before: Windows lacking `os.getuid`/`getpgid`/`killpg`, the 8.3 short-path vs `realpath` string compare, `Path.write_text` newline translation, `asyncio.run()` inside a test closing a loop the code under test still holds (fails on 3.10 and Windows while 3.12 Linux tolerates it), and selecting a registration hook by list index instead of by name.

## Remaining to 90%

+6,714 statements. Roughly three more waves of this size.

Separately worth knowing: ~2,051 statements sit in modules whose own tests CI **deselects** (`auto_improvement` spine, `cron_script`, `ops_mission_control` providers). `ci.yml` documents the reason — those tests need runner capabilities GitHub Actions lacks. New tests under `test/` are not deselected, so that mass is reachable, but each blocker has to be neutralized per file rather than by re-enabling the deselect.
