### PR TITLE
fix(test): teach the pet-overlay window double about setContentProtection

### DIFF
--- a/website/electron/mochi/test/petOverlays.test.js
+++ b/website/electron/mochi/test/petOverlays.test.js
@@ -172,6 +172,13 @@ function stubElectronForOpen() {
     setAcceptFirstMouse() {}
     setIgnoreMouseEvents() {}
     setVisibleOnAllWorkspaces() {}
+    // #3125 started calling setContentProtection to keep the overlay out of
+    // screen captures, but this double was not taught the method, so every
+    // createOverlayForDisplay threw "win.setContentProtection is not a
+    // function" and Electron Shell Tests went red on main. Recording the
+    // argument rather than swallowing it, so the behaviour #3125 shipped is
+    // actually asserted instead of merely not crashing.
+    setContentProtection(on) { this.contentProtection = on; }
     setAlwaysOnTop() {}
     loadURL() {}
     isVisible() { return false; }
@@ -225,6 +232,10 @@ test("the pet overlay is a non-activating panel on macOS only", () => {
   try {
     mod.openPetWindow("http://localhost:6777", "tok");
     assert.strictEqual(created.length, 1, "one overlay for the single display");
+    // #3125: the overlay must be excluded from screen captures on every
+    // platform, otherwise a region capture bakes the pet into the image and the
+    // macOS screenshot picker offers the overlay instead of the app underneath.
+    assert.strictEqual(created[0].contentProtection, true, "content protection on");
     const { type } = created[0].opts;
     if (process.platform === "darwin") {
       assert.strictEqual(type, "panel");


### PR DESCRIPTION
## What

`Electron Shell Tests` is **red on main**, which reds every open PR. One test
double is missing one method.

#3125 ("keep the companion overlay out of screen captures") added this to
`createOverlayForDisplay`:

```js
win.setContentProtection(true);
```

`petOverlays.test.js`'s `FakeWindow` was never taught that method, so every
overlay creation throws:

```
TypeError: win.setContentProtection is not a function
    at createOverlayForDisplay (website/electron/mochi/petOverlays.js:598:7)
```

## Why it records the argument instead of stubbing a no-op

A no-op `setContentProtection() {}` would unbreak CI in one line and leave
#3125's actual behaviour **untested** — the overlay could silently stop being
excluded from screen captures and nothing would notice.

The double now records the argument and the existing overlay test asserts it is
`true`. That matters on every platform, not just macOS: without it a region
capture bakes the pet into the image, and the macOS screenshot picker offers the
overlay instead of the app the user is pointing at.

## Verification

**Red-green**, so the assertion is proven to be load-bearing:

| | pass | fail |
|---|---|---|
| without this change | 22 | **1** |
| with it | **23** | 0 |

## One local-run gotcha worth recording

This file `require()`s `petOverlays` at **module top level**, outside the
`Module._load` stub the tests install for `electron`. It therefore only runs
where the real `electron` package is installed — CI installs it, a bare worktree
does not, and it fails with `Cannot find module 'electron'` before any test
runs. I verified locally by dropping a throwaway stub `electron` module into
`node_modules`, running the suite, and removing it; the stub is not part of this
diff.

## Context

This is the second main-side breakage blocking the coverage work today, after
the `LocalStorageDebugCoverage` hardcoded-title test fixed in
https://github.com/kirodotdev/KiroCrew/pull/3112. Both share a shape: a product
change lands and its test double or its asserted copy is not updated with it.
