### PR TITLE
fix(installer): bound the interpreter probe so a wedged shim cannot hang the install

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -128,9 +128,24 @@ command -v openssl >/dev/null 2>&1 || err "openssl is required to verify the sig
 # fine on 3.9 and then crash on first run. Prefer the newest interpreter the
 # project builds and tests on (3.12 is the CI target); 3.13 is untested and
 # only a last resort before bare python3, which itself only counts if >=3.10.
+# A version-manager shim (mise, pyenv, asdf) can wedge instead of answering --
+# notably when HOME does not hold the config the shim expects -- and an
+# unbounded probe then hangs the whole install on its FIRST candidate,
+# python3.12, leaving a spinning orphan behind. Bound it so a wedged candidate
+# fails over to the next one. A healthy interpreter answers in well under a
+# tenth of a second, so 5s is generous and caps the whole ladder at ~25s.
+# `timeout` is absent from a stock macOS, so its absence must leave the probe
+# working rather than fail every candidate.
+_PY_PROBE_TIMEOUT=""
+if command -v timeout >/dev/null 2>&1; then
+  _PY_PROBE_TIMEOUT="timeout 5"
+fi
+
 _py_usable() {
   command -v "$1" >/dev/null 2>&1 || return 1
-  "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null
+  # Unquoted on purpose: expands to two words, or to nothing when unavailable.
+  # shellcheck disable=SC2086
+  $_PY_PROBE_TIMEOUT "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null
 }
 
 # Resolve the newest supported interpreter into PY (left empty if none found).

--- a/test/installer_test_helpers.py
+++ b/test/installer_test_helpers.py
@@ -1,0 +1,55 @@
+"""Process-group-safe subprocess helper for the installer test suites.
+
+The installer tests run the real ``cli.sh``, which probes interpreters and
+package managers as grandchildren. ``subprocess.run(timeout=...)`` kills only
+the process it spawned, and pytest-timeout's signal only unwinds the Python
+frame, so a wedged grandchild survives either one: it is reparented to init and
+keeps burning a core until someone kills it by hand. Running the child as a
+session leader makes the whole tree killable as one process group.
+
+Callers are POSIX-only (``cli.sh`` is POSIX shell) and skip on Windows before
+reaching this module, which is what makes the ``killpg`` below safe.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+
+#: A hermetic installer run (fake curl, fake package managers) finishes in
+#: seconds, so this bound only ever trips on a wedge. It sits well under
+#: pytest-timeout's ceiling so that this helper, rather than pytest-timeout, is
+#: what reaps the tree.
+INSTALLER_TIMEOUT = 60.0
+
+
+def run_bounded(
+    argv: list[str],
+    env: dict[str, str],
+    timeout: float = INSTALLER_TIMEOUT,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``argv`` in its own process group; on timeout kill the whole group.
+
+    ``start_new_session`` makes the child a session leader, so its pid is also
+    its process-group id and one ``killpg`` reaps every descendant. Re-raises
+    ``subprocess.TimeoutExpired`` once the group is gone.
+    """
+    with subprocess.Popen(
+        argv,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        start_new_session=True,
+    ) as proc:
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass  # Exited between the timeout and the kill; nothing to reap.
+            proc.communicate()
+            raise
+    return subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)

--- a/test/test_cli_manifest_signature.py
+++ b/test/test_cli_manifest_signature.py
@@ -12,11 +12,13 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 import yaml
+from installer_test_helpers import run_bounded
 
 ROOT = Path(__file__).resolve().parents[1]
 HELPER = ROOT / "packaging" / "signing" / "cli-manifest.py"
@@ -322,6 +324,21 @@ esac
     )
     curl.chmod(0o755)
     pipx.chmod(0o755)
+
+    # cli.sh resolves an interpreter off PATH, and a bare host PATH hands it
+    # whatever version-manager shim is installed. Those shims resolve their tool
+    # installs under HOME, which this harness repoints at an empty temp dir, so
+    # a shim wedges instead of answering and the probe ladder stalls. Shadow
+    # EVERY candidate in cli.sh's ladder, not just the running version: the
+    # ladder tries python3.12 first, so on a 3.10 or 3.11 host that entry still
+    # reaches a host shim -- and a stock macOS has no `timeout` to bound it. The
+    # names are aliases rather than version claims; the probe only asserts
+    # >=3.10, which the interpreter running these tests satisfies. It must stay
+    # a REAL interpreter: cli.sh uses $PY for the signature and digest
+    # verification under test, so a stub would make those assertions vacuous.
+    for _name in ("python3.13", "python3.12", "python3.11", "python3.10", "python3"):
+        (tools / _name).symlink_to(sys.executable)
+
     return tools, curl_marker, install_marker
 
 
@@ -358,15 +375,68 @@ def _run_installer(
             "FAKE_INSTALL_MARKER": str(install_marker),
         }
     )
-    result = subprocess.run(
-        ["sh", str(script), "--cdn", CDN_BASE, *args],
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env,
-    )
+    result = run_bounded(["sh", str(script), "--cdn", CDN_BASE, *args], env)
     return result, curl_marker, install_marker
+
+
+def test_the_harness_shadows_every_interpreter_the_installer_probes(
+    tmp_path: Path,
+) -> None:
+    """No ladder entry may fall through to a host interpreter.
+
+    Shadowing only the running python3.X leaves cli.sh's first candidate
+    (python3.12) resolving to whatever the host has, which on a version-manager
+    host is a shim that wedges -- and a stock macOS has no ``timeout`` to bound
+    the probe. Read the ladder out of cli.sh so it cannot drift from this.
+    """
+    if os.name == "nt":
+        # The shadowing is symlink-based and Windows gates symlink creation on
+        # privilege, so this asserts a POSIX-only property. Every other caller
+        # of _write_fake_tools already skips Windows before reaching it.
+        pytest.skip("cli.sh and its PATH shadowing are POSIX-only")
+    tools, _curl_marker, _install_marker = _write_fake_tools(tmp_path / "run")
+
+    ladder = re.search(r"for _c in ([^;]+); do", INSTALLER.read_text())
+    assert ladder, "cli.sh no longer has a recognizable interpreter ladder"
+
+    candidates = [c for c in ladder.group(1).split() if c.startswith("python")]
+    assert candidates, "no interpreter candidates parsed out of cli.sh's ladder"
+
+    unshadowed = [c for c in candidates if not (tools / c).exists()]
+    assert not unshadowed, f"host interpreters reachable from the harness: {unshadowed}"
+
+
+def test_a_wedged_grandchild_does_not_outlive_the_bounded_run(tmp_path: Path) -> None:
+    """The timeout path must reap the whole tree, not just the shell it spawned.
+
+    Without the process-group kill a wedged grandchild is reparented to init and
+    keeps burning a core until someone notices by hand.
+    """
+    if os.name == "nt":
+        pytest.skip("process groups are POSIX-only")
+    pidfile = tmp_path / "grandchild.pid"
+    script = tmp_path / "spawn.sh"
+    script.write_text(
+        """#!/bin/sh
+# Detach a grandchild that outlives its parent shell, which is how a wedged
+# interpreter shim under `sh` behaves.
+sh -c 'echo $$ > "$1"; exec sleep 300' _ "$1" &
+wait
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        run_bounded(["sh", str(script), str(pidfile)], os.environ.copy(), 5.0)
+    pid = int(pidfile.read_text(encoding="utf-8").strip())
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.05)
+    pytest.fail(f"grandchild {pid} survived the bounded run")
 
 
 @pytest.mark.parametrize("pinned", [False, True])

--- a/test/test_installer_distro.py
+++ b/test/test_installer_distro.py
@@ -22,6 +22,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from installer_test_helpers import run_bounded
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CLI_SH = REPO_ROOT / "cli.sh"
@@ -46,6 +47,7 @@ def _run_cli_with_fake_env(
     tmp_path: Path,
     *,
     managers: list[str],
+    interpreters: dict[str, str] | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
     """Run cli.sh with a PATH that has NO python3 and only the named package
     managers (each a stub that records its name and args). Returns the process
@@ -54,6 +56,10 @@ def _run_cli_with_fake_env(
     The stubs deliberately do NOT install a working python, so cli.sh proceeds
     through every branch and then errs at the final "Python >=3.10 is required"
     guard — by which point the marker proves which manager it tried.
+
+    ``interpreters`` replaces the default too-old stub for the named
+    interpreters, which is how a scenario expresses a usable or a wedged
+    candidate.
     """
     tools = tmp_path / "tools"
     tools.mkdir()
@@ -73,7 +79,11 @@ def _run_cli_with_fake_env(
 
     for _util in ("sh", "env", "id", "awk", "sed", "mktemp", "rm", "rmdir",
                   "mkdir", "cat", "printf", "chmod", "ln", "date", "grep",
-                  "tr", "head", "cut", "dirname", "basename", "uname", "sleep"):
+                  "tr", "head", "cut", "dirname", "basename", "uname", "sleep",
+                  # cli.sh bounds its interpreter probe with `timeout` when one
+                  # exists, so the isolated PATH must expose it for that guard
+                  # to be exercised here at all.
+                  "timeout"):
         _link_real(_util)
 
     # A manager "under test" is an EXECUTABLE stub that records its args. The
@@ -118,12 +128,16 @@ def _run_cli_with_fake_env(
     for name in ("python3.13", "python3.12", "python3.11", "python3.10", "python3", "python"):
         stub = tools / name
         stub.write_text(
-            "#!/bin/sh\n"
-            'case "$*" in\n'
-            "  *version_info*) exit 1 ;;\n"  # cli.sh's >=3.10 gate -> too old
-            "  *--version*) echo 'Python 3.6.8' ;;\n"
-            "  *) exit 1 ;;\n"
-            "esac\n"
+            interpreters.get(name)
+            if interpreters and name in interpreters
+            else (
+                "#!/bin/sh\n"
+                'case "$*" in\n'
+                "  *version_info*) exit 1 ;;\n"  # cli.sh's >=3.10 gate -> too old
+                "  *--version*) echo 'Python 3.6.8' ;;\n"
+                "  *) exit 1 ;;\n"
+                "esac\n"
+            )
         )
         stub.chmod(0o755)
 
@@ -142,15 +156,35 @@ def _run_cli_with_fake_env(
         "HOME": str(tmp_path / "home"),
         "KIROCREW_HOME": str(tmp_path / "data-home"),
     }
-    result = subprocess.run(
-        [str(tools / "sh"), str(CLI_SH)],
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env,
-    )
+    result = run_bounded([str(tools / "sh"), str(CLI_SH)], env)
     return result, markers
+
+
+def test_cli_fails_over_from_a_wedged_interpreter_candidate(tmp_path: Path) -> None:
+    """A version-manager shim that never answers must not wedge the install.
+
+    python3.12 is probed FIRST, so a shim that hangs there used to hold
+    _resolve_python forever and leak a spinning orphan per invocation. The probe
+    is bounded, so resolution has to reach the usable python3 below it.
+    """
+    result, _markers = _run_cli_with_fake_env(
+        tmp_path,
+        managers=["apt-get"],
+        interpreters={
+            "python3.12": "#!/bin/sh\nexec sleep 300\n",
+            "python3": (
+                "#!/bin/sh\n"
+                'case "$*" in\n'
+                "  *version_info*) exit 0 ;;\n"  # a supported interpreter
+                "  *--version*) echo 'Python 3.12.0' ;;\n"
+                "  *) exit 0 ;;\n"
+                "esac\n"
+            ),
+        },
+    )
+
+    combined = result.stdout + result.stderr
+    assert "Python >=3.10 is required" not in combined, combined
 
 
 def test_cli_uses_apt_on_debian_ubuntu(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

A full backend test run on a machine that manages Python with **mise** (or pyenv/asdf) leaks
eight CPU-burning orphan processes, one per installer test, and each survives the test run
indefinitely:

```
python3.12 -c "import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)"
```

Each spins at ~114% CPU forever. On the host where this was found, eight of them had
accumulated ~8.5 CPU-hours between them and driven load average to **34.5 / 55.8 / 174.9**
with memory fine — pure CPU starvation. The eight installer tests in
`test_cli_manifest_signature.py` also failed on that host, each pinned at the 120s
pytest-timeout ceiling, making the file take 490s.

## Why it matters

Nothing reaps these orphans, so every suite run makes the machine permanently worse until
someone finds and kills them by hand. On an unattended runner that repeatedly runs the suite,
load climbs monotonically until co-tenant processes are starved of CPU. The same probe hang
also affects **real users**: an unbounded probe on the first candidate means
`curl … cli.sh | sh` can hang forever instead of falling through to the next interpreter.

## Fix (symptoms → root cause → change)

The orphan's command line appears in exactly one place: the `_py_usable` probe in `cli.sh`,
called from `_resolve_python`. Three things compound:

1. **`cli.sh` never bounds the probe.** `python3.12` is tried *first*, resolves to the
   version-manager shim, and a shim that fails to answer wedges `_resolve_python` forever.
2. **The shims wedge only under the test harness.** They resolve their tool installs under
   `$HOME`, and `_run_installer` repoints `HOME` at an empty temp dir — so a shim that answers
   in 40ms by hand never answers here. (Verified with `sh -x`: the ladder stalls on the first
   present shim.)
3. **The harness cannot clean up after itself.** `subprocess.run` was called with no timeout, so
   only pytest-timeout fired, and its signal unwinds the *Python frame* — leaving `sh` and its
   interpreter grandchild running, reparented to init.

Three changes, matching those three causes:

- **`cli.sh`** — bound the probe with `timeout 5` so a wedged candidate fails over to the next
  one instead of hanging the install. Guarded on `command -v timeout`, because a stock macOS has
  no `timeout` and an unguarded `timeout` there would fail *every* candidate and break the
  installer outright. A healthy interpreter answers in well under 100ms, so 5s is ~50× headroom
  and caps the whole ladder at ~25s.
- **`test/installer_test_helpers.py`** (new) — `run_bounded()` runs the child via
  `start_new_session=True`, which makes its pid its process-group id, and on timeout kills the
  whole **group**. This is what actually prevents the leak: a plain `proc.kill()` reaps only the
  direct child.
- **`test/test_cli_manifest_signature.py`** — make the harness hermetic by shadowing **every
  candidate in `cli.sh`'s ladder** (`python3.12 python3.11 python3.10 python3.13 python3`) with
  the interpreter already running the tests, so no candidate falls through to a host shim.
  Shadowing only the running `python3.X` is not enough: the ladder probes `python3.12` first, so
  on a 3.10 or 3.11 host that entry still reaches the host — and with no `timeout` on macOS it
  can wedge. Note `$PY` performs the real signature and digest verification these tests assert
  on (`cli.sh` lines 234/266/330), so this has to stay a **real** Python — a stub would make the
  assertions vacuous.

The last change is what makes the eight tests pass: **490s with 8 failures → 16s all green**,
and they now run in ~0.35s each instead of timing out.

## Tests

- `test_cli_fails_over_from_a_wedged_interpreter_candidate` — a `python3.12` stub that never
  returns must not wedge resolution; `cli.sh` has to reach the usable `python3` below it.
  Locks the `cli.sh` change.
- `test_a_wedged_grandchild_does_not_outlive_the_bounded_run` — spawns a detached grandchild
  that outlives its parent shell, then asserts the timeout path leaves nothing alive.
  Locks the process-group kill.
- `test_the_harness_shadows_every_interpreter_the_installer_probes` — parses the ladder **out of
  `cli.sh`** and asserts no candidate is left unshadowed, so adding a `python3.14` to the
  installer fails the test rather than silently reopening the hole.
- The distro harness gained an `interpreters` override (default behaviour unchanged) so a
  scenario can express a wedged or usable candidate, and `timeout` is now on its isolated PATH
  so the new guard is exercised there at all.

Both new tests are **mutation-proven**:

| Mutation | Result |
|---|---|
| `_PY_PROBE_TIMEOUT=""` (drop the bound) | failover test hangs past 120s (passes in 5.03s intact) |
| `os.killpg(...)` → `proc.kill()` | grandchild test fails at 60s — the orphan holds the stdout pipe open, so `communicate()` never sees EOF |
| shadow only `python3` + the running `python3.X` | drift test fails: `host interpreters reachable from the harness: ['python3.11', 'python3.10', 'python3.13']` |

## Known gap, deferred

On a stock macOS there is no `timeout`, so the `command -v timeout` guard leaves the probe
unbounded there and the `curl … | sh` hang remains reachable. Filed as #3136 rather than fixed
here: the mitigation is a pure-POSIX watchdog (background probe raced against `sleep`, kill the
loser), which adds a background job, a PID, and a kill that must not leak its own orphan — the
exact failure class this PR removes — inside a script that verifies release signatures. No macOS
reproduction has been observed; the incident was on Linux, and the Linux path is now bounded.

## Manual verification

- `sh -x` trace of the staged installer confirmed the stall location before the fix and the
  fail-over after it.
- Confirmed zero `version_info` processes remain after a full run of the installer suites
  (enumerated across `/proc` by signature, not by a CPU-sorted list).
- Suites run: `test_cli_manifest_signature.py`, `test_installer_distro.py`,
  `test_publish_feed_contract.py` — **58 passed** (the last two also assert on `cli.sh`'s source
  shape, which the added lines leave intact). `isort` and `flake8` clean on `test/`.
- `mypy src/kiro_crew/` is unaffected: no change under `src/`.
- Not verified on macOS. There the `command -v timeout` guard leaves the probe byte-for-byte as
  it is today, so the change is inert rather than untested-and-active.

## Screenshots

N/A — no user-visible UI change.
