### PR TITLE
refactor: move client port resolution to a light leaf module (#2933)

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -522,7 +522,8 @@ Each step checks if the tool is already installed and skips if present.
 ## Client Port Resolution
 
 `kirocrew token` / `status` / `logout` / `stop` / `restart` must find the port
-the gateway is actually bound to. `cli_server.resolve_client_port()` resolves it
+the gateway is actually bound to. `port_resolution.resolve_client_port()`
+(re-exported by `cli_server`) resolves it
 in this order, first hit wins. The MCP stdio servers (`mcp_core` /
 `mcp_computer`) resolve their gateway API base through the same helper —
 lazily, on the first gateway call, and cached for the process lifetime — so a

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -1159,7 +1159,7 @@ port and no config field ever names it). It is a **distinct variable from
 `KIROCREW_PORT`** on purpose: `KIROCREW_PORT` means operator intent and is
 persisted by `service_environment()` into unit files, while
 `KIROCREW_BOUND_PORT` is ephemeral observed truth that must never be frozen
-into persistent config. Clients read it via `cli_server.resolve_client_port`,
+into persistent config. Clients read it via `port_resolution.resolve_client_port`,
 one precedence step below the operator override.
 
 ## Model Resolution Chain

--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -674,7 +674,7 @@ marker is inert there, but the *filename* still matters to consumer 2.
 
 The marker's filename advertises which port a gateway serves, so `marker_ports()`
 lets a local client command (`token` / `status` / `logout` / `stop`, via
-`cli_server.resolve_client_port`) find a gateway on a non-default port with no
+`port_resolution.resolve_client_port`) find a gateway on a non-default port with no
 configuration. That path reads only the filename and ignores marker *contents*
 entirely. Resolution order is `--port`, then `KIROCREW_PORT`, then a port named
 by `dashboard.url`, then the sole gateway-owned marker, then the default 5476.
@@ -683,7 +683,7 @@ by `dashboard.url`, then the sole gateway-owned marker, then the default 5476.
 graceful shutdown, so a crash or SIGKILL leaves the file behind and an unrelated
 process may since have bound that port. Because client commands send the local
 secret (`X-Local-Secret`) to whatever answers, the consumer must verify the
-listener before trusting a discovered port. `cli_server._gateway_owns_port()`
+listener before trusting a discovered port. `port_resolution._gateway_owns_port()`
 does that in four fail-closed steps: the recorded pid must exist, must be among
 `platform_compat.find_listening_pids(port)`, must be owned by the caller's uid
 (which closes pid recycling into another user's process), and must look like a

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -7,14 +7,12 @@ import http.client
 import json
 import logging
 import os
-import shlex
 import shutil
 import signal
 import subprocess
 import sys
 import time
 import urllib.error
-import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -22,7 +20,6 @@ from kiro_crew import __version__, platform_compat
 from kiro_crew.beacon import is_default_home
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
-    _DEFAULT_PORT,
     _session_work_dir,
     build_provider_factory,
     config_dir,
@@ -34,7 +31,6 @@ from kiro_crew.dashboard import tailnet_serve
 from kiro_crew.dashboard.handlers.core import DASHBOARD_HTML_NOT_FOUND_MARKER
 from kiro_crew.dashboard.origin import (
     dashboard_origin,
-    parse_dashboard_url,
     resolve_dashboard_host,
 )
 from kiro_crew.dashboard.tailnet import is_governance_pinned_off, tailnet_origin
@@ -52,6 +48,26 @@ from kiro_crew.instances import run_marker
 from kiro_crew.learn import LessonStore
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.memory import MemoryStore
+
+# Client-side port resolution lives in kiro_crew.port_resolution, a light leaf
+# module the MCP stdio server can import without paying for this module's
+# import graph. Re-exported here (not merely used) because this namespace is
+# the historical public surface: external callers and a large body of tests
+# import and patch these names as ``kiro_crew.cli_server.<name>``, and the
+# chain's internal calls deliberately resolve through this namespace whenever
+# it is loaded (see port_resolution._patchable) so those patches keep
+# intercepting.
+from kiro_crew.port_resolution import (  # noqa: F401
+    _KIROCREW_SERVER_SUBCOMMANDS,
+    _args_look_like_kirocrew,
+    _basename_stem,
+    _config_url_port,
+    _gateway_owns_port,
+    _is_kirocrew_process,
+    _marker_port,
+    resolve_client_port,
+    resolve_client_port_ex,
+)
 from kiro_crew.preflight import run_preflight_checks
 from kiro_crew.sel import sel
 from kiro_crew.service import controller as service_controller
@@ -79,224 +95,6 @@ from kiro_crew.vector_memory import VectorMemoryStore
 # SPA's per-origin localStorage is keyed on that host, so emitting a different
 # origin would make every dashboard setting appear reset.
 _CLI_LOOPBACK = "127.0.0.1"
-
-
-def _config_url_port() -> int | None:
-    """Port explicitly named by ``dashboard.url``, or ``None``.
-
-    Distinct from :func:`parse_dashboard_url`, which substitutes
-    ``_DEFAULT_PORT`` for a portless URL (``http://my.host``). That substitution
-    is right for the *server* (it must bind something) but wrong for a client:
-    it would report "config says 5476" and short-circuit the run-marker
-    fallback below, even though the user never named a port. So detect the
-    explicit case and let a portless URL fall through.
-    """
-    try:
-        cfg = KiroCrewConfig.load()
-        url = cfg.dashboard.url or ""
-    except Exception:
-        # Config load failures must not break client commands.
-        return None
-    if not isinstance(url, str):
-        # ``dashboard.url`` is user-editable JSON and core installs may lack
-        # jsonschema, so the value can be any type (``"url": 123``). urlparse
-        # raises TypeError on a non-str, which is NOT a ValueError — without
-        # this guard a bad config type would crash every client command.
-        logging.getLogger(__name__).warning(
-            "Ignoring non-string dashboard.url of type %s", type(url).__name__
-        )
-        return None
-    if not url:
-        return None
-    try:
-        _, port = parse_dashboard_url(url)
-        # parse_dashboard_url already normalises the scheme, tolerates malformed
-        # URLs and applies the KIROCREW_PORT override; re-split only to learn
-        # whether the port was written down or defaulted in.
-        explicit = urllib.parse.urlsplit(url if "://" in url else f"http://{url}").port
-    except (TypeError, ValueError):
-        return None
-    return port if explicit is not None else None
-
-
-def _gateway_owns_port(port: int) -> bool:
-    """True only when *this user's* gateway process is listening on *port*.
-
-    Reachability is not enough to trust a discovered port. Client commands hand
-    the local secret to whatever answers (``_token`` and ``_logout`` send
-    ``X-Local-Secret``), and ``clear_marker`` runs only on graceful shutdown —
-    so a crashed gateway leaves a marker naming a port some unrelated process
-    may since have bound. A bare TCP connect would walk the secret straight into
-    that process, which could then mint owner tokens against the real gateway.
-
-    A command-line check is not enough either: argv is attacker-chosen, so a
-    listener launched as ``/tmp/kirocrew gateway`` would pass it. The proof used
-    here is an identity the attacker cannot forge, in three parts:
-
-    1. **Recorded pid** — ``run_marker.read_pid(port)`` reads the sidecar the
-       gateway wrote at ``0600`` inside the ``0700`` ``run/`` dir. Another local
-       user cannot write it, so they cannot nominate a process of theirs.
-    2. **Holds the port** — that pid must be among
-       ``platform_compat.find_listening_pids(port)``. This is what makes a stale
-       recorded pid harmless: it has to actually hold the port we are about to
-       send the secret to.
-    3. **Owned by us, and ours** — the pid's uid must equal the caller's
-       (``process_owner_uid``), and its argv must look like a gateway. The uid
-       check is what closes pid *recycling* into a foreign user's process; argv
-       remains only as defense in depth, never as the sole proof.
-
-    A same-user attacker is out of scope by construction: they can already read
-    ``.local_secret`` (mode ``0600``, their own uid), so nothing here can be an
-    escalation for them. The boundary this closes is a *different* local user.
-
-    **Fails closed** at every step: no sidecar, no recorded pid, a pid that does
-    not hold the port, an unresolvable uid, a missing lookup tool
-    (``find_listening_pids`` folds that into an empty list) or a throwing one —
-    all deny, and discovery is skipped in favour of the documented default.
-    ``--port`` and ``KIROCREW_PORT`` remain available on such hosts.
-
-    **Non-POSIX denies outright.** ``process_owner_uid`` cannot report an owner
-    on Windows, and a home that is writable by another user (a shared or
-    misconfigured ``KIROCREW_HOME``) would let them replace both the marker and
-    the sidecar with a forged listener — the file-permission argument that
-    carries step 1 is exactly what stops holding there. Rather than trust
-    steps 1-2 alone, discovery is skipped: Windows users keep ``--port`` /
-    ``KIROCREW_PORT``, which is precisely where they were before this fallback
-    existed, so nothing regresses. This is the one place the feature is
-    deliberately unavailable rather than approximated.
-    """
-    if not platform_compat.IS_POSIX:
-        return False
-    recorded = run_marker.read_pid(port)
-    if recorded is None:
-        return False
-    try:
-        pids = platform_compat.find_listening_pids(port)
-    except Exception:
-        return False
-    if recorded not in pids:
-        return False
-    owner = platform_compat.process_owner_uid(recorded)
-    if owner is None or owner != os.getuid():
-        return False
-    return _is_kirocrew_process(recorded)
-
-
-def _marker_port() -> int | None:
-    """Port of the sole gateway-owned run-marker, or ``None``.
-
-    Zero-configuration discovery for the common single-gateway box: the gateway
-    already advertises itself by writing ``<data-home>/run/gateway-<port>.bin``
-    (see :mod:`kiro_crew.instances.run_marker`), so a client with no ``--port``,
-    no ``KIROCREW_PORT`` and no port in ``dashboard.url`` can read that instead
-    of assuming 5476 and connecting to a dead port.
-
-    Two guards keep this from being a guess:
-
-    * **Ownership.** Only ports where a verified KiroCrew gateway process is
-      listening count (:func:`_gateway_owns_port`); a stale marker, or one whose
-      port has been taken over by an unrelated process, is discarded.
-    * **Ambiguity.** With several gateways up there is no basis to pick one, so
-      this refuses (returns ``None``, landing on the documented default) and
-      tells the user on stderr which ports it saw and how to name one.
-    """
-    try:
-        candidates = run_marker.marker_ports()
-    except Exception:
-        return None
-    if not candidates:
-        return None
-    owned = [p for p in candidates if _gateway_owns_port(p)]
-    if len(owned) == 1:
-        return owned[0]
-    if len(owned) > 1:
-        print(
-            f"⚠️  Multiple gateways are running (ports {', '.join(str(p) for p in owned)}); "
-            f"not guessing which one you meant — using {_DEFAULT_PORT}. "
-            "Pass --port or set KIROCREW_PORT to target a specific gateway.",
-            file=sys.stderr,
-        )
-    return None
-
-
-def resolve_client_port(cli_port: int | None) -> int:
-    """Return the dashboard port a *client* CLI command (token/status/logout/stop)
-    should talk to.
-
-    Resolution order:
-
-    1. Explicit ``--port`` CLI flag if the user passed one (``cli_port`` is not ``None``).
-    2. ``KIROCREW_PORT`` env var if set to a valid integer. Deliberately ABOVE
-       the bound-port export: an explicitly-set ``KIROCREW_PORT`` is how a
-       caller retargets a child at a DIFFERENT gateway — ``pod exec`` builds a
-       client env with ``KIROCREW_PORT=<pod-port>`` precisely so the command
-       reaches the pod, while the inherited ``KIROCREW_BOUND_PORT`` still
-       names the spawning LIVE gateway. Ranking the bound value higher would
-       walk pod ``token``/``status``/``logout`` (and the local secret they
-       carry) into the live gateway — a cross-plane isolation break.
-    3. ``KIROCREW_BOUND_PORT`` env var if set to a valid integer — the port the
-       parent gateway ACTUALLY bound, exported once its TCP site is listening
-       (``dashboard.server._export_bound_port``). Below the operator override
-       (see above); above config because a bound fact from the live parent
-       beats a guess re-derived from a portless ``dashboard.url``.
-    4. Port explicitly named by ``dashboard.url`` in the config file
-       (``<data-home>/config.json``), when it parses.
-    5. The sole gateway-owned run-marker (``<data-home>/run/gateway-<port>.bin``)
-       — see :func:`_marker_port`. Skipped when no marker's port is held by a
-       verified gateway process, and refused (with a stderr hint) when several
-       are.
-    6. ``_DEFAULT_PORT`` (5476) as the final fallback.
-
-    Steps 1, 2 and 4 match the server-side ``parse_dashboard_url()`` logic so
-    that ``kirocrew token`` / ``status`` / ``logout`` / ``stop`` all hit the
-    same port the gateway is actually bound to when the user has configured a
-    non-default ``dashboard.url`` (for example a dev instance on 6777 or an
-    alternative prod port like 7778). Steps 3 and 5 cover the case where
-    nothing was configured at all but a gateway is up on a non-default port
-    (e.g. started with ``kirocrew gateway --port 6776``): the parent's own
-    export, or the running gateway's marker, is better evidence than the 5476
-    default.
-    """
-    port, _ = resolve_client_port_ex(cli_port)
-    return port
-
-
-def resolve_client_port_ex(cli_port: int | None) -> tuple[int, bool]:
-    """Like :func:`resolve_client_port`, also reporting HOW the port resolved.
-
-    The second element is ``True`` when the port came from positive evidence
-    (an explicit flag, an env var, a configured port, or a verified
-    run-marker) and ``False`` when resolution fell through to
-    ``_DEFAULT_PORT``. Callers that cache a resolution for the process
-    lifetime need the distinction: a fall-through only proves nothing was
-    discoverable *at that instant* — during gateway boot the run-marker may
-    not be written yet — so pinning it would freeze the weakest outcome
-    forever, while every positive source is stable for the process lifetime.
-    """
-    if cli_port is not None:
-        return cli_port, True
-    env_port = os.environ.get("KIROCREW_PORT")
-    if env_port:
-        try:
-            return int(env_port), True
-        except ValueError:
-            # Fall through to bound/config/marker/default — main() validates
-            # this early, but guard here too in case the helper is reached via
-            # another path.
-            pass
-    bound_port = os.environ.get("KIROCREW_BOUND_PORT")
-    if bound_port:
-        try:
-            return int(bound_port), True
-        except ValueError:
-            pass
-    cfg_port = _config_url_port()
-    if cfg_port:
-        return cfg_port, True
-    discovered = _marker_port()
-    if discovered:
-        return discovered, True
-    return _DEFAULT_PORT, False
 
 
 def _probe_dashboard_health(port: int) -> None:
@@ -661,146 +459,6 @@ def _stop(cli_port: int | None = None) -> None:
         )
         print(f"No Kiro Crew gateway currently running on port {port} (process already exited).")
         sys.exit(1)
-
-
-# Subcommands that launch a long-running KiroCrew *server* process which
-# ``kirocrew stop`` may need to terminate. These mirror the entry-point
-# subcommands dispatched in ``cli.py`` (``gateway`` / ``dashboard``; ``start``
-# is the historical alias). The task runner (``run``) is intentionally excluded:
-# it is not bound to the dashboard port, so we must never SIGTERM it from
-# ``kirocrew stop``.
-_KIROCREW_SERVER_SUBCOMMANDS = frozenset({"gateway", "dashboard", "start"})
-
-
-def _basename_stem(tok: str) -> str:
-    """Basename of *tok* without a Windows ``.exe`` suffix.
-
-    Lets the venv launchers ``python.exe`` / ``kirocrew.exe`` match the same
-    checks as their POSIX ``python`` / ``kirocrew`` counterparts. ``shlex.split``
-    with ``posix=False`` leaves quotes on some tokens, so strip them too.
-
-    Split on BOTH separators explicitly rather than via ``os.path.basename``:
-    that is host-dependent (``posixpath`` on Linux does NOT split backslashes),
-    so a Windows cmdline classified on the Linux CI fleet would keep its full
-    ``D:\\...\\kirocrew.exe`` path and never match. This is host-independent — a
-    basename is whatever follows the last ``/`` or ``\\``.
-
-    Module scope rather than nested in :func:`_args_look_like_kirocrew` so
-    :func:`_own_console_script` shares the one definition.
-    """
-    cleaned = tok.strip('"')
-    base = cleaned.replace("\\", "/").rsplit("/", 1)[-1]
-    if base.lower().endswith(".exe"):
-        base = base[:-4]
-    return base
-
-
-def _args_look_like_kirocrew(args: str) -> bool:
-    """Return ``True`` if a process command-line *args* string is a KiroCrew server.
-
-    This gates ``os.kill(pid, SIGTERM)`` in :func:`_stop`, so it must be
-    **precise** (never match an unrelated process that merely mentions
-    "kirocrew") while still recognising *every* way the gateway can be spawned.
-
-    Instead of enumerating brittle substring variants (``kiro_crew.gateway`` vs
-    ``kiro_crew gateway`` vs ``kirocrew gateway`` …), we parse the command line
-    *structurally* and key on the real module/binary name plus a known server
-    subcommand (:data:`_KIROCREW_SERVER_SUBCOMMANDS`). This is deterministic and
-    robust to interpreter path, Python version suffix, and whitespace. Two spawn
-    shapes are recognised:
-
-    * **Module invocation** — ``<python> -m kiro_crew <subcmd>`` (the form used by
-      a service install and the launchd/systemd service), plus the legacy dotted
-      form ``<python> -m kiro_crew.<subcmd>``. A Python interpreter must precede
-      ``-m`` so we don't misread some other tool's ``-m`` flag (e.g. ``grep -m``).
-    * **Console script** — ``/path/to/kirocrew <subcmd>`` (used when the
-      ``kirocrew`` wrapper resolves on ``PATH``).
-
-    Examples::
-
-        >>> _args_look_like_kirocrew("/x/python3.10 -m kiro_crew gateway")
-        True
-        >>> _args_look_like_kirocrew("python3 -m kiro_crew.dashboard")
-        True
-        >>> _args_look_like_kirocrew("/usr/local/bin/kirocrew start")
-        True
-        >>> _args_look_like_kirocrew("python -m kiro_crew run /tmp/spec.md")  # task runner
-        False
-        >>> _args_look_like_kirocrew("vim /tmp/kirocrew-notes.txt")
-        False
-    """
-    # ``ps -o args=`` (POSIX) / Win32_Process.CommandLine (Windows WMI) return a
-    # shell-style string; tokenize it the way the host shell would. On Windows
-    # use posix=False so backslash path separators survive (default posix=True
-    # eats them: ``C:\Py\python.exe`` -> ``C:Pypython.exe``, breaking the
-    # interpreter/basename checks below). Fall back to a naive split on a
-    # malformed string (e.g. an odd quote) so this best-effort check never raises.
-    try:
-        tokens = shlex.split(args, posix=not platform_compat.IS_WINDOWS)
-    except ValueError:
-        tokens = args.split()
-
-    for index, token in enumerate(tokens):
-        # --- Module form: "<python> -m kiro_crew <subcmd>" / "-m kiro_crew.<subcmd>"
-        if token == "-m" and index + 1 < len(tokens):
-            # Only treat "-m" as Python's module flag when a Python interpreter
-            # precedes it; otherwise an unrelated tool's "-m" option could be
-            # misread (e.g. "grep -m kiro_crew gateway file"). The match is
-            # case-insensitive: the macOS framework build's interpreter basename
-            # is "Python" (capital P), which a case-sensitive startswith would
-            # miss, leaving stop/restart unable to find the gateway.
-            interpreter_seen = any(
-                _basename_stem(t).lower().startswith("python") for t in tokens[:index]
-            )
-            if interpreter_seen:
-                # "kiro_crew.gateway" -> ("kiro_crew", "gateway"); a bare
-                # "kiro_crew" -> ("kiro_crew", "").
-                package, _, dotted_subcmd = tokens[index + 1].partition(".")
-                if package == "kiro_crew":
-                    # Dotted submodule form: ``-m kiro_crew.gateway``.
-                    if dotted_subcmd in _KIROCREW_SERVER_SUBCOMMANDS:
-                        return True
-                    # Subcommand-as-argument form: ``-m kiro_crew gateway``. The
-                    # subcommand is argparse's first positional after the module,
-                    # i.e. always at index+2. Check only that slot so a later
-                    # positional/flag value cannot match — e.g.
-                    # ``-m kiro_crew run gateway`` ("gateway" is a file argument
-                    # to the task runner) must NOT be treated as a server.
-                    if (
-                        index + 2 < len(tokens)
-                        and tokens[index + 2] in _KIROCREW_SERVER_SUBCOMMANDS
-                    ):
-                        return True
-
-        # --- Console-script form: ".../kirocrew <subcmd>" (or kirocrew.exe on Win)
-        if (
-            _basename_stem(token) == "kirocrew"
-            and index + 1 < len(tokens)
-            and tokens[index + 1] in _KIROCREW_SERVER_SUBCOMMANDS
-        ):
-            return True
-
-    return False
-
-
-def _is_kirocrew_process(pid: int) -> bool:
-    """Return ``True`` if *pid* looks like a KiroCrew gateway process.
-
-    Resolves the process command line cross-platform via
-    :func:`platform_compat.process_command_line` (Linux ``/proc``, macOS ``ps``,
-    Windows ``Win32_Process`` WMI — the venv ``kirocrew.exe`` re-execs
-    ``python.exe`` so the image name alone is ambiguous there) and defers
-    classification to :func:`_args_look_like_kirocrew`.
-
-    ``process_command_line`` returns ``""`` on any failure (dead PID, missing
-    ``ps``, WMI error), which classifies as "not a match" — _stop()'s separate
-    ``listening_pid_tool_available()`` check already surfaces the tool-absent
-    case, so this never needs to raise.
-    """
-    out = platform_compat.process_command_line(pid)
-    if not out:
-        return False
-    return _args_look_like_kirocrew(out)
 
 
 def _pid_exited(pid: int) -> bool:

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1241,7 +1241,7 @@ def _export_bound_port(runner: web.AppRunner, port: int) -> None:
     frozen into a service install run from a gateway-descended shell, and
     would leak between tests through the process environment.
     ``KIROCREW_BOUND_PORT`` carries ephemeral truth only: consumed by
-    ``cli_server.resolve_client_port`` one step below the operator override,
+    ``port_resolution.resolve_client_port`` one step below the operator override,
     never persisted.
 
     *port* is ``0`` for an OS-assigned ephemeral bind (``--port auto``); the

--- a/src/kiro_crew/instances/run_marker.py
+++ b/src/kiro_crew/instances/run_marker.py
@@ -32,7 +32,7 @@ executable file (``-x``), the same boundary as the pre-existing
 Second consumer — port discovery:
     The marker's *filename* also advertises which port a gateway is serving, so
     :func:`marker_ports` lets a local client command (``token`` / ``status`` /
-    ``logout`` / ``stop``, via ``cli_server.resolve_client_port``) find a gateway
+    ``logout`` / ``stop``, via ``port_resolution.resolve_client_port``) find a gateway
     on a non-default port with zero configuration. That path reads only the
     filename, never the recorded launcher path.
 
@@ -42,7 +42,7 @@ Second consumer — port discovery:
     send the local secret (``X-Local-Secret``) to whatever is listening, the
     consumer MUST verify the listener before trusting a discovered port, using
     the pid sidecar this module writes beside the marker (:func:`read_pid`) — see
-    ``cli_server._gateway_owns_port``. This module deliberately does not offer a
+    ``port_resolution._gateway_owns_port``. This module deliberately does not offer a
     bare "is something listening" helper, so no caller can mistake reachability
     for identity.
 """
@@ -104,7 +104,7 @@ def read_pid(port: int) -> int | None:
     tools cannot write it either): another local user cannot point it at a
     process of theirs. It is NOT proof of liveness — a crashed gateway leaves
     its pid behind — so the caller must also confirm that pid currently holds
-    the port. See ``cli_server._gateway_owns_port``.
+    the port. See ``port_resolution._gateway_owns_port``.
 
     Read-only: never creates ``run/``.
     """

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -67,6 +67,7 @@ from kiro_crew.mcp_shared import (
 from kiro_crew.members import record_activity
 from kiro_crew.messaging.link import is_legacy_slack_key, legacy_key
 from kiro_crew.platform import redact_via_context as redact
+from kiro_crew.port_resolution import resolve_client_port_ex
 from kiro_crew.security import (
     BINARY_MIME_ALLOWLIST,
     redact_credentials,
@@ -144,8 +145,8 @@ from kiro_crew.validation import (
 def _resolve_api_port() -> tuple[int, bool]:
     """Resolve the gateway API port a callback should aim at.
 
-    Delegates to :func:`kiro_crew.cli_server.resolve_client_port`, the same
-    precedence every client CLI command applies: ``KIROCREW_PORT``, then a
+    Delegates to :func:`kiro_crew.port_resolution.resolve_client_port_ex`, the
+    same precedence every client CLI command applies: ``KIROCREW_PORT``, then a
     port **explicitly written** in ``dashboard.url``, then the sole
     gateway-owned run-marker, then the documented default. The marker step is
     what keeps a portless ``dashboard.url`` from collapsing to the default
@@ -153,15 +154,9 @@ def _resolve_api_port() -> tuple[int, bool]:
     substitutes the default for the *server's* benefit (it must bind
     something), which is exactly the wrong guess for a client callback.
 
-    The import is lazy on purpose: ``cli_server`` fans out into CLI-only
-    dependencies this stdio server otherwise never loads, and paying that once
-    on the first gateway call keeps the hot MCP-stdio import path lean.
-
     Returns ``(port, positive)`` — ``positive`` is ``False`` when resolution
     fell through to the default with no evidence behind it.
     """
-    from kiro_crew.cli_server import resolve_client_port_ex
-
     return resolve_client_port_ex(None)
 
 

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -1773,7 +1773,7 @@ def process_owner_uid(pid: int) -> int | None:
     must decide what to do with ``None`` explicitly rather than assume a match.
 
     Used to confirm that a pid a client is about to trust belongs to the calling
-    user (see ``cli_server._gateway_owns_port``), which is what makes pid
+    user (see ``port_resolution._gateway_owns_port``), which is what makes pid
     recycling into a *foreign* user's process non-exploitable.
     """
     try:

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -1200,7 +1200,7 @@ def pod_context(cfg: PodConfig, name: str) -> tuple[Path, dict[str, str]]:
 #                    `chat --tui` branches straight into `_tui` (cli.py:1818), so
 #                    excluding only `tui` left the same hole open. Every OTHER
 #                    client verb (`status`, `logout`, and the credential verb) goes
-#                    through `cli_server.resolve_client_port`, which DOES honour
+#                    through `port_resolution.resolve_client_port`, which DOES honour
 #                    `KIROCREW_PORT` — so this hazard is confined to `_tui`.
 #   logs           — `cli_server._logs_cmd` runs `journalctl -u <SERVICE_NAME>`,
 #                    the HOST service unit, so inside a pod it would show the LIVE

--- a/src/kiro_crew/port_resolution.py
+++ b/src/kiro_crew/port_resolution.py
@@ -1,0 +1,435 @@
+"""Client-side gateway port resolution — a deliberately light leaf module.
+
+Home of the resolution chain every *client* of a running gateway uses to find
+the port it should talk to: the CLI client commands (``token`` / ``status`` /
+``logout`` / ``stop``) and the MCP stdio server's gateway callbacks. Both kinds
+of consumer import this module at module scope; :mod:`kiro_crew.cli_server`
+re-exports every name so its public surface (and the many tests that patch
+these symbols there) is unchanged.
+
+Leanness is this module's contract, not an accident: the MCP stdio server is
+spawned once per CLI session and must not pay for ``cli_server``'s import graph
+(frontend build, service controllers, preflight, embeddings) just to learn a
+port number. Every import below is either stdlib or a module the MCP server
+already loads at startup. A regression test asserts that importing this module
+does not pull in ``kiro_crew.cli_server``.
+
+Patch-namespace contract
+------------------------
+
+A large body of tests patches these symbols in the ``cli_server`` namespace
+(``kiro_crew.cli_server._gateway_owns_port`` and friends). Chain-internal
+calls therefore resolve their callee through :func:`_patchable`, which
+prefers the ``cli_server`` namespace whenever that module is loaded and falls
+back to this module otherwise. In production the two namespaces hold the very
+same function objects (``cli_server`` re-exports them), so the lookup is
+behaviour-neutral; under test it is what lets a patch in the ``cli_server``
+namespace intercept a call made from inside the chain. The flip side: patch
+``cli_server.<name>``, not this module's namespace — patching a name here
+does NOT intercept chain-internal calls while ``cli_server`` is loaded, and
+in a test process it almost always is.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import sys
+import urllib.parse
+from typing import Any
+
+from kiro_crew import platform_compat
+
+# Referenced only through _patchable's ``globals()`` fallback (the class NAME
+# is itself a patch target — see _config_url_port), which flake8 cannot see.
+from kiro_crew.config.loader import KiroCrewConfig  # noqa: F401
+from kiro_crew.config.loader import _DEFAULT_PORT
+from kiro_crew.dashboard.origin import parse_dashboard_url
+from kiro_crew.instances import run_marker
+
+#: Module whose namespace test patches of the chain historically target.
+#: Looked up lazily via ``sys.modules`` — importing it here would recreate the
+#: exact heavy import edge this module exists to remove.
+_PATCH_NS = "kiro_crew.cli_server"
+
+
+def _patchable(name: str) -> Any:
+    """Resolve chain-internal callee *name* through the patched namespace.
+
+    Returns the attribute from :data:`_PATCH_NS` when that module is loaded
+    (so ``mock.patch("kiro_crew.cli_server.<name>")`` intercepts calls made
+    from inside the chain, exactly as it did when the chain lived there), and
+    from this module's own globals otherwise (the MCP stdio server never loads
+    ``cli_server``). The ``getattr`` fallback also covers the window where
+    ``cli_server`` is mid-import and has not bound its re-exports yet.
+    """
+    mod = sys.modules.get(_PATCH_NS)
+    if mod is not None:
+        fn = getattr(mod, name, None)
+        if fn is not None:
+            return fn
+    return globals()[name]
+
+
+def _config_url_port() -> int | None:
+    """Port explicitly named by ``dashboard.url``, or ``None``.
+
+    Distinct from :func:`parse_dashboard_url`, which substitutes
+    ``_DEFAULT_PORT`` for a portless URL (``http://my.host``). That substitution
+    is right for the *server* (it must bind something) but wrong for a client:
+    it would report "config says 5476" and short-circuit the run-marker
+    fallback below, even though the user never named a port. So detect the
+    explicit case and let a portless URL fall through.
+    """
+    try:
+        # The class NAME resolves through the patched namespace, not just the
+        # chain functions: tests rebind ``cli_server.KiroCrewConfig`` wholesale
+        # (``patch("kiro_crew.cli_server.KiroCrewConfig")``), which a direct
+        # global read here would silently miss.
+        cfg = _patchable("KiroCrewConfig").load()
+        url = cfg.dashboard.url or ""
+    except Exception:
+        # Config load failures must not break client commands.
+        return None
+    if not isinstance(url, str):
+        # ``dashboard.url`` is user-editable JSON and core installs may lack
+        # jsonschema, so the value can be any type (``"url": 123``). urlparse
+        # raises TypeError on a non-str, which is NOT a ValueError — without
+        # this guard a bad config type would crash every client command.
+        logging.getLogger(__name__).warning(
+            "Ignoring non-string dashboard.url of type %s", type(url).__name__
+        )
+        return None
+    if not url:
+        return None
+    try:
+        _, port = parse_dashboard_url(url)
+        # parse_dashboard_url already normalises the scheme, tolerates malformed
+        # URLs and applies the KIROCREW_PORT override; re-split only to learn
+        # whether the port was written down or defaulted in.
+        explicit = urllib.parse.urlsplit(url if "://" in url else f"http://{url}").port
+    except (TypeError, ValueError):
+        return None
+    return port if explicit is not None else None
+
+
+def _gateway_owns_port(port: int) -> bool:
+    """True only when *this user's* gateway process is listening on *port*.
+
+    Reachability is not enough to trust a discovered port. Client commands hand
+    the local secret to whatever answers (``_token`` and ``_logout`` send
+    ``X-Local-Secret``), and ``clear_marker`` runs only on graceful shutdown —
+    so a crashed gateway leaves a marker naming a port some unrelated process
+    may since have bound. A bare TCP connect would walk the secret straight into
+    that process, which could then mint owner tokens against the real gateway.
+
+    A command-line check is not enough either: argv is attacker-chosen, so a
+    listener launched as ``/tmp/kirocrew gateway`` would pass it. The proof used
+    here is an identity the attacker cannot forge, in three parts:
+
+    1. **Recorded pid** — ``run_marker.read_pid(port)`` reads the sidecar the
+       gateway wrote at ``0600`` inside the ``0700`` ``run/`` dir. Another local
+       user cannot write it, so they cannot nominate a process of theirs.
+    2. **Holds the port** — that pid must be among
+       ``platform_compat.find_listening_pids(port)``. This is what makes a stale
+       recorded pid harmless: it has to actually hold the port we are about to
+       send the secret to.
+    3. **Owned by us, and ours** — the pid's uid must equal the caller's
+       (``process_owner_uid``), and its argv must look like a gateway. The uid
+       check is what closes pid *recycling* into a foreign user's process; argv
+       remains only as defense in depth, never as the sole proof.
+
+    A same-user attacker is out of scope by construction: they can already read
+    ``.local_secret`` (mode ``0600``, their own uid), so nothing here can be an
+    escalation for them. The boundary this closes is a *different* local user.
+
+    **Fails closed** at every step: no sidecar, no recorded pid, a pid that does
+    not hold the port, an unresolvable uid, a missing lookup tool
+    (``find_listening_pids`` folds that into an empty list) or a throwing one —
+    all deny, and discovery is skipped in favour of the documented default.
+    ``--port`` and ``KIROCREW_PORT`` remain available on such hosts.
+
+    **Non-POSIX denies outright.** ``process_owner_uid`` cannot report an owner
+    on Windows, and a home that is writable by another user (a shared or
+    misconfigured ``KIROCREW_HOME``) would let them replace both the marker and
+    the sidecar with a forged listener — the file-permission argument that
+    carries step 1 is exactly what stops holding there. Rather than trust
+    steps 1-2 alone, discovery is skipped: Windows users keep ``--port`` /
+    ``KIROCREW_PORT``, which is precisely where they were before this fallback
+    existed, so nothing regresses. This is the one place the feature is
+    deliberately unavailable rather than approximated.
+    """
+    if not platform_compat.IS_POSIX:
+        return False
+    recorded = run_marker.read_pid(port)
+    if recorded is None:
+        return False
+    try:
+        pids = platform_compat.find_listening_pids(port)
+    except Exception:
+        return False
+    if recorded not in pids:
+        return False
+    owner = platform_compat.process_owner_uid(recorded)
+    if owner is None or owner != os.getuid():
+        return False
+    return _patchable("_is_kirocrew_process")(recorded)
+
+
+def _marker_port() -> int | None:
+    """Port of the sole gateway-owned run-marker, or ``None``.
+
+    Zero-configuration discovery for the common single-gateway box: the gateway
+    already advertises itself by writing ``<data-home>/run/gateway-<port>.bin``
+    (see :mod:`kiro_crew.instances.run_marker`), so a client with no ``--port``,
+    no ``KIROCREW_PORT`` and no port in ``dashboard.url`` can read that instead
+    of assuming 5476 and connecting to a dead port.
+
+    Two guards keep this from being a guess:
+
+    * **Ownership.** Only ports where a verified Kiro Crew gateway process is
+      listening count (:func:`_gateway_owns_port`); a stale marker, or one whose
+      port has been taken over by an unrelated process, is discarded.
+    * **Ambiguity.** With several gateways up there is no basis to pick one, so
+      this refuses (returns ``None``, landing on the documented default) and
+      tells the user on stderr which ports it saw and how to name one.
+    """
+    try:
+        candidates = run_marker.marker_ports()
+    except Exception:
+        return None
+    if not candidates:
+        return None
+    owns = _patchable("_gateway_owns_port")
+    owned = [p for p in candidates if owns(p)]
+    if len(owned) == 1:
+        return owned[0]
+    if len(owned) > 1:
+        print(
+            f"⚠️  Multiple gateways are running (ports {', '.join(str(p) for p in owned)}); "
+            f"not guessing which one you meant — using {_DEFAULT_PORT}. "
+            "Pass --port or set KIROCREW_PORT to target a specific gateway.",
+            file=sys.stderr,
+        )
+    return None
+
+
+def resolve_client_port(cli_port: int | None) -> int:
+    """Return the dashboard port a *client* CLI command (token/status/logout/stop)
+    should talk to.
+
+    Resolution order:
+
+    1. Explicit ``--port`` CLI flag if the user passed one (``cli_port`` is not ``None``).
+    2. ``KIROCREW_PORT`` env var if set to a valid integer. Deliberately ABOVE
+       the bound-port export: an explicitly-set ``KIROCREW_PORT`` is how a
+       caller retargets a child at a DIFFERENT gateway — ``pod exec`` builds a
+       client env with ``KIROCREW_PORT=<pod-port>`` precisely so the command
+       reaches the pod, while the inherited ``KIROCREW_BOUND_PORT`` still
+       names the spawning LIVE gateway. Ranking the bound value higher would
+       walk pod ``token``/``status``/``logout`` (and the local secret they
+       carry) into the live gateway — a cross-plane isolation break.
+    3. ``KIROCREW_BOUND_PORT`` env var if set to a valid integer — the port the
+       parent gateway ACTUALLY bound, exported once its TCP site is listening
+       (``dashboard.server._export_bound_port``). Below the operator override
+       (see above); above config because a bound fact from the live parent
+       beats a guess re-derived from a portless ``dashboard.url``.
+    4. Port explicitly named by ``dashboard.url`` in the config file
+       (``<data-home>/config.json``), when it parses.
+    5. The sole gateway-owned run-marker (``<data-home>/run/gateway-<port>.bin``)
+       — see :func:`_marker_port`. Skipped when no marker's port is held by a
+       verified gateway process, and refused (with a stderr hint) when several
+       are.
+    6. ``_DEFAULT_PORT`` (5476) as the final fallback.
+
+    Steps 1, 2 and 4 match the server-side ``parse_dashboard_url()`` logic so
+    that ``kirocrew token`` / ``status`` / ``logout`` / ``stop`` all hit the
+    same port the gateway is actually bound to when the user has configured a
+    non-default ``dashboard.url`` (for example a dev instance on 6777 or an
+    alternative prod port like 7778). Steps 3 and 5 cover the case where
+    nothing was configured at all but a gateway is up on a non-default port
+    (e.g. started with ``kirocrew gateway --port 6776``): the parent's own
+    export, or the running gateway's marker, is better evidence than the 5476
+    default.
+    """
+    port, _ = _patchable("resolve_client_port_ex")(cli_port)
+    return port
+
+
+def resolve_client_port_ex(cli_port: int | None) -> tuple[int, bool]:
+    """Like :func:`resolve_client_port`, also reporting HOW the port resolved.
+
+    The second element is ``True`` when the port came from positive evidence
+    (an explicit flag, an env var, a configured port, or a verified
+    run-marker) and ``False`` when resolution fell through to
+    ``_DEFAULT_PORT``. Callers that cache a resolution for the process
+    lifetime need the distinction: a fall-through only proves nothing was
+    discoverable *at that instant* — during gateway boot the run-marker may
+    not be written yet — so pinning it would freeze the weakest outcome
+    forever, while every positive source is stable for the process lifetime.
+    """
+    if cli_port is not None:
+        return cli_port, True
+    env_port = os.environ.get("KIROCREW_PORT")
+    if env_port:
+        try:
+            return int(env_port), True
+        except ValueError:
+            # Fall through to bound/config/marker/default — main() validates
+            # this early, but guard here too in case the helper is reached via
+            # another path.
+            pass
+    bound_port = os.environ.get("KIROCREW_BOUND_PORT")
+    if bound_port:
+        try:
+            return int(bound_port), True
+        except ValueError:
+            pass
+    cfg_port = _patchable("_config_url_port")()
+    if cfg_port:
+        return cfg_port, True
+    discovered = _patchable("_marker_port")()
+    if discovered:
+        return discovered, True
+    return _DEFAULT_PORT, False
+
+
+# Subcommands that launch a long-running Kiro Crew *server* process which
+# ``kirocrew stop`` may need to terminate. These mirror the entry-point
+# subcommands dispatched in ``cli.py`` (``gateway`` / ``dashboard``; ``start``
+# is the historical alias). The task runner (``run``) is intentionally excluded:
+# it is not bound to the dashboard port, so we must never SIGTERM it from
+# ``kirocrew stop``.
+_KIROCREW_SERVER_SUBCOMMANDS = frozenset({"gateway", "dashboard", "start"})
+
+
+def _basename_stem(tok: str) -> str:
+    """Basename of *tok* without a Windows ``.exe`` suffix.
+
+    Lets the venv launchers ``python.exe`` / ``kirocrew.exe`` match the same
+    checks as their POSIX ``python`` / ``kirocrew`` counterparts. ``shlex.split``
+    with ``posix=False`` leaves quotes on some tokens, so strip them too.
+
+    Split on BOTH separators explicitly rather than via ``os.path.basename``:
+    that is host-dependent (``posixpath`` on Linux does NOT split backslashes),
+    so a Windows cmdline classified on the Linux CI fleet would keep its full
+    ``D:\\...\\kirocrew.exe`` path and never match. This is host-independent — a
+    basename is whatever follows the last ``/`` or ``\\``.
+
+    Module scope rather than nested in :func:`_args_look_like_kirocrew` so
+    :func:`kiro_crew.cli_server._own_console_script` shares the one definition.
+    """
+    cleaned = tok.strip('"')
+    base = cleaned.replace("\\", "/").rsplit("/", 1)[-1]
+    if base.lower().endswith(".exe"):
+        base = base[:-4]
+    return base
+
+
+def _args_look_like_kirocrew(args: str) -> bool:
+    """Return ``True`` if a process command-line *args* string is a Kiro Crew server.
+
+    This gates ``os.kill(pid, SIGTERM)`` in ``cli_server._stop``, so it must be
+    **precise** (never match an unrelated process that merely mentions
+    "kirocrew") while still recognising *every* way the gateway can be spawned.
+
+    Instead of enumerating brittle substring variants (``kiro_crew.gateway`` vs
+    ``kiro_crew gateway`` vs ``kirocrew gateway`` …), we parse the command line
+    *structurally* and key on the real module/binary name plus a known server
+    subcommand (:data:`_KIROCREW_SERVER_SUBCOMMANDS`). This is deterministic and
+    robust to interpreter path, Python version suffix, and whitespace. Two spawn
+    shapes are recognised:
+
+    * **Module invocation** — ``<python> -m kiro_crew <subcmd>`` (the form used by
+      a service install and the launchd/systemd service), plus the legacy dotted
+      form ``<python> -m kiro_crew.<subcmd>``. A Python interpreter must precede
+      ``-m`` so we don't misread some other tool's ``-m`` flag (e.g. ``grep -m``).
+    * **Console script** — ``/path/to/kirocrew <subcmd>`` (used when the
+      ``kirocrew`` wrapper resolves on ``PATH``).
+
+    Examples::
+
+        >>> _args_look_like_kirocrew("/x/python3.10 -m kiro_crew gateway")
+        True
+        >>> _args_look_like_kirocrew("python3 -m kiro_crew.dashboard")
+        True
+        >>> _args_look_like_kirocrew("/usr/local/bin/kirocrew start")
+        True
+        >>> _args_look_like_kirocrew("python -m kiro_crew run /tmp/spec.md")  # task runner
+        False
+        >>> _args_look_like_kirocrew("vim /tmp/kirocrew-notes.txt")
+        False
+    """
+    # ``ps -o args=`` (POSIX) / Win32_Process.CommandLine (Windows WMI) return a
+    # shell-style string; tokenize it the way the host shell would. On Windows
+    # use posix=False so backslash path separators survive (default posix=True
+    # eats them: ``C:\Py\python.exe`` -> ``C:Pypython.exe``, breaking the
+    # interpreter/basename checks below). Fall back to a naive split on a
+    # malformed string (e.g. an odd quote) so this best-effort check never raises.
+    try:
+        tokens = shlex.split(args, posix=not platform_compat.IS_WINDOWS)
+    except ValueError:
+        tokens = args.split()
+
+    for index, token in enumerate(tokens):
+        # --- Module form: "<python> -m kiro_crew <subcmd>" / "-m kiro_crew.<subcmd>"
+        if token == "-m" and index + 1 < len(tokens):
+            # Only treat "-m" as Python's module flag when a Python interpreter
+            # precedes it; otherwise an unrelated tool's "-m" option could be
+            # misread (e.g. "grep -m kiro_crew gateway file"). The match is
+            # case-insensitive: the macOS framework build's interpreter basename
+            # is "Python" (capital P), which a case-sensitive startswith would
+            # miss, leaving stop/restart unable to find the gateway.
+            interpreter_seen = any(
+                _basename_stem(t).lower().startswith("python") for t in tokens[:index]
+            )
+            if interpreter_seen:
+                # "kiro_crew.gateway" -> ("kiro_crew", "gateway"); a bare
+                # "kiro_crew" -> ("kiro_crew", "").
+                package, _, dotted_subcmd = tokens[index + 1].partition(".")
+                if package == "kiro_crew":
+                    # Dotted submodule form: ``-m kiro_crew.gateway``.
+                    if dotted_subcmd in _KIROCREW_SERVER_SUBCOMMANDS:
+                        return True
+                    # Subcommand-as-argument form: ``-m kiro_crew gateway``. The
+                    # subcommand is argparse's first positional after the module,
+                    # i.e. always at index+2. Check only that slot so a later
+                    # positional/flag value cannot match — e.g.
+                    # ``-m kiro_crew run gateway`` ("gateway" is a file argument
+                    # to the task runner) must NOT be treated as a server.
+                    if (
+                        index + 2 < len(tokens)
+                        and tokens[index + 2] in _KIROCREW_SERVER_SUBCOMMANDS
+                    ):
+                        return True
+
+        # --- Console-script form: ".../kirocrew <subcmd>" (or kirocrew.exe on Win)
+        if (
+            _basename_stem(token) == "kirocrew"
+            and index + 1 < len(tokens)
+            and tokens[index + 1] in _KIROCREW_SERVER_SUBCOMMANDS
+        ):
+            return True
+
+    return False
+
+
+def _is_kirocrew_process(pid: int) -> bool:
+    """Return ``True`` if *pid* looks like a Kiro Crew gateway process.
+
+    Resolves the process command line cross-platform via
+    :func:`platform_compat.process_command_line` (Linux ``/proc``, macOS ``ps``,
+    Windows ``Win32_Process`` WMI — the venv ``kirocrew.exe`` re-execs
+    ``python.exe`` so the image name alone is ambiguous there) and defers
+    classification to :func:`_args_look_like_kirocrew`.
+
+    ``process_command_line`` returns ``""`` on any failure (dead PID, missing
+    ``ps``, WMI error), which classifies as "not a match" — ``cli_server._stop``'s
+    separate ``listening_pid_tool_available()`` check already surfaces the
+    tool-absent case, so this never needs to raise.
+    """
+    out = platform_compat.process_command_line(pid)
+    if not out:
+        return False
+    return _args_look_like_kirocrew(out)

--- a/test/test_mcp_api_port_resolution.py
+++ b/test/test_mcp_api_port_resolution.py
@@ -10,20 +10,34 @@ Two halves of one defect:
   had nothing better than that guess to inherit.
 
 These tests lock in the fix: ``mcp_core`` resolves lazily through
-``cli_server.resolve_client_port`` (env → explicit config port → live
-run-marker → default), and the dashboard server exports ``KIROCREW_BOUND_PORT``
-once its TCP site is listening.
+``port_resolution.resolve_client_port_ex`` (env → explicit config port → live
+run-marker → default; re-exported by ``cli_server``, whose namespace the
+chain-internal calls still resolve through so the patches below intercept),
+and the dashboard server exports ``KIROCREW_BOUND_PORT`` once its TCP site is
+listening.
 """
 
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import kiro_crew
 import kiro_crew.mcp_core as mcp_core
 from kiro_crew.dashboard.server import _export_bound_port
+
+#: Source root of the tree under test, pinned onto the probe subprocess's
+#: PYTHONPATH. Without it the child interpreter resolves whatever kiro_crew
+#: happens to be installed for it (pytest's ``pythonpath = src`` does not
+#: propagate to subprocesses) — a stale editable install would make the
+#: leaf-purity assertion pass vacuously against old code, and a non-editable
+#: install would fail it spuriously. Same pattern as test_perf_boot_path._probe.
+_SRC = str(Path(kiro_crew.__file__).resolve().parents[1])
 
 
 @pytest.fixture(autouse=True)
@@ -205,3 +219,35 @@ class TestExportBoundPort:
         monkeypatch.setenv("KIROCREW_BOUND_PORT", "1111")
         _export_bound_port(_StubRunner([]), 6776)
         assert os.environ["KIROCREW_BOUND_PORT"] == "6776"
+
+
+class TestPortResolutionStaysLeaf:
+    """``port_resolution`` exists so the MCP stdio server never pays for
+    ``cli_server``'s import graph (frontend build, service controllers,
+    preflight, embeddings). Lock that in: importing either the leaf or
+    ``mcp_core`` in a fresh interpreter must not pull ``cli_server`` in.
+    A fresh interpreter is required — this suite itself imports
+    ``cli_server``, so an in-process ``sys.modules`` check would always
+    see it loaded.
+    """
+
+    @pytest.mark.parametrize(
+        "module", ["kiro_crew.port_resolution", "kiro_crew.mcp_core"]
+    )
+    def test_import_does_not_pull_cli_server(self, module: str) -> None:
+        code = (
+            "import importlib, sys; "
+            f"importlib.import_module({module!r}); "
+            "assert 'kiro_crew.cli_server' not in sys.modules, "
+            f"'importing {module} pulled in the heavy cli_server graph'"
+        )
+        env = dict(os.environ)
+        env["PYTHONPATH"] = _SRC + os.pathsep + env.get("PYTHONPATH", "")
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
## What is the problem?

`mcp_core` resolved its gateway API port through a function-local import of `cli_server` (`_resolve_api_port`), because `cli_server`'s top-level import graph (frontend build, service controllers, preflight, embeddings) is far heavier than the MCP stdio server's own. The lazy import worked, but it left the resolution chain living in a module none of its non-CLI consumers can afford to import, with a comment explaining the workaround instead of a structure that removes the need for it.

## Why this issue matters to the user

The MCP stdio server is spawned once per CLI session; every gateway callback (`spawn_run`, `learn_add`, artifacts, monitors) rides the port this chain resolves. Keeping the chain inside `cli_server` means every future consumer faces the same choice: pay the heavy import graph or copy the lazy-import trick. A leaf module makes the cheap path the only path.

## How our fix solves it

Pure move, no logic edits. The chain (`resolve_client_port`, `resolve_client_port_ex`, `_config_url_port`, `_marker_port`, `_gateway_owns_port`, `_is_kirocrew_process`, plus the argv-classifier helpers `_args_look_like_kirocrew` / `_basename_stem` / `_KIROCREW_SERVER_SUBCOMMANDS` they depend on) moves to a new leaf module `kiro_crew.port_resolution`, whose imports are all stdlib or modules the MCP server already loads. `mcp_core` now imports it at module scope and the lazy-import comment is gone.

**Patch-namespace contract.** `cli_server` re-exports every moved name, so its public surface is unchanged. The constraint from the issue — ~38 existing tests patch these symbols in the `cli_server` namespace — is honoured without editing any of them: chain-internal calls resolve their callee through `_patchable()`, a `sys.modules` lookup that prefers the `cli_server` namespace whenever that module is loaded and falls back to the leaf's own globals otherwise (the MCP stdio server never loads `cli_server`). In production both namespaces hold the same function objects, so the lookup is behaviour-neutral. The `KiroCrewConfig` *name* is routed through the same hook because two tests rebind the class wholesale on `cli_server`.

**Zero test patch targets were changed.** All existing tests run unmodified.

## Verification

- New regression test (`TestPortResolutionStaysLeaf`) asserts in a fresh interpreter — `PYTHONPATH`-pinned to the tree under test — that importing `kiro_crew.port_resolution` or `kiro_crew.mcp_core` does not pull in `kiro_crew.cli_server`.
- `isort` / `flake8` / `mypy` clean; full backend suite run twice and failure-diffed against an unmodified-tree baseline in the same environment: identical failure count (83), all environmental (sandbox-unavailable, env leakage), none in port resolution.
- Pre-push review fleet: GPT 5.6 Sol PASS (zero findings); Opus 5 raised one blocking finding (the probe subprocess was not pinned to the reviewed tree — fixed by reusing `test_perf_boot_path`'s `PYTHONPATH` pattern) plus advisories (leaf-namespace patching caveat documented, present-tense docstring, three remaining cross-references re-pointed), all applied.

## Known limits

- `_patchable` returns `Any`, so the chain-internal edges lose static type coverage (accepted cost of the hook; noted by review as a candidate for later narrowing).
- Other function-local importers of the chain (`cli_setup`, `dashboard/port_reclaim`) still import via `cli_server`; they work unchanged through the re-exports and can migrate to the leaf independently.

Closes #2933
