### PR TITLE
ci(fork-review): split the resolver's two causes and retry a failed query

### DIFF
--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -85,18 +85,65 @@ jobs:
           head_sha="$WR_HEAD_SHA"
           if [ -z "$head_sha" ]; then echo "::error::no workflow_run head_sha"; exit 1; fi
 
+          # Bounded retry for the read-only resolver queries below. A single-shot
+          # `gh api` aborts on a transient TLS / 5xx / rate-limit error, and this
+          # lane then reported that as "no such PR" -- the wrong cause, on a PR
+          # that exists. Mirrors the gh_retry convention pr-readiness.yml adopted
+          # for the same single-shot failure mode (#2753). stderr is deliberately
+          # NOT discarded any more, so a failing query says why.
+          gh_read() {
+            local attempt rc=1 out
+            for attempt in 1 2 3; do
+              if out="$("$@")"; then
+                printf '%s' "$out"
+                return 0
+              else
+                # Capture INSIDE the else: after `fi`, `$?` is the status of the
+                # whole if-statement, which is 0 when a false condition has no
+                # else branch -- that would report a failed query as success.
+                rc=$?
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "resolver query attempt $attempt failed; retrying" >&2
+                sleep $((attempt * 5))
+              fi
+            done
+            return "$rc"
+          }
+
           # Resolve the PR by matching the open PR whose head SHA equals the
           # trigger head_sha (workflow_run.pull_requests is empty for forks).
-          pr="$(gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
-            --jq "[.[] | select(.head.sha == \"$head_sha\")][0].number // empty" 2>/dev/null || true)"
+          #
+          # An empty result has TWO causes that need OPPOSITE reporting, and
+          # collapsing them into one message made this abort unfalsifiable: the
+          # same text and the same exit 1 were emitted whether the query FAILED
+          # or whether it SUCCEEDED and matched nothing, while `2>/dev/null`
+          # discarded the only evidence of which.
+          #   * query FAILED -> nothing is known about this head. Retried above;
+          #     if it still fails, say the QUERY failed and fail closed.
+          #   * query SUCCEEDED with no match -> the push was superseded, or its
+          #     PR closed, while CI was queued. There is nothing to review.
+          # Both still exit 1, so the fail-closed finalize step is unchanged and
+          # no verdict is withheld; what changes is that the log names the cause.
+          if ! pr="$(gh_read gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
+            --jq "[.[] | select(.head.sha == \"$head_sha\")][0].number // empty")"; then
+            echo "::error::could not query open PRs while resolving $head_sha - the query itself failed on all 3 attempts; see the errors above"
+            exit 1
+          fi
           if [ -z "$pr" ]; then
-            echo "::error::could not resolve an open PR whose head SHA is $head_sha"
+            echo "::error::no open PR has head $head_sha - superseded or closed while CI was queued; nothing to review"
             exit 1
           fi
 
           # Authoritative base SHA straight from the PR (NOT from the artifact).
-          base_sha="$(gh api "repos/$REPO/pulls/$pr" --jq '.base.sha' 2>/dev/null || true)"
-          if [ -z "$base_sha" ]; then echo "::error::could not read base.sha for PR #$pr"; exit 1; fi
+          if ! base_sha="$(gh_read gh api "repos/$REPO/pulls/$pr" --jq '.base.sha')"; then
+            echo "::error::could not read base.sha for PR #$pr - the query itself failed on all 3 attempts; see the errors above"
+            exit 1
+          fi
+          if [ -z "$base_sha" ] || [ "$base_sha" = "null" ]; then
+            echo "::error::PR #$pr reported an empty base.sha; failing closed"
+            exit 1
+          fi
 
           echo "pr=$pr" >> "$GITHUB_OUTPUT"
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -86,18 +86,65 @@ jobs:
           head_sha="$WR_HEAD_SHA"
           if [ -z "$head_sha" ]; then echo "::error::no workflow_run head_sha"; exit 1; fi
 
+          # Bounded retry for the read-only resolver queries below. A single-shot
+          # `gh api` aborts on a transient TLS / 5xx / rate-limit error, and this
+          # lane then reported that as "no such PR" -- the wrong cause, on a PR
+          # that exists. Mirrors the gh_retry convention pr-readiness.yml adopted
+          # for the same single-shot failure mode (#2753). stderr is deliberately
+          # NOT discarded any more, so a failing query says why.
+          gh_read() {
+            local attempt rc=1 out
+            for attempt in 1 2 3; do
+              if out="$("$@")"; then
+                printf '%s' "$out"
+                return 0
+              else
+                # Capture INSIDE the else: after `fi`, `$?` is the status of the
+                # whole if-statement, which is 0 when a false condition has no
+                # else branch -- that would report a failed query as success.
+                rc=$?
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "resolver query attempt $attempt failed; retrying" >&2
+                sleep $((attempt * 5))
+              fi
+            done
+            return "$rc"
+          }
+
           # Resolve the PR by matching the open PR whose head SHA equals the
           # trigger head_sha (workflow_run.pull_requests is empty for forks).
-          pr="$(gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
-            --jq "[.[] | select(.head.sha == \"$head_sha\")][0].number // empty" 2>/dev/null || true)"
+          #
+          # An empty result has TWO causes that need OPPOSITE reporting, and
+          # collapsing them into one message made this abort unfalsifiable: the
+          # same text and the same exit 1 were emitted whether the query FAILED
+          # or whether it SUCCEEDED and matched nothing, while `2>/dev/null`
+          # discarded the only evidence of which.
+          #   * query FAILED -> nothing is known about this head. Retried above;
+          #     if it still fails, say the QUERY failed and fail closed.
+          #   * query SUCCEEDED with no match -> the push was superseded, or its
+          #     PR closed, while CI was queued. There is nothing to review.
+          # Both still exit 1, so the fail-closed finalize step is unchanged and
+          # no verdict is withheld; what changes is that the log names the cause.
+          if ! pr="$(gh_read gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
+            --jq "[.[] | select(.head.sha == \"$head_sha\")][0].number // empty")"; then
+            echo "::error::could not query open PRs while resolving $head_sha - the query itself failed on all 3 attempts; see the errors above"
+            exit 1
+          fi
           if [ -z "$pr" ]; then
-            echo "::error::could not resolve an open PR whose head SHA is $head_sha"
+            echo "::error::no open PR has head $head_sha - superseded or closed while CI was queued; nothing to review"
             exit 1
           fi
 
           # Authoritative base SHA straight from the PR (NOT from the artifact).
-          base_sha="$(gh api "repos/$REPO/pulls/$pr" --jq '.base.sha' 2>/dev/null || true)"
-          if [ -z "$base_sha" ]; then echo "::error::could not read base.sha for PR #$pr"; exit 1; fi
+          if ! base_sha="$(gh_read gh api "repos/$REPO/pulls/$pr" --jq '.base.sha')"; then
+            echo "::error::could not read base.sha for PR #$pr - the query itself failed on all 3 attempts; see the errors above"
+            exit 1
+          fi
+          if [ -z "$base_sha" ] || [ "$base_sha" = "null" ]; then
+            echo "::error::PR #$pr reported an empty base.sha; failing closed"
+            exit 1
+          fi
 
           echo "pr=$pr" >> "$GITHUB_OUTPUT"
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -90,18 +90,65 @@ jobs:
           head_sha="$WR_HEAD_SHA"
           if [ -z "$head_sha" ]; then echo "::error::no workflow_run head_sha"; exit 1; fi
 
+          # Bounded retry for the read-only resolver queries below. A single-shot
+          # `gh api` aborts on a transient TLS / 5xx / rate-limit error, and this
+          # lane then reported that as "no such PR" -- the wrong cause, on a PR
+          # that exists. Mirrors the gh_retry convention pr-readiness.yml adopted
+          # for the same single-shot failure mode (#2753). stderr is deliberately
+          # NOT discarded any more, so a failing query says why.
+          gh_read() {
+            local attempt rc=1 out
+            for attempt in 1 2 3; do
+              if out="$("$@")"; then
+                printf '%s' "$out"
+                return 0
+              else
+                # Capture INSIDE the else: after `fi`, `$?` is the status of the
+                # whole if-statement, which is 0 when a false condition has no
+                # else branch -- that would report a failed query as success.
+                rc=$?
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "resolver query attempt $attempt failed; retrying" >&2
+                sleep $((attempt * 5))
+              fi
+            done
+            return "$rc"
+          }
+
           # Resolve the PR by matching the open PR whose head SHA equals the
           # trigger head_sha (workflow_run.pull_requests is empty for forks).
-          pr="$(gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
-            --jq "[.[] | select(.head.sha == \"$head_sha\")][0].number // empty" 2>/dev/null || true)"
+          #
+          # An empty result has TWO causes that need OPPOSITE reporting, and
+          # collapsing them into one message made this abort unfalsifiable: the
+          # same text and the same exit 1 were emitted whether the query FAILED
+          # or whether it SUCCEEDED and matched nothing, while `2>/dev/null`
+          # discarded the only evidence of which.
+          #   * query FAILED -> nothing is known about this head. Retried above;
+          #     if it still fails, say the QUERY failed and fail closed.
+          #   * query SUCCEEDED with no match -> the push was superseded, or its
+          #     PR closed, while CI was queued. There is nothing to review.
+          # Both still exit 1, so the fail-closed finalize step is unchanged and
+          # no verdict is withheld; what changes is that the log names the cause.
+          if ! pr="$(gh_read gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
+            --jq "[.[] | select(.head.sha == \"$head_sha\")][0].number // empty")"; then
+            echo "::error::could not query open PRs while resolving $head_sha - the query itself failed on all 3 attempts; see the errors above"
+            exit 1
+          fi
           if [ -z "$pr" ]; then
-            echo "::error::could not resolve an open PR whose head SHA is $head_sha"
+            echo "::error::no open PR has head $head_sha - superseded or closed while CI was queued; nothing to review"
             exit 1
           fi
 
           # Authoritative base SHA straight from the PR (NOT from the artifact).
-          base_sha="$(gh api "repos/$REPO/pulls/$pr" --jq '.base.sha' 2>/dev/null || true)"
-          if [ -z "$base_sha" ]; then echo "::error::could not read base.sha for PR #$pr"; exit 1; fi
+          if ! base_sha="$(gh_read gh api "repos/$REPO/pulls/$pr" --jq '.base.sha')"; then
+            echo "::error::could not read base.sha for PR #$pr - the query itself failed on all 3 attempts; see the errors above"
+            exit 1
+          fi
+          if [ -z "$base_sha" ] || [ "$base_sha" = "null" ]; then
+            echo "::error::PR #$pr reported an empty base.sha; failing closed"
+            exit 1
+          fi
 
           echo "pr=$pr" >> "$GITHUB_OUTPUT"
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -85,18 +85,65 @@ jobs:
           head_sha="$WR_HEAD_SHA"
           if [ -z "$head_sha" ]; then echo "::error::no workflow_run head_sha"; exit 1; fi
 
+          # Bounded retry for the read-only resolver queries below. A single-shot
+          # `gh api` aborts on a transient TLS / 5xx / rate-limit error, and this
+          # lane then reported that as "no such PR" -- the wrong cause, on a PR
+          # that exists. Mirrors the gh_retry convention pr-readiness.yml adopted
+          # for the same single-shot failure mode (#2753). stderr is deliberately
+          # NOT discarded any more, so a failing query says why.
+          gh_read() {
+            local attempt rc=1 out
+            for attempt in 1 2 3; do
+              if out="$("$@")"; then
+                printf '%s' "$out"
+                return 0
+              else
+                # Capture INSIDE the else: after `fi`, `$?` is the status of the
+                # whole if-statement, which is 0 when a false condition has no
+                # else branch -- that would report a failed query as success.
+                rc=$?
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "resolver query attempt $attempt failed; retrying" >&2
+                sleep $((attempt * 5))
+              fi
+            done
+            return "$rc"
+          }
+
           # Resolve the PR by matching the open PR whose head SHA equals the
           # trigger head_sha (workflow_run.pull_requests is empty for forks).
-          pr="$(gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
-            --jq "[.[] | select(.head.sha == \"$head_sha\")][0].number // empty" 2>/dev/null || true)"
+          #
+          # An empty result has TWO causes that need OPPOSITE reporting, and
+          # collapsing them into one message made this abort unfalsifiable: the
+          # same text and the same exit 1 were emitted whether the query FAILED
+          # or whether it SUCCEEDED and matched nothing, while `2>/dev/null`
+          # discarded the only evidence of which.
+          #   * query FAILED -> nothing is known about this head. Retried above;
+          #     if it still fails, say the QUERY failed and fail closed.
+          #   * query SUCCEEDED with no match -> the push was superseded, or its
+          #     PR closed, while CI was queued. There is nothing to review.
+          # Both still exit 1, so the fail-closed finalize step is unchanged and
+          # no verdict is withheld; what changes is that the log names the cause.
+          if ! pr="$(gh_read gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
+            --jq "[.[] | select(.head.sha == \"$head_sha\")][0].number // empty")"; then
+            echo "::error::could not query open PRs while resolving $head_sha - the query itself failed on all 3 attempts; see the errors above"
+            exit 1
+          fi
           if [ -z "$pr" ]; then
-            echo "::error::could not resolve an open PR whose head SHA is $head_sha"
+            echo "::error::no open PR has head $head_sha - superseded or closed while CI was queued; nothing to review"
             exit 1
           fi
 
           # Authoritative base SHA straight from the PR (NOT from the artifact).
-          base_sha="$(gh api "repos/$REPO/pulls/$pr" --jq '.base.sha' 2>/dev/null || true)"
-          if [ -z "$base_sha" ]; then echo "::error::could not read base.sha for PR #$pr"; exit 1; fi
+          if ! base_sha="$(gh_read gh api "repos/$REPO/pulls/$pr" --jq '.base.sha')"; then
+            echo "::error::could not read base.sha for PR #$pr - the query itself failed on all 3 attempts; see the errors above"
+            exit 1
+          fi
+          if [ -z "$base_sha" ] || [ "$base_sha" = "null" ]; then
+            echo "::error::PR #$pr reported an empty base.sha; failing closed"
+            exit 1
+          fi
 
           echo "pr=$pr" >> "$GITHUB_OUTPUT"
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
> 🤖 Filed by **perpetual agent `flake-warden`** — an unsupervised agent on an hourly
> schedule. No human reviewed this before it was posted. Evidence is cited inline;
> anything marked suspected is not proven.

## What is wrong

All four fork review lanes resolve the PR with the same block:

```bash
pr="$(gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
  --jq "[.[] | select(.head.sha == \"$head_sha\")][0].number // empty" 2>/dev/null || true)"
if [ -z "$pr" ]; then
  echo "::error::could not resolve an open PR whose head SHA is $head_sha"
  exit 1
fi
```

`$pr` is empty for **two opposite reasons**, and this reports both with one
message while `2>/dev/null || true` throws away the only evidence of which:

* the **query failed** (transient TLS / 5xx / rate limit) — nothing is known about
  this head; or
* the **query succeeded and matched nothing** — the push was superseded, or its PR
  closed, while CI was queued.

The message asserts the second ("could not resolve an open PR"), so a failed query
is reported as an absent PR.

## This is not theoretical — it fired on an open fork PR today

`Fork UX Review` run [31587258550](https://github.com/kirodotdev/KiroCrew/actions/runs/31587258550)
attempt 1, job `94083850762` attempt 1, step 4 *Resolve and validate PR*:

```
2026-08-12T10:24:28.8478824Z ##[error]could not resolve an open PR whose head SHA is e4dca9083e06649a83672604a5449c754d3f4684
2026-08-12T10:24:28.8483845Z ##[error]Process completed with exit code 1.
```

That SHA is the head of **open fork PR #3025** (`leonlaiyc/KiroCrew`,
`fix/crew-companion-reminder-clock-flake`) — open, unchanged head, before during and
after the abort.

**The control is the strongest part:** three sibling lanes using the *identical*
resolver read that same head successfully about two minutes later, and published
real verdicts onto it:

| check-run on `e4dca9083e` | conclusion | completed |
|---|---|---|
| `UX Review` | **neutral** — "could not run (advisory)" | 10:24:29Z |
| `Design Review` | success — "PASS — sound design" | 10:26:09Z |
| `Opus 4.8 Review` | success — "no blocking findings" | 10:26:30Z |
| `GPT 5.6 Review` | success — "no blocking findings" | 10:26:49Z |

So "no open PR has this head" was **false**, and the cause was a query that failed.
The three siblings succeeding rules out staleness; nothing else in the block can
produce that outcome.

Consequence per lane, read from each finalize step rather than assumed: `UX Review`
and `Design Review` publish `neutral` ("could not run (advisory)"), while
`fork-gpt-review.yml:652` and `fork-opus-review.yml:422` publish
`conclusion=failure` in the same fallback — i.e. on those two lanes this path puts a
**red required check on an outside contributor's PR** for a verdict that was never
computed.

## The fix

Per lane, in the resolve step only:

* **Retry** the read-only resolver queries (3 attempts, 5s/10s backoff), mirroring
  the `gh_retry` convention `pr-readiness.yml` already adopted **for this exact
  failure mode** — its own comment cites #2753, "the same commit evaluated green
  then red 39 seconds apart with nothing pushed".
* **Keep stderr**, so a failing query says why.
* **Split the causes** into two distinct messages.
* **Validate `base.sha`** instead of accepting empty or `null`.

**Both causes still `exit 1`**, so the fail-closed finalize step is untouched and no
verdict is withheld — the change is diagnostic plus the retry. This is the same
cause split that landed in #2949 for `fork-workflow-guard.yml`, applied to the four
review lanes that still carry the original shape.

Deliberately **not** done here: gating the job so a genuinely superseded SHA ends
green instead of red. That needs a resolve-job split, which restructures a security
workflow — worth proposing separately, not smuggling into a diagnostic fix.

## Verification — red before, green after

No GitHub Actions runner locally, so I drove the **real step body** extracted from
each workflow (via `yaml.safe_load`, not a copy) against a stubbed `gh`:

| scenario | OLD | NEW |
|---|---|---|
| query always fails | exit 1, **"could not resolve an open PR"** (wrong cause), 1 call | exit 1, "could not **query** open PRs … failed on all 3 attempts", 3 calls |
| **fails twice then succeeds** (the #3025 case) | **exit 1** — false abort | **exit 0**, resolves `pr=3025` |
| succeeds, no match | exit 1, same message as a failure | exit 1, "no open PR has head … superseded or closed" |
| succeeds, match | exit 0 | exit 0, `GITHUB_OUTPUT` **byte-identical** to OLD |

Also: all four files `yaml.safe_load` cleanly, every resolve-step body passes
`bash -n` (exit 0), and the patched block is **byte-identical across all four lanes**
(1 distinct body).

**Honest limits.**
1. I could not reproduce a real API failure in CI, only stub one — but the live
   abort above is real, and the three sibling lanes are the control.
2. `actionlint` and `shellcheck` are not installed on this host and no CI job
   references them, so YAML parse plus `bash -n` is the strongest local gate I could
   run; CI is the real check.
3. The harness caught a **defect in my own first draft**: `rc=$?` placed after `fi`
   captures the *if-statement's* status, which is 0 when a false condition has no
   `else`, so a failed query would have been reported as success. Fixed by capturing
   inside `else` (the code carries a comment saying why). Flagging it because it is
   the kind of thing that reads fine and is wrong.
