### PR TITLE
fix(agent): preserve unowned hook keys

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -111,10 +111,21 @@ Note: there IS a top-level `agents/` directory used at runtime for project-level
 
 Default model: `claude-opus-4.8`. Default tools: `execute_bash`, `fs_read`, `fs_write`, `code`, `grep`, `glob`, `use_aws`, `web_fetch`, `web_search`, `introspect`, `session`, `report`, `@kirocrew-cron`, `@kirocrew-core`.
 
-**Security enforcement** (`agent.py`): `repair_agent_configs()` is the single entry point (called at install, gateway startup, and periodically ~60s). It runs two passes:
-
-1. `_enforce_denied_commands()` — injects bundled `deniedCommands` patterns into ALL agent configs in `~/.kiro/agents/` (not just kirocrew). Uses mtime to skip unchanged files. Replaces the agent's denied commands entirely with bundled defaults (canonical source; user-added patterns via dashboard are not supported). Targets both `execute_bash` and `shell` tool settings.
-2. `_sanitize_agent_hooks()` — strips invalid hook keys from agent configs. Kiro-cli 2.4.2+ rejects unknown variants in the `hooks` field (e.g. `auto_approve_tools`), causing silent fallback to the default agent which loses the internal MCP server, kirocrew-core, kirocrew-cron. `_kiro_hooks_only()` filters to valid events (`preToolUse`, `postToolUse`, `userPromptSubmit`, `agentSpawn`, `stop`). Also uses mtime-based caching to skip unchanged files. Bundled `auto_approve_tools` patterns are now applied at runtime in the hooks layer (`_BUNDLED_AUTO_APPROVE_TOOLS` in `hooks.py`) rather than being serialized to the config file.
+**Agent compatibility repair** (`agent.py`): `repair_agent_configs()` is the single
+entry point (called at install, gateway startup, and periodically ~60s). Its
+`_sanitize_agent_hooks()` pass repairs only the exact host-managed filenames in
+`agent_files.OWNED_KIRO_AGENT_FILES`. Kiro-cli rejects the legacy
+`auto_approve_tools` variant in an agent spec's `hooks` field, causing silent
+fallback to the default agent which loses the internal MCP servers. The repair
+therefore removes that one Kiro Crew-authored legacy key and preserves every
+unknown key; an unfamiliar key may belong to a newer kiro-cli schema or to the
+user. Foreign specs, prefix lookalikes such as `kirocrew-custom.json`, and app
+materialized specs are never scanned or rewritten. Mtime-based caching skips
+unchanged owned files. Bundled `auto_approve_tools` patterns are applied at
+runtime in the hooks layer (`_BUNDLED_AUTO_APPROVE_TOOLS` in `hooks.py`) rather
+than being serialized to the config file. `_kiro_hooks_only()` remains the
+strict filter for newly generated Kiro Crew specs, where Kiro Crew owns the whole
+output schema.
 
 ## Custom Agent Support
 

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -45,6 +45,7 @@ from kiro_crew.agent_files import HEARTBEAT_AGENT_FILENAME as _HEARTBEAT_AGENT_F
 from kiro_crew.agent_files import KNOWLEDGE_AGENT_FILENAME as _KNOWLEDGE_AGENT_FILENAME
 from kiro_crew.agent_files import LITE_AGENT_FILENAME as _LITE_AGENT_FILENAME
 from kiro_crew.agent_files import (
+    OWNED_KIRO_AGENT_FILES,
     REQUIRED_KIRO_AGENT_FILES,
 )
 from kiro_crew.agent_files import RESEARCH_AGENT_FILENAME as _RESEARCH_AGENT_FILENAME
@@ -974,11 +975,10 @@ _INTERNAL_HOOK_KEYS = frozenset(
 )
 
 # Valid kiro-cli hook event names — the UNION of the hardcoded baseline (kiro-cli's
-# known schema) and any event key present in bundled defaults. Used as the single
-# filter on both the generation path (bundled defaults -> generated spec) and the
-# repair/validation path (on-disk repair, user-input) — a new event added to
-# defaults.json is automatically accepted on both without a matching allowlist
-# update (#3362).
+# known schema) and any event key present in bundled defaults. Used for generated
+# specs and user-input validation; startup repair is ownership-scoped and removes
+# only legacy keys Kiro Crew serialized. A new event added to defaults.json is
+# automatically accepted without a matching allowlist update (#3362).
 _VALID_HOOK_EVENTS = frozenset(
     {"preToolUse", "postToolUse", "userPromptSubmit", "agentSpawn", "stop"}
 ) | frozenset(
@@ -987,13 +987,18 @@ _VALID_HOOK_EVENTS = frozenset(
     if k not in _INTERNAL_HOOK_KEYS
 )
 
+# Repair is subtractive against the runtime-only key Kiro Crew is known to have
+# serialized into its generated specs. Unknown keys may belong to a newer
+# kiro-cli schema or to the user.
+_LEGACY_KIROCREW_HOOK_KEYS = frozenset({"auto_approve_tools"})
+
 
 def _kiro_hooks_only(hooks: dict) -> dict:
     """Return only kiro-cli valid hook keys, stripping everything else.
 
-    Used on both the generation path (trusted bundled defaults) and the
-    repair/validation path (on-disk repair, user-supplied config) — screens
-    unknown keys that kiro-cli would reject.
+    Used on the generation path (trusted bundled defaults) and for user-supplied
+    config validation. On-disk startup repair is deliberately narrower because
+    unknown keys may belong to a newer kiro-cli schema or to the user.
     """
     return {k: v for k, v in hooks.items() if k in _VALID_HOOK_EVENTS}
 
@@ -3349,7 +3354,7 @@ def sync_aim_packages() -> None:
 
 
 def repair_agent_configs() -> None:
-    """Sanitize invalid hook keys in all agent configs."""
+    """Remove legacy Kiro Crew hook keys from agent configs owned by Kiro Crew."""
     _sanitize_agent_hooks()
 
 
@@ -3357,16 +3362,19 @@ _hooks_sanitized_mtimes: dict[str, float] = {}
 
 
 def _sanitize_agent_hooks() -> None:
-    """Remove KiroCrew-internal hook keys from kiro-cli agent configs.
+    """Remove legacy Kiro Crew hook keys from agent configs owned by Kiro Crew.
 
     Kiro-cli rejects unknown variants in the ``hooks`` field (e.g.
     ``auto_approve_tools``), causing it to silently fall back to the
     default agent — losing kirocrew-core, kirocrew-cron.
 
-    Auto-repairs configs for users who already have the invalid key from
-    prior versions.
+    Auto-repairs configs carrying keys Kiro Crew wrote in prior versions. Files
+    outside :data:`OWNED_KIRO_AGENT_FILES` and unrecognized hook keys are left
+    untouched because Kiro Crew does not own their schema or contents.
     """
-    for f in kiro_agents_dir_path().glob("*.json"):
+    agents_dir = kiro_agents_dir_path()
+    for filename in OWNED_KIRO_AGENT_FILES:
+        f = agents_dir / filename
         try:
             mtime = f.stat().st_mtime
         except OSError:
@@ -3380,19 +3388,20 @@ def _sanitize_agent_hooks() -> None:
         if not isinstance(hooks, dict):
             _hooks_sanitized_mtimes[str(f)] = mtime
             continue
-        clean_hooks = _kiro_hooks_only(hooks)
-        if len(clean_hooks) == len(hooks):
+        removed_keys = [key for key in hooks if key in _LEGACY_KIROCREW_HOOK_KEYS]
+        if not removed_keys:
             _hooks_sanitized_mtimes[str(f)] = mtime
             continue
-        invalid_keys = [k for k in hooks if k not in _VALID_HOOK_EVENTS]
-        data["hooks"] = clean_hooks
+        data["hooks"] = {
+            key: value for key, value in hooks.items() if key not in _LEGACY_KIROCREW_HOOK_KEYS
+        }
         _atomic_json_write(f, data)
         _hooks_sanitized_mtimes[str(f)] = f.stat().st_mtime
-        logger.info("Removed invalid hook keys %s from %s", invalid_keys, f.name)
+        logger.info("Removed legacy Kiro Crew hook keys %s from %s", removed_keys, f.name)
         sel().log_api_access(
             caller="system",
             operation="sanitize_agent_hooks",
             outcome="ok",
             source="agent",
-            resources=f"{f.name}: removed {invalid_keys}",
+            resources=f"{f.name}: removed {removed_keys}",
         )

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -1471,9 +1471,10 @@ class TestKiroHooksFiltering:
             "_INTERNAL_HOOK_KEYS), then update this pinned set."
         )
 
-    def test_sanitize_agent_hooks_repairs_existing_file(self, tmp_path: Path):
-        """_sanitize_agent_hooks removes invalid hook keys from existing configs."""
+    def test_sanitize_agent_hooks_repairs_owned_files_subtractively(self, tmp_path: Path):
+        """The repair removes only Kiro Crew's legacy key from every owned spec."""
         from kiro_crew.agent import _hooks_sanitized_mtimes, _sanitize_agent_hooks
+        from kiro_crew.agent_files import OWNED_KIRO_AGENT_FILES
 
         kiro_dir = tmp_path / "agents"
         kiro_dir.mkdir()
@@ -1482,17 +1483,49 @@ class TestKiroHooksFiltering:
             "hooks": {
                 "auto_approve_tools": ["kirocrew browse *"],
                 "postToolUse": [{"matcher": "execute_bash", "command": "audit.sh"}],
+                "futureHookEvent": [{"command": "future.sh"}],
             },
         }
-        (kiro_dir / "kirocrew.json").write_text(json.dumps(broken_config))
+        for filename in OWNED_KIRO_AGENT_FILES:
+            (kiro_dir / filename).write_text(json.dumps(broken_config))
 
         _hooks_sanitized_mtimes.clear()
         with patch("kiro_crew.agent.KIRO_AGENTS_DIR", kiro_dir):
             _sanitize_agent_hooks()
 
-        repaired = json.loads((kiro_dir / "kirocrew.json").read_text(encoding="utf-8"))
-        assert "auto_approve_tools" not in repaired["hooks"]
-        assert "postToolUse" in repaired["hooks"]
+        for filename in OWNED_KIRO_AGENT_FILES:
+            repaired = json.loads((kiro_dir / filename).read_text(encoding="utf-8"))
+            assert "auto_approve_tools" not in repaired["hooks"]
+            assert "postToolUse" in repaired["hooks"]
+            assert "futureHookEvent" in repaired["hooks"]
+
+    @pytest.mark.parametrize(
+        "filename", ["other-tool.json", "kirocrew-custom.json", "sample-app--worker.json"]
+    )
+    def test_sanitize_agent_hooks_does_not_touch_unowned_files(self, tmp_path: Path, filename: str):
+        """Foreign, prefix-lookalike, and app materialized specs stay byte-identical."""
+        from kiro_crew.agent import _hooks_sanitized_mtimes, _sanitize_agent_hooks
+
+        kiro_dir = tmp_path / "agents"
+        kiro_dir.mkdir()
+        original = json.dumps(
+            {
+                "name": "foreign-agent",
+                "hooks": {
+                    "auto_approve_tools": ["foreign tool"],
+                    "futureHookEvent": [{"command": "future.sh"}],
+                },
+            },
+            indent=2,
+        )
+        path = kiro_dir / filename
+        path.write_text(original, encoding="utf-8")
+
+        _hooks_sanitized_mtimes.clear()
+        with patch("kiro_crew.agent.KIRO_AGENTS_DIR", kiro_dir):
+            _sanitize_agent_hooks()
+
+        assert path.read_text(encoding="utf-8") == original
 
     def test_sanitize_agent_hooks_skips_clean_file(self, tmp_path: Path):
         """_sanitize_agent_hooks does not rewrite configs that are already clean."""


### PR DESCRIPTION
## Problem

`repair_agent_configs()` scanned every JSON agent spec under
`~/.kiro/agents/` and treated hook keys outside Kiro Crew's current event
allowlist as invalid. Startup could therefore delete user-authored or
forward-compatible hooks from specs Kiro Crew does not own.

## Change

- restrict compatibility repair to exact filenames in
  `OWNED_KIRO_AGENT_FILES`
- remove only the legacy `auto_approve_tools` key Kiro Crew historically
  serialized
- preserve unfamiliar hook keys in owned specs
- leave foreign, prefix-lookalike, and materialized app specs byte-identical
- document and test the ownership boundary

Materialized app specs are excluded intentionally: app field ownership treats
`hooks` as user-preserved, not framework-owned. Strict allowlisting remains
only for newly generated Kiro Crew specs, whose complete schema Kiro Crew
owns.

## Validation

- `pytest test/test_agent.py test/test_agent_spec_preflight.py -n auto
  --dist loadgroup --max-worker-restart=2 -q` (173 passed, 8 workers)
- `flake8 src/kiro_crew test`
- `isort --check-only src/kiro_crew/agent.py test/test_agent.py`
- docs lint, scrub lint, vendor manifest, brand, and diff gates

Full mypy reports only the three existing macOS xattr typing errors in
unmodified `hooks.py`.

Fixes #3116
