### PR TITLE
fix(installer): bound interpreter probe with POSIX watchdog for macOS

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -143,9 +143,41 @@ fi
 
 _py_usable() {
   command -v "$1" >/dev/null 2>&1 || return 1
-  # Unquoted on purpose: expands to two words, or to nothing when unavailable.
-  # shellcheck disable=SC2086
-  $_PY_PROBE_TIMEOUT "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null
+  if [ -n "$_PY_PROBE_TIMEOUT" ]; then
+    # Unquoted on purpose: expands to two words, or to nothing when unavailable.
+    # shellcheck disable=SC2086
+    $_PY_PROBE_TIMEOUT "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null
+    return $?
+  fi
+  # No `timeout` binary (stock macOS): emulate the same 5s bound with a POSIX
+  # watchdog, so a wedged version-manager shim still fails over to the next
+  # candidate instead of hanging the install on its first probe.
+  "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' >/dev/null 2>&1 &
+  _py_pid=$!
+  (
+    # On TERM from the fast-exit path below, kill our own in-flight `sleep`
+    # before exiting: a plain kill on this subshell cannot reach its child,
+    # which would otherwise linger for up to a second. kill -9 is untrappable,
+    # so the parent must TERM us for this cleanup to run.
+    trap 'kill "${_wd_sleep:-}" 2>/dev/null || true; exit 0' TERM
+    _i=0
+    while [ "$_i" -lt 5 ]; do
+      sleep 1 & _wd_sleep=$!
+      wait "$_wd_sleep" 2>/dev/null || true
+      kill -0 "$_py_pid" 2>/dev/null || exit 0
+      _i=$((_i + 1))
+    done
+    kill -9 "$_py_pid" 2>/dev/null || true
+  ) &
+  _watchdog_pid=$!
+  # Capture the probe's real exit status: a plain `wait ... || true` would
+  # overwrite $? and report every candidate as usable. 137 (killed by the
+  # watchdog) and 1 (version too old) must both read as "not usable".
+  _py_status=0
+  wait "$_py_pid" 2>/dev/null || _py_status=$?
+  kill "$_watchdog_pid" 2>/dev/null || true
+  wait "$_watchdog_pid" 2>/dev/null || true
+  return "$_py_status"
 }
 
 # Resolve the newest supported interpreter into PY (left empty if none found).

--- a/test/test_installer_distro.py
+++ b/test/test_installer_distro.py
@@ -48,6 +48,7 @@ def _run_cli_with_fake_env(
     *,
     managers: list[str],
     interpreters: dict[str, str] | None = None,
+    with_timeout: bool = True,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
     """Run cli.sh with a PATH that has NO python3 and only the named package
     managers (each a stub that records its name and args). Returns the process
@@ -82,8 +83,10 @@ def _run_cli_with_fake_env(
                   "tr", "head", "cut", "dirname", "basename", "uname", "sleep",
                   # cli.sh bounds its interpreter probe with `timeout` when one
                   # exists, so the isolated PATH must expose it for that guard
-                  # to be exercised here at all.
-                  "timeout"):
+                  # to be exercised here at all. ``with_timeout=False`` models a
+                  # stock macOS (no coreutils `timeout`), forcing the POSIX
+                  # watchdog fallback instead.
+                  *(("timeout",) if with_timeout else ())):
         _link_real(_util)
 
     # A manager "under test" is an EXECUTABLE stub that records its args. The
@@ -185,6 +188,50 @@ def test_cli_fails_over_from_a_wedged_interpreter_candidate(tmp_path: Path) -> N
 
     combined = result.stdout + result.stderr
     assert "Python >=3.10 is required" not in combined, combined
+
+
+def test_cli_bounds_wedged_interpreter_without_timeout_binary(tmp_path: Path) -> None:
+    """Stock macOS ships no coreutils `timeout`; the POSIX watchdog must bound
+    the probe there too.
+
+    Same wedged-shim scenario as above, but with `timeout` absent from PATH.
+    Before the watchdog existed, cli.sh simply ran the probe unbounded in this
+    configuration, so the hanging python3.12 shim wedged the install forever.
+    """
+    result, _markers = _run_cli_with_fake_env(
+        tmp_path,
+        managers=["apt-get"],
+        with_timeout=False,
+        interpreters={
+            "python3.12": "#!/bin/sh\nexec sleep 300\n",
+            "python3": (
+                "#!/bin/sh\n"
+                'case "$*" in\n'
+                "  *version_info*) exit 0 ;;\n"  # a supported interpreter
+                "  *--version*) echo 'Python 3.12.0' ;;\n"
+                "  *) exit 0 ;;\n"
+                "esac\n"
+            ),
+        },
+    )
+
+    combined = result.stdout + result.stderr
+    assert "Python >=3.10 is required" not in combined, combined
+
+
+def test_cli_watchdog_path_still_rejects_too_old_interpreters(tmp_path: Path) -> None:
+    """The watchdog fallback must propagate the probe's REAL exit status.
+
+    With `timeout` absent, every candidate is the default too-old stub (exits 1
+    at the version gate). If the watchdog path swallowed that status, cli.sh
+    would accept Python 3.6 as usable and skip the distro-install branch; the
+    apt-get marker proves the "no usable python" path was taken instead.
+    """
+    result, markers = _run_cli_with_fake_env(
+        tmp_path, managers=["apt-get"], with_timeout=False
+    )
+
+    assert (markers / "apt-get").exists(), result.stderr
 
 
 def test_cli_uses_apt_on_debian_ubuntu(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem / Motivation
Resolves #3136. cli.sh bounds its Python interpreter probe with coreutils `timeout`, but stock macOS ships no `timeout` binary. In that configuration the probe ran unbounded, so a wedged version-manager shim (mise / pyenv / asdf) on the FIRST candidate (`python3.12`) hung the entire install forever and leaked a spinning orphan process.

## Why it matters
The published one-liner `curl … cli.sh | sh` is the primary install path for macOS users. Any macOS machine with a misconfigured Python shim gets an indefinite hang with no error message -- the worst possible first-run experience -- while the same machine with coreutils installed recovers in 5 seconds.

## What changed
- `cli.sh`: when `timeout` is absent (`$_PY_PROBE_TIMEOUT` empty), emulate the same 5s bound with a pure-POSIX watchdog: run the probe in the background, race it against a `sleep 1` loop subshell that kills it after 5s, and propagate the probe's real exit status (a plain `wait || true` would clobber `$?` and accept too-old interpreters). PIDs quoted and the watchdog subshell reaped for `set -eu` hygiene.
- Kept main's `timeout 5` fast path untouched -- the watchdog covers only the no-`timeout` branch.

## Tests
- `test_cli_bounds_wedged_interpreter_without_timeout_binary`: wedged-shim scenario with `timeout` absent from the isolated PATH -- the probe must bound at ~5s and fail over to the usable `python3` below it (the PR's core behavior, previously untested).
- `test_cli_watchdog_path_still_rejects_too_old_interpreters`: with `timeout` absent, too-old (<3.10) stubs must still route to the distro-install branch -- proves exit-status propagation (fails against the unfixed watchdog).
- Existing installer suites (`test_installer_distro`, `test_installer_shim_and_cleanup`, `test_cli_manifest_signature`; 81 tests) pass locally; `sh -n cli.sh` clean.
