### PR TITLE
test(website): stop happy-dom orphaned navigation failing the shard

### DIFF
--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -452,6 +452,25 @@ export default defineConfig({
           disableJavaScriptFileLoading: true,
           disableJavaScriptEvaluation: true,
           disableCSSFileLoading: true,
+          // Resolve a declined resource load as a silent success instead of
+          // rejecting with a NotSupportedError. happy-dom runs the load
+          // asynchronously on DOM insertion, so that rejection is orphaned —
+          // it escapes the test that inserted the node and vitest counts it as
+          // a run-level unhandled error, failing the whole shard even when every
+          // assertion passed. We assert the serialized DOM, never the sandboxed
+          // widget runtime, so a no-op success preserves the contract under test.
+          handleDisabledFileLoadingAsSuccess: true,
+          // Never follow a link or form navigation over the network. An
+          // un-intercepted `<a href>` click — e.g. an artifact anchor a test
+          // clicks with no onArtifactOpen handler — otherwise makes happy-dom
+          // dial the document origin for real; that fetch outlives the test and
+          // its ECONNREFUSED lands after msw teardown as another orphaned
+          // rejection. Disabling navigation still falls back to setting the URL
+          // (no dial), so tests that read location after a click keep working.
+          navigation: {
+            disableMainFrameNavigation: true,
+            disableChildFrameNavigation: true,
+          },
         },
       },
     },


### PR DESCRIPTION
no issue closed: CI test-harness flake fix, no tracked issue.

## Problem

A frontend **Unit tests (shard N/4)** job intermittently fails with `exit 1` and **no failing assertion**. Because the shards run `vitest --reporter=blob`, no human summary is printed — the log shows only happy-dom `NotSupportedError ... loading is disabled` DOMExceptions and an `AggregateError: connect ECONNREFUSED` to the document origin (`/artifacts/my-report`), then `blob report written` and `exit 1`. The failure is effectively invisible and lands on **unrelated PRs** (first observed on a PR whose only change is a single CI workflow file).

## Why it matters

vitest counts *any* run-level unhandled rejection as a run failure, so a shard goes red even though **every test passed**. Unrelated PRs are blocked, re-run, and burn scarce macOS/GitHub runner time — noise that erodes trust in the gate.

## Fix (symptom → root cause → change)

- **Symptom:** `exit 1`, zero assertion failures; the log carries `ECONNREFUSED` to `http://localhost:<port>/artifacts/my-report` through happy-dom's `Fetch`, plus `"loading is disabled"` script/iframe DOMExceptions.
- **The `"loading is disabled"` lines are noise, not the cause.** `HTMLScriptElement.#loadScript` and `HTMLIFrameElement` route the disabled-load case to `page.console.error(...)` (already suppressed by `onConsoleLog`), never a rejection.
- **Root cause:** happy-dom performs a **real main-frame navigation** when a test clicks an un-intercepted `<a href>` — e.g. `MarkdownRenderer.artifactLink`'s shift-click and no-`onArtifactOpen` cases click `/artifacts/my-report`. That navigation fetch is fire-and-forget; its rejection is orphaned and, when it resolves after msw's `afterAll` `server.close()`, dials the real origin → `ECONNREFUSED`. A run-level unhandled rejection fails the shard. It is timing-dependent, which is why it strikes across shards/runs and unrelated PRs.
- **Change:** two documented happy-dom settings in the vitest happy-dom environment (`website/vite.config.ts`):
  - `navigation.disableMainFrameNavigation` + `disableChildFrameNavigation` — `BrowserFrameValidator.validateFrameNavigation` then returns `false`, so happy-dom falls back to `setURL` (no dial). Location-reading tests still work; the orphaned navigation fetch is gone.
  - `handleDisabledFileLoadingAsSuccess` — a declined script load resolves as a `load` event instead of erroring, removing the console noise and any future reject risk.

  This is a root-cause config fix — no rerun, no `sleep`, no relaxed assertion.

## Tests

- `npx tsc -b` — green.
- The 4 implicated files (`widgetSrcdoc`, `MarkdownRenderer.artifactLink`, `MarkdownRenderer.linkUnfurl`, `ArtifactBody.iframeBlob`) — 42/42 green.
- Full `website` suite — green **except** a pre-existing, order-dependent `App.test.tsx` "Kiro credits pill" flake that fails **identically on clean `origin/main`** (flips 2↔3 failures with this change stashed) and passes **13/13 in isolation**. Unrelated to this change; out of scope.

## Manual verification

- Ran the exact CI shard 2/4 command on `main` 3× — all green, confirming the target failure is non-deterministic.
- Confirmed against happy-dom 20.11.1 source that `disableMainFrameNavigation` short-circuits before any fetch (`BrowserFrameValidator.js:54`) and that the script/iframe disabled paths only `console.error`.

