### PR TITLE
fix(knowledge): record agent document ownership inside the ingest

### DIFF
--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -176,6 +176,25 @@ redacted before they cross into the store. Adds are serialised by a module lock,
 new items are attributed to a document by diffing the source's item ids around the
 ingest.
 
+**Ownership is recorded from inside the ingest, not after it returns.** The items become
+durable during `ingest_file`; `ingest_file` therefore takes an `on_committed` callback and
+invokes it in its finalize hop, on the success branch, right after the superseded group is
+deleted. The ids it hands over are **collected at each `add_item`**, not inferred from a
+before/after comparison of the source: `import_bundle` writes into the same aggregate in
+its own transaction and under no shared lock, so a comparison would attribute anything it
+committed meanwhile to whichever document happened to be ingesting — giving that document
+delete authority over knowledge it never created, and destroying it on the next edit. Writing the group
+afterwards instead would leave several awaits — the temp-file cleanup, the job-status read
+— between the items existing and the record that makes them replaceable, and each is a
+cancellation point on the gateway loop. Interrupted there, nothing names the items, and
+**both** of the aggregate's duplicate defences read that same row: `get_state` reports no
+previous group, so the next add replaces nothing and `find_document_by_hash` cannot see
+the content either. The document is then stored twice, and because replacement is what
+carries delete authority, an edited re-add leaves the superseded version searchable
+permanently. Running inside the hop gives the ownership write the same run-to-completion
+guarantee as the delete it belongs with. The `deduped` marker is written by the caller
+instead, because the duplicate gate returns before the hop ever runs.
+
 The tool takes the document TEXT and **never opens a file**. A path opened here on
 behalf of whatever supplied it is exactly the case where a component can be swapped for a
 link to a credential file between the check and the open, and a path pointing at a binary

--- a/src/kiro_crew/knowledge/agent_source.py
+++ b/src/kiro_crew/knowledge/agent_source.py
@@ -304,8 +304,18 @@ async def _add_agent_document(
     # claim for its previous content, and this document's text has changed.
     store.release_stale_claim(source_id, prev_hash, content_hash, old_item_ids)
 
-    before_ids = {r["id"] for r in store.db.execute(
-        "SELECT id FROM items WHERE source_id = ?", (source_id,)).fetchall()}
+    # Ownership is recorded from inside the ingest's finalize hop rather than
+    # after it returns. The items become durable during the ingest, and every
+    # await between that and a later write here -- the temp-file cleanup, the
+    # job-status read -- is a cancellation point that would leave them owned by
+    # nobody. Nothing then names the group: `get_state` reports no previous
+    # items, so the next add of this document neither replaces them nor is
+    # refused by `find_document_by_hash`, and the content is stored twice.
+    recorded_ids: list[str] = []
+
+    def _record_ownership(new_ids: list[str]) -> None:
+        recorded_ids[:] = new_ids
+        set_state(store, source_id, slug, content_hash, new_ids, title)
 
     tmp_path: str | None = None
     try:
@@ -325,6 +335,7 @@ async def _add_agent_document(
             original_name=f"{title}{_DEFAULT_EXT}",
             source_id=source_id,
             old_item_ids=old_item_ids,
+            on_committed=_record_ownership,
         )
     finally:
         if tmp_path:
@@ -349,10 +360,7 @@ async def _add_agent_document(
         return {"status": "error",
                 "error": f"ingestion did not complete (status={status})"}
 
-    after_ids = {r["id"] for r in store.db.execute(
-        "SELECT id FROM items WHERE source_id = ?", (source_id,)).fetchall()}
-    new_ids = list(after_ids - before_ids)
-    set_state(store, source_id, slug, content_hash, new_ids, title)
+    new_ids = list(recorded_ids)
     sel().log_tool_invocation(
         session_key="gateway", agent="knowledge-agent-source",
         tool_name="knowledge.agent_document.add", outcome="completed",

--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -372,13 +372,24 @@ class IngestionPipeline:
         except Exception:
             logger.debug("Post-ingest dedup skipped", exc_info=True)
 
-    async def ingest_file(self, path: str, on_progress=None, original_name: str = "", namespace: str = "default", source_id: str = "", old_item_ids: list[str] | None = None) -> str | None:
+    async def ingest_file(self, path: str, on_progress=None, original_name: str = "", namespace: str = "default", source_id: str = "", old_item_ids: list[str] | None = None, on_committed: Callable[[list[str]], None] | None = None) -> str | None:
         """Full pipeline. Returns job_id, or None if content hash unchanged.
 
         If source_id is provided, ingests into that existing source instead of
         creating a new one (used for remote source sync).
         If old_item_ids is provided, only those items are replaced (folder sources).
         Otherwise all items for the source are replaced (single-file sources).
+
+        ``on_committed`` receives the ids this call created -- collected at each
+        write, never inferred from a before/after comparison of the source, which
+        would also sweep up whatever another writer committed meanwhile. It runs
+        INSIDE the finalize hop, on the success branch and only there, right
+        after the old group is deleted. An aggregate source keyed by document has
+        to record which document owns those ids, and doing it after this
+        coroutine returns puts several awaits between the items becoming durable
+        and the record that makes them replaceable -- each one a cancellation
+        point that strands the items unowned. Passing the write in here gives it
+        the same run-to-completion guarantee as the delete it belongs with.
         """
         p = Path(path)
         display_name = original_name or p.name
@@ -515,6 +526,7 @@ class IngestionPipeline:
                 display_name=display_name, namespace=namespace,
                 existing=existing, old_item_ids=old_item_ids,
                 _old_item_ids=_old_item_ids, path=path, on_progress=on_progress,
+                on_committed=on_committed,
             )
         except Exception:
             try:
@@ -531,7 +543,7 @@ class IngestionPipeline:
     async def _ingest_file_body(self, *, job_id, source_id, props, meta, ext, text,
                                 uri, content_hash, display_name, namespace,
                                 existing, old_item_ids, _old_item_ids, path,
-                                on_progress) -> str | None:
+                                on_progress, on_committed=None) -> str | None:
         """Chunk/extract/store/finalize — split out so ingest_file can mark the
         pre-inserted job row 'failed' on ANY exception in one place."""
         # 4. Chunk (use per-source chunk size if configured)
@@ -559,6 +571,13 @@ class IngestionPipeline:
         chunk_contents = [chunk['content'] for chunk in chunks]
         extractions = await self.extractor.extract_batch(chunk_contents)
 
+        # What THIS call wrote, collected at the write itself rather than
+        # inferred from a before/after comparison of the source. `import_bundle`
+        # writes into the same aggregate in its own transaction and under no
+        # shared lock, so anything it commits while this ingest is awaiting would
+        # be attributed here -- handing a document delete authority over
+        # knowledge it never created.
+        created_item_ids: list[str] = []
         processed = 0
         for i, (chunk, extraction) in enumerate(zip(chunks, extractions)):
             try:
@@ -583,6 +602,7 @@ class IngestionPipeline:
                     tags=item_tags,
                     content_hash=content_hash,
                 )
+                created_item_ids.append(item_id)
                 self.store.add_source_location(
                     item_id=item_id, source_id=source_id,
                     chunk_range=f"{chunk.get('line_start', 0)}-{chunk.get('line_end', 0)}",
@@ -621,6 +641,8 @@ class IngestionPipeline:
             # and WAL + busy_timeout=10000 rides out write-lock contention.
             if processed == total:
                 self.store.delete_items_batch(_old_item_ids, owner_source_id=source_id)
+                if on_committed is not None:
+                    on_committed(list(created_item_ids))
                 if existing:
                     self.store.update_source(source_id, properties=json.dumps({**props, 'content_hash': content_hash, **meta}))
                 self.store.db.execute("UPDATE sources SET sync_status = 'synced' WHERE id = ?", (source_id,))

--- a/test/test_agent_source_ownership_durability.py
+++ b/test/test_agent_source_ownership_durability.py
@@ -1,0 +1,303 @@
+"""Ownership durability for the agent aggregate source.
+
+The items an add commits become durable inside ``ingest_file``. Recording which
+document owns them afterwards puts several awaits in between -- the temp-file
+cleanup, the job-status read -- and each is a cancellation point. Interrupted
+there, the items are owned by nobody, and BOTH duplicate defences for the
+aggregate read that ownership row: ``get_state`` reports no previous group, so
+the next add replaces nothing, and ``find_document_by_hash`` cannot see the
+content either. The document is then stored twice, and an edited re-add leaves
+the superseded version searchable for good.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.knowledge.agent_source import (
+    add_agent_document,
+    document_slug,
+    ensure_agent_source,
+    get_state,
+)
+from kiro_crew.knowledge.ingestion import IngestionPipeline
+from kiro_crew.knowledge.readers import FileReader
+from kiro_crew.knowledge.store import KnowledgeStore
+
+URI = "https://example.invalid/doc"
+OTHER_URI = "https://example.invalid/other"
+
+
+def _one_chunk(text, **kw):
+    return [{"content": text, "chunk_index": 0, "section_title": None,
+             "line_start": 0, "line_end": 0}]
+
+
+@pytest.fixture()
+def kstore(tmp_path):
+    s = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def pipeline(kstore):
+    extractor = MagicMock()
+    extractor._pool = None
+    extractor.extract_batch = AsyncMock(
+        side_effect=lambda contents: [
+            {"category": "document", "summary": "s", "entities": []} for _ in contents
+        ]
+    )
+    chunker = MagicMock()
+    for m in ("chunk", "chunk_markdown", "chunk_code", "chunk_slides"):
+        getattr(chunker, m).side_effect = _one_chunk
+    return IngestionPipeline(store=kstore, extractor=extractor, chunker=chunker,
+                             reader=FileReader(), embedder=None, dedup_enabled=False)
+
+
+IMPORTED_ID = "imported-item-1"
+
+
+def _imported_item(source_id):
+    """A row shaped the way ``import_bundle`` expects, landing in the aggregate."""
+    return {
+        "id": IMPORTED_ID, "title": "Imported", "content": "imported body",
+        "item_type": "document", "source_id": source_id, "chunk_index": 0,
+        "namespace": "default", "summary": None, "tags": "[]", "embedding": None,
+        "status": "active", "created_at": "2024-01-01T00:00:00",
+        "updated_at": "2024-01-01T00:00:00",
+    }
+
+
+def _bodies(store, source_id, needle):
+    return [r["content"] for r in store.db.execute(
+        "SELECT content FROM items WHERE source_id = ?", (source_id,)).fetchall()
+        if needle in r["content"]]
+
+
+def _live_ids(store, source_id):
+    return {r["id"] for r in store.db.execute(
+        "SELECT id FROM items WHERE source_id = ?", (source_id,)).fetchall()}
+
+
+def _interrupt_after_the_ingest(pipeline, exc):
+    """Fail at the first await AFTER the items are durable.
+
+    ``get_job_status`` is the first thing the add touches once ``ingest_file``
+    has returned, so raising there reproduces an interruption inside the window
+    without stubbing out the ownership write itself.
+    """
+    def boom(job_id):
+        raise exc
+    pipeline.get_job_status = boom
+
+
+class TestOwnershipSurvivesAnInterruptedAdd:
+    @pytest.mark.asyncio
+    async def test_re_adding_the_same_document_does_not_store_it_twice(
+        self, kstore, pipeline
+    ):
+        sid, _ = ensure_agent_source(kstore)
+        _interrupt_after_the_ingest(pipeline, RuntimeError("gateway went away"))
+        with pytest.raises(RuntimeError):
+            await add_agent_document(
+                pipeline, title="Doc", content="alpha body", source_uri=URI)
+        assert len(_bodies(kstore, sid, "alpha body")) == 1
+
+        del pipeline.get_job_status
+        await add_agent_document(
+            pipeline, title="Doc", content="alpha body", source_uri=URI)
+
+        assert len(_bodies(kstore, sid, "alpha body")) == 1
+
+    @pytest.mark.asyncio
+    async def test_an_edited_re_add_does_not_strand_the_old_version(
+        self, kstore, pipeline
+    ):
+        # The sharper harm: replacement is driven by the ownership record, so
+        # losing it means the superseded text can never be removed.
+        sid, _ = ensure_agent_source(kstore)
+        _interrupt_after_the_ingest(pipeline, RuntimeError("gateway went away"))
+        with pytest.raises(RuntimeError):
+            await add_agent_document(
+                pipeline, title="Doc", content="version one", source_uri=URI)
+
+        del pipeline.get_job_status
+        await add_agent_document(
+            pipeline, title="Doc", content="version two", source_uri=URI)
+
+        assert not _bodies(kstore, sid, "version one")
+        assert len(_bodies(kstore, sid, "version two")) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_second_document_with_identical_text_is_still_refused(
+        self, kstore, pipeline
+    ):
+        # `find_document_by_hash` is the aggregate's own duplicate gate and also
+        # reads the ownership row, so it fails in the same instant.
+        sid, _ = ensure_agent_source(kstore)
+        _interrupt_after_the_ingest(pipeline, RuntimeError("gateway went away"))
+        with pytest.raises(RuntimeError):
+            await add_agent_document(
+                pipeline, title="Doc", content="shared body", source_uri=URI)
+
+        del pipeline.get_job_status
+        result = await add_agent_document(
+            pipeline, title="Other", content="shared body", source_uri=OTHER_URI)
+
+        assert result["status"] == "duplicate"
+        assert len(_bodies(kstore, sid, "shared body")) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_add_still_leaves_the_document_owned(
+        self, kstore, pipeline
+    ):
+        # Cancellation is the ordinary case here, not an exotic one: the add
+        # runs on the gateway loop and the awaits after the ingest are real
+        # cancellation points.
+        sid, _ = ensure_agent_source(kstore)
+        _interrupt_after_the_ingest(pipeline, asyncio.CancelledError())
+        with pytest.raises(asyncio.CancelledError):
+            await add_agent_document(
+                pipeline, title="Doc", content="alpha body", source_uri=URI)
+
+        _, owned = get_state(kstore, sid, document_slug(URI))
+        assert set(owned) == _live_ids(kstore, sid)
+
+    @pytest.mark.asyncio
+    async def test_the_recorded_group_is_exactly_this_documents_items(
+        self, kstore, pipeline
+    ):
+        # The group is recorded from inside the ingest now, so pin that it still
+        # names this document's items and not a neighbour's.
+        sid, _ = ensure_agent_source(kstore)
+        await add_agent_document(
+            pipeline, title="First", content="first body", source_uri=URI)
+        first_owned = set(get_state(kstore, sid, document_slug(URI))[1])
+
+        await add_agent_document(
+            pipeline, title="Second", content="second body", source_uri=OTHER_URI)
+        second_owned = set(get_state(kstore, sid, document_slug(OTHER_URI))[1])
+
+        assert first_owned and second_owned
+        assert not (first_owned & second_owned)
+        assert first_owned | second_owned == _live_ids(kstore, sid)
+
+    @pytest.mark.asyncio
+    async def test_an_edit_replaces_the_group_rather_than_growing_it(
+        self, kstore, pipeline
+    ):
+        sid, _ = ensure_agent_source(kstore)
+        await add_agent_document(
+            pipeline, title="Doc", content="version one", source_uri=URI)
+
+        await add_agent_document(
+            pipeline, title="Doc", content="version two", source_uri=URI)
+
+        assert not _bodies(kstore, sid, "version one")
+        assert len(_bodies(kstore, sid, "version two")) == 1
+        assert set(get_state(kstore, sid, document_slug(URI))[1]) == _live_ids(kstore, sid)
+
+    @pytest.mark.asyncio
+    async def test_an_unrelated_document_is_untouched_by_a_neighbours_edit(
+        self, kstore, pipeline
+    ):
+        sid, _ = ensure_agent_source(kstore)
+        await add_agent_document(
+            pipeline, title="Keep", content="keep body", source_uri=OTHER_URI)
+        await add_agent_document(
+            pipeline, title="Doc", content="version one", source_uri=URI)
+
+        await add_agent_document(
+            pipeline, title="Doc", content="version two", source_uri=URI)
+
+        assert len(_bodies(kstore, sid, "keep body")) == 1
+        assert set(get_state(kstore, sid, document_slug(OTHER_URI))[1]) == {
+            i for i in _live_ids(kstore, sid)
+            if i not in set(get_state(kstore, sid, document_slug(URI))[1])}
+
+    @pytest.mark.asyncio
+    async def test_a_concurrent_import_never_joins_this_documents_group(
+        self, kstore, pipeline
+    ):
+        # The group must come from what THIS ingest wrote. `import_bundle` is an
+        # independent writer into the same aggregate -- its own transaction, and
+        # outside the add lock -- so anything it commits mid-ingest would be
+        # swept into the group by a before/after comparison of the source.
+        sid, _ = ensure_agent_source(kstore)
+        real_extract = pipeline.extractor.extract_batch
+
+        async def import_lands_mid_ingest(contents):
+            kstore.import_bundle({"items": [_imported_item(sid)]})
+            return await real_extract(contents)
+
+        pipeline.extractor.extract_batch = import_lands_mid_ingest
+
+        await add_agent_document(
+            pipeline, title="Doc", content="alpha body", source_uri=URI)
+
+        _, owned = get_state(kstore, sid, document_slug(URI))
+        assert IMPORTED_ID not in owned, (
+            "the document claims ownership of an item another writer committed")
+
+    @pytest.mark.asyncio
+    async def test_editing_a_document_cannot_delete_concurrently_imported_knowledge(
+        self, kstore, pipeline
+    ):
+        # The destructive consequence: ownership carries delete authority, so a
+        # group that over-claims deletes someone else's knowledge on the next
+        # edit of this document.
+        sid, _ = ensure_agent_source(kstore)
+        real_extract = pipeline.extractor.extract_batch
+
+        async def import_lands_mid_ingest(contents):
+            kstore.import_bundle({"items": [_imported_item(sid)]})
+            pipeline.extractor.extract_batch = real_extract
+            return await real_extract(contents)
+
+        pipeline.extractor.extract_batch = import_lands_mid_ingest
+        await add_agent_document(
+            pipeline, title="Doc", content="version one", source_uri=URI)
+
+        await add_agent_document(
+            pipeline, title="Doc", content="version two", source_uri=URI)
+
+        assert IMPORTED_ID in _live_ids(kstore, sid), (
+            "editing an agent document deleted imported knowledge")
+        assert _bodies(kstore, sid, "imported body")
+
+    @pytest.mark.asyncio
+    async def test_a_partial_ingest_records_no_ownership(self, kstore, pipeline):
+        # The callback fires only on the success branch. A chunk that fails
+        # leaves the ingest short of its total, and the finalizer rolls the
+        # created items back -- so recording a group there would name items that
+        # are about to be deleted.
+        sid, _ = ensure_agent_source(kstore)
+        kstore.add_source_location = MagicMock(side_effect=RuntimeError("no room"))
+
+        result = await add_agent_document(
+            pipeline, title="Doc", content="alpha body", source_uri=URI)
+
+        assert result["status"] == "error"
+        assert get_state(kstore, sid, document_slug(URI)) == (None, [])
+        assert not _bodies(kstore, sid, "alpha body")
+
+    @pytest.mark.asyncio
+    async def test_a_refused_duplicate_still_records_its_marker(
+        self, kstore, pipeline
+    ):
+        # The deduped branch returns before the finalize hop, so its state write
+        # stays on the caller side and must keep working.
+        sid, _ = ensure_agent_source(kstore)
+        await add_agent_document(
+            pipeline, title="Doc", content="shared body", source_uri=URI)
+
+        result = await add_agent_document(
+            pipeline, title="Other", content="shared body", source_uri=OTHER_URI)
+
+        assert result["status"] == "duplicate"
+        assert len(_bodies(kstore, sid, "shared body")) == 1


### PR DESCRIPTION
Closes #3058.

## Summary

- record an agent document's item group from **inside** the ingest instead of after it returns
- add an `on_committed` hook to `IngestionPipeline.ingest_file`, invoked in the finalize hop on the success branch
- take the group from the ids the ingest actually wrote, not from a before/after diff of the source
- cover the interrupted, cancelled, edited-replacement, cross-document, concurrent-import and preservation paths
- document the ownership-write invariant for the aggregate source

## The gap

The items an add commits become durable inside `ingest_file` — `store.add_item` runs its own `BEGIN`/`COMMIT` per item. The group is recorded afterwards, back in the caller, with the temp-file cleanup and the job-status read in between. Those awaits are cancellation points on the gateway loop. Interrupted there, `agent_item_state` has no row for the slug.

That costs **both** of the aggregate's duplicate defences at once, because both read that row:

- `get_state` returns `(None, [])`, so the unchanged-content shortcut misses **and** `ingest_file` receives an empty `old_item_ids` and deletes nothing;
- `find_document_by_hash` queries `agent_item_state WHERE status='active'`, so the cross-document gate cannot see the content either.

The pipeline's own pre-ingest gate cannot cover for it. As `find_document_by_hash`'s docstring says, that gate excludes the whole incoming `source_id` — "right for a source holding ONE document but blind inside an aggregate". `agent_item_state` exists to fix that blindness, and it is the row that went missing.

Nothing repairs it afterwards either: unlike artifacts, this source has **no reconcile pass** (`grep reconcile agent_source.py` is empty), and `_ADD_LOCK` serialises adds without making them durable.

## Fail-before on this PR's base (`4a8bc6ffc`)

```
test_re_adding_the_same_document_does_not_store_it_twice
    AssertionError: assert 2 == 1
test_an_edited_re_add_does_not_strand_the_old_version
    AssertionError: assert not ['version one']
test_a_second_document_with_identical_text_is_still_refused
    AssertionError: assert 'added' == 'duplicate'
test_a_cancelled_add_still_leaves_the_document_owned
    AssertionError: assert set() == {'09987ce5-...'}
test_a_concurrent_import_never_joins_this_documents_group
    AssertionError: the document claims ownership of an item another writer committed
test_editing_a_document_cannot_delete_concurrently_imported_knowledge
    AssertionError: editing an agent document deleted imported knowledge
```

6 failed / 5 passed on base; 11 passed with the fix. The five that pass on both are the preservation cases — they are there to catch the fix breaking ordinary behaviour, not to demonstrate the bug.

The interruption is applied at `get_job_status`, the first thing the add touches once `ingest_file` has returned. That is inside the window and does **not** stub out the ownership write itself, so the tests exercise the real seam rather than asserting on a mock.

The sharpest one is the second: replacement is what carries delete authority, so a lost ownership row means the superseded text can never be removed. It is unreachable from every document and stays in the search corpus for good.

## The fix

`ingest_file` takes an `on_committed` callback and invokes it inside `_finalize`, on the success branch, immediately after the superseded group is deleted — so the caller is handed exactly the ids this call created.

That hop already runs through `run_to_completion`, precisely so a committed delete and its state finalization cannot be separated by a cancellation. Its comment states the reasoning in the folder-scan context: a skipped finalizer "strands committed data (the next scan re-ingests alongside it -> duplicates)". An aggregate source's ownership write is the same kind of co-dependent write, and belongs in the same hop.

The `deduped` marker stays on the caller side, because the duplicate gate returns before the hop ever runs. There is a test for it.

### The group is what this ingest wrote, not what appeared in the source

`on_committed` is handed the ids collected at each `add_item`. Deriving them by
comparing the source's items before and after the ingest is **not** equivalent:
`import_bundle` writes into the same aggregate in its own transaction and under
no shared lock, so an item it commits while this ingest is awaiting would be
attributed to whichever document happened to be running.

The last two fail-before cases pin exactly that, with a real `import_bundle`
committing at the `extract_batch` await. The second is destructive rather than
cosmetic: the document takes delete authority over knowledge it never created,
and its next edit removes it.

## Rejected alternatives

- **Fully atomic item + ownership.** The permanent fix, and out of scope here: items are committed one at a time by `store.add_item`, so sharing a transaction with the ownership row means restructuring the pipeline's item writes — far beyond the proven bug.
- **A pending-intent row plus a residue sweep** (the shape used for artifacts). Rejected as much larger for no extra benefit here: it repairs residue *after* the fact and brings its own safety surface — transient state that must not cross a bundle boundary, malformed-state fail-safes, and attribution rules. Recording ownership inside the hop prevents the residue instead of cleaning it up.
- **A reconcile pass for the agent source.** There is no on-disk truth to reconcile against — the source is push-only — which is why it has none today.
- **A shared lock between adds and `import_bundle`.** Rejected once write-time provenance made it unnecessary: exact ids are correct under any interleaving, without coupling two independent writers.

## Known limitation

This closes the caller-side interruption and cancellation window: once the finalize hop starts, cancellation cannot skip the ownership write.

It does **not** make item creation and ownership one SQLite transaction. Items are committed individually by `store.add_item` well before the hop, and the ownership write is its own statement inside it, so a hard process termination, a storage failure, or a failure of the ownership write itself after the items have committed can still leave residue — and by then the superseded group may already have been deleted. Removing that boundary needs the atomic-write redesign described above, which is out of scope here.

## Verification

Windows 11 / py3.10.6.

- New file: **11 passed**; **6 failed / 5 passed** on pristine `origin/main` with the identical file.
- Adjacent suites (`test_knowledge_agent_source`, `test_knowledge`, `test_folder_watcher`, `test_knowledge_artifact_ingest`, `test_knowledge_dedup`, `test_knowledge_add_source`, `test_artifact_import_parity`, `test_mcp_knowledge_add_document`): **base 2F/370P/6s, branch 2F/370P/6s** — identical selection, identical failing nodes (`os.symlink` → `WinError 1314`, needs elevation on this host). Zero delta.
- `flake8`, `isort --check-only`, `mypy --platform linux`, `docs-lint`, brand gate, `git diff --check` all clean.

Spec updated in the same commit (`docs/system-specs/modules/knowledge.md`).


