### PR TITLE
test(chat): pin the block-assembler seed gate to one parse per mount

### DIFF
--- a/website/src/test/useBlockAssembler.throttle.test.ts
+++ b/website/src/test/useBlockAssembler.throttle.test.ts
@@ -56,6 +56,20 @@ describe('useBlockAssembler streaming throttle', () => {
     expect(parses()).toBe(afterMount + 2)
   })
 
+  it('parses once on a cold mount of a completed message, not twice', () => {
+    // Only a fresh mount runs the useState seed, so a rerender into
+    // streaming:false cannot reach it -- this has to mount false outright.
+    const text = `${MARK} done\n\`\`\`js\nconst x = 1\n\`\`\`\ntail`
+    const parses = countParsesOf(MARK)
+
+    const { result } = renderHook(() => useBlockAssembler(text, false))
+    // Read before the assertion below, which parses again on the same counter.
+    const afterMount = parses()
+
+    expect(afterMount).toBe(1)
+    expect(result.current).toEqual(parseBlocks(text, false))
+  })
+
   it('returns a stable reference across renders inside one window', () => {
     const { result, rerender } = renderHook(
       ({ text }) => useBlockAssembler(text, true),


### PR DESCRIPTION
## What

`useBlockAssembler` seeds its throttled state with a gated expression:

```ts
const [throttledBlocks, setThrottledBlocks] = useState<ContentBlock[]>(() =>
  streaming ? parseBlocks(rawText, true) : NO_BLOCKS,
)
```

For an already-completed message the memo above it parses, and this seed correctly returns `NO_BLOCKS`. Ungate it to `parseBlocks(rawText, streaming)` and you get a second full parse of the same text on every mount, for every completed message in a transcript. One parse is correct; two is the regression.

This adds one test case pinning that seed to exactly one parse per mount. **Test-only** — the hook is byte-identical to the base commit.

## Why the existing suite could not catch it

`countParsesOf` counts real parse invocations by patching `String.prototype.split` on a marked input (one `raw.split('\n')` per parse). It was installed in two cases, and both mount with `streaming` hardcoded `true`.

The cases that *do* reach `streaming: false` get there by `rerender` after mounting `true` — and a rerender does not re-run a `useState` initialiser. So the seed was never exercised from a cold mount under the counter. Every `initialProps` site in the file mounts `true` or omits the flag; literal `useBlockAssembler(..., false)` occurrences: 0.

That is the sharp version of the gap: even a test that *transitions* to `false` cannot reach the seed, because only a fresh mount runs it.

## Red/green, measured

| Step | Seed | Suite | Result | rc |
| ---------------------------- | ----------- | ---------- | -------------------------- | --- |
| baseline | gated | existing 6 | 6 passed | 0 |
| sabotage, existing suite | **ungated** | existing 6 | **6 passed — green** | 0 |
| sabotage, with new case      | **ungated** | 7          | 1 failed / 6 passed        | 1   |
| gate restored, with new case | gated       | 7          | 7 passed                   | 0   |

Against the ungated seed the new case reports **2** parses (`expected 2 to be 1`); with the gate restored it reports **1**. The ungated seed also typechecks clean, so a parse count is the only thing that distinguishes it.

The second row is the point of this PR: the shipped suite is fully green against the regression.

## Notes

Added as a case in the existing `useBlockAssembler.throttle.test.ts` rather than a new file, so the frontend test file count is unchanged.

`eslint`, `tsc --noEmit`, and the repo scrub gate all pass.
