### PR TITLE
fix: re-pin chat to bottom when the scroller viewport resizes

### DIFF
--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -1017,10 +1017,26 @@ export function useVirtualChat<T>(
 
       let genuineResize = false
       let firstMount = false
+      // True when the SCROLLER's own box resized (the observer watches it
+      // alongside the rows). Chrome around the transcript changes the viewport
+      // height with no scroll event and no row resize — the composer autosizes
+      // when a slot switch restores a long draft, attachment strips and
+      // banners mount, the browser window resizes. A viewport SHRINK while
+      // pinned leaves scrollTop at the old, now-too-small bottom target — the
+      // view rests slightly above the latest message ("switching sessions
+      // doesn't land at the bottom"). A GROW is clamped by the browser itself.
+      // Routed through pinAuto below, so the race-proof guard still applies:
+      // with follow released (reading history, anchor restore in flight) a
+      // viewport resize never moves the viewport.
+      let viewportResized = false
       // True when one of the resized entries is the caller-designated
       // streaming row (see `streamingIndex` option / syncHeightsNow's doc).
       let streamingRowResized = false
       for (const entry of entries) {
+        if (entry.target === el) {
+          viewportResized = true
+          continue
+        }
         const idx = elIndexRef.current.get(entry.target)
         if (idx === undefined) continue
         const it = itemsRef.current[idx]
@@ -1068,7 +1084,11 @@ export function useVirtualChat<T>(
       // for the length of the animation re-creates the spacer lurch that
       // `streamingIndex`'s immediate path exists to prevent. Collapsing the rail
       // mid-turn is rare; a visible lurch is not an acceptable trade for it.
-      if ((genuineResize || firstMount) && !streamingRowResized && isRailSettling()) {
+      //
+      // The viewport entry takes this deferral too: the animation resizes the
+      // scroller's box on every frame, and a per-frame viewport pin is exactly
+      // the write storm this window exists to hold back.
+      if ((genuineResize || firstMount || viewportResized) && !streamingRowResized && isRailSettling()) {
         railSettleFollowRef.current = railSettleFollowRef.current || stickRef.current
         if (railSettleTimerRef.current === null) {
           railSettleTimerRef.current = setTimeout(() => {
@@ -1096,7 +1116,10 @@ export function useVirtualChat<T>(
       // message right as the turn re-keys (single → grouped turn) and remounts
       // the row, which otherwise looks like a first-mount and skips the pin.
       // pinAuto still releases if the live geometry shows a real scroll-up.
-      const shouldFollow = genuineResize || (firstMount && stickRef.current)
+      // A viewport resize is likewise only followed while following — with
+      // stick released it must never move a reading user.
+      const shouldFollow =
+        genuineResize || ((firstMount || viewportResized) && stickRef.current)
       if (shouldFollow && (stickRef.current || performance.now() - lastUserScrollAtRef.current >= SCROLL_SETTLE_MS)) {
         pinAuto()
       }
@@ -1132,6 +1155,11 @@ export function useVirtualChat<T>(
     // exactly the currently-mounted rows (the null-element branch deletes on
     // unmount), so iterating it cannot resurrect a detached node.
     for (const el of elIndexRef.current.keys()) ro.observe(el)
+    // Observe the scroller's own box (the viewport branch above) — after the
+    // rows, so row-position assumptions about observation order keep holding.
+    // A re-created observer must re-observe it here; the `scrollerEl` effect
+    // below covers a scroller that mounts later than this effect.
+    if (scrollerRef.current) ro.observe(scrollerRef.current)
     return () => {
       ro.disconnect()
       // Cancel a frame queued by the last resize so it can't fire a
@@ -1148,6 +1176,18 @@ export function useVirtualChat<T>(
       resizeObserverRef.current = null
     }
   }, [recomputeWindow, pinAuto, scheduleHeightSync, syncHeightsNow, scrollerRef])
+
+  // Late-mounting scroller: the RO effect above observes `scrollerRef.current`
+  // at setup, but a scroller (or an ancestor) rendered AFTER that effect ran
+  // would never be observed — same rationale as the `scrollerEl` state for the
+  // scroll/IO listeners. observe() is idempotent, so the overlap with the
+  // setup-time observe is harmless.
+  useEffect(() => {
+    const el = scrollerEl
+    if (!el) return
+    resizeObserverRef.current?.observe(el)
+    return () => { resizeObserverRef.current?.unobserve(el) }
+  }, [scrollerEl])
 
   // ---- IntersectionObserver: top/bottom sentinels for window expansion ----
   useEffect(() => {

--- a/website/src/test/useVirtualChat.spacerLurch.test.tsx
+++ b/website/src/test/useVirtualChat.spacerLurch.test.tsx
@@ -315,7 +315,7 @@ describe('useVirtualChat: streamingIndex fix — the named row tracks live inste
   it('a NON-streaming row (index not named by streamingIndex) still debounces normally', () => {
     // Guards against an overbroad fix: naming row N as streaming must not
     // accidentally make every row's resizes immediate.
-    const { view } = mountStreaming(
+    const { el, view } = mountStreaming(
       'streaming-index-scoped',
       { scrollTop: 0, scrollHeight: 3000, clientHeight: 400 },
       mkItems(21),
@@ -324,9 +324,10 @@ describe('useVirtualChat: streamingIndex fix — the named row tracks live inste
     const nonStreamingNode = document.createElement('div')
     Object.defineProperty(nonStreamingNode, 'offsetHeight', { configurable: true, get: () => 100 })
     act(() => { view.result.current.measureRef(0)(nonStreamingNode) }) // pre-existing measured seed
-    // Resize a HISTORY row (index 0, not the streamingIndex = 20).
+    // Resize a HISTORY row (not the streamingIndex = 20, and not the scroller
+    // itself, which the observer also watches for viewport-box changes).
     const ro = FakeResizeObserver.instances[FakeResizeObserver.instances.length - 1]
-    const historyNode = [...ro.observed][0] as HTMLElement
+    const historyNode = [...ro.observed].find((n) => n !== el) as HTMLElement
     Object.defineProperty(historyNode, 'offsetHeight', { configurable: true, get: () => 150 })
     act(() => { ro.fire([{ target: historyNode }]) })
     // Still within the debounce window — must NOT have committed yet.

--- a/website/src/test/useVirtualChat.viewportResize.test.tsx
+++ b/website/src/test/useVirtualChat.viewportResize.test.tsx
@@ -1,0 +1,146 @@
+// Feature: chat-virtualizer — viewport-box resize re-pin.
+//
+// The row ResizeObserver tracks CONTENT heights; the viewport observer under
+// test here tracks the SCROLLER's own box. Chrome around the transcript
+// (composer autosize on draft restore, attachment strips, banners, a window
+// resize) shrinks the scroller with no scroll event and no row resize; while
+// pinned to the bottom that used to strand the view slightly ABOVE the new
+// bottom target ("switching sessions doesn't land at the bottom"). These tests
+// pin the re-pin, its follow-guard (a reading user is never yanked), and the
+// rail-collapse deferral (no per-frame scrollTop writes during the shell grid
+// animation).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { type RefObject } from 'react'
+import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
+import type { UseVirtualChatOptions } from '../hooks/virtualizer/types'
+import { setRailWidth, railWidthFor, RAIL_SETTLE_MS, __resetRailWidth } from '../hooks/useRailWidth'
+
+interface Geom { scrollTop: number; scrollHeight: number; clientHeight: number }
+
+function makeScroller(initial: Geom) {
+  const el = document.createElement('div')
+  const state: Geom = { ...initial }
+  const writes = { n: 0 }
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    get: () => state.scrollTop,
+    set: (v: number) => { writes.n++; state.scrollTop = v },
+  })
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => state.scrollHeight })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => state.clientHeight })
+  ;(el as unknown as { scrollTo: (o: { top: number }) => void }).scrollTo = (o) => { writes.n++; state.scrollTop = o.top }
+  return { el, state, writes }
+}
+
+interface Item { id: string }
+const getKey = (it: Item) => it.id
+const mkItems = (n: number): Item[] => Array.from({ length: n }, (_, i) => ({ id: `m${i}` }))
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+  cb: ResizeObserverCallback
+  observed = new Set<Element>()
+  constructor(cb: ResizeObserverCallback) { this.cb = cb; FakeResizeObserver.instances.push(this) }
+  observe(el: Element) { this.observed.add(el) }
+  unobserve(el: Element) { this.observed.delete(el) }
+  disconnect() { this.observed.clear() }
+  fire(entries: Partial<ResizeObserverEntry>[] = []) {
+    this.cb(entries as ResizeObserverEntry[], this as unknown as ResizeObserver)
+  }
+}
+
+describe('useVirtualChat: viewport-box resize re-pin', () => {
+  let origRO: typeof ResizeObserver | undefined
+  let origRaf: typeof requestAnimationFrame
+
+  beforeEach(() => {
+    localStorage.clear()
+    __resetRailWidth()
+    FakeResizeObserver.instances = []
+    origRO = globalThis.ResizeObserver
+    globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.ResizeObserver = origRO as typeof ResizeObserver
+    globalThis.requestAnimationFrame = origRaf
+    __resetRailWidth()
+  })
+
+  /** The shared observer (it watches the scroller element alongside rows). */
+  function viewportRO(el: HTMLElement): FakeResizeObserver {
+    const inst = FakeResizeObserver.instances.find((i) => i.observed.has(el))
+    expect(inst).toBeDefined()
+    return inst!
+  }
+
+  /** Deliver a viewport-box resize: an entry whose target is the scroller. */
+  function fireViewport(el: HTMLElement) {
+    viewportRO(el).fire([{ target: el } as Partial<ResizeObserverEntry>])
+  }
+
+  function mount(sessionId: string, geom: Geom, items: Item[]) {
+    const { el, state, writes } = makeScroller(geom)
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    const baseProps: UseVirtualChatOptions<Item> = { items, sessionId, getKey, externalScrollerRef: ref }
+    const view = renderHook((p: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(p), { initialProps: baseProps })
+    act(() => { vi.advanceTimersByTime(250) }) // settle mount timers
+    return { el, state, view, writes }
+  }
+
+  it('re-pins to the new bottom when the viewport shrinks while followed', () => {
+    // Pinned at the bottom: 2000 - 400 = 1600 (slot-entry forcePin).
+    const { el, state } = mount('viewport-shrink', { scrollTop: 0, scrollHeight: 2000, clientHeight: 400 }, mkItems(10))
+    expect(el.scrollTop).toBe(1600)
+
+    // The composer grows (draft restored / attachment strip mounts): the
+    // scroller's box shrinks by 60px. No scroll event, no row resize — only
+    // the viewport observer sees it. Old scrollTop is now 60px short.
+    act(() => {
+      state.clientHeight = 340
+      fireViewport(el)
+    })
+    expect(el.scrollTop).toBe(2000 - 340)
+  })
+
+  it('does NOT move a user who scrolled up when the viewport shrinks', () => {
+    const { el, state } = mount('viewport-noyank', { scrollTop: 0, scrollHeight: 2000, clientHeight: 400 }, mkItems(10))
+    expect(el.scrollTop).toBe(1600)
+
+    // User scrolls up to read history — the scroll handler releases follow.
+    act(() => { state.scrollTop = 600; el.dispatchEvent(new Event('scroll')) })
+
+    act(() => {
+      state.clientHeight = 340
+      fireViewport(el)
+    })
+    expect(el.scrollTop).toBe(600)
+  })
+
+  it('defers per-frame writes during the rail collapse and re-pins once at settle', () => {
+    const { el, state, writes } = mount('viewport-rail', { scrollTop: 0, scrollHeight: 2000, clientHeight: 400 }, mkItems(10))
+    expect(el.scrollTop).toBe(1600)
+    const before = writes.n
+
+    // Rail collapse arms the settle window; the shell grid animation resizes
+    // the scroller's box every frame. None of those frames may write scrollTop.
+    act(() => { setRailWidth(railWidthFor({ isMobile: false, collapsed: true })) })
+    act(() => {
+      for (let i = 0; i < 8; i++) {
+        state.clientHeight = 400 - i // width-driven reflow jitters the box
+        fireViewport(el)
+      }
+    })
+    expect(writes.n).toBe(before)
+
+    // One re-pin when the settle window closes (we were following).
+    act(() => { state.clientHeight = 340; vi.advanceTimersByTime(RAIL_SETTLE_MS + 1) })
+    expect(el.scrollTop).toBe(2000 - 340)
+  })
+})


### PR DESCRIPTION
# fix: re-pin chat to bottom when the scroller viewport resizes

## Problem

Switching to a session does not land the transcript at the bottom. The view rests slightly above the latest message, so the newest content sits partly below the fold and the user has to nudge-scroll every time they switch.

## Why it matters

Session switching is one of the most frequent dashboard actions, and "open at the bottom" is the virtualizer's stated contract (the slot-entry force-pin exists for exactly this). Landing short on every switch reads as broken scrolling and erodes trust in the follow behavior.

## Fix (symptoms → root cause → change)

- **Symptom**: after a slot switch the scroller sits a few tens of pixels above the bottom, with follow still armed.
- **Root cause**: the virtualizer observed row heights (per-row ResizeObserver) and pinned on slot entry and appends — but nothing observed the **scroller's own viewport box**. Per-slot chrome below the transcript settles *after* the entry pin: the composer autosizes when the slot's draft restores, attachment/paste strips and banners mount. That shrinks `clientHeight`, which moves the bottom target down **without firing any scroll event or row resize**, so no code path re-pins and the view is stranded above the bottom. (Only the shrink direction strands; a viewport grow is clamped by the browser itself.) `ChatPage.tsx` already carries a one-off compensation for one instance of this exact mechanism — the in-flow tip band — which is evidence the general mechanism was missing.
- **Change**: the shared ResizeObserver in `useVirtualChat.ts` now also observes the scroller element. A viewport-box entry routes through the existing race-proof `pinAuto`, gated on `stickRef` — so it re-pins while following and **never moves a user who scrolled up to read history** (including during an anchor restore, which runs with follow released). During the sidebar-rail collapse animation, viewport entries defer to the existing rail-settle window, so no per-frame scrollTop write storm is introduced. Two small lifecycle additions keep the scroller observed across observer re-creation and late-mounting scrollers.

Reviewer note (advisory, accepted): a viewport-only resize during rail settle arms the settle timer, whose close-out `syncHeightsNow()` is redundant when no row height changed. The sync is idempotent, and tracking a separate viewport-only settle reason costs more state than the redundant sync saves, so the shared path is kept deliberately.

## Tests

New file `website/src/test/useVirtualChat.viewportResize.test.tsx` (3 tests, each mutation-proven — disabling the guarded branch fails exactly the test that owns it):

1. **Re-pins to the new bottom** when the viewport shrinks while followed (the bug).
2. **Does NOT move a user who scrolled up** when the viewport shrinks (follow guard).
3. **Defers per-frame writes during the rail collapse** and re-pins once at settle close (write-storm guard).

One order-sensitive assertion in `useVirtualChat.spacerLurch.test.tsx` updated: the observed set now contains the scroller, so the "resize a history row" test selects a row node explicitly instead of `[...ro.observed][0]`.

Full frontend gate: `tsc -b` clean; vitest 1051 files / 17,709 tests passed. Backend untouched (frontend-only diff).

## Manual verification

Not performed against a live gateway (jsdom-simulated scroll geometry covers the mechanism; the pin math is the same `pinAuto` path used by streaming follow). To verify by hand: in one session type a multi-line draft (composer grows), switch to another session and back — the transcript should land flush at the bottom; then scroll up mid-history, resize the window or grow the composer, and confirm the view does not move.

## Screenshots

N/A — no visual surface changes. The diff alters scroll *position behavior* on session switch; a still frame of "chat scrolled to bottom" is indistinguishable from any other chat screenshot. The manual-verification steps above are the meaningful evidence for a reviewer.
