### PR TITLE
feat(discord): mirror a Discord conversation's dashboard turns back to the chat

### DIFF
--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -48,6 +48,7 @@ from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
 from kiro_crew.messaging.link import (
     ChannelLink,
+    bind_origin_mirror,
     build_dm_session_key,
     legacy_dashboard_mirror_key,
     release_conversation_location,
@@ -95,8 +96,8 @@ Commands:
 `!new` — Start a fresh conversation
 `!compact` — Compress context (when it gets long)
 `!sessions [query]` — Continue a recent or matching dashboard session here (owner only)
-`!link` — Mirror this conversation's dashboard tab here
-`!unlink` — Stop mirroring
+`!link` — Resume mirroring dashboard replies here (on by default)
+`!unlink` — Stop mirroring dashboard replies here
 `!stop` — Stop the current reply and clear the queue
 `!help` — Show this message
 
@@ -364,6 +365,18 @@ class DiscordDispatcher:
                 self.sessions.set_origin_link(
                     session_key, ChannelLink("discord", channel_id=channel_id)
                 )
+                # Bind this conversation as the session's outbound mirror so a
+                # turn the user later takes from the dashboard is delivered back
+                # here. Slack gets this from its own per-turn thread binding;
+                # Discord had it only behind an explicit `!link`, so the chat sat
+                # there looking dead while the conversation continued elsewhere.
+                # Inside the `resumed_key is None` branch with set_origin_link,
+                # for the same reason: a resumed session's own surface owns its
+                # output and `!link` refuses there too, so the automatic path must
+                # not do what the explicit one declines. (It would also decline on
+                # its own, having found the resume binding for this very channel —
+                # the placement is what keeps that from being load-bearing.)
+                self._bind_origin_mirror(session_key, channel_id)
             # Publish this turn's session identity so managed MCP tools resolve
             # X-Session-Key; one shared writer lives in messaging.identity.
             await publish_turn_identity(self.sessions, session_key)
@@ -899,8 +912,50 @@ class DiscordDispatcher:
             dm_scope=self.cfg.messaging.dm_scope,
         )
 
+    def _origin_mirror_link(self, channel_id: str) -> ChannelLink:
+        """The mirror location for the conversation a session is being read in.
+
+        One definition shared by the automatic bind, ``!link`` and ``!unlink``: an
+        unlink matches an occupied location by VALUE, so a second spelling of
+        "this conversation" would let the release miss the binding the bind wrote.
+
+        No ``thread_id``: a Discord thread IS a channel with its own id (the
+        inbound path takes ``thread_id`` FROM ``channel_id``), so *channel_id*
+        already scopes a thread conversation, and it is also the id the transport
+        posts to.
+        """
+        return ChannelLink("discord", channel_id=channel_id)
+
+    def _bind_origin_mirror(self, session_key: str, channel_id: str) -> None:
+        """Mirror this conversation's dashboard tab back to Discord, unasked.
+
+        The rule, the re-assert and the opt-out live in
+        :func:`~kiro_crew.messaging.link.bind_origin_mirror`, shared with the
+        Telegram dispatcher; this only supplies Discord's spelling of "this
+        conversation".
+
+        Synchronous and called ON the loop, like every other session-map
+        mutation. Interleaving is ordered by ``session_map._MAP_LOCK`` (held for
+        the whole of each guarded mutation, including the ``os.replace``), not by
+        the loop; what keeps the call here is that the write is BOUNDED — one
+        whole-map rewrite whose cost the loop pays once per conversation, on its
+        first turn only. ``test_the_binding_write_stays_on_the_loop_thread``
+        ratchets that placement.
+        """
+        bind_origin_mirror(
+            self.sessions,
+            key=session_key,
+            location=self._origin_mirror_link(channel_id),
+        )
+
     async def _handle_link(self, user_id: str, channel_id: str, thread_id: str = "") -> None:
-        """Mirror this conversation's dashboard tab back to Discord."""
+        """Re-enable mirroring of this conversation's dashboard tab back here.
+
+        Mirroring is automatic (see :meth:`_bind_origin_mirror`), so this is the
+        withdrawal of a previous ``!unlink`` rather than the only way to turn it
+        on. Clearing the opt-out is the load-bearing half: rebinding without it
+        would be undone by the next automatic bind check.
+        """
         assert self.client is not None
         # Refuse while a resumed session owns this conversation: linking would
         # rebind the same location and silently strand the resumed session.
@@ -912,23 +967,36 @@ class DiscordDispatcher:
             return
         key = self._session_key(user_id, thread_id)
         try:
-            self.sessions.set_mirror_link(key, ChannelLink("discord", channel_id=channel_id))
+            # One write for the whole sequence: each of these mutations would
+            # otherwise rewrite the entire session map, stalling the loop three
+            # times for what is one user-visible action.
+            #
+            # The claim goes FIRST inside the batch on purpose. ``batched_save``
+            # writes on the way out even when the block raises, so a refusal
+            # raised after the opt-out withdrawal would PERSIST that withdrawal
+            # for a link that never happened. ``set_mirror_link`` refuses before
+            # it mutates anything, so ordering it first leaves the batch clean
+            # and nothing is written.
+            with self.sessions.batched_save():
+                self.sessions.set_mirror_link(key, self._origin_mirror_link(channel_id))
+                self.sessions.set_mirror_opt_out(key, False)
+                # Drop any pre-unification row so a stale binding cannot outlive
+                # the rebind (reads prefer the channel key, but a leftover row
+                # would still answer a clear).
+                self.sessions.clear_mirror_link(legacy_dashboard_mirror_key(key))
         except ConversationOwnershipConflict:
-            # The resumed-session check above covers an inbound owner. This
-            # catches an occupant that check cannot see — an outbound-only
-            # dashboard mirror already pointing here. Same instruction either
-            # way, and reporting it beats surfacing a traceback as a generic
-            # command failure.
+            # Reachable past the resumed-session check above because that check
+            # fails CLOSED on duplicate inbound bindings: with two of them at this
+            # conversation `resumed_session` denies routing and returns None,
+            # while the claim is still refused. Same instruction either way, and
+            # reporting it beats surfacing a traceback as a generic command
+            # failure.
             logger.info("discord link refused: conversation already held")
             await self.client.send_message(
                 channel_id,
                 "⚠️ Another session is already linked here. Send `!unlink` first.",
             )
             return
-        # Drop any pre-unification row so a stale binding cannot outlive the
-        # rebind (reads prefer the channel key, but a leftover row would still
-        # answer a clear).
-        self.sessions.clear_mirror_link(legacy_dashboard_mirror_key(key))
         await self.client.send_message(
             channel_id,
             "✅ Linked. Replies from the dashboard for this conversation will "
@@ -947,12 +1015,17 @@ class DiscordDispatcher:
             )
             return
         key = self._session_key(user_id, thread_id)
-        reply, swept = release_conversation_location(
-            self.sessions,
-            key=key,
-            location=ChannelLink("discord", channel_id=channel_id),
-            channel="discord",
-        )
+        # Persist the refusal BEFORE releasing: mirroring is re-asserted on every
+        # inbound turn, so a release alone would be undone by the user's next
+        # message. Batched with the release so the pair is one whole-map write.
+        with self.sessions.batched_save():
+            self.sessions.set_mirror_opt_out(key, True)
+            reply, swept = release_conversation_location(
+                self.sessions,
+                key=key,
+                location=self._origin_mirror_link(channel_id),
+                channel="discord",
+            )
         if swept:
             # A swept binding can belong to a dashboard slot whose link chip is
             # projected at push time — nudge the dashboard like every other

--- a/src/kiro_crew/docs/discord-integration.md
+++ b/src/kiro_crew/docs/discord-integration.md
@@ -159,9 +159,22 @@ answers split across messages.
 | `!new` | Start a fresh conversation (shared for the current thread) |
 | `!compact` | Compress the current conversation context |
 | `!sessions` | Pick a recent dashboard session and continue it here (owner only) |
-| `!link` / `!unlink` | Mirror this conversation's dashboard tab here |
+| `!link` / `!unlink` | Resume or stop mirroring dashboard replies here (on by default) |
 | `!stop` | Stop the current reply and clear its queue |
 | `!help` | Show commands |
+
+### Continuing a Discord conversation from the dashboard
+
+A Discord conversation is its own mirror: every turn of that session is
+delivered back to the Discord channel it is read in, including the turns you
+later take from the session's dashboard tab. Nothing to switch on — the binding
+is (re-)asserted on each message you send, so it also survives a gateway
+restart or a rival claim that took it away.
+
+`!unlink` turns it off, and the refusal is remembered: without that, "off" would
+last exactly until your next message, since a conversation with no binding is
+indistinguishable from one that was never linked. `!link` withdraws it. Neither
+touches a binding you set explicitly from the dashboard to some other target.
 
 ### Continuing a dashboard session from Discord
 

--- a/src/kiro_crew/docs/telegram-integration.md
+++ b/src/kiro_crew/docs/telegram-integration.md
@@ -71,7 +71,9 @@ in Telegram offers them as autocomplete — `COMMAND_SPEC` in
   drive, so it expires on one clock everywhere. It does not weaken the
   PreToolUse gate: sensitive-path, governance-ceiling and deny-list blocks still
   refuse a tool.
-- `/link` / `/unlink` — mirror this conversation's dashboard tab here, or stop
+- `/link` / `/unlink` — resume or stop mirroring dashboard replies here; a
+  conversation is its own mirror by default, so `/link` only withdraws an
+  earlier `/unlink`
 - `/stop` (or `/cancel`) — stop the current reply and clear the queue
 - `/steer <msg>` — while a reply is generating, fold this message into it
   (overrides `queue_mode` for this message)

--- a/src/kiro_crew/messaging/link.py
+++ b/src/kiro_crew/messaging/link.py
@@ -442,6 +442,107 @@ def release_conversation_location(
     return "This conversation wasn't linked.", swept
 
 
+def _is_unrouted_slack_placeholder(link: ChannelLink) -> bool:
+    """True for a Slack link that names no thread, i.e. one nobody chose.
+
+    ``set_channel`` writes the conversation's namespaced bucket
+    (``discord:<id>``) into the legacy ``slack_channel_id`` field, and
+    :meth:`SessionMap.get_mirror_link` synthesizes a Slack ``ChannelLink`` from
+    that field whenever no explicit ``mirror`` row exists — so the first turn of
+    a new channel session reads back a Slack link it never asked for.
+
+    A threadless Slack row is not a routable mirror: an empty ``thread_ts`` is
+    Slack's own clear sentinel and never enters ``_thread_to_session``, so
+    nothing can be delivered through it. A real Slack mirror always names its
+    thread, which is why the thread — not the channel type — is what separates
+    bookkeeping from a binding.
+    """
+    return link.channel_type == SLACK_NAMESPACE and not link.thread_id
+
+
+def bind_origin_mirror(sessions: Any, *, key: str, location: ChannelLink) -> bool:
+    """Bind the conversation a session is being READ in as its own outbound mirror.
+
+    The in-channel counterpart of :func:`release_conversation_location`, shared by
+    the DM dispatchers and called from the inbound turn path. A channel
+    conversation IS its own mirror: the person reading the chat is the audience
+    for every turn of that session, including the turns they later take from the
+    dashboard. Slack has always stamped its own thread on every inbound turn and
+    ``SessionMap.get_mirror_link`` synthesizes a mirror from that binding, so a
+    dashboard turn on a Slack conversation has always reached Slack. A channel
+    that writes the binding only from its explicit link command reaches nobody:
+    ``_resolve_mirror_target`` finds no link for that channel and the chat sits
+    there looking dead while the conversation continues elsewhere.
+
+    Re-asserted on EVERY turn rather than only on a new session, because the
+    binding is what a restart-cold session, an unlink at this location by another
+    session, or a rival claim can take away — and only a self-healing bind cannot
+    leave a live conversation silently unmirrored. Those all REMOVE a binding;
+    none of them repoints one. So ANY binding already present is deliberate and is
+    left alone — whichever conversation and whichever CHANNEL it names. The
+    dashboard can point a session's mirror at any surface, so a channel
+    conversation whose owner aimed it elsewhere keeps that target; overwriting it
+    would silently redirect their replies into this chat. The one exception is the
+    unrouted Slack placeholder (:func:`_is_unrouted_slack_placeholder`) — the
+    first turn of a new channel session always reads one back, and it is
+    bookkeeping surfacing through the synthesis path rather than a choice.
+
+    Honours the persisted opt-out the in-channel unlink writes: without it, "off"
+    would last exactly until the user's next message, because an entry with no
+    binding is indistinguishable from one that was never linked. Declining is ALL
+    the opt-out does here — this never clears a binding it finds, so an explicit
+    dashboard link to a different target survives it.
+
+    *location* is the single definition of "this conversation", carrying whatever
+    thread/topic scoping the channel needs; the same value must be handed to
+    :func:`release_conversation_location`, which matches an occupied location by
+    VALUE, so a second spelling would let the release miss the binding this wrote.
+
+    Skipped entirely when *key* does not identify ONE conversation.
+    ``dm_scope="unified"`` collapses every allowed user's direct DMs into a single
+    ``unified:{agent}`` bucket — the channel and the user drop out of the key — so
+    "the origin conversation" has no single answer, and a mirror bound there would
+    deliver one user's dashboard replies into another user's chat. The test reads
+    the KEY rather than each channel's config, because the key is what the binding
+    hangs off: a config-derived check in each dispatcher could disagree with the
+    key actually in use, and one written per channel would have to be got right
+    again every time. A forum/thread route keeps its full bucket under any scope,
+    so it is unaffected, and the explicit in-channel link stays available — it
+    names the conversation the user is actually in.
+
+    Returns True iff a binding was written. Skipping is a no-op, and the steady
+    state is a READ: ``SessionMap`` rewrites the whole map per mutation on the
+    event loop, so a per-turn write would put that stall on the repeating path.
+
+    Never raises. This runs on the turn path, where an uncaught raise drops the
+    turn and answers the user nothing. ``ConversationOwnershipConflict`` is the
+    reachable one: a transport declaring
+    ``TransportCapabilities.supports_session_resume`` makes its conversations
+    inbound-committable, so an inbound-committed occupant refuses this claim. A
+    dispatcher that routes such a conversation to its occupant instead skips the
+    bind entirely — but its resolver fails CLOSED on duplicate inbound bindings
+    (ambiguous routing is denied), and that is precisely the state where the turn
+    path reaches this bind and the claim is refused. It is caught by type rather
+    than by name because ``session_map`` imports this module, so naming the
+    exception here would be an import cycle.
+    """
+    if channel_namespace_of(key) == DM_SCOPE_UNIFIED:
+        return False
+    if sessions.mirror_opt_out(key):
+        return False
+    existing = sessions.get_mirror_link(key)
+    if existing is not None and not _is_unrouted_slack_placeholder(existing):
+        return False
+    try:
+        sessions.set_mirror_link(key, location)
+    except Exception:
+        logger.debug(
+            "%s: origin mirror bind skipped for %s", location.channel_type, key, exc_info=True
+        )
+        return False
+    return True
+
+
 def seed_generation(
     sessions: Any,
     *,

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -40,8 +40,8 @@ from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn
 from kiro_crew.messaging.link import (
     CHAT_TYPE_DIRECT,
     CHAT_TYPE_FORUM,
-    DM_SCOPE_UNIFIED,
     ChannelLink,
+    bind_origin_mirror,
     build_dm_session_key,
     legacy_dashboard_mirror_key,
     release_conversation_location,
@@ -87,11 +87,6 @@ logger = logging.getLogger(__name__)
 # explicit override nor agent.default_agent is configured. Mirrors the Slack
 # path's _DEFAULT_KIROCREW_AGENT.
 _DEFAULT_KIROCREW_AGENT = "kirocrew"
-
-# This dispatcher's surface, as it appears in a ``ChannelLink.channel_type`` and
-# in a session key's first segment. Named so the mirror checks compare against
-# one spelling rather than repeating the literal.
-_CHANNEL = "telegram"
 
 # Upper bound on how many queued messages collapse into a single combined turn.
 # A single human won't realistically burst past this mid-turn; anything beyond
@@ -392,9 +387,9 @@ class TelegramDispatcher:
             # later takes from the dashboard is delivered back here. Slack gets
             # this from its own per-turn thread binding; Telegram had it only
             # behind an explicit /link. Called ON the loop, like every other
-            # session-map mutation: the map holds no lock, so the loop's own
-            # serialization is what keeps a read-modify-write from interleaving
-            # with a concurrent turn's.
+            # session-map mutation: `_MAP_LOCK` is what orders it against a
+            # concurrent mutation, and the write is bounded — one whole-map
+            # rewrite, on a conversation's first turn only.
             self._bind_origin_mirror(session_key, route, chat_id)
             # ── Attachment ingestion (mirrors Discord) ──
             if msg.attachments:
@@ -1360,88 +1355,26 @@ class TelegramDispatcher:
             thread_id=(str(topic) if topic is not None else None),
         )
 
-    def _origin_mirror_is_ambiguous(self, route: tuple[str, str]) -> bool:
-        """True when this route's session key does not identify a single chat.
-
-        ``dm_scope="unified"`` collapses every allowed user's direct DMs into one
-        ``unified:{agent}`` bucket — the channel and the user drop out of the key —
-        so a mirror bound on that session belongs to no particular chat, and the
-        one that happens to be bound receives every other user's dashboard
-        replies. A forum route keeps its full bucket under any scope.
-        """
-        slot, _comp = route
-        return (
-            self.cfg.messaging.dm_scope == DM_SCOPE_UNIFIED and slot == CHAT_TYPE_DIRECT
-        )
-
     def _bind_origin_mirror(
         self, session_key: str, route: tuple[str, str], chat_id: int
     ) -> None:
         """Mirror this conversation's dashboard tab back to Telegram, unasked.
 
-        Deliberately synchronous and called on the loop, like every other
-        session-map mutation in the codebase: :class:`SessionMap` holds no lock,
-        so the loop's own serialization is what keeps one read-modify-write from
-        interleaving with another's.
+        The rule, the re-assert and the opt-out live in
+        :func:`~kiro_crew.messaging.link.bind_origin_mirror`, shared with the
+        Discord dispatcher; this only supplies Telegram's spelling of "this
+        conversation".
 
-        A channel conversation IS its own mirror: the person reading the chat is
-        the audience for every turn of that session, including the turns they
-        later take from the dashboard. Slack has always bound its own thread on
-        every inbound turn, and ``get_mirror_link`` synthesizes a mirror from
-        that binding, so a dashboard turn on a Slack conversation has always
-        reached Slack. Telegram wrote the binding only from an explicit
-        ``/link``, so the same turn reached nobody: ``_resolve_mirror_target``
-        found no ``telegram`` link and the chat sat there looking dead while the
-        conversation continued elsewhere.
-
-        Skipped entirely when the session key does not identify ONE chat. Under
-        ``dm_scope="unified"`` a direct DM collapses to a ``unified:{agent}``
-        bucket with the channel and the user dropped out, so every allowed user's
-        DMs share one key and "the origin chat" has no single answer: binding it
-        would point that session's mirror at whichever chat bound it, and deliver
-        one user's dashboard replies into another user's chat. ``/link`` stays
-        available there — it names the chat the user is actually in. A forum route
-        keeps its full bucket under any scope, so it is unaffected.
-
-        Re-asserted on EVERY turn rather than only on a new session, because the
-        binding is what a restart-cold session, an unlink at this location by
-        another session, or a rival claim can take away — and only a self-healing
-        bind cannot leave a live conversation silently unmirrored. Those all
-        REMOVE a binding; none of them repoints one. So with the ambiguous scope
-        excluded above, an existing binding for this channel is always deliberate,
-        and this leaves it alone whether it names this chat or another one:
-        re-pointing a user's chosen target at the origin would undo an explicit
-        action with no signal. A binding for a DIFFERENT channel does not answer
-        the question this bind asks, so it does not block the write.
-
-        Honours the persisted opt-out ``/unlink`` writes: without it, "off" would
-        last exactly until the user's next message. Declining is ALL this does —
-        it never clears a binding it finds. ``/unlink`` persists the flag and the
-        release in one session-map write, so "opted out with a live binding" is
-        not a state the unlink path can leave behind; and every explicit bind
-        (``/link``, the dashboard's mirror-link endpoint) withdraws the flag.
+        Synchronous and called ON the loop, like every other session-map
+        mutation. Interleaving is ordered by ``session_map._MAP_LOCK``, not by the
+        loop; what keeps the call here is that the write is BOUNDED — one
+        whole-map rewrite, on a conversation's first turn only.
         """
-        if self._origin_mirror_is_ambiguous(route):
-            return
-        if self.sessions.mirror_opt_out(session_key):
-            return
-        existing = self.sessions.get_mirror_link(session_key)
-        if existing is not None and existing.channel_type == _CHANNEL:
-            return
-        desired = self._origin_mirror_link(route, chat_id)
-        try:
-            self.sessions.set_mirror_link(session_key, desired)
-        except Exception:
-            # Best-effort: this runs on the turn path, and an uncaught raise here
-            # drops the turn and answers the user nothing.
-            # ConversationOwnershipConflict is unreachable while Telegram
-            # declares no session resume (two outbound-only mirrors on one
-            # conversation are permitted by design), but declaring it later would
-            # make this bind the raise site — so it is caught rather than relying
-            # on that capability staying false.
-            logger.debug(
-                "Telegram: origin mirror bind skipped for %s", session_key, exc_info=True
-            )
+        bind_origin_mirror(
+            self.sessions,
+            key=session_key,
+            location=self._origin_mirror_link(route, chat_id),
+        )
 
     async def _handle_link(self, route: tuple[str, str], chat_id: int) -> None:
         """Re-enable mirroring of this conversation's dashboard tab back here.

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -60,6 +60,7 @@ from kiro_crew.messaging.attachments import cleanup
 from kiro_crew.messaging.link import ChannelLink, legacy_dashboard_mirror_key
 from kiro_crew.messaging.queue_receipt import receipt_text as _receipt_text
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.session import _opt_out_key
 from kiro_crew.session_map import ConversationOwnershipConflict
 
 _PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
@@ -211,19 +212,14 @@ class FakeSessions:
         self.mirror_links: dict[str, Any] = {}
         self.origin_links: dict[str, Any] = {}
         self.inbound_mirror_keys: set[str] = set()
+        self.mirror_opt_outs: set[str] = set()
         # Batch bookkeeping, mirroring the real SessionManager: the unlink path
         # wraps its three clears in one batch, and a double without the context
-        # manager would make that path unreachable from these tests.
+        # manager would make that path unreachable from these tests. Each entry is
+        # True when that mirror mutation ran inside a batch, so a test can pin
+        # that one user-visible action costs one whole-map write.
         self.batch_depth = 0
         self.batched_writes: list[bool] = []
-
-    @contextmanager
-    def batched_save(self) -> Any:
-        self.batch_depth += 1
-        try:
-            yield
-        finally:
-            self.batch_depth -= 1
 
     async def get_or_create(self, key: str, *, agent: Any = None, channel_id: Any = None) -> Any:
         self.last_agent = agent
@@ -276,11 +272,32 @@ class FakeSessions:
             raise ConversationOwnershipConflict(
                 f"{getattr(link, 'channel_type', '?')} conversation is already held"
             )
+        self.batched_writes.append(self.batch_depth > 0)
         self.mirror_links[key] = link
         if accepts_inbound:
             self.inbound_mirror_keys.add(key)
         else:
             self.inbound_mirror_keys.discard(key)
+
+    @contextmanager
+    def batched_save(self) -> Any:
+        self.batch_depth += 1
+        try:
+            yield
+        finally:
+            self.batch_depth -= 1
+
+    def set_mirror_opt_out(self, key: str, opted_out: bool) -> None:
+        # Bucket-keyed, like the real manager: the refusal is a preference about
+        # the CONVERSATION, so it must outlive a generation rotation.
+        self.batched_writes.append(self.batch_depth > 0)
+        if opted_out:
+            self.mirror_opt_outs.add(_opt_out_key(key))
+        else:
+            self.mirror_opt_outs.discard(_opt_out_key(key))
+
+    def mirror_opt_out(self, key: str) -> bool:
+        return _opt_out_key(key) in self.mirror_opt_outs
 
     def get_mirror_link(self, key: str) -> Any:
         return self.mirror_links.get(key)
@@ -301,6 +318,7 @@ class FakeSessions:
     def clear_mirror_link(self, key: str) -> bool:
         self.batched_writes.append(self.batch_depth > 0)
         self.inbound_mirror_keys.discard(key)
+        self.batched_writes.append(self.batch_depth > 0)
         return self.mirror_links.pop(key, None) is not None
 
     def clear_mirror_links_at(self, link: Any) -> list[str]:
@@ -353,12 +371,12 @@ class FakeCtx:
         return text, None
 
 
-def _cfg(soft: int = 80, default_agent: str = "") -> Any:
+def _cfg(soft: int = 80, default_agent: str = "", dm_scope: str = "per-channel-peer") -> Any:
     return SimpleNamespace(
         discord=SimpleNamespace(soft_threshold_pct=soft),
         agent=SimpleNamespace(default_agent=default_agent),
         messaging=SimpleNamespace(
-            dm_scope="per-channel-peer",
+            dm_scope=dm_scope,
             idle_reset_minutes=0,
             daily_reset_hour=-1,
             queue_mode="steer",
@@ -372,12 +390,13 @@ def _dispatcher(
     allowed_threads: set[str] | None = None,
     raise_on_get: bool = False,
     default_agent: str = "",
+    dm_scope: str = "per-channel-peer",
 ) -> tuple[DiscordDispatcher, FakeClient, FakeSessions]:
     sess = FakeSessions(raise_on_get=raise_on_get)
     d = DiscordDispatcher(
         sessions=sess,  # type: ignore[arg-type]
         ctx_builder=FakeCtx(),  # type: ignore[arg-type]
-        cfg=_cfg(default_agent=default_agent),
+        cfg=_cfg(default_agent=default_agent, dm_scope=dm_scope),
         allowed_user_ids=allowed,
         allowed_thread_ids=allowed_threads,
         agent=None,
@@ -1590,6 +1609,205 @@ class TestDispatcher:
         assert sess.mirror_links[key].channel_id == "c1"
         await d.handle_message(self._msg("!unlink"))
         assert key not in sess.mirror_links
+
+    # ── Automatic origin mirroring ────────────────────────────────────────
+    #
+    # A Discord conversation IS its own mirror. Without the per-turn bind the
+    # binding existed only after an explicit `!link`, so a turn later taken from
+    # the dashboard resolved no `discord` target and the chat sat there looking
+    # dead while the conversation continued elsewhere.
+
+    @pytest.mark.asyncio
+    async def test_a_turn_binds_this_conversation_as_its_own_mirror(self) -> None:
+        d, _cli, sess = _dispatcher({"u1"})
+        await d.handle_message(self._msg("hello"))
+        key = d._session_key("u1")
+        assert sess.mirror_links[key] == ChannelLink("discord", channel_id="c1", thread_id=None)
+
+    @pytest.mark.asyncio
+    async def test_a_thread_turn_binds_the_thread_channel(self) -> None:
+        # A Discord thread IS a channel with its own id, so channel_id already
+        # scopes the conversation and is also where the transport posts.
+        d, _cli, sess = _dispatcher({"u1"}, allowed_threads={"t9"})
+        await d.handle_message(
+            InboundMessage(
+                channel_type="discord",
+                user_id="u1",
+                conversation_id="t9",
+                text="hello",
+                thread_id="t9",
+            )
+        )
+        key = d._session_key("u1", "t9")
+        assert sess.mirror_links[key] == ChannelLink("discord", channel_id="t9", thread_id=None)
+
+    @pytest.mark.asyncio
+    async def test_the_second_turn_writes_nothing(self) -> None:
+        # The bind is re-asserted per turn, so the repeating path must be a READ:
+        # a session-map mutation rewrites the whole map on the event loop.
+        d, _cli, sess = _dispatcher({"u1"})
+        await d.handle_message(self._msg("first"))
+        writes = len(sess.batched_writes)
+        await d.handle_message(self._msg("second"))
+        assert len(sess.batched_writes) == writes
+
+    @pytest.mark.asyncio
+    async def test_unlink_survives_the_users_next_message(self) -> None:
+        # The whole point of persisting the refusal: an entry with no binding is
+        # indistinguishable from one that was never linked, so without the flag
+        # "off" would last exactly one message.
+        d, _cli, sess = _dispatcher({"u1"})
+        await d.handle_message(self._msg("hello"))
+        await d.handle_message(self._msg("!unlink"))
+        await d.handle_message(self._msg("hello again"))
+        assert sess.mirror_links == {}
+
+    @pytest.mark.asyncio
+    async def test_unlink_survives_a_generation_rotation(self) -> None:
+        # `!new` (and the configured idle/daily reset) rotate the :genN suffix.
+        # Keyed per generation the refusal would expire on rotation, so an idle
+        # reset would undo the user's `!unlink` with no action on their part.
+        d, _cli, sess = _dispatcher({"u1"})
+        await d.handle_message(self._msg("!unlink"))
+        await d.handle_message(self._msg("!new"))
+        await d.handle_message(self._msg("hello"))
+        assert sess.mirror_links == {}
+
+    @pytest.mark.asyncio
+    async def test_link_withdraws_the_refusal_so_the_bind_resumes(self) -> None:
+        d, _cli, sess = _dispatcher({"u1"})
+        await d.handle_message(self._msg("!unlink"))
+        await d.handle_message(self._msg("!link"))
+        assert sess.mirror_opt_outs == set()
+        sess.mirror_links.clear()  # simulate a sweep / restart-cold binding
+        await d.handle_message(self._msg("hello"))
+        assert sess.mirror_links[d._session_key("u1")].channel_id == "c1"
+
+    @pytest.mark.asyncio
+    async def test_link_and_unlink_each_cost_one_batched_write(self) -> None:
+        # One user-visible action, one whole-map write — each mutation would
+        # otherwise rewrite the entire session map on the loop.
+        d, _cli, sess = _dispatcher({"u1"})
+        await d.handle_message(self._msg("!link"))
+        assert sess.batched_writes and all(sess.batched_writes)
+        sess.batched_writes.clear()
+        await d.handle_message(self._msg("!unlink"))
+        assert sess.batched_writes and all(sess.batched_writes)
+
+    @pytest.mark.asyncio
+    async def test_a_refused_link_persists_nothing(self) -> None:
+        """Ordering guard inside the batch.
+
+        ``batched_save`` writes on the way out even when the block raises, so a
+        refusal raised AFTER the opt-out withdrawal would persist that withdrawal
+        for a link that never happened — silently turning mirroring back on. The
+        claim is refused before it mutates anything, so it goes first.
+        """
+        d, cli, sess = _dispatcher({"u1"})
+        await d.handle_message(self._msg("!unlink"))
+        self._occupy_ambiguously(sess)
+        await d.handle_message(self._msg("!link"))
+        assert any("already linked here" in t for t, _ in cli.sent)
+        assert sess.mirror_opt_outs == {_opt_out_key(d._session_key("u1"))}, (
+            "a refused link must not withdraw the refusal"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_refused_bind_still_answers_the_turn(self) -> None:
+        # An uncaught raise on the turn path would drop the turn and answer the
+        # user nothing.
+        d, cli, sess = _dispatcher({"u1"})
+        self._occupy_ambiguously(sess)
+        await d.handle_message(self._msg("hello world"))
+        assert "Answer: hello world" in (cli.final_text() or "")
+        assert d._session_key("u1") not in sess.mirror_links
+
+    @pytest.mark.asyncio
+    async def test_a_unified_dm_scope_is_not_auto_bound(self) -> None:
+        # dm_scope=unified collapses every allowed user's DMs into one
+        # unified:{agent} bucket — channel and user drop out of the key — so an
+        # automatic bind would deliver one user's dashboard replies into another
+        # user's chat. `!link` stays available: it names the channel the user is in.
+        d, _cli, sess = _dispatcher({"u1", "u2"}, dm_scope="unified")
+        await d.handle_message(self._msg("hello", user="u1"))
+        assert sess.mirror_links == {}
+
+    @pytest.mark.asyncio
+    async def test_a_thread_route_is_still_bound_under_a_unified_scope(self) -> None:
+        # A guild thread keys per-channel-peer regardless of dm_scope, so its
+        # bucket still names one conversation.
+        d, _cli, sess = _dispatcher({"u1"}, allowed_threads={"t9"}, dm_scope="unified")
+        await d.handle_message(
+            InboundMessage(
+                channel_type="discord",
+                user_id="u1",
+                conversation_id="t9",
+                text="hello",
+                thread_id="t9",
+            )
+        )
+        assert sess.mirror_links[d._session_key("u1", "t9")].channel_id == "t9"
+
+    @pytest.mark.asyncio
+    async def test_a_dashboard_mirror_aimed_at_another_channel_survives(self) -> None:
+        # The dashboard can aim this session's mirror at any surface. Overwriting
+        # it on the next Discord message would silently redirect the owner's
+        # replies from the chat they chose into this one.
+        d, _cli, sess = _dispatcher({"u1"})
+        key = d._session_key("u1")
+        chosen = ChannelLink("telegram", channel_id="7", thread_id=None)
+        sess.mirror_links[key] = chosen
+        await d.handle_message(self._msg("hello"))
+        assert sess.mirror_links == {key: chosen}
+
+    @pytest.mark.asyncio
+    async def test_a_resumed_session_is_not_bound_to_this_conversation(self) -> None:
+        """A resumed dashboard session's own surface owns its output.
+
+        Both writes live behind the ``resumed_key is None`` branch, which is what
+        keeps a dashboard entry from being stamped with Discord's identity;
+        ``set_origin_link`` is the observable half, since the mirror bind would
+        decline anyway on finding the resume binding for this same channel.
+        `!link` refuses in this state too, so the automatic path must not do what
+        the explicit one declines.
+        """
+        d, cli, sess = _dispatcher({"u1"})
+        resumed = ChannelLink("discord", channel_id="c1")
+        sess.mirror_links["dashboard:chat-1"] = resumed
+        sess.inbound_mirror_keys.add("dashboard:chat-1")
+        await d.handle_message(self._msg("hello world"))
+        assert "Answer: hello world" in (cli.final_text() or "")
+        assert sess.mirror_links == {"dashboard:chat-1": resumed}
+        assert sess.inbound_mirror_keys == {"dashboard:chat-1"}, "resume stayed two-way"
+        assert sess.origin_links == {}
+
+    @staticmethod
+    def _occupy_ambiguously(sess: FakeSessions) -> None:
+        """Occupy channel ``c1`` in the one state that reaches a refused claim.
+
+        Discord declares ``supports_session_resume``, so its conversations are
+        inbound-committable and an inbound-committed occupant refuses a claim. A
+        single such occupant never gets that far — the dispatcher routes the turn
+        to it and skips the bind, and `!link` refuses earlier. But
+        ``resumed_session`` fails CLOSED on duplicates: with two inbound bindings
+        it denies routing and reports none, so both paths proceed to a claim that
+        is then refused.
+        """
+        for key in ("dashboard:chat-9", "dashboard:chat-10"):
+            sess.mirror_links[key] = ChannelLink("discord", channel_id="c1")
+            sess.inbound_mirror_keys.add(key)
+
+    @pytest.mark.asyncio
+    async def test_an_explicit_bind_to_another_channel_is_not_repointed(self) -> None:
+        # Nothing repoints a binding: a swept or rival-claimed one is REMOVED, not
+        # moved. So a discord binding naming another channel is deliberate (the
+        # dashboard can bind a surfaced session anywhere).
+        d, _cli, sess = _dispatcher({"u1"})
+        key = d._session_key("u1")
+        chosen = ChannelLink("discord", channel_id="c-elsewhere")
+        sess.mirror_links[key] = chosen
+        await d.handle_message(self._msg("hello"))
+        assert sess.mirror_links == {key: chosen}
 
     @pytest.mark.asyncio
     async def test_unlink_clears_binding_stranded_by_generation_rotation(self) -> None:

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
 
@@ -10,6 +11,7 @@ from kiro_crew.discord.commands import parse_command, parse_command_argument
 from kiro_crew.discord.transport_dispatch import DiscordDispatcher
 from kiro_crew.messaging.link import ChannelLink
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.session import _opt_out_key
 from kiro_crew.session_map import ConversationOwnershipConflict
 
 
@@ -93,6 +95,7 @@ class _Sessions:
         self.mirror_links: dict[str, ChannelLink] = {}
         self.origin_links: dict[str, ChannelLink] = {}
         self.inbound_keys: set[str] = set()
+        self.mirror_opt_outs: set[str] = set()
         self.last_key = ""
         self.provider = _Provider()
 
@@ -125,6 +128,19 @@ class _Sessions:
 
     def set_origin_link(self, key: str, link: ChannelLink) -> None:
         self.origin_links[key] = link
+
+    @contextmanager
+    def batched_save(self) -> Any:
+        yield
+
+    def set_mirror_opt_out(self, key: str, opted_out: bool) -> None:
+        if opted_out:
+            self.mirror_opt_outs.add(_opt_out_key(key))
+        else:
+            self.mirror_opt_outs.discard(_opt_out_key(key))
+
+    def mirror_opt_out(self, key: str) -> bool:
+        return _opt_out_key(key) in self.mirror_opt_outs
 
     def get_origin_link(self, key: str) -> ChannelLink | None:
         return self.origin_links.get(key)

--- a/test/test_messaging_link.py
+++ b/test/test_messaging_link.py
@@ -1,8 +1,9 @@
-"""Tests for the two-level DM session-key builder in ``messaging.link``.
+"""Tests for the shared link helpers in ``messaging.link``.
 
-Covers the canonical channel-first shape, generation rotation, dmScope
-isolation vs unification, safe fallback on an unknown scope, and the reserved
-``group`` chat-type slot.
+Covers the two-level DM session-key builder — the canonical channel-first shape,
+generation rotation, dmScope isolation vs unification, safe fallback on an unknown
+scope, and the reserved ``group`` chat-type slot — plus the automatic origin-mirror
+bind the DM dispatchers share.
 """
 
 from __future__ import annotations
@@ -15,9 +16,12 @@ from kiro_crew.messaging.link import (
     DEFAULT_DM_SCOPE,
     DM_SCOPE_PER_CHANNEL_PEER,
     DM_SCOPE_UNIFIED,
+    ChannelLink,
+    bind_origin_mirror,
     build_dm_session_key,
     should_rotate_generation,
 )
+from kiro_crew.session_map import ConversationOwnershipConflict
 
 
 class TestBuildDmSessionKey:
@@ -133,3 +137,149 @@ class TestShouldRotateGeneration:
         last = _local_epoch(2026, 7, 9, 3, 0)
         now = _local_epoch(2026, 7, 10, 5, 0)
         assert should_rotate_generation(last, now, daily_reset_hour=-1) is False
+
+
+class _Sessions:
+    """The narrow session-manager surface :func:`bind_origin_mirror` touches."""
+
+    def __init__(self, *, raise_on_set: BaseException | None = None) -> None:
+        self.mirror_links: dict[str, ChannelLink] = {}
+        self.opt_outs: set[str] = set()
+        self.writes = 0
+        self._raise_on_set = raise_on_set
+
+    def mirror_opt_out(self, key: str) -> bool:
+        return key in self.opt_outs
+
+    def get_mirror_link(self, key: str) -> ChannelLink | None:
+        return self.mirror_links.get(key)
+
+    def set_mirror_link(self, key: str, link: ChannelLink) -> None:
+        if self._raise_on_set is not None:
+            raise self._raise_on_set
+        self.writes += 1
+        self.mirror_links[key] = link
+
+
+_HERE = ChannelLink("discord", channel_id="c1")
+
+
+class TestBindOriginMirror:
+    def test_an_unbound_conversation_is_bound_to_itself(self) -> None:
+        sess = _Sessions()
+        assert bind_origin_mirror(sess, key="discord:kirocrew:direct:u1", location=_HERE) is True
+        assert sess.mirror_links == {"discord:kirocrew:direct:u1": _HERE}
+
+    def test_the_steady_state_is_a_read(self) -> None:
+        """The re-assert runs per turn, so the repeating path must not write.
+
+        A mutation rewrites the whole session map on the event loop; a per-turn
+        write would put that stall on every message.
+        """
+        sess = _Sessions()
+        for _ in range(5):
+            bind_origin_mirror(sess, key="k", location=_HERE)
+        assert sess.writes == 1
+
+    def test_an_explicit_bind_to_another_location_is_not_repointed(self) -> None:
+        """Nothing repoints a binding — a swept or rival-claimed one is REMOVED.
+
+        So a binding naming another conversation on this channel is deliberate
+        (the dashboard can bind a surfaced session anywhere), and re-pointing it
+        at the origin would undo an explicit action with no signal.
+        """
+        sess = _Sessions()
+        chosen = ChannelLink("discord", channel_id="c-elsewhere")
+        sess.mirror_links["k"] = chosen
+        assert bind_origin_mirror(sess, key="k", location=_HERE) is False
+        assert sess.mirror_links["k"] == chosen
+
+    def test_an_explicit_bind_on_ANOTHER_CHANNEL_is_preserved(self) -> None:
+        """The dashboard can aim a session's mirror at any surface.
+
+        A Discord conversation whose owner pointed its dashboard mirror at a
+        Telegram chat must keep that target: overwriting it on the next Discord
+        message would silently redirect their replies into this chat.
+        """
+        sess = _Sessions()
+        chosen = ChannelLink("telegram", channel_id="7", thread_id=None)
+        sess.mirror_links["k"] = chosen
+        assert bind_origin_mirror(sess, key="k", location=_HERE) is False
+        assert sess.mirror_links["k"] == chosen
+
+    def test_a_real_slack_mirror_is_preserved(self) -> None:
+        """The exception is the missing THREAD, not the channel type.
+
+        A Slack mirror that names its thread is routable and deliberate.
+        """
+        sess = _Sessions()
+        chosen = ChannelLink("slack", channel_id="C123", thread_id="1785370133.085469")
+        sess.mirror_links["k"] = chosen
+        assert bind_origin_mirror(sess, key="k", location=_HERE) is False
+        assert sess.mirror_links["k"] == chosen
+
+    def test_the_unrouted_slack_placeholder_does_not_block_the_bind(self) -> None:
+        """``set_channel`` writes the namespaced bucket into ``slack_channel_id``.
+
+        ``get_mirror_link`` synthesizes a Slack link from that field whenever no
+        explicit mirror row exists, so the first turn of every new channel session
+        reads one back. An empty thread is Slack's own clear sentinel and never
+        enters the reverse index, so nothing can be delivered through it — it is
+        bookkeeping, not a binding.
+        """
+        sess = _Sessions()
+        sess.mirror_links["k"] = ChannelLink("slack", channel_id="discord:c1")
+        assert bind_origin_mirror(sess, key="k", location=_HERE) is True
+        assert sess.mirror_links["k"] == _HERE
+
+    def test_a_unified_bucket_is_never_bound(self) -> None:
+        """``dm_scope="unified"`` collapses every user's DMs into one bucket.
+
+        The channel and the user drop out of the key, so "the origin conversation"
+        has no single answer and a binding there would deliver one user's
+        dashboard replies into another user's chat.
+        """
+        sess = _Sessions()
+        assert bind_origin_mirror(sess, key="unified:kirocrew", location=_HERE) is False
+        assert bind_origin_mirror(sess, key="unified:kirocrew:gen4", location=_HERE) is False
+        assert sess.mirror_links == {}
+
+    def test_a_per_channel_bucket_under_the_same_config_is_bound(self) -> None:
+        """The guard is read off the KEY, so only the collapsed shape is excluded.
+
+        A forum/thread route keeps its full bucket under any scope.
+        """
+        sess = _Sessions()
+        assert (
+            bind_origin_mirror(sess, key="discord:kirocrew:group:t9", location=_HERE) is True
+        )
+
+    def test_an_opted_out_conversation_is_not_bound(self) -> None:
+        sess = _Sessions()
+        sess.opt_outs.add("k")
+        assert bind_origin_mirror(sess, key="k", location=_HERE) is False
+        assert sess.mirror_links == {}
+
+    def test_the_opt_out_never_clears_a_binding_it_finds(self) -> None:
+        """Declining is ALL it does: an explicit dashboard link must survive."""
+        sess = _Sessions()
+        sess.opt_outs.add("k")
+        chosen = ChannelLink("discord", channel_id="c-elsewhere")
+        sess.mirror_links["k"] = chosen
+        assert bind_origin_mirror(sess, key="k", location=_HERE) is False
+        assert sess.mirror_links["k"] == chosen
+
+    def test_a_refused_claim_does_not_drop_the_turn(self) -> None:
+        """This runs on the turn path: an uncaught raise answers the user nothing.
+
+        Reachable for a transport declaring ``supports_session_resume`` — a
+        dashboard session resumed into this conversation holds the location while
+        the transport's in-memory resume registry is cold after a restart.
+        """
+        sess = _Sessions(raise_on_set=ConversationOwnershipConflict("held"))
+        assert bind_origin_mirror(sess, key="k", location=_HERE) is False
+        assert sess.mirror_links == {}
+
+    def test_no_exception_from_the_claim_escapes(self) -> None:
+        sess = _Sessions(raise_on_set=RuntimeError("session map on fire"))
+        assert bind_origin_mirror(sess, key="k", location=_HERE) is False

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -3188,10 +3188,13 @@ class TestAutomaticOriginMirror:
         assert sess.successes == ["telegram:kirocrew:direct:7"]
 
     def test_the_binding_write_stays_on_the_loop_thread(self) -> None:
-        # SessionMap holds no lock, so the loop's own serialization is what keeps
-        # one read-modify-write from interleaving with another's. Offloading the
-        # write to a worker thread would remove that and let a late os.replace
-        # drop a persisted binding.
+        # The write is BOUNDED — one whole-map rewrite, on a conversation's first
+        # turn only — so the loop pays it inline rather than paying a thread hop.
+        # Interleaving is not the reason: `session_map._MAP_LOCK` orders every
+        # guarded mutation, `os.replace` included, so a worker could not drop a
+        # persisted binding. Offloading would therefore be safe but pointless
+        # here, and it would put an await between this bind and the turn it
+        # belongs to. Pinned so the placement is a decision, not an accident.
         d, _cli, sess = _dispatcher({7})
         wrote_on: list[int] = []
         original = sess.set_mirror_link


### PR DESCRIPTION
## 1. What is the problem?

A Discord-origin session had no `mirror` binding unless the user typed `!link`. `discord/transport_dispatch.py` wrote that binding only from its explicit link handler; the inbound turn path recorded `set_origin_link` (for the auto-compact notice) but never `set_mirror_link`. So when a turn on that conversation was later taken from the dashboard, `dashboard/chat_runner._resolve_mirror_target` found no `discord` link, resolved no outbound target, and the reply went to the dashboard only.

Slack does not have the gap: its inbound path stamps its own thread on every turn and `SessionMap.get_mirror_link` synthesizes a mirror from that binding. Telegram was fixed the same way. Discord was the last channel still behaving the other way.

## 2. Why this issue matters to the user

The Discord chat stops updating while the conversation is still alive on the other surface — it looks dead, with no signal that a reply happened. Someone who learns that continuing a Slack or Telegram conversation from the dashboard "just works" reasonably expects the same of Discord.

It also matters structurally: the invariant is channel-generic — a channel conversation IS its own mirror — but the implementation was not.

## 3. How our fix solves it

**Symptom** — a dashboard turn on a Discord conversation reaches nobody.
**Cause** — nothing on the inbound turn path binds the conversation as the session's outbound mirror.
**Fix** — bind it there, and put the rule in one place both dispatchers call.

`messaging/link.bind_origin_mirror(sessions, key=…, location=…)` now holds the whole rule, and Telegram's copy was **moved** into it rather than duplicated — with one deliberate semantic change to Telegram's cross-channel case, called out below:

- **Re-asserted on every turn**, not only on a new session. A restart-cold session, an unlink at this location by another session, or a rival claim can all take the binding away; only a self-healing bind cannot leave a live conversation silently unmirrored.
- **The steady state is a read.** The write is skipped when a binding for this channel already exists, so the repeating path costs no session-map save (a mutation rewrites the whole map on the event loop).
- **Any existing binding is left alone**, whichever conversation *and whichever channel* it names. Nothing repoints a binding — the paths above *remove* one — so a divergent binding is a deliberate dashboard link, and re-pointing it at the origin would undo an explicit action with no signal. The single exception is the unrouted Slack placeholder below, which every new channel session reads back on its first turn.
- **This changes Telegram's behaviour, deliberately, and it is why the extraction is not a pure move.** Telegram's pre-extraction rule blocked only on a binding for its *own* channel (`existing.channel_type == _CHANNEL`), so a Telegram conversation whose mirror had been dashboard-aimed at another surface was repointed back on its next message. The shared helper blocks on any non-placeholder binding, so that target now survives — which is what the GPT gate's blocking finding on `e81eccb3b` required, and `test_an_explicit_bind_on_ANOTHER_CHANNEL_is_preserved` pins it. Everything else about Telegram's path is unchanged.
- **`!unlink` persists a refusal, `!link` withdraws it.** Without persistence, "off" would last exactly until the user's next message, because an entry with no binding is indistinguishable from one that was never linked. The refusal only ever *declines*; it never clears a binding it finds.
- **The claim cannot drop a turn.** Discord declares `supports_session_resume`, so its conversations are inbound-committable and `ConversationOwnershipConflict` is genuinely reachable — the resume resolver fails closed on duplicate inbound bindings, which is exactly the state where the turn path reaches the bind and the claim is refused. The helper catches it (by type, not by name: `session_map` imports `messaging.link`, so naming the exception there would be an import cycle).
- **One definition of "this conversation".** `_origin_mirror_link` is shared by the bind, `!link` and `!unlink`, because the release matches an occupied location by *value* — a second spelling would let it miss the binding the bind wrote. The channel authority is `location.channel_type`, so there is no second argument that could disagree with it.
- **A collapsed key is never bound.** `dm_scope="unified"` folds every allowed user's direct DMs into a single `unified:{agent}` bucket — channel and user drop out of the key — so "the origin conversation" has no single answer and a binding there would deliver one user's dashboard replies into another user's chat. The helper reads this off the **key**, not each channel's config: the key is what the binding hangs off, so a config-derived check per dispatcher could disagree with the key actually in use, and Discord's DMs collapse under that scope exactly as Telegram's do. This replaces Telegram's per-channel `_origin_mirror_is_ambiguous`, and #3021's own Telegram tests pass unchanged against the extracted version. A thread/forum route keeps its full bucket under any scope and is unaffected; the explicit in-channel link stays available, since it names the conversation the user is in.

Two Discord-specific details:

- The bind sits inside the existing `resumed_key is None` branch, next to `set_origin_link`: a resumed dashboard session's own surface owns its output, and `!link` refuses in that state too.
- `!link`'s claim is ordered **first** inside its `batched_save` block. `batched_save` writes on the way out even when the block raises, so a refusal raised after the opt-out withdrawal would persist that withdrawal for a link that never happened — silently turning mirroring back on. `set_mirror_link` refuses before it mutates anything, so ordering it first leaves the batch clean.

While correcting the reachability rationale I also fixed a pre-existing comment on `_handle_link`'s refusal path: it claimed the catch covers "an outbound-only dashboard mirror", which cannot refuse an outbound-only claim. The real reachable state is the fail-closed duplicate-inbound one, and that is now what the comment and the test say.

Docs for both channels said mirroring was something `!link` / `/link` turned on; they now say it is on by default and describe what the commands actually do.

## 4. What tests we did

- **11 unit tests** for the shared helper (`test_messaging_link.py`): binds an unbound conversation, steady state writes once across five turns, an explicit bind elsewhere is not repointed, another channel's binding does not block, the channel authority is the location, a `unified:` bucket is never bound while a per-channel bucket under the same config is, opt-out declines, opt-out never clears, a refused claim and any other exception do not escape.
- **12 dispatcher tests** for Discord (`test_discord.py`): a turn binds the conversation, a thread turn binds the thread channel, the second turn writes nothing, `!unlink` survives the next message and a generation rotation, `!link` withdraws the refusal, `!link`/`!unlink` each cost one batched write, a refused link persists nothing, a refused bind still answers the turn, a resumed session is not bound (also closing a pre-existing gap: nothing pinned the `resumed_key is None` branch), a unified DM scope is not auto-bound, a thread route still is.
- **12/12 mutants caught** — including bind removed, bind moved out of the resumed guard, the `!link` batch reordered, either opt-out write dropped, the refusal keyed per generation instead of per bucket, the wrong channel id bound, the existing-binding guard removed, the opt-out ignored, the unified-scope guard removed, the exception guard removed, and the channel comparison hardcoded. The unified-scope mutant is caught by **#3021's own Telegram test** as well, which is the evidence that moving the rule into the helper preserved its behaviour.
- Local gates: `isort --check-only src/kiro_crew test`, `flake8 src/kiro_crew test`, `mypy src/kiro_crew/` (892 files) all clean; full backend suite run and its failure set diffed against the base commit (host-environment failures only, identical on both sides).

## 5. Any other suggestions on the work

- Telegram's `/link` has no `ConversationOwnershipConflict` guard. It is unreachable today (Telegram declares no session resume), so this PR does not add one, but the two handlers are now asymmetric in a way worth closing if Telegram ever gains resume.
- WeCom / WeChat / Teams / Webex dispatchers still have no origin mirror at all. With the helper extracted, each is a two-line call plus the opt-out pair in its own link handlers.

Targets `main`. #3021 has merged, so the corrected opt-out semantics this extraction carries are already on the base and the diff is this feature alone.

Fixes #3009
