### PR TITLE
fix(skills): update theme-pack-authoring variable counts to match 54-entry allowlist (#2966)

### DIFF
--- a/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
+++ b/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: theme-pack-authoring
-description: Build, validate, and install Kiro Crew theme packs -- pack anatomy, the 43-variable palette, role-tagged fonts, the overrides.css allowlist (what installs vs what actually renders), and the install-verify cycle. Use when the user wants to create or edit a theme pack.
+description: Build, validate, and install Kiro Crew theme packs -- pack anatomy, the 54-variable palette, role-tagged fonts, the overrides.css allowlist (what installs vs what actually renders), and the install-verify cycle. Use when the user wants to create or edit a theme pack.
 triggers: theme pack, custom theme, theme.json, variables.json, overrides.css, install theme, theme font, dashboard theme, build a theme
 ---
 
@@ -16,7 +16,7 @@ debugging time.
 ```
 my-theme/
 ├── theme.json          # manifest: slug, name, emoji, level, formatVersion, fonts[]
-├── variables.json      # dark + light palettes (43 allowlisted CSS vars)
+├── variables.json      # dark + light palettes (54 allowlisted CSS vars)
 ├── readme.md           # optional; attribution and notes
 ├── styles/
 │   ├── overrides.css   # optional; scoped structural CSS (see allowlist below)
@@ -68,7 +68,7 @@ a level-0 pack shipping a font is refused.
 
 ## variables.json — the palette
 
-Two blocks, `dark` and `light`, each holding up to **43 allowlisted variables**.
+Two blocks, `dark` and `light`, each holding up to **54 allowlisted variables**.
 Required minimum per block: `--bg`, `--text`, `--accent`. Unknown keys are
 REJECTED (install fails), so do not invent variables; the allowlist is
 `_THEME_CSS_VARS` in `src/kiro_crew/dashboard/theme_validate.py`.
@@ -76,16 +76,10 @@ REJECTED (install fails), so do not invent variables; the allowlist is
 - To clone a built-in theme's palette, transcribe its block from
   `website/src/index.css` (e.g. `[data-theme="kiro-dark"]`), keeping only
   allowlisted vars.
-- Five commonly-wanted vars are NOT in the allowlist: `--accent-fg` and the four
-  `--json-*` highlight colors. Patch them via overrides.css on the pack's own
-  scoped body selector — legal (not a font, `body` is allowlisted):
-
-```css
-[data-theme="custom-my-theme-dark"] body {
-  --accent-fg: #ffffff;
-  --json-key: #b07fff; --json-str: #7ee787; --json-num: #c19aff; --json-bool: #f94359;
-}
-```
+- `--accent-fg` and the four `--json-*` highlight colors (`--json-key`,
+  `--json-str`, `--json-num`, `--json-bool`) are allowlisted — set them directly
+  in `variables.json` like any other palette entry. No overrides.css workaround
+  is needed for them.
 
 ## overrides.css — what installs is NOT what renders
 


### PR DESCRIPTION
# What is the problem?

`main` is red on a deterministic shard-4 test:

```
FAILED test/test_theme_authoring_skill.py::test_variable_count_matches_validator
AssertionError: theme_validate._THEME_CSS_VARS now has 54 entries; update the counts in src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
```

PR #2923 widened the theme CSS allowlist from 43 to 54 entries, but it merged behind a stale base that predated this ratchet test, so the skill doc's `43` references were never updated. Backend Tests (3.10, 4), (3.12, 4), (Windows) (4) and Coverage Gate have failed on every main push and every open PR's merge ref since.

# Why this issue matters to the user

Every open PR inherits this red — CI is currently un-passable repo-wide, which blocks merges and trains contributors to ignore red checks.

# How our fix solves it

The ratchet test pins the skill markdown's stated counts to the live `theme_validate._THEME_CSS_VARS` length. The allowlist is correct at 54; only the doc is stale. This updates the three `43` references (frontmatter description, tree comment, palette prose) to `54`.

# What tests we did

- `test/test_theme_authoring_skill.py` — 3/3 pass locally (was 1 failing on unmodified main).
- Doc-only change (one markdown file); no production code touched.

# Any other suggestions on the work

The root cause — a green PR merging behind the commit that invalidated its assertions — is a merge-queue/stale-base process gap; issue #2966 documents it.

Closes #2966
