### PR TITLE
test: raise frontend coverage 84.71% -> 86.04% (+924 statements)

### DIFF
--- a/website/src/test/AppHostCoverage.test.tsx
+++ b/website/src/test/AppHostCoverage.test.tsx
@@ -1,0 +1,347 @@
+/**
+ * AppHost — the whole file, which no other suite touches.
+ *
+ * Four surfaces sit in front of the real host and each one is a different
+ * answer to "why is there no app here": no record at all, a record that is
+ * switched off, a record that ships agents but no UI, and the host itself.
+ * Behind them are the pieces a hosted app actually talks to — the permission
+ * lists handed to `AppApiProvider`, the CustomEvent bridge that stands in for a
+ * WebSocket subscription, the notify/navigate escapes, the dev-mode full-page
+ * reload, the Suspense skeleton, the bundle-load failure card and the error
+ * boundary with its retry.
+ *
+ * HARNESS. `../app-sdk` is replaced by a provider that records the props it was
+ * handed and renders its children. That is the only seam through which the four
+ * callbacks AppHost builds (`subscribeFn` / `navigateFn` / `notifyFn`) can be
+ * invoked at all: they are passed down, never called by AppHost itself, and the
+ * component that would call them is a real ESM bundle fetched over HTTP. The
+ * same stand-in doubles as the crash source for the error boundary — throwing
+ * from it is indistinguishable, from the boundary's point of view, from an app
+ * that throws on its first render.
+ *
+ * The dynamic `import('/apps/<name>/ui/<entry>')` is left REAL and left to
+ * fail: there is no `apps/` directory under the Vite root, so the import
+ * rejects, AppHost's own `.catch` turns it into the "Failed to load" card, and
+ * the console.error it logs on the way is what pins the bundle path.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, screen, fireEvent, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { renderWithProviders } from './helpers'
+import type { AppHostProps } from '../components/AppHost'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+/** Recorded `AppApiProvider` props + a one-shot render-throw switch. */
+const sdk = vi.hoisted(() => ({
+  props: null as null | Record<string, unknown>,
+  throwNext: false,
+}))
+
+vi.mock('../app-sdk', () => ({
+  AppApiProvider: (props: Record<string, unknown>) => {
+    sdk.props = props
+    if (sdk.throwNext) throw new Error('the app blew up during render')
+    return <div data-testid="sdk-provider">{props.children as ReactNode}</div>
+  },
+}))
+
+import AppHost from '../components/AppHost'
+
+type AppRecord = AppHostProps['app']
+
+interface HostedProps {
+  appName: string
+  appVersion?: string
+  allowedApiPaths: string[]
+  allowedEvents: string[]
+  subscribeFn: (event: string, cb: (data: unknown) => void) => () => void
+  navigateFn: (path: string) => void
+  notifyFn: (message: string, opts?: { type?: 'info' | 'success' | 'error' }) => void
+}
+
+/** The props AppHost handed the SDK provider on its most recent render. */
+function hosted(): HostedProps {
+  if (!sdk.props) throw new Error('AppApiProvider was never rendered')
+  return sdk.props as unknown as HostedProps
+}
+
+/**
+ * A third-party app id on purpose: `ledger-lens` is absent from
+ * `APP_MANIFEST_KEY`, so `appDisplayName` / `appDescription` fall through to
+ * the fixture's own strings instead of a localised first-party catalog entry.
+ */
+const NAME = 'ledger-lens'
+
+function appRecord(over: Partial<AppRecord> = {}): AppRecord {
+  return {
+    name: NAME,
+    displayName: 'Ledger Lens',
+    version: '0.9.0',
+    enabled: true,
+    manifest: {
+      version: '1.2.3',
+      description: 'Reads your books and explains them.',
+      ui: { entry: 'index.js' },
+      permissions: { api: ['/api/apps'], events: ['ledger:updated'] },
+    },
+    ...over,
+  }
+}
+
+function renderHost(app: AppRecord) {
+  return renderWithProviders(<AppHost app={app} />)
+}
+
+/** Let React.lazy settle: the import rejects, then the catch's module renders. */
+async function settleBundle() {
+  await waitFor(() => expect(screen.getByRole('heading', { level: 3 })).toBeTruthy())
+}
+
+let reloadSpy: ReturnType<typeof vi.fn>
+let errorSpy: ReturnType<typeof vi.spyOn>
+const origReload = window.location.reload
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  mockNavigate.mockClear()
+  sdk.props = null
+  sdk.throwNext = false
+  reloadSpy = vi.fn()
+  Object.defineProperty(window.location, 'reload', { configurable: true, value: reloadSpy })
+  // AppHost logs bundle-load failures and the boundary logs app crashes; both
+  // are intentional diagnostics, and one of them is an assertion target below.
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  errorSpy.mockRestore()
+  Object.defineProperty(window.location, 'reload', { configurable: true, value: origReload })
+})
+
+describe('AppHost — guard surfaces', () => {
+  it('offers a way back to Apps when there is no app record at all', () => {
+    renderHost(undefined as unknown as AppRecord)
+
+    expect(screen.getByTestId('page-title').textContent).toBe('App Not Found')
+    expect(screen.getByTestId('page-subtitle').textContent).toBe('"unknown" is not installed')
+    expect(screen.getByText('Install it from Apps or via CLI')).toBeTruthy()
+    expect(screen.queryByTestId('sdk-provider')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /apps/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/apps')
+  })
+
+  it('explains a disabled app instead of loading its bundle', () => {
+    renderHost(appRecord({ enabled: false }))
+
+    expect(screen.getByTestId('page-title').textContent).toBe('Ledger Lens')
+    expect(screen.getByTestId('page-subtitle').textContent).toBe('This app is disabled')
+    expect(screen.getByText('Enable this app from Apps to use it.')).toBeTruthy()
+    expect(screen.queryByTestId('sdk-provider')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /apps/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/apps')
+  })
+
+  it('treats a missing ui.entry as an agent-only app, not an error', () => {
+    renderHost(appRecord({
+      manifest: { version: '1.2.3', description: 'Reads your books and explains them.' },
+    }))
+
+    expect(screen.getByTestId('page-title').textContent).toBe('Ledger Lens')
+    expect(screen.getByTestId('page-subtitle').textContent).toBe('Reads your books and explains them.')
+    expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('Agent-only app')
+    expect(screen.queryByTestId('sdk-provider')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /apps/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/apps')
+  })
+
+  it('falls through to the agent-only surface when the manifest itself is absent', () => {
+    renderHost({ name: NAME, enabled: true })
+
+    // No manifest means no localised copy and no description: the id is all
+    // there is, and `appDescription` yields an empty string, which PageHeader
+    // then omits rather than rendering a blank subtitle row.
+    expect(screen.getByTestId('page-title').textContent).toBe(NAME)
+    expect(screen.queryByTestId('page-subtitle')).toBeNull()
+  })
+})
+
+describe('AppHost — hosting a real bundle', () => {
+  it('shows a named loading skeleton while the bundle is in flight', async () => {
+    renderHost(appRecord())
+
+    const line = screen.getByText(
+      (_content, el) => el?.tagName === 'P' && (el.textContent ?? '').startsWith('Loading'),
+    )
+    expect(line.textContent).toContain('Ledger Lens')
+
+    await settleBundle()
+  })
+
+  it('renders a failure card, naming the bundle path, when the import rejects', async () => {
+    renderHost(appRecord())
+    await settleBundle()
+
+    expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('Failed to load Ledger Lens')
+    // No PageHeader on this card — it replaces the app, not the whole page.
+    expect(screen.queryByTestId('page-title')).toBeNull()
+
+    const logged = errorSpy.mock.calls.map(c => String(c[0])).join('\n')
+    expect(logged).toContain(`[AppHost] Failed to load ${NAME} from /apps/${NAME}/ui/index.js:`)
+
+    fireEvent.click(screen.getByRole('button', { name: /apps/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/apps')
+  })
+
+  it('passes the manifest permission lists through to the SDK provider', async () => {
+    renderHost(appRecord())
+    await settleBundle()
+
+    expect(hosted().appName).toBe(NAME)
+    expect(hosted().allowedApiPaths).toEqual(['/api/apps'])
+    expect(hosted().allowedEvents).toEqual(['ledger:updated'])
+  })
+
+  it('scopes an app that declares no permissions to nothing at all', async () => {
+    renderHost(appRecord({
+      manifest: { version: '1.2.3', ui: { entry: 'index.js' } },
+    }))
+    await settleBundle()
+
+    expect(hosted().allowedApiPaths).toEqual([])
+    expect(hosted().allowedEvents).toEqual([])
+  })
+
+  it('prefers the manifest version and falls back to the installed record', async () => {
+    const { unmount } = renderHost(appRecord())
+    await settleBundle()
+    expect(hosted().appVersion).toBe('1.2.3')
+    unmount()
+
+    renderHost(appRecord({ manifest: { ui: { entry: 'index.js' } } }))
+    await settleBundle()
+    expect(hosted().appVersion).toBe('0.9.0')
+  })
+})
+
+describe('AppHost — the bridges handed to a hosted app', () => {
+  it('bridges host CustomEvents into an app subscription and unsubscribes on demand', async () => {
+    renderHost(appRecord())
+    await settleBundle()
+
+    const cb = vi.fn()
+    const off = hosted().subscribeFn('ledger:updated', cb)
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mc:app:ledger:updated', { detail: { total: 42 } }))
+    })
+    expect(cb).toHaveBeenCalledWith({ total: 42 })
+
+    off()
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mc:app:ledger:updated', { detail: { total: 43 } }))
+    })
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes an app navigation request through the host router', async () => {
+    renderHost(appRecord())
+    await settleBundle()
+
+    hosted().navigateFn('/apps/ledger-lens')
+    expect(mockNavigate).toHaveBeenCalledWith('/apps/ledger-lens')
+  })
+
+  it('turns an app notification into an mc:notify event, with and without a type', async () => {
+    renderHost(appRecord())
+    await settleBundle()
+
+    const seen: unknown[] = []
+    const listener = (e: Event) => seen.push((e as CustomEvent).detail)
+    window.addEventListener('mc:notify', listener)
+    try {
+      hosted().notifyFn('books balanced', { type: 'success' })
+      hosted().notifyFn('just so you know')
+    } finally {
+      window.removeEventListener('mc:notify', listener)
+    }
+
+    expect(seen).toEqual([
+      { message: 'books balanced', type: 'success' },
+      { message: 'just so you know' },
+    ])
+  })
+})
+
+describe('AppHost — dev-mode live reload', () => {
+  it('reloads only for its own app, and only while mounted', async () => {
+    const { unmount } = renderHost(appRecord())
+    await settleBundle()
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mc:app-reload', { detail: { app: 'other-app' } }))
+    })
+    expect(reloadSpy).not.toHaveBeenCalled()
+
+    // No detail at all — the broadcast shape a stray dispatcher would send.
+    act(() => { window.dispatchEvent(new CustomEvent('mc:app-reload')) })
+    expect(reloadSpy).not.toHaveBeenCalled()
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mc:app-reload', { detail: { app: NAME } }))
+    })
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+
+    unmount()
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mc:app-reload', { detail: { app: NAME } }))
+    })
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('AppHost — error boundary', () => {
+  it('catches an app crash, reports it, and remounts the app on retry', async () => {
+    sdk.throwNext = true
+    renderHost(appRecord())
+
+    expect(screen.getByTestId('page-title').textContent).toBe(NAME)
+    expect(screen.getByTestId('page-subtitle').textContent).toBe('App crashed')
+    expect(screen.getByRole('heading', { level: 3 }).textContent).toBe(`${NAME} encountered an error`)
+    expect(screen.getByText('the app blew up during render')).toBeTruthy()
+
+    const crashLog = errorSpy.mock.calls.map(c => String(c[0])).join('\n')
+    expect(crashLog).toContain(`[AppHost] ${NAME} crashed:`)
+
+    // Retry clears the boundary AND bumps the reset key, so the app is given a
+    // genuinely fresh lazy import rather than the cached rejected one.
+    sdk.throwNext = false
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+
+    await settleBundle()
+    expect(screen.queryByTestId('page-subtitle')).toBeNull()
+    expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('Failed to load Ledger Lens')
+  })
+
+  it('offers Apps as the other way out of a crashed app', async () => {
+    sdk.throwNext = true
+    renderHost(appRecord())
+
+    fireEvent.click(screen.getByRole('button', { name: /apps/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/apps')
+
+    // The crash fallback stays put: navigation is the host's business, and the
+    // boundary has nothing to re-render into.
+    expect(screen.getByTestId('page-subtitle').textContent).toBe('App crashed')
+    await act(async () => { await Promise.resolve() })
+  })
+})

--- a/website/src/test/ChatPageMoreCoverage.test.tsx
+++ b/website/src/test/ChatPageMoreCoverage.test.tsx
@@ -1,0 +1,665 @@
+/**
+ * Coverage-directed tests for the ChatPage handlers that are only reachable
+ * through a transcript row's own affordances or through a window event — the two
+ * entry points none of the ~35 existing ChatPage suites drive.
+ *
+ * Three cold areas, all through a real `render(<ChatPage />)`:
+ *
+ *  1. The row callbacks ChatPage hands to AssistantMessage: `handleFork` (all
+ *     three outcomes plus the cold-config refetch), `handlePlanFromHere`,
+ *     `handleQuote`, `handleAsk`, `handleRegenerate` (including the snapshot
+ *     rollback on a failed request), `handleSpeak` (both voice states) and
+ *     `handleApplyPlan`'s failure path. AssistantMessage is stubbed as a prop
+ *     recorder so the callbacks can be invoked directly — the card's own
+ *     rendering is covered by AssistantMessage.test.tsx.
+ *
+ *  2. The window-event listeners: `mc-config-changed` (chat-settings reload),
+ *     `toggle-pin-chat-sidebar`, and `mc:run-in-terminal` (both the non-string
+ *     guard and the PTY-never-connects timeout that reports failure back to the
+ *     code block).
+ *
+ *  3. The welcome-state "Continue a previous chat?" suggestion list and
+ *     `handleResumeSession`, reached by pre-filling the composer through the
+ *     widget bridge and letting the 300 ms history-query debounce fire.
+ *
+ * happy-dom has no layout, so the virtualizer is stubbed to mount every item
+ * (the technique ChatPageCoverage.test.tsx uses). Nothing else about the page is
+ * faked: grouping, the render dispatch and the handlers run for real.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, waitFor, fireEvent, within } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import { store as appStore } from '../store'
+import { setVoicePlaying } from '../store/chatSlice'
+import type { RootState } from '../store'
+import type { ChatMessage } from '../types'
+
+// --- Prop recorders ---------------------------------------------------------
+
+interface AssistantProps {
+  content: string
+  timestamp?: string
+  onFork?: (visibleIndex: number) => void | Promise<void>
+  onPlanFromHere?: (visibleIndex: number) => void | Promise<void>
+  onQuote?: (text: string, rect: DOMRect) => void
+  onAsk?: (text: string) => void
+  onSpeak?: (content: string) => void
+  onRegenerate?: () => void
+  onApplyPlan?: (steps: never[]) => Promise<boolean>
+  forkIndex?: number
+}
+let assistantProps: AssistantProps | null = null
+
+interface InputProps { value: string; onChange: (v: string) => void }
+let inputProps: InputProps | null = null
+
+vi.mock('../pages/chat', async () => {
+  const React = await import('react')
+  return {
+    ChatFooter: () => null,
+    McpInfoButton: () => null,
+    PinnedPrompt: () => null,
+    UserMessage: ({ content }: { content: string }) =>
+      React.createElement('div', { 'data-testid': 'user-msg' }, content),
+    AssistantMessage: (props: AssistantProps) => {
+      assistantProps = props
+      return React.createElement('div', { 'data-testid': 'assistant-msg' }, props.content)
+    },
+  }
+})
+
+// A minimal controlled composer. The real one is covered by ChatInput's own
+// suite, but its textarea has to EXIST because `handleQuote` and the widget
+// bridge look it up by aria-label to reveal the pre-filled text. The module's
+// named exports are kept: `effortLabel` is imported from here by the model and
+// reasoning-effort dropdowns that ChatPage also renders.
+vi.mock('../components/ChatInput', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/ChatInput')>()
+  const React = await import('react')
+  return {
+    ...actual,
+    default: (props: InputProps) => {
+      inputProps = props
+      return React.createElement('textarea', {
+        'aria-label': 'Message input',
+        value: props.value,
+        onChange: (e: { target: { value: string } }) => props.onChange(e.target.value),
+      })
+    },
+  }
+})
+
+vi.mock('../components/FlyingQuote', async () => {
+  const React = await import('react')
+  return { default: () => React.createElement('div', { 'data-testid': 'flying-quote' }) }
+})
+
+interface ProjectPickerProps { onSelect: (path: string) => void }
+let projectPickerProps: ProjectPickerProps | null = null
+vi.mock('../components/ProjectPicker', () => ({
+  default: (props: ProjectPickerProps) => { projectPickerProps = props; return null },
+}))
+
+// --- Child components stubbed to keep the render tree small ------------------
+vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../components/DiffPanel', () => ({ default: () => null }))
+vi.mock('../components/MarkdownRenderer', () => ({
+  default: ({ content }: { content?: string }) => content ?? null,
+}))
+vi.mock('../components/TypewriterText', () => ({ default: () => null }))
+vi.mock('../components/OverlayDrawer', () => ({ default: ({ children }: { children?: ReactNode }) => children }))
+vi.mock('../components/AgentDropdownList', () => ({ default: () => null, ManageAgentsFooter: () => null }))
+vi.mock('../components/ModelDropdownList', () => ({ default: () => null }))
+vi.mock('../components/InfoTip', () => ({ default: () => null }))
+vi.mock('../components/SegmentedControl', () => ({ default: () => null }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../pages/ChatSidebar', () => ({ default: () => null, SIDEBAR_MIN: 200, SIDEBAR_MAX: 500 }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../pages/chat/SessionColorPicker', () => ({ default: () => null }))
+
+// Mutable so the `mc-config-changed` test can flip a setting and prove the
+// listener re-reads it (the reload is dedupe-guarded on a JSON compare, so the
+// value has to actually change).
+let chatSettings: Record<string, unknown> = { contentWidth: 'compact' }
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ ...chatSettings }),
+  CONTENT_WIDTH: {
+    compact: { messages: '900px', input: '916px' },
+    comfortable: { messages: '84%', input: '85%' },
+    full: { messages: '92%', input: '93%' },
+  },
+}))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: null }) }))
+vi.mock('../hooks/useFilteredDropdown', () => ({
+  useFilteredDropdown: () => ({
+    filtered: [], query: '', setQuery: vi.fn(),
+    selectedIndex: 0, setSelectedIndex: vi.fn(), onKeyDown: vi.fn(),
+  }),
+}))
+vi.mock('../hooks/useVoiceInput', () => ({
+  useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }),
+  voiceInputSupported: false,
+}))
+
+// Mounts every display item so ChatPage's own row renderer runs for real.
+vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
+  useVirtualChat: (opts: { items?: unknown[]; getKey?: (it: unknown, i: number) => string }) => {
+    const items = opts.items ?? []
+    return {
+      virtualItems: items.map((data, index) => ({
+        key: opts.getKey ? opts.getKey(data, index) : String(index),
+        index,
+        mounted: true,
+        data,
+      })),
+      isAtBottom: true,
+      scrollToBottom: vi.fn(),
+      scrollToIndexSmooth: vi.fn(),
+      mountIndex: vi.fn(() => false),
+      measureRef: () => () => {},
+      topSentinelRef: { current: null },
+      bottomSentinelRef: { current: null },
+      offsetBefore: 0,
+      offsetAfter: 0,
+      totalHeight: 0,
+    }
+  },
+}))
+
+vi.mock('../api/pins', () => ({
+  PIN_PREVIEW_INPUT_MAX_CHARS: 4096,
+  pinsApi: {
+    list: vi.fn().mockResolvedValue({ pins: [] }),
+    create: vi.fn().mockResolvedValue({}),
+    remove: vi.fn().mockResolvedValue({ ok: true }),
+  },
+}))
+
+const apiMocks: Record<string, ReturnType<typeof vi.fn>> = {}
+/** Seed (or fetch) the mock for one api method so a test can assert it was
+ *  never called — reading it off `apiMocks` lazily would report `undefined`. */
+const apiSpy = (name: string) => {
+  if (!(name in apiMocks)) apiMocks[name] = vi.fn().mockResolvedValue({})
+  return apiMocks[name]
+}
+vi.mock('../api/client', () => ({
+  api: new Proxy({}, {
+    get: (_t, prop: string) => {
+      if (!(prop in apiMocks)) {
+        apiMocks[prop] = vi.fn().mockResolvedValue(
+          prop === 'chatSlotDetail' ? { messages: [], has_more: false, total: 0 } : {},
+        )
+      }
+      return apiMocks[prop]
+    },
+  }),
+  fileReadUrl: (p: string) => `/api/file?path=${encodeURIComponent(p)}`,
+  SEARCH_MIN_CHARS: 2,
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({
+  ok: true, status: 200, text: () => Promise.resolve(''), json: () => Promise.resolve({}),
+}) as never
+
+import ChatPage from '../pages/ChatPage'
+
+// --- Fixtures ---------------------------------------------------------------
+
+const SLOT = {
+  key: 'chat-1', title: 'chat-1', messages: 0, running: false,
+  mode: '', created: '', last_ts: '',
+}
+
+interface HistorySession { key: string; title: string; created: string; messages: number }
+
+const msg = (role: string, content: string, extra: Partial<ChatMessage> = {}): ChatMessage => ({
+  role, content, cls: '', ...extra,
+})
+
+interface RenderOpts {
+  /** Extra preloaded `chat` slice fields, merged over the reducer's own initial state. */
+  chat?: Record<string, unknown>
+  /** Past sessions `api.sessions` yields — ChatPage fetches them on mount, so a
+   *  preloaded `chat.history` would be overwritten before the first paint. */
+  sessions?: HistorySession[]
+}
+
+function renderChatPage(messages: ChatMessage[], opts: RenderOpts = {}) {
+  const { chat = {}, sessions = [] } = opts
+  apiMocks.chatSlots = vi.fn().mockResolvedValue([SLOT])
+  apiMocks.chatSlotDetail = vi.fn().mockResolvedValue({
+    messages, has_more: false, total: messages.length,
+  })
+  apiMocks.sessions = vi.fn().mockResolvedValue({ sessions, has_more: false })
+  // Spread the reducers' own initial state: RTK's preloadedState REPLACES a
+  // slice rather than merging, so a hand-rolled literal drops keys the reducers
+  // then mutate blindly (`activityTabRequest += 1` on an absent key).
+  const base = createTestStore().getState()
+  const store = createTestStore({
+    dashboard: {
+      ...base.dashboard,
+      status: { platform: 'darwin' } as unknown as RootState['dashboard']['status'],
+      connected: true,
+      slots: [SLOT] as unknown as RootState['dashboard']['slots'],
+    },
+    chat: {
+      ...base.chat,
+      activeSlot: 'chat-1',
+      ...chat,
+    } as unknown as RootState['chat'],
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/chat/chat-1']}>
+            <Routes>
+              <Route path="/chat/:slug?" element={<ChatPage mode="" />} />
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  if (messages.length) {
+    act(() => { store.dispatch({ type: 'chat/replaceMessages', payload: messages }) })
+  }
+  return { store }
+}
+
+/** Renders one user + one assistant row and waits for the card to mount. */
+async function renderTurn(opts: RenderOpts = {}) {
+  const out = renderChatPage([
+    msg('user', 'what changed?', { ts: '2026-08-12T07:00:00Z' }),
+    msg('assistant', 'two files changed', { ts: '2026-08-12T07:00:05Z' }),
+  ], opts)
+  await waitFor(() => expect(assistantProps).not.toBeNull())
+  return out
+}
+
+const makeAlertSpy = () => vi.spyOn(window, 'alert').mockImplementation(() => {})
+let alertSpy: ReturnType<typeof makeAlertSpy>
+
+beforeEach(() => {
+  assistantProps = null
+  inputProps = null
+  projectPickerProps = null
+  chatSettings = { contentWidth: 'compact' }
+  localStorage.clear()
+  sessionStorage.clear()
+  for (const k of Object.keys(apiMocks)) delete apiMocks[k]
+  alertSpy = makeAlertSpy()
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  alertSpy.mockRestore()
+})
+
+describe('ChatPage row callbacks — fork', () => {
+  it('forks at the row index with the head direction when the config is warm', async () => {
+    apiSpy('dashboardConfig').mockResolvedValue({ tail_fork_enabled: false })
+    apiSpy('forkChatSlot').mockResolvedValue({ ok: true, key: 'chat-2', title: 'fork' })
+    await renderTurn()
+    await act(async () => { await assistantProps!.onFork!(1) })
+    await waitFor(() => expect(apiMocks.forkChatSlot).toHaveBeenCalled())
+    expect(apiMocks.forkChatSlot).toHaveBeenCalledWith('chat-1', 1, undefined, undefined, 'head')
+    expect(alertSpy).not.toHaveBeenCalled()
+  })
+
+  it('re-reads the config when the query never produced one, so a tail fork stays a tail fork', async () => {
+    // The dashboardConfig query fails, so `forkCfg` is undefined at click time —
+    // the branch that must fetch rather than silently downgrade to a head fork.
+    apiSpy('dashboardConfig')
+      .mockRejectedValueOnce(new Error('config unavailable'))
+      .mockResolvedValue({ tail_fork_enabled: true })
+    apiSpy('forkChatSlot').mockResolvedValue({ ok: true, key: 'chat-2' })
+    await renderTurn()
+    await act(async () => { await assistantProps!.onFork!(3) })
+    await waitFor(() => expect(apiMocks.forkChatSlot).toHaveBeenCalled())
+    expect(apiMocks.forkChatSlot).toHaveBeenCalledWith('chat-1', 3, undefined, undefined, 'tail')
+  })
+
+  it('reports a refused fork through an alert instead of switching sessions', async () => {
+    apiSpy('forkChatSlot').mockResolvedValue({ ok: false, error: 'slot is busy' })
+    await renderTurn()
+    await act(async () => { await assistantProps!.onFork!(1) })
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled())
+    expect(String(alertSpy.mock.calls[0][0])).toContain('slot is busy')
+  })
+
+  it('still alerts when the fork request throws', async () => {
+    apiSpy('forkChatSlot').mockRejectedValue(new Error('network down'))
+    await renderTurn()
+    await act(async () => { await assistantProps!.onFork!(1) })
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled())
+    const said = String(alertSpy.mock.calls[0][0])
+    expect(said).toContain('Fork failed')
+    // Pinned deliberately: `unwrap()` rejects with a redux-toolkit
+    // SerializedError (a PLAIN OBJECT), so the handler's `e instanceof Error`
+    // test is false and the fallback `String(e)` renders '[object Object]' —
+    // the reason is lost from the alert. Reported, not fixed here; when the
+    // handler learns to read `.message` off a serialized error this assertion
+    // is the one that should flip to the real text.
+    expect(said).toContain('[object Object]')
+    expect(said).not.toContain('network down')
+  })
+})
+
+describe('ChatPage row callbacks — plan from here', () => {
+  it('forks into an orchestrator session without a direction', async () => {
+    apiSpy('forkChatSlot').mockResolvedValue({ ok: true, key: 'chat-2' })
+    await renderTurn()
+    await act(async () => { await assistantProps!.onPlanFromHere!(2) })
+    await waitFor(() => expect(apiMocks.forkChatSlot).toHaveBeenCalled())
+    expect(apiMocks.forkChatSlot).toHaveBeenCalledWith('chat-1', 2, undefined, 'orchestrator', undefined)
+    expect(alertSpy).not.toHaveBeenCalled()
+  })
+
+  it('reports a refused plan-from-here with its own message, not the fork one', async () => {
+    apiSpy('forkChatSlot').mockResolvedValue({ ok: false, error: 'no orchestrator agent' })
+    await renderTurn()
+    await act(async () => { await assistantProps!.onPlanFromHere!(2) })
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled())
+    const said = String(alertSpy.mock.calls[0][0])
+    expect(said).toContain('no orchestrator agent')
+    expect(said).not.toContain('Fork failed')
+  })
+
+  it('surfaces a failed plan apply and resolves false', async () => {
+    apiSpy('planFromChat').mockResolvedValue({ ok: false })
+    await renderTurn()
+    let applied: boolean | undefined
+    await act(async () => { applied = await assistantProps!.onApplyPlan!([]) })
+    expect(applied).toBe(false)
+    expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to apply plan'))
+  })
+
+  it('resolves true and leaves the page quiet when the plan is accepted', async () => {
+    apiSpy('planFromChat').mockResolvedValue({ ok: true, task_id: 'task-9' })
+    await renderTurn()
+    let applied: boolean | undefined
+    await act(async () => { applied = await assistantProps!.onApplyPlan!([]) })
+    expect(applied).toBe(true)
+    expect(apiMocks.planFromChat).toHaveBeenCalled()
+    expect(alertSpy).not.toHaveBeenCalled()
+  })
+
+  it('treats a thrown plan apply the same as a refusal', async () => {
+    apiSpy('planFromChat').mockRejectedValue(new Error('projects service down'))
+    await renderTurn()
+    let applied: boolean | undefined
+    await act(async () => { applied = await assistantProps!.onApplyPlan!([]) })
+    expect(applied).toBe(false)
+    expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to apply plan'))
+  })
+})
+
+describe('ChatPage row callbacks — quote and ask', () => {
+  it('quotes the selection into the composer and shows the transit animation', async () => {
+    await renderTurn()
+    const rect = { top: 10, left: 20, width: 5, height: 5 } as DOMRect
+    act(() => { assistantProps!.onQuote!('first line\nsecond line', rect) })
+    await waitFor(() => expect(inputProps!.value).toContain('> first line'))
+    expect(inputProps!.value).toContain('> second line')
+    expect(screen.getByTestId('flying-quote')).toBeInTheDocument()
+  })
+
+  it('appends a second quote below the first rather than replacing it', async () => {
+    await renderTurn()
+    const rect = { top: 0, left: 0, width: 1, height: 1 } as DOMRect
+    act(() => { assistantProps!.onQuote!('alpha', rect) })
+    await waitFor(() => expect(inputProps!.value).toContain('> alpha'))
+    act(() => { assistantProps!.onQuote!('beta', rect) })
+    await waitFor(() => expect(inputProps!.value).toContain('> beta'))
+    expect(inputProps!.value).toContain('> alpha')
+  })
+
+  it('routes Ask to the side panel and seeds it, leaving the main composer untouched', async () => {
+    const { store } = await renderTurn()
+    const seeds: (string | undefined)[] = []
+    const onSeed = (e: Event) => { seeds.push((e as CustomEvent).detail?.text) }
+    window.addEventListener('side-seed', onSeed)
+    try {
+      act(() => { assistantProps!.onAsk!('why is this slow?') })
+      await waitFor(() => expect(seeds).toContain('why is this slow?'))
+    } finally {
+      window.removeEventListener('side-seed', onSeed)
+    }
+    expect(store.getState().chat.activityTab).toBe('side')
+    expect(store.getState().chat.activityOpen).toBe(true)
+    expect(inputProps!.value).toBe('')
+  })
+})
+
+describe('ChatPage row callbacks — regenerate and speak', () => {
+  it('truncates back to the last user row and asks the server to regenerate', async () => {
+    apiSpy('regenerateSlot').mockResolvedValue({ ok: true })
+    const { store } = await renderTurn()
+    expect(assistantProps!.onRegenerate).toBeTypeOf('function')
+    await act(async () => { assistantProps!.onRegenerate!() })
+    await waitFor(() => expect(apiMocks.regenerateSlot).toHaveBeenCalledWith('chat-1'))
+    expect(store.getState().chat.messages).toHaveLength(1)
+    expect(store.getState().chat.messages[0].role).toBe('user')
+  })
+
+  it('restores the transcript when the regenerate request fails', async () => {
+    apiSpy('regenerateSlot').mockRejectedValue(new Error('runner busy'))
+    const { store } = await renderTurn()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      await act(async () => { assistantProps!.onRegenerate!() })
+      await waitFor(() => expect(store.getState().chat.messages).toHaveLength(2))
+    } finally {
+      warn.mockRestore()
+    }
+    expect(store.getState().chat.messages[1].role).toBe('assistant')
+  })
+
+  it('synthesizes speech for the row content when nothing is playing', async () => {
+    apiSpy('voiceSynthesize').mockResolvedValue({})
+    await renderTurn()
+    act(() => { assistantProps!.onSpeak!('two files changed') })
+    await waitFor(() => expect(apiMocks.voiceSynthesize).toHaveBeenCalledWith('chat-1', 'two files changed'))
+  })
+
+  it('stops playback instead of synthesizing again while a clip is playing', async () => {
+    const synth = apiSpy('voiceSynthesize')
+    await renderTurn()
+    // The handler reads `voicePlaying` off the app-wide store singleton (so the
+    // callback identity stays stable while a turn streams), not off the store
+    // this test renders with — so the flag has to be set there.
+    act(() => { appStore.dispatch(setVoicePlaying(true)) })
+    let stopped = 0
+    const onStop = () => { stopped += 1 }
+    window.addEventListener('voice-stop', onStop)
+    try {
+      act(() => { assistantProps!.onSpeak!('two files changed') })
+      await waitFor(() => expect(stopped).toBe(1))
+    } finally {
+      window.removeEventListener('voice-stop', onStop)
+      act(() => { appStore.dispatch(setVoicePlaying(false)) })
+    }
+    expect(synth).not.toHaveBeenCalled()
+  })
+})
+
+describe('ChatPage window-event listeners', () => {
+  it('re-reads the chat settings when a config change is broadcast', async () => {
+    await renderTurn()
+    expect(assistantProps!.timestamp).toBeUndefined()
+    chatSettings = { contentWidth: 'compact', showTimestamps: true }
+    act(() => { window.dispatchEvent(new Event('mc-config-changed')) })
+    await waitFor(() => expect(assistantProps!.timestamp).toBeTruthy())
+  })
+
+  it('toggles the sidebar pin and persists it', async () => {
+    await renderTurn()
+    expect(localStorage.getItem('mc-sidebar-pinned')).toBeNull()
+    act(() => { window.dispatchEvent(new Event('toggle-pin-chat-sidebar')) })
+    await waitFor(() => expect(localStorage.getItem('mc-sidebar-pinned')).not.toBeNull())
+    const first = localStorage.getItem('mc-sidebar-pinned')
+    act(() => { window.dispatchEvent(new Event('toggle-pin-chat-sidebar')) })
+    await waitFor(() => expect(localStorage.getItem('mc-sidebar-pinned')).not.toBe(first))
+  })
+
+  it('ignores a run-in-terminal request that carries no command', async () => {
+    const { store } = await renderTurn()
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mc:run-in-terminal', { detail: { reqId: 'r1' } }))
+    })
+    expect(store.getState().chat.activityOpen).toBe(false)
+  })
+
+  it('ignores a run-in-terminal request whose command is an empty string', async () => {
+    const { store } = await renderTurn()
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mc:run-in-terminal', { detail: { code: '', reqId: 'r3' } }))
+    })
+    expect(store.getState().chat.activityOpen).toBe(false)
+  })
+
+  it('answers a run-in-terminal request exactly once, carrying its reqId back', async () => {
+    const { store } = await renderTurn()
+    const results: { reqId?: string; ok?: boolean }[] = []
+    const onResult = (e: Event) => { results.push((e as CustomEvent).detail) }
+    window.addEventListener('mc:run-in-terminal-result', onResult)
+    try {
+      act(() => {
+        window.dispatchEvent(new CustomEvent('mc:run-in-terminal', {
+          detail: { code: 'npm test', reqId: 'r2' },
+        }))
+      })
+      // The handler opens the panel synchronously, then races the PTY against a
+      // ~6 s cap. Either leg answers; the `settled` latch is what guarantees the
+      // code-block button is told once and only once.
+      expect(store.getState().chat.activityOpen).toBe(true)
+      await act(async () => { await vi.advanceTimersByTimeAsync(7_000) })
+      await waitFor(() => expect(results.length).toBe(1), { timeout: 5_000 })
+    } finally {
+      window.removeEventListener('mc:run-in-terminal-result', onResult)
+    }
+    expect(results[0].reqId).toBe('r2')
+    expect(typeof results[0].ok).toBe('boolean')
+  })
+})
+
+describe('ChatPage welcome-state history suggestions', () => {
+  const HISTORY: HistorySession[] = [
+    { key: 'sess-a', title: 'rate limiter rollout', created: '2026-08-01T10:00:00Z', messages: 4 },
+    { key: 'sess-b', title: 'unrelated design doc', created: '2026-08-02T10:00:00Z', messages: 2 },
+  ]
+
+  /** Pre-fills the composer through the widget bridge, then lets the 300 ms
+   *  history-query debounce fire. */
+  async function typeQuery(text: string) {
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mc-widget-send', { detail: { text } }))
+    })
+    await waitFor(() => expect(inputProps!.value).toContain(text))
+    await act(async () => { await vi.advanceTimersByTimeAsync(400) })
+  }
+
+  it('offers only the matching past sessions and resumes the one clicked', async () => {
+    apiSpy('resumeChatSlot').mockResolvedValue({
+      ok: true, key: 'sess-a', messages: [], has_more: false, total: 0, mode: '',
+    })
+    const { store } = renderChatPage([], { sessions: HISTORY })
+    await waitFor(() => expect(inputProps).not.toBeNull())
+    await waitFor(() => expect(store.getState().chat.history).toHaveLength(2))
+    await typeQuery('rate limiter')
+    const list = await screen.findByRole('listbox', { name: 'Previous chats' }, { timeout: 5_000 })
+    const options = within(list).getAllByRole('option')
+    expect(options).toHaveLength(1)
+    await act(async () => { fireEvent.mouseDown(options[0]) })
+    await waitFor(() => expect(apiMocks.resumeChatSlot).toHaveBeenCalledWith('sess-a', 'rate limiter rollout'))
+    await waitFor(() => expect(store.getState().chat.activeSlot).toBe('sess-a'))
+  })
+
+  it('dismisses the suggestions on Escape', async () => {
+    const { store } = renderChatPage([], { sessions: HISTORY })
+    await waitFor(() => expect(inputProps).not.toBeNull())
+    await waitFor(() => expect(store.getState().chat.history).toHaveLength(2))
+    await typeQuery('rate limiter')
+    expect(await screen.findByRole('listbox', { name: 'Previous chats' }, { timeout: 5_000 })).toBeInTheDocument()
+    act(() => { fireEvent.keyDown(document, { key: 'Escape' }) })
+    await waitFor(() => expect(screen.queryByRole('listbox', { name: 'Previous chats' })).toBeNull())
+  })
+
+  it('offers nothing when no past session matches', async () => {
+    const { store } = renderChatPage([], { sessions: HISTORY })
+    await waitFor(() => expect(inputProps).not.toBeNull())
+    await waitFor(() => expect(store.getState().chat.history).toHaveLength(2))
+    await typeQuery('kubernetes migration')
+    expect(screen.queryByRole('listbox', { name: 'Previous chats' })).toBeNull()
+  })
+})
+
+describe('ChatPage project picker', () => {
+  it('writes the picked directory to the active session', async () => {
+    apiSpy('chatSlotProject').mockResolvedValue({ ok: true })
+    await renderTurn()
+    await waitFor(() => expect(projectPickerProps).not.toBeNull())
+    await act(async () => { projectPickerProps!.onSelect('/repo/service') })
+    await waitFor(() => expect(apiMocks.chatSlotProject).toHaveBeenCalledWith('chat-1', '/repo/service'))
+  })
+
+  it('swallows a failed project write instead of breaking the page', async () => {
+    apiSpy('chatSlotProject').mockRejectedValue(new Error('no such directory'))
+    await renderTurn()
+    await waitFor(() => expect(projectPickerProps).not.toBeNull())
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      await act(async () => { projectPickerProps!.onSelect('/nope') })
+      await waitFor(() => expect(err).toHaveBeenCalled())
+    } finally {
+      err.mockRestore()
+    }
+    // The composer is still mounted and interactive — the rejection did not
+    // escape into the render tree.
+    expect(inputProps).not.toBeNull()
+  })
+})
+
+describe('ChatPage widget composer bridge', () => {
+  it('appends a widget action below text the user already typed', async () => {
+    await renderTurn()
+    const rect = { top: 0, left: 0, width: 1, height: 1 } as DOMRect
+    act(() => { assistantProps!.onQuote!('context line', rect) })
+    await waitFor(() => expect(inputProps!.value).toContain('> context line'))
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mc-widget-send', { detail: { text: 'Merge it now' } }))
+    })
+    await waitFor(() => expect(inputProps!.value).toContain('Merge it now'))
+    expect(inputProps!.value).toContain('> context line')
+  })
+
+  it('ignores a widget action with no text', async () => {
+    await renderTurn()
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mc-widget-send', { detail: { text: '' } }))
+    })
+    act(() => {
+      window.dispatchEvent(new CustomEvent('mc-widget-send', { detail: {} }))
+    })
+    expect(inputProps!.value).toBe('')
+  })
+})

--- a/website/src/test/ChatSidebarMoreCoverage.test.tsx
+++ b/website/src/test/ChatSidebarMoreCoverage.test.tsx
@@ -1,0 +1,937 @@
+/**
+ * Coverage for the ChatSidebar's drag-and-drop brain — the parts no sibling
+ * suite reaches because they are not driven by DOM events at all:
+ *
+ *  1. `sidebarCollision`, the custom dnd-kit collision detector. Four distinct
+ *     gestures share one DndContext (nested-folder re-parent, root-folder
+ *     header-band re-parent, root-folder reorder, session assign), and the
+ *     detector is the only thing that tells them apart.
+ *  2. The `onDragStart` / `onDragOver` / `onDragEnd` / `onDragCancel` lifecycle,
+ *     including the drop routing table and the 500ms hover-to-expand timer.
+ *  3. The surfaces that exist ONLY while a drag is live: the chat-pane drop zone
+ *     portaled into ChatPage's pane, the root un-nest hint, and the DragOverlay
+ *     ghost.
+ *
+ * A pointer drag cannot be faithfully simulated in jsdom (it needs real
+ * PointerEvents plus layout measurement), so — following the precedent in
+ * `ChatSidebar.dragFreezeOrder.test.tsx` — DndContext is stubbed to capture the
+ * real lifecycle props, which are then invoked directly. The collision detector
+ * runs against fabricated rects, so dnd-kit's own `pointerWithin` /
+ * `closestCenter` (kept real, not mocked) do the geometry.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, act, waitFor, within, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import type { RootState } from '../store'
+import type { ChatFolder, ChatTag, TagColumn } from '../types'
+
+// Render framer-motion elements as plain DOM because jsdom cannot run projection.
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: Record<string, unknown>, ref: React.Ref<unknown>) => {
+      const clean: Record<string, unknown> = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children as React.ReactNode)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children?: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: { children?: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+/** Mutable so one test can flip the sidebar into board (tag-column) view. */
+const cfg = vi.hoisted(() => ({
+  value: { tagColumnsEnabled: false, confirmCloseSession: false, defaultAutopilot: false } as Record<string, unknown>,
+}))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => cfg.value,
+  saveChatConfig: vi.fn(),
+}))
+
+/** Lifecycle props + the collision detector, captured off the stubbed context. */
+const dnd = vi.hoisted(() => ({
+  onDragStart: undefined as ((e: unknown) => void) | undefined,
+  onDragOver: undefined as ((e: unknown) => void) | undefined,
+  onDragEnd: undefined as ((e: unknown) => void) | undefined,
+  onDragCancel: undefined as (() => void) | undefined,
+  collision: undefined as unknown,
+}))
+
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>()
+  return {
+    ...actual,
+    DndContext: (props: {
+      children?: unknown
+      collisionDetection?: unknown
+      onDragStart?: (e: unknown) => void
+      onDragOver?: (e: unknown) => void
+      onDragEnd?: (e: unknown) => void
+      onDragCancel?: () => void
+    }) => {
+      // Board-column contexts pass dnd-kit's own closestCenter; only the
+      // list-view context passes the sidebar's own detector, which is the
+      // one under test here.
+      if (props.collisionDetection && props.collisionDetection !== actual.closestCenter) {
+        dnd.collision = props.collisionDetection
+      }
+      dnd.onDragStart = props.onDragStart
+      dnd.onDragOver = props.onDragOver
+      dnd.onDragEnd = props.onDragEnd
+      dnd.onDragCancel = props.onDragCancel
+      return props.children as never
+    },
+    // The real overlay reads the active item off DndContext's internal store,
+    // which the stub above does not provide, so it would render nothing. It is
+    // a presentational portal — passing children through is what lets the ghost
+    // itself be asserted.
+    DragOverlay: (props: { children?: unknown }) => props.children as never,
+  }
+})
+
+const mocks = vi.hoisted(() => ({
+  chatFolders: vi.fn(),
+  updateChatFolder: vi.fn(),
+  setSlotFolder: vi.fn(),
+  sessions: vi.fn(),
+  sessionsSearch: vi.fn(),
+  chatTags: vi.fn(),
+  tagColumns: vi.fn(),
+  reorderTagColumns: vi.fn(),
+  dropSlotToColumn: vi.fn(),
+}))
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy(mocks as unknown as Record<string, unknown>, {
+    get: (target, prop: string) => (prop in target ? target[prop] : vi.fn().mockResolvedValue([])),
+  }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }) as unknown as typeof fetch
+
+import ChatSidebar from '../pages/ChatSidebar'
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+/** `f4` is hidden by the folder filter, so it lives in `folders` while its row
+ *  (and therefore its `[data-folder-drop]` node) is NOT in the DOM — the input
+ *  the hover-to-expand fallback branch needs. */
+const HIDDEN_FOLDER_ID = 'f4'
+const HIDDEN_FOLDERS_LS_KEY = 'mc-flat-hidden-folders'
+
+const FOLDERS: ChatFolder[] = [
+  { id: 'f1', name: 'Alpha', order: 0 },
+  { id: 'f2', name: 'Beta', order: 1, collapsed: true },
+  { id: 'f3', name: 'Gamma', order: 2, parent_id: 'f2' },
+  { id: HIDDEN_FOLDER_ID, name: 'Delta', order: 3, collapsed: true },
+]
+
+interface TestSlot {
+  key: string
+  title?: string
+  running: boolean
+  messages?: number
+  folder_id?: string
+  memory_mode?: 'persistent' | 'incognito' | 'temporary'
+  last_ts?: string
+}
+
+const SLOT_IN_FOLDER = 'chat-foldered'
+const SLOT_LOOSE = 'chat-loose'
+const SLOT_PRIVATE = 'chat-private'
+
+const SLOTS: TestSlot[] = [
+  { key: SLOT_IN_FOLDER, title: 'Foldered work', running: false, messages: 7, folder_id: 'f1', last_ts: '2026-03-01T00:00:00Z' },
+  { key: SLOT_LOOSE, title: 'Loose work', running: false, messages: 2, last_ts: '2026-02-01T00:00:00Z' },
+  { key: SLOT_PRIVATE, title: 'Private work', running: false, messages: 1, memory_mode: 'incognito', last_ts: '2026-01-01T00:00:00Z' },
+]
+
+/** Board (tag-column) view fixtures. `t-doing` is a STATUS tag, which is what
+ *  makes its column accept a session-card drop; `t-note` is a plain label, so
+ *  its column only accepts column reorders. */
+const TAGS: ChatTag[] = [
+  { id: 't-doing', name: 'Doing', color: '#4488ff', order: 0, status: true },
+  { id: 't-note', name: 'Note', color: '#dd8844', order: 1 },
+]
+const COLUMNS: TagColumn[] = [
+  { id: 'col-status', name: 'Doing lane', tag_ids: ['t-doing'], mode: 'any', order: 0 },
+  { id: 'col-plain', name: 'Notes lane', tag_ids: ['t-note'], mode: 'any', order: 1 },
+]
+
+interface RenderOpts {
+  slots?: TestSlot[]
+  folders?: ChatFolder[]
+  /** Attach a chat-pane element (with a composer inside unless suppressed). */
+  chatPane?: boolean
+  /** Omit the `[data-testid="input-wrapper"]` child from the pane. */
+  paneWithoutComposer?: boolean
+  onDropSessionRef?: (ref: { key: string; title: string; messages?: number }) => void
+  activeSlot?: string | null
+  /** Flip into board (tag-column) view and seed the column/tag caches. */
+  board?: boolean
+}
+
+let panes: HTMLElement[] = []
+
+function renderSidebar(opts: RenderOpts = {}) {
+  const slots = opts.slots ?? SLOTS
+  const folders = opts.folders ?? FOLDERS
+  mocks.chatFolders.mockResolvedValue(folders)
+  if (opts.board) {
+    cfg.value = { tagColumnsEnabled: true, confirmCloseSession: false, defaultAutopilot: false }
+    mocks.chatTags.mockResolvedValue(TAGS)
+    mocks.tagColumns.mockResolvedValue(COLUMNS)
+  }
+
+  let pane: HTMLElement | null = null
+  if (opts.chatPane) {
+    pane = document.createElement('div')
+    if (!opts.paneWithoutComposer) {
+      const composer = document.createElement('div')
+      composer.setAttribute('data-testid', 'input-wrapper')
+      pane.appendChild(composer)
+    }
+    document.body.appendChild(pane)
+    panes.push(pane)
+  }
+
+  // Redux Toolkit REPLACES a slice's state with `preloadedState` rather than
+  // merging it into the slice's initialState, so a hand-rolled partial silently
+  // drops every key it forgets and reducers that assume the real shape then
+  // throw as UNHANDLED rejections (which fail the run even while every test
+  // passes). Spread the genuine defaults first.
+  const defaults = createTestStore().getState()
+  const store = createTestStore({
+    dashboard: {
+      ...defaults.dashboard,
+      status: {}, connected: true, slots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as unknown as RootState['dashboard'],
+    chat: {
+      ...defaults.chat,
+      activeSlot: opts.activeSlot ?? null,
+      slotStatusDetail: {}, subagents: {}, slotActivity: {},
+      goalLoops: {}, workflowRuns: {}, subagentQueued: {}, slotHistory: [],
+    } as unknown as RootState['chat'],
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], folders)
+  qc.setQueryData(['tag-columns'], opts.board ? COLUMNS : [])
+  qc.setQueryData(['chat-tags'], opts.board ? TAGS : [])
+  const view = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots} activeSlot={opts.activeSlot ?? null} unreadSlots={[]}
+              history={[]} historyHasMore={false}
+              defaultAgent="" installedAgents={[{ name: 'builder', source: 'builtin' }]}
+              chatDropTarget={pane}
+              onDropSessionRef={opts.onDropSessionRef}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return { ...view, store, pane, qc }
+}
+
+// ── Collision-detector harness ──────────────────────────────────────────────
+
+interface Rect {
+  top: number
+  left: number
+  bottom: number
+  right: number
+  width: number
+  height: number
+}
+const rect = (top: number, left: number, width = 100, height = 34): Rect =>
+  ({ top, left, width, height, bottom: top + height, right: left + width })
+
+interface Container {
+  id: string
+  data: { current: Record<string, unknown> }
+  rect: { current: Rect }
+}
+const container = (id: string, data: Record<string, unknown>, r: Rect): Container =>
+  ({ id, data: { current: data }, rect: { current: r } })
+
+/** Invoke the captured detector against fabricated geometry. */
+function collide(opts: {
+  active: Record<string, unknown>
+  containers: Container[]
+  pointer?: { x: number; y: number }
+  collisionRect?: Rect
+}): string[] {
+  const detect = dnd.collision as ((args: unknown) => Array<{ id: string }>) | undefined
+  if (!detect) throw new Error('collisionDetection was never captured')
+  const hits = detect({
+    active: { id: 'active-item', data: { current: opts.active }, rect: { current: { initial: null, translated: null } } },
+    collisionRect: opts.collisionRect ?? rect(0, 0),
+    droppableRects: new Map(opts.containers.map(c => [c.id, c.rect.current])),
+    droppableContainers: opts.containers,
+    pointerCoordinates: opts.pointer ?? null,
+  })
+  return (hits ?? []).map(h => h.id)
+}
+
+/** The band geometry `sidebarCollision` uses for the root-folder header gesture
+ *  (FOLDER_HEADER_DROP_BAND = 34, re-parent between 25% and 75%). */
+const HEADER = rect(0, 0, 120, 34)
+const BAND_MIDDLE = { x: 20, y: 17 }
+const BAND_TOP_EDGE = { x: 20, y: 2 }
+
+beforeEach(() => {
+  localStorage.clear()
+  localStorage.setItem(HIDDEN_FOLDERS_LS_KEY, JSON.stringify([HIDDEN_FOLDER_ID]))
+  cfg.value = { tagColumnsEnabled: false, confirmCloseSession: false, defaultAutopilot: false }
+  mocks.chatFolders.mockResolvedValue(FOLDERS)
+  mocks.updateChatFolder.mockResolvedValue({ ok: true })
+  mocks.setSlotFolder.mockResolvedValue({ ok: true })
+  mocks.sessions.mockResolvedValue({ sessions: [], has_more: false })
+  mocks.sessionsSearch.mockResolvedValue({ sessions: [] })
+  mocks.chatTags.mockResolvedValue([])
+  mocks.tagColumns.mockResolvedValue([])
+  mocks.reorderTagColumns.mockResolvedValue({ ok: true })
+  mocks.dropSlotToColumn.mockResolvedValue({ ok: true })
+  // The sidebar (and the rows it renders) schedule setTimeout / setInterval
+  // work; without fake timers those callbacks fire after teardown and surface
+  // as unhandled 'window is not defined' errors, which redden the run even
+  // when every test passes.
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.clearAllMocks()
+  for (const p of panes) p.remove()
+  panes = []
+})
+
+describe('ChatSidebar — sidebarCollision routing', () => {
+  it('re-parents a NESTED folder drag to the innermost folder drop zone under the pointer', () => {
+    renderSidebar()
+    const ids = collide({
+      active: { type: 'folder', nested: true, subtree: ['f3'] },
+      containers: [
+        container('folder-drop:f1', { type: 'folder-drop', folderId: 'f1' }, HEADER),
+        container('f1', { type: 'folder' }, HEADER),
+      ],
+      pointer: BAND_MIDDLE,
+    })
+    // Only the folder-drop container survives the filter, and the header-band
+    // arithmetic is skipped entirely on the nested path.
+    expect(ids).toEqual(['folder-drop:f1'])
+  })
+
+  it('never offers a nested folder its own subtree as a drop target', () => {
+    renderSidebar()
+    const ids = collide({
+      active: { type: 'folder', nested: true, subtree: ['f2', 'f3'] },
+      containers: [
+        container('folder-drop:f2', { type: 'folder-drop', folderId: 'f2' }, HEADER),
+        container('folder-drop:f3', { type: 'folder-drop', folderId: 'f3' }, HEADER),
+      ],
+      pointer: BAND_MIDDLE,
+    })
+    expect(ids).toEqual([])
+  })
+
+  it('keeps the root lane (folderId null) reachable for a nested folder drag', () => {
+    renderSidebar()
+    const ids = collide({
+      active: { type: 'folder', nested: true, subtree: ['f3'] },
+      containers: [container('root-lane', { type: 'folder-drop', folderId: null }, HEADER)],
+      pointer: BAND_MIDDLE,
+    })
+    expect(ids).toEqual(['root-lane'])
+  })
+
+  it('a ROOT folder drag over the middle of another header re-parents (single folder-drop hit)', () => {
+    renderSidebar()
+    const ids = collide({
+      active: { type: 'folder', subtree: ['f1'] },
+      containers: [
+        container('folder-drop:f2', { type: 'folder-drop', folderId: 'f2' }, HEADER),
+        container('f2', { type: 'folder' }, HEADER),
+        container('f4', { type: 'folder' }, rect(400, 0)),
+      ],
+      pointer: BAND_MIDDLE,
+    })
+    expect(ids).toEqual(['folder-drop:f2'])
+  })
+
+  it('a ROOT folder drag on a header EDGE falls through to the sortable reorder', () => {
+    renderSidebar()
+    const ids = collide({
+      active: { type: 'folder', subtree: ['f1'] },
+      containers: [
+        container('folder-drop:f2', { type: 'folder-drop', folderId: 'f2' }, HEADER),
+        container('f2', { type: 'folder' }, HEADER),
+        container('f4', { type: 'folder' }, rect(400, 0)),
+      ],
+      pointer: BAND_TOP_EDGE,
+    })
+    // closestCenter over the `folder` containers only — the folder-drop zone is
+    // filtered out, and the nearest sortable to the collision rect leads.
+    expect(ids).toEqual(['f2', 'f4'])
+  })
+
+  it('a ROOT folder drag with no pointer coordinates reorders rather than re-parenting', () => {
+    renderSidebar()
+    const ids = collide({
+      active: { type: 'folder', subtree: ['f1'] },
+      containers: [
+        container('folder-drop:f2', { type: 'folder-drop', folderId: 'f2' }, HEADER),
+        container('f4', { type: 'folder' }, rect(400, 0)),
+        container('f2', { type: 'folder' }, HEADER),
+      ],
+    })
+    expect(ids).toEqual(['f2', 'f4'])
+  })
+
+  it('a SESSION drag resolves to whatever droppable the pointer is inside', () => {
+    renderSidebar()
+    const ids = collide({
+      active: { type: 'session', key: SLOT_LOOSE },
+      containers: [
+        container('folder-drop:f1', { type: 'folder-drop', folderId: 'f1' }, HEADER),
+        container('chat-pane-ref', { type: 'chat-pane-ref' }, rect(500, 500, 600, 400)),
+      ],
+      pointer: BAND_MIDDLE,
+    })
+    expect(ids).toEqual(['folder-drop:f1'])
+  })
+
+  it('a near-miss SESSION drag falls back to the nearest target but NEVER the chat pane', () => {
+    renderSidebar()
+    const ids = collide({
+      active: { type: 'session', key: SLOT_LOOSE },
+      containers: [
+        // Dead centre on the collision rect — it would win closestCenter
+        // outright if it were not excluded by type.
+        container('chat-pane-ref', { type: 'chat-pane-ref' }, rect(-17, -50, 100, 34)),
+        container('folder-drop:f1', { type: 'folder-drop', folderId: 'f1' }, rect(200, 0)),
+      ],
+      pointer: { x: 5_000, y: 5_000 },
+    })
+    expect(ids).toEqual(['folder-drop:f1'])
+  })
+})
+
+describe('ChatSidebar — drop routing (onDragEnd)', () => {
+  /** dnd-kit shapes: `active`/`over` each carry an id plus `data.current`. */
+  const dragEnd = (
+    active: { id: string; data?: Record<string, unknown> },
+    over: { id: string; data?: Record<string, unknown> } | null,
+  ) => act(() => {
+    dnd.onDragEnd?.({
+      active: { id: active.id, data: { current: active.data ?? {} } },
+      over: over ? { id: over.id, data: { current: over.data ?? {} } } : null,
+    })
+  })
+
+  it('a drop outside every target is a no-op', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd({ id: 'f1', data: { type: 'folder' } }, null)
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+    expect(mocks.setSlotFolder).not.toHaveBeenCalled()
+  })
+
+  it('re-parents a nested folder dropped on a folder zone', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd(
+      { id: 'f3', data: { type: 'folder', nested: true } },
+      { id: 'folder-drop:f1', data: { type: 'folder-drop', folderId: 'f1' } },
+    )
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalledWith('f3', { parent_id: 'f1' }))
+  })
+
+  it('moves a nested folder to the top level when dropped on the root lane', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd(
+      { id: 'f3', data: { type: 'folder', nested: true } },
+      { id: 'root-lane', data: { type: 'folder-drop', folderId: null } },
+    )
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalledWith('f3', { parent_id: '' }))
+  })
+
+  it('ignores a nested folder dropped on a sortable container rather than a folder zone', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd({ id: 'f3', data: { type: 'folder', nested: true } }, { id: 'f1', data: { type: 'folder' } })
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+  })
+
+  it('re-parents a root folder dropped on a folder zone', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd(
+      { id: 'f1', data: { type: 'folder' } },
+      { id: 'folder-drop:f2', data: { type: 'folder-drop', folderId: 'f2' } },
+    )
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalledWith('f1', { parent_id: 'f2' }))
+  })
+
+  it('ignores a root folder dropped on the root lane (it is already top level)', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd(
+      { id: 'f1', data: { type: 'folder' } },
+      { id: 'root-lane', data: { type: 'folder-drop', folderId: null } },
+    )
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+  })
+
+  it('reorders sibling root folders when the drop lands on a sortable container', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd({ id: 'f1', data: { type: 'folder' } }, { id: HIDDEN_FOLDER_ID, data: { type: 'folder' } })
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalled())
+    // Every persisted change is an `order` write — never a re-parent.
+    for (const call of mocks.updateChatFolder.mock.calls) {
+      expect(Object.keys(call[1] as object)).toEqual(['order'])
+    }
+  })
+
+  it('does nothing when a folder is dropped onto itself', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd({ id: 'f1', data: { type: 'folder' } }, { id: 'f1', data: { type: 'folder' } })
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+  })
+
+  it('assigns a session to the folder whose drop zone received it', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd(
+      { id: SLOT_LOOSE, data: { type: 'session', key: SLOT_LOOSE } },
+      { id: 'folder-drop:f1', data: { type: 'folder-drop', folderId: 'f1' } },
+    )
+    await waitFor(() => expect(mocks.setSlotFolder).toHaveBeenCalledWith(SLOT_LOOSE, 'f1'))
+  })
+
+  it('ungroups a session dropped on the root lane', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd(
+      { id: SLOT_IN_FOLDER, data: { type: 'session', key: SLOT_IN_FOLDER } },
+      { id: 'root-lane', data: { type: 'folder-drop', folderId: null } },
+    )
+    await waitFor(() => expect(mocks.setSlotFolder).toHaveBeenCalledWith(SLOT_IN_FOLDER, null))
+  })
+
+  it('assigns a session dropped on a folder sortable block to that folder', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd(
+      { id: SLOT_LOOSE, data: { type: 'session', key: SLOT_LOOSE } },
+      { id: 'f2', data: { type: 'folder' } },
+    )
+    await waitFor(() => expect(mocks.setSlotFolder).toHaveBeenCalledWith(SLOT_LOOSE, 'f2'))
+  })
+
+  it('stages a session reference when the drop lands on the chat pane', async () => {
+    const onDropSessionRef = vi.fn()
+    renderSidebar({ chatPane: true, onDropSessionRef })
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd(
+      { id: SLOT_IN_FOLDER, data: { type: 'session', key: SLOT_IN_FOLDER } },
+      { id: 'chat-pane-ref', data: { type: 'chat-pane-ref' } },
+    )
+    expect(onDropSessionRef).toHaveBeenCalledWith({ key: SLOT_IN_FOLDER, title: 'Foldered work', messages: 7 })
+    expect(mocks.setSlotFolder).not.toHaveBeenCalled()
+  })
+
+  it('refuses to stage a reference to a private session, independently of the affordance', async () => {
+    const onDropSessionRef = vi.fn()
+    renderSidebar({ chatPane: true, onDropSessionRef })
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd(
+      { id: SLOT_PRIVATE, data: { type: 'session', key: SLOT_PRIVATE } },
+      { id: 'chat-pane-ref', data: { type: 'chat-pane-ref' } },
+    )
+    expect(onDropSessionRef).not.toHaveBeenCalled()
+  })
+
+  it('refuses to stage a reference to the session already on screen', async () => {
+    const onDropSessionRef = vi.fn()
+    renderSidebar({ chatPane: true, onDropSessionRef, activeSlot: SLOT_LOOSE })
+    await waitFor(() => expect(dnd.onDragEnd).toBeTruthy())
+    dragEnd(
+      { id: SLOT_LOOSE, data: { type: 'session', key: SLOT_LOOSE } },
+      { id: 'chat-pane-ref', data: { type: 'chat-pane-ref' } },
+    )
+    expect(onDropSessionRef).not.toHaveBeenCalled()
+  })
+})
+
+describe('ChatSidebar — hover-to-expand (onDragOver)', () => {
+  const dragOver = (over: { id: string; data?: Record<string, unknown> } | null) => act(() => {
+    dnd.onDragOver?.({ over: over ? { id: over.id, data: { current: over.data ?? {} } } : null })
+  })
+
+  it('expands a collapsed folder after a sustained hover, animating its ring first', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragOver).toBeTruthy())
+    const zone = document.querySelector('[data-folder-drop="f2"]') as HTMLElement | null
+    expect(zone).toBeTruthy()
+
+    dragOver({ id: 'folder-drop:f2', data: { type: 'folder-drop', folderId: 'f2' } })
+    // Nothing yet — the dwell has to be sustained.
+    act(() => { vi.advanceTimersByTime(400) })
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+
+    // 500ms dwell fires the blink, which paints the ring inline.
+    act(() => { vi.advanceTimersByTime(150) })
+    expect(zone?.style.boxShadow).toContain('var(--accent)')
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+
+    // The blink runs for 450ms before the expand commits and the inline
+    // overrides are handed back to the stylesheet.
+    act(() => { vi.advanceTimersByTime(500) })
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalledWith('f2', { collapsed: false }))
+    expect(zone?.style.boxShadow).toBe('')
+  })
+
+  it('expands straight away when the folder has no row on screen to animate', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragOver).toBeTruthy())
+    // Hidden by the folder filter: present in `folders`, absent from the DOM.
+    expect(document.querySelector(`[data-folder-drop="${HIDDEN_FOLDER_ID}"]`)).toBeNull()
+
+    dragOver({ id: `folder-drop:${HIDDEN_FOLDER_ID}`, data: { type: 'folder-drop', folderId: HIDDEN_FOLDER_ID } })
+    act(() => { vi.advanceTimersByTime(600) })
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalledWith(HIDDEN_FOLDER_ID, { collapsed: false }))
+  })
+
+  it('cancels the pending expand when the pointer moves off the folder', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragOver).toBeTruthy())
+    dragOver({ id: 'folder-drop:f2', data: { type: 'folder-drop', folderId: 'f2' } })
+    act(() => { vi.advanceTimersByTime(200) })
+    // Moving onto an EXPANDED folder clears the timer instead of re-arming it.
+    dragOver({ id: 'folder-drop:f1', data: { type: 'folder-drop', folderId: 'f1' } })
+    act(() => { vi.advanceTimersByTime(1_000) })
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+  })
+
+  it('re-arms the timer when the hover moves to a DIFFERENT collapsed folder', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragOver).toBeTruthy())
+    dragOver({ id: `folder-drop:${HIDDEN_FOLDER_ID}`, data: { type: 'folder-drop', folderId: HIDDEN_FOLDER_ID } })
+    act(() => { vi.advanceTimersByTime(200) })
+    dragOver({ id: 'folder-drop:f2', data: { type: 'folder-drop', folderId: 'f2' } })
+    act(() => { vi.advanceTimersByTime(1_200) })
+    // Only the second folder ever expands — the first one's timer was dropped.
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalledWith('f2', { collapsed: false }))
+    const targets = mocks.updateChatFolder.mock.calls.map(c => c[0])
+    expect(targets).not.toContain(HIDDEN_FOLDER_ID)
+  })
+
+  it('clears a pending expand when the drag leaves every droppable', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragOver).toBeTruthy())
+    dragOver({ id: 'folder-drop:f2', data: { type: 'folder-drop', folderId: 'f2' } })
+    act(() => { vi.advanceTimersByTime(200) })
+    dragOver(null)
+    act(() => { vi.advanceTimersByTime(1_000) })
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+  })
+
+  it('a pending expand does not survive the drop', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragOver).toBeTruthy())
+    dragOver({ id: 'folder-drop:f2', data: { type: 'folder-drop', folderId: 'f2' } })
+    act(() => { vi.advanceTimersByTime(200) })
+    act(() => {
+      dnd.onDragEnd?.({
+        active: { id: SLOT_LOOSE, data: { current: { type: 'session', key: SLOT_LOOSE } } },
+        over: null,
+      })
+    })
+    act(() => { vi.advanceTimersByTime(1_000) })
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+  })
+})
+
+describe('ChatSidebar — surfaces that exist only during a drag', () => {
+  const dragStart = (data: Record<string, unknown>, id: string) => act(() => {
+    dnd.onDragStart?.({ active: { id, data: { current: data } } })
+  })
+
+  it('portals the chat-pane drop zone into the pane and outlines the composer', async () => {
+    renderSidebar({ chatPane: true, onDropSessionRef: vi.fn() })
+    await waitFor(() => expect(dnd.onDragStart).toBeTruthy())
+    expect(screen.queryByTestId('chat-pane-drop-zone')).toBeNull()
+
+    dragStart({ type: 'session', key: SLOT_LOOSE }, SLOT_LOOSE)
+    const zone = await screen.findByTestId('chat-pane-drop-zone', undefined, { timeout: 5_000 })
+    expect(zone.parentElement).toBe(panes[0])
+    expect(within(zone).getByText('Drop to reference this session')).toBeTruthy()
+    // Composer was measurable, so the destination itself is outlined.
+    expect(within(zone).getByTestId('chat-pane-drop-target')).toBeTruthy()
+    expect(zone.hasAttribute('data-refused')).toBe(false)
+  })
+
+  it('shows the refusal state (and no destination outline) for a private session', async () => {
+    renderSidebar({ chatPane: true, onDropSessionRef: vi.fn() })
+    await waitFor(() => expect(dnd.onDragStart).toBeTruthy())
+    dragStart({ type: 'session', key: SLOT_PRIVATE }, SLOT_PRIVATE)
+    const zone = await screen.findByTestId('chat-pane-drop-zone', undefined, { timeout: 5_000 })
+    expect(zone.hasAttribute('data-refused')).toBe(true)
+    expect(within(zone).getByText("Private sessions can't be referenced")).toBeTruthy()
+    expect(within(zone).queryByTestId('chat-pane-drop-target')).toBeNull()
+  })
+
+  it('falls back to a centred pill when the pane has no composer to measure', async () => {
+    renderSidebar({ chatPane: true, paneWithoutComposer: true, onDropSessionRef: vi.fn() })
+    await waitFor(() => expect(dnd.onDragStart).toBeTruthy())
+    dragStart({ type: 'session', key: SLOT_LOOSE }, SLOT_LOOSE)
+    const zone = await screen.findByTestId('chat-pane-drop-zone', undefined, { timeout: 5_000 })
+    expect(within(zone).queryByTestId('chat-pane-drop-target')).toBeNull()
+    expect(within(zone).getByText('Drop to reference this session')).toBeTruthy()
+  })
+
+  it('never mounts the zone when the host gave no drop handler', async () => {
+    renderSidebar({ chatPane: true })
+    await waitFor(() => expect(dnd.onDragStart).toBeTruthy())
+    dragStart({ type: 'session', key: SLOT_LOOSE }, SLOT_LOOSE)
+    expect(screen.queryByTestId('chat-pane-drop-zone')).toBeNull()
+  })
+
+  it('offers an un-nest target while a subfolder is being dragged', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragStart).toBeTruthy())
+    expect(screen.queryByText('Drop here to remove from folder')).toBeNull()
+    dragStart({ type: 'folder' }, 'f3')  // f3 is parented under f2
+    expect(await screen.findByText('Drop here to remove from folder', undefined, { timeout: 5_000 })).toBeTruthy()
+  })
+
+  it('offers an un-nest target while a foldered session is dragged over an empty root lane', async () => {
+    // Only slot is inside a folder, so the ungrouped lane is empty — the case
+    // the placeholder exists for.
+    renderSidebar({ slots: [SLOTS[0]] })
+    await waitFor(() => expect(dnd.onDragStart).toBeTruthy())
+    dragStart({ type: 'session', key: SLOT_IN_FOLDER }, SLOT_IN_FOLDER)
+    expect(await screen.findByText('Drop here to remove from folder', undefined, { timeout: 5_000 })).toBeTruthy()
+  })
+
+  it('previews the dragged folder in the overlay ghost', async () => {
+    renderSidebar()
+    await waitFor(() => expect(dnd.onDragStart).toBeTruthy())
+    dragStart({ type: 'folder' }, 'f1')
+    // "Alpha" is also the folder header, so count instances rather than
+    // asserting a single match.
+    await waitFor(() => expect(screen.getAllByText('Alpha').length).toBeGreaterThan(1))
+  })
+
+  it('previews the dragged session in the overlay ghost and clears it on cancel', async () => {
+    renderSidebar({ slots: [SLOTS[1]] })
+    await waitFor(() => expect(dnd.onDragStart).toBeTruthy())
+    dragStart({ type: 'session', key: SLOT_LOOSE }, SLOT_LOOSE)
+    await waitFor(() => expect(screen.getAllByText('Loose work').length).toBeGreaterThan(1))
+    act(() => { dnd.onDragCancel?.() })
+    await waitFor(() => expect(screen.getAllByText('Loose work')).toHaveLength(1))
+  })
+
+  it('falls back to the session key when the dragged slot has no distinct title', async () => {
+    renderSidebar({ slots: [{ key: SLOT_LOOSE, title: SLOT_LOOSE, running: false, messages: 1 }] })
+    await waitFor(() => expect(dnd.onDragStart).toBeTruthy())
+    dragStart({ type: 'session', key: SLOT_LOOSE }, SLOT_LOOSE)
+    await waitFor(() => expect(screen.getAllByText(SLOT_LOOSE).length).toBeGreaterThan(1))
+  })
+})
+
+describe('ChatSidebar — Older Sessions pane resize', () => {
+  const HISTORY_HEIGHT_LS_KEY = 'mc-history-height'
+
+  /** The separator only exists while the pane is expanded. */
+  function openAndGrabHandle() {
+    renderSidebar({ slots: [SLOTS[1]] })
+    act(() => { screen.getByLabelText('Older sessions').click() })
+    return screen.getByRole('separator', { name: 'Resize history pane' })
+  }
+
+  const drag = (handle: HTMLElement, fromY: number, toY: number) => {
+    fireEvent.pointerDown(handle, { clientY: fromY, pointerId: 1 })
+    fireEvent.pointerMove(handle, { clientY: toY, pointerId: 1 })
+  }
+
+  it('grows the pane when dragged upward and persists the new height', () => {
+    const handle = openAndGrabHandle()
+    // Default height is 240; the handle sits ABOVE the pane, so dragging up
+    // (negative dy) grows it.
+    drag(handle, 400, 300)
+    expect(document.body.style.cursor).toBe('ns-resize')
+    fireEvent.pointerUp(handle, { clientY: 300, pointerId: 1 })
+    expect(localStorage.getItem(HISTORY_HEIGHT_LS_KEY)).toBe('340')
+    // Global cursor / selection locks are released on drag end.
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+  })
+
+  it('clamps to the minimum height when dragged far downward', () => {
+    const handle = openAndGrabHandle()
+    drag(handle, 400, 4_000)
+    fireEvent.pointerUp(handle, { clientY: 4_000, pointerId: 1 })
+    expect(localStorage.getItem(HISTORY_HEIGHT_LS_KEY)).toBe('120')
+  })
+
+  it('clamps to the maximum height when dragged far upward', () => {
+    const handle = openAndGrabHandle()
+    drag(handle, 4_000, 0)
+    fireEvent.pointerUp(handle, { clientY: 0, pointerId: 1 })
+    expect(localStorage.getItem(HISTORY_HEIGHT_LS_KEY)).toBe('800')
+  })
+
+  it('restores the global cursor lock when the sidebar unmounts mid-drag', () => {
+    const view = renderSidebar({ slots: [SLOTS[1]] })
+    act(() => { screen.getByLabelText('Older sessions').click() })
+    const handle = screen.getByRole('separator', { name: 'Resize history pane' })
+    drag(handle, 400, 350)
+    expect(document.body.style.cursor).toBe('ns-resize')
+    // onEnd can never fire once the captured element is gone, so the unmount
+    // guard is the only thing that releases the lock.
+    view.unmount()
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+  })
+
+  it('restores a persisted height on mount and ignores an out-of-range one', () => {
+    localStorage.setItem(HISTORY_HEIGHT_LS_KEY, '999999')
+    const first = openAndGrabHandle()
+    expect(first).toBeTruthy()
+    // Rejected as out of range, so the default is written back instead.
+    expect(localStorage.getItem(HISTORY_HEIGHT_LS_KEY)).toBe('240')
+  })
+})
+
+describe('ChatSidebar — board column drag targets', () => {
+  /** A minimal DataTransfer stand-in: only `types` / `getData` / `setData` are
+   *  read by the handlers under test. */
+  const transfer = (types: string[], data: Record<string, string> = {}) => ({
+    types,
+    getData: (t: string) => data[t] ?? '',
+    setData: vi.fn(),
+    effectAllowed: 'none',
+  })
+
+  async function renderBoard() {
+    const view = renderSidebar({ board: true })
+    await waitFor(() => expect(screen.getByTestId('column-strip')).toBeTruthy())
+    return view
+  }
+
+  const column = (id: string) => screen.getByTestId(`column-${id}`)
+
+  it('accepts a column reorder anywhere on a column surface', async () => {
+    await renderBoard()
+    const notPrevented = fireEvent.dragOver(column('col-plain'), {
+      dataTransfer: transfer(['application/mc-column']),
+    })
+    // fireEvent returns false once the handler called preventDefault.
+    expect(notPrevented).toBe(false)
+    // A column reorder is not a card drop, so no ring highlight.
+    expect(column('col-plain').className).not.toContain('ring-accent')
+  })
+
+  it('highlights only a STATUS lane while a session card is dragged over it', async () => {
+    await renderBoard()
+    const status = column('col-status')
+    expect(fireEvent.dragOver(status, { dataTransfer: transfer(['text/plain']) })).toBe(false)
+    expect(status.className).toContain('ring-accent')
+
+    const plain = column('col-plain')
+    // A plain label column cannot receive a card, so the drag is not accepted.
+    expect(fireEvent.dragOver(plain, { dataTransfer: transfer(['text/plain']) })).toBe(true)
+    expect(plain.className).not.toContain('ring-accent')
+  })
+
+  it('drops the highlight again when the card leaves', async () => {
+    await renderBoard()
+    const status = column('col-status')
+    fireEvent.dragOver(status, { dataTransfer: transfer(['text/plain']) })
+    expect(status.className).toContain('ring-accent')
+    fireEvent.dragLeave(status)
+    expect(status.className).not.toContain('ring-accent')
+  })
+
+  it('persists a new column order when a column is dropped on a sibling', async () => {
+    await renderBoard()
+    fireEvent.drop(column('col-status'), {
+      dataTransfer: transfer(['application/mc-column'], { 'application/mc-column': 'col-plain' }),
+    })
+    await waitFor(() => expect(mocks.reorderTagColumns).toHaveBeenCalledWith(['col-plain', 'col-status']))
+  })
+
+  it('ignores a column dropped back onto itself', async () => {
+    await renderBoard()
+    fireEvent.drop(column('col-status'), {
+      dataTransfer: transfer(['application/mc-column'], { 'application/mc-column': 'col-status' }),
+    })
+    expect(mocks.reorderTagColumns).not.toHaveBeenCalled()
+    // Falls through to the card path, which finds no session key to move.
+    expect(mocks.dropSlotToColumn).not.toHaveBeenCalled()
+  })
+
+  it('assigns the dropped session to a status lane', async () => {
+    await renderBoard()
+    fireEvent.drop(column('col-status'), {
+      dataTransfer: transfer(['text/plain'], { 'text/plain': SLOT_LOOSE }),
+    })
+    await waitFor(() => expect(mocks.dropSlotToColumn).toHaveBeenCalledWith(SLOT_LOOSE, 'col-status'))
+  })
+
+  it('refuses a session drop on a column that is not a status lane', async () => {
+    await renderBoard()
+    fireEvent.drop(column('col-plain'), {
+      dataTransfer: transfer(['text/plain'], { 'text/plain': SLOT_LOOSE }),
+    })
+    expect(mocks.dropSlotToColumn).not.toHaveBeenCalled()
+  })
+
+  it('publishes the column id from the reorder grip', async () => {
+    await renderBoard()
+    const grip = within(column('col-status')).getAllByTitle('Drag to reorder')[0]
+    const dt = transfer([])
+    fireEvent.dragStart(grip, { dataTransfer: dt })
+    expect(dt.setData).toHaveBeenCalledWith('application/mc-column', 'col-status')
+  })
+})

--- a/website/src/test/IssueRadarPrListCoverage.test.tsx
+++ b/website/src/test/IssueRadarPrListCoverage.test.tsx
@@ -1,0 +1,556 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, within, act } from '@testing-library/react'
+import type { Key, ReactNode } from 'react'
+
+import type { PullRequest } from '../apps/issue-radar/api'
+
+// Behaviour pins for the pull-request LIST column (PrList.tsx) — the middle
+// column of Issue Radar's PR surface.
+//
+// What these cover, and why each one is load-bearing:
+//
+//  * The row's state icon is derived from three independent fields, and a merged
+//    PR is `state: 'closed'` WITH `merged_at` — so the precedence between them is
+//    the thing that can silently invert and paint a merged PR as closed.
+//  * A per-bucket check tally is only shown when it is COMPLETE. A truncated
+//    tally (more checks than one API page) omits a page that could hold the only
+//    failure, so "34 passing" there would be a confident lie — the aggregate
+//    rollup dot covers every check and is what must appear instead.
+//  * The diff bar rounds proportionally, and both ends are clamped: a one-line
+//    removal must still claim a red block, and a one-line addition a green one,
+//    or a lopsided PR reads as entirely one-sided.
+//  * A missing metric is never rendered as a zero — the whole bottom row is
+//    omitted when neither the diff shape nor the checks arrived.
+//  * The select checkbox renders only on a writable repo (every bulk action would
+//    403 otherwise) and sits BESIDE the card, not inside its <button>.
+//  * The footer count carries the caveat that explains it: a capped closed/merged
+//    page, or a repo-wide search result, each get their own tooltip.
+//  * The provider vocabulary is not decoration — calling a merge request a pull
+//    request in a GitLab workspace is simply wrong copy.
+
+/** Framer's `useReducedMotion` is read at render; flipping this drives the
+ * animated-vs-virtualized branch without a second mock factory. */
+const reduce = { value: false }
+
+// Surface Framer's `layout` prop as an attribute so a test can assert which
+// layout mode the cards mount with (same pattern as IssueRadarListResize).
+vi.mock('framer-motion', () => ({
+  useReducedMotion: () => reduce.value,
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({
+      children, layout, initial, animate, exit, transition, ...rest
+    }: Record<string, unknown> & { children?: ReactNode }) => {
+      void initial; void animate; void exit; void transition
+      return <div data-layout={String(layout)} {...rest}>{children}</div>
+    },
+  },
+}))
+
+// Virtuoso measures 0 height under happy-dom and would render no rows, so mock it
+// to a plain flow that renders every item. Tagged so a test can assert the large
+// list took the virtualized branch. `computeItemKey` is honoured rather than
+// substituted with the index: keying virtualized rows by position is what makes a
+// reordered list reuse the wrong row's DOM, so the real key function has to run.
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: ({ data, itemContent, computeItemKey }: {
+    data: unknown[]
+    itemContent: (i: number, d: unknown) => ReactNode
+    computeItemKey: (i: number, d: unknown) => Key
+  }) => (
+    <div data-testid="virtuoso">
+      {data.map((d, i) => <div key={computeItemKey(i, d)}>{itemContent(i, d)}</div>)}
+    </div>
+  ),
+}))
+
+// The bulk bar owns its own mutations, confirmation tokens and react-query hooks,
+// and is pinned by its own tests. This file is about the list, so it becomes a
+// marker.
+vi.mock('../apps/issue-radar/components/PrBulkBar', () => ({
+  default: () => <div>pr-bulk-bar</div>,
+}))
+
+const ctx = { value: {} as Record<string, unknown> }
+vi.mock('../apps/issue-radar/context', () => ({ useIssueRadar: () => ctx.value }))
+
+const PrList = (await import('../apps/issue-radar/components/PrList')).default
+
+const spies = {
+  setSelectedPull: vi.fn(),
+  refreshPulls: vi.fn(),
+  setPrQuery: vi.fn(),
+  togglePullChecked: vi.fn(),
+  clearCheckedPulls: vi.fn(),
+}
+
+function pr(over: Partial<PullRequest> = {}): PullRequest {
+  return {
+    number: 7,
+    title: 'Row title',
+    url: 'https://github.com/kirodotdev/Kiro/pull/7',
+    state: 'open',
+    draft: false,
+    labels: [],
+    author: 'alice',
+    updated_at: new Date().toISOString(),
+    merged_at: null,
+    ...over,
+  }
+}
+
+function setCtx(rows: PullRequest[], over: Record<string, unknown> = {}) {
+  ctx.value = {
+    filteredPulls: rows,
+    sortedPulls: rows,
+    pullsLoading: false,
+    pullsError: null,
+    pullsPartial: false,
+    prStateFilter: 'open',
+    colorByName: new Map<string, string>([['bug', 'ff0000']]),
+    selectedPull: null,
+    pullsRefreshing: false,
+    prQuery: '',
+    pullsUpdatedAt: Date.now(),
+    prPersonFilterActive: false,
+    prSearchTruncatedAt: null,
+    active: { owner: 'kirodotdev', repo: 'Kiro' },
+    canWrite: false,
+    checkedPulls: new Set<number>(),
+    ...spies,
+    ...over,
+  }
+}
+
+/** The card <button> for PR `n` — located by the `#n` it prints, so the lookup
+ * survives a title change and never matches the footer or the toolbar. */
+function cardFor(n: number): HTMLElement {
+  const card = screen.getAllByRole('button').find((b) => b.textContent?.includes(`#${n}`))
+  if (!card) throw new Error(`no card rendered for #${n}`)
+  return card
+}
+
+function manyPulls(n: number): PullRequest[] {
+  return Array.from({ length: n }, (_, i) => pr({ number: i + 1, title: `PR ${i + 1}` }))
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.clearAllMocks()
+  reduce.value = false
+  setCtx([pr()])
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+describe('PrList — card composition', () => {
+  it('paints the number, author, age, title and label chips', () => {
+    setCtx([pr({ labels: ['bug', 'perf'] })])
+    render(<PrList />)
+
+    const card = cardFor(7)
+    expect(card.textContent).toContain('#7')
+    expect(card.textContent).toContain('alice')
+    expect(within(card).getByText('Row title')).toBeTruthy()
+    // The known label takes its repo colour; an unknown one falls back to grey
+    // rather than rendering an invalid `#undefined`.
+    expect(within(card).getByText('bug').getAttribute('style')).toContain('#ff0000')
+    expect(within(card).getByText('perf').getAttribute('style')).toContain('#888888')
+  })
+
+  it('omits the author fragment when the row has no author', () => {
+    setCtx([pr({ author: null })])
+    render(<PrList />)
+    expect(cardFor(7).textContent).not.toContain('·')
+  })
+
+  it('selects the PR when its card is clicked', () => {
+    render(<PrList />)
+    fireEvent.click(cardFor(7))
+    expect(spies.setSelectedPull).toHaveBeenCalledWith(7)
+  })
+
+  it('marks the selected card with the accent border', () => {
+    setCtx([pr()], { selectedPull: 7 })
+    render(<PrList />)
+    expect(cardFor(7).className).toContain('border-accent')
+  })
+})
+
+describe('PrList — lifecycle icon precedence', () => {
+  it('paints merged over closed, then draft, then open', () => {
+    // A merged PR is ALSO `state: 'closed'`, so merged_at has to win or every
+    // merged row reads as closed-unmerged.
+    setCtx([
+      pr({ number: 1, title: 'Merged one', state: 'closed', merged_at: '2026-07-01T00:00:00Z' }),
+      pr({ number: 2, title: 'Closed one', state: 'closed' }),
+      // draft is only reachable while open, and must not outrank a merge.
+      pr({ number: 3, title: 'Draft one', draft: true }),
+      pr({ number: 4, title: 'Open one' }),
+    ])
+    render(<PrList />)
+
+    expect(cardFor(1).querySelector('svg.text-aim')).not.toBeNull()
+    expect(cardFor(2).querySelector('svg.text-danger')).not.toBeNull()
+    expect(cardFor(3).querySelector('svg.text-muted')).not.toBeNull()
+    expect(cardFor(4).querySelector('svg.text-ok')).not.toBeNull()
+  })
+
+  it('treats a draft that was merged as merged', () => {
+    setCtx([pr({ draft: true, state: 'closed', merged_at: '2026-07-01T00:00:00Z' })])
+    render(<PrList />)
+    const card = cardFor(7)
+    expect(card.querySelector('svg.text-aim')).not.toBeNull()
+    expect(card.querySelector('svg.text-muted')).toBeNull()
+  })
+})
+
+describe('PrList — diff shape', () => {
+  it('omits the whole bottom row when neither the diff nor the checks arrived', () => {
+    render(<PrList />)
+    // The metrics row is the only tabular-nums block inside a card; no row at all
+    // is the point — a "0 files, +0 −0" would claim the PR changes nothing.
+    expect(cardFor(7).querySelector('.tabular-nums')).toBeNull()
+  })
+
+  it('pluralizes the changed-file count', () => {
+    setCtx([
+      pr({ number: 1, title: 'One file', changed_files: 1 }),
+      pr({ number: 2, title: 'Three files', changed_files: 3 }),
+    ])
+    render(<PrList />)
+    expect(within(cardFor(1)).getByTitle('1 file changed')).toBeTruthy()
+    expect(within(cardFor(2)).getByTitle('3 files changed')).toBeTruthy()
+  })
+
+  it('fills the bar proportionally and never rounds a removal away', () => {
+    setCtx([pr({ additions: 100, deletions: 1 })])
+    render(<PrList />)
+    const card = cardFor(7)
+    // 100/101 rounds to 5 blocks, which would erase the removal entirely — the
+    // non-zero side always keeps one.
+    expect(card.querySelectorAll('.bg-ok')).toHaveLength(4)
+    expect(card.querySelectorAll('.bg-danger')).toHaveLength(1)
+    expect(within(card).getByText('+100')).toBeTruthy()
+    expect(within(card).getByText('\u22121')).toBeTruthy()
+  })
+
+  it('never rounds a tiny addition away either', () => {
+    setCtx([pr({ additions: 1, deletions: 100 })])
+    render(<PrList />)
+    expect(cardFor(7).querySelectorAll('.bg-ok')).toHaveLength(1)
+  })
+
+  it('fills every block for a one-sided change', () => {
+    setCtx([
+      pr({ number: 1, title: 'Additions only', additions: 4, deletions: 0 }),
+      pr({ number: 2, title: 'Removals only', additions: 0, deletions: 4 }),
+    ])
+    render(<PrList />)
+
+    const added = cardFor(1)
+    expect(added.querySelectorAll('.bg-ok')).toHaveLength(5)
+    expect(within(added).queryByText(/^\u2212/)).toBeNull()
+
+    const removed = cardFor(2)
+    expect(removed.querySelectorAll('.bg-ok')).toHaveLength(0)
+    expect(removed.querySelectorAll('.bg-danger')).toHaveLength(5)
+    expect(within(removed).queryByText(/^\+/)).toBeNull()
+  })
+
+  it('renders no bar when only the file count is known', () => {
+    setCtx([pr({ changed_files: 2, additions: 0, deletions: 0 })])
+    render(<PrList />)
+    const card = cardFor(7)
+    expect(within(card).getByTitle('2 files changed')).toBeTruthy()
+    expect(card.querySelectorAll('.bg-ok')).toHaveLength(0)
+    expect(card.querySelectorAll('.bg-danger')).toHaveLength(0)
+  })
+})
+
+describe('PrList — check reporting', () => {
+  const counts = (over: Partial<Record<'failure' | 'running' | 'success' | 'other', number>> = {}) => ({
+    failure: 0, running: 0, success: 0, other: 0, ...over,
+  })
+
+  it('tallies each non-empty bucket and omits the empty ones', () => {
+    setCtx([pr({ checks_counts: counts({ failure: 2, running: 1, success: 34 }) })])
+    render(<PrList />)
+
+    const card = cardFor(7)
+    expect(within(card).getByTitle('2 failing')).toBeTruthy()
+    expect(within(card).getByTitle('34 passing')).toBeTruthy()
+    // A green PR stays quiet: a zero bucket is absent, not rendered as "0".
+    expect(within(card).queryByTitle('0 skipped / neutral')).toBeNull()
+    // Only the running badge spins.
+    expect(within(card).getByTitle('1 running').querySelector('.animate-spin')).not.toBeNull()
+    expect(within(card).getByTitle('34 passing').querySelector('.animate-spin')).toBeNull()
+  })
+
+  it('falls back to the aggregate dot when the tally is truncated', () => {
+    // The omitted page could hold the only failure, so "34 passing" would be a
+    // confident lie; the rollup covers every check.
+    setCtx([pr({
+      checks_counts: counts({ success: 34 }), checks_truncated: true, checks_state: 'failure',
+    })])
+    render(<PrList />)
+
+    const card = cardFor(7)
+    expect(within(card).queryByTitle('34 passing')).toBeNull()
+    expect(within(card).getByTitle('checks failing')).toBeTruthy()
+  })
+
+  it('falls back to the aggregate dot when every bucket is zero', () => {
+    setCtx([pr({ checks_counts: counts(), checks_state: 'other' })])
+    render(<PrList />)
+    expect(within(cardFor(7)).getByTitle('checks skipped / neutral')).toBeTruthy()
+  })
+
+  it('paints the aggregate dot for each rollup state', () => {
+    setCtx([
+      pr({ number: 1, title: 'Failing', checks_state: 'failure' }),
+      pr({ number: 2, title: 'Running', checks_state: 'running' }),
+      pr({ number: 3, title: 'Passing', checks_state: 'success' }),
+      pr({ number: 4, title: 'Neutral', checks_state: 'other' }),
+    ])
+    render(<PrList />)
+
+    expect(within(cardFor(1)).getByLabelText('checks failing')).toBeTruthy()
+    expect(within(cardFor(3)).getByLabelText('checks passing')).toBeTruthy()
+    expect(within(cardFor(4)).getByLabelText('checks skipped / neutral')).toBeTruthy()
+    // Only the in-flight dot animates.
+    const running = within(cardFor(2)).getByLabelText('checks running')
+    expect(running.querySelector('.animate-spin')).not.toBeNull()
+    expect(within(cardFor(3)).getByLabelText('checks passing').querySelector('.animate-spin'))
+      .toBeNull()
+  })
+
+  it('shows no check element at all when the enrichment did not run', () => {
+    setCtx([pr({ checks_state: null, checks_counts: null, changed_files: 1 })])
+    render(<PrList />)
+    const card = cardFor(7)
+    // The metrics row is present for the diff, but carries no rollup dot.
+    expect(within(card).getByTitle('1 file changed')).toBeTruthy()
+    expect(within(card).queryByLabelText(/^checks /)).toBeNull()
+  })
+})
+
+describe('PrList — search box', () => {
+  it('reports every keystroke to the shared query state', () => {
+    render(<PrList />)
+    fireEvent.change(screen.getByLabelText('Search Pull Requests'), { target: { value: 'flake' } })
+    expect(spies.setPrQuery).toHaveBeenCalledWith('flake')
+  })
+
+  it('offers the clear affordance only while a query is set', () => {
+    render(<PrList />)
+    expect(screen.queryByRole('button', { name: 'Clear search' })).toBeNull()
+  })
+
+  it('clears the query from the clear button', () => {
+    setCtx([pr()], { prQuery: 'flake' })
+    render(<PrList />)
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search' }))
+    expect(spies.setPrQuery).toHaveBeenCalledWith('')
+  })
+})
+
+describe('PrList — list states', () => {
+  it('shows skeleton cards instead of rows while the first page loads', () => {
+    setCtx([pr()], { pullsLoading: true })
+    render(<PrList />)
+    expect(screen.getByRole('status')).toBeTruthy()
+    expect(screen.queryByText('Row title')).toBeNull()
+  })
+
+  it('surfaces the fetch error message', () => {
+    setCtx([], { pullsError: new Error('gh: rate limit exceeded') })
+    render(<PrList />)
+    expect(screen.getByText('gh: rate limit exceeded')).toBeTruthy()
+  })
+
+  it('blames the SEARCH when a query is what emptied the list', () => {
+    setCtx([], { prQuery: '  zzz  ' })
+    render(<PrList />)
+    expect(screen.getByText('No Pull Requests match your search.')).toBeTruthy()
+  })
+
+  it('blames the FILTERS when nothing is being searched', () => {
+    setCtx([])
+    render(<PrList />)
+    expect(screen.getByText('No matching Pull Requests.')).toBeTruthy()
+    expect(screen.getByText('Try clearing a filter in the sidebar.')).toBeTruthy()
+  })
+})
+
+describe('PrList — animation and virtualization', () => {
+  it('animates position only, and drops layout animation entirely mid-resize', () => {
+    // The default layout mode animates a width change with a scale transform,
+    // which stretches the card text every time the column rewraps.
+    const idle = render(<PrList />)
+    expect(idle.container.querySelector('[data-layout]')!.getAttribute('data-layout'))
+      .toBe('position')
+    idle.unmount()
+
+    const dragging = render(<PrList resizing />)
+    expect(dragging.container.querySelector('[data-layout]')!.getAttribute('data-layout'))
+      .toBe('false')
+  })
+
+  it('switches to the virtualized scroller above the animation cap', () => {
+    setCtx(manyPulls(201))
+    const { container } = render(<PrList />)
+    expect(screen.getByTestId('virtuoso')).toBeTruthy()
+    expect(container.querySelector('[data-layout]')).toBeNull()
+    // The virtualized rows are still selectable.
+    fireEvent.click(cardFor(1))
+    expect(spies.setSelectedPull).toHaveBeenCalledWith(1)
+  })
+
+  it('virtualizes a small list too when the user asked for reduced motion', () => {
+    reduce.value = true
+    const { container } = render(<PrList />)
+    expect(screen.getByTestId('virtuoso')).toBeTruthy()
+    expect(container.querySelector('[data-layout]')).toBeNull()
+  })
+})
+
+describe('PrList — bulk selection', () => {
+  it('offers no checkbox on a read-only repo', () => {
+    render(<PrList />)
+    expect(screen.queryByRole('checkbox')).toBeNull()
+  })
+
+  it('ticks and unticks a row through the shared selection', () => {
+    setCtx([pr()], { canWrite: true })
+    render(<PrList />)
+
+    const box = screen.getByRole('checkbox', { name: 'Select PR #7 for a bulk action' })
+    expect((box as HTMLInputElement).checked).toBe(false)
+    fireEvent.click(box)
+    expect(spies.togglePullChecked).toHaveBeenCalledWith(7)
+  })
+
+  it('reflects an already-ticked row as checked', () => {
+    setCtx([pr()], { canWrite: true, checkedPulls: new Set([7]) })
+    render(<PrList />)
+    const box = screen.getByRole('checkbox', { name: 'Select PR #7 for a bulk action' })
+    expect((box as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('disarms a selection on Escape', () => {
+    setCtx([pr()], { canWrite: true, checkedPulls: new Set([7]) })
+    render(<PrList />)
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(spies.clearCheckedPulls).toHaveBeenCalledTimes(1)
+    // Another key is not an escape hatch.
+    fireEvent.keyDown(window, { key: 'Enter' })
+    expect(spies.clearCheckedPulls).toHaveBeenCalledTimes(1)
+  })
+
+  it('binds no Escape handler when nothing is ticked', () => {
+    setCtx([pr()], { canWrite: true })
+    render(<PrList />)
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(spies.clearCheckedPulls).not.toHaveBeenCalled()
+  })
+})
+
+describe('PrList — footer', () => {
+  it('pluralizes the count and carries no caveat for an unfiltered open list', () => {
+    setCtx([pr({ number: 1, title: 'First' }), pr({ number: 2, title: 'Second' })])
+    render(<PrList />)
+    const count = screen.getByText('2 PRs')
+    expect(count.hasAttribute('title')).toBe(false)
+  })
+
+  it('renders the singular count for one row', () => {
+    render(<PrList />)
+    expect(screen.getByText('1 PR')).toBeTruthy()
+  })
+
+  it('marks a capped repo-wide search with a + and says where the cap came from', () => {
+    setCtx([pr()], { prPersonFilterActive: true, prSearchTruncatedAt: 50 })
+    render(<PrList />)
+    const count = screen.getByText('1 PR+')
+    expect(count.getAttribute('title'))
+      .toBe('Resolved by GitHub search across the whole repo, capped at the 50 most recently updated matches')
+  })
+
+  it('says an uncapped repo-wide search is complete', () => {
+    setCtx([pr()], { prPersonFilterActive: true })
+    render(<PrList />)
+    expect(screen.getByText('1 PR').getAttribute('title'))
+      .toMatch(/Resolved by GitHub search across the whole repo/)
+  })
+
+  it('warns that a closed/merged list is only the newest page', () => {
+    setCtx([pr()], { prStateFilter: 'closed' })
+    render(<PrList />)
+    expect(screen.getByText('1 PR').getAttribute('title'))
+      .toMatch(/capped at the 100 most recently updated/)
+  })
+
+  it('says the rest is still loading on a cold first paint', () => {
+    setCtx([pr()], { pullsPartial: true })
+    render(<PrList />)
+    expect(screen.getByText('Loading the rest…')).toBeTruthy()
+  })
+
+  it('shows the age of the list once it has been fetched', () => {
+    render(<PrList />)
+    expect(screen.getByTitle('Time since the PR list was last fetched from GitHub')).toBeTruthy()
+  })
+
+  it('omits the age before the first fetch lands', () => {
+    setCtx([pr()], { pullsUpdatedAt: 0 })
+    render(<PrList />)
+    expect(screen.queryByTitle('Time since the PR list was last fetched from GitHub')).toBeNull()
+  })
+
+  it('refetches from the refresh button', () => {
+    render(<PrList />)
+    const button = screen.getByRole('button', { name: 'Refresh pull requests' })
+    expect(button.getAttribute('title')).toBe('Re-fetch Pull Requests from GitHub')
+    fireEvent.click(button)
+    expect(spies.refreshPulls).toHaveBeenCalledTimes(1)
+  })
+
+  it('locks the refresh button and spins it while a refetch is in flight', () => {
+    setCtx([pr()], { pullsRefreshing: true })
+    render(<PrList />)
+    const button = screen.getByRole('button', { name: 'Refresh pull requests' })
+    expect((button as HTMLButtonElement).disabled).toBe(true)
+    expect(button.querySelector('.animate-spin')).not.toBeNull()
+  })
+})
+
+describe('PrList — provider vocabulary', () => {
+  it('calls them merge requests in a GitLab workspace', () => {
+    setCtx([pr()], {
+      active: { owner: 'acme', repo: 'widget', provider: 'gitlab', host: 'gitlab.com' },
+      canWrite: true,
+    })
+    render(<PrList />)
+
+    expect(screen.getByLabelText('Search Merge Requests')).toHaveProperty(
+      'placeholder', 'Search Merge Requests…',
+    )
+    expect(screen.getByRole('checkbox', { name: 'Select MR #7 for a bulk action' })).toBeTruthy()
+    const button = screen.getByRole('button', { name: 'Refresh merge requests' })
+    expect(button.getAttribute('title')).toBe('Re-fetch Merge Requests from GitLab')
+  })
+})
+
+describe('PrList — relative-time ticker', () => {
+  it('keeps re-rendering the ages on its own interval', () => {
+    render(<PrList />)
+    // The "3m ago" labels would otherwise freeze at their first paint for as long
+    // as the column stays open.
+    act(() => { vi.advanceTimersByTime(90_000) })
+    expect(cardFor(7).textContent).toContain('Row title')
+  })
+})

--- a/website/src/test/LocalStorageDebugCoverage.test.tsx
+++ b/website/src/test/LocalStorageDebugCoverage.test.tsx
@@ -1,0 +1,407 @@
+/**
+ * Coverage tests for the localStorage debug page.
+ *
+ * The file sat at 3/92 statements: only its module-level constants ran. Nothing
+ * below the top of the module had ever executed — not the scanner, not the
+ * prefix classifier, not one of the five mutating handlers (refresh / delete key
+ * / delete group / export / clear-orphans), and none of the render branches
+ * (the three usage-bar colours, the over-quota warning, the per-group delete
+ * button, the value inspector's expand + truncation, the filter, the 200-row
+ * cap).
+ *
+ * Harness notes:
+ *
+ * - Plain `render`, no providers. The page reads no Redux state, no router and
+ *   no query client; wrapping it in `renderWithProviders` would only pull in
+ *   ThemeProvider's rAF/setTimeout palette commit, which is not the code under
+ *   test and is exactly the kind of post-teardown callback that reddens a suite
+ *   with an unhandled error. Fake timers are armed anyway as a fence.
+ * - `fireEvent`, not `userEvent`: every interaction here is a synchronous state
+ *   update, and userEvent's own timer plumbing does not mix well with the fake
+ *   timers above.
+ * - Storage is the deterministic in-memory Storage the suite setup installs
+ *   (`integration/setup.ts`), so seeding means `setItem` on that double and
+ *   never on a real browser store. It is cleared before AND after every test so
+ *   nothing leaks into a neighbouring file.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+
+import LocalStorageDebug from '../pages/LocalStorageDebug'
+
+/** Approximate quota the page assumes (5 MiB). */
+const QUOTA = 5 * 1024 * 1024
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  localStorage.clear()
+})
+
+/** Replace storage contents with `pairs`, in the given insertion order. */
+function seed(pairs: Record<string, string>): void {
+  localStorage.clear()
+  for (const [k, v] of Object.entries(pairs)) localStorage.setItem(k, v)
+}
+
+/** The inspector row for one storage key (the clickable `role="button"` line). */
+function keyRow(key: string): HTMLElement {
+  const row = screen.getByText(key).closest('[role="button"]')
+  if (!row) throw new Error(`no inspector row for ${key}`)
+  return row as HTMLElement
+}
+
+/** The category-table row for one prefix label. */
+function groupRow(prefix: string): HTMLElement {
+  const cell = screen.getByText(prefix)
+  if (!cell.parentElement) throw new Error(`no category row for ${prefix}`)
+  return cell.parentElement
+}
+
+/** Every inspector row currently rendered, in DOM order. */
+function renderedKeys(): string[] {
+  return screen
+    .queryAllByLabelText('Delete key')
+    .map(b => (b.closest('[role="button"]') as HTMLElement).firstElementChild?.textContent ?? '')
+}
+
+/** The usage meter's filled bar. */
+function usageBar(container: HTMLElement): HTMLElement {
+  const bar = container.querySelector('.h-full.rounded-full')
+  if (!bar) throw new Error('no usage bar')
+  return bar as HTMLElement
+}
+
+// ─── scanning, grouping, sorting ─────────────────────────────────────────────
+
+describe('LocalStorageDebug scan', () => {
+  it('reports an empty store with no rows and no keys', () => {
+    const { container } = render(<LocalStorageDebug />)
+
+    expect(screen.getByText('0 keys')).toBeInTheDocument()
+    expect(renderedKeys()).toEqual([])
+    expect(screen.queryByText('(static keys)')).toBeNull()
+    expect(usageBar(container).getAttribute('style')).toContain('width: 0%')
+  })
+
+  it('sorts keys by descending size and counts them in the overview', () => {
+    seed({ small: 'a', huge: 'z'.repeat(500), medium: 'm'.repeat(50) })
+
+    render(<LocalStorageDebug />)
+
+    expect(screen.getByText('3 keys')).toBeInTheDocument()
+    expect(renderedKeys()).toEqual(['huge', 'medium', 'small'])
+  })
+
+  it('classifies every known prefix and buckets the rest as static keys', () => {
+    seed({
+      'vc_heights_chat': 'x',
+      'kirocrew:touched-files:s1': 'x',
+      'mc-cmt-read:42': 'x',
+      'mimir-tasks:board': 'x',
+      'sort:alpha': 'x',
+      'mc-chat-1': 'x',
+      'mc-paste-1': 'x',
+      'theme': 'dark',
+      'lang': 'en',
+    })
+
+    render(<LocalStorageDebug />)
+
+    for (const label of [
+      'vc_heights_*',
+      'kirocrew:touched-files:*',
+      'mc-cmt-read:*',
+      'mimir-tasks:*',
+      'sort:*',
+      'mc-chat-*',
+      'mc-paste-*',
+    ]) {
+      expect(within(groupRow(label)).getByText('1')).toBeInTheDocument()
+    }
+    // `theme` and `lang` match no pattern, so they share the fallback bucket.
+    expect(within(groupRow('(static keys)')).getByText('2')).toBeInTheDocument()
+  })
+
+  it('skips a null key index and treats a missing value as empty', () => {
+    seed({ ghost: 'x', real: 'y' })
+    const origKey = Storage.prototype.key
+    vi.spyOn(Storage.prototype, 'key').mockImplementation(function (
+      this: Storage,
+      i: number,
+    ) {
+      return i === 0 ? null : origKey.call(this, i)
+    })
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => null)
+
+    render(<LocalStorageDebug />)
+
+    expect(screen.getByText('1 keys')).toBeInTheDocument()
+    expect(renderedKeys()).toEqual(['real'])
+
+    fireEvent.click(keyRow('real'))
+    const pre = keyRow('real').parentElement?.querySelector('pre')
+    expect(pre).not.toBeNull()
+    expect(pre?.textContent).toBe('')
+  })
+})
+
+// ─── usage meter ─────────────────────────────────────────────────────────────
+
+describe('LocalStorageDebug usage meter', () => {
+  it('paints the bar with the accent colour below half quota', () => {
+    seed({ tiny: 'a' })
+
+    const { container } = render(<LocalStorageDebug />)
+
+    expect(usageBar(container).className).toContain('bg-accent')
+    expect(screen.queryByText(/app may crash on next write/)).toBeNull()
+  })
+
+  it('paints the bar amber past half quota without warning yet', () => {
+    seed({ chunky: 'a'.repeat(Math.round(QUOTA * 0.6)) })
+
+    const { container } = render(<LocalStorageDebug />)
+
+    expect(usageBar(container).className).toContain('bg-warn')
+    expect(screen.queryByText(/app may crash on next write/)).toBeNull()
+  })
+
+  it('warns and clamps the bar at 100% once the store exceeds the quota', () => {
+    seed({ overflowing: 'a'.repeat(QUOTA + 1000) })
+
+    const { container } = render(<LocalStorageDebug />)
+
+    const bar = usageBar(container)
+    expect(bar.className).toContain('bg-danger')
+    expect(bar.getAttribute('style')).toContain('width: 100%')
+    expect(screen.getByText(/Storage is 100% full/)).toBeInTheDocument()
+  })
+})
+
+// ─── mutating actions ────────────────────────────────────────────────────────
+
+describe('LocalStorageDebug actions', () => {
+  it('re-scans storage when refresh is pressed', () => {
+    seed({ first: 'a' })
+
+    render(<LocalStorageDebug />)
+    expect(renderedKeys()).toEqual(['first'])
+
+    localStorage.setItem('second', 'bb')
+    fireEvent.click(screen.getByTitle('Refresh'))
+
+    expect(renderedKeys()).toEqual(['second', 'first'])
+    expect(screen.getByText('2 keys')).toBeInTheDocument()
+  })
+
+  it('deletes one key from storage and from the list', () => {
+    seed({ keep: 'a', drop: 'bbbb' })
+
+    render(<LocalStorageDebug />)
+
+    fireEvent.click(within(keyRow('drop')).getByLabelText('Delete key'))
+
+    expect(localStorage.getItem('drop')).toBeNull()
+    expect(localStorage.getItem('keep')).toBe('a')
+    expect(renderedKeys()).toEqual(['keep'])
+  })
+
+  it('offers a group delete for prefixed buckets but not for static keys', () => {
+    seed({ 'sort:alpha': 'a', 'theme': 'dark' })
+
+    render(<LocalStorageDebug />)
+
+    expect(within(groupRow('sort:*')).getByRole('button', { name: /Clear/ })).toBeInTheDocument()
+    expect(within(groupRow('(static keys)')).queryByRole('button')).toBeNull()
+  })
+
+  it('deletes every key in a group', () => {
+    seed({ 'sort:alpha': 'a', 'sort:beta': 'bb', 'theme': 'dark' })
+
+    render(<LocalStorageDebug />)
+
+    fireEvent.click(within(groupRow('sort:*')).getByRole('button', { name: /Clear/ }))
+
+    expect(localStorage.getItem('sort:alpha')).toBeNull()
+    expect(localStorage.getItem('sort:beta')).toBeNull()
+    expect(localStorage.getItem('theme')).toBe('dark')
+    expect(screen.queryByText('sort:*')).toBeNull()
+    expect(renderedKeys()).toEqual(['theme'])
+  })
+
+  it('clears only the scroll-height orphan caches', () => {
+    seed({ 'vc_heights_a': 'a', 'vc_heights_b': 'bb', 'sort:alpha': 'c' })
+
+    render(<LocalStorageDebug />)
+
+    fireEvent.click(screen.getByTitle(/Delete cached scroll positions/))
+
+    expect(localStorage.getItem('vc_heights_a')).toBeNull()
+    expect(localStorage.getItem('vc_heights_b')).toBeNull()
+    expect(localStorage.getItem('sort:alpha')).toBe('c')
+    expect(renderedKeys()).toEqual(['sort:alpha'])
+  })
+
+  it('exports every key as a downloadable JSON blob', async () => {
+    seed({ alpha: 'one', beta: 'two' })
+
+    const blobs: Blob[] = []
+    const names: string[] = []
+    const origCreate = URL.createObjectURL
+    const origRevoke = URL.revokeObjectURL
+    const revoked: string[] = []
+    URL.createObjectURL = vi.fn((b: Blob) => {
+      blobs.push(b)
+      return 'blob:ls-debug'
+    }) as typeof URL.createObjectURL
+    URL.revokeObjectURL = vi.fn((u: string) => {
+      revoked.push(u)
+    }) as typeof URL.revokeObjectURL
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(function capture(this: HTMLAnchorElement) {
+        names.push(this.download)
+      })
+
+    try {
+      render(<LocalStorageDebug />)
+      fireEvent.click(screen.getByTitle('Export JSON'))
+
+      expect(blobs).toHaveLength(1)
+      expect(blobs[0].type).toBe('application/json')
+      expect(JSON.parse(await blobs[0].text())).toEqual({ alpha: 'one', beta: 'two' })
+      expect(names).toHaveLength(1)
+      expect(names[0]).toMatch(/^kirocrew-localstorage-\d+\.json$/)
+      expect(revoked).toEqual(['blob:ls-debug'])
+    } finally {
+      clickSpy.mockRestore()
+      URL.createObjectURL = origCreate
+      URL.revokeObjectURL = origRevoke
+    }
+  })
+})
+
+// ─── value inspector ─────────────────────────────────────────────────────────
+
+describe('LocalStorageDebug inspector', () => {
+  it('expands and collapses a value on click', () => {
+    seed({ 'sort:alpha': 'stored-payload' })
+
+    render(<LocalStorageDebug />)
+    const row = keyRow('sort:alpha')
+    expect(row).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(row)
+    expect(keyRow('sort:alpha')).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('stored-payload')).toBeInTheDocument()
+
+    fireEvent.click(keyRow('sort:alpha'))
+    expect(keyRow('sort:alpha')).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText('stored-payload')).toBeNull()
+  })
+
+  it('toggles with Enter and Space, and ignores other keys', () => {
+    seed({ 'sort:alpha': 'stored-payload' })
+
+    render(<LocalStorageDebug />)
+
+    fireEvent.keyDown(keyRow('sort:alpha'), { key: 'Enter' })
+    expect(keyRow('sort:alpha')).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.keyDown(keyRow('sort:alpha'), { key: ' ' })
+    expect(keyRow('sort:alpha')).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.keyDown(keyRow('sort:alpha'), { key: 'x' })
+    expect(keyRow('sort:alpha')).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('does not toggle when the keystroke came from the delete button', () => {
+    seed({ 'sort:alpha': 'stored-payload' })
+
+    render(<LocalStorageDebug />)
+
+    fireEvent.keyDown(within(keyRow('sort:alpha')).getByLabelText('Delete key'), { key: 'Enter' })
+
+    expect(keyRow('sort:alpha')).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('truncates a value longer than 2000 characters', () => {
+    seed({ bulky: 'q'.repeat(2500) })
+
+    render(<LocalStorageDebug />)
+    fireEvent.click(keyRow('bulky'))
+
+    const pre = keyRow('bulky').parentElement?.querySelector('pre')
+    expect(pre).not.toBeNull()
+    const shown = pre?.textContent ?? ''
+    expect(shown).toContain('(truncated)')
+    expect(shown.replace(/[^q]/g, '')).toHaveLength(2000)
+  })
+
+  it('shows an untruncated value at exactly the 2000-character boundary', () => {
+    seed({ edge: 'q'.repeat(2000) })
+
+    render(<LocalStorageDebug />)
+    fireEvent.click(keyRow('edge'))
+
+    const pre = keyRow('edge').parentElement?.querySelector('pre')
+    expect(pre?.textContent).not.toContain('(truncated)')
+    expect(pre?.textContent).toHaveLength(2000)
+  })
+})
+
+// ─── filter and overflow cap ─────────────────────────────────────────────────
+
+describe('LocalStorageDebug filter', () => {
+  it('filters keys case-insensitively and restores the full list when cleared', () => {
+    seed({ 'sort:alpha': 'a', 'mc-chat-1': 'b', 'theme': 'c' })
+
+    render(<LocalStorageDebug />)
+    const input = screen.getByLabelText('Filter keys')
+
+    fireEvent.change(input, { target: { value: 'SORT:' } })
+    expect(renderedKeys()).toEqual(['sort:alpha'])
+
+    fireEvent.change(input, { target: { value: '' } })
+    expect(renderedKeys()).toHaveLength(3)
+  })
+
+  it('renders nothing when the filter matches no key', () => {
+    seed({ 'sort:alpha': 'a' })
+
+    render(<LocalStorageDebug />)
+    fireEvent.change(screen.getByLabelText('Filter keys'), { target: { value: 'nope' } })
+
+    expect(renderedKeys()).toEqual([])
+  })
+
+  it('caps the list at 200 rows and says how many were hidden', () => {
+    const pairs: Record<string, string> = {}
+    for (let i = 0; i < 201; i++) pairs[`sort:k${String(i).padStart(3, '0')}`] = 'v'
+    seed(pairs)
+
+    render(<LocalStorageDebug />)
+
+    expect(renderedKeys()).toHaveLength(200)
+    expect(screen.getByText(/Showing 200 of\s+201/)).toBeInTheDocument()
+  })
+
+  it('drops the overflow notice once the filter narrows below the cap', () => {
+    const pairs: Record<string, string> = {}
+    for (let i = 0; i < 201; i++) pairs[`sort:k${String(i).padStart(3, '0')}`] = 'v'
+    seed(pairs)
+
+    render(<LocalStorageDebug />)
+    fireEvent.change(screen.getByLabelText('Filter keys'), { target: { value: 'k00' } })
+
+    expect(renderedKeys()).toHaveLength(10)
+    expect(screen.queryByText(/Showing 200 of/)).toBeNull()
+  })
+})

--- a/website/src/test/ProjectDetailPageCoverage.test.tsx
+++ b/website/src/test/ProjectDetailPageCoverage.test.tsx
@@ -1,0 +1,592 @@
+/**
+ * Coverage suite for `ProjectDetailPage` — everything the smoke suite
+ * (`ProjectDetailPage.test.tsx`) leaves cold.
+ *
+ * That suite pins the static surface: tab bar, view toggle, idea fallback, the
+ * export button. What was untested is the whole write side, which is where a
+ * silent failure loses a user's plan edits or strands a run behind an approval
+ * gate:
+ *
+ *  - the approvals poll and its `task-gate-<n>-` id parser,
+ *  - the approval banner (rendered, suppressed, and its go-to-task jump),
+ *  - approve/reject from the DAG and from the detail panel,
+ *  - the requires_approval / force_approval toggle, including its
+ *    response-shape interpretation and its failure branch,
+ *  - the two save paths (single-task PATCH for live runs, whole-plan PUT for
+ *    stopped ones) plus override merging and the error branch,
+ *  - pending-edit bookkeeping and the reset-on-run-change effect,
+ *  - `PlanningOverlay`'s ticking dots.
+ *
+ * Harness notes, all deliberate:
+ *  1. The three `aidlc` children are replaced by stubs that expose each
+ *     callback as a button and each interesting prop as a data attribute. The
+ *     real DagView lays out with measured geometry and TaskDetailPanel owns its
+ *     own edit form; neither is under test here, and going through them would
+ *     make these assertions about their internals instead of this page's.
+ *  2. framer-motion renders as plain DOM so the detail panel mounts and
+ *     unmounts synchronously — a real exit transition would make
+ *     "the selection cleared" pass or fail on timing.
+ *  3. The api client is automocked; every test sets the responses it needs.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, waitFor, act } from '@testing-library/react'
+import type { ProjectRun, TaskDetail } from '../types'
+
+vi.mock('../api/client')
+
+/* Render framer-motion elements as plain DOM (see harness note 2). */
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'initial', 'animate', 'exit', 'transition',
+    'variants', 'whileHover', 'whileTap', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: Record<string, unknown>, ref: React.Ref<unknown>) => {
+      const clean: Record<string, unknown> = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children' || FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children as React.ReactNode)
+    })
+  const cache = new Map<string, unknown>()
+  return {
+    motion: new Proxy({}, {
+      get: (_t, tag: string) => {
+        if (!cache.has(tag)) cache.set(tag, make(tag))
+        return cache.get(tag)
+      },
+    }),
+    AnimatePresence: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    useReducedMotion: () => false,
+  }
+})
+
+/** Update payload the stub panel sends on its next save / edit click. */
+let nextSave = { title: 'Renamed', description: 'New body', depends_on: [] as number[] }
+/** Resolved values of every `onToggleApproval` call, oldest first. */
+const toggleResults: boolean[] = []
+/** Resolved override (JSON) or `err:<reason>` for every `onSave` call. */
+const saveResults: string[] = []
+
+interface DagNodeStub { id: string; title: string; status: string; requires_approval?: boolean }
+
+vi.mock('../pages/aidlc/DagView', () => ({
+  default: ({ nodes, edges, onNodeClick, selectedId, pendingEditIds, approvalMap, onApprove }: {
+    nodes: DagNodeStub[]
+    edges: { from: string; to: string }[]
+    onNodeClick: (id: string) => void
+    selectedId?: string
+    pendingEditIds?: Set<string>
+    approvalMap?: Record<number, string>
+    onApprove?: (index: number, decision: 'approve' | 'reject') => void
+  }) => (
+    <div
+      data-testid="dag-view"
+      data-selected={selectedId ?? ''}
+      data-pending={[...(pendingEditIds ?? [])].sort().join(',')}
+      data-approvals={approvalMap ? Object.keys(approvalMap).sort().join(',') : 'none'}
+      data-edges={edges.map(e => `${e.from}>${e.to}`).sort().join(',')}
+    >
+      {nodes.map(n => (
+        <div key={n.id}>
+          <span>{`title-${n.id}:${n.title}`}</span>
+          {/* One action per row. AUTOSDE `max-two-buttons-per-row` is blocking and
+              its file-patterns match .tsx files under src, test files included, so
+              even a vi.mock stub cannot park three sibling actions in one group.
+              Each button is only a callback entry point here, so the extra
+              wrappers cost the test nothing. */}
+          <div>
+            <button type="button" onClick={() => onNodeClick(n.id)}>{`pick-${n.id}`}</button>
+          </div>
+          <div>
+            <button
+              type="button"
+              onClick={() => onApprove?.(Number(n.id), 'approve')}
+            >{`dag-ok-${n.id}`}</button>
+          </div>
+          <div>
+            <button
+              type="button"
+              onClick={() => onApprove?.(Number(n.id), 'reject')}
+            >{`dag-no-${n.id}`}</button>
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('../pages/aidlc/PhasedView', () => ({
+  default: ({ tasks, onTaskClick, selectedIndex, pendingEditIndexes }: {
+    tasks: TaskDetail[]
+    onTaskClick?: (index: number) => void
+    selectedIndex?: number | null
+    pendingEditIndexes?: Set<number>
+  }) => (
+    <div
+      data-testid="phased-view"
+      data-selected={selectedIndex ?? ''}
+      data-pending={[...(pendingEditIndexes ?? [])].sort().join(',')}
+    >
+      {tasks.map(t => (
+        <div key={t.index}>
+          <button type="button" onClick={() => onTaskClick?.(t.index)}>{`phase-pick-${t.index}`}</button>
+        </div>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('../pages/aidlc/TaskDetailPanel', () => ({
+  default: ({ task, allTasks, onClose, onApprove, onToggleApproval, editable, onSave, pendingEdits, onEdit }: {
+    task: TaskDetail
+    allTasks?: TaskDetail[]
+    onClose: () => void
+    onApprove?: (decision: 'approve' | 'reject') => void
+    onToggleApproval?: (index: number, field: 'requires_approval' | 'force_approval', value: boolean) => Promise<boolean>
+    editable?: boolean
+    onSave?: (index: number, updates: { title: string; description: string; depends_on: number[] }) => Promise<{ title: string; description: string; depends_on: number[] } | void>
+    pendingEdits?: Record<number, { title: string; description: string; depends_on: number[] }>
+    onEdit?: (index: number, updates?: { title: string; description: string; depends_on: number[] }) => void
+  }) => (
+    <div
+      data-testid="task-panel"
+      data-editable={String(!!editable)}
+      data-all-tasks={String((allTasks ?? []).length)}
+      data-pending={Object.keys(pendingEdits ?? {}).sort().join(',')}
+    >
+      <span>{`panel-task:${task.index}:${task.title}`}</span>
+      <div>
+        <button type="button" onClick={onClose}>panel-close</button>
+      </div>
+      {onApprove && (
+        <>
+          <div>
+            <button type="button" onClick={() => onApprove('approve')}>panel-approve</button>
+          </div>
+          <div>
+            <button type="button" onClick={() => onApprove('reject')}>panel-reject</button>
+          </div>
+        </>
+      )}
+      {onToggleApproval && (
+        <>
+          <div>
+            <button
+              type="button"
+              onClick={() => { void onToggleApproval(task.index, 'requires_approval', false).then(r => { toggleResults.push(r) }) }}
+            >toggle-req-off</button>
+          </div>
+          <div>
+            <button
+              type="button"
+              onClick={() => { void onToggleApproval(task.index, 'force_approval', true).then(r => { toggleResults.push(r) }) }}
+            >toggle-force-on</button>
+          </div>
+        </>
+      )}
+      <div>
+        <button
+          type="button"
+          onClick={() => {
+            void onSave?.(task.index, nextSave)
+              .then(r => { saveResults.push(JSON.stringify(r ?? null)) })
+              .catch((e: unknown) => { saveResults.push(`err:${e instanceof Error ? e.message : String(e)}`) })
+          }}
+        >panel-save</button>
+      </div>
+      <div>
+        <button type="button" onClick={() => onEdit?.(task.index, nextSave)}>panel-edit</button>
+      </div>
+      <div>
+        <button type="button" onClick={() => onEdit?.(task.index, undefined)}>panel-unedit</button>
+      </div>
+    </div>
+  ),
+}))
+
+import ProjectDetailPage from '../pages/ProjectDetailPage'
+import { renderWithProviders } from './helpers'
+import { api } from '../api/client'
+
+const step = (over: Partial<TaskDetail> = {}): TaskDetail => ({
+  index: 1, title: 'Setup', description: 'Init', status: 'pending', error: '', result: '',
+  attempts: 0, depends_on: [], requires_approval: false, ...over,
+})
+
+const mockRun = (overrides: Partial<ProjectRun> = {}): ProjectRun => ({
+  task_id: 'run-1', name: 'Test Run', running: false, status: 'planned',
+  steps: 3, completed: 0, failed: 0, skipped: 0, current_step: 0,
+  spec: 'test.md', spec_name: 'Test', error: '',
+  tokens_used: 0, replan_count: 0,
+  started_at: 1_700_000_000, finished_at: 0,
+  work_dir: '/tmp/test', branch_name: 'trunk', spec_content: '# Test spec',
+  lessons_learned: [], commits: 0, original_input: 'test input', source: 'text',
+  groups: [[1, 2], [3]],
+  task_details: [
+    step({ index: 1, title: 'Setup', description: 'Init' }),
+    step({ index: 2, title: 'Build', description: 'Compile', depends_on: [1] }),
+    step({ index: 3, title: 'Verify', description: 'Check', depends_on: [1, 2] }),
+  ],
+  ...overrides,
+})
+
+/** An approvals payload gating `indexes`, plus one id the parser must ignore. */
+const gates = (...indexes: number[]) => [
+  { id: 'tool-call-9', source: 'chat' },
+  ...indexes.map(i => ({ id: `task-gate-${i}-abc`, source: 'taskrunner' })),
+]
+
+const dag = () => screen.getByTestId('dag-view')
+
+/* PlanningOverlay runs a 500ms setInterval, and the approvals query polls every
+ * 3s. Both outlive a test that ends mid-tick; on a torn-down environment their
+ * callbacks throw "window is not defined" as an UNHANDLED error, which reddens
+ * CI with every test still reported as passing. Fake timers keep them off the
+ * real clock and clearAllTimers drops the pending ones at teardown;
+ * shouldAdvanceTime keeps waitFor and the polls behaving as they do live. */
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  toggleResults.length = 0
+  saveResults.length = 0
+  nextSave = { title: 'Renamed', description: 'New body', depends_on: [] }
+  vi.mocked(api.approvals).mockResolvedValue([])
+  // ThemeProvider boots through the same automocked client; without a value its
+  // query logs "Query data cannot be undefined" on every render.
+  vi.mocked(api.themeBoot).mockResolvedValue({})
+  vi.mocked(api.resolveApproval).mockResolvedValue({ ok: true })
+  vi.mocked(api.updateTask).mockResolvedValue({ ok: true, title: 'Renamed', description: 'New body', depends_on: [] })
+  vi.mocked(api.updatePlan).mockResolvedValue({ steps: [] })
+  vi.mocked(api.exportPlanYaml).mockResolvedValue(undefined)
+})
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('ProjectDetailPage approvals poll and banner', () => {
+  it('parses task-gate ids into a per-task map and ignores unrelated approvals', async () => {
+    vi.mocked(api.approvals).mockResolvedValue(gates(2))
+    renderWithProviders(<ProjectDetailPage run={mockRun({ status: 'running', running: true })} />)
+    await waitFor(() => expect(dag()).toHaveAttribute('data-approvals', '2'), { timeout: 5_000 })
+  })
+
+  it('does not poll approvals or pass a map to the DAG for a stopped run', async () => {
+    renderWithProviders(<ProjectDetailPage run={mockRun({ status: 'planned' })} />)
+    expect(dag()).toHaveAttribute('data-approvals', 'none')
+    await act(async () => { await vi.advanceTimersByTimeAsync(4_000) })
+    expect(api.approvals).not.toHaveBeenCalled()
+  })
+
+  it('banners the first gated task that is actually in progress', async () => {
+    vi.mocked(api.approvals).mockResolvedValue(gates(2))
+    renderWithProviders(
+      <ProjectDetailPage run={mockRun({
+        status: 'running',
+        task_details: [step({ index: 1 }), step({ index: 2, title: 'Build', status: 'in_progress' })],
+      })} />,
+    )
+    expect(await screen.findByRole('button', { name: /Go to Task/ }, { timeout: 5_000 })).toBeInTheDocument()
+    expect(screen.getByText(/Task 2 .*is waiting for your decision/)).toBeInTheDocument()
+  })
+
+  it('suppresses the banner when the gated task has not reached in_progress', async () => {
+    vi.mocked(api.approvals).mockResolvedValue(gates(2))
+    renderWithProviders(
+      <ProjectDetailPage run={mockRun({
+        status: 'running',
+        task_details: [step({ index: 1 }), step({ index: 2, title: 'Build', status: 'pending' })],
+      })} />,
+    )
+    await waitFor(() => expect(dag()).toHaveAttribute('data-approvals', '2'), { timeout: 5_000 })
+    expect(screen.queryByRole('button', { name: /Go to Task/ })).not.toBeInTheDocument()
+  })
+
+  it('jumps to the gated task from the banner', async () => {
+    vi.mocked(api.approvals).mockResolvedValue(gates(2))
+    renderWithProviders(
+      <ProjectDetailPage run={mockRun({
+        status: 'running',
+        task_details: [step({ index: 1 }), step({ index: 2, title: 'Build', status: 'in_progress' })],
+      })} />,
+    )
+    fireEvent.click(await screen.findByRole('button', { name: /Go to Task/ }, { timeout: 5_000 }))
+    expect(screen.getByText('panel-task:2:Build')).toBeInTheDocument()
+    expect(dag()).toHaveAttribute('data-selected', '2')
+  })
+})
+
+describe('ProjectDetailPage approve and reject', () => {
+  const runningRun = (over: Partial<ProjectRun> = {}) => mockRun({
+    status: 'running',
+    running: true,
+    task_details: [
+      step({ index: 1, title: 'Setup', status: 'in_progress' }),
+      step({ index: 2, title: 'Build', status: 'pending' }),
+    ],
+    ...over,
+  })
+
+  it('resolves a gate approved from the DAG and refreshes the run', async () => {
+    vi.mocked(api.approvals).mockResolvedValue(gates(1))
+    const onRefresh = vi.fn()
+    renderWithProviders(<ProjectDetailPage run={runningRun()} onRefresh={onRefresh} />)
+    await waitFor(() => expect(dag()).toHaveAttribute('data-approvals', '1'), { timeout: 5_000 })
+    fireEvent.click(screen.getByRole('button', { name: 'dag-ok-1' }))
+    await waitFor(() => expect(api.resolveApproval).toHaveBeenCalledWith('task-gate-1-abc', 'approve'), { timeout: 5_000 })
+    await waitFor(() => expect(onRefresh).toHaveBeenCalled(), { timeout: 5_000 })
+  })
+
+  it('opens the rejected task in the panel so the user can see why', async () => {
+    vi.mocked(api.approvals).mockResolvedValue(gates(1))
+    renderWithProviders(<ProjectDetailPage run={runningRun()} />)
+    await waitFor(() => expect(dag()).toHaveAttribute('data-approvals', '1'), { timeout: 5_000 })
+    fireEvent.click(screen.getByRole('button', { name: 'dag-no-1' }))
+    expect(await screen.findByText('panel-task:1:Setup', undefined, { timeout: 5_000 })).toBeInTheDocument()
+    expect(api.resolveApproval).toHaveBeenCalledWith('task-gate-1-abc', 'reject')
+  })
+
+  it('makes no request when the DAG approves a task that has no gate', async () => {
+    vi.mocked(api.approvals).mockResolvedValue(gates(1))
+    renderWithProviders(<ProjectDetailPage run={runningRun()} />)
+    await waitFor(() => expect(dag()).toHaveAttribute('data-approvals', '1'), { timeout: 5_000 })
+    fireEvent.click(screen.getByRole('button', { name: 'dag-ok-2' }))
+    await act(async () => { await vi.advanceTimersByTimeAsync(50) })
+    expect(api.resolveApproval).not.toHaveBeenCalled()
+  })
+
+  it('resolves the gate from the detail panel and keeps it open on reject', async () => {
+    vi.mocked(api.approvals).mockResolvedValue(gates(1))
+    renderWithProviders(<ProjectDetailPage run={runningRun()} />)
+    await waitFor(() => expect(dag()).toHaveAttribute('data-approvals', '1'), { timeout: 5_000 })
+    fireEvent.click(screen.getByRole('button', { name: 'pick-1' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'panel-approve' }, { timeout: 5_000 }))
+    await waitFor(() => expect(api.resolveApproval).toHaveBeenCalledWith('task-gate-1-abc', 'approve'), { timeout: 5_000 })
+    fireEvent.click(screen.getByRole('button', { name: 'panel-reject' }))
+    await waitFor(() => expect(api.resolveApproval).toHaveBeenCalledWith('task-gate-1-abc', 'reject'), { timeout: 5_000 })
+    expect(screen.getByTestId('task-panel')).toBeInTheDocument()
+  })
+
+  it('wires no approve action into the panel for an ungated task', async () => {
+    vi.mocked(api.approvals).mockResolvedValue(gates(1))
+    renderWithProviders(<ProjectDetailPage run={runningRun()} />)
+    await waitFor(() => expect(dag()).toHaveAttribute('data-approvals', '1'), { timeout: 5_000 })
+    fireEvent.click(screen.getByRole('button', { name: 'pick-2' }))
+    expect(await screen.findByTestId('task-panel', undefined, { timeout: 5_000 })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'panel-approve' })).not.toBeInTheDocument()
+  })
+})
+
+describe('ProjectDetailPage approval toggles', () => {
+  const openPanel = async (run: ProjectRun) => {
+    const rendered = renderWithProviders(<ProjectDetailPage run={run} />)
+    fireEvent.click(screen.getByRole('button', { name: 'pick-1' }))
+    await screen.findByTestId('task-panel', undefined, { timeout: 5_000 })
+    return rendered
+  }
+
+  it('clears force_approval alongside requires_approval and reports success', async () => {
+    const onRefresh = vi.fn()
+    renderWithProviders(<ProjectDetailPage run={mockRun()} onRefresh={onRefresh} />)
+    fireEvent.click(screen.getByRole('button', { name: 'pick-1' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'toggle-req-off' }, { timeout: 5_000 }))
+    await waitFor(() => expect(toggleResults).toEqual([true]), { timeout: 5_000 })
+    expect(api.updateTask).toHaveBeenCalledWith('run-1', 1, { requires_approval: false, force_approval: false })
+    expect(onRefresh).toHaveBeenCalled()
+  })
+
+  it('sends force_approval on its own, and treats an ok-less response as success', async () => {
+    vi.mocked(api.updateTask).mockResolvedValue({ index: 1 })
+    await openPanel(mockRun())
+    fireEvent.click(screen.getByRole('button', { name: 'toggle-force-on' }))
+    await waitFor(() => expect(toggleResults).toEqual([true]), { timeout: 5_000 })
+    expect(api.updateTask).toHaveBeenCalledWith('run-1', 1, { force_approval: true })
+  })
+
+  it('reports failure when the server answers ok: false', async () => {
+    vi.mocked(api.updateTask).mockResolvedValue({ ok: false })
+    await openPanel(mockRun())
+    fireEvent.click(screen.getByRole('button', { name: 'toggle-force-on' }))
+    await waitFor(() => expect(toggleResults).toEqual([false]), { timeout: 5_000 })
+  })
+
+  it('reports failure when the request itself fails', async () => {
+    vi.mocked(api.updateTask).mockRejectedValue(new Error('patch refused'))
+    await openPanel(mockRun())
+    fireEvent.click(screen.getByRole('button', { name: 'toggle-force-on' }))
+    await waitFor(() => expect(toggleResults).toEqual([false]), { timeout: 5_000 })
+  })
+
+  it('withholds the toggle for a run whose plan can no longer change', async () => {
+    renderWithProviders(<ProjectDetailPage run={mockRun({ status: 'completed' })} />)
+    fireEvent.click(screen.getByRole('button', { name: 'pick-1' }))
+    const panel = await screen.findByTestId('task-panel', undefined, { timeout: 5_000 })
+    expect(panel).toHaveAttribute('data-editable', 'false')
+    expect(screen.queryByRole('button', { name: 'toggle-force-on' })).not.toBeInTheDocument()
+  })
+
+  it('keeps a live run editable only while the task is still pending', async () => {
+    const live = mockRun({
+      status: 'running',
+      task_details: [step({ index: 1, status: 'in_progress' }), step({ index: 2, title: 'Build', status: 'pending' })],
+    })
+    renderWithProviders(<ProjectDetailPage run={live} />)
+    fireEvent.click(screen.getByRole('button', { name: 'pick-1' }))
+    expect(await screen.findByTestId('task-panel', undefined, { timeout: 5_000 })).toHaveAttribute('data-editable', 'false')
+    fireEvent.click(screen.getByRole('button', { name: 'pick-2' }))
+    await waitFor(() => expect(screen.getByTestId('task-panel')).toHaveAttribute('data-editable', 'true'), { timeout: 5_000 })
+  })
+})
+
+describe('ProjectDetailPage saving task edits', () => {
+  it('patches a single task for a live run and shows the returned title', async () => {
+    const live = mockRun({ status: 'running', task_details: [step({ index: 1, status: 'pending' })] })
+    vi.mocked(api.updateTask).mockResolvedValue({ title: 'Server title', description: 'Server body', depends_on: [] })
+    renderWithProviders(<ProjectDetailPage run={live} />)
+    fireEvent.click(screen.getByRole('button', { name: 'pick-1' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'panel-save' }, { timeout: 5_000 }))
+    await waitFor(() => expect(api.updateTask).toHaveBeenCalledWith('run-1', 1, nextSave), { timeout: 5_000 })
+    await waitFor(() => expect(screen.getByText('title-1:Server title')).toBeInTheDocument(), { timeout: 5_000 })
+    expect(saveResults).toEqual([JSON.stringify({ title: 'Server title', description: 'Server body', depends_on: [] })])
+  })
+
+  it('rewrites the whole plan for a stopped run and folds earlier saves into the payload', async () => {
+    vi.mocked(api.updatePlan).mockImplementation(async (_id: string, steps: unknown) => ({
+      steps: (steps as { title: string; description: string; depends_on: number[] }[]).map((s, i) => ({
+        index: i + 1, title: s.title, description: s.description, depends_on: s.depends_on,
+      })),
+    }))
+    renderWithProviders(<ProjectDetailPage run={mockRun()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'pick-1' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'panel-save' }, { timeout: 5_000 }))
+    await waitFor(() => expect(screen.getByText('title-1:Renamed')).toBeInTheDocument(), { timeout: 5_000 })
+
+    // Second save on a different task: the payload must still carry task 1's
+    // saved override, otherwise the first edit is silently rolled back.
+    nextSave = { title: 'Second', description: 'Second body', depends_on: [1] }
+    fireEvent.click(screen.getByRole('button', { name: 'pick-2' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'panel-save' }, { timeout: 5_000 }))
+    await waitFor(() => expect(screen.getByText('title-2:Second')).toBeInTheDocument(), { timeout: 5_000 })
+
+    expect(api.updatePlan).toHaveBeenCalledTimes(2)
+    const secondPayload = vi.mocked(api.updatePlan).mock.calls[1][1] as { title: string }[]
+    expect(secondPayload.map(s => s.title)).toEqual(['Renamed', 'Second', 'Verify'])
+    expect(screen.getByText('title-1:Renamed')).toBeInTheDocument()
+  })
+
+  it('keeps the local edit when the plan response omits the saved step', async () => {
+    vi.mocked(api.updatePlan).mockResolvedValue({})
+    renderWithProviders(<ProjectDetailPage run={mockRun()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'pick-1' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'panel-save' }, { timeout: 5_000 }))
+    await waitFor(() => expect(screen.getByText('title-1:Renamed')).toBeInTheDocument(), { timeout: 5_000 })
+    expect(saveResults).toEqual([JSON.stringify(nextSave)])
+  })
+
+  it('surfaces a failed plan rewrite to the caller instead of swallowing it', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(api.updatePlan).mockRejectedValue(new Error('plan locked'))
+    renderWithProviders(<ProjectDetailPage run={mockRun()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'pick-1' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'panel-save' }, { timeout: 5_000 }))
+    await waitFor(() => expect(saveResults).toEqual(['err:plan locked']), { timeout: 5_000 })
+    expect(err).toHaveBeenCalled()
+    expect(screen.getByText('title-1:Setup')).toBeInTheDocument()
+    err.mockRestore()
+  })
+})
+
+describe('ProjectDetailPage pending edits and selection', () => {
+  it('tracks a pending edit for both views and drops it when it is reverted', async () => {
+    renderWithProviders(<ProjectDetailPage run={mockRun()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'pick-2' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'panel-edit' }, { timeout: 5_000 }))
+    await waitFor(() => expect(dag()).toHaveAttribute('data-pending', '2'), { timeout: 5_000 })
+    expect(screen.getByTestId('task-panel')).toHaveAttribute('data-pending', '2')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Phased' }))
+    expect(screen.getByTestId('phased-view')).toHaveAttribute('data-pending', '2')
+
+    fireEvent.click(screen.getByRole('button', { name: 'panel-unedit' }))
+    await waitFor(() => expect(screen.getByTestId('phased-view')).toHaveAttribute('data-pending', ''), { timeout: 5_000 })
+  })
+
+  it('selects from the phased view and closes from the panel', async () => {
+    renderWithProviders(<ProjectDetailPage run={mockRun()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Phased' }))
+    fireEvent.click(screen.getByRole('button', { name: 'phase-pick-3' }))
+    expect(await screen.findByText('panel-task:3:Verify', undefined, { timeout: 5_000 })).toBeInTheDocument()
+    expect(screen.getByTestId('phased-view')).toHaveAttribute('data-selected', '3')
+    expect(screen.getByTestId('task-panel')).toHaveAttribute('data-all-tasks', '3')
+
+    fireEvent.click(screen.getByRole('button', { name: 'panel-close' }))
+    await waitFor(() => expect(screen.queryByTestId('task-panel')).not.toBeInTheDocument(), { timeout: 5_000 })
+  })
+
+  it('clears the selection and pending edits when the run changes', async () => {
+    const { rerender } = renderWithProviders(<ProjectDetailPage run={mockRun()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'pick-1' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'panel-edit' }, { timeout: 5_000 }))
+    await waitFor(() => expect(dag()).toHaveAttribute('data-pending', '1'), { timeout: 5_000 })
+
+    rerender(<ProjectDetailPage run={mockRun({ task_id: 'run-2' })} />)
+    await waitFor(() => expect(screen.queryByTestId('task-panel')).not.toBeInTheDocument(), { timeout: 5_000 })
+    expect(dag()).toHaveAttribute('data-pending', '')
+  })
+
+  it('feeds the DAG one edge per dependency', () => {
+    renderWithProviders(<ProjectDetailPage run={mockRun()} />)
+    expect(dag()).toHaveAttribute('data-edges', '1>2,1>3,2>3')
+  })
+})
+
+describe('ProjectDetailPage idea tab and export', () => {
+  it('hands the idea to the chat composer', () => {
+    const { store } = renderWithProviders(<ProjectDetailPage run={mockRun()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Idea' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit in Chat' }))
+    expect(store.getState().chat.pendingInput).toBe('# Test spec')
+  })
+
+  it('returns from the idea tab to the DAG after a detour through the phased view', () => {
+    renderWithProviders(<ProjectDetailPage run={mockRun()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Phased' }))
+    fireEvent.click(screen.getByRole('button', { name: 'DAG' }))
+    expect(screen.getByTestId('dag-view')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Idea' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Tasks' }))
+    expect(screen.getByTestId('dag-view')).toBeInTheDocument()
+  })
+
+  it('logs an export failure and re-enables the button', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(api.exportPlanYaml).mockRejectedValue(new Error('no plan'))
+    renderWithProviders(<ProjectDetailPage run={mockRun()} />)
+    fireEvent.click(screen.getByRole('button', { name: /Export YAML/ }))
+    await waitFor(() => expect(err).toHaveBeenCalled(), { timeout: 5_000 })
+    await waitFor(() => expect(screen.getByRole('button', { name: /Export YAML/ })).toBeEnabled(), { timeout: 5_000 })
+    err.mockRestore()
+  })
+})
+
+describe('ProjectDetailPage planning overlay', () => {
+  it('ticks the dots and hides the view toggle while planning', async () => {
+    renderWithProviders(<ProjectDetailPage run={mockRun({ status: 'planning' })} />)
+    const line = screen.getByText(/Generating execution plan/)
+    expect(line.textContent).toBe('Generating execution plan')
+    expect(screen.queryByRole('button', { name: 'DAG' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Export YAML/ })).not.toBeInTheDocument()
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(600) })
+    expect(line.textContent).toMatch(/^Generating execution plan\.{1,3}$/)
+
+    // Four more ticks are guaranteed to cross the reset branch (dots >= 3 -> '').
+    await act(async () => { await vi.advanceTimersByTimeAsync(2_100) })
+    expect(line.textContent).toMatch(/^Generating execution plan\.{0,3}$/)
+  })
+})

--- a/website/src/test/SettingsRemoteCrewPanelCoverage.test.tsx
+++ b/website/src/test/SettingsRemoteCrewPanelCoverage.test.tsx
@@ -1,0 +1,632 @@
+/**
+ * RemoteCrewPanel — coverage for the paths the behavioural suite leaves alone:
+ * the instance CRUD mutations (connect / disconnect / remove / diagnose) and
+ * every mutation's failure branch, the copy-to-clipboard affordances and their
+ * 1.5s revert, the enable-the-feature gate, the sign-in fetch when a job carries
+ * no prompt, a failed launch's card, and the pruning of a finished teardown.
+ *
+ * Kept separate from RemoteCrewPanel.test.tsx so the behavioural file stays a
+ * readable record of the defects it was written for.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createTestStore, renderWithProviders } from './helpers'
+import type {
+  CloudPreflight,
+  InstanceView,
+  InstanceTunnelStatus,
+  LaunchJob,
+} from '../api/client'
+import { RemoteCrewPanel } from '../pages/settings/RemoteCrewPanel'
+
+vi.mock('../api/client', () => {
+  class ApiError extends Error {
+    status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.status = status
+    }
+  }
+  return {
+    ApiError,
+    api: {
+      listInstances: vi.fn(),
+      addInstance: vi.fn(),
+      connectInstance: vi.fn(),
+      disconnectInstance: vi.fn(),
+      removeInstance: vi.fn(),
+      instanceStatus: vi.fn(),
+      patchConfig: vi.fn(),
+      cloudLaunches: vi.fn(),
+      cloudPreflight: vi.fn(),
+      cloudIamPolicy: vi.fn(),
+      cloudLaunch: vi.fn(),
+      cloudLaunchStatus: vi.fn(),
+      cloudLaunchCancel: vi.fn(),
+      cloudLaunchSignin: vi.fn(),
+      cloudStop: vi.fn(),
+      cloudStart: vi.fn(),
+      cloudDestroy: vi.fn(),
+    },
+  }
+})
+// The real helper falls back to a textarea + execCommand when the Clipboard API
+// is absent, and happy-dom implements neither — the fallback would reject and
+// surface as an unhandled rejection, which reddens CI with a green summary.
+vi.mock('../utils/clipboard', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(undefined),
+  copyCode: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { api, ApiError } from '../api/client'
+import { copyToClipboard } from '../utils/clipboard'
+
+const CLOUD_INSTANCE: InstanceView = {
+  id: 'kc1',
+  name: 'Kiro Crew Cloud (kc-3f9a)',
+  connection_method: 'ssm',
+  ssm_target: 'i-0abc123456789def0',
+  ssh_host: '',
+  aws_profile: 'Admin',
+  aws_region: 'us-west-2',
+  ssm_run_as: '',
+  remote_port: 5476,
+  local_port: 0,
+  ttl: '20h',
+  remote_bin: '',
+  was_connected: true,
+  status: { instance_id: 'i-0abc123456789def0', state: 'connected' },
+}
+const MANUAL_INSTANCE: InstanceView = {
+  id: 'm1',
+  name: 'dev-box-1',
+  connection_method: 'ssh',
+  ssm_target: '',
+  ssh_host: 'dev-box-1',
+  aws_profile: '',
+  aws_region: '',
+  ssm_run_as: '',
+  remote_port: 5476,
+  local_port: 0,
+  ttl: '20h',
+  remote_bin: '',
+  was_connected: false,
+  status: { instance_id: 'm1', state: 'disconnected' },
+}
+const CONNECTED_MANUAL: InstanceView = {
+  ...MANUAL_INSTANCE,
+  status: { instance_id: 'm1', state: 'connected' },
+}
+const DONE_JOB: LaunchJob = {
+  id: 'j-done',
+  tag: 'kc-3f9a',
+  instance_id: 'i-0abc123456789def0',
+  profile: 'Admin',
+  region: 'us-west-2',
+  size_key: 'balanced',
+  status: 'done',
+  steps: [],
+  signin: null,
+  created_at: 0,
+  updated_at: 0,
+}
+const RUNNING_JOB: LaunchJob = {
+  id: 'j-run',
+  tag: 'kc-4d10',
+  profile: '',
+  region: 'us-east-1',
+  size_key: 'light',
+  status: 'running',
+  signin: null,
+  created_at: 0,
+  updated_at: 0,
+  steps: [
+    { key: 'preflight', label: 'Checked your AWS setup', state: 'done' },
+    { key: 'provision', label: 'Created the instance', state: 'active' },
+    { key: 'connect', label: 'Connect', state: 'pending' },
+  ],
+}
+const PREFLIGHT_OK: CloudPreflight = {
+  reachable: true,
+  account: '1234•••7890',
+  arn: 'arn:aws:iam::x:user/dev',
+  ec2_reachable: true,
+  cloudformation_reachable: true,
+  ssm_reachable: true,
+  session_manager_plugin: true,
+  note: '',
+  detail: '',
+}
+
+const list = (instances: InstanceView[], extra: { active?: boolean; warm_set_cap?: number } = {}) => ({
+  active: extra.active ?? true,
+  warm_set_cap: extra.warm_set_cap ?? 5,
+  instances,
+})
+
+/** A store whose instances slice already holds a warm connection for `id`. */
+function storeWithWarm(id: string) {
+  const base = createTestStore().getState()
+  return createTestStore({
+    ...base,
+    instances: {
+      ...base.instances,
+      warm: { [id]: { port: 41234, token: 'stub' } },
+      mru: [id],
+      activeId: id,
+    },
+  })
+}
+
+const setup = () => userEvent.setup({ advanceTimers: (ms: number) => { vi.advanceTimersByTime(ms) } })
+
+/** Open the "Set up a new one" tab. */
+async function openSetupTab(u: ReturnType<typeof setup>) {
+  await u.click(await screen.findByRole('button', { name: /Set up a new one/i }))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  // The copy affordances schedule a 1.5s revert. Without fake timers that
+  // callback fires after teardown and throws as an unhandled error.
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.mocked(api.cloudLaunches).mockResolvedValue({ jobs: [] })
+  vi.mocked(api.cloudPreflight).mockResolvedValue(PREFLIGHT_OK)
+  // The status query is enabled by the mere existence of a persisted job, so a
+  // test that only cares about the crew list still polls it — an unmocked
+  // resolve returns undefined, which React Query rejects noisily.
+  vi.mocked(api.cloudLaunchStatus).mockResolvedValue(DONE_JOB)
+})
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+describe('RemoteCrewPanel — instance actions', () => {
+  it('reports progress on the clicked Connect, then explains a connect that did not finish', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([MANUAL_INSTANCE]))
+    let release: (v: InstanceTunnelStatus) => void = () => {}
+    vi.mocked(api.connectInstance).mockReturnValue(
+      new Promise<InstanceTunnelStatus>(r => { release = r }) as ReturnType<typeof api.connectInstance>,
+    )
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    await u.click(await screen.findByRole('button', { name: 'Connect' }))
+    // The busy key is per-instance, so the clicked row is the one that changes.
+    expect(await screen.findByRole('button', { name: /Connecting/ })).toBeInTheDocument()
+
+    // A resolved-but-not-connected tunnel with no error of its own falls back to
+    // the "try Diagnose" hint rather than showing an empty banner.
+    release({ instance_id: 'm1', state: 'error' })
+    expect(await screen.findByText(/Connection did not complete/i, undefined, { timeout: 5_000 })).toBeInTheDocument()
+
+    await u.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(screen.queryByText(/Connection did not complete/i)).not.toBeInTheDocument()
+  })
+
+  it('names the instance and the reason when Connect fails outright', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([MANUAL_INSTANCE]))
+    vi.mocked(api.connectInstance).mockRejectedValue(new ApiError(502, 'ssm tunnel refused'))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    await u.click(await screen.findByRole('button', { name: 'Connect' }))
+    expect(await screen.findByText(/Connect to m1 failed: ssm tunnel refused/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('drops the warm connection from the store when a crew is disconnected', async () => {
+    // The warm entry holds the loopback port for a mounted pane. Leaving it
+    // behind would keep a dead iframe in the switcher after the tunnel is gone.
+    vi.mocked(api.listInstances).mockResolvedValue(list([CONNECTED_MANUAL]))
+    vi.mocked(api.disconnectInstance).mockResolvedValue({ disconnected: 'm1', was_connected: true })
+    const u = setup()
+    const store = storeWithWarm('m1')
+    renderWithProviders(<RemoteCrewPanel />, { store })
+
+    await u.click(await screen.findByRole('button', { name: 'Disconnect' }))
+    await waitFor(() => expect(api.disconnectInstance).toHaveBeenCalledWith('m1'))
+    await waitFor(() => expect(store.getState().instances.warm).not.toHaveProperty('m1'))
+    expect(store.getState().instances.activeId).toBeNull()
+  })
+
+  it('surfaces a failed disconnect instead of leaving the row looking disconnected', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([CONNECTED_MANUAL]))
+    vi.mocked(api.disconnectInstance).mockRejectedValue(new Error('socket already gone'))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    await u.click(await screen.findByRole('button', { name: 'Disconnect' }))
+    expect(await screen.findByText(/Disconnect of m1 failed: socket already gone/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('removes a hand-added machine even when the pre-emptive disconnect fails', async () => {
+    // Remove disconnects first and swallows that failure on purpose: a tunnel
+    // that is already dead must not block unregistering the machine.
+    vi.mocked(api.listInstances).mockResolvedValue(list([MANUAL_INSTANCE]))
+    vi.mocked(api.disconnectInstance).mockRejectedValue(new Error('not connected'))
+    vi.mocked(api.removeInstance).mockResolvedValue({ removed: 'm1' } as never)
+    const u = setup()
+    const store = storeWithWarm('m1')
+    renderWithProviders(<RemoteCrewPanel />, { store })
+
+    await u.click(await screen.findByRole('button', { name: 'Remove dev-box-1' }))
+    await waitFor(() => expect(api.removeInstance).toHaveBeenCalledWith('m1'))
+    await waitFor(() => expect(store.getState().instances.warm).not.toHaveProperty('m1'))
+  })
+
+  it('surfaces a failed remove', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([MANUAL_INSTANCE]))
+    vi.mocked(api.disconnectInstance).mockResolvedValue({ disconnected: 'm1', was_connected: false })
+    vi.mocked(api.removeInstance).mockRejectedValue(new ApiError(409, 'registry is locked'))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    await u.click(await screen.findByRole('button', { name: 'Remove dev-box-1' }))
+    expect(await screen.findByText(/Remove of m1 failed: registry is locked/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('shows the diagnosis reason as a dismissible note', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([MANUAL_INSTANCE]))
+    vi.mocked(api.instanceStatus).mockResolvedValue({
+      instance_id: 'm1',
+      state: 'error',
+      diagnosis: { code: 'ssh_unreachable', ok: false, reason: 'host did not answer', probes: [] },
+    } as never)
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    await u.click(await screen.findByRole('button', { name: 'Diagnose dev-box-1' }))
+    expect(await screen.findByText(/m1: host did not answer/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+
+    await u.click(screen.getByRole('button', { name: 'Dismiss diagnosis' }))
+    expect(screen.queryByText(/m1: host did not answer/)).not.toBeInTheDocument()
+  })
+
+  it('says nothing when a diagnosis comes back clean', async () => {
+    // A healthy probe has no reason and no error, so there is nothing to report —
+    // a note reading "m1: undefined" would be worse than silence.
+    vi.mocked(api.listInstances).mockResolvedValue(list([MANUAL_INSTANCE]))
+    vi.mocked(api.instanceStatus).mockResolvedValue({ instance_id: 'm1', state: 'connected' } as never)
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    await u.click(await screen.findByRole('button', { name: 'Diagnose dev-box-1' }))
+    await waitFor(() => expect(api.instanceStatus).toHaveBeenCalledWith('m1', true))
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('surfaces a failed diagnose', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([MANUAL_INSTANCE]))
+    vi.mocked(api.instanceStatus).mockRejectedValue(new Error('probe blew up'))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    await u.click(await screen.findByRole('button', { name: 'Diagnose dev-box-1' }))
+    expect(await screen.findByText(/Diagnose of m1 failed: probe blew up/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('actually unregisters an unverifiable SSM crew once the removal is confirmed', async () => {
+    // The confirm step exists because Remove leaves a real cloud instance
+    // running; it must still complete when the user goes through with it.
+    vi.mocked(api.listInstances).mockResolvedValue(list([CLOUD_INSTANCE]))
+    vi.mocked(api.cloudLaunches).mockResolvedValue({ jobs: [] })
+    vi.mocked(api.disconnectInstance).mockResolvedValue({ disconnected: 'kc1', was_connected: true })
+    vi.mocked(api.removeInstance).mockResolvedValue({ removed: 'kc1' } as never)
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    await u.click(await screen.findByRole('button', { name: /Remove Kiro Crew Cloud/ }))
+    expect(await screen.findByText(/keeps running and billing/i)).toBeInTheDocument()
+    await u.click(screen.getByRole('button', { name: /Remove Kiro Crew Cloud/ }))
+    await waitFor(() => expect(api.removeInstance).toHaveBeenCalledWith('kc1'))
+  })
+
+  it('carries the crew AWS coordinates into a lifecycle call, and reports a failed Stop', async () => {
+    // A crew launched under a non-default profile/region is invisible to the
+    // gateway defaults, so the coordinates come off the row itself.
+    vi.mocked(api.listInstances).mockResolvedValue(list([CLOUD_INSTANCE]))
+    vi.mocked(api.cloudLaunches).mockResolvedValue({ jobs: [DONE_JOB] })
+    vi.mocked(api.cloudStop).mockRejectedValue(new ApiError(404, 'stack kc-3f9a not found'))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    await u.click(await screen.findByRole('button', { name: /^Stop Kiro Crew Cloud/ }))
+    await waitFor(() =>
+      expect(api.cloudStop).toHaveBeenCalledWith('kc-3f9a', {
+        profile: 'Admin',
+        region: 'us-west-2',
+        instanceId: 'i-0abc123456789def0',
+      }),
+    )
+    expect(await screen.findByText(/stack kc-3f9a not found/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('falls back to a generic message when a rejection is not an Error at all', async () => {
+    // Nothing guarantees a thrown value is an Error; interpolating it blindly
+    // would print "[object Object]" into the banner.
+    vi.mocked(api.listInstances).mockResolvedValue(list([CLOUD_INSTANCE]))
+    vi.mocked(api.cloudLaunches).mockResolvedValue({ jobs: [DONE_JOB] })
+    vi.mocked(api.cloudStart).mockRejectedValue('nope')
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    await u.click(await screen.findByRole('button', { name: /^Start Kiro Crew Cloud/ }))
+    expect(await screen.findByText('unknown error', undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('clears the Deleting… state once the teardown drops the row', async () => {
+    // The pending tag is pruned off the instance list, not a timer: the row (and
+    // its Deleting… button) must disappear on its own when AWS confirms.
+    let rows: InstanceView[] = [CLOUD_INSTANCE]
+    vi.mocked(api.listInstances).mockImplementation(async () => list(rows, { warm_set_cap: 0 }))
+    vi.mocked(api.cloudLaunches).mockResolvedValue({ jobs: [DONE_JOB] })
+    vi.mocked(api.cloudDestroy).mockResolvedValue({ ok: true })
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    // An absent cap falls back to the default rather than advertising "up to 0".
+    expect(await screen.findByText(/Up to 5 stay warm at once/i)).toBeInTheDocument()
+
+    await u.click(await screen.findByRole('button', { name: /^Delete Kiro Crew Cloud/ }))
+    expect(await screen.findByText(/terminates the EC2 instance/i)).toBeInTheDocument()
+    await u.click(screen.getByRole('button', { name: /^Confirm deleting/ }))
+    expect(await screen.findByRole('button', { name: /Deleting/, hidden: true })).toBeDisabled()
+
+    rows = []
+    await u.click(screen.getByRole('button', { name: 'Refresh' }))
+    expect(await screen.findByText(/No crews yet/i, undefined, { timeout: 5_000 })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Deleting/ })).not.toBeInTheDocument()
+  })
+
+  it('reports a cancel that the gateway refuses', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([]))
+    vi.mocked(api.cloudLaunches).mockResolvedValue({ jobs: [RUNNING_JOB] })
+    vi.mocked(api.cloudLaunchStatus).mockResolvedValue(RUNNING_JOB)
+    vi.mocked(api.cloudLaunchCancel).mockRejectedValue(new ApiError(409, 'too late to cancel'))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    await u.click(await screen.findByRole('button', { name: 'Cancel setup of kc-4d10' }))
+    expect(await screen.findByText(/too late to cancel/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('marks the in-progress row as cancelling while the request is open', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([]))
+    vi.mocked(api.cloudLaunches).mockResolvedValue({ jobs: [RUNNING_JOB] })
+    vi.mocked(api.cloudLaunchStatus).mockResolvedValue(RUNNING_JOB)
+    let release: (v: LaunchJob) => void = () => {}
+    vi.mocked(api.cloudLaunchCancel).mockReturnValue(
+      new Promise<LaunchJob>(r => { release = r }) as ReturnType<typeof api.cloudLaunchCancel>,
+    )
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    const cancel = await screen.findByRole('button', { name: 'Cancel setup of kc-4d10' })
+    await u.click(cancel)
+    await waitFor(() => expect(cancel).toBeDisabled())
+    expect(cancel).toHaveTextContent(/Cancelling/)
+    release({ ...RUNNING_JOB, status: 'cancelled' })
+  })
+})
+
+describe('RemoteCrewPanel — AWS prerequisites', () => {
+  it('marks Copied on the install command, then reverts on its own', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([]))
+    vi.mocked(api.cloudPreflight).mockResolvedValue({
+      ...PREFLIGHT_OK,
+      session_manager_plugin: false,
+      session_manager_plugin_command: 'sudo dnf install -y https://example.invalid/smp.rpm',
+    })
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+    await openSetupTab(u)
+
+    await u.click(await screen.findByRole('button', { name: /Copy command/ }))
+    expect(copyToClipboard).toHaveBeenCalledWith('sudo dnf install -y https://example.invalid/smp.rpm')
+    expect(await screen.findByRole('button', { name: /Copied/ })).toBeInTheDocument()
+
+    // The confirmation is transient, so the button becomes usable again.
+    await act(async () => { vi.advanceTimersByTime(1_600) })
+    expect(await screen.findByRole('button', { name: /Copy command/ })).toBeInTheDocument()
+  })
+
+  it('fetches the IAM policy on demand and confirms the copy', async () => {
+    // The policy is not shipped to the browser: a missing-permission user asks
+    // the gateway for it at the moment they need to paste it.
+    vi.mocked(api.listInstances).mockResolvedValue(list([]))
+    vi.mocked(api.cloudPreflight).mockResolvedValue({ ...PREFLIGHT_OK, cloudformation_reachable: false })
+    vi.mocked(api.cloudIamPolicy).mockResolvedValue({ policy: '{"Version":"2012-10-17"}' })
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+    await openSetupTab(u)
+
+    await u.click(await screen.findByRole('button', { name: /Copy policy JSON/ }))
+    await waitFor(() => expect(copyToClipboard).toHaveBeenCalledWith('{"Version":"2012-10-17"}'))
+    expect(await screen.findByRole('button', { name: /Copied/ })).toBeInTheDocument()
+  })
+
+  it('surfaces a failure to fetch the IAM policy rather than silently copying nothing', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([]))
+    vi.mocked(api.cloudPreflight).mockResolvedValue({ ...PREFLIGHT_OK, cloudformation_reachable: false })
+    vi.mocked(api.cloudIamPolicy).mockRejectedValue(new ApiError(500, 'policy render failed'))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+    await openSetupTab(u)
+
+    await u.click(await screen.findByRole('button', { name: /Copy policy JSON/ }))
+    expect(await screen.findByText(/policy render failed/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+    expect(copyToClipboard).not.toHaveBeenCalled()
+  })
+
+  it('re-probes the region the user just typed, not the remembered one', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([]))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+    await openSetupTab(u)
+    await waitFor(() => expect(api.cloudPreflight).toHaveBeenCalledWith(undefined, 'us-east-1'))
+
+    const regionInput = await screen.findByLabelText('Region')
+    await u.clear(regionInput)
+    await u.type(regionInput, 'eu-west-1')
+    await u.tab()  // blur commits the value the probe runs against
+
+    await waitFor(() => expect(api.cloudPreflight).toHaveBeenCalledWith(undefined, 'eu-west-1'))
+    expect(await screen.findByText(/in eu-west-1/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('explains an unreachable account and keeps Launch out of reach', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([]))
+    vi.mocked(api.cloudPreflight).mockResolvedValue({
+      ...PREFLIGHT_OK,
+      reachable: false,
+      account: '',
+      ec2_reachable: false,
+      cloudformation_reachable: false,
+      ssm_reachable: false,
+      session_manager_plugin: false,
+      detail: 'Credentials for this profile have expired.',
+    })
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+    await openSetupTab(u)
+
+    expect(await screen.findByText('Credentials for this profile have expired.')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Launch' })).toBeDisabled())
+    expect(screen.getByText(/Finish the AWS setup above/i)).toBeInTheDocument()
+  })
+
+  it('offers a re-check when the preflight request itself fails', async () => {
+    // No preflight object at all means the checklist cannot render — the panel
+    // must still say why and give the user a way to try again.
+    vi.mocked(api.listInstances).mockResolvedValue(list([]))
+    vi.mocked(api.cloudPreflight).mockRejectedValue(new ApiError(500, 'sts call timed out'))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+    await openSetupTab(u)
+
+    expect(await screen.findByText(/sts call timed out/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+    const recheck = await screen.findByRole('button', { name: /Re-check/ })
+    await u.click(recheck)
+    await waitFor(() => expect(vi.mocked(api.cloudPreflight).mock.calls.length).toBeGreaterThan(1))
+  })
+})
+
+describe('RemoteCrewPanel — launching', () => {
+  it('surfaces a rejected launch', async () => {
+    vi.mocked(api.listInstances).mockResolvedValue(list([]))
+    vi.mocked(api.cloudLaunch).mockRejectedValue(new ApiError(500, 'no capacity for m7g.2xlarge'))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+    await openSetupTab(u)
+
+    const launch = await screen.findByRole('button', { name: 'Launch' })
+    await waitFor(() => expect(launch).not.toBeDisabled())
+    await u.click(launch)
+    expect(await screen.findByText(/no capacity for m7g.2xlarge/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('fetches the device-code prompt when the job is waiting but carries none', async () => {
+    // The prompt lives on the gateway; a job that reached awaiting_signin before
+    // this tab existed has nothing to render until the dashboard asks for it.
+    const waiting: LaunchJob = { ...RUNNING_JOB, status: 'awaiting_signin', signin: null }
+    vi.mocked(api.listInstances).mockResolvedValue(list([]))
+    vi.mocked(api.cloudLaunches).mockResolvedValue({ jobs: [waiting] })
+    vi.mocked(api.cloudLaunchStatus).mockResolvedValue(waiting)
+    vi.mocked(api.cloudLaunchSignin).mockResolvedValue({
+      signin: { url: 'https://device.sso/verify', code: 'ABCD-9999' },
+    })
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+    await openSetupTab(u)
+
+    await u.click(await screen.findByRole('button', { name: /Open sign-in page/ }))
+    await waitFor(() => expect(api.cloudLaunchSignin).toHaveBeenCalledWith('j-run'))
+  })
+
+  it('surfaces a refused sign-in fetch', async () => {
+    const waiting: LaunchJob = { ...RUNNING_JOB, status: 'awaiting_signin', signin: null }
+    vi.mocked(api.listInstances).mockResolvedValue(list([]))
+    vi.mocked(api.cloudLaunches).mockResolvedValue({ jobs: [waiting] })
+    vi.mocked(api.cloudLaunchStatus).mockResolvedValue(waiting)
+    vi.mocked(api.cloudLaunchSignin).mockRejectedValue(new ApiError(409, 'no pending sign-in'))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+    await openSetupTab(u)
+
+    await u.click(await screen.findByRole('button', { name: /Open sign-in page/ }))
+    expect(await screen.findByText(/no pending sign-in/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('shows a failed launch with its step detail and no dead Cancel', async () => {
+    // A terminal job cannot be cancelled, and the step that broke carries the
+    // only server-authored explanation the user will get.
+    const failed: LaunchJob = {
+      ...RUNNING_JOB,
+      id: 'j-failed',
+      status: 'failed',
+      error: 'CloudFormation rolled the stack back',
+      steps: [
+        { key: 'preflight', label: 'Checked your AWS setup', state: 'done' },
+        { key: 'provision', label: 'Created the instance', state: 'failed', detail: 'InsufficientInstanceCapacity' },
+        { key: 'connect', label: 'Connect', state: 'pending' },
+      ],
+    }
+    vi.mocked(api.listInstances).mockResolvedValue(list([]))
+    vi.mocked(api.cloudLaunches).mockResolvedValue({ jobs: [failed] })
+    vi.mocked(api.cloudLaunchStatus).mockResolvedValue(failed)
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+    await openSetupTab(u)
+
+    expect(await screen.findByText('Launch failed')).toBeInTheDocument()
+    expect(screen.getByText('InsufficientInstanceCapacity')).toBeInTheDocument()
+    expect(screen.getByText('CloudFormation rolled the stack back')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Cancel setup of/ })).not.toBeInTheDocument()
+  })
+})
+
+describe('RemoteCrewPanel — disabled feature gate', () => {
+  it('enables the feature, reports progress, then asks for a restart', async () => {
+    vi.mocked(api.listInstances).mockRejectedValue(new ApiError(403, 'instances feature is disabled'))
+    let release: (v: unknown) => void = () => {}
+    vi.mocked(api.patchConfig).mockReturnValue(new Promise(r => { release = r }) as never)
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    const enable = await screen.findByRole('button', { name: /Enable remote crew management/ })
+    await u.click(enable)
+    await waitFor(() => expect(screen.getByRole('button', { name: /Enabling/ })).toBeDisabled())
+    expect(api.patchConfig).toHaveBeenCalledWith('instances.enabled', true)
+
+    release({ ok: true })
+    // The flag is on but the running gateway never opened its tunnels, so a
+    // restart is the next required step rather than an optional suggestion.
+    expect(await screen.findByRole('status', undefined, { timeout: 5_000 })).toHaveTextContent(/Restart the gateway/i)
+  })
+
+  it('surfaces a failure to write the config', async () => {
+    vi.mocked(api.listInstances).mockRejectedValue(new ApiError(403, 'instances feature is disabled'))
+    vi.mocked(api.patchConfig).mockRejectedValue(new ApiError(423, 'config is locked'))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    await u.click(await screen.findByRole('button', { name: /Enable remote crew management/ }))
+    expect(await screen.findByText(/config is locked/, undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('treats a non-403 failure as a load error, not a disabled feature', async () => {
+    // Only a 403 mentioning "disabled" is the gate. Any other failure must keep
+    // the panel intact so the user is not told to enable something already on.
+    vi.mocked(api.listInstances).mockRejectedValue(new ApiError(403, 'owner only'))
+    const u = setup()
+    renderWithProviders(<RemoteCrewPanel />)
+
+    expect(await screen.findByText('owner only', undefined, { timeout: 5_000 })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Enable remote crew management/ })).not.toBeInTheDocument()
+    await u.click(screen.getAllByRole('button', { name: 'Refresh' })[0])
+    await waitFor(() => expect(vi.mocked(api.listInstances).mock.calls.length).toBeGreaterThan(1))
+  })
+})

--- a/website/src/test/SettingsVoicePanelCoverage.test.tsx
+++ b/website/src/test/SettingsVoicePanelCoverage.test.tsx
@@ -1,0 +1,354 @@
+/**
+ * Coverage pass over Settings ▸ Voice (`pages/settings/VoicePanel.tsx`).
+ *
+ * Nothing mounted this panel before, so every branch was unexecuted: the load
+ * error + retry arm, the skeleton arm, both provider field sets (Piper and
+ * Amazon Polly), the optimistic `voice-config-changed` broadcast, the rollback
+ * on a failed save, the engine-compatibility fold when a voice changes, and the
+ * live Polly catalogue vs. the offline fallback list.
+ *
+ * Harness notes:
+ *  - `api` is a plain object literal, so `vi.spyOn` on the three voice methods
+ *    is enough; the module stays real.
+ *  - `SttSettings` is stubbed. It is a sibling panel with its own queries and
+ *    its own tests (`SttSettings.streaming.test.tsx`); mounting it here would
+ *    add unrelated fetches and duplicate copy to every query in this file.
+ *  - `renderWithProviders` supplies a QueryClient with `retry: false`, so a
+ *    rejected query surfaces on the first attempt.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+
+import { renderWithProviders } from './helpers'
+import { initI18n } from '../i18n'
+import { api } from '../api/client'
+import { VoicePanel } from '../pages/settings/VoicePanel'
+
+vi.mock('../pages/settings/SttSettings', () => ({
+  default: () => <div data-testid="stt-settings-stub" />,
+}))
+
+/* ── timers ───────────────────────────────────────────────────────────────── */
+
+// Radix Select (used by every SettingsSelect here) schedules deferred work on
+// open/close. On the real clock those callbacks can fire after vitest tears the
+// environment down and throw "window is not defined" as an UNHANDLED error —
+// every test passing and the run still exiting non-zero. `shouldAdvanceTime`
+// keeps the clock moving so `findBy*` behaves as it does with real timers.
+beforeEach(async () => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  await initI18n('en')
+})
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+/* ── fixtures ─────────────────────────────────────────────────────────────── */
+
+type VoiceConfig = Awaited<ReturnType<typeof api.voiceConfig>>
+
+function config(over: Record<string, unknown> = {}) {
+  return {
+    enabled: false,
+    provider: 'piper',
+    voice: 'Ruth',
+    engine: 'generative',
+    rate: '100%',
+    autoSpeak: false,
+    aws_profile: '',
+    region: '',
+    piper_binary: '',
+    piper_model: '',
+    piper_model_config: '',
+    piper_length_scale: 1.0,
+    ...over,
+  } as VoiceConfig
+}
+
+/** Two voices whose engine lists differ, so the compatibility fold is reachable. */
+const CATALOGUE = {
+  voices: [
+    { id: 'Ruth', name: 'Ruth', language: 'English (US)', languageCode: 'en-US', gender: 'Female', engines: ['generative', 'neural'] },
+    { id: 'Brian', name: 'Brian', language: 'English (UK)', languageCode: 'en-GB', gender: 'Male', engines: ['standard'] },
+  ],
+}
+
+interface SeedOpts {
+  /** Reject the config query instead of resolving it. */
+  configFails?: boolean
+  /** Never settle the config query, leaving the skeleton on screen. */
+  configPending?: boolean
+  /** Reject the Polly catalogue query. */
+  voicesFail?: boolean
+  /** Reject the save, driving the `onError` rollback arm. */
+  saveFails?: boolean
+}
+
+function seed(over: Record<string, unknown> = {}, opts: SeedOpts = {}) {
+  const cfg = config(over)
+
+  const load = vi.spyOn(api, 'voiceConfig')
+  if (opts.configFails) load.mockRejectedValue(new Error('config unavailable'))
+  else if (opts.configPending) load.mockReturnValue(new Promise<VoiceConfig>(() => {}))
+  else load.mockResolvedValue(cfg)
+
+  const voices = vi.spyOn(api, 'voiceVoices')
+  if (opts.voicesFail) voices.mockRejectedValue(new Error('no aws cli'))
+  else voices.mockResolvedValue(CATALOGUE)
+
+  const save = vi.spyOn(api, 'updateVoiceConfig')
+  if (opts.saveFails) save.mockRejectedValue(new Error('write refused'))
+  else save.mockImplementation(async (patch: object) => ({ ...cfg, ...patch }) as VoiceConfig)
+
+  const view = renderWithProviders(<VoicePanel />)
+  return { ...view, cfg, load, voices, save }
+}
+
+/** A field's label proves the success branch rendered. */
+const field = (name: string | RegExp) => screen.findByText(name)
+
+/** Locate a `SettingsSelect` by its accessible name (several are on screen). */
+const select = (name: RegExp) => screen.getByRole('combobox', { name })
+
+/** Radix Select ignores a `change` event on the trigger — open, then click. */
+async function pick(name: RegExp, option: string | RegExp) {
+  fireEvent.click(select(name))
+  const opt = await screen.findByRole('option', { name: option }, { timeout: 5_000 })
+  fireEvent.click(opt)
+}
+
+/* ── load states ──────────────────────────────────────────────────────────── */
+
+describe('VoicePanel load states', () => {
+  it('shows the failure text with a retry that refetches', async () => {
+    const { load } = seed({}, { configFails: true })
+    await screen.findByText('Failed to load voice config.', undefined, { timeout: 5_000 })
+
+    const calls = load.mock.calls.length
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await waitFor(() => expect(load.mock.calls.length).toBeGreaterThan(calls))
+  })
+
+  it('renders the skeleton while the config is in flight', async () => {
+    seed({}, { configPending: true })
+    // Section headers come from the panel itself, not the loaded branch.
+    await screen.findByRole('heading', { name: 'Text-to-Speech' })
+    expect(screen.queryByRole('switch', { name: 'Auto-speak Responses' })).toBeNull()
+    expect(screen.queryByRole('combobox', { name: /Provider/ })).toBeNull()
+  })
+
+  it('mounts the speech-to-text section alongside text-to-speech', async () => {
+    seed()
+    expect(await screen.findByTestId('stt-settings-stub')).toBeTruthy()
+    await screen.findByRole('heading', { name: 'Speech-to-Text' })
+  })
+})
+
+/* ── Piper (default provider) ─────────────────────────────────────────────── */
+
+describe('VoicePanel piper fields', () => {
+  it('renders the piper field set and no Polly-only fields', async () => {
+    seed({ piper_model: '/m.onnx', piper_binary: '/usr/bin/piper' })
+    await field('Piper Model')
+    await field('Piper Binary')
+    expect(select(/^Speed$/)).toBeTruthy()
+    expect(screen.queryByRole('combobox', { name: /^Voice$/ })).toBeNull()
+    expect(screen.queryByRole('combobox', { name: /^Engine$/ })).toBeNull()
+    expect(screen.queryByText('AWS Profile (Amazon Polly)')).toBeNull()
+  })
+
+  it('does not fetch the Polly catalogue for a piper user', async () => {
+    const { voices } = seed()
+    await field('Piper Model')
+    expect(voices).not.toHaveBeenCalled()
+  })
+
+  it('seeds the local input state from the loaded config', async () => {
+    seed({ piper_model: '/models/en.onnx', piper_binary: '/opt/piper' })
+    await field('Piper Model')
+    await waitFor(() => {
+      expect((screen.getByDisplayValue('/models/en.onnx') as HTMLInputElement).tagName).toBe('INPUT')
+    })
+    expect(screen.getByDisplayValue('/opt/piper')).toBeTruthy()
+  })
+
+  it('saves a trimmed piper model path on blur', async () => {
+    const { save } = seed()
+    await field('Piper Model')
+    const input = screen.getByPlaceholderText('~/piper/en_US-lessac-medium.onnx')
+    fireEvent.change(input, { target: { value: '  /models/new.onnx  ' } })
+    fireEvent.blur(input)
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ piper_model: '/models/new.onnx' }))
+  })
+
+  it('saves a trimmed piper binary path on blur', async () => {
+    const { save } = seed()
+    await field('Piper Binary')
+    const input = screen.getByPlaceholderText('(auto-detect)')
+    fireEvent.change(input, { target: { value: ' /usr/local/bin/piper ' } })
+    fireEvent.blur(input)
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ piper_binary: '/usr/local/bin/piper' }))
+  })
+
+  it('writes the numeric length_scale behind the friendly speed label', async () => {
+    const { save } = seed()
+    await field('Piper Model')
+    await pick(/^Speed$/, 'Fastest')
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ piper_length_scale: 0.7 }))
+  })
+
+  it('switches provider to Amazon Polly from the dropdown', async () => {
+    const { save } = seed()
+    await field('Piper Model')
+    await pick(/^Provider$/, 'Amazon Polly (cloud)')
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ provider: 'polly' }))
+  })
+})
+
+/* ── auto-speak toggle ────────────────────────────────────────────────────── */
+
+describe('VoicePanel auto-speak', () => {
+  it('turns voice on implicitly when auto-speak is enabled', async () => {
+    const { save } = seed({ autoSpeak: false, enabled: false })
+    const toggle = await screen.findByRole('switch', { name: 'Auto-speak Responses' })
+    fireEvent.click(toggle)
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ autoSpeak: true, enabled: true }))
+  })
+
+  it('leaves `enabled` alone when auto-speak is switched off', async () => {
+    const { save } = seed({ autoSpeak: true, enabled: true })
+    const toggle = await screen.findByRole('switch', { name: 'Auto-speak Responses' })
+    fireEvent.click(toggle)
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ autoSpeak: false }))
+  })
+
+  it('broadcasts the optimistic config on voice-config-changed', async () => {
+    const heard: unknown[] = []
+    const onChanged = (e: Event) => heard.push((e as CustomEvent).detail)
+    window.addEventListener('voice-config-changed', onChanged)
+    try {
+      seed({ autoSpeak: false })
+      const toggle = await screen.findByRole('switch', { name: 'Auto-speak Responses' })
+      fireEvent.click(toggle)
+      await waitFor(() => expect(heard.length).toBeGreaterThan(0))
+      expect(heard[0]).toMatchObject({ autoSpeak: true, enabled: true })
+    } finally {
+      window.removeEventListener('voice-config-changed', onChanged)
+    }
+  })
+})
+
+/* ── Amazon Polly ─────────────────────────────────────────────────────────── */
+
+describe('VoicePanel polly fields', () => {
+  it('renders the Polly field set and fetches the catalogue', async () => {
+    const { voices } = seed({ provider: 'polly' })
+    await field('AWS Profile (Amazon Polly)')
+    await field('AWS Region (Amazon Polly)')
+    expect(select(/^Voice$/)).toBeTruthy()
+    expect(select(/^Engine$/)).toBeTruthy()
+    await waitFor(() => expect(voices).toHaveBeenCalled())
+    expect(screen.queryByText('Piper Model')).toBeNull()
+  })
+
+  it('labels catalogue voices as name (locale gender-initial)', async () => {
+    seed({ provider: 'polly' })
+    await field('AWS Profile (Amazon Polly)')
+    fireEvent.click(select(/^Voice$/))
+    expect(await screen.findByRole('option', { name: 'Brian (en-GB M)' }, { timeout: 5_000 })).toBeTruthy()
+    expect(screen.getByRole('option', { name: 'Ruth (en-US F)' })).toBeTruthy()
+  })
+
+  it('offers the offline fallback list when the catalogue call fails', async () => {
+    seed({ provider: 'polly' }, { voicesFail: true })
+    await field('AWS Profile (Amazon Polly)')
+    fireEvent.click(select(/^Voice$/))
+    expect(await screen.findByRole('option', { name: 'Matthew (US M)' }, { timeout: 5_000 })).toBeTruthy()
+  })
+
+  it('folds the engine to the first supported one when the new voice cannot do it', async () => {
+    // Brian supports only `standard`, so keeping `generative` would send a
+    // combination Polly rejects.
+    const { save } = seed({ provider: 'polly', voice: 'Ruth', engine: 'generative' })
+    await field('AWS Profile (Amazon Polly)')
+    await pick(/^Voice$/, 'Brian (en-GB M)')
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ voice: 'Brian', engine: 'standard' }))
+  })
+
+  it('keeps the engine when the new voice still supports it', async () => {
+    const { save } = seed({ provider: 'polly', voice: 'Brian', engine: 'neural' })
+    await field('AWS Profile (Amazon Polly)')
+    await pick(/^Voice$/, 'Ruth (en-US F)')
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ voice: 'Ruth' }))
+  })
+
+  it('limits the engine dropdown to what the selected voice supports', async () => {
+    seed({ provider: 'polly', voice: 'Brian', engine: 'standard' })
+    await field('AWS Profile (Amazon Polly)')
+    fireEvent.click(select(/^Engine$/))
+    expect(await screen.findByRole('option', { name: 'standard' }, { timeout: 5_000 })).toBeTruthy()
+    expect(screen.queryByRole('option', { name: 'generative' })).toBeNull()
+  })
+
+  it('saves an engine change', async () => {
+    const { save } = seed({ provider: 'polly', voice: 'Ruth', engine: 'generative' })
+    await field('AWS Profile (Amazon Polly)')
+    await pick(/^Engine$/, 'neural')
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ engine: 'neural' }))
+  })
+
+  it('saves a speech-rate change', async () => {
+    const { save } = seed({ provider: 'polly' })
+    await field('AWS Profile (Amazon Polly)')
+    await pick(/^Speed$/, '120%')
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ rate: '120%' }))
+  })
+
+  it('saves trimmed profile and region on blur', async () => {
+    const { save } = seed({ provider: 'polly' })
+    await field('AWS Profile (Amazon Polly)')
+
+    const profile = screen.getByPlaceholderText('default')
+    fireEvent.change(profile, { target: { value: ' work ' } })
+    fireEvent.blur(profile)
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ aws_profile: 'work' }))
+
+    const region = screen.getByPlaceholderText('us-east-1')
+    fireEvent.change(region, { target: { value: ' us-west-2 ' } })
+    fireEvent.blur(region)
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ region: 'us-west-2' }))
+  })
+})
+
+/* ── save failure ─────────────────────────────────────────────────────────── */
+
+describe('VoicePanel save failure', () => {
+  it('surfaces the save error and rolls the local inputs back', async () => {
+    const { save } = seed({ provider: 'polly', aws_profile: 'original' }, { saveFails: true })
+    await field('AWS Profile (Amazon Polly)')
+
+    const profile = screen.getByPlaceholderText('default')
+    fireEvent.change(profile, { target: { value: 'typo' } })
+    fireEvent.blur(profile)
+
+    await waitFor(() => expect(save).toHaveBeenCalled())
+    await screen.findByText('Failed to save voice config', undefined, { timeout: 5_000 })
+    await waitFor(() => expect(screen.getByPlaceholderText('default')).toHaveValue('original'))
+  })
+
+  it('dismisses the save error banner', async () => {
+    seed({ provider: 'polly' }, { saveFails: true })
+    await field('AWS Profile (Amazon Polly)')
+
+    const region = screen.getByPlaceholderText('us-east-1')
+    fireEvent.change(region, { target: { value: 'eu-west-1' } })
+    fireEvent.blur(region)
+
+    const banner = await screen.findByText('Failed to save voice config', undefined, { timeout: 5_000 })
+    expect(banner).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+    await waitFor(() => expect(screen.queryByText('Failed to save voice config')).toBeNull())
+  })
+})

--- a/website/src/test/SettingsWebexPanelCoverage.test.tsx
+++ b/website/src/test/SettingsWebexPanelCoverage.test.tsx
@@ -1,0 +1,512 @@
+/**
+ * Coverage pass over Settings ▸ Webex (`pages/settings/WebexPanel.tsx`).
+ *
+ * Nothing mounted this panel before — `ChannelsPanel.test.tsx` only asserts that
+ * the settings nav routes to it — so every branch in the file was unexecuted:
+ * the two query states, the three status pills, both connection hints, the
+ * read-only remote view, the email allowlist editor (add / reject / dedupe /
+ * remove), the save payload's folder and credential folding, and both mutation
+ * arms with all four of their message shapes.
+ *
+ * Harness notes:
+ *  - `api` is a plain object literal, so `vi.spyOn` on the two Webex methods is
+ *    enough; the module stays real and nothing else in the tree is stubbed.
+ *  - `renderWithProviders` supplies the QueryClient with `retry: false`, so a
+ *    rejected query or mutation surfaces on the first attempt.
+ *  - Credentials here are obvious placeholders. The panel only forwards them to
+ *    a mocked writer, and `SecretField` never renders a stored secret back, so
+ *    there is nothing real to put in this file.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, waitFor, act } from '@testing-library/react'
+
+import { renderWithProviders } from './helpers'
+import { api, type WebexConfigData } from '../api/client'
+import { WebexPanel } from '../pages/settings/WebexPanel'
+
+/* ── timers ───────────────────────────────────────────────────────────────── */
+
+// The panel schedules two deferred resets (saved pill 6s, save error 8s). On the
+// real clock those callbacks fire after vitest tears the environment down and
+// throw "window is not defined" as an UNHANDLED error — every test passing and
+// the run still exiting non-zero. Fake timers keep them off the wall clock and
+// `clearAllTimers` drops the pending ones at teardown; `shouldAdvanceTime` keeps
+// the clock moving so `findBy*` behaves as it does with real timers.
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+})
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+/* ── fixtures ─────────────────────────────────────────────────────────────── */
+
+type SaveResult = Awaited<ReturnType<typeof api.saveWebexConfig>>
+
+const OK: SaveResult = { ok: true, restart_required: false, verify_warning: '' }
+
+const CREATE_BOT_URL = 'https://developer.webex.com/my-apps/new/bot'
+const SETUP_GUIDE =
+  'https://github.com/kirodotdev/KiroCrew/blob/main/src/kiro_crew/docs/webex-integration.md'
+
+/** Configured, not connected, nothing stored — the most branch-rich start. */
+function config(over: Partial<WebexConfigData> = {}): WebexConfigData {
+  return {
+    connected: false,
+    connect_error: '',
+    configured: true,
+    read_only: false,
+    bot_token_set: false,
+    bot_token_preview: '',
+    enabled: false,
+    allowed_emails: ['first@example.com'],
+    ...over,
+  }
+}
+
+interface SeedOpts {
+  /** Result of a save, a rejection to drive `onError`, or a never-settling write. */
+  save?: SaveResult | { reject: unknown } | { pending: true }
+}
+
+/** Install both Webex API seams and mount the panel. */
+function seed(cfgOver: Partial<WebexConfigData> = {}, opts: SeedOpts = {}) {
+  vi.spyOn(api, 'getWebexConfig').mockResolvedValue(config(cfgOver))
+
+  const save = vi.spyOn(api, 'saveWebexConfig')
+  let settle: (v: SaveResult) => void = () => {}
+  const want = opts.save ?? OK
+  if (want && typeof want === 'object' && 'reject' in want) {
+    save.mockRejectedValue(want.reject)
+  } else if (want && typeof want === 'object' && 'pending' in want) {
+    save.mockReturnValue(new Promise<SaveResult>(r => { settle = r }))
+  } else {
+    save.mockResolvedValue(want as SaveResult)
+  }
+
+  const view = renderWithProviders(<WebexPanel />)
+  return { ...view, save, settle }
+}
+
+/** Resolve once the query has hydrated and the form is on screen. */
+async function hydrated() {
+  return await screen.findByRole('heading', { name: 'Webex', level: 3 }, { timeout: 5_000 })
+}
+
+/** The save button, which only exists on a writable session. */
+function saveBtn() {
+  return screen.getByRole('button', { name: 'Save Webex settings' })
+}
+
+/** The allowlist's own text input, keyed off its placeholder. */
+function emailInput() {
+  return screen.getByPlaceholderText('you@example.com')
+}
+
+/* ── query states ─────────────────────────────────────────────────────────── */
+
+describe('WebexPanel query states', () => {
+  it('shows the loading line until the config query settles', () => {
+    vi.spyOn(api, 'getWebexConfig').mockReturnValue(new Promise<WebexConfigData>(() => {}))
+    renderWithProviders(<WebexPanel />)
+    expect(screen.getByText('Loading Webex config…')).toBeInTheDocument()
+  })
+
+  it('shows the gateway hint when the config query fails', async () => {
+    vi.spyOn(api, 'getWebexConfig').mockRejectedValue(new Error('offline'))
+    renderWithProviders(<WebexPanel />)
+    expect(
+      await screen.findByText('Cannot load Webex config. Is the gateway running?', undefined, {
+        timeout: 5_000,
+      }),
+    ).toBeInTheDocument()
+  })
+})
+
+/* ── status pill + connection hint ────────────────────────────────────────── */
+
+describe('WebexPanel connection status', () => {
+  it('reads Active with no hint when the gateway holds a live socket', async () => {
+    seed({ connected: true })
+    await hydrated()
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.queryByText(/Restart the gateway to connect/)).not.toBeInTheDocument()
+  })
+
+  it('reads Needs setup and stays silent when no credential is configured', async () => {
+    seed({ configured: false })
+    await hydrated()
+    expect(screen.getByText('Needs setup')).toBeInTheDocument()
+    expect(screen.queryByText(/Restart the gateway to connect/)).not.toBeInTheDocument()
+  })
+
+  it('explains a saved-but-inactive channel as needing a restart', async () => {
+    seed()
+    await hydrated()
+    expect(screen.getByText('Not active')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Settings are saved but the channel is not running. Restart the gateway to connect.',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('surfaces a startup failure with its own error string', async () => {
+    seed({ connect_error: 'dns_failure' })
+    await hydrated()
+    expect(screen.getByText(/Webex connection failed \(dns_failure\)/)).toBeInTheDocument()
+  })
+})
+
+/* ── credentials guide ────────────────────────────────────────────────────── */
+
+describe('WebexPanel credentials guide', () => {
+  it('links the developer portal, the setup guide, and the token help icon', async () => {
+    seed()
+    await hydrated()
+
+    expect(screen.getByRole('link', { name: /Create Webex bot/ })).toHaveAttribute(
+      'href',
+      CREATE_BOT_URL,
+    )
+    expect(screen.getByRole('link', { name: /^Setup guide/ })).toHaveAttribute('href', SETUP_GUIDE)
+    expect(screen.getByRole('link', { name: 'Where to find the bot token' })).toHaveAttribute(
+      'href',
+      SETUP_GUIDE,
+    )
+  })
+})
+
+/* ── read-only remote session ─────────────────────────────────────────────── */
+
+describe('WebexPanel read-only session', () => {
+  it('drops every writer and shows the stored preview only', async () => {
+    seed({
+      read_only: true,
+      bot_token_set: true,
+      bot_token_preview: 'Zm9v••••abcd',
+      allowed_emails: [],
+    })
+    await hydrated()
+
+    expect(
+      screen.getByText(
+        'Webex settings are managed on the machine running Kiro Crew and are read-only from remote sessions.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save Webex settings' })).not.toBeInTheDocument()
+    expect(screen.getByText('Zm9v••••abcd')).toBeInTheDocument()
+    // An empty allowlist under read-only renders the placeholder, not an editor.
+    expect(screen.getByText('(none)')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Add' })).not.toBeInTheDocument()
+  })
+
+  it('renders the unset credential row and hides the per-tag remove button', async () => {
+    seed({ read_only: true, allowed_emails: ['remote@example.com'] })
+    await hydrated()
+
+    expect(screen.getByText('(not set)')).toBeInTheDocument()
+    expect(screen.getByText('remote@example.com')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Remove remote@example.com' }),
+    ).not.toBeInTheDocument()
+  })
+})
+
+/* ── allowed-email editor ─────────────────────────────────────────────────── */
+
+describe('WebexPanel allowed-email editor', () => {
+  it('adds an address on click and keeps Add disabled while the draft is blank', async () => {
+    seed()
+    await hydrated()
+
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled()
+    fireEvent.change(emailInput(), { target: { value: '  second@example.com  ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(screen.getByText('second@example.com')).toBeInTheDocument()
+    expect(emailInput()).toHaveValue('')
+  })
+
+  it('adds on Enter and rejects an address with no @ sign', async () => {
+    seed()
+    await hydrated()
+
+    fireEvent.change(emailInput(), { target: { value: 'nobody' } })
+    fireEvent.keyDown(emailInput(), { key: 'Enter' })
+    expect(await screen.findByRole('alert', undefined, { timeout: 5_000 })).toHaveTextContent(
+      'is not a valid ID',
+    )
+    expect(screen.queryByText('nobody')).not.toBeInTheDocument()
+
+    // A well-shaped one clears the notice and lands as a tag.
+    fireEvent.change(emailInput(), { target: { value: 'second@example.com' } })
+    fireEvent.keyDown(emailInput(), { key: 'Enter' })
+    expect(screen.getByText('second@example.com')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('rejects whitespace, a leading @, a doubled @, a dotless domain and an over-long address', async () => {
+    seed()
+    await hydrated()
+
+    for (const bad of [
+      'two words@example.com',
+      '@example.com',
+      'you@@example.com',
+      'you@localhost',
+      `${'a'.repeat(250)}@example.com`,
+    ]) {
+      fireEvent.change(emailInput(), { target: { value: bad } })
+      fireEvent.keyDown(emailInput(), { key: 'Enter' })
+      expect(await screen.findByRole('alert', undefined, { timeout: 5_000 })).toHaveTextContent(
+        'is not a valid ID',
+      )
+    }
+    // Nothing was accepted: the seeded address is still the only tag.
+    expect(screen.getByText('first@example.com')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove first@example.com' })).toBeInTheDocument()
+  })
+
+  it('ignores a blank submit and de-dupes an address already on the list', async () => {
+    seed()
+    await hydrated()
+
+    fireEvent.keyDown(emailInput(), { key: 'Enter' })
+    fireEvent.keyDown(emailInput(), { key: 'a' })
+    expect(screen.getAllByText(/^first@example\.com$/)).toHaveLength(1)
+
+    fireEvent.change(emailInput(), { target: { value: 'first@example.com' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(screen.getAllByText(/^first@example\.com$/)).toHaveLength(1)
+    expect(emailInput()).toHaveValue('')
+  })
+
+  it('removes a tag and sends the shortened list on save', async () => {
+    const { save } = seed({ allowed_emails: ['first@example.com', 'second@example.com'] })
+    await hydrated()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove first@example.com' }))
+    expect(screen.queryByText('first@example.com')).not.toBeInTheDocument()
+
+    fireEvent.click(saveBtn())
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0]).toMatchObject({ allowed_emails: ['second@example.com'] })
+  })
+})
+
+/* ── save payload ─────────────────────────────────────────────────────────── */
+
+describe('WebexPanel save payload', () => {
+  it('forwards the enable toggle with an unfiled folder and reports success', async () => {
+    const { save } = seed()
+    await hydrated()
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Enable Webex channel' }))
+    fireEvent.click(saveBtn())
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0]).toEqual({
+      enabled: true,
+      allowed_emails: ['first@example.com'],
+      session_folder: '',
+    })
+    expect(await screen.findByText('Saved.', undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('falls back to the channel name when the folder is on but unnamed', async () => {
+    const { save } = seed()
+    await hydrated()
+
+    fireEvent.click(screen.getByRole('switch', { name: 'File sessions in a folder' }))
+    expect(screen.getByPlaceholderText('Webex')).toHaveValue('')
+    fireEvent.click(saveBtn())
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0]).toMatchObject({ session_folder: 'Webex' })
+  })
+
+  it('derives the folder toggle from a stored name and saves an edited one trimmed', async () => {
+    const { save } = seed({ session_folder: 'Inbox' })
+    await hydrated()
+
+    expect(screen.getByRole('switch', { name: 'File sessions in a folder' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+    fireEvent.change(screen.getByPlaceholderText('Webex'), { target: { value: ' Team Inbox ' } })
+    fireEvent.click(saveBtn())
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0]).toMatchObject({ session_folder: 'Team Inbox' })
+  })
+
+  it('keeps the folder name out of the payload once the toggle is switched off', async () => {
+    const { save } = seed({ session_folder: 'Inbox' })
+    await hydrated()
+
+    fireEvent.click(screen.getByRole('switch', { name: 'File sessions in a folder' }))
+    expect(screen.queryByPlaceholderText('Webex')).not.toBeInTheDocument()
+    fireEvent.click(saveBtn())
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0]).toMatchObject({ session_folder: '' })
+  })
+
+  it('sends a pasted credential trimmed and confirms it was verified with Webex', async () => {
+    const { save } = seed({}, { save: { ok: true, restart_required: true, verify_warning: '' } })
+    await hydrated()
+
+    fireEvent.change(screen.getByLabelText('Webex bot token'), {
+      target: { value: '  not-a-real-webex-token  ' },
+    })
+    fireEvent.click(saveBtn())
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0]).toMatchObject({ bot_token: 'not-a-real-webex-token' })
+    expect(
+      await screen.findByText('Verified with Webex and saved. Restart the gateway to connect.', undefined, {
+        timeout: 5_000,
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it('reports a restart-only save when no credential was submitted', async () => {
+    seed({}, { save: { ok: true, restart_required: true, verify_warning: '' } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    expect(
+      await screen.findByText('Saved. Restart the gateway to apply.', undefined, { timeout: 5_000 }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the verify warning beside the saved pill and withholds the verified claim', async () => {
+    seed(
+      {},
+      { save: { ok: true, restart_required: false, verify_warning: 'Token not checked with Webex.' } },
+    )
+    await hydrated()
+
+    fireEvent.change(screen.getByLabelText('Webex bot token'), {
+      target: { value: 'not-a-real-webex-token' },
+    })
+    fireEvent.click(saveBtn())
+
+    expect(
+      await screen.findByText('Token not checked with Webex.', undefined, { timeout: 5_000 }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Saved.')).toBeInTheDocument()
+  })
+
+  it('retires the saved pill six seconds later', async () => {
+    seed()
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    expect(await screen.findByText('Saved.', undefined, { timeout: 5_000 })).toBeInTheDocument()
+
+    await act(async () => { vi.advanceTimersByTime(6_100) })
+    expect(screen.queryByText('Saved.')).not.toBeInTheDocument()
+  })
+
+  it('folds Remove into a clear flag rather than an empty credential string', async () => {
+    const { save } = seed({ bot_token_set: true, bot_token_preview: 'Zm9v••••abcd' })
+    await hydrated()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    expect(screen.getByText('Will be removed on save.')).toBeInTheDocument()
+
+    fireEvent.click(saveBtn())
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    const payload = save.mock.calls[0][0]
+    expect(payload).toMatchObject({ bot_token_clear: true })
+    expect(payload.bot_token).toBeUndefined()
+  })
+
+  it('replaces a stored credential in place, keeping the clear flag off', async () => {
+    const { save } = seed({ bot_token_set: true, bot_token_preview: 'Zm9v••••abcd' })
+    await hydrated()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Replace' }))
+    fireEvent.change(screen.getByLabelText('Webex bot token'), {
+      target: { value: 'replacement-placeholder' },
+    })
+    fireEvent.click(saveBtn())
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    const payload = save.mock.calls[0][0]
+    expect(payload).toMatchObject({ bot_token: 'replacement-placeholder' })
+    expect(payload.bot_token_clear).toBeUndefined()
+  })
+
+  it('disables the button and reads Saving… while the write is in flight', async () => {
+    const { settle } = seed({}, { save: { pending: true } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    const pending = await screen.findByRole('button', { name: 'Saving…' }, { timeout: 5_000 })
+    expect(pending).toBeDisabled()
+
+    await act(async () => { settle(OK) })
+    expect(await screen.findByText('Saved.', undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+})
+
+/* ── save failure ─────────────────────────────────────────────────────────── */
+
+describe('WebexPanel save failure', () => {
+  it('unwraps the server error field out of a JSON response body', async () => {
+    seed({}, { save: { reject: new Error(JSON.stringify({ error: 'token rejected by Webex' })) } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    expect(
+      await screen.findByText('token rejected by Webex', undefined, { timeout: 5_000 }),
+    ).toBeInTheDocument()
+  })
+
+  it('keeps the raw body when the JSON response carries no error field', async () => {
+    const body = JSON.stringify({ detail: 'no error key here' })
+    seed({}, { save: { reject: new Error(body) } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    expect(await screen.findByText(body, undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('shows a non-JSON error message verbatim and retires it after eight seconds', async () => {
+    seed({}, { save: { reject: new Error('502 Bad Gateway') } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    expect(
+      await screen.findByText('502 Bad Gateway', undefined, { timeout: 5_000 }),
+    ).toBeInTheDocument()
+
+    await act(async () => { vi.advanceTimersByTime(8_100) })
+    expect(screen.queryByText('502 Bad Gateway')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the gateway hint when the rejection is not an Error', async () => {
+    seed({}, { save: { reject: 'connection reset' } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    expect(
+      await screen.findByText('Save failed. Is the gateway running?', undefined, { timeout: 5_000 }),
+    ).toBeInTheDocument()
+  })
+
+  it('falls back to the gateway hint for an Error with an empty message', async () => {
+    seed({}, { save: { reject: new Error('') } })
+    await hydrated()
+
+    fireEvent.click(saveBtn())
+    expect(
+      await screen.findByText('Save failed. Is the gateway running?', undefined, { timeout: 5_000 }),
+    ).toBeInTheDocument()
+  })
+})

--- a/website/src/test/SkillBrowserModalCoverage.test.tsx
+++ b/website/src/test/SkillBrowserModalCoverage.test.tsx
@@ -1,0 +1,514 @@
+/**
+ * SkillBrowserModalCoverage — behaviour coverage for the multi-provider skill
+ * discovery modal: the debounced search gate, the two-pane list/detail layout,
+ * the per-skill install lifecycle (installing / done / conflict / error),
+ * keyboard navigation, and the detail pane's lazy SKILL.md preview.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { DiscoveredSkill, DiscoverInstallResult, DiscoverSkillPreview } from '../types'
+
+/* ── Mocks: must be registered before the component is imported ── */
+const { mockApi, MockApiError } = vi.hoisted(() => {
+  class MockApiError extends Error {
+    readonly status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.name = 'ApiError'
+      this.status = status
+    }
+  }
+  return {
+    mockApi: {
+      discoverSkills: vi.fn(),
+      previewDiscoveredSkill: vi.fn(),
+      installDiscoveredSkill: vi.fn(),
+    },
+    MockApiError,
+  }
+})
+vi.mock('../api/client', () => ({ api: mockApi, ApiError: MockApiError }))
+
+vi.mock('../components/MarkdownRenderer', () => ({
+  default: ({ content }: { content: string }) => <div data-testid="md">{content}</div>,
+}))
+
+// The meta strip belongs to SkillDirectoryBrowser, whose module graph pulls in
+// the syntax-highlight worker client. Stub it and expose the three values the
+// MODAL derives (frontmatter > preview > search result) as data attributes —
+// that derivation is the behaviour under test, not the strip's own markup.
+vi.mock('../components/SkillDirectoryBrowser', () => ({
+  SkillMetaStrip: ({ description, triggers, tags }: {
+    description?: string
+    triggers?: string
+    tags?: string
+  }) => (
+    <div
+      data-testid="meta-strip"
+      data-description={description ?? ''}
+      data-triggers={triggers ?? ''}
+      data-tags={tags ?? ''}
+    />
+  ),
+}))
+
+import SkillBrowserModal, { formatInstalls } from '../components/SkillBrowserModal'
+
+/* ── Fixtures ── */
+const aSkill = (over: Partial<DiscoveredSkill> = {}): DiscoveredSkill => ({
+  id: 'acme/widget-wrangler',
+  name: 'widget-wrangler',
+  description: 'Wrangles widgets from end to end',
+  provider: 'skillsh',
+  display_provider: 'skills.sh',
+  repo_url: 'https://github.com/acme/widget-wrangler',
+  author: 'acme',
+  installed: false,
+  tags: ['widgets', 'ops'],
+  installs: 557834,
+  ...over,
+})
+
+const anInstall = (over: Partial<DiscoverInstallResult> = {}): DiscoverInstallResult => ({
+  ok: true,
+  key: 'skillsh:acme/widget-wrangler',
+  slug: 'widget-wrangler',
+  provider: 'skillsh',
+  kind: 'created',
+  file_count: 1,
+  ...over,
+})
+
+const SKILL_MD = [
+  '---',
+  'name: widget-wrangler',
+  'description: Frontmatter description wins',
+  'triggers: wrangle widgets, tidy widgets',
+  'tags: widgets, ops',
+  '---',
+  '# Wrangling widgets',
+].join('\n')
+
+function deferred<T>() {
+  let settle!: (value: T) => void
+  const promise = new Promise<T>(res => { settle = res })
+  return { promise, settle }
+}
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+
+function renderModal(opts: { open?: boolean; qc?: QueryClient; onClose?: () => void } = {}) {
+  const qc = opts.qc ?? makeClient()
+  const utils = render(
+    <QueryClientProvider client={qc}>
+      <SkillBrowserModal open={opts.open ?? true} onClose={opts.onClose ?? (() => {})} />
+    </QueryClientProvider>,
+  )
+  return { qc, ...utils }
+}
+
+/** Type into the combobox and step past the 300ms query debounce. */
+async function search(text: string) {
+  fireEvent.change(screen.getByRole('combobox', { name: 'Search skills' }), {
+    target: { value: text },
+  })
+  await act(async () => { await vi.advanceTimersByTimeAsync(350) })
+}
+
+// The modal debounces the query behind a 300ms setTimeout. Fake timers keep
+// that callback on a clock this file controls, and clearAllTimers drops any
+// pending one at teardown so it cannot fire into a torn-down document.
+// `shouldAdvanceTime` keeps react-query's own timers behaving as they do on
+// the real clock.
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  Object.values(mockApi).forEach(m => m.mockReset())
+  mockApi.discoverSkills.mockResolvedValue({ results: [], providers: ['skillsh'] })
+  mockApi.previewDiscoveredSkill.mockResolvedValue({
+    name: 'widget-wrangler',
+    description: 'Preview description',
+  } satisfies DiscoverSkillPreview)
+})
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+describe('SkillBrowserModal', () => {
+  it('formats install counts compactly', () => {
+    expect(formatInstalls(557834)).toBe('557.8K')
+    expect(formatInstalls(0)).toBe('0')
+  })
+
+  it('resets session state and refetches discovery results when it opens', () => {
+    const qc = makeClient()
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+    renderModal({ qc })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['discover-skills'] })
+  })
+
+  it('gates the provider query until two characters are typed', async () => {
+    renderModal()
+    expect(screen.getByText('Type at least 2 characters to search')).toBeInTheDocument()
+
+    await search('w')
+    expect(mockApi.discoverSkills).not.toHaveBeenCalled()
+    expect(screen.getByText('Type at least 2 characters to search')).toBeInTheDocument()
+  })
+
+  it('renders debounced results with provider badge, install count and description', async () => {
+    mockApi.discoverSkills.mockResolvedValue({
+      results: [aSkill(), aSkill({ id: 'acme/gadget-gardener', name: 'gadget-gardener', installs: 0, description: '' })],
+      providers: ['skillsh'],
+    })
+    renderModal()
+    await search('widget')
+
+    const row = await screen.findByRole('option', { name: 'widget-wrangler' })
+    expect(mockApi.discoverSkills).toHaveBeenCalledWith('widget')
+    expect(within(row).getByText('skills.sh')).toBeInTheDocument()
+    expect(within(row).getByText('557.8K installs')).toBeInTheDocument()
+    expect(within(row).getByText('Wrangles widgets from end to end')).toBeInTheDocument()
+    expect(screen.getByText('2 results')).toBeInTheDocument()
+    expect(screen.getByText('Searching: skillsh')).toBeInTheDocument()
+
+    // installs === 0 suppresses the download line entirely.
+    const bare = screen.getByRole('option', { name: 'gadget-gardener' })
+    expect(within(bare).queryByText(/installs/)).not.toBeInTheDocument()
+  })
+
+  it('empty result set shows the no-results placeholder', async () => {
+    mockApi.discoverSkills.mockResolvedValue({ results: [], providers: [] })
+    renderModal()
+    await search('nothing-here')
+
+    await waitFor(() => expect(mockApi.discoverSkills).toHaveBeenCalled())
+    expect(screen.getByText(/found for/)).toBeInTheDocument()
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('clearing the search drops the results and the selection', async () => {
+    mockApi.discoverSkills.mockResolvedValue({ results: [aSkill()], providers: ['skillsh'] })
+    renderModal()
+    await search('widget')
+    fireEvent.click(await screen.findByRole('option', { name: 'widget-wrangler' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search' }))
+    await act(async () => { await vi.advanceTimersByTimeAsync(350) })
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(screen.getByText('Type at least 2 characters to search')).toBeInTheDocument()
+  })
+
+  it('detail pane renders frontmatter meta, markdown body and provenance links', async () => {
+    mockApi.discoverSkills.mockResolvedValue({ results: [aSkill()], providers: ['skillsh'] })
+    mockApi.previewDiscoveredSkill.mockResolvedValue({
+      name: 'widget-wrangler',
+      description: 'Preview description',
+      author: 'preview-author',
+      license: 'MIT',
+      content: SKILL_MD,
+      files: ['SKILL.md'],
+      file_count: 3,
+    } satisfies DiscoverSkillPreview)
+    renderModal()
+    await search('widget')
+    fireEvent.click(await screen.findByRole('option', { name: 'widget-wrangler' }))
+
+    await waitFor(() =>
+      expect(mockApi.previewDiscoveredSkill).toHaveBeenCalledWith('skillsh', 'acme/widget-wrangler'))
+
+    const strip = await screen.findByTestId('meta-strip')
+    // Frontmatter beats the preview description, which beats the search row's.
+    expect(strip).toHaveAttribute('data-description', 'Frontmatter description wins')
+    expect(strip).toHaveAttribute('data-triggers', 'wrangle widgets, tidy widgets')
+    expect(strip).toHaveAttribute('data-tags', 'widgets, ops')
+    // Body is rendered without the YAML block.
+    const body = screen.getByTestId('md')
+    expect(body).toHaveTextContent('# Wrangling widgets')
+    expect(body).not.toHaveTextContent('Frontmatter description wins')
+
+    expect(screen.getByText('by preview-author')).toBeInTheDocument()
+    expect(screen.getByText('License: MIT')).toBeInTheDocument()
+    expect(screen.getByText('3 files')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Source/ }))
+      .toHaveAttribute('href', 'https://github.com/acme/widget-wrangler')
+  })
+
+  it('falls back to the search-result tags and author when the preview omits them', async () => {
+    mockApi.discoverSkills.mockResolvedValue({ results: [aSkill()], providers: ['skillsh'] })
+    mockApi.previewDiscoveredSkill.mockResolvedValue({
+      name: 'widget-wrangler',
+      description: '',
+      content: '# No frontmatter here',
+    } satisfies DiscoverSkillPreview)
+    renderModal()
+    await search('widget')
+    fireEvent.click(await screen.findByRole('option', { name: 'widget-wrangler' }))
+
+    const strip = await screen.findByTestId('meta-strip')
+    expect(strip).toHaveAttribute('data-description', 'Wrangles widgets from end to end')
+    expect(strip).toHaveAttribute('data-tags', 'widgets, ops')
+    expect(strip).toHaveAttribute('data-triggers', '')
+    expect(screen.getByText('by acme')).toBeInTheDocument()
+  })
+
+  it('refuses a non-http(s) repo_url as a Source link', async () => {
+    // repo_url is provider-controlled data: a javascript: scheme must never
+    // become a clickable href.
+    mockApi.discoverSkills.mockResolvedValue({
+      results: [aSkill({ repo_url: 'javascript:alert(1)' })],
+      providers: ['skillsh'],
+    })
+    renderModal()
+    await search('widget')
+    fireEvent.click(await screen.findByRole('option', { name: 'widget-wrangler' }))
+
+    await waitFor(() => expect(mockApi.previewDiscoveredSkill).toHaveBeenCalled())
+    expect(screen.queryByRole('link', { name: /Source/ })).not.toBeInTheDocument()
+  })
+
+  it('shows the preview spinner while SKILL.md is in flight', async () => {
+    mockApi.discoverSkills.mockResolvedValue({ results: [aSkill()], providers: ['skillsh'] })
+    const pending = deferred<DiscoverSkillPreview>()
+    mockApi.previewDiscoveredSkill.mockReturnValue(pending.promise)
+    renderModal()
+    await search('widget')
+    fireEvent.click(await screen.findByRole('option', { name: 'widget-wrangler' }))
+
+    expect(await screen.findByText('Loading preview...', undefined, { timeout: 5_000 })).toBeInTheDocument()
+
+    await act(async () => {
+      pending.settle({ name: 'widget-wrangler', description: 'Preview description' })
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    await waitFor(() => expect(screen.queryByText('Loading preview...')).not.toBeInTheDocument())
+  })
+
+  it('falls back to the description, then to a no-preview notice, without SKILL.md', async () => {
+    mockApi.discoverSkills.mockResolvedValue({
+      results: [aSkill({ description: '' })],
+      providers: ['skillsh'],
+    })
+    mockApi.previewDiscoveredSkill.mockResolvedValue({
+      name: 'widget-wrangler',
+      description: '',
+    } satisfies DiscoverSkillPreview)
+    renderModal()
+    await search('widget')
+    fireEvent.click(await screen.findByRole('option', { name: 'widget-wrangler' }))
+
+    expect(await screen.findByText('No preview available.')).toBeInTheDocument()
+    expect(screen.queryByTestId('meta-strip')).not.toBeInTheDocument()
+  })
+
+  it('lists the bundle manifest when the skill ships more than one file', async () => {
+    mockApi.discoverSkills.mockResolvedValue({ results: [aSkill()], providers: ['skillsh'] })
+    mockApi.previewDiscoveredSkill.mockResolvedValue({
+      name: 'widget-wrangler',
+      description: 'Preview description',
+      content: SKILL_MD,
+      files: ['SKILL.md', 'scripts/run.py'],
+      file_count: 2,
+    } satisfies DiscoverSkillPreview)
+    renderModal()
+    await search('widget')
+    fireEvent.click(await screen.findByRole('option', { name: 'widget-wrangler' }))
+
+    expect(await screen.findByText('Bundle contents (2 files)')).toBeInTheDocument()
+    expect(screen.getByText('scripts/run.py')).toBeInTheDocument()
+  })
+
+  it('install flow: installing spinner, then Installed, and the skills list is invalidated', async () => {
+    mockApi.discoverSkills.mockResolvedValue({ results: [aSkill()], providers: ['skillsh'] })
+    const pending = deferred<DiscoverInstallResult>()
+    mockApi.installDiscoveredSkill.mockReturnValue(pending.promise)
+    const qc = makeClient()
+    renderModal({ qc })
+    await search('widget')
+
+    const row = await screen.findByRole('option', { name: 'widget-wrangler' })
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+    fireEvent.click(within(row).getByRole('button', { name: 'Install' }))
+
+    expect(await screen.findByText('Installing...')).toBeInTheDocument()
+    expect(mockApi.installDiscoveredSkill)
+      .toHaveBeenCalledWith('skillsh', 'acme/widget-wrangler', { overwrite: undefined })
+
+    await act(async () => {
+      pending.settle(anInstall())
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(await screen.findByText('Installed')).toBeInTheDocument()
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['skills'] })
+    // Clicking the row after a local install must not re-offer Install.
+    expect(within(row).queryByRole('button', { name: 'Install' })).not.toBeInTheDocument()
+  })
+
+  it('reports the file count when a bundle install writes several files', async () => {
+    mockApi.discoverSkills.mockResolvedValue({ results: [aSkill()], providers: ['skillsh'] })
+    mockApi.installDiscoveredSkill.mockResolvedValue(anInstall({ file_count: 4, kind: 'updated' }))
+    renderModal()
+    await search('widget')
+
+    const row = await screen.findByRole('option', { name: 'widget-wrangler' })
+    fireEvent.click(within(row).getByRole('button', { name: 'Install' }))
+    expect(await screen.findByText('Installed 4 files')).toBeInTheDocument()
+  })
+
+  it('a 409 collision offers Overwrite, which retries with overwrite: true', async () => {
+    mockApi.discoverSkills.mockResolvedValue({ results: [aSkill()], providers: ['skillsh'] })
+    mockApi.installDiscoveredSkill.mockRejectedValueOnce(new MockApiError(409, 'already exists'))
+    renderModal()
+    await search('widget')
+
+    const row = await screen.findByRole('option', { name: 'widget-wrangler' })
+    fireEvent.click(within(row).getByRole('button', { name: 'Install' }))
+
+    expect(await screen.findByText('Exists', undefined, { timeout: 5_000 })).toBeInTheDocument()
+    mockApi.installDiscoveredSkill.mockResolvedValue(anInstall({ kind: 'updated' }))
+    fireEvent.click(within(row).getByRole('button', { name: 'Overwrite' }))
+
+    await waitFor(() => expect(mockApi.installDiscoveredSkill)
+      .toHaveBeenLastCalledWith('skillsh', 'acme/widget-wrangler', { overwrite: true }))
+    expect(await screen.findByText('Installed')).toBeInTheDocument()
+  })
+
+  it('surfaces a non-409 install failure on the row', async () => {
+    mockApi.discoverSkills.mockResolvedValue({ results: [aSkill()], providers: ['skillsh'] })
+    mockApi.installDiscoveredSkill.mockRejectedValue(new MockApiError(503, 'provider unavailable'))
+    renderModal()
+    await search('widget')
+
+    const row = await screen.findByRole('option', { name: 'widget-wrangler' })
+    fireEvent.click(within(row).getByRole('button', { name: 'Install' }))
+    expect(await screen.findByText('provider unavailable', undefined, { timeout: 5_000 })).toBeInTheDocument()
+  })
+
+  it('an already-installed result renders as Installed with no Install action', async () => {
+    mockApi.discoverSkills.mockResolvedValue({
+      results: [aSkill({ installed: true })],
+      providers: ['skillsh'],
+    })
+    renderModal()
+    await search('widget')
+
+    const row = await screen.findByRole('option', { name: 'widget-wrangler' })
+    expect(within(row).getByText('Installed')).toBeInTheDocument()
+    expect(within(row).queryByRole('button', { name: 'Install' })).not.toBeInTheDocument()
+
+    // Enter must not re-install what is already there.
+    const input = screen.getByRole('combobox', { name: 'Search skills' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockApi.installDiscoveredSkill).not.toHaveBeenCalled()
+  })
+
+  it('keyboard: ArrowDown selects the first row and Enter installs it', async () => {
+    mockApi.discoverSkills.mockResolvedValue({
+      results: [aSkill(), aSkill({ id: 'acme/gadget-gardener', name: 'gadget-gardener' })],
+      providers: ['skillsh'],
+    })
+    mockApi.installDiscoveredSkill.mockResolvedValue(anInstall())
+    renderModal()
+    await search('widget')
+    await screen.findByRole('option', { name: 'widget-wrangler' })
+    const input = screen.getByRole('combobox', { name: 'Search skills' })
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'widget-wrangler' }))
+      .toHaveAttribute('aria-selected', 'true'))
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'gadget-gardener' }))
+      .toHaveAttribute('aria-selected', 'true'))
+    // Clamped at the end of the list.
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    expect(screen.getByRole('option', { name: 'gadget-gardener' }))
+      .toHaveAttribute('aria-selected', 'true')
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'widget-wrangler' }))
+      .toHaveAttribute('aria-selected', 'true'))
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => expect(mockApi.installDiscoveredSkill)
+      .toHaveBeenCalledWith('skillsh', 'acme/widget-wrangler', { overwrite: undefined }))
+  })
+
+  it('keyboard: ArrowUp with nothing selected wraps to the last row, and rows handle their own keys', async () => {
+    mockApi.discoverSkills.mockResolvedValue({
+      results: [aSkill(), aSkill({ id: 'acme/gadget-gardener', name: 'gadget-gardener' })],
+      providers: ['skillsh'],
+    })
+    renderModal()
+    await search('widget')
+    const last = await screen.findByRole('option', { name: 'gadget-gardener' })
+    const input = screen.getByRole('combobox', { name: 'Search skills' })
+
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+    await waitFor(() => expect(last).toHaveAttribute('aria-selected', 'true'))
+
+    // The row itself is a keydown target once focusable.
+    fireEvent.keyDown(last, { key: 'ArrowUp' })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'widget-wrangler' }))
+      .toHaveAttribute('aria-selected', 'true'))
+    // An unhandled key is a no-op.
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(screen.getByRole('option', { name: 'widget-wrangler' }))
+      .toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('arrow keys are a no-op before any result arrives', async () => {
+    renderModal()
+    const input = screen.getByRole('combobox', { name: 'Search skills' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockApi.installDiscoveredSkill).not.toHaveBeenCalled()
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('a new result set drops a selection that is no longer present', async () => {
+    mockApi.discoverSkills.mockResolvedValue({ results: [aSkill()], providers: ['skillsh'] })
+    renderModal()
+    await search('widget')
+    fireEvent.click(await screen.findByRole('option', { name: 'widget-wrangler' }))
+    await waitFor(() => expect(mockApi.previewDiscoveredSkill).toHaveBeenCalled())
+
+    mockApi.discoverSkills.mockResolvedValue({
+      results: [aSkill({ id: 'acme/gadget-gardener', name: 'gadget-gardener' })],
+      providers: ['skillsh'],
+    })
+    await search('gadget')
+
+    await screen.findByRole('option', { name: 'gadget-gardener' })
+    expect(await screen.findByText('Select a skill to preview')).toBeInTheDocument()
+  })
+
+  it('the narrow-viewport Back button returns from the detail pane to the list', async () => {
+    mockApi.discoverSkills.mockResolvedValue({ results: [aSkill()], providers: ['skillsh'] })
+    renderModal()
+    await search('widget')
+    fireEvent.click(await screen.findByRole('option', { name: 'widget-wrangler' }))
+
+    // Single-pane mode: the list is hidden below the md breakpoint.
+    const list = screen.getByRole('listbox', { name: 'Skill search results' })
+    await waitFor(() => expect(list).toHaveClass('hidden'))
+
+    fireEvent.click(await screen.findByRole('button', { name: /Back to results/ }))
+    await waitFor(() => expect(list).not.toHaveClass('hidden'))
+  })
+
+  it('unmounting with a pending debounce never fires a provider query', async () => {
+    const { unmount } = renderModal()
+    fireEvent.change(screen.getByRole('combobox', { name: 'Search skills' }), {
+      target: { value: 'widget' },
+    })
+    unmount()
+    await act(async () => { await vi.advanceTimersByTimeAsync(1_000) })
+    expect(mockApi.discoverSkills).not.toHaveBeenCalled()
+  })
+})

--- a/website/src/test/SpecBuilderSpecDetailCoverage.test.tsx
+++ b/website/src/test/SpecBuilderSpecDetailCoverage.test.tsx
@@ -1,0 +1,472 @@
+// Coverage for SpecDetail — the spec workspace shell. Exercises the parts the
+// existing focused tests (chat gating, execute guard) leave untouched: the
+// header identity row, the persisted + draggable docs split, keyboard resize,
+// the fullscreen review overlay and its Esc handler, the phase-gated
+// approve/pause actions, the stacked review-comment tray, and fetch-error
+// surfacing.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// The embedded chat, the document renderer and the state panel are all covered
+// by their own tests; stubbing them keeps this file's assertions about
+// SpecDetail's own behaviour. The DocView stub exposes the selection-to-comment
+// callback as plain buttons so the tray can be driven deterministically.
+vi.mock('../apps/spec-builder/components/ChatColumn', () => ({
+  default: ({ name, slotKey, onSend }: {
+    name: string
+    slotKey?: string
+    onSend: (msg: string) => Promise<unknown>
+  }) => (
+    <div data-testid="chat-column" data-name={name} data-slot={slotKey ?? ''}>
+      <button type="button" data-testid="chat-send" onClick={() => { void onSend('typed in the chat') }}>
+        send
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('../apps/spec-builder/components/DocView', () => ({
+  default: ({ tab, running, addComment }: {
+    tab: string
+    running?: boolean
+    addComment: (c: { file: string; quote: string; note: string }) => void
+  }) => (
+    <div data-testid="doc-view" data-tab={tab} data-running={String(!!running)}>
+      <button
+        type="button"
+        data-testid="add-requirements-comment"
+        onClick={() => addComment({ file: 'requirements.md', quote: 'the system shall log', note: 'name the log' })}
+      >
+        add req
+      </button>
+      <button
+        type="button"
+        data-testid="add-design-comment"
+        onClick={() => addComment({ file: 'design.md', quote: 'a single module', note: 'split it' })}
+      >
+        add design
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('../apps/spec-builder/components/SpecStatePanel', () => ({
+  default: ({ sendMessage }: { sendMessage: (msg: string) => Promise<unknown> }) => (
+    <button type="button" data-testid="state-send" onClick={() => { void sendMessage('Decision: one') }}>
+      answer
+    </button>
+  ),
+}))
+
+import SpecDetail from '../apps/spec-builder/components/SpecDetail'
+import { LS } from '../apps/spec-builder/api'
+
+interface Call { url: string; method: string; body: string }
+
+let queryClient: QueryClient
+let calls: Call[]
+
+const BASE = {
+  name: 'checkout',
+  phase: 'requirements',
+  status: 'planning',
+  running: false,
+  working_dir: '/proj/checkout',
+  spec_dir: '/proj/checkout/.kiro/specs/checkout',
+  slot_key: 'spec-builder-checkout-99',
+  files: { 'requirements.md': '# r' },
+}
+
+const okRes = (text: string) => ({ ok: true, status: 200, text: () => Promise.resolve(text) })
+
+/** Stub fetch: GET answers with `detail`, writes are recorded. `onWrite` may
+ *  return a promise the test controls, to hold a mutation in flight. */
+function installFetch(
+  detail: Record<string, unknown>,
+  onWrite?: (url: string) => Promise<unknown> | undefined,
+) {
+  vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+    const method = init?.method || 'GET'
+    if (method !== 'GET') {
+      calls.push({ url, method, body: String(init?.body ?? '') })
+      const held = onWrite?.(url)
+      if (held) return held
+      return Promise.resolve(okRes('{"ok":true}'))
+    }
+    return Promise.resolve(okRes(JSON.stringify(detail)))
+  }))
+}
+
+function renderDetail(name = 'checkout', setErr: (m: string) => void = () => {}) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SpecDetail name={name} setErr={setErr} />
+    </QueryClientProvider>,
+  )
+}
+
+/** Pick a document tab regardless of whether SegmentedControl collapsed to its
+ *  dropdown (it does under a zero-width test layout). */
+async function selectTab(label: string) {
+  let options = screen.queryAllByRole('button', { name: label })
+  if (!options.length) {
+    fireEvent.click(screen.getAllByRole('button', { name: /Requirements|Design|Tasks/ })[0])
+    options = await screen.findAllByRole('button', { name: label })
+  }
+  fireEvent.click(options[options.length - 1])
+}
+
+beforeEach(() => {
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  calls = []
+  localStorage.clear()
+  // The pulsing dots and the poll both schedule work; without fake timers a
+  // callback can fire after teardown and throw as an unhandled error.
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('SpecDetail header', () => {
+  it('renders the spec identity, phase pill and working directory', async () => {
+    installFetch(BASE)
+    renderDetail()
+
+    expect(await screen.findByTestId('chat-column')).toHaveAttribute('data-slot', 'spec-builder-checkout-99')
+    expect(screen.getByText('requirements')).toBeInTheDocument()
+    expect(screen.getByTitle('/proj/checkout')).toBeInTheDocument()
+    // Not running: no activity indicator, and with no tasks.md no build action.
+    expect(screen.queryByText('working…')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Start building/i })).not.toBeInTheDocument()
+  })
+
+  it('announces agent activity while the spec is running', async () => {
+    installFetch({ ...BASE, running: true })
+    renderDetail()
+
+    expect(await screen.findByText('working…')).toBeInTheDocument()
+    expect(screen.getByTestId('doc-view')).toHaveAttribute('data-running', 'true')
+  })
+
+  it('shows the building label and a Pause action while executing', async () => {
+    installFetch({ ...BASE, status: 'executing', files: { 'requirements.md': '# r', 'tasks.md': '- [ ] one' } })
+    renderDetail()
+
+    expect(await screen.findByText('building')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Pause/ })).toBeInTheDocument()
+    // Executing hides both the approval and the build affordances.
+    expect(screen.queryByRole('button', { name: /Approve/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Start building/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('SpecDetail docs split', () => {
+  it('restores a persisted split width', async () => {
+    localStorage.setItem(LS.docPct, '60')
+    installFetch(BASE)
+    renderDetail()
+
+    await screen.findByTestId('doc-view')
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-valuenow', '60')
+  })
+
+  it('falls back to the default when the persisted width is corrupt', async () => {
+    localStorage.setItem(LS.docPct, 'not-a-number')
+    installFetch(BASE)
+    renderDetail()
+
+    await screen.findByTestId('doc-view')
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-valuenow', '44')
+  })
+
+  it('resizes with the arrow keys and persists the result', async () => {
+    installFetch(BASE)
+    renderDetail()
+
+    await screen.findByTestId('doc-view')
+    const divider = screen.getByRole('separator')
+
+    fireEvent.keyDown(divider, { key: 'ArrowLeft' })
+    expect(divider).toHaveAttribute('aria-valuenow', '48')
+    expect(localStorage.getItem(LS.docPct)).toBe('48')
+
+    fireEvent.keyDown(divider, { key: 'ArrowRight' })
+    expect(divider).toHaveAttribute('aria-valuenow', '44')
+
+    // Any other key is left to the browser.
+    fireEvent.keyDown(divider, { key: 'Enter' })
+    expect(divider).toHaveAttribute('aria-valuenow', '44')
+  })
+
+  it('drags within its clamp and releases the cursor lock on mouse up', async () => {
+    installFetch(BASE)
+    renderDetail()
+
+    await screen.findByTestId('doc-view')
+    const divider = screen.getByRole('separator')
+
+    fireEvent.mouseDown(divider)
+    expect(document.body.style.cursor).toBe('col-resize')
+
+    fireEvent.mouseMove(window, { clientX: 100 })
+    expect(divider).toHaveAttribute('aria-valuenow', '25')
+
+    fireEvent.mouseUp(window)
+    expect(document.body.style.cursor).toBe('')
+
+    // Listeners are gone: a later move must not move the divider.
+    fireEvent.mouseMove(window, { clientX: 400 })
+    expect(divider).toHaveAttribute('aria-valuenow', '25')
+  })
+
+  it('switches the rendered document when another tab is picked', async () => {
+    installFetch(BASE)
+    renderDetail()
+
+    expect(await screen.findByTestId('doc-view')).toHaveAttribute('data-tab', 'requirements')
+    await selectTab('Tasks')
+    await waitFor(() => expect(screen.getByTestId('doc-view')).toHaveAttribute('data-tab', 'tasks'))
+  })
+})
+
+describe('SpecDetail review overlay', () => {
+  it('opens the fullscreen review and closes it with Escape', async () => {
+    installFetch(BASE)
+    renderDetail()
+
+    await screen.findByTestId('doc-view')
+    fireEvent.click(screen.getByRole('button', { name: 'Expand document for review' }))
+
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    // The overlay mounts its own copy of the document pane.
+    expect(screen.getAllByTestId('doc-view')).toHaveLength(2)
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('closes the fullscreen review from its own close button', async () => {
+    installFetch(BASE)
+    renderDetail()
+
+    await screen.findByTestId('doc-view')
+    fireEvent.click(screen.getByRole('button', { name: 'Expand document for review' }))
+    await screen.findByRole('dialog')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close review view' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    // An unrelated key while collapsed is a no-op rather than a crash.
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})
+
+describe('SpecDetail phase actions', () => {
+  it('sends the phase-approval instruction and locks the button while in flight', async () => {
+    let release: (() => void) | undefined
+    installFetch(BASE, (url) => (url.includes('/message')
+      ? new Promise((res) => { release = () => res(okRes('{"ok":true}')) })
+      : undefined))
+    renderDetail()
+
+    const approve = await screen.findByRole('button', { name: /Approve → Design/ })
+    fireEvent.click(approve)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /Sending/ })).toBeDisabled())
+    const sent = calls.filter((c) => c.url.includes('/message'))
+    expect(sent).toHaveLength(1)
+    expect(JSON.parse(sent[0].body).text).toContain('Requirements approved')
+
+    release?.()
+    await waitFor(() => expect(screen.getByRole('button', { name: /Approve → Design/ })).toBeInTheDocument())
+  })
+
+  it('offers the tasks approval on the design phase', async () => {
+    installFetch({ ...BASE, phase: 'design', files: { 'requirements.md': '# r', 'design.md': '# d' } })
+    renderDetail()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Approve → Tasks/ }))
+    await waitFor(() => expect(calls.filter((c) => c.url.includes('/message'))).toHaveLength(1))
+    expect(JSON.parse(calls[0].body).text).toContain('Design approved')
+  })
+
+  it('offers no approval for a phase the table does not know', async () => {
+    installFetch({ ...BASE, phase: 'archived' })
+    renderDetail()
+
+    await screen.findByTestId('doc-view')
+    expect(screen.queryByRole('button', { name: /Approve/ })).not.toBeInTheDocument()
+    expect(screen.getByText('archived')).toBeInTheDocument()
+  })
+
+  it('pauses a running build and disables the control while stopping', async () => {
+    let release: (() => void) | undefined
+    installFetch(
+      { ...BASE, status: 'executing', files: { 'requirements.md': '# r', 'tasks.md': '- [ ] one' } },
+      (url) => (url.includes('/stop')
+        ? new Promise((res) => { release = () => res(okRes('{"ok":true}')) })
+        : undefined),
+    )
+    renderDetail()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Pause/ }))
+    await waitFor(() => expect(screen.getByRole('button', { name: /Pausing/ })).toBeDisabled())
+    expect(calls.filter((c) => c.url.includes('/stop'))).toHaveLength(1)
+    expect(JSON.parse(calls[0].body)).toEqual({
+      spec_dir: '/proj/checkout/.kiro/specs/checkout',
+      slot_key: 'spec-builder-checkout-99',
+    })
+
+    release?.()
+    await waitFor(() => expect(screen.getByRole('button', { name: /Pause/ })).not.toBeDisabled())
+  })
+
+  it('routes a state-panel answer through the shared message mutation', async () => {
+    installFetch(BASE)
+    renderDetail()
+
+    fireEvent.click(await screen.findByTestId('state-send'))
+    await waitFor(() => expect(calls.filter((c) => c.url.includes('/message'))).toHaveLength(1))
+    expect(JSON.parse(calls[0].body).text).toBe('Decision: one')
+  })
+
+  it('routes a chat message through the shared message mutation', async () => {
+    installFetch(BASE)
+    renderDetail()
+
+    fireEvent.click(await screen.findByTestId('chat-send'))
+    await waitFor(() => expect(calls.filter((c) => c.url.includes('/message'))).toHaveLength(1))
+    expect(JSON.parse(calls[0].body).text).toBe('typed in the chat')
+  })
+
+  it('hands the task list off to a build agent', async () => {
+    installFetch({ ...BASE, phase: 'tasks', files: { 'requirements.md': '# r', 'tasks.md': '- [ ] one' } })
+    renderDetail()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Start building/i }))
+    await waitFor(() => expect(calls.filter((c) => c.url.includes('/execute'))).toHaveLength(1))
+    expect(JSON.parse(calls[0].body).slot_key).toBe('spec-builder-checkout-99')
+  })
+
+  it('surfaces a refused handoff', async () => {
+    const setErr = vi.fn()
+    installFetch(
+      { ...BASE, phase: 'tasks', files: { 'requirements.md': '# r', 'tasks.md': '- [ ] one' } },
+      (url) => (url.includes('/execute')
+        ? Promise.resolve({ ok: false, status: 409, json: () => Promise.resolve({ error: 'spec moved' }) })
+        : undefined),
+    )
+    renderDetail('checkout', setErr)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Start building/i }))
+    await waitFor(() => expect(setErr).toHaveBeenCalledWith('spec moved'), { timeout: 5_000 })
+    // The control comes back so the user can retry once the identity is fresh.
+    await waitFor(() => expect(screen.getByRole('button', { name: /Start building/i })).not.toBeDisabled())
+  })
+
+  it('surfaces a refused pause', async () => {
+    const setErr = vi.fn()
+    installFetch(
+      { ...BASE, status: 'executing', files: { 'requirements.md': '# r', 'tasks.md': '- [ ] one' } },
+      (url) => (url.includes('/stop')
+        ? Promise.resolve({ ok: false, status: 409, json: () => Promise.resolve({ error: 'nothing running' }) })
+        : undefined),
+    )
+    renderDetail('checkout', setErr)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Pause/ }))
+    await waitFor(() => expect(setErr).toHaveBeenCalledWith('nothing running'), { timeout: 5_000 })
+  })
+})
+
+describe('SpecDetail review comment tray', () => {
+  it('stacks comments, removes one, and clears the rest', async () => {
+    installFetch(BASE)
+    renderDetail()
+
+    await screen.findByTestId('doc-view')
+    expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('add-requirements-comment'))
+    expect(await screen.findByText('1 pending comment')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('add-design-comment'))
+    expect(await screen.findByText('2 pending comments')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove comment on design.md' }))
+    expect(await screen.findByText('1 pending comment')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Remove comment on design.md' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
+    await waitFor(() => expect(screen.queryByText('1 pending comment')).not.toBeInTheDocument())
+    // Nothing stacked: sending is a no-op with no request behind it.
+    expect(calls.filter((c) => c.url.includes('/message'))).toHaveLength(0)
+  })
+
+  it('sends every stacked comment as one grouped message and empties the tray', async () => {
+    installFetch(BASE)
+    renderDetail()
+
+    await screen.findByTestId('doc-view')
+    fireEvent.click(screen.getByTestId('add-requirements-comment'))
+    fireEvent.click(screen.getByTestId('add-design-comment'))
+    await screen.findByText('2 pending comments')
+
+    fireEvent.click(screen.getByRole('button', { name: /Send all to agent/ }))
+
+    await waitFor(() => expect(calls.filter((c) => c.url.includes('/message'))).toHaveLength(1))
+    const text = JSON.parse(calls[0].body).text as string
+    expect(text).toContain('Review feedback on the spec documents')
+    expect(text).toContain('## requirements.md')
+    expect(text).toContain('## design.md')
+    expect(text).toContain('1. Regarding this passage')
+    expect(text).toContain('the system shall log')
+    expect(text).toContain('split it')
+
+    await waitFor(() => expect(screen.queryByText('2 pending comments')).not.toBeInTheDocument())
+  })
+
+  it('keeps the stack when the send fails', async () => {
+    const setErr = vi.fn()
+    installFetch(BASE, (url) => (url.includes('/message')
+      ? Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({ error: 'agent busy' }) })
+      : undefined))
+    renderDetail('checkout', setErr)
+
+    await screen.findByTestId('doc-view')
+    fireEvent.click(screen.getByTestId('add-requirements-comment'))
+    await screen.findByText('1 pending comment')
+
+    fireEvent.click(screen.getByRole('button', { name: /Send all to agent/ }))
+
+    await waitFor(() => expect(setErr).toHaveBeenCalledWith('agent busy'), { timeout: 5_000 })
+    // The comment survives so the review can be retried.
+    expect(screen.getByText('1 pending comment')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole('button', { name: /Send all to agent/ })).not.toBeDisabled())
+  })
+})
+
+describe('SpecDetail error surfacing', () => {
+  it('reports a failed detail fetch without clearing the pane', async () => {
+    const setErr = vi.fn()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: () => Promise.resolve({ error: 'spec index unavailable' }),
+    }))
+
+    renderDetail('checkout', setErr)
+
+    await waitFor(() => expect(setErr).toHaveBeenCalledWith('spec index unavailable'), { timeout: 5_000 })
+    // No detail: the chat stays withheld and the phase pill falls back.
+    expect(screen.queryByTestId('chat-column')).not.toBeInTheDocument()
+    expect(screen.getByText('…')).toBeInTheDocument()
+  })
+})

--- a/website/src/test/ThemeEditorCoverage.test.tsx
+++ b/website/src/test/ThemeEditorCoverage.test.tsx
@@ -1,0 +1,631 @@
+/**
+ * `components/themeEditor.tsx` — first tests for the custom-theme authoring
+ * surface (the `useThemeEditor` state machine, the two colour widgets, and the
+ * panel that wires them together).
+ *
+ * Two seams, both mocked, and nothing else: `useTheme` (the three theme-store
+ * writes the editor performs) and `api` (the two calls that only exist on the
+ * EDIT path). Everything else runs for real, including `i18nT`, because the
+ * group headings and per-variable labels ARE the catalog keys resolved at render
+ * time — a stub would prove nothing about what the user reads.
+ *
+ * The behaviours worth pinning are the ones a user can silently lose work to:
+ *
+ *  - which save path a click takes: create (`addCustomTheme`) versus update
+ *    (`api.updateTheme` + `loadCustomThemes` + the change event that makes every
+ *    other mounted consumer re-read), since taking the wrong one on an edit
+ *    forks the theme instead of saving it;
+ *  - every validation refusal in JSON mode, each of which must surface as text
+ *    rather than a swallowed throw;
+ *  - the picker/JSON hand-off in BOTH directions — a tab switch that dropped the
+ *    other pane's edits would discard typing the user can still see;
+ *  - delete, which is `confirm`-gated and must write nothing when declined.
+ *
+ * Fake timers are armed purely as a teardown guard: nothing in this tree
+ * schedules one today, and an unhandled late callback would redden the run while
+ * every test still reported as passing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, fireEvent, render, renderHook, screen, waitFor, within } from '@testing-library/react'
+
+import type { CustomThemeData } from '../hooks/useTheme'
+
+/* ── seams ────────────────────────────────────────────────────── */
+
+const themeStore = vi.hoisted(() => ({
+  addCustomTheme: vi.fn<(data: { name: string }) => Promise<unknown>>(),
+  deleteCustomTheme: vi.fn<(slug: string) => Promise<void>>(),
+  loadCustomThemes: vi.fn<() => Promise<void>>(),
+}))
+
+vi.mock('../hooks/useTheme', async importOriginal => {
+  const actual = await importOriginal<typeof import('../hooks/useTheme')>()
+  return { ...actual, useTheme: () => themeStore as unknown as ReturnType<typeof actual.useTheme> }
+})
+
+const apiMocks = vi.hoisted(() => ({
+  themeDetail: vi.fn<(slug: string) => Promise<Partial<CustomThemeData>>>(),
+  updateTheme: vi.fn<(slug: string, body: object) => Promise<unknown>>(),
+}))
+
+vi.mock('../api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return { ...actual, api: { ...actual.api, ...apiMocks } }
+})
+
+import {
+  ColorModeEditor,
+  ColorRow,
+  ThemeEditorPanel,
+  VAR_GROUPS,
+  getCurrentThemeVars,
+  toHex,
+  useThemeEditor,
+} from '../components/themeEditor'
+import { CUSTOM_THEMES_CHANGED_EVENT } from '../hooks/useTheme'
+
+/* ── fixtures ─────────────────────────────────────────────────── */
+
+/** A theme as `api.themeDetail` hands one back for the edit path. */
+const OCEAN: Partial<CustomThemeData> = {
+  name: 'Ocean',
+  emoji: '🌊',
+  dark: { '--bg': '#0b1220', '--accent': '#3b82f6' },
+  light: { '--bg': '#f8fafc', '--accent': '#2563eb' },
+}
+
+/** Minimum shape the JSON pane accepts: a name plus both mode maps. */
+const VALID_JSON = JSON.stringify({
+  name: 'Pasted',
+  dark: { '--bg': '#000000' },
+  light: { '--bg': '#ffffff' },
+})
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.clearAllMocks()
+  themeStore.addCustomTheme.mockResolvedValue({ slug: 'created' })
+  themeStore.deleteCustomTheme.mockResolvedValue()
+  themeStore.loadCustomThemes.mockResolvedValue()
+  apiMocks.themeDetail.mockResolvedValue(OCEAN)
+  apiMocks.updateTheme.mockResolvedValue({ ok: true })
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+/* ── harness ──────────────────────────────────────────────────── */
+
+/**
+ * Drives the real hook the way both call sites do: a trigger that opens a blank
+ * theme, a trigger that loads one for editing, and the panel rendered only while
+ * the editor is open (so a close is observable as the panel disappearing).
+ */
+function Harness({ slug = 'ocean' }: { slug?: string }) {
+  const editor = useThemeEditor()
+  return (
+    <div>
+      <button data-testid="open-new" onClick={editor.openNewTheme}>new</button>
+      <button data-testid="open-edit" onClick={() => void editor.openEditTheme(slug)}>edit</button>
+      {editor.editorOpen && <ThemeEditorPanel editor={editor} />}
+    </div>
+  )
+}
+
+/** Mount the harness and open a blank theme. */
+function openNew() {
+  const utils = render(<Harness />)
+  fireEvent.click(screen.getByTestId('open-new'))
+  return utils
+}
+
+/** Mount the harness and let the edit read settle. */
+async function openEdit(slug = 'ocean') {
+  const utils = render(<Harness slug={slug} />)
+  fireEvent.click(screen.getByTestId('open-edit'))
+  await waitFor(() => expect(apiMocks.themeDetail).toHaveBeenCalled())
+  return utils
+}
+
+/** The one button whose accessible name is exactly `name`. */
+function btn(name: string | RegExp): HTMLElement {
+  return screen.getByRole('button', { name })
+}
+
+/* ── pure helpers ─────────────────────────────────────────────── */
+
+describe('toHex', () => {
+  it('returns opaque black for an empty value', () => {
+    expect(toHex('')).toBe('#000000')
+  })
+
+  it('passes a six-digit hex through untouched', () => {
+    expect(toHex('#AABBCC')).toBe('#AABBCC')
+  })
+
+  it('expands a three-digit hex to six digits', () => {
+    expect(toHex('#abc')).toBe('#aabbcc')
+  })
+
+  it('resolves a non-hex colour through the computed style', () => {
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue(
+      { color: 'rgb(1, 2, 250)' } as unknown as CSSStyleDeclaration,
+    )
+    expect(toHex('rebeccapurple')).toBe('#0102fa')
+  })
+
+  it('falls back to black when the computed colour is not rgb', () => {
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue(
+      { color: 'oklch(0.7 0.1 200)' } as unknown as CSSStyleDeclaration,
+    )
+    expect(toHex('var(--nope)')).toBe('#000000')
+  })
+
+  it('falls back to black when resolving throws, leaving no probe node behind', () => {
+    vi.spyOn(window, 'getComputedStyle').mockImplementation(() => { throw new Error('no layout') })
+    const before = document.body.childElementCount
+    expect(toHex('color-mix(in srgb, red, blue)')).toBe('#000000')
+    expect(document.body.childElementCount).toBe(before)
+  })
+})
+
+describe('getCurrentThemeVars', () => {
+  it('reads every grouped variable plus the ungrouped extras', () => {
+    const vars = getCurrentThemeVars()
+    for (const group of VAR_GROUPS) {
+      for (const key of group.vars) expect(vars).toHaveProperty(key)
+    }
+    expect(vars).toHaveProperty('--shadow-lg')
+    expect(vars).toHaveProperty('--diff-add')
+    expect(Object.values(vars).every(v => typeof v === 'string')).toBe(true)
+  })
+
+  it('returns the trimmed value the document actually carries', () => {
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue(
+      { getPropertyValue: () => '  #123456  ' } as unknown as CSSStyleDeclaration,
+    )
+    expect(getCurrentThemeVars()['--bg']).toBe('#123456')
+  })
+})
+
+/* ── useThemeEditor ───────────────────────────────────────────── */
+
+describe('useThemeEditor', () => {
+  it('opens a blank theme seeded from the live CSS variables', () => {
+    const { result } = renderHook(() => useThemeEditor())
+    act(() => result.current.openNewTheme())
+
+    expect(result.current.editorOpen).toBe(true)
+    expect(result.current.isEditing).toBe(false)
+    expect(result.current.creatorMode).toBe('picker')
+    expect(result.current.themeName).toBe('')
+    expect(result.current.themeEmoji).toBe('✨')
+    expect(Object.keys(result.current.darkVars).length).toBeGreaterThan(0)
+    expect(result.current.lightVars).toEqual(result.current.darkVars)
+  })
+
+  it('loads a theme for editing and closes back to a clean slate', async () => {
+    const { result } = renderHook(() => useThemeEditor())
+    await act(async () => { await result.current.openEditTheme('ocean') })
+
+    expect(result.current.isEditing).toBe(true)
+    expect(result.current.editingSlug).toBe('ocean')
+    expect(result.current.themeName).toBe('Ocean')
+    expect(result.current.themeEmoji).toBe('🌊')
+    expect(result.current.darkVars).toEqual(OCEAN.dark)
+    expect(result.current.jsonText).toContain('"name": "Ocean"')
+
+    act(() => result.current.closeEditor())
+    expect(result.current.editorOpen).toBe(false)
+    expect(result.current.editingSlug).toBeNull()
+  })
+
+  it('substitutes defaults for the fields a stored theme omits', async () => {
+    apiMocks.themeDetail.mockResolvedValue({})
+    const { result } = renderHook(() => useThemeEditor())
+    await act(async () => { await result.current.openEditTheme('bare') })
+
+    expect(result.current.themeName).toBe('')
+    expect(result.current.themeEmoji).toBe('🎨')
+    expect(result.current.darkVars).toEqual({})
+    expect(result.current.lightVars).toEqual({})
+  })
+
+  it('opens the editor with an error when the theme cannot be read', async () => {
+    apiMocks.themeDetail.mockRejectedValue(new Error('404'))
+    const { result } = renderHook(() => useThemeEditor())
+    await act(async () => { await result.current.openEditTheme('gone') })
+
+    expect(result.current.error).toBe('Failed to load theme for editing')
+    expect(result.current.editorOpen).toBe(true)
+    expect(result.current.isEditing).toBe(false)
+  })
+
+  it('refuses to save a picker theme with no name', async () => {
+    const { result } = renderHook(() => useThemeEditor())
+    act(() => result.current.setThemeName('   '))
+    await act(async () => { await result.current.saveTheme() })
+
+    expect(result.current.error).toBe('Theme name is required.')
+    expect(themeStore.addCustomTheme).not.toHaveBeenCalled()
+    expect(result.current.saving).toBe(false)
+  })
+
+  it('creates from the picker with a trimmed name and the default emoji', async () => {
+    const { result } = renderHook(() => useThemeEditor())
+    act(() => {
+      result.current.setThemeName('  Sunset  ')
+      result.current.setThemeEmoji('  ')
+      result.current.updateDarkVar('--bg', '#101010')
+      result.current.updateLightVar('--bg', '#fefefe')
+    })
+    await act(async () => { await result.current.saveTheme() })
+
+    expect(themeStore.addCustomTheme).toHaveBeenCalledWith({
+      name: 'Sunset',
+      emoji: '✨',
+      dark: { '--bg': '#101010' },
+      light: { '--bg': '#fefefe' },
+    })
+    expect(result.current.editorOpen).toBe(false)
+  })
+
+  it('reports a non-Error save rejection through the catalog fallback', async () => {
+    themeStore.addCustomTheme.mockRejectedValue('nope')
+    const { result } = renderHook(() => useThemeEditor())
+    act(() => result.current.setThemeName('Sunset'))
+    await act(async () => { await result.current.saveTheme() })
+
+    expect(result.current.error).toBe('Failed to save theme')
+    expect(result.current.editorOpen).toBe(false)
+  })
+
+  it('rejects malformed JSON before any write', async () => {
+    const { result } = renderHook(() => useThemeEditor())
+    act(() => { result.current.setCreatorMode('json'); result.current.setJsonText('{ nope') })
+    await act(async () => { await result.current.saveTheme() })
+
+    expect(result.current.error).toBe('Invalid JSON — check syntax and try again.')
+    expect(themeStore.addCustomTheme).not.toHaveBeenCalled()
+  })
+
+  it('rejects JSON without a name', async () => {
+    const { result } = renderHook(() => useThemeEditor())
+    act(() => { result.current.setCreatorMode('json'); result.current.setJsonText('{"dark":{},"light":{}}') })
+    await act(async () => { await result.current.saveTheme() })
+
+    expect(result.current.error).toBe('JSON must include a "name" field.')
+  })
+
+  it('rejects JSON missing either mode map', async () => {
+    const { result } = renderHook(() => useThemeEditor())
+    act(() => { result.current.setCreatorMode('json'); result.current.setJsonText('{"name":"X","dark":{}}') })
+    await act(async () => { await result.current.saveTheme() })
+
+    expect(result.current.error).toBe('JSON must include "dark" and "light" objects.')
+  })
+
+  it('creates from valid JSON, defaulting the emoji', async () => {
+    const { result } = renderHook(() => useThemeEditor())
+    act(() => { result.current.setCreatorMode('json'); result.current.setJsonText(VALID_JSON) })
+    await act(async () => { await result.current.saveTheme() })
+
+    expect(themeStore.addCustomTheme).toHaveBeenCalledWith({
+      name: 'Pasted',
+      emoji: '✨',
+      dark: { '--bg': '#000000' },
+      light: { '--bg': '#ffffff' },
+    })
+  })
+
+  it('updates an existing theme from JSON and announces the change', async () => {
+    const seen = vi.fn()
+    window.addEventListener(CUSTOM_THEMES_CHANGED_EVENT, seen)
+    try {
+      const { result } = renderHook(() => useThemeEditor())
+      await act(async () => { await result.current.openEditTheme('ocean') })
+      act(() => { result.current.setCreatorMode('json'); result.current.setJsonText(VALID_JSON) })
+      await act(async () => { await result.current.saveTheme() })
+
+      expect(apiMocks.updateTheme).toHaveBeenCalledWith('ocean', {
+        name: 'Pasted',
+        emoji: '🎨',
+        dark: { '--bg': '#000000' },
+        light: { '--bg': '#ffffff' },
+      })
+      expect(themeStore.loadCustomThemes).toHaveBeenCalled()
+      expect(seen).toHaveBeenCalled()
+      expect(themeStore.addCustomTheme).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener(CUSTOM_THEMES_CHANGED_EVENT, seen)
+    }
+  })
+
+  it('does nothing on delete when no theme is targeted', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const { result } = renderHook(() => useThemeEditor())
+    await act(async () => { await result.current.handleDelete() })
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(themeStore.deleteCustomTheme).not.toHaveBeenCalled()
+  })
+
+  it('writes nothing when the delete confirmation is declined', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { result } = renderHook(() => useThemeEditor())
+    await act(async () => { await result.current.handleDelete('ocean') })
+
+    expect(themeStore.deleteCustomTheme).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a failed delete instead of closing the editor', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    themeStore.deleteCustomTheme.mockRejectedValue(new Error('in use'))
+    const { result } = renderHook(() => useThemeEditor())
+    await act(async () => { await result.current.openEditTheme('ocean') })
+    await act(async () => { await result.current.handleDelete() })
+
+    expect(result.current.error).toBe('in use')
+    expect(result.current.editorOpen).toBe(true)
+  })
+
+  it('reports a non-Error delete rejection through the catalog fallback', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    themeStore.deleteCustomTheme.mockRejectedValue('boom')
+    const { result } = renderHook(() => useThemeEditor())
+    await act(async () => { await result.current.handleDelete('ocean') })
+
+    expect(result.current.error).toBe('Failed to delete theme')
+  })
+
+  it('adopts only the fields present in pasted JSON and ignores invalid text', () => {
+    const { result } = renderHook(() => useThemeEditor())
+    act(() => result.current.syncJsonToPicker('{"name":"Half","dark":{"--bg":"#010101"}}'))
+
+    expect(result.current.themeName).toBe('Half')
+    expect(result.current.themeEmoji).toBe('✨')
+    expect(result.current.darkVars).toEqual({ '--bg': '#010101' })
+    expect(result.current.lightVars).toEqual({})
+
+    act(() => result.current.syncJsonToPicker('not json'))
+    expect(result.current.themeName).toBe('Half')
+  })
+
+  it('projects the picker to JSON only once there is something to project', () => {
+    const { result } = renderHook(() => useThemeEditor())
+    expect(result.current.pickerToJson).toBe('')
+
+    act(() => { result.current.setThemeName('Named'); result.current.setThemeEmoji('') })
+    expect(JSON.parse(result.current.pickerToJson)).toEqual({
+      name: 'Named', emoji: '✨', dark: {}, light: {},
+    })
+
+    act(() => { result.current.setThemeName(''); result.current.updateDarkVar('--bg', '#020202') })
+    expect(JSON.parse(result.current.pickerToJson).name).toBe('My Theme')
+  })
+})
+
+/* ── ColorRow ─────────────────────────────────────────────────── */
+
+describe('ColorRow', () => {
+  it('offers a native colour well for a simple colour and reports both edits', () => {
+    const onChange = vi.fn()
+    render(<ColorRow label="Background" value="#abc" onChange={onChange} />)
+
+    const well = screen.getByLabelText('Background color picker') as HTMLInputElement
+    expect(well.type).toBe('color')
+    expect(well.value).toBe('#aabbcc')
+
+    fireEvent.change(well, { target: { value: '#123456' } })
+    expect(onChange).toHaveBeenLastCalledWith('#123456')
+
+    fireEvent.change(screen.getByLabelText('Background'), { target: { value: 'salmon' } })
+    expect(onChange).toHaveBeenLastCalledWith('salmon')
+  })
+
+  it('accepts a bare colour keyword as simple', () => {
+    render(<ColorRow label="Accent" value="salmon" onChange={vi.fn()} />)
+    expect(screen.getByLabelText('Accent color picker')).toBeInTheDocument()
+  })
+
+  it('falls back to a preview swatch for a value a colour well cannot hold', () => {
+    render(<ColorRow label="Panel" value="linear-gradient(red, blue)" onChange={vi.fn()} />)
+
+    expect(screen.queryByLabelText('Panel color picker')).toBeNull()
+    expect(screen.getByLabelText('Panel')).toHaveValue('linear-gradient(red, blue)')
+  })
+})
+
+/* ── ColorModeEditor ──────────────────────────────────────────── */
+
+describe('ColorModeEditor', () => {
+  const VARS = { '--bg': '#111111', '--text': '#eeeeee' }
+
+  it('renders one collapsed accordion per variable group', () => {
+    render(<ColorModeEditor label="Dark Mode Colors" vars={VARS} onChange={vi.fn()} />)
+
+    expect(screen.getByText('Dark Mode Colors')).toBeInTheDocument()
+    for (const heading of ['Backgrounds', 'Text & Muted', 'Borders', 'Accent', 'Status']) {
+      // Regex, not an exact name: each accordion header's accessible name also
+      // carries the five swatch previews and the ▲/▼ affordance beside it.
+      expect(btn(new RegExp(heading))).toBeInTheDocument()
+    }
+    expect(screen.queryByLabelText('Background color picker')).toBeNull()
+  })
+
+  it('expands one group at a time and collapses it on a second click', () => {
+    const onChange = vi.fn()
+    render(<ColorModeEditor label="Dark Mode Colors" vars={VARS} onChange={onChange} />)
+
+    fireEvent.click(btn(/Backgrounds/))
+    expect(screen.getByLabelText('Background color picker')).toBeInTheDocument()
+    expect(screen.getByLabelText('Panel Strong')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Bg Hover'), { target: { value: '#333333' } })
+    expect(onChange).toHaveBeenCalledWith('--bg-hover', '#333333')
+
+    fireEvent.click(btn(/Text & Muted/))
+    expect(screen.queryByLabelText('Background color picker')).toBeNull()
+    expect(screen.getByLabelText('Muted Strong')).toBeInTheDocument()
+
+    fireEvent.click(btn(/Text & Muted/))
+    expect(screen.queryByLabelText('Muted Strong')).toBeNull()
+  })
+
+  it('titles each swatch preview with the variable it stands for', () => {
+    render(<ColorModeEditor label="Dark Mode Colors" vars={VARS} onChange={vi.fn()} />)
+    const row = btn(/Backgrounds/)
+
+    expect(within(row).getByTitle('Background: #111111')).toBeInTheDocument()
+    expect(within(row).getByTitle('Card: ?')).toBeInTheDocument()
+  })
+})
+
+/* ── ThemeEditorPanel ─────────────────────────────────────────── */
+
+describe('ThemeEditorPanel', () => {
+  it('opens on the picker with both mode editors and no destructive action', () => {
+    openNew()
+
+    expect(screen.getByLabelText('Theme Name')).toHaveValue('')
+    expect(screen.getByLabelText('Emoji')).toHaveValue('✨')
+    expect(screen.getByText('Dark Mode Colors')).toBeInTheDocument()
+    expect(screen.getByText('Light Mode Colors')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /Backgrounds/ })).toHaveLength(2)
+    expect(btn('Save Theme')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Delete Theme/ })).toBeNull()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('carries the picker into the JSON pane and the JSON edits back out', () => {
+    openNew()
+
+    fireEvent.change(screen.getByLabelText('Theme Name'), { target: { value: 'Draft' } })
+    fireEvent.click(btn(/Paste JSON/))
+
+    const area = screen.getByLabelText('Theme JSON') as HTMLTextAreaElement
+    expect(JSON.parse(area.value).name).toBe('Draft')
+
+    fireEvent.change(area, { target: { value: '{"name":"Renamed","emoji":"🌙"}' } })
+    fireEvent.click(btn(/Color Picker/))
+
+    expect(screen.getByLabelText('Theme Name')).toHaveValue('Renamed')
+    expect(screen.getByLabelText('Emoji')).toHaveValue('🌙')
+  })
+
+  it('adopts JSON edits on blur without leaving the pane', () => {
+    openNew()
+    fireEvent.click(btn(/Paste JSON/))
+
+    const area = screen.getByLabelText('Theme JSON')
+    fireEvent.change(area, { target: { value: '{"name":"Blurred"}' } })
+    fireEvent.blur(area)
+    fireEvent.click(btn(/Color Picker/))
+
+    expect(screen.getByLabelText('Theme Name')).toHaveValue('Blurred')
+  })
+
+  it('creates the theme and dismisses itself on save', async () => {
+    openNew()
+    fireEvent.change(screen.getByLabelText('Theme Name'), { target: { value: 'Fresh' } })
+    fireEvent.change(screen.getByLabelText('Emoji'), { target: { value: '🌞' } })
+    fireEvent.click(btn('Save Theme'))
+
+    await waitFor(() => expect(themeStore.addCustomTheme).toHaveBeenCalled(), { timeout: 5_000 })
+    expect(themeStore.addCustomTheme.mock.calls[0][0]).toMatchObject({ name: 'Fresh', emoji: '🌞' })
+    await waitFor(() => expect(screen.queryByLabelText('Theme Name')).toBeNull())
+  })
+
+  it('shows the in-flight label and blocks a second save while one is running', async () => {
+    let release = (): void => {}
+    themeStore.addCustomTheme.mockImplementation(
+      () => new Promise(resolve => { release = () => resolve({}) }),
+    )
+
+    openNew()
+    fireEvent.change(screen.getByLabelText('Theme Name'), { target: { value: 'Slow' } })
+    fireEvent.click(btn('Save Theme'))
+
+    const saving = await screen.findByRole('button', { name: /Saving/ }, { timeout: 5_000 })
+    expect(saving).toBeDisabled()
+
+    await act(async () => { release() })
+    await waitFor(() => expect(screen.queryByLabelText('Theme Name')).toBeNull())
+  })
+
+  it('surfaces a validation refusal as an alert and keeps the form open', async () => {
+    openNew()
+    fireEvent.click(btn(/Paste JSON/))
+    fireEvent.change(screen.getByLabelText('Theme JSON'), { target: { value: '{oops}' } })
+    fireEvent.click(btn('Save Theme'))
+
+    const alert = await screen.findByRole('alert', undefined, { timeout: 5_000 })
+    expect(alert).toHaveTextContent('Invalid JSON')
+    expect(screen.getByLabelText('Theme JSON')).toBeInTheDocument()
+  })
+
+  it('closes without writing when cancelled', () => {
+    openNew()
+    fireEvent.click(btn('Cancel'))
+
+    expect(screen.queryByLabelText('Theme Name')).toBeNull()
+    expect(themeStore.addCustomTheme).not.toHaveBeenCalled()
+  })
+
+  it('names the theme under edit and offers update plus delete', async () => {
+    await openEdit()
+
+    expect(screen.getByText(/Editing:/)).toBeInTheDocument()
+    expect(await screen.findByLabelText('Theme Name')).toHaveValue('Ocean')
+    expect(btn('Update Theme')).toBeInTheDocument()
+    expect(btn(/Delete Theme/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save Theme' })).toBeNull()
+  })
+
+  it('falls back to the slug while an edited theme has no name', async () => {
+    apiMocks.themeDetail.mockResolvedValue({ dark: {}, light: {} })
+    await openEdit('seafoam')
+
+    await waitFor(() => expect(screen.getByText(/seafoam/)).toBeInTheDocument())
+  })
+
+  it('takes the update path rather than creating a second theme', async () => {
+    const seen = vi.fn()
+    window.addEventListener(CUSTOM_THEMES_CHANGED_EVENT, seen)
+    try {
+      await openEdit()
+      await waitFor(() => expect(screen.getByLabelText('Theme Name')).toHaveValue('Ocean'))
+      fireEvent.click(btn('Update Theme'))
+
+      await waitFor(() => expect(apiMocks.updateTheme).toHaveBeenCalled(), { timeout: 5_000 })
+      expect(apiMocks.updateTheme).toHaveBeenCalledWith('ocean', {
+        name: 'Ocean', emoji: '🌊', dark: OCEAN.dark, light: OCEAN.light,
+      })
+      expect(themeStore.loadCustomThemes).toHaveBeenCalled()
+      expect(seen).toHaveBeenCalled()
+      expect(themeStore.addCustomTheme).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener(CUSTOM_THEMES_CHANGED_EVENT, seen)
+    }
+  })
+
+  it('deletes the edited theme once the confirmation is accepted', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    await openEdit()
+    fireEvent.click(btn(/Delete Theme/))
+
+    await waitFor(() => expect(themeStore.deleteCustomTheme).toHaveBeenCalledWith('ocean'), { timeout: 5_000 })
+    await waitFor(() => expect(screen.queryByLabelText('Theme Name')).toBeNull())
+  })
+
+  it('reports a failed load in the panel it opens', async () => {
+    apiMocks.themeDetail.mockRejectedValue(new Error('404'))
+    await openEdit('gone')
+
+    const alert = await screen.findByRole('alert', undefined, { timeout: 5_000 })
+    expect(alert).toHaveTextContent('Failed to load theme for editing')
+  })
+})


### PR DESCRIPTION
## What

12 new vitest files (359 tests) raising frontend statement coverage from
**84.71% → 86.04%**, a net **+924 statements**. Tests only — no product code is
touched.

## Why these components

Targets were ranked by **absolute uncovered-statement mass**, not by percentage.
An 800-statement page sitting at 72% carries more recoverable mass than a small
component at 20%, and ranking by percentage sends you to the wrong files.

| statements | file |
|---|---|
| 165 | `src/pages/ChatSidebar.tsx` |
| 87 | `src/pages/ChatPage.tsx` |
| 77 | `src/components/SkillBrowserModal.tsx` |
| 72 | `src/pages/ProjectDetailPage.tsx` |
| 71 | `src/pages/LocalStorageDebug.tsx` |
| 70 | `src/apps/issue-radar/components/PrList.tsx` |
| 69 | `src/pages/settings/WebexPanel.tsx` |
| 68 | `src/components/themeEditor.tsx` |
| 63 | `src/components/AppHost.tsx` |
| 58 | `src/pages/settings/VoicePanel.tsx` |
| 57 | `src/pages/settings/RemoteCrewPanel.tsx` |
| 51 | `src/apps/spec-builder/components/SpecDetail.tsx` |

## How the number was measured

**Measured, not estimated** — but it needed a correction worth stating plainly.

main publishes no readable frontend coverage artifact (only the per-shard
`frontend-blob-N`), so there is no baseline to union against the way the backend
lane does. Both sides were therefore produced locally:

- **baseline** — full suite with these 12 files excluded (1,011 files, 16,656 tests)
- **wave** — the 12 new files alone
- **delta** — union of the two, restricted to the baseline's denominator

Statement coverage is monotonic in the set of tests executed, so that union is
what CI will report.

Two **pre-existing** flakes (`MdNotebookPageCoverage`, `CliPanelCoverage`) fail
only under the full concurrent run and pass in isolation, so they were excluded
from the baseline run — vitest writes no coverage report *at all* on a non-zero
exit, so leaving them in risks losing the whole measurement.

That exclusion introduces a bias in the **flattering** direction, not a
conservative one: dropping those test files makes the modules they exercise look
under-covered, so lines that both they and this wave cover get miscredited to
this wave. Their coverage was measured separately and added back into the
baseline. The correction is real — it moves the delta from **1,014 down to 924**
statements and removes `CliPanel.tsx` from the contributor list entirely. The
figure above is the corrected one.

## Verification

- 12 files / **359 tests pass**
- `tsc --noEmit`: exit 0
- `eslint src/ --max-warnings 1116`: exit 0 (602 warnings, under the cap)
- `jscpd .`: 0 clones
- brand gate with `BRAND_BASE_REF=origin/main`: exit 0

## Scope

`FRONTEND_MIN` is deliberately **not** raised here. The floor ratchet is a
separate change once both lanes are on main, because it also has to update the
rounding comment in `ci.yml`, the prompt text in the review workflows, and
`docs/ci/ci-and-reviews.md` together.

Remaining gap to 90% on this lane after this PR: **2,737 statements**.
