### PR TITLE
test: freeze the clock the /side isolation assertion compares

### DIFF
--- a/test/test_side.py
+++ b/test/test_side.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -24,6 +25,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 from chat_test_helpers import _make_state
 
+from kiro_crew import context as context_module
 from kiro_crew.context import ContextBuilder
 from kiro_crew.dashboard.handlers.side import (
     _run_side_turn,
@@ -92,10 +94,42 @@ def _stub_run_side_turn(monkeypatch, *, answer: str = _SIDE_ANSWER):
     monkeypatch.setattr("kiro_crew.dashboard.handlers.side._run_side_turn", _fake_run)
 
 
+#: What a frozen clock reads. Any fixed instant does; a recognisable one makes an
+#: accidental real-clock read obvious in a failure diff.
+_FROZEN_NOW = datetime(2026, 1, 2, 3, 4, 5)
+
+
+class _FrozenClock(datetime):
+    """A ``datetime`` whose ``now()`` does not advance.
+
+    Subclassed rather than replaced with a stub: ``context`` happens to call only
+    ``now``, but a bare stub would break the moment any other ``datetime`` API is
+    used there, and that breakage would read as a defect in the test rather than
+    in its double.
+    """
+
+    @classmethod
+    def now(cls, tz=None):  # type: ignore[override]
+        return _FROZEN_NOW.replace(tzinfo=tz)
+
+
+def _freeze_context_clock(monkeypatch):
+    """Pin the clock that ``build_session_context`` renders into its output.
+
+    The rendered context carries a wall-clock read formatted to the MINUTE, so
+    comparing two renders byte-for-byte otherwise asserts that both happened
+    inside the same clock minute — a property no behaviour under test controls,
+    and one that breaks whenever a minute boundary lands between the two calls.
+    Freezing the clock keeps the equality total over everything else.
+    """
+    monkeypatch.setattr(context_module, "datetime", _FrozenClock)
+
+
 @pytest.mark.asyncio
 async def test_memory_isolation_byte_equal_after_round_trip(tmp_path, monkeypatch):
     """Parent build_session_context is byte-equal pre/post a /side round-trip."""
     _stub_run_side_turn(monkeypatch)
+    _freeze_context_clock(monkeypatch)
     state = _make_state(tmp_path)
     state.sessions.destroy = AsyncMock()
     parent = state.get_or_create_slot("parent")
@@ -112,6 +146,10 @@ async def test_memory_isolation_byte_equal_after_round_trip(tmp_path, monkeypatc
         conversation_log=state.conversation_log,
     )
     ctx_before = builder.build_session_context(session_key="parent")
+    # Proves the freeze reached the renderer. Without this, a rename or an
+    # inlined import in `context` would put the real clock back and hand the
+    # equality below its minute-boundary dependency again, silently.
+    assert _FROZEN_NOW.strftime("%Y-%m-%d %H:%M") in ctx_before
 
     app = _make_side_app(state)
     async with TestClient(TestServer(app)) as client:


### PR DESCRIPTION
Fixes #3033

## The defect

`test/test_side.py::test_memory_isolation_byte_equal_after_round_trip` asserts that the parent's rendered session context is byte-equal before and after a `/side` round-trip. Each render embeds its own wall-clock read, formatted to the **minute** — `build_session_context` renders `%A, %Y-%m-%d %H:%M %Z` at two sites in `src/kiro_crew/context.py`. So the assertion held only while both renders landed inside the same clock minute, and broke whenever a minute boundary fell between them.

CI's own diff on such a run is one character:

```
Skipping 1894 identical leading characters in diff, use -v to show
Skipping 1266 identical trailing characters in diff, use -v to show
- 08-12 10:43 UTC
+ 08-12 10:44 UTC
```

1894 identical leading and 1266 identical trailing characters either side of it — `/side` isolation was byte-exact and only the clock had moved.

## The fix

Option (1) from the issue: freeze the clock the renderer reads, rather than excluding the volatile line. The assertion stays **total** over everything `/side` could actually perturb, instead of gaining room in which a real divergence could hide.

Two deliberate details:

- **The double subclasses `datetime` instead of standing in for it.** `context` currently calls only `now`, but a bare stub would break the moment any other `datetime` API is used there, and that breakage would read as a defect in the test rather than in its double.
- **A guard asserts the frozen instant actually appears in the rendered context.** Without it, a rename or an inlined import in `context` would put the real clock back and hand the equality its minute-boundary dependency again — silently, since the test would still pass most of the time. The guard makes that failure loud and local.

Not done, matching the issue's explicit non-goals: no skip, no xfail, no fuzzy or substring comparison, no retry.

## Verification

- `pytest test/test_side.py` — 11 passed.
- **Mutation check.** Made the frozen clock advance one minute per call and re-ran: the test fails with `main context diverged after /side round-trip`, reproducing the CI failure exactly. So the freeze is what makes this deterministic, and the assertion still detects a divergence rather than having been defanged. Reverted before committing.
- `isort --check-only src/kiro_crew test`, `flake8 src/kiro_crew test` — clean.
- Test-only change; `src/` is untouched, so `mypy src/kiro_crew/` is unaffected.

## Scope

One test. The issue checked the 15 test files referencing `build_session_context` (104 call sites) and found this is the only place asserting equality between two rendered contexts — every other assertion is presence/absence of a substring, which a timestamp cannot affect. I did not re-derive that count.

Found while triaging this same shard going red on an unrelated PR (#3013), where it blocked a green run.
