### PR TITLE
fix(crew-companion): accept the first mouse click on the pet overlay

### DIFF
--- a/website/electron/crew-companion/petOverlay.js
+++ b/website/electron/crew-companion/petOverlay.js
@@ -65,6 +65,24 @@ function createOverlayFor(display) {
     hasShadow: false,
     enableLargerThanScreen: true,
     show: false,
+    /*
+     * Deliver the FIRST click to the page — a constructor option, the only place
+     * this can be set.
+     *
+     * On macOS a click into an inactive window is consumed to activate it, and this
+     * overlay is `setFocusable(false)` + `showInactive()`, so it never becomes the
+     * active window: EVERY click is a first-mouse click. Without this the window
+     * accepted `mousemove` (ignore-mouse is set with `forward: true`) but never the
+     * `mousedown` behind it — so the bubble's hover-revealed ✕ appeared under the
+     * cursor and did nothing when clicked, and the notification could not be
+     * dismissed at all.
+     *
+     * It used to be attempted as `win.setAcceptFirstMouse?.(true)` after
+     * construction. No such method exists on BrowserWindow — `acceptFirstMouse` is
+     * a BaseWindow CONSTRUCTOR option only — and the optional call swallowed the
+     * miss silently, which is why it read as done for so long.
+     */
+    acceptFirstMouse: true,
     webPreferences: {
       preload: path.join(__dirname, "pet-preload.js"),
       contextIsolation: true,
@@ -76,7 +94,6 @@ function createOverlayFor(display) {
   });
 
   win.setFocusable(false);
-  win.setAcceptFirstMouse?.(true);
   // Refuse input by default; the renderer re-enables it over the sprite alone.
   win.setIgnoreMouseEvents(true, { forward: true });
   // INVISIBLE TO SCREEN CAPTURE (macOS NSWindowSharingNone, Windows

--- a/website/electron/crew-companion/test/petHitbox.test.js
+++ b/website/electron/crew-companion/test/petHitbox.test.js
@@ -31,7 +31,6 @@ function stubElectron() {
       created.push(this);
     }
     setFocusable() {}
-    setAcceptFirstMouse() {}
     setContentProtection() {}
     setIgnoreMouseEvents(ignore, opts) { this.ignoreMouse = { ignore, opts }; }
     setVisibleOnAllWorkspaces() {}

--- a/website/electron/crew-companion/test/petOverlay.test.js
+++ b/website/electron/crew-companion/test/petOverlay.test.js
@@ -30,7 +30,6 @@ function stubElectron() {
       created.push(this);
     }
     setFocusable(v) { this.focusable = v; }
-    setAcceptFirstMouse() {}
     setContentProtection(v) { this.contentProtection = v; }
     setIgnoreMouseEvents(ignore, opts) { this.ignoreMouse = { ignore, opts }; }
     setVisibleOnAllWorkspaces(v, opts) { this.workspaces = { v, opts }; }
@@ -170,6 +169,37 @@ test("the overlay is excluded from screen capture", () => {
     for (const win of stub.created) {
       assert.strictEqual(win.contentProtection, true);
     }
+  } finally {
+    stub.restore();
+  }
+});
+
+test("the overlay accepts the first mouse click, or nothing in it can be clicked", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow();
+    const win = stub.created[0];
+
+    /*
+     * A never-focusable window shown inactive never becomes active, so on macOS
+     * every click into it is a "first mouse" click. Without this option that click
+     * is spent activating the window instead of reaching the page: the bubble's ✕
+     * revealed itself on hover (mousemove is forwarded) and then did nothing.
+     *
+     * Asserted on the CONSTRUCTOR options on purpose. `acceptFirstMouse` can only
+     * be set there — the earlier `win.setAcceptFirstMouse?.(true)` called a method
+     * BrowserWindow does not have, and the optional call made the miss invisible.
+     * The fake window deliberately does not define that method, so reintroducing
+     * the call fails loudly instead of silently doing nothing.
+     */
+    assert.strictEqual(win.opts.acceptFirstMouse, true);
+    assert.strictEqual(
+      typeof win.setAcceptFirstMouse,
+      "undefined",
+      "BrowserWindow has no setAcceptFirstMouse; the fake must not invent one",
+    );
   } finally {
     stub.restore();
   }

--- a/website/electron/mochi/petOverlays.js
+++ b/website/electron/mochi/petOverlays.js
@@ -657,6 +657,13 @@ function createOverlayForDisplay(display) {
     hasShadow: false,
     enableLargerThanScreen: true,
     show: false,
+    // Deliver the FIRST click to the page. This overlay is never focusable and is
+    // shown inactive, so on macOS every click is a first-mouse click and would
+    // otherwise be eaten activating a window that can never activate — leaving the
+    // pet hoverable but unclickable. Constructor-only: there is no
+    // `setAcceptFirstMouse()` on BrowserWindow, and the optional call that used to
+    // sit below hid that fact.
+    acceptFirstMouse: true,
     webPreferences: {
       preload: path.join(__dirname, "pet-preload.js"),
       contextIsolation: true,
@@ -668,7 +675,6 @@ function createOverlayForDisplay(display) {
   });
 
   win.setFocusable(false);
-  win.setAcceptFirstMouse?.(true);
   win.setIgnoreMouseEvents(true, { forward: true });
   win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
   // INVISIBLE TO SCREEN CAPTURE (macOS NSWindowSharingNone, Windows


### PR DESCRIPTION
Closes #3016

## What is broken

The Crew Companion's notification bubble cannot be dismissed. Hovering it reveals the ✕, and clicking that ✕ does nothing — the notification stays on screen (and for a `reminder`, which never auto-dismisses, it stays forever).

## Why

The overlay window is created `setFocusable(false)` and shown with `showInactive()`, so it never becomes the active window. On macOS a click into an inactive window is consumed to activate it, which means **every** click on this overlay is a first-mouse click. `setIgnoreMouseEvents(true, { forward: true })` keeps `mousemove` flowing, so `:hover` works and the ✕ appears under the cursor — but the `mousedown` behind it never reaches the page.

`acceptFirstMouse` was already meant to be set. It was attempted after construction:

```js
win.setFocusable(false);
win.setAcceptFirstMouse?.(true);   // no such method
```

`BrowserWindow` has no `setAcceptFirstMouse()` — `acceptFirstMouse` is a `BaseWindowOptions` **constructor** option only (confirmed against the pinned `electron` typings: `acceptFirstMouse?: boolean` exists, no setter does). The optional call swallowed the miss silently, and both test doubles defined a `setAcceptFirstMouse() {}` stub, so the fake made a non-existent API look real and no test could catch it.

## The change

- Set `acceptFirstMouse: true` in the constructor options for the Crew Companion pet overlay, and drop the no-op call.
- Same fix in `electron/mochi/petOverlays.js`, which carried an identical call for an identically non-focusable, shown-inactive overlay.
- The test doubles no longer define `setAcceptFirstMouse`, so reintroducing that call fails loudly instead of doing nothing.
- New test pins the option on the constructor options and asserts the fake does not invent the method.

Renderer-side dismissal was ruled out before changing anything: the built `pet.html` served by the gateway was driven in a real browser, where the bubble's ✕ closes it and `pointer-events` computes to `auto` on both `.cc-bubble-host` and `.cc-bubble-x`. The failure is entirely in the window's input path.

## Tests

```
cd website/electron && npm ci && npm test
# 863 pass / 0 fail
```

No Python, no `website/src`, no dist changes.

