### PR TITLE
refactor(prepare-pr): separate setup from validation gates

### DIFF
--- a/docs/ci/prepare-pr-portability.md
+++ b/docs/ci/prepare-pr-portability.md
@@ -13,7 +13,7 @@ The `prepare-pr` skill is one of the most valuable pieces of Kiro Crew's own dev
 
 But the skill reads today as specific to **Kiro Crew**. Its prose bakes in one project's conventions, so an agent running it in any other repo would follow instructions that don't apply. We want two things at once, and they appear to be in tension:
 
-1. Keep the skill **built-in** and keep it **standardizing Kiro Crew development** (the tuned gates, review bots, labels, and single-commit rule that make our PRs consistent).
+1. Keep the skill **built-in** and keep it **standardizing Kiro Crew development** (the tuned setup, gates, review bots, labels, and single-commit rule that make our PRs consistent).
 2. Make the skill **useful in any `gh`-based repo**, so other projects benefit from the same commit→green loop.
 
 This doc shows the tension is only in the *prose*, not the mechanism, and proposes a pluggable **project profile** layer that resolves both goals without forking the skill.
@@ -21,7 +21,7 @@ This doc shows the tension is only in the *prose*, not the mechanism, and propos
 ## 2. Why it matters
 
 - **Reuse.** The commit→sync→squash→open→poll→fix→converge loop is genuinely project-agnostic. Locking it to Kiro Crew wastes a good abstraction.
-- **Standardization stays intact.** A profile lets Kiro Crew keep its exact gates/reviewers/labels as *data*, so Kiro Crew devs get zero-config standardization while other repos get a working default.
+- **Standardization stays intact.** A profile lets Kiro Crew keep its exact setup/gates/reviewers/labels as *data*, so Kiro Crew devs get zero-config standardization while other repos get a working default.
 - **No parallel systems.** Evolving the one proven skill outward (a discovered profile layer) beats spawning a second `kirocrew-prepare-pr` skill that drifts from the generic one.
 
 ## 3. Current state — what is actually coupled
@@ -73,7 +73,7 @@ Everything project-specific is prose the agent reads, not code:
 
 The profile is the single home for everything that varies per repo. The review bots are just the most visible slice:
 
-1. **Local gates** — the test/lint/type commands the Phase-2 local gate runs (Kiro Crew: `pytest`, `isort`, `flake8`, `mypy`, `tsc -b`, `vitest`).
+1. **Local setup and gates** — ordered setup commands that provision prerequisites once per worktree without judging the diff, followed by pure test/lint/type gates on every Phase-2 iteration (Kiro Crew: Playwright browser setup, then `pytest`, `isort`, `flake8`, `mypy`, `tsc -b`, `vitest`).
 2. **Local reviewers** — a list of local review subagents, **one spawned per entry** (each pinned to a concrete `spawn_run` **model id**, with a `model_tier` fallback). A reviewer is either **contract-backed** (it mirrors a specific CI gate by reading that workflow's contract, e.g. `codex-review.yml`) or **standalone** (it reviews against an inline `rubric` with no CI counterpart). Reviewers do **not** have to bind to CI — a repo can add local-only reviewers (security, performance, a11y, house style) that no server gate mirrors, and a repo with no CI reviewers at all can still define reviewers by rubric. All reviewers inherit the shared `rule_files` (AUTOSDE / AGENTS.md).
 3. **Conventions** — single-commit rule (on/off), the readiness status context name + managed labels, an optional long-term-defer label, and the base branch override.
 
@@ -86,7 +86,7 @@ The profile is the single home for everything that varies per repo. The review b
 4. Generic fallback  →  scripts' built-in behavior                   (lowest precedence)
 ```
 
-Key nuance: **the `kirocrew` profile is NOT an unconditional global default.** It is auto-selected only when the skill detects it is in the Kiro Crew repo (see markers in §5.4). This prevents Kiro Crew's gates/labels from misfiring in an unrelated repo.
+Key nuance: **the `kirocrew` profile is NOT an unconditional global default.** It is auto-selected only when the skill detects it is in the Kiro Crew repo (see markers in §5.4). This prevents Kiro Crew's setup/gates/labels from misfiring in an unrelated repo.
 
 ### 5.3 Auto-detection rules (config-free path)
 
@@ -98,6 +98,7 @@ When there is no `.prepare-pr.toml`:
   - `Cargo.toml` → `cargo test` / `cargo clippy`
   - `go.mod` → `go test ./...` / `go vet`
   - `Makefile` with a `check`/`test` target → `make check`
+- **Setup:** auto-detection does not infer provisioning; it defaults to `[]` unless the profile declares it explicitly.
 - **Reviewers:** glob `.github/workflows/*review*.yml` and create one contract-backed reviewer per gate found. A repo may also declare standalone `rubric` reviewers with no CI counterpart. If neither exists, skip local review and rely on the server poll (the scripts still gate via exit codes).
 - **Conventions:** default to single-commit *off* unless a marker says otherwise; base branch from `preflight.py`'s existing detection; readiness context via the `pr_status.py` fallback (full rollup) unless a profile names one.
 
@@ -114,8 +115,14 @@ A minimal, stdlib-parseable (Python 3.11 `tomllib`) file. All keys optional; any
 base_branch = "main"          # optional; else preflight.py auto-detects
 single_commit = true          # enforce one-commit-per-PR squash
 
+[setup]
+# ordered prerequisite commands; run once per worktree, not a diff verdict
+commands = [
+  "(cd website && npx playwright install chromium)",
+]
+
 [gates]
-# ordered list of shell commands; all must exit 0 before a push
+# ordered pure checks; all must exit 0 before a push
 commands = [
   "python -m pytest -q",
   "isort --check-only src test",
@@ -175,7 +182,7 @@ The bundled `profiles/kirocrew.json` encodes exactly this Kiro Crew configuratio
 
 ### 5.6 Script changes
 
-- **`resolve_profile.py`** (NEW): implements the §5.2 resolution order and emits the resolved profile as JSON (`{source, base_branch, single_commit, gates[], rule_files[], reviewers[], readiness{}}`). Stdlib only, Python 3.9+; parses an external `.prepare-pr.toml` via `tomllib` (3.11+) or `tomli`, and errors loudly (exit 2) rather than silently ignoring a config it cannot parse. The bundled Kiro Crew profile ships as `profiles/kirocrew.json` (stdlib `json`, so the marker path needs no TOML parser and works on the 3.10 CI leg).
+- **`resolve_profile.py`** (NEW): implements the §5.2 resolution order and emits the resolved profile as JSON (`{source, base_branch, single_commit, setup[], gates[], rule_files[], reviewers[], readiness{}}`). Stdlib only, Python 3.9+; parses an external `.prepare-pr.toml` via `tomllib` (3.11+) or `tomli`, and errors loudly (exit 2) rather than silently ignoring a config it cannot parse. The bundled Kiro Crew profile ships as `profiles/kirocrew.json` (stdlib `json`, so the marker path needs no TOML parser and works on the 3.10 CI leg). Missing `setup` is normalized to `[]` for backward compatibility.
 - **`pr_status.py`:** accepts an optional readiness-context name (`--readiness-context` / `PREPARE_PR_READINESS_CONTEXT`) so a profile can name a non-default aggregate status; **keeps today's fallback** to the full rollup when unset or absent.
 - All other scripts: unchanged.
 
@@ -186,6 +193,7 @@ The bundled `profiles/kirocrew.json` encodes exactly this Kiro Crew configuratio
 | `.prepare-pr.toml` present | Use it verbatim. |
 | Kiro Crew markers present | Load bundled `kirocrew` profile. |
 | Other repo, detectable stack | Auto-detected gates + globbed reviewers. |
+| Profile omits `setup` | Normalize it to `[]`; existing profiles keep their previous behavior. |
 | No reviewers (no workflows to mirror, none declared) | Skip local review; rely on server poll (scripts still gate via exit codes). |
 | No readiness status | `pr_status.py` uses the full check rollup (existing behavior). |
 
@@ -201,7 +209,8 @@ flowchart TB
     FIXB --> PF
 
     RES --> SYNC["Phase 1 — Sync<br/>commit · rebase · squash to 1"]
-    SYNC --> GATE["Phase 2 — local gates<br/>run profile gate commands"]
+    SYNC --> SETUP["Phase 2 — ensure setup ran once<br/>skip after first successful pass"]
+    SETUP --> GATE["Phase 2 — local gates<br/>run pure profile checks"]
     GATE -->|"red"| FIXG["fix locally · amend"]
     FIXG --> GATE
     GATE -->|"green"| MIRROR["Phase 2 — local reviewers<br/>N model-pinned subagents<br/>contract-backed or standalone rubric"]
@@ -232,13 +241,13 @@ flowchart TB
     class PF pf;
     class RES prof;
     class SYNC,FIND sync;
-    class GATE,MIRROR gate;
+    class SETUP,GATE,MIRROR gate;
     class PUSH,POLL,WAIT push;
     class FIXB,FIXG,FIXR fix;
     class CONV,AM,DONE done;
 ```
 
-Everything outside the green nodes is identical across repos. Swapping the profile re-skins the gates, the reviewers, and the readiness signal without touching the loop.
+Everything outside the green nodes is identical across repos. Swapping the profile re-skins setup, gates, reviewers, and the readiness signal without touching the loop.
 
 ### 5.9 Diagram — how configuration (the profile) is injected
 
@@ -259,11 +268,11 @@ flowchart TB
     P3 --> PROF
     P4 --> PROF
 
-    PROF --> A1["gates.commands"]
+    PROF --> A1["setup.commands · gates.commands"]
     PROF --> A2["review.reviewers<br/>contract or rubric · rule_files · model ids"]
     PROF --> A3["single_commit · base_branch<br/>readiness.status_context · defer_label"]
 
-    A1 --> N1(["Phase 2 · local gates"])
+    A1 --> N1(["Phase 2 · setup once, then local gates"])
     A2 --> N2(["Phase 2 · review subagents"])
     A3 --> N3(["Phase 1 squash · Phase 3 poll · labels"])
 
@@ -280,7 +289,7 @@ flowchart TB
     class N1,N2,N3 node;
 ```
 
-The three axes (§5.1) map one-to-one onto the loop's green nodes. Anything a profile omits falls back down the resolution ladder (§5.7), so a repo with no config still runs the loop on auto-detected gates and the scripts' generic behavior.
+The three axes (§5.1) map one-to-one onto the loop's green nodes. Anything a profile omits falls back down the resolution ladder (§5.7), so a repo with no config still runs the loop with empty setup, auto-detected gates, and the scripts' generic behavior.
 
 ### 5.9 The reviewer-marker grammar (spec of record)
 
@@ -391,7 +400,7 @@ Built-in and portable are **not** in conflict:
 src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/
   SKILL.md                    # generic core loop + "Project profile" section
   profiles/
-    kirocrew.json             # bundled Kiro Crew profile (gates, reviewers, labels, single-commit)
+    kirocrew.json             # bundled Kiro Crew profile (setup, gates, reviewers, labels, single-commit)
   scripts/
     preflight.py
     resolve_profile.py        # NEW — resolves the profile to JSON
@@ -405,7 +414,8 @@ src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/
 
 ## 8. Migration & backward compatibility
 
-- Kiro Crew behavior is **unchanged**: the `kirocrew` profile reproduces today's exact gates/reviewers/labels, auto-selected by markers.
+- Kiro Crew validation behavior is **unchanged**: the `kirocrew` profile preserves the same setup/check commands, reviewers and labels, auto-selected by markers; it now distinguishes provisioning from verdict-producing gates.
+- Existing profiles remain compatible: an omitted `setup` section resolves to `setup = []`.
 - No `.prepare-pr.toml` is added to the Kiro Crew repo (the bundled profile covers it) — but one *may* be added later to make the config explicit/self-documenting.
 - The scripts remain backward-compatible; the readiness override is opt-in with the existing fallback intact.
 

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
@@ -148,7 +148,7 @@ blocker. Use a token with Checks read access.
 
 ## Project profile — everything repo-specific
 
-Gates, reviewers, and conventions come from a resolved profile, not from this prose.
+Setup, gates, reviewers, and conventions come from a resolved profile, not from this prose.
 Resolve once per run and keep the JSON for Phases 1–3:
 
 ```bash
@@ -157,9 +157,10 @@ python3 $SKILL_DIR/scripts/resolve_profile.py > /tmp/pp-profile.json
 
 Most-specific-wins: repo-root `.prepare-pr.toml` → Kiro Crew markers (auto-loads
 `profiles/kirocrew.json`) → stack auto-detect → generic fallback. The JSON always
-has `gates[]`, `reviewers[]` (each `{name, model, model_tier, contract, rubric}`),
-`rule_files[]`, `single_commit`, `base_branch`, and
-`readiness{status_context, defer_label}`.
+has `setup[]`, `gates[]`, `reviewers[]` (each
+`{name, model, model_tier, contract, rubric}`), `rule_files[]`, `single_commit`,
+`base_branch`, and `readiness{status_context, defer_label}`. A legacy profile with
+no `setup` resolves it to `[]`.
 
 **Every profile input is read from the base ref, not the checkout** — otherwise a
 branch could drop the lane that reviews it. A ref resolving to nothing is a hard
@@ -167,7 +168,7 @@ error (exit 2), never a silent fall back. Consequence: an **uncommitted
 `.prepare-pr.toml` edit is ignored**; commit it on the base branch or pass an
 explicit `base_ref`.
 
-- **In Kiro Crew:** the bundled profile — Rule-2 gates, `gpt` pinned to `gpt-5.6-sol` mirroring `codex-review.yml`, `opus` pinned to `claude-opus-4.8` mirroring `claude-review.yml`, `single_commit = true`, readiness context `PR Readiness`.
+- **In Kiro Crew:** the bundled profile — Playwright browser setup, Rule-2 gates, `gpt` pinned to `gpt-5.6-sol` mirroring `codex-review.yml`, `opus` pinned to `claude-opus-4.8` mirroring `claude-review.yml`, `single_commit = true`, readiness context `PR Readiness`.
 - **Elsewhere:** auto-detected gates + reviewers, or whatever `.prepare-pr.toml` declares. Pass a non-default readiness name via `--readiness-context` or `PREPARE_PR_READINESS_CONTEXT`; with none, `pr_status.py` uses the full rollup.
 
 **`single_commit` governs history handling in one place.** When `true`, run the
@@ -226,14 +227,24 @@ Never push until this is locally green — no open Critical/High. Local-green is
 cost and latency optimization, not a guarantee; the Phase 3 server poll stays the
 backstop.
 
-1. **Run the profile's `gates[]`.** All must exit 0 before review. For Kiro Crew that is the diff-scoped test runner / isort / flake8 / mypy, plus `tsc -b` for frontend changes.
+1. **Run `setup[]` once, then `gates[]` on every pass.** On the first Phase 2 pass
+   in a worktree, run the profile's `setup[]` in order. Setup may add prerequisites
+   to a per-user cache; it is not a verdict on the diff. A setup failure means the
+   environment is not ready: fix or report that environment problem before
+   evaluating the branch. Do not rerun setup unless the worktree or tool-cache state
+   was invalidated. Then run the profile's `gates[]` on every pass. Gates are pure
+   checks; a nonzero exit means the diff is not ready. For Kiro Crew that is the
+   diff-scoped test runner / isort / flake8 / mypy, plus `tsc -b` for frontend
+   changes. All gates must exit 0 before review.
 
-   **The gate list is data.** Read it from `profiles/kirocrew.json` `gates[]`. If a
-   CI-blocking gate is missing, add it to the profile, not here —
+   **The setup and gate lists are data.** Read them from
+   `profiles/kirocrew.json` `setup[]` and `gates[]`: provisioning belongs in setup;
+   only checks belong in gates. If a CI prerequisite or blocking gate is missing,
+   add it to the appropriate profile list, not here —
    `test/test_prepare_pr_profiles.py` pins the floor to `ci.yml`. **Before you add,
-   change or remove a gate, read `references/gate-floor.md`**: every entry's shape
-   is load-bearing and not guessable from the command, and that file also records
-   which CI checks have no local entry point.
+   change or remove setup or a gate, read `references/gate-floor.md`**: every
+   entry's shape is load-bearing and not guessable from the command, and that file
+   also records which CI checks have no local entry point.
 
    `scripts/run_scoped_tests.py` prints one of three verdicts and **all three are
    normal**: `cross-surface: N file(s)`, `full suite: the diff touches this

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
@@ -2,6 +2,9 @@
   "name": "kirocrew",
   "base_branch": "main",
   "single_commit": true,
+  "setup": [
+    "(cd website && npx playwright install chromium)"
+  ],
   "gates": [
     "python3 scripts/run_scoped_tests.py --test",
     "BASE=\"$(git merge-base HEAD origin/main)\" && SCOPED_TESTS_BASE_REF=\"$BASE\" python3 scripts/run_scoped_tests.py --surface backend",
@@ -36,7 +39,6 @@
     "BASE=\"$(git merge-base HEAD origin/main)\" && I18N_BASE_REF=\"$BASE\" npm --prefix website run i18n:check",
     "npm --prefix website run lint:phantom-classes -- --test",
     "BASE=\"$(git merge-base HEAD origin/main)\" && PHANTOM_BASE_REF=\"$BASE\" npm --prefix website run lint:phantom-classes",
-    "(cd website && npx playwright install chromium)",
     "BASE=\"$(git merge-base HEAD origin/main)\" && I18N_BASE_REF=\"$BASE\" npm --prefix website run i18n:render",
     "BASE=\"$(git merge-base HEAD origin/main)\" && I18N_BASE_REF=\"$BASE\" SCOPED_TESTS_BASE_REF=\"$BASE\" python3 scripts/run_scoped_tests.py --surface frontend",
     "npm --prefix website run jscpd",

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/references/gate-floor.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/references/gate-floor.md
@@ -1,13 +1,21 @@
 # Why the gate floor looks the way it does
 
-Maintainer-facing rationale for `profiles/kirocrew.json` `gates[]`. The loop does
+Maintainer-facing rationale for `profiles/kirocrew.json` `setup[]` and `gates[]`. The loop does
 not need to read this to run — `SKILL.md` Phase 2 carries the rules it executes.
-Read this when **adding, changing or removing a gate**, because every entry below
+Read this when **adding, changing or removing setup or a gate**, because every entry below
 is shaped by a failure that cost review rounds, and the shapes are not obvious.
 
-The three constraints every gate must satisfy at once:
+The two lists have different contracts:
 
-1. **No privilege.** A gate that needs root either blocks on a password prompt or
+- **`setup[]` provisions prerequisites once per worktree.** It may add to a
+  per-user, version-scoped tool cache. Failure means the environment is not
+  ready; it is not a verdict on the diff.
+- **`gates[]` contains pure checks run on every review iteration.** A gate must
+  not provision prerequisites. Failure means the diff is not ready.
+
+Every command in either list must still satisfy three constraints:
+
+1. **No privilege.** A command that needs root either blocks on a password prompt or
    changes the machine.
 2. **No replacing anything the developer relies on.** Adding to a per-user tool
    cache is fine — it is additive, idempotent and version-scoped, which is what
@@ -18,11 +26,9 @@ The three constraints every gate must satisfy at once:
 3. **CI's exact version.** A different version diverges from CI in *both*
    directions — newer reports findings CI will not, older misses findings CI will.
 
-Provisioning that satisfies all three may live in `gates[]`; provisioning that
-cannot (the Playwright **system libraries**, which need root) belongs to
-documented one-time setup instead. Splitting the floor into explicit `setup[]`
-and `gates[]` keys would make that boundary structural rather than conventional —
-worth doing, and tracked separately (#2599) rather than smuggled into a docs change.
+Provisioning that satisfies all three belongs in `setup[]`; checks belong in
+`gates[]`. Provisioning that cannot satisfy them (the Playwright **system
+libraries**, which need root) belongs to documented one-time host setup instead.
 
 ## Copy the whole CI step, not the half that looks like the check
 
@@ -30,7 +36,7 @@ A workflow step is often two commands: the detector's own self-test, then the
 scan. CI runs `check_brand_name.py --test` before the scan and `docs_lint.py
 --test` before `docs-lint.sh`. A PR that *changes a detector* fails the self-test
 while the scan stays clean, so a floor carrying only the scan passes locally and
-fails after push. Both self-tests sit ahead of their scans in the profile.
+fails after push. Both self-tests sit ahead of their scans in `gates[]`.
 
 ## Derive a ratchet; never transcribe it
 
@@ -70,12 +76,12 @@ when `sudo` is absent). A review gate would then either block on a password
 prompt or silently change the machine's system packages. CI can use it because CI
 *is* root in a disposable container; a workstation is neither.
 
-The floor therefore installs the **browser binary** only — no privilege required —
-and a genuinely missing system library surfaces at launch with Playwright's own
-message naming the exact `apt-get install` line. The **system libraries** are
-per-machine and privileged, so they belong to one-time setup: on a fresh Linux
-host run `sudo npx playwright install --with-deps chromium` once, alongside
-`npm ci`.
+The profile's `setup[]` therefore installs the **browser binary** only — no
+privilege required — and a genuinely missing system library surfaces at launch
+with Playwright's own message naming the exact `apt-get install` line. The
+**system libraries** are per-machine and privileged, so they belong to documented
+one-time host setup: on a fresh Linux host run
+`sudo npx playwright install --with-deps chromium` once, alongside `npm ci`.
 
 ## For a pinned external tool, run it ephemerally rather than installing it
 
@@ -125,7 +131,7 @@ before trusting a green from it.
 
 ## Scan by every shape a step can take
 
-`test/test_prepare_pr_profiles.py` holds the floor to `ci.yml` so that CI gaining
+`test/test_prepare_pr_profiles.py` holds both floor lists to `ci.yml` so that CI gaining
 a blocking scan fails a test rather than surfacing as a review round on a later
 PR. A check written as a bare binary (`cfn-lint`, `mypy`, `flake8`) is invisible to
 a `scripts/`-and-`npm run` scan, so the parity test also enumerates the **tool

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/resolve_profile.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/resolve_profile.py
@@ -2,8 +2,8 @@
 """resolve_profile.py - resolve the prepare-pr project profile for a repo.
 
 Emits the resolved profile as JSON on stdout so the prepare-pr skill can read
-gates / reviewers / conventions from DATA instead of hardcoding one project's
-conventions in prose.
+setup / gates / reviewers / conventions from DATA instead of hardcoding one
+project's conventions in prose.
 
 Resolution order (most-specific-wins):
   1. .prepare-pr.toml at the repo root   -> explicit config
@@ -19,6 +19,7 @@ Every resolved profile has the SAME shape:
     "source":        "config" | "kirocrew" | "auto-detect" | "generic",
     "base_branch":   str | null,
     "single_commit": bool,
+    "setup":         [str, ...],
     "gates":         [str, ...],
     "rule_files":    [str, ...],
     "reviewers":     [{"name","model","model_tier","contract","rubric"}, ...],
@@ -142,14 +143,19 @@ def load_toml_bytes(data, source):
 def normalize(raw, source):
     """Coerce a raw profile dict into the canonical shape with defaults.
 
-    Accepts both the JSON bundled-profile shape (top-level ``gates`` /
+    Accepts both the JSON bundled-profile shape (top-level ``setup`` / ``gates`` /
     ``reviewers`` / ``rule_files`` / ``readiness``) and the TOML
-    ``.prepare-pr.toml`` shape ([project], [gates].commands, [review] with
-    [[review.reviewers]], [readiness]).
+    ``.prepare-pr.toml`` shape ([project], [setup].commands, [gates].commands,
+    [review] with [[review.reviewers]], [readiness]).
     """
     proj = raw.get("project") if isinstance(raw.get("project"), dict) else {}
     base_branch = raw.get("base_branch", proj.get("base_branch"))
     single_commit = _as_bool(raw.get("single_commit", proj.get("single_commit", False)))
+
+    setup = raw.get("setup")
+    if isinstance(setup, dict):  # TOML [setup].commands
+        setup = setup.get("commands")
+    setup = list(setup or [])
 
     gates = raw.get("gates")
     if isinstance(gates, dict):  # TOML [gates].commands
@@ -186,6 +192,7 @@ def normalize(raw, source):
         "source": source,
         "base_branch": base_branch,
         "single_commit": single_commit,
+        "setup": setup,
         "gates": gates,
         "rule_files": rule_files,
         "reviewers": reviewers,

--- a/test/test_prepare_pr_profiles.py
+++ b/test/test_prepare_pr_profiles.py
@@ -55,6 +55,7 @@ def _toml_available():
 def test_generic_fallback_on_empty_repo(tmp_path):
     prof = resolve_profile.resolve(str(tmp_path))
     assert prof["source"] == "generic"
+    assert prof["setup"] == []
     assert prof["gates"] == []
     assert prof["reviewers"] == []
     assert prof["readiness"] == {"status_context": None, "defer_label": None}
@@ -156,6 +157,7 @@ def test_autodetect_python_stack(tmp_path):
     (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
     prof = resolve_profile.resolve(str(tmp_path))
     assert prof["source"] == "auto-detect"
+    assert prof["setup"] == []
     assert "python -m pytest -q" in prof["gates"]
 
 
@@ -195,6 +197,8 @@ def test_kirocrew_markers_load_bundled_profile(tmp_path):
     assert prof["source"] == "kirocrew"
     assert prof["single_commit"] is True
     assert prof["base_branch"] == "main"
+    assert prof["setup"] == ["(cd website && npx playwright install chromium)"]
+    assert all("playwright install" not in gate for gate in prof["gates"])
     assert prof["readiness"]["status_context"] == "PR Readiness"
     models = {r["name"]: r["model"] for r in prof["reviewers"]}
     assert models["gpt"] == "gpt-5.6-sol"
@@ -308,25 +312,25 @@ def _ci_workflow_run_text() -> str:
     )
 
 
-def test_every_floor_gate_names_a_real_target():
-    """A gate naming a script that does not exist fails for the wrong reason.
+def test_every_floor_command_names_a_real_target():
+    """A floor command naming a missing script fails for the wrong reason.
 
     The floor is data, so nothing type-checks it: a renamed script or npm
     script turns a gate into a command-not-found, which reads as a defect in
     the branch under review rather than as rot in the floor.
     """
     data = json.loads((PROFILES_DIR / "kirocrew.json").read_text(encoding="utf-8"))
-    gates = "\n".join(data["gates"])
+    commands = "\n".join(data["setup"] + data["gates"])
 
-    for rel in sorted(set(re.findall(r"\bscripts/[A-Za-z0-9_.-]+\.(?:py|sh)", gates))):
-        assert (REPO_ROOT / rel).is_file(), f"gate references missing script {rel}"
+    for rel in sorted(set(re.findall(r"\bscripts/[A-Za-z0-9_.-]+\.(?:py|sh)", commands))):
+        assert (REPO_ROOT / rel).is_file(), f"floor references missing script {rel}"
 
-    npm_scripts = set(re.findall(r"\bnpm(?: --prefix \S+)? run ([a-z0-9:-]+)", gates))
+    npm_scripts = set(re.findall(r"\bnpm(?: --prefix \S+)? run ([a-z0-9:-]+)", commands))
     declared = json.loads(
         (REPO_ROOT / "website" / "package.json").read_text(encoding="utf-8")
     )["scripts"]
     for name in sorted(npm_scripts):
-        assert name in declared, f"gate references undeclared npm script {name!r}"
+        assert name in declared, f"floor references undeclared npm script {name!r}"
 
 
 def test_ci_blocking_scans_are_covered_by_the_floor():
@@ -342,7 +346,10 @@ def test_ci_blocking_scans_are_covered_by_the_floor():
     """
     run_text = _ci_workflow_run_text()
     data = json.loads((PROFILES_DIR / "kirocrew.json").read_text(encoding="utf-8"))
-    gates = "\n".join(data["gates"])
+    # Only repeatable verdict-producing gates satisfy the CI floor. A command
+    # filed under setup runs once per worktree, so counting it here would let a
+    # future blocking CI check disappear from later prepare-pr passes.
+    floor = "\n".join(data["gates"])
 
     exempt_scripts = {
         # Chooses WHICH tests to run for the changed surface; not itself a gate.
@@ -364,17 +371,17 @@ def test_ci_blocking_scans_are_covered_by_the_floor():
     }
 
     invoked = set(re.findall(r"\bscripts/[A-Za-z0-9_.-]+\.(?:py|sh)", run_text))
-    missing = sorted(s for s in invoked - exempt_scripts if s not in gates)
+    missing = sorted(s for s in invoked - exempt_scripts if s not in floor)
     assert not missing, (
-        "ci.yml runs these scripts but the prepare-pr gate floor does not: "
+        "ci.yml runs these scripts but the prepare-pr floor does not: "
         f"{missing}. Add them to profiles/kirocrew.json gates[] in their "
         "CI-exact form, or exempt them here with a reason."
     )
 
     npm_invoked = set(re.findall(r"\bnpm run ([a-z0-9:-]+)", run_text))
-    npm_missing = sorted(n for n in npm_invoked if f"run {n}" not in gates)
+    npm_missing = sorted(n for n in npm_invoked if f"run {n}" not in floor)
     assert not npm_missing, (
-        f"ci.yml runs these npm scripts but the gate floor does not: {npm_missing}"
+        f"ci.yml runs these npm scripts but the floor does not: {npm_missing}"
     )
 
     # A blocking step can also be a bare binary -- `cfn-lint`, `mypy`, `flake8`
@@ -385,7 +392,7 @@ def test_ci_blocking_scans_are_covered_by_the_floor():
         # Environment setup, not gates.
         "pip": "installs the pinned lint tool",
         "uv": "resolves/installs dependencies",
-        "sudo": "privileged provisioning -- belongs in setup, never in a gate",
+        "sudo": "privileged provisioning -- belongs in manual host setup",
         # Wrappers whose payload is already covered by another assertion.
         "bash": "an interpreter prefix -- the payload is the .sh path, covered by "
                 "the script scan above",
@@ -407,10 +414,10 @@ def test_ci_blocking_scans_are_covered_by_the_floor():
     }
     tools = set(re.findall(r"(?m)^\s*run: ([a-z][a-z0-9_-]+) ", run_text))
     tool_missing = sorted(
-        t for t in tools - set(exempt_tools) if not re.search(rf"\b{re.escape(t)}\b", gates)
+        t for t in tools - set(exempt_tools) if not re.search(rf"\b{re.escape(t)}\b", floor)
     )
     assert not tool_missing, (
-        f"ci.yml runs these tools but the gate floor does not: {tool_missing}. "
+        f"ci.yml runs these tools but the floor does not: {tool_missing}. "
         "Add each to profiles/kirocrew.json gates[] in its CI-exact form, or "
         "add it to exempt_tools here with the reason it is not a local gate."
     )
@@ -630,6 +637,7 @@ def test_gate_rationale_reference_exists_and_is_pointed_at():
 def test_bundled_kirocrew_profile_is_valid_json():
     data = json.loads((PROFILES_DIR / "kirocrew.json").read_text())
     assert data["name"] == "kirocrew"
+    assert isinstance(data["setup"], list)
     # Every reviewer must carry a served model id (no bare gpt-5.6).
     for r in data["reviewers"]:
         assert r["model"] and r["model"] != "gpt-5.6"
@@ -641,6 +649,8 @@ def test_toml_config_path(tmp_path):
         "[project]\n"
         'base_branch = "trunk"\n'
         "single_commit = true\n\n"
+        "[setup]\n"
+        'commands = ["make bootstrap"]\n\n'
         "[gates]\n"
         'commands = ["make check"]\n\n'
         "[review]\n"
@@ -655,6 +665,7 @@ def test_toml_config_path(tmp_path):
         prof = resolve_profile.resolve(str(tmp_path))
         assert prof["source"] == "config"
         assert prof["base_branch"] == "trunk"
+        assert prof["setup"] == ["make bootstrap"]
         assert prof["gates"] == ["make check"]
         assert prof["rule_files"] == ["AGENTS.md"]
         assert prof["reviewers"][0]["model"] == "gpt-5.6-sol"
@@ -678,14 +689,21 @@ def test_partial_toml_config_fills_gates_from_autodetect(tmp_path):
     prof = resolve_profile.resolve(str(tmp_path))
     assert prof["source"] == "config"
     assert prof["base_branch"] == "trunk"
+    assert prof["setup"] == []
     assert "python -m pytest -q" in prof["gates"]  # filled from auto-detect
 
 
 def test_normalize_defaults_fill_missing_keys():
     prof = resolve_profile.normalize({}, "generic")
-    for key in ("source", "base_branch", "single_commit", "gates",
+    for key in ("source", "base_branch", "single_commit", "setup", "gates",
                 "rule_files", "reviewers", "readiness"):
         assert key in prof
+
+
+def test_legacy_profile_without_setup_stays_compatible():
+    prof = resolve_profile.normalize({"gates": ["make check"]}, "config")
+    assert prof["setup"] == []
+    assert prof["gates"] == ["make check"]
 
 
 def test_single_commit_string_false_is_not_truthy():


### PR DESCRIPTION
## Problem / Motivation

`prepare-pr` profiles mixed one-time environment provisioning with checks that produce a verdict. Setup failures therefore looked like defects in the branch, and every gate rerun repeated setup that had already succeeded.

## Why it matters

Environment readiness and branch correctness have different lifecycles. Separating them makes a failed setup diagnosable, keeps repeatable gates deterministic, and avoids downloading or installing the same prerequisite on every verification pass.

## What changed

- Added ordered `setup[]` commands alongside pure, repeatable `gates[]`.
- Moved Playwright Chromium provisioning from Kiro Crew's gate list into setup.
- Normalized profiles that omit setup to `setup: []` for backward compatibility.
- Covered bundled, TOML, auto-detected, generic, and legacy profile behavior.
- Updated the skill and portability/gate-floor documentation to distinguish environment readiness from diff readiness.
- Kept the CI blocking-command coverage floor intentionally gate-only: setup commands are rot-checked as real targets, but can never satisfy the requirement for a repeatable verdict gate.

The existing 38 validation gates retain their exact order and commands; the former Playwright provisioning command is now the single setup command.

## Tests

- `test_prepare_pr_profiles.py`: 40 passed, 1 skipped before and after the final rebase.
- Python 3.10 profile smoke: `setup=1`, `gates=38`; Playwright provisioning absent from gates.
- Regression review confirmed a future CI-blocking command placed only in `setup[]` still fails the gate-floor test.
- Docs lint self-test and 243-file scan.
- Black baseline, isort 6.0, flake8, mypy, `py_compile`, JSON validation.
- Resolver smoke, exact gate replay, harness parity, brand-name and subprocess-encoding gates.
- `git diff --check origin/main...HEAD`.

No flaky failure was rerun away.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** This changes CLI profile execution and documentation only; it has no rendered UI effect.

Closes #2599
