### PR TITLE
feat(issue-radar): address an investigation record by session verb

### DIFF
--- a/docs/system-specs/modules/issue-radar.md
+++ b/docs/system-specs/modules/issue-radar.md
@@ -43,7 +43,7 @@ wrapped in `_require_enabled` (returns 403 when the app is disabled).
 | GET | `/pull-ai` | AI summary of a PR (description + whole conversation + check state), cached against a fingerprint that hashes the conversation's CONTENT — so an edited comment invalidates it, not just a new one |
 | POST | `/labels/apply` | Apply label changes (add/remove) |
 | POST | `/issue/state` | Close/reopen an issue |
-| GET/PUT | `/investigation` | Per-issue investigation record. The PUT is the ONE app route also reachable with the gateway internal secret (`_MIXED_INTERNAL_API_PATHS`), because it is the write behind the `issue_radar_record_investigation` MCP tool — see [Recording findings](#recording-findings) |
+| GET/PUT | `/investigation` | Per-item investigation record, addressed by `kind` (number sequence) and optional `verb` (which job) — see [One record per item, per verb](#one-record-per-item-per-verb). The PUT is the ONE app route also reachable with the gateway internal secret (`_MIXED_INTERNAL_API_PATHS`), because it is the write behind the `issue_radar_record_investigation` MCP tool — see [Recording findings](#recording-findings) |
 | GET | `/dispatch-readiness` | Whether an issue in this repo may be handed to an implementation attempt, plus a machine-readable `reason` — see [Dispatch readiness](#dispatch-readiness) |
 | POST | `/repo/local-path` | Record a connected repo's local checkout. `local_path` is REQUIRED; an explicit `""` clears it and an omitted field is a 400. Validates and REFUSES; never falls back to a directory the user did not name |
 | GET/POST | `/recommendations` | AI label taxonomy recommendations |
@@ -192,6 +192,52 @@ triage prompt. When the agent concludes it writes its verdict back into the
 item's investigation record — that is what puts a verdict + summary on the
 issue's card instead of leaving it in chat scrollback.
 
+### One record per item, per verb
+
+A record holds exactly one `slot_key`, so two things address it: `kind` and
+`verb`. They are orthogonal, and both are folded into the filename.
+
+`kind` says which **number sequence** the item came from. GitHub draws issues and
+pull requests from one sequence, so `#5` is unambiguous and keeps the historical
+`investigation-<N>.json`. GitLab keeps two, so merge request `!5` gets
+`investigation-mr-<N>.json` — sharing the issue's file would make "Review MR !5"
+resume issue #5's session.
+
+`verb` says which **job** is being done on that item, for the case where a person
+runs two of them at once on one change request. An omitted verb is the item's
+primary record. An unknown verb is refused with a 400 rather than folded to the
+primary record: folding would silently produce the collision the dimension exists
+to prevent, and `store.investigation_path` raises on one too, so the route
+validation is not the only gate.
+
+Findings always belong to the primary record. Every agent-side write arrives
+through the MCP tool below, which sends no verb — so a verb record carries a
+session link and nothing else, and the browser is the only writer that names one.
+
+### Claiming the session link
+
+A record holds one `slot_key`, and a re-entry guard in one browser tab cannot see a
+click in another. So the record itself is what orders two tabs: a session-link write
+may pass `expected_slot_key`, and the store compares it to the stored link **inside
+the same exclusive lock as the read-back**, refusing with `409`
+(`investigation_slot_conflict`) when it has moved. Without that, two tabs both read
+"no session", both create one, and the later write replaces the first tab's link —
+leaving an agent running that nothing points at.
+
+The 409 carries the live record, because the loser needs the winner's `slot_key` to
+adopt that session instead of starting a second one. The frontend therefore claims
+**before seeding the first turn**: at that point its own slot has no turn yet, so
+losing is recoverable by removing it, whereas claiming after the seed would leave a
+running agent to either destroy or orphan.
+
+Naming a stale link is how a deliberate replacement is expressed — resuming a
+session whose slot was deleted rewrites the link, and the caller proves it is not
+racing by passing the value it read. Omitting the field keeps last-writer-wins,
+which is what every findings write needs: those never touch `slot_key` and must not
+fail on somebody else's session.
+
+### Why the write goes through an MCP tool
+
 That write goes through the **`issue_radar_record_investigation` MCP tool**, not
 a raw HTTP call. An agent session holds no dashboard credential:
 
@@ -250,6 +296,8 @@ repos/<owner>/<repo>/
   recommendations-cache.json        # AI label taxonomy
   tagging-cache.json                # Per-issue label proposals for the untagged queue
   investigation-<N>.json            # Per-issue investigation record
+  investigation-mr-<N>.json         # GitLab merge request (its own number sequence)
+  investigation-<verb>-<N>.json     # A second session verb on that item
   watch-state.json                  # Watcher high-water mark
 ```
 

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
@@ -2231,13 +2231,36 @@ def _item_kind(raw: object) -> str | None:
     return raw if isinstance(raw, str) and raw in provider.ITEM_KINDS else None
 
 
+def _record_verb(raw: object) -> tuple[str | None, web.Response | None]:
+    """Validate the record's session-verb field, absent meaning the item's primary
+    record. Returns ``(verb, error)`` -- the same shape as ``_parse_item_number``,
+    because ``None`` is a VALID verb here and so cannot double as "invalid".
+
+    An unknown verb is refused rather than folded to the primary record: the whole
+    point of the field is that two verbs on one item must not share a ``slot_key``,
+    so silently ignoring a typo would resume the wrong session -- the exact defect
+    the dimension exists to prevent.
+    """
+    if raw is None or raw == "":
+        return None, None
+    if isinstance(raw, str) and raw in store.RECORD_VERBS:
+        return raw, None
+    allowed = ", ".join(sorted(store.RECORD_VERBS))
+    return None, web.json_response(
+        {"error": f"'verb' must be omitted or one of: {allowed}"}, status=400
+    )
+
+
 async def _handle_get_investigation(request: web.Request) -> web.Response:
-    """GET /investigation?owner=<o>&repo=<r>&number=<n>[&kind=issue|pull] — the
-    local investigation record for one item (session link + status + findings), or
-    ``null`` when it has never been investigated. Read-only, no permission gate.
+    """GET /investigation?owner=<o>&repo=<r>&number=<n>[&kind=issue|pull][&verb=<v>]
+    — the local investigation record for one item (session link + status +
+    findings), or ``null`` when it has never been investigated. Read-only, no
+    permission gate.
 
     ``kind`` defaults to ``issue`` and only changes the answer on GitLab, where
-    issues and merge requests have independent number sequences."""
+    issues and merge requests have independent number sequences. ``verb`` selects
+    a per-session-verb record on the same item (``store.RECORD_VERBS``); omitted,
+    the answer is the item's primary record."""
     key = _key_from_request(request)
     owner, repo = key.owner, key.repo
     number_raw = (request.query.get("number") or "").strip()
@@ -2255,26 +2278,41 @@ async def _handle_get_investigation(request: web.Request) -> web.Response:
     item_kind = _item_kind(request.query.get("kind"))
     if item_kind is None:
         return web.json_response({"error": "'kind' must be 'issue' or 'pull'"}, status=400)
+    verb, verb_error = _record_verb(request.query.get("verb"))
+    if verb_error is not None:
+        return verb_error
 
     record = await _st(
         key, store.read_investigation, owner, repo, number,
-        kind=provider.investigation_kind(key, item_kind),
+        kind=provider.investigation_kind(key, item_kind), verb=verb,
     )
     return web.json_response({
-        **_identity(key), "number": number, "kind": item_kind,
+        **_identity(key), "number": number, "kind": item_kind, "verb": verb,
         "investigation": record,
     })
 
 
 async def _handle_put_investigation(request: web.Request) -> web.Response:
-    """PUT /investigation {"owner","repo","number", kind?, slot_key?, folder_id?,
-    status?, findings?} — upsert one item's investigation record.
+    """PUT /investigation {"owner","repo","number", kind?, verb?, slot_key?,
+    folder_id?, status?, findings?} — upsert one item's investigation record.
 
     ``kind`` (``issue`` / ``pull``, default ``issue``) is part of the record's
     identity on GitLab, where a merge request's number is drawn from a different
     sequence than an issue's. An agent PUT that omits it therefore addresses the
     ISSUE with that number -- which is why the seed prompts emit it (see
     ``lib/links.ts:recordIdentityJson``).
+
+    ``verb`` (one of ``store.RECORD_VERBS``) addresses the record for one session
+    verb on that item, so two verbs running concurrently do not overwrite each
+    other's ``slot_key``. Omitted -- as every agent-side write leaves it -- the
+    target is the item's primary record, which is where findings belong.
+
+    ``expected_slot_key`` makes a session-link write a compare-and-set against the
+    stored link, answering 409 with the live record when it has moved. A re-entry
+    guard lives in one browser tab and cannot see a click in another, so without it
+    two tabs both read "no session", both create one, and the later write replaces
+    the first tab's link -- leaving an agent running that nothing points at. Omit it
+    to keep last-writer-wins.
 
     Called by the Investigate button to link the freshly-created chat session
     (``slot_key`` + ``folder_id``), and again on resume to bump the "last opened"
@@ -2319,14 +2357,46 @@ async def _handle_put_investigation(request: web.Request) -> web.Response:
     item_kind = _item_kind(body.get("kind"))
     if item_kind is None:
         return web.json_response({"error": "'kind' must be 'issue' or 'pull'"}, status=400)
+    verb, verb_error = _record_verb(body.get("verb"))
+    if verb_error is not None:
+        return verb_error
 
     patch = {k: body[k] for k in ("slot_key", "folder_id", "status", "findings") if k in body}
-    saved = await _st(
-        key, store.write_investigation, owner, repo, number, patch,
-        kind=provider.investigation_kind(key, item_kind),
-    )
+    # A session-link write may claim the record: it proceeds only if the stored
+    # link still matches what the caller last saw. A re-entry guard is per-tab, so
+    # two tabs would otherwise both read "no session", both create one, and the
+    # later write would replace the first tab's link, leaving an agent running that
+    # nothing points at. Absent -- as every agent-side findings write leaves it --
+    # the write stays last-writer-wins.
+    claim: object = store._NO_CLAIM
+    if "expected_slot_key" in body:
+        raw_claim = body.get("expected_slot_key")
+        if raw_claim is not None and not isinstance(raw_claim, str):
+            return web.json_response(
+                {"error": "'expected_slot_key' must be a string or null"}, status=400
+            )
+        claim = raw_claim
+    try:
+        saved = await _st(
+            key, store.write_investigation, owner, repo, number, patch,
+            kind=provider.investigation_kind(key, item_kind), verb=verb,
+            expected_slot_key=claim,
+        )
+    except store.SlotClaimConflict as conflict:
+        # 409 carries the LIVE record so the caller can adopt the winner's session
+        # rather than starting a second one.
+        return web.json_response(
+            {
+                "error": "this item's session link changed since it was read",
+                "code": "investigation_slot_conflict",
+                **_identity(key), "number": number, "kind": item_kind, "verb": verb,
+                "investigation": conflict.record or None,
+            },
+            status=409,
+        )
     return web.json_response({
-        **_identity(key), "number": number, "kind": item_kind, "investigation": saved,
+        **_identity(key), "number": number, "kind": item_kind, "verb": verb,
+        "investigation": saved,
     })
 
 

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
@@ -1548,6 +1548,22 @@ def apply_state_change_to_caches(
 
 _INVESTIGATION_STATUSES = ("investigating", "resolved", "archived")
 
+# A second SESSION VERB on one item needs its own record, because the record holds
+# exactly one ``slot_key``. Reviewing a change request and answering the feedback
+# that change request received are two different jobs a person runs concurrently
+# on the same number, so sharing one record would make the second click resume the
+# first job's session and overwrite its link.
+#
+# This is orthogonal to ``kind``: ``kind`` says which number SEQUENCE the item
+# belongs to (see ``provider.investigation_kind``), while a verb says which job is
+# being done on that item. ``None`` is the item's primary record and keeps the
+# historical filename, so nothing that exists needs migrating.
+#
+# Every verb here is change-request-only. If a verb is ever added that also
+# applies to issues, it needs its own thought about the GitHub case, where an
+# issue and a change request cannot share a number but a verb record would.
+RECORD_VERBS = frozenset({"respond"})
+
 
 def _now_iso() -> str:
     """UTC timestamp, microsecond precision, ``Z`` suffix — stable, sortable, and
@@ -1563,7 +1579,13 @@ now_iso = _now_iso
 
 
 def investigation_path(
-    owner: str, repo: str, number: int, root: Path | None = None, *, kind: str = "issue"
+    owner: str,
+    repo: str,
+    number: int,
+    root: Path | None = None,
+    *,
+    kind: str = "issue",
+    verb: str | None = None,
 ) -> Path:
     """Path of one item's investigation record.
 
@@ -1575,19 +1597,36 @@ def investigation_path(
     Sharing one file between them would make "Review MR !5" resume issue #5's
     session and overwrite its findings.
 
-    ``"issue"`` deliberately keeps the historical filename, so every existing
-    record (all of which are GitHub's, where the namespace is shared) is found
-    exactly where it was written and nothing needs migrating.
+    ``verb`` separates two SESSION VERBS on the same item (see ``RECORD_VERBS``);
+    it is orthogonal to ``kind``, so a GitLab merge request being answered is
+    ``mr-respond-``. ``None`` is the item's primary record.
+
+    ``"issue"`` with no verb deliberately keeps the historical filename, so every
+    existing record (all of which are GitHub's, where the namespace is shared) is
+    found exactly where it was written and nothing needs migrating.
+
+    Raises ``ValueError`` on an unknown verb. Both values land in a filename with
+    no further sanitization, so this is the fail-closed backstop behind the route
+    validation rather than the only gate.
     """
+    if verb is not None and verb not in RECORD_VERBS:
+        raise ValueError(f"unknown investigation record verb: {verb!r}")
     suffix = "" if kind == "issue" else f"{kind}-"
-    return repo_data_dir(owner, repo, root) / f"investigation-{suffix}{int(number)}.json"
+    verb_suffix = "" if verb is None else f"{verb}-"
+    return repo_data_dir(owner, repo, root) / f"investigation-{suffix}{verb_suffix}{int(number)}.json"
 
 
 def read_investigation(
-    owner: str, repo: str, number: int, root: Path | None = None, *, kind: str = "issue"
+    owner: str,
+    repo: str,
+    number: int,
+    root: Path | None = None,
+    *,
+    kind: str = "issue",
+    verb: str | None = None,
 ) -> dict | None:
     """Return an item's investigation record, or None if never investigated."""
-    path = investigation_path(owner, repo, number, root, kind=kind)
+    path = investigation_path(owner, repo, number, root, kind=kind, verb=verb)
     if not path.is_file():
         return None
     try:
@@ -1675,9 +1714,28 @@ def _merge_findings(existing: Any, raw: Any) -> dict[str, Any] | None:
     return _normalize_findings(combined)
 
 
+class SlotClaimConflict(Exception):
+    """A session-link write lost a race for the record.
+
+    Carries the record as it actually stands, so the caller can adopt the winner's
+    session instead of creating a second one.
+    """
+
+    def __init__(self, record: dict[str, Any]):
+        super().__init__("the record's session link changed under this write")
+        self.record = record
+
+
+# Sentinel distinguishing "claim nothing, last-writer-wins" (the historical
+# behaviour every findings write relies on) from "claim only if the stored link is
+# still None", which cannot be expressed with None alone.
+_NO_CLAIM = object()
+
+
 def write_investigation(
     owner: str, repo: str, number: int, patch: dict[str, Any], *,
-    root: Path | None = None, kind: str = "issue",
+    root: Path | None = None, kind: str = "issue", verb: str | None = None,
+    expected_slot_key: Any = _NO_CLAIM,
 ) -> dict[str, Any]:
     """Upsert an issue's investigation record, MERGING ``patch`` into any
     existing record (last-writer-wins per field). ``started_at`` is stamped once
@@ -1687,14 +1745,34 @@ def write_investigation(
     ``findings`` (merged per key by :func:`_merge_findings`, so a patch carrying
     only ``verdict`` keeps the stored ``root_cause``/``summary``/labels; an
     explicit ``None`` clears them). A partial patch (even ``{}``, which just bumps
-    the open stamp) is valid. Returns the stored record."""
+    the open stamp) is valid. Returns the stored record.
+
+    ``expected_slot_key`` turns a session-link write into a compare-and-set:
+    the write proceeds only if the STORED link still equals what the caller last
+    saw, and otherwise raises :class:`SlotClaimConflict` carrying the live record.
+    A re-entry guard in one browser tab cannot see a click in another, so without
+    this two tabs both read "no session", both create one, and the later write
+    replaces the first tab's link — leaving an agent running that nothing points
+    at. The comparison happens inside the same exclusive lock as the read-back, so
+    the check and the write cannot be interleaved.
+
+    Omitted means no claim, which is what every agent-side findings write wants:
+    those do not touch ``slot_key`` and must not fail on someone else's session."""
     number = int(number)
     now = _now_iso()
-    lock_path = investigation_path(owner, repo, number, root, kind=kind).with_suffix(".lock")
+    lock_path = investigation_path(
+        owner, repo, number, root, kind=kind, verb=verb
+    ).with_suffix(".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with open(lock_path, "w") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
-            existing = read_investigation(owner, repo, number, root, kind=kind) or {}
+            existing = read_investigation(owner, repo, number, root, kind=kind, verb=verb) or {}
+            if expected_slot_key is not _NO_CLAIM:
+                stored = existing.get("slot_key")
+                # Normalize "" to None so a cleared link and an absent one compare
+                # equal, matching how the patch path treats them.
+                if (stored or None) != (expected_slot_key or None):
+                    raise SlotClaimConflict(existing)
 
             record: dict[str, Any] = {
                 "owner": owner,
@@ -1722,7 +1800,7 @@ def write_investigation(
                 )
 
             atomic_write(
-                investigation_path(owner, repo, number, root, kind=kind),
+                investigation_path(owner, repo, number, root, kind=kind, verb=verb),
                 json.dumps(record, indent=2),
             )
     return record

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_gitlab.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_gitlab.py
@@ -843,6 +843,42 @@ class TestInvestigationNamespace(unittest.TestCase):
         self.assertEqual(issue_record["slot_key"], "issue-slot")
         self.assertEqual(mr_record["slot_key"], "mr-slot")
 
+    def test_a_verb_record_is_orthogonal_to_the_kind_namespace(self):
+        # A GitLab merge request being ANSWERED is a third distinct record: the
+        # kind namespace and the session verb compose rather than override, so
+        # neither the issue's record nor the MR's own primary record is touched.
+        gl = provider.key_from_parts("group", "project", "gitlab", "gitlab.com")
+        issue_kind = provider.investigation_kind(gl, "issue")
+        mr_kind = provider.investigation_kind(gl, "pull")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            names = {
+                store.investigation_path("group", "project", 5, root, kind=issue_kind).name,
+                store.investigation_path("group", "project", 5, root, kind=mr_kind).name,
+                store.investigation_path(
+                    "group", "project", 5, root, kind=mr_kind, verb="respond"
+                ).name,
+            }
+            self.assertEqual(len(names), 3, names)
+            self.assertIn("investigation-mr-respond-5.json", names)
+
+            store.write_investigation(
+                "group", "project", 5, {"slot_key": "mr-slot"}, root=root, kind=mr_kind
+            )
+            store.write_investigation(
+                "group", "project", 5, {"slot_key": "mr-respond-slot"},
+                root=root, kind=mr_kind, verb="respond",
+            )
+            mr_record = store.read_investigation("group", "project", 5, root, kind=mr_kind)
+            respond_record = store.read_investigation(
+                "group", "project", 5, root, kind=mr_kind, verb="respond"
+            )
+
+        assert mr_record is not None and respond_record is not None
+        self.assertEqual(mr_record["slot_key"], "mr-slot")
+        self.assertEqual(respond_record["slot_key"], "mr-respond-slot")
+
     def test_the_issue_record_keeps_the_legacy_path_on_gitlab_too(self):
         # Only the namespace that has never been written to changes, so a GitLab
         # issue record written before this fix is still found.

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_investigation.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_investigation.py
@@ -186,5 +186,198 @@ class TestInvestigationStore(unittest.TestCase):
         self.assertIsNone(store.read_investigation("o", "r", 7, self.tmp))
 
 
+class TestRecordVerbNamespace(unittest.TestCase):
+    """One item can carry two concurrent session verbs.
+
+    The record holds exactly one ``slot_key``, so reviewing a change request and
+    answering the feedback it received must not share a record: the second click
+    would resume the first verb's session and overwrite its link. ``verb`` is
+    orthogonal to ``kind`` -- ``kind`` says which number sequence the item comes
+    from, ``verb`` says which job is being done on it.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_a_verb_record_does_not_share_the_primary_records_session_link(self):
+        store.write_investigation("o", "r", 5, {"slot_key": "review-slot"}, root=self.tmp)
+        store.write_investigation(
+            "o", "r", 5, {"slot_key": "respond-slot"}, root=self.tmp, verb="respond"
+        )
+
+        primary = store.read_investigation("o", "r", 5, self.tmp)
+        respond = store.read_investigation("o", "r", 5, self.tmp, verb="respond")
+        assert primary is not None and respond is not None
+        self.assertEqual(primary["slot_key"], "review-slot")
+        self.assertEqual(respond["slot_key"], "respond-slot")
+
+    def test_the_primary_record_keeps_the_historical_filename(self):
+        # An omitted verb must resolve to the file every existing record already
+        # lives in, so nothing needs migrating.
+        self.assertEqual(
+            store.investigation_path("o", "r", 5, self.tmp).name, "investigation-5.json"
+        )
+        self.assertEqual(
+            store.investigation_path("o", "r", 5, self.tmp, verb="respond").name,
+            "investigation-respond-5.json",
+        )
+
+    def test_a_verb_record_is_absent_until_written(self):
+        store.write_investigation("o", "r", 5, {"slot_key": "review-slot"}, root=self.tmp)
+        self.assertIsNone(store.read_investigation("o", "r", 5, self.tmp, verb="respond"))
+
+    def test_an_unknown_verb_is_refused_rather_than_folded(self):
+        # Folding an unrecognized verb to the primary record would silently produce
+        # the collision the dimension exists to prevent, so the store fails closed
+        # behind the route validation.
+        with self.assertRaises(ValueError):
+            store.investigation_path("o", "r", 5, self.tmp, verb="reviwe")
+        with self.assertRaises(ValueError):
+            store.write_investigation("o", "r", 5, {}, root=self.tmp, verb="reviwe")
+        with self.assertRaises(ValueError):
+            store.read_investigation("o", "r", 5, self.tmp, verb="reviwe")
+
+    def test_a_verb_write_leaves_no_stray_lock_beside_the_primary_record(self):
+        # The write resolves the path three times (lock, read-back, atomic write).
+        # If any one of them drops the verb, the record splits across two files.
+        store.write_investigation(
+            "o", "r", 5, {"slot_key": "respond-slot"}, root=self.tmp, verb="respond"
+        )
+        self.assertFalse(store.investigation_path("o", "r", 5, self.tmp).is_file())
+        self.assertTrue(
+            store.investigation_path("o", "r", 5, self.tmp, verb="respond").is_file()
+        )
+
+    def test_the_write_lock_is_per_record(self):
+        # A lock shared with the primary record would serialize two independent
+        # records against each other, so the lock's identity tracks the record's.
+        store.write_investigation("o", "r", 5, {}, root=self.tmp, verb="respond")
+        locks = {p.name for p in self.tmp.rglob("*.lock")}
+        self.assertIn("investigation-respond-5.lock", locks)
+        self.assertNotIn("investigation-5.lock", locks)
+
+    def test_a_verb_write_does_not_inherit_the_primary_records_fields(self):
+        # The read-back that feeds the merge must target the SAME record the write
+        # lands in. Reading the primary record here would leak one verb's findings
+        # and folder into the other -- invisible in any field the patch overwrites,
+        # which is why this asserts on fields the patch omits.
+        store.write_investigation(
+            "o", "r", 5,
+            {
+                "slot_key": "review-slot",
+                "folder_id": "review-folder",
+                "findings": {"verdict": "review-verdict"},
+            },
+            root=self.tmp,
+        )
+        respond = store.write_investigation(
+            "o", "r", 5, {"slot_key": "respond-slot"}, root=self.tmp, verb="respond"
+        )
+        self.assertEqual(respond["slot_key"], "respond-slot")
+        self.assertIsNone(respond["folder_id"])
+        self.assertIsNone(respond["findings"])
+
+    def test_findings_merge_independently_per_verb(self):
+        store.write_investigation(
+            "o", "r", 5, {"findings": {"verdict": "primary-verdict"}}, root=self.tmp
+        )
+        store.write_investigation(
+            "o", "r", 5, {"findings": {"verdict": "respond-verdict"}},
+            root=self.tmp, verb="respond",
+        )
+        primary = store.read_investigation("o", "r", 5, self.tmp)
+        respond = store.read_investigation("o", "r", 5, self.tmp, verb="respond")
+        assert primary is not None and respond is not None
+        self.assertEqual(primary["findings"]["verdict"], "primary-verdict")
+        self.assertEqual(respond["findings"]["verdict"], "respond-verdict")
+
+    def test_a_verb_record_is_removed_with_the_repo_cache(self):
+        store.add_connected_repo("o", "r", root=self.tmp)
+        store.write_investigation("o", "r", 7, {"slot_key": "s"}, root=self.tmp, verb="respond")
+        store.remove_connected_repo("o", "r", root=self.tmp)
+        self.assertIsNone(store.read_investigation("o", "r", 7, self.tmp, verb="respond"))
+
+
+class TestSlotClaim(unittest.TestCase):
+    """Claiming the session link is how two browser tabs stop double-creating.
+
+    A re-entry guard lives in one tab's memory, so it cannot see a click in
+    another. Without a compare-and-set both tabs read "no session", both create
+    one, and the later write replaces the first tab's link -- leaving an agent
+    running that nothing points at.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_claiming_an_unclaimed_record_succeeds(self):
+        rec = store.write_investigation(
+            "o", "r", 5, {"slot_key": "tab-one"}, root=self.tmp, expected_slot_key=None,
+        )
+        self.assertEqual(rec["slot_key"], "tab-one")
+
+    def test_the_second_tab_is_refused_and_told_who_won(self):
+        store.write_investigation(
+            "o", "r", 5, {"slot_key": "tab-one"}, root=self.tmp, expected_slot_key=None,
+        )
+        with self.assertRaises(store.SlotClaimConflict) as caught:
+            store.write_investigation(
+                "o", "r", 5, {"slot_key": "tab-two"}, root=self.tmp, expected_slot_key=None,
+            )
+        # The loser needs the winner's link to adopt that session instead.
+        self.assertEqual(caught.exception.record["slot_key"], "tab-one")
+        stored = store.read_investigation("o", "r", 5, self.tmp)
+        assert stored is not None
+        self.assertEqual(stored["slot_key"], "tab-one")
+
+    def test_naming_the_stale_link_allows_a_deliberate_replacement(self):
+        # Resuming a session whose slot was deleted legitimately rewrites the link;
+        # the caller proves it is not racing by naming the value it saw.
+        store.write_investigation(
+            "o", "r", 5, {"slot_key": "dead-slot"}, root=self.tmp, expected_slot_key=None,
+        )
+        rec = store.write_investigation(
+            "o", "r", 5, {"slot_key": "fresh-slot"}, root=self.tmp,
+            expected_slot_key="dead-slot",
+        )
+        self.assertEqual(rec["slot_key"], "fresh-slot")
+
+    def test_a_cleared_link_compares_equal_to_an_absent_one(self):
+        store.write_investigation("o", "r", 5, {"slot_key": ""}, root=self.tmp)
+        rec = store.write_investigation(
+            "o", "r", 5, {"slot_key": "tab-one"}, root=self.tmp, expected_slot_key=None,
+        )
+        self.assertEqual(rec["slot_key"], "tab-one")
+
+    def test_omitting_the_claim_keeps_last_writer_wins(self):
+        # Every agent-side findings write omits it and must never fail on somebody
+        # else's session link.
+        store.write_investigation(
+            "o", "r", 5, {"slot_key": "tab-one"}, root=self.tmp, expected_slot_key=None,
+        )
+        rec = store.write_investigation(
+            "o", "r", 5, {"findings": {"verdict": "a dupe"}}, root=self.tmp,
+        )
+        self.assertEqual(rec["slot_key"], "tab-one")
+        self.assertEqual(rec["findings"]["verdict"], "a dupe")
+
+    def test_the_claim_is_scoped_to_the_verb_record(self):
+        store.write_investigation(
+            "o", "r", 5, {"slot_key": "review-slot"}, root=self.tmp, expected_slot_key=None,
+        )
+        # The respond record is a different file, so its first claim is unclaimed.
+        rec = store.write_investigation(
+            "o", "r", 5, {"slot_key": "respond-slot"}, root=self.tmp,
+            verb="respond", expected_slot_key=None,
+        )
+        self.assertEqual(rec["slot_key"], "respond-slot")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_issue_radar_routes_ai_coverage.py
+++ b/test/test_issue_radar_routes_ai_coverage.py
@@ -1545,6 +1545,36 @@ class TestItemKind(unittest.TestCase):
             self.assertIsNone(routes._item_kind(raw))
 
 
+class TestRecordVerb(unittest.TestCase):
+    """``None`` is a VALID verb (the item's primary record), so this returns an
+    ``(verb, error)`` pair rather than using None to mean invalid."""
+
+    def test_absent_and_empty_mean_the_primary_record(self):
+        for raw in (None, ""):
+            verb, error = routes._record_verb(raw)
+            self.assertIsNone(verb)
+            self.assertIsNone(error)
+
+    def test_the_known_verbs_pass_through(self):
+        for verb in store.RECORD_VERBS:
+            self.assertEqual(routes._record_verb(verb), (verb, None))
+
+    def test_an_unknown_verb_is_refused_not_folded(self):
+        # Folding a typo to the primary record would resume the wrong session,
+        # which is the defect the dimension exists to prevent.
+        for raw in ("Respond", "reviwe", 7, [], True):
+            verb, error = routes._record_verb(raw)
+            self.assertIsNone(verb)
+            assert error is not None
+            self.assertEqual(error.status, 400)
+
+    def test_the_refusal_names_the_allowed_verbs(self):
+        _, error = routes._record_verb("reviwe")
+        assert error is not None
+        for verb in store.RECORD_VERBS:
+            self.assertIn(verb, _body(error)["error"])
+
+
 class TestPutInvestigationRoute(unittest.IsolatedAsyncioTestCase):
     """Local triage state only — nothing is written to the provider. The number
     becomes part of the record's FILENAME, so the bound matters more here than on
@@ -1618,6 +1648,93 @@ class TestPutInvestigationRoute(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(write.call_args[0][3], {})
         self.assertEqual(response.status, 200)
 
+    async def test_an_unknown_verb_is_400(self):
+        with _connected(), mock.patch.object(store, "write_investigation") as write:
+            response = await routes._handle_put_investigation(
+                _json_request("PUT", "investigation", {**self.GOOD, "verb": "reviwe"})
+            )
+        self.assertEqual(response.status, 400)
+        write.assert_not_called()
+
+    async def test_a_known_verb_selects_that_verbs_record(self):
+        with _connected(), mock.patch.object(
+            store, "write_investigation", return_value={}
+        ) as write:
+            response = await routes._handle_put_investigation(
+                _json_request(
+                    "PUT", "investigation", {**self.GOOD, "verb": "respond", "slot_key": "s1"}
+                )
+            )
+        self.assertEqual(write.call_args.kwargs["verb"], "respond")
+        self.assertEqual(_body(response)["verb"], "respond")
+
+    async def test_omitting_the_verb_targets_the_primary_record(self):
+        # Every agent-side write goes through the MCP tool, which sends no verb.
+        # Findings therefore land on the item's primary record, not a verb record.
+        with _connected(), mock.patch.object(
+            store, "write_investigation", return_value={}
+        ) as write:
+            response = await routes._handle_put_investigation(
+                _json_request("PUT", "investigation", {**self.GOOD, "findings": "a dupe"})
+            )
+        self.assertIsNone(write.call_args.kwargs["verb"])
+        self.assertIsNone(_body(response)["verb"])
+
+
+class TestPutInvestigationSlotClaim(unittest.IsolatedAsyncioTestCase):
+    """A session-link write may claim the record, so two browser tabs cannot both
+    create a session and leave one of the agents unreferenced."""
+
+    GOOD = {"owner": "o", "repo": "r", "number": 7}
+
+    async def test_the_claim_is_threaded_to_the_store(self):
+        with _connected(), mock.patch.object(
+            store, "write_investigation", return_value={}
+        ) as write:
+            await routes._handle_put_investigation(
+                _json_request("PUT", "investigation", {
+                    **self.GOOD, "slot_key": "tab-one", "expected_slot_key": None,
+                })
+            )
+        self.assertIsNone(write.call_args.kwargs["expected_slot_key"])
+
+    async def test_omitting_the_claim_leaves_last_writer_wins(self):
+        # The MCP findings write must not start failing on someone else's session.
+        with _connected(), mock.patch.object(
+            store, "write_investigation", return_value={}
+        ) as write:
+            await routes._handle_put_investigation(
+                _json_request("PUT", "investigation", {**self.GOOD, "findings": "a dupe"})
+            )
+        self.assertIs(write.call_args.kwargs["expected_slot_key"], store._NO_CLAIM)
+
+    async def test_a_lost_race_is_409_carrying_the_winning_record(self):
+        winner = {"owner": "o", "repo": "r", "number": 7, "slot_key": "tab-one"}
+        with _connected(), mock.patch.object(
+            store, "write_investigation", side_effect=store.SlotClaimConflict(winner)
+        ):
+            response = await routes._handle_put_investigation(
+                _json_request("PUT", "investigation", {
+                    **self.GOOD, "slot_key": "tab-two", "expected_slot_key": None,
+                })
+            )
+        self.assertEqual(response.status, 409)
+        payload = _body(response)
+        self.assertEqual(payload["code"], "investigation_slot_conflict")
+        # Without the winner's link the loser cannot adopt that session and would
+        # start a second one, which is the whole defect.
+        self.assertEqual(payload["investigation"]["slot_key"], "tab-one")
+
+    async def test_a_non_string_claim_is_400_and_writes_nothing(self):
+        with _connected(), mock.patch.object(store, "write_investigation") as write:
+            response = await routes._handle_put_investigation(
+                _json_request("PUT", "investigation", {
+                    **self.GOOD, "expected_slot_key": 7,
+                })
+            )
+        self.assertEqual(response.status, 400)
+        write.assert_not_called()
+
 
 class TestGetInvestigationRoute(unittest.IsolatedAsyncioTestCase):
     async def test_missing_query_parameters_are_400(self):
@@ -1641,6 +1758,31 @@ class TestGetInvestigationRoute(unittest.IsolatedAsyncioTestCase):
         payload = _body(response)
         self.assertIsNone(payload["investigation"])
         self.assertEqual(payload["kind"], "issue")
+        self.assertIsNone(payload["verb"])
+
+    async def test_an_unknown_verb_is_400_and_reads_nothing(self):
+        with _connected(), mock.patch.object(store, "read_investigation") as read:
+            response = await routes._handle_get_investigation(
+                _get("investigation", {
+                    "owner": "o", "repo": "r", "number": "7", "verb": "reviwe",
+                })
+            )
+        self.assertEqual(response.status, 400)
+        read.assert_not_called()
+
+    async def test_a_known_verb_reads_that_verbs_record(self):
+        with _connected(), mock.patch.object(
+            store, "read_investigation", return_value={"slot_key": "respond-slot"}
+        ) as read:
+            response = await routes._handle_get_investigation(
+                _get("investigation", {
+                    "owner": "o", "repo": "r", "number": "7", "verb": "respond",
+                })
+            )
+        self.assertEqual(read.call_args.kwargs["verb"], "respond")
+        payload = _body(response)
+        self.assertEqual(payload["verb"], "respond")
+        self.assertEqual(payload["investigation"]["slot_key"], "respond-slot")
 
 
 # ── remaining guards on the list, tagging and bulk-apply routes ──────────────


### PR DESCRIPTION
## Problem

An investigation record holds exactly one `slot_key`, and `kind` is the only
thing that currently separates two records for one number. `kind` answers *which
number sequence* an item came from — it is why GitLab's `!5` does not resume issue
`#5` — so a second **job** on one change request has nowhere to go.

Reviewing a change request and answering the feedback it received are two jobs a
person runs concurrently on the same number. Today they would share one record,
and the second click would resume the first job's session and overwrite its link.

No live defect: on GitHub issues and pull requests share one number sequence, so
an item is either an issue or a change request and Investigate/Review cannot
collide. The collision appears the moment a second change-request-side verb
exists, which is what this unblocks.

**Stacked on #2942** (its base branch) — merge that one first.

## Fix

`verb` becomes a second dimension, orthogonal to `kind`. `kind` keeps meaning
"which sequence"; `verb` means "which job"; the two compose in the filename, so a
GitLab merge request being answered is `investigation-mr-respond-5.json`.

An omitted verb is the item's primary record and keeps the historical filename, so
**nothing on disk needs migrating** — the same argument the `mr` namespace relies
on, and `test_the_primary_record_keeps_the_historical_filename` pins it.

## The three properties worth reviewing

**Refuse, do not fold.** An unknown verb is a 400 at the route, and
`store.investigation_path` raises on one as a fail-closed backstop. Folding an
unrecognized verb to the primary record would silently produce the exact collision
this dimension exists to prevent — which is the failure mode
`provider.investigation_kind`'s unconditional `return "issue"` already carries, so
this dimension deliberately does not copy that shape. The store validates because
both values land in a filename with no further sanitization; the route validation
should not be the only gate.

**The write resolves the path three times** — lock, read-back, atomic write — and
all three carry the verb. The read-back is the subtle one: dropping it there loads
`existing` from the *primary* record and writes it into the *verb* record, leaking
one job's `findings` and `folder_id` into the other. That leak is invisible in any
field the patch overwrites, which is why
`test_a_verb_write_does_not_inherit_the_primary_records_fields` asserts on the
fields the patch omits.

**Findings stay on the primary record.** Every agent-side write arrives through the
`issue_radar_record_investigation` MCP tool, which sends no verb — so that whole
path is untouched, including its 8-character cap on `kind` (`validation.py`). A
verb record carries a session link and nothing else, and the browser is its only
writer. `test_omitting_the_verb_targets_the_primary_record` pins that.

## Why this lands before its caller

The allowlist has one member (`respond`) and no caller yet. That is the same shape
as #2942, which shipped its readiness gate "on its own, ahead of anything that runs
an agent" — the storage contract is reviewable in isolation, and the surface that
consumes it is a separate, user-facing diff with its own strings and screenshots.

## Tests

11 new store tests (`tests/test_investigation.py::TestRecordVerbNamespace`, plus a
cross-dimension case in `tests/test_gitlab.py`) and 7 new route tests
(`TestRecordVerb`, plus verb cases on both handlers).

Every one was revert-verified by mutating the source and confirming the test fails.
**The first pass caught only 5 of 7 mutations** — a lock path that drops the verb
and a read-back that drops the verb both survived, because the original assertions
patched `slot_key` explicitly and so masked the inherited value. The
inheritance and per-record-lock assertions exist because of that gap:

| Mutation | Caught by |
|---|---|
| `atomic_write` drops the verb | 3 store tests |
| lock path drops the verb | `test_the_write_lock_is_per_record` |
| read-back drops the verb | `test_a_verb_write_does_not_inherit_the_primary_records_fields` |
| filename ignores the verb | 8 tests across both files |
| unknown verb folded, not raised | `test_an_unknown_verb_is_refused_rather_than_folded` |
| route accepts an unknown verb | 4 route tests |
| PUT never passes the verb | `test_a_known_verb_selects_that_verbs_record` |

## Verification

- 323 pass across `tests/test_investigation.py`, `tests/test_gitlab.py`,
  `test_issue_radar_routes_ai_coverage.py`; 477 pass with
  `test_issue_radar_investigation_tool.py` and `test_issue_radar_routes_coverage.py`
  added. No existing assertion changed.
- `isort --check-only src/kiro_crew test` and `flake8 src/kiro_crew test` exit 0.
- `mypy src/kiro_crew/` — clean, 889 source files.
- `./scripts/docs-lint.sh` exits 0 (196 markdown files).

## Manual verification

N/A — the contract is a filename and a 400, both asserted directly, and no
user-visible surface changes in this diff.

## Screenshots

N/A — no user-visible UI change.

no issue closed: prerequisite slice for a change-request-side agent verb; the
user-facing request it serves is filed separately.
