### PR TITLE
fix(session-map): lock SessionMap and make each action one critical section

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3674,6 +3674,27 @@ class DashboardState:
         slot = self._slots.get(slot_name)
         if not slot:
             return
+        # A thread handoff is ONE action with TWO persisted writes: the previous
+        # owner's link is cleared and this slot's is claimed. Each write rewrites
+        # the whole session map, so as two separate writes they are separately
+        # interruptible — a failure or a concurrent writer in between leaves the
+        # thread with no owner (the clear landed, the claim did not) or with two
+        # (the reverse). Batching makes the pair one critical section and one
+        # write, matching the same guarantee ``SessionMap.set_slack_link``
+        # already gives its own eviction-and-claim.
+        with self.sessions.batched_save() if self.sessions else contextlib.nullcontext():
+            self._link_slack_persisted(slot, slot_name, thread_ts, channel_id)
+        self.push_slots_update()
+
+    def _link_slack_persisted(
+        self, slot: Any, slot_name: str, thread_ts: str, channel_id: str
+    ) -> None:
+        """The link handoff itself: in-memory indexes plus both persisted writes.
+
+        Split out only so :meth:`link_slack` can wrap the whole sequence in one
+        ``batched_save``; the dashboard push stays OUTSIDE that block because it
+        is not a map mutation.
+        """
         # Remove stale mapping if slot was previously linked to a different thread
         old_ts = slot._slack_thread_ts
         if old_ts and old_ts != thread_ts:
@@ -3707,7 +3728,6 @@ class DashboardState:
             from kiro_crew.dashboard.chat_utils import effective_session_key
 
             self.sessions.set_slack_link(effective_session_key(slot), thread_ts, channel_id)
-        self.push_slots_update()
 
     def get_or_create_slot(
         self,

--- a/src/kiro_crew/messaging/link.py
+++ b/src/kiro_crew/messaging/link.py
@@ -414,10 +414,19 @@ def release_conversation_location(
 
     Returns ``(reply_text, swept_keys)``. A non-empty sweep is the caller's
     cue to refresh any dashboard projection of the cleared bindings.
+
+    The three clears are ONE critical section and one whole-map write: they are
+    one user-visible action ("nothing mirrors here anymore"), and each of them
+    would otherwise rewrite the entire map and be individually interruptible, so
+    a failure or a concurrent writer partway through could leave the location
+    half-freed while the reply already claimed ✅. Nesting is counted, so a
+    caller that batches a wider sequence around this one (Telegram pairs it with
+    the opt-out write) still gets a single write.
     """
-    cleared = int(sessions.clear_mirror_link(key))
-    cleared += int(sessions.clear_mirror_link(legacy_dashboard_mirror_key(key)))
-    swept = sessions.clear_mirror_links_at(location)
+    with sessions.batched_save():
+        cleared = int(sessions.clear_mirror_link(key))
+        cleared += int(sessions.clear_mirror_link(legacy_dashboard_mirror_key(key)))
+        swept = sessions.clear_mirror_links_at(location)
     if swept:
         logger.info(
             "%s: unlink swept %d mirror binding(s) at this conversation: %s",

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -7,13 +7,16 @@ generic ChannelLink mirror map) for bidirectional sync.
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import os
 import tempfile
-from collections.abc import Iterator
+import threading
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import ParamSpec, TypeVar
 
 from kiro_crew.config.paths import config_dir, kiro_sessions_dir
 from kiro_crew.messaging.link import (
@@ -69,6 +72,41 @@ def _has_durable_flag(entry: dict) -> bool:
     return any(flags.get(name) for name in _DURABLE_FLAGS)
 
 
+# Serializes every structural access to the map. MODULE-level, not per-instance,
+# because the instances are not the unit of exclusion: the read-only call sites
+# build their own throwaway ``SessionMap()`` (``handlers/session_storage.py``,
+# ``slack/handler.py``) while ``SessionManager`` holds the long-lived one, and
+# all of them resolve the same file. A per-instance lock would leave a throwaway
+# reader iterating its map while the live writer rewrites the file — the exact
+# pair this exists to order.
+#
+# REENTRANT because the public surface composes: ``set_mirror_link`` reaches
+# ``clear_mirror_link`` -> ``clear_slack_link`` -> ``_save`` -> ``_write``, and
+# ``batched_save`` blocks nest. A plain Lock would deadlock the first such call.
+_MAP_LOCK = threading.RLock()
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def _guarded(fn: Callable[_P, _R]) -> Callable[_P, _R]:
+    """Hold :data:`_MAP_LOCK` for the whole call.
+
+    Applied to every :class:`SessionMap` method that mutates the map, iterates
+    it, or reads several fields as one unit. Single-key probes are deliberately
+    left undecorated — see the class docstring's threading contract for why that
+    boundary is where it is, and ``test_session_map_locking.py`` for the ratchet
+    that keeps a new mutator from being added without it.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        with _MAP_LOCK:
+            return fn(*args, **kwargs)
+
+    return wrapper
+
+
 class ConversationOwnershipConflict(RuntimeError):
     """Raised when a second session tries to bind a conversation already held.
 
@@ -101,6 +139,60 @@ class SessionMap:
     Each entry is a dict with keys: ``sid``, ``slack_thread_ts``, ``slack_channel_id``.
     A reverse index ``_thread_to_session`` maps Slack thread_ts → session_key
     for bidirectional sync lookups.
+
+    THREADING CONTRACT
+    ------------------
+    Every mutation rewrites the WHOLE map from ``_data``, so a read-modify-write
+    is only atomic if nothing else touches the structure in between. Three rules
+    hold that together; the first two are enforced, the third cannot be:
+
+    1. **Any thread may call this class.** :data:`_MAP_LOCK` (module-level,
+       reentrant) guards every method that mutates the map, iterates it, or
+       reads several fields as one unit. Single-key probes (``get_cwd``,
+       ``get_flag``, ``get_session_for_thread``, …) are lock-free on purpose:
+       one ``dict.get`` cannot observe a half-applied write, and taking the lock
+       for them would put the map's cheapest reads — including the one on every
+       inbound Slack reply — behind its most expensive write. What that costs is
+       a rule for the WRITERS: a structure a lock-free reader looks at is
+       replaced by rebinding a finished copy, never cleared and refilled in
+       place (see :meth:`_rebuild_thread_index`).
+
+       Because a caller can now WAIT, what may be held under the lock is
+       bounded: **no guarded method reads or parses the map file.** The longest
+       hold is one whole-map write (0.77 ms at today's size) plus, in ``get`` and
+       ``prune``, a session-file stat per entry — costs the event loop already
+       paid inline before this lock existed. Loading a file into a fresh
+       instance is the one unbounded step, and :meth:`_load` is deliberately
+       unguarded so a worker-thread construction cannot stall the loop behind
+       its disk read.
+
+    2. **A multi-mutation sequence must say so.** Two locked calls are two
+       critical sections, and another thread's write can land between them and
+       be lost by the second one's whole-map rewrite. :meth:`batched_save` holds
+       the lock across the block, making the sequence one critical section AND
+       one write. Related mutations belong inside it — never merely adjacent.
+       It MUST NOT be held across an ``await``: the lock is per-thread
+       reentrant, so an await inside a batch lets another coroutine on the same
+       loop walk straight into the block, while a worker thread waiting on the
+       lock stalls until the await returns. ``test_session_map_locking.py``
+       ratchets this against the whole tree.
+
+    3. **Writes go through the LIVE map.** The lock orders access to the
+       structure; it cannot reconcile two instances that loaded ``_data``
+       independently, because the loser's rewrite is a whole-file write of a
+       stale snapshot. A throwaway ``SessionMap()`` is therefore READ-ONLY —
+       see ``session_transfer._join_layer_b`` for what a detached write costs.
+
+    Writes still happen synchronously on the caller's thread, which on the event
+    loop is a stall every task shares (~0.8 ms at today's map sizes, growing
+    linearly with entry count). Moving them off the loop is issue #2405, and the
+    lock is what makes that possible to attempt at all — before it, offloading a
+    single write made the map racy instead of non-blocking.
+
+    SCOPE: the lock is in-PROCESS. Two gateways writing one map file would still
+    lose updates, and nothing here changes that — the data-home singleton is what
+    keeps that from happening. ``history.ConversationLog._locked`` is the
+    cross-process, off-loop-enforcing primitive; this is deliberately not it.
     """
 
     def __init__(self) -> None:
@@ -113,30 +205,51 @@ class SessionMap:
 
     @contextmanager
     def batched_save(self) -> Iterator[None]:
-        """Collapse every ``_save()`` inside this block into one write at exit.
+        """One critical section and one write for every mutation in this block.
 
         A mutation rewrites the WHOLE map, so a caller making several related
-        mutations pays that cost once per call rather than once per operation —
-        and on the event loop each write is a stall every task shares. Nesting is
-        counted, and the write happens on the way out even if the block raises,
-        so a partial sequence is never left only in memory.
+        mutations pays that cost once per operation rather than once per
+        sequence — and on the event loop each write is a stall every task
+        shares. Nesting is counted, and the write happens on the way out even if
+        the block raises, so a partial sequence is never left only in memory.
 
-        MUST NOT be held across an ``await``. The map carries no lock, so the
-        loop's own serialization is what keeps a batch from interleaving with
-        another mutation; yielding inside one would let a concurrent write land
-        between the mutations and be lost by this batch's write.
+        The block also holds :data:`_MAP_LOCK` throughout, which is what makes
+        the sequence ATOMIC and not merely coalesced: without it another
+        thread's write could land between two of these mutations and then be
+        dropped by this batch's whole-map rewrite.
+
+        MUST NOT be held across an ``await``. The lock is reentrant per THREAD,
+        so it does not exclude a second coroutine on the same loop — an await
+        inside the block lets one interleave exactly as it would have without
+        any lock, and meanwhile a worker thread blocked on the lock waits for
+        the await to finish. ``test_session_map_locking.py`` ratchets this
+        against the whole tree, so the rule is checked rather than trusted.
         """
-        self._batch_depth += 1
-        try:
-            yield
-        finally:
-            self._batch_depth -= 1
-            if self._batch_depth == 0 and self._batch_dirty:
-                self._batch_dirty = False
-                self._write()
+        with _MAP_LOCK:
+            self._batch_depth += 1
+            try:
+                yield
+            finally:
+                self._batch_depth -= 1
+                if self._batch_depth == 0 and self._batch_dirty:
+                    self._batch_dirty = False
+                    self._write()
 
     def _load(self) -> None:
-        self._thread_to_session.clear()
+        """Populate this instance from the map file.
+
+        DELIBERATELY NOT ``@_guarded``. It runs from ``__init__`` only, on an
+        instance no other thread can reach yet, so the lock would protect
+        nothing here — and it would do harm: reading and parsing the file is the
+        one unbounded I/O step in this class, and a `SessionMap()` built on a
+        worker thread (``handlers/session_storage._build_index`` runs under
+        ``asyncio.to_thread``) would hold the lock across it, so a loop-side
+        ``set_slack_link`` would block on a worker's disk read and stall every
+        gateway task with it. The two shared effects it does have —
+        ``_rebuild_thread_index`` and the migration ``_save`` — take the lock
+        themselves, and both are bounded (see the class threading contract).
+        """
+        self._thread_to_session = {}
         if self._path.exists():
             try:
                 raw = json.loads(self._path.read_text(encoding="utf-8"))
@@ -212,6 +325,7 @@ class SessionMap:
         else:
             self._data = {}
 
+    @_guarded
     def _rebuild_thread_index(self) -> None:
         """Rebuild _thread_to_session from current _data.
 
@@ -227,8 +341,16 @@ class SessionMap:
         a self-link, which is a no-op rewrite); any other key holds the real
         conversation. This heals maps corrupted before the fix, on load, with no
         migration pass.
+
+        Built into a FRESH dict and rebound at the end, never cleared in place.
+        ``get_session_for_thread`` reads this index without the lock (one keyed
+        lookup, the hot path of every inbound Slack reply), so a clear-then-refill
+        would give it a window in which the thread it is resolving has no owner —
+        and "no owner" is not a delay there, it is a brand-new conversation
+        forked off the user's reply. A rebind is atomic under the GIL, so that
+        reader sees either the whole old index or the whole new one.
         """
-        self._thread_to_session.clear()
+        rebuilt: dict[str, str] = {}
         derived: dict[str, str] = {}
         for key, entry in self._data.items():
             ts = entry.get("slack_thread_ts")
@@ -242,16 +364,19 @@ class SessionMap:
                 # Self-derived: only usable if nothing else claims the thread.
                 derived.setdefault(ts, key)
                 continue
-            self._thread_to_session[ts] = key
+            rebuilt[ts] = key
         for ts, key in derived.items():
-            self._thread_to_session.setdefault(ts, key)
+            rebuilt.setdefault(ts, key)
+        self._thread_to_session = rebuilt
 
+    @_guarded
     def _save(self) -> None:
         if self._batch_depth:
             self._batch_dirty = True
             return
         self._write()
 
+    @_guarded
     def _write(self) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         tmp_fd, tmp_path = tempfile.mkstemp(dir=str(self._path.parent), suffix=".tmp")
@@ -292,6 +417,7 @@ class SessionMap:
                 key = canonical
         return key, entry
 
+    @_guarded
     def get(self, key: str) -> str | None:
         """Return kiro-cli session ID if mapping exists and .json file is present.
 
@@ -336,6 +462,7 @@ class SessionMap:
         """
         return self._resolve_alias(key)[1] is not None
 
+    @_guarded
     def _remove_entry(self, key: str) -> None:
         """Remove an entry and update reverse index."""
         entry = self._data.pop(key, None)
@@ -345,6 +472,7 @@ class SessionMap:
                 del self._thread_to_session[ts]
             self._save()
 
+    @_guarded
     def set(self, key: str, sid: str, *, provider: str = "", cwd: str = "") -> None:
         """Save mapping and persist to disk, preserving existing slack fields."""
         key = canonical_key(key)
@@ -378,6 +506,7 @@ class SessionMap:
             return ""
         return entry.get("provider", "")
 
+    @_guarded
     def clear_sid(self, key: str) -> None:
         """Clear the stored session ID without removing the entry.
 
@@ -400,10 +529,12 @@ class SessionMap:
             return ""
         return entry.get("discarded_sid", "")
 
+    @_guarded
     def delete(self, key: str) -> None:
         """Remove mapping and persist."""
         self._remove_entry(canonical_key(key))
 
+    @_guarded
     def prune(self) -> int:
         """Remove entries whose session files no longer exist.
 
@@ -457,6 +588,7 @@ class SessionMap:
             self._save()
         return len(stale)
 
+    @_guarded
     def mapped_sids_by_key(self) -> dict[str, str]:
         """Session key to kiro-cli session ID, for every entry that has one.
 
@@ -483,6 +615,7 @@ class SessionMap:
         """
         return is_channel_session_key(key) and key.endswith(thread_ts)
 
+    @_guarded
     def _evict_rival_claimants(self, key: str, thread_ts: str) -> list[str]:
         """Clear the Slack link fields of every OTHER entry claiming *thread_ts*.
 
@@ -511,6 +644,7 @@ class SessionMap:
             )
         return evicted
 
+    @_guarded
     def set_slack_link(self, key: str, thread_ts: str, channel_id: str | None) -> None:
         """Link a session to a Slack thread. Creates entry if needed.
 
@@ -560,6 +694,7 @@ class SessionMap:
                 self._thread_to_session[thread_ts] = key
         self._save()
 
+    @_guarded
     def get_slack_link(self, key: str) -> tuple[str | None, str | None]:
         """Return (thread_ts, channel_id) for a session."""
         entry = self._data.get(canonical_key(key))
@@ -567,6 +702,7 @@ class SessionMap:
             return None, None
         return entry.get("slack_thread_ts"), entry.get("slack_channel_id")
 
+    @_guarded
     def clear_slack_link(self, key: str) -> bool:
         """Remove the Slack link from a session, keeping the session itself.
 
@@ -603,6 +739,7 @@ class SessionMap:
     # special-casing Slack. Slack routes back through the dedicated fields;
     # every other channel stores a ``ChannelLink`` under ``mirror``.
 
+    @_guarded
     def set_mirror_link(
         self,
         key: str,
@@ -645,6 +782,7 @@ class SessionMap:
             entry.pop("mirror_accepts_inbound", None)
         self._save()
 
+    @_guarded
     def mirror_claim_blockers(
         self,
         key: str,
@@ -710,6 +848,7 @@ class SessionMap:
             return rivals
         return []
 
+    @_guarded
     def _mirror_key(self, key: str) -> str:
         """The key a session's mirror binding is actually stored under.
 
@@ -732,6 +871,7 @@ class SessionMap:
                 return legacy_dashboard_mirror_key(canon)
         return canon
 
+    @_guarded
     def get_mirror_link(self, key: str) -> ChannelLink | None:
         """Return a session's outbound mirror target as a channel-neutral link.
 
@@ -766,6 +906,7 @@ class SessionMap:
         entry = self._data.get(canonical_key(key))
         return bool(entry and entry.get("mirror_accepts_inbound"))
 
+    @_guarded
     def find_mirror_sessions(
         self,
         link: ChannelLink,
@@ -794,6 +935,7 @@ class SessionMap:
                 matches.append(key)
         return matches
 
+    @_guarded
     def clear_mirror_links_at(self, link: ChannelLink) -> list[str]:
         """Clear EVERY session whose mirror targets an exact non-Slack location.
 
@@ -823,6 +965,7 @@ class SessionMap:
             self._save()
         return cleared
 
+    @_guarded
     def clear_mirror_link(self, key: str) -> bool:
         """Remove a session's outbound mirror binding; return True iff one existed.
 
@@ -845,6 +988,7 @@ class SessionMap:
             return self.clear_slack_link(mkey)
         return False
 
+    @_guarded
     def max_generation(self, bucket: str) -> int:
         """Return the highest persisted DM generation for a session *bucket*.
 
@@ -866,6 +1010,7 @@ class SessionMap:
                     best = max(best, int(suffix))
         return best
 
+    @_guarded
     def find_key_by_sid(self, session_id: str) -> str | None:
         """Find the session map key for a given kiro-cli session ID."""
         for k, entry in self._data.items():
@@ -874,6 +1019,7 @@ class SessionMap:
                 return k
         return None
 
+    @_guarded
     def channel_key_for_stem(self, stem: str) -> str:
         """The real channel session key whose transcript filename is *stem*.
 
@@ -909,6 +1055,7 @@ class SessionMap:
         raw = entry.get("link")
         return ChannelLink.from_dict(raw) if raw else None
 
+    @_guarded
     def set_link(self, key: str, link: ChannelLink) -> None:
         """Set the session's OWN inbound-channel link. Creates entry if needed."""
         key = canonical_key(key)
@@ -930,6 +1077,7 @@ class SessionMap:
     # survive gateway restarts and ties its lifetime to the session (pruned
     # with the entry) rather than an ad-hoc bounded LRU in module-global dicts.
 
+    @_guarded
     def _ensure_entry(self, key: str) -> dict:
         """Return the entry for *key*, creating a blank one if absent."""
         entry = self._data.get(key)
@@ -938,6 +1086,7 @@ class SessionMap:
             self._data[key] = entry
         return entry
 
+    @_guarded
     def set_flag(self, key: str, flag: str, value: bool) -> None:
         """Set or clear a boolean per-conversation flag (e.g. ``temporary``).
 
@@ -975,6 +1124,7 @@ class SessionMap:
         flags = entry.get("flags")
         return bool(flags and flags.get(flag))
 
+    @_guarded
     def set_agent_override(self, key: str, agent: str | None) -> None:
         """Set (or clear, when *agent* is falsy) the per-thread agent override."""
         key = canonical_key(key)
@@ -992,6 +1142,7 @@ class SessionMap:
         entry = self._data.get(canonical_key(key))
         return entry.get("agent_override") if entry else None
 
+    @_guarded
     def set_project_override(self, key: str, project: str | None) -> None:
         """Set (or clear, when *project* is falsy) the per-thread project dir."""
         key = canonical_key(key)

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import os
 import threading
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
 
@@ -210,6 +211,19 @@ class FakeSessions:
         self.mirror_links: dict[str, Any] = {}
         self.origin_links: dict[str, Any] = {}
         self.inbound_mirror_keys: set[str] = set()
+        # Batch bookkeeping, mirroring the real SessionManager: the unlink path
+        # wraps its three clears in one batch, and a double without the context
+        # manager would make that path unreachable from these tests.
+        self.batch_depth = 0
+        self.batched_writes: list[bool] = []
+
+    @contextmanager
+    def batched_save(self) -> Any:
+        self.batch_depth += 1
+        try:
+            yield
+        finally:
+            self.batch_depth -= 1
 
     async def get_or_create(self, key: str, *, agent: Any = None, channel_id: Any = None) -> Any:
         self.last_agent = agent
@@ -285,10 +299,12 @@ class FakeSessions:
         ]
 
     def clear_mirror_link(self, key: str) -> bool:
+        self.batched_writes.append(self.batch_depth > 0)
         self.inbound_mirror_keys.discard(key)
         return self.mirror_links.pop(key, None) is not None
 
     def clear_mirror_links_at(self, link: Any) -> list[str]:
+        self.batched_writes.append(self.batch_depth > 0)
         cleared = self.find_mirror_sessions(link)
         for key in cleared:
             self.inbound_mirror_keys.discard(key)

--- a/test/test_session_map_locking.py
+++ b/test/test_session_map_locking.py
@@ -1,0 +1,463 @@
+"""SessionMap's threading contract: the lock, the batch, and the ratchets.
+
+Issue #2989. Every mutation rewrites the WHOLE map from ``_data``, so a
+read-modify-write is atomic only while nothing else touches the structure.
+Before ``_MAP_LOCK`` the event loop was the only thing providing that, which is
+why offloading a single write made the map racy instead of non-blocking (a
+``to_thread`` wrapper reverted on #2976 for exactly that reason).
+
+Four properties are pinned here:
+
+1. more than one thread may call the map, and no entry is lost;
+2. a ``batched_save`` block is ONE critical section, not merely one write;
+3. a lock-FREE reader never observes a half-built structure, which is the price
+   of leaving the hot single-key probes unlocked;
+4. the two rules that no runtime assertion can express are ratcheted
+   structurally — every mutating/iterating method holds the lock, and no
+   ``batched_save`` block anywhere in the tree awaits.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import kiro_crew.session_map as session_map_mod
+from kiro_crew.session_map import SESSION_MAP_FILENAME, SessionMap
+
+SRC = Path(session_map_mod.__file__).resolve().parent
+
+
+@pytest.fixture
+def session_map(tmp_path):
+    with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+        yield SessionMap()
+
+
+class TestConcurrentMutation:
+    """Property 1: any thread may call the map."""
+
+    def test_parallel_writers_lose_no_entry(self, session_map, tmp_path):
+        """Every key written from N threads survives in the persisted file.
+
+        Without the lock this is the lost update the issue describes: each
+        ``set`` rewrites the WHOLE map from ``_data``, so two threads that
+        interleave read-modify-write drop one another's entries — and the file
+        keeps whichever ``os.replace`` happened to land last.
+        """
+        errors: list[BaseException] = []
+        start = threading.Barrier(8)
+
+        def writer(n: int) -> None:
+            try:
+                start.wait(timeout=10)
+                for i in range(25):
+                    session_map.set(f"dashboard:t{n}-{i}", f"sid-{n}-{i}")
+            except BaseException as exc:  # pragma: no cover - reported below
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer, args=(n,)) for n in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert errors == []
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            reloaded = SessionMap()
+        persisted = reloaded.mapped_sids_by_key()
+        expected = {f"dashboard:t{n}-{i}": f"sid-{n}-{i}" for n in range(8) for i in range(25)}
+        assert persisted == expected
+
+    def test_iterating_reader_survives_concurrent_writer(self, session_map):
+        """A scan does not blow up on a dict mutated underneath it.
+
+        ``mapped_sids_by_key`` / ``find_key_by_sid`` iterate ``_data``. An
+        unlocked scan racing a writer raises ``RuntimeError: dictionary changed
+        size during iteration`` — a gateway-visible crash in whatever task
+        happened to be scanning, not a subtle inconsistency.
+
+        The switch interval is shortened for the duration: at the default 5 ms a
+        scan of a few hundred keys usually finishes inside one slice, so the
+        unlocked race is real but rarely observed, and a test that only
+        SOMETIMES catches it reports coverage it does not have.
+        """
+        for i in range(600):
+            session_map.set(f"dashboard:seed-{i}", f"sid-{i}")
+        errors: list[BaseException] = []
+        stop = threading.Event()
+        running = threading.Event()
+
+        def writer() -> None:
+            i = 0
+            try:
+                while not stop.is_set():
+                    session_map.set(f"dashboard:churn-{i}", f"sid-churn-{i}")
+                    running.set()
+                    session_map.delete(f"dashboard:churn-{i}")
+                    i += 1
+            except BaseException as exc:  # pragma: no cover - reported below
+                errors.append(exc)
+
+        previous_interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        t = threading.Thread(target=writer)
+        t.start()
+        try:
+            assert running.wait(timeout=10)
+            for _ in range(200):
+                session_map.mapped_sids_by_key()
+                session_map.find_key_by_sid("sid-599")
+        finally:
+            stop.set()
+            t.join(timeout=30)
+            sys.setswitchinterval(previous_interval)
+        assert errors == []
+
+
+class TestBatchIsOneCriticalSection:
+    """Property 2: a batch excludes other threads, not just extra writes."""
+
+    def test_writer_cannot_interleave_with_a_batch(self, session_map):
+        entered = threading.Event()
+        other_finished = threading.Event()
+
+        def other_writer() -> None:
+            entered.wait(timeout=10)
+            session_map.set("dashboard:outsider", "sid-outsider")
+            other_finished.set()
+
+        t = threading.Thread(target=other_writer)
+        t.start()
+        try:
+            with session_map.batched_save():
+                session_map.set("dashboard:a", "sid-a")
+                entered.set()
+                # The other thread is now runnable and wants the same map. It
+                # must not be able to complete its whole-map write inside this
+                # block: doing so would put its entry in a snapshot this batch
+                # then overwrites on exit.
+                assert not other_finished.wait(timeout=0.5)
+                session_map.set("dashboard:b", "sid-b")
+        finally:
+            entered.set()
+            t.join(timeout=30)
+
+        assert other_finished.is_set()
+        keys = session_map.mapped_sids_by_key()
+        assert {"dashboard:a", "dashboard:b", "dashboard:outsider"} <= set(keys)
+
+    def test_batch_still_collapses_to_one_write(self, session_map):
+        with patch.object(SessionMap, "_write", autospec=True) as write:
+            with session_map.batched_save():
+                session_map.set("dashboard:a", "sid-a")
+                session_map.set("dashboard:b", "sid-b")
+                session_map.set_flag("dashboard:a", "temporary", True)
+        assert write.call_count == 1
+
+    def test_lock_is_released_when_a_batch_raises(self, session_map):
+        with pytest.raises(ValueError):
+            with session_map.batched_save():
+                session_map.set("dashboard:a", "sid-a")
+                raise ValueError("boom")
+        # A leaked lock would hang this call rather than fail it.
+        done = threading.Event()
+
+        def probe() -> None:
+            session_map.set("dashboard:after", "sid-after")
+            done.set()
+
+        t = threading.Thread(target=probe)
+        t.start()
+        t.join(timeout=10)
+        assert done.is_set()
+        # The partial sequence still reached disk (unchanged pre-existing rule).
+        assert "dashboard:a" in session_map.mapped_sids_by_key()
+
+
+class TestLockFreeReadsSeeWholeStructures:
+    """Property 3: what leaving the hot probes unlocked obliges writers to do."""
+
+    def test_thread_index_probe_never_sees_a_missing_owner(self, session_map):
+        """``get_session_for_thread`` resolves during a concurrent rebuild.
+
+        The probe is lock-free — it is the hot path of every inbound Slack reply
+        — so a rebuild that CLEARED the index and refilled it would give the
+        probe a window where the thread has no owner. That is not a delay for
+        the caller: an unowned thread forks the user's reply into a brand-new
+        session. So the rebuild must publish a finished dict by rebinding.
+        """
+        for i in range(400):
+            session_map.set_slack_link(f"dashboard:chat-{i}", f"ts-{i}", "C1")
+        misses: list[str] = []
+        stop = threading.Event()
+        running = threading.Event()
+
+        def rebuilder() -> None:
+            while not stop.is_set():
+                session_map._rebuild_thread_index()
+                running.set()
+
+        previous_interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        t = threading.Thread(target=rebuilder)
+        t.start()
+        try:
+            assert running.wait(timeout=10)
+            for _ in range(4000):
+                if session_map.get_session_for_thread("ts-399") != "dashboard:chat-399":
+                    misses.append("unowned")
+                    break
+        finally:
+            stop.set()
+            t.join(timeout=30)
+            sys.setswitchinterval(previous_interval)
+        assert misses == []
+
+
+class TestLockHoldIsBounded:
+    """A caller can WAIT now, so what runs under the lock must stay bounded."""
+
+    def test_worker_thread_construction_does_not_block_the_loop(self, session_map, tmp_path):
+        """Building a `SessionMap()` off-loop must not stall a loop-side mutation.
+
+        `handlers/session_storage._build_index` constructs one under
+        `asyncio.to_thread`. If `_load` held the lock across its file read, a
+        loop-side `set_slack_link` would block on a worker's disk I/O — and the
+        stall is shared by every gateway task, including the heartbeat. The read
+        is made slow here so the difference is a decision, not a race.
+        """
+        for i in range(300):
+            session_map.set(f"dashboard:seed-{i}", f"sid-{i}")
+
+        real_read = Path.read_text
+        reading = threading.Event()
+        release = threading.Event()
+
+        def slow_read(self, *a, **kw):
+            if self.name == SESSION_MAP_FILENAME:
+                reading.set()
+                release.wait(timeout=10)
+            return real_read(self, *a, **kw)
+
+        loop_side_done = threading.Event()
+
+        def worker() -> None:
+            with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+                with patch.object(Path, "read_text", slow_read):
+                    SessionMap()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        try:
+            assert reading.wait(timeout=10), "worker never reached the file read"
+            # The worker is now parked INSIDE _load. A loop-side mutation must
+            # complete anyway.
+            mutator = threading.Thread(
+                target=lambda: (
+                    session_map.set_slack_link("dashboard:seed-0", "ts-0", "C1"),
+                    loop_side_done.set(),
+                )
+            )
+            mutator.start()
+            assert loop_side_done.wait(timeout=5), (
+                "a loop-side mutation blocked behind a worker thread's map file read"
+            )
+            mutator.join(timeout=10)
+        finally:
+            release.set()
+            t.join(timeout=30)
+
+    def test_no_guarded_method_reads_the_map_file(self):
+        """Ratchet: the file read/parse stays outside the lock.
+
+        This is the invariant behind the bound in the class contract. A future
+        `reload()` decorated `@_guarded` would reintroduce exactly the stall the
+        test above pins.
+        """
+        offenders = []
+        for fn in _session_map_class().body:
+            if not isinstance(fn, ast.FunctionDef):
+                continue
+            decorators = {d.id for d in fn.decorator_list if isinstance(d, ast.Name)}
+            if "_guarded" not in decorators:
+                continue
+            for node in ast.walk(fn):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if isinstance(func, ast.Attribute) and func.attr in {"read_text", "loads", "load"}:
+                    offenders.append(f"{fn.name} -> {func.attr}")
+        assert offenders == [], (
+            f"guarded methods read/parse the map file: {offenders}. Reading the "
+            "file is the one unbounded step in this class; holding the lock "
+            "across it lets an off-loop construction stall every gateway task."
+        )
+
+    def test_load_runs_only_from_init(self):
+        """`_load`'s safety rests on the instance being unpublished.
+
+        It is unguarded because `__init__` is the only caller, so no other thread
+        can see `self` yet. A second call site from a live instance would make it
+        an unsynchronized writer.
+        """
+        callers = []
+        for fn in _session_map_class().body:
+            if not isinstance(fn, ast.FunctionDef):
+                continue
+            for node in ast.walk(fn):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "_load"
+                ):
+                    callers.append(fn.name)
+        assert callers == ["__init__"], (
+            f"_load is called from {callers}; it is unguarded ONLY because the "
+            "instance is not yet shared with any other thread."
+        )
+
+
+def _session_map_class() -> ast.ClassDef:
+    tree = ast.parse((SRC / "session_map.py").read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "SessionMap":
+            return node
+    raise AssertionError("SessionMap class not found")
+
+
+def _touches_map_structure(fn: ast.FunctionDef) -> bool:
+    """True when *fn* mutates or iterates ``_data`` / ``_thread_to_session``.
+
+    Structural, not name-based: a new method is caught by what it does, not by
+    what it is called. Recognized shapes are assignment/``del`` to a subscript
+    of the dict, a ``.pop``/``.clear``/``.setdefault`` call on it, iteration
+    over it, and handing the whole dict to another callable (``json.dump``).
+    """
+    guarded = {"_data", "_thread_to_session"}
+
+    def names_map(node: ast.AST) -> bool:
+        return isinstance(node, ast.Attribute) and node.attr in guarded
+
+    for node in ast.walk(fn):
+        if isinstance(node, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for tgt in targets:
+                if isinstance(tgt, ast.Subscript) and names_map(tgt.value):
+                    return True
+        if isinstance(node, ast.Delete):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Subscript) and names_map(tgt.value):
+                    return True
+        if isinstance(node, ast.Call):
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr in {"pop", "clear", "setdefault"}
+                and names_map(func.value)
+            ):
+                return True
+            if any(names_map(arg) for arg in node.args):
+                return True
+        if isinstance(node, (ast.For, ast.comprehension)):
+            iterable = node.iter
+            if names_map(iterable):
+                return True
+            if (
+                isinstance(iterable, ast.Call)
+                and isinstance(iterable.func, ast.Attribute)
+                and iterable.func.attr in {"items", "keys", "values"}
+                and names_map(iterable.func.value)
+            ):
+                return True
+    return False
+
+
+class TestLockRatchet:
+    """Property 4a: a mutator cannot be added without the lock."""
+
+    def test_every_structural_method_holds_the_lock(self):
+        offenders = []
+        for fn in _session_map_class().body:
+            if not isinstance(fn, ast.FunctionDef):
+                continue
+            if fn.name == "batched_save":
+                continue  # takes the lock explicitly around its yield
+            decorators = {d.id for d in fn.decorator_list if isinstance(d, ast.Name)}
+            if _touches_map_structure(fn) and "_guarded" not in decorators:
+                offenders.append(fn.name)
+        assert offenders == [], (
+            "SessionMap methods mutate or iterate the map without @_guarded: "
+            f"{offenders}. The loop is no longer the only mutex — see the class "
+            "docstring's threading contract."
+        )
+
+    def test_ratchet_detects_an_unguarded_mutator(self):
+        """The ratchet above fails when the decorator is dropped.
+
+        Without this, a detector that silently stopped matching would keep
+        reporting an empty offender list forever.
+        """
+        fn = ast.parse(
+            "def set_thing(self, k, v):\n    self._data[k] = v\n    self._save()\n"
+        ).body[0]
+        assert isinstance(fn, ast.FunctionDef)
+        assert _touches_map_structure(fn)
+        scan = ast.parse("def read_thing(self, k):\n    return self._data.get(k)\n").body[0]
+        assert isinstance(scan, ast.FunctionDef)
+        assert not _touches_map_structure(scan)
+
+
+class TestNoAwaitInsideBatch:
+    """Property 4b: no ``batched_save`` block anywhere in the tree awaits."""
+
+    @staticmethod
+    def _batch_blocks(tree: ast.AST):
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.With, ast.AsyncWith)):
+                continue
+            for item in node.items:
+                expr = item.context_expr
+                if (
+                    isinstance(expr, ast.Call)
+                    and isinstance(expr.func, ast.Attribute)
+                    and expr.func.attr == "batched_save"
+                ):
+                    yield node
+                    break
+
+    def test_no_batch_block_awaits(self):
+        offenders: list[str] = []
+        for path in SRC.rglob("*.py"):
+            if "_vendor" in path.parts:
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError:  # pragma: no cover - the tree compiles in CI
+                continue
+            for block in self._batch_blocks(tree):
+                for inner in ast.walk(block):
+                    if isinstance(inner, (ast.Await, ast.AsyncFor, ast.AsyncWith)):
+                        offenders.append(f"{path.name}:{inner.lineno}")
+        assert offenders == [], (
+            "batched_save() is held across an await at: "
+            f"{offenders}. The lock is reentrant per THREAD, so an await lets "
+            "another coroutine on the same loop into the block while a worker "
+            "thread waiting on the lock stalls until the await returns."
+        )
+
+    def test_ratchet_detects_an_awaiting_batch(self):
+        tree = ast.parse(
+            "async def f(s):\n"
+            "    with s.batched_save():\n"
+            "        s.set('k', 'v')\n"
+            "        await s.flush()\n"
+        )
+        blocks = list(self._batch_blocks(tree))
+        assert len(blocks) == 1
+        assert any(isinstance(n, ast.Await) for n in ast.walk(blocks[0]))

--- a/test/test_session_map_mirror.py
+++ b/test/test_session_map_mirror.py
@@ -331,6 +331,32 @@ class TestReleaseConversationLocation:
         assert reply == "✅ Unlinked."
         assert swept == []
 
+    def test_the_three_clears_are_one_write(self, session_map):
+        # Freeing a location is ONE action. Its three clears each rewrite the
+        # whole map, so unbatched they are three writes and three separately
+        # interruptible steps — a crash or a concurrent writer partway through
+        # leaves the location half-freed while the reply already said ✅.
+        plant_binding(session_map, self.KEY, self.LINK)
+        plant_binding(session_map, f"{self.KEY}:gen1", self.LINK)
+        with patch.object(SessionMap, "_write", autospec=True) as write:
+            release_conversation_location(
+                session_map, key=self.KEY, location=self.LINK, channel="discord"
+            )
+        assert write.call_count == 1
+
+    def test_an_outer_batch_still_collapses_to_one_write(self, session_map):
+        # Telegram wraps this call together with its opt-out write. Nesting is
+        # counted, so the wider sequence must stay a single write rather than
+        # this function's batch flushing early inside it.
+        plant_binding(session_map, self.KEY, self.LINK)
+        with patch.object(SessionMap, "_write", autospec=True) as write:
+            with session_map.batched_save():
+                session_map.set_flag(self.KEY, "mirror_opt_out", True)
+                release_conversation_location(
+                    session_map, key=self.KEY, location=self.LINK, channel="discord"
+                )
+        assert write.call_count == 1
+
 
 class TestPrunePreservesMirror:
     def test_mirror_only_entry_survives_prune(self, tmp_path):

--- a/test/test_slack_thread_sync.py
+++ b/test/test_slack_thread_sync.py
@@ -1,6 +1,7 @@
 """Tests for Live Slack thread sync (bidirectional mirroring)."""
 from __future__ import annotations
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -109,6 +110,38 @@ class TestDashboardStateLinkSlack:
         assert state._slots["s2"]._slack_linked is True
         assert state._slots["s1"]._slack_thread_ts == "111.000"
         assert state._slots["s2"]._slack_thread_ts == "222.000"
+
+    def test_thread_handoff_persists_inside_one_batch(self, tmp_path):
+        """Both halves of a thread handoff land in a single session-map write.
+
+        Taking a thread from another slot clears the previous owner's link and
+        claims it here. Each of those rewrites the whole map, so as two separate
+        writes the pair is separately interruptible: the thread ends up with no
+        owner (clear landed, claim did not) or with two (the reverse).
+        """
+        state = _make_state(tmp_path)
+        depth = {"n": 0}
+        depth_at_write: list[int] = []
+
+        @contextmanager
+        def batched_save():
+            depth["n"] += 1
+            try:
+                yield
+            finally:
+                depth["n"] -= 1
+
+        state.sessions.batched_save = batched_save
+        state.sessions.set_slack_link = MagicMock(
+            side_effect=lambda *a, **k: depth_at_write.append(depth["n"])
+        )
+        state.get_or_create_slot("s1")
+        state.get_or_create_slot("s2")
+        state.link_slack("s1", "111.000", "C1")
+        # s2 takes the thread s1 holds: clear s1's persisted link, claim for s2.
+        state.link_slack("s2", "111.000", "C1")
+        assert len(depth_at_write) == 3
+        assert depth_at_write == [1, 1, 1]
 
 
 # -- Unit tests: slot restore with slack link --


### PR DESCRIPTION
## What is the problem?

`SessionMap` (`src/kiro_crew/session_map.py`) held **no lock**, and every mutation rewrote the **whole** map from `_data` (`mkstemp` + `json.dump(self._data)` + `os.replace`). The write is atomic per call; a read-modify-write **pair** is not. `grep -n "Lock\|threading" src/kiro_crew/session_map.py` returned nothing, and every call site was a direct on-loop call — so the event loop was the only mutex the structure had.

Two things followed from that, and both were load-bearing while written down nowhere:

- **Offloading any single mutation was unsafe, not merely unhelpful.** A worker thread's read-modify-write could interleave with the loop's, and the later `os.replace` would silently drop the other's entry. #2976 had to revert an `asyncio.to_thread` wrapper around one binding write for exactly this.
- **Nothing said "loop-only".** The next person to reach for `to_thread`, an executor, or a background sweep would reintroduce the race with no gate in the way.

## Why this issue matters to the user

The failure mode is a session that quietly stops being addressable. A dropped map entry is a conversation Kiro Crew can no longer resume: the user's next Slack or Telegram reply does not continue their thread, it silently starts a fresh one with none of the transcript. There is no error to see — the write "succeeded".

The audit for this change also found a live instance of that shape, independent of any threading: `_rebuild_thread_index` **cleared** `_thread_to_session` and refilled it, while `get_session_for_thread` — the hot path of every inbound Slack reply — reads that index with no lock. A reply landing inside that window resolves to no owner, and "no owner" is not a retry there, it is a forked conversation. `prune()` rebuilds the index on the live map, so the window is reachable in normal operation.

## How our fix solves it

Symptom → mechanism → fix:

1. **Entries vanish / a scan crashes mid-iteration** → `_data` is a plain dict mutated from whatever thread calls in → `_MAP_LOCK`, a **module-level** `threading.RLock`, held by every method that mutates the map, iterates it, or reads several fields as one unit (30 methods, via a `@_guarded` decorator).
   - **Module-level, not per-instance**, because instances are not the unit of exclusion: `handlers/session_storage.py` and `slack/handler.py` build throwaway `SessionMap()` readers while `SessionManager` holds the long-lived one, and all of them resolve the same file.
   - **Reentrant**, because the surface composes (`set_mirror_link` → `clear_mirror_link` → `clear_slack_link` → `_save` → `_write`) and batches nest; a plain `Lock` would deadlock the first such call.
   - Single-key probes (`get_cwd`, `get_flag`, `get_session_for_thread`, …) stay **lock-free on purpose**: one `dict.get` cannot observe a half-applied write, and locking them would put the map's cheapest reads — including the one on every inbound reply — behind its most expensive write.
   - **What may be held under the lock is bounded**, because a caller can now wait. **No guarded method reads or parses the map file**, so the longest hold is one whole-map write (0.77 ms, below) plus a session-file stat per entry in `get`/`prune` — costs the loop already paid inline before the lock existed. `_load` is deliberately **unguarded**: it runs from `__init__` only, on an instance no other thread can reach yet, so the lock would protect nothing there while making the one unbounded I/O step block every waiter. That matters concretely — `handlers/session_storage._build_index` constructs a `SessionMap()` under `asyncio.to_thread`, so a guarded `_load` would let a worker's disk read stall a loop-side `set_slack_link` and every gateway task with it.

2. **A two-call sequence is two critical sections** → another thread's write lands between them and is then dropped by the second one's whole-map rewrite → `batched_save()` now **holds the lock across the block**, so the sequence is atomic and not merely coalesced. Its "must not be held across an `await`" rule gains a sharper reason (the lock is reentrant **per thread**, so an await readmits another coroutine exactly as if there were no lock) and is now **ratcheted** rather than trusted.

3. **A lock-free reader could see a half-built structure** → `_rebuild_thread_index` cleared the index in place → it now builds a fresh dict and **rebinds** it. Rebinding is atomic under the GIL, so the probe sees either the whole old index or the whole new one. `_load` likewise rebinds instead of clearing.

4. **Audit: read-modify-write pairs that were separate writes** (the issue names the first):
   - `messaging/link.release_conversation_location` — three clears (own key, legacy spelling, sweep by location) → one batch, one write. Unbatched, a failure partway through leaves the location half-freed while the reply already said ✅. Telegram's wider batch around this call still collapses to one write (nesting is counted).
   - `dashboard/state.link_slack` — a thread handoff clears the previous owner's link and claims it here → one batch. As two writes it is separately interruptible: the thread ends up with **no** owner (clear landed, claim did not) or **two** (the reverse). This matches the guarantee `set_slack_link` already gives its own eviction-and-claim.

5. **Contract documented on the class** — the three rules, and honestly, their limits: the lock is **in-process** (two gateways writing one file would still lose updates; the data-home singleton is what prevents that), and it does **not** make a detached `SessionMap()` safe to write through, because that instance's whole-file write is a stale snapshot regardless of ordering.

**Scope deliberately stops here.** The issue asked to measure before choosing between "lock only" and "lock + serialized writer". Measured whole-map serialize+write on xfs:

| entries | file size | median | max |
|---|---|---|---|
| 195 (live map) | 42 KB | **0.77 ms** | 0.94 ms |
| 1,000 | 193 KB | 5.5 ms | 7.4 ms |
| 5,000 | 970 KB | 16.2 ms | 29.8 ms |
| 20,000 | 3.8 MB | 62.3 ms | 102.6 ms |

At today's real size the stall is sub-millisecond, so **the lock alone is the whole fix** and offloading is not justified yet — it becomes real past ~1,000 entries. That is #2405, and this change is its prerequisite: before the lock, offloading a write made the map racy instead of non-blocking.

## What tests we did

New `test/test_session_map_locking.py` (10 tests) plus additions to three existing files:

- **Concurrency**: 8 threads × 25 `set` calls — the reloaded file must equal the exact expected mapping; and an iterating reader (`mapped_sids_by_key`, `find_key_by_sid`) racing a churning writer must not raise. Both shorten `sys.setswitchinterval` for the duration, because at the default 5 ms the unlocked race is real but rarely observed and a test that only *sometimes* catches it reports coverage it does not have.
- **Batch atomicity**: a second thread cannot complete its write inside a batch; a batch is still one `_write`; a raising batch still persists its partial sequence and does not leak the lock.
- **Lock-free reads**: `get_session_for_thread` resolves correctly through 4,000 probes against a continuously rebuilding index.
- **Bounded lock hold**: a worker thread parked inside `_load`'s file read must not delay a loop-side `set_slack_link`; plus ratchets that no guarded method reads/parses the map file and that `_load` is called only from `__init__`.
- **Two AST ratchets**: every `SessionMap` method that structurally mutates or iterates the map carries `@_guarded` (detected by what it does, not by its name), and no `batched_save` block **anywhere in `src/`** contains an `Await`/`AsyncFor`/`AsyncWith`. Each ratchet has a companion test proving the detector still discriminates.
- **Batching**: `release_conversation_location` is one write (and stays one inside an outer batch); every persisted write of a `link_slack` handoff happens at batch depth ≥ 1.

Verification:

- **9/9 mutants caught** — strip every `@_guarded` (4 tests fail), unlock `batched_save`, clear the index in place instead of rebinding (2/2 repeat runs), put an `await` inside a real batch block, unbatch `release_conversation_location`, unbatch the `link_slack` handoff; re-guard `_load`; inject a guarded `reload()` that reads the file; add a second `_load` call site.
- **Full backend suite A/B against the base** (`1f69c6eae`): 43.9k tests, failure sets diffed by name with `comm`. No regression — the handful of IDs that differ between runs are pre-existing environmental/order-dependent failures (terminal-probe env allowlist, `gh` CLI ownership check) that reproduce identically on the base.
- **isort / flake8 7.1.0 / mypy 1.14.1** clean (892 source files). No frontend changes.
- Repeated the new file 3× for stability.

## Any other suggestions on the work

- **#2405 is now unblocked** and should decide between per-mutation offload and a single serialized writer using the numbers above. The lock plus the "publish by rebinding" rule are what make either safe to try.
- The `@_guarded` name deliberately differs from `history.ConversationLog._locked`, which is a *cross-process* file lock that also refuses on-loop entry. Sharing the name would have implied guarantees this does not make.
- Two mutation sites were left alone on purpose: `slack/handler._apply_temporary_modifier` / `_apply_incognito_modifier` each do `set_flag` + `set_slack_link` with an SEL audit call between them. They touch different fields, so batching buys one fewer write and no atomicity, and it would stretch the critical section over audit I/O.

Refs #2989

