### PR TITLE
refactor(apps): fold provenance "core" into "official"

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -58,7 +58,8 @@ Frontend badges and affordances read the same three fields
 (`origin === 'builtin'`, `resources === 'app'`, `lifecycle === 'gateway'`,
 `lifecycle !== 'locked'`). Provenance LABELS and the verified badge are a
 separate question: `/api/apps/registry` rows carry server-computed
-`provenance` (`"core" | "external" | "builtin"`) and `verified` fields,
+`provenance` (`"official" | "external" | "builtin"`, with `"core"` accepted by
+clients as the pre-migration spelling of `"official"`) and `verified` fields,
 stamped by `_apply_trust_fields` in `registry.py` where the server-attached
 `_registry` tag is authoritative. The helper OVERWRITES anything an index
 publishes, and derives `verified` from the INDEX-declared author snapshotted
@@ -74,6 +75,15 @@ two-word org name we actually publish mint the mark, and a fullwidth or
 zero-width rendering of our name does not silently lose it. Folding WIDENS the
 match, which is safe only because the `_registry` short-circuit runs first:
 the author is consulted exclusively for rows whose index we ship or sign.
+
+`"official"` means "an app WE list". The bundled `app-registry.json` is one
+delivery of that list — the offline seed shipped inside the wheel — so it
+carries the same value a signed remote catalog will, not a second one. Two
+values for one claim would put a weaker integrity guarantee (it rides on the
+install artifact and cannot be revoked before the next release) behind a label
+the client cannot tell apart from the stronger one. Provenance names WHOSE list
+an app is on; how that list reached the client is a separate axis and belongs in
+a separate field once there is more than one answer to record.
 
 The merge that builds those rows projects the index row explicitly rather than
 copying it: `_merge_manifest` starts from `_REGISTRY_ROW_KEYS` — identity, the

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -1064,7 +1064,21 @@ def _apply_trust_fields(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     - ``provenance``: ``"external"`` when ``_registry`` is set (the tag is
       applied server-side per configured registry and cannot be forged by
       index content); otherwise ``"builtin"`` when ``origin == "builtin"``,
-      else ``"core"`` (bundled ``app-registry.json`` or edition entry).
+      else ``"official"``.
+
+      ``"official"`` means "an app WE list", and the bundled
+      ``app-registry.json`` is one delivery of that list — the offline seed
+      that ships inside the wheel. It answers the same question the remote
+      signed catalog answers, so it gets the same value rather than a second
+      one: two provenance values for one claim would put a weaker integrity
+      guarantee (rides on the install artifact, cannot be revoked before the
+      next release) behind a label a client cannot tell apart from the
+      stronger one. The value names WHOSE list an app is on; how that list
+      reached the client is a separate axis, and belongs in a separate field
+      once there is more than one answer to record.
+
+      ``"core"`` was the previous spelling. Clients accept both during the
+      migration, so an older gateway's rows still label correctly.
     - ``verified``: ``True`` only when provenance is NOT ``"external"`` AND
       (``origin == "builtin"`` or the INDEX-declared author — snapshotted
       into ``_index_author`` by ``list_registry`` before the manifest merge
@@ -1089,7 +1103,7 @@ def _apply_trust_fields(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
             entry.pop("featured", None)
         else:
             builtin = entry.get("origin") == "builtin"
-            entry["provenance"] = "builtin" if builtin else "core"
+            entry["provenance"] = "builtin" if builtin else "official"
             entry["verified"] = builtin or folded_author in FIRST_PARTY_AUTHORS
     return entries
 

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -1229,7 +1229,7 @@ class TestApplyTrustFields:
         entry = {
             "name": "evil-app",
             "_registry": "evil-registry",
-            "provenance": "core",
+            "provenance": "official",
             "verified": True,
         }
         (out,) = registry._apply_trust_fields([entry])
@@ -1241,7 +1241,7 @@ class TestApplyTrustFields:
         (``_index_author``, taken by ``list_registry`` pre-merge)."""
         entry = {"name": "good-app", "_index_author": "KiroCrew"}  # brand-ok: author-spoof fixture
         (out,) = registry._apply_trust_fields([entry])
-        assert out["provenance"] == "core"
+        assert out["provenance"] == "official"
         assert out["verified"] is True
 
     def test_manifest_author_alone_never_mints_verified(self):
@@ -1258,7 +1258,7 @@ class TestApplyTrustFields:
     def test_core_third_party_author_is_not_verified_and_keeps_featured(self):
         entry = {"name": "community-app", "_index_author": "someone", "featured": 2}
         (out,) = registry._apply_trust_fields([entry])
-        assert out["provenance"] == "core"
+        assert out["provenance"] == "official"
         assert out["verified"] is False
         assert out["featured"] == 2  # curator flag preserved for core entries
 
@@ -1273,8 +1273,20 @@ class TestApplyTrustFields:
         degrade to unverified, not raise."""
         entry = {"name": "weird", "_index_author": 42}
         (out,) = registry._apply_trust_fields([entry])
-        assert out["provenance"] == "core"
+        assert out["provenance"] == "official"
         assert out["verified"] is False
+
+    def test_bundled_seed_row_is_official_not_a_separate_value(self):
+        """The bundled ``app-registry.json`` is the OFFLINE SEED of the list we
+        publish, not a different kind of app, so it carries the same provenance
+        a signed remote catalog will. Giving the seed its own value would put a
+        weaker integrity guarantee — it rides on the install artifact and cannot
+        be revoked before the next release — behind a label the client cannot
+        tell apart from the stronger one. Provenance names WHOSE list an app is
+        on; how the list arrived is a separate axis."""
+        entry = {"name": "launchdarkly", "repo": "https://example.com/org/app"}
+        (out,) = registry._apply_trust_fields([entry])
+        assert out["provenance"] == "official"
 
     def test_index_author_snapshot_never_leaks_into_payload(self):
         entry = {"name": "x", "_index_author": "KiroCrew"}  # brand-ok: author-spoof fixture
@@ -1366,7 +1378,7 @@ class TestApplyTrustFields:
         monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
 
         rows = {r["name"]: r for r in await registry.list_registry()}
-        assert rows["core-app"]["provenance"] == "core"
+        assert rows["core-app"]["provenance"] == "official"
         assert rows["core-app"]["verified"] is True
         assert rows["core-app"]["featured"] == 1
         # Manifest-published author does not mint the badge.

--- a/test/test_apps_registry_coverage.py
+++ b/test/test_apps_registry_coverage.py
@@ -962,7 +962,7 @@ class TestApplyTrustFields:
                     "_registry": "third-party",
                     "_index_author": "kirocrew",
                     "verified": True,
-                    "provenance": "core",
+                    "provenance": "official",
                     "featured": True,
                 }
             ]
@@ -986,7 +986,7 @@ class TestApplyTrustFields:
             ]
         )
         assert [r["verified"] for r in rows] == [True, False, False]
-        assert all(r["provenance"] == "core" for r in rows)
+        assert all(r["provenance"] == "official" for r in rows)
 
 
 class TestVersionNewer:

--- a/website/src/components/appstore/types.ts
+++ b/website/src/components/appstore/types.ts
@@ -37,7 +37,9 @@ export type RegistryApp = {
    * present they are authoritative and the client must not re-derive
    * trust from ``_registry`` absence.
    */
-  provenance?: 'core' | 'external' | 'builtin'
+  // 'core' is the pre-migration spelling of 'official'; both mean "an app WE
+  // list", the bundled index being the offline seed of that list.
+  provenance?: 'official' | 'core' | 'external' | 'builtin'
   verified?: boolean
   installed: boolean
   installedVersion?: string
@@ -110,13 +112,20 @@ export type InstalledApp = {
  * server-attached, and a row carrying it is external by construction — so
  * a ``provenance`` value smuggled through an OLDER gateway (which copies
  * index keys verbatim and computes nothing) can never relabel an external
- * row as built-in or core. The ``origin`` fallback exists only for rows
+ * row as built-in or official. The ``origin`` fallback exists only for rows
  * from older gateways that emit neither field.
+ *
+ * ``'core'`` is the previous spelling of ``'official'`` and is accepted for as
+ * long as a client can meet an older gateway. Both mean "an app WE list": the
+ * bundled ``app-registry.json`` is the offline seed of that list, not a
+ * separate kind of app.
  */
 export function sourceLabel(app: Pick<RegistryApp, '_registry' | 'origin' | 'provenance'>): string {
   if (app._registry) return app._registry
   if (app.provenance === 'builtin') return i18nT('components.appstore.types.built_in')
-  if (app.provenance === 'core') return i18nT('components.appstore.types.kirocrew_registry')
+  if (app.provenance === 'official' || app.provenance === 'core') {
+    return i18nT('components.appstore.types.kirocrew_registry')
+  }
   // Legacy fallback (older gateway: no ``provenance`` field).
   if (app.origin === 'builtin') return i18nT('components.appstore.types.built_in')
   return i18nT('components.appstore.types.kirocrew_registry')

--- a/website/src/test/appstoreCategories.test.ts
+++ b/website/src/test/appstoreCategories.test.ts
@@ -153,22 +153,31 @@ describe('server-computed trust fields (issue #580)', () => {
 
   it('sourceLabel prefers the server provenance field', () => {
     expect(sourceLabel({ provenance: 'builtin' })).toBe('Built-in')
-    expect(sourceLabel({ provenance: 'core', origin: 'builtin' })).toBe('Kiro Crew registry')
+    expect(sourceLabel({ provenance: 'official', origin: 'builtin' })).toBe('Kiro Crew registry')
     expect(sourceLabel({ provenance: 'external', _registry: 'labs' })).toBe('labs')
+  })
+
+  it('sourceLabel still accepts the pre-migration "core" spelling', () => {
+    // A newer client can meet an older gateway, which emits 'core' for the same
+    // claim 'official' now carries. Dropping the alias would silently fall the
+    // row through to the origin-based legacy arm.
+    expect(sourceLabel({ provenance: 'core', origin: 'builtin' })).toBe('Kiro Crew registry')
+    expect(sourceLabel({ provenance: 'core' })).toBe('Kiro Crew registry')
   })
 
   it('sourceLabel keeps the _registry name even with a smuggled provenance', () => {
     // Same older-gateway smuggling window: a tagged row is external by
-    // construction, so provenance:"core" from index content cannot relabel it.
+    // construction, so provenance:"official" from index content cannot relabel it.
+    expect(sourceLabel({ provenance: 'official', _registry: 'evil' })).toBe('evil')
     expect(sourceLabel({ provenance: 'core', _registry: 'evil' })).toBe('evil')
   })
 
   it('pickFeatured excludes provenance:"external" rows from curator flags', () => {
     const apps = [
       app({ name: 'external-shouty', featured: 1, provenance: 'external', _registry: 'evil' }),
-      app({ name: 'core-app', featured: 2, provenance: 'core' }),
+      app({ name: 'official-app', featured: 2, provenance: 'official' }),
     ]
-    expect(pickFeatured(apps)[0].name).toBe('core-app')
+    expect(pickFeatured(apps)[0].name).toBe('official-app')
   })
 
   it('pickFeatured excludes external rows signalled by EITHER field', () => {


### PR DESCRIPTION
> Stacked on #2961. Review that one first; this PR's diff against it is the 6 files below.

## Problem

`provenance` had three values — `builtin`, `external`, `core` — where `core` meant "a row from the bundled `app-registry.json` or an edition entry". That naming described where the row was *stored*, not what the value *asserts*, and it left no value for the remote signed catalog we are about to consume.

## Why it matters

The bundled index is not a kind of app. It is one **delivery** of the list we publish: the offline seed that ships inside the wheel. It answers the same question a signed remote catalog answers — *is this an app WE list* — so it should carry the same value.

Keeping a separate value for the seed would be worse than verbose, because the two deliveries do **not** carry the same integrity guarantee:

| | integrity | revocation |
|---|---|---|
| bundled seed | rides on the signed install artifact | none until the next release |
| signed catalog | re-established per fetch (signature + sidecar) | tombstones, newest-wins by date, ties fail closed |

Two provenance values would put the weaker guarantee behind a label the client cannot tell apart from the stronger one. Provenance names **whose list** an app is on; **how the list arrived** is a separate axis and belongs in its own field once there is more than one answer to record — which is when the catalog fetch lands, not now.

## Fix (symptoms → root cause → change)

Root cause: one field was carrying two questions, and the storage-shaped name made the conflation invisible.

`_apply_trust_fields` now stamps `official` where it stamped `core`. Nothing else about the derivation moves: `external` still short-circuits first on the server-attached `_registry` tag, and `builtin` still comes from the installed record's `origin`.

**Migration / backwards compatibility.** Clients accept both spellings. `sourceLabel` maps `official` and `core` to the same label, so a newer client meeting an older gateway still labels the row instead of falling through to the origin-based legacy arm. The `RegistryApp` union carries both, with `core` commented as the pre-migration spelling. The label copy and its i18n key are unchanged, so **no locale files move** and the i18n gate has nothing new to check.

## Tests

Backend assertions move to `official`, plus one new test that pins the *decision* rather than the value:

- `test_bundled_seed_row_is_official_not_a_separate_value` — a bundled-index row gets `official`, with the integrity/revocation reasoning in the docstring so the absence of a seed-specific value reads as deliberate rather than forgotten.

Frontend keeps its `core` cases as the migration regression and gains `official` cases beside them:

- `sourceLabel prefers the server provenance field` — now asserts `official`.
- `sourceLabel still accepts the pre-migration "core" spelling` — new; two cases, with and without `origin`.
- `sourceLabel keeps the _registry name even with a smuggled provenance` — now asserts both spellings cannot relabel a tagged row.
- `pickFeatured` fixture renamed `core-app` → `official-app`.

279 backend tests pass across the three registry files; 25 frontend tests pass in `appstoreCategories.test.ts`. `tsc -b`, `eslint`, `isort`, `flake8`, `mypy`, `docs-lint` and the brand gate all exit 0.

**Pre-existing main breakage, not this PR:** `test_theme_authoring_skill.py::test_variable_count_matches_validator` fails on Backend Tests shard 4 across all three platforms — `theme_validate._THEME_CSS_VARS` grew to 54 entries and the count in `builtin_skills/theme-pack-authoring/SKILL.md` was not updated. It also reds #2961 and is independent of both.

## Manual verification

No visible change: both spellings render the same existing label, and the only rows affected are the two bundled-index entries plus edition rows, which already displayed as "Kiro Crew registry".

## Screenshots

N/A — a provenance value rename behind an unchanged label.
