### PR TITLE
test(website): raise frontend coverage 83.38% -> at least 84.46%

### DIFF
--- a/website/src/test/ArtifactPanelCoverage.test.tsx
+++ b/website/src/test/ArtifactPanelCoverage.test.tsx
@@ -1,0 +1,596 @@
+/**
+ * Coverage suite for `ArtifactPanel` — the side-panel Artifacts tab.
+ *
+ * The one existing sibling (`ArtifactPanel.copyIcon.test.tsx`) never mounts the
+ * panel at all: it exercises `SelectionToolbar` in isolation. So everything the
+ * panel itself owns was cold — the seed-vs-live artifact precedence, the
+ * hydrating / load-failed branches, the three body kinds, the comments toggle,
+ * the submit-to-chat bar, the Escape handling, and the whole fullscreen portal
+ * (focus seeding, Tab trap, body-scroll lock). Each is pinned here.
+ *
+ * Kiro Crew convention: automocked api client + `renderWithProviders` on a real
+ * route so `useNavigate` runs for real against a sibling route.
+ *
+ * Three harness substitutions, all deliberate:
+ *  1. `ArtifactBody*` are replaced with markers. The real native body is a
+ *     lazily-imported Monaco instance and the real iframe body navigates a blob
+ *     page — neither belongs in a test of the panel's own wiring. The markers
+ *     echo back the props the panel chose (kind, slug, flush) so the branch that
+ *     selected them is still asserted.
+ *  2. `SelectionToolbar` is replaced with plain buttons that invoke each action.
+ *     A real toolbar needs a live DOM text selection with layout, which happy-dom
+ *     does not produce, so the panel's selection actions are otherwise
+ *     unreachable.
+ *  3. `useFileArtifactComments` is replaced with a stateful stub. The real hook
+ *     owns its own query + mutation graph (covered by its own suites); here it
+ *     only has to hand back a controllable comment list and a working sidebar
+ *     toggle, and to record the arguments the panel passes it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, waitFor, within, act } from '@testing-library/react'
+import { Routes, Route } from 'react-router-dom'
+import type { CSSProperties } from 'react'
+import ArtifactPanel from '../components/ArtifactPanel'
+import { renderWithProviders } from './helpers'
+import { api } from '../api/client'
+import { copyToClipboard } from '../utils/clipboard'
+import type { Artifact, ArtifactComment } from '../types'
+
+const SLUG = 'ops-widget'
+const NAME = 'Ops Widget'
+const SEED_CONTENT = 'seeded body text'
+const LIVE_CONTENT = 'live body text'
+const SELECTED_TEXT = 'a selected phrase'
+/** The submit-reset guard window in the component, in ms. */
+const SUBMIT_GUARD_MS = 400
+/** Mirrors the focus-trap selector the fullscreen overlay queries with. */
+const FOCUSABLE_SELECTOR = 'button:not([disabled]),textarea,input,a[href],select,[tabindex]:not([tabindex="-1"])'
+
+vi.mock('../api/client')
+vi.mock('../utils/clipboard', () => ({ copyToClipboard: vi.fn() }))
+
+/** Arguments the panel hands each comment layer; asserted per instance. */
+interface LayerArgs {
+  slug: string | null
+  usesIframe?: boolean
+  sidebarDefaultOpen?: boolean
+  sidebarClassName?: string
+  sidebarStyle?: CSSProperties
+}
+const layerArgs: LayerArgs[] = []
+const anchorRequests: string[] = []
+let stubComments: ArtifactComment[] = []
+
+// A stateful stand-in: real `sidebarOpen` state (so the toggle is exercised for
+// real) over a comment list the test controls. The two instances are told apart
+// by `sidebarClassName` — only the non-fullscreen layer is given the stacked
+// sizing — so each renders a distinguishable marker.
+vi.mock('../components/FileArtifactComments', async () => {
+  const { useState } = await import('react')
+  function useFileArtifactComments(args: LayerArgs) {
+    layerArgs.push(args)
+    const [sidebarOpen, setSidebarOpen] = useState(args.sidebarDefaultOpen ?? true)
+    const which = args.sidebarClassName ? 'stacked' : 'full'
+    return {
+      overlay: null,
+      popovers: <div data-testid={`popovers-${which}`} />,
+      sidebar: <div data-testid={`sidebar-${which}`} />,
+      requestAnchoredComment: () => { anchorRequests.push(which) },
+      toggleSidebar: () => setSidebarOpen((v: boolean) => !v),
+      sidebarOpen,
+      commentCount: stubComments.length,
+      comments: stubComments,
+      activeCommentId: null,
+      scrollNonce: 0,
+      unreadRootIds: new Set<string>(),
+      activateComment: () => {},
+      onIframeSelect: () => {},
+      onIframeOpenThread: () => {},
+      iframeScrollTarget: null,
+    }
+  }
+  return { useFileArtifactComments }
+})
+
+const makeRect = () => document.createElement('div').getBoundingClientRect()
+
+interface StubAction {
+  id: string
+  label: string
+  onClick: (text: string, rect: DOMRect) => void
+}
+vi.mock('../components/SelectionToolbar', () => ({
+  default: ({ actions }: { actions: StubAction[] }) => (
+    <div data-testid="selection-toolbar">
+      {actions.map((a) => (
+        <span key={a.id}>
+          <button type="button" aria-label={`selection ${a.id}`} onClick={() => a.onClick(SELECTED_TEXT, makeRect())}>
+            {a.label}
+          </button>
+          <button type="button" aria-label={`selection ${a.id} blank`} onClick={() => a.onClick('', makeRect())}>
+            {`${a.label} blank`}
+          </button>
+        </span>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('../components/ArtifactBody', () => ({
+  ArtifactBodyNative: ({ kind, content, flush, onChange }: {
+    kind: Artifact['kind']
+    content: string
+    flush?: boolean
+    onChange: (v: string) => void
+  }) => (
+    <div data-testid="body-native" data-kind={kind} data-flush={String(!!flush)}>
+      <span data-testid="body-native-content">{content}</span>
+      <button type="button" onClick={() => onChange('edited')}>attempt body edit</button>
+    </div>
+  ),
+  ArtifactBodyIframe: ({ artifact, slug }: { artifact: Artifact; slug: string }) => (
+    <div data-testid="body-iframe" data-kind={artifact.kind} data-slug={slug} />
+  ),
+  ArtifactBodyImage: ({ artifact, slug }: { artifact: Artifact; slug: string }) => (
+    <div data-testid="body-image" data-kind={artifact.kind} data-slug={slug} />
+  ),
+}))
+
+const mkArtifact = (overrides: Partial<Artifact> = {}): Artifact => ({
+  slug: SLUG,
+  name: NAME,
+  kind: 'markdown',
+  source: 'chat',
+  description: 'Panel fixture',
+  tags: [],
+  version: 3,
+  created_at: '2026-06-01T00:00:00Z',
+  updated_at: '2026-06-01T01:00:00Z',
+  content: LIVE_CONTENT,
+  ...overrides,
+})
+
+const mkComment = (overrides: Partial<ArtifactComment> = {}): ArtifactComment => ({
+  id: 'c1',
+  author: 'zezhen',
+  is_agent: false,
+  body: 'tighten this heading',
+  thread_id: 'c1',
+  status: 'open',
+  scope: 'private',
+  origin: 'local',
+  sync_state: 'local_only',
+  created_at: '2026-06-01T02:00:00Z',
+  updated_at: '2026-06-01T02:00:00Z',
+  ...overrides,
+})
+
+interface PanelOverrides {
+  kind?: Artifact['kind']
+  content?: string
+  onSubmitComments?: (message: string) => void
+  embedded?: boolean
+}
+
+function renderPanel({ kind = 'markdown', content = SEED_CONTENT, onSubmitComments, embedded }: PanelOverrides = {}) {
+  const onClose = vi.fn()
+  const utils = renderWithProviders(
+    <Routes>
+      <Route
+        path="/"
+        element={
+          <ArtifactPanel
+            slug={SLUG}
+            kind={kind}
+            content={content}
+            onClose={onClose}
+            onSubmitComments={onSubmitComments}
+            embedded={embedded}
+          />
+        }
+      />
+      <Route path="/artifacts/:slug" element={<div>full artifact page</div>} />
+    </Routes>,
+  )
+  return { onClose, ...utils }
+}
+
+/** Enter fullscreen and hand back the portal dialog. */
+async function enterFullscreen() {
+  fireEvent.click(screen.getByRole('button', { name: 'Full screen' }))
+  return await screen.findByRole('dialog')
+}
+
+describe('ArtifactPanel', () => {
+  beforeEach(() => {
+    // The submit guard schedules a 400ms reset; a real timer would fire after
+    // teardown and throw as an unhandled error. `shouldAdvanceTime` keeps the
+    // clock moving so findBy*/waitFor behave as they do with real timers.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.clearAllMocks()
+    layerArgs.length = 0
+    anchorRequests.length = 0
+    stubComments = []
+    vi.mocked(api.artifact).mockResolvedValue(mkArtifact())
+    // The provider tree's own boot query rides along on the automocked client;
+    // resolving it keeps React Query's "data cannot be undefined" out of stderr.
+    vi.mocked(api.themeBoot).mockResolvedValue({} as Awaited<ReturnType<typeof api.themeBoot>>)
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  describe('body selection', () => {
+    it('renders the live artifact once loaded, flushed against the panel padding', async () => {
+      renderPanel()
+      expect(await screen.findByText(NAME)).toBeInTheDocument()
+      const body = screen.getByTestId('body-native')
+      expect(body.getAttribute('data-kind')).toBe('markdown')
+      // Non-fullscreen drops the body's card chrome so a markdown artifact
+      // matches a markdown FILE in the same panel.
+      expect(body.getAttribute('data-flush')).toBe('true')
+      expect(screen.getByTestId('body-native-content').textContent).toBe(LIVE_CONTENT)
+    })
+
+    it('keeps the body read-only — the change handler is a no-op', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      fireEvent.click(screen.getByRole('button', { name: 'attempt body edit' }))
+      // No writer is wired up, so the content is unchanged and nothing throws.
+      expect(screen.getByTestId('body-native-content').textContent).toBe(LIVE_CONTENT)
+      expect(api.artifact).toHaveBeenCalledWith(SLUG)
+    })
+
+    it('renders the seeded kind and content until the live query resolves', () => {
+      vi.mocked(api.artifact).mockReturnValue(new Promise<Artifact>(() => {}))
+      renderPanel({ kind: 'text' })
+      // Seed renders synchronously; the slug stands in for the not-yet-known name.
+      expect(screen.getByText(SLUG)).toBeInTheDocument()
+      expect(screen.getByTestId('body-native').getAttribute('data-kind')).toBe('text')
+      expect(screen.getByTestId('body-native-content').textContent).toBe(SEED_CONTENT)
+    })
+
+    it('shows the hydrating state only when there is no seed content', () => {
+      vi.mocked(api.artifact).mockReturnValue(new Promise<Artifact>(() => {}))
+      renderPanel({ content: '' })
+      expect(screen.getByText('Loading artifact…')).toBeInTheDocument()
+      expect(screen.queryByTestId('body-native')).toBeNull()
+    })
+
+    it('shows the load-failure message when the fetch rejects with no seed', async () => {
+      vi.mocked(api.artifact).mockRejectedValue(new Error('artifact gone'))
+      renderPanel({ content: '' })
+      expect(await screen.findByText(/Couldn’t load this artifact/)).toBeInTheDocument()
+      expect(screen.queryByTestId('body-native')).toBeNull()
+    })
+
+    it('renders the image body for an image artifact', async () => {
+      vi.mocked(api.artifact).mockResolvedValue(mkArtifact({ kind: 'image', content: '' }))
+      renderPanel({ kind: 'image', content: '' })
+      const body = await screen.findByTestId('body-image')
+      expect(body.getAttribute('data-slug')).toBe(SLUG)
+      expect(body.getAttribute('data-kind')).toBe('image')
+    })
+
+    it('renders the iframe body for a widget and drops the selection toolbar', async () => {
+      vi.mocked(api.artifact).mockResolvedValue(mkArtifact({ kind: 'widget' }))
+      renderPanel({ kind: 'widget' })
+      const body = await screen.findByTestId('body-iframe')
+      expect(body.getAttribute('data-slug')).toBe(SLUG)
+      // Text selection is an in-iframe concern, so the DOM toolbar is not mounted.
+      expect(screen.queryByTestId('selection-toolbar')).toBeNull()
+      // Both comment layers are told the body is an iframe.
+      expect(layerArgs.every((a) => a.usesIframe === true)).toBe(true)
+    })
+  })
+
+  describe('comment layers', () => {
+    it('gives the panel layer stacked sizing and a collapsed default', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      const stacked = layerArgs.find((a) => a.sidebarClassName)
+      const full = layerArgs.find((a) => !a.sidebarClassName)
+      expect(stacked?.sidebarDefaultOpen).toBe(false)
+      expect(stacked?.sidebarClassName).toContain('rounded-xl')
+      expect(stacked?.sidebarStyle).toEqual({ maxHeight: 280, minHeight: 0 })
+      // The fullscreen layer keeps the full-page default (open, unsized).
+      expect(full?.sidebarDefaultOpen).toBeUndefined()
+      expect(full?.slug).toBe(SLUG)
+    })
+
+    it('toggles the comments sidebar and shows the count pill', async () => {
+      stubComments = [mkComment(), mkComment({ id: 'c2', thread_id: 'c2' })]
+      renderPanel()
+      await screen.findByText(NAME)
+      const toggle = screen.getByRole('button', { name: 'Show comments' })
+      expect(toggle.textContent).toBe('2')
+      expect(toggle.getAttribute('aria-pressed')).toBe('false')
+      expect(screen.queryByTestId('sidebar-stacked')).toBeNull()
+
+      fireEvent.click(toggle)
+      expect(await screen.findByTestId('sidebar-stacked')).toBeInTheDocument()
+      const opened = screen.getByRole('button', { name: 'Hide comments' })
+      expect(opened.getAttribute('aria-pressed')).toBe('true')
+
+      fireEvent.click(opened)
+      await waitFor(() => expect(screen.queryByTestId('sidebar-stacked')).toBeNull())
+    })
+
+    it('omits the count pill when there are no comments', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      expect(screen.getByRole('button', { name: 'Show comments' }).textContent).toBe('')
+    })
+
+    it('routes the selection comment action to the active layer', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      fireEvent.click(screen.getByRole('button', { name: 'selection comment' }))
+      expect(anchorRequests).toEqual(['stacked'])
+    })
+
+    it('copies selected text, and ignores a blank selection', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      fireEvent.click(screen.getByRole('button', { name: 'selection copy' }))
+      expect(copyToClipboard).toHaveBeenCalledWith(SELECTED_TEXT)
+
+      vi.mocked(copyToClipboard).mockClear()
+      fireEvent.click(screen.getByRole('button', { name: 'selection copy blank' }))
+      expect(copyToClipboard).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('header, footer and navigation', () => {
+    it('copies the slug from the footer', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      fireEvent.click(screen.getByTitle('Click to copy slug'))
+      expect(copyToClipboard).toHaveBeenCalledWith(SLUG)
+    })
+
+    it('navigates to the full artifact page', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      fireEvent.click(screen.getByRole('button', { name: 'Open full artifact page' }))
+      expect(await screen.findByText('full artifact page')).toBeInTheDocument()
+    })
+
+    it('renders as an embedded tab body without a resize handle', async () => {
+      renderPanel({ embedded: true })
+      await screen.findByText(NAME)
+      expect(screen.queryByRole('separator')).toBeNull()
+    })
+  })
+
+  describe('escape handling', () => {
+    it('closes the panel on Escape', async () => {
+      const { onClose } = renderPanel()
+      await screen.findByText(NAME)
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores keys other than Escape', async () => {
+      const { onClose } = renderPanel()
+      await screen.findByText(NAME)
+      fireEvent.keyDown(document.body, { key: 'a' })
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('leaves Escape to the field while the user is typing', async () => {
+      const onSubmitComments = vi.fn()
+      stubComments = [mkComment()]
+      const { onClose } = renderPanel({ onSubmitComments })
+      await screen.findByText(NAME)
+      fireEvent.click(screen.getByRole('button', { name: 'Toggle additional instruction' }))
+      const field = await screen.findByLabelText('Additional instruction')
+      fireEvent.keyDown(field, { key: 'Escape' })
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('leaves Escape to a contenteditable target', async () => {
+      const { onClose } = renderPanel()
+      await screen.findByText(NAME)
+      const editable = document.createElement('div')
+      // happy-dom does not derive isContentEditable from the attribute, so the
+      // property is set directly — the component reads exactly that property.
+      Object.defineProperty(editable, 'isContentEditable', { value: true })
+      document.body.appendChild(editable)
+      fireEvent.keyDown(editable, { key: 'Escape' })
+      expect(onClose).not.toHaveBeenCalled()
+      editable.remove()
+    })
+  })
+
+  describe('fullscreen overlay', () => {
+    it('locks body scroll while open and restores it on exit', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      const dialog = await enterFullscreen()
+      expect(document.body.style.overflow).toBe('hidden')
+      expect(within(dialog).getByText(NAME)).toBeInTheDocument()
+
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Exit full screen' }))
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+      expect(document.body.style.overflow).toBe('')
+    })
+
+    it('keeps the body card chrome in fullscreen while the panel body stays flush', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      await enterFullscreen()
+      const flushFlags = screen.getAllByTestId('body-native').map((b) => b.getAttribute('data-flush'))
+      expect(flushFlags).toHaveLength(2)
+      expect(flushFlags).toContain('true')
+      expect(flushFlags).toContain('false')
+    })
+
+    it('opens the fullscreen comment sidebar by default and can collapse it', async () => {
+      stubComments = [mkComment()]
+      renderPanel()
+      await screen.findByText(NAME)
+      const dialog = await enterFullscreen()
+      expect(screen.getByTestId('sidebar-full')).toBeInTheDocument()
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Hide comments' }))
+      await waitFor(() => expect(screen.queryByTestId('sidebar-full')).toBeNull())
+    })
+
+    it('swaps the panel popovers for the fullscreen layer popovers', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      expect(screen.getByTestId('popovers-stacked')).toBeInTheDocument()
+      await enterFullscreen()
+      expect(screen.queryByTestId('popovers-stacked')).toBeNull()
+      expect(screen.getByTestId('popovers-full')).toBeInTheDocument()
+    })
+
+    it('exits fullscreen on Escape before closing the panel', async () => {
+      const { onClose } = renderPanel()
+      await screen.findByText(NAME)
+      await enterFullscreen()
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+      expect(onClose).not.toHaveBeenCalled()
+
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('seeds focus on the first control when the overlay mounts', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      const dialog = await enterFullscreen()
+      const focusable = dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      expect(document.activeElement).toBe(focusable[0])
+    })
+
+    it('traps Tab focus inside the overlay in both directions', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      const dialog = await enterFullscreen()
+      // Same selector the overlay's own trap uses — a narrower one (buttons
+      // only) would miss the tabbable footer row and pick the wrong "last".
+      const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      expect(focusable.length).toBeGreaterThan(1)
+
+      last.focus()
+      fireEvent.keyDown(dialog, { key: 'Tab' })
+      expect(document.activeElement).toBe(first)
+
+      first.focus()
+      fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true })
+      expect(document.activeElement).toBe(last)
+
+      // Mid-list Tab is left to the browser, and a non-Tab key is ignored.
+      focusable[1].focus()
+      fireEvent.keyDown(dialog, { key: 'Tab' })
+      expect(document.activeElement).toBe(focusable[1])
+      fireEvent.keyDown(dialog, { key: 'Enter' })
+      expect(document.activeElement).toBe(focusable[1])
+    })
+
+    it('navigates to the full artifact page from the overlay header', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      const dialog = await enterFullscreen()
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Open full artifact page' }))
+      expect(await screen.findByText('full artifact page')).toBeInTheDocument()
+    })
+
+    it('copies the slug from the overlay footer', async () => {
+      renderPanel()
+      await screen.findByText(NAME)
+      const dialog = await enterFullscreen()
+      fireEvent.click(within(dialog).getByTitle('Click to copy slug'))
+      expect(copyToClipboard).toHaveBeenCalledWith(SLUG)
+    })
+  })
+
+  describe('submit to chat', () => {
+    it('hides the submit bar when no submit channel is supplied', async () => {
+      stubComments = [mkComment()]
+      renderPanel()
+      await screen.findByText(NAME)
+      expect(screen.queryByRole('button', { name: 'Submit' })).toBeNull()
+    })
+
+    it('hides the submit bar when every comment is agent-authored', async () => {
+      stubComments = [mkComment({ id: 'a1', thread_id: 'a1', is_agent: true, author: 'kiro' })]
+      renderPanel({ onSubmitComments: vi.fn() })
+      await screen.findByText(NAME)
+      expect(screen.queryByRole('button', { name: 'Submit' })).toBeNull()
+    })
+
+    it('submits only the human comments and guards against a double fire', async () => {
+      const onSubmitComments = vi.fn()
+      stubComments = [
+        mkComment(),
+        mkComment({ id: 'a1', thread_id: 'a1', is_agent: true, author: 'kiro', body: 'agent note' }),
+      ]
+      renderPanel({ onSubmitComments })
+      await screen.findByText(NAME)
+      expect(screen.getByText('1 comment to send to this chat')).toBeInTheDocument()
+
+      const submit = screen.getByRole('button', { name: 'Submit' })
+      fireEvent.click(submit)
+      expect(onSubmitComments).toHaveBeenCalledTimes(1)
+      const message = onSubmitComments.mock.calls[0][0] as string
+      expect(message).toContain(`${NAME} (${SLUG})`)
+      expect(message).toContain('tighten this heading')
+      expect(message).not.toContain('agent note')
+
+      // The guard disables the button for one short window, then releases it.
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled())
+      await act(async () => { vi.advanceTimersByTime(SUBMIT_GUARD_MS) })
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Submit' })).toBeEnabled())
+    })
+
+    it('threads an extra instruction through the message and clears it after submit', async () => {
+      const onSubmitComments = vi.fn()
+      const instruction = 'apply all of these in one pass'
+      stubComments = [mkComment()]
+      renderPanel({ onSubmitComments })
+      await screen.findByText(NAME)
+
+      const toggle = screen.getByRole('button', { name: 'Toggle additional instruction' })
+      expect(toggle.getAttribute('aria-pressed')).toBe('false')
+      fireEvent.click(toggle)
+      const field = await screen.findByLabelText('Additional instruction')
+      expect(field).toHaveFocus()
+      fireEvent.change(field, { target: { value: instruction } })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+      const message = onSubmitComments.mock.calls[0][0] as string
+      expect(message).toContain('OVERALL INSTRUCTION')
+      expect(message).toContain(instruction)
+      // Submitting collapses the affordance and drops the note.
+      await waitFor(() => expect(screen.queryByLabelText('Additional instruction')).toBeNull())
+    })
+
+    it('omits the instruction block when the toggle was never opened', async () => {
+      const onSubmitComments = vi.fn()
+      stubComments = [mkComment()]
+      renderPanel({ onSubmitComments })
+      await screen.findByText(NAME)
+      fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+      expect(onSubmitComments.mock.calls[0][0]).not.toContain('OVERALL INSTRUCTION')
+    })
+
+    it('renders a submit bar in the fullscreen overlay too', async () => {
+      const onSubmitComments = vi.fn()
+      stubComments = [mkComment(), mkComment({ id: 'c2', thread_id: 'c2' })]
+      renderPanel({ onSubmitComments })
+      await screen.findByText(NAME)
+      const dialog = await enterFullscreen()
+      const overlaySubmit = within(dialog).getByRole('button', { name: 'Submit' })
+      fireEvent.click(overlaySubmit)
+      expect(onSubmitComments).toHaveBeenCalledTimes(1)
+      expect(within(dialog).getByText('2 comments to send to this chat')).toBeInTheDocument()
+    })
+  })
+})

--- a/website/src/test/CrewCompanionColorCustomizerPanelCoverage.test.tsx
+++ b/website/src/test/CrewCompanionColorCustomizerPanelCoverage.test.tsx
@@ -1,0 +1,490 @@
+/**
+ * `apps/crew-companion/ColorCustomizerPanel.tsx` — the companion's whole
+ * recolouring surface, driven end to end through its one seam.
+ *
+ * The panel is a preset grid plus a manual per-body-part editor. Everything it can
+ * reach outside itself goes through `petBridge`, so that module is the only double
+ * here: the colour maths (`colorCustomizer`, `catPresets`, `builtInCatPresets`) and
+ * the data-URI encoder run for real, because the previews ARE their output and a
+ * stub would prove nothing about the image a user actually sees.
+ *
+ * The behaviours pinned below are the ones a user can be lied to by:
+ *
+ *  - what is read on mount reaches the previews (a saved map recolours the combined
+ *    thumbnail and pre-fills every colour input) and an EMPTY read leaves the art
+ *    alone rather than blanking it;
+ *  - the per-part highlight preview really fades the OTHER colours, with the dark
+ *    outline colours faded to their own shade;
+ *  - a preset click, an Enter/Space activation and a manual edit each persist
+ *    through `gallerySetColorMap` against the pack id the backend actually reloads
+ *    by (`kiro-ghost`), and an edit drops the active mark because the result is no
+ *    longer that preset;
+ *  - the save form's guard, and the two ways out of it, which differ on whether the
+ *    typed name survives;
+ *  - delete, which must persist the SHORTER list and must not double as a click on
+ *    the card the button sits inside.
+ *
+ * Fake timers are armed defensively (this panel schedules nothing of its own, but a
+ * colour input is exactly where a debounce lands later, and a stray callback firing
+ * after teardown surfaces as an unhandled error rather than a failed assertion).
+ *
+ * The user-visible strings are read through the real `i18nT`, never hardcoded: this
+ * panel's keys are absent from the English catalogue, so i18next echoes the key back
+ * and hardcoded copy would silently rot the day the catalogue gains them.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+
+import { i18nT } from '../i18n/t'
+import type { CatPreset } from '../apps/crew-companion/catPresets'
+import type { ColorMap } from '../apps/crew-companion/colorCustomizer'
+
+/* ── bridge double ────────────────────────────────────────────── */
+
+const presetsGetColorMap = vi.fn<(packId: string) => Promise<ColorMap | undefined>>()
+const presetsLoadCustom = vi.fn<() => Promise<CatPreset[]>>()
+const presetsSaveCustom = vi.fn<(presets: CatPreset[]) => Promise<void>>()
+const gallerySetColorMap = vi.fn<(packId: string, map: ColorMap) => Promise<void>>()
+
+const bridge = { presetsGetColorMap, presetsLoadCustom, presetsSaveCustom, gallerySetColorMap }
+
+vi.mock('../apps/crew-companion/petBridge', () => ({ petBridge: bridge, galleryApi: bridge }))
+
+const { ColorCustomizerPanel } = await import('../apps/crew-companion/ColorCustomizerPanel')
+const { BUILT_IN_CAT_PRESETS } = await import('../apps/crew-companion/builtInCatPresets')
+const { applySvgColorMap } = await import('../apps/crew-companion/colorCustomizer')
+const { toDataUri } = await import('../apps/crew-companion/animationResolver')
+
+/* ── fixtures ─────────────────────────────────────────────────── */
+
+/** The backend's canonical built-in pack id (appearances.py `DEFAULT_PACK`). */
+const PACK_ID = 'kiro-ghost'
+
+/**
+ * Idle art with four distinct source colours: two the panel has a body-part label
+ * for, one "dark" colour the highlight map fades differently, and one it has no
+ * label for at all — so the hex fallback is exercised too.
+ */
+const IDLE_SVG = [
+  '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">',
+  '<path fill="#F9A85F" d="M0 0h10v10H0z" />',
+  '<path fill="#FCD9B3" d="M2 2h4v4H2z" />',
+  '<path stroke="#522210" d="M0 0L10 10" />',
+  '<path fill="#123456" d="M8 8h2v2H8z" />',
+  '</svg>',
+].join('')
+
+/** The source colours the fixture art declares, in extraction order. */
+const SOURCES = ['#F9A85F', '#FCD9B3', '#522210', '#123456']
+
+/** Labels, read the way the component reads them. */
+const BODY_FUR = i18nT('apps.crewCompanion.color.bodyFur')
+const TUMMY = i18nT('apps.crewCompanion.color.tummyPaws')
+const OUTLINES = i18nT('apps.crewCompanion.color.outlines')
+const RESET = i18nT('apps.crewCompanion.color.reset')
+const SAVE_PRESET = i18nT('apps.crewCompanion.color.savePreset')
+const CANCEL = i18nT('apps.crewCompanion.gallery.cancel')
+const DELETE = i18nT('apps.crewCompanion.color.delete')
+const NAME_PLACEHOLDER = i18nT('apps.crewCompanion.color.promptName')
+
+/** A built-in card's display name is its i18n key resolved. */
+function builtInLabel(id: string): string {
+  const found = BUILT_IN_CAT_PRESETS.find(p => p.id === id)
+  if (!found) throw new Error(`no built-in preset ${id}`)
+  return i18nT(found.name)
+}
+
+function builtInMap(id: string): ColorMap {
+  const found = BUILT_IN_CAT_PRESETS.find(p => p.id === id)
+  if (!found) throw new Error(`no built-in preset ${id}`)
+  return found.colorMap
+}
+
+/** A preset in the shape `presetsLoadCustom` hands one back from disk. */
+function customPreset(over: Partial<CatPreset> = {}): CatPreset {
+  return {
+    id: 'custom-1',
+    name: 'Sunset Kitty',
+    description: '',
+    colorMap: { '#F9A85F': '#FF0000' },
+    swatches: ['#FF0000', '#F9A85F'],
+    builtIn: false,
+    ...over,
+  }
+}
+
+/* ── harness ──────────────────────────────────────────────────── */
+
+/** Flush the one mount read (a `Promise.all` of two bridge calls) inside `act`. */
+async function flush(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 5; i += 1) await Promise.resolve()
+  })
+}
+
+async function renderPanel(): Promise<HTMLElement> {
+  const { container } = render(<ColorCustomizerPanel idleSvgContent={IDLE_SVG} />)
+  await flush()
+  return container
+}
+
+/** The card wrapper for a preset, addressed through its preview image. */
+function card(name: string): HTMLElement {
+  const wrapper = screen.getByAltText(name).closest('[role="button"]')
+  if (!wrapper) throw new Error(`no preset card for ${name}`)
+  return wrapper as HTMLElement
+}
+
+/** The manual colour input belonging to one body-part card, by its label. */
+function colorInput(bodyPart: string): HTMLInputElement {
+  const cell = screen.getByAltText(bodyPart).parentElement
+  const input = cell?.querySelector<HTMLInputElement>('input[type="color"]')
+  if (!input) throw new Error(`no colour input for ${bodyPart}`)
+  return input
+}
+
+/** The map handed to the most recent `gallerySetColorMap` call. */
+function lastPersistedMap(): ColorMap {
+  const calls = gallerySetColorMap.mock.calls
+  expect(calls.length).toBeGreaterThan(0)
+  return calls[calls.length - 1][1]
+}
+
+/** Wait for the save form to have closed itself after a successful write. */
+async function formClosed(): Promise<void> {
+  await waitFor(() => expect(screen.queryByPlaceholderText(NAME_PLACEHOLDER)).toBeNull(), {
+    timeout: 5_000,
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.clearAllMocks()
+  presetsGetColorMap.mockResolvedValue({})
+  presetsLoadCustom.mockResolvedValue([])
+  presetsSaveCustom.mockResolvedValue(undefined)
+  gallerySetColorMap.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+/* ── mount ────────────────────────────────────────────────────── */
+
+describe('ColorCustomizerPanel — what is on screen after mount', () => {
+  it('renders both sections, every built-in preset and one editor per source colour', async () => {
+    const container = await renderPanel()
+
+    expect(screen.getByText(i18nT('apps.crewCompanion.color.presets'))).toBeTruthy()
+    expect(screen.getByText(i18nT('apps.crewCompanion.color.manual'))).toBeTruthy()
+    for (const preset of BUILT_IN_CAT_PRESETS) {
+      expect(screen.getByAltText(i18nT(preset.name))).toBeTruthy()
+    }
+
+    // The combined cell is the whole-art preview, not a per-part editor.
+    expect(screen.getByAltText('final')).toBeTruthy()
+    expect(screen.getByText(i18nT('apps.crewCompanion.color.currentEffect'))).toBeTruthy()
+
+    // Three labelled parts plus the colour with no label, which shows its hex.
+    expect(screen.getByAltText(BODY_FUR)).toBeTruthy()
+    expect(screen.getByAltText(TUMMY)).toBeTruthy()
+    expect(screen.getByAltText(OUTLINES)).toBeTruthy()
+    expect(screen.getByAltText('#123456')).toBeTruthy()
+    expect(container.querySelectorAll('input[type="color"]')).toHaveLength(SOURCES.length)
+
+    expect(presetsGetColorMap).toHaveBeenCalledWith(PACK_ID)
+    expect(presetsLoadCustom).toHaveBeenCalled()
+  })
+
+  it('recolours the combined preview and pre-fills the inputs from the saved map', async () => {
+    presetsGetColorMap.mockResolvedValue({ '#F9A85F': '#00FF00' })
+    await renderPanel()
+
+    expect(screen.getByAltText('final').getAttribute('src'))
+      .toBe(toDataUri(applySvgColorMap(IDLE_SVG, { '#F9A85F': '#00FF00' })))
+    expect(colorInput(BODY_FUR).value.toLowerCase()).toBe('#00ff00')
+    // An untouched part still shows its own source colour.
+    expect(colorInput(TUMMY).value.toLowerCase()).toBe('#fcd9b3')
+  })
+
+  it('leaves the art alone when the saved map and the custom list are empty', async () => {
+    await renderPanel()
+
+    expect(screen.getByAltText('final').getAttribute('src')).toBe(toDataUri(IDLE_SVG))
+    expect(colorInput(BODY_FUR).value.toLowerCase()).toBe('#f9a85f')
+    expect(screen.queryAllByRole('button', { name: DELETE })).toHaveLength(0)
+    expect(gallerySetColorMap).not.toHaveBeenCalled()
+  })
+
+  it('fades the other colours in a part preview, dark outlines to their own shade', async () => {
+    await renderPanel()
+
+    // Only the highlighted source keeps a real colour; the dark outline colour
+    // fades to #ECECEC and everything else to #FAFAFA.
+    const expected: ColorMap = {
+      '#F9A85F': '#F9A85F',
+      '#FCD9B3': '#FAFAFA',
+      '#522210': '#ECECEC',
+      '#123456': '#FAFAFA',
+    }
+    expect(screen.getByAltText(BODY_FUR).getAttribute('src'))
+      .toBe(toDataUri(applySvgColorMap(IDLE_SVG, expected)))
+  })
+
+  it('keeps a stored custom preset, drops malformed entries, and only customs get delete', async () => {
+    presetsLoadCustom.mockResolvedValue(
+      [null, 'not-a-preset', customPreset()] as unknown as CatPreset[],
+    )
+    await renderPanel()
+
+    expect(within(card('Sunset Kitty')).getByRole('button', { name: DELETE })).toBeTruthy()
+    expect(within(card(builtInLabel('tuxedo'))).queryByRole('button', { name: DELETE })).toBeNull()
+    // The two malformed entries added no cards of their own.
+    expect(screen.queryAllByRole('button', { name: DELETE })).toHaveLength(1)
+  })
+
+  it('previews a colourless custom preset as the unmodified art', async () => {
+    presetsLoadCustom.mockResolvedValue([customPreset({ colorMap: {} })])
+    await renderPanel()
+
+    expect(screen.getByAltText('Sunset Kitty').getAttribute('src')).toBe(toDataUri(IDLE_SVG))
+  })
+})
+
+/* ── applying presets and manual edits ────────────────────────── */
+
+describe('ColorCustomizerPanel — applying a preset', () => {
+  it('marks the clicked preset active and persists its colour map', async () => {
+    await renderPanel()
+
+    fireEvent.click(card(builtInLabel('tuxedo')))
+
+    expect(gallerySetColorMap).toHaveBeenCalledWith(PACK_ID, builtInMap('tuxedo'))
+    expect(card(builtInLabel('tuxedo')).getAttribute('aria-pressed')).toBe('true')
+    expect(card(builtInLabel('calico')).getAttribute('aria-pressed')).toBe('false')
+    // The manual editors follow the preset rather than keeping the source colour.
+    expect(colorInput(BODY_FUR).value.toLowerCase())
+      .toBe(String(builtInMap('tuxedo')['#F9A85F']).toLowerCase())
+  })
+
+  it('activates a card with Enter and with Space, and ignores other keys', async () => {
+    await renderPanel()
+
+    fireEvent.keyDown(card(builtInLabel('siamese')), { key: 'Enter' })
+    expect(lastPersistedMap()).toEqual(builtInMap('siamese'))
+    expect(card(builtInLabel('siamese')).getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.keyDown(card(builtInLabel('calico')), { key: ' ' })
+    expect(lastPersistedMap()).toEqual(builtInMap('calico'))
+    expect(card(builtInLabel('calico')).getAttribute('aria-pressed')).toBe('true')
+    expect(card(builtInLabel('siamese')).getAttribute('aria-pressed')).toBe('false')
+
+    const before = gallerySetColorMap.mock.calls.length
+    fireEvent.keyDown(card(builtInLabel('ragdoll')), { key: 'a' })
+    expect(gallerySetColorMap.mock.calls).toHaveLength(before)
+  })
+
+  it('merges a manual edit into the map and drops the active preset mark', async () => {
+    await renderPanel()
+    fireEvent.click(card(builtInLabel('tuxedo')))
+
+    fireEvent.change(colorInput(TUMMY), { target: { value: '#010203' } })
+
+    const persisted = lastPersistedMap()
+    expect(persisted['#FCD9B3']).toBe('#010203')
+    // Everything the preset set is still there — the edit is a merge, not a reset.
+    expect(persisted['#F9A85F']).toBe(builtInMap('tuxedo')['#F9A85F'])
+    expect(card(builtInLabel('tuxedo')).getAttribute('aria-pressed')).toBe('false')
+    expect(colorInput(TUMMY).value.toLowerCase()).toBe('#010203')
+  })
+
+  it('Reset clears the map, the active mark and the previews', async () => {
+    presetsGetColorMap.mockResolvedValue({ '#F9A85F': '#00FF00' })
+    await renderPanel()
+    fireEvent.click(card(builtInLabel('tuxedo')))
+
+    fireEvent.click(screen.getByRole('button', { name: RESET }))
+    await flush()
+
+    expect(lastPersistedMap()).toEqual({})
+    expect(card(builtInLabel('tuxedo')).getAttribute('aria-pressed')).toBe('false')
+    expect(screen.getByAltText('final').getAttribute('src')).toBe(toDataUri(IDLE_SVG))
+    expect(colorInput(BODY_FUR).value.toLowerCase()).toBe('#f9a85f')
+  })
+})
+
+/* ── saving a custom preset ───────────────────────────────────── */
+
+describe('ColorCustomizerPanel — saving the current colours as a preset', () => {
+  it('opens the form on demand and writes nothing for a whitespace-only name', async () => {
+    await renderPanel()
+    expect(screen.queryByPlaceholderText(NAME_PLACEHOLDER)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: SAVE_PRESET }))
+    const nameField = screen.getByPlaceholderText(NAME_PLACEHOLDER)
+    const confirm = screen.getByRole('button', { name: SAVE_PRESET }) as HTMLButtonElement
+    expect(confirm.disabled).toBe(true)
+
+    fireEvent.change(nameField, { target: { value: '   ' } })
+    expect(confirm.disabled).toBe(true)
+
+    fireEvent.keyDown(nameField, { key: 'Enter' })
+    await flush()
+    expect(presetsSaveCustom).not.toHaveBeenCalled()
+    // The form stays open so the name can be corrected.
+    expect(screen.getByPlaceholderText(NAME_PLACEHOLDER)).toBeTruthy()
+  })
+
+  it('saves the edited colours under the typed name and shows the new card', async () => {
+    await renderPanel()
+    fireEvent.change(colorInput(BODY_FUR), { target: { value: '#00ff00' } })
+
+    fireEvent.click(screen.getByRole('button', { name: SAVE_PRESET }))
+    fireEvent.change(screen.getByPlaceholderText(NAME_PLACEHOLDER), {
+      target: { value: 'Sunset Kitty' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: SAVE_PRESET }))
+    await formClosed()
+
+    const saved = presetsSaveCustom.mock.calls[0][0]
+    expect(saved).toHaveLength(1)
+    expect(saved[0].name).toBe('Sunset Kitty')
+    expect(saved[0].builtIn).toBe(false)
+    expect(saved[0].colorMap).toEqual({ '#F9A85F': '#00ff00' })
+    // One edited colour yields one swatch, and the pad brings it up to two — by
+    // repeating the same colour, which is what the pad actually has to hand.
+    expect(saved[0].swatches).toEqual(['#00ff00', '#00ff00'])
+
+    // The preset joins the grid once the form has closed.
+    expect(screen.getByAltText('Sunset Kitty')).toBeTruthy()
+  })
+
+  it('keeps the swatches as they are when two colours already differ', async () => {
+    await renderPanel()
+    fireEvent.change(colorInput(BODY_FUR), { target: { value: '#00ff00' } })
+    fireEvent.change(colorInput(TUMMY), { target: { value: '#0000ff' } })
+
+    fireEvent.click(screen.getByRole('button', { name: SAVE_PRESET }))
+    fireEvent.change(screen.getByPlaceholderText(NAME_PLACEHOLDER), {
+      target: { value: 'Two Tone' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: SAVE_PRESET }))
+    await formClosed()
+
+    // Two distinct values already satisfy the 2-swatch floor, so nothing is padded.
+    expect(presetsSaveCustom.mock.calls[0][0][0].swatches).toEqual(['#00ff00', '#0000ff'])
+  })
+
+  it('saves an untouched palette as a preset with no swatches at all', async () => {
+    await renderPanel()
+
+    fireEvent.click(screen.getByRole('button', { name: SAVE_PRESET }))
+    fireEvent.change(screen.getByPlaceholderText(NAME_PLACEHOLDER), {
+      target: { value: 'Nothing Changed' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: SAVE_PRESET }))
+    await formClosed()
+
+    // Nothing was edited, so there is no colour to pad from and the stored preset
+    // carries an empty swatch list.
+    expect(presetsSaveCustom.mock.calls[0][0][0].swatches).toEqual([])
+    expect(presetsSaveCustom.mock.calls[0][0][0].colorMap).toEqual({})
+  })
+
+  it('saves on Enter, and Escape closes the form while keeping the typed name', async () => {
+    await renderPanel()
+
+    fireEvent.click(screen.getByRole('button', { name: SAVE_PRESET }))
+    fireEvent.change(screen.getByPlaceholderText(NAME_PLACEHOLDER), {
+      target: { value: 'Via Enter' },
+    })
+    fireEvent.keyDown(screen.getByPlaceholderText(NAME_PLACEHOLDER), { key: 'Enter' })
+    await formClosed()
+    expect(presetsSaveCustom.mock.calls[0][0][0].name).toBe('Via Enter')
+
+    fireEvent.click(screen.getByRole('button', { name: SAVE_PRESET }))
+    fireEvent.change(screen.getByPlaceholderText(NAME_PLACEHOLDER), {
+      target: { value: 'Abandoned' },
+    })
+    fireEvent.keyDown(screen.getByPlaceholderText(NAME_PLACEHOLDER), { key: 'Escape' })
+    expect(screen.queryByPlaceholderText(NAME_PLACEHOLDER)).toBeNull()
+    expect(presetsSaveCustom).toHaveBeenCalledTimes(1)
+
+    // Escape only hides the form: reopening still holds what was typed.
+    fireEvent.click(screen.getByRole('button', { name: SAVE_PRESET }))
+    expect((screen.getByPlaceholderText(NAME_PLACEHOLDER) as HTMLInputElement).value)
+      .toBe('Abandoned')
+  })
+
+  it('Cancel closes the form and discards the typed name', async () => {
+    await renderPanel()
+
+    fireEvent.click(screen.getByRole('button', { name: SAVE_PRESET }))
+    fireEvent.change(screen.getByPlaceholderText(NAME_PLACEHOLDER), {
+      target: { value: 'Discarded' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: CANCEL }))
+    expect(screen.queryByPlaceholderText(NAME_PLACEHOLDER)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: SAVE_PRESET }))
+    expect((screen.getByPlaceholderText(NAME_PLACEHOLDER) as HTMLInputElement).value).toBe('')
+    expect(presetsSaveCustom).not.toHaveBeenCalled()
+  })
+})
+
+/* ── deleting a custom preset ─────────────────────────────────── */
+
+describe('ColorCustomizerPanel — deleting a custom preset', () => {
+  it('persists the shorter list and does not also apply the preset it sat on', async () => {
+    presetsLoadCustom.mockResolvedValue([customPreset()])
+    await renderPanel()
+
+    fireEvent.click(within(card('Sunset Kitty')).getByRole('button', { name: DELETE }))
+    await waitFor(() => expect(presetsSaveCustom).toHaveBeenCalledWith([]), { timeout: 5_000 })
+
+    expect(screen.queryByAltText('Sunset Kitty')).toBeNull()
+    // The card's own click handler must not have fired through the delete button.
+    expect(gallerySetColorMap).not.toHaveBeenCalled()
+  })
+
+  it('keeps the active mark when a DIFFERENT preset is deleted', async () => {
+    presetsLoadCustom.mockResolvedValue([
+      customPreset(),
+      customPreset({ id: 'custom-2', name: 'Ocean Kitty', colorMap: { '#F9A85F': '#0000FF' } }),
+    ])
+    await renderPanel()
+
+    fireEvent.click(card('Sunset Kitty'))
+    expect(card('Sunset Kitty').getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.click(within(card('Ocean Kitty')).getByRole('button', { name: DELETE }))
+    await waitFor(() => expect(presetsSaveCustom).toHaveBeenCalled(), { timeout: 5_000 })
+
+    expect(presetsSaveCustom.mock.calls[0][0].map(p => p.id)).toEqual(['custom-1'])
+    expect(screen.queryByAltText('Ocean Kitty')).toBeNull()
+    expect(card('Sunset Kitty').getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('clears the active mark when the ACTIVE preset is deleted', async () => {
+    presetsLoadCustom.mockResolvedValue([customPreset()])
+    await renderPanel()
+
+    fireEvent.click(card('Sunset Kitty'))
+    expect(card('Sunset Kitty').getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.click(within(card('Sunset Kitty')).getByRole('button', { name: DELETE }))
+    await waitFor(() => expect(screen.queryByAltText('Sunset Kitty')).toBeNull(), {
+      timeout: 5_000,
+    })
+
+    for (const preset of BUILT_IN_CAT_PRESETS) {
+      expect(card(i18nT(preset.name)).getAttribute('aria-pressed')).toBe('false')
+    }
+    // The colours the deleted preset applied are still in effect — delete removes
+    // the entry, not the look.
+    expect(colorInput(BODY_FUR).value.toLowerCase()).toBe('#ff0000')
+  })
+})

--- a/website/src/test/CrewCompanionPanelCoverage.test.tsx
+++ b/website/src/test/CrewCompanionPanelCoverage.test.tsx
@@ -1,0 +1,592 @@
+/**
+ * `panel.tsx` — the companion's panel window, driven through its real entry path.
+ *
+ * The file had no tests at all, and it is not importable in the ordinary way: `Panel`
+ * is never exported and the module MOUNTS ITSELF into `#root` at import time, after
+ * awaiting the dashboard theme. So the harness below is the module's own bootstrap —
+ * create the host, register the mocks it reaches for, then import it.
+ *
+ * What is asserted is what the window would actually do: which snapshot fields reach
+ * the card, that at most three chronological items are offered, the two suppress-close
+ * reports the main process depends on (`panelBreathing`, `panelHold`), the Escape rule
+ * and its one exception, and the four writes (add, remove, skip, breathing-done)
+ * including what happens when each of them fails.
+ *
+ * The card and the breathing exercise are replaced by stubs on purpose: both are
+ * covered by their own tests, `PetAvatar` inside the exercise resolves art through
+ * image decode that never settles under this DOM, and stubbing them keeps every
+ * assertion here about the panel's own logic.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { waitFor, fireEvent } from '@testing-library/react'
+
+import {
+  ADD_PATH,
+  BREATHING_DONE_PATH,
+  REMINDERS_PATH,
+  REMOVE_PATH,
+  SKIP_PATH,
+} from '../apps/crew-companion/constants'
+import type { PanelCardProps } from '../apps/crew-companion/PanelCard'
+
+/** The fire time the stub's add button asks for. Fixed, so the body is assertable. */
+const ADD_AT = '2031-04-05T06:07:00.000Z'
+
+// The theme adopt is a real same-origin stylesheet read in production; here it just
+// resolves so the bootstrap gets as far as `createRoot`.
+vi.mock('../apps/crew-companion/dashboardTheme', () => ({
+  adoptDashboardTheme: () => Promise.resolve(),
+  watchThemeChanges: () => () => {},
+  applyThemeId: () => {},
+  extractStylesheetHrefs: () => [],
+}))
+
+/** Callbacks the panel registered for `config:updated`. */
+let configCbs: Array<() => void> = []
+const petBridgeStub = {
+  onConfigUpdated: vi.fn((cb: () => void) => {
+    configCbs.push(cb)
+    return () => {
+      configCbs = configCbs.filter((c) => c !== cb)
+    }
+  }),
+}
+vi.mock('../apps/crew-companion/petBridge', () => ({ petBridge: petBridgeStub }))
+
+/** What the last add resolved to — the panel's own true/false contract. */
+let addResult: boolean | null = null
+
+/**
+ * The card, reduced to the props the panel computes plus one control per callback.
+ *
+ * Everything the panel decides is readable from the DOM this renders, so the
+ * assertions below never depend on the real card's layout or wording.
+ */
+vi.mock('../apps/crew-companion/PanelCard', () => ({
+  PanelCard: (props: PanelCardProps) => (
+    <div
+      data-testid="card"
+      data-view={props.view}
+      data-side={props.openSide}
+      data-break={String(props.breakMins)}
+      data-session={String(props.sessionOn)}
+      data-rows={String(props.upNext.length)}
+    >
+      {props.upNext.map((item) => (
+        <div
+          key={item.id}
+          data-testid={`row-${item.id}`}
+          data-rel={item.relLabel}
+          data-abs={item.absLabel ?? ''}
+          data-recurring={String(Boolean(item.recurring))}
+        >
+          {item.text}
+        </div>
+      ))}
+      <button type="button" data-testid="breathe" onClick={() => props.onBreathe?.()}>
+        breathe
+      </button>
+      <button type="button" data-testid="see-all" onClick={() => props.onSeeAll?.()}>
+        see all
+      </button>
+      <button type="button" data-testid="settings" onClick={() => props.onSettings?.()}>
+        settings
+      </button>
+      <button type="button" data-testid="back" onClick={() => props.onBack?.()}>
+        back
+      </button>
+      <button type="button" data-testid="close" onClick={() => props.onClose?.()}>
+        close
+      </button>
+      <button type="button" data-testid="remove" onClick={() => props.onRemove?.('r1')}>
+        remove
+      </button>
+      <button type="button" data-testid="skip" onClick={() => props.onSkip?.('r2')}>
+        skip
+      </button>
+      <button
+        type="button"
+        data-testid="add"
+        onClick={() => {
+          void Promise.resolve(props.onAdd?.('drink water', ADD_AT, 60)).then((ok) => {
+            addResult = ok ?? null
+          })
+        }}
+      >
+        add
+      </button>
+    </div>
+  ),
+}))
+
+/** The exercise, reduced to its two exits. */
+vi.mock('../apps/crew-companion/BreathingOverlay', () => ({
+  default: (props: { onDone: () => void; onEnd: () => void }) => (
+    <div data-testid="breathing">
+      <button type="button" data-testid="breathe-done" onClick={() => props.onDone()}>
+        done
+      </button>
+      <button type="button" data-testid="breathe-end" onClick={() => props.onEnd()}>
+        end
+      </button>
+    </div>
+  ),
+}))
+
+/**
+ * `panel.tsx` owns its own React root, so nothing in @testing-library can unmount it.
+ * Wrapping `createRoot` is what lets each test tear its window down, which keeps one
+ * test's 30s refresh interval out of the next.
+ */
+const roots: Array<{ unmount: () => void }> = []
+vi.mock('react-dom/client', async () => {
+  const actual = await vi.importActual<typeof import('react-dom/client')>('react-dom/client')
+  return {
+    ...actual,
+    createRoot: (container: Element | DocumentFragment, options?: never) => {
+      const root = actual.createRoot(container, options)
+      roots.push(root)
+      return root
+    },
+  }
+})
+
+interface Call {
+  url: string
+  method: string
+  body: Record<string, unknown> | null
+}
+
+/** Every request the panel made, in order. */
+let calls: Call[] = []
+/** What GET /reminders answers with. A test may rewrite it before mounting. */
+let snapshot: Record<string, unknown> = {}
+/** Paths whose fetch REJECTS (the offline path). */
+let rejecting = new Set<string>()
+/** Paths that answer not-ok (the backend refused). */
+let refusing = new Set<string>()
+
+/** The window-level preload bridge, as the panel sees it. */
+function installBridge() {
+  const preload = {
+    panelClose: vi.fn(),
+    panelBreathing: vi.fn(),
+    panelHold: vi.fn(),
+    onPanelOpened: vi.fn((cb: (side: 'left' | 'right') => void) => {
+      openedCbs.push(cb)
+      return () => {}
+    }),
+  }
+  ;(window as unknown as { crewCompanion?: typeof preload }).crewCompanion = preload
+  return preload
+}
+let openedCbs: Array<(side: 'left' | 'right') => void> = []
+let api: ReturnType<typeof installBridge>
+
+/**
+ * Mount the panel through its real entry path.
+ *
+ * `vi.resetModules()` is what makes a second mount possible at all: the bootstrap is
+ * module-level, so with a warm registry only the first test would ever render.
+ */
+async function mountPanel(): Promise<void> {
+  const host = document.createElement('div')
+  host.id = 'root'
+  document.body.appendChild(host)
+  vi.resetModules()
+  await import('../apps/crew-companion/panel')
+  await waitFor(() =>
+    expect(document.querySelector('[data-testid="card"]')).not.toBeNull(),
+  )
+}
+
+function card(): HTMLElement {
+  return document.querySelector('[data-testid="card"]') as HTMLElement
+}
+
+function control(id: string): HTMLElement {
+  return document.querySelector(`[data-testid="${id}"]`) as HTMLElement
+}
+
+function row(id: string): HTMLElement | null {
+  return document.querySelector(`[data-testid="row-${id}"]`)
+}
+
+function countOf(path: string): number {
+  return calls.filter((c) => c.url === path).length
+}
+
+function iso(minutesFromNow: number): string {
+  return new Date(Date.now() + minutesFromNow * 60_000).toISOString()
+}
+
+/** A snapshot with four pending reminders and one already-fired one-off. */
+function fourPending(): Record<string, unknown> {
+  return {
+    reminders: [
+      { id: 'r4', text: 'fourth', fireAt: iso(240), recurrence: null },
+      { id: 'rDone', text: 'fired', fireAt: iso(-60), recurrence: null, done: true },
+      { id: 'r2', text: 'second', fireAt: iso(120), recurrence: { everyMinutes: 60 } },
+      { id: 'r1', text: 'first', fireAt: iso(45), recurrence: null },
+      { id: 'r3', text: 'third', fireAt: iso(180), recurrence: null },
+    ],
+    breakReminderMins: 30,
+    sessionNotificationsEnabled: false,
+  }
+}
+
+beforeEach(() => {
+  // The panel schedules a 30s refresh, and its callback would fire after this
+  // environment is gone. Fake timers keep it inside the test's own lifetime;
+  // `shouldAdvanceTime` keeps the clock moving so `waitFor` behaves as with real ones.
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  calls = []
+  configCbs = []
+  openedCbs = []
+  rejecting = new Set<string>()
+  refusing = new Set<string>()
+  snapshot = { reminders: [] }
+  addResult = null
+  window.localStorage.clear()
+  // `vi.resetModules()` hands panel.tsx a FRESH i18next whose `initI18n()` (no
+  // argument) resolves the language from storage, so English is pinned here too.
+  window.localStorage.setItem('mc-lang', 'en')
+  api = installBridge()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      let body: Record<string, unknown> | null = null
+      if (typeof init?.body === 'string') {
+        body = JSON.parse(init.body) as Record<string, unknown>
+      }
+      calls.push({ url, method: init?.method ?? 'GET', body })
+      if (rejecting.has(url)) throw new Error('offline')
+      if (refusing.has(url)) return { ok: false, json: async () => ({}) } as unknown as Response
+      if (url === REMINDERS_PATH) {
+        return { ok: true, json: async () => snapshot } as unknown as Response
+      }
+      return { ok: true, json: async () => ({}) } as unknown as Response
+    }),
+  )
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) root.unmount()
+  document.querySelectorAll('#root').forEach((n) => n.remove())
+  delete (window as unknown as { crewCompanion?: unknown }).crewCompanion
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('the panel window mounts and reads its snapshot', () => {
+  it('mounts the card into #root once the theme has been adopted', async () => {
+    await mountPanel()
+    expect(card()).not.toBeNull()
+    expect(document.getElementById('root')?.contains(card())).toBe(true)
+  })
+
+  it('reads the reminder snapshot on mount', async () => {
+    await mountPanel()
+    await waitFor(() => expect(countOf(REMINDERS_PATH)).toBeGreaterThan(0))
+    expect(calls[0].method).toBe('GET')
+  })
+
+  it('offers at most three items, chronologically, with fired one-offs sunk', async () => {
+    snapshot = fourPending()
+    await mountPanel()
+    await waitFor(() => expect(card().dataset.rows).toBe('3'))
+    expect(row('r1')?.textContent).toBe('first')
+    expect(row('r2')).not.toBeNull()
+    expect(row('r3')).not.toBeNull()
+    // Beyond the truthful window, and the already-fired one never displaces a pending.
+    expect(row('r4')).toBeNull()
+    expect(row('rDone')).toBeNull()
+  })
+
+  it('labels an imminent item relatively and a later one absolutely too', async () => {
+    snapshot = fourPending()
+    await mountPanel()
+    await waitFor(() => expect(card().dataset.rows).toBe('3'))
+    // Under an hour: a countdown and no clock time.
+    expect(row('r1')?.dataset.rel).toContain('45')
+    expect(row('r1')?.dataset.abs).toBe('')
+    // Further out: a clock time appears beside it.
+    expect(row('r2')?.dataset.abs).not.toBe('')
+  })
+
+  it('marks a repeating reminder as recurring, so Skip is offered only there', async () => {
+    snapshot = fourPending()
+    await mountPanel()
+    await waitFor(() => expect(card().dataset.rows).toBe('3'))
+    expect(row('r2')?.dataset.recurring).toBe('true')
+    expect(row('r1')?.dataset.recurring).toBe('false')
+  })
+
+  it('threads the break cadence AND the session-alert state out of the same payload', async () => {
+    snapshot = fourPending()
+    await mountPanel()
+    // The regression this guards: `sessionNotificationsEnabled` sat in the payload
+    // and never left the fetch, so the footer claimed alerts were on regardless.
+    await waitFor(() => expect(card().dataset.session).toBe('false'))
+    expect(card().dataset.break).toBe('30')
+  })
+
+  it('keeps its defaults when the payload omits the two settings', async () => {
+    snapshot = { reminders: [] }
+    await mountPanel()
+    expect(card().dataset.break).toBe('45')
+    expect(card().dataset.session).toBe('true')
+  })
+
+  it('ignores settings of the wrong type rather than rendering NaN or blank', async () => {
+    snapshot = { reminders: [], breakReminderMins: 'soon', sessionNotificationsEnabled: 'yes' }
+    await mountPanel()
+    expect(card().dataset.break).toBe('45')
+    expect(card().dataset.session).toBe('true')
+  })
+
+  it('treats a non-array reminders field as an empty list', async () => {
+    snapshot = { reminders: { r1: 'first' } }
+    await mountPanel()
+    expect(card().dataset.rows).toBe('0')
+  })
+
+  it('renders the empty card when the backend refuses the read', async () => {
+    refusing.add(REMINDERS_PATH)
+    await mountPanel()
+    await waitFor(() => expect(countOf(REMINDERS_PATH)).toBeGreaterThan(0))
+    expect(card().dataset.rows).toBe('0')
+  })
+
+  it('survives a rejected read instead of tearing the window down', async () => {
+    rejecting.add(REMINDERS_PATH)
+    await mountPanel()
+    await waitFor(() => expect(countOf(REMINDERS_PATH)).toBeGreaterThan(0))
+    expect(card()).not.toBeNull()
+  })
+})
+
+describe('when the panel re-reads', () => {
+  it('refreshes on its own interval while the window stays open', async () => {
+    await mountPanel()
+    await waitFor(() => expect(countOf(REMINDERS_PATH)).toBeGreaterThan(0))
+    const before = countOf(REMINDERS_PATH)
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(countOf(REMINDERS_PATH)).toBeGreaterThan(before)
+  })
+
+  it('re-reads the moment a setting changes, instead of waiting out the poll', async () => {
+    await mountPanel()
+    await waitFor(() => expect(configCbs.length).toBeGreaterThan(0))
+    const before = countOf(REMINDERS_PATH)
+    snapshot = { reminders: [], breakReminderMins: 90, sessionNotificationsEnabled: true }
+    for (const cb of configCbs) cb()
+    // The footer beside the settings view used to disagree with it for up to 30s.
+    await waitFor(() => expect(card().dataset.break).toBe('90'))
+    expect(countOf(REMINDERS_PATH)).toBeGreaterThan(before)
+  })
+
+  it('stops polling once the window is torn down', async () => {
+    await mountPanel()
+    await waitFor(() => expect(countOf(REMINDERS_PATH)).toBeGreaterThan(0))
+    for (const root of roots.splice(0)) root.unmount()
+    const after = countOf(REMINDERS_PATH)
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(countOf(REMINDERS_PATH)).toBe(after)
+  })
+})
+
+describe('the side the panel opened on, and re-opening it', () => {
+  it('defaults to growing out of the companion on the right', async () => {
+    await mountPanel()
+    expect(card().dataset.side).toBe('right')
+  })
+
+  it('aims the spring left when the main process says the panel opened there', async () => {
+    await mountPanel()
+    await waitFor(() => expect(openedCbs.length).toBeGreaterThan(0))
+    for (const cb of openedCbs) cb('left')
+    await waitFor(() => expect(card().dataset.side).toBe('left'))
+  })
+
+  it('treats any other side as the right, never as an unset origin', async () => {
+    await mountPanel()
+    await waitFor(() => expect(openedCbs.length).toBeGreaterThan(0))
+    for (const cb of openedCbs) cb('up' as 'left' | 'right')
+    expect(card().dataset.side).toBe('right')
+  })
+
+  it('returns to the glance and re-reads the list on a fresh open', async () => {
+    await mountPanel()
+    fireEvent.click(control('settings'))
+    await waitFor(() => expect(card().dataset.view).toBe('settings'))
+    const before = countOf(REMINDERS_PATH)
+    for (const cb of openedCbs) cb('right')
+    // Relative labels go stale while the window is gone, so the list is re-read.
+    await waitFor(() => expect(card().dataset.view).toBe('main'))
+    expect(countOf(REMINDERS_PATH)).toBeGreaterThan(before)
+  })
+})
+
+describe('what the panel reports back so it is not closed on blur', () => {
+  it('reports the exercise as not running while the card is a glance', async () => {
+    await mountPanel()
+    await waitFor(() => expect(api.panelBreathing).toHaveBeenCalledWith(false))
+  })
+
+  it('reports the exercise as running the moment it starts', async () => {
+    await mountPanel()
+    fireEvent.click(control('breathe'))
+    await waitFor(() => expect(api.panelBreathing).toHaveBeenCalledWith(true))
+    expect(control('breathing')).not.toBeNull()
+  })
+
+  it('holds the window open while a secondary view is the destination', async () => {
+    await mountPanel()
+    await waitFor(() => expect(api.panelHold).toHaveBeenCalledWith(false))
+    fireEvent.click(control('see-all'))
+    await waitFor(() => expect(card().dataset.view).toBe('all'))
+    expect(api.panelHold).toHaveBeenCalledWith(true)
+  })
+
+  it('releases the hold on the way back to the list', async () => {
+    await mountPanel()
+    fireEvent.click(control('see-all'))
+    await waitFor(() => expect(card().dataset.view).toBe('all'))
+    api.panelHold.mockClear()
+    fireEvent.click(control('back'))
+    await waitFor(() => expect(card().dataset.view).toBe('main'))
+    expect(api.panelHold).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('closing the panel', () => {
+  it('closes on Escape', async () => {
+    await mountPanel()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(api.panelClose).toHaveBeenCalled()
+  })
+
+  it('does NOT close on Escape while the exercise is running', async () => {
+    await mountPanel()
+    fireEvent.click(control('breathe'))
+    await waitFor(() => expect(control('breathing')).not.toBeNull())
+    api.panelClose.mockClear()
+    // Escape belongs to the exercise here — losing a 48-second commitment to a
+    // stray key would be hostile.
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(api.panelClose).not.toHaveBeenCalled()
+  })
+
+  it('ignores every other key', async () => {
+    await mountPanel()
+    fireEvent.keyDown(window, { key: 'a' })
+    expect(api.panelClose).not.toHaveBeenCalled()
+  })
+
+  it('closes from the card’s own exit', async () => {
+    await mountPanel()
+    fireEvent.click(control('close'))
+    expect(api.panelClose).toHaveBeenCalled()
+  })
+
+  it('runs without a preload bridge at all rather than throwing', async () => {
+    delete (window as unknown as { crewCompanion?: unknown }).crewCompanion
+    await mountPanel()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    fireEvent.click(control('close'))
+    expect(card()).not.toBeNull()
+  })
+})
+
+describe('the four writes the panel owns', () => {
+  it('posts a new reminder and confirms it, then re-reads the list', async () => {
+    await mountPanel()
+    const before = countOf(REMINDERS_PATH)
+    fireEvent.click(control('add'))
+    await waitFor(() => expect(addResult).toBe(true))
+    const add = calls.find((c) => c.url === ADD_PATH)
+    expect(add?.method).toBe('POST')
+    expect(add?.body).toEqual({ text: 'drink water', fireAt: ADD_AT, everyMinutes: 60 })
+    expect(countOf(REMINDERS_PATH)).toBeGreaterThan(before)
+  })
+
+  it('reports the add as failed when the backend refuses it', async () => {
+    refusing.add(ADD_PATH)
+    await mountPanel()
+    fireEvent.click(control('add'))
+    // False, not a thrown error: the input keeps the text so it can be retried.
+    await waitFor(() => expect(addResult).toBe(false))
+  })
+
+  it('reports the add as failed when the request never lands', async () => {
+    rejecting.add(ADD_PATH)
+    await mountPanel()
+    fireEvent.click(control('add'))
+    await waitFor(() => expect(addResult).toBe(false))
+  })
+
+  it('removes a reminder by id and re-reads', async () => {
+    await mountPanel()
+    const before = countOf(REMINDERS_PATH)
+    fireEvent.click(control('remove'))
+    await waitFor(() => expect(countOf(REMOVE_PATH)).toBe(1))
+    expect(calls.find((c) => c.url === REMOVE_PATH)?.body).toEqual({ id: 'r1' })
+    await waitFor(() => expect(countOf(REMINDERS_PATH)).toBeGreaterThan(before))
+  })
+
+  it('skips a recurring reminder’s next occurrence by id', async () => {
+    await mountPanel()
+    fireEvent.click(control('skip'))
+    await waitFor(() => expect(countOf(SKIP_PATH)).toBe(1))
+    expect(calls.find((c) => c.url === SKIP_PATH)?.body).toEqual({ id: 'r2' })
+  })
+
+  it('leaves the list unchanged when a mutation never lands', async () => {
+    rejecting.add(REMOVE_PATH)
+    snapshot = fourPending()
+    await mountPanel()
+    await waitFor(() => expect(card().dataset.rows).toBe('3'))
+    fireEvent.click(control('remove'))
+    await waitFor(() => expect(countOf(REMOVE_PATH)).toBe(1))
+    expect(card().dataset.rows).toBe('3')
+  })
+
+  it('counts a completed exercise and returns to the card', async () => {
+    await mountPanel()
+    fireEvent.click(control('breathe'))
+    await waitFor(() => expect(control('breathing')).not.toBeNull())
+    fireEvent.click(control('breathe-done'))
+    await waitFor(() => expect(countOf(BREATHING_DONE_PATH)).toBe(1))
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="breathing"]')).toBeNull(),
+    )
+  })
+
+  it('still returns to the card when the tally POST fails', async () => {
+    rejecting.add(BREATHING_DONE_PATH)
+    await mountPanel()
+    fireEvent.click(control('breathe'))
+    await waitFor(() => expect(control('breathing')).not.toBeNull())
+    fireEvent.click(control('breathe-done'))
+    // The exercise still happened; only the tally missed it.
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="breathing"]')).toBeNull(),
+    )
+  })
+
+  it('does NOT count an exercise abandoned halfway', async () => {
+    await mountPanel()
+    fireEvent.click(control('breathe'))
+    await waitFor(() => expect(control('breathing')).not.toBeNull())
+    fireEvent.click(control('breathe-end'))
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="breathing"]')).toBeNull(),
+    )
+    expect(countOf(BREATHING_DONE_PATH)).toBe(0)
+    await waitFor(() => expect(api.panelBreathing).toHaveBeenLastCalledWith(false))
+  })
+})

--- a/website/src/test/CrewCompanionPanelViewsCoverage.test.tsx
+++ b/website/src/test/CrewCompanionPanelViewsCoverage.test.tsx
@@ -1,0 +1,562 @@
+/**
+ * The Crew Companion panel's secondary views, exercised through their real bridge
+ * seam.
+ *
+ * `PanelViews.tsx` holds four exported surfaces and one private one: the back row
+ * (`ViewHeader`), the full reminder list (`AllRemindersView`), the settings body
+ * (`SettingsView`, which owns the private `Toggle`), and the render guard
+ * (`ViewBoundary`). Every one of them talks to the desktop app through the module
+ * scoped `api = petBridge`, so the bridge is the only thing doubled here — the
+ * components, the shared `ReminderInput` composer, the skin context defaults and the
+ * real i18n catalog all run for real.
+ *
+ * The clock is faked and pinned: `AllRemindersView` builds every row label from
+ * `new Date()` at render time, so a real clock would make "30 min from now" a
+ * flake. `shouldAdvanceTime` keeps the clock moving so `waitFor` and the promise
+ * driven effects behave as they do with real timers, and the teardown clears any
+ * callback that would otherwise fire after the DOM is gone.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup, act } from '@testing-library/react'
+
+import type { Reminder } from '../apps/crew-companion/types'
+
+// ── Bridge double ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  api: {
+    remindersList: vi.fn(),
+    remindersRemove: vi.fn(),
+    getCrewCompanionConfig: vi.fn(),
+    updateConfig: vi.fn(),
+    onConfigUpdated: vi.fn(),
+  },
+}))
+
+vi.mock('../apps/crew-companion/petBridge', () => ({
+  petBridge: mocks.api,
+  galleryApi: mocks.api,
+}))
+
+const api = mocks.api
+
+// Imported AFTER the mock is registered, so the module level `api` binding in
+// PanelViews resolves to the double rather than the real bridge.
+const { ViewHeader, AllRemindersView, SettingsView, ViewBoundary } =
+  await import('../apps/crew-companion/PanelViews')
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+/** Pinned so every relative label below is arithmetic, not weather. */
+const NOW = new Date('2026-08-12T00:00:00.000Z')
+
+const at = (msFromNow: number) => new Date(NOW.getTime() + msFromNow).toISOString()
+
+const reminder = (over: Partial<Reminder> & Pick<Reminder, 'id' | 'text' | 'fireAt'>): Reminder => ({
+  recurrence: null,
+  ...over,
+})
+
+/** The unsubscribe handed back by `onConfigUpdated`, asserted on unmount. */
+let off: ReturnType<typeof vi.fn>
+/** The broadcast callback the view registers, so a test can fire `config:updated`. */
+let broadcast: () => void
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.setSystemTime(NOW)
+  vi.clearAllMocks()
+
+  off = vi.fn()
+  broadcast = () => {}
+  api.remindersList.mockResolvedValue([])
+  api.remindersRemove.mockResolvedValue(true)
+  api.getCrewCompanionConfig.mockResolvedValue({})
+  api.updateConfig.mockResolvedValue(true)
+  api.onConfigUpdated.mockImplementation((cb: () => void) => {
+    broadcast = cb
+    return off
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+// ── Query helpers ──────────────────────────────────────────────────────────
+
+/** Every reminder row, in document order, as normalized text. */
+const rowTexts = () =>
+  screen
+    .getAllByRole('button', { name: 'Remove reminder' })
+    .map((btn) => (btn.parentElement?.textContent ?? '').replace(/\s+/g, ' ').trim())
+
+/** The two settings switches, break first and session second — that is render order. */
+const switches = () => screen.getAllByRole('switch') as HTMLInputElement[]
+
+const customField = () => screen.getByLabelText('Custom minutes') as HTMLInputElement
+
+const preset = (mins: number) => screen.getByRole('button', { name: String(mins) })
+
+// ── ViewHeader ─────────────────────────────────────────────────────────────
+
+describe('ViewHeader — the only way out besides Escape', () => {
+  it('renders the title beside a labelled back button', () => {
+    render(<ViewHeader title="All reminders" onBack={vi.fn()} />)
+
+    expect(screen.getByText('All reminders')).toBeInTheDocument()
+    const back = screen.getByRole('button', { name: 'Back' })
+    // The title is a drag region, so the button opts out or the click is eaten.
+    expect(back).toHaveAttribute('title', 'Back')
+  })
+
+  it('calls onBack once per click', () => {
+    const onBack = vi.fn()
+    render(<ViewHeader title="Settings" onBack={onBack} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    expect(onBack).toHaveBeenCalledTimes(1)
+  })
+
+  it('survives the hover in and hover out handlers and still fires onBack', () => {
+    // The handlers repaint the button from the skin. What matters for behaviour is
+    // that neither one throws and the control keeps working afterwards — the
+    // resolved colours are CSS custom properties, not values worth asserting.
+    const onBack = vi.fn()
+    render(<ViewHeader title="Settings" onBack={onBack} />)
+    const back = screen.getByRole('button', { name: 'Back' })
+
+    fireEvent.mouseEnter(back)
+    fireEvent.mouseLeave(back)
+
+    fireEvent.click(back)
+    expect(onBack).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── AllRemindersView ───────────────────────────────────────────────────────
+
+describe('AllRemindersView — the full list', () => {
+  it('says it is reading while the list is still in flight', () => {
+    // A promise that never settles: the null state is the thing under test.
+    api.remindersList.mockReturnValue(new Promise<Reminder[]>(() => {}))
+    render(<AllRemindersView />)
+
+    expect(screen.getByText('Reading…')).toBeInTheDocument()
+    // The composer is offered even before the list arrives.
+    expect(screen.getByLabelText('Add a reminder in your own words')).toBeInTheDocument()
+  })
+
+  it('offers the empty state with a hint to type above, not to navigate back', async () => {
+    render(<AllRemindersView />)
+
+    expect(await screen.findByText('Nothing scheduled')).toBeInTheDocument()
+    expect(screen.getByText('Type what you want to remember above.')).toBeInTheDocument()
+  })
+
+  it('treats a failed read as an empty list rather than a broken screen', async () => {
+    api.remindersList.mockRejectedValue(new Error('bridge is down'))
+    render(<AllRemindersView />)
+
+    expect(await screen.findByText('Nothing scheduled')).toBeInTheDocument()
+  })
+
+  it('treats a bridge that answers with nothing as an empty list', async () => {
+    // Not the same path as a rejection: this one resolves, with no list in it.
+    api.remindersList.mockResolvedValue(undefined)
+    render(<AllRemindersView />)
+
+    expect(await screen.findByText('Nothing scheduled')).toBeInTheDocument()
+  })
+
+  it('sinks already-fired one-offs below pending ones and sorts the rest by time', async () => {
+    api.remindersList.mockResolvedValue([
+      reminder({ id: 'd', text: 'call mom', fireAt: at(3 * 86_400_000) }),
+      reminder({ id: 'a', text: 'watered the plants', fireAt: at(-2 * 3_600_000), done: true }),
+      reminder({ id: 'c', text: 'stretch', fireAt: at(2 * 3_600_000) }),
+      reminder({ id: 'b', text: 'stand up', fireAt: at(30 * 60_000) }),
+    ])
+    render(<AllRemindersView />)
+
+    await screen.findByText('stand up')
+    const order = rowTexts()
+    expect(order).toHaveLength(4)
+    expect(order[0]).toContain('stand up')
+    expect(order[1]).toContain('stretch')
+    expect(order[2]).toContain('call mom')
+    // The fired one is last, still visible — seeing what just fired is the point.
+    expect(order[3]).toContain('watered the plants')
+  })
+
+  it('labels each row through the shared time formatter', async () => {
+    api.remindersList.mockResolvedValue([
+      reminder({ id: 'b', text: 'stand up', fireAt: at(30 * 60_000) }),
+    ])
+    render(<AllRemindersView />)
+
+    // Under an hour is relative only.
+    expect(await screen.findByText('30 min from now')).toBeInTheDocument()
+  })
+
+  it('renders a repeat pill per recurrence granularity', async () => {
+    api.remindersList.mockResolvedValue([
+      reminder({
+        id: 'min', text: 'sip water', fireAt: at(10 * 60_000),
+        recurrence: { everyMinutes: 45 },
+      }),
+      reminder({
+        id: 'hr', text: 'stretch', fireAt: at(20 * 60_000),
+        recurrence: { everyMinutes: 120 },
+      }),
+      reminder({
+        id: 'day', text: 'stand up', fireAt: at(30 * 60_000),
+        recurrence: { everyMinutes: 2880 },
+      }),
+      reminder({
+        id: 'daily', text: 'call mom', fireAt: at(40 * 60_000),
+        recurrence: { everyMinutes: 1440 },
+      }),
+    ])
+    render(<AllRemindersView />)
+
+    await screen.findByText('sip water')
+    const order = rowTexts()
+    // Minutes, hours and days each go through the locale's own narrow unit; only
+    // the exact-day case gets its own word.
+    expect(order[0]).toMatch(/every\s*45\s*m/)
+    expect(order[1]).toMatch(/every\s*2\s*h/)
+    expect(order[2]).toMatch(/every\s*2\s*d/)
+    expect(order[3]).toMatch(/daily/)
+    // "every 2d" would be wrong for the exact-daily case, so prove it is absent.
+    expect(order[3]).not.toMatch(/every\s*1\s*d/)
+  })
+
+  it('omits the pill entirely for a one-off', async () => {
+    api.remindersList.mockResolvedValue([
+      reminder({ id: 'one', text: 'buy milk', fireAt: at(90 * 60_000) }),
+    ])
+    render(<AllRemindersView />)
+
+    await screen.findByText('buy milk')
+    expect(rowTexts()[0]).not.toMatch(/every/)
+  })
+
+  it('removes a row through the bridge and re-reads the list afterwards', async () => {
+    api.remindersList.mockResolvedValue([
+      reminder({ id: 'r-1', text: 'stretch', fireAt: at(3_600_000) }),
+    ])
+    render(<AllRemindersView />)
+    await screen.findByText('stretch')
+    expect(api.remindersList).toHaveBeenCalledTimes(1)
+
+    api.remindersList.mockResolvedValue([])
+    fireEvent.click(screen.getByRole('button', { name: 'Remove reminder' }))
+
+    await waitFor(() => expect(api.remindersRemove).toHaveBeenCalledWith('r-1'))
+    // The row is gone because the list re-read, not because it was spliced locally.
+    expect(await screen.findByText('Nothing scheduled')).toBeInTheDocument()
+    expect(api.remindersList).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-reads the list when the composer saves something', async () => {
+    const onAdd = vi.fn().mockResolvedValue(true)
+    render(<AllRemindersView onAdd={onAdd} />)
+    await screen.findByText('Nothing scheduled')
+    expect(api.remindersList).toHaveBeenCalledTimes(1)
+
+    api.remindersList.mockResolvedValue([
+      reminder({ id: 'new', text: 'stretch', fireAt: at(3_600_000) }),
+    ])
+    const input = screen.getByLabelText('Add a reminder in your own words') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'stretch in 20 minutes' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => expect(onAdd).toHaveBeenCalled())
+    expect(await screen.findByText('stretch')).toBeInTheDocument()
+    expect(api.remindersList).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not re-read when the save was refused', async () => {
+    const onAdd = vi.fn().mockResolvedValue(false)
+    render(<AllRemindersView onAdd={onAdd} />)
+    await screen.findByText('Nothing scheduled')
+
+    const input = screen.getByLabelText('Add a reminder in your own words') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'stretch in 20 minutes' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => expect(onAdd).toHaveBeenCalled())
+    // One read, from mount. A refused write has nothing new to show.
+    expect(api.remindersList).toHaveBeenCalledTimes(1)
+  })
+
+  it('still renders the composer when no onAdd was threaded through', async () => {
+    render(<AllRemindersView />)
+    await screen.findByText('Nothing scheduled')
+
+    const input = screen.getByLabelText('Add a reminder in your own words') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'stretch in 20 minutes' } })
+    fireEvent.submit(input.closest('form')!)
+
+    // Nothing to persist to, so the list never re-reads and nothing throws.
+    await waitFor(() => expect(api.remindersList).toHaveBeenCalledTimes(1))
+  })
+})
+
+// ── SettingsView ───────────────────────────────────────────────────────────
+
+describe('SettingsView — reads once, then follows the broadcast', () => {
+  it('shows both switches on and the stored cadence selected', async () => {
+    api.getCrewCompanionConfig.mockResolvedValue({
+      breakNudgesEnabled: true,
+      sessionNotificationsEnabled: true,
+      breakReminderMins: 60,
+    })
+    render(<SettingsView />)
+
+    await waitFor(() => expect(preset(60)).toHaveAttribute('aria-pressed', 'true'))
+    expect(preset(45)).toHaveAttribute('aria-pressed', 'false')
+    expect(switches()[0].checked).toBe(true)
+    expect(switches()[1].checked).toBe(true)
+    // The caveat is stated once for the whole section, not inside a toggle hint.
+    expect(screen.getByText(/always notify/i)).toBeInTheDocument()
+  })
+
+  it('keeps its defaults when the config answers with nothing usable', async () => {
+    api.getCrewCompanionConfig.mockResolvedValue({
+      breakNudgesEnabled: 'yes',
+      sessionNotificationsEnabled: null,
+      breakReminderMins: '90',
+    })
+    render(<SettingsView />)
+
+    await waitFor(() => expect(api.getCrewCompanionConfig).toHaveBeenCalled())
+    // Wrong types are ignored rather than coerced, so the 45 default survives.
+    expect(preset(45)).toHaveAttribute('aria-pressed', 'true')
+    expect(switches()[0].checked).toBe(true)
+    expect(switches()[1].checked).toBe(true)
+  })
+
+  it('survives a null config and a failed read', async () => {
+    api.getCrewCompanionConfig.mockResolvedValue(null)
+    render(<SettingsView />)
+    await waitFor(() => expect(preset(45)).toHaveAttribute('aria-pressed', 'true'))
+
+    cleanup()
+    api.getCrewCompanionConfig.mockRejectedValue(new Error('bridge is down'))
+    render(<SettingsView />)
+    await waitFor(() => expect(preset(45)).toHaveAttribute('aria-pressed', 'true'))
+  })
+
+  it('hides the cadence row while break nudges are off', async () => {
+    api.getCrewCompanionConfig.mockResolvedValue({ breakNudgesEnabled: false })
+    render(<SettingsView />)
+
+    await waitFor(() => expect(switches()[0].checked).toBe(false))
+    // The interval exists only because the toggle above it is on.
+    expect(screen.queryByLabelText('Custom minutes')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '45' })).not.toBeInTheDocument()
+  })
+
+  it('writes the break toggle through and folds the cadence row away', async () => {
+    render(<SettingsView />)
+    await waitFor(() => expect(customField()).toBeInTheDocument())
+
+    fireEvent.click(switches()[0])
+
+    expect(api.updateConfig).toHaveBeenCalledWith({ breakNudgesEnabled: false })
+    await waitFor(() => expect(screen.queryByLabelText('Custom minutes')).not.toBeInTheDocument())
+  })
+
+  it('writes the session toggle through without touching the cadence row', async () => {
+    render(<SettingsView />)
+    await waitFor(() => expect(customField()).toBeInTheDocument())
+
+    fireEvent.click(switches()[1])
+
+    expect(api.updateConfig).toHaveBeenCalledWith({ sessionNotificationsEnabled: false })
+    expect(screen.getByLabelText('Custom minutes')).toBeInTheDocument()
+  })
+
+  it('selects a preset and persists it', async () => {
+    render(<SettingsView />)
+    await waitFor(() => expect(preset(45)).toHaveAttribute('aria-pressed', 'true'))
+
+    fireEvent.click(preset(90))
+
+    expect(api.updateConfig).toHaveBeenCalledWith({ breakReminderMins: 90 })
+    expect(preset(90)).toHaveAttribute('aria-pressed', 'true')
+    expect(preset(45)).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('leaves the custom field blank while a preset is selected', async () => {
+    render(<SettingsView />)
+    await waitFor(() => expect(preset(45)).toHaveAttribute('aria-pressed', 'true'))
+
+    expect(customField().value).toBe('')
+  })
+
+  it('shows the live value in the custom field when the interval is not a preset', async () => {
+    api.getCrewCompanionConfig.mockResolvedValue({ breakReminderMins: 200 })
+    render(<SettingsView />)
+
+    await waitFor(() => expect(customField().value).toBe('200'))
+    // A custom value means no preset claims to be the current one.
+    for (const m of [30, 45, 60, 90]) {
+      expect(preset(m)).toHaveAttribute('aria-pressed', 'false')
+    }
+  })
+
+  it('seeds the draft on focus and commits it on blur', async () => {
+    render(<SettingsView />)
+    await waitFor(() => expect(customField()).toBeInTheDocument())
+    const field = customField()
+
+    field.focus()
+    // Focused on a preset value, so the field opens empty rather than pre-filled.
+    expect(field.value).toBe('')
+
+    fireEvent.change(field, { target: { value: '200' } })
+    expect(field.value).toBe('200')
+
+    fireEvent.blur(field)
+    expect(api.updateConfig).toHaveBeenCalledWith({ breakReminderMins: 200 })
+    await waitFor(() => expect(customField().value).toBe('200'))
+  })
+
+  it('seeds the draft with the live value when that value is custom', async () => {
+    api.getCrewCompanionConfig.mockResolvedValue({ breakReminderMins: 200 })
+    render(<SettingsView />)
+    await waitFor(() => expect(customField().value).toBe('200'))
+
+    customField().focus()
+    // Editing an existing custom interval starts from it, not from blank.
+    expect(customField().value).toBe('200')
+  })
+
+  it('clamps a below-floor and an above-ceiling entry instead of storing them raw', async () => {
+    render(<SettingsView />)
+    await waitFor(() => expect(customField()).toBeInTheDocument())
+
+    fireEvent.change(customField(), { target: { value: '2' } })
+    fireEvent.blur(customField())
+    expect(api.updateConfig).toHaveBeenLastCalledWith({ breakReminderMins: 5 })
+
+    fireEvent.change(customField(), { target: { value: '9999' } })
+    fireEvent.blur(customField())
+    expect(api.updateConfig).toHaveBeenLastCalledWith({ breakReminderMins: 480 })
+  })
+
+  it('leaves the stored interval alone when the entry is not a number', async () => {
+    render(<SettingsView />)
+    await waitFor(() => expect(preset(45)).toHaveAttribute('aria-pressed', 'true'))
+
+    fireEvent.change(customField(), { target: { value: 'soonish' } })
+    fireEvent.blur(customField())
+
+    // A bad value must not silently reset the setting.
+    expect(api.updateConfig).not.toHaveBeenCalled()
+    expect(preset(45)).toHaveAttribute('aria-pressed', 'true')
+    expect(customField().value).toBe('')
+  })
+
+  it('commits the custom entry on Enter', async () => {
+    render(<SettingsView />)
+    await waitFor(() => expect(customField()).toBeInTheDocument())
+    const field = customField()
+
+    field.focus()
+    fireEvent.change(field, { target: { value: '75' } })
+    fireEvent.keyDown(field, { key: 'Enter' })
+
+    // Enter blurs the field, and the blur is what writes.
+    await waitFor(() => expect(api.updateConfig).toHaveBeenCalledWith({ breakReminderMins: 75 }))
+  })
+
+  it('ignores other keys while typing', async () => {
+    render(<SettingsView />)
+    await waitFor(() => expect(customField()).toBeInTheDocument())
+    const field = customField()
+
+    field.focus()
+    fireEvent.change(field, { target: { value: '75' } })
+    fireEvent.keyDown(field, { key: 'a' })
+
+    expect(api.updateConfig).not.toHaveBeenCalled()
+    expect(field.value).toBe('75')
+  })
+
+  it('re-reads on a config broadcast and drops a half-typed draft', async () => {
+    render(<SettingsView />)
+    await waitFor(() => expect(preset(45)).toHaveAttribute('aria-pressed', 'true'))
+
+    customField().focus()
+    fireEvent.change(customField(), { target: { value: '77' } })
+    expect(customField().value).toBe('77')
+
+    // The dashboard app page edits the same settings; this window only hears it.
+    api.getCrewCompanionConfig.mockResolvedValue({ breakReminderMins: 90 })
+    await act(async () => { broadcast() })
+
+    await waitFor(() => expect(preset(90)).toHaveAttribute('aria-pressed', 'true'))
+    // The draft described a value the user is no longer setting.
+    expect(customField().value).toBe('')
+  })
+
+  it('unsubscribes from the broadcast on unmount', async () => {
+    const view = render(<SettingsView />)
+    await waitFor(() => expect(api.onConfigUpdated).toHaveBeenCalled())
+
+    view.unmount()
+    expect(off).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── ViewBoundary ───────────────────────────────────────────────────────────
+
+describe('ViewBoundary — a visible failure beats a blank window', () => {
+  const Boom: React.FC = () => { throw new Error('render exploded') }
+
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    // React logs the caught error itself; the boundary logs it again on purpose.
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+  })
+
+  it('renders its children untouched while nothing is wrong', () => {
+    render(
+      <ViewBoundary onBack={vi.fn()} label="This screen didn't load." back="Back">
+        <div>all reminders body</div>
+      </ViewBoundary>,
+    )
+
+    expect(screen.getByText('all reminders body')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument()
+  })
+
+  it('replaces a failed child with a labelled way out, and logs the cause', () => {
+    const onBack = vi.fn()
+    render(
+      <ViewBoundary onBack={onBack} label="This screen didn't load." back="Back">
+        <Boom />
+      </ViewBoundary>,
+    )
+
+    expect(screen.getByText("This screen didn't load.")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    expect(onBack).toHaveBeenCalledTimes(1)
+
+    // The cause is not swallowed — a blank panel with no log was the old failure.
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[panel] view failed to render:',
+      expect.any(Error),
+    )
+  })
+})

--- a/website/src/test/KnowledgeDetailViewCoverage.test.tsx
+++ b/website/src/test/KnowledgeDetailViewCoverage.test.tsx
@@ -1,0 +1,494 @@
+/**
+ * Coverage for the Knowledge Library detail view.
+ *
+ * DetailView owns four things no other suite exercises: the entity-highlighting
+ * pass over raw content, the inline tag editor, the related-items sidecar query,
+ * and the archive/delete mutations with their optimistic list surgery and
+ * rollback. Each is driven here through the real component with only the API
+ * module and the markdown renderer stubbed — the API because every path under
+ * test is a request shape, the renderer because its own suites cover it and its
+ * plugin chain would dominate the runtime.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest'
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ComponentProps } from 'react'
+import DetailView from '../pages/knowledge/DetailView'
+import * as api from '../pages/knowledge/api'
+import type { KnowledgeItem } from '../pages/knowledge/types'
+
+vi.mock('../pages/knowledge/api', () => ({ knowledgeApi: vi.fn() }))
+vi.mock('../components/MarkdownRenderer', () => ({
+  default: ({ content }: { content: string }) => <div data-testid="markdown">{content}</div>,
+}))
+
+type DetailProps = ComponentProps<typeof DetailView>
+type RelatedRow = KnowledgeItem & { shared_entities?: number }
+
+// Fixture knobs, reset per test so each test states only the shape it needs.
+let itemFixture: KnowledgeItem | null
+let itemPending: boolean
+let relatedFixture: RelatedRow[]
+let mutationError: Error | null
+
+const item = (over: Partial<KnowledgeItem> = {}): KnowledgeItem => ({
+  id: 'i1',
+  title: 'Ledger design notes',
+  item_type: 'design_doc',
+  status: 'active',
+  content: 'The Ledger keeps every entry.',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-02-03T00:00:00Z',
+  ...over,
+})
+
+/** Any request carrying a method is a mutation; reads answer from the fixtures. */
+function route(path: string, opts?: RequestInit): unknown {
+  if (opts?.method) return mutationError ? Promise.reject(mutationError) : { ok: true }
+  if (path.endsWith('/related')) return relatedFixture
+  if (itemPending) return new Promise(() => {})
+  return itemFixture
+}
+
+const calls = () => vi.mocked(api.knowledgeApi).mock.calls as [string, RequestInit | undefined][]
+const callsTo = (method: string) => calls().filter(([, o]) => o?.method === method)
+const bodyOf = (opts: RequestInit | undefined) => JSON.parse(String(opts?.body)) as Record<string, unknown>
+
+const makeClient = () => new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+})
+
+function renderDetail(props: Partial<DetailProps> = {}, queryClient: QueryClient = makeClient()) {
+  const onBack = vi.fn()
+  const onEntityClick = vi.fn()
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <DetailView itemId="i1" onBack={onBack} onEntityClick={onEntityClick} {...props} />
+    </QueryClientProvider>,
+  )
+  return { ...utils, queryClient, onBack, onEntityClick }
+}
+
+const writeText = vi.fn()
+let originalClipboard: PropertyDescriptor | undefined
+
+beforeAll(() => {
+  originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+})
+
+afterAll(() => {
+  if (originalClipboard) Object.defineProperty(navigator, 'clipboard', originalClipboard)
+  else delete (navigator as { clipboard?: unknown }).clipboard
+})
+
+beforeEach(() => {
+  // useCopy() schedules a 1.5s reset; a real timer would fire after teardown.
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.clearAllMocks()
+  itemFixture = item()
+  itemPending = false
+  relatedFixture = []
+  mutationError = null
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+  vi.mocked(api.knowledgeApi).mockImplementation(
+    ((path: string, opts?: RequestInit) => Promise.resolve(route(path, opts))) as typeof api.knowledgeApi,
+  )
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('DetailView — load states', () => {
+  it('shows a skeleton while the item request is in flight', async () => {
+    itemPending = true
+    const { container } = renderDetail()
+    await waitFor(() => expect(container.querySelector('[data-slot="skeleton"]')).toBeTruthy())
+    expect(screen.queryByText('Ledger design notes')).not.toBeInTheDocument()
+  })
+
+  it('reports a missing item when the request answers with no record', async () => {
+    itemFixture = null
+    renderDetail()
+    expect(await screen.findByText('Item not found')).toBeInTheDocument()
+  })
+
+  it('renders the header, type badge, timestamp, status and namespace chip', async () => {
+    itemFixture = item({ namespace: 'work', updated_at: '2026-02-03T00:00:00Z' })
+    renderDetail()
+    expect(await screen.findByRole('heading', { name: 'Ledger design notes' })).toBeInTheDocument()
+    expect(screen.getByText('design doc')).toBeInTheDocument()
+    expect(screen.getByText(/2026/)).toBeInTheDocument()
+    expect(screen.getByText('active')).toBeInTheDocument()
+    expect(screen.getByText('work')).toBeInTheDocument()
+  })
+
+  it('hides the namespace chip for the default namespace', async () => {
+    itemFixture = item({ namespace: 'default' })
+    renderDetail()
+    await screen.findByRole('heading', { name: 'Ledger design notes' })
+    expect(screen.queryByText('default')).not.toBeInTheDocument()
+  })
+
+  it('walks back to the list from the back button', async () => {
+    const { onBack } = renderDetail()
+    fireEvent.click(await screen.findByRole('button', { name: /Back to list/ }))
+    expect(onBack).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('DetailView — summary and source locations', () => {
+  it('renders the summary card with each source location', async () => {
+    itemFixture = item({
+      summary: 'How the ledger records mandate changes.',
+      source_locations: [
+        { item_id: 'i1', source_id: 's1', section_title: 'Overview', chunk_range: '1-3' },
+        { item_id: 'i1', source_id: 'raw-source-id' },
+      ],
+    })
+    renderDetail()
+    const card = (await screen.findByText('Summary')).parentElement as HTMLElement
+    expect(card).toHaveTextContent('How the ledger records mandate changes.')
+    expect(card).toHaveTextContent('Overview')
+    expect(card).toHaveTextContent('(1-3)')
+    // No section title: the raw source id stands in for it.
+    expect(card).toHaveTextContent('raw-source-id')
+  })
+
+  it('omits the summary card when the item has no summary', async () => {
+    renderDetail()
+    await screen.findByRole('heading', { name: 'Ledger design notes' })
+    expect(screen.queryByText('Summary')).not.toBeInTheDocument()
+  })
+})
+
+describe('DetailView — entities and relations', () => {
+  it('lists entities and reports a click on one', async () => {
+    itemFixture = item({ entities: [{ id: 'e1', name: 'Ledger', entity_type: 'concept' }] })
+    const { onEntityClick } = renderDetail()
+    expect(await screen.findByText('Entities (1)')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'concept Ledger' }))
+    expect(onEntityClick).toHaveBeenCalledWith('Ledger')
+  })
+
+  it('lists relations and reports clicks on either end, falling back to ids', async () => {
+    itemFixture = item({
+      content: 'no highlight here',
+      relations: [
+        { id: 'r1', source_id: 'e1', target_id: 'e2', relation_type: 'depends on', source_name: 'Ledger', target_name: 'Mandate' },
+        { id: 'r2', source_id: 'raw-source', target_id: 'raw-target', relation_type: 'mentions' },
+      ],
+    })
+    const { onEntityClick } = renderDetail()
+    const card = (await screen.findByText('Relations (2)')).parentElement as HTMLElement
+    expect(card).toHaveTextContent('depends on')
+    fireEvent.click(within(card).getByRole('button', { name: 'Ledger' }))
+    fireEvent.click(within(card).getByRole('button', { name: 'Mandate' }))
+    // The second relation carries no display names, so the ids are the labels.
+    fireEvent.click(within(card).getByRole('button', { name: 'raw-source' }))
+    fireEvent.click(within(card).getByRole('button', { name: 'raw-target' }))
+    expect(onEntityClick.mock.calls.map(c => c[0])).toEqual(['Ledger', 'Mandate', 'raw-source', 'raw-target'])
+  })
+})
+
+describe('DetailView — related items', () => {
+  it('fetches and lists related items, showing the shared-entity count when present', async () => {
+    itemFixture = item({ entities: [{ id: 'e1', name: 'Ledger', entity_type: 'concept' }] })
+    relatedFixture = [
+      { ...item({ id: 'r1', title: 'Ledger rollout plan', item_type: 'runbook' }), shared_entities: 3 },
+      item({ id: 'r2', title: 'Mandate policy', item_type: 'policy' }),
+    ]
+    renderDetail()
+    const card = (await screen.findByText('Related Items (2)')).parentElement as HTMLElement
+    expect(card).toHaveTextContent('Ledger rollout plan')
+    expect(card).toHaveTextContent('3 shared')
+    expect(card).toHaveTextContent('Mandate policy')
+    expect(calls().some(([p]) => p === '/items/i1/related')).toBe(true)
+  })
+
+  it('renders nothing when there are no related items', async () => {
+    itemFixture = item({ entities: [{ id: 'e1', name: 'Ledger', entity_type: 'concept' }] })
+    renderDetail()
+    await screen.findByText('Entities (1)')
+    expect(screen.queryByText(/Related Items/)).not.toBeInTheDocument()
+  })
+
+  it('skips the related request entirely when the item has no entities', async () => {
+    renderDetail()
+    await screen.findByRole('heading', { name: 'Ledger design notes' })
+    await waitFor(() => expect(calls().length).toBeGreaterThan(0))
+    expect(calls().some(([p]) => p.endsWith('/related'))).toBe(false)
+  })
+})
+
+describe('DetailView — content rendering', () => {
+  it('highlights entity mentions in raw content and reports a click on one', async () => {
+    itemFixture = item({
+      content: 'The Ledger keeps every entry, and C++ (core) reads it.',
+      entities: [
+        { id: 'e1', name: 'Ledger', entity_type: 'concept' },
+        { id: 'e2', name: 'C++ (core)', entity_type: 'component' },
+      ],
+    })
+    const { container, onEntityClick } = renderDetail()
+    await screen.findByText('Content')
+    const pre = container.querySelector('pre') as HTMLElement
+    // Regex-special characters in an entity name are escaped before matching,
+    // so the mention still becomes its own clickable span.
+    fireEvent.click(within(pre).getByRole('button', { name: 'C++ (core)' }))
+    fireEvent.click(within(pre).getByRole('button', { name: 'Ledger' }))
+    expect(onEntityClick.mock.calls.map(c => c[0])).toEqual(['C++ (core)', 'Ledger'])
+  })
+
+  it('leaves content untouched when the item has no entities', async () => {
+    const { container } = renderDetail()
+    await screen.findByText('Content')
+    const pre = container.querySelector('pre') as HTMLElement
+    expect(pre).toHaveTextContent('The Ledger keeps every entry.')
+    expect(within(pre).queryAllByRole('button')).toHaveLength(0)
+  })
+
+  it('renders markdown content through the markdown renderer with a chunk entity strip', async () => {
+    itemFixture = item({
+      tags: 'ops,content_type:markdown',
+      content: '# Ledger',
+      entities: [{ id: 'e1', name: 'Ledger', entity_type: 'concept' }],
+    })
+    const { container, onEntityClick } = renderDetail()
+    expect(await screen.findByTestId('markdown')).toHaveTextContent('# Ledger')
+    expect(container.querySelector('pre')).toBeNull()
+    const strip = (screen.getByText('Entities in this chunk:').parentElement) as HTMLElement
+    fireEvent.click(within(strip).getByRole('button', { name: 'Ledger' }))
+    expect(onEntityClick).toHaveBeenCalledWith('Ledger')
+  })
+
+  it('accepts an array of tags when deciding the content is markdown', async () => {
+    itemFixture = item({ tags: ['content_type:markdown'] as unknown as string, content: 'array tagged' })
+    renderDetail()
+    expect(await screen.findByTestId('markdown')).toHaveTextContent('array tagged')
+  })
+
+  it('falls back to the raw view when no tag marks the content as markdown', async () => {
+    itemFixture = item({ tags: 'ops,ledger' })
+    const { container } = renderDetail()
+    await screen.findByText('Content')
+    expect(container.querySelector('pre')).toBeTruthy()
+    expect(screen.queryByTestId('markdown')).not.toBeInTheDocument()
+  })
+
+  it('renders the match score for a search hit', async () => {
+    itemFixture = item({ _score: 0.4231, _match_type: 'semantic' })
+    renderDetail()
+    expect(await screen.findByText(/Match: semantic/)).toHaveTextContent('0.423')
+  })
+
+  it('omits the match score for an item opened outside a search', async () => {
+    renderDetail()
+    await screen.findByText('Content')
+    expect(screen.queryByText(/Match:/)).not.toBeInTheDocument()
+  })
+})
+
+describe('DetailView — tag editor', () => {
+  it('renders one chip per tag and no editor until asked', async () => {
+    itemFixture = item({ tags: 'ops, ledger' })
+    renderDetail()
+    expect(await screen.findByText('ops')).toBeInTheDocument()
+    expect(screen.getByText('ledger')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Comma-separated tags')).not.toBeInTheDocument()
+  })
+
+  it('shows a placeholder when the item carries no tags', async () => {
+    renderDetail()
+    expect(await screen.findByText('No tags')).toBeInTheDocument()
+  })
+
+  it('saves edited tags on Enter and closes the editor', async () => {
+    itemFixture = item({ tags: 'ops' })
+    renderDetail()
+    fireEvent.click(await screen.findByRole('button', { name: 'edit' }))
+    const input = screen.getByLabelText('Comma-separated tags')
+    fireEvent.change(input, { target: { value: 'ops, ledger' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => expect(callsTo('PATCH')).toHaveLength(1))
+    expect(bodyOf(callsTo('PATCH')[0][1])).toEqual({ tags: 'ops, ledger' })
+    await waitFor(() => expect(screen.queryByLabelText('Comma-separated tags')).not.toBeInTheDocument())
+  })
+
+  it('saves edited tags from the save button', async () => {
+    itemFixture = item({ tags: 'ops' })
+    renderDetail()
+    fireEvent.click(await screen.findByRole('button', { name: 'edit' }))
+    fireEvent.change(screen.getByLabelText('Comma-separated tags'), { target: { value: 'ledger' } })
+    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    await waitFor(() => expect(callsTo('PATCH')).toHaveLength(1))
+    expect(bodyOf(callsTo('PATCH')[0][1])).toEqual({ tags: 'ledger' })
+  })
+
+  it('abandons the edit from the cancel button without a request', async () => {
+    itemFixture = item({ tags: 'ops' })
+    renderDetail()
+    fireEvent.click(await screen.findByRole('button', { name: 'edit' }))
+    fireEvent.change(screen.getByLabelText('Comma-separated tags'), { target: { value: 'dropped' } })
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+    expect(await screen.findByRole('button', { name: 'edit' })).toBeInTheDocument()
+    expect(callsTo('PATCH')).toHaveLength(0)
+  })
+
+  it('abandons the edit on Escape without a request', async () => {
+    itemFixture = item({ tags: 'ops' })
+    renderDetail()
+    fireEvent.click(await screen.findByRole('button', { name: 'edit' }))
+    fireEvent.keyDown(screen.getByLabelText('Comma-separated tags'), { key: 'Escape' })
+    expect(await screen.findByRole('button', { name: 'edit' })).toBeInTheDocument()
+    expect(callsTo('PATCH')).toHaveLength(0)
+  })
+})
+
+describe('DetailView — copy and export', () => {
+  it('copies the content and reverts the button label once the flash expires', async () => {
+    renderDetail()
+    fireEvent.click(await screen.findByRole('button', { name: /Copy Content/ }))
+    expect(writeText).toHaveBeenCalledWith('The Ledger keeps every entry.')
+    expect(await screen.findByRole('button', { name: /Copied!/ })).toBeInTheDocument()
+    act(() => { vi.advanceTimersByTime(1600) })
+    expect(await screen.findByRole('button', { name: /Copy Content/ })).toBeInTheDocument()
+  })
+
+  it('copies the summary when the item has no content', async () => {
+    itemFixture = item({ content: '', summary: 'Ledger summary only' })
+    renderDetail()
+    fireEvent.click(await screen.findByRole('button', { name: /Copy Content/ }))
+    expect(writeText).toHaveBeenCalledWith('Ledger summary only')
+  })
+
+  it('copies the title when the item has neither content nor summary', async () => {
+    itemFixture = item({ content: '' })
+    renderDetail()
+    fireEvent.click(await screen.findByRole('button', { name: /Copy Content/ }))
+    expect(writeText).toHaveBeenCalledWith('Ledger design notes')
+  })
+
+  it('exports through a download link named after the item', async () => {
+    renderDetail()
+    const btn = await screen.findByRole('button', { name: /Export/ })
+    const anchorClick = vi.fn()
+    const anchors: HTMLAnchorElement[] = []
+    const create = document.createElement.bind(document)
+    const spy = vi.spyOn(document, 'createElement').mockImplementation(((tag: string, opts?: ElementCreationOptions) => {
+      const el = create(tag, opts)
+      if (tag === 'a') {
+        const a = el as HTMLAnchorElement
+        a.click = anchorClick
+        anchors.push(a)
+      }
+      return el
+    }) as typeof document.createElement)
+    try {
+      fireEvent.click(btn)
+    } finally {
+      spy.mockRestore()
+    }
+    expect(anchorClick).toHaveBeenCalledTimes(1)
+    expect(anchors[0].getAttribute('href')).toBe('/api/knowledge/items/i1/export')
+    expect(anchors[0].download).toBe('Ledger design notes.knowledge')
+  })
+})
+
+describe('DetailView — archive and delete', () => {
+  const seededList = (qc: QueryClient) => {
+    qc.setQueryData(['knowledge-items'], { items: [item(), item({ id: 'i2', title: 'Other' })], total: 2 })
+    return qc
+  }
+  type ListCache = { items: KnowledgeItem[]; total: number } | undefined
+
+  it('archives an active item, prunes it from the cached list and returns to the list', async () => {
+    const qc = seededList(makeClient())
+    const { onBack } = renderDetail({}, qc)
+    fireEvent.click(await screen.findByRole('button', { name: /Archive/ }))
+    await waitFor(() => expect(onBack).toHaveBeenCalledTimes(1))
+    expect(bodyOf(callsTo('PATCH')[0][1])).toEqual({ status: 'archived' })
+    const cached = qc.getQueryData(['knowledge-items']) as ListCache
+    expect(cached?.items.map(i => i.id)).toEqual(['i2'])
+    expect(cached?.total).toBe(1)
+  })
+
+  it('unarchives an archived item', async () => {
+    itemFixture = item({ status: 'archived' })
+    const { onBack } = renderDetail()
+    expect(screen.queryByRole('button', { name: /^Archive$/ })).not.toBeInTheDocument()
+    fireEvent.click(await screen.findByRole('button', { name: /Unarchive/ }))
+    await waitFor(() => expect(onBack).toHaveBeenCalledTimes(1))
+    expect(bodyOf(callsTo('PATCH')[0][1])).toEqual({ status: 'active' })
+  })
+
+  it('restores the cached list and surfaces the error when archiving fails', async () => {
+    mutationError = new Error('archive refused')
+    const qc = seededList(makeClient())
+    const { onBack } = renderDetail({}, qc)
+    fireEvent.click(await screen.findByRole('button', { name: /Archive/ }))
+    expect(await screen.findByText('archive refused', {}, { timeout: 5_000 })).toBeInTheDocument()
+    expect(onBack).not.toHaveBeenCalled()
+    const cached = qc.getQueryData(['knowledge-items']) as ListCache
+    expect(cached?.items.map(i => i.id)).toEqual(['i1', 'i2'])
+    expect(cached?.total).toBe(2)
+  })
+
+  it('leaves an empty cached list entry alone while archiving', async () => {
+    const qc = makeClient()
+    qc.setQueryData(['knowledge-items', 'page-2'], null)
+    const { onBack } = renderDetail({}, qc)
+    fireEvent.click(await screen.findByRole('button', { name: /Archive/ }))
+    await waitFor(() => expect(onBack).toHaveBeenCalledTimes(1))
+    expect(qc.getQueryData(['knowledge-items', 'page-2'])).toBeNull()
+  })
+
+  it('deletes the item once the confirmation is accepted', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const qc = seededList(makeClient())
+    const { onBack } = renderDetail({}, qc)
+    fireEvent.click(await screen.findByRole('button', { name: /Delete/ }))
+    await waitFor(() => expect(onBack).toHaveBeenCalledTimes(1))
+    expect(callsTo('DELETE')).toHaveLength(1)
+    expect(callsTo('DELETE')[0][0]).toBe('/items/i1')
+    expect((qc.getQueryData(['knowledge-items']) as ListCache)?.items.map(i => i.id)).toEqual(['i2'])
+  })
+
+  it('leaves an empty cached list entry alone while deleting', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const qc = makeClient()
+    qc.setQueryData(['knowledge-items', 'page-2'], null)
+    const { onBack } = renderDetail({}, qc)
+    fireEvent.click(await screen.findByRole('button', { name: /Delete/ }))
+    await waitFor(() => expect(onBack).toHaveBeenCalledTimes(1))
+    expect(qc.getQueryData(['knowledge-items', 'page-2'])).toBeNull()
+  })
+
+  it('does nothing when the delete confirmation is declined', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { onBack } = renderDetail()
+    fireEvent.click(await screen.findByRole('button', { name: /Delete/ }))
+    expect(callsTo('DELETE')).toHaveLength(0)
+    expect(onBack).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a failed delete and rolls the cached list back', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mutationError = new Error('delete refused')
+    const qc = seededList(makeClient())
+    renderDetail({}, qc)
+    fireEvent.click(await screen.findByRole('button', { name: /Delete/ }))
+    expect(await screen.findByText('delete refused', {}, { timeout: 5_000 })).toBeInTheDocument()
+    expect((qc.getQueryData(['knowledge-items']) as ListCache)?.items).toHaveLength(2)
+  })
+
+  it('falls back to a generic message when the failure carries no text', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mutationError = new Error('')
+    renderDetail()
+    fireEvent.click(await screen.findByRole('button', { name: /Delete/ }))
+    expect(await screen.findByText('Action failed', {}, { timeout: 5_000 })).toBeInTheDocument()
+  })
+})

--- a/website/src/test/MeetingsSettingsViewCoverage.test.tsx
+++ b/website/src/test/MeetingsSettingsViewCoverage.test.tsx
@@ -1,0 +1,370 @@
+/**
+ * Meetings SettingsView — the whole surface, which no other suite touches.
+ *
+ * Two things here are behaviour rather than rendering, and they are the reason
+ * the file is worth more than a smoke test:
+ *
+ *   1. The backend's PUT is a full validated REPLACE, so every change has to send
+ *      the complete config. The payload shape is asserted field-by-field, because
+ *      a patch that dropped an unrelated field would silently reset it.
+ *   2. Saves are CHAINED and each payload is derived from the CACHE at send time,
+ *      not from the render-time snapshot. Two rapid toggles of different agents
+ *      therefore both survive; the test drives exactly that race by holding the
+ *      first response open while the second toggle is queued.
+ *
+ * Harness follows MeetingsPage.test.tsx: hoisted `meetingsApi` doubles over the
+ * real module, one QueryClientProvider per render. No Redux — this view reads
+ * nothing from the store.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const apiMocks = vi.hoisted(() => ({
+  config: vi.fn(),
+  saveConfig: vi.fn(),
+  dictionary: vi.fn(),
+  addTerm: vi.fn(),
+  removeTerm: vi.fn(),
+}))
+
+vi.mock('../apps/meetings/api', async importOriginal => {
+  const actual = await importOriginal<typeof import('../apps/meetings/api')>()
+  return { ...actual, meetingsApi: apiMocks }
+})
+
+import SettingsView from '../apps/meetings/SettingsView'
+import type { ConfigResponse, DictionaryTerm, MeetingsConfig } from '../apps/meetings/api'
+
+const BASE_CONFIG: MeetingsConfig = {
+  meeting_agents: [
+    { id: 'note-taker', name: 'Note Taker', widget_type: 'markdown', enabled_by_default: true },
+    { id: 'sketch-artist', name: 'Sketch Artist', widget_type: 'html', enabled_by_default: true },
+  ],
+  stt_provider: 'local',
+  task_provider: 'taskei',
+  calendar: { provider: 'ics', source: '/tmp/team.ics' },
+  presets: { standup: { enabled_agents: ['note-taker'] } },
+  default_preset: 'standup',
+  poll_interval_active: 3,
+  poll_interval_idle: 30,
+}
+
+const REGISTRIES = {
+  task_providers: [
+    { id: 'taskei', label: 'Taskei' },
+    { id: 'github', label: 'GitHub' },
+  ],
+  calendar_providers: [
+    { id: 'none', label: 'No calendar' },
+    { id: 'ics', label: 'ICS file', requires_source: true },
+  ],
+  stt_providers: [{ id: 'local', label: 'Local' }],
+}
+
+function configResponse(overrides: Partial<MeetingsConfig> = {}): ConfigResponse {
+  return { ...REGISTRIES, config: { ...BASE_CONFIG, ...overrides } }
+}
+
+const TERM: DictionaryTerm = { correct: 'Kiro Crew', aliases: ['kiro cru', 'kero crew'] }
+
+function renderView() {
+  const notify = vi.fn()
+  const onBack = vi.fn()
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <SettingsView onBack={onBack} notify={notify} />
+    </QueryClientProvider>,
+  )
+  return { ...utils, notify, onBack, queryClient }
+}
+
+/** Opens a SimpleSelect by its accessible name and picks an option by label. */
+async function pickOption(selectName: string, optionLabel: string) {
+  fireEvent.click(await screen.findByRole('combobox', { name: selectName }))
+  fireEvent.click(await screen.findByRole('option', { name: optionLabel }))
+}
+
+/** The nth payload handed to the save endpoint, typed for field assertions. */
+function savedPayload(index: number): MeetingsConfig {
+  return apiMocks.saveConfig.mock.calls[index][0] as MeetingsConfig
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  apiMocks.config.mockResolvedValue(configResponse())
+  apiMocks.dictionary.mockResolvedValue({ terms: [] })
+  apiMocks.saveConfig.mockImplementation((config: MeetingsConfig) => Promise.resolve({ config }))
+  apiMocks.addTerm.mockResolvedValue({ terms: [TERM] })
+  apiMocks.removeTerm.mockResolvedValue({ terms: [] })
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('Meetings SettingsView — rendering', () => {
+  it('populates both provider pickers from the backend registries', async () => {
+    renderView()
+
+    expect(await screen.findByRole('combobox', { name: 'Task provider' })).toHaveTextContent(
+      'Taskei',
+    )
+    expect(screen.getByRole('combobox', { name: 'Calendar provider' })).toHaveTextContent(
+      'ICS file',
+    )
+    // The labels come from the registry rows, not from the id, so an
+    // out-of-repo provider shows its own name with no frontend change.
+    fireEvent.click(screen.getByRole('combobox', { name: 'Task provider' }))
+    expect(await screen.findByRole('option', { name: 'GitHub' })).toBeInTheDocument()
+  })
+
+  it('lists every configured agent with its own default-enabled switch', async () => {
+    renderView()
+
+    expect(await screen.findByText('note-taker')).toBeInTheDocument()
+    expect(screen.getByText('sketch-artist')).toBeInTheDocument()
+    expect(
+      screen.getByRole('switch', { name: 'Enable Note Taker by default' }),
+    ).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('treats a missing enabled_by_default as enabled and an explicit false as off', async () => {
+    apiMocks.config.mockResolvedValue(
+      configResponse({
+        meeting_agents: [
+          { id: 'note-taker', name: 'Note Taker', widget_type: 'markdown' },
+          {
+            id: 'sketch-artist',
+            name: 'Sketch Artist',
+            widget_type: 'html',
+            enabled_by_default: false,
+          },
+        ],
+      }),
+    )
+    renderView()
+
+    expect(
+      await screen.findByRole('switch', { name: 'Enable Note Taker by default' }),
+    ).toHaveAttribute('aria-checked', 'true')
+    expect(
+      screen.getByRole('switch', { name: 'Enable Sketch Artist by default' }),
+    ).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('shows the source field only for a provider that declares requires_source', async () => {
+    apiMocks.config.mockResolvedValue(configResponse({ calendar: { provider: 'none', source: '' } }))
+    renderView()
+
+    await screen.findByRole('combobox', { name: 'Calendar provider' })
+    expect(screen.queryByLabelText('Calendar source')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('A path to a local .ics file, or an https URL to one.'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('returns to the meetings list from the header action', async () => {
+    const { onBack } = renderView()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Back' }))
+    expect(onBack).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('Meetings SettingsView — saving config', () => {
+  it('sends the whole config with only the task provider replaced', async () => {
+    const { notify } = renderView()
+
+    await pickOption('Task provider', 'GitHub')
+
+    await waitFor(() => expect(apiMocks.saveConfig).toHaveBeenCalledTimes(1))
+    expect(savedPayload(0)).toEqual({ ...BASE_CONFIG, task_provider: 'github' })
+    await waitFor(() => expect(notify).toHaveBeenCalledWith('Saved.', { type: 'success' }))
+  })
+
+  it('keeps the existing calendar source when only the provider changes', async () => {
+    renderView()
+
+    await pickOption('Calendar provider', 'No calendar')
+
+    await waitFor(() => expect(apiMocks.saveConfig).toHaveBeenCalledTimes(1))
+    // `calendar` is a nested object: the field not being changed has to survive.
+    expect(savedPayload(0).calendar).toEqual({ provider: 'none', source: '/tmp/team.ics' })
+  })
+
+  it('trims the typed source, saves it, and drops the local draft', async () => {
+    renderView()
+
+    const field = await screen.findByLabelText('Calendar source')
+    fireEvent.change(field, { target: { value: '  /srv/calendars/team.ics  ' } })
+    expect(field).toHaveValue('  /srv/calendars/team.ics  ')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(apiMocks.saveConfig).toHaveBeenCalledTimes(1))
+    expect(savedPayload(0).calendar).toEqual({
+      provider: 'ics',
+      source: '/srv/calendars/team.ics',
+    })
+    // Draft cleared, so the field now mirrors what the server accepted.
+    await waitFor(() => expect(field).toHaveValue('/srv/calendars/team.ics'))
+  })
+
+  it('reports a failed save and leaves the chain usable for the next change', async () => {
+    const { notify } = renderView()
+    apiMocks.saveConfig.mockRejectedValueOnce(new Error('boom'))
+
+    await pickOption('Task provider', 'GitHub')
+
+    await waitFor(() =>
+      expect(notify).toHaveBeenCalledWith('Could not save the settings.', { type: 'error' }),
+    )
+
+    // A rejected save must not wedge the queue: the next change still sends.
+    fireEvent.click(screen.getByRole('switch', { name: 'Enable Note Taker by default' }))
+    await waitFor(() => expect(apiMocks.saveConfig).toHaveBeenCalledTimes(2))
+  })
+
+  it('rewrites only the toggled agent and leaves the rest of the roster alone', async () => {
+    renderView()
+
+    fireEvent.click(
+      await screen.findByRole('switch', { name: 'Enable Sketch Artist by default' }),
+    )
+
+    await waitFor(() => expect(apiMocks.saveConfig).toHaveBeenCalledTimes(1))
+    expect(savedPayload(0).meeting_agents).toEqual([
+      { id: 'note-taker', name: 'Note Taker', widget_type: 'markdown', enabled_by_default: true },
+      {
+        id: 'sketch-artist',
+        name: 'Sketch Artist',
+        widget_type: 'html',
+        enabled_by_default: false,
+      },
+    ])
+  })
+
+  it('derives a queued save from the config the previous save landed', async () => {
+    renderView()
+
+    // Hold the first response open so the second toggle is queued while the
+    // first request is still in flight — the race the chain exists for.
+    const held: Array<{ resolve: () => void }> = []
+    apiMocks.saveConfig.mockImplementationOnce(
+      (config: MeetingsConfig) =>
+        new Promise<{ config: MeetingsConfig }>(resolve => {
+          held.push({ resolve: () => resolve({ config }) })
+        }),
+    )
+
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable Note Taker by default' }))
+    await waitFor(() => expect(held).toHaveLength(1))
+    fireEvent.click(screen.getByRole('switch', { name: 'Enable Sketch Artist by default' }))
+    expect(apiMocks.saveConfig).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      held[0].resolve()
+    })
+
+    await waitFor(() => expect(apiMocks.saveConfig).toHaveBeenCalledTimes(2))
+    // Both toggles survive: the second payload was built from the first
+    // response, not from the render-time snapshot.
+    expect(savedPayload(1).meeting_agents.map(agent => [agent.id, agent.enabled_by_default])).toEqual(
+      [
+        ['note-taker', false],
+        ['sketch-artist', false],
+      ],
+    )
+  })
+})
+
+describe('Meetings SettingsView — speech dictionary', () => {
+  it('offers the empty state until a correction exists', async () => {
+    renderView()
+
+    expect(await screen.findByTestId('empty-state-title')).toHaveTextContent('No corrections yet')
+  })
+
+  it('refuses a correction that is missing either half', async () => {
+    const { notify } = renderView()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add' }))
+    expect(notify).toHaveBeenCalledWith('Enter what was heard and what it should say.', {
+      type: 'error',
+    })
+    expect(apiMocks.addTerm).not.toHaveBeenCalled()
+
+    // Aliases alone is still incomplete.
+    fireEvent.change(screen.getByLabelText('Misheard forms'), { target: { value: 'kiro cru' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(apiMocks.addTerm).not.toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledTimes(2)
+  })
+
+  it('splits the aliases on commas, submits on Enter, and clears both fields', async () => {
+    renderView()
+
+    const aliases = await screen.findByLabelText('Misheard forms')
+    const correct = screen.getByLabelText('Correct term')
+    fireEvent.change(aliases, { target: { value: ' kiro cru , , kero crew ' } })
+    fireEvent.change(correct, { target: { value: '  Kiro Crew  ' } })
+    fireEvent.keyDown(correct, { key: 'Enter' })
+
+    await waitFor(() =>
+      expect(apiMocks.addTerm).toHaveBeenCalledWith('Kiro Crew', ['kiro cru', 'kero crew']),
+    )
+    await waitFor(() => expect(aliases).toHaveValue(''))
+    expect(correct).toHaveValue('')
+    // The response replaced the cached list, so the new row renders.
+    expect(
+      await screen.findByRole('button', { name: 'Remove Kiro Crew' }, { timeout: 5_000 }),
+    ).toBeInTheDocument()
+  })
+
+  it('ignores every key other than Enter in the correct-term field', async () => {
+    renderView()
+
+    const correct = await screen.findByLabelText('Correct term')
+    fireEvent.change(screen.getByLabelText('Misheard forms'), { target: { value: 'kiro cru' } })
+    fireEvent.change(correct, { target: { value: 'Kiro Crew' } })
+    fireEvent.keyDown(correct, { key: 'a' })
+
+    expect(apiMocks.addTerm).not.toHaveBeenCalled()
+  })
+
+  it('reports a correction the backend rejected', async () => {
+    apiMocks.addTerm.mockRejectedValueOnce(new Error('nope'))
+    const { notify } = renderView()
+
+    fireEvent.change(await screen.findByLabelText('Misheard forms'), {
+      target: { value: 'kiro cru' },
+    })
+    fireEvent.change(screen.getByLabelText('Correct term'), { target: { value: 'Kiro Crew' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(
+      () =>
+        expect(notify).toHaveBeenCalledWith('Could not add that correction.', { type: 'error' }),
+      { timeout: 5_000 },
+    )
+  })
+
+  it('removes a correction and falls back to the empty state', async () => {
+    apiMocks.dictionary.mockResolvedValue({ terms: [TERM] })
+    renderView()
+
+    expect(await screen.findByText('kiro cru, kero crew')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Kiro Crew' }))
+
+    await waitFor(() => expect(apiMocks.removeTerm).toHaveBeenCalledWith('Kiro Crew'))
+    expect(await screen.findByTestId('empty-state-title')).toHaveTextContent('No corrections yet')
+  })
+})

--- a/website/src/test/MochiChatAppCoverage.test.tsx
+++ b/website/src/test/MochiChatAppCoverage.test.tsx
@@ -1,0 +1,492 @@
+// First coverage for Mochi's chat-window shell — `apps/mochi/src/renderer/ChatApp.tsx`.
+//
+// The shell owns no visible chrome of its own. Everything it does is wiring, so
+// these tests exercise exactly that wiring: which view is mounted, how the two
+// side rails are toggled and told to hide when the user leaves chat, how the
+// pinned-file list and its updated/deleted markers are folded together from
+// four separate backend channels, and what is unsubscribed on unmount.
+//
+// Two deliberate style choices:
+//
+//   1. The three child panels (ChatPanel + PinnedSidePanel, SettingsPanel,
+//      WatchlistPanel) are stubbed. They are each covered by their own test
+//      file, they are large, and a real chat transcript repeats the same text
+//      many times over — which would make any text query here ambiguous. The
+//      stubs publish the props they receive as data-* attributes so the shell's
+//      state can be read back exactly, with no reliance on rendered prose.
+//   2. `mochiApi` is the shell's only seam to the outside world, so it is the
+//      single module mock. Its `on*` members mirror the preload's
+//      `onX(cb) => off` shape, letting a test push a real backend frame and
+//      assert what the shell recomputes in response.
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resolvePetName } from '../apps/mochi/builtinPacks'
+
+/** Matches the shell's local re-declaration of the main-process entry. */
+interface PinnedFileEntry {
+  path: string
+  label: string
+  pinnedAt: number
+  updatedAt?: number
+}
+
+const mocks = vi.hoisted(() => {
+  type NavCb = (route: string) => void
+  type ChangedCb = (pins: unknown[]) => void
+  type UpdatedCb = (info: { path: string; updatedAt: number }) => void
+  type DeletedCb = (info: { path: string }) => void
+
+  const navSubs = new Set<NavCb>()
+  const changedSubs = new Set<ChangedCb>()
+  const updatedSubs = new Set<UpdatedCb>()
+  const deletedSubs = new Set<DeletedCb>()
+  /** Which unsubscribes the shell actually invoked, in order. */
+  const unsubbed: string[] = []
+
+  const api = {
+    getMochiConfig: vi.fn<() => Promise<Record<string, unknown>>>(),
+    getPinnedFiles: vi.fn<() => Promise<unknown>>(),
+    toggleWatchPanel: vi.fn(),
+    togglePinnedPanel: vi.fn(),
+    onNavigate: vi.fn((cb: NavCb) => {
+      navSubs.add(cb)
+      return () => { unsubbed.push('navigate'); navSubs.delete(cb) }
+    }),
+    onPinnedFilesChanged: vi.fn((cb: ChangedCb) => {
+      changedSubs.add(cb)
+      return () => { unsubbed.push('changed'); changedSubs.delete(cb) }
+    }),
+    onPinnedFileUpdated: vi.fn((cb: UpdatedCb) => {
+      updatedSubs.add(cb)
+      return () => { unsubbed.push('updated'); updatedSubs.delete(cb) }
+    }),
+    onPinnedFileDeleted: vi.fn((cb: DeletedCb) => {
+      deletedSubs.add(cb)
+      return () => { unsubbed.push('deleted'); deletedSubs.delete(cb) }
+    }),
+  }
+
+  return {
+    api,
+    unsubbed,
+    navSubCount: () => navSubs.size,
+    emitNavigate: (route: string) => { for (const cb of [...navSubs]) cb(route) },
+    emitChanged: (pins: unknown[]) => { for (const cb of [...changedSubs]) cb(pins) },
+    emitUpdated: (info: { path: string; updatedAt: number }) => {
+      for (const cb of [...updatedSubs]) cb(info)
+    },
+    emitDeleted: (info: { path: string }) => { for (const cb of [...deletedSubs]) cb(info) },
+    reset: () => {
+      navSubs.clear()
+      changedSubs.clear()
+      updatedSubs.clear()
+      deletedSubs.clear()
+      unsubbed.length = 0
+    },
+  }
+})
+
+vi.mock('../apps/mochi/src/mochiApi', () => ({ api: mocks.api }))
+
+interface StubChatPanelProps {
+  onToggleWatch?: () => void
+  watchPanelVisible?: boolean
+  onTogglePinned?: () => void
+  pinnedPanelVisible?: boolean
+  pinnedFileCount?: number
+}
+
+interface StubPinnedPanelProps {
+  pins: PinnedFileEntry[]
+  updatedPaths: Set<string>
+  deletedPaths: Set<string>
+  visible: boolean
+  petName?: string
+  onMarkSeen?: (path: string) => void
+}
+
+interface StubWatchlistProps {
+  visible: boolean
+  onClose: () => void
+  petName?: string
+}
+
+const serialize = (paths: Set<string>) => [...paths].sort().join('|')
+
+vi.mock('../apps/mochi/src/renderer/ChatPanel', () => ({
+  ChatPanel: ({
+    onToggleWatch, watchPanelVisible, onTogglePinned, pinnedPanelVisible, pinnedFileCount,
+  }: StubChatPanelProps) => (
+    <div
+      data-testid="stub-chat-panel"
+      data-watch-visible={String(watchPanelVisible)}
+      data-pinned-visible={String(pinnedPanelVisible)}
+      data-pin-count={String(pinnedFileCount)}
+    >
+      <button type="button" onClick={onToggleWatch}>flip the watch rail</button>
+      <button type="button" onClick={onTogglePinned}>flip the pinned rail</button>
+    </div>
+  ),
+  PinnedSidePanel: ({
+    pins, updatedPaths, deletedPaths, visible, petName, onMarkSeen,
+  }: StubPinnedPanelProps) => (
+    <div
+      data-testid="stub-pinned-panel"
+      data-visible={String(visible)}
+      data-pet={petName ?? ''}
+      data-pins={pins.map((p) => p.path).join('|')}
+      data-updated={serialize(updatedPaths)}
+      data-deleted={serialize(deletedPaths)}
+    >
+      <button type="button" onClick={() => onMarkSeen?.('/notes/alpha.md')}>
+        mark alpha seen
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('../apps/mochi/src/renderer/SettingsPanel', () => ({
+  SettingsPanel: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="stub-settings-panel">
+      <button type="button" onClick={onClose}>leave settings</button>
+    </div>
+  ),
+}))
+
+vi.mock('../apps/mochi/src/renderer/WatchlistPanel', () => ({
+  WatchlistPanel: ({ visible, onClose, petName }: StubWatchlistProps) => (
+    <div
+      data-testid="stub-watch-panel"
+      data-visible={String(visible)}
+      data-pet={petName ?? ''}
+    >
+      <button type="button" onClick={onClose}>close the watch rail</button>
+    </div>
+  ),
+}))
+
+const { ChatApp } = await import('../apps/mochi/src/renderer/ChatApp')
+
+const api = mocks.api
+
+function pin(path: string, over: Partial<PinnedFileEntry> = {}): PinnedFileEntry {
+  return { path, label: path.split('/').pop() ?? path, pinnedAt: 1_700_000_000_000, ...over }
+}
+
+beforeEach(() => {
+  // The shell schedules nothing itself, but a stray timer from any child would
+  // fire after teardown and surface as an unhandled `window is not defined`.
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.clearAllMocks()
+  mocks.reset()
+  api.getMochiConfig.mockResolvedValue({ petName: 'Nimbus' })
+  api.getPinnedFiles.mockResolvedValue([])
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+/** Mount and wait until the two mount-time reads have settled. */
+async function mountApp(): Promise<void> {
+  render(<ChatApp />)
+  await waitFor(() => {
+    expect(screen.getByTestId('stub-pinned-panel').getAttribute('data-pet')).not.toBe('')
+  }, { timeout: 5_000 })
+}
+
+const chatPanel = () => screen.getByTestId('stub-chat-panel')
+const pinnedPanel = () => screen.getByTestId('stub-pinned-panel')
+const watchPanel = () => screen.getByTestId('stub-watch-panel')
+
+describe('Mochi ChatApp — view selection', () => {
+  it('mounts the chat view with both rails hidden', async () => {
+    await mountApp()
+
+    expect(chatPanel().getAttribute('data-watch-visible')).toBe('false')
+    expect(chatPanel().getAttribute('data-pinned-visible')).toBe('false')
+    expect(chatPanel().getAttribute('data-pin-count')).toBe('0')
+    expect(pinnedPanel().getAttribute('data-visible')).toBe('false')
+    expect(watchPanel().getAttribute('data-visible')).toBe('false')
+    expect(screen.queryByTestId('stub-settings-panel')).toBeNull()
+    // Neither rail was touched on mount — the shell only calls out on a toggle.
+    expect(api.toggleWatchPanel).not.toHaveBeenCalled()
+    expect(api.togglePinnedPanel).not.toHaveBeenCalled()
+  })
+
+  it('switches to settings on a backend navigate frame and unmounts both rails', async () => {
+    await mountApp()
+
+    await act(async () => { mocks.emitNavigate('/settings') })
+
+    expect(await screen.findByTestId('stub-settings-panel')).toBeTruthy()
+    expect(screen.queryByTestId('stub-chat-panel')).toBeNull()
+    // Both rails are chat-only, so they leave the tree entirely.
+    expect(screen.queryByTestId('stub-pinned-panel')).toBeNull()
+    expect(screen.queryByTestId('stub-watch-panel')).toBeNull()
+  })
+
+  it('ignores a navigate frame for any other route', async () => {
+    await mountApp()
+
+    await act(async () => { mocks.emitNavigate('/avatars') })
+
+    expect(screen.queryByTestId('stub-settings-panel')).toBeNull()
+    expect(chatPanel()).toBeTruthy()
+  })
+
+  it('switches to settings on the in-window mochi-navigate event, and only for /settings', async () => {
+    await mountApp()
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('mochi-navigate', { detail: '/gallery' }))
+    })
+    expect(screen.queryByTestId('stub-settings-panel')).toBeNull()
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('mochi-navigate', { detail: '/settings' }))
+    })
+    expect(await screen.findByTestId('stub-settings-panel')).toBeTruthy()
+  })
+
+  it('returns to chat when the settings panel closes itself', async () => {
+    await mountApp()
+    await act(async () => { mocks.emitNavigate('/settings') })
+    await screen.findByTestId('stub-settings-panel')
+
+    fireEvent.click(screen.getByRole('button', { name: 'leave settings' }))
+
+    expect(await screen.findByTestId('stub-chat-panel')).toBeTruthy()
+    expect(screen.queryByTestId('stub-settings-panel')).toBeNull()
+  })
+
+  it('stops listening to the window event once unmounted', async () => {
+    await mountApp()
+    cleanup()
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('mochi-navigate', { detail: '/settings' }))
+    })
+
+    // Nothing is mounted, so the assertion that matters is that no state
+    // update was attempted on a torn-down tree — the listener was removed.
+    expect(screen.queryByTestId('stub-settings-panel')).toBeNull()
+  })
+})
+
+describe('Mochi ChatApp — pet name', () => {
+  it('passes the stored name to both rails', async () => {
+    await mountApp()
+
+    expect(pinnedPanel().getAttribute('data-pet')).toBe('Nimbus')
+    expect(watchPanel().getAttribute('data-pet')).toBe('Nimbus')
+  })
+
+  it('resolves an empty stored name to the active avatar name, never the empty string', async () => {
+    api.getMochiConfig.mockResolvedValue({ petName: '' })
+    const expected = resolvePetName({ petName: '' })
+    expect(expected).not.toBe('')
+
+    render(<ChatApp />)
+
+    await waitFor(() => {
+      expect(pinnedPanel().getAttribute('data-pet')).toBe(expected)
+    }, { timeout: 5_000 })
+    expect(watchPanel().getAttribute('data-pet')).toBe(expected)
+  })
+})
+
+describe('Mochi ChatApp — side rails', () => {
+  it('toggles the watch rail in both directions and mirrors it to the main process', async () => {
+    await mountApp()
+
+    fireEvent.click(screen.getByRole('button', { name: 'flip the watch rail' }))
+    await waitFor(() => {
+      expect(watchPanel().getAttribute('data-visible')).toBe('true')
+    })
+    expect(chatPanel().getAttribute('data-watch-visible')).toBe('true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'flip the watch rail' }))
+    await waitFor(() => {
+      expect(watchPanel().getAttribute('data-visible')).toBe('false')
+    })
+    expect(api.toggleWatchPanel.mock.calls).toEqual([[true], [false]])
+  })
+
+  it('lets the watch rail close itself through the same toggle', async () => {
+    await mountApp()
+    fireEvent.click(screen.getByRole('button', { name: 'flip the watch rail' }))
+    await waitFor(() => {
+      expect(watchPanel().getAttribute('data-visible')).toBe('true')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'close the watch rail' }))
+
+    await waitFor(() => {
+      expect(watchPanel().getAttribute('data-visible')).toBe('false')
+    })
+    expect(api.toggleWatchPanel.mock.calls).toEqual([[true], [false]])
+  })
+
+  it('toggles the pinned rail in both directions', async () => {
+    await mountApp()
+
+    fireEvent.click(screen.getByRole('button', { name: 'flip the pinned rail' }))
+    await waitFor(() => {
+      expect(pinnedPanel().getAttribute('data-visible')).toBe('true')
+    })
+    expect(chatPanel().getAttribute('data-pinned-visible')).toBe('true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'flip the pinned rail' }))
+    await waitFor(() => {
+      expect(pinnedPanel().getAttribute('data-visible')).toBe('false')
+    })
+    expect(api.togglePinnedPanel.mock.calls).toEqual([[true], [false]])
+  })
+
+  it('hides open rails on the way into settings and restores them on the way back', async () => {
+    await mountApp()
+    fireEvent.click(screen.getByRole('button', { name: 'flip the watch rail' }))
+    fireEvent.click(screen.getByRole('button', { name: 'flip the pinned rail' }))
+    await waitFor(() => {
+      expect(pinnedPanel().getAttribute('data-visible')).toBe('true')
+    })
+
+    await act(async () => { mocks.emitNavigate('/settings') })
+    await screen.findByTestId('stub-settings-panel')
+    expect(api.toggleWatchPanel.mock.calls).toEqual([[true], [false]])
+    expect(api.togglePinnedPanel.mock.calls).toEqual([[true], [false]])
+
+    fireEvent.click(screen.getByRole('button', { name: 'leave settings' }))
+    await screen.findByTestId('stub-chat-panel')
+
+    expect(api.toggleWatchPanel.mock.calls).toEqual([[true], [false], [true]])
+    expect(api.togglePinnedPanel.mock.calls).toEqual([[true], [false], [true]])
+    // Rail state survived the trip, so the restored rails come back open.
+    expect(pinnedPanel().getAttribute('data-visible')).toBe('true')
+    expect(watchPanel().getAttribute('data-visible')).toBe('true')
+  })
+
+  it('says nothing to the main process when no rail was open', async () => {
+    await mountApp()
+
+    await act(async () => { mocks.emitNavigate('/settings') })
+    await screen.findByTestId('stub-settings-panel')
+    fireEvent.click(screen.getByRole('button', { name: 'leave settings' }))
+    await screen.findByTestId('stub-chat-panel')
+
+    expect(api.toggleWatchPanel).not.toHaveBeenCalled()
+    expect(api.togglePinnedPanel).not.toHaveBeenCalled()
+  })
+})
+
+describe('Mochi ChatApp — pinned files', () => {
+  it('seeds the rail and the header count from the initial read', async () => {
+    api.getPinnedFiles.mockResolvedValue([pin('/notes/alpha.md'), pin('/notes/beta.md')])
+
+    await mountApp()
+
+    await waitFor(() => {
+      expect(pinnedPanel().getAttribute('data-pins')).toBe('/notes/alpha.md|/notes/beta.md')
+    }, { timeout: 5_000 })
+    expect(chatPanel().getAttribute('data-pin-count')).toBe('2')
+  })
+
+  it('keeps an empty list when the initial read answers with nothing', async () => {
+    api.getPinnedFiles.mockResolvedValue(null)
+
+    await mountApp()
+
+    expect(pinnedPanel().getAttribute('data-pins')).toBe('')
+    expect(chatPanel().getAttribute('data-pin-count')).toBe('0')
+  })
+
+  it('replaces the whole list on a changed frame', async () => {
+    await mountApp()
+
+    await act(async () => { mocks.emitChanged([pin('/notes/gamma.md')]) })
+
+    expect(pinnedPanel().getAttribute('data-pins')).toBe('/notes/gamma.md')
+    expect(chatPanel().getAttribute('data-pin-count')).toBe('1')
+  })
+
+  it('marks a file as updated and clears the mark when the rail reports it seen', async () => {
+    api.getPinnedFiles.mockResolvedValue([pin('/notes/alpha.md'), pin('/notes/beta.md')])
+    await mountApp()
+    await waitFor(() => {
+      expect(pinnedPanel().getAttribute('data-pins')).not.toBe('')
+    }, { timeout: 5_000 })
+
+    await act(async () => {
+      mocks.emitUpdated({ path: '/notes/alpha.md', updatedAt: 1_700_000_100_000 })
+      mocks.emitUpdated({ path: '/notes/beta.md', updatedAt: 1_700_000_200_000 })
+    })
+    expect(pinnedPanel().getAttribute('data-updated')).toBe('/notes/alpha.md|/notes/beta.md')
+
+    fireEvent.click(screen.getByRole('button', { name: 'mark alpha seen' }))
+
+    await waitFor(() => {
+      expect(pinnedPanel().getAttribute('data-updated')).toBe('/notes/beta.md')
+    })
+  })
+
+  it('marks a file as deleted', async () => {
+    api.getPinnedFiles.mockResolvedValue([pin('/notes/alpha.md')])
+    await mountApp()
+
+    await act(async () => { mocks.emitDeleted({ path: '/notes/alpha.md' }) })
+
+    expect(pinnedPanel().getAttribute('data-deleted')).toBe('/notes/alpha.md')
+  })
+
+  it('drops updated and deleted marks for files the changed frame no longer lists', async () => {
+    api.getPinnedFiles.mockResolvedValue([pin('/notes/alpha.md'), pin('/notes/beta.md')])
+    await mountApp()
+    await waitFor(() => {
+      expect(pinnedPanel().getAttribute('data-pins')).not.toBe('')
+    }, { timeout: 5_000 })
+
+    await act(async () => {
+      mocks.emitUpdated({ path: '/notes/alpha.md', updatedAt: 1_700_000_100_000 })
+      mocks.emitUpdated({ path: '/notes/beta.md', updatedAt: 1_700_000_200_000 })
+      mocks.emitDeleted({ path: '/notes/alpha.md' })
+      mocks.emitDeleted({ path: '/notes/beta.md' })
+    })
+    expect(pinnedPanel().getAttribute('data-updated')).toBe('/notes/alpha.md|/notes/beta.md')
+    expect(pinnedPanel().getAttribute('data-deleted')).toBe('/notes/alpha.md|/notes/beta.md')
+
+    // beta.md is gone from the authoritative list, so every mark naming it is
+    // pruned. alpha.md is still listed, so both of its marks survive.
+    await act(async () => { mocks.emitChanged([pin('/notes/alpha.md')]) })
+
+    expect(pinnedPanel().getAttribute('data-pins')).toBe('/notes/alpha.md')
+    expect(pinnedPanel().getAttribute('data-updated')).toBe('/notes/alpha.md')
+    expect(pinnedPanel().getAttribute('data-deleted')).toBe('/notes/alpha.md')
+  })
+
+  it('releases the three pinned subscriptions on unmount', async () => {
+    await mountApp()
+    expect(api.onPinnedFilesChanged).toHaveBeenCalledTimes(1)
+    expect(api.onPinnedFileUpdated).toHaveBeenCalledTimes(1)
+    expect(api.onPinnedFileDeleted).toHaveBeenCalledTimes(1)
+
+    cleanup()
+
+    expect([...mocks.unsubbed].sort()).toEqual(['changed', 'deleted', 'updated'])
+  })
+
+  it('leaves the navigate subscription registered after unmount', async () => {
+    // Current behaviour, asserted so a change is visible: the shell discards the
+    // unsubscribe `onNavigate` hands back, so its callback outlives the tree.
+    await mountApp()
+    expect(mocks.navSubCount()).toBe(1)
+
+    cleanup()
+
+    expect(mocks.unsubbed).not.toContain('navigate')
+    expect(mocks.navSubCount()).toBe(1)
+  })
+})

--- a/website/src/test/OpsSignalsPanelCoverage.test.tsx
+++ b/website/src/test/OpsSignalsPanelCoverage.test.tsx
@@ -1,0 +1,609 @@
+/**
+ * Render coverage for Ops Mission Control → Signals tab.
+ *
+ * `SignalsPanel` had no mounting test at all: every branch of the source table, the
+ * three mutually exclusive trust banners, the parked/recovered cards and the claim
+ * receipt were unexecuted. The panel exists to stop an operator reading silence as
+ * health, so the branches that distinguish "looked and saw nothing" from "could not
+ * look" are exactly the ones worth pinning to the screen.
+ *
+ * Harness, matching `OpsMissionControlPageCoverage.test.tsx`:
+ *
+ *  - `opsApi` is mocked whole while every real helper (`describeSourceHealth`,
+ *    `SIGNALS_QUERY_KEY`, `WEBHOOK_QUEUE_LIMIT`) is kept, because those helpers are
+ *    what decide each row's state.
+ *  - The panel's `/signals` and `/state` queries are `enabled: false` by design — the
+ *    tab owns an explicit "Poll now" press and reads `/state` out of the cache the
+ *    board fills. Tests therefore seed the cache with `setQueryData`, which is the
+ *    same path production uses, and only the poll-button test drives `refetch()`.
+ *  - Fake timers with `shouldAdvanceTime`, so nothing a card schedules can fire after
+ *    the environment is torn down.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, waitFor, within, act } from '@testing-library/react'
+import type { QueryClient } from '@tanstack/react-query'
+import { renderWithProviders } from './helpers'
+import {
+  SIGNALS_QUERY_KEY,
+  WEBHOOK_QUEUE_LIMIT,
+  opsApi,
+  type BoardState,
+  type Evidence,
+  type Incident,
+  type LedgerEntry,
+  type ProviderInfo,
+  type Severity,
+  type Signal,
+  type SignalsResult,
+  type SourcePollHealth,
+} from '../apps/ops-mission-control/api'
+import SignalsPanel from '../apps/ops-mission-control/SignalsPanel'
+
+vi.mock('../apps/ops-mission-control/api', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../apps/ops-mission-control/api')>()
+  return {
+    ...actual,
+    opsApi: {
+      providers: vi.fn(),
+      signals: vi.fn(),
+      state: vi.fn(),
+      claim: vi.fn(),
+    },
+  }
+})
+
+/* ── fixtures ─────────────────────────────────────────────────────────────── */
+
+const agoIso = (secs: number) => new Date(Date.now() - secs * 1000).toISOString()
+
+const mkProvider = (over: Partial<ProviderInfo> = {}): ProviderInfo => ({
+  id: 'cloudwatch',
+  display_name: 'CloudWatch',
+  roles: ['signal'],
+  configured: true,
+  config_fields: [],
+  secret_fields: [],
+  detail: 'Reads alarm state from your account.',
+  config: {},
+  secrets: {},
+  ...over,
+})
+
+const mkSignal = (over: Partial<Signal> = {}): Signal => ({
+  id: 'sig-1',
+  source: 'cloudwatch',
+  title: 'Checkout latency above threshold',
+  severity: 'critical',
+  state: 'firing',
+  fired_at: agoIso(600),
+  resource: 'svc/checkout',
+  url: 'https://console.example.com/alarm/1',
+  labels: {},
+  fingerprint: 'fp-1',
+  provider_key: '',
+  suppressed_by: '',
+  suppressed_reason: '',
+  ...over,
+})
+
+const okHealth = (over: Partial<SourcePollHealth> = {}): SourcePollHealth => ({
+  ok: true,
+  detail: '',
+  at: agoIso(30),
+  ...over,
+})
+
+const mkSignalsResult = (over: Partial<SignalsResult> = {}): SignalsResult => ({
+  signals: [],
+  firing: [],
+  cleared: [],
+  suppressed: [],
+  unclaimed: [],
+  errors: {},
+  poll_health: { cloudwatch: okHealth({ signals: 0 }) },
+  all_sources_healthy: true,
+  ...over,
+})
+
+const mkIncident = (over: Partial<Incident> = {}): Incident => ({
+  incident_id: 'omc-0001',
+  signal: mkSignal(),
+  status: 'investigating',
+  operating_mode: 'propose',
+  claimed_at: agoIso(60),
+  updated_at: agoIso(10),
+  slot_key: 'ops-mission-control-omc-0001',
+  slack_thread_ts: '',
+  ledger_matches: [],
+  diagnosis: '',
+  proposed_action: null,
+  resolution: '',
+  ...over,
+})
+
+const mkEntry = (over: Partial<LedgerEntry> = {}): LedgerEntry => ({
+  entry_id: 'entry-aaaabbbb',
+  pattern: 'Latency spike on a cold cache',
+  fix: 'Warm the cache and re-check',
+  fingerprints: ['fp-1'],
+  provider_keys: [],
+  confidence: 'high',
+  trust: 'verified',
+  use_count: 4,
+  miss_count: 0,
+  last_miss: '',
+  first_seen: agoIso(90000),
+  last_used: agoIso(400),
+  source: 'cloudwatch',
+  ...over,
+})
+
+interface ClaimEnvelope {
+  incident: Incident
+  matches: LedgerEntry[]
+  similar: LedgerEntry[]
+  exact_match_ids: string[]
+  evidence: Evidence[]
+  fast_path: boolean
+  brief: string
+}
+
+const mkClaim = (over: Partial<ClaimEnvelope> = {}): ClaimEnvelope => ({
+  incident: mkIncident(),
+  matches: [],
+  similar: [],
+  exact_match_ids: [],
+  evidence: [],
+  fast_path: false,
+  brief: '',
+  ...over,
+})
+
+/* ── harness ──────────────────────────────────────────────────────────────── */
+
+/** Mount with a provider list already resolved, waiting for the table to settle. */
+async function renderPanel(providers: ProviderInfo[] = [mkProvider()]) {
+  vi.mocked(opsApi.providers).mockResolvedValue({ providers })
+  const utils = renderWithProviders(<SignalsPanel />)
+  await screen.findByText('Signal sources')
+  return utils
+}
+
+/** Fill the shared `/signals` cache entry, the way the board's own poll does. */
+function seedSignals(client: QueryClient, over: Partial<SignalsResult> = {}) {
+  act(() => {
+    client.setQueryData(SIGNALS_QUERY_KEY, mkSignalsResult(over))
+  })
+}
+
+/** Fill the board's `/state` entry — the panel reads `webhook_queue` from it. */
+function seedBoardState(client: QueryClient, webhookQueue: number) {
+  act(() => {
+    client.setQueryData(['ops-mission-control', 'state'], {
+      webhook_queue: webhookQueue,
+    } as BoardState)
+  })
+}
+
+/** Data rows of the source table, header row dropped. */
+function sourceRows() {
+  return screen.getAllByRole('row').slice(1)
+}
+
+describe('SignalsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('waits on the provider list before drawing a table', async () => {
+    vi.mocked(opsApi.providers).mockReturnValue(
+      new Promise<{ providers: ProviderInfo[] }>(() => {}),
+    )
+    renderWithProviders(<SignalsPanel />)
+    expect(await screen.findByText('Loading…')).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('says no signal sources are registered when every provider is a sink', async () => {
+    await renderPanel([mkProvider({ roles: ['sink'] })])
+    expect(
+      await screen.findByText('No signal sources registered.'),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('draws every source as unpolled before a poll, with no trust banner', async () => {
+    await renderPanel([
+      mkProvider(),
+      mkProvider({ id: 'webhook', display_name: 'Inbound webhook' }),
+      mkProvider({ id: 'zabbix', display_name: 'Zabbix', configured: false }),
+    ])
+    await screen.findByText('CloudWatch')
+
+    // The badge label only. The Last-poll cell carries the longer sentence, so an
+    // exact match here counts badges and nothing else.
+    expect(screen.getAllByText('not polled yet')).toHaveLength(2)
+    expect(screen.getByText('not set up')).toBeInTheDocument()
+    expect(
+      screen.getAllByText('not polled yet — this is not the same as healthy'),
+    ).toHaveLength(2)
+
+    const [cloudwatch, , zabbix] = sourceRows()
+    // Firing and Parked both refuse to print a zero for a source that did not
+    // contribute; an unconfigured source has nothing to say about its last poll either.
+    expect(within(cloudwatch).getAllByText('—')).toHaveLength(2)
+    expect(within(zabbix).getAllByText('—')).toHaveLength(3)
+
+    expect(screen.queryByText(/Every configured source answered/)).toBeNull()
+    expect(screen.queryByText(/did not answer this poll/)).toBeNull()
+    expect(screen.getByText('Poll to see what is firing.')).toBeInTheDocument()
+  })
+
+  it('vouches for a quiet board once every configured source answered', async () => {
+    const { queryClient } = await renderPanel()
+    seedSignals(queryClient, {
+      poll_health: { cloudwatch: okHealth({ signals: 2 }) },
+      firing: [mkSignal(), mkSignal({ id: 'sig-2' })],
+      unclaimed: [mkSignal({ id: 'sig-2', title: 'Queue depth climbing' })],
+    })
+
+    expect(
+      await screen.findByText(/Every configured source answered\./),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/A signal that is absent from this poll can be read as recovered/),
+    ).toBeInTheDocument()
+    expect(screen.getByText('2 signals · 30s ago')).toBeInTheDocument()
+    expect(
+      screen.getByText(/2 firing · 0 parked at provider · 0 cleared · 1 not yet claimed/),
+    ).toBeInTheDocument()
+
+    const [cloudwatch] = sourceRows()
+    expect(within(cloudwatch).getByText('ok')).toBeInTheDocument()
+    expect(within(cloudwatch).getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('Queue depth climbing')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Claim' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Provider' })).toHaveAttribute(
+      'href',
+      'https://console.example.com/alarm/1',
+    )
+  })
+
+  it('qualifies the all-clear for a push source whose poll drains its spool', async () => {
+    const { queryClient } = await renderPanel([
+      mkProvider(),
+      mkProvider({ id: 'webhook', display_name: 'Inbound webhook' }),
+    ])
+    seedSignals(queryClient, {
+      poll_health: {
+        cloudwatch: okHealth({ signals: 1 }),
+        webhook: okHealth({ snapshot: false }),
+      },
+    })
+
+    expect(
+      await screen.findByText(
+        /EXCEPT for Inbound webhook — it delivers by push into a spool that each poll empties/,
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('· delivered by push, so an empty poll means nothing'),
+    ).toBeInTheDocument()
+    // A count present but absent from `signals` is "we answered", not "we saw zero".
+    expect(screen.getByText('answered · 30s ago')).toBeInTheDocument()
+    expect(screen.getByText('1 signal · 30s ago')).toBeInTheDocument()
+  })
+
+  it('names the sources that failed and prints each reason with its age', async () => {
+    const { queryClient } = await renderPanel([
+      mkProvider(),
+      mkProvider({ id: 'datadog', display_name: 'Datadog' }),
+      mkProvider({ id: 'zabbix', display_name: 'Zabbix' }),
+    ])
+    seedSignals(queryClient, {
+      all_sources_healthy: false,
+      errors: {
+        cloudwatch: 'Backing off after 3 consecutive failures',
+        datadog: 'ExpiredToken: the credential is stale',
+        zabbix: 'connection refused',
+      },
+      poll_health: {
+        cloudwatch: okHealth({ at: agoIso(7200) }),
+        datadog: { ok: false, detail: 'ignored in favour of errors', at: agoIso(200000) },
+        zabbix: { ok: false, detail: '', at: 'not-a-timestamp' },
+      },
+    })
+
+    expect(
+      await screen.findByText(
+        /CloudWatch, Datadog, Zabbix did not answer this poll\./,
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/absence of a signal does NOT mean recovery/),
+    ).toBeInTheDocument()
+
+    // A throttled skip is not an operator error, but it contributed nothing either.
+    expect(screen.getByText('backing off')).toBeInTheDocument()
+    expect(
+      screen.getByText('Backing off after 3 consecutive failures (2h ago)'),
+    ).toBeInTheDocument()
+    expect(screen.getAllByText('failed')).toHaveLength(2)
+    expect(
+      screen.getByText('ExpiredToken: the credential is stale (2d ago)'),
+    ).toBeInTheDocument()
+    // An unparseable timestamp yields no age rather than an invented one — but the
+    // parentheses are emitted from the truthiness of `status.at`, not from `age()`
+    // returning something, so the row prints an empty pair. Asserted as it renders.
+    expect(screen.getByText('connection refused ()')).toBeInTheDocument()
+  })
+
+  it('does not accuse a source of failing when nothing is configured', async () => {
+    const { queryClient } = await renderPanel([
+      mkProvider({ configured: false }),
+      mkProvider({ id: 'zabbix', display_name: 'Zabbix', configured: false }),
+    ])
+    seedSignals(queryClient, { all_sources_healthy: false, poll_health: {} })
+
+    expect(
+      await screen.findByText(/No signal source is configured, so nothing was polled/),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/did not answer this poll/)).toBeNull()
+  })
+
+  it('falls back to an unnamed warning when the failing source cannot be identified', async () => {
+    const { queryClient } = await renderPanel()
+    seedSignals(queryClient, {
+      all_sources_healthy: false,
+      poll_health: { cloudwatch: okHealth({ signals: 1 }) },
+    })
+
+    expect(
+      await screen.findByText(/At least one source did not answer this poll\./),
+    ).toBeInTheDocument()
+  })
+
+  it('disables the poll button while polling and surfaces a poll failure', async () => {
+    await renderPanel()
+    let reject: (err: Error) => void = () => {}
+    vi.mocked(opsApi.signals).mockReturnValue(
+      new Promise<SignalsResult>((_, rej) => {
+        reject = rej
+      }),
+    )
+
+    const button = screen.getByRole('button', { name: /Poll now/ })
+    fireEvent.click(button)
+
+    const polling = await screen.findByRole('button', { name: /Polling…/ })
+    expect(polling).toBeDisabled()
+
+    await act(async () => {
+      reject(new Error('the /signals route refused the poll'))
+      await Promise.resolve()
+    })
+
+    expect(
+      await screen.findByText('the /signals route refused the poll', undefined, {
+        timeout: 5_000,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Poll now/ })).toBeEnabled()
+  })
+
+  it('reports an exact ledger match and a cleared fast path on the claim receipt', async () => {
+    const { queryClient } = await renderPanel()
+    const signal = mkSignal()
+    seedSignals(queryClient, { unclaimed: [signal] })
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Claim' })).toBeInTheDocument(),
+    )
+    vi.mocked(opsApi.claim).mockResolvedValue(
+      mkClaim({
+        matches: [mkEntry()],
+        similar: [mkEntry({ entry_id: 'entry-ccccdddd' })],
+        exact_match_ids: ['entry-aaaabbbb'],
+        fast_path: true,
+      }),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Claim' }))
+
+    expect(
+      await screen.findByText('Claimed omc-0001.', undefined, { timeout: 5_000 }),
+    ).toBeInTheDocument()
+    expect(vi.mocked(opsApi.claim)).toHaveBeenCalledWith(signal)
+    expect(
+      screen.getByText(
+        /1 ledger entry matched — 1 on this provider's own identity, which is an exact match\./,
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/A proven pattern matched, so the agent may propose its fix directly/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/1 similar lesson attached as context — a near-miss, not a match\./),
+    ).toBeInTheDocument()
+  })
+
+  it('warns that several matches came from the shape hash and cleared no fast path', async () => {
+    const { queryClient } = await renderPanel()
+    seedSignals(queryClient, { unclaimed: [mkSignal()] })
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Claim' })).toBeInTheDocument(),
+    )
+    vi.mocked(opsApi.claim).mockResolvedValue(
+      mkClaim({ matches: [mkEntry(), mkEntry({ entry_id: 'entry-eeeeffff' })] }),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Claim' }))
+
+    expect(
+      await screen.findByText(
+        /2 ledger entries matched — all on our shape hash, which merges alarms differing only in a number\./,
+        undefined,
+        { timeout: 5_000 },
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/No pattern cleared the fast-path bar, so the agent must confirm/),
+    ).toBeInTheDocument()
+  })
+
+  it('says the investigation starts from scratch when the ledger had nothing', async () => {
+    const { queryClient } = await renderPanel()
+    seedSignals(queryClient, { unclaimed: [mkSignal()] })
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Claim' })).toBeInTheDocument(),
+    )
+    vi.mocked(opsApi.claim).mockResolvedValue(mkClaim())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Claim' }))
+
+    expect(
+      await screen.findByText(
+        'Nothing in the ledger matched, so the investigation starts from scratch.',
+        undefined,
+        { timeout: 5_000 },
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('surfaces a rejected claim verbatim', async () => {
+    const { queryClient } = await renderPanel()
+    seedSignals(queryClient, { unclaimed: [mkSignal()] })
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Claim' })).toBeInTheDocument(),
+    )
+    vi.mocked(opsApi.claim).mockRejectedValue(new Error('403: no rule grants a claim'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Claim' }))
+
+    expect(
+      await screen.findByText('403: no rule grants a claim', undefined, {
+        timeout: 5_000,
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the inbound webhook spool only while something is waiting in it', async () => {
+    const { queryClient } = await renderPanel()
+    expect(screen.queryByText(/inbound webhook signal/)).toBeNull()
+
+    seedBoardState(queryClient, 1)
+    expect(
+      await screen.findByText(
+        /1 inbound webhook signal delivered and waiting for the next cycle to pick it up/,
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/The spool is full at/)).toBeNull()
+  })
+
+  it('warns that a spool at the cap is discarding deliveries', async () => {
+    const { queryClient } = await renderPanel()
+    seedBoardState(queryClient, WEBHOOK_QUEUE_LIMIT)
+
+    expect(
+      await screen.findByText(
+        new RegExp(`${WEBHOOK_QUEUE_LIMIT} inbound webhook signals delivered`),
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        new RegExp(`The spool is full at ${WEBHOOK_QUEUE_LIMIT}, so the oldest deliveries`),
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('lists parked signals with their attribution and offers no claim for them', async () => {
+    const parked = (id: string, severity: Severity, over: Partial<Signal> = {}) =>
+      mkSignal({ id, severity, state: 'suppressed', title: `Parked ${id}`, ...over })
+    const { queryClient } = await renderPanel()
+    seedSignals(queryClient, {
+      suppressed: [
+        parked('s1', 'critical', { suppressed_reason: 'inhibited', suppressed_by: 'HostDown' }),
+        parked('s2', 'warning', { suppressed_reason: 'inhibited' }),
+        parked('s3', 'info', { suppressed_reason: 'silenced', suppressed_by: 'octocat' }),
+        parked('s4', 'info', { url: 'javascript:alert(1)' }),
+      ],
+    })
+
+    expect(await screen.findByText('Parked at the provider')).toBeInTheDocument()
+    // The park is respected: dispatch claims only `firing`, so no button here.
+    expect(screen.queryByRole('button', { name: 'Claim' })).toBeNull()
+    expect(screen.getAllByText('parked')).toHaveLength(4)
+    expect(screen.getAllByText('critical')).toHaveLength(1)
+    expect(screen.getAllByText('warning')).toHaveLength(1)
+    expect(screen.getAllByText('info')).toHaveLength(2)
+
+    expect(
+      screen.getByText(/Inhibited by HostDown — a higher-ranked alert is masking this one/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Inhibited by another alert — a higher-ranked alert is masking this one.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/Silenced by octocat — review or let the silence expire/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/This provider published no attribution, so we cannot say who parked it/),
+    ).toBeInTheDocument()
+    // A non-http URL is dropped rather than rendered as a link.
+    expect(screen.getAllByRole('link', { name: 'Provider' })).toHaveLength(3)
+
+    // "Nothing is firing" alone would be a lie while signals sit parked.
+    expect(
+      screen.getByText(
+        /nothing is firing, but the parked signals above are not being investigated/,
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('empty-state-subtitle')).toHaveTextContent(
+      'Nothing is firing — but 4 signals are parked at the provider (see above) and will not be picked up.',
+    )
+  })
+
+  it('explains an empty queue as already-claimed work when signals are firing', async () => {
+    const { queryClient } = await renderPanel()
+    seedSignals(queryClient, { firing: [mkSignal()] })
+
+    expect(await screen.findByTestId('empty-state-title')).toHaveTextContent(
+      'Nothing unclaimed',
+    )
+    expect(screen.getByTestId('empty-state-subtitle')).toHaveTextContent(
+      'Everything currently firing already has an incident.',
+    )
+  })
+
+  it('reports a genuinely quiet estate when nothing is firing or parked', async () => {
+    const { queryClient } = await renderPanel()
+    seedSignals(queryClient)
+
+    expect(await screen.findByTestId('empty-state-subtitle')).toHaveTextContent(
+      'No sources are reporting a firing signal.',
+    )
+    expect(screen.queryByText('Parked at the provider')).toBeNull()
+  })
+
+  it('separates provider-reported recovery from a signal that merely vanished', async () => {
+    const { queryClient } = await renderPanel()
+    seedSignals(queryClient, {
+      cleared: [mkSignal({ id: 'sig-9', title: 'Disk pressure back to normal', url: '' })],
+    })
+
+    expect(await screen.findByText('Reported recovered')).toBeInTheDocument()
+    expect(screen.getByText('recovered')).toBeInTheDocument()
+    expect(screen.getByText('Disk pressure back to normal')).toBeInTheDocument()
+    expect(
+      screen.getByText(/The provider said these are back to normal/),
+    ).toBeInTheDocument()
+    // No URL, so no provider link is invented for it.
+    expect(screen.queryByRole('link', { name: 'Provider' })).toBeNull()
+  })
+})

--- a/website/src/test/OverviewPromptsTabCoverage.test.tsx
+++ b/website/src/test/OverviewPromptsTabCoverage.test.tsx
@@ -1,0 +1,339 @@
+/**
+ * PromptsTab — the Prompts tab under Agent Capabilities.
+ *
+ * Pins the four query states (loading / error / empty / loaded), the
+ * user-vs-package split with its per-package grouping, the filter counts, the
+ * expand-collapse detail fetch (including its stale-response guard and its
+ * failure text), and the "Send to…" slot picker: which label each slot row
+ * shows, what the two navigation targets are, and how the picker closes.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import type { ChatSlot } from '../types'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const mockApi = vi.hoisted(() => ({
+  prompts: vi.fn(),
+  promptDetail: vi.fn(),
+  chatSlotDetail: vi.fn(),
+}))
+vi.mock('../api/client', () => ({ api: mockApi }))
+
+import PromptsTab from '../pages/overview/PromptsTab'
+
+interface Prompt {
+  name: string
+  fullName: string
+  description: string
+  path: string
+  package: string
+  source: string
+}
+
+/** A user prompt: `package` is empty, so its detail key is the bare name. */
+const USER: Prompt = { name: 'hello', fullName: 'hello', description: 'Say hello', path: '~/.kiro/prompts/hello.md', package: '', source: 'user' }
+/** A package prompt inside a named package. */
+const PKG: Prompt = { name: 'review', fullName: 'sage/review', description: 'Review a diff', path: '/pkgs/sage/review.md', package: 'sage', source: 'package' }
+/** A package prompt with NO package — groups under "unknown". */
+const ORPHAN: Prompt = { name: 'ship', fullName: 'ship', description: 'Ship it', path: '/pkgs/ship.md', package: '', source: 'package' }
+
+const ALL = [USER, PKG, ORPHAN]
+
+const slot = (over: Partial<ChatSlot>): ChatSlot => ({ key: 'k', messages: 0, running: false, ...over })
+
+function renderTab(slots: ChatSlot[] = []) {
+  const base = createTestStore().getState()
+  // preloadedState REPLACES a slice, so spread the real initial state first.
+  const store = createTestStore({ ...base, dashboard: { ...base.dashboard, slots } })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const view = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/overview']}>
+          <PromptsTab />
+        </MemoryRouter>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return { store, ...view }
+}
+
+/** The disclosure row for a prompt, addressed by its `@fullName`. */
+const row = (fullName: string) => screen.getByRole('button', { name: new RegExp(`@${fullName}`) })
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  mockNavigate.mockReset()
+  Object.values(mockApi).forEach(m => m.mockReset())
+  mockApi.prompts.mockResolvedValue(ALL)
+  mockApi.promptDetail.mockResolvedValue({ content: 'PROMPT BODY' })
+  mockApi.chatSlotDetail.mockResolvedValue({ messages: [], running: false })
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+describe('PromptsTab query states', () => {
+  it('shows the loading line while the list is in flight', async () => {
+    mockApi.prompts.mockReturnValue(new Promise(() => {}))
+    renderTab()
+    expect(await screen.findByText('Loading prompts…')).toBeInTheDocument()
+    // No filter box until there is something to filter.
+    expect(screen.queryByPlaceholderText('Filter prompts…')).not.toBeInTheDocument()
+  })
+
+  it('surfaces the query error message', async () => {
+    mockApi.prompts.mockRejectedValue(new Error('prompts endpoint exploded'))
+    renderTab()
+    expect(await screen.findByText('prompts endpoint exploded')).toBeInTheDocument()
+    // An error is not an empty list — the "install a package" nudge stays away.
+    expect(screen.queryByText(/No prompts found/)).not.toBeInTheDocument()
+  })
+
+  it('falls back to a generic message when the error carries none', async () => {
+    mockApi.prompts.mockRejectedValue(new Error(''))
+    renderTab()
+    expect(await screen.findByText('Failed to load prompts')).toBeInTheDocument()
+  })
+
+  it('names the registry singular in the empty state', async () => {
+    mockApi.prompts.mockResolvedValue([])
+    renderTab()
+    // "Packages" is de-pluralised for the install nudge.
+    expect(await screen.findByText(/No prompts found\. Install a package with prompts/)).toBeInTheDocument()
+  })
+})
+
+describe('PromptsTab listing', () => {
+  it('splits user from package prompts and groups packages by name', async () => {
+    renderTab()
+    expect(await screen.findByRole('heading', { name: 'User Prompts (1)' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Packages Prompts (2)' })).toBeInTheDocument()
+
+    // Group headers: the named package, and "unknown" for the one without.
+    expect(screen.getByText('sage')).toBeInTheDocument()
+    expect(screen.getByText('unknown')).toBeInTheDocument()
+
+    // Provenance badge: package prompts read "Package", others read their source.
+    expect(screen.getAllByText('Package')).toHaveLength(2)
+    expect(screen.getByText('user')).toBeInTheDocument()
+
+    // Collapsed by default.
+    expect(row('hello')).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByText('Say hello')).toBeInTheDocument()
+  })
+
+  it('filter narrows both sections independently and shows of-total counts', async () => {
+    renderTab()
+    await screen.findByRole('heading', { name: 'User Prompts (1)' })
+
+    fireEvent.change(screen.getByPlaceholderText('Filter prompts…'), { target: { value: 'review' } })
+    // Only the package side survives, and its title switches to the of-total form.
+    expect(await screen.findByRole('heading', { name: 'Packages Prompts (1 of 2)' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /User Prompts/ })).not.toBeInTheDocument()
+    expect(screen.queryByText('unknown')).not.toBeInTheDocument()
+
+    // Filtering on a description word reaches the user side instead.
+    fireEvent.change(screen.getByPlaceholderText('Filter prompts…'), { target: { value: 'SAY' } })
+    expect(await screen.findByRole('heading', { name: 'User Prompts (1 of 1)' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /Packages Prompts/ })).not.toBeInTheDocument()
+
+    // A miss on both sides leaves only the header card.
+    fireEvent.change(screen.getByPlaceholderText('Filter prompts…'), { target: { value: 'zzz' } })
+    await waitFor(() => expect(screen.queryByRole('heading', { name: /User Prompts/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole('heading', { name: /Packages Prompts/ })).not.toBeInTheDocument()
+    // Not the empty state either — the list itself is non-empty.
+    expect(screen.queryByText(/No prompts found/)).not.toBeInTheDocument()
+  })
+})
+
+describe('PromptsTab detail disclosure', () => {
+  it('expands a package prompt with its qualified detail key and collapses again', async () => {
+    renderTab()
+    await screen.findByRole('heading', { name: 'User Prompts (1)' })
+
+    fireEvent.click(row('sage/review'))
+    await waitFor(() => expect(mockApi.promptDetail).toHaveBeenCalledWith('sage/review'))
+    expect(await screen.findByText('PROMPT BODY')).toBeInTheDocument()
+    expect(screen.getByText('/pkgs/sage/review.md')).toBeInTheDocument()
+    expect(row('sage/review')).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.click(row('sage/review'))
+    await waitFor(() => expect(screen.queryByText('PROMPT BODY')).not.toBeInTheDocument())
+    expect(row('sage/review')).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('uses the bare name as detail key when a prompt has no package', async () => {
+    renderTab()
+    await screen.findByRole('heading', { name: 'User Prompts (1)' })
+    fireEvent.click(row('hello'))
+    await waitFor(() => expect(mockApi.promptDetail).toHaveBeenCalledWith('hello'))
+  })
+
+  it('expands on Enter and on Space', async () => {
+    renderTab()
+    await screen.findByRole('heading', { name: 'User Prompts (1)' })
+
+    fireEvent.keyDown(row('hello'), { key: 'Enter' })
+    await waitFor(() => expect(row('hello')).toHaveAttribute('aria-expanded', 'true'))
+
+    fireEvent.keyDown(row('hello'), { key: ' ' })
+    await waitFor(() => expect(row('hello')).toHaveAttribute('aria-expanded', 'false'))
+
+    // An unrelated key does nothing.
+    fireEvent.keyDown(row('hello'), { key: 'a' })
+    expect(row('hello')).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('renders empty content rather than crashing when the detail has none', async () => {
+    mockApi.promptDetail.mockResolvedValue({})
+    renderTab()
+    await screen.findByRole('heading', { name: 'User Prompts (1)' })
+    fireEvent.click(row('hello'))
+    await waitFor(() => expect(row('hello')).toHaveAttribute('aria-expanded', 'true'))
+    expect(screen.queryByText('PROMPT BODY')).not.toBeInTheDocument()
+  })
+
+  it('still expands, with a failure note, when the detail fetch rejects', async () => {
+    mockApi.promptDetail.mockRejectedValue(new Error('404'))
+    renderTab()
+    await screen.findByRole('heading', { name: 'User Prompts (1)' })
+    fireEvent.click(row('hello'))
+    expect(await screen.findByText('(failed to load)')).toBeInTheDocument()
+    expect(row('hello')).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('drops a slow first response once a second prompt has been clicked', async () => {
+    let releaseFirst: ((v: { content: string }) => void) | undefined
+    mockApi.promptDetail
+      .mockImplementationOnce(() => new Promise<{ content: string }>(res => { releaseFirst = res }))
+      .mockResolvedValue({ content: 'SECOND BODY' })
+
+    renderTab()
+    await screen.findByRole('heading', { name: 'User Prompts (1)' })
+
+    fireEvent.click(row('hello'))          // in flight, nothing expanded yet
+    fireEvent.click(row('sage/review'))    // supersedes it
+    expect(await screen.findByText('SECOND BODY')).toBeInTheDocument()
+
+    releaseFirst?.({ content: 'FIRST BODY' })
+    await waitFor(() => expect(screen.getByText('SECOND BODY')).toBeInTheDocument())
+    // The stale winner must not steal the open row.
+    expect(screen.queryByText('FIRST BODY')).not.toBeInTheDocument()
+    expect(row('hello')).toHaveAttribute('aria-expanded', 'false')
+    expect(row('sage/review')).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('drops a slow first FAILURE once a second prompt has been clicked', async () => {
+    let rejectFirst: ((e: Error) => void) | undefined
+    mockApi.promptDetail
+      .mockImplementationOnce(() => new Promise<{ content: string }>((_res, rej) => { rejectFirst = rej }))
+      .mockResolvedValue({ content: 'SECOND BODY' })
+
+    renderTab()
+    await screen.findByRole('heading', { name: 'User Prompts (1)' })
+
+    fireEvent.click(row('hello'))
+    fireEvent.click(row('sage/review'))
+    expect(await screen.findByText('SECOND BODY')).toBeInTheDocument()
+
+    rejectFirst?.(new Error('too late'))
+    await waitFor(() => expect(screen.getByText('SECOND BODY')).toBeInTheDocument())
+    // The superseded failure must not replace the open row's body.
+    expect(screen.queryByText('(failed to load)')).not.toBeInTheDocument()
+    expect(row('sage/review')).toHaveAttribute('aria-expanded', 'true')
+  })
+})
+
+describe('PromptsTab slot picker', () => {
+  async function openPicker(slots: ChatSlot[] = []) {
+    const ctx = renderTab(slots)
+    await screen.findByRole('heading', { name: 'User Prompts (1)' })
+    fireEvent.click(row('hello'))
+    await waitFor(() => expect(row('hello')).toHaveAttribute('aria-expanded', 'true'))
+    fireEvent.click(screen.getByRole('button', { name: /Use in Chat/ }))
+    expect(await screen.findByText('Send to…')).toBeInTheDocument()
+    return ctx
+  }
+
+  it('labels each slot by title, then agent, then key — and dots the running one', async () => {
+    await openPicker([
+      slot({ key: 'a', title: 'Alpha session', running: true }),
+      slot({ key: 'b', title: 'b', agent: 'researcher' }),
+      slot({ key: 'c' }),
+    ])
+    expect(screen.getByRole('button', { name: 'Alpha session' })).toBeInTheDocument()
+    // title === key is treated as no title, so the agent name wins.
+    expect(screen.getByRole('button', { name: 'researcher' })).toBeInTheDocument()
+    // No title and no agent leaves the raw key.
+    expect(screen.getByRole('button', { name: 'c' })).toBeInTheDocument()
+  })
+
+  it('says so when there is no chat to send to', async () => {
+    await openPicker()
+    expect(screen.getByText('No active chats')).toBeInTheDocument()
+  })
+
+  it('New Chat seeds the mention and routes to a fresh session', async () => {
+    const { store } = await openPicker()
+    fireEvent.click(screen.getByRole('button', { name: '+ New Chat' }))
+    expect(store.getState().chat.pendingInput).toBe('@hello')
+    expect(mockNavigate).toHaveBeenCalledWith('/chat?autoSend=1&newSession=1')
+    // Picker closes on send.
+    await waitFor(() => expect(screen.queryByText('Send to…')).not.toBeInTheDocument())
+  })
+
+  it('picking a slot switches to it and routes without newSession', async () => {
+    const { store } = await openPicker([slot({ key: 'chat/7', title: 'Seven' })])
+    fireEvent.click(screen.getByRole('button', { name: 'Seven' }))
+    expect(store.getState().chat.pendingInput).toBe('@hello')
+    await waitFor(() => expect(mockApi.chatSlotDetail).toHaveBeenCalledWith('chat/7'))
+    expect(mockNavigate).toHaveBeenCalledWith('/chat?autoSend=1')
+    expect(mockNavigate).not.toHaveBeenCalledWith('/chat?autoSend=1&newSession=1')
+  })
+
+  it('sends from the keyboard too', async () => {
+    await openPicker([slot({ key: 'chat/9', title: 'Nine' })])
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Nine' }), { key: 'Enter' })
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/chat?autoSend=1'))
+
+    fireEvent.click(screen.getByRole('button', { name: /Use in Chat/ }))
+    await screen.findByText('Send to…')
+    fireEvent.keyDown(screen.getByRole('button', { name: '+ New Chat' }), { key: ' ' })
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/chat?autoSend=1&newSession=1'))
+  })
+
+  it('ignores other keys on the picker rows', async () => {
+    await openPicker([slot({ key: 'chat/1', title: 'One' })])
+    fireEvent.keyDown(screen.getByRole('button', { name: 'One' }), { key: 'x' })
+    fireEvent.keyDown(screen.getByRole('button', { name: '+ New Chat' }), { key: 'Tab' })
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(screen.getByText('Send to…')).toBeInTheDocument()
+  })
+
+  it('closes on an outside mousedown but survives one inside itself', async () => {
+    await openPicker([slot({ key: 'chat/1', title: 'One' })])
+    fireEvent.mouseDown(screen.getByText('Send to…'))
+    expect(screen.getByText('Send to…')).toBeInTheDocument()
+
+    fireEvent.mouseDown(document.body)
+    await waitFor(() => expect(screen.queryByText('Send to…')).not.toBeInTheDocument())
+  })
+
+  it('the Use in Chat button toggles the picker back off', async () => {
+    await openPicker()
+    fireEvent.click(screen.getByRole('button', { name: /Use in Chat/ }))
+    await waitFor(() => expect(screen.queryByText('Send to…')).not.toBeInTheDocument())
+  })
+})

--- a/website/src/test/SessionGridViewCoverage.test.tsx
+++ b/website/src/test/SessionGridViewCoverage.test.tsx
@@ -1,0 +1,593 @@
+/**
+ * Coverage for SessionGridView — Kiro Crew's native in-place "terminal split"
+ * chat surface.
+ *
+ * The view is thin glue over useSessionGrid, and the parts worth pinning down are
+ * exactly the glue: seeding on entry, the three collapse rules (0 leaves → leave,
+ * 1 session → hand back to single chat, 1 placeholder → leave), the ⌘D/Ctrl+D
+ * split binding and its modifier guards, healing a restored layout against the
+ * live slot list, the slot-focus intent signal, per-leaf rendering (session /
+ * terminal / picker), and the PlaceholderPane picker itself (search, sort,
+ * occupied-slot exclusion, create, fork, split, close).
+ *
+ * ChatPane is stubbed: it is a full live chat surface of its own with its own
+ * tests, and the only contract this view has with it is the six props it passes.
+ * The split renderer (SessionGridLayout) and the grid state hook stay REAL so the
+ * tree transforms are exercised end to end.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, waitFor, fireEvent, within } from '@testing-library/react'
+import SessionGridView from '../components/SessionGridView'
+import { renderWithProviders } from './helpers'
+import { api } from '../api/client'
+import { emitSlotFocused } from '../hooks/useWebSocket'
+import type { GridNode } from '../hooks/useSessionGrid'
+
+vi.mock('../api/client')
+
+vi.mock('../hooks/useWebSocket', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../hooks/useWebSocket')>()
+  return { ...actual, emitSlotFocused: vi.fn() }
+})
+
+// A live ChatPane mounts the whole per-slot composer (ChatInput, model/agent
+// pickers, message store wiring). This view only ever hands it six props, so the
+// stub surfaces each callback as its own button and echoes the focused flag.
+vi.mock('../components/ChatPane', () => ({
+  default: ({
+    slotKey,
+    focused,
+    onFocus,
+    onRemove,
+    onSplitRight,
+    onSplitDown,
+  }: {
+    slotKey: string
+    focused?: boolean
+    onFocus?: () => void
+    onRemove?: () => void
+    onSplitRight?: () => void
+    onSplitDown?: () => void
+  }) => (
+    <div data-testid={`pane-${slotKey}`} data-focused={focused ? 'yes' : 'no'}>
+      <button type="button" aria-label={`focus ${slotKey}`} onClick={onFocus} />
+      <button type="button" aria-label={`remove ${slotKey}`} onClick={onRemove} />
+      <button type="button" aria-label={`right ${slotKey}`} onClick={onSplitRight} />
+      <button type="button" aria-label={`down ${slotKey}`} onClick={onSplitDown} />
+    </div>
+  ),
+}))
+
+const STORE_KEY = 'mc-split-layouts'
+
+type Slot = {
+  key: string
+  title?: string
+  running?: boolean
+  pending_approval?: boolean
+  messages?: number
+  agent?: string
+  last_activity_ts?: string
+}
+
+const leaf = (id: string, slot?: string): GridNode =>
+  slot ? { type: 'leaf', id, kind: 'session', slot } : { type: 'leaf', id, kind: 'placeholder' }
+
+const splitOf = (children: GridNode[]): GridNode => ({
+  type: 'split',
+  id: 'split-root',
+  dir: 'col',
+  children,
+  sizes: children.map(() => 1 / children.length),
+})
+
+/** Persist a layout under `anchor` so useSessionGrid restores it instead of seeding. */
+const seedStore = (anchor: string, tree: GridNode) => {
+  localStorage.setItem(STORE_KEY, JSON.stringify({ [anchor]: tree }))
+}
+
+/** Seed every endpoint the view (and its picker) can reach. */
+function seedApi(slots: Slot[] = []) {
+  const m = vi.mocked(api)
+  m.chatSlots = vi.fn().mockResolvedValue(slots)
+  m.createChatSlot = vi.fn().mockResolvedValue({ key: 'created-1' })
+  m.forkChatSlot = vi.fn().mockResolvedValue({ ok: true, key: 'forked-1' })
+  return m
+}
+
+function renderGrid(seedSlot?: string | null) {
+  const onClose = vi.fn()
+  const onCollapse = vi.fn()
+  const utils = renderWithProviders(
+    <SessionGridView onClose={onClose} onCollapse={onCollapse} seedSlot={seedSlot} />,
+  )
+  return { ...utils, onClose, onCollapse }
+}
+
+/** Every placeholder picker pane currently mounted (outer pane element). */
+function pickers(): HTMLElement[] {
+  return screen.queryAllByPlaceholderText('Search sessions…').map((input) => {
+    const pane = input.parentElement?.parentElement
+    if (!pane) throw new Error('picker pane element not found')
+    return pane as HTMLElement
+  })
+}
+
+const onlyPicker = (): HTMLElement => {
+  const all = pickers()
+  expect(all).toHaveLength(1)
+  return all[0]
+}
+
+/** The session rows inside a picker's scroll list (its last child). */
+const rowsOf = (picker: HTMLElement) =>
+  within(picker.lastElementChild as HTMLElement).queryAllByRole('button')
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.mocked(emitSlotFocused).mockClear()
+  seedApi()
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+describe('SessionGridView — entry seeding', () => {
+  it('splits the current session in place, session pane beside a fresh picker', async () => {
+    seedApi([{ key: 'a', title: 'Alpha' }])
+    renderGrid('a')
+
+    expect(await screen.findByTestId('pane-a')).toBeTruthy()
+    expect(pickers()).toHaveLength(1)
+  })
+
+  it('focuses the fresh picker, not the seeded session pane', async () => {
+    renderGrid('a')
+
+    const pane = await screen.findByTestId('pane-a')
+    expect(pane.getAttribute('data-focused')).toBe('no')
+  })
+
+  it('leaves split mode when there is no session to seed from', async () => {
+    const { onClose, onCollapse } = renderGrid(null)
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(onCollapse).not.toHaveBeenCalled()
+    // A lone placeholder is not a split, but it is still what renders until the
+    // parent surface tears the view down.
+    expect(pickers()).toHaveLength(1)
+  })
+
+  it('treats an omitted seedSlot the same as an explicit null', async () => {
+    const { onClose } = renderGrid()
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+  })
+
+  it('restores the layout persisted under the anchor instead of re-seeding', async () => {
+    seedStore('a', splitOf([leaf('l-a', 'a'), leaf('l-b', 'b')]))
+    seedApi([{ key: 'a' }, { key: 'b' }])
+    renderGrid('a')
+
+    expect(await screen.findByTestId('pane-a')).toBeTruthy()
+    expect(screen.getByTestId('pane-b')).toBeTruthy()
+    expect(pickers()).toHaveLength(0)
+  })
+})
+
+describe('SessionGridView — collapse rules', () => {
+  it('hands a lone surviving session back to the native single-chat surface', async () => {
+    renderGrid('a')
+    const picker = onlyPicker()
+
+    fireEvent.click(within(picker).getByLabelText('Close cell'))
+
+    await waitFor(() => expect(pickers()).toHaveLength(0))
+    expect(screen.getByTestId('pane-a')).toBeTruthy()
+  })
+
+  it('reports the collapsed slot to onCollapse', async () => {
+    const { onCollapse } = renderGrid('a')
+
+    fireEvent.click(within(onlyPicker()).getByLabelText('Close cell'))
+
+    await waitFor(() => expect(onCollapse).toHaveBeenCalledWith('a'))
+  })
+
+  it('falls back to the loading surface once every pane is closed', async () => {
+    const { onClose, onCollapse } = renderGrid('a')
+    fireEvent.click(within(onlyPicker()).getByLabelText('Close cell'))
+    await waitFor(() => expect(onCollapse).toHaveBeenCalledWith('a'))
+
+    fireEvent.click(screen.getByLabelText('remove a'))
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(screen.getByText('Loading…')).toBeTruthy()
+  })
+})
+
+describe('SessionGridView — split keybinding', () => {
+  it('splits the focused pane right on Cmd+D', async () => {
+    renderGrid('a')
+    await screen.findByTestId('pane-a')
+
+    fireEvent.keyDown(document, { key: 'd', metaKey: true })
+
+    await waitFor(() => expect(pickers()).toHaveLength(2))
+  })
+
+  it('splits on Ctrl+D as well, and accepts an upper-case key', async () => {
+    renderGrid('a')
+    await screen.findByTestId('pane-a')
+
+    fireEvent.keyDown(document, { key: 'D', ctrlKey: true })
+
+    await waitFor(() => expect(pickers()).toHaveLength(2))
+  })
+
+  it.each([
+    ['no modifier', { key: 'd' }],
+    ['Shift held', { key: 'd', metaKey: true, shiftKey: true }],
+    ['Alt held', { key: 'd', metaKey: true, altKey: true }],
+    ['another key', { key: 'k', metaKey: true }],
+  ])('ignores a keydown with %s', async (_label, init) => {
+    renderGrid('a')
+    await screen.findByTestId('pane-a')
+
+    fireEvent.keyDown(document, init)
+
+    expect(pickers()).toHaveLength(1)
+  })
+
+  it('is inert once the grid holds no panes at all', async () => {
+    const { onClose, onCollapse } = renderGrid('a')
+    fireEvent.click(within(onlyPicker()).getByLabelText('Close cell'))
+    await waitFor(() => expect(onCollapse).toHaveBeenCalled())
+    fireEvent.click(screen.getByLabelText('remove a'))
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+
+    fireEvent.keyDown(document, { key: 'd', metaKey: true })
+
+    expect(screen.getByText('Loading…')).toBeTruthy()
+    expect(pickers()).toHaveLength(0)
+  })
+
+  it('stops splitting after unmount', async () => {
+    const { unmount } = renderGrid('a')
+    await screen.findByTestId('pane-a')
+
+    unmount()
+    fireEvent.keyDown(document, { key: 'd', metaKey: true })
+
+    expect(pickers()).toHaveLength(0)
+  })
+})
+
+describe('SessionGridView — healing a restored layout', () => {
+  it('drops panes whose session disappeared while away', async () => {
+    seedStore('a', splitOf([leaf('l-a', 'a'), leaf('l-b', 'b')]))
+    seedApi([{ key: 'a' }])
+    const { onCollapse } = renderGrid('a')
+
+    await waitFor(() => expect(onCollapse).toHaveBeenCalledWith('a'))
+    expect(screen.queryByTestId('pane-b')).toBeNull()
+  })
+
+  it('keeps every pane when the whole layout is still live', async () => {
+    seedStore('a', splitOf([leaf('l-a', 'a'), leaf('l-b', 'b')]))
+    seedApi([{ key: 'a' }, { key: 'b' }])
+    const { onCollapse, onClose } = renderGrid('a')
+
+    await waitFor(() => expect(vi.mocked(api).chatSlots).toHaveBeenCalled())
+    expect(screen.getByTestId('pane-a')).toBeTruthy()
+    expect(screen.getByTestId('pane-b')).toBeTruthy()
+    expect(onCollapse).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not prune against an empty slot list', async () => {
+    seedStore('a', splitOf([leaf('l-a', 'a'), leaf('l-b', 'b')]))
+    seedApi([])
+    const { onClose } = renderGrid('a')
+
+    await waitFor(() => expect(vi.mocked(api).chatSlots).toHaveBeenCalled())
+    expect(screen.getByTestId('pane-a')).toBeTruthy()
+    expect(screen.getByTestId('pane-b')).toBeTruthy()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+describe('SessionGridView — slot-focus intent signal', () => {
+  it('emits a blur frame while a placeholder holds focus', async () => {
+    renderGrid('a')
+    await screen.findByTestId('pane-a')
+
+    expect(vi.mocked(emitSlotFocused).mock.calls.at(-1)).toEqual([null])
+  })
+
+  it('emits the pane slot once a session pane takes focus', async () => {
+    renderGrid('a')
+    await screen.findByTestId('pane-a')
+
+    fireEvent.click(screen.getByLabelText('focus a'))
+
+    await waitFor(() => expect(vi.mocked(emitSlotFocused).mock.calls.at(-1)).toEqual(['a']))
+    expect(screen.getByTestId('pane-a').getAttribute('data-focused')).toBe('yes')
+  })
+
+  it('emits the restored layout first pane on entry', async () => {
+    seedStore('a', splitOf([leaf('l-a', 'a'), leaf('l-b', 'b')]))
+    seedApi([{ key: 'a' }, { key: 'b' }])
+    renderGrid('a')
+
+    await waitFor(() => expect(vi.mocked(emitSlotFocused).mock.calls.at(-1)).toEqual(['a']))
+  })
+})
+
+describe('SessionGridView — leaf rendering', () => {
+  it('renders the Phase 2 notice for a terminal leaf', async () => {
+    seedStore(
+      'a',
+      splitOf([
+        leaf('l-a', 'a'),
+        { type: 'leaf', id: 'l-t', kind: 'terminal', termId: 'pty-1' },
+        leaf('l-b', 'b'),
+      ]),
+    )
+    seedApi([{ key: 'a' }, { key: 'b' }])
+    renderGrid('a')
+
+    expect(await screen.findByText('Terminal pane — coming in Phase 2')).toBeTruthy()
+  })
+
+  it('renders a picker for a session leaf that carries no slot', async () => {
+    seedStore(
+      'a',
+      splitOf([leaf('l-a', 'a'), { type: 'leaf', id: 'l-x', kind: 'session' }, leaf('l-b', 'b')]),
+    )
+    seedApi([{ key: 'a' }, { key: 'b' }])
+    renderGrid('a')
+
+    await screen.findByTestId('pane-a')
+    expect(pickers()).toHaveLength(1)
+  })
+
+  it('splits a session pane right and down from its own controls', async () => {
+    renderGrid('a')
+    await screen.findByTestId('pane-a')
+
+    fireEvent.click(screen.getByLabelText('right a'))
+    await waitFor(() => expect(pickers()).toHaveLength(2))
+
+    fireEvent.click(screen.getByLabelText('down a'))
+    await waitFor(() => expect(pickers()).toHaveLength(3))
+  })
+})
+
+describe('SessionGridView — picker list', () => {
+  it('excludes sessions already pinned in a pane', async () => {
+    seedApi([{ key: 'a', title: 'Alpha' }, { key: 'b', title: 'Bravo' }])
+    renderGrid('a')
+
+    await waitFor(() => expect(rowsOf(onlyPicker())).toHaveLength(1))
+    expect(rowsOf(onlyPicker())[0].textContent).toContain('Bravo')
+  })
+
+  it('orders approval-waiting first, then running, then most recent', async () => {
+    seedApi([
+      { key: 'idle', title: 'Idle one', last_activity_ts: '2026-08-01T00:00:00' },
+      { key: 'run', title: 'Running one', running: true },
+      { key: 'appr', title: 'Approval one', pending_approval: true },
+      { key: 'stale', title: 'Older one', last_activity_ts: '2026-07-01T00:00:00' },
+    ])
+    renderGrid(null)
+
+    await waitFor(() => expect(rowsOf(onlyPicker())).toHaveLength(4))
+    const titles = rowsOf(onlyPicker()).map((r) => r.textContent)
+    expect(titles[0]).toContain('Approval one')
+    expect(titles[1]).toContain('Running one')
+    expect(titles[2]).toContain('Idle one')
+    expect(titles[3]).toContain('Older one')
+  })
+
+  it('marks each row status on its dot and shows the message count', async () => {
+    seedApi([
+      { key: 'appr', title: 'Approval one', pending_approval: true, messages: 7 },
+      { key: 'run', title: 'Running one', running: true, messages: 3 },
+      { key: 'idle', title: 'Idle one' },
+    ])
+    renderGrid(null)
+
+    await waitFor(() => expect(rowsOf(onlyPicker())).toHaveLength(3))
+    const rows = rowsOf(onlyPicker())
+    expect(rows[0].querySelector('svg')?.getAttribute('class')).toContain('fill-warn')
+    expect(rows[1].querySelector('svg')?.getAttribute('class')).toContain('fill-ok')
+    expect(rows[2].querySelector('svg')?.getAttribute('class')).toContain('fill-muted')
+    expect(rows[0].textContent).toContain('7 msgs')
+    expect(rows[2].textContent).toContain('0 msgs')
+  })
+
+  it('falls back to the slot key when a session has no title', async () => {
+    seedApi([{ key: 'untitled-slot' }])
+    renderGrid(null)
+
+    await waitFor(() => expect(rowsOf(onlyPicker())).toHaveLength(1))
+    expect(rowsOf(onlyPicker())[0].textContent).toContain('untitled-slot')
+  })
+
+  it('filters by title, key and agent', async () => {
+    seedApi([
+      { key: 'a1', title: 'Alpha', agent: 'kirocrew' },
+      { key: 'b2', title: 'Bravo', agent: 'reviewer' },
+    ])
+    renderGrid(null)
+    await waitFor(() => expect(rowsOf(onlyPicker())).toHaveLength(2))
+    const input = screen.getByPlaceholderText('Search sessions…')
+
+    fireEvent.change(input, { target: { value: 'brav' } })
+    expect(rowsOf(onlyPicker())).toHaveLength(1)
+
+    fireEvent.change(input, { target: { value: 'a1' } })
+    expect(rowsOf(onlyPicker())[0].textContent).toContain('Alpha')
+
+    fireEvent.change(input, { target: { value: 'reviewer' } })
+    expect(rowsOf(onlyPicker())[0].textContent).toContain('Bravo')
+  })
+
+  it('shows the empty state when nothing matches the search', async () => {
+    seedApi([{ key: 'a1', title: 'Alpha' }])
+    renderGrid(null)
+    await waitFor(() => expect(rowsOf(onlyPicker())).toHaveLength(1))
+
+    fireEvent.change(screen.getByPlaceholderText('Search sessions…'), {
+      target: { value: 'nothing-like-this' },
+    })
+
+    expect(screen.getByText('No matching sessions')).toBeTruthy()
+    expect(rowsOf(onlyPicker())).toHaveLength(0)
+  })
+
+  it('pins the picked session into that cell', async () => {
+    seedApi([{ key: 'b', title: 'Bravo' }])
+    renderGrid('a')
+    await waitFor(() => expect(rowsOf(onlyPicker())).toHaveLength(1))
+
+    fireEvent.click(rowsOf(onlyPicker())[0])
+
+    expect(await screen.findByTestId('pane-b')).toBeTruthy()
+    expect(pickers()).toHaveLength(0)
+  })
+})
+
+describe('SessionGridView — picker controls', () => {
+  it('creates a session and pins it into the cell', async () => {
+    const m = seedApi([{ key: 'a' }, { key: 'zeta', title: 'Zeta' }])
+    renderGrid('a')
+    // Wait for the first slot payload: the view's heal-once prune runs off it and
+    // drops any session pane the list does not name (see the note on the fork test).
+    await waitFor(() => expect(rowsOf(onlyPicker())).toHaveLength(1))
+
+    fireEvent.click(within(onlyPicker()).getByRole('button', { name: 'New session' }))
+
+    expect(await screen.findByTestId('pane-created-1')).toBeTruthy()
+    expect(m.createChatSlot).toHaveBeenCalled()
+  })
+
+  it('leaves the cell empty when the created session has no key', async () => {
+    const m = seedApi([{ key: 'a' }])
+    m.createChatSlot = vi.fn().mockResolvedValue({})
+    renderGrid('a')
+
+    fireEvent.click(within(onlyPicker()).getByRole('button', { name: 'New session' }))
+
+    await waitFor(() => expect(m.createChatSlot).toHaveBeenCalled())
+    expect(pickers()).toHaveLength(1)
+  })
+
+  it('disables the create button and shows a spinner while creating', async () => {
+    const m = seedApi([{ key: 'a' }])
+    let release: (v: { key?: string }) => void = () => {}
+    m.createChatSlot = vi.fn().mockReturnValue(new Promise((res) => { release = res }))
+    renderGrid('a')
+    const create = within(onlyPicker()).getByRole('button', { name: 'New session' })
+
+    fireEvent.click(create)
+
+    await waitFor(() => expect((create as HTMLButtonElement).disabled).toBe(true))
+    expect(onlyPicker().querySelector('.animate-spin')).toBeTruthy()
+    release({ key: 'created-1' })
+    expect(await screen.findByTestId('pane-created-1')).toBeTruthy()
+  })
+
+  it('forks the focused session and pins the child', async () => {
+    const m = seedApi([{ key: 'a' }, { key: 'zeta', title: 'Zeta' }])
+    renderGrid('a')
+    // The wait is load-bearing, not politeness: the heal-once prune fires on the
+    // first non-empty slot payload, and a payload that predates the fork does not
+    // name the child — so a fork picked before it lands is pruned straight back out.
+    await waitFor(() => expect(rowsOf(onlyPicker())).toHaveLength(1))
+
+    fireEvent.click(within(onlyPicker()).getByRole('button', { name: 'Fork' }))
+
+    expect(await screen.findByTestId('pane-forked-1')).toBeTruthy()
+    expect(m.forkChatSlot).toHaveBeenCalledWith('a')
+  })
+
+  it('leaves the cell empty when the fork is refused', async () => {
+    const m = seedApi([{ key: 'a' }])
+    m.forkChatSlot = vi.fn().mockResolvedValue({ ok: false, key: 'forked-1' })
+    renderGrid('a')
+
+    fireEvent.click(within(onlyPicker()).getByRole('button', { name: 'Fork' }))
+
+    await waitFor(() => expect(m.forkChatSlot).toHaveBeenCalled())
+    expect(screen.queryByTestId('pane-forked-1')).toBeNull()
+  })
+
+  it('disables the fork button while no session is in the grid', async () => {
+    renderGrid(null)
+
+    const fork = within(onlyPicker()).getByRole('button', { name: 'Fork' }) as HTMLButtonElement
+    expect(fork.disabled).toBe(true)
+    expect(fork.getAttribute('title')).toBe('No session to fork yet')
+  })
+
+  it('names the fork source by title, falling back to its slot key', async () => {
+    seedApi([{ key: 'a', title: 'Alpha' }])
+    const { unmount } = renderGrid('a')
+
+    await waitFor(() =>
+      expect(within(onlyPicker()).getByRole('button', { name: 'Fork' }).getAttribute('title')).toBe(
+        'Fork Alpha (child session)',
+      ),
+    )
+
+    unmount()
+    localStorage.clear()
+    seedApi([])
+    renderGrid('a')
+    expect(within(onlyPicker()).getByRole('button', { name: 'Fork' }).getAttribute('title')).toBe(
+      'Fork a (child session)',
+    )
+  })
+
+  it('forks the pane that holds focus, not merely the first one', async () => {
+    seedStore('a', splitOf([leaf('l-a', 'a'), leaf('l-b', 'b'), leaf('l-p')]))
+    seedApi([{ key: 'a', title: 'Alpha' }, { key: 'b', title: 'Bravo' }])
+    renderGrid('a')
+    await screen.findByTestId('pane-b')
+
+    fireEvent.click(screen.getByLabelText('focus b'))
+
+    await waitFor(() =>
+      expect(within(onlyPicker()).getByRole('button', { name: 'Fork' }).getAttribute('title')).toBe(
+        'Fork Bravo (child session)',
+      ),
+    )
+  })
+
+  it('splits the picker cell right and down from its own controls', async () => {
+    renderGrid('a')
+    const picker = onlyPicker()
+
+    fireEvent.click(within(picker).getByLabelText('Split right'))
+    await waitFor(() => expect(pickers()).toHaveLength(2))
+
+    fireEvent.click(within(pickers()[0]).getByLabelText('Split down'))
+    await waitFor(() => expect(pickers()).toHaveLength(3))
+  })
+
+  it('focuses the picker cell it is pressed in', async () => {
+    renderGrid('a')
+    await screen.findByTestId('pane-a')
+    fireEvent.click(screen.getByLabelText('focus a'))
+    await waitFor(() => expect(screen.getByTestId('pane-a').getAttribute('data-focused')).toBe('yes'))
+
+    fireEvent.mouseDown(onlyPicker())
+
+    await waitFor(() => expect(screen.getByTestId('pane-a').getAttribute('data-focused')).toBe('no'))
+  })
+})

--- a/website/src/test/SettingsSlackPanelCoverage.test.tsx
+++ b/website/src/test/SettingsSlackPanelCoverage.test.tsx
@@ -1,0 +1,546 @@
+/**
+ * Coverage pass over Settings ▸ Slack (`pages/settings/SlackPanel.tsx`).
+ *
+ * Nothing mounted this panel before: `ChannelsPanel.test.tsx` and
+ * `SettingsPage.test.tsx` only assert that the nav routes to it. So every branch
+ * in the file was unexecuted — the three status pills, the four connection
+ * hints, the manifest card's loaded and failed shapes, the read-only remote
+ * view, the whole `TagListEditor` (add / reject / dedupe / remove), the save
+ * payload's folder and credential folding, and both mutation arms.
+ *
+ * Harness notes:
+ *  - `api` is a plain object literal, so `vi.spyOn` on the three Slack methods
+ *    is enough; the module stays real and nothing else in the tree is stubbed.
+ *  - `renderWithProviders` supplies the QueryClient with `retry: false`, so a
+ *    rejected query or mutation surfaces on the first attempt.
+ *  - Credentials in this file are obvious placeholders. The panel only ever
+ *    forwards them to a mocked writer, and `SecretField` never renders a stored
+ *    secret back, so there is nothing real to put here.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, waitFor, within, act } from '@testing-library/react'
+
+import { renderWithProviders } from './helpers'
+import { api, type SlackConfigData } from '../api/client'
+import { SlackPanel } from '../pages/settings/SlackPanel'
+
+/* ── timers ───────────────────────────────────────────────────────────────── */
+
+// The panel schedules three deferred resets (copied pill 1.5s, saved pill 6s,
+// save error 8s). On the real clock those callbacks fire after vitest tears the
+// environment down and throw "window is not defined" as an UNHANDLED error —
+// every test passing and the run still exiting non-zero. Fake timers keep them
+// off the wall clock and `clearAllTimers` drops the pending ones at teardown;
+// `shouldAdvanceTime` keeps the clock moving so `findBy*` behaves as it does
+// with real timers.
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+})
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+/* ── fixtures ─────────────────────────────────────────────────────────────── */
+
+type SaveResult = Awaited<ReturnType<typeof api.saveSlackConfig>>
+
+const MANIFEST = {
+  alias: 'tester',
+  manifest: 'display_information:\n  name: KiroCrew-tester\n',  // brand-ok: product emits KiroCrew-<alias> (slack-manifest.yaml)
+  create_url: 'https://example.invalid/apps/new',
+}
+
+/** Not-connected, fully configured, nothing stored — the most branch-rich start. */
+function config(over: Partial<SlackConfigData> = {}): SlackConfigData {
+  return {
+    connected: false,
+    connect_error: '',
+    configured: true,
+    read_only: false,
+    bot_token_set: false,
+    app_token_set: false,
+    bot_token_preview: '',
+    app_token_preview: '',
+    owner_id: 'U000OWNER',
+    command: 'kirocrew',
+    allowed_enterprise_ids: ['E000ONE'],
+    reactions_enabled: false,
+    show_thinking: false,
+    ...over,
+  }
+}
+
+const OK: SaveResult = { ok: true, restart_required: false, verify_warning: '' }
+
+interface SeedOpts {
+  /** Fail the manifest query instead of resolving it. */
+  manifestFails?: boolean
+  /** Result of a save, or a rejection to drive the `onError` arm. */
+  save?: SaveResult | { reject: unknown } | { pending: true }
+}
+
+/** Install the three Slack API seams and mount the panel. */
+function seed(cfgOver: Partial<SlackConfigData> = {}, opts: SeedOpts = {}) {
+  vi.spyOn(api, 'getSlackConfig').mockResolvedValue(config(cfgOver))
+
+  const manifest = vi.spyOn(api, 'getSlackManifest')
+  if (opts.manifestFails) manifest.mockRejectedValue(new Error('manifest unavailable'))
+  else manifest.mockResolvedValue(MANIFEST)
+
+  const save = vi.spyOn(api, 'saveSlackConfig')
+  let settle: (v: SaveResult) => void = () => {}
+  const want = opts.save ?? OK
+  if (want && typeof want === 'object' && 'reject' in want) {
+    save.mockRejectedValue(want.reject)
+  } else if (want && typeof want === 'object' && 'pending' in want) {
+    save.mockReturnValue(new Promise<SaveResult>(r => { settle = r }))
+  } else {
+    save.mockResolvedValue(want as SaveResult)
+  }
+
+  const view = renderWithProviders(<SlackPanel />)
+  return { ...view, save, settle }
+}
+
+/** Resolve once the query has hydrated and the form is on screen. */
+async function hydrated() {
+  return await screen.findByRole('heading', { name: 'Slack', level: 3 })
+}
+
+/** The save button, which only exists on a writable session. */
+function saveBtn() {
+  return screen.getByRole('button', { name: 'Save Slack settings' })
+}
+
+/** Install a clipboard whose `writeText` is observable (happy-dom's is getter-only). */
+function stubClipboard(impl: () => Promise<void>) {
+  const writeText = vi.fn(impl)
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+  return writeText
+}
+
+/* ── query states ─────────────────────────────────────────────────────────── */
+
+describe('SlackPanel query states', () => {
+  it('shows the loading line until the config query settles', async () => {
+    vi.spyOn(api, 'getSlackConfig').mockReturnValue(new Promise<SlackConfigData>(() => {}))
+    vi.spyOn(api, 'getSlackManifest').mockResolvedValue(MANIFEST)
+    renderWithProviders(<SlackPanel />)
+    expect(screen.getByText('Loading Slack config…')).toBeInTheDocument()
+  })
+
+  it('shows the gateway hint when the config query fails', async () => {
+    vi.spyOn(api, 'getSlackConfig').mockRejectedValue(new Error('offline'))
+    vi.spyOn(api, 'getSlackManifest').mockResolvedValue(MANIFEST)
+    renderWithProviders(<SlackPanel />)
+    expect(
+      await screen.findByText('Cannot load Slack config. Is the gateway running?', undefined, { timeout: 5_000 }),
+    ).toBeInTheDocument()
+  })
+})
+
+/* ── status pill + connection hint ────────────────────────────────────────── */
+
+describe('SlackPanel connection status', () => {
+  it('reads Connected with no hint when the gateway holds a live socket', async () => {
+    seed({ connected: true })
+    await hydrated()
+    expect(screen.getByText('Connected')).toBeInTheDocument()
+    expect(screen.queryByText(/Restart the gateway to connect/)).not.toBeInTheDocument()
+  })
+
+  it('reads Needs setup when no credentials are configured yet', async () => {
+    seed({ configured: false })
+    await hydrated()
+    expect(screen.getByText('Needs setup')).toBeInTheDocument()
+    expect(screen.queryByText(/not yet active/)).not.toBeInTheDocument()
+  })
+
+  it('explains a saved-but-inactive channel as needing a restart', async () => {
+    seed()
+    await hydrated()
+    expect(screen.getByText('Not connected')).toBeInTheDocument()
+    expect(
+      screen.getByText('Tokens are saved but not yet active. Restart the gateway to connect.'),
+    ).toBeInTheDocument()
+  })
+
+  it('calls out rejected credentials for invalid_auth specifically', async () => {
+    seed({ connect_error: 'invalid_auth' })
+    await hydrated()
+    expect(screen.getByText(/Slack rejected the stored tokens \(invalid_auth\)/)).toBeInTheDocument()
+  })
+
+  it('surfaces any other startup failure with its own error string', async () => {
+    seed({ connect_error: 'dns_failure' })
+    await hydrated()
+    expect(screen.getByText(/Slack connection failed at startup \(dns_failure\)/)).toBeInTheDocument()
+  })
+})
+
+/* ── manifest card ────────────────────────────────────────────────────────── */
+
+describe('SlackPanel manifest card', () => {
+  it('links the one-click create URL and copies the YAML, reverting the pill after 1.5s', async () => {
+    const writeText = stubClipboard(() => Promise.resolve())
+    seed()
+    await hydrated()
+
+    expect(screen.getByRole('link', { name: 'Create Slack app' })).toHaveAttribute('href', MANIFEST.create_url)
+    expect(screen.getByText(/named KiroCrew-tester/)).toBeInTheDocument()  // brand-ok: product emits KiroCrew-<alias> (slack-manifest.yaml)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy manifest YAML' }))
+    expect(writeText).toHaveBeenCalledWith(MANIFEST.manifest)
+    expect(await screen.findByText('Copied', undefined, { timeout: 5_000 })).toBeInTheDocument()
+
+    await act(async () => { vi.advanceTimersByTime(1_600) })
+    expect(screen.getByRole('button', { name: 'Copy manifest YAML' })).toBeInTheDocument()
+  })
+
+  it('keeps the pill unchanged when the clipboard write is refused', async () => {
+    stubClipboard(() => Promise.reject(new Error('clipboard denied')))
+    seed()
+    await hydrated()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy manifest YAML' }))
+    await act(async () => { vi.advanceTimersByTime(50) })
+    expect(screen.getByRole('button', { name: 'Copy manifest YAML' })).toBeInTheDocument()
+    expect(screen.queryByText('Copied')).not.toBeInTheDocument()
+  })
+
+  it('inertly disables create + copy while the manifest is unavailable', async () => {
+    const writeText = stubClipboard(() => Promise.resolve())
+    seed({}, { manifestFails: true })
+    await hydrated()
+
+    const create = screen.getByRole('link', { name: 'Create Slack app' })
+    expect(create).toHaveAttribute('href', '#')
+    expect(create).toHaveAttribute('aria-disabled', 'true')
+
+    const copy = screen.getByRole('button', { name: 'Copy manifest YAML' })
+    expect(copy).toBeDisabled()
+    expect(screen.getByText(/named KiroCrew-you/)).toBeInTheDocument()  // brand-ok: product emits KiroCrew-<alias> (slack-manifest.yaml)
+
+    fireEvent.click(copy)
+    expect(writeText).not.toHaveBeenCalled()
+  })
+})
+
+/* ── read-only remote session ─────────────────────────────────────────────── */
+
+describe('SlackPanel read-only session', () => {
+  it('drops every writer and shows stored previews only', async () => {
+    seed({
+      read_only: true,
+      bot_token_set: true,
+      bot_token_preview: 'xoxb-••••aaaa',
+      allowed_enterprise_ids: [],
+    })
+    await hydrated()
+
+    expect(
+      screen.getByText(
+        'Slack settings are managed on the machine running Kiro Crew and are read-only from remote sessions.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save Slack settings' })).not.toBeInTheDocument()
+    expect(screen.getByText('xoxb-••••aaaa')).toBeInTheDocument()
+    // The app-level credential is unset, so its read-only row says so.
+    expect(screen.getByText('(not set)')).toBeInTheDocument()
+    // An empty allowlist under read-only renders the placeholder, not an editor.
+    expect(screen.getByText('(none)')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Add' })).not.toBeInTheDocument()
+  })
+
+  it('hides the per-tag remove button while read-only', async () => {
+    seed({ read_only: true, allowed_enterprise_ids: ['E000ONE'] })
+    await hydrated()
+    expect(screen.getByText('E000ONE')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Remove E000ONE' })).not.toBeInTheDocument()
+  })
+})
+
+/* ── TagListEditor ────────────────────────────────────────────────────────── */
+
+describe('SlackPanel enterprise allowlist editor', () => {
+  /** The allowlist's own text input, keyed off its placeholder. */
+  function tagInput() {
+    return screen.getByPlaceholderText('E0123ABC456')
+  }
+
+  it('adds an org on click and keeps Add disabled while the draft is blank', async () => {
+    seed()
+    await hydrated()
+
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled()
+    fireEvent.change(tagInput(), { target: { value: ' T000TWO ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(screen.getByText('T000TWO')).toBeInTheDocument()
+    expect(tagInput()).toHaveValue('')
+  })
+
+  it('adds on Enter and rejects an ID that fails the E/T shape', async () => {
+    seed()
+    await hydrated()
+
+    fireEvent.change(tagInput(), { target: { value: 'lower' } })
+    fireEvent.keyDown(tagInput(), { key: 'Enter' })
+    expect(await screen.findByRole('alert', undefined, { timeout: 5_000 })).toHaveTextContent(
+      'is not a valid ID',
+    )
+    expect(screen.queryByText('lower')).not.toBeInTheDocument()
+
+    // A valid one clears the notice and lands as a tag.
+    fireEvent.change(tagInput(), { target: { value: 'E000TWO' } })
+    fireEvent.keyDown(tagInput(), { key: 'Enter' })
+    expect(screen.getByText('E000TWO')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('ignores a blank submit and de-dupes an org already on the list', async () => {
+    seed()
+    await hydrated()
+
+    fireEvent.keyDown(tagInput(), { key: 'Enter' })
+    fireEvent.keyDown(tagInput(), { key: 'a' })
+    expect(screen.getAllByText(/^E000ONE$/)).toHaveLength(1)
+
+    fireEvent.change(tagInput(), { target: { value: 'E000ONE' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(screen.getAllByText(/^E000ONE$/)).toHaveLength(1)
+    expect(tagInput()).toHaveValue('')
+  })
+
+  it('removes a tag and sends the shortened list on save', async () => {
+    const { save } = seed({ allowed_enterprise_ids: ['E000ONE', 'T000TWO'] })
+    await hydrated()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove E000ONE' }))
+    expect(screen.queryByText('E000ONE')).not.toBeInTheDocument()
+
+    fireEvent.click(saveBtn())
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0]).toMatchObject({ allowed_enterprise_ids: ['T000TWO'] })
+  })
+})
+
+/* ── save payload ─────────────────────────────────────────────────────────── */
+
+describe('SlackPanel save payload', () => {
+  it('trims the identity fields, forwards both toggles, and reports success', async () => {
+    const { save } = seed()
+    await hydrated()
+
+    fireEvent.change(screen.getByPlaceholderText('U0123ABC456'), { target: { value: '  U000NEW  ' } })
+    fireEvent.change(screen.getByPlaceholderText('kirocrew'), { target: { value: ' crew ' } })
+    fireEvent.click(screen.getByRole('switch', { name: 'Phase reactions' }))
+    fireEvent.click(screen.getByRole('switch', { name: 'Show thinking' }))
+    fireEvent.click(saveBtn())
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0]).toEqual({
+      owner_id: 'U000NEW',
+      command: 'crew',
+      allowed_enterprise_ids: ['E000ONE'],
+      reactions_enabled: true,
+      show_thinking: true,
+      session_folder: '',
+    })
+    expect(await screen.findByText('Saved.', undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('falls back to the channel name when the folder is on but unnamed', async () => {
+    const { save } = seed()
+    await hydrated()
+
+    fireEvent.click(screen.getByRole('switch', { name: 'File sessions in a folder' }))
+    expect(screen.getByPlaceholderText('Slack')).toHaveValue('')
+    fireEvent.click(saveBtn())
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0]).toMatchObject({ session_folder: 'Slack' })
+  })
+
+  it('derives the folder toggle from a stored name and saves an edited one', async () => {
+    const { save } = seed({ session_folder: 'Inbox' })
+    await hydrated()
+
+    expect(screen.getByRole('switch', { name: 'File sessions in a folder' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+    fireEvent.change(screen.getByPlaceholderText('Slack'), { target: { value: ' Team Inbox ' } })
+    fireEvent.click(saveBtn())
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0]).toMatchObject({ session_folder: 'Team Inbox' })
+  })
+
+  it('keeps the folder name out of the payload once the toggle is switched off', async () => {
+    const { save } = seed({ session_folder: 'Inbox' })
+    await hydrated()
+
+    fireEvent.click(screen.getByRole('switch', { name: 'File sessions in a folder' }))
+    expect(screen.queryByPlaceholderText('Slack')).not.toBeInTheDocument()
+    fireEvent.click(saveBtn())
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0]).toMatchObject({ session_folder: '' })
+  })
+
+  it('sends pasted credentials and confirms they were verified with Slack', async () => {
+    const { save } = seed({}, { save: { ok: true, restart_required: true, verify_warning: '' } })
+    await hydrated()
+
+    fireEvent.change(screen.getByLabelText('Slack bot token'), { target: { value: ' xoxb-not-a-real-value ' } })
+    fireEvent.change(screen.getByLabelText('Slack app token'), { target: { value: 'xapp-not-a-real-value' } })
+    fireEvent.click(saveBtn())
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0]).toMatchObject({
+      bot_token: 'xoxb-not-a-real-value',
+      app_token: 'xapp-not-a-real-value',
+    })
+    expect(
+      await screen.findByText('Verified with Slack and saved. Restart the gateway to connect.', undefined, {
+        timeout: 5_000,
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it('reports a restart-only save when nothing was verified', async () => {
+    seed({}, { save: { ok: true, restart_required: true, verify_warning: '' } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    expect(
+      await screen.findByText('Saved. Restart the gateway to apply.', undefined, { timeout: 5_000 }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the verify warning alongside the saved pill and withholds the verified claim', async () => {
+    seed(
+      {},
+      { save: { ok: true, restart_required: false, verify_warning: 'App-level credential not checked.' } },
+    )
+    await hydrated()
+
+    fireEvent.change(screen.getByLabelText('Slack bot token'), { target: { value: 'xoxb-not-a-real-value' } })
+    fireEvent.click(saveBtn())
+
+    expect(
+      await screen.findByText('App-level credential not checked.', undefined, { timeout: 5_000 }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Saved.')).toBeInTheDocument()
+  })
+
+  it('folds Remove into clear flags rather than empty credential strings', async () => {
+    const { save } = seed({
+      bot_token_set: true,
+      app_token_set: true,
+      bot_token_preview: 'xoxb-••••aaaa',
+      app_token_preview: 'xapp-••••bbbb',
+    })
+    await hydrated()
+
+    // Two stored credentials, so two identically-labelled Remove buttons: bot
+    // first in DOM order, app second.
+    const removes = screen.getAllByRole('button', { name: 'Remove' })
+    expect(removes).toHaveLength(2)
+    fireEvent.click(removes[0])
+    fireEvent.click(removes[1])
+    expect(screen.getAllByText('Will be removed on save.')).toHaveLength(2)
+
+    fireEvent.click(saveBtn())
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    const payload = save.mock.calls[0][0]
+    expect(payload).toMatchObject({ bot_token_clear: true, app_token_clear: true })
+    expect(payload.bot_token).toBeUndefined()
+    expect(payload.app_token).toBeUndefined()
+  })
+
+  it('replaces a stored credential in place, keeping the clear flag off', async () => {
+    const { save } = seed({ bot_token_set: true, bot_token_preview: 'xoxb-••••aaaa' })
+    await hydrated()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Replace' }))
+    fireEvent.change(screen.getByLabelText('Slack bot token'), { target: { value: 'xoxb-replacement' } })
+    fireEvent.click(saveBtn())
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    const payload = save.mock.calls[0][0]
+    expect(payload).toMatchObject({ bot_token: 'xoxb-replacement' })
+    expect(payload.bot_token_clear).toBeUndefined()
+  })
+
+  it('disables the button and reads Saving… while the write is in flight', async () => {
+    const { settle } = seed({}, { save: { pending: true } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    const pendingBtn = await screen.findByRole('button', { name: 'Saving…' }, { timeout: 5_000 })
+    expect(pendingBtn).toBeDisabled()
+
+    await act(async () => { settle(OK) })
+    expect(await screen.findByText('Saved.', undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+})
+
+/* ── save failure ─────────────────────────────────────────────────────────── */
+
+describe('SlackPanel save failure', () => {
+  it('unwraps the server error field out of a JSON response body', async () => {
+    seed({}, { save: { reject: new Error(JSON.stringify({ error: 'bot credential rejected by Slack' })) } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    expect(await screen.findByRole('alert', undefined, { timeout: 5_000 })).toHaveTextContent(
+      'bot credential rejected by Slack',
+    )
+  })
+
+  it('keeps the raw body when the JSON response carries no error field', async () => {
+    const body = JSON.stringify({ detail: 'no error key here' })
+    seed({}, { save: { reject: new Error(body) } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    expect(await screen.findByRole('alert', undefined, { timeout: 5_000 })).toHaveTextContent(body)
+  })
+
+  it('shows a non-JSON error message verbatim', async () => {
+    seed({}, { save: { reject: new Error('502 Bad Gateway') } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    expect(await screen.findByRole('alert', undefined, { timeout: 5_000 })).toHaveTextContent('502 Bad Gateway')
+  })
+
+  it('falls back to the gateway hint when the rejection is not an Error', async () => {
+    seed({}, { save: { reject: 'connection reset' } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    expect(await screen.findByRole('alert', undefined, { timeout: 5_000 })).toHaveTextContent(
+      'Save failed. Is the gateway running?',
+    )
+  })
+
+  it('clears a previous error when the next save is attempted', async () => {
+    seed({}, { save: { reject: new Error('502 Bad Gateway') } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    const alert = await screen.findByRole('alert', undefined, { timeout: 5_000 })
+    expect(alert).toHaveTextContent('502 Bad Gateway')
+
+    // handleSave clears the banner before dispatching, so the row is briefly clean.
+    vi.mocked(api.saveSlackConfig).mockReturnValue(new Promise<SaveResult>(() => {}))
+    fireEvent.click(saveBtn())
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument())
+    expect(within(screen.getByRole('button', { name: 'Saving…' })).queryByRole('alert')).toBeNull()
+  })
+})

--- a/website/src/test/WorkspacePickerCoverage.test.tsx
+++ b/website/src/test/WorkspacePickerCoverage.test.tsx
@@ -1,0 +1,411 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, act, waitFor } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { renderWithProviders } from './helpers'
+import WorkspacePicker from '../components/WorkspacePicker'
+import { api } from '../api/client'
+
+type BrowseDirsResult = Awaited<ReturnType<typeof api.browseDirs>>
+type PickerProps = ComponentProps<typeof WorkspacePicker>
+
+const DIRS = [
+  { name: 'alpha', path: '/home/u/alpha' },
+  { name: 'beta', path: '/home/u/beta' },
+]
+
+const browseResult = (
+  path = '/home/u',
+  parent = '/home',
+  dirs: { name: string; path: string }[] = DIRS,
+): BrowseDirsResult => ({ path, parent, dirs })
+
+/** happy-dom does not expose a DOMRect constructor; build the shape by hand. */
+const rect = (top: number, left: number, width = 80, height = 24): DOMRect => ({
+  top, left, width, height,
+  bottom: top + height,
+  right: left + width,
+  x: left, y: top,
+  toJSON: () => ({}),
+} as DOMRect)
+
+/**
+ * The picker bails out unless `anchorRef.current` is a live element, and its
+ * click-outside guard calls `anchor.contains(target)`. A detached node would
+ * make every outside-click assertion vacuous, so the anchor is a real button
+ * mounted in the document for the duration of each test.
+ */
+let anchor: HTMLButtonElement
+let anchorRef: { current: HTMLElement | null }
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  anchor = document.createElement('button')
+  anchor.textContent = 'anchor'
+  anchor.setAttribute('data-testid', 'anchor-btn')
+  document.body.appendChild(anchor)
+  anchorRef = { current: anchor }
+  Object.defineProperty(window, 'innerHeight', { value: 768, configurable: true })
+  vi.spyOn(api, 'browseDirs').mockResolvedValue(browseResult())
+  vi.spyOn(api, 'createWorkspace').mockResolvedValue({ ok: true })
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  anchor.remove()
+  vi.restoreAllMocks()
+})
+
+function renderPicker(overrides: Partial<PickerProps> = {}) {
+  const onOpenChange = vi.fn()
+  const onCreated = vi.fn()
+  const utils = renderWithProviders(
+    <WorkspacePicker
+      open={true}
+      onOpenChange={onOpenChange}
+      anchorRef={anchorRef}
+      onCreated={onCreated}
+      {...overrides}
+    />,
+  )
+  return { onOpenChange, onCreated, ...utils }
+}
+
+/** Wait for the initial browse() response to land. */
+const pathInput = () => screen.findByLabelText('Project directory path')
+const nameInput = () => screen.findByLabelText('Workspace name')
+
+/** Let the deferred click-outside listener attach (component uses setTimeout 0). */
+async function attachOutsideListener() {
+  await act(async () => { await vi.advanceTimersByTimeAsync(1) })
+}
+
+/** Render, then drive the browse view into the create view for `dir`. */
+async function enterCreateView(dir = '/home/u/alpha') {
+  const handles = renderPicker()
+  const input = await pathInput()
+  fireEvent.change(input, { target: { value: dir } })
+  fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+  await nameInput()
+  return handles
+}
+
+describe('WorkspacePicker', () => {
+  describe('visibility', () => {
+    it('renders nothing when closed', async () => {
+      renderPicker({ open: false })
+      await act(async () => { await vi.advanceTimersByTimeAsync(1) })
+      expect(screen.queryByRole('button', { name: 'Select' })).not.toBeInTheDocument()
+      expect(api.browseDirs).not.toHaveBeenCalled()
+    })
+
+    it('renders nothing when the anchor element is not mounted yet', async () => {
+      renderPicker({ anchorRef: { current: null } })
+      await waitFor(() => expect(api.browseDirs).toHaveBeenCalled())
+      expect(screen.queryByRole('button', { name: 'Select' })).not.toBeInTheDocument()
+    })
+
+    it('renders the browse view when open with a live anchor', async () => {
+      renderPicker()
+      expect(await pathInput()).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument()
+    })
+  })
+
+  describe('directory browsing', () => {
+    it('loads the default directory and seeds the path input with it', async () => {
+      renderPicker()
+      expect(await pathInput()).toHaveValue('/home/u')
+      expect(api.browseDirs).toHaveBeenCalledWith(undefined)
+    })
+
+    it('lists the returned subdirectories', async () => {
+      renderPicker()
+      expect(await screen.findByText('alpha')).toBeInTheDocument()
+      expect(screen.getByText('beta')).toBeInTheDocument()
+      expect(screen.queryByText('No subdirectories')).not.toBeInTheDocument()
+    })
+
+    it('descends into a subdirectory when its row is clicked', async () => {
+      renderPicker()
+      const row = (await screen.findByText('beta')).closest('button') as HTMLElement
+      vi.mocked(api.browseDirs).mockResolvedValue(
+        browseResult('/home/u/beta', '/home/u', [{ name: 'nested', path: '/home/u/beta/nested' }]),
+      )
+      fireEvent.click(row)
+      expect(await screen.findByText('nested')).toBeInTheDocument()
+      expect(api.browseDirs).toHaveBeenLastCalledWith('/home/u/beta')
+    })
+
+    it('offers a parent button that browses upward', async () => {
+      renderPicker()
+      const up = await screen.findByLabelText('Back')
+      vi.mocked(api.browseDirs).mockResolvedValue(
+        browseResult('/home', '/', [{ name: 'u', path: '/home/u' }]),
+      )
+      fireEvent.click(up)
+      await waitFor(() => expect(api.browseDirs).toHaveBeenLastCalledWith('/home'))
+    })
+
+    it('hides the parent button at the filesystem root', async () => {
+      vi.mocked(api.browseDirs).mockResolvedValue(browseResult('/', '/', []))
+      renderPicker()
+      await waitFor(() => expect(screen.getByLabelText('Project directory path')).toHaveValue('/'))
+      expect(screen.queryByLabelText('Back')).not.toBeInTheDocument()
+    })
+
+    it('shows the empty state when a directory has no children', async () => {
+      vi.mocked(api.browseDirs).mockResolvedValue(browseResult('/home/u', '/home', []))
+      renderPicker()
+      expect(await screen.findByText('No subdirectories')).toBeInTheDocument()
+    })
+
+    it('swallows a browse failure and stays usable', async () => {
+      vi.mocked(api.browseDirs).mockRejectedValue(new Error('nope'))
+      renderPicker()
+      expect(await screen.findByText('No subdirectories')).toBeInTheDocument()
+      expect(screen.getByLabelText('Project directory path')).toHaveValue('')
+    })
+  })
+
+  describe('typed filtering', () => {
+    it('narrows the list to entries matching the typed segment', async () => {
+      renderPicker()
+      const input = await pathInput()
+      fireEvent.change(input, { target: { value: '/home/u/al' } })
+      expect(screen.getByText('alpha')).toBeInTheDocument()
+      expect(screen.queryByText('beta')).not.toBeInTheDocument()
+    })
+
+    it('falls back to the empty state when nothing matches', async () => {
+      renderPicker()
+      const input = await pathInput()
+      fireEvent.change(input, { target: { value: 'zzz' } })
+      expect(screen.getByText('No subdirectories')).toBeInTheDocument()
+    })
+
+    it('keeps the full list when the input still equals the browsed path', async () => {
+      renderPicker()
+      const input = await pathInput()
+      fireEvent.change(input, { target: { value: '/HOME/U' } })
+      expect(screen.getByText('alpha')).toBeInTheDocument()
+      expect(screen.getByText('beta')).toBeInTheDocument()
+    })
+  })
+
+  describe('positioning', () => {
+    it('anchors below the trigger and clamps the left edge to the viewport', async () => {
+      anchor.getBoundingClientRect = () => rect(100, 200)
+      renderPicker()
+      const drop = (await pathInput()).closest('div.fixed') as HTMLElement
+      expect(drop.style.top).toBe('128px')
+      expect(drop.style.left).toBe('8px')
+      expect(drop.style.maxHeight).toBe('636px')
+    })
+
+    it('keeps the right-aligned offset when there is room', async () => {
+      anchor.getBoundingClientRect = () => rect(40, 900)
+      renderPicker()
+      const drop = (await pathInput()).closest('div.fixed') as HTMLElement
+      expect(drop.style.left).toBe('580px')
+    })
+
+    it('floors the max height at 200px in a short viewport', async () => {
+      Object.defineProperty(window, 'innerHeight', { value: 300, configurable: true })
+      anchor.getBoundingClientRect = () => rect(100, 200)
+      renderPicker()
+      const drop = (await pathInput()).closest('div.fixed') as HTMLElement
+      expect(drop.style.maxHeight).toBe('200px')
+    })
+  })
+
+  describe('selecting a directory', () => {
+    it('derives the workspace name from the last path segment', async () => {
+      await enterCreateView('/home/u/alpha')
+      expect(await nameInput()).toHaveValue('alpha')
+      expect(screen.getByText('Create Workspace')).toBeInTheDocument()
+      expect(screen.getByText('/home/u/alpha')).toBeInTheDocument()
+    })
+
+    it('ignores trailing slashes when deriving the name', async () => {
+      await enterCreateView('/home/u/alpha//')
+      expect(await nameInput()).toHaveValue('alpha')
+    })
+
+    it('falls back to the browsed path when the input is empty', async () => {
+      renderPicker()
+      const input = await pathInput()
+      fireEvent.change(input, { target: { value: '   ' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+      expect(await nameInput()).toHaveValue('u')
+      expect(screen.getByText('/home/u')).toBeInTheDocument()
+    })
+
+    it('selects on Enter in the path input', async () => {
+      renderPicker()
+      const input = await pathInput()
+      fireEvent.change(input, { target: { value: '  /home/u/beta  ' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+      expect(await nameInput()).toHaveValue('beta')
+    })
+
+    it('ignores Enter on a blank path input', async () => {
+      renderPicker()
+      const input = await pathInput()
+      fireEvent.change(input, { target: { value: '  ' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+      expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument()
+      expect(screen.queryByLabelText('Workspace name')).not.toBeInTheDocument()
+    })
+
+    it('closes on Escape in the path input', async () => {
+      const { onOpenChange } = renderPicker()
+      const input = await pathInput()
+      fireEvent.keyDown(input, { key: 'Escape' })
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('creating a workspace', () => {
+    it('refuses an empty name without calling the API', async () => {
+      await enterCreateView()
+      fireEvent.change(await nameInput(), { target: { value: '   ' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+      expect(await screen.findByText('Name required')).toBeInTheDocument()
+      expect(api.createWorkspace).not.toHaveBeenCalled()
+    })
+
+    it('clears a visible error as soon as the name is edited', async () => {
+      await enterCreateView()
+      fireEvent.change(await nameInput(), { target: { value: '' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+      expect(await screen.findByText('Name required')).toBeInTheDocument()
+      fireEvent.change(await nameInput(), { target: { value: 'ok' } })
+      expect(screen.queryByText('Name required')).not.toBeInTheDocument()
+    })
+
+    it('slugifies the name and reports the created workspace', async () => {
+      const { onCreated, onOpenChange } = renderPicker()
+      const input = await pathInput()
+      fireEvent.change(input, { target: { value: '/home/u/alpha' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+      fireEvent.change(await nameInput(), { target: { value: ' My Proj!ect ' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+      await waitFor(() => expect(onCreated).toHaveBeenCalledWith('my-proj-ect'))
+      expect(api.createWorkspace).toHaveBeenCalledWith({ name: 'my-proj-ect', dir: '/home/u/alpha' })
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    it('disables the button and shows progress while the request is in flight', async () => {
+      let settle: ((value: { ok: boolean }) => void) | undefined
+      vi.mocked(api.createWorkspace).mockReturnValue(
+        new Promise(resolve => { settle = resolve }),
+      )
+      const { onCreated } = renderPicker()
+      const input = await pathInput()
+      fireEvent.change(input, { target: { value: '/home/u/alpha' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+      const busy = await screen.findByRole('button', { name: 'Creating…' })
+      expect(busy).toBeDisabled()
+      await act(async () => { settle?.({ ok: true }) })
+      await waitFor(() => expect(onCreated).toHaveBeenCalledWith('alpha'))
+    })
+
+    it('surfaces a server-reported error and re-enables the button', async () => {
+      vi.mocked(api.createWorkspace).mockResolvedValue({ error: 'name already taken' })
+      const { onCreated, onOpenChange } = renderPicker()
+      const input = await pathInput()
+      fireEvent.change(input, { target: { value: '/home/u/alpha' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+      expect(await screen.findByText('name already taken', undefined, { timeout: 5_000 })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Create' })).not.toBeDisabled()
+      expect(onCreated).not.toHaveBeenCalled()
+      expect(onOpenChange).not.toHaveBeenCalled()
+    })
+
+    it('surfaces a thrown request failure', async () => {
+      vi.mocked(api.createWorkspace).mockRejectedValue(new Error('offline'))
+      renderPicker()
+      const input = await pathInput()
+      fireEvent.change(input, { target: { value: '/home/u/alpha' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+      expect(
+        await screen.findByText('Failed to create workspace', undefined, { timeout: 5_000 }),
+      ).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Create' })).not.toBeDisabled()
+    })
+
+    it('creates on Enter in the name input', async () => {
+      const { onCreated } = renderPicker()
+      const input = await pathInput()
+      fireEvent.change(input, { target: { value: '/home/u/beta' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+      fireEvent.keyDown(await nameInput(), { key: 'Enter' })
+      await waitFor(() => expect(onCreated).toHaveBeenCalledWith('beta'))
+    })
+
+    it('returns to the browse view on Escape in the name input', async () => {
+      await enterCreateView()
+      fireEvent.keyDown(await nameInput(), { key: 'Escape' })
+      expect(await pathInput()).toBeInTheDocument()
+      expect(screen.queryByText('Create Workspace')).not.toBeInTheDocument()
+    })
+
+    it('returns to the browse view via the Back button', async () => {
+      await enterCreateView()
+      fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+      expect(await pathInput()).toBeInTheDocument()
+      expect(screen.queryByLabelText('Workspace name')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('click-outside dismissal', () => {
+    it('closes on a mousedown outside the dropdown and the anchor', async () => {
+      const { onOpenChange } = renderPicker()
+      await pathInput()
+      await attachOutsideListener()
+      const outside = document.createElement('div')
+      document.body.appendChild(outside)
+      fireEvent.mouseDown(outside)
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+      outside.remove()
+    })
+
+    it('stays open for a mousedown inside the dropdown', async () => {
+      const { onOpenChange } = renderPicker()
+      const input = await pathInput()
+      await attachOutsideListener()
+      fireEvent.mouseDown(input)
+      expect(onOpenChange).not.toHaveBeenCalled()
+    })
+
+    it('stays open for a mousedown on the anchor itself', async () => {
+      const { onOpenChange } = renderPicker()
+      await pathInput()
+      await attachOutsideListener()
+      fireEvent.mouseDown(anchor)
+      expect(onOpenChange).not.toHaveBeenCalled()
+    })
+
+    it('detaches the listener on unmount', async () => {
+      const { onOpenChange, unmount } = renderPicker()
+      await pathInput()
+      await attachOutsideListener()
+      unmount()
+      fireEvent.mouseDown(document.body)
+      expect(onOpenChange).not.toHaveBeenCalled()
+    })
+
+    it('cancels the pending listener timer when unmounted before it fires', async () => {
+      const { onOpenChange, unmount } = renderPicker()
+      await pathInput()
+      unmount()
+      await act(async () => { await vi.advanceTimersByTimeAsync(1) })
+      fireEvent.mouseDown(document.body)
+      expect(onOpenChange).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## What

Twelve new frontend test files, raising the frontend lane from **83.38% to at least 84.46%**. First frontend wave of the push toward 90%.

```
before   52,499 / 62,962   83.38%   (main)
after    53,178 / 62,962   84.46%   (+679 statements, lower bound)
```

Targets were chosen by **uncovered-statement mass**. Eight were at 0% coverage:

| Target | Was |
|---|---|
| `pages/knowledge/DetailView.tsx` | 0% |
| `components/SessionGridView.tsx` | 0% |
| `apps/crew-companion/panel.tsx` | 0% |
| `apps/meetings/SettingsView.tsx` | 0% |
| `pages/overview/PromptsTab.tsx` | 0% |
| `apps/ops-mission-control/SignalsPanel.tsx` | 0% |
| `apps/mochi/src/renderer/ChatApp.tsx` | 0% |
| `components/WorkspacePicker.tsx` | 0% |
| `pages/settings/SlackPanel.tsx` | 15% |
| `apps/crew-companion/PanelViews.tsx` | 5% |
| `components/ArtifactPanel.tsx` | 3% |
| `apps/crew-companion/ColorCustomizerPanel.tsx` | 5% |

## Why the number is a lower bound

`MdNotebookPageCoverage.test.tsx` — a **pre-existing** file, not in this diff — fails intermittently under the full concurrent run. Vitest emits **no coverage report at all** when a run exits non-zero, so the measuring run excludes that file. Since main's baseline still counts its coverage while this run does not, the true gain is larger than the +679 quoted. Both the rate and the delta are conservative.

That flake will intermittently redden this PR too. It is main's problem, not this diff's, and should not be "fixed" here.

## Verification

- 348 tests, all passing, re-verified after rebasing onto current main
- `tsc --noEmit`: exit 0
- `eslint src/ --max-warnings 1116` (CI's own threshold): exit 0
- `jscpd .`: 0 clones
- **Zero unhandled errors** — the failure shape where every test passes and the job still exits non-zero, which also suppresses the coverage report
- Exit codes checked explicitly rather than read off piped output
- No product code touched — tests only

Each spec carried the traps this repo has hit before: the auto-dismiss-timer callback that fires after teardown and throws `window is not defined` as an unhandled error, Redux Toolkit `preloadedState` replacing a slice instead of merging, asserting on text that appears twice in the DOM, and `new Image()`/canvas decode never settling under jsdom.

## Remaining to 90%

+3,488 statements on this lane.
