### PR TITLE
fix(session-pid): rewrite PID files atomically so a failed write cannot silently drop runtimes

### DIFF
--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 from kiro_crew.constants import KIROCREW_SPAWNED_ENV, KIROCREW_SPAWNED_VALUE
 from kiro_crew.providers.base import LLMProvider
@@ -184,6 +185,40 @@ def _pid_file_lock():  # type: ignore[no-untyped-def]
             yield
 
 
+def _rewrite_pid_file(path: Path, content: str) -> bool:
+    """Replace *path*'s content atomically; log and return ``False`` on failure.
+
+    Atomic (temp file + rename) because a plain ``write_text`` truncates the
+    file to zero BEFORE writing the kept entries: a failure inside that window
+    leaves a SHORT file whose surviving content is perfectly well-formed, and
+    every dropped entry is an agent runtime no reaper can find again.
+
+    A failure here is REPORTED, not propagated. Pruning an entry is idempotent
+    and self-retrying: the next sweep — or the next gateway start — re-reads the
+    file, finds that PID already dead, and prunes it again, so a failed rewrite
+    costs one stale line rather than a runtime. Propagating would be worse than
+    the problem: ``cleanup_orphaned_sessions`` runs unguarded on the gateway's
+    startup path, and on Windows ``replace_with_retry`` deliberately declines to
+    retry a sharing violation while an event loop is running (an indexer or AV
+    scanner holding the temp file is enough), so an escaping error there aborts
+    startup entirely.
+
+    The tracking direction is the opposite case and must NOT be quieted this
+    way: failing to RECORD a freshly spawned PID is unrecoverable, because no
+    reaper can identify that runtime afterwards.
+    """
+    try:
+        atomic_write(path, content)
+        return True
+    except OSError:
+        logger.error(
+            "Could not rewrite PID file %s; its entries stay until the next sweep",
+            path,
+            exc_info=True,
+        )
+        return False
+
+
 # Basenames of agent runtimes whose lifecycle Kiro Crew manages through PID-file
 # tracking (kiro_pids.txt / kiro_session_pids.txt). Used to re-validate tracked
 # PIDs before a kill, and as a NEGATIVE gate in the work-orphan sweep: these
@@ -308,7 +343,15 @@ def _kill_pid_tree(pid: int) -> tuple[int, bool]:
 
 
 def _write_back_pid_file(killed_or_dead: set[str]) -> None:
-    """Remove *killed_or_dead* entries from the session PID file."""
+    """Remove *killed_or_dead* entries from the session PID file.
+
+    Rewrites via :func:`atomic_write` (temp file + rename). A plain
+    ``write_text`` truncates the file to zero BEFORE writing the kept entries,
+    so a crash or a write failure inside that window leaves a SHORT file whose
+    surviving content is perfectly well-formed — every dropped entry becomes an
+    agent runtime no reaper can ever find again, with nothing raised and
+    nothing logged. Rename makes the file either wholly old or wholly new.
+    """
     with _session_pid_file_lock():
         path = _session_pid_file_path()
         if path.exists():
@@ -316,10 +359,7 @@ def _write_back_pid_file(killed_or_dead: set[str]) -> None:
             keep = [
                 entry for entry in current if entry.strip() and entry.strip() not in killed_or_dead
             ]
-            path.write_text(
-                ("\n".join(keep) + "\n") if keep else "",
-                encoding="utf-8",
-            )
+            _rewrite_pid_file(path, ("\n".join(keep) + "\n") if keep else "")
 
 
 def _sweep_pid_entries(
@@ -638,10 +678,7 @@ def _cleanup_orphaned_mcp_servers() -> int:
 
         if lines_to_remove:
             kept = [ln for ln in lines if ln.strip() not in lines_to_remove]
-            path.write_text(
-                "\n".join(kept) + "\n" if kept else "",
-                encoding="utf-8",
-            )
+            _rewrite_pid_file(path, "\n".join(kept) + "\n" if kept else "")
 
     return killed
 
@@ -912,7 +949,7 @@ def _untrack_child_pids(pids: Mapping[int, object]) -> None:
         lines = [
             ln for ln in lines if ":" not in ln.strip() or ln.strip().split(":")[0] not in to_remove
         ]
-        path.write_text("\n".join(lines) + "\n" if lines else "", encoding="utf-8")
+        _rewrite_pid_file(path, "\n".join(lines) + "\n" if lines else "")
 
 
 def _untrack_pid(pid: int) -> None:
@@ -923,7 +960,7 @@ def _untrack_pid(pid: int) -> None:
             return
         lines = path.read_text(encoding="utf-8").splitlines()
         lines = [ln for ln in lines if ln.strip() != str(pid)]
-        path.write_text("\n".join(lines) + "\n" if lines else "", encoding="utf-8")
+        _rewrite_pid_file(path, "\n".join(lines) + "\n" if lines else "")
 
 
 def _untrack_session_pid(pid: int) -> None:
@@ -943,7 +980,7 @@ def _untrack_session_pid(pid: int) -> None:
         lines = [
             ln for ln in lines if ln.strip() != prefix and not ln.strip().startswith(prefix + ":")
         ]
-        path.write_text("\n".join(lines) + "\n" if lines else "", encoding="utf-8")
+        _rewrite_pid_file(path, "\n".join(lines) + "\n" if lines else "")
 
 
 # ── Sweep-protected PIDs ──────────────────────────────────────────────────

--- a/test/test_pid_lifecycle.py
+++ b/test/test_pid_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import signal
 import subprocess
@@ -2143,3 +2144,169 @@ class TestSweepSparesLiveProcess:
         finally:
             victim.kill()
             victim.wait()
+
+
+class TestPidFileRewriteIsAtomic:
+    """A PID-file rewrite must be atomic AND must never propagate its failure.
+
+    Atomic: ``Path.write_text`` truncates the target to zero BEFORE writing the
+    kept entries. A failure — or a hard kill — inside that window leaves a SHORT
+    file whose surviving content is still perfectly well-formed: nothing raised,
+    nothing logged, and every dropped entry is an agent runtime that no reaper
+    can ever find again, because these PID files are the ONLY record of which
+    runtimes this gateway owns.
+
+    Reported, not propagated: pruning an entry is idempotent and self-retrying,
+    so a failed rewrite costs one stale line. Propagating would cost the whole
+    gateway — ``cleanup_orphaned_sessions`` runs unguarded on the startup path,
+    and on Windows ``replace_with_retry`` declines to retry a sharing violation
+    while an event loop is running.
+
+    These tests fail the rename and then assert the original file is untouched,
+    which a truncating writer cannot satisfy because by then it has already
+    destroyed the original.
+    """
+
+    @staticmethod
+    def _fail_rename(*_args: object, **_kwargs: object) -> None:
+        raise OSError(28, "No space left on device")
+
+    @staticmethod
+    def _assert_reported(caplog: pytest.LogCaptureFixture) -> None:
+        assert any(
+            r.levelno >= logging.ERROR and "Could not rewrite PID file" in r.getMessage()
+            for r in caplog.records
+        ), "a failed PID-file rewrite must be reported at ERROR, never silently"
+
+    def test_write_back_failure_preserves_every_entry(
+        self,
+        session_pid_file: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from kiro_crew.session_pid import _write_back_pid_file
+
+        original = "100:200:tokA\n101:201:tokB\n102:202:tokC\n"
+        session_pid_file.write_text(original, encoding="utf-8")
+        monkeypatch.setattr("kiro_crew.atomic_write.replace_with_retry", self._fail_rename)
+
+        with caplog.at_level(logging.ERROR, logger="kiro_crew.session_pid"):
+            _write_back_pid_file({"101:201:tokB"})
+
+        # The rewrite never landed, so the ledger must still name all three
+        # runtimes. A truncating writer leaves only two — and the two it leaves
+        # look entirely valid, which is what makes the loss silent.
+        assert session_pid_file.read_text(encoding="utf-8") == original
+        self._assert_reported(caplog)
+
+    def test_untrack_session_pid_failure_preserves_every_entry(
+        self,
+        session_pid_file: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from kiro_crew.session_pid import _untrack_session_pid
+
+        gw = os.getpid()
+        original = f"{gw}:900:tokX\n{gw}:901:tokY\n"
+        session_pid_file.write_text(original, encoding="utf-8")
+        monkeypatch.setattr("kiro_crew.atomic_write.replace_with_retry", self._fail_rename)
+
+        with caplog.at_level(logging.ERROR, logger="kiro_crew.session_pid"):
+            _untrack_session_pid(900)
+
+        assert session_pid_file.read_text(encoding="utf-8") == original
+        self._assert_reported(caplog)
+
+    def test_untrack_pid_failure_preserves_every_entry(
+        self,
+        pid_file: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from kiro_crew.session_pid import _untrack_pid
+
+        original = "700\n701\n702\n"
+        pid_file.write_text(original, encoding="utf-8")
+        monkeypatch.setattr("kiro_crew.atomic_write.replace_with_retry", self._fail_rename)
+
+        with caplog.at_level(logging.ERROR, logger="kiro_crew.session_pid"):
+            _untrack_pid(701)
+
+        assert pid_file.read_text(encoding="utf-8") == original
+        self._assert_reported(caplog)
+
+    def test_untrack_child_pids_failure_preserves_every_entry(
+        self,
+        pid_file: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from kiro_crew.session_pid import _untrack_child_pids
+
+        original = "800:1\n801:1\n"
+        pid_file.write_text(original, encoding="utf-8")
+        monkeypatch.setattr("kiro_crew.atomic_write.replace_with_retry", self._fail_rename)
+
+        with caplog.at_level(logging.ERROR, logger="kiro_crew.session_pid"):
+            _untrack_child_pids({801: object()})
+
+        assert pid_file.read_text(encoding="utf-8") == original
+        self._assert_reported(caplog)
+
+    @pytest.mark.asyncio
+    async def test_windows_loop_sharing_violation_does_not_abort_caller(
+        self,
+        session_pid_file: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The startup path survives a Windows sharing violation on the rename.
+
+        ``replace_with_retry`` deliberately refuses to sleep-retry while an event
+        loop is running, so on Windows a scanner holding the temp file surfaces
+        as an immediate ``PermissionError``. ``cleanup_orphaned_sessions`` calls
+        this rewrite unguarded during gateway start, so the error escaping here
+        would abort startup.
+        """
+        from kiro_crew.session_pid import _write_back_pid_file
+
+        def _sharing_violation(*_a: object, **_kw: object) -> None:
+            raise PermissionError(32, "The process cannot access the file")
+
+        original = "100:200:tokA\n101:201:tokB\n"
+        session_pid_file.write_text(original, encoding="utf-8")
+        monkeypatch.setattr("kiro_crew.platform_compat.IS_WINDOWS", True)
+        monkeypatch.setattr("kiro_crew.atomic_write.os.replace", _sharing_violation)
+
+        # Runs with a live event loop, which is what disables the retry.
+        with caplog.at_level(logging.ERROR, logger="kiro_crew.session_pid"):
+            _write_back_pid_file({"101:201:tokB"})
+
+        assert session_pid_file.read_text(encoding="utf-8") == original
+        self._assert_reported(caplog)
+
+    def test_successful_rewrite_lands_and_leaves_no_temp_residue(
+        self, session_pid_file: Path
+    ) -> None:
+        from kiro_crew.session_pid import _write_back_pid_file
+
+        session_pid_file.write_text("100:200:tokA\n101:201:tokB\n", encoding="utf-8")
+
+        _write_back_pid_file({"101:201:tokB"})
+
+        assert session_pid_file.read_text(encoding="utf-8") == "100:200:tokA\n"
+        # atomic_write's mkstemp companion must not survive the rename.
+        assert not list(session_pid_file.parent.glob("*.tmp"))
+
+    def test_no_truncating_writer_remains_in_session_pid(self) -> None:
+        """Ratchet: every PID-file rewrite goes through the atomic chokepoint."""
+        import kiro_crew.session_pid as sp
+
+        source = Path(str(sp.__file__)).read_text(encoding="utf-8")
+        assert ".write_text(" not in source, (
+            "session_pid.py must rewrite PID files through _rewrite_pid_file(): "
+            "Path.write_text truncates the file before writing, so a failure "
+            "mid-write silently drops entries and leaks their runtimes until "
+            "the host reboots."
+        )


### PR DESCRIPTION
## What is the problem?

`session_pid.py` rewrote both PID files through `Path.write_text`, at five sites:
`_write_back_pid_file`, `cleanup_orphaned_session_roots`, `_untrack_child_pids`,
`_untrack_pid` and `_untrack_session_pid`.

`Path.write_text` truncates the target to zero **before** writing the kept
entries. A failure — or a hard kill — inside that window leaves a **short** file
whose surviving content is still perfectly well-formed: correct encoding, correct
format, just fewer lines. Nothing is raised and nothing is logged.

`kiro_pids.txt` and `kiro_session_pids.txt` are the *only* record of which agent
runtimes this gateway owns. Every reaper keys off them:
`cleanup_orphaned_sessions` at startup, `_periodic_pid_sweep` and
`cleanup_orphaned_session_roots` on the sweep interval. The `/proc` orphan scan
does **not** back them up for agent runtimes — `_is_sweepable_orphan_work`
excludes `_MANAGED_AGENT_MARKERS` on purpose, because those runtimes are meant to
be reclaimed by exactly this PID-file lifecycle.

So a dropped line is not a lost record. It is an agent runtime that no reaper can
ever find again.

The window is reached routinely rather than exceptionally: `_write_back_pid_file`
rewrites the session PID file on every sweep cycle that prunes an entry, and the
loop-stall watchdog terminates the gateway via `faulthandler`'s `exit=True`,
which runs no cleanup path.

## Why this issue matters to the user

An agent runtime holds hundreds of MB. A handful that nobody reaps is measured in
gigabytes the user cannot get back without noticing the processes and killing
them by hand.

The failure mode is the worst kind: no error, no log line, no degraded behaviour
at the time. The file left behind looks healthy, so nothing downstream suspects
it. Memory is simply lower than yesterday, and stays lower until the host
reboots.

## How our fix solves it

Symptom → root cause chain:

1. Memory disappears with no error and no leaked-process report.
2. The runtimes holding it are alive but absent from `kiro_session_pids.txt`.
3. Every agent-runtime reaper consults only that file, and the `/proc` scan
   deliberately declines agent runtimes, so an absent entry is unreachable.
4. Entries go absent because a rewrite truncated the file first and then failed
   part-way — silently, since the remainder is valid.
5. Root cause: the rewrite is not atomic.

All five rewrites now go through one chokepoint, `_rewrite_pid_file`, which
writes via `atomic_write` (temp file + `os.replace`, already the pattern in 187
call sites) and **reports** a failure at ERROR instead of propagating it. The
file on disk is either wholly the old content or wholly the new one, so a failed
rewrite loses nothing.

**Why reporting rather than propagating is the correct direction here.** Pruning
an entry is idempotent and self-retrying: the next sweep, or the next gateway
start, re-reads the file, finds that PID already dead, and prunes it again — so a
failed rewrite costs one stale line, not a runtime. Propagating would cost more
than the problem it reports: `cleanup_orphaned_sessions` calls this rewrite
**unguarded** on the gateway's startup path, and `replace_with_retry`
deliberately declines to sleep-retry a Windows sharing violation while an event
loop is running (holding the loop for the retry budget would be worse), so an
escaping error there aborts startup entirely. An indexer or AV scanner touching
the freshly written temp file is enough to trigger it.

The tracking direction is the opposite case and is deliberately **not** quieted
the same way: failing to RECORD a freshly spawned PID is unrecoverable, because
no reaper can identify that runtime afterwards. That asymmetry is stated in
`_rewrite_pid_file`'s docstring so the guard is not later copied to the wrong
place.

`fsync` stays at its default (off), matching every other caller: rename ordering
is what protects against a *killed process*, which is the case here. Only
whole-host power loss would need the flush, and paying it on every sweep cycle
buys nothing for this failure mode.

Note this fixes the "written, then later lost" half of #2930. The other half — a
tracking write that never lands at all, swallowed at debug level in
`acp/runtime.py` — is untouched here and still reproducible, so this PR
deliberately does not close the issue.

## What tests we did

New `TestPidFileRewriteIsAtomic` in `test/test_pid_lifecycle.py`. The tests fail
the rename and then assert the original file is **untouched** — an assertion a
truncating writer cannot satisfy, because by that point it has already destroyed
the original. Coverage: all four rewrite entry points reachable from the test
seam, the Windows sharing-violation path **with a live event loop** (the startup
case, which is where a propagating error would abort the gateway), a success-path
check that the content lands and no `.tmp` companion survives the rename, and a
source-level ratchet so a truncating writer cannot come back.

- **Mutation verified, both invariants separately:**
  - Reverting the write to `path.write_text` (dropping atomicity) turns **6 of 7**
    red — the seventh is the success-path test, which a truncating writer also
    satisfies, correctly so since it does not assert atomicity.
  - Removing the report-don't-propagate guard turns **5 of 7** red, including the
    Windows-on-loop startup case.
- Ran the 85 test files that reference `session_pid` or `atomic_write`: **6712
  passed**, and the failure set is **identical to the base commit** (`comm -13`
  and `comm -23` against a base run of the same 85 files both return empty). The
  7 pre-existing failures are all in `test_dashboard_peer_auth.py` (unix-socket
  peer auth) and `test_xdist_auto_cap.py`, are host-environment specific, and
  touch none of the changed code. Passed count is base + 7, exactly the new
  tests.
- `isort --check-only`, `flake8`, and `mypy src/kiro_crew/` (891 files) all clean,
  with mypy on a venv matching the `pyproject.toml` pin (1.14.1) and without
  `faiss` installed, per the CI-parity rule.
- No frontend files changed, so `tsc` / `vitest` / the i18n gates are not
  applicable.

## Any other suggestions on the work

Two follow-ups this PR deliberately leaves alone:

1. **The other half of #2930.** `acp/runtime.py` wraps `_track_pid` /
   `_track_session_pid` in `try: ... except Exception: logger.debug(...)`. If the
   append fails (ENOSPC, fd exhaustion, lock error) the runtime keeps working
   perfectly and is unreapable for the rest of the host's uptime, with one debug
   line as the only trace. `acp/client.py` has the inverse shape — no
   `try`/`finally` between subprocess creation and the tracking call — so an
   exception there unwinds with a live, untracked process already running. That is
   a separate change to error handling, not to durability, and it is the half that
   still reproduces.

2. **`atomic_write` adoption is not enforced anywhere.** The ratchet added here is
   scoped to `session_pid.py`. Other modules that persist
   reaper-or-recovery-critical state through `write_text` would have the same
   silent-truncation exposure; a repo-wide audit would be a reasonable separate
   pass, but blanket-converting every `write_text` is not obviously correct and
   should not ride along here.

Refs #2930
