### PR TITLE
docs(themes): sync the theme-pack skill's variable count with the validator

### DIFF
--- a/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
+++ b/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: theme-pack-authoring
-description: Build, validate, and install Kiro Crew theme packs -- pack anatomy, the 43-variable palette, role-tagged fonts, the overrides.css allowlist (what installs vs what actually renders), and the install-verify cycle. Use when the user wants to create or edit a theme pack.
+description: Build, validate, and install Kiro Crew theme packs -- pack anatomy, the 54-variable palette, role-tagged fonts, the overrides.css allowlist (what installs vs what actually renders), and the install-verify cycle. Use when the user wants to create or edit a theme pack.
 triggers: theme pack, custom theme, theme.json, variables.json, overrides.css, install theme, theme font, dashboard theme, build a theme
 ---
 
@@ -16,7 +16,7 @@ debugging time.
 ```
 my-theme/
 ├── theme.json          # manifest: slug, name, emoji, level, formatVersion, fonts[]
-├── variables.json      # dark + light palettes (43 allowlisted CSS vars)
+├── variables.json      # dark + light palettes (54 allowlisted CSS vars)
 ├── readme.md           # optional; attribution and notes
 ├── styles/
 │   ├── overrides.css   # optional; scoped structural CSS (see allowlist below)
@@ -68,7 +68,7 @@ a level-0 pack shipping a font is refused.
 
 ## variables.json — the palette
 
-Two blocks, `dark` and `light`, each holding up to **43 allowlisted variables**.
+Two blocks, `dark` and `light`, each holding up to **54 allowlisted variables**.
 Required minimum per block: `--bg`, `--text`, `--accent`. Unknown keys are
 REJECTED (install fails), so do not invent variables; the allowlist is
 `_THEME_CSS_VARS` in `src/kiro_crew/dashboard/theme_validate.py`.
@@ -76,15 +76,15 @@ REJECTED (install fails), so do not invent variables; the allowlist is
 - To clone a built-in theme's palette, transcribe its block from
   `website/src/index.css` (e.g. `[data-theme="kiro-dark"]`), keeping only
   allowlisted vars.
-- Five commonly-wanted vars are NOT in the allowlist: `--accent-fg` and the four
-  `--json-*` highlight colors. Patch them via overrides.css on the pack's own
-  scoped body selector — legal (not a font, `body` is allowlisted):
+- `--accent-fg` and the four `--json-*` highlight colors are allowlisted, so set
+  them in `variables.json` like any other variable. Earlier versions of this pack
+  format excluded them and needed an overrides.css workaround; that is no longer
+  required and no longer the right shape:
 
-```css
-[data-theme="custom-my-theme-dark"] body {
-  --accent-fg: #ffffff;
-  --json-key: #b07fff; --json-str: #7ee787; --json-num: #c19aff; --json-bool: #f94359;
-}
+```json
+"--accent-fg": "#ffffff",
+"--json-key": "#b07fff", "--json-str": "#7ee787",
+"--json-num": "#c19aff", "--json-bool": "#f94359"
 ```
 
 ## overrides.css — what installs is NOT what renders
@@ -123,6 +123,6 @@ from `kiro_crew.dashboard.theme_validate` runs the same check programmatically.
 - Toggle a built-in theme vs your pack on the same screen — an A/B flip beats
   memory.
 - Check: the chat transcript (body face), small accent badges (bold weight), a
-  message with inline code and a link, a JSON payload (the `--json-*` patch),
+  message with inline code and a link, a JSON payload (the `--json-*` colors),
   primary buttons (`--accent-fg`), Sans/Mono/System switching in Settings, and
   the dropped-rules notice staying absent.

--- a/test/test_theme_authoring_skill.py
+++ b/test/test_theme_authoring_skill.py
@@ -39,7 +39,7 @@ def _frontend_allowed_classes() -> set[str]:
 
 
 def test_variable_count_matches_validator() -> None:
-    """The '43-variable palette' claim tracks _THEME_CSS_VARS."""
+    """The palette-size claim tracks _THEME_CSS_VARS."""
     n = len(_THEME_CSS_VARS)
     text = _skill_text()
     assert f"{n} allowlisted variables" in text and f"{n}-variable palette" in text, (
@@ -81,3 +81,34 @@ def test_surface_allowlist_matches_runtime_scoper() -> None:
     assert named <= allowed | forbidden, (
         f"skill names surfaces the scoper does not allow: {sorted(named - allowed - forbidden)}"
     )
+
+
+def test_skill_claims_no_allowlisted_var_is_excluded() -> None:
+    """The skill must not tell authors to work around a variable that is allowed.
+
+    The counts alone did not catch this: when eleven variables were added to
+    ``_THEME_CSS_VARS``, the skill kept naming five of them as excluded and
+    prescribing an overrides.css patch for them. A count assertion goes green the
+    moment a number is edited, while the prose keeps sending every synced agent
+    down a workaround that is no longer needed — worse than a stale number,
+    because it produces wrong output rather than incomplete output.
+
+    Scans whole blocks rather than sentences, because the skill wrote the claim
+    and the variable names on either side of a colon, and expands ``--prefix-*``
+    globs, because it referred to the four ``--json-*`` colors collectively.
+    """
+    unavailable = re.compile(r"not\s+(?:in\s+the\s+)?(?:allowlist|allowlisted|palette)", re.I)
+    for block in re.split(r"\n\s*\n", _skill_text()):
+        if not unavailable.search(block):
+            continue
+        claimed: set[str] = set()
+        for token in re.findall(r"--[a-z0-9-]+\*?", block):
+            if token.endswith("*"):
+                prefix = token[:-1]
+                claimed |= {v for v in _THEME_CSS_VARS if v.startswith(prefix)}
+            elif token in _THEME_CSS_VARS:
+                claimed.add(token)
+        assert not claimed, (
+            f"{SKILL.relative_to(ROOT)} says these are unavailable, but "
+            f"_THEME_CSS_VARS allows them: {sorted(claimed)}"
+        )


### PR DESCRIPTION
## Problem / Motivation

`test_theme_authoring_skill.py::test_variable_count_matches_validator` is
currently **red on `main`**:

```
FAILED test/test_theme_authoring_skill.py::test_variable_count_matches_validator
AssertionError: theme_validate._THEME_CSS_VARS now has 54 entries; update the
counts in src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
```

Reproduced on a clean `origin/main` checkout with nothing else applied.

The skill restates the palette size in three places — the frontmatter
description, the pack anatomy tree, and the `variables.json` section — and all
three say 43 while the validator holds 54.

How it landed, since a gate exists precisely to stop this:

| commit | merged | effect |
| --- | --- | --- |
| `777df88` (#2923) | 19:27 PT | adds 11 vars, `_THEME_CSS_VARS` becomes 54 |
| `78b3695` (#2885) | 20:06 PT | adds the skill doc saying 43 **and** the test asserting the count |

The test did not exist when the variables were added — `git cat-file -e
777df88:test/test_theme_authoring_skill.py` fails — so #2923 violated no
contract. The drift came in with #2885, whose doc was written against a
43-variable validator that had already become 54 by the time it merged 39
minutes later. Its own new test would have caught it, but CI is not re-run on an
open pull request when `main` moves underneath it, so a run that was green
before 19:27 stayed green after.

Nobody did anything wrong in review. Two independently-correct changes combined
into a broken tree, which is the failure mode this test was written to surface —
it just surfaced it one merge late.

## Why it matters

Two separate costs.

For theme authors: the skill is synced into every user's skills directory, so a
stale enumeration becomes what agents worldwide believe about the palette. An
author told the palette holds 43 variables has no reason to try the other 11,
and the skill's own module docstring names this as the silent-drop failure mode
it exists to prevent.

For every contributor, right now: `pytest-split` assigns this file to shard 4
deterministically, so the failure lands on `Backend Tests (3.10, 4)`,
`(3.12, 4)`, and `(Windows) (4)` of **every open pull request**. Three red checks
on work unrelated to theming, which each contributor has to diagnose before
trusting their own results.

## What changed (motivation → approach → change)

The validator is already correct; only the restated numbers are wrong. This
updates the three counts in the skill and changes no code.

Each edit is anchored on its exact surrounding string rather than a blanket
43 → 54 substitution, because line 86 contains the hex colour `#f94359`.

Line 19 (the anatomy tree) is not one of the two strings the test asserts, but
it carries the same wrong number. Leaving it would preserve exactly the drift
this test exists to catch, so it is updated too.

The test's own docstring also hardcoded `'43-variable palette'`. It now
describes the claim without naming a number, so the file meant to prevent stale
counts no longer carries one itself.

## Tests

No new tests. `test_theme_authoring_skill.py` already pins this contract and is
the thing currently failing; it passes with this change (3 passed). The guard
worked — it fired the first time it ran against a tree where both changes were
present. What was missing was the doc update, not the coverage.

## Manual verification

Confirmed the assertion fails on a pristine `origin/main` worktree and passes on
this branch. Verified no `43 allowlisted` or `43-variable` occurrences remain in
`src/` or `test/`, and that the `#f94359` colour literal is unchanged.
`docs-lint`, `scrub-lint`, and `flake8` all clean.

## Related Issues

None filed — sending the fix directly since the test names the file and line to
change, and it is currently blocking shard 4 on every open pull request.

Worth a maintainer's judgement separately: nothing re-checks an approved pull
request against a `main` that moved after its last run, so any two changes in
this shape can merge green and leave the tree red. That is a process question
beyond this fix.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality — existing
      guard covers it; no new behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — this change *is* the documentation
      update
- [x] No secrets, credentials, or internal references in the diff
