### PR TITLE
fix(md-notebook): persist collapsed folders per vault

### DIFF
--- a/website/src/apps/md-notebook/MdNotebookPage.tsx
+++ b/website/src/apps/md-notebook/MdNotebookPage.tsx
@@ -42,6 +42,7 @@ import {
   PANEL_MIN_WIDTH,
   SAVE_DEBOUNCE_MS,
   SORTS,
+  collapsedKey,
   pinnedKey,
 } from './constants'
 import { MDNB_CSS } from './styles'
@@ -113,7 +114,13 @@ export default function MdNotebookPage() {
   const [dirty, setDirty] = useState(false)
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchHit[]>([])
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+  // Seeded from storage for the vault that will be restored, so returning to the
+  // app keeps the tree the user shaped. An empty set means every folder open, so
+  // initialising blind is what re-expanded the whole tree on every mount.
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => {
+    const vault = loadPref<string | null>(LS.activeVault, null)
+    return new Set(vault ? loadPref<string[]>(collapsedKey(vault), []) : [])
+  })
   const [syncing, setSyncing] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [editBlock, setEditBlock] = useState<EditRange | null>(null)
@@ -441,8 +448,10 @@ export default function MdNotebookPage() {
     savePref(LS.activeVault, activeVaultId)
     setLastSync(loadPref<number | null>(`mdnb-last-sync-${activeVaultId}`, null))
     // Pins are per-vault, so they are re-read here rather than carried over —
-    // a path pinned in one vault means nothing in another.
+    // a path pinned in one vault means nothing in another. Collapsed folders
+    // are per-vault for the same reason: the trees are unrelated.
     setPinned(new Set(loadPref<string[]>(pinnedKey(activeVaultId), [])))
+    setCollapsed(new Set(loadPref<string[]>(collapsedKey(activeVaultId), [])))
     setRenamingPath(null)
     void loadNotes()
   }, [activeVaultId, loadNotes])
@@ -616,6 +625,12 @@ export default function MdNotebookPage() {
   const writePinned = useCallback((next: Set<string>) => {
     setPinned(next)
     if (vaultRef.current) savePref(pinnedKey(vaultRef.current), [...next])
+  }, [])
+
+  /** Persist a new collapsed-folder set for the ACTIVE vault. Same shape as pins. */
+  const writeCollapsed = useCallback((next: Set<string>) => {
+    setCollapsed(next)
+    if (vaultRef.current) savePref(collapsedKey(vaultRef.current), [...next])
   }, [])
 
   const isPinned = useCallback((path: string) => pinned.has(path), [pinned])
@@ -1078,14 +1093,13 @@ export default function MdNotebookPage() {
   )
 
   const toggle = useCallback(
-    (name: string) =>
-      setCollapsed(prev => {
-        const next = new Set(prev)
-        if (next.has(name)) next.delete(name)
-        else next.add(name)
-        return next
-      }),
-    [],
+    (name: string) => {
+      const next = new Set(collapsed)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      writeCollapsed(next)
+    },
+    [collapsed, writeCollapsed],
   )
 
   const togglePanel = useCallback(() => {

--- a/website/src/apps/md-notebook/constants.ts
+++ b/website/src/apps/md-notebook/constants.ts
@@ -36,6 +36,14 @@ export const LS = {
 export const pinnedKey = (vaultId: string): string => `mdnb-pinned-${vaultId}`
 
 /**
+ * Collapsed folder names, per vault for the same reason pins are: two vaults
+ * hold different trees, so a name collapsed in one means nothing in the other.
+ * Local to this machine because it is view state, not content — writing it into
+ * the vault would sync one device's sidebar shape to every other.
+ */
+export const collapsedKey = (vaultId: string): string => `mdnb-collapsed-${vaultId}`
+
+/**
  * Sort options for the notes list. Keys are persisted, so renaming one resets
  * the user's choice to the default. Labels live in `labels.ts` (`sortLabel`),
  * keyed by these same ids, so the i18n key-reference gate can verify them.

--- a/website/src/test/MdNotebookPage.coverage.test.tsx
+++ b/website/src/test/MdNotebookPage.coverage.test.tsx
@@ -246,6 +246,38 @@ describe('MdNotebookPage', () => {
     expect(screen.getByRole('button', { name: 'One' })).toBeTruthy()
   })
 
+  it('persists a collapsed folder per vault, and clears it on re-expand', async () => {
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'folder' }))
+    await waitFor(() => expect(localStorage.getItem('mdnb-collapsed-v1')).toBe('["folder"]'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'folder' }))
+    await waitFor(() => expect(localStorage.getItem('mdnb-collapsed-v1')).toBe('[]'))
+  })
+
+  it('restores collapsed folders on mount, so the tree keeps its shape', async () => {
+    localStorage.setItem('mdnb-active-vault', '"v1"')
+    localStorage.setItem('mdnb-collapsed-v1', '["folder"]')
+    await renderPage()
+    // The folder itself is listed; only what is inside it stays hidden.
+    expect(await screen.findByRole('button', { name: 'folder' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Two' })).toBeNull()
+  })
+
+  it('keeps one vault’s collapsed folders out of another’s', async () => {
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'folder' }))
+    await waitFor(() => expect(localStorage.getItem('mdnb-collapsed-v1')).toBe('["folder"]'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Switch vault' }))
+    await userEvent.click(screen.getByRole('option', { name: /Second vault/ }))
+    await screen.findByRole('button', { name: 'Other' })
+    // The second vault has its own (absent) entry rather than inheriting one a
+    // folder name it does not have would have silently collapsed.
+    expect(localStorage.getItem('mdnb-collapsed-v2')).toBeNull()
+    expect(localStorage.getItem('mdnb-collapsed-v1')).toBe('["folder"]')
+  })
+
   // ── opening a note ────────────────────────────────────────────────────────
 
   it('opens a note on click, showing its body and its backlinks', async () => {


### PR DESCRIPTION
# What is the problem?

A folder collapsed in the Notes sidebar does not stay collapsed. The state is discarded when the page unmounts, so every return to the app renders the tree fully expanded.

# Why this issue matters to the user

A vault with real folder structure has to be re-collapsed by hand on every visit. The sidebar is the app's only navigation surface, so the shape the user gave it is the shape they navigate by — and it is thrown away between visits. Every other view preference here survives (active vault, open note, sort order, folders/flat, panel width, pinned notes), which makes this read as an oversight rather than a decision.

# How our fix solves it

Symptom → root cause chain:

1. `collapsed` was initialised blind: `useState<Set<string>>(new Set())`.
2. A folder counts as collapsed only when its name is IN that set, so an empty initial value means "every folder open".
3. Nothing wrote the set to storage on toggle, and nothing read it back on mount — so no path existed for the shape to return.

The fix follows the pinned-notes pattern already in this file rather than inventing a mechanism:

- `collapsedKey(vaultId)` in `constants.ts`, beside `pinnedKey`, with the same rationale documented — per vault because two vaults hold unrelated trees, and machine-local because this is view state, not content that should reach the git remote.
- `writeCollapsed`, the mirror of `writePinned`: sets state and persists to the active vault's key.
- `toggle` routed through it, exactly as `togglePin` goes through `writePinned`.
- The vault-switch effect re-reads it next to the pins.
- The initial `useState` seeds from the vault the app is about to restore, so the first paint already has the right shape instead of flashing expanded.

# What tests we did

Three tests added to `MdNotebookPage.coverage.test.tsx`, beside the existing collapse test:

- collapsing persists `mdnb-collapsed-v1` and re-expanding clears it
- a stored collapsed set is restored on mount, with the folder listed and its contents hidden
- one vault's collapsed set does not leak into another's key on a vault switch

Verified locally on the rebased branch: `npx tsc -b` clean; the four md-notebook suites 164 passed (161 before); `npx eslint src/ --max-warnings 1116` unchanged at 602 warnings; `npx jscpd .` 0 clones; `npm run i18n:check` 16/16 PASS; `scrub-lint`, `check_brand_name.py`, `docs-lint.sh` and `verify_vendor_manifest.py` all green.

The full frontend suite was not run locally — CI's four shards cover it.

# Manual verification

Ran the worktree's frontend through the Vite dev server against a real gateway and a real vault: collapsed a folder, navigated away and back, and the folder stayed collapsed. Switched vaults and returned; each vault kept its own tree shape.

# Any other suggestions on the work

A folder rename leaves its stored name behind as an entry that no longer matches anything in the tree. It is inert — an unmatched name simply never collapses a folder — so it is left out of this change rather than widening it. `repointPin` is the precedent if that is ever worth following for folders too.

Closes #2987
