### PR TITLE
fix: take auto_research campaigns DB off the event loop (#3050)

### DIFF
--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -136,7 +136,9 @@ Details worth knowing:
   base side and be charged to every PR in that window.
 - **The e2e gateway boots with `KIROCREW_STRICT_ON_LOOP_PERSIST=1`**, so an
   un-offloaded session-JSONL mutator that enters the lock on the event loop raises
-  and fails the gate at PR time. `KIROCREW_E2E_REQUIRE=1` turns an
+  and fails the gate at PR time (the knob also arms the auto_research
+  campaigns-DB chokepoint — see [e2e-gate.md](e2e-gate.md)).
+  `KIROCREW_E2E_REQUIRE=1` turns an
   environment-resolution miss into a hard failure, since a skipped suite would
   otherwise count as a pass having run zero browser specs. Details:
   [e2e-gate.md](e2e-gate.md).

--- a/docs/ci/e2e-gate.md
+++ b/docs/ci/e2e-gate.md
@@ -28,7 +28,10 @@ environment is not something a caller has to remember:
   discipline into an enforced invariant for the duration of the run. The harness
   gateway inherits this env, so any raw on-loop `ConversationLog._locked` entry
   that skipped the `*_off_loop` helpers raises `OnLoopPersistError` and fails the
-  gate instead of silently losing transcript data under real contention.
+  gate instead of silently losing transcript data under real contention. The same
+  knob also arms the auto_research campaigns-DB chokepoint (`_get_db()` raises
+  `OnLoopDBError` when entered on the event loop), so an un-offloaded DB call in
+  that app fails the gate too.
 - `-o addopts=` clears the `[tool:pytest]` defaults from `setup.cfg` (`-n auto`,
   `--dist loadgroup`, `--max-worker-restart=2`, `--timeout=120`). xdist would spawn
   one gateway per worker, and coverage of a subprocess gateway measures nothing, so

--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -239,7 +239,10 @@ no longer destroy older turns.
   call-site fails tests rather than losing data, or emits a **loud throttled
   warning** and proceeds via the single non-blocking safety-net acquire
   (default / production gateway, strict off — never a new hard failure in the
-  field). Strict is deliberately NOT auto-on under bare pytest (the suite's own
+  field). The strictness predicate is exported as `on_loop_persist_strict` and
+  shared by other off-loop-IO chokepoints (the auto_research campaigns-DB
+  guard raises its own `OnLoopDBError` under the same knob).
+  Strict is deliberately NOT auto-on under bare pytest (the suite's own
   async harness calls several mutators directly on the loop as a convenience, so
   auto-strict would flag harness code, not drift); the enforcement tests flip
   the env flag explicitly. Off the loop the check is a no-op (the sanctioned

--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,15 +1,15 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1409,
+    "missing_code": 1408,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 706,
+  "_compliant": 736,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
-      "missing_code": 41,
+      "missing_code": 40,
       "opaque_body": 3
     },
     "apps/builtins/code_review_sage/backend/routes.py": {

--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -31,6 +31,12 @@ from kiro_crew.config.paths import data_home
 from kiro_crew.dashboard.chat_utils import (
     slot_history_key,
 )
+
+# Single strictness knob shared with history.py's off-loop persistence
+# discipline (KIROCREW_STRICT_ON_LOOP_PERSIST / KIROCREW_DEV_MODE): one flag
+# makes every on-loop-IO chokepoint fail loud, rather than each module growing
+# its own env var that drifts out of dev/CI harnesses.
+from kiro_crew.history import on_loop_persist_strict
 from kiro_crew.knowledge.llm_pool import LLMPool
 from kiro_crew.platform_compat import is_link_or_junction, unlink_link_or_junction
 
@@ -190,7 +196,62 @@ def _safe_campaign_dir(campaign_id: str) -> Path | None:
 # --- Database ---
 
 
+class OnLoopDBError(AssertionError):
+    """``_get_db()`` was entered directly on the asyncio event loop.
+
+    Every connection carries a 30s busy timeout (see ``_get_db``), so a single
+    lock wait on the loop can freeze the whole gateway past the loop-stall
+    watchdog budget and hard-exit the process. All DB access from ``async def``
+    code MUST be offloaded (``asyncio.to_thread`` / ``run_in_executor``); the
+    campaigns-DB write contention is built in (the watchdog writes every cycle
+    while HTTP handlers read/write the same rows), so an on-loop call is not a
+    theoretical hazard here. Mirrors ``history.OnLoopPersistError``: strict
+    enforcement (dev/CI) raises so an un-offloaded call-site fails tests;
+    production logs a throttled warning and proceeds.
+    """
+
+
+# Throttle the production on-loop warning so a mis-wired hot path (e.g. the 5s
+# watchdog cycle) cannot flood the log; the diagnostic still fires once per
+# window per process.
+_ON_LOOP_DB_WARN_INTERVAL_S = 60.0
+_on_loop_db_warn_last: float = 0.0
+
+
+def _check_on_loop_db_discipline() -> None:
+    """Enforce (strict) or diagnose (production) an on-loop ``_get_db`` entry.
+
+    Called at the top of :func:`_get_db`. No running event loop means the
+    caller is already off-loop (worker thread / executor / CLI) — the common,
+    correct case — and this is a no-op.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return  # off-loop: the sanctioned path — nothing to flag
+    if on_loop_persist_strict():
+        raise OnLoopDBError(
+            "auto_research campaigns DB opened on the event loop; the 30s "
+            "busy timeout means one lock wait can stall the loop past the "
+            "watchdog budget and kill the gateway. Offload the DB section "
+            "(asyncio.to_thread / run_in_executor) like the surrounding "
+            "handlers do."
+        )
+    global _on_loop_db_warn_last
+    now = time.monotonic()
+    if now - _on_loop_db_warn_last >= _ON_LOOP_DB_WARN_INTERVAL_S:
+        _on_loop_db_warn_last = now
+        logger.warning(
+            "auto_research: _get_db() ran ON the event loop without "
+            "offloading; a contended write here blocks every task (including "
+            "the watchdog heartbeat) for up to 30s. Route it through "
+            "asyncio.to_thread / run_in_executor.",
+            stack_info=True,
+        )
+
+
 def _get_db() -> sqlite3.Connection:
+    _check_on_loop_db_discipline()
     dbp = db_path()
     dbp.parent.mkdir(parents=True, exist_ok=True)
     # Explicit 30s busy timeout (vs the 5s driver default). The research worker
@@ -233,16 +294,14 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         try:
             conn.execute("PRAGMA journal_mode=WAL")
             conn.execute("BEGIN")
-            conn.execute(
-                """CREATE TABLE IF NOT EXISTS campaigns (
+            conn.execute("""CREATE TABLE IF NOT EXISTS campaigns (
                 id TEXT PRIMARY KEY, name TEXT NOT NULL, question TEXT NOT NULL,
                 sub_questions TEXT NOT NULL DEFAULT '[]', sources TEXT NOT NULL DEFAULT '[]',
                 max_cycles INTEGER NOT NULL DEFAULT 30, idle_secs INTEGER NOT NULL DEFAULT 120,
                 status TEXT NOT NULL DEFAULT 'ready',
                 created_at REAL NOT NULL, started_at REAL, completed_at REAL,
                 total_cycles INTEGER NOT NULL DEFAULT 0, error_message TEXT,
-                success_criteria TEXT, auto_approve INTEGER NOT NULL DEFAULT 0)"""
-            )
+                success_criteria TEXT, auto_approve INTEGER NOT NULL DEFAULT 0)""")
             # Migrate DBs created before later columns were added.
             cols = {r["name"] for r in conn.execute("PRAGMA table_info(campaigns)")}
             if "success_criteria" not in cols:
@@ -710,39 +769,92 @@ def create_campaign(config: dict) -> dict:
     return {"id": campaign_id, "name": name, "status": CampaignStatus.READY}
 
 
-def update_campaign_status(campaign_id: str, new_status: str, **kwargs: Any) -> dict:
+def update_campaign_status(
+    campaign_id: str,
+    new_status: str,
+    *,
+    allowed_current: set | None = None,
+    expected_started_at: float | None = None,
+    **kwargs: Any,
+) -> dict:
+    """Transition a campaign's status atomically.
+
+    The status read and the UPDATE run inside ONE write transaction
+    (``BEGIN IMMEDIATE`` acquires the write lock before the read), so the
+    check-then-act cannot interleave with a concurrent transition from
+    another worker thread or process. This matters since the callers moved
+    off the event loop: the loop's run-to-completion no longer serializes
+    them, so e.g. two concurrent ``start`` requests could otherwise both
+    observe READY and both launch a worker.
+
+    ``allowed_current``: when given, the transition additionally requires the
+    CURRENT status to be in the set; a mismatch returns
+    ``{"error": ..., "code": "invalid_state", "current_status": ...}``
+    without writing. This is the conditional form of the HTTP action guard.
+
+    ``expected_started_at``: generation fence for background writers. Status
+    equality is not identity — a campaign paused and resumed while a watchdog
+    thread was deciding is RUNNING again, but it is a NEW run whose worker a
+    stale verdict must not touch (the ABA problem). ``started_at`` is rewritten
+    on every RUNNING transition, so it identifies the run generation: pass the
+    value READ FROM the observed row and the transition is refused
+    (``code: "stale_generation"``) when the row has been restarted since.
+    """
     if not _validate_campaign_id(campaign_id):
         return {"error": "invalid campaign_id"}
     db = _get_db()
-    row = db.execute("SELECT status FROM campaigns WHERE id = ?", (campaign_id,)).fetchone()
-    if row is None:
+    # Take the write lock BEFORE reading: makes read+check+write one atomic
+    # unit (busy_timeout absorbs contention; callers are on worker threads).
+    db.execute("BEGIN IMMEDIATE")
+    try:
+        row = db.execute(
+            "SELECT status, started_at FROM campaigns WHERE id = ?", (campaign_id,)
+        ).fetchone()
+        if row is None:
+            db.rollback()
+            return {"error": "campaign not found"}
+        current = row["status"]
+        if allowed_current is not None and current not in allowed_current:
+            db.rollback()
+            return {
+                "error": f"invalid source state: {current}",
+                "code": "invalid_state",
+                "current_status": current,
+            }
+        if expected_started_at is not None and row["started_at"] != expected_started_at:
+            db.rollback()
+            return {
+                "error": "campaign was restarted since this decision was made",
+                "code": "stale_generation",
+                "current_status": current,
+            }
+        if current in _TERMINAL_STATUSES and new_status not in (current, CampaignStatus.RUNNING):
+            db.rollback()
+            return {"error": f"invalid transition: {current} -> {new_status}"}
+        sets: list[str] = ["status = ?"]
+        vals: list[Any] = [new_status]
+        if new_status == CampaignStatus.RUNNING:
+            sets.append("started_at = ?")
+            vals.append(time.time())
+            # Clear the prior run's completed_at so resumed COMPLETE/STOPPED campaigns
+            # don't end up with completed_at < started_at (breaks duration math/UI).
+            sets.append("completed_at = ?")
+            vals.append(None)
+            kwargs.setdefault("error_message", None)  # clear stale failure on (re)start
+        if new_status in (CampaignStatus.COMPLETE, CampaignStatus.STOPPED, CampaignStatus.FAILED):
+            sets.append("completed_at = ?")
+            vals.append(time.time())
+        if "error_message" in kwargs:
+            sets.append("error_message = ?")
+            vals.append(kwargs["error_message"])
+        vals.append(campaign_id)
+        db.execute(f"UPDATE campaigns SET {', '.join(sets)} WHERE id = ?", vals)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
         db.close()
-        return {"error": "campaign not found"}
-    current = row["status"]
-    if current in _TERMINAL_STATUSES and new_status not in (current, CampaignStatus.RUNNING):
-        db.close()
-        return {"error": f"invalid transition: {current} -> {new_status}"}
-    sets: list[str] = ["status = ?"]
-    vals: list[Any] = [new_status]
-    if new_status == CampaignStatus.RUNNING:
-        sets.append("started_at = ?")
-        vals.append(time.time())
-        # Clear the prior run's completed_at so resumed COMPLETE/STOPPED campaigns
-        # don't end up with completed_at < started_at (breaks duration math/UI).
-        sets.append("completed_at = ?")
-        vals.append(None)
-        kwargs.setdefault("error_message", None)  # clear stale failure on (re)start
-    if new_status in (CampaignStatus.COMPLETE, CampaignStatus.STOPPED, CampaignStatus.FAILED):
-        sets.append("completed_at = ?")
-        vals.append(time.time())
-    if "error_message" in kwargs:
-        sets.append("error_message = ?")
-        vals.append(kwargs["error_message"])
-    vals.append(campaign_id)
-    db.execute("BEGIN")
-    db.execute(f"UPDATE campaigns SET {', '.join(sets)} WHERE id = ?", vals)
-    db.commit()
-    db.close()
     write_status(campaign_id, new_status, **kwargs)
     _audit(f"campaign_{new_status}", campaign_id)
     return {"id": campaign_id, "status": new_status}
@@ -989,6 +1101,82 @@ def _stalled_campaign_verdict(
     )
 
 
+def _fetch_running_campaigns() -> list[sqlite3.Row]:
+    """All RUNNING campaign rows the watchdog drives. Runs OFF the event loop."""
+    db = _get_db()
+    rows = db.execute(
+        "SELECT id, idle_secs, max_cycles, started_at, auto_approve, execution_mode "
+        "FROM campaigns WHERE status = ?",
+        (CampaignStatus.RUNNING,),
+    ).fetchall()
+    db.close()
+    return rows
+
+
+def _set_total_cycles(campaign_id: str, count: int) -> None:
+    """Persist the cycle counter. Runs OFF the event loop."""
+    db = _get_db()
+    db.execute("BEGIN")
+    db.execute("UPDATE campaigns SET total_cycles=? WHERE id=?", (count, campaign_id))
+    db.commit()
+    db.close()
+
+
+def _settle_cycle_advance(
+    campaign_id: str, latest: dict, count: int, max_cycles: int, expected_started_at: float | None
+) -> str | None:
+    """The watchdog's per-new-finding settle step. Runs OFF the event loop:
+    it performs several campaigns-DB writes that contend with concurrent HTTP
+    handlers.
+
+    Persists the advanced cycle counter, advances recursive exploration, and
+    applies the terminal status transition when one is due. Returns the
+    terminal event to emit (``"complete"`` / ``"stagnant"``) ONLY when the
+    transition actually persisted — a concurrent user Stop makes the campaign
+    terminal, ``update_campaign_status`` rejects the write, and emitting a
+    terminal SSE for a rejected transition would show clients a state that
+    disagrees with the persisted row. SSE emission stays with the caller on
+    the loop (``_emit_sse`` touches ``asyncio.Queue``, which is not
+    thread-safe).
+    """
+    _set_total_cycles(campaign_id, count)
+    # RL v2: advance recursive exploration (ingest agent-proposed emergent
+    # sub-questions + activate queued ones). Agent-mode only and fully
+    # guarded — must never break the watchdog.
+    _advance_exploration(campaign_id)
+    # allowed_current + expected_started_at: the settle decided these
+    # transitions while observing one RUNNING generation. A concurrent user
+    # action must win — Pause/Stop moves the status, and a pause+resume
+    # produces a NEW run that is RUNNING again (same status, different
+    # generation), which the started_at fence catches.
+    verified = latest.get("verification")
+    if isinstance(verified, dict) and verified.get("passed") is True:
+        res = update_campaign_status(
+            campaign_id,
+            CampaignStatus.COMPLETE,
+            allowed_current={CampaignStatus.RUNNING},
+            expected_started_at=expected_started_at,
+        )
+        return None if "error" in res else "complete"
+    if count >= max_cycles:
+        res = update_campaign_status(
+            campaign_id,
+            CampaignStatus.COMPLETE,
+            allowed_current={CampaignStatus.RUNNING},
+            expected_started_at=expected_started_at,
+        )
+        return None if "error" in res else "complete"
+    if check_stagnation(campaign_id):
+        res = update_campaign_status(
+            campaign_id,
+            CampaignStatus.STAGNANT,
+            allowed_current={CampaignStatus.RUNNING},
+            expected_started_at=expected_started_at,
+        )
+        return None if "error" in res else "stagnant"
+    return None
+
+
 async def _watchdog_loop(app: web.Application | None = None) -> None:
     state = app.get("state") if app is not None else None
     last_counts: dict[str, int] = {}
@@ -1013,20 +1201,17 @@ async def _watchdog_loop(app: web.Application | None = None) -> None:
                 # re-establishes trust and re-arms the loop in the per-campaign body.
                 await _suspend_research_loops_while_disabled(state)
                 continue
-            db = _get_db()
-            active = db.execute(
-                "SELECT id, idle_secs, max_cycles, started_at, auto_approve, execution_mode "
-                "FROM campaigns WHERE status = ?",
-                (CampaignStatus.RUNNING,),
-            ).fetchall()
-            db.close()
+            # Off the event loop: every connection carries the 30s busy
+            # timeout, and this SELECT contends with the same writers the
+            # handlers do (no-blocking-call-on-event-loop).
+            active = await asyncio.to_thread(_fetch_running_campaigns)
             for row in active:
                 cid = row["id"]
                 # Workflow-mode campaigns are driven by a Dynamic Workflow run;
                 # the adapter translates its events/result into the RL file+SSE
                 # model. The agent-mode body below does not apply to them.
                 if row["execution_mode"] == "workflow":
-                    await _poll_workflow_campaign(cid, state)
+                    await _poll_workflow_campaign(cid, state, row["started_at"])
                     continue
                 slot = state._slots.get(f"research-{cid}") if state is not None else None
                 # 24h auto-approve cap: expire trust and require re-authorization.
@@ -1034,19 +1219,30 @@ async def _watchdog_loop(app: web.Application | None = None) -> None:
                 if started and time.time() - started > _TRUST_TTL_SECS:
                     if slot is not None:
                         slot._trust = False
-                    qpath = _questions_path(cid)
-                    if qpath:
-                        qpath.write_text(
-                            json.dumps(
-                                {
-                                    "question": "Auto-approval expired after 24h. Resume to "
-                                    "re-authorize and continue."
-                                }
-                            )
-                        )
-                    update_campaign_status(cid, CampaignStatus.NEEDS_INPUT)
+                    # Transition FIRST (fenced on the observed generation);
+                    # write the re-auth question only for a persisted pause,
+                    # or a refused stale expiry would leave a stray question
+                    # file that pauses the user's freshly resumed run.
+                    res = await asyncio.to_thread(
+                        update_campaign_status,
+                        cid,
+                        CampaignStatus.NEEDS_INPUT,
+                        allowed_current={CampaignStatus.RUNNING},
+                        expected_started_at=started,
+                    )
                     _audit("campaign_trust_expired", cid)
-                    _emit_sse({"type": "needs_input", "campaign_id": cid})
+                    if "error" not in res:
+                        qpath = _questions_path(cid)
+                        if qpath:
+                            qpath.write_text(
+                                json.dumps(
+                                    {
+                                        "question": "Auto-approval expired after 24h. Resume to "
+                                        "re-authorize and continue."
+                                    }
+                                )
+                            )
+                        _emit_sse({"type": "needs_input", "campaign_id": cid})
                     continue
                 # Re-establish worker trust each cycle (restart-durable; bounded above).
                 if slot is not None and not slot._trust:
@@ -1062,8 +1258,15 @@ async def _watchdog_loop(app: web.Application | None = None) -> None:
                 # Attended: pause for the user. Unattended: discard the stray
                 # question + keep running (code-enforced; see helper).
                 if _should_pause_for_question(cid, bool(row["auto_approve"])):
-                    update_campaign_status(cid, CampaignStatus.NEEDS_INPUT)
-                    _emit_sse({"type": "needs_input", "campaign_id": cid})
+                    res = await asyncio.to_thread(
+                        update_campaign_status,
+                        cid,
+                        CampaignStatus.NEEDS_INPUT,
+                        allowed_current={CampaignStatus.RUNNING},
+                        expected_started_at=row["started_at"],
+                    )
+                    if "error" not in res:
+                        _emit_sse({"type": "needs_input", "campaign_id": cid})
                     continue
                 # Lightweight: count files without reading them all. Only parse
                 # the latest finding when count advances (avoids re-reading 50+
@@ -1076,33 +1279,28 @@ async def _watchdog_loop(app: web.Application | None = None) -> None:
                     continue
                 prev = last_counts[cid]
                 if count > prev:
+                    # Read the newest LLM-written finding (unbounded size) off
+                    # the loop, and emit new_finding BEFORE the settle writes —
+                    # the base ordering. last_counts advances only AFTER the
+                    # settle returns: if a settle write raises (e.g. a lock
+                    # wait that exhausts the busy timeout), the outer handler
+                    # logs it and the next cycle retries instead of silently
+                    # skipping this finding forever. A retried cycle re-emits
+                    # new_finding for the same finding — a benign duplicate.
+                    latest = await asyncio.to_thread(_read_finding_file, cycle_files[-1])
+                    _emit_sse({"type": "new_finding", "campaign_id": cid, "finding": latest})
+                    terminal = await asyncio.to_thread(
+                        _settle_cycle_advance,
+                        cid,
+                        latest,
+                        count,
+                        row["max_cycles"],
+                        row["started_at"],
+                    )
                     last_counts[cid] = count
                     last_ts[cid] = time.time()
-                    # Read only the newest finding (last file).
-                    latest = _read_finding_file(cycle_files[-1])
-                    _emit_sse({"type": "new_finding", "campaign_id": cid, "finding": latest})
-                    db2 = _get_db()
-                    db2.execute("BEGIN")
-                    db2.execute(
-                        "UPDATE campaigns SET total_cycles=? WHERE id=?",
-                        (count, cid),
-                    )
-                    db2.commit()
-                    db2.close()
-                    # RL v2: advance recursive exploration (ingest agent-proposed
-                    # emergent sub-questions + activate queued ones). Agent-mode
-                    # only and fully guarded — must never break the watchdog.
-                    _advance_exploration(cid)
-                    verified = latest.get("verification")
-                    if isinstance(verified, dict) and verified.get("passed") is True:
-                        update_campaign_status(cid, CampaignStatus.COMPLETE)
-                        _emit_sse({"type": "complete", "campaign_id": cid})
-                    elif count >= row["max_cycles"]:
-                        update_campaign_status(cid, CampaignStatus.COMPLETE)
-                        _emit_sse({"type": "complete", "campaign_id": cid})
-                    elif check_stagnation(cid):
-                        update_campaign_status(cid, CampaignStatus.STAGNANT)
-                        _emit_sse({"type": "stagnant", "campaign_id": cid})
+                    if terminal is not None:
+                        _emit_sse({"type": terminal, "campaign_id": cid})
                 elif cid in last_ts:
                     if slot is not None and slot.running:
                         # Agent is actively working this cycle (deep research can
@@ -1120,7 +1318,22 @@ async def _watchdog_loop(app: web.Application | None = None) -> None:
                         status, message = await asyncio.to_thread(
                             _stalled_campaign_verdict, cid, cycle_files
                         )
-                        update_campaign_status(cid, status, error_message=message)
+                        res = await asyncio.to_thread(
+                            update_campaign_status,
+                            cid,
+                            status,
+                            error_message=message,
+                            allowed_current={CampaignStatus.RUNNING},
+                            expected_started_at=row["started_at"],
+                        )
+                        if "error" in res:
+                            # The campaign was paused/stopped/restarted while
+                            # the verdict was being decided — the verdict is
+                            # stale. Touch NOTHING: tearing down the loop here
+                            # would kill the freshly resumed run's worker; the
+                            # next cycle re-baselines against the new
+                            # generation's started_at.
+                            continue
                         await _stop_loop(cid, remove=True)  # tear down so Resume re-arms cleanly
                         last_counts.pop(cid, None)
                         last_ts.pop(cid, None)
@@ -1175,13 +1388,21 @@ async def _launch_loop(request: web.Request, cid: str) -> None:
             "auto_research: cannot launch loop for %s (autonudge/state unavailable)", cid
         )
         return
-    db = _get_db()
-    row = db.execute(
-        "SELECT name, question, sub_questions, sources, scope_constraints, max_cycles, idle_secs, "
-        "success_criteria, auto_approve, parallel_workers, model FROM campaigns WHERE id = ?",
-        (cid,),
-    ).fetchone()
-    db.close()
+
+    def _read_launch_row() -> Any:
+        db = _get_db()
+        r = db.execute(
+            "SELECT name, question, sub_questions, sources, scope_constraints, max_cycles, "
+            "idle_secs, success_criteria, auto_approve, parallel_workers, model "
+            "FROM campaigns WHERE id = ?",
+            (cid,),
+        ).fetchone()
+        db.close()
+        return r
+
+    # Off the event loop: the connection carries the 30s busy timeout and the
+    # watchdog writes this table every cycle (no-blocking-call-on-event-loop).
+    row = await asyncio.to_thread(_read_launch_row)
     if row is None:
         return
     _write_brief(cid, row)
@@ -1476,50 +1697,63 @@ def _activate_emergent(campaign_id: str) -> list[dict]:
     if _sq.pending_count(queue) == 0:
         return []
     db = _get_db()
-    row = db.execute(
-        "SELECT execution_mode, max_subquestions_per_round, sub_questions, total_cycles "
-        "FROM campaigns WHERE id = ?",
-        (campaign_id,),
-    ).fetchone()
-    if row is None or row["execution_mode"] != DEFAULT_EXECUTION_MODE:
+    # BEGIN IMMEDIATE takes the write lock BEFORE the read: the whole-list
+    # sub_questions replacement below must not race a concurrent
+    # _handle_add_question append (both run on worker threads now), or one
+    # side's question is silently lost.
+    db.execute("BEGIN IMMEDIATE")
+    try:
+        row = db.execute(
+            "SELECT execution_mode, max_subquestions_per_round, sub_questions, total_cycles "
+            "FROM campaigns WHERE id = ?",
+            (campaign_id,),
+        ).fetchone()
+        if row is None or row["execution_mode"] != DEFAULT_EXECUTION_MODE:
+            db.rollback()
+            return []
+        subs = json.loads(row["sub_questions"] or "[]")
+        initial = [
+            s
+            for s in subs
+            if isinstance(s, dict) and s.get("origin") in ("grill", "manual", None, "")
+        ]
+        initial_open = [s for s in initial if s.get("status") != "answered"]
+        if initial_open and int(row["total_cycles"] or 0) < len(initial):
+            db.rollback()
+            return []  # still working the initial questions — hold emergent ones
+        k = int(
+            row["max_subquestions_per_round"]
+            if row["max_subquestions_per_round"] is not None
+            else DEFAULT_MAX_SUBQUESTIONS_PER_ROUND
+        )
+        activated = _sq.dequeue_top_k(queue, k)
+        if not activated:
+            db.rollback()
+            return []
+        for a in activated:
+            subs.append({"text": a["text"], "origin": "emergent", "status": "open"})
+        db.execute(
+            "UPDATE campaigns SET sub_questions = ? WHERE id = ?",
+            (json.dumps(subs), campaign_id),
+        )
+        full = db.execute(
+            "SELECT question, sub_questions, sources, scope_constraints, max_cycles, "
+            "idle_secs, success_criteria, auto_approve, parallel_workers "
+            "FROM campaigns WHERE id = ?",
+            (campaign_id,),
+        ).fetchone()
+        if full is not None:
+            # brief.md is rewritten while the write lock is held so briefs
+            # cannot publish out of commit order (see _append_question).
+            _write_brief(campaign_id, full)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
         db.close()
-        return []
-    subs = json.loads(row["sub_questions"] or "[]")
-    initial = [
-        s for s in subs if isinstance(s, dict) and s.get("origin") in ("grill", "manual", None, "")
-    ]
-    initial_open = [s for s in initial if s.get("status") != "answered"]
-    if initial_open and int(row["total_cycles"] or 0) < len(initial):
-        db.close()
-        return []  # still working the initial questions — hold emergent ones
-    k = int(
-        row["max_subquestions_per_round"]
-        if row["max_subquestions_per_round"] is not None
-        else DEFAULT_MAX_SUBQUESTIONS_PER_ROUND
-    )
-    activated = _sq.dequeue_top_k(queue, k)
-    if not activated:
-        db.close()
-        return []
-    for a in activated:
-        subs.append({"text": a["text"], "origin": "emergent", "status": "open"})
-    db.execute("BEGIN")
-    db.execute(
-        "UPDATE campaigns SET sub_questions = ? WHERE id = ?",
-        (json.dumps(subs), campaign_id),
-    )
-    db.commit()
     _sq.mark_analyzed(queue, activated)  # dedup ledger: never re-admit/re-activate
     _sq.save_queue(d, queue)
-    full = db.execute(
-        "SELECT question, sub_questions, sources, scope_constraints, max_cycles, "
-        "idle_secs, success_criteria, auto_approve, parallel_workers "
-        "FROM campaigns WHERE id = ?",
-        (campaign_id,),
-    ).fetchone()
-    db.close()
-    if full is not None:
-        _write_brief(campaign_id, full)  # surface the new emergent items next cycle
     _audit("campaign_emergent_activated", campaign_id)
     return activated
 
@@ -1652,6 +1886,11 @@ def _read_workflow_run_id(campaign_id: str) -> str | None:
 async def _launch_workflow(request: web.Request, cid: str) -> None:
     """Start the research methodology as a Dynamic Workflow (workflow mode).
 
+    Runs inside the caller's per-campaign action lock, immediately after the
+    RUNNING transition: only user actions rewrite started_at and they all
+    take the same lock, so the generation cannot change under this function
+    and the failure writes below need only the {RUNNING} status guard.
+
     Best-effort: if the gateway's WorkflowService is unavailable or the start
     fails, mark the campaign FAILED so it doesn't sit zombie in RUNNING. The
     watchdog adapter (`_poll_workflow_campaign`) translates the run's
@@ -1664,16 +1903,24 @@ async def _launch_workflow(request: web.Request, cid: str) -> None:
         logger.warning(
             "auto_research: workflow_service unavailable; cannot launch workflow for %s", cid
         )
-        update_campaign_status(
+        res = await asyncio.to_thread(
+            update_campaign_status,
             cid,
             CampaignStatus.FAILED,
             error_message="Dynamic Workflow engine unavailable — cannot start workflow mode.",
+            allowed_current={CampaignStatus.RUNNING},
         )
-        _emit_sse({"type": "failed", "campaign_id": cid})
+        if "error" not in res:
+            _emit_sse({"type": "failed", "campaign_id": cid})
         return
-    db = _get_db()
-    row = db.execute("SELECT * FROM campaigns WHERE id = ?", (cid,)).fetchone()
-    db.close()
+
+    def _read_full_row() -> Any:
+        db = _get_db()
+        r = db.execute("SELECT * FROM campaigns WHERE id = ?", (cid,)).fetchone()
+        db.close()
+        return r
+
+    row = await asyncio.to_thread(_read_full_row)
     if row is None:
         return
     args = build_workflow_args(dict(row))
@@ -1681,12 +1928,15 @@ async def _launch_workflow(request: web.Request, cid: str) -> None:
         res = await svc.start(RESEARCH_WORKFLOW_SOURCE, name="research-" + cid, args=args)
     except Exception:
         logger.exception("auto_research: workflow start failed for %s", cid)
-        update_campaign_status(
+        res = await asyncio.to_thread(
+            update_campaign_status,
             cid,
             CampaignStatus.FAILED,
             error_message="Workflow start failed — see gateway logs for details.",
+            allowed_current={CampaignStatus.RUNNING},
         )
-        _emit_sse({"type": "failed", "campaign_id": cid})
+        if "error" not in res:
+            _emit_sse({"type": "failed", "campaign_id": cid})
         return
     run_id = (res or {}).get("run_id")
     if run_id:
@@ -1694,10 +1944,15 @@ async def _launch_workflow(request: web.Request, cid: str) -> None:
         _audit("campaign_workflow_started", cid)
     else:
         logger.warning("auto_research: workflow start returned no run_id for %s: %s", cid, res)
-        update_campaign_status(
-            cid, CampaignStatus.FAILED, error_message="Workflow start returned no run ID."
+        res = await asyncio.to_thread(
+            update_campaign_status,
+            cid,
+            CampaignStatus.FAILED,
+            error_message="Workflow start returned no run ID.",
+            allowed_current={CampaignStatus.RUNNING},
         )
-        _emit_sse({"type": "failed", "campaign_id": cid})
+        if "error" not in res:
+            _emit_sse({"type": "failed", "campaign_id": cid})
 
 
 async def _stop_workflow(request: web.Request, cid: str) -> None:
@@ -1712,7 +1967,9 @@ async def _stop_workflow(request: web.Request, cid: str) -> None:
             logger.exception("auto_research: workflow cancel failed for %s", cid)
 
 
-async def _poll_workflow_campaign(campaign_id: str, state: Any) -> None:
+async def _poll_workflow_campaign(
+    campaign_id: str, state: Any, expected_started_at: float | None = None
+) -> None:
     """Adapter: translate a Dynamic Workflow run's events/result into the RL
     file + SSE model the existing UI consumes. Each `investigate:` agent that
     finishes becomes a cycle finding; on terminal the run's report is written to
@@ -1751,12 +2008,19 @@ async def _poll_workflow_campaign(campaign_id: str, state: Any) -> None:
                     run_meta = json.loads(run_file.read_text())
                     started_ts = float(run_meta.get("ts", 0))
                     if started_ts and (time.time() - started_ts) > 3600:
-                        update_campaign_status(
+                        res = await asyncio.to_thread(
+                            update_campaign_status,
                             campaign_id,
                             CampaignStatus.FAILED,
-                            error_message="Workflow run snapshot lost after 1h — run likely evicted or crashed.",
+                            error_message=(
+                                "Workflow run snapshot lost after 1h — "
+                                "run likely evicted or crashed."
+                            ),
+                            allowed_current={CampaignStatus.RUNNING},
+                            expected_started_at=expected_started_at,
                         )
-                        _emit_sse({"type": "failed", "campaign_id": campaign_id})
+                        if "error" not in res:
+                            _emit_sse({"type": "failed", "campaign_id": campaign_id})
                 except (json.JSONDecodeError, OSError, ValueError, TypeError):
                     pass
             return
@@ -1803,11 +2067,7 @@ async def _poll_workflow_campaign(campaign_id: str, state: Any) -> None:
             wrote = True
         if wrote:
             count = len(_list_cycle_files(campaign_id))
-            db = _get_db()
-            db.execute("BEGIN")
-            db.execute("UPDATE campaigns SET total_cycles=? WHERE id=?", (count, campaign_id))
-            db.commit()
-            db.close()
+            await asyncio.to_thread(_set_total_cycles, campaign_id, count)
             _emit_sse(
                 {
                     "type": "new_finding",
@@ -1823,17 +2083,28 @@ async def _poll_workflow_campaign(campaign_id: str, state: Any) -> None:
                 fs = (result or {}).get("findings") or []
                 report = "\n\n".join(str(x) for x in fs) if isinstance(fs, list) else ""
             d.joinpath("FINDINGS.md").write_text(_redact_llm(report) or "(no findings gathered)")
-            update_campaign_status(campaign_id, CampaignStatus.COMPLETE)
-            _emit_sse({"type": "complete", "campaign_id": campaign_id})
+            res = await asyncio.to_thread(
+                update_campaign_status,
+                campaign_id,
+                CampaignStatus.COMPLETE,
+                allowed_current={CampaignStatus.RUNNING},
+                expected_started_at=expected_started_at,
+            )
+            if "error" not in res:
+                _emit_sse({"type": "complete", "campaign_id": campaign_id})
         elif status in ("failed", "cancelled"):
-            update_campaign_status(
+            res = await asyncio.to_thread(
+                update_campaign_status,
                 campaign_id,
                 CampaignStatus.FAILED,
                 error_message=_redact_llm(
                     snap.get("error") or "workflow run ended without completing"
                 ),
+                allowed_current={CampaignStatus.RUNNING},
+                expected_started_at=expected_started_at,
             )
-            _emit_sse({"type": "failed", "campaign_id": campaign_id})
+            if "error" not in res:
+                _emit_sse({"type": "failed", "campaign_id": campaign_id})
     except Exception:
         logger.exception("auto_research: workflow poll failed for %s", campaign_id)
 
@@ -2097,6 +2368,23 @@ async def _handle_report(request: web.Request) -> web.Response:
     return web.json_response({"report": report})
 
 
+# Serializes one campaign's status transition + worker dispatch/teardown as a
+# unit. The DB transition itself is atomic (update_campaign_status), but the
+# dispatch that follows it awaits — without this lock a Stop can slip between
+# a Start's commit and its worker launch, tear down a loop that does not exist
+# yet, and leave the launched worker running against a STOPPED campaign.
+# Keyed per campaign; entries are dropped on delete. Loop-affine (asyncio.Lock),
+# which is safe because every acquirer runs on the gateway loop.
+_action_locks: dict[str, asyncio.Lock] = {}
+
+
+def _campaign_action_lock(campaign_id: str) -> asyncio.Lock:
+    lock = _action_locks.get(campaign_id)
+    if lock is None:
+        lock = _action_locks[campaign_id] = asyncio.Lock()
+    return lock
+
+
 async def _handle_action(request: web.Request) -> web.Response:
     if denied := _require_auth(request):
         return denied
@@ -2118,12 +2406,17 @@ async def _handle_action(request: web.Request) -> web.Response:
 
     # Fork: creates a new child campaign from a completed parent.
     if action == "fork":
-        db = _get_db()
-        parent = db.execute(
-            "SELECT id, question, sources, status, model FROM campaigns WHERE id = ?",
-            (cid,),
-        ).fetchone()
-        db.close()
+
+        def _read_fork_parent() -> Any:
+            db = _get_db()
+            r = db.execute(
+                "SELECT id, question, sources, status, model FROM campaigns WHERE id = ?",
+                (cid,),
+            ).fetchone()
+            db.close()
+            return r
+
+        parent = await asyncio.to_thread(_read_fork_parent)
         if parent is None:
             return web.json_response({"error": "Not found"}, status=404)
         if parent["status"] not in (CampaignStatus.COMPLETE, CampaignStatus.STOPPED):
@@ -2185,36 +2478,41 @@ async def _handle_action(request: web.Request) -> web.Response:
             CampaignStatus.NEEDS_INPUT,
         },
     }
-    db = _get_db()
-    srow = db.execute("SELECT status FROM campaigns WHERE id = ?", (cid,)).fetchone()
-    db.close()
-    if srow is None:
-        return web.json_response({"error": "Not found"}, status=404)
-    if srow["status"] not in allowed[action]:
-        return web.json_response(
-            {"error": f"Cannot {action} a campaign in '{srow['status']}' state"}, status=409
+
+    # Source-state validation and transition are ONE atomic conditional
+    # update (allowed_current): now that the guard and the write run on
+    # worker threads, a separate check-then-act would let two concurrent
+    # requests both observe READY and both launch a worker. The per-campaign
+    # lock additionally serializes the transition WITH its dispatch, so a
+    # second action cannot interleave between a commit and the worker
+    # launch/teardown that belongs to it.
+    async with _campaign_action_lock(cid):
+        result = await asyncio.to_thread(
+            update_campaign_status, cid, status_map[action], allowed_current=allowed[action]
         )
-    result = update_campaign_status(cid, status_map[action])
-    if "error" in result:
-        return web.json_response(result, status=404)
-    if action in ("start", "resume"):
-        mode = _campaign_execution_mode(cid)
-        if mode == "workflow":
-            await _launch_workflow(request, cid)
-        else:
-            await _launch_loop(request, cid)
-    elif action == "pause":
-        mode = _campaign_execution_mode(cid)
-        if mode == "workflow":
-            await _stop_workflow(request, cid)
-        else:
-            await _stop_loop(cid, remove=False)
-    elif action == "stop":
-        mode = _campaign_execution_mode(cid)
-        if mode == "workflow":
-            await _stop_workflow(request, cid)
-        else:
-            await _stop_loop(cid, remove=True)
+        if result.get("code") == "invalid_state":
+            return web.json_response(
+                {"error": f"Cannot {action} a campaign in '{result['current_status']}' state"},
+                status=409,
+            )
+        if "error" in result:
+            return web.json_response(result, status=404)
+        mode = await asyncio.to_thread(_campaign_execution_mode, cid)
+        if action in ("start", "resume"):
+            if mode == "workflow":
+                await _launch_workflow(request, cid)
+            else:
+                await _launch_loop(request, cid)
+        elif action == "pause":
+            if mode == "workflow":
+                await _stop_workflow(request, cid)
+            else:
+                await _stop_loop(cid, remove=False)
+        elif action == "stop":
+            if mode == "workflow":
+                await _stop_workflow(request, cid)
+            else:
+                await _stop_loop(cid, remove=True)
     return web.json_response(result)
 
 
@@ -2224,13 +2522,17 @@ async def _handle_delete(request: web.Request) -> web.Response:
     cid = request.match_info["id"]
     if not _validate_campaign_id(cid):
         return web.json_response({"error": "Invalid campaign ID"}, status=400)
-    # Tear down any running worker (agent loop or workflow run) first.
-    mode = _campaign_execution_mode(cid)
-    if mode == "workflow":
-        await _stop_workflow(request, cid)
-    else:
-        await _stop_loop(cid, remove=True)
-    result = delete_campaign(cid)
+    # Same serialization unit as _handle_action: teardown + row delete must
+    # not interleave with a concurrent action's transition + dispatch.
+    async with _campaign_action_lock(cid):
+        # Tear down any running worker (agent loop or workflow run) first.
+        mode = await asyncio.to_thread(_campaign_execution_mode, cid)
+        if mode == "workflow":
+            await _stop_workflow(request, cid)
+        else:
+            await _stop_loop(cid, remove=True)
+        result = await asyncio.to_thread(delete_campaign, cid)
+    _action_locks.pop(cid, None)
     if "error" in result:
         return web.json_response(result, status=404)
     _audit("campaign_deleted", cid)
@@ -2245,7 +2547,7 @@ async def _handle_nudge(request: web.Request) -> web.Response:
         return web.json_response({"error": "Invalid campaign ID"}, status=400)
     # Workflow-mode campaigns are driven by a deterministic DW script; guidance
     # injected mid-run has no effect (the script doesn't read guidance.txt).
-    if _campaign_execution_mode(cid) == "workflow":
+    if await asyncio.to_thread(_campaign_execution_mode, cid) == "workflow":
         return web.json_response(
             {
                 "error": "Nudge/guidance not supported in workflow mode — the script "
@@ -2264,7 +2566,15 @@ async def _handle_nudge(request: web.Request) -> web.Response:
     qp = _questions_path(cid)
     if qp and qp.exists():
         qp.unlink()
-        update_campaign_status(cid, CampaignStatus.RUNNING)
+        # Resume only from the paused-on-question state (RUNNING is a benign
+        # no-op re-assert); a campaign the user stopped/paused meanwhile must
+        # not be resurrected by answering a stale question.
+        await asyncio.to_thread(
+            update_campaign_status,
+            cid,
+            CampaignStatus.RUNNING,
+            allowed_current={CampaignStatus.NEEDS_INPUT, CampaignStatus.RUNNING},
+        )
     _audit("campaign_nudge", cid)
     return web.json_response({"ok": True})
 
@@ -2319,9 +2629,14 @@ async def _handle_report_status(request: web.Request) -> web.Response:
         return web.json_response({"error": "Invalid campaign ID"}, status=400)
     if not _HAS_ARTIFACTS:
         return web.json_response({"slug": None})
-    db = _get_db()
-    row = db.execute("SELECT report_artifact_slug FROM campaigns WHERE id = ?", (cid,)).fetchone()
-    db.close()
+
+    def _read_slug_row() -> Any:
+        db = _get_db()
+        r = db.execute("SELECT report_artifact_slug FROM campaigns WHERE id = ?", (cid,)).fetchone()
+        db.close()
+        return r
+
+    row = await asyncio.to_thread(_read_slug_row)
     if row is None:
         return web.json_response({"error": "Not found"}, status=404)
     slug = row["report_artifact_slug"]
@@ -2359,13 +2674,18 @@ async def _handle_to_artifact(request: web.Request) -> web.Response:
     findings_path = d / "FINDINGS.md"
     if not findings_path.exists():
         return web.json_response({"error": "No findings yet"}, status=404)
-    db = _get_db()
-    row = db.execute(
-        "SELECT question, sub_questions, total_cycles, status, report_artifact_slug "
-        "FROM campaigns WHERE id = ?",
-        (cid,),
-    ).fetchone()
-    db.close()
+
+    def _read_export_row() -> Any:
+        db = _get_db()
+        r = db.execute(
+            "SELECT question, sub_questions, total_cycles, status, report_artifact_slug "
+            "FROM campaigns WHERE id = ?",
+            (cid,),
+        ).fetchone()
+        db.close()
+        return r
+
+    row = await asyncio.to_thread(_read_export_row)
     if row is None:
         return web.json_response({"error": "Not found"}, status=404)
     question = row["question"]
@@ -2434,10 +2754,16 @@ async def _handle_to_artifact(request: web.Request) -> web.Response:
     # Persist the slug so the next export regenerates this same artifact and
     # the UI can show "View report" upfront.
     if art.slug != existing_slug:
-        db = _get_db()
-        db.execute("UPDATE campaigns SET report_artifact_slug = ? WHERE id = ?", (art.slug, cid))
-        db.commit()
-        db.close()
+
+        def _persist_slug() -> None:
+            db = _get_db()
+            db.execute(
+                "UPDATE campaigns SET report_artifact_slug = ? WHERE id = ?", (art.slug, cid)
+            )
+            db.commit()
+            db.close()
+
+        await asyncio.to_thread(_persist_slug)
     _audit("campaign_to_artifact", cid, slug=art.slug)
     return web.json_response(
         {"slug": art.slug, "name": name, "regenerated": regenerated},
@@ -2550,10 +2876,15 @@ async def _handle_to_knowledge(request: web.Request) -> web.Response:
         return web.json_response(
             {"error": "Already in Knowledge Library", "id": existing["id"]}, status=409
         )
+
     # Add source and trigger ingestion
-    db = _get_db()
-    row = db.execute("SELECT question FROM campaigns WHERE id = ?", (cid,)).fetchone()
-    db.close()
+    def _read_question_row() -> Any:
+        db = _get_db()
+        r = db.execute("SELECT question FROM campaigns WHERE id = ?", (cid,)).fetchone()
+        db.close()
+        return r
+
+    row = await asyncio.to_thread(_read_question_row)
     # The Knowledge Library is an external surface (RAG/search), so even the
     # source name metadata must be redacted before ingestion — matching the
     # treatment _handle_to_artifact applies to its artifact name.
@@ -2593,7 +2924,7 @@ async def _handle_add_question(request: web.Request) -> web.Response:
         return web.json_response({"error": "Invalid campaign ID"}, status=400)
     # Workflow-mode campaigns plan sub-questions at launch (the DW script
     # decomposes them internally); adding questions mid-run has no effect.
-    if _campaign_execution_mode(cid) == "workflow":
+    if await asyncio.to_thread(_campaign_execution_mode, cid) == "workflow":
         return web.json_response(
             {
                 "error": "Adding questions mid-run not supported in workflow mode — "
@@ -2608,32 +2939,56 @@ async def _handle_add_question(request: web.Request) -> web.Response:
     text = (body.get("text") or "").strip()
     if not text:
         return web.json_response({"error": "text required"}, status=400)
-    db = _get_db()
-    row = db.execute(
-        "SELECT sub_questions, question, sources, scope_constraints, max_cycles, "
-        "idle_secs, success_criteria, auto_approve FROM campaigns WHERE id = ?",
-        (cid,),
-    ).fetchone()
-    if row is None:
-        db.close()
+
+    def _append_question() -> list | None:
+        """Read-modify-write of sub_questions + brief rewrite, off the loop.
+        ``BEGIN IMMEDIATE`` takes the write lock BEFORE the read so two
+        concurrent appends (or an append racing the watchdog's emergent
+        activation) serialize instead of overwriting each other's whole-list
+        replacement. Returns the updated sub-question list, or None when the
+        campaign is gone."""
+        db = _get_db()
+        db.execute("BEGIN IMMEDIATE")
+        try:
+            row = db.execute(
+                "SELECT sub_questions, question, sources, scope_constraints, max_cycles, "
+                "idle_secs, success_criteria, auto_approve FROM campaigns WHERE id = ?",
+                (cid,),
+            ).fetchone()
+            if row is None:
+                db.rollback()
+                return None
+            subs = json.loads(row["sub_questions"] or "[]")
+            subs.append({"text": text, "origin": "manual", "status": "open"})
+            db.execute(
+                "UPDATE campaigns SET sub_questions = ? WHERE id = ?", (json.dumps(subs), cid)
+            )
+            # Re-read the row so _write_brief sees the updated sub_questions.
+            # parallel_workers MUST be included — _write_brief defaults it to 1 when
+            # absent, which would silently drop the parallel instruction from the brief.
+            row = db.execute(
+                "SELECT question, sub_questions, sources, scope_constraints, max_cycles, "
+                "idle_secs, success_criteria, auto_approve, parallel_workers "
+                "FROM campaigns WHERE id = ?",
+                (cid,),
+            ).fetchone()
+            # Regenerate brief.md while the write lock is still held: brief.md
+            # is the authoritative file the agent reads, and writing it after
+            # commit would let two appends commit in order yet publish their
+            # briefs out of order, leaving the older (question-missing) brief
+            # as the final one.
+            _write_brief(cid, row)
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+        return subs
+
+    subs = await asyncio.to_thread(_append_question)
+    if subs is None:
         return web.json_response({"error": "Not found"}, status=404)
-    subs = json.loads(row["sub_questions"] or "[]")
-    subs.append({"text": text, "origin": "manual", "status": "open"})
-    db.execute("BEGIN")
-    db.execute("UPDATE campaigns SET sub_questions = ? WHERE id = ?", (json.dumps(subs), cid))
-    db.commit()
-    # Re-read the row so _write_brief sees the updated sub_questions.
-    # parallel_workers MUST be included — _write_brief defaults it to 1 when
-    # absent, which would silently drop the parallel instruction from the brief.
-    row = db.execute(
-        "SELECT question, sub_questions, sources, scope_constraints, max_cycles, "
-        "idle_secs, success_criteria, auto_approve, parallel_workers "
-        "FROM campaigns WHERE id = ?",
-        (cid,),
-    ).fetchone()
-    db.close()
-    # Regenerate brief.md so the agent sees the new question next cycle.
-    _write_brief(cid, row)
     _audit("campaign_add_question", cid)
     _emit_sse({"type": "question_added", "campaign_id": cid})
     return web.json_response({"ok": True, "sub_questions": subs})

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -386,6 +386,13 @@ def _on_loop_persist_strict() -> bool:
 _ON_LOOP_TRUTHY = frozenset({"1", "true", "yes", "on"})
 _ON_LOOP_FALSY = frozenset({"0", "false", "no", "off"})
 
+# Public alias: other modules that enforce their own off-loop IO discipline
+# (e.g. the auto_research campaigns-DB chokepoint) share this single
+# strictness knob rather than growing per-module env vars that drift out of
+# dev/CI harnesses. Importing the public name keeps a rename of the private
+# implementation from breaking those modules at import time.
+on_loop_persist_strict = _on_loop_persist_strict
+
 
 def _check_on_loop_persist_discipline(key: str) -> None:
     """Enforce (strict) or diagnose (production) an on-loop ``_locked`` entry.
@@ -1815,9 +1822,7 @@ class ConversationLog:
                 )
                 return True
         except HistoryLockTimeout:
-            logger.warning(
-                "set_cached_intent_summary: lock timeout, not writing key=%s", key
-            )
+            logger.warning("set_cached_intent_summary: lock timeout, not writing key=%s", key)
             return False
 
     def append(
@@ -2307,9 +2312,7 @@ class ConversationLog:
             attempts = 0
         return max(0, attempts), retry_at
 
-    def _attempts_describe_current_span(
-        self, meta: dict, message_count: int | None
-    ) -> bool:
+    def _attempts_describe_current_span(self, meta: dict, message_count: int | None) -> bool:
         """True when the recorded attempts belong to the span in front of us now.
 
         A span is identified by where it starts AND how far it reaches: the
@@ -3053,8 +3056,7 @@ class ConversationLog:
                             continue
                         if (
                             d.get("_type") == "metadata"
-                            and str(d.get("memory_mode", "")).lower()
-                            in INCOGNITO_MEMORY_MODES
+                            and str(d.get("memory_mode", "")).lower() in INCOGNITO_MEMORY_MODES
                         ):
                             is_restricted = True
                             break
@@ -3223,9 +3225,7 @@ class ConversationLog:
         if "tab_id" in fields:
             self.invalidate_tab_id_cache()
 
-    def update_metadata_if(
-        self, key: str, fields: dict, guard: Callable[[dict], bool]
-    ) -> bool:
+    def update_metadata_if(self, key: str, fields: dict, guard: Callable[[dict], bool]) -> bool:
         """Merge *fields* only if *guard* still accepts the on-disk metadata.
 
         ``guard`` is evaluated INSIDE the cross-process lock, against the record
@@ -3839,11 +3839,7 @@ class ConversationLog:
                 # exactly like an undecodable one, so report it the same way --
                 # an empty dict that IS a genuine answer -- instead of throwing a
                 # non-OSError out of a read that callers treat as total.
-                meta = (
-                    data
-                    if isinstance(data, dict) and data.get("_type") == "metadata"
-                    else {}
-                )
+                meta = data if isinstance(data, dict) and data.get("_type") == "metadata" else {}
             except json.JSONDecodeError:
                 meta = {}
             self._meta_cache[key] = (mtime, meta)
@@ -4257,9 +4253,7 @@ class HistoryConsolidator:
             return False
         return (_time.time() if now is None else now) >= retry_at
 
-    async def _note_failed_attempt(
-        self, key: str, span: AttemptedSpan, reason: str
-    ) -> None:
+    async def _note_failed_attempt(self, key: str, span: AttemptedSpan, reason: str) -> None:
         """Charge one attempt for a billed turn that never reached the marker.
 
         Called only once the prompt has actually reached the provider, so a
@@ -4285,9 +4279,7 @@ class HistoryConsolidator:
         except Exception:
             # Without a persisted count the sweep cannot back off, so say so
             # loudly — but never let bookkeeping mask the original failure.
-            logger.warning(
-                "Could not persist consolidation retry state for %s", key, exc_info=True
-            )
+            logger.warning("Could not persist consolidation retry state for %s", key, exc_info=True)
             return
         if attempts < 1:
             # The session was deleted mid-consolidation, so nothing was recorded
@@ -4295,8 +4287,7 @@ class HistoryConsolidator:
             return
         if attempts < _CONSOLIDATION_MAX_ATTEMPTS:
             logger.warning(
-                "Consolidation attempt %d/%d failed for %s (%s); "
-                "next attempt in %.0fs",
+                "Consolidation attempt %d/%d failed for %s (%s); " "next attempt in %.0fs",
                 attempts,
                 _CONSOLIDATION_MAX_ATTEMPTS,
                 key,
@@ -4314,15 +4305,11 @@ class HistoryConsolidator:
             span.total,
         )
         try:
-            await asyncio.to_thread(
-                self._log.mark_consolidated, key, span.total, span.generation
-            )
+            await asyncio.to_thread(self._log.mark_consolidated, key, span.total, span.generation)
         except Exception:
             # The count stays at the cap, so retry_eligible() keeps refusing —
             # the span stops spending even though the marker is missing.
-            logger.warning(
-                "Could not mark abandoned consolidation for %s", key, exc_info=True
-            )
+            logger.warning("Could not mark abandoned consolidation for %s", key, exc_info=True)
 
     async def _note_environment_failure(self, key: str, reason: str) -> None:
         """Arm the backoff for a consolidation that never reached the provider.
@@ -4463,9 +4450,7 @@ class HistoryConsolidator:
         # expiry. Checked here (as well as inside _consolidate()) so the skip is
         # logged before a task is ever scheduled.
         if not self.retry_eligible(key, message_count=total):
-            logger.info(
-                "consolidate_session skipped for %s: consolidation retry backoff", key
-            )
+            logger.info("consolidate_session skipped for %s: consolidation retry backoff", key)
             return
         # Short-circuit sensitive sessions before scheduling a task
         messages = self._log._read_messages(key)
@@ -4575,9 +4560,7 @@ class HistoryConsolidator:
             # the sentinel lets those callbacks tell a refusal from a completed
             # pass and leave their bookkeeping untouched.
             if not self.retry_eligible(key, message_count=total):
-                logger.info(
-                    "_consolidate refused for %s: consolidation retry backoff", key
-                )
+                logger.info("_consolidate refused for %s: consolidation retry backoff", key)
                 return _CONSOLIDATION_REFUSED
             # Freeze the whole span identity from that one snapshot. The offset is
             # derived rather than returned because the snapshot slices at it
@@ -4728,9 +4711,7 @@ class HistoryConsolidator:
                 # unconsolidated: the span re-bills a full turn every idle window,
                 # and immediately after every restart. Charge the attempt.
                 if include_history:
-                    await self._note_failed_attempt(
-                        key, attempted, "empty LLM result"
-                    )
+                    await self._note_failed_attempt(key, attempted, "empty LLM result")
                 return None
 
             if entry := result.get("history_entry"):
@@ -4819,9 +4800,7 @@ class HistoryConsolidator:
             # skip conditions are false again on the next 60s tick. Charging the
             # attempt here is what converts that tight loop into backoff.
             if billed and include_history:
-                await self._note_failed_attempt(
-                    key, attempted, "exception after the LLM call"
-                )
+                await self._note_failed_attempt(key, attempted, "exception after the LLM call")
             raise
         finally:
             self._running.discard(key)
@@ -5683,9 +5662,7 @@ class HistoryConsolidator:
                     _time.monotonic() - t_start,
                     exc_info=True,
                 )
-                raise _ConsolidationNotDispatched(
-                    "background session unavailable"
-                ) from exc
+                raise _ConsolidationNotDispatched("background session unavailable") from exc
             t_acquired = _time.monotonic()
             wait_s = t_acquired - t_start
             # Reject all tools: this is a text/JSON-only generation turn. kiro

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,7 +20,9 @@ from kiro_crew.slack.handler import _PHASE_EMOJIS, _build_phase_emojis
 # ── Hypothesis profiles ─────────────────────────────────────────────────
 # Default (CI): fast iteration.  Run ``HYPOTHESIS_PROFILE=thorough python -m pytest``
 # for deeper coverage.
-settings.register_profile("default", max_examples=20, suppress_health_check=[HealthCheck.too_slow], deadline=None)
+settings.register_profile(
+    "default", max_examples=20, suppress_health_check=[HealthCheck.too_slow], deadline=None
+)
 settings.register_profile("thorough", max_examples=100)
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))
 
@@ -82,11 +84,7 @@ if platform_compat.IS_WINDOWS:
     # bypasses collect_ignore. One file, two readers, no drift.
     _ignore_listfile = os.path.join(os.path.dirname(__file__), "windows-collect-ignore.txt")
     with open(_ignore_listfile, encoding="utf-8") as _fh:
-        collect_ignore = [
-            name
-            for name in (ln.split("#", 1)[0].strip() for ln in _fh)
-            if name
-        ]
+        collect_ignore = [name for name in (ln.split("#", 1)[0].strip() for ln in _fh) if name]
 
 
 def make_escaping_link(inside: pathlib.Path, outside: pathlib.Path) -> str:
@@ -552,6 +550,14 @@ def _isolate_kirocrew_home(_isolation_dirs, monkeypatch):
     # would leak into every later test's port resolution. Clear it per test;
     # a test that wants it sets it via monkeypatch (which still wins).
     monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+    # Match CI on a dev box for the off-loop-IO strictness knob too: a developer
+    # with KIROCREW_DEV_MODE=1 (or KIROCREW_STRICT_ON_LOOP_PERSIST=1) exported
+    # would otherwise flip history's _locked guard AND the auto_research
+    # campaigns-DB guard strict for the whole suite, failing tests that call
+    # sync helpers directly on the loop as harness convenience. Tests that
+    # exercise strict mode set the env themselves via monkeypatch (which wins).
+    monkeypatch.delenv("KIROCREW_DEV_MODE", raising=False)
+    monkeypatch.delenv("KIROCREW_STRICT_ON_LOOP_PERSIST", raising=False)
     monkeypatch.setattr("kiro_crew.config.paths._resolved_home", None)
 
 
@@ -860,16 +866,29 @@ class MockSlackClient(SlackClientOps):
         self._fetch_message_result: str | None = None
         self._fetch_thread_replies_result: list[dict] = []
 
-    async def post_message(self, channel, text, thread_ts=None, unfurl_links=None, unfurl_media=None):
+    async def post_message(
+        self, channel, text, thread_ts=None, unfurl_links=None, unfurl_media=None
+    ):
         ts = f"{self._next_ts}.000000"
         self._next_ts += 1
         self.actions.append(
-            ("post", {"channel": channel, "text": text, "thread_ts": thread_ts, "ts": ts,
-                      "unfurl_links": unfurl_links, "unfurl_media": unfurl_media})
+            (
+                "post",
+                {
+                    "channel": channel,
+                    "text": text,
+                    "thread_ts": thread_ts,
+                    "ts": ts,
+                    "unfurl_links": unfurl_links,
+                    "unfurl_media": unfurl_media,
+                },
+            )
         )
         return ts
 
-    async def post_blocks(self, channel, blocks, text, thread_ts=None, unfurl_links=None, unfurl_media=None):
+    async def post_blocks(
+        self, channel, blocks, text, thread_ts=None, unfurl_links=None, unfurl_media=None
+    ):
         ts = f"{self._next_ts}.000000"
         self._next_ts += 1
         self.actions.append(
@@ -905,7 +924,18 @@ class MockSlackClient(SlackClientOps):
         return f"D{user_id}"
 
     async def post_ephemeral(self, channel, user_id, text, blocks=None, thread_ts=None):
-        self.actions.append(("ephemeral", {"channel": channel, "user_id": user_id, "text": text, "blocks": blocks, "thread_ts": thread_ts}))
+        self.actions.append(
+            (
+                "ephemeral",
+                {
+                    "channel": channel,
+                    "user_id": user_id,
+                    "text": text,
+                    "blocks": blocks,
+                    "thread_ts": thread_ts,
+                },
+            )
+        )
 
     async def views_publish(self, user_id, view):
         self.actions.append(("views_publish", {"user_id": user_id, "view": view}))
@@ -931,7 +961,9 @@ class MockSlackClient(SlackClientOps):
         )
 
     async def start_stream(self, channel, thread_ts, initial_text=None, team_id=None, user_id=None):
-        if not getattr(self, "_stream_enabled", False) or getattr(self, "_start_stream_fails", False):
+        if not getattr(self, "_stream_enabled", False) or getattr(
+            self, "_start_stream_fails", False
+        ):
             return None
         ts = f"{self._next_ts}.000000"
         self._next_ts += 1
@@ -986,8 +1018,20 @@ class MockSlackClient(SlackClientOps):
         self.actions.append(("fetch_message", {"channel": channel, "ts": ts}))
         return self._fetch_message_result
 
-    async def fetch_thread_replies(self, channel: str, thread_ts: str, limit: int = 200, warn_on_pagination: bool = True) -> list[dict]:
-        self.actions.append(("fetch_thread_replies", {"channel": channel, "thread_ts": thread_ts, "limit": limit, "warn_on_pagination": warn_on_pagination}))
+    async def fetch_thread_replies(
+        self, channel: str, thread_ts: str, limit: int = 200, warn_on_pagination: bool = True
+    ) -> list[dict]:
+        self.actions.append(
+            (
+                "fetch_thread_replies",
+                {
+                    "channel": channel,
+                    "thread_ts": thread_ts,
+                    "limit": limit,
+                    "warn_on_pagination": warn_on_pagination,
+                },
+            )
+        )
         return self._fetch_thread_replies_result
 
 

--- a/test/test_auto_research_handlers_coverage.py
+++ b/test/test_auto_research_handlers_coverage.py
@@ -295,6 +295,7 @@ class TestLaunchWorkflow:
     @pytest.mark.asyncio
     async def test_missing_workflow_service_fails_the_campaign(self, _isolate: Path, sse):
         cid = _campaign(execution_mode="workflow")
+        _running(cid)  # production launches only after the RUNNING transition
         await h._launch_workflow(_mk("PATCH", cid, app=_app(state=SimpleNamespace())), cid)
         assert _status(cid) == h.CampaignStatus.FAILED
         assert sse.types() == ["failed"]
@@ -303,6 +304,7 @@ class TestLaunchWorkflow:
     @pytest.mark.asyncio
     async def test_absent_state_fails_the_campaign(self, _isolate: Path, sse):
         cid = _campaign(execution_mode="workflow")
+        _running(cid)
         await h._launch_workflow(_mk("PATCH", cid, app=_app()), cid)
         assert _status(cid) == h.CampaignStatus.FAILED
 
@@ -331,6 +333,7 @@ class TestLaunchWorkflow:
     @pytest.mark.asyncio
     async def test_start_raising_fails_the_campaign(self, _isolate: Path, sse):
         cid = _campaign(execution_mode="workflow")
+        _running(cid)
         start = AsyncMock(side_effect=RuntimeError("engine down"))
         await h._launch_workflow(
             _mk("PATCH", cid, app=_app(state=_workflow_state(start=start))), cid
@@ -342,6 +345,7 @@ class TestLaunchWorkflow:
     @pytest.mark.asyncio
     async def test_start_without_a_run_id_fails_the_campaign(self, _isolate: Path, sse):
         cid = _campaign(execution_mode="workflow")
+        _running(cid)
         start = AsyncMock(return_value=None)
         await h._launch_workflow(
             _mk("PATCH", cid, app=_app(state=_workflow_state(start=start))), cid
@@ -625,9 +629,11 @@ class TestWatchdogLoop:
         _running(cid, started_at=time.time() - (h._TRUST_TTL_SECS + 60))
         slot = SimpleNamespace(_trust=True, running=False)
         state = SimpleNamespace(_slots={f"research-{cid}": slot})
-        assert await _drive_watchdog(
-            {"state": state}, lambda: _status(cid) == h.CampaignStatus.NEEDS_INPUT
-        )
+        # Wait on the SSE event, not the DB row: the status commits on a worker
+        # thread BEFORE the emit, so a status-based wait can cancel the watchdog
+        # at the await point and strand the emit.
+        assert await _drive_watchdog({"state": state}, lambda: "needs_input" in sse.types())
+        assert _status(cid) == h.CampaignStatus.NEEDS_INPUT
         assert slot._trust is False
         question = json.loads((h._campaign_dir(cid) / "questions.json").read_text())
         assert "24h" in question["question"]
@@ -657,9 +663,10 @@ class TestWatchdogLoop:
         cid = _campaign(auto_approve=False)
         _running(cid)
         (h._campaign_dir(cid) / "questions.json").write_text('{"question": "Which DB?"}')
-        assert await _drive_watchdog(
-            {"state": None}, lambda: _status(cid) == h.CampaignStatus.NEEDS_INPUT
-        )
+        # SSE is the last observable step (status commits on a worker thread
+        # first) — waiting on it avoids cancelling the watchdog mid-settle.
+        assert await _drive_watchdog({"state": None}, lambda: "needs_input" in sse.types())
+        assert _status(cid) == h.CampaignStatus.NEEDS_INPUT
         assert "needs_input" in sse.types()
 
     @pytest.mark.asyncio
@@ -677,7 +684,11 @@ class TestWatchdogLoop:
         try:
             assert await _await_until(lambda: polls["n"] >= 1)  # baseline count recorded
             _write_finding(cid, 2, verification={"passed": True})
-            assert await _await_until(lambda: _status(cid) == h.CampaignStatus.COMPLETE)
+            # The "complete" SSE is emitted after the settle thread persists the
+            # transition — waiting on it (not the row) keeps the cancel from
+            # landing between the commit and the emit.
+            assert await _await_until(lambda: "complete" in sse.types())
+            assert _status(cid) == h.CampaignStatus.COMPLETE
         finally:
             task.cancel()
             try:
@@ -700,7 +711,8 @@ class TestWatchdogLoop:
         try:
             assert await _await_until(lambda: polls["n"] >= 1)
             _write_finding(cid, 2)  # unverified, but hits max_cycles
-            assert await _await_until(lambda: _status(cid) == h.CampaignStatus.COMPLETE)
+            assert await _await_until(lambda: "complete" in sse.types())
+            assert _status(cid) == h.CampaignStatus.COMPLETE
         finally:
             task.cancel()
             try:
@@ -721,7 +733,8 @@ class TestWatchdogLoop:
         try:
             assert await _await_until(lambda: polls["n"] >= 1)
             _write_finding(cid, 6, new_findings_count=0)
-            assert await _await_until(lambda: _status(cid) == h.CampaignStatus.STAGNANT)
+            assert await _await_until(lambda: "stagnant" in sse.types())
+            assert _status(cid) == h.CampaignStatus.STAGNANT
         finally:
             task.cancel()
             try:
@@ -740,9 +753,11 @@ class TestWatchdogLoop:
         cid = _campaign(auto_approve=True)
         _running(cid)
         _write_finding(cid, 1)
-        assert await _drive_watchdog(
-            {"state": None}, lambda: _status(cid) == h.CampaignStatus.FAILED
-        )
+        # The "failed" SSE is the last observable in the stalled branch (status
+        # commits on a worker thread first) — waiting on it keeps the cancel
+        # from stranding the teardown + emit.
+        assert await _drive_watchdog({"state": None}, lambda: "failed" in sse.types())
+        assert _status(cid) == h.CampaignStatus.FAILED
         assert "stalled" in (h.get_campaign(cid) or {})["error_message"]
         stop_loop.assert_awaited_with(cid, remove=True)
         assert "failed" in sse.types()

--- a/test/test_auto_research_onloop_db.py
+++ b/test/test_auto_research_onloop_db.py
@@ -1,0 +1,426 @@
+"""Off-loop DB discipline for the auto_research campaigns DB.
+
+Every connection from ``_get_db()`` carries a 30s busy timeout, and the
+watchdog writes the campaigns table every cycle while HTTP handlers read and
+write the same rows — so a single ``_get_db()`` entered directly on the
+asyncio event loop can freeze the whole gateway past the loop-stall watchdog
+budget (25s) and hard-exit the process. These tests pin the discipline from
+three directions:
+
+1. the runtime chokepoint guard in ``_get_db()`` (strict raise / production
+   warn / off-loop no-op),
+2. a static AST ratchet: no ``async def`` in handlers.py calls a DB-touching
+   function directly (the offload pattern is ``asyncio.to_thread`` /
+   ``run_in_executor``, optionally via a nested sync helper),
+3. an end-to-end contention proof: a held write lock on the campaigns DB
+   stalls the affected handler, not the event loop's heartbeat.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import json
+import sqlite3
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.apps.builtins.auto_research import handlers as h
+from kiro_crew.apps.builtins.auto_research.handlers import (
+    CampaignStatus,
+    OnLoopDBError,
+    _get_db,
+    create_campaign,
+    get_campaign,
+    register_routes,
+    update_campaign_status,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path):
+    """Isolate DB and research dir per test (same shape as test_auto_research)."""
+    with (
+        patch(
+            "kiro_crew.apps.builtins.auto_research.handlers.DB_PATH",
+            tmp_path / "test.db",
+        ),
+        patch(
+            "kiro_crew.apps.builtins.auto_research.handlers.RESEARCH_DIR",
+            tmp_path / "research",
+        ),
+    ):
+        yield tmp_path
+
+
+class TestOnLoopGuard:
+    """The runtime chokepoint: ``_get_db()`` flags on-loop entry."""
+
+    @pytest.mark.asyncio
+    async def test_on_loop_get_db_raises_under_strict(self, monkeypatch):
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "1")
+        with pytest.raises(OnLoopDBError):
+            _get_db()
+
+    def test_off_loop_get_db_allowed_under_strict(self, monkeypatch):
+        """No running loop (worker thread / executor / CLI) is the sanctioned
+        path — strict mode must not flag it."""
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "1")
+        conn = _get_db()
+        try:
+            assert conn.execute("SELECT 1").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+    @pytest.mark.asyncio
+    async def test_on_loop_get_db_warns_in_production_mode(self, monkeypatch, caplog):
+        """Strict off (production): the on-loop entry proceeds but logs loudly,
+        so a mis-wired call-site is never silent."""
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "0")
+        monkeypatch.setattr(h, "_on_loop_db_warn_last", 0.0)  # reset throttle window
+        with caplog.at_level("WARNING", logger=h.logger.name):
+            conn = _get_db()
+            conn.close()
+        assert any("event loop" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_on_loop_warning_is_throttled(self, monkeypatch, caplog):
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "0")
+        monkeypatch.setattr(h, "_on_loop_db_warn_last", 0.0)
+        with caplog.at_level("WARNING", logger=h.logger.name):
+            for _ in range(3):
+                conn = _get_db()
+                conn.close()
+        assert sum("event loop" in r.message for r in caplog.records) == 1
+
+    def test_get_db_enters_the_guard(self):
+        """Mutation guard: removing the discipline check from ``_get_db``
+        silently disarms every other protection here — pin the call."""
+        tree = ast.parse(inspect.getsource(h._get_db))
+        fn = tree.body[0]
+        calls = [
+            n.func.id
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        ]
+        assert "_check_on_loop_db_discipline" in calls
+
+
+# Functions that open (or transitively open) the campaigns DB. A direct call
+# to any of these inside an ``async def`` in handlers.py runs the 30s busy
+# timeout on the event loop. Extend this set when adding a new sync DB helper.
+_DB_TOUCHING_FNS = frozenset(
+    {
+        "_get_db",
+        "update_campaign_status",
+        "delete_campaign",
+        "create_campaign",
+        "get_campaign",
+        "list_campaigns",
+        "validate_campaign",
+        "_campaign_execution_mode",
+        "_should_finalize",
+        "_ingest_emergent_questions",
+        "_activate_emergent",
+        "_advance_exploration",
+        "_settle_cycle_advance",
+        "_fetch_running_campaigns",
+        "_set_total_cycles",
+    }
+)
+
+
+class TestStaticRatchet:
+    def test_no_async_def_calls_db_functions_directly(self):
+        """AST ratchet: every DB touch from async code must be offloaded.
+
+        Enforced shape: inside an ``async def``, a DB-touching function may
+        only appear as an ARGUMENT to ``asyncio.to_thread`` /
+        ``run_in_executor`` — never called directly. A nested sync ``def``
+        whose body touches the DB is the other offload pattern; it must
+        itself be passed to ``to_thread``/``run_in_executor`` in the
+        enclosing async def, and a direct in-line call to it (``row =
+        _read_row()``) is flagged, since that re-runs the 30s busy wait on
+        the loop while staying invisible to a name-based scan.
+        """
+        src = Path(inspect.getsourcefile(h)).read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        violations: list[str] = []
+
+        def _body_touches_db(fn: ast.FunctionDef) -> bool:
+            for n in ast.walk(fn):
+                if (
+                    isinstance(n, ast.Call)
+                    and isinstance(n.func, ast.Name)
+                    and n.func.id in _DB_TOUCHING_FNS
+                ):
+                    return True
+            return False
+
+        def _is_offload_call(n: ast.Call) -> bool:
+            return isinstance(n.func, ast.Attribute) and n.func.attr in (
+                "to_thread",
+                "run_in_executor",
+            )
+
+        def scan(node: ast.AsyncFunctionDef) -> None:
+            db_closures = {
+                child.name
+                for child in ast.walk(node)
+                if isinstance(child, ast.FunctionDef) and _body_touches_db(child)
+            }
+            offloaded: set[str] = set()
+            flagged = _DB_TOUCHING_FNS | db_closures
+            stack = list(ast.iter_child_nodes(node))
+            while stack:
+                n = stack.pop()
+                if isinstance(n, ast.FunctionDef):
+                    continue  # nested sync helper body runs off-loop when offloaded
+                if isinstance(n, ast.Call):
+                    if _is_offload_call(n):
+                        offloaded.update(
+                            a.id for a in n.args if isinstance(a, ast.Name) and a.id in flagged
+                        )
+                    elif isinstance(n.func, ast.Name) and n.func.id in flagged:
+                        violations.append(f"{node.name}:{n.lineno} calls {n.func.id}() on the loop")
+                stack.extend(ast.iter_child_nodes(n))
+            for name in sorted(db_closures - offloaded):
+                violations.append(
+                    f"{node.name}: nested DB helper {name}() is defined but never "
+                    "passed to asyncio.to_thread / run_in_executor"
+                )
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef):
+                scan(node)
+        assert not violations, (
+            "direct campaigns-DB call(s) on the event loop (offload via "
+            "asyncio.to_thread / run_in_executor):\n" + "\n".join(violations)
+        )
+
+
+class TestContention:
+    @pytest.fixture
+    def app(self, tmp_path: Path):
+        @web.middleware
+        async def _inject_user(request, handler):
+            request["user"] = "test-user"
+            return await handler(request)
+
+        a = web.Application(middlewares=[_inject_user])
+        register_routes(a)
+        return a
+
+    @pytest.mark.asyncio
+    async def test_held_write_lock_stalls_handler_not_heartbeat(self, app, tmp_path: Path):
+        """A write lock held on the campaigns DB must stall only the request
+        that needs the lock — never the event loop. This is the production
+        failure shape: the watchdog writes every cycle, a user clicks Pause
+        mid-write, and before the fix the handler's 30s busy wait ran ON the
+        loop, silencing the gateway heartbeat past the watchdog kill budget.
+        """
+        async with TestClient(TestServer(app)) as c:
+            cr = await c.post(
+                "/api/apps/auto-research/campaigns",
+                json={"question": "How do teams handle rate limiting?", "sources": ["web"]},
+            )
+            assert cr.status == 201
+            cid = (await cr.json())["id"]
+            # Pause is only legal from RUNNING.
+            await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+
+            # Hold the campaigns-DB write lock like a mid-write watchdog cycle.
+            blocker = sqlite3.connect(str(tmp_path / "test.db"))
+            blocker.execute("BEGIN IMMEDIATE")
+
+            ticks = 0
+
+            async def heartbeat() -> None:
+                nonlocal ticks
+                while True:
+                    ticks += 1
+                    await asyncio.sleep(0.02)
+
+            hb = asyncio.create_task(heartbeat())
+            req = asyncio.create_task(
+                c.patch(f"/api/apps/auto-research/campaigns/{cid}", json={"action": "pause"})
+            )
+            try:
+                await asyncio.sleep(0.6)
+                # The handler is genuinely blocked on the contended write...
+                assert not req.done(), "handler finished despite a held write lock"
+                # ...while the event loop stayed live (~30 ticks expected; >=5
+                # is a generous slow-CI floor — an on-loop 30s busy wait yields
+                # 0-1 because this sleep itself cannot run either).
+                assert ticks >= 5, f"event loop starved during contended DB write (ticks={ticks})"
+            finally:
+                blocker.rollback()
+                blocker.close()
+                hb.cancel()
+            resp = await req
+            assert resp.status == 200
+            assert (await resp.json())["status"] == CampaignStatus.PAUSED
+
+
+class TestOffloadRaces:
+    """The offload removes the event loop's run-to-completion serialization,
+    so the check-then-act and read-modify-write sequences that used to be
+    atomic-by-construction must now be atomic in the database."""
+
+    @pytest.fixture
+    def app(self, tmp_path: Path):
+        @web.middleware
+        async def _inject_user(request, handler):
+            request["user"] = "test-user"
+            return await handler(request)
+
+        a = web.Application(middlewares=[_inject_user])
+        register_routes(a)
+        return a
+
+    def test_allowed_current_rejects_wrong_source_state(self):
+        c = create_campaign({"question": "How do teams handle rate limiting?", "sources": ["web"]})
+        cid = c["id"]
+        # READY is not a legal 'pause' source.
+        res = update_campaign_status(
+            cid, CampaignStatus.PAUSED, allowed_current={CampaignStatus.RUNNING}
+        )
+        assert res.get("code") == "invalid_state"
+        assert res["current_status"] == CampaignStatus.READY
+        # Nothing was written.
+        assert get_campaign(cid)["status"] == CampaignStatus.READY
+        # The matching source state transitions normally.
+        res = update_campaign_status(
+            cid, CampaignStatus.RUNNING, allowed_current={CampaignStatus.READY}
+        )
+        assert res == {"id": cid, "status": CampaignStatus.RUNNING}
+
+    @pytest.mark.asyncio
+    async def test_concurrent_start_launches_exactly_once(self, app):
+        """Two racing start requests: exactly one wins the atomic conditional
+        transition; the loser gets 409 instead of relaunching a duplicate
+        worker (before the fix both could observe READY across the thread
+        hop)."""
+        async with TestClient(TestServer(app)) as c:
+            cr = await c.post(
+                "/api/apps/auto-research/campaigns",
+                json={"question": "How do teams handle rate limiting?", "sources": ["web"]},
+            )
+            cid = (await cr.json())["id"]
+            r1, r2 = await asyncio.gather(
+                c.patch(f"/api/apps/auto-research/campaigns/{cid}", json={"action": "start"}),
+                c.patch(f"/api/apps/auto-research/campaigns/{cid}", json={"action": "start"}),
+            )
+            assert sorted([r1.status, r2.status]) == [200, 409]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_add_question_loses_nothing(self, app):
+        """N concurrent appends must all land: the RMW takes the write lock
+        BEFORE the read, so whole-list replacements serialize instead of
+        overwriting each other."""
+        async with TestClient(TestServer(app)) as c:
+            cr = await c.post(
+                "/api/apps/auto-research/campaigns",
+                json={"question": "How do teams handle rate limiting?", "sources": ["web"]},
+            )
+            cid = (await cr.json())["id"]
+            n = 12
+            responses = await asyncio.gather(
+                *(
+                    c.post(
+                        f"/api/apps/auto-research/campaigns/{cid}/questions",
+                        json={"text": f"question number {i}"},
+                    )
+                    for i in range(n)
+                )
+            )
+            assert all(r.status == 200 for r in responses)
+            final = await asyncio.to_thread(get_campaign, cid)
+            texts = {q["text"] for q in json.loads(final["sub_questions"])}
+            missing = {f"question number {i}" for i in range(n)} - texts
+            assert not missing, f"lost concurrent sub-question appends: {sorted(missing)}"
+
+    @pytest.mark.parametrize(
+        "user_state",
+        [CampaignStatus.STOPPED, CampaignStatus.PAUSED],
+    )
+    def test_settle_suppresses_terminal_event_when_transition_rejected(
+        self, tmp_path: Path, user_state
+    ):
+        """A user action landing before the watchdog's settle (Stop OR Pause —
+        the settle observed RUNNING, so any moved row wins) must make the
+        settle's terminal write a refused no-op with no terminal SSE event."""
+        c = create_campaign(
+            {
+                "question": "How do teams handle rate limiting?",
+                "sources": ["web"],
+                "max_cycles": 1,
+            }
+        )
+        cid = c["id"]
+        if user_state == CampaignStatus.PAUSED:
+            update_campaign_status(cid, CampaignStatus.RUNNING)
+        gen = (get_campaign(cid) or {}).get("started_at")
+        update_campaign_status(cid, user_state)
+        # count >= max_cycles would normally yield "complete"; the moved row
+        # must suppress both the write and the event.
+        terminal = h._settle_cycle_advance(cid, {"cycle": 1}, 1, 1, gen)
+        assert terminal is None
+        assert get_campaign(cid)["status"] == user_state
+
+    def test_settle_refuses_a_restarted_run_with_matching_status(self, tmp_path: Path):
+        """The ABA case: pause+resume while the settle thread was deciding.
+        The row is RUNNING again — same status the settle observed — but it is
+        a NEW run; the started_at generation fence must refuse the stale
+        terminal write instead of completing (and tearing down) the fresh
+        run."""
+        c = create_campaign(
+            {
+                "question": "How do teams handle rate limiting?",
+                "sources": ["web"],
+                "max_cycles": 1,
+            }
+        )
+        cid = c["id"]
+        update_campaign_status(cid, CampaignStatus.RUNNING)
+        old_gen = get_campaign(cid)["started_at"]
+        update_campaign_status(cid, CampaignStatus.PAUSED)
+        time.sleep(0.01)  # ensure the resume mints a distinct started_at
+        update_campaign_status(cid, CampaignStatus.RUNNING)
+        new_gen = get_campaign(cid)["started_at"]
+        assert new_gen != old_gen
+        terminal = h._settle_cycle_advance(cid, {"cycle": 1}, 1, 1, old_gen)
+        assert terminal is None
+        assert get_campaign(cid)["status"] == CampaignStatus.RUNNING
+
+    def test_stale_generation_is_refused_with_a_typed_code(self, tmp_path: Path):
+        c = create_campaign({"question": "How do teams handle rate limiting?", "sources": ["web"]})
+        cid = c["id"]
+        update_campaign_status(cid, CampaignStatus.RUNNING)
+        old_gen = get_campaign(cid)["started_at"]
+        update_campaign_status(cid, CampaignStatus.PAUSED)
+        time.sleep(0.01)
+        update_campaign_status(cid, CampaignStatus.RUNNING)
+        res = update_campaign_status(
+            cid,
+            CampaignStatus.COMPLETE,
+            allowed_current={CampaignStatus.RUNNING},
+            expected_started_at=old_gen,
+        )
+        assert res.get("code") == "stale_generation"
+        assert get_campaign(cid)["status"] == CampaignStatus.RUNNING
+        # The matching generation transitions normally.
+        cur_gen = get_campaign(cid)["started_at"]
+        res = update_campaign_status(
+            cid,
+            CampaignStatus.COMPLETE,
+            allowed_current={CampaignStatus.RUNNING},
+            expected_started_at=cur_gen,
+        )
+        assert res == {"id": cid, "status": CampaignStatus.COMPLETE}


### PR DESCRIPTION
## What is the problem?

`apps/builtins/auto_research/handlers.py` opens every SQLite connection with a deliberate 30-second busy timeout (`timeout=30.0` + `PRAGMA busy_timeout=30000`), and then calls `_get_db()` **directly on the asyncio event loop** from 7 `async def` HTTP handlers, both long-lived loops (`_watchdog_loop`, `_poll_workflow_campaign`), and six sync helpers reached from them with no thread hop.

## Why this issue matters to the user

The gateway runs everything on one event loop, and the loop-stall watchdog hard-exits the process after 25s of heartbeat silence. 30s > 25s, so a **single** contended lock wait on the loop can take down the whole gateway. The contention is built in, not hypothetical: the watchdog writes the campaigns table every 5s cycle, so a user clicking any Research Lab action button mid-write enters a handler that waits on the loop. The process then respawns into the same condition — a crash loop.

## How our fix solves it

Symptom → root cause → change:

- **Symptom**: gateway freezes/restarts while a research campaign is active.
- **Root cause**: the 30s busy wait runs on the event loop. The timeout itself is correct (it absorbs write contention instead of surfacing "database is locked" to the user) — the defect is *where* it waits. On a worker thread a 30s wait delays one request and nothing else.
- **Change**: every campaigns-DB section reachable from async code is offloaded via `asyncio.to_thread` (the pattern `_handle_create`/`_handle_list` already used). The watchdog's per-finding settle step, both workflow-mode poll/launch paths, and all remaining handlers now hop to a thread.

Removing the loop's run-to-completion serialization makes previously-unreachable races reachable, so the offload is paired with database-level atomicity (found by the pre-push review fleet):

- The HTTP action guard (start/pause/resume/stop) is now an **atomic conditional transition**: `update_campaign_status(allowed_current=...)` takes the write lock (`BEGIN IMMEDIATE`) before reading, validates the source state inside the same transaction, and returns a typed `invalid_state` result that maps to the same 409. Two racing `start` requests can no longer both observe READY and launch duplicate workers.
- Both `sub_questions` read-modify-writes (`_handle_add_question`, `_activate_emergent`) take the write lock **before** the read, so concurrent whole-list replacements serialize instead of silently dropping a question.
- State SSE events (`complete`/`stagnant`/`failed`/`needs_input`) are emitted **only when the transition actually persisted** — a concurrent user Stop makes the campaign terminal and the rejected write must not tell SSE clients otherwise.
- The watchdog emits `new_finding` before the settle writes (base ordering) and advances its cycle bookkeeping only after the settle succeeds, so a failed settle is retried next cycle instead of silently skipping the finding forever.

Regression protection, following `history.py`'s off-loop persistence discipline:

- `_get_db()` now enforces an on-loop discipline guard: under the shared strictness knob (`KIROCREW_STRICT_ON_LOOP_PERSIST=1` / `KIROCREW_DEV_MODE`, exported publicly from `history.py` as `on_loop_persist_strict`) an on-loop entry raises `OnLoopDBError`; in production it logs a throttled warning and proceeds. The e2e gate already boots with the knob armed, so it now covers this chokepoint too (docs updated).
- An AST ratchet test bans direct DB-touching calls inside any `async def` in the file, and requires nested sync DB closures to actually be passed to `to_thread`/`run_in_executor` (a direct in-line call to one is flagged).
- `test/conftest.py` scrubs `KIROCREW_DEV_MODE`/`KIROCREW_STRICT_ON_LOOP_PERSIST` per test (matching CI on a dev box), so a developer's exported dev-mode cannot flip either discipline strict for unrelated harness-convenience calls.

## What tests we did

- **New** `test/test_auto_research_onloop_db.py` (16 tests):
  - guard behavior: strict raise on-loop, off-loop allowed under strict, production warn + 60s throttle, AST pin that `_get_db` enters the guard
  - static AST ratchet (above)
  - end-to-end contention proof: a held `BEGIN IMMEDIATE` write lock stalls the Pause handler (still incomplete at +0.6s) while a 20ms heartbeat coroutine keeps ticking on the loop; releasing the lock completes the request with 200
  - race regressions: two concurrent `start` → exactly `[200, 409]`; 12 concurrent add-question requests → zero lost appends; settle suppresses the terminal event when a concurrent Stop made the row terminal; `allowed_current` unit semantics
- **Mutation-verified**: reverting one offload fails both the ratchet and the contention test (the loop measurably freezes for the full 30s busy wait); dropping the `allowed_current` guard fails the unit test *and* the concurrent-start test with `[200, 200]`; ignoring the settle result fails the suppression test; calling a nested DB closure in-line fails the ratchet.
- Full local gates: isort / flake8 / mypy (892 files) clean; full `python -m pytest` — 47,442 passed; every one of the 114+24 residual failures reproduced identically on untouched `origin/main` in the same environment (`/tmp` inode exhaustion mid-run + host-specific `gh`-resolution/system-binary-trust tests), zero regressions from this diff. `scripts/docs-lint.sh` and the brand-name gate pass. 5× repeat of the new test file: stable.
- Pre-push review fleet: GPT reviewer (2 BLOCKING + 1 MEDIUM — all fixed above) and Opus reviewer (0 BLOCKING + 6 advisories — all fixed, including the public `on_loop_persist_strict` alias, doc updates, the stronger ratchet, and the conftest env scrub).

## Manual verification

N/A — the contention test reproduces the production failure shape (held write lock + live heartbeat assertion) deterministically in-suite; no UI change.

## Any other suggestions

- `_handle_to_knowledge` still writes through `state.knowledge_store.db` on the loop; that is the Knowledge-store-wide pattern tracked separately in #2974 and is deliberately not widened into this PR.
- The 30s busy timeout is deliberately unchanged (see code comment): lowering it would trade a gateway kill for user-visible "database is locked" errors, and on a worker thread the long wait is harmless.

Closes #3050
