### PR TITLE
fix(test): resolve orphan-cache tooltip via i18n, unbreaking frontend shard 2

### DIFF
--- a/website/src/test/LocalStorageDebugCoverage.test.tsx
+++ b/website/src/test/LocalStorageDebugCoverage.test.tsx
@@ -28,6 +28,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, within } from '@testing-library/react'
 
 import LocalStorageDebug from '../pages/LocalStorageDebug'
+import { i18nT } from '../i18n/t'
+
+// Resolve the button's tooltip through the SAME lookup the component uses, rather
+// than repeating its English wording here. The literal this test used to match
+// ("Delete cached scroll positions") stopped existing when the copy was rewritten
+// to "Delete cached row heights and saved reading positions ...", which turned a
+// pure copy edit into a red shard. Going through the catalog means a reworded
+// string can never break this test, while a MISSING key still will -- which is
+// the failure actually worth catching.
+const ORPHAN_TITLE = i18nT(
+  'pages.localStorageDebug.delete_cached_scroll_positions_from_old_sessions',
+)
 
 /** Approximate quota the page assumes (5 MiB). */
 const QUOTA = 5 * 1024 * 1024
@@ -241,7 +253,7 @@ describe('LocalStorageDebug actions', () => {
 
     render(<LocalStorageDebug />)
 
-    fireEvent.click(screen.getByTitle(/Delete cached scroll positions/))
+    fireEvent.click(screen.getByTitle(ORPHAN_TITLE))
 
     expect(localStorage.getItem('vc_heights_a')).toBeNull()
     expect(localStorage.getItem('vc_heights_b')).toBeNull()


### PR DESCRIPTION
## What

`LocalStorageDebugCoverage.test.tsx` is failing on **main**, which reds frontend
shard 2 for every open PR. One line fixes it: the test now resolves the button's
tooltip through the same `i18nT` lookup the component uses instead of repeating
its English wording.

## Why it broke

The test queried a hardcoded literal:

```ts
screen.getByTitle(/Delete cached scroll positions/)
```

The copy has since been rewritten. The catalog value is now:

> Delete cached row heights and saved reading positions from old sessions (safe — rebuilt as you scroll)

The old substring no longer occurs, so `getByTitle` matched nothing. **The
product is fine** — this was a pure copy improvement, and my test turned it into
a CI failure. The test was wrong, not the rename.

## Why it looked like something else

Worth recording, because the surface symptoms pointed three different wrong
directions:

- Shard 2's log is full of `DOMException [NotSupportedError]: Failed to load
  script .../vendor/tailwindcss-browser.js` and `ECONNREFUSED 127.0.0.1:6776`.
  Both are **harmless noise** — that file exits 0 on its own.
- CI runs the shards with `--reporter=blob`, which prints **no summary**, so the
  failing test name never appears in the job log at all. The only way to see it
  was to reproduce `--shard=2/4` locally with a normal reporter.
- Because `Coverage Gate` and `PR Readiness` fail closed on an upstream frontend
  failure, one broken test presents as **four** red checks, which reads like a
  much bigger problem than it is.

## Verification

- the file alone: **exit 0**
- full `--shard=2/4`: **259 files / 3,680 tests pass, exit 0** (was 1 failed)
- `tsc --noEmit`: exit 0 · `eslint src/ --max-warnings 1116`: exit 0 · brand gate
  with `BRAND_BASE_REF=origin/main`: exit 0

## Latent risk this does not fix

Nine other `*Coverage.test.tsx` queries still match hardcoded English titles
(`ArtifactDetailPageCoverage`, `AppRootCoverage`, and others). They pass only
because their copy has not been rewritten yet, and each one will fail the same
way the moment it is — the i18n pass is actively moving through these pages.
Deliberately **not** touched here: they are not broken today and sweeping a
dozen unrelated files into a red-CI fix would make this un-reviewable. Worth a
follow-up that converts them, and ideally a lint rule against hardcoded
user-facing literals in `getByTitle` / `getByText`.
