### PR TITLE
fix(chat): cap follow-up chip width and clamp long option labels

### DIFF
--- a/website/src/components/FollowUpBar.tsx
+++ b/website/src/components/FollowUpBar.tsx
@@ -15,16 +15,53 @@ interface FollowUpBarProps {
   layout?: FollowUpLayout
 }
 
+/**
+ * Option labels are full user-voice instructions and can run to several
+ * hundred characters. Left unbounded they size to max-content: in the scroll
+ * layout (chips are `shrink-0`) one long option consumed the whole strip and
+ * the tail of its text sat outside the visible box, so it read as a single
+ * clipped pill with no other option in view. `followup-chip` (index.css) caps
+ * the width at roughly half the default composer, and the label wraps onto two
+ * clamped lines — the truncation is then explicit (ellipsis) instead of an
+ * invisible overflow.
+ */
+const CHIP_MAX_WIDTH = 'followup-chip'
+
 function chipClassName(isPicked: boolean, extra: string = '') {
-  return `${extra} px-3 py-1.5 rounded-lg text-[13px] cursor-pointer transition-all border ${
+  return `${extra} ${CHIP_MAX_WIDTH} px-3 py-1.5 rounded-lg text-[13px] text-left leading-snug cursor-pointer transition-all border ${
     isPicked
       ? 'border-solid border-accent/50 text-accent bg-accent-subtle'
       : 'border-border text-muted hover:text-text hover:border-accent/40 bg-bg-elevated'
   }`
 }
+
+/**
+ * The two-line clamp lives on an unpadded inner element on purpose:
+ * `-webkit-line-clamp` clips at the padding edge, so clamping the padded
+ * button itself leaves a sliver of the third line visible inside its bottom
+ * padding.
+ */
+function ChipLabel({ option }: { option: string }) {
+  return <span className="line-clamp-2 break-words">{option}</span>
+}
+
+/**
+ * Length above which a label is likely clamped. Past it the hover tooltip
+ * carries the full option text instead of the click hint — an unreadable label
+ * is the more pressing gap, and the gesture hint is still shown on every short
+ * chip and on the send segment. The DOM keeps the whole string either way, so
+ * the accessible name is never truncated.
+ */
+const LONG_LABEL_CHARS = 60
+
+function chipTooltip(option: string, hint: string) {
+  return option.length > LONG_LABEL_CHARS ? option : hint
+}
 /** Right-hand "send now" segment class — same palette as the chip body, divided by a border. */
 function sendSegmentClassName(isPicked: boolean) {
-  return `px-1.5 py-1.5 rounded-r-lg cursor-pointer transition-all border border-l-0 ${
+  // inline-flex + items-center keeps the arrow vertically centred when the
+  // chip body wraps onto a second line.
+  return `inline-flex items-center px-1.5 py-1.5 rounded-r-lg cursor-pointer transition-all border border-l-0 ${
     isPicked
       ? 'border-solid border-accent/50 text-accent bg-accent-subtle hover:bg-accent/20'
       : 'border-border text-muted hover:text-accent hover:border-accent/40 bg-bg-elevated'
@@ -68,7 +105,7 @@ function Chip({ option, isPicked, picked, quickSend, onSelect, onSend, className
   useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current) }, [])
 
   const useDebouncedClick = !!onSend && !(quickSend && !isPicked && picked.size === 0)
-  const title = chipTitle(isPicked, quickSend, picked, !!onSend)
+  const title = chipTooltip(option, chipTitle(isPicked, quickSend, picked, !!onSend))
   // The visible "send now" segment is the discoverable form of the existing
   // double-click-to-send gesture. Redundant (and hidden) in the quickSend
   // instant-send state, where a single click on an unpicked chip already
@@ -85,7 +122,7 @@ function Chip({ option, isPicked, picked, quickSend, onSelect, onSend, className
         className={className}
         title={title}
       >
-        {option}
+        <ChipLabel option={option} />
       </button>
     )
   }
@@ -124,14 +161,20 @@ function Chip({ option, isPicked, picked, quickSend, onSelect, onSend, className
       className={showSendSegment ? className.replace('rounded-lg', 'rounded-l-lg') : className}
       title={title}
     >
-      {option}
+      <ChipLabel option={option} />
     </button>
   )
 
   if (!showSendSegment) return mainChip
 
   return (
-    <span className="inline-flex items-stretch shrink-0">
+    // The cap is repeated on the wrapper because the wrapper — not the button —
+    // is the flex item here. Without it the wrapper's flex base size is the
+    // label's untruncated max-content width (the button's percentage max-width
+    // cannot resolve against an indefinite wrapper), leaving a wide empty gap
+    // before the next chip. On the flex item the percentage resolves against
+    // the strip's definite width.
+    <span className={`inline-flex items-stretch shrink-0 ${CHIP_MAX_WIDTH}`}>
       {mainChip}
       <button
         type="button"

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1608,6 +1608,14 @@ button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
 /* ── Table row striping ── */
 .table-striped tbody tr:nth-child(even){background:var(--card-hl)}
 
+/* ── Follow-up option chip width cap ──
+   An option label is a full user-voice instruction and can run to hundreds of
+   characters. Capped at roughly half the default composer width so at least
+   two options stay side by side and no single chip owns the whole strip; the
+   label itself clamps to two lines. Lives here because the same value is
+   applied to both the chip button and its split-button wrapper. */
+.followup-chip{max-width:min(100%,26rem)}
+
 /* ── Skeleton shimmer placeholder ── */
 .skeleton{
   background:linear-gradient(90deg,var(--bg-elevated) 25%,var(--bg-hover) 50%,var(--bg-elevated) 75%);

--- a/website/src/test/FollowUpBar.test.tsx
+++ b/website/src/test/FollowUpBar.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import FollowUpBar from '../components/FollowUpBar'
 
 // jsdom polyfill: scroll-layout uses ResizeObserver to track when the chip
@@ -246,6 +248,74 @@ describe('FollowUpBar', () => {
       expect(onSelect).toHaveBeenCalledTimes(0)
       act(() => { vi.advanceTimersByTime(250) })
       expect(onSelect).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ─── Long labels: bounded width, clamped text, full text on hover ────────
+  // Regression: an option is a full user-voice instruction and can be
+  // hundreds of characters. Unbounded, a `shrink-0` chip in the scroll layout
+  // sized to max-content, consumed the whole strip and pushed the tail of its
+  // own text out of the visible box.
+  describe('long option labels', () => {
+    const LONG = 'Implement blockers 3 & 4 plus the safe follow-ups and push, but leave blocker 1 (team access) and blocker 2 (CI) for me to handle myself'
+
+    it('caps chip width and clamps the label in the scroll layout', () => {
+      render(<FollowUpBar options={[LONG]} picked={new Set()} onSelect={() => {}} layout="scroll" />)
+      const chip = screen.getByRole('button', { name: LONG })
+      expect(chip.className).toContain('followup-chip')
+      // The clamp must sit on an unpadded inner element, not on the padded
+      // button — otherwise a sliver of the third line shows in the padding.
+      const label = chip.querySelector('span')
+      expect(label?.className).toContain('line-clamp-2')
+      expect(label?.className).toContain('break-words')
+      expect(chip.className).not.toContain('line-clamp-2')
+    })
+
+    it('caps the split-button wrapper too, not just the button', () => {
+      // The wrapper is the flex item when a send segment is present; without the
+      // cap it sizes to the label's untruncated max-content width and leaves a
+      // wide gap before the next chip.
+      render(<FollowUpBar options={[LONG]} picked={new Set()} onSelect={() => {}} onSend={() => {}} layout="scroll" />)
+      const wrapper = screen.getByRole('button', { name: LONG }).parentElement
+      expect(wrapper?.className).toContain('followup-chip')
+    })
+
+    it('backs the cap class with a real max-width rule', () => {
+      // jsdom does not load index.css, so the class assertions above would pass
+      // with the rule deleted. Read the stylesheet directly.
+      const css = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf-8')
+      expect(css).toMatch(/\.followup-chip\s*\{[^}]*max-width:\s*min\(100%,\s*26rem\)/)
+    })
+
+    it('caps chip width and clamps the label in the multiline layout', () => {
+      render(<FollowUpBar options={[LONG]} picked={new Set()} onSelect={() => {}} />)
+      const chip = screen.getByRole('button', { name: LONG })
+      expect(chip.className).toContain('followup-chip')
+      expect(chip.querySelector('span')?.className).toContain('line-clamp-2')
+    })
+
+    it('keeps the full label in the DOM so the accessible name is not truncated', () => {
+      render(<FollowUpBar options={[LONG]} picked={new Set()} onSelect={() => {}} layout="scroll" />)
+      expect(screen.getByRole('button', { name: LONG }).textContent).toBe(LONG)
+    })
+
+    it('shows the full text as the tooltip when the label is long', () => {
+      render(<FollowUpBar options={[LONG]} picked={new Set()} onSelect={() => {}} onSend={() => {}} />)
+      expect(screen.getByRole('button', { name: LONG }).getAttribute('title')).toBe(LONG)
+    })
+
+    it('leaves a short label tooltip as the gesture hint alone', () => {
+      render(<FollowUpBar options={['Merge it now']} picked={new Set()} onSelect={() => {}} onSend={() => {}} />)
+      const title = screen.getByRole('button', { name: 'Merge it now' }).getAttribute('title') ?? ''
+      expect(title.startsWith('Merge it now')).toBe(false)
+      expect(title).toMatch(/double-click/i)
+    })
+
+    it('still passes the untruncated option text to onSelect', () => {
+      const onSelect = vi.fn()
+      render(<FollowUpBar options={[LONG]} picked={new Set()} onSelect={onSelect} layout="scroll" />)
+      fireEvent.click(screen.getByRole('button', { name: LONG }))
+      expect(onSelect).toHaveBeenCalledWith(LONG, expect.any(Object))
     })
   })
 


### PR DESCRIPTION
## Problem

A follow-up option label is a full user-voice instruction and can run to hundreds
of characters. The chips had no width cap, so in the default `scroll` layout —
where chips are `shrink-0` — one long option sized to its max-content width,
consumed the whole strip, and pushed the tail of its own text outside the visible
box. It read as a single clipped pill with no other option in view, no ellipsis,
and no way to tell where the text ended without horizontally scrolling a
400-character label.

Reported from the dashboard: "upon large content aren't visible either and take
up the entire horizontal space".

## Change

- `.followup-chip` (index.css) caps the chip at `min(100%, 26rem)` — roughly half
  the default composer width — so at least two options stay side by side. The cap
  is applied to the split-button wrapper as well, because that is the flex item
  when a send segment is present; without it the wrapper still took the label's
  untruncated max-content width and left a ~500px gap before the next chip
  (measured in a Playwright harness: chip 2 started at x=1007 in a 900px strip).
- The label wraps onto two clamped lines, so truncation is explicit rather than
  an invisible overflow. The clamp sits on an unpadded inner span:
  `-webkit-line-clamp` clips at the padding edge, so clamping the padded button
  leaves a sliver of the third line showing inside its bottom padding (seen and
  fixed during verification).
- Past 60 characters the hover tooltip carries the full option text instead of
  the click hint — an unreadable label is the more pressing gap, and the hint
  still shows on short chips and on the send segment. The full string stays in the
  DOM, so the accessible name is never truncated.
- The send segment centres its arrow so it aligns with a two-line chip.

Both layouts (`scroll` and `multiline`) and both wide (900px composer) and narrow
(480px viewport) cases were checked in the browser; no chip overflows its row at
either width.

## Tests

Six new cases in `FollowUpBar.test.tsx` cover the cap on the button, the cap on
the split-button wrapper, the clamp living on the inner span (and NOT on the
button), the backing CSS rule, the tooltip switch, and that `onSelect` still
receives the untruncated option text.

Revert-verified: four fail with the component change reverted, and the CSS
assertion fails with the `.followup-chip` rule removed.

## Verification

- `vitest run` — 17225 pass. 3 failures in `App.test.tsx` (credits pill) are
  pre-existing on `origin/main`, A/B proven with the three touched files reverted:
  identical 3 failed / 77 passed on both sides.
- `tsc -b` clean, `npm run lint` 0 errors.
- `I18N_BASE_REF=origin/main npm run i18n:check` — 16 checks PASS.
- `check-i18n-render.mjs --build` — PASS `[vs-base]`, no surface got worse.
