### PR TITLE
fix: offload app register/deregister to executor in routes (#3075)

### DIFF
--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -2302,12 +2302,12 @@ def register_app(app_name: str) -> RegistrationResult:
         return result
 
     # NOTE: pruning of resources a manifest UPGRADE removed is NOT done here.
-    # register_app is called on the event loop by the enable/update handlers,
-    # and a prune (directory walk over every agent file + lock acquisition)
-    # scales with agent count and would stall chat/heartbeat. Those on-loop
-    # callers all deregister_app() first, so nothing stale survives for them to
-    # prune. The one path that re-registers WITHOUT a preceding deregister — the
-    # boot reconcile — does the prune itself, off the loop, in
+    # The enable/update route handlers all deregister_app() first, so nothing
+    # stale survives for them to prune — a prune here (a directory walk over
+    # every agent file + lock acquisition, scaling with agent count) would run
+    # redundantly on every one of those deregister-first calls. The one path
+    # that re-registers WITHOUT a preceding deregister — the boot reconcile —
+    # does the prune itself, off the loop, in
     # reconcile_enabled_app_resources(). See that function.
 
     # MCP servers BEFORE agents: _register_agents copies the app's own registered

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -32,6 +32,7 @@ from kiro_crew.apps.backend import (
     stop_app_backend,
 )
 from kiro_crew.apps.bridges import (
+    RegistrationResult,
     deregister_app,
     deregister_app_crons_from_service,
     register_app,
@@ -380,6 +381,29 @@ async def _start_backend_after_install(name: str) -> None:
         logger.warning("Backend auto-start after install failed for app %s", name, exc_info=True)
 
 
+async def _register_app_off_loop(name: str) -> RegistrationResult:
+    """Run ``register_app`` on the subprocess executor, off the event loop.
+
+    ``register_app`` / ``deregister_app`` do real filesystem work under
+    ``KIROCREW_HOME`` — manifest reads, skill-dir symlink walks, agent JSON
+    writes, and ``mcp.json`` read + atomic write.  On a stalled filesystem
+    (e.g. a dead network mount) those calls block in the kernel; run on the
+    loop they freeze every task including the liveness heartbeat until the
+    stall watchdog kills the gateway.  Same offload pattern as ``install_app``
+    and ``start_app_backend`` on these handlers.
+    """
+    return await asyncio.get_running_loop().run_in_executor(
+        subprocess_executor(), register_app, name
+    )
+
+
+async def _deregister_app_off_loop(name: str) -> RegistrationResult:
+    """Run ``deregister_app`` off the event loop (see ``_register_app_off_loop``)."""
+    return await asyncio.get_running_loop().run_in_executor(
+        subprocess_executor(), deregister_app, name
+    )
+
+
 async def handle_install_app(request: web.Request) -> web.Response:
     """POST /api/apps/install — install an app from a local path."""
     try:
@@ -433,7 +457,7 @@ async def handle_install_app(request: web.Request) -> web.Response:
         invalidate_app_secret_cache(result.name)
 
         # Auto-register resources
-        reg = register_app(result.name)
+        reg = await _register_app_off_loop(result.name)
         # Spawn the backend now so the app is reachable without a gateway reboot
         # (see _start_backend_after_install). No-op for backend-less apps.
         await _start_backend_after_install(result.name)
@@ -492,12 +516,12 @@ async def handle_update_app(request: web.Request) -> web.Response:
                 )
                 return web.json_response(reg_install, status=400)
             # Install succeeded — now safe to swap resources
-            deregister_app(name)
+            await _deregister_app_off_loop(name)
             await asyncio.get_running_loop().run_in_executor(
                 subprocess_executor(), stop_app_backend, name
             )
             if info.get("enabled"):
-                reg_result = register_app(name)
+                reg_result = await _register_app_off_loop(name)
                 await asyncio.get_running_loop().run_in_executor(
                     subprocess_executor(), start_app_backend, name
                 )
@@ -520,7 +544,7 @@ async def handle_update_app(request: web.Request) -> web.Response:
     # (The registry branch above locks inside install_from_registry.)
     async with app_lifecycle_lock(name):
         # Deregister old resources before update
-        deregister_app(name)
+        await _deregister_app_off_loop(name)
         await asyncio.get_running_loop().run_in_executor(
             subprocess_executor(), stop_app_backend, name
         )
@@ -533,7 +557,7 @@ async def handle_update_app(request: web.Request) -> web.Response:
         )
         if not up_result.ok:
             # Re-register old resources on failure
-            register_app(name)
+            await _register_app_off_loop(name)
             if info.get("enabled"):
                 await asyncio.get_running_loop().run_in_executor(
                     subprocess_executor(), start_app_backend, name
@@ -550,7 +574,7 @@ async def handle_update_app(request: web.Request) -> web.Response:
         # Re-register with new manifest if app was enabled
         up_reg = None
         if info.get("enabled"):
-            up_reg = register_app(name)
+            up_reg = await _register_app_off_loop(name)
             await asyncio.get_running_loop().run_in_executor(
                 subprocess_executor(), start_app_backend, name
             )
@@ -906,7 +930,7 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
             await asyncio.get_running_loop().run_in_executor(
                 subprocess_executor(), stop_app_backend, name
             )
-            deregister_app(name)
+            await _deregister_app_off_loop(name)
 
         # Step 4: Clean dependencies (atomic classify + ledger update)
         cleaned_deps: list[str] = []
@@ -1077,7 +1101,7 @@ async def handle_enable_app(request: web.Request) -> web.Response:
 
         # Register resources if gateway-managed
         if resources == "gateway":
-            reg = register_app(name)
+            reg = await _register_app_off_loop(name)
             backend = await asyncio.get_running_loop().run_in_executor(
                 subprocess_executor(), start_app_backend, name
             )
@@ -1145,7 +1169,7 @@ async def handle_enable_app(request: web.Request) -> web.Response:
                     await asyncio.get_running_loop().run_in_executor(
                         subprocess_executor(), stop_app_backend, name
                     )
-                    deregister_app(name)
+                    await _deregister_app_off_loop(name)
                 disable_app(name)
                 sel().log_api_access(
                     caller="dashboard",
@@ -1471,7 +1495,7 @@ async def handle_registry_install(request: web.Request) -> web.Response:
             return web.json_response(result, status=400)
 
         # Auto-register resources
-        reg = register_app(result["name"])
+        reg = await _register_app_off_loop(result["name"])
         # Spawn the backend now so apps with a server are reachable immediately —
         # without this the backend only starts on the next gateway reboot (via
         # start_enabled_app_backends), leaving the app's UI with "no reachable
@@ -1564,7 +1588,7 @@ async def handle_registry_install_stream(request: web.Request) -> web.StreamResp
         async with app_lifecycle_lock(name):
             r = await install_from_registry(name, log_lines=streaming_log)
             if r.get("ok") and not r.get("needsClientInstall"):
-                reg = register_app(r["name"])
+                reg = await _register_app_off_loop(r["name"])
                 # Spawn the backend immediately (see handle_registry_install) so
                 # the app is reachable without a gateway reboot. No-op for
                 # backend-less apps.

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -6643,19 +6643,19 @@ def publish_materialized_agents(names: Iterable[str]) -> None:
 def schedule_materialized_agents_refresh() -> None:
     """Refresh the snapshot from ANY context without blocking an event loop.
 
-    ``apps.bridges._register_agents`` is the writer that must trigger this, and it
-    runs on the loop for the dashboard paths: ``register_app`` documents that "it
-    is called on the event loop by the enable/update handlers", so clicking Enable
-    in the App Store reaches it with the loop live. Scanning inline there is the
-    same directory-walk-per-agent-file stall the neighbouring prune comment warns
-    about, so the scan is handed to the default executor and this returns
-    immediately. In a synchronous context (CLI, tests, the boot warm already on an
-    executor) it refreshes inline.
-
-    The offloaded refresh lands a few milliseconds later, so a turn dispatched in
-    that window sees the pre-enable snapshot and falls back for that one turn,
-    then self-heals — strictly better than the alternative of staying stale until
-    the next gateway boot. Never raises; the scan itself swallows its errors.
+    ``apps.bridges._register_agents`` is the writer that must trigger this. The
+    dashboard enable/update handlers dispatch ``register_app`` to an executor
+    thread, so from those paths this runs in a synchronous context (no running
+    loop) and refreshes inline — the scan is already off the loop, serialized
+    inside the awaited registration, so no stale-snapshot window exists there.
+    The same inline branch covers the CLI, tests, and the boot warm already on
+    an executor. For a caller that does hold a live loop, scanning inline would
+    be the same directory-walk-per-agent-file stall the neighbouring prune
+    comment warns about, so the scan is handed to the default executor and this
+    returns immediately; that offloaded refresh lands a few milliseconds later,
+    and a turn dispatched in that window sees the previous snapshot for one
+    turn, then self-heals — strictly better than staying stale until the next
+    gateway boot. Never raises; the scan itself swallows its errors.
     """
     try:
         loop = asyncio.get_running_loop()

--- a/test/test_app_routes.py
+++ b/test/test_app_routes.py
@@ -382,3 +382,85 @@ async def test_ui_file_no_cache_revalidation(tmp_path, monkeypatch):
             headers={"If-Modified-Since": last_modified},
         )
         assert resp304.status == 304
+
+
+# ---------------------------------------------------------------------------
+# Registration must run off the event loop (blocking KIROCREW_HOME filesystem
+# work — manifest reads, skill symlink walks, mcp.json atomic writes — would
+# otherwise freeze the gateway on a stalled mount).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_helper_dispatches_off_loop(monkeypatch):
+    """_register_app_off_loop runs register_app on an executor thread and
+    passes its return value through to the caller."""
+    import threading
+
+    import kiro_crew.apps.routes as routes_mod
+
+    loop_thread = threading.current_thread()
+    seen: dict[str, object] = {}
+    sentinel = SimpleNamespace(ok=True)
+
+    def _spy(name):
+        seen["name"] = name
+        seen["thread"] = threading.current_thread()
+        return sentinel
+
+    monkeypatch.setattr(routes_mod, "register_app", _spy)
+    result = await routes_mod._register_app_off_loop("some-app")
+    assert result is sentinel  # return value reaches the awaiting caller
+    assert seen["name"] == "some-app"
+    assert seen["thread"] is not loop_thread  # executor thread, not the loop
+
+
+@pytest.mark.asyncio
+async def test_deregister_helper_dispatches_off_loop(monkeypatch):
+    """_deregister_app_off_loop runs deregister_app on an executor thread."""
+    import threading
+
+    import kiro_crew.apps.routes as routes_mod
+
+    loop_thread = threading.current_thread()
+    seen: dict[str, object] = {}
+    sentinel = SimpleNamespace(ok=True)
+
+    def _spy(name):
+        seen["name"] = name
+        seen["thread"] = threading.current_thread()
+        return sentinel
+
+    monkeypatch.setattr(routes_mod, "deregister_app", _spy)
+    result = await routes_mod._deregister_app_off_loop("some-app")
+    assert result is sentinel
+    assert seen["name"] == "some-app"
+    assert seen["thread"] is not loop_thread
+
+
+@pytest.mark.asyncio
+async def test_install_route_registers_off_loop(tmp_path, monkeypatch):
+    """The install handler reaches register_app via the executor: the real
+    registration call must not execute on the event-loop thread."""
+    import threading
+
+    import kiro_crew.apps.routes as routes_mod
+
+    _setup_env(tmp_path, monkeypatch)
+    src = _make_app_source(tmp_path)
+    loop_thread = threading.current_thread()
+    seen: dict[str, object] = {}
+    real_register = routes_mod.register_app
+
+    def _spy(name):
+        seen["thread"] = threading.current_thread()
+        return real_register(name)
+
+    monkeypatch.setattr(routes_mod, "register_app", _spy)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post("/api/apps/install", json={"source": str(src)})
+        assert resp.status == 201
+        data = await resp.json()
+        assert data["ok"] is True
+        assert "registration" in data  # helper's return value still surfaces
+    assert seen["thread"] is not loop_thread


### PR DESCRIPTION
## Problem

`register_app()` / `deregister_app()` perform blocking `KIROCREW_HOME` filesystem work — manifest reads, skill-dir symlink walks, agent JSON writes, `mcp.json` read + atomic write — yet the async app route handlers called them **directly on the asyncio event loop** at 11 call sites in `src/kiro_crew/apps/routes.py` (install, update ×5, uninstall, enable ×2, registry install ×2). The neighbouring long operations on the same handlers (`install_app`, `start_app_backend`, `stop_app_backend`) already run through `run_in_executor`.

## Why it matters

If `KIROCREW_HOME` lives on a filesystem that can stall (a dead network mount), one app install/enable/update/uninstall request freezes the entire gateway — every task including the liveness heartbeat blocks until the stall watchdog kills the process, which respawns into the same condition (the `no-blocking-call-on-event-loop` crash-loop class, `blocking: true` in `AUTOSDE.yaml`).

## Fix (symptoms → root cause → change)

Symptom: gateway-wide freeze during app lifecycle operations on a stalled mount. Root cause: synchronous registration bridge functions invoked from async handlers on the loop. Change: add two small helpers in `routes.py` — `_register_app_off_loop` / `_deregister_app_off_loop` — that dispatch through `subprocess_executor()` (the same bounded pool the neighbouring lifecycle offloads use, keeping this wedge-prone work off the maintenance pool that the recovery sweeps need), and route **all 11** call sites through them. Return values pass through unchanged, so every caller that consumes the `RegistrationResult` behaves identically. The issue text names 4 call sites; the structural fix the issue itself calls for covers every on-loop call site in `routes.py`, so all 11 are converted — no bare on-loop `register_app`/`deregister_app` call remains in the file.

Two comments whose rationale depended on the old on-loop behaviour are updated in the same commit: the `schedule_materialized_agents_refresh` docstring in `config/loader.py` (the dashboard path arrives off-loop and takes the inline branch — the "offloaded refresh lands later" stale-snapshot window no longer exists on that path), and the prune-omission NOTE in `apps/bridges.py` (the correct rationale is that route callers deregister first, making a prune redundant — not loop latency).

Other `register_app` callers were checked and are already off-loop or out of the rule's scope: the boot reconcile runs via `run_in_executor` from `dashboard/server.py`, `pptx_maker` provision runs on a worker thread, CLI paths run before the loop starts, and the disable path routes through `teardown.py` which already offloads.

## Tests

Three tests added in `test/test_app_routes.py`:
- `test_register_helper_dispatches_off_loop` — `register_app` executes on an executor thread (not the loop thread), receives the right app name, and its return value reaches the awaiting caller.
- `test_deregister_helper_dispatches_off_loop` — same three properties for `deregister_app`.
- `test_install_route_registers_off_loop` — end-to-end through `POST /api/apps/install`: the real registration call runs off the loop thread and its result still surfaces in the response `registration` field.

Full backend gate run locally: isort, flake8, mypy clean; pytest 47,569 passed with only pre-existing environment failures (verified identical on pristine `origin/main` — sandbox-unavailable and network-dependent tests on this host).

## Manual verification

N/A — unit coverage sufficient: the change is a mechanical dispatch-path move with return-value passthrough locked by tests; no behaviour change on the success/failure paths.

## Known pre-existing property (noted, not changed)

If a client aborts an Enable/Update mid-registration, `CancelledError` releases `app_lifecycle_lock` while the started executor job runs to completion (an executor future cannot be cancelled). This property already holds for the pre-existing `start_app_backend`/`install_app` offloads in the same critical sections; this PR extends the class to registration but does not create it. The boot reconcile heals any half-registered state.

Closes #3075
