### PR TITLE
fix: offload apps-dir walk and instances-registry writes to threads (#3055)

### DIFF
--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -11,6 +11,7 @@ between apps.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -1557,7 +1558,9 @@ async def reconcile_app_crons_for_execution(cron_service: Any) -> list[str]:
     if cron_service is None:
         return []
 
-    app_infos = list_apps()
+    # list_apps() walks the apps dir (two file reads per app), and this runs on
+    # the gateway boot path — off the loop.
+    app_infos = await asyncio.to_thread(list_apps)
     installed_names = {app_name for app_info in app_infos if (app_name := app_info.get("name", ""))}
     cron_owner_names: set[str] = set()
     for job in cron_service.list_jobs(include_disabled=True):

--- a/src/kiro_crew/apps/hooks_integration.py
+++ b/src/kiro_crew/apps/hooks_integration.py
@@ -11,6 +11,7 @@ lifecycle points. An app that declares no hooks is a no-op.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any
@@ -293,7 +294,9 @@ async def on_gateway_startup(
     if not _lifecycle_dispatcher:
         return
 
-    enabled = [a for a in list_apps() if a.get("enabled")]
+    # list_apps() walks the apps dir (two file reads per app) — off the loop.
+    installed = await asyncio.to_thread(list_apps)
+    enabled = [a for a in installed if a.get("enabled")]
     if not enabled:
         return
 
@@ -377,7 +380,9 @@ async def on_gateway_shutdown() -> None:
     if not _lifecycle_dispatcher:
         return
 
-    enabled = [a for a in list_apps() if a.get("enabled")]
+    # list_apps() walks the apps dir (two file reads per app) — off the loop.
+    installed = await asyncio.to_thread(list_apps)
+    enabled = [a for a in installed if a.get("enabled")]
     apps_with_hooks = [
         a
         for a in enabled

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -1269,23 +1269,22 @@ def list_apps() -> list[dict[str, Any]]:
                 manifest = AppManifest.from_json_file(manifest_path)
                 manifest_data = manifest.to_dict()
                 # For self-managed apps, the app may update its own
-                # app.json without going through update_app().  Sync
-                # the version from the manifest so the dashboard shows
-                # the real version instead of a stale installed.json.
+                # app.json without going through update_app().  Reflect
+                # the manifest version in the RETURNED metadata only, so
+                # the dashboard shows the real version. Deliberately no
+                # write-back here: list_apps() must stay read-only —
+                # callers run it concurrently from worker threads, and a
+                # persisted read-modify-write of installed.json from a
+                # listing would race real mutators (install/enable/
+                # register) and silently overwrite their fields. The
+                # durable repair happens on the single-app paths
+                # (get_app / update_app).
                 if (
                     meta.lifecycle == "app"
                     and manifest.version
                     and manifest.version != meta.version
                 ):
-                    logger.debug(
-                        "Syncing %s version: installed=%s manifest=%s",
-                        meta.name,
-                        meta.version,
-                        manifest.version,
-                    )
                     meta.version = manifest.version
-                    meta.updatedAt = _now_iso()
-                    _write_installed(entry.name, meta)
             except Exception:
                 pass
         app_info: dict[str, Any] = {

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -196,7 +196,10 @@ async def _notify_builtin_service(request: web.Request, name: str) -> str | None
 
 async def handle_list_apps(request: web.Request) -> web.Response:
     """GET /api/apps — list all installed apps."""
-    apps = list_apps()
+    # list_apps() walks the apps dir and reads two files per installed app, and
+    # this endpoint re-runs it on every dashboard refresh — so the walk goes off
+    # the loop (its cost scales with installed app count).
+    apps = await asyncio.to_thread(list_apps)
     # Enrich with backend process status
     procs = {p["app_name"]: p for p in list_app_processes()}
     for app in apps:
@@ -304,7 +307,11 @@ async def handle_publish_providers(request: web.Request) -> web.Response:
     from the former deploy_web app), each with a ``configured`` flag. Built-in
     providers (the internal registry) are registered frontend-side and are not returned here.
     """
-    providers = collect_publish_providers(list_apps())
+    # Both the apps-dir walk (list_apps) and the per-provider configured-state
+    # probe (_provider_is_configured reads each app's persisted config file)
+    # touch disk, so the whole collection runs off the loop — same shape as the
+    # deploy registry read below.
+    providers = await asyncio.to_thread(lambda: collect_publish_providers(list_apps()))
     # Core deploy provider (always present, regardless of any app install state)
     try:
         from kiro_crew.deploy import profiles as _deploy_profiles

--- a/src/kiro_crew/dashboard/handlers_instances.py
+++ b/src/kiro_crew/dashboard/handlers_instances.py
@@ -17,6 +17,7 @@ crosses this boundary, it is never logged, and it never appears in list/status.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -144,7 +145,10 @@ async def api_instances_list(request: web.Request) -> web.Response:
         return denied
     state: DashboardState = request.app["state"]
     reg = _registry(state)
-    items = [_instance_view(state, i) for i in reg.list()]
+    # Registry calls read (and mutations atomically rewrite + fsync)
+    # instances.json under a threading lock a to_thread worker may hold across
+    # its fsync — so every registry touch in these handlers goes off the loop.
+    items = [_instance_view(state, i) for i in await asyncio.to_thread(reg.list)]
     _audit("list", "success")
     return web.json_response(
         {
@@ -168,7 +172,7 @@ async def api_instances_status(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     instance_id = request.match_info["id"]
     reg = _registry(state)
-    if reg.get(instance_id) is None:
+    if await asyncio.to_thread(reg.get, instance_id) is None:
         _audit("status", "denied", request_id=instance_id, error="not found")
         return web.json_response({"error": "not found"}, status=404)
     # Optional on-demand failure diagnosis: ?diagnose=1 runs the ordered probe
@@ -206,7 +210,8 @@ async def api_instances_add(request: web.Request) -> web.Response:
     if not isinstance(body, dict):
         return web.json_response({"error": "body must be an object"}, status=400)
     try:
-        inst = reg.add(
+        inst = await asyncio.to_thread(
+            reg.add,
             name=str(body.get("name", "")),
             ssh_host=str(body.get("ssh_host", "")),
             remote_port=int(body.get("remote_port", 7777)),
@@ -258,7 +263,7 @@ async def api_instances_update(request: web.Request) -> web.Response:
     }
     changes = {k: v for k, v in body.items() if k in allowed}
     try:
-        inst = reg.update(instance_id, **changes)
+        inst = await asyncio.to_thread(lambda: reg.update(instance_id, **changes))
     except InstanceNotFoundError as e:
         _audit("update", "denied", request_id=instance_id, error=str(e))
         return web.json_response({"error": str(e)}, status=404)
@@ -270,7 +275,15 @@ async def api_instances_update(request: web.Request) -> web.Response:
 
 
 async def api_instances_remove(request: web.Request) -> web.Response:
-    """DELETE /api/instances/{id} — remove an instance (disconnects first)."""
+    """DELETE /api/instances/{id} — remove an instance (disconnects first).
+
+    The pre-removal disconnect and the offloaded ``reg.remove`` are separate
+    awaits, so a reconnect landing between them can re-establish a tunnel for
+    the record while it is being deleted. The post-removal disconnect closes
+    that window: once the record is gone, ``connect`` refuses the unknown id,
+    so a final teardown after the successful remove cannot itself be raced —
+    any tunnel it finds is the leftover of a reconnect that slipped in.
+    """
     denied = _guard(request, "remove")
     if denied is not None:
         return denied
@@ -280,10 +293,12 @@ async def api_instances_remove(request: web.Request) -> web.Response:
     mgr = getattr(state, "instances_manager", None)
     if mgr is not None:
         await mgr.disconnect(instance_id)  # tear down any live tunnel first
-    existed = reg.remove(instance_id)
+    existed = await asyncio.to_thread(reg.remove, instance_id)
     if not existed:
         _audit("remove", "denied", request_id=instance_id, error="not found")
         return web.json_response({"error": "not found"}, status=404)
+    if mgr is not None:
+        await mgr.disconnect(instance_id)  # sweep any reconnect that raced the removal
     _audit("remove", "success", request_id=instance_id)
     return web.json_response({"removed": instance_id})
 
@@ -399,7 +414,7 @@ async def api_instances_restart(request: web.Request) -> web.Response:
         return denied
     state: DashboardState = request.app["state"]
     instance_id = request.match_info["id"]
-    if _registry(state).get(instance_id) is None:
+    if await asyncio.to_thread(_registry(state).get, instance_id) is None:
         _audit("restart", "denied", request_id=instance_id, error="not found")
         return web.json_response({"error": "not found"}, status=404)
     mgr = getattr(state, "instances_manager", None)
@@ -433,7 +448,7 @@ async def api_instances_send_session(request: web.Request) -> web.Response:
         return denied
     state: DashboardState = request.app["state"]
     instance_id = request.match_info["id"]
-    inst = _registry(state).get(instance_id)
+    inst = await asyncio.to_thread(_registry(state).get, instance_id)
     if inst is None:
         _audit("send_session", "denied", request_id=instance_id, error="not found")
         return web.json_response({"error": "not found", "code": "instance_not_found"}, status=404)

--- a/src/kiro_crew/instances/registry.py
+++ b/src/kiro_crew/instances/registry.py
@@ -415,15 +415,20 @@ class InstancesRegistry:
             )
             return inst
 
-    def update(self, instance_id: str, **changes: object) -> Instance:
+    def update(
+        self, instance_id: str, *, mark_last_active: bool = False, **changes: object
+    ) -> Instance:
         """Patch fields on an existing instance and return the updated record.
 
         Accepts any of: ``name``, ``ssh_host``, ``remote_port``, ``local_port``,
         ``ttl``, ``remote_bin``, ``connection_method``, ``ssm_target``,
         ``ssm_run_as``,
         ``aws_profile``, ``aws_region``, ``was_connected``. The ``id`` is
-        immutable. Raises :class:`InstanceNotFoundError` /
-        :class:`InvalidInstanceError`.
+        immutable. ``mark_last_active=True`` additionally records the instance
+        as the auto-revive target in the SAME read-modify-write, so callers that
+        need both (a connect persisting its hints) get one atomic file rewrite
+        instead of two — the pair becomes durable together. Raises
+        :class:`InstanceNotFoundError` / :class:`InvalidInstanceError`.
         """
         allowed = {
             "name",
@@ -454,6 +459,8 @@ class InstancesRegistry:
             for key, value in changes.items():
                 setattr(target, key, value)
             target.validate()
+            if mark_last_active:
+                doc.last_active_id = instance_id
             self._write(doc)
             logger.info("Updated instance %s: %s", instance_id, sorted(changes))
             return target

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -53,6 +53,7 @@ import signal
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import Any
 
 import aiohttp
 
@@ -811,6 +812,37 @@ class SshTunnelManager:
         self._token_minted_at: dict[str, float] = {}
         self._token_ttl_secs: dict[str, int] = {}
 
+    async def _persist_hint(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        """Run a registry hint write in a worker thread; return only when it is DONE.
+
+        A cancelled ``await asyncio.to_thread(...)`` abandons only the await —
+        the already-submitted worker thread keeps running, and its
+        read-modify-rewrite of ``instances.json`` can land AFTER the caller's
+        ``async with self._lock`` block has unwound. That late write races the
+        next locked write (e.g. a cancelled connect's ``was_connected=True``
+        overtaking a disconnect's reset and reviving an instance the user
+        disconnected). So on cancellation this helper keeps waiting for the
+        worker to finish, then re-raises the cancellation — the caller's lock
+        is not released until the write has durably completed. Write FAILURES
+        are swallowed: hint persistence is best-effort, matching the
+        pre-offload ``contextlib.suppress(Exception)`` semantics.
+        """
+        task: asyncio.Task[Any] = asyncio.ensure_future(asyncio.to_thread(fn, *args, **kwargs))
+        cancelled: asyncio.CancelledError | None = None
+        while True:
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError as e:
+                if task.done():
+                    raise  # write already completed; propagate the cancel as-is
+                cancelled = e
+                continue  # keep waiting: the worker write is still in flight
+            except Exception:
+                pass  # best-effort hint write
+            break
+        if cancelled is not None:
+            raise cancelled
+
     def _reserved_ports(self) -> set[int]:
         """Ports already taken: live tunnels + local_port set on any instance."""
         reserved: set[int] = {t.status.local_port for t in self._tunnels.values()}
@@ -956,7 +988,7 @@ class SshTunnelManager:
         :meth:`_resolve_transport`.
         """
         async with self._lock:
-            inst = self._registry.get(instance_id)
+            inst = await asyncio.to_thread(self._registry.get, instance_id)
             if inst is None:
                 raise KeyError(f"no instance with id {instance_id!r}")
 
@@ -1048,10 +1080,20 @@ class SshTunnelManager:
             self._store_token(instance_id, token, inst.ttl)
             self._schedule_token_refresh(instance_id)
 
-            # Persist hints: port assignment, was_connected, last-active.
-            with contextlib.suppress(Exception):
-                self._registry.update(instance_id, local_port=local_port, was_connected=True)
-                self._registry.set_last_active(instance_id)
+            # Persist hints: port assignment, was_connected, last-active — ONE
+            # read-modify-rewrite of instances.json (fsync), so the pair is
+            # durable together and the manager lock is held for a single fsync
+            # round-trip. _persist_hint runs it off the loop and does not
+            # return — even under cancellation — until the write completes, so
+            # the lock cannot release while the worker write is still in
+            # flight (a late hint write would race a subsequent disconnect).
+            await self._persist_hint(
+                self._registry.update,
+                instance_id,
+                mark_last_active=True,
+                local_port=local_port,
+                was_connected=True,
+            )
             # A successful (re)connect clears any stale give-up counter so the next
             # unexpected drop gets a full fresh recovery budget instead of tripping
             # the cap immediately.
@@ -1085,12 +1127,18 @@ class SshTunnelManager:
             # Clear the lazy-reconnect hint AND the recorded local port together
             # (one atomic write). local_port must return to the unallocated
             # sentinel so the now-free port is not treated as reserved forever.
-            with contextlib.suppress(Exception):
-                self._registry.update(
-                    instance_id,
-                    was_connected=False,
-                    local_port=_UNALLOCATED_PORT,
-                )
+            # _persist_hint runs the read-modify-rewrite off the loop and does
+            # not return — even if this handler is cancelled (e.g. aiohttp
+            # aborting at shutdown) — until the write completes: the in-memory
+            # teardown above is already done, so abandoning the persisted reset
+            # would leave was_connected=True plus a stale local_port, reviving
+            # an instance the user disconnected and pinning the freed port.
+            await self._persist_hint(
+                self._registry.update,
+                instance_id,
+                was_connected=False,
+                local_port=_UNALLOCATED_PORT,
+            )
             return tunnel is not None
 
     async def shutdown(self) -> None:
@@ -1174,12 +1222,23 @@ class SshTunnelManager:
         return await tunnel.start()
 
     async def _mark_recovered(self, instance_id: str) -> None:
-        """Reset the attempt counter (under lock, iff still tracked) + persist."""
+        """Reset the attempt counter and persist the hint, under lock, iff tracked.
+
+        The persist stays INSIDE the manager lock so write order equals
+        lock-acquisition order: a concurrent :meth:`disconnect`'s
+        ``was_connected=False`` (also written under the lock) can never be
+        overwritten by this recovery write landing late. The tracked-check
+        gates the persist — an instance the user disconnected must not be
+        re-marked auto-reconnectable. ``_persist_hint`` keeps the lock held
+        until the worker write completes even under cancellation; a cancelled
+        bare ``to_thread`` await would NOT stop the already-running thread, so
+        its write could land after the lock released and break the ordering.
+        """
         async with self._lock:
-            if instance_id in self._tunnels:
-                self._recover_attempts[instance_id] = 0
-        with contextlib.suppress(Exception):
-            self._registry.set_was_connected(instance_id, True)
+            if instance_id not in self._tunnels:
+                return
+            self._recover_attempts[instance_id] = 0
+            await self._persist_hint(self._registry.set_was_connected, instance_id, True)
 
     async def _recover(self, instance_id: str) -> None:
         """2-tier self-heal for an unhealthy tunnel (either transport).
@@ -1198,7 +1257,7 @@ class SshTunnelManager:
         """
         # Phase 1 — validate + bump the attempt counter under the lock, then release.
         async with self._lock:
-            inst = self._registry.get(instance_id)
+            inst = await asyncio.to_thread(self._registry.get, instance_id)
             current = self._tunnels.get(instance_id)
             if inst is None or current is None:
                 return  # disconnected / removed while we waited
@@ -1278,7 +1337,7 @@ class SshTunnelManager:
         Runs WITHOUT the manager lock (the probes do network I/O). Returns the
         result dict, or None for an unknown instance.
         """
-        inst = self._registry.get(instance_id)
+        inst = await asyncio.to_thread(self._registry.get, instance_id)
         if inst is None:
             return None
         tunnel = self._tunnels.get(instance_id)
@@ -1314,7 +1373,7 @@ class SshTunnelManager:
         probe detects the drop and self-heals (Stage 2) — no manual reconnect
         needed. Returns ``{ok, message}``.
         """
-        inst = self._registry.get(instance_id)
+        inst = await asyncio.to_thread(self._registry.get, instance_id)
         if inst is None:
             return {"ok": False, "message": "unknown instance"}
         try:
@@ -1622,7 +1681,7 @@ class SshTunnelManager:
         if the instance is still connected (guards a disconnect mid-mint). Uses
         whichever transport the instance is configured for.
         """
-        inst = self._registry.get(instance_id)
+        inst = await asyncio.to_thread(self._registry.get, instance_id)
         if inst is None or instance_id not in self._tunnels:
             return False
         try:

--- a/test/test_apps_instances_loop_offload.py
+++ b/test/test_apps_instances_loop_offload.py
@@ -1,0 +1,405 @@
+"""The apps-dir walk and the instances-registry writes stay off the event loop.
+
+``list_apps()`` walks the apps directory and reads two files per installed app;
+``InstancesRegistry``'s write methods each read then atomically rewrite
+``instances.json`` with an fsync. Neither belongs on the asyncio event loop:
+the loop runs callbacks one at a time, so a synchronous filesystem call inside
+an ``async def`` delays every other task (including the watchdog heartbeat) for
+its duration. These are bounded, latency-class costs — not stall-class — but
+the repo convention is to offload them via ``asyncio.to_thread``.
+
+Two enforcement tiers:
+
+- Behavior tests: drive each async entry point with a recording double and
+  assert the filesystem-touching call executed on a worker thread, not the
+  loop thread. Reverting an offload makes the recorded thread equal the loop
+  thread and fails the test.
+- AST ratchet: no direct (non-offloaded) call of the walk / registry-write
+  functions may appear lexically inside an ``async def`` frame of the owning
+  modules, so a future call site cannot silently regress. A nested ``def`` /
+  ``lambda`` is a separate frame (the offloaded callable itself) and is not
+  scanned, matching the scoping of ``test_no_blocking_call_on_loop.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+import kiro_crew.apps.bridges as bridges_mod
+import kiro_crew.apps.hooks_integration as hooks_mod
+import kiro_crew.apps.routes as routes_mod
+import kiro_crew.dashboard.handlers_instances as handlers_instances_mod
+from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _recorder(record: list[threading.Thread], result: Any = None) -> Callable[..., Any]:
+    """A stand-in that records the thread it runs on and returns *result*."""
+
+    def _fn(*args: Any, **kwargs: Any) -> Any:
+        record.append(threading.current_thread())
+        return result
+
+    return _fn
+
+
+class _RecordingRegistry:
+    """Duck-typed InstancesRegistry double recording the thread of each write."""
+
+    def __init__(self) -> None:
+        self.write_threads: list[threading.Thread] = []
+
+    def list(self) -> list[Any]:
+        return []
+
+    def get(self, instance_id: str) -> Any:
+        return None
+
+    def update(self, instance_id: str, **changes: object) -> Any:
+        self.write_threads.append(threading.current_thread())
+        return SimpleNamespace(id=instance_id)
+
+    def set_last_active(self, instance_id: str) -> None:
+        self.write_threads.append(threading.current_thread())
+
+    def set_was_connected(self, instance_id: str, value: bool) -> None:
+        self.write_threads.append(threading.current_thread())
+
+
+# ---------------------------------------------------------------------------
+# Behavior: the walk / write happens on a worker thread, not the loop thread
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_list_apps_walks_off_the_loop_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET /api/apps must not run the apps-dir walk on the loop thread."""
+    loop_thread = threading.current_thread()
+    walk_threads: list[threading.Thread] = []
+    monkeypatch.setattr(routes_mod, "list_apps", _recorder(walk_threads, result=[]))
+    monkeypatch.setattr(routes_mod, "list_app_processes", lambda: [])
+
+    resp = await routes_mod.handle_list_apps(make_mocked_request("GET", "/api/apps"))
+
+    assert resp.status == 200
+    assert walk_threads, "list_apps was never invoked"
+    assert all(t is not loop_thread for t in walk_threads), (
+        "the apps-dir walk ran synchronously on the event loop thread"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_publish_providers_collects_off_the_loop_thread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The publish-provider collection (walk + per-provider config reads)
+    must not run on the loop thread."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    loop_thread = threading.current_thread()
+    walk_threads: list[threading.Thread] = []
+    monkeypatch.setattr(routes_mod, "list_apps", _recorder(walk_threads, result=[]))
+
+    resp = await routes_mod.handle_publish_providers(
+        make_mocked_request("GET", "/api/publish-providers")
+    )
+
+    assert resp.status == 200
+    assert walk_threads, "list_apps was never invoked"
+    assert all(t is not loop_thread for t in walk_threads), (
+        "the publish-provider collection ran synchronously on the event loop thread"
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_startup_lists_apps_off_the_loop_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loop_thread = threading.current_thread()
+    walk_threads: list[threading.Thread] = []
+    # Truthy dispatcher so the function proceeds past its early return; the
+    # empty app list means it never actually dispatches into it.
+    monkeypatch.setattr(hooks_mod, "_lifecycle_dispatcher", SimpleNamespace())
+    monkeypatch.setattr(hooks_mod, "list_apps", _recorder(walk_threads, result=[]))
+
+    await hooks_mod.on_gateway_startup()
+
+    assert walk_threads, "list_apps was never invoked"
+    assert all(t is not loop_thread for t in walk_threads)
+
+
+@pytest.mark.asyncio
+async def test_gateway_shutdown_lists_apps_off_the_loop_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loop_thread = threading.current_thread()
+    walk_threads: list[threading.Thread] = []
+    monkeypatch.setattr(hooks_mod, "_lifecycle_dispatcher", SimpleNamespace())
+    monkeypatch.setattr(hooks_mod, "list_apps", _recorder(walk_threads, result=[]))
+
+    await hooks_mod.on_gateway_shutdown()
+
+    assert walk_threads, "list_apps was never invoked"
+    assert all(t is not loop_thread for t in walk_threads)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_registry_write_off_the_loop_thread() -> None:
+    """disconnect() persists the port/hint reset even with no live tunnel, and
+    that read-modify-rewrite of instances.json must run on a worker thread."""
+    loop_thread = threading.current_thread()
+    registry = _RecordingRegistry()
+    mgr = SshTunnelManager(registry)  # type: ignore[arg-type]
+
+    existed = await mgr.disconnect("no-such-instance")
+
+    assert existed is False
+    assert registry.write_threads, "the registry cleanup write never happened"
+    assert all(t is not loop_thread for t in registry.write_threads), (
+        "instances.json was rewritten synchronously on the event loop thread"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mark_recovered_registry_write_off_the_loop_thread() -> None:
+    """A tracked instance's recovery hint is persisted, on a worker thread."""
+    loop_thread = threading.current_thread()
+    registry = _RecordingRegistry()
+    mgr = SshTunnelManager(registry)  # type: ignore[arg-type]
+    mgr._tunnels["some-instance"] = SimpleNamespace()  # type: ignore[assignment]
+
+    await mgr._mark_recovered("some-instance")
+
+    assert registry.write_threads, "set_was_connected never happened"
+    assert all(t is not loop_thread for t in registry.write_threads)
+
+
+@pytest.mark.asyncio
+async def test_mark_recovered_skips_the_write_for_an_untracked_instance() -> None:
+    """After a disconnect pops the tunnel, a late recovery must NOT re-mark the
+    instance auto-reconnectable — the persist is gated on still being tracked
+    (and runs under the manager lock, so write order equals lock order)."""
+    registry = _RecordingRegistry()
+    mgr = SshTunnelManager(registry)  # type: ignore[arg-type]
+
+    await mgr._mark_recovered("disconnected-instance")
+
+    assert registry.write_threads == [], (
+        "recovery persisted was_connected=True for an instance no longer tracked"
+    )
+
+
+class _BlockingRegistry(_RecordingRegistry):
+    """Registry double whose write blocks until the test releases it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.release = threading.Event()
+        self.completed = False
+
+    def set_was_connected(self, instance_id: str, value: bool) -> None:
+        self.release.wait(timeout=10)
+        self.completed = True
+        super().set_was_connected(instance_id, value)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_persist_waits_for_the_worker_write() -> None:
+    """Cancelling a caller mid-persist must NOT unwind the frame (and release
+    the manager lock) while the worker write is still running — a cancelled
+    to_thread await does not stop the thread, so an early unwind would let the
+    late write race a subsequent locked write (e.g. a disconnect's reset)."""
+    registry = _BlockingRegistry()
+    mgr = SshTunnelManager(registry)  # type: ignore[arg-type]
+    mgr._tunnels["inst"] = SimpleNamespace()  # type: ignore[assignment]
+
+    task = asyncio.create_task(mgr._mark_recovered("inst"))
+    await asyncio.sleep(0.05)  # the worker write is submitted and blocked
+    task.cancel()
+    await asyncio.sleep(0.05)  # cancellation delivered
+
+    # The frame must still be waiting on the in-flight worker write.
+    assert not task.done(), (
+        "the coroutine unwound (releasing the manager lock) while the worker "
+        "write was still running"
+    )
+    assert mgr._lock.locked(), "the manager lock was released mid-write"
+
+    registry.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert registry.completed, "the worker write did not complete before unwind"
+    assert not mgr._lock.locked()
+
+
+def test_list_apps_is_read_only_under_version_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """list_apps() must not write installed.json back: it now runs concurrently
+    from worker threads, and a persisted read-modify-write from a listing
+    races real mutators (install/enable/register) and silently overwrites
+    their fields. The manifest version is still reflected in the RETURNED
+    metadata (display), just not persisted from this path."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    import json as _json
+
+    from kiro_crew.apps.manager import InstalledApp, _write_installed, apps_dir, list_apps
+
+    app_root = apps_dir() / "drift-app"
+    app_root.mkdir(parents=True)
+    (app_root / "app.json").write_text(
+        _json.dumps({"name": "drift-app", "version": "2.0.0", "description": "d"}),
+        encoding="utf-8",
+    )
+    _write_installed("drift-app", InstalledApp(name="drift-app", version="1.0.0", lifecycle="app"))
+    installed_path = app_root / "installed.json"
+    before = installed_path.read_text(encoding="utf-8")
+
+    rows = list_apps()
+
+    entry = next(a for a in rows if a["name"] == "drift-app")
+    assert entry["version"] == "2.0.0", "manifest version not reflected in the listing"
+    assert installed_path.read_text(encoding="utf-8") == before, (
+        "list_apps() wrote installed.json — the listing must be read-only"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AST ratchet: no direct sync call of the walk / registry writes in async frames
+# ---------------------------------------------------------------------------
+
+# Scopes not descended into from an async def body: a nested function or lambda
+# is a different execution frame (typically the offloaded callable itself).
+_NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+
+
+def _calls_in_async_frames(tree: ast.AST) -> list[tuple[str, ast.Call]]:
+    """All Call nodes lexically inside async def bodies (own frame only)."""
+    found: list[tuple[str, ast.Call]] = []
+
+    def _scan(node: ast.AST, owner: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, _NESTED_SCOPES):
+                continue
+            if isinstance(child, ast.Call):
+                found.append((owner, child))
+            _scan(child, owner)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef):
+            for stmt in node.body:
+                _scan(stmt, node.name)
+    return found
+
+
+def _module_tree(module: Any) -> ast.AST:
+    return ast.parse(inspect.getsource(module))
+
+
+@pytest.mark.parametrize(
+    "module,banned_names",
+    [
+        # _provider_is_configured (not the pure collect_publish_providers) is
+        # the disk-touching primitive behind the publish-provider collection: a
+        # future async call with an injected non-disk resolver must not trip
+        # this gate, while the default resolver's file reads must.
+        (routes_mod, {"list_apps", "_provider_is_configured"}),
+        (hooks_mod, {"list_apps"}),
+        (bridges_mod, {"list_apps"}),
+    ],
+)
+def test_no_direct_apps_walk_in_async_frames(module: Any, banned_names: set[str]) -> None:
+    """The apps-dir walk may not be called directly inside an async frame; it
+    must be handed to asyncio.to_thread as a callable (Name, not Call). Both
+    the bare-name form (``list_apps()``) and the attribute form
+    (``manager.list_apps()``) are matched, so re-importing the function under a
+    module prefix does not evade the gate."""
+    offenders: list[str] = []
+    for owner, call in _calls_in_async_frames(_module_tree(module)):
+        func = call.func
+        name = ""
+        if isinstance(func, ast.Name) and func.id in banned_names:
+            name = func.id
+        elif isinstance(func, ast.Attribute) and func.attr in banned_names:
+            name = func.attr
+        if name:
+            offenders.append(f"{module.__name__}:{owner}:{call.lineno} calls {name}()")
+    assert not offenders, "direct apps-dir walk on the event loop:\n" + "\n".join(offenders)
+
+
+def test_no_direct_registry_write_in_async_frames() -> None:
+    """InstancesRegistry methods (writes are a read + atomic rewrite + fsync of
+    instances.json; reads still block in the registry's threading lock while a
+    worker holds it across an fsync) may not be called directly inside an
+    async frame of the tunnel manager. Sync helpers (e.g. _reserved_ports) are
+    separate frames and stay out of scope."""
+    import kiro_crew.instances.ssh_tunnel_manager as stm_mod
+
+    write_methods = {
+        "update",
+        "set_last_active",
+        "set_was_connected",
+        "remove",
+        "get",
+        "list",
+        "get_last_active",
+    }
+    offenders: list[str] = []
+    for owner, call in _calls_in_async_frames(_module_tree(stm_mod)):
+        func = call.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr in write_methods
+            and isinstance(func.value, ast.Attribute)
+            and func.value.attr == "_registry"
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "self"
+        ):
+            offenders.append(f"{owner}:{call.lineno} calls self._registry.{func.attr}()")
+    assert not offenders, "direct registry write on the event loop:\n" + "\n".join(offenders)
+
+
+def test_no_direct_registry_call_in_instances_handler_async_frames() -> None:
+    """The instances dashboard handlers reach the registry as ``reg.<method>``
+    or ``_registry(state).<method>``; every registry touch there (reads
+    included — a read blocks in the registry's threading lock while a worker
+    holds it across an fsync) must be offloaded, never called directly inside
+    an async frame."""
+    registry_methods = {
+        "list",
+        "get",
+        "get_last_active",
+        "add",
+        "update",
+        "remove",
+        "set_last_active",
+        "set_was_connected",
+    }
+    offenders: list[str] = []
+    for owner, call in _calls_in_async_frames(_module_tree(handlers_instances_mod)):
+        func = call.func
+        if not (isinstance(func, ast.Attribute) and func.attr in registry_methods):
+            continue
+        receiver = func.value
+        is_reg_name = isinstance(receiver, ast.Name) and receiver.id == "reg"
+        is_registry_call = (
+            isinstance(receiver, ast.Call)
+            and isinstance(receiver.func, ast.Name)
+            and receiver.func.id == "_registry"
+        )
+        if is_reg_name or is_registry_call:
+            offenders.append(f"{owner}:{call.lineno} calls registry .{func.attr}() on the loop")
+    assert not offenders, "direct registry call on the event loop:\n" + "\n".join(offenders)

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -833,6 +833,22 @@ class TestRegistry:
         reg.set_last_active("cd-1")
         assert reg.get_last_active().id == "cd-1"
 
+    def test_update_mark_last_active_is_one_mutation(self, tmp_path):
+        """update(mark_last_active=True) records the auto-revive target in the
+        same read-modify-write as the field changes, and plain update leaves
+        the recorded target alone."""
+        reg = self._reg(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1", instance_id="cd-1")
+        reg.add(name="CD2", ssh_host="cd-2", instance_id="cd-2")
+
+        u = reg.update("cd-1", mark_last_active=True, local_port=7778, was_connected=True)
+        assert u.local_port == 7778 and u.was_connected is True
+        assert reg.get_last_active().id == "cd-1"
+
+        # A plain update on another instance does not steal the target.
+        reg.update("cd-2", local_port=7779)
+        assert reg.get_last_active().id == "cd-1"
+
     def test_remove_clears_last_active_and_reload(self, tmp_path):
         reg = self._reg(tmp_path)
         reg.add(name="CD", ssh_host="cd-1", instance_id="cd-1")
@@ -1683,6 +1699,39 @@ class TestHandlers:
             ).status
             == 404
         )
+
+    def test_remove_sweeps_a_reconnect_that_raced_the_removal(self, tmp_path, monkeypatch):
+        """The offloaded reg.remove yields the loop between the pre-removal
+        disconnect and the deletion, so a tab reconnect can re-establish a
+        tunnel for the record mid-delete. A successful removal must disconnect
+        AGAIN afterwards: the record is gone by then, so connect refuses new
+        attempts and the sweep tears down whatever slipped in."""
+        from kiro_crew.dashboard import handlers_instances as handlers
+
+        _enable(tmp_path, monkeypatch)
+        reg = self._reg(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+
+        class _RacingManager:
+            def __init__(self):
+                self.disconnect_calls = 0
+                self.live = False
+
+            async def disconnect(self, instance_id):
+                self.disconnect_calls += 1
+                if self.disconnect_calls == 1:
+                    # A reconnect slips in right after the pre-removal teardown.
+                    self.live = True
+                else:
+                    self.live = False
+                return True
+
+        mgr = _RacingManager()
+        state = _State(reg, manager=mgr)
+        r = asyncio.run(handlers.api_instances_remove(_FakeReq(state, match={"id": "cd-1"})))
+        assert r.status == 200
+        assert mgr.disconnect_calls == 2, "no post-removal teardown sweep ran"
+        assert mgr.live is False, "the racing reconnect's tunnel survived the removal"
 
     def test_connect_503_404_and_502(self, tmp_path, monkeypatch):
         from kiro_crew.dashboard import handlers_instances as handlers


### PR DESCRIPTION
## What is the problem?

`list_apps()` — which walks the apps directory and reads two files per installed app — was called synchronously inside `async def`s at four sites (`apps/routes.py` `handle_list_apps` / `handle_publish_providers`, `apps/hooks_integration.py` `on_gateway_startup` / `on_gateway_shutdown`), plus a fifth uncovered site found in review (`apps/bridges.py` `reconcile_app_crons_for_execution`, on the gateway boot path). The same shape existed for `InstancesRegistry` — each write is a read + atomic rewrite + fsync of `instances.json` — inside `ssh_tunnel_manager.py` (`connect`, `disconnect`, `_mark_recovered`) and in the `/api/instances*` dashboard handlers.

Scope, stated precisely: these are bounded, latency-class costs — they cannot reach the 25s watchdog budget on a healthy local filesystem, and none of the captured loop-stall dumps on the affected host was stalled in these frames. This is loop latency, not a stall cause.

## Why does this issue matter to the user?

The asyncio event loop runs callbacks one at a time, so any synchronous filesystem call inside an `async def` delays every other task — user turns, streaming, the watchdog heartbeat — for its duration. `GET /api/apps` re-runs the walk on every dashboard refresh and its cost scales with installed app count; the registry writes additionally fsync. The repo's convention (`apps/backend.py`, `deploy/handlers.py`, AUTOSDE `no-blocking-call-on-event-loop`) is to offload exactly this kind of work; these sites missed it.

## How does the fix solve it?

Symptom → root cause → change: dashboard/API latency spikes trace to synchronous disk I/O executing on the loop thread; the fix routes every such call through `await asyncio.to_thread(...)`, matching the existing style in the same modules. Review hardening on top of the mechanical offload:

- `connect()` now persists its hints (`local_port`, `was_connected`, last-active) as ONE registry mutation instead of two — `InstancesRegistry.update()` gained a keyword-only `mark_last_active` — so the pair is durable together and the manager lock is held for a single fsync round-trip.
- `disconnect()`'s persisted reset is wrapped in `asyncio.shield`: the offload introduced a cancellation point after the in-memory teardown, and an abandoned write would have left `was_connected=True` plus a stale `local_port` (reviving a disconnected instance and pinning the freed port).
- `_mark_recovered()`'s write now runs inside the manager lock and only while the tunnel is still tracked, so write order equals lock-acquisition order and a late recovery write can never overwrite a concurrent disconnect's `was_connected=False` (a race the naive offload would have introduced).
- **Durable-data semantic change (deliberate):** `list_apps()` no longer writes `installed.json` back when a self-managed app's manifest version drifts — the manifest version is reflected in the RETURNED metadata only (the dashboard still shows the real version), and `installed.json` on disk stays stale until a single-app path (`get_app`/`update_app`) touches that app. A listing that does hidden read-modify-writes cannot run concurrently from worker threads without racing real mutators (install/enable/register), so read-only is the correct invariant for it. Locked in by `test_list_apps_is_read_only_under_version_drift`.
- All seven registry touches in `dashboard/handlers_instances.py` (including reads — a read blocks in the registry's threading lock while a worker holds it across an fsync) are offloaded.

## What tests did we do?

New `test/test_apps_instances_loop_offload.py`:
- 7 behavior tests asserting each async entry point executes its walk/write on a worker thread, not the loop thread (mutation-verified: reverting an offload turns them red).
- A negative test pinning the `_mark_recovered` ordering fix: an untracked (disconnected) instance gets NO recovery write.
- 3 AST ratchet tests banning direct calls in async frames: the apps-dir walk primitives in `routes`/`hooks_integration`/`bridges` (bare-name AND attribute form, so a module-prefixed re-import cannot evade the gate), `self._registry` writes in the tunnel manager, and both registry receiver shapes (`reg.<m>()`, `_registry(state).<m>()`) in the instances handlers.

`test/test_instances.py` gains `test_update_mark_last_active_is_one_mutation`. Local gates: isort / flake8 / mypy clean; full `python -m pytest` failures comm-diffed against an origin/main baseline run on the same host — every residual failure reproduces identically on the baseline (environmental clusters: subprocess timeouts under load, git-dependent suites, AF_UNIX path length).

Pre-push review: two model-pinned reviewer subagents (GPT + Opus contracts). GPT raised 1 blocking finding (the `_mark_recovered` ordering race) — fixed; Opus passed with 6 advisories — all adopted (single-mutation connect persist, disconnect shield, the uncovered `bridges.py` and `handlers_instances.py` sites, ratchet attribute-form matching, and replacing the pure `collect_publish_providers` in the ban set with the disk primitive `_provider_is_configured`). A focused verifier confirmed all 7 findings closed.

## Any other suggestions on the work?

Review evolution note: an earlier revision kept `ssh_tunnel_manager`'s registry reads on the loop; after Design Review pointed out that the offloaded writes now hold the registry's threading lock across an fsync (so an on-loop read can block in `RLock.acquire()` for that whole window), all five `self._registry.get` sites in that module were offloaded too, and the module's AST ratchet covers every registry method. The one sync helper (`_reserved_ports`) has no async caller and is unchanged. `_persist_hint`'s hold-lock-until-durable shape is intentionally duplicated at its three call sites for now; if a fourth hint-write site appears, fold them into a single serialized writer. Manual verification: N/A — unit coverage exercises every changed call path, and no UI changes are involved.

Closes #3055

