### PR TITLE
fix(browser): reconcile @playwright-mcp against Browser Mode at boot

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -48,7 +48,11 @@ from kiro_crew.agent_files import (
     REQUIRED_KIRO_AGENT_FILES,
 )
 from kiro_crew.agent_files import RESEARCH_AGENT_FILENAME as _RESEARCH_AGENT_FILENAME
-from kiro_crew.browser.setup import converge_playwright_servers
+from kiro_crew.browser.setup import (
+    browser_mode_enabled,
+    converge_playwright_servers,
+    reconcile_playwright_in_config,
+)
 from kiro_crew.config import config_dir
 from kiro_crew.config import config_path as _mc_config_path
 from kiro_crew.config.paths import (
@@ -77,6 +81,17 @@ from kiro_crew.sel import (  # circular import: sel imports config which imports
 logger = logging.getLogger(__name__)
 
 
+def _config_has_server_env(data: dict) -> bool:
+    """True when ``data`` carries any MCP server spec with a non-empty ``env``
+    block — i.e. token/credential material (e.g. a Playwright proxy spec) that
+    must stay owner-only on disk rather than inherit a world-readable default.
+    """
+    servers = data.get("mcpServers") if isinstance(data, dict) else None
+    if not isinstance(servers, dict):
+        return False
+    return any(isinstance(spec, dict) and spec.get("env") for spec in servers.values())
+
+
 def _atomic_json_write(path: Path, data: dict) -> None:
     """Write JSON atomically via tmp+rename to prevent read-of-partial-file.
 
@@ -95,6 +110,14 @@ def _atomic_json_write(path: Path, data: dict) -> None:
                 mode = stat.S_IMODE(path.stat().st_mode)
             except FileNotFoundError:
                 mode = 0o644
+            # Security: an agent config that carries an MCP server ``env`` block
+            # (e.g. the token-bearing Playwright proxy spec) must never be group/
+            # other-readable. The default umask perms above (commonly 0644), or a
+            # looser mode carried over from an existing file, would expose those
+            # secrets to other local users — so force owner-only 0600 whenever the
+            # emitted config holds any env-bearing server spec.
+            if _config_has_server_env(data):
+                mode = 0o600
             platform_compat.fchmod_safe(f.fileno(), mode)
             json.dump(data, f, indent=2)
             f.write("\n")
@@ -2515,6 +2538,30 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
     # slash-containing keys), so this launch-target-keyed pass closes the
     # duplicate for them.
     converge_playwright_servers(config)
+
+    # Browser Mode is the SINGLE SOURCE OF TRUTH for the Playwright proxy on the
+    # primary agent, enforced on EVERY rebuild (not just a Settings toggle):
+    #   * Mode ON  + proxy registered -> ensure ``@playwright-mcp`` is mounted in
+    #     ``tools`` (an existing resolved spec is left as-is; tools-only, so the
+    #     PreToolUse gate governs approval — matching the shared-server sync
+    #     below);
+    #   * Mode OFF -> scrub the proxy server + its ``@`` refs so a stale ON-era
+    #     entry carried over from an existing config can never regress into a
+    #     mounted ``browser_*`` tool set ("off means off").
+    # The shared-server sync below independently mounts a registered proxy while
+    # Mode is on; this call is what makes the OFF direction and the ON invariant
+    # hold regardless of whether the proxy happens to be in the shared scopes.
+    if reconcile_playwright_in_config(config):
+        sel().log_api_access(
+            caller="system",
+            operation=("mcp_tools_added" if browser_mode_enabled() else "mcp_tools_removed"),
+            outcome="ok",
+            source="install_agent",
+            resources=(
+                f"@playwright-mcp browser-mode reconcile "
+                f"(browser_mode_enabled={browser_mode_enabled()})"
+            ),
+        )
 
     # Sync shared (user-installed) servers to tools/allowedTools.
     # These are explicitly installed by the user via `aim mcp install` or

--- a/src/kiro_crew/browser/setup.py
+++ b/src/kiro_crew/browser/setup.py
@@ -1505,6 +1505,102 @@ def remove_playwright_servers(config: dict) -> bool:
     return True
 
 
+def _registered_playwright_spec(canonical: str) -> "dict | None":
+    """The canonical Playwright PROXY spec as registered in kiro's ``mcp.json``.
+
+    Returns ``None`` when kiro's ``mcp.json`` is absent, unreadable, or the
+    canonical key is missing / holds a user's DIRECT (non-proxy) server. A
+    ``None`` here means "the proxy is not registered/resolvable", which is
+    exactly the condition under which :func:`add_playwright_servers` must mount
+    nothing — the enable invariant is *mode on AND proxy registered*, not mode
+    on alone.
+    """
+    mcp_json = _kiro_mcp_json_path()
+    if not mcp_json.is_file():
+        return None
+    try:
+        data = json.loads(mcp_json.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    servers = data.get("mcpServers") if isinstance(data, dict) else None
+    spec = servers.get(canonical) if isinstance(servers, dict) else None
+    return spec if _spec_is_proxy(spec) else None
+
+
+def add_playwright_servers(config: dict) -> bool:
+    """Ensure the canonical Playwright proxy is MOUNTED in ``config`` when Browser
+    Mode is on and the proxy is registered. The inverse of
+    :func:`remove_playwright_servers`; mutates in place, returns ``True`` iff
+    anything changed.
+
+    This is the ON-side counterpart the codebase previously lacked: OFF was
+    enforced at the agent-config level (``remove_playwright_servers`` via
+    :func:`deregister_playwright_proxy` / the boot migration), but ON relied on a
+    full ``rebuild_agent_config`` that neither gateway boot nor the Settings
+    toggle triggers — so a config last materialized while Mode was off never
+    regained ``@playwright-mcp`` and a fresh session saw zero ``browser_*`` tools
+    until the operator toggled off->on. This closes that asymmetry.
+
+    Guarantees:
+      * gated on :func:`browser_mode_enabled` — "off means off" is preserved;
+      * mounts the proxy SPEC (as registered in kiro's ``mcp.json``) only when
+        the canonical key is ABSENT — an already-present proxy spec is left
+        exactly as-is, so a rebuild's command-resolved entry is never clobbered
+        back to the unresolved ``mcp.json`` form;
+      * never touches a user's DIRECT (non-proxy) server under the canonical key
+        (authorship is by launch target, mirroring register/deregister);
+      * ``tools``-only mount, never ``allowedTools`` — the PreToolUse gate governs
+        approval, matching how the shared-server sync mounts user MCP servers.
+    """
+    if not browser_mode_enabled():
+        return False
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict):
+        servers = config["mcpServers"] = {}
+    canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
+    existing = servers.get(canonical)
+    changed = False
+    if existing is None:
+        # Not present: mount the proxy spec kiro's mcp.json carries. Absent there
+        # (proxy not registered / not resolvable) => nothing to mount.
+        spec = _registered_playwright_spec(canonical)
+        if spec is None:
+            return False
+        servers[canonical] = spec
+        changed = True
+    elif not _spec_is_proxy(existing):
+        # A user's own direct server holds the canonical key — never clobber it,
+        # and do not mount our @ref onto their server.
+        return False
+    # else: an existing proxy spec (rebuild-resolved or written by a prior sweep)
+    # is left untouched; only its @ref is ensured below.
+    ref = f"@{canonical}"
+    tools = config.get("tools")
+    if not isinstance(tools, list):
+        tools = config["tools"] = []
+    if ref not in tools:
+        tools.append(ref)
+        changed = True
+    if changed:
+        logger.info("Mounted Playwright proxy %r (Browser Mode enabled)", canonical)
+    return changed
+
+
+def reconcile_playwright_in_config(config: dict) -> bool:
+    """Make :func:`browser_mode_enabled` the SINGLE SOURCE OF TRUTH for the
+    Playwright proxy in an agent ``config``. Mutates in place, returns ``True``
+    iff anything changed.
+
+    * Mode ON  -> :func:`add_playwright_servers` (mount when registered);
+    * Mode OFF -> :func:`remove_playwright_servers` (scrub server + ``@`` refs so
+      a stale ON-era entry can never regress into a mounted ``browser_*`` tool
+      set on a rebuild).
+    """
+    if browser_mode_enabled():
+        return add_playwright_servers(config)
+    return remove_playwright_servers(config)
+
+
 def _owned_agent_config_files() -> list[Path]:
     """The EXACT agent-config files Kiro Crew generates that exist on disk.
 

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -2478,6 +2478,29 @@ async def _browser_config_finalize(
         ),
     )
 
+    # The single lock-protected writer of the owned agent configs is
+    # ``rebuild_agent_config`` (it runs ``reconcile_playwright_in_config`` to make
+    # Browser Mode the source of truth for ``@playwright-mcp``). The Settings
+    # toggle only rewrote kiro's mcp.json above, so trigger a rebuild here — before
+    # the session reset below — so the regenerated agent config reflects the new
+    # mode and the reset serves the correct tool surface. Best-effort: the
+    # preferences already landed, so a rebuild failure is logged, not raised (a
+    # 500 would wrongly tell the user nothing was saved). Mirrors mcp_custom.py.
+    try:
+        # circular import: kiro_crew.agent imports dashboard handlers.
+        from kiro_crew.agent import rebuild_agent_config
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+        # Hold the shared config-writer lock ACROSS the rebuild so a concurrent
+        # locked config mutation (e.g. an MCP toggle persisting under the same
+        # lock) cannot straddle this read-modify-write and be lost. Bounded
+        # critical section; rebuild_agent_config does not re-acquire this lock,
+        # so there is no re-entrancy/deadlock.
+        async with _get_config_lock():
+            await asyncio.to_thread(rebuild_agent_config)
+    except Exception:
+        logger.warning("browser config saved, but agent-config rebuild failed", exc_info=True)
+
     # Flipping the enable changes the agent's tool surface (register mounts the
     # browser_* tools, deregister removes them), and kiro-cli caches ``tools/list``
     # for the LIFETIME of a session — ACP has no ``tools/list_changed`` push. Reset

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import sys
 import unittest.mock
 from contextlib import ExitStack
@@ -475,6 +476,40 @@ class TestAtomicJsonWrite:
 
         assert stat.S_IMODE(target.stat().st_mode) == 0o644
         assert json.loads(target.read_text(encoding="utf-8")) == {"new": True}
+
+    def test_env_bearing_spec_forced_to_0o600(self, tmp_path: Path):
+        # Security (GPT finding): a config carrying an MCP server ``env`` block
+        # (token/credential material) must be written owner-only, not the 0644
+        # umask default a new file would otherwise get.
+        from kiro_crew.agent import _atomic_json_write
+
+        target = tmp_path / "with_env.json"
+        _atomic_json_write(
+            target,
+            {"mcpServers": {"playwright-mcp": {"command": "x", "env": {"TOKEN": "secret"}}}},
+        )
+
+        import stat
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    def test_env_bearing_tightens_loose_existing_perms(self, tmp_path: Path):
+        # Even an existing world-readable file (e.g. a 0644 kirocrew.json) is
+        # tightened to 0600 once it carries an env-bearing spec — the preserve
+        # path must not keep secrets group/other-readable.
+        from kiro_crew.agent import _atomic_json_write
+
+        target = tmp_path / "loose.json"
+        target.write_text("{}")
+        target.chmod(0o644)
+        _atomic_json_write(
+            target,
+            {"mcpServers": {"srv": {"command": "x", "env": {"TOKEN": "secret"}}}},
+        )
+
+        import stat
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
     def test_no_temp_file_left_on_success(self, tmp_path: Path):
         from kiro_crew.agent import _atomic_json_write
@@ -4375,3 +4410,82 @@ def test_ensure_agent_materialized_swallows_errors(tmp_path, monkeypatch):
 
     managed = Path(agent_mod.AGENT_FILENAME).stem
     assert agent_mod.ensure_agent_materialized(managed) is False
+
+
+class TestBrowserModeReconcileOnRebuild:
+    """rebuild_agent_config makes browser_mode_enabled() the single source of
+    truth for the Playwright proxy on the primary agent."""
+
+    _PROXY = {"command": "/usr/bin/kirocrew", "args": ["mcp-playwright-proxy", "--config", "x"]}
+
+    def test_mode_on_mounts_playwright_ref(self, tmp_path: Path):
+        cfg_dir = _bundled_defaults(tmp_path)
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch("kiro_crew.browser.setup.browser_mode_enabled", return_value=True)
+            )
+            stack.enter_context(patch("kiro_crew.agent.browser_mode_enabled", return_value=True))
+            stack.enter_context(
+                patch(
+                    "kiro_crew.browser.setup._registered_playwright_spec",
+                    return_value=dict(self._PROXY),
+                )
+            )
+            path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text(encoding="utf-8"))
+        assert "playwright-mcp" in config["mcpServers"]
+        assert "@playwright-mcp" in config["tools"]
+        # tools-only mount — never auto-approved.
+        assert "@playwright-mcp" not in config.get("allowedTools", [])
+
+    def test_mode_off_scrubs_carried_over_proxy(self, tmp_path: Path):
+        cfg_dir = _bundled_defaults(tmp_path)
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        # Existing config carries a stale ON-era proxy + its refs.
+        existing = {
+            "model": "claude-user-custom",
+            "tools": ["@playwright-mcp", "ReadFile"],
+            "allowedTools": ["@playwright-mcp"],
+            "mcpServers": {"playwright-mcp": dict(self._PROXY)},
+            "toolsSettings": {"execute_bash": {"deniedCommands": []}},
+            "hooks": {},
+        }
+        (kiro_dir / "kirocrew.json").write_text(json.dumps(existing))
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch("kiro_crew.browser.setup.browser_mode_enabled", return_value=False)
+            )
+            stack.enter_context(patch("kiro_crew.agent.browser_mode_enabled", return_value=False))
+            path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text(encoding="utf-8"))
+        assert "playwright-mcp" not in config["mcpServers"]
+        assert "@playwright-mcp" not in config["tools"]
+        assert "@playwright-mcp" not in config.get("allowedTools", [])
+
+    def test_rebuilt_config_with_token_bearing_proxy_is_0600(self, tmp_path: Path):
+        # End-to-end: with Browser Mode ON the reconcile mounts the registered
+        # proxy spec into the primary agent config; when that spec carries an
+        # ``env`` token block the written file must be owner-only 0600 (GPT
+        # finding: a token-bearing spec must never land in a 0644 file).
+        cfg_dir = _bundled_defaults(tmp_path)
+        proxy_with_env = {
+            "command": "/usr/bin/kirocrew",
+            "args": ["mcp-playwright-proxy", "--config", "x"],
+            "env": {"PLAYWRIGHT_PROXY_TOKEN": "secret-token-value"},
+        }
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch("kiro_crew.browser.setup.browser_mode_enabled", return_value=True)
+            )
+            stack.enter_context(patch("kiro_crew.agent.browser_mode_enabled", return_value=True))
+            stack.enter_context(
+                patch(
+                    "kiro_crew.browser.setup._registered_playwright_spec",
+                    return_value=dict(proxy_with_env),
+                )
+            )
+            path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text(encoding="utf-8"))
+        assert config["mcpServers"]["playwright-mcp"].get("env")  # env survived the write
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600

--- a/test/test_browser_setup.py
+++ b/test/test_browser_setup.py
@@ -2130,3 +2130,142 @@ class TestConvergeForensics:
 
         assert agent_mod.AGENT_FILENAME == agent_files.AGENT_FILENAME
         assert agent_mod.AGENT_FILENAME in agent_files.OWNED_KIRO_AGENT_FILES
+
+
+# ── TestAddPlaywrightServers ─────────────────────────────────────────────────
+
+
+_PROXY = {"command": "kirocrew", "args": ["mcp-playwright-proxy", "--config", "x"]}
+
+
+class TestAddPlaywrightServers:
+    """ON-side counterpart of remove_playwright_servers: mount the canonical
+    proxy + its @playwright-mcp tools ref when Browser Mode is on and the proxy
+    is registered. Symmetric security property to the OFF scrub."""
+
+    def test_mounts_server_and_tools_ref_when_registered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        _write_mcp_json(tmp_path, {_CANONICAL: dict(_PROXY)})
+        cfg: dict = {"mcpServers": {}, "tools": ["@other"], "allowedTools": []}
+        assert setup_mod.add_playwright_servers(cfg) is True
+        assert setup_mod._spec_is_proxy(cfg["mcpServers"][_CANONICAL])
+        assert f"@{_CANONICAL}" in cfg["tools"]
+        # tools-only mount: never auto-approved (PreToolUse gate governs it).
+        assert f"@{_CANONICAL}" not in cfg["allowedTools"]
+
+    def test_noop_when_mode_off(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        # "off means off": even with a registered proxy, add mounts nothing.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: False)
+        _write_mcp_json(tmp_path, {_CANONICAL: dict(_PROXY)})
+        cfg: dict = {"mcpServers": {}, "tools": []}
+        assert setup_mod.add_playwright_servers(cfg) is False
+        assert _CANONICAL not in cfg["mcpServers"]
+        assert cfg["tools"] == []
+
+    def test_noop_when_proxy_not_registered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Mode on but the proxy is not registered/resolvable in kiro's mcp.json
+        # → nothing to mount (the invariant is mode-on AND registered).
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        _write_mcp_json(tmp_path, {"some-user-mcp": {"command": "foo"}})
+        cfg: dict = {"mcpServers": {}, "tools": []}
+        assert setup_mod.add_playwright_servers(cfg) is False
+        assert _CANONICAL not in cfg["mcpServers"]
+
+    def test_existing_proxy_spec_not_clobbered_only_ref_ensured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A rebuild-resolved proxy spec (absolute command) must survive: add only
+        # ensures the @ref, never overwrites the present spec back to mcp.json's.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        _write_mcp_json(tmp_path, {_CANONICAL: dict(_PROXY)})
+        resolved = {"command": "/abs/kirocrew", "args": ["mcp-playwright-proxy", "--config", "x"]}
+        cfg: dict = {"mcpServers": {_CANONICAL: dict(resolved)}, "tools": []}
+        assert setup_mod.add_playwright_servers(cfg) is True
+        assert cfg["mcpServers"][_CANONICAL] == resolved  # untouched
+        assert cfg["tools"] == [f"@{_CANONICAL}"]
+        # Idempotent: a second pass with the ref already present is a no-op.
+        assert setup_mod.add_playwright_servers(cfg) is False
+
+    def test_user_direct_server_under_canonical_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        _write_mcp_json(tmp_path, {_CANONICAL: dict(_PROXY)})
+        direct = {"command": "npx", "args": ["@playwright/mcp@latest"]}
+        cfg: dict = {"mcpServers": {_CANONICAL: dict(direct)}, "tools": []}
+        assert setup_mod.add_playwright_servers(cfg) is False
+        assert cfg["mcpServers"][_CANONICAL] == direct
+        assert cfg["tools"] == []
+
+
+class TestReconcilePlaywrightInConfig:
+    """browser_mode_enabled() is the single source of truth: ON → add, OFF →
+    remove (scrub)."""
+
+    def test_on_mounts(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: True)
+        _write_mcp_json(tmp_path, {_CANONICAL: dict(_PROXY)})
+        cfg: dict = {"mcpServers": {}, "tools": []}
+        assert setup_mod.reconcile_playwright_in_config(cfg) is True
+        assert f"@{_CANONICAL}" in cfg["tools"]
+
+    def test_off_scrubs_stale_entry(self, monkeypatch: pytest.MonkeyPatch):
+        # A stale ON-era proxy carried over in an existing config must be scrubbed
+        # when Mode is off — a rebuild can never regress "off" into mounted tools.
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: False)
+        cfg: dict = {
+            "mcpServers": {_CANONICAL: dict(_PROXY)},
+            "tools": [f"@{_CANONICAL}", "@other"],
+            "allowedTools": [f"@{_CANONICAL}"],
+        }
+        assert setup_mod.reconcile_playwright_in_config(cfg) is True
+        assert _CANONICAL not in cfg["mcpServers"]
+        assert cfg["tools"] == ["@other"]
+        assert cfg["allowedTools"] == []
+
+
+class TestMigrateOffScrubsAgentFilesOnBoot:
+    """The gateway-boot migration with Browser Mode OFF must REMOVE any stale
+    proxy carried over in an owned agent config (security: off means off, don't
+    regress). The ON direction is now handled by rebuild_agent_config's boot
+    reconcile (single writer), covered in test_agent.py — not by this
+    migration."""
+
+    def test_boot_off_leaves_no_proxy_in_agent_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Mode OFF at boot: the proxy + its ref must be absent from the owned
+        # agent file (security: off means off, don't regress).
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: False)
+        kiro_dir = tmp_path / ".kiro" / "agents"
+        kiro_dir.mkdir(parents=True)
+        owned = kiro_dir / "kirocrew.json"
+        owned.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {_CANONICAL: dict(_PROXY)},
+                    "tools": [f"@{_CANONICAL}", "fs_read"],
+                    "allowedTools": [f"@{_CANONICAL}"],
+                }
+            )
+        )
+
+        migrate_owned_playwright_registration()
+
+        data = json.loads(owned.read_text(encoding="utf-8"))
+        assert _CANONICAL not in data["mcpServers"]
+        assert f"@{_CANONICAL}" not in data["tools"]
+        assert f"@{_CANONICAL}" not in data.get("allowedTools", [])

--- a/test/test_handlers_messaging_coverage.py
+++ b/test/test_handlers_messaging_coverage.py
@@ -1363,6 +1363,37 @@ class TestBrowserConfig:
         payload = _payload(resp)
         assert payload["sessions_reset"] == 0
 
+    def test_save_triggers_agent_config_rebuild(self, monkeypatch, tmp_path: Path) -> None:
+        # The toggle only rewrites kiro's mcp.json; rebuild_agent_config is the
+        # single lock-protected writer that reconciles @playwright-mcp into the
+        # owned agent config, so the save must trigger it (before the reset).
+        monkeypatch.setattr(loader, "data_home", lambda: tmp_path)
+        self._stub_enable_side_effects(monkeypatch)
+        monkeypatch.setattr(mod, "register_playwright_proxy", lambda: (None, "registered"))
+        import kiro_crew.agent as agent_mod
+
+        calls: list[int] = []
+        monkeypatch.setattr(agent_mod, "rebuild_agent_config", lambda *a, **k: calls.append(1))
+        resp = _run(mod.api_browser_config_save, _Req(_state(), {"enabled": True, "extension_mode": False}))
+        assert _payload(resp)["ok"] is True
+        assert calls == [1]
+
+    def test_save_survives_rebuild_failure(self, monkeypatch, tmp_path: Path) -> None:
+        # Best-effort: the preferences already landed, so a rebuild failure is
+        # logged, not raised — the save still returns 200 (never a 500).
+        monkeypatch.setattr(loader, "data_home", lambda: tmp_path)
+        self._stub_enable_side_effects(monkeypatch)
+        monkeypatch.setattr(mod, "register_playwright_proxy", lambda: (None, "registered"))
+        import kiro_crew.agent as agent_mod
+
+        def _boom(*a: Any, **k: Any) -> None:
+            raise RuntimeError("rebuild failed")
+
+        monkeypatch.setattr(agent_mod, "rebuild_agent_config", _boom)
+        resp = _run(mod.api_browser_config_save, _Req(_state(), {"enabled": True, "extension_mode": False}))
+        assert resp.status == 200
+        assert _payload(resp)["ok"] is True
+
 
 # ── small helpers ──
 

--- a/test/windows-expected-failures.txt
+++ b/test/windows-expected-failures.txt
@@ -19,6 +19,9 @@ test/test_acp_provider.py::TestStartKiroRuntimeResume::test_resume_loads_full_tr
 test/test_acp_runtime.py::test_periodic_sweep_skips_protected_runtime_pid
 test/test_agent.py::TestAtomicJsonWrite::test_new_file_gets_0o644
 test/test_agent.py::TestAtomicJsonWrite::test_preserves_existing_permissions
+test/test_agent.py::TestAtomicJsonWrite::test_env_bearing_spec_forced_to_0o600
+test/test_agent.py::TestAtomicJsonWrite::test_env_bearing_tightens_loose_existing_perms
+test/test_agent.py::TestBrowserModeReconcileOnRebuild::test_rebuilt_config_with_token_bearing_proxy_is_0600
 test/test_agent.py::TestKiroHooksAutoimport::test_kiro_hooks_autoimport_honors_custom_dir
 test/test_agent.py::TestKiroHooksAutoimport::test_kiro_hooks_autoimport_non_executable_emits_sel_audit
 test/test_agent.py::TestKiroHooksAutoimport::test_kiro_hooks_autoimport_skips_non_executable


### PR DESCRIPTION
## Problem

With **Browser Mode enabled**, the `browser_*` tools (e.g. `browser_navigate`) are frequently absent from a session. The only workaround is toggling Browser Mode off→on in Settings on every startup, while the UI meanwhile tells the user to "enable Browser Mode" — which is already on.

## Why it matters

Browser Mode being on is meant to be the single authorization for the built-in browser. A fresh gateway boot silently coming up without the tools makes the built-in browser unusable without a manual dance and erodes trust in the toggle — "on" should mean the tools are present, every session, every boot.

## Fix (symptoms → root cause → change)

- **Symptom:** `browser_navigate` missing from fresh sessions; a manual off→on toggle restores it until the next restart.
- **Root cause:** `browser_*` are MCP tools from the `playwright-mcp` proxy. The primary agent (`kirocrew`) has `includeMcpJson: false` + a **closed** `tools` allowlist, so a globally-registered `playwright-mcp` never reaches its tool surface unless `@playwright-mcp` is explicitly in the agent's tools. The single lock-protected writer of the agent config, `rebuild_agent_config`, **does** run at gateway boot (via `KiroCrewGateway._init_services` → `rebuild_agent_config()`, `src/kiro_crew/slack/gateway.py:1725`, which runs even when Slack is disabled) — but it never reconciled `@playwright-mcp` against `browser_mode_enabled()`, and its shared-server sync did not mount the proxy. **OFF** was already enforced at the agent-config level (`remove_playwright_servers` via `deregister_playwright_proxy` / the boot migration); **ON had no symmetric counterpart** inside the writer, so a config last materialized while Mode was off never regained the ref. The Settings toggle, separately, did **not** trigger a rebuild at all — so it too couldn't mount the tool. kiro-cli/ACP caches `tools/list` for the session lifetime (no `tools/list_changed` push), so the missing tools persist for the whole session.
- **Change:** make `browser_mode_enabled()` the **single source of truth**, reconciled by the single existing writer (`rebuild_agent_config`), with no second writer:
  - `browser/setup.py`: `reconcile_playwright_in_config(config)` — Mode ON → `add_playwright_servers` (mount `@playwright-mcp` **tools-only**, only when the proxy is actually registered in kiro's `mcp.json`; leave an existing resolved spec untouched; never clobber a user's own direct server); Mode OFF → `remove_playwright_servers` (scrub), so "off means off" is preserved. Helper `_registered_playwright_spec` reads the canonical proxy spec.
  - `agent.py`: call `reconcile_playwright_in_config(config)` inside `rebuild_agent_config` (after `converge_playwright_servers`). Because boot already runs `rebuild_agent_config`, this reconciles the tool surface at **every boot** — no separate agent-file sweep is introduced (a second writer would race the rebuild writer and copy a token-bearing spec into a world-readable file). Existing SEL logging (`mcp_tools_added` / `mcp_tools_removed`) is preserved.
  - `dashboard/handlers/messaging.py`: the Browser Mode toggle (`_browser_config_finalize`) now triggers `rebuild_agent_config` **under the shared `_get_config_lock()`** (before the session reset) so enabling/disabling takes effect immediately via the same single, serialized writer — a concurrent locked config mutation cannot straddle it and be lost. Best-effort: a rebuild failure is logged, not raised.
  - **Security (permissions):** `_atomic_json_write` now forces the agent config file to `0o600` whenever the emitted config carries any `mcpServers[*].env` block. In *extension* mode the playwright proxy spec carries a connection token; writing it into the primary agent file (which was `0o644`) would expose it to other OS accounts. This closes that at the single writer.

## Tests

- `test/test_browser_setup.py`: reconcile mounts `@playwright-mcp` when Mode ON / scrubs when OFF; no-op when Mode off or the proxy is unregistered; existing proxy spec not clobbered; a user's direct server under the canonical key untouched.
- `test/test_agent.py`: rebuild mounts the ref when Mode ON and scrubs a carried-over proxy when OFF; `_atomic_json_write` writes `0o600` for env/token-bearing configs (POSIX-only assertions, listed in `windows-expected-failures.txt` like the sibling perm tests, since `platform_compat.fchmod_safe` is a no-op on Windows).
- `test/test_handlers_messaging_coverage.py`: the toggle triggers `rebuild_agent_config`, and a rebuild failure is swallowed (best-effort).

## Manual verification

Not yet exercised end-to-end on a live install (the dev-backend isolated home deliberately refuses to write the shared agent home, and the worktree frontend isn't built). Recommended before merge: run the patched gateway against the real data home, confirm `~/.kiro/agents/kirocrew.json` gains `@playwright-mcp` on boot while Browser Mode is on, and that a fresh session opens a page without toggling.

no issue closed: no tracked issue filed for this bug.
