### PR TITLE
fix: offload blocking startup work in _init_services off the event loop (#3051)

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -27,7 +27,6 @@ import re
 import shutil
 import signal
 import socket
-import subprocess
 import sys
 import threading
 import time
@@ -72,7 +71,6 @@ from kiro_crew.config.loader import (
     CRED_WEIXIN_TOKEN,
     _session_work_dir,
     build_provider_factory,
-    config_dir,
     data_home,
 )
 from kiro_crew.config.paths import kiro_agents_dir
@@ -1526,11 +1524,63 @@ class GatewayOrchestrator:
             shutil.which("brazil-build") and (Path(proj).parent.parent / ".brazil").is_dir()
         )
 
-    def _check_missing_deps(self) -> None:
+    # Budgets for the two startup subprocesses below. Class attributes (not
+    # literals) so tests can shrink them to exercise the timeout/kill paths
+    # without waiting out the real budgets.
+    _DEP_INSTALL_TIMEOUT_SECS: float = 300.0
+    _KIRO_CLI_VERSION_TIMEOUT_SECS: float = 5.0
+    # Bound on the post-kill reap: a build-backend grandchild that survived
+    # the kill can hold the stdout/stderr pipes open, making an unbounded
+    # ``communicate()`` wait forever and hang boot.
+    _STARTUP_CHILD_REAP_SECS: float = 5.0
+
+    @staticmethod
+    async def _kill_startup_child(proc: "asyncio.subprocess.Process") -> None:
+        """Best-effort kill of a startup child and its descendants.
+
+        ``proc.kill()`` signals only the child's own PID; pip's build-backend
+        grandchildren survive it, keep writing into site-packages, and hold
+        the pipe write ends open. The tree kill covers them: process-group on
+        POSIX (the child is spawned with ``start_new_session``) and
+        ``taskkill /T`` on Windows. Async on purpose — the Windows branch
+        spawns ``taskkill`` (up to 5s), and ``kill_process_tree_async``
+        offloads it so the kill itself cannot stall the loop this fix exists
+        to protect (POSIX dispatches inline; ``killpg`` is non-blocking).
+        Falls back to a plain kill when the tree kill is refused
+        (already-dead child, non-int mocked PID in tests).
+        """
+        sig = getattr(signal, "SIGKILL", signal.SIGTERM)  # no SIGKILL on Windows
+        try:
+            await platform_compat.kill_process_tree_async(proc.pid, sig)
+        except Exception:
+            with contextlib.suppress(Exception):
+                proc.kill()
+
+    @classmethod
+    async def _reap_startup_child(cls, proc: "asyncio.subprocess.Process") -> None:
+        """Bounded reap after a kill — never lets a wedged pipe hang boot.
+
+        Best-effort by design: past the bound, boot proceeds and the OS reaps
+        the zombie eventually. ``suppress(Exception)`` deliberately does not
+        swallow ``CancelledError`` (a ``BaseException``).
+        """
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(proc.communicate(), timeout=cls._STARTUP_CHILD_REAP_SECS)
+
+    async def _check_missing_deps(self) -> None:
         """Auto-repair missing pip deps for venv installs.
 
         After auto-update, old code may have pulled new source via git reset
         but skipped ``pip install``. This catches the gap on next startup.
+
+        Async on purpose: the install can legitimately take minutes, and a
+        synchronous ``subprocess.run`` here would block the event loop for the
+        whole budget (see the module invariant — the loop runs callbacks one at
+        a time, so nothing else, including the loop-stall heartbeat once it is
+        armed, runs while a callback blocks). The child runs via
+        ``asyncio.create_subprocess_exec`` — the same pattern the auto-update
+        path in this file already uses — so the loop keeps servicing callbacks
+        while pip works.
         """
         missing = [pip for mod, pip in self._REQUIRED_DEPS if importlib.util.find_spec(mod) is None]
         if not missing:
@@ -1542,37 +1592,97 @@ class GatewayOrchestrator:
 
         logger.warning("Missing deps %s — installing directly", missing)
         print(f"👻 Installing missing dependencies: {', '.join(missing)}")
-        result = subprocess.run(
-            [sys.executable, "-m", "pip", "install", "--quiet", *missing],
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            *missing,
             cwd=proj,
-            capture_output=True,
-            timeout=300,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            # Own process group (POSIX; no-op on Windows) so a timeout kill
+            # reaches pip's build-backend grandchildren, not just pip itself.
+            start_new_session=platform_compat.IS_POSIX,
         )
-        if result.returncode == 0:
+        try:
+            _, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=self._DEP_INSTALL_TIMEOUT_SECS
+            )
+        except (TimeoutError, asyncio.TimeoutError):
+            await self._kill_startup_child(proc)
+            await self._reap_startup_child(proc)
+            print("❌ pip install timed out — run manually: kirocrew update")
+            logger.error(
+                "Dep repair timed out after %.0fs", self._DEP_INSTALL_TIMEOUT_SECS
+            )
+            return
+        except asyncio.CancelledError:
+            # Gateway shutdown / Ctrl-C mid-install: leaving pip running would
+            # race the NEXT boot's install of the same distributions — the
+            # half-installed state this repair path exists to fix.
+            await self._kill_startup_child(proc)
+            raise
+        if proc.returncode == 0:
             # Invalidate import caches so the new packages are found
             importlib.invalidate_caches()
             print("✅ Dependencies installed")
         else:
             print("❌ pip install failed — run manually: kirocrew update")
-            logger.error("Dep repair failed: %s", result.stderr.decode(errors="replace")[:500])
+            logger.error(
+                "Dep repair failed: %s", (stderr or b"").decode(errors="replace")[:500]
+            )
 
     # ------------------------------------------------------------------
     # Service initialisation
     # ------------------------------------------------------------------
 
-    def _init_services(self) -> None:
-        """Initialize memory, skills, hooks, context, history, sessions."""
-        if not self._slack_enabled:
-            logger.info("Slack not configured — starting without the Slack gateway")
+    async def _warn_if_kiro_cli_outdated(self) -> None:
+        """Warn when kiro-cli is too old for ``--agent`` (requires >= 1.26).
 
-        # Check kiro-cli version (--agent requires >= 1.26)
+        Never raises: an absent, hung, or unparseable kiro-cli must not break
+        boot. Off the loop via an async subprocess so a slow binary cannot
+        stall every other callback for the 5s budget, and a timeout is logged
+        (not silently swallowed) so a wedged kiro-cli that costs 5s on every
+        boot is diagnosable from gateway.log.
+        """
         try:
-            result = subprocess.run(
-                ["kiro-cli", "--version"], capture_output=True, text=True, timeout=5
+            proc = await asyncio.create_subprocess_exec(
+                "kiro-cli",
+                "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
-            if result.returncode == 0:
+        except Exception:
+            return  # binary missing/unspawnable — same silence as before
+        try:
+            out, _ = await asyncio.wait_for(
+                proc.communicate(), timeout=self._KIRO_CLI_VERSION_TIMEOUT_SECS
+            )
+        except (TimeoutError, asyncio.TimeoutError):
+            await self._kill_startup_child(proc)
+            await self._reap_startup_child(proc)
+            logger.warning(
+                "kiro-cli --version timed out after %.0fs",
+                self._KIRO_CLI_VERSION_TIMEOUT_SECS,
+            )
+            return
+        except asyncio.CancelledError:
+            await self._kill_startup_child(proc)
+            raise
+        except Exception:
+            # Transport/pipe errors must not abort boot (this helper's
+            # contract is "never raises" — the pre-#3051 code swallowed them
+            # via a blanket except). Kill+reap best-effort and continue.
+            await self._kill_startup_child(proc)
+            await self._reap_startup_child(proc)
+            logger.debug("kiro-cli --version probe failed", exc_info=True)
+            return
+        try:
+            if proc.returncode == 0:
                 # e.g. "kiro-cli 1.25.0" -> (1, 25, 0)
-                parts = result.stdout.strip().split()[-1].split(".")
+                parts = out.decode(errors="replace").strip().split()[-1].split(".")
                 major, minor = int(parts[0]), int(parts[1])
                 if (major, minor) < (1, 26):
                     print(
@@ -1580,11 +1690,30 @@ class GatewayOrchestrator:
                         "Update kiro-cli, or use the default claude-agent-acp backend."
                     )
         except Exception:
-            pass
+            pass  # unparseable version output — same silence as before
+
+    async def _init_services(self) -> None:
+        """Initialize memory, skills, hooks, context, history, sessions.
+
+        Async so the blocking pieces named by issue #3051 — the kiro-cli
+        version probe, the pip dep repair, ``VectorMemoryStore.init()`` and
+        ``memory.rebuild_index()`` — run off the event loop. Object
+        CONSTRUCTION deliberately stays on the loop thread:
+        ``SessionManager.__init__`` creates asyncio primitives (locks,
+        semaphores, queues), so hopping the whole method into a worker thread
+        would trade a blocking bug for a thread-affinity one. (Other sync
+        filesystem steps — agent-config install, builtin-skills copy — remain
+        on the loop; they are bounded small-file work, not usage-scaled.)
+        """
+        if not self._slack_enabled:
+            logger.info("Slack not configured — starting without the Slack gateway")
+
+        # Check kiro-cli version (--agent requires >= 1.26)
+        await self._warn_if_kiro_cli_outdated()
 
         # Auto-repair missing pip deps (handles chicken-and-egg after auto-update)
         try:
-            self._check_missing_deps()
+            await self._check_missing_deps()
         except Exception:
             logger.warning("Dep check failed", exc_info=True)
 
@@ -1680,7 +1809,10 @@ class GatewayOrchestrator:
             episodic_limit=self._cfg.memory.episodic_max_results,
             embedding_dim=self._cfg.memory.embedding_dim,
         )
-        self.vector_memory.init()
+        # Off-loop: init() connects sqlite and runs schema migrations, which
+        # scale with store size (VectorMemoryStore's own docs say async
+        # contexts should wrap it in asyncio.to_thread).
+        await asyncio.to_thread(self.vector_memory.init)
         memory.vector_store = self.vector_memory
 
         skills = SkillsLoader()
@@ -1731,11 +1863,13 @@ class GatewayOrchestrator:
         # Trigger skill extraction when sessions expire (idle/orphan)
         self.sessions.on_session_expire = self.consolidator.consolidate_session
 
-        # Channel history buffer
+        # Channel history buffer. data_home(), not config_dir(): this method is
+        # async and config_dir() re-runs start-of-process maintenance (mkdir,
+        # breadcrumb refresh, archive sweep) on every call — #1057.
         self.channel_history = ChannelHistory(
             observe_max_entries=self._cfg.observe_max_messages,
             observe_ttl_secs=int(self._cfg.observe_ttl_hours * 3600),
-            history_dir=config_dir() / "history",
+            history_dir=data_home() / "history",
         )
         self.ctx_builder.channel_history = self.channel_history
 
@@ -1746,8 +1880,9 @@ class GatewayOrchestrator:
             if ch_cfg.activation == ACTIVATION_OBSERVE:
                 self.channel_history.set_observe(ch_id)
 
-        # FTS index
-        indexed = memory.rebuild_index()
+        # FTS index. Off-loop: rebuild_index globs every history *.md and
+        # rewrites the index, so it scales with usage.
+        indexed = await asyncio.to_thread(memory.rebuild_index)
         logger.info("FTS index built: %d files", indexed)
 
     async def _open_dm_with_retry(
@@ -6556,7 +6691,7 @@ class GatewayOrchestrator:
         await cautious_boot.initialize()
 
         seen = SeenCache()
-        self._init_services()
+        await self._init_services()
 
         # Wire in-process embeddings (always-on) and kick background model download
         await self._start_embeddings()

--- a/test/test_agent_spec_preflight.py
+++ b/test/test_agent_spec_preflight.py
@@ -9,11 +9,12 @@ command instead of dumping a raw
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import logging
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -180,10 +181,13 @@ class TestGatewayInstallVerification:
             vector = stack.enter_context(patch("kiro_crew.vector_memory.VectorMemoryStore"))
             vector.return_value = MagicMock()
             stack.enter_context(patch("kiro_crew.agent.rebuild_agent_config", rebuild))
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"kiro-cli 2.16.0", b""))
             stack.enter_context(
-                patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="kiro-cli 2.16.0"))
+                patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc))
             )
-            orch._init_services()
+            asyncio.run(orch._init_services())
 
     def test_install_exception_logs_error_not_warning(self, tmp_path, caplog, capsys):
         orch = _make_orchestrator()

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -61,6 +61,15 @@ def _make_orchestrator(
 # ─── Helper utilities ────────────────────────────────────────────────────
 
 
+def _fake_async_proc(returncode: int = 0, stdout: bytes = b"", stderr: bytes = b""):
+    """A stand-in for an ``asyncio.create_subprocess_exec`` child process."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.kill = MagicMock()
+    return proc
+
+
 def _mock_sessions():
     """Return a mock SessionManager with common methods."""
     s = MagicMock()
@@ -345,8 +354,11 @@ class TestInitServices:
                                         with patch("kiro_crew.slack.gateway.HistoryConsolidator"):
                                             with patch("kiro_crew.slack.gateway.ChannelHistory"):
                                                 with patch("kiro_crew.agent.rebuild_agent_config", return_value=Path("/tmp/a")):
-                                                    with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="kiro-cli 1.30.0")):
-                                                        orch._init_services()
+                                                    with patch(
+                                                        "asyncio.create_subprocess_exec",
+                                                        new=AsyncMock(return_value=_fake_async_proc(stdout=b"kiro-cli 1.30.0")),
+                                                    ):
+                                                        asyncio.run(orch._init_services())
 
         assert orch.sessions is not None
         assert orch.ctx_builder is not None
@@ -377,8 +389,11 @@ class TestInitServices:
                                         with patch("kiro_crew.slack.gateway.HistoryConsolidator"):
                                             with patch("kiro_crew.slack.gateway.ChannelHistory"):
                                                 with patch("kiro_crew.agent.rebuild_agent_config", return_value=Path("/tmp/a")):
-                                                    with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="kiro-cli 1.30.0")):
-                                                        orch._init_services()
+                                                    with patch(
+                                                        "asyncio.create_subprocess_exec",
+                                                        new=AsyncMock(return_value=_fake_async_proc(stdout=b"kiro-cli 1.30.0")),
+                                                    ):
+                                                        asyncio.run(orch._init_services())
 
         assert orch.slack is None
         assert orch.sessions is not None
@@ -952,7 +967,7 @@ class TestBrazilInstallAndDeps:
     def test_check_missing_deps_no_missing(self):
         orch = _make_orchestrator()
         with patch("importlib.util.find_spec", return_value=MagicMock()):
-            orch._check_missing_deps()  # should not raise
+            asyncio.run(orch._check_missing_deps())  # should not raise
 
     def test_check_missing_deps_brazil_skips(self):
         orch = _make_orchestrator()
@@ -961,7 +976,7 @@ class TestBrazilInstallAndDeps:
                 with patch.object(
                     GatewayOrchestrator, "_is_brazil_install", return_value=True
                 ):
-                    orch._check_missing_deps()  # should not raise, skips pip
+                    asyncio.run(orch._check_missing_deps())  # should not raise, skips pip
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -2390,7 +2405,7 @@ class TestRunMethod:
         orch = _make_orchestrator()
 
         # Mock all init methods
-        orch._init_services = MagicMock()
+        orch._init_services = AsyncMock()
         # _init_services is mocked so vector_memory never gets created — mock
         # the default-on embeddings wiring too (it dereferences vector_memory).
         orch._start_embeddings = AsyncMock()
@@ -2437,7 +2452,7 @@ class TestRunMethod:
 
         orch = _make_orchestrator(no_dashboard=True)
 
-        orch._init_services = MagicMock()
+        orch._init_services = AsyncMock()
         orch._start_embeddings = AsyncMock()
         # run() spawns _auto_migrate_memory as a fire-and-forget task; with
         # _init_services mocked it would raise AttributeError on
@@ -4243,7 +4258,7 @@ class TestRunSignalAndBgSession:
         orch = _make_orchestrator(no_dashboard=True)
         orch._cfg.memory.embedding_provider = "llama_cpp"
 
-        orch._init_services = MagicMock()
+        orch._init_services = AsyncMock()
         orch._start_embeddings = AsyncMock()
         # run() spawns _auto_migrate_memory as a fire-and-forget task; with
         # _init_services mocked it would raise AttributeError on
@@ -4297,7 +4312,7 @@ class TestBgSessionDashboardBranch:
         """_start_bg_session prints dashboard URLs when not _no_dashboard."""
         orch = _make_orchestrator(no_dashboard=False, no_open=True)
 
-        orch._init_services = MagicMock()
+        orch._init_services = AsyncMock()
         orch._start_embeddings = AsyncMock()
         # run() spawns _auto_migrate_memory as a fire-and-forget task; with
         # _init_services mocked it would raise AttributeError on
@@ -4361,10 +4376,16 @@ class TestCheckMissingDepsPip:
                 with patch.object(
                     GatewayOrchestrator, "_is_brazil_install", return_value=False
                 ):
-                    with patch("subprocess.run") as mock_run:
-                        mock_run.return_value = MagicMock(returncode=0)
-                        orch._check_missing_deps()
-                    mock_run.assert_called_once()
+                    mock_exec = AsyncMock(return_value=_fake_async_proc(returncode=0))
+                    with patch("asyncio.create_subprocess_exec", mock_exec):
+                        asyncio.run(orch._check_missing_deps())
+                    mock_exec.assert_awaited_once()
+                    # Pin the command shape so a refactor cannot silently stop
+                    # installing (sys.executable -m pip install ...).
+                    import sys as _sys
+
+                    args = mock_exec.await_args.args
+                    assert args[:4] == (_sys.executable, "-m", "pip", "install")
 
     def test_pip_install_failure(self):
         orch = _make_orchestrator()
@@ -4373,11 +4394,278 @@ class TestCheckMissingDepsPip:
                 with patch.object(
                     GatewayOrchestrator, "_is_brazil_install", return_value=False
                 ):
-                    with patch("subprocess.run") as mock_run:
-                        mock_run.return_value = MagicMock(
-                            returncode=1, stderr=b"error"
-                        )
-                        orch._check_missing_deps()  # should not raise
+                    mock_exec = AsyncMock(
+                        return_value=_fake_async_proc(returncode=1, stderr=b"error")
+                    )
+                    with patch("asyncio.create_subprocess_exec", mock_exec):
+                        asyncio.run(orch._check_missing_deps())  # should not raise
+
+    def test_pip_install_timeout_kills_child(self):
+        """A wedged pip is killed and reaped; boot continues without raising."""
+        orch = _make_orchestrator()
+        proc = MagicMock()
+        proc.returncode = None
+        proc.kill = MagicMock()
+
+        async def _communicate():
+            if proc.kill.called:
+                return (b"", b"")  # post-kill reap returns immediately
+            await asyncio.sleep(3600)  # hang until wait_for cancels us
+            return (b"", b"")
+
+        proc.communicate = MagicMock(side_effect=_communicate)
+        with patch("importlib.util.find_spec", return_value=None):
+            with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/proj"}):
+                with patch.object(
+                    GatewayOrchestrator, "_is_brazil_install", return_value=False
+                ):
+                    with patch.object(
+                        GatewayOrchestrator, "_DEP_INSTALL_TIMEOUT_SECS", 0.05
+                    ):
+                        with patch(
+                            "asyncio.create_subprocess_exec",
+                            AsyncMock(return_value=proc),
+                        ):
+                            asyncio.run(orch._check_missing_deps())  # no raise
+        proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_version_probe_transport_error_does_not_abort_boot(self):
+        """_warn_if_kiro_cli_outdated must never raise.
+
+        A pipe/transport error from communicate() propagating out of this
+        helper would abort run() before the dashboard binds. The child is
+        still killed+reaped best-effort.
+        """
+        calls = {"n": 0}
+
+        async def _communicate():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("broken pipe")
+            return (b"", b"")  # the post-kill reap
+
+        proc = MagicMock()
+        proc.returncode = None
+        proc.kill = MagicMock()
+        proc.communicate = MagicMock(side_effect=_communicate)
+        orch = _make_orchestrator()
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await orch._warn_if_kiro_cli_outdated()  # must not raise
+        proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_pip_install_cancellation_kills_child(self):
+        """Gateway shutdown mid-install must not orphan pip.
+
+        A leaked pip would race the NEXT boot's install of the same
+        distributions — the half-installed state this repair path exists to
+        fix.
+        """
+        proc = MagicMock()
+        proc.returncode = None
+        proc.kill = MagicMock()
+
+        async def _communicate():
+            await asyncio.sleep(3600)  # hang until cancelled
+            return (b"", b"")
+
+        proc.communicate = MagicMock(side_effect=_communicate)
+        orch = _make_orchestrator()
+        with patch("importlib.util.find_spec", return_value=None):
+            with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/proj"}):
+                with patch.object(
+                    GatewayOrchestrator, "_is_brazil_install", return_value=False
+                ):
+                    with patch(
+                        "asyncio.create_subprocess_exec", AsyncMock(return_value=proc)
+                    ):
+                        task = asyncio.create_task(orch._check_missing_deps())
+                        await asyncio.sleep(0.05)  # let it reach the await
+                        task.cancel()
+                        with pytest.raises(asyncio.CancelledError):
+                            await task
+        proc.kill.assert_called_once()
+
+
+class TestInitServicesLoopResponsiveness:
+    """The event loop must keep servicing callbacks during slow startup work.
+
+    Invariant (issue #3051): the loop runs callbacks one at a time, so a
+    synchronous subprocess/scan inside ``_init_services`` starves every other
+    coroutine — including the loop-stall watchdog heartbeat once armed — for
+    its whole duration. These tests run a fast ticker concurrently with a
+    deliberately slow dependency install / store scan and assert the ticker's
+    max inter-tick gap stays under a load-adaptive ceiling. A regression to
+    the old synchronous shape (subprocess.run / a bare on-loop call) blocks
+    the ticker for the whole slow window and blows the ceiling.
+    """
+
+    _SLOW_SECS = 0.5
+    # Floor for the gap ceiling. The real ceiling adapts to host load (see
+    # _gap_ceiling): an absolute constant alone is the flake class AGENTS.md
+    # warns about — coverage + a saturated -n auto runner can produce
+    # hundred-ms scheduler hiccups on a perfectly healthy loop.
+    _MAX_GAP_SECS = 0.4
+    # Multiple of the measured control gap. The mutant signal is ~_SLOW_SECS
+    # (0.5s) vs a healthy ~0.01s, so 8x still kills every mutant on any host
+    # where the control gap stays under ~60ms.
+    _GAP_CEILING_FACTOR = 8
+
+    @staticmethod
+    def _gap_ticker(state: dict):
+        state["last"] = time.monotonic()
+
+        async def _ticker():
+            state["last"] = time.monotonic()
+            while True:
+                await asyncio.sleep(0.01)
+                now = time.monotonic()
+                state["max_gap"] = max(state["max_gap"], now - state["last"])
+                state["ticks"] += 1
+                state["last"] = now
+
+        return _ticker
+
+    @staticmethod
+    def _fold_final_gap(state: dict) -> None:
+        """Record the gap between the last tick and measurement end.
+
+        Without this, a block at the TAIL of the measured call is invisible:
+        the parent coroutine resumes first and cancels the ticker before it
+        can run once more to observe the gap.
+        """
+        state["max_gap"] = max(state["max_gap"], time.monotonic() - state["last"])
+
+    async def _gap_ceiling(self) -> float:
+        """Measure the host's baseline tick gap and derive the failure ceiling.
+
+        Runs the same ticker over a plain ``asyncio.sleep`` window with
+        nothing offloaded — any gap observed here is pure scheduler noise —
+        then allows the measured phase a small multiple of it, floored at
+        _MAX_GAP_SECS for quiet hosts.
+        """
+        control = {"ticks": 0, "max_gap": 0.0}
+        task = asyncio.create_task(self._gap_ticker(control)())
+        await asyncio.sleep(0.02)  # ticker baseline
+        try:
+            await asyncio.sleep(self._SLOW_SECS)
+            self._fold_final_gap(control)
+        finally:
+            task.cancel()
+        return max(self._MAX_GAP_SECS, self._GAP_CEILING_FACTOR * control["max_gap"])
+
+    @pytest.mark.asyncio
+    async def test_slow_pip_install_does_not_starve_heartbeat(self):
+        orch = _make_orchestrator()
+        ceiling = await self._gap_ceiling()
+        state = {"ticks": 0, "max_gap": 0.0}
+        _ticker = self._gap_ticker(state)
+
+        async def _slow_exec(*args, **kwargs):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.kill = MagicMock()
+
+            async def _communicate():
+                await asyncio.sleep(self._SLOW_SECS)  # yields to the loop
+                return (b"", b"")
+
+            proc.communicate = MagicMock(side_effect=_communicate)
+            return proc
+
+        def _blocking_run(*args, **kwargs):  # the OLD, buggy shape
+            time.sleep(self._SLOW_SECS)  # blocks the loop thread
+            return MagicMock(returncode=0, stdout="", stderr=b"")
+
+        with patch("importlib.util.find_spec", return_value=None):
+            with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/proj"}):
+                with patch.object(
+                    GatewayOrchestrator, "_is_brazil_install", return_value=False
+                ):
+                    # Patch BOTH shapes: the fixed code awaits the async exec
+                    # (ticker keeps running); a mutant reverted to
+                    # subprocess.run blocks the loop and starves the ticker.
+                    # The sync shape is patched on the subprocess MODULE (not
+                    # the gateway namespace) because the fixed gateway no
+                    # longer imports subprocess at all.
+                    with patch(
+                        "asyncio.create_subprocess_exec", side_effect=_slow_exec
+                    ):
+                        with patch(
+                            "subprocess.run",
+                            side_effect=_blocking_run,
+                        ):
+                            ticker_task = asyncio.create_task(_ticker())
+                            # Let the ticker establish its baseline BEFORE the
+                            # measured call: awaiting a coroutine runs it
+                            # inline, so without this yield an on-loop block
+                            # would happen before the first tick and never be
+                            # observed as a gap.
+                            await asyncio.sleep(0.02)
+                            try:
+                                await asyncio.wait_for(
+                                    orch._check_missing_deps(), timeout=10
+                                )
+                                self._fold_final_gap(state)
+                            finally:
+                                ticker_task.cancel()
+        assert state["max_gap"] < ceiling, (
+            f"loop blocked for {state['max_gap']:.2f}s during dep install "
+            f"(ceiling {ceiling:.2f}s)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_slow_fts_rebuild_does_not_starve_heartbeat(self):
+        """rebuild_index and vector init scale with usage; both must run off-loop."""
+        orch = _make_orchestrator(slack_enabled=False)
+        ceiling = await self._gap_ceiling()
+        state = {"ticks": 0, "max_gap": 0.0}
+        _ticker = self._gap_ticker(state)
+
+        def _slow_rebuild():
+            time.sleep(self._SLOW_SECS)  # off-loop this is harmless
+            return 3
+
+        def _slow_vector_init():
+            time.sleep(self._SLOW_SECS)  # off-loop this is harmless
+
+        mock_mem_inst = MagicMock()
+        mock_mem_inst.init = MagicMock()
+        mock_mem_inst.rebuild_index = MagicMock(side_effect=_slow_rebuild)
+        mock_vm_inst = MagicMock()
+        mock_vm_inst.init = MagicMock(side_effect=_slow_vector_init)
+        with patch("kiro_crew.slack.gateway.MemoryStore", return_value=mock_mem_inst):
+            with patch("kiro_crew.vector_memory.VectorMemoryStore") as mock_vm:
+                mock_vm.return_value = mock_vm_inst
+                with patch("kiro_crew.slack.gateway.SkillsLoader"):
+                    with patch("kiro_crew.slack.gateway.HookManager"):
+                        with patch("kiro_crew.slack.gateway.LessonStore"):
+                            with patch("kiro_crew.slack.gateway.ContextBuilder"):
+                                with patch("kiro_crew.slack.gateway.ConversationLog", return_value=MagicMock()):
+                                    with patch("kiro_crew.slack.gateway.SessionManager"):
+                                        with patch("kiro_crew.slack.gateway.HistoryConsolidator"):
+                                            with patch("kiro_crew.slack.gateway.ChannelHistory"):
+                                                with patch("kiro_crew.agent.rebuild_agent_config", return_value=Path("/tmp/a")):
+                                                    with patch(
+                                                        "asyncio.create_subprocess_exec",
+                                                        new=AsyncMock(return_value=_fake_async_proc(stdout=b"kiro-cli 1.30.0")),
+                                                    ):
+                                                        ticker_task = asyncio.create_task(_ticker())
+                                                        # Baseline tick first — see the
+                                                        # comment in the pip test above.
+                                                        await asyncio.sleep(0.02)
+                                                        try:
+                                                            await asyncio.wait_for(
+                                                                orch._init_services(), timeout=10
+                                                            )
+                                                            self._fold_final_gap(state)
+                                                        finally:
+                                                            ticker_task.cancel()
+        assert state["max_gap"] < ceiling, (
+            f"loop blocked for {state['max_gap']:.2f}s during service init "
+            f"(ceiling {ceiling:.2f}s)"
+        )
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -769,7 +769,11 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "session_pid.py::kill_orphan_mcps",
         "slack/gateway.py::_auto_apply_update",
         "slack/gateway.py::_check_missing_deps",
-        "slack/gateway.py::_init_services",
+        # The kiro-cli version probe, extracted from _init_services (issue
+        # #3051). Fixed argv ("kiro-cli --version"), no agent-influenced
+        # input; sandboxing the probe would be circular for the same reason
+        # as the other boot-time self-checks above.
+        "slack/gateway.py::_warn_if_kiro_cli_outdated",
         "testing/harness.py::spawn_feature_gateway",
         # Apple on-device speech (macOS only). None of these takes an agent-authored
         # command: the argv is a fixed toolchain path, the helper Kiro Crew itself


### PR DESCRIPTION
## What is the problem?

`GatewayOrchestrator._init_services()` (a plain `def` called from `async def run()`) ran four synchronous blocking operations directly on the asyncio event loop during boot:

- `subprocess.run([sys.executable, -m, pip, install, ...], timeout=300)` in `_check_missing_deps()` — up to 300s
- `subprocess.run(["kiro-cli", "--version"], timeout=5)` — up to 5s
- `memory.rebuild_index()` — globs every history `*.md` and rewrites the FTS index; scales with usage
- `VectorMemoryStore.init()` — sqlite connect + schema migrations; scales with store size

The event loop runs callbacks one at a time to completion, so while any of these runs, every other callback is starved.

One correction to the issue's severity claim, carried honestly per the evidence: on current main the loop-stall **watchdog is NOT yet armed** when `_init_services` runs — `run()` calls `_init_services()` (gateway.py:6559) *before* `_init_dashboard()` (gateway.py:6589), which is where `start_dashboard()` arms the watchdog. The issue's ordering claim compared lexical line numbers of method definitions, not execution order. So there is no watchdog-kill risk today; the defect is the loop-blocking class itself (boot-time unresponsiveness, and a latent hazard should startup ordering ever change).

## Why this issue matters to the user

Any coroutine scheduled before or during `_init_services` waits for the full block. In the worst case (dep self-heal after an auto-update) boot stalls up to 300s with the gateway process alive but the loop frozen — no dashboard socket, no signals serviced through the loop, nothing attributable in the logs. The two store scans grow with usage, so the stall gets worse on exactly the long-lived installs that matter most. It also violates the repo's own async discipline (the same file already offloads `warm_backend` and the persistence probe via `asyncio.to_thread`).

## How our fix solves it

Chain from symptom to root cause: boot unresponsiveness → synchronous blocking calls inside an `async def` call chain → `_init_services` made `async` and each blocking call individually moved off the loop, using the file's established idioms.

- `_check_missing_deps()` → `async`; pip runs via `asyncio.create_subprocess_exec` + `asyncio.wait_for` (the same pattern this file's auto-update path uses). Spawned with `start_new_session` on POSIX so a timeout kill reaches pip's build-backend grandchildren via `platform_compat.kill_process_tree` (per-PID kill leaves them running and holding the pipes). The post-kill reap is bounded (5s) so a wedged pipe cannot hang boot, and `CancelledError` (gateway shutdown mid-install) kills the child instead of orphaning a live pip that would race the next boot's install.
- The kiro-cli version probe is extracted to `_warn_if_kiro_cli_outdated()` — async subprocess, same timeout/kill/cancel hygiene, and a timeout now logs a warning instead of vanishing into `except Exception: pass` (a wedged kiro-cli costing 5s per boot is diagnosable from gateway.log).
- `VectorMemoryStore.init()` and `memory.rebuild_index()` → `await asyncio.to_thread(...)`. `VectorMemoryStore` opens sqlite with `check_same_thread=False` under an RLock, and its own docs direct async contexts to wrap `init()` in `to_thread`.
- Shape decision (issue offered two): the whole-method `to_thread` hop was rejected because `SessionManager.__init__` creates asyncio primitives (locks, semaphores, queues) — object construction stays on the loop thread; only the four blocking calls are offloaded.
- Incidental, forced by the async conversion: `ChannelHistory`'s `history_dir` now uses `data_home()` instead of `config_dir()` — the `test_no_config_dir_in_async` ratchet (issue #1057) forbids `config_dir()` inside async functions because it re-runs start-of-process maintenance on every call. Same resolved path, minus the maintenance sweep.

Deliberately NOT offloaded (scope): `rebuild_agent_config()` and `SkillsLoader()`'s builtin-skills copy are also sync filesystem work inside `_init_services`, but they are bounded small-file operations, not usage-scaled, and not named by the issue. Tracked in a follow-up issue.

## What tests we did

- New `TestInitServicesLoopResponsiveness`: runs a fast ticker concurrently with a deliberately slow (0.5s) dependency install / store scan and asserts the ticker's max inter-tick gap stays under a **load-adaptive ceiling** (measured control window × 8, floored at 0.4s — absolute-only thresholds are the flake class this suite bans). Includes a baseline-tick yield before the measured call and a final-gap fold after it, without which a head- or tail-positioned block is invisible to the ticker.
- New timeout test (`_DEP_INSTALL_TIMEOUT_SECS` shrunk via `patch.object`): a wedged pip is killed and reaped without raising.
- New cancellation test: cancelling `_check_missing_deps` mid-install kills the child.
- Mutation verification, 5/5 killed: revert pip to sync `subprocess.run`; `rebuild_index` back on-loop; `vector_memory.init` back on-loop; drop kill-on-timeout; drop kill-on-cancel.
- Existing tests updated mechanically: sync callers → `asyncio.run(...)`, `MagicMock` → `AsyncMock` where `run()` awaits `_init_services`, `subprocess.run` patches → `asyncio.create_subprocess_exec` fakes. Spawn-audit allowlist entry follows the extracted helper (`_init_services` no longer spawns; `_warn_if_kiro_cli_outdated` added with justification).
- Gates: isort / flake8 / mypy clean; full pytest run diffed against an origin/main baseline run with `comm -13` — zero deterministic branch-only failures (remaining diff-set entries fail on main solo or pass solo under `-n0`; they are pre-existing environmental/xdist flakes).
- Local model-pinned reviews: GPT mirror PASS; Opus mirror no BLOCKING, 5 advisories — 4 adopted in this diff (bounded reap + tree kill, cancellation cleanup, load-adaptive test ceiling, timeout observability), 1 deferred with a filed follow-up (remaining sync FS steps above).

## Manual verification

N/A — unit coverage sufficient: the responsiveness tests measure the exact loop property the fix exists to provide, and the timeout/cancel paths are exercised with shrunk budgets. No UI change.

## Any other suggestions on the work

Follow-up issue (filed after this PR opened) for offloading `rebuild_agent_config()` / builtin-skills copy, per the deferred advisory.

Closes #3051
