### PR TITLE
feat(cron): perpetual-agent foundations — reachable wake budget + transient retry

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1155,6 +1155,13 @@ Examples:
     cron_update.add_argument("--name", help="New job name")
     cron_update.add_argument("--message", help="New message")
     cron_update.add_argument("--every", type=int, dest="every_secs", help="New interval in seconds")
+    cron_update.add_argument(
+        "--timeout-secs",
+        type=int,
+        dest="timeout_secs",
+        default=None,
+        help="Per-wake execution budget in seconds (1..86400, default 1800)",
+    )
     cron_update.add_argument("--cron", dest="cron_expr", help="New cron expression")
     cron_update.add_argument("--channel", help="New channel ID")
     cron_update.add_argument(

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -878,7 +878,7 @@ def _cron(args: argparse.Namespace) -> None:
 
     elif action == "update":
         kwargs: dict = {}
-        for field in ("name", "message", "every_secs", "cron_expr", "channel"):
+        for field in ("name", "message", "every_secs", "cron_expr", "channel", "timeout_secs"):
             val = getattr(args, field, None)
             if val is not None:
                 if field == "channel":
@@ -909,7 +909,11 @@ def _cron(args: argparse.Namespace) -> None:
         if "every_secs" in kwargs and "cron_expr" in kwargs:
             print("Provide --every or --cron, not both")
             return
-        updated = svc.update_job(args.job_id, **kwargs)
+        try:
+            updated = svc.update_job(args.job_id, **kwargs)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
         if updated:
 
             audit_resources = f"job_id={args.job_id} fields={','.join(sorted(kwargs))}"

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -110,6 +110,11 @@ def referenced_skill_names() -> set[str]:
 _STORE_VERSION = 2
 _MIN_INTERVAL_SECS = 60
 _JOB_TIMEOUT_SECS = 1800  # 30 min per job
+# Margin the per-wake budget must leave above a command/script subprocess
+# timeout: the wake deadline cancels only the executor FUTURE (threads are
+# not interruptible), so a budget shorter than the subprocess bound leaves
+# the subprocess running while the guards clear and later wakes duplicate it.
+_SUBPROC_CLEANUP_ALLOWANCE_SECS = 5
 _TIMER_POLL_SECS = 30  # check for due cron-expr jobs
 _AUTO_PAUSE_THRESHOLD = 5  # consecutive failures before a script/command cron auto-pauses
 _REAPER_INTERVAL = 60  # seconds between reaper sweeps
@@ -1178,6 +1183,7 @@ class CronService:
         session_key: str = "",
         minimal_context: bool = False,
         timeout: int = 0,
+        timeout_secs: int = 0,
     ) -> CronJob:
         """Add a new job. Provide one of ``every_secs``, ``at_ts``, or ``cron_expr``.
 
@@ -1236,6 +1242,7 @@ class CronService:
             session_key=session_key,
             minimal_context=minimal_context,
             timeout=timeout,
+            timeout_secs=timeout_secs,
         )
         self._persist_add_locked(job)
         self._arm_timer()
@@ -1330,12 +1337,18 @@ class CronService:
         session_key: str = "",
         minimal_context: bool = False,
         timeout: int = 0,
+        timeout_secs: int = 0,
     ) -> CronJob:
         """Validate inputs and construct the :class:`CronJob` (no I/O, no lock).
 
         Shared by :meth:`add_job` and :meth:`add_job_async` so both perform
         identical validation on the event loop before any disk work. Raises
         ``ValueError`` on an invalid schedule or approval mode.
+
+        ``timeout_secs`` is the per-wake execution budget (the
+        ``asyncio.wait_for`` deadline in ``_execute_with_timeout``); ``0`` means
+        the ``_JOB_TIMEOUT_SECS`` default. Distinct from ``timeout``, which
+        bounds only script/command subprocesses.
 
         The optional presentation/routing fields (``agent_id``, ``model``,
         ``silent``, ``timezone``, ``strict_schedule``, ``hide_in_chat``) are set
@@ -1347,6 +1360,19 @@ class CronService:
         valid_approval_modes = ("", "auto")
         if approval_mode not in valid_approval_modes:
             raise ValueError(f"Invalid approval_mode: {approval_mode!r}")
+        if timeout_secs and not 1 <= int(timeout_secs) <= 86400:
+            raise ValueError(f"timeout_secs must be within 1..86400, got {timeout_secs}")
+        if timeout_secs and (command or script):
+            _eff_sub = int(timeout) if timeout else (30 if script else 300)
+            if int(timeout_secs) < _eff_sub + _SUBPROC_CLEANUP_ALLOWANCE_SECS:
+                raise ValueError(
+                    "timeout_secs (wake budget) must cover the command/script "
+                    f"subprocess timeout plus cleanup: need >= "
+                    f"{_eff_sub + _SUBPROC_CLEANUP_ALLOWANCE_SECS}, got {timeout_secs}. "
+                    "A shorter wake budget cancels only the executor future — "
+                    "the subprocess keeps running while the next wake launches "
+                    "a duplicate."
+                )
         if timezone and not is_valid_timezone(timezone):
             raise ValueError(f"Invalid timezone: {timezone!r}")
         skip_dates = skip_dates or []
@@ -1393,6 +1419,7 @@ class CronService:
             session_key=session_key,
             minimal_context=minimal_context,
             timeout=timeout,
+            timeout_secs=int(timeout_secs) if timeout_secs else _JOB_TIMEOUT_SECS,
         )
 
     def _persist_add_locked(self, job: CronJob) -> None:
@@ -1437,6 +1464,7 @@ class CronService:
         session_key: str = "",
         minimal_context: bool = False,
         timeout: int = 0,
+        timeout_secs: int = 0,
     ) -> CronJob:
         """Event-loop-safe :meth:`add_job`: the lock+save runs off the loop.
 
@@ -1483,6 +1511,7 @@ class CronService:
             session_key=session_key,
             minimal_context=minimal_context,
             timeout=timeout,
+            timeout_secs=timeout_secs,
         )
         await asyncio.to_thread(self._persist_add_locked, job)
         self._arm_timer()
@@ -1493,7 +1522,8 @@ class CronService:
         """Update fields on an existing job. Returns updated job or None if not found.
 
         Accepted kwargs: name, message, every_secs, cron_expr, agent_id, channel,
-        approval_mode, silent, skip_dates, timezone, thread_ts, model.
+        approval_mode, silent, skip_dates, timezone, thread_ts, model,
+        timeout_secs (per-wake execution budget, 1..86400).
 
         Raises :class:`CronStoreBusy` if the store lock is contended past the
         timeout; see :meth:`update_job_async` for the event-loop-safe variant.
@@ -1568,6 +1598,56 @@ class CronService:
                     for _d in kwargs["skip_dates"]:
                         if not is_valid_skip_date(_d):
                             raise ValueError(f"Invalid skip_date: {_d!r} (expected YYYY-MM-DD)")
+                # Per-wake budget and subprocess timeout: validated HERE, in
+                # the pre-mutation section with every other check, so a
+                # rejected update cannot leave earlier field mutations (name,
+                # message, ...) stranded on the in-memory job for a later
+                # save to persist. Assignments happen below with the rest.
+                _tsecs: int | None = None
+                if "timeout_secs" in kwargs and kwargs["timeout_secs"] is not None:
+                    try:
+                        _tsecs = int(kwargs["timeout_secs"])
+                    except (ValueError, TypeError) as e:
+                        raise ValueError(
+                            f"Invalid timeout_secs: {kwargs['timeout_secs']!r}"
+                        ) from e
+                    if not 1 <= _tsecs <= 86400:
+                        raise ValueError(
+                            f"timeout_secs must be within 1..86400, got {_tsecs}"
+                        )
+                # Script/command subprocess timeout. MCP cron_update has passed
+                # this since the field existed, but no branch consumed it — the
+                # update was accepted and silently dropped.
+                _tsub: int | None = None
+                if "timeout" in kwargs and kwargs["timeout"] is not None:
+                    try:
+                        _tsub = int(kwargs["timeout"])
+                    except (ValueError, TypeError) as e:
+                        raise ValueError(f"Invalid timeout: {kwargs['timeout']!r}") from e
+                    if not 0 <= _tsub <= 86400:
+                        raise ValueError(f"timeout must be within 0..86400, got {_tsub}")
+                # Cross-field: the wake budget must cover the subprocess bound
+                # plus cleanup, evaluated on the POST-update effective values —
+                # the wake deadline cancels only the executor future, so a
+                # shorter budget leaves the subprocess running while later
+                # wakes launch duplicates.
+                if job.command or job.script:
+                    _eff_secs = _tsecs if _tsecs is not None else job.timeout_secs
+                    _eff_sub_new = _tsub if _tsub is not None else job.timeout
+                    _eff_sub = (
+                        int(_eff_sub_new)
+                        if _eff_sub_new
+                        else (30 if job.script else 300)
+                    )
+                    if (_tsecs is not None or _tsub is not None) and _eff_secs < (
+                        _eff_sub + _SUBPROC_CLEANUP_ALLOWANCE_SECS
+                    ):
+                        raise ValueError(
+                            "timeout_secs (wake budget) must cover the "
+                            "command/script subprocess timeout plus cleanup: "
+                            f"need >= {_eff_sub + _SUBPROC_CLEANUP_ALLOWANCE_SECS}, "
+                            f"got {_eff_secs}"
+                        )
                 if "name" in kwargs and kwargs["name"]:
                     job.name = kwargs["name"]
                 if "message" in kwargs and kwargs["message"]:
@@ -1596,6 +1676,18 @@ class CronService:
                     job.folder_id = kwargs["folder_id"] or ""
                 if "model" in kwargs:
                     job.model = str(kwargs["model"] or "").strip()
+                # Per-wake budget (the asyncio.wait_for deadline in
+                # _execute_with_timeout). Distinct from ``timeout``, which
+                # bounds only script/command subprocesses. Until this branch
+                # existed the field was read, clamped and persisted but
+                # unreachable through every public writer — a job could only
+                # ever carry the creation-time default (Phase 0, Intervention
+                # 2: the operator had to edit the store under _file_lock by
+                # hand to keep an agent alive).
+                if _tsecs is not None:
+                    job.timeout_secs = _tsecs
+                if _tsub is not None:
+                    job.timeout = _tsub
 
                 # Schedule changes (already validated above)
                 if "cron_expr" in kwargs and kwargs["cron_expr"]:

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -1111,6 +1111,14 @@ def _list_tools() -> list[dict[str, Any]]:
                         "Defaults: 30s for scripts, 300s for commands. "
                         "Set higher for long-running tasks.",
                     },
+                    "timeout_secs": {
+                        "type": "integer",
+                        "description": "Per-wake execution budget in seconds "
+                        "(1..86400; the asyncio deadline for one run of this "
+                        "job, default 1800). Distinct from 'timeout', which "
+                        "bounds only script/command subprocesses. Raise it for "
+                        "agents whose single wake legitimately outgrows 30 min.",
+                    },
                 },
                 "required": ["name"],
             },
@@ -1126,6 +1134,20 @@ def _list_tools() -> list[dict[str, Any]]:
                     "message": {"type": "string", "description": "New message"},
                     "cron_expr": {"type": "string", "description": "New cron expression"},
                     "every": {"type": "integer", "description": "New interval in seconds (min 60)"},
+                    "timeout": {
+                        "type": "integer",
+                        "description": "Script/command subprocess timeout in "
+                        "seconds (0..86400; 0 = defaults: 30s script, 300s "
+                        "command).",
+                    },
+                    "timeout_secs": {
+                        "type": "integer",
+                        "description": "Per-wake execution budget in seconds "
+                        "(1..86400; the asyncio deadline for one run of this "
+                        "job, default 1800). Distinct from 'timeout', which "
+                        "bounds only script/command subprocesses. Raise it for "
+                        "jobs whose single run legitimately outgrows 30 min.",
+                    },
                     "agent": {"type": "string", "description": "New agent name"},
                     "channel": {"type": "string", "description": "New channel ID"},
                     "thread_ts": {
@@ -1543,6 +1565,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         hide_in_chat = args.get("hide_in_chat")
         strict_schedule = args.get("strict_schedule")
         timeout_val = args.get("timeout", 0)
+        timeout_secs_val = args.get("timeout_secs", 0)
         try:
             job = svc.add_job(
                 name=n,
@@ -1569,6 +1592,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                 session_key=session_key,
                 minimal_context=minimal_context if isinstance(minimal_context, bool) else False,
                 timeout=timeout_val or 0,
+                timeout_secs=timeout_secs_val or 0,
             )
         except CronStoreBusy:
             return "Error: cron store busy, please retry"
@@ -1646,6 +1670,8 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             kwargs["every_secs"] = args["every"]
         if "timeout" in args:
             kwargs["timeout"] = args["timeout"]
+        if "timeout_secs" in args:
+            kwargs["timeout_secs"] = args["timeout_secs"]
         if not kwargs:
             return "Error: no fields to update"
         try:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -147,9 +147,11 @@ from kiro_crew.learn import LessonStore
 from kiro_crew.llm_helpers import (
     PromptBusyExhaustedError,
     ToolApprovalPolicy,
+    acp_error_is_transient,
     provider_last_turn_usage,
     save_conversation_turn_off_loop,
     stream_and_collect,
+    transient_retry_delay,
 )
 from kiro_crew.mcp_cron import vet_job_at_fire_time
 from kiro_crew.mcp_gateway import is_gateway_supported
@@ -311,6 +313,11 @@ def _digest_chunk_size() -> int:
 
 
 SUBAGENT_DIGEST_CHUNK_SIZE = _digest_chunk_size()
+
+# Whole-callback transient retries for the cron LLM path (session acquire /
+# client creation / context assembly), mirroring the subagent path's budget.
+# In-stream transient errors are retried separately by stream_and_collect.
+_CRON_TRANSIENT_RETRIES = 2
 
 logger = logging.getLogger(__name__)
 
@@ -2222,6 +2229,12 @@ class GatewayOrchestrator:
                     )
 
         async def _cron_callback(job: CronJob) -> str | None:
+            # True once ANY prompt has been handed to the provider this
+            # invocation. The whole-callback transient retry below is only
+            # safe BEFORE dispatch: after it, tools may have run, so a
+            # resubmit risks duplicate side effects (in-stream transient
+            # errors are stream_and_collect's own retry's job).
+            _prompt_dispatched = False
             # helper picks stable vs ephemeral session key and
             # decides whether to prepend last_result, based on job.persistent_session.
             session_key, msg = build_cron_session_context(job)
@@ -2709,6 +2722,7 @@ class GatewayOrchestrator:
                         # Brackets only the model turn — session acquisition and
                         # the episodic-query embed above are setup, not the turn.
                         _turn_t0 = time.monotonic()
+                        _prompt_dispatched = True
                         result_text = await stream_and_collect(
                             client,
                             full_message,
@@ -2836,6 +2850,7 @@ class GatewayOrchestrator:
                 # above. acp reports no duration, so this is the row's fallback.
                 _turn_t0 = time.monotonic()
                 _gate = _GateTally()
+                _prompt_dispatched = True
                 result_text = await stream_and_collect(
                     client,
                     full_message,
@@ -3103,6 +3118,63 @@ class GatewayOrchestrator:
                         pass  # retry failed — fall through to dedup + alert
                     finally:
                         job._acp_retried = False  # type: ignore[attr-defined]
+                # ── Transient backend errors: retry the whole callback with ──
+                # backoff instead of counting a failure. stream_and_collect's
+                # in-stream retry only covers errors raised INSIDE the prompt
+                # stream; a throttle/5xx during session acquire, client
+                # creation, or context assembly propagates here and — before
+                # this branch existed — went straight to record_failure(),
+                # marching consecutive_failures toward auto-pause (threshold
+                # 5) on pure infrastructure weather. The subagent path has
+                # retried these 3x with backoff since it existed; this brings
+                # the cron path to the same semantics (Phase 0, Finding 1:
+                # five throttled wakes would silently auto-pause a healthy
+                # perpetual agent).
+                #
+                # Guarded by the same recursion marker pattern as the ACP
+                # retry: the attempt counter lives on the job for the duration
+                # of the outermost invocation only, and the recursive call
+                # re-enters the full callback so a retry that succeeds runs
+                # the complete delivery path.
+                if acp_error_is_transient(exc) and not _prompt_dispatched:
+                    _t_attempt = getattr(job, "_transient_attempts", 0)
+                    if _t_attempt < _CRON_TRANSIENT_RETRIES:
+                        job._transient_attempts = _t_attempt + 1  # type: ignore[attr-defined]
+                        _delay = transient_retry_delay(_t_attempt + 1)
+                        logger.warning(
+                            "Cron '%s': transient backend error (attempt %d/%d), "
+                            "retrying in %.1fs: %s",
+                            job.name,
+                            _t_attempt + 1,
+                            _CRON_TRANSIENT_RETRIES,
+                            _delay,
+                            exc,
+                        )
+                        # The backoff sleep AND the recursive call live inside
+                        # the counter-owning try/finally: a wake-budget
+                        # cancellation (asyncio.wait_for) landing in the sleep
+                        # would otherwise strand the just-consumed attempt on
+                        # the in-memory job, and later wakes would start with
+                        # fewer (or zero) retries.
+                        try:
+                            try:
+                                if _acquired and self.sessions is not None:
+                                    self.sessions.release(session_key)
+                                    _acquired = False
+                            except Exception:
+                                logger.debug(
+                                    "release before transient retry failed", exc_info=True
+                                )
+                            await asyncio.sleep(_delay)
+                            return await _cron_callback(job)
+                        finally:
+                            # Outermost frame owns the counter: clear it once
+                            # the retry chain unwinds — success, failure, or
+                            # cancellation.
+                            if _t_attempt == 0:
+                                job._transient_attempts = 0  # type: ignore[attr-defined]
+                    # Retries exhausted — fall through to dedup + alert +
+                    # record_failure: a persistent outage should still count.
                 logger.exception("Cron job '%s' failed", job.name)
                 # During an in-flight ACP retry (inner recursive _cron_callback
                 # call), suppress all notify/slack/dedup work — the outer

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2100,6 +2100,7 @@ CRON_ADD_SCHEMA = ToolSchema(
         ),
         FieldSpec("command", str, max_len=5000, pattern=re.compile(r"^[^\x00-\x1f\x7f]*$")),
         FieldSpec("timeout", int, min_val=0, max_val=3600),
+        FieldSpec("timeout_secs", int, min_val=1, max_val=86400),
     ],
     custom_validator=_validate_cron_add_requires_message_or_script,
 )
@@ -2445,6 +2446,8 @@ MCP_CRON_SCHEMAS: dict[str, ToolSchema] = {
             FieldSpec("persistent_session", bool),
             FieldSpec("minimal_context", bool),
             FieldSpec("hide_in_chat", bool),
+            FieldSpec("timeout", int, min_val=0, max_val=3600),
+            FieldSpec("timeout_secs", int, min_val=1, max_val=86400),
         ],
     ),
     "cron_remove": CRON_REMOVE_SCHEMA,

--- a/test/test_cron_wake_budget.py
+++ b/test/test_cron_wake_budget.py
@@ -1,0 +1,430 @@
+"""Tests for the per-wake budget knob (timeout_secs) and cron transient retry.
+
+Phase 1 foundations for perpetual agents (RFC rev 3, items 2 and 3):
+
+- ``timeout_secs`` (the asyncio deadline for one run) was read, clamped and
+  persisted but absent from every public mutation path — a job could only ever
+  carry the creation-time default. These tests pin it reachable through
+  ``add_job`` and ``update_job`` with validation.
+- ``timeout`` (script/command subprocess bound) was accepted by MCP
+  ``cron_update`` but silently dropped by ``_update_job_locked``; now consumed.
+- A transient backend error raised OUTSIDE the prompt stream (session acquire /
+  client creation) used to go straight to ``record_failure()``, marching a
+  healthy job toward auto-pause on infrastructure weather (Phase 0, Finding 1).
+  The callback now retries with backoff, mirroring the subagent path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Callable
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.acp.client import AcpError
+from kiro_crew.cron import _JOB_TIMEOUT_SECS, CronJob, CronSchedule, CronService
+
+
+class TestWakeBudgetKnob:
+    """timeout_secs must be settable at creation and by update, with bounds."""
+
+    def test_add_job_default(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="t", message="m", every_secs=300)
+        assert job.timeout_secs == _JOB_TIMEOUT_SECS
+
+    def test_add_job_explicit(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="t", message="m", every_secs=300, timeout_secs=3000)
+        assert job.timeout_secs == 3000
+        # Persisted, not just in-memory: reload from disk.
+        svc2 = CronService(base_dir=tmp_path)
+        svc2._load()
+        assert svc2.list_jobs()[0].timeout_secs == 3000
+
+    def test_add_job_rejects_out_of_range(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        with pytest.raises(ValueError, match="timeout_secs"):
+            svc.add_job(name="t", message="m", every_secs=300, timeout_secs=86401)
+
+    def test_update_job_sets_and_persists(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="t", message="m", every_secs=300)
+        updated = svc.update_job(job.id, timeout_secs=3000)
+        assert updated is not None
+        assert updated.timeout_secs == 3000
+        svc2 = CronService(base_dir=tmp_path)
+        svc2._load()
+        assert svc2.list_jobs()[0].timeout_secs == 3000
+
+    @pytest.mark.parametrize("bad", [0, -1, 86401])
+    def test_update_job_rejects_out_of_range(self, tmp_path: Path, bad: int) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="t", message="m", every_secs=300)
+        with pytest.raises(ValueError, match="timeout_secs"):
+            svc.update_job(job.id, timeout_secs=bad)
+        # Unchanged after the rejected update.
+        assert svc.list_jobs()[0].timeout_secs == _JOB_TIMEOUT_SECS
+
+    def test_update_job_rejects_non_int(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="t", message="m", every_secs=300)
+        with pytest.raises(ValueError, match="timeout_secs"):
+            svc.update_job(job.id, timeout_secs="soon")
+
+    def test_update_job_none_is_noop(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="t", message="m", every_secs=300, timeout_secs=3000)
+        updated = svc.update_job(job.id, timeout_secs=None, name="renamed")
+        assert updated is not None
+        assert updated.timeout_secs == 3000
+        assert updated.name == "renamed"
+
+    def test_runtime_deadline_reads_updated_value(self, tmp_path: Path) -> None:
+        """_execute_with_timeout derives its deadline from the updated field."""
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="t", message="m", every_secs=300)
+        svc.update_job(job.id, timeout_secs=2)
+        target = svc.list_jobs()[0]
+
+        async def _slow(_job: CronJob) -> None:
+            await asyncio.sleep(30)
+
+        svc._on_job = _slow
+
+        async def _run() -> None:
+            await asyncio.wait_for(svc._execute_with_timeout(target), timeout=10)
+
+        asyncio.run(_run())
+        assert target.last_status == "error"
+        assert "Timed out after 2s" in (target.last_error or "")
+
+
+class TestSubprocessTimeoutUpdate:
+    """The 'timeout' field (script/command bound) is now consumed by update."""
+
+    def test_update_job_sets_timeout(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="t", message="m", every_secs=300, command="true")
+        updated = svc.update_job(job.id, timeout=600)
+        assert updated is not None
+        assert updated.timeout == 600
+
+    def test_update_job_rejects_bad_timeout(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="t", message="m", every_secs=300, command="true")
+        with pytest.raises(ValueError, match="timeout"):
+            svc.update_job(job.id, timeout=-5)
+
+
+@pytest.fixture
+def gw_and_cb() -> tuple[Any, Callable[[], Any], Callable[..., Any]]:
+    """GatewayOrchestrator with mocked sessions; capture the cron callback.
+
+    Mirrors test_cron_acp_retry.py's fixture (uses __new__ to bypass
+    __init__). Update both if GatewayOrchestrator gains required attributes.
+    """
+    from kiro_crew.slack.gateway import GatewayOrchestrator
+
+    gw = GatewayOrchestrator.__new__(GatewayOrchestrator)
+    gw.sessions = MagicMock()
+    gw.sessions.get_pid = MagicMock(return_value=None)
+    gw.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), True, False))
+    gw.sessions.release = MagicMock()
+    gw.sessions.reset = AsyncMock()
+    gw.ctx_builder = MagicMock()
+    gw.ctx_builder.build_message = MagicMock(return_value=("msg", None))
+    gw.ctx_builder.hooks = MagicMock()
+    gw.slack = None
+    gw.conv_log = None
+    gw.dashboard_state = None
+    gw._owner_id = "U000"
+    gw.subagent_mgr = None
+    gw._cron_injecting = {}
+    gw._no_crons = False
+    gw._interactive_approval = MagicMock(return_value="interactive_cb")
+
+    captured_cb: list[Any] = [None]
+
+    def capture_cron(on_job: Any = None, **kw: Any) -> MagicMock:
+        captured_cb[0] = on_job
+        svc = MagicMock()
+        svc.start = AsyncMock()
+        return svc
+
+    return gw, lambda: captured_cb[0], capture_cron
+
+
+def _job(jid: str = "j1") -> CronJob:
+    return CronJob(
+        id=jid,
+        name="t-" + jid,
+        message="msg",
+        schedule=CronSchedule(kind="every", every_secs=60),
+    )
+
+
+def _transient_err(msg: str = "Bedrock ThrottlingException: rate exceeded") -> AcpError:
+    err = AcpError(msg)
+    err.transient = True  # structured verdict, the authoritative path
+    return err
+
+
+class TestCronTransientRetry:
+    """Pre-dispatch transient errors retry the callback instead of counting.
+
+    The retry is deliberately restricted to failures raised BEFORE the prompt
+    is handed to the provider (session acquire / client creation): after
+    dispatch, tools may already have executed, so a whole-callback resubmit
+    risks duplicating their side effects. In-stream transient errors are
+    stream_and_collect's own retry's job.
+    """
+
+    def _run(
+        self,
+        gw_and_cb: tuple[Any, Any, Any],
+        job: CronJob,
+        *,
+        get_or_create: Any,
+        mock_stream: Any,
+    ) -> Any:
+        gw, get_cb, capture_cron = gw_and_cb
+        gw.sessions.get_or_create = get_or_create
+        with (
+            patch("kiro_crew.slack.gateway.stream_and_collect", side_effect=mock_stream),
+            patch("kiro_crew.slack.gateway.redact_exfiltration_urls", return_value=("", False)),
+            patch("kiro_crew.slack.gateway.redact_credentials", return_value=("", False)),
+            patch(
+                "kiro_crew.slack.gateway.CronService.create",
+                new=AsyncMock(side_effect=capture_cron),
+            ),
+            patch("kiro_crew.slack.gateway.transient_retry_delay", return_value=0.0),
+        ):
+
+            async def _init_and_run() -> Any:
+                await gw._init_cron()
+                cb = get_cb()
+                assert cb is not None
+                return await cb(job)
+
+            return asyncio.run(_init_and_run())
+
+    def test_pre_dispatch_transient_error_retries_and_recovers(
+        self, gw_and_cb: tuple[Any, Any, Any]
+    ) -> None:
+        """A throttle during session acquire recovers on the retry, no count."""
+        acquire_calls = 0
+
+        async def flaky_acquire(*a: Any, **kw: Any) -> Any:
+            nonlocal acquire_calls
+            acquire_calls += 1
+            if acquire_calls == 1:
+                raise _transient_err()
+            return (MagicMock(), True, False)
+
+        async def mock_stream(*a: Any, **kw: Any) -> str:
+            return "recovered"
+
+        job = _job("jt1")
+        result = self._run(gw_and_cb, job, get_or_create=flaky_acquire, mock_stream=mock_stream)
+        assert result == "recovered"
+        assert acquire_calls == 2
+        assert job.consecutive_failures == 0
+
+    def test_transient_retries_exhausted_still_counts(
+        self, gw_and_cb: tuple[Any, Any, Any]
+    ) -> None:
+        """A persistent pre-dispatch outage exhausts retries and still counts.
+
+        The callback re-raises after alerting (cron's _execute owns
+        last_status), so the exception is expected to propagate.
+        """
+        acquire_calls = 0
+
+        async def dead_acquire(*a: Any, **kw: Any) -> Any:
+            nonlocal acquire_calls
+            acquire_calls += 1
+            raise _transient_err()
+
+        async def mock_stream(*a: Any, **kw: Any) -> str:
+            raise AssertionError("must not be reached")
+
+        job = _job("jt2")
+        with pytest.raises(AcpError):
+            self._run(gw_and_cb, job, get_or_create=dead_acquire, mock_stream=mock_stream)
+        # 1 original + _CRON_TRANSIENT_RETRIES recursive attempts.
+        from kiro_crew.slack.gateway import _CRON_TRANSIENT_RETRIES
+
+        assert acquire_calls == 1 + _CRON_TRANSIENT_RETRIES
+        # Exactly ONE failure for the whole chain, not one per attempt.
+        assert job.consecutive_failures == 1
+        # Counter cleared for the next scheduled run.
+        assert getattr(job, "_transient_attempts", 0) == 0
+
+    def test_post_dispatch_transient_error_does_not_retry(
+        self, gw_and_cb: tuple[Any, Any, Any]
+    ) -> None:
+        """A transient error AFTER prompt dispatch must not resubmit the turn.
+
+        Tools may already have executed; a whole-callback retry would repeat
+        their side effects (GPT review finding on the first revision).
+        """
+        stream_calls = 0
+
+        async def mock_stream(*a: Any, **kw: Any) -> str:
+            nonlocal stream_calls
+            stream_calls += 1
+            raise _transient_err()
+
+        job = _job("jt3")
+        with pytest.raises(AcpError):
+            self._run(
+                gw_and_cb,
+                job,
+                get_or_create=AsyncMock(return_value=(MagicMock(), True, False)),
+                mock_stream=mock_stream,
+            )
+        assert stream_calls == 1
+        assert job.consecutive_failures == 1
+
+    def test_non_transient_error_does_not_retry(self, gw_and_cb: tuple[Any, Any, Any]) -> None:
+        """An auth/validation error goes straight to the failure path."""
+        acquire_calls = 0
+
+        async def denied_acquire(*a: Any, **kw: Any) -> Any:
+            nonlocal acquire_calls
+            acquire_calls += 1
+            err = AcpError("AccessDeniedException: credential invalid")
+            err.transient = False
+            raise err
+
+        async def mock_stream(*a: Any, **kw: Any) -> str:
+            raise AssertionError("must not be reached")
+
+        job = _job("jt4")
+        with pytest.raises(AcpError):
+            self._run(gw_and_cb, job, get_or_create=denied_acquire, mock_stream=mock_stream)
+        assert acquire_calls == 1
+        assert job.consecutive_failures == 1
+
+    def test_transient_counter_resets_between_runs(self, gw_and_cb: tuple[Any, Any, Any]) -> None:
+        """Attempts do not accumulate across separate scheduled runs."""
+        gw, get_cb, capture_cron = gw_and_cb
+        acquire_calls = 0
+
+        async def flaky_acquire(*a: Any, **kw: Any) -> Any:
+            nonlocal acquire_calls
+            acquire_calls += 1
+            # Fail transiently once per RUN, succeed on the run's retry.
+            if acquire_calls % 2 == 1:
+                raise _transient_err("HTTP 503 from backend")
+            return (MagicMock(), True, False)
+
+        async def mock_stream(*a: Any, **kw: Any) -> str:
+            return "ok"
+
+        gw.sessions.get_or_create = flaky_acquire
+        job = _job("jt5")
+        with (
+            patch("kiro_crew.slack.gateway.stream_and_collect", side_effect=mock_stream),
+            patch("kiro_crew.slack.gateway.redact_exfiltration_urls", return_value=("", False)),
+            patch("kiro_crew.slack.gateway.redact_credentials", return_value=("", False)),
+            patch(
+                "kiro_crew.slack.gateway.CronService.create",
+                new=AsyncMock(side_effect=capture_cron),
+            ),
+            patch("kiro_crew.slack.gateway.transient_retry_delay", return_value=0.0),
+        ):
+
+            async def _two_runs() -> tuple[Any, Any]:
+                await gw._init_cron()
+                cb = get_cb()
+                r1 = await cb(job)
+                r2 = await cb(job)
+                return r1, r2
+
+            r1, r2 = asyncio.run(_two_runs())
+
+        assert (r1, r2) == ("ok", "ok")
+        assert acquire_calls == 4  # two runs x (1 transient failure + 1 retry)
+        assert job.consecutive_failures == 0
+
+
+class TestWakeBudgetSubprocessGuard:
+    """The wake budget must cover a command/script subprocess timeout."""
+
+    def test_add_rejects_budget_below_command_timeout(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        with pytest.raises(ValueError, match="wake budget"):
+            svc.add_job(
+                name="t", message="m", every_secs=300, command="true",
+                timeout=600, timeout_secs=60,
+            )
+
+    def test_update_rejects_budget_below_default_command_timeout(self, tmp_path: Path) -> None:
+        """timeout_secs=1 on a command job: default subprocess bound is 300s."""
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="t", message="m", every_secs=300, command="true")
+        with pytest.raises(ValueError, match="wake budget"):
+            svc.update_job(job.id, timeout_secs=1)
+        # Rejected update leaves the job untouched.
+        assert svc.list_jobs()[0].timeout_secs == _JOB_TIMEOUT_SECS
+
+    def test_update_rejects_raising_subprocess_timeout_above_budget(
+        self, tmp_path: Path
+    ) -> None:
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(
+            name="t", message="m", every_secs=300, command="true", timeout_secs=400,
+        )
+        with pytest.raises(ValueError, match="wake budget"):
+            svc.update_job(job.id, timeout=500)
+
+    def test_llm_jobs_are_not_constrained(self, tmp_path: Path) -> None:
+        """The guard only applies to command/script jobs."""
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="t", message="m", every_secs=300, timeout_secs=10)
+        assert job.timeout_secs == 10
+        updated = svc.update_job(job.id, timeout_secs=5)
+        assert updated is not None and updated.timeout_secs == 5
+
+    def test_rejected_update_leaves_other_fields_untouched(self, tmp_path: Path) -> None:
+        """A rejected timeout_secs must not strand earlier mutations (name).
+
+        GPT round-2 finding: validation ran after name/message mutated, so a
+        later save would persist the rejected partial update.
+        """
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(name="orig", message="m", every_secs=300, command="true")
+        with pytest.raises(ValueError, match="wake budget"):
+            svc.update_job(job.id, name="renamed", timeout_secs=1)
+        got = svc.list_jobs()[0]
+        assert got.name == "orig"
+        assert got.timeout_secs == _JOB_TIMEOUT_SECS
+
+    def test_add_allows_budget_covering_script_default(self, tmp_path: Path) -> None:
+        """Script default is 30s; a 60s budget clears it plus allowance."""
+        svc = CronService(base_dir=tmp_path)
+        svc._load()
+        job = svc.add_job(
+            name="t", message="m", every_secs=300,
+            script="~/.kiro/crew/crons/x.py:f", timeout_secs=60,
+        )
+        assert job.timeout_secs == 60


### PR DESCRIPTION
## What this is

Phase 1 foundations for perpetual agents — floor items **2** and **3** from [RFC rev 3](https://github.com/kirodotdev/KiroCrew/pull/3135), in evidence order. Both defects were found (and worked around by hand) during the Phase 0 probe.

## 1. Per-wake budget (`timeout_secs`) becomes reachable

The field was **read** (`cron.py` deadline derivation at `_execute_with_timeout`), **clamped** (`max(min(job.timeout_secs, 86400), _JOB_TIMEOUT_SECS)`), and **persisted** (load/save) — but absent from `_update_job_locked`'s per-field whitelist and from every public creation signature. A job could only ever carry the 1800s default. During Phase 0, keeping `flake-warden` alive (cf 2 of 5 toward auto-pause after two timeout-killed wakes) required editing the store by hand under `_file_lock` (PHASE0-LOG, Intervention 2).

Now settable with `1..86400` validation through every supported writer:
- `CronService.add_job` / `add_job_async` / `update_job`
- MCP `cron_add` / `cron_update` (schema + passthrough)
- CLI `kirocrew cron update <id> --timeout-secs N`

## 2. Bonus defect found while wiring: `timeout` was silently dropped on update

MCP `cron_update` has passed `timeout` (the script/command subprocess bound) since the field existed — but no branch in `_update_job_locked` consumed it. The update was accepted and silently did nothing. Now consumed with `0..86400` validation, and the missing `timeout`/`timeout_secs` schema properties added to `cron_update`.

## 3. Transient backend errors retry instead of marching toward auto-pause

`stream_and_collect` retries transient errors raised **inside** the prompt stream. But a throttle/5xx during session acquire, client creation, or context assembly propagates to `_cron_callback`'s exception handler, which went straight to `record_failure()` — so five bad-weather wakes would silently auto-pause a healthy job (`_AUTO_PAUSE_THRESHOLD = 5`). Phase 0, Finding 1: the first subject's first hour hit exactly this, reaching cf 2 on account-wide Bedrock throttling.

The callback now classifies with the existing `acp_error_is_transient` (structured verdict preferred) and retries the whole callback up to `_CRON_TRANSIENT_RETRIES = 2` times on the shared `transient_retry_delay` backoff curve — the same semantics the subagent path has had since it existed. Properties pinned by tests:

- a recovered retry counts **zero** failures;
- exhausted retries record exactly **one** failure for the chain (not one per attempt), so a real outage still reaches auto-pause;
- non-transient errors (auth/validation) do not retry;
- the attempt counter is owned by the outermost frame and resets between scheduled runs.

## Tests

16 new in `test/test_cron_wake_budget.py`. Regression: 967 cron-family, 218 gateway, 266 CLI tests pass. `isort`/`flake8`/`mypy` clean on all touched files.

## Explicitly out of scope

`kind="self"`, `agent_sleep`, the §7 contract preamble with the ranking step, and the life directory — next PR, per the RFC's Phase 1 floor. This PR is deliberately limited to fixes that stand on their own regardless of the RFC's fate.
