### PR TITLE
fix(chat): re-pin follow when the scroller's own height changes

### DIFF
--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -358,6 +358,12 @@ export function useVirtualChat<T>(
   // Timestamp (performance.now) of the last genuine USER scroll. Used to gate
   // RO-driven follow pins so they don't fire mid-fling — see SCROLL_SETTLE_MS.
   const lastUserScrollAtRef = useRef<number>(0)
+  // Last observed scroller clientHeight, so a ResizeObserver entry for the
+  // SCROLLER can be classified as a height change (the distance to the bottom
+  // moved) rather than a width change (rows rewrap and report themselves).
+  // `-1` means "not yet observed", which makes the observer's initial
+  // synthetic fire record the baseline instead of counting as a change.
+  const lastViewportHRef = useRef<number>(-1)
 
   // ---- Scroll-anchor preservation ----
   //
@@ -1017,10 +1023,27 @@ export function useVirtualChat<T>(
 
       let genuineResize = false
       let firstMount = false
+      // True when the SCROLLER's own height changed — the viewport shrank or
+      // grew under us, so the bottom moved without any content moving.
+      let viewportResized = false
       // True when one of the resized entries is the caller-designated
       // streaming row (see `streamingIndex` option / syncHeightsNow's doc).
       let streamingRowResized = false
       for (const entry of entries) {
+        // The scroller's own entry. Handled before the row lookup because the
+        // scroller is not in `elIndexRef` and would otherwise be skipped.
+        // Only a HEIGHT change matters here: a width change rewraps every
+        // mounted row, and those rows report themselves through the branch
+        // below, so acting on width too would double-fire on every frame of a
+        // panel animation.
+        if (entry.target === el) {
+          const h = el.clientHeight
+          if (lastViewportHRef.current >= 0 && h !== lastViewportHRef.current) {
+            viewportResized = true
+          }
+          lastViewportHRef.current = h
+          continue
+        }
         const idx = elIndexRef.current.get(entry.target)
         if (idx === undefined) continue
         const it = itemsRef.current[idx]
@@ -1068,7 +1091,7 @@ export function useVirtualChat<T>(
       // for the length of the animation re-creates the spacer lurch that
       // `streamingIndex`'s immediate path exists to prevent. Collapsing the rail
       // mid-turn is rare; a visible lurch is not an acceptable trade for it.
-      if ((genuineResize || firstMount) && !streamingRowResized && isRailSettling()) {
+      if ((genuineResize || firstMount || viewportResized) && !streamingRowResized && isRailSettling()) {
         railSettleFollowRef.current = railSettleFollowRef.current || stickRef.current
         if (railSettleTimerRef.current === null) {
           railSettleTimerRef.current = setTimeout(() => {
@@ -1096,7 +1119,17 @@ export function useVirtualChat<T>(
       // message right as the turn re-keys (single → grouped turn) and remounts
       // the row, which otherwise looks like a first-mount and skips the pin.
       // pinAuto still releases if the live geometry shows a real scroll-up.
-      const shouldFollow = genuineResize || (firstMount && stickRef.current)
+      // A VIEWPORT height change is followed on the same terms as a first-mount:
+      // only while stick is armed. The composer's textarea autosizes as the user
+      // types (44px up to 140px) and the scroller is the flex sibling above it,
+      // so every added line steals transcript height and pushes the bottom down
+      // with no content moving — no row resizes, no item appends, and no scroll
+      // event (shrinking the viewport RAISES the scroll maximum, so the browser
+      // has nothing to clamp). The same is true of the composer's drag-resize,
+      // the side panel docking to the bottom, a height-only window resize, and
+      // the mobile keyboard. Gated on stick so a reader scrolled up into history
+      // is never dragged to the bottom by their own typing.
+      const shouldFollow = genuineResize || ((firstMount || viewportResized) && stickRef.current)
       if (shouldFollow && (stickRef.current || performance.now() - lastUserScrollAtRef.current >= SCROLL_SETTLE_MS)) {
         pinAuto()
       }
@@ -1132,6 +1165,24 @@ export function useVirtualChat<T>(
     // exactly the currently-mounted rows (the null-element branch deletes on
     // unmount), so iterating it cannot resurrect a detached node.
     for (const el of elIndexRef.current.keys()) ro.observe(el)
+    // Observe the SCROLLER itself, not only its rows. Without this the hook has
+    // no signal at all when the viewport's own height changes: the follow pin is
+    // reachable only from a row resize, an itemCount increase, a slot entry,
+    // `scrollToBottom`, or a glide arrival, and a shrinking viewport is none of
+    // them. A `window` resize listener would not substitute — the composer
+    // growing fires no window resize.
+    //
+    // Deliberately the SAME observer as the rows, and deliberately NOT keyed on
+    // `scrollerEl` in this effect's deps: adding it there would re-create the
+    // observer when the element resolves, and both the row back-fill contract
+    // and its regression test rest on this being the one and only instance. The
+    // late-mount case (a scroller rendered after our first commit) is covered by
+    // the small effect below instead.
+    const sc = scrollerRef.current
+    if (sc) {
+      lastViewportHRef.current = sc.clientHeight
+      ro.observe(sc)
+    }
     return () => {
       ro.disconnect()
       // Cancel a frame queued by the last resize so it can't fire a
@@ -1148,6 +1199,24 @@ export function useVirtualChat<T>(
       resizeObserverRef.current = null
     }
   }, [recomputeWindow, pinAuto, scheduleHeightSync, syncHeightsNow, scrollerRef])
+
+  // Late-mounting scroller: the observer effect above runs once, so if the
+  // scroller was not in the tree yet (conditional loader, route transition —
+  // the reason the node is promoted to state at all) it observed nothing.
+  // Re-observe on the EXISTING instance when the element resolves or changes;
+  // `observe` is idempotent, so the common case where the effect above already
+  // caught it costs nothing.
+  useEffect(() => {
+    const ro = resizeObserverRef.current
+    if (!ro || !scrollerEl) return
+    lastViewportHRef.current = scrollerEl.clientHeight
+    ro.observe(scrollerEl)
+    // Unobserve on the CURRENT observer, not the one captured at setup: if the
+    // effect above re-ran in between it disconnected `ro` and built a fresh
+    // instance, and unobserving the dead one would leave the detached scroller
+    // observed on the live one until the next recreation.
+    return () => resizeObserverRef.current?.unobserve(scrollerEl)
+  }, [scrollerEl])
 
   // ---- IntersectionObserver: top/bottom sentinels for window expansion ----
   useEffect(() => {

--- a/website/src/test/useVirtualChat.completionSnap.test.tsx
+++ b/website/src/test/useVirtualChat.completionSnap.test.tsx
@@ -1,0 +1,207 @@
+// Feature: chat-virtualizer — the completion snap at the end of a turn must
+// leave a followed viewport at the bottom.
+//
+// WHAT THIS LOCKS IN, AND WHY IT PASSES TODAY. These cases were written to chase
+// a suspected end-of-turn scroll jump, on the theory that the snap could land
+// against stale computed geometry. That theory is WRONG, and these tests are the
+// evidence: `evaluateAutoPin` targets `bottomTarget(live geom)`, and a mounted
+// row's growth is in the browser's `scrollHeight` the instant it happens, so a
+// lagging spacer cannot mislead a pin for the streaming row — which is always
+// mounted. They are kept because the invariant is real, nothing else covers it,
+// and this is the only test that exercises the SEAM between computed spacers and
+// the pin: every other follow test fakes `scrollHeight` as an independent
+// number, and every other spacer test asserts on `totalHeight` directly.
+//
+// The mechanism under test: diff and code blocks stream inside SmoothResize, a
+// clipped wrapper driven toward the content height by a `height .32s` CSS
+// transition. At completion `enabled` flips false, the transition is removed and
+// the height goes to `auto`, so the wrapper SNAPS from its mid-animation height
+// to the natural one — upward while content was still growing. `streamingIndex`
+// goes undefined the instant the turn closes, and the 400ms
+// STREAMING_SETTLE_GRACE_MS that keeps the just-ended row on the immediate
+// height-sync path is deliberately NOT re-armed per resize, so the snap can land
+// inside that window or after it. Both are covered below.
+//
+// FIXTURE NOTE. The fake scroller COMPOSES `scrollHeight` the way a browser does:
+// the two spacer heights the hook reports (`offsetBefore` + `offsetAfter`, which
+// are computed and can therefore go stale) plus the REAL measured heights of the
+// mounted rows (current the moment the DOM changes). Deriving it from
+// `totalHeight` alone would be wrong in the other direction — it would hide a
+// mounted row's growth until the sync landed, which no browser does, and it
+// produces a phantom failure of exactly one growth tick.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { type RefObject } from 'react'
+
+import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
+import type { UseVirtualChatOptions } from '../hooks/virtualizer/types'
+
+interface Item { id: string }
+const getKey = (it: Item) => it.id
+const mkItems = (n: number): Item[] => Array.from({ length: n }, (_, i) => ({ id: `m${i}` }))
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+  cb: ResizeObserverCallback
+  observed = new Set<Element>()
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb
+    FakeResizeObserver.instances.push(this)
+  }
+  observe(el: Element) { this.observed.add(el) }
+  unobserve(el: Element) { this.observed.delete(el) }
+  disconnect() { this.observed.clear() }
+  fire(entries: Partial<ResizeObserverEntry>[]) {
+    this.cb(entries as ResizeObserverEntry[], this as unknown as ResizeObserver)
+  }
+}
+
+function mkEntry(target: HTMLElement, height: number): Partial<ResizeObserverEntry> {
+  Object.defineProperty(target, 'offsetHeight', { configurable: true, get: () => height })
+  return { target }
+}
+
+const CH = 800
+const HISTORY_H = 100
+const STREAM_START_H = 40
+/** Height the SmoothResize wrapper snaps up to when `enabled` flips false. */
+const SNAP_GROWTH = 120
+
+/**
+ * Mount with a scroller whose scrollHeight TRACKS the hook's computed
+ * totalHeight, so the fake DOM cannot know about a height the virtualizer has
+ * not synced yet — exactly the real coupling through the spacers.
+ */
+function mountStreaming(sessionId: string, items: Item[]) {
+  const el = document.createElement('div')
+  let scrollTop = 0
+  // Real measured heights of the MOUNTED rows, kept current by the test exactly
+  // as the DOM would be. Set after renderHook so the getter reads live output.
+  let realMounted = 0
+  let readSpacers: () => number = () => 0
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (v: number) => { scrollTop = v },
+  })
+  Object.defineProperty(el, 'scrollHeight', {
+    configurable: true,
+    get: () => readSpacers() + realMounted,
+  })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => CH })
+  ;(el as unknown as { scrollTo: (o: { top: number }) => void }).scrollTo = (o) => { scrollTop = o.top }
+
+  const ref: RefObject<HTMLDivElement | null> = { current: el }
+  const lastIdx = items.length - 1
+  const baseProps: UseVirtualChatOptions<Item> = {
+    items, sessionId, getKey, externalScrollerRef: ref, streamingIndex: lastIdx,
+  }
+  const view = renderHook(
+    (p: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(p),
+    { initialProps: baseProps },
+  )
+  readSpacers = () => view.result.current.offsetBefore + view.result.current.offsetAfter
+
+  for (let i = 0; i < lastIdx; i++) {
+    const node = document.createElement('div')
+    Object.defineProperty(node, 'offsetHeight', { configurable: true, get: () => HISTORY_H })
+    act(() => { view.result.current.measureRef(i)(node) })
+    realMounted += HISTORY_H
+  }
+  const streamNode = document.createElement('div')
+  Object.defineProperty(streamNode, 'offsetHeight', { configurable: true, get: () => STREAM_START_H })
+  act(() => { view.result.current.measureRef(lastIdx)(streamNode) })
+  realMounted += STREAM_START_H
+  act(() => { vi.advanceTimersByTime(120) })  // settle the first-mount seed
+
+  const ro = FakeResizeObserver.instances[FakeResizeObserver.instances.length - 1]
+  /** Resize the streaming row in the DOM sense: real height changes at once. */
+  const resizeStreamRow = (from: number, to: number) => {
+    realMounted += to - from
+    act(() => { ro.fire([mkEntry(streamNode, to)]) })
+  }
+  return { el, view, ro, streamNode, baseProps, lastIdx, resizeStreamRow }
+}
+
+const bottomOf = (el: HTMLDivElement) => el.scrollHeight - CH
+
+describe('useVirtualChat: the SmoothResize completion snap after a turn closes', () => {
+  let origRO: typeof ResizeObserver | undefined
+  let origRaf: typeof requestAnimationFrame
+
+  beforeEach(() => {
+    localStorage.clear()
+    FakeResizeObserver.instances = []
+    origRO = globalThis.ResizeObserver
+    globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.ResizeObserver = origRO as typeof ResizeObserver
+    globalThis.requestAnimationFrame = origRaf
+  })
+
+  it('lands at the bottom when the snap arrives AFTER the settle grace expires', () => {
+    const { el, view, baseProps, resizeStreamRow } = mountStreaming('snap-after-grace', mkItems(21))
+
+    // --- streaming: the eased wrapper grows, each tick synced immediately ---
+    let h = STREAM_START_H
+    for (let i = 0; i < 6; i++) {
+      resizeStreamRow(h, h + 10)
+      h += 10
+      act(() => { vi.advanceTimersByTime(16) })
+    }
+    // Settle the immediate-path sync so the baseline is exactly at the bottom.
+    act(() => { vi.advanceTimersByTime(200) })
+    expect(el.scrollTop).toBe(bottomOf(el))
+
+    // --- the turn closes: streamingIndex clears, arming the 400ms grace ---
+    act(() => { view.rerender({ ...baseProps, streamingIndex: undefined }) })
+
+    // --- the grace expires before the snap lands (a slow final block, a
+    // widget still settling, or simply a browser that scheduled the flip late) ---
+    act(() => { vi.advanceTimersByTime(500) })
+
+    // --- the completion snap: `enabled` flips false, the clip is removed and
+    // the wrapper jumps to its natural height in one step ---
+    resizeStreamRow(h, h + SNAP_GROWTH)
+
+    // Let the debounced height sync flush, so `totalHeight` — and with it the
+    // fake scrollHeight — finally reflects the snap.
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // Follow was never released, so the viewport must be at the bottom. The pin
+    // reads LIVE geometry, and the snap is already in the browser's scrollHeight
+    // by the time the observer fires — which is why a lagging spacer cannot pull
+    // this short. See the header: this is the invariant, not a known failure.
+    expect(el.scrollTop).toBe(bottomOf(el))
+  })
+
+  it('lands at the bottom when the snap arrives INSIDE the settle grace', () => {
+    const { el, view, baseProps, resizeStreamRow } = mountStreaming('snap-in-grace', mkItems(21))
+
+    let h = STREAM_START_H
+    for (let i = 0; i < 6; i++) {
+      resizeStreamRow(h, h + 10)
+      h += 10
+      act(() => { vi.advanceTimersByTime(16) })
+    }
+    act(() => { vi.advanceTimersByTime(200) })
+    expect(el.scrollTop).toBe(bottomOf(el))
+
+    act(() => { view.rerender({ ...baseProps, streamingIndex: undefined }) })
+    act(() => { vi.advanceTimersByTime(100) })          // still inside the 400ms grace
+    resizeStreamRow(h, h + SNAP_GROWTH)
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // The grace exists precisely to keep this case on the immediate path, so
+    // this is the CONTROL: it isolates the failure above to the grace expiring
+    // rather than to the snap itself.
+    expect(el.scrollTop).toBe(bottomOf(el))
+  })
+})

--- a/website/src/test/useVirtualChat.spacerLurch.test.tsx
+++ b/website/src/test/useVirtualChat.spacerLurch.test.tsx
@@ -324,9 +324,13 @@ describe('useVirtualChat: streamingIndex fix — the named row tracks live inste
     const nonStreamingNode = document.createElement('div')
     Object.defineProperty(nonStreamingNode, 'offsetHeight', { configurable: true, get: () => 100 })
     act(() => { view.result.current.measureRef(0)(nonStreamingNode) }) // pre-existing measured seed
-    // Resize a HISTORY row (index 0, not the streamingIndex = 20).
+    // Resize a HISTORY row (index 0, not the streamingIndex = 20). Selected by
+    // IDENTITY, not by position in the observed set: the set also contains the
+    // scroller element itself (the hook observes it to catch viewport-height
+    // changes), and in this harness the rows register after the observer is
+    // created, so the scroller can be first.
     const ro = FakeResizeObserver.instances[FakeResizeObserver.instances.length - 1]
-    const historyNode = [...ro.observed][0] as HTMLElement
+    const historyNode = nonStreamingNode
     Object.defineProperty(historyNode, 'offsetHeight', { configurable: true, get: () => 150 })
     act(() => { ro.fire([{ target: historyNode }]) })
     // Still within the debounce window — must NOT have committed yet.

--- a/website/src/test/useVirtualChat.viewportShrink.test.tsx
+++ b/website/src/test/useVirtualChat.viewportShrink.test.tsx
@@ -1,0 +1,175 @@
+// Feature: chat-virtualizer — a change in the SCROLLER'S OWN height must re-pin
+// a followed viewport to the bottom.
+//
+// GAP THIS PINS DOWN. Follow protection is driven entirely by ROW observation:
+// `pinAuto` is reached from a row ResizeObserver tick, an itemCount increase, a
+// slot entry, `scrollToBottom`, or a smooth-glide arrival — and every
+// `.observe()` call in the hook targets a row element or an IntersectionObserver
+// sentinel. The scroller is never observed and there is no window resize
+// listener. So when the scroller's own `clientHeight` shrinks, the distance to
+// the bottom grows with NO row resized and NO item appended: nothing fires, and
+// the viewport silently stops being at the bottom.
+//
+// The everyday trigger is the composer: its textarea autosizes from 44px up to
+// 140px as the user types or pastes (ChatInput's applyHeight), and the scroller
+// is the `flex:1` sibling above it, so every keystroke that adds a line steals
+// height from the transcript. The same mechanism covers the composer's manual
+// drag-resize, the side panel docking to the bottom, a height-only window
+// resize, and the mobile on-screen keyboard (there is no visualViewport handling
+// anywhere in the app).
+//
+// A window resize listener would NOT close this: the composer growing fires no
+// window resize. The scroller element itself has to be observed, which is why
+// the first case asserts on the observation and not only on the outcome.
+//
+// jsdom has no layout engine, so geometry is faked on a detached scroller passed
+// via `externalScrollerRef`, and the ResizeObserver is a controllable fake (the
+// same technique as the postStreamLurch and spacerLurch suites).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { type RefObject } from 'react'
+
+import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
+import type { UseVirtualChatOptions } from '../hooks/virtualizer/types'
+
+interface Geom { scrollTop: number; scrollHeight: number; clientHeight: number }
+
+/** A detached div with controllable, mutable scroll geometry. */
+function makeScroller(initial: Geom) {
+  const el = document.createElement('div')
+  const state: Geom = { ...initial }
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    get: () => state.scrollTop,
+    set: (v: number) => { state.scrollTop = v },
+  })
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => state.scrollHeight })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => state.clientHeight })
+  ;(el as unknown as { scrollTo: (o: { top: number }) => void }).scrollTo = (o) => { state.scrollTop = o.top }
+  return { el, state }
+}
+
+interface Item { id: string }
+const getKey = (it: Item) => it.id
+const mkItems = (n: number): Item[] => Array.from({ length: n }, (_, i) => ({ id: `m${i}` }))
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+  cb: ResizeObserverCallback
+  observed = new Set<Element>()
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb
+    FakeResizeObserver.instances.push(this)
+  }
+  observe(el: Element) { this.observed.add(el) }
+  unobserve(el: Element) { this.observed.delete(el) }
+  disconnect() { this.observed.clear() }
+  fire(entries: Partial<ResizeObserverEntry>[]) {
+    this.cb(entries as ResizeObserverEntry[], this as unknown as ResizeObserver)
+  }
+}
+
+const CH = 800                     // transcript viewport before the composer grows
+const SH = 5000
+const BOTTOM = SH - CH             // 4200 — where the slot-entry pin lands
+const COMPOSER_GROWTH = 96         // ~3 added lines of composer text
+const SHRUNK_CH = CH - COMPOSER_GROWTH
+const SHRUNK_BOTTOM = SH - SHRUNK_CH  // 4296 — the bottom after the viewport shrinks
+
+function mount(sessionId: string) {
+  const { el, state } = makeScroller({ scrollTop: 0, scrollHeight: SH, clientHeight: CH })
+  const ref: RefObject<HTMLDivElement | null> = { current: el }
+  const initialProps: UseVirtualChatOptions<Item> = {
+    items: mkItems(5), sessionId, getKey, externalScrollerRef: ref,
+  }
+  const view = renderHook((p: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(p), { initialProps })
+  const ro = FakeResizeObserver.instances[FakeResizeObserver.instances.length - 1]
+  return { el, state, view, ro }
+}
+
+describe('useVirtualChat: the scroller shrinking under a followed viewport', () => {
+  let origRO: typeof ResizeObserver | undefined
+  let origRaf: typeof requestAnimationFrame
+
+  beforeEach(() => {
+    localStorage.clear()
+    FakeResizeObserver.instances = []
+    origRO = globalThis.ResizeObserver
+    globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+  })
+
+  afterEach(() => {
+    globalThis.ResizeObserver = origRO as typeof ResizeObserver
+    globalThis.requestAnimationFrame = origRaf
+  })
+
+  it('observes the scroller element, not only the rows', () => {
+    const { el, ro } = mount('viewport-observed')
+    // Without this, a clientHeight change has no path into the hook at all:
+    // no row resized, no item appended, and no scroll event is dispatched
+    // (the browser only emits one if it has to clamp scrollTop, and shrinking
+    // the viewport RAISES the scroll maximum rather than lowering it).
+    expect(ro.observed.has(el)).toBe(true)
+  })
+
+  it('re-pins to the new bottom when the composer steals viewport height', () => {
+    const { el, state, ro } = mount('viewport-shrink-repin')
+    expect(el.scrollTop).toBe(BOTTOM)
+
+    // The composer autosizes: the transcript viewport loses 96px. scrollHeight
+    // is unchanged — the CONTENT did not move — so the bottom is now 96px
+    // further down and the viewport is no longer at it. Deliberately no scroll
+    // event and no row entry: this is the whole point of the gap.
+    act(() => {
+      state.clientHeight = SHRUNK_CH
+      ro.fire([{ target: el } as Partial<ResizeObserverEntry>])
+    })
+
+    expect(el.scrollTop).toBe(SHRUNK_BOTTOM)
+  })
+
+  it('does NOT chase the bottom when the user is scrolled up reading history', () => {
+    const { el, state, ro } = mount('viewport-shrink-released')
+
+    // Release follow the way a real user does: scroll well away from the bottom.
+    act(() => { state.scrollTop = 1000; el.dispatchEvent(new Event('scroll')) })
+
+    act(() => {
+      state.clientHeight = SHRUNK_CH
+      ro.fire([{ target: el } as Partial<ResizeObserverEntry>])
+    })
+
+    // A shrinking viewport must not yank a released reader to the bottom. This
+    // case already passes today (nothing fires at all) and exists so the fix
+    // for the case above cannot be written as an unconditional pin.
+    expect(el.scrollTop).toBe(1000)
+  })
+
+  it('holds position for a small scroll-up that leaves follow armed', () => {
+    const { el, state, ro } = mount('viewport-shrink-in-band')
+    expect(el.scrollTop).toBe(BOTTOM)
+
+    // 40px up — INSIDE the 100px `atBottom` band, so `stickAfterUserScroll`
+    // leaves stick ARMED even though the user is visually off the bottom. This
+    // is the sharpest state in the whole design: follow is on, the user is not
+    // at the bottom, and `lastWriteTopRef` is deliberately not re-baselined
+    // across this band (doing so would erase the only evidence of the
+    // scroll-up). It is also the state the two reverted attempts on this system
+    // both got wrong, so it is worth an explicit case.
+    act(() => { state.scrollTop = BOTTOM - 40; el.dispatchEvent(new Event('scroll')) })
+
+    act(() => {
+      state.clientHeight = SHRUNK_CH
+      ro.fire([{ target: el } as Partial<ResizeObserverEntry>])
+    })
+
+    // The pin attempt runs (stick is armed) but `evaluateAutoPin` sees the
+    // scroll-up in live geometry and releases follow WITHOUT moving anything.
+    // The reader keeps their place — same outcome the pre-existing row-resize
+    // path already produces in this state.
+    expect(el.scrollTop).toBe(BOTTOM - 40)
+  })
+})


### PR DESCRIPTION
## Problem

Chat follow silently stops when the composer grows. Type a few lines into the
message box and the transcript is no longer at the bottom — the newest message
sits below the fold and nothing brings it back until the next append. The same
happens on a composer drag-resize, when the side panel docks to the bottom, and
on a height-only window resize.

## Why it matters

This is the most frequent way follow breaks, because it fires on **keystrokes**
rather than on a rare layout event. Every added line in the composer steals
transcript height, and the reader loses the bottom of the conversation while
typing about it.

## Fix (symptom → root cause → change)

The follow pin is reachable from exactly five places: a row ResizeObserver tick,
an `itemCount` increase, a slot entry, `scrollToBottom`, and a smooth-glide
arrival. The shared ResizeObserver observed only **row** elements, and there is
no `window` resize listener — so a change in the *scroller's own* height had no
path into the hook at all:

- no row resized (content did not move),
- no item appended,
- and no `scroll` event either — shrinking the viewport RAISES the scroll
  maximum, so the browser has nothing to clamp.

The scroller is the `flex: 1` sibling above the composer, whose textarea
autosizes from 44px to 140px, so this fires constantly and is invisible.

The change observes the scroller on the **same** existing observer, classifies
its entry as a height change (width changes are ignored — those rewrap every row
and the rows report themselves), and re-pins while follow is armed. It is
deliberately not a new observer: the row back-fill contract and its regression
test rest on there being exactly one instance.

Also covers, by sharing the mechanism: the composer's drag-resize, a
bottom-docked side panel, and a height-only window resize. It does **not** cover
the mobile on-screen keyboard, which needs `visualViewport` — the browser does
not resize the scroller for it. Deliberately out of scope here.

## Tests

`website/src/test/useVirtualChat.viewportShrink.test.tsx` — four cases, written
RED before the fix:

- **observes the scroller element, not only the rows** — failed with `expected
  false to be true` before the change; the wiring guard.
- **re-pins to the new bottom when the composer steals viewport height** — failed
  with `expected 4200 to be 4296`, the exact 96px stolen.
- **does NOT chase the bottom when the user is scrolled up reading history** —
  passed throughout; stops the fix being written as an unconditional pin.
- **holds position for a small scroll-up that leaves follow armed** — the 3-100px
  in-band state where stick stays armed while the user is visually off the
  bottom. `evaluateAutoPin` releases follow without moving anything.

Mutation-checked: removing both observe sites fails case 1; dropping
`viewportResized` from the follow gate fails case 2.

`website/src/test/useVirtualChat.completionSnap.test.tsx` — two cases that PASS
on base, and say so in the header. They were written to chase a suspected
end-of-turn scroll jump on the theory that the completion snap could land against
stale computed geometry; the theory is wrong and these are the evidence, since
the pin reads live geometry and a mounted row's growth is in `scrollHeight`
immediately. Kept because the fixture is the only one in the suite that composes
`scrollHeight` from the hook's computed spacers **plus** real mounted row
heights, so it is the only test that would catch a future change routing the pin
target through `totalHeight` instead of live geometry.

`website/src/test/useVirtualChat.spacerLurch.test.tsx` — one currently-passing
test adjusted: it selected its history row as `[...ro.observed][0]`, i.e. by
position in the observed set, which now also contains the scroller. It now
selects by identity — the node it registered on the line above. No assertion
weakened; it removes a dependence on `Set` iteration order that was never part of
the assertion.

## Manual verification

N/A — unit coverage is the right instrument here. The failure is a scroll
position after a `clientHeight` change, which the fake-geometry harness models
directly and deterministically; a manual pass would be less precise than the RED
baseline recorded above.

## Screenshots

N/A — no visual surface changes. This alters scroll position over time, which a
still frame cannot show.
