### PR TITLE
fix(mochi): keep Mochi interactions from resurfacing the dashboard

### DIFF
--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -3202,7 +3202,7 @@ app.whenReady().then(async () => {
   // be answering before we ask it whether Mochi is on, and the pet page is
   // loaded from the gateway origin. Best-effort -- a failure here must never
   // block the dashboard, so everything is inside a catch that only logs.
-  initMochi({ backendUrl: BACKEND_URL, fetchLocalToken, glog });
+  initMochi({ backendUrl: BACKEND_URL, fetchLocalToken, glog, getMainWindow: () => mainWindow });
   // Same shape and the same best-effort contract: the companion's windows follow
   // the app's enabled state, and a failure here must never block the dashboard.
   try {

--- a/website/electron/mochi/index.js
+++ b/website/electron/mochi/index.js
@@ -1185,6 +1185,11 @@ function initMochi(deps) {
   BACKEND_URL = deps.backendUrl;
   fetchLocalToken = deps.fetchLocalToken;
   glog = deps.glog;
+  try {
+    require("./panelWindow").setMainWindowGetter(deps.getMainWindow);
+  } catch {
+    /* module shape changed */
+  }
   startMochiWatcher();
 }
 

--- a/website/electron/mochi/panelWindow.js
+++ b/website/electron/mochi/panelWindow.js
@@ -26,6 +26,59 @@ const path = require("path");
 const fs = require("fs");
 const { mochiPageUrl } = require("./pageUrl");
 
+// Returns the dashboard main window (a BaseWindow owned by main.js) or null.
+// Wired at init via setMainWindowGetter so the panel-close path can keep the
+// dashboard from being surfaced by macOS window promotion (see mochi-panel:close).
+let getMainWindow = null;
+function setMainWindowGetter(fn) {
+  getMainWindow = typeof fn === "function" ? fn : null;
+}
+
+// macOS only. A mouse click on the panel's own X makes this non-activating
+// panel the app's key window; hiding a key window makes macOS promote the app's
+// next FOCUSABLE regular window (the dashboard) to key and bring the app
+// forward -- resurfacing a dashboard the user had left behind another app. The
+// pet overlay never triggers this because it is setFocusable(false), so it is
+// never a promotion target; the pet-click and hotkey hides likewise don't,
+// because their gesture doesn't land in the panel. Mirror the pet: make the
+// dashboard briefly non-focusable across the hide so macOS finds no window to
+// promote and returns activation to the previously-active app, then restore
+// focusability so the user can click the dashboard again. No-op unless the
+// dashboard exists and is not itself the focused window.
+function hidePanelReleasingFocus() {
+  if (!panelWindow || panelWindow.isDestroyed()) return;
+  let mw = null;
+  try {
+    mw = process.platform === "darwin" && getMainWindow ? getMainWindow() : null;
+  } catch {
+    mw = null;
+  }
+  const shield =
+    mw &&
+    !mw.isDestroyed() &&
+    typeof mw.isFocusable === "function" &&
+    mw.isFocusable() &&
+    !mw.isFocused();
+  if (shield) {
+    try {
+      mw.setFocusable(false);
+    } catch {
+      /* BaseWindow shape changed */
+    }
+  }
+  panelWindow.hide();
+  if (shield) {
+    // Restore after the window-server settles (empirically stable by ~250ms).
+    setTimeout(() => {
+      try {
+        if (!mw.isDestroyed()) mw.setFocusable(true);
+      } catch {
+        /* torn down */
+      }
+    }, 300);
+  }
+}
+
 /** Original defaults (chatWindowManager.ts:16). */
 const PANEL_W = 320;
 const PANEL_H = 470;
@@ -257,7 +310,7 @@ function createPanelWindow(baseUrl, token = "") {
   win.on("close", (e) => {
     if (isQuitting) return;
     e.preventDefault();
-    win.hide();
+    hidePanelReleasingFocus();
     wasVisibleBeforeHide = false;
   });
 
@@ -355,7 +408,7 @@ function openPanelWindow(baseUrl, token = "") {
  */
 function togglePanelWindow(baseUrl, token = "") {
   if (panelWindow && !panelWindow.isDestroyed() && panelWindow.isVisible()) {
-    panelWindow.hide();
+    hidePanelReleasingFocus();
     return null;
   }
   return openPanelWindow(baseUrl, token);
@@ -382,7 +435,7 @@ function hidePanelWindow() {
     !isRendererGone(panelWindow) &&
     panelWindow.isVisible()
   ) {
-    panelWindow.hide();
+    hidePanelReleasingFocus();
     return true;
   }
   return false;
@@ -527,7 +580,7 @@ function bindPanelIpc(baseUrl) {
     if (/^https?:/.test(currentBaseUrl)) shell.openExternal(currentBaseUrl);
   });
   ipcMain.on("mochi-panel:close", () => {
-    if (panelWindow && !panelWindow.isDestroyed()) panelWindow.hide();
+    hidePanelReleasingFocus();
   });
 
   /**
@@ -594,6 +647,7 @@ module.exports = {
   clampPanelWidth,
   panelLeftForWidth,
   setPanelLogger,
+  setMainWindowGetter,
   hidePanelWindow,
   PANEL_W,
   PANEL_H,

--- a/website/electron/mochi/petOverlays.js
+++ b/website/electron/mochi/petOverlays.js
@@ -555,6 +555,18 @@ function createOverlayForDisplay(display) {
     y: display.bounds.y,
     width: display.bounds.width,
     height: display.bounds.height,
+    // A NON-ACTIVATING panel, macOS only (NSWindowStyleMaskNonactivatingPanel).
+    // Without it, a click on the pet activates the app, and the shell's
+    // app.on("activate") pulls a deliberately-hidden dashboard back up -- the
+    // user petted the cat and the whole app resurfaced. It also removes the
+    // knock-on where closing the chat panel revealed the dashboard: that only
+    // happened because the app had already been activated by the pet click, so
+    // hiding the panel handed key status to the dashboard window.
+    //
+    // Gated on darwin because `type` values are per-platform: "panel" is not
+    // one of Linux's (desktop/dock/toolbar/splash/notification) nor Windows'
+    // (toolbar) legal values, so passing it there would be rejected.
+    ...(process.platform === "darwin" ? { type: "panel" } : {}),
     frame: false,
     transparent: true,
     alwaysOnTop: true,

--- a/website/electron/mochi/test/panelWindow.test.js
+++ b/website/electron/mochi/test/panelWindow.test.js
@@ -524,3 +524,62 @@ test("panelLeftForWidth pulls a growing panel back inside the work area", () => 
   // Non-zero work-area origin (secondary display / menu bar offsets).
   assert.strictEqual(mod.panelLeftForWidth(1500, 600, { x: 1000, y: 0, width: 1000, height: 900 }), 1400);
 });
+
+test("closing the panel shields the dashboard from macOS window promotion (darwin)", (t) => {
+  // Force darwin so the guard runs regardless of the CI runner's OS.
+  const origPlatform = process.platform;
+  Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+  t.after(() => Object.defineProperty(process, "platform", { value: origPlatform, configurable: true }));
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const { mod, ipcHandlers } = loadModule();
+
+  // Stand-in dashboard BaseWindow: visible but behind another app (not focused),
+  // and focusable -- exactly the state where hiding the key panel would let
+  // macOS promote it to the front.
+  const calls = [];
+  const fakeMain = {
+    destroyed: false,
+    focusable: true,
+    focused: false,
+    isDestroyed() { return this.destroyed; },
+    isFocusable() { return this.focusable; },
+    isFocused() { return this.focused; },
+    setFocusable(v) { this.focusable = v; calls.push(v); },
+  };
+  mod.setMainWindowGetter(() => fakeMain);
+  mod.bindPanelIpc(BASE);
+  mod.openPanelWindow(BASE);
+
+  // The X button's IPC. It must make the dashboard non-focusable BEFORE the
+  // hide (so there is nothing for macOS to promote), then restore it.
+  ipcHandlers["mochi-panel:close"]();
+  assert.deepStrictEqual(calls, [false], "dashboard made non-focusable across the hide");
+
+  t.mock.timers.tick(300);
+  assert.deepStrictEqual(calls, [false, true], "dashboard focusability restored after the settle delay");
+});
+
+test("closing the panel does NOT touch a dashboard that is itself focused", (t) => {
+  const origPlatform = process.platform;
+  Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+  t.after(() => Object.defineProperty(process, "platform", { value: origPlatform, configurable: true }));
+
+  const { mod, ipcHandlers } = loadModule();
+  const calls = [];
+  const fakeMain = {
+    destroyed: false,
+    focusable: true,
+    focused: true, // dashboard is frontmost -- leave it alone
+    isDestroyed() { return this.destroyed; },
+    isFocusable() { return this.focusable; },
+    isFocused() { return this.focused; },
+    setFocusable(v) { this.focusable = v; calls.push(v); },
+  };
+  mod.setMainWindowGetter(() => fakeMain);
+  mod.bindPanelIpc(BASE);
+  mod.openPanelWindow(BASE);
+
+  ipcHandlers["mochi-panel:close"]();
+  assert.deepStrictEqual(calls, [], "a focused dashboard is never de-focused");
+});

--- a/website/electron/mochi/test/petOverlays.test.js
+++ b/website/electron/mochi/test/petOverlays.test.js
@@ -1,5 +1,7 @@
 const { test } = require("node:test");
 const assert = require("node:assert");
+const path = require("path");
+const Module = require("module");
 const {
   _inRect,
   isPetWindowOpen,
@@ -142,5 +144,95 @@ test("a stale closed handler does not evict the replacement overlay", () => {
     assert.equal(_getOverlays().get(DID), newWin, "replacement must survive a stale close");
   } finally {
     _getOverlays().delete(DID);
+  }
+});
+
+// The overlay covers a whole display and, when its hitbox says so, receives
+// real clicks. A click on a NORMAL window activates the app, and the shell's
+// app.on("activate") re-shows a deliberately-hidden dashboard -- so petting the
+// cat would resurface the whole app. NSWindowStyleMaskNonactivatingPanel
+// (type: "panel") is the fix, and dropping it regresses that SILENTLY, so the
+// shipped BrowserWindow option is what this pins.
+function stubElectronForOpen() {
+  const created = [];
+  class FakeWebContents {
+    on() {}
+    send() {}
+    isDestroyed() { return false; }
+    isLoading() { return true; }
+    setWindowOpenHandler() {}
+  }
+  class FakeWindow {
+    constructor(opts) {
+      this.opts = opts;
+      this.webContents = new FakeWebContents();
+      created.push(this);
+    }
+    setFocusable() {}
+    setAcceptFirstMouse() {}
+    setIgnoreMouseEvents() {}
+    setVisibleOnAllWorkspaces() {}
+    setAlwaysOnTop() {}
+    loadURL() {}
+    isVisible() { return false; }
+    isDestroyed() { return false; }
+    showInactive() {}
+    close() {}
+    on() {}
+  }
+  const DISPLAY = { id: 1, bounds: { x: 0, y: 0, width: 1440, height: 900 } };
+  return {
+    created,
+    electron: {
+      app: { on() {}, setActivationPolicy() {}, dock: { show() {} } },
+      BrowserWindow: FakeWindow,
+      ipcMain: { on() {}, handle() {} },
+      shell: { openExternal() {}, showItemInFolder() {} },
+      screen: {
+        getPrimaryDisplay: () => DISPLAY,
+        getAllDisplays: () => [DISPLAY],
+        getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+        on() {},
+      },
+    },
+  };
+}
+
+function loadPetOverlays() {
+  const stub = stubElectronForOpen();
+  const modPath = path.join(__dirname, "..", "petOverlays.js");
+  const panelPath = path.join(__dirname, "..", "panelWindow.js");
+  delete require.cache[require.resolve(modPath)];
+  delete require.cache[require.resolve(panelPath)]; // bindIpc requires it fresh
+  const origLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (request === "electron") return stub.electron;
+    return origLoad(request, parent, isMain);
+  };
+  try {
+    // petOverlays requires ./panelWindow LAZILY (inside openPetWindow). Load it
+    // now, while the stub is active, so it caches with the fake electron rather
+    // than resolving the real one after the override is torn down.
+    require(panelPath);
+    return { mod: require(modPath), ...stub };
+  } finally {
+    Module._load = origLoad;
+  }
+}
+
+test("the pet overlay is a non-activating panel on macOS only", () => {
+  const { mod, created } = loadPetOverlays();
+  try {
+    mod.openPetWindow("http://localhost:6777", "tok");
+    assert.strictEqual(created.length, 1, "one overlay for the single display");
+    const { type } = created[0].opts;
+    if (process.platform === "darwin") {
+      assert.strictEqual(type, "panel");
+    } else {
+      // "panel" is not a legal `type` off macOS; the option must be omitted.
+      assert.strictEqual(type, undefined);
+    }
+  } finally {
+    mod.closePetWindow();
   }
 });


### PR DESCRIPTION
## What

On macOS, two Mochi interactions could pull a deliberately hidden dashboard back to the front:

1. **Clicking the pet** activated the whole app.
2. **Closing the chat panel** (X button) surfaced the dashboard even when it sat behind another app.

## Why

- The pet overlay was a plain `BrowserWindow`. A click activated the app, and the shell's `app.on("activate")` shows `mainWindow` — so petting the cat resurfaced a dashboard the user had hidden.
- The chat panel is a non-activating panel, but a mouse-down **inside** it still makes it the app's key window. Hiding a key window makes macOS promote the app's next focusable regular window (the dashboard `BaseWindow`) and bring the app forward. `app.on("activate")` never fires here — it is pure window-server key promotion, which is why `blur()` alone did not help (key just transfers to the dashboard).

## Fix

- Pet overlay gets `type: "panel"` (NSWindowStyleMaskNonactivatingPanel) on macOS, matching the chat panel, so clicking the cat no longer activates the app.
- Every panel hide (X button, pet toggle, hotkey, Cmd-W) goes through `hidePanelReleasingFocus()`: on macOS, when the dashboard exists, is focusable, and is not itself focused, it makes the dashboard non-focusable across the `hide()` so the window server has no window to promote, then restores focusability after the compositor settles. This mirrors why the non-focusable pet overlay never triggered the promotion, and also removes a rare double-click-cat activation race.

## Testing

- 868 electron unit tests pass (`cd website/electron && npm test`).
- New regression tests: the pet overlay is a non-activating panel on macOS; closing the panel shields the dashboard (`setFocusable` false→true across the hide) and leaves an already-focused dashboard untouched.
- Manually verified on macOS with the dashboard hidden/behind another app: pet click, panel X close, pet double-click, hotkey hide, and Cmd-W no longer resurface it.
