### PR TITLE
test: patch moved mcp_core helpers where consumers import them (#3155)

### DIFF
--- a/test/test_mcp_core_more_coverage.py
+++ b/test/test_mcp_core_more_coverage.py
@@ -540,7 +540,7 @@ class TestWaitTool:
         with patch.object(mcp_core, "time", clock):
             with patch.object(mcp_core, "_resolve_session_key_strict", return_value=strict_key):
                 with patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:c"):
-                    with patch.object(mcp_core, "is_tool_cancelled", return_value=False):
+                    with patch("kiro_crew.mcp_tools.control.is_tool_cancelled", return_value=False):
                         with patch.object(mcp_core, "sel", lambda: rec):
                             with patch.object(mcp_core, "_post", post) as p:
                                 out = _call_tool_inner("wait", dict(args))
@@ -647,7 +647,7 @@ class TestWaitTool:
         rec = _RecordingSel()
         with patch.object(mcp_core, "time", clock):
             with patch.object(mcp_core, "_resolve_session_key_strict", return_value=""):
-                with patch.object(mcp_core, "is_tool_cancelled", return_value=True):
+                with patch("kiro_crew.mcp_tools.control.is_tool_cancelled", return_value=True):
                     with patch.object(mcp_core, "sel", lambda: rec):
                         with patch.object(mcp_core, "_post", lambda *a, **k: {}):
                             with pytest.raises(ToolCancelled) as ei:
@@ -947,8 +947,8 @@ class TestResourceStatusTool:
             else (lambda _c: cap)
         )
         with patch("kiro_crew.resource_status.probe", return_value=rstatus):
-            with patch.object(mcp_core, "KiroCrewConfig", cfg):
-                with patch.object(mcp_core, "resolve_max_subagents", resolver):
+            with patch("kiro_crew.mcp_tools.spawn.KiroCrewConfig", cfg):
+                with patch("kiro_crew.mcp_tools.spawn.resolve_max_subagents", resolver):
                     return _call_tool_inner("resource_status", {})
 
     def test_the_probe_summary_and_cap_are_reported(self) -> None:


### PR DESCRIPTION
## What broke

Main is red on Backend Tests shard 3 (3.10, 3.12, Windows) at `3c7cbf82`: 15 tests in `test/test_mcp_core_more_coverage.py` raise `AttributeError` because they `patch.object(mcp_core, ...)` two helpers that the per-domain mcp_tools refactor (#3127) moved out of `mcp_core` after #3118 added the tests. Main's own runs kept getting cancelled by rapid pushes, so the breakage surfaces in every open PR's merge-ref CI instead (first observed on #3141).

## What changed

Test-only: repoint three patch sites at the namespaces the handlers actually read at call time:

- `is_tool_cancelled` → `kiro_crew.mcp_tools.control.is_tool_cancelled` (control.py imports it from `mcp_shared` directly; it is not in mcp_core's `_HANDLER_SURFACE` seam)
- `resolve_max_subagents` → `kiro_crew.mcp_tools.spawn.resolve_max_subagents` (spawn.py imports it from `subagent` directly)
- `KiroCrewConfig` → `kiro_crew.mcp_tools.spawn.KiroCrewConfig`, repointed together with the resolver: the old target still resolves on mcp_core (no AttributeError) but no longer intercepts spawn.py's lookup, so the cap tests would silently have read the real config once the first two fixes landed.

## What was verified

`python -m pytest test/test_mcp_core_more_coverage.py` — 111/111 pass on this branch (15 failed at main). isort/flake8 clean on the touched file. No production code touched.

Closes #3155
