### PR TITLE
fix: use getattr for O_NOFOLLOW to support Windows

### DIFF
--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -1623,7 +1623,7 @@ async def api_file_download(request: web.Request) -> web.Response:
 
     # Read raw bytes via O_NOFOLLOW to atomically reject symlinks (no TOCTOU race).
     try:
-        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW",0))
         with os.fdopen(fd, "rb") as f:
             st = os.fstat(f.fileno())
             if st.st_size > _MAX_UPLOAD_BYTES:
@@ -1720,7 +1720,7 @@ async def api_file_raw(request: web.Request) -> web.Response:
     # Open with O_NOFOLLOW to atomically reject symlinks (no TOCTOU race).
     # Read header + full content through the same fd to avoid re-opening.
     try:
-        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
         with os.fdopen(fd, "rb") as f:
             st = os.fstat(f.fileno())
             if st.st_size > _MAX_UPLOAD_BYTES:

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -1623,7 +1623,7 @@ async def api_file_download(request: web.Request) -> web.Response:
 
     # Read raw bytes via O_NOFOLLOW to atomically reject symlinks (no TOCTOU race).
     try:
-        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW",0))
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
         with os.fdopen(fd, "rb") as f:
             st = os.fstat(f.fileno())
             if st.st_size > _MAX_UPLOAD_BYTES:


### PR DESCRIPTION
Closes #3164

## What

`os.O_NOFOLLOW` does not exist on Windows, causing an `AttributeError` crash in `dashboard/handlers/files.py` whenever the file viewer endpoint is called.

## Why

`O_NOFOLLOW` is a POSIX-only flag. The rest of the codebase already handles this with `getattr(os, "O_NOFOLLOW", 0)` — used in 15+ other places (`hooks.py`, `steering.py`, `apps/manager.py`, etc.). This PR applies the same pattern to the two affected lines.

## Change

- `files.py` line 1626: `os.O_NOFOLLOW` → `getattr(os, "O_NOFOLLOW", 0)`
- `files.py` line 1723: `os.O_NOFOLLOW` → `getattr(os, "O_NOFOLLOW", 0)`

## Testing

Reproduced and verified on Windows 11, Python 3.12. File viewer no longer crashes after this change.