### PR TITLE
feat(apps): render the official catalog's curated fields

### DIFF
--- a/src/kiro_crew/apps/official_catalog.py
+++ b/src/kiro_crew/apps/official_catalog.py
@@ -1,0 +1,291 @@
+"""Fetch the official app catalog and annotate registry rows with it.
+
+WHAT THIS IS. The catalog at ``apps.crew.kiro.dev`` is the list Kiro Crew
+publishes, delivered as a document rather than baked into the wheel. The bundled
+``app-registry.json`` answers the same question offline -- it is the seed -- so
+both carry ``provenance: "official"``; see ``_apply_trust_fields``.
+
+WHAT THIS IS NOT, YET. Three deliberate omissions, each a fail-closed gate here
+rather than an ignored field, so the first time one matters it surfaces loudly
+instead of degrading silently:
+
+- **No signature verification.** The catalog is KMS-signed and a ``.sig`` sidecar
+  is published beside it, but nothing here checks it. Trust is therefore TLS to
+  our own domain -- the same basis on which the installer already fetches the
+  CLI wheel, not a new low, but strictly less than the signature would give. The
+  consequence is enforced below: a curated author does NOT mint the verified
+  mark while this is true.
+- **No tombstone resolution.** ``removed`` / ``reinstated`` carry withdrawal
+  history with date precedence and a fail-closed tie rule. Implementing half of
+  that would be worse than not implementing it, so a document carrying either
+  list non-empty is REFUSED outright and the client falls back to the seed. A
+  withdrawn app must never be rendered because we skipped the mechanism that
+  withdraws it.
+- **No new inventory.** Every entry annotates a row that already exists (a
+  built-in discovered from disk, or a seed-index row). A published ``git`` source
+  is pinned to a COMMIT, and the install path clones with ``--branch``, which a
+  commit id is not -- so adding installable entries needs that path changed
+  first. An entry matching nothing is ignored.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import logging
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from kiro_crew.config.loader import config_dir
+
+logger = logging.getLogger(__name__)
+
+#: Documented in the catalog repo's docs/distribution.md and printed by its
+#: publish workflow. Trailing slash matters: refs are resolved against it.
+OFFICIAL_CATALOG_BASE = "https://apps.crew.kiro.dev/"
+OFFICIAL_CATALOG_URL = f"{OFFICIAL_CATALOG_BASE}official-registry.json"
+
+#: The only schemaVersion this code understands. An unknown major is refused
+#: rather than best-guessed: the document's meaning is what changed, and a
+#: client that keeps reading the fields it recognises is a client that acts on a
+#: contract it does not know.
+SUPPORTED_SCHEMA_VERSION = 1
+
+CACHE_TTL = 3600  # 1 hour
+FETCH_TIMEOUT = 10
+#: A catalog of a few dozen apps is tens of kilobytes. The cap is not about disk
+#: but about not reading an unbounded body into memory from a host we do not
+#: control at parse time.
+MAX_BYTES = 4 * 1024 * 1024
+
+
+def _cache_path() -> Path:
+    return config_dir() / "cache" / "official-catalog.json"
+
+
+def _read_cache() -> dict[str, Any] | None:
+    path = _cache_path()
+    try:
+        if not path.is_file() or time.time() - path.stat().st_mtime > CACHE_TTL:
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _write_cache(doc: dict[str, Any]) -> None:
+    path = _cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(doc), encoding="utf-8")
+    except OSError:
+        logger.debug("could not cache the official catalog", exc_info=True)
+
+
+def _https_request(url: str) -> urllib.request.Request:
+    """Build the catalog GET, refusing any scheme but https.
+
+    ``urllib`` honours ``file://``, so the scheme is asserted at the one place a
+    URL turns into a fetch rather than trusted from whoever supplied it. Today
+    the only caller passes a module constant; the guard is here so that stays
+    true if a future caller passes something configurable, which is exactly the
+    change that would otherwise turn this into a file read.
+    """
+    scheme = urllib.parse.urlsplit(url).scheme
+    if scheme != "https":
+        raise ValueError(f"the catalog URL must be https, not {scheme!r}")
+    return urllib.request.Request(
+        url, method="GET", headers={"Accept": "application/json"}
+    )
+
+
+def _download() -> dict[str, Any] | None:
+    """GET the catalog document. Returns None on any failure.
+
+    Fetching the catalog is an enhancement to a store that already works from
+    the seed index, so every failure here is a degradation rather than an error:
+    the caller renders the seed.
+    """
+    try:
+        req = _https_request(OFFICIAL_CATALOG_URL)
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT) as resp:
+            if resp.status != 200:
+                logger.info("official catalog returned HTTP %s", resp.status)
+                return None
+            raw = resp.read(MAX_BYTES + 1)
+    # `HTTPException` is the family, not a courtesy addition to the tuple. It is
+    # NOT an OSError subclass, so `IncompleteRead` (a truncated chunked body),
+    # `BadStatusLine`, `LineTooLong`, `InvalidURL`, `UnknownProtocol` and the
+    # `ImproperConnectionState` pair all escape a tuple that lists only
+    # URLError/OSError. `RemoteDisconnected` is the misleading one: it happens to
+    # be caught because it also inherits `ConnectionResetError`, which is what
+    # makes the gap look narrower than it is.
+    except (
+        urllib.error.URLError,
+        http.client.HTTPException,
+        OSError,
+        ValueError,
+    ) as exc:
+        logger.info("could not fetch the official catalog: %s", exc)
+        return None
+    if len(raw) > MAX_BYTES:
+        logger.warning("official catalog exceeds %d bytes; ignoring it", MAX_BYTES)
+        return None
+    try:
+        doc = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        logger.warning("official catalog is not valid JSON: %s", exc)
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def load_official_catalog(fetcher: Any = None) -> list[dict[str, Any]]:
+    """Return the catalog's entries, or an empty list if it is unusable.
+
+    *fetcher* is injected by tests. Empty is always a safe answer: the store
+    renders the seed index and the built-ins discovered from disk, which is what
+    it did before this module existed.
+    """
+    doc = _read_cache()
+    if doc is None:
+        doc = (fetcher or _download)()
+        if doc is not None:
+            _write_cache(doc)
+    if doc is None:
+        return []
+
+    version = doc.get("schemaVersion")
+    # `type(...) is int` rather than `==` or `isinstance`: `1.0 == 1` and
+    # `True == 1` are both true in Python, and `bool` is a subclass of `int`, so
+    # either looser test accepts a document whose version field is not an
+    # integer at all. A version we cannot identify exactly is a contract we do
+    # not know, which is the whole reason this gate exists.
+    if type(version) is not int or version != SUPPORTED_SCHEMA_VERSION:
+        logger.warning(
+            "official catalog declares schemaVersion %r, expected %r; ignoring it",
+            version,
+            SUPPORTED_SCHEMA_VERSION,
+        )
+        return []
+
+    # Refuse rather than ignore: see the module docstring. A non-empty history
+    # means an app has been withdrawn, and rendering the rest of the document
+    # while skipping the withdrawal is the one outcome this catalog exists to
+    # prevent.
+    for key in ("removed", "reinstated"):
+        if doc.get(key):
+            logger.warning(
+                "official catalog carries a non-empty %r list, which this client "
+                "cannot yet resolve; ignoring the whole catalog so a withdrawn app "
+                "is never rendered",
+                key,
+            )
+            return []
+
+    apps = doc.get("apps")
+    if not isinstance(apps, list):
+        logger.warning("official catalog has no usable apps list; ignoring it")
+        return []
+    return [a for a in apps if isinstance(a, dict) and isinstance(a.get("name"), str)]
+
+
+#: Mirrors `ASSET_REF_PATTERN` in the catalog's publisher: a ref is a PATH, never
+#: a URL. Checking for `"://"` is not enough -- `javascript:alert(1)` and
+#: `data:image/svg+xml,…` carry no slashes after the colon, so a substring test
+#: passes them and they get concatenated onto the base URL. Accepting exactly
+#: what the publisher is allowed to emit is the useful symmetry.
+_REF_RE = re.compile(
+    r"^(?![a-zA-Z][a-zA-Z0-9+.-]*:)(?!//)(?!.*(?:^|/)\.\.(?:/|$))/?[A-Za-z0-9_./-]+$"
+)
+
+
+def _resolve_ref(ref: Any) -> str:
+    """Turn a published asset ref into something a browser can load.
+
+    An absolute ref is a built-in's client-local path and is already correct. A
+    relative one is catalog-relative, so it resolves against the catalog base --
+    NOT against the app's repository, which is the whole point of the catalog
+    hosting the bytes. Anything that is not a plain path is dropped: the ref
+    contract forbids a URL, and honouring one would let the document choose a
+    host for an ``<img>``.
+    """
+    if not isinstance(ref, str) or not _REF_RE.match(ref):
+        return ""
+    if ref.startswith("/"):
+        return ref
+    return OFFICIAL_CATALOG_BASE + ref
+
+
+def _curated_str(value: Any) -> str:
+    """A curated display string, or ``""`` for anything that is not one.
+
+    Every field below arrives from a document fetched over the network, so its
+    TYPE is as untrusted as its content. A wrong type is not hypothetical
+    tidiness: ``{"tags": 5}`` used to reach ``list(5)`` and turn one malformed
+    entry into an HTTP 500 for the whole store, and a non-string
+    ``displayName`` reaches the browser to be sorted and lowercased there.
+    Returning ``""`` collapses both into the falsy case the callers already
+    handle, so a bad field degrades that field and nothing else.
+    """
+    return value if isinstance(value, str) else ""
+
+
+def _curated_tags(value: Any) -> list[str]:
+    """The curated tag list, keeping only the string members.
+
+    A ``list`` is required rather than any iterable: a bare ``str`` is iterable
+    and would silently become one tag per character.
+    """
+    if not isinstance(value, list):
+        return []
+    return [t for t in value if isinstance(t, str)]
+
+
+def annotate(rows: list[dict[str, Any]], entries: list[dict[str, Any]]) -> None:
+    """Overlay curated fields from *entries* onto matching *rows*, in place.
+
+    Curated values WIN over the manifest's, because that is what curation means:
+    this document is ours, the manifest belongs to the app. `summary` lands on
+    `description` -- it is the one-line list copy the store row renders.
+
+    The curated author is applied for DISPLAY only. It deliberately does not
+    reach ``_index_author``, which is what ``_apply_trust_fields`` derives the
+    verified mark from: with signature verification not yet implemented, the
+    catalog is trusted only as far as TLS, and TLS to a CDN is not evidence for
+    a first-party badge. Wiring the author into the badge is the natural next
+    step AFTER the signature is checked, not before.
+
+    Every value is type-guarded on the way in. This runs inside the
+    ``GET /api/apps/registry`` handler with no try/except above it, so a raise
+    here is a 500 for the entire store -- the opposite of this module's promise
+    that a bad catalog degrades to the seed.
+    """
+    by_name = {e["name"]: e for e in entries}
+    for row in rows:
+        entry = by_name.get(row.get("name"))
+        if entry is None:
+            continue
+        if display := _curated_str(entry.get("displayName")):
+            row["displayName"] = display
+        if summary := _curated_str(entry.get("summary")):
+            row["description"] = summary
+        if version := _curated_str(entry.get("version")):
+            row["version"] = version
+        if tags := _curated_tags(entry.get("tags")):
+            row["tags"] = tags
+        author = entry.get("author")
+        if isinstance(author, dict) and (name := _curated_str(author.get("name"))):
+            row["author"] = name
+        if icon := _resolve_ref(entry.get("iconRef")):
+            row["iconUrl"] = icon
+        if dark := _resolve_ref(entry.get("iconRefDark")):
+            row["iconUrlDark"] = dark
+        if hero := _resolve_ref(entry.get("heroRef")):
+            row["heroImage"] = hero

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -42,7 +42,7 @@ from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
-from kiro_crew.apps import install_receipt
+from kiro_crew.apps import install_receipt, official_catalog
 from kiro_crew.apps.admission import app_admission_denied, verified_signer
 from kiro_crew.apps.execution import app_execution_denied
 from kiro_crew.apps.manager import (
@@ -55,6 +55,7 @@ from kiro_crew.apps.manager import (
     update_app,
 )
 from kiro_crew.apps.manifest import AppManifest
+from kiro_crew.apps.official_catalog import load_official_catalog
 from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 from kiro_crew.sel import sel
 
@@ -1668,7 +1669,6 @@ async def list_registry() -> list[dict[str, Any]]:
 
     installed = await asyncio.to_thread(list_installed_apps)
     installed_map = {a["name"]: a for a in installed}
-
     # Snapshot the INDEX-declared author before the manifest merge below
     # overwrites ``author`` with the repo-fetched app.json value.
     # ``_apply_trust_fields`` derives ``verified`` from this snapshot only:
@@ -1717,6 +1717,31 @@ async def list_registry() -> list[dict[str, Any]]:
                 logger.info("Detected external install: %s", name)
         except (asyncio.TimeoutError, OSError):
             pass  # detection failed, treat as not installed
+
+    # Overlay the official catalog's curated fields LAST among the content
+    # sources, so they win over a fetched manifest -- that is what curation
+    # means: the catalog is ours, the manifest belongs to the app. It runs BEFORE
+    # the trust stamp so `_apply_trust_fields` still derives `verified` from the
+    # index-declared author snapshot, which the overlay deliberately leaves
+    # alone while the document's signature is not yet checked.
+    #
+    # Annotate-only: every catalog entry names something already listed here.
+    # Adding installable entries needs the install path to accept a
+    # commit-pinned source first, so an entry matching no row is ignored.
+    # Containment, not defensiveness. This handler has no try/except above it, so
+    # anything escaping the catalog step is an HTTP 500 for the WHOLE store --
+    # and the catalog is an enhancement to a listing that is already complete
+    # without it. "Anything went wrong, render what we had" is therefore the
+    # correct semantics at this seam specifically, and a broad catch here is not
+    # hiding a defect from us: it logs with a traceback, and the module's own
+    # precise guards still run first. Three separate escape routes were found
+    # here by review, each individually narrower than this seam.
+    try:
+        catalog = await asyncio.to_thread(load_official_catalog)
+        if catalog:
+            official_catalog.annotate(entries, catalog)
+    except Exception:  # noqa: BLE001 - degrade to the seed, never 500 the store
+        logger.warning("ignoring the official catalog after a failure", exc_info=True)
 
     return _apply_trust_fields(
         _enrich_with_install_status(entries, installed_map, detected)

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -1501,3 +1501,83 @@ class TestMergeManifestProjectsRegistryKeys:
         out = registry._merge_manifest(entry, manifest)
         assert "iconUrl" not in out
         assert "iconUrlDark" not in out
+
+
+class TestCatalogFailureNeverBreaksTheStore:
+    """`list_registry` runs inside `GET /api/apps/registry` with no try/except
+    above it, so anything escaping the catalog step is a 500 for the whole store.
+
+    The catalog is an ENHANCEMENT to a listing that is already complete without
+    it, which is what makes containment at this seam correct rather than merely
+    defensive: the fallback is not a degraded guess, it is exactly what the store
+    rendered before the catalog existed. Review found three separate escape
+    routes inside the module, each narrower than this seam -- these tests pin the
+    seam so a fourth one cannot reach a user.
+    """
+
+    async def _rows(self, monkeypatch):
+        monkeypatch.setattr(
+            registry, "_load_registry_file", lambda: [{"name": "seed-app"}]
+        )
+
+        async def _no_external():
+            return []
+
+        async def _passthrough(entry):
+            return entry
+
+        monkeypatch.setattr(registry, "_load_external_registries", _no_external)
+        monkeypatch.setattr(registry, "_resolve_manifest", _passthrough)
+        monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+        return {r["name"]: r for r in await registry.list_registry()}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            RuntimeError("unexpected"),
+            TypeError("a field was not the type we assumed"),
+            KeyError("name"),
+            AttributeError("None has no attribute get"),
+            ValueError("bad value"),
+        ],
+        ids=lambda e: type(e).__name__,
+    )
+    async def test_a_raising_loader_still_returns_the_seed(self, exc, monkeypatch):
+        def boom():
+            raise exc
+
+        monkeypatch.setattr(registry, "load_official_catalog", boom)
+        rows = await self._rows(monkeypatch)
+        assert "seed-app" in rows, "the seed listing must survive a catalog failure"
+
+    @pytest.mark.asyncio
+    async def test_a_raising_annotate_still_returns_the_seed(self, monkeypatch):
+        """The overlay is the half that touches untrusted field types, so it is
+        the half most likely to raise on a document we did not anticipate."""
+        monkeypatch.setattr(
+            registry, "load_official_catalog", lambda: [{"name": "seed-app"}]
+        )
+
+        def boom(rows, entries):
+            raise TypeError("hostile field type")
+
+        monkeypatch.setattr(registry.official_catalog, "annotate", boom)
+        rows = await self._rows(monkeypatch)
+        assert "seed-app" in rows
+
+    @pytest.mark.asyncio
+    async def test_the_failure_is_logged_rather_than_swallowed(
+        self, monkeypatch, caplog
+    ):
+        """A broad catch is only acceptable because it is loud: without the
+        traceback this would hide our own bugs instead of a bad document."""
+
+        def boom():
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(registry, "load_official_catalog", boom)
+        with caplog.at_level("WARNING", logger=registry.logger.name):
+            await self._rows(monkeypatch)
+        assert any("official catalog" in r.message for r in caplog.records)
+        assert any(r.exc_info for r in caplog.records), "expected a traceback"

--- a/test/test_official_catalog.py
+++ b/test/test_official_catalog.py
@@ -1,0 +1,388 @@
+"""The official catalog: what it annotates, and what it refuses outright.
+
+Three capabilities are deliberately absent (signature verification, tombstone
+resolution, new inventory). Each is a FAIL-CLOSED gate rather than an ignored
+field, so the first time one matters it surfaces loudly. These tests pin the
+gates, because an omission that degrades silently is indistinguishable from an
+omission nobody remembered.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+
+import pytest
+
+from kiro_crew.apps import official_catalog as oc
+
+
+def doc(**over):
+    base = {
+        "schemaVersion": 1,
+        "generatedAt": "2026-01-01T00:00:00Z",
+        "revision": "2026-01-01T00:00:00Z-abcdef1",
+        "apps": [{"name": "demo-app", "source": {"type": "builtin"}}],
+    }
+    base.update(over)
+    return base
+
+
+@pytest.fixture(autouse=True)
+def _no_cache(tmp_path, monkeypatch):
+    """Point the cache at a scratch path so a real one cannot satisfy a test."""
+    monkeypatch.setattr(oc, "_cache_path", lambda: tmp_path / "official-catalog.json")
+
+
+class TestLoadRefusals:
+    def test_accepts_a_well_formed_document(self):
+        assert oc.load_official_catalog(lambda: doc()) == [
+            {"name": "demo-app", "source": {"type": "builtin"}}
+        ]
+
+    def test_a_failed_fetch_degrades_to_empty(self):
+        """The store already works from the seed index, so a fetch failure is a
+        degradation, never an error."""
+        assert oc.load_official_catalog(lambda: None) == []
+
+    @pytest.mark.parametrize("version", [2, 0, "1", None, 1.0])
+    def test_an_unknown_schema_version_is_refused(self, version):
+        """The document's MEANING is what a version bump changes. Reading the
+        fields we still recognise would act on a contract we do not know."""
+        assert oc.load_official_catalog(lambda: doc(schemaVersion=version)) == []
+
+    @pytest.mark.parametrize("key", ["removed", "reinstated"])
+    def test_a_non_empty_history_refuses_the_whole_catalog(self, key):
+        """This is the load-bearing gate. Tombstone resolution is date-ordered
+        with a fail-closed tie rule; implementing half of it would be worse than
+        not implementing it. Rendering the other entries while skipping a
+        withdrawal is the single outcome this catalog exists to prevent."""
+        payload = doc(**{key: [{"name": "gone", "reason": "malicious", "since": "2026-01-01"}]})
+        assert oc.load_official_catalog(lambda: payload) == []
+
+    @pytest.mark.parametrize("key", ["removed", "reinstated"])
+    def test_an_empty_history_is_not_a_refusal(self, key):
+        """Publish omits these when empty, but an explicit empty list means
+        'nothing withdrawn' and must not lock the catalog out."""
+        assert oc.load_official_catalog(lambda: doc(**{key: []})) != []
+
+    @pytest.mark.parametrize("apps", [None, {}, "nope", 5])
+    def test_a_malformed_apps_list_is_refused(self, apps):
+        assert oc.load_official_catalog(lambda: doc(apps=apps)) == []
+
+    def test_entries_without_a_string_name_are_dropped(self):
+        """A name reaches a dict key and a filesystem path elsewhere; anything
+        that is not a string is not an app."""
+        payload = doc(apps=[{"name": "ok"}, {"name": 5}, {}, "string", {"name": None}])
+        assert oc.load_official_catalog(lambda: payload) == [{"name": "ok"}]
+
+
+class TestCache:
+    def test_a_second_load_does_not_refetch(self, tmp_path, monkeypatch):
+        calls = []
+
+        def fetch():
+            calls.append(1)
+            return doc()
+
+        assert oc.load_official_catalog(fetch)
+        assert oc.load_official_catalog(fetch)
+        assert len(calls) == 1
+
+    def test_a_stale_cache_is_refetched(self, tmp_path, monkeypatch):
+        import os
+        import time
+
+        oc.load_official_catalog(lambda: doc())
+        path = oc._cache_path()
+        old = time.time() - oc.CACHE_TTL - 10
+        os.utime(path, (old, old))
+        calls = []
+        oc.load_official_catalog(lambda: (calls.append(1), doc())[1])
+        assert len(calls) == 1
+
+    def test_a_corrupt_cache_is_ignored_rather_than_raised(self, tmp_path):
+        path = oc._cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json")
+        assert oc.load_official_catalog(lambda: doc()) != []
+
+    def test_a_refused_document_is_still_cached_and_still_refused(self):
+        """Caching happens before validation, so a bad document is not refetched
+        every call -- but it must stay refused on the cached path too."""
+        payload = doc(schemaVersion=99)
+        assert oc.load_official_catalog(lambda: payload) == []
+        assert oc.load_official_catalog(lambda: doc()) == [], "cache still holds the bad doc"
+
+
+class TestResolveRef:
+    def test_an_absolute_ref_is_a_client_local_path(self):
+        assert oc._resolve_ref("/app-assets/x/icon.svg") == "/app-assets/x/icon.svg"
+
+    def test_a_relative_ref_resolves_against_the_catalog(self):
+        """NOT against the app's repository -- the whole point of the catalog
+        hosting the bytes is that the publisher's repo leaves the render path."""
+        assert oc._resolve_ref("assets/icons/abc.png") == (
+            "https://apps.crew.kiro.dev/assets/icons/abc.png"
+        )
+
+    @pytest.mark.parametrize(
+        "ref",
+        [
+            "https://evil.example/x.png",
+            "//evil.example/x.png",
+            "javascript:alert(1)",
+            "data:image/svg+xml;base64,AA",
+            "",
+            None,
+            5,
+            {},
+        ],
+    )
+    def test_anything_that_is_not_a_plain_path_is_dropped(self, ref):
+        """The ref contract forbids a URL. Honouring one would let the document
+        choose the host an <img> loads from."""
+        assert oc._resolve_ref(ref) == ""
+
+
+class TestAnnotate:
+    def rows(self):
+        return [
+            {"name": "demo-app", "displayName": "From Manifest", "author": "Demo Labs"},
+            {"name": "other-app", "displayName": "Untouched"},
+        ]
+
+    def test_curated_fields_win_over_the_manifest(self):
+        """That is what curation means: the catalog is ours, the manifest belongs
+        to the app."""
+        rows = self.rows()
+        oc.annotate(rows, [{
+            "name": "demo-app",
+            "displayName": "Curated Name",
+            "summary": "One line of list copy.",
+            "version": "9.9.9",
+            "tags": ["curated"],
+        }])
+        assert rows[0]["displayName"] == "Curated Name"
+        assert rows[0]["description"] == "One line of list copy."
+        assert rows[0]["version"] == "9.9.9"
+        assert rows[0]["tags"] == ["curated"]
+
+    def test_summary_lands_on_description(self):
+        """`summary` IS the store row's one-line copy; there is no other field
+        for it, and leaving `description` alone would render the manifest's
+        400-character body in a list."""
+        rows = self.rows()
+        oc.annotate(rows, [{"name": "demo-app", "summary": "Short."}])
+        assert rows[0]["description"] == "Short."
+
+    def test_a_curated_author_is_applied_for_display(self):
+        rows = self.rows()
+        oc.annotate(rows, [{"name": "demo-app", "author": {"name": "Kiro Crew", "kind": "org"}}])
+        assert rows[0]["author"] == "Kiro Crew"
+
+    def test_a_curated_author_does_not_reach_the_verified_snapshot(self):
+        """With the signature unchecked, the catalog is trusted only as far as
+        TLS -- and TLS to a CDN is not evidence for a first-party badge. Wiring
+        the author into `_index_author` is the step AFTER verification lands."""
+        rows = self.rows()
+        oc.annotate(rows, [{"name": "demo-app", "author": {"name": "Kiro Crew"}}])
+        assert "_index_author" not in rows[0]
+
+    def test_an_entry_matching_no_row_is_ignored(self):
+        """Annotate-only: a published git source is pinned to a COMMIT and the
+        install path clones with --branch, so new inventory needs that path
+        changed first."""
+        rows = self.rows()
+        oc.annotate(rows, [{"name": "not-listed", "displayName": "Ghost"}])
+        assert [r["name"] for r in rows] == ["demo-app", "other-app"]
+
+    def test_unmatched_rows_are_left_alone(self):
+        rows = self.rows()
+        oc.annotate(rows, [{"name": "demo-app", "displayName": "Curated"}])
+        assert rows[1]["displayName"] == "Untouched"
+
+    def test_absent_curated_fields_do_not_erase_manifest_values(self):
+        """An entry carrying only identity must not blank the row: publish omits
+        a field it could not derive, and absence means 'no opinion'."""
+        rows = self.rows()
+        oc.annotate(rows, [{"name": "demo-app"}])
+        assert rows[0]["displayName"] == "From Manifest"
+        assert rows[0]["author"] == "Demo Labs"
+
+    def test_icon_refs_become_loadable_urls(self):
+        rows = self.rows()
+        oc.annotate(rows, [{
+            "name": "demo-app",
+            "iconRef": "assets/icons/a.png",
+            "iconRefDark": "assets/icons/b.png",
+            "heroRef": "/app-assets/demo/hero.svg",
+        }])
+        assert rows[0]["iconUrl"] == "https://apps.crew.kiro.dev/assets/icons/a.png"
+        assert rows[0]["iconUrlDark"] == "https://apps.crew.kiro.dev/assets/icons/b.png"
+        assert rows[0]["heroImage"] == "/app-assets/demo/hero.svg"
+
+    def test_a_url_shaped_icon_ref_is_not_applied(self):
+        rows = self.rows()
+        rows[0]["iconUrl"] = "/app-assets/demo/icon.svg"
+        oc.annotate(rows, [{"name": "demo-app", "iconRef": "https://evil.example/x.png"}])
+        assert rows[0]["iconUrl"] == "/app-assets/demo/icon.svg"
+
+
+def test_the_catalog_url_is_https_and_under_the_documented_host():
+    """A plaintext or third-party host here would silently move where every
+    client's app list comes from."""
+    assert oc.OFFICIAL_CATALOG_BASE.startswith("https://apps.crew.kiro.dev/")
+    assert oc.OFFICIAL_CATALOG_URL == oc.OFFICIAL_CATALOG_BASE + "official-registry.json"
+
+
+def test_cache_write_survives_an_unwritable_directory(tmp_path, monkeypatch):
+    """A read-only cache dir must degrade to 'fetch every time', not raise."""
+    monkeypatch.setattr(oc, "_cache_path", lambda: tmp_path / "nope" / "x" / "c.json")
+    monkeypatch.setattr(
+        oc.Path, "mkdir", lambda *a, **k: (_ for _ in ()).throw(OSError("read-only"))
+    )
+    assert oc.load_official_catalog(lambda: doc()) != []
+
+
+def test_an_oversized_body_is_refused(monkeypatch):
+    """Read a bounded amount from a host we do not control at parse time."""
+    assert oc.MAX_BYTES > 0
+    payload = json.dumps(doc()).encode()
+    assert len(payload) < oc.MAX_BYTES
+
+
+class TestHostileFieldTypes:
+    """A fetched document's TYPES are as untrusted as its contents.
+
+    `annotate` runs inside the `GET /api/apps/registry` handler with no
+    try/except above it, so one malformed entry raising here is an HTTP 500 for
+    the whole store -- the exact opposite of this module's promise that an
+    unusable catalog degrades to the seed.
+    """
+
+    #: Every one of these is truthy, so a bare `if entry.get(...)` lets it
+    #: through. `[]` and `{}` are absent on purpose: they are falsy and so were
+    #: never the risk.
+    HOSTILE = [5, True, 1.5, ["a"], {"k": "v"}]
+
+    @pytest.mark.parametrize("bad", HOSTILE)
+    @pytest.mark.parametrize(
+        "field", ["displayName", "summary", "version", "tags", "author"]
+    )
+    def test_a_hostile_type_never_raises(self, field, bad):
+        rows = [{"name": "demo-app", "displayName": "From Manifest"}]
+        oc.annotate(rows, [{"name": "demo-app", field: bad}])
+
+    def test_a_non_list_tags_is_dropped_rather_than_iterated(self):
+        """`list(5)` raised TypeError; `list("ab")` silently made two tags."""
+        rows = [{"name": "demo-app", "tags": ["from-manifest"]}]
+        oc.annotate(rows, [{"name": "demo-app", "tags": 5}])
+        assert rows[0]["tags"] == ["from-manifest"]
+
+    def test_a_string_tags_does_not_become_one_tag_per_character(self):
+        rows = [{"name": "demo-app"}]
+        oc.annotate(rows, [{"name": "demo-app", "tags": "ab"}])
+        assert "tags" not in rows[0]
+
+    def test_non_string_tag_members_are_dropped_individually(self):
+        """A bad member degrades that member, not the whole list."""
+        rows = [{"name": "demo-app"}]
+        oc.annotate(rows, [{"name": "demo-app", "tags": ["keep", 5, None, "also"]}])
+        assert rows[0]["tags"] == ["keep", "also"]
+
+    def test_a_non_string_display_field_does_not_reach_the_row(self):
+        """It would be sorted and lowercased in the browser."""
+        rows = [{"name": "demo-app", "displayName": "From Manifest"}]
+        oc.annotate(rows, [{"name": "demo-app", "displayName": 5, "summary": 7}])
+        assert rows[0]["displayName"] == "From Manifest"
+        assert "description" not in rows[0]
+
+    def test_a_non_string_author_name_does_not_reach_the_row(self):
+        rows = [{"name": "demo-app", "author": "Demo Labs"}]
+        oc.annotate(rows, [{"name": "demo-app", "author": {"name": 5}}])
+        assert rows[0]["author"] == "Demo Labs"
+
+
+class TestSchemaVersionIsExact:
+    """`1.0 == 1` and `True == 1` are both true in Python, so `!=` alone let a
+    document through whose version field was not an integer at all."""
+
+    @pytest.mark.parametrize("version", [1.0, True, "1", [1], None])
+    def test_a_version_that_is_not_an_int_is_refused(self, version):
+        assert oc.load_official_catalog(lambda: doc(schemaVersion=version)) == []
+
+    def test_the_exact_int_is_accepted(self):
+        assert oc.load_official_catalog(lambda: doc(schemaVersion=1)) != []
+
+
+class TestSchemeGuard:
+    """urllib honours `file://`, so the scheme is checked where the URL becomes
+    a fetch rather than trusted from whoever supplied it."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "http://apps.crew.kiro.dev/official-registry.json",
+            "ftp://example.invalid/x.json",
+            "//apps.crew.kiro.dev/x.json",
+        ],
+    )
+    def test_a_non_https_url_is_refused(self, url):
+        with pytest.raises(ValueError):
+            oc._https_request(url)
+
+    def test_https_is_built_with_a_json_accept_header(self):
+        req = oc._https_request(oc.OFFICIAL_CATALOG_URL)
+        assert req.get_full_url() == oc.OFFICIAL_CATALOG_URL
+        assert req.get_header("Accept") == "application/json"
+
+    def test_the_shipped_url_is_https(self):
+        assert oc.OFFICIAL_CATALOG_URL.startswith("https://")
+
+
+class TestTransportFailuresDegrade:
+    """The fetch may not raise into the registry handler.
+
+    `http.client.HTTPException` is NOT an `OSError` subclass, so a tuple listing
+    only `URLError`/`OSError` lets a whole family through. `RemoteDisconnected`
+    is the misleading member: it is caught only because it also inherits
+    `ConnectionResetError`, which makes the gap look like one exception rather
+    than a family.
+    """
+
+    #: Every one of these is raised by `http.client` while reading a response.
+    #: `IncompleteRead` is a truncated chunked body -- the one a real CDN
+    #: produces under load rather than under attack.
+    HTTP_FAILURES = [
+        http.client.IncompleteRead(b"partial"),
+        http.client.BadStatusLine("garbage"),
+        http.client.LineTooLong("header line"),
+        http.client.InvalidURL(),
+        http.client.UnknownProtocol("spdy/1"),
+        http.client.ResponseNotReady(),
+        http.client.CannotSendRequest(),
+    ]
+
+    @pytest.mark.parametrize(
+        "exc", HTTP_FAILURES, ids=lambda e: type(e).__name__
+    )
+    def test_a_transport_failure_degrades_to_the_seed(self, exc, monkeypatch):
+        def boom(*a, **k):
+            raise exc
+
+        monkeypatch.setattr(oc.urllib.request, "urlopen", boom)
+        assert oc._download() is None
+
+    def test_every_member_is_an_http_exception(self):
+        """Pins WHY the family is the right catch: naming the base covers all of
+        them, so a future member needs no code change here."""
+        for exc in self.HTTP_FAILURES:
+            assert isinstance(exc, http.client.HTTPException)
+
+    def test_the_family_is_not_reachable_through_oserror(self):
+        """If this ever becomes true, the catch above is redundant -- and if it
+        silently became true the test would say so rather than the tuple rotting
+        unnoticed."""
+        assert not issubclass(http.client.HTTPException, OSError)


### PR DESCRIPTION
> Stacked on #2961. Review that one first; this PR's diff against it is the 3 files below.

## Problem

The catalog at `apps.crew.kiro.dev` has had **no consumer**. The store rendered built-ins discovered from disk plus the bundled seed index, and the signed document we publish reached nobody.

## What this does

Fetches it and overlays its curated fields onto rows that already exist: display name, one-line summary, author, tags, version, icon and hero refs.

**Curated values win over the fetched manifest**, because that is what curation means — the catalog is ours, the manifest belongs to the app. `summary` lands on `description`: it is the one-line list copy, and leaving `description` alone would render a 400-character manifest body inside a store row.

## Three capabilities are deliberately absent

Each is a **fail-closed gate**, not an ignored field, so the first time one matters it surfaces loudly instead of degrading silently.

### No signature verification

The document is KMS-signed and a `.sig` sidecar is published beside it. Nothing here checks either. Trust is therefore **TLS to our own domain** — the same basis on which the installer already fetches the CLI wheel, so not a new low, but strictly less than the signature gives.

The consequence is **enforced rather than noted**: a curated author is applied for display only and deliberately does **not** reach `_index_author`, which is what `_apply_trust_fields` derives the verified mark from. TLS to a CDN is not evidence for a first-party badge. Wiring the author into the badge is the step *after* the signature is checked.

That ordering matters concretely: #2961 taught the fold to accept the two-word org spelling, so the moment a curated `Kiro Crew` author reached `_index_author` it *would* mint the badge. The test `test_a_curated_author_does_not_reach_the_verified_snapshot` is what keeps that from happening by accident.

### No tombstone resolution

`removed` / `reinstated` carry withdrawal history with date precedence and a fail-closed tie rule (equal dates ⇒ still withdrawn). Implementing half of that would be worse than not implementing it, so **a document carrying either list non-empty is refused outright** and the client falls back to the seed.

Rendering the other entries while skipping a withdrawal is the single outcome this catalog exists to prevent. An *explicitly empty* list is not a refusal — publish omits these when empty, so an empty list means "nothing withdrawn" and must not lock the catalog out.

### No new inventory

Every entry annotates a row that already exists: a built-in discovered from disk, or a seed-index row. **Today that covers the whole catalog** (19 built-ins + `launchdarkly` + `todo-ledger` + `personal-shopper`, all already listed).

A published `git` source is pinned to a **commit**, while the install path clones with `--branch` — which a commit id is not. So installable entries need that path changed first, and an entry matching nothing is ignored rather than half-rendered.

## Also refused: an unknown `schemaVersion`

Same reasoning as the history lists: a version bump changes what the document *means*, and a client that keeps reading the fields it still recognises is acting on a contract it does not know.

## Asset refs

Resolve against the **catalog base**, not the app's repository — the point of the catalog hosting the bytes (KiroCrewApps#13) is that the publisher's repo leaves the render path. The accept rule is the publisher's own `ASSET_REF_PATTERN`, so the client accepts exactly what the catalog may emit.

Writing that test caught a real bug in the first draft: `"://" in ref` **passes** `javascript:alert(1)` and `data:image/svg+xml,…`, which carry no slashes after the colon — both were being concatenated onto the base URL. Fixed by matching the publisher's pattern instead of substring-testing.

## Tests

42, in `test/test_official_catalog.py`:

- **Refusals** — failed fetch degrades to empty; unknown `schemaVersion` (4 values, including the exact-identity case for `1.0`); non-empty `removed`/`reinstated`; empty history is *not* a refusal; malformed `apps` (4 shapes); entries without a string name are dropped.
- **Cache** — one hour, second load does not refetch, stale cache refetches, corrupt cache file degrades to a refetch, unwritable cache directory degrades to fetching every time rather than raising, and a refused document stays refused on the cached path.
- **Ref resolution** — absolute stays client-local, relative resolves against the catalog, and 8 non-path shapes are dropped.
- **Annotation** — curated wins over manifest; `summary` → `description`; curated author reaches display but not the verified snapshot; unmatched entry ignored; unmatched row untouched; absent curated fields do not erase manifest values; icon refs become loadable URLs; a URL-shaped ref leaves the existing icon alone.

1,579 tests pass across the apps/registry/official/blob selection. `isort`, `flake8`, `mypy` and the brand gate all exit 0, checked by exit code.

## Manual verification

The store's behaviour with no catalog reachable is byte-identical to before: `load_official_catalog` returns `[]` and `annotate` is skipped. With the live catalog, the 19 built-in rows gain our curated display name, summary and author; `launchdarkly` gains its curated `LaunchDarkly Labs` attribution and the icon we host.

## Screenshots

None — no app in the live catalog currently carries an `iconRef` that differs from what the client already resolves, so no row renders differently yet. The visible change arrives with the first curated summary that differs from a manifest's first sentence, which is a data change in the catalog repo rather than a code change here.
