### PR TITLE
fix(session): reset pooled runtime context stats at warm-pool handoff (#2932)

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -2003,6 +2003,12 @@ class AcpClient:
         self._session_key = session_key
         self._channel_id = channel_id
         self._last_activity = time.monotonic()
+        # The prompt stats' context fields describe whatever this runtime did
+        # BEFORE the handoff — carry_over() deliberately preserves them across
+        # turn boundaries, so without this reset a recycled runtime hands its
+        # previous session's context_pct to the new chat and the first
+        # check_context_usage() compacts an empty conversation (#2932).
+        self.last_prompt_stats.reset_context_state()
         # Claim-push: tell gatewayd this runtime PID now belongs to
         # ``session_key`` so every MCP stub connection under it carries the
         # right ``_meta.caller`` immediately — event-driven replacement for

--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -354,6 +354,10 @@ class AcpSessionProvider(LLMProvider):
         self._session_key = session_key
         self._channel_id = channel_id
         self._runtime._last_activity = time.monotonic()
+        # Parity with AcpClient.rekey: the handle's prompt stats describe the
+        # session this runtime served BEFORE the handoff; leaking them lets
+        # check_context_usage() compact the new, empty session (#2932).
+        self._handle.last_prompt_stats.reset_context_state()
         # Claim-push: re-target every MCP stub connection under the shared
         # runtime's PID to the claiming session (see AcpClient.rekey for the
         # rationale). Fire-and-forget; no-ops without a gateway socket.

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -505,6 +505,34 @@ class AcpPromptStats:
             context_pct_unknown=self.context_pct_unknown,
         )
 
+    def reset_context_state(self) -> None:
+        """Drop ALL context state when the runtime is re-bound to a new session.
+
+        The inverse commitment of :meth:`carry_over`: that method preserves the
+        context fields because they describe the SESSION — which is exactly why
+        they must NOT survive a warm-pool handoff, where the runtime outlives
+        whatever it did before the re-bind. Stale stats handed to a new chat
+        make ``check_context_usage`` fire compaction on an empty conversation
+        (issue #2932).
+
+        Everything returns to dataclass defaults, window included: a handoff
+        may re-apply a different model post-claim, and a window measured before
+        the re-bind has no claim to describe the next session.
+
+        ``context_pct_unknown`` deliberately resets to ``False``, NOT ``True``:
+        the claimed runtime serves a fresh, never-prompted ``session/new``, so
+        "confirmed empty" is the accurate reading. Flagging it unknown would
+        collide with the flag's existing meaning — "the backend compacted this
+        session in place" — which the background-session recycle decision reads
+        as a recycle-now signal (``pct == 0.0 and unknown``); a just-claimed
+        provider must not match that predicate.
+        """
+        self.context_pct = 0.0
+        self.context_used_tokens = 0
+        self.context_window_tokens = 0
+        self.context_tokens_from_usage = False
+        self.context_pct_unknown = False
+
     def note_pct_reported(self) -> None:
         """Mark ``context_pct`` as backed by real telemetry.
 

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -3096,7 +3096,25 @@ class SessionManager:
             if pct > 0:
                 logger.info("Session %s context at %.0f%% (CC-managed)", key, pct)
         elif pct >= self._cfg.session.autocompact_pct:
-            self._trigger_compaction(key, f"context at {pct:.0f}%", pct)
+            # Defensive twin of the rekey-time reset (#2932): compaction is
+            # destructive-ish (it rewrites the conversation), so it must never
+            # fire on a percentage that no telemetry has confirmed for the
+            # CURRENT session binding. Today every path that raises context_pct
+            # also calls note_pct_reported(), so this gate is unreachable in
+            # production — it exists so a future handoff/reset path that
+            # preserves a stale pct while leaving it flagged unknown degrades
+            # to a skipped compaction instead of compacting an empty session.
+            # Fail-quiet on doubles: providers without the probe read as
+            # "confirmed" (unchanged behavior).
+            if _context_pct_is_unknown(provider):
+                logger.info(
+                    "Session %s context %.0f%% is unconfirmed for this session — "
+                    "skipping compaction until telemetry reports",
+                    key,
+                    pct,
+                )
+            else:
+                self._trigger_compaction(key, f"context at {pct:.0f}%", pct)
         elif pct >= _CONTEXT_WARN_PCT:
             logger.warning("Session %s context at %.0f%%", key, pct)
         elif pct > 0:

--- a/test/test_acp_session_provider.py
+++ b/test/test_acp_session_provider.py
@@ -652,6 +652,23 @@ class TestAcpSessionProviderRound4Parity:
         assert provider._channel_id == "chan-7"
         assert runtime._last_activity > 0.0
 
+    def test_rekey_resets_context_state(self):
+        """#2932 -- the handoff must drop the previous session's context state
+        (mirror of AcpClient.rekey): _make_handle seeds pct=42/5000/200000, so
+        a leak here would hand those numbers to the claiming session and let
+        check_context_usage compact its empty conversation."""
+        handle = _make_handle()
+        runtime = _make_runtime()
+        provider = AcpSessionProvider(handle, runtime)
+        assert handle.last_prompt_stats.context_pct == 42.0  # seeded stale state
+        provider.rekey("dashboard:slot9", "chan-7")
+        stats = handle.last_prompt_stats
+        assert stats.context_pct == 0.0
+        assert stats.context_used_tokens == 0
+        assert stats.context_window_tokens == 0
+        assert stats.context_tokens_from_usage is False
+        assert stats.context_pct_unknown is False
+
     def test_agent_reads_from_runtime(self):
         """#5 -- session.py session-info introspection reads
         provider.client._agent; mirror AcpClient._agent via the runtime."""

--- a/test/test_acp_types.py
+++ b/test/test_acp_types.py
@@ -60,3 +60,58 @@ class TestAcpPromptStats:
         # Raw token counts default to 0 (unknown) until a usage_update arrives.
         assert stats.context_used_tokens == 0
         assert stats.context_window_tokens == 0
+
+    def test_carry_over_preserves_context_state_intra_session(self):
+        """Within ONE session, context state must survive the per-turn re-init
+        (#2932's correct half: a turn boundary must not re-report an empty
+        context) while per-turn counters restart at zero."""
+        stats = AcpPromptStats(
+            event_count=7,
+            text_chunks=3,
+            tool_calls=[("execute", "ls")],
+            context_pct=88.5,
+            context_used_tokens=177_000,
+            context_window_tokens=200_000,
+            context_tokens_from_usage=True,
+        )
+        carried = stats.carry_over()
+        assert carried.context_pct == 88.5
+        assert carried.context_used_tokens == 177_000
+        assert carried.context_window_tokens == 200_000
+        assert carried.context_tokens_from_usage is True
+        assert carried.context_pct_unknown is False
+        # Per-turn counters do NOT carry.
+        assert carried.event_count == 0
+        assert carried.text_chunks == 0
+        assert carried.tool_calls == []
+
+    def test_reset_context_state_drops_session_scoped_fields(self):
+        """At a warm-pool handoff every context field must drop (#2932's bug
+        half: the stats describe whatever the runtime did before the re-bind),
+        landing on plain dataclass defaults. unknown stays False — the claimed
+        runtime serves a fresh never-prompted session, and True would collide
+        with the compacted-in-place recycle signal (pct==0 and unknown)."""
+        stats = AcpPromptStats(
+            context_pct=92.0,
+            context_used_tokens=184_000,
+            context_window_tokens=200_000,
+            context_tokens_from_usage=True,
+            context_pct_unknown=True,
+        )
+        stats.reset_context_state()
+        assert stats.context_pct == 0.0
+        assert stats.context_used_tokens == 0
+        assert stats.context_window_tokens == 0
+        assert stats.context_tokens_from_usage is False
+        assert stats.context_pct_unknown is False
+
+    def test_reset_context_state_does_not_match_recycle_predicate(self):
+        """A just-claimed provider must not read as 'compacted in place'
+        (pct == 0.0 and unknown) — that predicate drives the background
+        recycle decision, and matching it would self-recycle every pool
+        claim at its first turn-end if the two paths ever meet."""
+        stats = AcpPromptStats(context_pct=88.0, context_used_tokens=170_000)
+        stats.reset_after_compaction()
+        assert stats.context_pct == 0.0 and stats.context_pct_unknown is True
+        stats.reset_context_state()
+        assert not (stats.context_pct == 0.0 and stats.context_pct_unknown)

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -1912,6 +1912,39 @@ class TestCheckContextUsage:
             mock_trigger.assert_not_called()
         await mgr.close_all()
 
+    @pytest.mark.asyncio
+    async def test_no_compaction_when_pct_unconfirmed(self, cfg):
+        """#2932 defensive gate: a pct above threshold that no telemetry has
+        confirmed for the CURRENT session binding must NOT trigger compaction
+        (compacting an empty just-claimed session, then overflowing)."""
+        cfg.session.autocompact_pct = 90.0
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        provider, _, _ = await mgr.get_or_create("k1")
+        mgr.release("k1")
+        provider.context_usage_pct = lambda: 95.0
+        provider.context_usage_unknown = lambda: True
+        with patch.object(mgr, "_trigger_compaction") as mock_trigger:
+            pct = mgr.check_context_usage("k1", provider)
+            mock_trigger.assert_not_called()
+        assert pct == 95.0  # reading is still returned, only the trigger is gated
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_compaction_fires_when_pct_confirmed(self, cfg):
+        """Twin of the gate test: the same pct WITH confirmed telemetry
+        (context_usage_unknown False) still compacts — the gate must not
+        suppress legitimate triggers."""
+        cfg.session.autocompact_pct = 90.0
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        provider, _, _ = await mgr.get_or_create("k1")
+        mgr.release("k1")
+        provider.context_usage_pct = lambda: 95.0
+        provider.context_usage_unknown = lambda: False
+        with patch.object(mgr, "_trigger_compaction") as mock_trigger:
+            mgr.check_context_usage("k1", provider)
+            mock_trigger.assert_called_once_with("k1", "context at 95%", 95.0)
+        await mgr.close_all()
+
     def test_missing_session_still_returns_pct(self, cfg):
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
         mock_p = AsyncMock()
@@ -3576,6 +3609,66 @@ class TestGetOrCreatePoolClaim:
         mgr.release("dashboard:slot1")
         assert provider is mock_pooled
         assert is_new is True
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_pool_claim_resets_stale_context_and_skips_compaction(self, cfg):
+        """#2932 end-to-end: a pooled provider carrying a previous session's
+        context stats must not hand them to the claiming session. The claim
+        path calls client.rekey(), whose reset makes the first turn-end
+        check_context_usage read 0%/unknown instead of firing compaction on
+        an empty conversation."""
+        from kiro_crew.acp.client import AcpClient
+        from kiro_crew.providers.acp import AcpProvider
+
+        cfg.session.pool_size = 1
+        cfg.session.autocompact_pct = 90.0
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        mgr._pool_size = 1
+        mgr._pool_agent = "kirocrew"
+
+        # Real (unstarted) AcpClient seeded with the PREVIOUS session's stats —
+        # the exact leak shape from the issue: high confirmed pct, real counts.
+        real_client = AcpClient()
+        real_client.last_prompt_stats = AcpPromptStats(
+            context_pct=95.0,
+            context_used_tokens=190_000,
+            context_window_tokens=200_000,
+            context_tokens_from_usage=True,
+        )
+
+        mock_pooled = AsyncMock(spec=AcpProvider)
+        mock_pooled.start = AsyncMock()
+        mock_pooled.shutdown = AsyncMock()
+        mock_pooled.is_process_alive = lambda: True
+        mock_pooled.client = real_client
+        # Route the provider probes through the real client stats (mirrors
+        # AcpProvider.context_usage_pct / context_usage_unknown).
+        mock_pooled.context_usage_pct = lambda: real_client.last_prompt_stats.context_pct
+        mock_pooled.context_usage_unknown = (
+            lambda: real_client.last_prompt_stats.context_pct_unknown
+        )
+
+        mgr._warm_pool.put_nowait((mock_pooled, time.monotonic()))
+
+        provider, is_new, _ = await mgr.get_or_create("dashboard:slot1", agent="kirocrew")
+        mgr.release("dashboard:slot1")
+        assert provider is mock_pooled
+
+        # The handoff dropped the stale session-scoped state (back to plain
+        # defaults — NOT flagged unknown, which would collide with the
+        # compacted-in-place recycle predicate)...
+        stats = real_client.last_prompt_stats
+        assert stats.context_pct == 0.0
+        assert stats.context_used_tokens == 0
+        assert stats.context_window_tokens == 0
+        assert stats.context_pct_unknown is False
+
+        # ...so the first turn-end check does not compact the empty session.
+        with patch.object(mgr, "_trigger_compaction") as mock_trigger:
+            pct = mgr.check_context_usage("dashboard:slot1", provider)
+            mock_trigger.assert_not_called()
+        assert pct == 0.0
         await mgr.close_all()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What is the problem?

With the warm session pool enabled (default `session.pool_size: 2`), a brand-new chat can compact on its very first message — the compaction summary itself reports there was nothing to compact — and then fail repeatedly with `The context window overflowed` on an otherwise empty conversation (#2932). `AcpPromptStats.carry_over()` deliberately preserves context state (`context_pct`, token counts) across turn boundaries because it describes the session; nothing reset that state when a pooled runtime is re-bound to a different session, so any stale percentage on a claimed provider is read by `SessionManager.check_context_usage()` as the new session's occupancy and trips `autocompact_pct`.

## Why does this matter to the user?

A user on default config opens a fresh chat, sends one short message, and gets a billed summarization turn over nothing followed by hard overflow errors — on a conversation whose stored transcript is 2 KB. The only workaround is `session.pool_size 0`, which gives up warm-start latency for every chat.

## How does the fix solve it?

Symptom → root cause chain: first-message compaction on an empty chat → `check_context_usage()` reads `provider.context_usage_pct()` above threshold → the provider's `last_prompt_stats` still carries context state from before the pool handoff → `carry_over()` preserves that state by design and the handoff path never reset it.

The fix places the reset at the handoff chokepoint plus a defensive gate at the trigger:

1. **`AcpPromptStats.reset_context_state()`** returns all five context-scoped fields (`context_pct`, `context_used_tokens`, `context_window_tokens`, `context_tokens_from_usage`, `context_pct_unknown`) to dataclass defaults. Both `rekey()` implementations — `AcpClient.rekey` and `AcpSessionProvider.rekey`, the only warm-pool claim binding points — call it. `context_pct_unknown` resets to `False`, not `True`: a claimed runtime serves a fresh never-prompted `session/new` ("confirmed empty" is accurate), and `True` would collide with the compacted-in-place recycle predicate (`pct == 0.0 and unknown`) read by the background-session recycle decision.
2. **Defensive gate in `check_context_usage()`**: the compaction trigger is skipped when the provider reports its percentage as unconfirmed (`_context_pct_is_unknown`). Today every path that raises `context_pct` also confirms it (`note_pct_reported()`), so this branch is a guarded invariant rather than a reachable hot path — it exists so a future state that carries a high-but-unconfirmed pct degrades to a skipped compaction (with an INFO log) instead of compacting an empty session.

Honest route note: on current `main`, the classic warm pool only holds freshly spawned, never-prompted providers (`_fill_warm_pool` is the sole producer; the other two `put_nowait` sites are non-destructive re-enqueues), and `_kiro.dev/metadata` is demultiplexed per-session by `AcpRuntime` (test-pinned, no cross-talk). I could not identify an in-repo path on this HEAD that places a high `context_pct` on a claimed provider. The reporter's deployment is the 0.2.0 docker image; this fix makes the reported leak shape impossible at the handoff chokepoint regardless of which upstream path produces it. The reporter offered to test a patch against their deployment — that validation is the confirmation this PR's premise rests on, and I've asked for it on the issue.

## What tests did we run?

- `test_acp_types.py`: `carry_over()` preserves context state intra-session while per-turn counters restart; `reset_context_state()` drops all five fields to defaults; a reset state does NOT match the compacted-in-place recycle predicate.
- `test_acp_session_provider.py`: `AcpSessionProvider.rekey` resets the handle's seeded stale stats (kiro-shared path parity).
- `test_session.py`: end-to-end pool claim with a real (unstarted) `AcpClient` seeded with the issue's exact leak shape — claim resets the stats and the first turn-end `check_context_usage` does not compact; the gate skips an unconfirmed above-threshold pct and still compacts a confirmed one.
- Mutation verification: 5/5 mutants caught (drop the gate, drop either rekey reset, regress unknown to True, keep the pct).
- Full local gates: pytest (full suite baseline-diffed — zero new failures vs base; the one differing test is a bidirectionally flaky session-summary cache test unrelated to this diff), isort, flake8, mypy. No frontend changes.

## Manual verification

N/A beyond the above — the leak state cannot be produced by any in-repo path on this HEAD (see route note); the end-to-end test constructs the reported shape directly. Reporter validation against the 0.2.0 docker deployment requested on the issue.

Closes #2932
