### PR TITLE
feat(telegram): use sendRichMessage for table rendering

### DIFF
--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -58,6 +58,11 @@ _API_BASE = "https://api.telegram.org/bot{token}/{method}"
 #: Consecutive polling failures before the status callback reports unhealthy.
 _STATUS_FAILURE_THRESHOLD = 3
 
+#: Consecutive sendRichMessage 400s before we treat the method as unavailable.
+#: 400 is ambiguous -- a wrong payload shape fails every call, one oversized or
+#: 20+-column table fails only itself -- so latch on a streak, not one answer.
+_RICH_400_LATCH = 3
+
 #: Telegram's supported HTML tag set. Anything we may have to re-close when a
 #: rendered message has to be truncated mid-document.
 _TG_HTML_TAG_RE = re.compile(r"<(/?)([a-zA-Z][a-zA-Z0-9-]*)[^>]*>")
@@ -297,6 +302,12 @@ class TelegramClient:
         self._task: asyncio.Task[None] | None = None
         self._closed = False
         self._offset: int = 0
+        #: Latched True once sendRichMessage is known unavailable on this
+        #: server -- see send_rich_message for the error taxonomy.
+        self._rich_unsupported = False
+        #: Consecutive sendRichMessage 400s. A wrong payload shape fails every
+        #: call and latches; one bad table is cleared by the next good send.
+        self._rich_400_streak = 0
         # Optional health callback: called with (healthy, reason) when polling
         # transitions to persistently-failing or recovers. Set by the gateway
         # to keep the settings status badge truthful after startup.
@@ -397,6 +408,77 @@ class TelegramClient:
             params.pop("parse_mode", None)
             result = await self._api("sendMessage", params)
         return result.get("message_id") if result else None
+
+    async def send_rich_message(
+        self,
+        chat_id: int,
+        markdown: str,
+        *,
+        reply_markup: dict | None = None,
+        message_thread_id: int | None = None,
+        disable_notification: bool = False,
+    ) -> int | None:
+        """Send a Rich Message (Bot API 10.1+). Returns message_id on success.
+
+        Rich Messages natively render tables, headings, code blocks, lists, and
+        other structured markdown that the legacy sendMessage + parse_mode=HTML
+        cannot represent. The *markdown* field accepts standard GitHub-Flavored
+        Markdown including pipe-table syntax.
+
+        Pass ``disable_notification`` when this send REPLACES a message the user
+        was already notified about, so replacing a bubble does not ping twice.
+
+        Returns None on failure so the caller can fall back to sendMessage.
+
+        Availability is *learned*. A server that does not implement the method
+        rejects every call identically, so re-probing it per table would burn a
+        wasted round-trip forever; ``_rich_unsupported`` latches instead:
+
+        * **401/403/404 and any other 4xx except 400/429** -- server- or
+          auth-level, identical for every message: latch immediately.
+        * **400** -- ambiguous. It is what a wrong payload shape returns (every
+          call fails, so it must latch) but ALSO what one oversized or
+          20+-column table returns (content-specific, so it must NOT latch or a
+          single bad message disables rich rendering for the whole process).
+          Resolved by counting CONSECUTIVE 400s and latching at
+          ``_RICH_400_LATCH``: a wrong payload shape reaches that immediately,
+          while one bad table is cleared by the next table that sends.
+        * **429, 5xx, transport errors** -- transient: never latch, and clear
+          the 400 streak so unrelated failures cannot accumulate into a latch.
+        """
+        if self._rich_unsupported:
+            return None
+        params: dict[str, Any] = {
+            "chat_id": chat_id,
+            "rich_message": {"markdown": markdown},
+        }
+        if message_thread_id is not None:
+            params["message_thread_id"] = message_thread_id
+        if reply_markup:
+            params["reply_markup"] = reply_markup
+        if disable_notification:
+            params["disable_notification"] = True
+        err: dict[str, Any] = {}
+        result = await self._api("sendRichMessage", params, err_out=err)
+        if result:
+            self._rich_400_streak = 0
+            return result.get("message_id")
+        code = err.get("error_code")
+        if isinstance(code, int) and 400 <= code < 500 and code != 429:
+            if code == 400:
+                self._rich_400_streak += 1
+                if self._rich_400_streak < _RICH_400_LATCH:
+                    return None
+            logger.info(
+                "sendRichMessage unavailable on this Bot API server (code=%s); "
+                "falling back to HTML for the rest of the process.",
+                code,
+            )
+            self._rich_unsupported = True
+        else:
+            # Transient (429 / 5xx / transport): keep rich enabled.
+            self._rich_400_streak = 0
+        return None
 
     async def send_message_draft(
         self,
@@ -962,7 +1044,13 @@ class TelegramClient:
         return self._session
 
     async def _api(
-        self, method: str, params: dict, timeout: int = 30, *, record: bool = True
+        self,
+        method: str,
+        params: dict,
+        timeout: int = 30,
+        *,
+        record: bool = True,
+        err_out: dict | None = None,
     ) -> Any:
         """Call a Bot API method. Returns the 'result' field or None on error.
 
@@ -970,6 +1058,12 @@ class TelegramClient:
         we simply dropped would freeze the streaming bubble until the next
         chunk, which reads as a stutter -- so we wait out the (usually short)
         cool-down once and retry instead.
+
+        ``err_out``, when supplied, is populated with ``error_code`` and
+        ``description`` on a Telegram-level failure. Callers use it to tell a
+        PERMANENT failure (the method does not exist on this server) apart from
+        a transient one (rate limit, network), so they can stop re-probing an
+        unsupported method without disabling it on a blip.
         """
         session = await self._ensure_session()
 
@@ -1021,6 +1115,9 @@ class TelegramClient:
                         continue
                     if record:
                         _record_api_duration(method, _elapsed_ms(), ok=False, err_code=err_code)
+                    if err_out is not None:
+                        err_out["error_code"] = err_code
+                        err_out["description"] = err_desc
                     logger.warning(
                         "Telegram API %s failed: code=%s desc=%s",
                         method,

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -238,6 +238,109 @@ _ITALIC_USCORE_RE = re.compile(r"(?<!\w)_(?!\s)([^_\n]+?)(?<!\s)_(?!\w)")
 _LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
 _BULLET_RE = re.compile(r"^(\s*)[-*+]\s+", re.MULTILINE)
 
+# Characters a GFM separator row may contain (`| --- |`, `|:---|---:|`, `- | -`).
+_TABLE_SEP_CHARS = set("-:| \t")
+
+
+#: A line that opens or closes a fenced code block.
+_FENCE_LINE_RE = re.compile(r"^[ \t]*(?:`{3,}|~{3,})", re.MULTILINE)
+
+
+def _is_table_separator(line: str) -> bool:
+    """True if *line* is a GFM separator row (``| --- |``, ``---|---``)."""
+    stripped = line.strip()
+    if not stripped or not set(stripped) <= _TABLE_SEP_CHARS:
+        return False
+    return "-" in stripped and "|" in stripped
+
+
+def _has_table(text: str) -> bool:
+    """True if *text* contains a GFM pipe table.
+
+    A table is a line holding at least one ``|`` immediately followed by a
+    separator row. Outer pipes are optional on BOTH rows, because GFM accepts
+    ``a | b`` / ``--- | ---`` with no leading or trailing pipe -- anchoring on a
+    leading ``|`` silently missed those and rendered them as literal pipes.
+
+    The separator row must contain a dash (so it is a separator, not more data)
+    and a pipe (so a bare ``-----`` horizontal rule under a pipe-bearing
+    sentence is not mistaken for a table).
+
+    Deliberately does NOT exclude fenced code blocks. Table markup inside a
+    fence only means one extra rich send, not wrong output: Rich Markdown parses
+    fences itself and renders the sample as the code block it is. Screening for
+    fences here would mean maintaining CommonMark's fence rules (delimiter
+    character, run length, indentation, info strings) as a second parser beside
+    the one the HTML renderer already owns, and every gap between the two is a
+    bug -- for a check whose only job is deciding which transport to use.
+    """
+    lines = text.split("\n")
+    return any(
+        "|" in header and _is_table_separator(sep) for header, sep in zip(lines, lines[1:])
+    )
+
+
+def _seal_table_fallback(text: str) -> str:
+    """Render *text* for the no-Rich-Messages path: tables monospace, prose rich.
+
+    Reached only when ``sendRichMessage`` failed, which -- if this server never
+    supports it -- is the PERMANENT path for every table-bearing reply, so it
+    has to render at least as well as the plain HTML seal it replaces.
+
+    Wrapping the whole segment in one ``<pre>`` does not: a reply of three
+    paragraphs plus one small table would lose every bold, link and inline code
+    span and arrive as a monospace block showing literal ``**`` markers -- worse
+    than the ragged-pipes-but-formatted output it was meant to improve on. So
+    only the table runs are wrapped; surrounding prose keeps the normal HTML
+    rendering, and the table at least keeps its columns aligned.
+
+    A segment containing ANY code fence is handed to ``_md_to_telegram_html``
+    whole and never split. Splitting means rendering the pieces with separate
+    calls, so a cut that lands inside a fence tears the block in half and leaks
+    its delimiters -- and deciding reliably where a fence begins and ends means
+    reimplementing CommonMark's fence rules (delimiter character, run length,
+    indentation, info strings) as a SECOND parser that must agree with the one
+    the HTML renderer already uses. Declining to split is the cheap invariant
+    that removes the whole failure class: a fenced reply then renders exactly as
+    it does on the unmodified path, only without table alignment.
+    """
+    if _FENCE_LINE_RE.search(text):
+        return _md_to_telegram_html(text)
+    lines = text.split("\n")
+    parts: list[str] = []
+    prose: list[str] = []
+    i = 0
+
+    def _flush_prose() -> None:
+        if prose:
+            rendered = _md_to_telegram_html("\n".join(prose))
+            if rendered:
+                parts.append(rendered)
+            prose.clear()
+
+    while i < len(lines):
+        # A table starts on a pipe-bearing line whose successor is a separator.
+        # No fence can appear here -- a fenced segment returned above.
+        if (
+            "|" in lines[i]
+            and i + 1 < len(lines)
+            and _is_table_separator(lines[i + 1])
+        ):
+            _flush_prose()
+            block = [lines[i], lines[i + 1]]
+            i += 2
+            # Body rows run until the first line that is not part of the table.
+            while i < len(lines) and "|" in lines[i]:
+                block.append(lines[i])
+                i += 1
+            parts.append(f"<pre>{html.escape(chr(10).join(block))}</pre>")
+            continue
+        prose.append(lines[i])
+        i += 1
+
+    _flush_prose()
+    return "\n".join(p for p in parts if p)
+
 
 def _md_to_telegram_html(text: str) -> str:
     """Translate the agent's Markdown into Telegram's supported HTML subset."""
@@ -650,7 +753,54 @@ class TelegramRenderer(Renderer):
             if keyboard is None:
                 return
             text = "…"
-        html_text = _md_to_telegram_html(text)
+
+        # --- Rich Message path: tables detected → sendRichMessage (Bot API 10.1+) ---
+        # Rich Markdown renders pipe tables natively; the legacy HTML subset
+        # cannot express a table at all, so a table sealed through HTML always
+        # reaches the user as literal `|` characters.
+        #
+        # There is no editRichMessage, so a segment that already streamed a
+        # plaintext bubble cannot be *edited* into a rich one -- it has to be
+        # replaced. Order matters: SEND the rich message first and only delete
+        # the streamed bubble once it succeeded. Deleting first would lose the
+        # answer outright if the rich send then failed.
+        #
+        # Replacing means Telegram notifies twice: once for the streamed bubble,
+        # once for its replacement. The bubble already pinged the user, so the
+        # replacement is sent silently -- otherwise every table reply buzzes
+        # twice where main buzzed once. When nothing streamed there was no
+        # earlier ping, so the rich send is the only notification and must fire.
+        if _has_table(text):
+            mid = await self._client.send_rich_message(
+                self._chat_id,
+                text,
+                reply_markup=keyboard,
+                message_thread_id=self._thread_id,
+                disable_notification=self._stream_mid is not None,
+            )
+            if mid is not None:
+                if self._stream_mid is not None:
+                    # The rich message now carries this segment; drop the
+                    # superseded plaintext bubble so the user sees one message.
+                    await self._client.delete_message(self._chat_id, self._stream_mid)
+                    self._stream_mid = None
+                return
+            # Rich send failed -- the streamed bubble (if any) is untouched, so
+            # fall through and seal it the legacy way. Only the table runs are
+            # wrapped in <pre>; prose around them keeps its normal formatting,
+            # so this path never renders worse than the plain HTML seal.
+            #
+            # The segment was already sized against the plain HTML render, and
+            # <pre> wrapping only ADDS characters, so on a near-limit reply the
+            # wrapped form can overflow _rendered_limit() and have its tail cut
+            # by _cap_text(). Losing the end of the answer is worse than losing
+            # column alignment, so fall back to the plain render when it spills.
+            logger.debug("sendRichMessage failed for chat %s, falling back to HTML", self._chat_id)
+            html_text = _seal_table_fallback(text)
+            if len(html_text) > self._rendered_limit():
+                html_text = _md_to_telegram_html(text)
+        else:
+            html_text = _md_to_telegram_html(text)
         if self._stream_mid is not None:
             ok = await self._client.edit_message(
                 self._chat_id,

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -52,9 +52,11 @@ from kiro_crew.telegram.renderer import (
     TelegramApprovalDecider,
     TelegramRenderer,
     _extract_options,
+    _has_table,
     _may_exceed_rendered,
     _md_to_telegram_html,
     _rendered_len,
+    _seal_table_fallback,
     _split_markdown,
     _split_markdown_bounded,
     _split_text,
@@ -92,6 +94,13 @@ class FakeClient:
         self.send_threads: list[Any] = []
         self.typing_threads: list[Any] = []
         self._mid = 100
+        #: (markdown, reply_markup, thread) per sendRichMessage call.
+        self.rich_sent: list[tuple[str, Any, Any]] = []
+        self.rich_silent: list[bool] = []
+        #: message_ids passed to deleteMessage.
+        self.deleted: list[int] = []
+        #: When True, send_rich_message reports failure (server lacks the API).
+        self.rich_fails = False
 
     async def send_typing(self, chat_id: int, *, message_thread_id: Any = None) -> None:
         self.typing_threads.append(message_thread_id)
@@ -148,6 +157,26 @@ class FakeClient:
 
     async def answer_callback(self, callback_query_id: str, text: str = "") -> None:
         self.answered.append(callback_query_id)
+
+    async def send_rich_message(
+        self,
+        chat_id: int,
+        markdown: str,
+        *,
+        reply_markup: Any = None,
+        message_thread_id: Any = None,
+        disable_notification: bool = False,
+    ) -> Any:
+        await asyncio.sleep(0)  # yield like a real network await
+        if self.rich_fails:
+            return None
+        self._mid += 1
+        self.rich_silent.append(disable_notification)
+        self.rich_sent.append((markdown, reply_markup, message_thread_id))
+        return self._mid
+
+    async def delete_message(self, chat_id: int, message_id: int) -> None:
+        self.deleted.append(message_id)
 
     async def set_message_reaction(self, chat_id: int, message_id: int, emoji: str) -> None:
         self.reactions.append((message_id, emoji))
@@ -1051,6 +1080,278 @@ class TestTransportReceive:
 
 
 class TestRenderer:
+    def test_a_streamed_table_reply_still_goes_out_as_a_rich_message(self) -> None:
+        # THE regression this feature exists to prevent. A normal agent reply
+        # streams, so _stream_live has already sent a plaintext bubble and set
+        # _stream_mid by the time the segment is sealed. Gating the rich path on
+        # "_stream_mid is None" therefore skipped every real reply and the table
+        # reached the user as literal pipes -- the feature was dead in the only
+        # case that matters. Assert the rich send happens even though a bubble
+        # was streamed, and that the superseded bubble is deleted so the user is
+        # left with exactly one message.
+        table = "Here you go:\n\n| a | b |\n| --- | --- |\n| 1 | 2 |"
+        cli = FakeClient()
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk(table)
+            await r._stream_live(force=True)  # force the live bubble to exist
+            assert r._stream_mid is not None, "precondition: a bubble streamed"
+            await r._seal_current()
+
+        asyncio.run(_go())
+
+        assert len(cli.rich_sent) == 1, "table must be sealed via sendRichMessage"
+        assert "| a | b |" in cli.rich_sent[0][0], "raw markdown table is passed through"
+        assert cli.deleted, "the superseded plaintext bubble must be deleted"
+        assert r._stream_mid is None, "stream id cleared after the bubble is dropped"
+
+    def test_a_table_reply_falls_back_to_html_when_rich_is_unavailable(self) -> None:
+        # If sendRichMessage fails, the streamed bubble must survive and be
+        # sealed the legacy way. Losing the answer is far worse than a table
+        # that degrades to literal pipes, so the delete must NOT have happened.
+        table = "| a | b |\n| --- | --- |\n| 1 | 2 |"
+        cli = FakeClient()
+        cli.rich_fails = True
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk(table)
+            await r._stream_live(force=True)
+            await r._seal_current()
+
+        asyncio.run(_go())
+
+        assert cli.rich_sent == [], "rich send reported failure"
+        assert not cli.deleted, "a failed rich send must never delete the answer"
+        assert cli.edits, "the streamed bubble is still sealed via the HTML path"
+
+    def test_a_reply_without_a_table_never_touches_the_rich_api(self) -> None:
+        # Rich Messages are reserved for content the HTML subset cannot express.
+        # An ordinary reply must take the unchanged HTML path, so the new code
+        # adds zero API calls to the common case.
+        cli = FakeClient()
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk("just a plain **bold** answer, no table here")
+            await r._stream_live(force=True)
+            await r._seal_current()
+
+        asyncio.run(_go())
+
+        assert cli.rich_sent == [], "no table -> no rich send"
+        assert not cli.deleted, "no table -> the streamed bubble is edited, not replaced"
+
+    def test_table_detection_needs_a_separator_row(self) -> None:
+        # A line of pipes alone is not a table (prose, or a code sample), and
+        # sending it as rich would reflow it. Only a header + separator pair is.
+        assert _has_table("| a | b |\n| --- | --- |\n| 1 | 2 |")
+        assert _has_table("| a | b |\n|:---|---:|\n| 1 | 2 |")  # alignment colons
+        assert not _has_table("pipes | in | prose are not a table")
+        assert not _has_table("| a | b |\nno separator row follows")
+
+    def test_table_detection_accepts_gfm_tables_without_outer_pipes(self) -> None:
+        # GFM does not require leading/trailing pipes. Anchoring detection on a
+        # leading `|` silently missed these and shipped them as literal pipes.
+        assert _has_table("a | b\n--- | ---\n1 | 2")
+        assert _has_table("a | b\n---|---\n1 | 2")
+        assert _has_table("  a | b\n  --- | ---\n  1 | 2")  # indented
+        # A pipe-bearing sentence above a horizontal rule is NOT a table: the
+        # separator row has no pipe, so it stays on the ordinary HTML path.
+        assert not _has_table("cost | benefit analysis\n---------------------")
+
+    def test_a_degraded_table_is_sealed_monospace_not_as_ragged_pipes(self) -> None:
+        # When rich is unavailable the table still has to go out, but sealing it
+        # through the normal HTML path reflows it into ragged escaped pipes.
+        # <pre> keeps the columns aligned, so the degraded case stays readable.
+        cli = FakeClient()
+        cli.rich_fails = True
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk("| a | b |\n| --- | --- |\n| 1 | 2 |")
+            await r._stream_live(force=True)
+            await r._seal_current()
+
+        asyncio.run(_go())
+
+        sealed = cli.edits[-1][1]
+        assert "<pre>" in sealed and "</pre>" in sealed
+        assert "| a | b |" in sealed, "the table text survives inside the pre block"
+
+    def test_the_degraded_path_keeps_prose_formatting_around_the_table(self) -> None:
+        # Regression: wrapping the WHOLE segment in <pre> made a prose+table
+        # reply render worse than before the feature existed -- every bold, link
+        # and inline-code span was lost and `**` markers showed up literally.
+        # On a server without Rich Messages this is the permanent path, so it
+        # must never be a downgrade. Only the table run may be monospace.
+        text = "Here is the **summary**:\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n\nSee `docs` too."
+        out = _seal_table_fallback(text)
+
+        assert "<b>summary</b>" in out, "prose keeps its bold"
+        assert "<code>docs</code>" in out, "prose keeps its inline code"
+        assert "**" not in out, "no literal markdown markers leak to the user"
+        # The table is the only monospace run, and it is intact.
+        assert out.count("<pre>") == 1
+        table_block = out.split("<pre>")[1].split("</pre>")[0]
+        assert "| a | b |" in table_block and "| 1 | 2 |" in table_block
+        assert "summary" not in table_block, "prose must not be swallowed into the pre"
+
+    def test_the_degraded_path_handles_a_table_with_no_surrounding_prose(self) -> None:
+        # The bare-table case must not emit stray empty prose fragments.
+        out = _seal_table_fallback("| a | b |\n| --- | --- |\n| 1 | 2 |")
+        assert out.startswith("<pre>") and out.endswith("</pre>")
+        assert out.count("<pre>") == 1
+
+    def test_a_degraded_mixed_reply_keeps_its_prose_formatting_end_to_end(self) -> None:
+        # Pins the SEAL PATH, not just the helper: _seal_current must route the
+        # failed-rich case through the mixed-segment renderer. Asserting only on
+        # _seal_table_fallback() left the call site free to wrap the whole
+        # segment in <pre> again, which is exactly the regression to prevent.
+        cli = FakeClient()
+        cli.rich_fails = True
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk("The **key** result:\n\n| a | b |\n| --- | --- |\n| 1 | 2 |")
+            await r._stream_live(force=True)
+            await r._seal_current()
+
+        asyncio.run(_go())
+
+        sealed = cli.edits[-1][1]
+        assert "<b>key</b>" in sealed, "prose bold survives the degraded seal"
+        assert "**" not in sealed, "no literal markdown markers reach the user"
+        assert "<pre>" in sealed, "the table run is still monospace"
+        assert "key" not in sealed.split("<pre>")[1], "prose not swallowed into the pre"
+
+    def test_a_near_limit_degraded_reply_is_not_truncated_by_pre_overhead(self) -> None:
+        # The segment was sized against the PLAIN html render, and <pre> wrapping
+        # only adds characters, so on a near-limit reply the wrapped form can
+        # spill past the rendered ceiling and have its tail cut by _cap_text().
+        # Losing the end of the answer is worse than losing column alignment, so
+        # the plain render must win once the wrapped form would overflow.
+        cli = FakeClient()
+        cli.rich_fails = True
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+
+        # Many small tables: source stays under the plaintext rotate threshold
+        # while each table adds <pre></pre> overhead to the wrapped form.
+        one = "| a | b |\n| - | - |\n| 1 | 2 |\n\n"
+        text = one * (r._limit() // len(one) - 1)
+        assert len(_seal_table_fallback(text)) > r._rendered_limit(), (
+            "precondition: the wrapped form must overflow for this to test anything"
+        )
+        assert len(_md_to_telegram_html(text)) <= r._rendered_limit(), (
+            "precondition: the plain render must fit"
+        )
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk(text)
+            await r._seal_current()
+
+        asyncio.run(_go())
+
+        sealed = cli.final_text()
+        assert len(sealed) <= r._rendered_limit(), "degraded seal respects the rendered cap"
+        assert "<pre>" not in sealed, "overflowing wrap is dropped for the plain render"
+
+    def test_fenced_table_markup_costs_a_rich_send_but_never_wrong_output(self) -> None:
+        # Detection is deliberately fence-agnostic: a fenced sample of table
+        # markup does take the rich path, but Rich Markdown parses the fence
+        # itself and renders it as the code block it is. The cost is one extra
+        # send, not wrong output -- and it buys not maintaining a second
+        # CommonMark fence parser beside the HTML renderer's own.
+        fenced = "Example:\n\n```\n| a | b |\n| --- | --- |\n| 1 | 2 |\n```\n\ndone"
+        assert _has_table(fenced), "detection does not screen fences"
+        # A real table after a closed fence is of course still found.
+        assert _has_table(fenced + "\n\n| x | y |\n| --- | --- |\n| 1 | 2 |")
+
+    def test_the_degraded_path_never_splits_a_code_fence(self) -> None:
+        # The safety net lives on the FALLBACK side: a fenced segment renders
+        # whole via the normal path, so no fence can be torn in half.
+        fenced = "Example:\n\n```\n| a | b |\n| --- | --- |\n| 1 | 2 |\n```\n\ndone"
+        out = _seal_table_fallback(fenced)
+        assert out == _md_to_telegram_html(fenced), "rendered whole, unsplit"
+        assert "&#x60;" not in out and "```" not in out, "no literal fence markers leak"
+
+    def test_replacing_a_streamed_bubble_does_not_ping_the_user_twice(self) -> None:
+        # send-rich-then-delete means two messages exist briefly and Telegram
+        # notifies for each. The bubble already pinged, so the replacement must
+        # be silent -- otherwise every table reply buzzes twice where main
+        # buzzed once, a regression introduced by replacing instead of editing.
+        cli = FakeClient()
+        r = TelegramRenderer(cli, 71, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk("| a | b |\n| --- | --- |\n| 1 | 2 |")
+            await r._stream_live()  # streams the bubble -> user is pinged
+            await r._seal_current()
+
+        asyncio.run(_go())
+        assert cli.rich_sent, "rich send happened"
+        assert cli.rich_silent == [True], "the replacement is silent"
+
+    def test_a_table_that_never_streamed_still_notifies(self) -> None:
+        # No bubble streamed -> no earlier ping, so the rich send is the user's
+        # ONLY notification. Suppressing it here would deliver the answer
+        # silently and the reply would go unnoticed.
+        cli = FakeClient()
+        r = TelegramRenderer(cli, 72, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            # Throttle out the live frame -- the "segment never streamed"
+            # case named in _seal_current's docstring.
+            r._last_edit = time.monotonic()
+            await r.on_text_chunk("| a | b |\n| --- | --- |\n| 1 | 2 |")
+            assert r._stream_mid is None, "precondition: nothing streamed"
+            await r._seal_current()
+
+        asyncio.run(_go())
+        assert cli.rich_sent, "rich send happened"
+        assert cli.rich_silent == [False], "the only message must notify"
+
+    def test_a_fenced_reply_is_never_split_by_the_degraded_path(self) -> None:
+        # Splitting renders the pieces with separate _md_to_telegram_html calls,
+        # so a cut inside a fence tears the block and leaks its delimiters.
+        # Deciding where a fence starts/ends reliably means reimplementing
+        # CommonMark as a second parser; declining to split removes the class.
+        # These are the exact shapes that each defeated a hand-rolled parser:
+        cases = [
+            # plain fenced table markup
+            "Example:\n\n```\n| a | b |\n| --- | --- |\n| 1 | 2 |\n```\n\ndone",
+            # a ~~~ line inside a ``` block (mismatched delimiter)
+            "How:\n\n```\n~~~\n| a | b |\n| --- | --- |\n```\n\ndone",
+            # an info string on an inner delimiter
+            "How:\n\n```\n```python\n| a | b |\n| --- | --- |\n```\n\ndone",
+            # a longer opener closed only by a shorter run
+            "````\n```\n| a | b |\n| --- | --- |\n",
+            # a block fenced with tildes only -- the guard must cover both
+            # delimiter characters, not just backticks
+            "Example:\n\n~~~\n| a | b |\n| --- | --- |\n| 1 | 2 |\n~~~\n\ndone",
+        ]
+        for text in cases:
+            out = _seal_table_fallback(text)
+            assert out == _md_to_telegram_html(text), (
+                f"a fenced segment must render whole, unsplit: {text!r}"
+            )
+
+    def test_the_degraded_path_still_aligns_tables_with_no_fence_present(self) -> None:
+        # The no-split rule must not disable the feature for ordinary replies.
+        text = "Here:\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n\n**after**"
+        out = _seal_table_fallback(text)
+        assert "<pre>" in out, "a fence-free table still gets monospace alignment"
+        assert "<b>after</b>" in out, "prose around it keeps its formatting"
+
     def test_strip_steering_complete_and_unclosed(self) -> None:
         # Complete marker is removed anywhere in the text.
         out = _strip_steering("BANANA [STEERING steer-x: rephrase] tail")
@@ -3400,6 +3701,80 @@ class TestForumCallbackGate:
 
         assert asyncio.run(_go()) is False
         assert cli.answered == []
+
+
+class TestRichMessageAvailabilityLatch:
+    """sendRichMessage learns whether the server implements the method."""
+
+    def _client(self):
+        from kiro_crew.telegram.client import TelegramClient
+
+        return TelegramClient(token="12345:testtoken")
+
+    def _stub(self, client, monkeypatch, codes: list[int | None]) -> list[str]:
+        """Make _api fail with each code in turn; record the methods called."""
+        calls: list[str] = []
+        seq = list(codes)
+
+        async def _api(method, params, timeout=30, *, record=True, err_out=None):
+            calls.append(method)
+            code = seq.pop(0) if seq else None
+            if code is None:
+                return {"message_id": 7}
+            if err_out is not None:
+                err_out["error_code"] = code
+                err_out["description"] = "stub failure"
+            return None
+
+        monkeypatch.setattr(client, "_api", _api)
+        return calls
+
+    def test_a_404_latches_immediately_and_stops_re_probing(self, monkeypatch) -> None:
+        # A server without the method rejects every call the same way, so
+        # re-probing per table would waste a round-trip forever.
+        c = self._client()
+        calls = self._stub(c, monkeypatch, [404])
+        assert asyncio.run(c.send_rich_message(1, "| a |\n| - |")) is None
+        assert c._rich_unsupported is True
+        # Second call must short-circuit without touching the API at all.
+        assert asyncio.run(c.send_rich_message(1, "| a |\n| - |")) is None
+        assert calls == ["sendRichMessage"], "latched: no second request"
+
+    def test_a_429_never_latches(self, monkeypatch) -> None:
+        # Rate limiting is transient. Disabling rich rendering for the process
+        # because of one 429 would be a permanent penalty for a momentary limit.
+        c = self._client()
+        calls = self._stub(c, monkeypatch, [429, None])
+        assert asyncio.run(c.send_rich_message(1, "| a |\n| - |")) is None
+        assert c._rich_unsupported is False
+        assert asyncio.run(c.send_rich_message(1, "| a |\n| - |")) == 7
+        assert len(calls) == 2, "still probing after a transient failure"
+
+    def test_one_400_does_not_latch_but_a_streak_does(self, monkeypatch) -> None:
+        # 400 is ambiguous: a wrong payload shape fails EVERY call, while one
+        # oversized table fails only itself. Latch on the streak so a single bad
+        # message cannot disable rich rendering for the whole process.
+        from kiro_crew.telegram.client import _RICH_400_LATCH
+
+        c = self._client()
+        self._stub(c, monkeypatch, [400] * _RICH_400_LATCH)
+        for _ in range(_RICH_400_LATCH - 1):
+            assert asyncio.run(c.send_rich_message(1, "| a |\n| - |")) is None
+            assert c._rich_unsupported is False, "one bad table must not latch"
+        assert asyncio.run(c.send_rich_message(1, "| a |\n| - |")) is None
+        assert c._rich_unsupported is True, "a persistent 400 latches"
+
+    def test_a_successful_send_clears_the_400_streak(self, monkeypatch) -> None:
+        # Two unrelated bad tables spread over a session must not accumulate
+        # into a latch when good tables send in between.
+        from kiro_crew.telegram.client import _RICH_400_LATCH
+
+        c = self._client()
+        self._stub(c, monkeypatch, [400, None] * _RICH_400_LATCH)
+        for _ in range(_RICH_400_LATCH):
+            asyncio.run(c.send_rich_message(1, "| a |\n| - |"))  # 400
+            asyncio.run(c.send_rich_message(1, "| a |\n| - |"))  # success
+        assert c._rich_unsupported is False, "streak reset by each success"
 
 
 class TestClientHealth:


### PR DESCRIPTION
## What is the problem?

Agent output containing a markdown table reaches Telegram as literal `|` characters. The seal path renders through Telegram's HTML subset (`<b>/<i>/<code>/<pre>/<a>/<blockquote>`), which has no table construct at all, so pipe characters are escaped as ordinary text.

## Why this issue matters to the user

Tables are how the agent presents comparisons, mappings, and any structured result. On Telegram every one of them arrives as an unaligned wall of pipes, which reads as the bot being broken rather than as a formatting limitation.

## How our fix solves it

Bot API 10.1 added **Rich Messages**, whose Rich Markdown renders GFM pipe tables natively. The fix detects a table in the sealed segment and sends it via `sendRichMessage`, handing over the agent's raw markdown unchanged — Rich Markdown is a GFM superset, so no conversion step is needed.

The chain from symptom to root cause:

1. **Symptom** — pipes visible in the message.
2. **Cause** — `_md_to_telegram_html()` cannot express a table, and `html.escape()` passes `|` through as text.
3. **Fix** — bypass the HTML subset for table-bearing segments and use the API that models tables.

Four details the design turns on:

- **There is no `editRichMessage`.** A segment that already streamed a plaintext bubble cannot be edited into a rich one, it has to be *replaced*. The rich message is sent **first** and the superseded bubble deleted only once that succeeded — deleting first would lose the answer outright on a failed rich send.
- **Replacing must not double-ping.** Telegram notifies for both messages, so the replacement is sent with `disable_notification` — the bubble already pinged the user, and without this every table reply would buzz twice where `main` buzzed once. A segment that never streamed has had no earlier ping, so its rich send is the only notification and is left audible.
- **A segment containing any code fence is rendered whole and never split.** Splitting renders the pieces with separate calls, so a cut inside a fence tears the block and leaks its delimiters. Deciding reliably where a fence begins and ends means reimplementing CommonMark's rules (delimiter character, run length, indentation, info strings) as a *second* parser that must agree with the one the HTML renderer already owns — three review rounds each found a different gap between the two before that parser was dropped for this one-line invariant. Detection is therefore deliberately fence-agnostic: table markup inside a fence costs one extra rich send, not wrong output, because Rich Markdown parses fences itself.
- **A failed rich send is never fatal.** It falls through to the HTML seal, wrapped in `<pre>` so the degraded table stays monospace and column-aligned rather than reflowing into ragged escaped pipes.
- **Availability is learned, not assumed.** 4xx other than 400/429 latch immediately — server- or auth-level, identical for every message. `400` is ambiguous: a wrong payload shape fails *every* call (must latch) but one oversized or 20+-column table fails only itself (must not latch, or a single bad message disables rich rendering for the process). It therefore latches on a **streak of three**, which any successful send resets. 429/5xx/transport never latch.
- **Detection accepts GFM tables with no outer pipes** (`a | b` over `--- | ---`); requiring a leading `|` silently missed them. The separator row must contain both a dash and a pipe, so a horizontal rule under a pipe-bearing sentence is not mistaken for a table.

Replies without a table take the unchanged HTML path, so the common case gains zero API calls.

## What tests we did

Ten new cases in `test/test_telegram.py`:

| Test | Pins |
|---|---|
| `test_a_streamed_table_reply_still_goes_out_as_a_rich_message` | the case that actually matters — a real reply has already streamed a bubble when it is sealed |
| `test_a_table_reply_falls_back_to_html_when_rich_is_unavailable` | the answer survives a failed rich send; no delete happens |
| `test_a_reply_without_a_table_never_touches_the_rich_api` | no added API calls in the common case |
| `test_a_degraded_table_is_sealed_monospace_not_as_ragged_pipes` | `<pre>` fallback keeps columns aligned |
| `test_table_detection_needs_a_separator_row` | prose containing pipes is not a table |
| `test_table_detection_accepts_gfm_tables_without_outer_pipes` | outer pipes are optional on both rows |
| `test_a_404_latches_immediately_and_stops_re_probing` | no wasted round-trip per table on a server without the method |
| `test_a_429_never_latches` | a momentary rate limit is not a permanent penalty |
| `test_one_400_does_not_latch_but_a_streak_does` | one bad table cannot disable the feature; a wrong shape still does |
| `test_a_successful_send_clears_the_400_streak` | unrelated 400s spread over a session do not accumulate |

- **18/18 mutants caught.** One restores gating the rich path on `self._stream_mid is None`, which is the defect Design Review caught on the first revision: because `_stream_live` sends the bubble on the first chunk, that gate excluded every real streamed reply and left the feature dead in the only case that mattered.
- 257 tests pass; `flake8` / `isort` / `mypy` clean.

## Any other suggestions on the work

- **Verified against a live Bot API server.** `sendRichMessage` with `rich_message: {markdown: ...}` returned `HTTP 200 / ok:true` and a real `message_id`, and the table rendered with aligned columns in the client. The method exists and the payload shape in this PR is the accepted one, so the feature is not dead on arrival and the latch is a safety net rather than the expected path.
- `sendRichMessageDraft` could stream rich content live rather than only sealing rich, but it is private-chat-only and needs its own draft lifecycle — separate change.
- **A table too long for one message is a known bound, filed as #3010.** The shared segment splitter cuts it between body rows, so chunk 1 keeps the separator and renders rich while chunk 2+ fall back to literal pipes. Fixing it means sizing table segments against the 32,768-char rich budget instead of the 4,096 HTML one, which changes sizing for every message the renderer sends — too broad to fold in here.
- Only tables trigger the rich path. Headings, task lists, and math are also expressible in Rich Markdown and could route the same way once this lands.
- Unrelated pre-existing flake found while running the gates and filed separately as #2992 (`test_concurrent_queue_adds_share_one_receipt`, reproduced 4/8 on unmodified `main`).

Closes #2958
