### PR TITLE
test(companion): anchor the re-enable reminder to the clock its store uses

### DIFF
--- a/src/kiro_crew/apps/builtins/crew_companion/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/tests/test_routes.py
@@ -8,7 +8,7 @@ that true.
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -370,7 +370,13 @@ class TestHooks:
         await hooks.on_startup(ctx)
         store = hooks.get_store()
         assert store is not None
-        store.add("persisted", to_iso(NOW + timedelta(hours=3)))
+        # Anchored to the REAL clock, not the frozen NOW literal: unlike the
+        # `store` fixture, the store `on_startup` builds gets the default
+        # real-time clock, and its 1s tick fires anything already due. An
+        # instant relative to NOW is in the past, so the reminder would be
+        # fired and dropped whenever the tick beat the snapshot below.
+        future = datetime.now().astimezone() + timedelta(hours=3)
+        store.add("persisted", to_iso(future))
 
         await hooks.on_shutdown(ctx)
         await hooks.on_startup(ctx)


### PR DESCRIPTION
🤖 Filed by **perpetual agent `flake-warden`** — an unsupervised agent on an hourly
schedule. No human reviewed this before it was posted. Evidence is cited inline;
anything marked suspected is not proven.

Fixes the flake reported in #3019 (which I also filed).

## The defect

`TestHooks::test_a_reminder_added_before_disable_survives_re_enable` adds a
reminder it believes is three hours in the future, but the instant was anchored to
the module literal `NOW = parse_iso("2026-07-31T14:00:00")` — so against the real
clock it is roughly twelve days **overdue**.

Every other test in the file is immune because the `store` fixture injects that
frozen clock (`now=lambda: NOW`). This test is the one that does not use the
fixture: it takes the store built by `hooks.on_startup`, which is the single
construction site with no clock injected, so it runs on
`datetime.now().astimezone()`. That store's ticker is
`while not self._stop.wait(TICK_SECONDS)` with `TICK_SECONDS = 1.0`, and
`due_reminders` puts no lower bound on how overdue a row may be, so the first tick
fires the reminder, `advance` marks a non-recurring reminder `done=True`, and the
tick drops it. The re-enable takes the deliberate early-return path that keeps the
existing instance, so no reload can bring the row back and `snapshot()` sees `[]`.

The test therefore passed only while the tick lost the race — under about one
second of wall clock between `store.start()` and the snapshot.

## The fix

Anchor the instant to the clock the store under test actually uses. One line of
behaviour, plus a comment saying why the frozen literal is wrong *here*
specifically, since it is correct everywhere else in the file.

Deliberately **not** done: no tolerance widened, no timeout raised, nothing
skipped. The row was genuinely overdue, so the dependency has to be removed rather
than given more room — a larger tolerance would keep an assertion whose premise is
false.

## Red before, green after

Stall injected between `store.start()` and the snapshot to buy the wall clock a
contended runner gives for free (a pytest plugin wrapping `on_shutdown`, which
sits between the two in the test body; not part of this diff).

| stall | before | after |
|-------|--------|-------|
| 0s    | pass   | pass  |
| 0.9s  | pass   | pass  |
| 1.05s | **fail** | pass |
| 1.5s  | **fail** | pass |
| 2.5s  | —      | pass  |

The break sits exactly at the 1.0s tick period, and the failure is byte-identical
to what CI reported: `AssertionError: assert [] == ['persisted']`.

Full companion suite: 289 passed. `flake8`, `isort` and `mypy` on the changed file
all exit 0 (read explicitly, not off a truncated pipe).

## Scope check

I checked whether this has siblings before proposing a single-test fix: of the four
tests in the file that build a store through `hooks.on_startup`, this is the only
one that adds a reminder, so the frozen-literal-on-a-real-clock combination occurs
exactly once. The other three assert on runtime identity and need no instant.

## Honest limits

- The stall is injected, not observed. I did not reproduce the interleaving on a CI
  runner; the mechanism is proven statically and by the threshold above, and the
  CI sighting is the same assertion value.
- The rate in #3019 is published as a lower bound (one sighting in 199 Windows
  shard-4 executions), because a latest-attempt-only denominator discards
  attempt-1 failures.
