### PR TITLE
fix(md-notebook): arm the save-failure test's autosave debounce on fake timers (#2914)

### DIFF
--- a/website/src/test/MdNotebookPageCoverage.test.tsx
+++ b/website/src/test/MdNotebookPageCoverage.test.tsx
@@ -913,10 +913,31 @@ describe('MdNotebookPage — settings, guarded mutations and editor keys', () =>
   })
 
   it('surfaces a save failure that is not a disk conflict', async () => {
-    await mountDirty()
-    api.saveNote.mockRejectedValueOnce(new Error('no space left on device'))
-    await userEvent.click(screen.getByRole('button', { name: 'Sync' }))
+    await mountWithNote()
+    await userEvent.click(screen.getByRole('button', { name: 'Markdown source' }))
 
+    // The edit's autosave debounce must be armed on FAKE timers: on real ones
+    // the 1000ms debounce raced the Sync click, and when it fired first its
+    // flushSave consumed the single staged rejection — runSync's setError(null)
+    // then erased the very alert this test waits on. With the debounce pending
+    // on a clock that never advances, only the Sync path can consume it.
+    vi.useFakeTimers()
+    fireEvent.change(rawEditor(), { target: { value: '# Hello\n\nedited in the buffer' } })
+    api.saveNote.mockRejectedValueOnce(new Error('no space left on device'))
+    fireEvent.click(screen.getByRole('button', { name: 'Sync' }))
+    // Drain the microtask chain (runSync → flushSave → rejection) without
+    // reaching SAVE_DEBOUNCE_MS, then hand the clock back for the DOM wait.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    vi.useRealTimers()
+
+    // The alert's presence IS the proof the Sync path consumed the rejection:
+    // had the debounced autosave consumed it instead, runSync's setError(null)
+    // would have erased the banner before this query could see it. A saveNote
+    // call-count assertion would NOT be a stronger pin — earlier tests in this
+    // file leave real 1000ms debounce timers running past their own teardown,
+    // and one landing here inflates the shared mock's count nondeterministically.
     const alert = await screen.findByRole('alert', { timeout: 5_000 })
     expect(alert.textContent).toContain('no space left on device')
   })


### PR DESCRIPTION
# What is the problem?

The test `surfaces a save failure that is not a disk conflict` in `website/src/test/MdNotebookPageCoverage.test.tsx` is flaky in CI (shard 4): `findByRole('alert')` intermittently times out even though the production code is correct.

# Why this issue matters to the user

A flaky required check blocks unrelated PRs, trains contributors to re-run reds instead of reading them, and hides real regressions behind "probably the md-notebook flake again".

# How our fix solves it

Symptom → root cause chain:

1. The test mounted a dirty note on **real timers**, arming MdNotebookPage's 1000 ms autosave debounce (`SAVE_DEBOUNCE_MS`).
2. It then clicked Sync via `userEvent.click`, whose internal awaits yield to the event loop. Under CI load the debounce fired inside one of those yields.
3. The debounce's `flushSave` consumed the single staged `saveNote` rejection; `runSync` then ran `setError(null)`, erasing the very alert the test was waiting on.

Fix: the edit is armed on **fake timers** and Sync is clicked with `fireEvent` — synchronous, so there is zero event-loop yield between the edit and `runSync`'s `clearTimeout` of the debounce. Only the Sync path can consume the staged rejection. The microtask chain is drained with `advanceTimersByTimeAsync(0)`, then the clock is handed back to real timers for the DOM wait. No retry, no widened wait, no relaxed assertion.

The alert assertion itself pins which path consumed the rejection: a debounce consumption would have erased the banner. A `saveNote` call-count assertion was evaluated and deliberately **not** added — stack instrumentation (`listOnTimeout` → debounce callback of an unmounted prior render) proved that earlier tests in this file leave real 1000 ms debounce timers running past their own teardown, so a global call count on the shared mock is nondeterministic for reasons unrelated to this test. That cross-test timer leakage is filed separately.

# What tests we did

- The fixed test run 30/30 consecutive times green (previously ~1-in-10 failure under load with the original shape).
- Full frontend suite: 995 files / 16,329 tests green with `I18N_BASE_REF` pinned to the merge base; `npx tsc -b` clean.
- Backend gates (diff touches zero backend files): isort / flake8 7.1.0 / mypy 1.14.1 all green on pinned versions.
- Local model-pinned reviews: GPT (gpt-5.6-sol) PASS, Opus (claude-opus-5) PASS.

# Manual verification

N/A — test-only change; the 30x repeat run is the verification the issue asks for.

# Any other suggestions on the work

The leaked cross-test debounce timers (tests arming `window.setTimeout` debounces that survive component unmount) are a suite-wide hygiene issue that can pollute any test asserting on the shared `api.saveNote` mock; follow-up issue to be filed rather than widening this PR.

Closes #2914
