### PR TITLE
fix(skills): sync theme-pack doc variable count to the validator

### DIFF
--- a/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
+++ b/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: theme-pack-authoring
-description: Build, validate, and install Kiro Crew theme packs -- pack anatomy, the 43-variable palette, role-tagged fonts, the overrides.css allowlist (what installs vs what actually renders), and the install-verify cycle. Use when the user wants to create or edit a theme pack.
+description: Build, validate, and install Kiro Crew theme packs -- pack anatomy, the 54-variable palette, role-tagged fonts, the overrides.css allowlist (what installs vs what actually renders), and the install-verify cycle. Use when the user wants to create or edit a theme pack.
 triggers: theme pack, custom theme, theme.json, variables.json, overrides.css, install theme, theme font, dashboard theme, build a theme
 ---
 
@@ -16,7 +16,7 @@ debugging time.
 ```
 my-theme/
 ├── theme.json          # manifest: slug, name, emoji, level, formatVersion, fonts[]
-├── variables.json      # dark + light palettes (43 allowlisted CSS vars)
+├── variables.json      # dark + light palettes (54 allowlisted CSS vars)
 ├── readme.md           # optional; attribution and notes
 ├── styles/
 │   ├── overrides.css   # optional; scoped structural CSS (see allowlist below)
@@ -68,7 +68,7 @@ a level-0 pack shipping a font is refused.
 
 ## variables.json — the palette
 
-Two blocks, `dark` and `light`, each holding up to **43 allowlisted variables**.
+Two blocks, `dark` and `light`, each holding up to **54 allowlisted variables**.
 Required minimum per block: `--bg`, `--text`, `--accent`. Unknown keys are
 REJECTED (install fails), so do not invent variables; the allowlist is
 `_THEME_CSS_VARS` in `src/kiro_crew/dashboard/theme_validate.py`.


### PR DESCRIPTION
## What

Three-line doc fix. `test_variable_count_matches_validator` asserts the theme-pack skill doc states `len(theme_validate._THEME_CSS_VARS)` in two forms. The validator grew to **54** variables while the doc still said **43**, so the assertion fails.

## Why it matters now

**This is red on `main`, and it reddens a Backend Tests shard on every open PR regardless of what that PR changes.** I hit it on two unrelated coverage PRs (#2947, #2948) and confirmed it on a worktree with zero backend changes versus main, so it is not attributable to any branch.

It currently fails `Backend Tests (3.10, 4)`, `(3.12, 4)` and `Backend Tests (Windows) (4)`, and because `Coverage Gate` and `PR Readiness` fail closed behind an upstream failure, it takes those down too.

## Approach

The count is **read from the validator** rather than typed in, so it cannot drift again through a transcription slip in the fix itself. Three claims moved: the front-matter description, the `variables.json` tree comment, and the palette section. Only the counted claims were rewritten — other numbers in the doc are untouched.

## Verification

`test/test_theme_authoring_skill.py`: **3 passed** (was 1 failed, 2 passed).

Docs only — no code, no tests changed.
