### PR TITLE
fix: flush the slot before stamping a session summary's signature

### DIFF
--- a/docs/system-specs/modules/session-summary.md
+++ b/docs/system-specs/modules/session-summary.md
@@ -49,6 +49,22 @@ untouched.
 the cache; a metadata-only rewrite does not. This makes staleness exact and free
 to check — one `stat`, no content comparison.
 
+**The pass flushes the slot before it captures `sig`.** `_ChatSlot.append` marks a
+slot dirty and leaves the disk write to the 5s `_flush_loop`, and this pass is
+dispatched from `_finish_queue_cycle` in the same synchronous block that appended
+the turn's final assistant message. So at dispatch the transcript is always
+missing the very turn being summarised, and a signature taken then is invalidated
+the moment the loop fires — mid-model-call, since that call takes seconds. Every
+write was refused, on every turn, and the "don't advance the turn mark, the next
+turn retries" recovery could not converge because each turn reproduces it.
+`state.flush_slot_now(slot)` lands the pending write first, so the signature
+stamps the transcript the summary actually describes.
+
+Clearing the dirty bit is part of that, not incidental: a flush that wrote the
+bytes but left the slot dirty would be re-saved by the loop moments later, moving
+the mtime again. `flush_slot_now` is shared with `_flush_dirty_slots` so the
+generation-compare bookkeeping that makes the clear safe lives in one place.
+
 **It is a different file from the one-line summary.** `.summaries/<key>.json`
 holds the on-demand one-line description shown in the sessions list, written by
 `set_cached_summary`, which overwrites the whole file. The two artifacts have

--- a/src/kiro_crew/dashboard/chat_summary.py
+++ b/src/kiro_crew/dashboard/chat_summary.py
@@ -225,6 +225,22 @@ async def generate_session_summary(
         logger.debug("Session summary skipped for %s: %s", key, skip)
         return False
 
+    # Land this slot's pending transcript write BEFORE capturing the signature.
+    # ``_ChatSlot.append`` only marks the slot dirty; the bytes reach disk on the
+    # 5s ``_flush_loop``. This pass is dispatched from ``_finish_queue_cycle`` in
+    # the same synchronous block that just appended the turn's final assistant
+    # message, so the flush is always still pending here: the signature would be
+    # captured from a transcript that is about to change, and the write guard
+    # would refuse EVERY summary, on every turn. Not advancing the turn mark does
+    # not recover it either -- the next turn reproduces the same ordering.
+    #
+    # Slot-scoped rather than flushing every dirty slot: a summary has no
+    # business writing other sessions' transcripts. ``flush_slot_now`` carries
+    # the flush loop's dirty-bit bookkeeping, which matters here — a write that
+    # left the slot dirty would just be re-saved by the loop moments later,
+    # moving the mtime again and refusing the payload regardless.
+    await asyncio.to_thread(state.flush_slot_now, slot)
+
     # Capture the cache signature BEFORE reading the transcript. The signature
     # must be at least as old as the snapshot it stamps: any append landing
     # after this point advances the mtime, so the write guard in

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3148,38 +3148,55 @@ class DashboardState:
                 pass
             await asyncio.get_running_loop().run_in_executor(None, self._flush_dirty_slots)
 
+    def flush_slot_now(self, slot: _ChatSlot) -> None:
+        """Write ONE dirty slot to disk, with the flush loop's bookkeeping.
+
+        Shared with :meth:`_flush_dirty_slots` so the generation-compare contract
+        below lives in exactly one place. Callers that need a slot's pending
+        appends to be ON DISK before they read its transcript use this instead of
+        waiting up to ``_FLUSH_INTERVAL`` for the loop: the session-summary pass
+        stamps a cache signature from the transcript's mtime, so a pending write
+        landing afterwards invalidates the signature it just captured.
+
+        Clearing ``_dirty`` matters as much as the write. A caller that only
+        wrote the bytes would leave the slot dirty, the loop would re-save it
+        moments later, and the mtime would move again anyway.
+        """
+        if not self.conversation_log or not slot._dirty or not slot.messages:
+            return
+        from kiro_crew.dashboard.chat import _save_slot_to_history
+
+        # Clear the dirty bit only if NOTHING re-marked the slot while this save
+        # was running. This can run on an executor thread while the event loop
+        # keeps mutating the slot underneath it, so a plain post-save
+        # `_dirty = False` would overwrite a mark set DURING the save (e.g.
+        # _flush_file_changes attaching file_changes) — the stale snapshot would
+        # be the last thing written and every later pass would skip the slot, so
+        # the late mutation would never reach disk.
+        #
+        # The generation compare is used instead of consuming the bit up front
+        # because `_dirty` must stay True for the whole save: `chat_fork` reads
+        # it as "unpersisted state exists" (a False read makes it fork from
+        # stale disk), and `_save_slot_to_history`'s resumed-slot no-op guard is
+        # written assuming a dirty slot still reads dirty during the save.
+        # See the `_dirty` property for both contracts.
+        gen = slot._dirty_gen
+        try:
+            _save_slot_to_history(self, slot)
+        except Exception:
+            # Leave _dirty set so the next 5s pass retries.
+            logger.warning("Flush failed for slot %s", slot.key, exc_info=True)
+        else:
+            if slot._dirty_gen == gen:
+                slot._dirty = False
+
     def _flush_dirty_slots(self) -> None:
         """Write any slot with new messages to its JSONL file."""
         if not self.conversation_log:
             return
-        from kiro_crew.dashboard.chat import _save_slot_to_history
 
         for slot in list(self._slots.values()):
-            if not slot._dirty or not slot.messages:
-                continue
-            # Clear the dirty bit only if NOTHING re-marked the slot while this
-            # save was running. This runs on an executor thread and the event loop
-            # keeps mutating the slot underneath it, so a plain post-save
-            # `_dirty = False` would overwrite a mark set DURING the save (e.g.
-            # _flush_file_changes attaching file_changes) — the stale snapshot
-            # would be the last thing written and every later pass would skip the
-            # slot, so the late mutation would never reach disk.
-            #
-            # The generation compare is used instead of consuming the bit up front
-            # because `_dirty` must stay True for the whole save: `chat_fork` reads
-            # it as "unpersisted state exists" (a False read makes it fork from
-            # stale disk), and `_save_slot_to_history`'s resumed-slot no-op guard
-            # is written assuming a dirty slot still reads dirty during the save.
-            # See the `_dirty` property for both contracts.
-            gen = slot._dirty_gen
-            try:
-                _save_slot_to_history(self, slot)
-            except Exception:
-                # Leave _dirty set so the next 5s pass retries.
-                logger.warning("Flush failed for slot %s", slot.key, exc_info=True)
-            else:
-                if slot._dirty_gen == gen:
-                    slot._dirty = False
+            self.flush_slot_now(slot)
         # Snapshot the live tab set so a gateway restart can restore exactly
         # the tabs the user had open, regardless of last-message age. Without
         # this, restore_recent_sessions only brings back sessions whose

--- a/test/test_redact_meta_snapshot.py
+++ b/test/test_redact_meta_snapshot.py
@@ -186,6 +186,12 @@ def _flush_harness(save_fn):
     class _State:
         conversation_log = True
 
+        # The dirty-bit bookkeeping these tests pin now lives in
+        # ``flush_slot_now``, which ``_flush_dirty_slots`` calls per slot. Bind
+        # the REAL method so they still exercise production logic rather than a
+        # reimplementation of it.
+        flush_slot_now = DashboardState.flush_slot_now
+
         def __init__(self) -> None:
             self._slots = {"chat-1-test": slot}
 

--- a/test/test_session_summary_generate.py
+++ b/test/test_session_summary_generate.py
@@ -14,6 +14,7 @@ from chat_test_helpers import move_transcript_past
 
 from kiro_crew.config.loader import KiroCrewConfig, SessionSummaryConfig
 from kiro_crew.dashboard import chat_summary
+from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
 from kiro_crew.dashboard.chat_utils import slot_history_key
 from kiro_crew.dashboard.state import _ChatSlot
 from kiro_crew.history import ConversationLog
@@ -49,6 +50,20 @@ class _FakeState:
 
     def push_session_summary(self, key):
         self.pushed.append(key)
+
+    def flush_slot_now(self, slot):
+        """Mirror DashboardState.flush_slot_now: write, then clear the bit.
+
+        Clearing matters to what the pass under test relies on — a flush that
+        left the slot dirty would be re-saved by the 5s loop and move the mtime
+        again, so a stub that only wrote would hide the very bug this exercises.
+        """
+        if not slot._dirty or not slot.messages:
+            return
+        gen = slot._dirty_gen
+        _save_slot_to_history(self, slot)
+        if slot._dirty_gen == gen:
+            slot._dirty = False
 
 
 def _cfg(**overrides):
@@ -181,6 +196,87 @@ class TestGating:
         assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is True
         assert "request 0" in prompts[0]  # only on disk, not in slot.messages
 
+    async def test_the_turn_being_summarised_is_flushed_before_the_signature(
+        self, env, monkeypatch
+    ):
+        """The reason the panel stayed empty on every real session.
+
+        ``_ChatSlot.append`` marks the slot dirty; the bytes reach disk on the 5s
+        flush loop. This pass is dispatched from ``_finish_queue_cycle`` in the
+        same block that appended the turn's final assistant message, so the write
+        lands AFTER dispatch. A signature captured before it is stale the moment
+        the flush fires, and ``set_cached_intent_summary`` then refuses the
+        payload — on every turn, forever, since the next turn repeats it.
+
+        Here the slot carries a turn its transcript does not, which is exactly
+        the dirty-slot state at dispatch. The pass must flush it, then stamp the
+        post-flush mtime.
+        """
+        state, slot = env
+        log = state.conversation_log
+        # A turn the transcript does not have yet: dirty, unflushed. Assigning
+        # .messages bypasses _ChatSlot.append, which is what sets the bit in
+        # production, so set it explicitly — otherwise the flush is skipped and
+        # this test cannot distinguish the two behaviours.
+        slot.messages = _turns() + [
+            {"role": "user", "content": "the newest ask"},
+            {"role": "assistant", "content": "the reply that has not reached disk"},
+        ]
+        slot._dirty = True
+        _stub_llm(monkeypatch, _GOOD_REPLY)
+
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is True
+        # Stored AND readable as current: the signature matches the transcript
+        # that exists after the flush, so the strict reader serves it.
+        assert log.get_cached_intent_summary(state.hkey) is not None
+        # The unflushed turn reached disk, so the summary describes the whole
+        # session rather than everything except the turn that triggered it.
+        assert "the newest ask" in "".join(
+            m.get("content", "") for m in log.read_messages_chained(state.hkey)
+        )
+
+    async def test_the_flush_loop_firing_mid_model_call_does_not_lose_the_summary(
+        self, env, monkeypatch
+    ):
+        """The production symptom, reproduced.
+
+        The 5s flush loop is what actually invalidated the signature: it fires
+        while the model call is in flight, writes the dirty slot, and advances
+        the mtime past a signature captured before dispatch. The write guard then
+        refuses the payload and the panel never fills.
+
+        The stub below flushes the slot mid-call, standing in for that loop.
+        Flushing first makes it a no-op — the slot is already clean — so the
+        signature still matches at write time.
+        """
+        state, slot = env
+        log = state.conversation_log
+        slot.messages = _turns() + [
+            {"role": "user", "content": "the newest ask"},
+            {"role": "assistant", "content": "the reply that has not reached disk"},
+        ]
+        # Assigning .messages bypasses _ChatSlot.append, which is what sets the
+        # dirty bit in production. Set it explicitly or the flush stand-in below
+        # is inert and the test passes whether or not the fix is present.
+        slot._dirty = True
+
+        async def flush_then_reply(*args, **kwargs):
+            # Stand-in for _flush_dirty_slots firing during the model call. It
+            # mirrors that loop's guard: a CLEAN slot is skipped. So once the
+            # pass has flushed, this writes nothing and the signature holds;
+            # without the flush the slot is still dirty here and the write lands
+            # mid-call, moving the mtime out from under the captured signature.
+            if slot._dirty:
+                sig_before = log.session_mtime(state.hkey)
+                _save_slot_to_history(state, slot, force=True)
+                move_transcript_past(log, state.hkey, sig_before)
+            return _GOOD_REPLY
+
+        monkeypatch.setattr(chat_summary, "run_bg_oneliner", flush_then_reply)
+
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is True
+        assert log.get_cached_intent_summary(state.hkey) is not None
+
     async def test_an_append_during_the_transcript_read_refuses_the_write(
         self, env, monkeypatch
     ):
@@ -211,7 +307,12 @@ class TestGating:
         state, slot = env
         log = state.conversation_log
         log.delete_session(state.hkey)
-        _write_transcript(log, state.hkey, [{"role": "user", "content": "just one"}])
+        one_turn = [{"role": "user", "content": "just one"}]
+        _write_transcript(log, state.hkey, one_turn)
+        # The slot's in-memory window is the same conversation as its transcript:
+        # the pass flushes the window to disk before counting, so a fixture that
+        # left a longer window here would be counting a different session.
+        slot.messages = list(one_turn)
         called = []
         _stub_llm(monkeypatch, _GOOD_REPLY, called)
         ok = await chat_summary.generate_session_summary(state, slot, cfg=_cfg(min_user_turns=2))
@@ -241,15 +342,14 @@ class TestGating:
         state, slot = env
         log = state.conversation_log
         log.delete_session(state.hkey)
-        _write_transcript(
-            log,
-            state.hkey,
-            [
-                {"role": "user", "content": "real ask"},
-                {"role": "user", "content": "[Subagent completion event] done"},
-                {"role": "user", "content": '[Cron notification from "x"] fired'},
-            ],
-        )
+        rows = [
+            {"role": "user", "content": "real ask"},
+            {"role": "user", "content": "[Subagent completion event] done"},
+            {"role": "user", "content": '[Cron notification from "x"] fired'},
+        ]
+        _write_transcript(log, state.hkey, rows)
+        # Window and transcript are one conversation — see the note above.
+        slot.messages = list(rows)
         called = []
         _stub_llm(monkeypatch, _GOOD_REPLY, called)
         ok = await chat_summary.generate_session_summary(state, slot, cfg=_cfg(min_user_turns=2))


### PR DESCRIPTION
## Problem

The session summary panel never showed a summary. Not intermittently — **never**, on any session, since #2855 merged. Enabling `session_summary.enabled` produced a panel that read "No summary yet" forever.

The generator was running correctly the whole time: passing every gate, reading the transcript, spending a background model call, producing a valid payload — and then having its write refused and discarding it.

Measured on a real session, with `agent.log_level=DEBUG`:

```
16:44:34.111  user       (the only prompt — no follow-up)
16:45:26.192  assistant  the turn's final reply
              transcript mtime = 16:45:27.287     ← flush loop wrote it here
16:45:39.100  INFO  Session summary discarded for dashboard:chat-8-…: transcript gone or moved
```

## Why it matters

The feature is inert in production. Anyone who opts in gets a permanently empty panel and no indication why — the discard is logged at INFO, below the default `WARNING`, so it is invisible without turning the level up.

It also cannot self-heal. The refusal path deliberately does not advance the turn mark so "the next turn retries" — but every turn reproduces the same ordering, so it never converges.

## Fix (symptom → root cause → change)

**Symptom:** every write refused, `mtime != sig`.

**Root cause:** `_ChatSlot.append` marks a slot dirty and leaves the disk write to the 5s `_flush_loop`. The summary pass is dispatched from `_finish_queue_cycle` in the same synchronous block that appended the turn's final assistant message, so **at dispatch the transcript is always missing the very turn being summarised**. The signature captured there is invalidated the moment the loop fires — which lands mid-model-call, because that call takes seconds. The 1.1s gap between the assistant record's timestamp and the file's mtime above *is* that flush latency.

**The write guard is correct and is unchanged.** What was wrong is that the pass stamped a transcript it had not yet allowed to be written.

**Change:** the pass calls `state.flush_slot_now(slot)` before capturing `sig`.

Clearing the dirty bit is half the fix rather than a detail. `_save_slot_to_history` deliberately leaves `_dirty` set — the loop owns clearing it, because `chat_fork` reads the bit as "unpersisted state exists" and a false read makes it fork from stale disk. A flush that only wrote the bytes would be re-saved by the loop moments later and move the mtime again, refusing the write exactly as before. So the per-slot body of `_flush_dirty_slots` — including the generation compare that makes the clear safe against concurrent event-loop mutation — is **extracted into `flush_slot_now` and shared**, rather than duplicated with subtly different semantics.

Slot-scoped, not `_flush_dirty_slots`: a summary has no business writing other sessions' transcripts.

## Tests

- `test_the_turn_being_summarised_is_flushed_before_the_signature` — pins that the turn's own records reach disk before `sig` is taken, so the summary describes the session including the turn that triggered it.
- `test_the_flush_loop_firing_mid_model_call_does_not_lose_the_summary` — reproduces the production failure. The LLM stub stands in for the flush loop firing mid-call and **mirrors its skip-clean-slots guard**, so it writes nothing once the pass has flushed.

Both fail without the fix; the second fails with the exact production symptom (write refused). Verified by disabling the fix and re-running.

The three existing `_flush_dirty_slots` contract tests in `test_redact_meta_snapshot.py` are repointed at the extracted method so they still exercise production logic rather than a reimplementation.

127 tests pass across the session-summary suite plus those contract tests. `flake8`, `mypy`, `isort`, `docs-lint` clean.

## Manual verification

Verified end to end in an isolated dev gateway (`KIROCREW_HOME=~/.kirocrew-dev`, feature enabled) against a real session. Before the fix: three discards, zero stores. After:

```
17:13:41 INFO  Session summary stored for dashboard:chat-8-… (3 intents, 6 user turns)
```

The sidecar was written, and its `sig` matched the transcript mtime exactly — served as current, not stale. That is the first output this feature has ever produced.

## Screenshots

N/A — backend only. The panel that consumes this is a separate PR; no user-visible surface changes here.
