### PR TITLE
fix(gateway): clear headless run marker on shutdown

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -6816,7 +6816,7 @@ class GatewayOrchestrator:
         try:
             from kiro_crew.instances import run_marker
 
-            if not self._no_dashboard and self._dashboard_port:
+            if self._dashboard_port:
                 run_marker.clear_marker(self._dashboard_port)
         except Exception:
             logger.debug("Gateway run-marker clear skipped", exc_info=True)

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -2449,7 +2449,11 @@ class TestRunMethod:
         orch._init_subagents = MagicMock()
         orch._init_task_runner = MagicMock()
         orch._init_dashboard = AsyncMock()
-        orch._init_api_server = AsyncMock()
+
+        async def _init_api_server():
+            orch._dashboard_port = 6123
+
+        orch._init_api_server = AsyncMock(side_effect=_init_api_server)
         orch._init_autonudge = AsyncMock()
         orch._check_for_updates = AsyncMock()
         orch._shutdown = AsyncMock()
@@ -2466,12 +2470,19 @@ class TestRunMethod:
                                     with patch("os._exit"):
                                         with patch("resource.getrlimit", return_value=(256, 10240)):
                                             with patch("resource.setrlimit"):
-                                                await orch.run()
+                                                with patch(
+                                                    "kiro_crew.instances.run_marker.write_marker"
+                                                ):
+                                                    with patch(
+                                                        "kiro_crew.instances.run_marker.clear_marker"
+                                                    ) as clear_marker:
+                                                        await orch.run()
         finally:
             kiro_crew.shutdown_event.clear()
 
         orch._init_dashboard.assert_not_awaited()
         orch._init_api_server.assert_awaited_once()
+        clear_marker.assert_called_once_with(6123)
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Problem / Motivation

An API-only (`--no-dashboard`) gateway still serves the dashboard API and writes
the gateway run marker, but graceful shutdown skipped `clear_marker` because the
cleanup was gated on `_no_dashboard`. That left both the marker and PID sidecar
behind after a clean shutdown.

## Why it matters

The stale marker outlives the process, so the next start believes a gateway is
already running on that port. An API-only deployment is the headless/service case
where nobody is watching a console, so the wrong answer persists until someone
removes the file by hand.

## What changed

Clear the run marker whenever `_dashboard_port` was assigned, independent of
whether the dashboard UI was enabled. The cleanup remains best-effort and keeps
the existing exception handling, marker write behavior, crash-stale behavior,
and dashboard shutdown semantics unchanged.

`clear_marker` already has behavior-level coverage proving that it removes both
`gateway-<port>.bin` and `gateway-<port>.pid`. This PR adds call-site regression
coverage proving the headless run path invokes it with the API server's assigned
port.

## Tests

- fail-before mutation: restoring the old `_no_dashboard` gate makes
  `test_run_no_dashboard_uses_api_server` fail with zero `clear_marker` calls
- focused headless shutdown test passed on Windows using a temporary POSIX
  `resource` shim solely to execute this Linux-targeted test locally
- marker resolution suite: 15 passed
- `flake8` and `isort --check-only` passed
- `compileall` passed
- `mypy --platform linux src/kiro_crew/slack/gateway.py` passed
- `git diff --check` passed

Closes #2975

