### PR TITLE
fix(mochi): stop the pet overlay trapping the user behind a 403 page

### DIFF
--- a/website/electron/mochi/index.js
+++ b/website/electron/mochi/index.js
@@ -691,7 +691,7 @@ async function reconcileMochiAfterCurrent() {
 }
 
 async function reconcileMochi() {
-  const { openPetWindow, closePetWindow } = require("./petOverlays");
+  const { openPetWindow, closePetWindow, rearmBlankedOverlays, hasBlankedOverlay } = require("./petOverlays");
   const {
     closeAvatarWindowFromReconcile,
     setAvatarBaseUrl,
@@ -809,6 +809,22 @@ async function reconcileMochi() {
   // window is now the Avatars gallery, opened on demand rather than at startup.
   closeAvatarWindowFromReconcile();
   openPetWindow(mochiPetBaseUrl, mochiPetToken);
+  // An overlay stuck on a gateway error page (expired cookie or a transient 5xx)
+  // has hidden itself; re-arm it with a token that works for the CURRENT target.
+  // For a remote instance that is its own token; for self the pet rides the
+  // same-origin cookie (empty token) — exactly what expired — so carry the
+  // CURRENT local token on the URL to re-establish it. Reuse the cached token,
+  // never mint here: the reconcile probes already clear cachedGatewayToken on a
+  // genuine 401/403, so gatewayToken() re-mints only when the old one was truly
+  // rejected. Minting every tick while a non-auth 4xx/5xx keeps an overlay
+  // blanked would churn session nonces and evict pending auth links.
+  if (hasBlankedOverlay()) {
+    let rearmToken = mochiPetToken;
+    if (mochiPetInstanceId === SELF_INSTANCE) {
+      rearmToken = await gatewayToken();
+    }
+    rearmBlankedOverlays(mochiPetBaseUrl, rearmToken);
+  }
   // Fully enabled again: bring the panel back if disable had hidden it.
   restorePanelOnEnable(mochiPetBaseUrl, mochiPetToken);
   // FIRST OPEN: on the first enabled tick of a session (fresh enable, or the pet

--- a/website/electron/mochi/petOverlays.js
+++ b/website/electron/mochi/petOverlays.js
@@ -49,6 +49,88 @@ const PET_H = 128;
 /** Force-stop a drag that never saw a mouseup (upstream value). */
 const DRAG_SAFETY_MS = 10_000;
 
+// ── Overlay error-page recovery ────────────────────────────────────────────
+//
+// A pet overlay covers a WHOLE display and is frameless, click-through and
+// always-on-top. If its `pet.html` load is answered with a gateway error page
+// (a token-required 401/403 — e.g. the session cookie expired while the machine
+// slept and a reconnected display builds a fresh overlay — or any other
+// 4xx/5xx), that opaque page blankets the entire display with no title bar to
+// close and no click target: the only escape is force-quitting the whole app.
+//
+// An error page is a COMPLETED navigation (the gateway serves an HTML/JSON
+// body), so `did-fail-load` never fires and `did-finish-load` DOES — meaning
+// the overlay would happily show it. `did-navigate`'s httpResponseCode is the
+// only signal that the page is an error, not the pet.
+//
+// Recovery is owned entirely by the host's 5s reconcile tick. The handler here
+// only HIDES an error page and latches the overlay; the host re-arms it with a
+// token it already resolved for the current target (rearmBlankedOverlays). One
+// recovery path, living inside the loop that owns target/switch state — so there
+// is no provider seam, no retry budget, and no superseded-window race to guard.
+
+/** True for ANY gateway error page on the main frame (4xx/5xx) — the signal to
+ * hide, since an error body is a completed navigation, not a did-fail-load. */
+function isOverlayErrorPage(httpResponseCode) {
+  return typeof httpResponseCode === "number" && httpResponseCode >= 400;
+}
+
+/**
+ * Overlays hidden because their last main-frame navigation was a gateway error
+ * page, so the load-finished handler knows NOT to reveal them and the reconcile
+ * tick knows which to re-arm. A WeakSet so a closed/GC'd window drops out on its
+ * own and never pins a dead BrowserWindow.
+ * @type {WeakSet<object>}
+ */
+const overlayBlanked = new WeakSet();
+
+/**
+ * React to a completed main-frame navigation: an error page (>=400) latches the
+ * overlay as blanked and hides it so it can never cover the display; any other
+ * status clears the latch. Reloading is NOT done here — the reconcile tick owns
+ * it (rearmBlankedOverlays), so there is no async work and no switch race.
+ */
+function handleOverlayNavigation(win, httpResponseCode) {
+  if (win.isDestroyed()) return;
+  if (isOverlayErrorPage(httpResponseCode)) {
+    overlayBlanked.add(win);
+    win.hide();
+  } else {
+    overlayBlanked.delete(win);
+  }
+}
+
+/** True when any live overlay is currently hidden on an error page, so the host
+ * only re-mints a token when there is actually one to heal. */
+function hasBlankedOverlay() {
+  for (const win of overlays.values()) {
+    if (!win.isDestroyed() && overlayBlanked.has(win)) return true;
+  }
+  return false;
+}
+
+/**
+ * Re-arm every overlay hidden on an error page by reloading it with the
+ * (baseUrl, token) the host ALREADY resolved for the current target this
+ * reconcile tick. The host owns target resolution AND switches, so this takes
+ * concrete values rather than resolving again — no provider seam, no retry
+ * budget, and no superseded-window race (the reload is synchronous inside the
+ * tick). An empty token means no usable credential yet: stay blank and let the
+ * next tick try. Recovering an expired cookie and a transient 5xx share this one
+ * path.
+ */
+function rearmBlankedOverlays(baseUrl, token) {
+  if (!baseUrl || !token) return;
+  for (const [, win] of overlays) {
+    if (win.isDestroyed() || !overlayBlanked.has(win)) continue;
+    // Refresh the shared target so overlays built LATER for other displays load
+    // the same fresh origin + token.
+    currentBaseUrl = baseUrl;
+    currentToken = token;
+    win.loadURL(mochiPageUrl(currentBaseUrl, "pet.html", token));
+  }
+}
+
 // ── Overlay registry (broadcastService.ts, overlay half) ───────────────────
 
 /** @type {Map<number, BrowserWindow>} displayId -> overlay */
@@ -602,6 +684,14 @@ function createOverlayForDisplay(display) {
     const safeUrl = String(url || "").split("?")[0];
     console.warn(`Mochi pet: load failed (${code} ${desc}) for ${safeUrl}`);
   });
+
+  // A gateway error page (any status >= 400) is a COMPLETED navigation, not a
+  // did-fail-load, so without this the frameless full-display overlay would
+  // reveal it with no way to close it. Hide + latch here; the reconcile tick
+  // re-arms the overlay with a fresh token (rearmBlankedOverlays).
+  win.webContents.on("did-navigate", (_e, _url, httpResponseCode) => {
+    handleOverlayNavigation(win, httpResponseCode);
+  });
   win.webContents.on("render-process-gone", (_e, details) => {
     console.warn("Mochi pet: renderer gone —", details && details.reason);
     // Tear down so the reconcile loop recreates it: isDestroyed() stays false
@@ -651,7 +741,11 @@ function wireHandshake(win, displayId, pos) {
     };
     send();
     setTimeout(send, 300);
-    if (!win.isVisible()) win.showInactive();
+    // Never reveal an overlay currently hidden on a gateway error page (see the
+    // did-navigate latch): showing it would blanket the display with an
+    // uncloseable page. A healed reload clears the latch and re-fires
+    // did-finish-load, which then shows the pet.
+    if (!overlayBlanked.has(win) && !win.isVisible()) win.showInactive();
     startHitPoll();
     assertHostStaysInDock();
   });
@@ -787,7 +881,11 @@ function showPetWindow() {
   for (const win of overlays.values()) {
     if (win.isDestroyed()) continue;
     win.setAlwaysOnTop(true, "screen-saver");
-    if (!win.isVisible()) win.showInactive();
+    // Honor the error-page latch: the hide-all restore must not re-reveal an
+    // overlay currently hidden on a gateway error page (same guard as the
+    // load-finished handler), or CMD+SHIFT+H would bring the uncloseable page
+    // back after a persisted auth failure.
+    if (!overlayBlanked.has(win) && !win.isVisible()) win.showInactive();
   }
 }
 
@@ -871,7 +969,9 @@ async function transferPetToDisplayById(displayId, localX, localY) {
           resolve(true);
         }, 300);
       });
-      win.showInactive();
+      // Do not reveal an overlay hidden on a gateway error page (see the
+      // did-navigate latch); a healed reload clears the latch and shows it.
+      if (!overlayBlanked.has(win) && !win.isVisible()) win.showInactive();
     });
   }
 
@@ -893,11 +993,16 @@ module.exports = {
   transferPetToDisplayById,
   getSavedPetPos,
   broadcastToOverlays,
+  rearmBlankedOverlays,
+  hasBlankedOverlay,
   // Exported for tests: the pure geometry decisions, no Electron needed.
   _inRect: inRect,
   _shouldIgnoreAt: shouldIgnoreAt,
   _clampLocal: clampLocal,
   _findNearestDisplay: findNearestDisplay,
+  // Exported for tests: the error-page recovery policy + navigation handler.
+  _isOverlayErrorPage: isOverlayErrorPage,
+  _handleOverlayNavigation: handleOverlayNavigation,
   // Exported for tests: overlay-map lifecycle (identity-checked cleanup).
   _registerOverlay: registerOverlay,
   _getOverlays: getOverlays,

--- a/website/electron/mochi/test/petOverlays.test.js
+++ b/website/electron/mochi/test/petOverlays.test.js
@@ -236,3 +236,139 @@ test("the pet overlay is a non-activating panel on macOS only", () => {
     mod.closePetWindow();
   }
 });
+
+// ── Overlay error-page recovery ────────────────────────────────────────────
+// A pet overlay covers a whole frameless, click-through display, so a gateway
+// error page (401/403/4xx/5xx) rendered in it would trap the user behind an
+// uncloseable full-screen page (the reported "403 after sleep" bug). An error
+// page is a COMPLETED navigation, so the status code is the only signal; the
+// handler only hides+latches, and recovery is owned by the host's reconcile tick.
+const fs = require("node:fs");
+const {
+  _isOverlayErrorPage,
+  _handleOverlayNavigation,
+  hasBlankedOverlay,
+  rearmBlankedOverlays,
+  _registerOverlay,
+  _getOverlays,
+} = require("../petOverlays");
+
+// A fake overlay window: identity for the WeakSet, plus the methods the handler
+// and re-arm touch. Registered in the real overlays map so hasBlankedOverlay /
+// rearmBlankedOverlays see it, then removed in a finally.
+function fakeWin() {
+  return {
+    destroyed: false,
+    hidden: false,
+    loadedUrl: null,
+    isDestroyed() { return this.destroyed; },
+    hide() { this.hidden = true; },
+    showInactive() { this.hidden = false; },
+    isVisible() { return !this.hidden; },
+    loadURL(u) { this.loadedUrl = u; },
+    on() {},
+  };
+}
+
+test("any >=400 status is an error page; success and redirects are not", () => {
+  // The reported harm is "an opaque page blankets the display" — a 404/500 body
+  // traps the user identically to a 401/403, so hiding must cover all of them.
+  for (const code of [400, 401, 403, 404, 500, 503]) {
+    assert.equal(_isOverlayErrorPage(code), true, `${code} is an error page`);
+  }
+  for (const code of [200, 301, 304, undefined, null, "500"]) {
+    assert.equal(_isOverlayErrorPage(code), false, `${code} is not an error page`);
+  }
+});
+
+test("handleOverlayNavigation hides+latches an error page and clears on a good load", () => {
+  const DID = 99311;
+  const win = fakeWin();
+  _registerOverlay(DID, win);
+  try {
+    _handleOverlayNavigation(win, 403);
+    assert.equal(win.hidden, true, "an error page must hide the overlay");
+    assert.equal(hasBlankedOverlay(), true, "the overlay is latched as blanked");
+
+    _handleOverlayNavigation(win, 200); // a healed reload lands on 200
+    assert.equal(hasBlankedOverlay(), false, "a good load clears the latch");
+
+    _handleOverlayNavigation(win, 500); // a 5xx also latches, not only auth codes
+    assert.equal(hasBlankedOverlay(), true, "a 5xx error page also latches");
+
+    win.destroyed = true; // a destroyed window is a no-op, never throws
+    assert.doesNotThrow(() => _handleOverlayNavigation(win, 200));
+  } finally {
+    _getOverlays().delete(DID);
+  }
+});
+
+test("rearmBlankedOverlays reloads only blanked windows, with the token the host resolved", () => {
+  const BLANK = 99312;
+  const OK = 99313;
+  const blanked = fakeWin();
+  const healthy = fakeWin();
+  _registerOverlay(BLANK, blanked);
+  _registerOverlay(OK, healthy);
+  try {
+    _handleOverlayNavigation(blanked, 403); // latch the blanked one; healthy never errored
+    rearmBlankedOverlays("http://localhost:5476", "tok123");
+    assert.match(blanked.loadedUrl || "", /token=tok123/, "blanked overlay reloads with the host's token");
+    assert.equal(healthy.loadedUrl, null, "a non-blanked overlay is left untouched");
+  } finally {
+    _getOverlays().delete(BLANK);
+    _getOverlays().delete(OK);
+  }
+});
+
+test("rearmBlankedOverlays refuses to reload with an empty/missing token", () => {
+  const DID = 99314;
+  const win = fakeWin();
+  _registerOverlay(DID, win);
+  try {
+    _handleOverlayNavigation(win, 403);
+    rearmBlankedOverlays("http://localhost:5476", ""); // no usable credential
+    assert.equal(win.loadedUrl, null, "an empty token must not trigger a reload (it would 403 again)");
+    rearmBlankedOverlays("", "tok"); // no base url
+    assert.equal(win.loadedUrl, null, "a missing base url must not trigger a reload");
+  } finally {
+    _getOverlays().delete(DID);
+  }
+});
+
+// Source guards for invariants that cannot be exercised without Electron.
+const fsSrc = fs.readFileSync(path.join(__dirname, "..", "petOverlays.js"), "utf8");
+const idxSrc = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
+
+test("did-navigate delegates to the single navigation handler (no inline retry path)", () => {
+  assert.match(fsSrc, /did-navigate/, "must hook did-navigate (an error page is not a did-fail-load)");
+  assert.match(fsSrc, /handleOverlayNavigation\(win, httpResponseCode\)/,
+    "did-navigate must delegate to handleOverlayNavigation");
+  // The inline fast-retry machinery is gone (Fable: one reconcile-owned path).
+  for (const gone of ["setPetReauthProvider", "fastReauthOverlay", "reloadOverlayForCurrentTarget", "overlayReauthAttempts", "isRegisteredOverlay"]) {
+    assert.ok(!fsSrc.includes(gone), `${gone} must be removed (single reconcile-owned recovery path)`);
+  }
+  assert.ok(!idxSrc.includes("setPetReauthProvider"), "index.js must not wire a reauth provider anymore");
+});
+
+test("every showInactive reveal is guarded by the blanked latch", () => {
+  const reveals = fsSrc.match(/win\.showInactive\(\)/g) || [];
+  const guarded = fsSrc.match(/!overlayBlanked\.has\(win\)[\s\S]{0,80}win\.showInactive\(\)/g) || [];
+  assert.ok(reveals.length >= 3, "expected the three overlay reveal sites (handshake, showPetWindow, transfer)");
+  assert.equal(guarded.length, reveals.length, "every showInactive reveal must be latch-guarded");
+});
+
+test("reconcile re-arms with a current-target token: remote its own, self the cached local token", () => {
+  // The host passes the token it ALREADY resolved this tick; for self it reuses
+  // the probe-maintained cached token (empty-cookie case), only when something
+  // is actually blanked — and NEVER mints here, or a persistent non-auth error
+  // would churn a fresh session token every tick.
+  const callAt = idxSrc.indexOf("rearmBlankedOverlays(mochiPetBaseUrl");
+  assert.ok(callAt >= 0, "reconcile must call rearmBlankedOverlays with the resolved base url + token");
+  const region = idxSrc.slice(idxSrc.indexOf("if (hasBlankedOverlay())"), callAt + 60);
+  assert.match(region, /hasBlankedOverlay\(\)/, "only re-arm when an overlay is actually blanked");
+  assert.match(region, /SELF_INSTANCE/, "self supplies a local token (empty-cookie case)");
+  assert.match(region, /gatewayToken\(\)/, "self reuses the probe-maintained cached token");
+  assert.ok(!region.includes('cachedGatewayToken = ""'),
+    "must NOT clear the token cache in the rearm path — probe-driven invalidation only, or a persistent non-auth error mints every tick");
+});


### PR DESCRIPTION
## Problem

Mochi's pet overlay is a frameless, click-through, always-on-top `BrowserWindow` that spans an **entire display**. It loads `pet.html` from the gateway. When that load is answered with a gateway **error page** (a token-required 401/403, or any 4xx/5xx), Electron renders the opaque page across the whole display, with no title bar to close and no click target. The only escape is force-quitting the app.

This reproduces reliably as: the machine sleeps overnight (the session cookie's TTL expires), and the next morning **reconnecting a second display** builds a fresh overlay for it that loads `pet.html` with a now-stale credential → 403 → an uncloseable full-screen page on the second monitor.

### Why the existing handling missed it

An error page is a **completed navigation** (the gateway serves an HTML/JSON body), so `did-fail-load` never fires — only `did-finish-load` does, and that handler calls `showInactive()`. The overlay therefore *showed* the error page. The overlays also loaded with a token captured at open time (empty for the local gateway, relying on the cookie) and were never reloaded with a fresh one.

This is distinct from #1876 (`0010fab5f`), which fixed the **main dashboard window** being trapped in fullscreen — a different window and code path.

## Fix

Recovery is a **single path owned by the host's 5s reconcile tick** — no second resolver, no provider seam, no retry budget, no cross-window race to guard.

In `mochi/petOverlays.js`:
- Hook `did-navigate` (whose `httpResponseCode` is the only signal that the page is an error, not the pet) and delegate to `handleOverlayNavigation(win, code)`: **any status ≥ 400** latches the window in a `WeakSet` and `hide()`s it; any other status clears the latch. Reloading is NOT done here.
- Every `showInactive()` reveal path (handshake, hide-all restore, display transfer) is guarded by the latch, so no path re-reveals a hidden error page.
- `rearmBlankedOverlays(baseUrl, token)` reloads every still-blanked overlay with the `{baseUrl, token}` the host already resolved this tick, and refreshes the shared target so overlays built later for other displays use it too. An empty token is a no-op (stay blank, try next tick).

In `mochi/index.js` (`reconcileMochi`):
- When any overlay is blanked, re-arm it with a token that works for the **current target**: a remote instance's own token, or — for self, whose overlay rides the expired same-origin cookie — the current local token carried on the URL to re-establish the cookie.
- The rearm path **reuses** the probe-maintained cached token and **never clears** `cachedGatewayToken`. Only the existing `mochiEnabledState`/`mochiSettings` probes clear it on a genuine 401/403, so `gatewayToken()` re-mints only when the old token was truly rejected — a persistent non-auth 4xx/5xx does **not** churn a fresh session token every tick.

Trade-off: an error-page overlay heals within one reconcile tick (≤5s) instead of sub-second, in exchange for a single, switch-safe recovery path that lives inside the loop that owns target resolution.

## Tests

`mochi/test/petOverlays.test.js`:
- `isOverlayErrorPage` — any ≥400 hides; success/redirects do not.
- `handleOverlayNavigation` (driven with a fake window) — an error page hides + latches; a good load clears the latch; a 5xx latches too; a destroyed window is a safe no-op.
- `rearmBlankedOverlays` — reloads only blanked windows with the host-supplied token; refuses an empty/missing token.
- Source guards — `did-navigate` delegates to the single handler; the inline retry machinery (`setPetReauthProvider`/`fastReauthOverlay`/`overlayReauthAttempts`/…) is **removed**; every `showInactive` reveal is latch-guarded; reconcile reuses the cached token and never clears it in the rearm path.

`npm test` (website/electron): **875 passed, 0 failed** (rebased onto current `main`, which includes #3114's pet non-activating-panel change — both coexist).

## Manual verification

N/A for automated coverage — the trap and recovery are exercised by the fake-window unit tests and source guards above. The overlay is a non-focusable, click-through window, so the visible symptom is the presence/absence of an opaque full-screen page, which the latch + reveal-guards assert directly.
