### PR TITLE
test(companion): remove reminder re-enable clock race

### DIFF
--- a/src/kiro_crew/apps/builtins/crew_companion/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/tests/test_routes.py
@@ -8,7 +8,7 @@ that true.
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -370,7 +370,12 @@ class TestHooks:
         await hooks.on_startup(ctx)
         store = hooks.get_store()
         assert store is not None
-        store.add("persisted", to_iso(NOW + timedelta(hours=3)))
+        # The hook-built store uses the real clock, so a frozen test instant
+        # eventually becomes overdue and races the live tick thread.
+        store.add(
+            "persisted",
+            to_iso(datetime.now().astimezone() + timedelta(hours=3)),
+        )
 
         await hooks.on_shutdown(ctx)
         await hooks.on_startup(ctx)


### PR DESCRIPTION
## Problem

The re-enable lifecycle test used a fixed July 2026 timestamp while the store
created by `hooks.on_startup()` uses the real clock. The supposed future reminder
is now overdue, so the store's 1 Hz tick can legitimately fire and remove it
before the assertion.

## Fix

Anchor this test's reminder to the same real, timezone-aware clock semantics used
by the hook-built store. Other tests keep their injected frozen clock. Product
reminder behavior is unchanged.

## Validation

- fail-before with 1.1s scheduling pressure reproduced
  `assert [] == ['persisted']`
- fixed test passed under the same pressure
- target test passed 5 consecutive runs
- `test_routes.py`: 19 passed
- Crew Companion suite: 287 passed, 2 platform skips
- Linux-target mypy, flake8, isort, compileall, and diff-check passed

Closes #3019
