### PR TITLE
fix(governance): make the boot block bind, closing a sandbox escape

### DIFF
--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -1194,9 +1194,17 @@ def _policy(args: argparse.Namespace) -> None:
         # can tell an established issuer from a decorative one.
         print(f"🛡️  Security policy v{ceiling.version}")
         print(f"   provenance: {ceiling.signature_summary()}")
+        # Distinguish "the policy wrote this" from "the policy left it alone":
+        # an unwritten boot key binds nothing, so printing its declared default
+        # would report a control that is not in force.
+
+        def _boot_state(value: object) -> str:
+            return "unset" if value is None else str(value)
+
         print(
-            f"   boot: require_sandbox={ceiling.boot.require_sandbox} "
-            f"allow_terminal={ceiling.boot.allow_terminal} fail_closed={ceiling.boot.fail_closed}"
+            f"   boot: require_sandbox={_boot_state(ceiling.boot.require_sandbox)} "
+            f"allow_terminal={_boot_state(ceiling.boot.allow_terminal)} "
+            f"fail_closed={ceiling.boot.fail_closed} (always enforced)"
         )
         if not ceiling.controls:
             print("   (no governed scopes)")

--- a/src/kiro_crew/dashboard/handlers/terminal.py
+++ b/src/kiro_crew/dashboard/handlers/terminal.py
@@ -136,15 +136,62 @@ def _get_config(request: web.Request) -> dict:
         return {}
 
 
+def _governance_allows_terminal() -> bool:
+    """Read the governed ``boot.allow_terminal`` pin.
+
+    ``True`` unless a policy explicitly wrote ``allow_terminal: false``.  An
+    unwritten key is "no opinion" and must not disable the panel — the key
+    declared ``False`` as its default for its whole un-consumed life, so binding
+    that default would silently remove the terminal from every governed host
+    (see ``BootControls``).
+
+    Scope, stated honestly: this disables the SURFACE. It does not govern the
+    PTY — a permitted terminal still spawns an intentionally unsandboxed shell
+    with no per-command governance call.
+
+    Error posture is split, mirroring :func:`sandbox._governance_require_sandbox`.
+    A ``PlatformCompositionError`` means the host resolves to a governed edition
+    but no context was installed, so the policy overlay is absent — exactly the
+    state ``current_context`` raises on to stop "a future swallowing caller"
+    reintroducing a silent fail-open, and it re-raises on EVERY call rather than
+    caching, so it is not transient.  Returning ``True`` there would hand the
+    fleet an open terminal on the one host whose governance is known broken, so
+    it returns ``False``: the surface is not offered, and ``api_terminal_list``
+    reports ``enabled: false`` so the panel degrades instead of erroring.  Any
+    OTHER exception is a genuine transient on a host that never claimed to be
+    governed, and keeps the availability posture of the config read below.
+    """
+    from kiro_crew.platform.context import PlatformCompositionError
+
+    try:
+        from kiro_crew.platform.context import current_context
+
+        boot = getattr(getattr(current_context(), "governance", None), "boot", None)
+        return getattr(boot, "allow_terminal", None) is not False
+    except PlatformCompositionError:
+        return False
+    except Exception:
+        # Availability posture matches the config read below: a transient
+        # context error must not take the panel down on an ungoverned host.
+        return True
+
+
 def _is_enabled(request: web.Request) -> bool:
     """Terminal panel is enabled by default. Disable via config.json:
     {"dashboard": {"terminal": {"enabled": false}}}
+    ...or fleet-wide via an enterprise policy pinning ``boot.allow_terminal:
+    false``, which the running app cannot re-enable.
     Cached for 30s to avoid disk I/O per request.
+
+    Every terminal route gates on this one function, so a deny here disables the
+    whole feature — and ``api_terminal_list`` already reports ``enabled: false``,
+    which the frontend uses to hide the Terminal entry entirely rather than
+    leaving a dead panel.
     """
     now = time.monotonic()
     if now - _enabled_cache[1] < 30:
         return _enabled_cache[0]
-    result = bool(_get_config(request).get("enabled", True))
+    result = bool(_get_config(request).get("enabled", True)) and _governance_allows_terminal()
     _enabled_cache[0] = result
     _enabled_cache[1] = now
     return result

--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -1128,10 +1128,40 @@ def register_scope(name: str, spec: ScopeSpec) -> None:
 # ──────────────────────────────────────────────────────────────────────────
 @dataclass(frozen=True)
 class BootControls:
-    """Policy-only boot constraints (not a governed scope; checked at startup)."""
+    """Policy-only boot constraints (not a governed scope; checked at startup).
 
-    require_sandbox: bool = True
-    allow_terminal: bool = False
+    ``require_sandbox`` and ``allow_terminal`` are **tri-state**: ``None`` means
+    the policy did not write the key, and an unwritten key must preserve today's
+    behaviour rather than bind its declared default.
+
+    That distinction is load-bearing, not stylistic.  These keys were parsed but
+    consumed by nothing for their whole life, so their declared defaults were
+    never pressure-tested against a real fleet.  Binding them as declared would
+    have changed behaviour for every existing governed policy: ``allow_terminal``
+    defaulted to ``False``, so consuming it would silently remove the web
+    terminal from every governed host, and ``require_sandbox`` defaulted to
+    ``True``, so consuming it would newly fail-closed every governed host that
+    relies on the ``sandbox_allow_unsandboxed_exec`` escape.  Absence therefore
+    means "no opinion" — the same rule the governed scopes already follow, where
+    a control the policy does not name is ungoverned.
+
+    ``fail_closed`` stays a plain ``bool`` because ``parse_policy`` rejects
+    ``false`` outright: boot already aborts unconditionally, so the only honest
+    values are "declared true" and "not declared".  Every written value must be
+    a real JSON boolean — a quoted ``"false"`` is refused rather than coerced,
+    because ``bool("false")`` is ``True`` and would bind the inverse control.
+
+    ``require_sandbox`` closes the ``sandbox_allow_unsandboxed_exec`` escape and
+    *only* that one — the escape the ordinal floor cannot reach.  It does not
+    clamp ``agent.sandbox: "off"``, which returns unconfined argv before this
+    pin is consulted, so a policy pinning ``require_sandbox`` alone still leaves
+    an agent-writable route to an unsandboxed subprocess.  Pair it with a
+    ``sandbox.min_level`` floor, whose ordinal clamp is what rewrites ``off``
+    upward; the two controls are complementary, not alternatives.
+    """
+
+    require_sandbox: Optional[bool] = None
+    allow_terminal: Optional[bool] = None
     fail_closed: bool = True
 
 
@@ -1528,10 +1558,62 @@ def parse_policy(
     boot_raw = data.get("boot")
     if not isinstance(boot_raw, dict):
         raise PlatformCompositionError("security policy requires a 'boot' object")
+    # ``boot`` was the ONE block that silently ignored unknown keys while every
+    # archetype rejects a typo fail-closed.  Harmless while nothing consumed it;
+    # a silent security hole now that ``require_sandbox`` binds, because
+    # ``{"require_sandbxo": true}`` would read as "no opinion" and the operator
+    # would believe the fail-open escape was forbidden.
+    _reject_unknown_keys(
+        boot_raw, {"require_sandbox", "allow_terminal", "fail_closed"}, "boot"
+    )
+    # Every written boot value must be a real JSON boolean.  ``bool("false")``
+    # is ``True``, so coercing a quoted typo would bind the OPPOSITE of what the
+    # operator wrote, and for ``allow_terminal`` that opposite is fail-OPEN: the
+    # web terminal stays reachable across a fleet whose policy says it is shut,
+    # while ``policy show`` reports ``allow_terminal=True`` and corroborates the
+    # wrong belief.  A quoted value would also dodge the ``fail_closed: false``
+    # refusal below, because ``"false" is False`` is never true.  These keys
+    # bound to nothing before this change, so refusing every non-boolean
+    # (``0``/``1`` and ``null`` included) cannot break a policy that worked.
+    for key in ("require_sandbox", "allow_terminal", "fail_closed"):
+        if key in boot_raw and not isinstance(boot_raw[key], bool):
+            raise PlatformCompositionError(
+                f"boot.{key} must be a JSON boolean (true or false), not "
+                f"{type(boot_raw[key]).__name__}. A quoted \"false\" reads as "
+                "true and would silently invert the control."
+            )
+    # ``fail_closed: false`` is refused rather than honoured.  Boot already
+    # aborts unconditionally on an unreadable policy or a weakening profile
+    # ordinal, so the key cannot relax anything; wiring it would turn it into a
+    # switch that lets a fleet boot ungoverned, which is an anti-feature in a
+    # security ceiling.  Refusing is louder than silently ignoring, and leaves
+    # the door open for a separately-named runtime-polarity control later.
+    if boot_raw.get("fail_closed") is False:
+        raise PlatformCompositionError(
+            "boot.fail_closed cannot be set to false: boot is unconditionally "
+            "fail-closed (an unreadable policy or a profile looser than the "
+            "ceiling aborts startup regardless of this key). Remove the key, or "
+            "set it to true to declare the posture explicitly."
+        )
+    written_require_sandbox = boot_raw.get("require_sandbox")
+    written_allow_terminal = boot_raw.get("allow_terminal")
     boot = BootControls(
-        require_sandbox=bool(boot_raw.get("require_sandbox", True)),
-        allow_terminal=bool(boot_raw.get("allow_terminal", False)),
-        fail_closed=bool(boot_raw.get("fail_closed", True)),
+        # Tri-state: absent means "no opinion", NOT the declared default.  See
+        # BootControls' docstring for why binding the declared defaults would
+        # have changed behaviour for every existing governed policy.  The
+        # ``isinstance`` narrows for the type checker only — the loop above has
+        # already refused every non-boolean, so no written value is dropped.
+        require_sandbox=(
+            written_require_sandbox
+            if isinstance(written_require_sandbox, bool)
+            else None
+        ),
+        allow_terminal=(
+            written_allow_terminal if isinstance(written_allow_terminal, bool) else None
+        ),
+        # Only ``True`` can reach here: ``false`` is refused above and so is
+        # every non-boolean, so an absent key and a declared ``true`` agree.
+        fail_closed=True,
     )
     controls = _parse_controls(data, is_policy=True)
     identity = data.get("identity") or {}

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -2747,6 +2747,42 @@ def reset_backend() -> None:
 _SANDBOX_MODE_ALIASES = {"auto": "standard"}
 
 
+def _governance_require_sandbox() -> bool:
+    """Read the governed ``boot.require_sandbox`` pin, or ``False`` when unset.
+
+    This closes a hole that ``sandbox.min_level`` structurally cannot: the floor
+    clamps the *mode*, and it gates the ``mode == "off"`` and first-party
+    escapes, but ``_allow_unsandboxed_exec`` is a separate boolean the floor
+    never feeds into.  So on a host with no sandbox backend, a policy pinning
+    ``sandbox.min_level: strict`` could still be defeated by setting
+    ``agent.sandbox_allow_unsandboxed_exec`` — and that flag lives in
+    ``config.json``, which is NOT on the sensitive-path floor, so the agent can
+    write it directly.  ``boot.require_sandbox`` is the un-weakenable
+    counterpart, mirroring how ``channels.posture`` is the policy-only
+    counterpart to the ``slack.allowed_enterprise_ids`` config knob.
+
+    Absence means ``False`` ("no opinion") rather than the declared default —
+    binding an unwritten key would newly fail-closed every governed host that
+    relies on the escape.  See ``BootControls``.
+
+    Error posture matches :func:`_governance_sandbox_floor`: a
+    ``PlatformCompositionError`` (a host that should be governed but could not
+    compose) propagates rather than silently downgrading the guarantee; any
+    other transient error reads as "unpinned".
+    """
+    from kiro_crew.platform.context import PlatformCompositionError
+
+    try:
+        from kiro_crew.platform.context import current_context
+
+        boot = getattr(getattr(current_context(), "governance", None), "boot", None)
+        return getattr(boot, "require_sandbox", None) is True
+    except PlatformCompositionError:
+        raise
+    except Exception:
+        return False
+
+
 def _governance_sandbox_floor() -> str | None:
     """Read the governed ``sandbox.min_level`` floor, or ``None`` when ungoverned.
 
@@ -2872,6 +2908,10 @@ def wrap_argv(
     # the carve-out condition can never disagree about the same host.
     governance_floor = _governance_sandbox_floor()
     mode = _clamp_sandbox_mode_to_floor(mode, governance_floor)
+    # Read the ``boot.require_sandbox`` pin on the same ONE-read discipline: it
+    # is consulted by the no-backend gate AND the first-party carve-out below,
+    # and the two must never disagree about whether this host is pinned.
+    require_sandbox = _governance_require_sandbox()
 
     if mode == "off":
         # Fix #2: verify kiro-cli delegation before honoring "off". The
@@ -3147,7 +3187,15 @@ def wrap_argv(
         # This addresses a penetration-test finding — the previous behavior silently
         # returned unmodified argv, allowing the agent subprocess to access all
         # credential paths without any OS-level isolation.
-        if not _allow_unsandboxed_exec():
+        #
+        # ``require_sandbox`` (policy) OVERRIDES the operator opt-in, because the
+        # opt-in lives in ``config.json`` — off the sensitive-path floor, so the
+        # agent can write it — while the policy lives in the trust root the agent
+        # can neither read nor write.  Without this term a pinned
+        # ``sandbox.min_level`` was defeatable by one config flag on any
+        # backend-less host (the floor clamps ``mode`` and gates the other two
+        # escapes, but never feeds into ``_allow_unsandboxed_exec``).
+        if require_sandbox or not _allow_unsandboxed_exec():
             # ONE read of the pair: a concurrent re-probe swaps the whole tuple,
             # so failure and remedy can never come from different probes.
             transient, probe_reason, probe_remedy = _last_unshare_failure or (
@@ -3165,15 +3213,17 @@ def wrap_argv(
             #     failure still raises (it self-heals on the next spawn and must
             #     not buy a bypass) and ``foreign_sandbox`` still raises (the
             #     host's sandbox is fine; the remedy is config, not bypass);
-            #   * no governance ``sandbox.min_level`` floor is active — reuses
-            #     the ONE floor read taken at the top of this call (the same
-            #     value the clamp used), so no second profile walk runs and the
-            #     two checks cannot disagree; a governed host keeps fail-closing
+            #   * no governance ``sandbox.min_level`` floor is active and
+            #     ``boot.require_sandbox`` is not pinned — reuses the ONE read of
+            #     each taken at the top of this call (the same values the clamp
+            #     and the gate used), so no second profile walk runs and the
+            #     checks cannot disagree; a governed host keeps fail-closing
             #     for first-party spawns too.
             if (
                 first_party_fixed_argv
                 and _classify_unavailable(transient) == "no_backend"
                 and not governance_floor
+                and not require_sandbox
             ):
                 return _first_party_no_backend_passthrough(
                     argv, sandbox_level, strip_python_env
@@ -3264,8 +3314,14 @@ def wrap_argv(
             except Exception:
                 logger.warning("Failed to emit SEL audit event for sandbox denial", exc_info=True)
             raise SandboxUnavailableError(
-                "Sandbox backend unavailable and allow_unsandboxed_exec is not set. "
-                "No OS-level sandbox backend is available on this host, and the "
+                (
+                    "Sandbox backend unavailable and your organization's security "
+                    "policy pins boot.require_sandbox, which forbids the "
+                    "allow_unsandboxed_exec opt-out. "
+                    if require_sandbox
+                    else "Sandbox backend unavailable and allow_unsandboxed_exec is not set. "
+                )
+                + "No OS-level sandbox backend is available on this host, and the "
                 "agent subprocess cannot be safely isolated. "
                 f"Probe detail: {probe_reason}. " + guidance,
                 kind=_classify_unavailable(transient),

--- a/test/test_governance_policy.py
+++ b/test/test_governance_policy.py
@@ -1554,3 +1554,117 @@ class TestValidateReportsUngovernedCapabilities:
         ceiling = parse_policy(_policy_body(commands={"mode": MODE_DENY, "deny": ["nc *"]}))
         out = self._validate(capsys, ceiling)
         assert "UNGOVERNED" not in out
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# The boot block: tri-state keys, the fail_closed refusal, typo rejection
+# ──────────────────────────────────────────────────────────────────────────
+class TestBootControls:
+    """``boot`` keys bind only when written, and one of them refuses to weaken.
+
+    All three keys were parsed but consumed by nothing for their whole life, so
+    their declared defaults were never pressure-tested. Binding a declared
+    default would have changed behavior for every existing governed policy:
+    ``allow_terminal`` defaulted ``False`` (would delete the web terminal
+    fleet-wide) and ``require_sandbox`` defaulted ``True`` (would newly
+    fail-closed every host relying on the escape). Hence tri-state.
+    """
+
+    def _boot(self, **keys):
+        body = {"version": 1, "boot": keys}
+        return parse_policy(body).boot
+
+    def test_absent_keys_are_none_not_their_declared_defaults(self):
+        """REGRESSION GUARD for the whole design. Absence must be 'no opinion'."""
+        boot = self._boot(fail_closed=True)
+        assert boot.require_sandbox is None
+        assert boot.allow_terminal is None
+
+    def test_written_keys_bind_their_value(self):
+        boot = self._boot(require_sandbox=True, allow_terminal=False)
+        assert boot.require_sandbox is True
+        assert boot.allow_terminal is False
+
+    def test_written_false_is_distinguishable_from_absent(self):
+        """``False`` and ``None`` must not collapse — one binds, one does not."""
+        assert self._boot(require_sandbox=False).require_sandbox is False
+        assert self._boot().require_sandbox is None
+
+    def test_empty_boot_object_is_valid_and_opinion_free(self):
+        boot = self._boot()
+        assert (boot.require_sandbox, boot.allow_terminal) == (None, None)
+        assert boot.fail_closed is True
+
+    def test_fail_closed_false_is_refused(self):
+        """Boot aborts unconditionally, so ``false`` could only mislead.
+
+        Wiring it would turn it into a switch that lets a fleet boot ungoverned.
+        Refusing is louder than silently ignoring.
+        """
+        with pytest.raises(PlatformCompositionError) as exc:
+            self._boot(fail_closed=False)
+        assert "cannot be set to false" in str(exc.value)
+        assert "unconditionally" in str(exc.value)
+
+    def test_fail_closed_true_and_absent_both_resolve_true(self):
+        assert self._boot(fail_closed=True).fail_closed is True
+        assert self._boot().fail_closed is True
+
+    def test_stringy_boolean_is_refused_not_coerced(self):
+        """``bool("false")`` is ``True``, so coercion would invert the control.
+
+        The fail-open case is ``allow_terminal: "false"``: an operator who quotes
+        the value means to close the web terminal, and coercing it would leave
+        the terminal open while ``policy show`` reported it closed — the policy
+        and the running fleet would disagree with nothing to flag it.
+        """
+        for key in ("require_sandbox", "allow_terminal", "fail_closed"):
+            with pytest.raises(PlatformCompositionError) as excinfo:
+                self._boot(**{key: "false"})
+            assert f"boot.{key}" in str(excinfo.value)
+            assert "JSON boolean" in str(excinfo.value)
+
+    def test_stringy_fail_closed_cannot_dodge_the_false_refusal(self):
+        """``"false" is False`` is never true, so a quoted typo would slip past.
+
+        Without the type check, ``fail_closed: "false"`` is accepted silently
+        while a real ``false`` is refused loudly — the guard would be dodgeable
+        by exactly the mistake it exists to catch.
+        """
+        with pytest.raises(PlatformCompositionError) as excinfo:
+            self._boot(fail_closed="false")
+        assert "JSON boolean" in str(excinfo.value)
+
+    def test_integer_boolean_lookalikes_are_refused(self):
+        """``0``/``1`` are refused too: these keys bound to nothing before now,
+        so no working policy can have relied on the JSON-ish spelling."""
+        for value in (0, 1):
+            with pytest.raises(PlatformCompositionError):
+                self._boot(require_sandbox=value)
+
+    def test_explicit_null_is_refused_rather_than_read_as_absent(self):
+        """A written ``null`` is ambiguous — refuse it instead of guessing."""
+        with pytest.raises(PlatformCompositionError):
+            self._boot(allow_terminal=None)
+
+    def test_real_booleans_still_bind_after_the_type_check(self):
+        """The check must refuse look-alikes without narrowing the real values."""
+        assert self._boot(require_sandbox=True).require_sandbox is True
+        assert self._boot(allow_terminal=False).allow_terminal is False
+        assert self._boot(fail_closed=True).fail_closed is True
+
+    def test_unknown_boot_key_is_rejected(self):
+        """``boot`` was the ONE block that silently ignored typos.
+
+        Harmless while nothing consumed it; a silent security hole once
+        ``require_sandbox`` binds, because the misspelling reads as "no opinion"
+        while the author believes the escape is forbidden.
+        """
+        with pytest.raises(PlatformCompositionError) as exc:
+            self._boot(require_sandbxo=True)
+        assert "require_sandbxo" in str(exc.value)
+
+    def test_boot_object_is_still_required(self):
+        with pytest.raises(PlatformCompositionError) as exc:
+            parse_policy({"version": 1})
+        assert "requires a 'boot' object" in str(exc.value)

--- a/test/test_sandbox_first_party_exec.py
+++ b/test/test_sandbox_first_party_exec.py
@@ -18,6 +18,10 @@ Matrix pinned here:
   config, not bypass);
 * governance ``sandbox.min_level`` floor + flag -> raises (the carve-out must
   not duck the floor);
+* governance ``boot.require_sandbox`` pin + flag -> raises, and it OVERRIDES the
+  ``sandbox_allow_unsandboxed_exec`` opt-in (the floor structurally cannot: it
+  clamps ``mode`` and gates the other two escapes, but never feeds into
+  ``_allow_unsandboxed_exec``, and the opt-in lives in an agent-writable file);
 * ``sandbox_allow_unsandboxed_exec=true``       -> identical with or without
   the flag (the opt-in remains a strict superset);
 * backend available + flag       -> normal sandbox wrap (flag is inert).
@@ -240,3 +244,112 @@ class TestChokepointThreading:
         assert seen["flag"] is True
         sandbox_mod.sandboxed_spawn_argv(_ARGV)
         assert seen["flag"] is False
+
+
+class TestBootRequireSandboxOverridesTheOptIn:
+    """``boot.require_sandbox`` closes the one escape the ordinal floor cannot.
+
+    ``sandbox.min_level`` blocks the ``mode="off"`` escape (the clamp rewrites
+    the mode) and the first-party carve-out (its condition reads the floor). It
+    is structurally blind to the third: ``_allow_unsandboxed_exec`` is a separate
+    boolean the floor never feeds into, so on a backend-less host a pinned floor
+    was defeatable by ``agent.sandbox_allow_unsandboxed_exec`` — and that flag
+    lives in ``config.json``, which is NOT on the sensitive-path floor, so the
+    agent can write it. ``boot.require_sandbox`` is the un-weakenable
+    counterpart, so these tests pin the OVERRIDE, not merely the deny.
+    """
+
+    @staticmethod
+    def _pin(monkeypatch, value):
+        """Stub the composed ceiling's ``boot.require_sandbox`` to *value*."""
+
+        class _Boot:
+            require_sandbox = value
+
+        class _Ceiling:
+            boot = _Boot()
+
+        class _Ctx:
+            governance = _Ceiling()
+
+        monkeypatch.setattr(
+            "kiro_crew.platform.context.current_context", lambda: _Ctx()
+        )
+
+    def test_pin_raises_even_though_the_opt_in_is_set(self, monkeypatch):
+        """The load-bearing case: opt-in ON, no backend, pin ON -> still raises.
+
+        Without the pin this exact configuration returns unconfined argv, which
+        is the hole. ``detect_backend`` is forced to "none" and the opt-in to
+        True so the only thing standing between the agent and an unconfined
+        subprocess is the policy.
+        """
+        monkeypatch.setattr(sandbox_mod, "detect_backend", lambda config_mode="auto": "none")
+        monkeypatch.setattr(sandbox_mod, "_allow_unsandboxed_exec", lambda: True)
+        self._pin(monkeypatch, True)
+        with patch("kiro_crew.sel.sel", return_value=MagicMock()):
+            with pytest.raises(SandboxUnavailableError) as exc:
+                wrap_argv(_ARGV, mode="standard")
+        # The message must name the policy, not the missing opt-in — the opt-in
+        # IS set, so the old wording would send the operator down a dead end.
+        assert "boot.require_sandbox" in str(exc.value)
+
+    def test_without_the_pin_the_opt_in_still_works(self, monkeypatch):
+        """REGRESSION GUARD. An unpinned policy must not change today's behavior.
+
+        This is the case that would break every governed host if an unwritten
+        ``require_sandbox`` bound its declared default of ``True``.
+        """
+        monkeypatch.setattr(sandbox_mod, "detect_backend", lambda config_mode="auto": "none")
+        monkeypatch.setattr(sandbox_mod, "_allow_unsandboxed_exec", lambda: True)
+        self._pin(monkeypatch, None)  # key absent from the policy
+        with patch("kiro_crew.sel.sel", return_value=MagicMock()):
+            wrapped, cleanup = wrap_argv(_ARGV, mode="standard")
+        assert wrapped == _ARGV
+        assert cleanup is None
+
+    def test_explicit_false_also_leaves_the_opt_in_working(self, monkeypatch):
+        monkeypatch.setattr(sandbox_mod, "detect_backend", lambda config_mode="auto": "none")
+        monkeypatch.setattr(sandbox_mod, "_allow_unsandboxed_exec", lambda: True)
+        self._pin(monkeypatch, False)
+        with patch("kiro_crew.sel.sel", return_value=MagicMock()):
+            wrapped, _ = wrap_argv(_ARGV, mode="standard")
+        assert wrapped == _ARGV
+
+    def test_pin_also_closes_the_first_party_carve_out(self, monkeypatch):
+        """The carve-out reads the pin on the same one-read discipline as the floor."""
+        monkeypatch.setattr(sandbox_mod, "detect_backend", lambda config_mode="auto": "none")
+        monkeypatch.setattr(sandbox_mod, "_allow_unsandboxed_exec", lambda: False)
+        self._pin(monkeypatch, True)
+        with patch("kiro_crew.sel.sel", return_value=MagicMock()):
+            with pytest.raises(SandboxUnavailableError):
+                wrap_argv(_ARGV, mode="standard", first_party_fixed_argv=True)
+
+    def test_ungoverned_host_reads_as_unpinned(self, monkeypatch):
+        """No ceiling at all (standalone) must behave exactly as before."""
+        monkeypatch.setattr(sandbox_mod, "detect_backend", lambda config_mode="auto": "none")
+        monkeypatch.setattr(sandbox_mod, "_allow_unsandboxed_exec", lambda: True)
+
+        class _Ctx:
+            governance = None
+
+        monkeypatch.setattr(
+            "kiro_crew.platform.context.current_context", lambda: _Ctx()
+        )
+        with patch("kiro_crew.sel.sel", return_value=MagicMock()):
+            wrapped, _ = wrap_argv(_ARGV, mode="standard")
+        assert wrapped == _ARGV
+
+    def test_backend_available_makes_the_pin_inert(self, monkeypatch):
+        """The pin only governs the no-backend branch; a real sandbox still wraps."""
+        monkeypatch.setattr(
+            sandbox_mod, "detect_backend", lambda config_mode="auto": "sandbox-exec"
+        )
+        monkeypatch.setattr(sandbox_mod, "_allow_unsandboxed_exec", lambda: True)
+        self._pin(monkeypatch, True)
+        monkeypatch.setattr(
+            sandbox_mod, "sandbox_exec_argv", lambda *a, **k: (["/usr/bin/sandbox-exec"], None)
+        )
+        with patch("kiro_crew.sel.sel", return_value=MagicMock()):
+            wrapped, _ = wrap_argv(_ARGV, mode="standard")
+        assert wrapped == ["/usr/bin/sandbox-exec"]

--- a/test/test_terminal_handler.py
+++ b/test/test_terminal_handler.py
@@ -2941,3 +2941,108 @@ class TestPollTerminalTitles:
              patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError]):
             await terminal.poll_terminal_titles(self._app(sess))  # must not raise
         ws.send_str.assert_not_awaited()
+
+
+class TestBootAllowTerminalGate:
+    """``boot.allow_terminal: false`` disables the panel; absence must not.
+
+    Every terminal route gates on ``_is_enabled``, so this one function is the
+    whole enforcement surface. ``api_terminal_list`` already reports
+    ``enabled: false``, which the frontend uses to hide the Terminal entry — so
+    a policy deny degrades to "not offered" rather than a dead black panel.
+
+    Scope, deliberately: this disables the SURFACE. A permitted terminal still
+    spawns an intentionally unsandboxed PTY with no per-command governance.
+    """
+
+    @staticmethod
+    def _ceiling(monkeypatch, allow_terminal):
+        class _Boot:
+            pass
+
+        _Boot.allow_terminal = allow_terminal
+
+        class _Ceiling:
+            boot = _Boot()
+
+        class _Ctx:
+            governance = _Ceiling()
+
+        monkeypatch.setattr(
+            "kiro_crew.platform.context.current_context", lambda: _Ctx()
+        )
+
+    @staticmethod
+    def _fresh_cache(monkeypatch):
+        """Defeat the 30s memo so each case reads the policy it just set."""
+        terminal._enabled_cache[0] = False
+        terminal._enabled_cache[1] = 0.0
+        monkeypatch.setattr(terminal, "_get_config", lambda request: {})
+
+    def test_policy_false_disables_the_panel(self, monkeypatch):
+        self._fresh_cache(monkeypatch)
+        self._ceiling(monkeypatch, False)
+        assert terminal._is_enabled(MagicMock()) is False
+
+    def test_policy_absent_leaves_the_panel_enabled(self, monkeypatch):
+        """REGRESSION GUARD. The key defaulted False for its whole un-consumed
+        life, so binding that default would remove the terminal from every
+        governed host — including one whose policy never mentions it."""
+        self._fresh_cache(monkeypatch)
+        self._ceiling(monkeypatch, None)
+        assert terminal._is_enabled(MagicMock()) is True
+
+    def test_policy_true_leaves_the_panel_enabled(self, monkeypatch):
+        self._fresh_cache(monkeypatch)
+        self._ceiling(monkeypatch, True)
+        assert terminal._is_enabled(MagicMock()) is True
+
+    def test_ungoverned_host_leaves_the_panel_enabled(self, monkeypatch):
+        self._fresh_cache(monkeypatch)
+
+        class _Ctx:
+            governance = None
+
+        monkeypatch.setattr(
+            "kiro_crew.platform.context.current_context", lambda: _Ctx()
+        )
+        assert terminal._is_enabled(MagicMock()) is True
+
+    def test_transient_context_error_does_not_take_the_panel_down(self, monkeypatch):
+        """Availability posture: a transient context failure must not disable a
+        feature on an ungoverned host."""
+        self._fresh_cache(monkeypatch)
+
+        def _boom():
+            raise RuntimeError("context not composed yet")
+
+        monkeypatch.setattr("kiro_crew.platform.context.current_context", _boom)
+        assert terminal._is_enabled(MagicMock()) is True
+
+    def test_composition_error_disables_rather_than_failing_open(self, monkeypatch):
+        """A governed host whose overlay never composed must NOT get a terminal.
+
+        ``current_context`` raises ``PlatformCompositionError`` precisely to stop
+        a swallowing caller reintroducing a silent fail-open, and it re-raises on
+        every call rather than caching — so treating it as a transient would hand
+        an open terminal to the one host whose governance is known broken. This
+        is the same posture ``sandbox._governance_require_sandbox`` takes.
+        """
+        self._fresh_cache(monkeypatch)
+        from kiro_crew.platform.context import PlatformCompositionError
+
+        def _uncomposed():
+            raise PlatformCompositionError("non-standalone profile, no context")
+
+        monkeypatch.setattr(
+            "kiro_crew.platform.context.current_context", _uncomposed
+        )
+        assert terminal._is_enabled(MagicMock()) is False
+
+    def test_config_disable_still_wins_independently(self, monkeypatch):
+        """The config path and the policy path are independent ANDs."""
+        terminal._enabled_cache[0] = False
+        terminal._enabled_cache[1] = 0.0
+        monkeypatch.setattr(terminal, "_get_config", lambda request: {"enabled": False})
+        self._ceiling(monkeypatch, True)
+        assert terminal._is_enabled(MagicMock()) is False


### PR DESCRIPTION
## Problem

The enterprise security policy's `boot` block declares three keys —
`require_sandbox`, `allow_terminal`, `fail_closed`. All three are parsed into
`BootControls`, printed by `kirocrew policy show`, and **read by nothing else**.
The only consumers in the tree are the parse site and the print site.

One of them names a real security gap.

**`sandbox.min_level` does not guarantee the agent never runs unsandboxed.** It
blocks two of the three escapes in `wrap_argv`'s no-backend branch:

- `mode == "off"` — the clamp rewrites `mode` up to the floor first, so the branch
  is never entered;
- the `first_party_fixed_argv` carve-out — its condition explicitly requires
  `not governance_floor`.

It is structurally blind to the third. `_allow_unsandboxed_exec()` reads only
`agent.sandbox_allow_unsandboxed_exec` and never references the floor, so when
that flag is `True` the entire `if not _allow_unsandboxed_exec():` body —
including the `SandboxUnavailableError` raise — is skipped, falling through to
`_warn_no_isolation` + `return argv, None`: **unconfined**.

The complete chain: a policy pins `sandbox.min_level: strict`, the host has no
sandbox backend (every Windows host, macOS ≥ 26, a locked-down container), and
`agent.sandbox_allow_unsandboxed_exec` is set → the agent subprocess runs with no
OS-level isolation. And that flag lives in `config.json`, which is **not** on
`security._SENSITIVE_HOME_DIRS` — the dashboard PATCH allowlist does not expose
it, but a raw file write is not blocked, so the trigger is agent-reachable.

## Why it matters

An operator who pins `sandbox.min_level` reasonably believes they have made
unsandboxed execution impossible. They have not, and the thing that can undo it
is writable by the process the policy exists to constrain. That is the same shape
as a config knob without a policy counterpart — the pattern this codebase already
solves elsewhere with `channels.posture` as the un-weakenable counterpart to
`slack.allowed_enterprise_ids`.

Separately, `allow_terminal` names the ungoverned web-terminal surface: the PTY
takes no governance decision at all, so a policy currently has no way to close
that door even though the schema advertises the key.

## Fix

**Symptom** → three declared keys bind nothing, and one of them is the only
available lever over a reachable unsandboxed-execution path.

**Root cause** → the keys were never wired. Their declared defaults were
therefore never pressure-tested against a real policy, which turns out to be the
central constraint on how they can be wired at all (below). For the same reason,
the parse site's `bool()` coercion of these values had never mattered — nothing
read the result.

**Change** → five parts.

**1. `require_sandbox` binds at the no-backend gate** (`sandbox.py`). New
`_governance_require_sandbox()` sits beside `_governance_sandbox_floor()` and
inherits its error posture: a `PlatformCompositionError` propagates rather than
silently downgrading the guarantee on the very host meant to be governed; any
other transient error reads as unpinned. It is read **once** per `wrap_argv` call
on the same one-read discipline as the floor, because both the gate and the
first-party carve-out consult it and the two must never disagree about the same
host. The gate becomes `if require_sandbox or not _allow_unsandboxed_exec():`, so
policy overrides the config opt-in, and the carve-out gains `and not
require_sandbox`. The error message now names the policy when the policy is the
reason — the old wording ("allow_unsandboxed_exec is not set") would have sent an
operator down a dead end in exactly the case where it *is* set.

**Scope stated honestly: this closes the `_allow_unsandboxed_exec` escape and only
that one.** `require_sandbox` does not clamp `agent.sandbox: "off"`, which returns
unconfined argv earlier in `wrap_argv`, before the pin is consulted. A policy that
pins `require_sandbox` alone therefore still leaves an agent-writable route to an
unsandboxed subprocess; pairing it with a `sandbox.min_level` floor is what closes
both, since the ordinal clamp is what rewrites `off` upward. The two controls are
complementary, not alternatives, and `BootControls`' docstring now says so — the
field name reads as standalone-sufficient and nothing previously corrected that.

**2. `allow_terminal` binds at `_is_enabled()`** (`dashboard/handlers/terminal.py`).
All six terminal routes already gate on this one function, and
`api_terminal_list` already reports `enabled: false`, which the frontend uses to
hide the Terminal entry from the panel menu and the "Run in terminal" button — so
a policy deny degrades to "not offered" rather than a dead black panel. Reuses
the existing 30s memo; policy is boot-fixed so caching is safe. There are no
backend callers of these routes, so nothing else breaks.

**Scope stated honestly: this disables the SURFACE, it does not govern it.** A
permitted terminal still spawns an intentionally unsandboxed shell with no
per-command governance call. Sandboxing the PTY is a separate, larger effort.

**Error posture is split, not swallowed.** `current_context()` raises
`PlatformCompositionError` when the host resolves to a governed edition but no
context was installed — its docstring names that guard as existing so "a future
swallowing caller cannot reintroduce the silent fail-open", and it re-raises on
*every* call rather than caching, so it is not a transient. Catching it and
returning `True` would hand an open terminal to precisely the host whose
governance is known broken, so it returns `False` and the panel degrades to "not
offered" via the `enabled: false` path above. Any other exception stays an
availability transient and leaves the panel up, matching the config read. This
mirrors `sandbox._governance_require_sandbox`, which propagates the same error
rather than silently downgrading the guarantee — the two new readers in this
commit now agree about what a broken governed host means.

**3. Both bound keys are tri-state; absence means no opinion.** This is the
load-bearing design decision, and it is why the diff touches `BootControls`
rather than just adding two reads. Because nothing consumed these keys, their
declared defaults were never tested against a real fleet:

- `allow_terminal` defaulted to `False` → consuming it as declared would
  **silently remove the web terminal from every governed host**, including one
  whose policy never mentions the terminal;
- `require_sandbox` defaulted to `True` → consuming it as declared would **newly
  fail-close every governed host** that relies on the escape.

So `require_sandbox` and `allow_terminal` become `Optional[bool]` with `None` =
"the policy did not write this key", and only an explicitly-written key binds.
That is the same rule the governed scopes already follow, where a control the
policy does not name is ungoverned. `policy show` now prints `unset` rather than a
declared default, so it never reports a control that is not in force.

**4. `fail_closed: false` is refused at parse, and `boot` now rejects unknown
keys.** Boot already aborts unconditionally — `load_security_policy` raises on an
unreadable policy and `assert_governance_floor` raises on a weakening profile,
neither consulting this key — so `false` cannot relax anything today, and wiring
it would turn it into a switch that lets a fleet boot ungoverned. Refusing is
louder than silently ignoring and leaves room for a separately-named
runtime-polarity control later. `fail_closed` therefore stays a plain `bool`: the
only honest values are "declared true" and "not declared".

`boot` was also the **only** block that silently ignored unknown keys while every
archetype rejects a typo fail-closed. Harmless while nothing consumed it; a
silent security hole the moment `require_sandbox` binds, because
`{"require_sandbxo": true}` would read as "no opinion" while the author believed
the escape was forbidden. This is why it ships in the same change rather than as
a follow-up.

**5. Every written boot value must be a real JSON boolean.** The parse site
coerced with `bool()`, and `bool("false")` is `True` — so a quoted typo bound the
**opposite** of what the operator wrote. For `allow_terminal` that opposite is
**fail-open**: `"allow_terminal": "false"` left the web terminal reachable across
a fleet whose policy said it was shut, while `policy show` reported
`allow_terminal=True` and corroborated the wrong belief. A quoted value also
dodged part 4's `fail_closed: false` refusal, because `"false" is False` is never
true — the loud guard was bypassable by exactly the mistake it exists to catch.
There is no schema validation upstream of `parse_policy`, so this is the only
place it can be caught.

Non-booleans are now refused with a message naming the key
(`0`/`1` and an explicit `null` included). This ships here rather than as a
follow-up for the same reason as part 4: the coercion was inert while these keys
bound nothing, and **binding them is what makes it reachable**. Refusing cannot
break a working policy, because no policy could have depended on a value that
nothing read.

**Deliberately not in this PR.** `governance.py`'s capability-row parse has the
same `bool()` coercion shape for `enabled`. It is pre-existing on `main`, affects
every capability row rather than the `boot` block this change owns, and widening
the diff to cover it would re-arm every reviewer on surface this PR did not
introduce. Likewise, emitting a `policy validate` warning when `require_sandbox`
is pinned without a `sandbox.min_level` floor would be a genuine addition to the
validate surface — and that surface is being changed by a separate open PR, so
adding it here would collide. Both are follow-ups, recorded here so the omission
is a decision rather than an oversight.

## Tests

**`test/test_sandbox_first_party_exec.py` — `TestBootRequireSandboxOverridesTheOptIn`,
6 tests.** The file's module docstring matrix is extended with the new row.

- `test_pin_raises_even_though_the_opt_in_is_set` — the hole itself: no backend +
  opt-in `True` + pin → raises, and asserts the message names
  `boot.require_sandbox`. Without the pin this exact configuration returns
  unconfined argv.
- `test_without_the_pin_the_opt_in_still_works` and
  `test_explicit_false_also_leaves_the_opt_in_working` — regression guards for the
  tri-state; these are the cases that would break every governed host if an
  unwritten key bound its declared default.
- `test_pin_also_closes_the_first_party_carve_out` — the carve-out reads the pin.
- `test_ungoverned_host_reads_as_unpinned` — standalone behaves exactly as before.
- `test_backend_available_makes_the_pin_inert` — the pin governs only the
  no-backend branch.

**`test/test_governance_policy.py` — `TestBootControls`, 13 tests.** Absent keys
resolve to `None` not their declared defaults; written keys bind; written `False`
is distinguishable from absent; an empty `boot` object is valid and opinion-free;
`fail_closed: false` raises with the explanatory message; `fail_closed` true and
absent both resolve `True`; a misspelled key is rejected; `boot` is still required.

Five lock part 5 shut:

- `test_stringy_boolean_is_refused_not_coerced` — all three keys reject `"false"`,
  asserting the message names the key.
- `test_stringy_fail_closed_cannot_dodge_the_false_refusal` — the specific dodge:
  a real `false` is refused loudly, so a quoted one must not slip through quietly.
- `test_integer_boolean_lookalikes_are_refused` — `0`/`1`.
- `test_explicit_null_is_refused_rather_than_read_as_absent` — a written `null` is
  ambiguous and is refused rather than guessed into "no opinion".
- `test_real_booleans_still_bind_after_the_type_check` — the check refuses
  look-alikes without narrowing the values that must keep working.

**`test/test_terminal_handler.py` — `TestBootAllowTerminalGate`, 7 tests.** Policy
`false` disables; policy absent, policy `true` and an ungoverned host all leave it
enabled; the config path still disables independently. Each case resets
`_enabled_cache` so the 30s memo cannot leak between them. The two error postures
are tested separately, because they must not agree:
`test_transient_context_error_does_not_take_the_panel_down` (a `RuntimeError`
leaves the panel up) and
`test_composition_error_disables_rather_than_failing_open` (a
`PlatformCompositionError` disables it). The second fails against a single
`except Exception: return True`.

## Manual verification

Local gates on the rebased branch:

- `pytest` — **1364 passed, 15 skipped** across the six governance suites, five
  sandbox suites, `test_cli_commands_coverage.py`, `test_config_loader.py`,
  `test_terminal_handler.py` and `test_terminal_commands.py`.
- `isort --check-only` — clean on all seven changed files.
- `flake8` — clean on all seven changed files.
- `mypy` — no findings in `platform/governance.py`, `sandbox.py`,
  `dashboard/handlers/terminal.py` or `cli_commands.py`. Three pre-existing
  `hooks.py` findings are `os.setxattr`, which exists on Linux and not macOS, so
  they are a local-macOS artifact rather than something CI sees.
- `scripts/check_brand_name.py` — exit 0, including the base-ref variant over the
  lines this branch adds.
- `scripts/scrub-lint.sh --no-history`, `scripts/docs_lint.py --test` and
  `scripts/verify_vendor_manifest.py` — all exit 0.

The frontend gates are not implicated: this diff touches no file under `website/`.

Two pre-existing failures were excluded and confirmed not mine. Both are
`test_terminal_handler.py::TestTerminalWsIntegration` PTY-integration cases —
`test_stream_and_replay_forward_output_verbatim` and
`test_multibyte_output_survives_read_boundaries` — and both time out at 120s on a
**throwaway worktree checked out at clean `origin/main` with none of this
branch's code**, where that class reports 2 failed / 11 passed. This branch's run
of the same class is no worse. Since this diff does touch `terminal.py`, that was
verified against the base rather than assumed.

Parse behaviour before and after part 5, against an isolated data home:

```
                                    before          after
allow_terminal: false   (bool)      False           False        unchanged
allow_terminal: "false" (string)    True  ← open    REJECTED
allow_terminal: "no"    (string)    True  ← open    REJECTED
allow_terminal: 0       (int)       False           REJECTED
require_sandbox: "false"(string)    True            REJECTED
fail_closed: false      (bool)      REJECTED        REJECTED     unchanged
fail_closed: "false"    (string)    accepted        REJECTED
boot: {} (all absent)               None/None       None/None    unchanged
```

The two `fail_closed` rejections stay distinct: a real `false` still gets part 4's
policy refusal, while a quoted one now gets the type refusal.

End-to-end `policy show` against an isolated data home:

```
# all three keys written
boot: require_sandbox=True allow_terminal=False fail_closed=True (always enforced)

# only fail_closed written — the shape most existing policies have
boot: require_sandbox=unset allow_terminal=unset fail_closed=True (always enforced)

# fail_closed: false
PlatformCompositionError: boot.fail_closed cannot be set to false: boot is
unconditionally fail-closed (an unreadable policy or a profile looser than the
ceiling aborts startup regardless of this key). Remove the key, or set it to
true to declare the posture explicitly.
```

The third case aborts at policy load, which is the same fail-closed path any
malformed policy already takes.

no issue closed: found while writing the enterprise governance field manual; no
tracked issue was filed for it.
