### PR TITLE
ci(security): add OWASP top-ten ruleset to Semgrep scan

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -266,6 +266,7 @@ jobs:
             --config p/typescript \
             --config p/security-audit \
             --config p/secrets \
+            --config p/owasp-top-ten \
             --baseline-commit "$SEMGREP_BASELINE_REF" \
             --error
 


### PR DESCRIPTION
## Summary

Add `p/owasp-top-ten` to the Semgrep SAST scan, extending coverage to OWASP A01-A10 vulnerability patterns.

## Changes

One-line addition to `.github/workflows/code-review.yml`:

```yaml
--config p/owasp-top-ten \
```

This adds detection for:
- A01: Broken Access Control
- A02: Cryptographic Failures
- A03: Injection (SQL, command, SSRF, path traversal)
- A04: Insecure Design
- A05: Security Misconfiguration
- A07: Authentication Failures
- A08: Software and Data Integrity Failures (deserialization)
- A09: Security Logging and Monitoring Failures
- A10: Server-Side Request Forgery

## Scope

This PR only adds the community-maintained OWASP ruleset. Custom project-specific rules (`.semgrep/`) will follow in a separate validated PR after dry-running against the full codebase to avoid false positives.

## Risk

Zero — `p/owasp-top-ten` is a curated, actively-maintained Semgrep registry ruleset. The scan is diff-only (`--baseline-commit`), so only new code in future PRs is evaluated.
