### PR TITLE
fix(context): gate the [UI LANGUAGE] steer on shipped catalogs, not tag shape (#1130)

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -923,12 +923,20 @@ OS — so naming the browser was wrong on that surface. The row annotates itself
 with the language Auto actually resolves to ("Auto — Deutsch"), which answers the
 question accurately on every surface.
 
-The backend validates **shape only** (`_LANGUAGE_TAG_RE`, a conservative BCP-47
-subset), not membership in the set of shipped catalogs. That keeps "which
-languages exist" a pure frontend data change: add `locales/<tag>.json`, register
-the picker entry in `SUPPORTED_LANGUAGES`, and add the static import plus
-`AUTHORED_CATALOGS` entry in `i18n/index.ts`. No backend edit is required; a
-well-formed tag with no catalog falls back to detection client-side.
+The backend's **write path** validates **shape only** (`_LANGUAGE_TAG_RE`, a
+conservative BCP-47 subset), not membership in the set of shipped catalogs — a
+well-formed tag with no catalog stays writable and falls back to detection
+client-side. The **agent-injection read path** additionally requires catalog
+membership: `context.ui_language_tag()` checks the tag against
+`context._UI_LANGUAGE_CATALOGS` (a mirror of the non-dev-only
+`SUPPORTED_LANGUAGES` entries) and treats a non-catalog tag exactly like
+`""`/Auto — no `[UI LANGUAGE]` steer is emitted, so the agent is never steered
+to a language the chrome cannot render (#1130). Adding a language is therefore
+the three frontend edits — add `locales/<tag>.json`, register the picker entry
+in `SUPPORTED_LANGUAGES`, and add the static import plus `AUTHORED_CATALOGS`
+entry in `i18n/index.ts` — **plus one mechanical backend entry** in
+`_UI_LANGUAGE_CATALOGS`, which the drift gate in
+`test/test_context_ui_language.py` names explicitly on failure.
 
 Shipped catalogs (ordered by global speaker count, which is also the picker
 order): `en`, `zh-CN`, `hi`, `es`, `fr`, `bn`, `pt`, `ru`, `de`, `ja`, `ko`, `it`. Right-to-left
@@ -956,7 +964,8 @@ above is what says whether it worked.
 
 #### The tag reaches the agent, too
 
-`context.py::_build_ui_language_section` injects the configured tag into session
+`context.py::_build_ui_language_section` injects the configured tag — after the
+catalog-membership gate described above — into session
 context as a `[UI LANGUAGE] <tag>` block (next to `[CURRENT AGENT]`/`[RUNTIME]`,
 and in `minimal_context` mode as well). It exists for one string: the tool-call
 purpose (`__tool_use_purpose`), which the dashboard paints as the tool-call pill

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -889,9 +889,35 @@ def _build_user_profile_section(cfg: "KiroCrewConfig") -> str:
 #: tag-shaped is dropped rather than pasted into the system prompt.
 _UI_LANGUAGE_TAG_RE = re.compile(r"^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8}){0,2}$")
 
+#: The language catalogs the dashboard actually ships — a mirror of the
+#: non-dev-only entries in ``website/src/i18n/languages.ts``
+#: (``SUPPORTED_LANGUAGES``), which stays the single source of truth:
+#: ``test_context_ui_language.py`` parses that file and fails when this set
+#: drifts, so adding a language remains a frontend data change plus the one
+#: mechanical entry here that the drift test names explicitly.
+#:
+#: Membership is exact and case-sensitive because that is precisely how the
+#: frontend restores a PERSISTED choice: ``resolveLanguage()`` accepts a stored
+#: value only via ``isRestorableLanguage()`` → ``SUPPORTED_CODES.includes()``
+#: (no lowering, no primary-subtag fallback — those apply only to *browser*
+#: detection tags, which never reach this field). A stored ``zh-cn`` or
+#: ``zh-TW`` therefore degrades to auto-detect in the SPA, and the backend must
+#: reach the same verdict or the two disagree about the active language —
+#: which is exactly the bug this set exists to prevent (#1130).
+#:
+#: The dev-only ``en-XA`` pseudolocale is deliberately ABSENT: in a production
+#: build ``isRestorableLanguage()`` refuses to restore it (the chrome degrades
+#: to auto-detect), and even in a dev build steering a model to write
+#: pseudolocale prose is meaningless — the accent-and-bracket transform is
+#: generated, not a language a model can write. Treating it as non-catalog
+#: keeps injection behaviour identical across build modes.
+_UI_LANGUAGE_CATALOGS = frozenset(
+    {"en", "zh-CN", "hi", "es", "fr", "bn", "pt", "ru", "de", "ja", "ko", "it"}
+)
+
 
 def ui_language_tag(cfg: "KiroCrewConfig") -> str:
-    """Return ``dashboard.language`` as a validated BCP-47 tag, or ``""``.
+    """Return ``dashboard.language`` as a validated, *shipped* tag, or ``""``.
 
     Public because the UI language now steers more than the session-context block
     below: the dashboard's auto-titler asks a background model for a session name
@@ -900,16 +926,36 @@ def ui_language_tag(cfg: "KiroCrewConfig") -> str:
     value (see ``_UI_LANGUAGE_TAG_RE`` for why the shape is re-checked here even
     though the writer validates it).
 
-    ``""`` means "the backend does not know" — either nothing was chosen (the
-    "follow the browser" sentinel, resolved in the SPA's ``resolveLanguage()``)
-    or the stored value is not tag-shaped. Callers must treat it as unknown
-    rather than as English.
+    Beyond shape, the tag must name a catalog the dashboard actually ships
+    (``_UI_LANGUAGE_CATALOGS``). A shape-valid tag with no catalog — e.g. a
+    persisted ``ar``, or a language later removed from the frontend registry —
+    renders the chrome in English (the SPA falls back to detection), so steering
+    the agent to it would put tool-call purpose pills, and the Slack/Discord task
+    titles derived from them, in a language the UI around them cannot render.
+    Those purposes persist in session history and are inherited by forked
+    sessions, so the mismatch is durable. A non-catalog tag therefore takes the
+    identical path to ``""``: inject nothing, and the model mirrors the
+    conversation instead (#1130).
+
+    ``""`` means "the backend does not know" — nothing was chosen (the
+    "follow the browser" sentinel, resolved in the SPA's ``resolveLanguage()``),
+    the stored value is not tag-shaped, or it names no shipped catalog. Callers
+    must treat it as unknown rather than as English.
     """
     lang = cfg.dashboard.language
     if not isinstance(lang, str):
         return ""
     lang = lang.strip()
     if not lang or not _UI_LANGUAGE_TAG_RE.match(lang):
+        return ""
+    if lang not in _UI_LANGUAGE_CATALOGS:
+        # Debug, not warning: this fires on every context build for as long as
+        # the value stays persisted, and the UI itself already degraded to
+        # auto-detect — but without a line here an operator cannot distinguish
+        # "not configured" from "rejected" when the steer is absent.
+        logger.debug(
+            "dashboard.language %r names no shipped catalog; not steering", lang
+        )
         return ""
     return lang
 
@@ -944,7 +990,8 @@ def _build_ui_language_section(cfg: "KiroCrewConfig") -> str:
     silently degrade to the tag for anything missing from it anyway).
 
     Raw does not mean unchecked: the value is dropped unless it is genuinely a
-    ``str`` and tag-shaped (``_UI_LANGUAGE_TAG_RE``), so neither a malformed
+    ``str``, tag-shaped (``_UI_LANGUAGE_TAG_RE``), and names a shipped catalog
+    (``_UI_LANGUAGE_CATALOGS``), so neither a malformed
     config nor a stubbed one can paste arbitrary text into the system prompt or
     raise from a prompt builder — this runs on the session-start path, where an
     exception costs the whole turn.

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -151,8 +151,9 @@ _TITLE_REFRESH_PROMPT_TEMPLATE = (
 # Interpolating the raw BCP-47 tag mirrors context._build_ui_language_section:
 # the frontend's SUPPORTED_LANGUAGES registry is the single source of truth for
 # the shipped set, so a code→name table here would be a second list to keep in
-# sync. The tag is shape-validated by ``context.ui_language_tag`` before it
-# reaches the prompt.
+# sync. The tag is shape-validated AND catalog-gated by
+# ``context.ui_language_tag`` before it reaches the prompt, so a title is never
+# steered to a language the sidebar around it cannot render.
 _TITLE_LANGUAGE_TEMPLATE = (
     "Write the title in the language of BCP-47 tag {lang}. That is the language "
     "the sidebar around the title is rendered in, so the title must be in it "

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -299,12 +299,15 @@ async def api_ready(request: web.Request) -> web.Response:
 
 #: Accepted shape for ``dashboard.language`` — a conservative BCP-47 subset
 #: (``en``, ``zh-CN``, ``pt-BR``, ``zh-Hans-CN``). Deliberately validates SHAPE,
-#: not membership in the frontend's shipped-language list: keeping the set of
-#: available languages a pure frontend data change (``SUPPORTED_LANGUAGES`` +
-#: one catalog) means adding a language never needs a backend edit. An
-#: unrecognised-but-well-formed tag is safe because the SPA's
-#: ``resolveLanguage()`` falls back to browser detection for any code it has no
-#: catalog for.
+#: not membership in the frontend's shipped-language list: ``""`` and
+#: not-yet-shipped tags must stay writable (the SPA's ``resolveLanguage()``
+#: falls back to detection for any code it has no catalog for, so a persisted
+#: non-catalog value degrades gracefully client-side). Membership IS enforced,
+#: but at the point of use: ``context.ui_language_tag`` gates the agent-steer
+#: read path on ``_UI_LANGUAGE_CATALOGS`` so a non-catalog tag is never claimed
+#: to the model as the UI language (#1130). A new backend consumer of
+#: ``dashboard.language`` must route through that resolver rather than reading
+#: the raw field.
 _LANGUAGE_TAG_RE = re.compile(r"^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8}){0,2}$")
 
 

--- a/test/test_context_ui_language.py
+++ b/test/test_context_ui_language.py
@@ -11,10 +11,16 @@ and un-configured installs must see byte-identical context.
 from __future__ import annotations
 
 import json
+import re
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from kiro_crew.config.loader import config_path
-from kiro_crew.context import ContextBuilder, _build_ui_language_section
+from kiro_crew.context import (
+    _UI_LANGUAGE_CATALOGS,
+    ContextBuilder,
+    _build_ui_language_section,
+)
 from kiro_crew.learn import LessonStore
 from kiro_crew.memory import MemoryStore
 from kiro_crew.skills import SkillsLoader
@@ -101,13 +107,45 @@ class TestUiLanguageSection:
         assert ctx.index("[RUNTIME]") < ctx.index("[UI LANGUAGE]")
         assert ctx.index("[UI LANGUAGE]") < ctx.index("[WORKSPACE IDENTITY]")
 
-    def test_unshipped_but_wellformed_tag_passes_through(self, tmp_path):
-        """The backend validates shape, not membership in the frontend's
-        shipped list (see _LANGUAGE_TAG_RE) — so an unknown tag must not be
-        dropped here either."""
-        _seed_language("ja")
+    def test_non_catalog_tag_injects_nothing(self, tmp_path):
+        """A shape-valid tag with NO shipped catalog must take the identical
+        path to ""/Auto: the SPA's resolveLanguage() falls back to detection
+        for it, so the chrome renders in English while a steered agent would
+        write purpose pills — and the Slack/Discord task titles derived from
+        them — in the unsupported language, durably (purposes persist in
+        session history and are inherited by forked sessions). See #1130."""
+        for tag in ("ar", "th", "zz", "tlh"):
+            _seed_language(tag)
+            ctx = _builder(tmp_path).build_session_context()
+            assert "[UI LANGUAGE]" not in ctx, f"non-catalog {tag!r} was injected"
+
+    def test_regional_variant_resolves_like_the_frontend(self, tmp_path):
+        """Membership is exact, mirroring how the frontend restores a PERSISTED
+        choice: isRestorableLanguage() is SUPPORTED_CODES.includes() — no
+        case-folding, no primary-subtag fallback (those apply only to browser
+        detection tags, which never reach dashboard.language). A stored zh-TW
+        or zh-cn degrades to auto-detect in the SPA, so the backend must inject
+        nothing for it too, or the two disagree about the active language."""
+        for tag in ("zh-TW", "zh-cn", "en-GB", "pt-BR", "zh-Hans-CN"):
+            _seed_language(tag)
+            ctx = _builder(tmp_path).build_session_context()
+            assert "[UI LANGUAGE]" not in ctx, f"{tag!r} injected but not restorable"
+
+    def test_pseudolocale_is_not_injected(self, tmp_path):
+        """en-XA is registered but dev-only: a production build refuses to
+        restore it (isRestorableLanguage), and pseudolocale prose is a
+        generated transform, not a language a model can write. Excluding it
+        keeps injection identical across build modes."""
+        _seed_language("en-XA")
         ctx = _builder(tmp_path).build_session_context()
-        assert "[UI LANGUAGE] ja" in ctx
+        assert "[UI LANGUAGE]" not in ctx
+
+    def test_every_shipped_catalog_still_injects(self, tmp_path):
+        """The gate must not lose a single legitimate language."""
+        for tag in sorted(_UI_LANGUAGE_CATALOGS):
+            _seed_language(tag)
+            ctx = _builder(tmp_path).build_session_context()
+            assert f"[UI LANGUAGE] {tag}" in ctx, f"shipped {tag!r} was dropped"
 
     def test_malformed_tag_is_dropped(self, tmp_path):
         """`PUT /api/config/theme` shape-validates, but it is not the only way a
@@ -145,3 +183,92 @@ class TestUiLanguageSection:
         ctx = _builder(tmp_path).build_session_context()
         assert "[UI LANGUAGE]" not in ctx
         assert _build_ui_language_section(cfg) == ""
+
+
+# ── Catalog drift gate ─────────────────────────────────────────────────────────
+#
+# _UI_LANGUAGE_CATALOGS mirrors the frontend registry. The repo's contract is
+# that "which languages exist" stays a pure frontend data change in
+# website/src/i18n/languages.ts — so this gate is what keeps the backend copy
+# honest: add or remove a language there without updating the Python set and
+# this test fails naming both sides. A silent drift would re-create #1130 for
+# the next added language (backend refuses a tag the UI now renders) or, worse,
+# for a removed one (backend steers the agent to a language the UI no longer
+# ships).
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_LANGUAGES_TS = _REPO_ROOT / "website" / "src" / "i18n" / "languages.ts"
+
+# One registry entry: `{ code: 'xx-YY', label: '...' }`, optionally carrying
+# `devOnly: true`. Anchoring on `code:` inside an object literal keeps the
+# parse honest against comments mentioning tags (e.g. the RTL note naming
+# languages we deliberately do not ship).
+_ENTRY_RE = re.compile(
+    r"\{\s*code:\s*'(?P<code>[^']+)'\s*,\s*label:\s*'[^']*'\s*,?"
+    r"(?P<rest>[^}]*)\}",
+    re.DOTALL,
+)
+
+
+def _frontend_registry() -> tuple[set[str], set[str]]:
+    """(non-dev-only codes, dev-only codes) parsed from languages.ts."""
+    source = _LANGUAGES_TS.read_text(encoding="utf-8")
+    # Strip comments first: the file's docstrings mention codes ('en-XA',
+    # 'zh-CN') that must not be mistaken for entries.
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+    source = re.sub(r"//[^\n]*", "", source)
+    body = source.split("SUPPORTED_LANGUAGES", 1)[1].split("] as const", 1)[0]
+    shipped: set[str] = set()
+    dev_only: set[str] = set()
+    for m in _ENTRY_RE.finditer(body):
+        (dev_only if "devOnly: true" in m.group("rest") else shipped).add(m.group("code"))
+    # Fail LOUD on an entry the regex could not parse (reordered fields,
+    # double-quoted strings, ...). Without this the gate fails OPEN: at the
+    # moment a contributor adds an unparseable entry, the backend set also
+    # lacks that code, so both sides omit it and the equality check passes —
+    # recreating #1130 for exactly the language the gate exists to protect.
+    entry_count = body.count("code:")
+    parsed = len(shipped) + len(dev_only)
+    assert parsed == entry_count, (
+        f"parsed {parsed} registry entries but languages.ts declares "
+        f"{entry_count} — an entry no longer matches _ENTRY_RE; update the "
+        "parser in test/test_context_ui_language.py"
+    )
+    return shipped, dev_only
+
+
+class TestCatalogDriftGate:
+    def test_backend_set_matches_the_frontend_registry(self):
+        """_UI_LANGUAGE_CATALOGS == SUPPORTED_LANGUAGES minus devOnly, exactly.
+
+        On failure: edit _UI_LANGUAGE_CATALOGS in src/kiro_crew/context.py to
+        match website/src/i18n/languages.ts — that file stays the single source
+        of truth; the Python set is the derived copy.
+        """
+        shipped, _dev_only = _frontend_registry()
+        assert shipped, "parser found no registry entries — languages.ts moved?"
+        assert _UI_LANGUAGE_CATALOGS == shipped, (
+            "backend catalog set drifted from the frontend registry.\n"
+            f"  missing from backend: {sorted(shipped - _UI_LANGUAGE_CATALOGS)}\n"
+            f"  stale in backend:     {sorted(_UI_LANGUAGE_CATALOGS - shipped)}\n"
+            "Update _UI_LANGUAGE_CATALOGS in src/kiro_crew/context.py."
+        )
+
+    def test_dev_only_pseudolocale_stays_excluded(self):
+        """en-XA must remain registered-but-dev-only upstream AND absent from
+        the backend set — if the frontend ever promotes it (or adds another
+        devOnly code), this forces a deliberate decision instead of a silent
+        inherit."""
+        _shipped, dev_only = _frontend_registry()
+        assert dev_only == {"en-XA"}
+        assert not (_UI_LANGUAGE_CATALOGS & dev_only)
+
+    def test_parser_sees_the_known_shape(self):
+        """The regex parse is only trustworthy while it finds what we know is
+        there: a shipped regional tag and the dev-only marker. If languages.ts
+        is restructured, fail HERE with a clear message rather than letting
+        _frontend_registry() return garbage that happens to compare equal."""
+        shipped, dev_only = _frontend_registry()
+        assert "zh-CN" in shipped
+        assert "en" in shipped
+        assert "en-XA" in dev_only


### PR DESCRIPTION
## Problem

A `dashboard.language` value that is BCP-47-shaped but has no shipped catalog (e.g. `ar`, or `zh-TW`) is accepted by the write path and then **half-applies**: the SPA's `resolveLanguage()` refuses to restore a non-catalog value, so the chrome renders in English — but the backend injector checked only tag *shape*, so the agent was still steered to write tool-call purpose pills in the unsupported language. Those purposes are reused as Slack/Discord task titles, persist in session history, and are inherited by forked sessions, so the mixed-language state is durable and survives switching back to a supported language.

## Why it matters

The steer handed to the agent must never claim a language the UI cannot render. Every string around a purpose pill (buttons, timestamps, headers) follows the UI language; a pill in a language the chrome cannot show puts two languages on one line — permanently, because purposes are persisted.

## Fix (symptom → root cause → change)

Symptom: English chrome + foreign-language pills. Root cause: two validators both check shape only — the frontend gates a *persisted* choice on catalog membership (`isRestorableLanguage()` → `SUPPORTED_CODES.includes()`, exact and case-sensitive), the backend injector had no equivalent, so the two disagreed about the active language. Change: `context.ui_language_tag()` — the single resolver feeding both the `[UI LANGUAGE]` context block and the chat-title language steer — now also requires membership in `_UI_LANGUAGE_CATALOGS`, a mirror of the non-`devOnly` `SUPPORTED_LANGUAGES` entries. A non-catalog tag takes the identical path to `""`/Auto: inject nothing, model mirrors the conversation, chrome and agent always agree.

Design decisions:
- **Exact, case-sensitive membership** — precisely the frontend's persisted-choice rule. Primary-subtag and case-insensitive matching apply only to *browser detection* tags, which never reach `dashboard.language`; mirroring them here would inject for `zh-TW` while the SPA degrades it to auto, recreating the disagreement in the other direction.
- **`en-XA` pseudolocale excluded** — a production build refuses to restore it, and steering a model to write generated accent-transform prose is meaningless; excluding it keeps injection identical across build modes (rationale in the code comment).
- **`website/src/i18n/languages.ts` stays the single source of truth** — the Python set is a derived copy pinned by a drift test that parses `SUPPORTED_LANGUAGES` and fails naming both sides when they diverge. The parser also count-checks its own matches so an entry it cannot parse fails loud instead of letting the gate pass vacuously.
- **The `PUT /api/config/theme` write path is deliberately unchanged** (shape-only): `""` and not-yet-shipped tags must stay writable, and rejecting values users already persisted is out of scope. Its rationale comment is updated to point new consumers at the gated resolver, and the system spec (`docs/system-specs/modules/config.md`) now documents the read-path gate and the one extra backend entry a new language needs.
- The drop branch logs at `debug` so an operator can distinguish "not configured" from "rejected".

Out of scope (per the issue): recovery for sessions that already accumulated purposes in a stale language.

## Tests

- Non-catalog shape-valid tags (`ar`, `th`, `zz`, `tlh`) inject nothing — the regression test for this bug (mutation-checked: reverting the gate turns it red).
- Regional/case variants (`zh-TW`, `zh-cn`, `en-GB`, `pt-BR`, `zh-Hans-CN`) inject nothing, matching the frontend's restore verdict.
- `en-XA` injects nothing.
- Every shipped catalog still injects (derived from the set, so it tracks additions).
- `""`, whitespace, malformed values, marker-forging payloads: existing tests unchanged and green (no regression).
- Drift gate: backend set == frontend registry minus `devOnly`, exactly; `devOnly` stays `{en-XA}`; parser self-checks (known-shape probe + parsed-count == declared-count so an unparseable entry fails loud).

## Manual verification

N/A — unit coverage sufficient: the change is a pure predicate on the prompt-builder path, fully exercised by the context-build tests. No UI change (backend + docs only).

Local gates: isort/flake8 (CI-pinned versions) green; mypy green on changed files (4 pre-existing errors in untouched files reproduce on clean main); full pytest run diffed against a clean `origin/main` baseline with `comm` — zero regressions (all remaining failures are environmental and identical on base).

Pre-push review: GPT reviewer PASS; Opus reviewer 0 blocking, 4 advisories (spec update, write-path comment rationale, drift-gate fail-open, missing drop-branch log) — all four fixed in this commit.

Closes #1130
