### PR TITLE
fix: venv-first interpreter resolution for stdio MCP servers (#1807)

### DIFF
--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -30,6 +30,29 @@ The app manifest (`app.json`) declares your app's identity, resources, and requi
 | `sops` | string[] | Paths to SOP (Standard Operating Procedure) files |
 | `mcpServers` | object | MCP server definitions (same format as `mcp.json`) |
 
+### How a stdio `command` is resolved at registration
+
+A stdio entry's `command` (no `url`) is not always written verbatim — registration
+resolves it so the server starts under the interpreter its dependencies were
+installed against:
+
+- **A bare Python launcher** (`python`, `python3`, `py`, or the same with `.exe`)
+  resolves to the app's own venv interpreter (`.venv/bin/python3`, or
+  `.venv\Scripts\python.exe` on Windows) when it exists as a runnable file, else
+  to the gateway's own interpreter — never a PATH lookup. Exception: a server
+  whose `args` launch a `kiro_crew` module (`-m kiro_crew...`) always gets the
+  gateway's interpreter, since app venvs cannot import `kiro_crew`.
+- **Any other bare name** (no path separator, no drive qualifier) is rewritten
+  only when the app's venv provides that exact binary as a runnable file (a pip
+  console script — invisible to PATH because the venv is never activated). Note
+  this means a venv-provided binary shadows a same-named PATH dependency.
+  `node`, `npx`, `docker` and friends are otherwise left for PATH, as declared.
+- **A command carrying a path** (absolute or relative) is never rewritten. If it
+  does not point at a runnable file at registration time, a warning naming the
+  app, server, and command is logged — the entry is still written.
+- The host CLI name `kirocrew` is pinned to the running gateway before any of
+  the above applies.
+
 ## Scheduling
 
 ### `crons` — Cron Job Definitions

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -28,6 +28,7 @@ from kiro_crew.apps.execution import (
     shipped_builtin_app_root,
     shipped_builtin_module_path,
 )
+from kiro_crew.apps.interpreter import resolve_app_python, venv_python_path
 from kiro_crew.apps.manager import app_dir, get_app_manifest, list_apps
 from kiro_crew.apps.registry import minimal_env
 from kiro_crew.atomic_write import atomic_write
@@ -691,8 +692,11 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
         _env = minimal_env()  # don't leak secrets to pip/venv subprocesses
         try:
             if not venv_dir.exists():
+                # sys.executable, never a bare "python3": the bare name relies on
+                # PATH (absent on some hosts, a Store stub on Windows) — the same
+                # policy every app spawn path applies via apps/interpreter.
                 venv_cmd, _ = wrap_argv(
-                    ["python3", "-m", "venv", str(venv_dir)], mode="standard"
+                    [sys.executable, "-m", "venv", str(venv_dir)], mode="standard"
                 )
                 venv_cmd = cgroup_scope_argv(venv_cmd)  # cgroup DoS ceiling
                 subprocess.run(
@@ -700,10 +704,15 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                     check=True, capture_output=True, timeout=60, env=_env,
                     preexec_fn=resource_limit_preexec(),
                 )
-            pip_bin = str(venv_dir / "bin" / "pip")
+            # Invoke pip through the venv's own interpreter: `.venv/bin/pip` is
+            # POSIX-only (Windows venvs ship Scripts\), and `<venv python> -m pip`
+            # is the layout-independent spelling. Without it a Windows venv is
+            # created but never provisioned — and would then be preferred by the
+            # venv-first interpreter policy while holding none of the app's deps.
+            venv_python = str(venv_python_path(root))
             pip_cmd, _ = wrap_argv(
-                [pip_bin, "install", "--quiet", "--disable-pip-version-check",
-                 "-r", str(req_file)], mode="standard"
+                [venv_python, "-m", "pip", "install", "--quiet",
+                 "--disable-pip-version-check", "-r", str(req_file)], mode="standard"
             )
             pip_cmd = cgroup_scope_argv(pip_cmd)  # cgroup DoS ceiling
             subprocess.run(
@@ -869,13 +878,13 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
     elif backend_type == "asgi" or (
         not backend_type and _is_asgi_entry(entry)
     ):
-        venv_python = str(root / ".venv" / "bin" / "python3")
-        # Fall back to the gateway's own interpreter (sys.executable) rather than a bare
-        # "python3": a bare name relies on PATH, which isn't guaranteed (e.g. some
-        # build environments ship only a versioned interpreter, so execvp("python3") raises
-        # FileNotFoundError and the backend dies immediately). Matches the module-style
-        # branch above.
-        python_bin = venv_python if (root / ".venv" / "bin" / "python3").is_file() else sys.executable
+        # Prefer the app's venv interpreter, else the gateway's own (sys.executable) —
+        # never a bare "python3": a bare name relies on PATH, which isn't guaranteed
+        # (e.g. some build environments ship only a versioned interpreter, so
+        # execvp("python3") raises FileNotFoundError and the backend dies immediately).
+        # One policy shared with the stdio MCP registration path — see
+        # kiro_crew.apps.interpreter.
+        python_bin = resolve_app_python(root)
         # Derive the module path for uvicorn (e.g. backend.app:app)
         rel = entry.relative_to(root)
         parts = list(rel.parts)
@@ -895,10 +904,9 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
 
     # --- Plain Python backend (default) ---
     else:
-        venv_python = str(root / ".venv" / "bin" / "python3")
-        # See the ASGI branch: prefer the venv python, else the gateway's own interpreter
-        # (sys.executable) — a bare "python3" relies on PATH and isn't always present.
-        python_bin = venv_python if (root / ".venv" / "bin" / "python3").is_file() else sys.executable
+        # See the ASGI branch: venv python first, else the gateway's own interpreter —
+        # one policy shared with the stdio MCP registration path.
+        python_bin = resolve_app_python(root)
         cmd = [python_bin, entry_str]
         cwd = str(root)
 

--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -11,6 +11,7 @@ between apps.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -29,6 +30,7 @@ from kiro_crew.apps.execution import (
     app_execution_denied,
     shipped_builtin_app_root,
 )
+from kiro_crew.apps.interpreter import resolve_app_python, venv_provided_command
 from kiro_crew.apps.manager import (
     app_data_dir,
     app_dir,
@@ -46,6 +48,7 @@ from kiro_crew.config.loader import (
 from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.cron import CronStoreBusy
 from kiro_crew.cron_script import resolve_script_path
+from kiro_crew.executors import maintenance_executor
 from kiro_crew.platform.governance import may_skip_gate_now, strip_ungoverned_auto_approve
 from kiro_crew.sel import sel
 
@@ -502,7 +505,6 @@ def _pin_host_cli_command(app_name: str, cfg: dict[str, Any]) -> dict[str, Any]:
     """
     if cfg.get("command") != _HOST_CLI_COMMAND:
         return cfg
-    import sys
 
     pkg_parent = str(Path(kiro_crew_file()).parent.parent)
     env = dict(cfg.get("env") or {})
@@ -1760,13 +1762,15 @@ def _live_port_for(app_name: str, live_port: int | None) -> int | None:
         return None
 
 
-#: Bare python launchers an app manifest may name. Each is substituted with the RUNNING
-#: interpreter, which is the only one guaranteed to import ``kiro_crew``.
+#: Bare python launchers an app manifest may name. Each is substituted with a resolved
+#: absolute interpreter — the app's own venv python when it exists (the interpreter its
+#: dependencies were installed against), else the RUNNING interpreter, which is the only
+#: one guaranteed to import ``kiro_crew``.
 _BARE_PYTHON = frozenset({"python", "python3", "py"})
 
 
-def resolve_stdio_command(cfg: dict) -> dict:
-    """Resolve a bare ``python``/``python3`` MCP command to the running interpreter.
+def resolve_stdio_command(cfg: dict, app_root: Path | None = None) -> dict:
+    """Resolve a bare stdio MCP ``command`` to an absolute path, venv first.
 
     A manifest that hard-codes ``python3`` does not launch on a native Windows install (a venv
     there ships ``python.exe`` and no ``python3.exe``), so the spawn fails with ENOENT and the
@@ -1777,13 +1781,189 @@ def resolve_stdio_command(cfg: dict) -> dict:
     ``kiro_crew`` at all. ``mcp_gateway/rewriter.py`` bakes ``sys.executable`` into its stub
     entry for exactly that reason; this is the same decision for app manifests.
 
-    Only a BARE launcher is substituted. An absolute path, ``node``, ``docker`` or anything
-    else was chosen deliberately and is left untouched, as is an HTTP entry (no ``command``).
+    With ``app_root``, the resolution matches what the app's BACKEND launcher already does
+    (see :mod:`kiro_crew.apps.interpreter`): prefer the app's own venv interpreter — that is
+    where its ``requirements.txt`` was installed, so anything else risks starting the server
+    under an interpreter missing the app's dependencies — else fall back to the gateway's
+    ``sys.executable``. The two spawn paths share one policy on purpose; a second divergent
+    copy is the defect this shape removes.
+
+    The rewrite rule, precisely: only a BARE name (no path separator) is ever touched, and
+    then only when it is a known python launcher OR the app's venv provides that exact
+    binary (a venv console script — invisible to PATH because the venv is never activated).
+    An absolute path, a command carrying a path, or a bare PATH dependency the venv does not
+    provide (``node``, ``npx``, ``docker``) was chosen deliberately and is left untouched, as
+    is an HTTP entry (no ``command``). Getting this predicate wrong breaks working apps, so
+    the boundary is pinned by tests on both sides.
     """
     command = cfg.get("command")
-    if isinstance(command, str) and command.strip().lower() in _BARE_PYTHON:
-        cfg["command"] = sys.executable
+    if not isinstance(command, str):
+        return cfg
+    name = command.strip()
+    if (
+        not name
+        or os.sep in name
+        or (os.altsep is not None and os.altsep in name)
+        or os.path.splitdrive(name)[0]
+    ):
+        # Carries a path (or, on Windows, a drive qualifier like ``D:foo``,
+        # which pathlib would treat as a new anchor and silently discard the
+        # venv prefix in the join below) — deliberate, never rewritten.
+        return cfg
+    # ``python.exe`` / ``python3.exe`` are ordinary Windows spellings of the
+    # same launchers; normalise the suffix so they get the interpreter policy
+    # (venv-first, sys.executable fallback) instead of the console-script probe.
+    base = name.lower()
+    if base.endswith(".exe"):
+        base = base[:-4]
+    if base in _BARE_PYTHON:
+        if _targets_gateway_module(cfg):
+            # The server runs Kiro Crew's OWN code (``-m kiro_crew...``). App
+            # venvs are created WITHOUT --system-site-packages, so kiro_crew is
+            # not importable there and the venv interpreter would die on
+            # import; and even a venv that pip-installed its own kiro_crew is a
+            # version-skewed foreign copy the gateway must not execute. Gateway
+            # code runs provably under the gateway's interpreter — the same
+            # decision _pin_host_cli_command makes for the host CLI.
+            cfg["command"] = sys.executable
+        else:
+            cfg["command"] = resolve_app_python(app_root)
+            # The one remaining silent-death path: a script-entry server that
+            # imports gateway-env packages flips to the venv interpreter the
+            # moment a venv materialises and dies on import with no warning
+            # (the rewritten path exists). Make the chosen interpreter
+            # greppable so that diagnosis starts from a log line.
+            logger.debug(
+                "stdio MCP command %r resolved to interpreter %s", name, cfg["command"]
+            )
+    elif app_root is not None:
+        venv_cmd = venv_provided_command(app_root, name)
+        if venv_cmd is not None:
+            cfg["command"] = venv_cmd
     return cfg
+
+
+#: CPython interpreter options that consume the NEXT argv element as their
+#: value. Everything else the interpreter accepts is either a self-contained
+#: flag (-s, -u, -O, ...) or attaches its value in the same token (-Wignore,
+#: -Xdev). Kept as an explicit table so the scanner's skip logic is checkable
+#: against `python --help` rather than inferred per finding.
+_PY_OPTS_WITH_SEPARATE_VALUE = frozenset({"-X", "-W", "--check-hash-based-pycs"})
+
+
+def _targets_gateway_module(cfg: dict) -> bool:
+    """True when a python stdio entry launches a ``kiro_crew``-owned module.
+
+    Scans only the INTERPRETER-OPTION prefix of ``args``, mirroring CPython's
+    own argv parsing. The full branch table (each row is pinned by a test):
+
+    - ``-m`` (separate): the next element is the module — answer on it.
+    - ``-mMODULE`` (attached): CPython accepts the attached spelling too.
+    - ``-c`` / ``-cPROGRAM`` / ``--``: option parsing ends; nothing after is
+      an interpreter option, and no module launch is involved.
+    - a non-dash token: the script operand — everything after belongs to the
+      SCRIPT (``python3 server.py -m kiro_crew.mode``), never to CPython.
+    - ``-X``/``-W``/``--check-hash-based-pycs`` (separate form): consume TWO
+      tokens, so their value is never mistaken for the script operand.
+    - any other dash token: a value-less flag or an attached-value option —
+      consume one token.
+
+    Out of scope, conservatively: single-letter clustering that ends in ``m``
+    (``-sm kiro_crew``) reads here as an unknown flag followed by an operand
+    and answers False — the venv-first default applies. No manifest uses that
+    spelling; documenting the boundary beats guessing at getopt semantics.
+    """
+    args = cfg.get("args")
+    if not isinstance(args, list):
+        return False
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if not isinstance(arg, str):
+            return False
+        if arg == "-m":
+            if i + 1 < len(args):
+                module = args[i + 1]
+                return isinstance(module, str) and (
+                    module == "kiro_crew" or module.startswith("kiro_crew.")
+                )
+            return False
+        if arg.startswith("-m") and len(arg) > 2:
+            module = arg[2:]
+            return module == "kiro_crew" or module.startswith("kiro_crew.")
+        if arg == "--" or arg.startswith("-c") or not arg.startswith("-"):
+            return False
+        if arg in _PY_OPTS_WITH_SEPARATE_VALUE:
+            i += 2
+            continue
+        i += 1
+    return False
+
+
+def _warn_unresolvable_stdio_command(app_name: str, server_name: str, cfg: dict) -> None:
+    """Surface a stdio server whose command cannot spawn, instead of silent tool absence.
+
+    The failure mode this closes: kiro-cli spawns each registered server itself and reports
+    nothing when the spawn fails — the app's tools simply never appear. Emit one warning at
+    registration time naming the app, the server, and the command, so the operator has a log
+    line to find. Never raises: one bad server must not take down the whole registration
+    pass, and the entry is still written.
+
+    Deliberately checks only a command that CARRIES a path (one ``stat``). A bare name is
+    not probed: PATH at spawn time is not the gateway's PATH (kiro-cli strips env), a
+    legitimate binary may be installed later (``onEnable``) or live in app-local trees like
+    ``node_modules/.bin``, and walking PATH with ``shutil.which`` would multiply the stats.
+
+    Even the single stat can block in the kernel on a dead network mount, so the caller
+    (:func:`_schedule_unresolvable_warning`) runs this OFF the event loop whenever one is
+    running — the diagnostic is advisory and gates nothing, so it never needs to hold up
+    registration.
+    """
+    command = cfg.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return
+    name = command.strip()
+    has_sep = (
+        os.sep in name
+        or (os.altsep is not None and os.altsep in name)
+        or bool(os.path.splitdrive(name)[0])
+    )
+    if not has_sep:
+        return
+    if not platform_compat.is_executable_file(name):
+        logger.warning(
+            "App %s: stdio MCP server %r declares command %r which resolves to no "
+            "existing executable — the server will likely fail to spawn and its tools "
+            "will be silently unavailable",
+            app_name,
+            server_name,
+            command,
+        )
+
+
+def _schedule_unresolvable_warning(app_name: str, server_name: str, cfg: dict) -> None:
+    """Run the unresolvable-command probe without ever blocking the event loop.
+
+    ``_register_mcp_servers`` is a sync function reachable from async dashboard
+    handlers, so its thread MAY be the loop thread: a ``stat`` on a dead
+    network-mounted path there would freeze every task until the stall watchdog
+    kills the gateway. When a loop is running, hand the probe (with a snapshot
+    of the entry — registration mutates ``cfg`` after this point) to the
+    maintenance pool; the log line is the only output, so fire-and-forget is
+    the whole contract. With no loop (CLI, tests, worker threads), probe inline.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        _warn_unresolvable_stdio_command(app_name, server_name, cfg)
+        return
+    loop.run_in_executor(
+        maintenance_executor(),
+        _warn_unresolvable_stdio_command,
+        app_name,
+        server_name,
+        dict(cfg),
+    )
 
 
 def _register_mcp_servers(
@@ -1838,9 +2018,13 @@ def _register_mcp_servers(
                 cfg["url"] = _resolve_live_mcp_url(app_name, cfg["url"], live_port=resolved_port)
                 cfg.pop("disabled", None)  # backend is live — ensure enabled
             else:
-                # A stdio entry: resolve a bare `python`/`python3` to the running
-                # interpreter (see `resolve_stdio_command`).
-                cfg = resolve_stdio_command(cfg) if isinstance(cfg, dict) else cfg
+                # A stdio entry: resolve a bare interpreter to an absolute one — the
+                # app's venv python when present, else the running interpreter (see
+                # `resolve_stdio_command`) — and surface an unresolvable command
+                # instead of letting the tools go silently missing.
+                if isinstance(cfg, dict):
+                    cfg = resolve_stdio_command(cfg, app_root=app_dir(app_name))
+                    _schedule_unresolvable_warning(app_name, server_name, cfg)
             servers[namespaced] = cfg
             registered.append(namespaced)
         # LAST governance pass before this map hits disk. This file IS read by

--- a/src/kiro_crew/apps/interpreter.py
+++ b/src/kiro_crew/apps/interpreter.py
@@ -1,0 +1,96 @@
+"""Shared interpreter resolution for app spawn paths.
+
+One policy, two consumers. The app BACKEND launcher (``backend.py``) and the
+app stdio MCP SERVER registration (``bridges.py``) both spawn Python processes
+on an app's behalf, and both must refuse to trust a bare ``python3``: a bare
+name is resolved through PATH at spawn time, which is not guaranteed to exist
+(some hosts ship only a versioned interpreter, so ``execvp("python3")`` raises
+FileNotFoundError) and, even when present, may be an older system interpreter
+than the one the app's dependencies were installed against — the process then
+starts under the wrong interpreter and dies on import, with nothing surfaced
+to the user.
+
+The policy: prefer the app's OWN venv interpreter (that is where the app's
+``requirements.txt`` was installed, so it is the only interpreter guaranteed
+to carry the app's dependencies), else fall back to the gateway's own
+``sys.executable`` (always an absolute path to a real interpreter). Keeping
+the policy in one place is the point — two divergent copies is exactly the
+defect class this module removes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from kiro_crew import platform_compat
+
+
+def venv_python_path(root: Path) -> Path:
+    """The path where ``root``'s venv interpreter would live (may not exist).
+
+    POSIX venvs ship ``bin/python3``; native-Windows venvs ship
+    ``Scripts\\python.exe`` and no ``python3`` at all (the same layout split
+    ``cli_doctor`` and dev-fleet's ``_venv_python`` already handle).
+    """
+    if platform_compat.IS_WINDOWS:
+        return root / ".venv" / "Scripts" / "python.exe"
+    return root / ".venv" / "bin" / "python3"
+
+
+def _runnable(path: Path) -> bool:
+    """Executable AND non-empty — the resolution-safety predicate.
+
+    ``is_executable_file`` alone is not enough: on Windows it is an
+    extension-allowlist check (there is no execute bit), so a zero-byte
+    ``python.exe`` left by an interrupted copy/restore — the same shape as the
+    Microsoft-Store reparse stub — would be accepted and then fail at spawn
+    time with no diagnostic. An empty file cannot be a working interpreter or
+    console script on any platform, so the size check is applied uniformly.
+    """
+    try:
+        return platform_compat.is_executable_file(path) and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def resolve_app_python(root: Path | None) -> str:
+    """Absolute interpreter for processes spawned on an app's behalf.
+
+    Prefers ``<root>/.venv``'s interpreter when it exists as a runnable,
+    non-empty executable (the app's own dependencies live there), else the
+    gateway's ``sys.executable`` — never a bare PATH-resolved name. The
+    runnability check matters: a venv interpreter that lost its execute bit or
+    was truncated to zero bytes (a partial copy, a restore that dropped
+    content) would turn a working ``sys.executable`` fallback into a
+    guaranteed spawn failure. ``root=None`` means "no app context" and
+    resolves straight to ``sys.executable``.
+    """
+    if root is not None:
+        venv_py = venv_python_path(root)
+        if _runnable(venv_py):
+            return str(venv_py)
+    return sys.executable
+
+
+def venv_provided_command(root: Path, name: str) -> str | None:
+    """Absolute path of ``name`` if the app's venv provides it, else ``None``.
+
+    Covers console scripts a venv install creates (``.venv/bin/<name>`` on
+    POSIX, ``.venv\\Scripts\\<name>.exe`` on Windows — the ``.exe`` suffix is
+    appended only when ``name`` does not already carry it). Only a runnable
+    venv-provided binary is a safe rewrite target: anything else a manifest
+    names bare (``node``, ``docker``) was a deliberate PATH dependency and must
+    be left alone, and a non-executable venv file (a data artifact, a partial
+    pip install) must not displace a command that would otherwise work.
+
+    Callers must pass a bare NAME (no path separators, no drive qualifier) —
+    the caller-side guard in ``resolve_stdio_command`` enforces that, keeping
+    the join below inside the venv directory.
+    """
+    if platform_compat.IS_WINDOWS:
+        exe_name = name if name.lower().endswith(".exe") else f"{name}.exe"
+        candidate = root / ".venv" / "Scripts" / exe_name
+    else:
+        candidate = root / ".venv" / "bin" / name
+    return str(candidate) if _runnable(candidate) else None

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -975,6 +975,576 @@ class TestMCPRegistration:
 
 
 # ---------------------------------------------------------------------------
+# Stdio interpreter resolution (one policy shared with the backend launcher)
+# ---------------------------------------------------------------------------
+
+
+def _fake_venv_python(app_root: Path) -> Path:
+    """Create a runnable venv interpreter at the platform's expected location.
+
+    Non-empty and executable on purpose: the resolver rejects zero-byte files
+    (the Microsoft-Store-stub / interrupted-copy shape) and files without the
+    execute bit.
+    """
+    if platform_compat.IS_WINDOWS:
+        py = app_root / ".venv" / "Scripts" / "python.exe"
+    else:
+        py = app_root / ".venv" / "bin" / "python3"
+    py.parent.mkdir(parents=True, exist_ok=True)
+    py.write_text("#!/bin/sh\n")
+    py.chmod(0o755)
+    return py
+
+
+class TestStdioInterpreterResolution:
+    """The stdio MCP registration path must apply the SAME interpreter policy as the
+    app backend launcher: the app's own venv interpreter first (that is where its
+    requirements were installed), else the gateway's ``sys.executable`` — never a bare
+    PATH-resolved name. The rewrite predicate is deliberately narrow; both sides of
+    the boundary are pinned here because getting it wrong breaks working apps."""
+
+    def _register_stdio(self, tmp_path, app_env, monkeypatch, server_cfg, *, setup=None):
+        """Install an app with one stdio server and return its written entry.
+
+        ``setup(app_root)`` runs AFTER install (install_app removes a
+        pre-existing dest dir, so a venv must be created post-install).
+        """
+        import kiro_crew.apps.bridges as bmod
+
+        mcp_path = tmp_path / "mcp.json"
+        monkeypatch.setattr(bmod, "_mcp_json_path", lambda: mcp_path)
+        src = _make_app_source(tmp_path, mcpServers={"srv": server_cfg})
+        install_app(src)
+        if setup is not None:
+            setup(app_env["home"] / "apps" / "test-app")
+        manifest = AppManifest.from_json_file(
+            app_env["home"] / "apps" / "test-app" / APP_MANIFEST_FILENAME
+        )
+        registered = _register_mcp_servers("test-app", manifest)
+        assert registered == ["test-app:srv"]
+        data = json.loads(mcp_path.read_text(encoding="utf-8"))
+        return data["mcpServers"]["test-app:srv"]
+
+    def test_bare_python_resolves_to_the_app_venv_interpreter(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        import sys
+
+        created: list[Path] = []
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"command": "python3", "args": ["-m", "myapp.server"]},
+            setup=lambda root: created.append(_fake_venv_python(root)),
+        )
+        assert entry["command"] == str(created[0])
+        assert entry["command"] != sys.executable
+        # args survive untouched — the module path is what makes it the app's server.
+        assert entry["args"] == ["-m", "myapp.server"]
+
+    def test_bare_python_falls_back_to_sys_executable_without_a_venv(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        import sys
+
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"command": "python3", "args": ["-m", "myapp.server"]},
+        )
+        assert entry["command"] == sys.executable
+
+    def test_an_absolute_command_is_never_rewritten(self, tmp_path, app_env, monkeypatch):
+        # Even with a venv present: an explicit path was a deliberate choice.
+        cmd = "C:\\tools\\srv.exe" if platform_compat.IS_WINDOWS else "/usr/local/bin/srv"
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch, {"command": cmd, "args": []},
+            setup=_fake_venv_python,
+        )
+        assert entry["command"] == cmd
+
+    def test_a_bare_path_dependency_the_venv_lacks_is_left_alone(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # `node` is a legitimate PATH dependency; the app's venv does not provide
+        # it, so rewriting would break a working app.
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch, {"command": "node", "args": ["server.js"]},
+            setup=_fake_venv_python,
+        )
+        assert entry["command"] == "node"
+
+    def test_a_path_carrying_command_never_reaches_the_venv_lookup(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # The no-path-separator guard is a security boundary, not a nicety: a
+        # traversal-shaped command (`../data/evil`) must never be joined under
+        # `.venv/bin/` and rewritten to an absolute path outside the venv, even
+        # when the joined target happens to exist.
+        def plant_traversal_target(app_root: Path) -> None:
+            # A real venv layout (bin/ exists), plus a RUNNABLE file OUTSIDE
+            # bin/ that a naive `.venv/bin / <command>` join would reach via
+            # `..` — executable, so the separator guard is the only defence.
+            _fake_venv_python(app_root)
+            target = (app_root / ".venv" / "bin" / ".." / "data" / "evil").resolve()
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("#!/bin/sh\n")
+            target.chmod(0o755)
+
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"command": "../data/evil", "args": []},
+            setup=plant_traversal_target,
+        )
+        assert entry["command"] == "../data/evil"
+
+    def test_a_venv_provided_console_script_is_resolved(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # A console script pip installed into the app venv is invisible to PATH
+        # (the venv is never activated) — resolving it is what makes such a
+        # manifest work at all.
+        created: list[Path] = []
+
+        def make_script(app_root: Path) -> None:
+            if platform_compat.IS_WINDOWS:
+                script = app_root / ".venv" / "Scripts" / "my-mcp-server.exe"
+            else:
+                script = app_root / ".venv" / "bin" / "my-mcp-server"
+            script.parent.mkdir(parents=True, exist_ok=True)
+            script.write_text("#!/bin/sh\n")
+            script.chmod(0o755)
+            created.append(script)
+
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch, {"command": "my-mcp-server", "args": []},
+            setup=make_script,
+        )
+        assert entry["command"] == str(created[0])
+
+    @pytest.mark.skipif(
+        platform_compat.IS_WINDOWS, reason="Windows has no execute bit to drop"
+    )
+    def test_a_non_executable_venv_interpreter_is_not_used(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # A venv python that lost its execute bit (truncated copy, permissions
+        # dropped in transit) must not displace the always-runnable
+        # sys.executable fallback — rewriting to it guarantees EACCES at spawn.
+        import sys
+
+        def make_broken_venv(app_root: Path) -> None:
+            py = _fake_venv_python(app_root)
+            py.chmod(0o644)
+
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch, {"command": "python3", "args": []},
+            setup=make_broken_venv,
+        )
+        assert entry["command"] == sys.executable
+
+    @pytest.mark.skipif(
+        platform_compat.IS_WINDOWS, reason="Windows has no execute bit to drop"
+    )
+    def test_a_non_executable_venv_file_never_displaces_a_path_command(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # A non-runnable venv file with a matching name (a data artifact, a
+        # partial pip install) must not hijack a command PATH would satisfy.
+        def make_data_artifact(app_root: Path) -> None:
+            artifact = app_root / ".venv" / "bin" / "node"
+            artifact.parent.mkdir(parents=True, exist_ok=True)
+            artifact.write_text("not a binary")
+            artifact.chmod(0o644)
+
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch, {"command": "node", "args": ["server.js"]},
+            setup=make_data_artifact,
+        )
+        assert entry["command"] == "node"
+
+    def test_a_gateway_module_server_is_pinned_to_the_gateway_interpreter(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # A stdio server that runs Kiro Crew's OWN code (`-m kiro_crew...`) must
+        # run under the gateway's interpreter even when the app has a venv: app
+        # venvs are created without --system-site-packages, so kiro_crew is not
+        # importable there and the venv interpreter dies on import — silently,
+        # since the rewritten venv path exists and no warning fires.
+        import sys
+
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"command": "python3", "args": ["-s", "-m", "kiro_crew.apps.builtins.x.server"]},
+            setup=_fake_venv_python,
+        )
+        assert entry["command"] == sys.executable
+
+    def test_a_windows_exe_spelling_of_python_gets_the_interpreter_policy(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # `python.exe` is an ordinary Windows spelling of the same launcher; it
+        # must resolve through the interpreter policy, not miss the venv via a
+        # doubled `.exe` probe and fall through to PATH.
+        created: list[Path] = []
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"command": "python.exe", "args": []},
+            setup=lambda root: created.append(_fake_venv_python(root)),
+        )
+        assert entry["command"] == str(created[0])
+
+    @pytest.mark.skipif(
+        not platform_compat.IS_WINDOWS,
+        reason="drive-qualified names are a Windows path form",
+    )
+    def test_a_drive_qualified_command_is_never_rewritten(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # `D:foo` carries no separator but names a different drive; joining it
+        # under `.venv\Scripts` would DISCARD the venv anchor (pathlib treats
+        # the right operand as a new anchor), so the guard must reject it.
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch, {"command": "D:foo", "args": []},
+            setup=_fake_venv_python,
+        )
+        assert entry["command"] == "D:foo"
+
+    def test_a_zero_byte_venv_interpreter_is_not_used(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # The interrupted-copy / Store-stub shape: a zero-byte python.exe
+        # passes the Windows extension check (there is no execute bit), so the
+        # resolver must reject empty files on every platform.
+        import sys
+
+        def make_stub_venv(app_root: Path) -> None:
+            py = _fake_venv_python(app_root)
+            py.write_text("")  # truncate to zero bytes, still chmod +x
+
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch, {"command": "python3", "args": []},
+            setup=make_stub_venv,
+        )
+        assert entry["command"] == sys.executable
+
+    def test_a_script_argument_named_dash_m_does_not_trigger_the_gateway_pin(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # `python3 server.py -m kiro_crew.mode`: the -m belongs to the SCRIPT
+        # (CPython stops parsing its own options at the first operand), so the
+        # entry must resolve venv-first — pinning it to sys.executable would
+        # strand a venv-dependent server without its dependencies.
+        created: list[Path] = []
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"command": "python3", "args": ["server.py", "-m", "kiro_crew.mode"]},
+            setup=lambda root: created.append(_fake_venv_python(root)),
+        )
+        assert entry["command"] == str(created[0])
+
+    def test_interpreter_options_before_dash_m_still_trigger_the_pin(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        import sys
+
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"command": "python3", "args": ["-s", "-u", "-m", "kiro_crew.apps.x"]},
+            setup=_fake_venv_python,
+        )
+        assert entry["command"] == sys.executable
+
+    def test_separate_value_options_do_not_break_the_pin_scan(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # -X / -W / --check-hash-based-pycs consume the NEXT token as a value;
+        # the scanner must skip that value instead of reading it as the script
+        # operand and missing the -m that follows.
+        import sys
+
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"command": "python3",
+             "args": ["-X", "dev", "-W", "ignore", "-m", "kiro_crew.apps.x"]},
+            setup=_fake_venv_python,
+        )
+        assert entry["command"] == sys.executable
+
+    def test_an_attached_module_spelling_triggers_the_pin(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # CPython accepts -mMODULE in one token.
+        import sys
+
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"command": "python3", "args": ["-mkiro_crew.apps.x"]},
+            setup=_fake_venv_python,
+        )
+        assert entry["command"] == sys.executable
+
+    def test_a_dash_c_program_never_triggers_the_pin(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # -c consumes the rest as an inline program; an -m after it belongs to
+        # that program's argv, not to CPython. The attached spelling
+        # (-cPROGRAM) followed directly by dash tokens is the case where only
+        # the -c stop prevents a wrong pin — the following token is not a
+        # non-dash operand, so no other branch would halt the scan.
+        created: list[Path] = []
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"command": "python3",
+             "args": ["-cimport server", "-m", "kiro_crew.x"]},
+            setup=lambda root: created.append(_fake_venv_python(root)),
+        )
+        assert entry["command"] == str(created[0])
+
+    def test_an_option_value_that_looks_like_a_script_stays_venv_first(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # `-X importtime server.py`: the scan must not treat `importtime` as
+        # the operand, but `server.py` IS one — no pin, venv-first applies.
+        created: list[Path] = []
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"command": "python3", "args": ["-X", "importtime", "server.py"]},
+            setup=lambda root: created.append(_fake_venv_python(root)),
+        )
+        assert entry["command"] == str(created[0])
+
+    @pytest.mark.skipif(
+        not platform_compat.IS_WINDOWS,
+        reason="drive-qualified names are a Windows path form",
+    )
+    def test_a_missing_drive_qualified_command_logs_the_warning(
+        self, tmp_path, app_env, monkeypatch, caplog
+    ):
+        # `D:missing` carries no separator but names a location; it is never
+        # rewritten AND it must not silently skip the unresolvable diagnostic.
+        with caplog.at_level("WARNING", logger="kiro_crew.apps.bridges"):
+            entry = self._register_stdio(
+                tmp_path, app_env, monkeypatch, {"command": "D:missing", "args": []},
+            )
+        assert entry["command"] == "D:missing"
+        assert "resolves to no existing executable" in caplog.text
+
+    def test_the_host_cli_pin_still_wins(self, tmp_path, app_env, monkeypatch):
+        import sys
+
+        # `kirocrew` is pinned to `sys.executable -m kiro_crew` by
+        # _pin_host_cli_command BEFORE stdio resolution; the venv must not
+        # override that (the host CLI is gateway code, not app code).
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"command": "kirocrew", "args": ["app", "mcp", "test-app"]},
+            setup=_fake_venv_python,
+        )
+        assert entry["command"] == sys.executable
+        assert entry["args"][:3] == ["-s", "-m", "kiro_crew"]
+
+    def test_an_http_entry_is_unaffected(self, tmp_path, app_env, monkeypatch):
+        import kiro_crew.apps.backend as backend_mod
+
+        monkeypatch.setattr(backend_mod, "get_app_backend_port", lambda _n: 9000)
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch, {"url": "http://localhost:9000/mcp"}
+        )
+        assert "command" not in entry
+
+    def test_no_cwd_key_is_emitted_for_stdio_entries(self, tmp_path, app_env, monkeypatch):
+        # kiro-cli's documented local-server schema has no `cwd` property and
+        # (verified empirically against kiro-cli 2.17.0) a `cwd` key is parsed
+        # but IGNORED at spawn time — the server starts in the invocation dir
+        # regardless. Writing a key that claims to set the working directory but
+        # provably does nothing would be a standing lie in the agent config, and
+        # risks a stricter future parser rejecting the whole agent file. Keep
+        # the entry schema-clean until kiro-cli grows real support.
+        entry = self._register_stdio(
+            tmp_path, app_env, monkeypatch, {"command": "python3", "args": []},
+            setup=_fake_venv_python,
+        )
+        assert "cwd" not in entry
+
+    def test_an_unresolvable_path_command_logs_a_warning_and_still_registers(
+        self, tmp_path, app_env, monkeypatch, caplog
+    ):
+        # The missing diagnostic the issue names: kiro-cli reports nothing when a
+        # spawn fails, so registration is the one place a bad command can be
+        # surfaced. Warn — but never raise, and still write the entry. Only a
+        # path-carrying command is probed (one stat): a bare name is not, because
+        # PATH at spawn time is not the gateway's PATH, the binary may be
+        # installed later (onEnable, node_modules/.bin), and walking PATH with
+        # shutil.which from this event-loop-reachable path can block on a
+        # network-mounted PATH entry.
+        missing = str(tmp_path / "definitely" / "not-a-real-binary-1807")
+        with caplog.at_level("WARNING", logger="kiro_crew.apps.bridges"):
+            entry = self._register_stdio(
+                tmp_path, app_env, monkeypatch,
+                {"command": missing, "args": []},
+            )
+        assert entry["command"] == missing
+        warning = "\n".join(
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+        )
+        assert "test-app" in warning
+        assert "srv" in warning
+        # The message renders the command with %r, so Windows backslashes appear
+        # escaped — compare against the repr form, not the raw path.
+        assert repr(missing) in warning
+
+    def test_a_bare_name_is_not_probed_and_logs_no_warning(
+        self, tmp_path, app_env, monkeypatch, caplog
+    ):
+        with caplog.at_level("WARNING", logger="kiro_crew.apps.bridges"):
+            entry = self._register_stdio(
+                tmp_path, app_env, monkeypatch,
+                {"command": "definitely-not-a-real-binary-1807", "args": []},
+            )
+        assert entry["command"] == "definitely-not-a-real-binary-1807"
+        assert "resolves to no existing executable" not in caplog.text
+
+    def test_the_probe_is_offloaded_when_an_event_loop_is_running(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # The probe stats a caller-supplied path, which can block in the
+        # kernel on a dead network mount; on the loop thread that freezes
+        # every task until the stall watchdog kills the gateway. With a
+        # running loop the probe must go to the maintenance pool; with none
+        # (this test's own direct call) it runs inline.
+        import kiro_crew.apps.bridges as bmod
+
+        dispatched: list[tuple] = []
+
+        class _FakeLoop:
+            def run_in_executor(self, executor, fn, *args):
+                dispatched.append((executor, fn, args))
+
+        monkeypatch.setattr(
+            bmod.asyncio, "get_running_loop", lambda: _FakeLoop()
+        )
+        cfg = {"command": str(tmp_path / "nope" / "bin"), "args": []}
+        bmod._schedule_unresolvable_warning("app", "srv", cfg)
+        assert len(dispatched) == 1
+        _, fn, args = dispatched[0]
+        assert fn is bmod._warn_unresolvable_stdio_command
+        # The entry is snapshotted: registration mutates cfg after scheduling.
+        assert args[2] is not cfg and args[2] == cfg
+
+        # No loop -> inline (RuntimeError path).
+        monkeypatch.setattr(
+            bmod.asyncio, "get_running_loop",
+            lambda: (_ for _ in ()).throw(RuntimeError("no loop")),
+        )
+        dispatched.clear()
+        bmod._schedule_unresolvable_warning("app", "srv", cfg)
+        assert dispatched == []
+
+    def test_a_resolvable_command_logs_no_unresolvable_warning(
+        self, tmp_path, app_env, monkeypatch, caplog
+    ):
+        with caplog.at_level("WARNING", logger="kiro_crew.apps.bridges"):
+            self._register_stdio(
+                tmp_path, app_env, monkeypatch, {"command": "python3", "args": []},
+                setup=_fake_venv_python,
+            )
+        assert "resolves to no existing executable" not in caplog.text
+
+    def test_one_bad_server_does_not_block_its_siblings(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        import kiro_crew.apps.bridges as bmod
+
+        mcp_path = tmp_path / "mcp.json"
+        monkeypatch.setattr(bmod, "_mcp_json_path", lambda: mcp_path)
+        src = _make_app_source(
+            tmp_path,
+            mcpServers={
+                "bad": {"command": "definitely-not-a-real-binary-1807", "args": []},
+                "good": {"command": "python3", "args": ["-m", "x"]},
+            },
+        )
+        install_app(src)
+        manifest = AppManifest.from_json_file(
+            app_env["home"] / "apps" / "test-app" / APP_MANIFEST_FILENAME
+        )
+        registered = _register_mcp_servers("test-app", manifest)
+        assert sorted(registered) == ["test-app:bad", "test-app:good"]
+
+
+class TestBackendSharesTheInterpreterPolicy:
+    """The backend launcher and the stdio MCP registration must keep answering
+    identically — two divergent interpreter policies is the defect #1807 names.
+    These pin the shared helper to the backend's historical behaviour, so a
+    change to the helper's answer fails here rather than shipping a silent
+    policy fork."""
+
+    def test_venv_present_resolves_to_the_venv_interpreter(self, tmp_path):
+        from kiro_crew.apps.interpreter import resolve_app_python
+
+        venv_py = _fake_venv_python(tmp_path)
+        assert resolve_app_python(tmp_path) == str(venv_py)
+
+    def test_venv_absent_resolves_to_sys_executable(self, tmp_path):
+        import sys
+
+        from kiro_crew.apps.interpreter import resolve_app_python
+
+        assert resolve_app_python(tmp_path) == sys.executable
+
+    def test_no_app_context_resolves_to_sys_executable(self):
+        import sys
+
+        from kiro_crew.apps.interpreter import resolve_app_python
+
+        assert resolve_app_python(None) == sys.executable
+
+    @pytest.mark.skipif(
+        platform_compat.IS_WINDOWS, reason="pins the backend's historical POSIX layout"
+    )
+    def test_helper_matches_the_backend_historical_posix_policy(self, tmp_path):
+        # Literal reconstruction of the resolution backend.py carried inline
+        # before the extraction, checked on the two normal shapes (runnable
+        # venv interpreter present / no venv). One deliberate divergence is
+        # out of scope here and pinned by its own test: a venv python that
+        # exists but is NOT executable now falls back to sys.executable
+        # instead of being returned as a guaranteed-EACCES spawn target.
+        import sys
+
+        from kiro_crew.apps.interpreter import resolve_app_python
+
+        def historical(root: Path) -> str:
+            venv_python = str(root / ".venv" / "bin" / "python3")
+            return (
+                venv_python
+                if (root / ".venv" / "bin" / "python3").is_file()
+                else sys.executable
+            )
+
+        with_venv = tmp_path / "with-venv"
+        _fake_venv_python(with_venv)
+        without_venv = tmp_path / "without-venv"
+        without_venv.mkdir()
+        for root in (with_venv, without_venv):
+            assert resolve_app_python(root) == historical(root)
+
+    def test_the_backend_spawn_uses_the_shared_helper(self):
+        # Wiring check: the extraction is only real if backend.py CALLS the
+        # helper. Grepping the source keeps this honest without spawning.
+        import inspect
+
+        import kiro_crew.apps.backend as backend_mod
+
+        source = inspect.getsource(backend_mod)
+        assert source.count("resolve_app_python(") >= 2, (
+            "backend.py no longer routes both Python branches through the "
+            "shared interpreter helper"
+        )
+        assert '".venv" / "bin" / "python3").is_file()' not in source, (
+            "backend.py grew back an inline copy of the interpreter policy"
+        )
+
+
+# ---------------------------------------------------------------------------
 # MCP property tests
 # ---------------------------------------------------------------------------
 

--- a/test/test_apps_backend_coverage.py
+++ b/test/test_apps_backend_coverage.py
@@ -732,6 +732,32 @@ class TestDependencyInstall:
         assert any("venv" in argv for argv in runs), runs
         assert any("install" in argv for argv in runs), runs
 
+    def test_the_installer_never_shells_out_to_a_bare_interpreter(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Venv creation must use sys.executable and pip must run as
+        `<venv python> -m pip` — `.venv/bin/pip` is POSIX-only and a bare
+        `python3` relies on PATH. Anything else leaves a Windows venv created
+        but never provisioned, which the venv-first interpreter policy would
+        then prefer while it holds none of the app's dependencies."""
+        import sys
+
+        from kiro_crew.apps.interpreter import venv_python_path
+
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_text("requests\n")
+        runs = _record_runs(monkeypatch)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps-argv", _manifest("server.py"))
+        venv_run = " ".join(next(argv for argv in runs if "venv" in argv))
+        assert sys.executable in venv_run, venv_run
+        assert "python3 -m venv" not in venv_run, venv_run
+        pip_run = " ".join(next(argv for argv in runs if "install" in argv))
+        assert str(venv_python_path(spawn_root)) in pip_run, pip_run
+        assert "-m pip" in pip_run, pip_run
+        assert "/bin/pip" not in pip_run.replace("\\", "/"), pip_run
+
     def test_a_failed_dependency_install_does_not_block_the_spawn(
         self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -859,14 +885,24 @@ class TestAsgiDispatch:
     def test_the_app_venv_interpreter_is_preferred_when_present(
         self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        venv_bin = spawn_root / ".venv" / "bin"
-        venv_bin.mkdir(parents=True)
-        (venv_bin / "python3").write_text("")
+        # Real venv layout per platform: POSIX ships bin/python3, native Windows
+        # ships Scripts\python.exe (and no python3). The shared resolver honours
+        # both and requires the file to be runnable, so a permission-stripped
+        # interpreter cannot become a guaranteed-EACCES spawn target.
+        from kiro_crew import platform_compat as _pc
+
+        if _pc.IS_WINDOWS:
+            venv_py = spawn_root / ".venv" / "Scripts" / "python.exe"
+        else:
+            venv_py = spawn_root / ".venv" / "bin" / "python3"
+        venv_py.parent.mkdir(parents=True)
+        venv_py.write_text("#!/bin/sh\n")
+        venv_py.chmod(0o755)
         (spawn_root / "app.py").write_text(self._ASGI_SRC)
         seen = _capture_popen(monkeypatch)
         with pytest.raises(_StopSpawn):
             bmod._start_app_backend_body("asgi-venv", _manifest("app.py"))
-        assert seen["argv"][0] == str(venv_bin / "python3")
+        assert seen["argv"][0] == str(venv_py)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What is the problem?

An app manifest that declares a stdio MCP server with a bare interpreter name (`"command": "python3"`) gets two different interpreter policies depending on how the process is spawned. The app **backend** launcher (`apps/backend.py`) deliberately resolves the app's own `.venv/bin/python3`, falling back to `sys.executable`. The stdio MCP **registration** path (`apps/bridges.py`) resolved a bare launcher only to `sys.executable` — never the app's venv — so a server whose dependencies live in the app venv starts under an interpreter that lacks them and dies on import. And when any stdio command cannot spawn at all, nothing is logged anywhere: the app's tools are simply absent, which makes the diagnosis cost far higher than the defect's severity.

## Why this issue matters to the user

Both failure modes are silent. A user installs an app, the backend works, but the app's MCP tools never appear — no error in the log, no failed check, nothing to search for. The version-skew variant is also order-dependent: the app works on first install (no venv yet) and breaks on a later boot after the venv materialises, with no config change to point at.

## How our fix solves it

Symptom → root cause → change:

- **Root cause 1: two divergent copies of the interpreter policy.** Extracted the backend's resolution into a shared helper, `apps/interpreter.py` (`resolve_app_python`: app venv interpreter first — `.venv/bin/python3`, `.venv\Scripts\python.exe` on Windows — else `sys.executable`). Both the backend's Python branches and the stdio registration path now call it; the backend keeps no inline copy, and a test fails if one grows back.
- **Root cause 2: the stdio path never consulted the venv.** `resolve_stdio_command` now resolves a bare python launcher (including the `python.exe` Windows spelling) through the shared policy, and resolves a bare non-python name only when the app's venv actually provides that binary as a runnable file (a pip console script, invisible to PATH because the venv is never activated). The rewrite predicate is deliberately narrow — anything carrying a path separator or a Windows drive qualifier is never rewritten — and both sides of the boundary are pinned by tests.
- **Gateway-code guard:** a stdio server that runs KiroCrew's own code (`-m kiro_crew...`) is pinned to the gateway's interpreter even when a venv exists, because app venvs are created without `--system-site-packages` and cannot import `kiro_crew`.
- **Root cause 3: no diagnostic.** Registration now logs a warning naming the app, server, and command when a path-carrying command resolves to no runnable executable. It never raises — one bad server cannot block its siblings — and bare names are deliberately not probed (spawn-time PATH is not the gateway's PATH, and a `shutil.which` walk from this event-loop-reachable path could block on a network-mounted PATH entry).
- **Deliberate deviation — no `cwd` key is emitted.** Verified empirically against kiro-cli 2.17.0: a `cwd` key in an `mcpServers` entry is parsed without error but **ignored** at spawn time (probe server started in the invocation directory, not the declared `cwd`), and the documented local-server schema has no such property. Writing a key that provably does nothing would be a standing fiction in the agent config and risks a stricter future parser rejecting the whole agent file. Pinned by a test with the evidence in its comment.

Resolution requires the executable bit (`platform_compat.is_executable_file`), so a permission-stripped venv file can never displace a command that would otherwise work.

## What tests we did

- 20 new tests in `test/test_app_bridges.py`: venv-present / venv-absent / no-context resolution, absolute and path-carrying commands never rewritten, traversal-shaped commands never reach the venv join (with a planted runnable decoy), drive-qualified Windows names rejected, venv console scripts resolved, non-executable venv files never used (interpreter and console-script cases), gateway-module pin, `python.exe` spelling, host-CLI pin precedence, HTTP entries untouched, no `cwd` key emitted, warning fired/suppressed contract, one bad server not blocking siblings, backend/helper parity against a literal reconstruction of the pre-extraction logic, and a wiring check that the backend still routes through the helper.
- **Mutation-checked:** 8 hand-applied mutants (venv preference, separator guard, bare-python branch, venv-command branch, warning, gateway pin, executability check, `.exe` normalisation) — all 8 caught by the new tests.
- Full local gates green: pytest (47,502 passed; all remaining failures proven pre-existing on `origin/main` via same-set comparison), isort, flake8, mypy, brand-name gate, inclusive-language scan.
- Two model-pinned local reviewers (GPT + Opus mirrors of the CI gates) ran pre-push; all 5 legitimate findings fixed and re-verified by a focused verifier (7/7 closed, no new findings).

## Any other suggestions on the work

The working-directory half of the original report (relative script paths in stdio entries) is not fixable through the agent-config surface today because kiro-cli ignores `cwd`; if kiro-cli grows real `cwd` support, emitting the app root becomes a two-line follow-up in `resolve_stdio_command`.

Manual verification: N/A — unit coverage exercises the registration path end-to-end (install → register → written agent-config entry), and the kiro-cli `cwd` behaviour was verified live against kiro-cli 2.17.0.

Closes #1807
