### PR TITLE
fix(knowledge): offload folder watcher flush and claim writes

### DIFF
--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -179,6 +179,9 @@ Base metadata always carries `format`, `title` (file stem), `file_size`, `extens
 - Discovered files above `props["max_files"]` (default `DEFAULT_MAX_FILES` = 5000) are capped **newest-first** (sort by mtime desc); the surplus count is reported as `capped`.
 - Deletion detection uses the **full** discovered set (pre-cap) so capping never triggers false deletions; a vanished file's items are archived via `_handle_deleted` → `store.delete_items_batch`.
 - Change detection is mtime-then-content-hash: unchanged mtime → `last_seen` bump only; changed mtime but identical SHA-256 → state refresh, no re-ingest.
+- Batched `last_seen` flush/commit and stale-claim release run off the asyncio
+  event loop; each flush and its commit stay within one worker hop so they share
+  the thread-local SQLite connection.
 - Per-file state lives in the `folder_file_state` table with `status` ∈ `{done, scanning, skipped, failed, deduped}`. `scanning` is written **before** ingest so a crash mid-file is recoverable; `skipped`/`failed`/`deduped` files are not auto-retried (user must retry).
 - **TOCTOU defense**: `_ingest_file` re-resolves symlinks and re-checks `is_sensitive_path` at ingest time; a block writes `status='failed'` and emits an SEL `knowledge.source.file.ingest_denied` (`outcome="denied"`, `reason=sensitive_path_toctou`) audit event.
 - After a successful scan, each newly ingested/changed file gets a **targeted** cross-source dedup (`dedup_document(..., apply=True)`) — O(k·n) over the k changed files rather than a full O(n²) corpus sweep — so a folder copy collapses any matching one-shot upload.

--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -392,8 +392,8 @@ class FolderWatcher:
             if idx and idx % _PAUSE_RECHECK_FILES == 0:
                 paused = self._is_paused(source_id)
             if paused:
-                self._flush_last_seen(last_seen_batch)
-                self.store.db.commit()
+                await asyncio.to_thread(
+                    self._flush_last_seen_and_commit, last_seen_batch)
                 return {**stats, "status": "paused"}
 
             state = existing.get(file_path)
@@ -467,10 +467,14 @@ class FolderWatcher:
             # file has changed, so that claim now points at the wrong document and
             # has to go before the new content lands.
             if state:
-                self.store.release_stale_claim(
-                    source_id, state.get("content_hash"), content_hash,
+                await asyncio.to_thread(
+                    self.store.release_stale_claim,
+                    source_id,
+                    state.get("content_hash"),
+                    content_hash,
                     json.loads(state.get("item_ids", "[]") or "[]"),
-                    state.get("text_hash"))
+                    state.get("text_hash"),
+                )
 
             # New or changed file — ingest
             if state and state.get("status") == "done":
@@ -530,8 +534,8 @@ class FolderWatcher:
                         stats["budget_reached"] = 1
                         break
 
-        self._flush_last_seen(last_seen_batch)
-        self.store.db.commit()  # Batch commit for all non-crash-recovery updates
+        await asyncio.to_thread(
+            self._flush_last_seen_and_commit, last_seen_batch)
         # Always report chunks consumed so the caller can track global budget.
         stats["chunks_ingested"] = chunks_ingested
         # Targeted cross-source dedup for each newly ingested/changed file, so a folder
@@ -790,6 +794,22 @@ class FolderWatcher:
             "UPDATE folder_file_state SET last_seen = ? WHERE source_id = ? AND file_path = ?",
             batch)
         batch.clear()
+
+    def _flush_last_seen_and_commit(self, batch: list[tuple[str, str, str]]) -> None:
+        """Apply the accumulated last-seen touches and commit them.
+
+        Exists so the caller can offload BOTH in a single ``asyncio.to_thread``
+        hop. ``store.db`` is a thread-local connection, so two separate hops are
+        not equivalent to one: the default executor is free to run them on
+        different workers, and the commit would then land on a different
+        connection than the ``executemany`` it is meant to commit.
+
+        The commit deliberately does not run in a ``finally``. A failed flush has
+        nothing to commit, and the exception propagates to the caller exactly as
+        it did when both statements ran inline.
+        """
+        self._flush_last_seen(batch)
+        self.store.db.commit()
 
     def _is_paused(self, source_id: str) -> bool:
         """Check if source has scan_paused flag set."""

--- a/test/test_folder_watcher.py
+++ b/test/test_folder_watcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import contextlib
 import json
 import sqlite3
@@ -641,8 +642,39 @@ class TestOrphanCleanupExclusion:
         assert row is not None
 
 
+class _ThreadPerCallExecutor(concurrent.futures.ThreadPoolExecutor):
+    """Executor that gives every submitted call its OWN thread.
+
+    ``asyncio.to_thread`` runs on the loop's default ``ThreadPoolExecutor``,
+    which hands consecutive calls to the same idle worker. Under that executor
+    a flush and its commit land on one thread whether they were offloaded
+    together or separately, so a same-thread assertion cannot tell the two
+    apart -- and the store's connection is thread-local, which is exactly the
+    difference that matters. Never reusing a thread makes "one worker hop" and
+    "two worker hops" distinguishable, so splitting them fails the assertion.
+    """
+
+    def __init__(self) -> None:
+        # ``set_default_executor`` requires this concrete executor type on
+        # Python 3.12. The inherited pool stays idle; each submit gets its own
+        # live one-worker pool below so consecutive calls cannot reuse a thread.
+        super().__init__(max_workers=1)
+        self._per_call_executors: list[concurrent.futures.ThreadPoolExecutor] = []
+
+    def submit(self, fn, /, *args, **kwargs):  # type: ignore[override]
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        self._per_call_executors.append(executor)
+        return executor.submit(fn, *args, **kwargs)
+
+    def shutdown(self, wait=True, *, cancel_futures=False):  # type: ignore[override]
+        for executor in self._per_call_executors:
+            executor.shutdown(wait=wait, cancel_futures=cancel_futures)
+        self._per_call_executors.clear()
+        super().shutdown(wait=wait, cancel_futures=cancel_futures)
+
+
 class TestAsyncToThread:
-    """Test that _walk and _hash_file are offloaded to thread."""
+    """Blocking folder-scan work must not run on the event-loop thread."""
 
     @pytest.mark.asyncio
     async def test_walk_runs_in_thread(self, store, pipeline, tmp_path):
@@ -695,6 +727,103 @@ class TestAsyncToThread:
         assert threading.get_ident() not in dedup_threads, (
             "dedup_document ran on the event-loop thread; it must be offloaded via "
             "asyncio.to_thread (see ingestion.py / watcher.py for the precedent)")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("paused", [False, True])
+    async def test_last_seen_flush_and_commit_run_off_the_event_loop(
+            self, tmp_path, monkeypatch, paused):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        note = vault / "note.md"
+        note.write_text("hello")
+
+        db = MagicMock()
+        flush_threads: list[int] = []
+        commit_threads: list[int] = []
+        db.commit.side_effect = lambda: commit_threads.append(threading.get_ident())
+        store = MagicMock()
+        store.db = db
+        pipeline = MagicMock()
+        pipeline._dedup_enabled = False
+        fw = FolderWatcher(store, pipeline)
+        monkeypatch.setattr(fw, "_walk", lambda *a, **kw: [(str(note), 1.0)])
+        monkeypatch.setattr(
+            fw,
+            "_load_state",
+            lambda source_id: {
+                str(note): {"status": "done", "mtime": 2.0, "item_ids": "[]"}
+            },
+        )
+        monkeypatch.setattr(fw, "_is_paused", lambda source_id: paused)
+        original_flush = fw._flush_last_seen
+
+        def record_flush(batch):
+            flush_threads.append(threading.get_ident())
+            original_flush(batch)
+
+        monkeypatch.setattr(fw, "_flush_last_seen", record_flush)
+        loop_thread = threading.get_ident()
+        asyncio.get_running_loop().set_default_executor(_ThreadPerCallExecutor())
+
+        await fw.scan_source(
+            {"id": "source", "uri": str(vault), "properties": "{}"}
+        )
+
+        assert len(flush_threads) == len(commit_threads) == 1
+        assert flush_threads[0] != loop_thread, (
+            "the last-seen flush ran on the event-loop thread")
+        # The store's SQLite connection is thread-local, so a commit that lands
+        # on a different worker than its flush commits a DIFFERENT connection --
+        # which, under the thread-per-call executor above, is what splitting the
+        # single worker hop into two `asyncio.to_thread` calls produces.
+        assert flush_threads == commit_threads, (
+            "the flush and its commit ran on different worker threads, so they "
+            "used different thread-local SQLite connections; keep them in one "
+            "asyncio.to_thread hop")
+
+    @pytest.mark.asyncio
+    async def test_stale_claim_release_runs_off_the_event_loop(
+            self, tmp_path, monkeypatch):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        note = vault / "note.md"
+        note.write_text("changed")
+
+        store = MagicMock()
+        release_threads: list[int] = []
+        store.release_stale_claim.side_effect = (
+            lambda *args: release_threads.append(threading.get_ident())
+        )
+        pipeline = MagicMock()
+        pipeline._dedup_enabled = False
+        fw = FolderWatcher(store, pipeline)
+        monkeypatch.setattr(fw, "_walk", lambda *a, **kw: [(str(note), 2.0)])
+        monkeypatch.setattr(fw, "_hash_file", lambda path: "new-hash")
+        monkeypatch.setattr(
+            fw,
+            "_load_state",
+            lambda source_id: {
+                str(note): {
+                    "status": "deduped",
+                    "mtime": 1.0,
+                    "content_hash": "old-hash",
+                    "text_hash": "old-text-hash",
+                    "item_ids": "[]",
+                }
+            },
+        )
+        monkeypatch.setattr(fw, "_is_paused", lambda source_id: False)
+        monkeypatch.setattr(fw, "_update_state", MagicMock())
+        monkeypatch.setattr(fw, "_flush_last_seen", MagicMock())
+        monkeypatch.setattr(fw, "_ingest_file", AsyncMock(return_value=([], "deduped")))
+        loop_thread = threading.get_ident()
+
+        await fw.scan_source(
+            {"id": "source", "uri": str(vault), "properties": "{}"}
+        )
+
+        assert len(release_threads) == 1
+        assert release_threads[0] != loop_thread
 
 
 class TestDeleteSourceCascade:

--- a/test/test_perf_boot_path.py
+++ b/test/test_perf_boot_path.py
@@ -327,7 +327,6 @@ class _CountingDb:
         self._db = db
         self.select_sources = 0
         self.last_seen_execute = 0
-        self.last_seen_executemany = 0
 
     def execute(self, sql, *args, **kwargs):
         if "FROM sources WHERE id" in sql:
@@ -335,12 +334,6 @@ class _CountingDb:
         if "SET last_seen" in sql:
             self.last_seen_execute += 1
         return self._db.execute(sql, *args, **kwargs)
-
-    def executemany(self, sql, seq, *args, **kwargs):
-        seq = list(seq)
-        if "SET last_seen" in sql:
-            self.last_seen_executemany += 1
-        return self._db.executemany(sql, seq, *args, **kwargs)
 
     def __getattr__(self, name):
         return getattr(self._db, name)
@@ -391,8 +384,18 @@ class TestFolderWatcherScanQueryCount:
 
         counting = _CountingDb(store.db)
         # ``KnowledgeStore.db`` is a read-only property backed by a per-thread
-        # connection; the scan runs on this thread, so swap the thread-local.
+        # connection. This wrapper covers the on-loop pause reads; the batched
+        # write now runs on a worker connection and is observed at its method
+        # boundary below instead.
         store._thread_local.conn = counting
+        batch_sizes: list[int] = []
+        original_flush = fw._flush_last_seen
+
+        def _counting_flush(batch):
+            batch_sizes.append(len(batch))
+            original_flush(batch)
+
+        fw._flush_last_seen = _counting_flush  # type: ignore[method-assign]
         await fw.scan_source(source)
 
         assert counting.select_sources <= 2, (
@@ -402,7 +405,9 @@ class TestFolderWatcherScanQueryCount:
         assert counting.last_seen_execute == 0, (
             "last_seen touches must be batched, not issued one per file"
         )
-        assert counting.last_seen_executemany == 1
+        assert batch_sizes == [n_files], (
+            "all unchanged-file last_seen touches must land in one worker batch"
+        )
 
     @pytest.mark.asyncio
     async def test_last_seen_is_still_written(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem / Motivation

`_do_scan` carefully offloads its directory walk and hashing to a thread, then
writes SQLite **inline on the event loop**: the batched `last_seen` flush and its
commit (on both the normal and the paused early-return path) plus
`release_stale_claim`.

## Why it matters

Every one of those writes blocks the whole gateway — chat streaming, WebSocket
frames, cron dispatch — for as long as SQLite takes. The offload that was already
done makes this worse rather than better, because it removed the accidental
serialization that used to keep the scan short.

## What changed

- offload both batched `last_seen` flush/commit pairs from the asyncio event loop
- keep each flush and its commit in **one worker hop** so they share the store's
  thread-local SQLite connection
- offload `release_stale_claim` from the event loop
- add deterministic regression coverage for the normal, paused and stale-claim
  paths
- document the exact FolderWatcher scope covered by this change

This PR offloads the five synchronous write sites enumerated in #2974:
both batched `last_seen` flush/commit pairs and `release_stale_claim`.
Other FolderWatcher state writes are unchanged.

`_do_scan` already offloads its directory walk and file hashing, but these five
writes ran inline on the loop. SQLite waits for a write lock for up to the
connection timeout, so a concurrent writer could stall the loop for the whole
wait.

SQLite timeout and transaction policy are unchanged.

## Why flush and commit share one hop

This is the part worth reviewing closely. The following looks equivalent and is
not:

```python
await asyncio.to_thread(self._flush_last_seen, batch)
await asyncio.to_thread(self.store.db.commit)
```

`KnowledgeStore.db` is a **thread-local** connection, and the default executor is
free to run those two calls on different workers. The commit would then be issued
on a different connection than the `executemany` it is meant to commit. Against a
real store that raises `sqlite3.ProgrammingError: SQLite objects created in a
thread can only be used in that same thread`; against a mock it silently commits
nothing. So both statements go through a single helper in a single hop.

`release_stale_claim` has no such pairing — it is one self-contained call — so it
is offloaded on its own. No dedicated DB executor and no change to the store's
connection architecture.

## Failure semantics (unchanged)

- the commit is **not** in a `finally`: a failed flush still has nothing to
  commit, and the exception propagates to the caller exactly as it did inline;
- `_flush_last_seen` clears the batch after a successful `executemany`, as
  before;
- the connection is autocommit (`isolation_level=None`) and no `BEGIN` spans the
  scan, so moving the commit onto a worker connection cannot strand writes made
  earlier on the loop thread.

## Tests

The regression tests pin **connection ownership**, not merely "it ran off the
loop". They install an executor that gives every submitted call its own thread,
so a flush and a commit that were split apart land on different threads and fail
the assertion. Under the default `ThreadPoolExecutor` both hops reuse one idle
worker, and the split would go undetected.

Mutation evidence (each mutation applied, run, then reverted):

| Mutation | Result |
|---|---|
| final flush+commit split into two `to_thread` hops, **before** the executor seam | passed 3/3 — the bug was invisible |
| same split, **with** the seam | `[False]` fails 3/3 — "flush and its commit ran on different worker threads" |
| paused flush+commit split into two hops | `[True]` fails 2/2 |
| `release_stale_claim` inlined back onto the loop | fails — loop-thread assertion |
| production restored | 5 passed 3/3 |

The first split also made an unrelated pre-existing test fail with
`sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in
that same thread` against a real store — independent confirmation that the two
shapes are not interchangeable.

Local validation after rebasing onto current `origin/main` (Windows 11, Python
3.11.3):

- focused FolderWatcher and boot-path suites: **81 passed**, excluding the one
  pre-existing Windows symlink test that requires `SeCreateSymbolicLinkPrivilege`
  (`WinError 1314`); the full selection was 81 passed / that same one failed
- `isort --check-only`, `flake8`, `git diff --check`, and `docs-lint` all clean

Closes #2974

