### PR TITLE
fix(slack): cap concurrent Home Tab session collections

### DIFF
--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -300,6 +300,8 @@ The slash command and keyword (which post via `chat.postMessage`) use the shared
 
 The Home Tab requests up to `_HOME_TAB_SESSIONS_PER_KIND = 5` rows per kind so both surfaces stay well under Slack's 100-block view limit. The slash command and keyword each request `_SESSIONS_DEFAULT_LIMIT = 10` rows.
 
+**At most `_HOME_TAB_COLLECT_CONCURRENCY` Home Tab collections run at once.** Every `app_home_opened` from an allowed user schedules its own publish with no dedupe, and each collection reads up to `limit` transcripts on the process-wide default executor — shared with history appends, cron store writes and session storage. Ungated, a burst of tab opens fills that executor with multi-MB reads and unrelated `asyncio.to_thread` callers queue behind them. The gate wraps only the collection; the Slack API calls around it stay unserialized. It is created lazily rather than at import, because a module-level `asyncio.Semaphore` binds to whichever loop is current when the module loads and the gateway's loop does not exist yet.
+
 Each surface emits a SEL audit event for the data-access via `sel.log_api_access`:
 
 - Slash command: `slack.sessions_slash_data_access` (caller = Slack user id)

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -164,6 +164,30 @@ _MAX_SEEN = 5000
 # prevent GC of fire-and-forget tasks (Python event loop holds weak refs)
 _background_tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
 
+#: How many Home Tab session collections may run at once. Every
+#: ``app_home_opened`` from an allowed user schedules its own publish, and the
+#: collector reads up to ``per_kind * 10`` transcripts on worker threads. Those
+#: threads are the process-wide default executor, shared with history appends,
+#: cron store writes and session storage, so an unbounded fan-out of tab opens
+#: makes unrelated ``asyncio.to_thread`` callers queue behind multi-MB reads.
+#: One at a time is what the collector had before it was offloaded, when running
+#: on the loop serialized it by accident; this keeps that bound on purpose.
+_HOME_TAB_COLLECT_CONCURRENCY = 1
+_home_tab_collect_sem: asyncio.Semaphore | None = None
+
+
+def _home_tab_collect_gate() -> asyncio.Semaphore:
+    """The collector gate, created on the loop that first needs it.
+
+    Built lazily rather than at import: a module-level ``asyncio.Semaphore``
+    binds to whatever loop happens to be current when the module loads, and the
+    gateway's loop is not running yet at that point.
+    """
+    global _home_tab_collect_sem
+    if _home_tab_collect_sem is None:
+        _home_tab_collect_sem = asyncio.Semaphore(_HOME_TAB_COLLECT_CONCURRENCY)
+    return _home_tab_collect_sem
+
 
 class SeenCache:
     """Bounded set that remembers the last *maxlen* event IDs."""
@@ -1092,11 +1116,15 @@ async def _publish_home_tab(orch: GatewayOrchestrator, user_id: str) -> None:
                 except (AttributeError, TypeError):
                     per_kind = _HOME_TAB_SESSIONS_PER_KIND
                 # Single directory scan for both kinds; partition + cap in memory.
-                all_rows = await _collect_recent_sessions_off_loop(
-                    sess_mgr,
-                    limit=per_kind * 10,
-                    kind=(_SESSION_KIND_DASHBOARD, _SESSION_KIND_TASKRUNNER),
-                )
+                # Gated so a burst of tab opens cannot put N of these scans in
+                # the shared executor at once; the rest of the publish, which is
+                # Slack API calls, stays unserialized.
+                async with _home_tab_collect_gate():
+                    all_rows = await _collect_recent_sessions_off_loop(
+                        sess_mgr,
+                        limit=per_kind * 10,
+                        kind=(_SESSION_KIND_DASHBOARD, _SESSION_KIND_TASKRUNNER),
+                    )
                 sel().log_api_access(
                     caller=user_id,
                     operation="slack.home_tab_sessions_data_access",

--- a/test/test_slack_home_tab.py
+++ b/test/test_slack_home_tab.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from kiro_crew.slack import events as events_mod
 from kiro_crew.slack.events import _publish_home_tab
 
 # ---------------------------------------------------------------------------
@@ -692,3 +694,122 @@ class TestPublishHomeTabSessions:
         # rather than no section at all — visible signal that a section exists)
         assert "🧵 Sessions" in rendered
         assert "Sessions unavailable" in rendered
+
+
+class TestHomeTabCollectorConcurrency:
+    """The sessions collector runs on the process-wide default executor, shared
+    with history appends, cron store writes and session storage. A burst of tab
+    opens must not put N multi-MB scans in it at once."""
+
+    @staticmethod
+    def _tracking_collector(observed: list[int]):
+        """Stand in for the collector, recording how many run at once."""
+        live = 0
+
+        async def collect(*_a, **_kw):
+            nonlocal live
+            live += 1
+            observed.append(live)
+            # Yield so a second caller would interleave here if nothing gated it.
+            await asyncio.sleep(0)
+            live -= 1
+            return []
+
+        return collect
+
+    @pytest.mark.asyncio
+    @patch("kiro_crew.slack.events.is_yolo_mode", return_value=False)
+    @patch("kiro_crew.slack.events.format_schedule", return_value="every 5m")
+    @patch(
+        "kiro_crew.sso_status.get_sso_status_line",
+        new_callable=AsyncMock,
+        return_value="*SSO:* ok",
+    )
+    async def test_a_burst_of_publishes_runs_one_collector_at_a_time(
+        self, _mw, _fmt, _yolo, monkeypatch
+    ):
+        monkeypatch.setattr(events_mod, "is_owner", lambda _: True)
+        monkeypatch.setattr(events_mod, "is_allowed_user", lambda _: True)
+        monkeypatch.setattr(events_mod, "_home_tab_collect_sem", None, raising=False)
+        observed: list[int] = []
+        monkeypatch.setattr(
+            events_mod,
+            "_collect_recent_sessions_off_loop",
+            self._tracking_collector(observed),
+        )
+
+        await asyncio.gather(*(
+            _publish_home_tab(_make_orch(), f"U{i}") for i in range(6)
+        ))
+
+        assert observed, "the collector never ran"
+        assert max(observed) == 1, f"collectors overlapped: {observed}"
+
+    @pytest.mark.asyncio
+    @patch("kiro_crew.slack.events.is_yolo_mode", return_value=False)
+    @patch("kiro_crew.slack.events.format_schedule", return_value="every 5m")
+    @patch(
+        "kiro_crew.sso_status.get_sso_status_line",
+        new_callable=AsyncMock,
+        return_value="*SSO:* ok",
+    )
+    async def test_every_publish_still_completes(self, _mw, _fmt, _yolo, monkeypatch):
+        """Preservation: the gate serializes the scan, it does not drop a tab."""
+        monkeypatch.setattr(events_mod, "is_owner", lambda _: True)
+        monkeypatch.setattr(events_mod, "is_allowed_user", lambda _: True)
+        monkeypatch.setattr(events_mod, "_home_tab_collect_sem", None, raising=False)
+        observed: list[int] = []
+        monkeypatch.setattr(
+            events_mod,
+            "_collect_recent_sessions_off_loop",
+            self._tracking_collector(observed),
+        )
+        orchs = [_make_orch() for _ in range(4)]
+
+        await asyncio.gather(*(
+            _publish_home_tab(o, f"U{i}") for i, o in enumerate(orchs)
+        ))
+
+        assert len(observed) == 4
+        for o in orchs:
+            o.slack.views_publish.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("kiro_crew.slack.events.is_yolo_mode", return_value=False)
+    @patch("kiro_crew.slack.events.format_schedule", return_value="every 5m")
+    @patch(
+        "kiro_crew.sso_status.get_sso_status_line",
+        new_callable=AsyncMock,
+        return_value="*SSO:* ok",
+    )
+    async def test_a_failing_collector_does_not_strand_the_gate(
+        self, _mw, _fmt, _yolo, monkeypatch
+    ):
+        """A raising scan must release the gate, or the first failure wedges
+        every later Home Tab open."""
+        monkeypatch.setattr(events_mod, "is_owner", lambda _: True)
+        monkeypatch.setattr(events_mod, "is_allowed_user", lambda _: True)
+        monkeypatch.setattr(events_mod, "_home_tab_collect_sem", None, raising=False)
+
+        async def boom(*_a, **_kw):
+            raise RuntimeError("scan failed")
+
+        monkeypatch.setattr(events_mod, "_collect_recent_sessions_off_loop", boom)
+        orch = _make_orch()
+        await _publish_home_tab(orch, "U1")
+
+        observed: list[int] = []
+        monkeypatch.setattr(
+            events_mod,
+            "_collect_recent_sessions_off_loop",
+            self._tracking_collector(observed),
+        )
+        await asyncio.wait_for(_publish_home_tab(_make_orch(), "U2"), timeout=5)
+
+        assert observed == [1]
+
+    def test_the_gate_is_not_bound_at_import(self):
+        """Created lazily: a module-level Semaphore would bind to whichever loop
+        was current at import, not the gateway's."""
+        gate = getattr(events_mod, "_home_tab_collect_sem", None)
+        assert gate is None or isinstance(gate, asyncio.Semaphore)


### PR DESCRIPTION
Closes #3063.

## Summary

- cap how many Home Tab session collections run at once
- gate only the collection, not the Slack API calls around it
- build the gate on first use so it binds to the gateway's loop, not the import-time one
- cover the burst, the completion guarantee, and the failure path

## The gap

Every `app_home_opened` from an allowed user schedules its own `_publish_home_tab` with no throttle and no in-flight dedupe, and each publish collects up to `per_kind * 10` transcripts.

While that collection ran on the event loop it was serialized *by accident* — each publish froze the loop until it finished. Offloading it to worker threads removed the accident without replacing it, so a burst of tab opens now runs N collections concurrently. Those threads are the process-wide default executor, shared with history appends, cron store writes and session storage, so the fan-out pushes unrelated `asyncio.to_thread` callers behind multi-MB reads.

## Fail-before on this PR's base (`8d17fa982`)

```
test_a_burst_of_publishes_runs_one_collector_at_a_time
    AssertionError: collectors overlapped: [1, 2, 3, 4, 5, 6]
```

Six publishes, six collections in flight. The test substitutes a collector that records how many are running as it yields, so it measures the concurrency directly rather than timing anything.

The other three cases pass on base as well as on the branch — they exist to catch the gate breaking something, not to demonstrate the bug.

## The fix

An `asyncio.Semaphore(_HOME_TAB_COLLECT_CONCURRENCY)` around the collection. One at a time is what the collector effectively had before it was offloaded, so this is a return to a known bound rather than a new guess at one.

It wraps **only** the collection. The Slack API calls that surround it have no reason to queue behind each other, and serializing the whole publish would make a burst slower than it needs to be.

The gate is created on first use. A module-level `asyncio.Semaphore` binds to whichever loop is current when the module is imported, and the gateway's loop does not exist at that point — a test pins that it is not constructed at import.

Queued publishes wait on the semaphore rather than occupying a worker, so executor occupancy from this path is bounded by the constant regardless of how many tabs open at once.

## Rejected alternatives

- **Per-user in-flight dedupe** (the issue's other suggestion). It collapses one user reopening the tab, but N *different* users still fan out N collections — which is the shape of the consequence being fixed. Worth adding later as a work-avoidance optimisation; it does not bound the executor on its own.
- **A dedicated executor for the collector.** Bounds this path but leaves the shared executor's contention story split across two mechanisms, and nothing else in the module needs one.
- **Serializing the whole publish.** Simpler, but it queues Slack API round-trips behind each other for no benefit.

## Known limitation

A burst from one user still performs one collection per event, just never more than `_HOME_TAB_COLLECT_CONCURRENCY` at a time. This PR bounds concurrency, which is the reported consequence; it does not eliminate redundant work. That is what the per-user dedupe above would add.

## Verification

Windows 11 / py3.10.6.

- 1 new case fails on base and passes on the branch; 3 pass on both (every publish still completes and still calls `views_publish`; a raising collector releases the gate instead of wedging every later tab open; the gate is not bound at import).
- `test_slack_home_tab` + `test_slack_events_coverage` + `test_slack_sessions_view` + `test_slack_gateway`, identical selection: **base 2F/455P/4s → branch 1F/456P/4s**. Failing-node sets diffed: base-only = exactly the new case, **branch-only = empty**. The one failing on both is `TestCollectRecentSessions::test_skips_symlinks`, which needs symlink privileges this host does not have.
- `flake8`, `isort --check-only`, `mypy --platform linux`, `docs-lint`, brand gate, `git diff --check` all clean.

Spec updated in the same commit (`docs/system-specs/modules/slack-gateway.md`), which already documents this collector as the required entry point for async callers.
