### PR TITLE
ci: add PR-body marker waiver to Screenshot Evidence for fork PRs (#3115)

### DIFF
--- a/.github/workflows/screenshot-evidence.yml
+++ b/.github/workflows/screenshot-evidence.yml
@@ -13,6 +13,12 @@ name: Screenshot Evidence
 # locale catalogues, and type-only declarations change constantly without any
 # visual delta; gating on those would train contributors to paste a meaningless
 # screenshot to get green, which is worse than no gate.
+#
+# Two waiver paths exist for a genuinely non-visual change to a watched file:
+# the `no-screenshots` label (maintainers), and the `<!-- no-visual-delta -->`
+# PR-body marker plus a `**Why no screenshot:** <reason>` justification line
+# (self-service for fork contributors, who cannot add labels). Both warn
+# instead of passing silently.
 
 on:
   pull_request:
@@ -91,10 +97,44 @@ jobs:
 
           # Accept any form that actually renders as an image/video for a
           # reviewer: markdown image, HTML img/video, a committed
-          # temp-screenshots path, or a GitHub user-attachment URL.
+          # temp-screenshots path, or a GitHub user-attachment URL. Real
+          # evidence satisfies the gate outright, so it is checked before any
+          # waiver: a body carrying both a screenshot and the marker passes on
+          # the screenshot.
           if printf '%s' "$body" | grep -qiE '!\[[^]]*\]\([^)]+\)|<img[[:space:]]|<video[[:space:]]|temp-screenshots/|user-attachments/'; then
             echo "Visual evidence found in the PR description."
             exit 0
+          fi
+
+          # Fork-friendly escape hatch: fork contributors cannot add labels, so
+          # the PR body itself may declare a non-visual change with a marker
+          # comment. The marker is honored only together with a justification
+          # line, so the waiver is a reviewable claim rather than a silent
+          # bypass, and it fires a warning annotation so the run log shows that
+          # evidence was waived. The marker itself is matched with grep -F so
+          # body text is never read as a pattern; in both matches below the
+          # untrusted body only ever reaches grep as stdin data, never as a
+          # pattern or part of a command.
+          if printf '%s' "$body" | grep -qF -- '<!-- no-visual-delta -->'; then
+            # The justification needs visible content after the colon: literal
+            # asterisks are skipped so a bare bold "**Why no screenshot:**"
+            # does not count, while a reason opening with emphasis does.
+            if printf '%s' "$body" | grep -qiE 'why no screenshots?:(\*\*)?[[:space:]]*\**[^*[:space:]]'; then
+              echo "::warning::'<!-- no-visual-delta -->' marker present in the PR body -- visual-evidence requirement waived. The author's justification is in the PR description."
+              exit 0
+            fi
+            echo "::error::The PR body carries the '<!-- no-visual-delta -->' marker without a justification line."
+            {
+              echo "### Marker present, justification missing"
+              echo
+              echo "The \`<!-- no-visual-delta -->\` marker waives the screenshot requirement"
+              echo "only when the description also explains **why** nothing rendered changes."
+              echo "Add a line in this exact shape to the PR description (the \`edited\`"
+              echo "trigger re-runs this check on save, no push needed):"
+              echo
+              echo '    **Why no screenshot:** <one sentence naming why there is no visual delta>'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
           fi
 
           echo "::error::This PR changes a user-visible frontend surface but its description carries no screenshot or recording."
@@ -119,5 +159,8 @@ jobs:
             echo
             echo "**If the change genuinely has no visual delta** (pure rename, comment-only,"
             echo "or a non-rendering attribute), add the \`no-screenshots\` label and re-run."
+            echo "Fork contributors cannot add labels: instead edit the PR description to add"
+            echo "the \`<!-- no-visual-delta -->\` marker together with a justification line"
+            echo "\`**Why no screenshot:** <reason>\` -- the check re-runs on the edit."
           } >> "$GITHUB_STEP_SUMMARY"
           exit 1

--- a/test/test_pr_quality_gates.py
+++ b/test/test_pr_quality_gates.py
@@ -8,9 +8,13 @@ most importantly -- that `pr-readiness.yml` no longer force-passes a failing
 Design Review.
 """
 
+import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
 
@@ -53,6 +57,141 @@ class TestScreenshotEvidence:
         wf = _read("screenshot-evidence.yml")
         assert 'body="$(gh api' in wf
         assert "eval" not in wf
+
+    def test_has_fork_friendly_body_marker(self):
+        # Fork contributors cannot add labels, so the body marker must exist
+        # as a self-service waiver alongside the label.
+        wf = _read("screenshot-evidence.yml")
+        assert "<!-- no-visual-delta -->" in wf
+        # The marker is attacker-controlled text: fixed-string match only.
+        assert "grep -qF -- '<!-- no-visual-delta -->'" in wf
+
+    def test_marker_requires_justification(self):
+        # A bare marker is a silent bypass; the waiver must carry a reviewable
+        # claim and fail loudly without one.
+        wf = _read("screenshot-evidence.yml")
+        assert "why no screenshots?" in wf.lower()
+        assert "marker without a justification" in wf
+
+    def test_marker_waiver_warns_instead_of_passing_silently(self):
+        # A reviewer scanning the run log must see that evidence was waived.
+        wf = _read("screenshot-evidence.yml")
+        assert (
+            "::warning::'<!-- no-visual-delta -->' marker present" in wf
+        ), "waiver must emit a warning annotation naming the marker"
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or shutil.which("bash") is None,
+    reason="the evidence step runs under bash on ubuntu-latest",
+)
+class TestScreenshotEvidenceBodyLogic:
+    """Execute the real evidence step against fixture PR bodies.
+
+    Textual pins cannot prove the branch logic; this extracts the actual
+    ``run:`` script from the YAML and runs it with ``gh`` stubbed to return a
+    fixture body, so the waiver semantics are locked by behavior.
+    """
+
+    def _run_step(self, tmp_path: Path, body: str, exempt: str = "false"):
+        wf = yaml.safe_load(_read("screenshot-evidence.yml"))
+        steps = wf["jobs"]["screenshot-evidence"]["steps"]
+        step = next(
+            (s for s in steps if s.get("name") == "Require visual evidence in the PR body"),
+            None,
+        )
+        assert step is not None, "step 'Require visual evidence in the PR body' not found"
+        body_file = tmp_path / "body.txt"
+        body_file.write_text(body, encoding="utf-8")
+        # `gh api ... --jq '.body // ""'` prints the raw body: stub it with cat.
+        # The sentinel proves the stub (not a real gh on PATH) served the call.
+        sentinel = tmp_path / "gh-stub-invoked"
+        gh = tmp_path / "gh"
+        gh.write_text(
+            f'#!/bin/sh\ntouch "{sentinel}"\ncat "{body_file}"\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        gh.chmod(0o755)
+        summary = tmp_path / "summary.md"
+        summary.touch()
+        env = {
+            **os.environ,
+            "PATH": f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}",
+            # Starve any real gh of credentials so a stub-resolution failure
+            # can never turn into a live API call.
+            "GH_TOKEN": "",
+            "GITHUB_TOKEN": "",
+            "EXEMPT": exempt,
+            "REPO": "example/repo",
+            "PR": "1",
+            "GITHUB_STEP_SUMMARY": str(summary),
+        }
+        result = subprocess.run(
+            ["bash", "-c", step["run"]],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if exempt != "true":
+            # The label path exits before reading the body; every other path
+            # must have gone through the stub.
+            assert sentinel.exists(), "gh stub was never invoked"
+        return result
+
+    def test_marker_with_justification_passes_with_warning(self, tmp_path):
+        body = (
+            "<!-- no-visual-delta -->\n"
+            "**Why no screenshot:** internal string builder change, rendered\n"
+            "output is byte-identical.\n"
+        )
+        result = self._run_step(tmp_path, body)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" in result.stdout
+        assert "<!-- no-visual-delta -->" in result.stdout
+
+    def test_marker_alone_fails_with_explanation(self, tmp_path):
+        result = self._run_step(tmp_path, "<!-- no-visual-delta -->\njust trust me\n")
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "marker without a justification" in result.stdout
+
+    def test_empty_justification_does_not_waive(self, tmp_path):
+        # A justification label with nothing after the colon is still a bare
+        # marker: the claim must carry content.
+        body = "<!-- no-visual-delta -->\n**Why no screenshot:**\n"
+        result = self._run_step(tmp_path, body)
+        assert result.returncode == 1, result.stdout + result.stderr
+
+    def test_emphasis_opening_justification_waives(self, tmp_path):
+        # A reason that opens with markdown emphasis is still a reason.
+        body = "<!-- no-visual-delta -->\n**Why no screenshot:** *pure rename*, no delta.\n"
+        result = self._run_step(tmp_path, body)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" in result.stdout
+
+    def test_image_beats_marker(self, tmp_path):
+        # Real evidence satisfies the gate outright: a body carrying both a
+        # screenshot and an unjustified marker passes on the screenshot.
+        body = "<!-- no-visual-delta -->\n![shot](https://example.test/x.png)\n"
+        result = self._run_step(tmp_path, body)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Visual evidence found" in result.stdout
+
+    def test_no_marker_no_image_still_fails(self, tmp_path):
+        result = self._run_step(tmp_path, "A visual change with no evidence.\n")
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "::error::" in result.stdout
+
+    def test_image_in_body_still_passes(self, tmp_path):
+        result = self._run_step(tmp_path, "![shot](https://example.test/x.png)\n")
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_label_waiver_unchanged(self, tmp_path):
+        # The marker is an additional path; the label path must keep working.
+        result = self._run_step(tmp_path, "no evidence at all", exempt="true")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "'no-screenshots' label present" in result.stdout
 
 
 class TestCrossPlatform:


### PR DESCRIPTION
## What broke

The `Screenshot Evidence` check gates any diff touching watched frontend paths, and its only waiver is the `no-screenshots` label. Fork contributors cannot add labels, so an outside contributor whose change is genuinely non-visual (e.g. #3087's `srcdoc` string builder) can only wait for a maintainer.

## What changed

`.github/workflows/screenshot-evidence.yml`:
- New self-service waiver: the `<!-- no-visual-delta -->` marker in the PR body, honored only together with a justification line (`**Why no screenshot:** <reason>`). A bare marker fails with a step-summary explanation showing the exact required line.
- The waiver is auditable, not silent: it emits a `::warning::` annotation naming the marker when it fires. The label waiver is unchanged.
- The image-evidence check now runs before the marker block, so a body carrying real evidence passes on the evidence regardless of marker state.
- Safety unchanged: the marker is fixed-string matched (`grep -qF`); the untrusted body only ever reaches `grep` as stdin data, never as a pattern or part of a command; no API writes, so the check works on fork PRs with the read-only token.
- The failure guidance and the header comment document the new path (the label waiver was documented nowhere else).

`test/test_pr_quality_gates.py`: 4 new textual pins plus a functional class that extracts the actual `run:` script from the YAML and executes it under bash with a stubbed `gh` (sentinel-verified, credentials starved), covering: marker+justification passes with warning, marker alone fails with the explanation, empty justification fails, emphasis-opening justification passes, image beats marker, no-marker-no-image still fails, label waiver unchanged. Skipped on Windows per the existing `test_stable_release_gate.py` convention (the step runs under bash on ubuntu-latest).

## How the three required paths were exercised

Each is a subprocess test executing the real workflow step: `test_marker_with_justification_passes_with_warning` (exit 0 + warning annotation), `test_marker_alone_fails_with_explanation` (exit 1 + "marker without a justification"), `test_no_marker_no_image_still_fails` (exit 1, pre-existing behavior).

## What was verified

- `test/test_pr_quality_gates.py`: 30/30 green
- isort/flake8 clean on changed files; workflow YAML parses; brand gate green
- Full backend suite: 47904 passed; the 81 failures reproduce identically on the unmodified tree (sandbox/git environment, unrelated modules)
- Pre-push review: GPT 5.6 Sol PASS; Opus 5 raised 1 blocking (Windows-lane test guard) + 4 advisory findings, all five fixed and re-verified

## Known limits

The justification content is self-attested, same trust model as the label waiver; the `::warning::` keeps it visible to reviewers. A reason consisting solely of asterisks is rejected as empty.

<!-- no-visual-delta -->
**Why no screenshot:** CI workflow + backend test change only; no rendered surface is touched.

Closes #3115
