### PR TITLE
fix(md-notebook): cancel autosave timer on unmount

### DIFF
--- a/website/src/apps/md-notebook/MdNotebookPage.tsx
+++ b/website/src/apps/md-notebook/MdNotebookPage.tsx
@@ -454,6 +454,17 @@ export default function MdNotebookPage() {
   const [lastSyncByVault, setLastSyncByVault] = useState<Record<string, number>>({})
 
   const saveTimer = useRef<number | null>(null)
+  /**
+   * Requests the unmount flush must wait for before it writes.
+   *
+   * Not just saves. The flush targets `pathRef`, so anything that RETARGETS
+   * `pathRef` has to finish first: between a move's request and its reply the
+   * open note's path names a file the server has already moved away, and a write
+   * sent there is lost to a swallowed `ESTALE`. Entries are registered through
+   * their retarget, not merely around the request, because it is the retarget --
+   * not the response -- that makes the wait sufficient.
+   */
+  const writesInFlightRef = useRef(new Set<Promise<void>>())
   const contentRef = useRef('')
   const pathRef = useRef<string | null>(null)
   const vaultRef = useRef(activeVaultId)
@@ -476,6 +487,21 @@ export default function MdNotebookPage() {
     () => targetsSameNote(deletingRef.current, vaultRef.current, pathRef.current),
     [],
   )
+  /**
+   * Register a request the unmount flush must wait for; the returned function
+   * releases it. Callers hold it across the retarget, not just the request.
+   */
+  const trackWrite = useCallback(() => {
+    let release!: () => void
+    const entry = new Promise<void>(resolve => {
+      release = resolve
+    })
+    writesInFlightRef.current.add(entry)
+    return () => {
+      release()
+      writesInFlightRef.current.delete(entry)
+    }
+  }, [])
   useEffect(() => {
     dirtyRef.current = dirty
   }, [dirty])
@@ -493,6 +519,90 @@ export default function MdNotebookPage() {
     window.addEventListener('beforeunload', onBeforeUnload)
     return () => window.removeEventListener('beforeunload', onBeforeUnload)
   }, [])
+
+  // A pending edit is SENT on unmount, not cancelled. In-app navigation tears
+  // this page down without firing `beforeunload`, so inside the debounce window
+  // that timer is the only thing that would ever have persisted what the user
+  // just typed — cancelling it would trade a leaked timer for silent data loss.
+  // Same call the `minsTimer` teardown above makes for the auto-sync interval,
+  // for the same reason.
+  useEffect(
+    () => () => {
+      // `dirtyRef` is part of the gate, not just the write below. A save that
+      // FAILED clears the debounce on entry and releases its tracking on the way
+      // out, yet leaves the buffer dirty and re-arms nothing — only a keystroke
+      // arms the debounce. Gating on the timer and the tracked set alone would
+      // send that edit nowhere on the next navigation, which is the loss this
+      // effect exists to prevent.
+      if (!saveTimer.current && !writesInFlightRef.current.size && !dirtyRef.current) return
+
+      if (saveTimer.current) {
+        window.clearTimeout(saveTimer.current)
+        saveTimer.current = null
+      }
+
+      // Wait for the tracked requests before writing, for two different reasons.
+      // An autosave may already be retrying newer buffer snapshots, so the write
+      // needs the mtime that save produced: sending alongside its last attempt
+      // would carry a superseded mtime, come back ESTALE, and lose the edit — the
+      // exact outcome this effect exists to prevent. A move has to finish for an
+      // unrelated reason: it is what retargets `pathRef` onto the note's new
+      // path, and writing before that lands sends the edit to the path the move
+      // is vacating.
+      //
+      // The wait is bounded by the requests it waits on and holds no timer,
+      // listener or interval, only a promise closure, so unlike the debounce
+      // cancelled above it cannot run component logic at an arbitrary later time.
+      //
+      // `flushSave` is deliberately NOT reused here, and not because of its state
+      // setters — React 18 makes a post-unmount setState a silent no-op. The
+      // reason is that it reads LIVE refs: its retry loop re-reads
+      // `contentRef.current` on every attempt, and after unmount a move's own
+      // continuation reopens the note at its new path and repoints `contentRef`
+      // at DISK content. Reusing it would let that loop send the disk bytes back
+      // and clear the dirty flag against them, dropping the edit this effect
+      // exists to save. It also mutates `mtimeRef` and `saveTimer`, which a
+      // still-running `relocate` reads after this component is gone.
+      const activeWrites = [...writesInFlightRef.current]
+      // The buffer is snapshotted HERE, before the wait. No keystroke can arrive
+      // after unmount, and a request settling during the wait can repoint
+      // `contentRef` at disk content — a move reopens the note at its new path —
+      // which would write the file back unchanged and drop the edit.
+      const pendingContent = contentRef.current
+      const saveDirtySnapshot = async () => {
+        const vault = vaultRef.current
+        // The path is read AFTER the wait, so a completed move contributes its
+        // NEW path. `dirtyRef` is read live for the same reason: an in-flight
+        // save that succeeded during the wait already persisted this buffer.
+        const path = pathRef.current
+        // Read the delete state AFTER the wait above, because a delete can be
+        // confirmed while that save is still in flight.
+        //
+        // This is DEFENSE IN DEPTH, not a live hazard: reaching it needs a dirty
+        // buffer whose own note has a DELETE in flight, and three separate
+        // invariants currently make that state unreachable. `removeNote` flushes
+        // a pending edit and returns if it is still dirty BEFORE it arms
+        // `deletingRef`, and `edit` and `markDirty` — the only two sites that set
+        // the flag — both refuse while `openNoteIsDeleting()`. The check is here
+        // anyway because this write bypasses `flushSave`, and with it the ESTALE
+        // branch that recognises the backend's refusal to resurrect a deleted
+        // note; the callers below swallow that rejection, so without this the
+        // teardown write's safety would rest entirely on three invariants held
+        // in two other functions. Keeping it local means a later change to
+        // `removeNote`'s flush ordering cannot quietly turn this into a recreate.
+        if (targetsSameNote(deletingRef.current, vault, path)) return
+        if (vault && path && dirtyRef.current) {
+          await notesApi.saveNote(vault, path, pendingContent, mtimeRef.current ?? undefined)
+        }
+      }
+      if (activeWrites.length) {
+        void Promise.all(activeWrites).then(saveDirtySnapshot).catch(() => undefined)
+      } else {
+        void saveDirtySnapshot().catch(() => undefined)
+      }
+    },
+    [],
+  )
 
   // Re-render every 30s so the "5m ago" label ages without interaction.
   const [, setTick] = useState(0)
@@ -632,6 +742,7 @@ export default function MdNotebookPage() {
     // and the banner offers "Use the file on disk" against the NEW vault's buffer.
     const savingPath = pathRef.current
     const saving = { vault: vaultRef.current, path: savingPath }
+    const doneSave = trackWrite()
     try {
       // Save until what landed matches what the editor holds. `contentRef` can
       // move while the request is in flight, and the debounce timer was
@@ -677,8 +788,10 @@ export default function MdNotebookPage() {
       } else {
         setError(e instanceof Error ? e.message : String(e))
       }
+    } finally {
+      doneSave()
     }
-  }, [])
+  }, [trackWrite])
 
   const openNote = useCallback(async (path: string) => {
     if (!vaultRef.current) return
@@ -996,13 +1109,23 @@ export default function MdNotebookPage() {
         // now would retarget it to `to` without ever reconciling that content,
         // so a later save could overwrite the moved file from a stale base.
         if (pathRef.current === from && dirtyRef.current) return
-        await notesApi.moveNote(vault, from, to)
-        repointPin(vault, from, to)
-        if (vaultRef.current !== vault) return
-        if (pathRef.current === from) {
-          pathRef.current = to
-          setActivePath(to)
-          savePref(LS.openNote, to)
+        // Tracked THROUGH the retarget below, not just around the request. The
+        // unmount flush writes against `pathRef`, and until that assignment lands
+        // `pathRef` still names the path this move is vacating -- a flush that ran
+        // in the gap would send the edit to a file the server has already moved,
+        // and the swallowed ESTALE would lose it.
+        const doneMove = trackWrite()
+        try {
+          await notesApi.moveNote(vault, from, to)
+          repointPin(vault, from, to)
+          if (vaultRef.current !== vault) return
+          if (pathRef.current === from) {
+            pathRef.current = to
+            setActivePath(to)
+            savePref(LS.openNote, to)
+          }
+        } finally {
+          doneMove()
         }
         await loadNotes()
         if (pathRef.current === to) await openNote(to)
@@ -1010,7 +1133,7 @@ export default function MdNotebookPage() {
         setError(e instanceof Error ? e.message : String(e))
       }
     },
-    [flushSave, loadNotes, openNote, repointPin],
+    [flushSave, loadNotes, openNote, repointPin, trackWrite],
   )
 
   /** File a note into `folder` ('' = vault root), keeping its filename. */

--- a/website/src/test/MdNotebookPageCoverage.test.tsx
+++ b/website/src/test/MdNotebookPageCoverage.test.tsx
@@ -963,6 +963,144 @@ describe('MdNotebookPage — settings, guarded mutations and editor keys', () =>
     expect(dirty.defaultPrevented).toBe(true)
   })
 
+  it('flushes a pending autosave once when the page unmounts', async () => {
+    const view = await mountOnFakeTimersWithNote()
+    fireEvent.click(screen.getByRole('button', { name: 'Markdown source' }))
+    fireEvent.change(rawEditor(), { target: { value: 'unsaved work' } })
+
+    view.unmount()
+    expect(api.saveNote).toHaveBeenCalledWith('v1', 'One.md', 'unsaved work', 4)
+    expect(api.saveNote).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS)
+    })
+
+    // The cancelled debounce must not fire a second, post-unmount save.
+    expect(api.saveNote).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for an active autosave before flushing the final edit on unmount', async () => {
+    const first = deferred<{ ok: boolean; mtime: number }>()
+    const second = deferred<{ ok: boolean; mtime: number }>()
+    const third = deferred<{ ok: boolean; mtime: number }>()
+    api.saveNote
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise)
+      .mockImplementationOnce(() => third.promise)
+
+    const view = await mountOnFakeTimersWithNote()
+    fireEvent.click(screen.getByRole('button', { name: 'Markdown source' }))
+    fireEvent.change(rawEditor(), { target: { value: 'first edit' } })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS)
+    })
+
+    fireEvent.change(rawEditor(), { target: { value: 'second edit' } })
+    await act(async () => first.settle({ ok: true, mtime: 5 }))
+    expect(api.saveNote).toHaveBeenNthCalledWith(2, 'v1', 'One.md', 'second edit', 5)
+
+    fireEvent.change(rawEditor(), { target: { value: 'third edit' } })
+    await act(async () => second.settle({ ok: true, mtime: 6 }))
+    expect(api.saveNote).toHaveBeenNthCalledWith(3, 'v1', 'One.md', 'third edit', 6)
+
+    // Change the buffer during the final bounded retry. Teardown must not race
+    // that request with the old mtime; it waits, then saves the latest snapshot.
+    fireEvent.change(rawEditor(), { target: { value: 'final edit' } })
+    view.unmount()
+    expect(api.saveNote).toHaveBeenCalledTimes(3)
+
+    await act(async () => third.settle({ ok: true, mtime: 7 }))
+    expect(api.saveNote).toHaveBeenNthCalledWith(4, 'v1', 'One.md', 'final edit', 7)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS)
+    })
+    expect(api.saveNote).toHaveBeenCalledTimes(4)
+  })
+
+  it('cannot dirty a note whose delete is in flight, so unmount has nothing to resurrect', async () => {
+    // What keeps the unmount flush from writing a note back to disk after the
+    // user deleted it. The flush itself carries a `targetsSameNote` guard, but
+    // the reason that guard is unreachable is THIS invariant, so it is the one
+    // worth pinning: `edit` refuses while the open note's delete is in flight,
+    // so no content is committed and no debounce is ever armed to flush.
+    const del = deferred<{ ok: boolean }>()
+    api.deleteNote.mockImplementationOnce(() => del.promise)
+
+    const view = await mountWithNote()
+    await userEvent.click(screen.getByRole('button', { name: 'Markdown source' }))
+    // Delete the OPEN note and hold the request open, so the editor stays
+    // mounted for the round trip with `deletingRef` armed.
+    await confirmDelete('One')
+    expect(api.deleteNote).toHaveBeenCalledTimes(1)
+
+    fireEvent.change(rawEditor(), { target: { value: 'typed during the delete' } })
+    expect(api.saveNote).not.toHaveBeenCalled()
+
+    // Unmount inside what would have been the debounce window.
+    view.unmount()
+    expect(api.saveNote).not.toHaveBeenCalled()
+
+    await act(async () => del.settle({ ok: true }))
+  })
+
+  it('flushes on unmount after a failed save left the buffer dirty', async () => {
+    // A failed save is the one state with no timer and nothing tracked but an
+    // unpersisted edit: `flushSave` clears the debounce on entry and releases its
+    // tracking in `finally`, and only a keystroke re-arms the debounce. Teardown
+    // still has to write, or navigating away after a transient failure loses the
+    // edit exactly as the leaked timer used to.
+    const view = await mountOnFakeTimersWithNote()
+    fireEvent.click(screen.getByRole('button', { name: 'Markdown source' }))
+    fireEvent.change(rawEditor(), { target: { value: 'survives a failed save' } })
+
+    api.saveNote.mockRejectedValueOnce(new Error('no space left on device'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS)
+    })
+    expect(api.saveNote).toHaveBeenCalledTimes(1)
+
+    view.unmount()
+    expect(api.saveNote).toHaveBeenNthCalledWith(2, 'v1', 'One.md', 'survives a failed save', 4)
+  })
+
+  it('waits for an in-flight move before flushing, so the edit lands on the new path', async () => {
+    // A move retargets `pathRef` only when its response comes back, so between
+    // request and reply the open note's path names a file the server has already
+    // moved away. Writing there on unmount would send the edit to the old path
+    // and lose it to a swallowed ESTALE, so teardown has to wait for the move
+    // the same way it waits for an in-flight save.
+    const move = deferred<{ ok: boolean; path: string }>()
+    api.moveNote.mockImplementationOnce(() => move.promise)
+
+    const view = await mountWithNote()
+    await userEvent.click(screen.getByRole('button', { name: 'Markdown source' }))
+    rowAction('One', 'Rename note')
+    const field = await screen.findByRole('textbox', { name: 'Note name' })
+    await userEvent.clear(field)
+    await userEvent.type(field, 'Renamed{Enter}')
+    await waitFor(() => expect(api.moveNote).toHaveBeenCalledWith('v1', 'One.md', 'Renamed.md'))
+
+    // Type while the move is still in flight: `pathRef` still says One.md.
+    fireEvent.change(rawEditor(), { target: { value: 'typed during the move' } })
+    view.unmount()
+    // Nothing may be written to the path the move is vacating.
+    expect(api.saveNote).not.toHaveBeenCalled()
+
+    await act(async () => move.settle({ ok: true, path: 'Renamed.md' }))
+    // Once the move retargets `pathRef`, the edit goes to the NEW path. Both
+    // writes below target it: the flush, and then the move's own reopen, which
+    // goes through `openNote` and flushes the outgoing note first. That second
+    // write is relocate's pre-existing behaviour, not something teardown adds --
+    // it carries the same bytes to the same path and the backend refuses it on
+    // mtime. What matters, and what regressed before this fix, is that NEITHER
+    // of them is addressed to the path the move vacated.
+    expect(api.saveNote).toHaveBeenCalledWith('v1', 'Renamed.md', 'typed during the move', 4)
+    expect(api.saveNote).toHaveBeenCalledTimes(2)
+    expect(api.saveNote.mock.calls.every(c => c[1] === 'Renamed.md')).toBe(true)
+  })
+
   // ── panel ─────────────────────────────────────────────────────────────────
 
   it('drags the notes panel wider and remembers the width', async () => {
@@ -1085,12 +1223,16 @@ describe('MdNotebookPage — settings, guarded mutations and editor keys', () =>
 
     // The alert's presence IS the proof the Sync path consumed the rejection:
     // had the debounced autosave consumed it instead, runSync's setError(null)
-    // would have erased the banner before this query could see it. A saveNote
-    // call-count assertion would NOT be a stronger pin — earlier tests in this
-    // file leave real 1000ms debounce timers running past their own teardown,
-    // and one landing here inflates the shared mock's count nondeterministically.
+    // would have erased the banner before this query could see it.
     const alert = await screen.findByRole('alert', { timeout: 5_000 })
     expect(alert.textContent).toContain('no space left on device')
+    // And now the count, which #2964 could not assert: earlier tests in this
+    // file left real 1000ms debounce timers running past their own teardown, and
+    // one landing here inflated the shared mock nondeterministically. The page
+    // cancels that timer on unmount now, so exactly one save reached the mock —
+    // a stronger pin than the alert alone, because it rules out a second call
+    // having consumed the single staged rejection.
+    expect(api.saveNote).toHaveBeenCalledTimes(1)
   })
 
   it('reopens the open note when the change poll reports it was modified', async () => {


### PR DESCRIPTION
## Problem / Motivation

`MdNotebookPage` arms a 1000ms autosave debounce on every keystroke and never clears it when the page unmounts. The callback outlives the component and fires about a second later against a page that is gone.

In the test suite that lands inside whichever test is running by then, hitting the file-shared `api.saveNote` mock. #2964 proved it with a stack capture showing the second `saveNote` arriving via `listOnTimeout` from a prior test's unmounted component, and had to drop an otherwise useful call-count assertion because of it.

## Why it matters

The user-facing stake is the opposite of what the leak looks like. Leaving Notes by in-app navigation does not fire `beforeunload`, so inside that 1s window the pending timer is the ONLY thing that would ever have written the edit to disk. The bug is not that a stale write happens -- the write carries the newest buffer -- it is that a correct write is riding on an uncancelled timer, and the obvious "fix" of clearing it would silently lose whatever the user typed in the last second before navigating away.

For the suite the cost is concrete: a real cross-test race, and an assertion the project wanted but could not keep.

## What changed (motivation -> approach -> change)

Observed symptom: a `saveNote` call appears in a test that never made one.

Root cause: the `window.setTimeout` armed in `edit` outlives the component, because no teardown effect clears it.

Why the obvious change is wrong: cancelling alone is not sufficient, because that timer is load-bearing for in-app navigation. This file had already answered the same question once -- the `minsTimer` teardown effect clears its timer and then SENDS the pending auto-sync interval, with a comment saying a value the user watched land in the field must not be silently discarded.

The change does the same for the editor buffer, in one teardown effect:

- Clears the debounce, removing the leak.
- Runs whenever the buffer is dirty, not only when a timer or a tracked request exists. A FAILED save is the state that needs this: `flushSave` clears the debounce on entry and releases its tracking in `finally`, but leaves the buffer dirty and re-arms nothing, since only a keystroke arms the debounce.
- Sends the pending edit rather than dropping it, preserving the only path that saved it.
- When an autosave is already in flight, waits for it to settle first so the write carries the `mtime` that save produced. Sending alongside its last retry would carry a superseded `mtime`, come back `ESTALE`, and lose the edit -- the outcome the effect exists to prevent. That wait is bounded by the retry loop it waits on (at most 3 sequential `saveNote` calls) and holds no timer, listener or interval, only a promise closure, so unlike the debounce it replaces it cannot run component logic at an arbitrary later time.
- Waits for an in-flight MOVE for a different reason than a save: a move is what retargets `pathRef` onto the note's new path, so writing before it lands addresses the path the move is vacating and the edit is lost to a swallowed `ESTALE`. Registered through the retarget, not merely around the request, because it is the retarget that makes the wait sufficient.
- Snapshots the buffer at unmount rather than reading it after the wait. No keystroke can arrive once the page is gone, and a request settling during the wait can repoint `contentRef` at disk content -- a move reopens the note at its new path -- which would write the file back unchanged and drop the edit.
- Does not reuse `flushSave`, and not because of its state setters: React 18 makes a post-unmount `setState` a silent no-op. The reason is that `flushSave` re-reads `contentRef.current` live on every retry attempt, so it is exactly the path that would send those disk bytes back and clear the dirty flag against them. It also mutates `mtimeRef` and `saveTimer` that a still-running `relocate` reads.
- Re-checks `targetsSameNote(deletingRef.current, ...)` before writing. This is defense in depth, not a live hazard, and the code comment says so: `removeNote` flushes and bails while still dirty BEFORE it arms `deletingRef`, and `edit` and `markDirty` -- the only two sites that set the dirty flag -- both refuse while a delete is in flight, so the state is unreachable today. It is kept local because this write bypasses `flushSave`, and with it the `ESTALE` branch that recognises the backend refusing to resurrect a deleted note; the callers swallow that rejection, so without the check this write's safety would rest entirely on three invariants held in two other functions.

## Tests

Three tests in `MdNotebookPageCoverage.test.tsx`:

- The pending edit is written exactly once on unmount, and the cancelled debounce does not fire a second time.
- Three deferred saves driven by hand prove teardown waits for the in-flight retry and then writes the final snapshot with the fresh `mtime`.
- With a delete held open on the open note, typing commits nothing and arms nothing, so unmount has nothing to resurrect. This pins the invariant that makes the delete guard unreachable, rather than asserting the unreachable state itself.
- With a rename held open on the open note, typing and then unmounting writes nothing to the path being vacated, and once the move settles the edit lands on the new path.
- After a save fails and leaves the buffer dirty, unmount still writes the edit.

Mutation-verified rather than assumed:

| mutation | result |
|---|---|
| drop `edit`'s delete guard, keep the teardown guard | third test passes -- the teardown guard independently closes the hole |
| drop both guards | fails: `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| stop tracking the in-flight move, keep everything else | fails: the write is addressed to `"One.md"`, the path the rename vacated |
| drop the `dirtyRef` term from the teardown gate | fails: `expected 2nd "vi.fn()" call ... but called only 1 times` -- the edit after a failed save is never written |
| remove the whole teardown effect (pre-fix behaviour), run the file 10x | the restored call-count assertion reds in 8 of 10 runs |
| with the fix, run the file 10x | 10 of 10 green |

The second row is why the guard is kept: without it, typing during an in-flight delete and then navigating away does POST a write that resurrects the note. The last two rows are why the assertion #2964 dropped is safe to keep now, and they make it the regression pin for this issue -- delete the cancel and the suite goes red instead of silent.

Gates: `tsc --noEmit` clean; `eslint` clean on both changed files (one pre-existing a11y warning elsewhere in the file); 317 of 317 green across the 12 md-notebook test files. Rebased onto current `main` (146 commits, zero conflicts), which clears the base-owned reds this branch had been sitting on -- `Frontend Tests (3)` was failing in `src/i18n/style/hiStyle.test.ts` on an auto-research string, and `Backend Tests` shard 4 was red on three platforms for a diff containing zero Python.

## Manual verification

<!-- no-visual-delta -->

**Why no screenshot:** nothing rendered changes -- the diff is one unmount-teardown effect, comments and tests, with no markup, style, layout or copy touched; it makes an autosave that already happened happen deliberately.

N/A -- unit coverage sufficient. The change has no rendered surface: it makes an autosave that already happened happen deliberately, and the two states worth checking (does the edit reach disk, does a second call follow) are exactly what the mutation table above measures. There is no visual variant a screenshot could show.

## Notes and decisions

Two things #2984 asked for that turned out not to be worth building, recorded as decisions rather than omissions.

A `mountDirtyFakeTimers` helper is no longer needed. Post-fix the timer is cancelled at unmount, so none of the 8 real-timer `mountDirty` sites leaks one. What they do instead is issue the teardown `saveNote` synchronously during cleanup, recorded against the test that owns it, which cannot cross into the next test. The helper would be machinery with nothing left to protect.

The `savesInFlightRef` `Set` plus manually resolved deferred is more ceremony than a counter, but `flushSave` runs can overlap, so a set is the overlap-safe shape, and restructuring a delicate 100-line save function to save four lines is risk without payoff.

## Related Issues

Closes #2984

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
