### PR TITLE
feat(telegram): mirror a Telegram conversation's dashboard turns back to the chat

### DIFF
--- a/src/kiro_crew/dashboard/chat_mirror.py
+++ b/src/kiro_crew/dashboard/chat_mirror.py
@@ -453,15 +453,24 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
             logger.debug("mirror-link context delivery failed", exc_info=True)
 
     try:
-        state.sessions.set_mirror_link(
-            session_key,
-            link,
-            # Mark the binding inbound-capable only where the transport's inbound
-            # path actually resolves it. Without this the connect writes an
-            # outbound-only binding, ``resumed_session`` skips it, and the user's
-            # reply starts a brand-new session with none of this transcript.
-            accepts_inbound=_resumes_inbound(transport),
-        )
+        with state.sessions.batched_save():
+            # An explicit bind is explicit intent to mirror, so it withdraws any
+            # standing refusal of the AUTOMATIC bind. Without this the two
+            # disagree: a channel that re-asserts its own conversation every turn
+            # would keep declining while the user is looking at a link they just
+            # made, and a later automatic pass would have to guess which of the
+            # two the user meant.
+            state.sessions.set_mirror_opt_out(session_key, False)
+            state.sessions.set_mirror_link(
+                session_key,
+                link,
+                # Mark the binding inbound-capable only where the transport's
+                # inbound path actually resolves it. Without this the connect
+                # writes an outbound-only binding, ``resumed_session`` skips it,
+                # and the user's reply starts a brand-new session with none of
+                # this transcript.
+                accepts_inbound=_resumes_inbound(transport),
+            )
     except ConversationOwnershipConflict:
         # The precheck above covers the common case; this is the genuine race —
         # someone claimed the conversation while we were delivering. Report the

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -82,6 +82,7 @@ import threading
 import time
 from collections import deque
 from collections.abc import Awaitable, Callable
+from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol
@@ -115,8 +116,9 @@ from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.providers.base import CancelOutcome, LLMProvider
 from kiro_crew.sandbox import cleanup_stale_sandbox_profiles
 from kiro_crew.sel import sel
-from kiro_crew.session_map import SessionMap as SessionMap  # noqa: F401
 from kiro_crew.session_map import _kiro_sessions_dir  # noqa: F401
+from kiro_crew.session_map import MIRROR_OPT_OUT_FLAG
+from kiro_crew.session_map import SessionMap as SessionMap  # noqa: F401
 from kiro_crew.session_pid import (
     _build_child_map,
     _cleanup_orphaned_mcp_servers,
@@ -4191,6 +4193,37 @@ class SessionManager:
     def mirror_accepts_inbound(self, key: str) -> bool:
         """True iff this session's mirror is a session-resume (two-way) binding."""
         return self._session_map.mirror_accepts_inbound(key)
+
+    def set_mirror_opt_out(self, key: str, opted_out: bool) -> None:
+        """Record (or withdraw) a refusal of AUTOMATIC origin mirroring.
+
+        A channel that mirrors its own conversation by default needs an
+        in-channel "off" that the NEXT inbound message does not silently undo,
+        and clearing the binding cannot express that: an entry with no ``mirror``
+        is indistinguishable from one that was never linked, so the automatic
+        bind would fire again one message later. This flag is that difference.
+
+        Persisted, because the bind it suppresses is itself re-asserted on every
+        turn and survives a restart — an in-memory refusal would come back on
+        its own. Only the automatic bind consults it; an explicit ``/link`` or
+        dashboard link is a direct instruction and :meth:`set_mirror_link` never
+        reads it.
+        """
+        self._session_map.set_flag(key, MIRROR_OPT_OUT_FLAG, opted_out)
+
+    def mirror_opt_out(self, key: str) -> bool:
+        """True iff this conversation declined automatic origin mirroring."""
+        return self._session_map.get_flag(key, MIRROR_OPT_OUT_FLAG)
+
+    def batched_save(self) -> AbstractContextManager[None]:
+        """Collapse the session-map writes of a related mutation sequence into one.
+
+        Each mutation rewrites the whole map, so a caller making several of them
+        (a link, an unlink) pays that cost once per operation unless it says
+        otherwise. Must not be held across an ``await`` — see
+        :meth:`SessionMap.batched_save`.
+        """
+        return self._session_map.batched_save()
 
     def set_origin_link(self, key: str, link: ChannelLink) -> None:
         """Record the channel conversation this session was started from.

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -11,6 +11,8 @@ import json
 import logging
 import os
 import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from kiro_crew.config.paths import config_dir, kiro_sessions_dir
@@ -42,6 +44,29 @@ _KIRO_SESSIONS_DIR: Path | None = None
 def _kiro_sessions_dir() -> Path:
     """kiro-cli sessions directory, resolved against the live data home."""
     return _KIRO_SESSIONS_DIR if _KIRO_SESSIONS_DIR is not None else kiro_sessions_dir()
+
+
+# Per-conversation flag recording a refusal of automatic origin mirroring. Named
+# here rather than at the caller because it is an ON-DISK contract: the map
+# persists it, so renaming the literal would silently re-enable mirroring for
+# every conversation that had already turned it off.
+MIRROR_OPT_OUT_FLAG = "mirror_opt_out"
+
+# Flags that are durable SETTINGS rather than session-scoped state, and so keep
+# their entry alive through :meth:`SessionMap.prune`. Membership is opt-in
+# BECAUSE immortality has a cost: an entry that prune can never collect is a row
+# the map carries forever, and every mutation rewrites the whole map. A flag
+# describing one session (Slack's ``temporary`` / ``incognito`` threads) must
+# stay collectable — one leaked row per such thread would grow without bound.
+_DURABLE_FLAGS = frozenset({MIRROR_OPT_OUT_FLAG})
+
+
+def _has_durable_flag(entry: dict) -> bool:
+    """True iff *entry* carries a flag that must outlive its native session."""
+    flags = entry.get("flags")
+    if not isinstance(flags, dict):
+        return False
+    return any(flags.get(name) for name in _DURABLE_FLAGS)
 
 
 class ConversationOwnershipConflict(RuntimeError):
@@ -82,7 +107,33 @@ class SessionMap:
         self._path = config_dir() / SESSION_MAP_FILENAME
         self._data: dict[str, dict] = {}  # key → {"sid", "slack_thread_ts", "slack_channel_id"}
         self._thread_to_session: dict[str, str] = {}  # slack_thread_ts → session_key
+        self._batch_depth = 0
+        self._batch_dirty = False
         self._load()
+
+    @contextmanager
+    def batched_save(self) -> Iterator[None]:
+        """Collapse every ``_save()`` inside this block into one write at exit.
+
+        A mutation rewrites the WHOLE map, so a caller making several related
+        mutations pays that cost once per call rather than once per operation —
+        and on the event loop each write is a stall every task shares. Nesting is
+        counted, and the write happens on the way out even if the block raises,
+        so a partial sequence is never left only in memory.
+
+        MUST NOT be held across an ``await``. The map carries no lock, so the
+        loop's own serialization is what keeps a batch from interleaving with
+        another mutation; yielding inside one would let a concurrent write land
+        between the mutations and be lost by this batch's write.
+        """
+        self._batch_depth += 1
+        try:
+            yield
+        finally:
+            self._batch_depth -= 1
+            if self._batch_depth == 0 and self._batch_dirty:
+                self._batch_dirty = False
+                self._write()
 
     def _load(self) -> None:
         self._thread_to_session.clear()
@@ -196,6 +247,12 @@ class SessionMap:
             self._thread_to_session.setdefault(ts, key)
 
     def _save(self) -> None:
+        if self._batch_depth:
+            self._batch_dirty = True
+            return
+        self._write()
+
+    def _write(self) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         tmp_fd, tmp_path = tempfile.mkstemp(dir=str(self._path.parent), suffix=".tmp")
         try:
@@ -348,27 +405,56 @@ class SessionMap:
         self._remove_entry(canonical_key(key))
 
     def prune(self) -> int:
-        """Remove entries whose session files no longer exist."""
+        """Remove entries whose session files no longer exist.
+
+        An entry carrying a DURABLE flag is never deleted, and when its ``sid``
+        has gone stale the ``sid`` is cleared instead. A durable flag is a
+        per-conversation SETTING, not session state: it can be written before the
+        conversation has ever run a turn (``/unlink`` as the very first message
+        leaves no ``sid``, no thread and no mirror), and it must outlive the
+        native session the conversation happened to be using. Deleting the entry
+        either way would silently revert the setting at the next restart, and the
+        user's next message would land on the default they had just turned off.
+
+        Session-SCOPED flags (a temporary or incognito thread) are deliberately
+        NOT durable: they describe one session, so keeping their entries alive
+        would leak a never-collected row per such thread and grow the map — which
+        every mutation rewrites — without bound.
+
+        Returns the number of entries removed; a ``sid``-only reset is a repair,
+        not a removal, so it is not counted.
+        """
         sessions_dir = _kiro_sessions_dir()
-        stale = [
-            k
-            for k, entry in self._data.items()
-            if entry.get("provider") != "claude_code"
-            and (
-                (entry.get("sid") and not (sessions_dir / f"{entry['sid']}.json").exists())
-                or (
-                    not entry.get("sid")
-                    and not entry.get("slack_thread_ts")
-                    and not entry.get("mirror")
-                )
-            )
-        ]
+        stale: list[str] = []
+        repaired = False
+        for key, entry in self._data.items():
+            if entry.get("provider") == "claude_code":
+                continue
+            sid = entry.get("sid")
+            durable = _has_durable_flag(entry)
+            if sid and not (sessions_dir / f"{sid}.json").exists():
+                if durable:
+                    entry["sid"] = ""
+                    repaired = True
+                else:
+                    stale.append(key)
+            elif (
+                not sid
+                and not entry.get("slack_thread_ts")
+                and not entry.get("mirror")
+                and not durable
+            ):
+                stale.append(key)
         for k in stale:
             del self._data[k]
         if stale:
             self._rebuild_thread_index()
             self._save()
             logger.info("Pruned %d stale session map entries", len(stale))
+        elif repaired:
+            # A sid-only reset still has to reach disk, or the next startup sees
+            # the same stale sid and repairs it again forever.
+            self._save()
         return len(stale)
 
     def mapped_sids_by_key(self) -> dict[str, str]:

--- a/src/kiro_crew/telegram/commands.py
+++ b/src/kiro_crew/telegram/commands.py
@@ -5,8 +5,8 @@ Commands:
   /compact     — trigger context compaction
   /model       — pick the model from an inline-button list
   /yolo        — auto-approve every tool for a bounded window
-  /link        — mirror this conversation's dashboard tab back here
-  /unlink      — stop mirroring
+  /link        — resume mirroring dashboard replies here (on by default)
+  /unlink      — stop mirroring dashboard replies here
   /stop        — stop the current reply and clear the queue (alias: /cancel)
   /help        — show available commands
 
@@ -124,8 +124,8 @@ COMMAND_SPEC: tuple[tuple[str, str], ...] = (
     ("compact", "Compress the context when it gets long"),
     ("model", "Choose the model from a list"),
     ("yolo", "Auto-approve every tool for a while (on / off / renew)"),
-    ("link", "Mirror this conversation's dashboard tab here"),
-    ("unlink", "Stop mirroring the dashboard tab"),
+    ("link", "Resume mirroring dashboard replies here (on by default)"),
+    ("unlink", "Stop mirroring dashboard replies here"),
     ("stop", "Stop the current reply and clear the queue"),
     ("help", "Show the command list"),
 )

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -382,6 +382,14 @@ class TelegramDispatcher:
             _acquired = True
             if is_new:
                 await self.sessions.set_channel(session_key, channel_id)
+            # Bind this chat as the session's outbound mirror so a turn the user
+            # later takes from the dashboard is delivered back here. Slack gets
+            # this from its own per-turn thread binding; Telegram had it only
+            # behind an explicit /link. Called ON the loop, like every other
+            # session-map mutation: the map holds no lock, so the loop's own
+            # serialization is what keeps a read-modify-write from interleaving
+            # with a concurrent turn's.
+            self._bind_origin_mirror(session_key, route, chat_id)
             # ── Attachment ingestion (mirrors Discord) ──
             if msg.attachments:
                 attachment_result = await process_telegram_attachments(
@@ -1326,33 +1334,102 @@ class TelegramDispatcher:
             chat_type=slot,
         )
 
-    async def _handle_link(self, route: tuple[str, str], chat_id: int) -> None:
-        """Mirror this conversation's dashboard tab back to Telegram.
+    def _origin_mirror_link(self, route: tuple[str, str], chat_id: int) -> ChannelLink:
+        """The mirror location for the chat a conversation is being read in.
 
-        Binds the current session's dashboard mirror slot to this chat so the
-        dashboard turn loop delivers its replies (and the user-message echo)
-        here. ``/new`` starts a fresh, unlinked conversation.
+        One definition shared by the automatic bind, ``/link`` and ``/unlink``:
+        an unlink matches an occupied location by VALUE, so a second spelling of
+        "this chat" would let the release miss the binding the bind wrote.
+
+        Carries the forum Topic so dashboard-mirrored replies for a forum-linked
+        session thread back into the SAME Topic (via
+        ``_deliver_cross_surface_reply``'s ``thread_id=link.thread_id``), not the
+        supergroup General. ``None`` only for a DM — an authorized forum turn
+        always carries a Topic, General being denied at the gate.
+        """
+        topic = self._route_thread(route)
+        return ChannelLink(
+            "telegram",
+            channel_id=str(chat_id),
+            thread_id=(str(topic) if topic is not None else None),
+        )
+
+    def _bind_origin_mirror(
+        self, session_key: str, route: tuple[str, str], chat_id: int
+    ) -> None:
+        """Mirror this conversation's dashboard tab back to Telegram, unasked.
+
+        Deliberately synchronous and called on the loop, like every other
+        session-map mutation in the codebase: :class:`SessionMap` holds no lock,
+        so the loop's own serialization is what keeps one read-modify-write from
+        interleaving with another's.
+
+        A channel conversation IS its own mirror: the person reading the chat is
+        the audience for every turn of that session, including the turns they
+        later take from the dashboard. Slack has always bound its own thread on
+        every inbound turn, and ``get_mirror_link`` synthesizes a mirror from
+        that binding, so a dashboard turn on a Slack conversation has always
+        reached Slack. Telegram wrote the binding only from an explicit
+        ``/link``, so the same turn reached nobody: ``_resolve_mirror_target``
+        found no ``telegram`` link and the chat sat there looking dead while the
+        conversation continued elsewhere.
+
+        Re-asserted on EVERY turn rather than only on a new session, because the
+        binding is what a restart-cold session, an unlink at this location by
+        another session, or a rival claim can take away — and only a self-healing
+        bind cannot leave a live conversation silently unmirrored. The write is
+        skipped when the binding already says this, so the steady-state cost per
+        turn is a read, not a session-map save.
+
+        Honours the persisted opt-out ``/unlink`` writes: without it, "off" would
+        last exactly until the user's next message. Declining is ALL this does —
+        it never clears a binding it finds. ``/unlink`` persists the flag and the
+        release in one session-map write, so "opted out with a live binding" is
+        not a state the unlink path can leave behind; and every explicit bind
+        (``/link``, the dashboard's mirror-link endpoint) withdraws the flag, so
+        a binding that survives here is one the user asked for. Clearing it would
+        delete their link one turn later and re-create the very "chat looks dead"
+        symptom this bind exists to prevent.
+        """
+        if self.sessions.mirror_opt_out(session_key):
+            return
+        desired = self._origin_mirror_link(route, chat_id)
+        if self.sessions.get_mirror_link(session_key) == desired:
+            return
+        try:
+            self.sessions.set_mirror_link(session_key, desired)
+        except Exception:
+            # Best-effort: this runs on the turn path, and an uncaught raise here
+            # drops the turn and answers the user nothing.
+            # ConversationOwnershipConflict is unreachable while Telegram
+            # declares no session resume (two outbound-only mirrors on one
+            # conversation are permitted by design), but declaring it later would
+            # make this bind the raise site — so it is caught rather than relying
+            # on that capability staying false.
+            logger.debug(
+                "Telegram: origin mirror bind skipped for %s", session_key, exc_info=True
+            )
+
+    async def _handle_link(self, route: tuple[str, str], chat_id: int) -> None:
+        """Re-enable mirroring of this conversation's dashboard tab back here.
+
+        Mirroring is automatic (see :meth:`_bind_origin_mirror`), so this is the
+        withdrawal of a previous ``/unlink`` rather than the only way to turn it
+        on. Clearing the opt-out is the load-bearing half: rebinding without it
+        would be undone by the next automatic bind check.
         """
         assert self.client is not None
         key = self._session_key(route)
-        # Carry the forum Topic so dashboard-mirrored replies for a forum-linked
-        # session thread back into the SAME Topic (via
-        # ``_deliver_cross_surface_reply``'s ``thread_id=link.thread_id``), not
-        # the supergroup General. None only for a DM (an authorized forum turn
-        # always carries a Topic — General is denied at the gate).
-        topic = self._route_thread(route)
-        self.sessions.set_mirror_link(
-            key,
-            ChannelLink(
-                "telegram",
-                channel_id=str(chat_id),
-                thread_id=(str(topic) if topic is not None else None),
-            ),
-        )
-        # Drop any pre-unification row so a stale binding cannot outlive the
-        # rebind (reads prefer the channel key, but a leftover row would still
-        # answer a clear).
-        self.sessions.clear_mirror_link(legacy_dashboard_mirror_key(key))
+        # One write for the whole sequence: each of these mutations would
+        # otherwise rewrite the entire session map, stalling the loop three times
+        # for what is one user-visible action.
+        with self.sessions.batched_save():
+            self.sessions.set_mirror_opt_out(key, False)
+            self.sessions.set_mirror_link(key, self._origin_mirror_link(route, chat_id))
+            # Drop any pre-unification row so a stale binding cannot outlive the
+            # rebind (reads prefer the channel key, but a leftover row would still
+            # answer a clear).
+            self.sessions.clear_mirror_link(legacy_dashboard_mirror_key(key))
         await self._reply(
             chat_id,
             "✅ Linked. Replies from the dashboard for this conversation will "
@@ -1363,20 +1440,19 @@ class TelegramDispatcher:
     async def _handle_unlink(self, route: tuple[str, str], chat_id: int) -> None:
         assert self.client is not None
         key = self._session_key(route)
-        # Match the location exactly as _handle_link writes it (forum Topic
-        # included). No dashboard nudge here: a swept slot's link chip is
+        # Persist the refusal BEFORE releasing: mirroring is re-asserted on every
+        # inbound turn, so a release alone would be undone by the user's next
+        # message. Batched with the release so the pair is one whole-map write
+        # instead of four. No dashboard nudge here: a swept slot's link chip is
         # refreshed by the periodic channel_slot_reconciler push.
-        topic = self._route_thread(route)
-        reply, _swept = release_conversation_location(
-            self.sessions,
-            key=key,
-            location=ChannelLink(
-                "telegram",
-                channel_id=str(chat_id),
-                thread_id=(str(topic) if topic is not None else None),
-            ),
-            channel="telegram",
-        )
+        with self.sessions.batched_save():
+            self.sessions.set_mirror_opt_out(key, True)
+            reply, _swept = release_conversation_location(
+                self.sessions,
+                key=key,
+                location=self._origin_mirror_link(route, chat_id),
+                channel="telegram",
+            )
         await self._reply(chat_id, reply, thread=self._route_thread(route))
 
     def _persist_turn(

--- a/test/test_chat_mirror.py
+++ b/test/test_chat_mirror.py
@@ -250,6 +250,30 @@ class TestMirrorLink:
         assert link == ChannelLink("telegram", channel_id="123", thread_id=None)
 
     @pytest.mark.asyncio
+    async def test_an_explicit_link_withdraws_the_automatic_mirroring_opt_out(
+        self, tmp_path, monkeypatch
+    ):
+        """An explicit bind is explicit intent, so it clears a standing refusal.
+
+        A channel that re-asserts its own conversation every turn (Telegram)
+        declines while the flag is set. Leaving it set would make this endpoint
+        write a binding the channel then refuses to honour — the user is looking
+        at a link they made, and the chat stays silent.
+        """
+        state = _prep(tmp_path, monkeypatch)
+        state.register_channel_transport(_fake_transport("telegram"))
+        state.sessions.set_mirror_link = MagicMock()
+        state.sessions.set_mirror_opt_out = MagicMock()
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 200
+        state.sessions.set_mirror_opt_out.assert_called_once()
+        assert state.sessions.set_mirror_opt_out.call_args.args[1] is False
+
+    @pytest.mark.asyncio
     async def test_link_passes_thread_id(self, tmp_path, monkeypatch):
         state = _prep(tmp_path, monkeypatch)
         transport = _fake_transport("telegram")

--- a/test/test_session_map_mirror.py
+++ b/test/test_session_map_mirror.py
@@ -18,7 +18,7 @@ from kiro_crew.messaging.link import (
     legacy_dashboard_mirror_key,
     release_conversation_location,
 )
-from kiro_crew.session_map import ConversationOwnershipConflict, SessionMap
+from kiro_crew.session_map import MIRROR_OPT_OUT_FLAG, ConversationOwnershipConflict, SessionMap
 
 
 @pytest.fixture()
@@ -538,3 +538,152 @@ class TestConversationOwnership:
             "dashboard:brand-new"
         ]
         assert reloaded.mirror_accepts_inbound("dashboard:brand-new") is True
+
+
+class TestBatchedSave:
+    """One write per related mutation sequence, not one per mutation.
+
+    A mutation rewrites the WHOLE map (measured: ~1ms at 192 entries, ~43ms at
+    10k), and on the event loop each write is a stall every task shares.
+    """
+
+    LINK = ChannelLink(channel_type="telegram", channel_id="7")
+
+    def test_a_sequence_writes_once(self, session_map):
+        writes = []
+        with patch.object(session_map, "_write", side_effect=lambda: writes.append(1)):
+            with session_map.batched_save():
+                session_map.set_mirror_link("telegram:kirocrew:direct:7", self.LINK)
+                session_map.set_flag("telegram:kirocrew:direct:7", MIRROR_OPT_OUT_FLAG, True)
+                session_map.set("telegram:kirocrew:direct:7", "sid-1")
+        assert writes == [1]
+
+    def test_the_write_still_happens_when_the_block_raises(self, session_map):
+        writes = []
+        with patch.object(session_map, "_write", side_effect=lambda: writes.append(1)):
+            with pytest.raises(RuntimeError):
+                with session_map.batched_save():
+                    session_map.set_mirror_link("telegram:kirocrew:direct:7", self.LINK)
+                    raise RuntimeError("mid-sequence failure")
+        # Leaving the mutation only in memory would lose it on the next restart.
+        assert writes == [1]
+
+    def test_nesting_writes_once_at_the_outermost_exit(self, session_map):
+        writes = []
+        with patch.object(session_map, "_write", side_effect=lambda: writes.append(1)):
+            with session_map.batched_save():
+                with session_map.batched_save():
+                    session_map.set_mirror_link("telegram:kirocrew:direct:7", self.LINK)
+                assert writes == []  # inner exit must not write
+        assert writes == [1]
+
+    def test_a_block_that_mutates_nothing_writes_nothing(self, session_map):
+        writes = []
+        with patch.object(session_map, "_write", side_effect=lambda: writes.append(1)):
+            with session_map.batched_save():
+                session_map.get_mirror_link("telegram:kirocrew:direct:7")
+        assert writes == []
+
+    def test_the_batched_data_actually_reaches_disk(self, session_map, tmp_path):
+        key = "telegram:kirocrew:direct:7"
+        with session_map.batched_save():
+            session_map.set_mirror_link(key, self.LINK)
+            session_map.set_flag(key, MIRROR_OPT_OUT_FLAG, True)
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            reloaded = SessionMap()
+        assert reloaded.get_mirror_link(key) == self.LINK
+        assert reloaded.get_flag(key, MIRROR_OPT_OUT_FLAG) is True
+
+
+class TestAutomaticMirrorOptOut:
+
+    """The persisted refusal of automatic origin mirroring (issue #2959).
+
+    A channel that binds its own conversation on every inbound turn re-asserts
+    the mirror after a restart, so the in-channel "off" has to outlive the
+    binding it removes. Clearing ``mirror`` cannot express that — an entry with
+    no binding is indistinguishable from one that was never linked.
+    """
+
+    LINK = ChannelLink(channel_type="telegram", channel_id="7")
+
+    def test_opt_out_survives_a_reload(self, session_map, tmp_path):
+        session_map.set_flag("telegram:kirocrew:direct:7", MIRROR_OPT_OUT_FLAG, True)
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            reloaded = SessionMap()
+        assert reloaded.get_flag("telegram:kirocrew:direct:7", MIRROR_OPT_OUT_FLAG) is True
+
+    def test_clearing_the_binding_does_not_clear_the_opt_out(self, session_map):
+        """The two are independent: unlink does both, and only one must persist."""
+        key = "telegram:kirocrew:direct:7"
+        session_map.set_flag(key, MIRROR_OPT_OUT_FLAG, True)
+        session_map.set_mirror_link(key, self.LINK)
+        assert session_map.clear_mirror_link(key) is True
+        assert session_map.get_mirror_link(key) is None
+        assert session_map.get_flag(key, MIRROR_OPT_OUT_FLAG) is True
+
+    def test_the_flag_name_is_the_one_the_session_manager_writes(self):
+        """Pins the ON-DISK spelling.
+
+        ``SessionManager.set_mirror_opt_out`` is the only writer; a rename would
+        silently re-enable mirroring for every conversation that turned it off.
+        """
+        assert MIRROR_OPT_OUT_FLAG == "mirror_opt_out"
+
+    def test_a_session_scoped_flag_does_not_make_an_entry_immortal(self, session_map):
+        """Immortality is opt-in, because prune is the only collection path.
+
+        Slack's ``temporary`` / ``incognito`` flags describe ONE session, not a
+        durable preference. Keeping their entries would leak a row per such
+        thread — and the map is rewritten whole on every mutation, so the leak
+        costs every later write, not just disk.
+        """
+        for flag in ("temporary", "incognito"):
+            key = f"slack:kirocrew:{flag}"
+            session_map.set_flag(key, flag, True)
+        assert session_map.prune() == 2
+        assert session_map.get_flag("slack:kirocrew:temporary", "temporary") is False
+        assert session_map.get_flag("slack:kirocrew:incognito", "incognito") is False
+
+    def test_a_stale_sid_is_still_collected_when_the_flag_is_session_scoped(
+        self, session_map
+    ):
+        """The repair branch is for settings only, not for any flag at all."""
+        key = "slack:kirocrew:direct:7"
+        session_map.set(key, "sid-that-no-longer-exists")
+        session_map.set_flag(key, "temporary", True)
+        assert session_map.prune() == 1
+        assert key not in session_map._data
+
+    def test_prune_keeps_an_opt_out_that_has_nothing_else_on_it(self, session_map):
+        """``/unlink`` as the very first message writes exactly this shape.
+
+        No ``sid``, no thread, no mirror — which is the stale predicate. Pruned,
+        the setting silently reverts at the next restart and the user's next
+        message lands on the default they had just switched off.
+        """
+        key = "telegram:kirocrew:direct:7"
+        session_map.set_flag(key, MIRROR_OPT_OUT_FLAG, True)
+        assert session_map.prune() == 0
+        assert session_map.get_flag(key, MIRROR_OPT_OUT_FLAG) is True
+
+    def test_prune_clears_a_stale_sid_instead_of_dropping_the_opt_out(
+        self, session_map, tmp_path
+    ):
+        """The other stale branch: the setting must outlive the native session.
+
+        A conversation that HAS run turns carries a ``sid``. When kiro-cli
+        garbage-collects that session file the entry is stale by the first
+        predicate — and deleting it would take the opt-out with it, silently
+        restoring mirroring on the next message.
+        """
+        key = "telegram:kirocrew:direct:7"
+        session_map.set(key, "sid-that-no-longer-exists")
+        session_map.set_flag(key, MIRROR_OPT_OUT_FLAG, True)
+        assert session_map.prune() == 0
+        assert session_map.get_flag(key, MIRROR_OPT_OUT_FLAG) is True
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            reloaded = SessionMap()
+        # The repair reached disk, so the next startup does not redo it.
+        assert reloaded.get_flag(key, MIRROR_OPT_OUT_FLAG) is True
+        assert not (reloaded._data.get(key) or {}).get("sid")

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -10,7 +10,9 @@ turn + callback routing (transport_dispatch.py).
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
@@ -26,6 +28,7 @@ from kiro_crew.messaging.renderer import (
     OutputEvent,
 )
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.session_map import ConversationOwnershipConflict
 from kiro_crew.telegram.client import (
     TELEGRAM_CHUNK_LIMIT,
     TELEGRAM_MAX_TEXT,
@@ -242,6 +245,9 @@ class FakeSessions:
         self.queued: list = []
         self._gp = FakeProvider()
         self.mirror_links: dict[str, Any] = {}
+        self.mirror_opt_outs: set[str] = set()
+        self.batch_depth = 0
+        self.batched_writes: list[bool] = []
         self._pid: Any = None
 
     async def get_or_create(
@@ -281,9 +287,32 @@ class FakeSessions:
         return -1
 
     def set_mirror_link(self, key: str, link: Any) -> None:
+        self.batched_writes.append(self.batch_depth > 0)
         self.mirror_links[key] = link
 
+    def get_mirror_link(self, key: str) -> Any:
+        return self.mirror_links.get(key)
+
+    @contextmanager
+    def batched_save(self) -> Any:
+        self.batch_depth += 1
+        try:
+            yield
+        finally:
+            self.batch_depth -= 1
+
+    def set_mirror_opt_out(self, key: str, opted_out: bool) -> None:
+        self.batched_writes.append(self.batch_depth > 0)
+        if opted_out:
+            self.mirror_opt_outs.add(key)
+        else:
+            self.mirror_opt_outs.discard(key)
+
+    def mirror_opt_out(self, key: str) -> bool:
+        return key in self.mirror_opt_outs
+
     def clear_mirror_link(self, key: str) -> bool:
+        self.batched_writes.append(self.batch_depth > 0)
         return self.mirror_links.pop(key, None) is not None
 
     def clear_mirror_links_at(self, link: Any) -> list[str]:
@@ -2658,6 +2687,22 @@ class TestLinkCommand:
         assert sess.mirror_links == {}
         assert any("Unlinked" in t for t, _ in cli.sent)
 
+    def test_link_batches_its_writes_into_one_map_save(self) -> None:
+        # /link makes three mutations. Each would otherwise rewrite the entire
+        # session map, stalling the loop three times for one user action.
+        d, _cli, sess = _dispatcher({7})
+        asyncio.run(d._handle_link(("direct", "7"), 7))
+        assert sess.batched_writes and all(sess.batched_writes)
+        assert sess.batch_depth == 0
+
+    def test_unlink_batches_its_writes_into_one_map_save(self) -> None:
+        d, _cli, sess = _dispatcher({7})
+        asyncio.run(d._handle_link(("direct", "7"), 7))
+        sess.batched_writes.clear()
+        asyncio.run(d._handle_unlink(("direct", "7"), 7))
+        assert sess.batched_writes and all(sess.batched_writes)
+        assert sess.batch_depth == 0
+
     def test_unlink_leaves_other_locations_alone(self) -> None:
         # Exact-match sweep: a mirror into a DIFFERENT chat survives, and the
         # reply stays truthful when nothing points at this conversation.
@@ -2667,6 +2712,160 @@ class TestLinkCommand:
         asyncio.run(d._handle_unlink(("direct", "7"), 7))
         assert sess.mirror_links == {"dashboard:chat-9": other}
         assert any("wasn't linked" in t for t, _ in cli.sent)
+
+
+class TestAutomaticOriginMirror:
+    """A Telegram conversation mirrors itself, so dashboard turns reach the chat.
+
+    Issue #2959: a session started in Telegram had no ``telegram`` mirror unless
+    the user typed ``/link``, so ``_deliver_cross_surface_reply`` found no target
+    and a turn taken from the dashboard was never delivered back — the chat read
+    as dead while the conversation continued elsewhere.
+    """
+
+    @staticmethod
+    def _turn(d: Any, uid: str = "7", text: str = "hi") -> None:
+        asyncio.run(
+            d.handle_message(
+                InboundMessage(
+                    channel_type="telegram", user_id=uid, conversation_id=uid, text=text
+                )
+            )
+        )
+
+    def test_inbound_turn_binds_this_chat_as_the_mirror(self) -> None:
+        d, _cli, sess = _dispatcher({7})
+        self._turn(d)
+        link = sess.mirror_links[d._session_key(("direct", "7"))]
+        assert link == ChannelLink("telegram", channel_id="7", thread_id=None)
+
+    def test_forum_turn_binds_the_topic_not_the_supergroup_general(self) -> None:
+        # The bind shares _origin_mirror_link with /link, so a forum turn must
+        # carry the Topic id — a General-scoped binding would thread dashboard
+        # replies into the wrong place.
+        d, _cli, sess = _dispatcher(
+            {7}, allow_forum=True, allowed_forum_chat_ids=[-1001234567890]
+        )
+        asyncio.run(
+            d.handle_message(
+                TelegramInboundMessage(
+                    channel_type="telegram",
+                    user_id="7",
+                    conversation_id="-1001234567890",
+                    text="hi",
+                    chat_type="supergroup",
+                    thread_id="5",
+                    message_id=1,
+                )
+            )
+        )
+        route = ("forum", "-1001234567890:5")
+        link = sess.mirror_links[d._session_key(route)]
+        assert link == ChannelLink("telegram", channel_id="-1001234567890", thread_id="5")
+
+    def test_unlink_survives_the_next_message(self) -> None:
+        # The load-bearing half of the opt-out: mirroring is re-asserted every
+        # turn, so without a PERSISTED refusal "off" would last one message.
+        d, _cli, sess = _dispatcher({7})
+        self._turn(d)
+        asyncio.run(d._handle_unlink(("direct", "7"), 7))
+        assert sess.mirror_links == {}
+        self._turn(d, text="still off?")
+        assert sess.mirror_links == {}
+
+    def test_link_withdraws_the_opt_out_so_binding_resumes(self) -> None:
+        d, _cli, sess = _dispatcher({7})
+        asyncio.run(d._handle_unlink(("direct", "7"), 7))
+        asyncio.run(d._handle_link(("direct", "7"), 7))
+        sess.mirror_links.clear()  # prove the NEXT turn re-binds, not just /link
+        self._turn(d)
+        assert sess.mirror_links[d._session_key(("direct", "7"))] == ChannelLink(
+            "telegram", channel_id="7", thread_id=None
+        )
+
+    def test_steady_state_turn_does_not_rewrite_an_identical_binding(self) -> None:
+        # The bind is re-asserted every turn; skipping an unchanged write keeps
+        # the per-turn cost a read instead of a session-map save.
+        d, _cli, sess = _dispatcher({7})
+        self._turn(d)
+        writes: list[str] = []
+        original = sess.set_mirror_link
+
+        def _counting(key: str, link: Any) -> None:
+            writes.append(key)
+            original(key, link)
+
+        sess.set_mirror_link = _counting  # type: ignore[method-assign]
+        self._turn(d, text="second")
+        assert writes == []
+
+    def test_bind_repairs_a_binding_that_drifted_to_another_location(self) -> None:
+        # Self-healing: a live conversation whose binding was swept or rebound
+        # elsewhere must not stay silently unmirrored.
+        d, _cli, sess = _dispatcher({7})
+        key = d._session_key(("direct", "7"))
+        sess.mirror_links[key] = ChannelLink("telegram", channel_id="999")
+        self._turn(d)
+        assert sess.mirror_links[key] == ChannelLink(
+            "telegram", channel_id="7", thread_id=None
+        )
+
+    def test_a_refused_claim_does_not_break_the_turn(self) -> None:
+        # set_mirror_link raises ConversationOwnershipConflict when a rival holds
+        # the conversation. On the turn path an uncaught raise answers nothing.
+        d, cli, sess = _dispatcher({7})
+
+        def _refuse(key: str, link: Any) -> None:
+            raise ConversationOwnershipConflict("held by another session")
+
+        sess.set_mirror_link = _refuse  # type: ignore[method-assign]
+        self._turn(d, text="hello world")
+        assert cli.final_text() == "Answer: hello world"
+        assert sess.successes == ["telegram:kirocrew:direct:7"]
+
+    def test_the_binding_write_stays_on_the_loop_thread(self) -> None:
+        # SessionMap holds no lock, so the loop's own serialization is what keeps
+        # one read-modify-write from interleaving with another's. Offloading the
+        # write to a worker thread would remove that and let a late os.replace
+        # drop a persisted binding.
+        d, _cli, sess = _dispatcher({7})
+        wrote_on: list[int] = []
+        original = sess.set_mirror_link
+
+        def _recording(key: str, link: Any) -> None:
+            wrote_on.append(threading.get_ident())
+            original(key, link)
+
+        sess.set_mirror_link = _recording  # type: ignore[method-assign]
+        self._turn(d)
+        # asyncio.run drives the loop on THIS thread, so the loop's ident is ours.
+        assert wrote_on == [threading.get_ident()]
+
+    def test_an_explicit_relink_to_the_opted_out_chat_survives(self) -> None:
+        # The user /unlinked, then deliberately rebound this session to this same
+        # chat from the dashboard. That is indistinguishable by VALUE from an
+        # unlink that half-landed, so a bind that "repaired" the state would
+        # delete a link the user just made — re-creating the dead-chat symptom
+        # this feature exists to fix, for a user who did everything right.
+        d, _cli, sess = _dispatcher({7})
+        key = d._session_key(("direct", "7"))
+        explicit = ChannelLink("telegram", channel_id="7", thread_id=None)
+        sess.set_mirror_opt_out(key, True)
+        sess.mirror_links[key] = explicit
+        self._turn(d)
+        assert sess.mirror_links == {key: explicit}
+
+    def test_the_opt_out_leaves_an_explicit_mirror_elsewhere_alone(self) -> None:
+        # The dashboard can bind a surfaced session to any conversation. An
+        # opt-out for THIS chat says nothing about that target, so repairing an
+        # interrupted unlink must not double as deleting a link the user chose.
+        d, _cli, sess = _dispatcher({7})
+        key = d._session_key(("direct", "7"))
+        elsewhere = ChannelLink("telegram", channel_id="999", thread_id="4")
+        sess.mirror_links[key] = elsewhere
+        sess.set_mirror_opt_out(key, True)
+        self._turn(d)
+        assert sess.mirror_links == {key: elsewhere}
 
 
 def test_receipt_text_caps_displayed_items() -> None:


### PR DESCRIPTION
## 1. What is the problem?

A session started in Telegram has no Telegram mirror binding unless the user types `/link`. So when the user continues that same conversation from the dashboard, `_deliver_cross_surface_reply` resolves no outbound target and the reply is delivered nowhere. The Telegram chat stops updating while the conversation is still alive on the other surface.

Slack never had this gap, and the asymmetry is the whole bug. Slack's inbound path stamps its own thread on every turn (`slack/handler.py` → `set_slack_link`), and `SessionMap.get_mirror_link` synthesizes a mirror from that binding — so a dashboard turn on a Slack conversation has always reached Slack. Telegram only ever wrote the binding from the explicit `/link` handler.

## 2. Why this issue matters to the user

Telegram is where the user is reading. They switch to the dashboard for the things a chat client cannot do — attachments, long context, widgets — and expect the chat to keep reflecting the conversation. Instead the chat looks dead, and there is no signal that a reply happened at all: the user has to know that an undocumented-feeling `/link` exists and remember to type it first. Two surfaces, one conversation, and only one of them tells the truth.

## 3. How our fix solves it

**Symptom** — a dashboard turn on a Telegram session reaches nobody.
**Immediate cause** — `_resolve_mirror_target` finds no `telegram` link for the session.
**Root cause** — nothing on Telegram's inbound path binds the conversation as its own mirror; only `/link` does.

The fix states the invariant directly: **a channel conversation is its own mirror.** `TelegramDispatcher._bind_origin_mirror` binds the chat as the session's outbound mirror on the inbound turn path, right after `set_channel`, which is where Discord already records its origin link.

Three properties fall out of that, each deliberate:

- **Re-asserted every turn, not only on a new session.** The binding is exactly what a restart-cold session, an unlink at this location by another session, or a rival claim can take away. Only a self-healing bind cannot leave a live conversation silently unmirrored.
- **An unchanged binding is not rewritten, and the write stays on the event loop.** Steady-state cost per turn is a `get_mirror_link` read — zero writes. When a write *is* needed it runs on the loop, like every other session-map mutation in the tree: `SessionMap` carries no lock, so the loop's own serialization is what keeps one read-modify-write from interleaving with another's. A test pins the write to the loop thread so an "optimisation" that offloads it cannot land silently. Measured cost of a write: 1.05 ms on this host's real 192-entry map (43 ms at 10k); `slack/handler.py:3048` already pays one such write on **every** inbound Slack turn.
- **`/link` and `/unlink` batch their writes.** `SessionMap.batched_save()` collapses a related mutation sequence into a single whole-map write: `/link` goes 3 saves → 1, `/unlink` up to 4 → 1. Both are now cheaper than `main` for the same user action.
- **`/unlink` persists an opt-out, and every explicit bind withdraws it.** The flag is load-bearing: with the bind re-asserted every turn, clearing `mirror` cannot express "off", because an entry with no binding is indistinguishable from one that was never linked — "off" would have lasted exactly one message. The opt-out branch only *declines*; it never clears a binding it finds. That is safe because the two states it could be confused for are both handled at their source: `/unlink` writes the flag and the release in one session-map write, so "opted out with a live binding" is not a state it can leave behind, and every explicit bind (`/link`, the dashboard's mirror-link endpoint) withdraws the flag, so a binding that survives the check is one the user asked for. Clearing it would delete their link one turn later and re-create the very "chat looks dead" symptom this bind exists to prevent — for a user who did everything right.

`SessionMap.prune()` also had to stop deleting entries whose only content is a **durable** flag. Its stale predicate is "no `sid`, no thread, no mirror", and `/unlink` as the very first message in a conversation writes exactly that shape — so the setting was dropped at the next startup and the user's next message landed on the default they had just switched off. The same applies when a conversation that *has* run turns has its native session file garbage-collected: the `sid` is cleared and the entry kept, rather than deleted. Durability is an explicit opt-in set (`_DURABLE_FLAGS`), not "any flag": prune is the only collection path, so Slack's session-scoped `temporary` / `incognito` flags stay collectable — making them immortal would leak one permanent row per such thread, and every mutation rewrites the whole map.

Supporting changes: `_origin_mirror_link` is factored out as the single definition of "this chat" (an unlink matches an occupied location *by value*, so a second spelling would let the release miss the binding the bind wrote — and it is what carries the forum Topic id so a Topic-scoped session does not thread replies into the supergroup General). `SessionManager.set_mirror_opt_out` / `mirror_opt_out` are named accessors over the existing per-conversation flag store. `ConversationOwnershipConflict` is caught at the bind: it is unreachable while Telegram declares no session resume (two outbound-only mirrors on one conversation are permitted by design), but a transport that later declares resume would make this the raise site, and an uncaught raise on the turn path drops the turn and answers the user nothing.

Long replies needed no work — `_deliver_cross_surface_reply` already chunks on `transport.capabilities.max_message_chars` (4096 for Telegram). Dashboard-only sessions are unaffected by construction: they have no Telegram origin, so nothing binds and nothing is sent.

## 4. What tests we did

**20/20 mutants caught**, every mutant verified against the new classes *plus* the pre-existing `TestLinkCommand`, so the existing link/unlink contract is part of the ratchet. The set covers: the turn path never binding; the bind being offloaded to a worker thread (which would lose `SessionMap`'s only serialization); the opt-out guard ignored; the opt-out clearing a binding it finds (which would delete an explicit relink); the dashboard's bind failing to withdraw the flag; `/link` and `/unlink` failing to persist or withdraw the flag; an identical binding being rewritten every turn; the origin link dropping the forum Topic; a refused claim escaping the turn; `prune()` deleting a flag-only entry, deleting a flagged entry whose `sid` went stale, or never persisting the `sid` repair; `batched_save()` failing to collapse, dropping its write when the block raises, or writing early on a nested exit; and `/link` / `/unlink` not batching.

The off-loop mutant is the notable one: it pins the concurrency decision, so a future change that moves the write to a thread fails `test_the_binding_write_stays_on_the_loop_thread` rather than silently reintroducing the race. `TestBatchedSave` pins that a batch writes once, still writes when the block raises, does not write on an inner nested exit, writes nothing when nothing mutated, and that the batched data actually reaches disk. `TestAutomaticMirrorOptOut` pins the persisted side: the flag survives a `SessionMap` reload, clearing the binding does not clear the flag, a stale `sid` is repaired rather than deleted, session-scoped flags stay collectable, an explicit relink to the opted-out chat survives the next turn, and the on-disk spelling matches the constant the only writer uses.

Gates: full backend suite green; `isort` clean; `flake8` clean on every file in the diff; `mypy` clean over the diff (4 pre-existing boto3-stub errors remain in `transcribe.py` and `ops_mission_control/providers/cloudwatch.py`, neither in this diff, and CI's pinned lint is green on them). Branch-only full-suite failures were diffed against a baseline run on an unmodified `main` worktree: every one either reproduces there or passes in isolation — host-environment artifacts (`unshare(CLONE_NEWUSER)` EPERM, `/tmp` owned by uid 65534, `AF_UNIX path too long` from the long `TMPDIR` this host needs, mtime-based cache races, wall-clock timing). No frontend files are touched.

## 5. Any other suggestions on the work

- **Discord has the same gap.** `discord/transport_dispatch.py` binds `mirror` only from `!link`, so a dashboard turn on a Discord-origin conversation goes nowhere for exactly the reason described above. The invariant is channel-generic but this implementation is not — when Discord parity lands, the bind + opt-out pattern belongs in `messaging/link.py` rather than as a second per-channel copy. Filed as #3009.
- **`SessionMap` is unlocked and rewrites the whole map on the loop.** Not introduced here — every existing mutation does it, and this PR's steady-state increment is zero writes — but it caps how cheap any of these paths can get, and it is why the bind cannot be offloaded. Filed as #2989 (internal lock → serialized writer → document the contract → audit the multi-save sequences such as `release_conversation_location`). With a lock in place, `batched_save()` could safely span an `await` and the first-turn write could merge with `set_channel`'s.
- **Telegram never calls `set_origin_link`**, so a Telegram session gets no auto-compact notice — Discord records it at `discord/transport_dispatch.py:398` and `chat_compaction_notice.py` reads it. Same family of "unattended output about a live session cannot find the user", different symptom; deliberately left out rather than bundled.
- **`set_channel` writes through to the legacy `slack_channel_id` field** for a new Telegram session, so before this change `get_mirror_link` synthesized a bogus *Slack* `ChannelLink` pointing at `telegram:<user id>`. Harmless for mirroring (the Slack leg skips it, and the real `mirror` field now takes precedence), but `_deliver_auth_error_to_slack` reads `get_slack_link` and would try to post an auth error to a channel id that is not a Slack channel. Worth a separate look.
- `/link` is now a re-enable rather than the only way on. Its help text and the command catalogue were updated to say so; the reply copy reads correctly for both cases.

Fixes #2959
