### PR TITLE
fix(snapshot): refuse an unreadable crons file instead of crashing the merge

### DIFF
--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -491,6 +491,41 @@ def _merge_memory(src_db: Path, dst_db: Path) -> None:
         conn.close()
 
 
+def _usable_cron_shape(parsed: object, path: Path) -> bool:
+    """Refuse a crons file that parsed but is not shaped like a cron file.
+
+    The merge looks ``jobs`` up on the result and calls ``.get`` on every
+    entry, so valid JSON of the wrong shape -- a top level that is not an
+    object, a ``jobs`` that is not a list, a job that is not an object, or a
+    present name that is not encodable text -- would raise TypeError,
+    AttributeError, or UnicodeEncodeError a line or two further down: the
+    same crash the read guard exists to prevent, just moved. Only the structure the merge itself relies on is
+    checked; the fields of a job are the cron loader's business, not this
+    one's. A missing ``jobs`` key keeps its existing meaning of "no jobs".
+    """
+    if not isinstance(parsed, dict):
+        print(f"  ⚠️  {path} is not a cron file — skipping cron merge")
+        return False
+    jobs = parsed.get("jobs", [])
+    if not isinstance(jobs, list) or not all(
+        isinstance(job, dict)
+        and (
+            "name" not in job
+            or (
+                isinstance(job["name"], str)
+                # json.loads accepts lone-surrogate escapes, and a present name
+                # is UTF-8 encoded when the import id is hashed: a surrogate
+                # would raise UnicodeEncodeError there, the same crash moved.
+                and not any("\ud800" <= ch <= "\udfff" for ch in job["name"])
+            )
+        )
+        for job in jobs
+    ):
+        print(f"  ⚠️  {path} has an unusable job list — skipping cron merge")
+        return False
+    return True
+
+
 def _merge_crons(src_path: Path, dst_path: Path) -> None:
     try:
         src = json.loads(src_path.read_text(encoding="utf-8"))
@@ -501,6 +536,8 @@ def _merge_crons(src_path: Path, dst_path: Path) -> None:
         dst = json.loads(dst_path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         print(f"  ⚠️  Could not read {dst_path}: {exc} — skipping cron merge")
+        return
+    if not _usable_cron_shape(src, src_path) or not _usable_cron_shape(dst, dst_path):
         return
     existing = {j.get("name") for j in dst.get("jobs", [])}
     imported = 0

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -38,8 +38,7 @@ def _setup_fake_kirocrew(d: Path) -> None:
 
     # memory.db with all tables
     conn = sqlite3.connect(str(d / "memory.db"))
-    conn.executescript(
-        """
+    conn.executescript("""
         CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
         CREATE TABLE semantic_memory (key TEXT PRIMARY KEY, value_json TEXT NOT NULL,
             confidence REAL DEFAULT 0.5, source TEXT NOT NULL, created_at TEXT NOT NULL,
@@ -71,8 +70,7 @@ def _setup_fake_kirocrew(d: Path) -> None:
             VALUES ('user', 'prefers', 'dark_mode', 'ep1', '2026-01-01');
         INSERT INTO knowledge_edges (source_key, target_key, relation, weight, created_at)
             VALUES ('user', 'dark_mode', 'prefers', 1.0, '2026-01-01');
-    """
-    )
+    """)
     conn.close()
 
     (d / "crons.json").write_text(
@@ -452,6 +450,112 @@ class TestRestoreMerge:
         assert ret == 0
         assert (dst / "plan_memory/plan1.json").is_file()
         assert (dst / "plan_memory/local_plan.json").read_text(encoding="utf-8") == "local plan"
+
+    def test_merge_still_imports_other_components_after_a_crons_refusal(
+        self, tmp_path, monkeypatch
+    ):
+        """One unreadable component must not abort the whole merge."""
+        src = tmp_path / "src-partial"
+        _setup_fake_kirocrew(src)
+        (src / "crons.json").write_text("{not json", encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        tarball = _make_snapshot(src, tmp_path / "out-partial")
+
+        dst = tmp_path / "dst-partial"
+        _setup_fake_kirocrew(dst)
+        (dst / "telemetry_salt").unlink()
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+
+        assert restore_main([str(tarball), "--mode", "merge", "--force"]) == 0
+        assert (dst / "telemetry_salt").is_file()
+
+    def test_merge_refuses_a_crons_file_that_is_not_an_object(self, env, capsys, monkeypatch):
+        """Valid JSON is not a valid cron file; `jobs` is looked up on it."""
+        _, _, tarball, tmp_path = env
+        dst = tmp_path / "dst-list-crons"
+        _setup_fake_kirocrew(dst)
+        (dst / "crons.json").write_text('["not", "a", "cron file"]', encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+
+        assert ret == 0
+        assert "skipping" in capsys.readouterr().out.lower()
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            '{"jobs": null}',  # present but not iterable
+            '{"jobs": "not-a-list"}',  # iterable, but of characters
+            '{"jobs": [123]}',  # a list whose entries have no .get
+            '{"jobs": [{"name": []}]}',  # a present name must be hashable text
+            '{"jobs": [{"name": "\\ud800"}]}',  # a lone surrogate cannot be UTF-8 encoded
+        ],
+    )
+    def test_merge_refuses_a_crons_file_whose_jobs_are_the_wrong_shape(
+        self, env, capsys, monkeypatch, body
+    ):
+        """The merge reads each job and hashes present names, so the shape it
+        relies on has to hold before it starts."""
+        _, _, tarball, tmp_path = env
+        dst = tmp_path / f"dst-shape-{abs(hash(body))}"
+        _setup_fake_kirocrew(dst)
+        (dst / "crons.json").write_text(body, encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+
+        assert ret == 0
+        assert "skipping" in capsys.readouterr().out.lower()
+        assert (dst / "crons.json").read_text(encoding="utf-8") == body
+
+    def test_merge_refuses_an_incoming_crons_file_with_a_non_object_job(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Same contract on the incoming side."""
+        src = tmp_path / "src-bad-job"
+        _setup_fake_kirocrew(src)
+        (src / "crons.json").write_text('{"jobs": [123]}', encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        tarball = _make_snapshot(src, tmp_path / "out-bad-job")
+
+        dst = tmp_path / "dst-bad-job"
+        _setup_fake_kirocrew(dst)
+        keep = (dst / "crons.json").read_text(encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+
+        assert ret == 0
+        assert "skipping" in capsys.readouterr().out.lower()
+        assert (dst / "crons.json").read_text(encoding="utf-8") == keep
+
+    def test_merge_treats_a_missing_jobs_key_as_empty(self, env, monkeypatch):
+        """Preservation: absent `jobs` already meant "no jobs" and still does."""
+        _, _, tarball, tmp_path = env
+        dst = tmp_path / "dst-no-jobs-key"
+        _setup_fake_kirocrew(dst)
+        (dst / "crons.json").write_text('{"version": 1}', encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+
+        assert restore_main([str(tarball), "--mode", "merge", "--force"]) == 0
+
+        merged = json.loads((dst / "crons.json").read_text(encoding="utf-8"))
+        assert len(merged["jobs"]) == 1
+
+    def test_merge_still_imports_a_well_formed_crons_file(self, env, monkeypatch):
+        """Preservation: the guard must not change the ordinary merge."""
+        _, _, tarball, tmp_path = env
+        dst = tmp_path / "dst-good-crons"
+        _setup_fake_kirocrew(dst)
+        d = json.loads((dst / "crons.json").read_text(encoding="utf-8"))
+        d["jobs"][0]["name"] = "different-job"
+        (dst / "crons.json").write_text(json.dumps(d))
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+
+        restore_main([str(tarball), "--mode", "merge", "--force"])
+
+        assert len(json.loads((dst / "crons.json").read_text(encoding="utf-8"))["jobs"]) == 2
 
     def test_merge_restores_missing_security(self, env, capsys, monkeypatch):
         """TEST 16"""


### PR DESCRIPTION
Closes #3070.

## Summary

- refuse an unreadable `crons.json` during `restore --mode merge` instead of exiting with a traceback
- report which side was unreadable, and let the rest of the merge continue
- refuse a file that parses but is not a cron object, for the same reason
- read both sides as UTF-8

## Problem / Motivation

`_merge_crons` parsed both sides with a bare `json.loads`:

```python
src = json.loads(src_path.read_text())
dst = json.loads(dst_path.read_text())
```

Neither is guarded, so a corrupt file on either side ends the whole restore with an uncaught `JSONDecodeError` ? and the components that would have merged after crons never run. Every other rejection on this path reports and moves on.

Two smaller problems live in the same two lines:

- **A file that parses but is the wrong shape.** The merge looks `jobs` up on the result and calls `.get` on every entry, so a top level that is not an object, a `jobs` that is not a list, or a list holding something else raises `TypeError`/`AttributeError` one or two lines further down ? the same crash, moved.
- **No encoding.** `read_text()` uses the platform default, so a job name containing non-ASCII text raises `UnicodeDecodeError` on Windows against a file written as UTF-8 anywhere else.

## Fail-before on this PR's base (`c2d383213`)

```
test_merge_refuses_a_malformed_incoming_crons_file
test_merge_refuses_a_malformed_local_crons_file
test_merge_still_imports_other_components_after_a_crons_refusal
    json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes
test_merge_refuses_a_crons_file_that_is_not_an_object
    AttributeError: 'list' object has no attribute 'get'
test_merge_refuses_a_crons_file_whose_jobs_are_the_wrong_shape[{"jobs": null}]
    TypeError: 'NoneType' object is not iterable
test_merge_refuses_a_crons_file_whose_jobs_are_the_wrong_shape[{"jobs": "not-a-list"}]
    AttributeError: 'str' object has no attribute 'get'
test_merge_refuses_a_crons_file_whose_jobs_are_the_wrong_shape[{"jobs": [123]}]
test_merge_refuses_an_incoming_crons_file_with_a_non_object_job
    AttributeError: 'int' object has no attribute 'get'
```

The third is the one that shows the blast radius: a corrupt crons file also stops `telemetry_salt` from being restored, because the traceback ends the merge.

## Why it matters

The blast radius is the whole restore, not just crons. `restore --mode merge`
runs its components in sequence, so a corrupt `crons.json` ends the run with a
traceback and **everything queued behind crons never runs** — memory, notifications,
telemetry salt. A user restoring a backup after a disk problem, which is exactly
when a truncated JSON file is likely, silently gets a partial restore.

## What changed

Both reads go through one helper that reports and returns `None`, mirroring how the merge already stands down on an incoming database that fails its integrity check:

```
  ??  Source DB unreadable: {e} ? skipping merge          # existing
  ??  incoming crons.json unreadable: {e} ? skipping crons merge
```

The message names which side failed, because "the snapshot is corrupt" and "your local file is corrupt" call for different actions from the operator.

The same helper checks the structure the merge actually depends on ? top level is an object, `jobs` (when present) is a list, every entry is an object, and a present `name` is a string ? and nothing more. Job *fields* belong to the cron loader, not here, and a missing `jobs` key keeps its existing meaning of "no jobs"; both are pinned by tests.

No file is written on any refusal path, so the local `crons.json` is left exactly as it was ? asserted directly, including in the malformed-local case where the untouched bytes are compared.

`_merge_notifications` was checked for the same shape and already guards each line as it reads it, so it is unchanged. It is the only other `json.loads` in a merge reader.

## Rejected alternatives

- **Aborting the restore with a clean error instead of skipping.** Rejected: merge is explicitly per-component, and the existing unsound-database path skips rather than aborts. Aborting would also make one corrupt component block components that are perfectly readable.
- **Repairing or replacing the local file.** Merge keeps the local file by design; overwriting it on a parse failure would turn a reporting defect into data loss.
- **Full CronJob schema validation.** Rejected: the helper checks only what the merge algorithm itself dereferences. Validating job fields would duplicate the cron loader's contract in a second place, where it would drift.
- **Validating incoming JSON centrally at the start of the restore.** Out of scope here: that is the shape of the validation the backup work already added for the *install* paths, and extending it to merge-with-existing-file is a larger change than the reported crash needs.

## Tests

Windows 11 / py3.10.6.

- The 9 new refusal cases fail on base and pass on the branch; 2 preservation cases (`test_merge_still_imports_a_well_formed_crons_file`, `test_merge_treats_a_missing_jobs_key_as_empty`) pass on both.
- Current-head focused cron selection: **6 passed**. Full `test_snapshot.py` on local Python 3.10: **52 passed, 6 baseline failures**; all six call the Python 3.12-only `TarFile.extractall(filter=...)` test API and do not touch cron merge.
- `flake8`, `isort --check-only`, `mypy --platform linux`, brand gate, `git diff --check` all clean.

No spec update: `docs/system-specs/modules/cli.md` documents `restore` as a command table and none of the documented behaviour changes.


