### PR TITLE
docs(chat-sdk): name the grouped-role exception the registry cannot serve

### DIFF
--- a/docs/app-kit/api-reference.md
+++ b/docs/app-kit/api-reference.md
@@ -168,6 +168,14 @@ const renderers = [{
 <ChatMessageList messages={messages} running={running} renderers={renderers} />
 ```
 
+### Limitation: two roles are grouped before your entry is consulted
+
+`thinking` and `permission` (exported as `GROUPED_ROLES`, a frozen array) are assembled into one
+collapsible "worked through N steps" group **before** rows are resolved. An entry claiming either is
+still consulted, but it renders **inside** that group, and the group keeps its own summary and
+approval affordance — so you cannot yet use the registry to replace the built-in approval UI with
+your own. Substituting the group itself is not an extension point today — tracked in #2940.
+
 ### Replacing a built-in row
 
 Reuse the built-in's `id`:
@@ -219,6 +227,7 @@ Two rules the registry relies on:
 | `mergeRenderers(extra)` | function | shape-matched defaults, then host entries, then the rest |
 | `resolveRenderer(message, renderers)` | function | first entry that claims the message |
 | `ToolCallPill` | component | the store-free tool row the default registry uses |
+| `GROUPED_ROLES` | value | frozen array of the roles grouped before per-row resolution (see the limitation above) |
 | `MessageRenderer` | type | `{ id, roles, match?, render }` |
 | `MessageRenderContext` | type | what `render` is handed |
 

--- a/website/public/vendor/kirocrew-app-sdk.mjs
+++ b/website/public/vendor/kirocrew-app-sdk.mjs
@@ -9,5 +9,5 @@ export const {
   parseOptions, deriveFollowUpOptions, extractSteeringAcks, stripPartialOptionMarker,
   // Chat surfaces and the transcript row registry.
   useChatSession, ChatPanel, ChatEmbed, ChatMessageList,
-  defaultMessageRenderers, mergeRenderers, resolveRenderer, ToolCallPill,
+  defaultMessageRenderers, mergeRenderers, resolveRenderer, ToolCallPill, GROUPED_ROLES,
 } = m

--- a/website/src/app-sdk/ChatMessageList.tsx
+++ b/website/src/app-sdk/ChatMessageList.tsx
@@ -14,6 +14,7 @@ import { isSubagentCompletionMessage } from '../pages/chat/subagentCompletion'
 import {
   type MessageRenderer,
   type MessageRenderContext,
+  GROUPED_ROLES,
   mergeRenderers,
   resolveRenderer,
 } from './messageRenderers'
@@ -45,8 +46,6 @@ export interface ChatMessageListProps {
 
 // ── Stable helpers (outside component) ──
 
-const GROUPABLE = new Set(['thinking', 'permission'])
-
 function msgKey(m: ChatMessage, i: number): string {
   return (m.ts || '') + '-' + i + '-' + m.role
 }
@@ -74,7 +73,7 @@ const ChatMessageList = memo(function ChatMessageList({
       // A sub-agent completion the card cannot parse stays internal — the model
       // sees it, the reader does not.
       if (messages[i].role === 'subagent' && !isSubagentCompletionMessage(messages[i])) continue
-      if (GROUPABLE.has(messages[i].role)) {
+      if (GROUPED_ROLES.includes(messages[i].role)) {
         if (!group.length) groupStart = i
         group.push(messages[i])
       } else {

--- a/website/src/app-sdk/index.ts
+++ b/website/src/app-sdk/index.ts
@@ -312,6 +312,7 @@ export { default as ChatMessageList } from './ChatMessageList'
 // instead of forking the message list.
 export {
   defaultMessageRenderers,
+  GROUPED_ROLES,
   mergeRenderers,
   resolveRenderer,
   ToolCallPill,

--- a/website/src/app-sdk/messageRenderers.tsx
+++ b/website/src/app-sdk/messageRenderers.tsx
@@ -367,6 +367,24 @@ export function resolveRenderer(
 }
 
 /**
+ * Roles assembled into a collapsible group BEFORE per-row resolution, so the
+ * transcript shows "worked through N steps" instead of a wall of rows.
+ *
+ * Frozen, and an array rather than a Set, because this crosses into apps through
+ * the vendored SDK surface: a `ReadonlySet` is only a compile-time promise, and an
+ * app is plain JavaScript that never sees our types — one `delete('permission')`
+ * on a shared Set would stop the host grouping permissions and take the pending
+ * approval UI with it. Two entries, so `includes` costs nothing.
+ *
+ * Consequence worth knowing when you register an entry: an entry claiming one of
+ * these roles is still consulted, but its row renders INSIDE the group, and the
+ * group keeps its own summary and approval affordance. Replacing the group itself
+ * is not an extension point today — see the limitation note in
+ * docs/app-kit/api-reference.md.
+ */
+export const GROUPED_ROLES: readonly string[] = Object.freeze(['thinking', 'permission'])
+
+/**
  * Host entries sit between the SHAPE-matched defaults and the role-keyed ones.
  *
  * A shape-matched entry recognises a message by what it IS (`kind`), not by the

--- a/website/src/test/messageRenderers.test.ts
+++ b/website/src/test/messageRenderers.test.ts
@@ -18,6 +18,7 @@ import { join } from 'node:path'
 import type { ChatMessage } from '../types'
 import {
   defaultMessageRenderers,
+  GROUPED_ROLES,
   mergeRenderers,
   resolveRenderer,
   type MessageRenderer,
@@ -126,6 +127,40 @@ describe('host entries', () => {
     const ownStop: MessageRenderer = { id: 'stop_event', roles: ['*'], match: () => true, render: () => 'mine' }
     const merged = mergeRenderers([ownStop])
     expect(resolveRenderer(msg('system', { kind: 'stop_event' }), merged)).toBe(ownStop)
+  })
+})
+
+describe('grouped roles are a documented exception, not an accident', () => {
+  // `thinking` and `permission` are assembled into a collapsible group BEFORE
+  // per-row resolution, so an entry claiming one is consulted but renders INSIDE
+  // the group rather than replacing it. Pinning the set here keeps the docs and
+  // the transcript honest about which roles behave that way — silently adding a
+  // third would make the api-reference wrong without anything noticing.
+  it('names exactly the roles the transcript groups', () => {
+    expect([...GROUPED_ROLES].sort()).toEqual(['permission', 'thinking'])
+  })
+
+  it('cannot be mutated by a consumer at RUNTIME, not merely by type', () => {
+    // This value crosses into apps through the vendored SDK surface, and an app is
+    // plain JavaScript that never sees our types. A merely type-readonly export
+    // would let one `delete`/`push` stop the host grouping permissions and take the
+    // pending approval UI with it, so the guarantee has to survive type erasure.
+    expect(Object.isFrozen(GROUPED_ROLES)).toBe(true)
+    expect(() => {
+      (GROUPED_ROLES as string[]).push('notice')
+    }).toThrow()
+    // Whatever a caller tried, the set of grouped roles is unchanged.
+    expect([...GROUPED_ROLES].sort()).toEqual(['permission', 'thinking'])
+  })
+
+  it('leaves permission unclaimed by default, so nothing draws it per-row', () => {
+    // The group's own summary and approval affordance handle it.
+    expect(resolveRenderer(msg('permission'), defaultMessageRenderers)).toBeUndefined()
+  })
+
+  it('does resolve a host entry for a grouped role — it just renders in the group', () => {
+    const card: MessageRenderer = { id: 'approval', roles: ['permission'], render: () => 'card' }
+    expect(resolveRenderer(msg('permission'), mergeRenderers([card]))).toBe(card)
   })
 })
 


### PR DESCRIPTION
## What is the problem?

The transcript renderer registry that landed in #2924 documents itself as "claim a role and it is yours". For two roles that is not true, and the docs do not say so.

`ChatMessageList` assembles `thinking` and `permission` messages into one collapsible "worked through N steps" group in its **first** pass — before any row is resolved through the registry. An entry claiming either role is still consulted, but its row renders **inside** that group, and the group keeps its own summary and approval affordance.

For `permission` that is the case a host most wants to serve: its own approval card. So the documentation is wrong in the one place it matters, and the reader only finds out by building it and watching their card appear nested inside a group they meant to replace.

The grouped set was also written down twice — a hardcoded `GROUPABLE` in `ChatMessageList.tsx` and the prose in the api-reference — with nothing keeping them in agreement.

## Why this issue matters to the user

An app author reads `docs/app-kit/api-reference.md`, sees that undrawn roles are claimable, writes an approval renderer, and gets a result that looks like a bug in the SDK. The registry made every other row substitutable, so this is now the one shape of extension someone will reach for and not find — and the docs currently point them straight at it.

It also matters that this is stated rather than fixed here: substituting the approval UI inside an app embed is the remaining half of #510, and lifting the limitation changes grouping behaviour. That work belongs in its own change, with its own tests.

## How our fix solves it — symptom to root cause to change

Symptom: the docs promise something two roles cannot do. Root cause: grouping is a pre-pass keyed on role that runs before the registry is consulted, and nothing in the docs or the code said the two interact.

- `GROUPED_ROLES` moves out of `ChatMessageList.tsx` and is exported from `messageRenderers.tsx`, next to the registry it interacts with. The transcript consumes it, so the set exists once instead of once per reader.
- `docs/app-kit/api-reference.md` gains a **Limitation** section naming the two roles, what actually happens to an entry claiming one, and that replacing the group is not an extension point — with a pointer to #2940 for the real fix. The export table lists `GROUPED_ROLES`.
- The barrel and the vendor stub both export it, so an app can read the set rather than hardcode its own copy. (A name the barrel exports and the stub omits is a load-time failure for the whole app, so the drift ratchet added in #2924 covers this automatically.)

No behaviour change: grouping, resolution order, and every rendered row are byte-for-byte what they were. This change only makes an existing limitation legible and single-sourced.

## What tests we did

Three assertions added to `website/src/test/messageRenderers.test.ts`, each mutation-verified (3/3 mutants caught):

- `GROUPED_ROLES` names exactly `permission` and `thinking` — silently adding a third would make the api-reference wrong with nothing noticing. *(Mutant: add `notice` to the set → fails.)*
- `permission` is unclaimed by the default registry, so nothing draws it per-row and the group's own affordance is the only thing rendering it. *(Mutant: claim `permission` in the default `undrawn` entry → fails.)*
- A host entry for a grouped role **does** resolve — the limitation is about where it renders, not whether it is consulted. *(Mutant: drop `permission` from the grouped set → fails.)*

Gates, all green on base `516dac9d2`: `npx tsc -b`; `npm run i18n:check`; `npm run i18n:render`; `python3 scripts/docs_lint.py --test`; `./scripts/docs-lint.sh`; targeted `vitest` over the registry, protocol-boundary, `ChatMessageList` and `ChatEmbed` suites (83 tests); and the full frontend suite at 1001 files / 16405 tests passing with zero failures.

## Manual verification

N/A — docs, one moved constant, and tests. No rendered output changes, so there is nothing to look at.

Worth recording because it cost time to diagnose: on a host where `/tmp` is a RAM-backed tmpfs, `npm run i18n:render` fails with `ENOSPC: mkdtemp '/tmp/playwright-artifacts-…'` when memory is exhausted rather than when the disk is full — `df` shows space free while the write still fails. Pointing `TMPDIR` at real disk makes the same commit pass. The full suite's exit code 1 on that host comes from an unhandled post-teardown `setTimeout` in `website/src/pages/knowledge/helpers.ts:35`, raised by `KnowledgeListView.test.tsx`, which has no import relationship to this diff and passes in isolation.

## Any other suggestions on the work

#2940 carries the real fix (let a host-claimed role opt out of grouping, or give the group its own registry identity) and is the one that unblocks #510's remaining half. This PR deliberately does not attempt it.

Follows #2924. Part of the chat SDK work tracked in #2722.
