### PR TITLE
fix(dashboard): offer Korean in the STT language picker

### DIFF
--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -492,6 +492,7 @@ _STT_LANGUAGE_CODES: tuple[str, ...] = (
     "it-IT",
     "pt-BR",
     "ja-JP",
+    "ko-KR",
     "zh-CN",
 )
 

--- a/test/test_stt_stream.py
+++ b/test/test_stt_stream.py
@@ -741,6 +741,62 @@ class TestConfigPutRoundTrip:
             assert "fr-FR" in data["language_codes"]
 
 
+class TestSttLanguageCodes:
+    """The language list that drives the Chat Settings STT picker.
+
+    The picker is the only supported way to choose a recognition language, so a
+    language missing from this list is unreachable without hand-editing
+    config.json — even when the provider (AWS Transcribe) supports it.
+    """
+
+    def test_korean_is_offered(self):
+        """Korean must be selectable in the picker.
+
+        Regression: `ko-KR` was absent while ja-JP and zh-CN were present, so
+        Korean speakers could not choose their language from the dashboard.
+        """
+        from kiro_crew.dashboard.handlers.core import _STT_LANGUAGE_CODES
+
+        assert "ko-KR" in _STT_LANGUAGE_CODES
+
+    def test_codes_are_unique_and_well_formed(self):
+        """Every entry is a distinct `ll-CC` BCP-47 tag.
+
+        A duplicate renders twice in the dropdown, and a malformed tag is
+        rejected by Transcribe at stream-start rather than at selection time.
+        """
+        from kiro_crew.dashboard.handlers.core import _STT_LANGUAGE_CODES
+
+        assert len(set(_STT_LANGUAGE_CODES)) == len(_STT_LANGUAGE_CODES)
+        for code in _STT_LANGUAGE_CODES:
+            language, _, region = code.partition("-")
+            assert language.isalpha() and language.islower() and len(language) == 2, code
+            assert region.isalpha() and region.isupper() and len(region) == 2, code
+
+    @pytest.mark.asyncio
+    async def test_korean_round_trips_through_the_config_api(self, tmp_path, monkeypatch):
+        """Selecting Korean persists and is served back to the UI."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        from kiro_crew.dashboard import handlers
+
+        app = web.Application()
+        app.router.add_get("/api/config/stt", handlers.api_stt_config)
+        app.router.add_put("/api/config/stt", handlers.api_stt_config)
+
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.put(
+                "/api/config/stt",
+                json={"provider": "transcribe", "language_code": "ko-KR"},
+            )
+            assert resp.status == 200
+
+            resp = await client.get("/api/config/stt")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["language_code"] == "ko-KR"
+            assert "ko-KR" in data["language_codes"]
+
+
 class TestDefensiveGuards:
     """Regression tests for review-bot rev 2 findings (posts #9, #10)."""
 


### PR DESCRIPTION
# What is the problem?

Korean is not selectable as a speech-to-text recognition language. The Chat Settings STT language picker offers English, French, German, Spanish, Italian, Portuguese, Japanese and Chinese, but no Korean entry — so a Korean speaker cannot choose their own language from the dashboard.

# Why this issue matters to the user

The picker is the only supported way to set the recognition language, so its contents decide which languages the feature is usable in. AWS Transcribe supports Korean and the backend already accepts the tag, which makes this a gap in the surface rather than a missing capability: everything needed to transcribe Korean is present except the one line that lets a user ask for it.

The remaining route is to hand-edit `stt.language_code` in `config.json`. That is not a setting a user is expected to discover, and it silently splits the feature's audience — `ja-JP` and `zh-CN` are listed one line above, so Korean reads as an omission rather than a decision.

# How our fix solves it

Symptom → root cause chain:

1. `SttSettings.tsx` renders `stt.language_codes?.length ? stt.language_codes : ['en-US']` — the picker has no list of its own.
2. `language_codes` is served by `api_stt_config` from `_STT_LANGUAGE_CODES` in `src/kiro_crew/dashboard/handlers/core.py`.
3. That tuple listed `ja-JP` and `zh-CN` but not `ko-KR`, so no Korean option could ever render.

So the fix is one entry in the backend tuple, not a frontend change. `ko-KR` is added between `ja-JP` and `zh-CN`, keeping the CJK tags together in the order the list already uses.

Nothing else needed changing. The comment above the tuple already documents the contract this relies on — the PUT handler accepts any string and the tuple only drives the dropdown — which is also why the manual `config.json` override worked and why adding the entry is sufficient.

# What tests we did

Three tests added as `TestSttLanguageCodes` in `test/test_stt_stream.py`, beside the existing test that asserts the served `language_codes`:

- `ko-KR` is present in the picker list
- every entry is a distinct, well-formed `ll-CC` tag — this is what makes the test a guard on the list rather than on one string, so a future duplicate or malformed tag fails here instead of at stream-start
- a Korean selection round-trips through `PUT`/`GET /api/config/stt` and comes back in both `language_code` and `language_codes`

Confirmed the tests actually guard the defect: reverted the one-line source change and re-ran them — 2 failed, 1 passed; restored it — 3 passed.

Verified locally in a worktree: `isort` clean, `flake8` clean, `black --check` clean, `mypy` clean on the changed file, and 306 passed / 1 skipped across `test_stt_stream.py`, `test_transcribe.py`, `test_stt_endpointing.py`, `test_dashboard_handlers_core_coverage.py` and `test_apple_speech.py`.

Two things I did not do, deliberately. A repo-wide `mypy` run reports three pre-existing errors in `hooks.py` (`os.setxattr` / `getxattr` / `listxattr`), which are macOS-only — those attributes do not exist on darwin and CI runs on Linux; the file is untouched by this change. The frontend gates were not run because no frontend file changed.

# Manual verification

Not performed. The change is a single entry in the list the picker is built from, and the config-API round-trip test exercises the same path the dashboard uses to read and write it. Exercising the transcription itself would need live AWS Transcribe credentials.

# Any other suggestions on the work

This is scoped to the reported defect. Two adjacent things worth noting rather than folding in:

- The curated list will keep drifting behind what Transcribe supports. Serving the provider's own language set, or documenting the list as deliberately curated, would settle that — a maintainer call, not a bug fix.
- #2952 asks for Japanese STT and TTS. `ja-JP` is already in this tuple, so whatever that issue is about, it is not this list — most likely the TTS voice side. Left alone so the two are not conflated.

Closes #3001
