### PR TITLE
fix: offload acp spawn filesystem syscalls off the event loop (#3054)

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -152,10 +152,13 @@ Custom agents use cold start with `--agent <name>` flag at spawn time.
 
 `initialize` → `session/load` or `session/new` → `set_mode` (conditional) → `set_model` (conditional) → drain notifications → `session/prompt`
 
-`ensure_ready()` re-creates `_work_dir` on every call (idempotent `mkdir -p`) so
-that prompts still succeed if the directory was deleted externally between
-calls. kiro-cli's spawned shell inherits the client's cwd and does not revalidate
-it per-command.
+`ensure_ready()` creates `_work_dir` once per instance (off-loop `mkdir -p`,
+remembered via a flag) so the per-prompt warm path pays no filesystem syscall;
+`_spawn()` re-creates it (also off-loop) on every spawn, and `_reset_state()`
+clears the process and session id together, so every session-init path re-enters
+`_spawn` first. A per-prompt re-check could not repair external deletion for a
+live child anyway: kiro-cli's spawned shell inherits the client's cwd by inode,
+not by path, so re-creating the directory does not restore it.
 
 Steps 1–2 (`initialize`, `session/load` or `session/new`) block until a JSON-RPC
 response arrives (base 240s) because the session ID is required before proceeding.

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -31,7 +31,7 @@ import time
 from collections import deque
 from contextlib import aclosing
 from pathlib import Path
-from typing import Any, AsyncGenerator, AsyncIterator, Sequence
+from typing import Any, AsyncGenerator, AsyncIterator, Callable, Sequence, TypeVar
 
 from kiro_crew import model_registry, platform_compat
 from kiro_crew.acp._dispatch import (
@@ -130,6 +130,7 @@ logger = logging.getLogger(__name__)
 
 CLIENT_NAME = "kirocrew"
 CLIENT_VERSION = "0.1.2"
+_T = TypeVar("_T")
 # kiro-cli uses a date-stamped protocol; claude-agent-acp follows the
 # upstream ACP SDK (numeric integer, currently 1).  See acp.types.
 PROTOCOL_VERSION = "2025-08-22"
@@ -543,6 +544,22 @@ def _resolve_ssh_auth_sock(env: dict[str, str]) -> None:
             env["SSH_AUTH_SOCK"] = best
             logger.debug("Resolved SSH_AUTH_SOCK → %s", best)
             return
+
+
+def _resolve_spawn_env(env: dict[str, str]) -> dict[str, str]:
+    """Repair stale credential pointers in *env* before an agent spawn.
+
+    Bundles :func:`_resolve_ssh_auth_sock` (glob + stat over ``/tmp``) and
+    :func:`resolve_krb5_ccname` (lstat/stat of ``/tmp/krb5cc_<uid>``) so the
+    spawn path pays ONE thread hop for both. Both resolvers issue synchronous
+    filesystem syscalls whose latency scales with the ``/tmp`` entry count, so
+    they must never run on the event loop — call this via
+    ``asyncio.to_thread``. Mutates *env* in place and returns it for
+    convenience.
+    """
+    _resolve_ssh_auth_sock(env)
+    resolve_krb5_ccname(env)
+    return env
 
 
 # Subprocess stdout buffer — kiro-cli can send large JSON-RPC lines (tool outputs)
@@ -1785,6 +1802,10 @@ class AcpClient:
             from kiro_crew.config.paths import config_dir
 
             self._work_dir = config_dir() / "workspace"
+        # Once-per-instance guard for the ensure_ready work-dir check: True
+        # after the first (off-loop) mkdir, so the per-prompt warm path pays
+        # no filesystem syscall at all.
+        self._work_dir_ready = False
         self._model = model or DEFAULT_MODEL
         self._agent = agent
         self._sandbox_mode = sandbox_mode
@@ -2318,6 +2339,40 @@ class AcpClient:
 
     # ── Process Management ──
 
+    def _discard_sandbox_cleanup(self) -> None:
+        """Unlink and forget the sandbox temp file allocated by ``wrap_argv``.
+
+        wrap_argv writes a launcher/profile file that the spawned child
+        consumes at exec. Once no child will exec it — the spawn failed, was
+        cancelled, or the process is being reset — it must be removed here, or
+        each attempt leaks one file into the temp dir for the gateway's
+        lifetime (nothing else references the path after ``_spawn`` reassigns
+        ``self._sandbox_cleanup``).
+        """
+        if self._sandbox_cleanup:
+            try:
+                os.remove(self._sandbox_cleanup)
+            except OSError:
+                pass
+            self._sandbox_cleanup = None
+
+    async def _to_thread_guarding_sandbox(
+        self, fn: Callable[..., _T], /, *args: Any, **kwargs: Any
+    ) -> _T:
+        """``asyncio.to_thread`` that discards the sandbox file on failure.
+
+        After ``wrap_argv`` has allocated the sandbox temp file, every
+        suspension point before the exec is a leak window: a cancellation
+        (turn cancel, session close, shutdown) unwinds ``_spawn`` without
+        reaching ``_reset_state``, orphaning the file. Route any offload in
+        that window through here so the file is removed before re-raising.
+        """
+        try:
+            return await asyncio.to_thread(fn, *args, **kwargs)
+        except BaseException:
+            self._discard_sandbox_cleanup()
+            raise
+
     async def _spawn(self) -> None:
         """Start the ACP backend subprocess with stdio pipes.
 
@@ -2327,7 +2382,9 @@ class AcpClient:
         so it is unreachable here, but an internal companion that re-registers
         a Claude backend reuses this same client over the seam.
         """
-        self._work_dir.mkdir(parents=True, exist_ok=True)
+        # Off-loop: mkdir is a blocking syscall and the parent dirs may live on
+        # slow storage; the loop must never wait on the kernel here.
+        await asyncio.to_thread(self._work_dir.mkdir, parents=True, exist_ok=True)
 
         if self._is_claude:
             # Dormant seam — see method docstring. Binary resolution only; the
@@ -2390,7 +2447,11 @@ class AcpClient:
         # tool descendants with pids.max (fork bomb) + memory.max (RSS balloon).
         # No-op + loud warning where cgroup delegation is unavailable. --scope
         # execs into the target, so self._pid below is still the real child.
-        argv = cgroup_scope_argv(argv)
+        # Off-loop: first call probes /proc + /sys and the config read touches
+        # the config dir (mkdir + file read) — blocking syscalls that must not
+        # run on the loop. Guarded: wrap_argv above allocated the sandbox temp
+        # file, so a cancellation here must not orphan it.
+        argv = await self._to_thread_guarding_sandbox(cgroup_scope_argv, argv)
 
         # Build the child environment (process-group isolation flags are set on
         # the spawn kwargs below, per-platform).
@@ -2431,13 +2492,15 @@ class AcpClient:
             env.pop("KIROCREW_CHANNEL_ID", None)
 
         # Resolve SSH_AUTH_SOCK dynamically — the gateway's env may be stale
-        # after an ssh-agent restart.
-        _resolve_ssh_auth_sock(env)
-        # Resolve KRB5CCNAME to a FILE: ccache — the kernel keyring (the default
-        # on some Linux distros) is invisible to this child, so Kerberos-gated MCP
-        # servers fail without it. Covers the session agent and
-        # all ACP-provider subagents, which spawn through this same path.
-        resolve_krb5_ccname(env)
+        # after an ssh-agent restart — and KRB5CCNAME to a FILE: ccache (the
+        # kernel keyring, the default on some Linux distros, is invisible to
+        # this child, so Kerberos-gated MCP servers fail without it). Covers
+        # the session agent and all ACP-provider subagents, which spawn through
+        # this same path. Both resolvers glob/stat under /tmp, whose entry
+        # count is unbounded, so they run off-loop in ONE thread hop. Guarded:
+        # the sandbox temp file is live, so a cancellation here must not
+        # orphan it.
+        env = await self._to_thread_guarding_sandbox(_resolve_spawn_env, env)
         # Positive-identity marker for the orphan sweep: kiro-cli and every MCP
         # server it spawns inherit this, so escaped launcher trees (``npx
         # @playwright/mcp`` -> node) are identifiable as ours.
@@ -2449,7 +2512,11 @@ class AcpClient:
         # it here bounds ONLY auto resolution — explicit ``-n N``, non-xdist
         # runs, and venvs without xdist are unaffected. Respects a value
         # already present in the env; see resource_status.inject_xdist_auto_cap.
-        inject_xdist_auto_cap(env)
+        # Off-loop: resolving the cap reads the raw config, and that read
+        # enters config_dir() (mkdir + file IO + JSON parse) — blocking
+        # syscalls that must not run on the loop. Guarded: the sandbox temp
+        # file is live, so a cancellation here must not orphan it.
+        await self._to_thread_guarding_sandbox(inject_xdist_auto_cap, env)
 
         # Process-group isolation for clean tree-kill. Pass both flags explicitly
         # (NOT via **dict unpack — that breaks mypy's Popen overload resolution on
@@ -2691,12 +2758,7 @@ class AcpClient:
                     except Exception:
                         pass
         # Clean up sandbox temp files (macOS seatbelt profile)
-        if self._sandbox_cleanup:
-            try:
-                os.remove(self._sandbox_cleanup)
-            except OSError:
-                pass
-            self._sandbox_cleanup = None
+        self._discard_sandbox_cleanup()
         # Remove settings.local.json so bypassPermissions doesn't persist after crash
         if self._is_claude:
             _stale = self._work_dir / ".claude" / "settings.local.json"
@@ -3032,9 +3094,18 @@ class AcpClient:
         await self._drain_notifications()
 
     async def ensure_ready(self) -> None:
-        """Ensure process is spawned and session is initialized."""
-        # Re-create cwd in case it was deleted after spawn.
-        self._work_dir.mkdir(parents=True, exist_ok=True)
+        """Ensure process is spawned and session is initialized.
+
+        Runs before EVERY prompt, so the warm path must stay syscall-free:
+        the work dir is created once per instance (off-loop) and remembered —
+        a per-prompt mkdir would tax every prompt with a blocking syscall
+        whose latency scales with the parent directory's entry count.
+        Re-creating the directory later could not repair a live child anyway:
+        a process's cwd is bound to the inode, not the path.
+        """
+        if not self._work_dir_ready:
+            await asyncio.to_thread(self._work_dir.mkdir, parents=True, exist_ok=True)
+            self._work_dir_ready = True
         if self._process and self._process.returncode is None and self._session_id:
             return
 

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -24,7 +24,7 @@ import threading
 import time
 from collections import deque
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, TypeVar
 
 from kiro_crew import platform_compat
 from kiro_crew.acp._dispatch import (
@@ -94,6 +94,8 @@ __all__ = [
 
 
 # ── AcpRuntime ──
+
+_T = TypeVar("_T")
 
 _STDOUT_BUFFER_LIMIT = 10 * 1024 * 1024  # 10MB
 # How many in-flight request ids to name in the oversize-frame warning. A dropped
@@ -644,12 +646,46 @@ class AcpRuntime:
 
     # ── Lifecycle ──
 
+    def _discard_sandbox_cleanup(self) -> None:
+        """Unlink and forget the sandbox temp file allocated by ``wrap_argv``.
+
+        Mirrors ``AcpClient._discard_sandbox_cleanup``: once no child will
+        exec the launcher/profile file — spawn failed, was cancelled, or the
+        runtime is shutting down — it must be removed, or each attempt leaks
+        one file into the temp dir for the gateway's lifetime.
+        """
+        if self._sandbox_cleanup:
+            try:
+                os.remove(self._sandbox_cleanup)
+            except OSError:
+                pass
+            self._sandbox_cleanup = None
+
+    async def _to_thread_guarding_sandbox(
+        self, fn: Callable[..., _T], /, *args: Any, **kwargs: Any
+    ) -> _T:
+        """``asyncio.to_thread`` that discards the sandbox file on failure.
+
+        After ``wrap_argv`` has allocated the sandbox temp file, every
+        suspension point before the exec is a leak window: a cancellation
+        unwinds ``spawn`` without reaching the shutdown cleanup, orphaning the
+        file. Route any offload in that window through here so the file is
+        removed before re-raising.
+        """
+        try:
+            return await asyncio.to_thread(fn, *args, **kwargs)
+        except BaseException:
+            self._discard_sandbox_cleanup()
+            raise
+
     async def spawn(self) -> None:
         """Start the kiro-cli acp subprocess and complete protocol handshake."""
         if self._process is not None:
             raise AcpRuntimeError("Runtime already spawned")
 
-        self._work_dir.mkdir(parents=True, exist_ok=True)
+        # Off-loop: mkdir is a blocking syscall and the parent dirs may live on
+        # slow storage; the loop must never wait on the kernel here.
+        await asyncio.to_thread(self._work_dir.mkdir, parents=True, exist_ok=True)
 
         try:
             kiro_bin = await _resolve_kiro_bin_for_spawn()
@@ -693,7 +729,11 @@ class AcpRuntime:
         # tool descendants with pids.max (fork bomb) + memory.max (RSS balloon).
         # No-op + loud warning where cgroup delegation is unavailable. --scope
         # execs into the target, so self._pid below is still the real child.
-        argv = cgroup_scope_argv(argv)
+        # Off-loop: first call probes /proc + /sys and the config read touches
+        # the config dir (mkdir + file read) — blocking syscalls that must not
+        # run on the loop. Guarded: wrap_argv above allocated the sandbox temp
+        # file, so a cancellation here must not orphan it.
+        argv = await self._to_thread_guarding_sandbox(cgroup_scope_argv, argv)
 
         env = {**os.environ}
         if self._extra_env:
@@ -709,7 +749,11 @@ class AcpRuntime:
         env = scrub_agent_denied_env(env)
 
         env["PATH"] = augmented_path(env.get("PATH", ""))
-        resolve_krb5_ccname(env)
+        # Resolve KRB5CCNAME off-loop: it lstat/stats /tmp/krb5cc_<uid>, and a
+        # blocking syscall on the event loop stalls every other task. Guarded:
+        # the sandbox temp file is live, so a cancellation here must not
+        # orphan it.
+        await self._to_thread_guarding_sandbox(resolve_krb5_ccname, env)
         # Positive-identity marker for the orphan sweep: kiro-cli and every MCP
         # server it spawns inherit this, so escaped launcher trees (``npx
         # @playwright/mcp`` -> node) are identifiable as ours.
@@ -718,7 +762,11 @@ class AcpRuntime:
         # mirrors acp/client.py): xdist sizes auto to the CPU count, ignoring
         # memory; PYTEST_XDIST_AUTO_NUM_WORKERS bounds ONLY auto resolution.
         # Respects a pre-set value; see resource_status.inject_xdist_auto_cap.
-        inject_xdist_auto_cap(env)
+        # Off-loop: resolving the cap reads the raw config, and that read
+        # enters config_dir() (mkdir + file IO + JSON parse) — blocking
+        # syscalls that must not run on the loop. Guarded: the sandbox temp
+        # file is live, so a cancellation here must not orphan it.
+        await self._to_thread_guarding_sandbox(inject_xdist_auto_cap, env)
 
         self._process = await create_subprocess_limited(
             *argv,
@@ -902,11 +950,7 @@ class AcpRuntime:
                 except Exception:
                     logger.debug("AcpRuntime: PID untracking failed for %s", pid, exc_info=True)
 
-        if self._sandbox_cleanup:
-            try:
-                os.remove(self._sandbox_cleanup)
-            except OSError:
-                pass
+        self._discard_sandbox_cleanup()
 
     # ── Reader Task (single owner of stdout) ──
 

--- a/test/test_acp_spawn_offload.py
+++ b/test/test_acp_spawn_offload.py
@@ -1,0 +1,331 @@
+"""Tests pinning the off-loop offload of the ACP spawn filesystem work.
+
+The spawn prelude performs synchronous filesystem syscalls whose latency
+scales with the ``/tmp`` entry count (``_resolve_ssh_auth_sock`` globs
+``/tmp/ssh-*/agent.*`` + stats each match; ``resolve_krb5_ccname`` lstat/stats
+``/tmp/krb5cc_<uid>``) plus a ``mkdir`` of the work dir. None of these may run
+on the asyncio event loop: a blocking call there stalls every other task,
+including the watchdog heartbeat. These tests pin three contracts:
+
+1. ``AcpClient._spawn`` runs both env resolvers and the work-dir mkdir on a
+   non-loop thread (one bundled thread hop for the resolvers).
+2. ``AcpClient.ensure_ready`` — which runs before EVERY prompt — performs at
+   most ONE mkdir, on the first call per instance and off-loop; every later
+   call performs none. (``_spawn`` also creates the dir, and ``_reset_state``
+   clears the process and session id together, so every session-init path
+   re-enters ``_spawn`` first.)
+3. ``AcpRuntime.spawn`` runs its mkdir and ``resolve_krb5_ccname`` on a
+   non-loop thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import traceback
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import kiro_crew.acp.client as client_mod
+import kiro_crew.acp.runtime as runtime_mod
+from kiro_crew.acp.client import AcpClient, _resolve_spawn_env
+from kiro_crew.acp.runtime import AcpRuntime
+
+
+async def _stop_stderr_drain(client: AcpClient) -> None:
+    """Cancel and await the stderr-drain task a mocked _spawn started.
+
+    A mock process has a truthy stderr, so _spawn starts _drain_stderr over it;
+    left alive, its exception surfaces against an unrelated test at collection.
+    """
+    task = client._stderr_task
+    if task is not None:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+    client._stderr_task = None
+
+
+class TestResolveSpawnEnv:
+    def test_bundles_both_resolvers_and_returns_env(self) -> None:
+        env = {"PATH": "/usr/bin"}
+        with (
+            patch.object(client_mod, "_resolve_ssh_auth_sock") as ssh,
+            patch.object(client_mod, "resolve_krb5_ccname") as krb,
+        ):
+            result = _resolve_spawn_env(env)
+        ssh.assert_called_once_with(env)
+        krb.assert_called_once_with(env)
+        assert result is env
+
+
+class TestClientSpawnOffLoop:
+    @pytest.mark.asyncio
+    async def test_spawn_env_resolution_and_mkdir_run_off_loop(self, tmp_path) -> None:
+        loop_thread = threading.current_thread()
+        ssh_threads: list[threading.Thread] = []
+        krb_threads: list[threading.Thread] = []
+        cgroup_threads: list[threading.Thread] = []
+        xdist_threads: list[threading.Thread] = []
+        mkdir_threads: list[threading.Thread] = []
+
+        # On-loop mkdir failures capture the offending stack: the spawn path
+        # has several lazy, cache-cold callees (config reads, probes), so the
+        # thread identity alone does not name the regressing call site.
+        mkdir_stacks: list[str] = []
+
+        def _rec_mkdir(*a, **kw):
+            t = threading.current_thread()
+            mkdir_threads.append(t)
+            if t is loop_thread:
+                mkdir_stacks.append("".join(traceback.format_stack()))
+
+        client = AcpClient(work_dir=tmp_path / "workspace", session_key="k")
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.returncode = None
+
+        with (
+            patch("kiro_crew.acp.client._resolve_kiro_bin", return_value="/usr/bin/kiro-cli"),
+            patch.object(client_mod, "ensure_agent_materialized"),
+            patch(
+                "kiro_crew.acp.client.wrap_argv",
+                return_value=(["/usr/bin/kiro-cli", "acp"], None),
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=mock_proc,
+            ),
+            patch("kiro_crew.session._track_pid"),
+            patch("kiro_crew.session._track_session_pid"),
+            # PID 12345 may be a real host process; without this, the early
+            # descendant scan can find its children and _track_child_pids then
+            # writes tracking state (mkdir included) on the loop thread —
+            # host-dependent noise this test must not observe.
+            patch.object(client_mod, "_get_child_pids", return_value=[]),
+            patch.object(
+                client_mod,
+                "_resolve_ssh_auth_sock",
+                side_effect=lambda env: ssh_threads.append(threading.current_thread()),
+            ),
+            patch.object(
+                client_mod,
+                "resolve_krb5_ccname",
+                side_effect=lambda env: krb_threads.append(threading.current_thread()),
+            ),
+            # cgroup_scope_argv's first call probes /proc + /sys and reads the
+            # config (mkdir + file IO) — record its thread directly so the
+            # assertion does not depend on this host's cgroup delegation.
+            patch.object(
+                client_mod,
+                "cgroup_scope_argv",
+                side_effect=lambda argv: (
+                    cgroup_threads.append(threading.current_thread()),
+                    argv,
+                )[1],
+            ),
+            # inject_xdist_auto_cap resolves its cap from the raw config, and
+            # that read enters config_dir() (mkdir + file IO) — record its
+            # thread directly so the assertion does not depend on whether the
+            # host env already carries PYTEST_XDIST_AUTO_NUM_WORKERS (which
+            # would short-circuit the config read).
+            patch.object(
+                client_mod,
+                "inject_xdist_auto_cap",
+                side_effect=lambda env: xdist_threads.append(threading.current_thread()),
+            ),
+            patch(
+                "pathlib.Path.mkdir",
+                side_effect=_rec_mkdir,
+            ),
+        ):
+            await client._spawn()
+
+        await _stop_stderr_drain(client)
+
+        assert ssh_threads, "_resolve_ssh_auth_sock must run during _spawn"
+        assert krb_threads, "resolve_krb5_ccname must run during _spawn"
+        assert cgroup_threads, "cgroup_scope_argv must run during _spawn"
+        assert xdist_threads, "inject_xdist_auto_cap must run during _spawn"
+        assert mkdir_threads, "the work-dir mkdir must run during _spawn"
+        for t in ssh_threads:
+            assert t is not loop_thread, "ssh resolver ran on the loop thread"
+        for t in krb_threads:
+            assert t is not loop_thread, "krb5 resolver ran on the loop thread"
+        for t in cgroup_threads:
+            assert t is not loop_thread, "cgroup_scope_argv ran on the loop thread"
+        for t in xdist_threads:
+            assert t is not loop_thread, "inject_xdist_auto_cap ran on the loop thread"
+        for t in mkdir_threads:
+            assert t is not loop_thread, "mkdir ran on the loop thread:\n" + "\n".join(mkdir_stacks)
+
+
+class TestEnsureReadyWorkDir:
+    @pytest.mark.asyncio
+    async def test_work_dir_created_once_off_loop_then_never_again(self, tmp_path) -> None:
+        """ensure_ready runs before EVERY prompt; the work-dir check must pay
+        one off-loop mkdir on the FIRST call and no syscall afterwards —
+        restoring a per-prompt mkdir fails this test."""
+        loop_thread = threading.current_thread()
+        client = AcpClient(work_dir=tmp_path / "workspace", session_key="k")
+        proc = MagicMock()
+        proc.returncode = None
+        client._process = proc
+        client._session_id = "sess-1"
+
+        mkdir_threads: list[threading.Thread] = []
+        with patch(
+            "pathlib.Path.mkdir",
+            side_effect=lambda *a, **kw: mkdir_threads.append(threading.current_thread()),
+        ):
+            await client.ensure_ready()
+            assert len(mkdir_threads) == 1, "first ensure_ready must create the work dir"
+            assert mkdir_threads[0] is not loop_thread, "work-dir mkdir ran on the loop thread"
+
+            for _ in range(3):
+                await client.ensure_ready()
+        assert len(mkdir_threads) == 1, "warm ensure_ready must perform no mkdir"
+
+
+class TestRuntimeSpawnOffLoop:
+    @pytest.mark.asyncio
+    async def test_spawn_mkdir_and_krb5_run_off_loop(self, tmp_path, monkeypatch) -> None:
+        loop_thread = threading.current_thread()
+        krb_threads: list[threading.Thread] = []
+        cgroup_threads: list[threading.Thread] = []
+        xdist_threads: list[threading.Thread] = []
+        mkdir_threads: list[threading.Thread] = []
+
+        class _StopSpawn(Exception):
+            pass
+
+        async def resolve_bin() -> str:
+            return "/usr/bin/kiro-cli"
+
+        async def stop_spawn(*args, **kwargs):
+            raise _StopSpawn()
+
+        def _rec_cgroup(argv):
+            cgroup_threads.append(threading.current_thread())
+            return argv
+
+        monkeypatch.setattr(runtime_mod, "_resolve_kiro_bin_for_spawn", resolve_bin)
+        monkeypatch.setattr(runtime_mod, "ensure_agent_materialized", lambda agent: None)
+        monkeypatch.setattr(
+            runtime_mod, "wrap_argv", lambda argv, mode, **kw: (list(argv), None)
+        )
+        monkeypatch.setattr(runtime_mod, "cgroup_scope_argv", _rec_cgroup)
+        monkeypatch.setattr(
+            runtime_mod,
+            "inject_xdist_auto_cap",
+            lambda env: xdist_threads.append(threading.current_thread()),
+        )
+        monkeypatch.setattr(
+            runtime_mod,
+            "resolve_krb5_ccname",
+            lambda env: krb_threads.append(threading.current_thread()),
+        )
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", stop_spawn)
+
+        runtime = AcpRuntime(work_dir=tmp_path / "workspace")
+        with (
+            patch(
+                "pathlib.Path.mkdir",
+                side_effect=lambda *a, **kw: mkdir_threads.append(threading.current_thread()),
+            ),
+            pytest.raises(_StopSpawn),
+        ):
+            await runtime.spawn()
+
+        assert krb_threads, "resolve_krb5_ccname must run during spawn"
+        assert cgroup_threads, "cgroup_scope_argv must run during spawn"
+        assert xdist_threads, "inject_xdist_auto_cap must run during spawn"
+        assert mkdir_threads, "the work-dir mkdir must run during spawn"
+        for t in krb_threads + cgroup_threads + xdist_threads + mkdir_threads:
+            assert t is not loop_thread, "blocking spawn-prelude syscall ran on the loop thread"
+
+
+class TestSpawnCancellationSandboxCleanup:
+    """A cancellation landing in one of the offload hops AFTER ``wrap_argv``
+    allocated the sandbox temp file must not orphan that file: nothing else
+    unlinks it on the cancel path, and the next spawn reassigns
+    ``_sandbox_cleanup``, leaking one file per cancelled attempt."""
+
+    @staticmethod
+    def _sandbox_file(tmp_path) -> str:
+        f = tmp_path / "sandbox-profile.sb"
+        f.write_text("(profile)")
+        return str(f)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("raise_in", ["cgroup", "env"])
+    async def test_client_spawn_cancel_unlinks_sandbox_file(
+        self, tmp_path, raise_in
+    ) -> None:
+        sandbox_file = self._sandbox_file(tmp_path)
+        client = AcpClient(work_dir=tmp_path / "workspace", session_key="k")
+
+        def _cgroup(argv):
+            if raise_in == "cgroup":
+                raise asyncio.CancelledError()
+            return argv
+
+        def _env(env):
+            raise asyncio.CancelledError()
+
+        with (
+            patch("kiro_crew.acp.client._resolve_kiro_bin", return_value="/usr/bin/kiro-cli"),
+            patch.object(client_mod, "ensure_agent_materialized"),
+            patch(
+                "kiro_crew.acp.client.wrap_argv",
+                return_value=(["/usr/bin/kiro-cli", "acp"], sandbox_file),
+            ),
+            patch.object(client_mod, "cgroup_scope_argv", side_effect=_cgroup),
+            patch.object(client_mod, "_resolve_spawn_env", side_effect=_env),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await client._spawn()
+
+        assert not Path(sandbox_file).exists(), "cancelled spawn orphaned the sandbox file"
+        assert client._sandbox_cleanup is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("raise_in", ["cgroup", "krb5"])
+    async def test_runtime_spawn_cancel_unlinks_sandbox_file(
+        self, tmp_path, monkeypatch, raise_in
+    ) -> None:
+        sandbox_file = self._sandbox_file(tmp_path)
+
+        async def resolve_bin() -> str:
+            return "/usr/bin/kiro-cli"
+
+        def _cgroup(argv):
+            if raise_in == "cgroup":
+                raise asyncio.CancelledError()
+            return argv
+
+        def _krb5(env):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(runtime_mod, "_resolve_kiro_bin_for_spawn", resolve_bin)
+        monkeypatch.setattr(runtime_mod, "ensure_agent_materialized", lambda agent: None)
+        monkeypatch.setattr(
+            runtime_mod,
+            "wrap_argv",
+            lambda argv, mode, **kw: (list(argv), sandbox_file),
+        )
+        monkeypatch.setattr(runtime_mod, "cgroup_scope_argv", _cgroup)
+        monkeypatch.setattr(runtime_mod, "resolve_krb5_ccname", _krb5)
+
+        runtime = AcpRuntime(work_dir=tmp_path / "workspace")
+        with pytest.raises(asyncio.CancelledError):
+            await runtime.spawn()
+
+        assert not Path(sandbox_file).exists(), "cancelled spawn orphaned the sandbox file"
+        assert runtime._sandbox_cleanup is None


### PR DESCRIPTION
## Problem

The ACP spawn prelude runs synchronous filesystem syscalls on the asyncio event loop, and one of them runs before EVERY prompt:

- `AcpClient._spawn`: `_resolve_ssh_auth_sock` (globs `/tmp/ssh-*/agent.*` + stats each match), `resolve_krb5_ccname` (lstat/stat of `/tmp/krb5cc_<uid>`), the work-dir `mkdir`, `cgroup_scope_argv` (first call probes `/proc` + `/sys`; its config read enters `config_dir()`, which does mkdir + file IO), and `inject_xdist_auto_cap` (same on-loop config read — caught by this PR's own guard test on CI, where `PYTEST_XDIST_AUTO_NUM_WORKERS` is absent so the config path actually runs).
- `AcpRuntime.spawn`: the same `mkdir`, `resolve_krb5_ccname`, and `cgroup_scope_argv` pattern.
- `AcpClient.ensure_ready` (runs before every prompt): an unconditional `self._work_dir.mkdir(parents=True, exist_ok=True)`.

Measured on the affected host: at 93,238 `/tmp` entries the ssh-sock glob costs ~44ms (`os.listdir('/tmp')` alone is 37ms). This is a per-spawn / per-prompt latency tax that grows with a directory nobody manages — it is nowhere near the 25s watchdog budget, and none of 7 captured loop-stall dumps was stalled in these frames. Not a stall cause; scoped as a latency defect.

## Why it matters

The gateway runs everything on one loop. Every millisecond a spawn-prelude syscall holds the loop is a millisecond during which every other session's chat turn, websocket frame, and the watchdog heartbeat wait. The per-prompt mkdir means every prompt on the host pays it, and the cost is unbounded in `/tmp` growth.

## Fix (symptoms → root cause → change)

Root cause: blocking syscalls inside `async def` bodies (`async` does not mean the body yields), plus a per-prompt re-check that cannot deliver what its comment promised — a process's cwd is bound to the inode, not the path, so re-creating a deleted work dir never repairs a live child.

Changes:
- New module helper `_resolve_spawn_env` bundles `_resolve_ssh_auth_sock` + `resolve_krb5_ccname` so `AcpClient._spawn` pays ONE `asyncio.to_thread` hop for both.
- The work-dir `mkdir` in `AcpClient._spawn` and `AcpRuntime.spawn` is offloaded via `asyncio.to_thread`.
- `cgroup_scope_argv` and `inject_xdist_auto_cap` are offloaded in both spawn paths — both reach `_raw_config()` → `config_dir()`, whose on-loop mkdir + file IO the new guard test caught live (cgroup during development on this host, xdist on CI where the short-circuiting env var is absent). `_raw_config`'s docstring claims per-process caching it does not have, so this cost recurs per spawn.
- `ensure_ready`'s per-prompt mkdir is replaced by a once-per-instance `_work_dir_ready` flag + off-loop mkdir: the warm (every-prompt) path now performs no syscall, while the pinned contract (`TestEnsureReadyRecreatesWorkDir`: first call creates the dir without spawning) still holds.
- The offload hops sit between `wrap_argv` (which allocates the sandbox launcher/profile temp file) and the exec, so they widen the window where a cancellation would orphan that file. Each hop in that window routes through `_to_thread_guarding_sandbox`, which unlinks the file before re-raising; the existing unlink sites in `_reset_state` / runtime shutdown are consolidated into a shared `_discard_sandbox_cleanup` chokepoint.
- `docs/system-specs/modules/acp-client.md` updated in the same commit to the new `ensure_ready` contract.

Deliberately out of scope (needs a size-threshold decision, not a mechanical wrap): the on-loop `json.loads` of ACP frames up to the 10MB stdout buffer limit (`runtime.py` reader loop, `client.py` response parse). Follow-up material.

## Tests

`test/test_acp_spawn_offload.py` (new):
- `AcpClient._spawn` runs the env resolvers, `cgroup_scope_argv`, and the mkdir on a non-loop thread (thread identity recorded per callee; on-loop mkdir failures capture the offending stack, which is how the `cgroup_scope_argv` → `config_dir()` mkdir was found).
- `ensure_ready` performs exactly one off-loop mkdir on the first call and none afterwards.
- `AcpRuntime.spawn` same off-loop assertions.
- A cancellation raised inside either offload hop (parametrized per hop, both classes) unlinks the sandbox temp file and clears `_sandbox_cleanup`.
- `_resolve_spawn_env` unit: calls both resolvers, returns the same dict.

Mutation-verified: 15/15 mutants caught (each offload reverted to on-loop, the per-prompt mkdir restored, the once-flag dropped, each guard downgraded to a plain `to_thread`, a resolver dropped from the bundle).

Gates: pytest full suite (98 remaining failures are host-environmental — `SandboxUnavailableError` from missing userns delegation, `AF_UNIX path too long`, missing `gh` — proven identical on `origin/main` via A/B `comm` diff, zero symmetric difference), isort, flake8, mypy (892 files clean), docs-lint, brand gate.

## Manual verification

N/A — unit coverage sufficient: the defect and fix are thread-placement properties asserted directly by the new tests; the 44ms glob figure comes from the issue's measurement on the affected host.

## Screenshots

N/A — backend-only change, no UI surface.

Closes #3054
