### PR TITLE
test: raise backend coverage 88.85% -> 89.57% (+1,574 statements)

### DIFF
--- a/test/test_acp_client_more_coverage.py
+++ b/test/test_acp_client_more_coverage.py
@@ -1,0 +1,1553 @@
+"""Additional coverage for :mod:`kiro_crew.acp.client`.
+
+Every test here drives real product code with injected fakes at the boundary the
+product actually calls (``glob``/``subprocess``/``kiro_sessions_dir``/the hook and
+skill-observer getters), never a live subprocess, sandbox, git or network. The
+POSIX-only tests are marked as such because the branches they exercise
+(``os.kill``, ``/proc``, ``ps``, AF_UNIX sockets) have no Windows equivalent.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import socket
+import stat
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import kiro_crew.acp.client as acp_client
+from kiro_crew.acp.client import (
+    AcpAuthRequired,
+    AcpClient,
+    AcpError,
+    AcpProcessDied,
+    AcpTimeoutError,
+    OversizeLineUnrecoverable,
+    _direct_children,
+    _drain_oversize_line,
+    _extract_advisory_detail,
+    _format_acp_error,
+    _get_child_pids,
+    _get_start_time,
+    _is_transient_raw_error,
+    _read_basename,
+    _rejected_model_from_error,
+    _resolve_ssh_auth_sock,
+    _substitute_model_from_advisory,
+    advertised_model_ids,
+    resolve_usable_model,
+)
+from kiro_crew.acp.types import (
+    ACP_BACKEND_CLAUDE,
+    EVENT_AGENT_SWITCHED,
+    EVENT_COMPLETE,
+    EVENT_MCP_OAUTH_REQUEST,
+    EVENT_MCP_SERVER_INIT_FAILURE,
+    EVENT_MCP_SERVER_INITIALIZED,
+    EVENT_PERMISSION_REQUEST,
+    EVENT_TOOL_CALL,
+    EVENT_TOOL_CALL_UPDATE,
+    EVENT_TOOL_RESULT,
+    METHOD_COMMANDS_EXECUTE,
+    UPDATE_AGENT_THOUGHT_CHUNK,
+    UPDATE_TOOL_CALL,
+    AcpEvent,
+    JsonRpcMessage,
+)
+from kiro_crew.hooks import HOOK_EVENT_POST_TOOL_USE
+
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX-only APIs (os.kill, /proc, ps, AF_UNIX sockets)"
+)
+
+
+def _client(tmp_path: Path, **kwargs) -> AcpClient:
+    """An AcpClient pinned to *tmp_path* so nothing is written outside it."""
+    return AcpClient(work_dir=tmp_path, **kwargs)
+
+
+def _live_process() -> MagicMock:
+    """A mock subprocess that looks alive with a writable, drainable stdin."""
+    proc = MagicMock()
+    proc.returncode = None
+    proc.stdin = MagicMock()
+    proc.stdin.drain = AsyncMock()
+    return proc
+
+
+# ── Module-level model helpers ──
+
+
+class TestAdvertisedModelIds:
+    def test_extracts_ids_from_both_shapes(self):
+        entries = [
+            {"modelId": "opus"},
+            {"value": "sonnet"},
+            {"modelId": "   "},  # blank -> dropped
+            {"name": "no id"},  # no id key -> dropped
+            {"modelId": 7},  # non-str -> dropped
+            "not-a-dict",
+        ]
+        assert advertised_model_ids(entries) == ["opus", "sonnet"]
+
+    def test_tuple_is_accepted(self):
+        assert advertised_model_ids(({"modelId": "a"},)) == ["a"]
+
+    def test_non_sequence_degrades_to_empty(self):
+        # A surprising payload must degrade to "entitlement unknown", not raise.
+        assert advertised_model_ids({"modelId": "a"}) == []
+        assert advertised_model_ids(None) == []
+
+
+class TestResolveUsableModel:
+    def test_empty_preferred_inherits_default(self):
+        assert resolve_usable_model("", ["opus"]) == ""
+
+    def test_unknown_advertised_withholds_auto_but_trusts_concrete(self):
+        assert resolve_usable_model("auto", None) == ""
+        assert resolve_usable_model("auto", []) == ""
+        assert resolve_usable_model("opus", None) == "opus"
+
+    def test_auto_only_sent_when_advertised(self):
+        assert resolve_usable_model("auto", ["auto", "opus"]) == "auto"
+        assert resolve_usable_model("auto", ["opus"]) == ""
+
+    def test_concrete_model_kept_when_served_else_inherits(self):
+        assert resolve_usable_model("opus", ["opus", "sonnet"]) == "opus"
+        assert resolve_usable_model("haiku", ["opus", "sonnet"]) == ""
+
+
+class TestUsageLimitIsTerminal:
+    _ERR = {
+        "code": -32603,
+        "message": "Internal error",
+        "data": (
+            "Encountered an error in the response stream: You have reached your "
+            "monthly limit for this model (request_id: abc-123)"
+        ),
+    }
+
+    def test_not_retryable(self):
+        # Ahead of the throttle branch: a spent allowance does not clear on retry.
+        assert _is_transient_raw_error(self._ERR) is False
+
+    def test_message_quotes_provider_and_adds_period(self):
+        out = _format_acp_error(self._ERR)
+        assert "monthly limit for this model." in out
+        assert "Retrying will not help until the limit resets." in out
+        assert "(request_id: abc-123)" in out
+        # The envelope prefix and the duplicated request_id are stripped.
+        assert "Encountered an error in the response stream" not in out
+        assert out.count("abc-123") == 1
+
+
+class TestRejectedModelFromError:
+    def test_non_dict_is_none(self):
+        assert _rejected_model_from_error("boom") is None
+
+    def test_invalid_model_id_wins(self):
+        assert _rejected_model_from_error({"data": "Invalid model ID: auto"}) == "auto"
+
+    def test_unavailable_wording_is_matched(self):
+        err = {"message": "", "data": "The model 'opus-9' is not available"}
+        assert _rejected_model_from_error(err) == "opus-9"
+
+    def test_error_naming_no_model_is_none(self):
+        assert _rejected_model_from_error({"data": "ThrottlingException"}) is None
+
+
+class TestAdvisoryHelpers:
+    def test_detail_of_non_dict_is_empty(self):
+        assert _extract_advisory_detail(["not", "a", "dict"]) == ""
+
+    def test_plain_string_data_is_the_detail(self):
+        assert _extract_advisory_detail({"data": "raw detail"}) == "raw detail"
+
+    def test_substitute_none_when_wording_absent(self):
+        # A genuine advisory (code + "is restricted" + "Using X instead") is
+        # required; strip the substitute clause and no model can be adopted.
+        err = {"code": -32603, "data": {"details": "Model 'x' is restricted by policy."}}
+        assert _substitute_model_from_advisory(err) is None
+
+    def test_substitute_strips_surrounding_quotes(self):
+        err = {
+            "code": -32603,
+            "data": {
+                "details": (
+                    'Model "a" is restricted by your organization\'s settings. '
+                    "Using 'global.anthropic.sonnet' instead."
+                )
+            },
+        }
+        assert _substitute_model_from_advisory(err) == "global.anthropic.sonnet"
+
+    def test_substitute_strips_trailing_punctuation(self):
+        err = {
+            "code": -32603,
+            "data": {
+                "details": (
+                    "Model a is restricted by your organization's settings. "
+                    "Using global.anthropic.sonnet, instead."
+                )
+            },
+        }
+        assert _substitute_model_from_advisory(err) == "global.anthropic.sonnet"
+
+
+# ── Oversize stdout drain ──
+
+
+class TestDrainOversizeLine:
+    @pytest.mark.asyncio
+    async def test_drains_to_the_frame_boundary(self):
+        reader = asyncio.StreamReader(limit=64)
+        reader.feed_data(b"X" * 500 + b"\n")
+        reader.feed_data(b'{"jsonrpc":"2.0","method":"session/update"}\n')
+
+        with pytest.raises(asyncio.LimitOverrunError) as caught:
+            await reader.readuntil(b"\n")
+        discarded = await _drain_oversize_line(reader, caught.value)
+
+        assert discarded == 501  # the oversize payload plus its newline
+        # The stream is left ON a frame boundary: the next frame reads intact.
+        assert await reader.readuntil(b"\n") == b'{"jsonrpc":"2.0","method":"session/update"}\n'
+
+    @pytest.mark.asyncio
+    async def test_budget_exhaustion_raises(self, monkeypatch):
+        monkeypatch.setattr(acp_client, "_OVERSIZE_DRAIN_MAX_BYTES", 100)
+        reader = asyncio.StreamReader(limit=64)
+        reader.feed_data(b"X" * 5000)  # never terminated
+
+        with pytest.raises(asyncio.LimitOverrunError) as caught:
+            await reader.readuntil(b"\n")
+        with pytest.raises(OversizeLineUnrecoverable, match="no frame boundary"):
+            await _drain_oversize_line(reader, caught.value)
+
+    @pytest.mark.asyncio
+    async def test_zero_length_prefix_raises_instead_of_spinning(self):
+        reader = asyncio.StreamReader(limit=64)
+        exc = asyncio.LimitOverrunError("separator not found", 0)
+        with pytest.raises(OversizeLineUnrecoverable, match="0-byte oversize prefix"):
+            await _drain_oversize_line(reader, exc)
+
+    @pytest.mark.asyncio
+    async def test_drain_survives_a_second_overrun_mid_line(self):
+        """A line that overruns again while draining keeps draining, not raising."""
+        reader = asyncio.StreamReader(limit=64)
+        reader.feed_data(b"A" * 200)
+
+        async def _feed_rest():
+            await asyncio.sleep(0.01)
+            reader.feed_data(b"B" * 200)  # second overrun of the SAME line
+            await asyncio.sleep(0.01)
+            reader.feed_data(b"\n")  # terminator at last
+
+        feeder = asyncio.get_running_loop().create_task(_feed_rest())
+        try:
+            with pytest.raises(asyncio.LimitOverrunError) as caught:
+                await reader.readuntil(b"\n")
+            discarded = await _drain_oversize_line(reader, caught.value)
+        finally:
+            await feeder
+
+        assert discarded == 401  # 200 + 200 payload bytes + the newline
+
+
+# ── Credential-pointer repair ──
+
+
+@_POSIX_ONLY
+class TestResolveSshAuthSock:
+    def test_live_socket_is_kept(self, tmp_path):
+        sock_path = tmp_path / "live.sock"
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as srv:
+            srv.bind(str(sock_path))
+            env = {"SSH_AUTH_SOCK": str(sock_path)}
+            _resolve_ssh_auth_sock(env)
+        assert env["SSH_AUTH_SOCK"] == str(sock_path)
+
+    def test_stale_pointer_is_repaired_to_newest_socket(self, tmp_path, monkeypatch):
+        old, new = tmp_path / "agent.1", tmp_path / "agent.2"
+        socks = []
+        for path in (old, new):
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.bind(str(path))
+            socks.append(s)
+        try:
+            assert stat.S_ISSOCK(os.stat(old).st_mode)
+            os.utime(old, (1_000_000, 1_000_000))
+            os.utime(new, (2_000_000, 2_000_000))
+            monkeypatch.setattr(
+                acp_client,
+                "glob",
+                types.SimpleNamespace(glob=lambda pattern: [str(old), str(new)]),
+            )
+            env = {"SSH_AUTH_SOCK": str(tmp_path / "gone.sock")}
+            _resolve_ssh_auth_sock(env)
+        finally:
+            for s in socks:
+                s.close()
+        assert env["SSH_AUTH_SOCK"] == str(new)
+
+    def test_darwin_uses_launchd_pattern(self, tmp_path, monkeypatch):
+        seen: list[str] = []
+
+        def _fake_glob(pattern):
+            seen.append(pattern)
+            return []
+
+        monkeypatch.setattr(acp_client.sys, "platform", "darwin")
+        monkeypatch.setattr(acp_client, "glob", types.SimpleNamespace(glob=_fake_glob))
+        env: dict[str, str] = {}
+        _resolve_ssh_auth_sock(env)
+        assert seen == ["/tmp/com.apple.launchd.*/Listeners"]
+        assert "SSH_AUTH_SOCK" not in env
+
+    def test_windows_is_a_noop(self, monkeypatch):
+        # Bare os.getuid() below would AttributeError on win32, so the guard
+        # must return before any resolution work happens.
+        monkeypatch.setattr(acp_client.platform_compat, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            acp_client,
+            "glob",
+            types.SimpleNamespace(glob=lambda p: pytest.fail("glob must not run on win32")),
+        )
+        env = {"SSH_AUTH_SOCK": "/nonexistent"}
+        _resolve_ssh_auth_sock(env)
+        assert env == {"SSH_AUTH_SOCK": "/nonexistent"}
+
+
+# ── Process-tree helpers ──
+
+
+@_POSIX_ONLY
+class TestProcessTreeHelpers:
+    def test_pid_cycle_does_not_recurse_forever(self, monkeypatch):
+        tree = {10: [11], 11: [10]}
+        monkeypatch.setattr(acp_client, "_direct_children", lambda pid: tree.get(pid, []))
+        assert _get_child_pids(10) == [11]
+
+    def test_visited_pid_returns_empty(self):
+        assert _get_child_pids(10, {10}) == []
+
+    def test_direct_children_falls_back_to_pgrep(self, monkeypatch):
+        calls: list[list[str]] = []
+
+        def _fake_check_output(cmd, **kwargs):
+            calls.append(cmd)
+            return b"4242 4243\n"
+
+        monkeypatch.setattr(acp_client.subprocess_mod, "check_output", _fake_check_output)
+        # A PID with no /proc entry falls through the Linux fast path to pgrep.
+        assert _direct_children(2**30) == [4242, 4243]
+        assert calls and calls[0][:2] == ["pgrep", "-P"]
+
+    def test_direct_children_swallows_pgrep_failure(self, monkeypatch):
+        def _boom(cmd, **kwargs):
+            raise OSError("no pgrep")
+
+        monkeypatch.setattr(acp_client.subprocess_mod, "check_output", _boom)
+        assert _direct_children(2**30) == []
+
+    def test_start_time_on_darwin_hashes_ps_output(self, monkeypatch):
+        monkeypatch.setattr(acp_client.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            acp_client.platform_compat, "trusted_system_bin", lambda name: "/bin/ps"
+        )
+        monkeypatch.setattr(
+            acp_client.subprocess_mod, "check_output", lambda cmd, **kw: b" Wed Aug 12 10:00 \n"
+        )
+        assert _get_start_time(999) == hash(b"Wed Aug 12 10:00")
+
+    def test_start_time_none_without_trusted_ps(self, monkeypatch):
+        monkeypatch.setattr(acp_client.sys, "platform", "darwin")
+        monkeypatch.setattr(acp_client.platform_compat, "trusted_system_bin", lambda name: None)
+        monkeypatch.setattr(
+            acp_client.subprocess_mod,
+            "check_output",
+            lambda *a, **k: pytest.fail("ps must not be spawned without a trusted binary"),
+        )
+        assert _get_start_time(999) is None
+
+    def test_basename_none_without_trusted_ps(self, monkeypatch):
+        monkeypatch.setattr(acp_client.sys, "platform", "darwin")
+        monkeypatch.setattr(acp_client.platform_compat, "trusted_system_bin", lambda name: None)
+        assert _read_basename(999) is None
+
+    def test_basename_none_when_ps_reports_nothing(self, monkeypatch):
+        monkeypatch.setattr(acp_client.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            acp_client.platform_compat, "trusted_system_bin", lambda name: "/bin/ps"
+        )
+        monkeypatch.setattr(acp_client.subprocess_mod, "check_output", lambda cmd, **kw: b"   \n")
+        assert _read_basename(999) is None
+
+
+# ── Small client accessors ──
+
+
+class TestClientAccessors:
+    def test_process_state_accessors(self, tmp_path):
+        client = _client(tmp_path)
+        assert client.is_process_alive() is False
+        assert client.exit_code is None
+        assert client.resumed is False
+        assert client.has_unfinished_turn() is False
+
+        client._process = _live_process()
+        assert client.is_process_alive() is True
+        assert client.exit_code is None
+        assert client.has_unfinished_turn() is True  # turn not done + process alive
+
+        client._process.returncode = 3
+        assert client.is_process_alive() is False
+        assert client.exit_code == 3
+        assert client.has_unfinished_turn() is False
+
+    def test_set_resume_session_id(self, tmp_path):
+        client = _client(tmp_path)
+        client.set_resume_session_id("sid-1")
+        assert client._resume_session_id == "sid-1"
+
+    def test_supports_steer_is_backend_dependent(self, tmp_path):
+        assert _client(tmp_path).supports_steer is True
+        assert _client(tmp_path, acp_backend=ACP_BACKEND_CLAUDE).supports_steer is False
+
+    def test_rekey_rebinds_and_drops_previous_context(self, tmp_path):
+        client = _client(tmp_path, session_key="old", channel_id="C-old")
+        client.last_prompt_stats.context_pct = 73.0
+        client.last_prompt_stats.context_used_tokens = 400
+        client.last_prompt_stats.context_window_tokens = 1000
+        client.last_prompt_stats.context_tokens_from_usage = True
+
+        client.rekey("new", "C-new")
+
+        assert client._session_key == "new"
+        assert client._channel_id == "C-new"
+        # Stale context must not be handed to the new chat (#2932).
+        assert client.last_prompt_stats.context_pct == 0.0
+        assert client.last_prompt_stats.context_used_tokens == 0
+        assert client.last_prompt_stats.context_window_tokens == 0
+        assert client.last_prompt_stats.context_tokens_from_usage is False
+
+    def test_is_responsive_needs_a_live_process_and_recent_io(self, tmp_path):
+        client = _client(tmp_path)
+        assert client.is_responsive() is False  # no process at all
+
+        client._process = _live_process()
+        client._last_activity = 0.0
+        assert client.is_responsive(stale_threshold=1.0) is False
+
+        client.touch_activity()
+        assert client.is_responsive(stale_threshold=1.0) is True
+
+
+class TestModelAndConfigGuards:
+    @pytest.mark.asyncio
+    async def test_set_model_before_session_is_refused(self, tmp_path):
+        client = _client(tmp_path)
+        with pytest.raises(AcpError, match="before session is initialized"):
+            await client.set_model("opus")
+
+    @pytest.mark.asyncio
+    async def test_set_config_option_before_session_is_refused(self, tmp_path):
+        client = _client(tmp_path)
+        with pytest.raises(AcpError, match="before session is initialized"):
+            await client.set_config_option("effort", "high")
+
+    @pytest.mark.asyncio
+    async def test_claude_set_model_routes_through_set_config_option(self, tmp_path):
+        client = _client(tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        client._session_id = "sid"
+        client.set_config_option = AsyncMock()
+        # Claude ids live in a different namespace than the advertised list, so
+        # the entitlement pre-check must NOT run on this backend.
+        client._available_models = [{"modelId": "claude-opus-4-8"}]
+
+        await client.set_model("global.anthropic.claude-sonnet-4-6")
+
+        client.set_config_option.assert_awaited_once_with(
+            "model", "global.anthropic.claude-sonnet-4-6"
+        )
+        assert client._model == "global.anthropic.claude-sonnet-4-6"
+        assert client._resolved_model_id == "global.anthropic.claude-sonnet-4-6"
+
+    def test_capture_available_models_tolerates_odd_payloads(self, tmp_path):
+        client = _client(tmp_path)
+
+        client._capture_available_models({"models": "nope"})
+        assert client.available_models() == []
+
+        client._capture_available_models({"models": {"availableModels": "nope"}})
+        assert client.available_models() == []
+
+        client._capture_available_models(
+            {
+                "models": {
+                    "currentModelId": "opus",
+                    "availableModels": [
+                        "not-a-dict",
+                        {"name": "no id"},
+                        {"value": "sonnet", "description": "fast"},
+                    ],
+                }
+            }
+        )
+        assert client._resolved_model_id == "opus"
+        assert client.available_models() == [
+            {"modelId": "sonnet", "name": "sonnet", "description": "fast"}
+        ]
+
+    def test_config_option_update_replaces_the_option_set(self, tmp_path):
+        client = _client(tmp_path)
+        msg = _notify(
+            "session/update",
+            {
+                "update": {
+                    "sessionUpdate": "config_option_update",
+                    # No "effort" entry, so no effort levels are published.
+                    "configOptions": [{"id": "mode", "options": [{"value": "plan"}]}],
+                }
+            },
+        )
+
+        client._track_usage_update(msg)
+
+        assert client.acp_config_options == [{"id": "mode", "options": [{"value": "plan"}]}]
+        assert client.get_valid_effort_levels() == []
+        assert client.supports_config_option("mode") is True
+        assert client.supports_config_option("effort") is False
+
+    def test_unknown_claude_session_update_is_ignored(self, tmp_path):
+        client = _client(tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        msg = _notify("session/update", {"update": {"sessionUpdate": "brand_new_thing"}})
+
+        client._track_usage_update(msg)  # must not raise
+
+        assert client.acp_config_options == []
+
+
+# ── stderr drain ──
+
+
+class TestDrainStderr:
+    @pytest.mark.asyncio
+    async def test_suppressed_markers_are_dropped_but_keep_liveness(self, tmp_path, monkeypatch):
+        # Interval 0 so the throttled summary fires within the test.
+        monkeypatch.setattr(acp_client, "_SUPPRESSED_STDERR_SUMMARY_INTERVAL_SECS", 0.0)
+        client = _client(tmp_path)
+        client._last_activity = 0.0
+
+        reader = asyncio.StreamReader()
+        reader.feed_data(b"\n")  # blank -> skipped entirely
+        reader.feed_data(b'Unexpected case: {"thinking_tokens": 3}\n')
+        reader.feed_data(b"real failure\n")
+        reader.feed_eof()
+
+        await client._drain_stderr(reader)
+
+        # Only the genuine error survives in the bounded diagnostics buffer.
+        assert list(client._stderr_lines) == ["real failure"]
+        assert client._last_activity > 0.0
+
+    @pytest.mark.asyncio
+    async def test_residual_suppressed_count_is_flushed_at_eof(self, tmp_path, caplog):
+        client = _client(tmp_path)
+        reader = asyncio.StreamReader()
+        reader.feed_data(b"thinking_tokens delta\n")
+        reader.feed_eof()
+
+        with caplog.at_level(logging.DEBUG, logger=acp_client.logger.name):
+            await client._drain_stderr(reader)
+
+        assert not client._stderr_lines
+        assert any("suppressed 1 adapter stderr marker" in r.getMessage() for r in caplog.records)
+
+
+# ── Liveness / reset ──
+
+
+class TestResetPaths:
+    @pytest.mark.asyncio
+    async def test_retire_consumes_a_finished_consult_exception(self, tmp_path):
+        client = _client(tmp_path)
+        loop = asyncio.get_running_loop()
+        done = loop.create_future()
+        done.set_exception(RuntimeError("proc walk blew up"))
+        client._consult_future = done
+        previous_oracle = client._liveness_oracle
+
+        client._retire_liveness_state()
+
+        assert client._consult_future is None
+        assert client._liveness_oracle is not previous_oracle
+        # The exception was retrieved, so asyncio will not report it at GC.
+        assert done.exception() is not None
+
+    def test_reset_state_unlinks_claude_settings_and_survives_pipe_errors(self, tmp_path):
+        client = _client(tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        stale = tmp_path / ".claude" / "settings.local.json"
+        stale.parent.mkdir(parents=True)
+        stale.write_text('{"permissions": {"defaultMode": "bypassPermissions"}}')
+
+        proc = MagicMock()
+        proc.stdin.close.side_effect = OSError("already closed")
+        client._process = proc
+        client._pid = None
+        client._child_pids = {}
+
+        client._reset_state()
+
+        assert not stale.exists()  # bypassPermissions must not persist a crash
+        assert client._process is None
+        assert client._session_id is None
+
+
+# ── ensure_ready ──
+
+
+class TestEnsureReady:
+    @pytest.mark.asyncio
+    async def test_retries_once_with_a_fresh_process(self, tmp_path):
+        client = _client(tmp_path)
+        attempts = {"init": 0}
+
+        async def _spawn():
+            client._process = _live_process()
+
+        async def _init():
+            attempts["init"] += 1
+            if attempts["init"] == 1:
+                raise AcpError("MCP server crashed")
+            client._session_id = "sid"
+
+        async def _snapshot():
+            raise RuntimeError("proc scan failed")  # must not abort startup
+
+        def _reset():
+            client._process = None
+
+        client._spawn = _spawn
+        client._initialize_session = _init
+        client._snapshot_process_tree = _snapshot
+        client._kill_process = AsyncMock()
+        client._reset_state = _reset
+
+        await client.ensure_ready()
+
+        assert attempts["init"] == 2
+        assert client._session_id == "sid"
+        assert client._kill_process.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_auth_required_propagates_after_the_retry(self, tmp_path):
+        client = _client(tmp_path)
+
+        async def _spawn():
+            client._process = _live_process()
+
+        async def _init():
+            raise AcpAuthRequired("kiro-cli is not logged in")
+
+        client._spawn = _spawn
+        client._initialize_session = _init
+        client._snapshot_process_tree = AsyncMock()
+        client._kill_process = AsyncMock()
+        client._reset_state = MagicMock()
+
+        with pytest.raises(AcpAuthRequired):
+            await client.ensure_ready()
+
+        assert client._kill_process.await_count == 2  # once per attempt
+
+    @pytest.mark.asyncio
+    async def test_shutdown_kills_and_resets(self, tmp_path):
+        client = _client(tmp_path)
+        client._kill_process = AsyncMock()
+        client._reset_state = MagicMock()
+
+        await client.shutdown()
+
+        client._kill_process.assert_awaited_once_with(force=True)
+        client._reset_state.assert_called_once()
+
+
+# ── JSON-RPC transport ──
+
+
+class TestTransport:
+    @pytest.mark.asyncio
+    async def test_send_response_requires_a_process(self, tmp_path):
+        client = _client(tmp_path)
+        with pytest.raises(AcpError, match="not running"):
+            await client._send_response(1, {"ok": True})
+
+    @pytest.mark.asyncio
+    async def test_send_response_writes_the_selected_outcome(self, tmp_path):
+        client = _client(tmp_path)
+        client._process = _live_process()
+        client._last_activity = 0.0
+
+        await client._send_response("req-1", {"outcome": {"outcome": "selected"}})
+
+        written = client._process.stdin.write.call_args[0][0].decode()
+        assert json.loads(written) == {
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "result": {"outcome": {"outcome": "selected"}},
+        }
+        assert client._last_activity > 0.0
+
+    @pytest.mark.asyncio
+    async def test_send_prompt_ships_prompt_blocks(self, tmp_path):
+        client = _client(tmp_path)
+        client._session_id = "sid"
+        client._send_request = AsyncMock(return_value=3)
+
+        assert await client._send_prompt("hello there") == 3
+
+        method, params = client._send_request.await_args[0]
+        assert method == acp_client.METHOD_PROMPT
+        assert params["sessionId"] == "sid"
+        assert any(
+            block.get("type") == "text" and "hello there" in block.get("text", "")
+            for block in params["prompt"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_error_requires_a_process(self, tmp_path):
+        client = _client(tmp_path)
+        with pytest.raises(AcpError, match="not running"):
+            await client._send_error(1, -32601, "Method not found")
+
+    @pytest.mark.asyncio
+    async def test_send_error_writes_a_jsonrpc_error_frame(self, tmp_path):
+        client = _client(tmp_path)
+        client._process = _live_process()
+
+        await client._send_error("req-9", -32601, "Method not found: fs/read_text_file")
+
+        written = client._process.stdin.write.call_args[0][0].decode()
+        assert json.loads(written) == {
+            "jsonrpc": "2.0",
+            "id": "req-9",
+            "error": {"code": -32601, "message": "Method not found: fs/read_text_file"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_send_error_reports_a_broken_pipe_as_process_death(self, tmp_path):
+        client = _client(tmp_path)
+        client._process = _live_process()
+        client._process.stdin.drain = AsyncMock(side_effect=BrokenPipeError("gone"))
+
+        with pytest.raises(AcpProcessDied, match="pipe broken"):
+            await client._send_error(1, -32601, "Method not found")
+
+    @pytest.mark.asyncio
+    async def test_eof_on_dead_process_reports_redacted_stderr_tail(self, tmp_path):
+        client = _client(tmp_path)
+        proc = MagicMock()
+        proc.returncode = 42
+        proc.stdout = AsyncMock()
+        proc.stdout.readline = AsyncMock(return_value=b"")
+        client._process = proc
+        client._stderr_lines.append("boom: aws_secret_access_key=AKIAIOSFODNN7EXAMPLE1234")
+
+        async def _fault():
+            # Still pending when _read_message checks, so the EOF path awaits it
+            # under its own 0.5s budget and absorbs the failure.
+            await asyncio.sleep(0.01)
+            raise RuntimeError("stderr drain died")
+
+        client._stderr_task = asyncio.get_running_loop().create_task(_fault())
+
+        with pytest.raises(AcpError) as caught:
+            await client._read_message(timeout=1.0)
+
+        assert "exited (code=42)" in str(caught.value)
+        assert "AKIAIOSFODNN7EXAMPLE1234" not in str(caught.value)
+
+
+# ── _dispatch_events: mid-session MCP notifications ──
+
+
+def _fake_loop(frames):
+    """A _prompt_loop stand-in yielding pre-classified (action, msg) frames."""
+
+    async def _loop(req_id, timeout):
+        for frame in frames:
+            yield frame
+
+    return _loop
+
+
+def _notify(method, params):
+    return JsonRpcMessage(method=method, params=params)
+
+
+class TestDispatchMcpNotifications:
+    @pytest.mark.asyncio
+    async def test_oauth_and_server_lifecycle_events(self, tmp_path):
+        client = _client(tmp_path)
+        client._read_new_tool_results_sync = lambda: []
+        client._prompt_loop = _fake_loop(
+            [
+                ("agent_switched", _notify("_kiro.dev/agent_switched", {"agentName": "reviewer"})),
+                # Unsafe scheme: refused BEFORE dedupe is recorded.
+                (
+                    "mcp_oauth_request",
+                    _notify("m", {"serverName": "evil", "oauthUrl": "javascript:alert(1)"}),
+                ),
+                # No serverName: cannot be correlated with a later init event.
+                ("mcp_oauth_request", _notify("m", {"oauthUrl": "https://auth.example/1"})),
+                (
+                    "mcp_oauth_request",
+                    _notify("m", {"serverName": "github", "oauthUrl": "https://auth.example/1"}),
+                ),
+                # Duplicate for the same server is dropped.
+                (
+                    "mcp_oauth_request",
+                    _notify("m", {"serverName": "github", "oauthUrl": "https://auth.example/1"}),
+                ),
+                ("mcp_server_initialized", _notify("m", {"serverName": "github"})),
+                # Dedupe was cleared by the init, so a later retry surfaces again.
+                (
+                    "mcp_oauth_request",
+                    _notify("m", {"serverName": "github", "oauthUrl": "https://auth.example/2"}),
+                ),
+                (
+                    "mcp_server_init_failure",
+                    _notify("m", {"serverName": "github", "error": "token expired"}),
+                ),
+                ("mcp_server_initialized", _notify("m", {"name": ""})),  # nameless -> no event
+                ("complete", JsonRpcMessage(id=1, result={"stopReason": "end_turn"})),
+            ]
+        )
+
+        events = [ev async for ev in client._dispatch_events(1, 5.0)]
+
+        assert [ev.kind for ev in events] == [
+            EVENT_AGENT_SWITCHED,
+            EVENT_MCP_OAUTH_REQUEST,
+            EVENT_MCP_SERVER_INITIALIZED,
+            EVENT_MCP_OAUTH_REQUEST,
+            EVENT_MCP_SERVER_INIT_FAILURE,
+            EVENT_COMPLETE,
+        ]
+        assert events[0].text == "reviewer"
+        assert events[1].server_name == "github"
+        assert events[1].oauth_url == "https://auth.example/1"
+        assert events[3].oauth_url == "https://auth.example/2"
+        assert events[4].text == "token expired"
+        # The failure banner also clears dedupe so a retry can surface.
+        assert "github" not in client._oauth_emitted_servers
+        assert events[-1].stop_reason == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_unsafe_oauth_url_never_records_dedupe(self, tmp_path):
+        client = _client(tmp_path)
+        client._read_new_tool_results_sync = lambda: []
+        client._prompt_loop = _fake_loop(
+            [
+                (
+                    "mcp_oauth_request",
+                    _notify("m", {"serverName": "srv", "oauthUrl": "data:text/html,x"}),
+                ),
+                (
+                    "mcp_oauth_request",
+                    _notify("m", {"serverName": "srv", "oauthUrl": "https://auth.example/ok"}),
+                ),
+                ("complete", JsonRpcMessage(id=1, result={})),
+            ]
+        )
+
+        events = [ev async for ev in client._dispatch_events(1, 5.0)]
+
+        assert [ev.kind for ev in events] == [EVENT_MCP_OAUTH_REQUEST, EVENT_COMPLETE]
+        assert events[0].oauth_url == "https://auth.example/ok"
+
+
+# ── Commands / steer ──
+
+
+class TestCommandsAndSteer:
+    @pytest.mark.asyncio
+    async def test_send_command_with_args_uses_the_object_form(self, tmp_path):
+        client = _client(tmp_path)
+        client._session_id = "sid"
+        client.ensure_ready = AsyncMock()
+        client._send_request = AsyncMock(return_value=11)
+        client._wait_for_response = AsyncMock(return_value={"text": "effort set"})
+
+        assert await client.send_command("/effort high", {"level": "high"}) == "effort set"
+
+        method, payload = client._send_request.await_args[0]
+        assert method == METHOD_COMMANDS_EXECUTE
+        assert payload == {
+            "sessionId": "sid",
+            "command": {"command": "effort", "args": {"level": "high"}},
+        }
+
+    @pytest.mark.asyncio
+    async def test_send_command_redacts_credentials_in_output(self, tmp_path):
+        client = _client(tmp_path)
+        client._session_id = "sid"
+        client.ensure_ready = AsyncMock()
+        client._send_request = AsyncMock(return_value=11)
+        client._wait_for_response = AsyncMock(
+            return_value={"message": "token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"}
+        )
+
+        out = await client.send_command("/usage")
+
+        assert "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" not in out
+
+    @pytest.mark.asyncio
+    async def test_send_command_timeout_returns_empty(self, tmp_path):
+        client = _client(tmp_path)
+        client._session_id = "sid"
+        client.ensure_ready = AsyncMock()
+        client._send_request = AsyncMock(return_value=11)
+        client._wait_for_response = AsyncMock(side_effect=AcpTimeoutError())
+
+        assert await client.send_command("/compact") == ""
+
+    @pytest.mark.asyncio
+    async def test_steer_wraps_the_message(self, tmp_path):
+        client = _client(tmp_path)
+        client._session_id = "sid"
+        client._send_request = AsyncMock(return_value=5)
+
+        assert await client.steer("  focus on tests  ") is True
+
+        method, params = client._send_request.await_args[0]
+        assert method == "_session/steer"
+        assert params["sessionId"] == "sid"
+        assert params["message"] == "<user_message>\nfocus on tests\n</user_message>"
+
+    @pytest.mark.asyncio
+    async def test_steer_refuses_without_text_or_session(self, tmp_path):
+        client = _client(tmp_path)
+        client._send_request = AsyncMock()
+
+        client._session_id = "sid"
+        assert await client.steer("   ") is False
+        client._session_id = None
+        assert await client.steer("hello") is False
+        client._send_request.assert_not_awaited()
+
+
+# ── send_message read path ──
+
+
+class TestReadPromptResponse:
+    @pytest.mark.asyncio
+    async def test_metadata_and_compaction_frames_are_applied(self, tmp_path):
+        client = _client(tmp_path)
+        client._send_error = AsyncMock()
+        client._prompt_loop = _fake_loop(
+            [
+                (
+                    "server_request_unknown",
+                    JsonRpcMessage(id="s-1", method="fs/read_text_file", params={}),
+                ),
+                (
+                    "compaction",
+                    _notify("_kiro.dev/compaction/status", {"status": {"type": "failed"}}),
+                ),
+                ("metadata", _notify("_kiro.dev/metadata", {"contextUsagePercentage": 42.5})),
+                ("complete", JsonRpcMessage(id=1, result={"stopReason": "end_turn"})),
+            ]
+        )
+
+        assert await client._read_prompt_response(1, 5.0) == ""
+        # An unhandled inbound request is answered so the agent fails fast.
+        client._send_error.assert_awaited_once_with(
+            "s-1", acp_client._JSONRPC_METHOD_NOT_FOUND, "Method not found: fs/read_text_file"
+        )
+        assert client.last_prompt_stats.context_pct == 42.5
+        assert client._last_stop_reason == "end_turn"
+        assert client._turn_done.is_set()
+
+
+# ── Chunk / tool extraction ──
+
+
+class TestExtractHelpers:
+    def test_thought_chunk_is_flagged_as_thinking(self, tmp_path):
+        client = _client(tmp_path)
+        msg = _notify(
+            "session/update",
+            {
+                "update": {
+                    "sessionUpdate": UPDATE_AGENT_THOUGHT_CHUNK,
+                    "content": {"text": "weighing options"},
+                }
+            },
+        )
+        assert client._extract_text_chunk(msg) == ("weighing options", True)
+
+    def test_thought_chunk_with_malformed_content_degrades(self, tmp_path):
+        client = _client(tmp_path)
+        msg = _notify(
+            "session/update",
+            {"update": {"sessionUpdate": UPDATE_AGENT_THOUGHT_CHUNK, "content": "oops"}},
+        )
+        assert client._extract_text_chunk(msg) == (None, True)
+
+    def test_tool_params_cache_is_capped(self, tmp_path):
+        client = _client(tmp_path)
+        client._tool_call_params = {
+            f"old-{i}": {"path": "x"} for i in range(acp_client._MAX_CACHED_TOOL_PARAMS + 1)
+        }
+        msg = _notify(
+            "session/update",
+            {
+                "update": {
+                    "sessionUpdate": UPDATE_TOOL_CALL,
+                    "toolCallId": "new-1",
+                    "title": "read",
+                    "kind": "read",
+                    "rawInput": {"path": "/tmp/x"},
+                }
+            },
+        )
+
+        event = client._extract_tool_event(msg)
+
+        assert event is not None and event.kind == EVENT_TOOL_CALL
+        # Wholesale clear, then the fresh entry — bounded, not unbounded growth.
+        assert client._tool_call_params == {"new-1": {"path": "/tmp/x"}}
+
+    def test_tool_result_skips_non_dict_raw_output_items(self, tmp_path):
+        client = _client(tmp_path)
+        msg = _notify(
+            "session/update",
+            {
+                "update": {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "t1",
+                    "status": "completed",
+                    "rawOutput": {"items": ["junk", None, {"Text": "hello"}]},
+                }
+            },
+        )
+
+        event = client._extract_tool_call_update(msg)
+
+        assert event is not None
+        assert event.kind == EVENT_TOOL_RESULT
+        assert event.tool_output == "hello"
+        assert event.tool_final is True
+
+    def test_refinement_accepts_a_string_raw_input(self, tmp_path):
+        client = _client(tmp_path)
+        msg = _notify(
+            "session/update",
+            {
+                "update": {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "t2",
+                    "rawInput": "ls -la",
+                }
+            },
+        )
+
+        event = client._extract_tool_call_refinement(msg)
+
+        assert event is not None and event.kind == EVENT_TOOL_CALL_UPDATE
+        assert event.tool_input == "ls -la"
+        assert client._tool_call_inputs["t2"] == "ls -la"
+
+    def test_refinement_falls_back_to_repr_for_unserializable_input(self, tmp_path):
+        client = _client(tmp_path)
+        sentinel = object()
+        msg = _notify(
+            "session/update",
+            {
+                "update": {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "t3",
+                    "rawInput": {"probe": sentinel},
+                }
+            },
+        )
+
+        event = client._extract_tool_call_refinement(msg)
+
+        assert event is not None
+        assert "probe" in event.tool_input  # str(dict), not a crash
+
+
+# ── JSONL tool results ──
+
+
+class TestReadNewToolResults:
+    def _write(self, tmp_path, monkeypatch, body: str) -> AcpClient:
+        monkeypatch.setattr(acp_client, "kiro_sessions_dir", lambda: tmp_path)
+        # newline="\n" matters even though no "\n" is visible on this line: the
+        # newlines arrive inside `body`. Without it, Windows writes CRLF here
+        # while a later write that DOES pass newline="\n" writes LF, so the two
+        # differ in byte length and the reader's saved f.tell() offset resumes at
+        # the wrong place -- the second read then returns nothing.
+        (tmp_path / "sid.jsonl").write_text(body, encoding="utf-8", newline="\n")
+        client = _client(tmp_path)
+        client._session_id = "sid"
+        return client
+
+    def test_no_session_or_missing_file_yields_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(acp_client, "kiro_sessions_dir", lambda: tmp_path)
+        client = _client(tmp_path)
+        assert client._read_new_tool_results_sync() == []
+        client._session_id = "sid"
+        assert client._read_new_tool_results_sync() == []
+
+    def test_parses_json_text_and_skips_malformed_lines(self, tmp_path, monkeypatch):
+        lines = [
+            json.dumps({"kind": "Other"}),
+            "not json at all",
+            "",
+            json.dumps(
+                {
+                    "kind": "ToolResults",
+                    "data": {
+                        "content": [
+                            {"kind": "ignored"},
+                            {"kind": "toolResult", "data": "not-a-dict"},
+                            {
+                                "kind": "toolResult",
+                                "data": {
+                                    "toolUseId": "t-stdout",
+                                    "content": [
+                                        {"kind": "json", "data": {"stdout": "OUT"}},
+                                        {"kind": "text", "data": "TAIL"},
+                                        "junk-block",
+                                    ],
+                                },
+                            },
+                            {
+                                "kind": "toolResult",
+                                "data": {
+                                    "toolUseId": "t-json",
+                                    "content": [{"kind": "json", "data": {"rc": 0}}],
+                                },
+                            },
+                            {
+                                "kind": "toolResult",
+                                "data": {"toolUseId": "t-empty", "content": []},
+                            },
+                        ]
+                    },
+                }
+            ),
+        ]
+        client = self._write(tmp_path, monkeypatch, "\n".join(lines) + "\n")
+
+        results = client._read_new_tool_results_sync()
+
+        assert [(r.tool_call_id, r.tool_output) for r in results] == [
+            ("t-stdout", "OUT\nTAIL"),
+            ("t-json", json.dumps({"rc": 0}, indent=2)),
+        ]
+        assert all(r.kind == EVENT_TOOL_RESULT for r in results)
+        # A second call sees no new lines.
+        assert client._read_new_tool_results_sync() == []
+
+    def test_partial_trailing_line_is_left_for_the_next_call(self, tmp_path, monkeypatch):
+        complete = json.dumps(
+            {
+                "kind": "ToolResults",
+                "data": {
+                    "content": [
+                        {
+                            "kind": "toolResult",
+                            "data": {
+                                "toolUseId": "t1",
+                                "content": [{"kind": "text", "data": "first"}],
+                            },
+                        }
+                    ]
+                },
+            }
+        )
+        path = tmp_path / "sid.jsonl"
+        client = self._write(tmp_path, monkeypatch, complete + "\n" + '{"kind": "ToolRes')
+
+        first = client._read_new_tool_results_sync()
+        assert [r.tool_call_id for r in first] == ["t1"]
+        pos_after_first = client._jsonl_pos
+
+        # Completing the partial line makes it readable without re-reading the first.
+        rest = json.dumps(
+            {
+                "kind": "ToolResults",
+                "data": {
+                    "content": [
+                        {
+                            "kind": "toolResult",
+                            "data": {
+                                "toolUseId": "t2",
+                                "content": [{"kind": "text", "data": "second"}],
+                            },
+                        }
+                    ]
+                },
+            }
+        )
+        path.write_text(complete + "\n" + rest + "\n", encoding="utf-8", newline="\n")
+        second = client._read_new_tool_results_sync()
+        assert [r.tool_call_id for r in second] == ["t2"]
+        assert client._jsonl_pos > pos_after_first
+
+    def test_unreadable_file_is_swallowed(self, tmp_path, monkeypatch):
+        client = self._write(tmp_path, monkeypatch, "")
+
+        def _boom(*args, **kwargs):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(acp_client, "open", _boom, raising=False)
+        assert client._read_new_tool_results_sync() == []
+
+
+# ── Permission events ──
+
+
+class TestPermissionEvent:
+    def test_non_string_label_and_kind_are_normalised(self, tmp_path):
+        client = _client(tmp_path)
+        msg = JsonRpcMessage(
+            id="req-1",
+            method="session/request_permission",
+            params={
+                "toolCall": {"title": "rm -rf build", "toolCallId": "tc-1", "kind": "execute"},
+                "options": [
+                    {"optionId": "allow_once", "name": 7, "kind": ["nope"]},
+                    {"optionId": 42, "name": "bad id"},  # non-str id -> skipped
+                    "not-a-dict",
+                ],
+            },
+        )
+
+        event = client._build_permission_event(msg)
+
+        assert event.kind == EVENT_PERMISSION_REQUEST
+        assert event.options == [{"id": "allow_once", "label": ""}]
+        # Legacy id with no usable kind still resolves the allow ids.
+        assert client._permission_options["req-1"]["once"] == "allow_once"
+        # is_shell is deny-by-default: the payload's own kind is untrusted.
+        assert event.is_shell is False
+
+    def test_inline_params_recovered_when_input_came_from_cache(self, tmp_path):
+        client = _client(tmp_path)
+        client._tool_call_inputs["tc-2"] = '{"path": "/etc/hosts"}'
+        msg = JsonRpcMessage(
+            id="req-2",
+            method="session/request_permission",
+            params={
+                "toolCall": {
+                    "title": "write",
+                    "toolCallId": "tc-2",
+                    "params": {"path": "/etc/hosts"},
+                },
+                "options": [{"optionId": "reject", "kind": "reject_once", "name": "Reject"}],
+            },
+        )
+
+        event = client._build_permission_event(msg)
+
+        assert event.tool_input == '{"path": "/etc/hosts"}'
+        assert event.raw_tool_params == {"path": "/etc/hosts"}
+        assert client._permission_options["req-2"] == {"reject": "reject"}
+
+    def test_debug_logging_redacts_the_payload(self, tmp_path, caplog):
+        client = _client(tmp_path)
+        msg = JsonRpcMessage(
+            id="req-3",
+            method="session/request_permission",
+            params={
+                "toolCall": {
+                    "title": "curl",
+                    "toolCallId": "tc-3",
+                    "input": {"token": "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"},
+                }
+            },
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=acp_client.logger.name):
+            event = client._build_permission_event(msg)
+
+        debug = "\n".join(r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG)
+        assert "Permission toolCall payload" in debug
+        assert "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" not in debug
+        assert event.raw_tool_params == {"token": "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"}
+
+
+# ── Context window backfill ──
+
+
+class TestBackfillContextWindow:
+    def test_authoritative_usage_counts_are_never_overwritten(self, tmp_path):
+        client = _client(tmp_path)
+        client.last_prompt_stats.context_tokens_from_usage = True
+        client.last_prompt_stats.context_used_tokens = 123
+
+        client._backfill_context_window(90.0)
+
+        assert client.last_prompt_stats.context_used_tokens == 123
+
+    def test_unknown_model_leaves_the_window_alone(self, tmp_path, monkeypatch):
+        client = _client(tmp_path, model="mystery-model")
+        monkeypatch.setattr(acp_client.model_registry, "has_known_window", lambda m: False)
+
+        client._backfill_context_window(50.0)
+
+        assert client.last_prompt_stats.context_window_tokens == 0
+        assert client.last_prompt_stats.context_used_tokens == 0
+
+    def test_zero_registry_window_is_refused(self, tmp_path, monkeypatch):
+        client = _client(tmp_path, model="weird-model")
+        monkeypatch.setattr(acp_client.model_registry, "has_known_window", lambda m: True)
+        monkeypatch.setattr(acp_client.model_registry, "model_window", lambda m: 0)
+
+        client._backfill_context_window(50.0)
+
+        assert client.last_prompt_stats.context_window_tokens == 0
+
+    def test_derives_used_tokens_from_a_known_window(self, tmp_path, monkeypatch):
+        client = _client(tmp_path, model="known-model")
+        monkeypatch.setattr(acp_client.model_registry, "has_known_window", lambda m: True)
+        monkeypatch.setattr(acp_client.model_registry, "model_window", lambda m: 200_000)
+
+        client._backfill_context_window(float("nan"))
+        assert client.last_prompt_stats.context_used_tokens == 0  # NaN -> 0
+
+        client._backfill_context_window(25.0)
+        assert client.last_prompt_stats.context_window_tokens == 200_000
+        assert client.last_prompt_stats.context_used_tokens == 50_000
+
+
+# ── Post-compaction metadata drain ──
+
+
+class TestDrainPostCompactionMetadata:
+    def _reader(self, client, frames):
+        queue = list(frames)
+
+        async def _read_message(timeout=0.0):
+            if not queue:
+                return None
+            item = queue.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        client._read_message = _read_message
+
+    @pytest.mark.asyncio
+    async def test_returns_on_the_first_real_percentage(self, tmp_path):
+        client = _client(tmp_path)
+        notification = _notify("session/update", {"update": {}})
+        self._reader(
+            client,
+            [
+                None,  # silent read
+                _notify("_kiro.dev/metadata", {"meteringUsage": []}),  # no pct -> keep draining
+                notification,  # buffered for the main loop
+                _notify("_kiro.dev/metadata", {"contextUsagePercentage": 12.0}),
+            ],
+        )
+
+        await client._drain_post_compaction_metadata(grace=5.0)
+
+        assert client.last_prompt_stats.context_pct == 12.0
+        assert client._mcp_notifications == [notification]
+
+    @pytest.mark.asyncio
+    async def test_process_death_propagates(self, tmp_path):
+        client = _client(tmp_path)
+        self._reader(client, [AcpError("ACP process exited (code=1)")])
+
+        with pytest.raises(AcpError):
+            await client._drain_post_compaction_metadata(grace=5.0)
+
+    @pytest.mark.asyncio
+    async def test_other_read_failures_end_the_drain_quietly(self, tmp_path):
+        client = _client(tmp_path)
+        self._reader(client, [RuntimeError("reader wedged")])
+
+        await client._drain_post_compaction_metadata(grace=5.0)
+
+        assert client.last_prompt_stats.context_pct == 0.0
+
+
+# ── Skill-read telemetry ──
+
+
+class _Observer:
+    def __init__(self, keys=None, resolve_exc=None, credit_exc=None):
+        self._keys = keys or []
+        self._resolve_exc = resolve_exc
+        self._credit_exc = credit_exc
+        self.credited: list[list[str]] = []
+
+    def resolve_tool_read_keys(self, tool_name, raw_params, command):
+        if self._resolve_exc:
+            raise self._resolve_exc
+        return list(self._keys)
+
+    def credit_skill_reads(self, keys):
+        if self._credit_exc:
+            raise self._credit_exc
+        self.credited.append(list(keys))
+
+
+def _skill_call(tool_call_id="tc-1"):
+    return AcpEvent(
+        kind=EVENT_TOOL_CALL,
+        tool_call_id=tool_call_id,
+        tool_name="fs_read",
+        raw_tool_params={"path": "/skills/demo/SKILL.md"},
+    )
+
+
+class TestSkillReadTelemetry:
+    @pytest.mark.asyncio
+    async def test_noted_set_is_capped_then_credited_on_completion(self, tmp_path, monkeypatch):
+        observer = _Observer(keys=["demo"])
+        monkeypatch.setattr(acp_client, "get_global_skill_read_observer", lambda: observer)
+        client = _client(tmp_path)
+        client._skill_read_noted = {f"old-{i}" for i in range(acp_client._MAX_NOTED_SKILL_READS)}
+        client._pending_skill_reads = {"old-0": ["stale"]}
+
+        await client._maybe_note_skill_read(_skill_call())
+
+        assert client._skill_read_noted == {"tc-1"}  # cleared wholesale, then re-seeded
+        assert client._pending_skill_reads == {"tc-1": ["demo"]}
+
+        client._maybe_credit_skill_read(
+            AcpEvent(kind=EVENT_TOOL_RESULT, tool_call_id="tc-1", tool_final=True)
+        )
+
+        assert observer.credited == [["demo"]]
+        assert client._pending_skill_reads == {}
+
+    @pytest.mark.asyncio
+    async def test_resolution_failure_leaves_nothing_pending(self, tmp_path, monkeypatch):
+        observer = _Observer(resolve_exc=RuntimeError("skills tree unreadable"))
+        monkeypatch.setattr(acp_client, "get_global_skill_read_observer", lambda: observer)
+        client = _client(tmp_path)
+
+        await client._maybe_note_skill_read(_skill_call("tc-2"))
+
+        assert client._pending_skill_reads == {}
+
+    def test_credit_is_skipped_without_an_observer(self, tmp_path, monkeypatch):
+        client = _client(tmp_path)
+        client._pending_skill_reads = {"tc-3": ["demo"]}
+        monkeypatch.setattr(acp_client, "get_global_skill_read_observer", lambda: None)
+
+        client._maybe_credit_skill_read(
+            AcpEvent(kind=EVENT_TOOL_RESULT, tool_call_id="tc-3", tool_final=True)
+        )
+
+        assert client._pending_skill_reads == {}  # popped, but nothing delivered
+
+    def test_credit_failure_is_swallowed(self, tmp_path, monkeypatch):
+        observer = _Observer(credit_exc=RuntimeError("ledger locked"))
+        monkeypatch.setattr(acp_client, "get_global_skill_read_observer", lambda: observer)
+        client = _client(tmp_path)
+        client._pending_skill_reads = {"tc-4": ["demo"]}
+
+        client._maybe_credit_skill_read(
+            AcpEvent(kind=EVENT_TOOL_RESULT, tool_call_id="tc-4", tool_final=True)
+        )
+
+        assert observer.credited == []
+
+
+# ── Hook engine parity for audit-source clients ──
+
+
+class TestHookFailuresAreNonFatal:
+    @pytest.mark.asyncio
+    async def test_pre_tool_hook_error_does_not_break_dispatch(self, tmp_path, monkeypatch):
+        client = _client(tmp_path, audit_source="code-review-sage")
+        monkeypatch.setattr(acp_client, "get_global_hook_store", lambda: object())
+        fired: list[str] = []
+
+        async def _boom(store, tool_name, tool_input, **kwargs):
+            fired.append(tool_name)
+            raise RuntimeError("hook script exploded")
+
+        monkeypatch.setattr(acp_client, "fire_tool_hooks", _boom)
+
+        # Must return normally — a hook failure never blocks the tool.
+        await client._maybe_fire_pre_tool_hooks(
+            AcpEvent(kind=EVENT_TOOL_CALL, title="ls", tool_input="{}")
+        )
+
+        assert fired == ["ls"]  # the hook really was attempted before it failed
+
+    @pytest.mark.asyncio
+    async def test_post_tool_hook_strips_the_running_prefix(self, tmp_path, monkeypatch):
+        fired: list[dict] = []
+
+        class _Store:
+            async def fire(self, event, **kwargs):
+                fired.append({"event": event, **kwargs})
+
+        monkeypatch.setattr(acp_client, "get_global_hook_store", lambda: _Store())
+        client = _client(tmp_path, audit_source="knowledge-pool")
+        client._observed_tool_calls["tc-9"] = ("Running: ls -la", "execute")
+
+        await client._maybe_fire_post_tool_hooks(
+            AcpEvent(
+                kind=EVENT_TOOL_RESULT,
+                tool_call_id="tc-9",
+                tool_output="total 0",
+                tool_final=True,
+            )
+        )
+
+        assert fired[0]["tool_name"] == "ls -la"
+        assert fired[0]["tool_response"] == {"output": "total 0"}
+
+    @pytest.mark.asyncio
+    async def test_post_tool_hook_error_is_swallowed(self, tmp_path, monkeypatch):
+        attempts: list[str] = []
+
+        class _Store:
+            async def fire(self, event, **kwargs):
+                attempts.append(event)
+                raise RuntimeError("hook store down")
+
+        monkeypatch.setattr(acp_client, "get_global_hook_store", lambda: _Store())
+        client = _client(tmp_path, audit_source="knowledge-pool")
+
+        await client._maybe_fire_post_tool_hooks(
+            AcpEvent(kind=EVENT_TOOL_RESULT, tool_call_id="tc-10", tool_output="x")
+        )
+
+        assert attempts == [HOOK_EVENT_POST_TOOL_USE]
+
+
+class TestToolInterruptedAudit:
+    def test_sel_failure_does_not_propagate(self, tmp_path, monkeypatch, caplog):
+        client = _client(tmp_path)
+        client._session_id = "sid"
+
+        def _boom():
+            raise RuntimeError("SEL backend unavailable")
+
+        monkeypatch.setattr("kiro_crew.sel.sel", _boom)
+
+        with caplog.at_level(logging.WARNING, logger=acp_client.logger.name):
+            client._emit_tool_interrupted_sel("unit-test")
+
+        messages = " ".join(r.getMessage() for r in caplog.records)
+        assert "SEL audit failed for tool_interrupted" in messages

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -1,0 +1,1251 @@
+"""Coverage for the thinly-tested command dispatchers in ``kiro_crew.cli_server``.
+
+Everything here injects a fake at the seam the product actually reaches:
+
+* ``subprocess.run`` / ``os.execvp`` — the CLI shells out to git, journalctl and
+  tail. A CI runner has no installed systemd unit, no launchd, and (for the
+  update path) no writable checkout, so every spawn is replaced by a recorder.
+* ``current_platform`` / ``svc_linux.UNIT_PATH`` / ``svc_macos.STDOUT_LOG`` —
+  patched so the platform-specific log sources are exercised on any host without
+  a ``skipif``. Nothing here reads a real journal or plist.
+* ``sel()`` — replaced with a recorder so the audit contract can be asserted
+  directly instead of inferred from the security log on disk.
+
+The gateway/taskrunner coroutines are driven with ``asyncio.run`` (the repo does
+not enable pytest-asyncio auto mode).
+"""
+
+import argparse
+import asyncio
+import os
+import subprocess
+import sys
+import types
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import cli_server, platform_compat
+from kiro_crew.config.loader import _DEFAULT_PORT
+from kiro_crew.dashboard.handlers.core import DASHBOARD_HTML_NOT_FOUND_MARKER
+from kiro_crew.platform.update_layout import InstallLayout
+from kiro_crew.service import linux as svc_linux
+from kiro_crew.service import macos as svc_macos
+from kiro_crew.service.common import Platform
+
+
+class _SelRecorder:
+    """Stand-in for :func:`kiro_crew.sel.sel` that records audit calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def log_api_access(self, **kw) -> None:
+        self.calls.append(kw)
+
+    @property
+    def operations(self) -> list[str]:
+        return [c.get("operation", "") for c in self.calls]
+
+
+@pytest.fixture
+def sel_rec(monkeypatch):
+    rec = _SelRecorder()
+    monkeypatch.setattr(cli_server, "sel", lambda: rec)
+    return rec
+
+
+class _Resp:
+    """Minimal ``urlopen`` result usable as a context manager."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read(self, n: int = -1) -> bytes:
+        return self._payload if n is None or n < 0 else self._payload[:n]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        return False
+
+
+# --------------------------------------------------------------------------
+# resolve_client_port_ex — malformed env values must fall through, not raise
+# --------------------------------------------------------------------------
+
+
+class TestResolveClientPortExFallThrough:
+    """A non-numeric port env var degrades to the next source, never ValueError."""
+
+    @pytest.fixture(autouse=True)
+    def _no_other_sources(self, monkeypatch):
+        monkeypatch.setattr(cli_server, "_config_url_port", lambda: None)
+        monkeypatch.setattr(cli_server, "_marker_port", lambda: None)
+
+    def test_garbage_kirocrew_port_falls_to_default(self, monkeypatch) -> None:
+        monkeypatch.setenv("KIROCREW_PORT", "not-a-number")
+        monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+        assert cli_server.resolve_client_port_ex(None) == (_DEFAULT_PORT, False)
+
+    def test_garbage_bound_port_falls_to_default(self, monkeypatch) -> None:
+        monkeypatch.delenv("KIROCREW_PORT", raising=False)
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "")
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "12x4")
+        assert cli_server.resolve_client_port_ex(None) == (_DEFAULT_PORT, False)
+
+    def test_garbage_kirocrew_port_still_honours_bound_port(self, monkeypatch) -> None:
+        """The fall-through lands on the NEXT source, not straight on the default."""
+        monkeypatch.setenv("KIROCREW_PORT", "oops")
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "9931")
+        assert cli_server.resolve_client_port_ex(None) == (9931, True)
+
+
+# --------------------------------------------------------------------------
+# _probe_dashboard_health
+# --------------------------------------------------------------------------
+
+
+class TestProbeDashboardHealth:
+    """Warns only when the served body carries the stale-dashboard marker."""
+
+    def test_stale_marker_warns_on_stderr(self, monkeypatch, capsys) -> None:
+        body = f"<html>{DASHBOARD_HTML_NOT_FOUND_MARKER}</html>".encode()
+        monkeypatch.setattr(cli_server, "loopback_urlopen", lambda *a, **k: _Resp(body))
+        cli_server._probe_dashboard_health(5476)
+        assert "stale dashboard" in capsys.readouterr().err
+
+    def test_healthy_body_is_silent(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(
+            cli_server, "loopback_urlopen", lambda *a, **k: _Resp(b"<html>ok</html>")
+        )
+        cli_server._probe_dashboard_health(5476)
+        assert capsys.readouterr().err == ""
+
+    def test_network_error_is_swallowed(self, monkeypatch, capsys) -> None:
+        def boom(*a, **k):
+            raise urllib.error.URLError("refused")
+
+        monkeypatch.setattr(cli_server, "loopback_urlopen", boom)
+        cli_server._probe_dashboard_health(5476)  # must not raise
+        assert capsys.readouterr().err == ""
+
+
+# --------------------------------------------------------------------------
+# _logout
+# --------------------------------------------------------------------------
+
+
+class TestLogout:
+    """Every failure mode exits non-zero with an operator-facing reason."""
+
+    @pytest.fixture
+    def secret_home(self, monkeypatch, tmp_path):
+        (tmp_path / ".local_secret").write_text("s3cr3t\n", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(cli_server, "config_dir", lambda: tmp_path)
+        return tmp_path
+
+    def test_missing_secret_reports_gateway_down(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setattr(cli_server, "config_dir", lambda: tmp_path)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._logout(5476)
+        assert exc.value.code == 1
+        assert "Gateway not running" in capsys.readouterr().out
+
+    def test_ok_response_reports_success(self, monkeypatch, secret_home, capsys) -> None:
+        monkeypatch.setattr(cli_server, "loopback_urlopen", lambda *a, **k: _Resp(b'{"ok": true}'))
+        cli_server._logout(5476)
+        assert "revoked" in capsys.readouterr().out
+
+    def test_not_ok_response_surfaces_error_field(self, monkeypatch, secret_home, capsys) -> None:
+        monkeypatch.setattr(
+            cli_server,
+            "loopback_urlopen",
+            lambda *a, **k: _Resp(b'{"ok": false, "error": "store locked"}'),
+        )
+        with pytest.raises(SystemExit) as exc:
+            cli_server._logout(5476)
+        assert exc.value.code == 1
+        assert "store locked" in capsys.readouterr().out
+
+    def test_http_error_reports_status_code(self, monkeypatch, secret_home, capsys) -> None:
+        def boom(*a, **k):
+            raise urllib.error.HTTPError("u", 403, "no", {}, None)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(cli_server, "loopback_urlopen", boom)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._logout(5476)
+        assert exc.value.code == 1
+        assert "HTTP 403" in capsys.readouterr().out
+
+    def test_connection_refused_reports_gateway_down(
+        self, monkeypatch, secret_home, capsys
+    ) -> None:
+        def boom(*a, **k):
+            raise urllib.error.URLError("refused")
+
+        monkeypatch.setattr(cli_server, "loopback_urlopen", boom)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._logout(5476)
+        assert exc.value.code == 1
+        assert "Gateway not running" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------
+# _stop
+# --------------------------------------------------------------------------
+
+
+class TestStopViaService:
+    """No ``--port`` means the service manager gets first refusal."""
+
+    def test_service_stop_short_circuits_port_scan(self, monkeypatch, sel_rec, capsys) -> None:
+        monkeypatch.setattr(cli_server, "resolve_client_port", lambda p: 5476)
+        monkeypatch.setattr(cli_server.service_controller, "stop_service", lambda: True)
+
+        def unreachable(port):  # pragma: no cover - asserts the short-circuit
+            raise AssertionError("port scan must not run when the service stopped")
+
+        monkeypatch.setattr(platform_compat, "find_listening_pids", unreachable)
+        cli_server._stop(None)
+        assert "Stopped kirocrew service" in capsys.readouterr().out
+        assert sel_rec.calls[0]["resources"].endswith("via=service")
+
+    def test_explicit_port_bypasses_the_service(self, monkeypatch, sel_rec, capsys) -> None:
+        monkeypatch.setattr(cli_server, "resolve_client_port", lambda p: 8123)
+
+        def unreachable():  # pragma: no cover - asserts the bypass
+            raise AssertionError("service must not be consulted for an explicit port")
+
+        monkeypatch.setattr(cli_server.service_controller, "stop_service", unreachable)
+        monkeypatch.setattr(platform_compat, "find_listening_pids", lambda port: [])
+        with pytest.raises(SystemExit) as exc:
+            cli_server._stop(8123)
+        assert exc.value.code == 1
+        assert "No Kiro Crew gateway currently running on port 8123" in capsys.readouterr().out
+        assert sel_rec.calls[-1]["outcome"] == "no_target"
+
+
+class TestStopOnWindows:
+    """The Windows branch kills the whole tree via ``platform_compat``."""
+
+    @pytest.fixture(autouse=True)
+    def _windows(self, monkeypatch):
+        monkeypatch.setattr(cli_server, "resolve_client_port", lambda p: 5476)
+        monkeypatch.setattr(cli_server.service_controller, "stop_service", lambda: False)
+        monkeypatch.setattr(platform_compat, "find_listening_pids", lambda port: [4242])
+        monkeypatch.setattr(cli_server, "_is_kirocrew_process", lambda pid: True)
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+        monkeypatch.setattr(cli_server, "_pid_exited", lambda pid: True)
+        monkeypatch.setattr("time.sleep", lambda s: None)
+
+    def test_tree_kill_reports_terminated(self, monkeypatch, sel_rec, capsys) -> None:
+        seen: list[int] = []
+        monkeypatch.setattr(
+            platform_compat, "kill_process_tree", lambda pid, sig: seen.append(pid)
+        )
+        cli_server._stop(None)
+        out = capsys.readouterr().out
+        assert seen == [4242]
+        assert "Terminated gateway (pid 4242)" in out
+        assert sel_rec.calls[-1]["outcome"] == "allowed"
+
+    def test_already_gone_pid_is_not_reported_as_stopped(
+        self, monkeypatch, sel_rec, capsys
+    ) -> None:
+        def gone(pid, sig):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(platform_compat, "kill_process_tree", gone)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._stop(None)
+        assert exc.value.code == 1
+        assert "process already exited" in capsys.readouterr().out
+
+    def test_permission_error_asks_for_sudo_and_exits(self, monkeypatch, sel_rec, capsys) -> None:
+        def denied(pid, sig):
+            raise PermissionError
+
+        monkeypatch.setattr(platform_compat, "kill_process_tree", denied)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._stop(None)
+        assert exc.value.code == 1
+        assert "No permission to stop pid 4242" in capsys.readouterr().out
+        assert sel_rec.calls[-1]["outcome"] == "denied"
+
+    def test_generic_taskkill_failure_rechecks_liveness(self, monkeypatch, capsys) -> None:
+        """An OSError from taskkill is only "denied" if the pid is still alive."""
+
+        def oserr(pid, sig):
+            raise OSError("taskkill exit 1")
+
+        monkeypatch.setattr(platform_compat, "kill_process_tree", oserr)
+        monkeypatch.setattr(platform_compat, "pid_exists", lambda pid: True)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._stop(None)
+        assert exc.value.code == 1
+        assert "No permission to stop pid 4242" in capsys.readouterr().out
+
+    def test_generic_taskkill_failure_on_dead_pid_is_not_denied(
+        self, monkeypatch, capsys
+    ) -> None:
+        def oserr(pid, sig):
+            raise OSError("taskkill exit 1")
+
+        monkeypatch.setattr(platform_compat, "kill_process_tree", oserr)
+        monkeypatch.setattr(platform_compat, "pid_exists", lambda pid: False)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._stop(None)
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "process already exited" in out
+        assert "No permission" not in out
+
+
+# --------------------------------------------------------------------------
+# _service_cmd / _sandbox_cmd
+# --------------------------------------------------------------------------
+
+
+class TestServiceCmd:
+    """Each action forwards to the controller and audits the resulting rc."""
+
+    @pytest.mark.parametrize(
+        "action,fn,operation",
+        [
+            ("install", "install_service", "service_install"),
+            ("uninstall", "uninstall_service", "service_uninstall"),
+            ("status", "service_status", "service_status"),
+        ],
+    )
+    def test_action_forwards_and_audits(
+        self, monkeypatch, sel_rec, action, fn, operation
+    ) -> None:
+        monkeypatch.setattr(cli_server.service_controller, fn, lambda: 0)
+        rc = cli_server._service_cmd(argparse.Namespace(service_action=action))
+        assert rc == 0
+        assert sel_rec.operations == [operation]
+        assert sel_rec.calls[0]["outcome"] == "allowed"
+
+    def test_nonzero_rc_is_audited_as_error(self, monkeypatch, sel_rec) -> None:
+        monkeypatch.setattr(cli_server.service_controller, "install_service", lambda: 3)
+        assert cli_server._service_cmd(argparse.Namespace(service_action="install")) == 3
+        assert sel_rec.calls[0]["outcome"] == "error"
+        assert "rc=3" in sel_rec.calls[0]["resources"]
+
+    def test_unknown_action_prints_usage_and_returns_2(self, sel_rec, capsys) -> None:
+        assert cli_server._service_cmd(argparse.Namespace(service_action=None)) == 2
+        assert "Usage: kirocrew service" in capsys.readouterr().err
+        assert sel_rec.calls == []
+
+
+class TestSandboxCmd:
+    """Profile writes are audited; the read-only status probe is not."""
+
+    def test_install_profile_forwards_path_and_audits(self, monkeypatch, sel_rec) -> None:
+        seen: list[str | None] = []
+        monkeypatch.setattr(
+            cli_server.service_controller,
+            "install_launcher_profile",
+            lambda p: seen.append(p) or 0,
+        )
+        rc = cli_server._sandbox_cmd(
+            argparse.Namespace(sandbox_action="install-profile", path="/opt/app.AppImage")
+        )
+        assert rc == 0
+        assert seen == ["/opt/app.AppImage"]
+        assert sel_rec.operations == ["sandbox_profile_install"]
+        assert "/opt/app.AppImage" in sel_rec.calls[0]["resources"]
+
+    def test_install_profile_without_path_records_appimage_placeholder(
+        self, monkeypatch, sel_rec
+    ) -> None:
+        monkeypatch.setattr(cli_server.service_controller, "install_launcher_profile", lambda p: 1)
+        assert (
+            cli_server._sandbox_cmd(argparse.Namespace(sandbox_action="install-profile", path=None))
+            == 1
+        )
+        assert sel_rec.calls[0]["outcome"] == "error"
+        assert "$APPIMAGE" in sel_rec.calls[0]["resources"]
+
+    def test_remove_profile_audits(self, monkeypatch, sel_rec) -> None:
+        monkeypatch.setattr(cli_server.service_controller, "remove_launcher_profile", lambda: 0)
+        assert cli_server._sandbox_cmd(argparse.Namespace(sandbox_action="remove-profile")) == 0
+        assert sel_rec.operations == ["sandbox_profile_remove"]
+
+    def test_status_is_not_audited(self, monkeypatch, sel_rec) -> None:
+        monkeypatch.setattr(
+            cli_server.service_controller, "sandbox_profile_status", lambda p: 7
+        )
+        rc = cli_server._sandbox_cmd(argparse.Namespace(sandbox_action="status", path=None))
+        assert rc == 7
+        assert sel_rec.calls == []
+
+    def test_unknown_action_prints_usage_and_returns_2(self, sel_rec, capsys) -> None:
+        assert cli_server._sandbox_cmd(argparse.Namespace(sandbox_action="bogus")) == 2
+        assert "Usage: kirocrew sandbox" in capsys.readouterr().err
+        assert sel_rec.calls == []
+
+
+# --------------------------------------------------------------------------
+# _logs_cmd
+# --------------------------------------------------------------------------
+
+
+class _ExecCalled(Exception):
+    """Raised by the ``os.execvp`` stub — the real call never returns."""
+
+    def __init__(self, file: str, argv: list[str]) -> None:
+        super().__init__(file)
+        self.file = file
+        self.argv = argv
+
+
+@pytest.fixture
+def fake_execvp(monkeypatch):
+    def _execvp(file, argv):
+        raise _ExecCalled(file, list(argv))
+
+    monkeypatch.setattr(os, "execvp", _execvp)
+
+
+class TestLogsCmdSystemd:
+    """Journal first, sudo only as a fallback, and never a blind sudo prompt."""
+
+    @pytest.fixture(autouse=True)
+    def _systemd(self, monkeypatch, tmp_path):
+        unit = tmp_path / "kirocrew.service"
+        unit.write_text("[Unit]\n", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(cli_server, "current_platform", lambda: Platform.SYSTEMD)
+        monkeypatch.setattr(svc_linux, "UNIT_PATH", unit)
+
+    def test_unprivileged_journal_is_execed_when_probe_returns_rows(
+        self, monkeypatch, sel_rec, fake_execvp
+    ) -> None:
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(a[0], 0, "-- Logs begin --\n", ""),
+        )
+        with pytest.raises(_ExecCalled) as exc:
+            cli_server._logs_cmd(argparse.Namespace(follow=True, lines=42))
+        assert exc.value.file == "journalctl"
+        assert exc.value.argv[0] == "journalctl"
+        assert "-f" in exc.value.argv
+        assert "42" in exc.value.argv
+        # Audited BEFORE the exec, or the record would never be written.
+        assert sel_rec.operations == ["logs"]
+        assert "follow=True lines=42" in sel_rec.calls[0]["resources"]
+
+    def test_empty_probe_without_tty_refuses_instead_of_hanging_on_sudo(
+        self, monkeypatch, sel_rec, capsys
+    ) -> None:
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 1, "", "denied")
+        )
+        monkeypatch.setattr(sys, "stdin", types.SimpleNamespace(isatty=lambda: False))
+        with pytest.raises(SystemExit) as exc:
+            cli_server._logs_cmd(argparse.Namespace(follow=False, lines=10))
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "stdin is not a TTY" in err
+        assert "systemd-journal" in err
+
+    def test_empty_probe_with_tty_falls_back_to_sudo_journalctl(
+        self, monkeypatch, sel_rec, fake_execvp
+    ) -> None:
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0, "   \n", "")
+        )
+        monkeypatch.setattr(sys, "stdin", types.SimpleNamespace(isatty=lambda: True))
+        with pytest.raises(_ExecCalled) as exc:
+            cli_server._logs_cmd(argparse.Namespace(follow=True, lines=5))
+        assert exc.value.file == "sudo"
+        assert exc.value.argv[:2] == ["sudo", "journalctl"]
+        assert exc.value.argv[-1] == "-f"
+        assert "--no-pager" in exc.value.argv
+
+    def test_missing_unit_falls_through_to_the_plain_log_file(
+        self, monkeypatch, tmp_path, sel_rec, fake_execvp
+    ) -> None:
+        monkeypatch.setattr(svc_linux, "UNIT_PATH", tmp_path / "absent.service")
+        log = tmp_path / "gateway.log"
+        log.write_text("hi\n", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(cli_server, "config_dir", lambda: tmp_path)
+
+        def unreachable(*a, **k):  # pragma: no cover - proves no journal probe
+            raise AssertionError("journalctl must not be probed without an installed unit")
+
+        monkeypatch.setattr(subprocess, "run", unreachable)
+        with pytest.raises(_ExecCalled) as exc:
+            cli_server._logs_cmd(argparse.Namespace(follow=False, lines=3))
+        assert exc.value.file == "tail"
+        assert exc.value.argv == ["tail", "-n", "3", str(log)]
+
+
+class TestLogsCmdOtherSources:
+    """launchd stdout file, plain log file, and the "nothing to tail" refusal."""
+
+    def test_launchd_stdout_log_is_tailed(
+        self, monkeypatch, tmp_path, sel_rec, fake_execvp
+    ) -> None:
+        stdout_log = tmp_path / "launchd-gateway.log"
+        stdout_log.write_text("x\n", encoding="utf-8", newline="\n")
+        monkeypatch.setattr(cli_server, "current_platform", lambda: Platform.LAUNCHD)
+        monkeypatch.setattr(svc_macos, "STDOUT_LOG", stdout_log)
+        with pytest.raises(_ExecCalled) as exc:
+            cli_server._logs_cmd(argparse.Namespace(follow=True, lines=8))
+        assert exc.value.argv == ["tail", "-n", "8", "-f", str(stdout_log)]
+
+    def test_no_log_source_at_all_exits_with_guidance(
+        self, monkeypatch, tmp_path, sel_rec, capsys
+    ) -> None:
+        monkeypatch.setattr(cli_server, "current_platform", lambda: Platform.UNSUPPORTED)
+        monkeypatch.setattr(cli_server, "config_dir", lambda: tmp_path)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._logs_cmd(argparse.Namespace(follow=False, lines=100))
+        assert exc.value.code == 1
+        assert "No gateway logs found" in capsys.readouterr().err
+        assert sel_rec.operations == ["logs"]
+
+    def test_zero_lines_argument_falls_back_to_the_default(
+        self, monkeypatch, tmp_path, sel_rec, fake_execvp
+    ) -> None:
+        """``lines=0`` is falsy, so the product substitutes 100 rather than tailing nothing."""
+        monkeypatch.setattr(cli_server, "current_platform", lambda: Platform.UNSUPPORTED)
+        monkeypatch.setattr(cli_server, "config_dir", lambda: tmp_path)
+        (tmp_path / "gateway.log").write_text("x\n", encoding="utf-8", newline="\n")
+        with pytest.raises(_ExecCalled) as exc:
+            cli_server._logs_cmd(argparse.Namespace(follow=False, lines=0))
+        assert exc.value.argv[:3] == ["tail", "-n", "100"]
+
+
+# --------------------------------------------------------------------------
+# _gateway
+# --------------------------------------------------------------------------
+
+
+class _FakeCfg:
+    """Config double for ``_gateway`` — records ``save()`` instead of writing."""
+
+    saved = 0
+
+    def save(self) -> None:
+        type(self).saved += 1
+
+    @classmethod
+    def load(cls) -> "_FakeCfg":
+        return cls()
+
+
+class TestGateway:
+    """Start-up reconciliation runs, then ``run_gateway`` receives the flags verbatim."""
+
+    @pytest.fixture
+    def gw(self, monkeypatch, tmp_path):
+        captured: dict = {}
+
+        async def _run_gateway(cfg, **kw):
+            captured["cfg"] = cfg
+            captured["kw"] = kw
+
+        monkeypatch.setattr(cli_server, "run_gateway", _run_gateway)
+        monkeypatch.setattr(cli_server, "activate_mise", lambda: [])
+        monkeypatch.setattr(cli_server, "ensure_dev_dist_symlink", lambda: tmp_path / "dist")
+        monkeypatch.setattr(cli_server, "_should_reconcile_launchd_launcher", lambda: False)
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text("{}", encoding="utf-8")
+        monkeypatch.setattr(cli_server, "config_path", lambda: cfg_file)
+
+        class _Cfg(_FakeCfg):
+            saved = 0
+
+        monkeypatch.setattr(cli_server, "KiroCrewConfig", _Cfg)
+        monkeypatch.setattr("kiro_crew.cli._node_ok", lambda: True)
+        return captured, _Cfg
+
+    def test_flags_are_forwarded_to_run_gateway(self, gw) -> None:
+        captured, cfg_cls = gw
+        asyncio.run(
+            cli_server._gateway(
+                no_dashboard=True, no_crons=True, no_open=True, port_override="9001"
+            )
+        )
+        assert captured["kw"]["no_dashboard"] is True
+        assert captured["kw"]["no_crons"] is True
+        assert captured["kw"]["port_override"] == "9001"
+        # Existing config file -> no default config written.
+        assert cfg_cls.saved == 0
+
+    def test_missing_config_is_created_before_load(self, gw, monkeypatch, tmp_path, capsys) -> None:
+        captured, cfg_cls = gw
+        monkeypatch.setattr(cli_server, "config_path", lambda: tmp_path / "absent.json")
+        asyncio.run(cli_server._gateway())
+        assert cfg_cls.saved == 1
+        assert "Created default config" in capsys.readouterr().out
+
+    def test_missing_dist_warns_but_still_starts(self, gw, monkeypatch, caplog) -> None:
+        captured, _ = gw
+        monkeypatch.setattr(cli_server, "ensure_dev_dist_symlink", lambda: None)
+        with caplog.at_level("WARNING", logger="kiro_crew.cli_server"):
+            asyncio.run(cli_server._gateway(no_dashboard=False))
+        assert any("dist/ not found" in r.message for r in caplog.records)
+        assert "kw" in captured
+
+    def test_slack_only_skips_the_dist_check(self, gw, monkeypatch) -> None:
+        captured, _ = gw
+
+        def unreachable():  # pragma: no cover - proves the skip
+            raise AssertionError("dist must not be resolved in slack-only mode")
+
+        monkeypatch.setattr(cli_server, "ensure_dev_dist_symlink", unreachable)
+        asyncio.run(cli_server._gateway(no_dashboard=True))
+        assert captured["kw"]["no_dashboard"] is True
+
+    def test_stale_node_triggers_ensure_node(self, gw, monkeypatch) -> None:
+        calls: list[str] = []
+        monkeypatch.setattr("kiro_crew.cli._node_ok", lambda: False)
+        monkeypatch.setattr("kiro_crew.cli._ensure_node", lambda *a: calls.append("ensured"))
+        asyncio.run(cli_server._gateway(no_dashboard=True))
+        assert calls == ["ensured"]
+
+    def test_mise_activation_is_logged_when_it_changes_the_env(
+        self, gw, monkeypatch, caplog
+    ) -> None:
+        monkeypatch.setattr(cli_server, "activate_mise", lambda: ["PATH"])
+        with caplog.at_level("INFO", logger="kiro_crew.cli_server"):
+            asyncio.run(cli_server._gateway(no_dashboard=True))
+        assert any("Activated mise" in r.message for r in caplog.records)
+
+    def test_launchd_launcher_repair_failure_is_non_fatal(self, gw, monkeypatch, caplog) -> None:
+        captured, _ = gw
+        monkeypatch.setattr(cli_server, "_should_reconcile_launchd_launcher", lambda: True)
+
+        def boom():
+            raise OSError("read-only Application Support")
+
+        monkeypatch.setattr(svc_macos, "ensure_live_program", boom)
+        with caplog.at_level("WARNING", logger="kiro_crew.cli_server"):
+            asyncio.run(cli_server._gateway(no_dashboard=True))
+        assert any("live-gateway launcher" in r.message for r in caplog.records)
+        assert "kw" in captured  # the gateway still started
+
+
+# --------------------------------------------------------------------------
+# _run_task
+# --------------------------------------------------------------------------
+
+
+class _FakeStore:
+    def __init__(self, *a, **kw) -> None:
+        self.kwargs = kw
+        self.inited = False
+
+    def init(self) -> None:
+        self.inited = True
+
+
+class _FakeVectorStore(_FakeStore):
+    embed_fn = None
+    embed_fn_factory = None
+
+
+class _FakeSessions:
+    def __init__(self, cfg, provider_factory=None) -> None:
+        self.cfg = cfg
+        self.pool_started = False
+        self.closed = False
+
+    async def start_pool(self) -> None:
+        self.pool_started = True
+
+    async def close_all(self) -> None:
+        self.closed = True
+
+
+class _Result:
+    def __init__(self, status: str, error: str = "") -> None:
+        self.status = status
+        self.error = error
+        self.name = "demo"
+        self.task_id = "t-1"
+        self.tasks = [1, 2, 3]
+
+
+@pytest.fixture
+def taskrunner_env(monkeypatch, tmp_path):
+    """Replace every collaborator ``_run_task`` constructs, and expose the spies."""
+    from kiro_crew.config import KiroCrewConfig
+
+    state: dict = {"vector": None, "sessions": None, "runner_kwargs": None, "observed": []}
+
+    monkeypatch.setattr(KiroCrewConfig, "load", classmethod(lambda cls: cls()))
+    monkeypatch.setattr(cli_server, "KiroCrewConfig", KiroCrewConfig)
+    monkeypatch.setattr(cli_server, "build_provider_factory", lambda cfg: object())
+
+    def _sessions(cfg, provider_factory=None):
+        state["sessions"] = _FakeSessions(cfg, provider_factory)
+        return state["sessions"]
+
+    monkeypatch.setattr(cli_server, "SessionManager", _sessions)
+    monkeypatch.setattr(cli_server, "MemoryStore", _FakeStore)
+
+    def _vector(**kw):
+        state["vector"] = _FakeVectorStore(**kw)
+        return state["vector"]
+
+    monkeypatch.setattr(cli_server, "VectorMemoryStore", _vector)
+    monkeypatch.setattr(cli_server, "ConversationLog", _FakeStore)
+    monkeypatch.setattr(cli_server, "LessonStore", _FakeStore)
+    monkeypatch.setattr(cli_server, "SkillsLoader", _FakeStore)
+    monkeypatch.setattr(cli_server, "HistoryConsolidator", lambda **kw: object())
+    monkeypatch.setattr(cli_server, "hooks_config_from_config_dict", lambda h: {})
+    monkeypatch.setattr(cli_server, "HookManager", lambda hc: object())
+    monkeypatch.setattr(cli_server, "ContextBuilder", lambda **kw: object())
+    monkeypatch.setattr(
+        cli_server, "register_skill_read_observer", lambda ctx: state["observed"].append(ctx)
+    )
+    monkeypatch.setattr(cli_server, "_session_work_dir", lambda key: tmp_path)
+    monkeypatch.setattr(cli_server, "make_sync_embed_fn", lambda: (lambda text: [0.0]))
+    monkeypatch.setattr(cli_server, "model_file_present", lambda: True)
+    monkeypatch.setattr(cli_server, "store_embedding_space_is_stale", lambda vs: False)
+
+    def _install_runner(result: _Result) -> None:
+        class _Runner:
+            def __init__(self, **kw) -> None:
+                state["runner_kwargs"] = kw
+
+            async def run(self, spec_path, name=""):
+                state["ran"] = (spec_path, name)
+                return result
+
+        monkeypatch.setattr(cli_server, "TaskRunner", _Runner)
+
+    state["install_runner"] = _install_runner
+    return state
+
+
+def _spec(tmp_path: Path) -> Path:
+    spec = tmp_path / "task.md"
+    spec.write_text("# Task\n\n- step one\n", encoding="utf-8", newline="\n")
+    return spec
+
+
+class TestRunTask:
+    """Spec validation, embedding degradation, and the three terminal statuses."""
+
+    def test_missing_spec_exits_before_building_anything(self, tmp_path, capsys) -> None:
+        args = argparse.Namespace(spec=str(tmp_path / "nope.md"))
+        with pytest.raises(SystemExit) as exc:
+            asyncio.run(cli_server._run_task(args))
+        assert exc.value.code == 1
+        assert "Spec file not found" in capsys.readouterr().err
+
+    def test_completed_task_wires_runner_and_closes_sessions(
+        self, taskrunner_env, tmp_path, capsys
+    ) -> None:
+        taskrunner_env["install_runner"](_Result("completed"))
+        spec = _spec(tmp_path)
+        args = argparse.Namespace(
+            spec=str(spec), no_test=True, fresh=False, timeout=90, name="my-run"
+        )
+        asyncio.run(cli_server._run_task(args))
+        kw = taskrunner_env["runner_kwargs"]
+        assert kw["auto_test"] is False  # --no-test inverts into auto_test
+        assert kw["fresh"] is False
+        assert kw["global_timeout"] == 90.0
+        assert taskrunner_env["ran"] == (spec.resolve(), "my-run")
+        assert taskrunner_env["sessions"].pool_started is True
+        assert taskrunner_env["sessions"].closed is True
+        assert taskrunner_env["observed"]  # skill-read observer registered
+        out = capsys.readouterr().out
+        assert "Task completed" in out and "(3 steps)" in out
+
+    def test_fresh_flag_is_forwarded_and_announced(
+        self, taskrunner_env, tmp_path, capsys
+    ) -> None:
+        taskrunner_env["install_runner"](_Result("completed"))
+        args = argparse.Namespace(
+            spec=str(_spec(tmp_path)), no_test=False, fresh=True, timeout=0, name=""
+        )
+        asyncio.run(cli_server._run_task(args))
+        assert taskrunner_env["runner_kwargs"]["fresh"] is True
+        assert taskrunner_env["runner_kwargs"]["auto_test"] is True
+        assert "Running spec (fresh)" in capsys.readouterr().out
+
+    def test_failed_task_exits_one_with_the_error(
+        self, taskrunner_env, tmp_path, capsys
+    ) -> None:
+        taskrunner_env["install_runner"](_Result("failed", error="step 2 blew up"))
+        args = argparse.Namespace(
+            spec=str(_spec(tmp_path)), no_test=False, fresh=False, timeout=0, name=""
+        )
+        with pytest.raises(SystemExit) as exc:
+            asyncio.run(cli_server._run_task(args))
+        assert exc.value.code == 1
+        assert "step 2 blew up" in capsys.readouterr().err
+
+    def test_cancelled_task_exits_one(self, taskrunner_env, tmp_path, capsys) -> None:
+        taskrunner_env["install_runner"](_Result("cancelled"))
+        args = argparse.Namespace(
+            spec=str(_spec(tmp_path)), no_test=False, fresh=False, timeout=0, name=""
+        )
+        with pytest.raises(SystemExit) as exc:
+            asyncio.run(cli_server._run_task(args))
+        assert exc.value.code == 1
+        assert "cancelled" in capsys.readouterr().out
+
+    def test_embed_fn_is_bound_when_the_model_is_present(self, taskrunner_env, tmp_path) -> None:
+        taskrunner_env["install_runner"](_Result("completed"))
+        args = argparse.Namespace(
+            spec=str(_spec(tmp_path)), no_test=False, fresh=False, timeout=0, name=""
+        )
+        asyncio.run(cli_server._run_task(args))
+        assert taskrunner_env["vector"].embed_fn is not None
+        assert taskrunner_env["vector"].embed_fn_factory is not None
+
+    def test_absent_model_degrades_to_keyword_search_without_downloading(
+        self, taskrunner_env, tmp_path, monkeypatch, capsys
+    ) -> None:
+        monkeypatch.setattr(cli_server, "model_file_present", lambda: False)
+
+        def unreachable(vs):  # pragma: no cover - staleness needs an embed_fn
+            raise AssertionError("staleness must not be probed without an embed_fn")
+
+        monkeypatch.setattr(cli_server, "store_embedding_space_is_stale", unreachable)
+        taskrunner_env["install_runner"](_Result("completed"))
+        args = argparse.Namespace(
+            spec=str(_spec(tmp_path)), no_test=False, fresh=False, timeout=0, name=""
+        )
+        asyncio.run(cli_server._run_task(args))
+        assert taskrunner_env["vector"].embed_fn is None
+        # The factory stays wired even without the model.
+        assert taskrunner_env["vector"].embed_fn_factory is not None
+        assert "keyword search for this run" in capsys.readouterr().err
+
+    def test_stale_vector_space_clears_both_embed_hooks(
+        self, taskrunner_env, tmp_path, monkeypatch, capsys
+    ) -> None:
+        monkeypatch.setattr(cli_server, "store_embedding_space_is_stale", lambda vs: True)
+        taskrunner_env["install_runner"](_Result("completed"))
+        args = argparse.Namespace(
+            spec=str(_spec(tmp_path)), no_test=False, fresh=False, timeout=0, name=""
+        )
+        asyncio.run(cli_server._run_task(args))
+        vector = taskrunner_env["vector"]
+        assert vector.embed_fn is None
+        assert vector.embed_fn_factory is None
+        assert "Embedding model changed" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# _update — git checkout path
+# --------------------------------------------------------------------------
+
+
+class _GitStub:
+    """Routes ``subprocess.run`` by argv prefix so each branch is reachable."""
+
+    def __init__(self, **rc: int) -> None:
+        self.rc = rc
+        self.calls: list[list[str]] = []
+        self.status_out = ""
+
+    def __call__(self, argv, **kw):
+        self.calls.append(list(argv))
+        if argv[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(argv, self.rc.get("rev_parse", 0), "main\n", "")
+        if argv[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(argv, self.rc.get("fetch", 0), "", "no remote")
+        if argv[:2] == ["git", "diff"]:
+            return subprocess.CompletedProcess(argv, self.rc.get("diff", 1), "", "")
+        if argv[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(argv, 0, self.status_out, "")
+        if argv[:2] == ["git", "reset"]:
+            return subprocess.CompletedProcess(argv, self.rc.get("reset", 0), "", "dirty")
+        if argv[0] == "kiro-cli":
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        if "pip" in argv:
+            return subprocess.CompletedProcess(argv, self.rc.get("pip", 0), "", "wheel error")
+        return subprocess.CompletedProcess(argv, self.rc.get("setup", 0), "", "")
+
+
+@pytest.fixture
+def git_checkout(monkeypatch, tmp_path):
+    """A KIROCREW_PROJECT_DIR that looks like a git checkout, with git stubbed out."""
+    proj = tmp_path / "proj"
+    (proj / ".git").mkdir(parents=True)
+    monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+    monkeypatch.setattr(
+        "kiro_crew.platform.update_governance.resolve_remote_url",
+        lambda p, remote="", branch="": "https://github.com/kirodotdev/KiroCrew.git",
+    )
+    monkeypatch.setattr(
+        "kiro_crew.platform.update_governance.update_blocked_reason", lambda url: ""
+    )
+    monkeypatch.setattr(cli_server.shutil, "which", lambda name: None)
+    monkeypatch.setattr(cli_server, "build_frontend_sync", lambda p: None)
+    monkeypatch.setattr("kiro_crew.cli._ensure_node", lambda *a: None)
+    return proj
+
+
+class TestUpdateGitPath:
+    """Every early-exit branch of the git update, plus the full success path."""
+
+    def test_branch_detection_failure_exits(self, monkeypatch, git_checkout, capsys) -> None:
+        monkeypatch.setattr(subprocess, "run", _GitStub(rev_parse=128))
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update()
+        assert exc.value.code == 1
+        assert "Could not determine current branch" in capsys.readouterr().out
+
+    def test_detached_head_is_treated_as_mainline_and_pin_is_checked_first(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        stub = _GitStub()
+
+        def _run(argv, **kw):
+            if argv[:2] == ["git", "rev-parse"]:
+                return subprocess.CompletedProcess(argv, 0, "HEAD\n", "")
+            return stub(argv, **kw)
+
+        monkeypatch.setattr(subprocess, "run", _run)
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_governance.update_blocked_reason",
+            lambda url: "remote not on the fleet allowlist",
+        )
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update()
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "blocked by security policy" in out
+        assert "fleet allowlist" in out
+        # Blocked before any fetch touched the tree.
+        assert not any(c[:2] == ["git", "fetch"] for c in stub.calls)
+
+    def test_fetch_failure_exits(self, monkeypatch, git_checkout, capsys) -> None:
+        monkeypatch.setattr(subprocess, "run", _GitStub(fetch=1))
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update()
+        assert exc.value.code == 1
+        assert "git fetch failed" in capsys.readouterr().out
+
+    def test_no_new_commits_returns_without_resetting(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        stub = _GitStub(diff=0)
+        monkeypatch.setattr(subprocess, "run", stub)
+        cli_server._update()
+        assert "Already up to date" in capsys.readouterr().out
+        assert not any(c[:2] == ["git", "reset"] for c in stub.calls)
+
+    def test_local_changes_prompt_and_abort_leaves_tree_alone(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        stub = _GitStub()
+        stub.status_out = " M src/a.py\n?? scratch.txt\n"
+        monkeypatch.setattr(subprocess, "run", stub)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update()
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "will be discarded" in out
+        assert " M src/a.py" in out
+        assert "?? scratch.txt" not in out  # untracked files are preserved, not listed
+        assert "Aborted." in out
+        assert not any(c[:2] == ["git", "reset"] for c in stub.calls)
+
+    def test_local_changes_confirmed_proceeds_to_reset(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        stub = _GitStub()
+        stub.status_out = " M src/a.py\n"
+        monkeypatch.setattr(subprocess, "run", stub)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "Y")
+        cli_server._update()
+        assert any(c[:2] == ["git", "reset"] for c in stub.calls)
+        assert "Kiro Crew updated!" in capsys.readouterr().out
+
+    def test_reset_failure_exits(self, monkeypatch, git_checkout, capsys) -> None:
+        monkeypatch.setattr(subprocess, "run", _GitStub(reset=1))
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update()
+        assert exc.value.code == 1
+        assert "git reset failed" in capsys.readouterr().out
+
+    def test_pip_install_failure_exits(self, monkeypatch, git_checkout, capsys) -> None:
+        monkeypatch.setattr(subprocess, "run", _GitStub(pip=1))
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update()
+        assert exc.value.code == 1
+        assert "Install failed" in capsys.readouterr().out
+
+    def test_success_updates_kiro_cli_and_refreshes_agent_config(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        stub = _GitStub()
+        monkeypatch.setattr(subprocess, "run", stub)
+        monkeypatch.setattr(cli_server.shutil, "which", lambda name: "/usr/bin/kiro-cli")
+        built: list[Path] = []
+        monkeypatch.setattr(cli_server, "build_frontend_sync", lambda p: built.append(p))
+        cli_server._update()
+        out = capsys.readouterr().out
+        assert "Kiro Crew updated!" in out
+        assert "Agent config refreshed" in out
+        assert built == [git_checkout]
+        assert ["kiro-cli", "update"] in stub.calls
+        assert any("setup" in c for c in stub.calls)
+
+    def test_agent_config_refresh_failure_only_warns(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        monkeypatch.setattr(subprocess, "run", _GitStub(setup=1))
+        cli_server._update()  # non-fatal
+        out = capsys.readouterr().out
+        assert "Kiro Crew updated!" in out
+        assert "Agent config refresh failed" in out
+
+
+class TestUpdateWheelDispatch:
+    """No git checkout means the wheel path gets a correctly shaped layout."""
+
+    def test_layout_is_built_from_the_distribution(self, monkeypatch, capsys) -> None:
+        monkeypatch.delenv("KIROCREW_PROJECT_DIR", raising=False)
+        monkeypatch.setattr("kiro_crew.beacon.distribution", lambda: "wheel")
+        seen: list[InstallLayout] = []
+        monkeypatch.setattr(cli_server, "_update_wheel", lambda layout: seen.append(layout))
+        cli_server._update()
+        assert len(seen) == 1
+        assert seen[0].kind == "wheel"
+        assert seen[0].is_git is False
+        assert seen[0].is_externally_managed is False
+
+    def test_unknown_distribution_defaults_to_wheel(self, monkeypatch) -> None:
+        monkeypatch.delenv("KIROCREW_PROJECT_DIR", raising=False)
+        monkeypatch.setattr("kiro_crew.beacon.distribution", lambda: "")
+        seen: list[InstallLayout] = []
+        monkeypatch.setattr(cli_server, "_update_wheel", lambda layout: seen.append(layout))
+        cli_server._update()
+        assert seen[0].kind == "wheel"
+
+
+# --------------------------------------------------------------------------
+# _update_wheel — feed validation and installer failures
+# --------------------------------------------------------------------------
+
+
+_LAYOUT = InstallLayout(
+    kind="wheel", proj="", is_git=False, is_externally_managed=False, guidance=""
+)
+
+
+@pytest.fixture
+def wheel_feed(monkeypatch):
+    """Pin the CDN bases, channel, and installer command; return a payload setter."""
+    monkeypatch.setattr(
+        "kiro_crew.platform.update_layout.cdn_bases",
+        lambda: ("https://cdn.example.com", "https://cdn.example.com"),
+    )
+    monkeypatch.setattr("kiro_crew.platform.update_layout.release_channel", lambda: "stable")
+    monkeypatch.setattr(
+        "kiro_crew.platform.update_layout.wheel_update_command",
+        lambda channel=None: "curl -fsSL https://cdn.example.com/cli.sh | sh",
+    )
+    monkeypatch.setattr(
+        "kiro_crew.platform.update_governance.update_blocked_reason", lambda url: ""
+    )
+
+    def _no_network(*a, **k):
+        raise AssertionError("the feed must not be fetched on this path")
+
+    # Default-deny so a validation branch that is supposed to exit BEFORE the
+    # fetch can never reach the real CDN from a test runner.
+    monkeypatch.setattr("urllib.request.urlopen", _no_network)
+
+    def _serve(payload: bytes) -> None:
+        monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: _Resp(payload))
+
+    return _serve
+
+
+class TestUpdateWheelFeedValidation:
+    """A hostile or broken feed must never reach the installer."""
+
+    def test_pinned_feed_base_blocks_the_update(self, monkeypatch, wheel_feed, capsys) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_governance.update_blocked_reason",
+            lambda url: "source pinned to an internal mirror",
+        )
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update_wheel(_LAYOUT)
+        assert exc.value.code == 1
+        assert "internal mirror" in capsys.readouterr().out
+
+    def test_pinned_artifact_base_blocks_even_when_the_feed_is_allowed(
+        self, monkeypatch, wheel_feed, capsys
+    ) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_layout.cdn_bases",
+            lambda: ("https://feed.example.com", "https://artifacts.example.com"),
+        )
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_governance.update_blocked_reason",
+            lambda url: "" if "feed" in url else "artifact host not allowed",
+        )
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update_wheel(_LAYOUT)
+        assert exc.value.code == 1
+        assert "artifact host not allowed" in capsys.readouterr().out
+
+    def test_cdn_base_with_shell_metacharacters_is_refused(
+        self, monkeypatch, wheel_feed, capsys
+    ) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_layout.cdn_bases",
+            lambda: ("https://cdn.example.com;id", "https://cdn.example.com"),
+        )
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update_wheel(_LAYOUT)
+        assert exc.value.code == 1
+        assert "disallowed characters" in capsys.readouterr().out
+
+    def test_oversized_feed_is_refused(self, wheel_feed, capsys) -> None:
+        wheel_feed(b"x" * (65536 + 10))
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update_wheel(_LAYOUT)
+        assert exc.value.code == 1
+        assert "too large" in capsys.readouterr().out
+
+    def test_non_json_feed_is_refused(self, wheel_feed, capsys) -> None:
+        wheel_feed(b"<html>404</html>")
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update_wheel(_LAYOUT)
+        assert exc.value.code == 1
+        assert "not valid JSON" in capsys.readouterr().out
+
+    def test_json_array_feed_is_refused(self, wheel_feed, capsys) -> None:
+        wheel_feed(b"[]")
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update_wheel(_LAYOUT)
+        assert exc.value.code == 1
+        assert "unexpected format" in capsys.readouterr().out
+
+    def test_channel_mismatch_is_refused(self, wheel_feed, capsys) -> None:
+        wheel_feed(
+            b'{"schema": "kirocrew-cli-artifact-manifest-v1", '
+            b'"channel": "insider", "version": "9.9.9"}'
+        )
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update_wheel(_LAYOUT)
+        assert exc.value.code == 1
+        assert "Feed channel mismatch" in capsys.readouterr().out
+
+    def test_missing_version_is_refused(self, wheel_feed, capsys) -> None:
+        wheel_feed(b'{"schema": "kirocrew-cli-artifact-manifest-v1", "channel": "stable"}')
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update_wheel(_LAYOUT)
+        assert exc.value.code == 1
+        assert "No version in release feed" in capsys.readouterr().out
+
+
+class TestUpdateWheelInstaller:
+    """Once the feed is trusted, the installer's failure modes stay actionable."""
+
+    @pytest.fixture(autouse=True)
+    def _newer_feed(self, wheel_feed, monkeypatch):
+        wheel_feed(
+            b'{"schema": "kirocrew-cli-artifact-manifest-v1", '
+            b'"channel": "stable", "version": "999.0.0"}'
+        )
+        monkeypatch.setattr(sys, "platform", "linux")
+
+    def test_windows_refuses_the_posix_installer(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(sys, "platform", "win32")
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update_wheel(_LAYOUT)
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "not supported on Windows" in out
+        assert "cli.sh | sh" in out  # manual command still printed
+
+    def test_missing_sh_prints_the_manual_command(self, monkeypatch, capsys) -> None:
+        def boom(*a, **k):
+            raise FileNotFoundError("sh")
+
+        monkeypatch.setattr(subprocess, "run", boom)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update_wheel(_LAYOUT)
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "'sh' not found" in out
+        assert "cli.sh | sh" in out
+
+    def test_installer_timeout_prints_the_manual_command(self, monkeypatch, capsys) -> None:
+        def boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="sh", timeout=300)
+
+        monkeypatch.setattr(subprocess, "run", boom)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update_wheel(_LAYOUT)
+        assert exc.value.code == 1
+        assert "timed out" in capsys.readouterr().out
+
+    def test_installer_nonzero_exit_is_surfaced(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 17)
+        )
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update_wheel(_LAYOUT)
+        assert exc.value.code == 1
+        assert "exited with code 17" in capsys.readouterr().out
+
+    def test_success_reports_the_new_version_and_restart_hint(self, monkeypatch, capsys) -> None:
+        seen: list[list[str]] = []
+
+        def _run(argv, **kw):
+            seen.append(list(argv))
+            return subprocess.CompletedProcess(argv, 0)
+
+        monkeypatch.setattr(subprocess, "run", _run)
+        cli_server._update_wheel(_LAYOUT)
+        out = capsys.readouterr().out
+        assert "updated to 999.0.0" in out
+        assert "kirocrew restart" in out
+        assert seen[0][:2] == ["sh", "-c"]
+
+    def test_unparseable_remote_version_updates_anyway(
+        self, monkeypatch, wheel_feed, capsys
+    ) -> None:
+        """``_is_newer`` returning None must fail OPEN — an update is safer than a stall."""
+        wheel_feed(
+            b'{"schema": "kirocrew-cli-artifact-manifest-v1", '
+            b'"channel": "stable", "version": "not-a-version"}'
+        )
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0)
+        )
+        cli_server._update_wheel(_LAYOUT)
+        out = capsys.readouterr().out
+        assert "Could not compare versions" in out
+        assert "updated to not-a-version" in out
+
+    def test_already_latest_returns_without_running_the_installer(
+        self, monkeypatch, wheel_feed, capsys
+    ) -> None:
+        from kiro_crew import __version__ as local_version
+
+        wheel_feed(
+            b'{"schema": "kirocrew-cli-artifact-manifest-v1", "channel": "stable", '
+            + f'"version": "{local_version}"'.encode()
+            + b"}"
+        )
+
+        def unreachable(*a, **k):  # pragma: no cover - proves the early return
+            raise AssertionError("installer must not run when already current")
+
+        monkeypatch.setattr(subprocess, "run", unreachable)
+        cli_server._update_wheel(_LAYOUT)
+        assert "Already on the latest version" in capsys.readouterr().out

--- a/test/test_dashboard_chat_handlers_coverage.py
+++ b/test/test_dashboard_chat_handlers_coverage.py
@@ -1,0 +1,1321 @@
+"""Coverage for the untested helpers and small routes in ``chat_handlers``.
+
+Scope is deliberately the parts of the module no existing test file reaches:
+the context-meter number gate, the live model-switch path (``_wire_model_id`` /
+``_try_live_model_switch`` / ``_reapply_effort_after_live_switch``), the
+follow-up redaction + owner gate, the recent-projects store, and the small
+slot routes (color / context-inject / queue edit-cancel-reorder / workspace).
+
+Everything here is in-process: no subprocess, no git, no sandbox, no network.
+The two functions that would touch the real filesystem outside ``tmp_path``
+(``_recent_projects_path`` consumers) have ``config_dir`` redirected, and the
+one gate that is anchored on the *real* ``$HOME`` (``is_sensitive_path``) is
+injected rather than satisfied with a real credential directory.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer, make_mocked_request
+
+from kiro_crew.acp.client import AcpModelUnavailable
+from kiro_crew.dashboard import chat_handlers as ch
+from kiro_crew.dashboard.chat_persistence import get_reasoning_effort_values
+from kiro_crew.dashboard.state import _MAX_PENDING_CONTEXT, DashboardState, _ChatSlot
+from kiro_crew.providers.acp import AcpProvider
+from kiro_crew.providers.base import LLMProvider
+
+MOD = "kiro_crew.dashboard.chat_handlers"
+
+
+# ── shared fixtures / builders ───────────────────────────────────────────────
+
+
+@pytest.fixture
+def _sel():
+    """Neutralize the security event log (it otherwise opens the real store)."""
+    fake = MagicMock()
+    with patch(f"{MOD}.sel", return_value=fake):
+        yield fake
+
+
+def _state(slot: _ChatSlot | None = None) -> DashboardState:
+    state = MagicMock(spec=DashboardState)
+    state._slots = {}
+    if slot is not None:
+        state._slots[slot.key] = slot
+    state.push_slots_update = MagicMock()
+    state.broadcast_ws = MagicMock()
+    state.broadcast_context_usage = MagicMock()
+    state.sessions = MagicMock()
+    state.sessions.get_provider = MagicMock(return_value=None)
+    return state
+
+
+def _app(state: DashboardState, method: str, path: str, handler) -> web.Application:
+    app = web.Application()
+    app["state"] = state
+    app.router.add_route(method, path, handler)
+    return app
+
+
+def _acp(**attrs):
+    """An AcpProvider double that still satisfies ``isinstance``."""
+    provider = MagicMock(spec=AcpProvider)
+    provider.is_claude_backend = False
+    provider.has_active_turn = MagicMock(return_value=False)
+    provider.available_models = MagicMock(return_value=[])
+    provider.supports_effort = MagicMock(return_value=False)
+    provider.change_effort = AsyncMock(return_value=True)
+    provider.clear_effort = AsyncMock(return_value=True)
+    provider.client = MagicMock()
+    provider.client.set_model = AsyncMock(return_value=None)
+    for key, value in attrs.items():
+        setattr(provider, key, value)
+    return provider
+
+
+# ── _finite_number ───────────────────────────────────────────────────────────
+
+
+class TestFiniteNumber:
+    def test_int_and_float_pass_through_as_float(self):
+        assert ch._finite_number(3) == 3.0
+        assert isinstance(ch._finite_number(3), float)
+        assert ch._finite_number(0.5) == 0.5
+
+    def test_bool_is_rejected_despite_being_an_int(self):
+        # bool would otherwise serialize as 1/0 and render as a real reading.
+        assert ch._finite_number(True) is None
+        assert ch._finite_number(False) is None
+
+    def test_non_numeric_rejected(self):
+        assert ch._finite_number("42") is None
+        assert ch._finite_number(None) is None
+        assert ch._finite_number([1]) is None
+
+    def test_nan_and_inf_rejected(self):
+        assert ch._finite_number(float("nan")) is None
+        assert ch._finite_number(float("inf")) is None
+        assert ch._finite_number(float("-inf")) is None
+
+
+# ── _context_reading ─────────────────────────────────────────────────────────
+
+
+class TestContextReading:
+    def test_unusable_pct_yields_no_reading(self):
+        assert ch._context_reading("x", 10, 200, stale=False) == {}
+
+    def test_zero_pct_without_window_is_not_a_measurement(self):
+        assert ch._context_reading(0, 0, 0, stale=False) == {}
+
+    def test_zero_pct_with_window_is_reported(self):
+        out = ch._context_reading(0, 0, 200_000, stale=False)
+        assert out["context_pct"] == 0.0
+        assert out["context_window_tokens"] == 200_000
+        assert "context_used_tokens" not in out
+
+    def test_pct_only_reading_omits_token_fields(self):
+        out = ch._context_reading(11.5, 0, 0, stale=False)
+        assert out == {"context_pct": 11.5, "context_stale": False}
+
+    def test_full_reading_carries_both_counts(self):
+        out = ch._context_reading(44, 88_000, 200_000, stale=False)
+        assert out["context_used_tokens"] == 88_000
+        assert out["context_window_tokens"] == 200_000
+        assert out["context_stale"] is False
+
+    def test_stale_reading_drops_used_but_keeps_window(self):
+        out = ch._context_reading(44, 88_000, 200_000, stale=True)
+        assert out["context_stale"] is True
+        assert out["context_window_tokens"] == 200_000
+        assert "context_used_tokens" not in out
+
+
+# ── _context_snapshot_fields / _inner ────────────────────────────────────────
+
+
+class TestContextSnapshotFields:
+    @pytest.mark.asyncio
+    async def test_live_provider_is_authoritative(self):
+        slot = _ChatSlot("s1")
+        state = _state(slot)
+        provider = MagicMock()
+        provider.context_usage_pct = MagicMock(return_value=33.0)
+        provider.context_used_tokens = MagicMock(return_value=66_000)
+        provider.context_window_tokens = MagicMock(return_value=200_000)
+        state.sessions.get_provider = MagicMock(return_value=provider)
+
+        out = await ch._context_snapshot_fields(state, slot)
+
+        assert out["context_pct"] == 33.0
+        assert out["context_used_tokens"] == 66_000
+        assert out["context_stale"] is False
+        # A live reading must not pay for the snapshot file.
+        state.ensure_context_snapshots_loaded.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cold_session_falls_back_to_snapshot_marked_stale(self):
+        slot = _ChatSlot("s1")
+        slot.model = "opus-4.8-1m"
+        state = _state(slot)
+        state.context_snapshot_for = MagicMock(
+            return_value={
+                "model": "opus-4.8-1m",
+                "pct": 12.0,
+                "used_tokens": 24_000,
+                "window_tokens": 200_000,
+            }
+        )
+
+        out = await ch._context_snapshot_fields(state, slot)
+
+        assert out["context_pct"] == 12.0
+        assert out["context_stale"] is True
+        assert "context_used_tokens" not in out
+        state.ensure_context_snapshots_loaded.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_snapshot_from_a_different_model_is_discarded(self):
+        slot = _ChatSlot("s1")
+        slot.model = "sonnet-4.5"
+        state = _state(slot)
+        state.context_snapshot_for = MagicMock(
+            return_value={"model": "opus-4.8-1m", "pct": 90.0, "window_tokens": 200_000}
+        )
+
+        assert await ch._context_snapshot_fields(state, slot) == {}
+
+    @pytest.mark.asyncio
+    async def test_missing_snapshot_yields_empty(self):
+        slot = _ChatSlot("s1")
+        state = _state(slot)
+        state.context_snapshot_for = MagicMock(return_value=None)
+
+        assert await ch._context_snapshot_fields(state, slot) == {}
+
+    @pytest.mark.asyncio
+    async def test_failure_degrades_to_empty_instead_of_raising(self):
+        slot = _ChatSlot("s1")
+        state = _state(slot)
+        state.sessions.get_provider = MagicMock(side_effect=RuntimeError("pool gone"))
+
+        assert await ch._context_snapshot_fields(state, slot) == {}
+
+
+# ── _has_conversation ────────────────────────────────────────────────────────
+
+
+class TestHasConversation:
+    def test_empty_slot_has_nothing_to_continue_from(self):
+        assert ch._has_conversation(_ChatSlot("s1")) is False
+
+    def test_compaction_notice_alone_is_scaffolding(self):
+        slot = _ChatSlot("s1")
+        slot.messages.append(
+            {"role": "assistant", "content": "compacted", "meta": {"kind": "compaction"}}
+        )
+        assert ch._has_conversation(slot) is False
+
+    def test_empty_content_does_not_count(self):
+        slot = _ChatSlot("s1")
+        slot.messages.append({"role": "user", "content": ""})
+        assert ch._has_conversation(slot) is False
+
+    def test_a_real_user_row_qualifies(self):
+        slot = _ChatSlot("s1")
+        slot.messages.append({"role": "system", "content": "boot"})
+        slot.messages.append({"role": "user", "content": "hi"})
+        assert ch._has_conversation(slot) is True
+
+
+# ── _wire_model_id ───────────────────────────────────────────────────────────
+
+
+class TestWireModelId:
+    def test_claude_backend_cannot_express_default(self):
+        assert ch._wire_model_id(_acp(is_claude_backend=True), "sonnet-4.5") == "sonnet-4.5"
+        assert ch._wire_model_id(_acp(is_claude_backend=True), "") == ""
+        assert ch._wire_model_id(_acp(is_claude_backend=True), "auto") == ""
+
+    def test_claude_backend_translates_canonical_key(self):
+        wire = ch._wire_model_id(_acp(is_claude_backend=True), "opus-4.8-1m")
+        assert wire == "global.anthropic.claude-opus-4-8[1m]"
+
+    def test_kiro_default_needs_auto_to_be_advertised(self):
+        without = _acp(available_models=MagicMock(return_value=[{"modelId": "claude-opus-4.8"}]))
+        assert ch._wire_model_id(without, "") == ""
+        with_auto = _acp(
+            available_models=MagicMock(
+                return_value=[{"modelId": "auto"}, {"modelId": "claude-opus-4.8"}]
+            )
+        )
+        assert ch._wire_model_id(with_auto, "auto") == "auto"
+
+    def test_kiro_translates_canonical_key_to_dotted_id(self):
+        assert ch._wire_model_id(_acp(), "opus-4.8-1m") == "claude-opus-4.8"
+
+
+# ── _reapply_effort_after_live_switch ────────────────────────────────────────
+
+
+class TestReapplyEffortAfterLiveSwitch:
+    @pytest.mark.asyncio
+    async def test_model_without_effort_selector_is_a_persisted_noop(self):
+        slot = _ChatSlot("s1")
+        slot.reasoning_effort = "high"
+        provider = _acp(supports_effort=MagicMock(return_value=False))
+
+        assert await ch._reapply_effort_after_live_switch("s1", slot, provider) is True
+        provider.change_effort.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_slot_override_is_pushed_and_its_result_returned(self):
+        slot = _ChatSlot("s1")
+        slot.reasoning_effort = "high"
+        provider = _acp(
+            supports_effort=MagicMock(return_value=True),
+            change_effort=AsyncMock(return_value=False),
+        )
+
+        assert await ch._reapply_effort_after_live_switch("s1", slot, provider) is False
+        provider.change_effort.assert_awaited_once_with("high")
+
+    @pytest.mark.asyncio
+    async def test_no_override_reresolves_default_and_ignores_its_result(self):
+        slot = _ChatSlot("s1")
+        slot.reasoning_effort = ""
+        provider = _acp(
+            supports_effort=MagicMock(return_value=True),
+            clear_effort=AsyncMock(return_value=False),
+        )
+
+        # False from clear_effort is benign: no default existed to push.
+        assert await ch._reapply_effort_after_live_switch("s1", slot, provider) is True
+        provider.clear_effort.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_provider_error_asks_for_a_reset(self):
+        slot = _ChatSlot("s1")
+        slot.reasoning_effort = "max"
+        provider = _acp(
+            supports_effort=MagicMock(return_value=True),
+            change_effort=AsyncMock(side_effect=RuntimeError("stdout busy")),
+        )
+
+        assert await ch._reapply_effort_after_live_switch("s1", slot, provider) is False
+
+
+# ── _try_live_model_switch ───────────────────────────────────────────────────
+
+
+class TestTryLiveModelSwitch:
+    @pytest.mark.asyncio
+    async def test_non_acp_provider_falls_back_to_reset(self):
+        slot = _ChatSlot("s1")
+        assert await ch._try_live_model_switch("s1", slot, None, "opus-4.8-1m") is False
+        other = MagicMock(spec=LLMProvider)
+        assert await ch._try_live_model_switch("s1", slot, other, "opus-4.8-1m") is False
+
+    @pytest.mark.asyncio
+    async def test_active_turn_falls_back_to_reset(self):
+        provider = _acp(has_active_turn=MagicMock(return_value=True))
+        assert (
+            await ch._try_live_model_switch("s1", _ChatSlot("s1"), provider, "opus-4.8-1m") is False
+        )
+        provider.client.set_model.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unrepresentable_target_falls_back_to_reset(self):
+        # kiro backend that never advertised "auto" cannot express the default.
+        provider = _acp(available_models=MagicMock(return_value=[{"modelId": "claude-opus-4.8"}]))
+        assert await ch._try_live_model_switch("s1", _ChatSlot("s1"), provider, "") is False
+        provider.client.set_model.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_model_unavailable_propagates_instead_of_resetting(self):
+        provider = _acp()
+        provider.client.set_model = AsyncMock(side_effect=AcpModelUnavailable("nope"))
+        with pytest.raises(AcpModelUnavailable):
+            await ch._try_live_model_switch("s1", _ChatSlot("s1"), provider, "opus-4.8-1m")
+
+    @pytest.mark.asyncio
+    async def test_generic_set_model_failure_falls_back_to_reset(self):
+        provider = _acp()
+        provider.client.set_model = AsyncMock(side_effect=RuntimeError("broken pipe"))
+        assert (
+            await ch._try_live_model_switch("s1", _ChatSlot("s1"), provider, "opus-4.8-1m") is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_effort_reapply_failure_falls_back_to_reset(self):
+        provider = _acp(
+            supports_effort=MagicMock(return_value=True),
+            change_effort=AsyncMock(side_effect=RuntimeError("x")),
+        )
+        slot = _ChatSlot("s1")
+        slot.reasoning_effort = "high"
+
+        assert await ch._try_live_model_switch("s1", slot, provider, "opus-4.8-1m") is False
+        provider.client.set_model.assert_awaited_once_with("claude-opus-4.8")
+
+    @pytest.mark.asyncio
+    async def test_success_sends_the_wire_id(self):
+        provider = _acp()
+        assert await ch._try_live_model_switch("s1", _ChatSlot("s1"), provider, "sonnet-4.5") is True
+        provider.client.set_model.assert_awaited_once_with("claude-sonnet-4.5")
+
+
+# ── _broadcast_context_reset ─────────────────────────────────────────────────
+
+
+class TestBroadcastContextReset:
+    def test_no_provider_sends_a_zeroed_reset(self):
+        state = _state()
+        ch._broadcast_context_reset(state, "s1", None)
+        state.broadcast_context_usage.assert_called_once()
+        _, payload = state.broadcast_context_usage.call_args.args
+        assert payload == {"slot": "s1", "pct": 0.0, "reset": True}
+
+    def test_live_provider_payload_carries_rebased_stats(self):
+        state = _state()
+        provider = MagicMock()
+        provider.context_usage_pct = MagicMock(return_value=7.25)
+        provider.context_window_tokens = MagicMock(return_value=200_000)
+        provider.context_used_tokens = MagicMock(return_value=14_000)
+
+        ch._broadcast_context_reset(state, "s1", provider)
+
+        _, payload = state.broadcast_context_usage.call_args.args
+        assert payload["slot"] == "s1"
+        assert payload["pct"] == 7.2
+        assert payload["reset"] is True
+
+    def test_broadcast_failure_is_swallowed(self):
+        state = _state()
+        state.broadcast_context_usage = MagicMock(side_effect=RuntimeError("no clients"))
+        # Must not raise: a failed broadcast cannot fail the model switch.
+        ch._broadcast_context_reset(state, "s1", None)
+
+
+# ── _redact_followup_item ────────────────────────────────────────────────────
+
+
+class TestRedactFollowupItem:
+    def test_missing_fields_become_empty_strings(self):
+        assert ch._redact_followup_item({}) == {"title": "", "description": "", "prompt": ""}
+
+    def test_text_fields_are_redacted(self):
+        secret = "ghp_" + "A" * 36
+        out = ch._redact_followup_item({"title": f"use {secret}", "prompt": "ok"})
+        assert secret not in out["title"]
+        assert "REDACTED" in out["title"]
+        assert out["prompt"] == "ok"
+
+    def test_clean_branch_is_kept(self):
+        out = ch._redact_followup_item({"title": "t", "branch": "feat/thing"})
+        assert out["branch"] == "feat/thing"
+
+    def test_branch_is_dropped_when_redaction_changes_it(self):
+        # A mangled ref is worse than no ref: the frontend derives one instead.
+        out = ch._redact_followup_item({"title": "t", "branch": "feat/" + "ghp_" + "A" * 36})
+        assert "branch" not in out
+
+    def test_non_string_branch_is_ignored(self):
+        assert "branch" not in ch._redact_followup_item({"title": "t", "branch": 7})
+
+
+# ── deny_non_dashboard_caller ────────────────────────────────────────────────
+
+
+class TestDenyNonDashboardCaller:
+    def test_internal_secret_caller_is_allowed_without_an_app_claim(self):
+        request = make_mocked_request("POST", "/x")
+        request["internal_auth"] = True
+        # No owner predicate should even be consulted on this path.
+        with patch(
+            "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request"
+        ) as owner:
+            assert ch.deny_non_dashboard_caller(request, "op") is None
+            owner.assert_not_called()
+
+    def test_owner_request_is_allowed(self, _sel):
+        request = make_mocked_request("POST", "/x")
+        with patch(
+            "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+            return_value=True,
+        ):
+            assert ch.deny_non_dashboard_caller(request, "op") is None
+
+    def test_non_owner_is_refused_and_audited(self, _sel):
+        request = make_mocked_request("POST", "/x")
+        request["user"] = "someone-else"
+        with patch(
+            "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+            return_value=False,
+        ):
+            resp = ch.deny_non_dashboard_caller(request, "chat_slot_followup")
+        assert resp is not None
+        assert resp.status == 403
+        _sel.log_api_access.assert_called_once()
+        assert _sel.log_api_access.call_args.kwargs["outcome"] == "denied"
+
+    def test_audit_failure_still_refuses(self, _sel):
+        _sel.log_api_access.side_effect = RuntimeError("sel down")
+        request = make_mocked_request("POST", "/x")
+        with patch(
+            "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+            return_value=False,
+        ):
+            resp = ch.deny_non_dashboard_caller(request, "op")
+        assert resp is not None and resp.status == 403
+
+
+# ── recent projects store ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def _recent_dir(tmp_path: Path):
+    """Point the recent-projects file at tmp_path."""
+    with patch(f"{MOD}.config_dir", return_value=tmp_path):
+        yield tmp_path
+
+
+class TestRecentProjects:
+    def test_path_is_derived_from_config_dir(self, _recent_dir):
+        assert ch._recent_projects_path() == _recent_dir / "recent_projects.json"
+
+    def test_save_prepends_and_dedupes(self, _recent_dir):
+        ch._save_recent_project("/a")
+        ch._save_recent_project("/b")
+        ch._save_recent_project("/a")
+        stored = json.loads((_recent_dir / "recent_projects.json").read_text(encoding="utf-8"))
+        assert stored == ["/a", "/b"]
+
+    def test_save_caps_the_list(self, _recent_dir):
+        fp = _recent_dir / "recent_projects.json"
+        fp.write_text(json.dumps([f"/p{i}" for i in range(ch._MAX_RECENT_PROJECTS + 20)]), "utf-8")
+        ch._save_recent_project("/new")
+        stored = json.loads(fp.read_text(encoding="utf-8"))
+        assert len(stored) == ch._MAX_RECENT_PROJECTS
+        assert stored[0] == "/new"
+
+    def test_corrupt_file_is_replaced_not_raised(self, _recent_dir):
+        fp = _recent_dir / "recent_projects.json"
+        fp.write_text("{not json", encoding="utf-8")
+        ch._save_recent_project("/a")
+        assert json.loads(fp.read_text(encoding="utf-8")) == ["/a"]
+
+    def test_non_list_payload_is_discarded(self, _recent_dir):
+        fp = _recent_dir / "recent_projects.json"
+        fp.write_text(json.dumps({"dirs": ["/a"]}), encoding="utf-8")
+        ch._save_recent_project("/b")
+        assert json.loads(fp.read_text(encoding="utf-8")) == ["/b"]
+
+    def test_no_temp_file_is_left_behind_on_write_failure(self, _recent_dir):
+        with patch(f"{MOD}.os.replace", side_effect=OSError("read-only")):
+            with pytest.raises(OSError):
+                ch._save_recent_project("/a")
+        assert list(_recent_dir.glob("*.tmp")) == []
+
+    @pytest.mark.asyncio
+    async def test_endpoint_drops_missing_and_non_string_entries(self, _recent_dir, _sel):
+        real = _recent_dir / "proj"
+        real.mkdir()
+        (_recent_dir / "recent_projects.json").write_text(
+            json.dumps([str(real), str(_recent_dir / "gone"), 7]), encoding="utf-8"
+        )
+        state = _state()
+        app = _app(state, "GET", "/api/recent-projects", ch.api_recent_projects)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/api/recent-projects")
+            assert resp.status == 200
+            assert (await resp.json())["dirs"] == [str(real)]
+
+    @pytest.mark.asyncio
+    async def test_endpoint_drops_sensitive_directories(self, _recent_dir, _sel):
+        real = _recent_dir / "proj"
+        real.mkdir()
+        (_recent_dir / "recent_projects.json").write_text(json.dumps([str(real)]), encoding="utf-8")
+        state = _state()
+        app = _app(state, "GET", "/api/recent-projects", ch.api_recent_projects)
+        # is_sensitive_path is anchored on the real $HOME, so inject the verdict
+        # rather than materialize a credential directory on this machine.
+        with patch(f"{MOD}.is_sensitive_path", return_value=True):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.get("/api/recent-projects")
+                assert (await resp.json())["dirs"] == []
+
+    @pytest.mark.asyncio
+    async def test_endpoint_tolerates_an_unreadable_store(self, _recent_dir, _sel):
+        (_recent_dir / "recent_projects.json").write_text("[[[", encoding="utf-8")
+        state = _state()
+        app = _app(state, "GET", "/api/recent-projects", ch.api_recent_projects)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/api/recent-projects")
+            assert resp.status == 200
+            assert (await resp.json())["dirs"] == []
+
+
+# ── _resume_session_identity ─────────────────────────────────────────────────
+
+
+class TestResumeSessionIdentity:
+    def test_dashboard_key_gets_the_dashboard_spelling(self):
+        state = _state()
+        assert ch._resume_session_identity(state, "mytab") == "dashboard:mytab"
+
+    def test_channel_key_resolves_through_the_session_map(self):
+        state = _state()
+        state.sessions.channel_key_for_stem = MagicMock(return_value="slack:1712.44")
+        assert ch._resume_session_identity(state, "slack_1712_44") == "slack:1712.44"
+
+    def test_unmapped_channel_key_falls_back_to_dashboard_spelling(self):
+        state = _state()
+        state.sessions.channel_key_for_stem = MagicMock(return_value="")
+        assert ch._resume_session_identity(state, "slack_1712_44") == "dashboard:slack_1712_44"
+
+
+# ── _get_pattern_from_pending ────────────────────────────────────────────────
+
+
+class TestGetPatternFromPending:
+    def test_empty_request_id_short_circuits(self):
+        assert ch._get_pattern_from_pending(_ChatSlot("s1"), "", "pattern") == ""
+
+    def test_matching_permission_row_yields_the_field(self):
+        slot = _ChatSlot("s1")
+        slot.messages.append(
+            {"role": "permission", "cls": json.dumps({"request_id": "r1", "pattern": "rm -rf"})}
+        )
+        assert ch._get_pattern_from_pending(slot, "r1", "pattern") == "rm -rf"
+
+    def test_absent_field_yields_empty_string(self):
+        slot = _ChatSlot("s1")
+        slot.messages.append({"role": "permission", "cls": json.dumps({"request_id": "r1"})})
+        assert ch._get_pattern_from_pending(slot, "r1", "pattern") == ""
+
+    def test_non_object_and_malformed_cls_are_skipped_not_raised(self):
+        slot = _ChatSlot("s1")
+        slot.messages.append({"role": "permission", "cls": "[1, 2]"})
+        slot.messages.append({"role": "permission", "cls": "{not json"})
+        slot.messages.append({"role": "assistant", "cls": json.dumps({"request_id": "r1"})})
+        assert ch._get_pattern_from_pending(slot, "r1", "pattern") == ""
+
+    def test_newest_matching_row_wins(self):
+        slot = _ChatSlot("s1")
+        slot.messages.append(
+            {"role": "permission", "cls": json.dumps({"request_id": "r1", "pattern": "old"})}
+        )
+        slot.messages.append(
+            {"role": "permission", "cls": json.dumps({"request_id": "r1", "pattern": "new"})}
+        )
+        assert ch._get_pattern_from_pending(slot, "r1", "pattern") == "new"
+
+
+# ── PATCH /api/chat/slots/{slot}/color ───────────────────────────────────────
+
+
+class TestSlotColor:
+    async def _patch(self, state, name, payload):
+        app = _app(state, "PATCH", "/api/chat/slots/{slot}/color", ch.api_chat_slot_color)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.patch(f"/api/chat/slots/{name}/color", json=payload)
+            return resp.status, await resp.json()
+
+    @pytest.mark.asyncio
+    async def test_unknown_slot_is_404(self):
+        status, _ = await self._patch(_state(), "missing", {"color_index": 1})
+        assert status == 404
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self):
+        slot = _ChatSlot("s1")
+        state = _state(slot)
+        app = _app(state, "PATCH", "/api/chat/slots/{slot}/color", ch.api_chat_slot_color)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.patch(
+                "/api/chat/slots/s1/color",
+                data="not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_index_is_rejected(self):
+        slot = _ChatSlot("s1")
+        status, body = await self._patch(_state(slot), "s1", {"color_index": ch.MAX_COLOR_INDEX + 1})
+        assert status == 400
+        assert str(ch.MAX_COLOR_INDEX) in body["error"]
+        assert slot.color_index is None
+
+    @pytest.mark.asyncio
+    async def test_negative_index_is_rejected(self):
+        slot = _ChatSlot("s1")
+        status, _ = await self._patch(_state(slot), "s1", {"color_index": -1})
+        assert status == 400
+
+    @pytest.mark.asyncio
+    async def test_bool_index_is_rejected(self):
+        slot = _ChatSlot("s1")
+        status, _ = await self._patch(_state(slot), "s1", {"color_index": True})
+        assert status == 400
+
+    @pytest.mark.asyncio
+    async def test_valid_index_is_stored_and_pushed(self):
+        slot = _ChatSlot("s1")
+        state = _state(slot)
+        status, body = await self._patch(state, "s1", {"color_index": 3})
+        assert (status, body) == (200, {"ok": True, "color_index": 3})
+        assert slot.color_index == 3
+        assert slot._dirty is True
+        state.push_slots_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_null_clears_the_color(self):
+        slot = _ChatSlot("s1")
+        slot.color_index = 5
+        status, body = await self._patch(_state(slot), "s1", {"color_index": None})
+        assert (status, body) == (200, {"ok": True, "color_index": None})
+        assert slot.color_index is None
+
+
+# ── POST /api/chat/slots/{slot}/context ──────────────────────────────────────
+
+
+class TestSlotContextInject:
+    async def _post(self, state, name, payload, *, app_claim: str | None = None):
+        async def route(request: web.Request) -> web.Response:
+            if app_claim is not None:
+                request["app"] = app_claim
+            return await ch.api_chat_slot_context(request)
+
+        app = _app(state, "POST", "/api/chat/slots/{slot}/context", route)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(f"/api/chat/slots/{name}/context", json=payload)
+            return resp.status, await resp.json()
+
+    @pytest.mark.asyncio
+    async def test_unknown_slot_is_404(self, _sel):
+        status, body = await self._post(_state(), "missing", {"content": "x"})
+        assert status == 404
+        assert body["error"] == "slot not found"
+
+    @pytest.mark.asyncio
+    async def test_app_token_cannot_reach_an_unscoped_slot(self, _sel):
+        slot = _ChatSlot("s1")
+        status, _ = await self._post(_state(slot), "s1", {"content": "x"}, app_claim="notes")
+        assert status == 404
+        assert _sel.log_api_access.call_args.kwargs["outcome"] == "denied"
+        assert slot._pending_context == []
+
+    @pytest.mark.asyncio
+    async def test_app_token_cannot_reach_another_apps_slot(self, _sel):
+        slot = _ChatSlot("s1")
+        slot._app = "meetings"
+        status, _ = await self._post(_state(slot), "s1", {"content": "x"}, app_claim="notes")
+        assert status == 404
+        assert "does not own" in _sel.log_api_access.call_args.kwargs["error"]
+
+    @pytest.mark.asyncio
+    async def test_owning_app_is_allowed(self, _sel):
+        slot = _ChatSlot("s1")
+        slot._app = "notes"
+        status, body = await self._post(_state(slot), "s1", {"content": "x"}, app_claim="notes")
+        assert (status, body) == (200, {"ok": True, "pending": 1})
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self, _sel):
+        slot = _ChatSlot("s1")
+        app = _app(_state(slot), "POST", "/api/chat/slots/{slot}/context", ch.api_chat_slot_context)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/context",
+                data="{",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_missing_content_is_400(self, _sel):
+        slot = _ChatSlot("s1")
+        status, body = await self._post(_state(slot), "s1", {"source": "watch"})
+        assert status == 400
+        assert body["error"] == "content is required"
+
+    @pytest.mark.asyncio
+    async def test_oversize_content_is_400(self, _sel):
+        slot = _ChatSlot("s1")
+        status, body = await self._post(_state(slot), "s1", {"content": "x" * 40_001})
+        assert status == 400
+        assert "40000" in body["error"]
+        assert slot._pending_context == []
+
+    @pytest.mark.asyncio
+    async def test_entry_records_source_ephemeral_and_max_age(self, _sel):
+        slot = _ChatSlot("s1")
+        status, body = await self._post(
+            _state(slot),
+            "s1",
+            {"content": "note", "source": "watch", "ephemeral": False, "maxAge": 300},
+        )
+        assert (status, body) == (200, {"ok": True, "pending": 1})
+        entry = slot._pending_context[0]
+        assert entry["content"] == "note"
+        assert entry["source"] == "watch"
+        assert entry["ephemeral"] is False
+        assert entry["maxAge"] == 300
+        assert isinstance(entry["injectedAt"], float)
+
+    @pytest.mark.asyncio
+    async def test_max_age_is_omitted_when_not_supplied(self, _sel):
+        slot = _ChatSlot("s1")
+        await self._post(_state(slot), "s1", {"content": "note"})
+        assert "maxAge" not in slot._pending_context[0]
+        assert slot._pending_context[0]["ephemeral"] is True
+
+    @pytest.mark.asyncio
+    async def test_per_source_cap_is_429(self, _sel):
+        slot = _ChatSlot("s1")
+        slot._pending_context = [
+            {"content": "c", "source": "watch"} for _ in range(ch._MAX_CONTEXT_PER_SOURCE)
+        ]
+        status, body = await self._post(_state(slot), "s1", {"content": "x", "source": "watch"})
+        assert status == 429
+        assert "watch" in body["error"]
+        # A different source is unaffected by another's cap.
+        status2, _ = await self._post(_state(slot), "s1", {"content": "x", "source": "other"})
+        assert status2 == 200
+
+    @pytest.mark.asyncio
+    async def test_queue_is_fifo_evicted_at_the_shared_ceiling(self, _sel):
+        slot = _ChatSlot("s1")
+        slot._pending_context = [{"content": f"c{i}", "source": ""} for i in range(50)]
+        assert len(slot._pending_context) == _MAX_PENDING_CONTEXT
+        status, body = await self._post(_state(slot), "s1", {"content": "newest"})
+        assert (status, body) == (200, {"ok": True, "pending": _MAX_PENDING_CONTEXT})
+        assert slot._pending_context[0]["content"] == "c1"
+        assert slot._pending_context[-1]["content"] == "newest"
+
+
+# ── queue mutation routes ────────────────────────────────────────────────────
+
+
+class TestQueueCancel:
+    async def _delete(self, state, name, qid):
+        app = _app(
+            state,
+            "DELETE",
+            "/api/chat/slots/{slot}/queue/{queue_id}",
+            ch.api_chat_slot_queue_cancel,
+        )
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.delete(f"/api/chat/slots/{name}/queue/{qid}")
+            return resp.status, await resp.json()
+
+    @pytest.mark.asyncio
+    async def test_unknown_slot_is_404(self, _sel):
+        status, _ = await self._delete(_state(), "missing", "q1")
+        assert status == 404
+
+    @pytest.mark.asyncio
+    async def test_unknown_queue_id_is_404(self, _sel):
+        slot = _ChatSlot("s1")
+        status, body = await self._delete(_state(slot), "s1", "nope")
+        assert status == 404
+        assert body["error"] == "queue item not found"
+
+    @pytest.mark.asyncio
+    async def test_cancel_removes_the_item_and_broadcasts(self, _sel):
+        slot = _ChatSlot("s1")
+        qid = slot.queue_append("second thoughts")
+        state = _state(slot)
+
+        status, body = await self._delete(state, "s1", qid)
+
+        assert status == 200
+        assert body["content"] == "second thoughts"
+        assert slot._queue == []
+        event, payload = state.broadcast_ws.call_args.args
+        assert event == "queue_cancel"
+        assert payload["queue_id"] == qid
+        state.push_slots_update.assert_called_once()
+
+
+class TestQueueEdit:
+    async def _patch(self, state, name, qid, payload):
+        app = _app(
+            state, "PATCH", "/api/chat/slots/{slot}/queue/{queue_id}", ch.api_chat_slot_queue_edit
+        )
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.patch(f"/api/chat/slots/{name}/queue/{qid}", json=payload)
+            return resp.status, await resp.json()
+
+    @pytest.mark.asyncio
+    async def test_unknown_slot_is_404(self, _sel):
+        status, _ = await self._patch(_state(), "missing", "q1", {"content": "x"})
+        assert status == 404
+
+    @pytest.mark.asyncio
+    async def test_blank_content_is_rejected(self, _sel):
+        slot = _ChatSlot("s1")
+        qid = slot.queue_append("orig")
+        status, body = await self._patch(_state(slot), "s1", qid, {"content": "   "})
+        assert status == 400
+        assert "non-empty" in body["error"]
+        assert slot._queue[0]["content"] == "orig"
+
+    @pytest.mark.asyncio
+    async def test_non_string_content_is_rejected(self, _sel):
+        slot = _ChatSlot("s1")
+        qid = slot.queue_append("orig")
+        status, _ = await self._patch(_state(slot), "s1", qid, {"content": 5})
+        assert status == 400
+
+    @pytest.mark.asyncio
+    async def test_unknown_queue_id_is_404(self, _sel):
+        slot = _ChatSlot("s1")
+        status, body = await self._patch(_state(slot), "s1", "nope", {"content": "x"})
+        assert status == 404
+        assert body["error"] == "queue item not found"
+
+    @pytest.mark.asyncio
+    async def test_edit_replaces_content_in_place(self, _sel):
+        slot = _ChatSlot("s1")
+        first = slot.queue_append("one")
+        second = slot.queue_append("two")
+        state = _state(slot)
+
+        status, body = await self._patch(state, "s1", first, {"content": "ONE"})
+
+        assert status == 200
+        assert body["content"] == "ONE"
+        assert [item["id"] for item in slot._queue] == [first, second]
+        assert slot._queue[0]["content"] == "ONE"
+        assert state.broadcast_ws.call_args.args[0] == "queue_edit"
+
+
+class TestQueueReorder:
+    async def _put(self, state, name, payload):
+        app = _app(
+            state, "PUT", "/api/chat/slots/{slot}/queue/order", ch.api_chat_slot_queue_reorder
+        )
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.put(f"/api/chat/slots/{name}/queue/order", json=payload)
+            return resp.status, await resp.json()
+
+    @pytest.mark.asyncio
+    async def test_unknown_slot_is_404(self, _sel):
+        status, _ = await self._put(_state(), "missing", {"order": []})
+        assert status == 404
+
+    @pytest.mark.asyncio
+    async def test_non_list_order_is_400(self, _sel):
+        slot = _ChatSlot("s1")
+        status, body = await self._put(_state(slot), "s1", {"order": "q1"})
+        assert status == 400
+        assert "list of queue id strings" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_non_string_ids_are_400(self, _sel):
+        slot = _ChatSlot("s1")
+        status, _ = await self._put(_state(slot), "s1", {"order": [1, 2]})
+        assert status == 400
+
+    @pytest.mark.asyncio
+    async def test_unknown_ids_are_400(self, _sel):
+        slot = _ChatSlot("s1")
+        slot.queue_append("a")
+        status, body = await self._put(_state(slot), "s1", {"order": ["ghost"]})
+        assert status == 400
+        assert "ghost" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_partial_order_puts_named_ids_first(self, _sel):
+        slot = _ChatSlot("s1")
+        a = slot.queue_append("a")
+        b = slot.queue_append("b")
+        c = slot.queue_append("c")
+        state = _state(slot)
+
+        status, _ = await self._put(state, "s1", {"order": [c, a]})
+
+        assert status == 200
+        assert [item["id"] for item in slot._queue] == [c, a, b]
+        event, payload = state.broadcast_ws.call_args.args
+        assert event == "queue_reorder"
+        assert payload["order"] == [c, a, b]
+
+    @pytest.mark.asyncio
+    async def test_queued_rows_are_reordered_and_other_rows_kept(self, _sel):
+        slot = _ChatSlot("s1")
+        a = slot.queue_append("a")
+        b = slot.queue_append("b")
+        slot.messages.append({"role": "user", "content": "hi", "cls": ""})
+        slot.messages.append({"role": "queued", "content": "a", "cls": json.dumps({"queue_id": a})})
+        slot.messages.append({"role": "queued", "content": "b", "cls": json.dumps({"queue_id": b})})
+        # A queued row with unparseable cls must survive rather than vanish.
+        slot.messages.append({"role": "queued", "content": "orphan", "cls": "{bad"})
+
+        status, _ = await self._put(_state(slot), "s1", {"order": [b, a]})
+
+        assert status == 200
+        assert [m["content"] for m in slot.messages] == ["hi", "b", "a", "orphan"]
+
+
+# ── POST /api/chat/slots/{slot}/workspace ────────────────────────────────────
+
+
+class TestSlotWorkspace:
+    async def _post(self, state, name, payload):
+        app = _app(state, "POST", "/api/chat/slots/{slot}/workspace", ch.api_chat_slot_workspace)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(f"/api/chat/slots/{name}/workspace", json=payload)
+            return resp.status, await resp.json()
+
+    @pytest.mark.asyncio
+    async def test_unknown_slot_is_404(self):
+        status, _ = await self._post(_state(), "missing", {"workspace": "w"})
+        assert status == 404
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self):
+        slot = _ChatSlot("s1")
+        app = _app(
+            _state(slot), "POST", "/api/chat/slots/{slot}/workspace", ch.api_chat_slot_workspace
+        )
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/workspace",
+                data="nope",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_switch_is_refused_once_the_conversation_started(self):
+        slot = _ChatSlot("s1")
+        slot.workspace = "default"
+        slot.total_messages = 3
+        status, body = await self._post(_state(slot), "s1", {"workspace": "other"})
+        assert status == 409
+        assert "new session" in body["error"]
+        assert slot.workspace == "default"
+
+    @pytest.mark.asyncio
+    async def test_switch_resets_the_session_and_repoints_the_project(self):
+        slot = _ChatSlot("s1")
+        state = _state(slot)
+        with patch(f"{MOD}._reset_slot_session", new=AsyncMock()) as reset:
+            with patch(f"{MOD}.default_project_dir", return_value="/tmp/ws-other"):
+                status, body = await self._post(state, "s1", {"workspace": "other"})
+
+        assert (status, body) == (200, {"ok": True, "workspace": "other"})
+        assert slot.workspace == "other"
+        assert slot.project == "/tmp/ws-other"
+        reset.assert_awaited_once()
+        assert reset.await_args.args[2] == "dashboard:s1"
+        state.push_slots_update.assert_called_once()
+
+
+# ── POST /api/chat/slots/{slot}/reasoning-effort ──────────────────────────────
+
+
+def _valid_effort() -> str:
+    """A level the endpoint currently accepts.
+
+    The set is mutated at runtime by ACP (``update_reasoning_effort_values``),
+    so it is read rather than hard-coded — a literal would rot the day kiro
+    renames a level.
+    """
+    levels = get_reasoning_effort_values() - {""}
+    assert levels, "no non-default effort level advertised"
+    return sorted(levels)[0]
+
+
+class TestSlotReasoningEffort:
+    async def _post(self, state, name, payload):
+        app = _app(
+            state,
+            "POST",
+            "/api/chat/slots/{slot}/reasoning-effort",
+            ch.api_chat_slot_reasoning_effort,
+        )
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(f"/api/chat/slots/{name}/reasoning-effort", json=payload)
+            return resp.status, await resp.json()
+
+    @pytest.mark.asyncio
+    async def test_unknown_slot_is_404(self):
+        status, _ = await self._post(_state(), "missing", {"reasoning_effort": ""})
+        assert status == 404
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self):
+        slot = _ChatSlot("s1")
+        app = _app(
+            _state(slot),
+            "POST",
+            "/api/chat/slots/{slot}/reasoning-effort",
+            ch.api_chat_slot_reasoning_effort,
+        )
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/reasoning-effort",
+                data="~",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_unknown_level_is_rejected(self):
+        slot = _ChatSlot("s1")
+        bogus = "turbo"
+        assert bogus not in get_reasoning_effort_values()
+        status, body = await self._post(_state(slot), "s1", {"reasoning_effort": bogus})
+        assert status == 400
+        assert "must be one of" in body["error"]
+        assert slot.reasoning_effort == ""
+
+    @pytest.mark.asyncio
+    async def test_non_string_level_is_rejected(self):
+        slot = _ChatSlot("s1")
+        status, _ = await self._post(_state(slot), "s1", {"reasoning_effort": 3})
+        assert status == 400
+
+    @pytest.mark.asyncio
+    async def test_unchanged_level_short_circuits(self):
+        level = _valid_effort()
+        slot = _ChatSlot("s1")
+        slot.reasoning_effort = level
+        state = _state(slot)
+        status, body = await self._post(state, "s1", {"reasoning_effort": level})
+        assert (status, body) == (200, {"ok": True, "reasoning_effort": level})
+        state.push_slots_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_active_turn_defers_the_live_push(self):
+        level = _valid_effort()
+        slot = _ChatSlot("s1")
+        state = _state(slot)
+        provider = _acp(
+            supports_effort=MagicMock(return_value=True),
+            has_active_turn=MagicMock(return_value=True),
+        )
+        state.sessions.get_provider = MagicMock(return_value=provider)
+
+        with patch(f"{MOD}._reset_slot_session", new=AsyncMock()) as reset:
+            status, body = await self._post(state, "s1", {"reasoning_effort": level})
+
+        assert status == 200
+        assert body["deferred"] is True
+        assert slot.reasoning_effort == level
+        provider.change_effort.assert_not_awaited()
+        reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_live_push_avoids_the_reset(self):
+        level = _valid_effort()
+        slot = _ChatSlot("s1")
+        state = _state(slot)
+        provider = _acp(
+            supports_effort=MagicMock(return_value=True),
+            change_effort=AsyncMock(return_value=True),
+        )
+        state.sessions.get_provider = MagicMock(return_value=provider)
+
+        with patch(f"{MOD}._reset_slot_session", new=AsyncMock()) as reset:
+            status, body = await self._post(state, "s1", {"reasoning_effort": level})
+
+        assert (status, body) == (200, {"ok": True, "reasoning_effort": level})
+        provider.change_effort.assert_awaited_once_with(level)
+        reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_clearing_the_level_calls_clear_effort(self):
+        slot = _ChatSlot("s1")
+        slot.reasoning_effort = _valid_effort()
+        state = _state(slot)
+        provider = _acp(
+            supports_effort=MagicMock(return_value=True),
+            clear_effort=AsyncMock(return_value=True),
+        )
+        state.sessions.get_provider = MagicMock(return_value=provider)
+
+        with patch(f"{MOD}._reset_slot_session", new=AsyncMock()) as reset:
+            status, body = await self._post(state, "s1", {"reasoning_effort": ""})
+
+        assert (status, body) == (200, {"ok": True, "reasoning_effort": ""})
+        provider.clear_effort.assert_awaited_once()
+        reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_live_push_failure_falls_back_to_a_reset(self):
+        level = _valid_effort()
+        slot = _ChatSlot("s1")
+        state = _state(slot)
+        provider = _acp(
+            supports_effort=MagicMock(return_value=True),
+            change_effort=AsyncMock(side_effect=RuntimeError("stdout busy")),
+        )
+        state.sessions.get_provider = MagicMock(return_value=provider)
+
+        with patch(f"{MOD}._reset_slot_session", new=AsyncMock()) as reset:
+            status, _ = await self._post(state, "s1", {"reasoning_effort": level})
+
+        assert status == 200
+        assert slot.reasoning_effort == level
+        reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_effort_incapable_model_persists_without_a_reset(self):
+        level = _valid_effort()
+        slot = _ChatSlot("s1")
+        state = _state(slot)
+        provider = _acp(supports_effort=MagicMock(return_value=False))
+        state.sessions.get_provider = MagicMock(return_value=provider)
+
+        with patch(f"{MOD}._reset_slot_session", new=AsyncMock()) as reset:
+            status, _ = await self._post(state, "s1", {"reasoning_effort": level})
+
+        assert status == 200
+        assert slot.reasoning_effort == level
+        reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_live_session_resets_so_the_cold_start_picks_it_up(self):
+        level = _valid_effort()
+        slot = _ChatSlot("s1")
+        state = _state(slot)
+        state.sessions.get_provider = MagicMock(return_value=None)
+
+        with patch(f"{MOD}._reset_slot_session", new=AsyncMock()) as reset:
+            status, _ = await self._post(state, "s1", {"reasoning_effort": level})
+
+        assert status == 200
+        reset.assert_awaited_once()
+
+
+# ── POST /api/chat/slots/{slot}/followup ─────────────────────────────────────
+
+
+def _item(**over) -> dict:
+    base = {"title": "Ship it", "description": "open the PR", "prompt": "open a PR for this"}
+    base.update(over)
+    return base
+
+
+class TestSlotFollowup:
+    async def _post(self, state, name, payload, *, owner: bool = True):
+        async def route(request: web.Request) -> web.Response:
+            # The MCP relay arrives with the internal-secret grant, which is the
+            # branch this endpoint is actually reached on.
+            request["internal_auth"] = owner
+            return await ch.api_chat_slot_followup(request)
+
+        app = _app(state, "POST", "/api/chat/slots/{slot}/followup", route)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(f"/api/chat/slots/{name}/followup", json=payload)
+            return resp.status, await resp.json()
+
+    def _state_with(self, slot, delivered: int = 1):
+        state = _state(slot)
+        state.deliver_ws_owners = AsyncMock(return_value=delivered)
+        return state
+
+    @pytest.mark.asyncio
+    async def test_non_owner_is_refused_before_the_slot_lookup(self, _sel):
+        with patch(
+            "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+            return_value=False,
+        ):
+            status, body = await self._post(
+                self._state_with(None), "missing", {"items": [_item()]}, owner=False
+            )
+        assert status == 403
+        assert body["error"] == "forbidden"
+
+    @pytest.mark.asyncio
+    async def test_unknown_slot_is_404(self):
+        status, _ = await self._post(self._state_with(None), "missing", {"items": [_item()]})
+        assert status == 404
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self):
+        slot = _ChatSlot("s1")
+
+        async def route(request: web.Request) -> web.Response:
+            request["internal_auth"] = True
+            return await ch.api_chat_slot_followup(request)
+
+        app = _app(self._state_with(slot), "POST", "/api/chat/slots/{slot}/followup", route)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/followup",
+                data="%",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_non_object_body_is_400(self):
+        slot = _ChatSlot("s1")
+        status, _ = await self._post(self._state_with(slot), "s1", [_item()])
+        assert status == 400
+
+    @pytest.mark.asyncio
+    async def test_schema_violation_is_400(self):
+        slot = _ChatSlot("s1")
+        # An unknown per-item field is fail-closed by the shared schema.
+        status, body = await self._post(
+            self._state_with(slot), "s1", {"items": [_item(colour="red")]}
+        )
+        assert status == 400
+        assert "colour" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_empty_items_is_400(self):
+        slot = _ChatSlot("s1")
+        status, _ = await self._post(self._state_with(slot), "s1", {"items": []})
+        assert status == 400
+
+    @pytest.mark.asyncio
+    async def test_delivered_count_comes_from_the_owner_send(self):
+        slot = _ChatSlot("s1")
+        slot.project = "/tmp/proj"
+        state = self._state_with(slot, delivered=2)
+
+        status, body = await self._post(state, "s1", {"items": [_item(), _item(title="Later")]})
+
+        assert status == 200
+        assert body == {"ok": True, "count": 2, "delivered": 2}
+        event, payload = state.deliver_ws_owners.await_args.args
+        assert event == "followup_card"
+        assert payload["slot"] == "s1"
+        assert [i["title"] for i in payload["items"]] == ["Ship it", "Later"]
+
+    @pytest.mark.asyncio
+    async def test_unscoped_slot_gets_the_worktree_warning(self):
+        slot = _ChatSlot("s1")
+        slot.project = ""
+        status, body = await self._post(self._state_with(slot), "s1", {"items": [_item()]})
+        assert status == 200
+        assert "no project directory" in body["warning"]
+
+    @pytest.mark.asyncio
+    async def test_a_failed_delivery_reports_zero_not_a_500(self):
+        slot = _ChatSlot("s1")
+        slot.project = "/tmp/proj"
+        state = _state(slot)
+        state.deliver_ws_owners = AsyncMock(side_effect=RuntimeError("socket gone"))
+
+        status, body = await self._post(state, "s1", {"items": [_item()]})
+
+        assert status == 200
+        assert body["delivered"] == 0

--- a/test/test_dashboard_files_coverage.py
+++ b/test/test_dashboard_files_coverage.py
@@ -1,0 +1,1194 @@
+"""Coverage tests for ``kiro_crew.dashboard.handlers.files``.
+
+The handlers in that module were largely exercised only through their happy
+paths (or not at all). This file targets the endpoints and error arms the
+existing suite leaves untouched:
+
+* ``/api/file-read`` — the ``resolve=1`` project-relative branch, the
+  directory-vs-missing 404 discrimination, the HEAD probe, per-extension
+  content types, the 512 KB truncation flag, and the read-failure 500.
+* ``/api/file-write`` — body/schema rejection, the atomic
+  mkstemp-then-``os.replace`` write, and the temp-file cleanup on failure.
+* ``/api/file-raw`` — every magic-byte branch of the content sniffer plus the
+  size, symlink and unrecognized-format refusals.
+* ``/api/file-watch`` — the SSE prelude, the first change event, and the
+  post-validation symlink-swap abort.
+* ``/api/outbox`` and ``/api/outbox/{filename}`` — listing filters and the
+  download refusals.
+* ``/api/reveal`` — the ``action=open`` arms and the no-opener fallback.
+* ``/api/upload`` and ``/api/screenshot`` — the non-macOS refusal and, with a
+  faked ``asyncio.create_subprocess_exec``, the success, cancel and timeout
+  arms. No real process is ever spawned.
+* ``/api/dashboard/config`` — the PUT field validation matrix and the
+  cancellation audit arm.
+* ``_content_matches_ext`` / ``_fuzzy_score`` — pure-function branches.
+
+Every test either fakes the subprocess boundary or stays inside ``tmp_path``,
+so nothing here depends on this machine having a display server, a sandbox
+backend, or an ``open``/``xdg-open`` binary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from tmpdir_helpers import short_tmp_base
+
+from kiro_crew.dashboard.handlers import files as files_mod
+
+# ``api_file_raw`` and ``api_file_download`` open with ``os.O_NOFOLLOW``, which
+# only exists on POSIX; the whole code path is unreachable on Windows.
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.O_NOFOLLOW does not exist on Windows, so this handler cannot run there",
+)
+
+
+@pytest.fixture()
+def mock_sel():
+    """Stub the SEL audit sink that every handler in this module writes to."""
+    with patch("kiro_crew.dashboard.handlers.files._sel") as m:
+        instance = MagicMock()
+        m.return_value = instance
+        yield instance
+
+
+def _app(method: str, route: str, handler) -> web.Application:
+    app = web.Application()
+    app.router.add_route(method, route, handler)
+    return app
+
+
+def _get_app(route: str, handler) -> web.Application:
+    app = web.Application()
+    app.router.add_get(route, handler)  # allow_head=True → HEAD hits the same handler
+    return app
+
+
+# ── /api/file-read ──
+
+
+# Every test below that hands a real `tmp_path` to the file-read/write/watch
+# endpoints is POSIX-only, because the PRODUCT rejects native Windows paths
+# before any branch under test is reached: FILE_READ_SCHEMA / FILE_WRITE_SCHEMA
+# in validation.py pin `path` to `^[~/][-\w.@~/ ]+$`, which admits neither the
+# `C:` drive prefix nor a backslash separator. A Windows tmp_path like
+# `C:\Users\runneradmin\AppData\Local\Temp\pytest-...` therefore 400s as
+# "invalid input" no matter what the endpoint would otherwise do.
+#
+# This is the same defect class as deploy's `_LOCAL_DIR_RE` (reported from the
+# first coverage wave): a POSIX-shaped allowlist guarding a path that reaches
+# real file I/O. Widening it is security-relevant and belongs in its own
+# reviewed change, NOT in a coverage PR -- so these classes are skipped on
+# win32 and will start covering Windows for free once the schema is fixed.
+_WINDOWS_PATH_DEFECT = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "FILE_READ/WRITE_SCHEMA reject native Windows paths (no drive letter or "
+        "backslash in the allowed pattern), so every request 400s before the "
+        "branch under test -- product defect, not a test defect"
+    ),
+)
+
+
+@_WINDOWS_PATH_DEFECT
+class TestFileRead:
+    @staticmethod
+    def _client_app() -> web.Application:
+        return _get_app("/api/file-read", files_mod.api_file_read)
+
+    @pytest.mark.asyncio
+    async def test_reads_text_and_defaults_to_text_plain(self, tmp_path, mock_sel):
+        f = tmp_path / "notes.txt"
+        f.write_text("hello there", encoding="utf-8")
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-read?path={f}")
+            assert resp.status == 200
+            assert resp.content_type == "text/plain"
+            assert await resp.text() == "hello there"
+
+    @pytest.mark.asyncio
+    async def test_content_type_per_extension(self, tmp_path, mock_sel):
+        cases = {
+            "a.json": "application/json",
+            "a.jsonl": "application/x-ndjson",
+            "a.csv": "text/csv",
+            "a.md": "text/markdown",
+            "a.markdown": "text/markdown",
+            "a.py": "text/plain",
+        }
+        async with TestClient(TestServer(self._client_app())) as client:
+            for name, expected in cases.items():
+                f = tmp_path / name
+                f.write_text("x", encoding="utf-8")
+                resp = await client.get(f"/api/file-read?path={f}")
+                assert resp.status == 200, name
+                assert resp.content_type == expected, name
+
+    @pytest.mark.asyncio
+    async def test_truncates_at_cap_and_flags_it(self, tmp_path, mock_sel):
+        f = tmp_path / "big.txt"
+        f.write_text("a" * 512_001, encoding="utf-8")
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-read?path={f}")
+            assert resp.status == 200
+            assert resp.headers["X-Truncated"] == "true"
+            assert len(await resp.text()) == 512_000
+
+    @pytest.mark.asyncio
+    async def test_untruncated_file_has_no_flag(self, tmp_path, mock_sel):
+        f = tmp_path / "small.txt"
+        f.write_text("short", encoding="utf-8")
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-read?path={f}")
+            assert "X-Truncated" not in resp.headers
+
+    @pytest.mark.asyncio
+    async def test_head_probe_reports_file_kind(self, tmp_path, mock_sel):
+        f = tmp_path / "probe.md"
+        f.write_text("# hi", encoding="utf-8")
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.head(f"/api/file-read?path={f}")
+            assert resp.status == 200
+            assert resp.headers["X-Path-Kind"] == "file"
+
+    @pytest.mark.asyncio
+    async def test_directory_is_404_but_labelled_dir(self, tmp_path, mock_sel):
+        d = tmp_path / "adir"
+        d.mkdir()
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-read?path={d}")
+            assert resp.status == 404
+            assert resp.headers["X-Path-Kind"] == "dir"
+            assert (await resp.json())["error"] == "is a directory"
+
+    @pytest.mark.asyncio
+    async def test_missing_path_is_404_labelled_missing(self, tmp_path, mock_sel):
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-read?path={tmp_path}/nope.txt")
+            assert resp.status == 404
+            assert resp.headers["X-Path-Kind"] == "missing"
+            assert (await resp.json())["error"] == "not found"
+
+    @pytest.mark.asyncio
+    async def test_schema_violation_is_400(self, mock_sel):
+        # '$' is outside FILE_READ_SCHEMA's allowed character class.
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get("/api/file-read?path=/tmp/$evil")
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "invalid input"
+
+    @pytest.mark.asyncio
+    async def test_forbidden_path_is_400(self, tmp_path, mock_sel):
+        f = tmp_path / "blocked.txt"
+        f.write_text("x", encoding="utf-8")
+        with patch.object(files_mod, "_validate_dashboard_path", return_value=None):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.get(f"/api/file-read?path={f}")
+                assert resp.status == 400
+                assert (await resp.json())["error"] == "invalid or forbidden path"
+
+    @pytest.mark.asyncio
+    async def test_resolve_without_project_dir_is_400(self, mock_sel, monkeypatch):
+        monkeypatch.delenv("KIROCREW_PROJECT_DIR", raising=False)
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get("/api/file-read?resolve=1&path=notes.md")
+            assert resp.status == 400
+            assert "no project dir" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_resolve_relative_path_against_project(self, tmp_path, mock_sel, monkeypatch):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "readme.md").write_text("# in project", encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get("/api/file-read?resolve=1&path=readme.md")
+            assert resp.status == 200
+            assert await resp.text() == "# in project"
+
+    @pytest.mark.asyncio
+    async def test_resolve_escaping_project_is_400(self, tmp_path, mock_sel, monkeypatch):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (tmp_path / "outside.md").write_text("secret", encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get("/api/file-read?resolve=1&path=../outside.md")
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "path outside project directory"
+
+    @pytest.mark.asyncio
+    async def test_credentials_in_content_are_redacted(self, tmp_path, mock_sel):
+        f = tmp_path / "creds.txt"
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        f.write_text(f"aws_access_key_id={secret}\n", encoding="utf-8", newline="\n")
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-read?path={f}")
+            assert resp.status == 200
+            assert secret not in await resp.text()
+
+    @pytest.mark.asyncio
+    async def test_read_failure_is_500(self, tmp_path, mock_sel):
+        f = tmp_path / "boom.txt"
+        f.write_text("x", encoding="utf-8")
+        with patch.object(files_mod, "redact", side_effect=RuntimeError("nope")):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.get(f"/api/file-read?path={f}")
+                assert resp.status == 500
+                assert (await resp.json())["error"] == "failed to read file"
+        assert any(
+            kw.get("outcome") == "failure"
+            for _, kw in mock_sel.log_tool_invocation.call_args_list
+        )
+
+
+# ── /api/file-write ──
+
+
+@_WINDOWS_PATH_DEFECT
+class TestFileWrite:
+    @staticmethod
+    def _client_app() -> web.Application:
+        return _app("POST", "/api/file-write", files_mod.api_file_write)
+
+    @pytest.mark.asyncio
+    async def test_writes_content_atomically(self, tmp_path, mock_sel):
+        f = tmp_path / "doc.md"
+        f.write_text("old", encoding="utf-8")
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.post(
+                "/api/file-write", json={"path": str(f), "content": "brand new"}
+            )
+            assert resp.status == 200
+            assert await resp.json() == {"ok": True}
+        assert f.read_text(encoding="utf-8") == "brand new"
+        # The mkstemp scratch file must not survive a successful replace.
+        assert [p.name for p in tmp_path.iterdir()] == ["doc.md"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_body_is_400(self, mock_sel):
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.post(
+                "/api/file-write", data="not json", headers={"Content-Type": "application/json"}
+            )
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "invalid JSON body"
+
+    @pytest.mark.asyncio
+    async def test_non_object_body_is_400(self, mock_sel):
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.post("/api/file-write", json=["a", "list"])
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "invalid JSON body"
+
+    @pytest.mark.asyncio
+    async def test_schema_violation_is_400(self, mock_sel):
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.post(
+                "/api/file-write", json={"path": "/tmp/$evil", "content": "x"}
+            )
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "invalid input"
+
+    @pytest.mark.asyncio
+    async def test_forbidden_path_is_400(self, tmp_path, mock_sel):
+        f = tmp_path / "x.md"
+        f.write_text("x", encoding="utf-8")
+        with patch.object(files_mod, "_validate_dashboard_path", return_value=None):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.post(
+                    "/api/file-write", json={"path": str(f), "content": "y"}
+                )
+                assert resp.status == 400
+                assert (await resp.json())["error"] == "invalid or forbidden path"
+
+    @pytest.mark.asyncio
+    async def test_missing_file_is_404(self, tmp_path, mock_sel):
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.post(
+                "/api/file-write", json={"path": f"{tmp_path}/absent.md", "content": "y"}
+            )
+            assert resp.status == 404
+            assert (await resp.json())["error"] == "not found"
+
+    @pytest.mark.asyncio
+    async def test_copymode_failure_does_not_abort_the_write(self, tmp_path, mock_sel):
+        """``shutil.copymode`` is best-effort: an OSError must not fail the save."""
+        f = tmp_path / "modes.md"
+        f.write_text("old", encoding="utf-8")
+        with patch.object(shutil, "copymode", side_effect=OSError("no perms")):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.post(
+                    "/api/file-write", json={"path": str(f), "content": "kept"}
+                )
+                assert resp.status == 200
+        assert f.read_text(encoding="utf-8") == "kept"
+
+    @pytest.mark.asyncio
+    async def test_replace_failure_is_500_and_cleans_up_temp(self, tmp_path, mock_sel):
+        f = tmp_path / "doomed.md"
+        f.write_text("original", encoding="utf-8")
+        with patch.object(os, "replace", side_effect=OSError("replace failed")):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.post(
+                    "/api/file-write", json={"path": str(f), "content": "never lands"}
+                )
+                assert resp.status == 500
+                assert (await resp.json())["error"] == "failed to write file"
+        assert f.read_text(encoding="utf-8") == "original"
+        assert [p.name for p in tmp_path.iterdir()] == ["doomed.md"]
+
+    @pytest.mark.asyncio
+    async def test_temp_unlink_failure_still_reports_500(self, tmp_path, mock_sel):
+        """The cleanup ``os.unlink`` is itself wrapped: its OSError is swallowed
+        so the caller still gets the real 500 rather than an unhandled error."""
+        f = tmp_path / "twice.md"
+        f.write_text("original", encoding="utf-8")
+        with patch.object(os, "replace", side_effect=OSError("replace failed")), \
+             patch.object(os, "unlink", side_effect=OSError("unlink failed")):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.post(
+                    "/api/file-write", json={"path": str(f), "content": "nope"}
+                )
+                assert resp.status == 500
+        # The scratch file survives here precisely because unlink was blocked.
+        leftovers = [p for p in tmp_path.iterdir() if p.name != "twice.md"]
+        for p in leftovers:
+            p.unlink()
+
+
+# ── /api/file-raw ──
+
+
+@posix_only
+class TestFileRaw:
+    @staticmethod
+    def _client_app() -> web.Application:
+        return _get_app("/api/file-raw", files_mod.api_file_raw)
+
+    @pytest.mark.asyncio
+    async def test_image_magic_bytes_drive_content_type(self, tmp_path, mock_sel):
+        cases = {
+            "a.png": (b"\x89PNG\r\n\x1a\n" + b"\x00" * 8, "image/png"),
+            "a.jpg": (b"\xff\xd8\xff\xe0" + b"\x00" * 8, "image/jpeg"),
+            "a87.gif": (b"GIF87a" + b"\x00" * 8, "image/gif"),
+            "a89.gif": (b"GIF89a" + b"\x00" * 8, "image/gif"),
+            "a.bmp": (b"BM" + b"\x00" * 12, "image/bmp"),
+            "le.tiff": (b"II\x2a\x00" + b"\x00" * 8, "image/tiff"),
+            "be.tiff": (b"MM\x00\x2a" + b"\x00" * 8, "image/tiff"),
+            "a.ico": (b"\x00\x00\x01\x00" + b"\x00" * 8, "image/x-icon"),
+            "a.webp": (b"RIFF" + b"\x00" * 4 + b"WEBP" + b"\x00" * 4, "image/webp"),
+            "a.pdf": (b"%PDF-1.7\n" + b"\x00" * 4, "application/pdf"),
+        }
+        async with TestClient(TestServer(self._client_app())) as client:
+            for name, (payload, expected) in cases.items():
+                f = tmp_path / name
+                f.write_bytes(payload)
+                resp = await client.get(f"/api/file-raw?path={f}")
+                assert resp.status == 200, name
+                assert resp.headers["Content-Type"] == expected, name
+                assert resp.headers["X-Content-Type-Options"] == "nosniff"
+                assert await resp.read() == payload, name
+
+    @pytest.mark.asyncio
+    async def test_bare_svg_gets_script_blocking_csp(self, tmp_path, mock_sel):
+        f = tmp_path / "icon.svg"
+        f.write_bytes(b"\xef\xbb\xbf  <svg xmlns='http://www.w3.org/2000/svg'/>")
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-raw?path={f}")
+            assert resp.status == 200
+            assert resp.headers["Content-Type"] == "image/svg+xml"
+            assert resp.headers["Content-Security-Policy"] == (
+                "script-src 'none'; style-src 'unsafe-inline'"
+            )
+
+    @pytest.mark.asyncio
+    async def test_xml_prologue_svg_recognized(self, tmp_path, mock_sel):
+        f = tmp_path / "declared.svg"
+        f.write_bytes(b"<?xml version='1.0'?>\n<svg width='1' height='1'></svg>")
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-raw?path={f}")
+            assert resp.status == 200
+            assert resp.headers["Content-Type"] == "image/svg+xml"
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_content_is_403(self, tmp_path, mock_sel):
+        f = tmp_path / "plain.png"  # lying extension; content decides
+        f.write_bytes(b"just some text, not an image at all")
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-raw?path={f}")
+            assert resp.status == 403
+            assert "not a recognized format" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_forbidden_path_is_400(self, mock_sel):
+        with patch("kiro_crew.dashboard.handlers._validate_dashboard_path", return_value=None):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.get("/api/file-raw?path=/tmp/whatever.png")
+                assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_sensitive_path_is_403(self, tmp_path, mock_sel):
+        f = tmp_path / "s.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n")
+        with patch("kiro_crew.security.is_sensitive_path", return_value=True):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.get(f"/api/file-raw?path={f}")
+                assert resp.status == 403
+                assert (await resp.json())["error"] == "sensitive path blocked"
+
+    @pytest.mark.asyncio
+    async def test_missing_path_is_404(self, tmp_path, mock_sel):
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-raw?path={tmp_path}/gone.png")
+            assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_oversize_file_is_413(self, tmp_path, mock_sel, monkeypatch):
+        f = tmp_path / "big.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+        monkeypatch.setattr(files_mod, "_MAX_UPLOAD_BYTES", 8)
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-raw?path={f}")
+            assert resp.status == 413
+            assert (await resp.json())["error"] == "file too large"
+
+    @pytest.mark.asyncio
+    async def test_symlink_is_refused_by_o_nofollow(self, tmp_path, mock_sel):
+        target = tmp_path / "real.png"
+        target.write_bytes(b"\x89PNG\r\n\x1a\n")
+        link = tmp_path / "link.png"
+        os.symlink(target, link)
+        # Hand the handler the link itself: the real validator would have
+        # realpath'd it away, and O_NOFOLLOW is what must catch it.
+        with patch(
+            "kiro_crew.dashboard.handlers._validate_dashboard_path", return_value=str(link)
+        ):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.get(f"/api/file-raw?path={link}")
+                assert resp.status == 403
+                assert (await resp.json())["error"] == "symlinks not allowed"
+
+
+# ── /api/file-watch ──
+
+
+@_WINDOWS_PATH_DEFECT
+class TestFileWatch:
+    @staticmethod
+    def _client_app() -> web.Application:
+        return _get_app("/api/file-watch", files_mod.api_file_watch)
+
+    @pytest.mark.asyncio
+    async def test_schema_violation_is_400(self, mock_sel):
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get("/api/file-watch?path=/tmp/$evil")
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "invalid input"
+
+    @pytest.mark.asyncio
+    async def test_forbidden_path_is_400(self, tmp_path, mock_sel):
+        f = tmp_path / "w.txt"
+        f.write_text("x", encoding="utf-8")
+        with patch.object(files_mod, "_validate_dashboard_path", return_value=None):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.get(f"/api/file-watch?path={f}")
+                assert resp.status == 400
+                assert (await resp.json())["error"] == "invalid or forbidden path"
+
+    @pytest.mark.asyncio
+    async def test_missing_path_is_404(self, tmp_path, mock_sel):
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-watch?path={tmp_path}/absent.txt")
+            assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_streams_first_change_event(self, tmp_path, mock_sel):
+        f = tmp_path / "live.md"
+        f.write_text("first revision\n", encoding="utf-8", newline="\n")
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-watch?path={f}")
+            assert resp.status == 200
+            assert resp.headers["Content-Type"].startswith("text/event-stream")
+            assert resp.headers["Cache-Control"] == "no-cache"
+            chunk = await asyncio.wait_for(resp.content.readuntil(b"\n\n"), timeout=10)
+            payload = json.loads(chunk.decode("utf-8").split("data: ", 1)[1].strip())
+            assert payload["content"] == "first revision\n"
+            assert payload["mtime"] > 0
+            resp.close()
+
+    @pytest.mark.asyncio
+    async def test_symlink_swapped_after_validation_aborts_stream(self, tmp_path, mock_sel):
+        """The watcher re-resolves the path on every change and bails if the
+        realpath moved, so a post-validation symlink swap cannot be used to
+        stream a different file's contents."""
+        f = tmp_path / "swapped.md"
+        f.write_text("content\n", encoding="utf-8", newline="\n")
+        target = str(f)
+        real_realpath = os.path.realpath
+        seen: list[str] = []
+
+        def fake_realpath(p, *a, **kw):
+            if p == target:
+                seen.append(p)
+                # First resolution (the baseline) is honest; the second reports a
+                # different destination, i.e. the link was repointed.
+                return target if len(seen) == 1 else target + ".elsewhere"
+            return real_realpath(p, *a, **kw)
+
+        with patch.object(files_mod, "_validate_dashboard_path", return_value=target), \
+             patch.object(os.path, "realpath", fake_realpath):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.get(f"/api/file-watch?path={f}")
+                assert resp.status == 200
+                body = await asyncio.wait_for(resp.content.read(), timeout=10)
+                # Stream ends without ever emitting the file's contents.
+                assert body == b""
+        assert len(seen) >= 2, "the watcher never re-resolved the path"
+        assert any(
+            kw.get("tool_name") == "file_watch" and kw.get("outcome") == "denied"
+            for _, kw in mock_sel.log_tool_invocation.call_args_list
+        )
+
+
+# ── /api/outbox ──
+
+
+@pytest.fixture()
+def outbox(tmp_path):
+    """A short, low-entropy outbox dir.
+
+    ``tmp_path`` is not usable here: on macOS it carries high-entropy directory
+    ids that trip ``redact_credentials()`` on the echoed path, so the handlers
+    reject the fixture rather than the code under test. Same reasoning as
+    ``test_outbox_binary.py``.
+    """
+    base = Path(tempfile.mkdtemp(dir=short_tmp_base()))
+    odir = base / "outbox"
+    odir.mkdir()
+    with patch("kiro_crew.config.loader.outbox_dir", return_value=odir):
+        try:
+            yield odir
+        finally:
+            shutil.rmtree(base, ignore_errors=True)
+
+
+class TestOutboxList:
+    @staticmethod
+    def _client_app() -> web.Application:
+        return _get_app("/api/outbox", files_mod.api_outbox_list)
+
+    @pytest.mark.asyncio
+    async def test_absent_outbox_returns_empty_list(self, outbox, mock_sel):
+        outbox.rmdir()
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get("/api/outbox")
+            assert resp.status == 200
+            assert await resp.json() == {"files": []}
+
+    @pytest.mark.asyncio
+    async def test_lists_files_newest_first_and_skips_dirs(self, outbox, mock_sel):
+        (outbox / "old.txt").write_text("old", encoding="utf-8")
+        (outbox / "new.txt").write_text("new", encoding="utf-8")
+        (outbox / "a_subdir").mkdir()
+        os.utime(outbox / "old.txt", (1_600_000_000, 1_600_000_000))
+        os.utime(outbox / "new.txt", (1_700_000_000, 1_700_000_000))
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get("/api/outbox")
+            files = (await resp.json())["files"]
+        assert [f["filename"] for f in files] == ["new.txt", "old.txt"]
+        assert files[0]["size"] == len("new")
+        assert files[0]["modified"] == 1_700_000_000
+
+    @pytest.mark.asyncio
+    async def test_filename_that_looks_like_a_credential_is_hidden(self, outbox, mock_sel):
+        # A GitHub PAT-shaped name is rewritten by redact(), so the entry is
+        # dropped rather than advertised over the API.
+        secretish = "ghp_" + "a" * 36
+        (outbox / secretish).write_text("x", encoding="utf-8")
+        (outbox / "ordinary.txt").write_text("x", encoding="utf-8")
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get("/api/outbox")
+            names = {f["filename"] for f in (await resp.json())["files"]}
+        assert names == {"ordinary.txt"}
+
+    @pytest.mark.asyncio
+    async def test_entry_removed_mid_scan_is_skipped(self, outbox, mock_sel):
+        (outbox / "racey.txt").write_text("x", encoding="utf-8")
+        (outbox / "stable.txt").write_text("x", encoding="utf-8")
+        real_stat = Path.stat
+
+        def flaky_stat(self, *a, **kw):
+            if self.name == "racey.txt":
+                raise FileNotFoundError(self.name)
+            return real_stat(self, *a, **kw)
+
+        with patch.object(Path, "stat", flaky_stat):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.get("/api/outbox")
+                names = {f["filename"] for f in (await resp.json())["files"]}
+        assert names == {"stable.txt"}
+
+
+class TestOutboxDownload:
+    """Driven by calling the handler directly: the refusals under test are keyed
+    off ``match_info``, and routing a literal ``..`` through the client would be
+    normalized away by the URL layer before the handler ever sees it."""
+
+    @staticmethod
+    def _request(filename: str):
+        req = MagicMock()
+        req.match_info = {"filename": filename}
+        return req
+
+    @pytest.mark.asyncio
+    async def test_traversal_out_of_outbox_is_403(self, outbox, mock_sel):
+        (outbox.parent / "escape.txt").write_text("secret", encoding="utf-8")
+        resp = await files_mod.api_outbox_download(self._request("../escape.txt"))
+        assert resp.status == 403
+        assert json.loads(resp.body)["error"] == "forbidden"
+
+    @pytest.mark.asyncio
+    async def test_oversize_file_is_413(self, outbox, mock_sel):
+        from kiro_crew.hooks import FileTooLargeError
+
+        (outbox / "huge.txt").write_text("x", encoding="utf-8")
+        with patch(
+            "kiro_crew.hooks.safe_read_file_bytes",
+            side_effect=FileTooLargeError("file exceeds 50 MB"),
+        ):
+            resp = await files_mod.api_outbox_download(self._request("huge.txt"))
+        assert resp.status == 413
+        assert "50 MB" in json.loads(resp.body)["error"]
+
+    @pytest.mark.asyncio
+    async def test_unreadable_file_is_403(self, outbox, mock_sel):
+        (outbox / "denied.txt").write_text("x", encoding="utf-8")
+        with patch("kiro_crew.hooks.safe_read_file_bytes", return_value=None):
+            resp = await files_mod.api_outbox_download(self._request("denied.txt"))
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_credential_bearing_text_aborts_download(self, outbox, mock_sel):
+        (outbox / "leak.txt").write_text("ghp_" + "b" * 36, encoding="utf-8")
+        resp = await files_mod.api_outbox_download(self._request("leak.txt"))
+        assert resp.status == 400
+        assert "redacted" in json.loads(resp.body)["error"]
+
+    @pytest.mark.asyncio
+    async def test_text_is_served_as_attachment(self, outbox, mock_sel):
+        (outbox / "report.md").write_text("# clean report\n", encoding="utf-8", newline="\n")
+        resp = await files_mod.api_outbox_download(self._request("report.md"))
+        assert resp.status == 200
+        assert resp.headers["Content-Disposition"].startswith("attachment;")
+        assert resp.headers["X-Content-Type-Options"] == "nosniff"
+        assert resp.body == b"# clean report\n"
+
+    @pytest.mark.asyncio
+    async def test_svg_is_never_served_inline(self, outbox, mock_sel):
+        (outbox / "logo.svg").write_text("<svg/>", encoding="utf-8")
+        resp = await files_mod.api_outbox_download(self._request("logo.svg"))
+        assert resp.status == 200
+        assert resp.headers["Content-Type"] == "image/svg+xml"
+        assert resp.headers["Content-Disposition"].startswith("attachment;")
+
+
+# ── /api/reveal ──
+
+
+class TestRevealPath:
+    @staticmethod
+    def _client_app() -> web.Application:
+        return _app("POST", "/api/reveal", files_mod.api_reveal_path)
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_body_is_400(self, mock_sel):
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.post(
+                "/api/reveal", data="{", headers={"Content-Type": "application/json"}
+            )
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "invalid JSON body"
+
+    @pytest.mark.asyncio
+    async def test_traversal_in_path_is_400(self, mock_sel):
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.post("/api/reveal", json={"path": "/tmp/../etc/hosts"})
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "invalid path"
+
+    @pytest.mark.asyncio
+    async def test_open_action_rejects_non_regular_file(self, tmp_path, mock_sel):
+        d = tmp_path / "adir"
+        d.mkdir()
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.post("/api/reveal", json={"path": str(d), "action": "open"})
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "not a regular file"
+
+    @pytest.mark.asyncio
+    async def test_open_action_on_macos_uses_open(self, tmp_path, mock_sel):
+        f = tmp_path / "doc.pdf"
+        f.write_text("x", encoding="utf-8")
+        with patch("sys.platform", "darwin"), patch("subprocess.Popen") as popen:
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.post(
+                    "/api/reveal", json={"path": str(f), "action": "open"}
+                )
+                assert resp.status == 200
+        popen.assert_called_once_with(["open", str(f)])
+
+    @pytest.mark.asyncio
+    async def test_open_action_on_linux_uses_xdg_open(self, tmp_path, mock_sel):
+        f = tmp_path / "doc.pdf"
+        f.write_text("x", encoding="utf-8")
+        with patch("sys.platform", "linux"), \
+             patch("shutil.which", return_value="/usr/bin/xdg-open"), \
+             patch("subprocess.Popen") as popen:
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.post(
+                    "/api/reveal", json={"path": str(f), "action": "open"}
+                )
+                assert resp.status == 200
+        popen.assert_called_once_with(["xdg-open", str(f)])
+
+    @pytest.mark.asyncio
+    async def test_open_action_without_opener_returns_copy_path(self, tmp_path, mock_sel):
+        f = tmp_path / "doc.pdf"
+        f.write_text("x", encoding="utf-8")
+        with patch("sys.platform", "linux"), patch("shutil.which", return_value=None):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.post(
+                    "/api/reveal", json={"path": str(f), "action": "open"}
+                )
+                assert resp.status == 200
+                assert await resp.json() == {"ok": True, "copy": str(f)}
+
+    @pytest.mark.asyncio
+    async def test_reveal_on_macos_uses_dash_r(self, tmp_path, mock_sel):
+        f = tmp_path / "doc.pdf"
+        f.write_text("x", encoding="utf-8")
+        with patch("sys.platform", "darwin"), patch("subprocess.Popen") as popen:
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.post("/api/reveal", json={"path": str(f)})
+                assert resp.status == 200
+        popen.assert_called_once_with(["open", "-R", str(f)])
+
+    @pytest.mark.asyncio
+    async def test_reveal_on_linux_opens_parent_dir(self, tmp_path, mock_sel):
+        f = tmp_path / "doc.pdf"
+        f.write_text("x", encoding="utf-8")
+        with patch("sys.platform", "linux"), \
+             patch("shutil.which", return_value="/usr/bin/xdg-open"), \
+             patch("subprocess.Popen") as popen:
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.post("/api/reveal", json={"path": str(f)})
+                assert resp.status == 200
+        popen.assert_called_once_with(["xdg-open", str(tmp_path)])
+
+    @pytest.mark.asyncio
+    async def test_reveal_without_opener_returns_copy_path(self, tmp_path, mock_sel):
+        f = tmp_path / "doc.pdf"
+        f.write_text("x", encoding="utf-8")
+        with patch("sys.platform", "linux"), patch("shutil.which", return_value=None):
+            async with TestClient(TestServer(self._client_app())) as client:
+                resp = await client.post("/api/reveal", json={"path": str(f)})
+                assert resp.status == 200
+                assert await resp.json() == {"ok": True, "copy": str(f)}
+
+
+# ── /api/upload and /api/screenshot (native pickers) ──
+
+
+class _FakeProc:
+    """Stand-in for ``asyncio.subprocess.Process``.
+
+    No process is spawned. ``fail_first`` makes the first await raise
+    ``TimeoutError`` so the handler's ``asyncio.wait_for`` arm is reached without
+    a real 120-second wait; ``kill_raises`` drives the ``ProcessLookupError``
+    branch of the cleanup.
+    """
+
+    def __init__(self, stdout: bytes = b"", *, fail_first: bool = False,
+                 kill_raises: bool = False) -> None:
+        self._stdout = stdout
+        self._fail_first = fail_first
+        self._kill_raises = kill_raises
+        self.killed = False
+        self.awaits = 0
+
+    async def communicate(self):
+        self.awaits += 1
+        if self._fail_first and self.awaits == 1:
+            raise asyncio.TimeoutError
+        return self._stdout, b""
+
+    async def wait(self):
+        self.awaits += 1
+        if self._fail_first and self.awaits == 1:
+            raise asyncio.TimeoutError
+        return 0
+
+    def kill(self):
+        self.killed = True
+        if self._kill_raises:
+            raise ProcessLookupError
+
+
+class TestNativePickers:
+    @pytest.mark.asyncio
+    async def test_upload_is_refused_off_macos(self, mock_sel):
+        with patch("sys.platform", "linux"):
+            async with TestClient(
+                TestServer(_app("POST", "/api/upload", files_mod.api_upload))
+            ) as client:
+                resp = await client.post("/api/upload")
+                assert resp.status == 400
+                assert "only available on macOS" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_upload_returns_selected_paths(self, mock_sel):
+        proc = _FakeProc(stdout=b"/Users/x/a.png\n\n/Users/x/b.txt\n")
+        with patch("sys.platform", "darwin"), \
+             patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as spawn:
+            async with TestClient(
+                TestServer(_app("POST", "/api/upload", files_mod.api_upload))
+            ) as client:
+                resp = await client.post("/api/upload")
+                assert resp.status == 200
+                assert (await resp.json())["paths"] == ["/Users/x/a.png", "/Users/x/b.txt"]
+        assert spawn.await_args.args[0] == "osascript"
+
+    @pytest.mark.asyncio
+    async def test_upload_cancelled_dialog_returns_no_paths(self, mock_sel):
+        proc = _FakeProc(stdout=b"\n  \n")
+        with patch("sys.platform", "darwin"), \
+             patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            async with TestClient(
+                TestServer(_app("POST", "/api/upload", files_mod.api_upload))
+            ) as client:
+                resp = await client.post("/api/upload")
+                assert await resp.json() == {"paths": []}
+
+    @pytest.mark.asyncio
+    async def test_upload_timeout_kills_dialog_and_returns_504(self, mock_sel):
+        proc = _FakeProc(fail_first=True, kill_raises=True)
+        with patch("sys.platform", "darwin"), \
+             patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            async with TestClient(
+                TestServer(_app("POST", "/api/upload", files_mod.api_upload))
+            ) as client:
+                resp = await client.post("/api/upload")
+                assert resp.status == 504
+                assert (await resp.json())["error"] == "Finder dialog timed out"
+        assert proc.killed
+
+    @pytest.mark.asyncio
+    async def test_screenshot_is_refused_off_macos(self, mock_sel):
+        with patch("sys.platform", "linux"):
+            async with TestClient(
+                TestServer(_app("POST", "/api/screenshot", files_mod.api_screenshot))
+            ) as client:
+                resp = await client.post("/api/screenshot")
+                assert resp.status == 400
+                assert "only available on macOS" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_screenshot_returns_captured_path(self, tmp_path, mock_sel, monkeypatch):
+        shots = tmp_path / "screenshots"
+        monkeypatch.setattr(files_mod, "_SCREENSHOT_DIR", shots)
+        captured: dict[str, tuple] = {}
+
+        async def fake_exec(*argv, **kwargs):
+            captured["argv"] = argv
+            # screencapture writes the file itself; mimic that side effect.
+            Path(argv[2]).write_bytes(b"\x89PNG\r\n\x1a\n")
+            return _FakeProc()
+
+        with patch("sys.platform", "darwin"), \
+             patch("asyncio.create_subprocess_exec", fake_exec):
+            async with TestClient(
+                TestServer(_app("POST", "/api/screenshot", files_mod.api_screenshot))
+            ) as client:
+                resp = await client.post("/api/screenshot")
+                assert resp.status == 200
+                path = (await resp.json())["path"]
+        assert captured["argv"][:2] == ("screencapture", "-i")
+        assert Path(path).parent == shots
+        assert Path(path).read_bytes().startswith(b"\x89PNG")
+
+    @pytest.mark.asyncio
+    async def test_screenshot_user_cancel_returns_empty_path(self, tmp_path, mock_sel,
+                                                             monkeypatch):
+        monkeypatch.setattr(files_mod, "_SCREENSHOT_DIR", tmp_path / "shots")
+        with patch("sys.platform", "darwin"), \
+             patch("asyncio.create_subprocess_exec", AsyncMock(return_value=_FakeProc())):
+            async with TestClient(
+                TestServer(_app("POST", "/api/screenshot", files_mod.api_screenshot))
+            ) as client:
+                resp = await client.post("/api/screenshot")
+                # No file was written, so the user dismissed the crosshair.
+                assert await resp.json() == {"path": ""}
+
+    @pytest.mark.asyncio
+    async def test_screenshot_timeout_returns_504(self, tmp_path, mock_sel, monkeypatch):
+        monkeypatch.setattr(files_mod, "_SCREENSHOT_DIR", tmp_path / "shots")
+        proc = _FakeProc(fail_first=True)
+        with patch("sys.platform", "darwin"), \
+             patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            async with TestClient(
+                TestServer(_app("POST", "/api/screenshot", files_mod.api_screenshot))
+            ) as client:
+                resp = await client.post("/api/screenshot")
+                assert resp.status == 504
+                assert (await resp.json())["error"] == "screenshot timed out"
+        assert proc.killed
+
+
+# ── /api/dashboard/config ──
+
+
+@pytest.fixture()
+def cfg_file(tmp_path):
+    p = tmp_path / "config.json"
+    p.write_text("{}", encoding="utf-8")
+    with patch("kiro_crew.config.loader.config_path", return_value=p):
+        yield p
+
+
+@pytest.fixture()
+def config_client_app(cfg_file, mock_sel) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/api/dashboard/config", files_mod.api_dashboard_config)
+    app.router.add_put("/api/dashboard/config", files_mod.api_dashboard_config)
+    return app
+
+
+class TestDashboardConfigPut:
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self, config_client_app):
+        async with TestClient(TestServer(config_client_app)) as client:
+            resp = await client.put(
+                "/api/dashboard/config",
+                data="{",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "invalid JSON"
+
+    @pytest.mark.asyncio
+    async def test_non_object_body_is_400(self, config_client_app):
+        async with TestClient(TestServer(config_client_app)) as client:
+            resp = await client.put("/api/dashboard/config", json=[1, 2, 3])
+            assert resp.status == 400
+            assert "must be a JSON object" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_field_is_rejected(self, config_client_app):
+        async with TestClient(TestServer(config_client_app)) as client:
+            resp = await client.put("/api/dashboard/config", json={"nope": 1})
+            assert resp.status == 400
+            assert "Unknown fields" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_deprecated_and_read_only_keys_are_dropped_not_rejected(
+        self, config_client_app
+    ):
+        """The settings UI PUTs back everything the GET returned, so a removed
+        key and a read-only key must be ignored rather than 400 the whole save."""
+        async with TestClient(TestServer(config_client_app)) as client:
+            resp = await client.put(
+                "/api/dashboard/config",
+                json={
+                    "tail_fork_head_handling": "whatever",
+                    "gitlab_hosts": ["gitlab.example.com"],
+                    "jira_hosts": ["jira.example.com"],
+                    "session_grid": True,
+                },
+            )
+            assert resp.status == 200
+            got = await (await client.get("/api/dashboard/config")).json()
+        assert got["session_grid"] is True
+        # Read-only fields were not persisted from the PUT body.
+        assert got["gitlab_hosts"] == []
+        assert got["jira_hosts"] == []
+
+    @pytest.mark.asyncio
+    async def test_boolean_fields_reject_non_booleans(self, config_client_app):
+        bool_fields = [
+            "restore_sessions",
+            "merge_queued_messages",
+            "tail_fork_enabled",
+            "folder_suggestions_enabled",
+            "link_previews",
+            "quick_send",
+            "session_grid",
+            "mcp_app_panel",
+        ]
+        async with TestClient(TestServer(config_client_app)) as client:
+            for field in bool_fields:
+                resp = await client.put("/api/dashboard/config", json={field: "yes"})
+                assert resp.status == 400, field
+                assert field in (await resp.json())["error"], field
+
+    @pytest.mark.asyncio
+    async def test_coded_boolean_errors_carry_a_machine_code(self, config_client_app):
+        coded = {
+            "folder_suggestions_enabled": "invalid_folder_suggestions_enabled",
+            "link_previews": "invalid_link_previews",
+            "mcp_app_panel": "invalid_mcp_app_panel",
+        }
+        async with TestClient(TestServer(config_client_app)) as client:
+            for field, code in coded.items():
+                resp = await client.put("/api/dashboard/config", json={field: 1})
+                assert (await resp.json())["code"] == code, field
+
+    @pytest.mark.asyncio
+    async def test_restore_window_minutes_is_clamped(self, config_client_app):
+        async with TestClient(TestServer(config_client_app)) as client:
+            resp = await client.put(
+                "/api/dashboard/config", json={"restore_window_minutes": 99_999}
+            )
+            assert resp.status == 200
+            assert (await (await client.get("/api/dashboard/config")).json())[
+                "restore_window_minutes"
+            ] == 1440
+
+            resp = await client.put(
+                "/api/dashboard/config", json={"restore_window_minutes": -5}
+            )
+            assert resp.status == 200
+            assert (await (await client.get("/api/dashboard/config")).json())[
+                "restore_window_minutes"
+            ] == 0
+
+    @pytest.mark.asyncio
+    async def test_restore_window_minutes_rejects_non_integer(self, config_client_app):
+        async with TestClient(TestServer(config_client_app)) as client:
+            resp = await client.put(
+                "/api/dashboard/config", json={"restore_window_minutes": "soon"}
+            )
+            assert resp.status == 400
+            assert "must be an integer" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_enum_fields_reject_unknown_values(self, config_client_app):
+        async with TestClient(TestServer(config_client_app)) as client:
+            resp = await client.put("/api/dashboard/config", json={"widget_density": "medium"})
+            assert resp.status == 400
+            assert "widget_density" in (await resp.json())["error"]
+
+            resp = await client.put("/api/dashboard/config", json={"verbosity": "loud"})
+            assert resp.status == 400
+            assert "verbosity" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_full_valid_put_round_trips_through_get(self, config_client_app):
+        payload = {
+            "restore_sessions": True,
+            "restore_window_minutes": 30,
+            "merge_queued_messages": True,
+            "widget_density": "less",
+            "verbosity": "ultra",
+            "quick_send": True,
+            "session_grid": True,
+            "mcp_app_panel": True,
+            "tail_fork_enabled": True,
+            "link_previews": True,
+            "folder_suggestions_enabled": True,
+        }
+        async with TestClient(TestServer(config_client_app)) as client:
+            resp = await client.put("/api/dashboard/config", json=payload)
+            assert resp.status == 200
+            got = await (await client.get("/api/dashboard/config")).json()
+        for key, want in payload.items():
+            assert got[key] == want, key
+
+    @pytest.mark.asyncio
+    async def test_cancellation_mid_load_is_still_audited(self, mock_sel):
+        """A client disconnect while the config load is off-loop must not leave
+        the authorized access absent from the SEL chain."""
+        for method, tool in (("PUT", "dashboard_config_write"),
+                             ("GET", "dashboard_config_read")):
+            mock_sel.reset_mock()
+            req = MagicMock()
+            req.method = method
+            with patch("asyncio.to_thread", side_effect=asyncio.CancelledError):
+                with pytest.raises(asyncio.CancelledError):
+                    await files_mod.api_dashboard_config(req)
+            mock_sel.log_tool_invocation.assert_called_once_with(
+                session_key="dashboard",
+                tool_name=tool,
+                outcome="failure",
+                error="request_cancelled",
+            )
+
+
+# ── pure helpers ──
+
+
+class TestContentMatchesExt:
+    def test_zip_container_requires_pk_signature(self):
+        assert files_mod._content_matches_ext(".docx", b"PK\x03\x04rest")
+        assert files_mod._content_matches_ext(".zip", b"PK\x05\x06")
+        assert files_mod._content_matches_ext(".odt", b"PK\x07\x08")
+        assert not files_mod._content_matches_ext(".xlsx", b"<html>nope</html>")
+
+    def test_webp_needs_the_compound_riff_signature(self):
+        assert files_mod._content_matches_ext(".webp", b"RIFF\x00\x00\x00\x00WEBPmore")
+        assert not files_mod._content_matches_ext(".webp", b"RIFF\x00\x00\x00\x00WAVEmore")
+
+    def test_known_prefixes_are_enforced(self):
+        assert files_mod._content_matches_ext(".png", b"\x89PNG\r\n\x1a\n")
+        assert not files_mod._content_matches_ext(".png", b"\xff\xd8\xffnot a png")
+        assert files_mod._content_matches_ext(".gif", b"GIF89a")
+        assert files_mod._content_matches_ext(".pdf", b"%PDF-1.4")
+        assert files_mod._content_matches_ext(".gz", b"\x1f\x8b\x08")
+
+    def test_unsignable_extensions_pass_through(self):
+        # No reliable magic for text or SVG: the extension allowlist is the gate.
+        assert files_mod._content_matches_ext(".md", b"# anything")
+        assert files_mod._content_matches_ext(".svg", b"<svg/>")
+
+
+class TestFuzzyScore:
+    def test_exact_and_stem_matches_outrank_everything(self):
+        exact = files_mod._fuzzy_score("readme.md", "readme.md", "docs/readme.md")
+        stem = files_mod._fuzzy_score("readme", "readme.md", "docs/readme.md")
+        prefix = files_mod._fuzzy_score("read", "readme.md", "docs/readme.md")
+        infix = files_mod._fuzzy_score("adme", "readme.md", "docs/readme.md")
+        assert exact > prefix > infix
+        assert stem > prefix
+
+    def test_path_only_match_scores_below_name_match(self):
+        in_path = files_mod._fuzzy_score("docs", "readme.md", "docs/readme.md")
+        in_name = files_mod._fuzzy_score("adme", "readme.md", "docs/readme.md")
+        assert 0 < in_path < in_name
+
+    def test_subsequence_match_on_filename(self):
+        # 'rdm' appears in order inside 'readme.md' but is not a substring.
+        assert files_mod._fuzzy_score("rdm", "readme.md", "readme.md") > 0
+
+    def test_subsequence_falls_back_to_the_relative_path(self):
+        # 'dcsx' is not a subsequence of the filename, but is one of the path.
+        assert files_mod._fuzzy_score("dcsx", "readme.md", "docs/extra/readme.md") > 0
+
+    def test_unmatched_query_scores_zero(self):
+        assert files_mod._fuzzy_score("zzqq", "readme.md", "docs/readme.md") == 0.0
+
+    def test_shorter_names_get_the_brevity_bonus(self):
+        short = files_mod._fuzzy_score("log", "log.txt", "log.txt")
+        long = files_mod._fuzzy_score("log", "log_with_a_very_long_name.txt",
+                                      "log_with_a_very_long_name.txt")
+        assert short > long

--- a/test/test_dev_fleet_server_more_coverage.py
+++ b/test/test_dev_fleet_server_more_coverage.py
@@ -1,0 +1,1185 @@
+"""Further coverage for the Dev Fleet standalone backend.
+
+Complements ``test_dev_fleet_server_coverage.py`` by driving the branches that
+need a *spawn* double rather than a plain helper stub: the sandboxed
+``_run_cmd`` chokepoint, the ``_start_run`` streaming worker, the gh/git PR
+query layer, trusted-binary resolution, live-checkout resolution, and the
+restart-gateway backends.
+
+No real subprocess, no git, no gh, no network, no sleeps beyond a single 10 ms
+``wait_for`` deadline, and no writes outside ``tmp_path``. Every spawn is
+intercepted at BOTH chokepoints the product uses -- ``sandboxed_spawn_argv``
+(which raises on a runner with no sandbox backend) and
+``create_subprocess_limited`` -- so nothing here depends on the host having a
+sandbox, a service manager, or POSIX process groups.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+import kiro_crew.apps.builtins.dev_fleet.server as mod
+from kiro_crew import platform_compat
+from kiro_crew.apps.builtins.dev_fleet import gateway_service
+
+
+# --------------------------------------------------------------------------
+# doubles
+# --------------------------------------------------------------------------
+class _FakeProc:
+    """Subprocess stand-in for the two spawn call sites in this module."""
+
+    def __init__(
+        self,
+        *,
+        lines: list[bytes] | None = None,
+        rc: int = 0,
+        readline_error: BaseException | None = None,
+        communicate_delay: float | None = None,
+        kill_error: BaseException | None = None,
+    ) -> None:
+        self.pid = 4321
+        self.returncode: int | None = None
+        self.stdout = self
+        self.kills = 0
+        self.waits = 0
+        self._lines = list(lines or [])
+        self._rc = rc
+        self._readline_error = readline_error
+        self._communicate_delay = communicate_delay
+        self._kill_error = kill_error
+
+    # -- stream side (used by _start_run) --
+    async def readline(self) -> bytes:
+        if self._readline_error is not None:
+            raise self._readline_error
+        return self._lines.pop(0) if self._lines else b""
+
+    # -- communicate side (used by _run_cmd) --
+    async def communicate(self) -> tuple[bytes, bytes]:
+        if self._communicate_delay is not None:
+            await asyncio.sleep(self._communicate_delay)
+        self.returncode = self._rc
+        return b"out", b"err"
+
+    async def wait(self) -> int:
+        self.waits += 1
+        self.returncode = self._rc
+        return self._rc
+
+    def kill(self) -> None:
+        self.kills += 1
+        if self._kill_error is not None:
+            raise self._kill_error
+
+
+def _spawn_returns(monkeypatch, proc: _FakeProc) -> list[tuple]:
+    """Install a ``create_subprocess_limited`` double; return the call log."""
+    calls: list[tuple] = []
+
+    async def _fake(*argv, **kwargs):
+        calls.append((argv, kwargs))
+        return proc
+
+    monkeypatch.setattr(mod, "create_subprocess_limited", _fake)
+    return calls
+
+
+def _spawn_raises(monkeypatch, exc: BaseException) -> None:
+    async def _fake(*argv, **kwargs):
+        raise exc
+
+    monkeypatch.setattr(mod, "create_subprocess_limited", _fake)
+
+
+def _passthrough_sandbox(monkeypatch, cleanup: str | None = None) -> None:
+    """``sandboxed_spawn_argv`` double: identity argv, no OS isolation."""
+    monkeypatch.setattr(
+        mod,
+        "sandboxed_spawn_argv",
+        lambda argv, tier, env=None: (list(argv), dict(env or {}), cleanup),
+    )
+
+
+def _run_cmd_queue(monkeypatch, results: list[tuple[int, str, str]]) -> list[list[str]]:
+    """Replace ``_run_cmd`` with a scripted queue; return the argv log."""
+    seen: list[list[str]] = []
+
+    async def _fake(cmd, **kwargs):
+        seen.append(list(cmd))
+        return results[len(seen) - 1] if len(seen) <= len(results) else (1, "", "")
+
+    monkeypatch.setattr(mod, "_run_cmd", _fake)
+    return seen
+
+
+async def _drain_run(rid: str) -> dict:
+    """Let the _start_run worker task finish, then return its record."""
+    for _ in range(2000):
+        if mod._RUNS[rid]["status"] != "running":
+            return mod._RUNS[rid]
+        await asyncio.sleep(0)
+    raise AssertionError(f"run {rid} never left 'running'")
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    """Reset the module caches these tests read or write."""
+    monkeypatch.setattr(mod, "_RUNS", {})
+    monkeypatch.setattr(mod, "_ACTIVE_RUNS", {})
+    monkeypatch.setattr(mod, "_PR_CACHE", {})
+    monkeypatch.setattr(mod, "_FALLBACK_REPOS", [])
+    monkeypatch.setattr(mod, "_OWNER_REPO", None)
+    monkeypatch.setattr(mod, "_OWNER_REPO_RETRY_AT", 0.0)
+    monkeypatch.setattr(mod, "_TRUSTED_BIN_CACHE", {})
+    monkeypatch.setattr(mod, "_GIT_TRUSTED_HELPERS", None)
+    monkeypatch.setattr(mod, "_LIVE_WORKTREE", None)
+    monkeypatch.setattr(mod, "_LIVE_CHECK_AT", 0.0)
+    monkeypatch.setattr(mod, "_MAKE_LIVE_COMMITTED", False)
+    monkeypatch.setattr(mod, "_MAKE_LIVE_LOCK", asyncio.Lock())
+
+
+# --------------------------------------------------------------------------
+# _run_cmd -- the sandboxed spawn chokepoint
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_run_cmd_refuses_unresolvable_bare_tool(monkeypatch):
+    """A bare command name that resolves to no trusted binary never spawns."""
+    monkeypatch.setattr(mod, "_trusted_bin", lambda name: None)
+    _spawn_raises(monkeypatch, AssertionError("must not spawn"))
+
+    rc, out, err = await mod._run_cmd(["git", "status"])
+
+    assert (rc, out) == (-1, "")
+    assert err.startswith(mod._UNRESOLVED_TOOL_PREFIX)
+    assert "'git'" in err
+
+
+@pytest.mark.asyncio
+async def test_run_cmd_spawn_oserror_deletes_sandbox_cleanup_file(monkeypatch, tmp_path):
+    """An OSError from the spawn reports it AND removes the launcher temp file."""
+    leftover = tmp_path / "launcher.sh"
+    leftover.write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
+    monkeypatch.setattr(mod, "_trusted_bin", lambda name: "/usr/bin/git")
+    _passthrough_sandbox(monkeypatch, cleanup=str(leftover))
+    _spawn_raises(monkeypatch, OSError("ENOMEM"))
+
+    rc, out, err = await mod._run_cmd(["git", "status"])
+
+    assert (rc, out) == (-1, "")
+    assert err == "spawn failed: ENOMEM"
+    assert not leftover.exists()
+
+
+@pytest.mark.asyncio
+async def test_run_cmd_timeout_kills_tree_and_reports(monkeypatch, tmp_path):
+    """A communicate() that outlives *timeout* is reaped, not left running."""
+    monkeypatch.setattr(mod, "_trusted_bin", lambda name: "/usr/bin/git")
+    _passthrough_sandbox(monkeypatch, cleanup=str(tmp_path / "never-written"))
+    proc = _FakeProc(communicate_delay=5.0)
+    _spawn_returns(monkeypatch, proc)
+    killed: list[int] = []
+    monkeypatch.setattr(mod, "_kill_tree", AsyncMock(side_effect=killed.append))
+
+    rc, out, err = await mod._run_cmd(["git", "status"], timeout=0)
+
+    assert (rc, out, err) == (-1, "", "timeout (0s)")
+    assert killed == [proc.pid]
+    # kill() + wait() both ran, and the missing cleanup file was tolerated.
+    assert (proc.kills, proc.waits) == (1, 1)
+
+
+@pytest.mark.asyncio
+async def test_run_cmd_success_removes_cleanup_file(monkeypatch, tmp_path):
+    """The happy path deletes the sandbox launcher in its finally block."""
+    launcher = tmp_path / "launcher2.sh"
+    launcher.write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
+    monkeypatch.setattr(mod, "_trusted_bin", lambda name: "/usr/bin/git")
+    _passthrough_sandbox(monkeypatch, cleanup=str(launcher))
+    _spawn_returns(monkeypatch, _FakeProc(rc=0))
+
+    rc, out, err = await mod._run_cmd(["git", "status"])
+
+    assert (rc, out, err) == (0, "out", "err")
+    assert not launcher.exists()
+
+
+@pytest.mark.asyncio
+async def test_kill_tree_swallows_process_lookup_error(monkeypatch):
+    """A pid that vanished between enumeration and signalling is not an error."""
+    def _boom(pid: int) -> None:
+        raise ProcessLookupError(pid)
+
+    monkeypatch.setattr(mod, "_kill_tree_sync", _boom)
+    assert await mod._kill_tree(999999) is None
+
+
+# --------------------------------------------------------------------------
+# _start_run -- background streaming worker
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_start_run_records_spawn_failure(monkeypatch):
+    _spawn_raises(monkeypatch, OSError("no fork"))
+
+    rid = await mod._start_run("provision", ["kirocrew", "pod", "up"])
+    rec = await _drain_run(rid)
+
+    assert rec["exit_code"] == -1
+    assert rec["output"] == ["[error] spawn failed: no fork"]
+    assert rec["label"] == "provision"
+
+
+@pytest.mark.asyncio
+async def test_start_run_parses_step_markers_and_caps_output(monkeypatch, tmp_path):
+    """Markers set step/step_label; the tail window is capped at 500 lines."""
+    done = tmp_path / "profile.json"
+    done.write_text("{}", encoding="utf-8", newline="\n")
+    lines = [b"::step::2::npm ci\n", b"::step::nope::\n"]
+    lines += [b"line %d\n" % i for i in range(510)]
+    _spawn_returns(monkeypatch, _FakeProc(lines=lines, rc=0))
+
+    rid = await mod._start_run(
+        "build", ["kirocrew", "pod", "provision"],
+        cleanup_paths=[str(done), str(tmp_path / "absent")],
+    )
+    rec = await _drain_run(rid)
+
+    assert (rec["status"], rec["exit_code"]) == ("done", 0)
+    # The malformed marker leaves both fields at the last good values.
+    assert (rec["step"], rec["step_label"]) == (2, "npm ci")
+    assert len(rec["output"]) == 500
+    assert rec["output"][-1] == "line 509"
+    # A missing cleanup path is tolerated; a real one is deleted.
+    assert not done.exists()
+
+
+@pytest.mark.asyncio
+async def test_start_run_deadline_marks_timeout(monkeypatch):
+    """A run past _RUN_DEADLINE_S is killed and recorded as timeout, not done."""
+    monkeypatch.setattr(mod, "_RUN_DEADLINE_S", -1)
+    proc = _FakeProc(lines=[b"never read\n"], rc=0)
+    _spawn_returns(monkeypatch, proc)
+    killed: list[int] = []
+    monkeypatch.setattr(mod, "_kill_tree", AsyncMock(side_effect=killed.append))
+
+    rid = await mod._start_run("sync", ["kirocrew", "sync"])
+    rec = await _drain_run(rid)
+
+    assert rec["status"] == "timeout"
+    assert rec["exit_code"] == -1
+    assert rec["output"] == ["[timeout] process killed after -1s deadline"]
+    assert killed == [proc.pid]
+
+
+@pytest.mark.asyncio
+async def test_start_run_stream_error_reaps_live_child(monkeypatch):
+    """A readline() blowup still reaps the subprocess before recording."""
+    proc = _FakeProc(readline_error=ValueError("line too long"))
+    _spawn_returns(monkeypatch, proc)
+    killed: list[int] = []
+    monkeypatch.setattr(mod, "_kill_tree", AsyncMock(side_effect=killed.append))
+
+    rid = await mod._start_run("sync", ["kirocrew", "sync"])
+    rec = await _drain_run(rid)
+
+    assert rec["status"] == "done"
+    assert rec["exit_code"] == -1
+    assert rec["output"] == ["[error] line too long"]
+    assert killed == [proc.pid]
+    assert proc.kills == 1
+
+
+@pytest.mark.asyncio
+async def test_start_run_stream_error_tolerates_already_reaped_child(monkeypatch):
+    """kill() raising ProcessLookupError must not mask the original error."""
+    proc = _FakeProc(
+        readline_error=ValueError("boom"), kill_error=ProcessLookupError(4321)
+    )
+    _spawn_returns(monkeypatch, proc)
+    monkeypatch.setattr(mod, "_kill_tree", AsyncMock())
+
+    rid = await mod._start_run("sync", ["kirocrew", "sync"])
+    rec = await _drain_run(rid)
+
+    assert rec["output"] == ["[error] boom"]
+
+
+# --------------------------------------------------------------------------
+# PR query layer (gh / git through _run_cmd)
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_repo_owner_name_none_when_remote_lookup_fails(monkeypatch):
+    monkeypatch.setattr(mod, "_upstream_remote", AsyncMock(return_value="origin"))
+    _run_cmd_queue(monkeypatch, [(1, "", "fatal: no such remote")])
+    assert await mod._repo_owner_name() is None
+
+
+@pytest.mark.asyncio
+async def test_repo_owner_name_none_when_url_unparseable(monkeypatch):
+    monkeypatch.setattr(mod, "_upstream_remote", AsyncMock(return_value="origin"))
+    _run_cmd_queue(monkeypatch, [(0, "not-a-remote-url\n", "")])
+    assert await mod._repo_owner_name() is None
+
+
+@pytest.mark.asyncio
+async def test_repo_owner_name_parses_ssh_url(monkeypatch):
+    monkeypatch.setattr(mod, "_upstream_remote", AsyncMock(return_value="origin"))
+    _run_cmd_queue(monkeypatch, [(0, "git@github.com:kirodotdev/KiroCrew.git\n", "")])
+    assert await mod._repo_owner_name() == "kirodotdev/KiroCrew"
+
+
+@pytest.mark.asyncio
+async def test_get_owner_repo_caches_success_and_backs_off_failure(monkeypatch):
+    """Success is cached permanently; a failure arms a retry deadline."""
+    calls = []
+
+    async def _lookup():
+        calls.append(1)
+        return None
+
+    monkeypatch.setattr(mod, "_repo_owner_name", _lookup)
+    assert await mod._get_owner_repo() is None
+    assert mod._OWNER_REPO_RETRY_AT > 0
+    # Second call is inside the back-off window: no new lookup.
+    assert await mod._get_owner_repo() is None
+    assert len(calls) == 1
+
+    monkeypatch.setattr(mod, "_OWNER_REPO_RETRY_AT", 0.0)
+    monkeypatch.setattr(mod, "_repo_owner_name", AsyncMock(return_value="o/r"))
+    assert await mod._get_owner_repo() == "o/r"
+    # Now cached: a lookup that would raise is never reached.
+    monkeypatch.setattr(mod, "_repo_owner_name", AsyncMock(side_effect=RuntimeError))
+    assert await mod._get_owner_repo() == "o/r"
+
+
+@pytest.mark.asyncio
+async def test_pr_query_one_none_on_gh_failure(monkeypatch):
+    _run_cmd_queue(monkeypatch, [(1, "", "gh: not logged in")])
+    assert await mod._pr_query_one("o/r", "feat/x") is None
+
+
+@pytest.mark.asyncio
+async def test_pr_query_one_none_on_unparseable_json(monkeypatch):
+    _run_cmd_queue(monkeypatch, [(0, "<html>rate limited</html>", "")])
+    assert await mod._pr_query_one("o/r", "feat/x") is None
+
+
+@pytest.mark.asyncio
+async def test_pr_query_one_none_on_empty_result(monkeypatch):
+    _run_cmd_queue(monkeypatch, [(0, "[]", "")])
+    assert await mod._pr_query_one("o/r", "feat/x") is None
+
+
+@pytest.mark.asyncio
+async def test_pr_query_one_moves_body_to_internal_key(monkeypatch):
+    """``body`` becomes ``_body`` so _redact_pr drops it from the payload."""
+    payload = json.dumps([{"number": 7, "state": "OPEN", "body": None}])
+    seen = _run_cmd_queue(monkeypatch, [(0, payload, "")])
+
+    pr = await mod._pr_query_one("o/r", "feat/x")
+
+    assert pr is not None
+    assert pr["_repo"] == "o/r"
+    assert pr["_body"] == ""
+    assert "body" not in pr
+    assert "--head" in seen[0] and "feat/x" in seen[0]
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_status_needs_owner_and_branch(monkeypatch):
+    monkeypatch.setattr(mod, "_get_owner_repo", AsyncMock(return_value=None))
+    assert await mod._fetch_pr_status("feat/x") is None
+
+    monkeypatch.setattr(mod, "_get_owner_repo", AsyncMock(return_value="o/r"))
+    assert await mod._fetch_pr_status("") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_status_falls_back_to_legacy_remote(monkeypatch):
+    """A miss upstream is retried against the ancestor-verified legacy repos."""
+    monkeypatch.setattr(mod, "_get_owner_repo", AsyncMock(return_value="new/repo"))
+    monkeypatch.setattr(mod, "_FALLBACK_REPOS", ["dead/repo", "old/repo"])
+    asked: list[str] = []
+
+    async def _one(owner_repo: str, branch: str):
+        asked.append(owner_repo)
+        return {"number": 1, "_repo": owner_repo} if owner_repo == "old/repo" else None
+
+    monkeypatch.setattr(mod, "_pr_query_one", _one)
+
+    pr = await mod._fetch_pr_status("feat/x")
+
+    assert pr == {"number": 1, "_repo": "old/repo"}
+    assert asked == ["new/repo", "dead/repo", "old/repo"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_status_none_when_no_repo_has_the_branch(monkeypatch):
+    monkeypatch.setattr(mod, "_get_owner_repo", AsyncMock(return_value="new/repo"))
+    monkeypatch.setattr(mod, "_FALLBACK_REPOS", ["old/repo"])
+    monkeypatch.setattr(mod, "_pr_query_one", AsyncMock(return_value=None))
+    assert await mod._fetch_pr_status("feat/x") is None
+
+
+@pytest.mark.asyncio
+async def test_head_contained_in_pr_identical_oid_skips_git(monkeypatch):
+    _run_cmd_queue(monkeypatch, [])  # any spawn would return (1, "", "")
+    assert await mod._head_contained_in_pr("/wt", " abc123 ", "abc123\n") is True
+
+
+@pytest.mark.asyncio
+async def test_head_contained_in_pr_uses_ancestor_check(monkeypatch):
+    seen = _run_cmd_queue(monkeypatch, [(0, "", "")])
+    assert await mod._head_contained_in_pr("/wt", "aaa", "bbb") is True
+    assert seen[0][-3:] == ["--is-ancestor", "aaa", "bbb"]
+
+
+@pytest.mark.asyncio
+async def test_head_contained_in_pr_false_when_diverged(monkeypatch):
+    _run_cmd_queue(monkeypatch, [(1, "", "")])
+    assert await mod._head_contained_in_pr("/wt", "aaa", "bbb") is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_head_oid_requires_owner_and_branch(monkeypatch):
+    monkeypatch.setattr(mod, "_get_owner_repo", AsyncMock(return_value=None))
+    assert await mod._fetch_pr_head_oid("feat/x") is None
+    assert await mod._fetch_pr_head_oid("", repo="o/r") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_head_oid_none_when_gh_fails(monkeypatch):
+    _run_cmd_queue(monkeypatch, [(1, "", "gh error")])
+    assert await mod._fetch_pr_head_oid("feat/x", repo="o/r") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_head_oid_none_on_bad_json(monkeypatch):
+    _run_cmd_queue(monkeypatch, [(0, "not json", "")])
+    assert await mod._fetch_pr_head_oid("feat/x", repo="o/r") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_pr_head_oid_gated_on_merged_state(monkeypatch):
+    """An OPEN PR yields None: only a MERGED verdict may authorize removal."""
+    _run_cmd_queue(
+        monkeypatch,
+        [
+            (0, json.dumps({"state": "OPEN", "headRefOid": "deadbeef"}), ""),
+            (0, json.dumps({"state": "MERGED", "headRefOid": "cafe1234"}), ""),
+        ],
+    )
+    assert await mod._fetch_pr_head_oid("feat/x", repo="o/r") is None
+    assert await mod._fetch_pr_head_oid("feat/x", repo="o/r") == "cafe1234"
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_serves_terminal_entry_without_refetch(monkeypatch):
+    """A MERGED entry is permanently terminal; a stale OPEN entry refetches."""
+    monkeypatch.setattr(
+        mod,
+        "_PR_CACHE",
+        {
+            "merged": {"data": {"state": "MERGED"}, "ts": 0.0},
+            "stale": {"data": {"state": "OPEN"}, "ts": 0.0},
+        },
+    )
+    fetch = AsyncMock(return_value={"state": "OPEN", "number": 9})
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+
+    assert await mod._pr_status_cached("merged") == {"state": "MERGED"}
+    fetch.assert_not_awaited()
+
+    assert await mod._pr_status_cached("stale") == {"state": "OPEN", "number": 9}
+    assert mod._PR_CACHE["stale"]["data"]["number"] == 9
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_skips_base_branch(monkeypatch):
+    monkeypatch.setattr(mod, "_fetch_pr_status", AsyncMock(side_effect=RuntimeError))
+    assert await mod._pr_status_cached(mod.BASE_BRANCH) is None
+    assert await mod._pr_status_cached("") is None
+
+
+# --------------------------------------------------------------------------
+# trusted binary resolution
+# --------------------------------------------------------------------------
+def test_trusted_bin_honours_operator_absolute_override(monkeypatch, tmp_path):
+    """An absolute executable named in the service env wins outright."""
+    tool = tmp_path / "gh-override"
+    tool.write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
+    tool.chmod(0o755)
+    monkeypatch.setenv(mod._bin_override_var("gh"), str(tool))
+    monkeypatch.setattr(mod, "_TRUSTED_BIN_DIRS", ())
+
+    assert mod._trusted_bin("gh") == str(tool)
+    # Cached, so a later env change cannot repoint an already-vetted tool.
+    monkeypatch.delenv(mod._bin_override_var("gh"))
+    assert mod._trusted_bin("gh") == str(tool)
+
+
+def test_trusted_bin_ignores_relative_override(monkeypatch, tmp_path):
+    """A non-absolute override is discarded rather than PATH-resolved."""
+    monkeypatch.setenv(mod._bin_override_var("gh"), "gh")
+    monkeypatch.setattr(mod, "_TRUSTED_BIN_DIRS", (str(tmp_path),))
+    assert mod._trusted_bin("gh") is None
+
+
+def test_trusted_bin_rejects_candidate_under_home(monkeypatch, tmp_path):
+    """A bin dir whose resolved target sits under $HOME fails closed."""
+    home = tmp_path / "home"
+    binder = home / "bin"
+    binder.mkdir(parents=True)
+    tool = binder / "git"
+    tool.write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
+    tool.chmod(0o755)
+    monkeypatch.delenv(mod._bin_override_var("git"), raising=False)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setattr(mod, "_TRUSTED_BIN_DIRS", (str(binder),))
+
+    assert mod._trusted_bin("git") is None
+
+
+def test_trusted_bin_rejects_self_writable_target(monkeypatch, tmp_path):
+    """A binary we can write is a plantable shim, never a trusted tool."""
+    binder = tmp_path / "sysbin"
+    binder.mkdir()
+    tool = binder / "git"
+    tool.write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
+    tool.chmod(0o755)
+    monkeypatch.delenv(mod._bin_override_var("git"), raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "elsewhere"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "elsewhere"))
+    monkeypatch.setattr(platform_compat, "IS_POSIX", True)
+    monkeypatch.setattr(mod, "_TRUSTED_BIN_DIRS", (str(binder),))
+
+    assert mod._trusted_bin("git") is None
+
+
+def test_trusted_bin_tolerates_filesystem_error(monkeypatch, tmp_path):
+    """An OSError while vetting a candidate skips it instead of propagating."""
+    binder = tmp_path / "sysbin2"
+    binder.mkdir()
+    tool = binder / "git"
+    tool.write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
+    tool.chmod(0o755)
+    monkeypatch.delenv(mod._bin_override_var("git"), raising=False)
+    monkeypatch.setattr(mod, "_TRUSTED_BIN_DIRS", (str(binder),))
+    real_access = os.access
+
+    def _flaky(path, mode, **kwargs):
+        if str(path) == str(tool):
+            raise OSError("EIO")
+        return real_access(path, mode, **kwargs)
+
+    monkeypatch.setattr(mod.os, "access", _flaky)
+
+    assert mod._trusted_bin("git") is None
+
+
+# --------------------------------------------------------------------------
+# credential helper loading
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_sanitize_helper_rejects_gh_shape_without_trusted_gh(monkeypatch):
+    """The gh helper shape is only accepted when gh itself resolves trusted."""
+    monkeypatch.setattr(mod, "_trusted_bin", lambda name: None)
+    assert mod._sanitize_helper_value("!/opt/gh auth git-credential") is None
+
+    monkeypatch.setattr(mod, "_trusted_bin", lambda name: "/usr/bin/gh")
+    assert (
+        mod._sanitize_helper_value("!/opt/gh auth git-credential")
+        == "!/usr/bin/gh auth git-credential"
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_trusted_helpers_skips_unverifiable_and_counts(monkeypatch, caplog):
+    """A rejected helper is logged by KEY only and never enters the env."""
+    monkeypatch.setattr(mod, "_trusted_bin", lambda name: "/usr/bin/gh")
+    _run_cmd_queue(
+        monkeypatch,
+        [
+            (0, "credential.helper store\ncredential.helper osxkeychain\n", ""),
+            (1, "", ""),
+        ],
+    )
+
+    with caplog.at_level("WARNING"):
+        await mod._load_trusted_credential_helpers()
+
+    helpers = mod._GIT_TRUSTED_HELPERS
+    assert helpers is not None
+    values = [v for k, v in helpers.items() if k.startswith("GIT_CONFIG_VALUE_")]
+    assert values == ["osxkeychain"]
+    assert helpers["GIT_CONFIG_COUNT"] == "5"
+    assert "store" not in caplog.text
+    assert "credential.helper" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_load_trusted_helpers_caps_at_nine_entries(monkeypatch):
+    """The env slot budget stops the scan rather than overflowing GIT_CONFIG_*."""
+    monkeypatch.setattr(mod, "_trusted_bin", lambda name: "/usr/bin/gh")
+    many = "\n".join(["credential.helper libsecret"] * 12) + "\n"
+    _run_cmd_queue(monkeypatch, [(0, many, ""), (0, many, "")])
+
+    await mod._load_trusted_credential_helpers()
+
+    helpers = mod._GIT_TRUSTED_HELPERS
+    assert helpers is not None
+    assert len([k for k in helpers if k.startswith("GIT_CONFIG_KEY_")]) == 9
+    assert helpers["GIT_CONFIG_COUNT"] == "13"
+
+
+@pytest.mark.asyncio
+async def test_load_trusted_helpers_empty_when_no_config(monkeypatch):
+    _run_cmd_queue(monkeypatch, [(1, "", ""), (0, "", "")])
+    await mod._load_trusted_credential_helpers()
+    assert mod._GIT_TRUSTED_HELPERS == {}
+
+
+# --------------------------------------------------------------------------
+# live-checkout resolution
+# --------------------------------------------------------------------------
+def test_same_path_false_on_oserror(monkeypatch):
+    """An unresolvable path compares unequal instead of raising."""
+    real_resolve = Path.resolve
+
+    def _boom(self, *a, **kw):
+        if self.name == "explodes":
+            raise OSError("ELOOP")
+        return real_resolve(self, *a, **kw)
+
+    monkeypatch.setattr(mod.Path, "resolve", _boom)
+    assert mod._same_path("/tmp/explodes", "/tmp/explodes") is False
+
+
+def test_launchd_live_worktree_none_when_exec_is_not_a_venv_binary(monkeypatch, tmp_path):
+    """A launcher pointed at a system kirocrew names no worktree."""
+    script = tmp_path / "live-gateway"
+    script.write_text(
+        "#!/bin/sh\nexec '/usr/bin/kirocrew' gateway\n", encoding="utf-8", newline="\n"
+    )
+    monkeypatch.setattr(
+        gateway_service.LaunchdBackend, "live_program", staticmethod(lambda: script)
+    )
+    assert mod._launchd_live_worktree() is None
+
+
+def test_launchd_live_worktree_none_without_exec_line(monkeypatch, tmp_path):
+    script = tmp_path / "live-gateway"
+    script.write_text("#!/bin/sh\nsleep 1\n", encoding="utf-8", newline="\n")
+    monkeypatch.setattr(
+        gateway_service.LaunchdBackend, "live_program", staticmethod(lambda: script)
+    )
+    assert mod._launchd_live_worktree() is None
+
+
+def test_launchd_live_worktree_resolves_venv_grandparent(monkeypatch, tmp_path):
+    checkout = tmp_path / "wt-feat"
+    exe = checkout / ".venv" / "bin" / "kirocrew"
+    script = tmp_path / "live-gateway"
+    script.write_text(f"#!/bin/sh\nexec '{exe}' gateway\n", encoding="utf-8", newline="\n")
+    monkeypatch.setattr(
+        gateway_service.LaunchdBackend, "live_program", staticmethod(lambda: script)
+    )
+    assert mod._launchd_live_worktree() == str(checkout.resolve())
+
+
+@pytest.mark.asyncio
+async def test_live_worktree_path_uses_launchd_on_darwin(monkeypatch):
+    monkeypatch.setattr(mod.live_target, "read_target", lambda: None)
+    monkeypatch.setattr(mod.sys, "platform", "darwin")
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/bin/launchctl")
+    monkeypatch.setattr(mod, "_launchd_live_worktree", lambda: "/checkouts/wt")
+
+    assert await mod._live_worktree_path(fresh=True) == "/checkouts/wt"
+
+
+@pytest.mark.asyncio
+async def test_live_worktree_path_none_without_systemd(monkeypatch):
+    monkeypatch.setattr(mod.live_target, "read_target", lambda: None)
+    monkeypatch.setattr(mod.sys, "platform", "win32")
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(side_effect=RuntimeError))
+
+    assert await mod._live_worktree_path(fresh=True) is None
+
+
+@pytest.mark.asyncio
+async def test_live_worktree_path_falls_back_to_execstart(monkeypatch):
+    """An older unit with no WorkingDirectory is read off ExecStart's path=."""
+    # A fabricated, space-free path: the regex the product uses truncates at the
+    # first space, so a tmp_path containing one would make this assert the wrong
+    # thing on some runners.
+    checkout = Path("/opt/kirocrew-checkouts/co")
+    exe = checkout / ".venv" / "bin" / "kirocrew"
+    monkeypatch.setattr(mod.live_target, "read_target", lambda: None)
+    monkeypatch.setattr(mod.sys, "platform", "linux")
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/bin/systemctl")
+    _run_cmd_queue(
+        monkeypatch,
+        [
+            (0, "\n", ""),
+            (0, f"ExecStart={{ path={exe} ; argv[]=... }}", ""),
+        ],
+    )
+
+    assert await mod._live_worktree_path(fresh=True) == str(checkout.resolve())
+
+
+@pytest.mark.asyncio
+async def test_live_worktree_path_prefers_working_directory(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod.live_target, "read_target", lambda: None)
+    monkeypatch.setattr(mod.sys, "platform", "linux")
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/bin/systemctl")
+    seen = _run_cmd_queue(monkeypatch, [(0, f"{tmp_path}\n", "")])
+
+    assert await mod._live_worktree_path(fresh=True) == str(tmp_path.resolve())
+    # The ExecStart fallback is not consulted when WorkingDirectory answers.
+    assert len(seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_live_worktree_path_serves_cache_until_ttl(monkeypatch):
+    """Only ``fresh=True`` bypasses the display cache."""
+    monkeypatch.setattr(mod, "_LIVE_WORKTREE", "/cached")
+    monkeypatch.setattr(mod, "_LIVE_CHECK_AT", mod.time.monotonic())
+    monkeypatch.setattr(mod.live_target, "read_target", lambda: None)
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(side_effect=RuntimeError))
+
+    assert await mod._live_worktree_path() == "/cached"
+
+
+# --------------------------------------------------------------------------
+# _find_worktree_by_path
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_find_worktree_by_path_rejects_empty(monkeypatch):
+    monkeypatch.setattr(mod, "_discover_worktrees", AsyncMock(side_effect=RuntimeError))
+    target, err = await mod._find_worktree_by_path("")
+    assert target is None
+    assert err == "'path' must be a non-empty string"
+
+
+@pytest.mark.asyncio
+async def test_find_worktree_by_path_rejects_unresolvable(monkeypatch):
+    """A NUL byte cannot be resolved: reported as invalid, never enumerated."""
+    monkeypatch.setattr(mod, "_discover_worktrees", AsyncMock(side_effect=RuntimeError))
+    target, err = await mod._find_worktree_by_path("/wt/\x00bad")
+    assert target is None
+    assert err is not None and err.startswith("invalid path:")
+
+
+@pytest.mark.asyncio
+async def test_find_worktree_by_path_matches_known_worktree(monkeypatch, tmp_path):
+    wt = {"name": "feat", "path": str(tmp_path)}
+    monkeypatch.setattr(mod, "_discover_worktrees", AsyncMock(return_value=[wt]))
+    assert await mod._find_worktree_by_path(str(tmp_path)) == (wt, None)
+
+
+@pytest.mark.asyncio
+async def test_find_worktree_by_path_refuses_unknown_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        mod, "_discover_worktrees",
+        AsyncMock(return_value=[{"name": "feat", "path": str(tmp_path / "other")}]),
+    )
+    target, err = await mod._find_worktree_by_path(str(tmp_path / "mine"))
+    assert target is None
+    assert err is not None and err.startswith("path is not a known worktree:")
+
+
+# --------------------------------------------------------------------------
+# _dropin_path
+# --------------------------------------------------------------------------
+def test_dropin_path_honours_xdg_config_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    got = mod._dropin_path()
+    assert got.name == "make-live.conf"
+    assert got.parent.name == f"{mod._LIVE_GATEWAY_UNIT}.d"
+    assert got.is_relative_to(tmp_path / "xdg")
+
+
+def test_dropin_path_falls_back_to_home_config(monkeypatch, tmp_path):
+    home = tmp_path / "h"
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    assert mod._dropin_path() == (
+        home / ".config" / "systemd" / "user"
+        / f"{mod._LIVE_GATEWAY_UNIT}.d" / "make-live.conf"
+    )
+
+
+# --------------------------------------------------------------------------
+# _restart_gateway
+# --------------------------------------------------------------------------
+class _FakeBackend:
+    """Service-backend double for the restart paths."""
+
+    def __init__(self, *, active: bool = True, ok: bool = True, err: str = "") -> None:
+        self._active = active
+        self._ok = ok
+        self._err = err
+        self.restarts = 0
+
+    async def active(self) -> bool:
+        return self._active
+
+    async def status(self) -> str:
+        return gateway_service.STATUS_OK
+
+    async def restart_detached(self) -> tuple[bool, str]:
+        self.restarts += 1
+        return self._ok, self._err
+
+
+@pytest.mark.asyncio
+async def test_restart_gateway_refuses_when_cutover_committed(monkeypatch):
+    monkeypatch.setattr(mod, "_MAKE_LIVE_COMMITTED", True)
+    monkeypatch.setattr(mod, "_gateway_backend", lambda: pytest.fail("must not probe"))
+
+    out = await mod._restart_gateway()
+
+    assert out["ok"] is False
+    assert "Make Live cutover is in progress" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_restart_gateway_refuses_while_make_live_lock_held(monkeypatch):
+    lock = asyncio.Lock()
+    monkeypatch.setattr(mod, "_MAKE_LIVE_LOCK", lock)
+    monkeypatch.setattr(mod, "_gateway_backend", lambda: pytest.fail("must not probe"))
+
+    async with lock:
+        out = await mod._restart_gateway()
+
+    assert out["ok"] is False
+    assert "Make Live cutover is in progress" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_restart_gateway_uses_service_backend(monkeypatch):
+    svc = _FakeBackend(active=True, ok=True)
+    monkeypatch.setattr(mod, "_gateway_backend", lambda: svc)
+    monkeypatch.setattr(mod, "_gateway_start_id", AsyncMock(return_value="stamp-1"))
+
+    out = await mod._restart_gateway()
+
+    assert out == {"ok": True, "start_id": "stamp-1"}
+    assert svc.restarts == 1
+    # Latched so a second restart cannot race the pending one.
+    assert mod._MAKE_LIVE_COMMITTED is True
+
+
+@pytest.mark.asyncio
+async def test_restart_gateway_reports_service_failure_without_latching(monkeypatch):
+    svc = _FakeBackend(active=True, ok=False, err="Job failed")
+    monkeypatch.setattr(mod, "_gateway_backend", lambda: svc)
+    monkeypatch.setattr(mod, "_gateway_start_id", AsyncMock(return_value=None))
+
+    out = await mod._restart_gateway()
+
+    assert out == {"ok": False, "error": "Job failed"}
+    assert mod._MAKE_LIVE_COMMITTED is False
+
+
+@pytest.mark.asyncio
+async def test_restart_gateway_falls_back_to_foreground(monkeypatch):
+    """No drivable manager: the detached foreground respawn is the last resort."""
+    monkeypatch.setattr(mod, "_gateway_backend", lambda: None)
+    monkeypatch.setattr(mod, "_live_user_unit_status", AsyncMock(return_value="no_user_unit"))
+    fg = _FakeBackend(ok=True)
+    monkeypatch.setattr(mod, "_foreground_backend", lambda: fg)
+    monkeypatch.setattr(mod, "_gateway_start_id", AsyncMock(return_value="pid-77"))
+
+    out = await mod._restart_gateway()
+
+    assert out == {"ok": True, "start_id": "pid-77"}
+    assert fg.restarts == 1
+
+
+@pytest.mark.asyncio
+async def test_restart_gateway_reports_foreground_failure(monkeypatch):
+    monkeypatch.setattr(mod, "_gateway_backend", lambda: _FakeBackend(active=False))
+    monkeypatch.setattr(mod, "_live_user_unit_status", AsyncMock(return_value="no_agent"))
+    monkeypatch.setattr(
+        mod, "_foreground_backend", lambda: _FakeBackend(ok=False, err="no marker")
+    )
+    monkeypatch.setattr(mod, "_gateway_start_id", AsyncMock(return_value=None))
+
+    out = await mod._restart_gateway()
+
+    assert out == {"ok": False, "error": "no marker"}
+    assert mod._MAKE_LIVE_COMMITTED is False
+
+
+@pytest.mark.asyncio
+async def test_restart_gateway_refuses_confined_status(monkeypatch):
+    """A mis-set-up manager keeps its named remedy instead of a blind respawn."""
+    monkeypatch.setattr(mod, "_gateway_backend", lambda: _FakeBackend(active=False))
+    monkeypatch.setattr(
+        mod, "_live_user_unit_status", AsyncMock(return_value="user_unit_inactive")
+    )
+    monkeypatch.setattr(mod, "_foreground_backend", lambda: pytest.fail("not eligible"))
+
+    out = await mod._restart_gateway()
+
+    assert out == {"ok": False, "error": "gateway is not running as a user service"}
+
+
+@pytest.mark.asyncio
+async def test_restart_gateway_handler_returns_result(monkeypatch):
+    monkeypatch.setattr(mod, "_sel", lambda: _NullSel())
+    monkeypatch.setattr(mod, "_restart_gateway", AsyncMock(return_value={"ok": True}))
+
+    request = make_mocked_request("POST", "/api/restart-gateway")
+    resp = await mod.api_dev_fleet_restart_gateway(request)
+
+    assert resp.status == 200
+    assert json.loads(resp.text) == {"ok": True}
+
+
+class _NullSel:
+    def log_tool_invocation(self, **kw) -> None:  # pragma: no cover - sink
+        pass
+
+
+def _body_request(raw: bytes) -> MagicMock:
+    """Request double shaped like the one _audited + _json_body consume."""
+    request = MagicMock()
+    request.read = AsyncMock(return_value=raw)
+    try:
+        request.json = AsyncMock(return_value=json.loads(raw or b"{}"))
+    except ValueError as exc:
+        request.json = AsyncMock(side_effect=exc)
+    request.content_length = len(raw)
+    request.can_read_body = True
+    return request
+
+
+@pytest.mark.asyncio
+async def test_make_live_handler_rejects_unparseable_body(monkeypatch):
+    monkeypatch.setattr(mod, "_sel", lambda: _NullSel())
+    monkeypatch.setattr(mod, "_make_live", AsyncMock(side_effect=RuntimeError))
+
+    resp = await mod.api_dev_fleet_make_live(_body_request(b"{not json"))
+
+    assert resp.status == 400
+    assert json.loads(resp.text) == {"error": "invalid JSON body"}
+
+
+@pytest.mark.asyncio
+async def test_make_live_handler_requires_path_string(monkeypatch):
+    monkeypatch.setattr(mod, "_sel", lambda: _NullSel())
+    monkeypatch.setattr(mod, "_make_live", AsyncMock(side_effect=RuntimeError))
+    raw = json.dumps({"path": 12}).encode()
+
+    resp = await mod.api_dev_fleet_make_live(_body_request(raw))
+
+    assert resp.status == 400
+    assert json.loads(resp.text) == {"error": "'path' must be a non-empty string"}
+
+
+@pytest.mark.asyncio
+async def test_make_live_handler_validates_dry_run_type(monkeypatch):
+    monkeypatch.setattr(mod, "_sel", lambda: _NullSel())
+    monkeypatch.setattr(mod, "_make_live", AsyncMock(side_effect=RuntimeError))
+    raw = json.dumps({"path": "/wt/feat", "dry_run": "yes"}).encode()
+
+    resp = await mod.api_dev_fleet_make_live(_body_request(raw))
+
+    assert resp.status == 400
+    assert json.loads(resp.text) == {"error": "dry_run must be a boolean"}
+
+
+@pytest.mark.asyncio
+async def test_make_live_handler_passes_dry_run_through(monkeypatch):
+    monkeypatch.setattr(mod, "_sel", lambda: _NullSel())
+    make_live = AsyncMock(return_value={"ok": True, "dry_run": True})
+    monkeypatch.setattr(mod, "_make_live", make_live)
+    raw = json.dumps({"path": "/wt/feat", "dry_run": True}).encode()
+
+    resp = await mod.api_dev_fleet_make_live(_body_request(raw))
+
+    assert resp.status == 200
+    make_live.assert_awaited_once_with("/wt/feat", True)
+
+
+@pytest.mark.asyncio
+async def test_make_live_refuses_missing_worktree_path(monkeypatch, tmp_path):
+    """A known worktree whose directory is gone is refused before any mutation."""
+    gone = tmp_path / "removed"
+    monkeypatch.setattr(
+        mod, "_find_worktree_by_path",
+        AsyncMock(return_value=({"name": "removed", "path": str(gone)}, None)),
+    )
+    monkeypatch.setattr(mod, "_in_pod", lambda: pytest.fail("checked too late"))
+
+    out = await mod._make_live(str(gone))
+
+    assert out["ok"] is False
+    assert out["code"] == "missing_path"
+
+
+def test_kill_tree_sync_kills_descendants_first(monkeypatch):
+    """Descendants are enumerated before the group kill erases their PPIDs."""
+    order: list[str] = []
+    monkeypatch.setattr(
+        platform_compat, "process_descendants",
+        lambda pid: (order.append(f"enum:{pid}"), [11, 12])[1],
+    )
+
+    def _kill(pid: int) -> None:
+        order.append(f"kill:{pid}")
+        if pid == 11:
+            raise ProcessLookupError(pid)
+
+    monkeypatch.setattr(platform_compat, "kill_process_tree", _kill)
+
+    mod._kill_tree_sync(7)
+
+    assert order == ["enum:7", "kill:7", "kill:11", "kill:12"]
+
+
+def test_kill_tree_sync_tolerates_primary_kill_failure(monkeypatch):
+    """A group kill that fails still lets the descendant sweep run."""
+    killed: list[int] = []
+    monkeypatch.setattr(platform_compat, "process_descendants", lambda pid: [21])
+
+    def _kill(pid: int) -> None:
+        killed.append(pid)
+        if pid == 9:
+            raise OSError("EPERM")
+
+    monkeypatch.setattr(platform_compat, "kill_process_tree", _kill)
+
+    mod._kill_tree_sync(9)
+
+    assert killed == [9, 21]
+
+
+# --------------------------------------------------------------------------
+# pod config + request-body validation
+# --------------------------------------------------------------------------
+def test_load_cfg_none_when_pod_config_unloadable(monkeypatch):
+    """A pod config that will not load degrades to None, never an exception."""
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", True)
+
+    class _Boom:
+        @staticmethod
+        def load():
+            raise RuntimeError("no pods dir")
+
+    monkeypatch.setattr(mod, "PodConfig", _Boom, raising=False)
+    assert mod._load_cfg() is None
+
+
+def test_load_cfg_none_when_pods_unavailable(monkeypatch):
+    monkeypatch.setattr(mod, "_POD_AVAILABLE", False)
+    assert mod._load_cfg() is None
+
+
+@pytest.mark.asyncio
+async def test_worktree_remove_handler_rejects_unparseable_body(monkeypatch):
+    monkeypatch.setattr(mod, "_sel", lambda: _NullSel())
+    monkeypatch.setattr(mod, "_worktree_remove", AsyncMock(side_effect=RuntimeError))
+
+    resp = await mod.api_dev_fleet_worktree_remove(_body_request(b"[1, 2]"))
+
+    assert resp.status == 400
+    assert json.loads(resp.text) == {"error": "body must be an object"}
+
+
+@pytest.mark.asyncio
+async def test_pod_name_action_rejects_unparseable_body(monkeypatch):
+    action = AsyncMock(side_effect=RuntimeError)
+    resp = await mod._pod_name_action(_body_request(b"nope"), action)
+
+    assert resp.status == 400
+    assert json.loads(resp.text) == {"error": "invalid JSON body"}
+    action.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pod_name_action_requires_known_worktree(monkeypatch):
+    monkeypatch.setattr(
+        mod, "_find_worktree", AsyncMock(return_value=(None, "no such worktree"))
+    )
+    action = AsyncMock(side_effect=RuntimeError)
+
+    resp = await mod._pod_name_action(_body_request(b'{"name": "ghost"}'), action)
+
+    assert resp.status == 400
+    assert json.loads(resp.text) == {"error": "no such worktree"}
+    action.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------
+# service drivability probes
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_gateway_service_reason_none_when_drivable(monkeypatch):
+    monkeypatch.setattr(mod, "_gateway_service_active", AsyncMock(return_value=True))
+    assert await mod._gateway_service_reason() is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_service_reason_appends_unknown_checkout_hint(monkeypatch):
+    """An unattributable gateway gets the extra Pull+Build caveat."""
+    monkeypatch.setattr(mod, "_gateway_service_active", AsyncMock(return_value=False))
+    monkeypatch.setattr(mod, "_live_user_unit_status", AsyncMock(return_value="no_agent"))
+    monkeypatch.setattr(mod, "_live_worktree_path", AsyncMock(return_value=None))
+
+    reason = await mod._gateway_service_reason()
+
+    assert reason is not None
+    assert "does not belong to any known worktree" in reason
+
+
+@pytest.mark.asyncio
+async def test_gateway_service_reason_omits_hint_for_known_checkout(monkeypatch):
+    monkeypatch.setattr(mod, "_gateway_service_active", AsyncMock(return_value=False))
+    monkeypatch.setattr(
+        mod, "_live_user_unit_status", AsyncMock(return_value="user_unit_inactive")
+    )
+    monkeypatch.setattr(mod, "_live_worktree_path", AsyncMock(return_value="/co"))
+
+    reason = await mod._gateway_service_reason()
+
+    assert reason is not None
+    assert "does not belong to any known worktree" not in reason
+
+
+@pytest.mark.asyncio
+async def test_gateway_service_active_accepts_foreground_backend(monkeypatch):
+    """With no drivable manager, an unconfined foreground backend still counts."""
+    monkeypatch.setattr(mod, "_GATEWAY_SERVICE_ACTIVE", None)
+    monkeypatch.setattr(mod, "_GATEWAY_SERVICE_CHECK_AT", 0.0)
+    monkeypatch.setattr(mod, "_gateway_backend", lambda: None)
+    monkeypatch.setattr(mod, "_live_user_unit_status", AsyncMock(return_value="no_systemd"))
+    monkeypatch.setattr(mod, "_foreground_backend", lambda: _FakeBackend())
+
+    assert await mod._gateway_service_active() is True
+    assert mod._GATEWAY_SERVICE_ACTIVE is True
+
+
+@pytest.mark.asyncio
+async def test_gateway_service_active_false_when_foreground_confined(monkeypatch):
+    monkeypatch.setattr(mod, "_GATEWAY_SERVICE_ACTIVE", None)
+    monkeypatch.setattr(mod, "_GATEWAY_SERVICE_CHECK_AT", 0.0)
+    monkeypatch.setattr(mod, "_gateway_backend", lambda: _FakeBackend(active=False))
+    monkeypatch.setattr(
+        mod, "_live_user_unit_status", AsyncMock(return_value="user_unit_inactive")
+    )
+    monkeypatch.setattr(mod, "_foreground_backend", lambda: pytest.fail("not eligible"))
+
+    assert await mod._gateway_service_active() is False

--- a/test/test_gatewayd_more_coverage.py
+++ b/test/test_gatewayd_more_coverage.py
@@ -1,0 +1,995 @@
+"""Behavioural coverage for ``mcp_gateway.gatewayd``'s connection handler.
+
+The existing gatewayd suites cover the supporting machinery (sweepers, codec,
+audit emitters) and the happy-path register/claim/recaller flows over a real
+socket. What stays untested is the decision tree inside
+:func:`gatewayd._handle_connection`: the control-frame short-circuits, the
+peer-identity degradation paths, the bridge-frame hygiene checks, every
+backend-acquire rejection arm (ensure_backend pre-flight vs the legacy lazy
+path -- they differ in whether the reply is tagged fallback-eligible), the
+transparent-respawn arms, and the disconnect-time cancel/recycle block.
+
+Everything is driven with in-memory doubles: the reader is a scripted frame
+source, the writer records bytes, and the backend-acquire seam
+(``gatewayd._acquire_backend``) is replaced, so no subprocess is spawned and
+no sandbox is touched. The two ``run_gatewayd`` tests bind a real local
+endpoint under ``tmp_path`` and are POSIX-only for that reason.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.mcp_gateway import gatewayd as gw
+from kiro_crew.mcp_gateway.backend import Backend, BackendGone, _PendingRequest
+from kiro_crew.mcp_gateway.pool import BackendUnavailable, PoolAtCapacity, PoolKey
+
+pytestmark = pytest.mark.xdist_group("mcp_gateway")
+
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="binds an AF_UNIX endpoint under tmp_path; Windows uses a named pipe "
+    "whose name is not a filesystem path",
+)
+
+_STUB = "stub-cov-1"
+
+
+# --- doubles -----------------------------------------------------------------
+
+
+class _FakeWriter:
+    """``asyncio.StreamWriter`` double recording every written frame."""
+
+    def __init__(self) -> None:
+        self.writes: list[bytes] = []
+
+    def write(self, payload: bytes) -> None:
+        self.writes.append(payload)
+
+    async def drain(self) -> None:
+        return None
+
+    def frames(self) -> list[Any]:
+        return [json.loads(p.decode("utf-8")) for p in self.writes]
+
+
+class _ScriptedReader:
+    """Hands out queued frames, then EOFs like a closed stub transport.
+
+    A queued ``bytes`` is returned verbatim (so malformed / oversize frames can
+    be exercised), a ``dict`` is serialised as one JSON line, and a queued
+    exception is raised on that read.
+    """
+
+    def __init__(self, *items: Any) -> None:
+        self._items = list(items)
+
+    @property
+    def remaining(self) -> int:
+        return len(self._items)
+
+    async def readuntil(self, sep: bytes = b"\n") -> bytes:
+        if not self._items:
+            raise asyncio.IncompleteReadError(b"", None)
+        item = self._items.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        if isinstance(item, bytes):
+            return item
+        return json.dumps(item).encode("utf-8") + b"\n"
+
+
+def _register_frame(**overrides: Any) -> dict[str, Any]:
+    """A complete Register payload: every PoolKey field plus stub identity."""
+    frame: dict[str, Any] = {
+        "type": "register",
+        "stub_uuid": _STUB,
+        "poolable": True,
+        "server_name": "demo-mcp",
+        "agent_name": "cov-agent",
+        "command_args_hash": "a" * 8,
+        "effective_env_hash": "e" * 8,
+        "work_dir": "/tmp/cov",
+        "binary_version": "1.0",
+        "os_uid": 1000,
+        "sandbox_mode": "none",
+        "autoapprove_set_hash": "b" * 8,
+        "approval_mode": "reads",
+        "trust_all_tools": False,
+        "user_identity": "cov",
+        "config_snapshot_hash": "c" * 8,
+        "session_key": "sess-cov",
+        "session_type": "dashboard",
+        "ancestor_pids": [4242],
+    }
+    frame.update(overrides)
+    return frame
+
+
+def _pool_label(**overrides: Any) -> str:
+    """The human-readable pool label gatewayd puts on audit records."""
+    return PoolKey.from_register(_register_frame(**overrides)).human_readable()
+
+
+def _fake_pool(**overrides: Any) -> MagicMock:
+    pool = MagicMock()
+    pool.unreserve = MagicMock()
+    pool.reserve = MagicMock()
+    pool.release_exclusive = AsyncMock(return_value=None)
+    pool.get = AsyncMock(return_value=None)
+    pool.all_backends = MagicMock(return_value=[])
+    pool.metrics_snapshot_async = AsyncMock(return_value={"backends": 0})
+    for name, value in overrides.items():
+        setattr(pool, name, value)
+    return pool
+
+
+def _resolver(pool_key: PoolKey) -> tuple[str, list[str], dict[str, str], str]:
+    return "demo-mcp-server", [], {}, pool_key.work_dir
+
+
+async def _noop_pump() -> None:
+    return None
+
+
+def _fake_backend(pid: int = 4242) -> Backend:
+    """A real ``Backend`` over mock pipes: alive, with an inert stdout pump."""
+    proc = MagicMock()
+    proc.returncode = None
+    proc.pid = pid
+    stdin = MagicMock()
+    stdin.write = MagicMock()
+    stdin.drain = AsyncMock()
+    now = time.monotonic()
+    backend = Backend(
+        pool_key=PoolKey.from_register(_register_frame()),
+        process=proc,
+        stdin=stdin,
+        stdout=MagicMock(),
+        created_at=now,
+        last_used_at=now,
+    )
+    backend.run_stdout_pump = _noop_pump  # type: ignore[method-assign]
+    return backend
+
+
+async def _handle(
+    reader: Any,
+    writer: Any,
+    pool: Any,
+    *,
+    socket_path: Path = Path("/tmp/cov-gatewayd.sock"),
+    hot_keys: Any = None,
+) -> None:
+    await gw._handle_connection(reader, writer, pool, _resolver, socket_path, hot_keys)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module_globals():
+    """The conn index and probe registry are process-global; keep tests clean."""
+    gw._CONN_INDEX.clear()
+    gw._STUB_PROBES.clear()
+    yield
+    gw._CONN_INDEX.clear()
+    gw._STUB_PROBES.clear()
+
+
+@pytest.fixture
+def peer_ok(monkeypatch):
+    """Peer principal positively confirmed, with no SO_PEERCRED pid available."""
+    monkeypatch.setattr(gw.socketsec, "PEER_IDENTITY_SUPPORTED", True)
+    monkeypatch.setattr(
+        gw.socketsec, "check_peer_is_self", lambda w: gw.socketsec.PeerCredResult.MATCH
+    )
+    monkeypatch.setattr(gw.socketsec, "get_peer_pid", lambda w: None)
+
+
+# --- peer gate ---------------------------------------------------------------
+
+
+class TestPeerGate:
+    @pytest.mark.asyncio
+    async def test_mismatched_peer_is_refused_before_the_first_frame_is_read(
+        self, monkeypatch
+    ):
+        """On a platform with no identity mechanism a positively-parsed foreign
+        principal is still refused -- and refused before any frame is read."""
+        monkeypatch.setattr(gw.socketsec, "PEER_IDENTITY_SUPPORTED", False)
+        monkeypatch.setattr(
+            gw.socketsec,
+            "check_peer_is_self",
+            lambda w: gw.socketsec.PeerCredResult.MISMATCH,
+        )
+        owner_only = MagicMock(return_value=True)
+        monkeypatch.setattr(gw.socketsec, "socket_owner_only", owner_only)
+        denials: list[str] = []
+        monkeypatch.setattr(gw, "_audit_peer_denied", denials.append)
+
+        reader = _ScriptedReader(_register_frame())
+        writer = _FakeWriter()
+        await _handle(reader, writer, _fake_pool())
+
+        assert writer.writes == []
+        assert reader.remaining == 1, "the register frame must never be read"
+        assert denials and "mismatch" in denials[0]
+        owner_only.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_supported_platform_refuses_an_unverifiable_peer(self, monkeypatch):
+        monkeypatch.setattr(gw.socketsec, "PEER_IDENTITY_SUPPORTED", True)
+        monkeypatch.setattr(
+            gw.socketsec,
+            "check_peer_is_self",
+            lambda w: gw.socketsec.PeerCredResult.UNVERIFIABLE,
+        )
+        denials: list[str] = []
+        monkeypatch.setattr(gw, "_audit_peer_denied", denials.append)
+
+        writer = _FakeWriter()
+        await _handle(_ScriptedReader(_register_frame()), writer, _fake_pool())
+
+        assert writer.writes == []
+        assert denials and "unverifiable" in denials[0]
+
+
+# --- first-frame short circuits ---------------------------------------------
+
+
+class TestControlFrames:
+    @pytest.mark.asyncio
+    async def test_eof_before_the_first_frame_closes_without_a_reply(self, peer_ok):
+        writer = _FakeWriter()
+        await _handle(_ScriptedReader(), writer, _fake_pool())
+        assert writer.writes == []
+
+    @pytest.mark.asyncio
+    async def test_ping_is_answered_with_pong_and_closes(self, peer_ok):
+        writer = _FakeWriter()
+        await _handle(_ScriptedReader({"type": "ping"}, {"type": "ping"}), writer, _fake_pool())
+        assert writer.frames() == [{"type": "pong"}]
+
+    @pytest.mark.asyncio
+    async def test_stats_merges_the_warm_pool_hit_tally(self, peer_ok):
+        hot_keys = MagicMock()
+        hot_keys.hit_stats = MagicMock(return_value={"warm_hits": 7, "warm_misses": 2})
+        pool = _fake_pool(
+            metrics_snapshot_async=AsyncMock(return_value={"backends": 3, "sessions": 5})
+        )
+        writer = _FakeWriter()
+
+        await _handle(_ScriptedReader({"type": "stats"}), writer, pool, hot_keys=hot_keys)
+
+        assert writer.frames() == [
+            {"type": "stats", "backends": 3, "sessions": 5, "warm_hits": 7, "warm_misses": 2}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_stats_omits_warm_keys_when_prewarming_is_disabled(self, peer_ok):
+        writer = _FakeWriter()
+        await _handle(_ScriptedReader({"type": "stats"}), writer, _fake_pool())
+        assert writer.frames() == [{"type": "stats", "backends": 0}]
+
+    @pytest.mark.asyncio
+    async def test_abort_frame_cancels_in_flight_work_for_the_named_runtime(self, peer_ok):
+        conn = gw._StubConn("stub-abort", [7777], "demo-mcp", None)
+        gw._conn_index_add(conn)
+        backend = MagicMock()
+        backend.cancel_in_flight_for_stub = AsyncMock(return_value=["f1", "f2"])
+        pool = _fake_pool(all_backends=MagicMock(return_value=[backend]))
+        writer = _FakeWriter()
+
+        await _handle(
+            _ScriptedReader({"type": "abort", "pids": [7777], "reason": "hard stop"}),
+            writer,
+            pool,
+        )
+
+        assert writer.frames() == [{"type": "aborted", "cancelled": 2, "stubs": 1}]
+        backend.cancel_in_flight_for_stub.assert_awaited_once_with("stub-abort")
+
+    @pytest.mark.asyncio
+    async def test_app_call_is_refused_and_audited_when_the_feature_is_off(
+        self, peer_ok, monkeypatch
+    ):
+        from kiro_crew.mcp_gateway import app_call as app_call_mod
+        from kiro_crew.mcp_gateway import backend as backend_mod
+
+        monkeypatch.setattr(backend_mod, "_mcp_apps_enabled", lambda: False)
+        audits: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        monkeypatch.setattr(
+            app_call_mod, "_audit", lambda *a, **k: audits.append((a, k))
+        )
+        forwarded = AsyncMock()
+        monkeypatch.setattr(app_call_mod, "handle_app_call", forwarded)
+        writer = _FakeWriter()
+
+        await _handle(
+            _ScriptedReader({"type": "app-call", "spool_id": "sp-1", "tool": "do_thing"}),
+            writer,
+            _fake_pool(),
+        )
+
+        assert writer.frames() == [
+            {"type": "app-call-rejected", "reason": "mcp-apps feature disabled"}
+        ]
+        forwarded.assert_not_awaited()
+        assert audits == [
+            (
+                ("denied", "mcp-apps feature disabled"),
+                {"spool_id": "sp-1", "tool": "do_thing"},
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_app_call_is_forwarded_when_the_feature_is_on(self, peer_ok, monkeypatch):
+        from kiro_crew.mcp_gateway import app_call as app_call_mod
+        from kiro_crew.mcp_gateway import backend as backend_mod
+
+        monkeypatch.setattr(backend_mod, "_mcp_apps_enabled", lambda: True)
+        handled = AsyncMock(return_value={"type": "app-call-result", "ok": True})
+        monkeypatch.setattr(app_call_mod, "handle_app_call", handled)
+        pool = _fake_pool()
+        frame = {"type": "app-call", "spool_id": "sp-2", "tool": "render"}
+        writer = _FakeWriter()
+
+        await _handle(_ScriptedReader(frame), writer, pool)
+
+        assert writer.frames() == [{"type": "app-call-result", "ok": True}]
+        assert handled.await_args.args[0] is pool
+        assert handled.await_args.args[1]["spool_id"] == "sp-2"
+
+    @pytest.mark.asyncio
+    async def test_unknown_first_frame_type_is_dropped_silently(self, peer_ok):
+        writer = _FakeWriter()
+        await _handle(_ScriptedReader({"type": "not-a-thing"}), writer, _fake_pool())
+        assert writer.writes == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_register_is_rejected_with_the_missing_field_list(self, peer_ok):
+        writer = _FakeWriter()
+        await _handle(
+            _ScriptedReader({"type": "register", "stub_uuid": _STUB}), writer, _fake_pool()
+        )
+
+        frames = writer.frames()
+        assert len(frames) == 1
+        assert frames[0]["type"] == "rejected"
+        assert frames[0]["reason"].startswith("malformed Register:")
+        assert "server_name" in frames[0]["reason"]
+
+    @pytest.mark.asyncio
+    async def test_register_without_a_stub_uuid_is_rejected(self, peer_ok):
+        writer = _FakeWriter()
+        await _handle(_ScriptedReader(_register_frame(stub_uuid="")), writer, _fake_pool())
+        assert writer.frames() == [{"type": "rejected", "reason": "missing stub_uuid"}]
+
+
+# --- registration bookkeeping ------------------------------------------------
+
+
+class TestRegisterBookkeeping:
+    @pytest.mark.asyncio
+    async def test_registered_reply_advertises_the_negotiated_capabilities(self, peer_ok):
+        writer = _FakeWriter()
+        register = _register_frame()
+        await _handle(_ScriptedReader(register), writer, _fake_pool())
+
+        frames = writer.frames()
+        assert len(frames) == 1
+        expected_prefix = "pending-" + PoolKey.from_register(register).stable_hash()[:12]
+        assert frames[0]["type"] == "registered"
+        assert frames[0]["backend_id"] == expected_prefix
+        assert frames[0]["capabilities"] == list(gw.REGISTERED_CAPABILITIES)
+
+    @pytest.mark.asyncio
+    async def test_peer_identity_resolution_failure_leaves_the_stub_unidentified(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(gw.socketsec, "PEER_IDENTITY_SUPPORTED", True)
+        monkeypatch.setattr(
+            gw.socketsec, "check_peer_is_self", lambda w: gw.socketsec.PeerCredResult.MATCH
+        )
+        monkeypatch.setattr(gw.socketsec, "get_peer_pid", lambda w: 4321)
+
+        def _boom(peer_pid: int) -> tuple[str, list[int]]:
+            raise RuntimeError("/proc read failed")
+
+        monkeypatch.setattr(gw, "_resolve_peer_identity", _boom)
+        allowed: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            gw, "_audit_peer_allowed", lambda caller, label: allowed.append((caller, label))
+        )
+
+        register = _register_frame()
+        register.pop("session_key")
+        writer = _FakeWriter()
+        await _handle(_ScriptedReader(register), writer, _fake_pool())
+
+        assert writer.frames()[0]["type"] == "registered"
+        assert allowed == [("", _pool_label())]
+
+    @pytest.mark.asyncio
+    async def test_pid_start_id_snapshot_failure_registers_with_unknown_tokens(
+        self, peer_ok, monkeypatch
+    ):
+        """A failed start-token snapshot must degrade to 'unknown', not deny:
+        an empty map makes every later claim count as a match."""
+
+        def _boom(pid: int) -> Optional[str]:
+            raise OSError("procfs unreadable")
+
+        monkeypatch.setattr(gw, "_get_process_start_id", _boom)
+        seen: list[gw._StubConn] = []
+        real_add = gw._conn_index_add
+
+        def _spy(conn: gw._StubConn) -> None:
+            seen.append(conn)
+            real_add(conn)
+
+        monkeypatch.setattr(gw, "_conn_index_add", _spy)
+
+        writer = _FakeWriter()
+        await _handle(_ScriptedReader(_register_frame()), writer, _fake_pool())
+
+        assert len(seen) == 1
+        assert seen[0].ancestor_pids == [4242]
+        assert seen[0].pid_start_ids == {}
+
+    @pytest.mark.asyncio
+    async def test_hot_key_observation_records_the_pool_hit_outcome(self, peer_ok):
+        hot_keys = MagicMock()
+        pool = _fake_pool(get=AsyncMock(return_value=MagicMock()))
+        register = _register_frame()
+
+        await _handle(_ScriptedReader(register), _FakeWriter(), pool, hot_keys=hot_keys)
+
+        hot_keys.record.assert_called_once_with(register)
+        hot_keys.record_outcome.assert_called_once_with(hit=True)
+
+    @pytest.mark.asyncio
+    async def test_hot_key_observation_records_a_miss_on_a_cold_key(self, peer_ok):
+        hot_keys = MagicMock()
+        await _handle(
+            _ScriptedReader(_register_frame()), _FakeWriter(), _fake_pool(), hot_keys=hot_keys
+        )
+        hot_keys.record_outcome.assert_called_once_with(hit=False)
+
+
+# --- bridge-phase frame hygiene ---------------------------------------------
+
+
+class TestBridgeFrameHygiene:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_frame,is_fatal",
+        [
+            (asyncio.LimitOverrunError("no separator found", 64), True),
+            (b"", True),
+            (b"x" * (gw._MAX_FRAME_BYTES + 2), True),
+            (b"not json at all\n", False),
+            (b"[1, 2, 3]\n", False),
+        ],
+        ids=["limit-overrun", "empty-line", "oversize", "non-json", "non-object"],
+    )
+    async def test_bad_bridge_frames_never_reach_the_backend(
+        self, peer_ok, monkeypatch, bad_frame, is_fatal
+    ):
+        """A malformed frame is dropped and the session continues; a frame that
+        breaks the framing itself (overrun, empty read, oversize) drops the
+        connection. Neither may ever acquire a backend."""
+        acquire = AsyncMock()
+        monkeypatch.setattr(gw, "_acquire_backend", acquire)
+        # The trailing ping is the probe: it is answered only if the connection
+        # survived the bad frame.
+        reader = _ScriptedReader(_register_frame(), bad_frame, {"type": "ping"})
+        writer = _FakeWriter()
+
+        await _handle(reader, writer, _fake_pool())
+
+        acquire.assert_not_awaited()
+        if is_fatal:
+            assert [f["type"] for f in writer.frames()] == ["registered"]
+            assert reader.remaining == 1, "the connection must end at the bad frame"
+        else:
+            assert [f["type"] for f in writer.frames()] == ["registered", "pong"]
+            assert reader.remaining == 0
+
+    @pytest.mark.asyncio
+    async def test_bridge_ping_is_answered_without_acquiring_a_backend(
+        self, peer_ok, monkeypatch
+    ):
+        acquire = AsyncMock()
+        monkeypatch.setattr(gw, "_acquire_backend", acquire)
+        writer = _FakeWriter()
+
+        await _handle(
+            _ScriptedReader(_register_frame(), {"type": "ping"}), writer, _fake_pool()
+        )
+
+        assert [f["type"] for f in writer.frames()] == ["registered", "pong"]
+        acquire.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unregister_closes_the_connection(self, peer_ok, monkeypatch):
+        acquire = AsyncMock()
+        monkeypatch.setattr(gw, "_acquire_backend", acquire)
+        reader = _ScriptedReader(
+            _register_frame(), {"type": "unregister"}, {"jsonrpc": "2.0", "id": 1}
+        )
+        writer = _FakeWriter()
+
+        await _handle(reader, writer, _fake_pool())
+
+        assert [f["type"] for f in writer.frames()] == ["registered"]
+        assert reader.remaining == 1, "frames after unregister must not be read"
+        acquire.assert_not_awaited()
+
+
+# --- backend acquire rejection arms -----------------------------------------
+
+
+class TestEnsureBackendRejections:
+    """The pre-flight arm: a rejection the stub can still recover from is
+    tagged ``fallback: True`` so it runs an unpooled per-session exec."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "exc,expected_reason,fallback,audit",
+        [
+            (
+                gw._TargetUnknown("no target mapping for server 'demo-mcp'"),
+                "no target mapping for server 'demo-mcp'",
+                False,
+                "_audit_pool_rejected",
+            ),
+            (
+                BackendUnavailable("circuit breaker OPEN"),
+                "circuit breaker OPEN",
+                True,
+                "_audit_pool_fallback",
+            ),
+            (
+                PoolAtCapacity("pool full"),
+                "pool full",
+                True,
+                "_audit_pool_fallback",
+            ),
+            (
+                OSError("ENOMEM"),
+                "backend spawn failed: ENOMEM",
+                True,
+                "_audit_pool_fallback",
+            ),
+            (
+                RuntimeError("gateway bug"),
+                "internal error: gateway bug",
+                False,
+                "_audit_pool_rejected",
+            ),
+        ],
+        ids=["target-unknown", "breaker-open", "at-capacity", "spawn-oserror", "internal"],
+    )
+    async def test_each_failure_mode_produces_its_own_rejection_shape(
+        self, peer_ok, monkeypatch, exc, expected_reason, fallback, audit
+    ):
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(side_effect=exc))
+        audited: list[tuple[str, str, str]] = []
+        monkeypatch.setattr(
+            gw, audit, lambda caller, label, reason: audited.append((caller, label, reason))
+        )
+        reader = _ScriptedReader(
+            _register_frame(), {"type": "ensure_backend"}, {"type": "ping"}
+        )
+        writer = _FakeWriter()
+
+        await _handle(reader, writer, _fake_pool())
+
+        frames = writer.frames()
+        assert [f["type"] for f in frames] == ["registered", "rejected"]
+        assert frames[1]["reason"] == expected_reason
+        assert frames[1].get("fallback", False) is fallback
+        assert reader.remaining == 1, "the connection must end at the rejection"
+        assert audited and audited[0][0] == "sess-cov"
+        assert audited[0][1] == _pool_label()
+
+    @pytest.mark.asyncio
+    async def test_ready_is_sent_after_the_stub_is_attached(self, peer_ok, monkeypatch):
+        backend = _fake_backend()
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(return_value=(backend, True)))
+        pool = _fake_pool()
+        writer = _FakeWriter()
+
+        await _handle(
+            _ScriptedReader(_register_frame(), {"type": "ensure_backend"}), writer, pool
+        )
+
+        assert [f["type"] for f in writer.frames()] == ["registered", "ready"]
+        # Reservation released once the attach made refcount>0 protect the key,
+        # and the stub detached again when the connection ended.
+        pool.unreserve.assert_called_once()
+        assert backend.refcount == 0
+
+    @pytest.mark.asyncio
+    async def test_a_private_backend_never_releases_a_pooled_reservation(
+        self, peer_ok, monkeypatch
+    ):
+        """``poolable`` absent => connection-private backend, which took no
+        reservation; releasing one would decrement a co-digest pooled stub."""
+        backend = _fake_backend()
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(return_value=(backend, True)))
+        register = _register_frame()
+        register.pop("poolable")
+        pool = _fake_pool()
+
+        await _handle(
+            _ScriptedReader(register, {"type": "ensure_backend"}), _FakeWriter(), pool
+        )
+
+        pool.unreserve.assert_not_called()
+        pool.release_exclusive.assert_awaited_once_with(_STUB)
+
+
+class TestLazySpawnRejections:
+    """The legacy arm: the stub already forwarded a real frame, so a fallback
+    exec would lose it -- no rejection here may be tagged fallback-eligible."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "exc,expected_reason,audit_reason",
+        [
+            (gw._TargetUnknown("no target mapping"), "no target mapping", "no target mapping"),
+            (PoolAtCapacity("pool full"), "pool full", "pool full"),
+            (
+                BackendUnavailable("circuit breaker OPEN"),
+                "circuit breaker OPEN",
+                "circuit breaker OPEN",
+            ),
+            (RuntimeError("boom"), "backend spawn failed: boom", "spawn failed: boom"),
+        ],
+        ids=["target-unknown", "at-capacity", "breaker-open", "internal"],
+    )
+    async def test_rejections_are_terminal_and_never_fallback_eligible(
+        self, peer_ok, monkeypatch, exc, expected_reason, audit_reason
+    ):
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(side_effect=exc))
+        rejected: list[tuple[str, str, str]] = []
+        monkeypatch.setattr(
+            gw,
+            "_audit_pool_rejected",
+            lambda caller, label, reason: rejected.append((caller, label, reason)),
+        )
+        writer = _FakeWriter()
+
+        await _handle(
+            _ScriptedReader(
+                _register_frame(), {"jsonrpc": "2.0", "id": 4, "method": "tools/list"}
+            ),
+            writer,
+            _fake_pool(),
+        )
+
+        frames = writer.frames()
+        assert [f["type"] for f in frames] == ["registered", "rejected"]
+        assert frames[1]["reason"] == expected_reason
+        assert "fallback" not in frames[1]
+        assert rejected and rejected[0][2] == audit_reason
+
+
+# --- transparent respawn -----------------------------------------------------
+
+
+class TestBackendGoneHandling:
+    @pytest.mark.asyncio
+    async def test_unrecoverable_backend_death_ends_with_a_jsonrpc_error(
+        self, peer_ok, monkeypatch
+    ):
+        backend = _fake_backend()
+        backend.forward_from_stub = AsyncMock(  # type: ignore[method-assign]
+            side_effect=BackendGone("stdin closed")
+        )
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(return_value=(backend, True)))
+        monkeypatch.setattr(gw, "_respawn_backend_for_stub", AsyncMock(return_value=None))
+        reader = _ScriptedReader(
+            _register_frame(),
+            {"jsonrpc": "2.0", "id": 9, "method": "tools/list"},
+            {"type": "ping"},
+        )
+        writer = _FakeWriter()
+
+        await _handle(reader, writer, _fake_pool())
+
+        frames = writer.frames()
+        assert frames[-1] == {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "error": {"code": -32000, "message": "backend gone: stdin closed"},
+        }
+        assert reader.remaining == 1, "a terminal error must close the connection"
+
+    @pytest.mark.asyncio
+    async def test_successful_respawn_replays_the_captured_initialize_and_retries(
+        self, peer_ok, monkeypatch
+    ):
+        backend = _fake_backend()
+        backend.forward_from_stub = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[None, BackendGone("pipe died")]
+        )
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(return_value=(backend, True)))
+
+        fresh = _fake_backend(pid=5151)
+        inbox: "asyncio.Queue[bytes]" = asyncio.Queue()
+        replacement = asyncio.create_task(asyncio.Event().wait(), name="cov-drain")
+        respawn_args: list[tuple[Any, ...]] = []
+
+        async def _respawn(*args: Any):
+            # Mirror the real helper's contract: it stops the old inbox drain
+            # before handing back a fresh backend, so the two writer tasks
+            # never race onto the same socket.
+            respawn_args.append(args)
+            old_writer_task = args[8]
+            if old_writer_task is not None:
+                old_writer_task.cancel()
+            return fresh, inbox, replacement
+
+        monkeypatch.setattr(gw, "_respawn_backend_for_stub", _respawn)
+
+        init = {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+        writer = _FakeWriter()
+        await _handle(
+            _ScriptedReader(
+                _register_frame(),
+                init,
+                {"jsonrpc": "2.0", "id": 2, "method": "tools/call"},
+            ),
+            writer,
+            _fake_pool(),
+        )
+
+        # The respawn helper is handed the initialize frame captured earlier on
+        # this connection, so the fresh backend can be re-primed.
+        assert respawn_args and respawn_args[0][5] == init
+        assert writer.frames()[-1] == {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "error": {
+                "code": -32000,
+                "message": "backend restarted mid-call, retry: pipe died",
+            },
+        }
+        assert replacement.done(), "the replacement writer task is cancelled on exit"
+
+
+# --- disconnect-time cancel / recycle ---------------------------------------
+
+
+class TestDisconnectTeardown:
+    def _seed_in_flight(self, backend: Backend) -> None:
+        backend._pending_requests["f1"] = _PendingRequest(
+            stub_uuid=_STUB, original_id=7, method="tools/call"
+        )
+
+    @pytest.mark.asyncio
+    async def test_in_flight_work_is_cancelled_then_the_drained_backend_recycles(
+        self, peer_ok, monkeypatch
+    ):
+        backend = _fake_backend()
+        self._seed_in_flight(backend)
+        recycle = AsyncMock(return_value=True)
+        backend.recycle_if_idle = recycle  # type: ignore[method-assign]
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(return_value=(backend, True)))
+
+        await _handle(
+            _ScriptedReader(_register_frame(), {"type": "ensure_backend"}),
+            _FakeWriter(),
+            _fake_pool(),
+        )
+
+        sent = [call.args[0] for call in backend.stdin.write.call_args_list]
+        assert any(b"notifications/cancelled" in payload for payload in sent)
+        assert backend.refcount == 0
+        recycle.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_cancel_still_detaches_the_stub(self, peer_ok, monkeypatch):
+        backend = _fake_backend()
+        self._seed_in_flight(backend)
+        backend.cancel_in_flight_for_stub = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("stdin gone")
+        )
+        recycle = AsyncMock(return_value=True)
+        backend.recycle_if_idle = recycle  # type: ignore[method-assign]
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(return_value=(backend, True)))
+
+        await _handle(
+            _ScriptedReader(_register_frame(), {"type": "ensure_backend"}),
+            _FakeWriter(),
+            _fake_pool(),
+        )
+
+        assert backend.refcount == 0
+        assert _STUB not in backend._stub_inboxes
+        recycle.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_quarantined_backend_recycles_once_it_drains(self, peer_ok, monkeypatch):
+        backend = _fake_backend()
+        backend.quarantined = True
+        recycle = AsyncMock(return_value=True)
+        backend.recycle_if_idle = recycle  # type: ignore[method-assign]
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(return_value=(backend, True)))
+
+        await _handle(
+            _ScriptedReader(_register_frame(), {"type": "ensure_backend"}),
+            _FakeWriter(),
+            _fake_pool(),
+        )
+
+        recycle.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_healthy_idle_backend_is_left_for_the_sweeper(self, peer_ok, monkeypatch):
+        backend = _fake_backend()
+        recycle = AsyncMock(return_value=True)
+        backend.recycle_if_idle = recycle  # type: ignore[method-assign]
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(return_value=(backend, True)))
+
+        await _handle(
+            _ScriptedReader(_register_frame(), {"type": "ensure_backend"}),
+            _FakeWriter(),
+            _fake_pool(),
+        )
+
+        recycle.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_private_backend_release_never_masks_teardown(
+        self, peer_ok, monkeypatch
+    ):
+        backend = _fake_backend()
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(return_value=(backend, True)))
+        pool = _fake_pool(
+            release_exclusive=AsyncMock(side_effect=RuntimeError("pool wedged"))
+        )
+
+        # The handler must return normally: a teardown-time failure here would
+        # otherwise skip the writer-task cancel and mask the real cause.
+        await _handle(
+            _ScriptedReader(_register_frame(), {"type": "ensure_backend"}),
+            _FakeWriter(),
+            pool,
+        )
+
+        pool.release_exclusive.assert_awaited_once_with(_STUB)
+
+
+# --- daemon lifecycle --------------------------------------------------------
+
+
+@_POSIX_ONLY
+class TestRunGatewaydLifecycle:
+    @pytest.mark.asyncio
+    async def test_prewarm_count_is_clamped_and_persisted_hot_keys_are_warmed(
+        self, tmp_path, monkeypatch
+    ):
+        """``prewarm_count >= max_backends`` would pin the whole pool, so it is
+        clamped to leave one reclaimable slot -- and only the clamped number of
+        persisted hot keys is warmed."""
+        socket_path = tmp_path / "gw.sock"
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        hot_keys_path = tmp_path / "hot-keys.json"
+        now = time.time()
+        hot_keys_path.write_text(
+            json.dumps(
+                {
+                    "keys": [
+                        {
+                            "register": _register_frame(server_name="hot-one"),
+                            "hits": 9,
+                            "last_seen": now,
+                        },
+                        {
+                            "register": _register_frame(server_name="hot-two"),
+                            "hits": 4,
+                            "last_seen": now,
+                        },
+                    ],
+                    "totals": {"hits": 3, "misses": 1},
+                }
+            ),
+            encoding="utf-8",
+        )
+        credential_path = tmp_path / "creds.json"
+        credential_path.write_text("{}", encoding="utf-8")
+
+        warmed: list[str] = []
+        first_warm = asyncio.Event()
+
+        async def _fake_acquire(pool, pool_key, resolver, **kwargs):
+            warmed.append(pool_key.server_name)
+            first_warm.set()
+            return _fake_backend(), True
+
+        monkeypatch.setattr(gw, "_acquire_backend", _fake_acquire)
+        audits: list[str] = []
+        monkeypatch.setattr(gw, "_audit_prewarm_spawn", audits.append)
+
+        stop_event = asyncio.Event()
+        daemon = asyncio.create_task(
+            gw.run_gatewayd(
+                socket_path,
+                max_backends=2,
+                idle_timeout_secs=300,
+                stop_event=stop_event,
+                target_resolver=_resolver,
+                prewarm_count=5,
+                credential_watch_paths=[credential_path],
+            )
+        )
+        try:
+            await asyncio.wait_for(first_warm.wait(), timeout=10)
+            assert socket_path.exists(), "the endpoint must be bound before warming"
+        finally:
+            stop_event.set()
+            await asyncio.wait_for(daemon, timeout=15)
+
+        # max_backends=2 clamps prewarm_count 5 -> 1, so only the hottest key
+        # is warmed and audited.
+        assert warmed == ["hot-one"]
+        assert audits == [_pool_label(server_name="hot-one")]
+        # Clean shutdown unbinds the endpoint and flushes the hot-key tally.
+        assert not socket_path.exists()
+        assert hot_keys_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_a_crashing_connection_handler_is_logged_and_the_daemon_keeps_serving(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        socket_path = tmp_path / "gw-crash.sock"
+        handled = asyncio.Event()
+
+        async def _explode(*args, **kwargs):
+            handled.set()
+            raise RuntimeError("handler blew up")
+
+        monkeypatch.setattr(gw, "_handle_connection", _explode)
+
+        stop_event = asyncio.Event()
+        daemon = asyncio.create_task(
+            gw.run_gatewayd(
+                socket_path,
+                max_backends=2,
+                idle_timeout_secs=300,
+                stop_event=stop_event,
+                target_resolver=_resolver,
+            )
+        )
+        try:
+            for _ in range(500):
+                if socket_path.exists():
+                    break
+                await asyncio.sleep(0.02)
+            assert socket_path.exists(), "the daemon never bound its endpoint"
+            with caplog.at_level(logging.ERROR, logger=gw.logger.name):
+                _, writer = await asyncio.open_unix_connection(str(socket_path))
+                writer.close()
+                await asyncio.wait_for(handled.wait(), timeout=10)
+                # The accept loop survives a crashing handler: a second
+                # connection is still accepted.
+                _, writer2 = await asyncio.open_unix_connection(str(socket_path))
+                writer2.close()
+                await asyncio.sleep(0.05)
+        finally:
+            stop_event.set()
+            await asyncio.wait_for(daemon, timeout=15)
+
+        assert any("connection handler crashed" in rec.message for rec in caplog.records)

--- a/test/test_mcp_core_more_coverage.py
+++ b/test/test_mcp_core_more_coverage.py
@@ -1,0 +1,1054 @@
+"""Coverage tests for previously-untested ``kiro_crew.mcp_core`` surfaces.
+
+Focus areas, all confirmed uncovered before this file existed:
+
+* the parent-PID ladder (``_get_ppid`` / ``_ppid_via_libproc``) — every OS
+  branch is driven with an injected fake, so the macOS libproc path and the
+  ``ps`` last-resort fallback are exercised on any platform without ever
+  spawning a real process or loading a real dylib,
+* the four governance chokepoint helpers (``_deny_channel_agent_messaging``,
+  ``_vet_messaging_governance``, ``_vet_channel_governance``,
+  ``_vet_memory_writes_governance``) plus ``_audit_governance_deny`` — deny,
+  allow, evaluation-error/degrade and fail-closed branches,
+* the ``wait`` tool's whole sleep loop, driven by a fake clock (no real
+  sleeping) — unidentified vs identified pings, the dashboard's early-end
+  handshake, keepalive failure, and cancellation,
+* the ``spawn_status`` / ``learn_add`` / ``learn_list`` / ``learn_remove`` /
+  ``task_run`` / ``ops_mission_control_api`` tool bodies,
+* small helpers: ``_redact_json_strings``, ``_autonudge_binding_key``,
+  ``_casefold_match_span``'s expanding-fold fallbacks, ``_crew_machine_markers``,
+  ``_crew_public_text`` and ``_crew_identity``.
+
+Every HTTP call is mocked at mcp_core's own ``_get`` / ``_post`` / ``_delete``
+seams; nothing here touches the network, a gateway, a subprocess, the sandbox,
+git, or a path outside ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import struct
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew import mcp_core
+from kiro_crew.mcp_core import (
+    _audit_governance_deny,
+    _autonudge_binding_key,
+    _call_tool_inner,
+    _casefold_match_span,
+    _crew_identity,
+    _crew_machine_markers,
+    _crew_public_text,
+    _deny_channel_agent_messaging,
+    _get_ppid,
+    _governance_app,
+    _ppid_via_libproc,
+    _redact_json_strings,
+    _resolve_artifact_folder_id,
+    _vet_channel_governance,
+    _vet_memory_writes_governance,
+    _vet_messaging_governance,
+)
+from kiro_crew.mcp_shared import ToolCancelled
+
+_GOV = "kiro_crew.platform.governance_profiles"
+
+
+class _RecordingSel:
+    """Stand-in for ``sel()`` that records instead of writing the SEL log."""
+
+    def __init__(self) -> None:
+        self.tools: list[dict[str, Any]] = []
+        self.governance: list[dict[str, Any]] = []
+
+    def log_tool_invocation(self, **kw: Any) -> None:
+        self.tools.append(kw)
+
+    def log_governance_decision(self, **kw: Any) -> None:
+        self.governance.append(kw)
+
+
+class _FakeClock:
+    """Monotonic clock advanced only by ``sleep`` — no real waiting."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, secs: float) -> None:
+        self.slept.append(secs)
+        self.now += secs
+
+
+def _fake_libproc(ppid: int, ret: int = 232, expect_pid: int | None = None):
+    """Build a ``ctypes.CDLL`` replacement whose ``proc_pidinfo`` fills a buffer.
+
+    ``struct proc_bsdinfo`` opens with five uint32s; ``pbi_ppid`` is index 4,
+    which is what the product unpacks.
+    """
+
+    def cdll(name: str, use_errno: bool = False):
+        assert name == "libproc.dylib"
+
+        def proc_pidinfo(pid, flavor, arg, buf, size):
+            if expect_pid is not None:
+                assert pid == expect_pid
+            # flavor 3 == PROC_PIDTBSDINFO
+            assert flavor == 3
+            buf[0:20] = struct.pack("<5I", 0, 0, 0, pid, ppid)
+            return ret
+
+        return SimpleNamespace(proc_pidinfo=proc_pidinfo)
+
+    return cdll
+
+
+# ── _ppid_via_libproc ────────────────────────────────────────────────────
+
+
+class TestPpidViaLibproc:
+    def test_unpacks_pbi_ppid_from_the_libproc_buffer(self) -> None:
+        with patch.object(ctypes, "CDLL", _fake_libproc(4242, expect_pid=1234)):
+            assert _ppid_via_libproc(1234) == 4242
+
+    def test_short_read_is_rejected_rather_than_unpacked(self) -> None:
+        # n <= 16 means pbi_ppid (offset 16..20) was never written; a real
+        # unpack there would return whatever the zeroed buffer held (0) and
+        # look like a legitimate "parent is pid 0".
+        with patch.object(ctypes, "CDLL", _fake_libproc(4242, ret=16)):
+            assert _ppid_via_libproc(1234) == 0
+
+    def test_missing_dylib_returns_zero_so_the_caller_can_fall_back(self) -> None:
+        def boom(*_a: Any, **_kw: Any):
+            raise OSError("libproc.dylib not found")
+
+        with patch.object(ctypes, "CDLL", boom):
+            assert _ppid_via_libproc(1234) == 0
+
+
+# ── _get_ppid ───────────────────────────────────────────────────────────
+
+
+class _FakeProcStatus:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def read_text(self) -> str:
+        return self._text
+
+
+class TestGetPpid:
+    def test_windows_delegates_to_platform_compat(self) -> None:
+        with patch.object(mcp_core, "platform", SimpleNamespace(system=lambda: "Windows")):
+            with patch.object(mcp_core.platform_compat, "get_ppid", return_value=77) as gp:
+                assert _get_ppid(5) == 77
+        gp.assert_called_once_with(5)
+
+    def test_windows_zero_is_normalized_and_never_falls_through_to_ps(self) -> None:
+        spawned: list[Any] = []
+        fake_sub = SimpleNamespace(check_output=lambda *a, **k: spawned.append(a))
+        with patch.object(mcp_core, "platform", SimpleNamespace(system=lambda: "Windows")):
+            with patch.object(mcp_core.platform_compat, "get_ppid", return_value=0):
+                with patch.object(mcp_core, "subprocess", fake_sub):
+                    assert _get_ppid(5) == 0
+        assert spawned == []
+
+    def test_linux_parses_ppid_out_of_proc_status(self) -> None:
+        status = "Name:\tpython3\nState:\tS (sleeping)\nPPid:\t9931\nTracerPid:\t0\n"
+        with patch.object(mcp_core, "platform", SimpleNamespace(system=lambda: "Linux")):
+            with patch.object(mcp_core, "Path", lambda p: _FakeProcStatus(status)):
+                assert _get_ppid(1) == 9931
+
+    def test_linux_status_without_a_ppid_line_falls_back_to_ps(self) -> None:
+        fake_sub = SimpleNamespace(check_output=lambda *a, **k: " 4004\n")
+        with patch.object(mcp_core, "platform", SimpleNamespace(system=lambda: "Linux")):
+            with patch.object(mcp_core, "Path", lambda p: _FakeProcStatus("Name:\tx\n")):
+                with patch.object(mcp_core, "subprocess", fake_sub):
+                    assert _get_ppid(1) == 4004
+
+    def test_darwin_uses_libproc_when_it_answers(self) -> None:
+        fake_sub = SimpleNamespace(check_output=lambda *a, **k: pytest.fail("ps was spawned"))
+        with patch.object(mcp_core, "platform", SimpleNamespace(system=lambda: "Darwin")):
+            with patch.object(mcp_core, "_ppid_via_libproc", return_value=515):
+                with patch.object(mcp_core, "subprocess", fake_sub):
+                    assert _get_ppid(9) == 515
+
+    def test_darwin_libproc_miss_falls_back_to_ps(self) -> None:
+        calls: list[Any] = []
+
+        def check_output(argv, **kw):
+            calls.append(argv)
+            return "  808 \n"
+
+        with patch.object(mcp_core, "platform", SimpleNamespace(system=lambda: "Darwin")):
+            with patch.object(mcp_core, "_ppid_via_libproc", return_value=0):
+                with patch.object(mcp_core, "subprocess", SimpleNamespace(check_output=check_output)):
+                    assert _get_ppid(9) == 808
+        assert calls == [["ps", "-o", "ppid=", "-p", "9"]]
+
+    def test_blocked_ps_on_an_unknown_platform_returns_zero(self) -> None:
+        def check_output(*_a: Any, **_kw: Any):
+            raise PermissionError("Operation not permitted")
+
+        with patch.object(mcp_core, "platform", SimpleNamespace(system=lambda: "Plan9")):
+            with patch.object(mcp_core, "subprocess", SimpleNamespace(check_output=check_output)):
+                assert _get_ppid(9) == 0
+
+    def test_only_the_first_ppid_line_is_read(self) -> None:
+        # Every OS branch here is driven by injected fakes, so this runs on the
+        # Windows runners too even though /proc is Linux-only in production.
+        with patch.object(mcp_core, "platform", SimpleNamespace(system=lambda: "Linux")):
+            with patch.object(mcp_core, "Path", lambda p: _FakeProcStatus("PPid:\t11\nPPid:\t22\n")):
+                assert _get_ppid(1) == 11
+
+
+# ── channel-agent containment + governance audit ─────────────────────────
+
+
+class TestDenyChannelAgentMessaging:
+    def test_non_channel_caller_is_not_denied(self) -> None:
+        assert _deny_channel_agent_messaging("dashboard:chat-1-9", "send_message") is None
+
+    def test_channel_caller_is_denied_and_audited(self) -> None:
+        rec = _RecordingSel()
+        with patch("kiro_crew.sel.sel", lambda: rec):
+            out = _deny_channel_agent_messaging("channel:C123:agent-1", "send_message")
+        assert out is not None
+        assert "send_message is not available to channel agents" in out
+        assert rec.tools[0]["outcome"] == "rejected_blocked_tool"
+        assert rec.tools[0]["session_key"] == "channel:C123:agent-1"
+        assert rec.tools[0]["tool_kind"] == "kirocrew-core"
+
+    def test_audit_failure_never_unblocks_the_deny(self) -> None:
+        def boom() -> Any:
+            raise RuntimeError("SEL file unwritable")
+
+        with patch("kiro_crew.sel.sel", boom):
+            out = _deny_channel_agent_messaging("channel:C1:a", "send_notification")
+        assert out is not None and "not available to channel agents" in out
+
+
+class TestAuditGovernanceDeny:
+    def test_records_the_decision_fields(self) -> None:
+        rec = _RecordingSel()
+        decision = SimpleNamespace(rule="no-messaging", layer="policy", reason="ceiling")
+        with patch("kiro_crew.sel.sel", lambda: rec):
+            _audit_governance_deny("dashboard:chat-1-9", "send_message", "channels", decision)
+        assert rec.governance == [
+            {
+                "session_key": "dashboard:chat-1-9",
+                "tool_name": "send_message",
+                "scope": "channels",
+                "outcome": "denied",
+                "rule": "no-messaging",
+                "layer": "policy",
+                "reason": "ceiling",
+            }
+        ]
+
+    def test_a_sel_failure_is_swallowed(self) -> None:
+        def boom() -> Any:
+            raise RuntimeError("no disk")
+
+        with patch("kiro_crew.sel.sel", boom):
+            assert _audit_governance_deny("s", "t", "scope", object()) is None
+
+
+class TestGovernanceApp:
+    def test_reads_the_app_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KIROCREW_APP_NAME", "ops-mission-control")
+        assert _governance_app() == "ops-mission-control"
+
+    def test_absent_outside_an_app_backend(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KIROCREW_APP_NAME", raising=False)
+        assert _governance_app() == ""
+
+
+class TestVetMessagingGovernance:
+    def test_permitted_decision_returns_none(self) -> None:
+        with patch(f"{_GOV}.vet_and_audit", return_value=SimpleNamespace(permitted=True)):
+            assert _vet_messaging_governance("dashboard:chat-1-9") is None
+
+    def test_denied_decision_returns_the_reason(self) -> None:
+        with patch(f"{_GOV}.vet_and_audit", return_value=SimpleNamespace(permitted=False)) as va:
+            out = _vet_messaging_governance("dashboard:chat-1-9", tool_name="send_notification")
+        assert out == "outbound messaging blocked by governance policy"
+        # The audit must be attributed to the REAL calling tool, not the default.
+        assert va.call_args.kwargs["tool_name"] == "send_notification"
+        assert va.call_args.kwargs["log_warning"] is False
+
+    def test_evaluation_error_degrades_open_for_send_message(self) -> None:
+        with patch(f"{_GOV}.vet_and_audit", side_effect=RuntimeError("no context")):
+            with patch(f"{_GOV}.audit_governance_degraded") as degraded:
+                assert _vet_messaging_governance("dashboard:chat-1-9") is None
+        assert degraded.call_args.kwargs["scope"] == "capabilities.messaging"
+
+    def test_evaluation_error_denies_when_fail_closed(self) -> None:
+        with patch(f"{_GOV}.vet_and_audit", side_effect=RuntimeError("no context")):
+            with patch(f"{_GOV}.audit_governance_degraded") as degraded:
+                out = _vet_messaging_governance(
+                    "dashboard:chat-1-9", tool_name="send_notification", fail_closed=True
+                )
+        assert out == "governance evaluation failed; denying (fail-closed)"
+        # The degrade is audited on the fail-closed path too.
+        assert degraded.call_count == 1
+
+    def test_a_failing_degrade_audit_does_not_escape(self) -> None:
+        with patch(f"{_GOV}.vet_and_audit", side_effect=RuntimeError("no context")):
+            with patch(f"{_GOV}.audit_governance_degraded", side_effect=RuntimeError("no disk")):
+                assert _vet_messaging_governance("dashboard:chat-1-9") is None
+
+    def test_platform_composition_error_propagates(self) -> None:
+        from kiro_crew.platform.context import PlatformCompositionError
+
+        with patch(f"{_GOV}.vet_and_audit", side_effect=PlatformCompositionError("unbooted")):
+            with pytest.raises(PlatformCompositionError):
+                _vet_messaging_governance("dashboard:chat-1-9")
+
+
+class TestVetChannelGovernance:
+    def test_permitted_transport_returns_none(self) -> None:
+        with patch(f"{_GOV}.governance_permits", return_value=SimpleNamespace(permitted=True)):
+            assert _vet_channel_governance("dashboard:chat-1-9", "slack") is None
+
+    def test_denied_transport_names_the_transport_and_audits(self) -> None:
+        rec = _RecordingSel()
+        decision = SimpleNamespace(permitted=False, rule="channels", layer="policy", reason="off")
+        with patch(f"{_GOV}.governance_permits", return_value=decision) as gp:
+            with patch("kiro_crew.sel.sel", lambda: rec):
+                out = _vet_channel_governance("dashboard:chat-1-9", "discord")
+        assert out == "messaging via transport 'discord' blocked by governance policy"
+        # A bare member id queries the ScopedMap ``members`` ruleset.
+        assert gp.call_args.args == ("channels", "discord")
+        assert rec.governance[0]["tool_name"] == "send_message:discord"
+        assert rec.governance[0]["scope"] == "channels"
+
+    def test_evaluation_error_degrades_open_and_is_audited(self) -> None:
+        with patch(f"{_GOV}.governance_permits", side_effect=RuntimeError("no context")):
+            with patch(f"{_GOV}.audit_governance_degraded") as degraded:
+                assert _vet_channel_governance("dashboard:chat-1-9", "slack") is None
+        assert degraded.call_args.args == ("send_message:slack",)
+        assert degraded.call_args.kwargs["scope"] == "channels"
+
+    def test_a_failing_degrade_audit_does_not_escape(self) -> None:
+        with patch(f"{_GOV}.governance_permits", side_effect=RuntimeError("no context")):
+            with patch(f"{_GOV}.audit_governance_degraded", side_effect=RuntimeError("no disk")):
+                assert _vet_channel_governance("dashboard:chat-1-9", "slack") is None
+
+    def test_platform_composition_error_propagates(self) -> None:
+        from kiro_crew.platform.context import PlatformCompositionError
+
+        with patch(f"{_GOV}.governance_permits", side_effect=PlatformCompositionError("unbooted")):
+            with pytest.raises(PlatformCompositionError):
+                _vet_channel_governance("dashboard:chat-1-9", "slack")
+
+
+class TestVetMemoryWritesGovernance:
+    def test_permitted_returns_none(self) -> None:
+        with patch(f"{_GOV}.governance_permits", return_value=SimpleNamespace(permitted=True)):
+            assert _vet_memory_writes_governance("dashboard:chat-1-9") is None
+
+    def test_denied_write_is_reported_and_audited_as_learn_add(self) -> None:
+        rec = _RecordingSel()
+        decision = SimpleNamespace(
+            permitted=False, rule="memory_writes", layer="profile", reason="sandboxed app"
+        )
+        with patch(f"{_GOV}.governance_permits", return_value=decision) as gp:
+            with patch("kiro_crew.sel.sel", lambda: rec):
+                out = _vet_memory_writes_governance("dashboard:chat-1-9")
+        assert out == "durable memory writes blocked by governance policy"
+        assert gp.call_args.args == ("capabilities.memory_writes", "")
+        assert rec.governance[0]["tool_name"] == "learn_add"
+        assert rec.governance[0]["scope"] == "capabilities.memory_writes"
+
+    def test_evaluation_error_degrades_open(self) -> None:
+        with patch(f"{_GOV}.governance_permits", side_effect=RuntimeError("no context")):
+            with patch(f"{_GOV}.audit_governance_degraded") as degraded:
+                assert _vet_memory_writes_governance("dashboard:chat-1-9") is None
+        assert degraded.call_args.kwargs["scope"] == "capabilities.memory_writes"
+
+    def test_platform_composition_error_propagates(self) -> None:
+        from kiro_crew.platform.context import PlatformCompositionError
+
+        with patch(f"{_GOV}.governance_permits", side_effect=PlatformCompositionError("x")):
+            with pytest.raises(PlatformCompositionError):
+                _vet_memory_writes_governance("dashboard:chat-1-9")
+
+
+# ── small helpers ───────────────────────────────────────────────────────
+
+
+class TestRedactJsonStrings:
+    def test_redacts_keys_and_values_recursively_and_passes_scalars_through(self) -> None:
+        with patch.object(mcp_core, "redact", lambda s: s.replace("SECRET", "[REDACTED]")):
+            out = _redact_json_strings(
+                {
+                    "SECRET-key": ["SECRET-item", 3, None, True],
+                    "nested": {"inner": "keep SECRET here"},
+                    "num": 7,
+                }
+            )
+        assert out == {
+            "[REDACTED]-key": ["[REDACTED]-item", 3, None, True],
+            "nested": {"inner": "keep [REDACTED] here"},
+            "num": 7,
+        }
+
+    def test_a_bare_scalar_is_returned_unchanged(self) -> None:
+        assert _redact_json_strings(12) == 12
+        assert _redact_json_strings(None) is None
+
+
+class TestAutonudgeBindingKey:
+    @pytest.mark.parametrize(
+        "session_key,expected",
+        [
+            ("dashboard:chat-3-1712345678", "chat-3-1712345678"),
+            ("slack:C123:1712345678.1", "slack:C123:1712345678.1"),
+            ("discord:99:1", "discord:99:1"),
+            ("cron:nightly", None),
+            ("subagent:abc123", None),
+            ("", None),
+        ],
+    )
+    def test_maps_only_nudge_able_sessions(self, session_key: str, expected: str | None) -> None:
+        assert _autonudge_binding_key(session_key) == expected
+
+
+class TestCasefoldMatchSpanExpandingFolds:
+    """``ß`` casefolds to ``ss``, so a match offset can land mid-expansion."""
+
+    def test_start_offset_inside_an_expansion_snaps_to_the_enclosing_char(self) -> None:
+        # "aßb".casefold() == "assb"; needle "sb" starts at cf offset 2, which is
+        # no source-char boundary (bounds are 0,1,3,4) -> snap back to the 'ß'.
+        span = _casefold_match_span("aßb", "sb")
+        assert span == (1, 3)
+        assert "aßb"[span[0] : span[1]] == "ßb"
+
+    def test_end_offset_inside_an_expansion_snaps_outward(self) -> None:
+        # needle "as" ends at cf offset 2, mid-'ß' -> snap out to include it.
+        span = _casefold_match_span("aßb", "as")
+        assert span == (0, 2)
+        assert "aßb"[span[0] : span[1]] == "aß"
+
+    def test_no_match_and_empty_needle_return_none(self) -> None:
+        assert _casefold_match_span("abc", "zz") is None
+        assert _casefold_match_span("abc", "") is None
+
+
+class TestResolveArtifactFolderId:
+    def test_root_and_blank_refs_resolve_to_the_root_folder(self) -> None:
+        assert _resolve_artifact_folder_id("") == ("", None)
+        assert _resolve_artifact_folder_id("  RooT ") == ("", None)
+
+    def test_a_backend_error_is_propagated_not_swallowed(self) -> None:
+        with patch.object(mcp_core, "_get", return_value={"error": "HTTP 403"}) as g:
+            assert _resolve_artifact_folder_id("Designs") == ("", "HTTP 403")
+        g.assert_called_once_with("/api/artifact-folders")
+
+    def test_a_ref_of_only_separators_resolves_to_root(self) -> None:
+        with patch.object(mcp_core, "_get", return_value={"folders": []}):
+            assert _resolve_artifact_folder_id("///") == ("", None)
+
+    def test_a_nested_human_path_resolves_case_insensitively(self) -> None:
+        folders = [
+            {"id": "f1", "name": "Designs", "parent_id": None},
+            {"id": "f2", "name": "Mocks", "parent_id": "f1"},
+        ]
+        with patch.object(mcp_core, "_get", return_value={"folders": folders}):
+            assert _resolve_artifact_folder_id("designs/MOCKS") == ("f2", None)
+            assert _resolve_artifact_folder_id("f2") == ("f2", None)
+            fid, err = _resolve_artifact_folder_id("designs/nope")
+            assert fid == "" and err == "folder not found: designs/nope"
+
+
+class TestCrewMachineMarkers:
+    def test_a_root_temp_dir_is_never_used_as_a_marker(self) -> None:
+        # A marker of "/" would rewrite every slash in a public comment.
+        with patch.object(mcp_core, "tempfile", SimpleNamespace(gettempdir=lambda: "/")):
+            values = [value for value, _ in _crew_machine_markers()]
+        assert "/" not in values
+
+    def test_markers_are_longest_first(self) -> None:
+        markers = _crew_machine_markers()
+        lengths = [len(value) for value, _ in markers]
+        assert lengths == sorted(lengths, reverse=True)
+
+    def test_a_short_hostname_is_not_scrubbed(self) -> None:
+        with patch.object(mcp_core.socket, "gethostname", return_value="dev"):
+            assert "dev" not in [value for value, _ in _crew_machine_markers()]
+
+    def test_a_distinctive_hostname_is_scrubbed(self) -> None:
+        with patch.object(mcp_core.socket, "gethostname", return_value="dev-dsk-example-2b"):
+            assert ("dev-dsk-example-2b", "<host>") in _crew_machine_markers()
+
+    def test_an_unavailable_hostname_is_tolerated(self) -> None:
+        with patch.object(mcp_core.socket, "gethostname", side_effect=OSError("no dns")):
+            assert all(placeholder != "<host>" for _, placeholder in _crew_machine_markers())
+
+
+class TestCrewPublicText:
+    def test_a_windows_marker_is_scrubbed_in_both_slash_forms(self) -> None:
+        markers = [("C:\\Users\\alice", "<home>")]
+        with patch.object(mcp_core, "_crew_machine_markers", return_value=markers):
+            with patch.object(mcp_core, "redact", lambda s: s):
+                out = _crew_public_text("saw C:\\Users\\alice and C:/Users/alice")
+        assert out == "saw <home> and <home>"
+        assert "alice" not in out
+
+    def test_a_posix_marker_is_scrubbed_once(self) -> None:
+        with patch.object(mcp_core, "_crew_machine_markers", return_value=[("/home/bob", "<home>")]):
+            with patch.object(mcp_core, "redact", lambda s: s):
+                assert _crew_public_text("cwd=/home/bob/x") == "cwd=<home>/x"
+
+
+class TestCrewIdentity:
+    def test_identity_is_taken_from_the_top_level_when_present(self) -> None:
+        payload = {"owner": "o", "repo": "r", "crew": {"id": "c1"}}
+        assert _crew_identity(payload) == ("o", "r", "c1")
+
+    def test_identity_falls_back_to_the_crew_record_then_a_work_item(self) -> None:
+        assert _crew_identity({"crew": {"owner": "o", "repo": "r", "id": "c2"}}) == ("o", "r", "c2")
+        payload = {
+            "crew": {},
+            "items": ["not-a-dict", {"owner": "o", "repo": "r", "crew_id": "c3"}],
+        }
+        assert _crew_identity(payload) == ("o", "r", "c3")
+
+    def test_missing_owner_repo_or_crew_id_yields_none(self) -> None:
+        assert _crew_identity({"crew": {"id": "c1"}}) is None
+        # owner/repo present but no crew id anywhere: a write cannot be addressed.
+        assert _crew_identity({"owner": "o", "repo": "r", "crew": {}, "items": []}) is None
+        # Malformed shapes must not raise.
+        assert _crew_identity({"crew": "nope", "items": "nope"}) is None
+
+
+# ── the ``wait`` tool ───────────────────────────────────────────────────
+
+
+class TestWaitTool:
+    def _run(self, args: dict[str, Any], *, strict_key: str, post):
+        clock = _FakeClock()
+        rec = _RecordingSel()
+        with patch.object(mcp_core, "time", clock):
+            with patch.object(mcp_core, "_resolve_session_key_strict", return_value=strict_key):
+                with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
+                    with patch.object(mcp_core, "is_tool_cancelled", return_value=False):
+                        with patch.object(mcp_core, "sel", lambda: rec):
+                            with patch.object(mcp_core, "_post", post) as p:
+                                out = _call_tool_inner("wait", dict(args))
+        return out, clock, rec, p
+
+    def test_an_unidentified_sleep_publishes_nothing_and_pings_slowly(self) -> None:
+        posts: list[tuple[str, dict]] = []
+
+        def post(path, body=None, **_kw):
+            posts.append((path, body))
+            return {}
+
+        out, clock, rec, _ = self._run(
+            {"seconds": 120, "reason": "waiting on CI"}, strict_key="", post=post
+        )
+        assert out == "Waited 120s. Resuming: waiting on CI"
+        # No wait_id is published without an authoritative identity, and no
+        # retirement POST is sent because nothing was ever published.
+        assert [body for _, body in posts] == [{}, {}]
+        # Unidentified sleeps revert to the 60s staleness cadence, not 5s.
+        assert clock.slept == [60.0, 60.0]
+        assert rec.tools[0]["tool_name"] == "wait"
+        assert rec.tools[0]["outcome"] == "success"
+
+    def test_an_identified_sleep_publishes_its_deadline_and_retires_the_card(self) -> None:
+        posts: list[tuple[str, dict]] = []
+
+        def post(path, body=None, **_kw):
+            posts.append((path, body))
+            return {}
+
+        out, clock, _rec, _ = self._run(
+            {"seconds": 60, "reason": "deploy"}, strict_key="dashboard:chat-1-9", post=post
+        )
+        assert out == "Waited 60s. Resuming: deploy"
+        first = posts[0][1]
+        assert first["seconds"] == 60
+        assert first["remaining"] == 60
+        assert first["interval"] == mcp_core.WAIT_PING_SECS
+        wait_id = first["wait_id"]
+        assert posts[-1][1] == {"wait_id": wait_id, "wait_done": True}
+        # 5s cadence while identified -> 12 sleeps over a 60s wait.
+        assert clock.slept == [5.0] * 12
+
+    def test_only_a_reply_naming_this_wait_ends_it_early(self) -> None:
+        seen: list[dict] = []
+
+        def post(path, body=None, **_kw):
+            body = body or {}
+            seen.append(body)
+            if len(seen) == 1:
+                # A stale reply about a DIFFERENT sleep must be ignored.
+                return {"end_wait": "some-other-wait-id"}
+            return {"end_wait": body.get("wait_id")}
+
+        out, clock, _rec, _ = self._run(
+            {"seconds": 300, "reason": "review"}, strict_key="dashboard:chat-1-9", post=post
+        )
+        assert out.startswith("Wait ended early by the user after 5s of 300s.")
+        assert out.endswith("Resuming: review")
+        # One sleep happened between the ignored reply and the matching one.
+        assert clock.slept == [5.0]
+        assert seen[-1] == {"wait_id": seen[0]["wait_id"], "wait_done": True}
+
+    def test_an_unidentified_sleep_ignores_an_end_wait_reply(self) -> None:
+        def post(path, body=None, **_kw):
+            # Backend answering about somebody else's wait; we sent no wait_id.
+            return {"end_wait": "whatever"}
+
+        out, clock, _rec, _ = self._run(
+            {"seconds": 60, "reason": "x"}, strict_key="", post=post
+        )
+        assert out == "Waited 60s. Resuming: x"
+        assert clock.slept == [60.0]
+
+    def test_a_failing_keepalive_is_best_effort(self) -> None:
+        def post(path, body=None, **_kw):
+            raise OSError("gateway down")
+
+        out, clock, _rec, _ = self._run(
+            {"seconds": 60, "reason": "x"}, strict_key="dashboard:chat-1-9", post=post
+        )
+        assert out == "Waited 60s. Resuming: x"
+        assert clock.slept == [5.0] * 12
+
+    def test_a_failing_retirement_post_does_not_break_the_result(self) -> None:
+        calls: list[dict] = []
+
+        def post(path, body=None, **_kw):
+            body = body or {}
+            calls.append(body)
+            if body.get("wait_done"):
+                raise OSError("gateway down")
+            return {}
+
+        out, _clock, _rec, _ = self._run(
+            {"seconds": 60, "reason": "x"}, strict_key="dashboard:chat-1-9", post=post
+        )
+        assert out == "Waited 60s. Resuming: x"
+        assert calls[-1]["wait_done"] is True
+
+    def test_cancellation_raises_tool_cancelled_with_elapsed_seconds(self) -> None:
+        clock = _FakeClock()
+        rec = _RecordingSel()
+        with patch.object(mcp_core, "time", clock):
+            with patch.object(mcp_core, "_resolve_session_key_strict", return_value=""):
+                with patch.object(mcp_core, "is_tool_cancelled", return_value=True):
+                    with patch.object(mcp_core, "sel", lambda: rec):
+                        with patch.object(mcp_core, "_post", lambda *a, **k: {}):
+                            with pytest.raises(ToolCancelled) as ei:
+                                _call_tool_inner("wait", {"seconds": 60, "reason": "x"})
+        assert "wait cancelled after 0s" in str(ei.value)
+        # A cancelled sleep never reports success.
+        assert rec.tools == []
+
+    def test_the_reason_is_redacted_before_it_reaches_the_transcript(self) -> None:
+        out, _clock, _rec, _ = self._run(
+            {"seconds": 60, "reason": "creds AKIAIOSFODNN7EXAMPLE in the log"},
+            strict_key="",
+            post=lambda *a, **k: {},
+        )
+        assert "AKIAIOSFODNN7EXAMPLE" not in out
+        assert out.startswith("Waited 60s. Resuming: ")
+
+
+# ── spawn_status / learn_* / task_run ───────────────────────────────────
+
+
+class TestSpawnStatusTool:
+    def test_a_non_alphanumeric_agent_id_is_refused_before_any_request(self) -> None:
+        with patch.object(mcp_core, "_get", side_effect=AssertionError("no request expected")):
+            assert _call_tool_inner("spawn_status", {"agent_id": "../etc"}) == (
+                "Error: invalid agent_id"
+            )
+            assert _call_tool_inner("spawn_status", {}) == "Error: invalid agent_id"
+
+    def test_paging_and_grep_arguments_become_query_parameters(self) -> None:
+        with patch.object(mcp_core, "_get", return_value={"result": "ok"}) as g:
+            _call_tool_inner(
+                "spawn_status",
+                {"agent_id": "abc123", "offset": 10, "limit": 5, "grep": " ERROR "},
+            )
+        path = g.call_args.args[0]
+        assert path.startswith("/api/spawn/abc123?")
+        assert "offset=10" in path and "limit=5" in path and "grep=" in path
+
+    def test_non_positive_paging_values_are_dropped(self) -> None:
+        with patch.object(mcp_core, "_get", return_value={"result": "ok"}) as g:
+            _call_tool_inner(
+                "spawn_status",
+                {"agent_id": "abc123", "offset": 0, "limit": -1, "grep": "   "},
+            )
+        assert g.call_args.args[0] == "/api/spawn/abc123"
+
+    def test_a_transport_error_is_surfaced(self) -> None:
+        with patch.object(mcp_core, "_get", return_value={"error": "HTTP 404"}):
+            out = _call_tool_inner("spawn_status", {"agent_id": "abc123"})
+        assert out == "Error: HTTP 404"
+
+    def test_a_grep_error_from_the_backend_is_surfaced(self) -> None:
+        payload = {"result": "x", "result_meta": {"grep_error": "bad regex"}}
+        with patch.object(mcp_core, "_get", return_value=payload):
+            assert _call_tool_inner("spawn_status", {"agent_id": "a1"}) == "Error: bad regex"
+
+    def test_an_empty_result_is_reported_as_such(self) -> None:
+        with patch.object(mcp_core, "_get", return_value={"result": ""}):
+            assert _call_tool_inner("spawn_status", {"agent_id": "a1"}) == "_No result._"
+
+    def test_a_paged_read_is_prefixed_with_a_continuation_header(self) -> None:
+        payload = {
+            "result": "line-a\nline-b",
+            "result_meta": {
+                "total_lines": 90,
+                "matched_lines": 4,
+                "offset": 10,
+                "returned_lines": 2,
+                "has_more": True,
+            },
+        }
+        with patch.object(mcp_core, "_get", return_value=payload):
+            out = _call_tool_inner("spawn_status", {"agent_id": "a1"})
+        header, body = out.split("\n", 1)
+        assert "4 line(s) matched grep of 90 total" in header
+        assert "showing lines 10-12 of 90" in header
+        assert "call again with offset=12" in header
+        assert body == "line-a\nline-b"
+
+    def test_the_transcript_is_redacted(self) -> None:
+        payload = {"result": "token AKIAIOSFODNN7EXAMPLE leaked"}
+        with patch.object(mcp_core, "_get", return_value=payload):
+            out = _call_tool_inner("spawn_status", {"agent_id": "a1"})
+        assert "AKIAIOSFODNN7EXAMPLE" not in out
+
+
+class TestLearnAddTool:
+    def test_a_missing_rule_is_refused(self) -> None:
+        assert _call_tool_inner("learn_add", {}) == "Error: rule is required"
+
+    def test_a_governance_denial_blocks_the_write(self) -> None:
+        with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
+            with patch.object(mcp_core, "_vet_memory_writes_governance", return_value="blocked"):
+                with patch.object(mcp_core, "_post", side_effect=AssertionError("no write")):
+                    out = _call_tool_inner("learn_add", {"rule": "always X"})
+        assert out == "Error: blocked"
+
+    def _allowed(self):
+        return patch.object(mcp_core, "_vet_memory_writes_governance", return_value=None)
+
+    def test_a_workspace_scoped_lesson_requires_a_workspace_name(self) -> None:
+        with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
+            with self._allowed():
+                with patch.object(mcp_core, "_post", side_effect=AssertionError("no write")):
+                    out = _call_tool_inner(
+                        "learn_add", {"rule": "r", "scope": "workspace"}
+                    )
+        assert out == "Error: workspace name is required when scope='workspace'"
+
+    def test_the_negative_clause_and_workspace_are_forwarded(self) -> None:
+        with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
+            with self._allowed():
+                with patch.object(mcp_core, "_post", return_value={"ok": True}) as p:
+                    out = _call_tool_inner(
+                        "learn_add",
+                        {
+                            "rule": "always X",
+                            "category": "preference",
+                            "scope": "workspace",
+                            "workspace": "default",
+                            "negative": "never Y",
+                        },
+                    )
+        assert out == "Saved lesson (workspace): always X"
+        assert p.call_args.args == (
+            "/api/lessons",
+            {
+                "rule": "always X",
+                "category": "preference",
+                "scope": "workspace",
+                "negative": "never Y",
+                "workspace": "default",
+            },
+        )
+
+    def test_an_unknown_session_error_becomes_an_actionable_message(self) -> None:
+        with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
+            with self._allowed():
+                with patch.object(mcp_core, "_post", return_value={"error": "unknown session"}):
+                    out = _call_tool_inner("learn_add", {"rule": "r"})
+        assert out.startswith("Lesson was NOT saved:")
+        assert "re-state the lesson" in out
+
+    def test_any_other_backend_error_is_passed_through(self) -> None:
+        with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
+            with self._allowed():
+                with patch.object(mcp_core, "_post", return_value={"error": "HTTP 500"}):
+                    assert _call_tool_inner("learn_add", {"rule": "r"}) == "Error: HTTP 500"
+
+
+class TestLearnListAndRemoveTools:
+    def test_a_transport_error_is_not_rendered_as_an_empty_memory(self) -> None:
+        with patch.object(mcp_core, "_get", return_value={"error": "HTTP 403"}):
+            assert _call_tool_inner("learn_list", {}) == "Error: HTTP 403"
+
+    def test_an_empty_store_says_so(self) -> None:
+        with patch.object(mcp_core, "_get", return_value={"lessons": []}):
+            assert _call_tool_inner("learn_list", {}) == "No lessons saved."
+
+    def test_lessons_are_rendered_with_their_category(self) -> None:
+        lessons = [{"category": "tool", "rule": "use X"}, {"rule": "no category"}]
+        with patch.object(mcp_core, "_get", return_value={"lessons": lessons}):
+            out = _call_tool_inner("learn_list", {})
+        assert out == "[tool] use X\n[?] no category"
+
+    def test_learn_remove_reports_the_query_it_deleted_by(self) -> None:
+        with patch.object(mcp_core, "_delete", return_value={"removed": 2}) as d:
+            out = _call_tool_inner("learn_remove", {"query": "always X"})
+        assert out == "Removed lessons matching: always X"
+        assert d.call_args.args == ("/api/lessons", {"rule": "always X"})
+
+    def test_learn_remove_surfaces_a_backend_error(self) -> None:
+        with patch.object(mcp_core, "_delete", return_value={"error": "HTTP 500"}):
+            assert _call_tool_inner("learn_remove", {"query": "q"}) == "Error: HTTP 500"
+
+
+class TestTaskRunTool:
+    def test_a_cron_caller_is_attributed_as_cron(self) -> None:
+        with patch.object(mcp_core, "_resolve_session_key", return_value="cron:nightly"):
+            with patch.object(mcp_core, "_post", return_value={"ok": True}) as p:
+                out = _call_tool_inner("task_run", {"spec": "do the thing", "name": "Nightly"})
+        assert out == "Task runner started: Nightly"
+        assert p.call_args.args[1]["source"] == "cron"
+
+    def test_an_unnamed_task_is_labelled_from_the_spec_head(self) -> None:
+        with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
+            with patch.object(mcp_core, "_post", return_value={"ok": True}) as p:
+                out = _call_tool_inner("task_run", {"spec": "s" * 200})
+        assert p.call_args.args[1]["source"] == "mcp"
+        assert out == "Task runner started: " + "s" * 80
+
+    def test_a_backend_error_is_surfaced(self) -> None:
+        with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
+            with patch.object(mcp_core, "_post", return_value={"error": "no runner"}):
+                assert _call_tool_inner("task_run", {"spec": "x"}) == "Error: no runner"
+
+
+# ── ops_mission_control_api ─────────────────────────────────────────────
+
+
+class TestOpsMissionControlApiTool:
+    def test_a_pair_outside_the_allowlist_is_refused_at_the_handler(self) -> None:
+        # Defense in depth: the schema checks the same pair, so this branch is
+        # only reachable by calling the handler directly — which is exactly the
+        # property it exists to guarantee.
+        with patch.object(mcp_core, "_get", side_effect=AssertionError("no request")):
+            out = _call_tool_inner(
+                "ops_mission_control_api", {"method": "GET", "path": "/dispatch"}
+            )
+        assert out == (
+            "Error: GET /dispatch is not part of the ops-mission-control agent surface."
+        )
+
+    def test_a_get_is_prefixed_with_the_app_route_and_carries_the_query(self) -> None:
+        with patch.object(mcp_core, "_get", return_value={"incidents": []}) as g:
+            out = _call_tool_inner(
+                "ops_mission_control_api",
+                {"method": "GET", "path": "/incidents", "query": "status=open"},
+            )
+        assert g.call_args.args == ("/api/apps/ops-mission-control/incidents?status=open",)
+        assert out == '{"incidents": []}'
+
+    def test_a_malformed_body_is_refused(self) -> None:
+        with patch.object(mcp_core, "_post", side_effect=AssertionError("no request")):
+            out = _call_tool_inner(
+                "ops_mission_control_api",
+                {"method": "POST", "path": "/ledger", "body_json": "{not json"},
+            )
+        assert out == "Error: body_json is not valid JSON."
+
+    def test_a_non_object_body_is_refused(self) -> None:
+        with patch.object(mcp_core, "_post", side_effect=AssertionError("no request")):
+            out = _call_tool_inner(
+                "ops_mission_control_api",
+                {"method": "POST", "path": "/ledger", "body_json": "[1, 2]"},
+            )
+        assert out == "Error: body_json must encode a JSON object."
+
+    def test_a_post_body_is_sanitized_and_redacted_on_the_way_in(self) -> None:
+        body_json = '{"note": "key AKIAIOSFODNN7EXAMPLE", "zw": "a\\u200bb"}'
+        with patch.object(mcp_core, "_post", return_value={"ok": True}) as p:
+            out = _call_tool_inner(
+                "ops_mission_control_api",
+                {"method": "POST", "path": "/ledger", "body_json": body_json},
+            )
+        sent = p.call_args.args[1]
+        assert "AKIAIOSFODNN7EXAMPLE" not in sent["note"]
+        assert "\u200b" not in sent["zw"]
+        assert out == '{"ok": true}'
+
+    def test_an_empty_body_posts_an_empty_object(self) -> None:
+        with patch.object(mcp_core, "_post", return_value={"ok": True}) as p:
+            _call_tool_inner(
+                "ops_mission_control_api", {"method": "POST", "path": "/ledger/hygiene"}
+            )
+        assert p.call_args.args == ("/api/apps/ops-mission-control/ledger/hygiene", {})
+
+    def test_an_oversized_response_is_truncated_with_a_narrowing_hint(self) -> None:
+        with patch.object(mcp_core, "_get", return_value={"blob": "x" * 70_000}):
+            out = _call_tool_inner(
+                "ops_mission_control_api", {"method": "GET", "path": "/state"}
+            )
+        assert len(out) < 70_000
+        assert "truncated (" in out
+        assert "Narrow the" in out
+
+    def test_the_response_is_redacted_before_truncation(self) -> None:
+        payload = {"signal": "creds AKIAIOSFODNN7EXAMPLE here"}
+        with patch.object(mcp_core, "_get", return_value=payload):
+            out = _call_tool_inner(
+                "ops_mission_control_api", {"method": "GET", "path": "/signals"}
+            )
+        assert "AKIAIOSFODNN7EXAMPLE" not in out
+
+    def test_a_non_serializable_response_value_still_renders(self) -> None:
+        # ``default=str`` keeps a stray object from raising out of the tool.
+        with patch.object(mcp_core, "_get", return_value={"when": object()}):
+            out = _call_tool_inner(
+                "ops_mission_control_api", {"method": "GET", "path": "/rotation"}
+            )
+        assert out.startswith('{"when": "<object object at')
+
+
+# ── resource_status ─────────────────────────────────────────────────────
+
+
+class TestResourceStatusTool:
+    def _run(self, posture: str, *, cap: Any = 3):
+        rstatus = SimpleNamespace(
+            posture=posture, summary_lines=lambda: ["Memory: 19G free", "Load: 1.2"]
+        )
+        cfg = SimpleNamespace(load=staticmethod(lambda: object()))
+        resolver = (
+            (lambda _c: (_ for _ in ()).throw(RuntimeError("unreadable config")))
+            if cap == "raise"
+            else (lambda _c: cap)
+        )
+        with patch("kiro_crew.resource_status.probe", return_value=rstatus):
+            with patch.object(mcp_core, "KiroCrewConfig", cfg):
+                with patch.object(mcp_core, "resolve_max_subagents", resolver):
+                    return _call_tool_inner("resource_status", {})
+
+    def test_the_probe_summary_and_cap_are_reported(self) -> None:
+        out = self._run("ample")
+        assert out.startswith("Memory: 19G free\nLoad: 1.2\n")
+        assert "  Concurrent sub-agent cap: 3" in out
+
+    def test_an_unreadable_config_omits_the_cap_line_instead_of_failing(self) -> None:
+        out = self._run("ample", cap="raise")
+        assert "Concurrent sub-agent cap" not in out
+        assert "ample headroom" in out
+
+    def test_a_zero_cap_is_not_advertised(self) -> None:
+        assert "Concurrent sub-agent cap" not in self._run("ample", cap=0)
+
+    @pytest.mark.parametrize(
+        "posture,needle",
+        [
+            ("critical", "do NOT start heavy work"),
+            ("tight", "prefer the lighter path"),
+            ("ample", "ample headroom — heavy work is fine"),
+            # An unmeasurable host must not silently read as "fine".
+            ("unknown", "headroom could not be measured"),
+        ],
+    )
+    def test_each_posture_gets_its_own_guidance(self, posture: str, needle: str) -> None:
+        assert needle in self._run(posture)
+
+
+# ── issue_radar_record_investigation ────────────────────────────────────
+
+
+class TestIssueRadarRecordInvestigation:
+    _BASE = {"owner": "o", "repo": "r", "number": 7}
+
+    def test_identity_fields_are_sent_explicitly_with_defaults(self) -> None:
+        with patch.object(mcp_core, "_put", return_value={"investigation": {}}) as p:
+            out = _call_tool_inner("issue_radar_record_investigation", dict(self._BASE))
+        assert p.call_args.args == (
+            "/api/apps/issue-radar/investigation",
+            {
+                "owner": "o",
+                "repo": "r",
+                "number": 7,
+                "provider": "github",
+                "host": "github.com",
+                "kind": "issue",
+                "status": "resolved",
+            },
+        )
+        assert out.startswith("Recorded status `resolved` for o/r#7")
+        assert "status badge only" in out
+
+    def test_empty_finding_fields_are_dropped_so_a_partial_update_keeps_prior_text(self) -> None:
+        args = dict(self._BASE, verdict="real bug", root_cause="", summary="", next_action="fix")
+        saved = {"investigation": {"findings": {"verdict": "real bug"}}}
+        with patch.object(mcp_core, "_put", return_value=saved) as p:
+            out = _call_tool_inner("issue_radar_record_investigation", args)
+        findings = p.call_args.args[1]["findings"]
+        assert set(findings) == {"verdict", "next_action"}
+        assert "verdict `real bug`" in out
+
+    def test_findings_and_labels_are_redacted_on_the_way_in(self) -> None:
+        args = dict(
+            self._BASE,
+            verdict="leaks AKIAIOSFODNN7EXAMPLE",
+            suggested_labels=["", "bug AKIAIOSFODNN7EXAMPLE"],
+        )
+        with patch.object(mcp_core, "_put", return_value={"investigation": {}}) as p:
+            _call_tool_inner("issue_radar_record_investigation", args)
+        findings = p.call_args.args[1]["findings"]
+        assert "AKIAIOSFODNN7EXAMPLE" not in findings["verdict"]
+        # The falsy label is dropped, the redacted one survives.
+        assert len(findings["suggested_labels"]) == 1
+        assert "AKIAIOSFODNN7EXAMPLE" not in findings["suggested_labels"][0]
+
+    def test_a_gitlab_merge_request_is_referenced_with_a_bang(self) -> None:
+        args = dict(
+            self._BASE, provider="gitlab", host="gitlab.com", kind="pull", verdict="ok"
+        )
+        saved = {"investigation": {"findings": {"verdict": "ok"}}}
+        with patch.object(mcp_core, "_put", return_value=saved):
+            out = _call_tool_inner("issue_radar_record_investigation", args)
+        assert "for o/r!7:" in out
+
+    def test_a_github_pull_request_keeps_the_hash_form(self) -> None:
+        args = dict(self._BASE, kind="pull", verdict="ok")
+        saved = {"investigation": {"findings": {"verdict": "ok"}}}
+        with patch.object(mcp_core, "_put", return_value=saved):
+            assert "for o/r#7:" in _call_tool_inner("issue_radar_record_investigation", args)
+
+    def test_saved_findings_without_a_verdict_are_labelled(self) -> None:
+        saved = {"investigation": {"findings": {"summary": "s"}}}
+        with patch.object(mcp_core, "_put", return_value=saved):
+            out = _call_tool_inner(
+                "issue_radar_record_investigation", dict(self._BASE, summary="s")
+            )
+        assert "verdict `(no verdict)`" in out
+
+    def test_a_backend_error_is_surfaced(self) -> None:
+        with patch.object(mcp_core, "_put", return_value={"error": "HTTP 409"}):
+            out = _call_tool_inner("issue_radar_record_investigation", dict(self._BASE))
+        assert out == "Error: HTTP 409"

--- a/test/test_session_more_coverage.py
+++ b/test/test_session_more_coverage.py
@@ -1,0 +1,954 @@
+"""Refusal, retry and teardown edges of ``kiro_crew.session`` the suites skip.
+
+The behavioural session suites drive happy paths: a session is created, used,
+reset. What they leave untested is the half of ``SessionManager`` that exists
+only for things going wrong, and each of those branches is load-bearing:
+
+* **Queue-race guards.** Six drain loops read ``_warm_pool`` with
+  ``while not empty(): get_nowait()``. The ``except asyncio.QueueEmpty: break``
+  arm is the only thing standing between a concurrent claim and an exception
+  escaping a shutdown or config-reload path. It is driven here with a queue
+  double that reports non-empty and then refuses to yield — the exact shape a
+  racing ``_drain_and_claim`` produces.
+* **Teardown that must not raise.** ``close_all``, ``reset`` and
+  ``_discard_pool_provider`` each swallow failures from a provider, a runtime
+  kill, a child sweep. A swallowed failure is indistinguishable from success
+  unless a test makes the failure happen, so every one of those handlers is
+  exercised with the underlying call raising.
+* **Respawn retries.** ``get_bg_session`` re-spawns a dead ``_bg`` runtime once
+  and then gives up. Both halves matter: retrying forever wedges a background
+  caller, and not retrying at all drops chat titles on a runtime that died.
+* **Delegation surface.** The ``_session_map`` wrappers are one-liners, which is
+  why they are worth pinning: a wrong argument order or a dropped keyword is
+  invisible at the call site and silently loses a mirror binding.
+
+No test here starts a process, touches the OS sandbox, shells out to git, or
+writes outside ``tmp_path``: every provider, runtime and queue is a double, and
+the three functions that would reach the OS (``platform_compat.pid_exists``,
+``acp.client._get_child_pids``, ``_sync_kill_provider``) are patched at the
+chokepoint the product actually calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew import platform_compat
+from kiro_crew.config import KiroCrewConfig
+from kiro_crew.messaging.link import ChannelLink
+from kiro_crew.session import (
+    BACKGROUND_KEY,
+    SessionManager,
+    _Session,
+)
+
+
+@pytest.fixture
+def cfg():
+    c = KiroCrewConfig()
+    c.session.timeout_secs = 60
+    c.session.pool_size = 0
+    return c
+
+
+@pytest.fixture
+def mgr(cfg):
+    """A manager with no provider factory — nothing can cold-start by accident."""
+    return SessionManager(cfg)
+
+
+def _provider(**attrs):
+    """A provider double carrying only the attributes a test names.
+
+    ``SimpleNamespace`` rather than ``MagicMock``: the probe helpers
+    (``_provider_has_unfinished_turn`` and friends) accept only an exact
+    ``True``, and an auto-generated attribute would make a filter pass for the
+    wrong reason.
+    """
+    base = {
+        "shutdown": AsyncMock(),
+        "context_usage_pct": lambda: 0.0,
+        "cwd": "",
+        "is_process_alive": lambda: True,
+    }
+    base.update(attrs)
+    return SimpleNamespace(**base)
+
+
+def _register(mgr: SessionManager, key: str, **kwargs) -> _Session:
+    provider = kwargs.pop("provider", None) or _provider()
+    sess = _Session(provider=provider, **kwargs)
+    mgr._sessions[key] = sess
+    return sess
+
+
+class _RacedQueue:
+    """Queue double that reports non-empty and then refuses to yield.
+
+    Models the window a concurrent ``_drain_and_claim`` opens: the drain loops
+    check ``empty()`` and call ``get_nowait()`` without holding a lock, so the
+    entry can be gone by the time they ask for it.
+    """
+
+    def __init__(self, qsize: int = 1) -> None:
+        self._qsize = qsize
+
+    def empty(self) -> bool:
+        return False
+
+    def qsize(self) -> int:
+        return self._qsize
+
+    def get_nowait(self):
+        raise asyncio.QueueEmpty
+
+    def put_nowait(self, item) -> None:  # pragma: no cover — nothing was taken
+        raise AssertionError("nothing was claimed, so nothing can be returned")
+
+
+class _Bang(BaseException):
+    """A BaseException that is NOT an Exception — the arm below ``except Exception``."""
+
+
+# ── Session-map delegation ───────────────────────────────────────────────────
+
+
+class TestSessionMapDelegation:
+    """The thin wrappers must forward the caller's arguments verbatim.
+
+    Each one is a single ``return self._session_map.X(...)``, so the only thing
+    that can break is the plumbing: a dropped keyword or a swapped positional
+    silently loses a link binding instead of failing loudly.
+    """
+
+    @pytest.fixture
+    def smap(self, mgr):
+        fake = MagicMock()
+        mgr._session_map = fake
+        return fake
+
+    def test_resumable_hint_folds_the_key_before_asking(self, mgr, smap) -> None:
+        _register(mgr, "slack:1.2")
+        smap.has_hint.return_value = True
+        assert mgr.resumable_hint("1.2") is True
+        # The bare thread_ts folded onto the live canonical entry.
+        smap.has_hint.assert_called_once_with("slack:1.2")
+
+    def test_clear_slack_link_returns_the_maps_verdict(self, mgr, smap) -> None:
+        smap.clear_slack_link.return_value = False
+        assert mgr.clear_slack_link("dashboard:a") is False
+        smap.clear_slack_link.assert_called_once_with("dashboard:a")
+
+    def test_channel_key_for_stem_passes_the_stem_through(self, mgr, smap) -> None:
+        smap.channel_key_for_stem.return_value = "channel:slack_C1"
+        assert mgr.channel_key_for_stem("channel_slack_C1") == "channel:slack_C1"
+        smap.channel_key_for_stem.assert_called_once_with("channel_slack_C1")
+
+    def test_set_mirror_link_forwards_accepts_inbound_as_a_keyword(self, mgr, smap) -> None:
+        link = ChannelLink(channel_type="discord", channel_id="C9")
+        mgr.set_mirror_link("dashboard:a", link, accepts_inbound=True)
+        smap.set_mirror_link.assert_called_once_with(
+            "dashboard:a", link, accepts_inbound=True
+        )
+
+    def test_get_mirror_link_returns_the_stored_link(self, mgr, smap) -> None:
+        link = ChannelLink(channel_type="discord", channel_id="C9")
+        smap.get_mirror_link.return_value = link
+        assert mgr.get_mirror_link("dashboard:a") is link
+
+    def test_mirror_accepts_inbound_is_the_maps_answer(self, mgr, smap) -> None:
+        smap.mirror_accepts_inbound.return_value = True
+        assert mgr.mirror_accepts_inbound("dashboard:a") is True
+        smap.mirror_accepts_inbound.assert_called_once_with("dashboard:a")
+
+    def test_batched_save_hands_back_the_maps_context_manager(self, mgr, smap) -> None:
+        sentinel = MagicMock()
+        smap.batched_save.return_value = sentinel
+        assert mgr.batched_save() is sentinel
+
+    def test_find_mirror_sessions_forwards_inbound_only(self, mgr, smap) -> None:
+        link = ChannelLink(channel_type="discord", channel_id="C9")
+        smap.find_mirror_sessions.return_value = ["dashboard:a"]
+        assert mgr.find_mirror_sessions(link, inbound_only=True) == ["dashboard:a"]
+        smap.find_mirror_sessions.assert_called_once_with(link, inbound_only=True)
+
+    def test_mirror_claim_blockers_forwards_key_link_and_flag(self, mgr, smap) -> None:
+        link = ChannelLink(channel_type="discord", channel_id="C9")
+        smap.mirror_claim_blockers.return_value = ["dashboard:b"]
+        assert mgr.mirror_claim_blockers("dashboard:a", link, accepts_inbound=True) == [
+            "dashboard:b"
+        ]
+        smap.mirror_claim_blockers.assert_called_once_with(
+            "dashboard:a", link, accepts_inbound=True
+        )
+
+    def test_clear_mirror_link_returns_whether_one_was_present(self, mgr, smap) -> None:
+        smap.clear_mirror_link.return_value = True
+        assert mgr.clear_mirror_link("dashboard:a") is True
+
+    def test_clear_mirror_links_at_returns_the_cleared_keys(self, mgr, smap) -> None:
+        link = ChannelLink(channel_type="discord", channel_id="C9")
+        smap.clear_mirror_links_at.return_value = ["dashboard:a", "dashboard:b"]
+        assert mgr.clear_mirror_links_at(link) == ["dashboard:a", "dashboard:b"]
+
+    def test_max_generation_returns_the_persisted_high_water_mark(self, mgr, smap) -> None:
+        smap.max_generation.return_value = 7
+        assert mgr.max_generation("unified:kirocrew") == 7
+        smap.max_generation.assert_called_once_with("unified:kirocrew")
+
+
+class TestMirrorOptOut:
+    def test_a_key_with_no_generation_suffix_has_no_legacy_row_to_check(self, mgr) -> None:
+        """When bucket and generation key are the SAME string there is no
+        legacy row, so the read must answer False without a promoting write."""
+        with patch.object(mgr._session_map, "batched_save") as batched:
+            assert mgr.mirror_opt_out("dashboard:abc") is False
+        batched.assert_not_called()
+
+    def test_a_refusal_stored_on_the_bucket_is_honoured(self, mgr) -> None:
+        mgr.set_mirror_opt_out("dashboard:abc", True)
+        assert mgr.mirror_opt_out("dashboard:abc") is True
+
+
+# ── Cancel / callback registration ───────────────────────────────────────────
+
+
+class TestCancelAndCallbacks:
+    @pytest.mark.asyncio
+    async def test_cancel_current_on_an_unknown_key_reports_no_turn(self, mgr) -> None:
+        assert await mgr.cancel_current("dashboard:ghost") == "no_turn"
+
+    def test_replacing_a_recycle_callback_warns(self, mgr, caplog) -> None:
+        async def cb(key, *, reason):  # pragma: no cover — never invoked
+            return None
+
+        mgr.set_recycle_callback(cb)
+        with caplog.at_level("WARNING", logger="kiro_crew.session"):
+            mgr.set_recycle_callback(cb)
+        assert "Recycle callback already registered" in caplog.text
+        assert mgr._on_recycled is cb
+
+    @pytest.mark.asyncio
+    async def test_a_raising_recycle_callback_never_escapes(self, mgr) -> None:
+        mgr.set_recycle_callback(AsyncMock(side_effect=RuntimeError("boom")))
+        await mgr._fire_recycle_callback("dashboard:a", reason="rss")
+
+
+# ── context_info / _resolve_agent_model ──────────────────────────────────────
+
+
+class TestContextInfoModelResolution:
+    @pytest.mark.asyncio
+    async def test_an_auto_model_on_a_named_agent_is_resolved_from_agent_json(
+        self, mgr
+    ) -> None:
+        """``client._model == "auto"`` is not a model the dashboard can show, so
+        a named (non-``kirocrew``) agent falls through to its JSON pin."""
+        from kiro_crew.providers.acp import AcpProvider
+
+        provider = MagicMock(spec=AcpProvider)
+        provider.context_usage_pct = MagicMock(return_value=12.0)
+        provider.context_window_tokens = MagicMock(return_value=200_000)
+        provider.shutdown = AsyncMock()
+        provider.client = MagicMock()
+        provider.client._model = "auto"
+        provider.client._agent = "researcher"
+        _register(mgr, "dashboard:slot1", provider=provider)
+
+        with patch.object(
+            SessionManager, "_resolve_agent_model", staticmethod(lambda a: "sonnet-9")
+        ):
+            info = mgr.context_info()
+
+        assert info[0]["model"] == "sonnet-9"
+        assert info[0]["agent"] == "researcher"
+
+
+class TestResolveAgentModel:
+    @pytest.fixture(autouse=True)
+    def _clear_class_cache(self):
+        SessionManager._agent_model_cache = {}
+        yield
+        SessionManager._agent_model_cache = {}
+
+    def test_a_missing_agents_dir_resolves_to_auto(self, tmp_path) -> None:
+        """``stat()`` on an absent dir raises OSError; mtime 0.0 must be used as
+        the cache stamp rather than the lookup blowing up."""
+        missing = tmp_path / "nope"
+        with patch("kiro_crew.agent.kiro_agents_dir_path", return_value=missing):
+            assert SessionManager._resolve_agent_model("researcher") == "auto"
+        assert SessionManager._agent_model_cache["researcher"][1] == 0.0
+
+    def test_an_unparsable_agent_file_is_skipped_not_fatal(self, tmp_path) -> None:
+        """A hand-edited agent JSON with a syntax error must not take the whole
+        resolver down — every other agent's model would stop resolving."""
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "researcher.json").write_text("{not json", encoding="utf-8")
+        with patch("kiro_crew.agent.kiro_agents_dir_path", return_value=agents):
+            assert SessionManager._resolve_agent_model("researcher") == "auto"
+
+    def test_a_readable_agent_file_supplies_its_pinned_model(self, tmp_path) -> None:
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "researcher.json").write_text(
+            '{"name": "researcher", "model": "sonnet-9"}', encoding="utf-8"
+        )
+        with patch("kiro_crew.agent.kiro_agents_dir_path", return_value=agents):
+            assert SessionManager._resolve_agent_model("researcher") == "sonnet-9"
+
+    def test_a_raising_spec_reader_falls_back_to_auto(self, tmp_path) -> None:
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "researcher.json").write_text('{"name": "researcher"}', encoding="utf-8")
+        with patch("kiro_crew.agent.kiro_agents_dir_path", return_value=agents), patch(
+            "kiro_crew.session.spec_model", side_effect=RuntimeError("bad spec")
+        ):
+            assert SessionManager._resolve_agent_model("researcher") == "auto"
+
+
+# ── Runtime PID probes ───────────────────────────────────────────────────────
+
+
+class TestRuntimePidProbes:
+    def test_a_runtime_reporting_a_nonpositive_pid_is_omitted(self, mgr) -> None:
+        mgr._bg_runtime = SimpleNamespace(
+            is_alive=lambda: True, pid=0, _spawn_monotonic=1.0
+        )
+        assert [r for r in mgr.runtime_pids() if r["key"] == "Background runtime"] == []
+
+    def test_a_raising_liveness_probe_drops_only_that_row(self, mgr) -> None:
+        def boom():
+            raise RuntimeError("probe exploded")
+
+        mgr._bg_runtime = SimpleNamespace(is_alive=boom, pid=42)
+        mgr._subagent_runtimes["dashboard:a"] = SimpleNamespace(
+            is_alive=lambda: True, pid=99, _spawn_monotonic=None
+        )
+        rows = mgr.runtime_pids()
+        labels = {r["key"] for r in rows}
+        assert "Background runtime" not in labels
+        assert "Subagent runtime (dashboard:a)" in labels
+
+    def test_a_raising_bg_probe_does_not_break_the_sweep_shield(self, mgr) -> None:
+        def boom():
+            raise RuntimeError("probe exploded")
+
+        mgr._bg_runtime = SimpleNamespace(is_alive=boom, pid=42)
+        mgr._subagent_runtimes["dashboard:a"] = SimpleNamespace(
+            is_alive=lambda: True, pid=99
+        )
+        assert mgr._companion_runtime_pids() == {99}
+
+
+# ── Warm-pool queue races ────────────────────────────────────────────────────
+
+
+class TestWarmPoolQueueRaces:
+    def test_claim_loses_the_entry_between_check_and_take(self, mgr) -> None:
+        mgr._warm_pool = _RacedQueue()
+        mgr._pool_agent = "kirocrew"
+        assert mgr._claim_from_pool("kirocrew") is None
+
+    def test_pool_pid_peek_survives_a_lost_entry(self, mgr) -> None:
+        mgr._warm_pool = _RacedQueue()
+        mgr._pool_sweep_pids.add(77)
+        assert mgr._pool_pids() == {77}
+
+    @pytest.mark.asyncio
+    async def test_drain_warm_pool_survives_a_lost_entry(self, mgr) -> None:
+        mgr._warm_pool = _RacedQueue()
+        assert await mgr.drain_warm_pool() == []
+
+    @pytest.mark.asyncio
+    async def test_refresh_defaults_survives_a_lost_entry(self, mgr) -> None:
+        mgr._warm_pool = _RacedQueue()
+        mgr._discard_pool_provider = AsyncMock()
+        with patch.object(mgr, "start_pool", AsyncMock()), patch(
+            "kiro_crew.session.build_provider_factory", return_value=MagicMock()
+        ):
+            await mgr.refresh_defaults()
+        mgr._discard_pool_provider.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reload_provider_factory_survives_a_lost_entry(self, mgr) -> None:
+        mgr._warm_pool = _RacedQueue()
+        mgr._discard_pool_provider = AsyncMock()
+        stale = _register(mgr, "dashboard:a")
+        with patch.object(mgr, "start_pool", AsyncMock()), patch(
+            "kiro_crew.session.build_provider_factory", return_value=MagicMock()
+        ):
+            await mgr.reload_provider_factory()
+        assert mgr._sessions == {}
+        stale.provider.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_health_sweep_survives_a_lost_entry(self, mgr) -> None:
+        mgr._pool_size = 1
+        mgr._warm_pool = _RacedQueue()
+        mgr._fill_warm_pool = AsyncMock()
+        mgr._discard_pool_provider = AsyncMock()
+        await mgr._sweep_warm_pool_once()
+        mgr._discard_pool_provider.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_health_sweep_no_ops_when_the_pool_is_disabled(self, mgr) -> None:
+        """With ``pool_size == 0`` the sweep must not even look at the queue —
+        reading it would make a disabled pool pay for a sweep it cannot use."""
+
+        class _Tripwire(_RacedQueue):
+            def qsize(self) -> int:
+                raise AssertionError("the sweep read the queue on a disabled pool")
+
+        mgr._pool_size = 0
+        mgr._warm_pool = _Tripwire()
+        await mgr._sweep_warm_pool_once()
+
+    @pytest.mark.asyncio
+    async def test_a_raising_liveness_probe_counts_as_dead(self, mgr) -> None:
+        """The probe is the ONLY liveness signal; a provider that cannot answer
+        must be discarded, not re-enqueued as healthy."""
+
+        def boom():
+            raise RuntimeError("rpc wedged")
+
+        dead = _provider(is_process_alive=boom, exit_code=None)
+        mgr._pool_size = 1
+        mgr._pool_ttl_secs = 0
+        await mgr._warm_pool.put((dead, 0.0))
+        mgr._fill_warm_pool = AsyncMock()
+        mgr._discard_pool_provider = AsyncMock()
+        await mgr._sweep_warm_pool_once()
+        mgr._discard_pool_provider.assert_awaited_once()
+        assert mgr._discard_pool_provider.await_args.args[0] is dead
+
+
+class TestPoolHealthLoop:
+    @pytest.mark.asyncio
+    async def test_a_failing_sweep_is_logged_and_the_loop_keeps_going(self, mgr) -> None:
+        """A sweep failure must not end the loop — the pool would then never be
+        swept again for the gateway's whole lifetime."""
+        mgr._POOL_HEALTH_INTERVAL = 0
+        sweep = AsyncMock(side_effect=[RuntimeError("sweep blew up"), asyncio.CancelledError])
+        mgr._sweep_warm_pool_once = sweep
+        with pytest.raises(asyncio.CancelledError):
+            await mgr._pool_health_loop()
+        assert sweep.await_count == 2
+
+
+class TestPoolDecisionMetric:
+    def test_a_failing_recorder_never_reaches_the_caller(self, mgr) -> None:
+        with patch("kiro_crew.session.get_recorder", side_effect=RuntimeError("no otel")):
+            mgr._record_pool_decision("hit", "dashboard:a")
+
+
+# ── Pool provider discard ────────────────────────────────────────────────────
+
+
+class TestDiscardPoolProvider:
+    @pytest.mark.asyncio
+    async def test_a_base_exception_during_shutdown_still_dispatches_the_kill(
+        self, mgr
+    ) -> None:
+        """A non-``Exception`` BaseException (a cancellation-class escape) must
+        not skip the hard kill — the provider would leak its whole process tree."""
+
+        async def shutdown():
+            raise _Bang()
+
+        provider = _provider(shutdown=shutdown)
+        with patch("kiro_crew.session._sync_kill_provider") as killer:
+            with pytest.raises(_Bang):
+                await mgr._discard_pool_provider(provider, "unit")
+        # Dispatched to the executor; wait for the worker to pick it up.
+        for _ in range(200):
+            if killer.call_count:
+                break
+            await asyncio.sleep(0.001)
+        assert killer.call_args.args[0] is provider
+
+    @pytest.mark.asyncio
+    async def test_an_unanswerable_liveness_probe_reads_as_dead(self, mgr) -> None:
+        """With no tracked PID the provider's own view is the fallback; a raising
+        probe must resolve to "gone" rather than trigger a kill on nothing."""
+
+        def boom():
+            raise RuntimeError("wedged")
+
+        provider = _provider(is_process_alive=boom)
+        with patch("kiro_crew.session._sync_kill_provider") as killer:
+            await mgr._discard_pool_provider(provider, "unit")
+        assert killer.call_count == 0
+
+
+# ── Stale-session eviction ───────────────────────────────────────────────────
+
+
+class TestEvictStaleSession:
+    @pytest.mark.asyncio
+    async def test_a_failing_shutdown_still_leaves_the_entry_evicted(self, mgr) -> None:
+        sess = _register(mgr, "task:step1", provider=_provider(shutdown=AsyncMock(side_effect=OSError)))
+        await mgr._evict_stale_session("task:step1", sess)
+        assert "task:step1" not in mgr._sessions
+
+    @pytest.mark.asyncio
+    async def test_an_entry_owned_by_someone_else_is_left_alone(self, mgr) -> None:
+        ours = _Session(provider=_provider())
+        theirs = _register(mgr, "task:step1")
+        await mgr._evict_stale_session("task:step1", ours)
+        assert mgr._sessions["task:step1"] is theirs
+        ours.provider.shutdown.assert_not_awaited()
+
+
+# ── Background provider dispatch ─────────────────────────────────────────────
+
+
+class TestBackgroundProviderDispatch:
+    def test_an_unreadable_provider_setting_defaults_to_the_kiro_backend(self, mgr) -> None:
+        """``_bg`` must keep working when the config object cannot answer — the
+        alternative is losing chat titles and consolidation to a config edge."""
+
+        class _Boom:
+            @property
+            def provider(self):
+                raise RuntimeError("config exploded")
+
+        mgr._cfg = SimpleNamespace(agent=_Boom())
+        assert mgr._bg_provider_is_kiro() is True
+
+    @pytest.mark.asyncio
+    async def test_ensure_background_no_ops_without_a_factory(self, mgr) -> None:
+        await mgr._ensure_background()
+        assert BACKGROUND_KEY not in mgr._sessions
+
+    @pytest.mark.asyncio
+    async def test_losing_the_background_race_shuts_the_duplicate_down(self, cfg) -> None:
+        """Two concurrent ``_ensure_background`` calls must leave ONE registered
+        provider and no orphan: the loser tears its own provider down."""
+        winner = _provider()
+        loser = _provider()
+
+        async def _start():
+            # A racing coroutine registered the key while we were starting.
+            mgr._sessions[BACKGROUND_KEY] = _Session(provider=winner, is_new=False)
+
+        loser.start = _start
+        mgr = SessionManager(cfg, provider_factory=lambda *a, **k: loser)
+        await mgr._ensure_background()
+        assert mgr._sessions[BACKGROUND_KEY].provider is winner
+        loser.shutdown.assert_awaited_once()
+
+
+class TestGetBgSessionRespawn:
+    """``get_bg_session`` retries a dead ``_bg`` runtime exactly once."""
+
+    @pytest.fixture
+    def fake_runtime_cls(self):
+        import kiro_crew.acp.runtime as runtime_mod
+
+        created: list[object] = []
+
+        class _FakeRuntime:
+            def __init__(self, **kwargs) -> None:
+                self.kwargs = kwargs
+                self.pid = 4242
+                created.append(self)
+
+            async def spawn(self) -> None:
+                return None
+
+            def is_alive(self) -> bool:
+                return True
+
+            def has_active_sessions(self) -> bool:
+                return True
+
+            async def create_session(self, **kwargs):
+                return SimpleNamespace(session_id="sid-fresh")
+
+            async def kill(self) -> None:  # pragma: no cover — replacement only
+                return None
+
+        with patch.object(runtime_mod, "AcpRuntime", _FakeRuntime):
+            yield created
+
+    @pytest.mark.asyncio
+    async def test_a_dead_runtime_is_reaped_before_being_replaced(
+        self, mgr, fake_runtime_cls
+    ) -> None:
+        """Overwriting without ``kill()`` would leak the process AND its
+        sweep-protected PID, so the reap must happen even when it fails."""
+        doomed = SimpleNamespace(
+            is_alive=lambda: False,
+            pid=11,
+            kill=AsyncMock(side_effect=RuntimeError("kill failed")),
+        )
+        mgr._bg_runtime = doomed
+        handle = await mgr.get_bg_session()
+        assert handle.session_id == "sid-fresh"
+        doomed.kill.assert_awaited_once()
+        assert len(fake_runtime_cls) == 1
+        assert mgr._bg_runtime is fake_runtime_cls[0]
+
+    @pytest.mark.asyncio
+    async def test_a_still_live_runtime_that_keeps_failing_gives_up_after_one_retry(
+        self, mgr, fake_runtime_cls
+    ) -> None:
+        from kiro_crew.acp.runtime import AcpRuntimeDead
+
+        create = AsyncMock(side_effect=AcpRuntimeDead("gone"))
+        mgr._bg_runtime = SimpleNamespace(
+            is_alive=lambda: True,
+            has_active_sessions=lambda: True,
+            _stale_by_age=lambda: False,
+            pid=11,
+            create_session=create,
+            kill=AsyncMock(),
+        )
+        with pytest.raises(AcpRuntimeDead):
+            await mgr.get_bg_session()
+        # One initial attempt plus exactly one retry — not an unbounded loop.
+        assert create.await_count == 2
+        assert fake_runtime_cls == []
+
+    @pytest.mark.asyncio
+    async def test_a_runtime_that_dies_mid_create_is_reaped_and_respawned(
+        self, mgr, fake_runtime_cls
+    ) -> None:
+        from kiro_crew.acp.runtime import AcpRuntimeDead
+
+        alive = [True]
+
+        async def create_session(**kwargs):
+            alive[0] = False
+            raise AcpRuntimeDead("died mid-create")
+
+        doomed = SimpleNamespace(
+            is_alive=lambda: alive[0],
+            has_active_sessions=lambda: True,
+            _stale_by_age=lambda: False,
+            pid=11,
+            create_session=create_session,
+            kill=AsyncMock(side_effect=RuntimeError("kill failed")),
+        )
+        mgr._bg_runtime = doomed
+        handle = await mgr.get_bg_session()
+        assert handle.session_id == "sid-fresh"
+        doomed.kill.assert_awaited_once()
+        assert len(fake_runtime_cls) == 1
+
+
+# ── reset() teardown ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def no_child_scan():
+    """Neutralize the three ``acp.client`` helpers ``reset`` calls.
+
+    They read ``/proc`` (or spawn ``ps``/``pgrep`` on macOS) and are the reason
+    a naive reset test cannot run on a CI runner.
+    """
+    with patch("kiro_crew.acp.client._get_child_pids", return_value=[]), patch(
+        "kiro_crew.acp.client._capture_child_records", return_value={}
+    ), patch("kiro_crew.acp.client._kill_escaped_children") as sweep:
+        yield sweep
+
+
+class TestResetTeardown:
+    @pytest.mark.asyncio
+    async def test_an_ephemeral_claude_process_supplies_the_pid_to_verify(
+        self, mgr, no_child_scan, monkeypatch
+    ) -> None:
+        """With neither an ACP client nor a long-lived ``_proc``, the ephemeral
+        ``_active_proc`` is the only handle to the process — reset must find it,
+        or the post-shutdown liveness check silently probes nothing."""
+        probed: list[int] = []
+        monkeypatch.setattr(
+            platform_compat, "pid_exists", lambda pid: probed.append(pid) or False
+        )
+        provider = _provider(_active_proc=SimpleNamespace(returncode=None, pid=4242))
+        _register(mgr, "dashboard:a", provider=provider)
+
+        assert await mgr.reset("dashboard:a") is True
+        assert probed == [4242]
+
+    @pytest.mark.asyncio
+    async def test_a_survivor_whose_tree_and_pid_kills_both_fail_is_not_fatal(
+        self, mgr, no_child_scan, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(platform_compat, "pid_exists", lambda pid: True)
+        tree = AsyncMock(side_effect=OSError("no such pgid"))
+        single = AsyncMock(side_effect=ProcessLookupError)
+        monkeypatch.setattr(platform_compat, "kill_process_tree_async", tree)
+        monkeypatch.setattr(platform_compat, "kill_pid_async", single)
+        provider = _provider(_proc=SimpleNamespace(returncode=None, pid=4242))
+        _register(mgr, "dashboard:a", provider=provider)
+
+        assert await mgr.reset("dashboard:a") is True
+        tree.assert_awaited_once()
+        single.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_child_sweep_is_logged_not_raised(
+        self, mgr, no_child_scan, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(platform_compat, "pid_exists", lambda pid: False)
+        no_child_scan.side_effect = RuntimeError("sweep exploded")
+        provider = _provider(
+            _client=SimpleNamespace(_pid=4242, _child_pids={99: object()}),
+        )
+        _register(mgr, "dashboard:a", provider=provider)
+
+        assert await mgr.reset("dashboard:a") is True
+        assert no_child_scan.called
+
+    @pytest.mark.asyncio
+    async def test_a_failing_subagent_runtime_release_still_completes_the_reset(
+        self, mgr, no_child_scan
+    ) -> None:
+        _register(mgr, "dashboard:a")
+        mgr._subagent_runtimes["dashboard:a"] = SimpleNamespace()
+        mgr.release_subagent_runtime = AsyncMock(side_effect=RuntimeError("runtime wedged"))
+
+        assert await mgr.reset("dashboard:a") is True
+        assert "dashboard:a" not in mgr._sessions
+        mgr.release_subagent_runtime.assert_awaited_once_with("dashboard:a")
+
+
+# ── Drain of unfinished turns ────────────────────────────────────────────────
+
+
+class TestDrainActiveTurns:
+    @pytest.mark.asyncio
+    async def test_every_uncooperative_shape_is_counted_and_none_escapes(self, mgr) -> None:
+        """Four ways a provider can refuse to reach a safe boundary. Each is
+        swallowed per-provider, and all four still count as drained so the
+        caller's log reflects what it waited on."""
+        no_cancel = _provider(has_unfinished_turn=lambda: True, cancel=None)
+        raising = _provider(
+            has_unfinished_turn=lambda: True,
+            cancel=AsyncMock(side_effect=RuntimeError("cancel exploded")),
+        )
+        waiter_timeout = _provider(
+            has_unfinished_turn=lambda: True,
+            cancel=AsyncMock(return_value="no_turn"),
+            wait_turn_done=AsyncMock(side_effect=asyncio.TimeoutError),
+        )
+        waiter_broken = _provider(
+            has_unfinished_turn=lambda: True,
+            cancel=AsyncMock(return_value="no_turn"),
+            wait_turn_done=AsyncMock(side_effect=RuntimeError("waiter exploded")),
+        )
+        for i, p in enumerate((no_cancel, raising, waiter_timeout, waiter_broken)):
+            _register(mgr, f"dashboard:{i}", provider=p)
+
+        assert await mgr.drain_active_turns(timeout=0.05) == 4
+        waiter_timeout.wait_turn_done.assert_awaited_once()
+        waiter_broken.wait_turn_done.assert_awaited_once()
+
+
+# ── close_all ────────────────────────────────────────────────────────────────
+
+
+class TestCloseAll:
+    @pytest.mark.asyncio
+    async def test_every_teardown_step_can_fail_and_shutdown_still_completes(
+        self, mgr
+    ) -> None:
+        """Shutdown is the last chance to release kiro-cli's native session
+        locks, so no single failing step may abort the rest of it."""
+        mgr.drain_active_turns = AsyncMock(side_effect=RuntimeError("drain exploded"))
+        bg = SimpleNamespace(kill=AsyncMock(side_effect=RuntimeError("bg kill failed")))
+        mgr._bg_runtime = bg
+        mgr._subagent_runtimes["dashboard:a"] = SimpleNamespace()
+        mgr.release_subagent_runtime = AsyncMock(side_effect=RuntimeError("release failed"))
+        sess = _register(
+            mgr, "dashboard:a", provider=_provider(shutdown=AsyncMock(side_effect=OSError))
+        )
+
+        await mgr.close_all()
+
+        bg.kill.assert_awaited_once()
+        assert mgr._bg_runtime is None
+        assert mgr._sessions == {}
+        sess.provider.shutdown.assert_awaited_once()
+        assert mgr._closing is True
+
+    @pytest.mark.asyncio
+    async def test_the_pool_drain_survives_a_lost_entry(self, mgr) -> None:
+        mgr.drain_active_turns = AsyncMock(return_value=0)
+        mgr._warm_pool = _RacedQueue()
+        await mgr.close_all()
+        assert mgr._sessions == {}
+
+
+# ── release(cleanup=True) ────────────────────────────────────────────────────
+
+
+class TestReleaseCleanup:
+    def test_an_unreadable_session_id_does_not_block_the_release(self, mgr) -> None:
+        """The semaphore release is the important half: skipping it on a failed
+        cleanup probe would wedge the key for the rest of the process."""
+
+        class _Provider(SimpleNamespace):
+            @property
+            def session_id(self):
+                raise RuntimeError("no session id")
+
+        sess = _register(mgr, "subagent:run1", provider=_Provider())
+        sess.semaphore._value = 0
+        mgr.release("subagent:run1", cleanup=True)
+        assert sess.semaphore._value == 1
+
+
+# ── stop_turn hooks ──────────────────────────────────────────────────────────
+
+
+class TestStopTurnHooks:
+    @pytest.mark.asyncio
+    async def test_a_failing_soft_hook_still_reports_a_soft_stop(self, mgr) -> None:
+        provider = _provider(cancel=AsyncMock(return_value="acked"))
+        sess = _register(mgr, "dashboard:a", provider=provider)
+        outcome = await mgr.stop_turn(
+            "dashboard:a", on_soft=AsyncMock(side_effect=RuntimeError("hook exploded"))
+        )
+        assert outcome == "soft"
+        assert sess.prev_turn_cancelled is True
+
+    @pytest.mark.asyncio
+    async def test_a_failing_hard_hook_still_reports_a_hard_stop(
+        self, mgr, no_child_scan
+    ) -> None:
+        provider = _provider(
+            cancel=AsyncMock(return_value="acked"),
+            runtime_info=lambda: (None, None),
+        )
+        _register(mgr, "dashboard:a", provider=provider)
+        outcome = await mgr.stop_turn(
+            "dashboard:a",
+            force=True,
+            on_hard=AsyncMock(side_effect=RuntimeError("hook exploded")),
+        )
+        assert outcome == "hard"
+        assert "dashboard:a" not in mgr._sessions
+        # The eager respawn task has no factory to use; drain it so the loop
+        # does not report a pending task at teardown.
+        await asyncio.gather(*mgr._background_tasks, return_exceptions=True)
+
+
+# ── recycle_background refusals ──────────────────────────────────────────────
+
+
+class TestRecycleBackgroundRefusals:
+    @pytest.mark.asyncio
+    async def test_a_dead_background_provider_is_not_recycled_under_us(self, mgr) -> None:
+        """``_reacquire_and_validate`` failing means we own nothing — tearing
+        anything down here would kill a session another path already owns."""
+        provider = _provider(is_process_alive=lambda: False)
+        sess = _register(mgr, BACKGROUND_KEY, provider=provider)
+        await mgr.recycle_background()
+        assert mgr._sessions[BACKGROUND_KEY] is sess
+        assert sess.semaphore._value == 1
+
+    @pytest.mark.asyncio
+    async def test_a_full_background_session_with_no_factory_keeps_its_provider(
+        self, mgr
+    ) -> None:
+        provider = _provider(context_usage_pct=lambda: 88.0)
+        sess = _register(mgr, BACKGROUND_KEY, provider=provider)
+        await mgr.recycle_background()
+        assert sess.provider is provider
+        provider.shutdown.assert_not_awaited()
+        assert sess.semaphore._value == 1
+
+    @pytest.mark.asyncio
+    async def test_a_failing_shutdown_of_the_replaced_provider_is_swallowed(
+        self, cfg
+    ) -> None:
+        old = _provider(
+            context_usage_pct=lambda: 88.0,
+            shutdown=AsyncMock(side_effect=OSError("shutdown exploded")),
+        )
+        new = _provider(start=AsyncMock())
+        mgr = SessionManager(cfg, provider_factory=lambda *a, **k: new)
+        sess = _register(mgr, BACKGROUND_KEY, provider=old)
+
+        await mgr.recycle_background()
+
+        assert sess.provider is new
+        old.shutdown.assert_awaited_once()
+        assert sess.semaphore._value == 1
+
+
+# ── open_task_session ────────────────────────────────────────────────────────
+
+
+class TestOpenTaskSession:
+    @pytest.mark.asyncio
+    async def test_reusing_a_live_session_adopts_the_callers_approval_policy(
+        self, mgr
+    ) -> None:
+        """A later step of the same run may escalate to auto-approval; the
+        reused session must adopt it rather than keep the first step's policy."""
+        sess = _register(mgr, "taskrunner:run1:step2", approval_policy="")
+        provider, is_new, resumed = await mgr.open_task_session(
+            "taskrunner:run1", "taskrunner:run1:step2", approval_policy="auto"
+        )
+        assert (provider, is_new, resumed) == (sess.provider, False, False)
+        assert sess.approval_policy == "auto"
+        mgr.release("taskrunner:run1:step2")
+
+    @pytest.mark.asyncio
+    async def test_losing_the_cold_start_race_tears_down_the_duplicate(self, mgr) -> None:
+        """Two steps cold-starting the same key must leave ONE registered
+        session; the loser terminates its own extra session on the shared
+        runtime even when that teardown fails."""
+        key = "taskrunner:run1:step2"
+        winner_provider = _provider()
+
+        async def create_session(**kwargs):
+            # A racing step registered the key while our RPC was in flight.
+            mgr._sessions[key] = _Session(provider=winner_provider, is_new=False)
+            return SimpleNamespace(session_id="sid-dup")
+
+        runtime = SimpleNamespace(create_session=create_session)
+        mgr._get_or_bootstrap_run_runtime = AsyncMock(return_value=runtime)
+
+        dup = _provider(shutdown=AsyncMock(side_effect=RuntimeError("terminate failed")))
+        with patch(
+            "kiro_crew.acp.session_provider.AcpSessionProvider",
+            side_effect=lambda handle, rt: dup,
+        ):
+            provider, is_new, resumed = await mgr.open_task_session("taskrunner:run1", key)
+
+        assert (provider, is_new, resumed) == (winner_provider, False, False)
+        dup.shutdown.assert_awaited_once()
+        assert mgr._sessions[key].provider is winner_provider
+        mgr.release(key)
+
+
+# ── Signal escalation ────────────────────────────────────────────────────────
+
+
+class TestResetSignalEscalation:
+    """No ``skipif`` here on purpose: ``platform_compat.SIGKILL`` is defined on
+    every platform (it falls back to the raw ``9`` where ``signal.SIGKILL`` is
+    absent), and the kill entry points are doubles, so the assertion is about
+    the product's escalation decision rather than about OS signal delivery."""
+
+    @pytest.mark.asyncio
+    async def test_a_surviving_process_is_force_killed_with_sigkill(
+        self, mgr, no_child_scan, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(platform_compat, "pid_exists", lambda pid: True)
+        tree = AsyncMock()
+        monkeypatch.setattr(platform_compat, "kill_process_tree_async", tree)
+        provider = _provider(_client=SimpleNamespace(_pid=4242, _child_pids=None))
+        _register(mgr, "dashboard:a", provider=provider)
+
+        assert await mgr.reset("dashboard:a") is True
+        tree.assert_awaited_once_with(4242, platform_compat.SIGKILL)

--- a/test/test_slack_gateway_more_coverage.py
+++ b/test/test_slack_gateway_more_coverage.py
@@ -1,0 +1,809 @@
+"""Further coverage for ``kiro_crew.slack.gateway``.
+
+``test_slack_gateway.py``, ``test_slack_gateway_coverage.py`` and
+``test_slack_gateway_cron_exec_coverage.py`` already drive the cron executor,
+the autonudge fire paths and the happy arms of ``_deliver_result``. The
+surfaces exercised here had no test anywhere in the suite before this file:
+
+* ``_warn_if_kiro_cli_outdated`` — every arm: unspawnable binary, probe
+  timeout (kill + bounded reap), cancellation, transport error, the
+  outdated-version warning and the unparseable-output silence.
+* ``_deliver_result`` — the ``slack`` / ``slack:<chan>`` / no-``dashboard_state``
+  arms, the post-failure ``except``, and the ``default_deliver`` lookup failure.
+* ``_connect_slack``'s reason extraction when the Slack error object's
+  ``response`` cannot be read.
+* ``_shutdown``'s slot-save failure arm and the three background-task
+  cancellations (model download, auto-migration, boot update check).
+* ``_init_dashboard`` / ``_init_api_server`` ``--port`` override + the
+  ephemeral (``--port auto``) bound-port read-back.
+* ``_start_embeddings``' custom-model arm, ``_auto_migrate_memory``'s
+  reconcile-first / audit-failure / download-error arms and
+  ``_set_memory_migrated``.
+* ``_init_crew``'s failure arm, ``_init_mcp_discovery``'s populated arm,
+  ``_subagent_coalescer``'s broadcast closures, ``_notify_nudge_expired``'s
+  runtime-budget wording, ``_persist_slot_title``'s no-log guard,
+  ``_remember_options``' best-effort ``except``, ``_deliver_cron_response``'s
+  unresolvable-channel and OPTIONS-post-failure arms, and
+  ``_is_heartbeat_safe_tool``'s malformed-``mcp__``-prefix normalisation.
+
+Everything is driven through mocked collaborators: ``asyncio``'s process
+spawner, the process-tree killer, the embedding backend, the dashboard/API
+server starters and the Slack client are all patched, so no subprocess, no
+signal, no socket and no write outside the per-test ``KIROCREW_HOME`` (pinned
+by ``test/conftest.py``) happens. Style and patch seams mirror
+``test_slack_gateway.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.autonudge import NudgeLoop
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.slack import gateway as gw
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _make_orchestrator(**kwargs: Any) -> Any:
+    """Build a GatewayOrchestrator with mocked credentials (no Slack tokens).
+
+    Returned as ``Any`` on purpose: every test below swaps real collaborators
+    for mocks, which do not satisfy the declared attribute types.
+    """
+    cfg = KiroCrewConfig()
+    creds = {"KIROCREW_OWNER_ID": "U_OWNER"}
+    with patch.object(cfg, "load_credentials", return_value=creds):
+        return gw.GatewayOrchestrator(
+            cfg,
+            no_dashboard=kwargs.pop("no_dashboard", True),
+            no_crons=kwargs.pop("no_crons", True),
+            no_open=True,
+        )
+
+
+def _mock_dashboard_state() -> MagicMock:
+    ds = MagicMock()
+    ds._slots = {}
+    ds.notify = MagicMock()
+    ds.push_slots_update = MagicMock()
+    ds.push_refresh = MagicMock()
+    ds.push_slot_title = MagicMock()
+    ds.broadcast_ws = MagicMock()
+    ds.broadcast_ws_subagent_subscribers = MagicMock()
+    ds.get_slot = MagicMock(return_value=None)
+    ds.channel_transports = {}
+    return ds
+
+
+def _mock_slack(*, dm: str | None = "D1") -> MagicMock:
+    slack = MagicMock()
+    slack.open_dm = AsyncMock(return_value=dm)
+    slack.post_message = AsyncMock(return_value="111.1")
+    slack.post_blocks = AsyncMock(return_value="222.2")
+    return slack
+
+
+def _slack_default_deliver() -> Any:
+    """Pin ``heartbeat.default_deliver`` to "slack" for tagless deliveries."""
+    return patch.object(
+        gw.KiroCrewConfig,
+        "load",
+        return_value=SimpleNamespace(heartbeat=SimpleNamespace(default_deliver="slack")),
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: _is_heartbeat_safe_tool normalisation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestHeartbeatSafeToolNormalisation:
+    """A malformed ``mcp__`` title yields no server-qualified identity."""
+
+    def test_mcp_prefix_without_tool_segment_is_refused(self):
+        # "mcp__foo".split("__", 2) is only 2 parts, so neither the qualified
+        # form nor the bare-name strip applies: the title stays "mcp__foo",
+        # misses HEARTBEAT_SAFE_TOOLS, and (qualified == "") can never match an
+        # edition entry -> deny-by-default.
+        assert gw._is_heartbeat_safe_tool("mcp__foo") is False
+
+    def test_at_prefix_without_slash_is_refused(self):
+        assert gw._is_heartbeat_safe_tool("@server-only") is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: _warn_if_kiro_cli_outdated
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _probe_proc(communicate: Any, *, returncode: int = 0) -> MagicMock:
+    proc = MagicMock()
+    proc.pid = 424242
+    proc.returncode = returncode
+    proc.communicate = communicate
+    proc.kill = MagicMock()
+    return proc
+
+
+class TestWarnIfKiroCliOutdated:
+    """The boot-time kiro-cli version probe never raises and never hangs."""
+
+    @pytest.mark.asyncio
+    async def test_unspawnable_binary_is_silent(self, capsys):
+        orch = _make_orchestrator()
+        with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError("kiro-cli")):
+            await orch._warn_if_kiro_cli_outdated()
+        assert "outdated" not in capsys.readouterr().out
+
+    @pytest.mark.asyncio
+    async def test_probe_timeout_kills_and_reaps(self, caplog):
+        calls: list[int] = []
+
+        async def _communicate() -> tuple[bytes, bytes]:
+            calls.append(1)
+            if len(calls) == 1:
+                await asyncio.sleep(0.05)  # outlives the 1ms budget below
+            return (b"kiro-cli 9.9.9", b"")
+
+        proc = _probe_proc(_communicate)
+        orch = _make_orchestrator()
+        orch._KIRO_CLI_VERSION_TIMEOUT_SECS = 0.001
+        with caplog.at_level("WARNING"):
+            with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+                with patch.object(
+                    gw.platform_compat, "kill_process_tree_async", AsyncMock()
+                ) as killer:
+                    await orch._warn_if_kiro_cli_outdated()
+        killer.assert_awaited_once()
+        assert killer.await_args.args[0] == 424242
+        # The reap re-entered communicate() rather than leaving a zombie.
+        assert len(calls) == 2
+        assert "timed out" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_cancellation_kills_child_and_propagates(self):
+        async def _communicate() -> tuple[bytes, bytes]:
+            raise asyncio.CancelledError
+
+        proc = _probe_proc(_communicate)
+        orch = _make_orchestrator()
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            with patch.object(gw.platform_compat, "kill_process_tree_async", AsyncMock()) as killer:
+                with pytest.raises(asyncio.CancelledError):
+                    await orch._warn_if_kiro_cli_outdated()
+        killer.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_transport_error_falls_back_to_plain_kill(self):
+        async def _communicate() -> tuple[bytes, bytes]:
+            raise BrokenPipeError("pipe gone")
+
+        proc = _probe_proc(_communicate)
+        orch = _make_orchestrator()
+        # Tree kill refused (already-dead child) -> plain proc.kill() fallback.
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            with patch.object(
+                gw.platform_compat,
+                "kill_process_tree_async",
+                AsyncMock(side_effect=ProcessLookupError),
+            ):
+                await orch._warn_if_kiro_cli_outdated()  # must not raise
+        proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_outdated_version_warns(self, capsys):
+        async def _communicate() -> tuple[bytes, bytes]:
+            return (b"kiro-cli 1.25.0\n", b"")
+
+        proc = _probe_proc(_communicate)
+        orch = _make_orchestrator()
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await orch._warn_if_kiro_cli_outdated()
+        out = capsys.readouterr().out
+        assert "1.25 is outdated" in out
+
+    @pytest.mark.asyncio
+    async def test_current_version_is_quiet(self, capsys):
+        async def _communicate() -> tuple[bytes, bytes]:
+            return (b"kiro-cli 1.26.0\n", b"")
+
+        orch = _make_orchestrator()
+        with patch(
+            "asyncio.create_subprocess_exec", AsyncMock(return_value=_probe_proc(_communicate))
+        ):
+            await orch._warn_if_kiro_cli_outdated()
+        assert "outdated" not in capsys.readouterr().out
+
+    @pytest.mark.asyncio
+    async def test_unparseable_output_is_silent(self, capsys):
+        async def _communicate() -> tuple[bytes, bytes]:
+            return (b"some-other-binary\n", b"")
+
+        orch = _make_orchestrator()
+        with patch(
+            "asyncio.create_subprocess_exec", AsyncMock(return_value=_probe_proc(_communicate))
+        ):
+            await orch._warn_if_kiro_cli_outdated()
+        assert "outdated" not in capsys.readouterr().out
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: _deliver_result routing arms
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDeliverResultRouting:
+    """Background-result routing for the Slack and no-dashboard arms."""
+
+    @pytest.mark.asyncio
+    async def test_default_deliver_lookup_failure_falls_through(self):
+        orch = _make_orchestrator()
+        orch.slack = None
+        orch.dashboard_state = None
+        with patch.object(gw.KiroCrewConfig, "load", side_effect=RuntimeError("no config")):
+            await orch._deliver_result("Title", "task", "result", "")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_dashboard_slot_arm_without_dashboard_state(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = None
+        orch.slack = _mock_slack()
+        await orch._deliver_result("Title", "task", "result", "dashboard:s1")
+        # The dashboard arm returns early; nothing leaks to Slack.
+        orch.slack.post_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_new_slot_arm_without_dashboard_state(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = None
+        orch.slack = _mock_slack()
+        await orch._deliver_result("Title", "task", "result", "dashboard")
+        orch.slack.post_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_slack_only_arm_posts_dm_without_notifying(self):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.slack = _mock_slack(dm="D9")
+        await orch._deliver_result("Title", "task", "result", "slack")
+        orch.slack.open_dm.assert_awaited_once_with("U_OWNER")
+        assert orch.slack.post_message.await_count >= 1
+        assert orch.slack.post_message.await_args.args[0] == "D9"
+        # "slack" is Slack-ONLY: no bell notification.
+        ds.notify.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_slack_only_arm_survives_dm_failure(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = None
+        orch.slack = _mock_slack()
+        orch.slack.open_dm = AsyncMock(side_effect=RuntimeError("slack down"))
+        await orch._deliver_result("Title", "task", "result", "slack")  # must not raise
+        orch.slack.post_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_slack_thread_arm_without_ts_falls_back_to_dm(self):
+        # "slack:C1" is only two segments, so there is no thread to reply in:
+        # the fallback opens the owner's DM and still rings the bell.
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.slack = _mock_slack(dm="D7")
+        await orch._deliver_result("Title", "task", "result", "slack:C1")
+        orch.slack.open_dm.assert_awaited_once_with("U_OWNER")
+        assert orch.slack.post_message.await_args.args[0] == "D7"
+        ds.notify.assert_called_once()
+        assert ds.notify.call_args.args[0] == "heartbeat"
+
+    @pytest.mark.asyncio
+    async def test_default_arm_notifies_even_when_dm_unavailable(self):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.slack = _mock_slack(dm=None)
+        with _slack_default_deliver():
+            await orch._deliver_result("Title", "task", "result", "")
+        orch.slack.post_message.assert_not_awaited()
+        ds.notify.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_default_arm_notifies_after_post_failure(self):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.slack = _mock_slack()
+        orch.slack.post_message = AsyncMock(side_effect=RuntimeError("rate limited"))
+        with _slack_default_deliver():
+            await orch._deliver_result("Title", "task", "result", "")
+        # The Slack failure is swallowed; the bell still fires.
+        ds.notify.assert_called_once()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: _connect_slack
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestConnectSlack:
+    """Connect failures stay non-fatal and record a short reason."""
+
+    @pytest.mark.asyncio
+    async def test_unreadable_error_response_falls_back_to_class_name(self):
+        class _Boom(Exception):
+            pass
+
+        exc = _Boom("connect refused")
+        resp = MagicMock()
+        resp.get = MagicMock(side_effect=TypeError("not a mapping"))
+        exc.response = resp  # type: ignore[attr-defined]
+
+        orch = _make_orchestrator()
+        orch._socket_client = MagicMock()
+        orch._socket_client.connect = AsyncMock(side_effect=exc)
+        with patch.object(gw, "_channel_transport_permitted", return_value=True):
+            assert await orch._connect_slack() is False
+        assert orch._slack_connect_error == "_Boom"
+
+    @pytest.mark.asyncio
+    async def test_governance_denial_drops_socket_client(self):
+        orch = _make_orchestrator()
+        orch._socket_client = MagicMock()
+        orch._socket_client.connect = AsyncMock()
+        with patch.object(gw, "_channel_transport_permitted", return_value=False):
+            assert await orch._connect_slack() is False
+        assert orch._socket_client is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: _shutdown
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestShutdownExtras:
+    """Teardown arms not reached by ``test_slack_gateway.py``."""
+
+    @pytest.mark.asyncio
+    async def test_slot_save_failure_does_not_abort_shutdown(self):
+        orch = _make_orchestrator()
+        orch.cron_svc = None
+        orch.heartbeat_svc = None
+        orch.subagent_mgr = None
+        orch.sessions = None
+        orch._dashboard_runner = None
+        ds = _mock_dashboard_state()
+        ds._loop_watchdog = None
+        ds._loop_heartbeat = None
+        orch.dashboard_state = ds
+        orch._stop_mcp_broker = AsyncMock()
+        with patch(
+            "kiro_crew.dashboard.chat.save_all_slots_to_history",
+            side_effect=RuntimeError("history lock"),
+        ):
+            await orch._shutdown()  # must not raise
+        # Teardown continued past the failed save.
+        ds.file_indexes.stop_all.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cancels_background_tasks_and_closes_socket(self):
+        orch = _make_orchestrator()
+        orch.cron_svc = None
+        orch.heartbeat_svc = None
+        orch.subagent_mgr = None
+        orch.sessions = None
+        orch.dashboard_state = None
+        orch._dashboard_runner = None
+        orch._stop_mcp_broker = AsyncMock()
+        orch._socket_client = MagicMock()
+        orch._socket_client.close = AsyncMock()
+
+        async def _forever() -> None:
+            await asyncio.sleep(30)
+
+        model = asyncio.create_task(_forever())
+        migrate = asyncio.create_task(_forever())
+        update = asyncio.create_task(_forever())
+        orch._model_download_task = model
+        orch._auto_migrate_task = migrate
+        orch._update_check_task = update
+        with patch.object(gw.registry, "shutdown_tasks", return_value=[]):
+            await orch._shutdown()
+        orch._socket_client.close.assert_awaited_once()
+        assert model.cancelled() and migrate.cancelled() and update.cancelled()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: _init_dashboard / _init_api_server port handling
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _prepared_orchestrator() -> Any:
+    orch = _make_orchestrator()
+    orch._cfg.dashboard.url = "http://127.0.0.1:5476"
+    orch.sessions = MagicMock()
+    orch.cron_svc = MagicMock()
+    orch.subagent_mgr = None
+    orch.task_runner = None
+    orch.slack = None
+    return orch
+
+
+class TestDashboardPortSelection:
+    """``--port`` override + ephemeral bound-port read-back."""
+
+    @pytest.mark.asyncio
+    async def test_ephemeral_port_is_read_back_from_runner(self):
+        orch = _prepared_orchestrator()
+        orch._port_override = "auto"
+        runner = MagicMock()
+        runner.addresses = [("127.0.0.1", 54321)]
+        ds = _mock_dashboard_state()
+        with patch.object(gw, "LessonStore", MagicMock()):
+            with patch.object(gw, "start_dashboard", AsyncMock(return_value=(runner, ds))) as start:
+                await orch._init_dashboard()
+        assert start.await_args.kwargs["port"] == 0
+        assert orch._dashboard_port == 54321
+        assert ds.no_crons is True
+
+    @pytest.mark.asyncio
+    async def test_literal_port_override_is_used_verbatim(self):
+        orch = _prepared_orchestrator()
+        orch._port_override = "8123"
+        runner = MagicMock()
+        runner.addresses = [("127.0.0.1", 999)]
+        with patch.object(gw, "LessonStore", MagicMock()):
+            with patch.object(
+                gw, "start_dashboard", AsyncMock(return_value=(runner, _mock_dashboard_state()))
+            ) as start:
+                await orch._init_dashboard()
+        assert start.await_args.kwargs["port"] == 8123
+        # A non-zero request means the runner's bound address is never consulted.
+        assert orch._dashboard_port == 8123
+
+    @pytest.mark.asyncio
+    async def test_api_server_ephemeral_port_is_read_back(self):
+        orch = _prepared_orchestrator()
+        orch._port_override = "auto"
+        runner = MagicMock()
+        runner.addresses = [("127.0.0.1", 45454)]
+        ds = _mock_dashboard_state()
+        with patch.object(gw, "LessonStore", MagicMock()):
+            with patch(
+                "kiro_crew.dashboard.start_api_server", AsyncMock(return_value=(runner, ds))
+            ) as start:
+                await orch._init_api_server()
+        assert start.await_args.kwargs["port"] == 0
+        assert orch._dashboard_port == 45454
+        assert ds.no_crons is True
+
+    @pytest.mark.asyncio
+    async def test_api_server_literal_port_override(self):
+        orch = _prepared_orchestrator()
+        orch._port_override = "9100"
+        runner = MagicMock()
+        runner.addresses = [("127.0.0.1", 1)]
+        with patch.object(gw, "LessonStore", MagicMock()):
+            with patch(
+                "kiro_crew.dashboard.start_api_server",
+                AsyncMock(return_value=(runner, _mock_dashboard_state())),
+            ) as start:
+                await orch._init_api_server()
+        assert start.await_args.kwargs["port"] == 9100
+        assert orch._dashboard_port == 9100
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: embeddings + auto-migration
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestStartEmbeddings:
+    """A custom model that cannot be used is reported, not downloaded."""
+
+    @pytest.mark.asyncio
+    async def test_unusable_custom_model_warns_and_skips_bind(self, caplog):
+        orch = _make_orchestrator()
+        orch.vector_memory = MagicMock()
+        orch.vector_memory.embed_fn = None
+        sentinel = object()
+        with caplog.at_level("WARNING"):
+            with patch.object(gw, "model_file_present", return_value=False):
+                with patch.object(gw, "embedding_model_is_custom", return_value=True):
+                    with patch.object(gw, "start_background_model_download", return_value=sentinel):
+                        await orch._start_embeddings()
+        assert orch.vector_memory.embed_fn is None
+        assert orch.vector_memory.embed_fn_factory is gw.make_sync_embed_fn
+        assert orch._model_download_task is sentinel
+        assert "Custom embedding model is not usable" in caplog.text
+
+
+class TestAutoMigrateMemory:
+    """Boot-time markdown→vector migration and the re-embed sweep."""
+
+    @pytest.mark.asyncio
+    async def test_migration_flips_flag_and_survives_audit_failure(self):
+        orch = _make_orchestrator()
+        store = MagicMock()
+        store.embed_fn = None
+        store.migrate_from_markdown = MagicMock(
+            return_value={"semantic": 2, "episodic": 3, "skipped": 1}
+        )
+        store._log_event = MagicMock(side_effect=RuntimeError("audit sink down"))
+        store.backfill_missing_embeddings = MagicMock(return_value=3)
+        orch.vector_memory = store
+        orch._cfg.memory.migrated = False
+        orch.consolidator = MagicMock()
+        orch._set_memory_migrated = AsyncMock()
+        embedder = MagicMock()
+        embedder.is_ready = MagicMock(return_value=True)
+        embedder.wait_ready = MagicMock(return_value=True)
+
+        with patch.object(gw, "get_shared_embedder", return_value=embedder):
+            with patch.object(gw, "model_file_present", return_value=True):
+                with patch.object(gw, "make_sync_embed_fn", return_value=lambda s: [0.0]):
+                    with patch.object(gw, "reconcile_store_embedding_space") as reconcile:
+                        with patch("kiro_crew.memory.legacy_memory_present", return_value=True):
+                            await orch._auto_migrate_memory()
+
+        orch._set_memory_migrated.assert_awaited_once_with(True)
+        assert orch._cfg.memory.migrated is True
+        assert orch.consolidator._migrated is True
+        store.migrate_from_markdown.assert_called_once()
+        store.backfill_missing_embeddings.assert_called_once()
+        # Reconciled once up front (ready backend) and once inside the sweep.
+        assert reconcile.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_download_error_and_unready_model_defer_the_sweep(self, caplog):
+        orch = _make_orchestrator()
+        store = MagicMock()
+        store.embed_fn = None
+        orch.vector_memory = store
+        orch._cfg.memory.migrated = True  # phase 1 already done
+        orch.consolidator = None
+        embedder = MagicMock()
+        embedder.is_ready = MagicMock(return_value=False)
+        embedder.wait_ready = MagicMock(return_value=False)
+
+        async def _boom() -> None:
+            raise RuntimeError("download failed")
+
+        orch._model_download_task = asyncio.create_task(_boom())
+
+        with caplog.at_level("INFO"):
+            with patch.object(gw, "get_shared_embedder", return_value=embedder):
+                with patch.object(gw, "model_file_present", return_value=False):
+                    await orch._auto_migrate_memory()
+
+        store.backfill_missing_embeddings.assert_not_called()
+        assert "deferring" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_missing_store_is_a_no_op(self, caplog):
+        orch = _make_orchestrator()
+        orch.vector_memory = None
+        with caplog.at_level("DEBUG"):
+            await orch._auto_migrate_memory()
+        assert "vector memory not initialised" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_set_memory_migrated_delegates_to_handler(self):
+        orch = _make_orchestrator()
+        with patch(
+            "kiro_crew.dashboard.handlers.memory._set_migrated", AsyncMock()
+        ) as set_migrated:
+            await orch._set_memory_migrated(True)
+        set_migrated.assert_awaited_once_with(True)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: small init / notification surfaces
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestInitCrew:
+    """Crew mode is optional: a construction failure disables it silently."""
+
+    def test_orchestrator_failure_disables_crew_mode(self, caplog):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        ds.crew = None
+        orch.dashboard_state = ds
+        with caplog.at_level("WARNING"):
+            with patch(
+                "kiro_crew.crew_chat.CrewOrchestrator", side_effect=RuntimeError("bad wiring")
+            ):
+                orch._init_crew()
+        assert "crew mode disabled" in caplog.text
+
+    def test_no_dashboard_state_skips_crew_setup(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = None
+        with patch("kiro_crew.crew_chat.CrewOrchestrator") as ctor:
+            orch._init_crew()
+        ctor.assert_not_called()
+
+
+class TestInitMcpDiscovery:
+    """Configured MCP servers are logged at boot for diagnosability."""
+
+    def test_configured_servers_are_listed(self, caplog):
+        orch = _make_orchestrator()
+        servers = [SimpleNamespace(name="builder-mcp"), SimpleNamespace(name="playwright-mcp")]
+        with caplog.at_level("INFO"):
+            with patch("kiro_crew.mcp_discovery.list_servers", return_value=servers):
+                orch._init_mcp_discovery()
+        assert "builder-mcp, playwright-mcp" in caplog.text
+
+    def test_listing_failure_is_swallowed(self):
+        orch = _make_orchestrator()
+        with patch("kiro_crew.mcp_discovery.list_servers", side_effect=RuntimeError("boom")):
+            orch._init_mcp_discovery()  # must not raise
+
+
+class TestSubagentCoalescer:
+    """The lazily-built coalescer broadcasts through dashboard_state."""
+
+    def test_broadcast_closures_route_to_dashboard_state(self):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        coalescer = orch._subagent_coalescer()
+        assert orch._subagent_coalescer() is coalescer  # cached
+        coalescer._broadcast_all("subagent_event", {"a": 1})
+        coalescer._broadcast_subs("subagent_status", {"b": 2})
+        ds.broadcast_ws.assert_called_once_with("subagent_event", {"a": 1})
+        ds.broadcast_ws_subagent_subscribers.assert_called_once_with("subagent_status", {"b": 2})
+
+
+class TestNotifyNudgeExpired:
+    """Expiry wording distinguishes the runtime budget from the cycle cap."""
+
+    def test_runtime_budget_wording(self):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        loop = NudgeLoop(
+            id="loop-1",
+            slot_key="chat-1",
+            message="keep checking",
+            max_cycles=10,
+            cycle_count=3,
+            max_runtime_secs=60,
+            created_ts=time.time() - 600,
+        )
+        orch._notify_nudge_expired(loop)
+        ds.notify.assert_called_once()
+        title = ds.notify.call_args.args[1]
+        body = ds.notify.call_args.args[2]
+        assert title == "Monitoring loop spent its time budget"
+        assert "60s wall-clock budget" in body
+
+    def test_cycle_cap_wording(self):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        loop = NudgeLoop(
+            id="loop-2",
+            slot_key="chat-2",
+            message="keep checking",
+            max_cycles=4,
+            cycle_count=4,
+        )
+        orch._notify_nudge_expired(loop)
+        assert ds.notify.call_args.args[1] == "Monitoring loop hit its cycle cap"
+
+    def test_no_dashboard_state_is_a_no_op(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = None
+        orch._notify_nudge_expired(
+            NudgeLoop(id="l", slot_key="chat-3", message="m")
+        )  # must not raise
+
+
+class TestPersistSlotTitle:
+    """Title persistence is skipped when there is no conversation log."""
+
+    @pytest.mark.asyncio
+    async def test_missing_conversation_log_skips_write(self):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        ds.conversation_log = None
+        orch.dashboard_state = ds
+        slot = MagicMock()
+        slot.key = "chat-1"
+        with patch("asyncio.to_thread", AsyncMock()) as to_thread:
+            await orch._persist_slot_title(slot)
+        to_thread.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_failure_is_best_effort(self, caplog):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        conv = MagicMock()
+        conv.set_title = MagicMock(side_effect=RuntimeError("disk full"))
+        ds.conversation_log = conv
+        orch.dashboard_state = ds
+        slot = MagicMock()
+        slot.key = "chat-1"
+        slot.title = "💓 something"
+        with caplog.at_level("WARNING"):
+            await orch._persist_slot_title(slot)  # must not raise
+        assert "failed to persist slot title" in caplog.text
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: OPTIONS bookkeeping + cron subagent response delivery
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRememberOptions:
+    """Recording a posted OPTIONS control is best-effort."""
+
+    def test_record_failure_is_swallowed(self, caplog):
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        with caplog.at_level("DEBUG"):
+            with patch.object(gw, "remember_slack_options", side_effect=RuntimeError("store busy")):
+                orch._remember_options("cron:j1", "C1", "111.1", ["A", "B"], [{}], "Options")
+        assert "Failed to record OPTIONS control" in caplog.text
+
+    def test_no_ts_or_choices_records_nothing(self):
+        orch = _make_orchestrator()
+        with patch.object(gw, "remember_slack_options") as remember:
+            orch._remember_options("cron:j1", "C1", "", ["A"], [{}], "Options")
+            orch._remember_options("cron:j1", "C1", "111.1", [], [{}], "Options")
+        remember.assert_not_called()
+
+
+class TestDeliverCronResponse:
+    """A cron session's post-subagent response routes to Slack."""
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_channel_returns_false(self, caplog):
+        orch = _make_orchestrator()
+        orch.slack = _mock_slack()
+        sessions = MagicMock()
+        sessions.get_channel = MagicMock(return_value="")
+        sessions.get_thread = MagicMock(return_value=None)
+        orch.sessions = sessions
+        orch._open_dm_with_retry = AsyncMock(return_value=None)
+        with caplog.at_level("WARNING"):
+            assert await orch._deliver_cron_response("cron:j1", "done") is False
+        orch._open_dm_with_retry.assert_awaited_once()
+        assert "no channel resolved" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_options_post_failure_still_delivers_text(self, caplog):
+        orch = _make_orchestrator()
+        slack = _mock_slack()
+        slack.post_blocks = AsyncMock(side_effect=RuntimeError("block kit rejected"))
+        orch.slack = slack
+        sessions = MagicMock()
+        sessions.get_channel = MagicMock(return_value="C1")
+        sessions.get_thread = MagicMock(return_value="111.1")
+        orch.sessions = sessions
+        with caplog.at_level("DEBUG"):
+            ok = await orch._deliver_cron_response(
+                "cron:j1", "All done.\n\n[OPTIONS: Merge it now | Hold off]"
+            )
+        assert ok is True
+        assert slack.post_message.await_count >= 1
+        assert slack.post_message.await_args.args[0] == "C1"
+        assert "failed to post OPTIONS blocks" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_silent_and_empty_text_short_circuit(self):
+        orch = _make_orchestrator()
+        orch.slack = _mock_slack()
+        orch.sessions = MagicMock()
+        assert await orch._deliver_cron_response("cron:j1", "x", silent=True) is False
+        assert await orch._deliver_cron_response("cron:j1", "   ") is False
+        orch.slack.post_message.assert_not_awaited()

--- a/test/test_slack_handler_more_coverage.py
+++ b/test/test_slack_handler_more_coverage.py
@@ -1,0 +1,1266 @@
+"""Additional coverage for ``kiro_crew.slack.handler``.
+
+Focuses on branches the existing ``test_slack_handler*.py`` files leave
+untouched:
+
+* the rich-streaming ``EVENT_TOOL_CALL`` path (task cards, elapsed-time timer,
+  the ``wait``-tool stream finalisation) and stream rotation after a failed
+  ``append_stream``
+* the ACP failure ladder inside ``handle_message``
+  (timeout / process-died / prompt-busy)
+* hook verdicts on tool calls and permission requests, plus per-session trust
+* the defence-in-depth authorisation re-checks in ``handle_interaction``
+* small module-level helpers: ``_add_phase_reaction``, ``set_orch_cfg``
+  provider validation, ``_handle_cron_command`` list rendering,
+  ``_handle_run_command`` idle status, ``_resolve_agent_name`` project lookup.
+
+Everything runs against in-process doubles: no subprocess, no git, no network,
+no sandbox. ``MockSlackClient`` comes from ``test/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+import kiro_crew.slack.handler as h
+from conftest import MockSlackClient
+from kiro_crew.acp.client import AcpProcessDied, AcpPromptBusy, AcpTimeoutError
+from kiro_crew.acp.types import (
+    EVENT_COMPLETE,
+    EVENT_PERMISSION_REQUEST,
+    EVENT_TEXT_CHUNK,
+    EVENT_TOOL_CALL,
+    AcpEvent,
+)
+from kiro_crew.cron import CronJob, CronSchedule
+from kiro_crew.hooks import TOOL_ALLOW, TOOL_AUTO_APPROVE, TOOL_DENY, ToolHookResult
+from kiro_crew.slack.handler import handle_interaction, handle_message
+
+# ──────────────────────────────────────────────────────────────────────
+# doubles
+# ──────────────────────────────────────────────────────────────────────
+
+
+class FakeProvider:
+    """Provider double yielding a scripted event list, then ``complete``."""
+
+    def __init__(self, events=None, raises: BaseException | None = None):
+        self._events = events or []
+        self._raises = raises
+        self.approved: list = []
+        self.rejected: list = []
+
+    async def stream(self, message, timeout=120.0):
+        for event in self._events:
+            yield event
+        if self._raises is not None:
+            raise self._raises
+        yield AcpEvent(kind=EVENT_COMPLETE)
+
+    async def approve_tool(self, request_id, option_id="allow_once"):
+        self.approved.append(request_id)
+
+    async def reject_tool(self, request_id):
+        self.rejected.append(request_id)
+
+    async def start(self):
+        pass
+
+    async def shutdown(self):
+        pass
+
+    def context_usage_pct(self):
+        return 0.0
+
+
+class FakeSessions:
+    """Minimal SessionManager surface used by ``handle_message``."""
+
+    def __init__(self, provider: FakeProvider | None = None):
+        self._provider = provider or FakeProvider()
+        self.keys_seen: list[str] = []
+        self._is_new = True
+        self.reset_calls: list[str] = []
+        self.failures: list[str] = []
+        self.policies: dict[str, str] = {}
+        self._session_map = None
+
+    async def get_or_create(self, key, agent=None, channel_id=None):
+        self.keys_seen.append(key)
+        was_new = self._is_new
+        self._is_new = False
+        return self._provider, was_new, False
+
+    def check_context_usage(self, key, provider):
+        return 0.0
+
+    def record_success(self, key):
+        pass
+
+    async def record_failure(self, key):
+        self.failures.append(key)
+        return False
+
+    async def try_acquire(self, key):
+        return self.has_session(key)
+
+    def release(self, key):
+        pass
+
+    def is_busy(self, key):
+        return False
+
+    def begin_turn(self, key):
+        pass
+
+    async def set_channel(self, key, channel_id):
+        pass
+
+    def get_channel(self, key):
+        return None
+
+    def set_slack_link(self, key, thread_ts, channel_id):
+        pass
+
+    def get_slack_link(self, key):
+        return None, None
+
+    def get_session_for_thread(self, thread_ts):
+        return None
+
+    def set_approval_policy(self, key, policy):
+        self.policies[key] = policy
+
+    async def close_all(self):
+        pass
+
+    async def remove(self, key):
+        pass
+
+    async def destroy(self, key):
+        pass
+
+    def has_session(self, key):
+        return key in self.keys_seen
+
+    def get_provider(self, key):
+        return None
+
+    async def reset(self, key):
+        self.reset_calls.append(key)
+
+    def get_pid(self, key):
+        return None
+
+    def enqueue(self, key, msg_ts, text, **kwargs):
+        return False
+
+    def is_cancelled(self, key, msg_ts):
+        return False
+
+    def dequeue(self, key):
+        return None
+
+    def clear_queue(self, key):
+        pass
+
+    async def stop_turn(self, key, *, force=False, on_soft=None, on_hard=None):
+        return "soft"
+
+
+class _StreamingSlack(MockSlackClient):
+    """MockSlackClient with the Slack rich-streaming API enabled."""
+
+    def __init__(self):
+        super().__init__()
+        self._stream_enabled = True
+
+
+class _RotatingSlack(_StreamingSlack):
+    """``append_stream`` fails once, forcing exactly one stream rotation."""
+
+    def __init__(self):
+        super().__init__()
+        self._appends = 0
+
+    async def append_stream(self, channel, ts, text):
+        self._appends += 1
+        await super().append_stream(channel, ts, text)
+        return self._appends != 1
+
+
+def _has_approval_prompt(slack) -> bool:
+    """True when an interactive tool-approval Block Kit prompt was posted."""
+    for kind, kw in slack.actions:
+        if kind != "blocks":
+            continue
+        for block in kw.get("blocks") or []:
+            for el in block.get("elements") or []:
+                if el.get("action_id") == h._ACTION_APPROVE:
+                    return True
+    return False
+
+
+def _kinds(slack) -> list[str]:
+    return [a[0] for a in slack.actions]
+
+
+def _all_text(slack) -> str:
+    return " ".join(
+        str(a[1].get("text") or "")
+        for a in slack.actions
+        if a[0] in ("post", "update", "stop_stream", "append_stream")
+    )
+
+
+@pytest.fixture()
+def owner(monkeypatch):
+    monkeypatch.setattr(h, "_owner_id", "U1")
+    return "U1"
+
+
+@pytest.fixture(autouse=True)
+def _clean_approval_state():
+    h._pending_approvals.clear()
+    h._linked_approvals.clear()
+    h._trusted_sessions.clear()
+    yield
+    h._pending_approvals.clear()
+    h._linked_approvals.clear()
+    h._trusted_sessions.clear()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _add_phase_reaction
+# ──────────────────────────────────────────────────────────────────────
+class TestAddPhaseReaction:
+    @pytest.mark.asyncio
+    async def test_suppressed_phase_adds_nothing(self, monkeypatch):
+        """A ``null`` sentinel in ``slack.reactions`` means "no emoji at all"."""
+        monkeypatch.setitem(h._PHASE_EMOJIS, "done", None)
+        slack = MockSlackClient()
+        await h._add_phase_reaction(slack, "C1", "m1", "done")
+        assert slack.actions == []
+
+    @pytest.mark.asyncio
+    async def test_configured_phase_is_added(self, monkeypatch):
+        monkeypatch.setitem(h._PHASE_EMOJIS, "done", "tada")
+        slack = MockSlackClient()
+        await h._add_phase_reaction(slack, "C1", "m1", "done")
+        assert slack.actions == [("react", {"channel": "C1", "ts": "m1", "emoji": "tada"})]
+
+    @pytest.mark.asyncio
+    async def test_unknown_phase_is_ignored(self):
+        """A phase with no entry at all resolves to None -> no API call."""
+        slack = MockSlackClient()
+        await h._add_phase_reaction(slack, "C1", "m1", "not-a-phase")
+        assert slack.actions == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# privacy modifiers
+# ──────────────────────────────────────────────────────────────────────
+class TestIncognitoModifierIdempotence:
+    @pytest.mark.asyncio
+    async def test_second_apply_is_a_no_op(self):
+        """``!incognito`` twice in one thread must not re-notify the user."""
+        h._mark_incognito("slack:t1")
+        slack = MockSlackClient()
+        await h._apply_incognito_modifier("slack:t1", "U1", "C1", slack, FakeSessions(), "t1")
+        assert slack.actions == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# set_orch_cfg — voice_reply provider validation
+# ──────────────────────────────────────────────────────────────────────
+class _Cfg:
+    def __init__(self, voice_reply: dict):
+        self.raw = {"voice_reply": voice_reply}
+
+
+class TestSetOrchCfgProviderValidation:
+    def test_unknown_provider_falls_back_to_polly(self, monkeypatch, caplog):
+        monkeypatch.setattr(h, "_vc", h._VoiceConfig())
+        monkeypatch.setattr(h, "_orch_cfg", None, raising=False)
+        with caplog.at_level("WARNING"):
+            h.set_orch_cfg(_Cfg({"enabled": True, "provider": "ploly"}))
+        assert h._vc.provider == "polly"
+        assert "ploly" in caplog.text
+
+    def test_valid_provider_is_kept_and_enabled_implies_auto_reply(self, monkeypatch):
+        monkeypatch.setattr(h, "_vc", h._VoiceConfig())
+        monkeypatch.setattr(h, "_orch_cfg", None, raising=False)
+        h.set_orch_cfg(_Cfg({"enabled": True, "provider": "piper", "voice_id": "Amy"}))
+        assert h._vc.provider == "piper"
+        assert h._vc.global_enabled is True
+        # auto_reply_to_voice defaults to the value of `enabled`.
+        assert h._vc.auto_reply_to_voice is True
+        assert h._vc.default_voice == "Amy"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _resolve_agent_name — project-local agents win
+# ──────────────────────────────────────────────────────────────────────
+class TestResolveAgentNameProject:
+    def test_project_agent_declared_name_wins_over_stem(self, tmp_path):
+        agents = tmp_path / ".kiro" / "agents"
+        agents.mkdir(parents=True)
+        (agents / "reviewer.json").write_text(
+            json.dumps({"name": "team-reviewer"}), encoding="utf-8"
+        )
+        assert h._resolve_agent_name("reviewer", str(tmp_path)) == "team-reviewer"
+
+    def test_non_matching_project_agent_does_not_short_circuit(self, tmp_path):
+        agents = tmp_path / ".kiro" / "agents"
+        agents.mkdir(parents=True)
+        (agents / "reviewer.json").write_text(json.dumps({"name": "x"}), encoding="utf-8")
+        # No project match and (in an isolated KIROCREW_HOME) no user agent either.
+        assert h._resolve_agent_name("nope", str(tmp_path)) is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _handle_cron_command — `cron list` rendering
+# ──────────────────────────────────────────────────────────────────────
+class _FakeCronService:
+    def __init__(self, jobs):
+        self._jobs = jobs
+
+    def list_jobs(self, include_disabled=False):
+        return list(self._jobs)
+
+
+def _at_job(job_id: str, offset: float, **kw) -> CronJob:
+    return CronJob(
+        id=job_id,
+        name=job_id,
+        message=f"do {job_id}",
+        schedule=CronSchedule(kind="at", at_ts=time.time() + offset),
+        **kw,
+    )
+
+
+class TestCronListRendering:
+    @pytest.mark.asyncio
+    async def test_relative_next_run_buckets(self):
+        jobs = [
+            _at_job("days", 2 * 86400 + 3 * 3600 + 1800),
+            _at_job("hours", 5 * 3600 + 30 * 60 + 30),
+            _at_job("mins", 5 * 60 + 30),
+            _at_job("soon", 30),
+        ]
+        out = await _handle_cron("cron list", jobs)
+        assert "⏭ in 2d 3h" in out
+        assert "⏭ in 5h 30m" in out
+        assert "⏭ in 5m" in out
+        assert "⏭ in <1m" in out
+
+    @pytest.mark.asyncio
+    async def test_last_status_markers_and_disabled_prefix(self):
+        jobs = [
+            _at_job("okjob", 600, last_status="ok"),
+            _at_job("badjob", 600, last_status="error"),
+            CronJob(
+                id="offjob",
+                name="offjob",
+                message="paused work",
+                schedule=CronSchedule(kind="every", every_secs=60),
+                enabled=False,
+            ),
+        ]
+        out = await _handle_cron("cron list", jobs)
+        lines = {line.split("`")[1]: line for line in out.splitlines() if "`" in line}
+        assert lines["okjob"].endswith(("✓", "m")) and " ✓" in lines["okjob"]
+        assert " ❌" in lines["badjob"]
+        assert lines["offjob"].startswith("⏸️")
+        # A disabled job has no next run at all.
+        assert "⏭" not in lines["offjob"]
+
+    @pytest.mark.asyncio
+    async def test_due_now_renders_now(self):
+        job = CronJob(
+            id="due",
+            name="due",
+            message="tick",
+            schedule=CronSchedule(kind="every", every_secs=60),
+            created_ts=1.0,
+        )
+        out = await _handle_cron("cron list", [job])
+        assert "⏭ now" in out
+
+    @pytest.mark.asyncio
+    async def test_message_is_truncated_to_50_chars(self):
+        job = _at_job("long", 600)
+        job.message = "x" * 200
+        out = await _handle_cron("cron list", [job])
+        assert "x" * 50 in out
+        assert "x" * 51 not in out
+
+    @pytest.mark.asyncio
+    async def test_empty_and_unrecognised_forms(self):
+        assert await _handle_cron("cron list", []) == "No cron jobs scheduled."
+        # not a cron command at all
+        assert await _handle_cron("hello there", []) is None
+        # known action, missing job id
+        assert await _handle_cron("cron pause", []) is None
+        # unknown action with a job id
+        assert await _handle_cron("cron frobnicate j1", []) is None
+
+
+async def _handle_cron(text: str, jobs) -> str | None:
+    return await h._handle_cron_command(text, _FakeCronService(jobs), "C1", "t1")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _handle_run_command
+# ──────────────────────────────────────────────────────────────────────
+class _FakeRunner:
+    def __init__(self, running=False, status=None):
+        self.running = running
+        self._status = status or {}
+        self.cancelled = False
+        self.started: list[Path] = []
+
+    def status(self):
+        return dict(self._status)
+
+    def cancel(self):
+        self.cancelled = True
+
+    async def start_background(self, spec_path, source=""):
+        self.started.append(spec_path)
+
+
+class TestRunCommand:
+    @pytest.mark.asyncio
+    async def test_status_when_idle(self):
+        out = await h._handle_run_command(
+            "task run status", _FakeRunner(), MockSlackClient(), "C1", "t1"
+        )
+        assert out == "No task running."
+
+    @pytest.mark.asyncio
+    async def test_status_when_running(self):
+        runner = _FakeRunner(
+            running=True,
+            status={"running": True, "status": "step", "completed": 2, "steps": 5, "current_step": 3},
+        )
+        out = await h._handle_run_command("task run status", runner, MockSlackClient(), "C1", "t1")
+        assert "Steps: 2/5" in out
+        assert "Current: step 3" in out
+
+    @pytest.mark.asyncio
+    async def test_cancel_paths(self):
+        idle = _FakeRunner()
+        assert (
+            await h._handle_run_command("task run cancel", idle, MockSlackClient(), "C1", "t1")
+            == "No task running."
+        )
+        assert idle.cancelled is False
+        busy = _FakeRunner(running=True)
+        assert "cancelled" in await h._handle_run_command(
+            "task run cancel", busy, MockSlackClient(), "C1", "t1"
+        )
+        assert busy.cancelled is True
+
+    @pytest.mark.asyncio
+    async def test_project_run_alias_and_missing_spec(self, tmp_path):
+        missing = tmp_path / "nope.md"
+        out = await h._handle_run_command(
+            f"project run {missing}", _FakeRunner(), MockSlackClient(), "C1", "t1"
+        )
+        assert "Spec file not found" in out
+
+    @pytest.mark.asyncio
+    async def test_start_success_and_failure(self, tmp_path):
+        spec = tmp_path / "task.md"
+        spec.write_text("# task\n", encoding="utf-8", newline="\n")
+
+        runner = _FakeRunner()
+        out = await h._handle_run_command(
+            f"task run {spec}", runner, MockSlackClient(), "C1", "t1"
+        )
+        assert "Task started" in out and runner.started == [spec]
+
+        class _Boom(_FakeRunner):
+            async def start_background(self, spec_path, source=""):
+                raise RuntimeError("spawn refused")
+
+        out = await h._handle_run_command(
+            f"task run {spec}", _Boom(), MockSlackClient(), "C1", "t1"
+        )
+        assert "Failed to start: spawn refused" in out
+
+    @pytest.mark.asyncio
+    async def test_non_run_text_is_not_intercepted(self):
+        runner = _FakeRunner()
+        slack = MockSlackClient()
+        assert await h._handle_run_command("hello", runner, slack, "C1", "t1") is None
+        assert await h._handle_run_command("task run ", runner, slack, "C1", "t1") is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _handle_slash_command — !agent off with an unwritable config
+# ──────────────────────────────────────────────────────────────────────
+class TestSlashAgentResetFailure:
+    @pytest.mark.asyncio
+    async def test_config_write_failure_is_reported_not_raised(self, monkeypatch, owner):
+        def _boom(name):
+            raise ValueError("Failed to write config: disk full")
+
+        monkeypatch.setattr(h, "_set_default_agent", _boom)
+        slack = MockSlackClient()
+        out = await h._handle_slash_command(
+            "!agent off",
+            slack,
+            FakeSessions(),
+            "C1",
+            "t1",
+            "m1",
+            "slack:t1",
+            owner,
+        )
+        assert out == ""
+        assert "disk full" in _all_text(slack)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _maybe_auto_title_slack — a tool request during titling must be rejected
+# ──────────────────────────────────────────────────────────────────────
+class _TitleSessions(FakeSessions):
+    def __init__(self, provider):
+        super().__init__(provider)
+        self.released: list[str] = []
+
+    def release(self, key):
+        self.released.append(key)
+
+
+class TestAutoTitleToolRejection:
+    @pytest.mark.asyncio
+    async def test_permission_request_is_rejected_and_title_still_set(self):
+        provider = FakeProvider(
+            [
+                AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rq1", title="Bash"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="Deploy plan review"),
+                AcpEvent(kind=EVENT_COMPLETE),
+            ]
+        )
+        sessions = _TitleSessions(provider)
+        slack = MockSlackClient()
+        await h._maybe_auto_title_slack(
+            slack, sessions, "C1", "slack:t1", None, "user text", "assistant text"
+        )
+        # The titling session is never allowed to run tools.
+        assert provider.rejected == ["rq1"]
+        titles = [a for a in slack.actions if a[0] == "set_thread_title"]
+        assert titles and titles[0][1]["title"] == "Deploy plan review"
+        assert sessions.released  # BACKGROUND_KEY released in the finally
+
+    @pytest.mark.asyncio
+    async def test_skip_reply_clears_the_claim_for_retry(self):
+        h._titled_threads["slack:t2"] = "auto"
+        provider = FakeProvider(
+            [AcpEvent(kind=EVENT_TEXT_CHUNK, text="SKIP"), AcpEvent(kind=EVENT_COMPLETE)]
+        )
+        slack = MockSlackClient()
+        await h._maybe_auto_title_slack(
+            slack, _TitleSessions(provider), "C1", "slack:t2", None, "hi", "hello"
+        )
+        assert "slack:t2" not in h._titled_threads
+        assert not [a for a in slack.actions if a[0] == "set_thread_title"]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# handle_interaction — defence-in-depth re-checks
+# ──────────────────────────────────────────────────────────────────────
+def _revoking_allow_check(monkeypatch):
+    """``is_allowed_user`` that passes the entry gate then revokes.
+
+    Models an authorisation revoked between the outer gate and the inner
+    re-check — the reason those inner checks exist.
+    """
+    calls = {"n": 0}
+
+    def _fake(user_id):
+        calls["n"] += 1
+        return calls["n"] == 1
+
+    monkeypatch.setattr(h, "is_allowed_user", _fake)
+    return calls
+
+
+class TestHandleInteractionAuthReChecks:
+    @pytest.mark.asyncio
+    async def test_late_trust_click_rejected_when_authorisation_revoked(self, monkeypatch):
+        calls = _revoking_allow_check(monkeypatch)
+        slack = MockSlackClient()
+        out = await handle_interaction(
+            "C1", "m1", h._ACTION_TRUST, "U1", thread_ts="t1", slack=slack
+        )
+        assert out is None
+        assert calls["n"] == 2
+        assert h._trusted_sessions == set()
+        # Rejected before any Slack call is made.
+        assert slack.actions == []
+
+    @pytest.mark.asyncio
+    async def test_late_trust_click_needs_a_slack_client_to_verify_ownership(self, owner):
+        out = await handle_interaction(
+            "C1", "m1", h._ACTION_TRUST, owner, thread_ts="t1", slack=None
+        )
+        assert out is None
+        assert h._trusted_sessions == set()
+
+    @pytest.mark.asyncio
+    async def test_late_trust_click_denied_when_not_thread_owner(self, owner):
+        slack = MockSlackClient()
+        slack._fetch_thread_replies_result = [{"user": "U_OTHER"}]
+        out = await handle_interaction(
+            "C1", "m1", h._ACTION_TRUST, owner, thread_ts="t1", slack=slack
+        )
+        assert out is None
+        assert h._trusted_sessions == set()
+
+    @pytest.mark.asyncio
+    async def test_late_trust_refused_when_session_map_lookup_fails(self, monkeypatch, owner):
+        import kiro_crew.session as session_mod
+
+        class _BoomMap:
+            def __init__(self):
+                raise RuntimeError("session map unreadable")
+
+        monkeypatch.setattr(session_mod, "SessionMap", _BoomMap)
+        slack = MockSlackClient()
+        slack._fetch_thread_replies_result = [{"user": owner}]
+        out = await handle_interaction(
+            "C1", "m1", h._ACTION_TRUST, owner, thread_ts="t1", slack=slack
+        )
+        # Fail closed: no trust granted when the thread->session mapping is unknown.
+        assert out is None
+        assert h._trusted_sessions == set()
+
+    @pytest.mark.asyncio
+    async def test_late_trust_refused_when_ownership_fetch_raises(self, owner):
+        class _Boom(MockSlackClient):
+            async def fetch_thread_replies(self, channel, thread_ts, limit=200, **kw):
+                raise RuntimeError("slack down")
+
+        out = await handle_interaction(
+            "C1", "m1", h._ACTION_TRUST, owner, thread_ts="t1", slack=_Boom()
+        )
+        assert out is None
+        assert h._trusted_sessions == set()
+
+    @pytest.mark.asyncio
+    async def test_late_trust_binds_to_the_linked_dashboard_session(self, monkeypatch, owner):
+        """A thread linked to a dashboard slot must grant trust on the LINKED
+        session key, not the bare thread ts."""
+        import kiro_crew.session as session_mod
+
+        class _Map:
+            def get_session_for_thread(self, thread_ts):
+                return "dash:slot-1"
+
+        monkeypatch.setattr(session_mod, "SessionMap", _Map)
+        slack = MockSlackClient()
+        slack._fetch_thread_replies_result = [{"user": owner}]
+        sessions = FakeSessions()
+        out = await handle_interaction(
+            "C1", "m1", h._ACTION_TRUST, owner, thread_ts="t1", slack=slack, sessions=sessions
+        )
+        assert out == h._ACTION_TRUST
+        assert h._trusted_sessions == {"dash:slot-1"}
+        assert sessions.policies == {"dash:slot-1": "auto"}
+
+    @pytest.mark.asyncio
+    async def test_trust_escalation_rejected_when_authorisation_revoked(self, monkeypatch):
+        calls = _revoking_allow_check(monkeypatch)
+        provider = FakeProvider()
+        pending = h._PendingApproval(provider, "rq7", session_key="slack:t1")
+        h._pending_approvals["C1:m1"] = pending
+        sessions = FakeSessions()
+
+        out = await handle_interaction(
+            "C1", "m1", h._ACTION_TRUST, "U1", thread_ts="t1", sessions=sessions
+        )
+        assert out == h._ACTION_REJECT
+        assert calls["n"] == 2
+        # The turn is unblocked with a rejection, trust is NOT granted, and the
+        # entry is consumed so a retry cannot reuse it.
+        assert pending.future.result() == h._OUTCOME_REJECTED
+        assert h._trusted_sessions == set()
+        assert sessions.policies == {}
+        assert "C1:m1" not in h._pending_approvals
+
+    @pytest.mark.asyncio
+    async def test_trust_without_session_key_still_approves(self, owner):
+        provider = FakeProvider()
+        pending = h._PendingApproval(provider, "rq8", session_key="")
+        h._pending_approvals["C1:m1"] = pending
+
+        out = await handle_interaction("C1", "m1", h._ACTION_TRUST, owner)
+        assert out == h._ACTION_TRUST
+        assert provider.approved == ["rq8"]
+        assert pending.future.result() == h._OUTCOME_APPROVED
+        # Nothing to trust — the set stays empty rather than gaining "".
+        assert h._trusted_sessions == set()
+
+    @pytest.mark.asyncio
+    async def test_trust_with_session_key_propagates_policy_to_subagents(self, owner):
+        provider = FakeProvider()
+        h._pending_approvals["C1:m1"] = h._PendingApproval(
+            provider, "rq9", session_key="slack:t1"
+        )
+        sessions = FakeSessions()
+        out = await handle_interaction(
+            "C1", "m1", h._ACTION_TRUST, owner, thread_ts="t1", sessions=sessions
+        )
+        assert out == h._ACTION_TRUST
+        assert "slack:t1" in h._trusted_sessions
+        assert sessions.policies["slack:t1"] == "auto"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# handle_message — rich streaming tool cards
+# ──────────────────────────────────────────────────────────────────────
+class TestStreamingToolCards:
+    @pytest.mark.asyncio
+    async def test_consecutive_tools_complete_the_previous_card(self, monkeypatch):
+        monkeypatch.setattr(h, "_EDIT_INTERVAL", 0.0)
+        slack = _StreamingSlack()
+        provider = FakeProvider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="Let me look."),
+                AcpEvent(
+                    kind=EVENT_TOOL_CALL,
+                    title="Read File",
+                    tool_kind="read",
+                    tool_purpose="Read config",
+                ),
+                AcpEvent(kind=EVENT_TOOL_CALL, title="Grep", tool_kind="grep"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="Done."),
+            ]
+        )
+        await handle_message(slack, FakeSessions(provider), "C1", "go", None, "m1", "U1")
+
+        cards = [a[1] for a in slack.actions if a[0] == "append_task"]
+        statuses = [(c["task_id"], c["status"]) for c in cards]
+        # First tool opens tool_1, second tool completes tool_1 then opens tool_2.
+        assert ("tool_1", "in_progress") in statuses
+        assert ("tool_1", "complete") in statuses
+        assert ("tool_2", "in_progress") in statuses
+        # The purpose (not the raw tool name) is the card title when present.
+        assert any(c["title"] == "Read config" for c in cards)
+        # Thread status reflects the running tool.
+        assert any(
+            a[1].get("status") == "is using Grep"
+            for a in slack.actions
+            if a[0] == "set_thread_status"
+        )
+        assert "Done." in _all_text(slack)
+
+    @pytest.mark.asyncio
+    async def test_wait_tool_finalises_the_stream(self, monkeypatch):
+        """The ``wait`` MCP tool blocks for up to 30min, so the stream must be
+        closed rather than left open until Slack errors it out."""
+        monkeypatch.setattr(h, "_EDIT_INTERVAL", 0.0)
+        slack = _StreamingSlack()
+        provider = FakeProvider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="waiting for CI"),
+                AcpEvent(kind=EVENT_TOOL_CALL, title="wait", tool_kind="mcp"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="CI is green"),
+            ]
+        )
+        await handle_message(slack, FakeSessions(provider), "C1", "go", None, "m1", "U1")
+
+        kinds = _kinds(slack)
+        # Stream closed mid-turn, then reopened for the post-wait text.
+        assert kinds.count("start_stream") >= 2
+        assert kinds.count("stop_stream") >= 2
+        # The pre-wait text was already published, so only post-wait text is
+        # carried in the final message.
+        final = [a[1]["text"] for a in slack.actions if a[0] == "stop_stream"][-1]
+        assert "CI is green" in (final or "")
+
+    @pytest.mark.asyncio
+    async def test_failed_append_rotates_the_stream(self, monkeypatch):
+        monkeypatch.setattr(h, "_EDIT_INTERVAL", 0.0)
+        slack = _RotatingSlack()
+        provider = FakeProvider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="first chunk "),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="second chunk"),
+            ]
+        )
+        await handle_message(slack, FakeSessions(provider), "C1", "go", None, "m1", "U1")
+
+        # One rotation: the dead stream is stopped and a fresh one started.
+        assert _kinds(slack).count("start_stream") >= 2
+        assert "second chunk" in _all_text(slack)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# handle_message — ACP failure ladder
+# ──────────────────────────────────────────────────────────────────────
+class TestAcpFailureLadder:
+    @pytest.mark.asyncio
+    async def test_timeout_publishes_partial_output(self):
+        slack = MockSlackClient()
+        sessions = FakeSessions(FakeProvider(raises=AcpTimeoutError("half an answer")))
+        await handle_message(slack, sessions, "C1", "go", None, "m1", "U1")
+        assert "half an answer" in _all_text(slack)
+        assert sessions.failures == ["m1"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_without_partial_output_falls_back_to_notice(self):
+        slack = MockSlackClient()
+        sessions = FakeSessions(FakeProvider(raises=AcpTimeoutError()))
+        await handle_message(slack, sessions, "C1", "go", None, "m1", "U1")
+        assert "timed out" in _all_text(slack).lower()
+
+    @pytest.mark.asyncio
+    async def test_process_died_is_reported(self):
+        slack = MockSlackClient()
+        sessions = FakeSessions(FakeProvider(raises=AcpProcessDied("boom")))
+        await handle_message(slack, sessions, "C1", "go", None, "m1", "U1")
+        assert "process died" in _all_text(slack).lower()
+        assert sessions.failures == ["m1"]
+
+    @pytest.mark.asyncio
+    async def test_prompt_busy_resets_the_session(self):
+        slack = MockSlackClient()
+        sessions = FakeSessions(FakeProvider(raises=AcpPromptBusy("prompt in flight")))
+        await handle_message(slack, sessions, "C1", "go", None, "m1", "U1")
+        # A wedged session must be reset so the NEXT message cold-starts.
+        assert sessions.reset_calls == ["m1"]
+        assert "prompt in flight" in _all_text(slack)
+
+    @pytest.mark.asyncio
+    async def test_prompt_busy_reset_failure_is_swallowed(self):
+        class _NoReset(FakeSessions):
+            async def reset(self, key):
+                raise RuntimeError("reset refused")
+
+        slack = MockSlackClient()
+        sessions = _NoReset(FakeProvider(raises=AcpPromptBusy("prompt in flight")))
+        await handle_message(slack, sessions, "C1", "go", None, "m1", "U1")
+        # The reply still reaches the user even though the reset failed.
+        assert "prompt in flight" in _all_text(slack)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# handle_message — hook verdicts and per-session trust
+# ──────────────────────────────────────────────────────────────────────
+class _Builder:
+    """ContextBuilder double: real-shaped hooks, no memory/embedding work."""
+
+    def __init__(self, tool_result: ToolHookResult):
+        self.conversation_log = None
+        self.hooks = _Hooks(tool_result)
+
+    def build_message(self, text, is_new, session_key, **kw):
+        return text, None
+
+
+class _Hooks:
+    auto_approve_subagent_spawn = False
+
+    def __init__(self, tool_result: ToolHookResult):
+        self._tool_result = tool_result
+        self.tool_calls: list[str] = []
+
+    def on_message(self, *a, **kw):
+        from kiro_crew.hooks import HookResult
+
+        return HookResult(action="none")
+
+    def on_tool_call(self, title, **kw):
+        self.tool_calls.append(title)
+        return self._tool_result
+
+
+class TestToolHookVerdicts:
+    @pytest.mark.asyncio
+    async def test_tool_call_deny_is_surfaced_as_unenforceable_warning(self):
+        """EVENT_TOOL_CALL is informational — the tool is ALREADY running, so a
+        hook deny warns instead of claiming it was blocked."""
+        slack = MockSlackClient()
+        builder = _Builder(ToolHookResult(action=TOOL_DENY, reason="denylisted"))
+        provider = FakeProvider(
+            [
+                AcpEvent(kind=EVENT_TOOL_CALL, title="rm -rf /tmp/x", tool_kind="execute"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="tail"),
+            ]
+        )
+        await handle_message(
+            slack,
+            FakeSessions(provider),
+            "C1",
+            "go",
+            None,
+            "m1",
+            "U1",
+            context_builder=builder,
+        )
+        text = _all_text(slack)
+        assert "flagged by security" in text
+        assert "cannot be stopped here" in text
+        assert builder.hooks.tool_calls == ["rm -rf /tmp/x"]
+
+    @pytest.mark.asyncio
+    async def test_permission_request_hook_auto_approve(self):
+        slack = MockSlackClient()
+        builder = _Builder(ToolHookResult(action=TOOL_AUTO_APPROVE))
+        provider = FakeProvider(
+            [
+                AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rq1", title="Read"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="read it"),
+            ]
+        )
+        await handle_message(
+            slack,
+            FakeSessions(provider),
+            "C1",
+            "go",
+            None,
+            "m1",
+            "U1",
+            approval_mode=h.APPROVAL_INTERACTIVE,
+            context_builder=builder,
+        )
+        assert provider.approved == ["rq1"]
+        assert provider.rejected == []
+        # No approval prompt was posted — the hook answered it.
+        assert not _has_approval_prompt(slack)
+
+    @pytest.mark.asyncio
+    async def test_permission_request_hook_deny(self):
+        slack = MockSlackClient()
+        builder = _Builder(ToolHookResult(action=TOOL_DENY, reason="sensitive path"))
+        provider = FakeProvider(
+            [
+                AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rq2", title="Write"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="tail"),
+            ]
+        )
+        await handle_message(
+            slack,
+            FakeSessions(provider),
+            "C1",
+            "go",
+            None,
+            "m1",
+            "U1",
+            approval_mode=h.APPROVAL_INTERACTIVE,
+            context_builder=builder,
+        )
+        assert provider.rejected == ["rq2"]
+        assert provider.approved == []
+        assert "blocked by hooks" in _all_text(slack)
+
+    @pytest.mark.asyncio
+    async def test_trusted_session_auto_approves_in_interactive_mode(self):
+        slack = MockSlackClient()
+        h._trusted_sessions.add("m1")
+        builder = _Builder(ToolHookResult(action=TOOL_ALLOW))
+        provider = FakeProvider(
+            [
+                AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rq3", title="Bash"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="ok"),
+            ]
+        )
+        await handle_message(
+            slack,
+            FakeSessions(provider),
+            "C1",
+            "go",
+            None,
+            "m1",
+            "U1",
+            approval_mode=h.APPROVAL_INTERACTIVE,
+            context_builder=builder,
+        )
+        assert provider.approved == ["rq3"]
+        # Trust means no button prompt at all.
+        assert not _has_approval_prompt(slack)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# handle_message — review-mode ephemeral draft
+# ──────────────────────────────────────────────────────────────────────
+class TestReviewMode:
+    @pytest.mark.asyncio
+    async def test_answer_is_held_back_as_an_ephemeral_draft(self, monkeypatch):
+        monkeypatch.setattr(h, "_EDIT_INTERVAL", 0.0)
+        slack = _StreamingSlack()
+        provider = FakeProvider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="Proposed answer "),
+                AcpEvent(kind=EVENT_TOOL_CALL, title="Read File", tool_kind="read"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="for review"),
+            ]
+        )
+        await handle_message(
+            slack,
+            FakeSessions(provider),
+            "C1",
+            "go",
+            None,
+            "m1",
+            "U1",
+            channel_activation=h.ACTIVATION_REVIEW,
+            user_display_name="Zed",
+        )
+
+        # Nothing was streamed or posted publicly.
+        assert not [a for a in slack.actions if a[0] in ("append_stream", "append_task")]
+        assert not [a for a in slack.actions if a[0] == "post"]
+        # The draft went out as an ephemeral with review buttons...
+        eph = [a[1] for a in slack.actions if a[0] == "ephemeral"]
+        assert len(eph) == 1
+        assert "Proposed answer" in eph[0]["text"] and "for review" in eph[0]["text"]
+        assert eph[0]["user_id"] == "U1"
+        assert eph[0]["blocks"]
+        # ...and the thread indicator says a review is outstanding.
+        assert any(
+            a[1].get("status") == "Awaiting review…"
+            for a in slack.actions
+            if a[0] == "set_thread_status"
+        )
+        # The draft is retrievable by the requester for the button handlers.
+        keys = [k for k in h._review_drafts if k.startswith("C1|m1|")]
+        assert len(keys) == 1
+        draft, requester = h._review_drafts_get(keys[0])
+        assert requester == "U1" and "Proposed answer" in draft
+        h._review_drafts.clear()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# handle_message — voice reply opt-in
+# ──────────────────────────────────────────────────────────────────────
+_LONG_ANSWER = "This reply is comfortably longer than the fifty-character voice threshold."
+
+
+def _voice_on(monkeypatch, **fields):
+    vc = h._VoiceConfig(**fields)
+    monkeypatch.setattr(h, "_vc", vc)
+    return vc
+
+
+class TestVoiceReply:
+    @pytest.mark.asyncio
+    async def test_missing_tts_backend_warns_the_opted_in_user(self, monkeypatch):
+        _voice_on(monkeypatch, global_enabled=True, provider="piper")
+        monkeypatch.setattr(h, "_tts_available", lambda **kw: False)
+        slack = MockSlackClient()
+        provider = FakeProvider([AcpEvent(kind=EVENT_TEXT_CHUNK, text=_LONG_ANSWER)])
+        await handle_message(slack, FakeSessions(provider), "C1", "go", None, "m1", "U1")
+
+        eph = [a[1]["text"] for a in slack.actions if a[0] == "ephemeral"]
+        assert len(eph) == 1
+        assert "provider=piper" in eph[0]
+        # piper-specific remediation, not the Polly one.
+        assert "piper_model" in eph[0]
+        assert "ada credentials" not in eph[0]
+
+    @pytest.mark.asyncio
+    async def test_voice_memo_gets_the_voice_in_voice_out_notice(self, monkeypatch):
+        _voice_on(monkeypatch, auto_reply_to_voice=True, provider="polly")
+        monkeypatch.setattr(h, "_tts_available", lambda **kw: False)
+        slack = MockSlackClient()
+        provider = FakeProvider([AcpEvent(kind=EVENT_TEXT_CHUNK, text=_LONG_ANSWER)])
+        await handle_message(
+            slack, FakeSessions(provider), "C1", "go", None, "m1", "U1", had_voice_input=True
+        )
+        eph = [a[1]["text"] for a in slack.actions if a[0] == "ephemeral"]
+        assert len(eph) == 1
+        assert "Received your voice memo" in eph[0]
+        assert "ada credentials" in eph[0]
+
+    @pytest.mark.asyncio
+    async def test_available_backend_synthesises_with_per_thread_overrides(self, monkeypatch):
+        vc = _voice_on(monkeypatch, provider="polly")
+        vc.sessions.add("m1")
+        vc.voices["m1"] = "Joanna"
+        vc.engines["m1"] = "neural"
+        monkeypatch.setattr(h, "_tts_available", lambda **kw: True)
+        seen: list[dict] = []
+
+        async def _fake_voice(slack_, channel, reply_ts, text, **kw):
+            seen.append({"text": text, **kw})
+
+        monkeypatch.setattr(h, "_safe_voice_reply", _fake_voice)
+        slack = MockSlackClient()
+        provider = FakeProvider([AcpEvent(kind=EVENT_TEXT_CHUNK, text=_LONG_ANSWER)])
+        await handle_message(slack, FakeSessions(provider), "C1", "go", None, "m1", "U1")
+        await asyncio.sleep(0)  # let the fire-and-forget task run
+
+        assert len(seen) == 1
+        assert seen[0]["voice_id"] == "Joanna"
+        assert seen[0]["engine"] == "neural"
+        assert not [a for a in slack.actions if a[0] == "ephemeral"]
+
+    @pytest.mark.asyncio
+    async def test_short_answer_is_not_spoken(self, monkeypatch):
+        _voice_on(monkeypatch, global_enabled=True)
+        monkeypatch.setattr(h, "_tts_available", lambda **kw: False)
+        slack = MockSlackClient()
+        provider = FakeProvider([AcpEvent(kind=EVENT_TEXT_CHUNK, text="short")])
+        await handle_message(slack, FakeSessions(provider), "C1", "go", None, "m1", "U1")
+        assert not [a for a in slack.actions if a[0] == "ephemeral"]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# maybe_route_linked_thread — hand-off into a linked dashboard slot
+# ──────────────────────────────────────────────────────────────────────
+class _Slot:
+    def __init__(self, running=False):
+        self.key = "slot-1"
+        self.running = running
+        self.task = None
+        self.appended: list[tuple[str, str]] = []
+        self.queued: list[str] = []
+
+    def append(self, role, text, cls):
+        self.appended.append((role, text))
+
+    def queue_append(self, text):
+        self.queued.append(text)
+
+
+class _DashState:
+    def __init__(self, slot):
+        self._slot = slot
+        self._background_tasks: set = set()
+        self.broadcasts: list[tuple[str, dict]] = []
+        self.slot_pushes = 0
+
+    def get_linked_slot(self, thread_ts):
+        return self._slot
+
+    def broadcast_ws(self, event, payload):
+        self.broadcasts.append((event, payload))
+
+    def push_slots_update(self):
+        self.slot_pushes += 1
+
+
+class TestLinkedThreadRouting:
+    @pytest.mark.asyncio
+    async def test_idle_slot_starts_a_dashboard_turn(self, monkeypatch, owner):
+        import kiro_crew.dashboard.chat as chat_mod
+
+        ran: list[str] = []
+
+        async def _fake_run_chat(state, slot, text):
+            ran.append(text)
+
+        monkeypatch.setattr(chat_mod, "_run_chat", _fake_run_chat)
+        slot = _Slot(running=False)
+        state = _DashState(slot)
+        monkeypatch.setattr(h, "_dashboard_state", state, raising=False)
+
+        handled = await h.maybe_route_linked_thread(
+            "check the build", "slack:t1", owner, "C1", MockSlackClient(), "t1"
+        )
+        assert handled is True
+        # The task is created, registered for cancellation, and tracked on the slot.
+        assert slot.task is not None
+        assert slot.task in state._background_tasks
+        await slot.task
+        assert ran == ["check the build"]
+        assert slot.queued == []
+        assert state.slot_pushes == 1
+        assert slot.appended == [("user", "check the build")]
+
+    @pytest.mark.asyncio
+    async def test_busy_slot_queues_instead_of_racing(self, monkeypatch, owner):
+        slot = _Slot(running=True)
+        state = _DashState(slot)
+        monkeypatch.setattr(h, "_dashboard_state", state, raising=False)
+
+        handled = await h.maybe_route_linked_thread(
+            "second message", "slack:t1", owner, "C1", MockSlackClient(), "t1"
+        )
+        assert handled is True
+        assert slot.queued == ["second message"]
+        assert slot.task is None
+
+    @pytest.mark.asyncio
+    async def test_bang_command_falls_through_to_normal_handling(self, monkeypatch, owner):
+        slot = _Slot()
+        monkeypatch.setattr(h, "_dashboard_state", _DashState(slot), raising=False)
+        # `!stop` must reach the Slack handler even in a linked thread — it is
+        # how the user halts the turn.
+        handled = await h.maybe_route_linked_thread(
+            "!stop", "slack:t1", owner, "C1", MockSlackClient(), "t1"
+        )
+        assert handled is False
+        assert slot.appended == []
+
+    @pytest.mark.asyncio
+    async def test_unauthorised_user_is_denied_not_routed(self, monkeypatch):
+        monkeypatch.setattr(h, "_owner_id", "U_OWNER")
+        slot = _Slot()
+        monkeypatch.setattr(h, "_dashboard_state", _DashState(slot), raising=False)
+        slack = MockSlackClient()
+        handled = await h.maybe_route_linked_thread(
+            "leak the secrets", "slack:t1", "U_INTRUDER", "C1", slack, "t1"
+        )
+        assert handled is True
+        assert slot.appended == [] and slot.queued == []
+        assert "Not authorized." in _all_text(slack)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# StatusReactionController — stall watchdog upgrade path
+# ──────────────────────────────────────────────────────────────────────
+class TestStallWatchdog:
+    @pytest.mark.asyncio
+    async def test_soft_then_hard_stall_emoji_replaces_not_stacks(self, monkeypatch):
+        monkeypatch.setattr(h, "_STALL_SOFT_SECS", 0.001)
+        monkeypatch.setattr(h, "_STALL_HARD_SECS", 0.005)
+        slack = MockSlackClient()
+        ctrl = h.StatusReactionController(slack, "C1", "m1")
+        ctrl.on_progress()
+        await asyncio.sleep(0.05)
+        reacts = [a[1]["emoji"] for a in slack.actions if a[0] == "react"]
+        unreacts = [a[1]["emoji"] for a in slack.actions if a[0] == "unreact"]
+        assert h._STALL_EMOJI_SOFT in reacts
+        assert h._STALL_EMOJI_HARD in reacts
+        # Upgrading to the hard emoji removes the soft one.
+        assert h._STALL_EMOJI_SOFT in unreacts
+        ctrl.finalize()
+        await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_paused_watchdog_adds_nothing(self, monkeypatch):
+        monkeypatch.setattr(h, "_STALL_SOFT_SECS", 0.001)
+        monkeypatch.setattr(h, "_STALL_HARD_SECS", 0.005)
+        slack = MockSlackClient()
+        ctrl = h.StatusReactionController(slack, "C1", "m1")
+        ctrl.on_progress()
+        ctrl.pause_stall_watchdog()
+        await asyncio.sleep(0.05)
+        reacts = [a[1]["emoji"] for a in slack.actions if a[0] == "react"]
+        assert h._STALL_EMOJI_SOFT not in reacts
+        assert h._STALL_EMOJI_HARD not in reacts
+        ctrl.finalize()
+        await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_disabled_controller_never_calls_slack(self):
+        slack = MockSlackClient()
+        ctrl = h.StatusReactionController(slack, "C1", "m1", enabled=False)
+        ctrl.set_phase("queued")
+        ctrl.on_progress()
+        ctrl.resume_stall_watchdog()
+        ctrl.finalize()
+        await asyncio.sleep(0.01)
+        assert slack.actions == []

--- a/test/test_spec_builder_routes_coverage.py
+++ b/test/test_spec_builder_routes_coverage.py
@@ -1,0 +1,4382 @@
+"""Coverage tests for Spec Builder's backend route module.
+
+``src/kiro_crew/apps/builtins/spec_builder/backend/routes.py`` had no test file at
+all: every helper and all thirteen handlers were unexercised. This file covers it
+at three levels.
+
+  * the **pure predicates and coercions** -- ``_known_status``, ``_numeric``,
+    ``_valid_name`` / ``_usable_name`` / ``_owns_slot_key``, ``_opted_in``,
+    ``_client_identity_mismatch``, ``_normalize_spec_state``. Each one is the
+    single place a bound, an allowlist or a fail-closed default lives, and a
+    deleted bound is invisible without a test that names the refusal.
+  * the **app-owned state files** -- settings, the spec index and the deletion
+    tombstones. All three are read back as UNTRUSTED (an agent writes into them),
+    so the shape guards are the behaviour under test: a list where an object was
+    expected, an entry missing ``spec_dir``, a credential parked in an index KEY,
+    a delete reservation abandoned by a dead process.
+  * the **filesystem chokepoints** -- ``_safe_dir``, ``_spec_file``,
+    ``_verified_spec_dir`` and the STOP-sentinel pair, which are what keep a
+    symlink planted inside a spec directory from redirecting a read or a write.
+
+Nothing here spawns a process or touches a network: ``_git`` is exercised with
+``_prepare_git_spawn`` and ``create_subprocess_limited`` replaced, so neither the
+OS sandbox nor a real ``git`` binary is required (a GitHub runner has neither the
+sandbox backend nor this desk's paths). Every write lands under ``tmp_path`` or
+the per-test ``KIROCREW_HOME`` that ``conftest.py`` pins.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from conftest import requires_symlinks
+from kiro_crew.apps.builtins.spec_builder.backend import routes as r
+
+# A name that satisfies _NAME_RE yet does NOT survive _redact -- the exact shape
+# _usable_name exists to reject (a description can slugify into one).
+CRED_NAME = "ghp_" + "a" * 36
+
+
+@pytest.fixture(autouse=True)
+def _pin_state_dir(tmp_path: Path):
+    """Point the app's three state files at tmp_path, and clear module globals.
+
+    ``_SLOT_KEYS`` is process-global and rebuilt from every index read, so a key
+    left behind by one test would make ``_slot_key`` resolve another test's spec.
+    """
+    state = tmp_path / "app-state"
+    saved = dict(r._SLOT_KEYS)
+    with (
+        mock.patch.object(r, "_STATE_DIR", state),
+        mock.patch.object(r, "_INDEX_PATH", state / "index.json"),
+        mock.patch.object(r, "_DELETED_PATH", state / "deleted.json"),
+        mock.patch.object(r, "_SETTINGS_PATH", state / "settings.json"),
+    ):
+        r._SLOT_KEYS.clear()
+        yield state
+    r._SLOT_KEYS.clear()
+    r._SLOT_KEYS.update(saved)
+
+
+@pytest.fixture(autouse=True)
+def _quiet_sel():
+    """A stub SEL so audits are observable and ``_audit_tool`` reports success.
+
+    Left as the real object, ``_audit_tool(critical=True)`` would do a synchronous
+    HMAC log write on every ``_git`` call; set to ``None`` it would return False
+    and make ``_git`` fail closed in every test. A stub keeps both honest.
+    """
+    log = mock.MagicMock()
+    with mock.patch.object(r, "sel", lambda: log):
+        yield log
+
+
+def _write_index(entries: dict) -> None:
+    r._index_path().parent.mkdir(parents=True, exist_ok=True)
+    r._index_path().write_text(json.dumps(entries))
+
+
+def _entry(spec_dir: Path, **over) -> dict:
+    base = {
+        "working_dir": str(spec_dir.parent),
+        "spec_dir": str(spec_dir),
+        "spec_type": "feature",
+        "status": "planning",
+        "slot_key": "spec-builder-demo-0123abcd",
+        "created_at": 100.0,
+        "updated_at": 200.0,
+    }
+    base.update(over)
+    return base
+
+
+# -- pure predicates and coercions -------------------------------------------
+
+
+class TestKnownStatus:
+    """index.json is agent-writable, so the stored status is untrusted: an
+    unrecognised one is REPORTED as planning rather than echoed back."""
+
+    @pytest.mark.parametrize("value", ["planning", "executing"])
+    def test_recognised_statuses_pass_through(self, value):
+        assert r._known_status(value) == value
+
+    @pytest.mark.parametrize("value", ["", None, 0, "EXECUTING", "deleted", ["executing"]])
+    def test_anything_else_reads_as_planning(self, value):
+        assert r._known_status(value) == "planning"
+
+
+class TestNumeric:
+    def test_numbers_survive(self):
+        assert r._numeric(12.5) == 12.5
+        assert r._numeric("7") == 7.0
+
+    @pytest.mark.parametrize("value", [None, "later", [], {}, object()])
+    def test_non_numbers_become_zero(self, value):
+        assert r._numeric(value) == 0.0
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_nan_and_infinities_become_zero(self, value):
+        # float() accepts these and json.dumps writes them as bare NaN/Infinity,
+        # which is not JSON -- one poisoned timestamp would break the whole list.
+        assert r._numeric(value) == 0.0
+        json.dumps({"t": r._numeric(value)})
+
+
+class TestNames:
+    @pytest.mark.parametrize("name", ["a", "demo", "my-spec_1", "A" * 64])
+    def test_grammar_accepts(self, name):
+        assert r._valid_name(name)
+
+    @pytest.mark.parametrize(
+        "name", ["", "-lead", "_lead", "has space", "dot.name", "sl/ash", "..", "A" * 65]
+    )
+    def test_grammar_refuses(self, name):
+        assert not r._valid_name(name)
+
+    def test_a_credential_shaped_name_passes_the_grammar_but_is_not_usable(self):
+        # _usable_name is the admission predicate _load_index applies, so a name
+        # that _redact would rewrite must be refused BEFORE it is stored --
+        # otherwise the next load drops the entry it was just written into.
+        assert r._valid_name(CRED_NAME)
+        assert r._redact(CRED_NAME) != CRED_NAME
+        assert not r._usable_name(CRED_NAME)
+
+
+class TestOwnsSlotKey:
+    def test_the_legacy_name_derived_key_is_owned(self):
+        assert r._owns_slot_key("demo", "spec-builder-demo")
+
+    def test_a_per_creation_key_is_owned(self):
+        assert r._owns_slot_key("demo", "spec-builder-demo-0123abcd")
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "spec-builder-other-0123abcd",  # another spec's key
+            "spec-builder-demo-0123abc",  # 7 hex, not 8
+            "spec-builder-demo-0123ABCD",  # uppercase suffix
+            "spec-builder-demo-zzzzzzzz",  # not hex
+            "spec-builder-demo-",  # empty suffix
+            "demo",  # no prefix
+        ],
+    )
+    def test_foreign_or_malformed_keys_are_not_owned(self, key):
+        assert not r._owns_slot_key("demo", key)
+
+    def test_an_unusable_name_owns_nothing(self):
+        assert not r._owns_slot_key("has space", "spec-builder-has space")
+
+
+class TestSlotKeyResolution:
+    def test_falls_back_to_the_name_derived_key(self):
+        assert r._slot_key("demo") == "spec-builder-demo"
+
+    def test_prefers_the_persisted_key(self):
+        r._SLOT_KEYS["demo"] = "spec-builder-demo-0123abcd"
+        assert r._slot_key("demo") == "spec-builder-demo-0123abcd"
+
+    def test_a_persisted_key_that_fails_the_grammar_is_ignored(self):
+        r._SLOT_KEYS["demo"] = "not-a-slot-key"
+        assert r._slot_key("demo") == "spec-builder-demo"
+
+    def test_new_slot_key_is_unique_and_owned(self):
+        first, second = r._new_slot_key("demo"), r._new_slot_key("demo")
+        assert first != second
+        assert r._owns_slot_key("demo", first)
+
+
+class TestRedact:
+    def test_non_strings_and_empties_come_back_as_empty_strings(self):
+        assert r._redact(None) == ""  # type: ignore[arg-type]
+        assert r._redact("") == ""
+
+    def test_a_credential_is_scrubbed(self):
+        assert CRED_NAME not in r._redact(f"use {CRED_NAME} to auth")
+
+    def test_it_fails_closed_when_the_security_module_is_missing(self):
+        # Everything through _redact is agent- or user-authored on its way to the
+        # browser, so with no way to scrub it the text must be WITHHELD, not served.
+        with mock.patch.object(r, "_HAS_SECURITY", False):
+            assert r._redact("plain text") == r._UNSCRUBBABLE
+
+
+class TestOptedIn:
+    def test_only_the_json_true_opts_in(self):
+        assert r._opted_in({"use_worktree": True}, "use_worktree")
+
+    @pytest.mark.parametrize("value", ["true", "false", 1, "1", [1], {"a": 1}, "0"])
+    def test_truthy_non_booleans_do_not_opt_in(self, value):
+        # Both flags this guards cause side effects a caller cannot undo by
+        # retrying (a git worktree; adopting documents already on disk).
+        assert not r._opted_in({"use_worktree": value}, "use_worktree")
+
+    def test_a_missing_field_does_not_opt_in(self):
+        assert not r._opted_in({}, "import_existing")
+
+
+class TestClientIdentityMismatch:
+    def test_an_unpinned_claim_never_mismatches(self):
+        claim = r._ClientClaim("", "")
+        assert not r._client_identity_mismatch(claim, "/spec", "spec-builder-demo-0123abcd")
+
+    def test_a_different_directory_mismatches(self):
+        claim = r._ClientClaim("/other", "")
+        assert r._client_identity_mismatch(claim, "/spec", "spec-builder-demo-0123abcd")
+
+    def test_a_different_slot_key_mismatches_even_on_the_same_directory(self):
+        # Two specs CAN share a directory across a delete + re-import; they can
+        # never share a per-creation slot key. That is what makes it decisive.
+        claim = r._ClientClaim("/spec", "spec-builder-demo-ffffffff")
+        assert r._client_identity_mismatch(claim, "/spec", "spec-builder-demo-0123abcd")
+
+    def test_a_claimed_key_against_no_actual_key_is_not_compared(self):
+        claim = r._ClientClaim("/spec", "spec-builder-demo-ffffffff")
+        assert not r._client_identity_mismatch(claim, "/spec", "")
+
+
+class TestNormalizeSpecState:
+    """``.spec-state.json`` is LLM output, so every field is treated as hostile."""
+
+    @pytest.mark.parametrize("raw", [None, [], "text", 3])
+    def test_a_non_object_payload_is_rejected_outright(self, raw):
+        assert r._normalize_spec_state(raw) is None
+
+    def test_unknown_keys_are_dropped_and_the_schema_is_always_complete(self):
+        out = r._normalize_spec_state({"surprise": "x"})
+        assert out == {"decisions": [], "blocking": "", "context": {"template": ""}}
+
+    def test_a_well_formed_decision_is_projected(self):
+        out = r._normalize_spec_state(
+            {
+                "decisions": [
+                    {
+                        "id": "d1",
+                        "title": "Which store?",
+                        "options": ["A", "B", 7, ""],
+                        "recommended": "A",
+                        "answer": None,
+                    }
+                ],
+                "blocking": "waiting on review",
+                "context": {"template": "issue_radar"},
+            }
+        )
+        assert out is not None
+        assert out["decisions"] == [
+            {
+                "id": "d1",
+                "title": "Which store?",
+                # non-strings and empties dropped, not coerced
+                "options": ["A", "B"],
+                "recommended": "A",
+                "answer": "",
+            }
+        ]
+        assert out["blocking"] == "waiting on review"
+        assert out["context"] == {"template": "issue_radar"}
+
+    @pytest.mark.parametrize(
+        "decisions",
+        [
+            [None],  # crashed SpecStatePanel before it was dropped here
+            ["a string"],
+            [{"title": ""}],  # no id and no title
+            [{"id": "d1"}],  # no title
+        ],
+    )
+    def test_malformed_decisions_are_dropped(self, decisions):
+        out = r._normalize_spec_state({"decisions": decisions})
+        assert out is not None and out["decisions"] == []
+
+    def test_a_decision_without_an_id_falls_back_to_its_title(self):
+        out = r._normalize_spec_state({"decisions": [{"title": "Which store?"}]})
+        assert out is not None and out["decisions"][0]["id"] == "Which store?"
+
+    def test_lists_are_capped(self):
+        out = r._normalize_spec_state(
+            {
+                "decisions": [
+                    {"id": f"d{i}", "title": "t", "options": ["o"] * (r._MAX_OPTIONS + 5)}
+                    for i in range(r._MAX_DECISIONS + 10)
+                ]
+            }
+        )
+        assert out is not None
+        assert len(out["decisions"]) == r._MAX_DECISIONS
+        assert len(out["decisions"][0]["options"]) == r._MAX_OPTIONS
+
+    def test_fields_are_length_capped(self):
+        out = r._normalize_spec_state({"blocking": "x" * (r._MAX_FIELD + 50)})
+        assert out is not None and len(out["blocking"]) == r._MAX_FIELD
+
+    def test_a_non_object_context_yields_an_empty_template(self):
+        out = r._normalize_spec_state({"context": "issue_radar"})
+        assert out is not None and out["context"] == {"template": ""}
+
+    def test_a_credential_in_a_value_is_scrubbed(self):
+        out = r._normalize_spec_state({"blocking": f"waiting on {CRED_NAME}"})
+        assert out is not None and CRED_NAME not in out["blocking"]
+
+
+class TestCleanStr:
+    def test_non_strings_become_empty(self):
+        for value in (None, 5, [], {}):
+            assert r._clean_str(value) == ""
+
+
+# -- settings store -----------------------------------------------------------
+
+
+class TestSettingsStore:
+    def test_a_missing_file_reads_as_the_default(self):
+        assert r._load_settings() == {"base_path": ""}
+
+    @pytest.mark.parametrize("text", ["not json", "[1, 2]", "null", '"a string"'])
+    def test_a_malformed_or_wrongly_shaped_file_reads_as_the_default(self, text):
+        r._settings_path().parent.mkdir(parents=True, exist_ok=True)
+        r._settings_path().write_text(text)
+        assert r._load_settings() == {"base_path": ""}
+
+    def test_a_non_string_base_path_is_normalized_at_the_read_chokepoint(self):
+        # {"base_path": []} is a dict, so an outer-shape-only guard passed it and
+        # every reader then called .strip() on a list -- a 500 on spec creation.
+        r._settings_path().parent.mkdir(parents=True, exist_ok=True)
+        r._settings_path().write_text(json.dumps({"base_path": [], "other": 1}))
+        assert r._load_settings() == {"base_path": "", "other": 1}
+
+    def test_save_then_load_round_trips_and_creates_the_state_dir(self, tmp_path):
+        r._save_settings({"base_path": str(tmp_path)})
+        assert r._load_settings()["base_path"] == str(tmp_path)
+
+
+# -- deletion tombstones ------------------------------------------------------
+
+
+class TestTombstones:
+    def test_a_missing_file_is_an_empty_list(self):
+        assert r._load_deleted() == []
+
+    @pytest.mark.parametrize("text", ["not json", '{"a": 1}', "null"])
+    def test_a_malformed_or_wrongly_shaped_file_is_an_empty_list(self, text):
+        r._deleted_path().parent.mkdir(parents=True, exist_ok=True)
+        r._deleted_path().write_text(text)
+        assert r._load_deleted() == []
+
+    def test_non_string_and_blank_entries_are_discarded(self):
+        r._deleted_path().parent.mkdir(parents=True, exist_ok=True)
+        r._deleted_path().write_text(json.dumps(["/a", 7, None, "   ", "/b"]))
+        assert r._load_deleted() == ["/a", "/b"]
+
+    def test_remembering_appends_and_dedupes_keeping_the_newest_position(self):
+        r._remember_deleted("/a")
+        r._remember_deleted("/b")
+        r._remember_deleted("/a")
+        assert r._load_deleted() == ["/b", "/a"]
+
+    def test_an_empty_directory_is_not_remembered(self):
+        r._remember_deleted("")
+        assert not r._deleted_path().exists()
+
+    def test_the_file_is_bounded_so_it_cannot_grow_without_limit(self):
+        r._deleted_path().parent.mkdir(parents=True, exist_ok=True)
+        r._deleted_path().write_text(json.dumps([f"/d{i}" for i in range(r._MAX_TOMBSTONES + 20)]))
+        r._remember_deleted("/newest")
+        current = r._load_deleted()
+        assert len(current) == r._MAX_TOMBSTONES
+        assert current[-1] == "/newest"
+
+    def test_forgetting_removes_only_the_named_directory(self):
+        r._remember_deleted("/a")
+        r._remember_deleted("/b")
+        r._forget_deleted("/a")
+        assert r._load_deleted() == ["/b"]
+
+    def test_forgetting_an_untombstoned_directory_writes_nothing(self):
+        r._forget_deleted("/never-deleted")
+        assert not r._deleted_path().exists()
+
+    def test_forgetting_nothing_is_a_no_op(self):
+        r._forget_deleted("")
+        assert not r._deleted_path().exists()
+
+    def test_a_failed_write_is_swallowed_because_the_delete_already_committed(self):
+        with mock.patch.object(r, "atomic_write", side_effect=OSError("read-only")):
+            r._remember_deleted("/a")  # must not raise
+            r._deleted_path().parent.mkdir(parents=True, exist_ok=True)
+            r._deleted_path().write_text(json.dumps(["/a"]))
+            r._forget_deleted("/a")  # must not raise
+        assert r._load_deleted() == ["/a"]
+
+
+# -- index store --------------------------------------------------------------
+
+
+class TestIndexStore:
+    def test_a_missing_file_is_an_empty_index(self):
+        assert r._load_index() == {}
+
+    @pytest.mark.parametrize("text", ["not json", "[1]", "null"])
+    def test_a_malformed_or_wrongly_shaped_file_is_an_empty_index(self, text):
+        r._index_path().parent.mkdir(parents=True, exist_ok=True)
+        r._index_path().write_text(text)
+        assert r._load_index() == {}
+
+    def test_an_entry_missing_spec_dir_is_dropped(self, tmp_path):
+        # Handlers index meta["spec_dir"] directly, which is what turned a
+        # shapeless entry into a 500 on the whole endpoint.
+        _write_index(
+            {
+                "good": _entry(tmp_path / "good"),
+                "empty": {},
+                "blank": {"spec_dir": "   "},
+                "wrong-type": {"spec_dir": 7},
+                "not-an-object": "nope",
+            }
+        )
+        assert list(r._load_index()) == ["good"]
+
+    def test_an_entry_without_a_working_dir_still_lists(self, tmp_path):
+        # working_dir is deliberately NOT required: it is re-validated at the slot
+        # chokepoint, so such a spec lists and reads -- it just cannot be run.
+        _write_index({"demo": {"spec_dir": str(tmp_path / "demo")}})
+        assert list(r._load_index()) == ["demo"]
+
+    def test_a_key_that_fails_the_grammar_is_dropped(self, tmp_path):
+        _write_index({"has space": _entry(tmp_path / "a"), "ok": _entry(tmp_path / "b")})
+        assert list(r._load_index()) == ["ok"]
+
+    def test_a_credential_shaped_key_is_dropped_rather_than_scrubbed(self, tmp_path):
+        # GET /specs returns the key as "name"; scrubbing it would produce a name
+        # that no longer matches the directory the entry points at.
+        _write_index({CRED_NAME: _entry(tmp_path / "a"), "ok": _entry(tmp_path / "b")})
+        assert list(r._load_index()) == ["ok"]
+
+    def test_reading_rebuilds_the_slot_key_map_only_for_owned_keys(self, tmp_path):
+        _write_index(
+            {
+                "mine": _entry(tmp_path / "mine", slot_key="spec-builder-mine-0123abcd"),
+                "stolen": _entry(tmp_path / "stolen", slot_key="spec-builder-mine-0123abcd"),
+                "untyped": _entry(tmp_path / "untyped", slot_key=7),
+            }
+        )
+        r._load_index()
+        assert r._SLOT_KEYS == {"mine": "spec-builder-mine-0123abcd"}
+
+    def test_saving_also_refreshes_the_slot_key_map(self, tmp_path):
+        # Read-only refresh was not enough: a create commits through _mutate_index,
+        # whose re-read rebuilt the map from the PRE-insert snapshot.
+        r._save_index({"demo": _entry(tmp_path / "demo", slot_key="spec-builder-demo-abcdef01")})
+        assert r._SLOT_KEYS["demo"] == "spec-builder-demo-abcdef01"
+
+    def test_a_reservation_left_by_a_dead_process_is_released_on_read(self, tmp_path):
+        _write_index(
+            {"demo": _entry(tmp_path / "demo", deleting={"owner": "999:deadbeef", "at": 1.0})}
+        )
+        assert r._DELETING not in r._load_index()["demo"]
+
+    def test_a_pre_existing_bare_timestamp_reservation_reads_as_foreign(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo", deleting=1.0)})
+        assert r._DELETING not in r._load_index()["demo"]
+
+    def test_a_reservation_this_process_still_owns_is_left_alone(self, tmp_path):
+        # This is what keeps an in-flight delete's own concurrent reads from
+        # cancelling its reservation underneath it.
+        _write_index(
+            {"demo": _entry(tmp_path / "demo", deleting={"owner": r._PROCESS_ID, "at": 1.0})}
+        )
+        assert r._load_index()["demo"][r._DELETING]["owner"] == r._PROCESS_ID
+
+    def test_reservation_is_ours_needs_a_mapping_with_our_owner(self):
+        assert r._reservation_is_ours({r._DELETING: {"owner": r._PROCESS_ID}})
+        assert not r._reservation_is_ours({r._DELETING: {"owner": "1:other"}})
+        assert not r._reservation_is_ours({r._DELETING: 12.0})
+        assert not r._reservation_is_ours({})
+
+    def test_the_process_id_carries_more_than_a_reusable_pid(self):
+        pid, _, unique = r._PROCESS_ID.partition(":")
+        assert pid == str(os.getpid())
+        assert len(unique) == 32
+
+
+# -- path resolution ----------------------------------------------------------
+
+
+class TestSafeDir:
+    @pytest.mark.parametrize("raw", ["", "   "])
+    def test_an_empty_value_is_unusable(self, raw):
+        assert r._safe_dir(raw) is None
+
+    def test_a_relative_path_is_refused_before_realpath_makes_it_absolute(self, tmp_path):
+        # realpath resolves a relative value against the gateway's own cwd and
+        # always returns an absolute path, so testing afterwards can never fail.
+        assert r._safe_dir(".") is None
+        assert r._safe_dir("relative/dir") is None
+
+    def test_an_existing_directory_comes_back_fully_resolved(self, tmp_path):
+        assert r._safe_dir(str(tmp_path)) == Path(os.path.realpath(tmp_path))
+
+    def test_a_missing_directory_is_unusable_by_default(self, tmp_path):
+        assert r._safe_dir(str(tmp_path / "nope")) is None
+
+    def test_a_file_is_not_a_directory(self, tmp_path):
+        target = tmp_path / "f.txt"
+        target.write_text("x")
+        assert r._safe_dir(str(target)) is None
+
+    def test_a_sensitive_location_is_refused(self, tmp_path):
+        with mock.patch.object(r, "is_sensitive_path", return_value=True):
+            assert r._safe_dir(str(tmp_path)) is None
+
+    def test_must_exist_false_accepts_a_destination_the_app_will_create(self, tmp_path):
+        dest = tmp_path / "a" / "b" / "c"
+        assert r._safe_dir(str(dest), must_exist=False) == Path(os.path.realpath(dest))
+
+    def test_must_exist_false_still_tests_the_nearest_existing_ancestor(self, tmp_path):
+        dest = tmp_path / "not-yet"
+
+        def _sensitive(path: str) -> bool:
+            return path == os.path.realpath(tmp_path)
+
+        with mock.patch.object(r, "is_sensitive_path", side_effect=_sensitive):
+            # Naming a not-yet-created subdirectory of a credential directory must
+            # not slip through on a stat miss.
+            assert r._safe_dir(str(dest), must_exist=False) is None
+
+    def test_safe_dir_optional_is_the_positional_only_form(self, tmp_path):
+        dest = tmp_path / "later"
+        assert r._safe_dir_optional(str(dest)) == r._safe_dir(str(dest), must_exist=False)
+
+    @requires_symlinks
+    def test_symlinks_are_resolved_before_the_sensitivity_test(self, tmp_path):
+        secret = tmp_path / "secret"
+        secret.mkdir()
+        link = tmp_path / "benign"
+        link.symlink_to(secret, target_is_directory=True)
+
+        def _sensitive(path: str) -> bool:
+            return path == os.path.realpath(secret)
+
+        with mock.patch.object(r, "is_sensitive_path", side_effect=_sensitive):
+            assert r._safe_dir(str(link)) is None
+
+
+class TestContained:
+    def test_a_directory_contains_itself_and_its_children(self, tmp_path):
+        assert r._contained(tmp_path, tmp_path)
+        assert r._contained(tmp_path / "a" / "b", tmp_path)
+
+    def test_a_sibling_is_not_contained(self, tmp_path):
+        assert not r._contained(tmp_path.parent / "elsewhere", tmp_path)
+
+
+class TestResolveSpecDir:
+    def test_the_default_is_the_kiro_standard_location(self, tmp_path):
+        assert r._resolve_spec_dir(str(tmp_path), "demo") == (
+            tmp_path / ".kiro" / "specs" / "demo"
+        ).resolve()
+
+    def test_an_absolute_base_path_override_stays_per_spec(self, tmp_path):
+        r._save_settings({"base_path": str(tmp_path / "store")})
+        assert r._resolve_spec_dir(str(tmp_path), "demo") == (tmp_path / "store" / "demo").resolve()
+
+
+class TestScanSubdirs:
+    def test_build_and_vcs_noise_and_hidden_entries_are_skipped(self, tmp_path):
+        for name in ("src", "docs", "node_modules", "__pycache__", "venv", "env", ".git"):
+            (tmp_path / name).mkdir()
+        (tmp_path / "a-file").write_text("x")
+        assert [d["name"] for d in r._scan_subdirs(str(tmp_path))] == ["docs", "src"]
+
+    def test_the_listing_is_bounded(self, tmp_path):
+        for i in range(r._BROWSE_MAX_DIRS + 5):
+            (tmp_path / f"d{i:04d}").mkdir()
+        assert len(r._scan_subdirs(str(tmp_path))) == r._BROWSE_MAX_DIRS
+
+    def test_a_missing_base_scans_to_nothing_rather_than_raising(self, tmp_path):
+        assert r._scan_subdirs(str(tmp_path / "gone")) == []
+
+    def test_each_entry_carries_its_full_path(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        assert r._scan_subdirs(str(tmp_path)) == [
+            {"name": "src", "path": str(tmp_path / "src")}
+        ]
+
+    @requires_symlinks
+    def test_a_link_pointing_at_a_sensitive_directory_is_not_listed(self, tmp_path):
+        secret = tmp_path / "secret"
+        secret.mkdir()
+        (tmp_path / "looks-fine").symlink_to(secret, target_is_directory=True)
+        (tmp_path / "src").mkdir()
+
+        def _sensitive(path: str) -> bool:
+            return path == os.path.realpath(secret)
+
+        with mock.patch.object(r, "is_sensitive_path", side_effect=_sensitive):
+            assert [d["name"] for d in r._scan_subdirs(str(tmp_path))] == ["src"]
+
+
+# -- spec files ---------------------------------------------------------------
+
+
+class TestSpecFile:
+    def test_a_plain_file_inside_the_spec_dir_resolves(self, tmp_path):
+        (tmp_path / "tasks.md").write_text("- [ ] one")
+        assert r._spec_file(tmp_path, "tasks.md") == tmp_path / "tasks.md"
+
+    def test_a_name_that_does_not_exist_yet_still_resolves(self, tmp_path):
+        # The write path needs a resolvable target for a file it is about to create.
+        assert r._spec_file(tmp_path, "STOP") == tmp_path / "STOP"
+
+    @requires_symlinks
+    def test_a_symlinked_spec_file_is_refused(self, tmp_path):
+        # Outside the guarded root (which is `spec`, below) but still INSIDE this
+        # test's own tmp_path, so the file dies with the test. tmp_path.parent is
+        # the shared pytest run directory -- writing there leaks files across
+        # tests and is how a scratch dir accumulates hundreds of thousands of
+        # entries until /tmp runs out of inodes.
+        outside = tmp_path / "credentials"
+        outside.write_text("secret")
+        spec = tmp_path / "spec"
+        spec.mkdir()
+        (spec / "requirements.md").symlink_to(outside)
+        assert r._spec_file(spec, "requirements.md") is None
+
+    def test_a_sensitive_target_is_refused(self, tmp_path):
+        (tmp_path / "tasks.md").write_text("x")
+        with mock.patch.object(r, "is_sensitive_path", return_value=True):
+            assert r._spec_file(tmp_path, "tasks.md") is None
+
+    def test_a_name_that_escapes_the_spec_dir_is_refused(self, tmp_path):
+        spec = tmp_path / "spec"
+        spec.mkdir()
+        assert r._spec_file(spec, os.path.join("..", "outside.md")) is None
+
+
+class TestReadSpecText:
+    def test_a_present_file_is_read(self, tmp_path):
+        (tmp_path / "tasks.md").write_text("- [x] done\n", newline="\n")
+        assert r._read_spec_text(tmp_path, "tasks.md") == "- [x] done\n"
+
+    def test_a_missing_file_is_none(self, tmp_path):
+        assert r._read_spec_text(tmp_path, "tasks.md") is None
+
+    def test_it_fails_closed_when_the_safe_reader_is_unavailable(self, tmp_path):
+        (tmp_path / "tasks.md").write_text("x")
+        with mock.patch.object(r, "safe_read_file_bytes_nolink", None):
+            assert r._read_spec_text(tmp_path, "tasks.md") is None
+
+    def test_a_raising_reader_fails_closed(self, tmp_path):
+        with mock.patch.object(
+            r, "safe_read_file_bytes_nolink", side_effect=RuntimeError("boom")
+        ):
+            assert r._read_spec_text(tmp_path, "tasks.md") is None
+
+    def test_undecodable_bytes_are_replaced_rather_than_raising(self, tmp_path):
+        (tmp_path / "tasks.md").write_bytes(b"ok \xff\xfe")
+        text = r._read_spec_text(tmp_path, "tasks.md")
+        assert text is not None and text.startswith("ok ")
+
+    def test_the_read_is_capped_at_the_documented_size(self, tmp_path):
+        reader = mock.Mock(return_value=b"x")
+        with mock.patch.object(r, "safe_read_file_bytes_nolink", reader):
+            r._read_spec_text(tmp_path, "tasks.md")
+        assert reader.call_args.kwargs["max_bytes"] == r._MAX_SPEC_BYTES
+        assert reader.call_args.kwargs["within_root"] == str(tmp_path)
+
+
+class TestDerivePhase:
+    def test_no_documents_is_the_new_phase(self, tmp_path):
+        assert r._derive_phase(tmp_path) == "new"
+
+    @pytest.mark.parametrize(
+        "files,expected",
+        [
+            (["requirements.md"], "requirements"),
+            (["requirements.md", "design.md"], "design"),
+            (["requirements.md", "design.md", "tasks.md"], "tasks"),
+            (["tasks.md"], "tasks"),
+        ],
+    )
+    def test_the_furthest_document_written_names_the_phase(self, tmp_path, files, expected):
+        for name in files:
+            (tmp_path / name).write_text("x")
+        assert r._derive_phase(tmp_path) == expected
+
+
+class TestCollectSpecDocuments:
+    def test_absent_documents_read_as_none_and_the_state_file_as_none(self, tmp_path):
+        phase, files, state = r._collect_spec_documents(tmp_path)
+        assert phase == "new"
+        assert files == {"tasks.md": None, "design.md": None, "requirements.md": None}
+        assert state is None
+
+    def test_documents_are_redacted_on_their_way_out(self, tmp_path):
+        (tmp_path / "requirements.md").write_text(f"token is {CRED_NAME}")
+        phase, files, _state = r._collect_spec_documents(tmp_path)
+        assert phase == "requirements"
+        assert files["requirements.md"] is not None
+        assert CRED_NAME not in files["requirements.md"]
+
+    def test_a_valid_state_file_is_normalized(self, tmp_path):
+        (tmp_path / ".spec-state.json").write_text(
+            json.dumps({"blocking": "review", "surprise": 1})
+        )
+        _phase, _files, state = r._collect_spec_documents(tmp_path)
+        assert state == {"decisions": [], "blocking": "review", "context": {"template": ""}}
+
+    def test_a_malformed_state_file_is_none_rather_than_an_error(self, tmp_path):
+        (tmp_path / ".spec-state.json").write_text("{ not json")
+        _phase, _files, state = r._collect_spec_documents(tmp_path)
+        assert state is None
+
+
+# -- the STOP sentinel --------------------------------------------------------
+
+
+class TestVerifiedSpecDir:
+    def test_a_directory_that_is_exactly_itself_verifies(self, tmp_path):
+        assert r._verified_spec_dir(tmp_path) == tmp_path
+
+    def test_a_relative_path_never_verifies(self):
+        assert r._verified_spec_dir(Path("spec")) is None
+
+    def test_a_missing_directory_does_not_verify(self, tmp_path):
+        assert r._verified_spec_dir(tmp_path / "gone") is None
+
+    def test_a_sensitive_directory_does_not_verify(self, tmp_path):
+        with mock.patch.object(r, "is_sensitive_path", return_value=True):
+            assert r._verified_spec_dir(tmp_path) is None
+
+    @requires_symlinks
+    def test_a_directory_replaced_by_a_symlink_does_not_verify(self, tmp_path):
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "indexed"
+        link.symlink_to(real, target_is_directory=True)
+        # realpath disagrees with the path the index recorded -> REPLACED.
+        assert r._verified_spec_dir(link) is None
+
+
+class TestStopSentinel:
+    @pytest.mark.skipif(
+        not r._CAN_PIN_DIR,
+        reason="directory pinning needs O_DIRECTORY + dir_fd, which Windows lacks",
+    )
+    def test_writing_lands_the_sentinel_in_the_verified_directory(self, tmp_path):
+        assert r._write_stop_sentinel(tmp_path) is True
+        assert (tmp_path / r._STOP_FILE).is_file()
+        # No temp file left behind.
+        assert [p.name for p in tmp_path.iterdir()] == [r._STOP_FILE]
+
+    @pytest.mark.skipif(
+        not r._CAN_PIN_DIR,
+        reason="directory pinning needs O_DIRECTORY + dir_fd, which Windows lacks",
+    )
+    @requires_symlinks
+    def test_a_planted_stop_symlink_is_destroyed_rather_than_written_through(self, tmp_path):
+        # Outside `spec` but inside this test's tmp_path -- see the note on
+        # _spec_file's symlink test about not writing to tmp_path.parent.
+        elsewhere = tmp_path / "victim"
+        elsewhere.write_text("original")
+        spec = tmp_path / "spec"
+        spec.mkdir()
+        (spec / r._STOP_FILE).symlink_to(elsewhere)
+        assert r._write_stop_sentinel(spec) is True
+        assert not (spec / r._STOP_FILE).is_symlink()
+        assert elsewhere.read_text() == "original"
+
+    def test_writing_refuses_a_directory_that_does_not_verify(self, tmp_path):
+        assert r._write_stop_sentinel(tmp_path / "gone") is False
+
+    def test_without_pinning_the_write_fails_closed(self, tmp_path):
+        # A path-based write can be redirected into ANOTHER spec by a directory
+        # swapped underneath it, so no sentinel is better than the wrong one.
+        with mock.patch.object(r, "_CAN_PIN_DIR", False):
+            assert r._write_stop_sentinel(tmp_path) is False
+        assert not (tmp_path / r._STOP_FILE).exists()
+
+    @pytest.mark.skipif(
+        not r._CAN_PIN_DIR,
+        reason="directory pinning needs O_DIRECTORY + dir_fd, which Windows lacks",
+    )
+    def test_clearing_removes_our_own_stale_sentinel(self, tmp_path):
+        (tmp_path / r._STOP_FILE).write_text("1")
+        r._clear_stop_sentinel(tmp_path)
+        assert not (tmp_path / r._STOP_FILE).exists()
+
+    def test_clearing_an_absent_sentinel_is_a_no_op(self, tmp_path):
+        r._clear_stop_sentinel(tmp_path)  # must not raise
+
+    def test_clearing_refuses_a_directory_that_does_not_verify(self, tmp_path):
+        marker = tmp_path / r._STOP_FILE
+        marker.write_text("1")
+        with mock.patch.object(r, "_verified_spec_dir", return_value=None):
+            r._clear_stop_sentinel(tmp_path)
+        assert marker.exists()
+
+    def test_without_pinning_clearing_does_nothing(self, tmp_path):
+        marker = tmp_path / r._STOP_FILE
+        marker.write_text("1")
+        with mock.patch.object(r, "_CAN_PIN_DIR", False):
+            r._clear_stop_sentinel(tmp_path)
+        assert marker.exists()
+
+    @pytest.mark.skipif(
+        not r._CAN_PIN_DIR,
+        reason="directory pinning needs O_DIRECTORY + dir_fd, which Windows lacks",
+    )
+    def test_arming_clears_a_stale_sentinel_and_returns_its_path(self, tmp_path):
+        (tmp_path / r._STOP_FILE).write_text("1")
+        assert r._arm_stop_sentinel(tmp_path) == str(tmp_path / r._STOP_FILE)
+        assert not (tmp_path / r._STOP_FILE).exists()
+
+    def test_arming_returns_an_empty_string_when_the_directory_fails_verification(self, tmp_path):
+        assert r._arm_stop_sentinel(tmp_path / "gone") == ""
+
+
+class TestStopSentinelIdentityGate:
+    def test_a_caller_with_no_identity_still_gets_the_plain_write(self, tmp_path):
+        with mock.patch.object(r, "_write_stop_sentinel", return_value=True) as write:
+            assert r._write_stop_sentinel_for_spec(tmp_path) is True
+        write.assert_called_once_with(tmp_path)
+
+    def test_a_matching_identity_is_written(self, tmp_path):
+        key = "spec-builder-demo-0123abcd"
+        _write_index({"demo": _entry(tmp_path, slot_key=key)})
+        with mock.patch.object(r, "_write_stop_sentinel", return_value=True):
+            assert r._write_stop_sentinel_for_spec(tmp_path, "demo", key) is True
+
+    def test_a_replacement_creation_is_refused(self, tmp_path):
+        # A same-name delete + re-import between the caller's check and this write
+        # would otherwise halt a run the user has only just started.
+        _write_index({"demo": _entry(tmp_path, slot_key="spec-builder-demo-ffffffff")})
+        with mock.patch.object(r, "_write_stop_sentinel", return_value=True) as write:
+            assert (
+                r._write_stop_sentinel_for_spec(tmp_path, "demo", "spec-builder-demo-0123abcd")
+                is False
+            )
+        write.assert_not_called()
+
+
+class TestPrepareHandoff:
+    def test_an_unverifiable_spec_dir_is_not_ready(self, tmp_path):
+        assert r._prepare_handoff(tmp_path / "gone") == (False, "")
+
+    def test_a_replacement_creation_is_refused_before_the_sentinel_is_touched(self, tmp_path):
+        marker = tmp_path / r._STOP_FILE
+        marker.write_text("1")
+        _write_index({"demo": _entry(tmp_path, slot_key="spec-builder-demo-ffffffff")})
+        assert r._prepare_handoff(tmp_path, "demo", "spec-builder-demo-0123abcd") == (False, "")
+        # Arming is destructive -- it removes the STOP a Pause wrote.
+        assert marker.exists()
+
+    @pytest.mark.skipif(
+        not r._CAN_PIN_DIR,
+        reason="directory pinning needs O_DIRECTORY + dir_fd, which Windows lacks",
+    )
+    def test_a_missing_tasks_file_is_not_ready_but_still_arms(self, tmp_path):
+        ready, sentinel = r._prepare_handoff(tmp_path)
+        assert ready is False
+        assert sentinel == str(tmp_path / r._STOP_FILE)
+
+    @pytest.mark.skipif(
+        not r._CAN_PIN_DIR,
+        reason="directory pinning needs O_DIRECTORY + dir_fd, which Windows lacks",
+    )
+    def test_a_real_tasks_file_is_ready(self, tmp_path):
+        (tmp_path / "tasks.md").write_text("- [ ] one")
+        assert r._prepare_handoff(tmp_path) == (True, str(tmp_path / r._STOP_FILE))
+
+    @pytest.mark.skipif(
+        not r._CAN_PIN_DIR,
+        reason="directory pinning needs O_DIRECTORY + dir_fd, which Windows lacks",
+    )
+    @requires_symlinks
+    def test_a_symlinked_tasks_file_does_not_satisfy_the_gate(self, tmp_path):
+        # Outside `spec` but inside this test's tmp_path -- see the note on
+        # _spec_file's symlink test about not writing to tmp_path.parent.
+        outside = tmp_path / "other-tasks.md"
+        outside.write_text("- [ ] not ours")
+        spec = tmp_path / "spec"
+        spec.mkdir()
+        (spec / "tasks.md").symlink_to(outside)
+        # is_file() FOLLOWS the link, so the gate used to pass and the autonomous
+        # run then edited a file outside the spec directory.
+        ready, _sentinel = r._prepare_handoff(spec)
+        assert ready is False
+
+
+# -- prompts ------------------------------------------------------------------
+
+
+class TestSeedPrompt:
+    def test_a_feature_spec_asks_for_all_three_documents(self, tmp_path):
+        text = r._seed_prompt("feature", "demo", tmp_path, str(tmp_path.parent), "")
+        for fname in ("requirements.md", "design.md", "tasks.md"):
+            assert str(tmp_path / fname) in text
+        assert "FEATURE spec" in text
+
+    def test_a_quick_spec_deliberately_skips_design(self, tmp_path):
+        text = r._seed_prompt("quick", "demo", tmp_path, str(tmp_path.parent), "")
+        assert str(tmp_path / "design.md") not in text
+        assert "Do NOT write design.md" in text
+
+    def test_an_unknown_type_falls_back_to_the_feature_plan(self, tmp_path):
+        text = r._seed_prompt("nonsense", "demo", tmp_path, str(tmp_path.parent), "")
+        assert "FEATURE spec" in text
+        assert str(tmp_path / "design.md") in text
+
+    def test_the_description_is_appended_only_when_it_has_content(self, tmp_path):
+        assert "initial description" not in r._seed_prompt(
+            "bug", "demo", tmp_path, str(tmp_path.parent), "   "
+        )
+        assert "flaky on retry" in r._seed_prompt(
+            "bug", "demo", tmp_path, str(tmp_path.parent), " flaky on retry "
+        )
+
+    def test_it_begins_with_the_first_deliverable_for_the_type(self, tmp_path):
+        text = r._seed_prompt("quick", "demo", tmp_path, str(tmp_path.parent), "")
+        assert "Begin with requirements.md" in text
+
+    def test_the_state_file_is_named_as_plumbing_not_a_deliverable(self, tmp_path):
+        text = r._seed_prompt("feature", "demo", tmp_path, str(tmp_path.parent), "")
+        assert str(tmp_path / ".spec-state.json") in text
+
+
+class TestExecPrompt:
+    def test_it_names_the_tasks_file_and_the_working_dir(self, tmp_path):
+        text = r._exec_prompt("demo", tmp_path, str(tmp_path.parent))
+        assert str(tmp_path / "tasks.md") in text
+        assert str(tmp_path.parent) in text
+        assert "no cd needed" in text
+
+
+# -- misc small helpers -------------------------------------------------------
+
+
+class TestUnlinkQuietly:
+    def test_it_removes_a_file(self, tmp_path):
+        target = tmp_path / "env"
+        target.write_text("x")
+        r._unlink_quietly(str(target))
+        assert not target.exists()
+
+    def test_a_missing_file_and_an_oserror_are_both_swallowed(self, tmp_path):
+        r._unlink_quietly(str(tmp_path / "gone"))
+        # A directory raises on unlink; the helper must not propagate it.
+        r._unlink_quietly(str(tmp_path))
+        assert tmp_path.is_dir()
+
+
+class TestDiscardQueuedWork:
+    def test_all_three_relaunch_sources_are_dropped(self):
+        slot = SimpleNamespace(
+            _queue=["next"], _pending_steers=["steer"], _pending_synthesis=True
+        )
+        r._discard_queued_work(slot)
+        assert slot._queue == []
+        assert slot._pending_steers == []
+        assert slot._pending_synthesis is False
+
+    def test_a_slot_missing_those_attributes_is_tolerated(self):
+        slot = SimpleNamespace()
+        r._discard_queued_work(slot)  # failing to discard must not break teardown
+        assert slot._pending_synthesis is False
+
+    def test_a_sequence_that_refuses_to_clear_does_not_stop_the_rest(self):
+        angry = mock.Mock()
+        angry.clear.side_effect = RuntimeError("nope")
+        slot = SimpleNamespace(_queue=angry, _pending_steers=["steer"])
+        r._discard_queued_work(slot)
+        assert slot._pending_steers == []
+
+
+class TestAudit:
+    def test_an_api_audit_reaches_sel(self, _quiet_sel):
+        r._audit("spec_create", "demo")
+        assert _quiet_sel.log_api_access.call_args.kwargs["caller"] == r.APP_NAME
+        assert _quiet_sel.log_api_access.call_args.kwargs["operation"] == "spec_create"
+
+    def test_a_raising_sel_never_breaks_the_request(self, _quiet_sel):
+        _quiet_sel.log_api_access.side_effect = RuntimeError("log down")
+        r._audit("spec_create", "demo")  # must not raise
+
+    def test_no_sel_means_no_audit_and_no_error(self):
+        with mock.patch.object(r, "sel", None):
+            r._audit("spec_create", "demo")
+
+    def test_a_tool_audit_records_the_subcommand_and_redacts_the_cwd(self, _quiet_sel):
+        assert r._audit_tool("invoked", "worktree", f"/repo/{CRED_NAME}", critical=True) is True
+        kwargs = _quiet_sel.log_tool_invocation.call_args.kwargs
+        assert kwargs["tool_name"] == "git"
+        assert kwargs["metadata"] == {"subcommand": "worktree"}
+        assert kwargs["critical"] is True
+        assert CRED_NAME not in kwargs["resources"]
+
+    def test_a_tool_audit_carries_the_return_code_when_there_is_one(self, _quiet_sel):
+        r._audit_tool("failure", "rev-parse", "/repo", rc=128)
+        assert _quiet_sel.log_tool_invocation.call_args.kwargs["metadata"]["rc"] == 128
+
+    def test_a_tool_audit_that_could_not_be_recorded_reports_false(self, _quiet_sel):
+        # The "invoked" event is a PRECONDITION for spawning git, not a
+        # nice-to-have: False here is what makes _git refuse to run.
+        _quiet_sel.log_tool_invocation.side_effect = OSError("log unwritable")
+        assert r._audit_tool("invoked", "worktree", "/repo", critical=True) is False
+
+    def test_no_sel_means_a_tool_audit_cannot_be_recorded(self):
+        with mock.patch.object(r, "sel", None):
+            assert r._audit_tool("invoked", "worktree", "/repo", critical=True) is False
+
+
+class TestModuleContracts:
+    def test_the_state_files_default_under_the_data_home(self):
+        # Resolved per call, never bound at import: config_dir() reads
+        # KIROCREW_HOME every time, and freezing it breaks pod + test isolation.
+        with (
+            mock.patch.object(r, "_STATE_DIR", None),
+            mock.patch.object(r, "_INDEX_PATH", None),
+            mock.patch.object(r, "_DELETED_PATH", None),
+            mock.patch.object(r, "_SETTINGS_PATH", None),
+        ):
+            state = r._state_dir()
+            assert state.name == r.APP_NAME
+            assert state.parent.name == "workspace"
+            assert r._index_path() == state / "index.json"
+            assert r._deleted_path() == state / "deleted.json"
+            assert r._settings_path() == state / "settings.json"
+
+    def test_the_autonomous_loop_and_the_arming_window_are_both_bounded(self):
+        assert r._EXEC_MAX_CYCLES > 0
+        assert isinstance(r._ARMING_GRACE_SECS, float) and r._ARMING_GRACE_SECS > 0
+
+    def test_git_unavailable_is_distinct_from_gits_own_exit_codes(self):
+        assert r._GIT_UNAVAILABLE == 127
+
+
+class TestSecurityModuleUnavailable:
+    """The module's import-time fallbacks, exercised by importing it for real
+    with ``kiro_crew.security`` unimportable -- the only way those lines run."""
+
+    @staticmethod
+    def _load_without_security():
+        import importlib.util
+
+        saved = sys.modules.get("kiro_crew.security")
+        # ``None`` in sys.modules makes the import statement raise ImportError,
+        # which is exactly the condition the try/except in the module guards.
+        sys.modules["kiro_crew.security"] = None  # type: ignore[assignment]
+        try:
+            spec = importlib.util.spec_from_file_location("_sb_nosec", r.__file__)
+            assert spec is not None and spec.loader is not None
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+        finally:
+            if saved is not None:
+                sys.modules["kiro_crew.security"] = saved
+            else:  # pragma: no cover - security is always importable in prod
+                del sys.modules["kiro_crew.security"]
+
+    def test_every_path_reads_as_sensitive_when_it_cannot_be_judged(self, tmp_path):
+        module = self._load_without_security()
+        assert module._HAS_SECURITY is False
+        # Fail CLOSED: with no way to make the judgement, treat every path as
+        # sensitive rather than waving them all through.
+        assert module.is_sensitive_path(str(tmp_path)) is True
+        assert module._safe_dir(str(tmp_path)) is None
+
+    def test_text_is_withheld_rather_than_served_unscrubbed(self):
+        module = self._load_without_security()
+        assert module._redact("plain text") == module._UNSCRUBBABLE
+
+
+# -- index transactions (async) -----------------------------------------------
+
+
+class TestIndexTransactions:
+    @pytest.mark.asyncio
+    async def test_aload_index_reads_off_the_event_loop(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        assert list(await r._aload_index()) == ["demo"]
+
+    @pytest.mark.asyncio
+    async def test_a_mutation_returning_true_commits(self, tmp_path):
+        def _insert(index: dict) -> bool:
+            index["demo"] = _entry(tmp_path / "demo")
+            return True
+
+        assert await r._mutate_index(_insert) is True
+        assert list(r._load_index()) == ["demo"]
+
+    @pytest.mark.asyncio
+    async def test_a_mutation_returning_false_aborts_without_writing(self, tmp_path):
+        def _abort(index: dict) -> bool:
+            index["demo"] = _entry(tmp_path / "demo")
+            return False
+
+        assert await r._mutate_index(_abort) is False
+        assert not r._index_path().exists()
+
+    @pytest.mark.asyncio
+    async def test_the_mutation_sees_a_freshly_read_index_not_the_callers_snapshot(self, tmp_path):
+        _write_index({"first": _entry(tmp_path / "first")})
+        seen: list[list[str]] = []
+
+        def _look(index: dict) -> bool:
+            seen.append(sorted(index))
+            return False
+
+        await r._mutate_index(_look)
+        assert seen == [["first"]]
+
+
+class TestTouchSpec:
+    @pytest.mark.asyncio
+    async def test_a_missing_spec_returns_none_so_the_caller_aborts(self):
+        assert await r._touch_spec("gone", status="executing") is None
+
+    @pytest.mark.asyncio
+    async def test_fields_are_stamped_with_a_fresh_updated_at(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        fresh = await r._touch_spec("demo", status="executing")
+        assert fresh is not None
+        assert fresh["status"] == "executing"
+        assert fresh["updated_at"] > 200.0
+        assert r._load_index()["demo"]["status"] == "executing"
+
+    @pytest.mark.asyncio
+    async def test_an_entry_reserved_for_deletion_is_treated_as_already_gone(self, tmp_path):
+        # A message landing mid-delete used to stamp the doomed entry and get a
+        # non-None return, which every caller reads as "the spec is live".
+        _write_index(
+            {
+                "demo": _entry(
+                    tmp_path / "demo", deleting={"owner": r._PROCESS_ID, "at": time.time()}
+                )
+            }
+        )
+        assert await r._touch_spec("demo", status="executing") is None
+
+    @pytest.mark.asyncio
+    async def test_a_different_spec_dir_refuses(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        assert await r._touch_spec("demo", expect_spec_dir="/elsewhere") is None
+
+    @pytest.mark.asyncio
+    async def test_a_different_slot_key_refuses(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        assert await r._touch_spec("demo", expect_slot_key="spec-builder-demo-ffffffff") is None
+
+    @pytest.mark.asyncio
+    async def test_a_matching_pair_of_pins_is_accepted(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        fresh = await r._touch_spec(
+            "demo",
+            expect_spec_dir=str(tmp_path / "demo"),
+            expect_slot_key="spec-builder-demo-0123abcd",
+            status="executing",
+        )
+        assert fresh is not None and fresh["status"] == "executing"
+
+
+class TestDeleteReservation:
+    @pytest.mark.asyncio
+    async def test_marking_reserves_the_name_and_stamps_our_ownership(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        assert await r._mark_deleting(
+            "demo",
+            expect_spec_dir=str(tmp_path / "demo"),
+            expect_slot_key="spec-builder-demo-0123abcd",
+        )
+        held = json.loads(r._index_path().read_text())["demo"][r._DELETING]
+        assert held["owner"] == r._PROCESS_ID
+
+    @pytest.mark.asyncio
+    async def test_marking_refuses_a_spec_that_moved(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        assert not await r._mark_deleting(
+            "demo", expect_spec_dir="/elsewhere", expect_slot_key=""
+        )
+        assert not await r._mark_deleting(
+            "demo",
+            expect_spec_dir=str(tmp_path / "demo"),
+            expect_slot_key="spec-builder-demo-ffffffff",
+        )
+
+    @pytest.mark.asyncio
+    async def test_marking_a_missing_spec_refuses(self):
+        assert not await r._mark_deleting("gone", expect_spec_dir="/x", expect_slot_key="")
+
+    @pytest.mark.asyncio
+    async def test_releasing_leaves_the_entry_exactly_as_it_was(self, tmp_path):
+        entry = _entry(tmp_path / "demo")
+        _write_index({"demo": dict(entry)})
+        await r._mark_deleting(
+            "demo", expect_spec_dir=str(tmp_path / "demo"), expect_slot_key=""
+        )
+        assert await r._unmark_deleting("demo", expect_spec_dir=str(tmp_path / "demo"))
+        assert r._load_index()["demo"] == entry
+
+    @pytest.mark.asyncio
+    async def test_releasing_a_reservation_that_is_not_there_reports_false(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        assert not await r._unmark_deleting("demo", expect_spec_dir=str(tmp_path / "demo"))
+        assert not await r._unmark_deleting("demo", expect_spec_dir="/elsewhere")
+
+
+class TestClaimExecution:
+    @pytest.mark.asyncio
+    async def test_a_missing_spec_reports_gone(self):
+        reason, entry = await r._claim_execution(
+            "gone", expect_spec_dir="/x", expect_slot_key="", live_running=False
+        )
+        assert reason == r._CLAIM_GONE and entry == {}
+
+    @pytest.mark.asyncio
+    async def test_an_identity_that_moved_reports_gone(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        reason, _ = await r._claim_execution(
+            "demo",
+            expect_spec_dir=str(tmp_path / "demo"),
+            expect_slot_key="spec-builder-demo-ffffffff",
+            live_running=False,
+        )
+        assert reason == r._CLAIM_GONE
+
+    @pytest.mark.asyncio
+    async def test_planning_is_claimed_exactly_once(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        pins = {
+            "expect_spec_dir": str(tmp_path / "demo"),
+            "expect_slot_key": "spec-builder-demo-0123abcd",
+        }
+        with mock.patch.object(r, "_exec_loop_active", return_value=False):
+            first, entry = await r._claim_execution("demo", live_running=False, **pins)
+            second, _ = await r._claim_execution("demo", live_running=False, **pins)
+        assert first == r._CLAIM_OK
+        assert entry["status"] == "executing"
+        # The pre-arm window is stamped so a concurrent poll cannot reconcile the
+        # state away before the loop exists.
+        assert entry["exec_arming_at"] > 0
+        assert second == r._CLAIM_TAKEN
+
+    @pytest.mark.asyncio
+    async def test_a_live_running_slot_blocks_the_claim(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        with mock.patch.object(r, "_exec_loop_active", return_value=False):
+            reason, _ = await r._claim_execution(
+                "demo",
+                expect_spec_dir=str(tmp_path / "demo"),
+                expect_slot_key="",
+                live_running=True,
+            )
+        assert reason == r._CLAIM_TAKEN
+
+    @pytest.mark.asyncio
+    async def test_a_live_nudge_loop_blocks_the_claim(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        with mock.patch.object(r, "_exec_loop_active", return_value=True):
+            reason, _ = await r._claim_execution(
+                "demo",
+                expect_spec_dir=str(tmp_path / "demo"),
+                expect_slot_key="",
+                live_running=False,
+            )
+        assert reason == r._CLAIM_TAKEN
+
+
+class TestEffectiveStatus:
+    @pytest.mark.asyncio
+    async def test_planning_passes_straight_through(self):
+        assert await r._effective_status("demo", {"status": "planning"}, None) == "planning"
+
+    @pytest.mark.asyncio
+    async def test_an_unrecognised_stored_status_reads_as_planning(self):
+        assert await r._effective_status("demo", {"status": "nonsense"}, None) == "planning"
+
+    @pytest.mark.asyncio
+    async def test_a_live_nudge_loop_means_still_executing(self):
+        with mock.patch.object(r, "_exec_loop_active", return_value=True):
+            assert await r._effective_status("demo", {"status": "executing"}, None) == "executing"
+
+    @pytest.mark.asyncio
+    async def test_a_running_turn_means_still_executing(self):
+        slot = SimpleNamespace(running=True)
+        with mock.patch.object(r, "_exec_loop_active", return_value=False):
+            assert await r._effective_status("demo", {"status": "executing"}, slot) == "executing"
+
+    @pytest.mark.asyncio
+    async def test_the_pre_arm_window_is_not_reconciled_away(self, tmp_path):
+        # The handoff records "executing" BEFORE it arms the loop, so a poll
+        # landing there legitimately sees no loop and no running turn.
+        meta = _entry(tmp_path / "demo", status="executing", exec_arming_at=time.time())
+        _write_index({"demo": dict(meta)})
+        with mock.patch.object(r, "_exec_loop_active", return_value=False):
+            assert await r._effective_status("demo", meta, None) == "executing"
+        assert r._load_index()["demo"]["status"] == "executing"
+
+    @pytest.mark.asyncio
+    async def test_a_stale_arming_stamp_no_longer_masks_the_reconciliation(self, tmp_path):
+        meta = _entry(
+            tmp_path / "demo",
+            status="executing",
+            exec_arming_at=time.time() - r._ARMING_GRACE_SECS - 5,
+        )
+        _write_index({"demo": dict(meta)})
+        with mock.patch.object(r, "_exec_loop_active", return_value=False):
+            assert await r._effective_status("demo", meta, None) == "planning"
+
+    @pytest.mark.asyncio
+    async def test_an_unparseable_arming_stamp_does_not_grant_a_window(self, tmp_path):
+        meta = _entry(tmp_path / "demo", status="executing", exec_arming_at="soon")
+        _write_index({"demo": dict(meta)})
+        with mock.patch.object(r, "_exec_loop_active", return_value=False):
+            assert await r._effective_status("demo", meta, None) == "planning"
+
+    @pytest.mark.asyncio
+    async def test_a_finished_run_is_settled_back_to_planning_and_persisted(self, tmp_path):
+        # A capped loop that ran out of cycles left "executing" in the index
+        # forever: the UI offered Pause on a run that had already finished.
+        meta = _entry(tmp_path / "demo", status="executing")
+        _write_index({"demo": dict(meta)})
+        with mock.patch.object(r, "_exec_loop_active", return_value=False):
+            assert await r._effective_status("demo", meta, None) == "planning"
+        assert r._load_index()["demo"]["status"] == "planning"
+
+    @pytest.mark.asyncio
+    async def test_the_settle_is_identity_pinned_so_a_replacement_is_not_stamped(self, tmp_path):
+        # Same name AND path, different creation: without the slot_key pin the
+        # stamp lands on the replacement and hides Pause for its whole run.
+        stale = _entry(tmp_path / "demo", status="executing")
+        replacement = _entry(
+            tmp_path / "demo", status="executing", slot_key="spec-builder-demo-ffffffff"
+        )
+        _write_index({"demo": replacement})
+        with mock.patch.object(r, "_exec_loop_active", return_value=False):
+            assert await r._effective_status("demo", stale, None) == "planning"
+        assert r._load_index()["demo"]["status"] == "executing"
+
+
+# -- the nudge loop -----------------------------------------------------------
+
+
+def _autonudge(loop=None, *, svc_missing: bool = False):
+    """Patch the autonudge accessor to a stub service holding ``loop``."""
+    if svc_missing:
+        return mock.patch.object(r, "_autonudge_instance", lambda: None)
+    svc = mock.MagicMock()
+    svc.get_by_slot.return_value = loop
+    svc.remove = mock.AsyncMock()
+    patcher = mock.patch.object(r, "_autonudge_instance", lambda: svc)
+    patcher.svc = svc  # type: ignore[attr-defined]
+    return patcher
+
+
+class TestExecLoopLookup:
+    def test_no_autonudge_module_means_no_loop_id(self):
+        with mock.patch.object(r, "_autonudge_instance", None):
+            assert r._exec_loop_id("demo") is None
+            assert r._exec_loop_active("demo") is False
+
+    def test_no_running_service_means_no_loop_id(self):
+        with _autonudge(svc_missing=True):
+            assert r._exec_loop_id("demo") is None
+            assert r._exec_loop_active("demo") is False
+
+    def test_no_loop_for_this_slot(self):
+        with _autonudge(None):
+            assert r._exec_loop_id("demo") is None
+            assert r._exec_loop_active("demo") is False
+
+    def test_a_live_loop_reports_its_id(self):
+        with _autonudge(SimpleNamespace(id="loop-7", active=True)):
+            assert r._exec_loop_id("demo") == "loop-7"
+            assert r._exec_loop_active("demo") is True
+
+    def test_a_loop_with_no_id_is_reported_as_none(self):
+        with _autonudge(SimpleNamespace(id="", active=True)):
+            assert r._exec_loop_id("demo") is None
+
+    def test_a_deactivated_loop_is_not_active(self):
+        # The loop is CAPPED, and the service deactivates it without telling this
+        # app -- so the index's status cannot be trusted by itself.
+        with _autonudge(SimpleNamespace(id="loop-7", active=False)):
+            assert r._exec_loop_active("demo") is False
+
+    def test_a_raising_lookup_is_swallowed(self):
+        svc = mock.MagicMock()
+        svc.get_by_slot.side_effect = RuntimeError("store down")
+        with mock.patch.object(r, "_autonudge_instance", lambda: svc):
+            assert r._exec_loop_id("demo") is None
+            assert r._exec_loop_active("demo") is False
+
+
+class TestRemoveNudgeLoop:
+    @pytest.mark.asyncio
+    async def test_a_pinned_caller_that_captured_nothing_removes_nothing(self):
+        patcher = _autonudge(SimpleNamespace(id="loop-7"))
+        with patcher:
+            await r._remove_nudge_loop("demo", only_loop_id=None)
+        patcher.svc.remove.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_an_unpinned_removal_takes_whatever_loop_is_there(self):
+        patcher = _autonudge(SimpleNamespace(id="loop-7"))
+        with patcher:
+            await r._remove_nudge_loop("demo")
+        patcher.svc.remove.assert_awaited_once_with("loop-7")  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_a_pin_that_does_not_match_the_live_loop_removes_nothing(self):
+        # The lookup is by slot key, derived from the name, so an unpinned removal
+        # on an abort path would cancel a same-name spec's loop.
+        patcher = _autonudge(SimpleNamespace(id="loop-NEW"))
+        with patcher:
+            await r._remove_nudge_loop("demo", only_loop_id="loop-OLD")
+        patcher.svc.remove.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_a_removal_failure_propagates_rather_than_reporting_success(self):
+        patcher = _autonudge(SimpleNamespace(id="loop-7"))
+        patcher.svc.remove.side_effect = OSError("store unwritable")  # type: ignore[attr-defined]
+        with patcher, pytest.raises(OSError):
+            await r._remove_nudge_loop("demo", only_loop_id="loop-7")
+
+    @pytest.mark.asyncio
+    async def test_no_service_is_a_no_op(self):
+        with _autonudge(svc_missing=True):
+            await r._remove_nudge_loop("demo")
+
+
+# -- git ----------------------------------------------------------------------
+
+
+class _FakeProc:
+    """The slice of ``asyncio.subprocess.Process`` that ``_git`` touches."""
+
+    def __init__(self, rc: int = 0, out: bytes = b"", err: bytes = b""):
+        self.returncode: int | None = None
+        self._rc, self._out, self._err = rc, out, err
+        self.killed = False
+
+    async def communicate(self):
+        self.returncode = self._rc
+        return self._out, self._err
+
+    def kill(self):
+        self.killed = True
+
+    async def wait(self):
+        self.returncode = -9
+        return self.returncode
+
+
+def _git_env(proc=None, *, cleanup: str = ""):
+    """Replace the sandbox spawn seam so no subprocess and no real git is needed.
+
+    ``sandboxed_spawn_argv`` probes the OS sandbox host and writes a scrubbed-env
+    temp file; a GitHub runner has neither that backend nor a guarantee of git, so
+    both this and ``create_subprocess_limited`` are injected.
+    """
+    spawn = mock.Mock(return_value=(["git", "--version"], {"PATH": "/usr/bin"}, cleanup))
+    create = mock.AsyncMock(return_value=proc if proc is not None else _FakeProc())
+    return spawn, create, mock.patch.multiple(
+        r, _prepare_git_spawn=spawn, create_subprocess_limited=create
+    )
+
+
+class TestGit:
+    @pytest.mark.asyncio
+    async def test_a_successful_command_returns_trimmed_streams(self, tmp_path):
+        proc = _FakeProc(0, b"  /repo/root\n", b"")
+        _spawn, _create, patch = _git_env(proc)
+        with patch:
+            rc, out, err = await r._git(str(tmp_path), "rev-parse", "--show-toplevel")
+        assert (rc, out, err) == (0, "/repo/root", "")
+
+    @pytest.mark.asyncio
+    async def test_a_nonzero_return_code_is_reported_not_raised(self, tmp_path, _quiet_sel):
+        proc = _FakeProc(128, b"", b"fatal: not a git repository")
+        _spawn, _create, patch = _git_env(proc)
+        with patch:
+            rc, _out, err = await r._git(str(tmp_path), "rev-parse")
+        assert rc == 128 and "not a git repository" in err
+        outcomes = [c.kwargs["outcome"] for c in _quiet_sel.log_tool_invocation.call_args_list]
+        assert outcomes == ["invoked", "failure"]
+
+    @pytest.mark.asyncio
+    async def test_it_refuses_to_spawn_when_the_invocation_cannot_be_audited(self, tmp_path):
+        # Audit-or-deny: a process this app runs on the user's repository must be
+        # reconstructable from the audit log, so no record means no spawn.
+        _spawn, create, patch = _git_env()
+        with patch, mock.patch.object(r, "_audit_tool", return_value=False):
+            rc, out, err = await r._git(str(tmp_path), "worktree", "add")
+        assert rc == r._GIT_UNAVAILABLE
+        assert out == "" and "audit unavailable" in err
+        create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_sandbox_that_cannot_build_an_argv_degrades_instead_of_500ing(self, tmp_path):
+        with mock.patch.object(r, "_prepare_git_spawn", side_effect=RuntimeError("no backend")):
+            rc, _out, err = await r._git(str(tmp_path), "rev-parse")
+        assert rc == r._GIT_UNAVAILABLE and "RuntimeError" in err
+
+    @pytest.mark.asyncio
+    async def test_no_git_on_the_host_degrades_instead_of_500ing(self, tmp_path):
+        # Browsing a folder calls _repo_info, so letting this propagate turned the
+        # project picker's first request into a 500 on a machine without git.
+        _spawn, create, patch = _git_env()
+        create.side_effect = FileNotFoundError("git")
+        with patch:
+            rc, _out, err = await r._git(str(tmp_path), "rev-parse")
+        assert rc == r._GIT_UNAVAILABLE and err == "git is not installed"
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_spawn_kills_the_child_and_re_raises(self, tmp_path):
+        proc = _FakeProc()
+        _spawn, create, patch = _git_env(proc)
+        create.side_effect = KeyboardInterrupt("cancelled")
+        with patch, mock.patch.object(r, "_halt_git", mock.AsyncMock()) as halt:
+            with pytest.raises(KeyboardInterrupt):
+                await r._git(str(tmp_path), "worktree", "add")
+        halt.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_the_scrubbed_env_temp_file_is_always_removed(self, tmp_path):
+        leftover = tmp_path / "scrubbed-env"
+        leftover.write_text("x")
+        _spawn, _create, patch = _git_env(cleanup=str(leftover))
+        with patch:
+            await r._git(str(tmp_path), "rev-parse")
+        assert not leftover.exists()
+
+    @pytest.mark.asyncio
+    async def test_a_command_with_no_arguments_still_audits_a_blank_subcommand(
+        self, tmp_path, _quiet_sel
+    ):
+        _spawn, _create, patch = _git_env()
+        with patch:
+            await r._git(str(tmp_path))
+        assert _quiet_sel.log_tool_invocation.call_args.kwargs["metadata"]["subcommand"] == ""
+
+
+class TestHaltGit:
+    @pytest.mark.asyncio
+    async def test_nothing_to_do_for_a_missing_or_finished_process(self):
+        await r._halt_git(None, "worktree")
+        done = _FakeProc()
+        done.returncode = 0
+        await r._halt_git(done, "worktree")
+        assert done.killed is False
+
+    @pytest.mark.asyncio
+    async def test_a_live_process_is_killed_and_reaped(self):
+        proc = _FakeProc()
+        await r._halt_git(proc, "worktree")
+        assert proc.killed is True
+        assert proc.returncode == -9
+
+    @pytest.mark.asyncio
+    async def test_a_process_that_is_already_gone_needs_no_reap(self):
+        proc = _FakeProc()
+        proc.kill = mock.Mock(side_effect=ProcessLookupError())  # type: ignore[method-assign]
+        proc.wait = mock.AsyncMock(side_effect=AssertionError("must not reap"))  # type: ignore
+        await r._halt_git(proc, "worktree")
+
+    @pytest.mark.asyncio
+    async def test_a_process_stuck_after_the_kill_is_logged_rather_than_hung_on(self):
+        proc = _FakeProc()
+
+        async def _never():
+            # asyncio.TimeoutError, NOT the builtin: `_halt_git` catches
+            # `asyncio.TimeoutError`, and on Python 3.10 that is
+            # concurrent.futures.TimeoutError -- a DIFFERENT class from
+            # builtins.TimeoutError. The two only became the same class in 3.11,
+            # so raising the builtin here passes on 3.11/3.12 and escapes the
+            # handler uncaught on 3.10, which is exactly what CI caught.
+            raise asyncio.TimeoutError
+
+        proc.wait = _never  # type: ignore[method-assign]
+        with mock.patch.object(r, "_GIT_HALT_SECS", 0.01):
+            await r._halt_git(proc, "worktree")  # must return, not raise
+        assert proc.killed is True
+
+
+class TestRepoInfo:
+    @pytest.mark.asyncio
+    async def test_a_path_outside_a_repository(self):
+        with mock.patch.object(r, "_git", mock.AsyncMock(return_value=(128, "", "fatal"))):
+            assert await r._repo_info("/tmp/x") == {"is_git": False}
+
+    @pytest.mark.asyncio
+    async def test_a_repository_with_an_origin_main_base(self):
+        calls = {
+            ("rev-parse", "--show-toplevel"): (0, "/repo", ""),
+            ("rev-parse", "--abbrev-ref", "HEAD"): (0, "feature/x", ""),
+            ("rev-parse", "--verify", "--quiet", "origin/main"): (0, "sha", ""),
+        }
+
+        async def _fake(cwd, *args):
+            return calls.get(tuple(args), (1, "", ""))
+
+        with mock.patch.object(r, "_git", _fake):
+            assert await r._repo_info("/repo") == {
+                "is_git": True,
+                "root": "/repo",
+                "branch": "feature/x",
+                "default_base": "origin/main",
+            }
+
+    @pytest.mark.asyncio
+    async def test_with_no_known_remote_base_it_falls_back_to_the_current_branch(self):
+        async def _fake(cwd, *args):
+            if args[:2] == ("rev-parse", "--show-toplevel"):
+                return 0, "/repo", ""
+            if args == ("rev-parse", "--abbrev-ref", "HEAD"):
+                return 0, "trunk", ""
+            return 1, "", ""
+
+        with mock.patch.object(r, "_git", _fake):
+            info = await r._repo_info("/repo")
+        assert info["default_base"] == "trunk"
+
+    @pytest.mark.asyncio
+    async def test_an_empty_toplevel_is_not_a_repository(self):
+        with mock.patch.object(r, "_git", mock.AsyncMock(return_value=(0, "", ""))):
+            assert await r._repo_info("/tmp/x") == {"is_git": False}
+
+
+class TestWorktreeCreation:
+    @pytest.mark.asyncio
+    async def test_it_refuses_to_reuse_an_existing_path(self, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        (tmp_path / "repo-wt-demo").mkdir()
+        result = await r._create_worktree(str(root), "demo")
+        assert isinstance(result, str) and "already exists" in result
+
+    @pytest.mark.asyncio
+    async def test_a_successful_creation_returns_the_sibling_path_and_branch(self, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        seen: list[tuple] = []
+
+        async def _fake(cwd, *args):
+            seen.append(args)
+            return 0, "/repo", ""
+
+        with (
+            mock.patch.object(r, "_git", _fake),
+            mock.patch.object(
+                r, "_repo_info", mock.AsyncMock(return_value={"default_base": "origin/main"})
+            ),
+        ):
+            result = await r._create_worktree(str(root), "demo")
+        assert result == (str(tmp_path / "repo-wt-demo"), "spec/demo")
+        assert seen[-1] == (
+            "worktree",
+            "add",
+            str(tmp_path / "repo-wt-demo"),
+            "-b",
+            "spec/demo",
+            "origin/main",
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_failed_git_call_reports_its_last_line_redacted(self, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        with (
+            mock.patch.object(
+                r, "_git", mock.AsyncMock(return_value=(128, "", f"noise\nfatal: {CRED_NAME}"))
+            ),
+            mock.patch.object(r, "_repo_info", mock.AsyncMock(return_value={})),
+        ):
+            result = await r._create_worktree(str(root), "demo")
+        assert isinstance(result, str)
+        assert result.startswith("fatal: ") and CRED_NAME not in result
+
+    @pytest.mark.asyncio
+    async def test_a_failure_with_no_stderr_still_reports_the_return_code(self, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        with (
+            mock.patch.object(r, "_git", mock.AsyncMock(return_value=(3, "", ""))),
+            mock.patch.object(r, "_repo_info", mock.AsyncMock(return_value={})),
+        ):
+            result = await r._create_worktree(str(root), "demo")
+        assert result == "git worktree add failed (rc=3)"
+
+
+class TestWorktreeRemoval:
+    @pytest.mark.asyncio
+    async def test_it_prunes_before_deleting_the_branch(self):
+        seen: list[tuple] = []
+
+        async def _fake(cwd, *args):
+            seen.append(args)
+            return 0, "", ""
+
+        with mock.patch.object(r, "_git", _fake):
+            await r._remove_worktree("/repo", "/repo-wt-demo", "spec/demo")
+        # A leftover registration keeps the branch checked-out from git's view.
+        assert seen == [
+            ("worktree", "remove", "--force", "/repo-wt-demo"),
+            ("worktree", "prune"),
+            ("branch", "-D", "spec/demo"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_without_a_branch_only_the_worktree_is_removed(self):
+        seen: list[tuple] = []
+
+        async def _fake(cwd, *args):
+            seen.append(args)
+            return 0, "", ""
+
+        with mock.patch.object(r, "_git", _fake):
+            await r._remove_worktree("/repo", "/repo-wt-demo")
+        assert ("branch", "-D", "") not in seen
+        assert len(seen) == 2
+
+    @pytest.mark.asyncio
+    async def test_missing_arguments_make_it_a_no_op(self):
+        git = mock.AsyncMock()
+        with mock.patch.object(r, "_git", git):
+            await r._remove_worktree("", "/wt")
+            await r._remove_worktree("/repo", "")
+        git.assert_not_awaited()
+
+
+class TestRollbackWorktreeIfOurs:
+    @pytest.mark.asyncio
+    async def test_nothing_was_created_so_nothing_is_removed(self):
+        remove = mock.AsyncMock()
+        with mock.patch.object(r, "_remove_worktree", remove):
+            assert (
+                await r._rollback_worktree_if_ours(
+                    "demo", was_ours=True, repo_root="/repo", created_worktree="",
+                    worktree_branch="spec/demo",
+                )
+                is False
+            )
+        remove.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_entry_that_is_no_longer_ours_is_left_alone(self):
+        # remove --force plus branch -D would discard the REPLACEMENT spec's
+        # uncommitted work; an orphaned worktree is recoverable by hand.
+        remove = mock.AsyncMock()
+        with mock.patch.object(r, "_remove_worktree", remove):
+            assert (
+                await r._rollback_worktree_if_ours(
+                    "demo", was_ours=False, repo_root="/repo",
+                    created_worktree="/repo-wt-demo", worktree_branch="spec/demo",
+                )
+                is False
+            )
+        remove.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_our_own_worktree_is_removed(self):
+        remove = mock.AsyncMock()
+        with mock.patch.object(r, "_remove_worktree", remove):
+            assert (
+                await r._rollback_worktree_if_ours(
+                    "demo", was_ours=True, repo_root="/repo",
+                    created_worktree="/repo-wt-demo", worktree_branch="spec/demo",
+                )
+                is True
+            )
+        remove.assert_awaited_once_with("/repo", "/repo-wt-demo", "spec/demo")
+
+
+# -- worker slots -------------------------------------------------------------
+
+
+class _Slot:
+    """The slice of the gateway's ``_ChatSlot`` this module touches."""
+
+    def __init__(self, key: str, *, app: str | None = r.APP_NAME, running: bool = False):
+        self.key = key
+        self._app = app
+        self.running = running
+        self.project: str | None = None
+        self.title = ""
+        self._titled = False
+        self.messages: list[dict] = []
+        self.task = None
+        self._queue: list[str] = []
+        self._pending_steers: list[str] = []
+        self._pending_synthesis = False
+        self.queued: list[str] = []
+
+    def queue_append(self, message: str) -> None:
+        self._queue.append(message)
+
+    def append(self, role: str, content: str) -> None:
+        self.messages.append({"role": role, "content": content, "ts": ""})
+
+
+class _State:
+    """A stand-in dashboard state: a slot registry plus the hooks this app calls."""
+
+    def __init__(self, **slots: _Slot):
+        self._slots: dict[str, _Slot] = dict(slots)
+        self.titles: list[tuple[str, str]] = []
+        self.pushes = 0
+        self._background_tasks: set = set()
+        self.sessions = SimpleNamespace(stop_turn=mock.AsyncMock())
+        self.conversation_log = None
+
+    def get_slot(self, key: str):
+        return self._slots.get(key)
+
+    def get_or_create_slot(self, *, name: str, app: str | None = None):
+        slot = self._slots.get(name)
+        if slot is None:
+            slot = _Slot(name, app=app)
+            self._slots[name] = slot
+        return slot
+
+    def push_slot_title(self, key: str, title: str) -> None:
+        self.titles.append((key, title))
+
+    def push_slots_update(self) -> None:
+        self.pushes += 1
+
+
+def _no_rehydrate():
+    return mock.patch.object(r, "rehydrate_slot_from_history_async", mock.AsyncMock(return_value=None))
+
+
+class TestEnsureWorkerSlot:
+    @pytest.mark.asyncio
+    async def test_no_state_yields_no_slot(self, tmp_path):
+        assert await r._ensure_worker_slot(None, "demo", _entry(tmp_path)) is None
+
+    @pytest.mark.asyncio
+    async def test_a_name_that_fails_the_admission_predicate_is_refused(self, tmp_path, _quiet_sel):
+        # The name becomes a slot key and then a history key, so an unbounded
+        # value would flow into core's session-key parsing.
+        state = _State()
+        assert await r._ensure_worker_slot(state, CRED_NAME, _entry(tmp_path)) is None
+        assert state._slots == {}
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_slot_name_denied" in ops
+
+    @pytest.mark.asyncio
+    async def test_a_cold_slot_is_created_scoped_and_titled(self, tmp_path):
+        state = _State()
+        with _no_rehydrate():
+            slot = await r._ensure_worker_slot(state, "demo", _entry(tmp_path / "spec"))
+        assert slot is not None
+        assert slot._app == r.APP_NAME
+        # cwd for the worker's CLI process; without it every tool pill is cd-noise.
+        assert slot.project == str(Path(os.path.realpath(tmp_path)))
+        assert slot.title == "Spec: demo"
+        assert state.titles == [("spec-builder-demo", "Spec: demo")]
+
+    @pytest.mark.asyncio
+    async def test_the_persisted_transcript_is_pulled_back_before_a_slot_exists(self, tmp_path):
+        state = _State()
+        rehydrate = mock.AsyncMock(return_value=None)
+        with mock.patch.object(r, "rehydrate_slot_from_history_async", rehydrate):
+            await r._ensure_worker_slot(state, "demo", _entry(tmp_path / "spec"))
+        rehydrate.assert_awaited_once()
+        assert rehydrate.await_args.kwargs["adopt_closed"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_creating_caller_must_not_adopt_a_closed_transcript(self, tmp_path):
+        # A delete leaves the old spec's archived transcript on disk under a
+        # name-derived key, so a fresh spec must not be handed that conversation.
+        state = _State()
+        rehydrate = mock.AsyncMock(return_value=None)
+        with mock.patch.object(r, "rehydrate_slot_from_history_async", rehydrate):
+            await r._ensure_worker_slot(
+                state, "demo", _entry(tmp_path / "spec"), adopt_closed=False
+            )
+        assert rehydrate.await_args.kwargs["adopt_closed"] is False
+
+    @pytest.mark.asyncio
+    async def test_a_restored_transcript_is_audited(self, tmp_path, _quiet_sel):
+        state = _State()
+        restored = _Slot("spec-builder-demo")
+        with mock.patch.object(
+            r, "rehydrate_slot_from_history_async", mock.AsyncMock(return_value=restored)
+        ):
+            await r._ensure_worker_slot(state, "demo", _entry(tmp_path / "spec"))
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_transcript_restored" in ops
+
+    @pytest.mark.asyncio
+    async def test_a_failing_restore_leaves_the_app_working(self, tmp_path):
+        state = _State()
+        with mock.patch.object(
+            r,
+            "rehydrate_slot_from_history_async",
+            mock.AsyncMock(side_effect=RuntimeError("bad transcript")),
+        ):
+            slot = await r._ensure_worker_slot(state, "demo", _entry(tmp_path / "spec"))
+        assert slot is not None
+
+    @pytest.mark.asyncio
+    async def test_a_slot_owned_by_another_app_is_refused_not_taken_over(self, tmp_path):
+        state = _State(**{"spec-builder-demo": _Slot("spec-builder-demo", app="issue-radar")})
+        with _no_rehydrate():
+            assert await r._ensure_worker_slot(state, "demo", _entry(tmp_path / "spec")) is None
+        # Its ownership and project must be untouched.
+        assert state._slots["spec-builder-demo"]._app == "issue-radar"
+        assert state._slots["spec-builder-demo"].project is None
+
+    @pytest.mark.asyncio
+    async def test_an_unscoped_slot_under_our_key_is_somebody_elses_conversation(self, tmp_path):
+        state = _State(**{"spec-builder-demo": _Slot("spec-builder-demo", app=None)})
+        with _no_rehydrate():
+            assert await r._ensure_worker_slot(state, "demo", _entry(tmp_path / "spec")) is None
+
+    @pytest.mark.asyncio
+    async def test_our_own_existing_slot_is_adopted_and_rescoped(self, tmp_path):
+        existing = _Slot("spec-builder-demo")
+        state = _State(**{"spec-builder-demo": existing})
+        with _no_rehydrate():
+            slot = await r._ensure_worker_slot(state, "demo", _entry(tmp_path / "spec"))
+        assert slot is existing and existing.project is not None
+
+    @pytest.mark.asyncio
+    async def test_an_already_titled_slot_keeps_its_title(self, tmp_path):
+        existing = _Slot("spec-builder-demo")
+        existing.title = "Renamed by the user"
+        existing._titled = True
+        state = _State(**{"spec-builder-demo": existing})
+        with _no_rehydrate():
+            await r._ensure_worker_slot(state, "demo", _entry(tmp_path / "spec"))
+        assert existing.title == "Renamed by the user"
+        assert state.titles == []
+
+    @pytest.mark.asyncio
+    async def test_an_indexed_working_dir_that_no_longer_validates_refuses_the_slot(
+        self, tmp_path, _quiet_sel
+    ):
+        state = _State()
+        meta = _entry(tmp_path / "spec", working_dir=str(tmp_path / "deleted-project"))
+        with _no_rehydrate():
+            assert await r._ensure_worker_slot(state, "demo", meta) is None
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_working_dir_denied" in ops
+
+    @pytest.mark.asyncio
+    async def test_a_missing_working_dir_key_counts_as_unusable(self, tmp_path):
+        # An unscoped slot is worse than a mis-scoped one: chat_runner passes
+        # cwd=slot.project, so the worker would inherit the GATEWAY's cwd.
+        state = _State()
+        meta = {"spec_dir": str(tmp_path / "spec")}
+        with _no_rehydrate():
+            assert await r._ensure_worker_slot(state, "demo", meta) is None
+
+    @pytest.mark.asyncio
+    async def test_a_spec_replaced_while_the_slot_was_acquired_is_refused(self, tmp_path):
+        state = _State()
+        r._SLOT_KEYS["demo"] = "spec-builder-demo-0123abcd"
+
+        async def _swap_identity(*_a, **_kw):
+            r._SLOT_KEYS["demo"] = "spec-builder-demo-ffffffff"
+            return None
+
+        with mock.patch.object(r, "rehydrate_slot_from_history_async", _swap_identity):
+            assert await r._ensure_worker_slot(state, "demo", _entry(tmp_path / "spec")) is None
+        assert state._slots == {}
+
+    @pytest.mark.asyncio
+    async def test_a_replacement_landing_after_the_working_dir_check_is_refused(self, tmp_path):
+        state = _State()
+        r._SLOT_KEYS["demo"] = "spec-builder-demo-0123abcd"
+        real_safe_dir = r._safe_dir
+
+        def _safe_then_swap(raw, **kw):
+            r._SLOT_KEYS["demo"] = "spec-builder-demo-ffffffff"
+            return real_safe_dir(raw, **kw)
+
+        with _no_rehydrate(), mock.patch.object(r, "_safe_dir", _safe_then_swap):
+            assert await r._ensure_worker_slot(state, "demo", _entry(tmp_path / "spec")) is None
+
+    @pytest.mark.asyncio
+    async def test_a_slot_that_rejects_scoping_is_still_returned(self, tmp_path):
+        # Scoping failures are logged, not fatal -- a partially-built slot must not
+        # take the whole request down.
+        class _Frozen(_Slot):
+            _ready = False
+
+            def __setattr__(self, name, value):
+                if name == "project" and self._ready:
+                    raise RuntimeError("slot is frozen")
+                super().__setattr__(name, value)
+
+        frozen = _Frozen("spec-builder-demo")
+        frozen._ready = True
+        state = _State(**{"spec-builder-demo": frozen})
+        with _no_rehydrate():
+            slot = await r._ensure_worker_slot(state, "demo", _entry(tmp_path / "spec"))
+        assert slot is frozen
+        assert frozen.title == ""  # the scoping block aborted before titling
+
+
+class TestSlotIdentityMoved:
+    def test_an_unchanged_mapping_has_not_moved(self):
+        r._SLOT_KEYS["demo"] = "spec-builder-demo-0123abcd"
+        assert r._slot_identity_moved("demo", "spec-builder-demo-0123abcd") is False
+
+    def test_a_rewritten_mapping_has_moved_and_is_audited(self, _quiet_sel):
+        r._SLOT_KEYS["demo"] = "spec-builder-demo-ffffffff"
+        assert r._slot_identity_moved("demo", "spec-builder-demo-0123abcd") is True
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_slot_replaced_midflight" in ops
+
+
+class TestTeardownWorkerSlot:
+    @pytest.mark.asyncio
+    async def test_no_state_is_reported_as_nothing_at_risk(self):
+        assert await r._teardown_worker_slot(None, "demo") is True
+
+    @pytest.mark.asyncio
+    async def test_a_pinned_caller_that_captured_nothing_tears_nothing_down(self):
+        state = _State(**{"spec-builder-demo": _Slot("spec-builder-demo")})
+        assert await r._teardown_worker_slot(state, "demo", only_slot=None) is True
+        assert "spec-builder-demo" in state._slots
+
+    @pytest.mark.asyncio
+    async def test_an_absent_slot_is_nothing_at_risk(self):
+        assert await r._teardown_worker_slot(_State(), "demo") is True
+
+    @pytest.mark.asyncio
+    async def test_a_slot_replaced_since_capture_is_left_alone(self):
+        live = _Slot("spec-builder-demo")
+        state = _State(**{"spec-builder-demo": live})
+        captured = _Slot("spec-builder-demo")
+        assert await r._teardown_worker_slot(state, "demo", only_slot=captured) is True
+        assert state._slots["spec-builder-demo"] is live
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_slot_is_never_deleted_by_name_collision(self):
+        state = _State(**{"spec-builder-demo": _Slot("spec-builder-demo", app="issue-radar")})
+        assert await r._teardown_worker_slot(state, "demo") is True
+        assert "spec-builder-demo" in state._slots
+
+    @pytest.mark.asyncio
+    async def test_a_captured_slot_with_a_malformed_key_falls_back_to_the_name(self):
+        slot = _Slot("spec-builder-demo")
+        slot.key = "not a slot key"  # type: ignore[assignment]
+        state = _State(**{"spec-builder-demo": slot})
+        with mock.patch(
+            "kiro_crew.dashboard.chat_persistence.save_slot_off_loop", mock.AsyncMock()
+        ):
+            assert await r._teardown_worker_slot(state, "demo", only_slot=slot) is True
+        assert state._slots == {}
+
+    @pytest.mark.asyncio
+    async def test_the_slot_is_popped_queued_work_dropped_and_the_turn_cancelled(self):
+        slot = _Slot("spec-builder-demo", running=True)
+        slot._queue = ["next prompt"]
+        slot._pending_synthesis = True
+        task = mock.Mock()
+        task.cancel = mock.Mock()
+        slot.task = task  # type: ignore[assignment]
+        state = _State(**{"spec-builder-demo": slot})
+
+        async def _cancelled(*_a, **_kw):
+            raise asyncio.CancelledError
+
+        with (
+            mock.patch(
+                "kiro_crew.dashboard.chat_persistence.save_slot_off_loop", mock.AsyncMock()
+            ) as save,
+            mock.patch.object(asyncio, "wait_for", _cancelled),
+        ):
+            assert await r._teardown_worker_slot(state, "demo") is True
+        assert state._slots == {}
+        # _run_chat's end-of-turn block would otherwise start the next prompt.
+        assert slot._queue == [] and slot._pending_synthesis is False
+        task.cancel.assert_called_once()
+        assert save.await_args.kwargs["closed"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_failed_archive_is_tolerated_when_it_was_not_required(self):
+        slot = _Slot("spec-builder-demo")
+        state = _State(**{"spec-builder-demo": slot})
+        with mock.patch(
+            "kiro_crew.dashboard.chat_persistence.save_slot_off_loop",
+            mock.AsyncMock(side_effect=OSError("disk full")),
+        ):
+            assert await r._teardown_worker_slot(state, "demo") is True
+        assert state._slots == {}
+
+    @pytest.mark.asyncio
+    async def test_a_required_archive_that_fails_puts_the_slot_back(self, _quiet_sel):
+        # The transcript is the user's data: reporting success would discard a
+        # conversation that was never written.
+        slot = _Slot("spec-builder-demo")
+        state = _State(**{"spec-builder-demo": slot})
+        with mock.patch(
+            "kiro_crew.dashboard.chat_persistence.save_slot_off_loop",
+            mock.AsyncMock(side_effect=OSError("disk full")),
+        ):
+            assert (
+                await r._teardown_worker_slot(state, "demo", require_archive=True) is False
+            )
+        assert state._slots["spec-builder-demo"] is slot
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_slot_archive_failed" in ops
+
+
+class TestHaltActiveTurn:
+    @pytest.mark.asyncio
+    async def test_a_pinned_caller_that_captured_nothing_stops_nothing(self):
+        assert await r._halt_active_turn(_State(), "demo", only_slot=None) is False
+
+    @pytest.mark.asyncio
+    async def test_no_slot_or_no_running_turn_means_nothing_to_stop(self):
+        assert await r._halt_active_turn(_State(), "demo") is False
+        state = _State(**{"spec-builder-demo": _Slot("spec-builder-demo", running=False)})
+        assert await r._halt_active_turn(state, "demo") is False
+
+    @pytest.mark.asyncio
+    async def test_a_slot_replaced_since_capture_is_not_stopped(self):
+        live = _Slot("spec-builder-demo", running=True)
+        state = _State(**{"spec-builder-demo": live})
+        assert await r._halt_active_turn(state, "demo", only_slot=_Slot("x")) is False
+
+    @pytest.mark.asyncio
+    async def test_an_unscoped_slot_sharing_our_key_is_not_cancelled(self):
+        # A plain POST /api/chat conversation that merely shares the key must not
+        # lose its turn to this app's Pause button.
+        state = _State(**{"spec-builder-demo": _Slot("spec-builder-demo", app=None, running=True)})
+        assert await r._halt_active_turn(state, "demo") is False
+
+    @pytest.mark.asyncio
+    async def test_the_turn_is_stopped_cooperatively_then_cancelled(self):
+        slot = _Slot("spec-builder-demo", running=True)
+        slot._queue = ["next"]
+        task = mock.Mock()
+        task.done.return_value = False
+        slot.task = task  # type: ignore[assignment]
+        state = _State(**{"spec-builder-demo": slot})
+
+        async def _cancelled(*_a, **_kw):
+            raise asyncio.CancelledError
+
+        with mock.patch.object(asyncio, "wait_for", _cancelled):
+            assert await r._halt_active_turn(state, "demo") is True
+        state.sessions.stop_turn.assert_awaited_once()
+        assert state.sessions.stop_turn.await_args.kwargs["force"] is False
+        task.cancel.assert_called_once()
+        assert slot._queue == []
+        # Pause must LEAVE the slot so the user can resume.
+        assert state._slots["spec-builder-demo"] is slot
+
+    @pytest.mark.asyncio
+    async def test_a_failing_cooperative_stop_still_cancels(self):
+        slot = _Slot("spec-builder-demo", running=True)
+        state = _State(**{"spec-builder-demo": slot})
+        state.sessions.stop_turn.side_effect = RuntimeError("no session")
+        assert await r._halt_active_turn(state, "demo") is True
+
+
+class TestHaltExecution:
+    @pytest.mark.asyncio
+    async def test_it_sentinels_then_removes_the_loop_then_stops_the_turn(self, tmp_path):
+        order: list[str] = []
+        with (
+            mock.patch.object(
+                r,
+                "_write_stop_sentinel_for_spec",
+                lambda *a, **k: order.append("sentinel") or True,
+            ),
+            mock.patch.object(
+                r,
+                "_remove_nudge_loop",
+                mock.AsyncMock(side_effect=lambda *a, **k: order.append("loop")),
+            ),
+            mock.patch.object(
+                r,
+                "_halt_active_turn",
+                mock.AsyncMock(side_effect=lambda *a, **k: order.append("turn")),
+            ),
+        ):
+            await r._halt_execution(_State(), "demo", tmp_path, reason="user stop")
+        assert order == ["sentinel", "loop", "turn"]
+
+    @pytest.mark.asyncio
+    async def test_a_missing_sentinel_is_not_fatal_because_the_two_stops_are(self, tmp_path):
+        with (
+            mock.patch.object(r, "_write_stop_sentinel_for_spec", return_value=False),
+            mock.patch.object(r, "_remove_nudge_loop", mock.AsyncMock()) as loop,
+            mock.patch.object(r, "_halt_active_turn", mock.AsyncMock()) as turn,
+        ):
+            await r._halt_execution(_State(), "demo", tmp_path, reason="user stop")
+        loop.assert_awaited_once()
+        turn.assert_awaited_once()
+
+
+# -- transcript relay ---------------------------------------------------------
+
+
+class TestSerializeMessages:
+    @pytest.mark.asyncio
+    async def test_the_live_slot_wins_and_system_turns_are_hidden(self):
+        slot = _Slot("spec-builder-demo")
+        slot.messages = [
+            {"role": "system", "content": "internal", "ts": "1"},
+            {"role": "user", "content": "hello", "ts": "2"},
+            {"role": "assistant", "content": "hi", "ts": "3"},
+        ]
+        state = _State(**{"spec-builder-demo": slot})
+        assert await r._serialize_messages(state, "spec-builder-demo") == [
+            {"role": "user", "content": "hello", "ts": "2"},
+            {"role": "assistant", "content": "hi", "ts": "3"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_tool_turn_is_compacted_to_its_first_line(self):
+        slot = _Slot("spec-builder-demo")
+        slot.messages = [{"role": "tool", "content": "fs_write tasks.md\nmore\nlines", "ts": "1"}]
+        state = _State(**{"spec-builder-demo": slot})
+        out = await r._serialize_messages(state, "spec-builder-demo")
+        assert out == [{"role": "tool", "content": "fs_write tasks.md", "ts": "1"}]
+
+    @pytest.mark.asyncio
+    async def test_an_empty_tool_turn_does_not_raise_on_the_first_line(self):
+        slot = _Slot("spec-builder-demo")
+        slot.messages = [{"role": "tool", "content": "", "ts": "1"}]
+        state = _State(**{"spec-builder-demo": slot})
+        assert await r._serialize_messages(state, "spec-builder-demo") == [
+            {"role": "tool", "content": "", "ts": "1"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_content_is_redacted_before_it_leaves_the_backend(self):
+        slot = _Slot("spec-builder-demo")
+        slot.messages = [{"role": "assistant", "content": f"use {CRED_NAME}", "ts": "1"}]
+        state = _State(**{"spec-builder-demo": slot})
+        out = await r._serialize_messages(state, "spec-builder-demo")
+        assert CRED_NAME not in out[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_a_cold_slot_falls_back_to_the_persisted_transcript_off_loop(self):
+        state = _State()
+        state.conversation_log = SimpleNamespace(  # type: ignore[assignment]
+            read_messages=mock.Mock(return_value=[{"role": "user", "content": "old", "ts": "9"}])
+        )
+        assert await r._serialize_messages(state, "spec-builder-demo") == [
+            {"role": "user", "content": "old", "ts": "9"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_object_shaped_messages_are_read_by_attribute(self):
+        state = _State()
+        state.conversation_log = SimpleNamespace(  # type: ignore[assignment]
+            read_messages=mock.Mock(
+                return_value=[SimpleNamespace(role="user", content="old", ts="9")]
+            )
+        )
+        assert await r._serialize_messages(state, "spec-builder-demo") == [
+            {"role": "user", "content": "old", "ts": "9"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_failing_history_read_yields_an_empty_transcript(self):
+        state = _State()
+        state.conversation_log = SimpleNamespace(  # type: ignore[assignment]
+            read_messages=mock.Mock(side_effect=OSError("gone"))
+        )
+        assert await r._serialize_messages(state, "spec-builder-demo") == []
+
+    @pytest.mark.asyncio
+    async def test_no_conversation_log_yields_an_empty_transcript(self):
+        assert await r._serialize_messages(_State(), "spec-builder-demo") == []
+
+
+class TestDispatchTurn:
+    @pytest.mark.asyncio
+    async def test_an_idle_slot_starts_a_turn(self):
+        slot = _Slot("spec-builder-demo")
+        state = _State(**{"spec-builder-demo": slot})
+        with mock.patch("kiro_crew.dashboard.chat_runner._run_chat", mock.AsyncMock()):
+            r._dispatch_turn(state, slot, "do the thing")
+            assert slot.messages == [{"role": "user", "content": "do the thing", "ts": ""}]
+            assert slot.task is not None
+            assert slot.task in state._background_tasks
+            assert state.pushes == 1
+            await slot.task
+
+    @pytest.mark.asyncio
+    async def test_the_turn_is_bounded_by_the_shared_chat_timeout(self):
+        slot = _Slot("spec-builder-demo")
+        state = _State(**{"spec-builder-demo": slot})
+        seen: dict = {}
+
+        def _capture(coro, timeout=None):
+            seen["timeout"] = timeout
+            coro.close()
+
+            async def _noop():
+                return None
+
+            return _noop()
+
+        with (
+            mock.patch("kiro_crew.dashboard.chat_runner._run_chat", mock.AsyncMock()),
+            mock.patch.object(asyncio, "wait_for", _capture),
+        ):
+            r._dispatch_turn(state, slot, "do the thing")
+            await slot.task
+        assert seen["timeout"] == r.CHAT_TURN_TIMEOUT
+
+    def test_a_busy_slot_queues_the_turn_and_shows_it_redacted(self):
+        slot = _Slot("spec-builder-demo", running=True)
+        state = _State(**{"spec-builder-demo": slot})
+        r._dispatch_turn(state, slot, f"use {CRED_NAME}")
+        assert slot._queue == [f"use {CRED_NAME}"]
+        # "queued" is NOT a role the slot suppresses the global SSE push for, so
+        # this text reaches every connected dashboard client.
+        assert slot.messages[0]["role"] == "queued"
+        assert CRED_NAME not in slot.messages[0]["content"]
+        assert state.pushes == 1
+
+    def test_a_slot_that_cannot_queue_or_echo_is_tolerated(self):
+        slot = _Slot("spec-builder-demo", running=True)
+        slot.queue_append = mock.Mock(side_effect=RuntimeError("full"))  # type: ignore
+        slot.append = mock.Mock(side_effect=RuntimeError("closed"))  # type: ignore
+        state = _State(**{"spec-builder-demo": slot})
+        r._dispatch_turn(state, slot, "text")
+        assert state.pushes == 1
+
+
+# -- discovery + spec dir preparation ----------------------------------------
+
+
+def _spec_tree(root: Path, name: str, *files: str) -> Path:
+    spec = root / ".kiro" / "specs" / name
+    spec.mkdir(parents=True)
+    for fname in files:
+        (spec / fname).write_text("x")
+    return spec
+
+
+class TestDiscoverFolderSpecs:
+    def test_a_spec_shaped_directory_under_a_known_root_is_adopted(self, tmp_path):
+        found = _spec_tree(tmp_path, "from-cli", "requirements.md")
+        index = {"seed": _entry(tmp_path / "seed", working_dir=str(tmp_path))}
+        assert r._discover_folder_specs(index) is True
+        assert index["from-cli"]["spec_dir"] == str(found)
+        assert index["from-cli"]["discovered"] is True
+        assert r._owns_slot_key("from-cli", index["from-cli"]["slot_key"])
+
+    def test_nothing_to_add_reports_false(self, tmp_path):
+        (tmp_path / ".kiro" / "specs").mkdir(parents=True)
+        index = {"seed": _entry(tmp_path / "seed", working_dir=str(tmp_path))}
+        assert r._discover_folder_specs(index) is False
+
+    def test_a_directory_without_kiro_markdown_is_not_a_spec(self, tmp_path):
+        _spec_tree(tmp_path, "just-notes", "notes.txt")
+        index = {"seed": _entry(tmp_path / "seed", working_dir=str(tmp_path))}
+        assert r._discover_folder_specs(index) is False
+
+    def test_a_deleted_directory_is_not_adopted_back(self, tmp_path):
+        found = _spec_tree(tmp_path, "deleted-one", "tasks.md")
+        r._remember_deleted(str(found))
+        index = {"seed": _entry(tmp_path / "seed", working_dir=str(tmp_path))}
+        # Deleting is a decision; the tombstone is what remembers it.
+        assert r._discover_folder_specs(index) is False
+        assert "deleted-one" not in index
+
+    def test_an_already_indexed_directory_is_not_re_added(self, tmp_path):
+        found = _spec_tree(tmp_path, "known", "tasks.md")
+        index = {"known": _entry(found, working_dir=str(tmp_path))}
+        assert r._discover_folder_specs(index) is False
+
+    def test_a_name_that_fails_the_admission_predicate_is_skipped(self, tmp_path):
+        _spec_tree(tmp_path, CRED_NAME, "tasks.md")
+        index = {"seed": _entry(tmp_path / "seed", working_dir=str(tmp_path))}
+        # Admitting on the grammar alone would re-add an entry the next load
+        # drops, rediscovering it on every call.
+        assert r._discover_folder_specs(index) is False
+
+    def test_a_file_where_a_spec_directory_would_be_is_skipped(self, tmp_path):
+        base = tmp_path / ".kiro" / "specs"
+        base.mkdir(parents=True)
+        (base / "a-file.md").write_text("x")
+        index = {"seed": _entry(tmp_path / "seed", working_dir=str(tmp_path))}
+        assert r._discover_folder_specs(index) is False
+
+    def test_an_unusable_indexed_root_is_not_enumerated(self, tmp_path):
+        index = {"seed": _entry(tmp_path / "seed", working_dir=str(tmp_path / "gone"))}
+        assert r._discover_folder_specs(index) is False
+
+    def test_a_sensitive_indexed_root_is_not_enumerated(self, tmp_path):
+        _spec_tree(tmp_path, "inside", "tasks.md")
+        index = {"seed": _entry(tmp_path / "seed", working_dir=str(tmp_path))}
+        with mock.patch.object(r, "is_sensitive_path", return_value=True):
+            assert r._discover_folder_specs(index) is False
+
+    def test_a_root_with_no_specs_directory_is_skipped(self, tmp_path):
+        index = {"seed": _entry(tmp_path / "seed", working_dir=str(tmp_path))}
+        assert r._discover_folder_specs(index) is False
+
+    def test_an_unreadable_specs_directory_is_skipped(self, tmp_path):
+        _spec_tree(tmp_path, "one", "tasks.md")
+        index = {"seed": _entry(tmp_path / "seed", working_dir=str(tmp_path))}
+        with mock.patch.object(Path, "iterdir", side_effect=OSError("denied")):
+            assert r._discover_folder_specs(index) is False
+
+    def test_a_failing_stat_falls_back_to_now(self, tmp_path):
+        _spec_tree(tmp_path, "one", "tasks.md")
+        index = {"seed": _entry(tmp_path / "seed", working_dir=str(tmp_path))}
+        real_stat = Path.stat
+        seen: list[str] = []
+
+        def _boom(self, *a, **kw):
+            # The product stats the candidate twice: once through is_dir(), then
+            # again for created_at. Only the second one is the guarded call.
+            if self.name == "one":
+                seen.append(str(self))
+                if len(seen) > 1:
+                    raise OSError("stat failed")
+            return real_stat(self, *a, **kw)
+
+        with mock.patch.object(Path, "stat", _boom):
+            assert r._discover_folder_specs(index) is True
+        assert index["one"]["created_at"] > 0
+        assert index["one"]["created_at"] == index["one"]["updated_at"]
+
+
+class TestLoadIndexWithDiscovery:
+    def test_it_returns_the_index_and_every_derived_phase_in_one_hop(self, tmp_path):
+        found = _spec_tree(tmp_path, "found", "requirements.md", "design.md")
+        _write_index({"seed": _entry(tmp_path / "seed", working_dir=str(tmp_path))})
+        index, phases = r._load_index_with_discovery()
+        assert set(index) == {"seed", "found"}
+        assert phases["found"] == "design"
+        assert phases["seed"] == "new"
+        # Discovery persists, so the next read does not have to rescan.
+        assert "found" in json.loads(r._index_path().read_text())
+        assert found.is_dir()
+
+
+class TestPrepareSpecDir:
+    def test_it_creates_the_spec_directory(self, tmp_path):
+        spec_dir, refusal = r._prepare_spec_dir(str(tmp_path), tmp_path, "demo", False)
+        assert refusal == ""
+        assert spec_dir == (tmp_path / ".kiro" / "specs" / "demo").resolve()
+        assert spec_dir.is_dir()
+
+    def test_a_resolved_path_outside_the_declared_root_is_refused(self, tmp_path):
+        outside = tmp_path.parent / "elsewhere"
+        with mock.patch.object(r, "_resolve_spec_dir", return_value=outside / "demo"):
+            _spec_dir, refusal = r._prepare_spec_dir(str(tmp_path), tmp_path, "demo", False)
+        assert refusal == "escape"
+
+    def test_the_settings_base_path_becomes_the_declared_root(self, tmp_path):
+        store = tmp_path / "store"
+        store.mkdir()
+        r._save_settings({"base_path": str(store)})
+        spec_dir, refusal = r._prepare_spec_dir(str(tmp_path), tmp_path, "demo", False)
+        assert refusal == ""
+        assert spec_dir == (store / "demo").resolve()
+
+    def test_a_destination_that_resolves_somewhere_sensitive_is_refused(self, tmp_path):
+        real_sensitive = r.is_sensitive_path
+        target = str((tmp_path / ".kiro" / "specs" / "demo").resolve())
+
+        def _sensitive(path: str, *a, **kw) -> bool:
+            # Containment only says "under the declared root"; if that root grows a
+            # link into a credential tree, BOTH paths resolve through it.
+            return path == target or real_sensitive(path, *a, **kw)
+
+        with mock.patch.object(r, "is_sensitive_path", _sensitive):
+            _spec_dir, refusal = r._prepare_spec_dir(str(tmp_path), tmp_path, "demo", False)
+        assert refusal == "escape"
+
+    def test_existing_kiro_documents_are_not_adopted_by_overwrite(self, tmp_path):
+        _spec_tree(tmp_path, "demo", "requirements.md", "tasks.md")
+        _spec_dir, refusal = r._prepare_spec_dir(str(tmp_path), tmp_path, "demo", False)
+        assert refusal == "existing:requirements.md, tasks.md"
+
+    def test_opting_in_adopts_them(self, tmp_path):
+        _spec_tree(tmp_path, "demo", "requirements.md")
+        _spec_dir, refusal = r._prepare_spec_dir(str(tmp_path), tmp_path, "demo", True)
+        assert refusal == ""
+
+    def test_a_failing_mkdir_is_reported_rather_than_raised(self, tmp_path):
+        with mock.patch.object(Path, "mkdir", side_effect=OSError("read-only fs")):
+            _spec_dir, refusal = r._prepare_spec_dir(str(tmp_path), tmp_path, "demo", False)
+        assert refusal.startswith("mkdir:") and "read-only fs" in refusal
+
+
+# -- HTTP: request plumbing ---------------------------------------------------
+
+
+BASE = f"/api/apps/{r.APP_NAME}"
+
+
+def _readable_payload():
+    """A payload stub whose ``at_eof()`` is False, so ``can_read_body`` is True.
+
+    ``make_mocked_request`` defaults to an empty stream, which reads as "no body"
+    -- and ``_client_claim`` only consults the body when it can be read.
+    """
+    payload = mock.Mock()
+    payload.at_eof.return_value = False
+    return payload
+
+
+def _mk(
+    method: str,
+    path: str,
+    *,
+    state=None,
+    match: dict | None = None,
+    query: str = "",
+    body=...,
+    authed: bool = True,
+):
+    """A mocked aiohttp request for a handler under test."""
+    full = f"{BASE}/{path}" + (f"?{query}" if query else "")
+    app = {"state": state} if state is not None else {}
+    kwargs = {"app": app, "match_info": match or {}}
+    if body is not ...:
+        kwargs["payload"] = _readable_payload()
+    req = make_mocked_request(method, full, **kwargs)  # type: ignore[arg-type]
+    if authed:
+        req["user"] = "test-user"
+    if body is not ...:
+        if body is None:
+            req.json = mock.AsyncMock(side_effect=ValueError("bad json"))  # type: ignore
+        else:
+            req.json = mock.AsyncMock(return_value=body)  # type: ignore[method-assign]
+    return req
+
+
+def _body(response) -> dict:
+    assert isinstance(response, web.Response)
+    raw = response.body
+    assert isinstance(raw, bytes)
+    return json.loads(raw.decode("utf-8"))
+
+
+@pytest.fixture(autouse=True)
+def _no_autonudge():
+    """Default to "no autonudge service" so nothing reaches a live loop registry."""
+    with mock.patch.object(r, "_autonudge_instance", lambda: None):
+        yield
+
+
+class TestRequireAuth:
+    def test_a_request_the_auth_middleware_never_touched_is_401(self):
+        denied = r._require_auth(_mk("GET", "specs", authed=False))
+        assert denied is not None and denied.status == 401
+        assert _body(denied)["code"] == "unauthorized"
+
+    def test_an_authenticated_request_passes(self):
+        assert r._require_auth(_mk("GET", "specs")) is None
+
+
+class TestReadJson:
+    @pytest.mark.asyncio
+    async def test_a_payload_that_does_not_decode_is_400(self):
+        out = await r._read_json(_mk("POST", "specs", body=None))
+        assert isinstance(out, web.Response) and out.status == 400
+        assert _body(out)["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_a_json_value_that_is_not_an_object_is_400(self):
+        out = await r._read_json(_mk("POST", "specs", body=[1, 2]))
+        assert isinstance(out, web.Response) and out.status == 400
+        assert _body(out)["code"] == "body_not_object"
+
+    @pytest.mark.asyncio
+    async def test_an_object_is_returned_as_a_dict(self):
+        assert await r._read_json(_mk("POST", "specs", body={"a": 1})) == {"a": 1}
+
+
+class TestRequireEnabled:
+    @pytest.mark.asyncio
+    async def test_a_disabled_app_is_denied_even_though_the_route_is_registered(self):
+        # Routes are wired once at gateway startup, so a default-disabled app
+        # would otherwise stay callable.
+        inner = mock.AsyncMock(return_value=web.json_response({"ok": True}))
+        wrapped = r._require_enabled(inner)
+        with mock.patch.object(r, "is_app_enabled", return_value=False):
+            out = await wrapped(_mk("GET", "specs"))
+        assert out.status == 403 and _body(out)["code"] == "app_disabled"
+        inner.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_enabled_app_reaches_the_handler(self):
+        inner = mock.AsyncMock(return_value=web.json_response({"ok": True}))
+        wrapped = r._require_enabled(inner)
+        with mock.patch.object(r, "is_app_enabled", return_value=True):
+            out = await wrapped(_mk("GET", "specs"))
+        assert _body(out) == {"ok": True}
+
+    def test_the_wrapper_keeps_the_handlers_identity(self):
+        assert r._require_enabled(r._handle_list).__name__ == "_handle_list"
+
+
+class TestClientClaim:
+    @pytest.mark.asyncio
+    async def test_a_delete_carries_its_claim_in_the_query_string(self):
+        req = _mk("DELETE", "specs/demo", query="spec_dir=/s&slot_key=spec-builder-demo-0123abcd")
+        assert await r._client_claim(req) == r._ClientClaim("/s", "spec-builder-demo-0123abcd")
+
+    @pytest.mark.asyncio
+    async def test_a_post_can_carry_it_in_the_body(self):
+        req = _mk(
+            "POST",
+            "specs/demo/stop",
+            body={"spec_dir": " /s ", "slot_key": " spec-builder-demo-0123abcd "},
+        )
+        assert await r._client_claim(req) == r._ClientClaim("/s", "spec-builder-demo-0123abcd")
+
+    @pytest.mark.asyncio
+    async def test_a_request_with_neither_is_unpinned_rather_than_refused(self):
+        # An older tab predates these fields, so "" must keep working.
+        assert await r._client_claim(_mk("POST", "specs/demo/stop")) == r._ClientClaim("", "")
+
+    @pytest.mark.asyncio
+    async def test_a_body_that_does_not_decode_leaves_the_claim_empty(self):
+        assert await r._client_claim(_mk("POST", "specs/demo/stop", body=None)) == r._ClientClaim(
+            "", ""
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_non_object_body_leaves_the_claim_empty(self):
+        assert await r._client_claim(
+            _mk("POST", "specs/demo/stop", body=["nope"])
+        ) == r._ClientClaim("", "")
+
+    @pytest.mark.asyncio
+    async def test_the_query_string_is_not_overridden_by_the_body(self):
+        req = _mk(
+            "POST",
+            "specs/demo/stop",
+            query="spec_dir=/from-query&slot_key=spec-builder-demo-0123abcd",
+            body={"spec_dir": "/from-body", "slot_key": "spec-builder-demo-ffffffff"},
+        )
+        assert (await r._client_claim(req)).spec_dir == "/from-query"
+
+
+# -- HTTP: repo info, browse, settings ---------------------------------------
+
+
+class TestHandleRepoInfo:
+    @pytest.mark.asyncio
+    async def test_unauthenticated(self):
+        out = await r._handle_repo_info(_mk("GET", "repo-info", authed=False))
+        assert out.status == 401
+
+    @pytest.mark.asyncio
+    async def test_no_path_answers_not_a_repo_without_running_git(self):
+        git = mock.AsyncMock()
+        with mock.patch.object(r, "_repo_info", git):
+            out = await r._handle_repo_info(_mk("GET", "repo-info"))
+        assert _body(out) == {"is_git": False}
+        git.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_path_that_fails_the_chokepoint_answers_not_a_repo(self, tmp_path):
+        # The hand-rolled is_absolute()/is_dir() pair skipped the sensitive-path
+        # denial _safe_dir applies, and statted on the event loop.
+        out = await r._handle_repo_info(
+            _mk("GET", "repo-info", query=f"path={tmp_path}/missing")
+        )
+        assert _body(out) == {"is_git": False}
+
+    @pytest.mark.asyncio
+    async def test_a_real_directory_is_probed(self, tmp_path):
+        with mock.patch.object(
+            r, "_repo_info", mock.AsyncMock(return_value={"is_git": True, "root": str(tmp_path)})
+        ):
+            out = await r._handle_repo_info(_mk("GET", "repo-info", query=f"path={tmp_path}"))
+        assert _body(out)["is_git"] is True
+
+
+class TestHandleBrowse:
+    @pytest.mark.asyncio
+    async def test_unauthenticated(self):
+        out = await r._handle_browse(_mk("GET", "browse", authed=False))
+        assert out.status == 401
+
+    @pytest.mark.asyncio
+    async def test_a_denied_path_is_403_and_audited(self, tmp_path, _quiet_sel):
+        out = await r._handle_browse(_mk("GET", "browse", query=f"path={tmp_path}/gone"))
+        assert out.status == 403 and _body(out)["code"] == "access_denied"
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_browse_denied" in ops
+
+    @pytest.mark.asyncio
+    async def test_a_named_path_lists_its_subdirectories_and_its_parent(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        with mock.patch.object(r, "_repo_info", mock.AsyncMock(return_value={"is_git": True})):
+            out = await r._handle_browse(_mk("GET", "browse", query=f"path={tmp_path}"))
+        payload = _body(out)
+        assert payload["path"] == str(Path(os.path.realpath(tmp_path)))
+        assert payload["parent"] == os.path.dirname(os.path.realpath(tmp_path))
+        assert [d["name"] for d in payload["dirs"]] == ["src"]
+        assert payload["is_git"] is True
+        # recents are only attached to the INITIAL empty-path call.
+        assert "recents" not in payload
+
+    @pytest.mark.asyncio
+    async def test_the_initial_call_defaults_to_home_and_attaches_recents(self, tmp_path):
+        with (
+            mock.patch.object(Path, "home", return_value=tmp_path),
+            mock.patch.object(r, "_repo_info", mock.AsyncMock(return_value={})),
+            mock.patch.object(r, "_read_recent_projects", return_value=["/p1"]),
+        ):
+            out = await r._handle_browse(_mk("GET", "browse"))
+        payload = _body(out)
+        assert payload["recents"] == ["/p1"]
+        assert payload["is_git"] is False
+
+
+class TestReadRecentProjects:
+    def test_a_missing_file_is_an_empty_list(self):
+        assert r._read_recent_projects() == []
+
+    def test_only_existing_directories_survive_and_the_list_is_bounded(self, tmp_path):
+        from kiro_crew.config.paths import config_dir
+
+        real = [str(tmp_path / f"p{i}") for i in range(12)]
+        for path in real:
+            Path(path).mkdir()
+        config_dir().mkdir(parents=True, exist_ok=True)
+        (config_dir() / "recent_projects.json").write_text(
+            json.dumps([*real, str(tmp_path / "gone"), 7, None])
+        )
+        assert r._read_recent_projects() == real[:10]
+
+    def test_a_malformed_or_wrongly_shaped_file_is_an_empty_list(self):
+        from kiro_crew.config.paths import config_dir
+
+        config_dir().mkdir(parents=True, exist_ok=True)
+        (config_dir() / "recent_projects.json").write_text('{"not": "a list"}')
+        assert r._read_recent_projects() == []
+
+
+class TestHandleSettings:
+    @pytest.mark.asyncio
+    async def test_unauthenticated_on_both_verbs(self):
+        assert (await r._handle_get_settings(_mk("GET", "settings", authed=False))).status == 401
+        assert (await r._handle_put_settings(_mk("PUT", "settings", authed=False))).status == 401
+
+    @pytest.mark.asyncio
+    async def test_the_default_is_an_empty_base_path(self):
+        assert _body(await r._handle_get_settings(_mk("GET", "settings"))) == {"base_path": ""}
+
+    @pytest.mark.asyncio
+    async def test_a_stored_base_path_is_redacted_on_its_way_out(self):
+        # settings.json is agent-writable, so a credential parked in base_path
+        # would otherwise be rendered verbatim in the dashboard.
+        r._save_settings({"base_path": f"/srv/{CRED_NAME}"})
+        assert CRED_NAME not in _body(await r._handle_get_settings(_mk("GET", "settings")))[
+            "base_path"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_body_is_400(self):
+        out = await r._handle_put_settings(_mk("PUT", "settings", body=None))
+        assert out.status == 400
+
+    @pytest.mark.asyncio
+    async def test_a_relative_base_path_is_refused(self):
+        out = await r._handle_put_settings(_mk("PUT", "settings", body={"base_path": "specs"}))
+        assert out.status == 400 and _body(out)["code"] == "base_path_not_absolute"
+
+    @pytest.mark.asyncio
+    async def test_a_base_path_that_fails_the_chokepoint_is_refused(self, tmp_path):
+        # Without this, spec storage could be repointed at a credential directory
+        # and every subsequent spec would write into it.
+        with mock.patch.object(r, "is_sensitive_path", return_value=True):
+            out = await r._handle_put_settings(
+                _mk("PUT", "settings", body={"base_path": str(tmp_path)})
+            )
+        assert out.status == 400 and _body(out)["code"] == "base_path_not_a_directory"
+
+    @pytest.mark.asyncio
+    async def test_a_usable_base_path_is_stored_fully_resolved(self, tmp_path):
+        out = await r._handle_put_settings(
+            _mk("PUT", "settings", body={"base_path": f" {tmp_path} "})
+        )
+        assert _body(out) == {"ok": True, "base_path": str(Path(os.path.realpath(tmp_path)))}
+        assert r._load_settings()["base_path"] == str(Path(os.path.realpath(tmp_path)))
+
+    @pytest.mark.asyncio
+    async def test_an_empty_base_path_clears_the_override(self, tmp_path):
+        r._save_settings({"base_path": str(tmp_path)})
+        out = await r._handle_put_settings(_mk("PUT", "settings", body={"base_path": ""}))
+        assert _body(out) == {"ok": True, "base_path": ""}
+        assert r._load_settings()["base_path"] == ""
+
+
+# -- HTTP: list ---------------------------------------------------------------
+
+
+class TestHandleList:
+    @pytest.mark.asyncio
+    async def test_unauthenticated(self):
+        assert (await r._handle_list(_mk("GET", "specs", authed=False))).status == 401
+
+    @pytest.mark.asyncio
+    async def test_an_empty_index_still_reports_the_default_location(self):
+        payload = _body(await r._handle_list(_mk("GET", "specs", state=_State())))
+        assert payload == {"specs": [], "default_base": ".kiro/specs"}
+
+    @pytest.mark.asyncio
+    async def test_every_string_from_the_index_is_redacted(self, tmp_path):
+        _write_index(
+            {
+                "demo": _entry(
+                    tmp_path / f"specs/{CRED_NAME}",
+                    working_dir=str(tmp_path),
+                    spec_type=CRED_NAME,
+                )
+            }
+        )
+        payload = _body(await r._handle_list(_mk("GET", "specs", state=_State())))
+        assert CRED_NAME not in json.dumps(payload)
+
+    @pytest.mark.asyncio
+    async def test_a_delete_in_flight_is_not_a_spec_the_user_still_has(self, tmp_path):
+        _write_index(
+            {
+                "doomed": _entry(
+                    tmp_path / "doomed", deleting={"owner": r._PROCESS_ID, "at": time.time()}
+                ),
+                "kept": _entry(tmp_path / "kept"),
+            }
+        )
+        payload = _body(await r._handle_list(_mk("GET", "specs", state=_State())))
+        assert [s["name"] for s in payload["specs"]] == ["kept"]
+
+    @pytest.mark.asyncio
+    async def test_the_status_is_reconciled_rather_than_echoed(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo", status="executing")})
+        payload = _body(await r._handle_list(_mk("GET", "specs", state=_State())))
+        # A capped nudge loop that ran out of cycles leaves "executing" forever.
+        assert payload["specs"][0]["status"] == "planning"
+
+    @pytest.mark.asyncio
+    async def test_the_live_running_flag_comes_from_the_slot(self, tmp_path):
+        state = _State(
+            **{"spec-builder-demo-0123abcd": _Slot("spec-builder-demo-0123abcd", running=True)}
+        )
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        payload = _body(await r._handle_list(_mk("GET", "specs", state=state)))
+        assert payload["specs"][0]["running"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_gateway_with_no_state_still_lists(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        payload = _body(await r._handle_list(_mk("GET", "specs")))
+        assert payload["specs"][0]["running"] is False
+
+    @pytest.mark.asyncio
+    async def test_the_derived_phase_is_reported(self, tmp_path):
+        spec = tmp_path / "demo"
+        spec.mkdir()
+        (spec / "requirements.md").write_text("x")
+        _write_index({"demo": _entry(spec)})
+        payload = _body(await r._handle_list(_mk("GET", "specs", state=_State())))
+        assert payload["specs"][0]["phase"] == "requirements"
+
+    @pytest.mark.asyncio
+    async def test_agent_written_timestamps_cannot_break_the_sort(self, tmp_path):
+        # Mixing a str and a float in one sort key raises TypeError, which turned a
+        # single malformed entry into a 500 on EVERY list request.
+        _write_index(
+            {
+                "newest": _entry(tmp_path / "a", updated_at=900.0),
+                "broken": _entry(tmp_path / "b", updated_at="soon", created_at="also-soon"),
+                "middle": _entry(tmp_path / "c", updated_at=500.0),
+            }
+        )
+        payload = _body(await r._handle_list(_mk("GET", "specs", state=_State())))
+        assert [s["name"] for s in payload["specs"]] == ["newest", "middle", "broken"]
+        assert payload["specs"][-1]["updated_at"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_an_entry_with_no_updated_at_orders_by_created_at(self, tmp_path):
+        _write_index(
+            {
+                "older": _entry(tmp_path / "a", updated_at=0, created_at=100.0),
+                "newer": _entry(tmp_path / "b", updated_at=0, created_at=800.0),
+            }
+        )
+        payload = _body(await r._handle_list(_mk("GET", "specs", state=_State())))
+        assert [s["name"] for s in payload["specs"]] == ["newer", "older"]
+
+
+# -- HTTP: create -------------------------------------------------------------
+
+
+@pytest.fixture
+def _no_dispatch():
+    """Replace the turn relay: creating a real task needs a live chat runner."""
+    with mock.patch.object(r, "_dispatch_turn") as dispatch:
+        yield dispatch
+
+
+class TestHandleCreate:
+    @pytest.mark.asyncio
+    async def test_unauthenticated(self):
+        assert (await r._handle_create(_mk("POST", "specs", authed=False))).status == 401
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_body_is_400(self):
+        assert (await r._handle_create(_mk("POST", "specs", body=None))).status == 400
+
+    @pytest.mark.asyncio
+    async def test_a_name_that_fails_the_grammar_is_400(self):
+        out = await r._handle_create(_mk("POST", "specs", body={"name": "has space"}))
+        assert out.status == 400 and _body(out)["code"] == "invalid_name"
+
+    @pytest.mark.asyncio
+    async def test_a_credential_shaped_name_is_400_not_a_spec_the_loader_will_drop(self):
+        out = await r._handle_create(_mk("POST", "specs", body={"name": CRED_NAME}))
+        assert out.status == 400 and _body(out)["code"] == "invalid_name"
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_spec_type_is_400(self, tmp_path):
+        out = await r._handle_create(
+            _mk("POST", "specs", body={"name": "demo", "spec_type": "epic"})
+        )
+        assert out.status == 400 and _body(out)["code"] == "invalid_spec_type"
+
+    @pytest.mark.asyncio
+    async def test_a_relative_working_dir_is_400(self):
+        out = await r._handle_create(
+            _mk("POST", "specs", body={"name": "demo", "working_dir": "project"})
+        )
+        assert out.status == 400 and _body(out)["code"] == "working_dir_not_absolute"
+
+    @pytest.mark.asyncio
+    async def test_a_missing_or_sensitive_working_dir_gets_one_indistinguishable_400(
+        self, tmp_path
+    ):
+        # One response for "missing", "not a directory" and "sensitive" so the
+        # endpoint cannot be used to probe the filesystem.
+        out = await r._handle_create(
+            _mk("POST", "specs", body={"name": "demo", "working_dir": str(tmp_path / "gone")})
+        )
+        assert out.status == 400 and _body(out)["code"] == "working_dir_not_a_directory"
+        with mock.patch.object(r, "is_sensitive_path", return_value=True):
+            out = await r._handle_create(
+                _mk("POST", "specs", body={"name": "demo", "working_dir": str(tmp_path)})
+            )
+        assert _body(out)["code"] == "working_dir_not_a_directory"
+
+    @pytest.mark.asyncio
+    async def test_a_duplicate_name_is_409(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        out = await r._handle_create(
+            _mk("POST", "specs", body={"name": "demo", "working_dir": str(tmp_path)})
+        )
+        assert out.status == 409 and _body(out)["code"] == "spec_exists"
+
+    @pytest.mark.asyncio
+    async def test_a_successful_create_returns_201_and_seeds_the_agent(
+        self, tmp_path, _no_dispatch, _quiet_sel
+    ):
+        state = _State()
+        with _no_rehydrate():
+            out = await r._handle_create(
+                _mk(
+                    "POST",
+                    "specs",
+                    state=state,
+                    body={
+                        "name": "demo",
+                        "working_dir": str(tmp_path),
+                        "spec_type": "quick",
+                        "description": "add a picker",
+                    },
+                )
+            )
+        payload = _body(out)
+        assert out.status == 201
+        assert payload["name"] == "demo" and payload["spec_type"] == "quick"
+        assert payload["status"] == "planning" and payload["worktree_branch"] == ""
+        spec_dir = Path(payload["spec_dir"])
+        assert spec_dir.is_dir()
+        # A fresh per-creation key, so a reused name never appends to the previous
+        # spec's transcript.
+        stored = r._load_index()["demo"]
+        assert r._owns_slot_key("demo", stored["slot_key"])
+        assert stored["slot_key"] != "spec-builder-demo"
+        seed = _no_dispatch.call_args.args[2]
+        assert "add a picker" in seed and "QUICK spec" in seed
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_create" in ops
+
+    @pytest.mark.asyncio
+    async def test_creating_clears_an_earlier_tombstone_for_the_same_directory(
+        self, tmp_path, _no_dispatch
+    ):
+        spec_dir = (tmp_path / ".kiro" / "specs" / "demo").resolve()
+        r._remember_deleted(str(spec_dir))
+        with _no_rehydrate():
+            out = await r._handle_create(
+                _mk(
+                    "POST",
+                    "specs",
+                    state=_State(),
+                    body={"name": "demo", "working_dir": str(tmp_path)},
+                )
+            )
+        assert out.status == 201
+        # Creating is an explicit decision that outranks an earlier delete.
+        assert r._load_deleted() == []
+
+    @pytest.mark.asyncio
+    async def test_existing_kiro_documents_are_409_with_the_opt_in_named(self, tmp_path):
+        _spec_tree(tmp_path, "demo", "requirements.md")
+        out = await r._handle_create(
+            _mk("POST", "specs", body={"name": "demo", "working_dir": str(tmp_path)})
+        )
+        assert out.status == 409
+        payload = _body(out)
+        assert payload["code"] == "spec_files_exist"
+        assert "import_existing" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_a_resolved_path_outside_its_root_is_400_and_audited(
+        self, tmp_path, _quiet_sel
+    ):
+        with mock.patch.object(
+            r, "_prepare_spec_dir", return_value=(tmp_path / "elsewhere", "escape")
+        ):
+            out = await r._handle_create(
+                _mk("POST", "specs", body={"name": "demo", "working_dir": str(tmp_path)})
+            )
+        assert out.status == 400 and _body(out)["code"] == "spec_path_outside_root"
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_path_escape_denied" in ops
+
+    @pytest.mark.asyncio
+    async def test_a_directory_that_cannot_be_created_is_400(self, tmp_path):
+        with mock.patch.object(
+            r, "_prepare_spec_dir", return_value=(tmp_path / "x", "mkdir:read-only fs")
+        ):
+            out = await r._handle_create(
+                _mk("POST", "specs", body={"name": "demo", "working_dir": str(tmp_path)})
+            )
+        assert out.status == 400 and _body(out)["code"] == "spec_dir_creation_failed"
+        assert "read-only fs" in _body(out)["error"]
+
+    @pytest.mark.asyncio
+    async def test_a_concurrent_create_that_wins_the_index_makes_this_one_409(self, tmp_path):
+        # The duplicate check at the top is stale by the time the awaits are done,
+        # so the insert is the arbitration and the loser touches no slot state.
+        with mock.patch.object(r, "_mutate_index", mock.AsyncMock(return_value=False)):
+            out = await r._handle_create(
+                _mk(
+                    "POST",
+                    "specs",
+                    state=_State(),
+                    body={"name": "demo", "working_dir": str(tmp_path)},
+                )
+            )
+        assert out.status == 409 and _body(out)["code"] == "spec_exists"
+
+    @pytest.mark.asyncio
+    async def test_a_slot_owned_by_another_app_unwinds_the_insert(self, tmp_path):
+        state = _State(
+            **{"spec-builder-demo": _Slot("spec-builder-demo", app="issue-radar")}
+        )
+        with _no_rehydrate(), mock.patch.object(r, "_ensure_worker_slot", mock.AsyncMock(return_value=None)):
+            out = await r._handle_create(
+                _mk(
+                    "POST",
+                    "specs",
+                    state=state,
+                    body={"name": "demo", "working_dir": str(tmp_path)},
+                )
+            )
+        assert out.status == 409 and _body(out)["code"] == "slot_owned_by_another_app"
+        assert r._load_index() == {}
+
+    @pytest.mark.asyncio
+    async def test_a_spec_replaced_during_slot_setup_is_409_and_unwound(
+        self, tmp_path, _no_dispatch, _quiet_sel
+    ):
+        state = _State()
+
+        async def _steal(*_a, **_kw):
+            # A concurrent delete + re-import lands in the slot-setup window; the
+            # seed prompt must not drive the replacement's agent.
+            index = r._load_index()
+            index["demo"]["slot_key"] = "spec-builder-demo-ffffffff"
+            r._save_index(index)
+            return _Slot("spec-builder-demo")
+
+        with mock.patch.object(r, "_ensure_worker_slot", _steal):
+            out = await r._handle_create(
+                _mk(
+                    "POST",
+                    "specs",
+                    state=state,
+                    body={"name": "demo", "working_dir": str(tmp_path)},
+                )
+            )
+        assert out.status == 409 and _body(out)["code"] == "spec_changed_during_create"
+        _no_dispatch.assert_not_called()
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_create_aborted" in ops
+
+    @pytest.mark.asyncio
+    async def test_the_unwind_leaves_a_replacements_entry_alone(self, tmp_path, _no_dispatch):
+        """The pop keys off the NAME, so an unpinned unwind would delete a
+        same-name spec created while we were validating."""
+        replacement = _entry(tmp_path / "other", slot_key="spec-builder-demo-ffffffff")
+
+        async def _replace(*_a, **_kw):
+            r._save_index({"demo": dict(replacement)})
+            return None
+
+        with mock.patch.object(r, "_ensure_worker_slot", _replace):
+            out = await r._handle_create(
+                _mk(
+                    "POST",
+                    "specs",
+                    state=_State(),
+                    body={"name": "demo", "working_dir": str(tmp_path)},
+                )
+            )
+        assert out.status == 409
+        assert r._load_index()["demo"]["slot_key"] == "spec-builder-demo-ffffffff"
+
+    @pytest.mark.asyncio
+    async def test_a_title_that_cannot_be_set_does_not_fail_the_create(
+        self, tmp_path, _no_dispatch
+    ):
+        class _NoTitle(_Slot):
+            def __setattr__(self, name, value):
+                if name == "title" and getattr(self, "_ready", False):
+                    raise RuntimeError("frozen")
+                super().__setattr__(name, value)
+
+        slot = _NoTitle("spec-builder-demo")
+        slot._ready = True
+        with mock.patch.object(r, "_ensure_worker_slot", mock.AsyncMock(return_value=slot)):
+            out = await r._handle_create(
+                _mk(
+                    "POST",
+                    "specs",
+                    state=_State(),
+                    body={"name": "demo", "working_dir": str(tmp_path)},
+                )
+            )
+        assert out.status == 201
+
+
+class TestHandleCreateWithWorktree:
+    @pytest.mark.asyncio
+    async def test_a_non_repository_is_400(self, tmp_path):
+        with mock.patch.object(r, "_repo_info", mock.AsyncMock(return_value={"is_git": False})):
+            out = await r._handle_create(
+                _mk(
+                    "POST",
+                    "specs",
+                    body={
+                        "name": "demo",
+                        "working_dir": str(tmp_path),
+                        "use_worktree": True,
+                    },
+                )
+            )
+        assert out.status == 400 and _body(out)["code"] == "worktree_requires_git"
+
+    @pytest.mark.asyncio
+    async def test_a_failed_creation_is_400(self, tmp_path):
+        with (
+            mock.patch.object(
+                r,
+                "_repo_info",
+                mock.AsyncMock(return_value={"is_git": True, "root": str(tmp_path)}),
+            ),
+            mock.patch.object(
+                r, "_create_worktree", mock.AsyncMock(return_value="path already exists")
+            ),
+        ):
+            out = await r._handle_create(
+                _mk(
+                    "POST",
+                    "specs",
+                    body={"name": "demo", "working_dir": str(tmp_path), "use_worktree": True},
+                )
+            )
+        assert out.status == 400 and _body(out)["code"] == "worktree_creation_failed"
+
+    @pytest.mark.asyncio
+    async def test_a_worktree_that_is_not_a_usable_directory_is_rolled_back(self, tmp_path):
+        remove = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                r,
+                "_repo_info",
+                mock.AsyncMock(return_value={"is_git": True, "root": str(tmp_path)}),
+            ),
+            mock.patch.object(
+                r,
+                "_create_worktree",
+                mock.AsyncMock(return_value=(str(tmp_path / "wt-gone"), "spec/demo")),
+            ),
+            mock.patch.object(r, "_remove_worktree", remove),
+        ):
+            out = await r._handle_create(
+                _mk(
+                    "POST",
+                    "specs",
+                    body={"name": "demo", "working_dir": str(tmp_path), "use_worktree": True},
+                )
+            )
+        assert out.status == 400 and _body(out)["code"] == "worktree_unusable"
+        remove.assert_awaited_once_with(str(tmp_path), str(tmp_path / "wt-gone"), "spec/demo")
+
+    @pytest.mark.asyncio
+    async def test_the_worktree_becomes_the_containment_root_for_the_spec_files(
+        self, tmp_path, _no_dispatch
+    ):
+        # Without re-validating the worktree, containment is still measured against
+        # the ORIGINAL checkout and every worktree-mode create fails.
+        worktree = tmp_path / "repo-wt-demo"
+        worktree.mkdir()
+        with (
+            _no_rehydrate(),
+            mock.patch.object(
+                r,
+                "_repo_info",
+                mock.AsyncMock(return_value={"is_git": True, "root": str(tmp_path)}),
+            ),
+            mock.patch.object(
+                r, "_create_worktree", mock.AsyncMock(return_value=(str(worktree), "spec/demo"))
+            ),
+        ):
+            out = await r._handle_create(
+                _mk(
+                    "POST",
+                    "specs",
+                    state=_State(),
+                    body={"name": "demo", "working_dir": str(tmp_path), "use_worktree": True},
+                )
+            )
+        payload = _body(out)
+        assert out.status == 201
+        assert payload["worktree_branch"] == "spec/demo"
+        assert payload["working_dir"] == str(Path(os.path.realpath(worktree)))
+        assert payload["spec_dir"].startswith(str(Path(os.path.realpath(worktree))))
+
+    @pytest.mark.asyncio
+    async def test_a_refusal_after_the_worktree_exists_removes_it(self, tmp_path):
+        worktree = tmp_path / "repo-wt-demo"
+        worktree.mkdir()
+        remove = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                r,
+                "_repo_info",
+                mock.AsyncMock(return_value={"is_git": True, "root": str(tmp_path)}),
+            ),
+            mock.patch.object(
+                r, "_create_worktree", mock.AsyncMock(return_value=(str(worktree), "spec/demo"))
+            ),
+            mock.patch.object(r, "_remove_worktree", remove),
+            mock.patch.object(r, "_prepare_spec_dir", return_value=(worktree, "escape")),
+        ):
+            out = await r._handle_create(
+                _mk(
+                    "POST",
+                    "specs",
+                    body={"name": "demo", "working_dir": str(tmp_path), "use_worktree": True},
+                )
+            )
+        assert out.status == 400
+        remove.assert_awaited_once()
+
+
+# -- HTTP: detail, transcript, message ----------------------------------------
+
+
+class TestHandleGet:
+    @pytest.mark.asyncio
+    async def test_unauthenticated(self):
+        out = await r._handle_get(_mk("GET", "specs/demo", match={"name": "demo"}, authed=False))
+        assert out.status == 401
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_spec_is_404(self):
+        out = await r._handle_get(_mk("GET", "specs/demo", match={"name": "demo"}))
+        assert out.status == 404 and _body(out)["code"] == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_the_documents_state_and_context_counters_are_returned(self, tmp_path):
+        spec = tmp_path / "demo"
+        spec.mkdir()
+        (spec / "requirements.md").write_text("the requirements")
+        (spec / "tasks.md").write_text("- [ ] one")
+        (spec / ".spec-state.json").write_text(json.dumps({"blocking": "review"}))
+        _write_index({"demo": _entry(spec, worktree_branch="spec/demo")})
+        slot = _Slot("spec-builder-demo-0123abcd", running=True)
+        slot.messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "content": "fs_write"},
+            {"role": "tool", "content": "fs_read"},
+            {"role": "assistant", "content": "done"},
+        ]
+        state = _State(**{"spec-builder-demo-0123abcd": slot})
+        with _no_rehydrate():
+            out = await r._handle_get(
+                _mk("GET", "specs/demo", state=state, match={"name": "demo"})
+            )
+        payload = _body(out)
+        assert payload["phase"] == "tasks"
+        assert payload["files"]["requirements.md"] == "the requirements"
+        assert payload["files"]["design.md"] is None
+        assert payload["state"]["blocking"] == "review"
+        assert payload["running"] is True
+        assert payload["slot_key"] == "spec-builder-demo-0123abcd"
+        assert payload["context"] == {
+            "worktree_branch": "spec/demo",
+            "turns": 1,
+            "tool_calls": 2,
+        }
+
+    @pytest.mark.asyncio
+    async def test_without_a_live_slot_the_key_is_resolved_from_the_index(self, tmp_path):
+        spec = tmp_path / "demo"
+        spec.mkdir()
+        _write_index({"demo": _entry(spec)})
+        # The SPA must NOT derive the key from the name: keys are per-creation, so a
+        # reused name would mount the embed against the previous transcript.
+        out = await r._handle_get(_mk("GET", "specs/demo", match={"name": "demo"}))
+        payload = _body(out)
+        assert payload["slot_key"] == "spec-builder-demo-0123abcd"
+        assert payload["running"] is False
+
+    @pytest.mark.asyncio
+    async def test_a_spec_deleted_while_the_documents_were_read_is_404(self, tmp_path):
+        spec = tmp_path / "demo"
+        spec.mkdir()
+        _write_index({"demo": _entry(spec)})
+
+        def _collect_then_delete(_spec_dir):
+            r._save_index({})
+            return "new", {}, None
+
+        with mock.patch.object(r, "_collect_spec_documents", _collect_then_delete):
+            out = await r._handle_get(
+                _mk("GET", "specs/demo", state=_State(), match={"name": "demo"})
+            )
+        assert out.status == 404
+
+    @pytest.mark.asyncio
+    async def test_a_spec_recreated_elsewhere_during_the_read_is_409(self, tmp_path):
+        spec = tmp_path / "demo"
+        spec.mkdir()
+        _write_index({"demo": _entry(spec)})
+
+        def _collect_then_replace(_spec_dir):
+            r._save_index({"demo": _entry(tmp_path / "somewhere-else")})
+            return "new", {}, None
+
+        with mock.patch.object(r, "_collect_spec_documents", _collect_then_replace):
+            out = await r._handle_get(
+                _mk("GET", "specs/demo", state=_State(), match={"name": "demo"})
+            )
+        assert out.status == 409 and _body(out)["code"] == "spec_changed_during_read"
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_slot_refuses_the_whole_detail_read(self, tmp_path):
+        # Returning 200 anyway let the user read, message into and approve tool
+        # calls in an unrelated session from this app.
+        spec = tmp_path / "demo"
+        spec.mkdir()
+        _write_index({"demo": _entry(spec)})
+        state = _State(
+            **{
+                "spec-builder-demo-0123abcd": _Slot(
+                    "spec-builder-demo-0123abcd", app="issue-radar"
+                )
+            }
+        )
+        with _no_rehydrate():
+            out = await r._handle_get(
+                _mk("GET", "specs/demo", state=state, match={"name": "demo"})
+            )
+        assert out.status == 409 and _body(out)["code"] == "slot_owned_by_another_app"
+
+    @pytest.mark.asyncio
+    async def test_index_strings_are_redacted(self, tmp_path):
+        spec = tmp_path / "demo"
+        spec.mkdir()
+        _write_index({"demo": _entry(spec, spec_type=CRED_NAME, worktree_branch=CRED_NAME)})
+        out = await r._handle_get(_mk("GET", "specs/demo", match={"name": "demo"}))
+        assert CRED_NAME not in json.dumps(_body(out))
+
+
+class TestHandleMessages:
+    @pytest.mark.asyncio
+    async def test_unauthenticated(self):
+        out = await r._handle_messages(
+            _mk("GET", "specs/demo/messages", match={"name": "demo"}, authed=False)
+        )
+        assert out.status == 401
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_spec_is_404(self):
+        out = await r._handle_messages(
+            _mk("GET", "specs/demo/messages", state=_State(), match={"name": "demo"})
+        )
+        assert out.status == 404
+
+    @pytest.mark.asyncio
+    async def test_the_transcript_and_the_running_flag_are_returned(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        slot = _Slot("spec-builder-demo-0123abcd", running=True)
+        slot.messages = [{"role": "user", "content": "hello", "ts": "1"}]
+        state = _State(**{"spec-builder-demo-0123abcd": slot})
+        with _no_rehydrate():
+            out = await r._handle_messages(
+                _mk("GET", "specs/demo/messages", state=state, match={"name": "demo"})
+            )
+        assert _body(out) == {
+            "messages": [{"role": "user", "content": "hello", "ts": "1"}],
+            "running": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_slot_refuses_rather_than_leaking_the_conversation(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        state = _State(
+            **{
+                "spec-builder-demo-0123abcd": _Slot(
+                    "spec-builder-demo-0123abcd", app="issue-radar"
+                )
+            }
+        )
+        with _no_rehydrate():
+            out = await r._handle_messages(
+                _mk("GET", "specs/demo/messages", state=state, match={"name": "demo"})
+            )
+        assert out.status == 409 and _body(out)["code"] == "slot_owned_by_another_app"
+
+
+class TestHandleMessage:
+    @pytest.mark.asyncio
+    async def test_unauthenticated(self):
+        out = await r._handle_message(
+            _mk("POST", "specs/demo/message", match={"name": "demo"}, authed=False)
+        )
+        assert out.status == 401
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_spec_is_404(self):
+        out = await r._handle_message(
+            _mk("POST", "specs/demo/message", state=_State(), match={"name": "demo"})
+        )
+        assert out.status == 404
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_body_is_400(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        out = await r._handle_message(
+            _mk("POST", "specs/demo/message", state=_State(), match={"name": "demo"}, body=None)
+        )
+        assert out.status == 400
+
+    @pytest.mark.asyncio
+    async def test_an_empty_text_is_400(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        out = await r._handle_message(
+            _mk(
+                "POST",
+                "specs/demo/message",
+                state=_State(),
+                match={"name": "demo"},
+                body={"text": "   "},
+            )
+        )
+        assert out.status == 400 and _body(out)["code"] == "text_required"
+
+    @pytest.mark.asyncio
+    async def test_a_claim_naming_a_different_directory_is_409(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        out = await r._handle_message(
+            _mk(
+                "POST",
+                "specs/demo/message",
+                state=_State(),
+                match={"name": "demo"},
+                body={"text": "go", "spec_dir": "/somewhere-else"},
+            )
+        )
+        assert out.status == 409 and _body(out)["code"] == "stale_client"
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_slot_refuses_the_dispatch(self, tmp_path, _no_dispatch):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        with mock.patch.object(r, "_ensure_worker_slot", mock.AsyncMock(return_value=None)):
+            out = await r._handle_message(
+                _mk(
+                    "POST",
+                    "specs/demo/message",
+                    state=_State(),
+                    match={"name": "demo"},
+                    body={"text": "go"},
+                )
+            )
+        assert out.status == 409 and _body(out)["code"] == "slot_owned_by_another_app"
+        _no_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_delete_that_lands_during_slot_acquisition_is_409(
+        self, tmp_path, _no_dispatch
+    ):
+        # _ensure_worker_slot awaits, so a delete can start AND finish between the
+        # first check and the dispatch.
+        _write_index({"demo": _entry(tmp_path / "demo")})
+
+        async def _slot_then_delete(*_a, **_kw):
+            r._save_index({})
+            return _Slot("spec-builder-demo-0123abcd")
+
+        with mock.patch.object(r, "_ensure_worker_slot", _slot_then_delete):
+            out = await r._handle_message(
+                _mk(
+                    "POST",
+                    "specs/demo/message",
+                    state=_State(),
+                    match={"name": "demo"},
+                    body={"text": "go"},
+                )
+            )
+        assert out.status == 409 and _body(out)["code"] == "stale_client"
+        _no_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_turn_is_relayed_and_the_spec_stamped(self, tmp_path, _no_dispatch):
+        _write_index({"demo": _entry(tmp_path / "demo", working_dir=str(tmp_path))})
+        with _no_rehydrate():
+            out = await r._handle_message(
+                _mk(
+                    "POST",
+                    "specs/demo/message",
+                    state=_State(),
+                    match={"name": "demo"},
+                    body={
+                        "text": " draft it ",
+                        "spec_dir": str(tmp_path / "demo"),
+                        "slot_key": "spec-builder-demo-0123abcd",
+                    },
+                )
+            )
+        assert _body(out) == {"ok": True}
+        assert _no_dispatch.call_args.args[2] == "draft it"
+        assert r._load_index()["demo"]["updated_at"] > 200.0
+
+
+# -- HTTP: handoff ------------------------------------------------------------
+
+
+@pytest.fixture
+def _armed():
+    """A stub autonudge service plus a successful authorization."""
+    svc = mock.MagicMock()
+    svc.get_by_slot.return_value = None
+    svc.remove = mock.AsyncMock()
+    authz = mock.AsyncMock(return_value=(SimpleNamespace(id="loop-1"), None, 0))
+    with (
+        mock.patch.object(r, "_autonudge_instance", lambda: svc),
+        mock.patch.object(r, "authorize_and_add_nudge", authz),
+        mock.patch.object(r, "_exec_loop_active", return_value=False),
+    ):
+        yield SimpleNamespace(svc=svc, authz=authz)
+
+
+def _ready_handoff(sentinel: str = "/spec/STOP"):
+    return mock.patch.object(r, "_prepare_handoff", return_value=(True, sentinel))
+
+
+def _handoff_request(tmp_path, state, **body):
+    _write_index({"demo": _entry(tmp_path / "demo", working_dir=str(tmp_path))})
+    return _mk(
+        "POST",
+        "specs/demo/handoff",
+        state=state,
+        match={"name": "demo"},
+        body=body or {},
+    )
+
+
+class TestHandleHandoff:
+    @pytest.mark.asyncio
+    async def test_unauthenticated(self):
+        out = await r._handle_handoff(
+            _mk("POST", "specs/demo/handoff", match={"name": "demo"}, authed=False)
+        )
+        assert out.status == 401
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_spec_is_404(self):
+        out = await r._handle_handoff(
+            _mk("POST", "specs/demo/handoff", state=_State(), match={"name": "demo"})
+        )
+        assert out.status == 404
+
+    @pytest.mark.asyncio
+    async def test_a_stale_claim_is_refused_before_the_sentinel_is_disarmed(self, tmp_path):
+        prepare = mock.Mock(return_value=(True, "/spec/STOP"))
+        with mock.patch.object(r, "_prepare_handoff", prepare):
+            out = await r._handle_handoff(
+                _handoff_request(tmp_path, _State(), spec_dir="/somewhere-else")
+            )
+        assert out.status == 409 and _body(out)["code"] == "stale_client"
+        # _prepare_handoff CLEARS the STOP sentinel a Pause wrote.
+        prepare.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_missing_tasks_file_is_409(self, tmp_path):
+        with mock.patch.object(r, "_prepare_handoff", return_value=(False, "")):
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        assert out.status == 409 and _body(out)["code"] == "tasks_missing"
+
+    @pytest.mark.asyncio
+    async def test_a_spec_replaced_during_the_filesystem_hop_is_409(self, tmp_path):
+        def _prepare_then_replace(*_a, **_kw):
+            r._save_index({"demo": _entry(tmp_path / "demo", slot_key="spec-builder-demo-ffffffff")})
+            return True, "/spec/STOP"
+
+        with mock.patch.object(r, "_prepare_handoff", _prepare_then_replace):
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        assert out.status == 409 and _body(out)["code"] == "spec_changed_during_start"
+
+    @pytest.mark.asyncio
+    async def test_no_autonudge_service_fails_closed_with_503(self, tmp_path, _quiet_sel):
+        # This used to swallow the failure and run an autonomous turn WITHOUT
+        # passing the authorization chokepoint at all.
+        with _ready_handoff():
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        assert out.status == 503 and _body(out)["code"] == "autonudge_unavailable"
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_handoff_denied" in ops
+
+    @pytest.mark.asyncio
+    async def test_a_missing_authorization_helper_also_fails_closed(self, tmp_path):
+        svc = mock.MagicMock()
+        with (
+            _ready_handoff(),
+            mock.patch.object(r, "_autonudge_instance", lambda: svc),
+            mock.patch.object(r, "authorize_and_add_nudge", None),
+        ):
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        assert out.status == 503 and _body(out)["code"] == "autonudge_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_a_second_handoff_is_409_rather_than_a_second_dispatch(
+        self, tmp_path, _armed, _no_dispatch
+    ):
+        with _ready_handoff(), _no_rehydrate():
+            first = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+            assert first.status == 200
+            second = await r._handle_handoff(
+                _mk(
+                    "POST",
+                    "specs/demo/handoff",
+                    state=_State(),
+                    match={"name": "demo"},
+                    body={},
+                )
+            )
+        assert second.status == 409 and _body(second)["code"] == "already_executing"
+
+    @pytest.mark.asyncio
+    async def test_a_claim_that_cannot_be_recorded_is_500_and_starts_nothing(
+        self, tmp_path, _armed, _no_dispatch
+    ):
+        # Pause keys off the recorded state, so the run must not proceed without it.
+        with (
+            _ready_handoff(),
+            mock.patch.object(r, "_claim_execution", mock.AsyncMock(side_effect=OSError("disk"))),
+        ):
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        assert out.status == 500 and _body(out)["code"] == "exec_state_write_failed"
+        _no_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_spec_that_disappears_at_the_claim_is_409(self, tmp_path, _armed):
+        with (
+            _ready_handoff(),
+            mock.patch.object(
+                r, "_claim_execution", mock.AsyncMock(return_value=(r._CLAIM_GONE, {}))
+            ),
+        ):
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        assert out.status == 409 and _body(out)["code"] == "spec_changed_during_start"
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_slot_gives_the_claim_back(self, tmp_path, _armed, _no_dispatch):
+        with (
+            _ready_handoff(),
+            mock.patch.object(r, "_ensure_worker_slot", mock.AsyncMock(return_value=None)),
+        ):
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        assert out.status == 409 and _body(out)["code"] == "slot_owned_by_another_app"
+        # Otherwise the spec stays marked executing with nothing running.
+        stored = r._load_index()["demo"]
+        assert stored["status"] == "planning" and stored["exec_arming_at"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_an_authorization_that_raises_is_503_and_unwinds(
+        self, tmp_path, _armed, _no_dispatch, _quiet_sel
+    ):
+        _armed.authz.side_effect = RuntimeError("authz exploded")
+        with _ready_handoff(), _no_rehydrate():
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        assert out.status == 503 and _body(out)["code"] == "authorization_failed"
+        assert r._load_index()["demo"]["status"] == "planning"
+        _no_dispatch.assert_not_called()
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_handoff_aborted" in ops
+
+    @pytest.mark.asyncio
+    async def test_a_refused_authorization_is_403_and_unwinds(
+        self, tmp_path, _armed, _no_dispatch
+    ):
+        _armed.authz.return_value = (None, "message limit reached", 0)
+        with _ready_handoff(), _no_rehydrate():
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        assert out.status == 403 and _body(out)["code"] == "authorization_refused"
+        assert "message limit reached" in _body(out)["error"]
+        assert r._load_index()["demo"]["status"] == "planning"
+
+    @pytest.mark.asyncio
+    async def test_a_pre_existing_slot_is_not_torn_down_by_the_unwind(
+        self, tmp_path, _armed, _no_dispatch
+    ):
+        # A pre-existing slot carries the user's conversation; destroying it
+        # because a later write failed loses work the handoff never owned.
+        _armed.authz.return_value = (None, "refused", 0)
+        slot = _Slot("spec-builder-demo-0123abcd")
+        state = _State(**{"spec-builder-demo-0123abcd": slot})
+        with _ready_handoff(), _no_rehydrate():
+            out = await r._handle_handoff(_handoff_request(tmp_path, state))
+        assert out.status == 403
+        assert state._slots["spec-builder-demo-0123abcd"] is slot
+
+    @pytest.mark.asyncio
+    async def test_a_delete_landing_during_authorization_is_409_and_removes_the_loop(
+        self, tmp_path, _armed, _no_dispatch
+    ):
+        async def _authz_then_delete(**_kw):
+            r._save_index({})
+            return SimpleNamespace(id="loop-1"), None, 0
+
+        _armed.authz.side_effect = _authz_then_delete
+        remove = mock.AsyncMock()
+        with _ready_handoff(), _no_rehydrate(), mock.patch.object(r, "_remove_nudge_loop", remove):
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        assert out.status == 409 and _body(out)["code"] == "spec_changed_during_start"
+        # Ours arrives after the delete's own by-name teardown, so it must be
+        # removed here or it nudges a spec that no longer exists.
+        assert remove.await_args.kwargs["only_loop_id"] == "loop-1"
+
+    @pytest.mark.asyncio
+    async def test_a_successful_handoff_arms_a_bounded_loop_and_dispatches(
+        self, tmp_path, _armed, _no_dispatch
+    ):
+        with _ready_handoff("/spec/STOP"), _no_rehydrate():
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        assert _body(out) == {"ok": True, "status": "executing"}
+        kwargs = _armed.authz.await_args.kwargs
+        # Bounded: svc.add was called directly once, with max_cycles=0 -- an
+        # unbounded loop. The shared chokepoint is what enforces the cap.
+        assert kwargs["max_cycles"] == r._EXEC_MAX_CYCLES
+        assert kwargs["stop_sentinel_path"] == "/spec/STOP"
+        assert kwargs["source"] == "app:spec-builder"
+        assert kwargs["caller"] == "test-user"
+        stored = r._load_index()["demo"]
+        assert stored["status"] == "executing"
+        # The pre-arm exemption ends once the reconciler can see the loop.
+        assert stored["exec_arming_at"] == 0.0
+        prompt = _no_dispatch.call_args.args[2]
+        assert "EXECUTION HANDOFF" in prompt and "tasks.md" in prompt
+
+
+# -- HTTP: stop ---------------------------------------------------------------
+
+
+class TestHandleStopExecution:
+    @pytest.mark.asyncio
+    async def test_unauthenticated(self):
+        out = await r._handle_stop_execution(
+            _mk("POST", "specs/demo/stop", match={"name": "demo"}, authed=False)
+        )
+        assert out.status == 401
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_spec_is_404(self):
+        out = await r._handle_stop_execution(
+            _mk("POST", "specs/demo/stop", state=_State(), match={"name": "demo"})
+        )
+        assert out.status == 404
+
+    @pytest.mark.asyncio
+    async def test_a_stale_claim_is_refused_before_anything_is_halted(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo", status="executing")})
+        halt = mock.AsyncMock()
+        with mock.patch.object(r, "_halt_execution", halt):
+            out = await r._handle_stop_execution(
+                _mk(
+                    "POST",
+                    "specs/demo/stop",
+                    state=_State(),
+                    match={"name": "demo"},
+                    body={"slot_key": "spec-builder-demo-ffffffff"},
+                )
+            )
+        assert out.status == 409 and _body(out)["code"] == "stale_client"
+        halt.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_halt_is_503_rather_than_a_false_stopped(self, tmp_path, _quiet_sel):
+        _write_index({"demo": _entry(tmp_path / "demo", status="executing")})
+        with mock.patch.object(
+            r, "_halt_execution", mock.AsyncMock(side_effect=OSError("store down"))
+        ):
+            out = await r._handle_stop_execution(
+                _mk("POST", "specs/demo/stop", state=_State(), match={"name": "demo"})
+            )
+        assert out.status == 503 and _body(out)["code"] == "stop_failed"
+        # Saying "stopped" would be false and the user would not retry.
+        assert r._load_index()["demo"]["status"] == "executing"
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_stop_failed" in ops
+
+    @pytest.mark.asyncio
+    async def test_a_spec_deleted_while_halting_is_404_not_a_resurrected_entry(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo", status="executing")})
+
+        async def _halt_then_delete(*_a, **_kw):
+            r._save_index({})
+
+        with mock.patch.object(r, "_halt_execution", _halt_then_delete):
+            out = await r._handle_stop_execution(
+                _mk("POST", "specs/demo/stop", state=_State(), match={"name": "demo"})
+            )
+        assert out.status == 404
+        assert r._load_index() == {}
+
+    @pytest.mark.asyncio
+    async def test_a_successful_stop_records_planning(self, tmp_path, _quiet_sel):
+        _write_index({"demo": _entry(tmp_path / "demo", status="executing")})
+        halt = mock.AsyncMock()
+        with mock.patch.object(r, "_halt_execution", halt):
+            out = await r._handle_stop_execution(
+                _mk(
+                    "POST",
+                    "specs/demo/stop",
+                    state=_State(),
+                    match={"name": "demo"},
+                    body={
+                        "spec_dir": str(tmp_path / "demo"),
+                        "slot_key": "spec-builder-demo-0123abcd",
+                    },
+                )
+            )
+        assert _body(out) == {"ok": True, "status": "planning"}
+        assert r._load_index()["demo"]["status"] == "planning"
+        assert halt.await_args.kwargs["expect_slot_key"] == "spec-builder-demo-0123abcd"
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_stop_execution" in ops
+
+
+# -- HTTP: delete -------------------------------------------------------------
+
+
+class TestHandleDelete:
+    @pytest.mark.asyncio
+    async def test_unauthenticated(self):
+        out = await r._handle_delete(
+            _mk("DELETE", "specs/demo", match={"name": "demo"}, authed=False)
+        )
+        assert out.status == 401
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_spec_is_404(self):
+        out = await r._handle_delete(
+            _mk("DELETE", "specs/demo", state=_State(), match={"name": "demo"})
+        )
+        assert out.status == 404
+
+    @pytest.mark.asyncio
+    async def test_a_stale_claim_is_refused_and_leaves_no_tombstone(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        out = await r._handle_delete(
+            _mk(
+                "DELETE",
+                "specs/demo",
+                state=_State(),
+                match={"name": "demo"},
+                query="spec_dir=/somewhere-else",
+            )
+        )
+        assert out.status == 409 and _body(out)["code"] == "stale_client"
+        assert "demo" in r._load_index()
+
+    @pytest.mark.asyncio
+    async def test_a_reservation_that_cannot_be_taken_is_404_and_clears_the_tombstone(
+        self, tmp_path
+    ):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        with mock.patch.object(r, "_mark_deleting", mock.AsyncMock(return_value=False)):
+            out = await r._handle_delete(
+                _mk("DELETE", "specs/demo", state=_State(), match={"name": "demo"})
+            )
+        assert out.status == 404
+        # Leaving it would hide a spec the user still has from their own list.
+        assert r._load_deleted() == []
+
+    @pytest.mark.asyncio
+    async def test_a_failed_loop_removal_aborts_the_delete_and_releases_everything(
+        self, tmp_path, _quiet_sel
+    ):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        with mock.patch.object(
+            r, "_remove_nudge_loop", mock.AsyncMock(side_effect=OSError("store unwritable"))
+        ):
+            out = await r._handle_delete(
+                _mk("DELETE", "specs/demo", state=_State(), match={"name": "demo"})
+            )
+        assert out.status == 503 and _body(out)["code"] == "loop_removal_failed"
+        stored = r._load_index()["demo"]
+        assert r._DELETING not in stored
+        assert r._load_deleted() == []
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_delete_aborted" in ops
+
+    @pytest.mark.asyncio
+    async def test_a_failed_archive_aborts_the_delete(self, tmp_path):
+        # The conversation is the user's data; a failed history write used to be
+        # logged at DEBUG while the delete returned 200.
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        with (
+            mock.patch.object(r, "_remove_nudge_loop", mock.AsyncMock()),
+            mock.patch.object(r, "_teardown_worker_slot", mock.AsyncMock(return_value=False)),
+        ):
+            out = await r._handle_delete(
+                _mk("DELETE", "specs/demo", state=_State(), match={"name": "demo"})
+            )
+        assert out.status == 503 and _body(out)["code"] == "archive_failed"
+        assert "nothing was deleted" in _body(out)["error"]
+        assert r._DELETING not in r._load_index()["demo"]
+        assert r._load_deleted() == []
+
+    @pytest.mark.asyncio
+    async def test_an_archive_failure_whose_reservation_also_sticks_says_so(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        with (
+            mock.patch.object(r, "_remove_nudge_loop", mock.AsyncMock()),
+            mock.patch.object(r, "_teardown_worker_slot", mock.AsyncMock(return_value=False)),
+            mock.patch.object(r, "_unmark_deleting", mock.AsyncMock(return_value=False)),
+        ):
+            out = await r._handle_delete(
+                _mk("DELETE", "specs/demo", state=_State(), match={"name": "demo"})
+            )
+        assert out.status == 503
+        assert "may need a reload" in _body(out)["error"]
+
+    @pytest.mark.asyncio
+    async def test_an_archived_spec_whose_record_survives_is_503_not_an_undelete(self, tmp_path):
+        # Un-deleting would be the lie the ordering exists to prevent: the
+        # conversation is ALREADY archived. The reservation stays so a retry is
+        # idempotent.
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        with (
+            mock.patch.object(r, "_mark_deleting", mock.AsyncMock(return_value=True)),
+            mock.patch.object(r, "_remove_nudge_loop", mock.AsyncMock()),
+            mock.patch.object(r, "_teardown_worker_slot", mock.AsyncMock(return_value=True)),
+            mock.patch.object(r, "_mutate_index", mock.AsyncMock(return_value=False)),
+        ):
+            out = await r._handle_delete(
+                _mk("DELETE", "specs/demo", state=_State(), match={"name": "demo"})
+            )
+        assert out.status == 503 and _body(out)["code"] == "index_write_failed"
+
+    @pytest.mark.asyncio
+    async def test_a_successful_delete_tombstones_the_directory_and_drops_the_entry(
+        self, tmp_path, _quiet_sel
+    ):
+        spec = tmp_path / "demo"
+        spec.mkdir()
+        (spec / "tasks.md").write_text("- [x] done")
+        _write_index({"demo": _entry(spec)})
+        slot = _Slot("spec-builder-demo-0123abcd")
+        state = _State(**{"spec-builder-demo-0123abcd": slot})
+        with (
+            mock.patch.object(r, "_remove_nudge_loop", mock.AsyncMock()),
+            mock.patch(
+                "kiro_crew.dashboard.chat_persistence.save_slot_off_loop", mock.AsyncMock()
+            ),
+        ):
+            out = await r._handle_delete(
+                _mk(
+                    "DELETE",
+                    "specs/demo",
+                    state=state,
+                    match={"name": "demo"},
+                    query=f"spec_dir={spec}&slot_key=spec-builder-demo-0123abcd",
+                )
+            )
+        assert _body(out) == {"ok": True}
+        assert r._load_index() == {}
+        assert r._load_deleted() == [str(spec)]
+        # The .md files are the user's own project files -- they stay.
+        assert (spec / "tasks.md").is_file()
+        assert state._slots == {}
+        ops = [c.kwargs["operation"] for c in _quiet_sel.log_api_access.call_args_list]
+        assert "spec_delete" in ops
+
+    @pytest.mark.asyncio
+    async def test_the_runtime_is_captured_only_after_the_name_is_reserved(self, tmp_path):
+        """With the marker set first, a concurrent message cannot materialize a new
+        slot that this capture has already passed."""
+        _write_index({"demo": _entry(tmp_path / "demo")})
+        order: list[str] = []
+        real_mark = r._mark_deleting
+
+        async def _mark(*a, **kw):
+            order.append("reserved")
+            return await real_mark(*a, **kw)
+
+        def _loop_id(name):
+            order.append("captured")
+            return None
+
+        with (
+            mock.patch.object(r, "_mark_deleting", _mark),
+            mock.patch.object(r, "_exec_loop_id", _loop_id),
+            mock.patch.object(r, "_remove_nudge_loop", mock.AsyncMock()),
+            mock.patch.object(r, "_teardown_worker_slot", mock.AsyncMock(return_value=True)),
+        ):
+            out = await r._handle_delete(
+                _mk("DELETE", "specs/demo", state=_State(), match={"name": "demo"})
+            )
+        assert out.status == 200
+        assert order == ["reserved", "captured"]
+
+
+# -- route registration -------------------------------------------------------
+
+
+class TestRegisterRoutes:
+    def test_every_documented_route_is_registered_and_gated(self):
+        app = web.Application()
+        r.register_routes(app)
+        registered = {
+            (route.method, route.resource.canonical)  # type: ignore[union-attr]
+            for route in app.router.routes()
+            # aiohttp registers a HEAD companion for every GET on its own.
+            if route.method != "HEAD"
+        }
+        base = f"/api/apps/{r.APP_NAME}"
+        assert registered == {
+            ("GET", f"{base}/settings"),
+            ("PUT", f"{base}/settings"),
+            # POST alias: the SPA page uses POST for settings writes.
+            ("POST", f"{base}/settings"),
+            ("GET", f"{base}/repo-info"),
+            ("GET", f"{base}/browse"),
+            ("GET", f"{base}/specs"),
+            ("POST", f"{base}/specs"),
+            ("GET", f"{base}/specs/{{name}}"),
+            ("GET", f"{base}/specs/{{name}}/messages"),
+            ("POST", f"{base}/specs/{{name}}/message"),
+            ("POST", f"{base}/specs/{{name}}/handoff"),
+            # Alias: the SPA page calls this "execute".
+            ("POST", f"{base}/specs/{{name}}/execute"),
+            ("POST", f"{base}/specs/{{name}}/stop"),
+            ("DELETE", f"{base}/specs/{{name}}"),
+        }
+
+    def test_registration_creates_nothing_on_disk(self, tmp_path):
+        # This runs during start_dashboard ON THE EVENT LOOP, so a KIROCREW_HOME on
+        # stalled network storage would freeze gateway startup on a directory the
+        # app may never need.
+        r.register_routes(web.Application())
+        assert not r._state_dir().exists()
+
+    @pytest.mark.asyncio
+    async def test_the_handoff_and_execute_aliases_are_the_same_handler(self):
+        app = web.Application()
+        r.register_routes(app)
+        handlers = {
+            route.resource.canonical: route.handler  # type: ignore[union-attr]
+            for route in app.router.routes()
+            if route.method == "POST"
+        }
+        base = f"/api/apps/{r.APP_NAME}"
+        assert (
+            handlers[f"{base}/specs/{{name}}/handoff"].__name__
+            == handlers[f"{base}/specs/{{name}}/execute"].__name__
+            == "_handle_handoff"
+        )
+
+
+# -- failure branches the happy paths never reach -----------------------------
+
+
+class TestFilesystemErrorsAreSwallowed:
+    def test_an_entry_that_cannot_be_probed_is_skipped_not_fatal(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        with mock.patch.object(r, "is_sensitive_path", side_effect=OSError("stale mount")):
+            assert r._scan_subdirs(str(tmp_path)) == []
+
+    def test_a_spec_file_that_cannot_be_probed_is_refused(self, tmp_path):
+        (tmp_path / "tasks.md").write_text("x")
+        with mock.patch.object(r, "is_sensitive_path", side_effect=OSError("stale mount")):
+            assert r._spec_file(tmp_path, "tasks.md") is None
+
+    def test_a_spec_dir_that_cannot_be_probed_does_not_verify(self, tmp_path):
+        with mock.patch.object(r, "is_sensitive_path", side_effect=OSError("stale mount")):
+            assert r._verified_spec_dir(tmp_path) is None
+
+    @pytest.mark.skipif(
+        not r._CAN_PIN_DIR,
+        reason="directory pinning needs O_DIRECTORY + dir_fd, which Windows lacks",
+    )
+    def test_a_directory_that_cannot_be_pinned_fails_the_sentinel_write(self, tmp_path):
+        with mock.patch.object(os, "open", side_effect=OSError("EACCES")):
+            assert r._write_stop_sentinel(tmp_path) is False
+
+    @pytest.mark.skipif(
+        not r._CAN_PIN_DIR,
+        reason="directory pinning needs O_DIRECTORY + dir_fd, which Windows lacks",
+    )
+    def test_a_failed_sentinel_write_cleans_up_its_temp_file(self, tmp_path):
+        real_open = os.open
+        calls: list[int] = []
+
+        def _fail_the_temp(*args, **kwargs):
+            calls.append(1)
+            if len(calls) > 1:  # the directory pin succeeded; the temp create fails
+                raise OSError("ENOSPC")
+            return real_open(*args, **kwargs)
+
+        with mock.patch.object(os, "open", _fail_the_temp):
+            assert r._write_stop_sentinel(tmp_path) is False
+        assert list(tmp_path.iterdir()) == []
+
+    @pytest.mark.skipif(
+        not r._CAN_PIN_DIR,
+        reason="directory pinning needs O_DIRECTORY + dir_fd, which Windows lacks",
+    )
+    def test_a_directory_that_cannot_be_pinned_leaves_the_sentinel_alone(self, tmp_path):
+        marker = tmp_path / r._STOP_FILE
+        marker.write_text("1")
+        with mock.patch.object(os, "open", side_effect=OSError("EACCES")):
+            r._clear_stop_sentinel(tmp_path)
+        assert marker.exists()
+
+
+class TestPrepareGitSpawn:
+    def test_it_passes_the_sandbox_triple_straight_through(self):
+        argv = ["git", "-C", "/repo", "rev-parse"]
+        with mock.patch.object(
+            r, "sandboxed_spawn_argv", return_value=(["wrapped"], {"PATH": "/bin"}, "/tmp/env")
+        ) as wrap:
+            assert r._prepare_git_spawn(argv) == (["wrapped"], {"PATH": "/bin"}, "/tmp/env")
+        wrap.assert_called_once_with(argv)
+
+
+class TestHaltGitReapRace:
+    @pytest.mark.asyncio
+    async def test_a_process_that_dies_during_the_reap_is_not_an_error(self):
+        proc = _FakeProc()
+        proc.wait = mock.AsyncMock(side_effect=ProcessLookupError())  # type: ignore
+        await r._halt_git(proc, "worktree")
+        assert proc.killed is True
+
+
+class TestTeardownFailureBranches:
+    @pytest.mark.asyncio
+    async def test_a_registry_lookup_that_raises_reads_as_no_slot(self):
+        state = _State()
+        state.get_slot = mock.Mock(side_effect=RuntimeError("registry broken"))  # type: ignore
+        assert await r._teardown_worker_slot(state, "demo") is True
+
+    @pytest.mark.asyncio
+    async def test_a_registry_pop_that_raises_does_not_stop_the_teardown(self):
+        class _StubbornRegistry(dict):
+            def pop(self, *_a, **_kw):
+                raise RuntimeError("frozen registry")
+
+        slot = _Slot("spec-builder-demo")
+        state = _State()
+        state._slots = _StubbornRegistry({"spec-builder-demo": slot})  # type: ignore[assignment]
+        with mock.patch(
+            "kiro_crew.dashboard.chat_persistence.save_slot_off_loop", mock.AsyncMock()
+        ) as save:
+            assert await r._teardown_worker_slot(state, "demo") is True
+        save.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_worker_task_that_raises_while_being_cancelled_is_tolerated(self):
+        slot = _Slot("spec-builder-demo", running=True)
+        slot.task = mock.Mock()  # type: ignore[assignment]
+        state = _State(**{"spec-builder-demo": slot})
+
+        async def _explode(*_a, **_kw):
+            raise RuntimeError("teardown blew up")
+
+        with (
+            mock.patch(
+                "kiro_crew.dashboard.chat_persistence.save_slot_off_loop", mock.AsyncMock()
+            ),
+            mock.patch.object(asyncio, "wait_for", _explode),
+        ):
+            assert await r._teardown_worker_slot(state, "demo") is True
+
+    @pytest.mark.asyncio
+    async def test_a_slot_that_cannot_be_put_back_after_a_failed_archive_still_reports_false(self):
+        class _NoWrites(dict):
+            def __setitem__(self, *_a, **_kw):
+                raise RuntimeError("frozen registry")
+
+            def pop(self, key, default=None):
+                return dict.pop(self, key, default)
+
+        slot = _Slot("spec-builder-demo")
+        state = _State()
+        state._slots = _NoWrites({"spec-builder-demo": slot})  # type: ignore[assignment]
+        with mock.patch(
+            "kiro_crew.dashboard.chat_persistence.save_slot_off_loop",
+            mock.AsyncMock(side_effect=OSError("disk full")),
+        ):
+            assert await r._teardown_worker_slot(state, "demo", require_archive=True) is False
+
+    @pytest.mark.asyncio
+    async def test_a_worker_task_that_raises_while_pausing_is_tolerated(self):
+        slot = _Slot("spec-builder-demo", running=True)
+        task = mock.Mock()
+        task.done.return_value = False
+        slot.task = task  # type: ignore[assignment]
+        state = _State(**{"spec-builder-demo": slot})
+
+        async def _explode(*_a, **_kw):
+            raise RuntimeError("pause blew up")
+
+        with mock.patch.object(asyncio, "wait_for", _explode):
+            assert await r._halt_active_turn(state, "demo") is True
+
+    def test_a_slot_that_rejects_the_synthesis_reset_is_tolerated(self):
+        class _NoSynthesis:
+            def __setattr__(self, name, value):
+                raise RuntimeError("frozen slot")
+
+        r._discard_queued_work(_NoSynthesis())  # must not raise
+
+
+class TestDeleteRaceBranches:
+    @pytest.mark.asyncio
+    async def test_an_entry_that_moved_under_the_reservation_is_not_popped(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+
+        async def _teardown_then_move(*_a, **_kw):
+            index = r._load_index()
+            index["demo"]["spec_dir"] = str(tmp_path / "moved")
+            r._save_index(index)
+            return True
+
+        with (
+            mock.patch.object(r, "_remove_nudge_loop", mock.AsyncMock()),
+            mock.patch.object(r, "_teardown_worker_slot", _teardown_then_move),
+        ):
+            out = await r._handle_delete(
+                _mk("DELETE", "specs/demo", state=_State(), match={"name": "demo"})
+            )
+        assert out.status == 503 and _body(out)["code"] == "index_write_failed"
+        # The reservation stays, which keeps the spec hidden and the retry idempotent.
+        assert r._load_index()["demo"][r._DELETING]["owner"] == r._PROCESS_ID
+
+    @pytest.mark.asyncio
+    async def test_an_entry_whose_creation_changed_is_not_popped(self, tmp_path):
+        _write_index({"demo": _entry(tmp_path / "demo")})
+
+        async def _teardown_then_rekey(*_a, **_kw):
+            index = r._load_index()
+            index["demo"]["slot_key"] = "spec-builder-demo-ffffffff"
+            r._save_index(index)
+            return True
+
+        with (
+            mock.patch.object(r, "_remove_nudge_loop", mock.AsyncMock()),
+            mock.patch.object(r, "_teardown_worker_slot", _teardown_then_rekey),
+        ):
+            out = await r._handle_delete(
+                _mk("DELETE", "specs/demo", state=_State(), match={"name": "demo"})
+            )
+        assert out.status == 503 and _body(out)["code"] == "index_write_failed"
+
+
+class TestHandoffUnwindFailureBranches:
+    @pytest.mark.asyncio
+    async def test_a_loop_that_cannot_be_removed_while_unwinding_is_logged_not_raised(
+        self, tmp_path, _armed, _no_dispatch
+    ):
+        # This is already an abort path -- the reason that brought us here is the
+        # story worth surfacing, so the removal stays best-effort HERE only.
+        async def _authz_then_delete(**_kw):
+            r._save_index({})
+            return SimpleNamespace(id="loop-1"), None, 0
+
+        _armed.authz.side_effect = _authz_then_delete
+        with (
+            _ready_handoff(),
+            _no_rehydrate(),
+            mock.patch.object(
+                r, "_remove_nudge_loop", mock.AsyncMock(side_effect=OSError("store down"))
+            ),
+        ):
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        assert out.status == 409 and _body(out)["code"] == "spec_changed_during_start"
+
+    @pytest.mark.asyncio
+    async def test_an_execution_state_that_cannot_be_cleared_while_unwinding_is_logged(
+        self, tmp_path, _armed, _no_dispatch
+    ):
+        _armed.authz.return_value = (None, "refused", 0)
+        real_touch = r._touch_spec
+        calls: list[int] = []
+
+        async def _touch(*a, **kw):
+            calls.append(1)
+            if kw.get("status") == "planning":
+                raise OSError("index unwritable")
+            return await real_touch(*a, **kw)
+
+        with _ready_handoff(), _no_rehydrate(), mock.patch.object(r, "_touch_spec", _touch):
+            out = await r._handle_handoff(_handoff_request(tmp_path, _State()))
+        # The refusal the user needs to see survives the failed unwind.
+        assert out.status == 403 and _body(out)["code"] == "authorization_refused"

--- a/test/test_taskrunner_coverage.py
+++ b/test/test_taskrunner_coverage.py
@@ -1,0 +1,1299 @@
+"""Coverage-focused tests for the :mod:`kiro_crew.taskrunner` orchestrator.
+
+Exercises the surfaces the existing task-runner suites leave untouched: the
+workspace-dir security gate, plan/update_task validation, ``execute_plan``'s
+lifecycle (success, failure, cancellation), run teardown (cleanup, trust
+revocation, delete/cancel/pause/retry), lesson extraction, and the runs-registry
+persistence + crash-recovery paths.
+
+Every boundary that would need a real host is faked: git (``git_coord``), the
+provider/session layer (``SessionManager``), the test runner (``run_tests``),
+and the embedding pool. Nothing here spawns a subprocess, touches the sandbox,
+or writes outside ``tmp_path``, so the file behaves identically on a CI runner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew import taskrunner as tr
+from kiro_crew.safety_override import safety_override
+from kiro_crew.task_models import Project, Task, TaskStatus
+from kiro_crew.taskrunner import TaskRunner, _auto_approve_scope, _resolve_workspace_dir
+
+# ── Fixtures / helpers ──
+
+
+def _sessions() -> MagicMock:
+    """A SessionManager double covering every method TaskRunner touches."""
+    sessions = MagicMock()
+    sessions._sessions = {}
+    sessions.get_or_create = AsyncMock(return_value=(MagicMock(), True, False))
+    sessions.release = MagicMock()
+    sessions.reset = AsyncMock()
+    sessions.cancel_current = AsyncMock()
+    sessions.release_subagent_runtime = AsyncMock()
+    sessions.recycle_background = AsyncMock()
+    sessions.is_provider_alive = AsyncMock(return_value=None)
+    return sessions
+
+
+def _runner(tmp_path: Path, **kwargs) -> TaskRunner:
+    kwargs.setdefault("sessions", _sessions())
+    return TaskRunner(auto_test=False, work_dir=Path(tmp_path), **kwargs)
+
+
+def _seed_run(
+    runner: TaskRunner,
+    tmp_path: Path,
+    *,
+    status: str = "planned",
+    task_id: str = "plan_1",
+    name: str = "demo",
+    tasks: list[Task] | None = None,
+) -> Project:
+    if tasks is None:
+        tasks = [Task(index=1, title="One", description="d")]
+    run = Project(
+        spec_path=str(tmp_path / "spec.md"),
+        spec_content="# spec",
+        status=status,
+        task_id=task_id,
+        name=name,
+        work_dir=str(tmp_path),
+        tasks=tasks,
+    )
+    runner._runs[task_id] = run
+    return run
+
+
+def _busy_task() -> MagicMock:
+    """A stand-in for an in-flight asyncio.Task (done() is False)."""
+    task = MagicMock()
+    task.done = MagicMock(return_value=False)
+    return task
+
+
+_YAML_SPEC = (
+    "agents:\n"
+    "  first:\n"
+    "    prompt: do a thing\n"
+    "  second:\n"
+    "    prompt: do another\n"
+    "    depends_on: [first]\n"
+)
+
+
+def _scripted_sleep(steps: list):
+    """``asyncio.sleep`` stand-in that runs one callback per tick, then cancels.
+
+    Lets a watchdog iteration be driven deterministically without a real delay:
+    tick *i* runs ``steps[i]``, and the tick after the script is exhausted
+    raises ``CancelledError`` exactly as a cancelled watchdog task would.
+    """
+    state = {"n": 0}
+
+    async def _sleep(_delay=0, *_args, **_kwargs):
+        index = state["n"]
+        state["n"] += 1
+        if index >= len(steps):
+            raise asyncio.CancelledError()
+        steps[index]()
+
+    return _sleep
+
+
+def _noop() -> None:
+    return None
+
+
+# ── _resolve_workspace_dir ──
+
+
+class TestResolveWorkspaceDir:
+    def test_blank_returns_empty_string(self) -> None:
+        assert _resolve_workspace_dir("   ") == ""
+        assert _resolve_workspace_dir("") == ""
+
+    def test_traversal_is_canonicalized(self, tmp_path: Path) -> None:
+        target = tmp_path / "ws"
+        target.mkdir()
+        raw = str(tmp_path / "ws" / ".." / "ws")
+        assert _resolve_workspace_dir(raw) == str(target.resolve())
+
+    def test_sensitive_path_rejected_and_audited(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(tr, "is_sensitive_path", lambda p: True)
+        audit = MagicMock()
+        monkeypatch.setattr(tr, "sel", lambda: audit)
+        with pytest.raises(ValueError, match="sensitive/credential path"):
+            _resolve_workspace_dir(str(tmp_path))
+        kwargs = audit.log_tool_invocation.call_args.kwargs
+        assert kwargs["outcome"] == "denied"
+        assert kwargs["metadata"]["reason"] == "sensitive_path"
+
+    def test_rejection_survives_audit_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A dead SEL must not turn a denial into an acceptance."""
+        monkeypatch.setattr(tr, "is_sensitive_path", lambda p: True)
+        monkeypatch.setattr(tr, "sel", MagicMock(side_effect=RuntimeError("sel down")))
+        with pytest.raises(ValueError, match="rejected"):
+            _resolve_workspace_dir(str(tmp_path))
+
+    def test_acceptance_survives_audit_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(tr, "sel", MagicMock(side_effect=RuntimeError("sel down")))
+        assert _resolve_workspace_dir(str(tmp_path)) == str(tmp_path.resolve())
+
+
+# ── YAML decomposition audit wrapper ──
+
+
+class TestDecomposeYamlWithAudit:
+    def test_success_logs_task_count(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        audit = MagicMock()
+        monkeypatch.setattr(tr, "sel", lambda: audit)
+        tasks = tr._decompose_yaml_with_audit(_YAML_SPEC, "plan_1")
+        assert [t.index for t in tasks] == [1, 2]
+        assert tasks[1].depends_on == [1]
+        kwargs = audit.log_tool_invocation.call_args.kwargs
+        assert kwargs["outcome"] == "ok"
+        assert kwargs["metadata"] == {"task_id": "plan_1", "task_count": 2}
+
+    def test_failure_logs_error_and_reraises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        audit = MagicMock()
+        monkeypatch.setattr(tr, "sel", lambda: audit)
+        with pytest.raises(ValueError):
+            tr._decompose_yaml_with_audit("not: a workflow\n", "plan_2")
+        kwargs = audit.log_tool_invocation.call_args.kwargs
+        assert kwargs["outcome"] == "error"
+        assert kwargs["metadata"]["task_id"] == "plan_2"
+
+
+# ── current_run ──
+
+
+class TestCurrentRun:
+    def test_none_when_registry_empty(self, tmp_path: Path) -> None:
+        assert _runner(tmp_path).current_run is None
+
+    def test_returns_most_recently_registered(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, task_id="a", name="a")
+        last = _seed_run(runner, tmp_path, task_id="b", name="b")
+        assert runner.current_run is last
+
+
+# ── plan() ──
+
+
+class TestPlan:
+    @pytest.mark.asyncio
+    async def test_missing_spec_file(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            await runner.plan(source="file", spec_path=str(tmp_path / "nope.md"))
+
+    @pytest.mark.asyncio
+    async def test_empty_spec_file(self, tmp_path: Path) -> None:
+        spec = tmp_path / "spec.md"
+        spec.write_text("   \n", encoding="utf-8", newline="\n")
+        runner = _runner(tmp_path)
+        with pytest.raises(ValueError, match="empty"):
+            await runner.plan(source="file", spec_path=str(spec))
+
+    @pytest.mark.asyncio
+    async def test_file_source_decomposes_content(self, tmp_path: Path) -> None:
+        spec = tmp_path / "spec.md"
+        spec.write_text("# Build the thing\n", encoding="utf-8", newline="\n")
+        runner = _runner(tmp_path)
+        with patch.object(
+            TaskRunner,
+            "_decompose",
+            AsyncMock(return_value=[Task(index=1, title="T", description="d")]),
+        ) as dec:
+            run = await runner.plan(source="file", spec_path=str(spec))
+        assert dec.await_args.args[0] == "# Build the thing"
+        assert run.status == "planned"
+        assert run.spec_content == "# Build the thing"
+        assert runner._runs[run.task_id] is run
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("source", ["spec", "text"])
+    async def test_empty_input_text(self, tmp_path: Path, source: str) -> None:
+        runner = _runner(tmp_path)
+        with pytest.raises(ValueError, match="Input text is empty"):
+            await runner.plan(input_text="  ", source=source)
+
+    @pytest.mark.asyncio
+    async def test_text_source_leaves_spec_content_blank(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        with patch.object(
+            TaskRunner,
+            "_decompose",
+            AsyncMock(return_value=[Task(index=1, title="T", description="d")]),
+        ):
+            run = await runner.plan(input_text="ship it", source="text")
+        assert run.spec_content == ""
+        assert run.original_input == "ship it"
+        assert Path(run.work_dir).is_dir()
+
+    @pytest.mark.asyncio
+    async def test_yaml_source_bypasses_llm(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        with patch.object(TaskRunner, "_decompose", AsyncMock()) as dec:
+            run = await runner.plan(input_text=_YAML_SPEC, source="yaml")
+        dec.assert_not_awaited()
+        assert [t.index for t in run.tasks] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_workspace_override_becomes_work_dir(self, tmp_path: Path) -> None:
+        override = tmp_path / "override"
+        override.mkdir()
+        runner = _runner(tmp_path)
+        with patch.object(
+            TaskRunner,
+            "_decompose",
+            AsyncMock(return_value=[Task(index=1, title="T", description="d")]),
+        ):
+            run = await runner.plan(
+                input_text="go", source="text", workspace_dir=str(override)
+            )
+        assert run.work_dir == str(override.resolve())
+
+    @pytest.mark.asyncio
+    async def test_decompose_timeout_becomes_value_error(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        with patch.object(
+            TaskRunner, "_decompose", AsyncMock(side_effect=asyncio.TimeoutError())
+        ):
+            with pytest.raises(ValueError, match="timed out"):
+                await runner.plan(input_text="go", source="text")
+        assert runner._runs == {}
+
+    @pytest.mark.asyncio
+    async def test_decompose_cancelled_becomes_value_error(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        with patch.object(
+            TaskRunner, "_decompose", AsyncMock(side_effect=asyncio.CancelledError())
+        ):
+            with pytest.raises(ValueError, match="cancelled"):
+                await runner.plan(input_text="go", source="text")
+
+    @pytest.mark.asyncio
+    async def test_empty_plan_rejected(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        with patch.object(TaskRunner, "_decompose", AsyncMock(return_value=[])):
+            with pytest.raises(ValueError, match="Could not generate a plan"):
+                await runner.plan(input_text="go", source="text")
+
+    def test_cancel_plan_cancels_live_task_only(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner.cancel_plan()  # no plan task — must not raise
+        live = _busy_task()
+        runner._plan_task = live
+        runner.cancel_plan()
+        live.cancel.assert_called_once()
+        done = MagicMock()
+        done.done = MagicMock(return_value=True)
+        runner._plan_task = done
+        runner.cancel_plan()
+        done.cancel.assert_not_called()
+
+
+# ── update_plan / update_task ──
+
+
+class TestUpdatePlan:
+    @pytest.mark.asyncio
+    async def test_unknown_run(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        with pytest.raises(ValueError, match="not found"):
+            await runner.update_plan("nope", [])
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", ["running", "cancelling"])
+    async def test_refuses_while_active(self, tmp_path: Path, status: str) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, status=status)
+        with pytest.raises(ValueError, match=f"while {status}"):
+            await runner.update_plan("plan_1", [])
+
+
+class TestUpdateTask:
+    @pytest.mark.asyncio
+    async def test_unknown_run(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        with pytest.raises(ValueError, match="not found"):
+            await runner.update_task("nope", 1, {})
+
+    @pytest.mark.asyncio
+    async def test_unknown_task_index(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path)
+        with pytest.raises(ValueError, match="Task 9 not found"):
+            await runner.update_task("plan_1", 9, {})
+
+    @pytest.mark.asyncio
+    async def test_refuses_non_pending_task(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(
+            runner,
+            tmp_path,
+            tasks=[Task(index=1, title="One", description="d", status=TaskStatus.PASSED)],
+        )
+        with pytest.raises(ValueError, match="status=passed"):
+            await runner.update_task("plan_1", 1, {"title": "x"})
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "updates,message",
+        [
+            ({"title": "  "}, "title must be a non-empty string"),
+            ({"title": 42}, "title must be a non-empty string"),
+            ({"title": "x" * 501}, "title too long"),
+            ({"description": 7}, "description must be a string"),
+            ({"description": "d" * 5001}, "description too long"),
+            ({"depends_on": "1,2"}, "depends_on must be a list"),
+        ],
+    )
+    async def test_validation_errors(
+        self, tmp_path: Path, updates: dict, message: str
+    ) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path)
+        with pytest.raises(ValueError, match=message):
+            await runner.update_task("plan_1", 1, updates)
+
+    @pytest.mark.asyncio
+    async def test_invalid_field_leaves_task_untouched(self, tmp_path: Path) -> None:
+        """Validation happens before any mutation, so a late error rolls nothing back."""
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path)
+        with pytest.raises(ValueError, match="description too long"):
+            await runner.update_task(
+                "plan_1", 1, {"title": "new", "description": "d" * 5001}
+            )
+        assert runner._runs["plan_1"].tasks[0].title == "One"
+
+    @pytest.mark.asyncio
+    async def test_applies_changes_and_filters_deps(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(
+            runner,
+            tmp_path,
+            tasks=[
+                Task(index=1, title="One", description="a"),
+                Task(index=2, title="Two", description="b"),
+            ],
+        )
+        result = await runner.update_task(
+            "demo",  # resolvable by name too
+            2,
+            {
+                "title": "  Renamed  ",
+                "description": "longer",
+                # 0 and 5 are out of range (must be 0 < d < index); "x" is not numeric
+                "depends_on": [1, 0, 5, "x"],
+                "requires_approval": 1,
+                "force_approval": 0,
+            },
+        )
+        assert result == {
+            "index": 2,
+            "title": "Renamed",
+            "description": "longer",
+            "depends_on": [1],
+            "requires_approval": True,
+            "force_approval": False,
+        }
+        assert (tmp_path / "runs.json").exists()
+
+
+# ── execute_plan ──
+
+
+class TestExecutePlan:
+    @pytest.mark.asyncio
+    async def test_unknown_run(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        with pytest.raises(ValueError, match="not found"):
+            await runner.execute_plan("nope")
+
+    @pytest.mark.asyncio
+    async def test_refuses_non_startable_status(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, status="running")
+        with pytest.raises(ValueError, match="not in a startable state"):
+            await runner.execute_plan("plan_1")
+
+    @pytest.mark.asyncio
+    async def test_concurrency_cap_checked_before_mutation(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, status="failed")
+        run.tasks[0].status = TaskStatus.FAILED
+        runner._tasks = {f"other{i}": _busy_task() for i in range(3)}
+        with pytest.raises(ValueError, match="Too many concurrent tasks"):
+            await runner.execute_plan("plan_1")
+        # state untouched: the guard runs before the resume reset
+        assert run.status == "failed"
+        assert run.tasks[0].status == TaskStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_resume_resets_only_unfinished_tasks(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(
+            runner,
+            tmp_path,
+            status="failed",
+            tasks=[
+                Task(index=1, title="ok", description="d", status=TaskStatus.PASSED),
+                Task(
+                    index=2,
+                    title="bad",
+                    description="d",
+                    status=TaskStatus.FAILED,
+                    error="boom",
+                    attempts=3,
+                ),
+            ],
+        )
+        run.error = "boom"
+        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()), patch.object(
+            TaskRunner, "_watchdog_loop", AsyncMock()
+        ), patch.object(tr.git_coord, "init_workspace", AsyncMock()):
+            task_id = await runner.execute_plan("plan_1")
+            await runner._tasks[task_id]
+        assert run.tasks[0].status == TaskStatus.PASSED
+        assert run.tasks[1].attempts == 0
+        assert run.tasks[1].error == ""
+        assert run.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_fresh_resets_passed_tasks_too(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(
+            runner,
+            tmp_path,
+            status="paused",
+            tasks=[Task(index=1, title="ok", description="d", status=TaskStatus.PASSED)],
+        )
+        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()), patch.object(
+            TaskRunner, "_watchdog_loop", AsyncMock()
+        ), patch.object(tr.git_coord, "init_workspace", AsyncMock()):
+            task_id = await runner.execute_plan("plan_1", fresh=True)
+            await runner._tasks[task_id]
+        assert run.tasks[0].attempts == 0
+        assert run.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_workspace_override_only_for_planned_runs(self, tmp_path: Path) -> None:
+        override = tmp_path / "elsewhere"
+        override.mkdir()
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, status="paused")
+        original = run.work_dir
+        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()), patch.object(
+            TaskRunner, "_watchdog_loop", AsyncMock()
+        ), patch.object(tr.git_coord, "init_workspace", AsyncMock()):
+            task_id = await runner.execute_plan("plan_1", workspace_dir=str(override))
+            await runner._tasks[task_id]
+        assert run.work_dir == original
+
+    @pytest.mark.asyncio
+    async def test_happy_path_grants_then_revokes_trust(self, tmp_path: Path) -> None:
+        notify = AsyncMock()
+        consolidator = MagicMock()
+        runner = _runner(tmp_path, on_notify=notify, consolidator=consolidator)
+        run = _seed_run(runner, tmp_path, task_id="plan_trust")
+        run.branch_name = "feat/x"
+        scope = _auto_approve_scope("plan_trust")
+        finalize = AsyncMock()
+        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()) as exec_tasks, patch.object(
+            TaskRunner, "_watchdog_loop", AsyncMock()
+        ), patch.object(tr.git_coord, "init_workspace", AsyncMock()) as init_ws, patch.object(
+            tr.git_coord, "finalize", finalize
+        ):
+            task_id = await runner.execute_plan("plan_trust", auto_approve=True)
+            assert safety_override().is_scope_active(scope) is True
+            await runner._tasks[task_id]
+        exec_tasks.assert_awaited_once()
+        init_ws.assert_awaited_once()
+        finalize.assert_awaited_once()
+        consolidator.maybe_consolidate.assert_called_once_with("taskrunner:run:plan_trust")
+        assert run.status == "completed"
+        assert run.finished_at > 0
+        assert task_id not in runner._tasks
+        # trust never outlives the run
+        assert safety_override().is_scope_active(scope) is False
+
+    @pytest.mark.asyncio
+    async def test_git_init_failure_does_not_abort_run(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path)
+        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()), patch.object(
+            TaskRunner, "_watchdog_loop", AsyncMock()
+        ), patch.object(
+            tr.git_coord, "init_workspace", AsyncMock(side_effect=RuntimeError("no git"))
+        ):
+            task_id = await runner.execute_plan("plan_1")
+            await runner._tasks[task_id]
+        assert run.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_execution_error_marks_run_failed(self, tmp_path: Path) -> None:
+        notify = AsyncMock()
+        runner = _runner(tmp_path, on_notify=notify)
+        run = _seed_run(runner, tmp_path)
+        with patch.object(
+            TaskRunner, "_execute_tasks", AsyncMock(side_effect=RuntimeError("kaboom"))
+        ), patch.object(TaskRunner, "_watchdog_loop", AsyncMock()), patch.object(
+            tr.git_coord, "init_workspace", AsyncMock()
+        ):
+            task_id = await runner.execute_plan("plan_1")
+            await runner._tasks[task_id]
+        assert run.status == "failed"
+        assert run.error == "kaboom"
+        assert any("error" in call.args[0].lower() for call in notify.await_args_list)
+
+    @pytest.mark.asyncio
+    async def test_cancellation_finalizes_as_cancelled(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(
+            runner,
+            tmp_path,
+            tasks=[
+                Task(index=1, title="a", description="d", status=TaskStatus.IN_PROGRESS),
+                Task(index=2, title="b", description="d"),
+            ],
+        )
+        with patch.object(
+            TaskRunner, "_execute_tasks", AsyncMock(side_effect=asyncio.CancelledError())
+        ), patch.object(TaskRunner, "_watchdog_loop", AsyncMock()), patch.object(
+            tr.git_coord, "init_workspace", AsyncMock()
+        ):
+            task_id = await runner.execute_plan("plan_1")
+            await runner._tasks[task_id]
+        assert run.status == "cancelled"
+        assert run.tasks[0].status == TaskStatus.CANCELLED
+        assert run.tasks[1].status == TaskStatus.CANCELLED
+
+
+class TestPlanToChatContext:
+    def test_unknown_run(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        with pytest.raises(ValueError, match="not found"):
+            runner.plan_to_chat_context("nope")
+
+    def test_renders_known_run(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path)
+        assert "One" in runner.plan_to_chat_context("plan_1")
+
+
+# ── Teardown: sessions, trust, runtime ──
+
+
+class TestCleanupRunSessions:
+    @pytest.mark.asyncio
+    async def test_no_sessions_still_releases_runtime(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path)
+        await runner._cleanup_run_sessions(run)
+        runner._sessions.cancel_current.assert_not_awaited()
+        runner._sessions.release_subagent_runtime.assert_awaited_once_with(
+            "taskrunner:plan_1:runtime"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancels_releases_and_resets_run_sessions_only(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path)
+        runner._sessions._sessions = {
+            "taskrunner:plan_1:task1": object(),
+            "taskrunner:other:task1": object(),
+            "dashboard": object(),
+        }
+        with patch("asyncio.sleep", AsyncMock()):
+            await runner._cleanup_run_sessions(run)
+        assert [c.args[0] for c in runner._sessions.cancel_current.await_args_list] == [
+            "taskrunner:plan_1:task1"
+        ]
+        assert [c.args[0] for c in runner._sessions.reset.await_args_list] == [
+            "taskrunner:plan_1:task1"
+        ]
+        assert run.error == ""
+
+    @pytest.mark.asyncio
+    async def test_reset_failure_is_recorded_on_the_run(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path)
+        runner._sessions._sessions = {"taskrunner:plan_1:task1": object()}
+        runner._sessions.cancel_current = AsyncMock(side_effect=RuntimeError("nope"))
+        runner._sessions.release = MagicMock(side_effect=RuntimeError("nope"))
+        runner._sessions.reset = AsyncMock(side_effect=RuntimeError("stuck"))
+        with patch("asyncio.sleep", AsyncMock()):
+            await runner._cleanup_run_sessions(run)
+        assert run.error == "Cancel cleanup failed for 1 session(s)"
+        runner._sessions.release_subagent_runtime.assert_awaited_once()
+
+
+class TestRunTrust:
+    def test_grant_and_revoke_keep_flag_and_scope_in_sync(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, task_id="trust_sync")
+        scope = _auto_approve_scope("trust_sync")
+        runner._grant_run_trust(run, True)
+        assert run.auto_approve is True
+        assert safety_override().is_scope_active(scope) is True
+        runner._grant_run_trust(run, False)
+        assert run.auto_approve is False
+        assert safety_override().is_scope_active(scope) is False
+
+    @pytest.mark.asyncio
+    async def test_release_runtime_revokes_scope(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, task_id="trust_release")
+        runner._grant_run_trust(run, True)
+        await runner._release_run_runtime(run)
+        assert safety_override().is_scope_active(_auto_approve_scope("trust_release")) is False
+
+    @pytest.mark.asyncio
+    async def test_release_runtime_swallows_failures(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path)
+        runner._sessions.release_subagent_runtime = AsyncMock(side_effect=RuntimeError("x"))
+        monkeypatch.setattr(
+            tr, "safety_override", MagicMock(side_effect=RuntimeError("override down"))
+        )
+        await runner._release_run_runtime(run)  # must not raise
+
+
+# ── delete / cancel / pause ──
+
+
+class TestDeleteRun:
+    @pytest.mark.asyncio
+    async def test_unknown_run_returns_false(self, tmp_path: Path) -> None:
+        assert await _runner(tmp_path).delete_run("nope") is False
+
+    @pytest.mark.asyncio
+    async def test_running_run_is_cancelled_and_dropped(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, status="running")
+        live = _busy_task()
+        runner._tasks["plan_1"] = live
+        runner._stall_cancelled_ids.add("plan_1")
+        assert await runner.delete_run("plan_1") is True
+        live.cancel.assert_called_once()
+        assert "plan_1" not in runner._runs
+        assert "plan_1" not in runner._tasks
+        assert "plan_1" not in runner._stall_cancelled_ids
+
+    @pytest.mark.asyncio
+    async def test_audit_failure_does_not_fail_delete(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path)
+        import kiro_crew.sel as sel_mod
+
+        monkeypatch.setattr(sel_mod, "sel", MagicMock(side_effect=RuntimeError("sel down")))
+        assert await runner.delete_run("plan_1") is True
+        assert runner._runs == {}
+
+
+class TestCancelAndPause:
+    def test_cancel_by_name_resolves_every_match(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, task_id="a", name="shared", status="running")
+        _seed_run(runner, tmp_path, task_id="b", name="shared", status="running")
+        tasks = {key: _busy_task() for key in ("a", "b")}
+        runner._tasks.update(tasks)
+        runner.cancel("shared")
+        assert [r.status for r in runner._runs.values()] == ["cancelling", "cancelling"]
+        for task in tasks.values():
+            task.cancel.assert_called_once()
+
+    def test_cancel_unknown_id_is_a_noop(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, status="running")
+        runner.cancel("ghost")
+        assert runner._runs["plan_1"].status == "running"
+
+    def test_cancel_all_touches_running_runs_only(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, task_id="a", name="a", status="running")
+        _seed_run(runner, tmp_path, task_id="b", name="b", status="completed")
+        live, done = _busy_task(), MagicMock()
+        done.done = MagicMock(return_value=True)
+        runner._tasks.update({"a": live, "b": done})
+        runner.cancel()
+        assert runner._runs["a"].status == "cancelling"
+        assert runner._runs["b"].status == "completed"
+        live.cancel.assert_called_once()
+        done.cancel.assert_not_called()
+
+    def test_pause_running_run_by_name(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, status="running")
+        live = _busy_task()
+        runner._tasks["plan_1"] = live
+        runner.pause("demo")
+        assert runner._runs["plan_1"].status == "pausing"
+        live.cancel.assert_called_once()
+
+    def test_pause_ignores_unknown_and_idle_runs(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, status="paused")
+        runner.pause("ghost")
+        runner.pause("plan_1")
+        assert runner._runs["plan_1"].status == "paused"
+
+
+# ── retry_from_task ──
+
+
+class TestRetryFromTask:
+    @pytest.mark.asyncio
+    async def test_unknown_run(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="not found"):
+            await _runner(tmp_path).retry_from_task("nope", 1)
+
+    @pytest.mark.asyncio
+    async def test_refuses_running_run(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, status="running")
+        with pytest.raises(ValueError, match="Cannot retry a running task"):
+            await runner.retry_from_task("plan_1", 1)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", ["cancelling", "pausing"])
+    async def test_refuses_mid_cancel(self, tmp_path: Path, status: str) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, status=status)
+        with pytest.raises(ValueError, match="cancel is in progress"):
+            await runner.retry_from_task("plan_1", 1)
+
+    @pytest.mark.asyncio
+    async def test_resets_from_index_and_completes(self, tmp_path: Path) -> None:
+        notify = AsyncMock()
+        runner = _runner(tmp_path, on_notify=notify)
+        run = _seed_run(
+            runner,
+            tmp_path,
+            status="failed",
+            tasks=[
+                Task(index=1, title="a", description="d", status=TaskStatus.PASSED),
+                Task(
+                    index=2,
+                    title="b",
+                    description="d",
+                    status=TaskStatus.FAILED,
+                    error="boom",
+                    attempts=2,
+                ),
+            ],
+        )
+        run.finished_at = 123.0
+        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()) as exec_tasks, patch.object(
+            TaskRunner, "_watchdog_loop", AsyncMock()
+        ):
+            task_id = await runner.retry_from_task("plan_1", 2)
+            await runner._tasks[task_id]
+        exec_tasks.assert_awaited_once()
+        assert run.tasks[0].status == TaskStatus.PASSED
+        assert run.tasks[1].status == TaskStatus.PENDING
+        assert run.tasks[1].attempts == 0
+        assert run.status == "completed"
+        assert run.finished_at > 123.0
+
+    @pytest.mark.asyncio
+    async def test_reinits_git_when_work_dir_is_missing(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, status="failed")
+        run.branch_name = "feat/x"
+        run.work_dir = str(tmp_path / "gone")
+        init_ws = AsyncMock(side_effect=RuntimeError("git absent"))
+        with patch.object(TaskRunner, "_execute_tasks", AsyncMock()), patch.object(
+            TaskRunner, "_watchdog_loop", AsyncMock()
+        ), patch.object(tr.git_coord, "init_workspace", init_ws):
+            task_id = await runner.retry_from_task("plan_1", 1)
+            await runner._tasks[task_id]
+        init_ws.assert_awaited_once()
+        assert run.status == "completed"  # git failure is non-fatal
+
+    @pytest.mark.asyncio
+    async def test_failure_marks_run_failed(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, status="failed")
+        with patch.object(
+            TaskRunner, "_execute_tasks", AsyncMock(side_effect=RuntimeError("nope"))
+        ), patch.object(TaskRunner, "_watchdog_loop", AsyncMock()):
+            task_id = await runner.retry_from_task("plan_1", 1)
+            await runner._tasks[task_id]
+        assert run.status == "failed"
+        assert run.error == "nope"
+
+    @pytest.mark.asyncio
+    async def test_pausing_mid_retry_finalizes_as_paused(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(
+            runner,
+            tmp_path,
+            status="failed",
+            tasks=[Task(index=1, title="a", description="d")],
+        )
+
+        async def _pause_then_cancel(*_args, **_kwargs):
+            run.status = "pausing"
+            run.tasks[0].status = TaskStatus.IN_PROGRESS
+            raise asyncio.CancelledError()
+
+        with patch.object(
+            TaskRunner, "_execute_tasks", AsyncMock(side_effect=_pause_then_cancel)
+        ), patch.object(TaskRunner, "_watchdog_loop", AsyncMock()):
+            task_id = await runner.retry_from_task("plan_1", 1)
+            await runner._tasks[task_id]
+        assert run.status == "paused"
+        assert run.tasks[0].status == TaskStatus.PENDING
+
+
+# ── start_background failure paths ──
+
+
+class TestStartBackground:
+    @pytest.mark.asyncio
+    async def test_run_failure_marks_placeholder_failed(self, tmp_path: Path) -> None:
+        spec = tmp_path / "spec.md"
+        spec.write_text("# do it\n", encoding="utf-8", newline="\n")
+        runner = _runner(tmp_path)
+        with patch.object(TaskRunner, "run", AsyncMock(side_effect=RuntimeError("bang"))):
+            task_id = await runner.start_background(str(spec))
+            await runner._tasks[task_id]
+        run = runner._runs[task_id]
+        assert run.status == "failed"
+        assert run.error == "bang"
+        assert run.spec_content == "# do it"
+        assert task_id not in runner._tasks
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_rolls_back_placeholder(self, tmp_path: Path) -> None:
+        spec = tmp_path / "spec.md"
+        spec.write_text("# do it\n", encoding="utf-8", newline="\n")
+        runner = _runner(tmp_path)
+        with patch.object(
+            TaskRunner, "_apersist_runs", AsyncMock(side_effect=OSError("disk full"))
+        ):
+            with pytest.raises(OSError):
+                await runner.start_background(str(spec))
+        assert runner._runs == {}
+        assert runner._tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_prunes_cron_runs_and_caps_history(self, tmp_path: Path) -> None:
+        spec = tmp_path / "spec.md"
+        spec.write_text("# do it\n", encoding="utf-8", newline="\n")
+        runner = _runner(tmp_path)
+        cron = _seed_run(runner, tmp_path, task_id="cron_done", name="c", status="completed")
+        cron.source = "cron"
+        for i in range(12):
+            _seed_run(
+                runner, tmp_path, task_id=f"old{i:02d}", name=f"o{i}", status="completed"
+            )
+        with patch.object(TaskRunner, "run", AsyncMock()):
+            task_id = await runner.start_background(str(spec))
+            await runner._tasks[task_id]
+        assert "cron_done" not in runner._runs
+        # oldest 2 of the 12 pruned, last 10 kept, plus the new placeholder
+        assert "old00" not in runner._runs and "old01" not in runner._runs
+        assert "old11" in runner._runs
+        assert len(runner._runs) == 11
+
+
+# ── Lessons ──
+
+
+class TestLessonExtraction:
+    @pytest.mark.asyncio
+    async def test_no_store_is_a_noop(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        with patch.object(TaskRunner, "_call_llm_for_lesson", AsyncMock()) as call:
+            await runner._extract_lesson(Task(index=1, title="t", description="d"))
+        call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_rule_writes_nothing(self, tmp_path: Path) -> None:
+        store = MagicMock()
+        runner = _runner(tmp_path, lesson_store=store)
+        with patch.object(
+            TaskRunner, "_call_llm_for_lesson", AsyncMock(return_value={"category": "tool"})
+        ):
+            await runner._extract_lesson(Task(index=1, title="t", description="d"))
+        store.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_saves_to_lesson_store_and_records_on_run(self, tmp_path: Path) -> None:
+        store = MagicMock()
+        notify = AsyncMock()
+        runner = _runner(tmp_path, lesson_store=store, on_notify=notify)
+        run = _seed_run(runner, tmp_path)
+        task = Task(index=3, title="t", description="d", error="E" * 600)
+        with patch.object(
+            TaskRunner,
+            "_call_llm_for_lesson",
+            AsyncMock(return_value={"rule": "R", "category": "tool", "negative": "N"}),
+        ) as call:
+            await runner._extract_lesson(task, run=run)
+        store.save.assert_called_once()
+        lesson = store.save.call_args.args[0]
+        assert (lesson.rule, lesson.category, lesson.negative) == ("R", "tool", "N")
+        # the failure text handed to the LLM is truncated
+        assert 'Error: "' + "E" * 500 + '"' in call.await_args.args[0]
+        assert run.lessons_learned == ["R"]
+        notify.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_vector_store_path_uses_embed_pool(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = MagicMock()
+        consolidator = MagicMock()
+        runner = _runner(tmp_path, lesson_store=store, consolidator=consolidator)
+        pool = AsyncMock()
+        monkeypatch.setattr(tr, "run_in_embed_pool", pool)
+        with patch.object(
+            TaskRunner, "_call_llm_for_lesson", AsyncMock(return_value={"rule": "R"})
+        ):
+            await runner._extract_lesson(Task(index=1, title="t", description="d"))
+        store.save.assert_not_called()
+        assert pool.await_args.args == (
+            consolidator._vector_store.write_lesson,
+            "R",
+            "tool",
+            None,
+            "task_runner",
+        )
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_is_swallowed(self, tmp_path: Path) -> None:
+        store = MagicMock()
+        runner = _runner(tmp_path, lesson_store=store)
+        with patch.object(
+            TaskRunner, "_call_llm_for_lesson", AsyncMock(side_effect=RuntimeError("down"))
+        ):
+            await runner._extract_lesson(Task(index=1, title="t", description="d"))
+        store.save.assert_not_called()
+
+
+class TestCallLlmForLesson:
+    @pytest.mark.asyncio
+    async def test_returns_parsed_json_and_releases_session(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner = _runner(tmp_path)
+        monkeypatch.setattr(
+            tr, "stream_and_collect_json", AsyncMock(return_value={"rule": "R"})
+        )
+        assert await runner._call_llm_for_lesson("p") == {"rule": "R"}
+        runner._sessions.release.assert_called_once()
+        runner._sessions.recycle_background.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_session_failure_returns_none_and_still_recycles(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._sessions.get_or_create = AsyncMock(side_effect=RuntimeError("no provider"))
+        assert await runner._call_llm_for_lesson("p") is None
+        runner._sessions.recycle_background.assert_awaited_once()
+
+
+# ── History logging ──
+
+
+class TestLogTask:
+    def test_without_conversation_log_is_a_noop(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path)
+        runner._log_task("hist", run, Task(index=1, title="T", description="d"))
+
+    def test_off_loop_appends_user_then_assistant(self, tmp_path: Path) -> None:
+        log = MagicMock()
+        runner = _runner(tmp_path, conversation_log=log)
+        run = _seed_run(runner, tmp_path)
+        task = Task(index=2, title="T", description="d", result="R" * 2500)
+        runner._log_task("hist", run, task)
+        roles = [call.args[1] for call in log.append.call_args_list]
+        assert roles == ["user", "assistant"]
+        assert log.append.call_args_list[0].args[2] == "[Task: spec.md] Task 2: T"
+        assert log.append.call_args_list[1].args[2] == "R" * 2000
+
+    def test_off_loop_uses_task_id_when_spec_path_is_blank(self, tmp_path: Path) -> None:
+        log = MagicMock()
+        runner = _runner(tmp_path, conversation_log=log)
+        run = _seed_run(runner, tmp_path)
+        run.spec_path = ""
+        runner._log_task("hist", run, Task(index=1, title="T", description="d"))
+        assert log.append.call_args_list[0].args[2] == "[Task: plan_1] Task 1: T"
+        assert log.append.call_args_list[1].args[2] == "Task completed."
+
+    def test_off_loop_append_failure_is_swallowed(self, tmp_path: Path) -> None:
+        log = MagicMock()
+        log.append = MagicMock(side_effect=RuntimeError("history locked"))
+        runner = _runner(tmp_path, conversation_log=log)
+        run = _seed_run(runner, tmp_path)
+        runner._log_task("hist", run, Task(index=1, title="T", description="d"))
+        log.append.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_on_loop_offloads_the_write(self, tmp_path: Path) -> None:
+        log = MagicMock()
+        runner = _runner(tmp_path, conversation_log=log)
+        run = _seed_run(runner, tmp_path)
+        runner._log_task("hist", run, Task(index=1, title="T", description="d"))
+        for _ in range(100):
+            if log.append.call_count >= 2:
+                break
+            await asyncio.sleep(0.005)
+        assert [call.args[1] for call in log.append.call_args_list] == ["user", "assistant"]
+
+    @pytest.mark.asyncio
+    async def test_on_loop_failure_is_reported_not_raised(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        log = MagicMock()
+        log.append = MagicMock(side_effect=RuntimeError("history locked"))
+        runner = _runner(tmp_path, conversation_log=log)
+        run = _seed_run(runner, tmp_path)
+        with caplog.at_level(logging.DEBUG, logger="kiro_crew.taskrunner"):
+            runner._log_task("hist", run, Task(index=1, title="T", description="d"))
+            for _ in range(100):
+                if any("history locked" in rec.getMessage() for rec in caplog.records):
+                    break
+                await asyncio.sleep(0.005)
+        assert any("history locked" in rec.getMessage() for rec in caplog.records)
+
+
+# ── Watchdog ──
+
+
+class TestWatchdogLoop:
+    @pytest.mark.asyncio
+    async def test_returns_when_run_leaves_running(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _seed_run(runner, tmp_path, status="running")
+
+        def _finish() -> None:
+            run.status = "completed"
+
+        with patch("asyncio.sleep", _scripted_sleep([_finish])):
+            await runner._watchdog_loop(run)
+        runner._sessions.is_provider_alive.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dead_process_resets_session_at_threshold(self, tmp_path: Path) -> None:
+        notify = AsyncMock()
+        runner = _runner(tmp_path, on_notify=notify)
+        run = _seed_run(runner, tmp_path, status="running")
+        run.started_at = run.last_task_time = time.time()
+        run.current_task = 4
+        runner._sessions.is_provider_alive = AsyncMock(return_value=False)
+        runner._sessions.reset = AsyncMock(side_effect=RuntimeError("stuck"))
+        with patch("asyncio.sleep", _scripted_sleep([_noop, _noop])):
+            await runner._watchdog_loop(run)
+        # _DEAD_THRESHOLD consecutive dead checks before the reset fires
+        assert runner._sessions.reset.await_count == 1
+        assert runner._sessions.reset.await_args.args == ("taskrunner:plan_1:task4",)
+        assert any("process died" in call.args[0] for call in notify.await_args_list)
+
+    @pytest.mark.asyncio
+    async def test_global_timeout_stops_the_watchdog(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path, global_timeout=1.0)
+        run = _seed_run(runner, tmp_path, status="running")
+        run.started_at = time.time() - 30
+        run.last_task_time = time.time()
+        sleeper = _scripted_sleep([_noop, _noop])
+        with patch("asyncio.sleep", sleeper):
+            await runner._watchdog_loop(run)
+        # returned on the first tick rather than consuming the second
+        runner._sessions.is_provider_alive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stall_cancel_resets_once_per_run(self, tmp_path: Path) -> None:
+        notify = AsyncMock()
+        runner = _runner(tmp_path, on_notify=notify)
+        run = _seed_run(runner, tmp_path, status="running")
+        run.started_at = time.time()
+        run.last_task_time = time.time() - tr._STALL_CANCEL_TIMEOUT - 60
+        runner._sessions.reset = AsyncMock(side_effect=RuntimeError("stuck"))
+        with patch("asyncio.sleep", _scripted_sleep([_noop, _noop])):
+            await runner._watchdog_loop(run)
+        assert "plan_1" in runner._stall_cancelled_ids
+        # second tick sees the id already recorded and does not reset again
+        assert runner._sessions.reset.await_count == 1
+        assert any("stalled task" in call.args[0] for call in notify.await_args_list)
+
+
+# ── Tests hook ──
+
+
+class TestRunTests:
+    @pytest.mark.asyncio
+    async def test_no_command_configured(self, tmp_path: Path) -> None:
+        ok, out = await _runner(tmp_path)._run_tests()
+        assert (ok, out) == (True, "no test command configured")
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_run_tests(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner = _runner(tmp_path)
+        runner._test_cmd = ["pytest", "-q"]
+        fake = AsyncMock(return_value=(False, "1 failed"))
+        monkeypatch.setattr(tr, "run_tests", fake)
+        assert await runner._run_tests() == (False, "1 failed")
+        assert fake.await_args.args == (["pytest", "-q"], Path(tmp_path))
+
+
+# ── Registry persistence ──
+
+
+class TestPersistence:
+    def test_cron_and_transient_runs_are_not_serialized(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        keep = _seed_run(runner, tmp_path, task_id="keep", name="keep", status="completed")
+        cron = _seed_run(runner, tmp_path, task_id="cron", name="cron", status="completed")
+        cron.source = "cron"
+        _seed_run(runner, tmp_path, task_id="tmp", name="tmp", status="pending")
+        runner._persist_runs()
+        data = json.loads((tmp_path / "runs.json").read_text(encoding="utf-8"))
+        assert [item["task_id"] for item in data] == [keep.task_id]
+
+    def test_write_failure_does_not_advance_the_watermark(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner = _runner(tmp_path)
+        _seed_run(runner, tmp_path, status="completed")
+        monkeypatch.setattr(tr, "atomic_write", MagicMock(side_effect=OSError("full")))
+        runner._persist_runs()
+        assert runner._persist_written == 0
+        assert not (tmp_path / "runs.json").exists()
+
+    def test_stale_snapshot_never_clobbers_a_newer_one(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._commit_snapshot(5, '["new"]')
+        runner._commit_snapshot(2, '["stale"]')
+        assert (tmp_path / "runs.json").read_text(encoding="utf-8") == '["new"]'
+        assert runner._persist_written == 5
+
+
+def _registry_item(**overrides) -> dict:
+    item = {
+        "task_id": "r1",
+        "name": "r1",
+        "spec_path": "spec.md",
+        "status": "running",
+        "source": "text",
+        "auto_approve": True,
+        "task_details": [
+            {
+                "index": 1,
+                "title": "one",
+                "description": "d",
+                "status": "in_progress",
+                "attempts": 2,
+            }
+        ],
+    }
+    item.update(overrides)
+    return item
+
+
+class TestLoadRuns:
+    def test_missing_file_starts_empty(self, tmp_path: Path) -> None:
+        assert _runner(tmp_path)._runs == {}
+
+    def test_corrupt_registry_is_preserved_as_sidecar(self, tmp_path: Path) -> None:
+        (tmp_path / "runs.json").write_text("{not json", encoding="utf-8")
+        runner = _runner(tmp_path)
+        assert runner._runs == {}
+        assert (tmp_path / "runs.json.corrupt").exists()
+        assert not (tmp_path / "runs.json").exists()
+
+    def test_sidecar_failure_still_starts_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "runs.json").write_text("{not json", encoding="utf-8")
+        monkeypatch.setattr(
+            Path, "replace", MagicMock(side_effect=OSError("cannot rename"))
+        )
+        runner = _runner(tmp_path)
+        assert runner._runs == {}
+        assert (tmp_path / "runs.json").exists()
+
+    def test_running_run_recovers_as_resumable_without_trust(self, tmp_path: Path) -> None:
+        (tmp_path / "runs.json").write_text(
+            json.dumps([_registry_item()]), encoding="utf-8"
+        )
+        runner = _runner(tmp_path)
+        run = runner._runs["r1"]
+        assert run.status == "paused"
+        assert "crashed" in run.error
+        assert run.tasks[0].status == TaskStatus.PENDING
+        assert run.tasks[0].attempts == 1
+        assert run.auto_approve is False
+        assert safety_override().is_scope_active(_auto_approve_scope("r1")) is False
+
+    def test_running_run_without_tasks_recovers_as_failed(self, tmp_path: Path) -> None:
+        (tmp_path / "runs.json").write_text(
+            json.dumps([_registry_item(task_details=[])]), encoding="utf-8"
+        )
+        run = _runner(tmp_path)._runs["r1"]
+        assert run.status == "failed"
+        assert "decomposition" in run.error
+
+    def test_planning_run_recovers_as_failed(self, tmp_path: Path) -> None:
+        (tmp_path / "runs.json").write_text(
+            json.dumps([_registry_item(status="planning", task_details=[])]),
+            encoding="utf-8",
+        )
+        run = _runner(tmp_path)._runs["r1"]
+        assert run.status == "failed"
+        assert "re-plan" in run.error
+
+    def test_cancelling_run_recovers_as_cancelled(self, tmp_path: Path) -> None:
+        details = [
+            {"index": 1, "title": "a", "description": "", "status": "in_progress", "attempts": 2},
+            {"index": 2, "title": "b", "description": "", "status": "pending", "attempts": 0},
+            {"index": 3, "title": "c", "description": "", "status": "passed", "attempts": 1},
+        ]
+        (tmp_path / "runs.json").write_text(
+            json.dumps([_registry_item(status="cancelling", task_details=details)]),
+            encoding="utf-8",
+        )
+        run = _runner(tmp_path)._runs["r1"]
+        assert run.status == "cancelled"
+        assert [t.status for t in run.tasks] == [
+            TaskStatus.CANCELLED,
+            TaskStatus.CANCELLED,
+            TaskStatus.PASSED,
+        ]
+        assert run.tasks[0].attempts == 1
+
+    def test_structural_error_keeps_earlier_runs(self, tmp_path: Path) -> None:
+        good = _registry_item(task_id="good", status="completed", task_details=[])
+        bad = _registry_item(task_id="bad", status="completed", task_details=[{"title": "x"}])
+        (tmp_path / "runs.json").write_text(json.dumps([good, bad]), encoding="utf-8")
+        runner = _runner(tmp_path)
+        assert list(runner._runs) == ["good"]


### PR DESCRIPTION
## What

12 new test files (1,342 tests) raising backend statement coverage from
**88.85% → 89.57%**, a net **+1,574 statements**. Tests only — no product code.

## This lands short of 90%, by 962 statements

Stating that up front rather than letting the number imply the target was hit.
The remaining gap after this wave is **962 statements**.

Conversion is falling wave over wave, which is the useful signal here:

| wave | files | statements gained |
|---|---|---|
| #2947 | 12 | +2,084 |
| #3005 | 12 | +3,558 |
| this one | 12 | **+1,574** (58% of ~2,700 targeted) |

The cheap mass is gone. What is left sits behind I/O, subprocess and network
boundaries where a test has to fake three layers to reach one branch, so **do
not size the next wave off a previous one** — that assumption is what made this
wave look like it would close the gap.

## Targets

Ranked by absolute uncovered-statement mass, not percentage: a 300-statement
module at 88% carries more recoverable mass than a small module at 20%.

| statements | module |
|---|---|
| 225 | `spec_builder/backend/routes.py` |
| 201 | `cli_server.py` |
| 176 | `taskrunner.py` |
| 139 | `mcp_gateway/gatewayd.py` |
| 129 | `acp/client.py` |
| 120 | `session.py` |
| 113 | `slack/handler.py` |
| 103 | `mcp_core.py` |
| 103 | `dashboard/handlers/files.py` |
| 88 | `dev_fleet/server.py` |
| 68 | `slack/gateway.py` |
| 48 | `mcp_gateway/prewarm.py` |

## How the number was measured

**Measured, not estimated.** The 12 new files were run alone with
`--cov=kiro_crew --cov=sage_lib` to an XML, and that covered `(file, line)` set
was unioned against main's **freshly downloaded** `coverage-backend` CI
artifact, restricted to CI's own denominator. Statement coverage is monotonic in
the set of tests executed, so the union is what CI will report — no
extrapolation, and it costs ~70 seconds instead of a full-suite run.

Baseline is main's current published artifact (196,585/221,245 = 88.85%).

## Verification

- `pytest` on the 12 files: **1,342 passed**
- `flake8 -j 1`: exit 0
- `isort --check-only`: exit 0

One caveat worth recording: an earlier verification run of this same set threw
`Different tests were collected between gw1 and gw29` under xdist. That was
**not** a defect in the tests — it was a race between pytest collection and a
subagent still writing a file into the worktree. Re-running after the writes
settled is clean. Don't verify a worktree while it is still being written to.

## Scope

`BACKEND_MIN` is untouched — https://github.com/kirodotdev/KiroCrew/pull/3104
owns raising the floors to 85%.
