### PR TITLE
fix(test): repoint mcp_core coverage patches at consuming modules (main red)

### DIFF
--- a/test/test_mcp_core_more_coverage.py
+++ b/test/test_mcp_core_more_coverage.py
@@ -540,7 +540,7 @@ class TestWaitTool:
         with patch.object(mcp_core, "time", clock):
             with patch.object(mcp_core, "_resolve_session_key_strict", return_value=strict_key):
                 with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
-                    with patch.object(mcp_core, "is_tool_cancelled", return_value=False):
+                    with patch("kiro_crew.mcp_tools.control.is_tool_cancelled", return_value=False):
                         with patch.object(mcp_core, "sel", lambda: rec):
                             with patch.object(mcp_core, "_post", post) as p:
                                 out = _call_tool_inner("wait", dict(args))
@@ -647,7 +647,7 @@ class TestWaitTool:
         rec = _RecordingSel()
         with patch.object(mcp_core, "time", clock):
             with patch.object(mcp_core, "_resolve_session_key_strict", return_value=""):
-                with patch.object(mcp_core, "is_tool_cancelled", return_value=True):
+                with patch("kiro_crew.mcp_tools.control.is_tool_cancelled", return_value=True):
                     with patch.object(mcp_core, "sel", lambda: rec):
                         with patch.object(mcp_core, "_post", lambda *a, **k: {}):
                             with pytest.raises(ToolCancelled) as ei:
@@ -947,8 +947,8 @@ class TestResourceStatusTool:
             else (lambda _c: cap)
         )
         with patch("kiro_crew.resource_status.probe", return_value=rstatus):
-            with patch.object(mcp_core, "KiroCrewConfig", cfg):
-                with patch.object(mcp_core, "resolve_max_subagents", resolver):
+            with patch("kiro_crew.mcp_tools.spawn.KiroCrewConfig", cfg):
+                with patch("kiro_crew.mcp_tools.spawn.resolve_max_subagents", resolver):
                     return _call_tool_inner("resource_status", {})
 
     def test_the_probe_summary_and_cap_are_reported(self) -> None:


### PR DESCRIPTION
## What broke

Main is red on **Backend Tests shard 3** across all three platforms (3.10, 3.12, Windows) since #3127 (mcp_core split) and the coverage tests landed near-simultaneously:

```
AttributeError: <module 'kiro_crew.mcp_core'> does not have the attribute 'resolve_max_subagents'
AttributeError: <module 'kiro_crew.mcp_core'> does not have the attribute 'is_tool_cancelled'
```

8 tests in `test_mcp_core_more_coverage.py` fail on main itself (run 31649415191) and leak into every open PR whose CI merges current main (observed on #3148).

## Root cause

#3127's design late-binds handler plumbing through `mcp_core.X` attribute lookups precisely to preserve monkeypatch sites — but these two symbols are the exception: the extracted handlers import them **directly** (`mcp_tools/control.py:28` imports `is_tool_cancelled` from `mcp_shared`; `mcp_tools/spawn.py:32` imports `resolve_max_subagents` from `subagent`). `patch.object(mcp_core, ...)` on a missing attribute raises immediately.

## Fix (test-only)

Repoint the three patches at the consuming modules:
- `kiro_crew.mcp_tools.control.is_tool_cancelled` — `wait` handler, 2 sites
- `kiro_crew.mcp_tools.spawn.resolve_max_subagents` — `resource_status` handler

Plus one **silently-dead patch** found in the same fixture: `patch.object(mcp_core, "KiroCrewConfig")` no longer influences `resource_status` (spawn.py imports it directly), so the test stub was ignored and the test read the real on-disk config. Repointed to `kiro_crew.mcp_tools.spawn.KiroCrewConfig`.

## Verification

111/111 tests in the file pass locally; flake8/isort clean. No source changes.
