### PR TITLE
ci(fork-guard): split the two causes of an unresolved PR head

### DIFF
--- a/.github/workflows/fork-workflow-guard.yml
+++ b/.github/workflows/fork-workflow-guard.yml
@@ -70,9 +70,28 @@ jobs:
 
           # Resolve the PR by matching the open PR whose head SHA == head_sha
           # (workflow_run.pull_requests is empty for forks).
-          pr="$(gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
-            --jq "[.[] | select(.head.sha == \"$head_sha\")][0].number // empty" 2>/dev/null || true)"
-          if [ -z "$pr" ]; then echo "::error::could not resolve an open PR for $head_sha"; exit 1; fi
+          # An empty result here has TWO causes that need OPPOSITE handling, and
+          # collapsing them is what made this abort unfalsifiable: the same
+          # message and the same exit 1 were emitted whether the query failed or
+          # whether it succeeded and found nothing.
+          #   * query FAILED (5xx, rate limit, network) -> we know nothing about
+          #     this PR. Stay red and loud: skipping here would let a fork PR
+          #     that really does touch .github/** proceed with no verdict.
+          #   * query SUCCEEDED, no OPEN PR has this head -> the push was
+          #     superseded, or its PR closed, while CI was queued. There is
+          #     nothing to evaluate, and this abort is upstream of both
+          #     check-run POSTs, so nothing was published and no verdict is
+          #     withheld. Report it and exit 0.
+          # stderr is no longer discarded, so a failing query now says why.
+          if ! pr="$(gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
+            --jq "[.[] | select(.head.sha == \"$head_sha\")][0].number // empty")"; then
+            echo "::error::could not query open PRs while resolving $head_sha - the query itself failed; see the error above"
+            exit 1
+          fi
+          if [ -z "$pr" ]; then
+            echo "::notice::no open PR has head $head_sha - superseded or closed while CI was queued; nothing to evaluate"
+            exit 0
+          fi
 
           # AUTHORITATIVE, COMPLETE changed-file list from the paginated PR-files
           # endpoint. NOT the compare API — its `.files` caps at 300, which would


### PR DESCRIPTION
🤖 Filed by **perpetual agent `flake-warden`** — an unsupervised agent on an hourly schedule. No human reviewed this before it was posted. Evidence is cited inline; anything marked suspected is not proven.

## What this changes

Three lines in `fork-workflow-guard.yml`'s resolver. The step looked up the open PR whose head matches the triggering SHA with `2>/dev/null || true`, then branched on an empty variable — so **a failed query and a query that succeeded and matched nothing produced a byte-identical message and the same `exit 1`.** They now get opposite handling:

| Outcome | Before | After |
|---|---|---|
| Query failed (5xx, rate limit, network) | `exit 1`, cause unknown, stderr discarded | `exit 1`, stderr visible, message says the query failed |
| Query succeeded, no open PR has this head | `exit 1`, same message | `exit 0` with a `::notice::` |

No check-run behaviour changes on any path, and the resolved-PR path is untouched.

## Why exiting 0 there withholds no verdict

The abort is **upstream of both check-run POSTs** in this step — the fail-closed POST and the verdict POST. On the old path nothing was ever published: the run just went red on the default branch without telling anyone anything about any PR. Verified empirically over 6 stale SHAs earlier (#2762): the only guard check-run on each was a `skipped` one posted by the `pull_request_target` route, completed *before* the failure.

## The correction this carries, and why it is not a bare `exit 1` → `exit 0`

A flat flip would have been wrong, and I have a fresh datapoint proving it rather than a theory.

Guard runs, last 100 (window 2026-08-12T02:11:57Z → 03:42:56Z): 70 skipped, 27 success, **3 failure**, all `att 1`, all firing this abort:

- run `31557149967` att 1 — SHA `f2d1d24a9`
- run `31558263482` att 1 — SHA `976f9f744`
- run `31556173411` att 1 — SHA `69c7cbad0`

**`f2d1d24a9` was not stale.** It is the head of **open fork PR #2937** (`leonlaiyc/KiroCrew`), single commit, no force-push in its timeline, created 02:11:49Z — *before* the guard ran at 02:31:39Z — and still its head now. The commit carries **zero** guard check-runs. So the guard silently produced no verdict for a live fork PR, and under a flat `exit 0` that silence would also have been green. #2937 touches no CI files, so nothing was missed here; the mechanism is what matters.

That is 1 of 3 failures in a 90-minute window that the authorised one-liner would have converted into a silent skip.

## Honest limits

- **I cannot attribute the other two SHAs.** They are not the head of any currently-open PR, but they could have been open at the time and closed since.
- **A method correction that weakens my own #2762:** `commits/<sha>/pulls` returns `[]` for a *fork* head SHA whether it is stale or not — `f2d1d24a9` returns `[]` too. Some of #2762's staleness evidence rests on that emptiness and is therefore weaker than filed. The reliable test is matching `pulls?state=open` head SHAs across **all** pages; this repo currently has more than one page of open PRs. I will correct #2762 separately.
- **I could not reproduce a real API failure in CI**, only stub it. The split is verified locally, not observed live.
- **Historical per-cause counts are unrecoverable** — the identical message is the whole defect. This change is what makes the split measurable from here on.

## Verification

`yaml.safe_load` parses; the extracted step body passes `bash -n`. The resolver prologue was then run under three stubbed outcomes, old vs new:

```
OLD(main)   query_failed    exit=1  ::error::could not resolve an open PR for f2d1d24a9...
OLD(main)   query_ok_empty  exit=1  ::error::could not resolve an open PR for f2d1d24a9...   <- identical
OLD(main)   query_ok_match  exit=0  RESOLVED_PR=[2937]
NEW(patch)  query_failed    exit=1  ::error::could not query open PRs while resolving ...
NEW(patch)  query_ok_empty  exit=0  ::notice::no open PR has head f2d1d24a9 - superseded ...
NEW(patch)  query_ok_match  exit=0  RESOLVED_PR=[2937]
```

No workflow was re-run to produce any of this.

## If you disagree

"A security workflow should fail loudly rather than log quietly" is a legitimate position and it is your call, not mine. The part I would ask you to keep either way is the cause split: whatever the stale branch does, a swallowed query failure should not look like an answer.

Refs #2878 (this file's header overclaims a required blocking check), #2762 (the failure class).
