### PR TITLE
fix(telegram): key the mirror opt-out by the durable bucket and keep explicit binds

### DIFF
--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -78,6 +78,7 @@ import asyncio
 import inspect
 import logging
 import os
+import re
 import threading
 import time
 from collections import deque
@@ -390,6 +391,34 @@ _CIRCUIT_BREAKER_THRESHOLD = 5
 # Cap on remembered per-session channel notice targets. reset()/remove() evict
 # their own entries, so this only bounds sessions dropped by some other path.
 _MAX_ORIGIN_LINKS = 512
+
+
+# Trailing ``:gen{N}`` on a session key. Matched here rather than reused from
+# messaging.link because that module's copy is private to its own parser.
+_GEN_SUFFIX_RE = re.compile(r"^gen\d+$")
+
+
+def _opt_out_key(key: str) -> str:
+    """The key an automatic-mirroring refusal is stored under.
+
+    The durable BUCKET, never the generation-suffixed session key. The refusal is
+    a preference about the CONVERSATION, not about one session — the same reason
+    the per-route model choice is not keyed by session — and generations rotate
+    on ``/new`` and on the configured idle/daily reset. Keyed per generation, an
+    idle rotation would silently undo the user's "off" with no action on their
+    part, and every rotated generation would strand its own row that pruning is
+    forbidden to collect. Bucket-keyed, one conversation holds one such row.
+
+    The suffix is stripped textually rather than through the canonical parser,
+    because the shapes that most need it are the ones the parser rejects: a
+    ``dm_scope="unified"`` bucket is ``unified:{agent}``, which is too short for
+    the §9 grammar, so a parser-only rule would leave unified conversations keyed
+    per generation — exactly the bug this function exists to prevent.
+    """
+    canon = canonical_key(key)
+    head, sep, tail = canon.rpartition(":")
+    return head if sep and _GEN_SUFFIX_RE.match(tail) else canon
+
 
 # Background session recycle thresholds (more aggressive than chat compaction)
 _BG_RECYCLE_PCT = 70.0  # recycle at 70% — well before overflow
@@ -4209,11 +4238,41 @@ class SessionManager:
         dashboard link is a direct instruction and :meth:`set_mirror_link` never
         reads it.
         """
-        self._session_map.set_flag(key, MIRROR_OPT_OUT_FLAG, opted_out)
+        with self._session_map.batched_save():
+            self._session_map.set_flag(_opt_out_key(key), MIRROR_OPT_OUT_FLAG, opted_out)
+            # Retire a refusal an earlier build stored under the generation key,
+            # so it cannot outlive a withdrawal made through the bucket.
+            legacy = canonical_key(key)
+            if legacy != _opt_out_key(key):
+                self._session_map.set_flag(legacy, MIRROR_OPT_OUT_FLAG, False)
 
     def mirror_opt_out(self, key: str) -> bool:
-        """True iff this conversation declined automatic origin mirroring."""
-        return self._session_map.get_flag(key, MIRROR_OPT_OUT_FLAG)
+        """True iff this conversation declined automatic origin mirroring.
+
+        Reads the bucket, then falls back to the generation key an earlier build
+        wrote. Without the fallback, upgrading silently restores mirroring for
+        every conversation that had already turned it off — the exact failure the
+        flag exists to prevent, delivered by the fix for it.
+
+        A legacy hit is PROMOTED to the bucket, which is why this read writes.
+        Reading it without promoting would honour the refusal for the generation
+        it was stored under and lose it at the next rotation, so an upgrading user
+        would keep the expiring behaviour this change exists to remove. Retiring
+        the old row in the same write also stops it holding an entry that pruning
+        is forbidden to collect, one per generation.
+        """
+        bucket = _opt_out_key(key)
+        if self._session_map.get_flag(bucket, MIRROR_OPT_OUT_FLAG):
+            return True
+        legacy = canonical_key(key)
+        if legacy == bucket:
+            return False
+        if not self._session_map.get_flag(legacy, MIRROR_OPT_OUT_FLAG):
+            return False
+        with self._session_map.batched_save():
+            self._session_map.set_flag(bucket, MIRROR_OPT_OUT_FLAG, True)
+            self._session_map.set_flag(legacy, MIRROR_OPT_OUT_FLAG, False)
+        return True
 
     def batched_save(self) -> AbstractContextManager[None]:
         """Collapse the session-map writes of a related mutation sequence into one.

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -40,6 +40,7 @@ from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn
 from kiro_crew.messaging.link import (
     CHAT_TYPE_DIRECT,
     CHAT_TYPE_FORUM,
+    DM_SCOPE_UNIFIED,
     ChannelLink,
     build_dm_session_key,
     legacy_dashboard_mirror_key,
@@ -86,6 +87,11 @@ logger = logging.getLogger(__name__)
 # explicit override nor agent.default_agent is configured. Mirrors the Slack
 # path's _DEFAULT_KIROCREW_AGENT.
 _DEFAULT_KIROCREW_AGENT = "kirocrew"
+
+# This dispatcher's surface, as it appears in a ``ChannelLink.channel_type`` and
+# in a session key's first segment. Named so the mirror checks compare against
+# one spelling rather than repeating the literal.
+_CHANNEL = "telegram"
 
 # Upper bound on how many queued messages collapse into a single combined turn.
 # A single human won't realistically burst past this mid-turn; anything beyond
@@ -1354,6 +1360,20 @@ class TelegramDispatcher:
             thread_id=(str(topic) if topic is not None else None),
         )
 
+    def _origin_mirror_is_ambiguous(self, route: tuple[str, str]) -> bool:
+        """True when this route's session key does not identify a single chat.
+
+        ``dm_scope="unified"`` collapses every allowed user's direct DMs into one
+        ``unified:{agent}`` bucket — the channel and the user drop out of the key —
+        so a mirror bound on that session belongs to no particular chat, and the
+        one that happens to be bound receives every other user's dashboard
+        replies. A forum route keeps its full bucket under any scope.
+        """
+        slot, _comp = route
+        return (
+            self.cfg.messaging.dm_scope == DM_SCOPE_UNIFIED and slot == CHAT_TYPE_DIRECT
+        )
+
     def _bind_origin_mirror(
         self, session_key: str, route: tuple[str, str], chat_id: int
     ) -> None:
@@ -1374,28 +1394,41 @@ class TelegramDispatcher:
         found no ``telegram`` link and the chat sat there looking dead while the
         conversation continued elsewhere.
 
+        Skipped entirely when the session key does not identify ONE chat. Under
+        ``dm_scope="unified"`` a direct DM collapses to a ``unified:{agent}``
+        bucket with the channel and the user dropped out, so every allowed user's
+        DMs share one key and "the origin chat" has no single answer: binding it
+        would point that session's mirror at whichever chat bound it, and deliver
+        one user's dashboard replies into another user's chat. ``/link`` stays
+        available there — it names the chat the user is actually in. A forum route
+        keeps its full bucket under any scope, so it is unaffected.
+
         Re-asserted on EVERY turn rather than only on a new session, because the
         binding is what a restart-cold session, an unlink at this location by
         another session, or a rival claim can take away — and only a self-healing
-        bind cannot leave a live conversation silently unmirrored. The write is
-        skipped when the binding already says this, so the steady-state cost per
-        turn is a read, not a session-map save.
+        bind cannot leave a live conversation silently unmirrored. Those all
+        REMOVE a binding; none of them repoints one. So with the ambiguous scope
+        excluded above, an existing binding for this channel is always deliberate,
+        and this leaves it alone whether it names this chat or another one:
+        re-pointing a user's chosen target at the origin would undo an explicit
+        action with no signal. A binding for a DIFFERENT channel does not answer
+        the question this bind asks, so it does not block the write.
 
         Honours the persisted opt-out ``/unlink`` writes: without it, "off" would
         last exactly until the user's next message. Declining is ALL this does —
         it never clears a binding it finds. ``/unlink`` persists the flag and the
         release in one session-map write, so "opted out with a live binding" is
         not a state the unlink path can leave behind; and every explicit bind
-        (``/link``, the dashboard's mirror-link endpoint) withdraws the flag, so
-        a binding that survives here is one the user asked for. Clearing it would
-        delete their link one turn later and re-create the very "chat looks dead"
-        symptom this bind exists to prevent.
+        (``/link``, the dashboard's mirror-link endpoint) withdraws the flag.
         """
+        if self._origin_mirror_is_ambiguous(route):
+            return
         if self.sessions.mirror_opt_out(session_key):
             return
-        desired = self._origin_mirror_link(route, chat_id)
-        if self.sessions.get_mirror_link(session_key) == desired:
+        existing = self.sessions.get_mirror_link(session_key)
+        if existing is not None and existing.channel_type == _CHANNEL:
             return
+        desired = self._origin_mirror_link(route, chat_id)
         try:
             self.sessions.set_mirror_link(session_key, desired)
         except Exception:

--- a/test/test_session_map_mirror.py
+++ b/test/test_session_map_mirror.py
@@ -18,6 +18,7 @@ from kiro_crew.messaging.link import (
     legacy_dashboard_mirror_key,
     release_conversation_location,
 )
+from kiro_crew.session import SessionManager, _opt_out_key
 from kiro_crew.session_map import MIRROR_OPT_OUT_FLAG, ConversationOwnershipConflict, SessionMap
 
 
@@ -26,6 +27,18 @@ def session_map(tmp_path):
     """A SessionMap backed by a temp directory."""
     with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
         yield SessionMap()
+
+
+def _manager_over(session_map):
+    """A SessionManager wired to just this map.
+
+    ``set_mirror_opt_out`` / ``mirror_opt_out`` touch nothing but
+    ``_session_map``, so binding that one attribute exercises the real accessors
+    without standing up a whole manager.
+    """
+    mgr = SessionManager.__new__(SessionManager)
+    mgr._session_map = session_map
+    return mgr
 
 
 def plant_binding(session_map, key, link, *, accepts_inbound=False):
@@ -629,6 +642,86 @@ class TestAutomaticMirrorOptOut:
         silently re-enable mirroring for every conversation that turned it off.
         """
         assert MIRROR_OPT_OUT_FLAG == "mirror_opt_out"
+
+    def test_the_refusal_is_keyed_by_the_durable_bucket_not_the_generation(self):
+        """A preference about the conversation, not about one session.
+
+        ``/new`` and the configured idle/daily reset rotate the ``:genN`` suffix.
+        Keyed per generation the refusal expires on rotation — an idle reset would
+        undo the user's "off" unprompted — and each rotated generation strands its
+        own row that pruning is forbidden to collect.
+        """
+        assert _opt_out_key("telegram:kirocrew:direct:7:gen3") == "telegram:kirocrew:direct:7"
+        assert _opt_out_key("telegram:kirocrew:direct:7") == "telegram:kirocrew:direct:7"
+        assert (
+            _opt_out_key("telegram:kirocrew:forum:-100123:5:gen9")
+            == "telegram:kirocrew:forum:-100123:5"
+        )
+        # Outside the canonical grammar there is no generation to strip.
+        assert _opt_out_key("dashboard:chat-9") == "dashboard:chat-9"
+
+    def test_the_suffix_is_stripped_even_when_the_key_does_not_parse(self):
+        """The shapes that most need stripping are the ones the parser rejects.
+
+        A ``dm_scope="unified"`` bucket is ``unified:{agent}`` — too short for the
+        canonical grammar — so a parser-only rule would leave every unified
+        conversation keyed per generation, which is the bug being fixed.
+        """
+        assert _opt_out_key("unified:kirocrew:gen3") == "unified:kirocrew"
+        assert _opt_out_key("unified:kirocrew") == "unified:kirocrew"
+        # A trailing segment that merely starts with "gen" is not a generation.
+        assert _opt_out_key("telegram:kirocrew:direct:general") == (
+            "telegram:kirocrew:direct:general"
+        )
+
+    def test_every_generation_shares_one_flag_row(self, session_map):
+        """Bucket-keying is what bounds the unprunable rows to one per chat."""
+        for gen in ("", ":gen1", ":gen2", ":gen7"):
+            session_map.set_flag(
+                _opt_out_key(f"telegram:kirocrew:direct:7{gen}"), MIRROR_OPT_OUT_FLAG, True
+            )
+        flagged = [k for k, e in session_map._data.items() if e.get("flags")]
+        assert flagged == ["telegram:kirocrew:direct:7"]
+
+    def test_a_refusal_stored_under_the_old_generation_key_is_still_honoured(
+        self, session_map
+    ):
+        """Upgrading must not silently restore mirroring.
+
+        An earlier build keyed the refusal by the generation-suffixed session key.
+        Reading only the bucket would miss every refusal already on disk — the
+        fix for the expiry bug would itself deliver the expiry bug, once.
+        """
+        mgr = _manager_over(session_map)
+        key = "telegram:kirocrew:direct:7:gen3"
+        session_map.set_flag(key, MIRROR_OPT_OUT_FLAG, True)
+        assert mgr.mirror_opt_out(key) is True
+
+    def test_reading_a_legacy_refusal_promotes_it_to_the_bucket(self, session_map):
+        """Otherwise the refusal is honoured for that generation and lost at the next.
+
+        Reading without promoting hands an upgrading user the expiring behaviour
+        this change exists to remove, and leaves an unprunable row per generation.
+        """
+        mgr = _manager_over(session_map)
+        session_map.set_flag("telegram:kirocrew:direct:7:gen3", MIRROR_OPT_OUT_FLAG, True)
+        assert mgr.mirror_opt_out("telegram:kirocrew:direct:7:gen3") is True
+        # Promoted to the bucket, and the generation row retired with it.
+        assert session_map.get_flag("telegram:kirocrew:direct:7", MIRROR_OPT_OUT_FLAG) is True
+        assert (
+            session_map.get_flag("telegram:kirocrew:direct:7:gen3", MIRROR_OPT_OUT_FLAG)
+            is False
+        )
+        # And it now survives the rotation that would have dropped it.
+        assert mgr.mirror_opt_out("telegram:kirocrew:direct:7:gen4") is True
+
+    def test_withdrawing_also_retires_the_old_generation_key(self, session_map):
+        """Otherwise a legacy refusal outlives the withdrawal that cleared it."""
+        mgr = _manager_over(session_map)
+        key = "telegram:kirocrew:direct:7:gen3"
+        session_map.set_flag(key, MIRROR_OPT_OUT_FLAG, True)
+        mgr.set_mirror_opt_out(key, False)
+        assert mgr.mirror_opt_out(key) is False
 
     def test_a_session_scoped_flag_does_not_make_an_entry_immortal(self, session_map):
         """Immortality is opt-in, because prune is the only collection path.

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -28,6 +28,7 @@ from kiro_crew.messaging.renderer import (
     OutputEvent,
 )
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.session import _opt_out_key
 from kiro_crew.session_map import ConversationOwnershipConflict
 from kiro_crew.telegram.client import (
     TELEGRAM_CHUNK_LIMIT,
@@ -333,12 +334,12 @@ class FakeSessions:
     def set_mirror_opt_out(self, key: str, opted_out: bool) -> None:
         self.batched_writes.append(self.batch_depth > 0)
         if opted_out:
-            self.mirror_opt_outs.add(key)
+            self.mirror_opt_outs.add(_opt_out_key(key))
         else:
-            self.mirror_opt_outs.discard(key)
+            self.mirror_opt_outs.discard(_opt_out_key(key))
 
     def mirror_opt_out(self, key: str) -> bool:
-        return key in self.mirror_opt_outs
+        return _opt_out_key(key) in self.mirror_opt_outs
 
     def clear_mirror_link(self, key: str) -> bool:
         self.batched_writes.append(self.batch_depth > 0)
@@ -398,6 +399,7 @@ def _cfg(
     *,
     allow_forum: bool = False,
     allowed_forum_chat_ids: list | None = None,
+    dm_scope: str = "per-channel-peer",
 ) -> Any:
     return SimpleNamespace(
         telegram=SimpleNamespace(
@@ -407,7 +409,7 @@ def _cfg(
         ),
         agent=SimpleNamespace(default_agent=default_agent),
         messaging=SimpleNamespace(
-            dm_scope="per-channel-peer",
+            dm_scope=dm_scope,
             idle_reset_minutes=0,
             daily_reset_hour=-1,
             queue_mode="steer",
@@ -422,6 +424,7 @@ def _dispatcher(
     default_agent: str = "",
     allow_forum: bool = False,
     allowed_forum_chat_ids: list | None = None,
+    dm_scope: str = "per-channel-peer",
 ) -> tuple[TelegramDispatcher, FakeClient, FakeSessions]:
     sess = FakeSessions(raise_on_get=raise_on_get)
     d = TelegramDispatcher(
@@ -431,6 +434,7 @@ def _dispatcher(
             default_agent=default_agent,
             allow_forum=allow_forum,
             allowed_forum_chat_ids=allowed_forum_chat_ids,
+            dm_scope=dm_scope,
         ),
         allowed_user_ids=allowed,
         agent=None,
@@ -3100,15 +3104,74 @@ class TestAutomaticOriginMirror:
         self._turn(d, text="second")
         assert writes == []
 
-    def test_bind_repairs_a_binding_that_drifted_to_another_location(self) -> None:
-        # Self-healing: a live conversation whose binding was swept or rebound
-        # elsewhere must not stay silently unmirrored.
+    def test_an_explicit_bind_to_a_different_chat_is_not_repointed(self) -> None:
+        # Nothing repoints a binding: a swept or rival-claimed one is REMOVED,
+        # not moved. So a telegram binding naming another chat is always
+        # deliberate (the dashboard can bind a surfaced session anywhere), and
+        # re-pointing it at the origin would undo an explicit action silently.
         d, _cli, sess = _dispatcher({7})
         key = d._session_key(("direct", "7"))
-        sess.mirror_links[key] = ChannelLink("telegram", channel_id="999")
+        chosen = ChannelLink("telegram", channel_id="999", thread_id=None)
+        sess.mirror_links[key] = chosen
+        self._turn(d)
+        assert sess.mirror_links == {key: chosen}
+
+    def test_a_binding_for_another_channel_does_not_block_the_bind(self) -> None:
+        # set_channel writes the legacy slack_channel_id for a new telegram
+        # session, so the first turn can see a synthesized non-telegram link.
+        # That says nothing about telegram mirroring and must not suppress it.
+        d, _cli, sess = _dispatcher({7})
+        key = d._session_key(("direct", "7"))
+        sess.mirror_links[key] = ChannelLink("slack", channel_id="telegram:7")
         self._turn(d)
         assert sess.mirror_links[key] == ChannelLink(
             "telegram", channel_id="7", thread_id=None
+        )
+
+    def test_the_refusal_survives_a_generation_rotation(self) -> None:
+        # /new and the configured idle/daily reset rotate the :genN suffix. Keyed
+        # per generation the flag would expire on rotation — an idle reset would
+        # undo the user's /unlink with no action on their part, which is the very
+        # failure the persisted flag exists to prevent.
+        d, _cli, sess = _dispatcher({7})
+        asyncio.run(d._handle_unlink(("direct", "7"), 7))
+        before = d._session_key(("direct", "7"))
+        d._conv.bump_gen(("direct", "7"))
+        after = d._session_key(("direct", "7"))
+        assert after != before, "generation did not rotate; test would be vacuous"
+        assert sess.mirror_opt_out(after) is True
+
+    def test_a_unified_dm_scope_is_not_auto_bound(self) -> None:
+        # dm_scope=unified collapses every allowed user's DMs into one
+        # unified:{agent} bucket — channel and user drop out of the key — so a
+        # mirror bound there belongs to no particular chat and would deliver one
+        # user's dashboard replies into another user's chat.
+        d, _cli, sess = _dispatcher({7}, dm_scope="unified")
+        self._turn(d)
+        assert sess.mirror_links == {}
+
+    def test_a_forum_route_is_still_bound_under_a_unified_scope(self) -> None:
+        # A forum route keeps its full bucket under any dm_scope, so it names one
+        # Topic and stays unambiguous.
+        d, _cli, sess = _dispatcher(
+            {7}, allow_forum=True, allowed_forum_chat_ids=[-1001234567890], dm_scope="unified"
+        )
+        asyncio.run(
+            d.handle_message(
+                TelegramInboundMessage(
+                    channel_type="telegram",
+                    user_id="7",
+                    conversation_id="-1001234567890",
+                    text="hi",
+                    chat_type="supergroup",
+                    thread_id="5",
+                    message_id=1,
+                )
+            )
+        )
+        route = ("forum", "-1001234567890:5")
+        assert sess.mirror_links[d._session_key(route)] == ChannelLink(
+            "telegram", channel_id="-1001234567890", thread_id="5"
         )
 
     def test_a_refused_claim_does_not_break_the_turn(self) -> None:


### PR DESCRIPTION
## 1. What is the problem?

Three defects in the Telegram origin-mirror that shipped in #2976 (`36a4e9bbe`). Design Review raised all three on that PR's final SHA, after it had already been merged.

1. **The opt-out expires on generation rotation.** `set_mirror_opt_out` keyed the flag by the session key it was handed, and Telegram hands it `_session_key(route)` — which carries the `:gen{N}` suffix that `/new` and the configured idle/daily reset rotate. After any rotation `mirror_opt_out()` is `False` and the bind re-links.
2. **Every opted-out generation stranded an unprunable row.** `_DURABLE_FLAGS` exempts a flagged entry from `prune()`; combined with per-generation keying, each `/unlink`-then-rotate cycle left one entry nothing would ever collect.
3. **The per-turn re-assert overwrote an explicit divergent binding.** The dashboard mirror-link endpoint withdraws the opt-out and writes the user's chosen link; if it targeted anywhere other than the origin chat, the next inbound turn found `get_mirror_link() != desired` and rebound to the origin.

## 2. Why this issue matters to the user

(1) and (3) both re-create the exact symptom #2959 existed to remove — the chat silently stops reflecting what the user asked for — except now it happens to a user who did everything right. They act deliberately (`/unlink`, or picking a mirror target in the dashboard) and the next message reverts it with no signal.

(1) is worse than the original bug in one respect: it is **time-triggered**. With `idle_reset_minutes` or `daily_reset_hour` configured, the rotation happens while nobody is at the keyboard, so `/unlink` comes undone overnight and the user has no event to associate it with.

(2) is a slow leak with no collection path on a structure whose every write rewrites the whole map, so the stranded rows tax every later write rather than only disk.

## 3. How our fix solves it

**Symptom** — `/unlink` stops holding, and an explicit mirror choice gets overwritten.
**Immediate cause** — the flag is looked up under a key that changed, and the bind treats "points elsewhere" as drift to repair.
**Root cause** — the refusal was scoped to a *session* when it is a property of the *conversation*, and the bind assumed it was the only thing that ever writes a binding.

**(1) and (2) are one move: key the refusal by the durable bucket.** The codebase already names this — `ParsedSessionKey.bucket` is "the key with any generation suffix removed", and the per-route model preference is deliberately keyed the same way for the same stated reason: it is a preference about the peer, not about one session. Derivation lives inside the two accessors, so a writer and a reader cannot disagree about it, and a key outside the canonical grammar (a `dashboard:` row, a legacy Slack spelling) has no generation to strip and is used as-is. One conversation now holds one flag row, which is what makes the `_DURABLE_FLAGS` carve-out bounded rather than a leak.

**(3): stop treating a divergent binding as drift.** The re-assert exists because a restart-cold session, an unlink at this location by another session, or a rival claim can take a binding away — but every one of those *removes* a binding; none of them repoints one. So an existing binding for this channel is always deliberate, and it is now left alone whichever chat it names. A binding for a *different* channel does not answer the question the bind asks, so it does not suppress the write — which matters because the first turn legitimately sees one: `set_channel` writes `telegram:<user id>` into the legacy `slack_channel_id` field, and `get_mirror_link` synthesizes a Slack link from it.

**(4) `dm_scope="unified"` makes the origin chat undefined, so the bind now refuses it.** Review raised this against the first push and it is worse than a routing bug. Under unified scope a direct DM collapses to a `unified:{agent}` bucket with **the channel and the user dropped out of the key** — verified by construction: `build_dm_session_key` for users `7` and `8` both return `unified:kirocrew:gen1`. Every allowed user's DMs therefore share one session key, so a mirror bound on it belongs to no particular chat, and whichever chat bound it would receive *every other user's* dashboard replies. That is a cross-user content leak, not misrouting.

Making the last speaker win (rebinding whenever `existing != desired`) does not fix it — it just moves the leak to whoever spoke most recently, and it reintroduces (3). So the bind refuses the ambiguous case outright: `_origin_mirror_is_ambiguous` skips when the scope is unified **and** the route is a direct chat. A forum route keeps its full bucket under any scope, so it stays unambiguous and still binds; `/link` remains available under unified scope because it names the chat the user is actually in.

**(5) A refusal already on disk under a generation key is still honoured.** #2976 is merged, so a `/unlink` typed against it persisted under the suffixed key. Reading only the bucket would miss it — the fix for the expiry bug would deliver that same bug once, on upgrade. `mirror_opt_out` reads the bucket then falls back to the generation key, and **promotes** a legacy hit to the bucket — which is why that read writes. Reading without promoting would honour the refusal for the generation it was stored under and lose it at the next rotation, so an upgrading user would keep the expiring behaviour this change removes. The promotion retires the old row in the same write, so it cannot hold an unprunable entry per generation either. A withdrawal likewise retires the legacy entry so it cannot outlive the withdrawal that cleared it. Every such pair goes in one `batched_save`.

The suffix is also stripped textually rather than through the canonical parser, because the shape that most needs it is the one the parser rejects: `parse_session_key("unified:kirocrew:gen3")` returns `None` (three segments, too short for the §9 grammar), so a parser-only rule would leave every unified conversation keyed per generation — the very bug being fixed.

## 4. What tests we did

**10/10 mutants caught** on this delta:

| Mutant | Caught by |
|---|---|
| unified dm_scope is auto-bound (one user's replies reach another's chat) | unified-not-auto-bound |
| ambiguity check ignores chat_type (forum stops binding too) | forum-still-bound-under-unified |
| existing same-channel binding is re-pointed to origin | 2 tests |
| same-channel guard widened to ANY channel (first turn never binds) | another-channel-does-not-block |
| generation suffix not stripped (refusal expires on rotation) | 4 tests |
| suffix strip is not anchored (a `general` segment is eaten) | suffix-stripped-when-key-does-not-parse |
| legacy per-generation refusal is not read (upgrade restores mirroring) | old-generation-key-still-honoured |
| legacy refusal is read but not promoted (lost at next rotation) | reading-promotes-it-to-the-bucket |
| promotion does not retire the generation row | reading-promotes-it-to-the-bucket |
| legacy refusal is not retired on withdrawal | withdrawing-retires-the-old-key |

`test_the_refusal_survives_a_generation_rotation` drives a real `/unlink`, rotates the generation through `ConversationState.bump_gen`, and asserts the refusal still reads true — failing loudly rather than vacuously if the key did not actually change. `test_every_generation_shares_one_flag_row` asserts four generations collapse to exactly one flagged row. The two legacy-flag tests bind a real `SessionManager` to a temp `SessionMap` so they exercise the production accessors rather than a double.

Gates: affected suites green; full backend suite **43859 passed**; `isort` clean; `flake8` clean on every file in the diff; `mypy` clean over the diff (the 4 pre-existing boto3-stub errors in `transcribe.py` and `ops_mission_control/providers/cloudwatch.py` are outside it). Branch-only full-suite failures were diffed against a baseline run on an unmodified `main` worktree and all reproduce there — host-environment artifacts (`unshare(CLONE_NEWUSER)` EPERM, `/tmp` owned by uid 65534, `AF_UNIX path too long` from the long `TMPDIR` this host needs, `TestRunProbe` with per-run membership, session-summary mtime races). That last family includes `TestWriteGuard::test_an_append_during_generation_refuses_the_stale_payload`, which is the one red the Windows shard reported on the first push. No frontend files are touched.

## 5. Any other suggestions on the work

- The bucket-keying makes the `_DURABLE_FLAGS` prune carve-out bounded, but it does not remove it: a bucket entry carrying only the flag (a `/unlink` before the conversation ever ran a turn) still has to survive pruning. That is one row per opted-out conversation, which is the intended cost.
- **Discord still has the whole origin-mirror gap** (#3009). When that lands, the bind + opt-out pattern should move into `messaging/link.py` rather than becoming a second per-channel copy — and the bucket-keying and the explicit-bind rule are two of the properties the shared helper has to carry.
- `SessionMap` remains unlocked and rewrites the whole map on the event loop (#2989). Unchanged here; it is why this bind stays synchronous.

Fixes #3020
