### PR TITLE
fix(acp): give session start its own timeout budget (#2946)

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -105,6 +105,17 @@ _STDOUT_BUFFER_LIMIT = 10 * 1024 * 1024  # 10MB
 _DROP_IDS_IN_LOG = 8
 _INIT_TIMEOUT = 30.0
 _REQUEST_TIMEOUT = 30.0
+# Session start (session/new, session/load) gets its own budget because kiro-cli
+# blocks the response while it initializes the session's MCP servers, and a
+# remote server pending OAuth holds that initialization for its FULL 30s
+# authorization wait. _REQUEST_TIMEOUT is also 30s, so sharing it turns session
+# start into a race the client usually loses: kiro-cli creates the session, the
+# client gives up a beat earlier, and the slot dies. This must stay comfortably
+# ABOVE the backend's 30s OAuth wait plus the initialization tail that follows
+# it (observed: remaining servers register within ~1s after the wait; a
+# 71-server agent with no pending OAuth completes in ~14s) — do NOT "tidy" it
+# back down to _REQUEST_TIMEOUT. See issue #2946.
+_SESSION_NEW_TIMEOUT = 90.0
 _INIT_NOTIFICATION_BUFFER_LIMIT = 100
 # Teardown must be snappy: a session is usually terminated on a hot path
 # (background task done, subagent reaped). kiro-cli's terminate handler responds
@@ -1462,7 +1473,9 @@ class AcpRuntime:
         self._session_inits_in_flight += 1
         session_id = ""
         try:
-            resp = await self._send_and_await(METHOD_SESSION_NEW, params)
+            resp = await self._send_and_await(
+                METHOD_SESSION_NEW, params, timeout=_SESSION_NEW_TIMEOUT
+            )
             session_id = str(resp.get("sessionId") or "")
             if not session_id:
                 raise AcpRuntimeError(f"session/new did not return sessionId: {resp}")
@@ -1574,7 +1587,16 @@ class AcpRuntime:
         self._session_inits_in_flight += 1
         loaded_session_id = ""
         try:
-            resp = await self._send_and_await(METHOD_SESSION_LOAD, load_params)
+            # session/load is gated by the SAME MCP (re-)initialization as
+            # session/new — kiro-cli re-initializes the session's servers on
+            # load, and the runtime stages mcp/oauth_request frames while
+            # EITHER request is in flight (the _session_inits_in_flight-keyed
+            # staging in _reader_loop, closed by _finish_session_init; see
+            # docs/system-specs/modules/acp-client.md "loading a session
+            # triggers MCP re-initialization") — so it gets the same budget.
+            resp = await self._send_and_await(
+                METHOD_SESSION_LOAD, load_params, timeout=_SESSION_NEW_TIMEOUT
+            )
 
             # A genuine resume echoes "modes" in the response (same signal AcpClient
             # keys on). Anything else means load did not actually restore state.
@@ -1696,7 +1718,9 @@ class AcpRuntime:
             return await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError:
             self._pending_requests.pop(req_id, None)
-            raise AcpRuntimeError(f"Request {method} timed out")
+            # Name the budget: a session-start timeout (90s) must be
+            # distinguishable from a generic control-plane one (30s).
+            raise AcpRuntimeError(f"Request {method} timed out after {timeout:g}s")
 
     async def _drain_stderr(self) -> None:
         """Drain stderr to prevent subprocess blocking."""

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -507,9 +507,13 @@ async def _bg_mcp_probe() -> None:
 async def api_mcp_servers(request: web.Request) -> web.Response:
     """GET /api/mcp — list configured MCP servers with enabled state.
 
-    Reads from ``~/.kiro/settings/mcp.json`` — the global MCP config that
-    kiro-cli ACP actually loads at runtime.  Agent-level ``mcpServers``
-    and ``includeMcpJson`` are ignored by kiro-cli in ACP mode.
+    Inventory comes from ``list_servers()``, which merges the agent config's
+    ``mcpServers``, the scope-tagged ``mcp.json`` files (Kiro Crew data home
+    and ``~/.kiro/settings/mcp.json``), and provider-global entries. This
+    handler describes what the DASHBOARD shows; it makes no claim about which
+    of these sources kiro-cli itself loads at session time — that is backend
+    behaviour this repo cannot verify (see issue #2946, where agent-level and
+    disabled entries still initialized).
     """
     global _mcp_probe_in_progress
     from kiro_crew.mcp_discovery import list_servers  # circular import

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -31,6 +31,8 @@ from spawn_test_helpers import strip_spawn_shim
 
 from kiro_crew.acp.client import _OVERSIZE_DRAIN_MAX_BYTES
 from kiro_crew.acp.runtime import (
+    _REQUEST_TIMEOUT,
+    _SESSION_NEW_TIMEOUT,
     _TERMINATE_TIMEOUT,
     AcpRuntime,
     AcpRuntimeDead,
@@ -3260,7 +3262,7 @@ class TestAcpRuntimeLoadSession:
 
         sent: list[tuple[str, dict]] = []
 
-        async def _fake_send(method, params):
+        async def _fake_send(method, params, timeout=None):
             sent.append((method, params))
             # session/load echoes "modes"; set_mode echoes nothing meaningful.
             if method == METHOD_SESSION_LOAD:
@@ -3308,7 +3310,7 @@ class TestAcpRuntimeLoadSession:
         rt, _, _ = _make_runtime()
         rt._can_load_session = True
 
-        async def _fake_send(method, params):
+        async def _fake_send(method, params, timeout=None):
             return {}  # no "modes" → load did not actually restore state
 
         monkeypatch.setattr(rt, "_send_and_await", _fake_send)
@@ -3327,7 +3329,7 @@ class TestAcpRuntimeLoadSession:
         rt._can_load_session = True
         captured: dict = {}
 
-        async def _fake_send(method, params):
+        async def _fake_send(method, params, timeout=None):
             if method == METHOD_SESSION_LOAD:
                 captured.update(params)
                 return {"modes": {}, "models": []}
@@ -3406,7 +3408,7 @@ async def test_create_session_registers_queue_on_success(monkeypatch):
     registered so the returned handle receives its frames."""
     rt, _, _ = _make_runtime()
 
-    async def _fake_send(method, params):
+    async def _fake_send(method, params, timeout=None):
         if method == METHOD_SESSION_NEW:
             return {"sessionId": "sid-ok"}
         return {}
@@ -3813,7 +3815,7 @@ async def test_mcp_free_runtime_skips_no_report_ceiling(monkeypatch):
     rt._process = proc
     rt._pid = 4242
 
-    async def _fake_send(method, params):
+    async def _fake_send(method, params, timeout=None):
         if method == METHOD_SESSION_NEW:
             return {"sessionId": "sid-lite"}
         return {}
@@ -3871,7 +3873,7 @@ async def test_reader_retains_mcp_registration_frames_during_init():
     task = asyncio.create_task(rt._reader_loop())
     try:
 
-        async def _fake_send(method, params):
+        async def _fake_send(method, params, timeout=None):
             if method == METHOD_SESSION_NEW:
                 # Frames arrive while session/new is in flight — before the
                 # queue can be registered under the not-yet-known session id.
@@ -5207,3 +5209,78 @@ def test_parse_session_modes_shapes():
     assert ids == ["kirocrew", "ops", "code-reviewer"]
     assert current == "kirocrew"
     assert advertised is True
+
+
+# ── Session-start timeout budget (#2946) ──
+#
+# kiro-cli blocks the session/new (and session/load) response while it
+# initializes the session's MCP servers; a remote server pending OAuth holds
+# that for its full 30s authorization wait. These tests lock in the CALL SITE
+# — the timeout actually handed to _send_and_await — not just the constant,
+# because dropping the ``timeout=`` argument silently reverts to the generic
+# 30s _REQUEST_TIMEOUT, which is the exact regression.
+
+
+@pytest.mark.asyncio
+async def test_session_new_call_site_passes_budget_above_request_timeout(monkeypatch):
+    """create_session must hand _send_and_await an explicit session/new timeout
+    that exceeds _REQUEST_TIMEOUT — the generic default equals the backend's
+    30s OAuth wait, turning session start into a race the client loses."""
+    rt, _, _ = _make_runtime()
+    rt._expect_mcp_reports = False  # skip the MCP drain wait — not under test
+    seen: dict[str, object] = {}
+
+    async def _fake_send(method, params, timeout=None):
+        if method == METHOD_SESSION_NEW:
+            seen["timeout"] = timeout
+            return {"sessionId": "sid-budget"}
+        return {}
+
+    monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+
+    await rt.create_session(cwd="/w", mcp_servers=[])
+
+    assert seen["timeout"] == _SESSION_NEW_TIMEOUT
+    assert isinstance(seen["timeout"], float)
+    assert seen["timeout"] > _REQUEST_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_session_load_call_site_passes_budget_above_request_timeout(monkeypatch):
+    """load_session is gated by the same MCP re-initialization (kiro-cli
+    re-initializes servers on load; oauth_request frames are staged while
+    either request is in flight), so it must carry the same budget."""
+    rt, _, _ = _make_runtime()
+    rt._can_load_session = True
+    rt._expect_mcp_reports = False  # skip the MCP drain wait — not under test
+    seen: dict[str, object] = {}
+
+    async def _fake_send(method, params, timeout=None):
+        if method == METHOD_SESSION_LOAD:
+            seen["timeout"] = timeout
+            return {"modes": {"currentModeId": "kirocrew"}}
+        return {}
+
+    monkeypatch.setattr(rt, "_send_and_await", _fake_send)
+
+    await rt.load_session("/home/u/.kiro/sessions/cli/sid-9.json", "sid-9", cwd="/w")
+
+    assert seen["timeout"] == _SESSION_NEW_TIMEOUT
+    assert seen["timeout"] > _REQUEST_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_send_and_await_timeout_error_names_the_budget():
+    """The timeout message must carry the budget that elapsed so a 90s
+    session-start timeout is distinguishable from a generic 30s one. The
+    'timed out' substring is load-bearing (chat_runner matches on it)."""
+    rt, _, _ = _make_runtime()
+
+    with pytest.raises(AcpRuntimeError) as exc_info:
+        # stdin is mocked and nothing ever responds → wait_for times out.
+        await rt._send_and_await("probe/method", {}, timeout=0.01)
+
+    msg = str(exc_info.value)
+    assert "timed out" in msg
+    assert "0.01s" in msg
+    assert "probe/method" in msg


### PR DESCRIPTION
Closes #2946

## Problem

A remote MCP server awaiting OAuth authorization makes kiro-cli hold the `session/new` response for its full 30s authorization wait. The client's ceiling for that request is *also* 30s — `create_session` sends `session/new` through `_send_and_await` without an explicit timeout, inheriting the generic `_REQUEST_TIMEOUT`. Two equal numbers turn session start into a race the client usually loses: the user sees `AcpRuntimeError: Request session/new timed out`, the chat slot dies, and the runtime is killed even though kiro-cli had already created the session. The reporter measured one OAuth-pending server costing 31.3s vs 5.4s once removed, and showed server count is not the factor (a 71-server agent completes in 13.8s).

## Why it matters

Any user with one remote MCP server pending OAuth gets a dead slot on every new session — and the failure is indistinguishable from a generic transport fault, so it reads as flakiness rather than "authorize your server".

## Fix (symptoms → root cause → change)

Symptom: `session/new` times out at exactly 30s with a pending-OAuth server. Root cause: session start shares `_REQUEST_TIMEOUT` (30s) with every other control-plane request, and the backend's OAuth wait is also 30s — the client's deadline expires a beat before the response arrives. Change: give session start its own budget.

- **`_SESSION_NEW_TIMEOUT = 90.0`** added alongside the existing per-phase constants (`_INIT_TIMEOUT` / `_REQUEST_TIMEOUT` / `_TERMINATE_TIMEOUT`) in `src/kiro_crew/acp/runtime.py`, with a comment naming *why* it exceeds the backend wait (30s OAuth hold + the observed ≤1s–14s initialization tail) so it does not get "tidied" back to 30. The sibling transport already does this: `AcpClient` uses a 240s init budget for the same MCP-initialization mechanism (`client.py` `_INIT_TIMEOUT`, "MCP servers can be slow to initialize"). 90s is deliberately tighter — it only needs to clear the single 30s OAuth hold plus the tail, and the multiplexed runtime path benefits from failing faster than the client path when something is genuinely wrong.
- **Passed at the `session/new` call site** (`create_session`), matching the four existing call sites that pass an explicit `timeout=`.
- **`session/load` gets the same budget** — verified, not assumed: the repo's own module doc (`docs/system-specs/modules/acp-client.md`: "loading a session triggers MCP re-initialization") and the runtime's staging code (OAuth-request frames are staged while *either* request is in flight, keyed on `_session_inits_in_flight`, which both call sites increment) establish that `session/load` is gated by the same MCP initialization wait.
- **The timeout error names its budget** — `Request {method} timed out after {timeout:g}s` — so a 90s session-start timeout is distinguishable from a generic 30s one. The `"timed out"` substring is preserved; the only in-repo consumer matches on that substring (`chat_runner.py`), and no consumer exact-matches the old string.
- **Corrected the misdirecting `api_mcp_servers` docstring** (`src/kiro_crew/dashboard/handlers/mcp.py`), which asserted agent-level `mcpServers` are "ignored by kiro-cli in ACP mode". The issue's evidence contradicts it, and it also contradicted `docs/architecture/mcp.md` and `agent.py` (`includeMcpJson: false`). The new text describes what this handler itself reads via `list_servers()` and deliberately asserts nothing about kiro-cli's own loading behaviour, which this repo cannot verify.

### Non-goals (from the issue; deliberately not implemented)

- **No session adoption.** Taking over the session kiro-cli already created requires correlating a sessionId that was never returned — a design change with leak risk.
- **No retry of `session/new`.** It doubles the wait and can double-create a session.
- **The failure message does not name the pending OAuth server.** The issue suggests it, but it is unreachable as written: the reporter's own timeline has `mcp/oauth_request` arriving at 30.6s, *after* the 30.0s deadline, so `_pending_oauth_requests` is still empty when the error is raised. The budget fix is what recovers the actionable UI — once `session/new` completes, the notification arrives and the existing `pop_pending_oauth_requests` path already renders the Authorize affordance.
- **`_REQUEST_TIMEOUT` itself is unchanged.** It bounds every other control-plane request; widening it globally would slow teardown detection, which is deliberately snappy (`_TERMINATE_TIMEOUT = 5.0` is untouched and still bounds eviction).

## Tests

Three tests added to `test/test_acp_runtime.py` (the existing home for runtime timeout behaviour):

- `test_session_new_call_site_passes_budget_above_request_timeout` — locks the **call site**, not just the constant: asserts the timeout actually handed to `_send_and_await` for `session/new` equals `_SESSION_NEW_TIMEOUT` and exceeds `_REQUEST_TIMEOUT`. **Mutation-proven**: reverting only the call-site `timeout=` argument turns this test red (`assert None == 90.0`); restoring turns it green.
- `test_session_load_call_site_passes_budget_above_request_timeout` — same lock for `session/load`.
- `test_send_and_await_timeout_error_names_the_budget` — drives a real `_send_and_await` timeout and asserts the message carries the method, the budget (`0.01s`), and the load-bearing `"timed out"` substring.

Eight pre-existing `_send_and_await` fakes gained a `timeout=None` parameter (the call sites now pass it), matching the two fakes that already had it.

## Manual verification

N/A — unit coverage locks the call sites and the message format; the 30s-vs-90s race itself requires a remote MCP server pending OAuth, which the issue's reporter timeline documents and this repo cannot reproduce in CI.

## Screenshots

N/A — backend-only change, no UI surface.
