### PR TITLE
fix(ci): retry readiness reads and publish a non-terminal verdict on transport failure (#2753)

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -127,6 +127,60 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # Transient network/TLS errors between the runner and api.github.com can
+      # abort a single-shot `gh` call, and under `set -e` that ended the whole
+      # evaluation before the publish step could run -- leaving a permanently
+      # red check unrelated to actual readiness (issue #2753: the same commit
+      # evaluated green then red 39 seconds apart with nothing pushed). Every
+      # READ-ONLY gh call below now goes through this bounded helper: 3
+      # attempts with short backoff, mirroring the bounded-attempts convention
+      # in publish-installer.yml. Stdout is buffered per attempt so a failed
+      # attempt's partial output (e.g. an aborted --paginate stream) never
+      # leaks into a pipe. WRITE calls are deliberately NOT retried here; the
+      # label writes have their own narrow race tolerance (see drop_label /
+      # ensure_label), and a lost-response retry of a DELETE outside that
+      # tolerance would turn an applied change into a new failure.
+      - name: Install bounded retry helper for read-only gh calls
+        run: |
+          cat > "$RUNNER_TEMP/gh-retry.sh" <<'HELPER'
+          gh_retry() {
+            local attempt out err rc=1
+            for attempt in 1 2 3; do
+              # timeout bounds a HANGING attempt (gh applies no HTTP request
+              # timeout of its own); rc 124 is just another retryable failure.
+              if out="$(timeout 120 "$@" 2>"$RUNNER_TEMP/gh-retry-err")"; then
+                cat "$RUNNER_TEMP/gh-retry-err" >&2
+                printf '%s\n' "$out"
+                return 0
+              else
+                rc=$?
+              fi
+              err="$(cat "$RUNNER_TEMP/gh-retry-err" 2>/dev/null || true)"
+              printf '%s\n' "$err" >&2
+              # A non-429 HTTP 4xx is a PERMANENT request error (renamed
+              # workflow file, missing scope, bad endpoint): retrying cannot
+              # fix it, and calling it "transient" would misdiagnose a
+              # misconfiguration as network trouble. Return a distinct code
+              # immediately so callers can fail loud instead of publishing a
+              # pending "could not be evaluated" verdict forever.
+              # EXCEPTION: GitHub's primary/secondary rate limits surface as
+              # HTTP 403 with rate-limit text in the body -- those are
+              # transient exactly like a 429 and must be retried, not failed.
+              if grep -Eq 'HTTP 4[0-9][0-9]' <<<"$err" \
+                && ! grep -q 'HTTP 429' <<<"$err" \
+                && ! grep -Eiq 'rate limit|abuse detection' <<<"$err"; then
+                echo "gh_retry: permanent HTTP error (no retry): $*" >&2
+                return 22
+              fi
+              echo "gh_retry: attempt $attempt/3 failed (rc=$rc): $*" >&2
+              if [ "$attempt" -lt 3 ]; then
+                sleep $(( attempt * 2 ))
+              fi
+            done
+            return "$rc"
+          }
+          HELPER
+
       - name: Resolve current pull request revision
         id: context
         env:
@@ -143,6 +197,7 @@ jobs:
           RUN_HEAD_REF: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
+          source "$RUNNER_TEMP/gh-retry.sh"
           case "$EVENT" in
             workflow_dispatch) PR="$INPUT_PR"; EXPECTED_SHA="$INPUT_SHA" ;;
             workflow_run)
@@ -169,7 +224,7 @@ jobs:
               # exactly as the verdict step binds monitored runs below; fall
               # back to SHA-only when either is absent.
               if [ -z "$PR" ]; then
-                PR="$(gh api --paginate \
+                PR="$(gh_retry gh api --paginate \
                   "repos/$REPO/pulls?state=open&per_page=100" \
                   | jq -rs \
                       --arg sha "$RUN_SHA" \
@@ -195,7 +250,7 @@ jobs:
             *) echo "::error::unsupported event: $EVENT"; exit 1 ;;
           esac
 
-          pr_json="$(gh pr view "$PR" --repo "$REPO" \
+          pr_json="$(gh_retry gh pr view "$PR" --repo "$REPO" \
             --json number,state,isDraft,isCrossRepository,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url)"
           SHA="$(jq -r '.headRefOid' <<<"$pr_json")"
           STATE="$(jq -r '.state' <<<"$pr_json")"
@@ -204,7 +259,7 @@ jobs:
           # A PR whose base is any other branch -- a stacked PR sitting on
           # another feature branch -- can never start those lanes, so the
           # verdict step marks them ineligible instead of pending-forever.
-          DEFAULT_BRANCH="$(gh api "repos/$REPO" --jq '.default_branch')"
+          DEFAULT_BRANCH="$(gh_retry gh api "repos/$REPO" --jq '.default_branch')"
 
           {
             echo "pr=$PR"
@@ -239,6 +294,7 @@ jobs:
           PR: ${{ steps.context.outputs.pr }}
         run: |
           set -euo pipefail
+          source "$RUNNER_TEMP/gh-retry.sh"
 
           # A peer run of this workflow can remove the same label between our
           # snapshot and our DELETE, and a label that is already gone has
@@ -259,7 +315,7 @@ jobs:
             return 1
           }
 
-          current="$(gh api "repos/$REPO/issues/$PR/labels" --paginate --jq '.[].name')"
+          current="$(gh_retry gh api "repos/$REPO/issues/$PR/labels" --paginate --jq '.[].name')"
           for label in \
             "readiness: checking" \
             "readiness: action required" \
@@ -288,6 +344,12 @@ jobs:
           TRIGGER_ACTION: ${{ github.event.action }}
         run: |
           set -euo pipefail
+          source "$RUNNER_TEMP/gh-retry.sh"
+
+          # Set when a read-only API call keeps failing after the bounded
+          # retries: the verdict is then UNKNOWN, not red -- see the explicit
+          # non-terminal branch after the evaluation loop.
+          transport_failed=false
 
           # CI, Build and CodeQL only ever run for a PR whose base is the
           # default branch: ci.yml / build.yml declare `pull_request:
@@ -372,8 +434,15 @@ jobs:
               # real review has not posted yet) -> pending.
               cname="${file#checkrun:}"
               enc="$(jq -rn --arg v "$cname" '$v | @uri')"
-              cruns="$(gh api --method GET \
-                "repos/$REPO/commits/$SHA/check-runs?check_name=$enc&per_page=100")"
+              cruns="$(gh_retry gh api --method GET \
+                "repos/$REPO/commits/$SHA/check-runs?check_name=$enc&per_page=100")" || {
+                rc=$?
+                # 22 = permanent HTTP error (misconfiguration): fail loud so it
+                # is diagnosed, never diluted into "transient network trouble".
+                if [ "$rc" -eq 22 ]; then exit 1; fi
+                transport_failed=true
+                break
+              }
               total="$(jq '.check_runs | length' <<<"$cruns")"
               incomplete="$(jq '[.check_runs[]
                 | select(.status != "completed")] | length' <<<"$cruns")"
@@ -419,16 +488,26 @@ jobs:
               continue
             fi
             if [ "$file" = "dynamic/github-code-scanning/codeql" ]; then
-              runs="$(gh api --method GET \
-                "repos/$REPO/actions/runs?event=dynamic&head_sha=$SHA&per_page=100")"
+              runs="$(gh_retry gh api --method GET \
+                "repos/$REPO/actions/runs?event=dynamic&head_sha=$SHA&per_page=100")" || {
+                rc=$?
+                if [ "$rc" -eq 22 ]; then exit 1; fi
+                transport_failed=true
+                break
+              }
               run="$(jq -c --arg path "$file" '
                 [.workflow_runs[] | select(.path == $path)]
                 | sort_by(.created_at)
                 | last // empty
               ' <<<"$runs")"
             else
-              runs="$(gh api --method GET \
-                "repos/$REPO/actions/workflows/$file/runs?event=pull_request&head_sha=$SHA&per_page=20")"
+              runs="$(gh_retry gh api --method GET \
+                "repos/$REPO/actions/workflows/$file/runs?event=pull_request&head_sha=$SHA&per_page=20")" || {
+                rc=$?
+                if [ "$rc" -eq 22 ]; then exit 1; fi
+                transport_failed=true
+                break
+              }
               # Bind the run to this PR by (head repository, head branch), NOT
               # by `.pull_requests`: that array is empty on every fork run, so
               # filtering on it matched nothing and reported each already-green
@@ -481,6 +560,81 @@ jobs:
               fi
             fi
           done
+
+          # A read that still fails after the bounded retries is a TRANSPORT
+          # failure: this revision's verdict is UNKNOWN, not red. Publish an
+          # explicit non-terminal "could not be evaluated" verdict (a pending
+          # status under the existing "readiness: checking" label) instead of
+          # exiting non-zero, so the publish step still runs and the job never
+          # leaves a red check for a network blip. This deliberately does NOT
+          # weaken the gate: pending blocks merge exactly like failure does,
+          # and only a transport error with NO already-observed blocker takes
+          # this branch -- a genuine failure recorded by an earlier lane
+          # dominates (the `failed` guard below), falling through to the normal
+          # action-required verdict, so a known red is never masked by a later
+          # lane's network trouble. Recovery is automatic -- the self-heal
+          # sweep re-fires any pending readiness status older than its
+          # staleness window, and any later monitored-workflow event recomputes
+          # sooner.
+          if [ "$transport_failed" = "true" ] && [ "${#failed[@]}" -eq 0 ]; then
+            # The tiebreaker for every ambiguous case is an asymmetry:
+            # publishing "pending" can only ever BLOCK a merge, never allow
+            # one, so pending is the fail-safe write whenever validation
+            # state is unknown. Concretely: if the SHA already carries a
+            # BLOCKING verdict (failure/error), this truncated run defers --
+            # the merge is already held, and overwriting the red with
+            # pending would only discard its diagnostics and set the sweep
+            # re-firing. Every other case publishes pending: an existing
+            # SUCCESS must not be left mergeable when a rerun's validation
+            # state is unknown (the green may be stale -- that is the unsafe
+            # direction); an UNREADABLE verdict state gets the same
+            # treatment, because the worst a pending can do to an unseen
+            # verdict is block a merge that a re-evaluation will unblock;
+            # and pending-over-pending / no-status just refresh the
+            # self-heal sweep's staleness clock.
+            existing_state="$(timeout 120 gh api "repos/$REPO/commits/$SHA/status" \
+              --jq '[.statuses[] | select(.context == "PR Readiness")][0].state // empty' \
+              2>/dev/null)" || existing_state="__unreadable__"
+            if [ "$existing_state" = "failure" ] || [ "$existing_state" = "error" ]; then
+              {
+                echo "state=deferred"
+                echo "status_state="
+              } >> "$GITHUB_OUTPUT"
+              {
+                echo "### PR Readiness: deferred to an existing blocking verdict"
+                echo
+                echo "- PR: #$PR"
+                echo "- Revision: \`$SHA\`"
+                echo
+                echo "This run's evaluation was truncated by a GitHub API"
+                echo "failure, but the revision already carries a blocking"
+                echo "readiness verdict (\`$existing_state\`) from another run."
+                echo "The merge is already held; overwriting that verdict with"
+                echo "pending would only discard its diagnostics, so nothing"
+                echo "was published."
+              } > "$RUNNER_TEMP/pr-readiness-summary.md"
+              exit 0
+            fi
+            {
+              echo "state=could_not_evaluate"
+              echo "label=readiness: checking"
+              echo "status_state=pending"
+              echo "description=Readiness could not be evaluated (transient GitHub API failure); it will be re-evaluated"
+            } >> "$GITHUB_OUTPUT"
+            {
+              echo "### PR Readiness: could not be evaluated"
+              echo
+              echo "- PR: #$PR"
+              echo "- Revision: \`$SHA\`"
+              echo
+              echo "A read-only GitHub API call kept failing after bounded"
+              echo "retries, so this revision's verdict is unknown -- not red."
+              echo "A non-terminal \`pending\` status was published; the"
+              echo "self-heal sweep or the next monitored-workflow event will"
+              echo "re-evaluate it."
+            } > "$RUNNER_TEMP/pr-readiness-summary.md"
+            exit 0
+          fi
 
           # A pull_request_target open/synchronize/reopen/edit run is meant to
           # surface a transient "checking" signal while validation spins up.
@@ -571,6 +725,17 @@ jobs:
               echo "**Waiting**"
               printf -- "- %s\n" "${waiting[@]}"
             fi
+            # Reached with transport_failed=true only via the fall-through
+            # above (an already-observed blocker dominates the pending
+            # fallback): the arrays stopped filling at the break, so say so --
+            # otherwise the summary silently reads as a complete evaluation.
+            if [ "$transport_failed" = "true" ]; then
+              echo
+              echo "> Evaluation was truncated by a GitHub API failure before"
+              echo "> every lane could be read; the verdict above is computed"
+              echo "> from the lanes read so far and will be recomputed"
+              echo "> automatically."
+            fi
           } > "$RUNNER_TEMP/pr-readiness-summary.md"
 
       - name: Publish status and label
@@ -586,7 +751,14 @@ jobs:
           DESCRIPTION: ${{ steps.verdict.outputs.description }}
         run: |
           set -euo pipefail
-          current_sha="$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq '.headRefOid')"
+          source "$RUNNER_TEMP/gh-retry.sh"
+          # A truncated evaluation that deferred to an existing terminal
+          # verdict emits no status_state: there is nothing safe to publish.
+          if [ -z "$STATUS_STATE" ]; then
+            echo "Evaluation deferred to an existing verdict on $SHA; publishing nothing."
+            exit 0
+          fi
+          current_sha="$(gh_retry gh pr view "$PR" --repo "$REPO" --json headRefOid --jq '.headRefOid')"
           if [ "$current_sha" != "$SHA" ]; then
             echo "Ignoring publish for stale revision $SHA; PR #$PR is now at $current_sha."
             exit 0
@@ -597,6 +769,23 @@ jobs:
           # FIRST and on its own. The labels below are advisory decoration; a
           # cosmetic label call must never be in a position to decide whether
           # the required check reports anything at all.
+          #
+          # This POST is deliberately NOT retried. A commit status is
+          # last-write-wins per SHA+context, GitHub offers no conditional
+          # write, and two runs can evaluate the SAME revision concurrently
+          # (see the concurrency comment above) -- so ANY retry races a
+          # concurrent run's newer verdict: between whatever guard read a
+          # retry could take and its re-POST, another run can publish, and
+          # the re-POST would republish this run's verdict over it (a stale
+          # green over a fresh red, or a pending over a terminal). Three
+          # successive guard designs ("any status exists", compare-and-swap
+          # on the status id, fail-safe reads) each narrowed but could not
+          # close that window -- the API gives no atomic primitive to close
+          # it with. A failed POST therefore fails the step loud instead:
+          # the run shows red with an actionable error, a re-run (or the
+          # next monitored-workflow event) re-evaluates and republishes,
+          # and no verdict is ever silently overwritten. The POST is
+          # bounded (gh applies no HTTP timeout of its own).
           jq -n \
             --arg state "$STATUS_STATE" \
             --arg target_url "$URL" \
@@ -606,8 +795,15 @@ jobs:
               target_url: $target_url,
               description: $description,
               context: "PR Readiness"
-            }' \
-            | gh api --method POST "repos/$REPO/statuses/$SHA" --input - >/dev/null
+            }' > "$RUNNER_TEMP/readiness-status.json"
+          if ! timeout 120 gh api --method POST "repos/$REPO/statuses/$SHA" \
+            --input "$RUNNER_TEMP/readiness-status.json" >/dev/null; then
+            echo "::error::Failed to publish the readiness status for $SHA." \
+              "The POST is not retried (a retry can overwrite a concurrent" \
+              "run's newer verdict); re-run this workflow to re-evaluate" \
+              "and republish."
+            exit 1
+          fi
 
           # Two runs can evaluate the SAME revision concurrently: each
           # pull_request_target run gets its own concurrency group keyed on
@@ -649,7 +845,7 @@ jobs:
             "readiness: action required|D73A4A|A blocking check or review needs attention"
             "readiness: passed|0E8A16|Eligible automated validation passed for the current revision"
           )
-          existing_labels="$(gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name')"
+          existing_labels="$(gh_retry gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name')"
           for spec in "${label_specs[@]}"; do
             name="${spec%%|*}"
             rest="${spec#*|}"
@@ -660,7 +856,7 @@ jobs:
             fi
           done
 
-          current="$(gh api "repos/$REPO/issues/$PR/labels" --paginate --jq '.[].name')"
+          current="$(gh_retry gh api "repos/$REPO/issues/$PR/labels" --paginate --jq '.[].name')"
           for label in \
             "readiness: checking" \
             "readiness: action required" \

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -401,6 +401,34 @@ Two subtleties:
   recompute it on an unchanged commit, freezing the status at pending indefinitely.
   So it is added only when the live evaluation still found something genuinely
   incomplete.
+- **A transport error during evaluation is non-terminal.** Every read-only `gh`
+  call goes through a bounded retry helper (3 attempts with backoff, 120s cap per
+  attempt); a non-429 HTTP 4xx is treated as permanent misconfiguration and fails
+  the job loudly instead of retrying. If an **evaluation** read still fails after
+  the retries, the evaluate step publishes an explicit non-terminal "could not be
+  evaluated" verdict (`pending` under `readiness: checking`) instead of exiting
+  non-zero — so a transient network/TLS blip during evaluation never leaves a red
+  check-run or skips the publish step (issue #2753: the same commit evaluated
+  green then red 39 seconds apart). Exhausted retries in the other steps (context
+  resolution, closed-PR label cleanup, the publish step's own reads) still fail
+  the job — only the evaluation loop has the non-terminal branch. This does not
+  weaken the gate: `pending` blocks merge exactly like `failure`, and only a
+  transport error with no already-observed blocker takes that branch (a genuine
+  failure recorded by an earlier lane dominates and the verdict stays the
+  terminal red `action required`, with a summary note that the evaluation was
+  truncated). Recovery is automatic — the self-heal sweep re-fires stale pending
+  statuses, and any later monitored-workflow event recomputes sooner. A truncated
+  run defers (publishes nothing) only when the revision already carries a
+  **blocking** verdict — the merge is already held and pending would only discard
+  the red's diagnostics. Every other prior state publishes pending: an existing
+  *success* is re-pended (a rerun means validation state is unknown again, and a
+  stale green left mergeable is the unsafe direction — pending can only ever
+  block, never allow), and an unreadable verdict state gets the same fail-safe
+  treatment. The status
+  POST itself is never retried: commit statuses are last-write-wins with no
+  conditional write, so any retry races a concurrent run's newer verdict — a
+  failed POST fails the step loud and a re-run republishes. The label writes
+  keep only the narrow 404/already-exists race tolerance they already have.
 - **Nothing keys off `workflow_run.pull_requests`.** That array is empty whenever the
   head repository is a fork, the same GitHub behaviour the `fork-*` workflows already
   work around. The job gate admits every `pull_request` and `dynamic` run and lets the

--- a/test/test_pr_readiness_evaluate.py
+++ b/test/test_pr_readiness_evaluate.py
@@ -1,0 +1,481 @@
+"""Behavioural tests for pr-readiness.yml's evaluate-step transport resilience.
+
+Issue #2753: every read-only ``gh`` call in the readiness evaluation was
+single-shot inside a fail-fast shell step, so one transient network/TLS error
+aborted the job before the publish step could run -- the same commit was
+observed evaluating green then red 39 seconds apart with nothing pushed.
+
+These tests extract the real "Evaluate current revision" script (plus the
+retry-helper install step it sources) and execute them with ``gh`` replaced by
+a stub, verifying the three properties that matter:
+
+1. A transient failure is retried and the evaluation still reaches its REAL
+   verdict (the retry helper works and does not corrupt piped output).
+2. A persistent transport failure produces the explicit NON-TERMINAL
+   "could not be evaluated" verdict (pending / ``readiness: checking``) and
+   exit 0 -- never a red check.
+3. A genuine failing workflow conclusion still produces the terminal red
+   ``action required`` verdict -- the fallback must not suppress real reds.
+
+Skipped where the POSIX toolchain the script needs (bash, jq) is unavailable,
+mirroring test_pr_readiness_sweep.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "pr-readiness.yml"
+)
+
+pytestmark = pytest.mark.skipif(
+    not WORKFLOW.exists()
+    or os.name == "nt"
+    or shutil.which("bash") is None
+    or shutil.which("jq") is None,
+    reason="requires the workflow plus a POSIX bash and jq",
+)
+
+# ``gh`` stub. Serves canned workflow-run / check-run JSON keyed on the URL,
+# and can simulate a flaky or dead endpoint: any URL containing $FLAKY_SUBSTR
+# fails with a TLS-style error until its per-run counter exceeds $FLAKY_FAILS.
+GH_STUB = r"""#!/usr/bin/env bash
+set -euo pipefail
+url=""
+for arg in "$@"; do
+  case "$arg" in repos/*|*/actions/*) url="$arg" ;; esac
+done
+if [ -n "${FLAKY_SUBSTR:-}" ] && [[ "$url" == *"$FLAKY_SUBSTR"* ]]; then
+  count=0
+  [ -f "$FIXTURES/flaky_count" ] && count="$(cat "$FIXTURES/flaky_count")"
+  count=$(( count + 1 ))
+  printf '%s' "$count" > "$FIXTURES/flaky_count"
+  if [ "$count" -le "${FLAKY_FAILS:-0}" ]; then
+    if [ -n "${HTTP_ERROR:-}" ]; then
+      echo "gh: $HTTP_ERROR" >&2
+    else
+      echo "tls: failed to verify certificate: x509: certificate is not valid for any names, but wanted to match api.github.com" >&2
+    fi
+    # Emit a partial page on stdout so the test proves the retry helper
+    # buffers per attempt and never leaks failed-attempt output into a pipe.
+    printf '{"workflow_runs":[{"trunc'
+    exit 1
+  fi
+fi
+case "$url" in
+  *"/commits/"*"/check-runs"*)             cat "$FIXTURES/check_runs.json"; exit 0 ;;
+  *"/commits/"*"/status"*)
+    # The truncated-fallback's defer guard: the CURRENT "PR Readiness"
+    # commit-status state (gh applies --jq itself, so the stub emits the
+    # final value). No fixture = no status exists. A __FAIL__ fixture
+    # makes the read itself fail, exercising the unverifiable branch.
+    if [ -f "$FIXTURES/existing_status_state.txt" ]; then
+      state="$(cat "$FIXTURES/existing_status_state.txt")"
+      if [ "$state" = "__FAIL__" ]; then
+        echo 'gh: Server Error (HTTP 500)' >&2
+        exit 1
+      fi
+      printf '%s\n' "$state"
+    fi
+    exit 0 ;;
+  *"/actions/workflows/ci.yml/runs"*)      cat "$FIXTURES/ci_runs.json"; exit 0 ;;
+  *"/actions/workflows/"*"/runs"*)         cat "$FIXTURES/green_runs.json"; exit 0 ;;
+  *"/actions/runs?event=dynamic"*)         cat "$FIXTURES/codeql_runs.json"; exit 0 ;;
+esac
+echo "gh stub: unhandled: $*" >&2
+exit 90
+"""
+
+
+def _steps() -> list[dict]:
+    spec = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return spec["jobs"]["readiness"]["steps"]
+
+
+def _helper_script() -> str:
+    for step in _steps():
+        if "run" in step and "cat > \"$RUNNER_TEMP/gh-retry.sh\"" in step["run"]:
+            return step["run"]
+    raise AssertionError("retry-helper install step not found")
+
+
+def _evaluate_script() -> str:
+    for step in _steps():
+        if step.get("id") == "verdict":
+            return step["run"]
+    raise AssertionError("evaluate step not found")
+
+
+def _run_json(name: str, *, status: str, conclusion: str) -> str:
+    return json.dumps(
+        {
+            "workflow_runs": [
+                {
+                    "head_repository": {"full_name": "kirodotdev/KiroCrew"},
+                    "head_branch": "feat/x",
+                    "path": (
+                        "dynamic/github-code-scanning/codeql"
+                        if name == "codeql"
+                        else f".github/workflows/{name}"
+                    ),
+                    "status": status,
+                    "conclusion": conclusion,
+                    "created_at": "2026-08-11T00:00:00Z",
+                }
+            ]
+        }
+    )
+
+
+class Runner:
+    """Executes the evaluate step against one stubbed repository state."""
+
+    def __init__(self, root: Path) -> None:
+        self.fixtures = root / "fixtures"
+        bindir = root / "bin"
+        self.temp = root / "runner_temp"
+        for d in (self.fixtures, bindir, self.temp):
+            d.mkdir(parents=True)
+        stub = bindir / "gh"
+        stub.write_text(GH_STUB)
+        stub.chmod(0o755)
+        self.output = root / "github_output"
+        self.output.touch()
+        self.env = {
+            **os.environ,
+            "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+            "FIXTURES": str(self.fixtures),
+            "RUNNER_TEMP": str(self.temp),
+            "GITHUB_OUTPUT": str(self.output),
+            "REPO": "kirodotdev/KiroCrew",
+            "PR": "2650",
+            "SHA": "a686d96a83859a73eb93b322de04b21bdea5f093",
+            "HEAD_REPO": "kirodotdev/KiroCrew",
+            "HEAD_REF": "feat/x",
+            "DRAFT": "false",
+            "FORK": "false",
+            "BASE_REF": "main",
+            "DEFAULT_BRANCH": "main",
+            "TRIGGER_EVENT": "workflow_run",
+            "TRIGGER_ACTION": "completed",
+        }
+        # Materialize the helper exactly as CI does: run the install step.
+        subprocess.run(
+            ["bash", "-c", _helper_script()],
+            env=self.env,
+            check=True,
+            capture_output=True,
+        )
+        # Default fixtures: everything green and completed.
+        green = _run_json("green.yml", status="completed", conclusion="success")
+        (self.fixtures / "green_runs.json").write_text(green)
+        (self.fixtures / "ci_runs.json").write_text(
+            _run_json("ci.yml", status="completed", conclusion="success")
+        )
+        (self.fixtures / "codeql_runs.json").write_text(
+            _run_json("codeql", status="completed", conclusion="success")
+        )
+        (self.fixtures / "check_runs.json").write_text(
+            json.dumps(
+                {
+                    "check_runs": [
+                        {"status": "completed", "conclusion": "success"}
+                    ]
+                }
+            )
+        )
+
+    def evaluate(
+        self,
+        *,
+        flaky_substr: str = "",
+        flaky_fails: int = 0,
+        fork: bool = False,
+        http_error: str = "",
+        existing_status_state: str = "",
+    ):
+        env = dict(self.env)
+        if fork:
+            env["FORK"] = "true"
+        if http_error:
+            env["HTTP_ERROR"] = http_error
+        state_file = self.fixtures / "existing_status_state.txt"
+        state_file.unlink(missing_ok=True)
+        if existing_status_state:
+            state_file.write_text(existing_status_state + "\n")
+        if flaky_substr:
+            env["FLAKY_SUBSTR"] = flaky_substr
+            env["FLAKY_FAILS"] = str(flaky_fails)
+        proc = subprocess.run(
+            ["bash", "-c", _evaluate_script()],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        outputs = {}
+        for line in self.output.read_text().splitlines():
+            key, _, value = line.partition("=")
+            outputs[key] = value
+        return proc, outputs
+
+
+@pytest.fixture()
+def runner(tmp_path: Path) -> Runner:
+    return Runner(tmp_path)
+
+
+class TestTransientFailureIsRetried:
+    def test_one_flake_still_reaches_the_real_verdict(self, runner: Runner):
+        # The observed #2753 failure site: the per-workflow runs read. One
+        # transient failure, then success -- the retry must absorb it and the
+        # evaluation must land on the REAL verdict, not the fallback.
+        proc, outputs = runner.evaluate(
+            flaky_substr="codex-review.yml/runs", flaky_fails=1
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "success"
+        assert outputs["label"] == "readiness: passed"
+        # The stub was actually retried (counter advanced past the failure).
+        assert int((runner.fixtures / "flaky_count").read_text()) >= 2
+
+    def test_failed_attempt_output_never_leaks(self, runner: Runner):
+        # The stub prints a partial JSON page before failing; if the helper
+        # streamed instead of buffering, the retry's good page would be
+        # corrupted and jq would blow up. Reaching the real verdict proves
+        # per-attempt buffering.
+        proc, outputs = runner.evaluate(
+            flaky_substr="build.yml/runs", flaky_fails=2
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "success"
+
+
+class TestPersistentTransportFailureIsNonTerminal:
+    def test_publishes_could_not_evaluate_and_exits_zero(self, runner: Runner):
+        # Endpoint dead for all 3 attempts: the job must NOT go red. It exits
+        # 0 with the explicit non-terminal verdict so the publish step runs.
+        proc, outputs = runner.evaluate(
+            flaky_substr="codex-review.yml/runs", flaky_fails=99
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "pending"
+        assert outputs["label"] == "readiness: checking"
+        assert "could not be evaluated" in outputs["description"]
+        # Exactly 3 attempts -- bounded, not infinite.
+        assert int((runner.fixtures / "flaky_count").read_text()) == 3
+        summary = (runner.temp / "pr-readiness-summary.md").read_text()
+        assert "could not be evaluated" in summary
+
+    def test_commit_status_description_fits_the_api_limit(self, runner: Runner):
+        proc, outputs = runner.evaluate(
+            flaky_substr="ci.yml/runs", flaky_fails=99
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert len(outputs["description"]) <= 140
+
+    def test_fork_checkrun_lane_takes_the_same_fallback(self, runner: Runner):
+        # A fork PR's AI-review lanes are read from the head SHA's check-runs
+        # (checkrun: specs) -- a different branch of the evaluate loop than the
+        # workflow-runs reads. A persistent transport failure there must take
+        # the same non-terminal fallback, since fork PRs are the lane that
+        # produced the documented frozen-verdict incidents.
+        proc, outputs = runner.evaluate(
+            flaky_substr="check-runs", flaky_fails=99, fork=True
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "pending"
+        assert outputs["label"] == "readiness: checking"
+        assert "could not be evaluated" in outputs["description"]
+
+    def test_a_truncated_run_defers_to_an_existing_blocking_verdict(
+        self, runner: Runner
+    ):
+        # The revision already carries a blocking verdict (failure/error):
+        # the merge is already held, and overwriting the red with pending
+        # would only discard its diagnostics and set the sweep re-firing.
+        # The truncated run defers: exit 0, nothing published.
+        proc, outputs = runner.evaluate(
+            flaky_substr="codex-review.yml/runs",
+            flaky_fails=99,
+            existing_status_state="failure",
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["state"] == "deferred"
+        assert outputs.get("status_state", "") == ""
+        summary = (runner.temp / "pr-readiness-summary.md").read_text()
+        assert "deferred" in summary
+
+    def test_a_truncated_run_re_pends_an_existing_success(
+        self, runner: Runner
+    ):
+        # An existing SUCCESS must NOT be deferred to: a monitored rerun on
+        # the same revision means validation state is unknown again, and
+        # leaving the stale green in place would keep branch protection
+        # mergeable while nothing has verified the revision. Pending can
+        # only ever BLOCK a merge -- publishing it over success is the
+        # fail-safe write, and re-evaluation restores the true verdict.
+        proc, outputs = runner.evaluate(
+            flaky_substr="codex-review.yml/runs",
+            flaky_fails=99,
+            existing_status_state="success",
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "pending"
+        assert outputs["label"] == "readiness: checking"
+
+    def test_a_truncated_run_still_publishes_over_a_pending_status(
+        self, runner: Runner
+    ):
+        # An existing PENDING status is not a completed verdict -- it is this
+        # same fallback from an earlier run. Pending-over-pending loses
+        # nothing, and the refreshed timestamp keeps the self-heal sweep's
+        # staleness clock honest.
+        proc, outputs = runner.evaluate(
+            flaky_substr="codex-review.yml/runs",
+            flaky_fails=99,
+            existing_status_state="pending",
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "pending"
+        assert outputs["label"] == "readiness: checking"
+
+    def test_an_unreadable_verdict_state_publishes_pending(
+        self, runner: Runner
+    ):
+        # The defer-guard read failing leaves the verdict state unknown.
+        # The worst a pending can do to an unseen verdict is block a merge
+        # that re-evaluation will unblock, while deferring would leave a
+        # possibly-stale green mergeable -- so unreadable publishes pending.
+        proc, outputs = runner.evaluate(
+            flaky_substr="codex-review.yml/runs",
+            flaky_fails=99,
+            existing_status_state="__FAIL__",
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "pending"
+        assert outputs["label"] == "readiness: checking"
+
+
+class TestPermanentHttpErrorFailsLoud:
+    def test_http_404_is_not_laundered_into_pending(self, runner: Runner):
+        # A non-429 HTTP 4xx (renamed workflow file, missing scope) is a
+        # permanent misconfiguration: retrying cannot fix it, and publishing
+        # the pending fallback would hide it behind "transient network
+        # failure" forever (the sweep re-fires pending statuses endlessly).
+        # The helper must not retry it, and the job must fail loudly.
+        proc, outputs = runner.evaluate(
+            flaky_substr="codex-review.yml/runs",
+            flaky_fails=99,
+            http_error="HTTP 404: Not Found (repos/x/actions/workflows/codex-review.yml/runs)",
+        )
+        assert proc.returncode != 0
+        assert outputs.get("status_state") != "pending"
+        # No retries: the endpoint was hit exactly once.
+        assert int((runner.fixtures / "flaky_count").read_text()) == 1
+
+    def test_http_429_is_still_retried_as_transient(self, runner: Runner):
+        # Rate limiting is the one HTTP error class that IS transient.
+        proc, outputs = runner.evaluate(
+            flaky_substr="build.yml/runs",
+            flaky_fails=1,
+            http_error="HTTP 429: rate limited",
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "success"
+        assert int((runner.fixtures / "flaky_count").read_text()) >= 2
+
+    def test_rate_limit_403_is_retried_as_transient(self, runner: Runner):
+        # GitHub's primary and secondary rate limits surface as HTTP 403
+        # (not 429) with rate-limit text in the body. They are transient:
+        # classifying them permanent would turn readiness red on a busy
+        # runner -- recreating the exact symptom this change fixes.
+        proc, outputs = runner.evaluate(
+            flaky_substr="build.yml/runs",
+            flaky_fails=1,
+            http_error=(
+                "HTTP 403: You have exceeded a secondary rate limit. "
+                "Please wait a few minutes before you try again."
+            ),
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "success"
+        # It WAS retried past the failure.
+        assert int((runner.fixtures / "flaky_count").read_text()) >= 2
+
+    def test_plain_403_is_still_permanent(self, runner: Runner):
+        # A 403 WITHOUT rate-limit text (missing scope, SSO enforcement)
+        # is a real misconfiguration: no retry, fail loud.
+        proc, outputs = runner.evaluate(
+            flaky_substr="codex-review.yml/runs",
+            flaky_fails=99,
+            http_error="HTTP 403: Resource not accessible by integration",
+        )
+        assert proc.returncode != 0
+        assert outputs.get("status_state") != "pending"
+        assert int((runner.fixtures / "flaky_count").read_text()) == 1
+
+
+class TestGenuineFailureStaysRed:
+    def test_real_failing_conclusion_is_still_action_required(
+        self, runner: Runner
+    ):
+        # The obvious misreading of this change is "transport resilience
+        # softened real failures". It must not: a completed/failure CI run
+        # still yields the terminal red verdict.
+        (runner.fixtures / "ci_runs.json").write_text(
+            _run_json("ci.yml", status="completed", conclusion="failure")
+        )
+        proc, outputs = runner.evaluate()
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "failure"
+        assert outputs["label"] == "readiness: action required"
+
+    def test_real_failure_plus_flake_on_another_lane_stays_red(
+        self, runner: Runner
+    ):
+        # A transient blip elsewhere must not launder a genuine red into the
+        # non-terminal pending fallback once the retry absorbs the blip.
+        (runner.fixtures / "ci_runs.json").write_text(
+            _run_json("ci.yml", status="completed", conclusion="failure")
+        )
+        proc, outputs = runner.evaluate(
+            flaky_substr="claude-review.yml/runs", flaky_fails=1
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "failure"
+        assert outputs["label"] == "readiness: action required"
+
+    def test_observed_red_dominates_persistent_transport_failure(
+        self, runner: Runner
+    ):
+        # Precedence when BOTH happen: CI already recorded a genuine failure,
+        # then a later lane's read dies for all 3 attempts. The fallback must
+        # NOT mask the known red behind "could not be evaluated" -- an
+        # already-observed blocker wins and the verdict stays terminal red.
+        # (ci.yml is evaluated before the review lanes, so the failure is in
+        # `failed[]` by the time the transport failure aborts the loop.)
+        (runner.fixtures / "ci_runs.json").write_text(
+            _run_json("ci.yml", status="completed", conclusion="failure")
+        )
+        proc, outputs = runner.evaluate(
+            flaky_substr="claude-review.yml/runs", flaky_fails=99
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "failure"
+        assert outputs["label"] == "readiness: action required"
+        assert "could not be evaluated" not in outputs["description"]
+        # The red verdict was computed from a partial read -- the summary must
+        # say so instead of presenting itself as a complete evaluation.
+        summary = (runner.temp / "pr-readiness-summary.md").read_text()
+        assert "truncated" in summary

--- a/test/test_pr_readiness_publish.py
+++ b/test/test_pr_readiness_publish.py
@@ -85,9 +85,22 @@ if [ "$1" = "api" ]; then
     exit 0
   fi
   if [ "${2:-}" = "--method" ] && [ "${3:-}" = "POST" ]; then
-    body="$(cat)"
+    # The status POST passes --input <file>; the label POST still
+    # pipes --input - via stdin.
+    body=""
+    prev=""
+    for arg in "$@"; do
+      if [ "$prev" = "--input" ] && [ "$arg" != "-" ]; then
+        body="$(cat "$arg")"
+      fi
+      prev="$arg"
+    done
+    if [ -z "$body" ]; then
+      body="$(cat)"
+    fi
     case "${4:-}" in
       *"/statuses/"*)
+        echo x >> "$FIXTURES/status_post_attempts.txt"
         if [ -f "$FIXTURES/fail_status" ]; then
           echo 'gh: Server Error (HTTP 500)' >&2
           exit 1
@@ -115,6 +128,15 @@ def _step(name: str) -> str:
     steps = spec["jobs"]["readiness"]["steps"]
     matches = [s["run"] for s in steps if s.get("name") == name and "run" in s]
     assert len(matches) == 1, f"expected exactly one {name!r} step, got {len(matches)}"
+    return matches[0]
+
+
+def _helper_script() -> str:
+    """The retry-helper install step every other step sources at runtime."""
+    spec = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = spec["jobs"]["readiness"]["steps"]
+    matches = [s["run"] for s in steps if "run" in s and "cat > \"$RUNNER_TEMP/gh-retry.sh\"" in s["run"]]
+    assert len(matches) == 1, "expected exactly one retry-helper install step"
     return matches[0]
 
 
@@ -178,6 +200,14 @@ class Runner:
         (self.tmp / "pr-readiness-summary.md").write_text("## summary\n")
         self.summary = root / "step-summary.md"
         self.summary.write_text("")
+        # The steps under test `source "$RUNNER_TEMP/gh-retry.sh"`; in CI the
+        # first job step writes it there. Reproduce that provisioning here.
+        subprocess.run(  # noqa: S603 - fixed argv, workflow-authored script
+            ["bash", "-c", _helper_script()],
+            env={**os.environ, "RUNNER_TEMP": str(self.tmp)},
+            check=True,
+            capture_output=True,
+        )
         self.env = {
             **os.environ,
             "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
@@ -220,6 +250,7 @@ class Runner:
             flag.unlink(missing_ok=True)
             if on:
                 flag.write_text("1")
+        (self.fixtures / "status_post_attempts.txt").unlink(missing_ok=True)
         for stale in ("calls.txt", "deleted.txt", "added.txt", "published_status.json"):
             (self.fixtures / stale).unlink(missing_ok=True)
 
@@ -311,6 +342,17 @@ def test_the_verdict_is_published_before_any_label_call(runner: Runner) -> None:
 # ── But a real failure must still be a failure ───────────────────────────────
 
 
+def test_a_deferred_evaluation_publishes_nothing(runner: Runner) -> None:
+    """A truncated evaluation that deferred to an existing terminal verdict
+    emits an empty status_state; the publish step must no-op green -- no
+    status POST, no label churn."""
+    result = runner.run(status_state="")
+    assert result.ok, result.proc.stderr
+    assert result.published is None
+    attempts_file = runner.fixtures / "status_post_attempts.txt"
+    assert not attempts_file.exists()
+
+
 def test_a_failure_to_publish_the_verdict_fails_the_step(runner: Runner) -> None:
     """The tolerance is scoped to the advisory labels, not to the verdict.
 
@@ -320,6 +362,19 @@ def test_a_failure_to_publish_the_verdict_fails_the_step(runner: Runner) -> None
     result = runner.run(fail_status=True)
     assert not result.ok
     assert result.published is None
+
+
+def test_a_failed_post_is_never_retried(runner: Runner) -> None:
+    """Commit statuses are last-write-wins with no conditional write, so a
+    retry after a failed POST races a concurrent run's newer verdict for the
+    same revision -- between any guard read and the re-POST another run can
+    publish, and the re-POST would overwrite it (a stale green over a fresh
+    red, or a pending over a terminal). The step makes exactly ONE attempt
+    and fails loud; a re-run republishes."""
+    result = runner.run(fail_status=True)
+    assert not result.ok
+    attempts = (runner.fixtures / "status_post_attempts.txt").read_text()
+    assert len(attempts.splitlines()) == 1
 
 
 def test_an_unexpected_label_error_still_fails_the_step(


### PR DESCRIPTION
## Problem

`PR Readiness` can go red for reasons that have nothing to do with readiness. Every
`gh` call in `pr-readiness.yml` was single-shot inside a fail-fast (`set -e`) shell
step, so one transient network/TLS error aborted the whole evaluation, skipped the
publish step, and left a permanently red check on the PR. Proven on PR #2650: the
same commit was evaluated twice, 39 seconds apart, with nothing pushed — green at
04:32:59, red at 04:33:38, the red job's log ending in an x509 TLS error on the
`codex-review.yml` runs read. Of the workflow's 100 most recent failures, 21 are
this transport class (#2853 fixed the other dominant class, the label race, and
explicitly deferred this one to this issue).

## Why it matters

`PR Readiness` is the only required status check on protected branches. A red
check-run caused by a network blip makes authors and maintainers chase phantom
failures, hides real signal, and (via `pull_request_target` runs, which surface as
check-runs) leaves a permanent red mark on the PR that no later event can clean up.

## Fix (symptoms → root cause → change)

Root cause: ~13 single-shot `gh` calls under `set -e`, each able to end the job
before the verdict computed three lines above could be published.

Three changes, mirroring the bounded-attempts resilience convention already used in
`publish-installer.yml`:

1. **A bounded retry helper for every read-only `gh` call.** A new first step
   writes `gh_retry()` (3 attempts, 2s/4s backoff, 120s timeout per attempt so a
   hanging attempt cannot eat the job's 20-minute cap) to `$RUNNER_TEMP`; each step
   sources it. Stdout is buffered per attempt so a failed attempt's partial
   `--paginate` output never leaks into a pipe. A **non-rate-limit HTTP 4xx is not
   retried**: it is a permanent misconfiguration (renamed workflow file, missing
   scope), returned as a distinct code, and fails the job loudly instead of being
   misdiagnosed as network trouble.
2. **On final transport failure during evaluation, publish an explicit non-terminal
   verdict.** The evaluate step publishes `pending` under the existing
   `readiness: checking` label with the description "Readiness could not be
   evaluated (transient GitHub API failure); it will be re-evaluated" and exits 0,
   so the publish step still runs and no red check-run is left behind. Recovery is
   automatic: the self-heal sweep re-fires stale pending statuses, and any later
   monitored-workflow event recomputes sooner.
3. **The status POST is never retried — a failed POST fails the step loud.**
   A commit status is last-write-wins per SHA+context, GitHub offers no
   conditional write, and two runs can evaluate the same revision
   concurrently — so *any* retry races a concurrent run's newer verdict:
   between whatever guard read a retry could take and its re-POST, another
   run can publish, and the re-POST would republish this run's verdict over
   it (a stale green over a fresh red, or a pending over a terminal). No
   guard closes that window without an atomic primitive the API does not
   provide, so the step makes exactly one timeout-bounded attempt and, on
   failure, exits red with an actionable error — a re-run (or the next
   monitored-workflow event) re-evaluates and republishes, and no verdict is
   ever silently overwritten. The label writes keep
   only the narrow 404/already-exists race tolerance from #2853 and are otherwise
   deliberately not retried (a lost-response DELETE retry would turn an applied
   change into a new failure).

**What this change must NOT be read as — and does not do.** It does not widen any
threshold, skip any check, or suppress a genuine failing verdict. Only a transport
error becomes non-terminal, and it becomes *pending*, which blocks merge exactly
like *failure* does. A monitored workflow that really failed still produces the
terminal red `action required` verdict — including when a transport failure happens
*after* the red was observed: an already-recorded blocker dominates the fallback
(the `${#failed[@]} -eq 0` guard), and the step summary then notes the evaluation
was truncated. The fallback's tiebreaker for every ambiguous prior state is an
asymmetry: pending can only ever BLOCK a merge, never allow one. So a truncated
run defers (publishes nothing, exits green) only when the revision already
carries a *blocking* verdict -- the merge is already held, and pending would
only discard the red's diagnostics. An existing *success* is re-pended instead
of deferred to: a monitored rerun means validation state is unknown again, and
leaving the stale green mergeable is the unsafe direction -- re-evaluation
restores the true verdict. An unreadable verdict state gets the same fail-safe
pending. Pending-over-pending still publishes (it refreshes the sweep's
staleness clock). A permanent HTTP error (a 4xx that is not a rate limit) still fails the job red. Rate limits -- HTTP 429, and GitHub's primary/secondary limits which surface as HTTP 403 with rate-limit text -- are retried as transient.

## Tests

New `test/test_pr_readiness_evaluate.py` — extracts the real evaluate-step script
plus the helper install step and executes them against a `gh` stub (the harness
convention of `test_pr_readiness_sweep.py` / `test_pr_readiness_publish.py`):

- a transient failure is retried and the evaluation reaches its REAL verdict;
- a failed attempt's partial stdout never corrupts the retried read;
- a persistent transport failure publishes the non-terminal pending verdict, exits
  0, and attempts exactly 3 times (bounded);
- the commit-status description fits the API's 140-char limit;
- the fork `checkrun:` lane takes the same fallback;
- a genuine failing conclusion still yields `action required` — alone, with a
  transient blip on another lane, and with a *persistent* transport failure after
  the red was observed (precedence), asserting the truncation note;
- a permanent HTTP 404 is not retried and is not laundered into pending; HTTP 429
  and rate-limit HTTP 403 (GitHub secondary limits) are retried as transient; a
  plain 403 (missing scope, SSO) stays permanent and fails loud.

`test_pr_readiness_publish.py`'s harness now materializes the sourced helper the
way CI does, and its stub accepts the status POST's `--input <file>` form. New
publish/evaluate cases: a failed status POST makes exactly ONE attempt and fails
the step; a truncated run defers only to an existing *blocking* verdict, while
an existing *success* and an unreadable verdict state both publish pending.

All guards were mutation-probed: reverting the fallback, the blocking-only
defer condition, the single-attempt POST, the precedence guard, or the
permanent-4xx classification each makes its test fail.

## Manual verification

N/A — the behavioural harness executes the workflow's actual shell against a stub;
the network-failure paths it exercises cannot be reproduced on demand against the
live API. Doc bullet updated in `docs/ci/ci-and-reviews.md` in the same commit.

## Screenshots

N/A — CI workflow change, no UI surface.

Closes #2753







