### PR TITLE
perf(memory): build the lesson cosine scorer once per query, not per row

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -496,6 +496,8 @@ User-taught corrections ("always do X", "never do Y"). Single write path through
 
 Categories: `tool`, `preference`, `knowledge`. Injected as a `[Learned corrections]` block. The vector path ranks lessons by hybrid relevance to the incoming request and fills the caller's character budget, stating in the block how many of the stored lessons are shown and how many are omitted; the JSONL path caps at `_MAX_LESSONS_IN_CONTEXT = 50`. The JSONL store itself retains `_MAX_LESSONS_TOTAL = 200` and prunes oldest-first beyond that, so what reaches the context and what sits on disk are different numbers.
 
+Vector scoring builds one scorer per query (`_stored_similarity_scorer`) so the query vector and its norm are derived once instead of once per lesson — the same hoisting `_sqlite_vector_search` does for episodic rows. There is a numpy path and a stdlib fallback, because numpy is guarded by `_HAS_NUMPY`; both produce the same ranking. Stored lesson vectors are un-normalized (unlike episodic vectors, which are L2-normalized for FAISS inner-product scoring), so both norms are divided out per row rather than assuming unit length. A row whose vector has a different dimensionality than the query — a row written under a previous embedding model — is incomparable and scores 0.0, matching `_sqlite_vector_search` and `HybridRetriever._cosine_similarity`, rather than being truncated against the query's leading elements.
+
 ### Conflict resolution: which layer wins
 
 Priority, highest first. A lower layer never overrides a higher one:

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -2370,6 +2370,7 @@ class VectorMemoryStore:
         """
         query_words = _stem_words(set(re.findall(r"\w+", query_text.lower())))
         query_emb = self._try_embed(query_text) if self.embed_fn else None
+        similarity = self._stored_similarity_scorer(query_emb)
         scored: list[tuple[float, tuple[dict, str]]] = []
         for entry in entries:
             row, text = entry
@@ -2377,23 +2378,70 @@ class VectorMemoryStore:
             # ``lesson.<md5hash>``, which carries no words, so there is no key
             # term to weight here the way get_semantic_context() weights its own.
             overlap = len(query_words & _stem_words(set(re.findall(r"\w+", text.lower()))))
-            score = _hybrid_score(
-                _keyword_score(overlap), self._stored_similarity(row, query_emb)
-            )
+            score = _hybrid_score(_keyword_score(overlap), similarity(row))
             scored.append((score, entry))
         scored.sort(key=lambda pair: -pair[0])
         return [entry for _, entry in scored]
 
-    def _stored_similarity(self, entry: dict, query_emb: list[float] | None) -> float:
-        """Cosine similarity between *query_emb* and a row's stored embedding."""
-        blob = entry.get("embedding")
-        if query_emb is None or not isinstance(blob, bytes) or len(blob) < 4:
-            return 0.0
-        try:
-            stored = struct.unpack(f"{len(blob) // 4}f", blob)
-        except struct.error:
-            return 0.0
-        return max(0.0, self._cosine_sim(query_emb, list(stored)))
+    @staticmethod
+    def _stored_similarity_scorer(
+        query_emb: list[float] | None,
+    ) -> Callable[[dict], float]:
+        """Build a cosine scorer for one query, with query-side work done once.
+
+        The query vector and its norm are the same for every row, so deriving
+        them per row repeats a full pass over the query once per lesson. Hoisting
+        them out of the loop is where nearly all of the saving is — vectorizing
+        the dot product while still converting the query inside the loop keeps
+        most of the original cost. ``_sqlite_vector_search`` already normalizes
+        its query once for the same reason; this is the lesson-path equivalent.
+
+        Stored lesson vectors are un-normalized by contract (see
+        ``backfill_lesson_embeddings``), so the row norm stays inside the loop
+        and both norms are divided out. A bare inner product would be correct
+        only while the embedding model happens to emit unit vectors, which
+        nothing enforces.
+
+        A row whose vector has a different dimensionality is incomparable and
+        scores 0.0 rather than being truncated against the query, matching
+        ``_sqlite_vector_search`` and ``HybridRetriever._cosine_similarity``.
+        """
+        if not query_emb:
+            return lambda row: 0.0
+        q_len = len(query_emb)
+        q_bytes = q_len * 4
+
+        if _HAS_NUMPY:
+            q_vec = np.asarray(query_emb, dtype=np.float32)
+            q_norm = float(np.linalg.norm(q_vec))
+            if not q_norm:
+                return lambda row: 0.0
+
+            def numpy_scorer(row: dict) -> float:
+                blob = row.get("embedding")
+                if not isinstance(blob, bytes) or len(blob) != q_bytes:
+                    return 0.0
+                vec = np.frombuffer(blob, dtype=np.float32)
+                denom = float(np.linalg.norm(vec)) * q_norm
+                return max(0.0, float(vec @ q_vec) / denom) if denom else 0.0
+
+            return numpy_scorer
+
+        q_norm_py = math.sqrt(sum(x * x for x in query_emb))
+        if not q_norm_py:
+            return lambda row: 0.0
+
+        def stdlib_scorer(row: dict) -> float:
+            blob = row.get("embedding")
+            if not isinstance(blob, bytes) or len(blob) != q_bytes:
+                return 0.0
+            vec = struct.unpack(f"{q_len}f", blob)
+            denom = math.sqrt(sum(y * y for y in vec)) * q_norm_py
+            if not denom:
+                return 0.0
+            return max(0.0, sum(x * y for x, y in zip(query_emb, vec)) / denom)
+
+        return stdlib_scorer
 
     # ── Migration & Import ──
 

--- a/test/test_lesson_ranking.py
+++ b/test/test_lesson_ranking.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import struct
 from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
+from kiro_crew import vector_memory
 from kiro_crew.vector_memory import VectorMemoryStore
 
 # Deliberately share no significant words, so write_lesson's topic-overlap
@@ -156,6 +158,96 @@ class TestVectorScoring:
         block = store.get_lessons_context(query_text="database migration deploying")
 
         assert shown(block)[0] == MIGRATION
+
+
+class TestStoredVectorComparability:
+    """The per-query scorer must not let a row win on shape or magnitude."""
+
+    def test_mismatched_dimension_vector_cannot_win_by_truncation(
+        self, store: VectorMemoryStore
+    ) -> None:
+        """A vector of another dimensionality is incomparable, not a match.
+
+        Rows written under a previous embedding model keep that model's
+        dimensionality. Comparing one against a query from the current model used
+        to score only the leading elements while each norm still used its own
+        full vector, so the shorter row could reach a perfect 1.0 and outrank the
+        row that genuinely matches.
+
+        The blob is rewritten directly because that is the only way the mismatch
+        arises: ``write_lesson`` embeds every row with whatever ``embed_fn`` is
+        bound at the time, and handing it a short vector up front instead trips
+        the dedup comparison — which truncates the same way — so the row is
+        treated as a duplicate and never stored at all.
+        """
+        probe = "unrelated probe phrasing"
+        vectors = {
+            TABS: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            MIGRATION: [1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+            probe: [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        }
+        store.embed_fn = lambda text: vectors.get(text, [0.0] * 8)
+        store.write_lesson(TABS)
+        store.write_lesson(MIGRATION)
+        # Leave TABS in a 4-dimensional space. Truncated against the query's
+        # first four elements it scores 1.0; compared honestly it is unrelated.
+        stale = struct.pack("4f", 1.0, 1.0, 1.0, 1.0)
+        key = next(row["key"] for row in store.get_lessons() if TABS in row["value_json"])
+        store.db.execute(
+            "UPDATE semantic_memory SET embedding = ? WHERE key = ?", (stale, key)
+        )
+        store.db.commit()
+
+        block = store.get_lessons_context(query_text=probe)
+
+        assert shown(block) == [MIGRATION, TABS], (
+            "a row embedded in another dimensionality was scored as a match"
+        )
+
+    def test_row_vector_magnitude_does_not_decide_ranking(
+        self, store: VectorMemoryStore
+    ) -> None:
+        """Stored vectors are un-normalized, so both norms must be divided out.
+
+        A plain inner product would rank the long, badly-aligned vector above the
+        short, perfectly-aligned one.
+        """
+        probe = "unrelated probe phrasing"
+        vectors = {
+            MIGRATION: [1.0, 0.0, 0.0],  # unit length, points at the query
+            TABS: [3.0, 4.0, 0.0],  # length 5, only 0.6 cosine
+            probe: [1.0, 0.0, 0.0],
+        }
+        store.embed_fn = lambda text: vectors.get(text, [0.0, 0.0, 1.0])
+        store.write_lesson(MIGRATION)
+        store.write_lesson(TABS)
+
+        block = store.get_lessons_context(query_text=probe)
+
+        assert shown(block)[0] == MIGRATION, "a longer vector outranked a better-aligned one"
+
+    def test_ranking_is_identical_without_numpy(
+        self, store: VectorMemoryStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """numpy is an optional dependency, so the stdlib path must agree with it."""
+        probe = "unrelated probe phrasing"
+        vectors = {
+            TABS: [0.9, 0.1, 0.2],
+            MIGRATION: [0.2, 0.9, 0.1],
+            FORCE_PUSH: [0.4, 0.4, 0.5],
+            DIGEST: [0.1, 0.2, 0.9],
+            probe: [0.7, 0.5, 0.3],
+        }
+        store.embed_fn = lambda text: vectors.get(text, [0.0, 0.0, 0.0])
+        for rule in (TABS, MIGRATION, FORCE_PUSH, DIGEST):
+            store.write_lesson(rule)
+
+        with_numpy = shown(store.get_lessons_context(query_text=probe))
+        monkeypatch.setattr(vector_memory, "_HAS_NUMPY", False)
+        without_numpy = shown(store.get_lessons_context(query_text=probe))
+
+        assert without_numpy == with_numpy
+        assert len(with_numpy) == 4
 
 
 class TestImportedLessonShapes:


### PR DESCRIPTION
## Problem / Motivation

Lesson ranking scores every stored lesson against the incoming request on each
session build. It does that through `_cosine_sim`, which for **each row**:

1. recomputes `norm_a` — the *query's* own norm, identical on every iteration;
2. materializes the stored blob as a Python list (`list(struct.unpack(...))`);
3. sums three full-length generator expressions (dot, `norm_a`, `norm_b`).

Until recently this was overshadowed by the keyword pass. #2944 memoized the
per-word stem and removed that cost, which left the cosine as the dominant cost
of the scoring pass. Unlike stemming, it has no cache to warm — it is recomputed
arithmetic, so it costs the same on the thousandth session as on the first.

Measurements, and the reasoning that the cosine was *not* worth fixing before
#2944 landed, are in #3103.

## Why it matters

The work sits on the session-open path, before the first token is generated, so
it is latency a user waits through rather than background cost. It scales with
the store, and the store only ever appends — so this is the component that
quietly gets worse the longer someone uses the product, which is exactly the
shape of the problem #2944 addressed on the other half of the same loop.

There is also a correctness half, below, which is not a performance concern at
all: today a row embedded in a different dimensionality can be scored as a
perfect match.

## What changed (motivation → approach → change)

**Goal:** stop paying per-row for work that depends only on the query.

**Approach.** Build the scorer once per query (`_stored_similarity_scorer`)
instead of calling a static helper per row. The query vector and its norm are
derived up front; per-row work drops to one buffer view and one dot product.
This is not a new idea in this module — `_sqlite_vector_search` already
normalizes its query once outside its own row loop. The lesson path was the
outlier that did not.

Three decisions worth stating, because each rules out a simpler-looking change:

- **numpy is used but not required.** It is a declared dependency and already
  imported here, but it is guarded by `_HAS_NUMPY` and several paths in this
  module deliberately degrade without it, so a numpy-only implementation would
  regress those installs from working to broken. The stdlib path is kept, and
  it also gets faster, because hoisting the query norm helps it too.
- **Both norms stay divided out.** Lesson vectors are stored *un-normalized* on
  purpose — the backfill says so explicitly: "Stored un-normalized to match
  `write_lesson()`: `_cosine_sim()` normalizes both operands itself." (The
  L2-normalization elsewhere in this module belongs to the episodic/FAISS path,
  which scores inner product and so needs unit vectors.) A plain inner product
  would be correct only while the embedding model happens to emit unit vectors,
  which nothing enforces — a silent, model-dependent ranking corruption.
- **Scope is the lesson path only.** `_stored_similarity` had exactly one caller,
  `_rank_lessons`. `_cosine_sim` keeps its four other callers untouched, so
  semantic-memory retrieval and the lesson dedup/contradiction checks are
  unaffected by this PR.

**Correctness change, forced by the above.** A row whose vector has a different
dimensionality than the query is now incomparable and scores `0.0`. Previously
`zip()` truncation scored it against the query's leading elements while each norm
still used its own full vector, so a shorter row could reach a perfect `1.0` and
outrank the row that genuinely matched. Vectorizing forces the question, because
a dimension mismatch raises rather than truncating quietly — and the answer is
already settled twice in this tree, both times as `0.0`:

- `_sqlite_vector_search`, in this same file: `if n_floats != q_len: continue`
- `HybridRetriever._cosine_similarity`, whose docstring says it "mirrors the
  length guard already enforced in `vector_memory.py`" and which has a dedicated
  regression test for it

So this aligns the remaining outlier rather than inventing a rule. It becomes
reachable whenever the embedding model or its dimensionality changes with rows
already in the store.

**Docs.** `docs/system-specs/modules/memory-skills-hooks.md` is the owning module
doc and is updated in this same commit.

## Tests

Three tests in `test/test_lesson_ranking.py`, under `TestStoredVectorComparability`:

- `test_mismatched_dimension_vector_cannot_win_by_truncation` — the regression
  test for the behavior change. A row left in a 4-dimensional space is set up so
  truncation against an 8-dimensional query scores it a perfect `1.0`, ahead of
  the row that genuinely matches. **Verified to fail on `main`** with the
  intended assertion, and to pass with this change.
- `test_row_vector_magnitude_does_not_decide_ranking` — a long, badly-aligned
  vector must not outrank a short, well-aligned one. This makes the
  un-normalized-storage constraint executable, so the "just use a bare dot
  product" variant cannot be reintroduced silently.
- `test_ranking_is_identical_without_numpy` — patches `_HAS_NUMPY` off and
  asserts the ranking is unchanged, so the stdlib fallback cannot rot unnoticed.

The second and third pass on `main` as well, by construction — they pin
constraints rather than the behavior change. Only the first is a regression test
for this diff, and it is the one verified red before / green after.

Note on the first test's setup: it rewrites the stored blob directly rather than
handing `write_lesson` a short vector. That is deliberate and not a shortcut —
`write_lesson` embeds every row with whatever `embed_fn` is bound at the time, and
the dedup comparison truncates the same way, so a short vector supplied up front
is treated as a duplicate and the row is never stored at all. An earlier version
of this test did exactly that and passed against unfixed code for that reason.

## Manual verification

N/A for UI. The numeric claims were verified against a real lesson store rather
than only synthetic fixtures, because float equivalence and ranking stability are
what could silently break:

- Output matches the previous implementation to within float32 rounding on the
  numpy path and **exactly** on the stdlib path; the two agree with each other.
- The resulting ranking order is identical for every row.
- Still exact when stored vectors are deliberately scaled so they are no longer
  unit-length, whereas a bare inner product diverges by whole similarity points
  under the same test — which is what ruled that variant out.

Gates run locally: `pytest` over the memory/lessons/context surface (48 files),
`isort`, `flake8`, `mypy` (893 files), scrub-lint, docs-lint, and the diff-scoped
brand gate. The pre-existing failures in that run reproduce identically on a
pristine `origin/main` worktree and are unrelated local-environment artifacts.

## Related Issues

Fixes #3103

Follows #2944, which fixed the other half of the same loop and is what made this
component worth addressing.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Placeholder per the template — the CLA wording is to be supplied by OSPO and has
not been invented here. Happy to sign whatever lands.
