### PR TITLE
refactor: centralize bundled-interpreter detection (#3017)

### DIFF
--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -123,6 +123,15 @@ x64 gate doubles as proof the bundle runs under Rosetta. In
 intentional there), and `extraResources` ships the `backend-dist/` directory
 wholesale so single- and dual-backend layouts both package.
 
+> **Renaming `backend-dist/` is load-bearing at runtime.** The backend detects
+> "am I the bundled interpreter?" via
+> `platform_compat.is_bundled_interpreter()`
+> (`BUNDLED_BACKEND_DIST_DIRNAME`), which is what stops `pip` from writing
+> into the signed bundle during app builds. `test/test_platform_compat.py`
+> pins that constant to both `extraResources` here and
+> `packaging/build-desktop.sh`, so a rename fails a test — update the constant
+> and the packaging layer in the same change.
+
 **Trade-off:** the DMG carries two full Python backend trees, so it is
 roughly **2× the size** of a per-arch DMG — expect ~350–400 MB. That is the
 price of one artifact + one update feed; a per-arch feed split was

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -2802,8 +2802,11 @@ async def _run_app_build(
         # soft-skip: a Python app that declares a build step needs its packages
         # importable by the gateway, and skipping the install while reporting
         # success would recreate exactly the silent-broken-install shape this
-        # function is written to prevent.
-        if "backend-dist" in Path(sys.executable).resolve().parts:
+        # function is written to prevent. Detection lives in
+        # platform_compat.is_bundled_interpreter() — the single owner of the
+        # packaging-layout sentinel — so a bundler rename breaks its pinned test
+        # instead of silently un-matching an inline check here.
+        if platform_compat.is_bundled_interpreter():
             return {
                 "ok": False,
                 "name": app_name,

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -75,6 +75,35 @@ _SUBPROCESS_NO_WINDOW: int = getattr(subprocess, "CREATE_NO_WINDOW", 0)
 # child tree taskkill /T-reapable. Add DETACHED_PROCESS to the flags for a
 # fully detached, console-less child (e.g. the gateway respawn).
 
+# ── Desktop-app bundled interpreter detection ──
+#: Directory name the desktop build stages the bundled python-build-standalone
+#: runtime under (``Resources/backend-dist/…`` inside the app bundle). The
+#: authoritative spellings live in the packaging layer — electron-builder's
+#: ``extraResources`` mapping in ``website/electron/package.json`` and the
+#: staging steps in ``packaging/build-desktop.sh`` — and this constant MUST
+#: match them: ``test_platform_compat.py`` pins the two together so a packaging
+#: rename breaks a test instead of a runtime guarantee.
+BUNDLED_BACKEND_DIST_DIRNAME: str = "backend-dist"
+
+
+def is_bundled_interpreter() -> bool:
+    """Return True when this process runs on the desktop app's bundled interpreter.
+
+    Contract: the desktop build ships a python-build-standalone runtime inside
+    the application bundle, always under a ``backend-dist`` path component
+    (see :data:`BUNDLED_BACKEND_DIST_DIRNAME`). On macOS that bundle is
+    code-signed, so anything that would write into the interpreter's tree —
+    most notably ``pip install`` into its site-packages — invalidates the
+    signature and breaks subsequent launches/updates, and the write is
+    discarded on every app update anyway. Callers use this predicate to refuse
+    such writes loudly.
+
+    This is the ONE place the packaging layout's directory name is interpreted
+    at runtime; never re-inline the sentinel at a call site.
+    """
+    return BUNDLED_BACKEND_DIST_DIRNAME in Path(sys.executable).resolve().parts
+
+
 # ── macOS TCC-protected home subdirectories ──
 # macOS gates these home subdirectories behind TCC (Transparency, Consent and
 # Control). The FIRST read of any one of them by a given app triggers a modal

--- a/test/test_apps_registry_coverage.py
+++ b/test/test_apps_registry_coverage.py
@@ -1645,6 +1645,10 @@ class TestRunAppBuild:
         next launch/update. Reporting a skipped build as ok would recreate the
         silent-broken-install failure this function exists to prevent, so the
         build fails with an explicit error instead.
+
+        Detection routes through ``platform_compat.is_bundled_interpreter()``;
+        the tests in ``test_platform_compat.py`` pin its sentinel to the
+        packaging layer so a bundler rename cannot silently un-match this guard.
         """
         (tmp_path / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
         bundled = tmp_path / "App.app" / "Contents" / "Resources" / "backend-dist"

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -12,6 +12,7 @@ output we can assert directly), and the process-helper return contracts.
 from __future__ import annotations
 
 import errno
+import json
 import logging
 import os
 import shutil
@@ -21,6 +22,7 @@ import sys
 import tempfile
 import time
 import types
+from pathlib import Path
 
 import pytest
 
@@ -2723,3 +2725,74 @@ def test_an_absent_tool_reports_no_unpinned_path(tmp_path, monkeypatch):
     monkeypatch.setenv("PATH", str(tmp_path))
 
     assert pc.tool_outside_trusted_dirs("definitely-not-a-system-tool") is None
+
+
+# ── Desktop bundled-interpreter detection ──
+
+_REPO_ROOT = Path(__file__).parent.parent
+
+
+class TestIsBundledInterpreter:
+    """``is_bundled_interpreter`` is the single runtime owner of the desktop
+    packaging-layout sentinel; these tests pin both its behavior and its
+    agreement with the packaging layer, so a bundler directory rename breaks a
+    test here instead of silently un-matching the runtime guard (which would
+    let pip write into the signed macOS bundle)."""
+
+    def test_bundled_interpreter_path_is_detected(self, tmp_path, monkeypatch):
+        """The real desktop layout — a python-build-standalone runtime under
+        ``Resources/backend-dist/`` — must be recognized. The literal directory
+        name is deliberate here: the test pins the real-world layout, not the
+        constant (asserting via the constant would be tautological)."""
+        bundled = (
+            tmp_path
+            / "App.app"
+            / "Contents"
+            / "Resources"
+            / "backend-dist"
+            / "kirocrew-backend-arm64"
+            / "bin"
+            / "python3.12"
+        )
+        monkeypatch.setattr(pc.sys, "executable", str(bundled))
+        assert pc.is_bundled_interpreter() is True
+
+    def test_regular_interpreter_path_is_not_detected(self, tmp_path, monkeypatch):
+        """An ordinary venv interpreter must not trip the guard — a false
+        positive would refuse every Python app build on normal installs."""
+        regular = tmp_path / "gateway-venv" / "bin" / "python3.12"
+        monkeypatch.setattr(pc.sys, "executable", str(regular))
+        assert pc.is_bundled_interpreter() is False
+
+    def test_sentinel_matches_electron_builder_packaging_layout(self):
+        """Pin the constant to electron-builder's ``extraResources`` target so
+        a packaging rename fails HERE, not at runtime inside a signed bundle."""
+        pkg_json = _REPO_ROOT / "website" / "electron" / "package.json"
+        pkg = json.loads(pkg_json.read_text(encoding="utf-8"))
+        targets = {
+            res["to"]
+            for res in pkg["build"]["extraResources"]
+            if isinstance(res, dict) and "to" in res
+        }
+        assert pc.BUNDLED_BACKEND_DIST_DIRNAME in targets, (
+            "platform_compat.BUNDLED_BACKEND_DIST_DIRNAME no longer matches the "
+            "electron-builder extraResources target in website/electron/package.json. "
+            "If the desktop packaging directory was renamed, update the constant "
+            "(and this test) in the same change — otherwise the bundled-interpreter "
+            "guard silently stops matching and pip can write into the signed bundle."
+        )
+
+    def test_sentinel_matches_desktop_build_script_staging_dir(self):
+        """Same pin against the build script that stages the runtime trees.
+
+        Asserts the directory NAME as a path component — not any exact
+        shell-quoted expression — so a script refactor that introduces a
+        variable for the staging path does not false-positive this pin."""
+        script = (_REPO_ROOT / "packaging" / "build-desktop.sh").read_text(encoding="utf-8")
+        needle = f"/{pc.BUNDLED_BACKEND_DIST_DIRNAME}"
+        assert needle in script, (
+            "packaging/build-desktop.sh no longer stages anything under a "
+            f"'{pc.BUNDLED_BACKEND_DIST_DIRNAME}' directory — keep "
+            "platform_compat.BUNDLED_BACKEND_DIST_DIRNAME in sync with the "
+            "packaging layer (see is_bundled_interpreter)."
+        )


### PR DESCRIPTION
## Problem

`_run_app_build` in `src/kiro_crew/apps/registry.py` detects the desktop app's bundled interpreter with an inline sentinel:

```python
if "backend-dist" in Path(sys.executable).resolve().parts:
```

This couples the registry to the desktop packaging layout (`Resources/backend-dist/…`). If the bundler ever renames that directory, the check silently stops matching.

## Why it matters

The check is what stops `pip install` from writing into the desktop app's signed bundle. On macOS a write into the bundled interpreter's site-packages invalidates the code signature and breaks subsequent launches/updates. A silent un-match after a packaging rename would re-open exactly that failure — and the existing regression test (`test_desktop_bundled_interpreter_never_runs_pip`) pins the behavior for `backend-dist`-shaped paths but cannot detect a layout rename.

## Fix (symptoms → root cause → change)

Root cause: the packaging-layout sentinel was interpreted at a call site instead of being owned once next to the other platform/layout knowledge.

- Add `platform_compat.is_bundled_interpreter()` with a `BUNDLED_BACKEND_DIST_DIRNAME` constant and a docstring stating the contract (single runtime owner of the sentinel; never re-inline at call sites).
- `registry.py` now calls the helper; the loud-failure semantics are unchanged.
- Pin the constant to the packaging layer in tests, so a rename breaks a test instead of a runtime guarantee:
  - one test asserts it matches electron-builder's `extraResources` target in `website/electron/package.json`;
  - one asserts the directory name appears as a path component in `packaging/build-desktop.sh` (name, not an exact shell expression, so a script-variable refactor can't false-positive).
- `docs/build/desktop-app.md` notes the coupling next to the layout description.

## Tests

- `test/test_platform_compat.py::TestIsBundledInterpreter` (4 new): bundled desktop layout detected; ordinary venv path not detected; sentinel pinned to `extraResources`; sentinel pinned to `build-desktop.sh`.
- `test/test_apps_registry_coverage.py::test_desktop_bundled_interpreter_never_runs_pip` still pins the end-to-end registry refusal (docstring updated to reference the shared helper).
- Local gates: isort / flake8 / mypy clean; full backend suite run — 47,553 passed; the 113 failures reproduce identically on a clean `origin/main` checkout on this host (sandbox backend unavailable, broken `jq`, process-probe limits) and are unrelated to this change.

## Manual verification

N/A — unit coverage sufficient: the change is a pure refactor of a predicate plus test/doc pins; both detection branches and both packaging pins are exercised directly.

## Screenshots

N/A — no UI change.

Closes #3017
