### PR TITLE
fix(sandbox): let a governance floor override the unsandboxed-exec opt-in

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -2783,6 +2783,26 @@ def _clamp_sandbox_mode(mode: str) -> str:
     return _clamp_sandbox_mode_to_floor(mode, _governance_sandbox_floor())
 
 
+def _floor_mandates_sandbox(floor: str | None) -> bool:
+    """True when an already-read ``sandbox.min_level`` *floor* requires isolation.
+
+    ``None`` means ungoverned.  A governed floor at the LOOSEST tier is a policy
+    that explicitly requires nothing, so testing the raw string for truthiness
+    would read "no isolation required" as "isolation mandatory" and refuse a
+    spawn the operator legitimately opted into — while telling them a floor of
+    ``off`` forbids unsandboxed execution.
+
+    The loosest tier is derived from the enforcer-owned ordinal registry rather
+    than hardcoded, matching :func:`_clamp_sandbox_mode_to_floor`: a renamed or
+    re-ordered scale must not silently invert this test.
+    """
+    if not floor:
+        return False
+    from kiro_crew.platform.governance import _ORDINAL_SCALES
+
+    return floor != _ORDINAL_SCALES["sandbox"][0]
+
+
 def _clamp_sandbox_mode_to_floor(mode: str, floor: str | None) -> str:
     """Clamp *mode* UP to an already-read ``sandbox.min_level`` *floor*, if any.
 
@@ -3147,7 +3167,22 @@ def wrap_argv(
         # This addresses a penetration-test finding — the previous behavior silently
         # returned unmodified argv, allowing the agent subprocess to access all
         # credential paths without any OS-level isolation.
-        if not _allow_unsandboxed_exec():
+        #
+        # ONE read of the opt-in: the gate below and the message that explains a
+        # refusal must describe the same state, and a concurrent config reload
+        # must not let them disagree about the same spawn.
+        opted_in = _allow_unsandboxed_exec()
+        # A governance ``sandbox.min_level`` floor OVERRIDES the config opt-in
+        # (issue #3162).  Before this, the floor did the opposite of what pinning
+        # it implies: it disabled the audited first-party carve-out below while
+        # leaving this broad opt-in untouched, so a governed fleet lost the
+        # constrained path and kept the unconstrained one.  ``config.json`` is not
+        # policy — the floor is — so the flag cannot re-open this on a governed
+        # host.  Derived from the ONE floor read taken at the top of this call,
+        # and via ``_floor_mandates_sandbox`` rather than raw truthiness, because
+        # a pinned floor of the loosest tier requires nothing and must not deny.
+        floor_mandates_sandbox = _floor_mandates_sandbox(governance_floor)
+        if floor_mandates_sandbox or not opted_in:
             # ONE read of the pair: a concurrent re-probe swaps the whole tuple,
             # so failure and remedy can never come from different probes.
             transient, probe_reason, probe_remedy = _last_unshare_failure or (
@@ -3244,6 +3279,41 @@ def wrap_argv(
                 )
             else:
                 guidance = _no_backend_guidance()
+            # When the policy floor is what refused, every guidance above points
+            # at the wrong lever: the operator HAS set the opt-in and the flag is
+            # deliberately powerless here, so naming it would send them down a
+            # dead end.  Replace the remedy rather than appending to it.
+            policy_overrode_opt_in = floor_mandates_sandbox and opted_in
+            if policy_overrode_opt_in:
+                guidance = (
+                    "This host is GOVERNED: an enterprise policy pins "
+                    f"sandbox.min_level={governance_floor!r}, which forbids "
+                    "unsandboxed execution regardless of "
+                    "agent.sandbox_allow_unsandboxed_exec — that flag is set on "
+                    "this host and is deliberately powerless against the policy, "
+                    "so editing config.json cannot resolve this. A governed host "
+                    "also withholds the first-party carve-out, so Kiro Crew's own "
+                    "built-in spawns are refused here too: this host runs no "
+                    "agent subprocess until it has a working sandbox backend "
+                    "(see docs/system-specs/modules/security.md) or the policy "
+                    "owner relaxes sandbox.min_level."
+                )
+                sel_reason = (
+                    "No sandbox backend available and a governance "
+                    f"sandbox.min_level={governance_floor!r} floor forbids "
+                    "unsandboxed exec (the config opt-in is set but overridden)"
+                )
+                refusal = (
+                    "Sandbox backend unavailable and a governance policy forbids "
+                    "unsandboxed execution. "
+                )
+            else:
+                sel_reason = (
+                    "No sandbox backend available and allow_unsandboxed_exec is not set"
+                )
+                refusal = (
+                    "Sandbox backend unavailable and allow_unsandboxed_exec is not set. "
+                )
             # Emit SEL audit event for this security-relevant denial so it
             # appears in the tamper-evident audit log (security-review requirement).
             try:
@@ -3256,16 +3326,13 @@ def wrap_argv(
                     tool_name=argv[0] if argv else "unknown",
                     tool_kind="subprocess",
                     outcome="denied",
-                    error=(
-                        "No sandbox backend available and allow_unsandboxed_exec "
-                        f"is not set (probe: {probe_reason})"
-                    ),
+                    error=(f"{sel_reason} (probe: {probe_reason})"),
                 )
             except Exception:
                 logger.warning("Failed to emit SEL audit event for sandbox denial", exc_info=True)
             raise SandboxUnavailableError(
-                "Sandbox backend unavailable and allow_unsandboxed_exec is not set. "
-                "No OS-level sandbox backend is available on this host, and the "
+                refusal
+                + "No OS-level sandbox backend is available on this host, and the "
                 "agent subprocess cannot be safely isolated. "
                 f"Probe detail: {probe_reason}. " + guidance,
                 kind=_classify_unavailable(transient),

--- a/test/test_sandbox_first_party_exec.py
+++ b/test/test_sandbox_first_party_exec.py
@@ -18,6 +18,12 @@ Matrix pinned here:
   config, not bypass);
 * governance ``sandbox.min_level`` floor + flag -> raises (the carve-out must
   not duck the floor);
+* governance floor + flag + NON-first-party spawn -> raises, and the refusal
+  names the policy rather than the flag the operator already set: the floor
+  outranks ``sandbox_allow_unsandboxed_exec`` because ``config.json`` is not
+  policy (issue #3162);
+* no floor + flag                               -> unchanged passthrough (the
+  population that relies on the opt-in keeps working byte-for-byte);
 * ``sandbox_allow_unsandboxed_exec=true``       -> identical with or without
   the flag (the opt-in remains a strict superset);
 * backend available + flag       -> normal sandbox wrap (flag is inert).
@@ -197,6 +203,126 @@ class TestCarveOutStillRaises:
         with patch("kiro_crew.sel.sel", return_value=MagicMock()):
             with pytest.raises(SandboxUnavailableError):
                 wrap_argv(_ARGV, mode="standard", first_party_fixed_argv=True)
+
+
+class TestGovernanceFloorOverridesTheOptIn:
+    """A ``sandbox.min_level`` floor outranks ``sandbox_allow_unsandboxed_exec``.
+
+    The floor already refused the *audited* first-party carve-out
+    (``TestCarveOutStillRaises.test_governance_floor_raises_despite_flag``) while
+    having no effect at all on the broad config opt-in, so pinning a floor
+    weakened the constrained path and left the unconstrained one alone. These
+    pin the corrected direction: on a governed host the config flag grants
+    nothing, because ``config.json`` is not policy (issue #3162).
+    """
+
+    @pytest.fixture
+    def governed(self, monkeypatch):
+        """A host whose policy pins the floor, with the opt-in ALSO set.
+
+        Patched at the SOURCE so both consumers of the shared read — the mode
+        clamp and the floor gate — agree about this host, matching
+        ``test_governance_floor_raises_despite_flag``.
+        """
+        monkeypatch.setattr(sandbox_mod, "detect_backend", lambda config_mode="auto": "none")
+        monkeypatch.setattr(sandbox_mod, "_allow_unsandboxed_exec", lambda: True)
+        monkeypatch.setattr(
+            "kiro_crew.platform.governance_profiles.governance_floor_ordinal",
+            lambda scope, **kwargs: "strict",
+        )
+
+    def test_governed_host_raises_even_though_the_opt_in_is_set(self, governed):
+        """THE FIX. Before this, these exact conditions returned bare argv."""
+        with patch("kiro_crew.sel.sel", return_value=MagicMock()):
+            with pytest.raises(SandboxUnavailableError) as exc_info:
+                wrap_argv(_ARGV, mode="strict")
+        assert exc_info.value.kind == "no_backend"
+
+    def test_refusal_names_the_policy_not_the_missing_flag(self, governed):
+        """The operator HAS set the flag, so the old wording would misdirect.
+
+        ``allow_unsandboxed_exec is not set`` would send them to edit a config
+        key that is deliberately powerless here.
+        """
+        sel_instance = MagicMock()
+        with patch("kiro_crew.sel.sel", return_value=sel_instance):
+            with pytest.raises(SandboxUnavailableError) as exc_info:
+                wrap_argv(_ARGV, mode="strict")
+        message = str(exc_info.value)
+        assert "sandbox.min_level" in message
+        assert "governance policy forbids" in message
+        assert "allow_unsandboxed_exec is not set" not in message
+        # The audit trail must be able to distinguish a policy refusal from a
+        # plain missing-opt-in refusal.
+        error = sel_instance.log_tool_invocation.call_args.kwargs["error"]
+        assert "sandbox.min_level" in error
+        assert "overridden" in error
+
+    def test_ungoverned_host_with_the_opt_in_is_unchanged(self, monkeypatch):
+        """REGRESSION GUARD. Only governed hosts change; this is the population
+        that relies on the opt-in and must keep working byte-for-byte."""
+        monkeypatch.setattr(sandbox_mod, "detect_backend", lambda config_mode="auto": "none")
+        monkeypatch.setattr(sandbox_mod, "_allow_unsandboxed_exec", lambda: True)
+        with patch("kiro_crew.sel.sel", return_value=MagicMock()):
+            assert wrap_argv(_ARGV, mode="strict") == (_ARGV, None)
+
+    def test_governed_host_without_the_opt_in_keeps_its_original_message(
+        self, monkeypatch
+    ):
+        """A governed host that never set the flag is refused for the ordinary
+        reason, so the policy wording must not leak into that case."""
+        monkeypatch.setattr(sandbox_mod, "detect_backend", lambda config_mode="auto": "none")
+        monkeypatch.setattr(sandbox_mod, "_allow_unsandboxed_exec", lambda: False)
+        monkeypatch.setattr(
+            "kiro_crew.platform.governance_profiles.governance_floor_ordinal",
+            lambda scope, **kwargs: "strict",
+        )
+        with patch("kiro_crew.sel.sel", return_value=MagicMock()):
+            with pytest.raises(SandboxUnavailableError) as exc_info:
+                wrap_argv(_ARGV, mode="strict")
+        assert "allow_unsandboxed_exec is not set" in str(exc_info.value)
+
+    def test_a_floor_of_the_loosest_tier_does_not_deny(self, monkeypatch):
+        """REGRESSION GUARD. ``sandbox.min_level: off`` is a governed floor that
+        requires NOTHING — the loosest tier of ("off", "standard", "cc", "strict").
+
+        Testing the floor string for raw truthiness would read "no isolation
+        required" as "isolation mandatory": it would deny a spawn the operator
+        legitimately opted into, and tell them a floor of ``off`` forbids
+        unsandboxed execution. This population must be byte-for-byte unchanged.
+        """
+        monkeypatch.setattr(sandbox_mod, "detect_backend", lambda config_mode="auto": "none")
+        monkeypatch.setattr(sandbox_mod, "_allow_unsandboxed_exec", lambda: True)
+        monkeypatch.setattr(
+            "kiro_crew.platform.governance_profiles.governance_floor_ordinal",
+            lambda scope, **kwargs: "off",
+        )
+        with patch("kiro_crew.sel.sel", return_value=MagicMock()):
+            assert wrap_argv(_ARGV, mode="standard") == (_ARGV, None)
+
+    def test_every_tier_above_the_loosest_denies(self, monkeypatch):
+        """The tiers that DO mandate isolation all refuse, so the fix cannot be
+        satisfied by only the tier this change was written against."""
+        monkeypatch.setattr(sandbox_mod, "detect_backend", lambda config_mode="auto": "none")
+        monkeypatch.setattr(sandbox_mod, "_allow_unsandboxed_exec", lambda: True)
+        for tier in ("standard", "cc", "strict"):
+            monkeypatch.setattr(
+                "kiro_crew.platform.governance_profiles.governance_floor_ordinal",
+                lambda scope, _tier=tier, **kwargs: _tier,
+            )
+            with patch("kiro_crew.sel.sel", return_value=MagicMock()):
+                with pytest.raises(SandboxUnavailableError):
+                    wrap_argv(_ARGV, mode="standard")
+
+    def test_message_does_not_promise_that_built_in_spawns_keep_running(self, governed):
+        """A governed host withholds the first-party carve-out as well, so the
+        guidance must not tell an operator built-in tooling is unaffected."""
+        with patch("kiro_crew.sel.sel", return_value=MagicMock()):
+            with pytest.raises(SandboxUnavailableError) as exc_info:
+                wrap_argv(_ARGV, mode="strict")
+        message = str(exc_info.value)
+        assert "withholds the first-party carve-out" in message
+        assert "runs no agent subprocess" in message
 
 
 class TestFlagIsOtherwiseInert:


### PR DESCRIPTION
## Problem

A governance `sandbox.min_level` floor affected the **wrong one** of the two paths
that can end in an unconfined spawn in `wrap_argv`'s no-backend branch.

**It disabled the narrow, audited path.** The first-party carve-out (#1563) —
package-derived argv, call sites allowlisted by
`test_spawn_audit.py::FIRST_PARTY_SPAWNS`, env-scrubbed, warned once per process,
SEL-audited under its own `unconfined` outcome — is refused when a floor is active.
That is deliberate and this PR **leaves it exactly as it was**.

**It had no effect on the broad path.** `_allow_unsandboxed_exec()` reads
`agent.sandbox_allow_unsandboxed_exec` from `config.json` and never consulted the
floor, so with that flag true the entire fail-closed branch was skipped — including
for the hostile-input paths #1563 deliberately separated out, where a repo-controlled
worktree `include.path` can make `git` read `~/.aws/credentials`, and the Papyrus
`latex.py` / `gitops.py` chokepoints. A policy pin could not reach them.

So pinning a floor **weakened the constrained path and left the unconstrained one
alone** — the opposite of what pinning it implies.

## Why it matters

An operator who pins `sandbox.min_level` is making a statement about isolation. On a
backend-less host (Windows, or a Linux container without user namespaces) that
statement was silently inverted: the audited built-in spawns were refused, while the
paths that take untrusted input kept running unconfined as long as a config flag said
so. `config.json` is not policy; the floor is.

## Fix (symptom → root cause → change)

**Symptom** → a governed fleet's hostile-input spawns run unconfined despite a pinned
floor, and the refusal an operator eventually sees names the wrong lever.

**Root cause** → the floor was consulted at the carve-out and nowhere else. The gate
that decides whether to fail closed (`if not _allow_unsandboxed_exec():`) short-circuits
before any floor-based refusal, so the floor never reached it.

**Change** → the gate consults the floor too:

1. **`_floor_mandates_sandbox(floor)`** decides whether a floor actually requires
   isolation. This is not `bool(floor)`: the scale is `("off", "standard", "cc",
   "strict")`, so a governed floor of `off` is a **truthy string that mandates
   nothing**. Testing raw truthiness would read "no isolation required" as "isolation
   mandatory" — denying a spawn the operator legitimately opted into, and telling them
   a floor of `off` forbids unsandboxed execution. The loosest tier is derived from the
   enforcer-owned `_ORDINAL_SCALES` registry rather than hardcoded, matching
   `_clamp_sandbox_mode_to_floor`, so a renamed or re-ordered scale cannot silently
   invert the test.
2. **The gate becomes `if floor_mandates_sandbox or not opted_in:`**, derived from the
   single floor read already taken at the top of the call (the same value the clamp
   used) plus a single new read of the opt-in — so the gate and the message that
   explains a refusal can never describe different states.
3. **The refusal text tells the truth.** An operator who set the flag was previously
   told `allow_unsandboxed_exec is not set` and sent to edit a key that is deliberately
   powerless there. The policy branch now names `sandbox.min_level`, says the flag is
   overridden, states that a governed host withholds the first-party carve-out too (so
   built-in spawns are refused as well — this host runs no agent subprocess until it has
   a backend or the floor is relaxed), and points at the two real remedies. The SEL audit
   error is likewise distinguishable, so a policy refusal and a plain missing-opt-in
   refusal are not conflated in the audit log.

### Behaviour change to review before this lands

Governed hosts only.

- A governed backend-less fleet that had set `sandbox_allow_unsandboxed_exec` **loses
  unconfined execution and now fails closed.** This is the fix, but it is a fail-closed
  change on upgrade and deserves a release note.
- **A floor of the loosest tier (`off`) is not affected** — pinned or not, that
  population behaves exactly as before.
- **Ungoverned hosts are byte-for-byte unchanged.**

Both of the last two are pinned by regression tests rather than left to review.

### Disclosed, and deliberately not changed

The untouched carve-out condition tests the floor with raw truthiness
(`and not governance_floor`), so it treats a pinned `off` as governed too. That
predates this PR, it is a refusal rather than a permission, and correcting it would
mean reopening the carve-out decision — which is recorded as intentional in
`TestCarveOutStillRaises::test_governance_floor_raises_despite_flag`. Out of scope here;
noted so it is not read as introduced by this change.

## Tests

`test/test_sandbox_first_party_exec.py` — new class
`TestGovernanceFloorOverridesTheOptIn` (7 tests). The module docstring's matrix gains
the corresponding rows.

Genuine regression guards (each **fails** against the pre-fix commit):

- `test_governed_host_raises_even_though_the_opt_in_is_set` — the fix itself; these
  exact conditions previously returned bare argv.
- `test_refusal_names_the_policy_not_the_missing_flag` — asserts the message names
  `sandbox.min_level`, does **not** contain `allow_unsandboxed_exec is not set`, and
  that the SEL error is distinguishable.
- `test_a_floor_of_the_loosest_tier_does_not_deny` — the `off` tier must not deny.
- `test_message_does_not_promise_that_built_in_spawns_keep_running` — the earlier draft
  of this PR claimed built-in spawns were unaffected, which was false.

Coverage rather than guards (pass on both commits, kept deliberately):

- `test_every_tier_above_the_loosest_denies` — `standard`/`cc`/`strict` all refuse, so
  the fix cannot be satisfied by only the tier it was written against.
- `test_ungoverned_host_with_the_opt_in_is_unchanged` — the population that relies on
  the opt-in.
- `test_governed_host_without_the_opt_in_keeps_its_original_message` — the policy
  wording must not leak into the ordinary refusal.

## Manual verification

- `pytest` — **912 passed, 9 skipped** across the sandbox, spawn-audit, governance,
  config-loader and worktree suites.
- `isort --check-only`, `flake8` — clean on both changed files.
- `mypy src/kiro_crew/sandbox.py` — no findings in this file. Three pre-existing
  `hooks.py` findings are `os.setxattr`, which exists on Linux and not macOS, so they
  are a local-macOS artifact rather than something CI sees.
- `scripts/check_brand_name.py` (including the base-ref variant),
  `scripts/scrub-lint.sh --no-history` — exit 0.

Not verified on real hardware: I did not run this on an actual backend-less host
(Windows or a userns-less container). The no-backend branch is exercised by stubbing
`detect_backend` the way the existing tests in this file do, which is how every other
case in this matrix is covered. Frontend gates are not implicated — the diff touches no
file under `website/`.

Fixes #3162
