### PR TITLE
fix(test): await mouseup listener registration in companion press-hold-release test (#2925)

### DIFF
--- a/website/src/test/CrewCompanionPet.coverage.test.tsx
+++ b/website/src/test/CrewCompanionPet.coverage.test.tsx
@@ -13,7 +13,7 @@
  * localStorage, the panel opening on a tap and NOT on a drag, and the reactions the
  * session socket drives.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach, onTestFinished } from 'vitest'
 import { waitFor, fireEvent } from '@testing-library/react'
 
 import { PENDING_PATH, PRESENCE_PATH } from '../apps/crew-companion/constants'
@@ -498,7 +498,25 @@ describe('pointer and keyboard on the companion', () => {
   })
 
   it('holds the panel open from the PRESS and releases it on mouseup', async () => {
+    /*
+     * The release path is a window-level `mouseup` listener registered in a
+     * passive effect (pet.tsx), while `mountPet` only awaits the DOM commit
+     * (`.cc-pet` present). Under CI load the one-shot `mouseUp` below could fire
+     * before React flushed that effect, the event was lost, and the final
+     * `waitFor` timed out (issue #2925). React flushes a commit's passive
+     * effects synchronously and without yielding, so once `waitFor` observes
+     * any `mouseup` registration from the mount commit, that whole pass — which
+     * includes the release listener (pet.tsx, alongside useDrag.ts and
+     * useMouseForward.ts) — has already run: a state-based wait, not a
+     * wall-clock one. An exact registration count cannot be asserted here
+     * because useMouseForward re-registers on its dep changes.
+     */
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    onTestFinished(() => addSpy.mockRestore())
     await mountPet()
+    await waitFor(() =>
+      expect(addSpy.mock.calls.some(([type]) => type === 'mouseup')).toBe(true),
+    )
     fireEvent.mouseDown(petEl(), { clientX: 340, clientY: 240, button: 0 })
     expect(api.panelHold).toHaveBeenCalledWith(true)
     fireEvent.mouseUp(window)


### PR DESCRIPTION
# What is the problem?

`CrewCompanionPet.coverage.test.tsx > pointer and keyboard on the companion > holds the panel open from the PRESS and releases it on mouseup` fails intermittently on CI (Frontend Tests shard 1) with:

```
AssertionError: expected "vi.fn()" to be called with arguments: [ false ]
```

Observed on PR #2923 (run 31550911687, head `dda3b660d`) whose diff touched nothing related to the companion. It passes 4/4 locally and on prior heads — a flake, not a regression.

# Why this issue matters to the user

Every flake on a shared CI shard turns unrelated PRs red, forces re-runs, and erodes trust in the gate — contributors start treating red Frontend Tests as noise, which is how real regressions slip through.

# How our fix solves it

Symptom → root cause chain:

- The failing assertion is `waitFor(() => expect(api.panelHold).toHaveBeenCalledWith(false))` after `fireEvent.mouseUp(window)`.
- The release path is a **window-level `mouseup` listener registered in a passive effect** (`pet.tsx`: `window.addEventListener('mouseup', release)` inside `useEffect`).
- `mountPet()` only awaits the DOM commit (`.cc-pet` present). React attaches the element's own synthetic handlers at commit (which is why `panelHold(true)` from `onMouseDown` always succeeded), but **passive effects flush after commit**. Under CI load the one-shot `mouseUp` event could be dispatched into a window with no listener yet — the event is lost, nothing can ever call `panelHold(false)`, and the `waitFor` times out (~1414 ms in the failing run, consistent with `waitFor`'s 1 s default timeout plus overhead).

The fix replaces the implicit wall-clock race with a state-based wait: spy on `window.addEventListener` and `waitFor` a `mouseup` registration before dispatching any events. React flushes a commit's passive effects synchronously and without yielding, so observing any `mouseup` registration from the mount commit proves the whole pass — including the release listener — has run. The spy is restored via `onTestFinished` so a failing await cannot leak the wrapper onto the shared `window` for the remaining ~40 tests in the file (this file's `afterEach` uses `clearAllMocks`, which does not unwrap spies).

An exact-registration-count assertion was tried and rejected empirically: `useMouseForward` re-registers its listener on dep changes (8 registrations observed by assertion time, not 3), so a count would reintroduce timing fragility.

# What tests we did

- The changed test file: 56/56 pass.
- Robustness loop per the issue's fix guidance: **20 consecutive runs of the fixed test, 0 failures** (run twice — before and after adopting reviewer feedback).
- Full frontend gates: `npx tsc -b` clean; full `vitest run` (16,402 tests across 2 shards, `I18N_BASE_REF` pinned to merge-base) — all pass; `npm run i18n:check` and `npm run i18n:render` both green.
- Backend gates (pinned venv, `flake8==7.1.0`): isort / flake8 / mypy all clean. Full pytest failures are environmental only — the diff touches a single `.tsx` test file that pytest does not collect.
- Pre-push review: two model-pinned read-only reviewers. GPT: PASS. Opus: no blocking findings, 2 advisories — both adopted (mechanism comment corrected to name the synchronous passive-flush invariant; `onTestFinished` restore replacing the in-body `mockRestore` that a failing await would skip).

# Any other suggestions on the work

The `some(type === 'mouseup')` predicate is satisfied by any of the three mount-effect registrations (`pet.tsx`, `useDrag.ts`, `useMouseForward.ts`), which is sound today because they share one synchronous passive pass. If the release listener is ever moved behind a condition or into a later-mounting child, this wait would no longer cover it — the comment in the test documents this so a future triager doesn't rule it out.

Closes #2925
