### PR TITLE
fix(updates): auto-update toggle can lose a concurrent config write

### DIFF
--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -24,8 +24,7 @@ from kiro_crew.config.loader import (
     ConfigReadError,
     KiroCrewConfig,
     config_path,
-    read_config_for_update,
-    write_config_atomically,
+    update_config_locked,
 )
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.platform.update_governance import (
@@ -721,19 +720,33 @@ async def api_update_auto(request: web.Request) -> web.Response:
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
     enabled = body.get("enabled", True)
-    # Read, modify, write config. The read fails CLOSED: treating an unreadable
-    # config as {} would write back a single-key file and wipe every other
-    # setting the user has (see read_config_for_update).
-    path = config_path()
+
+    def _set_auto_update(data: dict) -> dict:
+        data["auto_update"] = enabled
+        # RETURN it: `update_config_locked` reads a `None` return as "do not write" and
+        # exits with the data untouched, so an in-place-only callback silently drops the
+        # write while still reporting success.
+        return data
+
+    # `update_config_locked` holds the advisory lock across the READ and the write, so no
+    # other process can land between them -- the whole point, since the in-process
+    # `_get_config_lock()` this endpoint used to rely on does not serialize against the CLI
+    # or a second gateway.
+    #
+    # Offloaded because that lock is blocking: called inline from this coroutine it would
+    # stall every session and the liveness heartbeat while contended, which is what the
+    # repo's `no-blocking-call-on-event-loop` rule forbids.
+    #
+    # The read still fails CLOSED (`on_corrupt` defaults to "fail"): treating an unreadable
+    # config as {} would write back a single-key file and wipe every other setting the user
+    # has (see read_config_for_update).
     try:
-        data = read_config_for_update(path)
+        await asyncio.to_thread(update_config_locked, config_path(), mutate=_set_auto_update)
     except ConfigReadError:
         logger.exception("Refusing to toggle auto-update: config is unreadable")
         return web.json_response(
             {"error": "failed to read config file", "code": "config_unreadable"}, status=500
         )
-    data["auto_update"] = enabled
-    write_config_atomically(path, data)
     return web.json_response({"ok": True, "auto_update": enabled})
 
 

--- a/test/test_update_auto_locked.py
+++ b/test/test_update_auto_locked.py
@@ -1,0 +1,76 @@
+"""The auto-update toggle serializes against writers outside this process."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.config import loader as cfg_loader
+
+
+@pytest.fixture()
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    d = tmp_path / "home"
+    d.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(d))
+    cfg = d / "config.json"
+    cfg.write_text(
+        json.dumps({"timezone": "UTC", "auto_update": False, "session": {"timeout_secs": 7200}}),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+def test_a_writer_landing_mid_update_is_not_lost(home: Path) -> None:
+    """The lock spans the read AND the write, so the competing setting survives.
+
+    The competing writer is driven from inside the `mutate` callback -- i.e. at the exact moment
+    the endpoint holds the config open -- because that is the window the old in-process
+    asyncio lock left unprotected. It runs in a thread and must BLOCK on the advisory lock
+    until the callback returns.
+    """
+    landed = threading.Event()
+
+    def competing_writer() -> None:
+        # A separate lock acquisition, exactly as another process would take it.
+        cfg_loader.update_config_locked(
+            home,
+            mutate=lambda d: {**d, "timezone": "Asia/Shanghai"},
+        )
+        landed.set()
+
+    def _toggle(data: dict) -> dict:
+        data["auto_update"] = True
+        t = threading.Thread(target=competing_writer)
+        t.start()
+        # The competing writer must NOT have completed while this callback holds the lock.
+        # A 0.5s window is generous; if it lands, the lock does not span the callback.
+        assert not landed.wait(timeout=0.5), "the competing write landed inside the lock hold"
+        return data
+
+    cfg_loader.update_config_locked(home, mutate=_toggle)
+    # Now it may proceed.
+    assert landed.wait(timeout=10), "the competing writer never completed"
+
+    on_disk = json.loads(home.read_text(encoding="utf-8"))
+    assert on_disk["auto_update"] is True, "the endpoint's own edit was lost"
+    assert on_disk["timezone"] == "Asia/Shanghai", "the competing writer's setting was reverted"
+    assert on_disk["session"]["timeout_secs"] == 7200, "an untouched setting was dropped"
+
+
+def test_an_unreadable_config_refuses_instead_of_resetting(home: Path) -> None:
+    """Fail-closed: a truncated config must not be replaced by a single-key file.
+
+    This is the data-loss shape `read_config_for_update` exists to prevent, and it still holds
+    through the locked primitive because `on_corrupt` defaults to "fail".
+    """
+    home.write_text('{"timezone": "UTC", "auto_upda', encoding="utf-8")
+    before = home.read_text(encoding="utf-8")
+
+    with pytest.raises(cfg_loader.ConfigReadError):
+        cfg_loader.update_config_locked(home, mutate=lambda d: {**d, "auto_update": True})
+
+    assert home.read_text(encoding="utf-8") == before, "the unreadable config was overwritten"


### PR DESCRIPTION
fix(updates): auto-update toggle can lose a concurrent config write

`POST /api/update/auto` read `config.json`, set one key, and wrote the whole dict
back, holding only `_get_config_lock()` — an `asyncio.Lock`. That serializes
coroutines inside ONE gateway process and does nothing against another writer, so a
`kirocrew config set` (or a second gateway) landing between the read and the write was
silently reverted. Part of #2147.

Converted to `update_config_locked`, which #2784 added as the locked primitive for
config.json: it holds an advisory file lock across the READ and the write, so no
writer can land between them and nothing has to be reconstructed afterwards.

Demonstrated rather than assumed. Driving the old shape against a competing writer:

    old shape -> competing setting LOST  (timezone='UTC')
                 endpoint's own edit auto_update=True

The endpoint's write lands and reports success while the other writer's setting is
gone — the exact silent shape #2147 describes.

Three details this conversion turns on, none of them visible from the call line:

* **`mutate` must RETURN the dict.** `update_config_locked` treats a `None` return as
  "do not write" and exits with the data untouched, so the natural in-place callback
  (`def _m(d): d["k"] = v`) silently skips the write while still reporting success.
* **The lock is blocking, so a coroutine must offload it.** Called inline from this
  handler it would stall every session and the liveness heartbeat while contended —
  the repo's `no-blocking-call-on-event-loop` rule. Hence
  `await asyncio.to_thread(...)`. #2784's own four call sites are CLI-synchronous, so
  its migration did not have to answer this; the remaining ones do.
* **The read still fails CLOSED.** `on_corrupt` defaults to `"fail"`, so
  `ConfigReadError` still escapes the lock and the handler's existing 500 branch keeps
  working — treating an unreadable config as `{}` would write back a single-key file
  and wipe every setting the user has.

## Tests

Two new, and the first fails on the pre-migration code:

* a writer that lands between the endpoint's read and its write is not lost — driven
  from inside the `mutate` callback, i.e. exactly the window the `asyncio.Lock` left
  open, and asserting the competing writer BLOCKS until the callback returns;
* an unreadable config still refuses instead of being replaced by a single-key file.

The 92 existing tests across the update/config suites pass unchanged.

## Manual verification

N/A — the concurrency property is what matters here and it is covered by the new
tests, which fail against the old shape for the right reason.

## Scope

One call site. An AST survey of `main` finds 24 remaining `write_config_atomically`
call sites across 11 files, every one targeting `config_path()`, and **12 of them sit
directly inside `async def`**. They are deliberately not in this PR: this one settles
the off-loop pattern on the simplest case — a single-key read-modify-write with
nothing between the read and the write that needs to talk HTTP — before it is
replicated. The others each carry their own wrinkle (a handler returning
`web.json_response` from inside the critical section, a site raising its own
`ConfigCorruptError`, a helper already nested under `_get_config_lock()`), so a
mechanical find-and-replace would break them.
