### PR TITLE
perf: skip MCP overlay rewrite when a stat-only fingerprint matches (#2521)

### DIFF
--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -8,6 +8,13 @@ same-named entry in the agent spec (see ``session_servers.py``).
 
 Servers in :data:`UNPOOLABLE_SERVERS` are left unwrapped because they bind
 to ``KIROCREW_SESSION_KEY`` and cannot be safely shared across sessions.
+
+The rewrite is fingerprint-cached: a content-signature snapshot of every input is
+kept at ``<overlay_dir>/.rewrite-fingerprint``, and a boot whose inputs all
+match serves the previous run's overlays (and its cached ``target_env``)
+instead of re-parsing, re-resolving and re-writing everything. The prune
+pass runs on both paths. Any doubt — torn file, missing output, unresolved
+command — falls through to the full rewrite.
 """
 
 from __future__ import annotations
@@ -21,16 +28,61 @@ import shlex
 import shutil
 import sys
 import tempfile
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from kiro_crew import platform_compat
+from kiro_crew import __version__, platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 from kiro_crew.mcp_gateway.hashing import hash_command, is_secret_env_key
 from kiro_crew.mcp_utils import mcp_server_alias
 
 logger = logging.getLogger(__name__)
+
+# Fingerprint of the last completed rewrite, stored inside the overlay dir so
+# an unchanged boot can skip re-parsing every agent spec, re-resolving every
+# command through ``shutil.which`` and re-writing every overlay file. The name
+# deliberately has NO ``.json`` suffix: ``pathlib``'s ``glob("*.json")``
+# matches dotfiles, so a ``.json``-suffixed name would be deleted by the
+# stale-overlay prune pass and would make ``overlay_ready()`` report an empty
+# overlay dir as ready.
+_FINGERPRINT_NAME = ".rewrite-fingerprint"
+
+# Bump when the rewrite's OUTPUT shape changes for identical inputs (new stub
+# flags, changed overlay layout, ...) so upgraded installs regenerate instead
+# of serving overlays produced by older logic. The package version is also in
+# the fingerprint, so a release bump invalidates regardless; this constant is
+# the explicit knob for in-development changes.
+_FINGERPRINT_SCHEMA = 2
+
+
+@dataclass
+class _RewritePassNotes:
+    """Observations from one full rewrite pass that decide cacheability.
+
+    ``which_results`` records every ``shutil.which`` probe as
+    ``(bare_command, search_path) -> resolved-or-""``. The resolved path is an
+    OUTPUT of filesystem state the stat-based fingerprint cannot see (a binary
+    removed from, added to, or shadowed within an unchanged PATH), so the
+    cache-hit path re-runs exactly these probes and compares — a disagreement
+    in either direction forces the full rewrite.
+
+    ``sidecar_write_failed`` and ``source_read_failed`` mark transient I/O
+    faults: the produced output set is incomplete for reasons that can clear
+    without any fingerprinted input changing, so the run must not be cached
+    (and a previous run's fingerprint must be removed, or it could still match
+    and freeze the degraded state).
+    """
+
+    which_results: dict[str, str] = field(default_factory=dict)
+    sidecar_write_failed: bool = False
+    source_read_failed: bool = False
+
+
+# Separator inside a stored which-probe key (bare command NUL search-path).
+# NUL is legal in JSON strings and cannot appear in either component.
+_WHICH_KEY_SEP = "\0"
 
 # Reserved for MCP servers that explicitly opt out of the broker even
 # when they could support it (e.g. dev/diagnostic servers that want the
@@ -75,6 +127,7 @@ def _build_stub_entry(
     approval_mode: str,
     sidecars_written: set[str] | None = None,
     poolable: bool = False,
+    notes: _RewritePassNotes | None = None,
 ) -> dict[str, Any]:
     """Return the rewritten ``mcpServers[name]`` entry.
 
@@ -113,6 +166,17 @@ def _build_stub_entry(
             filter(None, [env_path, os.environ.get("PATH", "")])
         )
         resolved = shutil.which(target_command, path=search_path)
+        # Record the probe RESULT, not just the attempt: which() reads
+        # filesystem state (directory contents, PATHEXT matches, shadowing
+        # order) that a stat-based fingerprint cannot see. The cache-hit path
+        # re-runs exactly these probes and compares, so a binary that was
+        # removed, reinstalled at another PATH prefix, or newly shadowed
+        # invalidates the cache — in BOTH directions (failed→resolves and
+        # resolved→different/none).
+        if notes is not None:
+            notes.which_results[
+                f"{target_command}{_WHICH_KEY_SEP}{search_path}"
+            ] = resolved or ""
         if resolved:
             target_command = resolved
         else:
@@ -250,6 +314,12 @@ def _build_stub_entry(
         if wrote_sidecar:
             stub_args.extend(["--env-file", str(env_file)])
         else:
+            # Transient fault: the overlay written this pass omits --env-file,
+            # and an old sidecar may still exist at this name — so an
+            # existence check cannot detect the degradation. Mark the pass
+            # uncacheable so the next boot retries the write.
+            if notes is not None:
+                notes.sidecar_write_failed = True
             # No protected sidecar, so nothing to point the stub at. In the
             # pooled path this only changes the PoolKey hash (the declared env
             # is never applied to a shared backend anyway -- see the warning
@@ -325,6 +395,7 @@ def _rewrite_single_spec(
     inject_servers: dict[str, Any] | None = None,
     target_env: dict[str, str] | None = None,
     sidecars_written: set[str] | None = None,
+    notes: _RewritePassNotes | None = None,
 ) -> tuple[dict[str, Any], int]:
     """Return ``(new_spec, wrapped_count)``. Idempotent.
 
@@ -416,6 +487,7 @@ def _rewrite_single_spec(
             # Sharing is global over the stub set: being stubbed is the only
             # per-server decision, so there is nothing further to consult here.
             poolable=pooling_enabled,
+            notes=notes,
         )
         wrapped += 1
 
@@ -492,6 +564,7 @@ def _rewrite_single_spec(
             approval_mode=approval_mode,
             sidecars_written=sidecars_written,
             poolable=pooling_enabled,
+            notes=notes,
         )
         wrapped += 1
         seen_targets.add(inject_sig)
@@ -558,6 +631,346 @@ def _injectable_settings_servers(
     return out
 
 
+def _stat_sig(path: Path) -> list[Any] | None:
+    """Return ``[size, mtime_ns, sha256]`` for *path*, or ``None`` if it
+    cannot be read. Size and nanosecond mtime are cheap discriminators, but
+    neither is sufficient alone or together: a same-size write can land inside
+    one filesystem timestamp tick (coarse on some filesystems), and a
+    ``chmod`` changes neither — so the content digest is what makes a
+    signature collision impossible for changed bytes. The files signed here
+    are small JSON documents, so hashing them is microseconds against the
+    parse+resolve+write pass the fingerprint exists to skip."""
+    try:
+        st = path.stat()
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+    return [st.st_size, st.st_mtime_ns, digest]
+
+
+def _rewrite_inputs_fingerprint(
+    *,
+    source_dir: Path,
+    settings_path: Path,
+    overlay_dir: Path,
+    socket_path: Path,
+    work_dir: Path,
+    sandbox_mode: str,
+    approval_mode: str,
+    stub_set: frozenset[str],
+    pooling_enabled: bool,
+) -> dict[str, Any]:
+    """Return a JSON-serializable snapshot of every input that can change
+    :func:`rewrite_agents`'s output.
+
+    Enumerated against the code, not guessed:
+
+    * ``sources`` / ``settings`` — the parsed spec files (size+mtime+digest).
+    * ``socket_path`` / ``work_dir`` — baked into stub argv and the PoolKey.
+    * ``sandbox_mode`` / ``approval_mode`` / ``stub_servers`` /
+      ``pooling_enabled`` — decide stub flags and which entries are shareable.
+    * ``python`` — ``sys.executable`` is baked into every overlay ``command``,
+      so a moved/upgraded interpreter must regenerate the overlays.
+    * ``path_env`` / ``pathext`` — feed the ``shutil.which`` resolution of bare
+      command names. The other half of which()'s input — the CONTENTS of the
+      searched directories — is not stat-able here; it is covered by the
+      stored per-probe results, which the cache-hit path re-runs and compares
+      (see :class:`_RewritePassNotes`).
+    * ``schema`` / ``package`` — invalidate on rewriter logic changes.
+
+    ``mcp_gateway.forward_declared_env`` is deliberately NOT here: it selects
+    warning text only; the written overlays and sidecars are identical either
+    way (gatewayd reads that flag at spawn time, not from the overlay).
+    """
+    sources: dict[str, list[Any] | None] = {
+        p.name: _stat_sig(p) for p in sorted(source_dir.glob("*.json"))
+    }
+    return {
+        "schema": _FINGERPRINT_SCHEMA,
+        "package": __version__,
+        "python": sys.executable,
+        "path_env": os.environ.get("PATH", ""),
+        "pathext": os.environ.get("PATHEXT", ""),
+        "source_dir": str(source_dir),
+        "overlay_dir": str(overlay_dir),
+        "socket_path": str(socket_path),
+        "work_dir": str(work_dir),
+        "sandbox_mode": sandbox_mode,
+        "approval_mode": approval_mode,
+        "stub_servers": sorted(stub_set),
+        "pooling_enabled": bool(pooling_enabled),
+        "sources": sources,
+        "settings": _stat_sig(settings_path),
+    }
+
+
+def _load_fingerprint(path: Path) -> dict[str, Any] | None:
+    """Load and validate a stored fingerprint. NEVER raises: a missing,
+    unreadable, torn, or malformed file returns ``None``, which callers treat
+    as "do the full rewrite" — unreadable must never mean "match"."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    inputs = data.get("inputs")
+    outputs = data.get("outputs")
+    which = data.get("which")
+    if not (
+        isinstance(inputs, dict)
+        and isinstance(outputs, dict)
+        and isinstance(which, dict)
+    ):
+        return None
+    overlays = outputs.get("overlays")
+    sidecars = outputs.get("sidecars")
+    if not (isinstance(overlays, dict) and isinstance(sidecars, dict)):
+        return None
+
+    def _valid_sig(sig: Any) -> bool:
+        return (
+            isinstance(sig, list)
+            and len(sig) == 3
+            and isinstance(sig[0], int)
+            and isinstance(sig[1], int)
+            and isinstance(sig[2], str)
+        )
+
+    for name, sig in (*overlays.items(), *sidecars.items()):
+        # Names are joined onto the overlay/sidecar dirs below; refuse
+        # anything that could escape them, so a corrupted or tampered file
+        # degrades to a full rewrite instead of probing arbitrary paths.
+        if not isinstance(name, str) or "/" in name or "\\" in name or name in (".", ".."):
+            return None
+        if not _valid_sig(sig):
+            return None
+    settings_sig = outputs.get("settings_overlay")
+    if settings_sig is not None and not _valid_sig(settings_sig):
+        return None
+    if not all(
+        isinstance(k, str) and _WHICH_KEY_SEP in k and isinstance(v, str)
+        for k, v in which.items()
+    ):
+        return None
+    return data
+
+
+def _cached_rewrite_result(
+    stored: dict[str, Any],
+    *,
+    overlay_dir: Path,
+    stubs_dir: Path,
+) -> tuple[dict[str, int], dict[str, str]] | None:
+    """Serve the previous rewrite's result without redoing the work.
+
+    Returns ``None`` (caller falls through to the full rewrite) unless every
+    output the previous run produced still exists WITH the size+mtime+digest it
+    was recorded with — a deleted or edited overlay/sidecar must be
+    regenerated, not skipped over (an edited overlay would diverge from the
+    cached ``target_env``: the stub's PoolKey would hash the edited command
+    while gatewayd spawns the recorded one). The previous run's
+    ``shutil.which`` probes are also re-run and compared: directory contents
+    are which() input the stat fingerprint cannot see, so a target binary
+    removed, moved between PATH prefixes, or newly shadowed forces the full
+    rewrite instead of serving a dead absolute path forever.
+
+    On success the prune passes still run (stat-only), so a stray file in the
+    overlay tree is removed exactly as on the full path — including a
+    leftover settings overlay whose source is gone.
+    """
+    outputs = stored["outputs"]
+    overlay_sigs: dict[str, Any] = outputs["overlays"]
+    sidecar_sigs: dict[str, Any] = outputs["sidecars"]
+    env_dir = env_sidecar_dir_for_stubs(stubs_dir)
+    settings_overlay_file = overlay_dir.parent / "settings" / "mcp.json"
+    try:
+        for name, sig in overlay_sigs.items():
+            if _stat_sig(overlay_dir / name) != sig:
+                return None
+        for name, sig in sidecar_sigs.items():
+            if _stat_sig(env_dir / name) != sig:
+                return None
+        settings_sig = outputs.get("settings_overlay")
+        if settings_sig is not None:
+            if _stat_sig(settings_overlay_file) != settings_sig:
+                return None
+        elif settings_overlay_file.is_file():
+            # The previous run produced no settings overlay, yet one exists —
+            # e.g. its deletion failed transiently on the full path (Windows
+            # sharing violation). Removed global MCP servers must not stay
+            # active: retry the deletion, and refuse the cache if it survives.
+            try:
+                settings_overlay_file.unlink()
+            except OSError:
+                return None
+    except OSError:
+        return None
+
+    # Re-run the recorded which() probes: a few directory stats per bare
+    # command, no spec parsing. Closes the staleness gap in both directions
+    # (resolved -> gone/different AND unresolved -> now-resolves).
+    for key, recorded in stored["which"].items():
+        bare, _, search_path = key.partition(_WHICH_KEY_SEP)
+        try:
+            current = shutil.which(bare, path=search_path) or ""
+        except OSError:
+            return None
+        if current != recorded:
+            return None
+
+    # Re-assert owner-only protection on EVERY artifact the cached result
+    # serves — a chmod / DACL edit changes no stat-or-digest signature, and
+    # on Windows the file DACL (not the containing directory) is what carries
+    # access. The invariant is FAIL-LOUD end to end: every call in this block
+    # raises on failure, and any failure falls through to the full rewrite —
+    # a lockdown that cannot be re-asserted must never be served from cache.
+    # That is why ``restrict_to_owner`` (raises on both platforms) is used for
+    # files rather than ``chmod_safe`` (logs-and-continues on POSIX), and why
+    # the POSIX directory modes are re-applied with a raw ``os.chmod`` after
+    # ``make_owner_only_dir`` (which warns-and-continues). Windows directory
+    # DACLs stay best-effort inside ``make_owner_only_dir``: there the file
+    # DACL is the carrier of access, and every file is fail-loud below.
+    try:
+        if env_dir.is_dir():
+            platform_compat.make_owner_only_dir(env_dir)
+            if platform_compat.IS_POSIX:
+                # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions -- 0o700 is OWNER-ONLY, the tightest traversable mode for this credential-sidecar directory; the rule's suggested 0o644 would grant world-read and drop the execute bit a directory needs. Raw os.chmod (not make_owner_only_dir alone) because this path must FAIL LOUD into the full rewrite.  # noqa: E501
+                os.chmod(env_dir, 0o700)
+        protected: list[Path] = [
+            *(overlay_dir / n for n in overlay_sigs),
+            *(env_dir / n for n in sidecar_sigs),
+            overlay_dir / _FINGERPRINT_NAME,
+        ]
+        if settings_sig is not None:
+            platform_compat.make_owner_only_dir(settings_overlay_file.parent)
+            if platform_compat.IS_POSIX:
+                # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions -- same as the env_dir site above: 0o700 is owner-only and fail-loud is required.  # noqa: E501
+                os.chmod(settings_overlay_file.parent, 0o700)
+            protected.append(settings_overlay_file)
+        for artifact in protected:
+            platform_compat.restrict_to_owner(artifact)
+    except OSError:
+        # The full rewrite re-creates each artifact through its own
+        # protect-before-content writers, whose failure handling marks the
+        # pass uncacheable.
+        return None
+
+    # The prune pass runs even when the rewrite is skipped: a deleted agent
+    # spec changes the fingerprint (its file leaves the stat set) and takes the
+    # full path, but a foreign file in the overlay tree does not, and must
+    # still be swept.
+    for stale in overlay_dir.glob("*.json"):
+        if stale.name not in overlay_sigs:
+            try:
+                stale.unlink()
+            except OSError:
+                pass
+    if env_dir.is_dir():
+        for stale in env_dir.glob("*.json"):
+            if stale.name not in sidecar_sigs:
+                try:
+                    stale.unlink()
+                except OSError:
+                    pass
+
+    # Reconstruct the result from the just-validated OVERLAYS rather than
+    # trusting a payload stored in the fingerprint. The overlays are the
+    # executable authority either way — kiro-cli sessions receive their stub
+    # argv directly — so rebuilding ``target_env`` from them means the
+    # fingerprint carries no command material at all: tampering with it can
+    # at worst skip a rewrite, never inject a command that is not already in
+    # the overlay files. Iteration is sorted by name to match the full path's
+    # sorted source glob, so ``setdefault`` first-wins resolution is
+    # byte-identical to a fresh rewrite.
+    results: dict[str, int] = {}
+    target_env: dict[str, str] = {}
+    try:
+        for name in sorted(overlay_sigs):
+            spec = json.loads((overlay_dir / name).read_text())
+            servers = spec.get("mcpServers", {}) if isinstance(spec, dict) else {}
+            if not isinstance(servers, dict):
+                servers = {}
+            wrapped = sum(
+                1
+                for entry in servers.values()
+                if isinstance(entry, dict)
+                and (
+                    entry.get(_WRAPPER_MARKER) is True
+                    or entry.get(_WRAPPER_MARKER_LEGACY) is True
+                )
+            )
+            if wrapped:
+                results[name] = wrapped
+            _collect_target_env(servers, target_env)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    logger.info(
+        "mcp-gateway rewriter: inputs unchanged since last rewrite — "
+        "serving cached overlays (%d agent file(s), %d target env var(s), overlay=%s)",
+        len(overlay_sigs),
+        len(target_env),
+        overlay_dir,
+    )
+    return results, target_env
+
+
+def _store_fingerprint(
+    path: Path,
+    *,
+    inputs: dict[str, Any],
+    outputs: dict[str, Any],
+    which: dict[str, str],
+) -> None:
+    """Persist the rewrite fingerprint atomically, protection BEFORE content.
+
+    The payload holds only input/output signatures and which-probe results —
+    never the ``target_env`` command material, which the cache-hit path
+    reconstructs from the validated overlays — but it follows the env-sidecar
+    protect-before-content pattern rather than plain ``atomic_write`` anyway
+    (``atomic_write``'s ``mode=`` is applied pre-write on POSIX but is inert
+    on Windows, where the DACL is the only carrier of access). A torn or
+    failed write must be unreadable-as-JSON (→ full rewrite), never readable
+    as a match; any failure is logged and swallowed — the only consequence is
+    a full rewrite on the next boot.
+    """
+    payload = {
+        "inputs": inputs,
+        "outputs": outputs,
+        "which": which,
+    }
+    wrote = False
+    try:
+        fd, tmp = tempfile.mkstemp(
+            prefix=f".{path.name}-", suffix=".tmp", dir=str(path.parent)
+        )
+        fd_owned = True
+        try:
+            platform_compat.fchmod_safe(fd, 0o600)
+            if not platform_compat.IS_POSIX:
+                platform_compat.restrict_to_owner(tmp)
+            with os.fdopen(fd, "w") as fh:
+                fd_owned = False  # fdopen owns the descriptor now
+                fh.write(json.dumps(payload, sort_keys=True))
+            os.replace(tmp, path)
+            wrote = True
+        finally:
+            if fd_owned:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+            if not wrote:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp)
+    except OSError:
+        logger.debug(
+            "rewriter: could not persist rewrite fingerprint at %s "
+            "(next boot does a full rewrite)",
+            path,
+            exc_info=True,
+        )
+
+
 def rewrite_agents(
     *,
     source_dir: Path,
@@ -572,7 +985,10 @@ def rewrite_agents(
     """Populate ``overlay_dir`` with rewritten copies of ``source_dir/*.json``.
 
     Never modifies ``source_dir``. Idempotent — safe to call on every
-    KiroCrew startup.
+    Kiro Crew startup. When no input changed since the last completed run
+    (see :func:`_rewrite_inputs_fingerprint`) the rewrite loop is skipped and
+    the cached ``(results, target_env)`` is returned; the stale-file prune
+    still runs on that path.
 
     Args:
         source_dir: Usually ``~/.kiro/agents/``.
@@ -629,10 +1045,40 @@ def rewrite_agents(
     # instead.
     stubs_dir = overlay_dir.parent / "stubs"
     platform_compat.make_owner_only_dir(stubs_dir)
+
+    # Skip the whole rewrite when nothing that feeds it changed since the last
+    # completed run. The fingerprint stats and digests only the small JSON
+    # inputs (no JSON parsing, no per-server ``shutil.which``, no writes), so
+    # an unchanged warm boot pays a few reads instead of the full
+    # parse+resolve+write pass. Any read/validation failure
+    # falls through to the full rewrite — unreadable never means "match".
+    kiro_settings_json = source_dir.parent / "settings" / "mcp.json"
+    fingerprint_path = overlay_dir / _FINGERPRINT_NAME
+    current_inputs = _rewrite_inputs_fingerprint(
+        source_dir=source_dir,
+        settings_path=kiro_settings_json,
+        overlay_dir=overlay_dir,
+        socket_path=socket_path,
+        work_dir=work_dir,
+        sandbox_mode=sandbox_mode,
+        approval_mode=approval_mode,
+        stub_set=stub_set,
+        pooling_enabled=pooling_enabled,
+    )
+    stored = _load_fingerprint(fingerprint_path)
+    if stored is not None and stored.get("inputs") == current_inputs:
+        cached = _cached_rewrite_result(
+            stored, overlay_dir=overlay_dir, stubs_dir=stubs_dir
+        )
+        if cached is not None:
+            return cached
+
     written: set[str] = set()
     written_sidecars: set[str] = set()
     results: dict[str, int] = {}
     target_env: dict[str, str] = {}
+    notes = _RewritePassNotes()
+    overlay_write_failed = False
 
     # Read the GLOBAL ~/.kiro/settings/mcp.json FIRST. kiro-cli merges this
     # file into every agent at runtime — any bare-name server declared here
@@ -649,7 +1095,6 @@ def rewrite_agents(
     # from the settings overlay. Empty-mcpServers agents then get pooled
     # coverage with the right identity, and no name ever appears wrapped in
     # both overlays. Non-poolable / HTTP settings servers stay raw in settings.
-    kiro_settings_json = source_dir.parent / "settings" / "mcp.json"
     settings_src_spec: dict[str, Any] | None = None
     settings_poolable: dict[str, Any] = {}
     if kiro_settings_json.is_file():
@@ -658,13 +1103,31 @@ def rewrite_agents(
             if isinstance(loaded, dict):
                 settings_src_spec = loaded
                 settings_poolable = _injectable_settings_servers(loaded, stub_set)
-        except (OSError, json.JSONDecodeError) as exc:
+        except OSError as exc:
+            # Transient read failure: same reasoning as the per-agent site —
+            # do not cache a pass that treated an existing settings file as
+            # absent (it would also have pruned the settings overlay).
+            notes.source_read_failed = True
+            logger.warning("failed to read global mcp.json: %s", exc)
+        except json.JSONDecodeError as exc:
+            # Content problem — cacheable; a fix changes the stat signature.
             logger.warning("failed to read global mcp.json: %s", exc)
 
     for path in sorted(source_dir.glob("*.json")):
         try:
             spec = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError) as exc:
+        except OSError as exc:
+            # Transient: the file stat'ed fine for the fingerprint but could
+            # not be read. Readability can return without size/mtime changing,
+            # so caching this incomplete pass would serve overlays missing
+            # this agent forever. Mark the pass uncacheable.
+            notes.source_read_failed = True
+            logger.warning("skipping agent %s: %s", path.name, exc)
+            continue
+        except json.JSONDecodeError as exc:
+            # Deterministic: the CONTENT is bad, and fixing it changes the
+            # file's stat signature, which invalidates the fingerprint — so
+            # this skip is safe to cache.
             logger.warning("skipping agent %s: %s", path.name, exc)
             continue
         if not isinstance(spec, dict):
@@ -691,6 +1154,7 @@ def rewrite_agents(
             inject_servers=settings_poolable,
             target_env=target_env,
             sidecars_written=written_sidecars,
+            notes=notes,
         )
         _collect_target_env(new_spec.get("mcpServers", {}), target_env)
         target = overlay_dir / path.name
@@ -706,6 +1170,7 @@ def rewrite_agents(
                 platform_compat.restrict_to_owner(target)
         except OSError as exc:
             logger.warning("failed to write overlay %s: %s", target, exc)
+            overlay_write_failed = True
             continue
         written.add(path.name)
         if wrapped:
@@ -787,6 +1252,7 @@ def rewrite_agents(
         except OSError as exc:
             logger.warning("failed to write global mcp.json overlay: %s", exc)
             settings_overlay_path = None
+            overlay_write_failed = True
     else:
         # Source settings/mcp.json absent (deleted between runs): prune any
         # previously-written settings overlay, mirroring the per-agent
@@ -805,6 +1271,58 @@ def rewrite_agents(
         len(target_env),
         overlay_dir,
     )
+    # Persist the fingerprint so the next unchanged boot skips this pass.
+    # ``current_inputs`` was stat'ed BEFORE the files were read: if a file
+    # changed in between, the stored stats are older than the content the
+    # overlays reflect, the next boot's stat mismatches, and the rewrite runs
+    # again — an extra rewrite, never a stale overlay. Not cached when any
+    # transient fault left the output set incomplete (a later boot must retry
+    # even though no fingerprinted input changed).
+    uncacheable = ""
+    if notes.source_read_failed:
+        uncacheable = "transient source read failure(s)"
+    elif notes.sidecar_write_failed:
+        uncacheable = "env sidecar write failure(s)"
+    elif overlay_write_failed:
+        uncacheable = "overlay write failure(s)"
+    if uncacheable:
+        logger.debug("rewriter: %s; not caching this rewrite", uncacheable)
+        # Remove any fingerprint from an earlier successful run: it could
+        # still match the current inputs (this rewrite may have been forced by
+        # a missing output, not an input change) and would freeze the
+        # degraded state instead of retrying.
+        with contextlib.suppress(OSError):
+            fingerprint_path.unlink(missing_ok=True)
+    else:
+        output_sigs: dict[str, Any] = {
+            "overlays": {n: _stat_sig(overlay_dir / n) for n in sorted(written)},
+            "sidecars": {
+                n: _stat_sig(env_dir / n) for n in sorted(written_sidecars)
+            },
+            "settings_overlay": (
+                _stat_sig(settings_overlay_path)
+                if settings_overlay_path is not None
+                else None
+            ),
+        }
+        # A None signature means an output vanished between write and stat —
+        # storing it would produce a fingerprint the loader rejects anyway;
+        # skip storing so the next boot simply rewrites.
+        if (
+            all(output_sigs["overlays"].values())
+            and all(output_sigs["sidecars"].values())
+            and (
+                settings_overlay_path is None
+                or output_sigs["settings_overlay"] is not None
+            )
+        ):
+            _store_fingerprint(
+                fingerprint_path,
+                inputs=current_inputs,
+                outputs=output_sigs,
+                which=notes.which_results,
+            )
+
     # NOTE: the settings overlay path (when present) is bind-mounted by
     # ``sandbox.py`` via a fixed location derived from the overlay dir —
     # callers do not need to thread it back through ``results``. Keeping

--- a/test/test_mcp_gateway_rewriter_fingerprint.py
+++ b/test/test_mcp_gateway_rewriter_fingerprint.py
@@ -1,0 +1,713 @@
+"""Rewrite-fingerprint cache for the MCP overlay rewriter.
+
+``rewrite_agents`` skips the parse/resolve/write pass when a stat-only
+fingerprint of every input matches the previous completed run. These tests pin
+the two sides of that contract: an unchanged boot is served from cache with a
+byte-identical result, and EVERY input that can change the output invalidates
+the cache — a missed input would ship a stale overlay silently, which is
+strictly worse than the boot cost the cache removes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kiro_crew.mcp_gateway import rewriter
+from kiro_crew.mcp_gateway.rewriter import (
+    _FINGERPRINT_NAME,
+    overlay_ready,
+    rewrite_agents,
+)
+
+# Absolute on POSIX and treated as absolute by ntpath (leading slash), so the
+# ``shutil.which`` bare-name resolution path is never entered and the fixture
+# behaves identically on every CI platform.
+_CMD = "/usr/bin/env"
+
+
+def _mk_tree(root: Path, *, n_agents: int = 2, with_env: bool = True) -> Path:
+    src = root / "agents"
+    src.mkdir(parents=True, exist_ok=True)
+    settings = root / "settings"
+    settings.mkdir(exist_ok=True)
+    (settings / "mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "global-x": {"command": _CMD, "args": ["g"], "poolable": True}
+                }
+            }
+        )
+    )
+    for i in range(n_agents):
+        servers: dict[str, Any] = {
+            "srv": {"command": _CMD, "args": [f"a{i}"], "poolable": True}
+        }
+        if with_env:
+            servers["srv"]["env"] = {"K": "v"}
+        (src / f"agent-{i}.json").write_text(
+            json.dumps({"name": f"agent-{i}", "mcpServers": servers})
+        )
+    return src
+
+
+def _rewrite(root: Path, **overrides: Any) -> tuple[dict[str, int], dict[str, str]]:
+    kwargs: dict[str, Any] = dict(
+        source_dir=root / "agents",
+        overlay_dir=root / "mcp-gateway" / "agents",
+        socket_path=root / "gw.sock",
+        work_dir=root / "wd",
+        sandbox_mode="auto",
+        approval_mode="interactive",
+        # Stubbing is opt-in per server name; the fixture's servers must be
+        # listed or nothing is wrapped and no sidecar/target_env exists.
+        stub_servers=frozenset({"srv", "global-x"}),
+        pooling_enabled=True,
+    )
+    kwargs.update(overrides)
+    return rewrite_agents(**kwargs)
+
+
+@pytest.fixture()
+def rewrite_counter(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Count entries into the per-spec rewrite; zero new counts == skipped."""
+    calls = {"n": 0}
+    real = rewriter._rewrite_single_spec
+
+    def spy(*args: Any, **kwargs: Any) -> Any:
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(rewriter, "_rewrite_single_spec", spy)
+    return calls
+
+
+def _bump_mtime(path: Path) -> None:
+    st = path.stat()
+    os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+
+def test_unchanged_inputs_skip_the_rewrite_and_return_identical_result(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    _mk_tree(tmp_path)
+    cold = _rewrite(tmp_path)
+    assert rewrite_counter["n"] == 2
+
+    warm = _rewrite(tmp_path)
+    assert rewrite_counter["n"] == 2  # no spec re-parsed
+    # The caller feeds target_env into GatewaySpec.mcp_target_env — the cached
+    # result must be exactly what a full rewrite would have returned.
+    assert warm == cold
+    assert warm[1]  # non-trivial: target env actually carries entries
+
+
+def test_source_content_change_invalidates(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    src = _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    spec = json.loads((src / "agent-0.json").read_text())
+    spec["mcpServers"]["srv"]["args"] = ["changed-and-longer"]
+    (src / "agent-0.json").write_text(json.dumps(spec))
+
+    before = rewrite_counter["n"]
+    _, target_env = _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2
+    assert any("changed-and-longer" in v for v in target_env.values())
+
+
+def test_same_size_mtime_bump_invalidates(tmp_path: Path, rewrite_counter: dict[str, int]) -> None:
+    """size+mtime_ns together: a same-size write must still invalidate."""
+    src = _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    _bump_mtime(src / "agent-0.json")
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2
+
+
+def test_settings_mcp_json_change_invalidates(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    """settings/mcp.json is an input; omitting it would serve stale overlays
+    after a global MCP config edit."""
+    _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    _bump_mtime(tmp_path / "settings" / "mcp.json")
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2
+
+
+def test_settings_mcp_json_deletion_invalidates_and_prunes_overlay(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
+    assert settings_overlay.is_file()
+    (tmp_path / "settings" / "mcp.json").unlink()
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2
+    assert not settings_overlay.exists()
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"sandbox_mode": "strict"},
+        {"approval_mode": "yolo-ish"},
+        {"stub_servers": frozenset({"srv"})},
+        {"pooling_enabled": False},
+    ],
+)
+def test_config_parameter_change_invalidates(
+    tmp_path: Path, rewrite_counter: dict[str, int], override: dict[str, Any]
+) -> None:
+    _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path, **override)
+    assert rewrite_counter["n"] == before + 2
+
+
+def test_socket_and_work_dir_change_invalidates(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    """socket_path and work_dir are in the stub argv and the PoolKey."""
+    _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path, socket_path=tmp_path / "other.sock")
+    assert rewrite_counter["n"] == before + 2
+    _rewrite(tmp_path, socket_path=tmp_path / "other.sock", work_dir=tmp_path / "wd2")
+    assert rewrite_counter["n"] == before + 4
+
+
+def test_path_env_change_invalidates(
+    tmp_path: Path, rewrite_counter: dict[str, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PATH feeds shutil.which bare-name resolution."""
+    _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    monkeypatch.setenv("PATH", str(tmp_path / "extra-bin") + os.pathsep + os.environ.get("PATH", ""))
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2
+
+
+def test_package_version_change_invalidates(
+    tmp_path: Path, rewrite_counter: dict[str, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An upgraded package must regenerate overlays written by older logic."""
+    _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    monkeypatch.setattr(rewriter, "__version__", "999.0.0-test")
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2
+
+
+def test_deleted_agent_spec_invalidates_and_prunes(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    src = _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-1.json"
+    assert overlay.is_file()
+    (src / "agent-1.json").unlink()
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 1  # one agent left
+    assert not overlay.exists()
+
+
+def test_missing_overlay_file_forces_full_rewrite(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    """A manually deleted overlay must be regenerated, not skipped over."""
+    _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
+    overlay.unlink()
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2
+    assert overlay.is_file()
+
+
+def test_missing_env_sidecar_forces_full_rewrite(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    _mk_tree(tmp_path, with_env=True)
+    _rewrite(tmp_path)
+    env_dir = tmp_path / "mcp-gateway" / "stubs" / "env"
+    sidecars = list(env_dir.glob("*.json"))
+    assert sidecars
+    sidecars[0].unlink()
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2
+    assert list(env_dir.glob("*.json"))
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "not json at all {{{",
+        json.dumps("a string, not an object"),
+        json.dumps({"inputs": {}, "outputs": {}}),  # missing results/target_env
+        json.dumps(
+            {
+                "inputs": {},
+                "outputs": {"overlays": ["../escape.json"], "sidecars": [],
+                            "settings_overlay": False},
+                "results": {},
+                "target_env": {},
+            }
+        ),  # path traversal in a recorded name
+    ],
+)
+def test_bad_fingerprint_means_full_rewrite_not_a_match(
+    tmp_path: Path, rewrite_counter: dict[str, int], content: str
+) -> None:
+    """Unreadable/malformed must mean 'rewrite', never 'match' — and never raise."""
+    _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    assert fp.is_file()
+    fp.write_text(content)
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2
+    # and the full rewrite healed the fingerprint
+    assert json.loads(fp.read_text())["inputs"]
+
+
+def test_traversal_name_in_matching_fingerprint_is_rejected(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    """Defense in depth: recorded output names are joined onto the overlay
+    dirs, so a tampered fingerprint whose INPUTS still match must be refused
+    on its names, not probed outside the tree."""
+    _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    data = json.loads(fp.read_text())
+    data["outputs"]["overlays"]["../escape.json"] = [1, 1]
+    fp.write_text(json.dumps(data))
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2  # full rewrite, not a match
+
+
+def test_skip_path_still_prunes_stray_overlay_and_sidecar(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    """The prune pass must not live inside the skipped branch."""
+    _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    stray_overlay = tmp_path / "mcp-gateway" / "agents" / "stray.json"
+    stray_overlay.write_text("{}")
+    stray_sidecar = tmp_path / "mcp-gateway" / "stubs" / "env" / "stray.json"
+    stray_sidecar.write_text("{}")
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before  # cache hit
+    assert not stray_overlay.exists()
+    assert not stray_sidecar.exists()
+
+
+def test_unresolved_bare_command_is_reprobed_and_install_invalidates(
+    tmp_path: Path, rewrite_counter: dict[str, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """which() failure depends on filesystem state the stat fingerprint cannot
+    see. An unchanged failure is cacheable (the re-probe agrees), but the
+    binary APPEARING at an already-listed PATH dir — no PATH string change, no
+    spec change — must invalidate via the recorded-probe comparison."""
+    bin_dir = tmp_path / "extra-bin"
+    bin_dir.mkdir()
+    monkeypatch.setenv("PATH", str(bin_dir) + os.pathsep + os.environ.get("PATH", ""))
+    src = _mk_tree(tmp_path, n_agents=1, with_env=False)
+    spec = json.loads((src / "agent-0.json").read_text())
+    spec["mcpServers"]["srv"]["command"] = "kirocrew-test-definitely-missing-cmd"
+    (src / "agent-0.json").write_text(json.dumps(spec))
+
+    _rewrite(tmp_path)
+    fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    assert fp.exists()  # unresolved probes are recorded, not cache-disabling
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before  # still unresolved -> cache hit
+
+    # Install the binary WITHOUT touching PATH or the spec. On Windows,
+    # shutil.which resolves bare names only through PATHEXT, so the file
+    # needs a .bat suffix there; the spec keeps declaring the bare name.
+    exe_name = (
+        "kirocrew-test-definitely-missing-cmd.bat"
+        if os.name == "nt"
+        else "kirocrew-test-definitely-missing-cmd"
+    )
+    exe = bin_dir / exe_name
+    exe.write_text("#!/bin/sh\nexit 0\n")
+    exe.chmod(0o755)
+
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 1  # probe disagreed -> full rewrite
+    overlay = json.loads(
+        (tmp_path / "mcp-gateway" / "agents" / "agent-0.json").read_text()
+    )
+    args = overlay["mcpServers"]["srv"]["args"]
+    i = args.index("--target-command")
+    # normcase: which() may report a differently-cased/slashed spelling on
+    # Windows than pathlib's str().
+    assert os.path.normcase(args[i + 1]) == os.path.normcase(str(exe))
+
+
+def test_resolved_binary_removal_invalidates(
+    tmp_path: Path, rewrite_counter: dict[str, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other direction: a bare command that RESOLVED is later removed
+    while PATH and specs are unchanged — the cache must not keep serving the
+    dead absolute path (the pre-fix every-boot rewrite would have healed it)."""
+    bin_dir = tmp_path / "extra-bin"
+    bin_dir.mkdir()
+    # .bat on Windows: shutil.which resolves bare names only through PATHEXT.
+    exe_name = (
+        "kirocrew-test-vanishing-cmd.bat"
+        if os.name == "nt"
+        else "kirocrew-test-vanishing-cmd"
+    )
+    exe = bin_dir / exe_name
+    exe.write_text("#!/bin/sh\nexit 0\n")
+    exe.chmod(0o755)
+    monkeypatch.setenv("PATH", str(bin_dir) + os.pathsep + os.environ.get("PATH", ""))
+    src = _mk_tree(tmp_path, n_agents=1, with_env=False)
+    spec = json.loads((src / "agent-0.json").read_text())
+    spec["mcpServers"]["srv"]["command"] = "kirocrew-test-vanishing-cmd"
+    (src / "agent-0.json").write_text(json.dumps(spec))
+
+    _rewrite(tmp_path)
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before  # resolved and unchanged -> cache hit
+
+    exe.unlink()  # binary removed; PATH string and specs unchanged
+
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 1  # probe disagreed -> full rewrite
+
+
+def test_edited_overlay_content_forces_full_rewrite(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    """Outputs are validated by size+mtime_ns, not mere existence: a
+    hand-edited overlay would diverge from the cached target_env (the stub's
+    PoolKey would hash the edited command while gatewayd spawns the recorded
+    one), so it must be regenerated."""
+    _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
+    data = json.loads(overlay.read_text())
+    overlay.write_text(json.dumps(data, indent=4))  # same JSON, different bytes
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2
+    assert json.loads(overlay.read_text()) == data  # regenerated canonical form
+
+
+def test_same_size_same_mtime_content_change_invalidates(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    """The content digest is load-bearing: a same-size write whose mtime is
+    restored to the recorded tick (coarse-timestamp collision, or a tool that
+    preserves times) must still invalidate — e.g. an autoApprove entry
+    swapped for an equal-length one changes the permission surface."""
+    src = _mk_tree(tmp_path, n_agents=1)
+    spec_path = src / "agent-0.json"
+    original = spec_path.read_text()
+    _rewrite(tmp_path)
+    st = spec_path.stat()
+
+    # Same byte length, different bytes; then force the ORIGINAL mtime back.
+    assert "agent-0" in original
+    spec_path.write_text(original.replace("agent-0", "tnega-0"))
+    os.utime(spec_path, ns=(st.st_atime_ns, st.st_mtime_ns))
+    assert spec_path.stat().st_size == st.st_size
+    assert spec_path.stat().st_mtime_ns == st.st_mtime_ns
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 1  # digest mismatch -> full rewrite
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permission bits")
+def test_cache_hit_retightens_all_artifact_permissions(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    """A chmod changes no content signature, so the cache-hit path must
+    re-assert owner-only permissions on EVERY served artifact — overlay
+    files, env sidecars, the settings overlay (file + dir), and the
+    fingerprint — not just the containing directories (on Windows the file
+    DACL is what carries access)."""
+    import stat as _stat
+
+    _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)
+    overlay_dir = tmp_path / "mcp-gateway" / "agents"
+    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
+    env_dir = tmp_path / "mcp-gateway" / "stubs" / "env"
+    artifacts = [
+        overlay_dir / "agent-0.json",
+        settings_overlay,
+        overlay_dir / _FINGERPRINT_NAME,
+        *env_dir.glob("*.json"),
+    ]
+    assert len(artifacts) >= 4  # incl. at least one sidecar
+    for a in artifacts:
+        a.chmod(0o644)
+    settings_overlay.parent.chmod(0o755)
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before  # cache hit (chmod is stat-invisible)
+    for a in artifacts:
+        assert _stat.S_IMODE(a.stat().st_mode) == 0o600, a
+    assert _stat.S_IMODE(settings_overlay.parent.stat().st_mode) == 0o700
+
+
+def test_transient_source_read_failure_is_not_cached(
+    tmp_path: Path, rewrite_counter: dict[str, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file that stats fine but fails to READ must not freeze an incomplete
+    output set: readability can return without the stat signature changing."""
+    _mk_tree(tmp_path)
+    real_read = Path.read_text
+    fail = {"on": True}
+
+    def flaky(self: Path, *args: Any, **kwargs: Any) -> str:
+        if fail["on"] and self.name == "agent-0.json" and "agents" in self.parts:
+            raise OSError("transient I/O error")
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", flaky)
+    _rewrite(tmp_path)
+    fail["on"] = False
+
+    fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    assert not fp.exists()  # degraded pass not cached
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2  # full retry
+    assert (tmp_path / "mcp-gateway" / "agents" / "agent-0.json").is_file()
+    assert fp.is_file()  # healthy pass cached again
+
+
+def test_transient_settings_read_failure_is_not_cached(
+    tmp_path: Path, rewrite_counter: dict[str, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The settings/mcp.json read site has the same transient-failure rule as
+    the agent-spec site: a pass that treated an existing settings file as
+    absent (and pruned its overlay) must not be cached, and a fingerprint from
+    an earlier healthy run must be removed."""
+    src = _mk_tree(tmp_path)
+    _rewrite(tmp_path)  # healthy run: fingerprint exists
+    fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    assert fp.is_file()
+
+    _bump_mtime(src / "agent-0.json")  # invalidate so the next call rewrites
+    real_read = Path.read_text
+    fail = {"on": True}
+
+    def flaky(self: Path, *args: Any, **kwargs: Any) -> str:
+        if fail["on"] and self.name == "mcp.json" and "settings" in self.parts:
+            raise OSError("transient I/O error")
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", flaky)
+    _rewrite(tmp_path)
+    fail["on"] = False
+
+    assert not fp.exists()  # degraded pass not cached, stale fingerprint gone
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2  # full retry after fault clears
+    assert fp.is_file()
+    # The settings overlay is back (the degraded pass had pruned it).
+    assert (tmp_path / "mcp-gateway" / "settings" / "mcp.json").is_file()
+
+
+def test_malformed_json_source_is_still_cacheable(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    """JSONDecodeError is a CONTENT problem: fixing it changes the stat
+    signature, so the skip is deterministic and safe to cache."""
+    src = _mk_tree(tmp_path)
+    (src / "broken.json").write_text("{not json")
+    _rewrite(tmp_path)
+    assert (tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME).is_file()
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before  # cache hit despite the bad file
+
+
+def test_sidecar_write_failure_is_not_cached(
+    tmp_path: Path, rewrite_counter: dict[str, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed env-sidecar write leaves the overlay without --env-file while
+    an older sidecar may still exist at that name, so existence checks cannot
+    see the degradation — the pass must simply not be cached."""
+    import tempfile as _tempfile
+
+    _mk_tree(tmp_path, with_env=True)
+    _rewrite(tmp_path)  # healthy run: sidecars + fingerprint exist
+    fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    assert fp.is_file()
+
+    # Invalidate, then fail every sidecar write during the forced rewrite.
+    spec_path = tmp_path / "agents" / "agent-0.json"
+    spec = json.loads(spec_path.read_text())
+    spec["mcpServers"]["srv"]["args"] = ["changed-args"]
+    spec_path.write_text(json.dumps(spec))
+
+    real_mkstemp = _tempfile.mkstemp
+    env_tail = os.path.join("stubs", "env")
+    fail = {"on": True}
+
+    def failing(*args: Any, **kwargs: Any) -> Any:
+        if fail["on"] and str(kwargs.get("dir", "")).endswith(env_tail):
+            raise OSError("disk full")
+        return real_mkstemp(*args, **kwargs)
+
+    monkeypatch.setattr(_tempfile, "mkstemp", failing)
+    _rewrite(tmp_path)
+    fail["on"] = False
+
+    assert not fp.exists()  # degraded pass not cached, stale fingerprint removed
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before + 2  # full retry after fault clears
+    assert fp.is_file()
+
+
+def test_stray_settings_overlay_is_pruned_on_the_skip_path(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    """A settings overlay whose deletion failed on a prior full pass must not
+    survive cache hits — removed global MCP servers must not stay active."""
+    src = _mk_tree(tmp_path, n_agents=1)
+    (tmp_path / "settings" / "mcp.json").unlink()
+    _bump_mtime(src / "agent-0.json")  # ensure fresh inputs
+    _rewrite(tmp_path)  # fingerprint records: no settings overlay
+
+    stray = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
+    stray.parent.mkdir(parents=True, exist_ok=True)
+    stray.write_text("{}")
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before  # cache hit
+    assert not stray.exists()  # and the stray overlay was swept
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permission bits")
+def test_fingerprint_file_is_owner_only(tmp_path: Path) -> None:
+    """The fingerprint records resolved commands and their args (which can
+    legitimately carry credentials in user specs); ratchet the 0600 mode so a
+    refactor to a plain write cannot silently loosen it."""
+    import stat as _stat
+
+    _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)
+    fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    assert _stat.S_IMODE(fp.stat().st_mode) == 0o600
+
+
+def test_lockdown_failure_falls_through_to_full_rewrite(
+    tmp_path: Path, rewrite_counter: dict[str, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cache-hit lockdown is fail-loud on every platform: a foreign-owned
+    or otherwise unprotectable artifact must never be served from cache — the
+    cache hit aborts and the full rewrite re-creates the artifact through its
+    protect-before-content writers."""
+    from kiro_crew import platform_compat as _pc
+
+    _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)
+
+    real = _pc.restrict_to_owner
+    fail = {"on": True}
+
+    def failing(path: Any) -> None:
+        if fail["on"] and str(path).endswith("agent-0.json"):
+            raise OSError("operation not permitted (foreign owner)")
+        real(path)
+
+    monkeypatch.setattr(
+        "kiro_crew.mcp_gateway.rewriter.platform_compat.restrict_to_owner", failing
+    )
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
+    fail["on"] = False
+    assert rewrite_counter["n"] == before + 1  # cache refused -> full rewrite
+
+
+def test_fingerprint_carries_no_command_material(tmp_path: Path) -> None:
+    """Security ratchet: the fingerprint must never store target_env/results —
+    the cache-hit path reconstructs them from the validated overlays, so
+    tampering with the fingerprint can at worst skip a rewrite, never make
+    gatewayd spawn a command that is not already in the overlay files."""
+    _mk_tree(tmp_path, n_agents=1)
+    _, target_env = _rewrite(tmp_path)
+    assert target_env  # the run did produce command material...
+    fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    data = json.loads(fp.read_text())
+    assert set(data.keys()) == {"inputs", "outputs", "which"}
+    # ...and none of it is in the fingerprint.
+    assert "KIROCREW_MCP_TARGET" not in fp.read_text()
+
+
+def test_fingerprint_file_survives_prune_and_does_not_fake_overlay_ready(
+    tmp_path: Path,
+) -> None:
+    """The fingerprint must be invisible to the *.json plumbing: pathlib's
+    glob('*.json') matches dotfiles, so a .json-suffixed name would be pruned
+    as stale and would make an empty overlay dir report ready."""
+    assert not _FINGERPRINT_NAME.endswith(".json")
+    src = _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)
+    overlay_dir = tmp_path / "mcp-gateway" / "agents"
+    fp = overlay_dir / _FINGERPRINT_NAME
+    assert fp.is_file()
+
+    # Full rewrite (input change) must not prune the fingerprint.
+    _bump_mtime(src / "agent-0.json")
+    _rewrite(tmp_path)
+    assert fp.is_file()
+
+    # With no overlays, the fingerprint alone must not make the dir "ready".
+    for p in overlay_dir.glob("*.json"):
+        p.unlink()
+    assert not overlay_ready(overlay_dir)


### PR DESCRIPTION
## Problem

`rewrite_agents()` performs a full unconditional rewrite of the MCP agent overlays on every gateway boot: it parses every `~/.kiro/agents/*.json` spec, resolves bare commands through `shutil.which`, computes PoolKey hashes, and rewrites every overlay and env sidecar — whether or not any input changed since the last boot. On real profiles this is ~170ms of boot cost paid by every user on every launch, for work that almost always produces byte-identical output.

## Why it matters

Boot latency is paid by everyone, every launch, and it compounds: the longer startup holds the event loop, the closer the gateway gets to the loop-stall watchdog. The rewrite is the kind of unconditional maintenance the repo's own boot-path rule forbids adding — this PR removes it from the steady-state boot.

## Fix (symptom → root cause → change)

The cost is structural: there was no fingerprint, cache, or short-circuit anywhere in the path. The fix computes a fingerprint of every output-affecting input before the work loop, persists it at `<overlay_dir>/.rewrite-fingerprint` (temp file protected with 0600/DACL BEFORE any payload byte is written, then atomically renamed — a torn file is unreadable-as-JSON and means "rewrite", never "match"), and skips the rewrite loop when it matches. The fingerprint stores **no command material** — on a cache hit, `results` and `target_env` are **reconstructed from the digest-validated overlay files** via the same `_collect_target_env` the full path uses (byte-identical result, pinned by test), so tampering with the fingerprint can at worst skip or force a rewrite, never make gatewayd spawn a command that is not already in the overlays.

**Inputs enumerated against the code** (not the issue text): per-file size+`mtime_ns`+sha256 of `source_dir/*.json` and `settings/mcp.json` (the digest closes same-size same-tick collisions — e.g. an `autoApprove` entry swapped for an equal-length one); `socket_path` and `work_dir` (stub argv + PoolKey); `sandbox_mode`, `approval_mode`, `stub_servers`, `pooling_enabled`; `sys.executable` (baked into every overlay `command`); `PATH`/`PATHEXT`; package version + schema constant. One input the issue's list missed is covered separately: `mcp_gateway.forward_declared_env` was verified to select warning text only (no output byte differs), and is deliberately excluded.

**What stats cannot see, the cache-hit path verifies or re-asserts directly:**
- Every `shutil.which` probe from the previous run is recorded (`bare_cmd → resolved-or-none`) and **re-run on cache hit** — directory contents are which() input, so a binary removed, reinstalled at a different PATH prefix, or newly shadowed invalidates the cache in both directions instead of serving a dead absolute path forever.
- Every recorded output (overlays, sidecars, settings overlay) is validated by size+`mtime_ns`+digest — an edited overlay must not diverge from the cached `target_env` (the stub's PoolKey would hash the edited command while gatewayd spawns the recorded one).
- Owner-only permissions are **re-tightened**, not just validated (a `chmod` changes no signature): the env-sidecar dir, the settings overlay dir, and the settings overlay file (0600).
- The prune pass runs on the skip path too, including a leftover settings overlay whose source is gone (a transiently failed deletion must not keep removed global servers active).

**Transient faults never freeze:** a source read `OSError` (file stats fine but is unreadable — readability can return without the stat changing), a sidecar write failure (the overlay omits `--env-file` while an old sidecar still exists at that name), or an overlay write failure all make the pass uncacheable *and* delete any prior fingerprint. `JSONDecodeError` stays cacheable — fixing the content changes the signature. `PoolKey` is untouched.

## Measurement (same machine, same fixture: 10 agents × 3 stdio servers + settings/mcp.json, warm boot × 10)

| | warm mean | warm min |
|---|---|---|
| before (main) | 21.06 ms | 18.37 ms |
| after | 2.32 ms | 2.27 ms |

~9× on this fixture; the absolute saving scales with profile size (the issue measured ~170ms on a real profile). The 2.32ms includes hashing every input file, re-running the recorded which() probes, and reconstructing `target_env` from the validated overlays. Cached `results`/`target_env` verified byte-identical to a fresh run.

## Tests

31 tests in `test/test_mcp_gateway_rewriter_fingerprint.py`; 10 targeted mutants killed (drop settings input, mtime-seconds coarsening, drop size, remove which re-probe, weaken content check to existence, skip settings sweep, cache on read/sidecar failure, loosen 0600, settings-site flag removal). Highlights:

- unchanged inputs → skip, cached result equals the fresh result exactly
- every input invalidates: content change, same-size mtime bump, settings edit/deletion, each config parameter, socket/work-dir, PATH, package version
- which re-probes: binary installed at an existing PATH dir invalidates (no PATH/spec change); resolved binary removed invalidates
- deleted/edited overlay or sidecar → regenerated; corrupt/malformed/traversal-tampered fingerprints → full rewrite, never a match, never a raise
- skip path still prunes stray overlays, sidecars, and a stray settings overlay
- transient read/sidecar faults not cached + stale fingerprint removed; fingerprint file is 0600 (POSIX ratchet), invisible to `*.json` prune globs and `overlay_ready()`

Local reviews: GPT (4 BLOCKING) and Opus (1 BLOCKING + 3 advisories) — all findings fixed, focused verifier confirms all closed with no new findings. Full gates green (pytest full-suite failure set comm-diffed against unmodified main: zero branch-only regressions, the residual set reproduces on main or passes in isolation; isort/flake8 clean; mypy: same 4 pre-existing errors as main, none in changed files).

## Manual verification

N/A — unit coverage exercises the full `rewrite_agents` entry point against real files in tmp dirs, including both cache-hit and invalidation paths; no UI surface.

Closes #2521
