### PR TITLE
fix(acp): classify kiro-cli's nameless model-unavailable wording as transient

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -871,6 +871,17 @@ _NOT_LOGGED_IN_MESSAGE = (
 # string); throttle, auth, and the 5xx family match the combined
 # `data + message` haystack so a 5xx token in either field is caught.
 _RE_MODEL_UNAVAILABLE = re.compile(r"[Tt]he model '([^']+)' is not available")
+# kiro-cli >= 2.16 rewording of the same capacity/rollout rejection, which
+# names NO model: "The model you've selected is temporarily unavailable.
+# Please use '/model' to select a different model and try again." Without its
+# own pattern this wording fell through to the unknown-shape branch and was
+# classified terminal, so unattended callers (cron, subagents, consolidation)
+# failed fast on a momentary blip their retry ladder exists to absorb — the
+# exact drift hazard the marker-coupling note above warns about. The quote
+# class covers both the straight and typographic apostrophe in "you've".
+_RE_MODEL_TEMP_UNAVAILABLE = re.compile(
+    r"[Tt]he model you['\u2019]ve selected is temporarily unavailable"
+)
 # MPS ValidationException wording for a model the partition/account does not
 # serve — distinct from the "is not available" capacity string above. Covers the
 # ``auto`` sentinel in partitions that do not serve it.
@@ -1043,6 +1054,13 @@ def _is_transient_raw_error(
         # check so limit wording that also reads as rate-limiting stays terminal.
         return False
     if _RE_MODEL_UNAVAILABLE.search(data):
+        return True
+    if _RE_MODEL_TEMP_UNAVAILABLE.search(data):
+        # Nameless capacity rejection (kiro-cli >= 2.16 wording). Matched
+        # against `data` only, like its named sibling above, so a phrase echo
+        # in the JSON-RPC `message` can't flip an otherwise-terminal error.
+        # No entitlement check is possible (the wording names no model), but
+        # the bounded retry budget caps the cost if one ever slips through.
         return True
     if _RE_THROTTLE_NAMED.search(haystack) or _RE_THROTTLE_GENERIC.search(haystack):
         return True
@@ -1225,6 +1243,21 @@ def _format_acp_error(error: object, available_models: Sequence[str] | None = No
                 f"different model in the model picker, (2) set agent.model to "
                 f"'auto' in ~/.kiro/crew/config.json, or (3) wait a minute and "
                 f"retry."
+                f"{req_id_suffix}"
+            )
+        elif _RE_MODEL_TEMP_UNAVAILABLE.search(data):
+            # Same capacity/rollout rejection as above in kiro-cli >= 2.16
+            # wording, which names no model. Rewritten for the same reasons as
+            # its named sibling: the provider's advice quotes the '/model' TUI
+            # command, which does nothing in the dashboard, Slack, or a cron —
+            # and the "is unavailable on the backend" prose keeps the
+            # _TRANSIENT_MARKERS string fallback recognising it for free.
+            formatted = (
+                "The selected model is unavailable on the backend right now "
+                "(capacity throttle or region rollout). Try: (1) pick a "
+                "different model in the model picker, (2) set agent.model to "
+                "'auto' in ~/.kiro/crew/config.json, or (3) wait a minute and "
+                "retry."
                 f"{req_id_suffix}"
             )
         elif _RE_THROTTLE_NAMED.search(haystack) or _RE_THROTTLE_GENERIC.search(haystack):

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -76,6 +76,13 @@ _TRANSIENT_MARKERS = (
     # would resurrect the pointless retry loop #1550 removed.
     "is unavailable on the backend",
     "is unavailable on bedrock",
+    # kiro-cli >= 2.16 nameless capacity wording ("The model you've selected
+    # is temporarily unavailable..."). The formatter now rewrites it into the
+    # "on the backend" prose above, but a transcript or history line written
+    # by a pre-rewrite gateway carries the raw passthrough — this marker keeps
+    # those classifying. Deliberately skips the "you've" apostrophe so
+    # straight and typographic quotes both match the substring.
+    "selected is temporarily unavailable",
     "transient error (http 5xx)",  # _format_acp_error's generic-5xx message
 )
 

--- a/test/test_acp_error_surface.py
+++ b/test/test_acp_error_surface.py
@@ -56,6 +56,21 @@ _PROMPT_BUSY = {
     "data": "Prompt already in progress",
 }
 
+# kiro-cli >= 2.16 rewording of the capacity rejection, which names NO model.
+# The exact frame from a live cron failure (gateway.log 2026-08-12 02:57), with
+# the request id value swapped. Before its own pattern existed this fell
+# through to the unknown-shape branch and classified TERMINAL, so unattended
+# callers failed fast on a momentary blip instead of retrying.
+_MODEL_TEMP_UNAVAILABLE = {
+    "code": -32603,
+    "message": "Internal error",
+    "data": (
+        "The model you've selected is temporarily unavailable. Please use "
+        "'/model' to select a different model and try again. (request_id: "
+        "863ae6fe-de1d-4149-b3ff-6ee02d8d58a2)"
+    ),
+}
+
 
 def _handle() -> AcpSessionHandle:
     rt = MagicMock()
@@ -179,6 +194,70 @@ class TestEntitlementReachesTheHandlePath:
         assert exc.transient is True
 
 
+class TestNamelessCapacityWording:
+    """kiro-cli >= 2.16's nameless capacity rejection must stay retryable.
+
+    The rewording dropped the model name from "The model 'X' is not
+    available", so ``_RE_MODEL_UNAVAILABLE`` no longer matches and the error
+    fell through to the unknown-shape branch: passthrough text (fine) with a
+    TERMINAL verdict (not fine). A cron hit exactly this during a backend
+    capacity blip — the run before and after both succeeded — and failed
+    without spending a single retry attempt.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver", [_raise_via_wait, _raise_via_dispatch])
+    async def test_verdict_is_transient(self, driver):
+        """The retry ladder must get a shot at a momentary capacity blip."""
+        assert (await driver(_MODEL_TEMP_UNAVAILABLE)).transient is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver", [_raise_via_wait, _raise_via_dispatch])
+    async def test_formatted_is_actionable(self, driver):
+        msg = str(await driver(_MODEL_TEMP_UNAVAILABLE))
+
+        # Rewritten into the capacity guidance, not the raw passthrough.
+        assert "model picker" in msg
+        # The provider's '/model' TUI advice does nothing in the dashboard,
+        # Slack, or a cron — it must not be echoed (same contract as the
+        # named-model branch).
+        assert "/model" not in msg
+        # request_id survives for support correlation.
+        assert "863ae6fe-de1d-4149-b3ff-6ee02d8d58a2" in msg
+
+    def test_message_field_echo_does_not_flip_verdict(self):
+        """The pattern is data-scoped, like its named sibling.
+
+        A phrase echo in the JSON-RPC ``message`` alone must not reclassify an
+        otherwise-terminal error as transient.
+        """
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        echo_only = {
+            "code": -32603,
+            "message": "The model you've selected is temporarily unavailable.",
+            "data": "ValidationException: malformed request",
+        }
+        assert _is_transient_raw_error(echo_only) is False
+
+    def test_typographic_apostrophe_still_matches(self):
+        """Providers flip between straight and curly quotes; both must match."""
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        curly = dict(_MODEL_TEMP_UNAVAILABLE, data="The model you\u2019ve selected is temporarily unavailable.")
+        assert _is_transient_raw_error(curly) is True
+
+    def test_pre_rewrite_passthrough_still_classifies_via_marker(self):
+        """A transcript written by a pre-fix gateway carries the raw wording.
+
+        The string-fallback path (``_TRANSIENT_MARKERS``) must recognise it so
+        history-restored messages keep their retry verdict.
+        """
+        from kiro_crew.llm_helpers import is_transient_backend_error
+
+        assert is_transient_backend_error(str(_MODEL_TEMP_UNAVAILABLE["data"]))
+
+
 class TestRunnerPromptBusyIsStructural:
     """The runner's retry gate must not depend on error-message wording."""
 
@@ -232,6 +311,7 @@ class TestTransientMarkerCoupling:
         "error",
         [
             _MODEL_UNAVAILABLE,
+            _MODEL_TEMP_UNAVAILABLE,
             {"code": -32603, "message": "Internal error", "data": "ThrottlingException"},
             {"code": -32603, "message": "Internal error", "data": "InternalServerError"},
         ],


### PR DESCRIPTION
## Problem

kiro-cli ≥ 2.16 reworded its model-capacity rejection. The old wording named the model:

> The model 'claude-opus-4.8' is not available. Please use '/model' to select a different model and try again.

The new wording does not:

> The model you've selected is temporarily unavailable. Please use '/model' to select a different model and try again.

`_RE_MODEL_UNAVAILABLE` (`the model 'X' is not available`) no longer matches, so the error falls through to `_format_acp_error`'s unknown-shape branch: the passthrough text is fine, but `_is_transient_raw_error` returns **terminal**. Unattended callers — cron jobs, subagents, memory consolidation, anything on `stream_and_collect`'s retry ladder — fail fast on a momentary capacity blip instead of spending a single retry attempt. This is exactly the rewording hazard the `_TRANSIENT_MARKERS` comment warns about ("Any future rewording of that branch must add its marker here").

Observed live (gateway log, sanitized): a 15-minute cron failed at first attempt on exactly this wording during a backend capacity blip. The runs immediately before and after both succeeded, and interactive chat sessions that hit the same error in the same window recovered on manual retry — the failure was genuinely transient, and only the unattended path paid for the misclassification:

```
02:41 success
02:56 failure  The model you've selected is temporarily unavailable. Please use '/model' to ...
03:11 success
```

No retry warnings preceded the failure (a generic HTTP-5xx in the same window did retry, confirming the ladder itself works).

## Fix

A dedicated pattern, `_RE_MODEL_TEMP_UNAVAILABLE`, feeding both coupled consumers:

- `_is_transient_raw_error`: matches `data` only (same scope as its named sibling, so a phrase echo in the JSON-RPC `message` can't flip an otherwise-terminal error), returns transient.
- `_format_acp_error`: new curated branch that rewrites into the existing capacity guidance. Same contract as the named-model branch: the provider's `/model` TUI advice does nothing in the dashboard, Slack, or a cron, so it is not echoed; the "is unavailable on the backend" prose keeps the `_TRANSIENT_MARKERS` string fallback recognising the formatted text with no new marker needed.
- `_TRANSIENT_MARKERS`: one marker for the **raw passthrough** wording, so transcripts and history lines written by pre-fix gateways still classify. The marker substring skips the "you've" apostrophe so straight and typographic quotes both match.

No behavior change for any currently-recognised error shape: the new pattern only claims a wording that previously landed in the unknown-shape fallback.

## Tests

- 7 new tests (all fail pre-fix, mutation-verified): transient verdict carried on both handle raise paths, formatted text actionable with request_id preserved and no `/model` echo, `message`-field echo does not flip the verdict, typographic apostrophe matches, raw pre-fix passthrough classifies via marker fallback, and the new frame added to the marker-coupling parametrize.
- 596 tests green across the acp-client / error-surface / llm-helpers neighborhood; 161 green on a repo-wide `-k "transient or acp_error"` sweep.
- isort / flake8 / mypy clean on touched files.
