### PR TITLE
test: raise frontend coverage 86.17% -> 88.29% (+1,470 statements)

### DIFF
--- a/website/src/test/AppsPageW3Coverage.test.tsx
+++ b/website/src/test/AppsPageW3Coverage.test.tsx
@@ -1,0 +1,712 @@
+/**
+ * AppsPage — action paths, uninstall dialog, and failure branches.
+ *
+ * `AppsPageDiscover.test.tsx` covers the editorial/browse rendering surface.
+ * This file covers what it does not touch: the navigation helpers (Cmd-click,
+ * `autoAction` router state), the enable path including the trust-denied
+ * consent hand-off, the Library disable toast, Update All's failure report,
+ * the whole uninstall confirmation dialog (every provenance notice, the
+ * dependency preview, keep-data / keep-dependency wiring), the query-error
+ * card, the empty states, and `pickFeatured`'s trust filter.
+ *
+ * Timers are faked (`shouldAdvanceTime`) because the disable and Update All
+ * success paths arm a 4s toast dismissal — a real timer would fire after
+ * teardown and make vitest exit non-zero with every test passing, which
+ * suppresses the coverage report entirely.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+
+// --- Mocks -----------------------------------------------------------------
+const listApps = vi.fn()
+const listRegistry = vi.fn()
+const listRegistries = vi.fn()
+const enableApp = vi.fn()
+const disableApp = vi.fn()
+const updateApp = vi.fn()
+const uninstallApp = vi.fn()
+const uninstallPreview = vi.fn()
+
+vi.mock('../api/client', () => ({
+  api: {
+    listApps: (...a: unknown[]) => listApps(...a),
+    listRegistry: (...a: unknown[]) => listRegistry(...a),
+    listRegistries: (...a: unknown[]) => listRegistries(...a),
+    updateRegistries: vi.fn(),
+    refreshRegistries: vi.fn(),
+    enableApp: (...a: unknown[]) => enableApp(...a),
+    disableApp: (...a: unknown[]) => disableApp(...a),
+    updateApp: (...a: unknown[]) => updateApp(...a),
+    uninstallApp: (...a: unknown[]) => uninstallApp(...a),
+    uninstallPreview: (...a: unknown[]) => uninstallPreview(...a),
+    installApp: vi.fn(),
+    openApp: vi.fn(),
+    trustApp: vi.fn(),
+    untrustApp: vi.fn(),
+    getApp: vi.fn(),
+  },
+}))
+
+vi.mock('../hooks/useTheme', () => ({ useTheme: () => ({ theme: 'dark' }) }))
+
+vi.mock('../components/AppIcon', () => ({
+  default: ({ icon }: { icon?: string }) => <div data-testid="app-icon" data-icon={icon || ''} />,
+}))
+
+/* SegmentedControl measures its container (0px under happy-dom) and collapses
+   to a dropdown, hiding the tab labels — stub it with plain buttons. Each
+   button gets its OWN wrapper element so the row never reads as three peer
+   actions (`max-two-buttons-per-row`), regardless of how many segments a
+   caller passes. */
+vi.mock('../components/SegmentedControl', () => ({
+  default: ({ segments, onChange }: {
+    segments: { key: string; label: string }[]
+    onChange: (key: string) => void
+  }) => (
+    <div>
+      {segments.map(s => (
+        <div key={s.key}>
+          <button type="button" onClick={() => onChange(s.key)}>{s.label}</button>
+        </div>
+      ))}
+    </div>
+  ),
+}))
+
+/* SimpleSelect wraps a Radix Select, which commits inside `flushSync` and
+   needs an open-then-click cycle. The sort control is not the code under test
+   — its `onChange` is — so stub it with always-rendered options, each in its
+   own wrapper for the same button-row reason as above. */
+vi.mock('../components/SimpleSelect', () => ({
+  default: ({ options, optionLabels, value, onChange, 'aria-label': ariaLabel }: {
+    options: string[]
+    optionLabels?: string[]
+    value: string
+    onChange: (v: string) => void
+    'aria-label'?: string
+  }) => (
+    <span role="group" aria-label={ariaLabel}>
+      {options.map((o, i) => (
+        <span key={o}>
+          <button type="button" role="option" aria-selected={o === value} onClick={() => onChange(o)}>
+            {optionLabels?.[i] ?? o}
+          </button>
+        </span>
+      ))}
+    </span>
+  ),
+}))
+
+import AppsPage, { pickFeatured } from '../pages/AppsPage'
+import type { RegistryApp } from '../components/appstore/types'
+
+/** Detail-route probe: reports the app name and the `autoAction` router state. */
+function DetailProbe() {
+  const loc = useLocation()
+  const state = loc.state as { autoAction?: string } | null
+  return (
+    <div data-testid="detail-route" data-path={loc.pathname} data-auto={state?.autoAction || ''} />
+  )
+}
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/apps']}>
+        <Routes>
+          <Route path="/apps" element={<AppsPage />} />
+          <Route path="/apps/detail/:name" element={<DetailProbe />} />
+          <Route path="/apps/:name" element={<DetailProbe />} />
+          <Route path="/secretary-ui" element={<div data-testid="app-ui-route" />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+/** A hidden-by-default builtin: installed, switched OFF, so Discover offers Enable. */
+const BUILTIN_OFF = {
+  name: 'pets', displayName: 'Pets', version: '1.0.0', enabled: false,
+  installedAt: '2026-06-01T00:00:00Z', origin: 'builtin', resources: 'gateway', lifecycle: 'locked',
+  manifest: {
+    name: 'pets', version: '1.0.0', displayName: 'Pets', description: 'A desk companion.',
+    author: 'kirocrew', tags: ['fun'], ui: { pages: [{ route: '/pets', label: 'Pets', icon: 'Cat' }] },
+  },
+}
+
+/** An installed third-party app with an update pending and resources to remove. */
+const SECRETARY = {
+  name: 'secretary', displayName: 'Secretary', version: '1.0.0', enabled: true,
+  installedAt: '2026-07-01T00:00:00Z', origin: 'registry', resources: 'gateway', lifecycle: 'gateway',
+  manifest: {
+    name: 'secretary', version: '1.0.0', displayName: 'Secretary', description: 'Slack inbox manager.',
+    author: 'zezhexu', tags: ['slack', 'inbox'], agents: ['secretary'], skills: ['mochi-slack'],
+    crons: [{ name: 'inbox-sweep' }], repo: 'https://github.com/z/secretary',
+    ui: { pages: [{ route: '/secretary-ui', label: 'Secretary', icon: 'Bot' }] },
+  },
+}
+
+const REGISTRY_APPS = [
+  {
+    name: 'oncall-radar', displayName: 'Oncall Radar', author: 'kirocrew',
+    description: 'Oncall operations dashboard.', version: '2.0.0',
+    tags: ['oncall'], installed: false, updateAvailable: false, provenance: 'core',
+  },
+  {
+    name: 'secretary', displayName: 'Secretary', author: 'zezhexu',
+    description: 'Slack inbox manager.', version: '1.1.0', _registry: 'kirodotdev-labs',
+    tags: ['slack'], installed: true, updateAvailable: true, provenance: 'external',
+    repo: 'https://github.com/z/secretary',
+  },
+]
+
+const NO_DEPS = { dependencies: { removable: [], shared: [], userInstalled: [] } }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  sessionStorage.clear()
+  listApps.mockResolvedValue([BUILTIN_OFF, SECRETARY])
+  listRegistry.mockResolvedValue({ apps: REGISTRY_APPS })
+  listRegistries.mockResolvedValue({
+    registries: [{ name: 'kirodotdev-labs', repo: 'https://github.com/kirodotdev-labs/registry', branch: 'main' }],
+  })
+  enableApp.mockResolvedValue({ ok: true })
+  disableApp.mockResolvedValue({ ok: true })
+  updateApp.mockResolvedValue({ ok: true })
+  uninstallApp.mockResolvedValue({ ok: true })
+  uninstallPreview.mockResolvedValue(NO_DEPS)
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+/** Wait for the Discover catalog to be on screen. */
+const catalogReady = () => screen.findByRole('heading', { name: 'All apps' })
+
+/** The row for one app in Discover's dense list (the LAST such surface — the
+ *  editorial cards render the same accessible name above it). */
+async function browseRow(name: string) {
+  const rows = await screen.findAllByRole('button', { name: `View details for ${name}` })
+  return rows[rows.length - 1]
+}
+
+const goLibrary = () => fireEvent.click(screen.getByText('Library'))
+
+describe('AppsPage — Discover navigation', () => {
+  it('Cmd-clicks a row into a new tab instead of routing in place', async () => {
+    const open = vi.spyOn(window, 'open').mockReturnValue(null)
+    renderPage()
+    await catalogReady()
+    fireEvent.click(await browseRow('Oncall Radar'), { metaKey: true })
+    expect(open).toHaveBeenCalledWith('/apps/detail/oncall-radar', '_blank', 'noopener,noreferrer')
+    // The in-place navigation must NOT also happen.
+    expect(screen.queryByTestId('detail-route')).toBeNull()
+    open.mockRestore()
+  })
+
+  it('Install routes to the detail page carrying the install autoAction in router state', async () => {
+    renderPage()
+    await catalogReady()
+    const row = await browseRow('Oncall Radar')
+    fireEvent.click(within(row).getByRole('button', { name: 'Install' }))
+    const probe = await screen.findByTestId('detail-route')
+    expect(probe).toHaveAttribute('data-path', '/apps/detail/oncall-radar')
+    expect(probe).toHaveAttribute('data-auto', 'install')
+  })
+
+  it('Update on an installed row routes with the update autoAction', async () => {
+    renderPage()
+    await catalogReady()
+    const row = await browseRow('Secretary')
+    fireEvent.click(within(row).getByRole('button', { name: 'Update' }))
+    const probe = await screen.findByTestId('detail-route')
+    expect(probe).toHaveAttribute('data-path', '/apps/detail/secretary')
+    expect(probe).toHaveAttribute('data-auto', 'update')
+  })
+
+  it('Add source in the rail opens the Sources popover', async () => {
+    renderPage()
+    await catalogReady()
+    fireEvent.click(screen.getByRole('button', { name: /Add source/ }))
+    expect(await screen.findByText('Install from Path')).toBeInTheDocument()
+  })
+
+  it('sorting by category regroups the list without dropping rows', async () => {
+    renderPage()
+    await catalogReady()
+    const sort = screen.getByRole('group', { name: 'Sort apps' })
+    expect(within(sort).getByRole('option', { name: 'Name' })).toHaveAttribute('aria-selected', 'true')
+    fireEvent.click(within(sort).getByRole('option', { name: 'Category' }))
+    await waitFor(() =>
+      expect(within(sort).getByRole('option', { name: 'Category' })).toHaveAttribute('aria-selected', 'true'))
+    // All three catalog entries survive the re-sort (builtin + 2 registry rows).
+    expect(screen.getByText('3 apps')).toBeInTheDocument()
+  })
+})
+
+describe('AppsPage — enable path', () => {
+  it('enables a switched-off builtin and broadcasts the apps-changed event', async () => {
+    const onChanged = vi.fn()
+    window.addEventListener('mc:apps-changed', onChanged)
+    renderPage()
+    await catalogReady()
+    const row = await browseRow('Pets')
+    fireEvent.click(within(row).getByRole('button', { name: /^Enable/ }))
+    await waitFor(() => expect(enableApp).toHaveBeenCalledWith('pets'))
+    await waitFor(() => expect(onChanged).toHaveBeenCalled())
+    window.removeEventListener('mc:apps-changed', onChanged)
+  })
+
+  it('opens the trust consent modal when enable is refused for missing trust', async () => {
+    enableApp.mockRejectedValue({ body: JSON.stringify({ code: 'app_execution_denied' }) })
+    renderPage()
+    await catalogReady()
+    const row = await browseRow('Pets')
+    fireEvent.click(within(row).getByRole('button', { name: /^Enable/ }))
+    expect(await screen.findByText('Trust Pets to run its own code?')).toBeInTheDocument()
+    // A consent prompt is not an error — the error card must stay away.
+    expect(screen.queryByText(/Failed to enable/)).toBeNull()
+  })
+
+  it('shows the raw failure in the error card for a non-trust enable failure', async () => {
+    enableApp.mockRejectedValue(new Error('gateway is busy'))
+    renderPage()
+    await catalogReady()
+    const row = await browseRow('Pets')
+    fireEvent.click(within(row).getByRole('button', { name: /^Enable/ }))
+    expect(await screen.findByText('gateway is busy')).toBeInTheDocument()
+    expect(screen.queryByText('Trust Pets to run its own code?')).toBeNull()
+  })
+
+  it('falls back to the generic enable message when the failure carries no text', async () => {
+    enableApp.mockRejectedValue({})
+    renderPage()
+    await catalogReady()
+    const row = await browseRow('Pets')
+    fireEvent.click(within(row).getByRole('button', { name: /^Enable/ }))
+    expect(await screen.findByText('Failed to enable pets')).toBeInTheDocument()
+  })
+})
+
+describe('AppsPage — query failures and empty states', () => {
+  it('surfaces the apps-query failure and lets the user dismiss it', async () => {
+    listApps.mockRejectedValue(new Error(''))
+    renderPage()
+    expect(await screen.findByText('Failed to load apps')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    await waitFor(() => expect(screen.queryByText('Failed to load apps')).toBeNull())
+  })
+
+  it('surfaces the registry-query failure with its own message', async () => {
+    listRegistry.mockRejectedValue(new Error('registry unreachable'))
+    renderPage()
+    expect(await screen.findByText('registry unreachable')).toBeInTheDocument()
+  })
+
+  it('shows the empty catalog state when nothing is browsable', async () => {
+    listApps.mockResolvedValue([])
+    listRegistry.mockResolvedValue({ apps: [] })
+    renderPage()
+    expect(await screen.findByText('No apps available')).toBeInTheDocument()
+    expect(screen.getByText('Add an app source (gear icon above) or install from a local path.')).toBeInTheDocument()
+  })
+
+  it('shows the no-match state when the search excludes every row', async () => {
+    renderPage()
+    await catalogReady()
+    fireEvent.change(screen.getByLabelText('Search apps'), { target: { value: 'nothing-matches-this' } })
+    expect(await screen.findByText('No matching apps')).toBeInTheDocument()
+    expect(screen.getByText('Try a different search or category.')).toBeInTheDocument()
+  })
+
+  it('shows the empty Library state when no app is installed', async () => {
+    listApps.mockResolvedValue([])
+    listRegistry.mockResolvedValue({ apps: [] })
+    renderPage()
+    await screen.findByText('No apps available')
+    goLibrary()
+    expect(await screen.findByText('No apps installed yet')).toBeInTheDocument()
+  })
+
+  it('shows the no-match Library state when the search excludes every installed app', async () => {
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    await screen.findByText('Slack inbox manager.')
+    fireEvent.change(screen.getByLabelText('Search apps'), { target: { value: 'nothing-matches-this' } })
+    expect(await screen.findByText('No matching apps')).toBeInTheDocument()
+    expect(screen.getByText('Try a different search term')).toBeInTheDocument()
+  })
+
+  it('matches an installed app by its manifest tags', async () => {
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    await screen.findByText('Slack inbox manager.')
+    fireEvent.change(screen.getByLabelText('Search apps'), { target: { value: 'inbox' } })
+    // The tag match keeps the row; nothing falls through to the empty state.
+    await waitFor(() => expect(screen.queryByText('No matching apps')).toBeNull())
+    expect(screen.getByText('Slack inbox manager.')).toBeInTheDocument()
+  })
+})
+
+describe('AppsPage — Library actions', () => {
+  it('opens the app UI page from the card and the detail page from its name', async () => {
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    fireEvent.click(await screen.findByRole('button', { name: 'Open' }))
+    expect(await screen.findByTestId('app-ui-route')).toBeInTheDocument()
+  })
+
+  it('routes to the detail page when the card name is clicked', async () => {
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    fireEvent.click(await screen.findByRole('button', { name: 'Secretary' }))
+    const probe = await screen.findByTestId('detail-route')
+    expect(probe).toHaveAttribute('data-path', '/apps/detail/secretary')
+    expect(probe).toHaveAttribute('data-auto', '')
+  })
+
+  it('toasts after disabling a builtin and clears the toast on dismiss', async () => {
+    listApps.mockResolvedValue([{ ...BUILTIN_OFF, enabled: true }])
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    fireEvent.click(await screen.findByRole('button', { name: 'Disable' }))
+    await waitFor(() => expect(disableApp).toHaveBeenCalledWith('pets'))
+    expect(await screen.findByText('Disabled. You can re-enable it from the Discover tab.')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss message' }))
+    await waitFor(() =>
+      expect(screen.queryByText('Disabled. You can re-enable it from the Discover tab.')).toBeNull())
+  })
+
+  it('reports a failed disable with the action-failed message', async () => {
+    disableApp.mockRejectedValue({})
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    fireEvent.click(await screen.findByRole('button', { name: 'Disable' }))
+    expect(await screen.findByText('Failed to disable secretary')).toBeInTheDocument()
+  })
+
+  it('names the apps that failed during Update All', async () => {
+    updateApp.mockRejectedValue(new Error('clone failed'))
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    fireEvent.click(await screen.findByRole('button', { name: 'Update All' }))
+    expect(await screen.findByText('Failed to update: secretary')).toBeInTheDocument()
+  })
+
+  it('reports success after Update All and shows no error', async () => {
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    fireEvent.click(await screen.findByRole('button', { name: 'Update All' }))
+    expect(await screen.findByText('Updated 1 app.')).toBeInTheDocument()
+    expect(screen.queryByText(/Failed to update/)).toBeNull()
+  })
+})
+
+describe('AppsPage — uninstall dialog', () => {
+  const openDialog = async () => {
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    fireEvent.click(await screen.findByRole('button', { name: 'Uninstall' }))
+    return screen.findByRole('dialog', { name: 'Confirm uninstall' })
+  }
+
+  it('lists the resources the removal takes with it', async () => {
+    const dialog = await openDialog()
+    expect(within(dialog).getByText('Uninstall Secretary?')).toBeInTheDocument()
+    expect(within(dialog).getByText('1 agent')).toBeInTheDocument()
+    expect(within(dialog).getByText('1 skill')).toBeInTheDocument()
+    expect(within(dialog).getByText('1 cron job')).toBeInTheDocument()
+    // Registry provenance notice (gateway-managed resources, no app secret).
+    expect(within(dialog).getByText(/the downloaded source code will be removed/)).toBeInTheDocument()
+  })
+
+  it('warns about a self-managed app whose resources live outside Kiro Crew', async () => {
+    listApps.mockResolvedValue([{ ...SECRETARY, origin: 'local', resources: 'app' }])
+    const dialog = await openDialog()
+    expect(within(dialog).getByText(/This is a self-managed app/)).toBeInTheDocument()
+  })
+
+  it('warns when the manifest ships an uninstall script', async () => {
+    listApps.mockResolvedValue([{
+      ...SECRETARY,
+      origin: 'local',
+      resources: 'app',
+      manifest: { ...SECRETARY.manifest, setup: { onUninstall: 'cleanup.sh' } },
+    }])
+    const dialog = await openDialog()
+    expect(within(dialog).getByText(/This app has an uninstall script/)).toBeInTheDocument()
+    expect(within(dialog).getByText(/your local source code will not be affected/)).toBeInTheDocument()
+  })
+
+  it('names the app secret for a self-managed registry install', async () => {
+    listApps.mockResolvedValue([{ ...SECRETARY, resources: 'app' }])
+    const dialog = await openDialog()
+    expect(within(dialog).getByText(/the app secret, and the downloaded source code/)).toBeInTheDocument()
+    expect(within(dialog).getByText(/The app itself is managed externally/)).toBeInTheDocument()
+  })
+
+  it('renders the dependency preview and passes the kept dependency to the uninstall call', async () => {
+    uninstallPreview.mockResolvedValue({
+      dependencies: {
+        removable: [{ id: 'skills/mochi-slack', reason: 'installed with this app' }],
+        shared: [{ id: 'skills/widgets', reason: 'also used by Pets' }],
+        userInstalled: [{ id: 'skills/grill' }],
+      },
+    })
+    const dialog = await openDialog()
+    expect(within(dialog).getByText('Dependencies:')).toBeInTheDocument()
+    expect(within(dialog).getByText('installed with this app')).toBeInTheDocument()
+    expect(within(dialog).getByText(/also used by Pets/)).toBeInTheDocument()
+    expect(within(dialog).getByText('Kept — installed by you')).toBeInTheDocument()
+
+    fireEvent.click(within(dialog).getByLabelText('Keep dependency mochi-slack'))
+    fireEvent.click(within(dialog).getByLabelText('Keep app data'))
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Uninstall' }))
+    await waitFor(() =>
+      expect(uninstallApp).toHaveBeenCalledWith('secretary', false, false, ['skills/mochi-slack']))
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Confirm uninstall' })).toBeNull())
+  })
+
+  it('unticking then re-ticking a dependency leaves it out of the keep list', async () => {
+    uninstallPreview.mockResolvedValue({
+      dependencies: { removable: [{ id: 'skills/mochi-slack', reason: 'installed with this app' }], shared: [], userInstalled: [] },
+    })
+    const dialog = await openDialog()
+    const box = within(dialog).getByLabelText('Keep dependency mochi-slack')
+    fireEvent.click(box)
+    fireEvent.click(box)
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Uninstall' }))
+    await waitFor(() => expect(uninstallApp).toHaveBeenCalledWith('secretary', true, false, []))
+  })
+
+  it('hides the dependency block when the preview reports none', async () => {
+    const dialog = await openDialog()
+    expect(within(dialog).queryByText('Dependencies:')).toBeNull()
+  })
+
+  it('still opens the dialog when the preview request fails', async () => {
+    uninstallPreview.mockRejectedValue(new Error('preview unavailable'))
+    const dialog = await openDialog()
+    expect(within(dialog).queryByText('Dependencies:')).toBeNull()
+    expect(within(dialog).getByText('Uninstall Secretary?')).toBeInTheDocument()
+  })
+
+  it('reports a failed uninstall and closes the dialog', async () => {
+    uninstallApp.mockRejectedValue({})
+    const dialog = await openDialog()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Uninstall' }))
+    expect(await screen.findByText('Failed to uninstall secretary')).toBeInTheDocument()
+    expect(screen.queryByRole('dialog', { name: 'Confirm uninstall' })).toBeNull()
+  })
+
+  it('Cancel closes the dialog without calling the API', async () => {
+    const dialog = await openDialog()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Confirm uninstall' })).toBeNull())
+    expect(uninstallApp).not.toHaveBeenCalled()
+  })
+
+  it('Escape and a backdrop click both close the dialog', async () => {
+    const first = await openDialog()
+    fireEvent.keyDown(first, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Confirm uninstall' })).toBeNull())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Uninstall' }))
+    const second = await screen.findByRole('dialog', { name: 'Confirm uninstall' })
+    fireEvent.click(second)
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Confirm uninstall' })).toBeNull())
+    expect(uninstallApp).not.toHaveBeenCalled()
+  })
+})
+
+describe('AppsPage — editorial layer wiring', () => {
+  /** Default catalog order (no curator flags): verified first, then name —
+   *  Oncall Radar spotlights, Pets and Secretary take the feature cards. */
+  it('routes to the detail page from the spotlight body', async () => {
+    renderPage()
+    await catalogReady()
+    const surfaces = screen.getAllByRole('button', { name: 'View details for Oncall Radar' })
+    fireEvent.click(surfaces[0])
+    expect(await screen.findByTestId('detail-route')).toHaveAttribute('data-path', '/apps/detail/oncall-radar')
+  })
+
+  it('Get on the spotlight carries the install autoAction', async () => {
+    renderPage()
+    await catalogReady()
+    const spotlight = screen.getAllByRole('button', { name: 'View details for Oncall Radar' })[0]
+    fireEvent.click(within(spotlight).getByRole('button', { name: 'Get' }))
+    expect(await screen.findByTestId('detail-route')).toHaveAttribute('data-auto', 'install')
+  })
+
+  it('a feature card opens the detail page and can enable its app', async () => {
+    renderPage()
+    await catalogReady()
+    const card = screen.getAllByRole('button', { name: 'View details for Pets' })[0]
+    fireEvent.click(within(card).getByRole('button', { name: /^Enable/ }))
+    await waitFor(() => expect(enableApp).toHaveBeenCalledWith('pets'))
+    fireEvent.click(screen.getAllByRole('button', { name: 'View details for Pets' })[0])
+    expect(await screen.findByTestId('detail-route')).toHaveAttribute('data-path', '/apps/detail/pets')
+  })
+
+  it('enables from the spotlight and Gets from the feature card', async () => {
+    // Pets sorts ahead of Zeta App (both verified), so the switched-off builtin
+    // takes the spotlight and the uninstalled core app takes the feature card.
+    listApps.mockResolvedValue([BUILTIN_OFF])
+    listRegistry.mockResolvedValue({
+      apps: [{
+        name: 'zeta-app', displayName: 'Zeta App', author: 'kirocrew', description: 'Later in the alphabet.',
+        version: '1.0.0', tags: ['github'], installed: false, provenance: 'core',
+      }],
+    })
+    renderPage()
+    await catalogReady()
+    const spotlight = screen.getAllByRole('button', { name: 'View details for Pets' })[0]
+    fireEvent.click(within(spotlight).getByRole('button', { name: 'Enable' }))
+    await waitFor(() => expect(enableApp).toHaveBeenCalledWith('pets'))
+
+    const card = screen.getAllByRole('button', { name: 'View details for Zeta App' })[0]
+    fireEvent.click(within(card).getByRole('button', { name: 'Get' }))
+    const probe = await screen.findByTestId('detail-route')
+    expect(probe).toHaveAttribute('data-path', '/apps/detail/zeta-app')
+    expect(probe).toHaveAttribute('data-auto', 'install')
+  })
+})
+
+describe('AppsPage — Library enable and update', () => {
+  it('Update on a Library card routes to the streaming detail page', async () => {
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    fireEvent.click(await screen.findByRole('button', { name: 'Update' }))
+    const probe = await screen.findByTestId('detail-route')
+    expect(probe).toHaveAttribute('data-path', '/apps/detail/secretary')
+    expect(probe).toHaveAttribute('data-auto', 'update')
+    // Navigation only — the page must not call the update endpoint itself.
+    expect(updateApp).not.toHaveBeenCalled()
+  })
+
+  it('enables a switched-off installed app from the Library', async () => {
+    listApps.mockResolvedValue([{ ...SECRETARY, enabled: false }])
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    fireEvent.click(await screen.findByRole('button', { name: 'Enable' }))
+    await waitFor(() => expect(enableApp).toHaveBeenCalledWith('secretary'))
+  })
+
+  it('opens consent from the Library using the installed record when the catalog has no row', async () => {
+    // origin `local` and absent from the registry, so `trustTarget` has to fall
+    // back to the installed record for the name shown in the consent dialog.
+    listApps.mockResolvedValue([{
+      ...SECRETARY, name: 'localapp', displayName: 'Local App', enabled: false, origin: 'local',
+    }])
+    listRegistry.mockResolvedValue({ apps: [] })
+    enableApp.mockRejectedValue({ code: 'app_execution_denied' })
+    renderPage()
+    await screen.findByText('No apps available')
+    goLibrary()
+    fireEvent.click(await screen.findByRole('button', { name: 'Enable' }))
+    expect(await screen.findByText('Trust Local App to run its own code?')).toBeInTheDocument()
+    expect(screen.getByText('https://github.com/z/secretary')).toBeInTheDocument()
+  })
+})
+
+describe('AppsPage — toast expiry', () => {
+  it('the disable toast clears itself after four seconds', async () => {
+    listApps.mockResolvedValue([{ ...BUILTIN_OFF, enabled: true }])
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    fireEvent.click(await screen.findByRole('button', { name: 'Disable' }))
+    await screen.findByText('Disabled. You can re-enable it from the Discover tab.')
+    await act(async () => { vi.advanceTimersByTime(4000) })
+    expect(screen.queryByText('Disabled. You can re-enable it from the Discover tab.')).toBeNull()
+  })
+
+  it('the Update All toast clears itself after four seconds', async () => {
+    renderPage()
+    await catalogReady()
+    goLibrary()
+    fireEvent.click(await screen.findByRole('button', { name: 'Update All' }))
+    await screen.findByText('Updated 1 app.')
+    await act(async () => { vi.advanceTimersByTime(4000) })
+    expect(screen.queryByText('Updated 1 app.')).toBeNull()
+  })
+})
+
+describe('AppsPage — sources rail', () => {
+  it('counts built-ins, a stale registry, and the core registry separately', async () => {
+    listRegistry.mockResolvedValue({
+      apps: [
+        { name: 'core-app', displayName: 'Core App', author: 'kirocrew', description: 'From the core file.', version: '1.0.0', tags: ['github'], installed: false, provenance: 'core' },
+        { name: 'ghost-app', displayName: 'Ghost App', author: 'someone', description: 'From a registry no longer configured.', version: '1.0.0', tags: ['github'], installed: false, _registry: 'ghost-registry', provenance: 'external' },
+      ],
+    })
+    renderPage()
+    await catalogReady()
+    const rail = screen.getByText('SOURCES').parentElement as HTMLElement
+    // Configured registry keeps its row at zero; the stale tag gets its own.
+    expect(within(rail).getByText('Built-in · kirocrew')).toBeInTheDocument()
+    expect(within(rail).getByText('kirodotdev-labs')).toBeInTheDocument()
+    expect(within(rail).getByText('ghost-registry')).toBeInTheDocument()
+    expect(within(rail).getByText('Kiro Crew registry')).toBeInTheDocument()
+    expect(within(rail).getByText('0 apps')).toBeInTheDocument()
+  })
+})
+
+describe('pickFeatured', () => {
+  const app = (over: Partial<RegistryApp>): RegistryApp => ({
+    name: 'x', displayName: 'X', description: '', version: '1.0.0', author: '', installed: false, ...over,
+  })
+
+  it('ignores a featured flag published by an external registry', () => {
+    const picked = pickFeatured([
+      app({ name: 'plain', displayName: 'Plain' }),
+      app({ name: 'shouty', displayName: 'Shouty', featured: 0, _registry: 'evil' }),
+    ])
+    // The external row cannot buy the first slot; it falls to deterministic order.
+    expect(picked.map(a => a.name)).toEqual(['plain', 'shouty'])
+  })
+
+  it('drops a provenance-external row out of the flagged group too', () => {
+    const picked = pickFeatured([
+      app({ name: 'plain', displayName: 'Plain' }),
+      app({ name: 'sneaky', displayName: 'Sneaky', featured: 0, provenance: 'external' }),
+    ])
+    expect(picked[0].name).toBe('plain')
+  })
+
+  it('orders numbered flags first, then hero art, then verified, then name', () => {
+    const picked = pickFeatured([
+      app({ name: 'named-last', displayName: 'Zeta' }),
+      app({ name: 'verified', displayName: 'Alpha', verified: true }),
+      app({ name: 'art', displayName: 'Beta', heroImage: '/hero.png' }),
+      app({ name: 'flag-2', displayName: 'Second', featured: 2 }),
+      app({ name: 'flag-1', displayName: 'First', featured: 1 }),
+    ])
+    expect(picked.map(a => a.name)).toEqual(['flag-1', 'flag-2', 'art'])
+  })
+
+  it('breaks a shared flag rank by display name', () => {
+    const picked = pickFeatured([
+      app({ name: 'b', displayName: 'Bravo', featured: true }),
+      app({ name: 'a', displayName: 'Alpha', featured: true }),
+    ])
+    expect(picked.map(a => a.name)).toEqual(['a', 'b'])
+  })
+})

--- a/website/src/test/ChatPageW3Coverage.test.tsx
+++ b/website/src/test/ChatPageW3Coverage.test.tsx
@@ -1,0 +1,815 @@
+/**
+ * Coverage-directed tests for two cold halves of ChatPage.tsx that the ~37
+ * existing ChatPage suites leave almost entirely unexecuted.
+ *
+ *  1. `renderUserContent` — the exported module-level renderer for a USER
+ *     bubble. Every existing suite either mocks it away or renders assistant
+ *     rows, so its whole attachment/folder/paste/knowledge decision tree is
+ *     cold: the standalone-upload card path, the inline `@label` chip path, the
+ *     folder chip (clickable and inert variants, plus shift-click reveal), the
+ *     knowledge-context chip, and the three paste shapes (token present,
+ *     token missing but content re-collapsible, neither). These are exercised
+ *     directly — no ChatPage render — because the function is exported and pure
+ *     apart from the two callbacks injected into it.
+ *
+ *  2. The handlers ChatPage hands DOWN to four children that no suite drives:
+ *     `QueueStack` (cancel / interrupt / edit / reorder of a queued message),
+ *     `FollowUpCard`'s `onStartInWorktree` (five distinct failure branches plus
+ *     the success path), `ChatInput`'s `onScreenshot`, and `SidePanel`'s
+ *     `onAddSourceToChat` / `onFileSave` / `onArtifactOpen`. Each of those four
+ *     is stubbed as a PROP RECORDER so the callback can be invoked directly;
+ *     the children's own rendering is covered by their own suites.
+ *
+ * happy-dom has no layout, so the virtualizer is stubbed to mount every item
+ * (the technique ChatPageCoverage.test.tsx uses). Nothing else about the page
+ * is faked: the handlers, the store wiring and the render dispatch run for real.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import { i18nT } from '../i18n/t'
+import { store as appStore } from '../store'
+import type { RootState } from '../store'
+import type { ChatMessage } from '../types'
+import type { PasteBlock } from '../utils/pasteTokens'
+import { PREFILL_STORAGE_KEY } from '../utils/navIntent'
+
+// --- Stubs whose only job is to keep the render tree small -------------------
+
+vi.mock('../components/MarkdownRenderer', () => ({
+  default: ({ content }: { content?: string }) => content ?? null,
+}))
+
+// PastedChip owns hover-dwell timers and a portal; its own suite covers those.
+// Stubbed to a marker so a paste assertion is about ChatPage's SPLIT decision.
+vi.mock('../components/PastedChip', async () => {
+  const React = await import('react')
+  return {
+    default: ({ block }: { block: PasteBlock }) =>
+      React.createElement('span', { 'data-testid': 'paste-chip' }, `#${block.seq}`),
+  }
+})
+
+vi.mock('../pages/chat', async () => {
+  const React = await import('react')
+  return {
+    ChatFooter: () => null,
+    McpInfoButton: () => null,
+    PinnedPrompt: () => null,
+    UserMessage: ({ content }: { content: string }) =>
+      React.createElement('div', { 'data-testid': 'user-msg' }, content),
+    AssistantMessage: ({ content }: { content: string }) =>
+      React.createElement('div', { 'data-testid': 'assistant-msg' }, content),
+  }
+})
+
+// --- Prop recorders for the four children under test ------------------------
+
+interface QueueProps {
+  messages: ChatMessage[]
+  onCancel: (id: string) => void
+  onInterrupt: (id: string) => void
+  onEdit: (id: string, content: string) => void
+  onReorder: (id: string, direction: 'next' | 'later') => void
+}
+let queueProps: QueueProps | null = null
+vi.mock('../components/QueueStack', async (importOriginal) => {
+  // isSystemDelivery / isNonInteractiveQueued are imported from here by
+  // ChatPage to classify queued rows — keep the real ones.
+  const actual = await importOriginal<typeof import('../components/QueueStack')>()
+  return {
+    ...actual,
+    default: (props: QueueProps) => { queueProps = props; return null },
+    SubagentDeliveryProgress: () => null,
+  }
+})
+
+interface FollowupItem { title: string; prompt: string; description?: string; branch?: string }
+interface FollowupProps {
+  items: FollowupItem[]
+  onAddToSession: (item: FollowupItem) => void
+  onStartInWorktree: (item: FollowupItem) => Promise<void>
+  onSkip: (index: number) => void
+}
+let followupProps: FollowupProps | null = null
+vi.mock('../components/FollowUpCard', () => ({
+  default: (props: FollowupProps) => { followupProps = props; return null },
+}))
+
+interface SidePanelProps {
+  onAddSourceToChat: (text: string) => void
+  onFileSave: (path: string, content: string) => Promise<void>
+  onArtifactOpen: (slug: string) => Promise<void>
+}
+let sidePanelProps: SidePanelProps | null = null
+vi.mock('../pages/chat/SidePanel', () => ({
+  default: (props: SidePanelProps) => { sidePanelProps = props; return null },
+  CHAT_PANE_MIN_W: 420,
+  sidePanelFillWidth: () => false,
+}))
+
+interface InputProps {
+  value: string
+  onChange: (v: string) => void
+  onScreenshot?: () => void
+  pendingFiles?: string[]
+  uploading?: boolean
+}
+let inputProps: InputProps | null = null
+vi.mock('../components/ChatInput', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/ChatInput')>()
+  const React = await import('react')
+  return {
+    ...actual,
+    default: (props: InputProps) => {
+      inputProps = props
+      return React.createElement('textarea', {
+        'aria-label': 'Message input',
+        value: props.value,
+        onChange: (e: { target: { value: string } }) => props.onChange(e.target.value),
+      })
+    },
+  }
+})
+
+vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
+vi.mock('../components/FlyingQuote', () => ({ default: () => null }))
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../components/DiffPanel', () => ({ default: () => null }))
+vi.mock('../components/TypewriterText', () => ({ default: () => null }))
+vi.mock('../components/OverlayDrawer', () => ({ default: ({ children }: { children?: ReactNode }) => children }))
+vi.mock('../components/AgentDropdownList', () => ({ default: () => null, ManageAgentsFooter: () => null }))
+vi.mock('../components/ModelDropdownList', () => ({ default: () => null }))
+vi.mock('../components/InfoTip', () => ({ default: () => null }))
+vi.mock('../components/SegmentedControl', () => ({ default: () => null }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/SearchResultsList', () => ({ default: () => null }))
+vi.mock('../pages/ChatSidebar', () => ({ default: () => null, SIDEBAR_MIN: 200, SIDEBAR_MAX: 500 }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../pages/chat/SessionColorPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ contentWidth: 'compact' }),
+  CONTENT_WIDTH: {
+    compact: { messages: '900px', input: '916px' },
+    comfortable: { messages: '84%', input: '85%' },
+    full: { messages: '92%', input: '93%' },
+  },
+}))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: null }) }))
+vi.mock('../hooks/useFilteredDropdown', () => ({
+  useFilteredDropdown: () => ({
+    filtered: [], query: '', setQuery: vi.fn(),
+    selectedIndex: 0, setSelectedIndex: vi.fn(), onKeyDown: vi.fn(),
+  }),
+}))
+vi.mock('../hooks/useVoiceInput', () => ({
+  useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }),
+  voiceInputSupported: false,
+}))
+vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
+  useVirtualChat: (opts: { items?: unknown[]; getKey?: (it: unknown, i: number) => string }) => {
+    const items = opts.items ?? []
+    return {
+      virtualItems: items.map((data, index) => ({
+        key: opts.getKey ? opts.getKey(data, index) : String(index),
+        index,
+        mounted: true,
+        data,
+      })),
+      isAtBottom: true,
+      scrollToBottom: vi.fn(),
+      scrollToIndexSmooth: vi.fn(),
+      mountIndex: vi.fn(() => false),
+      measureRef: () => () => {},
+      topSentinelRef: { current: null },
+      bottomSentinelRef: { current: null },
+      offsetBefore: 0,
+      offsetAfter: 0,
+      totalHeight: 0,
+    }
+  },
+}))
+vi.mock('../api/pins', () => ({
+  PIN_PREVIEW_INPUT_MAX_CHARS: 4096,
+  pinsApi: {
+    list: vi.fn().mockResolvedValue({ pins: [] }),
+    create: vi.fn().mockResolvedValue({}),
+    remove: vi.fn().mockResolvedValue({ ok: true }),
+  },
+}))
+
+const apiMocks: Record<string, ReturnType<typeof vi.fn>> = {}
+/** Seed (or fetch) the mock for one api method so a test can assert it was
+ *  never called — reading it off `apiMocks` lazily would report `undefined`. */
+const apiSpy = (name: string) => {
+  if (!(name in apiMocks)) apiMocks[name] = vi.fn().mockResolvedValue({})
+  return apiMocks[name]
+}
+vi.mock('../api/client', () => ({
+  api: new Proxy({}, {
+    get: (_t, prop: string) => {
+      if (!(prop in apiMocks)) {
+        apiMocks[prop] = vi.fn().mockResolvedValue(
+          prop === 'chatSlotDetail' ? { messages: [], has_more: false, total: 0 } : {},
+        )
+      }
+      return apiMocks[prop]
+    },
+  }),
+  fileReadUrl: (p: string) => `/api/file?path=${encodeURIComponent(p)}`,
+  SEARCH_MIN_CHARS: 2,
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatPage, { renderUserContent, virtualKeyFor, messageRowKey } from '../pages/ChatPage'
+
+// --- Fixtures ---------------------------------------------------------------
+
+const SLOT = {
+  key: 'chat-1', title: 'chat-1', messages: 0, running: false,
+  mode: '', created: '', last_ts: '', project: '/repo/main',
+}
+
+const msg = (role: string, content: string, extra: Partial<ChatMessage> = {}): ChatMessage => ({
+  role, content, cls: '', ...extra,
+})
+
+const openFile = vi.fn()
+const openFolder = vi.fn()
+
+/** Renders just the exported user-bubble renderer (no ChatPage). */
+function renderBubble(content: string, meta?: Record<string, unknown>, withFolder = true) {
+  return render(
+    <div>{renderUserContent(content, meta, openFile, withFolder ? openFolder : undefined)}</div>,
+  )
+}
+
+interface RenderOpts {
+  chat?: Record<string, unknown>
+  /** Server-side queue for the active slot. The mount fetch is authoritative —
+   *  `hydrateQueuedBubbles` rebuilds the queued rows from THIS list and drops
+   *  any pre-seeded ones, so a preloaded `queued` message never survives. */
+  queue?: { id: string; content: string }[]
+}
+
+function renderChatPage(messages: ChatMessage[], opts: RenderOpts = {}) {
+  const { chat = {}, queue = [] } = opts
+  apiSpy('chatSlots').mockResolvedValue([SLOT])
+  apiSpy('chatSlotDetail').mockResolvedValue({
+    messages, queue, has_more: false, total: messages.length,
+  })
+  apiSpy('sessions').mockResolvedValue({ sessions: [], has_more: false })
+  // RTK's preloadedState REPLACES a slice rather than merging, so spread the
+  // reducers' own initial state — a hand-rolled literal drops keys the reducers
+  // then mutate blindly.
+  const base = createTestStore().getState()
+  const store = createTestStore({
+    dashboard: {
+      ...base.dashboard,
+      status: { platform: 'darwin' } as unknown as RootState['dashboard']['status'],
+      connected: true,
+      slots: [SLOT] as unknown as RootState['dashboard']['slots'],
+    },
+    chat: {
+      ...base.chat,
+      activeSlot: 'chat-1',
+      ...chat,
+    } as unknown as RootState['chat'],
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/chat/chat-1']}>
+            <Routes>
+              {/* noUrlSync: the route→slot sync would otherwise pull activeSlot
+                  back to the URL's `chat-1` the moment a handler switches the
+                  page to a freshly created session. */}
+              <Route path="/chat/:slug?" element={<ChatPage mode="" noUrlSync />} />
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return { store }
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  queueProps = null
+  followupProps = null
+  sidePanelProps = null
+  inputProps = null
+  openFile.mockClear()
+  openFolder.mockClear()
+  localStorage.clear()
+  sessionStorage.clear()
+  for (const k of Object.keys(apiMocks)) delete apiMocks[k]
+  fetchMock = vi.fn().mockResolvedValue({
+    ok: true, status: 200, text: () => Promise.resolve(''), json: () => Promise.resolve({}),
+  })
+  globalThis.fetch = fetchMock as never
+  // ChatPage reads the COMMITTED active slot off the module-singleton store (not
+  // the Provider's), so the singleton has to be neutral between tests or one
+  // test's slot leaks into the next one's guards.
+  appStore.dispatch({ type: 'chat/setActiveSlot', payload: null })
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+})
+
+afterEach(() => {
+  appStore.dispatch({ type: 'chat/setActiveSlot', payload: null })
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+// ===========================================================================
+// 1. renderUserContent
+// ===========================================================================
+
+describe('renderUserContent — attachments', () => {
+  it('renders a bare upload as a block card and opens it on click', () => {
+    renderBubble('[attached_file 1] /home/u/q3/report.pdf', { files: ['/home/u/q3/report.pdf'] })
+    const card = screen.getByRole('button', {
+      name: i18nT('pages.chatPage.open_file', { path: '/home/u/q3/report.pdf' }),
+    })
+    // The LLM-facing marker must never survive into the bubble text.
+    expect(document.body.textContent).not.toContain('attached_file')
+    expect(card).toHaveTextContent('report.pdf')
+    fireEvent.click(card)
+    expect(openFile).toHaveBeenCalledWith('/home/u/q3/report.pdf')
+  })
+
+  it('disambiguates two same-named uploads by widening the label', () => {
+    renderBubble(
+      '[attached_file 1] /home/u/q3/report.pdf\n[attached_file 2] /home/u/q4/report.pdf',
+      { files: ['/home/u/q3/report.pdf', '/home/u/q4/report.pdf'] },
+    )
+    expect(screen.getByText('q3/report.pdf')).toBeInTheDocument()
+    expect(screen.getByText('q4/report.pdf')).toBeInTheDocument()
+  })
+
+  it('keeps a file woven into a sentence as an inline chip, not a card', () => {
+    renderBubble('please read [attached_file 1] /home/u/notes.md and summarise', {
+      files: ['/home/u/notes.md'],
+    })
+    const chip = screen.getByRole('button', {
+      name: i18nT('pages.chatPage.open_file', { path: '/home/u/notes.md' }),
+    })
+    expect(chip).toHaveTextContent('@notes.md')
+    // Inline chips flow inside the sentence, so the surrounding prose survives.
+    expect(document.body.textContent).toContain('please read')
+    expect(document.body.textContent).toContain('and summarise')
+    fireEvent.click(chip)
+    expect(openFile).toHaveBeenCalledWith('/home/u/notes.md')
+  })
+
+  it('renders an attachment nothing in the text references as a message-level card', () => {
+    // Optimistic empty-caption bubble: meta carries the file, the text has no
+    // token for it at all.
+    renderBubble('here you go', { files: ['/home/u/diagram.pdf'] })
+    expect(
+      screen.getByRole('button', {
+        name: i18nT('pages.chatPage.open_file', { path: '/home/u/diagram.pdf' }),
+      }),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('renderUserContent — folder references', () => {
+  const CONTENT = 'check [attached_dir 1] /repo/main/src for dead code'
+  const META = { dirs: ['/repo/main/src'] }
+
+  it('rewrites a dir marker to a clickable @label/ chip', () => {
+    renderBubble(CONTENT, META)
+    const chip = screen.getByRole('button', {
+      name: i18nT('pages.chatPage.open_folder', { path: '/repo/main/src' }),
+    })
+    expect(chip).toHaveTextContent('@src/')
+    expect(document.body.textContent).not.toContain('attached_dir')
+    fireEvent.click(chip)
+    expect(openFolder).toHaveBeenCalledWith('/repo/main/src')
+  })
+
+  it('shift-click reveals the folder in the OS file manager instead of opening the panel', () => {
+    renderBubble(CONTENT, META)
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: i18nT('pages.chatPage.open_folder', { path: '/repo/main/src' }),
+      }),
+      { shiftKey: true },
+    )
+    expect(apiMocks.revealPath).toHaveBeenCalledWith('/repo/main/src')
+    expect(openFolder).not.toHaveBeenCalled()
+  })
+
+  it('degrades to an inert span when no folder handler is supplied', () => {
+    renderBubble(CONTENT, META, false)
+    expect(screen.queryByRole('button')).toBeNull()
+    // Still identifies the folder — the path lives in the tooltip.
+    expect(document.querySelector('[title="/repo/main/src"]')).not.toBeNull()
+  })
+})
+
+describe('renderUserContent — knowledge context chip', () => {
+  const KNOWLEDGE = {
+    items: 2,
+    tokens: 1234,
+    titles: ['Runbook', 'RFC'],
+    content: [{ title: 'Runbook', text: 'restart the gateway' }],
+  }
+
+  it('summarises the injected knowledge and expands it on click', () => {
+    renderBubble('why is it down?', { knowledge: KNOWLEDGE })
+    const toggle = screen.getByRole('button', {
+      name: i18nT('pages.chatPage.expand_knowledge_context'),
+    })
+    expect(document.body.textContent).toContain('1,234')
+    expect(screen.queryByText('restart the gateway')).toBeNull()
+    fireEvent.click(toggle)
+    expect(screen.getByText('restart the gateway')).toBeInTheDocument()
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(toggle)
+    expect(screen.queryByText('restart the gateway')).toBeNull()
+  })
+
+  it('renders the chip but nothing to expand when only the counts travelled', () => {
+    renderBubble('why is it down?', { knowledge: { items: 1, tokens: 10, titles: ['RFC'] } })
+    const toggle = screen.getByRole('button', {
+      name: i18nT('pages.chatPage.expand_knowledge_context'),
+    })
+    fireEvent.click(toggle)
+    // No `content` on the meta, so the expanded panel has nothing to show and
+    // must not render an empty box... the chip itself stays.
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+  })
+})
+
+describe('renderUserContent — collapsed pastes', () => {
+  const block: PasteBlock = {
+    id: 'pb1', seq: 1, lines: 5, content: 'l1\nl2\nl3\nl4\nl5',
+  }
+
+  it('splits the message around a paste token and keeps the prose inline', () => {
+    renderBubble('before\n[ Paste #1 · 5 lines ]\nafter', { pastes: [block] })
+    expect(screen.getByTestId('paste-chip')).toHaveTextContent('#1')
+    expect(document.body.textContent).toContain('before')
+    expect(document.body.textContent).toContain('after')
+  })
+
+  it('re-collapses an expanded history message whose token was lost', () => {
+    // The backend re-serves the EXPANDED content; only meta.pastes travels with
+    // it. Without the deterministic re-collapse the raw paste would be handed
+    // to the markdown renderer.
+    renderBubble(`before\n${block.content}\nafter`, { pastes: [block] })
+    expect(screen.getByTestId('paste-chip')).toBeInTheDocument()
+    expect(document.body.textContent).not.toContain('l3')
+  })
+
+  it('falls back to a plain render when neither the token nor the content is present', () => {
+    renderBubble('nothing to see', { pastes: [{ ...block, content: 'unrelated text' }] })
+    expect(screen.queryByTestId('paste-chip')).toBeNull()
+    expect(document.body.textContent).toContain('nothing to see')
+  })
+
+  it('renders an inline file chip in the segment beside a paste chip', () => {
+    renderBubble('see [attached_file 1] /x/a.txt too\n[ Paste #1 · 5 lines ]', {
+      pastes: [block],
+      files: ['/x/a.txt'],
+    })
+    expect(screen.getByTestId('paste-chip')).toBeInTheDocument()
+    const chip = screen.getByRole('button', {
+      name: i18nT('pages.chatPage.open_file', { path: '/x/a.txt' }),
+    })
+    fireEvent.click(chip)
+    expect(openFile).toHaveBeenCalledWith('/x/a.txt')
+  })
+
+  it('cards an attachment the paste message never references', () => {
+    renderBubble('[ Paste #1 · 5 lines ]', { pastes: [block], files: ['/x/orphan.txt'] })
+    expect(screen.getByTestId('paste-chip')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: i18nT('pages.chatPage.open_file', { path: '/x/orphan.txt' }),
+      }),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('row identity helpers', () => {
+  it('keys an empty turn on its index rather than crashing on a missing lead row', () => {
+    expect(virtualKeyFor({ kind: 'turn', items: [], complete: true }, 7, messageRowKey))
+      .toBe('turn-empty-7')
+  })
+
+  it('gives a single and the turn it leads the SAME key so a regroup never remounts', () => {
+    const m = msg('assistant', 'hi', { ts: '2026-08-12T09:00:00Z' })
+    const single = { kind: 'single' as const, msg: m, idx: 3 }
+    expect(virtualKeyFor({ kind: 'turn', items: [single], complete: false }, 0, messageRowKey))
+      .toBe(virtualKeyFor(single, 0, messageRowKey))
+  })
+})
+
+// ===========================================================================
+// 2. Handlers handed to children
+// ===========================================================================
+
+describe('ChatPage — queued message actions', () => {
+  const TWO = [
+    { id: 'q1', content: 'run the tests' },
+    { id: 'q2', content: 'then deploy' },
+  ]
+
+  async function renderWithQueue(queue = TWO) {
+    const out = renderChatPage([msg('user', 'first', { ts: '2026-08-12T07:00:00Z' })], { queue })
+    await waitFor(() => expect(queueProps?.messages?.length).toBe(2))
+    return out
+  }
+
+  it('cancelling a queued card restores its text to the composer and tells the server', async () => {
+    await renderWithQueue()
+    act(() => { queueProps!.onCancel('q1') })
+    await waitFor(() => expect(inputProps!.value).toBe('run the tests'))
+    expect(apiMocks.cancelQueuedMessage).toHaveBeenCalledWith('chat-1', 'q1')
+    // Optimistically removed rather than waiting for the WS echo.
+    await waitFor(() => expect(queueProps!.messages.map(m => m.meta?.queueId)).toEqual(['q2']))
+  })
+
+  it('interrupting a queued card asks the server to interrupt that entry only', async () => {
+    await renderWithQueue()
+    act(() => { queueProps!.onInterrupt('q2') })
+    expect(apiMocks.interruptSlot).toHaveBeenCalledWith('chat-1', 'q2')
+    expect(apiSpy('cancelQueuedMessage')).not.toHaveBeenCalled()
+  })
+
+  it('editing a queued card trims and commits, and refuses a blank edit', async () => {
+    await renderWithQueue()
+    act(() => { queueProps!.onEdit('q1', '   ') })
+    expect(apiSpy('editQueuedMessage')).not.toHaveBeenCalled()
+    act(() => { queueProps!.onEdit('q1', '  run the tests twice  ') })
+    expect(apiMocks.editQueuedMessage).toHaveBeenCalledWith('chat-1', 'q1', 'run the tests twice')
+    await waitFor(() =>
+      expect(queueProps!.messages.find(m => m.meta?.queueId === 'q1')?.content)
+        .toBe('run the tests twice'),
+    )
+  })
+
+  it('reordering submits the FULL order so a hidden system delivery is not demoted', async () => {
+    // A sub-agent delivery sits between the two visible cards. It never renders
+    // as a card, but omitting it from the submitted order would let the backend
+    // re-append it at the tail — silently demoting automation.
+    renderChatPage([msg('user', 'first', { ts: '2026-08-12T07:00:00Z' })], {
+      queue: [
+        { id: 'q1', content: 'run the tests' },
+        { id: 'sys1', content: '[Subagent completion event] Agent X completed ✅ done' },
+        { id: 'q2', content: 'then deploy' },
+      ],
+    })
+    await waitFor(() => expect(queueProps?.messages?.length).toBe(2))
+    expect(queueProps!.messages.map(m => m.meta?.queueId)).toEqual(['q1', 'q2'])
+    act(() => { queueProps!.onReorder('q1', 'later') })
+    expect(apiMocks.reorderQueuedMessages).toHaveBeenCalledWith('chat-1', ['q2', 'sys1', 'q1'])
+  })
+
+  it('ignores a reorder that would run off either end of the visible stack', async () => {
+    await renderWithQueue()
+    act(() => { queueProps!.onReorder('q1', 'next') })
+    act(() => { queueProps!.onReorder('q2', 'later') })
+    act(() => { queueProps!.onReorder('nope', 'later') })
+    expect(apiSpy('reorderQueuedMessages')).not.toHaveBeenCalled()
+  })
+})
+
+describe('ChatPage — follow-up "start in worktree"', () => {
+  const ITEM: FollowupItem = { title: 'Add a Retry Guard!', prompt: 'add the retry guard' }
+
+  async function renderWithFollowup() {
+    const out = renderChatPage(
+      [msg('user', 'done?', { ts: '2026-08-12T07:00:00Z' })],
+      {
+        chat: {
+          activeSlot: 'chat-1',
+          followups: { 'chat-1': { items: [ITEM], ts: 1000 } },
+        },
+      },
+    )
+    await waitFor(() => expect(followupProps).not.toBeNull())
+    return out
+  }
+
+  /** chatSlotDetail is the only api call inside `switchSlot`, so failing it for
+   *  one key is how the switch is made to reject without touching the store. */
+  const detailFailsFor = (badKey: string) => {
+    apiMocks.chatSlotDetail.mockImplementation((key: string) =>
+      key === badKey
+        ? Promise.reject(new Error('detail unavailable'))
+        : Promise.resolve({ messages: [], queue: [], has_more: false, total: 0 }),
+    )
+  }
+
+  /** The handler compares the COMMITTED active slot (module-singleton store)
+   *  against the new key to decide whether a switch is needed at all. Seeding it
+   *  to the new key drives the already-in-focus branch — the one that reaches
+   *  the prefill + card-clear tail. */
+  const commitActiveSlot = (key: string) => {
+    appStore.dispatch({ type: 'chat/setActiveSlot', payload: key })
+  }
+
+  it('creates the worktree, hands the prompt over, and clears the card', async () => {
+    apiSpy('createWorktree').mockResolvedValue({ path: '/repo/wt-retry' })
+    apiSpy('createChatSlot').mockResolvedValue({ key: 'chat-2' })
+    const { store } = await renderWithFollowup()
+    commitActiveSlot('chat-2')
+    await act(async () => { await followupProps!.onStartInWorktree(ITEM) })
+    // Branch name slugified from the title under FOLLOWUP_BRANCH_RE's grammar.
+    expect(apiMocks.createWorktree).toHaveBeenCalledWith('/repo/main', 'followup/add-a-retry-guard')
+    // The prompt travels through the prefill channel BEFORE the switch, so the
+    // per-slot draft restore applies it instead of racing it.
+    expect(JSON.parse(sessionStorage.getItem(PREFILL_STORAGE_KEY) || '{}')).toMatchObject({
+      slotKey: 'chat-2', prompt: 'add the retry guard',
+    })
+    // Only THIS card is cleared, keyed on the ts that was rendered.
+    expect(store.getState().chat.followups?.['chat-1']).toBeUndefined()
+  })
+
+  it('honours a branch name the agent supplied instead of slugifying', async () => {
+    apiSpy('createWorktree').mockResolvedValue({ path: '/repo/wt-x' })
+    apiSpy('createChatSlot').mockResolvedValue({ key: 'chat-2' })
+    await renderWithFollowup()
+    commitActiveSlot('chat-2')
+    await act(async () => {
+      await followupProps!.onStartInWorktree({ ...ITEM, branch: 'fix/explicit' })
+    })
+    expect(apiMocks.createWorktree).toHaveBeenCalledWith('/repo/main', 'fix/explicit')
+  })
+
+  it('falls back to a placeholder slug when the title has no usable characters', async () => {
+    apiSpy('createWorktree').mockResolvedValue({ path: '/repo/wt-y' })
+    apiSpy('createChatSlot').mockResolvedValue({ key: 'chat-2' })
+    await renderWithFollowup()
+    commitActiveSlot('chat-2')
+    await act(async () => {
+      await followupProps!.onStartInWorktree({ ...ITEM, title: '!!! ???' })
+    })
+    expect(apiMocks.createWorktree).toHaveBeenCalledWith('/repo/main', 'followup/suggestion')
+  })
+
+  it('refuses before creating a session when the worktree returns no path', async () => {
+    apiSpy('createWorktree').mockResolvedValue({ error: 'branch already exists' })
+    await renderWithFollowup()
+    await expect(followupProps!.onStartInWorktree(ITEM)).rejects.toThrow('branch already exists')
+    // Creating the session first would leave an empty one to clean up by hand.
+    expect(apiSpy('createChatSlot')).not.toHaveBeenCalled()
+  })
+
+  it('names the reusable worktree when the session could not be created', async () => {
+    apiSpy('createWorktree').mockResolvedValue({ path: '/repo/wt-retry' })
+    apiSpy('createChatSlot').mockRejectedValue(new Error('slot service down'))
+    await renderWithFollowup()
+    await expect(followupProps!.onStartInWorktree(ITEM)).rejects.toThrow(
+      /Worktree created at \/repo\/wt-retry.*could not be opened and scoped/s,
+    )
+  })
+
+  it('fails closed rather than prefilling the wrong session when no key came back', async () => {
+    apiSpy('createWorktree').mockResolvedValue({ path: '/repo/wt-retry' })
+    // A fulfilled thunk with no key would otherwise skip every guard below and
+    // prefill whatever session happens to be on screen.
+    apiSpy('createChatSlot').mockResolvedValue({})
+    await renderWithFollowup()
+    await expect(followupProps!.onStartInWorktree(ITEM)).rejects.toThrow(/no session was returned/)
+    expect(sessionStorage.getItem(PREFILL_STORAGE_KEY)).toBeNull()
+  })
+
+  it('reports a ready worktree whose session could not be opened', async () => {
+    apiSpy('createWorktree').mockResolvedValue({ path: '/repo/wt-retry' })
+    apiSpy('createChatSlot').mockResolvedValue({ key: 'chat-2' })
+    await renderWithFollowup()
+    detailFailsFor('chat-2')
+    await expect(followupProps!.onStartInWorktree(ITEM)).rejects.toThrow(
+      /Worktree ready at \/repo\/wt-retry.*could not be opened/s,
+    )
+  })
+
+  it('refuses to prefill when the switch resolved but the session never took focus', async () => {
+    apiSpy('createWorktree').mockResolvedValue({ path: '/repo/wt-retry' })
+    apiSpy('createChatSlot').mockResolvedValue({ key: 'chat-2' })
+    await renderWithFollowup()
+    // The switch resolves, but the committed active slot never becomes chat-2 —
+    // prefilling here would drop the prompt into an unrelated conversation.
+    await expect(followupProps!.onStartInWorktree(ITEM)).rejects.toThrow(/is not in focus/)
+  })
+
+  it('adding to the session merges into the composer draft and clears the card', async () => {
+    const { store } = await renderWithFollowup()
+    act(() => { inputProps!.onChange('half-typed thought') })
+    await waitFor(() => expect(inputProps!.value).toBe('half-typed thought'))
+    act(() => { followupProps!.onAddToSession(ITEM) })
+    await waitFor(() => expect(inputProps!.value).toContain('add the retry guard'))
+    // APPEND, never replace — the half-typed text must survive.
+    expect(inputProps!.value).toContain('half-typed thought')
+    expect(store.getState().chat.followups?.['chat-1']).toBeUndefined()
+  })
+})
+
+describe('ChatPage — side panel callbacks', () => {
+  async function renderWithPanel() {
+    const out = renderChatPage(
+      [msg('user', 'look at this', { ts: '2026-08-12T07:00:00Z' })],
+      { chat: { activeSlot: 'chat-1', activityOpen: true } },
+    )
+    await waitFor(() => expect(sidePanelProps).not.toBeNull())
+    return out
+  }
+
+  it('appends a review comment below whatever is already in the composer', async () => {
+    await renderWithPanel()
+    act(() => { sidePanelProps!.onAddSourceToChat('nit: rename this') })
+    await waitFor(() => expect(inputProps!.value).toBe('nit: rename this'))
+    act(() => { sidePanelProps!.onAddSourceToChat('and this one') })
+    await waitFor(() => expect(inputProps!.value).toBe('nit: rename this\n\nand this one'))
+  })
+
+  it('writes an edited file through the file-write endpoint', async () => {
+    await renderWithPanel()
+    await act(async () => { await sidePanelProps!.onFileSave('/repo/main/a.ts', 'next') })
+    expect(fetchMock).toHaveBeenCalledWith('/api/file-write', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ path: '/repo/main/a.ts', content: 'next' }),
+    }))
+  })
+
+  it('surfaces a refused write instead of reporting success', async () => {
+    await renderWithPanel()
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 403 })
+    await expect(sidePanelProps!.onFileSave('/etc/hosts', 'nope')).rejects.toThrow('Save failed: 403')
+  })
+
+  it('records an involvement breadcrumb and seeds the tab when an artifact opens', async () => {
+    await renderWithPanel()
+    apiSpy('artifact').mockResolvedValue({ slug: 'plan', kind: 'markdown', content: '# plan' })
+    await act(async () => { await sidePanelProps!.onArtifactOpen('plan') })
+    expect(apiMocks.recordArtifactReference).toHaveBeenCalledWith('plan', 'chat-1')
+    expect(apiMocks.artifact).toHaveBeenCalledWith('plan')
+  })
+
+  it('still opens the tab when the artifact fetch fails', async () => {
+    await renderWithPanel()
+    apiSpy('artifact').mockRejectedValue(new Error('gone'))
+    // The panel's own query renders the error state; the open must not throw.
+    await act(async () => { await sidePanelProps!.onArtifactOpen('missing') })
+    expect(apiMocks.artifact).toHaveBeenCalledWith('missing')
+  })
+
+  it('ignores an artifact open with no slug', async () => {
+    await renderWithPanel()
+    await act(async () => { await sidePanelProps!.onArtifactOpen('') })
+    expect(apiSpy('recordArtifactReference')).not.toHaveBeenCalled()
+  })
+})
+
+describe('ChatPage — composer screenshot', () => {
+  it('stages the captured file on the slot that asked for it', async () => {
+    renderChatPage([msg('user', 'see this', { ts: '2026-08-12T07:00:00Z' })])
+    await waitFor(() => expect(inputProps).not.toBeNull())
+    apiSpy('screenshot').mockResolvedValue({ path: '/tmp/shot.png' })
+    await act(async () => { inputProps!.onScreenshot!() })
+    await waitFor(() => expect(inputProps!.pendingFiles).toContain('/tmp/shot.png'))
+    expect(inputProps!.uploading).toBe(false)
+  })
+
+  it('leaves the composer untouched when the capture is cancelled', async () => {
+    renderChatPage([msg('user', 'see this', { ts: '2026-08-12T07:00:00Z' })])
+    await waitFor(() => expect(inputProps).not.toBeNull())
+    apiSpy('screenshot').mockRejectedValue(new Error('user cancelled'))
+    await act(async () => { inputProps!.onScreenshot!() })
+    await waitFor(() => expect(inputProps!.uploading).toBe(false))
+    expect(inputProps!.pendingFiles).toEqual([])
+  })
+
+  it('stages nothing when the capture returns no path', async () => {
+    renderChatPage([msg('user', 'see this', { ts: '2026-08-12T07:00:00Z' })])
+    await waitFor(() => expect(inputProps).not.toBeNull())
+    apiSpy('screenshot').mockResolvedValue({ path: '' })
+    await act(async () => { inputProps!.onScreenshot!() })
+    await waitFor(() => expect(inputProps!.uploading).toBe(false))
+    expect(inputProps!.pendingFiles).toEqual([])
+  })
+})

--- a/website/src/test/ChatSidebarW3Coverage.test.tsx
+++ b/website/src/test/ChatSidebarW3Coverage.test.tsx
@@ -1,0 +1,534 @@
+/**
+ * Coverage for two ChatSidebar surfaces no sibling suite drives end to end:
+ *
+ *  1. The LIST-VIEW folder header — its collapse toggle, double-click rename,
+ *     and every item of its ⋯ menu (Rename, New subfolder, Move folder to,
+ *     Folder settings, Hide when empty, Delete folder) plus the row's
+ *     "new chat in folder" button. The sibling suites assert the menu's items
+ *     are PRESENT; here they are activated, so the folder mutations behind them
+ *     (create / delete / optimistic PATCH + rollback) run.
+ *  2. The sort-and-filter menu's write paths: toggling a filter on and clearing
+ *     it from its chip, choosing a sort order, "Show all folders", and the
+ *     Recent submenu's preset buttons + custom amount field.
+ *
+ * `FolderConfigModal` is stubbed to a submit/close pair: the modal itself is
+ * covered by its own suite, and what is under test here is the sidebar's
+ * `onSubmit` — which builds the create payload, and for edit mode builds a PATCH
+ * from `draft.touched` only and rethrows so a rejected save keeps the modal open.
+ *
+ * Radix menus open on keyboard activation (Enter) — the path happy-dom handles;
+ * their pointer path needs real PointerEvents. Submenus open on ArrowRight,
+ * which is the one key the Recent row's own onKeyDown lets fall through.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import type { RootState } from '../store'
+import type { ChatFolder } from '../types'
+
+// Render framer-motion elements as plain DOM because happy-dom cannot run projection.
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: Record<string, unknown>, ref: React.Ref<unknown>) => {
+      const clean: Record<string, unknown> = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children as React.ReactNode)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children?: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: { children?: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+
+/** What the stubbed modal hands back, and what the sidebar handed it. */
+const modal = vi.hoisted(() => ({
+  draft: {
+    name: 'Gamma', color: '', projectDir: '', defaultAgent: '',
+    touched: [] as string[],
+  },
+  props: null as Record<string, unknown> | null,
+  submitError: null as unknown,
+}))
+vi.mock('../components/FolderConfigModal', async () => {
+  const React = await import('react')
+  return {
+    default: (props: Record<string, unknown>) => {
+      modal.props = props
+      const folder = props.folder as ChatFolder | undefined
+      // One button per wrapper: three sibling <button>s in one parent trip the
+      // max-two-buttons-per-row review rule, test files included.
+      return React.createElement('div', {
+        'data-testid': 'folder-modal',
+        'data-mode': String(props.mode),
+        'data-parent': String(props.parentId ?? ''),
+        'data-folder': folder?.id ?? '',
+      }, [
+        React.createElement('div', { key: 's' }, React.createElement('button', {
+          type: 'button',
+          'data-testid': 'folder-modal-submit',
+          onClick: () => {
+            modal.submitError = null
+            void (props.onSubmit as (d: unknown) => Promise<void>)(modal.draft)
+              .catch((err: unknown) => { modal.submitError = err })
+          },
+        }, 'save')),
+        React.createElement('div', { key: 'c' }, React.createElement('button', {
+          type: 'button',
+          'data-testid': 'folder-modal-close',
+          onClick: props.onClose as () => void,
+        }, 'cancel')),
+      ])
+    },
+  }
+})
+
+const cfg = vi.hoisted(() => ({
+  value: { tagColumnsEnabled: false, confirmCloseSession: false, defaultAutopilot: false } as Record<string, unknown>,
+}))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => cfg.value,
+  saveChatConfig: vi.fn(),
+}))
+
+const mocks = vi.hoisted(() => ({
+  chatFolders: vi.fn(),
+  createChatFolder: vi.fn(),
+  updateChatFolder: vi.fn(),
+  deleteChatFolder: vi.fn(),
+  createChatSlot: vi.fn(),
+  setSlotColor: vi.fn(),
+  sessions: vi.fn(),
+  sessionsSearch: vi.fn(),
+  chatTags: vi.fn(),
+  tagColumns: vi.fn(),
+  kirocrewConfig: vi.fn(),
+}))
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy(mocks as unknown as Record<string, unknown>, {
+    get: (target, prop: string) => (prop in target ? target[prop] : vi.fn().mockResolvedValue([])),
+  }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatSidebar from '../pages/ChatSidebar'
+import { RECENT_UNIT_MS, DEFAULT_RECENT_WINDOW_MS } from '../pages/recentWindow'
+
+interface TestSlot {
+  key: string
+  title?: string
+  running: boolean
+  messages?: number
+  folder_id?: string
+  last_ts?: string
+}
+
+const ALPHA: ChatFolder = { id: 'f1', name: 'Alpha', order: 0 }
+const BETA: ChatFolder = { id: 'f2', name: 'Beta', order: 1 }
+const FILED: TestSlot = { key: 'k1', title: 'filed chat', running: false, messages: 2, folder_id: 'f1' }
+const LOOSE: TestSlot = { key: 'k2', title: 'loose chat', running: false, messages: 1 }
+
+function renderSidebar(opts: { slots?: TestSlot[]; folders?: ChatFolder[] } = {}) {
+  const slots = opts.slots ?? [FILED, LOOSE]
+  const folders = opts.folders ?? [ALPHA]
+  mocks.chatFolders.mockResolvedValue(folders)
+  // Redux Toolkit REPLACES a slice's state with `preloadedState` rather than
+  // merging it with initialState, so spread the genuine defaults first — a
+  // hand-rolled partial drops keys the reducers legitimately assume.
+  const defaults = createTestStore().getState()
+  const store = createTestStore({
+    dashboard: {
+      ...defaults.dashboard,
+      status: {}, connected: true, slots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as unknown as RootState['dashboard'],
+    chat: {
+      ...defaults.chat,
+      activeSlot: null, slotStatusDetail: {}, subagents: {}, slotActivity: {},
+      goalLoops: {}, workflowRuns: {}, subagentQueued: {}, slotHistory: [],
+    } as unknown as RootState['chat'],
+  })
+  // staleTime + refetchOnMount keep the seeded folder list authoritative. An
+  // on-mount refetch resolving mid-test re-renders the folder rows and unmounts
+  // an open ⋯ menu underneath the assertions.
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity, refetchOnMount: false },
+      mutations: { retry: false },
+    },
+  })
+  qc.setQueryData(['chat-folders'], folders)
+  qc.setQueryData(['tag-columns'], [])
+  const view = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots as never} activeSlot={null} unreadSlots={[]}
+              history={[]} historyHasMore={false}
+              defaultAgent="" installedAgents={[{ name: 'builder', source: 'builtin' }]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return { ...view, store, qc }
+}
+
+/**
+ * Open a folder header's ⋯ menu. Keyboard activation is the path happy-dom
+ * handles (the pointer path needs real PointerEvents), and the menu survives
+ * only for the current tick: Radix tears it down on the first macrotask because
+ * nothing in happy-dom holds the focus it grabs. That is why this helper is
+ * SYNCHRONOUS and every caller must drive the item it wants in the same tick,
+ * with no await in between — the item's onClick still runs, and what it sets in
+ * motion (a mutation, the rename field, the folder modal) outlives the menu.
+ */
+function openFolderMenu(folderId: string) {
+  fireEvent.keyDown(screen.getByTestId(`folder-menu-${folderId}`), { key: 'Enter' })
+  // The menu is up in this tick; confirm it so a silent no-open cannot
+  // masquerade as a passing negative assertion.
+  expect(screen.getByTestId(`folder-settings-${folderId}`)).toBeTruthy()
+}
+
+/**
+ * The folder-header rename field. Every keystroke re-renders the sidebar and
+ * replaces this input's DOM node, so a captured reference goes stale after the
+ * first event — re-read it before each interaction instead. It is the only
+ * textbox in the sidebar with no placeholder (the session search box has one).
+ */
+function folderRenameField(): HTMLInputElement {
+  const el = screen.getAllByRole('textbox').find(node => !node.getAttribute('placeholder'))
+  if (!el) throw new Error('folder rename field is not mounted')
+  return el as HTMLInputElement
+}
+
+/** Open the sort-and-filter menu and wait for its Filter heading. */
+async function openFilterMenu() {
+  fireEvent.keyDown(screen.getByLabelText('Sort and filter sessions'), { key: 'Enter' })
+  await screen.findByText('Filter')
+}
+
+beforeEach(() => {
+  // The api stubs live in a hoisted object shared across tests, so their call
+  // logs have to be cleared here or a later negative assertion inherits an
+  // earlier test's calls.
+  vi.clearAllMocks()
+  localStorage.clear()
+  cfg.value = { tagColumnsEnabled: false, confirmCloseSession: false, defaultAutopilot: false }
+  modal.props = null
+  modal.submitError = null
+  modal.draft = { name: 'Gamma', color: '', projectDir: '', defaultAgent: '', touched: [] }
+  mocks.chatFolders.mockResolvedValue([ALPHA])
+  mocks.createChatFolder.mockResolvedValue({ id: 'f9', name: 'Gamma', order: 2 })
+  mocks.updateChatFolder.mockResolvedValue({ ok: true })
+  mocks.deleteChatFolder.mockResolvedValue({ ok: true })
+  mocks.createChatSlot.mockResolvedValue({ key: 'k-new', title: '', running: false, messages: 0 })
+  mocks.setSlotColor.mockResolvedValue({ ok: true })
+  mocks.sessions.mockResolvedValue({ sessions: [], has_more: false })
+  mocks.sessionsSearch.mockResolvedValue({ sessions: [] })
+  mocks.chatTags.mockResolvedValue([])
+  mocks.tagColumns.mockResolvedValue([])
+  mocks.kirocrewConfig.mockResolvedValue({ dashboard: { recent_tint_count: 3 } })
+})
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('ChatSidebar — list-view folder header', () => {
+  it('collapses the folder through the row toggle', async () => {
+    renderSidebar()
+    fireEvent.click(screen.getByLabelText('Collapse folder Alpha'))
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalledWith('f1', { collapsed: true }))
+  })
+
+  it('renames from the ⋯ menu and commits the trimmed name on Enter', async () => {
+    renderSidebar()
+    openFolderMenu('f1')
+    fireEvent.click(screen.getByTestId('folder-rename-f1'))
+    fireEvent.change(folderRenameField(), { target: { value: '  Renamed  ' } })
+    fireEvent.keyDown(folderRenameField(), { key: 'Enter' })
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalledWith('f1', { name: 'Renamed' }))
+    // Committing closes the field.
+    await waitFor(() => expect(screen.getAllByRole('textbox').every(n => n.getAttribute('placeholder'))).toBe(true))
+  })
+
+  it('opens the same field on a double-click of the name, and Escape abandons it', async () => {
+    renderSidebar()
+    fireEvent.doubleClick(screen.getByTitle('Double-click to rename'))
+    fireEvent.change(folderRenameField(), { target: { value: 'Nope' } })
+    fireEvent.keyDown(folderRenameField(), { key: 'Escape' })
+    await waitFor(() => expect(screen.getAllByRole('textbox').every(n => n.getAttribute('placeholder'))).toBe(true))
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+    expect(screen.getByTitle('Double-click to rename').textContent).toBe('Alpha')
+  })
+
+  it('does not PATCH a name that trims to nothing', async () => {
+    renderSidebar()
+    openFolderMenu('f1')
+    fireEvent.click(screen.getByTestId('folder-rename-f1'))
+    fireEvent.change(folderRenameField(), { target: { value: '   ' } })
+    fireEvent.keyDown(folderRenameField(), { key: 'Enter' })
+    await waitFor(() => expect(screen.getAllByRole('textbox').every(n => n.getAttribute('placeholder'))).toBe(true))
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+  })
+
+  it('creates a subfolder seeded with this folder as the parent', async () => {
+    renderSidebar()
+    openFolderMenu('f1')
+    fireEvent.click(screen.getByText('New subfolder'))
+    const host = await screen.findByTestId('folder-modal')
+    expect(host.getAttribute('data-mode')).toBe('create')
+    expect(host.getAttribute('data-parent')).toBe('f1')
+    modal.draft = { name: 'Gamma', color: '#abcdef', projectDir: '', defaultAgent: 'builder', touched: ['name'] }
+    fireEvent.click(screen.getByTestId('folder-modal-submit'))
+    await waitFor(() => expect(mocks.createChatFolder).toHaveBeenCalledWith(
+      'Gamma', 'f1', { project_dir: undefined, default_agent: 'builder', color: '#abcdef' },
+    ))
+    // Only a successful create closes the modal.
+    await waitFor(() => expect(screen.queryByTestId('folder-modal')).toBeNull())
+  })
+
+  it('PATCHes only the fields the settings modal reports as touched', async () => {
+    renderSidebar()
+    openFolderMenu('f1')
+    fireEvent.click(screen.getByText('Folder settings'))
+    const host = await screen.findByTestId('folder-modal')
+    expect(host.getAttribute('data-mode')).toBe('edit')
+    expect(host.getAttribute('data-folder')).toBe('f1')
+    modal.draft = { name: 'Edited', color: '', projectDir: '/tmp/ignored', defaultAgent: 'x', touched: ['name', 'color'] }
+    fireEvent.click(screen.getByTestId('folder-modal-submit'))
+    // '' is a legitimate color instruction (clears back to gray), so it rides
+    // along; projectDir/defaultAgent were untouched and must not.
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalledWith('f1', { name: 'Edited', color: '' }))
+    await waitFor(() => expect(screen.queryByTestId('folder-modal')).toBeNull())
+  })
+
+  it('closes an untouched settings save without issuing a PATCH', async () => {
+    renderSidebar()
+    openFolderMenu('f1')
+    fireEvent.click(screen.getByText('Folder settings'))
+    await screen.findByTestId('folder-modal')
+    modal.draft = { name: 'Alpha', color: '', projectDir: '', defaultAgent: '', touched: [] }
+    fireEvent.click(screen.getByTestId('folder-modal-submit'))
+    await waitFor(() => expect(screen.queryByTestId('folder-modal')).toBeNull())
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+  })
+
+  it('rethrows a rejected settings save so the modal can show the reason', async () => {
+    mocks.updateChatFolder.mockRejectedValue(new Error('project_dir is not a directory'))
+    renderSidebar()
+    openFolderMenu('f1')
+    fireEvent.click(screen.getByText('Folder settings'))
+    await screen.findByTestId('folder-modal')
+    modal.draft = { name: 'Edited', color: '', projectDir: '/nope', defaultAgent: '', touched: ['projectDir'] }
+    fireEvent.click(screen.getByTestId('folder-modal-submit'))
+    await waitFor(() => expect(modal.submitError).toBeInstanceOf(Error))
+    // Still open — the sidebar never called onClose.
+    expect(screen.getByTestId('folder-modal')).toBeTruthy()
+    // The optimistic rename was rolled back, so the header shows the old name.
+    await waitFor(() => expect(screen.getByTitle('Double-click to rename').textContent).toBe('Alpha'))
+  })
+
+  it('re-parents the folder from the Move folder to submenu', async () => {
+    renderSidebar({ folders: [ALPHA, BETA] })
+    openFolderMenu('f1')
+    fireEvent.keyDown(screen.getByText('Move folder to'), { key: 'ArrowRight' })
+    fireEvent.click(screen.getByTitle('Beta'))
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalledWith('f1', { parent_id: 'f2' }))
+  })
+
+  it('ignores a Move folder to pick that is already the current parent', async () => {
+    renderSidebar({ folders: [ALPHA, BETA] })
+    openFolderMenu('f1')
+    fireEvent.keyDown(screen.getByText('Move folder to'), { key: 'ArrowRight' })
+    fireEvent.click(screen.getByTitle('No folder (root)'))
+    await waitFor(() => expect(screen.queryByText('Move folder to')).toBeNull())
+    expect(mocks.updateChatFolder).not.toHaveBeenCalled()
+  })
+
+  it('offers Hide when empty only for a folder with archived sessions and no live ones', async () => {
+    const archived: ChatFolder = { ...ALPHA, history_count: 2 }
+    renderSidebar({ slots: [LOOSE], folders: [archived] })
+    openFolderMenu('f1')
+    fireEvent.click(screen.getByTestId('folder-hide-f1'))
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalledWith('f1', { hidden: true }))
+  })
+
+  it('withholds Hide when empty while the folder still holds a session', async () => {
+    renderSidebar({ slots: [FILED], folders: [{ ...ALPHA, history_count: 2 }] })
+    openFolderMenu('f1')
+    expect(screen.queryByTestId('folder-hide-f1')).toBeNull()
+  })
+
+  it('deletes the folder only once the confirm is accepted', async () => {
+    const confirmFn = vi.fn().mockReturnValue(false)
+    vi.stubGlobal('confirm', confirmFn)
+    renderSidebar()
+    openFolderMenu('f1')
+    fireEvent.click(screen.getByTestId('folder-delete-f1'))
+    expect(confirmFn).toHaveBeenCalledWith('Delete "Alpha"? Sessions will be ungrouped.')
+    expect(mocks.deleteChatFolder).not.toHaveBeenCalled()
+
+    confirmFn.mockReturnValue(true)
+    openFolderMenu('f1')
+    fireEvent.click(screen.getByTestId('folder-delete-f1'))
+    await waitFor(() => expect(mocks.deleteChatFolder).toHaveBeenCalledWith('f1'))
+  })
+
+  it('starts a chat inside the folder from the row button', async () => {
+    renderSidebar()
+    fireEvent.click(screen.getByLabelText('New chat in Alpha'))
+    await waitFor(() => expect(mocks.createChatSlot).toHaveBeenCalled())
+    // Folder membership rides the create payload (9th arg) so the slot is
+    // published in its final location instead of jumping in from the root.
+    expect(mocks.createChatSlot.mock.calls[0][8]).toBe('f1')
+  })
+
+  it('expands a collapsed folder before creating the chat inside it', async () => {
+    renderSidebar({ folders: [{ ...ALPHA, collapsed: true }] })
+    fireEvent.click(screen.getByLabelText('New chat in Alpha'))
+    await waitFor(() => expect(mocks.updateChatFolder).toHaveBeenCalledWith('f1', { collapsed: false }))
+  })
+
+  it('logs a failed folder-scoped create instead of failing silently', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.createChatSlot.mockRejectedValue(new Error('no capacity'))
+    renderSidebar()
+    fireEvent.click(screen.getByLabelText('New chat in Alpha'))
+    await waitFor(() => expect(err).toHaveBeenCalledWith('Failed to create chat in folder:', expect.anything()))
+  })
+})
+
+describe('ChatSidebar — sort and filter menu', () => {
+  it('turns a filter on from the menu and clears it from its chip', async () => {
+    renderSidebar()
+    await openFilterMenu()
+    fireEvent.click(screen.getByText('Unread'))
+    const chip = await screen.findByLabelText('Clear Unread filter')
+    expect(localStorage.getItem('mc-session-unread-only')).toBe('1')
+    fireEvent.click(chip)
+    await waitFor(() => expect(screen.queryByLabelText('Clear Unread filter')).toBeNull())
+    expect(localStorage.getItem('mc-session-unread-only')).toBe('0')
+  })
+
+  it('drains a persisted unread filter that loads with nothing unread', async () => {
+    // Restoring "unread only" against an empty unread set would show an empty
+    // list with no explanation, so the filter turns itself off on the first
+    // post-load tick and clears its persistence key.
+    localStorage.setItem('mc-session-unread-only', '1')
+    renderSidebar()
+    await waitFor(() => expect(localStorage.getItem('mc-session-unread-only')).toBe('0'))
+    expect(screen.queryByLabelText('Clear Unread filter')).toBeNull()
+    expect(screen.getByText('loose chat')).toBeTruthy()
+  })
+
+  it('persists the chosen sort order', async () => {
+    renderSidebar()
+    await openFilterMenu()
+    fireEvent.click(screen.getByText('A → Z'))
+    await waitFor(() => expect(localStorage.getItem('mc-session-sort')).toBe('name-asc'))
+  })
+
+  it('restores every hidden folder in one action', async () => {
+    localStorage.setItem('mc-flat-hidden-folders', JSON.stringify(['f1', 'f2']))
+    renderSidebar({ folders: [ALPHA, BETA] })
+    await openFilterMenu()
+    fireEvent.click(await screen.findByTestId('folder-filter-show-all'))
+    await waitFor(() => expect(localStorage.getItem('mc-flat-hidden-folders')).toBe('[]'))
+    // With nothing hidden the reset row retires itself.
+    expect(screen.queryByTestId('folder-filter-show-all')).toBeNull()
+  })
+
+  it('toggles the Recent filter from its submenu row, by pointer and by keyboard', async () => {
+    renderSidebar()
+    await openFilterMenu()
+    const row = await screen.findByRole('menuitem', { name: /Recent/ })
+    fireEvent.click(row)
+    await waitFor(() => expect(localStorage.getItem('mc-session-recent-only')).toBe('1'))
+    // Enter is preventDefaulted so it toggles instead of opening the submenu.
+    fireEvent.keyDown(row, { key: 'Enter' })
+    await waitFor(() => expect(localStorage.getItem('mc-session-recent-only')).toBe('0'))
+  })
+
+  it('commits a preset window from the Recent picker', async () => {
+    renderSidebar()
+    await openFilterMenu()
+    fireEvent.keyDown(await screen.findByRole('menuitem', { name: /Recent/ }), { key: 'ArrowRight' })
+    fireEvent.click(await screen.findByText('1 week'))
+    await waitFor(() => expect(localStorage.getItem('mc-session-recent-window-ms')).toBe(String(7 * RECENT_UNIT_MS.days)))
+    // The preset re-seeds the custom drafts so the boxes track the choice.
+    expect(await screen.findByLabelText('Custom recency amount')).toHaveValue(7)
+  })
+
+  it('clamps a custom amount and commits it on Enter', async () => {
+    renderSidebar()
+    await openFilterMenu()
+    fireEvent.keyDown(await screen.findByRole('menuitem', { name: /Recent/ }), { key: 'ArrowRight' })
+    const amount = await screen.findByLabelText('Custom recency amount')
+    fireEvent.change(amount, { target: { value: '0' } })
+    fireEvent.keyDown(amount, { key: 'Enter' })
+    // 0 is below the minimum, so it clamps to 1 of the current unit (hours).
+    await waitFor(() => expect(localStorage.getItem('mc-session-recent-window-ms')).toBe(String(RECENT_UNIT_MS.hours)))
+    expect(amount).toHaveValue(1)
+  })
+
+  it('commits a custom amount on blur too', async () => {
+    renderSidebar()
+    await openFilterMenu()
+    fireEvent.keyDown(await screen.findByRole('menuitem', { name: /Recent/ }), { key: 'ArrowRight' })
+    const amount = await screen.findByLabelText('Custom recency amount')
+    fireEvent.change(amount, { target: { value: '3' } })
+    fireEvent.blur(amount)
+    await waitFor(() => expect(localStorage.getItem('mc-session-recent-window-ms')).toBe(String(3 * RECENT_UNIT_MS.hours)))
+  })
+
+  it('falls back to the default window when localStorage throws', async () => {
+    // Private mode / disabled storage: the read happens in a useState
+    // initializer during render, so a throw must not take the sidebar down.
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => {
+      if (key === 'mc-session-recent-window-ms') throw new Error('storage disabled')
+      return null
+    })
+    renderSidebar()
+    await openFilterMenu()
+    const row = await screen.findByRole('menuitem', { name: /Recent/ })
+    expect(row.textContent).toContain('1h')
+    expect(DEFAULT_RECENT_WINDOW_MS).toBe(RECENT_UNIT_MS.hours)
+  })
+})

--- a/website/src/test/GalleryPanelCoverage.test.tsx
+++ b/website/src/test/GalleryPanelCoverage.test.tsx
@@ -1,0 +1,903 @@
+/**
+ * Mochi `GalleryPanel` — first tests for
+ * `apps/mochi/src/renderer/GalleryPanel.tsx`.
+ *
+ * The gallery window is the whole appearance-pack surface: the card grid with
+ * its per-format thumbnails, the detail sheet (state / mood grids, apply,
+ * export, edit, delete), the header's four entry points into the editors, the
+ * toast + error banners, and the three main-process broadcasts it subscribes
+ * to. None of that was covered.
+ *
+ * What is mocked, and why:
+ *   - `mochiApi` is the component's ONLY seam to the main process, so it is the
+ *     single behavioural double. Every state machine below is driven by what
+ *     that seam returns, including its failure shapes.
+ *   - `PackEditor` / `SpriteImporter` / `PetdexImporter` / `ColorCustomizerPanel`
+ *     are separate multi-step surfaces with their own tests; here they stand in
+ *     as prop harnesses so the gallery's OWN navigation, prefill and
+ *     refused-save wiring is what gets asserted.
+ *   - `SpriteRenderer` / `LottieRenderer` decode through `new Image()` and
+ *     lottie-web, neither of which settles under happy-dom. Stubbed so the
+ *     thumbnail BRANCH SELECTION (svg / lottie / sprite / no-art) and the props
+ *     handed down (frame size, fps, mirror transform) are what is checked.
+ *
+ * Real code that is deliberately NOT mocked: `toDataUri`,
+ * `applySvgColorMap`, `resolveActivePackId`, and the i18n catalog — the colour
+ * recolouring of the default-mochi thumbnail is asserted through the real
+ * transform, and every label is looked up with `i18nT` so a copy edit cannot
+ * silently break these tests.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup, act, within } from '@testing-library/react'
+
+import type { PackMeta } from '../apps/mochi/src/shared/appearanceTypes'
+import { i18nT } from '../i18n/t'
+
+// ── Doubles ────────────────────────────────────────────────────────────────
+
+type Fn = ReturnType<typeof vi.fn>
+
+const H = vi.hoisted(() => {
+  const listeners: {
+    active?: (data?: { packId?: string }) => void
+    packs?: () => void
+    color?: (data: { packId: string; colorMap: Record<string, string> }) => void
+  } = {}
+  const offs = { active: 0, packs: 0, color: 0 }
+  /** Payload the SpriteImporter stub hands back through `onDone`. */
+  const spriteDone: { payload: Record<string, unknown> } = { payload: {} }
+  const api: Record<string, unknown> = {}
+
+  const install = () => {
+    for (const k of Object.keys(api)) delete api[k]
+    api.galleryListPacks = vi.fn()
+    api.galleryGetPackDetail = vi.fn()
+    api.getMochiConfig = vi.fn()
+    api.presetsGetColorMap = vi.fn()
+    api.gallerySetActive = vi.fn()
+    api.galleryExport = vi.fn()
+    api.galleryDelete = vi.fn()
+    api.galleryImportBundle = vi.fn()
+    api.gallerySaveSpritePack = vi.fn()
+    api.onGalleryActiveChanged = vi.fn((cb: (d?: { packId?: string }) => void) => {
+      listeners.active = cb
+      return () => { offs.active += 1 }
+    })
+    api.onGalleryPacksChanged = vi.fn((cb: () => void) => {
+      listeners.packs = cb
+      return () => { offs.packs += 1 }
+    })
+    api.onColorMapChanged = vi.fn((cb: (d: { packId: string; colorMap: Record<string, string> }) => void) => {
+      listeners.color = cb
+      return () => { offs.color += 1 }
+    })
+    offs.active = 0
+    offs.packs = 0
+    offs.color = 0
+    spriteDone.payload = {}
+  }
+
+  return { api, listeners, offs, spriteDone, install }
+})
+
+vi.mock('../apps/mochi/src/mochiApi', () => ({ api: H.api }))
+
+vi.mock('../apps/mochi/src/renderer/PackEditor', () => ({
+  PackEditor: ({ existingPack, onSave, onCancel }: {
+    existingPack?: { name: string }
+    onSave: () => void
+    onCancel: () => void
+  }) => (
+    <div data-testid="pack-editor">
+      <span>editor-for:{existingPack ? existingPack.name : 'new-pack'}</span>
+      <div><button onClick={onSave}>editor-save</button></div>
+      <div><button onClick={onCancel}>editor-cancel</button></div>
+    </div>
+  ),
+}))
+
+vi.mock('../apps/mochi/src/renderer/PetdexImporter', () => ({
+  PetdexImporter: ({ onReady, onUseFile, onCancel }: {
+    onReady: (next: { name: string }) => void
+    onUseFile: () => void
+    onCancel: () => void
+  }) => (
+    <div data-testid="petdex-importer">
+      <div><button onClick={() => onReady({ name: 'Bulbasaur' })}>petdex-ready</button></div>
+      <div><button onClick={onUseFile}>petdex-use-file</button></div>
+      <div><button onClick={onCancel}>petdex-cancel</button></div>
+    </div>
+  ),
+}))
+
+vi.mock('../apps/mochi/src/renderer/SpriteImporter', () => ({
+  SpriteImporter: ({ existingPack, prefill, saveError, onDone, onCancel }: {
+    existingPack?: { name: string }
+    prefill?: { name: string }
+    saveError?: string | null
+    onDone: (result: Record<string, unknown>) => void
+    onCancel: () => void
+  }) => (
+    <div data-testid="sprite-importer">
+      <span>sprite-for:{existingPack ? existingPack.name : 'new-pack'}</span>
+      <span data-testid="sprite-prefill">{prefill ? prefill.name : 'no-prefill'}</span>
+      {saveError ? <span data-testid="sprite-save-error">{saveError}</span> : null}
+      <div><button onClick={() => onDone(H.spriteDone.payload)}>sprite-done</button></div>
+      <div><button onClick={onCancel}>sprite-cancel</button></div>
+    </div>
+  ),
+}))
+
+vi.mock('../apps/mochi/src/renderer/ColorCustomizer', () => ({
+  ColorCustomizerPanel: ({ idleSvgContent }: { idleSvgContent: string }) => (
+    <div data-testid="color-panel">{idleSvgContent}</div>
+  ),
+}))
+
+vi.mock('../apps/mochi/src/renderer/SpriteRenderer', () => ({
+  SpriteRenderer: ({ src, frameWidth, frameHeight, fps, displaySize }: {
+    src: string
+    frameWidth: number
+    frameHeight: number
+    fps?: number
+    displaySize?: number
+  }) => (
+    <div
+      data-testid="sprite-renderer"
+      data-src={src}
+      data-fw={String(frameWidth)}
+      data-fh={String(frameHeight)}
+      data-fps={String(fps)}
+      data-size={String(displaySize)}
+    />
+  ),
+}))
+
+vi.mock('../apps/mochi/src/renderer/LottieRenderer', () => ({
+  LottieRenderer: ({ animationData, width }: { animationData: string; width?: number }) => (
+    <div data-testid="lottie-renderer" data-anim={animationData} data-w={String(width)} />
+  ),
+}))
+
+const { GalleryPanel } = await import('../apps/mochi/src/renderer/GalleryPanel')
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const ORANGE = '#F5A623'
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg"><circle r="4" fill="${ORANGE}" /></svg>`
+const LOTTIE = '{"v":"5.7.1","layers":[]}'
+
+const svg = (content = SVG) => ({ content, format: 'svg' as const })
+const lottie = (content = LOTTIE) => ({ content, format: 'lottie' as const })
+const sprite = (content: string) => ({ content, format: 'sprite' as const })
+
+const meta = (over: Partial<PackMeta> & { id: string; name: string }): PackMeta => ({
+  author: 'Kiro',
+  description: '',
+  type: 'built-in',
+  format: 'svg',
+  thumbnail: '',
+  ...over,
+})
+
+const MOCHI = meta({ id: 'default-mochi', name: 'Mochi Cat', description: 'a soft round cat' })
+const GHOST = meta({ id: 'kiro-ghost', name: 'Kiro Ghost', format: 'lottie' })
+const PIXEL = meta({ id: 'pixel-bot', name: 'Pixel Bot', author: 'Zed', type: 'custom', format: 'sprite' })
+const DRAWN = meta({ id: 'hand-drawn', name: 'Hand Drawn', author: 'Zed', type: 'custom' })
+const BLANK = meta({ id: 'no-art', name: 'No Art', author: 'Nobody', type: 'custom' })
+
+const PACKS: PackMeta[] = [MOCHI, GHOST, PIXEL, DRAWN, BLANK]
+
+interface Detail {
+  meta: PackMeta
+  animations: Record<string, { content: string; format: 'svg' | 'lottie' | 'sprite' }>
+  sprite?: { frameWidth: number; frameHeight: number; fps: number; flipX?: boolean }
+  flipX?: boolean
+}
+
+/** `offline` is deliberately absent so the "missing required slot" cell renders. */
+const DETAILS: Record<string, Detail | null> = {
+  'default-mochi': {
+    meta: MOCHI,
+    animations: {
+      idle: svg(),
+      walking: svg(),
+      thinking: svg(),
+      working: svg(),
+      error: svg(),
+      peeking: svg(),
+      happy: svg(),
+      // Present but empty: the pack declares the slot and ships no art, which is
+      // the ambiguity AnimThumbnail warns about.
+      sleepy: svg(''),
+    },
+  },
+  'kiro-ghost': {
+    meta: GHOST,
+    animations: { idle: lottie(), walking: lottie() },
+    flipX: true,
+  },
+  'pixel-bot': {
+    meta: PIXEL,
+    animations: { idle: sprite('QUJD'), walking: sprite('data:image/png;base64,REVG') },
+    sprite: { frameWidth: 48, frameHeight: 24, fps: 9, flipX: true },
+  },
+  'hand-drawn': { meta: DRAWN, animations: { idle: svg(), walking: svg() } },
+  'no-art': { meta: BLANK, animations: {} },
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const fn = (name: string): Fn => H.api[name] as Fn
+
+/** The silenced `console.warn` spy installed for every test. */
+let warnSpy: Fn
+
+const t = (key: string, vars?: Record<string, unknown>) => i18nT(key, vars)
+
+function cardFor(name: string): HTMLElement {
+  const all = Array.from(document.querySelectorAll('[aria-pressed]')) as HTMLElement[]
+  const hit = all.find((el) => el.textContent?.includes(name))
+  if (!hit) throw new Error(`no pack card for ${name}`)
+  return hit
+}
+
+/**
+ * The overlay and the sheet, in that order.
+ *
+ * Queried by the explicit attribute rather than `getAllByRole('presentation')`:
+ * every `alt=""` thumbnail is ALSO role=presentation, so the role query returns
+ * the images too and "the sheet" would resolve to a thumbnail.
+ */
+function sheetNodes(): HTMLElement[] {
+  return Array.from(document.querySelectorAll('div[role="presentation"]')) as HTMLElement[]
+}
+
+function sheet(): HTMLElement {
+  const nodes = sheetNodes()
+  if (nodes.length === 0) throw new Error('detail sheet is not open')
+  return nodes[nodes.length - 1]
+}
+
+/** The decoded `src` of a card's thumbnail image. */
+function thumbSrc(name: string): string {
+  const img = cardFor(name).querySelector('img')
+  if (!img) throw new Error(`no thumbnail image for ${name}`)
+  return decodeURIComponent(img.getAttribute('src') ?? '')
+}
+
+async function mount() {
+  const view = render(<GalleryPanel />)
+  await waitFor(() => expect(screen.queryByText(t('apps.mochi.gallery.loading'))).toBeNull())
+  return view
+}
+
+async function open(name: string) {
+  fireEvent.click(cardFor(name))
+  await waitFor(() => expect(sheetNodes().length).toBeGreaterThan(0))
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  // The empty-slot fixture makes AnimThumbnail warn by design; silenced here so
+  // only the test that asserts the warning cares about it.
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {}) as unknown as Fn
+  H.install()
+  fn('galleryListPacks').mockResolvedValue(PACKS)
+  fn('galleryGetPackDetail').mockImplementation((id: string) =>
+    Promise.resolve(DETAILS[id] ?? null))
+  fn('getMochiConfig').mockResolvedValue({ activeAppearance: 'default-mochi' })
+  fn('presetsGetColorMap').mockResolvedValue({})
+  fn('gallerySetActive').mockResolvedValue({ ok: true })
+  fn('galleryExport').mockResolvedValue({ ok: true })
+  fn('galleryDelete').mockResolvedValue({ ok: true })
+  fn('galleryImportBundle').mockResolvedValue({ ok: true })
+  fn('gallerySaveSpritePack').mockResolvedValue({ ok: true, packId: 'pixel-bot' })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+// ── Grid ───────────────────────────────────────────────────────────────────
+
+describe('GalleryPanel — grid', () => {
+  it('shows the loading line first, then one card per pack', async () => {
+    render(<GalleryPanel />)
+    expect(screen.getByText(t('apps.mochi.gallery.loading'))).toBeTruthy()
+
+    await waitFor(() => expect(screen.queryByText(t('apps.mochi.gallery.loading'))).toBeNull())
+    for (const p of PACKS) expect(cardFor(p.name)).toBeTruthy()
+    expect(within(cardFor('Pixel Bot')).getByText('Zed')).toBeTruthy()
+    expect(within(cardFor('Pixel Bot')).getByText(t('apps.mochi.gallery.custom'))).toBeTruthy()
+    expect(within(cardFor('Mochi Cat')).getByText(t('apps.mochi.gallery.built_in'))).toBeTruthy()
+  })
+
+  it('marks only the configured pack as active', async () => {
+    await mount()
+    expect(within(cardFor('Mochi Cat')).getByText(t('apps.mochi.gallery.active'))).toBeTruthy()
+    expect(within(cardFor('Kiro Ghost')).queryByText(t('apps.mochi.gallery.active'))).toBeNull()
+  })
+
+  it('renders an svg thumbnail as an inline data URI', async () => {
+    await mount()
+    const img = cardFor('Hand Drawn').querySelector('img') as HTMLImageElement
+    expect(img.getAttribute('src')).toContain('data:image/svg+xml,')
+    expect(thumbSrc('Hand Drawn')).toContain(ORANGE)
+  })
+
+  it('renders a lottie thumbnail through LottieRenderer, mirrored by the pack flag', async () => {
+    await mount()
+    const stub = within(cardFor('Kiro Ghost')).getByTestId('lottie-renderer')
+    expect(stub.getAttribute('data-anim')).toBe(LOTTIE)
+    expect(stub.getAttribute('data-w')).toBe('80')
+    expect((stub.parentElement as HTMLElement).style.transform).toBe('scaleX(-1)')
+  })
+
+  it('renders a sprite thumbnail with the pack sprite config and its flip', async () => {
+    await mount()
+    const stub = within(cardFor('Pixel Bot')).getByTestId('sprite-renderer')
+    expect(stub.getAttribute('data-src')).toBe('data:image/png;base64,QUJD')
+    expect(stub.getAttribute('data-fw')).toBe('48')
+    expect(stub.getAttribute('data-fh')).toBe('24')
+    expect(stub.getAttribute('data-fps')).toBe('9')
+    expect((stub.parentElement as HTMLElement).style.transform).toBe('scaleX(-1)')
+  })
+
+  it('falls back to the cat glyph when the pack has no idle art', async () => {
+    await mount()
+    const card = cardFor('No Art')
+    expect(card.querySelector('img')).toBeNull()
+    expect(within(card).queryByTestId('sprite-renderer')).toBeNull()
+    expect(card.querySelector('svg')).toBeTruthy()
+  })
+
+  it('keeps rendering when one pack detail lookup rejects', async () => {
+    fn('galleryGetPackDetail').mockImplementation((id: string) =>
+      id === 'kiro-ghost' ? Promise.reject(new Error('nope')) : Promise.resolve(DETAILS[id] ?? null))
+    await mount()
+    expect(cardFor('Kiro Ghost')).toBeTruthy()
+    expect(within(cardFor('Kiro Ghost')).queryByTestId('lottie-renderer')).toBeNull()
+    expect(screen.queryByText('nope')).toBeNull()
+  })
+
+  it('shows the empty state when there are no packs', async () => {
+    fn('galleryListPacks').mockResolvedValue([])
+    await mount()
+    expect(screen.getByText(t('apps.mochi.gallery.empty'))).toBeTruthy()
+  })
+
+  it('banners a pack-list failure and lets it be dismissed', async () => {
+    fn('galleryListPacks').mockRejectedValue(new Error('ipc down'))
+    await mount()
+    expect(screen.getByText('ipc down')).toBeTruthy()
+
+    fireEvent.click(screen.getByLabelText(t('apps.mochi.chatPanel.dismiss')))
+    expect(screen.queryByText('ipc down')).toBeNull()
+  })
+
+  it('falls back to the built-in pack when the config read fails', async () => {
+    fn('getMochiConfig').mockRejectedValue(new Error('no config'))
+    await mount()
+    expect(within(cardFor('Mochi Cat')).getByText(t('apps.mochi.gallery.active'))).toBeTruthy()
+    expect(fn('presetsGetColorMap')).not.toHaveBeenCalled()
+  })
+
+  it('recolours only the default-mochi thumbnail from the stored colour map', async () => {
+    fn('presetsGetColorMap').mockResolvedValue({ [ORANGE]: '#00FF00' })
+    await mount()
+    const mochi = thumbSrc('Mochi Cat')
+    const drawn = thumbSrc('Hand Drawn')
+    expect(mochi).toContain('#00FF00')
+    expect(drawn).toContain(ORANGE)
+  })
+
+  it('ignores an empty stored colour map', async () => {
+    await mount()
+    expect(thumbSrc('Mochi Cat')).toContain(ORANGE)
+  })
+})
+
+// ── Detail sheet ───────────────────────────────────────────────────────────
+
+describe('GalleryPanel — detail sheet', () => {
+  it('opens on card click with metadata and the state grid', async () => {
+    await mount()
+    await open('Mochi Cat')
+
+    const panel = sheet()
+    expect(within(panel).getByText('a soft round cat')).toBeTruthy()
+    expect(within(panel).getByText('Kiro · SVG')).toBeTruthy()
+    expect(within(panel).getByText(t('apps.mochi.gallery.states'))).toBeTruthy()
+    expect(within(panel).getByText(t('apps.mochi.state.idle'))).toBeTruthy()
+    // Optional states only appear when the pack ships them.
+    expect(within(panel).getByText(t('apps.mochi.state.peeking'))).toBeTruthy()
+    expect(within(panel).queryByText(t('apps.mochi.state.peekThinking'))).toBeNull()
+    // A required slot with no art still gets a labelled cell.
+    expect(within(panel).getByText(t('apps.mochi.state.offline'))).toBeTruthy()
+    expect(within(panel).getByText('—')).toBeTruthy()
+  })
+
+  it('lists mood animations only for packs that ship them', async () => {
+    await mount()
+    await open('Mochi Cat')
+    expect(within(sheet()).getByText(t('apps.mochi.gallery.moods'))).toBeTruthy()
+    expect(within(sheet()).getByText(t('apps.mochi.mood.happy'))).toBeTruthy()
+
+    fireEvent.click(within(sheet()).getByLabelText(t('apps.mochi.watchPanel.close')))
+    await open('Hand Drawn')
+    expect(within(sheet()).queryByText(t('apps.mochi.gallery.moods'))).toBeNull()
+  })
+
+  it('warns instead of silently drawing an empty box for a declared-but-empty slot', async () => {
+    await mount()
+    await open('Mochi Cat')
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[mochi] animation thumbnail has no usable art',
+      expect.objectContaining({ format: 'svg', contentLength: 0 }),
+    )
+  })
+
+  it('passes an already-encoded sprite frame through untouched', async () => {
+    await mount()
+    await open('Pixel Bot')
+    const stubs = within(sheet()).getAllByTestId('sprite-renderer')
+    const walking = stubs.find((s) => s.getAttribute('data-src') === 'data:image/png;base64,REVG')
+    expect(walking).toBeTruthy()
+    // Sprite-only flip: this pack carries no pack-level flag, so `sprite.flipX` wins.
+    expect((stubs[0].parentElement as HTMLElement).style.transform).toBe('scaleX(-1)')
+  })
+
+  it('toggles the sheet closed when the same card is clicked again', async () => {
+    await mount()
+    await open('Kiro Ghost')
+    fireEvent.click(cardFor('Kiro Ghost'))
+    await waitFor(() => expect(sheetNodes()).toHaveLength(0))
+  })
+
+  it('opens from the keyboard on Enter and on Space', async () => {
+    await mount()
+    fireEvent.keyDown(cardFor('Hand Drawn'), { key: 'Enter' })
+    await waitFor(() => expect(sheetNodes().length).toBeGreaterThan(0))
+    fireEvent.click(within(sheet()).getByLabelText(t('apps.mochi.watchPanel.close')))
+
+    fireEvent.keyDown(cardFor('Hand Drawn'), { key: ' ' })
+    await waitFor(() => expect(sheetNodes().length).toBeGreaterThan(0))
+  })
+
+  it('ignores unrelated keys on a card', async () => {
+    await mount()
+    fireEvent.keyDown(cardFor('Hand Drawn'), { key: 'a' })
+    expect(sheetNodes()).toHaveLength(0)
+  })
+
+  it('closes on the overlay click but not on a click inside the sheet', async () => {
+    await mount()
+    await open('Hand Drawn')
+    const nodes = sheetNodes()
+    fireEvent.click(nodes[nodes.length - 1])
+    expect(sheetNodes().length).toBeGreaterThan(0)
+
+    fireEvent.click(sheetNodes()[0])
+    await waitFor(() => expect(sheetNodes()).toHaveLength(0))
+  })
+
+  it('banners a null detail response without opening the sheet', async () => {
+    await mount()
+    fn('galleryGetPackDetail').mockResolvedValue(null)
+    fireEvent.click(cardFor('Hand Drawn'))
+
+    await waitFor(() => expect(
+      screen.getByText(t('apps.mochi.errors.load_pack_detail'))).toBeTruthy())
+    expect(sheetNodes()).toHaveLength(0)
+  })
+
+  it('banners a rejected detail response with the thrown message', async () => {
+    await mount()
+    fn('galleryGetPackDetail').mockRejectedValue(new Error('detail exploded'))
+    fireEvent.click(cardFor('Hand Drawn'))
+
+    await waitFor(() => expect(screen.getByText('detail exploded')).toBeTruthy())
+    expect(sheetNodes()).toHaveLength(0)
+  })
+
+  it('offers the colour customiser only for default-mochi', async () => {
+    await mount()
+    await open('Mochi Cat')
+    const toggle = within(sheet()).getByText(t('apps.mochi.color.customize_btn'))
+    expect(within(sheet()).getByTestId('color-panel').textContent).toBe(SVG)
+
+    fireEvent.click(toggle)
+    expect(within(sheet()).getByText(t('apps.mochi.color.hide_btn'))).toBeTruthy()
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.color.hide_btn')))
+    expect(within(sheet()).getByText(t('apps.mochi.color.customize_btn'))).toBeTruthy()
+  })
+
+  it('hides the colour customiser for every other pack', async () => {
+    await mount()
+    await open('Hand Drawn')
+    expect(within(sheet()).queryByText(t('apps.mochi.color.customize_btn'))).toBeNull()
+    expect(within(sheet()).queryByTestId('color-panel')).toBeNull()
+  })
+
+  it('shows apply for an inactive pack and the custom-pack actions only for custom packs', async () => {
+    await mount()
+    await open('Kiro Ghost')
+    expect(within(sheet()).getByText(t('apps.mochi.gallery.apply'))).toBeTruthy()
+    expect(within(sheet()).queryByText(t('apps.mochi.gallery.export'))).toBeNull()
+    expect(within(sheet()).queryByText(t('apps.mochi.gallery.delete'))).toBeNull()
+
+    fireEvent.click(within(sheet()).getByLabelText(t('apps.mochi.watchPanel.close')))
+    await open('Mochi Cat')
+    // Active pack: no apply button, and the active badge in the header instead.
+    expect(within(sheet()).queryByText(t('apps.mochi.gallery.apply'))).toBeNull()
+    expect(within(sheet()).getByText(t('apps.mochi.gallery.active'))).toBeTruthy()
+  })
+})
+
+// ── Actions ────────────────────────────────────────────────────────────────
+
+describe('GalleryPanel — actions', () => {
+  it('marks the pack active only after the write is confirmed', async () => {
+    await mount()
+    await open('Kiro Ghost')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.apply')))
+
+    await waitFor(() => expect(
+      within(sheet()).getByText(t('apps.mochi.gallery.active'))).toBeTruthy())
+    expect(fn('gallerySetActive')).toHaveBeenCalledWith('kiro-ghost')
+    expect(within(sheet()).queryByText(t('apps.mochi.gallery.apply'))).toBeNull()
+  })
+
+  it('does not mark a pack active when the write is refused', async () => {
+    fn('gallerySetActive').mockResolvedValue({ ok: false, error: 'read-only disk' })
+    await mount()
+    await open('Kiro Ghost')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.apply')))
+
+    await waitFor(() => expect(screen.getByText('read-only disk')).toBeTruthy())
+    expect(within(sheet()).getByText(t('apps.mochi.gallery.apply'))).toBeTruthy()
+  })
+
+  it('falls back to the generic apply error when the refusal carries no message', async () => {
+    fn('gallerySetActive').mockResolvedValue({ ok: false })
+    await mount()
+    await open('Kiro Ghost')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.apply')))
+
+    await waitFor(() => expect(
+      screen.getByText(t('apps.mochi.errors.apply_pack'))).toBeTruthy())
+  })
+
+  it('banners a thrown apply', async () => {
+    fn('gallerySetActive').mockRejectedValue(new Error('apply threw'))
+    await mount()
+    await open('Kiro Ghost')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.apply')))
+
+    await waitFor(() => expect(screen.getByText('apply threw')).toBeTruthy())
+  })
+
+  it('toasts a successful export and clears the toast on its own', async () => {
+    await mount()
+    await open('Pixel Bot')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.export')))
+
+    await waitFor(() => expect(
+      screen.getByText(t('apps.mochi.gallery.export_success'))).toBeTruthy())
+    expect(fn('galleryExport')).toHaveBeenCalledWith('pixel-bot')
+
+    act(() => { vi.advanceTimersByTime(2100) })
+    const toast = screen.getByText(t('apps.mochi.gallery.export_success'))
+    expect(toast.style.animation).toContain('toastOut')
+
+    act(() => { vi.advanceTimersByTime(500) })
+    expect(screen.queryByText(t('apps.mochi.gallery.export_success'))).toBeNull()
+  })
+
+  it('stays silent when the export dialog is cancelled', async () => {
+    fn('galleryExport').mockResolvedValue(null)
+    await mount()
+    await open('Pixel Bot')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.export')))
+
+    await waitFor(() => expect(fn('galleryExport')).toHaveBeenCalled())
+    expect(screen.queryByText(t('apps.mochi.gallery.export_success'))).toBeNull()
+    expect(screen.queryByText(t('apps.mochi.errors.export'))).toBeNull()
+  })
+
+  it('banners a refused and a thrown export', async () => {
+    fn('galleryExport').mockResolvedValue({ ok: false, error: 'no write access' })
+    await mount()
+    await open('Pixel Bot')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.export')))
+    await waitFor(() => expect(screen.getByText('no write access')).toBeTruthy())
+
+    fn('galleryExport').mockRejectedValue(new Error('export threw'))
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.export')))
+    await waitFor(() => expect(screen.getByText('export threw')).toBeTruthy())
+  })
+
+  it('does not delete when the confirm dialog is dismissed', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    await mount()
+    await open('Pixel Bot')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.delete')))
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      t('apps.mochi.gallery.delete_confirm', { name: 'Pixel Bot' }))
+    expect(fn('galleryDelete')).not.toHaveBeenCalled()
+    expect(sheetNodes().length).toBeGreaterThan(0)
+  })
+
+  it('closes the sheet and refetches after a confirmed delete', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    await mount()
+    await open('Pixel Bot')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.delete')))
+
+    await waitFor(() => expect(sheetNodes()).toHaveLength(0))
+    expect(fn('galleryDelete')).toHaveBeenCalledWith('pixel-bot')
+    expect(fn('galleryListPacks')).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the sheet open and banners a refused delete', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    fn('galleryDelete').mockResolvedValue({ ok: false, error: 'pack in use' })
+    await mount()
+    await open('Pixel Bot')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.delete')))
+
+    await waitFor(() => expect(screen.getByText('pack in use')).toBeTruthy())
+    expect(sheetNodes().length).toBeGreaterThan(0)
+    expect(fn('galleryListPacks')).toHaveBeenCalledTimes(1)
+  })
+
+  it('banners a thrown delete', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    fn('galleryDelete').mockRejectedValue(new Error('delete threw'))
+    await mount()
+    await open('Pixel Bot')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.delete')))
+
+    await waitFor(() => expect(screen.getByText('delete threw')).toBeTruthy())
+  })
+
+  it('toasts a successful bundle import, and reports its failures', async () => {
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.gallery.import_bundle')))
+    await waitFor(() => expect(
+      screen.getByText(t('apps.mochi.gallery.import_success'))).toBeTruthy())
+
+    fn('galleryImportBundle').mockResolvedValue({ ok: false, error: 'bad zip' })
+    fireEvent.click(screen.getByText(t('apps.mochi.gallery.import_bundle')))
+    await waitFor(() => expect(screen.getByText('bad zip')).toBeTruthy())
+
+    fn('galleryImportBundle').mockRejectedValue(new Error('import threw'))
+    fireEvent.click(screen.getByText(t('apps.mochi.gallery.import_bundle')))
+    await waitFor(() => expect(screen.getByText('import threw')).toBeTruthy())
+  })
+
+  it('stays silent when the import dialog is cancelled', async () => {
+    fn('galleryImportBundle').mockResolvedValue(null)
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.gallery.import_bundle')))
+
+    await waitFor(() => expect(fn('galleryImportBundle')).toHaveBeenCalled())
+    expect(screen.queryByText(t('apps.mochi.gallery.import_success'))).toBeNull()
+  })
+})
+
+// ── Editor navigation ──────────────────────────────────────────────────────
+
+describe('GalleryPanel — editor navigation', () => {
+  it('opens a blank editor from the header and toasts a created pack', async () => {
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.gallery.create_new')))
+    expect(screen.getByText('editor-for:new-pack')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('editor-save'))
+    await waitFor(() => expect(
+      screen.getByText(t('apps.mochi.editor.create_success'))).toBeTruthy())
+    expect(screen.queryByTestId('pack-editor')).toBeNull()
+    expect(fn('galleryListPacks')).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns to the gallery when the editor is cancelled', async () => {
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.gallery.create_new')))
+    fireEvent.click(screen.getByText('editor-cancel'))
+
+    expect(screen.queryByTestId('pack-editor')).toBeNull()
+    expect(cardFor('Mochi Cat')).toBeTruthy()
+    expect(fn('galleryListPacks')).toHaveBeenCalledTimes(1)
+  })
+
+  it('edits an svg pack in the pack editor and toasts a saved pack', async () => {
+    await mount()
+    await open('Hand Drawn')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.edit')))
+
+    expect(screen.getByText('editor-for:Hand Drawn')).toBeTruthy()
+    expect(sheetNodes()).toHaveLength(0)
+
+    fireEvent.click(screen.getByText('editor-save'))
+    await waitFor(() => expect(
+      screen.getByText(t('apps.mochi.editor.save_success'))).toBeTruthy())
+  })
+
+  it('edits a sprite pack in the sprite importer instead', async () => {
+    await mount()
+    await open('Pixel Bot')
+    fireEvent.click(within(sheet()).getByText(t('apps.mochi.gallery.edit')))
+
+    expect(screen.getByText('sprite-for:Pixel Bot')).toBeTruthy()
+    expect(screen.getByTestId('sprite-prefill').textContent).toBe('no-prefill')
+  })
+
+  it('opens a blank sprite importer from the header and cancels back', async () => {
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.sprite.title')))
+    expect(screen.getByText('sprite-for:new-pack')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('sprite-cancel'))
+    expect(screen.queryByTestId('sprite-importer')).toBeNull()
+    expect(cardFor('Mochi Cat')).toBeTruthy()
+  })
+
+  it('carries a petdex pick into the sprite importer as prefill', async () => {
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.petdex.title')))
+    fireEvent.click(screen.getByText('petdex-ready'))
+
+    expect(screen.getByTestId('sprite-prefill').textContent).toBe('Bulbasaur')
+  })
+
+  it('enters the sprite importer with no prefill when the petdex user brings a file', async () => {
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.petdex.title')))
+    fireEvent.click(screen.getByText('petdex-use-file'))
+
+    expect(screen.getByTestId('sprite-prefill').textContent).toBe('no-prefill')
+  })
+
+  it('returns to the gallery when the petdex importer is cancelled', async () => {
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.petdex.title')))
+    fireEvent.click(screen.getByText('petdex-cancel'))
+
+    expect(screen.queryByTestId('petdex-importer')).toBeNull()
+    expect(cardFor('Mochi Cat')).toBeTruthy()
+  })
+
+  it('stays in the sprite importer when the save is refused, then leaves once it lands', async () => {
+    fn('gallerySaveSpritePack').mockResolvedValue({ ok: false, error: 'sheet too tall' })
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.sprite.title')))
+    fireEvent.click(screen.getByText('sprite-done'))
+
+    await waitFor(() => expect(
+      screen.getByTestId('sprite-save-error').textContent).toBe('sheet too tall'))
+    expect(screen.getByTestId('sprite-importer')).toBeTruthy()
+
+    fn('gallerySaveSpritePack').mockResolvedValue({ ok: true, packId: 'new-sheet' })
+    fireEvent.click(screen.getByText('sprite-done'))
+    await waitFor(() => expect(screen.queryByTestId('sprite-importer')).toBeNull())
+    expect(screen.getByText(t('apps.mochi.editor.create_success'))).toBeTruthy()
+  })
+
+  it('reports the generic sprite-save error when the refusal carries no message', async () => {
+    fn('gallerySaveSpritePack').mockResolvedValue({ ok: false })
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.sprite.title')))
+    fireEvent.click(screen.getByText('sprite-done'))
+
+    await waitFor(() => expect(screen.getByTestId('sprite-save-error').textContent)
+      .toBe(t('apps.mochi.errors.create_sprite_pack')))
+  })
+
+  it('treats an absent save channel as a refused save', async () => {
+    H.api.gallerySaveSpritePack = undefined
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.sprite.title')))
+    fireEvent.click(screen.getByText('sprite-done'))
+
+    await waitFor(() => expect(screen.getByTestId('sprite-save-error')).toBeTruthy())
+    expect(screen.getByTestId('sprite-importer')).toBeTruthy()
+  })
+
+  it('re-applies the pack when the saved sheet overwrites the active one', async () => {
+    H.spriteDone.payload = { overwriteId: 'default-mochi' }
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.sprite.title')))
+    fireEvent.click(screen.getByText('sprite-done'))
+
+    await waitFor(() => expect(fn('gallerySetActive')).toHaveBeenCalledWith('default-mochi'))
+    await waitFor(() => expect(screen.queryByTestId('sprite-importer')).toBeNull())
+  })
+
+  it('re-applies when the newly assigned pack id is the active one', async () => {
+    fn('gallerySaveSpritePack').mockResolvedValue({ ok: true, packId: 'default-mochi' })
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.sprite.title')))
+    fireEvent.click(screen.getByText('sprite-done'))
+
+    await waitFor(() => expect(fn('gallerySetActive')).toHaveBeenCalledWith('default-mochi'))
+  })
+
+  it('does not re-apply when the saved pack is not the active one', async () => {
+    await mount()
+    fireEvent.click(screen.getByText(t('apps.mochi.sprite.title')))
+    fireEvent.click(screen.getByText('sprite-done'))
+
+    await waitFor(() => expect(screen.queryByTestId('sprite-importer')).toBeNull())
+    expect(fn('gallerySetActive')).not.toHaveBeenCalled()
+  })
+})
+
+// ── Broadcasts ─────────────────────────────────────────────────────────────
+
+describe('GalleryPanel — broadcasts', () => {
+  it('moves the active badge when the main process names the new pack', async () => {
+    await mount()
+    act(() => { H.listeners.active?.({ packId: 'kiro-ghost' }) })
+
+    expect(within(cardFor('Kiro Ghost')).getByText(t('apps.mochi.gallery.active'))).toBeTruthy()
+    expect(within(cardFor('Mochi Cat')).queryByText(t('apps.mochi.gallery.active'))).toBeNull()
+    expect(fn('getMochiConfig')).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-reads the config when the broadcast carries no pack id', async () => {
+    await mount()
+    fn('getMochiConfig').mockResolvedValue({ activeAppearance: 'pixel-bot' })
+    act(() => { H.listeners.active?.({}) })
+
+    await waitFor(() => expect(
+      within(cardFor('Pixel Bot')).getByText(t('apps.mochi.gallery.active'))).toBeTruthy())
+  })
+
+  it('refetches the grid when the pack set changes', async () => {
+    await mount()
+    fn('galleryListPacks').mockResolvedValue([...PACKS, meta({ id: 'newbie', name: 'Newbie' })])
+    act(() => { H.listeners.packs?.() })
+
+    await waitFor(() => expect(cardFor('Newbie')).toBeTruthy())
+  })
+
+  it('recolours default-mochi live, and reverts when the map is emptied', async () => {
+    await mount()
+    act(() => { H.listeners.color?.({ packId: 'default-mochi', colorMap: { [ORANGE]: '#123456' } }) })
+    await waitFor(() => expect(thumbSrc('Mochi Cat')).toContain('#123456'))
+
+    act(() => { H.listeners.color?.({ packId: 'default-mochi', colorMap: {} }) })
+    await waitFor(() => expect(thumbSrc('Mochi Cat')).toContain(ORANGE))
+  })
+
+  it('ignores a colour map broadcast for another pack', async () => {
+    await mount()
+    act(() => { H.listeners.color?.({ packId: 'hand-drawn', colorMap: { [ORANGE]: '#123456' } }) })
+
+    const src = thumbSrc('Hand Drawn')
+    expect(src).toContain(ORANGE)
+    expect(src).not.toContain('#123456')
+  })
+
+  it('renders when the colour-map channel is absent from the bridge', async () => {
+    H.api.onColorMapChanged = undefined
+    await mount()
+    expect(cardFor('Mochi Cat')).toBeTruthy()
+  })
+
+  it('unsubscribes from every channel on unmount', async () => {
+    const view = await mount()
+    view.unmount()
+
+    expect(H.offs.active).toBe(1)
+    expect(H.offs.packs).toBe(1)
+    expect(H.offs.color).toBe(1)
+  })
+})

--- a/website/src/test/IssueRadarContextCoverage.test.tsx
+++ b/website/src/test/IssueRadarContextCoverage.test.tsx
@@ -1,0 +1,712 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  IssueRadarProvider, useIssueRadar, type IssueRadarContextValue,
+} from '../apps/issue-radar/context'
+import { REFRESH_DEFAULTS, UI_STATE_KEY } from '../apps/issue-radar/lib/format'
+
+// Behaviour pins for the Issue Radar data layer (`context.tsx`) that the
+// surface-level component tests never reach: the persisted-crew-UI coercions,
+// the filter/sort/selection reducers for BOTH lists, the two refresh mutations,
+// the bulk-tick rules, the cross-reference stack, and the repo-switch reset.
+//
+// The provider is driven through the context value itself (a probe component
+// captures it) rather than through rendered controls: every branch here is a
+// state rule, so asserting on the value is both closer to the contract and
+// keeps the harness free of the button clusters the design lint forbids.
+
+const api = {
+  me: vi.fn(),
+  issues: vi.fn(),
+  issuesFirstPage: vi.fn(),
+  labels: vi.fn(),
+  members: vi.fn(),
+  getSettings: vi.fn(),
+  pulls: vi.fn(),
+  pullsFirstPage: vi.fn(),
+  searchPulls: vi.fn(),
+  crews: vi.fn(),
+}
+
+vi.mock('../apps/issue-radar/api', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  issueRadarApi: {
+    me: (...a: unknown[]) => api.me(...a),
+    issues: (...a: unknown[]) => api.issues(...a),
+    issuesFirstPage: (...a: unknown[]) => api.issuesFirstPage(...a),
+    labels: (...a: unknown[]) => api.labels(...a),
+    members: (...a: unknown[]) => api.members(...a),
+    getSettings: (...a: unknown[]) => api.getSettings(...a),
+    pulls: (...a: unknown[]) => api.pulls(...a),
+    pullsFirstPage: (...a: unknown[]) => api.pullsFirstPage(...a),
+    searchPulls: (...a: unknown[]) => api.searchPulls(...a),
+    crews: (...a: unknown[]) => api.crews(...a),
+  },
+}))
+
+const ME = 'octocat'
+const ACTIVE = { owner: 'kirodotdev', repo: 'Kiro' }
+const OTHER = { owner: 'kirodotdev', repo: 'Other' }
+const REPOS = [
+  { ...ACTIVE, permissions: { pull: true, triage: true } },
+  { ...OTHER, permissions: { pull: true } },
+]
+/** repoScopeKey(ACTIVE) — provider:host:owner/repo. */
+const SCOPE = 'github:github.com:kirodotdev/Kiro'
+const CREW_UI_KEY = 'kc:issue-radar:crew-ui'
+
+// #1 authored + assigned to me. #2 authored by a roster member, also assigned to
+// me. #3 authored by a stranger who carries a member author_association, which is
+// the roster-less fallback the member filters accept.
+const ISSUES = [
+  {
+    number: 1, title: 'Alpha crash', url: '', comments: 0, labels: ['bug'],
+    author: ME, assignees: [ME], author_association: 'NONE', updated_at: '2026-07-03T00:00:00Z',
+  },
+  {
+    number: 2, title: 'Beta docs', url: '', comments: 0, labels: ['bug', 'ui'],
+    author: 'member1', assignees: [ME], author_association: 'NONE', updated_at: '2026-07-01T00:00:00Z',
+  },
+  {
+    number: 3, title: 'Gamma', url: '', comments: 0, labels: [],
+    author: 'stranger', assignees: [], author_association: 'COLLABORATOR', updated_at: '2026-07-02T00:00:00Z',
+  },
+]
+const LABELS = [
+  { name: 'ui', color: 'aaaaaa', description: '' },
+  { name: 'bug', color: 'bbbbbb', description: '' },
+  { name: 'zeta', color: 'cccccc', description: '' },
+]
+const PULLS = [
+  {
+    number: 10, title: 'Add widget', url: '', state: 'open', draft: false, labels: ['bug'],
+    author: ME, assignees: [ME], requested_reviewers: [ME], author_association: 'NONE',
+    merged_at: null, head: 'feat/widget', base: 'main', updated_at: '2026-07-05T00:00:00Z',
+  },
+  {
+    number: 11, title: 'Fix thing', url: '', state: 'open', draft: true, labels: ['ui'],
+    author: 'member1', assignees: [], requested_reviewers: [], author_association: 'NONE',
+    merged_at: null, head: 'fix/thing', base: 'main', updated_at: '2026-07-04T00:00:00Z',
+  },
+  {
+    number: 12, title: 'Docs pass', url: '', state: 'open', draft: false, labels: [],
+    author: 'stranger', assignees: [], requested_reviewers: [], author_association: 'COLLABORATOR',
+    merged_at: null, head: 'docs/pass', base: 'main', updated_at: '2026-07-06T00:00:00Z',
+  },
+]
+const CLOSED_PULLS = [
+  {
+    number: 20, title: 'Merged one', url: '', state: 'closed', draft: false, labels: [],
+    author: 'someone', assignees: [], requested_reviewers: [], merged_at: '2026-07-07T00:00:00Z',
+    head: 'a', base: 'main', updated_at: '2026-07-07T00:00:00Z',
+  },
+  {
+    number: 21, title: 'Rejected one', url: '', state: 'closed', draft: false, labels: [],
+    author: 'someone', assignees: [], requested_reviewers: [], merged_at: null,
+    head: 'b', base: 'main', updated_at: '2026-07-08T00:00:00Z',
+  },
+]
+const CREWS = [
+  { id: 'c1', name: 'Alpha crew', created_at: '2026-07-01T00:00:00Z' },
+  { id: 'c2', name: 'Beta crew', created_at: '2026-07-02T00:00:00Z' },
+]
+
+let ctx = null as unknown as IssueRadarContextValue
+const onSwitch = vi.fn()
+
+function Probe() {
+  ctx = useIssueRadar()
+  return null
+}
+
+function renderProvider(opts: { seedPulls?: unknown } = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  if (opts.seedPulls !== undefined) {
+    client.setQueryData(['issue-radar', 'pulls', SCOPE, 'open'], opts.seedPulls)
+  }
+  render(
+    <QueryClientProvider client={client}>
+      <IssueRadarProvider repos={REPOS} active={ACTIVE} onSwitch={onSwitch} onAddRepo={() => {}}>
+        <Probe />
+      </IssueRadarProvider>
+    </QueryClientProvider>,
+  )
+  return client
+}
+
+/** Open straight onto the PR surface — `prSurfaceActive` follows the restored
+ * `mainView`, and the PR queries are gated on it. */
+function persistUi(state: Record<string, unknown>) {
+  localStorage.setItem(UI_STATE_KEY, JSON.stringify(state))
+}
+
+/** Run a context action inside act() so the resulting render is flushed. */
+async function drive(fn: () => void) {
+  await act(async () => { fn() })
+}
+
+const issueNumbers = () => ctx.sortedIssues.map((i) => i.number)
+const pullNumbers = () => ctx.sortedPulls.map((p) => p.number)
+
+async function readyIssues() {
+  await waitFor(() => expect(ctx.issues).toHaveLength(ISSUES.length))
+}
+async function readyPulls() {
+  await waitFor(() => expect(ctx.pulls).toHaveLength(PULLS.length))
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  onSwitch.mockReset()
+  for (const fn of Object.values(api)) fn.mockReset()
+  api.me.mockResolvedValue({ login: ME })
+  api.issues.mockImplementation((_ref: unknown, opts: { state?: string } = {}) =>
+    Promise.resolve({ issues: opts.state === 'closed' ? [] : ISSUES }))
+  api.issuesFirstPage.mockResolvedValue({ issues: [], partial: false })
+  api.labels.mockResolvedValue({ labels: LABELS })
+  api.members.mockResolvedValue({ members: [{ login: 'member1', role: 'admin' }] })
+  api.getSettings.mockResolvedValue({ settings: null })
+  api.pulls.mockImplementation((_ref: unknown, opts: { state?: string } = {}) =>
+    Promise.resolve({ pulls: opts.state === 'closed' ? CLOSED_PULLS : PULLS, bulk_max: 5 }))
+  api.pullsFirstPage.mockResolvedValue({ pulls: [], partial: false })
+  api.searchPulls.mockResolvedValue({ pulls: [PULLS[0]], truncated: true, limit: 100, bulk_max: 7 })
+  api.crews.mockResolvedValue({
+    crews: CREWS, counts: { on_duty: 2, working: 1, paused: 0 },
+    settings: { schema: 1, claim_ttl_hours: 4, needs_human_label: 'needs-human', commit_trailer: 'Crew' },
+  })
+})
+
+afterEach(() => { vi.clearAllMocks() })
+
+describe('useIssueRadar guard', () => {
+  it('throws when read outside the provider', () => {
+    function Bare() {
+      useIssueRadar()
+      return null
+    }
+    expect(() => render(<Bare />)).toThrow(/must be used within/)
+  })
+})
+
+describe('persisted crew UI', () => {
+  // The roster effect re-points a stale selection one fetch later, so the
+  // coercion is only observable while the roster is still in flight.
+  function renderWithPendingRoster(stored: string) {
+    localStorage.setItem(CREW_UI_KEY, stored)
+    api.crews.mockImplementation(() => new Promise(() => {}))
+    return renderProvider()
+  }
+
+  it('restores a valid crew selection, filter, sort field and direction', async () => {
+    renderWithPendingRoster(JSON.stringify({
+      crewView: { kind: 'crew', id: 'c2' }, crewFilter: 'paused',
+      crewSortKey: 'name', crewSortDir: 'desc',
+    }))
+    await waitFor(() => expect(ctx.crewView).toEqual({ kind: 'crew', id: 'c2' }))
+    expect(ctx.crewFilter).toBe('paused')
+    expect(ctx.crewSortKey).toBe('name')
+    expect(ctx.crewSortDir).toBe('desc')
+  })
+
+  it('drops a crew selection with an unknown kind, and one with no id', async () => {
+    renderWithPendingRoster(JSON.stringify({ crewView: { kind: 'squad', id: 'c2' } }))
+    await waitFor(() => expect(ctx.crewView).toEqual({ kind: 'none' }))
+    localStorage.setItem(CREW_UI_KEY, JSON.stringify({ crewView: { kind: 'crew', id: '' } }))
+    renderProvider()
+    await waitFor(() => expect(ctx.crewView).toEqual({ kind: 'none' }))
+  })
+
+  it('keeps the unselected state for kind:none, and falls back on every bad field', async () => {
+    renderWithPendingRoster(JSON.stringify({
+      crewView: { kind: 'none' }, crewFilter: 'nope',
+      crewSortKey: 'retired', crewSortDir: 'sideways',
+    }))
+    await waitFor(() => expect(ctx.crewFilter).toBe('all'))
+    expect(ctx.crewView).toEqual({ kind: 'none' })
+    expect(ctx.crewSortKey).toBe('status')
+    expect(ctx.crewSortDir).toBe('asc')
+  })
+
+  it('falls back to defaults when the stored blob is not JSON', async () => {
+    renderWithPendingRoster('{not json')
+    await waitFor(() => expect(ctx.crewFilter).toBe('all'))
+    expect(ctx.crewView).toEqual({ kind: 'none' })
+    expect(ctx.crewSortKey).toBe('status')
+  })
+
+  it('writes the crews UI back to its own key on change', async () => {
+    renderProvider()
+    await waitFor(() => expect(ctx.crews).toHaveLength(2))
+    await drive(() => ctx.setCrewFilter('working'))
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem(CREW_UI_KEY) ?? '{}')).toEqual({
+        crewView: { kind: 'crew', id: 'c1' },
+        crewFilter: 'working',
+        crewSortKey: 'status',
+        crewSortDir: 'asc',
+      })
+    })
+  })
+})
+
+describe('crew roster', () => {
+  it('opens the first crew when nothing valid is selected', async () => {
+    localStorage.setItem(CREW_UI_KEY, JSON.stringify({ crewView: { kind: 'crew', id: 'retired' } }))
+    renderProvider()
+    await waitFor(() => expect(ctx.crewView).toEqual({ kind: 'crew', id: 'c1' }))
+    expect(ctx.crewCounts).toEqual({ on_duty: 2, working: 1, paused: 0 })
+    expect(ctx.crewSettings?.claim_ttl_hours).toBe(4)
+    expect(ctx.crewsLoading).toBe(false)
+    expect(ctx.crewsError).toBeNull()
+  })
+
+  it('keeps a selection the roster still contains', async () => {
+    localStorage.setItem(CREW_UI_KEY, JSON.stringify({ crewView: { kind: 'crew', id: 'c2' } }))
+    renderProvider()
+    await waitFor(() => expect(ctx.crews).toHaveLength(2))
+    expect(ctx.crewView).toEqual({ kind: 'crew', id: 'c2' })
+  })
+
+  it('leaves nothing selected on a repo with no crews', async () => {
+    api.crews.mockResolvedValue({ crews: [], counts: { on_duty: 0, working: 0, paused: 0 } })
+    renderProvider()
+    await waitFor(() => expect(ctx.crewsLoading).toBe(false))
+    expect(ctx.crewView).toEqual({ kind: 'none' })
+    expect(ctx.crewSettings).toBeNull()
+  })
+
+  it('reports a roster failure and falls back to defaults', async () => {
+    api.crews.mockRejectedValue(new Error('store unreadable'))
+    renderProvider()
+    await waitFor(() => expect(ctx.crewsError?.message).toBe('store unreadable'))
+    expect(ctx.crews).toEqual([])
+    expect(ctx.crewCounts).toEqual({ on_duty: 0, working: 0, paused: 0 })
+  })
+
+  it('navigates to the crews surface, optionally jumping to a page', async () => {
+    renderProvider()
+    await waitFor(() => expect(ctx.crews).toHaveLength(2))
+    await drive(() => ctx.openCrews())
+    expect(ctx.mainView).toBe('crews')
+    expect(ctx.expanded).toBe('crews')
+    expect(ctx.crewView).toEqual({ kind: 'crew', id: 'c1' })
+    await drive(() => ctx.openCrews({ kind: 'crew', id: 'c2' }))
+    expect(ctx.crewView).toEqual({ kind: 'crew', id: 'c2' })
+  })
+
+  it('flips the direction on the active roster sort field and switches on another', async () => {
+    renderProvider()
+    await waitFor(() => expect(ctx.crews).toHaveLength(2))
+    await drive(() => ctx.cycleCrewSort('status'))
+    expect(ctx.mainView).toBe('crews')
+    expect(ctx.crewSortKey).toBe('status')
+    expect(ctx.crewSortDir).toBe('desc')
+    await drive(() => ctx.cycleCrewSort('name'))
+    expect(ctx.crewSortKey).toBe('name')
+    // Switching fields keeps the stated reading order rather than resetting it.
+    expect(ctx.crewSortDir).toBe('desc')
+  })
+})
+
+describe('issue filters, sort and selection', () => {
+  it('derives label colours, counts, member roles and the label ordering', async () => {
+    renderProvider()
+    await readyIssues()
+    await waitFor(() => expect(ctx.memberRoleByLogin.get('member1')).toBe('admin'))
+    expect(ctx.colorByName.get('bug')).toBe('bbbbbb')
+    expect(ctx.countByLabel.get('bug')).toBe(2)
+    expect(ctx.countByLabel.get('ui')).toBe(1)
+    // Most-used first; a repo label carried by no open issue sorts last.
+    expect(ctx.sortedRepoLabels.map((l) => l.name)).toEqual(['bug', 'ui', 'zeta'])
+    expect(ctx.activePermissions).toEqual({ pull: true, triage: true })
+    expect(ctx.canWrite).toBe(true)
+  })
+
+  it('applies the person and member filters, and clears them together', async () => {
+    renderProvider()
+    await readyIssues()
+    expect(ctx.hasMemberIssues).toBe(true)
+
+    await drive(() => ctx.toggleRequestedByMe())
+    expect(ctx.mainView).toBe('issues')
+    expect(issueNumbers()).toEqual([1])
+
+    await drive(() => ctx.toggleRequestedByMe())
+    await drive(() => ctx.toggleAssignedToMe())
+    expect(issueNumbers()).toEqual([2, 1])
+
+    await drive(() => ctx.toggleAssignedToMe())
+    await drive(() => ctx.toggleCreatedByMember())
+    // #2 via the roster, #3 via its member author_association.
+    expect(issueNumbers()).toEqual([3, 2])
+
+    expect(ctx.anyFilterActive).toBe(true)
+    await drive(() => ctx.clearFilters())
+    expect(ctx.anyFilterActive).toBe(false)
+    expect(issueNumbers()).toEqual([3, 2, 1])
+  })
+
+  it('intersects selected labels and drops one on a second toggle', async () => {
+    renderProvider()
+    await readyIssues()
+    await drive(() => ctx.toggleLabel('bug'))
+    expect(issueNumbers()).toEqual([2, 1])
+    await drive(() => ctx.toggleLabel('ui'))
+    expect(issueNumbers()).toEqual([2])
+    await drive(() => ctx.toggleLabel('ui'))
+    expect(issueNumbers()).toEqual([2, 1])
+    expect(ctx.selectedLabels.has('bug')).toBe(true)
+  })
+
+  it('searches the number, title, author and label names', async () => {
+    renderProvider()
+    await readyIssues()
+    await drive(() => ctx.setQuery('#2'))
+    expect(issueNumbers()).toEqual([2])
+    await drive(() => ctx.setQuery('gamma'))
+    expect(issueNumbers()).toEqual([3])
+    await drive(() => ctx.setQuery('stranger'))
+    expect(issueNumbers()).toEqual([3])
+    await drive(() => ctx.setQuery('ui'))
+    expect(issueNumbers()).toEqual([2])
+    await drive(() => ctx.setQuery('nothing-matches'))
+    expect(issueNumbers()).toEqual([])
+  })
+
+  it('cycles the sort field and direction', async () => {
+    renderProvider()
+    await readyIssues()
+    expect(issueNumbers()).toEqual([3, 2, 1])
+    await drive(() => ctx.cycleSort('number'))
+    expect(ctx.sortDir).toBe('asc')
+    expect(issueNumbers()).toEqual([1, 2, 3])
+    await drive(() => ctx.cycleSort('updated'))
+    expect(ctx.sortKey).toBe('updated')
+    expect(issueNumbers()).toEqual([2, 3, 1])
+  })
+
+  it('clears the detail pane when the filters exclude the selected issue', async () => {
+    renderProvider()
+    await readyIssues()
+    await drive(() => ctx.setSelectedIssue(2))
+    expect(ctx.activeIssue?.number).toBe(2)
+    await drive(() => ctx.setQuery('gamma'))
+    expect(ctx.activeIssue).toBeNull()
+  })
+
+  it('treats unlabeled issues as untriaged under the default settings', async () => {
+    renderProvider()
+    await readyIssues()
+    expect(ctx.repoSettings.unlabeled_is_untriaged).toBe(true)
+    expect(ctx.needsTriage(ISSUES[2])).toBe(true)
+    expect(ctx.needsTriage(ISSUES[0])).toBe(false)
+    expect(ctx.isGoodFirstIssue(ISSUES[0])).toBe(false)
+  })
+
+  it("honours the repo's configured triage and good-first-issue labels", async () => {
+    api.getSettings.mockResolvedValue({
+      settings: {
+        triage_labels: ['bug'], unlabeled_is_untriaged: false,
+        good_first_issue_labels: ['ui'], notify_on_new_issue: false, revision: 3,
+      },
+    })
+    renderProvider()
+    await readyIssues()
+    await waitFor(() => expect(ctx.repoSettings.revision).toBe(3))
+    expect(ctx.needsTriage(ISSUES[0])).toBe(true)
+    // Unlabeled no longer counts once the repo opts out.
+    expect(ctx.needsTriage(ISSUES[2])).toBe(false)
+    expect(ctx.isGoodFirstIssue(ISSUES[1])).toBe(true)
+    expect(ctx.isGoodFirstIssue(ISSUES[0])).toBe(false)
+  })
+
+  it('navigates to a dashboard tab', async () => {
+    renderProvider()
+    await readyIssues()
+    await drive(() => ctx.openDashboard('tagging'))
+    expect(ctx.mainView).toBe('dashboard')
+    expect(ctx.dashboardTab).toBe('tagging')
+    expect(ctx.expanded).toBe('dashboards')
+  })
+
+  it('re-validates refresh preferences on write', async () => {
+    renderProvider()
+    await readyIssues()
+    // 1ms is not one of the offered intervals — a hand-set value must not install.
+    await drive(() => ctx.setRefreshPrefs({ listPollMs: 1 }))
+    expect(ctx.refreshPrefs.listPollMs).toBe(REFRESH_DEFAULTS.listPollMs)
+    await drive(() => ctx.setRefreshPrefs({ pollInBackground: true }))
+    expect(ctx.refreshPrefs.pollInBackground).toBe(true)
+  })
+})
+
+describe('manual refresh', () => {
+  it('replaces the issue and label caches and re-reads the members', async () => {
+    renderProvider()
+    await readyIssues()
+    api.issues.mockResolvedValue({ issues: [ISSUES[0]] })
+    api.labels.mockResolvedValue({ labels: [LABELS[1]] })
+    await drive(() => ctx.refresh())
+    await waitFor(() => expect(ctx.issues).toHaveLength(1))
+    expect(ctx.repoLabels.map((l) => l.name)).toEqual(['bug'])
+    expect(api.issues).toHaveBeenCalledWith(ACTIVE, { refresh: true, state: 'open' })
+    expect(api.labels).toHaveBeenCalledWith(ACTIVE, { refresh: true })
+    await waitFor(() => expect(ctx.refreshing).toBe(false))
+    expect(ctx.issuesUpdatedAt).toBeGreaterThan(0)
+  })
+})
+
+describe('pull-request filters, sort and selection', () => {
+  it('derives the PR label counts and the server bulk cap', async () => {
+    persistUi({ mainView: 'pulls' })
+    renderProvider()
+    await readyPulls()
+    expect(ctx.countByPrLabel.get('bug')).toBe(1)
+    expect(ctx.countByPrLabel.get('ui')).toBe(1)
+    expect(ctx.prBulkMax).toBe(5)
+    expect(ctx.hasMemberPulls).toBe(true)
+    expect(ctx.pullsPartial).toBe(false)
+    expect(ctx.pullsError).toBeNull()
+  })
+
+  it('filters on drafts, member authorship and labels, then clears', async () => {
+    persistUi({ mainView: 'pulls' })
+    renderProvider()
+    await readyPulls()
+
+    await drive(() => ctx.togglePrDraftOnly())
+    expect(ctx.mainView).toBe('pulls')
+    expect(pullNumbers()).toEqual([11])
+
+    await drive(() => ctx.togglePrDraftOnly())
+    await drive(() => ctx.togglePrCreatedByMember())
+    expect(pullNumbers()).toEqual([12, 11])
+
+    await drive(() => ctx.togglePrCreatedByMember())
+    await drive(() => ctx.togglePrLabel('ui'))
+    expect(pullNumbers()).toEqual([11])
+    await drive(() => ctx.togglePrLabel('ui'))
+    expect(pullNumbers()).toEqual([12, 11, 10])
+
+    await drive(() => ctx.togglePrLabel('bug'))
+    expect(ctx.anyPrFilterActive).toBe(true)
+    await drive(() => ctx.clearPrFilters())
+    expect(ctx.anyPrFilterActive).toBe(false)
+    expect(pullNumbers()).toEqual([12, 11, 10])
+  })
+
+  it('searches the number, title, author, branches and labels', async () => {
+    persistUi({ mainView: 'pulls' })
+    renderProvider()
+    await readyPulls()
+    await drive(() => ctx.setPrQuery('#11'))
+    expect(pullNumbers()).toEqual([11])
+    await drive(() => ctx.setPrQuery('widget'))
+    expect(pullNumbers()).toEqual([10])
+    await drive(() => ctx.setPrQuery('stranger'))
+    expect(pullNumbers()).toEqual([12])
+    await drive(() => ctx.setPrQuery('fix/thing'))
+    expect(pullNumbers()).toEqual([11])
+    await drive(() => ctx.setPrQuery('main'))
+    expect(pullNumbers()).toEqual([12, 11, 10])
+    await drive(() => ctx.setPrQuery('ui'))
+    expect(pullNumbers()).toEqual([11])
+    await drive(() => ctx.setPrQuery('no-such-thing'))
+    expect(pullNumbers()).toEqual([])
+  })
+
+  it('splits the closed set into merged and unmerged', async () => {
+    persistUi({ mainView: 'pulls' })
+    renderProvider()
+    await readyPulls()
+    await drive(() => ctx.setPrStateFilter('merged'))
+    await waitFor(() => expect(pullNumbers()).toEqual([20]))
+    await drive(() => ctx.setPrStateFilter('closed'))
+    await waitFor(() => expect(pullNumbers()).toEqual([21]))
+    // Both filters read the one CLOSED fetch.
+    expect(api.pulls).toHaveBeenCalledWith(ACTIVE, { state: 'closed', poll: false })
+  })
+
+  it('cycles the PR sort field and direction, and clears a hidden selection', async () => {
+    persistUi({ mainView: 'pulls' })
+    renderProvider()
+    await readyPulls()
+    expect(pullNumbers()).toEqual([12, 11, 10])
+    await drive(() => ctx.cyclePrSort('number'))
+    expect(ctx.prSortDir).toBe('asc')
+    expect(pullNumbers()).toEqual([10, 11, 12])
+    await drive(() => ctx.cyclePrSort('updated'))
+    expect(ctx.prSortKey).toBe('updated')
+    expect(pullNumbers()).toEqual([11, 10, 12])
+
+    await drive(() => ctx.setSelectedPull(10))
+    expect(ctx.activePull?.number).toBe(10)
+    await drive(() => ctx.setPrQuery('docs'))
+    expect(ctx.activePull).toBeNull()
+  })
+
+  it('excludes every row when a person filter is on but no login resolved', async () => {
+    // /me answered without a login: the person filter is REQUESTED (so the list
+    // query stands down) but not ACTIVE, so the client-side person predicates run
+    // against the rows already resident in the cache and can match nobody.
+    api.me.mockResolvedValue({ login: null })
+    persistUi({ mainView: 'pulls', prAuthoredByMe: true })
+    renderProvider({ seedPulls: { pulls: PULLS, bulk_max: 5 } })
+    await readyPulls()
+    await waitFor(() => expect(ctx.me).toBeNull())
+    expect(ctx.prPersonFilterActive).toBe(false)
+    expect(pullNumbers()).toEqual([])
+
+    // Each person predicate is checked independently, so drop the previous one
+    // before asserting the next (an earlier match would short-circuit the row).
+    await drive(() => ctx.togglePrAuthoredByMe())
+    await drive(() => ctx.togglePrAssignedToMe())
+    await waitFor(() => expect(pullNumbers()).toEqual([]))
+
+    await drive(() => ctx.togglePrAssignedToMe())
+    await drive(() => ctx.togglePrReviewRequestedByMe())
+    await waitFor(() => expect(pullNumbers()).toEqual([]))
+  })
+})
+
+describe('pull-request search source', () => {
+  it('swaps to the whole-repo search when a person filter resolves', async () => {
+    persistUi({ mainView: 'pulls' })
+    renderProvider()
+    await readyPulls()
+
+    await drive(() => ctx.togglePrAuthoredByMe())
+    await waitFor(() => expect(ctx.prPersonFilterActive).toBe(true))
+    await waitFor(() => expect(pullNumbers()).toEqual([10]))
+    // The search's own cap is reported rather than claimed as complete.
+    expect(ctx.prSearchTruncatedAt).toBe(100)
+    expect(ctx.prBulkMax).toBe(7)
+    expect(api.searchPulls).toHaveBeenCalledWith(ACTIVE, {
+      state: 'open', author: ME, assignee: undefined, reviewRequested: undefined,
+    })
+
+    // Refresh targets the ACTIVE source — a refetch of the uncached search route.
+    const before = api.searchPulls.mock.calls.length
+    await drive(() => ctx.refreshPulls())
+    await waitFor(() => expect(api.searchPulls.mock.calls.length).toBeGreaterThan(before))
+    expect(api.pulls).not.toHaveBeenCalledWith(ACTIVE, expect.objectContaining({ refresh: true }))
+  })
+
+  it('falls back to the row count when the search reports no cap', async () => {
+    api.searchPulls.mockResolvedValue({ pulls: [PULLS[0], PULLS[1]], truncated: true })
+    persistUi({ mainView: 'pulls', prReviewRequestedByMe: true })
+    renderProvider()
+    await waitFor(() => expect(ctx.prSearchTruncatedAt).toBe(2))
+    expect(ctx.pullsLoading).toBe(false)
+  })
+})
+
+describe('manual PR refresh', () => {
+  it('busts the list cache and reports a failed refresh', async () => {
+    persistUi({ mainView: 'pulls' })
+    renderProvider()
+    await readyPulls()
+
+    api.pulls.mockResolvedValueOnce({ pulls: [PULLS[2]], bulk_max: 5 })
+    await drive(() => ctx.refreshPulls())
+    await waitFor(() => expect(pullNumbers()).toEqual([12]))
+    expect(api.pulls).toHaveBeenCalledWith(ACTIVE, { refresh: true, state: 'open' })
+
+    api.pulls.mockRejectedValueOnce(new Error('rate limited'))
+    await drive(() => ctx.refreshPulls())
+    await waitFor(() => expect(ctx.pullsError?.message).toBe('rate limited'))
+    expect(ctx.pullsRefreshing).toBe(false)
+  })
+})
+
+describe('bulk PR selection', () => {
+  it('ticks one row, ticks and clears every rendered row, and drops the lot', async () => {
+    persistUi({ mainView: 'pulls' })
+    renderProvider()
+    await readyPulls()
+
+    await drive(() => ctx.togglePullChecked(10))
+    expect([...ctx.checkedPulls]).toEqual([10])
+    await drive(() => ctx.togglePullChecked(10))
+    expect(ctx.checkedPulls.size).toBe(0)
+
+    await drive(() => ctx.toggleAllPullsChecked())
+    expect([...ctx.checkedPulls].sort()).toEqual([10, 11, 12])
+    // Already all ticked — the same action clears.
+    await drive(() => ctx.toggleAllPullsChecked())
+    expect(ctx.checkedPulls.size).toBe(0)
+
+    await drive(() => ctx.togglePullChecked(11))
+    await drive(() => ctx.clearCheckedPulls())
+    expect(ctx.checkedPulls.size).toBe(0)
+  })
+
+  it('select-all reaches only the rows the active filter renders', async () => {
+    persistUi({ mainView: 'pulls' })
+    renderProvider()
+    await readyPulls()
+    await drive(() => ctx.togglePrDraftOnly())
+    await drive(() => ctx.toggleAllPullsChecked())
+    expect([...ctx.checkedPulls]).toEqual([11])
+  })
+
+  it('drops the ticks when the PR filters move', async () => {
+    persistUi({ mainView: 'pulls' })
+    renderProvider()
+    await readyPulls()
+    await drive(() => ctx.toggleAllPullsChecked())
+    expect(ctx.checkedPulls.size).toBe(3)
+    await drive(() => ctx.setPrQuery('widget'))
+    await waitFor(() => expect(ctx.checkedPulls.size).toBe(0))
+  })
+})
+
+describe('cross-reference sheet', () => {
+  it('pushes, refuses a duplicate top, pops and closes', async () => {
+    renderProvider()
+    await readyIssues()
+    expect(ctx.refStack).toEqual([])
+
+    await drive(() => ctx.openRef({ kind: 'issue', number: 5 }))
+    expect(ctx.refStack).toEqual([{ kind: 'issue', number: 5 }])
+    // Re-opening the ref already on top is a no-op.
+    await drive(() => ctx.openRef({ kind: 'issue', number: 5 }))
+    expect(ctx.refStack).toHaveLength(1)
+
+    await drive(() => ctx.openRef({ kind: 'pull', number: 6 }))
+    expect(ctx.refStack).toHaveLength(2)
+    await drive(() => ctx.popRef())
+    expect(ctx.refStack).toEqual([{ kind: 'issue', number: 5 }])
+    await drive(() => ctx.closeRefs())
+    expect(ctx.refStack).toEqual([])
+  })
+})
+
+describe('repo switch', () => {
+  it('resets the search, filters, selections and crew page, then hands off', async () => {
+    persistUi({ mainView: 'pulls' })
+    renderProvider()
+    await readyPulls()
+    await readyIssues()
+    await waitFor(() => expect(ctx.crewView).toEqual({ kind: 'crew', id: 'c1' }))
+
+    await drive(() => ctx.setQuery('alpha'))
+    await drive(() => ctx.toggleLabel('bug'))
+    await drive(() => ctx.setSelectedIssue(1))
+    await drive(() => ctx.setPrQuery('widget'))
+    await drive(() => ctx.togglePrDraftOnly())
+    await drive(() => ctx.setSelectedPull(11))
+
+    await drive(() => ctx.switchRepo(OTHER))
+    expect(onSwitch).toHaveBeenCalledWith(OTHER)
+    expect(ctx.query).toBe('')
+    expect(ctx.anyFilterActive).toBe(false)
+    expect(ctx.selectedIssue).toBeNull()
+    expect(ctx.prQuery).toBe('')
+    expect(ctx.anyPrFilterActive).toBe(false)
+    expect(ctx.selectedPull).toBeNull()
+    // A crew id names a crew in ONE repo's store, so the page cannot carry over.
+    expect(ctx.crewView).toEqual({ kind: 'none' })
+  })
+})

--- a/website/src/test/MdNotebookApiCoverage.test.tsx
+++ b/website/src/test/MdNotebookApiCoverage.test.tsx
@@ -1,0 +1,434 @@
+/**
+ * Coverage for the Notes app's API client (`src/apps/md-notebook/api.ts`).
+ *
+ * Every existing Notes test MOCKS this module, so none of its real request
+ * building, error translation or Knowledge-registration recovery paths ever
+ * executed. These tests drive the real module with a stubbed `fetch` and assert
+ * the wire shape (method, URL, body) plus each error branch.
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  ApiError,
+  knowledgeRegister,
+  knowledgeUnregister,
+  notesApi,
+} from '../apps/md-notebook/api'
+import { API_BASE } from '../apps/md-notebook/constants'
+import { i18nT } from '../i18n/t'
+import type { Vault } from '../apps/md-notebook/types'
+
+type StubReply = {
+  ok?: boolean
+  status?: number
+  statusText?: string
+  json?: unknown
+  /** Make `res.json()` reject, the way a non-JSON body does. */
+  jsonThrows?: boolean
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+/** Queue one reply per upcoming request, in order. */
+function reply(...replies: StubReply[]): void {
+  for (const r of replies) {
+    const status = r.status ?? 200
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: r.ok ?? status < 400,
+        status,
+        statusText: r.statusText ?? '',
+        json: () =>
+          r.jsonThrows ? Promise.reject(new Error('not json')) : Promise.resolve(r.json ?? {}),
+      }),
+    )
+  }
+}
+
+/** The URL and init of the nth (0-based) request made. */
+function callAt(i: number): { url: string; init: RequestInit } {
+  const args = fetchMock.mock.calls[i]
+  return { url: String(args[0]), init: (args[1] ?? {}) as RequestInit }
+}
+
+const VAULT: Vault = {
+  id: 'v1',
+  name: 'My Vault',
+  repo: 'git@example.com:me/notes.git',
+  branch: 'main',
+  localPath: '/home/me/vaults/notes',
+  readOnly: false,
+  subfolder: 'docs',
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('mdnbCall request shape', () => {
+  it('sends a GET with no body and returns the parsed payload', async () => {
+    reply({ json: { ok: true, features: ['search'] } })
+    const out = await notesApi.health()
+    expect(out).toEqual({ ok: true, features: ['search'] })
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/health`)
+    expect(init.method).toBe('GET')
+    expect(init.body).toBeUndefined()
+    expect(init.credentials).toBe('same-origin')
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+  })
+
+  it('serialises the body for a POST', async () => {
+    reply({ json: { vault: VAULT } })
+    await notesApi.cloneVault({ url: 'https://example.com/n.git', pat: 'p', knowledge: true })
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/vaults`)
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(String(init.body))).toEqual({
+      url: 'https://example.com/n.git',
+      pat: 'p',
+      knowledge: true,
+    })
+  })
+})
+
+describe('mdnbCall error translation', () => {
+  it('raises ApiError carrying the server error, status and body', async () => {
+    reply({ status: 422, json: { error: 'bad path', detail: 'x' } })
+    const err = await notesApi.health().catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(ApiError)
+    const api = err as ApiError
+    expect(api.name).toBe('ApiError')
+    expect(api.message).toBe('bad path')
+    expect(api.status).toBe(422)
+    expect(api.body).toEqual({ error: 'bad path', detail: 'x' })
+    expect(api.staleBackend).toBe(false)
+  })
+
+  it('falls back to statusText when the payload carries no error string', async () => {
+    reply({ status: 500, statusText: 'Internal Server Error', json: { error: 7 } })
+    const err = (await notesApi.health().catch((e: unknown) => e)) as ApiError
+    expect(err.message).toBe('Internal Server Error')
+    expect(err.status).toBe(500)
+  })
+
+  it('treats an unparseable body as empty', async () => {
+    reply({ status: 502, statusText: 'Bad Gateway', jsonThrows: true })
+    const err = (await notesApi.health().catch((e: unknown) => e)) as ApiError
+    expect(err.message).toBe('Bad Gateway')
+    expect(err.body).toEqual({})
+  })
+
+  it('returns an empty object when a successful reply is not JSON', async () => {
+    reply({ status: 200, jsonThrows: true })
+    await expect(notesApi.health()).resolves.toEqual({})
+  })
+
+  it('rewrites a "no route" reply into the stale-backend message', async () => {
+    reply({ status: 404, json: { error: 'no route: POST /trash/open' } })
+    const err = (await notesApi.openTrash(null).catch((e: unknown) => e)) as ApiError
+    expect(err.staleBackend).toBe(true)
+    expect(err.message).toBe(i18nT('apps.mdNotebook.banner.staleBackendRoute'))
+    expect(err.message).not.toContain('no route')
+    // The raw payload is still available to callers.
+    expect(err.body).toEqual({ error: 'no route: POST /trash/open' })
+  })
+
+  it('does not treat a mid-string "no route" as stale — the marker is anchored', async () => {
+    reply({ status: 400, json: { error: 'sync failed: no route: /x' } })
+    const err = (await notesApi.health().catch((e: unknown) => e)) as ApiError
+    expect(err.staleBackend).toBe(false)
+    expect(err.message).toBe('sync failed: no route: /x')
+  })
+})
+
+describe('vault query building', () => {
+  it('leaves the path untouched when no vault is active', async () => {
+    reply({ json: { notes: [] } })
+    await notesApi.listNotes(null)
+    expect(callAt(0).url).toBe(`${API_BASE}/notes`)
+  })
+
+  it('appends with ? on a bare path and encodes the id', async () => {
+    reply({ json: { notes: [] } })
+    await notesApi.listNotes('a b&c')
+    expect(callAt(0).url).toBe(`${API_BASE}/notes?vault=a+b%26c`)
+  })
+
+  it('appends with & when the path already carries a query', async () => {
+    reply({ json: { results: [] } })
+    await notesApi.search('v1', 'hello world')
+    expect(callAt(0).url).toBe(`${API_BASE}/search?q=hello%20world&vault=v1`)
+  })
+})
+
+describe('vault endpoints', () => {
+  it('lists vaults', async () => {
+    reply({ json: { vaults: [VAULT], hasPat: true, hasGhAuth: false } })
+    const out = await notesApi.listVaults()
+    expect(out.vaults).toHaveLength(1)
+    expect(out.hasPat).toBe(true)
+    expect(callAt(0).url).toBe(`${API_BASE}/vaults`)
+  })
+
+  it('attaches a vault in place', async () => {
+    reply({ json: { vault: VAULT } })
+    await notesApi.attachVault({ path: '/tmp/n', subfolder: 'docs' })
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/vaults/attach`)
+    expect(JSON.parse(String(init.body))).toEqual({ path: '/tmp/n', subfolder: 'docs' })
+  })
+
+  it('forgets a vault by encoded id', async () => {
+    reply({ json: { ok: true, localPath: '/tmp/n' } })
+    await notesApi.forgetVault('a/b c')
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/vaults?vault=a%2Fb%20c`)
+    expect(init.method).toBe('DELETE')
+  })
+
+  it('toggles the knowledge flag', async () => {
+    reply({ json: { vault: VAULT } })
+    await notesApi.setVaultKnowledge('v1', true, 'src-9')
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/vaults/knowledge`)
+    expect(init.method).toBe('PUT')
+    expect(JSON.parse(String(init.body))).toEqual({
+      vault: 'v1',
+      knowledge: true,
+      sourceId: 'src-9',
+    })
+  })
+
+  it('stores a PAT', async () => {
+    reply({ json: { hasPat: true, hasGhAuth: true } })
+    const out = await notesApi.setPat('ghp_x')
+    expect(out).toEqual({ hasPat: true, hasGhAuth: true })
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/pat`)
+    expect(init.method).toBe('PUT')
+  })
+
+  it('opens the folder picker', async () => {
+    reply({ json: { path: null, cancelled: true } })
+    const out = await notesApi.pickFolder()
+    expect(out.cancelled).toBe(true)
+    expect(callAt(0).url).toBe(`${API_BASE}/pick-folder`)
+  })
+})
+
+describe('note endpoints', () => {
+  it('reads a note with both the path and the vault in the query', async () => {
+    reply({ json: { path: 'a/b.md', content: '#', mtime: 5 } })
+    await notesApi.readNote('v1', 'a/b c.md')
+    expect(callAt(0).url).toBe(`${API_BASE}/note?path=a%2Fb%20c.md&vault=v1`)
+  })
+
+  it('saves a note with the mtime guard', async () => {
+    reply({ json: { ok: true, mtime: 9 } })
+    await notesApi.saveNote('v1', 'a.md', 'body', 8)
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/note?vault=v1`)
+    expect(init.method).toBe('PUT')
+    expect(JSON.parse(String(init.body))).toEqual({
+      path: 'a.md',
+      content: 'body',
+      baseMtime: 8,
+    })
+  })
+
+  it('omits baseMtime when the caller has no snapshot', async () => {
+    reply({ json: { ok: true, mtime: 1 } })
+    await notesApi.saveNote(null, 'a.md', 'body')
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/note`)
+    expect(JSON.parse(String(init.body))).toEqual({ path: 'a.md', content: 'body' })
+  })
+
+  it('deletes a note', async () => {
+    reply({ json: { ok: true } })
+    await notesApi.deleteNote('v1', 'a.md')
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/note?path=a.md&vault=v1`)
+    expect(init.method).toBe('DELETE')
+  })
+
+  it('creates a note in a folder', async () => {
+    reply({ json: { path: 'f/Untitled.md' } })
+    const out = await notesApi.newNote('v1', 'f')
+    expect(out.path).toBe('f/Untitled.md')
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/note/new?vault=v1`)
+    expect(JSON.parse(String(init.body))).toEqual({ folder: 'f' })
+  })
+
+  it('duplicates a note', async () => {
+    reply({ json: { path: 'a copy.md' } })
+    await notesApi.duplicateNote('v1', 'a.md')
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/note/duplicate?vault=v1`)
+    expect(JSON.parse(String(init.body))).toEqual({ path: 'a.md' })
+  })
+
+  it('moves a note', async () => {
+    reply({ json: { ok: true, path: 'b.md' } })
+    await notesApi.moveNote('v1', 'a.md', 'b.md')
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/note/move?vault=v1`)
+    expect(JSON.parse(String(init.body))).toEqual({ from: 'a.md', to: 'b.md' })
+  })
+
+  it('polls for external changes since a revision', async () => {
+    reply({ json: { rev: 4, changed: ['a.md'], watching: true } })
+    const out = await notesApi.changes('v1', 3)
+    expect(out.changed).toEqual(['a.md'])
+    expect(callAt(0).url).toBe(`${API_BASE}/changes?since=3&vault=v1`)
+  })
+})
+
+describe('git endpoints', () => {
+  it('syncs', async () => {
+    reply({ json: { result: { pushed: 1 } } })
+    await notesApi.sync('v1')
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/sync?vault=v1`)
+    expect(init.method).toBe('POST')
+    expect(init.body).toBeUndefined()
+  })
+
+  it('commits locally', async () => {
+    reply({ json: { result: { committed: 2 } } })
+    await notesApi.commit('v1')
+    expect(callAt(0).url).toBe(`${API_BASE}/commit?vault=v1`)
+  })
+
+  it('opens the trash folder without sending a path', async () => {
+    reply({ json: { opened: false, empty: true, path: '' } })
+    const out = await notesApi.openTrash('v1')
+    expect(out.empty).toBe(true)
+    const { url, init } = callAt(0)
+    expect(url).toBe(`${API_BASE}/trash/open?vault=v1`)
+    expect(init.body).toBeUndefined()
+  })
+})
+
+describe('knowledgeRegister', () => {
+  it('registers the vault content path and confirms the source', async () => {
+    reply({ status: 201, json: { id: 'src-1', file_count: 12 } }, { status: 200 })
+    const out = await knowledgeRegister(VAULT)
+    expect(out).toEqual({ sourceId: 'src-1', fileCount: 12 })
+
+    const add = callAt(0)
+    expect(add.url).toBe('/api/knowledge/sources')
+    expect(add.init.method).toBe('POST')
+    expect(JSON.parse(String(add.init.body))).toEqual({
+      name: 'My Vault',
+      source_type: 'obsidian_vault',
+      uri: '/home/me/vaults/notes/docs',
+      properties: {},
+    })
+
+    const confirm = callAt(1)
+    expect(confirm.url).toBe('/api/knowledge/sources/src-1/confirm')
+    expect(confirm.init.method).toBe('POST')
+  })
+
+  it('omits the subfolder from the uri when the vault has none', async () => {
+    reply({ status: 200, json: { id: 'src-2' } }, { status: 200 })
+    const out = await knowledgeRegister({ ...VAULT, subfolder: undefined })
+    expect(out).toEqual({ sourceId: 'src-2', fileCount: undefined })
+    expect(JSON.parse(String(callAt(0).init.body)).uri).toBe('/home/me/vaults/notes')
+  })
+
+  it('adopts the existing source id on 409 instead of failing', async () => {
+    reply({ status: 409, json: { id: 'src-old', error: 'already registered' } }, { status: 200 })
+    const out = await knowledgeRegister(VAULT)
+    expect(out.sourceId).toBe('src-old')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces the server error when registration fails', async () => {
+    reply({ status: 500, json: { error: 'disk full' } })
+    await expect(knowledgeRegister(VAULT)).rejects.toThrow('disk full')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports the status when a failed registration carries no error text', async () => {
+    reply({ status: 503, jsonThrows: true })
+    await expect(knowledgeRegister(VAULT)).rejects.toThrow('knowledge add failed (503)')
+  })
+
+  it('rejects a 2xx reply that carries no source id', async () => {
+    reply({ status: 200, json: {} })
+    await expect(knowledgeRegister(VAULT)).rejects.toThrow(
+      'knowledge add returned no source id',
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('prefers the payload error over the generic no-id message on 409', async () => {
+    reply({ status: 409, json: { error: 'conflict without id' } })
+    await expect(knowledgeRegister(VAULT)).rejects.toThrow('conflict without id')
+  })
+
+  it('removes the orphan source when confirmation fails', async () => {
+    reply(
+      { status: 201, json: { id: 'src 3' } },
+      { status: 500, json: { error: 'scan refused' } },
+      { status: 200 },
+    )
+    await expect(knowledgeRegister(VAULT)).rejects.toThrow('scan refused')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    const del = callAt(2)
+    expect(del.url).toBe('/api/knowledge/sources/src%203')
+    expect(del.init.method).toBe('DELETE')
+  })
+
+  it('still reports the confirm failure when the cleanup delete also fails', async () => {
+    reply(
+      { status: 201, json: { id: 'src-4' } },
+      { status: 500, jsonThrows: true },
+      { status: 500, json: { error: 'delete refused' } },
+    )
+    await expect(knowledgeRegister(VAULT)).rejects.toThrow('knowledge confirm failed (500)')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('knowledgeUnregister', () => {
+  it('does nothing without a source id', async () => {
+    await knowledgeUnregister(undefined)
+    await knowledgeUnregister(null)
+    await knowledgeUnregister('')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('deletes the source by encoded id', async () => {
+    reply({ status: 200 })
+    await knowledgeUnregister('a/b')
+    const { url, init } = callAt(0)
+    expect(url).toBe('/api/knowledge/sources/a%2Fb')
+    expect(init.method).toBe('DELETE')
+    expect(init.credentials).toBe('same-origin')
+  })
+
+  it('treats an already-gone source as success', async () => {
+    reply({ status: 404, json: { error: 'not found' } })
+    await expect(knowledgeUnregister('src-9')).resolves.toBeUndefined()
+  })
+
+  it('raises the server error on any other failure', async () => {
+    reply({ status: 500, json: { error: 'locked' } })
+    await expect(knowledgeUnregister('src-9')).rejects.toThrow('locked')
+  })
+
+  it('reports the status when the failure carries no error text', async () => {
+    reply({ status: 500, jsonThrows: true })
+    await expect(knowledgeUnregister('src-9')).rejects.toThrow('knowledge remove failed (500)')
+  })
+})

--- a/website/src/test/MochiChatPanelCoverage.test.tsx
+++ b/website/src/test/MochiChatPanelCoverage.test.tsx
@@ -1,0 +1,776 @@
+/**
+ * Mochi chat panel — the paths `MochiChatPanel.coverage.test.tsx` leaves alone.
+ *
+ * That file covers the panel's headline flows (send, slash commands, approvals,
+ * the destructive confirmations). This one takes the parts that only appear once
+ * the panel is put under conditions a no-layout test environment does not supply
+ * by itself:
+ *
+ *  - the two lazy-history loaders (the "content does not fill the container"
+ *    auto-load, and the sentinel becoming visible again) plus the pre-paint
+ *    scroll correction that keeps the reading position steady when messages are
+ *    PREPENDED — which needs a scroll geometry, so the metrics are stubbed;
+ *  - the floating stop capsule's measured offset, which comes from a
+ *    ResizeObserver on the bottom stack;
+ *  - the scroll-position pill, which needs a scroller that is not at its end;
+ *  - the markdown component table the reply renderer installs (tables, lists,
+ *    inline code, remote vs. local images) and the widget branches of both the
+ *    streaming and the committed renderer;
+ *  - `relativeTime`'s whole ladder, from "now" to an absolute date;
+ *  - the timer-driven affordances: the rotating placeholder, the copy
+ *    confirmation reverting, and the gateway-start button's 8s settle window.
+ *
+ * Timers: the panel runs a 10s placeholder interval and several deferred state
+ * updates, so every test that needs to jump forward installs fake timers with
+ * `shouldAdvanceTime` (so awaited work still progresses) and `afterEach` drops
+ * whatever is still queued — an orphan timer firing after teardown would make
+ * the run exit non-zero with every test green, and no coverage report written.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+type AnyFn = (...args: never[]) => unknown
+
+/** Captured `on*` subscribers, keyed by the api method that registered them. */
+const subscribers = new Map<string, Set<AnyFn>>()
+
+function subscribe(channel: string) {
+  return (cb: AnyFn) => {
+    const set = subscribers.get(channel) ?? new Set<AnyFn>()
+    set.add(cb)
+    subscribers.set(channel, set)
+    return () => { set.delete(cb) }
+  }
+}
+
+/** Push a backend frame to whatever the panel registered on `channel`. */
+function emit(channel: string, ...args: unknown[]): void {
+  for (const cb of Array.from(subscribers.get(channel) ?? [])) {
+    ;(cb as (...a: unknown[]) => unknown)(...args)
+  }
+}
+
+/** Chat history handed back by `getChatHistory`; set per test before render. */
+let history: unknown[] = []
+/** Initial backend reachability, so the offline banner can be exercised. */
+let backendOnline = true
+
+const sendMessage = vi.fn(async () => undefined)
+const stopGeneration = vi.fn(async () => undefined)
+const retryConnect = vi.fn(async () => ({ ok: true } as { ok: boolean; message?: string }))
+const resetMochi = vi.fn(async () => undefined)
+const respondApproval = vi.fn(async () => undefined as unknown)
+const openLightbox = vi.fn()
+const previewFile = vi.fn()
+const unpinFile = vi.fn()
+const markPinnedSeen = vi.fn()
+const openWidgetExternal = vi.fn()
+const readLocalImage = vi.fn(async (_path: string): Promise<string | null> => null)
+
+vi.mock('../apps/mochi/src/mochiApi', () => ({
+  api: {
+    getMochiConfig: async () => ({ petName: 'Mochi', theme: 'mocha' }),
+    getConfig: async () => ({
+      shortcuts: {
+        toggleWindow: 'CommandOrControl+Shift+M',
+        screenCapture: 'CommandOrControl+Shift+X',
+        hideAll: 'CommandOrControl+Shift+H',
+      },
+    }),
+    getPetStateInfo: async () => ({ state: 'idle', mood: 'neutral' }),
+    getChatHistory: async () => history,
+    getBackendStatus: async () => backendOnline,
+    onStateChange: subscribe('onStateChange'),
+    onMood: subscribe('onMood'),
+    onPeeking: subscribe('onPeeking'),
+    onConfigUpdated: subscribe('onConfigUpdated'),
+    onChatChunk: subscribe('onChatChunk'),
+    onChatDone: subscribe('onChatDone'),
+    onChatMessage: subscribe('onChatMessage'),
+    onBackendStatus: subscribe('onBackendStatus'),
+    onBackendSwitching: subscribe('onBackendSwitching'),
+    onSlotsUpdate: subscribe('onSlotsUpdate'),
+    onCaptureDone: subscribe('onCaptureDone'),
+    onApprovalRequest: subscribe('onApprovalRequest'),
+    onApprovalResolvedExternal: subscribe('onApprovalResolvedExternal'),
+    onThemeChanged: subscribe('onThemeChanged'),
+    onContextUsage: subscribe('onContextUsage'),
+    sendMessage,
+    stopGeneration,
+    retryConnect,
+    resetMochi,
+    respondApproval,
+    openLightbox,
+    previewFile,
+    revealFile: vi.fn(),
+    unpinFile,
+    markPinnedSeen,
+    openExternal: vi.fn(),
+    openWidgetExternal,
+    readLocalImage,
+    closeChat: vi.fn(),
+    openSettings: vi.fn(),
+    galleryOpen: vi.fn(),
+    openDashboard: vi.fn(),
+    newSession: vi.fn(async () => undefined),
+    editResend: vi.fn(async () => ({ ok: true })),
+    deleteHistory: vi.fn(async () => undefined),
+  },
+}))
+
+const { ChatPanel, PinnedSidePanel } = await import('../apps/mochi/src/renderer/ChatPanel')
+
+/** Property overrides installed for one test, undone by `afterEach`. */
+const restores: (() => void)[] = []
+
+/**
+ * Replace a prototype accessor (`scrollHeight`, `offsetHeight`, …) for one test.
+ *
+ * The environment has no layout, so every metric the panel reads is 0 and the
+ * geometry-dependent branches are unreachable. Overriding the accessor is the
+ * only way to give the component a scroller that is taller than its viewport.
+ */
+function stubMetric(proto: object, name: string, get: () => number): void {
+  const original = Object.getOwnPropertyDescriptor(proto, name)
+  Object.defineProperty(proto, name, { configurable: true, get })
+  restores.push(() => {
+    if (original) Object.defineProperty(proto, name, original)
+    else delete (proto as Record<string, unknown>)[name]
+  })
+}
+
+/**
+ * Record every scroll position assigned to any element, for one test.
+ *
+ * The panel writes `scrollTop` from several places (the post-load jump to the
+ * end, and the pre-paint correction under test), so reading the final value
+ * proves nothing about which write happened. The log does.
+ */
+function recordScrollTops(): number[] {
+  const written: number[] = []
+  let current = 0
+  const original = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollTop')
+  Object.defineProperty(Element.prototype, 'scrollTop', {
+    configurable: true,
+    get: () => current,
+    set: (v: number) => { current = v; written.push(v) },
+  })
+  restores.push(() => {
+    if (original) Object.defineProperty(Element.prototype, 'scrollTop', original)
+    else delete (Element.prototype as unknown as Record<string, unknown>).scrollTop
+  })
+  return written
+}
+
+/** Replace a global (IntersectionObserver, ResizeObserver) for one test. */
+function stubGlobal(name: string, value: unknown): void {
+  const holder = globalThis as unknown as Record<string, unknown>
+  const original = holder[name]
+  holder[name] = value
+  restores.push(() => { holder[name] = original })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  subscribers.clear()
+  history = []
+  backendOnline = true
+  sendMessage.mockResolvedValue(undefined)
+  retryConnect.mockResolvedValue({ ok: true })
+  readLocalImage.mockResolvedValue(null)
+})
+
+afterEach(() => {
+  // Drop deferred work before the DOM goes away: the panel queues 8s and 1.5s
+  // updates, and one landing after teardown fails the run on its own.
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  while (restores.length > 0) restores.pop()!()
+})
+
+/** Render the panel and wait until the mount-time config reads have settled. */
+async function renderPanel(props: Partial<React.ComponentProps<typeof ChatPanel>> = {}) {
+  const view = render(<ChatPanel {...props} />)
+  await screen.findByText(/Idle/)
+  return view
+}
+
+/** The panel's composer. */
+function composer(): HTMLTextAreaElement {
+  return screen.getByPlaceholderText(/./) as HTMLTextAreaElement
+}
+
+/**
+ * A turn, in the shape both channels use.
+ *
+ * The id matters for the live channel (`chat:message`) — the panel keys the
+ * bubble and its entry animation off it. History entries are re-keyed on load,
+ * so the same helper serves both.
+ */
+function turn(role: string, content: string, timestamp = 1700000000000) {
+  return { id: `t-${role}-${timestamp}-${content.length}`, role, content, timestamp }
+}
+
+describe('ChatPanel lazy history', () => {
+  it('pulls in earlier turns until the transcript fills the scroller', async () => {
+    // 25 turns, but only 10 render at first. With nothing filling the viewport
+    // the panel keeps asking for more rather than leaving the user with a short
+    // transcript and no way to notice there is more.
+    history = Array.from({ length: 25 }, (_, i) => turn('user', `turn ${i}`, 1700000000000 + i))
+    await renderPanel()
+    expect(await screen.findByText('turn 24')).toBeInTheDocument()
+    expect(screen.queryByText('turn 0')).not.toBeInTheDocument()
+    expect(await screen.findByText('turn 0', {}, { timeout: 5000 })).toBeInTheDocument()
+    // Everything is loaded, so the load-earlier affordance is gone.
+    expect(screen.queryByText(/Load earlier messages/)).not.toBeInTheDocument()
+  })
+
+  it('keeps the reading position steady when the sentinel pulls older turns in', async () => {
+    // A scroller that is taller than its viewport, so the auto-loader above
+    // stays out of the way and the sentinel path is the one under test. Height
+    // grows with the number of rendered rows, which is what makes the
+    // pre-paint correction observable.
+    stubMetric(Element.prototype, 'clientHeight', () => 0)
+    stubMetric(Element.prototype, 'scrollHeight', function (this: Element) {
+      return this.childElementCount * 100
+    })
+
+    const observers: ((entries: unknown[]) => void)[] = []
+    stubGlobal('IntersectionObserver', class {
+      constructor(private readonly cb: (entries: unknown[]) => void) { observers.push(cb) }
+      observe() { this.cb([{ isIntersecting: true }]) }
+      unobserve() {}
+      disconnect() {}
+      takeRecords() { return [] }
+    })
+
+    history = Array.from({ length: 25 }, (_, i) => turn('user', `turn ${i}`, 1700000000000 + i))
+    const { container } = await renderPanel()
+    await screen.findByText('turn 24')
+    const scroller = container.querySelector('.chat-scroll') as HTMLElement
+    expect(screen.queryByText('turn 14')).not.toBeInTheDocument()
+
+    const before = scroller.scrollHeight
+    const scrollTops = recordScrollTops()
+    act(() => { observers.forEach(cb => cb([{ isIntersecting: true }])) })
+    expect(await screen.findByText('turn 14')).toBeInTheDocument()
+    // The prepended rows made the content taller; the panel pushes the scroll
+    // position down by exactly that much so the turn the user was reading does
+    // not jump off screen.
+    const grew = scroller.scrollHeight - before
+    expect(grew).toBeGreaterThan(0)
+    expect(scrollTops).toContain(grew)
+
+    // The in-flight guard is released once the prepend has settled, so scrolling
+    // back up again keeps walking the history instead of stopping at one page.
+    await waitFor(async () => {
+      act(() => { observers.forEach(cb => cb([{ isIntersecting: true }])) })
+      expect(await screen.findByText('turn 4')).toBeInTheDocument()
+    }, { timeout: 5000 })
+  })
+})
+
+describe('ChatPanel scroll position pill', () => {
+  it('offers a way back to the latest turn once the user scrolls away from it', async () => {
+    stubMetric(Element.prototype, 'clientHeight', () => 0)
+    stubMetric(Element.prototype, 'scrollHeight', () => 1000)
+    history = [turn('assistant', 'older answer')]
+    const { container } = await renderPanel()
+    await screen.findByText('older answer')
+    const scroller = container.querySelector('.chat-scroll') as HTMLElement
+    const scrollTo = vi.fn()
+    scroller.scrollTo = scrollTo as unknown as typeof scroller.scrollTo
+
+    expect(screen.queryByRole('button', { name: 'Scroll to Latest' })).not.toBeInTheDocument()
+    fireEvent.scroll(scroller)
+    const pill = await screen.findByRole('button', { name: 'Scroll to Latest' })
+
+    // The pill dims under the pointer, which is how it reads as pressable.
+    await userEvent.hover(pill)
+    expect(pill.style.opacity).toBe('0.85')
+    await userEvent.unhover(pill)
+    expect(pill.style.opacity).toBe('1')
+
+    await userEvent.click(pill)
+    expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' })
+  })
+})
+
+describe('ChatPanel floating stop capsule', () => {
+  it('lifts clear of the bottom stack as the composer grows', async () => {
+    let stackHeight = 0
+    stubMetric(HTMLElement.prototype, 'offsetHeight', () => stackHeight)
+    const observers: (() => void)[] = []
+    stubGlobal('ResizeObserver', class {
+      constructor(private readonly cb: () => void) { observers.push(() => this.cb()) }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    })
+
+    await renderPanel()
+    emit('onChatMessage', turn('user', 'do a thing'))
+    const stop = await screen.findByRole('button', { name: /Stop/ })
+    const floating = stop.parentElement as HTMLElement
+    // Nothing measured yet: the fallback keeps the capsule off the composer.
+    expect(floating.style.bottom).toBe('62px')
+
+    stackHeight = 80
+    act(() => { observers.forEach(fire => fire()) })
+    // Re-measured, so a grown composer cannot end up underneath the capsule.
+    await waitFor(() => expect(floating.style.bottom).toBe('98px'))
+  })
+})
+
+describe('ChatPanel context menu dismissal', () => {
+  it('leaves the text selection alone instead of hijacking the right-click', async () => {
+    const { container } = await renderPanel()
+    const selection = vi.spyOn(window, 'getSelection').mockReturnValue({
+      toString: () => 'some selected words',
+    } as unknown as Selection)
+    try {
+      fireEvent.contextMenu(container.firstChild as HTMLElement, { clientX: 5, clientY: 5 })
+      // The browser's own copy menu belongs to a selection; the pet menu would
+      // replace it and there would be no way to copy the transcript.
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    } finally {
+      selection.mockRestore()
+    }
+  })
+
+  it('closes the menu on the next click anywhere in the panel', async () => {
+    const { container } = await renderPanel()
+    const shell = container.firstChild as HTMLElement
+    fireEvent.contextMenu(shell, { clientX: 5, clientY: 5 })
+    await screen.findByRole('menu')
+    fireEvent.click(shell)
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument())
+  })
+})
+
+describe('ChatPanel reset confirmation', () => {
+  it('cancels without resetting anything', async () => {
+    history = [turn('user', 'kept turn')]
+    const { container } = await renderPanel()
+    await screen.findByText('kept turn')
+    fireEvent.contextMenu(container.firstChild as HTMLElement, { clientX: 5, clientY: 5 })
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Reset Mochi' }))
+    await screen.findByText('Reset Mochi?')
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByText('Reset Mochi?')).not.toBeInTheDocument())
+    expect(resetMochi).not.toHaveBeenCalled()
+    expect(screen.getByText('kept turn')).toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel gateway start', () => {
+  it('reports the start as under way and re-offers it once the window lapses', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    backendOnline = false
+    await renderPanel()
+    const start = await screen.findByRole('button', { name: 'Start Kiro Crew' }, { timeout: 5000 })
+    retryConnect.mockResolvedValueOnce({ ok: true })
+    await userEvent.click(start)
+
+    // Two separate surfaces: the button is replaced by a progress label, and the
+    // message line explains what is happening.
+    expect(await screen.findByText('Connecting...')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Start Kiro Crew' })).not.toBeInTheDocument()
+
+    // The socket never connects, so the panel gives up waiting and lets the user
+    // try again rather than sitting on "Connecting..." forever.
+    await act(async () => { await vi.advanceTimersByTimeAsync(8000) })
+    expect(await screen.findByRole('button', { name: 'Start Kiro Crew' })).toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel screen capture', () => {
+  /** Answer the upload route without touching the network. */
+  function stubUpload(status: number, body: unknown) {
+    const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify(body), { status }),
+    )
+    restores.push(() => spy.mockRestore())
+    return spy
+  }
+
+  it('keeps the crop and says why it could not be attached', async () => {
+    stubUpload(415, { error: 'Unsupported file type' })
+    const { container } = await renderPanel()
+    // 'QUJD' is base64 for 'ABC' — cropToFile runs it through atob.
+    emit('onCaptureDone', 'QUJD')
+    expect(await screen.findByText('Unsupported file type')).toBeInTheDocument()
+    // Losing the capture outright would be worse than showing it locally only.
+    await waitFor(() =>
+      expect(container.querySelector('img[src="data:image/png;base64,QUJD"]')).not.toBeNull(),
+    )
+  })
+
+  it('opens the kept crop in the lightbox', async () => {
+    stubUpload(200, { paths: [] })
+    const { container } = await renderPanel()
+    emit('onCaptureDone', 'QUJD')
+    const preview = await waitFor(() => {
+      const found = container.querySelector('img[src="data:image/png;base64,QUJD"]')
+      expect(found).not.toBeNull()
+      return found as HTMLImageElement
+    })
+    // The dismiss dot is revealed by hovering the thumbnail.
+    const wrapper = preview.parentElement as HTMLElement
+    fireEvent.mouseEnter(wrapper)
+    expect((wrapper.querySelector('.x-btn') as HTMLElement).style.opacity).toBe('1')
+    fireEvent.mouseLeave(wrapper)
+    expect((wrapper.querySelector('.x-btn') as HTMLElement).style.opacity).toBe('0')
+
+    await userEvent.click(preview)
+    expect(openLightbox).toHaveBeenCalledWith('QUJD')
+  })
+
+  it('attaches an image pasted into the composer', async () => {
+    stubUpload(200, { paths: ['/home/u/uploads/pasted.png'] })
+    await renderPanel()
+    const file = new File(['x'], 'pasted.png', { type: 'image/png' })
+    fireEvent.paste(composer(), {
+      clipboardData: {
+        items: [{ kind: 'file', type: file.type, getAsFile: () => file }],
+        files: [file],
+        types: ['Files'],
+      },
+    })
+    // The strip records what will be sent; the typed text stays clean.
+    expect(await screen.findByAltText('pasted.png')).toBeInTheDocument()
+    expect(composer()).toHaveValue('')
+  })
+})
+
+describe('ChatPanel streaming renderer', () => {
+  it('paints buffered chunks on the next frame', async () => {
+    await renderPanel()
+    // No done frame: the chunk has to reach the bubble through the throttle on
+    // its own, which is what the user sees mid-answer.
+    emit('onChatChunk', 'thinking out loud')
+    expect(await screen.findByText('thinking out loud')).toBeInTheDocument()
+  })
+
+  it('drops a buffered chunk when the panel goes away mid-answer', async () => {
+    const view = await renderPanel()
+    emit('onChatChunk', 'half a thought')
+    // Unmounting with a frame still pending must not leave it to fire into a
+    // dead component.
+    view.unmount()
+    expect(screen.queryByText('half a thought')).not.toBeInTheDocument()
+  })
+
+  it('renders a completed widget and keeps streaming the text after it', async () => {
+    await renderPanel()
+    emit('onChatChunk', 'Here it is <mcwidget title="Chart">bars</mcwidget> and more to come')
+    emit('onChatDone')
+    expect(await screen.findByTitle('Chart')).toBeInTheDocument()
+    expect(screen.getByText('Here it is')).toBeInTheDocument()
+    expect(screen.getByText(/and more to come/)).toBeInTheDocument()
+    expect(screen.queryByText(/mcwidget/)).not.toBeInTheDocument()
+  })
+
+  it('hands a streamed widget to the OS browser on request', async () => {
+    await renderPanel()
+    emit('onChatChunk', '<mcwidget title="Chart">bars</mcwidget>')
+    emit('onChatDone')
+    await screen.findByTitle('Chart')
+    await userEvent.click(screen.getByRole('button', { name: 'Open in browser' }))
+    expect(openWidgetExternal).toHaveBeenCalledTimes(1)
+    expect(openWidgetExternal.mock.calls[0][1]).toBe('Chart')
+  })
+})
+
+describe('ChatPanel reply markdown', () => {
+  it('renders a table with the panel cell metrics', async () => {
+    history = [turn('assistant', '| Env | State |\n| --- | --- |\n| beta | green |')]
+    await renderPanel()
+    const header = await screen.findByText('Env')
+    expect(header.tagName).toBe('TH')
+    expect(header.style.fontWeight).toBe('600')
+    const cell = screen.getByText('beta')
+    expect(cell.tagName).toBe('TD')
+    expect(cell.style.padding).toBe('3px 6px')
+    expect(cell.closest('table')?.style.borderCollapse).toBe('collapse')
+  })
+
+  it('renders both list flavours with the panel spacing', async () => {
+    history = [turn('assistant', '- first\n- second\n\n1. step one\n2. step two')]
+    await renderPanel()
+    const bullet = await screen.findByText('first')
+    expect(bullet.tagName).toBe('LI')
+    expect(bullet.closest('ul')?.style.paddingLeft).toBe('16px')
+    expect(screen.getByText('step one').closest('ol')?.style.paddingLeft).toBe('16px')
+  })
+
+  it('leaves inline code that is not a file path as code', async () => {
+    history = [turn('assistant', 'Run `npm test` and wait.')]
+    await renderPanel()
+    const code = await screen.findByText('npm test')
+    expect(code.tagName).toBe('CODE')
+    // A path would have become a chip with preview/reveal buttons instead.
+    expect(screen.queryByRole('button', { name: 'Preview' })).not.toBeInTheDocument()
+  })
+
+  it('leaves a remote image for the browser to load', async () => {
+    // `.svg` is outside the extension list the reply renderer lifts paths out
+    // with, so this reference survives into the markdown image component — the
+    // one place the local-vs-remote decision is actually made.
+    history = [turn('assistant', '![banner](https://example.com/banner.svg)')]
+    const { container } = await renderPanel()
+    await waitFor(() =>
+      expect(container.querySelector('img[src="https://example.com/banner.svg"]')).not.toBeNull(),
+    )
+    // Nothing local about it, so the app-api reader is not involved.
+    expect(readLocalImage).not.toHaveBeenCalled()
+  })
+
+  it('reads an on-disk image through the app api even for an unlisted extension', async () => {
+    // A bare `<img src="/home/...">` would be resolved against the gateway
+    // origin and 404, so any absolute path has to go through the reader.
+    readLocalImage.mockResolvedValue('QUJD')
+    history = [turn('assistant', '![diagram](/home/u/diagram.svg)')]
+    const { container } = await renderPanel()
+    await waitFor(() => expect(readLocalImage).toHaveBeenCalledWith('/home/u/diagram.svg'))
+    expect(container.querySelector('img[src="/home/u/diagram.svg"]')).toBeNull()
+    const img = container.querySelector('img[src^="data:image/png;base64,"]') as HTMLImageElement
+    await userEvent.click(img)
+    expect(openLightbox).toHaveBeenCalledWith('/home/u/diagram.svg')
+  })
+
+  it('renders a widget in a committed reply alongside its images', async () => {
+    readLocalImage.mockResolvedValue('QUJD')
+    history = [
+      turn('assistant', 'Chart below\n<mcwidget title="Usage">bars</mcwidget>\n/home/u/shot.png'),
+    ]
+    await renderPanel()
+    expect(await screen.findByTitle('Usage')).toBeInTheDocument()
+    expect(screen.getByText('Chart below')).toBeInTheDocument()
+    // The bare path is lifted out of the text and rendered as the image itself.
+    await waitFor(() => expect(readLocalImage).toHaveBeenCalledWith('/home/u/shot.png'))
+    expect(screen.queryByText(/shot\.png/)).not.toBeInTheDocument()
+  })
+
+  it('names the widget generically when the model gave it no title', async () => {
+    history = [turn('assistant', '<mcwidget>bars</mcwidget>')]
+    await renderPanel()
+    expect(await screen.findByTitle('Widget')).toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel user message content', () => {
+  it('renders a markdown image the user typed as the image', async () => {
+    readLocalImage.mockResolvedValue('QUJD')
+    history = [turn('user', '![my shot](/home/u/typed.png)')]
+    await renderPanel()
+    await waitFor(() => expect(readLocalImage).toHaveBeenCalledWith('/home/u/typed.png'))
+  })
+
+  it('opens a captured screenshot carried on the message', async () => {
+    await renderPanel()
+    emit('onChatMessage', { ...turn('user', 'what is this'), id: 'm-ss', screenshot: 'QUJD' })
+    const shot = await waitFor(() => {
+      const found = document.querySelector('img[src="data:image/png;base64,QUJD"]')
+      expect(found).not.toBeNull()
+      return found as HTMLImageElement
+    })
+    await userEvent.click(shot)
+    expect(openLightbox).toHaveBeenCalledWith('QUJD')
+  })
+})
+
+describe('ChatPanel timestamps', () => {
+  it('ages each turn from "now" up to an absolute date', async () => {
+    const now = Date.now()
+    const min = 60_000
+    history = [
+      turn('assistant', 'just landed', now),
+      turn('assistant', 'half a minute', now - 30_000),
+      turn('assistant', 'five minutes', now - 5 * min),
+      turn('assistant', 'three hours', now - 3 * 60 * min),
+      turn('assistant', 'two days', now - 2 * 24 * 60 * min),
+      turn('assistant', 'last month', now - 40 * 24 * 60 * min),
+    ]
+    await renderPanel()
+    await screen.findByText('just landed')
+    expect(screen.getByText('now')).toBeInTheDocument()
+    expect(screen.getByText('30 seconds ago')).toBeInTheDocument()
+    expect(screen.getByText('5 minutes ago')).toBeInTheDocument()
+    expect(screen.getByText('3 hours ago')).toBeInTheDocument()
+    expect(screen.getByText('2 days ago')).toBeInTheDocument()
+    // Beyond a week "N days ago" stops being useful, so it becomes a date.
+    expect(screen.getByText(/^\d{1,2}\/\d{1,2},/)).toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel copy confirmation', () => {
+  it('reverts to the copy action after acknowledging the copy', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    history = [turn('assistant', 'the answer')]
+    await renderPanel()
+    await user.click(await screen.findByRole('button', { name: 'Copy markdown' }))
+    const copied = await screen.findByRole('button', { name: 'Copied' })
+    expect(copied.style.opacity).toBe('1')
+
+    // The tick is an acknowledgement, not a new state — it has to go away.
+    await act(async () => { await vi.advanceTimersByTimeAsync(1500) })
+    expect(await screen.findByRole('button', { name: 'Copy markdown' })).toBeInTheDocument()
+  })
+
+  it('brings the copy action forward under the pointer', async () => {
+    history = [turn('assistant', 'the answer')]
+    await renderPanel()
+    const copy = await screen.findByRole('button', { name: 'Copy markdown' })
+    fireEvent.mouseEnter(copy)
+    expect(copy.style.transform).toBe('scale(1.2)')
+    expect(copy.style.color).toBe('var(--text-muted)')
+    fireEvent.mouseLeave(copy)
+    expect(copy.style.transform).toBe('scale(1)')
+    expect(copy.style.color).toBe('var(--text-faint)')
+  })
+
+  it('brings the edit action forward under the pointer', async () => {
+    history = [turn('user', 'my question')]
+    await renderPanel()
+    const edit = await screen.findByRole('button', { name: 'Edit & resend' })
+    fireEvent.mouseEnter(edit)
+    expect(edit.style.transform).toBe('scale(1.2)')
+    fireEvent.mouseLeave(edit)
+    expect(edit.style.transform).toBe('scale(1)')
+  })
+})
+
+describe('ChatPanel composer focus and tips', () => {
+  it('takes the caret back when the window is refocused', async () => {
+    await renderPanel()
+    composer().blur()
+    expect(document.activeElement).not.toBe(composer())
+    fireEvent.focus(window)
+    // The panel is a small always-on-top window: refocusing it should leave the
+    // user able to type immediately.
+    expect(document.activeElement).toBe(composer())
+  })
+
+  it('rotates the placeholder tip', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    await renderPanel()
+    const first = composer().placeholder
+    await act(async () => { await vi.advanceTimersByTimeAsync(10_000) })
+    expect(composer().placeholder).not.toBe(first)
+  })
+})
+
+describe('ChatPanel stop capsule hover', () => {
+  it('dims the stop capsule under the pointer', async () => {
+    await renderPanel()
+    emit('onChatMessage', turn('user', 'long job'))
+    const stop = await screen.findByRole('button', { name: /Stop/ })
+    fireEvent.mouseEnter(stop)
+    expect(stop.style.opacity).toBe('0.8')
+    fireEvent.mouseLeave(stop)
+    expect(stop.style.opacity).toBe('1')
+  })
+})
+
+describe('ChatPanel trust scopes', () => {
+  it('grants every tool when the widest scope is chosen deliberately', async () => {
+    await renderPanel()
+    emit('onApprovalRequest', {
+      id: 'req-9', tool: 'execute_bash', toolInput: 'cat x',
+      fullCommand: 'cat x', baseCommand: 'cat',
+    })
+    await userEvent.click(await screen.findByRole('button', { name: 'Trust' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Trust all tools' }))
+    expect(respondApproval).toHaveBeenCalledWith('req-9', 'trust', undefined)
+    expect(await screen.findByText('Trusted')).toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel file chip', () => {
+  it('previews the file from the keyboard as well as the pointer', async () => {
+    history = [turn('assistant', 'Check `src/app/notes.md` please.')]
+    await renderPanel()
+    const chip = await screen.findByTitle('src/app/notes.md')
+    expect(chip).toHaveAttribute('role', 'button')
+    fireEvent.keyDown(chip, { key: 'Enter' })
+    expect(previewFile).toHaveBeenCalledWith('src/app/notes.md')
+    fireEvent.keyDown(chip, { key: ' ' })
+    expect(previewFile).toHaveBeenCalledTimes(2)
+    // An unrelated key must not open anything.
+    fireEvent.keyDown(chip, { key: 'a' })
+    expect(previewFile).toHaveBeenCalledTimes(2)
+  })
+
+  it('highlights the chip actions under the pointer', async () => {
+    history = [turn('assistant', 'Check `src/app/notes.md` please.')]
+    await renderPanel()
+    const preview = await screen.findByRole('button', { name: 'Preview' })
+    fireEvent.mouseEnter(preview)
+    expect(preview.style.color).toBe('var(--accent)')
+    fireEvent.mouseLeave(preview)
+    expect(preview.style.color).toBe('var(--text-muted)')
+  })
+})
+
+describe('ChatPanel pointer feedback', () => {
+  it('presses the send paw in and lets it back out', async () => {
+    await renderPanel()
+    const send = screen.getByRole('button', { name: 'Send' })
+    fireEvent.mouseDown(send)
+    expect(send.style.transform).toBe('scale(0.88)')
+    fireEvent.mouseUp(send)
+    expect(send.style.transform).toBe('scale(1)')
+    fireEvent.mouseDown(send)
+    fireEvent.mouseLeave(send)
+    // Releasing outside the button must not leave it stuck pressed.
+    expect(send.style.transform).toBe('scale(1)')
+  })
+
+  it('fades the edit-cancel action under the pointer', async () => {
+    history = [turn('user', 'never mind')]
+    await renderPanel()
+    await userEvent.click(await screen.findByRole('button', { name: 'Edit & resend' }))
+    const cancel = screen.getByRole('button', { name: 'Cancel' })
+    fireEvent.mouseEnter(cancel)
+    expect(cancel.style.opacity).toBe('0.7')
+    fireEvent.mouseLeave(cancel)
+    expect(cancel.style.opacity).toBe('1')
+  })
+
+  it('underlines a link only while it is hovered', async () => {
+    history = [turn('assistant', 'See [the docs](https://example.com/guide).')]
+    await renderPanel()
+    const link = await screen.findByText('the docs')
+    fireEvent.mouseEnter(link)
+    expect(link.style.textDecoration).toBe('underline')
+    fireEvent.mouseLeave(link)
+    expect(link.style.textDecoration).toBe('none')
+  })
+
+  it('highlights the reveal action on a file chip', async () => {
+    history = [turn('assistant', 'Check `src/app/notes.md` please.')]
+    await renderPanel()
+    const reveal = await screen.findByRole('button', { name: 'Show in file manager' })
+    fireEvent.mouseEnter(reveal)
+    expect(reveal.style.color).toBe('var(--accent)')
+    fireEvent.mouseLeave(reveal)
+    expect(reveal.style.color).toBe('var(--text-muted)')
+  })
+})
+
+describe('PinnedSidePanel chip hover', () => {
+  it('withdraws the unpin dot when the pointer leaves the chip', async () => {
+    const pin = { path: '/home/u/src/a.ts', label: '', pinnedAt: 1 }
+    render(
+      <PinnedSidePanel pins={[pin]} updatedPaths={new Set()} deletedPaths={new Set()} visible />,
+    )
+    await userEvent.hover(screen.getByText('a.ts'))
+    expect(screen.getByRole('button', { name: 'Unpin' })).toBeInTheDocument()
+    await userEvent.unhover(screen.getByText('a.ts'))
+    expect(screen.queryByRole('button', { name: 'Unpin' })).not.toBeInTheDocument()
+    expect(unpinFile).not.toHaveBeenCalled()
+  })
+})

--- a/website/src/test/PandaOfficeSceneCoverage.test.tsx
+++ b/website/src/test/PandaOfficeSceneCoverage.test.tsx
@@ -1,0 +1,659 @@
+/**
+ * PandaOfficeScene — the Worlds panda den — driven frame by frame.
+ *
+ * `Scenes.test.tsx` only proves the scene mounts a canvas, so everything the
+ * den actually DOES after mount (the doorway glow while a panda walks in, the
+ * blinking monitors, the steaming mug, the bamboo-coffee run, the whiteboard
+ * visit, the pair-programming huddle and its chat lines) never ran. happy-dom
+ * has no 2D context and no frame clock, so the harness supplies both:
+ *
+ *   - a RECORDING canvas context, so a test can ask "was the doorway glow
+ *     painted?" or "which labels landed on the overlay?" instead of reading
+ *     pixels;
+ *   - a hand-driven `requestAnimationFrame`, so a test advances exactly N
+ *     frames with no dependence on a real animation clock;
+ *   - a pinned `Math.random` and `Date.now`, so the huddle, coffee and
+ *     whiteboard dice rolls and the speech-bubble expiry are deterministic.
+ *
+ * Timers are FAKE but deliberately NOT auto-advancing: the scene arms 3s-4.5s
+ * `window.setTimeout`s for its breaks, and fast-forwarding ~1800 frames burns
+ * more than that in real time, so `shouldAdvanceTime` would let a break expire
+ * mid-walk and make these assertions flaky. Every timer is therefore stepped
+ * explicitly and the queue is dropped in `afterEach`, so no scene timer can
+ * survive teardown and fail the run with an unhandled callback.
+ *
+ * Recording is switched off while fast-forwarding thousands of frames (the
+ * huddle only rolls at tick 1800) and switched back on for the single frame
+ * under assertion, so memory stays flat.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act, fireEvent } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import chatReducer from '../store/chatSlice'
+import PandaOfficeScene from '../pages/scenes/PandaOfficeScene'
+import { markAgentsKnown } from '../hooks/sceneStateCache'
+import type { AgentSource } from '../hooks/useAgentSync'
+
+/** The popover and the in-world "New session" sign are the only api callers
+ *  reachable from this scene; stub them so nothing dials the network. */
+vi.mock('../api/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      chatSlotDetail: vi.fn(() => Promise.resolve({ messages: [] })),
+      createChatSlot: vi.fn(() => Promise.resolve({})),
+    },
+  }
+})
+
+/* ── Scene geometry mirrored from PandaOfficeScene (it exports none of it) ── */
+/** The scene hardcodes S = 3 rather than reading SCENE_SCALE. */
+const S = 3
+const W = 440, H = 300
+/** Desk anchors; a panda sits at (x + 10, y + 20). */
+const DESKS = [
+  { x: 40, y: 120 }, { x: 120, y: 120 }, { x: 200, y: 120 }, { x: 280, y: 120 },
+  { x: 40, y: 200 }, { x: 120, y: 200 }, { x: 200, y: 200 }, { x: 280, y: 200 },
+]
+const COFFEE = { x: 390, y: 240 }
+const CLOCK = { x: 170, y: 22 }
+
+/* ── Recording 2D context ── */
+
+interface FillRecord { x: number; y: number; w: number; h: number; color: string }
+interface TextRecord { text: string; x: number; y: number }
+
+interface Recorder {
+  ctx: CanvasRenderingContext2D
+  fills: FillRecord[]
+  texts: TextRecord[]
+  /** How many dashed-line runs the huddle link asked for. */
+  dashes: { count: number }
+}
+
+/**
+ * A 2D context that remembers what it was told to draw. Unknown members become
+ * no-op spies on first access, so a helper reaching for `ellipse`, `roundRect`
+ * or `setLineDash` never has to be enumerated here.
+ */
+function createRecorder(): Recorder {
+  const fills: FillRecord[] = []
+  const texts: TextRecord[] = []
+  const dashes = { count: 0 }
+  const gradient = { addColorStop: vi.fn() }
+
+  const store: Record<string, unknown> = {
+    fillStyle: '#000000',
+    strokeStyle: '#000000',
+    globalAlpha: 1,
+    lineWidth: 1,
+    font: '',
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    imageSmoothingEnabled: false,
+    canvas: { width: 0, height: 0 },
+    createLinearGradient: vi.fn(() => gradient),
+    createRadialGradient: vi.fn(() => gradient),
+    createPattern: vi.fn(() => null),
+    // Width proportional to length so the real word-wrapper actually wraps.
+    measureText: vi.fn((t: string) => ({ width: t.length * 8 })),
+    getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(4) })),
+  }
+  store.fillRect = (x: number, y: number, w: number, h: number) => {
+    if (capturing) fills.push({ x, y, w, h, color: String(store.fillStyle) })
+  }
+  store.fillText = (text: string, x: number, y: number) => {
+    if (capturing) texts.push({ text, x, y })
+  }
+  store.setLineDash = (pattern: number[]) => {
+    if (capturing && pattern.length) dashes.count++
+  }
+
+  const ctx = new Proxy(store, {
+    get(target, prop) {
+      const key = String(prop)
+      if (!(key in target)) target[key] = vi.fn()
+      return target[key]
+    },
+    set(target, prop, value) {
+      target[String(prop)] = value
+      return true
+    },
+  }) as unknown as CanvasRenderingContext2D
+
+  return { ctx, fills, texts, dashes }
+}
+
+/* ── Harness state ── */
+
+/** Every context handed out this test, in creation order. */
+let recorders: Recorder[] = []
+/** Frame callbacks queued by the scene loop, keyed by the id rAF handed back. */
+let queuedFrames = new Map<number, FrameRequestCallback>()
+let frameSeq = 0
+/** Value `Math.random()` returns — low enough to pass every routine dice roll. */
+let rand = 0.05
+/** Value `Date.now()` returns — tests advance it to age a speech bubble. */
+let nowMs = 1_700_000_000_000
+/** While false, the recording context drops everything (fast-forward mode). */
+let capturing = true
+
+beforeEach(() => {
+  recorders = []
+  queuedFrames = new Map()
+  frameSeq = 0
+  rand = 0.05
+  nowMs = 1_700_000_000_000
+  capturing = true
+  vi.useFakeTimers()
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => {
+    const rec = createRecorder()
+    recorders.push(rec)
+    return rec.ctx
+  }) as unknown as HTMLCanvasElement['getContext']
+  // happy-dom lays nothing out, so the hit-test would divide by a zero-width
+  // rect. Give the canvas its real on-screen box instead.
+  vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    left: 0, top: 0, right: W * S, bottom: H * S, width: W * S, height: H * S,
+    x: 0, y: 0, toJSON: () => ({}),
+  } as DOMRect)
+  vi.spyOn(Math, 'random').mockImplementation(() => rand)
+  vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    const id = ++frameSeq
+    queuedFrames.set(id, cb)
+    return id
+  })
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => { queuedFrames.delete(id) })
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+  localStorage.clear()
+})
+
+/** Advance every live scene loop by exactly `n` frames, recording each one. */
+function runFrames(n: number) {
+  act(() => {
+    for (let i = 0; i < n; i++) {
+      const due = [...queuedFrames.values()]
+      queuedFrames.clear()
+      due.forEach(cb => cb(0))
+    }
+  })
+}
+
+/** Fast-forward `n` frames without recording anything they paint. */
+function fastForward(n: number) {
+  capturing = false
+  runFrames(n)
+  capturing = true
+}
+
+/** Fire the scene's break timers that come due within `ms`. */
+function advanceTimers(ms: number) {
+  act(() => { vi.advanceTimersByTime(ms) })
+}
+
+/** Drop everything recorded so far, so the next frame stands alone. */
+function clearRecords() {
+  recorders.forEach(r => { r.fills.length = 0; r.texts.length = 0; r.dashes.count = 0 })
+}
+
+/**
+ * Step the loop in bursts, recording only the last frame of each burst, until
+ * `pred` holds. Frame-exact expectations would be brittle — a panda's walk
+ * length depends on which desk it started from — so poll instead of guessing.
+ */
+function stepUntil(pred: () => boolean, maxFrames: number, burst = 10): boolean {
+  for (let elapsed = 0; elapsed < maxFrames; elapsed += burst) {
+    fastForward(burst - 1)
+    clearRecords()
+    runFrames(1)
+    if (pred()) return true
+  }
+  return false
+}
+
+function agent(over: Partial<AgentSource> & { id: string }): AgentSource {
+  return { name: over.id, label: 'default', kind: 'slot', running: false, detail: '', ...over }
+}
+
+function mount(agents: AgentSource[], visible = true) {
+  const store = configureStore({ reducer: { chat: chatReducer } })
+  const base = recorders.length
+  const view = render(
+    <Provider store={store}>
+      <MemoryRouter><PandaOfficeScene agents={agents} visible={visible} /></MemoryRouter>
+    </Provider>,
+  )
+  const rerender = (next: AgentSource[], nextVisible = visible) => view.rerender(
+    <Provider store={store}>
+      <MemoryRouter><PandaOfficeScene agents={next} visible={nextVisible} /></MemoryRouter>
+    </Provider>,
+  )
+  // initSceneCanvases takes the pixel context first, then the text overlay.
+  return { ...view, rerender, pixel: recorders[base], overlay: recorders[base + 1] }
+}
+
+/** Text drawn on a context, in draw order. */
+const labels = (rec: Recorder) => rec.texts.map(t => t.text)
+const hasColor = (rec: Recorder, color: string) => rec.fills.some(f => f.color === color)
+/** Where a given label landed, or undefined when it was not drawn. */
+const textAt = (rec: Recorder, text: string) => rec.texts.find(t => t.text === text)
+/** Whether a pixel of exactly this colour and size landed on this spot. */
+const fillAt = (rec: Recorder, color: string, x: number, y: number, w: number, h: number) =>
+  rec.fills.some(f => f.color === color && f.x === x && f.y === y && f.w === w && f.h === h)
+
+/**
+ * Whether the cubicle nameplate for `name` is hanging on desk `deskIdx`.
+ * Matched by position, because the whiteboard prints the same 8-character
+ * clipping of a running panda's name on its kanban cards.
+ */
+function hasNameplate(rec: Recorder, deskIdx: number, name: string): boolean {
+  const desk = DESKS[deskIdx]
+  return rec.texts.some(t => t.text === name.slice(0, 8)
+    && t.x === (desk.x + 15) * S && t.y === (desk.y + 1) * S)
+}
+
+const DOOR_GLOW = 'rgba(255,200,50,0.08)'
+const MUG_STEAM = 'rgba(255,255,255,0.1)'
+const SCREEN_GREEN = '#33ff33'
+const CLOCK_HAND_DOT = '#f00'
+const COLLAB_MARK = '#f90'
+const PANDA_BLACK = '#222'
+const BAMBOO = '#6b8e23'
+const DEN_SIGN = '🐼 Panda Den'
+
+/** Names are 9 characters so the full label never collides with the
+ *  8-character cubicle nameplate the scene derives from it. */
+const ROSALINDA = 'Rosalinda'
+const FERDINAND = 'Ferdinand'
+const BERNADETT = 'Bernadett'
+const CONSTANZA = 'Constanza'
+
+/** Four pandas the den has already met, so they start seated at desks 0-3. */
+function seatedCrew(prefix: string, running = true): AgentSource[] {
+  const names = [ROSALINDA, FERDINAND, BERNADETT, CONSTANZA]
+  const sources = names.map((name, i) => agent({ id: `slot-${prefix}-${i}`, name, running, detail: '3 msgs' }))
+  markAgentsKnown('panda-office', sources.map(s => s.id))
+  return sources
+}
+
+/* ── Tests ── */
+
+describe('PandaOfficeScene fittings', () => {
+  it('renders the pixel canvas and the text overlay with accessible labels', () => {
+    const view = mount([])
+    expect(view.getByLabelText('Panda office scene')).toBeInTheDocument()
+    expect(view.getByLabelText('Panda office scene labels')).toBeInTheDocument()
+  })
+
+  it('keeps the pixel canvas unsmoothed and sized to the scene', () => {
+    const view = mount([])
+    const canvas = view.getByLabelText('Panda office scene') as HTMLCanvasElement
+    expect(canvas.style.imageRendering).toBe('pixelated')
+    expect(canvas.width).toBe(W * S)
+    expect(canvas.height).toBe(H * S)
+  })
+
+  it('paints the den signage, the kanban columns and the gym on the first frame', () => {
+    const { overlay } = mount([])
+    expect(labels(overlay)).toContain(DEN_SIGN)
+    expect(labels(overlay)).toEqual(expect.arrayContaining(['To Do', 'Active', 'Done']))
+    expect(labels(overlay)).toContain('pull-ups')
+    // The doorway sign is painted on the overlay too.
+    expect(labels(overlay)).toContain('IN')
+    // Nothing is running, so the board shows the placeholder card.
+    expect(labels(overlay)).toContain('No tasks')
+  })
+
+  it('counts an empty den and marks all eight cubicles vacant', () => {
+    const { overlay } = mount([])
+    expect(labels(overlay)).toContain('0/8 agents')
+    expect(labels(overlay).filter(t => t === 'empty')).toHaveLength(8)
+  })
+
+  it('draws nothing while hidden and starts drawing once it becomes visible', () => {
+    const { overlay, rerender } = mount([agent({ id: 'slot-hidden' })], false)
+    runFrames(5)
+    expect(overlay.texts).toHaveLength(0)
+
+    rerender([agent({ id: 'slot-hidden' })], true)
+    runFrames(1)
+    expect(labels(overlay)).toContain(DEN_SIGN)
+  })
+
+  it('lists the running pandas on the whiteboard instead of the placeholder', () => {
+    const { overlay } = mount(seatedCrew('board'))
+    expect(labels(overlay)).not.toContain('No tasks')
+    // Cards are clipped to eight characters.
+    expect(labels(overlay)).toContain(ROSALINDA.slice(0, 8))
+    expect(labels(overlay)).toContain(CONSTANZA.slice(0, 8))
+  })
+})
+
+describe('PandaOfficeScene animated fittings', () => {
+  it('flashes the clock second dot on the alternating 16-frame phase', () => {
+    const { pixel } = mount([])
+    clearRecords()
+    runFrames(1)               // tick 2 — dot off
+    expect(hasColor(pixel, CLOCK_HAND_DOT)).toBe(false)
+
+    fastForward(15)
+    clearRecords()
+    runFrames(1)               // tick 18 — dot on
+    expect(fillAt(pixel, CLOCK_HAND_DOT, (CLOCK.x - 0.5) * S, (CLOCK.y - 0.5) * S, S, S)).toBe(true)
+  })
+
+  it('blinks a cursor on an occupied monitor', () => {
+    const { pixel } = mount(seatedCrew('cursor'))
+    fastForward(7)
+    clearRecords()
+    runFrames(1)               // tick 9 — cursor phase on
+    // The typed lines are 0.8 tall; the cursor is the square one.
+    const cursor = pixel.fills.filter(f => f.color === SCREEN_GREEN && f.h === 1 * S)
+    expect(cursor.length).toBeGreaterThan(0)
+    expect(cursor[0].x).toBe((DESKS[0].x + 13) * S)
+  })
+
+  it('shows a standby dot on a vacant monitor and drips the coffee machine', () => {
+    const { pixel } = mount([agent({ id: 'slot-standby' })])
+    fastForward(31)
+    clearRecords()
+    runFrames(1)               // tick 33 — both 32-frame phases on
+    const vacant = DESKS[7]
+    expect(fillAt(pixel, '#333', (vacant.x + 14) * S, (vacant.y + 9) * S, S, S)).toBe(true)
+    expect(pixel.fills.some(f => f.x === (COFFEE.x + 5) * S && f.y === (COFFEE.y + 8) * S)).toBe(true)
+  })
+
+  it('steams the mug on an occupied desk only', () => {
+    const { pixel } = mount(seatedCrew('steam'))
+    clearRecords()
+    runFrames(1)               // tick 2 — steam phase off
+    expect(hasColor(pixel, MUG_STEAM)).toBe(false)
+
+    fastForward(15)
+    clearRecords()
+    runFrames(1)               // tick 18 — steam phase on
+    expect(hasColor(pixel, MUG_STEAM)).toBe(true)
+  })
+
+  it('drifts pollen through the den once the spawn tick comes round', () => {
+    const { pixel } = mount([])
+    const pollen = (r: Recorder) => r.fills.filter(f => f.color.startsWith('rgba(255,240,200'))
+    clearRecords()
+    runFrames(1)               // tick 2 — nothing airborne yet
+    expect(pollen(pixel)).toHaveLength(0)
+
+    fastForward(10)
+    clearRecords()
+    runFrames(1)               // past ticks 6 and 12 — motes alive and drifting
+    expect(pollen(pixel).length).toBeGreaterThan(0)
+  })
+
+  it('opens the pandas eyes after the mount-frame blink', () => {
+    const { pixel } = mount(seatedCrew('blink'))
+    const seat = { x: DESKS[0].x + 10, y: DESKS[0].y + 20 }
+    // Eye whites sit inside the black patches, offset by the facing direction.
+    const leftEye = () => fillAt(pixel, '#fff', (seat.x + 2.5) * S, (seat.y - 4) * S, S, S)
+
+    clearRecords()
+    runFrames(1)               // tick 2 — still inside the 3-frame blink window
+    expect(leftEye()).toBe(false)
+
+    fastForward(2)
+    clearRecords()
+    runFrames(1)               // tick 5 — eyes open
+    expect(leftEye()).toBe(true)
+  })
+})
+
+describe('PandaOfficeScene arrivals', () => {
+  it('walks an unseen panda in through the doorway, which glows on the flashing frame', () => {
+    const { pixel, overlay } = mount([agent({ id: 'slot-newcomer', name: ROSALINDA })])
+    fastForward(7)
+    clearRecords()
+    runFrames(1)               // tick 9 — glow phase on while still entering
+    expect(hasColor(pixel, DOOR_GLOW)).toBe(true)
+    // Still short of the desk, so no cubicle nameplate yet.
+    expect(hasNameplate(overlay, 0, ROSALINDA)).toBe(false)
+    // The walker is still over by the door, not at the desk.
+    const name = textAt(overlay, ROSALINDA)
+    expect(name).toBeDefined()
+    expect(name!.x).toBeLessThan(DESKS[0].x * S)
+  })
+
+  it('hangs the cubicle nameplate once the newcomer reaches its desk', () => {
+    const { overlay, pixel } = mount([agent({ id: 'slot-settler', name: FERDINAND })])
+    const seated = stepUntil(() => hasNameplate(overlay, 0, FERDINAND), 400)
+    expect(seated).toBe(true)
+    // It walked the whole way over: the label now sits on desk 0.
+    expect(textAt(overlay, FERDINAND)!.x).toBe((DESKS[0].x + 14) * S)
+    // Arrival ends the entrance, so the doorway stops glowing.
+    fastForward(7)
+    clearRecords()
+    runFrames(1)
+    expect(hasColor(pixel, DOOR_GLOW)).toBe(false)
+  })
+
+  it('seats an already-known panda at once, typing, with its nameplate up', () => {
+    const known = agent({ id: 'slot-returning', name: BERNADETT, running: true, detail: '7 msgs' })
+    markAgentsKnown('panda-office', [known.id])
+    const { overlay, pixel } = mount([known])
+    fastForward(7)
+    clearRecords()
+    runFrames(1)               // tick 9 — the typing arm phase that idles never draws
+    expect(hasNameplate(overlay, 0, BERNADETT)).toBe(true)
+    expect(labels(overlay)).toContain('active')
+    expect(labels(overlay)).toContain('7 msgs')
+    // Seated at desk 0, so the name label sits over that desk.
+    expect(textAt(overlay, BERNADETT)!.x).toBe((DESKS[0].x + 14) * S)
+    // A typing arm is raised one pixel above where a resting arm hangs.
+    const seat = { x: DESKS[0].x + 10, y: DESKS[0].y + 20 }
+    expect(fillAt(pixel, PANDA_BLACK, (seat.x - 1) * S, (seat.y + 2) * S, 2 * S, 3 * S)).toBe(true)
+  })
+
+  it('caps the den at its eight desks', () => {
+    const many = Array.from({ length: 12 }, (_, i) => agent({ id: `slot-crowd-${i}`, running: true }))
+    const { overlay } = mount(many)
+    expect(labels(overlay)).toContain('8/8 agents')
+    expect(labels(overlay).filter(t => t === 'empty')).toHaveLength(0)
+  })
+
+  it('badges each panda by kind: chat, cron and subagent', () => {
+    const { pixel } = mount([
+      agent({ id: 'slot-badge', name: ROSALINDA }),
+      agent({ id: 'cron-badge', name: FERDINAND, kind: 'cron' }),
+      agent({ id: 'spawn-badge', name: BERNADETT, kind: 'spawn' }),
+    ])
+    // Badges are drawn on the pixel canvas, not the text overlay.
+    expect(labels(pixel)).toEqual(expect.arrayContaining(['💬', '⏰', '🔀']))
+  })
+})
+
+describe('PandaOfficeScene live session updates', () => {
+  it('reuses a seated panda when its session is renamed and stops running', () => {
+    const before = agent({ id: 'slot-rename', name: ROSALINDA, running: true, detail: '3 msgs' })
+    markAgentsKnown('panda-office', [before.id])
+    const { overlay, rerender } = mount([before])
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay)).toContain('active')
+
+    rerender([agent({ id: 'slot-rename', name: FERDINAND, running: false, detail: '9 msgs' })])
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay)).toContain(FERDINAND)
+    expect(labels(overlay)).toContain('9 msgs')
+    expect(labels(overlay)).toContain('idle')
+    expect(labels(overlay)).not.toContain('active')
+    // Reused, not re-entered: the desk still shows its nameplate.
+    expect(hasNameplate(overlay, 0, FERDINAND)).toBe(true)
+    // Idle now, so the board falls back to the placeholder card.
+    expect(labels(overlay)).toContain('No tasks')
+  })
+
+  it('raises a speech bubble for a new last message, fades it, then drops it', () => {
+    const base = agent({ id: 'slot-talker', name: CONSTANZA, running: true })
+    markAgentsKnown('panda-office', [base.id])
+    const { overlay, rerender } = mount([base])
+
+    rerender([{ ...base, lastMessage: 'Shipping the review lane' }])
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay).join(' ')).toContain('Shipping')
+
+    // 6.5s in: past the fade threshold, still on screen.
+    nowMs += 6_500
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay).join(' ')).toContain('Shipping')
+
+    // Past the 7s lifetime the bubble is gone.
+    nowMs += 1_000
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay).join(' ')).not.toContain('Shipping')
+  })
+
+  it('leaves the bubble down when a rerender repeats the same message', () => {
+    const base = agent({ id: 'slot-repeat', name: ROSALINDA, lastMessage: 'same text' })
+    markAgentsKnown('panda-office', [base.id])
+    const { overlay, rerender } = mount([base])
+    nowMs += 20_000
+    rerender([{ ...base }])
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay).join(' ')).not.toContain('same text')
+  })
+})
+
+describe('PandaOfficeScene daily routine', () => {
+  it('sends one panda for bamboo and another to the whiteboard, then walks them back', () => {
+    const { overlay, pixel } = mount(seatedCrew('routine'))
+
+    // The bamboo break rolls at tick 600; the walk across the den is ~525 frames.
+    const atMachine = stepUntil(() => {
+      const name = textAt(overlay, ROSALINDA)
+      return !!name && name.x > 340 * S
+    }, 1400, 25)
+    expect(atMachine).toBe(true)
+    // A panda on a break carries a bamboo stalk, not a mug: 1 wide, 5 tall.
+    expect(pixel.fills.some(f => f.color === BAMBOO && f.w === 1 * S && f.h === 5 * S)).toBe(true)
+
+    // Stop the dice rolling so the tick-1800 huddle cannot hijack the walkers.
+    rand = 0.9
+    // The whiteboard visit rolled at tick 900 and parks a panda up by the board.
+    const atBoard = stepUntil(() => {
+      const name = textAt(overlay, FERDINAND)
+      return !!name && name.y < 120 * S
+    }, 900, 25)
+    expect(atBoard).toBe(true)
+
+    // Both breaks are time-boxed by real timeouts, so expiring them sends the
+    // walkers home to their own cubicles.
+    advanceTimers(4_000)
+    const backAtDesk = stepUntil(() => {
+      const name = textAt(overlay, ROSALINDA)
+      return !!name && name.x < (DESKS[0].x + 40) * S
+    }, 900, 25)
+    expect(backAtDesk).toBe(true)
+  })
+
+  it('pairs two pandas mid-room, prints both chat lines, then breaks the huddle', () => {
+    const { overlay, pixel } = mount(seatedCrew('huddle'))
+
+    // Refuse every break roll on the way up so all four stay seated, then arm a
+    // value that passes the huddle roll (< 0.3) and picks the second chat pair.
+    rand = 0.9
+    fastForward(1798)          // ticks 2 … 1799
+    rand = 0.2
+    clearRecords()
+    runFrames(1)               // tick 1800 — the huddle rolls
+    expect(labels(overlay)).toContain('CR approved!')
+    // The partner has not answered yet, and the pair is linked by a dashed line.
+    expect(labels(overlay)).not.toContain('Ship it! 🐼')
+    expect(pixel.dashes.count).toBeGreaterThan(0)
+    expect(hasColor(pixel, COLLAB_MARK)).toBe(true)
+
+    // The reply lands 1.2s later.
+    advanceTimers(1_300)
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay)).toContain('Ship it! 🐼')
+
+    // The huddle is capped at 4.5s, after which both go quiet.
+    advanceTimers(3_300)
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay)).not.toContain('CR approved!')
+    expect(labels(overlay)).not.toContain('Ship it! 🐼')
+    expect(hasColor(pixel, COLLAB_MARK)).toBe(false)
+  })
+
+  it('sends the surviving partner home when the other leaves mid-huddle', () => {
+    const crew = seatedCrew('departed')
+    const { overlay, rerender } = mount(crew)
+
+    rand = 0.9
+    fastForward(1798)
+    rand = 0.2
+    clearRecords()
+    runFrames(1)               // tick 1800 — pandas 0 and 1 pair up
+    expect(labels(overlay)).toContain('CR approved!')
+
+    // The first partner's session ends while the two are still talking.
+    rerender(crew.slice(1))
+    advanceTimers(5_000)
+    clearRecords()
+    runFrames(1)
+
+    // The huddle is torn down rather than steering a departed panda's desk.
+    expect(labels(overlay)).not.toContain('CR approved!')
+    expect(labels(overlay)).not.toContain(ROSALINDA)
+    // Its cubicle is free again and the survivor keeps its own nameplate.
+    expect(labels(overlay)).toContain('empty')
+    expect(hasNameplate(overlay, 1, FERDINAND)).toBe(true)
+  })
+})
+
+describe('PandaOfficeScene hover', () => {
+  it('names the hovered panda and gives it the dens own status flavour', () => {
+    const seated = agent({ id: 'slot-hovered', name: BERNADETT, running: true, detail: '3 msgs' })
+    markAgentsKnown('panda-office', [seated.id])
+    const view = mount([seated])
+    const canvas = view.getByLabelText('Panda office scene')
+    const seat = { x: DESKS[0].x + 10, y: DESKS[0].y + 20 }
+
+    fireEvent.mouseMove(canvas, { clientX: seat.x * S, clientY: seat.y * S })
+    expect(view.getByText(BERNADETT)).toBeInTheDocument()
+    expect(view.getByText('Grinding PRs')).toBeInTheDocument()
+    expect(view.getByText(/Working/)).toBeInTheDocument()
+
+    fireEvent.mouseLeave(canvas)
+    expect(view.queryByText('Grinding PRs')).toBeNull()
+  })
+
+  it('gives an idle panda the waiting-on-review flavour and ignores empty floor', () => {
+    const seated = agent({ id: 'slot-idler', name: CONSTANZA, kind: 'cron', running: false, detail: 'hourly' })
+    markAgentsKnown('panda-office', [seated.id])
+    const view = mount([seated])
+    const canvas = view.getByLabelText('Panda office scene')
+    const seat = { x: DESKS[0].x + 10, y: DESKS[0].y + 20 }
+
+    fireEvent.mouseMove(canvas, { clientX: seat.x * S, clientY: seat.y * S })
+    expect(view.getByText('Waiting for CR approval')).toBeInTheDocument()
+
+    // Far corner of the floor: nobody is standing there.
+    fireEvent.mouseMove(canvas, { clientX: 5 * S, clientY: 290 * S })
+    expect(view.queryByText('Waiting for CR approval')).toBeNull()
+  })
+})

--- a/website/src/test/SpriteImporterCoverage.test.tsx
+++ b/website/src/test/SpriteImporterCoverage.test.tsx
@@ -1,0 +1,807 @@
+/**
+ * Crew Companion sprite importer — first tests for
+ * `apps/crew-companion/SpriteImporter.tsx`.
+ *
+ * The importer is the whole "turn a sprite sheet into an appearance pack" screen:
+ * pick a sheet, detect its grid, slice it into rows, map each row onto one of the
+ * pet's slots, and hand the result to its owner. Nothing here was covered, so
+ * every behaviour below is pinned for the first time — including the two the
+ * source calls out as bugs it already had to fix: a random CLIP must travel as
+ * `randomAssignments` (the bridge files an unknown key in `assignments` as a
+ * mood, which silently disabled a pack's random behaviour), and a failed save
+ * must leave the editor mounted with the user's edits intact.
+ *
+ * Three boundaries are stubbed, deliberately:
+ *
+ *   - **Image decode + canvas.** The importer measures the sheet with
+ *     `new Image()` and slices it through a 2d canvas. happy-dom never decodes an
+ *     image (`load` never fires, `naturalWidth` stays 0) and has no canvas, so no
+ *     row would ever exist. A fake `Image` reports the pixel size the test asks
+ *     for and hands the test control of when `load` lands (`settle()`), while the
+ *     canvas returns the alpha map the test built. Everything above that seam —
+ *     the real `detectFrameSize`, the slicing loop, the assignment state machine,
+ *     the dirty check, the save classification — runs for real.
+ *   - **`SpriteRenderer`**, which drives a `requestAnimationFrame` loop off its
+ *     own image decode and has its own tests. Here it stands in as a marker so
+ *     the importer's OWN row/slot wiring is what gets asserted.
+ *   - **`SimpleSelect`**, a Radix listbox that needs pointer capture and a
+ *     portal to open. Swapped for a native `<select>` carrying the same props,
+ *     so a row choice is one `change` event rather than a popover dance.
+ *
+ * No test depends on real elapsed time or on an animation frame landing.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, act, cleanup, within } from '@testing-library/react'
+
+import type { PackMeta } from '../apps/crew-companion/appearanceTypes'
+
+// ── Bridge double ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  api: {
+    importSpriteFile: vi.fn<() => Promise<unknown>>(),
+    galleryGetPackDetail: vi.fn<(packId: string) => Promise<unknown>>(),
+    galleryReadPackFile: vi.fn<(packId: string, file: string) => Promise<string | null>>(),
+    getCrewCompanionConfig: vi.fn<() => Promise<unknown>>(),
+  },
+}))
+
+vi.mock('../apps/crew-companion/petBridge', () => ({ galleryApi: mocks.api }))
+
+vi.mock('../apps/crew-companion/SpriteRenderer', () => ({
+  SpriteRenderer: ({ src, frameWidth, frameHeight, fps, displaySize }: {
+    src: string
+    frameWidth: number
+    frameHeight: number
+    fps?: number
+    displaySize?: number
+  }) => (
+    <span
+      data-strip={src}
+      data-frame={`${frameWidth}x${frameHeight}@${fps ?? 0}`}
+      data-display={displaySize ?? 0}
+    />
+  ),
+}))
+
+vi.mock('../components/SimpleSelect', () => ({
+  default: ({ options, optionLabels, value, onChange, clearLabel, 'aria-label': ariaLabel }: {
+    options: string[]
+    optionLabels?: string[]
+    value: string
+    onChange: (v: string) => void
+    clearLabel?: string
+    'aria-label'?: string
+  }) => (
+    <select aria-label={ariaLabel} value={value} onChange={(e) => onChange(e.target.value)}>
+      {clearLabel !== undefined ? <option value="">{clearLabel}</option> : null}
+      {options.map((opt, i) => (
+        <option key={opt} value={opt}>{optionLabels?.[i] ?? opt}</option>
+      ))}
+    </select>
+  ),
+}))
+
+import { SpriteImporter } from '../apps/crew-companion/SpriteImporter'
+
+const api = mocks.api
+
+// ── Image / canvas doubles ─────────────────────────────────────────────────
+
+interface AlphaMap {
+  width: number
+  height: number
+  data: Uint8ClampedArray
+}
+
+/** Pixel size the next decoded image reports. */
+let sheetSize = { width: 64, height: 64 }
+/** What `getImageData` hands to frame detection. */
+let sheetPixels: AlphaMap = alphaOpaque(64, 64)
+/** Images whose `load` has not been delivered yet. */
+const awaitingDecode: FakeImage[] = []
+/** Makes each sliced row's data URI distinguishable. */
+let sliceSeq = 0
+
+/**
+ * An `Image` that decodes only when the test says so.
+ *
+ * Both consumers in the importer are supported: the file-pick path assigns
+ * `onload`, the slicing effect uses `addEventListener('load')` and removes it on
+ * cleanup — so a stale image from a superseded slice pass fires into nothing,
+ * exactly as in the browser.
+ */
+class FakeImage {
+  naturalWidth = 0
+  naturalHeight = 0
+  onload: (() => void) | null = null
+  private readonly handlers = new Set<() => void>()
+  private value = ''
+
+  get src(): string { return this.value }
+
+  set src(next: string) {
+    this.value = next
+    this.naturalWidth = sheetSize.width
+    this.naturalHeight = sheetSize.height
+    awaitingDecode.push(this)
+  }
+
+  addEventListener(type: string, cb: () => void): void {
+    if (type === 'load') this.handlers.add(cb)
+  }
+
+  removeEventListener(type: string, cb: () => void): void {
+    if (type === 'load') this.handlers.delete(cb)
+  }
+
+  finishLoad(): void {
+    this.onload?.()
+    for (const cb of [...this.handlers]) cb()
+  }
+}
+
+/** A sheet with no transparent gaps at all: detection can learn nothing from it. */
+function alphaOpaque(width: number, height: number): AlphaMap {
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let i = 3; i < data.length; i += 4) data[i] = 255
+  return { width, height, data }
+}
+
+/**
+ * A sheet ruled by 1px transparent grid lines every `pitch` px, under `topPad`
+ * fully transparent rows — the shape `detectFrameSize` is built to read.
+ */
+function alphaRuled(width: number, height: number, pitch: number, topPad: number): AlphaMap {
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let y = topPad; y < height; y++) {
+    if ((y - topPad) % pitch === pitch - 1) continue
+    for (let x = 0; x < width; x++) {
+      if (x % pitch === pitch - 1) continue
+      data[(y * width + x) * 4 + 3] = 255
+    }
+  }
+  return { width, height, data }
+}
+
+interface CanvasSeam {
+  getContext: unknown
+  toDataURL: unknown
+}
+const canvasProto = HTMLCanvasElement.prototype as unknown as CanvasSeam
+let realGetContext: unknown
+let realToDataURL: unknown
+
+/**
+ * Deliver pending promises and image decodes, alternating: each decode commits
+ * state whose effect creates the NEXT image (pick -> measure -> slice), so one
+ * pass is never enough.
+ */
+async function settle(passes = 4): Promise<void> {
+  for (let i = 0; i < passes; i++) {
+    await act(async () => { await Promise.resolve() })
+    const batch = awaitingDecode.splice(0, awaitingDecode.length)
+    if (batch.length === 0) continue
+    await act(async () => { for (const img of batch) img.finishLoad() })
+  }
+}
+
+// ── Query helpers ──────────────────────────────────────────────────────────
+
+/** The input sitting under a `NumberField` / pack-info label. */
+function fieldInput(label: string): HTMLInputElement {
+  const input = screen.getByText(label).parentElement?.querySelector('input')
+  if (!input) throw new Error(`no input beside "${label}"`)
+  return input as HTMLInputElement
+}
+
+/** One slot's row selector, found by the slot id the importer labels it with. */
+function slotSelect(slot: string): HTMLSelectElement {
+  return screen.getByLabelText(slot) as HTMLSelectElement
+}
+
+function saveButton(): HTMLButtonElement {
+  return screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement
+}
+
+function pickerButton(): HTMLButtonElement {
+  return screen.getByRole('button', { name: /Select Sprite Sheet|Change File/ }) as HTMLButtonElement
+}
+
+/** The overwrite-or-save-as-new dialog's own panel (the title's parent card). */
+function saveDialog(): HTMLElement {
+  const panel = screen.getByText('Overwrite existing or save as new?').parentElement
+  if (!panel) throw new Error('save dialog is not open')
+  return panel as HTMLElement
+}
+
+/** Pick a sheet through the file button and let it decode. */
+async function pickSheet(content = 'SHEETBYTES'): Promise<void> {
+  api.importSpriteFile.mockResolvedValue({ ok: true, value: { content } })
+  fireEvent.click(pickerButton())
+  await settle()
+}
+
+const existingPack: PackMeta = {
+  id: 'pack-77',
+  name: 'Pixel Ghost',
+  author: 'Zed',
+  description: 'a small pixel ghost',
+  type: 'custom',
+  format: 'sprite',
+  thumbnail: 'thumb.png',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  awaitingDecode.length = 0
+  sliceSeq = 0
+  sheetSize = { width: 64, height: 64 }
+  sheetPixels = alphaOpaque(64, 64)
+  api.galleryGetPackDetail.mockResolvedValue(null)
+  api.galleryReadPackFile.mockResolvedValue(null)
+  api.importSpriteFile.mockResolvedValue(null)
+  api.getCrewCompanionConfig.mockResolvedValue({ language: 'en' })
+
+  vi.stubGlobal('Image', FakeImage)
+  realGetContext = canvasProto.getContext
+  realToDataURL = canvasProto.toDataURL
+  canvasProto.getContext = () => ({
+    clearRect: () => {},
+    drawImage: () => {},
+    getImageData: () => sheetPixels,
+  })
+  canvasProto.toDataURL = function (this: HTMLCanvasElement): string {
+    return `data:image/png;base64,slice-${this.width}x${this.height}-${sliceSeq++}`
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  canvasProto.getContext = realGetContext
+  canvasProto.toDataURL = realToDataURL
+  vi.unstubAllGlobals()
+})
+
+describe('SpriteImporter — before a sheet is picked', () => {
+  it('offers only the file picker and refuses to save', () => {
+    render(<SpriteImporter onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    expect(screen.getByText(/Create Sprite Pack/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Select Sprite Sheet/ })).toBeInTheDocument()
+    // No sheet means no rows, so neither the row previews nor the slot grids exist.
+    expect(screen.queryByText(/^Animations found in your sheet/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Required (just Idle)')).not.toBeInTheDocument()
+    expect(saveButton()).toBeDisabled()
+    // The missing-slot hint is suppressed until there is something to assign.
+    expect(screen.queryByText(/^Missing:/)).not.toBeInTheDocument()
+    // Nothing was read from storage: this is a fresh pack, not an edit.
+    expect(api.galleryGetPackDetail).not.toHaveBeenCalled()
+  })
+
+  it('starts every frame field on its default and keeps the sprite unflipped', () => {
+    render(<SpriteImporter onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    expect(fieldInput('Frame W').value).toBe('32')
+    expect(fieldInput('Frame H').value).toBe('32')
+    expect(fieldInput('FPS').value).toBe('8')
+    expect(fieldInput('Y Offset').value).toBe('0')
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('leaves the screen untouched when the pick is cancelled, refused or empty', async () => {
+    render(<SpriteImporter onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    // Cancelled: the bridge answers with nothing at all.
+    api.importSpriteFile.mockResolvedValue(null)
+    fireEvent.click(pickerButton())
+    await settle()
+    expect(screen.getByRole('button', { name: /Select Sprite Sheet/ })).toBeInTheDocument()
+
+    // Refused: a reason the owner shows, but no bytes.
+    api.importSpriteFile.mockResolvedValue({ ok: false, error: 'That image could not be read' })
+    fireEvent.click(pickerButton())
+    await settle()
+    expect(screen.getByRole('button', { name: /Select Sprite Sheet/ })).toBeInTheDocument()
+
+    // Accepted but empty: an ok with no content is not a sheet.
+    api.importSpriteFile.mockResolvedValue({ ok: true, value: { content: '' } })
+    fireEvent.click(pickerButton())
+    await settle()
+
+    expect(screen.getByRole('button', { name: /Select Sprite Sheet/ })).toBeInTheDocument()
+    expect(document.querySelector('img')).toBeNull()
+    expect(screen.queryByText('Required (just Idle)')).not.toBeInTheDocument()
+  })
+
+  it('reports a failed save from its owner without unmounting the work', () => {
+    render(<SpriteImporter onDone={vi.fn()} onCancel={vi.fn()} saveError="disk is full" />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('disk is full')
+    // The picker is still there: the configured sheet was not thrown away.
+    expect(screen.getByRole('button', { name: /Select Sprite Sheet/ })).toBeInTheDocument()
+  })
+
+  it('shows no alert while the owner has reported nothing', () => {
+    render(<SpriteImporter onDone={vi.fn()} onCancel={vi.fn()} saveError={null} />)
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('calls back on cancel', () => {
+    const onCancel = vi.fn()
+    render(<SpriteImporter onDone={vi.fn()} onCancel={onCancel} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('SpriteImporter — picking a sheet', () => {
+  it('slices the sheet on the default grid when it carries no detectable rules', async () => {
+    render(<SpriteImporter onDone={vi.fn()} onCancel={vi.fn()} />)
+    await pickSheet()
+
+    // Detection reports the whole sheet as one frame, which is refused rather
+    // than applied — a 64px "frame" on a 64px sheet is not a grid.
+    expect(fieldInput('Frame W').value).toBe('32')
+    expect(fieldInput('Frame H').value).toBe('32')
+    expect(fieldInput('Y Offset').value).toBe('0')
+
+    expect(screen.getByText('Animations found in your sheet (2)')).toBeInTheDocument()
+    expect(screen.getByText('Preview (64×64px → 2 cols × 2 rows)')).toBeInTheDocument()
+    // Two row previews, each rendered at the sheet's own frame size. The slot
+    // cards render theirs at 64px, so the two are told apart by that.
+    expect(document.querySelectorAll('[data-display="0"]')).toHaveLength(2)
+    expect(document.querySelectorAll('[data-display="64"]')).toHaveLength(0)
+    // floor(64/32) = 2 frames per row.
+    expect(screen.getAllByText('2f')).toHaveLength(2)
+    // The sheet itself is shown, and the button now offers to replace it.
+    expect(document.querySelector('img')?.getAttribute('src')).toBe('data:image/png;base64,SHEETBYTES')
+    expect(screen.getByRole('button', { name: /Change File/ })).toBeInTheDocument()
+    // Every slot starts empty, and only Idle is required.
+    expect(slotSelect('idle').value).toBe('')
+    expect(slotSelect('walking').value).toBe('')
+    expect(screen.getByText('Missing: Idle')).toBeInTheDocument()
+  })
+
+  it('adopts a detected grid and top offset from a ruled sheet', async () => {
+    // 64x66 ruled every 16px with two blank rows on top.
+    sheetSize = { width: 64, height: 66 }
+    sheetPixels = alphaRuled(64, 66, 16, 2)
+    render(<SpriteImporter onDone={vi.fn()} onCancel={vi.fn()} />)
+    await pickSheet()
+
+    // 15px of art between 1px rules, and the two blank rows become the offset.
+    expect(fieldInput('Frame W').value).toBe('15')
+    expect(fieldInput('Frame H').value).toBe('15')
+    expect(fieldInput('Y Offset').value).toBe('2')
+    // ceil((66-2)/15) = 5 rows, the last one clipped to the sheet's bottom edge.
+    expect(screen.getByText('Animations found in your sheet (5)')).toBeInTheDocument()
+    // floor(64/15) = 4 columns per row.
+    expect(screen.getAllByText('4f')).toHaveLength(5)
+  })
+
+  it('offers every optional slot group once there are rows to assign', async () => {
+    render(<SpriteImporter onDone={vi.fn()} onCancel={vi.fn()} />)
+    await pickSheet()
+
+    expect(screen.getByText('Required (just Idle)')).toBeInTheDocument()
+    for (const group of ['Status', 'Breathing', 'Random']) {
+      // Each optional group announces itself as optional, so a user who skips
+      // one is not left wondering what they broke. Matched on the whole label,
+      // which spans two nodes (the group name and the "(optional)" note).
+      expect(screen.getByText(
+        (_content, el) => el?.textContent === `${group} (optional)`,
+      )).toBeInTheDocument()
+    }
+    for (const slot of ['idle', 'done', 'error', 'inhale', 'hold', 'exhale', 'walking']) {
+      expect(slotSelect(slot)).toBeInTheDocument()
+    }
+    // Each selector lists one option per row plus the clear row.
+    expect(slotSelect('done').querySelectorAll('option')).toHaveLength(3)
+  })
+
+  it('re-slices the rows when the frame height changes', async () => {
+    render(<SpriteImporter onDone={vi.fn()} onCancel={vi.fn()} />)
+    await pickSheet()
+    expect(screen.getByText('Animations found in your sheet (2)')).toBeInTheDocument()
+
+    fireEvent.change(fieldInput('Frame H'), { target: { value: '16' } })
+    await settle()
+
+    expect(screen.getByText('Animations found in your sheet (4)')).toBeInTheDocument()
+    // The row previews follow the new geometry.
+    expect(document.querySelector('[data-strip]')).toHaveAttribute('data-frame', '32x16@8')
+  })
+
+  it('drops every row when the Y offset runs past the bottom of the sheet', async () => {
+    render(<SpriteImporter onDone={vi.fn()} onCancel={vi.fn()} />)
+    await pickSheet()
+    expect(screen.getByText('Animations found in your sheet (2)')).toBeInTheDocument()
+
+    fireEvent.change(fieldInput('Y Offset'), { target: { value: '200' } })
+    await settle()
+
+    expect(screen.queryByText(/^Animations found in your sheet/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Required (just Idle)')).not.toBeInTheDocument()
+    // With nothing to assign the missing hint goes quiet again, and so does Save.
+    expect(screen.queryByText(/^Missing:/)).not.toBeInTheDocument()
+    expect(saveButton()).toBeDisabled()
+  })
+
+  it('keeps slicing on the default frame width when the field is emptied to zero', async () => {
+    render(<SpriteImporter onDone={vi.fn()} onCancel={vi.fn()} />)
+    await pickSheet()
+
+    fireEvent.change(fieldInput('Frame W'), { target: { value: '0' } })
+    await settle()
+
+    // The field keeps what the user typed…
+    expect(fieldInput('Frame W').value).toBe('0')
+    // …while the slicer refuses to divide by it and holds the 32px default, so
+    // the rows survive a half-typed number.
+    expect(screen.getByText('Animations found in your sheet (2)')).toBeInTheDocument()
+    // The grid summary counts columns at 1px rather than dividing by zero.
+    expect(screen.getByText('Preview (64×64px → 64 cols × 2 rows)')).toBeInTheDocument()
+  })
+})
+
+describe('SpriteImporter — saving a new pack', () => {
+  it('holds Save back until the pack has a name and an idle row', async () => {
+    render(<SpriteImporter onDone={vi.fn()} onCancel={vi.fn()} />)
+    await pickSheet()
+
+    fireEvent.change(fieldInput('Name *'), { target: { value: 'Sprout' } })
+    // Named, but nothing is assigned yet.
+    expect(saveButton()).toBeDisabled()
+
+    fireEvent.change(slotSelect('idle'), { target: { value: '0' } })
+    expect(screen.queryByText(/^Missing:/)).not.toBeInTheDocument()
+    expect(saveButton()).toBeEnabled()
+
+    // Whitespace is not a name.
+    fireEvent.change(fieldInput('Name *'), { target: { value: '   ' } })
+    expect(saveButton()).toBeDisabled()
+
+    fireEvent.change(fieldInput('Name *'), { target: { value: 'Sprout' } })
+    fireEvent.change(slotSelect('idle'), { target: { value: '' } })
+    expect(saveButton()).toBeDisabled()
+    expect(screen.getByText('Missing: Idle')).toBeInTheDocument()
+  })
+
+  it('hands the owner the grid, the sliced strips and the row mapping', async () => {
+    const onDone = vi.fn()
+    render(<SpriteImporter onDone={onDone} onCancel={vi.fn()} />)
+    await pickSheet()
+
+    fireEvent.change(fieldInput('Name *'), { target: { value: 'Sprout' } })
+    fireEvent.change(fieldInput('Author'), { target: { value: 'Zed' } })
+    fireEvent.change(fieldInput('Character Description'), { target: { value: 'a leafy sprout' } })
+    fireEvent.change(fieldInput('FPS'), { target: { value: '12' } })
+    fireEvent.click(screen.getByRole('switch'))
+    fireEvent.change(slotSelect('idle'), { target: { value: '0' } })
+    fireEvent.change(slotSelect('done'), { target: { value: '1' } })
+    // A fresh import has nothing to overwrite, so Save commits with no dialog.
+    fireEvent.click(saveButton())
+
+    expect(screen.queryByText('Overwrite existing or save as new?')).not.toBeInTheDocument()
+    expect(onDone).toHaveBeenCalledTimes(1)
+    const data = onDone.mock.calls[0][0]
+    expect(data).toMatchObject({
+      name: 'Sprout',
+      author: 'Zed',
+      description: 'a leafy sprout',
+      frameWidth: 32,
+      frameHeight: 32,
+      fps: 12,
+      flipX: true,
+      offsetY: 0,
+      sourceImage: 'data:image/png;base64,SHEETBYTES',
+    })
+    expect(data.overwriteId).toBeUndefined()
+    expect(data.rowAssignments).toEqual({ idle: 0, done: 1 })
+    // Each mapped slot carries the sliced strip for its row, not the whole sheet.
+    expect(data.assignments.idle).toMatch(/^data:image\/png;base64,slice-64x32-\d+$/)
+    expect(data.assignments.done).toMatch(/^data:image\/png;base64,slice-64x32-\d+$/)
+    expect(data.assignments.done).not.toBe(data.assignments.idle)
+    // No random clip was assigned, so the key is absent rather than empty.
+    expect(data.randomAssignments).toBeUndefined()
+  })
+
+  it('files a random slot as a clip instead of a state', async () => {
+    const onDone = vi.fn()
+    render(<SpriteImporter onDone={onDone} onCancel={vi.fn()} />)
+    await pickSheet()
+
+    fireEvent.change(fieldInput('Name *'), { target: { value: 'Sprout' } })
+    fireEvent.change(slotSelect('idle'), { target: { value: '0' } })
+    fireEvent.change(slotSelect('walking'), { target: { value: '1' } })
+    fireEvent.click(saveButton())
+
+    const data = onDone.mock.calls[0][0]
+    // Walking is spontaneous behaviour: it must NOT land in `assignments`, which
+    // the bridge would file as a mood.
+    expect('walking' in data.assignments).toBe(false)
+    expect(data.randomAssignments.walking).toMatch(/^data:image\/png;base64,slice-64x32-\d+$/)
+    // The row mapping still records it, so the sheet can be re-edited.
+    expect(data.rowAssignments).toEqual({ idle: 0, walking: 1 })
+  })
+
+  it('leaves unassigned slots out of the saved pack entirely', async () => {
+    const onDone = vi.fn()
+    render(<SpriteImporter onDone={onDone} onCancel={vi.fn()} />)
+    await pickSheet()
+
+    fireEvent.change(fieldInput('Name *'), { target: { value: 'Sprout' } })
+    fireEvent.change(slotSelect('idle'), { target: { value: '0' } })
+    fireEvent.change(slotSelect('hold'), { target: { value: '1' } })
+    // Assigned then cleared: the slot goes back to carrying nothing.
+    fireEvent.change(slotSelect('hold'), { target: { value: '' } })
+    fireEvent.click(saveButton())
+
+    const data = onDone.mock.calls[0][0]
+    expect(data.rowAssignments).toEqual({ idle: 0 })
+    expect('hold' in data.assignments).toBe(false)
+    expect('error' in data.assignments).toBe(false)
+  })
+
+  it('lets one row serve several slots without slicing it twice', async () => {
+    const onDone = vi.fn()
+    render(<SpriteImporter onDone={onDone} onCancel={vi.fn()} />)
+    await pickSheet()
+
+    fireEvent.change(fieldInput('Name *'), { target: { value: 'Sprout' } })
+    fireEvent.change(slotSelect('idle'), { target: { value: '0' } })
+    fireEvent.change(slotSelect('inhale'), { target: { value: '0' } })
+    fireEvent.click(saveButton())
+
+    const data = onDone.mock.calls[0][0]
+    expect(data.assignments.inhale).toBe(data.assignments.idle)
+  })
+})
+
+describe('SpriteImporter — editing an existing pack', () => {
+  const spriteDetail = (over: Record<string, unknown> = {}) => ({
+    sprite: {
+      frameWidth: 32,
+      frameHeight: 32,
+      fps: 12,
+      flipX: true,
+      offsetY: 0,
+      source: 'sheet.png',
+      // Idle is mapped, so the stored pack is savable as-is and the dirty check
+      // is the only thing gating Save.
+      rowAssignments: { idle: 1, done: 0 },
+      ...over,
+    },
+  })
+
+  async function mountEdit(detail: unknown, onDone = vi.fn()): Promise<ReturnType<typeof vi.fn>> {
+    api.galleryGetPackDetail.mockResolvedValue(detail)
+    render(<SpriteImporter existingPack={existingPack} onDone={onDone} onCancel={vi.fn()} />)
+    await settle()
+    return onDone
+  }
+
+  it('restores the stored grid, sheet and row mapping, and starts clean', async () => {
+    api.galleryReadPackFile.mockResolvedValue('STOREDSHEET')
+    await mountEdit(spriteDetail())
+
+    expect(screen.getByText('Edit Sprite Pack')).toBeInTheDocument()
+    expect(api.galleryGetPackDetail).toHaveBeenCalledWith('pack-77')
+    expect(api.galleryReadPackFile).toHaveBeenCalledWith('pack-77', 'sheet.png')
+    expect(document.querySelector('img')?.getAttribute('src')).toBe('data:image/png;base64,STOREDSHEET')
+    expect(fieldInput('Name *').value).toBe('Pixel Ghost')
+    expect(fieldInput('Author').value).toBe('Zed')
+    expect(fieldInput('FPS').value).toBe('12')
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByText('Animations found in your sheet (2)')).toBeInTheDocument()
+    expect(slotSelect('idle').value).toBe('1')
+    expect(slotSelect('done').value).toBe('0')
+    // Nothing has changed yet, so there is nothing to save.
+    expect(saveButton()).toBeDisabled()
+  })
+
+  it('re-opens Save as soon as anything differs from the stored pack', async () => {
+    api.galleryReadPackFile.mockResolvedValue('STOREDSHEET')
+    await mountEdit(spriteDetail())
+    expect(saveButton()).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('switch'))
+    expect(saveButton()).toBeEnabled()
+
+    // Flipping back restores the stored state exactly, so it is clean again.
+    fireEvent.click(screen.getByRole('switch'))
+    expect(saveButton()).toBeDisabled()
+  })
+
+  it('asks whether to overwrite or branch once the pack is dirty', async () => {
+    api.galleryReadPackFile.mockResolvedValue('STOREDSHEET')
+    const onDone = await mountEdit(spriteDetail())
+
+    fireEvent.change(fieldInput('Name *'), { target: { value: 'Pixel Ghost v2' } })
+    fireEvent.click(saveButton())
+
+    expect(onDone).not.toHaveBeenCalled()
+    fireEvent.click(within(saveDialog()).getByRole('button', { name: 'Overwrite' }))
+
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(onDone.mock.calls[0][0]).toMatchObject({ overwriteId: 'pack-77', name: 'Pixel Ghost v2' })
+    expect(screen.queryByText('Overwrite existing or save as new?')).not.toBeInTheDocument()
+  })
+
+  it('branches into a new pack instead when asked', async () => {
+    api.galleryReadPackFile.mockResolvedValue('STOREDSHEET')
+    const onDone = await mountEdit(spriteDetail())
+
+    fireEvent.change(fieldInput('Name *'), { target: { value: 'Pixel Ghost v2' } })
+    fireEvent.click(saveButton())
+    fireEvent.click(within(saveDialog()).getByRole('button', { name: 'Save as New' }))
+
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(onDone.mock.calls[0][0].overwriteId).toBeUndefined()
+  })
+
+  it('keeps the editor and its edits when the dialog is dismissed', async () => {
+    api.galleryReadPackFile.mockResolvedValue('STOREDSHEET')
+    const onDone = await mountEdit(spriteDetail())
+
+    fireEvent.change(fieldInput('Name *'), { target: { value: 'Pixel Ghost v2' } })
+    fireEvent.click(saveButton())
+    fireEvent.click(within(saveDialog()).getByRole('button', { name: 'Cancel' }))
+
+    expect(onDone).not.toHaveBeenCalled()
+    expect(screen.queryByText('Overwrite existing or save as new?')).not.toBeInTheDocument()
+    expect(fieldInput('Name *').value).toBe('Pixel Ghost v2')
+    expect(saveButton()).toBeEnabled()
+  })
+
+  it('keeps a loaded clip name as a random clip rather than turning it into a mood', async () => {
+    api.galleryReadPackFile.mockResolvedValue('STOREDSHEET')
+    const onDone = await mountEdit({
+      randomNames: ['look away'],
+      sprite: {
+        frameWidth: 32, frameHeight: 32, fps: 8, offsetY: 0, source: 'sheet.png',
+        rowAssignments: { idle: 0, 'look away': 1 },
+      },
+    })
+
+    // The clip has no slot of its own on this screen, so the only proof it
+    // survived the round trip is what the save carries.
+    fireEvent.click(screen.getByRole('switch'))
+    fireEvent.click(saveButton())
+    fireEvent.click(within(saveDialog()).getByRole('button', { name: 'Overwrite' }))
+
+    const data = onDone.mock.calls[0][0]
+    expect('look away' in data.assignments).toBe(false)
+    expect(data.randomAssignments['look away']).toMatch(/^data:image\/png;base64,slice-64x32-\d+$/)
+    expect(data.rowAssignments).toMatchObject({ idle: 0, 'look away': 1 })
+  })
+
+  it('files an unrecognised slot as a mood when the pack claims no such clip', async () => {
+    api.galleryReadPackFile.mockResolvedValue('STOREDSHEET')
+    const onDone = await mountEdit({
+      randomNames: [],
+      sprite: {
+        frameWidth: 32, frameHeight: 32, fps: 8, offsetY: 0, source: 'sheet.png',
+        rowAssignments: { idle: 0, happy: 1 },
+      },
+    })
+
+    fireEvent.click(screen.getByRole('switch'))
+    fireEvent.click(saveButton())
+    fireEvent.click(within(saveDialog()).getByRole('button', { name: 'Overwrite' }))
+
+    const data = onDone.mock.calls[0][0]
+    expect(data.assignments.happy).toMatch(/^data:image\/png;base64,slice-64x32-\d+$/)
+    expect(data.randomAssignments).toBeUndefined()
+  })
+
+  it('rebuilds the rows from the stored strips when the source sheet is gone', async () => {
+    const onDone = await mountEdit({
+      sprite: {
+        frameWidth: 24, frameHeight: 24, fps: 12, offsetY: 0,
+        rowAssignments: { idle: 1 },
+      },
+      animations: {
+        idle: { content: 'IDLEBYTES', format: 'sprite' },
+        done: { content: 'IDLEBYTES', format: 'sprite' },
+        error: { content: 'data:image/png;base64,ERRBYTES', format: 'sprite' },
+      },
+    })
+
+    // No source means no decode: the rows come from the strips themselves, and
+    // the stored rowAssignments are dropped in favour of the rebuilt mapping.
+    expect(api.galleryReadPackFile).not.toHaveBeenCalled()
+    expect(screen.getByText('Animations found in your sheet (2)')).toBeInTheDocument()
+    // The two slots sharing a strip share its row; the bare base64 one is
+    // promoted to a data URI, the already-prefixed one is left alone.
+    expect(slotSelect('idle').value).toBe('0')
+    expect(slotSelect('done').value).toBe('0')
+    expect(slotSelect('error').value).toBe('1')
+    expect(document.querySelectorAll('[data-strip="data:image/png;base64,IDLEBYTES"]').length).toBeGreaterThan(0)
+    expect(document.querySelectorAll('[data-strip="data:image/png;base64,ERRBYTES"]').length).toBeGreaterThan(0)
+    // A strip has no frame count to report.
+    expect(screen.getAllByText('0f')).toHaveLength(2)
+    // Rebuilt-from-strips is still the stored state, so Save stays shut.
+    expect(saveButton()).toBeDisabled()
+
+    fireEvent.change(fieldInput('FPS'), { target: { value: '10' } })
+    fireEvent.click(saveButton())
+    fireEvent.click(within(saveDialog()).getByRole('button', { name: 'Overwrite' }))
+
+    const data = onDone.mock.calls[0][0]
+    // There was no source sheet to carry over, and none is invented.
+    expect(data.sourceImage).toBeUndefined()
+    expect(data).toMatchObject({ fps: 10, frameWidth: 24, frameHeight: 24, overwriteId: 'pack-77' })
+    expect(data.assignments.idle).toBe('data:image/png;base64,IDLEBYTES')
+  })
+
+  it('falls back to the stored strips when reading the source sheet fails', async () => {
+    api.galleryReadPackFile.mockResolvedValue(null)
+    await mountEdit({
+      ...spriteDetail(),
+      animations: { idle: 'IDLEBYTES' },
+    })
+
+    expect(api.galleryReadPackFile).toHaveBeenCalledWith('pack-77', 'sheet.png')
+    // A bare filename entry is still readable — entryContent takes the string.
+    expect(screen.getByText('Animations found in your sheet (1)')).toBeInTheDocument()
+    expect(slotSelect('idle').value).toBe('0')
+    expect(document.querySelector('img')).toBeNull()
+  })
+
+  it('shows an empty editor when the pack detail carries no sprite', async () => {
+    await mountEdit({ sprite: null })
+
+    expect(screen.getByText('Edit Sprite Pack')).toBeInTheDocument()
+    expect(screen.queryByText('Required (just Idle)')).not.toBeInTheDocument()
+    expect(saveButton()).toBeDisabled()
+  })
+
+  it('survives a pack whose detail cannot be read at all', async () => {
+    await mountEdit(null)
+
+    expect(screen.getByText('Edit Sprite Pack')).toBeInTheDocument()
+    expect(fieldInput('Name *').value).toBe('Pixel Ghost')
+    expect(fieldInput('Frame W').value).toBe('32')
+    expect(saveButton()).toBeDisabled()
+  })
+
+  it('falls back to the defaults for a stored pack that recorded no geometry', async () => {
+    api.galleryReadPackFile.mockResolvedValue('STOREDSHEET')
+    await mountEdit({ sprite: { source: 'sheet.png' } })
+
+    expect(fieldInput('Frame W').value).toBe('32')
+    expect(fieldInput('Frame H').value).toBe('32')
+    expect(fieldInput('FPS').value).toBe('8')
+    expect(fieldInput('Y Offset').value).toBe('0')
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false')
+    // No stored mapping, so every slot is empty and Idle is reported missing.
+    expect(slotSelect('idle').value).toBe('')
+    expect(screen.getByText('Missing: Idle')).toBeInTheDocument()
+  })
+
+  it('re-slices a replacement sheet, but does not count it as a change on its own', async () => {
+    api.galleryReadPackFile.mockResolvedValue('STOREDSHEET')
+    await mountEdit(spriteDetail())
+    expect(screen.getByText('Animations found in your sheet (2)')).toBeInTheDocument()
+
+    sheetSize = { width: 64, height: 128 }
+    sheetPixels = alphaOpaque(64, 128)
+    await pickSheet('REPLACEMENT')
+
+    // The taller sheet is adopted and re-sliced on the stored 32px grid.
+    expect(screen.getByText('Animations found in your sheet (4)')).toBeInTheDocument()
+    expect(document.querySelector('img')?.getAttribute('src')).toBe('data:image/png;base64,REPLACEMENT')
+    // The dirty check compares the pack's FIELDS (name, grid, assignments) and
+    // the sheet is not one of them, so swapping the art alone leaves Save shut.
+    // Pinned as it stands: the new sheet cannot be saved until something the
+    // snapshot does watch also changes.
+    expect(saveButton()).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('switch'))
+    expect(saveButton()).toBeEnabled()
+  })
+})

--- a/website/src/test/WateringHoleSceneCoverage.test.tsx
+++ b/website/src/test/WateringHoleSceneCoverage.test.tsx
@@ -1,0 +1,687 @@
+/**
+ * WateringHoleScene — the Worlds Serengeti savanna — driven frame by frame.
+ *
+ * `Scenes.test.tsx` only proves the scene mounts a canvas, so everything the
+ * savanna actually DOES after mount (species selection by agent id, the home
+ * spot reservation pass, the giraffe reaching into an acacia, the warthog
+ * rooting in a dirt patch, the elephant drinking and ringing the hole with
+ * ripples, the amble and the shade rest, and the return home once a session
+ * stops running) never ran. happy-dom has no 2D context and no frame clock, so
+ * the harness supplies both:
+ *
+ *   - a RECORDING canvas context, so a test can ask "was the drinking trunk
+ *     painted?" or "which labels landed on the overlay?" instead of reading
+ *     pixels. Strokes are recorded too, because the water ripples are the one
+ *     thing this scene draws with `stroke()` rather than a filled rect;
+ *   - a hand-driven `requestAnimationFrame`, so a test advances exactly N
+ *     frames with no dependence on a real animation clock;
+ *   - a pinned `Math.random` and `Date.now`, so the activity dice rolls and the
+ *     speech-bubble expiry are deterministic.
+ *
+ * The scene itself arms no timers, so real timers are left alone; nothing here
+ * opens the thread popover, which is the only interval `useSceneInteraction`
+ * ever starts.
+ *
+ * Recording is switched off while fast-forwarding the hundreds of frames an
+ * elephant needs to walk to the water, and switched back on for the single
+ * frame under assertion, so memory stays flat.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act, fireEvent } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import chatReducer from '../store/chatSlice'
+import WateringHoleScene from '../pages/scenes/WateringHoleScene'
+import { markAgentsKnown } from '../hooks/sceneStateCache'
+import { SCENE_SCALE } from '../pages/scenes/config'
+import type { AgentSource } from '../hooks/useAgentSync'
+
+/** The thread popover and the in-world "New session" sign are the only api
+ *  callers reachable from this scene; stub them so nothing dials the network. */
+vi.mock('../api/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      chatSlotDetail: vi.fn(() => Promise.resolve({ messages: [] })),
+      createChatSlot: vi.fn(() => Promise.resolve({})),
+    },
+  }
+})
+
+/* ── Scene geometry mirrored from WateringHoleScene (it exports none of it) ── */
+const S = SCENE_SCALE
+const W = 480, H = 340
+const HORIZON_Y = 130
+const HOLE = { cx: 240, cy: 240, rx: 70, ry: 26 }
+/** Home spots 0 and 1 — the only two this file ever needs to name. */
+const HOME_0 = { x: 90, y: 200 }
+const HOME_1 = { x: 175, y: 200 }
+/** First foreground acacia; a browsing giraffe stands at (x - 12, y + 10). */
+const TREE_0 = { x: 70, y: 120 }
+/** Distant tree, which is where an elephant goes to rest in the shade. */
+const TREE_2 = { x: 235, y: 95 }
+/** First dirt patch, where a foraging warthog roots. */
+const FORAGE_0 = { x: 130, y: 270 }
+/** First rim station, where an elephant drinks. */
+const DRINK_0 = { x: HOLE.cx - 50, y: HOLE.cy - 8 }
+
+/* ── Palette mirrored from the scene ── */
+const GIRAFFE_BODY = '#f3d27a'
+const WARTHOG_BODY = '#7c5a3c'
+const ELEPHANT_BODY = '#9aa0a6'
+const TREE_LEAVES = '#3f6e36'
+const TREE_TRUNK = '#6b3f24'
+const DIRT = '#7a4f28'
+const GRASS_LIGHT = '#d7b14a'
+const GRASS_MID = '#b88a36'
+const GRASS_DARK = '#94682a'
+/** Ripple strokes are built as `rgba(207, 230, 244, <alpha>)`. */
+const RIPPLE_RGB = 'rgba(207, 230, 244'
+
+/* ── Species selection, mirrored from the scene's djb2 hash ── */
+const ANIMAL_KINDS = ['giraffe', 'warthog', 'elephant'] as const
+type AnimalKind = typeof ANIMAL_KINDS[number]
+
+function speciesOf(id: string): AnimalKind {
+  let h = 5381
+  for (let i = 0; i < id.length; i++) h = ((h << 5) + h + id.charCodeAt(i)) >>> 0
+  return ANIMAL_KINDS[h % ANIMAL_KINDS.length]
+}
+
+/**
+ * An agent id that the scene will turn into `kind`. Species is a pure function
+ * of the id, so the search is deterministic; `prefix` keeps each test's ids
+ * distinct so the module-level known-agent cache cannot leak between tests.
+ */
+function idOf(kind: AnimalKind, prefix: string): string {
+  for (let i = 0; i < 400; i++) {
+    const id = `slot-${prefix}-${i}`
+    if (speciesOf(id) === kind) return id
+  }
+  throw new Error(`no ${kind} id found for prefix ${prefix}`)
+}
+
+/* ── Recording 2D context ── */
+
+interface FillRecord { x: number; y: number; w: number; h: number; color: string }
+interface TextRecord { text: string; x: number; y: number }
+
+interface Recorder {
+  ctx: CanvasRenderingContext2D
+  fills: FillRecord[]
+  texts: TextRecord[]
+  /** strokeStyle of every `stroke()` call — the ripples are stroked, not filled. */
+  strokes: string[]
+}
+
+/**
+ * A 2D context that remembers what it was told to draw. Unknown members become
+ * no-op spies on first access, so a helper reaching for `ellipse`, `arc` or
+ * `roundRect` never has to be enumerated here.
+ */
+function createRecorder(): Recorder {
+  const fills: FillRecord[] = []
+  const texts: TextRecord[] = []
+  const strokes: string[] = []
+  const gradient = { addColorStop: vi.fn() }
+
+  const store: Record<string, unknown> = {
+    fillStyle: '#000000',
+    strokeStyle: '#000000',
+    globalAlpha: 1,
+    lineWidth: 1,
+    font: '',
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    imageSmoothingEnabled: false,
+    canvas: { width: 0, height: 0 },
+    createLinearGradient: vi.fn(() => gradient),
+    createRadialGradient: vi.fn(() => gradient),
+    createPattern: vi.fn(() => null),
+    // Width proportional to length so the real word-wrapper actually wraps.
+    measureText: vi.fn((t: string) => ({ width: t.length * 8 })),
+    getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(4) })),
+  }
+  store.fillRect = (x: number, y: number, w: number, h: number) => {
+    if (capturing) fills.push({ x, y, w, h, color: String(store.fillStyle) })
+  }
+  store.fillText = (text: string, x: number, y: number) => {
+    if (capturing) texts.push({ text, x, y })
+  }
+  store.stroke = () => {
+    if (capturing) strokes.push(String(store.strokeStyle))
+  }
+
+  const ctx = new Proxy(store, {
+    get(target, prop) {
+      const key = String(prop)
+      if (!(key in target)) target[key] = vi.fn()
+      return target[key]
+    },
+    set(target, prop, value) {
+      target[String(prop)] = value
+      return true
+    },
+  }) as unknown as CanvasRenderingContext2D
+
+  return { ctx, fills, texts, strokes }
+}
+
+/* ── Harness state ── */
+
+/** Every context handed out this test, in creation order. */
+let recorders: Recorder[] = []
+/** Frame callbacks queued by the scene loop, keyed by the id rAF handed back. */
+let queuedFrames = new Map<number, FrameRequestCallback>()
+let frameSeq = 0
+/** Value `Math.random()` returns — tests reassign it to steer the dice rolls. */
+let rand = 0.05
+/** Value `Date.now()` returns — tests advance it to age a speech bubble. */
+let nowMs = 1_700_000_000_000
+/** While false, the recording context drops everything (fast-forward mode). */
+let capturing = true
+
+beforeEach(() => {
+  recorders = []
+  queuedFrames = new Map()
+  frameSeq = 0
+  rand = 0.05
+  nowMs = 1_700_000_000_000
+  capturing = true
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => {
+    const rec = createRecorder()
+    recorders.push(rec)
+    return rec.ctx
+  }) as unknown as HTMLCanvasElement['getContext']
+  // happy-dom lays nothing out, so the hit-test would divide by a zero-width
+  // rect. Give the canvas its real on-screen box instead.
+  vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    left: 0, top: 0, right: W * S, bottom: H * S, width: W * S, height: H * S,
+    x: 0, y: 0, toJSON: () => ({}),
+  } as DOMRect)
+  vi.spyOn(Math, 'random').mockImplementation(() => rand)
+  vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    const id = ++frameSeq
+    queuedFrames.set(id, cb)
+    return id
+  })
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => { queuedFrames.delete(id) })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  localStorage.clear()
+})
+
+/** Advance every live scene loop by exactly `n` frames, recording each one. */
+function runFrames(n: number) {
+  act(() => {
+    for (let i = 0; i < n; i++) {
+      const due = [...queuedFrames.values()]
+      queuedFrames.clear()
+      due.forEach(cb => cb(0))
+    }
+  })
+}
+
+/** Fast-forward `n` frames without recording anything they paint. */
+function fastForward(n: number) {
+  capturing = false
+  runFrames(n)
+  capturing = true
+}
+
+/** Drop everything recorded so far, so the next frame stands alone. */
+function clearRecords() {
+  recorders.forEach(r => { r.fills.length = 0; r.texts.length = 0; r.strokes.length = 0 })
+}
+
+/**
+ * Step the loop in bursts, recording only the last frame of each burst, until
+ * `pred` holds. Frame-exact expectations would be brittle — a walk's length
+ * depends on the species' speed and the spot the dice picked — so poll instead
+ * of guessing.
+ */
+function stepUntil(pred: () => boolean, maxFrames: number, burst = 10): boolean {
+  for (let elapsed = 0; elapsed < maxFrames; elapsed += burst) {
+    fastForward(burst - 1)
+    clearRecords()
+    runFrames(1)
+    if (pred()) return true
+  }
+  return false
+}
+
+function agent(over: Partial<AgentSource> & { id: string }): AgentSource {
+  return { name: over.id, label: 'default', kind: 'slot', running: false, detail: '', ...over }
+}
+
+/** An agent the savanna has already met, so it starts at its home spot. */
+function known(over: Partial<AgentSource> & { id: string }): AgentSource {
+  const src = agent(over)
+  markAgentsKnown('serengeti', [src.id])
+  return src
+}
+
+function mount(agents: AgentSource[], visible = true) {
+  const store = configureStore({ reducer: { chat: chatReducer } })
+  const base = recorders.length
+  const view = render(
+    <Provider store={store}>
+      <MemoryRouter><WateringHoleScene agents={agents} visible={visible} /></MemoryRouter>
+    </Provider>,
+  )
+  const rerender = (next: AgentSource[], nextVisible = visible) => view.rerender(
+    <Provider store={store}>
+      <MemoryRouter><WateringHoleScene agents={next} visible={nextVisible} /></MemoryRouter>
+    </Provider>,
+  )
+  // initSceneCanvases takes the pixel context first, then the text overlay.
+  return { ...view, rerender, pixel: recorders[base], overlay: recorders[base + 1] }
+}
+
+/* ── Assertion helpers ── */
+
+const labels = (rec: Recorder) => rec.texts.map(t => t.text)
+/** Where a given label landed, or undefined when it was not drawn. */
+const textAt = (rec: Recorder, text: string) => rec.texts.find(t => t.text === text)
+/** Whether a rect of exactly this colour and size was painted anywhere. */
+const hasRect = (rec: Recorder, color: string, w: number, h: number) =>
+  rec.fills.some(f => f.color === color && f.w === w * S && f.h === h * S)
+/** Whether a rect of exactly this colour, size and position was painted. */
+const fillAt = (rec: Recorder, color: string, x: number, y: number, w: number, h: number) =>
+  rec.fills.some(f => f.color === color && f.x === x * S && f.y === y * S && f.w === w * S && f.h === h * S)
+const hasRipple = (rec: Recorder) => rec.strokes.some(s => s.startsWith(RIPPLE_RGB))
+
+/** Posture fingerprints — each is a rect size only that posture ever paints. */
+/** Neck stretched 15 tall into the canopy. */
+const giraffeBrowsing = (rec: Recorder) => hasRect(rec, GIRAFFE_BODY, 3, 15)
+/** Forelegs splayed to 9 tall instead of the standing 11. */
+const giraffeDrinking = (rec: Recorder) => hasRect(rec, GIRAFFE_BODY, 2, 9)
+/** Head dipped to 3 tall instead of the standing 4. */
+const warthogForaging = (rec: Recorder) => hasRect(rec, WARTHOG_BODY, 4, 3)
+/** Trunk extended 12 straight down into the water. */
+const elephantDrinking = (rec: Recorder) => hasRect(rec, ELEPHANT_BODY, 2, 12)
+
+const TITLE = 'Watering Hole'
+const CANVAS_LABEL = 'Watering hole scene'
+const OVERLAY_LABEL = 'Watering hole scene labels'
+const RUNNING_BADGE = '●'
+const IDLE_BADGE = '○'
+
+/** Names are 9 characters, comfortably inside the 24-character wrap width the
+ *  recorder's proportional `measureText` implies for a name label. */
+const ROSALINDA = 'Rosalinda'
+const FERDINAND = 'Ferdinand'
+const BERNADETT = 'Bernadett'
+
+/* ── Tests ── */
+
+describe('WateringHoleScene savanna', () => {
+  it('renders the pixel canvas and the text overlay with accessible labels', () => {
+    const view = mount([])
+    expect(view.getByLabelText(CANVAS_LABEL)).toBeInTheDocument()
+    expect(view.getByLabelText(OVERLAY_LABEL)).toBeInTheDocument()
+  })
+
+  it('keeps the pixel canvas unsmoothed and sized to the scene', () => {
+    const view = mount([])
+    const canvas = view.getByLabelText(CANVAS_LABEL) as HTMLCanvasElement
+    expect(canvas.style.imageRendering).toBe('pixelated')
+    expect(canvas.width).toBe(W * S)
+    expect(canvas.height).toBe(H * S)
+  })
+
+  it('titles the scene and counts an empty savanna on the very first frame', () => {
+    const { overlay } = mount([])
+    expect(textAt(overlay, TITLE)).toBeDefined()
+    expect(textAt(overlay, TITLE)!.x).toBe((W / 2) * S)
+    expect(labels(overlay)).toContain('0/8 on the savanna')
+  })
+
+  it('bands the ground, digs the dirt patches and plants the acacia trunks', () => {
+    const { pixel } = mount([])
+    expect(fillAt(pixel, GRASS_LIGHT, 0, HORIZON_Y, W, 30)).toBe(true)
+    expect(fillAt(pixel, GRASS_MID, 0, HORIZON_Y + 30, W, 60)).toBe(true)
+    expect(fillAt(pixel, GRASS_DARK, 0, HORIZON_Y + 90, W, H - HORIZON_Y - 90)).toBe(true)
+    // Forage patches are 14 wide, centred on the spot.
+    expect(fillAt(pixel, DIRT, FORAGE_0.x - 7, FORAGE_0.y, 14, 5)).toBe(true)
+    // The nearest acacia's trunk is 5 wide and 70 tall, centred under the canopy.
+    expect(fillAt(pixel, TREE_TRUNK, TREE_0.x - 2, TREE_0.y, 5, 70)).toBe(true)
+  })
+
+  it('draws nothing while hidden and starts drawing once it becomes visible', () => {
+    const { overlay, rerender } = mount([agent({ id: 'slot-hidden' })], false)
+    runFrames(5)
+    expect(overlay.texts).toHaveLength(0)
+
+    rerender([agent({ id: 'slot-hidden' })], true)
+    runFrames(1)
+    expect(labels(overlay)).toContain(TITLE)
+  })
+
+  it('caps the savanna at its eight home spots', () => {
+    const many = Array.from({ length: 12 }, (_, i) => agent({ id: `slot-crowd-${i}`, running: true }))
+    const { overlay } = mount(many)
+    expect(labels(overlay)).toContain('8/8 on the savanna')
+  })
+
+  it('cancels the frame loop on unmount so no callback outlives the scene', () => {
+    const view = mount([known({ id: idOf('elephant', 'unmount'), name: ROSALINDA })])
+    runFrames(3)
+    expect(queuedFrames.size).toBe(1)
+    act(() => { view.unmount() })
+    expect(queuedFrames.size).toBe(0)
+  })
+})
+
+describe('WateringHoleScene arrivals', () => {
+  it('stands a known animal at its home spot and slides an unseen one in from the edge', () => {
+    const settled = known({ id: idOf('elephant', 'settled'), name: ROSALINDA })
+    const newcomer = agent({ id: idOf('elephant', 'newcomer'), name: FERDINAND })
+    const { overlay } = mount([settled, newcomer])
+
+    // Labels are centred nine pixels right of the animal's own x.
+    expect(textAt(overlay, ROSALINDA)!.x).toBe((HOME_0.x + 9) * S)
+    // The newcomer starts at x = -20, still off the left edge of the savanna.
+    expect(textAt(overlay, FERDINAND)!.x).toBeLessThan(0)
+  })
+
+  it('keeps an existing animal on its spot when a new agent is inserted ahead of it', () => {
+    const resident = known({ id: idOf('warthog', 'resident'), name: ROSALINDA })
+    const { overlay, rerender } = mount([resident])
+    expect(textAt(overlay, ROSALINDA)!.x).toBe((HOME_0.x + 9) * S)
+
+    // The arrival is listed FIRST, so a naive spot search would hand it the
+    // resident's spot and stack two animals on one patch of grass.
+    const arrival = agent({ id: idOf('warthog', 'arrival'), name: FERDINAND })
+    rerender([arrival, resident])
+
+    const parked = stepUntil(
+      () => textAt(overlay, FERDINAND)?.x === (HOME_1.x + 9) * S,
+      600, 25,
+    )
+    expect(parked).toBe(true)
+    expect(textAt(overlay, ROSALINDA)!.x).toBe((HOME_0.x + 9) * S)
+  })
+
+  it('gives each agent id a stable species, so the savanna shows a mix', () => {
+    const ids = {
+      giraffe: idOf('giraffe', 'mix'),
+      warthog: idOf('warthog', 'mix'),
+      elephant: idOf('elephant', 'mix'),
+    }
+    const crew = [
+      known({ id: ids.giraffe, name: ROSALINDA }),
+      known({ id: ids.warthog, name: FERDINAND }),
+      known({ id: ids.elephant, name: BERNADETT }),
+    ]
+    const first = mount(crew)
+    expect(hasRect(first.pixel, GIRAFFE_BODY, 14, 7)).toBe(true)
+    expect(hasRect(first.pixel, WARTHOG_BODY, 11, 5)).toBe(true)
+    expect(hasRect(first.pixel, ELEPHANT_BODY, 15, 9)).toBe(true)
+
+    // Species is hashed from the id, not drawn from a queue, so remounting the
+    // same ids reproduces the same three animals.
+    act(() => { first.unmount() })
+    const again = mount(crew)
+    expect(hasRect(again.pixel, GIRAFFE_BODY, 14, 7)).toBe(true)
+    expect(hasRect(again.pixel, WARTHOG_BODY, 11, 5)).toBe(true)
+    expect(hasRect(again.pixel, ELEPHANT_BODY, 15, 9)).toBe(true)
+  })
+
+  it('badges a running animal filled and an idle one hollow', () => {
+    const busy = known({ id: idOf('elephant', 'busy'), name: ROSALINDA, running: true })
+    const resting = known({ id: idOf('elephant', 'resting'), name: FERDINAND })
+    const { overlay } = mount([busy, resting])
+
+    // Non-giraffe badges ride four pixels above the animal's anchor.
+    expect(textAt(overlay, RUNNING_BADGE)).toEqual(
+      expect.objectContaining({ x: (HOME_0.x + 9) * S, y: (HOME_0.y - 4) * S }),
+    )
+    expect(textAt(overlay, IDLE_BADGE)).toEqual(
+      expect.objectContaining({ x: (HOME_1.x + 9) * S, y: (HOME_0.y - 4) * S }),
+    )
+  })
+
+  it('reuses a settled animal when its session is renamed instead of re-entering it', () => {
+    const before = known({ id: idOf('elephant', 'rename'), name: ROSALINDA, detail: '3 msgs' })
+    const { overlay, rerender } = mount([before])
+    expect(labels(overlay)).toContain('3 msgs')
+    // Name sits below the animal, detail six pixels below the name.
+    expect(textAt(overlay, ROSALINDA)!.y).toBe((HOME_0.y + 32) * S)
+    expect(textAt(overlay, '3 msgs')!.y).toBe((HOME_0.y + 38) * S)
+
+    rerender([{ ...before, name: FERDINAND, detail: '9 msgs' }])
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay)).toContain(FERDINAND)
+    expect(labels(overlay)).toContain('9 msgs')
+    expect(labels(overlay)).not.toContain(ROSALINDA)
+    // Reused, not re-entered: it never left its home spot.
+    expect(textAt(overlay, FERDINAND)!.x).toBe((HOME_0.x + 9) * S)
+  })
+})
+
+describe('WateringHoleScene messages', () => {
+  it('raises a speech bubble for a new last message, fades it, then drops it', () => {
+    const base = known({ id: idOf('elephant', 'talker'), name: ROSALINDA })
+    const { overlay, rerender } = mount([base])
+
+    rerender([{ ...base, lastMessage: 'Drinking deep' }])
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay)).toContain('Drinking deep')
+
+    // 6.5s in: past the fade threshold, still on screen.
+    nowMs += 6_500
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay)).toContain('Drinking deep')
+
+    // Past the 7s lifetime the bubble is gone.
+    nowMs += 1_000
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay)).not.toContain('Drinking deep')
+  })
+
+  it('leaves the bubble down when a rerender repeats the same message', () => {
+    const base = known({ id: idOf('elephant', 'repeat'), name: ROSALINDA, lastMessage: 'same text' })
+    const { overlay, rerender } = mount([base])
+    rerender([{ ...base }])
+    clearRecords()
+    runFrames(1)
+    expect(labels(overlay)).not.toContain('same text')
+  })
+})
+
+describe('WateringHoleScene activities', () => {
+  it('sends a running giraffe to an acacia and stretches its neck into the leaves', () => {
+    // rand 0.05 loses the 50/50 against water and picks the nearest foreground
+    // tree; the distant one would put the giraffe above the horizon.
+    const g = known({ id: idOf('giraffe', 'browse'), name: ROSALINDA, running: true })
+    const { pixel, overlay } = mount([g])
+
+    expect(giraffeBrowsing(pixel)).toBe(true)
+    // A leaf pixel at the mouth is the only filled rect in the canopy colour.
+    expect(hasRect(pixel, TREE_LEAVES, 2, 1)).toBe(true)
+    // The badge lifts clear of the raised head while browsing.
+    expect(textAt(overlay, RUNNING_BADGE)!.y).toBe((HOME_0.y - 14) * S)
+
+    const arrived = stepUntil(
+      () => textAt(overlay, ROSALINDA)!.x === (TREE_0.x - 12 + 9) * S,
+      600, 25,
+    )
+    expect(arrived).toBe(true)
+    expect(textAt(overlay, ROSALINDA)!.y).toBe((TREE_0.y + 10 + 32) * S)
+  })
+
+  it('splays a giraffes forelegs when the dice send it to the water instead', () => {
+    rand = 0.9
+    const g = known({ id: idOf('giraffe', 'sip'), name: ROSALINDA, running: true })
+    const { pixel } = mount([g])
+    expect(giraffeDrinking(pixel)).toBe(true)
+    expect(giraffeBrowsing(pixel)).toBe(false)
+  })
+
+  it('drops a running warthogs snout into the nearest dirt patch', () => {
+    const w = known({ id: idOf('warthog', 'root'), name: FERDINAND, running: true })
+    const { pixel, overlay } = mount([w])
+    expect(warthogForaging(pixel)).toBe(true)
+
+    const arrived = stepUntil(
+      () => textAt(overlay, FERDINAND)!.x === (FORAGE_0.x - 7 + 9) * S,
+      600, 25,
+    )
+    expect(arrived).toBe(true)
+  })
+
+  it('sends a warthog to the rim instead when the dice lose the forage roll', () => {
+    rand = 0.9
+    const w = known({ id: idOf('warthog', 'thirsty'), name: FERDINAND, running: true })
+    const { pixel, overlay } = mount([w])
+    // A drinking warthog keeps its head up — only foraging dips the snout.
+    expect(warthogForaging(pixel)).toBe(false)
+    expect(hasRect(pixel, WARTHOG_BODY, 4, 4)).toBe(true)
+
+    const atRim = stepUntil(
+      () => textAt(overlay, FERDINAND)!.y === (HOLE.cy + 12 + 32) * S,
+      600, 25,
+    )
+    expect(atRim).toBe(true)
+    // Last rim station, eight pixels back from the water's edge.
+    expect(textAt(overlay, FERDINAND)!.x).toBe((HOLE.cx + 35 - 8 + 9) * S)
+  })
+
+  it('walks a running elephant to the rim, drops its trunk in and rings the water', () => {
+    const e = known({ id: idOf('elephant', 'drink'), name: BERNADETT, running: true })
+    const { pixel, overlay } = mount([e])
+    expect(elephantDrinking(pixel)).toBe(true)
+    // Nothing has reached the water yet, so the surface is still.
+    expect(hasRipple(pixel)).toBe(false)
+
+    const rippling = stepUntil(() => hasRipple(pixel), 900, 24)
+    expect(rippling).toBe(true)
+    // Ripples only spawn once the animal is standing at its rim station.
+    expect(textAt(overlay, BERNADETT)!.x).toBe((DRINK_0.x - 8 + 9) * S)
+
+    // Rings are retired once they age out, so a long drink cannot accumulate
+    // one ring per spawn: at a ring every 24 frames and a 40-frame life, only
+    // a couple are ever alive at once.
+    fastForward(120)
+    clearRecords()
+    runFrames(1)
+    expect(pixel.strokes.length).toBeGreaterThan(0)
+    expect(pixel.strokes.length).toBeLessThanOrEqual(3)
+  })
+
+  it('ambles an elephant across the open savanna on the prowl roll', () => {
+    rand = 0.5
+    const e = known({ id: idOf('elephant', 'prowl'), name: BERNADETT, running: true })
+    const { pixel, overlay } = mount([e])
+    // Ambling keeps the standing posture: the trunk hangs and curls.
+    expect(elephantDrinking(pixel)).toBe(false)
+    expect(hasRect(pixel, ELEPHANT_BODY, 2, 5)).toBe(true)
+
+    const ambled = stepUntil(
+      () => textAt(overlay, BERNADETT)!.x === (240 + 9) * S,
+      900, 25,
+    )
+    expect(ambled).toBe(true)
+    expect(textAt(overlay, BERNADETT)!.y).toBe((260 + 32) * S)
+  })
+
+  it('parks an elephant in the shade of a tree on the rest roll', () => {
+    rand = 0.9
+    const e = known({ id: idOf('elephant', 'shade'), name: BERNADETT, running: true })
+    const { overlay } = mount([e])
+
+    const shaded = stepUntil(
+      () => textAt(overlay, BERNADETT)!.y === (TREE_2.y + 55 + 32) * S,
+      900, 25,
+    )
+    expect(shaded).toBe(true)
+    expect(textAt(overlay, BERNADETT)!.x).toBe((TREE_2.x - 12 + 9) * S)
+  })
+
+  it('abandons the activity and walks home once the session stops running', () => {
+    const w = known({ id: idOf('warthog', 'stopped'), name: FERDINAND, running: true })
+    const { pixel, overlay, rerender } = mount([w])
+
+    const rooting = stepUntil(
+      () => textAt(overlay, FERDINAND)!.x === (FORAGE_0.x - 7 + 9) * S,
+      600, 25,
+    )
+    expect(rooting).toBe(true)
+
+    rerender([{ ...w, running: false }])
+    // A stationary animal whose session went quiet holds its pose for 30 frames
+    // and then heads back to its home spot.
+    const home = stepUntil(
+      () => textAt(overlay, FERDINAND)!.x === (HOME_0.x + 9) * S,
+      900, 25,
+    )
+    expect(home).toBe(true)
+    expect(labels(overlay)).toContain(IDLE_BADGE)
+    expect(warthogForaging(pixel)).toBe(false)
+  })
+
+  it('resets an animal to idle when its session changes kind mid-activity', () => {
+    const e = known({ id: idOf('elephant', 'flipped'), name: BERNADETT, running: true })
+    const { pixel, rerender } = mount([e])
+    expect(elephantDrinking(pixel)).toBe(true)
+
+    rerender([{ ...e, kind: 'cron' }])
+    clearRecords()
+    runFrames(1)
+    // Back to the hanging trunk, aimed at its home spot rather than the water.
+    expect(elephantDrinking(pixel)).toBe(false)
+    expect(hasRect(pixel, ELEPHANT_BODY, 2, 5)).toBe(true)
+  })
+
+  it('starts a newly-running animal wandering without waiting out a full dwell', () => {
+    const base = known({ id: idOf('elephant', 'woken'), name: BERNADETT })
+    const { pixel, rerender } = mount([base])
+    expect(elephantDrinking(pixel)).toBe(false)
+
+    rerender([{ ...base, running: true }])
+    clearRecords()
+    runFrames(1)
+    expect(elephantDrinking(pixel)).toBe(true)
+  })
+})
+
+describe('WateringHoleScene hover', () => {
+  it('names the hovered animal and gives it the savannas own status flavour', () => {
+    const e = known({ id: idOf('elephant', 'hover'), name: BERNADETT, running: true, detail: '3 msgs' })
+    const view = mount([e])
+    const canvas = view.getByLabelText(CANVAS_LABEL)
+
+    fireEvent.mouseMove(canvas, { clientX: HOME_0.x * S, clientY: HOME_0.y * S })
+    expect(view.getByText(BERNADETT)).toBeInTheDocument()
+    expect(view.getByText('On the move')).toBeInTheDocument()
+    expect(view.getByText(/Working/)).toBeInTheDocument()
+
+    fireEvent.mouseLeave(canvas)
+    expect(view.queryByText('On the move')).toBeNull()
+  })
+
+  it('calls an idle animal resting and ignores empty grass', () => {
+    const e = known({ id: idOf('elephant', 'idlehover'), name: ROSALINDA, kind: 'cron', detail: 'hourly' })
+    const view = mount([e])
+    const canvas = view.getByLabelText(CANVAS_LABEL)
+
+    fireEvent.mouseMove(canvas, { clientX: HOME_0.x * S, clientY: HOME_0.y * S })
+    expect(view.getByText('Resting')).toBeInTheDocument()
+
+    // Far corner of the savanna: nothing is standing there.
+    fireEvent.mouseMove(canvas, { clientX: 5 * S, clientY: 330 * S })
+    expect(view.queryByText('Resting')).toBeNull()
+  })
+})

--- a/website/src/test/bubbleLayoutCoverage.test.tsx
+++ b/website/src/test/bubbleLayoutCoverage.test.tsx
@@ -1,0 +1,534 @@
+/**
+ * `bubbleLayout` — the geometry the pet's speech bubble is placed by.
+ *
+ * Nothing here touches the DOM: it is pure arithmetic over rectangles, and that
+ * is exactly why it goes wrong silently. A bubble placed half off-screen, or
+ * placed on top of the pet it is supposed to be speaking from, still renders
+ * happily — the only witness is the number a human never reads.
+ *
+ * So every case below pins a real decision rather than a return type:
+ *
+ *  - the clamp that keeps a bubble inside the screen, including the degenerate
+ *    screen that is NARROWER than the bubble (max < min, where a naive
+ *    `Math.min(max, ...)` would push the bubble off the left edge instead);
+ *  - the score that makes an overlapping placement lose to a clamped one — the
+ *    100000 term is the whole reason the bubble does not cover the pet's face;
+ *  - the candidate filter in `pickBubblePlacementWithinBounds`, where a crowded
+ *    screen edge must leave only one viable side rather than let the random pick
+ *    choose a badly clamped one;
+ *  - `resolveWideBubbleSize`'s widening loop, asserted on the SEQUENCE of widths
+ *    it measures at, because the bug shape there is an off-by-one step or a loop
+ *    that never terminates;
+ *  - the `||` defaulting on the option bags, which means a caller passing `0`
+ *    gets the default and not zero — surprising, but load-bearing, and callers
+ *    do pass computed values.
+ *
+ * Randomness is injected, never stubbed globally: `pickBubblePlacement*` calls
+ * `random()` exactly three times (jitter X, jitter Y, then the choice among
+ * viable candidates), so a fixed sequence makes the whole placement exact.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  BUBBLE_LAYOUT_DEFAULTS,
+  BubblePriority,
+  buildBubbleCandidates,
+  canReplaceBubble,
+  clamp,
+  expandRect,
+  pickBubblePlacement,
+  pickBubblePlacementWithinBounds,
+  rectOverlapArea,
+  resolveBubbleGap,
+  resolveBubbleRect,
+  resolveBubbleRectWithinBounds,
+  resolveWideBubbleSize,
+  scoreBubblePlacement,
+  scoreBubblePlacementWithinBounds,
+  type AnchorRect,
+  type Candidate,
+  type Rect,
+  type Size,
+} from '../apps/mochi/src/shared/bubbleLayout'
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+/** A 100x100 pet window sitting in the middle of a 1000x800 screen. */
+const centredAnchor: AnchorRect = {
+  left: 450,
+  top: 400,
+  right: 550,
+  bottom: 500,
+  width: 100,
+  height: 100,
+}
+
+const wideBounds: Rect = { left: 0, top: 0, right: 1000, bottom: 800 }
+
+/**
+ * `random` with a scripted tape. Reads, in order: jitter X, jitter Y, and the
+ * pick among viable candidates. Falls back to 0 once exhausted so an extra call
+ * cannot make a case pass by accident.
+ */
+function scriptedRandom(...values: number[]): () => number {
+  let index = 0
+  return () => (index < values.length ? values[index++] : 0)
+}
+
+/** A measurer whose height shrinks as it is given more width. */
+function shrinkingMeasurer(natural: Size, heightAt: (width: number) => number) {
+  const widths: (number | null)[] = []
+  const measure = (width: number | null): Size => {
+    widths.push(width)
+    if (width == null) return natural
+    return { width, height: heightAt(width) }
+  }
+  return { measure, widths }
+}
+
+// ── clamp / rect helpers ────────────────────────────────────────────────────
+
+describe('clamp', () => {
+  it('bounds a value on both sides and passes an in-range value through', () => {
+    expect(clamp(5, 10, 20)).toBe(10)
+    expect(clamp(25, 10, 20)).toBe(20)
+    expect(clamp(14, 10, 20)).toBe(14)
+  })
+
+  it('returns min when the range is inverted, instead of the smaller max', () => {
+    // A screen narrower than the bubble produces max < min. Returning `max`
+    // here would place the bubble left of the screen's own left margin.
+    expect(clamp(50, 12, -110)).toBe(12)
+  })
+})
+
+describe('expandRect', () => {
+  it('grows every side by the padding', () => {
+    expect(expandRect({ left: 100, top: 200, right: 300, bottom: 400 }, 10)).toEqual({
+      left: 90,
+      top: 190,
+      right: 310,
+      bottom: 410,
+    })
+  })
+
+  it('shrinks on a negative padding', () => {
+    expect(expandRect({ left: 0, top: 0, right: 100, bottom: 100 }, -5)).toEqual({
+      left: 5,
+      top: 5,
+      right: 95,
+      bottom: 95,
+    })
+  })
+})
+
+describe('rectOverlapArea', () => {
+  it('multiplies the overlapping width by the overlapping height', () => {
+    const a: Rect = { left: 0, top: 0, right: 100, bottom: 50 }
+    const b: Rect = { left: 50, top: 25, right: 150, bottom: 75 }
+    expect(rectOverlapArea(a, b)).toBe(50 * 25)
+  })
+
+  it('is 0 for disjoint rectangles on either axis', () => {
+    const base: Rect = { left: 0, top: 0, right: 100, bottom: 100 }
+    expect(rectOverlapArea(base, { left: 200, top: 0, right: 300, bottom: 100 })).toBe(0)
+    expect(rectOverlapArea(base, { left: 0, top: 200, right: 100, bottom: 300 })).toBe(0)
+  })
+
+  it('is 0 for rectangles that only touch on an edge', () => {
+    expect(
+      rectOverlapArea(
+        { left: 0, top: 0, right: 100, bottom: 100 },
+        { left: 100, top: 0, right: 200, bottom: 100 }
+      )
+    ).toBe(0)
+  })
+})
+
+// ── gap ─────────────────────────────────────────────────────────────────────
+
+describe('resolveBubbleGap', () => {
+  it('uses minGap for a bubble shorter than half the pet', () => {
+    expect(resolveBubbleGap(centredAnchor, 40)).toBe(BUBBLE_LAYOUT_DEFAULTS.minGap)
+  })
+
+  it('grows with the bubble height past the threshold', () => {
+    // threshold = height * 0.5 = 50; offset = 30; 10 + 30 * 0.1 = 13.
+    expect(resolveBubbleGap(centredAnchor, 80)).toBe(13)
+  })
+
+  it('saturates at maxGap for a very tall bubble', () => {
+    expect(resolveBubbleGap(centredAnchor, 1000)).toBe(BUBBLE_LAYOUT_DEFAULTS.maxGap)
+  })
+
+  it('honours an explicit threshold, factor and range', () => {
+    expect(
+      resolveBubbleGap(centredAnchor, 30, {
+        minGap: 5,
+        maxGap: 50,
+        gapGrowthFactor: 1,
+        heightThreshold: 0,
+      })
+    ).toBe(35)
+  })
+})
+
+// ── candidates ──────────────────────────────────────────────────────────────
+
+describe('buildBubbleCandidates', () => {
+  it('centres `top` on the pet and offsets the two side placements', () => {
+    const candidates = buildBubbleCandidates(centredAnchor, 180, 80, 0, 0, 20)
+
+    expect(candidates.map(candidate => candidate.name)).toEqual(['top', 'top-right', 'top-left'])
+    expect(candidates.every(candidate => candidate.arrowSide === 'bottom')).toBe(true)
+    expect(candidates.every(candidate => candidate.targetY === centredAnchor.top)).toBe(true)
+    // All three sit on the same line above the pet: top - height - gap.
+    expect(candidates.every(candidate => candidate.top === 300)).toBe(true)
+
+    expect(candidates[0]).toMatchObject({ left: 410, targetX: 500, bias: 0 })
+    expect(candidates[1]).toMatchObject({ left: 514, targetX: 526, bias: 2 })
+    expect(candidates[2]).toMatchObject({ left: 306, targetX: 474, bias: 2 })
+  })
+
+  it('adds the jitter to every candidate', () => {
+    const plain = buildBubbleCandidates(centredAnchor, 180, 80, 0, 0, 20)
+    const jittered = buildBubbleCandidates(centredAnchor, 180, 80, 7, -3, 20)
+
+    jittered.forEach((candidate, index) => {
+      expect(candidate.left).toBe(plain[index].left + 7)
+      expect(candidate.top).toBe(plain[index].top - 3)
+      // The arrow target is the pet, so jitter must NOT move it.
+      expect(candidate.targetX).toBe(plain[index].targetX)
+    })
+  })
+})
+
+// ── rect resolution ─────────────────────────────────────────────────────────
+
+describe('resolveBubbleRectWithinBounds', () => {
+  const candidate: Candidate = {
+    name: 'top-left',
+    left: -44,
+    top: 300,
+    targetX: 474,
+    targetY: 400,
+    arrowSide: 'bottom',
+    bias: 2,
+  }
+
+  it('pulls a candidate hanging off the left edge back inside the margin', () => {
+    expect(resolveBubbleRectWithinBounds(candidate, 180, 80, wideBounds, 12)).toEqual({
+      left: 12,
+      top: 300,
+      right: 192,
+      bottom: 380,
+    })
+  })
+
+  it('offsets against a non-zero bounds origin (second monitor)', () => {
+    const rightMonitor: Rect = { left: 1920, top: 0, right: 3200, bottom: 800 }
+    expect(resolveBubbleRectWithinBounds(candidate, 180, 80, rightMonitor, 12)).toEqual({
+      left: 1932,
+      top: 300,
+      right: 2112,
+      bottom: 380,
+    })
+  })
+
+  it('falls back to the min edge when the bubble is wider than the screen', () => {
+    const tiny: Rect = { left: 0, top: 0, right: 100, bottom: 100 }
+    expect(resolveBubbleRectWithinBounds(candidate, 200, 80, tiny, 10)).toEqual({
+      left: 10,
+      top: 10,
+      right: 210,
+      bottom: 90,
+    })
+  })
+
+  it('clamps down to the bottom margin when there is no room above', () => {
+    const shortBounds: Rect = { left: 0, top: 0, right: 1000, bottom: 360 }
+    const rect = resolveBubbleRectWithinBounds(candidate, 180, 80, shortBounds, 12)
+    expect(rect.top).toBe(268)
+    expect(rect.bottom).toBe(348)
+  })
+})
+
+describe('resolveBubbleRect', () => {
+  it('is the 0-origin form of resolveBubbleRectWithinBounds', () => {
+    const candidate: Candidate = {
+      name: 'top',
+      left: 410,
+      top: 300,
+      targetX: 500,
+      targetY: 400,
+      arrowSide: 'bottom',
+      bias: 0,
+    }
+    expect(resolveBubbleRect(candidate, 180, 80, 1000, 800, 12)).toEqual(
+      resolveBubbleRectWithinBounds(candidate, 180, 80, wideBounds, 12)
+    )
+  })
+})
+
+// ── scoring ─────────────────────────────────────────────────────────────────
+
+describe('scoreBubblePlacementWithinBounds', () => {
+  const farAway: Rect = { left: 900, top: 700, right: 950, bottom: 750 }
+
+  it('scores an unclamped, non-overlapping candidate as its bias alone', () => {
+    const candidate: Candidate = {
+      name: 'top-right',
+      left: 514,
+      top: 300,
+      targetX: 526,
+      targetY: 400,
+      arrowSide: 'bottom',
+      bias: 2,
+    }
+    expect(scoreBubblePlacementWithinBounds(candidate, 180, 80, wideBounds, farAway, 12)).toBe(2)
+  })
+
+  it('charges twice the distance the candidate had to be clamped', () => {
+    const candidate: Candidate = {
+      name: 'top',
+      left: -30,
+      top: -20,
+      targetX: 0,
+      targetY: 0,
+      arrowSide: 'bottom',
+      bias: 2,
+    }
+    // Clamped by 40 on x and 30 on y => 70 * 2, plus the bias.
+    expect(
+      scoreBubblePlacementWithinBounds(candidate, 100, 50, { left: 0, top: 0, right: 500, bottom: 500 }, farAway, 10)
+    ).toBe(142)
+  })
+
+  it('adds a 100000 penalty plus the area when it would cover the pet', () => {
+    const candidate: Candidate = {
+      name: 'top',
+      left: 0,
+      top: 0,
+      targetX: 0,
+      targetY: 0,
+      arrowSide: 'bottom',
+      bias: 0,
+    }
+    const pet: Rect = { left: 50, top: 25, right: 150, bottom: 75 }
+    expect(
+      scoreBubblePlacementWithinBounds(candidate, 100, 50, { left: 0, top: 0, right: 500, bottom: 500 }, pet, 0)
+    ).toBe(100000 + 50 * 25)
+  })
+
+  it('prefers a heavily clamped placement over one that covers the pet', () => {
+    const screen: Rect = { left: 0, top: 0, right: 500, bottom: 500 }
+    const pet: Rect = { left: 50, top: 25, right: 150, bottom: 75 }
+    const onThePet: Candidate = {
+      name: 'top',
+      left: 10,
+      top: 10,
+      targetX: 0,
+      targetY: 0,
+      arrowSide: 'bottom',
+      bias: 0,
+    }
+    // Off-screen by 4610px, so its clamp penalty is enormous — and it still has
+    // to win, or a tight screen puts the bubble on the pet's face.
+    const wildlyOffScreen: Candidate = { ...onThePet, left: 5000, top: 10 }
+
+    const overlapScore = scoreBubblePlacementWithinBounds(onThePet, 100, 50, screen, pet, 10)
+    const clampScore = scoreBubblePlacementWithinBounds(wildlyOffScreen, 100, 50, screen, pet, 10)
+
+    expect(overlapScore).toBeGreaterThan(100000)
+    expect(clampScore).toBe((5000 - 390) * 2)
+    expect(clampScore).toBeLessThan(overlapScore)
+  })
+})
+
+describe('scoreBubblePlacement', () => {
+  it('is the 0-origin form of scoreBubblePlacementWithinBounds', () => {
+    const candidate: Candidate = {
+      name: 'top',
+      left: 410,
+      top: 300,
+      targetX: 500,
+      targetY: 400,
+      arrowSide: 'bottom',
+      bias: 0,
+    }
+    const pet = expandRect(centredAnchor as unknown as Rect, 10)
+    expect(scoreBubblePlacement(candidate, 180, 80, 1000, 800, pet, 12)).toBe(
+      scoreBubblePlacementWithinBounds(candidate, 180, 80, wideBounds, pet, 12)
+    )
+  })
+})
+
+// ── picking ─────────────────────────────────────────────────────────────────
+
+describe('pickBubblePlacementWithinBounds', () => {
+  it('picks the centred placement on an open screen and applies no jitter at 0.5', () => {
+    const picked = pickBubblePlacementWithinBounds(centredAnchor, 180, 80, wideBounds, {
+      gap: 20,
+      random: scriptedRandom(0.5, 0.5, 0),
+    })
+    expect(picked).toMatchObject({ name: 'top', left: 410, top: 300 })
+  })
+
+  it('can land on a lower-ranked but still viable candidate', () => {
+    // All three score within the 6-point viability window on an open screen,
+    // so the third random draw decides — this is the "bubble moves around"
+    // behaviour, not a bug.
+    const picked = pickBubblePlacementWithinBounds(centredAnchor, 180, 80, wideBounds, {
+      gap: 20,
+      random: scriptedRandom(0.5, 0.5, 0.99),
+    })
+    expect(picked.name).toBe('top-left')
+  })
+
+  it('drops badly clamped candidates when the pet is against the right edge', () => {
+    const edgeAnchor: AnchorRect = {
+      left: 300,
+      top: 400,
+      right: 400,
+      bottom: 500,
+      width: 100,
+      height: 100,
+    }
+    const narrow: Rect = { left: 0, top: 0, right: 400, bottom: 800 }
+
+    // `top` and `top-right` both have to be dragged left to fit, so only
+    // `top-left` survives the filter — every random draw must return it.
+    for (const draw of [0, 0.5, 0.99]) {
+      const picked = pickBubblePlacementWithinBounds(edgeAnchor, 180, 80, narrow, {
+        gap: 20,
+        random: scriptedRandom(0.5, 0.5, draw),
+      })
+      expect(picked).toMatchObject({ name: 'top-left', left: 156 })
+    }
+  })
+
+  it('derives the gap from the bubble height when none is given', () => {
+    const picked = pickBubblePlacementWithinBounds(centredAnchor, 180, 80, wideBounds, {
+      random: scriptedRandom(0.5, 0.5, 0),
+    })
+    expect(picked.top).toBe(centredAnchor.top - 80 - resolveBubbleGap(centredAnchor, 80))
+  })
+
+  it('uses an explicit gap of 0 verbatim rather than deriving one', () => {
+    const picked = pickBubblePlacementWithinBounds(centredAnchor, 180, 80, wideBounds, {
+      gap: 0,
+      random: scriptedRandom(0.5, 0.5, 0),
+    })
+    expect(picked.top).toBe(centredAnchor.top - 80)
+  })
+
+  it('scales the jitter by the configured ranges', () => {
+    const picked = pickBubblePlacementWithinBounds(centredAnchor, 180, 80, wideBounds, {
+      gap: 20,
+      jitterX: 100,
+      jitterY: 40,
+      random: scriptedRandom(1, 0, 0),
+    })
+    // (1 - 0.5) * 100 => +50 on x; (0 - 0.5) * 40 => -20 on y.
+    expect(picked).toMatchObject({ left: 460, top: 280 })
+  })
+
+  it('defaults the jitter ranges when they are passed as 0', () => {
+    // The implementation defaults with `||`, so 0 means "use the default" —
+    // a caller wanting no jitter must inject a constant `random` instead.
+    const picked = pickBubblePlacementWithinBounds(centredAnchor, 180, 80, wideBounds, {
+      gap: 20,
+      jitterX: 0,
+      jitterY: 0,
+      random: scriptedRandom(1, 1, 0),
+    })
+    expect(picked.left).toBe(410 + Math.round(0.5 * BUBBLE_LAYOUT_DEFAULTS.jitterX))
+    expect(picked.top).toBe(300 + Math.round(0.5 * BUBBLE_LAYOUT_DEFAULTS.jitterY))
+  })
+
+  it('runs off Math.random when no random is injected', () => {
+    const picked = pickBubblePlacementWithinBounds(centredAnchor, 180, 80, wideBounds, { gap: 20 })
+    expect(['top', 'top-right', 'top-left']).toContain(picked.name)
+    expect(Math.abs(picked.top - 300)).toBeLessThanOrEqual(BUBBLE_LAYOUT_DEFAULTS.jitterY)
+  })
+})
+
+describe('pickBubblePlacement', () => {
+  it('is the 0-origin form of pickBubblePlacementWithinBounds', () => {
+    const options = { gap: 20, random: scriptedRandom(0.5, 0.5, 0) }
+    expect(pickBubblePlacement(centredAnchor, 180, 80, 1000, 800, options)).toEqual(
+      pickBubblePlacementWithinBounds(centredAnchor, 180, 80, wideBounds, {
+        gap: 20,
+        random: scriptedRandom(0.5, 0.5, 0),
+      })
+    )
+  })
+})
+
+// ── widening ────────────────────────────────────────────────────────────────
+
+describe('resolveWideBubbleSize', () => {
+  it('accepts a naturally wide measurement without re-measuring', () => {
+    const { measure, widths } = shrinkingMeasurer({ width: 200, height: 100 }, () => 100)
+    expect(resolveWideBubbleSize(measure)).toEqual({ width: 200, height: 100 })
+    expect(widths).toEqual([null])
+  })
+
+  it('widens in steps until the bubble is wider than tall or maxWidth is hit', () => {
+    const { measure, widths } = shrinkingMeasurer({ width: 100, height: 300 }, width => 600 - width)
+    expect(resolveWideBubbleSize(measure)).toEqual({ width: 280, height: 320 })
+    // First re-measure lifts the natural 100 to minWidth, then +24 per step,
+    // with the last step clamped to maxWidth rather than overshooting to 300.
+    expect(widths).toEqual([null, 180, 204, 228, 252, 276, 280])
+  })
+
+  it('stops as soon as the height drops below the width', () => {
+    const { measure, widths } = shrinkingMeasurer({ width: 100, height: 300 }, width => width - 1)
+    expect(resolveWideBubbleSize(measure)).toEqual({ width: 180, height: 179 })
+    expect(widths).toEqual([null, 180])
+  })
+
+  it('honours explicit min/max/step', () => {
+    const { measure, widths } = shrinkingMeasurer({ width: 40, height: 80 }, width => 200 - width)
+    expect(resolveWideBubbleSize(measure, { minWidth: 50, maxWidth: 100, widthStep: 10 })).toEqual({
+      width: 100,
+      height: 100,
+    })
+    expect(widths).toEqual([null, 50, 60, 70, 80, 90, 100])
+  })
+
+  it('falls back to the defaults when the options are passed as 0', () => {
+    const { measure, widths } = shrinkingMeasurer({ width: 100, height: 90 }, () => 90)
+    expect(resolveWideBubbleSize(measure, { minWidth: 0, maxWidth: 0, widthStep: 0 })).toEqual({
+      width: BUBBLE_LAYOUT_DEFAULTS.minWidth,
+      height: 90,
+    })
+    // A literal 0 step with a 0 max would loop forever; the defaults are what
+    // keep this terminating.
+    expect(widths).toEqual([null, BUBBLE_LAYOUT_DEFAULTS.minWidth])
+  })
+})
+
+// ── priority ────────────────────────────────────────────────────────────────
+
+describe('canReplaceBubble', () => {
+  it('lets an equal or higher priority bubble take over', () => {
+    expect(canReplaceBubble(BubblePriority.Chat, BubblePriority.Chat)).toBe(true)
+    expect(canReplaceBubble(BubblePriority.Error, BubblePriority.Notification)).toBe(true)
+    expect(canReplaceBubble(BubblePriority.Approval, BubblePriority.Chat)).toBe(true)
+  })
+
+  it('refuses to let chatter interrupt an approval prompt', () => {
+    expect(canReplaceBubble(BubblePriority.Chat, BubblePriority.Approval)).toBe(false)
+    expect(canReplaceBubble(BubblePriority.Notification, BubblePriority.Error)).toBe(false)
+  })
+
+  it('orders the priorities chat < notification < error < approval', () => {
+    expect([
+      BubblePriority.Chat,
+      BubblePriority.Notification,
+      BubblePriority.Error,
+      BubblePriority.Approval,
+    ]).toEqual([0, 1, 2, 3])
+  })
+})

--- a/website/src/test/chatSliceCoverage.test.tsx
+++ b/website/src/test/chatSliceCoverage.test.tsx
@@ -1,0 +1,1075 @@
+/**
+ * Second behaviour-coverage pass over `src/store/chatSlice.ts`, aimed at the
+ * paths `ChatSliceCoverage.test.tsx` leaves untouched:
+ *
+ *  - the transcript-equality helpers behind switchSlot's reference-stability
+ *    skip (`sameTranscript` / `sameMessage` / `jsonEqual`),
+ *  - the two slot-detail merge passes (`mergePreservedThinking`,
+ *    `mergePreservedClientTs`) reached through `refreshSlot.fulfilled`,
+ *  - the remaining background-frame reconcile branches in
+ *    `applyNonActiveFrame` (sendId scan, tail fallback, stale permissions,
+ *    the background tool-log cap),
+ *  - the active-slot frame branches: stop-card replacement, compacting,
+ *    thinking dedup, a permission arriving for an already-rejected tool,
+ *    the steer break and the tail reconcile fallback,
+ *  - the approval / permission reducers (`removeByApprovalId`,
+ *    `resolveByApprovalId` cross-slot lookup, `clearPendingPermissions`),
+ *  - the per-slot activity seeding read from real localStorage,
+ *  - and the thunks whose bodies were never entered: `resumeFromHistory`,
+ *    `deleteHistorySession`, `loadOlderMessages`, the delete-navigates-to-a-peer
+ *    path, and the create-slot colour / project carry.
+ *
+ * A real store is used for everything except the deliberately-partial-state
+ * cases, and every assertion reads observable state back out.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+
+import chatReducer, {
+  appendSlotMessage,
+  clearFocusToolCallId,
+  clearPendingPermissions,
+  createSlot,
+  deleteHistorySession,
+  deleteSlot,
+  fetchHistory,
+  finalizeAssistant,
+  hydrateSlotMessages,
+  markSubagentApproving,
+  openActivityToTool,
+  removeByApprovalId,
+  removeQueuedMessage,
+  cancelQueuedMessage,
+  replaceMessages,
+  resolveByApprovalId,
+  resumeFromHistory,
+  selectSubagentActivityCount,
+  setActiveSlot,
+  setFolderSuggestion,
+  setFollowupCard,
+  sseActivityEvent,
+  sseChatMessage,
+  sseChatMessageUpdate,
+  sseSideResult,
+  sseSubagentBatchChunks,
+  sseSubagentChunk,
+  sseSubagentDone,
+  sseSubagentPending,
+  sseSubagentSpawn,
+  sseToolActivity,
+  sseToolResult,
+  switchSlot,
+  truncateAfterIndex,
+} from '../store/chatSlice'
+import dashboardReducer, { addSlotOptimistic } from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+import instancesReducer from '../store/instancesSlice'
+import { SPAWN_LAUNCH_MARKER } from '../pages/chat/types'
+import type { ChatMessage, ChatSlot } from '../types'
+import type { RootState } from '../store'
+
+const apiMock = vi.hoisted(() => ({
+  chatSlotDetail: vi.fn(),
+  chatSlots: vi.fn(),
+  chatSlotProject: vi.fn(),
+  createChatSlot: vi.fn(),
+  deleteChatSlot: vi.fn(),
+  deleteSession: vi.fn(),
+  resumeChatSlot: vi.fn(),
+  sessions: vi.fn(),
+  setSlotColor: vi.fn(),
+}))
+
+vi.mock('../api/client', () => ({ api: apiMock }))
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      chat: chatReducer,
+      dashboard: dashboardReducer,
+      notifications: notificationsReducer,
+      instances: instancesReducer,
+    },
+    middleware: (getDefault) => getDefault({ serializableCheck: false, immutableCheck: false }),
+  })
+}
+
+type Store = ReturnType<typeof makeStore>
+const chat = (store: Store) => store.getState().chat
+
+const slotRow = (key: string, extra: Partial<ChatSlot> = {}): ChatSlot => ({
+  key,
+  title: key,
+  messages: 0,
+  running: false,
+  ...extra,
+} as ChatSlot)
+
+const msg = (over: Partial<ChatMessage> & { role: string; content: string }): ChatMessage =>
+  ({ cls: '', ...over }) as ChatMessage
+
+/** A slot-detail payload as `fetchSlotDetail` normalizes it, dispatched
+ *  directly so a reducer branch can be reached without a network round trip. */
+function detail(key: string, messages: ChatMessage[], over: Record<string, unknown> = {}) {
+  return {
+    key,
+    messages,
+    running: false,
+    stopping: false,
+    hasMore: false,
+    total: messages.length,
+    queue: [],
+    context: undefined,
+    ...over,
+  }
+}
+
+const lifecycle = (type: string, arg: string, payload: unknown) => ({
+  type,
+  meta: { arg, requestId: 'req-1', requestStatus: type.endsWith('fulfilled') ? 'fulfilled' : 'pending' },
+  payload,
+})
+
+/** The pristine slice state, for the deliberately-partial-state cases below. */
+const initial = chatReducer(undefined, { type: '@@INIT' })
+
+beforeEach(() => {
+  for (const fn of Object.values(apiMock)) fn.mockReset()
+  apiMock.chatSlots.mockResolvedValue([])
+  apiMock.setSlotColor.mockResolvedValue({})
+  apiMock.chatSlotProject.mockResolvedValue({})
+  apiMock.deleteChatSlot.mockResolvedValue({})
+})
+
+describe('chatSlice transcript equality on a repeat slot fetch', () => {
+  // Switching back to an already-loaded slot re-fetches a history that is
+  // usually identical. The skip is what keeps every consumer's reference (and
+  // the virtualizer's measured row heights) intact, so it has to survive
+  // messages whose renderable fields are arrays and nested objects.
+  const withVariants = (): ChatMessage[] => [
+    msg({ role: 'user', content: 'hi', ts: '1', meta: { mid: 'u1' } }),
+    msg({
+      role: 'assistant',
+      content: 'there',
+      ts: '2',
+      meta: { mid: 'a1', tags: ['x'] },
+      variants: [{ content: 'v1', ts: '2' }, { content: 'v2' }],
+      variant_idx: 1,
+    }),
+  ]
+
+  it('keeps the existing array when the refetched transcript renders identically', async () => {
+    apiMock.chatSlotDetail.mockImplementation(async () => ({ messages: withVariants(), running: false, total: 2 }))
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    const first = chat(store).messages
+    await store.dispatch(switchSlot('B'))
+    await store.dispatch(switchSlot('A'))
+    expect(chat(store).messages).toBe(first)
+  })
+
+  it('replaces the array when a variant list differs in shape or length', async () => {
+    apiMock.chatSlotDetail.mockImplementation(async () => ({ messages: withVariants(), running: false, total: 2 }))
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    const first = chat(store).messages
+
+    // One fewer variant: same message count, so the skip must be decided by the
+    // per-field comparison rather than by array length.
+    apiMock.chatSlotDetail.mockImplementation(async () => {
+      const m = withVariants()
+      m[1].variants = [{ content: 'v1', ts: '2' }]
+      return { messages: m, running: false, total: 2 }
+    })
+    await store.dispatch(switchSlot('B'))
+    await store.dispatch(switchSlot('A'))
+    expect(chat(store).messages).not.toBe(first)
+    expect(chat(store).messages[1].variants).toHaveLength(1)
+  })
+
+  it('replaces the array when a meta value stops being an array', async () => {
+    apiMock.chatSlotDetail.mockImplementation(async () => ({ messages: withVariants(), running: false, total: 2 }))
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    const first = chat(store).messages
+
+    apiMock.chatSlotDetail.mockImplementation(async () => {
+      const m = withVariants()
+      m[1].meta = { mid: 'a1', tags: { x: true } }
+      return { messages: m, running: false, total: 2 }
+    })
+    await store.dispatch(switchSlot('B'))
+    await store.dispatch(switchSlot('A'))
+    expect(chat(store).messages).not.toBe(first)
+    expect(chat(store).messages[1].meta?.tags).toEqual({ x: true })
+  })
+
+  it('replaces the array when a meta value becomes a bare string', async () => {
+    apiMock.chatSlotDetail.mockImplementation(async () => ({ messages: withVariants(), running: false, total: 2 }))
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    const first = chat(store).messages
+
+    apiMock.chatSlotDetail.mockImplementation(async () => {
+      const m = withVariants()
+      m[1].meta = { mid: 'a1', tags: 'x' }
+      return { messages: m, running: false, total: 2 }
+    })
+    await store.dispatch(switchSlot('B'))
+    await store.dispatch(switchSlot('A'))
+    expect(chat(store).messages).not.toBe(first)
+    expect(chat(store).messages[1].meta?.tags).toBe('x')
+  })
+
+  it('replaces the array when a meta object gains a key', async () => {
+    apiMock.chatSlotDetail.mockImplementation(async () => ({ messages: withVariants(), running: false, total: 2 }))
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    const first = chat(store).messages
+
+    apiMock.chatSlotDetail.mockImplementation(async () => {
+      const m = withVariants()
+      m[1].meta = { mid: 'a1', tags: ['x'], pinned: true }
+      return { messages: m, running: false, total: 2 }
+    })
+    await store.dispatch(switchSlot('B'))
+    await store.dispatch(switchSlot('A'))
+    expect(chat(store).messages).not.toBe(first)
+    expect(chat(store).messages[1].meta?.pinned).toBe(true)
+  })
+})
+
+describe('chatSlice slot-detail refresh merges', () => {
+  it('re-inserts a reasoning block above its answer and keeps an unanchored one', () => {
+    // Reasoning is never persisted server-side, so the refresh fired on
+    // chat_done would drop it without this merge. The second block's scan hits
+    // a `user` row before any answer, so it has no anchor and must still
+    // survive rather than being silently dropped.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'thinking', content: 'because…' }),
+      msg({ role: 'assistant', content: 'answer one', ts: '2' }),
+      msg({ role: 'thinking', content: 'orphan reasoning' }),
+      msg({ role: 'user', content: 'next question', ts: '3' }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'assistant', content: 'answer one', ts: '2' }),
+      msg({ role: 'user', content: 'next question', ts: '3' }),
+    ])))
+    const roles = s.messages.map(m => m.role)
+    expect(roles).toEqual(['thinking', 'assistant', 'user', 'thinking'])
+    expect(s.messages[0].content).toBe('because…')
+    expect(s.messages[3].content).toBe('orphan reasoning')
+  })
+
+  it('carries a durable client identity onto the reloaded copy by exact ts', () => {
+    // Pass 1: a stamp that already has a server ts matches its incoming copy by
+    // that ts. The rows around it must be skipped, not mis-paired: one already
+    // carries a clientTs, one has no ts at all, and one has a ts the transcript
+    // never stamped.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'assistant', content: 'reloaded once', ts: '20', meta: { clientTs: 'msg-durable' } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'already stamped', ts: '10', meta: { clientTs: 'msg-kept' } }),
+      msg({ role: 'tool', content: 'no ts at all' }),
+      msg({ role: 'assistant', content: 'different row', ts: '99' }),
+      msg({ role: 'assistant', content: 'reloaded once', ts: '20' }),
+    ])))
+    const byContent = Object.fromEntries(s.messages.map(m => [m.content, m.meta?.clientTs]))
+    expect(byContent['reloaded once']).toBe('msg-durable')
+    expect(byContent['already stamped']).toBe('msg-kept')
+    expect(byContent['different row']).toBeUndefined()
+    expect(byContent['no ts at all']).toBeUndefined()
+  })
+
+  it('pairs a freshly-streamed identity newest-first and skips a stamped incoming row', () => {
+    // Pass 2: a ts-less stamp (born this session) has nothing to match on, so
+    // it pairs against the newest unused row of the same role. An incoming row
+    // that already carries a clientTs is never a candidate.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'assistant', content: 'streamed now', meta: { clientTs: 'msg-fresh' } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'assistant', content: 'streamed now', ts: '5', meta: { clientTs: 'msg-other' } }),
+      msg({ role: 'assistant', content: 'streamed now', ts: '6' }),
+    ])))
+    expect(s.messages.map(m => m.meta?.clientTs)).toEqual(['msg-other', 'msg-fresh'])
+  })
+
+  it('declines to hand a fresh identity to a row that already carries one', () => {
+    // The only content match in the incoming history was already stamped by an
+    // earlier reload, so the fresh identity has nowhere to land and the
+    // reloaded row must keep the stamp it already has.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'assistant', content: 'streamed now', meta: { clientTs: 'msg-fresh' } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'assistant', content: 'streamed now', ts: '5', meta: { clientTs: 'msg-other' } }),
+      msg({ role: 'assistant', content: 'a different answer', ts: '6' }),
+    ])))
+    expect(s.messages.map(m => m.meta?.clientTs)).toEqual(['msg-other', undefined])
+  })
+
+  it('discards a refresh that resolved for a slot the user already left', () => {
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([msg({ role: 'user', content: 'mine' })]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'B', detail('B', [
+      msg({ role: 'user', content: 'someone else\u2019s history' }),
+    ])))
+    expect(s.messages.map(m => m.content)).toEqual(['mine'])
+  })
+
+  it('merges a locally-resolved permission back over the refreshed history and orders mixed stamps', () => {
+    // The client's resolved flag is the only record that the approval was
+    // answered, so it wins over the server copy — and re-injecting it forces a
+    // sort across ISO, epoch, and missing timestamps.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'permission', content: 'run tests?', ts: '1700000002', meta: { approval_id: 'ap-1', resolved: 'approved' } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'oldest', ts: '2023-11-14T22:13:20.000Z' }),
+      msg({ role: 'permission', content: 'run tests?', ts: '1700000002', meta: { approval_id: 'ap-1' } }),
+      msg({ role: 'permission', content: 'write file?', ts: '1700000003', meta: { approval_id: 'ap-2' } }),
+      msg({ role: 'assistant', content: 'no stamp' }),
+    ])))
+    const perms = s.messages.filter(m => m.role === 'permission')
+    expect(perms.find(m => m.meta?.approval_id === 'ap-1')?.meta?.resolved).toBe('approved')
+    // The server-only approval is adopted, not dropped.
+    expect(perms.find(m => m.meta?.approval_id === 'ap-2')).toBeDefined()
+    // A row with no ts sorts to the front (epoch 0); the ISO row parses to the
+    // same second as ap-1 rather than to a millisecond value.
+    expect(s.messages[0].content).toBe('no stamp')
+    expect(s.messages.map(m => m.content)).toContain('oldest')
+  })
+
+  it('keeps a background pane\u2019s locally-resolved approval when its cache is warmed', () => {
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, hydrateSlotMessages({
+      slot: 'B',
+      messages: [msg({ role: 'permission', content: 'run?', meta: { approval_id: 'ap-9', resolved: 'rejected' } })],
+    }))
+    s = chatReducer(s, lifecycle('chat/warmSlotCache/fulfilled', 'B', detail('B', [
+      msg({ role: 'permission', content: 'run?', meta: { approval_id: 'ap-9' } }),
+    ])))
+    expect(s.slotMessages.B[0].meta?.resolved).toBe('rejected')
+    expect(s.slotRun.B.state).toBe('idle')
+  })
+
+  it('drops a slot-detail payload whose key would poison the prototype', () => {
+    let s = chatReducer(initial, setActiveSlot('__proto__'))
+    const poisoned = detail('__proto__', [msg({ role: 'user', content: 'hostile' })])
+    for (const type of ['chat/switchSlot/fulfilled', 'chat/refreshSlot/fulfilled', 'chat/warmSlotCache/fulfilled']) {
+      s = chatReducer(s, lifecycle(type, '__proto__', poisoned))
+    }
+    expect(s.messages).toEqual([])
+    expect(Object.keys(s.slotMessages)).toEqual([])
+    expect(({} as Record<string, unknown>).hostile).toBeUndefined()
+  })
+})
+
+describe('chatSlice background-slot reconcile', () => {
+  it('caps the background pane tool log when reasoning lands on a full log', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('front'))
+    for (let i = 0; i < 100; i++) {
+      store.dispatch(sseToolActivity({
+        slot: 'bg', tool: `t${i}`, kind: 'read', purpose: '', input_preview: '', tool_call_id: `tc-${i}`,
+      }))
+    }
+    expect(chat(store).slotActivity.bg.toolLog).toHaveLength(100)
+    store.dispatch(sseChatMessage({ slot: 'bg', role: 'chunk', content: 'thinking out loud' }))
+    const log = chat(store).slotActivity.bg.toolLog
+    expect(log).toHaveLength(100)
+    expect(log[log.length - 1].type).toBe('reasoning')
+    // The oldest tool entry is the one that was evicted.
+    expect(log[0].text).toBe('t1')
+  })
+
+  it('rejects a background pane\u2019s unanswered approvals when a new turn starts', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('front'))
+    store.dispatch(hydrateSlotMessages({
+      slot: 'bg',
+      messages: [
+        msg({ role: 'permission', content: 'with meta', meta: { approval_id: 'ap-1' } }),
+        msg({ role: 'permission', content: 'no meta at all' }),
+        msg({ role: 'permission', content: 'already answered', meta: { approval_id: 'ap-3', resolved: 'approved' } }),
+      ],
+    }))
+    store.dispatch(sseChatMessage({ slot: 'bg', role: 'user', content: 'next turn' }))
+    const perms = chat(store).slotMessages.bg.filter(m => m.role === 'permission')
+    expect(perms.map(m => m.meta?.resolved)).toEqual(['rejected', 'rejected', 'approved'])
+  })
+
+  it('reconciles a background echo by sendId even after streaming pushed rows on top', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('front'))
+    store.dispatch(appendSlotMessage({
+      slot: 'bg',
+      message: msg({ role: 'user', content: 'do it', meta: { sendId: 'send-7' } }),
+    }))
+    store.dispatch(sseChatMessage({ slot: 'bg', role: 'chunk', content: 'working' }))
+    store.dispatch(sseChatMessage({
+      slot: 'bg', role: 'user', content: 'do it', ts: '42', meta: { sendId: 'send-7', mid: 'mid-7' },
+    }))
+    const users = chat(store).slotMessages.bg.filter(m => m.role === 'user')
+    expect(users).toHaveLength(1)
+    expect(users[0].ts).toBe('42')
+    expect(users[0].meta?.mid).toBe('mid-7')
+    expect(users[0].meta?.optimistic).toBeUndefined()
+  })
+
+  it('stops the background sendId scan at a steer bubble instead of adopting it', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('front'))
+    store.dispatch(appendSlotMessage({
+      slot: 'bg',
+      message: msg({ role: 'user', content: 'steered', meta: { steer: true, optimistic: true } }),
+    }))
+    store.dispatch(sseChatMessage({
+      slot: 'bg', role: 'user', content: 'a different send', meta: { sendId: 'send-9', mid: 'mid-9' },
+    }))
+    const users = chat(store).slotMessages.bg.filter(m => m.role === 'user')
+    expect(users).toHaveLength(2)
+    expect(users[0].meta?.mid).toBeUndefined()
+  })
+
+  it('stops the background sendId scan at the first user row that is not the match', () => {
+    // The scan looks at the newest user row and stops there: an echo for a send
+    // this pane never made must not adopt somebody else's bubble.
+    const store = makeStore()
+    store.dispatch(setActiveSlot('front'))
+    store.dispatch(appendSlotMessage({
+      slot: 'bg',
+      message: msg({ role: 'user', content: 'mine', meta: { sendId: 'send-1' } }),
+    }))
+    store.dispatch(sseChatMessage({
+      slot: 'bg', role: 'user', content: 'not mine', meta: { sendId: 'send-2', mid: 'mid-2' },
+    }))
+    const users = chat(store).slotMessages.bg.filter(m => m.role === 'user')
+    expect(users.map(m => m.content)).toEqual(['mine', 'not mine'])
+    expect(users[0].meta?.optimistic).toBe(true)
+  })
+
+  it('reconciles a background echo with no sendId by matching the tail content', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('front'))
+    store.dispatch(appendSlotMessage({ slot: 'bg', message: msg({ role: 'user', content: 'queued then popped' }) }))
+    store.dispatch(sseChatMessage({
+      slot: 'bg', role: 'user', content: 'queued then popped', ts: '77', meta: { mid: 'mid-tail' },
+    }))
+    const users = chat(store).slotMessages.bg.filter(m => m.role === 'user')
+    expect(users).toHaveLength(1)
+    expect(users[0].ts).toBe('77')
+    expect(users[0].meta?.mid).toBe('mid-tail')
+  })
+})
+
+describe('chatSlice active-slot frame branches', () => {
+  it('replaces an active stop card in place instead of stacking a second one', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseChatMessage({ slot: 'A', role: 'system', content: 'Stopping…', kind: 'stop_event', meta: { id: 'stop-1' } }))
+    store.dispatch(sseChatMessage({ slot: 'A', role: 'system', content: 'Stopped', kind: 'stop_event', meta: { id: 'stop-1' } }))
+    const cards = chat(store).messages.filter(m => m.kind === 'stop_event')
+    expect(cards).toHaveLength(1)
+    expect(cards[0].content).toBe('Stopped')
+  })
+
+  it('blocks the composer while a compaction runs on the active slot', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseChatMessage({ slot: 'A', role: 'compacting', content: '' }))
+    expect(chat(store).slotState).toBe('compacting')
+    expect(chat(store).slotRunning).toBe(true)
+    expect(chat(store).messages).toEqual([])
+  })
+
+  it('keeps a single thinking placeholder for the active turn', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseChatMessage({ slot: 'A', role: 'thinking', content: '' }))
+    store.dispatch(sseChatMessage({ slot: 'A', role: 'thinking', content: '' }))
+    expect(chat(store).messages.filter(m => m.role === 'thinking')).toHaveLength(1)
+  })
+
+  it('pre-resolves a permission whose tool was already rejected', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseToolActivity({
+      slot: 'A', tool: 'bash', kind: 'shell', purpose: '', input_preview: 'rm -rf', tool_call_id: 'tc-9',
+    }))
+    store.dispatch(replaceMessages([
+      msg({ role: 'permission', content: 'first ask', meta: { approval_id: 'ap-1', tool_call_id: 'tc-9' } }),
+    ]))
+    store.dispatch(resolveByApprovalId({ id: 'ap-1', decision: 'rejected' }))
+    // A re-broadcast of the same tool's permission must not reopen the bar.
+    store.dispatch(sseChatMessage({
+      slot: 'A', role: 'permission', content: 'second ask',
+      cls: JSON.stringify({ request_id: 'ap-2', tool_input: 'rm -rf', tool_call_id: 'tc-9' }),
+    }))
+    const latest = chat(store).messages[chat(store).messages.length - 1]
+    expect(latest.meta?.approval_id).toBe('ap-2')
+    expect(latest.meta?.resolved).toBe('rejected')
+  })
+
+  it('rejects an active unanswered approval that carries no meta on a new turn', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(replaceMessages([msg({ role: 'permission', content: 'metaless' })]))
+    store.dispatch(sseChatMessage({ slot: 'A', role: 'user', content: 'new turn' }))
+    expect(chat(store).messages[0].meta?.resolved).toBe('rejected')
+  })
+
+  it('stops the active sendId scan at a steer bubble', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(replaceMessages([msg({ role: 'user', content: 'steered', meta: { steer: true } })]))
+    store.dispatch(sseChatMessage({
+      slot: 'A', role: 'user', content: 'another send', meta: { sendId: 'send-3', mid: 'mid-3' },
+    }))
+    expect(chat(store).messages.filter(m => m.role === 'user')).toHaveLength(2)
+  })
+
+  it('reconciles an active echo with no sendId against the tail bubble', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(replaceMessages([msg({ role: 'user', content: 'promoted from queue' })]))
+    store.dispatch(sseChatMessage({
+      slot: 'A', role: 'user', content: 'promoted from queue', ts: '88', meta: { mid: 'mid-88' },
+    }))
+    const users = chat(store).messages.filter(m => m.role === 'user')
+    expect(users).toHaveLength(1)
+    expect(users[0].meta?.mid).toBe('mid-88')
+    expect(users[0].ts).toBe('88')
+  })
+})
+
+describe('chatSlice message patching', () => {
+  it('patches a message by timestamp in both the live list and the slot cache', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(replaceMessages([msg({ role: 'assistant', content: 'needs auth', ts: '11', meta: { kind: 'mcp_oauth' } })]))
+    store.dispatch(hydrateSlotMessages({
+      slot: 'B',
+      messages: [msg({ role: 'assistant', content: 'needs auth', ts: '12', meta: { kind: 'mcp_oauth' } })],
+    }))
+    store.dispatch(sseChatMessageUpdate({ slot: 'A', ts: '11', content: 'authenticated', meta: { authed: true } }))
+    store.dispatch(sseChatMessageUpdate({ slot: 'B', ts: '12', meta: { authed: true } }))
+    store.dispatch(sseChatMessageUpdate({ slot: 'B', ts: 'no-such-ts', content: 'ignored' }))
+    expect(chat(store).messages[0].content).toBe('authenticated')
+    expect(chat(store).messages[0].meta?.authed).toBe(true)
+    expect(chat(store).slotMessages.B[0].meta?.authed).toBe(true)
+    expect(chat(store).slotMessages.B[0].content).toBe('needs auth')
+  })
+
+  it('patches a tool row by call id in the background slot cache as well', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(replaceMessages([msg({ role: 'tool', content: 'active tool', meta: { tool_call_id: 'tc-1' } })]))
+    store.dispatch(hydrateSlotMessages({
+      slot: 'A',
+      messages: [msg({ role: 'tool', content: 'ignored, A is active', meta: { tool_call_id: 'tc-1' } })],
+    }))
+    store.dispatch(hydrateSlotMessages({
+      slot: 'B',
+      messages: [
+        msg({ role: 'assistant', content: 'not a tool row' }),
+        msg({ role: 'tool', content: 'cached tool', meta: { tool_call_id: 'tc-1' } }),
+      ],
+    }))
+    store.dispatch(sseChatMessageUpdate({ slot: 'A', tool_call_id: 'tc-1', content: 'patched active' }))
+    store.dispatch(sseChatMessageUpdate({ slot: 'B', tool_call_id: 'tc-1', content: 'patched cache', meta: { output: 'ok' } }))
+    expect(chat(store).messages[0].content).toBe('patched active')
+    expect(chat(store).slotMessages.B[1].content).toBe('patched cache')
+    expect(chat(store).slotMessages.B[1].meta?.output).toBe('ok')
+    expect(chat(store).slotMessages.B[0].content).toBe('not a tool row')
+  })
+
+  it('ignores an update frame with no slot', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(replaceMessages([msg({ role: 'assistant', content: 'untouched', ts: '11' })]))
+    store.dispatch(sseChatMessageUpdate({ slot: '', ts: '11', content: 'clobbered' }))
+    expect(chat(store).messages[0].content).toBe('untouched')
+  })
+
+  it('merges a tool_call_update into the existing pill rather than adding one', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseToolActivity({
+      slot: 'A', tool: 'bash', kind: '', purpose: '', input_preview: '', tool_call_id: 'tc-1',
+    }))
+    store.dispatch(sseToolActivity({
+      slot: 'A', tool: 'bash', kind: 'shell', purpose: 'list the worktree', input_preview: 'ls -la',
+      tool_call_id: 'tc-1', is_update: true, is_shell: true,
+    }))
+    const log = chat(store).toolLog
+    expect(log).toHaveLength(1)
+    expect(log[0].purpose).toBe('list the worktree')
+    expect(log[0].input).toBe('ls -la')
+    expect(log[0].kind).toBe('shell')
+    expect(log[0].is_shell).toBe(true)
+  })
+
+  it('marks the permission message resolved when its approval resolves', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(replaceMessages([msg({ role: 'permission', content: 'run?', meta: { approval_id: 'ap-1' } })]))
+    store.dispatch(sseActivityEvent({ slot: 'A', kind: 'approval', text: 'run?', approval_id: 'ap-1', approval_type: 'tool' }))
+    store.dispatch(sseActivityEvent({ slot: 'A', kind: 'approval_resolved', text: '', approval_id: 'ap-1' }))
+    expect(chat(store).toolLog[0].type).toBe('approval_resolved')
+    expect(chat(store).messages[0].meta?.resolved).toBe('approved')
+  })
+
+  it('copies a spawn launch result onto every tool row sharing the call id', () => {
+    // An auto-approved tool produces two rows for one call id and the server
+    // patches both, so stopping at the newest would leave the pair disagreeing.
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(replaceMessages([
+      msg({ role: 'assistant', content: 'not a tool row' }),
+      msg({ role: 'tool', content: 'no meta yet' }),
+      msg({ role: 'tool', content: 'other call', meta: { tool_call_id: 'tc-other' } }),
+      msg({ role: 'tool', content: 'pre-approval', meta: { tool_call_id: 'tc-1' } }),
+      msg({ role: 'tool', content: 'post-approval', meta: { tool_call_id: 'tc-1' } }),
+    ]))
+    store.dispatch(sseToolResult({ slot: 'A', tool_call_id: 'tc-1', output: `Spawned 2 ${SPAWN_LAUNCH_MARKER}` }))
+    const outs = chat(store).messages.map(m => m.meta?.output)
+    expect(outs[3]).toContain('Spawned 2')
+    expect(outs[4]).toContain('Spawned 2')
+    expect(outs[2]).toBeUndefined()
+    expect(outs[1]).toBeUndefined()
+  })
+})
+
+describe('chatSlice approval and permission reducers', () => {
+  it('drops the approval row once its request is withdrawn', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(replaceMessages([
+      msg({ role: 'permission', content: 'run?', meta: { approval_id: 'ap-1' } }),
+      msg({ role: 'assistant', content: 'kept' }),
+    ]))
+    store.dispatch(removeByApprovalId('ap-1'))
+    expect(chat(store).messages.map(m => m.content)).toEqual(['kept'])
+  })
+
+  it('resolves an approval that lives in a background slot cache and flags its tool pill', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseToolActivity({
+      slot: 'A', tool: 'bash', kind: 'shell', purpose: '', input_preview: '', tool_call_id: 'tc-5',
+    }))
+    store.dispatch(hydrateSlotMessages({
+      slot: 'B',
+      messages: [msg({ role: 'permission', content: 'run?', meta: { approval_id: 'ap-5', tool_call_id: 'tc-5' } })],
+    }))
+    store.dispatch(resolveByApprovalId({ id: 'ap-5', decision: 'rejected' }))
+    expect(chat(store).slotMessages.B[0].meta?.resolved).toBe('rejected')
+    expect(chat(store).toolLog[0].rejected).toBe(true)
+  })
+
+  it('defaults an unspecified decision to approved', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(replaceMessages([msg({ role: 'permission', content: 'run?', meta: { approval_id: 'ap-1' } })]))
+    store.dispatch(resolveByApprovalId({ id: 'ap-1' }))
+    expect(chat(store).messages[0].meta?.resolved).toBe('approved')
+  })
+
+  it('rejects every unanswered approval and unfinished tool when the turn is stopped', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseToolActivity({
+      slot: 'A', tool: 'bash', kind: 'shell', purpose: '', input_preview: '', tool_call_id: 'tc-1',
+    }))
+    store.dispatch(sseToolActivity({
+      slot: 'A', tool: 'read', kind: 'read', purpose: '', input_preview: '', tool_call_id: 'tc-2',
+    }))
+    store.dispatch(sseToolResult({ slot: 'A', tool_call_id: 'tc-2', output: 'done' }))
+    store.dispatch(replaceMessages([
+      msg({ role: 'permission', content: 'with meta', meta: { approval_id: 'ap-1' } }),
+      msg({ role: 'permission', content: 'metaless' }),
+      msg({ role: 'permission', content: 'answered', meta: { approval_id: 'ap-3', resolved: 'approved' } }),
+    ]))
+    store.dispatch(clearPendingPermissions())
+    expect(chat(store).messages.map(m => m.meta?.resolved)).toEqual(['rejected', 'rejected', 'approved'])
+    const log = chat(store).toolLog
+    expect(log.find(e => e.tool_call_id === 'tc-1')?.rejected).toBe(true)
+    // The finished tool keeps its output and is not marked rejected.
+    expect(log.find(e => e.tool_call_id === 'tc-2')?.rejected).toBeUndefined()
+  })
+})
+
+describe('chatSlice transcript editing reducers', () => {
+  it('appends a finalized answer when no stream is open', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(finalizeAssistant({ content: 'from a channel replay', ts: '9' }))
+    expect(chat(store).messages).toHaveLength(1)
+    expect(chat(store).messages[0].role).toBe('assistant')
+    expect(chat(store).messages[0].ts).toBe('9')
+  })
+
+  it('truncates the transcript at a fork point', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(replaceMessages([
+      msg({ role: 'user', content: 'one' }),
+      msg({ role: 'assistant', content: 'two' }),
+      msg({ role: 'user', content: 'three' }),
+    ]))
+    store.dispatch(truncateAfterIndex(1))
+    expect(chat(store).messages.map(m => m.content)).toEqual(['one'])
+  })
+
+  it('hydrates a background slot exactly once and never the active one', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(hydrateSlotMessages({ slot: 'A', messages: [msg({ role: 'user', content: 'active' })] }))
+    expect(chat(store).slotMessages.A).toBeUndefined()
+
+    store.dispatch(sseChatMessage({ slot: 'B', role: 'assistant', content: 'live frame first' }))
+    store.dispatch(hydrateSlotMessages({ slot: 'B', messages: [msg({ role: 'user', content: 'history' })] }))
+    store.dispatch(hydrateSlotMessages({ slot: 'B', messages: [msg({ role: 'user', content: 'second attempt' })] }))
+    expect(chat(store).slotMessages.B.map(m => m.content)).toEqual(['history', 'live frame first'])
+  })
+
+  it('focuses a tool call inline and clears the signal once consumed', () => {
+    const store = makeStore()
+    store.dispatch(openActivityToTool('tc-42'))
+    expect(chat(store).focusToolCallId).toBe('tc-42')
+    store.dispatch(clearFocusToolCallId())
+    expect(chat(store).focusToolCallId).toBeNull()
+  })
+
+  it('ignores queued-bubble edits aimed at a slot with no transcript', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(removeQueuedMessage({ slot: 'unknown', content: 'x' }))
+    store.dispatch(cancelQueuedMessage({ slot: 'unknown', queue_id: 'q-1' }))
+    expect(chat(store).slotMessages.unknown).toBeUndefined()
+  })
+
+  it('promotes a queued bubble matched by content when no queue id is supplied', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(replaceMessages([
+      msg({ role: 'queued', content: 'run the suite', ts: '5', meta: { queueId: 'q-1' } }),
+    ]))
+    store.dispatch(removeQueuedMessage({ slot: 'A', content: 'run the suite' }))
+    expect(chat(store).messages.map(m => m.role)).toEqual(['user'])
+    expect(chat(store).messages[0].ts).toBe('5')
+  })
+})
+
+describe('chatSlice sub-agent cards', () => {
+  it('marks an approving sub-agent that lives under a background slot', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseSubagentSpawn({ slot: 'B', id: 'ag-1', task: 'read specs', agent: 'kirocrew' }))
+    store.dispatch(markSubagentApproving({ id: 'ag-1', approving: true }))
+    expect(chat(store).slotActivity.B.subagents['ag-1'].approving).toBe(true)
+    // An id nobody holds is a silent no-op rather than a crash.
+    store.dispatch(markSubagentApproving({ id: 'ag-missing', approving: true }))
+    expect(chat(store).slotActivity.B.subagents['ag-missing']).toBeUndefined()
+  })
+
+  it('truncates a runaway sub-agent stream from the front', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseSubagentSpawn({ slot: 'A', id: 'ag-1', task: 't', agent: 'kirocrew' }))
+    store.dispatch(sseSubagentChunk({ slot: 'A', id: 'ag-1', text: 'x'.repeat(50_001) }))
+    const streamed = chat(store).subagents['ag-1'].streaming
+    expect(streamed.length).toBeLessThan(50_001)
+    expect(streamed.endsWith('x')).toBe(true)
+    expect(streamed).toContain('\n')
+  })
+
+  it('truncates a runaway stream delivered as a coalesced batch too', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseSubagentSpawn({ slot: 'A', id: 'ag-1', task: 't', agent: 'kirocrew' }))
+    store.dispatch(sseSubagentBatchChunks({ chunks: [{ id: 'ag-1', slot: 'A', text: 'y'.repeat(50_001) }] }))
+    expect(chat(store).subagents['ag-1'].streaming.length).toBeLessThan(50_001)
+  })
+
+  it('finds a finishing card filed under a different slot key', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseSubagentSpawn({ slot: 'B', id: 'ag-7', task: 'read specs', agent: 'kirocrew' }))
+    store.dispatch(sseSubagentDone({ slot: 'C', id: 'ag-7', elapsed: 12, outcome: 'completed' }))
+    expect(chat(store).slotActivity.B.subagents['ag-7'].status).toBe('done')
+    expect(chat(store).slotActivity.B.subagents['ag-7'].elapsed).toBe(12)
+  })
+
+  it('backfills a native card\u2019s task, agent, and inline result on completion', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseSubagentSpawn({ slot: 'A', id: 'native:1', task: '', agent: '' }))
+    store.dispatch(sseSubagentDone({
+      slot: 'A', id: 'native:1', elapsed: 3, outcome: 'completed',
+      task: 'summarize the log', agent: 'explorer', result: 'all green',
+    }))
+    const card = chat(store).subagents['native:1']
+    expect(card.task).toBe('summarize the log')
+    expect(card.result).toBe('all green')
+    // A spawn with no agent falls back to the default name, so `agent` is
+    // already set and the done payload must not overwrite it.
+    expect(card.agent).toBe('kirocrew')
+  })
+
+  it('names the agent on a card that finished straight from the approval queue', () => {
+    // A pending spawn-approval card is minted with an empty agent (the approval
+    // title carries no agent name), so a completion is the first frame that can
+    // fill it in.
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseSubagentPending({ slot: 'A', id: 'ag-2', task: '', approval_id: 'ap-2' }))
+    expect(chat(store).subagents['ag-2'].agent).toBe('')
+    store.dispatch(sseSubagentDone({
+      slot: 'A', id: 'ag-2', elapsed: 1, outcome: 'stopped', task: 'never ran', agent: 'explorer',
+    }))
+    const card = chat(store).subagents['ag-2']
+    expect(card.agent).toBe('explorer')
+    expect(card.task).toBe('never ran')
+    expect(card.status).toBe('stopped')
+    // A stopped card carries no error text, and a managed id keeps no inline result.
+    expect(card.error).toBeUndefined()
+    expect(card.result).toBeUndefined()
+  })
+
+  it('counts nothing for a slot whose activity bucket has no sub-agent map', () => {
+    const state = {
+      chat: { activeSlot: null, subagents: {}, slotActivity: { bg: {} }, subagentQueued: undefined },
+    } as unknown as RootState
+    expect(selectSubagentActivityCount(state)).toBe(0)
+  })
+})
+
+describe('chatSlice side conversation frames', () => {
+  it('drops a side frame whose slot id would poison the prototype', () => {
+    const store = makeStore()
+    store.dispatch(sseSideResult({ slot: '__proto__', run_id: 'r1', role: 'user', content: 'hostile' }))
+    expect(Object.keys(chat(store).slotSide)).toEqual([])
+  })
+
+  it('blocks a late assistant chunk that arrives after the side was closed', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseSideResult({ slot: 'A', run_id: 'r1', role: 'user', content: 'question' }))
+    store.dispatch({ type: 'chat/sideClose', payload: 'A' })
+    store.dispatch(sseSideResult({ slot: 'A', run_id: 'r1', role: 'assistant', content: 'too late' }))
+    expect(chat(store).slotSide.A).toBeUndefined()
+  })
+
+  it('keeps an errored side answer as its own row and stops the spinner', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseSideResult({ slot: 'A', run_id: 'r1', role: 'user', content: 'question' }))
+    store.dispatch(sseSideResult({ slot: 'A', run_id: 'r1', role: 'assistant', content: 'partial ' }))
+    store.dispatch(sseSideResult({ slot: 'A', run_id: 'r1', role: 'assistant', content: 'boom', is_error: true }))
+    const side = chat(store).slotSide.A
+    expect(side.messages.map(m => m.is_error)).toEqual([undefined, undefined, true])
+    expect(side.pending).toBe(false)
+  })
+
+  it('ignores a redelivered side chunk with byte-identical content', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('A'))
+    store.dispatch(sseSideResult({ slot: 'A', run_id: 'r1', role: 'user', content: 'question' }))
+    store.dispatch(sseSideResult({ slot: 'A', run_id: 'r1', role: 'assistant', content: 'answer', ts: 1 }))
+    store.dispatch(sseSideResult({ slot: 'A', run_id: 'r1', role: 'assistant', content: 'answer', ts: 2 }))
+    const side = chat(store).slotSide.A
+    expect(side.messages.filter(m => m.role === 'assistant')).toHaveLength(1)
+    expect(side.messages[1].ts).toBe(new Date(1000).toISOString())
+  })
+})
+
+describe('chatSlice partial preloaded state', () => {
+  // Older persisted state and hand-built fixtures can arrive without a key the
+  // slice added later; indexing an absent map throws and would drop the update.
+  it('creates the follow-up and folder maps on demand', () => {
+    const bare = { ...initial, followups: undefined, folderSuggestions: undefined } as unknown as typeof initial
+    let s = chatReducer(bare, setFollowupCard({ slot: 'A', items: [{ title: 'T', description: 'd', prompt: 'p' }] }))
+    s = chatReducer(s, setFolderSuggestion({ slot: 'A', folderId: 'f1', folderName: 'Work', breadcrumb: 'Work' }))
+    expect(s.followups.A.items).toHaveLength(1)
+    expect(s.folderSuggestions.A.folderName).toBe('Work')
+  })
+
+  it('creates the hydration guard map on demand', () => {
+    const bare = { ...initial, activeSlot: 'A', slotHydrated: undefined } as unknown as typeof initial
+    const s = chatReducer(bare, hydrateSlotMessages({ slot: 'B', messages: [msg({ role: 'user', content: 'x' })] }))
+    expect(s.slotHydrated.B).toBe(true)
+  })
+
+  it('creates the slot message cache on demand when a warm lands', () => {
+    const bare = { ...initial, activeSlot: 'A', slotMessages: undefined } as unknown as typeof initial
+    const s = chatReducer(bare, lifecycle('chat/warmSlotCache/fulfilled', 'B', detail('B', [
+      msg({ role: 'user', content: 'warmed' }),
+    ])))
+    expect(s.slotMessages.B.map(m => m.content)).toEqual(['warmed'])
+  })
+})
+
+describe('chatSlice thunks', () => {
+  it('resumes an archived session and files it in the sidebar', async () => {
+    apiMock.resumeChatSlot.mockResolvedValue({
+      ok: true, key: 'resumed', messages: [
+        { role: 'user', content: 'old question', cls: '' },
+        { role: 'chunk', content: 'dropped', cls: '' },
+      ],
+      has_more: true, total: 12, mode: 'dashboard', surface: 'dashboard', memory_mode: 'full',
+    })
+    const store = makeStore()
+    store.dispatch(setActiveSlot('origin'))
+    await store.dispatch(resumeFromHistory({ key: 'resumed', title: 'Old chat' }))
+    const s = chat(store)
+    expect(s.activeSlot).toBe('resumed')
+    // Streaming scaffolding roles never enter the transcript.
+    expect(s.messages.map(m => m.role)).toEqual(['user'])
+    expect(s.slotHasMore).toBe(true)
+    expect(s.slotOldestIndex).toBe(11)
+    expect(store.getState().dashboard.slots.some(sl => sl.key === 'resumed')).toBe(true)
+  })
+
+  it('leaves state alone when a resume is refused', async () => {
+    apiMock.resumeChatSlot.mockResolvedValue({ ok: false, key: 'resumed', messages: [] })
+    const store = makeStore()
+    store.dispatch(setActiveSlot('origin'))
+    await store.dispatch(resumeFromHistory({ key: 'resumed', title: 'Old chat' }))
+    expect(chat(store).activeSlot).toBe('origin')
+  })
+
+  it('removes a deleted session from the history list', async () => {
+    apiMock.sessions.mockResolvedValue({ sessions: [{ key: 'h1' }, { key: 'h2' }], has_more: false })
+    apiMock.deleteSession.mockResolvedValue({})
+    const store = makeStore()
+    await store.dispatch(fetchHistory(false))
+    expect(chat(store).history).toHaveLength(2)
+    await store.dispatch(deleteHistorySession('h1'))
+    expect(apiMock.deleteSession).toHaveBeenCalledWith('h1')
+    expect(chat(store).history.map(h => h.key)).toEqual(['h2'])
+  })
+
+  // The older-page REQUEST is exercised at the reducer boundary rather than
+  // through `loadOlderMessages()`: the thunk dispatches `pending` (which sets
+  // `loadingOlder`) before its payload creator reads that same flag as a
+  // re-entrancy guard, so the creator always returns null and never fetches.
+  // Driving the thunk here would only assert that defect.
+  it('prepends an older page and tracks the remaining depth', () => {
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([msg({ role: 'user', content: 'newest', ts: '9' })]))
+    s = chatReducer(s, lifecycle('chat/loadOlder/pending', 'A', undefined))
+    expect(s.loadingOlder).toBe(true)
+    s = chatReducer(s, lifecycle('chat/loadOlder/fulfilled', 'A', {
+      slot: 'A',
+      messages: [msg({ role: 'user', content: 'older', ts: '1' })],
+      hasMore: true,
+      total: 10,
+    }))
+    expect(s.messages.map(m => m.content)).toEqual(['older', 'newest'])
+    expect(s.slotHasMore).toBe(true)
+    // Two rows are now resident, so eight remain above them.
+    expect(s.slotOldestIndex).toBe(8)
+    expect(s.loadingOlder).toBe(false)
+  })
+
+  it('ignores an older page that resolved for a slot the user left', () => {
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([msg({ role: 'user', content: 'newest' })]))
+    s = chatReducer(s, lifecycle('chat/loadOlder/fulfilled', 'B', {
+      slot: 'B', messages: [msg({ role: 'user', content: 'other slot' })], hasMore: false, total: 1,
+    }))
+    expect(s.messages.map(m => m.content)).toEqual(['newest'])
+    // A null payload (nothing left to page) is also a no-op.
+    s = chatReducer(s, lifecycle('chat/loadOlder/fulfilled', 'A', null))
+    expect(s.messages.map(m => m.content)).toEqual(['newest'])
+  })
+
+  it('clears the older-page spinner when the fetch fails', () => {
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, lifecycle('chat/loadOlder/pending', 'A', undefined))
+    s = chatReducer(s, { type: 'chat/loadOlder/rejected', meta: { arg: 'A', requestId: 'req-1', requestStatus: 'rejected' }, error: { message: 'offline' } })
+    expect(s.loadingOlder).toBe(false)
+  })
+
+  it('navigates to a peer session on the same surface when the active one is deleted', async () => {
+    apiMock.chatSlotDetail.mockResolvedValue({ messages: [], running: false })
+    const store = makeStore()
+    store.dispatch(addSlotOptimistic(slotRow('peer', { mode: 'dashboard', surface: 'dashboard' })))
+    store.dispatch(addSlotOptimistic(slotRow('doomed', { mode: 'dashboard', surface: 'dashboard' })))
+    store.dispatch(addSlotOptimistic(slotRow('other-surface', { mode: 'slack', surface: 'slack' })))
+    await store.dispatch(switchSlot('peer'))
+    await store.dispatch(switchSlot('doomed'))
+
+    await store.dispatch(deleteSlot('doomed'))
+    expect(chat(store).activeSlot).toBe('peer')
+    expect(store.getState().dashboard.slots.some(sl => sl.key === 'doomed')).toBe(false)
+  })
+
+  it('falls back to a cleared view when navigating to the peer fails', async () => {
+    apiMock.chatSlotDetail.mockResolvedValueOnce({ messages: [], running: false })
+    const store = makeStore()
+    store.dispatch(addSlotOptimistic(slotRow('peer', { mode: 'dashboard', surface: 'dashboard' })))
+    store.dispatch(addSlotOptimistic(slotRow('doomed', { mode: 'dashboard', surface: 'dashboard' })))
+    await store.dispatch(switchSlot('doomed'))
+    store.dispatch(sseChatMessage({ slot: 'doomed', role: 'assistant', content: 'will be dropped' }))
+
+    apiMock.chatSlotDetail.mockRejectedValue(new Error('gone'))
+    await store.dispatch(deleteSlot('doomed'))
+    expect(chat(store).messages).toEqual([])
+    expect(chat(store).slotRunning).toBe(false)
+  })
+
+  it('carries an explicit colour and a project directory onto a new session', async () => {
+    apiMock.createChatSlot.mockResolvedValue({ key: 'fresh' })
+    const store = makeStore()
+    await store.dispatch(createSlot({ color_index: 4, project: '/tmp/worktree' }))
+    expect(apiMock.setSlotColor).toHaveBeenCalledWith('fresh', 4)
+    expect(apiMock.chatSlotProject).toHaveBeenCalledWith('fresh', '/tmp/worktree')
+    const created = store.getState().dashboard.slots.find(sl => sl.key === 'fresh')
+    expect(created?.color_index).toBe(4)
+    expect(created?.project).toBe('/tmp/worktree')
+    expect(chat(store).activeSlot).toBe('fresh')
+  })
+
+  it('clears the active view when a delete resolves for the slot still on screen', () => {
+    let s = chatReducer(initial, setActiveSlot('doomed'))
+    s = chatReducer(s, replaceMessages([msg({ role: 'user', content: 'stale' })]))
+    s = chatReducer(s, lifecycle('chat/deleteSlot/fulfilled', 'doomed', 'doomed'))
+    expect(s.activeSlot).toBeNull()
+    expect(s.messages).toEqual([])
+    expect(s.toolLog).toEqual([])
+  })
+})
+
+describe('chatSlice per-slot activity seeding from storage', () => {
+  const KEYS = ['mc-activity-open:alpha', 'mc-activity-open:beta', 'mc-activity-open:', 'unrelated-key']
+
+  afterEach(() => {
+    for (const k of KEYS) window.localStorage.removeItem(k)
+    vi.resetModules()
+  })
+
+  it('restores each chat\u2019s panel open state on a cold load', async () => {
+    window.localStorage.setItem('mc-activity-open:alpha', 'true')
+    window.localStorage.setItem('mc-activity-open:beta', 'false')
+    // A bare prefix (no slot) and an unrelated key must both be skipped.
+    window.localStorage.setItem('mc-activity-open:', 'true')
+    window.localStorage.setItem('unrelated-key', 'true')
+    vi.resetModules()
+    const fresh = await import('../store/chatSlice')
+    const store = configureStore({ reducer: { chat: fresh.default } })
+    const seeded = store.getState().chat.slotActivity
+    expect(seeded.alpha).toEqual({ toolLog: [], subagents: {}, activityOpen: true })
+    expect(seeded.beta.activityOpen).toBe(false)
+    expect(Object.keys(seeded).sort()).toEqual(['alpha', 'beta'])
+  })
+})


### PR DESCRIPTION
## What

12 new vitest files (554 tests) raising frontend statement coverage from
**86.17% → 88.29%**, a net **+1,470 statements**. Tests only — no product code.

## Short of 90% by 1,184 statements, and the shortfall is informative

Stating it up front. More useful than the total is **where** the gain came from:

| statements | file | starting coverage |
|---|---|---|
| 354 | `src/pages/scenes/PandaOfficeScene.tsx` | 21% |
| 214 | `src/apps/mochi/src/renderer/GalleryPanel.tsx` | 0% |
| 171 | `src/apps/crew-companion/SpriteImporter.tsx` | 0% |
| 82 | `src/pages/scenes/WateringHoleScene.tsx` | 77% |
| 79 | `src/apps/mochi/src/renderer/ChatPanel.tsx` | 89% |
| 79 | `src/pages/AppsPage.tsx` | 65% |
| 74 | `src/apps/issue-radar/context.tsx` | 77% |
| 72 | `src/store/chatSlice.ts` | 95% |

Three surfaces starting at or near zero produced **739 of the 1,470**.
Meanwhile `ChatPage.tsx` — the single largest target at **481** uncovered
statements — contributed **nothing measurable**.

That is the pattern worth carrying forward: **files starting near zero convert
far better than large, already-partly-covered pages.** The remaining uncovered
lines in a 79%-covered page are the hard branches (error paths behind mocked
transports, effects that need a specific store state), and a wave sized off
"biggest uncovered count" will keep over-promising on them.

## How the number was measured

**Measured, not estimated.** main publishes no readable frontend coverage
artifact (only per-shard `frontend-blob-N`), so both sides were produced locally:

- **baseline** — full suite without these 12 files: 1,033 files, 17,125 tests
- **wave** — the 12 new files alone
- **delta** — union of the two, restricted to the baseline's denominator

Statement coverage is monotonic in the set of tests executed, so that union is
what CI will report.

### Two corrections that each would have inflated the figure

- `MdNotebookPageCoverage` and `CliPanelCoverage` are **pre-existing**
  concurrent-run flakes and had to be excluded from the baseline (vitest writes
  **no** coverage report at all on a non-zero exit). Their coverage is measured
  separately and added **back** into the baseline — without that, lines they
  already cover get miscredited to this wave.
- cobertura repeats every `<line>` inside `<methods>`. Counting occurrences
  rather than de-duplicating by line number inflated one denominator from 69k to
  **83k** and moved the reported rate by more than a point. The parser
  de-duplicates.

The baseline run first failed on `LocalStorageDebugCoverage`, which is **broken
on main** and fixed separately in
https://github.com/kirodotdev/KiroCrew/pull/3112. That one-line fix was applied
locally to make the baseline measurable, then reverted — it is **not** in this
diff.

## Verification

- 13 files / **554 tests pass**
- `tsc --noEmit`: exit 0
- `eslint src/ --max-warnings 1116`: exit 0 (0 errors)
- `jscpd .`: 0 clones
- brand gate with `BRAND_BASE_REF=origin/main`: exit 0
- structural scan: no stub places 3+ sibling buttons in one row, including
  `.map` bodies that emit one button per item — AUTOSDE
  `max-two-buttons-per-row` covers test files, and this wave's stubs each wrap
  their button

## Scope

`FRONTEND_MIN` is untouched — https://github.com/kirodotdev/KiroCrew/pull/3104
owns raising the floors to 85%.
