### PR TITLE
test(mochi): stub setContentProtection on FakeWindow in petOverlays test

### DIFF
--- a/website/electron/mochi/test/petOverlays.test.js
+++ b/website/electron/mochi/test/petOverlays.test.js
@@ -172,6 +172,7 @@ function stubElectronForOpen() {
     setAcceptFirstMouse() {}
     setIgnoreMouseEvents() {}
     setVisibleOnAllWorkspaces() {}
+    setContentProtection() {}
     setAlwaysOnTop() {}
     loadURL() {}
     isVisible() { return false; }


### PR DESCRIPTION
## Problem

The Electron Shell Tests job fails deterministically:

```
✖ the pet overlay is a non-activating panel on macOS only
  TypeError: win.setContentProtection is not a function
      at createOverlayForDisplay (website/electron/mochi/petOverlays.js:680:7)
      at Object.openPetWindow (website/electron/mochi/petOverlays.js:841:17)
```

## Why it matters

`petOverlays.test.js` reddens the always-on `electron-test` CI job, which blocks `PR Readiness` for every PR that touches the Electron shell. Despite reading like a flake, it fails on every run.

## Fix (symptom → root cause → change)

- Symptom: `win.setContentProtection is not a function` thrown from `createOverlayForDisplay`.
- Root cause: production `createOverlayForDisplay` gained a `win.setContentProtection(true)` call (screen-capture invisibility — macOS `NSWindowSharingNone` / Windows `WDA_EXCLUDEFROMCAPTURE`), but the test's `FakeWindow` stub in `stubElectronForOpen()` was never given that method. Every test that calls `openPetWindow` therefore throws before it can assert. This is a test/source drift, not a flake.
- Change: add a `setContentProtection() {}` no-op to `FakeWindow`, alongside the existing `setVisibleOnAllWorkspaces` / `setAlwaysOnTop` no-op stubs. Only `createOverlayForDisplay` calls `setContentProtection`, and only this test file exercises that window-creation path, so no other stub needs the method.

## Tests

No new tests — this repairs the existing `petOverlays.test.js` suite. Verified locally: `node --test mochi/test/petOverlays.test.js` → 23/23 pass (was 1 failing), and the full `npm test` electron suite → 893/893 pass.

## Manual verification

N/A — unit coverage sufficient. The stub mirrors the real Electron `BrowserWindow.setContentProtection` (a void setter) and the assertions read window state back, so the stubbed no-op is faithful.

no issue closed: no tracked issue filed for this CI failure.
