### PR TITLE
test: assert rate limiter fast path never sleeps instead of timing it (#3008)

### DIFF
--- a/test/test_knowledge_budget.py
+++ b/test/test_knowledge_budget.py
@@ -10,9 +10,8 @@ Covers:
 """
 import asyncio
 import sqlite3
-import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from kiro_crew.config.loader import KnowledgeConfig
 
@@ -65,10 +64,21 @@ class TestEmbedRateLimiter:
     def test_high_rate_does_not_block(self):
         from kiro_crew.knowledge.ingestion import EmbedRateLimiter
         limiter = EmbedRateLimiter(rate_limit=10000)
-        start = time.monotonic()
-        asyncio.run(limiter.acquire())
-        elapsed = time.monotonic() - start
-        assert elapsed < 0.1
+        tokens_before = limiter._tokens
+        # "Does not block" means the sleeping slow path is never reached:
+        # patch asyncio.sleep and assert it was never awaited (a wall-clock
+        # bound here would only measure asyncio.run() setup cost, which flakes
+        # under CI load). Note: ingestion.py does a plain `import asyncio`, so
+        # this rebinds asyncio.sleep process-wide for the duration of the
+        # block; asyncio.run() internals never call asyncio.sleep, and the
+        # patch is reverted on exit.
+        fake_sleep = AsyncMock()
+        with patch("kiro_crew.knowledge.ingestion.asyncio.sleep", fake_sleep):
+            asyncio.run(limiter.acquire())
+        fake_sleep.assert_not_awaited()
+        # The fast path must still consume exactly one token, proving
+        # acquire() did real work rather than returning early.
+        assert limiter._tokens == tokens_before - 1.0
 
     def test_rate_limit_setter_resets_bucket(self):
         from kiro_crew.knowledge.ingestion import EmbedRateLimiter


### PR DESCRIPTION
Closes #3008

## What broke

`TestEmbedRateLimiter::test_high_rate_does_not_block` asserted `elapsed < 0.1` around `asyncio.run(limiter.acquire())`. With `rate_limit=10000` the bucket is constructed full, so `acquire()` takes the fast path and never reaches `await asyncio.sleep(...)`; the timed region measures only `asyncio.run()` event-loop setup and teardown. Under `pytest -n auto` load on Windows runners that setup cost reached 0.219s-0.266s and the assertion went red on unrelated branches (sightings on #2764 and #2955, including a same-SHA red/green pair).

## What changed (test only)

- `test/test_knowledge_budget.py::test_high_rate_does_not_block` now asserts the behaviour its name claims: `asyncio.sleep` (patched via `AsyncMock` on `kiro_crew.knowledge.ingestion.asyncio.sleep`) is never awaited, and `_tokens` decrements by exactly 1.0, proving `acquire()` consumed a token rather than returning early.
- Dropped the `time.monotonic()` / `elapsed` assertion and the `time` import (nothing else in the file uses it).
- `src/kiro_crew/knowledge/ingestion.py` is intentionally untouched: the product code is correct, only the test's oracle was wrong.

The exact float equality is deterministic: the bucket starts full, the refill clamps back to `10000.0` via `min(rate_limit, ...)`, and `10000.0 - 1.0` is exactly representable.

## Verification

- Scratch check: draining the bucket so `acquire()` takes the sleeping path makes `assert_not_awaited()` fail, confirming the new oracle catches a regression in the fast path. Reverted before commit.
- No wall-clock residue: `grep -n 'monotonic|elapsed'` on the file returns nothing.
- Scanned the rest of `test/test_knowledge_budget.py` for other wall-clock `elapsed <` assertions of the same shape: there are none.
- Gates: isort, flake8, mypy clean; full pytest 45791 passed (74 failures are pre-existing local-env issues in unrelated git/sandbox-dependent files, sample verified failing on the unmodified tree).
- Pre-push review: GPT 5.6 Sol PASS zero findings; Opus 5 PASS zero blocking (comment advisory applied; float-equality and sync-def shape confirmed deterministic/pre-existing).
