### PR TITLE
fix(dashboard): stop the session the turn runs on, not dashboard:<slot>

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -1413,6 +1413,17 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
     if not slot:
         return web.json_response({"error": "not found"}, status=404)
     force = request.query.get("force", "").lower() == "true"
+    # The session the slot's turns actually RUN on, which is what has to be
+    # cancelled. `_history_key_for(name)` is wrong for every slot that carries a
+    # `linked_session_key`: a cron-born tab (`cron-<job_id>` → `cron:<job_id>`),
+    # a channel-born tab (`slack:<ts>`) and a workflow-born tab all run their
+    # turns under that key (`chat_runner` resolves it with
+    # `effective_session_key`), while the dashboard-prefixed spelling names a
+    # session that never existed. `SessionManager.stop_turn` then finds nothing
+    # and returns "idle", the handler settles the card as "stopped", and the
+    # turn keeps streaming — so Stop is a silent no-op that reports success,
+    # once per press.
+    session_key = effective_session_key(slot)
 
     # Escalation path: a second stop press while a cooperative cancel is
     # already pending hard-kills. We escalate on ANY second press — not only
@@ -1441,9 +1452,9 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         # Unblock chat runner if it's suspended waiting for tool approval or on
         # a pending ask_question card.
         _unblock_pending_waits(state, slot)
-        await state.sessions.stop_turn(_history_key_for(name), force=True, on_hard=_on_hard_force)
+        await state.sessions.stop_turn(session_key, force=True, on_hard=_on_hard_force)
         sel().log_tool_invocation(
-            session_key=_history_key_for(name),
+            session_key=session_key,
             agent=getattr(slot, "agent", "") or "kirocrew",
             source="dashboard",
             tool_name="dashboard_stop",
@@ -1463,7 +1474,7 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         else:
             _info = "stop already in progress"
         sel().log_tool_invocation(
-            session_key=_history_key_for(name),
+            session_key=session_key,
             agent=getattr(slot, "agent", "") or "kirocrew",
             source="dashboard",
             tool_name="dashboard_stop",
@@ -1526,7 +1537,7 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
     _unblock_pending_waits(state, slot)
 
     outcome = await state.sessions.stop_turn(
-        _history_key_for(name), force=False, preserve_queue=True, on_soft=_on_soft, on_hard=_on_hard
+        session_key, force=False, preserve_queue=True, on_soft=_on_soft, on_hard=_on_hard
     )
     # Resolve orphaned card when provider reports no active turn
     if outcome == "idle" and slot._stop_event_id:
@@ -1534,7 +1545,7 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         slot._stop_state = "idle"
         state.push_slots_update()
     sel().log_tool_invocation(
-        session_key=_history_key_for(name),
+        session_key=session_key,
         agent=getattr(slot, "agent", "") or "kirocrew",
         source="dashboard",
         tool_name="dashboard_stop",
@@ -1880,13 +1891,17 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
         return web.json_response({"error": "not found"}, status=404)
     if not slot.running:
         return web.json_response({"ok": True, "info": "not running"})
+    # Same reason as `api_chat_slot_stop`: cancel the session the turns RUN on,
+    # not the dashboard-prefixed spelling of the slot key, which names nothing
+    # for a slot carrying a `linked_session_key`.
+    session_key = effective_session_key(slot)
     # Idempotent guard: interrupt already in progress. State alone decides —
     # do NOT also require _stop_event_id: after the early soft_pending claim
     # below, a concurrent request can arrive before the stop card is created
     # (event id still None), and a compound condition would let it through.
     if slot._stop_state != "idle":
         sel().log_tool_invocation(
-            session_key=_history_key_for(name),
+            session_key=session_key,
             agent=getattr(slot, "agent", "") or "kirocrew",
             source="dashboard",
             tool_name="dashboard_interrupt",
@@ -1951,7 +1966,7 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
     _unblock_pending_waits(state, slot)
 
     outcome = await state.sessions.stop_turn(
-        _history_key_for(name),
+        session_key,
         force=False,
         preserve_queue=True,
         on_soft=_on_soft,
@@ -1963,7 +1978,7 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
         slot._stop_state = "idle"
         state.push_slots_update()
     sel().log_tool_invocation(
-        session_key=_history_key_for(name),
+        session_key=session_key,
         agent=getattr(slot, "agent", "") or "kirocrew",
         source="dashboard",
         tool_name="dashboard_interrupt",

--- a/test/test_stop_handler_idempotent.py
+++ b/test/test_stop_handler_idempotent.py
@@ -22,6 +22,10 @@ class _FakeSlot:
         self._auto_run = False
         self.running = True
         self.key = "test-slot"
+        #: Set on every slot whose turns run on a session it did not name
+        #: itself — a cron-born tab (``cron:<job_id>``), a channel-born tab
+        #: (``slack:<ts>``), a workflow-born tab. Empty for a plain chat tab.
+        self.linked_session_key = ""
         self.agent = "kirocrew"
         self.messages: list[dict] = []
         self._dirty = False
@@ -436,3 +440,77 @@ class TestStopCardTeardownRace:
         await _make_stop_resolver(state, slot, "soft", None)()
 
         assert slot._stop_state == "idle"
+
+
+class TestStopCancelsTheSessionTheTurnRunsOn:
+    """Stop must address the session the slot's turns actually run on.
+
+    A slot carrying ``linked_session_key`` runs its turns under THAT key —
+    ``chat_runner`` resolves it with ``effective_session_key`` — so cancelling
+    ``dashboard:<slot key>`` reaches a session that never existed.
+    ``SessionManager.stop_turn`` finds nothing, returns "idle", and the handler
+    settles the card as "stopped" while the turn keeps streaming: a Stop that
+    reports success and does nothing, once per press.
+    """
+
+    @staticmethod
+    def _request(state):
+        from aiohttp import web
+
+        app = web.Application()
+        app["state"] = state
+        request = MagicMock()
+        request.app = app
+        request.match_info = {"slot": "test-slot"}
+        request.query = {}
+        return request
+
+    @pytest.mark.asyncio
+    async def test_stop_uses_the_linked_session_key(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot()
+        slot.linked_session_key = "cron:40b4958a"
+        state = _FakeState(slot)
+
+        with patch("kiro_crew.dashboard.chat_handlers.sel"), patch(
+            "kiro_crew.dashboard.chat_handlers._reject_pending_approvals"
+        ):
+            await api_chat_slot_stop(self._request(state))
+
+        assert state.sessions.stop_turn.await_args.args[0] == "cron:40b4958a"
+
+    @pytest.mark.asyncio
+    async def test_stop_falls_back_to_the_dashboard_key(self):
+        """A plain chat tab has no linked key, and must keep its own."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot()
+        state = _FakeState(slot)
+
+        with patch("kiro_crew.dashboard.chat_handlers.sel"), patch(
+            "kiro_crew.dashboard.chat_handlers._reject_pending_approvals"
+        ):
+            await api_chat_slot_stop(self._request(state))
+
+        assert state.sessions.stop_turn.await_args.args[0] == "dashboard:test-slot"
+
+    @pytest.mark.asyncio
+    async def test_interrupt_uses_the_linked_session_key(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_interrupt
+
+        slot = _FakeSlot()
+        slot.linked_session_key = "slack:1786000000.1"
+        # /interrupt is only reachable with something queued to promote.
+        slot._queue = [{"queue_id": "q1", "content": "next"}]
+        state = _FakeState(slot)
+
+        request = self._request(state)
+        request.content_length = 0
+
+        with patch("kiro_crew.dashboard.chat_handlers.sel"), patch(
+            "kiro_crew.dashboard.chat_handlers._reject_pending_approvals"
+        ):
+            await api_chat_slot_interrupt(request)
+
+        assert state.sessions.stop_turn.await_args.args[0] == "slack:1786000000.1"


### PR DESCRIPTION
## Problem / Motivation

Pressing **Stop** on a session whose tab was born from a cron job (or from Slack/Discord, or from a workflow) does nothing, and the UI says it worked. Each press appends another red `[Stopped]` card while the turn keeps streaming, so the transcript ends up with a stack of them and the agent is still running.

Observed on a cron-born tab: ten presses, ten `[Stopped]` cards, ten matching SEL rows — all `outcome=idle`, i.e. nothing was ever cancelled.

```
2026-08-12T14:54:46Z dashboard_stop outcome=idle {'slot': 'cron-40b4958a', 'force': False}
2026-08-12T14:54:49Z dashboard_stop outcome=idle {'slot': 'cron-40b4958a', 'force': False}
... (10 rows in 12 seconds)
```

## Why it matters

Stop is the control a user reaches for when something is going wrong, and a Stop that reports success and does nothing is worse than one that errors: the user stops watching. The blast radius is whatever the turn does next — file writes, pushes, tool calls. It also hits the sessions where that matters most: cron-born tabs are unattended by definition, and channel-born tabs are the ones a user cannot see the process for.

Second-order damage: the false cards are indistinguishable from real ones, so the transcript records a clean stop for a turn that ran on.

## What changed (motivation → approach → change)

`api_chat_slot_stop` and `api_chat_slot_interrupt` addressed the session as `_history_key_for(name)`, which unconditionally prepends `dashboard:` and therefore yields `dashboard:<slot key>`. Every slot carrying a `linked_session_key` runs its turns under **that** key instead — `cron:<job_id>` (`cron_inject.py:90`), `slack:<ts>` (`channel_slots.py:310`), a workflow's own key (`workflow_inject.py:156`) — and `chat_runner` resolves it with `effective_session_key` (`chat_runner.py:3136`). The stop path did not, so `SessionManager.stop_turn` was handed a key no live session owns.

From there the failure is silent by construction: `stop_turn` returns `"idle"` for an unknown key, and the handler's orphaned-card branch treats `"idle"` as "there was no turn to cancel" and settles the card as `stopped`. It also resets `_stop_state` to `"idle"`, and `slot.running` is still true, so the idempotency guard lets the *next* press through to mint a fresh card — which is why the cards accumulate one per press instead of the guard collapsing them.

The fix is the one #2462 prescribed: resolve the key once per handler with `effective_session_key(slot)` and use it for both `stop_turn` calls (soft and the force escalation), the interrupt path's call, and the SEL `session_key` fields in the same functions. `effective_session_key` falls back to `_history_key_for(slot.key)`, so a plain chat tab is unaffected.

Deliberately not in scope: the other `_history_key_for(name)` call sites in this module (`/reset`, `/clear`, session removal) have the same question, but they are a different feature with a different failure mode and belong in their own change. `stop_turn` returning `"idle"` for a key it cannot resolve — indistinguishable, at the handler, from a turn that genuinely just ended — is also left alone; with the key correct it no longer misfires, and tightening it would change the contract for every caller.

## Tests

`test/test_stop_handler_idempotent.py`, new `TestStopCancelsTheSessionTheTurnRunsOn`:

- `test_stop_uses_the_linked_session_key` — a slot linked to `cron:40b4958a` reaches `stop_turn` with that key.
- `test_stop_falls_back_to_the_dashboard_key` — an unlinked chat tab still gets `dashboard:test-slot`, so the fallback is locked in and this is not a blanket rename.
- `test_interrupt_uses_the_linked_session_key` — same for `/interrupt`, linked to `slack:<ts>`.

The fake slot gained `linked_session_key = ""`, matching the real slot's default.

Mutation-checked: with the production change stashed, the two linked-key tests fail with `assert 'dashboard:test-slot' == 'cron:40b4958a'` / `== 'slack:1786000000.1'` and the fallback test still passes — so they assert the fix rather than the mock.

## Manual verification

N/A — the defect is a wrong argument at one call boundary, and the tests assert that boundary directly. Reproducing it live needs a cron-born tab mid-turn; the SEL rows quoted above are that reproduction, captured before the fix.

## Screenshots / video

Not a UI change — included because the whole defect is what the UI *claims*. Nine `[중지됨]` (`[Stopped]`) cards, one per press, above a `생각 중` (`Thinking…`) row whose spinner is still turning: the turn never stopped, and every press was reported as a clean stop. Captured on the cron-born tab that produced the ten `outcome=idle` SEL rows quoted above. Home path masked; the dashboard was in Korean.

![Nine [Stopped] cards stacked above a still-spinning "Thinking..." row](https://github.com/tjdwlsdlaek/KiroCrew/raw/8918bb5f15f0ebe1b263cf67d98d0b584ac0a53e/temp-screenshots/stop-linked-session-key/stop-cards-while-still-thinking.png)

Hosted on a commit-pinned path in the fork rather than committed to this branch, deliberately: this PR's CI has already run green, and an amend + force-push to add an image would reset the fork workflow approval and discard that run for no reviewable gain. The URL is SHA-pinned, so it survives this branch's deletion the same way a `temp-screenshots/` commit would. Say the word and I will fold it into the branch instead.

## CI note

Two red shards, `Backend Tests (Windows) (1)` and `(4)`, fail in tests this diff cannot reach:

- `test/test_ai_runner_coverage.py::TestCalibrate::test_a_ruler_that_disagrees_with_the_result_is_logged`
- `test/test_session_summary_storage.py::TestWriteGuard::test_an_append_during_generation_refuses_the_stale_payload`

Neither imports `dashboard/chat_handlers.py` nor the stop path, both are log/timing assertions of the shape that flakes on the Windows runners, and both pass locally on this branch. Every other shard — including all four Linux backend shards on 3.10 and 3.12, macOS gateway, and the E2E job — is green.

## Related Issues

Fixes #2462

The issue reasoned this out from the code and closed with "**Unverified:** I have not reproduced this against a live linked session ... in case `SessionManager.stop_turn` normalizes the key somewhere I did not find." It does not: `stop_turn` folds the key and does a plain `self._sessions.get(key)` (`session.py:4299`), so an unknown key returns `"idle"` before any cancel is sent. The SEL rows confirm it in production, and widen the scope from channel-linked slots to every slot with a `linked_session_key` — cron-born tabs included, which is where it was actually hit.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs describe the stop key
- [x] No secrets, credentials, or internal references in the diff

