### PR TITLE
feat(knowledge): add .jsonl and .ndjson to FileReader.SUPPORTED

### DIFF
--- a/src/kiro_crew/knowledge/readers.py
+++ b/src/kiro_crew/knowledge/readers.py
@@ -34,7 +34,8 @@ class FileReader:
     SUPPORTED = {
         '', '.md', '.txt', '.org', '.py', '.java', '.ts', '.js', '.rs', '.go',
         '.html', '.htm', '.docx', '.pdf',
-        '.csv', '.log', '.json', '.yaml', '.yml', '.sh', '.rb', '.c', '.cpp', '.h',
+        '.csv', '.log', '.json', '.jsonl', '.ndjson', '.yaml', '.yml',
+        '.sh', '.rb', '.c', '.cpp', '.h',
     }
 
     _DISPATCH = {

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -213,7 +213,7 @@ class TestFileReader:
 
     def test_supported_formats(self):
         reader = FileReader()
-        for ext in ('.md', '.txt', '.py', '.html', '.json', '.yaml', '.csv'):
+        for ext in ('.md', '.txt', '.py', '.html', '.json', '.jsonl', '.ndjson', '.yaml', '.csv'):
             assert ext in reader.SUPPORTED, f"{ext} missing from SUPPORTED"
 
 


### PR DESCRIPTION
## Summary

Add `.jsonl` and `.ndjson` to `FileReader.SUPPORTED` so the knowledge source folder watcher picks up JSON Lines / Newline-Delimited JSON files during scans.

## Motivation

`.jsonl` (JSON Lines) and `.ndjson` (Newline-Delimited JSON, IANA `application/x-ndjson`) are widely used for:
- Structured data exports (e.g. shared lesson files synced across teams)
- Log streams and event records
- ML training data and evaluation datasets

These are plain UTF-8 text files — one JSON object per line — and require no special reader. The existing `_read_text` fallback handles them correctly.

## Changes

- `src/kiro_crew/knowledge/readers.py`: Added `'.jsonl'` and `'.ndjson'` to `FileReader.SUPPORTED`
- `test/test_knowledge.py`: Updated `test_supported_formats` assertion to cover both new extensions

## Testing

- Verified both extensions are now in the `SUPPORTED` set
- No new dispatch entry needed — `_read_text` already reads any text-based file with UTF-8 (latin-1 fallback)