### PR TITLE
refactor: drive SafeLoader subclasses directly instead of yaml.load

### DIFF
--- a/src/kiro_crew/onboarding_import.py
+++ b/src/kiro_crew/onboarding_import.py
@@ -72,6 +72,22 @@ class _NoAliasSafeLoader(yaml.SafeLoader):
         return super().compose_node(parent, index)
 
 
+def _load_no_alias_yaml(text: str) -> Any:
+    """Parse ONE YAML document with :class:`_NoAliasSafeLoader`.
+
+    Driving the loader instance is what ``yaml.load`` does with an explicit
+    ``Loader=``, so the parse is identical — but the SafeLoader subclass is the
+    only construction path here, with no ``yaml.load`` call whose safety a
+    reader (or a scanner keyed on the call name) has to infer from the
+    ``Loader=`` argument.
+    """
+    loader = _NoAliasSafeLoader(text)
+    try:
+        return loader.get_single_data()
+    finally:
+        loader.dispose()
+
+
 SOURCE_IDS = ("codex", "claude_code", "meshclaw", "openclaw", "hermes")
 # Conflict strategies. ``skip`` is the default and the only non-destructive one;
 # the other two require an explicit user choice per apply request. See
@@ -894,7 +910,7 @@ def _read_simple_yaml(path: Path, anchor: Path, scan: _Scan) -> dict[str, Any]:
     if text is None:
         return {}
     try:
-        result = yaml.load(text, Loader=_NoAliasSafeLoader)
+        result = _load_no_alias_yaml(text)
     except (yaml.YAMLError, RecursionError, ValueError):
         scan.diagnostic("settings", "invalid_config")
         return {}

--- a/test/test_deploy_cwe770_throttle_waf.py
+++ b/test/test_deploy_cwe770_throttle_waf.py
@@ -15,6 +15,7 @@ is an opt-in WafWebAclArn parameter gated by a Condition onto WebACLId.
 from pathlib import Path
 
 import yaml
+from yaml_helpers import load_with
 
 REPO = Path(__file__).resolve().parents[1]
 TPL_DIR = (
@@ -46,7 +47,7 @@ _TagTolerantLoader.add_multi_constructor(None, _construct_intrinsic)
 
 
 def _load(text):
-    return yaml.load(text, Loader=_TagTolerantLoader)  # noqa: S506 — tag-blind CFN parse
+    return load_with(_TagTolerantLoader, text)
 
 
 class TestPartAApiGwThrottling:

--- a/test/test_deploy_round29_fixes.py
+++ b/test/test_deploy_round29_fixes.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from yaml_helpers import load_with
 
 from kiro_crew.deploy import handlers
 
@@ -176,7 +177,7 @@ def _load_cfn_yaml(path: Path) -> dict:
     )
 
     with open(path) as f:
-        return yaml.load(f, Loader=CfnLoader)  # noqa: S506 — tag-blind CFN parse
+        return load_with(CfnLoader, f)
 
 
 class TestF3IdentitySourceList:

--- a/test/test_deploy_round35_fixes.py
+++ b/test/test_deploy_round35_fixes.py
@@ -9,6 +9,7 @@ F2: the "file-too-large" staging rejection (added in R33) must be in the
 from pathlib import Path
 
 import yaml
+from yaml_helpers import load_with
 
 from kiro_crew.deploy import iam as iam_mod
 
@@ -57,7 +58,7 @@ class TestF1ApiGwTagCondition:
         )
         for name in ("app-apigw.yaml", "app-apigw-ddb.yaml"):
             raw = (TEMPLATES / name).read_text(encoding="utf-8")
-            doc = yaml.load(raw, Loader=_CfnLoader)  # noqa: S506 — tag-blind CFN parse
+            doc = load_with(_CfnLoader, raw)
             api = next(
                 r for r in doc["Resources"].values()
                 if r.get("Type") == "AWS::ApiGatewayV2::Api"

--- a/test/test_deploy_web_iam.py
+++ b/test/test_deploy_web_iam.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from yaml_helpers import load_with
+
 from kiro_crew.deploy import engine
 from kiro_crew.deploy import iam as iam_mod
 
@@ -55,7 +57,7 @@ def test_policy_prefix_matches_template_bucket():
 
     template_path = _PKG / "skills" / "artifact-deploy" / "templates" / "base-stack.yaml"
     with open(template_path) as f:
-        tmpl = yaml.load(f, Loader=_CfnLoader)  # noqa: S506
+        tmpl = load_with(_CfnLoader, f)
     bucket_name = tmpl["Resources"]["OriginBucket"]["Properties"]["BucketName"]
     # Template uses !Sub 'kirocrew-deploy-${AWS::AccountId}-${AWS::Region}'
     # The IAM prefix must be 'kirocrew-deploy-*' to cover all account/region combos.
@@ -90,7 +92,7 @@ def test_audit_log_bucket_has_versioning_enabled():
 
     template_path = _PKG / "skills" / "artifact-deploy" / "templates" / "base-stack.yaml"
     with open(template_path) as f:
-        tmpl = yaml.load(f, Loader=_CfnLoader)  # noqa: S506
+        tmpl = load_with(_CfnLoader, f)
 
     resources = tmpl["Resources"]
     for name in ("OriginBucket", "LogBucket"):
@@ -378,7 +380,7 @@ def test_reaper_template_includes_engine_arch_permissions():
 
     template_path = _PKG / "skills" / "artifact-deploy" / "templates" / "reaper.yaml"
     with open(template_path) as f:
-        tmpl = yaml.load(f, Loader=_CfnLoader)  # noqa: S506
+        tmpl = load_with(_CfnLoader, f)
 
     role_props = tmpl["Resources"]["ReaperRole"]["Properties"]
     stmts = role_props["Policies"][0]["PolicyDocument"]["Statement"]

--- a/test/test_yaml_safe_loading.py
+++ b/test/test_yaml_safe_loading.py
@@ -1,0 +1,77 @@
+"""Guard: no source in this repo parses YAML through ``yaml.load``.
+
+``yaml.load`` is only as safe as its ``Loader=`` argument, and that safety is
+invisible at the call site: a reviewer — and every static scanner that matches
+on the call name — has to chase the loader class to tell an untrusted-input RCE
+apart from a deliberate CloudFormation tag-tolerant parse. So the repo parses
+either with ``yaml.safe_load``, or by driving a ``yaml.SafeLoader`` subclass
+directly (``load_with`` in `test/yaml_helpers.py`, ``_load_no_alias_yaml`` in
+``onboarding_import``), which makes the safe base class the only construction
+path and needs no per-line suppression comment to stay quiet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from yaml_helpers import load_with
+
+_REPO = Path(__file__).resolve().parents[1]
+
+# Built at runtime so this guard's own source does not contain the needles.
+_NEEDLES = tuple(f"yaml.{name}(" for name in ("load", "load_all", "unsafe_load"))
+
+# The bundled llama.cpp binding is third-party source, not ours to restyle.
+_SKIP_DIRS = ("_vendor", "__pycache__", "node_modules")
+
+# This module asserts the ABSENCE of the pattern in another module, so the
+# needle appears there as string data rather than as a call.
+_ALLOWLIST = frozenset(
+    {
+        "src/kiro_crew/apps/builtins/ops_mission_control/tests/test_schedule_file.py",
+    }
+)
+
+
+def _candidate_files() -> list[Path]:
+    files: list[Path] = []
+    for root in (_REPO / "src", _REPO / "test"):
+        for path in root.rglob("*.py"):
+            if any(part in _SKIP_DIRS for part in path.parts):
+                continue
+            if path.relative_to(_REPO).as_posix() in _ALLOWLIST:
+                continue
+            files.append(path)
+    return files
+
+
+def test_no_yaml_load_call_sites() -> None:
+    offenders: list[str] = []
+    for path in _candidate_files():
+        source = path.read_text(encoding="utf-8", errors="ignore")
+        for lineno, line in enumerate(source.splitlines(), start=1):
+            if any(needle in line for needle in _NEEDLES):
+                offenders.append(f"{path.relative_to(_REPO).as_posix()}:{lineno}")
+    assert not offenders, (
+        "parse YAML with yaml.safe_load, or drive a yaml.SafeLoader subclass "
+        f"directly (see test/yaml_helpers.py load_with): {offenders}"
+    )
+
+
+def test_load_with_parses_through_a_safe_subclass() -> None:
+    class _TagTolerant(yaml.SafeLoader):
+        pass
+
+    _TagTolerant.add_multi_constructor(
+        None, lambda loader, suffix, node: loader.construct_scalar(node)
+    )
+
+    doc = load_with(_TagTolerant, "Name: !Sub value\n")
+    assert doc == {"Name": "value"}
+
+
+def test_load_with_refuses_an_unsafe_loader() -> None:
+    with pytest.raises(TypeError):
+        load_with(yaml.UnsafeLoader, "a: 1\n")

--- a/test/yaml_helpers.py
+++ b/test/yaml_helpers.py
@@ -1,0 +1,34 @@
+"""Parse YAML through an explicit loader class, without calling ``yaml.load``.
+
+CloudFormation templates carry intrinsic tags (``!Sub``/``!Ref``/``!GetAtt``/
+``!If``) that ``yaml.safe_load`` refuses, so the deploy tests register tag
+constructors on a ``yaml.SafeLoader`` subclass and parse with that.
+
+Driving the loader instance directly is exactly what ``yaml.load`` does with an
+explicit ``Loader=``, so the parse is unchanged — but it keeps the safe base
+class as the only construction path and leaves no ``yaml.load`` call for
+scanners that key on the call name alone and cannot see that the loader
+subclasses ``SafeLoader`` (bandit B506 / "Unsafe YAML Load").
+"""
+
+from __future__ import annotations
+
+from typing import IO, Any
+
+import yaml
+
+
+def load_with(loader_cls: type, stream: str | bytes | IO[Any]) -> Any:
+    """Parse ONE YAML document from ``stream`` using ``loader_cls``.
+
+    ``loader_cls`` MUST derive from ``yaml.SafeLoader``. A loader that can
+    construct arbitrary Python objects is refused rather than run, so widening
+    the parse by swapping the class fails loudly instead of silently.
+    """
+    if not (isinstance(loader_cls, type) and issubclass(loader_cls, yaml.SafeLoader)):
+        raise TypeError(f"loader must subclass yaml.SafeLoader, got {loader_cls!r}")
+    loader = loader_cls(stream)
+    try:
+        return loader.get_single_data()
+    finally:
+        loader.dispose()


### PR DESCRIPTION
## Summary

Every `yaml.load(...)` call in the repo already passes a `yaml.SafeLoader`
subclass — the deploy tests need one because CloudFormation templates carry
intrinsic tags (`!Sub`/`!Ref`/`!GetAtt`/`!If`) that `yaml.safe_load` refuses, and
`onboarding_import` needs one that additionally rejects anchors/aliases so an
untrusted foreign-agent config cannot amplify into a billion-laughs traversal.

The calls are safe, but the safety is invisible at the call site: a reader has to
chase the loader class, and a static scanner that matches on the call name cannot
see the base class at all. bandit B506 compares the `Loader=` argument literally
against `SafeLoader`/`CSafeLoader`, so **every** subclass is reported as an unsafe
load (7 findings across 5 files, High severity). The `# noqa: S506` markers
currently on those lines are flake8/ruff syntax — bandit honors `# nosec` only, so
they never suppressed anything.

This drives the loader instance directly, which is exactly what `yaml.load` does
with an explicit `Loader=`. The parse is unchanged, the safe base class becomes the
only construction path, and no per-line suppression comment is needed.

- `test/yaml_helpers.py` — shared `load_with(loader_cls, stream)` that **refuses** a
  loader which does not subclass `yaml.SafeLoader`, so widening the parse by
  swapping the class fails loudly instead of silently.
- `src/kiro_crew/onboarding_import.py` — `_load_no_alias_yaml` keeps
  `_NoAliasSafeLoader` as the only path for untrusted config.
- `test/test_yaml_safe_loading.py` — guard that no source under `src/` or `test/`
  reintroduces a `yaml.load` call site, so the next hand-rolled CFN loader cannot
  quietly regress this. Same idea as the existing narrower guard in the
  ops-mission-control tests.

No behavior change: `load_with` and `_load_no_alias_yaml` do what
`yaml.load(stream, Loader=cls)` does internally (`cls(stream).get_single_data()`
with `dispose()` in a `finally`).

## Testing

- `bandit -r src test -t B506` → **0** findings (was 7).
- `pytest test/test_yaml_safe_loading.py test/test_deploy_web_iam.py test/test_deploy_round29_fixes.py test/test_deploy_round35_fixes.py test/test_deploy_cwe770_throttle_waf.py test/test_onboarding_import.py` → 302 passed.
- `isort --check-only src/kiro_crew test`, `flake8` on the touched files, `mypy src/kiro_crew/` (891 files) → all clean.
- Developed and verified in a dedicated worktree off `origin/main`.

## Blocked features

None. Frontend untouched, so `tsc`/`vitest` were not re-run.