### PR TITLE
fix: keep the companion overlay out of screen captures

### DIFF
--- a/website/electron/crew-companion/petOverlay.js
+++ b/website/electron/crew-companion/petOverlay.js
@@ -79,6 +79,15 @@ function createOverlayFor(display) {
   win.setAcceptFirstMouse?.(true);
   // Refuse input by default; the renderer re-enables it over the sprite alone.
   win.setIgnoreMouseEvents(true, { forward: true });
+  // INVISIBLE TO SCREEN CAPTURE (macOS NSWindowSharingNone, Windows
+  // WDA_EXCLUDEFROMCAPTURE; no-op elsewhere). The overlay covers a whole display,
+  // so without this it is the topmost window at EVERY point on the screen: the
+  // macOS screenshot picker (Cmd+Shift+4 space / Cmd+Shift+5 window mode) offers
+  // the overlay instead of the app the user is pointing at, and a region capture
+  // or recording bakes the companion into the result. A decoration must not
+  // appear in the user's screenshots, screen recordings, or screen shares — the
+  // same reason computer use's cursor overlay sets NSWindowSharingNone.
+  win.setContentProtection(true);
   // Follow the user across spaces and over full-screen apps — a companion that
   // vanished when you switched desktops would not be company.
   win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });

--- a/website/electron/crew-companion/test/petHitbox.test.js
+++ b/website/electron/crew-companion/test/petHitbox.test.js
@@ -32,6 +32,7 @@ function stubElectron() {
     }
     setFocusable() {}
     setAcceptFirstMouse() {}
+    setContentProtection() {}
     setIgnoreMouseEvents(ignore, opts) { this.ignoreMouse = { ignore, opts }; }
     setVisibleOnAllWorkspaces() {}
     loadURL() {}

--- a/website/electron/crew-companion/test/petOverlay.test.js
+++ b/website/electron/crew-companion/test/petOverlay.test.js
@@ -31,6 +31,7 @@ function stubElectron() {
     }
     setFocusable(v) { this.focusable = v; }
     setAcceptFirstMouse() {}
+    setContentProtection(v) { this.contentProtection = v; }
     setIgnoreMouseEvents(ignore, opts) { this.ignoreMouse = { ignore, opts }; }
     setVisibleOnAllWorkspaces(v, opts) { this.workspaces = { v, opts }; }
     loadURL(u) { this.loadedUrl = u; }
@@ -150,6 +151,25 @@ test("the overlay is transparent, frameless, always on top and not focusable", (
     assert.strictEqual(win.opts.webPreferences.backgroundThrottling, false);
     // Follows the user across spaces and over full-screen apps.
     assert.deepStrictEqual(win.workspaces, { v: true, opts: { visibleOnFullScreen: true } });
+  } finally {
+    stub.restore();
+  }
+});
+
+test("the overlay is excluded from screen capture", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow();
+
+    // A display-sized window is the topmost window at every point on the screen.
+    // Without content protection the macOS screenshot window picker offers the
+    // overlay instead of the app under the cursor, and every region capture or
+    // recording has the companion baked into it.
+    for (const win of stub.created) {
+      assert.strictEqual(win.contentProtection, true);
+    }
   } finally {
     stub.restore();
   }

--- a/website/electron/mochi/petOverlays.js
+++ b/website/electron/mochi/petOverlays.js
@@ -577,6 +577,13 @@ function createOverlayForDisplay(display) {
   win.setAcceptFirstMouse?.(true);
   win.setIgnoreMouseEvents(true, { forward: true });
   win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  // INVISIBLE TO SCREEN CAPTURE (macOS NSWindowSharingNone, Windows
+  // WDA_EXCLUDEFROMCAPTURE; no-op elsewhere). This window covers a whole display,
+  // so without this it is the topmost window at EVERY point: the macOS screenshot
+  // picker (Cmd+Shift+4 space / Cmd+Shift+5 window mode) offers the overlay
+  // instead of the app the user is pointing at, and a region capture bakes the pet
+  // into the image. Doubly necessary here because of the screen-saver level below.
+  win.setContentProtection(true);
   // "screen-saver" — above ordinary always-on-top windows, so the pet is not
   // buried by other floating panels.
   win.setAlwaysOnTop(true, "screen-saver");


### PR DESCRIPTION
## What breaks today

The crew companion opens one transparent, always-on-top window **per display,
each covering that display's full bounds** (`petOverlay.js` — full-bounds so the
sprite can wander without the main process repositioning a small window every
frame). The consequence is that the overlay is the topmost window at *every*
point on the screen:

- macOS's screenshot picker — `Cmd+Shift+4` then space, or `Cmd+Shift+5` in
  "capture/record selected window" mode — highlights and selects the **overlay**
  instead of the app the user is pointing at.
- A region capture or screen recording bakes the companion sprite into the
  result.

Same defect in the older Mochi pet overlay (`mochi/petOverlays.js`), which is
worse there because that window also sits at the `screen-saver` level.

## The fix

Both overlay creators now call `win.setContentProtection(true)`:
`NSWindowSharingNone` on macOS, `WDA_EXCLUDEFROMCAPTURE` on Windows, a no-op
elsewhere. The window still renders on the desktop and stays click-through; the
capture subsystem simply does not see it.

This is not a new mechanism in this repo — computer use's cursor overlay already
sets `setSharingType: 0` for exactly the same reason (A/B verified in
`docs/system-specs/modules/computer-use.md`): a decoration must not appear in the
pixels someone later reads.

**Intended side effect:** the companion no longer appears in screen recordings or
screen shares either. For a full-screen decorative overlay that is the right
default.

## Tests

`website/electron/crew-companion/test/petOverlay.test.js` gains a case asserting
content protection is on for every overlay, with the reason in the test body so a
future edit cannot quietly drop it. The two companion window fakes learn the
method.

```
cd website/electron && npm test
ℹ tests 866   ℹ pass 866   ℹ fail 0
```

Brand gate clean. No docs change: no spec documents the overlay's window flags —
the rationale lives in the code comment next to the call.

## Verification note

This was built on a headless Linux dev host, so the macOS half — screenshot
picker no longer offering the overlay, sprite absent from `screencapture` output
— needs a check on a Mac build. The in-repo A/B evidence for the same AppKit
property is in the computer-use spec.
