### PR TITLE
fix(chat): anchor tool elapsed timer to persisted start timestamp

### DIFF
--- a/website/src/pages/chat/ToolCallLine.tsx
+++ b/website/src/pages/chat/ToolCallLine.tsx
@@ -294,8 +294,16 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
   }, shallowEqual)
   const showWaitCountdown = !!waitState && waitState.deadline_ts > 0
   const [activityNow, setActivityNow] = useState(() => Date.now())
-  const activityStartRef = useRef(Date.now())
+  // Seed from the tool log's start timestamp so the elapsed clock survives
+  // unmount/remount (e.g. navigating away and back). Falls back to Date.now()
+  // only when no persisted timestamp is available (first mount of a brand-new
+  // tool call before the log entry arrives).
+  const activityStartRef = useRef(ts || Date.now())
   const wasPendingRef = useRef(hasPendingPerm)
+  // Tracks whether approval resolved during this mount — once set, the ts
+  // re-anchor effect is suppressed so the post-approval Date.now() anchor
+  // is not overwritten by the pre-approval ts.
+  const approvalResolvedRef = useRef(false)
   const [endingWait, setEndingWait] = useState(false)
 
   // Re-arm the button for a NEW sleep. Left latched otherwise: after a
@@ -328,9 +336,22 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
     if (wasPendingRef.current) {
       activityStartRef.current = Date.now()
       wasPendingRef.current = false
+      approvalResolvedRef.current = true
       setActivityNow(Date.now())
     }
   }, [hasPendingPerm])
+
+  // When the tool log timestamp arrives (or on remount with a persisted ts),
+  // re-anchor the elapsed clock so it reflects real wall time since the tool
+  // started — not time since the component mounted. Skip if approval just
+  // resolved in this mount — the post-approval Date.now() is the correct anchor
+  // for approved commands (the pre-approval ts would inflate the timer by the
+  // entire approval wait).
+  useEffect(() => {
+    if (ts && !hasPendingPerm && !approvalResolvedRef.current) {
+      activityStartRef.current = ts
+    }
+  }, [ts, hasPendingPerm])
 
   useEffect(() => {
     if (!showShellActivity && !showWaitCountdown) return

--- a/website/src/test/ToolCallLine.test.tsx
+++ b/website/src/test/ToolCallLine.test.tsx
@@ -652,3 +652,28 @@ describe('ToolCallLine auto-denied detection', () => {
     expect(container.querySelector('.text-warn')).toBeFalsy()
   })
 })
+
+describe('ToolCallLine elapsed timer survives remount', () => {
+  it('shows elapsed time anchored to the tool log timestamp, not mount time', () => {
+    // Simulate a tool that started 30 seconds ago
+    const startTs = Date.now() - 30_000
+    const store = createTestStore({
+      chat: {
+        messages: [toolMsg()],
+        toolLog: [{ type: 'tool', text: 'echo hello', tool_call_id: 'tc_1', is_shell: true, ts: startTs }],
+        slotRunning: true,
+      } as unknown as ChatState,
+    })
+    const { unmount } = renderWithProviders(<ToolCallLine message={toolMsg()} running />, { store })
+    // Should show ~30s, not 0s — proving the timer uses the persisted ts
+    const statusText = screen.getByText(/Running ·/)
+    expect(statusText.textContent).toMatch(/30|29|31/)
+
+    // Unmount and remount (simulates navigating away and back)
+    unmount()
+    renderWithProviders(<ToolCallLine message={toolMsg()} running />, { store })
+    const afterRemount = screen.getByText(/Running ·/)
+    // Still shows ~30s, NOT reset to 0s
+    expect(afterRemount.textContent).toMatch(/30|29|31/)
+  })
+})


### PR DESCRIPTION
## Problem

The "Running · Xs" elapsed timer under a tool call pill resets to 0 whenever the user navigates away from the chat and returns — or any other scenario that causes the `ToolCallLine` component to unmount/remount (virtualizer recycling, split-view transitions). This is confusing: the timer claims the tool just started when it has actually been running for much longer.

## Why it matters

Users rely on the elapsed timer to gauge how long a tool has been running. A timer that resets on every tab switch erodes trust in the indicator and makes it impossible to tell whether a tool is genuinely stuck vs recently started.

## Fix (symptoms → root cause → change)

**Symptom:** Timer shows "Running · 0s" after navigating back to a session with a running tool.

**Root cause:** `activityStartRef = useRef(Date.now())` in `ToolCallLine.tsx` — `Date.now()` is called fresh on every mount, so the elapsed computation always measures from "now" regardless of when the tool actually started.

**Change:** The tool log entry already carries a `ts` field (the real start timestamp, persisted in the Redux store and surviving across remounts). The fix:
1. Seeds `activityStartRef` from `ts` on initial mount (falling back to `Date.now()` only when no log entry has arrived yet)
2. Adds a sync effect that re-anchors `activityStartRef` when `ts` arrives or on remount — so the timer always reflects real wall time since the tool started
3. Preserves the existing permission-approval reset (timer correctly resets after approval because the tool only begins executing at that point)

## Tests

- Added `ToolCallLine elapsed timer survives remount` test: creates a tool that started 30s ago, asserts the timer shows ~30s, unmounts/remounts, and asserts it still shows ~30s (not 0s)

## Manual verification

N/A — the test directly exercises the unmount/remount path that triggers this bug and the elapsed calculation is fully deterministic.

Fixes #3044
