### PR TITLE
fix(dashboard): restore full-height expanded widgets

### DIFF
--- a/website/src/components/WidgetFrame.tsx
+++ b/website/src/components/WidgetFrame.tsx
@@ -574,7 +574,7 @@ export default function WidgetFrame({ html, title = 'Widget', slug, messageTs, w
   return (
     <div
       ref={containerRef}
-      className={`group my-2 transition-colors ${expanded ? 'fixed inset-4 z-[100] rounded-xl border border-border bg-card overflow-hidden shadow-2xl' : ''}`}
+      className={`group my-2 transition-colors ${expanded ? 'fixed inset-4 z-[100] flex flex-col rounded-xl border border-border bg-card overflow-hidden shadow-2xl' : ''}`}
     >
       {!visible ? (
         /* Skeleton — mirrors the visible layout (same header bar + a reserved
@@ -635,7 +635,7 @@ export default function WidgetFrame({ html, title = 'Widget', slug, messageTs, w
         </IconButtonGroup>
       </div>
 
-      {blobUrl && <div className="relative">
+      {blobUrl && <div className={expanded ? 'relative flex-1 min-h-0 bg-card' : 'relative'}>
         {/* Parent-side progress indicator. REQUIRED in addition to the in-iframe
             overlay: the iframe below renders at opacity 0 until its onLoad
             fires, so anything inside it is invisible during exactly the window
@@ -648,7 +648,7 @@ export default function WidgetFrame({ html, title = 'Widget', slug, messageTs, w
             // centred indicator drifts below the fold — mounted but invisible,
             // which is the very failure this is meant to prevent.
             className="absolute inset-0 z-10 flex items-start justify-center gap-2 rounded bg-card pt-6 text-[12px] text-muted"
-            style={{ height: expanded ? 'calc(100% - 36px)' : height }}
+            style={{ height: expanded ? '100%' : height }}
           >
             <span
               className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-border motion-reduce:animate-none"
@@ -667,7 +667,7 @@ export default function WidgetFrame({ html, title = 'Widget', slug, messageTs, w
           onLoad={() => setIframeLoaded(true)}
           sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
           className="w-full border-none bg-card transition-opacity duration-200 ease-out motion-reduce:transition-none"
-          style={{ height: expanded ? 'calc(100% - 36px)' : height, opacity: iframeLoaded ? 1 : 0 }}
+          style={{ height: expanded ? '100%' : height, opacity: iframeLoaded ? 1 : 0 }}
           title={title}
         />
       </div>}

--- a/website/src/test/WidgetFrame.test.tsx
+++ b/website/src/test/WidgetFrame.test.tsx
@@ -6,6 +6,8 @@ import WidgetFrame from '../components/WidgetFrame'
 import { ThemeProvider } from '../hooks/useTheme'
 import { api, ApiError } from '../api/client'
 import { effectiveWidgetSlug } from '../lib/widgetSlug'
+import { i18nT } from '../i18n/t'
+import { TAILWIND_COMPLEXITY_THRESHOLD } from '../lib/widgetComplexity'
 
 // WidgetFrame consumes useTheme(), which requires a ThemeProvider, and now
 // useQuery, which requires a QueryClient. Wrap every render here to mirror the
@@ -916,5 +918,99 @@ describe('WidgetFrame exists-vs-pinned states', () => {
 
     const slug = effectiveWidgetSlug({ messageTs: TS, widgetIndex: 0 })
     expect(queryClient.getQueryData(['artifact-saved', slug])).toEqual({ exists: false, pinned: false })
+  })
+})
+
+// Structural-contract tests for the expanded (full-screen) layout.
+//
+// Percentage iframe heights require an unbroken definite-height chain: the
+// expanded root is a fixed-position flex column, the body wrapper is a
+// shrinkable flex-1 item, and the iframe resolves 100% against it so it fills
+// the space below the toolbar. These tests pin that CLASS STRUCTURE only —
+// happy-dom computes no layout, so they cannot observe rendered geometry.
+// Real display regressions need a browser-level geometry assertion.
+describe('WidgetFrame expanded layout (structural contract)', () => {
+  const expandLabel = () => i18nT('components.widgetFrame.expand')
+
+  it('expanded: root is a flex column and the body wrapper/iframe form an unbroken height chain', () => {
+    const { container } = wrap(<WidgetFrame html="<p>hi</p>" title="T" />)
+    const root = container.firstElementChild as HTMLElement
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement
+
+    // Collapsed baseline: measured pixel height, plain wrapper, no modal classes.
+    expect(iframe.style.height).not.toBe('100%')
+    expect(root.classList.contains('flex-col')).toBe(false)
+
+    const btn = container.querySelector(
+      `button[aria-label="${expandLabel()}"]`,
+    ) as HTMLButtonElement
+    expect(btn).not.toBeNull()
+    act(() => { btn.click() })
+
+    // Token-level checks: `flex` must be its own class (flex-col alone sets
+    // no display), and `inset-4` is what makes the fixed root's height
+    // definite — without it the chain below has nothing to resolve against.
+    // classList.contains() (not jest-dom's toHaveClass) because this TS
+    // project does not load the matcher's type extensions for test files.
+    expect(root.classList.contains('fixed')).toBe(true)
+    expect(root.classList.contains('inset-4')).toBe(true)
+    expect(root.classList.contains('flex')).toBe(true)
+    expect(root.classList.contains('flex-col')).toBe(true)
+    // The wrapper introduced for the progress indicator must fill the modal.
+    const bodyWrapper = iframe.parentElement as HTMLElement
+    expect(bodyWrapper.classList.contains('flex-1')).toBe(true)
+    expect(bodyWrapper.classList.contains('min-h-0')).toBe(true)
+    // The iframe resolves against the flexed wrapper, not a magic 36px calc.
+    expect(iframe.style.height).toBe('100%')
+  })
+
+  it('expanded: the loading overlay of a heavy widget spans the full body wrapper', () => {
+    // Enough unique Tailwind utility classes to cross the complexity
+    // threshold, so the parent-side progress overlay actually renders and
+    // its expanded-mode height style is exercised.
+    const classes = Array.from(
+      { length: TAILWIND_COMPLEXITY_THRESHOLD + 10 },
+      (_, i) => `p-${i}`,
+    ).join(' ')
+    const { container } = wrap(<WidgetFrame html={`<div class="${classes}">x</div>`} title="T" />)
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement
+    // The overlay stays mounted until the iframe's load event, which the
+    // mocked blob: URL never fires in this environment.
+    const overlay = iframe.parentElement!.querySelector(
+      '[class*="absolute"][class*="inset-0"]',
+    ) as HTMLElement
+    expect(overlay).not.toBeNull()
+    expect(overlay.style.height).not.toBe('100%')
+
+    const btn = container.querySelector(
+      `button[aria-label="${expandLabel()}"]`,
+    ) as HTMLButtonElement
+    act(() => { btn.click() })
+
+    expect(overlay.style.height).toBe('100%')
+  })
+
+  it('restores the collapsed layout on minimize', () => {
+    const { container } = wrap(<WidgetFrame html="<p>hi</p>" title="T" />)
+    const root = container.firstElementChild as HTMLElement
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement
+    const collapsedHeight = iframe.style.height
+
+    const expandBtn = container.querySelector(
+      `button[aria-label="${expandLabel()}"]`,
+    ) as HTMLButtonElement
+    act(() => { expandBtn.click() })
+    const minimizeBtn = container.querySelector(
+      `button[aria-label="${i18nT('components.widgetFrame.minimize')}"]`,
+    ) as HTMLButtonElement
+    expect(minimizeBtn).not.toBeNull()
+    act(() => { minimizeBtn.click() })
+
+    expect(root.classList.contains('flex-col')).toBe(false)
+    // The expanded-only sizing classes must be gone; don't pin the exact
+    // class list so harmless collapsed-mode additions don't break this.
+    expect(iframe.parentElement!.classList.contains('flex-1')).toBe(false)
+    expect(iframe.parentElement!.classList.contains('min-h-0')).toBe(false)
+    expect(iframe.style.height).toBe(collapsedHeight)
   })
 })


### PR DESCRIPTION
## Problem / Motivation
Expanding a chat widget can leave the iframe close to its default height instead of filling the modal. Only the toolbar and a short strip of widget content remain visible, while the click-outside backdrop shows through the rest of the modal.

The issue reproduces when expanding a chat widget whose iframe is wrapped by the progress-indicator container introduced in #2076. This makes content-heavy widgets difficult to inspect in expanded mode.

## Why it matters
Expanded mode provides the available viewport space needed for dashboards, long reports, and comparison tables. When the iframe does not fill that space, users must scroll inside a small content area and cannot use the expanded view as intended.

## What changed (motivation → approach → change)
The progress-indicator wrapper introduced an auto-height element between the definite-height expanded container and the iframe. As a result, the iframe's percentage height no longer resolved against the expanded container and fell back close to its default height.

This also exposed the click-outside backdrop over the unused part of the modal. The expanded root forms a stacking context, so its negative-z backdrop child paints above the root's own background.

The fix replaces the explicit toolbar-height subtraction (`calc(100% - 36px)`) with a flex-column layout consistent with the other full-screen panels:

- The expanded container uses `flex flex-col`.
- The toolbar keeps its intrinsic height.
- The widget body uses `flex-1 min-h-0` and a card background.
- The iframe and loading overlay resolve `height: 100%` against that body.

Collapsed mode continues to use the widget's measured pixel height, so its height cache and inline chat layout are unchanged.

## Tests
Added three structural regression tests covering:

- The expanded root, body wrapper, and iframe height chain.
- Full-height rendering of the heavy-widget loading overlay.
- Restoration of measured-height collapsed mode after minimizing.

The tests intentionally assert the required DOM and class contract because `happy-dom` does not compute browser layout. Mutation checks confirmed that removing `flex`, `inset-4`, or the overlay height change causes the relevant regression test to fail.

Validation performed:

- `npx vitest run src/test/WidgetFrame.test.tsx` — 38 passed
- ESLint on both changed files — passed
- `npx tsc -b` — passed
The TypeScript project excludes test files, so `npx tsc -b` covers the component change rather than the new test code.

## Manual verification
Verified in an isolated development instance that:

- Expanded widget content fills the body below the toolbar.
- The backdrop dims the page behind the modal without covering its content.
- Click-outside and Minimize restore the inline widget at its measured height.
- Collapsed rendering remains visually unchanged.

## Screenshots / video
| Before fix | After fix |
|---|---|
| ![Expanded widget before the fix](https://github.com/user-attachments/assets/36d4f261-f3b7-4870-9500-f523275f3fb1) | ![Expanded widget after the fix](https://github.com/user-attachments/assets/e4dc7c75-77bf-4849-8778-7908ebb4249c) |


## Related Issues
N/A — no issue filed; this description contains the full diagnosis.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and regression tests were added
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc describes the widget expand layout behavior
- [x] No secrets, credentials, or internal references in the diff