### PR TITLE
fix(telegram): make the length splitter table-aware (#3010)

### DIFF
--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -52,6 +52,12 @@ _ALBUM_MAX_GROUPS = 64
 # Safe chunk boundary (leave room for markdown overhead).
 TELEGRAM_CHUNK_LIMIT = 4000
 
+#: sendRichMessage markdown payload limit (Bot API 10.1 Rich Messages). Far
+#: larger than sendMessage's 4096. The rich path carries the segment's raw
+#: markdown with no HTML render step, so source length IS payload length and
+#: table-bearing segments are budgeted against this cap, not the render cap.
+TELEGRAM_RICH_MAX_CHARS = 32768
+
 # Bot API base URL.
 _API_BASE = "https://api.telegram.org/bot{token}/{method}"
 

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Any
 from kiro_crew.constants import OPTIONS_RE_TRAILER, split_trailing_protocol_suffix
 from kiro_crew.messaging.renderer import Renderer, apply_options_cap
 from kiro_crew.messaging.transport import TransportCapabilities
+from kiro_crew.telegram.client import TELEGRAM_RICH_MAX_CHARS
 
 if TYPE_CHECKING:
     from kiro_crew.telegram.client import TelegramClient
@@ -452,6 +453,97 @@ def _split_markdown_bounded(text: str, rendered_limit: int) -> list[str]:
         chunks = _split_markdown(text, src_limit)
 
 
+def _table_blocks(text: str) -> list[tuple[bool, list[str]]]:
+    """Partition *text* into alternating ``(is_table, lines)`` blocks.
+
+    Uses the same run detection as ``_seal_table_fallback``: a table starts on
+    a pipe-bearing line whose successor is a separator row and extends while
+    lines carry a pipe. Callers must screen out fenced text first (see
+    ``_split_markdown_table_aware``).
+    """
+    lines = text.split("\n")
+    blocks: list[tuple[bool, list[str]]] = []
+    prose: list[str] = []
+    i = 0
+    while i < len(lines):
+        if "|" in lines[i] and i + 1 < len(lines) and _is_table_separator(lines[i + 1]):
+            if prose:
+                blocks.append((False, prose))
+                prose = []
+            block = [lines[i], lines[i + 1]]
+            i += 2
+            while i < len(lines) and "|" in lines[i]:
+                block.append(lines[i])
+                i += 1
+            blocks.append((True, block))
+            continue
+        prose.append(lines[i])
+        i += 1
+    if prose:
+        blocks.append((False, prose))
+    return blocks
+
+
+def _split_table_rows(rows: list[str], limit: int) -> list[str]:
+    """Split one table run at ROW boundaries into chunks of <=``limit`` chars.
+
+    Every continuation chunk repeats the header and separator row, so each
+    chunk is independently detected by ``_has_table`` and seals through the
+    rich path. The alternative (bare body rows) fails detection and arrives as
+    literal pipes -- the exact defect table-aware splitting exists to fix.
+
+    A single row longer than ``limit`` cannot be cut (there is no sub-row
+    boundary that keeps the table valid); its chunk is returned oversize and
+    the client's tag-safe truncation is the backstop.
+    """
+    header, sep = rows[0], rows[1]
+    head_len = len(header) + len(sep) + 2  # + the two joining newlines
+    chunks: list[str] = []
+    cur = [header, sep]
+    cur_len = head_len
+    for row in rows[2:]:
+        row_cost = len(row) + 1  # + the joining newline
+        if cur_len + row_cost > limit and len(cur) > 2:
+            chunks.append("\n".join(cur))
+            cur = [header, sep]
+            cur_len = head_len
+        cur.append(row)
+        cur_len += row_cost
+    chunks.append("\n".join(cur))
+    return chunks
+
+
+def _split_markdown_table_aware(text: str, rendered_limit: int, rich_limit: int) -> list[str]:
+    """Split markdown that holds at least one table, keeping table runs whole.
+
+    Table runs are atomic the way fenced code blocks are in ``_split_markdown``:
+    a cut inside one strands header-less body rows that fail table detection
+    and seal as literal pipes. Prose between tables budgets against
+    ``rendered_limit`` (it seals through the HTML path); a table run budgets
+    against ``rich_limit`` in SOURCE chars (it seals through sendRichMessage,
+    which takes the markdown unrendered) and is split at row boundaries with
+    the header repeated only when it alone exceeds that.
+
+    Fence-bearing text falls back to the fence-aware bounded splitter: deciding
+    where a fence begins and ends means reimplementing CommonMark's fence rules
+    as a second parser (the same invariant ``_seal_table_fallback`` documents),
+    and a pipe pattern inside a fence is not a table anyway.
+    """
+    if _FENCE_LINE_RE.search(text):
+        return _split_markdown_bounded(text, rendered_limit)
+    out: list[str] = []
+    for is_table, lines in _table_blocks(text):
+        block = "\n".join(lines)
+        if is_table:
+            if len(block) <= rich_limit:
+                out.append(block)
+            else:
+                out.extend(_split_table_rows(lines, rich_limit))
+        elif block.strip():
+            out.extend(_split_markdown_bounded(block, rendered_limit))
+    return [c for c in out if c.strip()]
+
+
 def _strip_md(text: str) -> str:
     """Flatten Markdown to clean plaintext for the streaming typewriter frames
     (and as the safe fallback if an HTML final edit is ever rejected) -- avoids
@@ -671,7 +763,12 @@ class TelegramRenderer(Renderer):
         Rotation triggers on the SOURCE budget or on the RENDERED HTML cap,
         whichever binds first: a segment can sit under the source budget and
         still render past Telegram's hard limit once ``html.escape`` inflates
-        it."""
+        it.
+
+        Table-bearing segments budget against the RICH cap instead: they seal
+        through sendRichMessage, so holding the whole table in one segment is
+        what keeps it one rich message rather than a rich head followed by
+        header-less pipe-text continuations."""
         limit = self._limit()
         rendered_cap = self._rendered_limit()
         raw = "".join(self._buf)
@@ -682,7 +779,36 @@ class TelegramRenderer(Renderer):
             if _rendered_len(raw) <= rendered_cap:
                 return
         raw, protocol_suffix = split_trailing_protocol_suffix(raw)
-        chunks = _split_markdown_bounded(raw, rendered_cap)
+        if _has_table(raw):
+            # Table segments seal through sendRichMessage, whose payload budget
+            # is far larger than the HTML render cap, so they are budgeted
+            # against the rich cap: a table sized to the HTML budget cuts
+            # row-wise, and its header-less continuations fail table detection
+            # and arrive as literal pipes. Under the rich cap, most tables that
+            # overflow the HTML budget fit ONE rich message and never split.
+            rich_cap = self._rich_limit()
+            if len(raw) <= rich_cap:
+                return
+            # The buffer's final line may still be STREAMING: its next token
+            # can arrive after this rotation. A partial row that has not yet
+            # received its first pipe reads as prose to the block parser (GFM
+            # rows need no outer pipe), which would strand it -- and the rest
+            # of the table -- in a header-less segment. Detach the unterminated
+            # line, split only complete lines, and keep it with the tail.
+            # _has_table guarantees at least two lines, so a newline exists.
+            head, nl, partial = raw.rpartition("\n")
+            head += nl
+            chunks = _split_markdown_table_aware(head, rendered_cap, rich_cap)
+            if chunks:
+                # Reattach what the line-joining splitter drops: the complete
+                # prefix's trailing newlines, then the unterminated line. The
+                # tail keeps streaming, so both must survive or the next
+                # streamed token glues onto the previous row.
+                chunks[-1] += head[len(head.rstrip("\n")) :] + partial
+            else:
+                chunks = [partial]
+        else:
+            chunks = _split_markdown_bounded(raw, rendered_cap)
         # Mid-stream the source fence is often still OPEN (the model has not
         # emitted its closing ``` yet). _split_markdown balances each chunk by
         # appending a synthetic closer, which is right for the chunks we seal but
@@ -799,6 +925,24 @@ class TelegramRenderer(Renderer):
             html_text = _seal_table_fallback(text)
             if len(html_text) > self._rendered_limit():
                 html_text = _md_to_telegram_html(text)
+                if len(html_text) > self._rendered_limit():
+                    # The segment was sized against the RICH budget, so it can
+                    # be several HTML messages long -- letting the client's
+                    # truncation backstop cap it would drop content. Re-split
+                    # against the HTML budget instead: header repetition keeps
+                    # every chunk of the table detected, so the whole table
+                    # degrades uniformly to <pre> rather than half-rich,
+                    # half-pipes. All chunks but the last ship here; the last
+                    # flows into the normal seal below so the keyboard lands on
+                    # the final message.
+                    chunks = self._degraded_table_chunks(text)
+                    for ch in chunks[:-1]:
+                        await self._seal_chunk_html(ch)
+                    if chunks:
+                        text = chunks[-1]
+                    html_text = _seal_table_fallback(text)
+                    if len(html_text) > self._rendered_limit():
+                        html_text = _md_to_telegram_html(text)
         else:
             html_text = _md_to_telegram_html(text)
         if self._stream_mid is not None:
@@ -971,6 +1115,90 @@ class TelegramRenderer(Renderer):
         than subtracting a second, guessed tag allowance.
         """
         return max(500, self.capabilities.max_message_chars or 4000)
+
+    def _rich_limit(self) -> int:
+        """Budget for one sendRichMessage payload, in SOURCE chars.
+
+        The rich path passes the segment's markdown through unrendered, so
+        unlike the HTML seal there is no escape inflation to measure -- source
+        length is payload length. The headroom mirrors ``_limit``'s allowance
+        for the steer chip and a reattached protocol suffix.
+        """
+        return TELEGRAM_RICH_MAX_CHARS - 256
+
+    def _degraded_table_chunks(self, text: str) -> list[str]:
+        """Split an oversize degraded segment so every chunk's RENDERED form fits.
+
+        ``_split_table_rows`` budgets source chars, but the degraded seal
+        renders through ``_seal_table_fallback`` and ``html.escape`` inflation
+        is multiplicative (see ``_may_exceed_rendered``), so a source budget
+        with fixed headroom still ships oversize chunks that the client's
+        backstop truncates -- silent row loss. Mirror
+        ``_split_markdown_bounded``: measure the worst rendered chunk and
+        shrink the source budget proportionally until everything fits or the
+        floor is reached (where content is genuinely indivisible and the
+        backstop is the last resort).
+        """
+        rendered_cap = self._rendered_limit()
+        src_cap = max(_MIN_SPLIT_LIMIT, rendered_cap - 128)
+        while True:
+            chunks = _split_markdown_table_aware(text, src_cap, src_cap)
+            worst = max((len(_seal_table_fallback(c)) for c in chunks), default=0)
+            if worst <= rendered_cap:
+                return chunks
+            if src_cap <= _MIN_SPLIT_LIMIT:
+                break
+            scaled = int(src_cap * (rendered_cap / worst) * 0.95)
+            new_cap = max(_MIN_SPLIT_LIMIT, min(scaled, src_cap - 128))
+            if new_cap >= src_cap:
+                new_cap = _MIN_SPLIT_LIMIT  # guarantee progress to the floor
+            src_cap = new_cap
+        # Floor reached with an oversize chunk: a single row exceeds the cap,
+        # and no row-boundary cut can help. Hand each offender to the bounded
+        # splitter, which cuts inside the line. Those pieces lose their table
+        # framing (they arrive as escaped text), but losing alignment on one
+        # monster row beats the client backstop truncating its tail away. The
+        # headroom covers the <pre> wrapper on any piece that stays detected.
+        out: list[str] = []
+        for c in chunks:
+            if len(_seal_table_fallback(c)) > rendered_cap:
+                out.extend(_split_markdown_bounded(c, max(_MIN_SPLIT_LIMIT, rendered_cap - 64)))
+            else:
+                out.append(c)
+        return out
+
+    async def _seal_chunk_html(self, chunk: str) -> None:
+        """Seal one leading chunk of an overflowing degraded segment as HTML.
+
+        The first chunk re-uses the streamed bubble (it is the OLDEST message,
+        so it must carry the earliest content or the reply reads out of order);
+        later chunks are fresh sends. Mirrors the tail seal's degradation
+        ladder: HTML edit -> plaintext edit, or HTML send -> plaintext send.
+        """
+        html_text = _seal_table_fallback(chunk)
+        if len(html_text) > self._rendered_limit():
+            html_text = _md_to_telegram_html(chunk)
+        if self._stream_mid is not None:
+            mid = self._stream_mid
+            self._stream_mid = None
+            ok = await self._client.edit_message(
+                self._chat_id, mid, html_text, parse_mode="HTML", retry_plain=False
+            )
+            if ok:
+                return
+            if await self._client.edit_message(self._chat_id, mid, _strip_md(chunk)):
+                return
+        mid2 = await self._client.send_message(
+            self._chat_id,
+            html_text,
+            parse_mode="HTML",
+            retry_plain=False,
+            message_thread_id=self._thread_id,
+        )
+        if mid2 is None:
+            await self._client.send_message(
+                self._chat_id, _strip_md(chunk), message_thread_id=self._thread_id
+            )
 
     def _chip_for_seal(self, i: int) -> str | None:
         """The steer chip (a "> quote" blockquote of the USER's own words) that

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -60,6 +60,8 @@ from kiro_crew.telegram.renderer import (
     _seal_table_fallback,
     _split_markdown,
     _split_markdown_bounded,
+    _split_markdown_table_aware,
+    _split_table_rows,
     _split_text,
     _strip_steering,
     build_inline_keyboard,
@@ -1882,6 +1884,267 @@ class TestRenderer:
             return len(cli.sent) - n
 
         assert asyncio.run(_go()) == 0
+
+
+# ── renderer.py: table-aware splitting + rich budget selection ──────────────
+
+
+class TestTableAwareSplitting:
+    def _renderer(self, cli: FakeClient) -> TelegramRenderer:
+        return TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+
+    def _table(self, rows: int, fill: str = "x", width: int = 80) -> str:
+        head = "| id | data |\n| --- | --- |\n"
+        return head + "".join(f"| {i:05d} | {fill * width} |\n" for i in range(rows))
+
+    def test_a_table_that_fits_one_rich_message_is_never_split(self) -> None:
+        # THE fix for the half-rich/half-pipes defect: a table that overflows
+        # the HTML budget used to be cut row-wise, stranding header-less body
+        # rows on the literal-pipe path. Sized against the rich budget it is
+        # one segment, one sendRichMessage, one rendered table.
+        cli = FakeClient()
+        r = self._renderer(cli)
+        table = self._table(120)
+        assert r._limit() < len(table) <= r._rich_limit(), (
+            "precondition: overflows the HTML budget, fits the rich budget"
+        )
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk(table)
+            await r.on_done()
+
+        asyncio.run(_go())
+
+        assert len(cli.rich_sent) == 1, "one logical table -> one rich message"
+        md = cli.rich_sent[0][0]
+        assert "| 00000 |" in md and "| 00119 |" in md, "no row lost"
+        assert _has_table(md)
+
+    def test_a_table_over_the_rich_budget_splits_into_table_detected_chunks(self) -> None:
+        # When even the rich budget overflows, cuts land at row boundaries and
+        # every continuation repeats the header + separator, so EVERY chunk is
+        # table-detected and renders rich -- never a ragged pipe-text tail.
+        cli = FakeClient()
+        r = self._renderer(cli)
+        table = self._table(300, fill="y", width=120)
+        assert len(table) > r._rich_limit(), "precondition: overflows the rich budget"
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk(table)
+            await r.on_done()
+
+        asyncio.run(_go())
+
+        assert len(cli.rich_sent) >= 2, "an over-rich-budget table needs several rich sends"
+        for md, _, _ in cli.rich_sent:
+            assert _has_table(md), "every chunk carries the header, so it seals rich"
+            assert len(md) <= r._rich_limit()
+        joined = "\n".join(md for md, _, _ in cli.rich_sent)
+        for i in (0, 150, 299):
+            assert f"| {i:05d} |" in joined, "no row lost across the chunks"
+
+    def test_an_oversize_table_degrades_uniformly_when_rich_is_unavailable(self) -> None:
+        # A segment sized against the rich budget can be several HTML messages
+        # long. When the rich send fails it must be re-split and shipped whole
+        # -- truncation would silently drop rows -- and header repetition keeps
+        # every chunk on the <pre> path, so degradation is uniform.
+        cli = FakeClient()
+        cli.rich_fails = True
+        r = self._renderer(cli)
+        table = self._table(120, fill="k", width=90)
+        assert r._limit() < len(table) <= r._rich_limit()
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk(table)
+            await r.on_done()
+
+        asyncio.run(_go())
+
+        assert cli.rich_sent == []
+        bodies = [e[1] for e in cli.edits if "<pre>" in e[1]]
+        bodies += [s[0] for s in cli.sent if "<pre>" in s[0]]
+        assert len(bodies) >= 2, "the oversize segment ships as several HTML messages"
+        joined = "\n".join(bodies)
+        for i in (0, 60, 119):
+            assert f"| {i:05d} |" in joined, "no row lost to truncation"
+        for b in bodies:
+            assert len(b) <= TELEGRAM_MAX_TEXT, "each chunk respects the hard cap"
+
+    def test_split_table_rows_repeats_the_header_on_every_chunk(self) -> None:
+        rows = ["| a | b |", "| --- | --- |"] + [f"| {i} | {'z' * 50} |" for i in range(40)]
+        chunks = _split_table_rows(rows, 600)
+        assert len(chunks) > 1
+        for c in chunks:
+            assert c.startswith("| a | b |\n| --- | --- |\n")
+            assert _has_table(c)
+            assert len(c) <= 600
+        body = "\n".join(chunks)
+        for i in range(40):
+            assert body.count(f"| {i} | ") == 1, "each row appears exactly once"
+
+    def test_split_table_rows_cannot_cut_inside_a_single_oversize_row(self) -> None:
+        # There is no sub-row boundary that keeps the table valid, so the row
+        # splitter returns it oversize; the degraded ladder is what bounds it.
+        rows = ["| a |", "| --- |", "| " + "w" * 900 + " |"]
+        chunks = _split_table_rows(rows, 400)
+        assert len(chunks) == 1
+        assert _has_table(chunks[0])
+
+    def test_a_single_monster_row_is_cut_inside_rather_than_truncated(self) -> None:
+        # A row bigger than one message has no valid row-boundary cut. The
+        # degraded ladder must cut INSIDE it (losing table framing for that row
+        # only) rather than shipping an oversize chunk the client backstop
+        # would truncate -- the tail of the row has to reach the user.
+        cli = FakeClient()
+        cli.rich_fails = True
+        r = self._renderer(cli)
+        marker_head, marker_tail = "ROWSTART", "ROWEND"
+        row = f"| {marker_head} {'v' * 6000} {marker_tail} |"
+        table = f"| a |\n| --- |\n{row}\n"
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk(table)
+            await r.on_done()
+
+        asyncio.run(_go())
+
+        bodies = [t for _, t, _ in cli.edits] + [t for t, _ in cli.sent]
+        joined = "".join(bodies)
+        assert marker_head in joined and marker_tail in joined, "both row ends survive"
+        assert joined.count("v" * 100) * 100 >= 5900, "the row body ships whole"
+        for b in bodies:
+            assert len(b) <= TELEGRAM_MAX_TEXT, "no chunk relies on backstop truncation"
+
+    def test_table_aware_split_budgets_prose_against_the_html_cap(self) -> None:
+        # Prose around a table seals through the HTML path, so it must keep the
+        # rendered budget even while the table beside it rides the rich budget.
+        prose = ("lorem ipsum dolor sit amet " * 90).strip()
+        table = "| a | b |\n| --- | --- |\n" + "\n".join(
+            f"| {i} | {'q' * 100} |" for i in range(40)
+        )
+        chunks = _split_markdown_table_aware(prose + "\n\n" + table, 1000, len(table) + 10)
+        table_chunks = [c for c in chunks if _has_table(c)]
+        assert len(table_chunks) == 1, "the table run stays atomic"
+        assert table_chunks[0] == table
+        prose_chunks = [c for c in chunks if not _has_table(c)]
+        assert prose_chunks, "the prose still ships"
+        assert all(len(_md_to_telegram_html(c)) <= 1000 for c in prose_chunks)
+
+    def test_table_aware_split_falls_back_to_the_bounded_splitter_for_fences(self) -> None:
+        # Fence-bearing text keeps the fence-aware splitter: deciding where a
+        # fence ends means growing a second CommonMark parser, and a pipe
+        # pattern inside a fence is not a table anyway.
+        text = "```\n| a | b |\n| --- | --- |\n" + "x\n" * 500 + "```"
+        assert _split_markdown_table_aware(text, 800, 32000) == _split_markdown_bounded(text, 800)
+
+    def test_non_table_content_splits_exactly_as_before(self) -> None:
+        # Regression guard for the shared sizing path: replies without a table
+        # must take the identical bounded split they always did, sealing each
+        # chunk to the same HTML the bounded splitter implies. Markup makes the
+        # sealed HTML distinguishable from plaintext live-stream frames.
+        text = "para **one**. " * 150 + "\n\n" + "para _two_! " * 250
+        assert not _has_table(text)
+        cli = FakeClient()
+        r = self._renderer(cli)
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk(text)
+            await r.on_done()
+
+        asyncio.run(_go())
+
+        assert cli.rich_sent == [], "no table -> the rich path is never touched"
+        # The seal strips the segment before rendering (pre-existing behavior),
+        # so normalize both sides the same way for the comparison.
+        expected = [
+            _md_to_telegram_html(c.strip())
+            for c in _split_markdown_bounded(text, r._rendered_limit())
+        ]
+        assert len(expected) > 1, "precondition: long enough to actually rotate"
+        finals = [t for _, t, _ in cli.edits if "<b>" in t or "<i>" in t]
+        finals += [t for t, _ in cli.sent if "<b>" in t or "<i>" in t]
+        assert sorted(finals) == sorted(expected), "sealed bodies match the bounded split"
+
+    def test_an_escape_heavy_degraded_table_is_never_truncated(self) -> None:
+        # html.escape inflation inside <pre> is multiplicative, so a degraded
+        # split that budgets SOURCE chars ships oversize chunks the client
+        # backstop truncates -- silent row loss. The re-split must measure the
+        # RENDERED form: every shipped chunk fits the cap and every row lands.
+        cli = FakeClient()
+        cli.rich_fails = True
+        r = self._renderer(cli)
+        table = self._table(100, fill="<&>", width=25)
+        assert r._limit() < len(table) <= r._rich_limit()
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk(table)
+            await r.on_done()
+
+        asyncio.run(_go())
+
+        bodies = [t for _, t, _ in cli.edits if "<pre>" in t]
+        bodies += [t for t, _ in cli.sent if "<pre>" in t]
+        assert len(bodies) >= 2
+        for b in bodies:
+            assert len(b) <= r._rendered_limit(), "every RENDERED chunk fits the cap"
+        joined = "\n".join(bodies)
+        for i in range(100):
+            assert f"| {i:05d} |" in joined, "no row lost to escape inflation"
+
+    def test_a_row_streamed_after_an_over_budget_rotation_stays_its_own_row(self) -> None:
+        # The block splitter joins lines without the buffer's trailing newline.
+        # The retained tail keeps streaming, so dropping it would glue the next
+        # streamed row onto the previous one and corrupt the table mid-stream.
+        cli = FakeClient()
+        r = self._renderer(cli)
+        table = self._table(300, fill="y", width=120)
+        assert len(table) > r._rich_limit()
+        assert table.endswith("\n")
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk(table)
+            await r.on_text_chunk("| 99999 | sentinel |\n")
+            await r.on_done()
+
+        asyncio.run(_go())
+
+        lines = [ln for md, _, _ in cli.rich_sent for ln in md.split("\n")]
+        assert "| 99999 | sentinel |" in lines, "the streamed row survives as its own line"
+        assert not any("||" in ln.replace("| |", "") for ln in lines), "no glued rows"
+
+    def test_a_partial_row_at_rotation_time_is_not_stranded_as_prose(self) -> None:
+        # GFM rows need no outer pipe, so a row whose first pipe has not
+        # streamed yet reads as prose to the block parser. A rotation firing at
+        # that instant must keep the unterminated line with the streaming tail;
+        # emitting it as a prose chunk strands it -- and the rows after it --
+        # outside the table.
+        cli = FakeClient()
+        r = self._renderer(cli)
+        head = "id | data\n--- | ---\n"
+        rows = "".join(f"{i:05d} | {'y' * 120}\n" for i in range(300))
+        assert len(head + rows) > r._rich_limit()
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            # First delivery ends mid-row, BEFORE the row's first pipe.
+            await r.on_text_chunk(head + rows + "99999")
+            await r.on_text_chunk(" | sentinel\n")
+            await r.on_done()
+
+        asyncio.run(_go())
+
+        assert len(cli.rich_sent) >= 2
+        lines = [ln for md, _, _ in cli.rich_sent for ln in md.split("\n")]
+        assert "99999 | sentinel" in lines, "the partial row finishes inside the table"
+        for md, _, _ in cli.rich_sent:
+            assert _has_table(md), "every chunk stays table-detected"
 
 
 # ── renderer.py: interactive approval decider ───────────────────────────────


### PR DESCRIPTION
## What broke

A markdown table too long for one Telegram message was cut row-wise by the length rotation before sealing (#3010). The splitter is fence-aware but not table-aware: the first chunk keeps the header + separator, is table-detected, and seals rich via `sendRichMessage`; continuation chunks hold bare body rows, fail detection, and seal through the HTML path as literal `|` characters. One logical table arrives half rich, half ragged pipes.

## What changed (splitting + budget selection only)

- **Rich budget for table segments.** New `TELEGRAM_RICH_MAX_CHARS = 32768` (`client.py`). The rich path takes the segment's markdown unrendered, so source length is payload length. `_rotate_on_length` now budgets a table-bearing segment against `_rich_limit()` (32768 − 256 headroom) instead of the ~4k HTML cap — most tables that overflow the HTML budget fit **one** rich message and are never split at all.
- **Table-aware splitter** (`_split_markdown_table_aware` + `_table_blocks` + `_split_table_rows`). A table run is atomic the way fenced code already is. When a table alone exceeds even the rich budget, cuts land **only at row boundaries** and every continuation chunk **repeats the header + separator row**, so each chunk is independently table-detected and renders rich. Prose between tables keeps the HTML render budget. The buffer's trailing newlines are reattached to the retained streaming tail so a later streamed row can't glue onto the previous one.
- **Degraded path ships whole, uniformly.** When `sendRichMessage` fails (or is latched unavailable), a rich-sized segment can span several HTML messages. `_degraded_table_chunks` re-splits with a **rendered-aware shrink loop** (measures `len(_seal_table_fallback(chunk))`, mirrors `_split_markdown_bounded`) and `_seal_chunk_html` ships every chunk — header repetition keeps every chunk on the `<pre>` path, so the whole table degrades uniformly instead of being truncated by the client backstop or arriving half-formatted. Header repetition on the fallback is a deliberate choice over suppressing rich for the whole table: it preserves rich rendering whenever the server supports it and costs one repeated header line per chunk otherwise.

## Known limits (documented in code)

- A **single row** longer than the applicable budget has no row-boundary cut point that keeps the table valid; the degraded ladder cuts inside it with the bounded splitter, so the row loses its table framing (escaped text pieces) but ships whole -- nothing is left to the truncation backstop.
- **Fence-bearing segments** keep the fence-aware bounded splitter — the same no-second-CommonMark-parser invariant `_seal_table_fallback` documents. Such mixed segments keep today's behavior.
- Budget selection does not consult the client's learned rich availability; on a permanently rich-less server the degraded multi-message ladder handles it without data loss.

## What was verified

- Fail-before reproduced on unmodified source (1 rich message + 3 stranded pipe-text messages → 1 rich message, nothing stranded).
- 11 new tests (`TestTableAwareSplitting`): fits-one-rich-message not split; over-rich-budget tables produce chunks that are each table-detected with no row lost; escape-heavy degraded tables never truncated (fail-before: worst rendered 14,572 chars vs 4,000 cap under the old source-budget split); row streamed after an over-budget rotation stays its own row; header repetition and oversize-row floor unit tests; prose budget, fence fallback, and an exact-body regression guard that non-table content splits identically to before.
- Full telegram suite 269/269; isort/flake8 clean on touched files; mypy delta zero vs main; brand gate clean.
- Pre-push review fleet: GPT 5.6 Sol + Opus 5. Both converged on one blocking finding (degraded re-split budgeted source chars, so escape inflation could truncate) — fixed with the rendered-aware shrink loop plus a regression test. Advisory fixes applied: mid-stream trailing-newline glue, weak regression test strengthened, comment tense, test line length.

Renderer HTML escaping and the rich-message API surface are unchanged.

Closes #3010

