### PR TITLE
fix(build): retry electron-builder on transient network failures, not just ENOTEMPTY

### DIFF
--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -495,20 +495,46 @@ log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
   # which performs no retries -- fails the final rmdir with ENOTEMPTY and the
   # whole build aborts (electron-userland/electron-builder#6890). It is a
   # transient race, so retry from a swept, clean dir a bounded number of times.
+  #
+  # Transient network/TLS failures in electron-builder's own fetches:
+  # electron-builder downloads more than the electron zip -- the AppImage and
+  # NSIS/Squirrel targets pull their own tooling mid-build through `got`. A
+  # dropped connection there ("socket hang up") or a TLS-intercepted response
+  # ("self-signed certificate") aborts the whole build *after* the electron
+  # download has already reported progress=100%. Those are per-execution
+  # network events rather than build errors: the same commit passes on a plain
+  # re-run, and one matrix leg fails while its siblings go green on the same
+  # attempt. They share the bounded budget below, take a longer backoff than
+  # the local .DS_Store sweep, and still fail the build once it is exhausted --
+  # a real outage must stay visible.
   attempt=1; max_attempts=3
   while : ; do
     eb_log="$(mktemp "${TMPDIR:-/tmp}/kc-eb.XXXXXX")"
     if CSC_IDENTITY_AUTO_DISCOVERY=false ./node_modules/.bin/electron-builder "${EB_ARGS[@]}" 2>&1 | tee "$eb_log"; then
       rm -f "$eb_log"; break
     fi
-    if grep -q "ENOTEMPTY" "$eb_log" && [ "$attempt" -lt "$max_attempts" ]; then
-      echo "  ⚠ macOS .DS_Store/ENOTEMPTY temp-dir race (attempt $attempt/$max_attempts); sweeping .DS_Store and retrying…" >&2
-      find dist -name .DS_Store -delete 2>/dev/null || true
-      rm -rf dist/*-temp 2>/dev/null || true
-      rm -f "$eb_log"; attempt=$((attempt + 1)); sleep 2; continue
+    # Classify the failure before deciding: each transient class needs its own
+    # cleanup, and anything unrecognised must still abort on the first failure.
+    eb_transient=""
+    if grep -q "ENOTEMPTY" "$eb_log"; then
+      eb_transient="ds_store"
+    elif grep -qE "socket hang up|self[- ]signed certificate|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND" "$eb_log"; then
+      eb_transient="network"
+    fi
+    if [ -n "$eb_transient" ] && [ "$attempt" -lt "$max_attempts" ]; then
+      if [ "$eb_transient" = "ds_store" ]; then
+        echo "  ⚠ macOS .DS_Store/ENOTEMPTY temp-dir race (attempt $attempt/$max_attempts); sweeping .DS_Store and retrying…" >&2
+        find dist -name .DS_Store -delete 2>/dev/null || true
+        rm -rf dist/*-temp 2>/dev/null || true
+        eb_backoff=2
+      else
+        echo "  ⚠ transient network/TLS failure in an electron-builder fetch (attempt $attempt/$max_attempts); retrying…" >&2
+        eb_backoff=$((attempt * 10))
+      fi
+      rm -f "$eb_log"; attempt=$((attempt + 1)); sleep "$eb_backoff"; continue
     fi
     rm -f "$eb_log"
-    echo "❌ electron-builder failed (not the .DS_Store race, or retries exhausted)." >&2
+    echo "❌ electron-builder failed (not a known transient class, or retries exhausted)." >&2
     exit 1
   done
 )


### PR DESCRIPTION
🤖 Filed by **perpetual agent `flake-warden`** — an unsupervised agent on an hourly
schedule. No human reviewed this before it was posted. Evidence is cited inline;
anything marked suspected is not proven.

Fixes #3088.

## What was wrong

`packaging/build-desktop.sh:504` gated its bounded retry loop on one literal:

```bash
if grep -q "ENOTEMPTY" "$eb_log" && [ "$attempt" -lt "$max_attempts" ]; then
```

The loop itself is fine and already bounded — it was added for the macOS
`.DS_Store`/`ENOTEMPTY` race. But any *other* transient failure fell through to
`:511-512` and killed the build on its first occurrence. All 4 `Build Desktop`
failures in a 10.2-hour window were exactly that, and none was a build error:

| job | attempt | leg | error |
|---|---|---|---|
| `94190132454` | run `31618771896` att 2 | ubuntu-22.04 | `socket hang up` |
| `94190132569` | run `31618771896` att 2 | ubuntu-22.04-arm | `socket hang up` |
| `94189149268` | run `31619067571` att 1 | ubuntu-22.04-arm | `socket hang up` |
| `94052238906` | run `31577268135` att 1 | macos-15 | `self-signed certificate` |

**Same SHA, red then green:** run `31577268135` head `9bed7c1624286ce0e5c4738bcc5e0ca418fd4cd5`
failed `Build Desktop (macos-15)` on attempt 1 (job `94052238906`) and passed it on
attempt 2 (job `94056189334`). **Same SHA, same attempt, one leg red:** run
`31619067571` attempt 1 had `ubuntu-22.04-arm` red and `ubuntu-22.04` green.

The electron zip is not the fetch that fails — job `94189149268` logs
`downloaded label=electron progress=100%` and then dies at
`building target=AppImage`. The AppImage and NSIS/Squirrel targets pull their own
tooling mid-build through `got`, and that fetch has no retry anywhere in the path.

Full evidence, rates and limits are in #3088.

## The change

Classify the failure, then decide. Network/TLS errors become a second transient
class sharing the same `max_attempts=3` budget, with a longer backoff
(`attempt * 10s`) than the local `.DS_Store` sweep.

**What does not change — this is the whole review:**

- the `ENOTEMPTY` arm keeps its exact message, its `.DS_Store` sweep, its
  `dist/*-temp` removal and its `sleep 2`;
- a genuine build error still aborts on the **first** failure with zero retries;
- an exhausted budget still `exit 1`s, so a real outage stays visible.

I am not widening a threshold or masking a failure. A persistent network outage
still fails the build; what changes is that a single dropped connection no longer
does.

This follows the repo's own convention rather than a new one: `pr-readiness.yml`
already wraps read-only `gh` calls in a bounded retry, and its comment
(`:130-142`) cites #2753 for this same class of transient TLS error.

## Verification: red before green

`bash -n` passes. Neither `actionlint` nor `shellcheck` is installed on this host
and no workflow references them, so that plus the harness below is the strongest
local gate available — **CI is the first real linter this patch meets.**

The harness extracts the **real** loop body from the file (by locating
`attempt=1; max_attempts=3` and its matching `done`, not by pasting a copy) for
both `origin/main` and this branch, and drives each under `set -euo pipefail`
against a stubbed `./node_modules/.bin/electron-builder` with a scripted outcome
plan and a per-invocation counter. `sleep` is shadowed so the backoff arithmetic
still runs but the harness stays fast.

| arm | plan | OLD (`origin/main`) | NEW |
|---|---|---|---|
| network transient, then success | `hangup, ok` | **exit 1**, 1 invocation | **exit 0**, 2 invocations |
| TLS intercept, then success | `tls, ok` | **exit 1**, 1 invocation | **exit 0**, 2 invocations |
| network transient, never recovers | `hangup` | exit 1, 1 invocation | exit 1, **3** invocations |
| CONTROL — `.DS_Store` race, then success | `enotempty, ok` | exit 0, 2 invocations | exit 0, 2 invocations, identical message |
| CONTROL — genuine build error | `real` | exit 1, 1 invocation | exit 1, **1** invocation |
| CONTROL — happy path | `ok` | exit 0, 1 invocation | exit 0, 1 invocation |

Rows 1-2 are the flake: red before, green after. Row 3 is the §5 protection — the
build still fails, just not on the first packet loss. Rows 4-6 are the regression
controls, and row 5 is the one that matters most: the predicate did **not** become
"retry everything".

## What I did not establish

- **I never reproduced this against a real electron-builder run**, because I cannot
  make a runner's connection drop. The loop's control flow is verified against the
  extracted block with a stub; the packaging behaviour on retry is not re-verified
  here beyond the fact that the `ENOTEMPTY` arm already re-invokes the same command
  the same way.
- I did not identify the remote host that hung up — the log gives the `got` stack
  and the failing target, not the URL.
- The error-string list is drawn from the two strings actually observed plus the
  classic transient socket family (`ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`,
  `ENOTFOUND`). Those four are **not** observed in this repo's logs; they are
  included because they are the same class, and a reviewer who wants the predicate
  narrowed to only what was observed would be making a reasonable call.
- The match is against the whole electron-builder log, so a genuinely broken build
  whose log happens to contain one of these strings would be retried up to 3 times
  before failing. That costs bounded queue time and changes no verdict, but it is a
  real trade-off rather than a free win.
