### PR TITLE
fix(docker): keep credential scrub keys in sync

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -66,11 +66,18 @@ CONFIG="$ACTIVE_HOME/config.json"
 ENV_FILE="$ACTIVE_HOME/.env"
 
 # ── 1. Credential sync: env -> .env file, then scrub ─────────────────────
-# Keys mirror the product's credential key list (config/loader.py
-# _CREDENTIAL_KEYS). Replace-or-append line-wise so operator-added lines
-# and comments in .env survive; grep -v (not sed) avoids escaping issues
-# with arbitrary secret bytes.
-CRED_KEYS="SLACK_BOT_TOKEN SLACK_APP_TOKEN KIROCREW_OWNER_ID DISCORD_BOT_TOKEN TELEGRAM_BOT_TOKEN WECOM_BOT_ID WECOM_SECRET WEBEX_BOT_TOKEN"
+# Derive keys from the product's authoritative credential list. The fallback
+# keeps a broken installation diagnosable instead of leaving credentials in the
+# gateway environment; a regression test pins it to _CREDENTIAL_KEYS so it
+# cannot silently drift. Replace-or-append line-wise so operator-added lines
+# and comments in .env survive; grep -v (not sed) avoids escaping issues with
+# arbitrary secret bytes.
+CRED_KEYS_FALLBACK="SLACK_APP_TOKEN SLACK_BOT_TOKEN KIROCREW_OWNER_ID WECOM_BOT_ID WECOM_SECRET TELEGRAM_BOT_TOKEN DISCORD_BOT_TOKEN WEBEX_BOT_TOKEN MICROSOFT_APP_ID MICROSOFT_APP_PASSWORD MICROSOFT_APP_TENANT_ID WEIXIN_TOKEN"
+if ! CRED_KEYS=$(python3 -c 'from kiro_crew.config.loader import _CREDENTIAL_KEYS; print(" ".join(_CREDENTIAL_KEYS))' 2>/dev/null) || [ -z "$CRED_KEYS" ]; then
+    CRED_KEYS="$CRED_KEYS_FALLBACK"
+    echo "[entrypoint] WARNING: could not load the product credential key list;" \
+         "using the built-in fallback." >&2
+fi
 for KEY in $CRED_KEYS; do
     VAL=$(eval "printf '%s' \"\${$KEY:-}\"")
     if [ -n "$VAL" ]; then

--- a/test/test_docker_entrypoint.py
+++ b/test/test_docker_entrypoint.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import stat
 import subprocess
 import sys
@@ -55,6 +56,7 @@ def _run_entrypoint(
     home: Path,
     *args: str,
     probe_backend_available: bool = False,
+    credential_keys_available: bool = True,
     resolver_python: str | None = None,
     extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
@@ -83,6 +85,8 @@ def _run_entrypoint(
         '#!/bin/sh\n'
         'case "${2:-}" in\n'
         '  *ensure_data_home*) exec "$ENTRYPOINT_TEST_REAL_PYTHON" "$@" ;;\n'
+        '  *_CREDENTIAL_KEYS*) [ "$ENTRYPOINT_TEST_CREDENTIAL_KEYS_AVAILABLE" = 1 ]'
+        ' || exit 1; exec "$ENTRYPOINT_TEST_REAL_PYTHON" "$@" ;;\n'
         f'  *detect_backend*) exit {0 if probe_backend_available else 1} ;;\n'
         '  *) exec "$ENTRYPOINT_TEST_REAL_PYTHON" "$@" ;;\n'
         'esac\n',
@@ -99,6 +103,7 @@ def _run_entrypoint(
         "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
         "ENTRYPOINT_TEST_ENV_CAPTURE": str(home / "captured-env"),
         "ENTRYPOINT_TEST_REAL_PYTHON": resolver_python or sys.executable,
+        "ENTRYPOINT_TEST_CREDENTIAL_KEYS_AVAILABLE": "1" if credential_keys_available else "0",
     }
     if extra_env:
         env.update(extra_env)
@@ -344,6 +349,19 @@ def test_broken_resolver_falls_back_to_default_home(tmp_path: Path) -> None:
 # ── Credential env -> .env sync + scrub ─────────────────────────────────
 
 
+def test_credential_fallback_matches_authoritative_key_list() -> None:
+    """The emergency literal must change whenever the product list changes."""
+    from kiro_crew.config.loader import _CREDENTIAL_KEYS
+
+    script = ENTRYPOINT.read_text(encoding="utf-8")
+    match = re.search(r'^CRED_KEYS_FALLBACK="([A-Z0-9_ ]+)"$', script, re.MULTILINE)
+
+    assert match is not None, "entrypoint credential fallback literal is missing"
+    fallback_keys = match.group(1).split()
+    assert len(fallback_keys) == len(set(fallback_keys)), "fallback contains duplicate keys"
+    assert set(fallback_keys) == set(_CREDENTIAL_KEYS)
+
+
 def test_channel_credentials_move_to_env_file_and_leave_environ(tmp_path: Path) -> None:
     """Credentials delivered as container env must land in the product's
     .env file (0600) and be ABSENT from the environment the gateway is
@@ -372,6 +390,56 @@ def test_channel_credentials_move_to_env_file_and_leave_environ(tmp_path: Path) 
     assert "WECOM_SECRET" not in captured
     # The secret value itself must not be echoed to stdout/stderr (docker
     # logs are readable indefinitely).
+    assert secret not in result.stdout
+    assert secret not in result.stderr
+
+
+def test_new_credential_keys_are_derived_and_scrubbed(tmp_path: Path) -> None:
+    """Keys added to the backend list are picked up without a shell edit."""
+    new_credentials = {
+        key: f"{key.lower()}-test-value"
+        for key in (
+            "MICROSOFT_APP_ID",
+            "MICROSOFT_APP_PASSWORD",
+            "MICROSOFT_APP_TENANT_ID",
+            "WEIXIN_TOKEN",
+        )
+    }
+    result = _run_entrypoint(
+        tmp_path,
+        probe_backend_available=False,
+        extra_env=new_credentials,
+    )
+    assert result.returncode == 0, result.stderr
+
+    env_file = tmp_path / ".kiro" / "crew" / ".env"
+    content = env_file.read_text(encoding="utf-8")
+    captured = (tmp_path / "captured-env").read_text(encoding="utf-8")
+    for key, value in new_credentials.items():
+        assert f"{key}={value}" in content
+        assert key not in captured
+        assert value not in result.stdout
+        assert value not in result.stderr
+
+
+def test_credential_fallback_still_scrubs_when_product_import_fails(
+    tmp_path: Path,
+) -> None:
+    """A broken import must fail safe rather than retain known credentials."""
+    secret = "weixin-token-test-value"
+    result = _run_entrypoint(
+        tmp_path,
+        probe_backend_available=False,
+        credential_keys_available=False,
+        extra_env={"WEIXIN_TOKEN": secret},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "using the built-in fallback" in result.stderr
+
+    env_file = tmp_path / ".kiro" / "crew" / ".env"
+    assert f"WEIXIN_TOKEN={secret}" in env_file.read_text(encoding="utf-8")
+    captured = (tmp_path / "captured-env").read_text(encoding="utf-8")
+    assert "WEIXIN_TOKEN" not in captured
     assert secret not in result.stdout
     assert secret not in result.stderr
 


### PR DESCRIPTION
## Problem

The Docker entrypoint had an 8-key credential scrub mirror while the authoritative `_CREDENTIAL_KEYS` contains 12. The four missing Microsoft and Weixin credentials supplied through the container environment therefore remained in the long-lived gateway environment.

## Fix

- derive scrub key names from `_CREDENTIAL_KEYS`
- retain a complete literal fallback if the product import fails
- cover the four previously missing Microsoft and Weixin credentials
- add a set-parity ratchet so the fallback cannot silently drift or contain duplicates

The derivation reads credential names only; it never reads or prints credential values.

## Safety

For both the derived and fallback paths, each credential is persisted to the supported `.env` file before the key is removed from the environment inherited by the gateway. Existing failure handling remains unchanged: if persisting a value fails, the entrypoint keeps that value in the environment so the gateway can still read it instead of losing the credential.

## Tests

- POSIX shell syntax check (`sh -n`)
- real-shell derived-list and forced-import-failure fallback harnesses
- all four newly covered keys verified in `.env` and absent from the gateway environment
- fallback `WEIXIN_TOKEN` verified persisted, scrubbed, and absent from logs
- fallback set parity and duplicate-key ratchet
- mutation checks: removing `WEIXIN_TOKEN` from the fallback fails the ratchet; restoring the old 8-key derivation reproduces the gateway-environment leak
- Black 26.3.1 (changed ranges), isort, Flake8, Python compile, and `git diff --check`
- Windows collected all 18 entrypoint tests; they are POSIX-only and skipped there by design, while Linux CI provides the native pytest execution

Closes #2921
