### PR TITLE
fix(governance): warn when a policy leaves capability rows ungoverned

### DIFF
--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -1170,7 +1170,12 @@ def _policy(args: argparse.Namespace) -> None:
     effective ceiling.  No mutation — purely diagnostic, so it is MCP-safe.
     """
     from kiro_crew.platform.context import current_context
-    from kiro_crew.platform.governance import SCOPE_CATALOG, gate_decision, resolve
+    from kiro_crew.platform.governance import (
+        CAPABILITY,
+        SCOPE_CATALOG,
+        gate_decision,
+        resolve,
+    )
     from kiro_crew.platform.governance_profiles import (
         get_store_profile,
         resolve_active_scope,
@@ -1204,6 +1209,31 @@ def _policy(args: argparse.Namespace) -> None:
             print("Policy: none (editable secure-defaults) — nothing to validate.")
         else:
             print(f"Policy: v{ceiling.version} OK ({len(ceiling.controls)} governed scopes).")
+            # A capability the policy does not name is UNGOVERNED, and an
+            # ungoverned control is permitted — omission never denies (see the
+            # CAPABILITY-DEFAULT CONTRACT in platform/governance.py). That is the
+            # same rule every other archetype follows, but it is the one authors
+            # most often get wrong, because a partial `capabilities` block LOOKS
+            # like a complete statement. Report the gap so an unpinned row reads
+            # as a choice instead of an oversight.
+            unnamed = sorted(
+                scope
+                for scope, spec in SCOPE_CATALOG.items()
+                if spec.kind == CAPABILITY and scope not in ceiling.controls
+            )
+            if unnamed and len(unnamed) < sum(
+                1 for spec in SCOPE_CATALOG.values() if spec.kind == CAPABILITY
+            ):
+                print(
+                    f"   ⚠️  governs capabilities but leaves {len(unnamed)} "
+                    "row(s) UNGOVERNED (therefore permitted):"
+                )
+                for scope in unnamed:
+                    print(f"        {scope}")
+                print(
+                    "      Omission does not deny. Name each row explicitly "
+                    "(enabled true or false) if you meant to decide it."
+                )
         # Force-load every profile; the store records invalid ones as deny-all.
         from kiro_crew.platform.governance_profiles import _profiles_dir
 

--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -936,12 +936,39 @@ class ScopeSpec:
     kind: str
     matcher: str = _DEFAULT_MATCHER
     ordinal_scale: str = ""
-    capability_default: bool = False  # policy-absence default for CapabilityGate
+    capability_default: bool = False  # see the CAPABILITY-DEFAULT CONTRACT note below
     # for CapabilityGate: scope-name -> matcher for its inner ScopedRulesets
     scope_matchers: Mapping[str, str] = field(default_factory=dict)
 
 
-# Built-in catalog.  ``capability_default`` follows Validation rule 8.
+# ── CAPABILITY-DEFAULT CONTRACT (read before touching any capability_default) ──
+#
+# ``capability_default`` supplies ``enabled`` when the capability's KEY IS PRESENT
+# in the document but its ``enabled`` field is omitted, e.g.
+#
+#     "capabilities": {"publish": {"scopes": {"destinations": {...}}}}
+#
+# which configures publish's destinations without stating whether publish is on,
+# and therefore resolves to this default.  That is the ONLY case it covers.
+#
+# It does NOT apply when the key is absent.  ``_parse_controls`` materializes only
+# the children physically present in the document, so an unnamed capability is an
+# absent scope, and ``resolve`` PERMITS an absent scope (``_PERMIT_NOT_GOVERNED``)
+# exactly as it does for an unnamed ``mcp``, ``commands`` or ``network.egress``.
+# Omission means ungoverned-and-permitted for every archetype; capabilities are
+# not a special case, and making them one would put a namespace-specific rule in
+# a loader whose whole contract is that a newly registered scope family parses
+# without a loader edit.
+#
+# Consequence for authors, and the reason a governed fleet should enumerate all of
+# them: a policy cannot deny a capability by leaving it out.  ``kirocrew policy
+# validate`` reports a partially-governed ``capabilities`` block so the gap is
+# visible instead of implied.
+#
+# Verified 2026-08-11 by executing parse_policy + resolve; several comments below
+# previously described the absent-key case and were wrong.
+
+# Built-in catalog.
 SCOPE_CATALOG: Dict[str, ScopeSpec] = {
     "tools": ScopeSpec(RULESET, matcher="identifier"),
     "mcp": ScopeSpec(RULESET, matcher="mcp"),
@@ -967,7 +994,7 @@ SCOPE_CATALOG: Dict[str, ScopeSpec] = {
     # by kiro_crew.safety_override at the activation seam, against the HOST
     # profile and fail-closed.
     "yolo_duration": ScopeSpec(RULESET, matcher="identifier"),
-    # Capabilities (Validation rule 8 registered defaults):
+    # Capabilities (registered defaults — see the CAPABILITY-DEFAULT CONTRACT above):
     "capabilities.spawn": ScopeSpec(
         CAPABILITY, capability_default=True, scope_matchers={"agents": "identifier"}
     ),
@@ -977,9 +1004,11 @@ SCOPE_CATALOG: Dict[str, ScopeSpec] = {
     "capabilities.messaging": ScopeSpec(CAPABILITY, capability_default=False),
     # Publishing an artifact's bytes to an external destination is an
     # exfil/external-side-effect surface (like messaging), so it is opt-in
-    # (capability_default=False): when a policy governs capabilities.* but omits
-    # publish, publishing is denied.  When NO policy is present the standalone
-    # default still permits everything.  The inner ``destinations`` ruleset
+    # (capability_default=False): a policy that names ``publish`` while omitting
+    # ``enabled`` — typically to configure its destinations — resolves to denied.
+    # Note this does NOT make omission of the whole key deny: an unnamed publish
+    # is ungoverned and permitted (see the CAPABILITY-DEFAULT CONTRACT above).
+    # The inner ``destinations`` ruleset
     # bounds WHICH publish-provider ids are allowed once the capability is on
     # (the direct analogue of capabilities.spawn's ``agents`` ruleset).  WHO
     # implements a destination is the orthogonal CPP PublishRegistry seam; this
@@ -992,8 +1021,8 @@ SCOPE_CATALOG: Dict[str, ScopeSpec] = {
     # injected into the agent's FIRST turn — third-party text entering the
     # model's context (mirrors capabilities.publish being a governable external
     # surface). Making it a capability row lets an enterprise POLICY
-    # force-disable persona injection wholesale. Default True: policy-absence
-    # keeps personas working (this is a tone-only surface; the deny floor +
+    # force-disable persona injection wholesale. Default True: naming the row
+    # without ``enabled`` keeps personas working (this is a tone-only surface; the deny floor +
     # PreToolUse gate still bind every action the persona could ask for), while
     # a governing policy can pin it off. Data row only — CONTRACT_VERSION and
     # the evaluator are untouched (per spec).
@@ -1004,8 +1033,8 @@ SCOPE_CATALOG: Dict[str, ScopeSpec] = {
     # surface that, like capabilities.publish, an enterprise POLICY must be able
     # to close. Making install a capability row lets a managed-fleet ceiling
     # ban pack installation wholesale (consulted in ``api_themes_install``).
-    # Default True: policy-absence keeps install working for the standalone
-    # single-user owner; a governing policy can pin it off. Data row only —
+    # Default True: naming the row without ``enabled`` keeps install working for the
+    # standalone single-user owner; a governing policy can pin it off. Data row only —
     # CONTRACT_VERSION and the evaluator are untouched (mirrors theme_persona).
     "capabilities.theme_install": ScopeSpec(CAPABILITY, capability_default=True),
     # The anonymous heartbeat (``beacon.py``) and official-app install receipt
@@ -1019,7 +1048,8 @@ SCOPE_CATALOG: Dict[str, ScopeSpec] = {
     # ``security._SENSITIVE_HOME_DIRS``, so the agent can neither read nor rewrite
     # its own ceiling.
     #
-    # Default True: policy-absence keeps the documented default-on behavior for the
+    # Default True: naming the row without ``enabled`` keeps the documented default-on
+    # behavior for the
     # standalone user, who still has the toggle, the CLI, and the env var. Consulted
     # at THREE chokepoints, because any one alone would be a half-control:
     #   * ``beacon.should_send`` — blocks the send itself (the actual egress);
@@ -1052,12 +1082,12 @@ SCOPE_CATALOG: Dict[str, ScopeSpec] = {
     # ``security._SENSITIVE_HOME_DIRS`` — the agent can neither read nor rewrite
     # its own ceiling.
     #
-    # Default True: policy-absence must keep TODAY's behaviour byte-for-byte.
-    # The feature is already off by default in config, so a default of False
-    # would mean a fleet policy that governs some OTHER ``capabilities.*`` row
-    # silently forbids tailnet derivation it never mentioned — a behaviour change
-    # for an unrelated policy, which is the failure ``capability_default`` exists
-    # to avoid (Validation rule 8). An enterprise that wants it off says so.
+    # Default True: naming this row without ``enabled`` must keep TODAY's behaviour
+    # byte-for-byte. The feature is already off by default in config, so a default
+    # of False would deny tailnet derivation for a policy that mentioned the row
+    # only to configure something about it. (An unnamed row is ungoverned and
+    # permitted regardless of this default — see the CAPABILITY-DEFAULT CONTRACT
+    # above.) An enterprise that wants it off says so.
     # Consulted at THREE chokepoints, because any one alone is a half-control:
     #   * ``tailnet.resolve_tailnet_host`` — returns "" so no origin is derived
     #     and the daemon is not even consulted (the action itself);

--- a/test/test_governance_policy.py
+++ b/test/test_governance_policy.py
@@ -19,6 +19,7 @@ import pytest
 
 from kiro_crew.platform.context import PlatformCompositionError
 from kiro_crew.platform.governance import (
+    CAPABILITY,
     MODE_ALLOW,
     MODE_DENY,
     SCOPE_CATALOG,
@@ -1414,3 +1415,142 @@ class TestPolicyShowReporting:
     def test_show_no_policy_unchanged(self, capsys):
         out = self._show(capsys, None)
         assert "No enterprise security policy is active" in out
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Capability omission — the settled contract
+# ──────────────────────────────────────────────────────────────────────────
+def _capability_scopes() -> list[str]:
+    return [name for name, spec in SCOPE_CATALOG.items() if spec.kind == CAPABILITY]
+
+
+class TestCapabilityOmissionIsUngoverned:
+    """An unnamed capability is UNGOVERNED and therefore PERMITTED. On purpose.
+
+    This class exists because the opposite is an inviting mistake. Several
+    ``SCOPE_CATALOG`` comments once described ``capability_default`` as applying
+    when a policy "governs ``capabilities.*`` but omits" a row, which does not
+    match the code. The tempting fix is to make the code match the comments by
+    filling unnamed rows with their registered defaults.
+
+    That fix was implemented, measured, and rejected. Three reasons, recorded here
+    so the next person does not repeat it:
+
+    1. It breaks the model's central invariant. Omission means
+       ungoverned-and-permitted for `mcp`, `tools`, `commands`, `filesystem.*` and
+       `network.egress`; making `capabilities` the one archetype that infers a
+       value is a per-control special case in an evaluator whose stated contract
+       is that it dispatches on archetype and never on scope name.
+    2. It requires a namespace-specific branch in ``_parse_controls``, whose
+       documented contract is that a newly ``register_scope``'d family parses with
+       NO loader edit. A companion's own capability family would not get the same
+       treatment, so the behaviour would not even be uniform.
+    3. It destroys an audit signal. ``Decision.layer == "default"`` means "nothing
+       governed this", which is what operators are told to alert on to find
+       missing controls. A row filled from a catalog default resolves at
+       ``layer="policy"`` and so becomes indistinguishable from one a human
+       actually wrote.
+
+    The real defect was documentation, and the protection is
+    ``kirocrew policy validate`` reporting a partially-governed block.
+    """
+
+    def test_unnamed_capability_is_permitted_and_reads_as_ungoverned(self):
+        ceiling = parse_policy(_policy_body(capabilities={"script_hooks": {"enabled": False}}))
+        for scope in _capability_scopes():
+            if scope == "capabilities.script_hooks":
+                continue
+            decision = resolve(ceiling, None, scope, "")
+            assert decision.permitted, f"{scope} must be permitted by omission"
+            # Load-bearing: `default` is the audit signal for "nobody governed
+            # this". A filled-in row would report `policy` and hide the gap.
+            assert decision.layer == "default", f"{scope} must read as ungoverned"
+
+    def test_named_row_is_still_governed(self):
+        ceiling = parse_policy(_policy_body(capabilities={"script_hooks": {"enabled": False}}))
+        decision = resolve(ceiling, None, "capabilities.script_hooks", "")
+        assert not decision.permitted
+        assert decision.layer == "policy"
+
+    def test_omission_behaves_identically_across_archetypes(self):
+        """The consistency argument, asserted rather than assumed."""
+        ceiling = parse_policy(_policy_body(capabilities={"cron": {"enabled": False}}))
+        for scope, item in (
+            ("mcp", "@anything/tool"),
+            ("tools", "anything"),
+            ("commands", "echo hi"),
+            ("filesystem.read", "/etc/hosts"),
+            ("network.egress", "example.com"),
+            ("capabilities.messaging", ""),
+        ):
+            decision = resolve(ceiling, None, scope, item)
+            assert decision.permitted, f"unnamed {scope} must permit"
+            assert decision.layer == "default", f"unnamed {scope} must read as ungoverned"
+
+    def test_no_capabilities_block_leaves_every_capability_ungoverned(self):
+        ceiling = parse_policy(_policy_body(commands={"mode": MODE_DENY, "deny": ["nc *"]}))
+        for scope in _capability_scopes():
+            assert resolve(ceiling, None, scope, "").permitted
+
+    def test_present_key_without_enabled_uses_the_registered_default(self):
+        """The case ``capability_default`` DOES cover — and the only one.
+
+        Naming a capability to configure its inner scopes, without saying whether
+        it is on, resolves to the registered default: off for the exfil surfaces,
+        on for the benign ones.
+        """
+        ceiling = parse_policy(
+            _policy_body(
+                capabilities={
+                    "publish": {"scopes": {"destinations": {"mode": MODE_ALLOW, "allow": ["x"]}}},
+                    "spawn": {"scopes": {"agents": {"mode": MODE_ALLOW, "allow": ["a"]}}},
+                }
+            )
+        )
+        assert not resolve(ceiling, None, "capabilities.publish", "").permitted
+        assert SCOPE_CATALOG["capabilities.publish"].capability_default is False
+        assert resolve(ceiling, None, "capabilities.spawn", "").permitted
+        assert SCOPE_CATALOG["capabilities.spawn"].capability_default is True
+
+
+class TestValidateReportsUngovernedCapabilities:
+    """`kirocrew policy validate` must surface a partially-governed block.
+
+    Since omission cannot deny, the only protection against an author believing
+    otherwise is telling them which rows they left open.
+    """
+
+    def _validate(self, capsys, ceiling):
+        import argparse
+        from unittest.mock import patch
+
+        from kiro_crew import cli_commands
+
+        args = argparse.Namespace(policy_action="validate")
+        with patch(
+            "kiro_crew.platform.context.current_context",
+            return_value=type("Ctx", (), {"governance": ceiling})(),
+        ):
+            cli_commands._policy(args)
+        return capsys.readouterr().out
+
+    def test_partial_block_lists_the_ungoverned_rows(self, capsys):
+        ceiling = parse_policy(_policy_body(capabilities={"script_hooks": {"enabled": False}}))
+        out = self._validate(capsys, ceiling)
+        assert "UNGOVERNED" in out
+        assert "Omission does not deny" in out
+        assert "capabilities.cron" in out
+        # The row the author DID name must not be reported as a gap.
+        assert "capabilities.script_hooks\n" not in out.split("UNGOVERNED", 1)[1]
+
+    def test_fully_enumerated_block_reports_no_gap(self, capsys):
+        body = {scope.split(".", 1)[1]: {"enabled": True} for scope in _capability_scopes()}
+        out = self._validate(capsys, parse_policy(_policy_body(capabilities=body)))
+        assert "UNGOVERNED" not in out
+        assert "✅ valid" in out
+
+    def test_policy_that_never_mentions_capabilities_reports_no_gap(self, capsys):
+        """Silence about capabilities entirely is not a partial statement."""
+        ceiling = parse_policy(_policy_body(commands={"mode": MODE_DENY, "deny": ["nc *"]}))
+        out = self._validate(capsys, ceiling)
+        assert "UNGOVERNED" not in out


### PR DESCRIPTION
## Problem

Several `SCOPE_CATALOG` comments describe `capability_default` as applying when a
policy **governs `capabilities.*` but omits a row**. It does not. `capabilities.publish`
states it outright:

> when a policy governs capabilities.\* but omits publish, publishing is denied

That is false. `_parse_controls` materializes only the children physically present
in the document, so an unnamed capability is an **absent scope**, and `resolve`
returns `_PERMIT_NOT_GOVERNED` for an absent scope. A policy cannot deny a
capability by leaving it out.

Verified by executing the real parser and resolver against a policy whose
`capabilities` block names only `script_hooks`:

```
ceiling.controls keys        -> ['capabilities.script_hooks']

capabilities.cron            get() -> None
capabilities.publish         get() -> None
capabilities.messaging       get() -> None

resolve(capabilities.cron)      permitted=True  layer='default'
resolve(capabilities.publish)   permitted=True  layer='default'
resolve(capabilities.messaging) permitted=True  layer='default'
```

## Why it matters

A policy author who reasons from the comment believes `script_hooks`, `cron`,
`messaging` and `publish` are closed by omission. They are open. The comment
asserts a fail-closed property the code does not provide, on four controls that
include script execution and an external-side-effect surface.

This is a documentation defect pointing the unsafe direction, not a resolver bug —
which is why the fix below corrects the comments and adds a diagnostic rather than
changing what any policy resolves to.

## Fix

**Symptom** → the comments and the code disagree about what an omitted capability
key means.

**Root cause** → `capability_default` is real but narrower than documented. It
supplies `enabled` only when the capability's key **is present** without it, e.g.
`"publish": {"scopes": {"destinations": {...}}}` — configuring publish's
destinations without stating whether publish is on, which then resolves to
publish's registered `off`. That path is reachable and deliberate. Only its
documented *scope* was wrong.

**Change** → three parts.

1. **Keep the behaviour.** Making a governed `capabilities` block fill its unnamed
   rows from their registered defaults was implemented, measured, and rejected:

   - It breaks the model's central invariant. Omission already means
     ungoverned-and-permitted for `mcp`, `tools`, `commands`, `filesystem.*` and
     `network.egress`. Making `capabilities` the one archetype that infers a value
     is the per-control special case the four-shape design exists to prevent, in an
     evaluator whose contract is to dispatch on archetype and never on scope name.
   - It needs a namespace-specific branch in `_parse_controls`, whose documented
     contract is that a newly `register_scope`'d family parses with **no loader
     edit**. Gated on the literal `capabilities` key it would not treat a
     separately registered capability family the same way, so the behaviour would
     not even be uniform.
   - It destroys an audit signal. `Decision.layer == "default"` means "nothing
     governed this" and is the cheapest detector for a control missing from a
     policy. A row filled from a catalog default resolves at `layer="policy"` and
     becomes indistinguishable from one a human wrote.

2. **Correct the comments.** Replaces the scattered, and in one case actively
   wrong, `policy-absence` wording with a single `CAPABILITY-DEFAULT CONTRACT`
   note above `SCOPE_CATALOG` stating what the default does cover, what it does
   not, and why capabilities are not a special case. The `publish`, `theme_persona`,
   `theme_install`, `telemetry` and `tailnet_origin` comments are corrected in
   place. `tailnet_origin`'s justification argued from a scenario that cannot
   occur, so its reasoning is restated against the case that can.

3. **Surface the gap instead of inferring a value.** `kirocrew policy validate`
   now reports a partially-governed `capabilities` block and names the rows left
   open. It fires only when the policy governs `capabilities` **and** leaves rows
   unnamed — a policy that never mentions capabilities is not a partial statement
   and is silent, and a fully enumerated block is silent. Read from
   `ceiling.controls` + `SCOPE_CATALOG`, so it covers any registered capability
   rather than a hardcoded list.

```
Policy: v1 OK (3 governed scopes).
   ⚠️  governs capabilities but leaves 8 row(s) UNGOVERNED (therefore permitted):
        capabilities.cron
        capabilities.memory_writes
        capabilities.messaging
        capabilities.publish
        capabilities.spawn
        capabilities.tailnet_origin
        capabilities.telemetry
        capabilities.theme_persona
      Omission does not deny. Name each row explicitly (enabled true or false) if you meant to decide it.
   (no profiles directory)
✅ valid
```

**No policy's resolved behaviour changes.** `platform/governance.py` is
comments-only; the sole functional change is the new `validate` output in
`cli_commands.py`.

## Tests

`test/test_governance_policy.py`, two new classes, 8 tests.

`TestCapabilityOmissionIsUngoverned` pins the settled contract, and its docstring
records the rejected alternative with all three reasons so the next reader does not
re-attempt it:

- `test_unnamed_capability_is_permitted_and_reads_as_ungoverned` — permitted, and
  asserts `layer == "default"`, which is the audit property a fill step would break.
- `test_named_row_is_still_governed`
- `test_omission_behaves_identically_across_archetypes` — asserts `mcp`, `tools`,
  `commands`, `filesystem.read`, `network.egress` and `capabilities.messaging` all
  behave the same when unnamed, turning the consistency argument into a gate.
- `test_no_capabilities_block_leaves_every_capability_ungoverned`
- `test_present_key_without_enabled_uses_the_registered_default` — the path
  `capability_default` does cover, asserted against the registered values so a
  future default flip fails here rather than silently.

`TestValidateReportsUngovernedCapabilities` covers the new output: partial block
lists the gaps, fully enumerated block reports none, and a policy that never
mentions capabilities reports none.

No existing test needed changing, which is itself the evidence that resolved
behaviour is unchanged.

## Manual verification

Local gates on the branch:

- `pytest` — 229 passed across `test_governance_policy.py`,
  `test_governance_policy_viewer.py`, `test_governance_profiles.py`,
  `test_governance_boot.py`. Wider run across all 10 governance suites plus
  `test_beacon.py` and `test_tailnet_governance.py` (the two policy-layer-only
  capabilities): 711 passed.
- `isort --check-only` — clean on all three changed files.
- `flake8` — clean on all three changed files.
- `mypy` — no findings in `platform/governance.py` or `cli_commands.py`. Three
  pre-existing `hooks.py` `os.setxattr` findings reproduce with this branch's
  changes stashed (macOS-only API), so they are base, not this change.
- `scripts/check_brand_name.py` — exit 0.

End-to-end, against an isolated data home with a policy whose `capabilities` block
names only `script_hooks` and `theme_install`, `kirocrew policy validate` produced
the output quoted above; with every row named it printed no warning; with no
`capabilities` key it printed no warning.
