### PR TITLE
fix(test): measure ReDoS cost with thread_time so CPU bursts cannot skew it (#2811)

### DIFF
--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -8,6 +8,7 @@ catalog, the pure ``compute_effective_denied`` resolver, the dual-tier
 from __future__ import annotations
 
 import json
+import threading
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -507,19 +508,42 @@ class TestIsDeniedReDoSResistance:
     #: separating linear from quadratic (4.0) and from anything exponential.
     _MAX_DOUBLING_RATIO = 3.0
 
-    def _elapsed(self, command: str) -> float:
-        """CPU time, not wall-clock — the property under test is algorithmic complexity.
+    @staticmethod
+    def _cpu_cost(fn: Callable[[], object]) -> float:
+        """CPU consumed by THIS thread while ``fn`` runs — the cost chokepoint.
 
-        Wall-clock measures this process's work PLUS however long the OS gave the core to
-        someone else, so on a loaded CI runner (four xdist workers over two vCPUs) a scan that
-        burns ~2s of CPU can report >5s elapsed and fail a test whose subject never regressed.
-        ``process_time`` counts only CPU consumed by this process, which is exactly what a
-        backtracking blow-up inflates: measured 1:1 against wall-clock when idle (2.228s vs
-        2.230s), and a genuinely catastrophic pattern burns CPU rather than waiting.
+        ``thread_time`` is the one clock that isolates the subject's own work: wall-clock
+        adds however long the OS gave the core to other processes, and ``process_time``
+        adds CPU burned by OTHER THREADS of this process, so a concurrent in-process burst
+        wider than one sampling window lands in some samples and not others and perturbs
+        any comparison built on them. ``is_denied`` is single-threaded pure-regex work, so
+        per-thread CPU is its complete cost, and a genuinely catastrophic pattern inflates
+        it just the same (measured 1:1 against wall-clock when idle: 2.228s vs 2.230s).
         """
-        start = time.process_time()
-        is_denied(command)
-        return time.process_time() - start
+        start = time.thread_time()
+        fn()
+        return time.thread_time() - start
+
+    def _elapsed(self, command: str) -> float:
+        """CPU time of one ``is_denied`` scan — see ``_cpu_cost`` for the clock choice."""
+        return self._cpu_cost(lambda: is_denied(command))
+
+    def test_elapsed_routes_through_the_cpu_cost_chokepoint(self, monkeypatch):
+        # Every timing sample in this class must go through ``_cpu_cost`` — a raw
+        # clock read in ``_elapsed`` would silently re-open the burst-perturbation
+        # channel while every behavioral test stays green.
+        calls: list[object] = []
+
+        def fake_cpu_cost(fn: Callable[[], object]) -> float:
+            calls.append(fn)
+            fn()
+            return 0.123
+
+        monkeypatch.setattr(
+            TestIsDeniedReDoSResistance, "_cpu_cost", staticmethod(fake_cpu_cost)
+        )
+        assert self._elapsed("git status") == 0.123
+        assert len(calls) == 1
 
     def _doubling_ratio(self, build: Callable[[int], str], n: int) -> float:
         """CPU cost at ``2n`` divided by cost at ``n`` — the shape, not the magnitude.
@@ -538,6 +562,59 @@ class TestIsDeniedReDoSResistance:
         # Guard a degenerate denominator: if the small case is unmeasurable the ratio is
         # meaningless, so report a passing value rather than dividing by ~0.
         return double / best if best > 1e-6 else 1.0
+
+    def test_cpu_cost_is_immune_to_other_threads_where_process_time_is_not(self):
+        """The measurement clock must not see other threads' CPU.
+
+        The ratio tests in this class compare CPU-cost samples taken at different
+        times, so any clock that can be inflated by a concurrent in-process CPU burst
+        (another worker thread, GC) turns one-sided bursts into false ratio failures.
+        This pins the invariant with a synthetic workload whose true cost is fixed by
+        construction: spin until this thread has consumed a set amount of CPU, while
+        burst threads saturate the process. ``_cpu_cost`` must report the true cost;
+        the process-wide clock demonstrably cannot, which is why ``_cpu_cost`` exists.
+        """
+        true_cost = 0.05
+
+        def burn() -> None:
+            end = time.thread_time() + true_cost
+            while time.thread_time() < end:
+                pass
+
+        stop = threading.Event()
+
+        def spin() -> None:
+            while not stop.is_set():
+                for _ in range(1000):
+                    pass
+
+        spinners = [threading.Thread(target=spin, daemon=True) for _ in range(2)]
+        for thread in spinners:
+            thread.start()
+        try:
+            for _ in range(5):
+                process_start = time.process_time()
+                measured = self._cpu_cost(burn)
+                process_delta = time.process_time() - process_start
+                assert measured < true_cost * 2.0, (
+                    f"_cpu_cost reported {measured:.3f}s for {true_cost}s of own-thread "
+                    "work — the clock is seeing other threads' CPU"
+                )
+                # The control: the process-wide clock DOES absorb the burst (it
+                # accumulates the spinners' CPU during their GIL timeslices), so a
+                # clean _cpu_cost reading above is discriminating, not vacuous.
+                assert process_delta > measured, (
+                    "process_time did not exceed thread_time under a 2-spinner burst — "
+                    "the burst harness is not generating in-process noise"
+                )
+        finally:
+            stop.set()
+            for thread in spinners:
+                thread.join(timeout=5.0)
+            assert not any(thread.is_alive() for thread in spinners), (
+                "burst spinner failed to stop — it would poison every later "
+                "process-wide timing in this worker"
+            )
 
     def test_git_prefixed_flag_spam_returns_fast(self):
         # The historical regression input: whitespace/flag spam after ``git``.


### PR DESCRIPTION
## What is the problem?

`TestIsDeniedReDoSResistance`'s doubling-ratio guard fails roughly 1 run in 145 on the Windows shard with no regression present. The assertion compares CPU cost at input size `n` vs `2n`, but the measurements are taken with `time.process_time()` — a **process-wide** clock that sums CPU across every thread of the pytest worker.

## Why this issue matters to the user

Every false red on this shard costs a contributor a triage round on an unrelated PR, and repeated exposure trains people to re-run instead of read — which is how a real ReDoS regression would eventually slip through the exact guard built to catch it.

## How our fix solves it

Symptom → root cause chain: the flaky assertion compares two `min()`-of-3 sample floors taken at different times → an in-process CPU burst (another test's leftover worker thread, GC) wider than one sampling window lands in some samples and not others → the burst enters the numbers at all **only because the clock is process-wide**. `is_denied` is single-threaded pure-regex work, so `time.thread_time()` — which counts only the calling thread — is its complete cost.

The change routes every timing sample in the class through a single `_cpu_cost` chokepoint that measures with `thread_time`. The sampling shape (best-of-3, doubling ratio, 3.0 threshold) is untouched: no threshold raise, no rerun, no estimator surgery. Other threads' CPU can no longer enter any measurement, closing the whole perturbation class rather than narrowing the window it can land in.

Detection strength is preserved: a genuine quadratic regression inflates the subject thread's own CPU, so every sample still reads ~4x and the 3.0 threshold still fires. Coverage instrumentation (CI enables `--cov` on 3.12 only) executes in the measuring thread and is still counted, so the ratio's instrumentation-cancellation property is unchanged.

## What tests we did

- `test_cpu_cost_is_immune_to_other_threads_where_process_time_is_not` — proves the mechanism: two spinner threads saturate the process while a workload with a fixed true cost (bounded by its own `thread_time`) runs; `_cpu_cost` must report the true cost, and a `process_time` control reading taken across the same window must exceed it (so the clean reading is discriminating, not vacuous). Teardown joins the spinners and asserts none leaked. Costs (50ms) sit well above the ~15.6ms Windows CPU-clock quantum.
- `test_elapsed_routes_through_the_cpu_cost_chokepoint` — pins that `_elapsed` routes through `_cpu_cost`, so a raw clock read cannot silently re-open the channel while behavioral tests stay green.
- Mutation-verified: restoring `process_time` in the chokepoint, switching it to wall-clock, and bypassing the chokepoint in `_elapsed` each turn a test red.
- Full `test_denied_commands_security.py` (488 tests) green 5x consecutively, including under CI-default addopts (xdist + coverage). Full backend suite: 43,706 passed; the 31 failures are host-environment issues reproduced identically on unmodified `origin/main` (userns EPERM, AF_UNIX path length).

## Any other suggestions on the work

If `is_denied` ever delegates matching to worker threads, `thread_time` would undercount and this clock choice must be revisited — the `_cpu_cost` docstring records that assumption.

Closes #2811
