### PR TITLE
fix(chat): dismiss a chat tab without waiting on a peer's transcript

### DIFF
--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1196,14 +1196,28 @@ export const deleteSlot = createAsyncThunk(
     // backend that emits a distinct `slot.surface` keeps "switch to a peer
     // session" pinned to the same nav destination.
     const deletedSurface = deletedSlot ? slotSurfaceKey(deletedSlot) : ''
-    // Navigate before removeSlotOptimistic to prevent useEffect race
+    // Navigate before removeSlotOptimistic to prevent a useEffect race: the
+    // active slot must already name a surviving peer by the time this slot
+    // leaves the list.
+    //
+    // What that ordering constrains is the STATE transitions, not the I/O.
+    // `switchSlot.pending` assigns `activeSlot` synchronously as it is
+    // dispatched, so the invariant above holds from that call — not from the
+    // moment its history fetch resolves. That fetch is unbounded (the peer's
+    // whole transcript, megabytes on a long session), so it is carried as a
+    // promise rather than awaited here: blocking on it would hold the dismissed
+    // tab on screen for the length of an unrelated conversation's load, which
+    // reads as a dead close control. The peer paints from the `slotMessages`
+    // cache when it has one, or from `slotLoading` behind the already-removed
+    // tab when it does not.
+    let navigation: Promise<unknown> | undefined
     if (root.chat.activeSlot === key) {
       const sameSurface = new Set(root.dashboard.slots.filter(s => slotSurfaceKey(s) === deletedSurface).map(s => s.key))
       const prev = root.chat.slotHistory.filter(k => k !== key && sameSurface.has(k)).pop()
         || root.dashboard.slots.filter(s => s.key !== key && sameSurface.has(s.key)).map(s => s.key)[0]
       dispatch({ type: 'chat/setActiveSlot', payload: null })
       if (prev) {
-        await dispatch(switchSlot(prev)).unwrap().catch(() => dispatch({ type: 'chat/clearSlotState' }))
+        navigation = dispatch(switchSlot(prev)).unwrap().catch(() => dispatch({ type: 'chat/clearSlotState' }))
       } else {
         dispatch({ type: 'chat/clearSlotState' })
       }
@@ -1215,6 +1229,15 @@ export const deleteSlot = createAsyncThunk(
     } catch {
       dispatch(fetchSlots())
       throw new Error('save failed')
+    } finally {
+      // Settle the peer navigation before this thunk reports back, on the
+      // failure path too. Callers that await it treat resolution as "the
+      // dismissal is done" and then read the store (an app agent tearing its
+      // session down, the create-first-then-delete mode switch), so resolving
+      // mid-fetch would hand them a half-loaded peer. Rejection is already
+      // absorbed by the `.catch` above, so this cannot throw and cannot mask
+      // the error being propagated.
+      await navigation
     }
     return key
   },

--- a/website/src/test/ChatSliceCoverage.test.tsx
+++ b/website/src/test/ChatSliceCoverage.test.tsx
@@ -1134,6 +1134,60 @@ describe('chatSlice thunks', () => {
     expect(chat(store).activeSlot).toBeNull()
   })
 
+  // The dismissed tab must not wait on an unrelated conversation's transcript.
+  // The peer's history fetch is unbounded, so awaiting it before the removal
+  // pins the close control for as long as that load takes; only the state
+  // transitions are ordered, and `switchSlot.pending` completes those
+  // synchronously.
+  it('removes the dismissed slot before the peer history fetch resolves', async () => {
+    let releasePeer: (v: unknown) => void = () => {}
+    const peerFetch = new Promise(resolve => { releasePeer = resolve })
+    apiMock.chatSlotDetail.mockReturnValue(peerFetch)
+    apiMock.deleteChatSlot.mockResolvedValue({})
+    const store = makeStore()
+    store.dispatch(sseSlots([slotRow('doomed'), slotRow('peer')]))
+    store.dispatch(setActiveSlot('doomed'))
+
+    const pending = store.dispatch(deleteSlot('doomed'))
+    // Let the thunk run up to its first real suspension point.
+    await Promise.resolve()
+
+    // The peer's transcript is still in flight...
+    expect(apiMock.chatSlotDetail).toHaveBeenCalledWith('peer')
+    // ...yet the tab is already gone and focus already moved.
+    expect(root(store).dashboard.slots.map(s => s.key)).not.toContain('doomed')
+    expect(chat(store).activeSlot).toBe('peer')
+
+    releasePeer({ messages: [], running: false })
+    await pending
+    expect(chat(store).activeSlot).toBe('peer')
+  })
+
+  // The thunk still owns the navigation it started: a caller that awaits the
+  // dismissal reads the store afterwards, so resolution must mean the peer
+  // settled, not merely that the DELETE returned.
+  it('does not resolve the dismissal until the peer navigation settles', async () => {
+    let releasePeer: (v: unknown) => void = () => {}
+    const peerFetch = new Promise(resolve => { releasePeer = resolve })
+    apiMock.chatSlotDetail.mockReturnValue(peerFetch)
+    apiMock.deleteChatSlot.mockResolvedValue({})
+    const store = makeStore()
+    store.dispatch(sseSlots([slotRow('doomed'), slotRow('peer')]))
+    store.dispatch(setActiveSlot('doomed'))
+
+    let settled = false
+    const pending = store.dispatch(deleteSlot('doomed')).then(r => { settled = true; return r })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    releasePeer({ messages: [{ role: 'user', content: 'peer history' }], running: false })
+    const outcome = await pending
+    expect(settled).toBe(true)
+    expect(outcome.type).toBe('chat/deleteSlot/fulfilled')
+    expect(chat(store).slotLoading).toBe(false)
+  })
+
   it('evicts every per-slot cache once a delete succeeds', async () => {
     apiMock.chatSlotDetail.mockResolvedValue({ messages: [{ role: 'user', content: 'hi' }], running: false })
     apiMock.deleteChatSlot.mockResolvedValue({})


### PR DESCRIPTION
## Problem

Dismissing the chat you are currently viewing leaves the tab sitting in the sidebar for a noticeable beat — seconds, on a busy workspace — before it disappears. The close control reads as dead: the content pane has already switched to a neighbouring session, but the tab you clicked is still listed.

Dismissing a *background* tab is unaffected and feels instant, which is the tell.

## Why it matters

The delay scales with the size of an unrelated conversation, so it gets worse as a workspace ages and nothing about the user's own action explains it. Measured on a real 13-tab workspace: median open-tab transcript 0.57 MB, but four tabs between 7 MB and 21.25 MB — so roughly one dismissal in three lands on a multi-megabyte neighbour. For the 21.25 MB tab that is ~230 ms of gateway CPU (12 ms read, 126 ms parse, 92 ms re-serialize) plus a 21.26 MB response body, browser-side `JSON.parse`, filter and render before the tab is allowed to go. Over a tunnelled or remote dashboard connection the transfer dominates and the wait is plainly visible.

A close control that does not respond to a click is read as a broken control, not a slow one.

## Fix (symptoms → root cause → change)

**Symptom:** the dismissed tab lingers, but only when it is the active tab.

**Root cause:** `deleteSlot` navigates to a peer session before removing the dismissed slot, and it `await`ed that navigation. The navigation's payload is `fetchSlotDetail`, which deliberately requests the peer's history with **no limit** (`// No limit → backend returns all chained history`), so the removal was gated on loading an entire unrelated conversation off disk and over the wire. The `activeSlot === key` guard is why only the active tab pays it.

The navigate-before-remove order itself is correct and load-bearing — the original comment records that it prevents a `useEffect` race, and the active slot must already name a surviving peer by the time this slot leaves the list.

**Change:** the ordering that invariant needs is between the **state transitions**, not the I/O. `switchSlot.pending` assigns `state.activeSlot` synchronously as the thunk is dispatched — `createAsyncThunk` dispatches `pending` inside the `dispatch()` call, before the payload creator's first `await` — so the invariant holds from the dispatch, not from the fetch resolving. The peer fetch is therefore carried as a `navigation` promise and no longer awaited before `removeSlotOptimistic(key)`.

The order of dispatches is unchanged; only the I/O wait between them is gone. There is now strictly one *fewer* intermediate render than before, because no `await` separates the navigation from the removal.

`navigation` is still awaited in a `finally`, so the thunk resolves only after the peer settles on both the success and the failure path. That preserves the completion contract for the callers that `await` it — the app agents in `auto-improvement` and `issue-radar` tearing a session down, and ChatPage's create-first-then-delete mode switch — which treat resolution as "the dismissal is done" and then read the store. Its `.catch` is attached at creation, so `await navigation` cannot throw and cannot mask the propagating `save failed` error.

Behaviour after the change: the tab goes on click, and the peer paints from the `slotMessages` cache when it has one (the common case when hopping between visited tabs — no network at all) or shows `slotLoading` behind the already-removed tab when it does not.

## Tests

Two tests added to `website/src/test/ChatSliceCoverage.test.tsx`, both against a real store, asserting observable state:

- **`removes the dismissed slot before the peer history fetch resolves`** — holds the peer's `chatSlotDetail` open on a deferred promise and asserts that `dashboard.slots` no longer contains the dismissed key, and `activeSlot` is already the peer, *while that fetch is still in flight*. This is the regression guard: it fails if the `await` is ever restored.
- **`does not resolve the dismissal until the peer navigation settles`** — asserts the thunk has not settled while the peer fetch is pending, then that it fulfils once released. This guards the opposite over-correction: dropping `await navigation` and resolving early.

Both proven non-vacuous by mutation:

| Mutation | Result |
|---|---|
| restore `await` before the removal | test 1 fails: `expected [ 'doomed', 'peer' ] to not include 'doomed'` |
| `await navigation` → `void navigation` | test 2 fails: `expected true to be false` |

Gates run locally: `tsc -b`, `eslint` on both changed files, diff-scoped brand-name gate, and the targeted vitest files — all clean on the current head. An earlier full-suite run on this diff was green at **17195 passed**, 2 expected-fail, 3 skipped.

An earlier revision of this PR showed `Frontend Tests (2)` red along with `Frontend Coverage Merge` and `Coverage Gate` downstream of it. That was **not** from this diff: it was the stale `LocalStorageDebugCoverage` tooltip assertion broken by the copy rewording in #2882, since fixed on `main` by #3112 (which resolves the tooltip through i18n). This branch is rebased onto that fix, and the previously-failing file passes locally here.

One further note from the earlier full-suite run, also not from this diff: a single unhandled error from a 2.5 s toast timer in `src/apps/crew-companion/GalleryPanel.tsx:1080` calling `setToast` after jsdom tore its environment down, originating in `CrewCompanionGallery.coverage.test.tsx`. Neither file is touched here, and it did not reproduce when that file was run alone or paired sequentially on clean `main`, so it appears load-dependent rather than deterministic. Flagging it rather than claiming a clean run.

## Manual verification

Not yet performed. The change is a timing change to an existing removal, so a still frame cannot show it; a before/after screen recording against a pod seeded with multi-megabyte transcripts is the evidence that would, and I can capture one if a reviewer wants it. Unit coverage pins both directions of the behaviour (the removal ordering and the completion contract), and the reasoning about `switchSlot.pending`'s synchronous dispatch is verified against the reducer rather than assumed.

no issue closed: reported directly by the maintainer in chat; no tracked issue exists for it.
