### PR TITLE
fix(browse): keep operator mcp.json fields across browse mode switches

### DIFF
--- a/docs/system-specs/modules/browser.md
+++ b/docs/system-specs/modules/browser.md
@@ -166,6 +166,49 @@ Playwright MCP's `browser_snapshot` returns full accessibility trees (50-100K to
 - Compresses to compact outline: only interactive elements (links, buttons, inputs, headings, images) with refs
 - ~95% token reduction on heavy pages
 
+**Registration status contract:** `register_playwright_proxy()` returns one of
+four statuses, and every caller that reports the outcome must distinguish them,
+because two of the four mean the `browser_*` tools will NOT work:
+
+| Status | Meaning |
+|---|---|
+| `registered` | KiroCrew's proxy entry was written or refreshed under the canonical alias. |
+| `mode-disabled` | Browser Mode is off, so nothing was written (see above). |
+| `kept-user-entry` | A user-authored NON-proxy server holds the canonical key; it is left byte-identical. |
+| `shadowed-by-agent` | The entry was written, but an agent spec in `~/.kiro/agents/*.json` declares the same server name. An agent's own `mcpServers` declaration wins at resolution, so the write has no effect until that spec is removed. `agent_specs_shadowing()` names the offending files and `print_shadow_warning()` renders them. |
+
+**Mode switches update in place, never rebuild.** `_apply_mode_to_entry()` sets
+only the fields a mode owns — `command`, `args`, and the extension token — and
+leaves every other key on the entry untouched. An operator's `env` (notably a
+`KIROCREW_PLAYWRIGHT_CMD` launcher pin, which on some hosts is the only reason a
+launcher resolves at all), a `timeout`, or any field a future schema adds
+therefore survives `browse extension on|off`. The token is mode-owned: headless
+removes it rather than carrying a stale one.
+
+**Browser Mode OFF carries operator fields in a sidecar.** Turning Browser Mode
+off must DELETE the entry — availability is the consent gate, so the `browser_*`
+tools have to actually disappear — which would otherwise take the operator's own
+fields with it. `deregister_playwright_proxy()` therefore stashes them to
+`$KIROCREW_HOME/playwright-entry-carryover.json` (mode `0600`) and the next
+registration restores them into the fresh entry. Properties:
+
+- Captured only from an entry Kiro Crew authored (`_spec_is_proxy`), so a user's
+  own server under the canonical key is never copied out of their config. The
+  guard lives inside `capture_entry_carryover()` rather than at its call sites,
+  because the stale-MCP purge deletes by command basename and can match a server
+  Kiro Crew does not own.
+- The extension token is **not** stashed: it is re-minted per mode, and copying it
+  would spread a credential to a second file for no benefit.
+- One-shot — the stash is consumed and deleted by the restore, so it cannot
+  resurrect configuration the operator later abandoned.
+
+**The stale-MCP purge carries too.** `clean_stale_managed_mcp()` removes an entry
+whose command is the dead predecessor binary — correctly, since that command is
+unusable — and `cli_setup` registers the proxy again immediately afterwards. The
+purge therefore stashes the operator-owned fields the same way deregistration
+does, so an operator who migrated from the predecessor does not silently lose a
+launcher pin to `kirocrew setup` or an update.
+
 **Registration (one canonical server, no duplicates):** kiro-cli splits an agent
 `@server` reference on `/`, so a slash-containing key like `@playwright/mcp` is
 mis-parsed as `@server/tool` and exposes none of the server's tools. The proxy is

--- a/src/kiro_crew/browser/cli.py
+++ b/src/kiro_crew/browser/cli.py
@@ -113,6 +113,9 @@ def _cmd_setup() -> None:
     if reg_status == "kept-user-entry":
         print(f"  \u00b7 Proxy NOT registered           {mcp_json}")
         print("    (you already have your own 'playwright-mcp' server — left untouched)")
+    elif reg_status == "shadowed-by-agent":
+        print(f"  \u2717 Proxy registered but SHADOWED  {mcp_json}")
+        _setup.print_shadow_warning()
     else:
         print(f"  \u2713 Proxy registered               {mcp_json}")
 
@@ -198,6 +201,9 @@ def _reregister_proxy() -> None:
     if status == "kept-user-entry":
         print("  Kept your existing playwright-mcp entry in mcp.json (left untouched).")
         print("  Remove it to let KiroCrew manage the browse server.")
+    elif status == "shadowed-by-agent":
+        print("  Wrote the entry, but it is SHADOWED and will not be used:")
+        _setup.print_shadow_warning("  ")
 
 
 def _cmd_auth_health() -> None:

--- a/src/kiro_crew/browser/setup.py
+++ b/src/kiro_crew/browser/setup.py
@@ -1669,6 +1669,112 @@ def _kiro_mcp_locked() -> Iterator[None]:
             yield
 
 
+#: The token describes extension mode itself, so a mode switch owns it: headless
+#: must clear it rather than keep a stale one.
+_MODE_OWNED_ENV_KEY = "PLAYWRIGHT_MCP_EXTENSION_TOKEN"
+
+#: Fields a browse mode decides. Everything else on the entry belongs to the
+#: operator and is carried across a Browser-Mode round trip via the sidecar.
+_MODE_OWNED_FIELDS = frozenset({"command", "args"})
+
+
+def _carryover_path() -> Path:
+    """Where operator-owned entry fields wait out a Browser-Mode OFF period.
+
+    Turning Browser Mode off DELETES the mcp.json entry on purpose: tool
+    availability is the consent gate, so the ``browser_*`` tools must actually
+    disappear. That deletion would also take the operator's own fields with it,
+    so they are stashed here and restored by the next registration.
+    """
+    return config_dir() / "playwright-entry-carryover.json"
+
+
+def capture_entry_carryover(entry: object) -> None:
+    """Stash the operator-owned fields of a proxy entry before it is deleted.
+
+    Ignores anything that is not a Kiro Crew proxy entry, so a user's own server
+    is never copied out of their config. The guard lives here rather than at the
+    call site because callers include the stale-MCP purge, which deletes by
+    command basename and can match a server Kiro Crew does not own. The
+    mode-owned extension token is dropped rather than stashed: it is re-minted
+    per mode, and copying it would spread a credential to a second file for no
+    benefit.
+    """
+    if not isinstance(entry, dict) or not _spec_is_proxy(entry):
+        return
+    keep = {k: v for k, v in entry.items() if k not in _MODE_OWNED_FIELDS}
+    env = keep.get("env")
+    if isinstance(env, dict):
+        env = {k: v for k, v in env.items() if k != _MODE_OWNED_ENV_KEY}
+        if env:
+            keep["env"] = env
+        else:
+            keep.pop("env", None)
+    else:
+        keep.pop("env", None)
+    path = _carryover_path()
+    try:
+        if not keep:
+            path.unlink(missing_ok=True)
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write(path, json.dumps(keep, indent=2), mode=0o600)
+    except OSError:
+        pass
+
+
+def _consume_entry_carryover() -> dict:
+    """Return the stashed operator fields and drop the stash.
+
+    One-shot on purpose: a stash that outlived its round trip would resurrect
+    configuration the operator may have deliberately abandoned.
+    """
+    path = _carryover_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        data = None
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+    return data if isinstance(data, dict) else {}
+
+
+def _apply_mode_to_entry(
+    servers: dict, canonical: str, args: list[str], token: str | None
+) -> None:
+    """Set ONLY the fields a browse mode owns on the canonical entry, in place.
+
+    ``command``, ``args`` and the extension token are what a mode switch decides;
+    every other key the operator put on this entry (a launcher pin in ``env``, a
+    ``timeout``, anything a future schema adds) is none of this function's
+    business and is left exactly as found. Rebuilding the entry from scratch
+    would discard all of it, including the ``KIROCREW_PLAYWRIGHT_CMD`` launcher
+    pin that is the only reason some hosts resolve a launcher at all.
+
+    ``token=None`` means headless: the key is removed, not carried over.
+    """
+    entry = servers.get(canonical)
+    if not isinstance(entry, dict):
+        # A fresh slot: restore whatever a previous Browser-Mode OFF stashed, so a
+        # Settings round trip does not cost the operator their own fields.
+        entry = _consume_entry_carryover()
+    entry["command"] = _kirocrew_bin()
+    entry["args"] = args
+    env = entry.get("env")
+    env = dict(env) if isinstance(env, dict) else {}
+    if token is None:
+        env.pop(_MODE_OWNED_ENV_KEY, None)
+    else:
+        env[_MODE_OWNED_ENV_KEY] = token
+    if env:
+        entry["env"] = env
+    else:
+        entry.pop("env", None)
+    servers[canonical] = entry
+
+
 def _patch_mcp_extension_unlocked(token: str) -> None:
     """Write the ``--extension`` proxy entry. Caller MUST hold ``_kiro_mcp_locked``."""
     mcp_json = _kiro_mcp_json_path()
@@ -1686,14 +1792,9 @@ def _patch_mcp_extension_unlocked(token: str) -> None:
         servers = data.setdefault("mcpServers", {})
         if not isinstance(servers, dict):
             servers = data["mcpServers"] = {}
-        entry = {
-            "command": _kirocrew_bin(),
-            "args": ["mcp-playwright-proxy", "--extension"],
-            "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": token},
-        }
         canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
         _drop_superseded_playwright(servers, canonical)
-        servers[canonical] = entry
+        _apply_mode_to_entry(servers, canonical, ["mcp-playwright-proxy", "--extension"], token)
         mcp_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
         platform_compat.chmod_safe(str(mcp_json), 0o600)
         _record_owned_mcp_key(canonical)
@@ -1717,13 +1818,11 @@ def _patch_mcp_headless_unlocked() -> None:
         if not isinstance(servers, dict):
             servers = data["mcpServers"] = {}
         config_path = str(config_dir() / "playwright-config.json")
-        entry = {
-            "command": _kirocrew_bin(),
-            "args": ["mcp-playwright-proxy", "--config", config_path],
-        }
         canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
         _drop_superseded_playwright(servers, canonical)
-        servers[canonical] = entry
+        _apply_mode_to_entry(
+            servers, canonical, ["mcp-playwright-proxy", "--config", config_path], None
+        )
         mcp_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
         _record_owned_mcp_key(canonical)
     except (json.JSONDecodeError, OSError):
@@ -1794,6 +1893,52 @@ def check_playwright_launchable() -> tuple[bool, str]:
     return True, cmd
 
 
+def agent_specs_shadowing(canonical: str | None = None) -> list[Path]:
+    """Agent spec files that declare ``canonical`` and therefore SHADOW mcp.json.
+
+    Defaults to the canonical Playwright server key.
+
+    An agent's own ``mcpServers`` declaration always wins over a settings-level
+    server of the same name, so an agent-level ``playwright-mcp`` silently
+    overrides the proxy this module just registered. Registration reads only
+    ``mcp.json``, so without this probe it reports success while the entry that
+    actually launches is somebody else's.
+
+    Best-effort: an unreadable or malformed spec is skipped rather than raising,
+    since this only decorates a status message.
+    """
+    if canonical is None:
+        canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
+    shadowing: list[Path] = []
+    try:
+        specs = sorted(kiro_agents_dir().glob("*.json"))
+    except OSError:
+        return shadowing
+    for spec in specs:
+        try:
+            data = json.loads(spec.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        servers = data.get("mcpServers")
+        if isinstance(servers, dict) and canonical in servers:
+            shadowing.append(spec)
+    return shadowing
+
+
+def print_shadow_warning(indent: str = "    ") -> None:
+    """Name the agent specs that shadow the canonical proxy entry.
+
+    A shadowed registration wrote a correct entry that nothing will launch, so
+    every path that reports the outcome of a registration must say this rather
+    than print success.
+    """
+    for spec in agent_specs_shadowing():
+        print(f"{indent}an agent spec declares 'playwright-mcp' and wins: {spec}")
+    print(f"{indent}remove that entry, or browsing will keep using it instead")
+
+
 def register_playwright_proxy() -> tuple[Path, str]:
     """Register KiroCrew's Playwright proxy in kiro's ``mcp.json``.
 
@@ -1803,10 +1948,13 @@ def register_playwright_proxy() -> tuple[Path, str]:
     proxy entry via the mode-appropriate patch (extension vs headless config).
 
     Returns ``(mcp_json_path, status)`` where ``status`` is ``"registered"``
-    (KiroCrew's proxy was written/refreshed) or ``"kept-user-entry"`` (a
+    (KiroCrew's proxy was written/refreshed), ``"kept-user-entry"`` (a
     user-authored NON-proxy server already holds the canonical ``playwright-mcp``
     key, so we left it untouched rather than clobber their config — authorship is
-    by launch target, not key name, mirroring the boot-time migration guard).
+    by launch target, not key name, mirroring the boot-time migration guard), or
+    ``"shadowed-by-agent"`` (the entry was written, but an agent spec declares the
+    same server name and an agent's own declaration wins, so the write has no
+    effect until that spec is removed).
     """
     mcp_json = _kiro_mcp_json_path()
     # Registration is the AUTHORIZATION: once the proxy is in mcp.json the
@@ -1838,6 +1986,8 @@ def register_playwright_proxy() -> tuple[Path, str]:
         else:
             mcp_json.write_text(json.dumps({"mcpServers": {}}, indent=2), encoding="utf-8")
         _patch_mcp_for_mode_unlocked()
+    if agent_specs_shadowing(canonical):
+        return mcp_json, "shadowed-by-agent"
     return mcp_json, "registered"
 
 
@@ -1886,6 +2036,7 @@ def deregister_playwright_proxy() -> tuple[Path, str]:
                 kept_user_entry = user_owns_canonical
                 removed = False
                 if _spec_is_proxy(canon):
+                    capture_entry_carryover(canon)
                     del servers[canonical]
                     removed = True
                 before = len(servers)

--- a/src/kiro_crew/cli_setup.py
+++ b/src/kiro_crew/cli_setup.py
@@ -17,6 +17,7 @@ from kiro_crew.acp.client import KIRO_CLI_BIN
 from kiro_crew.browser.setup import (
     browser_mode_enabled,
     generate_playwright_config,
+    print_shadow_warning,
     refresh_storage_state,
     register_playwright_proxy,
 )
@@ -385,6 +386,9 @@ def _setup_impl(
             _, status = register_playwright_proxy()
             if status == "kept-user-entry":
                 print("  Kept your existing playwright-mcp entry in mcp.json (left untouched)")
+            elif status == "shadowed-by-agent":
+                print("  Proxy registered but SHADOWED by an agent spec:")
+                print_shadow_warning("  ")
             else:
                 print("  Browser Mode is on — proxy registered in mcp.json")
         except Exception:

--- a/src/kiro_crew/mcp_cleanup.py
+++ b/src/kiro_crew/mcp_cleanup.py
@@ -62,6 +62,26 @@ def _invokes_meshclaw(spec: object) -> bool:
     return stem == "meshclaw"
 
 
+def _stash_operator_fields(spec: object) -> None:
+    """Carry operator-owned fields out of a proxy entry this purge deletes.
+
+    The purge removes an entry whose *command* is unusable, but fields the
+    operator added to it -- notably an ``env.KIROCREW_PLAYWRIGHT_CMD`` launcher
+    pin -- remain valid. Setup registers the proxy again right after purging
+    (``cli_setup``), which restores the stash. Only a KiroCrew-authored proxy
+    entry is captured, so a user's own server is never copied out.
+
+    Imported lazily: ``browser.setup`` is a heavier module and does not import
+    this one, so keeping the edge one-way and late avoids an import cycle.
+    """
+    try:
+        from kiro_crew.browser.setup import capture_entry_carryover  # noqa: PLC0415
+
+        capture_entry_carryover(spec)
+    except Exception:  # pragma: no cover - carryover is best-effort
+        logger.debug("Could not stash operator fields before purge", exc_info=True)
+
+
 def clean_stale_managed_mcp() -> list[str]:
     """Remove stale managed-binary MCP entries from ``~/.kiro/settings/mcp.json``.
 
@@ -98,6 +118,7 @@ def clean_stale_managed_mcp() -> list[str]:
     if not removed:
         return []
     for name in removed:
+        _stash_operator_fields(servers[name])
         del servers[name]
     try:
         _KIRO_MCP_JSON.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")

--- a/test/test_browser_config_journeys.py
+++ b/test/test_browser_config_journeys.py
@@ -1,0 +1,334 @@
+"""Journey test: an operator's Playwright config must survive real user actions.
+
+Simulates the sequences an operator actually performs -- toggling extension mode,
+turning Browser Mode off and back on in Settings, and a gateway restart -- and
+asserts the fields KiroCrew does not own are still there afterwards. The field
+that matters is ``env.KIROCREW_PLAYWRIGHT_CMD``: on a host whose launcher is not
+otherwise discoverable it is the only reason browsing works at all, so losing it
+to a toggle is indistinguishable from the feature breaking.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import kiro_crew.mcp_cleanup as cleanup_mod
+from kiro_crew.browser import setup as setup_mod
+from kiro_crew.browser.setup import (
+    converge_playwright_servers,
+    deregister_playwright_proxy,
+    register_playwright_proxy,
+)
+from kiro_crew.mcp_utils import mcp_server_alias
+
+_CANONICAL = mcp_server_alias("@playwright/mcp")
+_PIN = "/opt/pw/cli.js"
+
+
+def _mcp_json(home: Path) -> Path:
+    return home / ".kiro" / "settings" / "mcp.json"
+
+
+def _read_entry(home: Path) -> dict | None:
+    path = _mcp_json(home)
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return (data.get("mcpServers") or {}).get(_CANONICAL)
+
+
+def _seed_pinned_entry(home: Path) -> None:
+    """An operator's working config: KiroCrew's proxy plus their own launcher pin."""
+    path = _mcp_json(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    _CANONICAL: {
+                        "command": "kirocrew",
+                        "args": ["mcp-playwright-proxy", "--extension"],
+                        "env": {
+                            "KIROCREW_PLAYWRIGHT_CMD": _PIN,
+                            "PLAYWRIGHT_MCP_EXTENSION_TOKEN": "tok",
+                        },
+                        "timeout": 60,
+                    },
+                    "other-mcp": {"command": "unrelated"},
+                }
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestOperatorConfigSurvivesUserJourneys:
+    @pytest.fixture()
+    def home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "get_extension_token", lambda: "tok")
+        _seed_pinned_entry(tmp_path)
+        return tmp_path
+
+    def _mode(self, monkeypatch: pytest.MonkeyPatch, *, browser: bool, extension: bool) -> None:
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: browser)
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: extension)
+
+    def test_extension_toggled_off_and_on(self, home: Path, monkeypatch: pytest.MonkeyPatch):
+        # `kirocrew browse extension off` then `on` -- two mode switches.
+        self._mode(monkeypatch, browser=True, extension=False)
+        register_playwright_proxy()
+        assert (_read_entry(home) or {}).get("env", {}).get("KIROCREW_PLAYWRIGHT_CMD") == _PIN
+
+        self._mode(monkeypatch, browser=True, extension=True)
+        register_playwright_proxy()
+        entry = _read_entry(home) or {}
+        assert entry.get("env", {}).get("KIROCREW_PLAYWRIGHT_CMD") == _PIN
+        assert entry.get("timeout") == 60
+
+    def test_browser_mode_off_then_on_in_settings(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The Settings toggle: deregister removes the tools, re-enabling restores
+        # them. The operator's pin must not be collateral damage of that round trip.
+        self._mode(monkeypatch, browser=True, extension=True)
+        deregister_playwright_proxy()
+
+        self._mode(monkeypatch, browser=True, extension=True)
+        register_playwright_proxy()
+
+        entry = _read_entry(home) or {}
+        assert entry.get("env", {}).get("KIROCREW_PLAYWRIGHT_CMD") == _PIN
+
+    def test_gateway_restart_converge(self, home: Path, monkeypatch: pytest.MonkeyPatch):
+        # Boot-path convergence runs on every gateway start.
+        self._mode(monkeypatch, browser=True, extension=True)
+        converge_playwright_servers({})
+        entry = _read_entry(home) or {}
+        assert entry.get("env", {}).get("KIROCREW_PLAYWRIGHT_CMD") == _PIN
+
+    def test_unrelated_servers_untouched(self, home: Path, monkeypatch: pytest.MonkeyPatch):
+        self._mode(monkeypatch, browser=True, extension=True)
+        register_playwright_proxy()
+        data = json.loads(_mcp_json(home).read_text(encoding="utf-8"))
+        assert data["mcpServers"]["other-mcp"] == {"command": "unrelated"}
+
+
+class TestEveryPlaywrightSettingSurvives:
+    """Inventory sweep: every piece of Playwright state vs every write path.
+
+    Each case names the file and the action, so a regression says which setting
+    was lost to which command rather than "browsing broke".
+    """
+
+    @pytest.fixture()
+    def home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "config_dir", lambda: tmp_path / "crew")
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        (tmp_path / "crew").mkdir(parents=True, exist_ok=True)
+        _seed_pinned_entry(tmp_path)
+        return tmp_path
+
+    def _cfg(self, home: Path) -> Path:
+        return home / "crew" / "playwright-config.json"
+
+    def test_extension_token_survives_a_mode_round_trip(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        token_file = home / "crew" / "playwright-extension-token"
+        token_file.write_text("operator-token")
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        register_playwright_proxy()
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: True)
+        register_playwright_proxy()
+        assert token_file.read_text() == "operator-token"
+
+    def test_browser_engine_choice_survives_a_mode_round_trip(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        setup_mod.set_browser_engine("firefox")
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        register_playwright_proxy()
+        deregister_playwright_proxy()
+        register_playwright_proxy()
+        assert setup_mod.get_browser_engine() == "firefox"
+
+    def test_engine_choice_is_honoured_by_config_regeneration(self, home: Path):
+        setup_mod.set_browser_engine("webkit")
+        setup_mod.generate_playwright_config()
+        cfg = json.loads(self._cfg(home).read_text(encoding="utf-8"))
+        assert cfg["browser"]["browserName"] == "webkit"
+        # channel is chromium-only; firefox/webkit reject it.
+        assert "channel" not in cfg["browser"]["launchOptions"]
+
+    def test_storage_state_is_attached_only_when_present(self, home: Path):
+        setup_mod.generate_playwright_config()
+        cfg = json.loads(self._cfg(home).read_text(encoding="utf-8"))
+        assert cfg["browser"]["contextOptions"] == {}
+
+        (home / "crew" / "playwright-storage-state.json").write_text('{"cookies":[]}')
+        setup_mod.generate_playwright_config()
+        cfg = json.loads(self._cfg(home).read_text(encoding="utf-8"))
+        assert cfg["browser"]["contextOptions"]["storageState"].endswith(
+            "playwright-storage-state.json"
+        )
+
+
+class TestUpdateLifecycle:
+    """`kirocrew setup` (which an update runs) purges stale entries, then registers.
+
+    A user migrated from the predecessor has a canonical entry whose command is
+    the dead binary. The purge is correct to remove it, but the operator's own
+    fields on that entry are still valid.
+    """
+
+    @pytest.fixture()
+    def home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "config_dir", lambda: tmp_path / "crew")
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "get_extension_token", lambda: "tok")
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: True)
+        # mcp_cleanup resolves its target at IMPORT time, so patching Path.home
+        # is not enough: whenever another test imported the module first, the
+        # purge would run against the real ~/.kiro/settings/mcp.json.
+        monkeypatch.setattr(cleanup_mod, "_KIRO_MCP_JSON", _mcp_json(tmp_path))
+        (tmp_path / "crew").mkdir(parents=True, exist_ok=True)
+        return tmp_path
+
+    def _seed_predecessor_entry(self, home: Path) -> None:
+        path = _mcp_json(home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        _CANONICAL: {
+                            # Points at the dead predecessor runtime, so the purge
+                            # is right to remove it -- the command is unusable.
+                            "command": "/opt/MeshClaw/bin/meshclaw",
+                            "args": ["mcp-playwright-proxy"],
+                            "env": {"KIROCREW_PLAYWRIGHT_CMD": _PIN},
+                            "timeout": 120000,
+                        },
+                        "other-mcp": {"command": "unrelated"},
+                    }
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+    def test_purge_removes_the_dead_predecessor_entry(self, home: Path):
+        self._seed_predecessor_entry(home)
+        removed = cleanup_mod.clean_stale_managed_mcp()
+        assert _CANONICAL in removed
+        assert _read_entry(home) is None
+        # A genuine user server is never collateral.
+        data = json.loads(_mcp_json(home).read_text(encoding="utf-8"))
+        assert data["mcpServers"]["other-mcp"] == {"command": "unrelated"}
+
+    def test_operator_pin_survives_the_update_purge_then_register(self, home: Path):
+        # The sequence cli_setup runs: clean_stale_managed_mcp() at :313, then
+        # register_playwright_proxy() at :386.
+        self._seed_predecessor_entry(home)
+        cleanup_mod.clean_stale_managed_mcp()
+        register_playwright_proxy()
+
+        entry = _read_entry(home)
+        assert entry is not None
+        # The dead command is replaced -- that is the point of the purge.
+        assert entry["command"] == "kirocrew"
+        # The pin is the operator's, still valid, and the only reason a launcher
+        # resolves on some hosts.
+        assert entry.get("env", {}).get("KIROCREW_PLAYWRIGHT_CMD") == _PIN
+        assert entry.get("timeout") == 120000
+
+    def test_purge_does_not_stash_a_users_own_server(self, home: Path):
+        # _invokes_meshclaw matches on command basename alone, so the purge can
+        # remove a server Kiro Crew never authored. Its fields must not be
+        # carried into the proxy sidecar and reappear on the proxy entry.
+        path = _mcp_json(home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "their-own-thing": {
+                            "command": "/opt/MeshClaw/bin/meshclaw",
+                            "args": ["something-else"],
+                            "env": {"THEIR_SECRET": "x"},
+                        }
+                    }
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        assert "their-own-thing" in cleanup_mod.clean_stale_managed_mcp()
+        assert not setup_mod._carryover_path().exists()
+
+        register_playwright_proxy()
+        assert "THEIR_SECRET" not in (_read_entry(home) or {}).get("env", {})
+
+
+class TestCarryoverSemantics:
+    """The stash exists only to survive one Browser-Mode round trip."""
+
+    @pytest.fixture()
+    def home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "config_dir", lambda: tmp_path / "crew")
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "get_extension_token", lambda: "tok")
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: True)
+        _seed_pinned_entry(tmp_path)
+        return tmp_path
+
+    def test_token_is_not_copied_into_the_stash(self, home: Path):
+        deregister_playwright_proxy()
+        stash = json.loads(setup_mod._carryover_path().read_text(encoding="utf-8"))
+        assert stash["env"]["KIROCREW_PLAYWRIGHT_CMD"] == _PIN
+        # The token is re-minted per mode; duplicating it to a second file would
+        # spread a credential for no benefit.
+        assert "PLAYWRIGHT_MCP_EXTENSION_TOKEN" not in stash.get("env", {})
+
+    def test_stash_is_consumed_once(self, home: Path):
+        deregister_playwright_proxy()
+        assert setup_mod._carryover_path().exists()
+        register_playwright_proxy()
+        assert not setup_mod._carryover_path().exists()
+
+        # A second OFF/ON with nothing operator-owned must not resurrect the pin.
+        path = _mcp_json(home)
+        data = json.loads(path.read_text(encoding="utf-8"))
+        entry = data["mcpServers"][_CANONICAL]
+        entry.pop("env", None)
+        entry.pop("timeout", None)
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        deregister_playwright_proxy()
+        register_playwright_proxy()
+        assert "KIROCREW_PLAYWRIGHT_CMD" not in (_read_entry(home) or {}).get("env", {})
+
+    def test_user_owned_entry_is_never_stashed(self, home: Path):
+        # deregister leaves a user's own non-proxy server alone, so there is
+        # nothing of theirs to carry and nothing to copy out of their config.
+        path = _mcp_json(home)
+        path.write_text(
+            json.dumps(
+                {"mcpServers": {_CANONICAL: {"command": "their-own", "env": {"SECRET": "x"}}}},
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        deregister_playwright_proxy()
+        assert not setup_mod._carryover_path().exists()
+        assert (_read_entry(home) or {})["command"] == "their-own"

--- a/test/test_browser_setup.py
+++ b/test/test_browser_setup.py
@@ -1140,6 +1140,162 @@ class TestCheckPlaywrightLaunchable:
         assert Path(detail).parent == node_dir
 
 
+class TestOperatorEnvSurvivesReregistration:
+    """A re-registration must not silently drop operator-supplied ``env``.
+
+    ``KIROCREW_PLAYWRIGHT_CMD`` is the documented escape hatch for a host whose
+    launcher is not otherwise discoverable, so an install can depend on it
+    entirely. A mode switch owns command/args/token and must leave it alone.
+    """
+
+    def _entry_with_env(self, tmp_path: Path, env: dict) -> Path:
+        return _write_mcp_json(
+            tmp_path,
+            {
+                _CANONICAL: {
+                    "command": "kirocrew",
+                    "args": ["mcp-playwright-proxy", "--extension"],
+                    "env": env,
+                }
+            },
+        )
+
+    def test_headless_keeps_launcher_override_and_drops_stale_token(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        mcp_json = self._entry_with_env(
+            tmp_path,
+            {"KIROCREW_PLAYWRIGHT_CMD": "/opt/pw/cli.js", "PLAYWRIGHT_MCP_EXTENSION_TOKEN": "old"},
+        )
+
+        register_playwright_proxy()
+
+        env = json.loads(mcp_json.read_text(encoding="utf-8"))["mcpServers"][_CANONICAL]["env"]
+        assert env["KIROCREW_PLAYWRIGHT_CMD"] == "/opt/pw/cli.js"
+        # The token describes extension mode, so headless must not carry it over.
+        assert "PLAYWRIGHT_MCP_EXTENSION_TOKEN" not in env
+
+    def test_extension_keeps_launcher_override_and_refreshes_token(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: True)
+        monkeypatch.setattr(setup_mod, "get_extension_token", lambda: "fresh")
+        mcp_json = self._entry_with_env(
+            tmp_path,
+            {"KIROCREW_PLAYWRIGHT_CMD": "/opt/pw/cli.js", "PLAYWRIGHT_MCP_EXTENSION_TOKEN": "old"},
+        )
+
+        register_playwright_proxy()
+
+        env = json.loads(mcp_json.read_text(encoding="utf-8"))["mcpServers"][_CANONICAL]["env"]
+        assert env["KIROCREW_PLAYWRIGHT_CMD"] == "/opt/pw/cli.js"
+        assert env["PLAYWRIGHT_MCP_EXTENSION_TOKEN"] == "fresh"
+
+    def test_unrelated_operator_fields_survive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A mode switch owns command/args/token and nothing else. Rebuilding the
+        # entry would drop every other key the operator added.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        mcp_json = _write_mcp_json(
+            tmp_path,
+            {
+                _CANONICAL: {
+                    "command": "kirocrew",
+                    "args": ["mcp-playwright-proxy", "--extension"],
+                    "env": {"KIROCREW_PLAYWRIGHT_CMD": "/opt/pw/cli.js"},
+                    "timeout": 60,
+                    "disabled": False,
+                }
+            },
+        )
+
+        register_playwright_proxy()
+
+        entry = json.loads(mcp_json.read_text(encoding="utf-8"))["mcpServers"][_CANONICAL]
+        assert entry["timeout"] == 60
+        assert entry["disabled"] is False
+        assert entry["env"]["KIROCREW_PLAYWRIGHT_CMD"] == "/opt/pw/cli.js"
+        # ...while the mode-owned fields DID change to headless.
+        assert entry["args"][:2] == ["mcp-playwright-proxy", "--config"]
+
+    def test_no_env_key_written_when_nothing_to_carry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        _write_mcp_json(tmp_path, {})
+
+        register_playwright_proxy()
+
+        mcp_json = tmp_path / ".kiro" / "settings" / "mcp.json"
+        entry = json.loads(mcp_json.read_text(encoding="utf-8"))["mcpServers"][_CANONICAL]
+        assert "env" not in entry
+
+
+class TestAgentShadowDetection:
+    """An agent-level server of the same name WINS, so registration must say so."""
+
+    def _agent_spec(self, tmp_path: Path, servers: dict) -> Path:
+        agents = tmp_path / ".kiro" / "agents"
+        agents.mkdir(parents=True, exist_ok=True)
+        spec = agents / "kirocrew.json"
+        spec.write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
+        return spec
+
+    def test_reports_shadowed_when_agent_declares_same_server(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        _write_mcp_json(tmp_path, {})
+        spec = self._agent_spec(tmp_path, {_CANONICAL: {"command": "somewhere-else"}})
+
+        mcp_json, status = register_playwright_proxy()
+
+        assert status == "shadowed-by-agent"
+        # The write still happened; only the report changes.
+        servers = json.loads(mcp_json.read_text(encoding="utf-8"))["mcpServers"]
+        assert "mcp-playwright-proxy" in servers[_CANONICAL]["args"]
+        assert setup_mod.agent_specs_shadowing() == [spec]
+
+    def test_registered_when_agent_declares_unrelated_server(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        _write_mcp_json(tmp_path, {})
+        self._agent_spec(tmp_path, {"other-mcp": {"command": "foo"}})
+
+        _, status = register_playwright_proxy()
+        assert status == "registered"
+
+    def test_malformed_agent_spec_is_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        agents = tmp_path / ".kiro" / "agents"
+        agents.mkdir(parents=True)
+        (agents / "broken.json").write_text("{not json", encoding="utf-8")
+        assert setup_mod.agent_specs_shadowing() == []
+
+
 class TestRegisterPlaywrightProxy:
     def test_creates_mcp_json_and_registers_canonical(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Problem

Three ways an operator's working Playwright config silently stopped working:

1. Re-running `kirocrew browse extension on|off` rebuilt the canonical
   `playwright-mcp` entry in `~/.kiro/settings/mcp.json` from scratch, discarding
   every other key on it — including `env.KIROCREW_PLAYWRIGHT_CMD`, the documented
   launcher pin that on some hosts is the only reason a launcher resolves at all.
2. Turning Browser Mode **off and back on in Settings** deleted the entry and
   recreated it empty, losing the same pin.
3. Registration read **only** `mcp.json`. An agent-level `mcpServers` declaration
   of the same name wins at resolution (`mcp_gateway/rewriter.py`), so such an
   entry shadowed the proxy while the CLI printed `Proxy registered`.

4. **An update** (which runs `kirocrew setup`) purged the entry and recreated it
   empty. `clean_stale_managed_mcp()` removes a server whose command is the dead
   predecessor binary — right to do, the command is unusable — and `cli_setup`
   registers the proxy again 70 lines later, so an operator who migrated from the
   predecessor lost the pin with only a `logger.info` to show for it.

## Why it matters

All three are silent and all three end in "every `browser_*` tool is gone" with a
config that reads as correctly wired. On the host this was found on the pin was
stripped, the npm token had expired, the proxy died at startup, and the CLI still
reported success — the visible symptom was browsing tools vanishing with nothing
to point at.

## Fix (symptom → root cause → change)

- **Pin lost on a mode switch.** Root cause: both patch helpers built a fresh
  `entry` dict and assigned it over the old one, so any key they did not author was
  dropped. Change: `_apply_mode_to_entry()` mutates in place and sets **only** the
  fields a mode owns (`command`, `args`, extension token). The token stays
  mode-owned, so headless clears it rather than carrying a stale one.
- **Pin lost on a Browser-Mode round trip.** Root cause: deregistration must
  delete the entry (availability is the consent gate — the tools have to actually
  disappear), which took the operator's fields with it. Change: deregistration
  stashes the operator-owned fields to `$KIROCREW_HOME/playwright-entry-carryover.json`
  (mode `0600`) and the next registration restores them. The stash is captured only
  from an entry KiroCrew authored, never carries the extension token (re-minted per
  mode; copying it would spread a credential to a second file), and is consumed by
  the restore so it cannot resurrect abandoned config.
- **Pin lost on an update.** Root cause: the stale-MCP purge deletes entries
  without going through the carryover. Change: the purge stashes operator-owned
  fields first, so the registration that follows restores them. The
  `_spec_is_proxy` guard moved *inside* `capture_entry_carryover()` for this:
  the purge matches on command basename alone and can hit a server KiroCrew does
  not own, which must never be copied into the proxy sidecar.

- **Shadowed registration reported as success.** Root cause: no reader of agent
  specs on the registration path. Change: `agent_specs_shadowing()`, a new
  `shadowed-by-agent` status, and all three reporting callers (`browse setup`,
  `browse extension on|off`, `kirocrew setup`) name the offending spec via
  `print_shadow_warning()`.

Deliberately **not** included: a local-disk probe for an installed
`@playwright/mcp` ahead of the `npx` fallback. It was in an earlier revision and
removed after review — deriving a node prefix from `which node` is unsound across
version-manager shims and keg-style prefixes (verified: on a mise shim `.resolve()`
lands on the version manager's own binary and the probe returned `None`), and it
would add a runtime package source that `_resolve_playwright_core_cli()` does not
search, reintroducing the browser-revision mismatch that function exists to
prevent (`"Executable doesn't exist"`). Startup depending on registry auth is a
real design issue that needs its own change.

## Tests

`test/test_browser_config_journeys.py` (new) simulates what an operator actually
does and asserts the pin survives each: extension toggled off→on, **Browser Mode
off→on in Settings**, gateway-restart convergence, and unrelated servers left
alone. The Browser-Mode case is the one that failed before the sidecar. Plus
sidecar semantics: the token is not copied into the stash, the stash is consumed
once and cannot resurrect abandoned config, and a user's own non-proxy entry is
never stashed.

`TestUpdateLifecycle` runs the real `cli_setup` sequence (purge at :313, then
register at :386) against a predecessor-era entry: the dead command is replaced,
the pin and `timeout` survive, a genuine user server is not collateral, and a
user's own server that merely *invokes* the old binary is never stashed. Note the
fixture patches `mcp_cleanup._KIRO_MCP_JSON` directly — that module resolves its
target at import time, so patching `Path.home` alone would let the purge run
against the developer's real `~/.kiro/settings/mcp.json`.

An inventory sweep (`TestEveryPlaywrightSettingSurvives`) then walks every piece
of Playwright state against every write path, so a regression names the setting
and the command rather than "browsing broke": the extension token and the
`browser-engine` selection both survive a mode round trip, engine selection is
honoured by config regeneration (and `channel` stays chromium-only), and
`storageState` is attached only when the file exists.

`test/test_browser_setup.py`: `TestOperatorEnvSurvivesReregistration` (the pin
survives both modes; a stale token does not survive into headless;
`test_unrelated_operator_fields_survive` pins both halves — `timeout`/`disabled`
survive **and** `args` did switch — so it fails if the rebuild returns) and
`TestAgentShadowDetection` (new status, negative control, malformed spec skipped).

## Manual verification

N/A — unit coverage is sufficient. Every defect is config-write behaviour and is
asserted directly against the written `mcp.json`.

## Screenshots

N/A — no user-visible UI change (CLI output only).

## Spec

`docs/system-specs/modules/browser.md` updated in this commit per AGENTS.md: the
four-value registration status contract, the in-place-update rule, and the sidecar
carryover properties.

## Known gap, out of scope

`dashboard/handlers/messaging.py` passes the status string into `mcp_status` and
`website/src/pages/settings/BrowserPanel.tsx` types but never reads it, so the
dashboard Browser toggle still swallows a shadowed registration. That is a frontend
change and is left for a follow-up.

Separately, `playwright-config.json` is regenerated wholesale by
`generate_playwright_config()`, so it has no place for an operator to put a
launch flag — a corporate `--proxy-server` arg does not survive the next
`browse setup`. That file is derived state by design (`repair_playwright_config`
self-heals it at proxy startup), so merging hand edits into it would create
unresolvable drift; the right fix is a real config knob that regeneration reads.
Out of scope here and worth its own change.

