### PR TITLE
test: fence yaml.full_load in the unsafe-load guard

### DIFF
--- a/test/test_yaml_safe_loading.py
+++ b/test/test_yaml_safe_loading.py
@@ -21,7 +21,21 @@ from yaml_helpers import load_with
 _REPO = Path(__file__).resolve().parents[1]
 
 # Built at runtime so this guard's own source does not contain the needles.
-_NEEDLES = tuple(f"yaml.{name}(" for name in ("load", "load_all", "unsafe_load"))
+# ``full_load`` is fenced alongside the obvious ones: FullLoader is the
+# historically exploitable path (it still constructs arbitrary Python objects
+# through tags), so leaving it out would let a future call site walk straight
+# through this fence.
+_NEEDLES = tuple(
+    f"yaml.{name}("
+    for name in (
+        "load",
+        "load_all",
+        "unsafe_load",
+        "unsafe_load_all",
+        "full_load",
+        "full_load_all",
+    )
+)
 
 # The bundled llama.cpp binding is third-party source, not ours to restyle.
 _SKIP_DIRS = ("_vendor", "__pycache__", "node_modules")


### PR DESCRIPTION
Follow-up to #2999, closing the one gap Design Review flagged on it.

## What

`test/test_yaml_safe_loading.py` rejects `yaml.load` call sites under `src/` and `test/`. Its needle list covered `load`, `load_all` and `unsafe_load` — but not `full_load`. `FullLoader` still constructs arbitrary Python objects through tags, so it is the historically exploitable loader; leaving it out meant a future call site could walk straight through the fence the guard exists to build. The `*_all` streaming variants are fenced for the same reason.

## Why it is a separate PR

This was raised as an advisory suggestion on #2999 after that branch had already been pushed, and folding it in would have needed a force-push to keep the one-commit-per-PR shape. It is recorded on #2999 as accepted-with-patch-ready; this is that patch, rebased onto current `main`.

## Testing

- No `yaml.full_load(` / `yaml.unsafe_load_all(` / `yaml.full_load_all(` call sites exist under `src/` or `test/` today, so the widening is a no-op against current source and cannot fail the guard on landing. Verified before widening.
- `pytest test/test_yaml_safe_loading.py`: 3 passed.
- `isort --check-only`, `black --check`, `flake8`: clean.

Test-only change; no `src/` or frontend surface touched.