### PR TITLE
feat(apps): dark-appearance app icons

### DIFF
--- a/docs/app-kit/publishing-guide.md
+++ b/docs/app-kit/publishing-guide.md
@@ -94,10 +94,21 @@ Path form depends on distribution: a registry app uses a repo-relative path
 
 | Field | Rendered where | Aspect |
 |-------|----------------|--------|
-| `iconPath` | Card and row icon, and the gradient fallback's centerpiece | Square PNG with transparency; 256x256 or larger |
+| `iconPath` / `iconPathDark` | Card and row icon, the sidebar glyph, and the gradient fallback's centerpiece | Square, **512x512**, **opaque** — no transparency. The dark variant is optional |
 | `screenshots` / `screenshotsDark` | Detail-page gallery with a lightbox; the first screenshot is also the last-resort hero | Landscape; around 1200px wide |
 | `heroImage` / `heroImageDark` | Discover rows, Library rows, the featured spotlight, feature cards, and the detail banner when no detail-specific art exists | 16:9 (for example 1200x675) |
 | `heroImageDetail` / `heroImageDetailDark` | Detail-page banner only, preferred there over `heroImage` | 25:6 (for example 1200x288) |
+
+The required icon must be **opaque**. An opaque tile carries its own
+background, so it reads correctly on any surface — which is what makes
+`iconPathDark` genuinely optional rather than a latent bug. A transparent icon
+that looks right on light chrome turns into a dark smear on dark chrome, and an
+app that then omits the dark variant ships a broken card.
+
+Built-in first-party apps take a different path: their icon is an SVG under
+`/app-assets/`, inlined and painted from the theme's `--ico-a` / `--ico-b`
+tokens, so a single file covers both appearances and no dark variant exists.
+Raster art cannot repaint, which is the whole reason the variant field is here.
 
 Ship hero art. Every store surface uses it, and it is the difference between
 looking like a product and looking like a list entry.

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -934,10 +934,23 @@ def _merge_manifest(entry: dict[str, Any], manifest: dict[str, Any]) -> dict[str
     if "platform" in manifest:
         result["platform"] = manifest["platform"]
 
-    # Icon — convert repo-relative path to blob proxy URL
+    # Icon — convert repo-relative path to blob proxy URL.
+    #
+    # Only ``iconPath`` (repo-relative) is honoured, never a manifest-declared
+    # ``iconUrl``: an index-fetched manifest is untrusted content, and copying an
+    # absolute URL out of it would let a third party point the store's <img> at
+    # any host it likes. Rewriting a repo-relative path keeps every icon fetch
+    # on our own proxy, which enforces the extension allowlist and the
+    # trusted-host gate.
     icon_path = manifest.get("iconPath", "")
     if icon_path and repo:
         result["iconUrl"] = f"/api/apps/blob?repo={repo}&path={icon_path}"
+    # Dark-appearance variant. Raster icons have fixed bytes, so an app that
+    # must read well on both backgrounds ships two files; first-party
+    # ``/app-assets/`` SVGs are inlined and repaint from theme tokens instead.
+    icon_path_dark = manifest.get("iconPathDark", "")
+    if icon_path_dark and repo:
+        result["iconUrlDark"] = f"/api/apps/blob?repo={repo}&path={icon_path_dark}"
     # Lucide fallback icon from manifest extra fields
     if manifest.get("icon"):
         result["icon"] = manifest["icon"]

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -1470,3 +1470,34 @@ class TestMergeManifestProjectsRegistryKeys:
         entry = {"name": "demo-app", "_index_author": "Kiro Crew"}
         out = registry._merge_manifest(entry, self.MANIFEST)
         assert out["_index_author"] == "Kiro Crew"
+
+    def test_dark_icon_path_becomes_a_blob_url(self):
+        """A raster icon cannot repaint from theme tokens, so an app may ship a
+        dark variant; it routes through the same proxy as the light one."""
+        entry = {"name": "demo-app", "repo": "DemoRepo"}
+        manifest = {**self.MANIFEST, "iconPath": "a/i.png", "iconPathDark": "a/i-dark.png"}
+        out = registry._merge_manifest(entry, manifest)
+        assert out["iconUrl"] == "/api/apps/blob?repo=DemoRepo&path=a/i.png"
+        assert out["iconUrlDark"] == "/api/apps/blob?repo=DemoRepo&path=a/i-dark.png"
+
+    def test_dark_icon_is_omitted_when_absent(self):
+        """Absence must not publish an empty string: the client treats a falsy
+        dark variant as "fall back to the light one", and an empty key would
+        also widen the payload for every app that ships one icon."""
+        entry = {"name": "demo-app", "repo": "DemoRepo"}
+        out = registry._merge_manifest(entry, {**self.MANIFEST, "iconPath": "a/i.png"})
+        assert "iconUrlDark" not in out
+
+    def test_manifest_declared_icon_url_is_never_copied(self):
+        """An index-fetched manifest is untrusted content. Honouring an absolute
+        ``iconUrl`` from it would let a third party point the store's <img> at
+        any host; only repo-relative paths rewritten through our proxy are used."""
+        entry = {"name": "demo-app", "repo": "DemoRepo"}
+        manifest = {
+            **self.MANIFEST,
+            "iconUrl": "https://evil.example/track.png",
+            "iconUrlDark": "https://evil.example/track-dark.png",
+        }
+        out = registry._merge_manifest(entry, manifest)
+        assert "iconUrl" not in out
+        assert "iconUrlDark" not in out

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1204,8 +1204,8 @@ export default function App() {
             // the builtin lucide glyph, then the generic package icon.
             const customIconUrl = target.iconUrl
             const builtinIcon = target.builtin ? getBuiltinIcon(iconName) : undefined
-            const baseIcon = customIconUrl
-              ? <AppIcon iconUrl={customIconUrl} icon={iconName} size={16} />
+            const baseIcon = customIconUrl || target.iconUrlDark
+              ? <AppIcon iconUrl={customIconUrl} iconUrlDark={target.iconUrlDark} icon={iconName} size={16} />
               : target.pageIconUrl
                 ? <img src={'/apps/' + a.name + '/ui/' + target.pageIconUrl} alt="" className="w-4 h-4 rounded-sm object-contain" />
                 : builtinIcon

--- a/website/src/appNav.ts
+++ b/website/src/appNav.ts
@@ -26,6 +26,7 @@ export interface AppNavRecord {
   orphaned?: boolean
   manifest?: {
     iconUrl?: string
+    iconUrlDark?: string
     ui?: {
       entry?: string
       pages?: Array<{ route: string; icon?: string; iconUrl?: string; label?: string }>
@@ -55,6 +56,8 @@ export interface AppNavTarget {
   builtin: boolean
   /** Custom top-level icon (an absolute `/app-assets/...` path), when the manifest has one. */
   iconUrl: string
+  /** Dark-appearance variant of `iconUrl`, when the manifest ships one. */
+  iconUrlDark: string
   /** Lucide glyph name from the app's first UI page, for the builtin icon lookup. */
   iconName: string
   /** Page-relative icon file (installed apps), resolved against `/apps/<name>/ui/`. */
@@ -102,6 +105,7 @@ export function appNavTarget(app: AppNavRecord): AppNavTarget | null {
     orphaned,
     builtin: isBuiltin,
     iconUrl: app.manifest?.iconUrl || '',
+    iconUrlDark: app.manifest?.iconUrlDark || '',
     iconName: page.icon || '',
     pageIconUrl: page.iconUrl || '',
   }

--- a/website/src/components/AppIcon.tsx
+++ b/website/src/components/AppIcon.tsx
@@ -9,12 +9,17 @@
  *       selected  → --ico-a: var(--accent) --ico-b: var(--text)
  *     Non-app-asset iconUrls (e.g. registry blob proxy) render as a plain <img>.
  *  2. A lucide-react icon from ICON_MAP (falls back to Package).
+ *
+ * Both paths honour ``iconUrlDark``: the inline path rarely needs it (theme
+ * tokens already repaint first-party SVGs), but a raster icon has fixed bytes,
+ * so an app that wants to read well on both backgrounds ships two files.
  */
 import { useEffect, useId, useMemo, useState } from 'react'
 import DOMPurify from 'dompurify'
 import {
   Shield, Bot, Search, Tag, Users, Zap, Star, Package, Cat,
 } from 'lucide-react'
+import { useTheme } from '../hooks/useTheme'
 
 const ICON_MAP: Record<string, typeof Shield> = {
   Shield, Bot, Search, Tag, Users, Zap, Star, Package, Cat,
@@ -57,18 +62,35 @@ function uniquifyIds(markup: string, prefix: string): string {
 export default function AppIcon({
   icon,
   iconUrl,
+  iconUrlDark,
   size = 20,
   selected = false,
 }: {
   icon?: string
   iconUrl?: string
+  /**
+   * Optional dark-appearance variant. Resolution mirrors ``useHeroArt``:
+   * prefer the current theme's art, fall back to the other one. Falling back
+   * in BOTH directions matters — an app that ships only a dark icon should
+   * render it in light mode rather than dropping to the lucide glyph, which
+   * would read as "this app has no icon".
+   *
+   * First-party ``/app-assets/`` SVGs do not need this: they are inlined and
+   * painted from the --ico-a/--ico-b theme tokens, so one file already covers
+   * both appearances. It exists for the raster path, where the bytes are fixed.
+   */
+  iconUrlDark?: string
   size?: number
   /** Lit (accent-dominant) vs idle (muted + accent highlight). */
   selected?: boolean
 }) {
+  const { theme } = useTheme()
+  const url = (theme === 'dark'
+    ? (iconUrlDark || iconUrl)
+    : (iconUrl || iconUrlDark)) || undefined
   const [imgFailed, setImgFailed] = useState(false)
   const [markup, setMarkup] = useState<string | null>(
-    isAppAssetSvg(iconUrl) ? svgCache.get(iconUrl) ?? null : null,
+    isAppAssetSvg(url) ? svgCache.get(url) ?? null : null,
   )
   const rawId = useId()
   // React's useId yields ':r0:' style tokens; sanitize for use in SVG ids.
@@ -87,29 +109,30 @@ export default function AppIcon({
 
   useEffect(() => {
     // Reset per-URL state so a reused AppIcon instance never shows a stale
-    // icon or a sticky failure when its iconUrl changes. Hydrate synchronously
-    // from cache when available; otherwise clear and fetch below.
+    // icon or a sticky failure when its icon changes — including a THEME flip,
+    // which changes ``url`` without any prop the parent re-keys on. Hydrate
+    // synchronously from cache when available; otherwise clear and fetch below.
     setImgFailed(false)
-    const cached = isAppAssetSvg(iconUrl) ? svgCache.get(iconUrl) ?? null : null
+    const cached = isAppAssetSvg(url) ? svgCache.get(url) ?? null : null
     setMarkup(cached)
-    if (!isAppAssetSvg(iconUrl) || svgCache.has(iconUrl)) return
+    if (!isAppAssetSvg(url) || svgCache.has(url)) return
     let cancelled = false
-    fetch(iconUrl)
+    fetch(url)
       .then((r) => (r.ok ? r.text() : Promise.reject(new Error('fetch failed'))))
       .then((text) => {
         if (text.trim().startsWith('<svg')) {
-          svgCache.set(iconUrl, text)
+          svgCache.set(url, text)
           if (!cancelled) setMarkup(text)
         }
       })
       .catch(() => { if (!cancelled) setImgFailed(true) })
     return () => { cancelled = true }
-  }, [iconUrl])
+  }, [url])
 
   // Themeable inline SVG path. The `.app-icon` class sets idle tokens
   // (--ico-a: muted, --ico-b: accent); `data-selected` OR an ancestor
   // `.group:hover` promotes to the lit accent-dominant state (see index.css).
-  if (isAppAssetSvg(iconUrl) && !imgFailed) {
+  if (isAppAssetSvg(url) && !imgFailed) {
     if (scopedMarkup) {
       return (
         <span
@@ -125,11 +148,12 @@ export default function AppIcon({
     return <span className="inline-flex shrink-0" style={{ width: size, height: size }} />
   }
 
-  // Non-app-asset image (e.g. registry blob proxy).
-  if (iconUrl && !imgFailed) {
+  // Non-app-asset image (e.g. registry blob proxy). Raster art cannot repaint
+  // from theme tokens, which is the whole reason ``iconUrlDark`` exists.
+  if (url && !imgFailed) {
     return (
       <img
-        src={iconUrl}
+        src={url}
         alt=""
         className="rounded-lg object-contain"
         style={{ width: size, height: size }}

--- a/website/src/components/appstore/AppListRow.tsx
+++ b/website/src/components/appstore/AppListRow.tsx
@@ -36,7 +36,7 @@ export default function AppListRow({ app, busy, onOpen, onGet, onUpdate, onEnabl
       onClick={onOpen}
     >
       {/* Hero capsule — 16:9 crop of the app's own art, gradient when absent */}
-      <HeroCapsule name={app.name} art={app} icon={app.icon} iconUrl={app.iconUrl} />
+      <HeroCapsule name={app.name} art={app} icon={app.icon} iconUrl={app.iconUrl} iconUrlDark={app.iconUrlDark} />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5 text-[14px] font-semibold text-text-strong">
           <span className="truncate">{appDisplayName(app)}</span>

--- a/website/src/components/appstore/FeatureCard.tsx
+++ b/website/src/components/appstore/FeatureCard.tsx
@@ -46,7 +46,7 @@ export default function FeatureCard({ app, onOpen, onGet, onEnable, busy }: {
           />
         ) : (
           <div className="w-[52px] h-[52px] rounded-[14px] bg-white/15 border border-white/25 backdrop-blur-sm grid place-items-center text-white">
-            {(app.iconUrl || app.icon) ? <AppIcon icon={app.icon} iconUrl={app.iconUrl} size={32} /> : <Package size={26} />}
+            {(app.iconUrl || app.icon) ? <AppIcon icon={app.icon} iconUrl={app.iconUrl} iconUrlDark={app.iconUrlDark} size={32} /> : <Package size={26} />}
           </div>
         )}
       </div>

--- a/website/src/components/appstore/FeaturedSpotlight.tsx
+++ b/website/src/components/appstore/FeaturedSpotlight.tsx
@@ -78,7 +78,7 @@ export default function FeaturedSpotlight({ app, onOpen, onGet, onEnable, busy }
           />
         ) : (
           <div className="w-[92px] h-[92px] rounded-3xl bg-white/15 border border-white/25 backdrop-blur-sm grid place-items-center text-white">
-            {(app.iconUrl || app.icon) ? <AppIcon icon={app.icon} iconUrl={app.iconUrl} size={56} /> : <Package size={44} />}
+            {(app.iconUrl || app.icon) ? <AppIcon icon={app.icon} iconUrl={app.iconUrl} iconUrlDark={app.iconUrlDark} size={56} /> : <Package size={44} />}
           </div>
         )}
       </div>

--- a/website/src/components/appstore/HeroCapsule.tsx
+++ b/website/src/components/appstore/HeroCapsule.tsx
@@ -26,6 +26,7 @@ export default function HeroCapsule({
   art,
   icon,
   iconUrl,
+  iconUrlDark,
   className = 'w-24 h-[54px]',
 }: {
   /** App name — seeds the deterministic gradient when there is no art. */
@@ -33,10 +34,11 @@ export default function HeroCapsule({
   art: HeroArtFields
   icon?: string
   iconUrl?: string
+  iconUrlDark?: string
   className?: string
 }) {
   const hero = useHeroArt(art)
-  const hasIcon = !!(icon || iconUrl)
+  const hasIcon = !!(icon || iconUrl || iconUrlDark)
 
   return (
     <div
@@ -46,7 +48,7 @@ export default function HeroCapsule({
       {hero.src ? (
         <img src={hero.src} alt="" className="absolute inset-0 w-full h-full object-cover" onError={hero.onError} />
       ) : hasIcon ? (
-        <AppIcon icon={icon} iconUrl={iconUrl} size={28} />
+        <AppIcon icon={icon} iconUrl={iconUrl} iconUrlDark={iconUrlDark} size={28} />
       ) : (
         <Package size={22} />
       )}

--- a/website/src/components/appstore/InstalledAppCard.tsx
+++ b/website/src/components/appstore/InstalledAppCard.tsx
@@ -47,9 +47,11 @@ export default function InstalledAppCard({
   const canUninstall = app.lifecycle !== 'locked'
   const hasOpenCommand = !!m?.openCommand
   // Derive icon URL: prefer manifest iconUrl (builtins), fallback to blob proxy (registry)
-  const iconUrl = m?.iconUrl || (m?.iconPath && m?.repo
-    ? `/api/apps/blob?repo=${encodeURIComponent(m.repo)}&path=${encodeURIComponent(m.iconPath)}`
+  const blob = (p?: string) => (p && m?.repo
+    ? `/api/apps/blob?repo=${encodeURIComponent(m.repo)}&path=${encodeURIComponent(p)}`
     : undefined)
+  const iconUrl = m?.iconUrl || blob(m?.iconPath)
+  const iconUrlDark = m?.iconUrlDark || blob(m?.iconPathDark)
 
   return (
     <div className="border border-border rounded-lg hover:border-accent/30 transition-colors overflow-hidden">
@@ -77,6 +79,7 @@ export default function InstalledAppCard({
               art={{ heroImage: m?.heroImage, heroImageDark: m?.heroImageDark, screenshots: m?.screenshots, repo: m?.repo }}
               icon={pageIcon}
               iconUrl={iconUrl}
+              iconUrlDark={iconUrlDark}
               className="w-24 h-[54px] mt-0.5"
             />
             <div className="flex-1 min-w-0">

--- a/website/src/components/appstore/types.ts
+++ b/website/src/components/appstore/types.ts
@@ -18,6 +18,10 @@ export type RegistryApp = {
   author: string
   icon?: string
   iconUrl?: string
+  // Dark-appearance variant of iconUrl. Raster icons have fixed bytes, so an
+  // app that must read well on both backgrounds ships two files; first-party
+  // /app-assets/ SVGs are inlined and repaint from theme tokens instead.
+  iconUrlDark?: string
   tags?: string[]
   highlights?: string[]
   screenshots?: string[]
@@ -97,6 +101,8 @@ export type InstalledApp = {
     highlights?: string[]
     license?: string
     iconUrl?: string
+    iconUrlDark?: string
+    iconPathDark?: string
     openCommand?: string
     hidden?: boolean
   }

--- a/website/src/pages/AppDetailPage.tsx
+++ b/website/src/pages/AppDetailPage.tsx
@@ -33,6 +33,7 @@ type AppInfo = {
   author: string
   icon?: string
   iconUrl?: string
+  iconUrlDark?: string
   tags?: string[]
   highlights?: string[]
   screenshots?: string[]
@@ -250,6 +251,7 @@ export default function AppDetailPage() {
           // icon and hero instead of the generic Package box.
           icon: registryEntry?.icon || m.ui?.pages?.[0]?.icon || '',
           iconUrl: registryEntry?.iconUrl || m.iconUrl || m.ui?.pages?.[0]?.iconUrl || '',
+          iconUrlDark: registryEntry?.iconUrlDark || m.iconUrlDark || '',
           tags: m.tags || registryEntry?.tags || [],
           highlights: m.highlights || registryEntry?.highlights || [],
           screenshots: registryEntry?.screenshots || m.screenshots || [],
@@ -660,7 +662,7 @@ export default function AppDetailPage() {
         {/* Hero */}
         <div className="flex items-start gap-5 mb-6">
           <div className="w-24 h-24 rounded-2xl bg-accent/10 flex items-center justify-center shrink-0 overflow-hidden">
-            <AppIcon icon={app.icon} iconUrl={app.iconUrl} size={64} />
+            <AppIcon icon={app.icon} iconUrl={app.iconUrl} iconUrlDark={app.iconUrlDark} size={64} />
           </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-3 mb-1 flex-wrap">

--- a/website/src/test/AppIcon.darkSelection.test.tsx
+++ b/website/src/test/AppIcon.darkSelection.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * AppIcon dark-appearance selection.
+ *
+ * Raster icons have fixed bytes, so an app may ship a dark variant. Resolution
+ * mirrors `useHeroArt`: prefer the current theme's art, fall back to the other
+ * one in BOTH directions — an app that ships only a dark icon must still render
+ * it in light mode rather than dropping to the lucide glyph, which would read as
+ * "this app has no icon".
+ */
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import AppIcon from '../components/AppIcon'
+
+const theme = { current: 'light' as 'light' | 'dark' }
+vi.mock('../hooks/useTheme', () => ({ useTheme: () => ({ theme: theme.current }) }))
+
+const LIGHT = '/api/apps/blob?repo=Demo&path=icon.png'
+const DARK = '/api/apps/blob?repo=Demo&path=icon-dark.png'
+
+function srcOf(): string {
+  return screen.getByRole('presentation', { hidden: true }).getAttribute('src') || ''
+}
+
+describe('AppIcon dark selection', () => {
+  beforeEach(() => { theme.current = 'light' })
+
+  it('renders the light icon in light mode', () => {
+    render(<AppIcon iconUrl={LIGHT} iconUrlDark={DARK} />)
+    expect(srcOf()).toBe(LIGHT)
+  })
+
+  it('renders the dark icon in dark mode', () => {
+    theme.current = 'dark'
+    render(<AppIcon iconUrl={LIGHT} iconUrlDark={DARK} />)
+    expect(srcOf()).toBe(DARK)
+  })
+
+  it('falls back to the light icon in dark mode when no dark variant exists', () => {
+    theme.current = 'dark'
+    render(<AppIcon iconUrl={LIGHT} />)
+    expect(srcOf()).toBe(LIGHT)
+  })
+
+  it('falls back to the dark icon in light mode when only a dark variant exists', () => {
+    render(<AppIcon iconUrlDark={DARK} />)
+    expect(srcOf()).toBe(DARK)
+  })
+
+  it('falls through to the lucide glyph when neither variant exists', () => {
+    const { container } = render(<AppIcon icon="Shield" />)
+    expect(container.querySelector('svg')).toBeTruthy()
+    expect(container.querySelector('img')).toBeNull()
+  })
+})


### PR DESCRIPTION
> Stacked on #2961. Review that one first; this PR's diff against it is the 14 files below.

## Problem

`useHeroArt` has resolved hero art per theme since it landed, and manifests carry `heroImageDark` / `screenshotsDark`. **Icons had no equivalent** — `AppIcon` contained no theme handling at all (a grep for `dark` in it hit only comments), so a raster icon designed for light chrome rendered unchanged on dark chrome.

## Why it matters

First-party built-ins never needed this: their icon is an SVG under `/app-assets/`, inlined and painted from the `--ico-a` / `--ico-b` theme tokens, so one file already covers both appearances. **Raster art cannot repaint**, which is exactly the case this adds a variant for — every third-party registry app, whose icon arrives as a PNG through the blob proxy.

## Fix (symptoms → root cause → change)

Root cause: the icon path was written before the theme-aware art path existed and was never brought in line with it.

`AppIcon` takes `iconUrlDark` and resolves it the way `useHeroArt` resolves hero art: prefer the current theme's asset, fall back to the other one. **The fallback runs in both directions on purpose** — an app that ships only a dark icon renders it in light mode rather than dropping to the lucide glyph, which would read as "this app has no icon".

One subtlety worth calling out in review: the chosen URL replaces `iconUrl` **throughout** the component, including the effect's dependency array. A theme flip changes the resolved URL without changing any prop the parent re-keys on, so keying the fetch and the `imgFailed` latch on the prop would have left the previous theme's markup on screen.

Threaded through every surface that had an icon: store row, feature card, featured spotlight, detail page, installed-app card, sidebar.

**Registry rows** gain `iconUrlDark`, rewritten through the blob proxy from a new `iconPathDark` manifest field exactly as `iconUrl` is rewritten from `iconPath`.

**A manifest-declared absolute `iconUrl` is still never copied.** An index-fetched manifest is untrusted content, and honouring an absolute URL from it would let a third party point the store's `<img>` at any host it likes — a tracking pixel at minimum. Only repo-relative paths rewritten through our own proxy are used, which keeps the extension allowlist and the trusted-host gate in the path. That property was implicit before; it now has a named test.

## Spec change: the required icon must be opaque

The publishing guide's icon row moves from *"square PNG with transparency; 256x256 or larger"* to **512x512, opaque**.

An opaque tile carries its own background, so it reads correctly on any surface — and that is precisely what makes `iconPathDark` genuinely optional rather than a latent bug. A transparent icon that looks right on light chrome becomes a dark smear on dark chrome; an app that then omits the variant ships a broken card. This mirrors Apple, which forbids alpha on the App Store icon for the same reason and treats the dark appearance as a separate, optional well.

512 rather than 1024: our largest consumer is the 28px store capsule (84px at DPR 3), so 512 applies Apple's ~6x master-headroom ratio to our render sizes instead of copying their pixel count, which serves device surfaces we do not have.

## Tests

9 new, and the frontend selection is mutation-proven — reverting it to plain `iconUrl` fails 2 of the 5.

- Frontend (`src/test/AppIcon.darkSelection.test.tsx`) — light icon in light mode; dark icon in dark mode; dark mode with no dark variant falls back to light; light mode with ONLY a dark variant renders it; neither variant falls through to the lucide glyph.
- Backend (`TestMergeManifestProjectsRegistryKeys`) — `iconPathDark` becomes a blob URL alongside `iconPath`; `iconUrlDark` is **omitted** when absent rather than published empty (the client treats falsy as "use the light one"); a manifest-declared absolute `iconUrl` / `iconUrlDark` is refused.

282 backend tests pass across the registry files; 43 frontend tests pass across `AppIcon.darkSelection`, `appNav`, and `appstoreCategories`. `tsc -b`, `eslint` (0 errors), `isort`, `flake8`, `mypy`, `docs-lint` and the brand gate all exit 0, checked by exit code.

## Manual verification

No behaviour change for any app shipping one icon: the resolver returns the same URL it returned before, and `iconUrlDark` is absent from those rows. The visible delta is limited to apps that add the new field.

## Screenshots

None — the `no-screenshots` label applies for the same reason as #2961: no app currently ships `iconPathDark`, so there is no row whose rendering differs. A screenshot pair would be two identical images. The behaviour that *is* new is covered by the five selection tests, which assert the chosen `src` per theme — a stronger check than a still frame, which cannot show a theme flip.
