### PR TITLE
fix(config): refresh the stale version stamp an upgrade leaves in config.json (#3102)

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -833,6 +833,77 @@ def stamp_config_meta(data: dict) -> dict:
     }
 
 
+def refresh_config_meta_stamp() -> bool:
+    """Re-stamp ``config.json``'s ``meta`` block when it names another build.
+
+    The stamp is only ever written as a side effect of a config write, so an
+    upgrade that never touches ``config.json`` leaves ``lastTouchedVersion``
+    naming the *previous* build indefinitely. That contradicts the field's
+    documented meaning ("the build that wrote the bytes now on disk") and
+    sends anyone debugging a version question chasing a build that is no
+    longer installed (#3102). Called once per gateway start, off the boot
+    path: a version check on one small file, a rewrite only when it differs.
+
+    Deliberately a plain field refresh, not a migration hook: the stamp is
+    replaced, every other key is preserved, and nothing else changes. When
+    the stored version already matches, the file is not rewritten at all
+    (no mtime churn, no ``lastTouchedAt`` bump).
+
+    The read-modify-write goes through :func:`update_config_locked` — the
+    required path for new ``config.json`` mutations — so the refresh holds
+    the sidecar advisory lock and can never revert a concurrent settings
+    write with its own earlier snapshot. Callers that run while the
+    dashboard serves requests must ALSO hold the in-process asyncio config
+    lock (``_get_config_lock``) around the call, because the legacy writers
+    serialize on that lock alone.
+
+    Best-effort by design — a stale stamp is a diagnostic blemish, never
+    worth failing a boot over. Returns ``True`` when a refresh was written,
+    ``False`` when nothing needed doing (absent/empty file, current stamp)
+    or the file could not be safely read (an unreadable/torn config must
+    never be replaced with a stamped-but-empty one).
+    """
+    path = config_path()
+    if not path.exists():
+        return False
+
+    wrote = False
+
+    def _stamp_if_stale(data: dict) -> dict | None:
+        nonlocal wrote
+        if not data:
+            # Absent or emptied between the exists() check and the lock hold:
+            # there is nothing to refresh, and writing would CREATE a config
+            # holding only a meta block.
+            return None
+        meta = data.get("meta")
+        stored = meta.get("lastTouchedVersion") if isinstance(meta, dict) else None
+        if stored == __version__:
+            return None  # current: skip the write entirely
+        wrote = True
+        return data  # update_config_locked stamps the meta block itself
+
+    try:
+        update_config_locked(path, mutate=_stamp_if_stale)
+    except ConfigReadError:
+        logger.debug(
+            "config meta stamp refresh skipped: %s unreadable; leaving it untouched",
+            path,
+            exc_info=True,
+        )
+        return False
+    except OSError:
+        logger.debug(
+            "config meta stamp refresh failed: could not lock or write %s",
+            path,
+            exc_info=True,
+        )
+        return False
+    if wrote:
+        _invalidate_config_cache()
+    return wrote
+
+
 def workspace_dir_for(workspace: str | None = None) -> Path:
     """Resolve a named workspace to its directory path.
 

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -59,6 +59,31 @@ from kiro_crew.validation import (
 
 logger = logging.getLogger(__name__)
 
+
+async def run_config_write(fn, /, *args, **kwargs):
+    """Run a blocking ``config.json`` writer under BOTH config locks.
+
+    Every ``config.json`` read-modify-write must serialize against two writer
+    generations at once: the sidecar advisory flock that ``update_config_locked``
+    takes (covering CLI / boot-refresh / other-process writers), and the
+    loop-side :func:`_get_config_lock` asyncio lock that the dashboard's legacy
+    handlers still rely on *alone* (bare ``read_config_for_update`` +
+    ``write_config_atomically`` — e.g. the memory-settings PUT). A writer that
+    holds only one of the two can interleave with the other family and silently
+    revert its settings from a stale snapshot.
+
+    This helper is the one async entry point that holds both: the asyncio lock
+    is acquired on the event loop, then ``fn`` (a sync callable that itself
+    routes through ``update_config_locked``) runs in a worker thread so the
+    flock wait never blocks the loop. Mirrors the boot-time meta-stamp refresh
+    in ``server.py``, which established the pattern.
+    """
+    from kiro_crew.dashboard.handlers.agents import _get_config_lock  # lazy: import cycle
+
+    async with _get_config_lock():
+        return await asyncio.to_thread(fn, *args, **kwargs)
+
+
 # Per-turn compaction-failure backoff. See
 # _broadcast_compaction_result for the full rationale. Kept small: this is a
 # UX/spam guard, not a correctness gate — the underlying compaction attempt

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -29,7 +29,11 @@ from kiro_crew.autonudge_authz import authorize_and_add_nudge
 from kiro_crew.browser.setup import migrate_owned_playwright_registration
 from kiro_crew.channel_transcript_migration import migrate_channel_transcripts
 from kiro_crew.config import data_home
-from kiro_crew.config.loader import KiroCrewConfig, refresh_materialized_agents
+from kiro_crew.config.loader import (
+    KiroCrewConfig,
+    refresh_config_meta_stamp,
+    refresh_materialized_agents,
+)
 from kiro_crew.dashboard import (
     cautious_boot,
     channel_slots,
@@ -2997,6 +3001,28 @@ async def start_dashboard(
     # gets its own launch window instead of landing on top of the app backends.
     await cautious_boot.pause_before("MCP server probe")
     asyncio.create_task(handlers._bg_mcp_probe())
+
+    # Refresh config.json's meta stamp when an upgrade left it naming the
+    # previous build (#3102). Post-bind and fire-and-forget (never awaited on
+    # the boot path), and the file I/O runs in a thread so the version check —
+    # one small fixed-path file, O(1), rewrite only on mismatch — never holds
+    # the event loop. Two locks cover both writer generations: the refresh
+    # itself goes through update_config_locked (sidecar advisory lock), and
+    # the loop-side asyncio config lock is held around the off-thread call so
+    # the legacy writers that serialize on that lock alone cannot land inside
+    # the refresh's read→write window. Best-effort: a stale stamp is a
+    # diagnostic blemish, so a failure here is logged and boot proceeds.
+    async def _refresh_meta_stamp() -> None:
+        try:
+            async with handlers._get_config_lock():
+                if await asyncio.to_thread(refresh_config_meta_stamp):
+                    logger.info("config.json meta stamp refreshed to the running version")
+        except Exception:
+            logger.debug("config meta stamp refresh failed", exc_info=True)
+
+    _stamp_task = asyncio.create_task(_refresh_meta_stamp())
+    state._background_tasks.add(_stamp_task)
+    _stamp_task.add_done_callback(state._background_tasks.discard)
 
     # Start terminal orphan reaper (kills PTYs with no WS past the reaper window)
     _reaper = asyncio.create_task(handlers.reap_orphaned_terminals(app))

--- a/src/kiro_crew/slack/allowlist.py
+++ b/src/kiro_crew/slack/allowlist.py
@@ -20,8 +20,7 @@ from typing import TYPE_CHECKING
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
     config_path,
-    read_config_for_update,
-    write_config_atomically,
+    update_config_locked,
 )
 from kiro_crew.dashboard.origin import (
     dashboard_origin,
@@ -299,22 +298,6 @@ async def send_dashboard_link(
 # ---------------------------------------------------------------------------
 
 
-def _read_config() -> dict:
-    """Read config.json for a read-modify-write, failing CLOSED.
-
-    Always re-reads from disk so manual edits are respected. Raises
-    ``ConfigReadError`` on an unreadable (but present) config: the caller
-    rewrites the WHOLE file, so returning ``{}`` here would replace every
-    other setting with an allowlist-only config.
-    """
-    return read_config_for_update(config_path())
-
-
-def _write_config(data: dict) -> None:
-    """Write *data* back to config.json atomically, preserving its mode."""
-    write_config_atomically(config_path(), data)
-
-
 def _update_config_list(
     section_key: str,
     id_field: str,
@@ -326,28 +309,39 @@ def _update_config_list(
     """Add or remove an entry in a ``config.json → slack.<section_key>`` list.
 
     Each entry is a dict with at least *id_field*.  Idempotent — adding
-    a duplicate or removing a missing entry is a no-op.  Always re-reads
-    the file first so manual edits aren't clobbered.
+    a duplicate or removing a missing entry is a no-op (no write at all).
+    Goes through :func:`update_config_locked` so the read-modify-write holds
+    the sidecar advisory lock: a concurrent config writer (dashboard PATCH,
+    CLI, the boot-time meta refresh) cannot land inside this write's window
+    and be silently reverted, and manual edits are still respected because
+    the read happens fresh inside the lock hold.
     """
-    data = _read_config()
-    slack_cfg = data.setdefault("slack", {})
-    entries: list[dict] = slack_cfg.setdefault(section_key, [])
+    changed = ""
 
-    if remove:
-        filtered = [e for e in entries if e.get(id_field) != target_id]
-        if len(filtered) == len(entries):
-            return  # wasn't there — no-op
-        slack_cfg[section_key] = filtered
-        _write_config(data)
-        logger.info("Removed %s=%s from config slack.%s", id_field, target_id, section_key)
-    else:
+    def _apply(data: dict) -> dict | None:
+        nonlocal changed
+        slack_cfg = data.setdefault("slack", {})
+        entries: list[dict] = slack_cfg.setdefault(section_key, [])
+        if remove:
+            filtered = [e for e in entries if e.get(id_field) != target_id]
+            if len(filtered) == len(entries):
+                return None  # wasn't there — no-op, no write
+            slack_cfg[section_key] = filtered
+            changed = "Removed"
+            return data
         if any(e.get(id_field) == target_id for e in entries):
-            return  # already present — no-op
+            return None  # already present — no-op, no write
         entry: dict[str, str] = {id_field: target_id}
         if name:
             entry["name"] = name
         entries.append(entry)
-        _write_config(data)
+        changed = "Added"
+        return data
+
+    update_config_locked(config_path(), mutate=_apply)
+    if changed == "Removed":
+        logger.info("Removed %s=%s from config slack.%s", id_field, target_id, section_key)
+    elif changed == "Added":
         logger.info("Added %s=%s (%s) to config slack.%s", id_field, target_id, name, section_key)
 
 

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -40,6 +40,7 @@ from kiro_crew.config.loader import (
 )
 from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.cron import format_schedule
+from kiro_crew.dashboard.chat_utils import run_config_write
 from kiro_crew.dashboard.handlers import get_update_info
 from kiro_crew.dashboard.token_auth import LINK_WINDOW_SECS, MAX_SESSION_TTL_SECS, parse_duration
 from kiro_crew.executors import subprocess_executor
@@ -293,12 +294,12 @@ async def _handle_agent(
     if args:
         name = args.strip().split()[0]
         if name.lower() in ("off", "default"):
-            _set_default_agent("")
+            await run_config_write(_set_default_agent, "")
             await respond("🔄 Reset to default agent.")
             return
         resolved = _resolve_agent_name(name)
         if resolved:
-            _set_default_agent(resolved)
+            await run_config_write(_set_default_agent, resolved)
             await respond(f"🔄 Switched to agent: *{resolved}*")
             return
         await respond(f"❌ Unknown agent `{name}`. Pick one below:")

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -42,8 +42,7 @@ from kiro_crew.config.loader import (
     ConfigReadError,
     KiroCrewConfig,
     config_path,
-    read_config_for_update,
-    write_config_atomically,
+    update_config_locked,
 )
 from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.context import (
@@ -64,6 +63,7 @@ from kiro_crew.dashboard.chat_utils import (
     mint_options_token,
     options_control_is_stale,
     remember_slack_options,
+    run_config_write,
 )
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.history import ConversationLog, HistoryConsolidator
@@ -1057,15 +1057,19 @@ def _set_default_agent(name: str) -> None:
     path = config_path()
     if is_sensitive_path(str(path)):
         raise ValueError(f"Refusing to write to sensitive path: {path}")
+
+    def _apply(data: dict) -> dict:
+        data.setdefault("agent", {})["default_agent"] = name
+        return data
+
     try:
-        data = read_config_for_update(path)
+        # Locked read-modify-write: holds the sidecar advisory lock so a
+        # concurrent config writer (dashboard PATCH, CLI, the boot-time meta
+        # refresh) cannot land between this read and write and get reverted.
+        update_config_locked(path, mutate=_apply)
     except ConfigReadError as e:
         # Fail closed: writing back a {} baseline would drop every other setting.
         raise ValueError(f"Failed to read config: {e}") from e
-    data.setdefault("agent", {})["default_agent"] = name
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        write_config_atomically(path, data)
     except OSError as e:
         raise ValueError(f"Failed to write config: {e}") from e
     _cached_default_agent = name
@@ -1080,20 +1084,25 @@ def _persist_channel_config(
     path = config_path()
     if is_sensitive_path(str(path)):
         raise ValueError(f"Refusing to write to sensitive path: {path}")
+
+    def _apply(data: dict) -> dict:
+        slack_data = data.setdefault("slack", {})
+        channels = slack_data.setdefault("channels", {})
+        ch = channels.setdefault(channel_id, {})
+        if activation is not None:
+            ch["activation"] = activation
+        if agent is not None:
+            ch["agent"] = agent
+        return data
+
     try:
-        data = read_config_for_update(path)
+        # Locked read-modify-write (see _set_default_agent): without the
+        # sidecar lock, a `!channel always` racing any other config writer
+        # could be silently reverted by the loser's stale snapshot.
+        update_config_locked(path, mutate=_apply)
     except ConfigReadError as e:
         # Fail closed: writing back a {} baseline would drop every other setting.
         raise ValueError(f"Failed to read config: {e}") from e
-    slack_data = data.setdefault("slack", {})
-    channels = slack_data.setdefault("channels", {})
-    ch = channels.setdefault(channel_id, {})
-    if activation is not None:
-        ch["activation"] = activation
-    if agent is not None:
-        ch["agent"] = agent
-    try:
-        write_config_atomically(path, data)
     except OSError as e:
         raise ValueError(f"Failed to write config: {e}") from e
 
@@ -1641,7 +1650,7 @@ async def _handle_slash_command(
         agent_name = parts[1]
         if agent_name.lower() in ("default", "off"):
             try:
-                _set_default_agent("")
+                await run_config_write(_set_default_agent, "")
             except ValueError as e:
                 await slack.post_message(channel, f"❌ {e}", reply_ts)
                 return ""
@@ -1665,7 +1674,7 @@ async def _handle_slash_command(
             )
             return ""
         try:
-            _set_default_agent(resolved)
+            await run_config_write(_set_default_agent, resolved)
         except ValueError as e:
             await slack.post_message(channel, f"❌ {e}", reply_ts)
             return ""
@@ -2009,7 +2018,7 @@ async def _handle_slash_command(
                     )
                     return ""
                 agent_name = resolved
-            _persist_channel_config(channel, agent=agent_name)
+            await run_config_write(_persist_channel_config, channel, agent=agent_name)
             _reload_orch_cfg()
             sel().log_api_access(
                 caller=user_id,
@@ -2031,7 +2040,7 @@ async def _handle_slash_command(
             )
             return ""
 
-        _persist_channel_config(channel, activation=subcmd)
+        await run_config_write(_persist_channel_config, channel, activation=subcmd)
         _reload_orch_cfg()
         sel().log_api_access(
             caller=user_id,

--- a/src/kiro_crew/slack/interactions.py
+++ b/src/kiro_crew/slack/interactions.py
@@ -26,13 +26,13 @@ from kiro_crew.config.loader import (
     ACTIVATION_REVIEW,
     ConfigReadError,
     config_path,
-    read_config_for_update,
-    write_config_atomically,
+    update_config_locked,
 )
 from kiro_crew.cron import CronStoreBusy
 from kiro_crew.dashboard.chat_utils import (
     forget_slack_options_for_thread,
     options_control_is_stale,
+    run_config_write,
     slack_options_owner_keys_snapshot,
     slack_options_slot,
 )
@@ -196,25 +196,25 @@ async def _handle_config_submission(payload: dict) -> None:
     chan_vals = values.get("channels_block", {}).get("mc_config_channels", {})
     new_channels = set(chan_vals.get("selected_channels") or [])
 
-    # Read BEFORE mutating runtime state. Fail closed on an unreadable config:
-    # writing back a {} baseline would drop every other setting the user has.
-    # Order matters — applying the in-memory change first would make a refused
-    # save look like it took effect, then silently revert on restart.
+    # Persist through the locked read-modify-write BEFORE mutating runtime
+    # state. Fail closed on an unreadable config: writing back a {} baseline
+    # would drop every other setting the user has. Order matters — applying
+    # the in-memory change first would make a refused save look like it took
+    # effect, then silently revert on restart. The sidecar lock keeps a
+    # concurrent config writer (dashboard PATCH, CLI, boot-time meta refresh)
+    # from being reverted by this write's stale snapshot, and vice versa.
     cp = config_path()
+
+    def _apply(data: dict) -> dict:
+        slack_cfg = data.setdefault("slack", {})
+        slack_cfg["tracking_channels"] = [{"channel_id": cid} for cid in sorted(new_channels)]
+        return data
+
     try:
-        data = read_config_for_update(cp)
+        await run_config_write(update_config_locked, cp, mutate=_apply)
     except ConfigReadError:
         logger.exception("Refusing to persist config from modal: config unreadable")
         return
-
-    slack_cfg = data.setdefault("slack", {})
-    slack_cfg["tracking_channels"] = [{"channel_id": cid} for cid in sorted(new_channels)]
-
-    # Persist FIRST, then mutate runtime state. A failed write (disk full,
-    # permissions) must not leave live state ahead of what is on disk — that
-    # silently reverts on the next restart.
-    try:
-        write_config_atomically(cp, data)
     except OSError:
         logger.exception("Failed to persist config from modal")
         return
@@ -1053,7 +1053,7 @@ async def _handle_ch_activation(payload: dict, action: dict) -> None:
 
     from kiro_crew.slack.handler import _persist_channel_config
 
-    _persist_channel_config(cid, activation=new_mode)
+    await run_config_write(_persist_channel_config, cid, activation=new_mode)
     if _orch:
         from kiro_crew.config.loader import KiroCrewConfig
 
@@ -1081,7 +1081,7 @@ async def _handle_ch_agent(payload: dict, action: dict) -> None:
 
     from kiro_crew.slack.handler import _persist_channel_config
 
-    _persist_channel_config(cid, agent=new_agent)
+    await run_config_write(_persist_channel_config, cid, agent=new_agent)
     if _orch:
         from kiro_crew.config.loader import KiroCrewConfig
 
@@ -1109,7 +1109,7 @@ async def _handle_ch_remove(payload: dict, action: dict) -> None:
 
     _orch._tracking_channels.discard(cid)
     set_tracking_channels(_orch._tracking_channels)
-    persist_tracking_channel(cid, remove=True)
+    await run_config_write(persist_tracking_channel, cid, remove=True)
     logger.info("Channel %s removed from tracking", cid)
     sel().log_api_access(
         caller=caller,
@@ -1137,7 +1137,7 @@ async def _handle_ch_add(payload: dict, action: dict) -> None:
 
     _orch._tracking_channels.add(cid)
     set_tracking_channels(_orch._tracking_channels)
-    persist_tracking_channel(cid)
+    await run_config_write(persist_tracking_channel, cid)
     logger.info("Channel %s added to tracking", cid)
     sel().log_api_access(
         caller=caller,
@@ -1173,18 +1173,12 @@ async def _handle_voice_config_submission(payload: dict) -> None:
     def _txt(block_id: str, action_id: str) -> str:
         return (values.get(block_id, {}).get(action_id, {}).get("value") or "").strip()
 
-    # Read BEFORE mutating the live voice config. Fail closed on an unreadable
-    # config: writing back a {} baseline would drop every other setting. Order
-    # matters — mutating `_vc` first would let rejected settings drive live TTS
-    # until the next restart, even though the save was refused.
+    # Compute the new values WITHOUT touching the live config yet. Fail closed
+    # on an unreadable config: writing back a {} baseline would drop every
+    # other setting. Order matters — mutating `_vc` first would let rejected
+    # settings drive live TTS until the next restart, even though the save was
+    # refused.
     cp = config_path()
-    try:
-        data = read_config_for_update(cp)
-    except ConfigReadError:
-        logger.exception("Refusing to persist voice settings: config unreadable")
-        return
-
-    # Compute the new values WITHOUT touching the live config yet.
     tts_block = values.get("tts_enabled_block", {}).get("mc_voice_tts_enabled", {})
     selected = {o.get("value") for o in tts_block.get("selected_options", [])}
     enabled = "enabled" in selected
@@ -1196,20 +1190,26 @@ async def _handle_voice_config_submission(payload: dict) -> None:
     aws_profile = _txt("profile_block", "mc_voice_profile")
     region = _txt("region_block", "mc_voice_region")
 
-    vr = data.setdefault("voice_reply", {})
-    vr["enabled"] = enabled
-    vr["auto_speak"] = auto_speak
-    vr["voice_id"] = voice
-    vr["engine"] = engine
-    vr["rate"] = rate
-    vr["pitch"] = pitch
-    vr["aws_profile"] = aws_profile
-    vr["region"] = region
+    def _apply(data: dict) -> dict:
+        vr = data.setdefault("voice_reply", {})
+        vr["enabled"] = enabled
+        vr["auto_speak"] = auto_speak
+        vr["voice_id"] = voice
+        vr["engine"] = engine
+        vr["rate"] = rate
+        vr["pitch"] = pitch
+        vr["aws_profile"] = aws_profile
+        vr["region"] = region
+        return data
 
-    # Persist FIRST, then apply to the live config. A failed write must not leave
-    # rejected settings driving live TTS until the next restart.
+    # Persist FIRST (locked read-modify-write), then apply to the live config.
+    # A failed write must not leave rejected settings driving live TTS until
+    # the next restart.
     try:
-        write_config_atomically(cp, data)
+        await run_config_write(update_config_locked, cp, mutate=_apply)
+    except ConfigReadError:
+        logger.exception("Refusing to persist voice settings: config unreadable")
+        return
     except OSError:
         logger.exception("Failed to persist voice config from modal")
         return
@@ -2084,7 +2084,9 @@ async def _handle_allowlist(
             return
         _orch._allowed_users.add(new_user_id)
         set_allowed_users(_orch._allowed_users)
-        persist_allowed_user(new_user_id, name=display_name)
+        await run_config_write(
+            persist_allowed_user, new_user_id, name=display_name
+        )
         sel().log_api_access(
             caller=approver_id,
             operation="slack.allowlist.approve",
@@ -2113,7 +2115,7 @@ async def _handle_allowlist(
         # Remove from in-memory set and persisted config
         _orch._allowed_users.discard(new_user_id)
         set_allowed_users(_orch._allowed_users)
-        persist_allowed_user(new_user_id, remove=True)
+        await run_config_write(persist_allowed_user, new_user_id, remove=True)
         sel().log_api_access(
             caller=approver_id,
             operation="slack.allowlist.deny",
@@ -2161,7 +2163,9 @@ async def _handle_track_channel(
             return
         _orch._tracking_channels.add(target_channel_id)
         set_tracking_channels(_orch._tracking_channels)
-        persist_tracking_channel(target_channel_id, name=channel_name)
+        await run_config_write(
+            persist_tracking_channel, target_channel_id, name=channel_name
+        )
         sel().log_api_access(
             caller=approver_id,
             operation="slack.track_channel.approve",
@@ -2178,7 +2182,9 @@ async def _handle_track_channel(
         # Remove from in-memory set and persisted config
         _orch._tracking_channels.discard(target_channel_id)
         set_tracking_channels(_orch._tracking_channels)
-        persist_tracking_channel(target_channel_id, remove=True)
+        await run_config_write(
+            persist_tracking_channel, target_channel_id, remove=True
+        )
         sel().log_api_access(
             caller=approver_id,
             operation="slack.track_channel.deny",
@@ -2216,7 +2222,7 @@ async def _handle_agent_select(
 
     if agent_name.lower() in ("off", "default"):
         try:
-            _set_default_agent("")
+            await run_config_write(_set_default_agent, "")
         except ValueError:
             return
         label = "🔄 Reset to default agent."
@@ -2225,7 +2231,7 @@ async def _handle_agent_select(
         if not resolved:
             return
         try:
-            _set_default_agent(resolved)
+            await run_config_write(_set_default_agent, resolved)
         except ValueError:
             return
         label = f"🔄 Switched to agent: *{resolved}*"
@@ -2264,23 +2270,24 @@ async def _handle_users_select(
 
     new_users = set(action.get("selected_users") or [])
 
-    # Read BEFORE mutating runtime state. Fail closed on an unreadable config:
-    # writing back a {} baseline would drop every other setting. Order matters —
-    # applying the in-memory change first would make a refused save look applied,
-    # then silently revert on restart.
+    # Persist through the locked read-modify-write BEFORE mutating runtime
+    # state. Fail closed on an unreadable config: writing back a {} baseline
+    # would drop every other setting. Order matters — applying the in-memory
+    # change first would make a refused save look applied, then silently
+    # revert on restart.
     cp = config_path()
+
+    def _apply(data: dict) -> dict:
+        data.setdefault("slack", {})["allowed_users"] = [
+            {"slack_id": uid} for uid in sorted(new_users)
+        ]
+        return data
+
     try:
-        data = read_config_for_update(cp)
+        await run_config_write(update_config_locked, cp, mutate=_apply)
     except ConfigReadError:
         logger.exception("Refusing to persist users from select: config unreadable")
         return
-
-    data.setdefault("slack", {})["allowed_users"] = [{"slack_id": uid} for uid in sorted(new_users)]
-
-    # Persist FIRST, then mutate runtime state (a failed write must not leave
-    # live state ahead of disk — it silently reverts on restart).
-    try:
-        write_config_atomically(cp, data)
     except OSError:
         logger.exception("Failed to persist users from select")
         return
@@ -2313,19 +2320,20 @@ async def _handle_channels_select(
     # Read BEFORE mutating runtime state (see the users-select handler above for
     # why the order is load-bearing).
     cp = config_path()
+
+    def _apply(data: dict) -> dict:
+        data.setdefault("slack", {})["tracking_channels"] = [
+            {"channel_id": cid} for cid in sorted(new_channels)
+        ]
+        return data
+
+    # Persist FIRST (locked read-modify-write), then mutate runtime state
+    # (see the users-select handler).
     try:
-        data = read_config_for_update(cp)
+        await run_config_write(update_config_locked, cp, mutate=_apply)
     except ConfigReadError:
         logger.exception("Refusing to persist channels from select: config unreadable")
         return
-
-    data.setdefault("slack", {})["tracking_channels"] = [
-        {"channel_id": cid} for cid in sorted(new_channels)
-    ]
-
-    # Persist FIRST, then mutate runtime state (see the users-select handler).
-    try:
-        write_config_atomically(cp, data)
     except OSError:
         logger.exception("Failed to persist channels from select")
         return
@@ -2543,7 +2551,7 @@ async def _handle_allowlist_remove(
 
     _orch._allowed_users.discard(target_id)
     set_allowed_users(_orch._allowed_users)
-    persist_allowed_user(target_id, remove=True)
+    await run_config_write(persist_allowed_user, target_id, remove=True)
 
     from kiro_crew.slack.blocks import allowlist_list_block
 
@@ -2584,7 +2592,7 @@ async def _handle_channel_remove(
 
     _orch._tracking_channels.discard(target_id)
     set_tracking_channels(_orch._tracking_channels)
-    persist_tracking_channel(target_id, remove=True)
+    await run_config_write(persist_tracking_channel, target_id, remove=True)
 
     from kiro_crew.slack.blocks import channel_list_block
 

--- a/test/test_config_meta_stamp.py
+++ b/test/test_config_meta_stamp.py
@@ -176,3 +176,159 @@ class TestConfigSaveKeepsMeta:
 
         assert saved["meta"]["lastTouchedVersion"] == __version__
         assert saved["agent"]["approval_mode"] == "interactive"
+
+
+class TestRefreshConfigMetaStamp:
+    """Upgrade-staleness repair for the stamp (#3102).
+
+    The stamp is only written as a side effect of a config write, so an
+    upgrade that never touches ``config.json`` leaves ``lastTouchedVersion``
+    naming the previous build. ``refresh_config_meta_stamp`` (called once per
+    gateway start, off the boot path) re-stamps exactly when the stored
+    version differs — and must never rewrite, create, or clobber otherwise.
+    """
+
+    def _patch_home(self, config_dir: Path):
+        return patch(
+            "kiro_crew.config.loader.config_path", return_value=config_dir / "config.json"
+        )
+
+    def test_stale_stamp_is_refreshed_and_settings_survive(self, tmp_path: Path) -> None:
+        from kiro_crew.config.loader import refresh_config_meta_stamp
+
+        (tmp_path / "config.json").write_text(
+            json.dumps({"meta": _OLD_STAMP, **_REAL_SETTINGS}), encoding="utf-8"
+        )
+        with self._patch_home(tmp_path):
+            assert refresh_config_meta_stamp() is True
+        saved = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+        assert saved["meta"]["lastTouchedVersion"] == __version__
+        assert saved["meta"]["lastTouchedAt"] != _OLD_STAMP["lastTouchedAt"]
+        assert {k: v for k, v in saved.items() if k != "meta"} == _REAL_SETTINGS
+
+    def test_missing_meta_block_is_stamped(self, tmp_path: Path) -> None:
+        from kiro_crew.config.loader import refresh_config_meta_stamp
+
+        (tmp_path / "config.json").write_text(json.dumps(_REAL_SETTINGS), encoding="utf-8")
+        with self._patch_home(tmp_path):
+            assert refresh_config_meta_stamp() is True
+        saved = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+        assert saved["meta"]["lastTouchedVersion"] == __version__
+
+    def test_current_stamp_is_not_rewritten(self, tmp_path: Path) -> None:
+        """No mtime churn / ``lastTouchedAt`` bump when nothing is stale."""
+        from kiro_crew.config.loader import refresh_config_meta_stamp, stamp_config_meta
+
+        current = stamp_config_meta(dict(_REAL_SETTINGS))
+        raw = json.dumps(current)
+        (tmp_path / "config.json").write_text(raw, encoding="utf-8")
+        with self._patch_home(tmp_path):
+            assert refresh_config_meta_stamp() is False
+        assert (tmp_path / "config.json").read_text(encoding="utf-8") == raw
+
+    def test_absent_file_is_left_absent(self, tmp_path: Path) -> None:
+        from kiro_crew.config.loader import refresh_config_meta_stamp
+
+        with self._patch_home(tmp_path):
+            assert refresh_config_meta_stamp() is False
+        assert not (tmp_path / "config.json").exists()
+
+    def test_unreadable_file_is_never_clobbered(self, tmp_path: Path) -> None:
+        """A torn/garbage config must not be replaced with a stamped empty one."""
+        from kiro_crew.config.loader import refresh_config_meta_stamp
+
+        (tmp_path / "config.json").write_text("{not json", encoding="utf-8")
+        with self._patch_home(tmp_path):
+            assert refresh_config_meta_stamp() is False
+        assert (tmp_path / "config.json").read_text(encoding="utf-8") == "{not json"
+
+    def test_refresh_routes_through_the_locked_primitive(self) -> None:
+        """The refresh must hold the sidecar advisory lock for its read-modify-write.
+
+        update_config_locked is 'the required path for new config.json
+        mutations' (its own docstring): it serializes the whole read→write
+        under the <config>.lock sidecar, so a boot-time refresh can never
+        revert a concurrent settings write with its own earlier snapshot.
+        A bare read_config_for_update + write_config_atomically pair
+        reintroduces exactly that lost-update race.
+        """
+        import inspect
+
+        from kiro_crew.config import loader
+
+        src = inspect.getsource(loader.refresh_config_meta_stamp)
+        assert "update_config_locked(" in src
+        assert "write_config_atomically(" not in src
+
+    def test_gateway_schedules_the_refresh_off_the_boot_path(self) -> None:
+        """start_dashboard fires the refresh as a deferred, off-loop task.
+
+        Structural on purpose: booting a full gateway to observe one config
+        write is a heavyweight harness for a wiring fact. The refresh must be
+        (a) present in start_dashboard, (b) wrapped in to_thread inside a
+        created task, never awaited inline, and (c) scheduled AFTER the
+        socket binds — an inline `await asyncio.to_thread(...)` placed
+        before _start_site would satisfy (a) and (b) alone, so the ordering
+        assertion is what actually pins the boot-path rule
+        (AUTOSDE: no-new-work-on-gateway-boot-path).
+        """
+        import inspect
+
+        from kiro_crew.dashboard import server
+
+        src = inspect.getsource(server.start_dashboard)
+        assert "asyncio.to_thread(refresh_config_meta_stamp)" in src
+        assert "await refresh_config_meta_stamp" not in src
+        assert "_stamp_task = asyncio.create_task(" in src
+        assert src.index("await _start_site(") < src.index(
+            "asyncio.to_thread(refresh_config_meta_stamp)"
+        )
+
+
+class TestDashboardNeverSurfacesThePersistedMarker:
+    """The version the dashboard reports is the running build's, not the stamp.
+
+    Issue #3102's reporter found ``lastTouchedVersion: 0.1.3`` in their config
+    and reasonably suspected it fed the Settings header. It does not — every
+    status producer reports ``kiro_crew.__version__`` — and this locks that
+    in: wiring the persisted marker into any dashboard module fails here.
+    """
+
+    def test_status_producers_report_the_running_version(self) -> None:
+        import kiro_crew
+        from kiro_crew.dashboard import ws
+        from kiro_crew.dashboard.handlers import updates
+
+        assert ws._local_version == kiro_crew.__version__
+        assert updates._local_version == kiro_crew.__version__
+
+    def test_api_status_reads_the_module_version(self) -> None:
+        import inspect
+
+        from kiro_crew.dashboard import handlers_system
+
+        src = inspect.getsource(handlers_system.api_status)
+        assert '"version": kiro_crew.__version__' in src
+
+    def test_no_dashboard_module_reads_the_marker(self) -> None:
+        import re
+
+        dashboard_dir = (
+            Path(__file__).resolve().parents[1] / "src" / "kiro_crew" / "dashboard"
+        )
+        # Match an actual READ of the field — subscript or .get() — not a bare
+        # mention: a comment documenting "the running version, NOT the
+        # persisted lastTouchedVersion marker" is the natural way to record
+        # this invariant and must not turn the suite red.
+        read_pattern = re.compile(
+            r"""\[\s*["']lastTouchedVersion["']\s*\]|get\(\s*["']lastTouchedVersion["']"""
+        )
+        offenders = [
+            p
+            for p in dashboard_dir.rglob("*.py")
+            if read_pattern.search(p.read_text(encoding="utf-8", errors="ignore"))
+        ]
+        assert offenders == [], (
+            "the persisted config stamp must never be surfaced as the app "
+            f"version; remove the read from: {offenders}"
+        )

--- a/test/test_run_config_write.py
+++ b/test/test_run_config_write.py
@@ -1,0 +1,104 @@
+"""Both-locks discipline for Slack ``config.json`` writers (#3102 review).
+
+``run_config_write`` exists because two writer generations serialize on two
+DIFFERENT locks: ``update_config_locked`` takes the sidecar advisory flock,
+while the dashboard's legacy handlers (e.g. the memory-settings PUT) do a bare
+read-modify-write under only the loop-side ``_get_config_lock()``. A Slack
+writer holding only the flock can interleave with the legacy family and
+silently revert its settings. The helper is the single async entry point that
+holds both: asyncio lock on the loop, blocking writer in a worker thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.dashboard.chat_utils import run_config_write
+
+SRC = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+
+#: The sync config-writing callables Slack's async handlers invoke. Every
+#: invocation from async Slack code must go through run_config_write.
+_CONFIG_WRITERS = (
+    "update_config_locked",
+    "_set_default_agent",
+    "_persist_channel_config",
+    "persist_allowed_user",
+    "persist_tracking_channel",
+)
+
+_SLACK_SOURCES = ("interactions.py", "handler.py", "events.py", "allowlist.py")
+
+
+class TestRunConfigWrite:
+    @pytest.mark.asyncio
+    async def test_returns_the_callables_result(self) -> None:
+        assert await run_config_write(lambda a, b=0: a + b, 40, b=2) == 42
+
+    @pytest.mark.asyncio
+    async def test_holds_the_loop_side_config_lock_while_fn_runs(self) -> None:
+        """While the dashboard lock is held, the write must not start."""
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+        ran = asyncio.Event()
+
+        async def _write() -> None:
+            await run_config_write(lambda: ran.set())
+
+        lock = _get_config_lock()
+        async with lock:
+            task = asyncio.create_task(_write())
+            await asyncio.sleep(0.05)
+            assert not ran.is_set(), "write started while a legacy writer held the lock"
+        await asyncio.wait_for(task, timeout=5)
+        assert ran.is_set()
+
+    @pytest.mark.asyncio
+    async def test_runs_fn_off_the_event_loop(self) -> None:
+        """The blocking flock wait must land in a worker thread, not the loop."""
+        import threading
+
+        loop_thread = threading.current_thread()
+        fn_thread: list[threading.Thread] = []
+        await run_config_write(lambda: fn_thread.append(threading.current_thread()))
+        assert fn_thread and fn_thread[0] is not loop_thread
+
+
+class TestSlackWritersUseBothLocks:
+    """Structural lock-ins: no Slack async caller bypasses the helper."""
+
+    def test_no_slack_config_write_is_offloaded_without_the_loop_lock(self) -> None:
+        # `asyncio.to_thread(<config writer>` holds only the flock — the exact
+        # single-lock bypass this round's review blocked on.
+        pattern = re.compile(
+            r"asyncio\.to_thread\(\s*(?:" + "|".join(_CONFIG_WRITERS) + r")\b"
+        )
+        offenders = [
+            f"{name}: {m.group(0)!r}"
+            for name in _SLACK_SOURCES
+            for m in pattern.finditer((SRC / "slack" / name).read_text(encoding="utf-8"))
+        ]
+        assert offenders == [], f"config writers offloaded without _get_config_lock: {offenders}"
+
+    def test_no_slack_async_function_calls_a_config_writer_inline(self) -> None:
+        """Inside `async def`, a bare (un-awaited-wrapper) writer call blocks the
+        loop on the flock. Definitions and run_config_write args don't match."""
+        import ast
+
+        offenders: list[str] = []
+        for name in _SLACK_SOURCES:
+            tree = ast.parse((SRC / "slack" / name).read_text(encoding="utf-8"))
+            for fn in ast.walk(tree):
+                if not isinstance(fn, ast.AsyncFunctionDef):
+                    continue
+                for node in ast.walk(fn):
+                    if not isinstance(node, ast.Call):
+                        continue
+                    callee = node.func
+                    if isinstance(callee, ast.Name) and callee.id in _CONFIG_WRITERS:
+                        offenders.append(f"{name}:{node.lineno} {fn.name} -> {callee.id}")
+        assert offenders == [], f"inline config-writer calls on the event loop: {offenders}"

--- a/test/test_slack_handler_coverage_branches.py
+++ b/test/test_slack_handler_coverage_branches.py
@@ -256,51 +256,48 @@ class TestConfigWriteFailures:
         return cfg
 
     def test_set_default_agent_read_error(self, monkeypatch):
-        def _boom(_path):
+        def _boom(_path, *, mutate):
             raise ConfigReadError("config.json is not valid JSON")
 
-        monkeypatch.setattr(h, "read_config_for_update", _boom)
+        monkeypatch.setattr(h, "update_config_locked", _boom)
         with pytest.raises(ValueError, match="Failed to read config"):
             h._set_default_agent("kirocrew")
         assert h._cached_default_agent is None
 
     def test_set_default_agent_write_error(self, monkeypatch):
-        monkeypatch.setattr(h, "read_config_for_update", lambda _p: {})
-
-        def _boom(_path, _data):
+        def _boom(_path, *, mutate):
             raise OSError("disk full")
 
-        monkeypatch.setattr(h, "write_config_atomically", _boom)
+        monkeypatch.setattr(h, "update_config_locked", _boom)
         with pytest.raises(ValueError, match="Failed to write config"):
             h._set_default_agent("kirocrew")
         # Cache must NOT advance past a failed write.
         assert h._cached_default_agent is None
 
     def test_persist_channel_config_read_error(self, monkeypatch):
-        def _boom(_path):
+        def _boom(_path, *, mutate):
             raise ConfigReadError("truncated file")
 
-        monkeypatch.setattr(h, "read_config_for_update", _boom)
+        monkeypatch.setattr(h, "update_config_locked", _boom)
         with pytest.raises(ValueError, match="Failed to read config"):
             h._persist_channel_config("C1", activation="mention")
 
     def test_persist_channel_config_write_error(self, monkeypatch):
-        monkeypatch.setattr(h, "read_config_for_update", lambda _p: {})
-
-        def _boom(_path, _data):
+        def _boom(_path, *, mutate):
             raise OSError("read-only filesystem")
 
-        monkeypatch.setattr(h, "write_config_atomically", _boom)
+        monkeypatch.setattr(h, "update_config_locked", _boom)
         with pytest.raises(ValueError, match="Failed to write config"):
             h._persist_channel_config("C1", agent="kirocrew")
 
-    def test_persist_channel_config_merges_both_fields(self, monkeypatch):
-        written: dict = {}
-        monkeypatch.setattr(h, "read_config_for_update", lambda _p: {"slack": {"bot": "x"}})
-        monkeypatch.setattr(
-            h, "write_config_atomically", lambda _p, data: written.update(data)
-        )
+    def test_persist_channel_config_merges_both_fields(self, monkeypatch, tmp_path):
+        # Real file through the real locked primitive: the write must merge
+        # into existing settings, not overwrite them.
+        cfg = tmp_path / "config.json"
+        cfg.write_text(json.dumps({"slack": {"bot": "x"}}), encoding="utf-8", newline="\n")
+        monkeypatch.setattr(h, "config_path", lambda: cfg)
         h._persist_channel_config("C9", activation="always", agent="kirocrew")
+        written = json.loads(cfg.read_text(encoding="utf-8"))
         ch = written["slack"]["channels"]["C9"]
         assert ch == {"activation": "always", "agent": "kirocrew"}
         # Sibling keys survive the merge.

--- a/test/test_slack_interactions_coverage.py
+++ b/test/test_slack_interactions_coverage.py
@@ -265,10 +265,10 @@ class TestConfigSubmission:
     async def test_unreadable_config_fails_closed(
         self, orch: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def boom(_path: Any) -> dict:
+        def boom(_path: Any, **_kw: Any) -> dict:
             raise ConfigReadError("corrupt")
 
-        monkeypatch.setattr(ix, "read_config_for_update", boom)
+        monkeypatch.setattr(ix, "update_config_locked", boom)
         await ix._handle_config_submission(self._view(["C9"]))
         # Runtime state must NOT move ahead of an unwritable disk.
         assert orch._tracking_channels == set()
@@ -277,10 +277,10 @@ class TestConfigSubmission:
     async def test_write_failure_leaves_runtime_untouched(
         self, orch: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def boom(_path: Any, _data: Any) -> None:
+        def boom(_path: Any, **_kw: Any) -> None:
             raise OSError("disk full")
 
-        monkeypatch.setattr(ix, "write_config_atomically", boom)
+        monkeypatch.setattr(ix, "update_config_locked", boom)
         await ix._handle_config_submission(self._view(["C9"]))
         assert orch._tracking_channels == set()
 
@@ -879,10 +879,10 @@ class TestVoiceConfigSubmission:
     async def test_unreadable_config_fails_closed(
         self, orch: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def boom(_path: Any) -> dict:
+        def boom(_path: Any, **_kw: Any) -> dict:
             raise ConfigReadError("corrupt")
 
-        monkeypatch.setattr(ix, "read_config_for_update", boom)
+        monkeypatch.setattr(ix, "update_config_locked", boom)
         sh._vc.global_enabled = False
         await ix._handle_voice_config_submission(_voice_view(tts=["enabled"]))
         # Live TTS must not be driven by a refused save.
@@ -892,10 +892,10 @@ class TestVoiceConfigSubmission:
     async def test_write_failure_leaves_live_config_untouched(
         self, orch: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def boom(_path: Any, _data: Any) -> None:
+        def boom(_path: Any, **_kw: Any) -> None:
             raise OSError("disk full")
 
-        monkeypatch.setattr(ix, "write_config_atomically", boom)
+        monkeypatch.setattr(ix, "update_config_locked", boom)
         sh._vc.global_enabled = False
         await ix._handle_voice_config_submission(_voice_view(tts=["enabled"]))
         assert sh._vc.global_enabled is False
@@ -1221,10 +1221,10 @@ class TestUsersSelect:
     async def test_unreadable_config_fails_closed(
         self, orch: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def boom(_path: Any) -> dict:
+        def boom(_path: Any, **_kw: Any) -> dict:
             raise ConfigReadError("corrupt")
 
-        monkeypatch.setattr(ix, "read_config_for_update", boom)
+        monkeypatch.setattr(ix, "update_config_locked", boom)
         action = {"action_id": "mc_users_select", "selected_users": ["Ua"]}
         await ix._handle_users_select(_payload(), action, "C1", "m1", "U1")
         assert orch._allowed_users == set()
@@ -1233,10 +1233,10 @@ class TestUsersSelect:
     async def test_write_failure_leaves_runtime_untouched(
         self, orch: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def boom(_path: Any, _data: Any) -> None:
+        def boom(_path: Any, **_kw: Any) -> None:
             raise OSError("disk full")
 
-        monkeypatch.setattr(ix, "write_config_atomically", boom)
+        monkeypatch.setattr(ix, "update_config_locked", boom)
         action = {"action_id": "mc_users_select", "selected_users": ["Ua"]}
         await ix._handle_users_select(_payload(), action, "C1", "m1", "U1")
         assert orch._allowed_users == set()
@@ -1275,10 +1275,10 @@ class TestChannelsSelect:
     async def test_unreadable_config_fails_closed(
         self, orch: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def boom(_path: Any) -> dict:
+        def boom(_path: Any, **_kw: Any) -> dict:
             raise ConfigReadError("corrupt")
 
-        monkeypatch.setattr(ix, "read_config_for_update", boom)
+        monkeypatch.setattr(ix, "update_config_locked", boom)
         action = {"action_id": "mc_channels_select", "selected_channels": ["Ca"]}
         await ix._handle_channels_select(_payload(), action, "C1", "m1", "U1")
         assert orch._tracking_channels == set()
@@ -1287,10 +1287,10 @@ class TestChannelsSelect:
     async def test_write_failure_leaves_runtime_untouched(
         self, orch: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def boom(_path: Any, _data: Any) -> None:
+        def boom(_path: Any, **_kw: Any) -> None:
             raise OSError("disk full")
 
-        monkeypatch.setattr(ix, "write_config_atomically", boom)
+        monkeypatch.setattr(ix, "update_config_locked", boom)
         action = {"action_id": "mc_channels_select", "selected_channels": ["Ca"]}
         await ix._handle_channels_select(_payload(), action, "C1", "m1", "U1")
         assert orch._tracking_channels == set()


### PR DESCRIPTION
# Problem

After upgrading a desktop install from 0.1.3 to 0.2.0, the Settings page reported two different versions at once — the Overview header and the tab bar said 0.1.3 while About said 0.2.0 — and the Releases tab failed with "Could not load the release notes." The reporter also found `config.json` still carrying `"lastTouchedVersion": "0.1.3"` long after the upgrade.

# Why it matters

Version is the first thing anyone checks when reporting a problem or verifying an update landed. Three surfaces on one page giving two answers means none can be trusted, and the stale `lastTouchedVersion` marker actively misleads whoever debugs it: the field's own docstring says it names "the build that wrote the bytes now on disk", but after an upgrade it silently keeps naming a build that is no longer installed — which is exactly what sent this issue's investigation down the wrong path.

# Fix (symptoms → root cause → change)

**Confirmed version chain (traced, not assumed).** The issue proposed a stale cached frontend chunk carrying a build-time version constant. That hypothesis was checked and ruled out — by the reporter's own evidence (a grep of the packed app found `0.1.3` nowhere) and by the code: the header and tab bar read `s.dashboard.status?.version` (`website/src/pages/SettingsPage.tsx:83`), a **runtime** value that only enters the Redux store from live gateway pushes. All three status producers report the running module constant `kiro_crew.__version__` directly: the WebSocket push (`dashboard/ws.py:317`), the SSE stream (`dashboard/handlers/updates.py`), and `/api/status` (`dashboard/handlers_system.py:202`). Nothing persists or caches it, and nothing anywhere reads `meta.lastTouchedVersion` for display.

So a header showing 0.1.3 means the dashboard was talking to a **gateway process actually running 0.1.3**. The desktop shell adopts an already-listening same-family gateway regardless of version (`website/electron/instance-guard.js`, `decideGatewayAction` → `same-family` reuse), so after an in-place upgrade an old gateway process that survived keeps serving the dashboard: header/tab bar show the old gateway's version, About shows the shell's own (`info?.version` from the Electron updater, `AboutPanel.tsx:347`). The Releases failure is downstream of the same split: the tab calls the gateway's `/api/releases`, an endpoint that shipped in 0.2.0 (CHANGELOG "Releases tab"), so a 0.1.3 gateway 404s it and the panel shows its fetch-failure message. The reporter verified the 0.2.0 backend **binary on disk**, which says nothing about the process holding the port.

**What this PR changes.** The in-repo defect this leaves behind is the marker: `meta.lastTouchedVersion` is only written as a side effect of a config write (`stamp_config_meta`), so an upgrade that never touches `config.json` leaves it stale forever — corroborating the wrong theory in this issue and any future one. The fix makes it mean what its docstring says:

- `refresh_config_meta_stamp()` (`src/kiro_crew/config/loader.py`): re-stamps the `meta` block when the stored version differs from the running `__version__`. A plain field refresh, not a migration framework: every other key is preserved, a matching stamp writes nothing (no mtime churn), an absent/empty config is left alone, and an unreadable/torn config is never replaced (fail-closed via `ConfigReadError`). The read-modify-write routes through `update_config_locked` — the required locked path for new `config.json` mutations — so the refresh holds the sidecar advisory lock and cannot revert a concurrent settings write with its own earlier snapshot. Both failure exits log at debug so a permanently unwritable config is distinguishable from a healthy refresh.
- `start_dashboard` (`src/kiro_crew/dashboard/server.py`): fires the refresh once per gateway start, **post-bind**, as `asyncio.create_task` + `asyncio.to_thread` (never awaited on the boot path, per the `no-new-work-on-gateway-boot-path` rule), holding the in-process asyncio config lock around the off-thread call so legacy writers that serialize on that lock alone are also covered.
- **Slack config writers converted to the locked path** (`slack/handler.py`, `slack/interactions.py`, `slack/allowlist.py`): review surfaced that seven Slack-side `config.json` writers — `!channel` activation/agent, the config/voice/users/channels modals, and the allowlist add/remove helpers — held *neither* the sidecar lock nor the asyncio config lock, so any of them racing any other writer (including the new refresh) could be silently reverted by the loser's stale snapshot. All seven now route through `update_config_locked`, preserving their fail-closed reads, persist-before-runtime-mutation ordering, and idempotent no-op semantics (the allowlist helpers skip the write entirely when nothing changes). This closes the pre-existing lost-update window between Slack writers and dashboard/CLI writers as well, not just against the refresh. Because two writer generations serialize on two different locks — the locked primitive takes the sidecar flock, while legacy dashboard handlers (e.g. the memory-settings PUT) do a bare read-modify-write under only the loop-side asyncio config lock — every converted Slack call goes through a new `run_config_write` helper (`dashboard/chat_utils.py`) that holds BOTH: the asyncio lock on the event loop, then the blocking writer via `asyncio.to_thread` in a worker thread (the sync helpers `_set_default_agent` / `_persist_channel_config` / `persist_allowed_user` / `persist_tracking_channel` stay synchronous and are wrapped at each async call site). This matches how the boot-time refresh and the dashboard PATCH handlers invoke the same primitive, so a concurrent lock holder can never stall chat turns or the liveness heartbeat, and neither writer family can silently revert the other from a stale snapshot.

**Deliberately out of scope** (product decision, not repo convention): whether the desktop shell should refuse or restart a same-family gateway whose version differs from its own. `decideGatewayAction`'s reuse-on-ambiguity contract is load-bearing for dev gateways and `ssh -L` forwards; changing adoption semantics needs a maintainer call. This PR makes the surviving evidence truthful; it does not change gateway adoption, the update mechanism, or the release feed.

# Tests

`test/test_config_meta_stamp.py` (+9):

- **Refresh behavior:** stale stamp → refreshed to `__version__` with all settings preserved; missing `meta` block → stamped; current stamp → file bytes untouched (no rewrite); absent file → left absent; garbage file → never clobbered.
- **Locked-path lock-in (structural):** `refresh_config_meta_stamp` must route through `update_config_locked` and must not call `write_config_atomically` directly — reintroducing the bare read-modify-write pair fails the test.
- **Boot-path lock-in (structural):** the refresh must appear in `start_dashboard` after `await _start_site(...)`, wrapped in `create_task` + `to_thread`, never awaited inline — an inline pre-bind `await` fails the ordering assertion.
- **Single-source lock-in:** `ws.py` and `handlers/updates.py` `_local_version` are `kiro_crew.__version__`; `api_status` reads the module version; and no dashboard module performs an actual read (subscript/`.get()`) of `lastTouchedVersion` — wiring the persisted marker into any dashboard surface fails the suite.

All 21 tests in the file pass, plus 1,287 across the touched Slack/config test files, including a new `test_run_config_write.py` (behavioral: the helper holds the loop-side lock while the writer runs off-thread; structural: no Slack async caller invokes a config writer inline or offloads one without the loop lock — both proven non-vacuous against the pre-fix patterns); isort/flake8 clean; mypy clean over 939 files. Two model-pinned pre-push reviewers ran: GPT 5.6 Sol found 1 blocking (the unlocked read-modify-write race — fixed by routing through `update_config_locked` + holding the asyncio config lock at the call site); Opus 5 independently found the same blocking plus 3 advisories (silent failure exits, a boot-path test hole, a mention-vs-read test overmatch) — all fixed. The server GPT reviewer's round-1 blocking finding (the Slack `!channel` writer held neither lock, so the refresh could still erase it) is fixed by the locked-path conversion above.

# Manual verification

Seeded a config carrying `"lastTouchedVersion": "0.1.3"` under a scratch `KIROCREW_HOME` and invoked the refresh: the stamp updates to the running version, all other keys survive byte-identical, and a second invocation writes nothing. Full-suite pytest on the dev host: 47,810 passed; the 90 failures/19 errors carry explicit `ENOSPC`/tmpfs-inode signatures from concurrent suites sharing the host's `/tmp` and touch no file in this diff (my test file passes 21/21 in isolation).

# Screenshots

N/A — no user-visible UI change. The dashboard already renders the running gateway's version on every surface; this PR fixes the on-disk marker and locks the display invariant in with tests.

Closes #3102

