### PR TITLE
fix(test): stage summary-cache staleness by pinning mtime, not by racing the clock (#2981)

### DIFF
--- a/test/chat_test_helpers.py
+++ b/test/chat_test_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import AsyncMock, MagicMock
 
 from aiohttp import web
@@ -9,6 +10,21 @@ from aiohttp import web
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.history import ConversationLog
 from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
+
+
+def move_transcript_past(log: ConversationLog, key: str, sig: float) -> None:
+    """Deterministically advance a transcript's mtime past *sig*.
+
+    Two consecutive filesystem writes can land inside one timestamp tick
+    (~15.6 ms on Windows), leaving the second write with an mtime identical
+    to the first -- a staged "transcript moved on" then has not moved on at
+    all, and any staleness assertion keyed on the mtime signature becomes a
+    coin flip (#2981, same class as #2449). Pinning the mtime makes the test
+    exercise the signature COMPARISON rather than the platform's clock
+    resolution (testing-conventions.md § Determinism).
+    """
+    path = log._path(key)
+    os.utime(path, (sig + 1, sig + 1))
 
 
 class _ReadyKiroPrerequisiteService(KiroPrerequisiteService):

--- a/test/test_dashboard_sessions_summarize.py
+++ b/test/test_dashboard_sessions_summarize.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import move_transcript_past
 
 from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_TEXT_CHUNK
 from kiro_crew.dashboard.handlers import api_sessions_summarize
@@ -131,10 +132,9 @@ class TestSessionsSummarizeHandler:
         async with TestClient(TestServer(_make_app(log, "sum", created))) as c:
             await c.post("/api/sessions/summarize", json={"keys": ["alpha"]})
             # New activity in the session — mtime advances, cache is stale.
-            import time as _t
-
-            _t.sleep(0.01)
+            sig = log.session_mtime("alpha")  # what the first call cached against
             log.append("alpha", "user", "a new turn changes the transcript")
+            move_transcript_past(log, "alpha", sig)  # don't rely on the OS tick (#2981)
             await c.post("/api/sessions/summarize", json={"keys": ["alpha"]})
         assert len(created) == 2
 

--- a/test/test_session_summary_api.py
+++ b/test/test_session_summary_api.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
-from chat_test_helpers import _make_state
+from chat_test_helpers import _make_state, move_transcript_past
 
 from kiro_crew.config.loader import KiroCrewConfig, SessionSummaryConfig
 from kiro_crew.dashboard import chat_handlers
@@ -106,8 +106,10 @@ class TestSummaryEndpoint:
         hkey = slot_history_key(slot)
         log = state.conversation_log
         log.append(hkey, "user", "hello")
-        log.set_cached_intent_summary(hkey, _payload(), log.session_mtime(hkey))
+        sig = log.session_mtime(hkey)
+        log.set_cached_intent_summary(hkey, _payload(), sig)
         log.append(hkey, "user", "a newer turn")
+        move_transcript_past(log, hkey, sig)  # don't rely on the OS tick (#2981)
 
         async with TestClient(TestServer(_make_app(state))) as client:
             body = await (await client.get("/api/chat/slots/s1/summary")).json()

--- a/test/test_session_summary_generate.py
+++ b/test/test_session_summary_generate.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from chat_test_helpers import move_transcript_past
 
 from kiro_crew.config.loader import KiroCrewConfig, SessionSummaryConfig
 from kiro_crew.dashboard import chat_summary
@@ -190,11 +191,15 @@ class TestGating:
         state, slot = env
         log = state.conversation_log
         real_read = log.read_messages_chained
+        # Production captures the signature at generation start; the racing
+        # append below must provably land PAST it, not merely after it in time.
+        pre_read_sig = log.session_mtime(state.hkey)
 
         def racing_read(key):
             records = real_read(key)
             # A concurrent turn appends while generation is reading.
             log.append(key, "user", "landed mid-read")
+            move_transcript_past(log, key, pre_read_sig)  # don't rely on the OS tick (#2981)
             return records
 
         monkeypatch.setattr(log, "read_messages_chained", racing_read)
@@ -270,7 +275,10 @@ class TestCaching:
         called = []
         _stub_llm(monkeypatch, _GOOD_REPLY, called)
         await chat_summary.generate_session_summary(state, slot, cfg=_cfg())
-        state.conversation_log.append(state.hkey, "user", "another")
+        log = state.conversation_log
+        sig = log.session_mtime(state.hkey)  # what pass 1 stamped the sidecar with
+        log.append(state.hkey, "user", "another")
+        move_transcript_past(log, state.hkey, sig)  # don't rely on the OS tick (#2981)
         slot._summary_turn_mark = 0
         assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is True
         assert len(called) == 2

--- a/test/test_session_summary_storage.py
+++ b/test/test_session_summary_storage.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from chat_test_helpers import move_transcript_past
 
 from kiro_crew.history import ConversationLog
 
@@ -51,9 +52,11 @@ class TestIntentSummarySidecar:
 
     def test_a_new_message_invalidates_the_cache(self, log):
         log.append("s1", "user", "hello")
-        log.set_cached_intent_summary("s1", _payload(), log.session_mtime("s1"))
+        sig = log.session_mtime("s1")
+        log.set_cached_intent_summary("s1", _payload(), sig)
         assert log.get_cached_intent_summary("s1") is not None
         log.append("s1", "user", "another turn")
+        move_transcript_past(log, "s1", sig)  # don't rely on the OS tick
         assert log.get_cached_intent_summary("s1") is None
 
     def test_a_stale_signature_is_rejected(self, log):
@@ -170,6 +173,7 @@ class TestWriteGuard:
         log.append("s1", "user", "hello")
         sig = log.session_mtime("s1")
         log.append("s1", "user", "a newer turn")  # transcript moved on
+        move_transcript_past(log, "s1", sig)  # don't rely on the OS tick
 
         assert log.set_cached_intent_summary("s1", _payload(), sig) is False
         assert log.get_cached_intent_summary("s1") is None


### PR DESCRIPTION
# Problem

`test/test_session_summary_storage.py::TestWriteGuard::test_an_append_during_generation_refuses_the_stale_payload` fails intermittently on Windows CI shards with `AssertionError: assert True is False`, while Linux shards of the same run pass. The reporter showed fail → pass → fail across heads including a pure rebase with an identical tree, establishing nondeterminism rather than a branch defect.

# Why it matters

A flaky required check costs every PR author a re-run round and erodes trust in red: a genuine regression in the session-summary write guard could hide behind "that test is just flaky on Windows." The same latent premise sat in four more tests (found during the sibling audit and local review), so the class would keep resurfacing after any single-site patch.

# Fix (symptoms -> root cause -> change)

**Symptom:** the guard returned True (wrote the payload) where the test expects False (refused).

**Root cause — in the test, not the guard.** `set_cached_intent_summary` refuses a write when the transcript's mtime no longer equals the signature captured at generation start (`src/kiro_crew/history.py:1810`). The test staged "the transcript moved on" with a second `log.append(...)`, relying on the OS to stamp that write with a *different* mtime. Windows file timestamps advance in ~15.6 ms ticks, so both appends can land inside one tick: the mtime is byte-identical, `sig` still matches, and the guard — correctly, per its own logic — writes. Only tick alignment differed across the reporter's identical-tree heads.

**Change — make the staged staleness deterministic.** A shared helper `move_transcript_past(log, key, sig)` (in `test/chat_test_helpers.py`) pins the transcript mtime to `sig + 1` via `os.utime`, so each test exercises the guard's *comparison* instead of the platform's clock resolution — per `docs/system-specs/common/testing-conventions.md` § Determinism, and mirroring the shape of PR #2505 (issue #2449, same Windows-tick class). Five sites carried the clock-dependent premise and all are pinned: the flaky guard test and `test_a_new_message_invalidates_the_cache` (`test_session_summary_storage.py`), `test_a_stale_summary_is_served_and_flagged` (`test_session_summary_api.py`), `test_a_new_message_makes_it_regenerate` and `test_an_append_during_the_transcript_read_refuses_the_write` (`test_session_summary_generate.py`), and `test_cache_invalidated_when_session_changes` (`test_dashboard_sessions_summarize.py` — which also loses its sub-tick `time.sleep(0.01)`, itself below the 15.6 ms tick and a standing violation of the no-sleep flake convention). No assertion was relaxed, no skip/xfail/rerun added, no sleep inserted. The helper's docstring names the platform constraint so a later author does not "simplify" the staging back into two bare appends.

**Production-guard scope judgement (assessed per the issue, deliberately not changed here).** The same granularity means that in production on Windows, an append landing in the same tick as the signature capture would not be noticed by the guard, which would then store a genuinely stale summary as fresh. This is *reachable* but narrow: `generate_session_summary` captures `sig`, then reads the full transcript, then awaits a model call taking seconds — the vulnerable window is only an append racing the initial capture into one 15.6 ms tick, and the consequence is a summary stale by exactly that one message, corrected on the next pass (the turn mark is not advanced on refusal, and any later append invalidates the cache). A robust remedy is not small-and-local: adding a discriminator (file size or a write counter) to the signature changes the persisted sidecar schema and the signature contract shared by `get_cached_intent_summary`, `read_intent_summary`, `get_cached_summary`/`set_cached_summary`, and the sessions API handler — a design change across ~6 comparison sites and two sidecar formats. Left for a maintainer decision rather than smuggled into a test-flake fix.

# Tests

- All five pinned tests continue to pass and now do so deterministically on any timestamp granularity.
- Non-vacuity proven by mutation: neutering the guard's `!= sig` comparison makes `test_an_append_during_generation_refuses_the_stale_payload` and `test_an_append_during_the_transcript_read_refuses_the_write` fail with exactly the reported flake signature (`assert True is False`); restoring it makes them pass. The tests still test the guard.
- Sibling audit: the delete-mid-generation test and `test_a_successful_write_reports_true` were checked and are inherently deterministic (deleted file → `None != sig`; no intervening write), so they are unchanged.

# Manual verification

N/A — unit coverage sufficient: the flake mechanism (mtime tick collision) is fully reproduced by the mutation probe, and the fix is test-only.

# Screenshots

N/A — test-only change, no user-visible surface.

Closes #2981
