### PR TITLE
feat(update): drain-aware update apply — shared lease, quiesce gate, bounded drain

### DIFF
--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -40,7 +40,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterator
 
-from kiro_crew import platform_compat, shutdown_event
+from kiro_crew import platform_compat, shutdown_event, update_drain
 from kiro_crew.atomic_write import replace_with_retry
 from kiro_crew.config.loader import config_dir
 from kiro_crew.config.paths import legacy_home
@@ -1073,6 +1073,17 @@ class AutoNudgeService:
             )
             await self.update(loop.id, active=False, stopped_reason="runtime_budget")
             self._emit("expired", loop)
+            return
+        # Quiesce gate (RFC §5 step 3): while an update is draining, firing a
+        # nudge would start a brand-new agent turn seconds before an
+        # intentional restart — the turn dies mid-prompt and the cycle is
+        # wasted. Defer by re-arming with a short delay instead: the loop's
+        # bookkeeping is untouched (no cycle consumed, nothing persisted), and
+        # loops survive the restart anyway (autonudge.json re-arms at boot),
+        # so on the slow path the relaunched gateway fires it instead.
+        if update_drain.drain_gate.is_draining():
+            logger.info("AutoNudge: update drain in progress — deferring fire for %s", loop.id)
+            self._arm_timer(loop, delay=min(30.0, loop.idle_secs))
             return
         # Fire. Update state only if the callback reports actual delivery —
         # otherwise skipped nudges (e.g. slot mid-turn) inflate cycle_count and

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -79,6 +79,7 @@ from kiro_crew.skill_usage import register_skill_read_observer
 from kiro_crew.skills import SkillsLoader
 from kiro_crew.slack.gateway import run_gateway
 from kiro_crew.taskrunner import TaskRunner
+from kiro_crew.update_drain import UpdateLease, _consume_lease_if_unchanged, _pid_alive
 from kiro_crew.vector_memory import VectorMemoryStore
 
 # Loopback address used for the CLI's OWN requests to the gateway. Deliberately
@@ -956,16 +957,47 @@ def _update() -> None:
     * **externally managed** (desktop app, Docker) — print guidance on how
       to update via the correct surface instead of failing with an opaque error.
     """
-    from kiro_crew.platform.update_layout import (
-        EXTERNALLY_MANAGED,
-        InstallLayout,
-    )
-
     print("👻 Updating Kiro Crew…\n")
 
     proj = os.environ.get("KIROCREW_PROJECT_DIR", "")
     proj_path = Path(proj) if proj else None
     is_git = proj_path is not None and (proj_path / ".git").exists()
+
+    # Serialize with every other update path via the shared lease — ACQUIRED,
+    # not just read. A read-then-proceed check is a TOCTOU: the dashboard (or
+    # boot auto-apply) can acquire immediately after a clean read and both
+    # would mutate the same checkout/venv concurrently. Holding the lease for
+    # the whole update makes the CLI a first-class §5 participant: the
+    # gateway paths refuse while we hold it, and vice versa. A dead holder's
+    # leftover (crashed apply) is consumed through the guarded consume path
+    # (cross-process lock + identity re-check) and the acquire retried once,
+    # so a stale file keeps not blocking a manual update.
+    lease = UpdateLease()
+    refusal = lease.acquire(from_version=__version__, source="cli_update")
+    if refusal is not None:
+        stale = lease.read()
+        holder_alive = stale is not None and _pid_alive(int(stale.get("pid") or 0))
+        if stale is not None and not holder_alive and _consume_lease_if_unchanged(lease, stale):
+            refusal = lease.acquire(from_version=__version__, source="cli_update")
+        if refusal is not None:
+            print(
+                "  ❌ Another update is in flight — running two updates over "
+                "the same tree can corrupt the install.\n"
+                f"     {refusal}"
+            )
+            return
+    try:
+        _update_locked(proj, proj_path, is_git)
+    finally:
+        lease.release()
+
+
+def _update_locked(proj: str, proj_path: Path | None, is_git: bool) -> None:
+    """The update body proper; runs with the update lease held (see _update)."""
+    from kiro_crew.platform.update_layout import (
+        EXTERNALLY_MANAGED,
+        InstallLayout,
+    )
 
     if not is_git:
         # Not a git checkout — check if externally managed or wheel install.

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -169,6 +169,7 @@ _KNOWN_CONFIG_SECTIONS: frozenset = frozenset(
         "snapshot_dir",
         "timezone",
         "auto_update",
+        "update_drain_timeout_secs",
         "registries",
     }
 )
@@ -5398,6 +5399,15 @@ class KiroCrewConfig:
         default=True,
         metadata=_meta("Auto Update", "Enable automatic update checks."),
     )
+    update_drain_timeout_secs: int = field(
+        default=300,
+        metadata=_meta(
+            "Update Drain Timeout (secs)",
+            "Max seconds an update waits for in-flight agent work (turns, "
+            "cron runs, subagents) to finish before restarting the gateway. "
+            "0 restarts immediately.",
+        ),
+    )
     timezone: str = field(
         default="",
         metadata=_meta(
@@ -6254,6 +6264,9 @@ class KiroCrewConfig:
                 cursor_motion=_safe_bool(computer_use_data.get("cursor_motion", False), False),
             ),
             auto_update=data.get("auto_update", True),
+            update_drain_timeout_secs=_safe_int(
+                data.get("update_drain_timeout_secs", 300), 300, lo=0
+            ),
             timezone=data.get("timezone", ""),
             snapshot_dir=data.get("snapshot_dir", ""),
             registries=[
@@ -6487,6 +6500,7 @@ class KiroCrewConfig:
             "snapshot_dir": self.snapshot_dir,
             "timezone": self.timezone,
             "auto_update": self.auto_update,
+            "update_drain_timeout_secs": self.update_drain_timeout_secs,
         }
         # External registries (always serialized so save() round-trips the field)
         d["registries"] = [asdict(r) for r in self.registries]

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -46,7 +46,7 @@ except ImportError:
     get_description = None  # type: ignore[assignment]
 from croniter import croniter  # type: ignore[import-untyped]
 
-from kiro_crew import cron_script, platform_compat, sel, shutdown_event
+from kiro_crew import cron_script, platform_compat, sel, shutdown_event, update_drain
 from kiro_crew.config.loader import KiroCrewConfig, config_dir, data_home
 from kiro_crew.constants import env_flag_enabled
 from kiro_crew.cron_history import CronHistoryStore, CronRunRecord
@@ -2069,6 +2069,24 @@ class CronService:
         """Return whether a job is currently executing."""
         return job_id in self._executing
 
+    def executing_count(self) -> int:
+        """Number of jobs currently executing (jitter sleepers included).
+
+        Consulted by the gateway's in-flight-work counter so an update drain
+        (RFC §5 step 5) waits for a mid-run job — its agent session or script
+        subprocess dies with the gateway. Jobs merely DUE are not in
+        ``_executing`` at all (the post-restart tick picks them up).
+
+        Jitter sleepers COUNT: every drain path holds the drain gate, and the
+        jitter sleep in ``_run_job_isolated`` wakes on the gate's drain event
+        and runs immediately — so by the time a drain polls this count, a
+        claimed job is real work in flight, not a 59-minute sleep burning the
+        drain timeout. Excluding sleepers (the previous behavior) silently
+        lost cron-expression invocations: the drain reported idle, the exec
+        killed the sleeper, and the scheduled minute had passed by relaunch.
+        """
+        return len(self._executing)
+
     def running_since(self, job_id: str) -> float | None:
         """Return the epoch start time of a running job, or None."""
         return self._job_start_times.get(job_id)
@@ -2376,6 +2394,23 @@ class CronService:
             for j in snapshot
             if j.enabled and j.id not in self._executing and self._is_due(j, now)
         ]
+        # Quiesce gate (RFC §5 step 3): while an update is draining, claim NO
+        # due work — the swap is imminent and a job claimed now extends the
+        # drain the swap is waiting on. Interval ('every') and one-shot ('at')
+        # schedules stay due until they run, so the relaunched gateway's first
+        # tick picks them up. A cron-expression job is due only inside its
+        # matching minute: it is claimed after the swap if that minute has not
+        # passed, and a swap that crosses the minute boundary skips that one
+        # invocation — the drain design accepts this so the swap window stays
+        # free of new work. Already-executing jobs are untouched: the drain
+        # counts them via executing_count() and waits (bounded) for them.
+        if update_drain.drain_gate.is_draining():
+            if due:
+                logger.info(
+                    "Cron tick: update drain in progress — deferring %d due-job claim(s)",
+                    len(due),
+                )
+            return
 
         if not due:
             return
@@ -2422,7 +2457,24 @@ class CronService:
             # real result as "cancelled".
             if jitter > 0:
                 logger.debug("Cron: applying %.0fs jitter to job '%s'", jitter, job.name)
-                await asyncio.sleep(jitter)
+                # Drain-aware sleep: if an update drain begins while this job
+                # is in its jitter window, wake and run IMMEDIATELY. The exec
+                # that follows a drain would otherwise kill the sleeper, and
+                # for cron-expression jobs the scheduled minute has passed by
+                # the relaunch, so the invocation would be silently lost.
+                # Jitter is load-spreading, not semantics — running at the
+                # scheduled minute during a drain is more correct, and the
+                # drain then waits for this run like any other in-flight work.
+                try:
+                    await asyncio.wait_for(
+                        update_drain.drain_gate.drain_event().wait(), timeout=jitter
+                    )
+                    logger.info(
+                        "Cron: update drain began during jitter for '%s' — running now",
+                        job.name,
+                    )
+                except asyncio.TimeoutError:
+                    pass  # normal path: jitter elapsed, no drain
             exec_started_at = time.time()
             # Notify dashboard that the job has started executing so the live
             # is_running badge appears without a manual reload.

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -17,7 +17,7 @@ from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionResetError
 
 from kiro_crew import __version__ as _local_version
-from kiro_crew import shutdown_event
+from kiro_crew import shutdown_event, update_drain
 from kiro_crew.beacon import distribution
 from kiro_crew.changelog import Release, build_release_list
 from kiro_crew.config.loader import (
@@ -911,41 +911,105 @@ async def _venv_pip_install(proj: str, state: DashboardState) -> bool:
     return True
 
 
-async def _restart_gateway(state: DashboardState) -> None:
-    """Save state, close sessions, and exec the same Python process."""
-    state.push_update_progress("restarting", "Restarting server…")
-    exe = sys.executable
-    if not os.path.isfile(exe) or not os.access(exe, os.X_OK):
-        state.push_update_progress("error", "Cannot restart: invalid Python executable path")
-        return
-    # circular import: kiro_crew.dashboard.chat imports from
-    # kiro_crew.dashboard.handlers (which re-exports this module), so this
-    # must stay inline to avoid an import cycle at module load.
-    from kiro_crew.dashboard.chat import save_all_slots_to_history
-    from kiro_crew.executors import subprocess_executor
+async def _restart_gateway(
+    state: DashboardState,
+    *,
+    drain: bool = True,
+    lease: "update_drain.UpdateLease | None" = None,
+) -> None:
+    """Save state, close sessions, and exec the same Python process.
 
+    When ``drain`` is true (default) and the gateway registered an in-flight
+    counter, waits — bounded by ``update_drain_timeout_secs`` — for running
+    turns, cron executions, and subagents to finish first (RFC §5 step 5), so
+    an intentional restart doesn't kill work mid-prompt.
+
+    ``lease`` is the caller-held update lease for a BARE restart (no code
+    swap): just before the exec it is marked as a restart-only handoff
+    (``expect_change=False``) so the next boot's verification consumes it
+    silently. The update path marks its own lease and passes None here.
+    """
+    gate_entered = False
+    # getattr: duck-typed states (tests, embedded setups) may not define the
+    # counter attribute at all — treat that the same as "no counter wired".
+    count_in_flight = getattr(state, "count_in_flight", None)
+    if drain and count_in_flight is not None:
+        state.push_update_progress("restarting", "Waiting for in-flight agent work to finish…")
+        try:
+            cfg = await asyncio.to_thread(KiroCrewConfig.load)
+            timeout = float(cfg.update_drain_timeout_secs)
+        except Exception:
+            timeout = update_drain.DEFAULT_DRAIN_TIMEOUT_SECS
+        # The gate stays held from here THROUGH the execv: releasing it after
+        # the drain but before the exec reopens background intake for the
+        # history-save/session-cleanup/final-sleep window, and a cron or
+        # autonudge fire starting in that window is killed mid-operation by
+        # the exec. The finally below runs only on the non-restart exits
+        # (early return, exception) — a successful execv never returns.
+        update_drain.drain_gate.enter()
+        gate_entered = True
     try:
-        # Offload the synchronous per-slot save (per-session lock + disk I/O)
-        # to the bounded subprocess_executor with a deadline: on the event loop
-        # a contended session raises HistoryLockTimeout and a wedged disk would
-        # block the restart, so a slot's final save must run off-loop and be
-        # time-bounded rather than stall (or silently drop) here.
-        await asyncio.wait_for(
-            asyncio.get_running_loop().run_in_executor(
-                subprocess_executor(), save_all_slots_to_history, state
-            ),
-            timeout=5.0,
-        )
-    except Exception:
-        logger.debug("History save before restart failed", exc_info=True)
-    try:
-        await state.sessions.close_all()
-    except Exception:
-        logger.debug("Session cleanup before restart failed", exc_info=True)
-    sys.stdout.flush()
-    sys.stderr.flush()
-    await asyncio.sleep(0.5)
-    os.execv(exe, [exe, "-m", "kiro_crew"] + sys.argv[1:])
+        if gate_entered:
+            await update_drain.drain_in_flight(
+                shutdown_event,
+                count_in_flight,
+                drain_timeout=timeout,
+                what="restart",
+            )
+            if shutdown_event.is_set():
+                # A real shutdown owns the process now — don't race
+                # _shutdown() with an execv.
+                logger.warning("Restart aborted: shutdown began during drain")
+                return
+        state.push_update_progress("restarting", "Restarting server…")
+        exe = sys.executable
+        if not os.path.isfile(exe) or not os.access(exe, os.X_OK):
+            state.push_update_progress("error", "Cannot restart: invalid Python executable path")
+            return
+        # circular import: kiro_crew.dashboard.chat imports from
+        # kiro_crew.dashboard.handlers (which re-exports this module), so this
+        # must stay inline to avoid an import cycle at module load.
+        from kiro_crew.dashboard.chat import save_all_slots_to_history
+        from kiro_crew.executors import subprocess_executor
+
+        try:
+            # Offload the synchronous per-slot save (per-session lock + disk I/O)
+            # to the bounded subprocess_executor with a deadline: on the event loop
+            # a contended session raises HistoryLockTimeout and a wedged disk would
+            # block the restart, so a slot's final save must run off-loop and be
+            # time-bounded rather than stall (or silently drop) here.
+            await asyncio.wait_for(
+                asyncio.get_running_loop().run_in_executor(
+                    subprocess_executor(), save_all_slots_to_history, state
+                ),
+                timeout=5.0,
+            )
+        except Exception:
+            logger.debug("History save before restart failed", exc_info=True)
+        if lease is not None:
+            # §5 step 8→9 for a bare restart: hand the lease to the next boot
+            # marked "no version change expected" so verification consumes it
+            # silently instead of reporting a failed update. The handoff write
+            # MUST precede close_all(): mark_restarting raises on a failed
+            # write (disk full, rename failure), and once close_all() has set
+            # _closing every subsequent agent turn is rejected — aborting
+            # there would leave a live gateway permanently closing. Failing
+            # here instead aborts the restart while the gateway is still
+            # fully serving.
+            await lease.mark_restarting_async(expect_change=False)
+        try:
+            await state.sessions.close_all()
+        except Exception:
+            logger.debug("Session cleanup before restart failed", exc_info=True)
+        sys.stdout.flush()
+        sys.stderr.flush()
+        await asyncio.sleep(0.5)
+        os.execv(exe, [exe, "-m", "kiro_crew"] + sys.argv[1:])
+    finally:
+        # Reached only when the restart did NOT happen — a leaked gate would
+        # silently freeze cron claims and autonudge fires forever.
+        if gate_entered:
+            update_drain.drain_gate.exit()
 
 
 async def api_update_channel(request: web.Request) -> web.Response:
@@ -1072,6 +1136,23 @@ async def api_gateway_restart(request: web.Request) -> web.Response:
     """
     state: DashboardState = request.app["state"]
 
+    # Atomically ACQUIRE the shared update lease for the restart (not merely
+    # read it): a read-then-schedule check leaves a TOCTOU window — an update
+    # could take the lease during the 250ms response-flush delay and the
+    # delayed exec would swap the process mid-`pip install`. Holding the
+    # lease also serializes concurrent restart requests. The refusal covers
+    # both "an update is applying" and "a restart is already scheduled".
+    restart_lease = update_drain.UpdateLease()
+    refusal = await restart_lease.acquire_async(from_version=_local_version, source="gateway_restart")
+    if refusal:
+        return web.json_response(
+            {
+                "error": f"Restart refused: {refusal}",
+                "code": "update_in_flight",
+            },
+            status=409,
+        )
+
     # Reply BEFORE restarting. os.execv replaces the process image, so a restart
     # kicked off inline would tear down the connection mid-response and the
     # client could not distinguish "restarting" from "the request failed".
@@ -1079,10 +1160,15 @@ async def api_gateway_restart(request: web.Request) -> web.Response:
         # Let the response flush before the process image is replaced.
         await asyncio.sleep(0.25)
         try:
-            await _restart_gateway(state)
+            await _restart_gateway(state, lease=restart_lease)
         except Exception:
             logger.exception("Gateway restart failed")
             state.push_update_progress("failed", "Restart failed — check logs")
+        finally:
+            # Reached only when the exec did NOT happen (abort or failure) —
+            # a successful execv never returns, and its marked handoff is
+            # consumed by the next boot's verification.
+            await restart_lease.release_async()
 
     task = asyncio.create_task(_restart())
     state._background_tasks.add(task)
@@ -1148,8 +1234,51 @@ async def api_update_apply(request: web.Request) -> web.Response:
             status=409,
         )
 
+    # RFC §5 step 2: one update in flight, ever. The lease also closes a
+    # previously-unguarded race — two concurrent POSTs each drove their own
+    # git pull + pip install + execv. Acquired BEFORE the background task is
+    # created so the refused caller gets an honest 409, not an "ok" whose
+    # apply then dies against the winner's.
+    lease = update_drain.UpdateLease()
+    refusal = await lease.acquire_async(from_version=_local_version, source="dashboard_apply")
+    if refusal:
+        logger.warning("Update refused: %s", refusal)
+        return web.json_response(
+            {"error": f"Update refused: {refusal}", "code": "update_in_flight"},
+            status=409,
+        )
+
     async def _apply() -> None:
+        # §5 step 3: quiesce background intake (cron claims, autonudge fires)
+        # for the whole apply, not merely the final drain — on the git engine
+        # the pull below already mutates the running install, so work started
+        # mid-apply would run on half-swapped code (issue #2324).
+        update_drain.drain_gate.enter()
+        restarted = False
         try:
+            # §5 step 5: drain BEFORE the first mutation, not just before the
+            # restart. The pull/rebuild/pip below replace the very modules a
+            # running cron or subagent may lazily import mid-job — draining
+            # only at restart time would let that work execute on a mixed
+            # old/new module set while pip swaps its dependencies.
+            state.push_update_progress("pulling", "Waiting for in-flight agent work to finish…")
+            try:
+                cfg = await asyncio.to_thread(KiroCrewConfig.load)
+                timeout = float(cfg.update_drain_timeout_secs)
+            except Exception:
+                timeout = update_drain.DEFAULT_DRAIN_TIMEOUT_SECS
+            await update_drain.drain_in_flight(
+                shutdown_event,
+                # getattr: DashboardState defines this, but duck-typed states
+                # (tests, embedded/API-only setups) may not — no counter
+                # simply means nothing to drain.
+                getattr(state, "count_in_flight", None),
+                drain_timeout=timeout,
+                what="dashboard update",
+            )
+            if shutdown_event.is_set():
+                logger.warning("Update aborted: shutdown began during drain")
+                return
             state.push_update_progress("pulling", "Pulling latest changes…")
             pull = await asyncio.create_subprocess_exec(
                 "git",
@@ -1184,11 +1313,39 @@ async def api_update_apply(request: web.Request) -> web.Response:
 
             # Restart: save history + clean up sessions then exec the same process.
             logger.info("Update complete — saving history and cleaning up before restart")
-            await _restart_gateway(state)
+            # §5 step 8→9 handoff: record the post-pull HEAD as the
+            # handshake's primary identity (the git engine updates
+            # per-commit; __version__ rarely changes, so a version-keyed
+            # handshake would report false failures for successful pulls).
+            # The probe is centralized in update_drain (trusted-path git
+            # resolution; '' degrades to version comparison).
+            head_sha = await update_drain.current_head_commit_async()
+            await lease.mark_restarting_async(target_commit=head_sha)
+            restarted = True
+            # drain=True (a SECOND, usually-instant drain): the pull/build/
+            # install above takes minutes, and an interactive turn that
+            # STARTED during it would die at the execv — background intake is
+            # gated, but interactive turns are deliberately not refused
+            # (#2217). On an idle gateway this re-drain returns immediately.
+            await _restart_gateway(state, drain=True)
+            # _restart_gateway returns (instead of exec'ing) only when it
+            # aborted — e.g. a real shutdown arrived mid-drain.
+            restarted = False
         except Exception:
+            # An exception anywhere means the process did NOT exec into the
+            # new code (a successful execv never returns OR raises).
+            restarted = False
             logger.exception("Update failed")
             state.push_update_progress("failed", "Update failed — check logs")
             state.push_refresh("update_failed")
+        finally:
+            update_drain.drain_gate.exit()
+            if not restarted:
+                # The process did not exec into the new code — a lease left
+                # behind would block every future update until the next boot
+                # consumes it, and a 'restarting' state at next boot would
+                # misreport this failed apply as an interrupted restart.
+                await lease.release_async()
 
     task = asyncio.create_task(_apply())
     state._background_tasks.add(task)

--- a/src/kiro_crew/dashboard/stale_asset_watchdog.py
+++ b/src/kiro_crew/dashboard/stale_asset_watchdog.py
@@ -31,6 +31,7 @@ import logging
 from collections.abc import Callable
 from typing import Protocol
 
+from kiro_crew import update_drain
 from kiro_crew.dashboard.handlers.core import _DIST_INDEX
 
 logger = logging.getLogger(__name__)
@@ -109,7 +110,8 @@ async def run_stale_asset_watchdog(
     down.
 
     Once a vanish is confirmed, in-flight backend work is *drained* before the
-    shutdown event is set (see ``_drain_in_flight``): the prune only breaks
+    shutdown event is set (see :func:`kiro_crew.update_drain.drain_in_flight`,
+    the shared §5 drain): the prune only breaks
     static-asset serving, so active ACP turns can finish rather than being
     killed mid-prompt when the supervisor restarts a fresh process.
 
@@ -174,7 +176,20 @@ async def run_stale_asset_watchdog(
                 # Someone else shut us down during the confirm window; don't
                 # log a misleading "watchdog fired" CRITICAL.
                 return
-            await _drain_in_flight(
+            if update_drain.drain_gate.is_draining():
+                # A coordinated update is applying right now (lease held,
+                # RFC §5): the vanish is the update's own build step pruning
+                # and re-staging the bundle, and the apply path owns the
+                # drain + restart. Firing here would double-trigger — a
+                # SIGTERM-style shutdown racing the update's execv. Stand
+                # down; if the apply fails and leaves the assets gone, the
+                # gate is released and the next tick handles it normally.
+                logger.info(
+                    "Stale-asset watchdog: assets missing during a "
+                    "coordinated update apply — standing down this tick."
+                )
+                continue
+            await _drain_with_gate(
                 shutdown_event,
                 count_in_flight,
                 drain_timeout=drain_timeout,
@@ -187,7 +202,7 @@ async def run_stale_asset_watchdog(
             # Re-check once more now that in-flight work has drained. This
             # covers a rebuild that outlives the confirmation but finishes
             # while turns are still draining; it adds no grace on an idle
-            # gateway, where _drain_in_flight returns immediately. Without it a
+            # gateway, where the drain returns immediately. Without it a
             # drain long enough for the assets to reappear still ends in a
             # shutdown — the healthy-gateway kill the confirmation exists to
             # prevent.
@@ -207,89 +222,30 @@ async def run_stale_asset_watchdog(
             return
 
 
-async def _drain_in_flight(
+async def _drain_with_gate(
     shutdown_event: _ShutdownSignal,
     count_in_flight: Callable[[], int] | None,
     *,
     drain_timeout: float,
     drain_poll: float,
 ) -> None:
-    """Wait (bounded) for in-flight backend turns to finish before shutdown.
+    """Run the shared drain while HOLDING the drain gate.
 
-    An update prune breaks only static-asset serving; live ACP turns keep
-    working. Draining lets active turns complete (result captured, history
-    saved) instead of being killed mid-prompt when the supervisor restarts —
-    directly preventing the "❌ lost to gateway restart / no result captured"
-    orphaning seen on an abrupt prune.
-
-    Returns as soon as any of the following is true:
-      * there is no in-flight work,
-      * the ``drain_timeout`` elapses (remaining tasks are snapshotted for
-        resume by the normal shutdown path), or
-      * an external shutdown is signalled mid-drain (SIGTERM wins).
-
-    Any failure to count in-flight work is treated as "idle" — a broken
-    predicate must never wedge shutdown.
+    Holding the gate here does two things the raw drain does not: it stops
+    cron/autonudge from starting new work that the imminent supervisor
+    restart would kill, and it wakes cron jobs sleeping in their jitter
+    window (they wait on the gate's drain event) so a claimed invocation
+    executes and is waited for instead of being killed mid-sleep after its
+    scheduled minute has passed.
     """
-    if count_in_flight is None or drain_timeout <= 0:
-        return
+    update_drain.drain_gate.enter()
     try:
-        pending = count_in_flight()
-    except Exception:
-        logger.debug(
-            "Stale-asset watchdog: initial in-flight count failed — "
-            "skipping drain.",
-            exc_info=True,
+        await update_drain.drain_in_flight(
+            shutdown_event,
+            count_in_flight,
+            drain_timeout=drain_timeout,
+            drain_poll=drain_poll,
+            what="stale-asset watchdog",
         )
-        return
-    if pending <= 0:
-        return
-
-    logger.warning(
-        "Stale-asset watchdog: draining %d in-flight task(s) before shutdown "
-        "(up to %.0fs)…",
-        pending,
-        drain_timeout,
-    )
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + drain_timeout
-    while True:
-        remaining = deadline - loop.time()
-        if remaining <= 0:
-            break
-        # Sleep interruptibly: an external SIGTERM sets shutdown_event and
-        # wakes us immediately so we don't keep draining past a real shutdown.
-        try:
-            await asyncio.wait_for(
-                shutdown_event.wait(), timeout=min(drain_poll, remaining)
-            )
-            logger.warning(
-                "Stale-asset watchdog: external shutdown during drain — "
-                "stopping drain."
-            )
-            return
-        except asyncio.TimeoutError:
-            pass
-        try:
-            pending = count_in_flight()
-        except Exception:
-            logger.debug(
-                "Stale-asset watchdog: in-flight count failed mid-drain — "
-                "proceeding with shutdown.",
-                exc_info=True,
-            )
-            return
-        if pending <= 0:
-            logger.warning(
-                "Stale-asset watchdog: all in-flight tasks drained — "
-                "proceeding with shutdown."
-            )
-            return
-
-    logger.warning(
-        "Stale-asset watchdog: drain timeout (%.0fs) elapsed with %d task(s) "
-        "still in flight — proceeding with shutdown; open sessions resume "
-        "from snapshot on restart.",
-        drain_timeout,
-        pending,
-    )
+    finally:
+        update_drain.drain_gate.exit()

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2256,6 +2256,11 @@ class DashboardState:
         # constructed. The central chat runner reads this latch so every turn
         # entry path is protected, including task/workflow continuations.
         self.kiro_prerequisite_service: Any = None
+        # Callable returning the gateway's in-flight work count (turns, cron
+        # runs, subagents) — set by the gateway, consumed by the update/restart
+        # handlers to drain before restarting (RFC §5 step 5). None (e.g. in
+        # tests or API-only setups without a counter) means "skip draining".
+        self.count_in_flight: Callable[[], int] | None = None
         self.subagents = subagents
         # Crew Mode control plane; attached by the gateway after
         # SubagentManager construction (None = crew mode unavailable).

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -227,6 +227,13 @@ from kiro_crew.subagent_completion_meta import (
     wave_final_meta,
 )
 from kiro_crew.taskrunner import TaskRunner
+from kiro_crew.update_drain import (
+    UpdateLease,
+    current_head_commit_async,
+    drain_gate,
+    drain_in_flight,
+    verify_after_restart,
+)
 
 if TYPE_CHECKING:
     from kiro_crew.dashboard.state import _ChatSlot
@@ -1116,11 +1123,12 @@ class GatewayOrchestrator:
     def _count_in_flight_work(self) -> int:
         """Count in-flight backend tasks that an abrupt restart would lose.
 
-        Used by the stale-asset watchdog to drain before shutting down: an
-        update prune only breaks static-asset serving, not live ACP turns, so
-        letting active turns finish avoids the "❌ lost to gateway restart /
-        no result captured" orphaning. Counts active provider turns (dashboard
-        chat + task-runner sessions) plus in-flight Slack session turns.
+        Used by the stale-asset watchdog and the update drain (RFC §5 step 5)
+        to wait before restarting: letting active work finish avoids the
+        "❌ lost to gateway restart / no result captured" orphaning. Counts
+        active provider turns (dashboard chat + task-runner sessions),
+        in-flight Slack session turns, executing cron jobs, and running
+        subagents (whose kiro-cli processes are children of this gateway).
 
         Defensive: any failure to introspect a surface is treated as idle, so
         a broken accessor can never wedge shutdown.
@@ -1146,6 +1154,25 @@ class GatewayOrchestrator:
         for task in list(self._session_tasks.values()):
             if not task.done():
                 count += 1
+        # Executing cron jobs. A cron mid-run holds an agent session (or a
+        # script/command subprocess) that an abrupt restart kills; jobs merely
+        # *due* don't count — the post-restart scan picks those up.
+        if self.cron_svc is not None:
+            try:
+                count += self.cron_svc.executing_count()
+            except Exception:
+                logger.debug("in-flight count: cron executing_count() failed", exc_info=True)
+        # Subagent work across its whole lifecycle: running agents (kiro-cli
+        # processes are CHILDREN of this gateway — they die with it), spawns
+        # accepted into the queue but not yet started (they'd vanish without
+        # a completion event), and terminal reports still delivering a
+        # finished run's result. A drain must wait for all three.
+        try:
+            mgr = getattr(self, "subagent_mgr", None)
+            if mgr is not None:
+                count += mgr.drainable_work_count
+        except Exception:
+            logger.debug("in-flight count: subagent drainable_work_count failed", exc_info=True)
         return count
 
     # ------------------------------------------------------------------
@@ -5922,6 +5949,13 @@ class GatewayOrchestrator:
             self.dashboard_state.slack_client = self.slack
         if self.dashboard_state:
             self.dashboard_state.no_crons = self._no_crons  # dashboard mode
+            # Wire the in-flight counter HERE, synchronously with dashboard
+            # creation and before the next await: the HTTP server is already
+            # accepting requests, and an early POST /api/update or /api/restart
+            # arriving before the counter is wired would see None and restart
+            # without draining — killing e.g. an overdue cron that started at
+            # boot (RFC §5 step 5).
+            self.dashboard_state.count_in_flight = self._count_in_flight_work
 
     async def _init_api_server(self) -> None:
         """Start a minimal API-only HTTP server for MCP tool transport."""
@@ -5958,6 +5992,9 @@ class GatewayOrchestrator:
                 self._dashboard_port = addresses[0][1]
         if self.dashboard_state:
             self.dashboard_state.no_crons = self._no_crons  # API-only mode
+            # Same wiring as the dashboard path — the API-only server exposes
+            # the update/restart endpoints too.
+            self.dashboard_state.count_in_flight = self._count_in_flight_work
 
     async def _start_embeddings(self) -> None:
         """Wire in-process embeddings and kick background model download.
@@ -6394,6 +6431,23 @@ class GatewayOrchestrator:
             from kiro_crew import __version__ as _running_version
             from kiro_crew.dashboard.handlers import _do_update_check, _update_info
 
+            # §5 step 9: if the previous process restarted for an update,
+            # verify the swap actually took — a lease in 'restarting' state
+            # at boot is the prior process's handoff. Runs BEFORE this boot's
+            # own check so a failed swap is reported (not silently retried
+            # into a loop) and so the consumed lease can't refuse this
+            # check's own auto-apply. Off-loop: it reads/unlinks a file.
+            try:
+                outcome = await asyncio.to_thread(verify_after_restart, _running_version)
+                if outcome:
+                    print(f"👻 {outcome}")
+                    # A FAILED handshake must reach a surface the user sees —
+                    # a headless/systemd install never shows the console.
+                    if self.dashboard_state and "did NOT take effect" in outcome:
+                        self.dashboard_state.push_update_progress("failed", outcome)
+            except Exception:
+                logger.debug("Update verification at boot failed", exc_info=True)
+
             await _do_update_check()
             from kiro_crew.platform.update_governance import min_version, update_required
 
@@ -6508,6 +6562,12 @@ class GatewayOrchestrator:
         proj = os.environ.get("KIROCREW_PROJECT_DIR", "")
         if not proj:
             return
+        # RFC §5 (drain-then-swap) state, function-scoped so the outer except
+        # can release exactly what THIS invocation took. The lease serializes
+        # updates across paths and processes; the gate quiesces background
+        # intake (cron claims, autonudge fires) while draining.
+        lease: UpdateLease | None = None
+        gate_entered = False
         try:
             # Detect current branch
             branch_proc = await asyncio.create_subprocess_exec(
@@ -6584,6 +6644,42 @@ class GatewayOrchestrator:
                 # No diff — already up to date
                 if self.dashboard_state:
                     self.dashboard_state.clear_update_progress()
+                return
+
+            # New commits confirmed — the tree WILL be mutated from here on.
+            # On the git engine, install and swap are the same step: the
+            # `reset --hard` below replaces the running install's files
+            # (issue #2324 — assets swapped under a live gateway). So the §5
+            # sequence starts NOW, before the first mutation, not just before
+            # the restart: take the lease (one update in flight, ever), stop
+            # claiming new background work, and drain what is already running.
+            lease = UpdateLease()
+            refusal = await lease.acquire_async(
+                from_version=kiro_crew.__version__, source="auto_apply"
+            )
+            if refusal:
+                lease = None
+                logger.warning("Auto-update: refused — %s", refusal)
+                if self.dashboard_state:
+                    self.dashboard_state.clear_update_progress()
+                return
+            drain_gate.enter()
+            gate_entered = True
+            if self.dashboard_state:
+                self.dashboard_state.push_update_progress(
+                    "pulling", "Waiting for in-flight agent work to finish…"
+                )
+            cfg = await asyncio.to_thread(KiroCrewConfig.load)
+            await drain_in_flight(
+                shutdown_event,
+                self._count_in_flight_work,
+                drain_timeout=float(cfg.update_drain_timeout_secs),
+                what="auto-update",
+            )
+            if shutdown_event.is_set():
+                # A real shutdown arrived mid-drain — it owns the process now;
+                # applying an update during teardown would race _shutdown().
+                logger.warning("Auto-update: shutdown during drain — aborting apply")
                 return
 
             # Warn if local tracked-file edits will be discarded
@@ -6709,6 +6805,22 @@ class GatewayOrchestrator:
                     )
 
             logger.info("Auto-update: rebuild complete, restarting")
+            # Re-drain before checkpoint + handoff + exec (usually instant):
+            # the fetch/reset/build/pip above take minutes, and an interactive
+            # turn or manually-triggered cron that STARTED during them would
+            # die at the execv — the gate blocks scheduled background intake,
+            # but not interactive turns (#2217) or manual cron triggers. Must
+            # run BEFORE close_all(), which kills the very turns being waited
+            # for.
+            await drain_in_flight(
+                shutdown_event,
+                self._count_in_flight_work,
+                drain_timeout=float(cfg.update_drain_timeout_secs),
+                what="auto-update pre-exec",
+            )
+            if shutdown_event.is_set():
+                logger.warning("Auto-update: shutdown during pre-exec drain — aborting")
+                return
             # Re-read version from rebuilt package
             importlib.reload(kiro_crew)
             new_ver = kiro_crew.__version__
@@ -6735,6 +6847,25 @@ class GatewayOrchestrator:
                         "Dashboard slot save before auto-update restart failed",
                         exc_info=True,
                     )
+            # §5 step 8→9 handoff: record that the swap succeeded and the
+            # restart is imminent. The relaunched process (same PID — execv)
+            # finds this lease state at boot and verifies the version actually
+            # changed before reporting the update successful. The handoff
+            # write MUST precede close_all(): mark_restarting raises on a
+            # failed write (disk full, rename failure), and once close_all()
+            # has set _closing every subsequent agent turn is rejected —
+            # failing here instead aborts the restart while the gateway is
+            # still fully serving.
+            if lease is not None:
+                # Record the post-swap HEAD as the handshake's primary
+                # identity — the git engine updates per-commit, and
+                # __version__ alone makes verification vacuous (target is
+                # read from the post-reset tree, so version match proves
+                # nothing about the swap). The probe is centralized in
+                # update_drain (trusted-path git resolution; '' degrades to
+                # version comparison).
+                head_sha = await current_head_commit_async()
+                await lease.mark_restarting_async(target=new_ver, target_commit=head_sha)
             if self.sessions:
                 await self.sessions.close_all()
             # Use -m kiro_crew rather than sys.argv[0] so the restart resolves
@@ -6749,6 +6880,17 @@ class GatewayOrchestrator:
                 self.dashboard_state.push_update_progress(
                     "failed", f"Restart failed — run: {restart_command_hint()}"
                 )
+        finally:
+            # Reached only when the apply did NOT restart (early return,
+            # refusal, or failure) — a successful os.execv never returns, so
+            # the marked-restarting lease deliberately survives for the boot
+            # verification handshake. Everything else must clean up: a leaked
+            # gate would silently stop cron claims and autonudge fires forever,
+            # and a leaked lease would block every future update for hours.
+            if gate_entered:
+                drain_gate.exit()
+            if lease is not None:
+                await lease.release_async()
 
     # ------------------------------------------------------------------
     # Main run loop
@@ -7118,7 +7260,9 @@ class GatewayOrchestrator:
         # install's static assets and triggers graceful shutdown so the
         # supervisor can restart a fresh process. It first drains in-flight
         # backend turns (count_in_flight) so active work isn't killed
-        # mid-prompt by the restart.
+        # mid-prompt by the restart. (The dashboard's own count_in_flight
+        # handle is wired at dashboard creation in _init_dashboard /
+        # _init_api_server — before the HTTP server takes requests.)
         _watchdog = asyncio.create_task(
             run_stale_asset_watchdog(shutdown_event, count_in_flight=self._count_in_flight_work)
         )

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -2526,6 +2526,25 @@ class SubagentManager:
     def running_count(self) -> int:
         return self._running_count
 
+    @property
+    def drainable_work_count(self) -> int:
+        """Work an abrupt gateway restart would lose, across the lifecycle.
+
+        ``running_count`` alone undercounts: a spawn accepted into the queue
+        has not incremented it yet (it is admitted by ``_drain_queue`` later),
+        and a finished run's terminal report may still be delivering its
+        result after the slot was released. Both die with the process — a
+        queued spawn vanishes without ever producing a completion event, and
+        a killed report strands a tombstoned result nobody is told about —
+        so the update/asset drains must wait for them like any running turn.
+        The report-task overlap with a still-counted slot can briefly double
+        count; drains only ever poll this until it reaches zero, so counting
+        high is safe where counting low loses work.
+        """
+        count = self._running_count + len(self._queue)
+        count += sum(1 for t in self._report_tasks if not t.done())
+        return count
+
     def running_agents_for(self, parent_key: str) -> list[dict]:
         """Return summary dicts for agents belonging to *parent_key*."""
         from kiro_crew.security import redact_credentials, redact_exfiltration_urls

--- a/src/kiro_crew/update_drain.py
+++ b/src/kiro_crew/update_drain.py
@@ -1,0 +1,696 @@
+"""Shared drain-and-restart primitives for applying updates (RFC §5).
+
+The update-architecture RFC (`docs/request-for-change/rfc-update-architecture.md`,
+§5 "Drain-then-swap") specifies one lifecycle for applying an update to a
+running gateway: take a lease, stop starting new background work, wait for
+in-flight work to finish (bounded), checkpoint, swap, restart, verify. Before
+this module, each restart-after-update path did a different subset:
+
+* ``SlackGateway._auto_apply_update`` (boot auto-apply) restarted immediately —
+  no lease, no drain; in-flight turns died mid-prompt.
+* ``POST /api/update`` (dashboard apply) likewise, and two concurrent POSTs
+  raced each other's ``git pull`` + ``pip install`` with no serialization.
+* The stale-asset watchdog (``dashboard/stale_asset_watchdog.py``) drained,
+  but its in-flight counter missed cron executions and subagent runs — both
+  die with the gateway (subagent kiro-cli processes are children of it).
+
+This module extracts the three shared primitives so every path agrees:
+
+``UpdateLease``
+    "One update in flight, ever" (§5 step 2) as a filesystem lease that
+    outlives the gateway process. The apply paths refuse to start while a
+    live lease exists, and the boot path performs the §5 step-9 verification
+    handshake — an update is only reported successful once the relaunched
+    gateway confirms it is running a different version.
+
+``drain_gate``
+    A process-local flag marking "an update is draining" (§5 step 3 for
+    *background* intake). ``CronService`` checks it before claiming due jobs
+    and ``AutoNudgeService`` checks it before firing a loop — both defer, so
+    the work is picked up after the restart instead of being started seconds
+    before an intentional process swap. Interactive turn intake is
+    deliberately NOT refused here: refusing inbound messages without a
+    queue is the message-loss bug tracked in issue #2217, and closing it
+    properly (queue + replay) is the remaining Phase-3 work in the RFC.
+
+``drain_in_flight``
+    The bounded wait (§5 step 5), generalized from the watchdog's private
+    helper: poll a counter until it reaches zero, the deadline passes, or an
+    external shutdown wins. Any failure to count is treated as idle — a
+    broken predicate must never wedge a shutdown or an update.
+
+The lease file lives in the gateway's ``run/`` directory (owner-only 0700,
+same trust model as the run marker) so a supervisor or a second gateway
+process can read it while the original process is gone during the swap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+import os
+import subprocess
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Protocol
+
+from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.loader import config_dir
+
+logger = logging.getLogger(__name__)
+
+_LEASE_FILE = "update-lease.json"
+
+# Defaults for the bounded in-flight drain used by the update paths. The
+# stale-asset watchdog keeps its own (shorter) defaults — an asset vanish has
+# already broken dashboard serving, so it drains with more urgency.
+DEFAULT_DRAIN_TIMEOUT_SECS = 300.0
+DEFAULT_DRAIN_POLL_SECS = 2.0
+
+
+class _ShutdownSignal(Protocol):
+    """Minimal contract needed from a shutdown-signalling event."""
+
+    def is_set(self) -> bool:
+        ...
+
+    async def wait(self) -> bool:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Drain gate — background-intake quiesce (§5 step 3)
+# ---------------------------------------------------------------------------
+
+
+class DrainGate:
+    """Process-local "an update is draining" flag.
+
+    Reference-counted: the dashboard apply path holds it across the whole
+    pull/build/install while the shared restart helper takes it again for the
+    final drain — nested holders must compose without the inner ``exit()``
+    dropping the outer hold. Writers are the lease-holding apply/restart
+    paths; readers (cron tick, autonudge fire) only ever need a synchronous
+    ``is_draining()`` at their claim/fire choke points. Event-loop-confined,
+    so no locking.
+
+    ``drain_event`` lets long sleepers wake the moment a drain begins: a cron
+    job in its jitter window (up to 59 min for daily jobs) waits on this
+    event with its jitter as the timeout — when a drain starts it runs
+    immediately instead of being killed mid-sleep by the exec after its
+    scheduled minute has passed. Jitter is load-spreading, not semantics, and
+    during a drain the herd it spreads does not exist.
+
+    Note the scope asymmetry: this gate is PROCESS-LOCAL while the update
+    lease is cross-process. A second gateway on the same data home keeps
+    claiming its own cron jobs during this process's apply; the lease (which
+    that gateway's own apply paths honor) is the cross-process boundary.
+    """
+
+    def __init__(self) -> None:
+        self._depth = 0
+        self._event: asyncio.Event | None = None
+
+    def is_draining(self) -> bool:
+        return self._depth > 0
+
+    def drain_event(self) -> asyncio.Event:
+        """The event set while draining (lazily created on the running loop)."""
+        if self._event is None:
+            self._event = asyncio.Event()
+        return self._event
+
+    def enter(self) -> None:
+        self._depth += 1
+        self.drain_event().set()
+
+    def exit(self) -> None:
+        self._depth = max(0, self._depth - 1)
+        if self._depth == 0 and self._event is not None:
+            self._event.clear()
+
+
+#: The gateway-wide gate. ``cron.py`` and ``autonudge.py`` import this module
+#: (a leaf — it imports neither) and consult the gate at their single
+#: claim/fire choke points.
+drain_gate = DrainGate()
+
+
+# ---------------------------------------------------------------------------
+# Bounded drain (§5 step 5)
+# ---------------------------------------------------------------------------
+
+
+async def drain_in_flight(
+    shutdown_event: _ShutdownSignal,
+    count_in_flight: Callable[[], int] | None,
+    *,
+    drain_timeout: float,
+    drain_poll: float = DEFAULT_DRAIN_POLL_SECS,
+    what: str = "update",
+) -> bool:
+    """Wait (bounded) for in-flight work to finish.
+
+    Returns ``True`` when the count reached zero, ``False`` when the deadline
+    elapsed with work still in flight or an external shutdown interrupted the
+    wait. Callers proceed either way — the deadline exists precisely so a
+    wedged turn cannot defer a restart forever (§5 step 5) — but the return
+    value lets them log honestly which case occurred.
+
+    Any failure to count is treated as "idle": a broken predicate must never
+    wedge shutdown. Mirrors the defensive shape the stale-asset watchdog
+    established.
+    """
+    if count_in_flight is None or drain_timeout <= 0:
+        return True
+    try:
+        pending = count_in_flight()
+    except Exception:
+        logger.debug("%s drain: initial in-flight count failed — skipping", what, exc_info=True)
+        return True
+    if not isinstance(pending, int):
+        # A counter returning a non-int (a Mock in duck-typed tests, a broken
+        # accessor) is a broken predicate — treat as idle; it must never spin
+        # the drain or crash the apply/shutdown path. NB: int() coercion is
+        # NOT equivalent — Mock defines __int__, silently becoming a nonzero
+        # constant that waits out the whole timeout.
+        logger.debug("%s drain: non-integer in-flight count — treating as idle", what)
+        return True
+    if pending <= 0:
+        return True
+
+    logger.info(
+        "%s drain: waiting for %d in-flight task(s) (up to %.0fs)…",
+        what,
+        pending,
+        drain_timeout,
+    )
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + drain_timeout
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        # Sleep interruptibly: an external SIGTERM sets shutdown_event and
+        # wakes us immediately — a real shutdown always outranks a drain.
+        try:
+            await asyncio.wait_for(shutdown_event.wait(), timeout=min(drain_poll, remaining))
+            logger.warning("%s drain: external shutdown during drain — stopping", what)
+            return False
+        except asyncio.TimeoutError:
+            pass
+        try:
+            pending = count_in_flight()
+        except Exception:
+            logger.debug("%s drain: count failed mid-drain — treating as idle", what, exc_info=True)
+            return True
+        if not isinstance(pending, int):
+            logger.debug("%s drain: non-integer count mid-drain — treating as idle", what)
+            return True
+        if pending <= 0:
+            logger.info("%s drain: all in-flight work finished", what)
+            return True
+
+    logger.warning(
+        "%s drain: timeout (%.0fs) elapsed with %d task(s) still in flight — "
+        "proceeding; open sessions resume from snapshot on restart.",
+        what,
+        drain_timeout,
+        pending,
+    )
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Update lease (§5 steps 2–8) + post-restart verification (§5 step 9)
+# ---------------------------------------------------------------------------
+
+
+#: Construction grace for an unparsable lease file: younger than this, it may
+#: be another process between its O_EXCL create and its json write — leave it.
+_CORRUPT_LEASE_GRACE_SECS = 60.0
+
+
+def self_path_mtime(path: Path) -> float:
+    """Small seam for the lease-construction grace (patchable in tests)."""
+    return path.stat().st_mtime
+
+
+def current_head_commit() -> str:
+    """Resolve the running install's HEAD SHA, '' when not a git checkout.
+
+    This is the ONLY git invocation in the update chain — the async call
+    sites go through :func:`current_head_commit_async` — so the binary-trust
+    invariant lives in one place: ``git`` is resolved from fixed system
+    directories via ``platform_compat.trusted_system_bin``, never from
+    ``PATH``. A gateway's ``PATH`` can legitimately lead with agent-writable
+    directories (a worktree venv's ``bin``), and this probe runs with the
+    unsandboxed gateway's credentials, so a bare argv name would let a
+    planted ``git`` shim execute arbitrary code. No trusted binary means no
+    commit identity: return '' and let the handshake fall back to version
+    comparison, its documented degradation.
+
+    Sync subprocess — callers run off-loop (verification already runs inside
+    ``asyncio.to_thread``). Best-effort: any failure returns '' and the
+    handshake falls back to version comparison.
+    """
+    proj = os.environ.get("KIROCREW_PROJECT_DIR", "")
+    if not proj or not os.path.exists(os.path.join(proj, ".git")):
+        return ""
+    git_bin = platform_compat.trusted_system_bin("git")
+    if git_bin is None:
+        return ""
+    try:
+        out = subprocess.run(
+            [git_bin, "rev-parse", "HEAD"],
+            cwd=proj,
+            capture_output=True,
+            timeout=10,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return out.stdout.strip() if out.returncode == 0 else ""
+
+
+async def current_head_commit_async() -> str:
+    """Async twin of :func:`current_head_commit` for on-loop callers."""
+    return await asyncio.to_thread(current_head_commit)
+
+
+def _lease_path() -> Path:
+    return Path(config_dir()) / "run" / _LEASE_FILE
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    # platform_compat.pid_exists is the cross-OS probe. A raw
+    # ``os.kill(pid, 0)`` is NOT usable here: on Windows any signal other
+    # than CTRL_C_EVENT/CTRL_BREAK_EVENT is delivered via TerminateProcess,
+    # so "checking" a live lease holder would kill it.
+    try:
+        return platform_compat.pid_exists(pid)
+    except OverflowError:
+        # A pid too large for the OS pid type cannot name a live process —
+        # it is a malformed lease value, not a holder.
+        return False
+
+
+def _normalize_lease_fields(data: dict[str, Any]) -> dict[str, Any]:
+    """Coerce the numeric lease fields; a payload that cannot coerce is corrupt.
+
+    Readers do arithmetic on ``pid`` / ``acquired_at`` (holder liveness, lease
+    age), so a hand-edited or torn lease carrying e.g. a string pid must
+    degrade to the corrupt-lease path — refusal at acquire, grace-then-consume
+    at boot verification — instead of raising out of update handling and
+    leaving the lease permanently blocking updates. Non-finite values are
+    rejected too: ``json.loads`` accepts ``Infinity``/``NaN``, which pass a
+    bare ``float()`` but blow up age arithmetic.
+    """
+    for key, cast in (("pid", int), ("acquired_at", float), ("restart_at", float)):
+        value = data.get(key)
+        if value is None:
+            continue
+        try:
+            coerced = cast(value)
+        except (TypeError, ValueError, OverflowError):
+            return {}
+        if isinstance(coerced, float) and not math.isfinite(coerced):
+            return {}
+        data[key] = coerced
+    return data
+
+
+class UpdateLease:
+    """Filesystem lease serializing update application across processes.
+
+    States: ``draining`` (apply path is quiescing + swapping bytes) and
+    ``restarting`` (the process is about to exec the new code; the next boot
+    owns verification). The lease survives the process on purpose — with
+    ``os.execv`` the PID persists across the swap, and with an external
+    supervisor relaunch the original process is gone entirely; in both cases
+    an in-memory flag would vanish or lie.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or _lease_path()
+        self._held = False
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def read(self) -> dict[str, Any] | None:
+        """Return the current lease payload, or None when absent/corrupt."""
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+        except OSError:
+            logger.debug("update lease: unreadable at %s", self._path, exc_info=True)
+            return None
+        try:
+            data = json.loads(raw)
+        except ValueError:
+            # A corrupt lease is a crashed writer; treat as reclaimable.
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        return _normalize_lease_fields(data)
+
+    def acquire(self, *, from_version: str, source: str) -> str | None:
+        """Try to take the lease. Returns None on success, else a refusal reason.
+
+        ``O_CREAT | O_EXCL`` is the ONLY arbiter: any existing lease file is a
+        refusal, full stop. There is deliberately no reclaim-by-unlink here —
+        an unlink-then-create window lets two contenders both "reclaim" a
+        stale file and both succeed, which is precisely the double-apply the
+        lease exists to prevent. Stale leases are consumed ONLY through
+        :func:`_consume_lease_if_unchanged` (cross-process lock + identity
+        re-check): by :func:`verify_after_restart` at boot, and by the CLI
+        update path for a dead holder's leftover before it retries its own
+        acquire.
+
+        Fails CLOSED: if the lease file cannot be created (unwritable data
+        home, disk error), the update is refused rather than run unleased —
+        an unserialized apply can corrupt the install, which is strictly
+        worse than an update that reports an actionable environment error.
+        """
+        existing = self.read()
+        if existing is not None:
+            holder_pid = int(existing.get("pid") or 0)
+            age = time.time() - float(existing.get("acquired_at") or 0)
+            state = str(existing.get("state") or "corrupt")
+            return (
+                f"an update is already in flight (state={state}, "
+                f"pid={holder_pid}, started {int(age)}s ago); if this is a "
+                f"stale leftover it is cleared on the next gateway boot, or "
+                f"remove {self._path} manually"
+            )
+
+        payload = {
+            "pid": os.getpid(),
+            "acquired_at": time.time(),
+            "state": "draining",
+            "from_version": from_version,
+            "source": source,
+        }
+        try:
+            self._path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            return "an update is already in flight (lease appeared concurrently)"
+        except OSError as exc:
+            logger.error("update lease: cannot write %s (%s) — refusing update", self._path, exc)
+            return f"cannot create the update lease at {self._path}: {exc}"
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh)
+        except OSError as exc:
+            # The file exists but is unreadable garbage — remove OUR OWN
+            # just-created file (exclusive create proves ownership) and refuse.
+            logger.error("update lease: write failed at %s (%s) — refusing update", self._path, exc)
+            try:
+                self._path.unlink()
+            except OSError:
+                pass
+            return f"cannot write the update lease at {self._path}: {exc}"
+        self._held = True
+        return None
+
+    def mark_restarting(
+        self, *, target: str = "", target_commit: str = "", expect_change: bool = True
+    ) -> None:
+        """Record that the swap is done and the restart is imminent (§5 step 8).
+
+        The relaunched process finds this state and runs the verification
+        handshake. ``target_commit`` is the post-swap HEAD SHA and is the
+        PRIMARY identity on the git engine: ``__version__`` bumps rarely,
+        while the git engine updates per-commit — a version-keyed handshake
+        would report false failures for most successful pulls and vacuous
+        successes when the version file didn't change. ``target`` (a version
+        string) remains the fallback identity for engines without commits.
+        ``expect_change=False`` marks a bare restart handoff (no bytes were
+        swapped — e.g. ``POST /api/restart``): verification then consumes the
+        lease silently. A failed handoff write RAISES rather than being
+        swallowed: exec preserves the PID, so a lease stuck in 'draining'
+        after a suppressed failure would 409 every later update/restart until
+        the next boot — the caller must abort the restart and release.
+        """
+        if not self._held:
+            return
+        data = self.read() or {}
+        data["state"] = "restarting"
+        data["restart_at"] = time.time()
+        data["expect_change"] = expect_change
+        if target_commit:
+            data["target_commit"] = target_commit
+        if target:
+            data["target"] = target
+        try:
+            # atomic_write = mkstemp (unpredictable name) + rename in the
+            # lease's own directory. A deterministic sibling like
+            # ``update-lease.tmp`` can be pre-created as a symlink by a local
+            # attacker, turning this handoff write into an arbitrary-file
+            # overwrite with the gateway's credentials; mkstemp's O_EXCL
+            # random name makes that unreachable (module invariant: no
+            # predictable temp paths, ever).
+            atomic_write(self._path, json.dumps(data), mode=0o600)
+        except OSError:
+            # MUST propagate: exec preserves the PID, so a lease left in
+            # 'draining' state after a swallowed handoff failure is
+            # indistinguishable from a live apply — every later update and
+            # restart would 409 until the next boot. Raising lets the caller
+            # abort the restart and release the lease instead.
+            logger.error("update lease: handoff write failed at %s", self._path)
+            raise
+
+    def release(self) -> None:
+        """Drop the lease (apply failed or was refused before restart)."""
+        if not self._held:
+            return
+        self._held = False
+        try:
+            self._path.unlink()
+        except OSError:
+            pass
+
+    # -- async twins -------------------------------------------------------
+    # Every lease operation touches the filesystem (read/mkdir/open/replace/
+    # unlink). The apply paths run on the gateway's single event loop, and a
+    # data home on a network mount or a stalled disk would freeze every chat
+    # turn and the liveness heartbeat (the no-blocking-call-on-event-loop
+    # rule). Async callers use these; the sync forms remain for boot-time and
+    # test use off-loop.
+
+    async def acquire_async(self, *, from_version: str, source: str) -> str | None:
+        return await asyncio.to_thread(self.acquire, from_version=from_version, source=source)
+
+    async def mark_restarting_async(
+        self, *, target: str = "", target_commit: str = "", expect_change: bool = True
+    ) -> None:
+        await asyncio.to_thread(
+            self.mark_restarting,
+            target=target,
+            target_commit=target_commit,
+            expect_change=expect_change,
+        )
+
+    async def release_async(self) -> None:
+        await asyncio.to_thread(self.release)
+
+
+def _consume_lease_if_unchanged(lease: UpdateLease, snapshot: dict[str, Any]) -> bool:
+    """Unlink the lease iff it still holds the payload the verdict was based on.
+
+    The consume decision in :func:`verify_after_restart` is made from a read
+    taken before slow work (a pid liveness probe, a git subprocess with a 10s
+    timeout). By the time the unlink runs, a peer gateway on the same data
+    home may have consumed the same dead lease and a new apply may have
+    legitimately re-acquired the path via ``O_EXCL``. An unguarded path-unlink
+    would then delete the LIVE lease — reopening the concurrent double-apply
+    the lease exists to prevent. So consumption is serialized under a
+    cross-process file lock and re-validated against the snapshot:
+
+    * dict snapshot: unlink only when the re-read payload is identical — a
+      re-acquired lease always differs (fresh pid + acquired_at).
+    * corrupt snapshot (``{}``): unlink only when the file is still unparsable
+      AND still past the construction grace — a fresh contender's mid-write
+      file is young and is left alone.
+
+    ``acquire`` itself needs no lock: its ``O_EXCL`` create only succeeds
+    after an unlink, and every unlink is either serialized here or
+    owner-scoped (``release`` / the failed-write cleanup act on a payload the
+    same object just created exclusively). The lock file is deliberately never
+    deleted — unlinking a lock file reintroduces the same race on the lock
+    itself (a waiter blocked on the old inode and a fresh creator can both
+    hold "the" lock at once).
+
+    Returns True when this process consumed the lease, False when it was left
+    alone (already consumed, re-acquired, still in grace, or lock unavailable
+    — leaving a leftover for the next boot is strictly safer than an
+    unserialized unlink).
+    """
+    lock_path = lease.path.with_name(lease.path.name + ".lock")
+    try:
+        # O_NOFOLLOW (where the platform has it) keeps the same symlink
+        # discipline as the lease writes: a pre-planted symlink at the lock
+        # path must fail the open, not silently redirect the lock (and the
+        # O_CREAT) to an attacker-chosen target.
+        flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+        lock_fd = os.open(lock_path, flags, 0o600)
+    except OSError:
+        logger.warning("update lease: cannot open consume lock %s — leaving lease", lock_path)
+        return False
+    try:
+        with platform_compat.file_lock(lock_fd, exclusive=True):
+            current = lease.read()
+            if current is None:
+                return False  # already consumed by a peer
+            if snapshot:
+                if current != snapshot:
+                    return False  # re-acquired or rewritten since the verdict
+            else:
+                if current:
+                    return False  # was corrupt, now parses: a new live lease
+                try:
+                    age = time.time() - self_path_mtime(lease.path)
+                except OSError:
+                    return False  # vanished under the lock
+                if age < _CORRUPT_LEASE_GRACE_SECS:
+                    return False  # fresh contender mid-write
+            try:
+                lease.path.unlink()
+            except OSError:
+                return False
+            return True
+    except OSError:
+        # file_lock fails closed (Windows raises on a stuck holder): leaving
+        # the lease for the next boot beats an unserialized unlink.
+        logger.warning("update lease: consume lock unavailable at %s — leaving lease", lock_path)
+        return False
+    finally:
+        os.close(lock_fd)
+
+
+def verify_after_restart(current_version: str) -> str | None:
+    """§5 step 9: the boot-time half of the update handshake.
+
+    Called once at gateway startup. If a lease in ``restarting`` state exists,
+    the previous process swapped bytes and restarted into us — report whether
+    the swap actually took (version changed / matches target) and clear the
+    lease. Returns a human-readable outcome line for the caller to surface,
+    or None when there was no restart to verify.
+
+    Without this, "update succeeded" means "we started something", not "the
+    new version is serving" — the exact omission §5 calls the most expensive.
+    """
+    lease = UpdateLease()
+    data = lease.read()
+    if data is None:
+        return None
+    if not data:
+        # Empty/corrupt payload. This is what a lease looks like in the
+        # microsecond window between another process's O_EXCL create and its
+        # json.dump — unlinking it here would let a third contender acquire
+        # the same path and run a concurrent apply. Give it a construction
+        # grace; only garbage that stays unparsable past the grace is a
+        # crashed writer's leftover and gets consumed.
+        try:
+            age = time.time() - self_path_mtime(lease.path)
+        except OSError:
+            return None  # vanished under us — nothing to verify
+        if age < _CORRUPT_LEASE_GRACE_SECS:
+            logger.debug(
+                "update lease: unparsable but %.1fs young — leaving it (may be mid-write)", age
+            )
+            return None
+        logger.warning("update lease: unparsable and stale (%.0fs) — consuming", age)
+        _consume_lease_if_unchanged(lease, {})
+        return None
+    state = str(data.get("state") or "")
+    holder = int(data.get("pid") or 0)
+    holder_alive = _pid_alive(holder)
+    # Holder-aware consumption. This is the ONLY place leases are consumed
+    # (acquire never reclaims), so it must not touch a lease that is still
+    # someone's live serialization token:
+    #  * live pid in ANOTHER process = a second gateway on the same data home
+    #    (e.g. --port 9999) is mid-apply right now;
+    #  * OUR pid in 'draining' state = an apply already in flight in this
+    #    process (the dashboard accepts POST /api/update before this boot
+    #    task runs).
+    # Only a dead holder's leftover, or our own 'restarting' handoff
+    # (os.execv preserves the PID), is consumed here.
+    if holder_alive and holder != os.getpid():
+        logger.info(
+            "update lease: held by live pid %d (state=%s) — leaving it to its owner",
+            holder,
+            state or "corrupt",
+        )
+        return None
+    outcome: str | None = None
+    if state == "restarting":
+        prior = str(data.get("from_version") or "")
+        target = str(data.get("target") or "")
+        target_commit = str(data.get("target_commit") or "")
+        current_commit = current_head_commit()
+        if not data.get("expect_change", True):
+            # Bare-restart handoff (POST /api/restart): no bytes were swapped,
+            # so an unchanged version is the expected outcome — consume
+            # silently rather than reporting a failed update.
+            logger.info("Gateway restart handoff consumed (no update expected).")
+        elif target_commit and current_commit:
+            # PRIMARY identity on the git engine: updates are per-commit while
+            # __version__ bumps rarely — a version-keyed handshake reports
+            # false failures for most successful pulls and vacuous successes
+            # when the version file didn't change.
+            if current_commit == target_commit:
+                outcome = (
+                    f"Update verified: now at {current_commit[:9]} "
+                    f"(running {current_version})."
+                )
+            else:
+                outcome = (
+                    f"Update did NOT take effect: running {current_commit[:9]} "
+                    f"but the update installed {target_commit[:9]} — check the "
+                    f"update logs."
+                )
+                logger.critical("%s", outcome)
+        elif target and current_version == target:
+            outcome = f"Update verified: now running {current_version} (was {prior})."
+        elif prior and current_version != prior:
+            outcome = f"Update verified: now running {current_version} (was {prior})."
+        else:
+            outcome = (
+                f"Update did NOT take effect: still running {current_version} "
+                f"after a restart that expected a new version"
+                + (f" ({target})" if target else "")
+                + " — check the update logs."
+            )
+            logger.critical("%s", outcome)
+    elif state == "draining":
+        if holder_alive:
+            # Our own pid, still draining: an apply is in flight in THIS
+            # process right now — not a leftover, do not consume.
+            return None
+        # Dead holder mid-apply (crash or supervisor kill during the swap).
+        # The tree may be half-updated.
+        outcome = (
+            "Previous update was interrupted mid-apply (lease was still in "
+            "'draining' state at boot) — the install may be inconsistent; "
+            "re-run the update to converge."
+        )
+        logger.warning("%s", outcome)
+    # A consumed handoff, a dead holder's leftover, or a corrupt lease: the
+    # restart owns it either way — but only while the file still holds the
+    # exact payload this verdict was computed from. If a peer consumed it (or
+    # a new apply re-acquired the path) since our read, the verdict belongs to
+    # that peer: consume nothing and report nothing.
+    if not _consume_lease_if_unchanged(lease, data):
+        return None
+    return outcome

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -1009,6 +1009,68 @@ class TestUpdateGitPath:
         assert "Agent config refresh failed" in out
 
 
+class TestUpdateLeaseSerialization:
+    """`_update()` ACQUIRES and holds the shared update lease for its whole
+    run — a read-then-proceed check is a TOCTOU that lets the dashboard
+    acquire right after a clean read and mutate the tree concurrently."""
+
+    def test_live_holder_refuses_without_touching_the_tree(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        from kiro_crew.update_drain import UpdateLease
+
+        stub = _GitStub()
+        monkeypatch.setattr(subprocess, "run", stub)
+        other = UpdateLease()
+        assert other.acquire(from_version="0.0.1", source="dashboard_apply") is None
+        try:
+            cli_server._update()
+        finally:
+            other.release()
+        assert "in flight" in capsys.readouterr().out
+        assert not stub.calls, "no git command may run while another update holds the lease"
+
+    def test_acquires_for_the_body_and_releases_on_exit(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        from kiro_crew.update_drain import UpdateLease
+
+        monkeypatch.setattr(subprocess, "run", _GitStub(diff=0))  # "already up to date"
+        held: dict = {}
+        orig = cli_server._update_locked
+
+        def probe(proj, proj_path, is_git):
+            held["payload"] = UpdateLease().read()
+            return orig(proj, proj_path, is_git)
+
+        monkeypatch.setattr(cli_server, "_update_locked", probe)
+        cli_server._update()
+        assert held["payload"] and held["payload"]["source"] == "cli_update", (
+            "the lease must be held while the update body runs"
+        )
+        assert UpdateLease().read() is None, "the lease must be released on exit"
+
+    def test_dead_holder_leftover_is_consumed_and_update_proceeds(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        import json as _json
+
+        from kiro_crew.update_drain import UpdateLease
+
+        leftover = UpdateLease()
+        leftover.path.parent.mkdir(parents=True, exist_ok=True)
+        leftover.path.write_text(
+            _json.dumps({"pid": 424242, "acquired_at": 1.0, "state": "draining"})
+        )
+        monkeypatch.setattr(cli_server, "_pid_alive", lambda pid: False)
+        monkeypatch.setattr(subprocess, "run", _GitStub(diff=0))
+        cli_server._update()
+        assert "Already up to date" in capsys.readouterr().out
+        assert UpdateLease().read() is None, (
+            "the dead holder's leftover must be consumed and our own lease released"
+        )
+
+
 class TestUpdateWheelDispatch:
     """No git checkout means the wheel path gets a correctly shaped layout."""
 

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -5637,6 +5637,83 @@ class TestCountInFlightWork:
         orch._session_tasks = {"x": undone}
         assert orch._count_in_flight_work() == 2
 
+    def test_counts_executing_cron_jobs(self):
+        """A cron mid-run dies with the gateway — it must count (RFC §5)."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = None
+        orch._session_tasks = {}
+        orch.subagent_mgr = None
+        cron = MagicMock()
+        cron.executing_count.return_value = 2
+        orch.cron_svc = cron
+        assert orch._count_in_flight_work() == 2
+
+    def test_counts_running_subagents(self):
+        """Subagent kiro-cli processes are gateway children — they count."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = None
+        orch._session_tasks = {}
+        orch.cron_svc = None
+        mgr = MagicMock()
+        mgr.drainable_work_count = 3
+        orch.subagent_mgr = mgr
+        assert orch._count_in_flight_work() == 3
+
+    def test_subagent_count_covers_whole_lifecycle(self):
+        """Queued spawns and in-flight terminal reports die with the process
+        just like running agents — the drain must count all three, or an
+        update restart drops accepted work (queued spawn vanishes, finished
+        result never delivered)."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = None
+        orch._session_tasks = {}
+        orch.cron_svc = None
+        undone_report = MagicMock()
+        undone_report.done.return_value = False
+        done_report = MagicMock()
+        done_report.done.return_value = True
+        from kiro_crew.subagent import SubagentManager
+
+        mgr = SubagentManager(sessions=MagicMock(), ctx_builder=None)
+        mgr._running_count = 1
+        mgr._queue = [{"task": "queued-a"}, {"task": "queued-b"}]
+        mgr._report_tasks = {undone_report, done_report}
+        orch.subagent_mgr = mgr
+        # 1 running + 2 queued + 1 undelivered report; the done report is not work.
+        assert orch._count_in_flight_work() == 4
+
+    def test_cron_and_subagent_introspection_failures_are_idle(self):
+        """Broken accessors on the NEW surfaces must not wedge shutdown."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = None
+        orch._session_tasks = {}
+        cron = MagicMock()
+        cron.executing_count.side_effect = RuntimeError("boom")
+        orch.cron_svc = cron
+        mgr = MagicMock()
+        # property access raising via PropertyMock on the type
+        type(mgr).drainable_work_count = property(
+            lambda self: (_ for _ in ()).throw(RuntimeError())
+        )
+        orch.subagent_mgr = mgr
+        assert orch._count_in_flight_work() == 0
+
+    def test_all_four_surfaces_sum(self):
+        orch = _make_orchestrator()
+        state = MagicMock()
+        state.sessions.active_providers.return_value = [_provider(True)]
+        orch.dashboard_state = state
+        undone = MagicMock()
+        undone.done.return_value = False
+        orch._session_tasks = {"x": undone}
+        cron = MagicMock()
+        cron.executing_count.return_value = 1
+        orch.cron_svc = cron
+        mgr = MagicMock()
+        mgr.drainable_work_count = 1
+        orch.subagent_mgr = mgr
+        assert orch._count_in_flight_work() == 4
+
 
 class TestChannelTransportStartGate:
     """`_start_channel_transports` gates each non-Slack transport start on the

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -182,6 +182,15 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # would hide and break the callback. The child is SIGKILLed on timeout or
         # task cancellation, so it never orphans.
         "acp/kas_auth.py::resolve_kas_access_token",
+        # Update-verification HEAD probe (RFC drain-then-swap step 9): one
+        # fixed argv — ``[<trusted git>, "rev-parse", "HEAD"]`` — with a 10s
+        # timeout, no shell, and cwd pinned to ``KIROCREW_PROJECT_DIR`` (operator
+        # environment, not agent input). The binary is resolved via
+        # ``platform_compat.trusted_system_bin`` (fixed system dirs, PATH
+        # ignored), and the probe degrades to '' without it. Read-only; output
+        # is compared against the lease's recorded target commit and never
+        # executed or echoed to an agent surface.
+        "update_drain.py::current_head_commit",
         # Tailnet origin derivation + forwarded-peer whois (RFC:
         # rfc-tailnet-dashboard-access): one fixed argv — ``["<tailscale>",
         # "status", "--json"]`` or ``["<tailscale>", "whois", "--json",
@@ -608,7 +617,9 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "cli_doctor.py::_linger_enabled",
         "cli_server.py::_logs_cmd",
         "cli_server.py::_spawn_detached_gateway",
-        "cli_server.py::_update",
+        # The lease-holding update body (git fetch/reset/pip over the operator's
+        # own checkout; argv is fixed, cwd is KIROCREW_PROJECT_DIR).
+        "cli_server.py::_update_locked",
         "cli_server.py::_update_wheel",
         "cli_setup.py::_setup_electron",
         # Cursor Motion overlay renderer: `<this interpreter> -m

--- a/test/test_update_channel_and_restart.py
+++ b/test/test_update_channel_and_restart.py
@@ -276,7 +276,7 @@ class TestRestartEndpoint:
         """
         started = asyncio.Event()
 
-        async def _fake_restart(_state: object) -> None:
+        async def _fake_restart(_state: object, **_kw: object) -> None:
             started.set()
 
         async def _run() -> web.Response:

--- a/test/test_update_drain.py
+++ b/test/test_update_drain.py
@@ -1,0 +1,809 @@
+"""Tests for kiro_crew.update_drain — the shared §5 drain-then-swap primitives.
+
+Covers the three primitives this module contributes to the update
+architecture RFC's §5 lifecycle:
+
+* ``DrainGate`` — reference-counted background-intake quiesce flag.
+* ``drain_in_flight`` — bounded wait for in-flight work, fail-idle on a
+  broken counter, interruptible by an external shutdown.
+* ``UpdateLease`` + ``verify_after_restart`` — the cross-process
+  "one update in flight, ever" lease and the boot-time half of the
+  §5 step-9 verification handshake.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kiro_crew import update_drain
+from kiro_crew.update_drain import (
+    DrainGate,
+    UpdateLease,
+    drain_in_flight,
+    verify_after_restart,
+)
+
+# ---------------------------------------------------------------------------
+# DrainGate
+# ---------------------------------------------------------------------------
+
+
+def test_drain_gate_basic():
+    gate = DrainGate()
+    assert not gate.is_draining()
+    gate.enter()
+    assert gate.is_draining()
+    gate.exit()
+    assert not gate.is_draining()
+
+
+def test_drain_gate_nested_holders_compose():
+    """The dashboard apply holds the gate while _restart_gateway takes it
+    again — the inner exit must not drop the outer hold."""
+    gate = DrainGate()
+    gate.enter()  # outer: api_update_apply
+    gate.enter()  # inner: _restart_gateway
+    gate.exit()  # inner done
+    assert gate.is_draining(), "outer hold must survive the inner exit"
+    gate.exit()
+    assert not gate.is_draining()
+
+
+def test_drain_gate_exit_floors_at_zero():
+    gate = DrainGate()
+    gate.exit()  # unbalanced exit must not go negative
+    gate.enter()
+    assert gate.is_draining()
+
+
+# ---------------------------------------------------------------------------
+# drain_in_flight
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drain_returns_true_immediately_when_idle():
+    ev = asyncio.Event()
+    assert await drain_in_flight(ev, lambda: 0, drain_timeout=30.0) is True
+
+
+@pytest.mark.asyncio
+async def test_drain_none_counter_is_idle():
+    ev = asyncio.Event()
+    assert await drain_in_flight(ev, None, drain_timeout=30.0) is True
+
+
+@pytest.mark.asyncio
+async def test_drain_zero_timeout_skips_waiting():
+    ev = asyncio.Event()
+    assert await drain_in_flight(ev, lambda: 5, drain_timeout=0) is True
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_until_work_finishes():
+    ev = asyncio.Event()
+    counts = [2, 1, 0]
+
+    def counter() -> int:
+        # First call is the pre-loop sample; subsequent calls are polls.
+        return counts.pop(0) if counts else 0
+
+    result = await drain_in_flight(ev, counter, drain_timeout=5.0, drain_poll=0.01)
+    assert result is True
+    assert not counts, "drain returned before the count reached zero"
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_returns_false():
+    ev = asyncio.Event()
+    result = await drain_in_flight(ev, lambda: 3, drain_timeout=0.05, drain_poll=0.01)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_drain_external_shutdown_wins():
+    """SIGTERM (shutdown_event set) mid-drain stops waiting immediately."""
+    ev = asyncio.Event()
+
+    async def set_soon() -> None:
+        await asyncio.sleep(0.02)
+        ev.set()
+
+    setter = asyncio.create_task(set_soon())
+    start = time.monotonic()
+    result = await drain_in_flight(ev, lambda: 9, drain_timeout=30.0, drain_poll=0.5)
+    elapsed = time.monotonic() - start
+    await setter
+    assert result is False
+    assert elapsed < 5.0, "shutdown must interrupt the drain, not wait out the timeout"
+
+
+@pytest.mark.asyncio
+async def test_drain_broken_counter_fails_idle():
+    """A raising counter must never wedge the drain (treated as idle)."""
+    ev = asyncio.Event()
+
+    def broken() -> int:
+        raise RuntimeError("introspection broke")
+
+    assert await drain_in_flight(ev, broken, drain_timeout=30.0) is True
+
+
+@pytest.mark.asyncio
+async def test_drain_counter_breaking_mid_drain_fails_idle():
+    ev = asyncio.Event()
+    calls = {"n": 0}
+
+    def flaky() -> int:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return 2
+        raise RuntimeError("broke mid-drain")
+
+    result = await drain_in_flight(ev, flaky, drain_timeout=5.0, drain_poll=0.01)
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# UpdateLease
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def lease_path(tmp_path: Path) -> Path:
+    return tmp_path / "run" / "update-lease.json"
+
+
+def test_lease_acquire_writes_draining_state(lease_path: Path):
+    lease = UpdateLease(lease_path)
+    assert lease.acquire(from_version="1.0.0", source="test") is None
+    data = json.loads(lease_path.read_text())
+    assert data["state"] == "draining"
+    assert data["from_version"] == "1.0.0"
+    assert data["source"] == "test"
+    assert data["pid"] == os.getpid()
+
+
+def test_lease_second_acquire_refused_while_holder_alive(lease_path: Path):
+    first = UpdateLease(lease_path)
+    assert first.acquire(from_version="1.0.0", source="a") is None
+    second = UpdateLease(lease_path)
+    refusal = second.acquire(from_version="1.0.0", source="b")
+    assert refusal is not None
+    assert "already in flight" in refusal
+    # The refused instance must not clobber the winner's lease on release().
+    second.release()
+    assert lease_path.exists()
+
+
+def test_lease_release_unlinks(lease_path: Path):
+    lease = UpdateLease(lease_path)
+    lease.acquire(from_version="1.0.0", source="test")
+    lease.release()
+    assert not lease_path.exists()
+
+
+def test_lease_dead_holder_still_refused_at_acquire(lease_path: Path, monkeypatch):
+    """Acquire NEVER reclaims — even a dead holder's lease refuses; only boot
+    verification consumes it (an unlink-then-create window would let two
+    contenders both 'reclaim' and both succeed)."""
+    lease_path.parent.mkdir(parents=True)
+    lease_path.write_text(
+        json.dumps(
+            {
+                "pid": 1234567,
+                "acquired_at": time.time() - 7200,
+                "state": "draining",
+            }
+        )
+    )
+    monkeypatch.setattr(update_drain, "_pid_alive", lambda pid: False)
+    lease = UpdateLease(lease_path)
+    refusal = lease.acquire(from_version="2.0.0", source="test")
+    assert refusal is not None
+    assert "already in flight" in refusal
+    assert lease_path.exists(), "acquire must not unlink an existing lease"
+
+
+def test_lease_live_holder_not_reclaimed_even_when_old(lease_path: Path, monkeypatch):
+    """Age alone never breaks a lease whose holder is demonstrably alive."""
+    lease_path.parent.mkdir(parents=True)
+    lease_path.write_text(
+        json.dumps(
+            {
+                "pid": os.getpid(),
+                "acquired_at": time.time() - 30,
+                "state": "draining",
+            }
+        )
+    )
+    monkeypatch.setattr(update_drain, "_pid_alive", lambda pid: True)
+    lease = UpdateLease(lease_path)
+    assert lease.acquire(from_version="2.0.0", source="test") is not None
+
+
+def test_lease_corrupt_file_refused_at_acquire(lease_path: Path):
+    lease_path.parent.mkdir(parents=True)
+    lease_path.write_text("{not json")
+    lease = UpdateLease(lease_path)
+    refusal = lease.acquire(from_version="2.0.0", source="test")
+    assert refusal is not None
+    assert "corrupt" in refusal
+
+
+def test_lease_malformed_fields_refused_at_acquire_without_crash(lease_path: Path):
+    """Valid JSON with wrong-typed fields (hand-edited or torn lease) must
+    degrade to the corrupt-lease refusal, not raise out of acquire — a
+    ValueError here surfaces as an HTTP 500 while the lease keeps blocking
+    every later update."""
+    lease_path.parent.mkdir(parents=True)
+    for payload in (
+        {"pid": "not-a-pid", "acquired_at": "yesterday", "state": 42},
+        {"pid": 123, "acquired_at": "Infinity", "state": "draining"},
+        {"pid": None, "acquired_at": float("nan"), "state": "draining"},
+    ):
+        lease_path.write_text(json.dumps(payload))
+        lease = UpdateLease(lease_path)
+        refusal = lease.acquire(from_version="2.0.0", source="test")
+        assert refusal is not None, payload
+        assert "corrupt" in refusal, payload
+        assert lease_path.exists(), "acquire must not unlink an existing lease"
+
+
+def test_lease_read_coerces_numeric_strings(lease_path: Path):
+    """Numeric fields serialized as strings still coerce — only genuinely
+    unconvertible values are treated as corrupt."""
+    lease_path.parent.mkdir(parents=True)
+    lease_path.write_text(
+        json.dumps({"pid": "1234", "acquired_at": "99.5", "state": "draining"})
+    )
+    data = UpdateLease(lease_path).read()
+    assert data == {"pid": 1234, "acquired_at": 99.5, "state": "draining"}
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="POSIX dir mode bits don't restrict creation on Windows"
+)
+def test_lease_acquire_fails_closed_on_unwritable_dir(tmp_path: Path):
+    """An uncreatable lease refuses the update rather than running unleased."""
+    ro_dir = tmp_path / "ro"
+    ro_dir.mkdir(mode=0o500)
+    lease = UpdateLease(ro_dir / "run" / "update-lease.json")
+    refusal = lease.acquire(from_version="1.0.0", source="test")
+    assert refusal is not None
+    assert "cannot create" in refusal
+
+
+def test_current_head_commit_requires_trusted_git(tmp_path: Path, monkeypatch):
+    """The HEAD probe must never resolve git from PATH — a gateway's PATH can
+    lead with agent-writable dirs, so a planted shim would run with the
+    unsandboxed gateway's credentials. No trusted binary -> no subprocess,
+    '' result, handshake falls back to version comparison."""
+    proj = tmp_path / "proj"
+    (proj / ".git").mkdir(parents=True)
+    monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+    monkeypatch.setattr(
+        update_drain.platform_compat, "trusted_system_bin", lambda name: None
+    )
+    calls: list = []
+    monkeypatch.setattr(
+        update_drain.subprocess, "run", lambda *a, **k: calls.append(a)
+    )
+    assert update_drain.current_head_commit() == ""
+    assert not calls, "no subprocess may be spawned without a trusted git"
+
+
+def test_current_head_commit_spawns_the_trusted_path(tmp_path: Path, monkeypatch):
+    proj = tmp_path / "proj"
+    (proj / ".git").mkdir(parents=True)
+    monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+    monkeypatch.setattr(
+        update_drain.platform_compat, "trusted_system_bin", lambda name: "/usr/bin/git"
+    )
+    seen: dict = {}
+
+    def fake_run(argv, **kw):
+        seen["argv"] = argv
+        return SimpleNamespace(returncode=0, stdout="abc123\n")
+
+    monkeypatch.setattr(update_drain.subprocess, "run", fake_run)
+    assert update_drain.current_head_commit() == "abc123"
+    assert seen["argv"][0] == "/usr/bin/git", "argv[0] must be the pinned path"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_mark_restarting_ignores_planted_predictable_tmp_symlink(
+    lease_path: Path, tmp_path: Path
+):
+    """A symlink pre-planted at the predictable sibling name (update-lease.tmp)
+    must never receive the handoff write — temp files use unpredictable
+    mkstemp names, so a local attacker cannot aim the write at another file."""
+    lease = UpdateLease(lease_path)
+    assert lease.acquire(from_version="1.0.0", source="test") is None
+    victim = tmp_path / "victim.txt"
+    victim.write_text("untouched")
+    planted = lease_path.with_suffix(".tmp")
+    planted.symlink_to(victim)
+    lease.mark_restarting(target="1.1.0")
+    assert victim.read_text() == "untouched", "write must not follow a planted symlink"
+    assert json.loads(lease_path.read_text())["state"] == "restarting"
+
+
+def test_lease_mark_restarting(lease_path: Path):
+    lease = UpdateLease(lease_path)
+    lease.acquire(from_version="1.0.0", source="test")
+    lease.mark_restarting(target="1.1.0")
+    data = json.loads(lease_path.read_text())
+    assert data["state"] == "restarting"
+    assert data["target"] == "1.1.0"
+    assert data["from_version"] == "1.0.0"
+
+
+def test_lease_mark_restarting_noop_when_not_held(lease_path: Path):
+    lease = UpdateLease(lease_path)
+    lease.mark_restarting(target="1.1.0")
+    assert not lease_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# verify_after_restart (§5 step 9)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def homed_lease(lease_path: Path, monkeypatch) -> Path:
+    monkeypatch.setattr(update_drain, "_lease_path", lambda: lease_path)
+    return lease_path
+
+
+def test_verify_no_lease_returns_none(homed_lease: Path):
+    assert verify_after_restart("1.1.0") is None
+
+
+def test_verify_success_when_version_changed(homed_lease: Path):
+    lease = UpdateLease(homed_lease)
+    lease.acquire(from_version="1.0.0", source="test")
+    lease.mark_restarting(target="1.1.0")
+    outcome = verify_after_restart("1.1.0")
+    assert outcome is not None
+    assert "verified" in outcome.lower()
+    assert "1.1.0" in outcome
+    assert not homed_lease.exists(), "verification must consume the lease"
+
+
+def test_verify_success_without_target_uses_from_version(homed_lease: Path):
+    lease = UpdateLease(homed_lease)
+    lease.acquire(from_version="1.0.0", source="test")
+    lease.mark_restarting()
+    outcome = verify_after_restart("1.0.1")
+    assert outcome is not None
+    assert "verified" in outcome.lower()
+
+
+def test_verify_failure_when_version_unchanged(homed_lease: Path, caplog):
+    lease = UpdateLease(homed_lease)
+    lease.acquire(from_version="1.0.0", source="test")
+    lease.mark_restarting(target="1.1.0")
+    outcome = verify_after_restart("1.0.0")
+    assert outcome is not None
+    assert "did not take effect" in outcome.lower()
+    assert not homed_lease.exists(), "a failed swap must still consume the lease"
+
+
+def test_verify_interrupted_apply_dead_holder(homed_lease: Path, monkeypatch):
+    """A 'draining' lease whose holder is DEAD = interrupted mid-apply."""
+    lease = UpdateLease(homed_lease)
+    lease.acquire(from_version="1.0.0", source="test")
+    monkeypatch.setattr(update_drain, "_pid_alive", lambda pid: False)
+    outcome = verify_after_restart("1.0.0")
+    assert outcome is not None
+    assert "interrupted" in outcome.lower()
+    assert not homed_lease.exists()
+
+
+def test_verify_leaves_other_live_gateways_lease(homed_lease: Path, monkeypatch):
+    """A live lease held by ANOTHER process (second gateway on the same data
+    home) must never be consumed by this boot's verification."""
+    homed_lease.parent.mkdir(parents=True)
+    homed_lease.write_text(
+        json.dumps({"pid": os.getpid() + 1, "acquired_at": time.time(), "state": "draining"})
+    )
+    monkeypatch.setattr(update_drain, "_pid_alive", lambda pid: True)
+    assert verify_after_restart("1.1.0") is None
+    assert homed_lease.exists(), "another process's live lease must survive"
+
+
+def test_verify_leaves_own_in_flight_draining_lease(homed_lease: Path):
+    """Our own pid, still 'draining' = an apply in flight in this process
+    (POST /api/update racing the boot check) — not a leftover to consume."""
+    lease = UpdateLease(homed_lease)
+    lease.acquire(from_version="1.0.0", source="test")
+    assert verify_after_restart("1.0.0") is None
+    assert homed_lease.exists()
+
+
+# ---------------------------------------------------------------------------
+# Quiesce-gate wiring (cron claims + autonudge fires defer while draining)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def held_gate():
+    """Hold the global drain gate for the duration of a test, always releasing."""
+    update_drain.drain_gate.enter()
+    try:
+        yield update_drain.drain_gate
+    finally:
+        update_drain.drain_gate.exit()
+
+
+@pytest.mark.asyncio
+async def test_cron_tick_defers_claims_while_draining(tmp_path, held_gate):
+    """_on_timer must not CLAIM due jobs mid-drain; they stay due for the
+    relaunched gateway's first tick."""
+    from kiro_crew.cron import CronJob, CronSchedule, CronService
+
+    svc = CronService(base_dir=tmp_path)
+    job = CronJob(
+        id="j1",
+        name="due-job",
+        message="hi",
+        schedule=CronSchedule(kind="every", every_secs=1),
+        created_ts=time.time() - 60,
+    )
+    svc._jobs = [job]
+
+    async def fail_if_run(*a, **k):  # pragma: no cover - must not be reached
+        raise AssertionError("job must not start while draining")
+
+    svc._run_job_isolated = fail_if_run  # type: ignore[method-assign]
+    await svc._on_timer()
+    assert "j1" not in svc._executing, "drain tick must not claim the job"
+    assert not svc._running_tasks
+
+
+@pytest.mark.asyncio
+async def test_cron_tick_defers_cron_expression_jobs_while_draining(tmp_path, held_gate):
+    """A minute-matched cron-expression job due DURING the drain is deferred
+    like every other schedule kind — no due job of any kind is claimed while
+    the drain gate is active, so the swap window stays free of new work. The
+    job is claimed after the swap if its matching minute has not passed; a
+    swap crossing the minute boundary skips that one invocation by design."""
+    from kiro_crew.cron import CronJob, CronSchedule, CronService
+
+    svc = CronService(base_dir=tmp_path)
+    interval = CronJob(
+        id="iv",
+        name="interval",
+        message="hi",
+        schedule=CronSchedule(kind="every", every_secs=1),
+        created_ts=time.time() - 60,
+    )
+    expr = CronJob(
+        id="cx",
+        name="expr",
+        message="hi",
+        schedule=CronSchedule(kind="cron", cron_expr="* * * * *"),
+        created_ts=time.time() - 3600,
+    )
+    svc._tick_scan_locked = lambda: [interval, expr]  # type: ignore[method-assign]
+
+    ran: list[str] = []
+
+    async def record_run(job):  # pragma: no cover - must not be reached
+        ran.append(job.id)
+
+    svc._run_job_isolated = record_run  # type: ignore[method-assign]
+    await svc._on_timer()
+    await asyncio.sleep(0.05)
+    assert "cx" not in svc._executing, "cron-expression job must be deferred mid-drain"
+    assert "iv" not in svc._executing, "interval job stays deferred"
+    assert not svc._running_tasks
+    assert ran == []
+
+
+@pytest.mark.asyncio
+async def test_autonudge_timer_defers_fire_while_draining(tmp_path, held_gate, monkeypatch):
+    """_timer must re-arm (not fire, not consume a cycle) mid-drain."""
+    from kiro_crew.autonudge import AutoNudgeService, NudgeLoop
+
+    svc = AutoNudgeService(base_dir=tmp_path)
+    fired: list[str] = []
+
+    async def on_fire(loop: NudgeLoop) -> bool:  # pragma: no cover - must not fire
+        fired.append(loop.id)
+        return True
+
+    svc._on_fire = on_fire
+    loop = NudgeLoop(
+        id="l1",
+        slot_key="s1",
+        message="nudge",
+        idle_secs=1,
+        active=True,
+    )
+    svc._loops[loop.id] = loop
+    rearmed: list[float | None] = []
+
+    def fake_arm(lp: NudgeLoop, delay: float | None = None) -> None:
+        rearmed.append(delay)
+
+    monkeypatch.setattr(svc, "_arm_timer", fake_arm)
+    await svc._timer(loop, delay=0)
+    assert not fired, "loop must not fire while an update is draining"
+    assert rearmed, "loop must be re-armed for after the drain/restart"
+    assert loop.cycle_count == 0, "a deferred fire must not consume a cycle"
+
+
+# ---------------------------------------------------------------------------
+# Review-round regressions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lease_async_twins_roundtrip(lease_path: Path):
+    """acquire/mark_restarting/release must be awaitable (event-loop-safe)."""
+    lease = UpdateLease(lease_path)
+    assert await lease.acquire_async(from_version="1.0.0", source="t") is None
+    await lease.mark_restarting_async(target="1.1.0")
+    assert json.loads(lease_path.read_text())["state"] == "restarting"
+    await lease.release_async()
+    assert not lease_path.exists()
+
+
+def test_cron_executing_count_includes_jitter_sleepers(tmp_path):
+    """Jitter sleepers COUNT: every drain path holds the gate, and the jitter
+    sleep wakes on the gate's drain event and runs immediately — so a
+    claimed job is real in-flight work by the time a drain polls the count.
+    (Excluding sleepers silently lost cron-expression invocations killed
+    mid-sleep after their scheduled minute passed.)"""
+    from kiro_crew.cron import CronService
+
+    svc = CronService(base_dir=tmp_path)
+    svc._executing = {"sleeping", "working", "just-claimed"}
+    assert svc.executing_count() == 3
+
+
+def test_drain_gate_event_set_and_cleared():
+    """The drain event is set while ANY holder is in and cleared on last exit."""
+    gate = update_drain.DrainGate()
+    ev = gate.drain_event()
+    assert not ev.is_set()
+    gate.enter()
+    gate.enter()
+    assert ev.is_set()
+    gate.exit()
+    assert ev.is_set(), "nested exit must not clear the event"
+    gate.exit()
+    assert not ev.is_set()
+
+
+@pytest.mark.asyncio
+async def test_jitter_sleeper_wakes_on_drain(tmp_path, monkeypatch):
+    """A cron job in its jitter window runs immediately when a drain begins,
+    instead of sleeping out the jitter (and being killed by the exec)."""
+    from kiro_crew.cron import CronJob, CronSchedule, CronService
+
+    svc = CronService(base_dir=tmp_path)
+    job = CronJob(
+        id="j1",
+        name="daily",
+        message="hi",
+        schedule=CronSchedule(kind="every", every_secs=3600),
+        created_ts=time.time() - 7200,
+    )
+    monkeypatch.setattr(svc, "_compute_jitter", lambda j: 30.0)
+    ran = asyncio.Event()
+
+    async def on_job(j):
+        ran.set()
+        return "ok"
+
+    svc._on_job = on_job
+    svc._job_run_meta[job.id] = (time.time(), "scheduled")
+    svc._executing.add(job.id)
+    task = asyncio.create_task(svc._run_job_isolated(job))
+    await asyncio.sleep(0.05)
+    assert not ran.is_set(), "job must still be in its jitter sleep"
+    update_drain.drain_gate.enter()
+    try:
+        await asyncio.wait_for(ran.wait(), timeout=5.0)
+    finally:
+        update_drain.drain_gate.exit()
+        if not task.done():
+            await asyncio.wait_for(task, timeout=10.0)
+
+
+# ---------------------------------------------------------------------------
+# Server review round 1 regressions
+# ---------------------------------------------------------------------------
+
+
+def test_verify_leaves_young_corrupt_lease(homed_lease: Path):
+    """An unparsable lease younger than the construction grace may be another
+    process between O_EXCL create and json.dump — verification must not
+    unlink it (that would let a third contender double-acquire)."""
+    homed_lease.parent.mkdir(parents=True)
+    homed_lease.write_text("")  # created, not yet written
+    assert verify_after_restart("1.1.0") is None
+    assert homed_lease.exists()
+
+
+def test_verify_consumes_stale_corrupt_lease(homed_lease: Path, monkeypatch):
+    homed_lease.parent.mkdir(parents=True)
+    homed_lease.write_text("{garbage")
+    monkeypatch.setattr(
+        update_drain, "self_path_mtime", lambda p: time.time() - 3600
+    )
+    assert verify_after_restart("1.1.0") is None
+    assert not homed_lease.exists(), "stale corrupt lease is a crashed writer's leftover"
+
+
+def test_verify_leaves_lease_reacquired_after_read(homed_lease: Path, monkeypatch):
+    """Consume-vs-reacquire race: between verify's read and its consume, a
+    peer gateway consumes the same dead lease and a new apply legitimately
+    re-acquires the path. The stale verdict must not unlink the LIVE lease —
+    that would let a second update start mid-apply."""
+    homed_lease.parent.mkdir(parents=True)
+    dead = {"pid": 4242, "acquired_at": time.time() - 600, "state": "draining"}
+    homed_lease.write_text(json.dumps(dead))
+    live = {"pid": 999999, "acquired_at": time.time(), "state": "draining"}
+
+    def swap_then_dead(pid: int) -> bool:
+        # Simulate the peer's consume + a fresh acquire landing inside the
+        # window between verify's read and its unlink.
+        homed_lease.write_text(json.dumps(live))
+        return False
+
+    monkeypatch.setattr(update_drain, "_pid_alive", swap_then_dead)
+    assert verify_after_restart("1.1.0") is None, "verdict belongs to the peer"
+    assert homed_lease.exists(), "must not unlink a re-acquired live lease"
+    assert json.loads(homed_lease.read_text())["pid"] == 999999
+
+
+def test_verify_leaves_fresh_corrupt_lease_swapped_in_after_grace_check(
+    homed_lease: Path, monkeypatch
+):
+    """Corrupt-branch race: the pre-lock read saw a stale unparsable lease,
+    but by consume time the path holds a DIFFERENT young unparsable file (a
+    fresh contender between O_EXCL create and json.dump). The in-lock grace
+    re-check must leave it."""
+    homed_lease.parent.mkdir(parents=True)
+    homed_lease.write_text("{garbage")
+    ages = iter([3600.0, 1.0])
+    monkeypatch.setattr(
+        update_drain, "self_path_mtime", lambda p: time.time() - next(ages)
+    )
+    assert verify_after_restart("1.1.0") is None
+    assert homed_lease.exists(), "a young mid-write file must survive consumption"
+
+
+def test_verify_malformed_fields_treated_as_corrupt(homed_lease: Path, monkeypatch):
+    """Wrong-typed lease fields at boot verification degrade to the
+    corrupt-lease path (grace, then consume) instead of raising — a crash
+    here aborts startup verification and strands the lease forever."""
+    homed_lease.parent.mkdir(parents=True)
+    homed_lease.write_text(
+        json.dumps({"pid": ["not", "a", "pid"], "state": "restarting"})
+    )
+    monkeypatch.setattr(
+        update_drain, "self_path_mtime", lambda p: time.time() - 3600
+    )
+    assert verify_after_restart("1.1.0") is None
+    assert not homed_lease.exists(), "stale malformed lease must be consumed"
+
+
+def test_verify_consumes_bare_restart_handoff_silently(homed_lease: Path):
+    """A restart-only handoff (expect_change=False) with an UNCHANGED version
+    is the expected outcome — no 'update did not take effect' report."""
+    lease = UpdateLease(homed_lease)
+    lease.acquire(from_version="1.0.0", source="gateway_restart")
+    lease.mark_restarting(expect_change=False)
+    assert verify_after_restart("1.0.0") is None
+    assert not homed_lease.exists(), "the handoff must still be consumed"
+
+
+def test_verify_commit_identity_wins_over_version(homed_lease: Path, monkeypatch):
+    """On the git engine the handshake keys on the HEAD SHA: an unchanged
+    version with a matching commit is SUCCESS (the overwhelming case for a
+    successful pull), and a mismatched commit is failure even when the
+    version string looks right."""
+    lease = UpdateLease(homed_lease)
+    lease.acquire(from_version="1.0.0", source="test")
+    lease.mark_restarting(target="1.0.0", target_commit="a" * 40)
+    monkeypatch.setattr(update_drain, "current_head_commit", lambda: "a" * 40)
+    outcome = verify_after_restart("1.0.0")
+    assert outcome is not None and "verified" in outcome.lower()
+
+    lease2 = UpdateLease(homed_lease)
+    lease2.acquire(from_version="1.0.0", source="test")
+    lease2.mark_restarting(target="1.0.0", target_commit="a" * 40)
+    monkeypatch.setattr(update_drain, "current_head_commit", lambda: "b" * 40)
+    outcome = verify_after_restart("1.0.0")
+    assert outcome is not None and "did not take effect" in outcome.lower()
+
+
+def test_verify_falls_back_to_version_without_commits(homed_lease: Path, monkeypatch):
+    """Non-git engines (no resolvable HEAD) keep the version handshake."""
+    monkeypatch.setattr(update_drain, "current_head_commit", lambda: "")
+    lease = UpdateLease(homed_lease)
+    lease.acquire(from_version="1.0.0", source="test")
+    lease.mark_restarting(target="1.1.0")
+    outcome = verify_after_restart("1.1.0")
+    assert outcome is not None and "verified" in outcome.lower()
+
+
+# ---------------------------------------------------------------------------
+# GPT review round 4 regressions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restart_handoff_write_precedes_close_all(monkeypatch):
+    """§5 step 8→9 ordering: the lease handoff write runs BEFORE close_all().
+
+    mark_restarting raises on a failed write (disk full, rename failure), and
+    close_all() puts the session manager into its closing state — an abort
+    after that point leaves a live gateway that rejects every subsequent
+    turn. The write must happen while the gateway is still fully serving."""
+    from kiro_crew.dashboard.handlers import updates
+
+    order: list[str] = []
+
+    class FakeSessions:
+        async def close_all(self):
+            order.append("close_all")
+
+    class FakeState:
+        sessions = FakeSessions()
+
+        def push_update_progress(self, *a, **k):
+            pass
+
+    class FakeLease:
+        async def mark_restarting_async(self, **kw):
+            order.append("mark_restarting")
+
+    monkeypatch.setattr(updates.os, "execv", lambda *a: order.append("execv"))
+    monkeypatch.setattr("kiro_crew.dashboard.chat.save_all_slots_to_history", lambda s: None)
+    await updates._restart_gateway(FakeState(), drain=False, lease=FakeLease())
+    assert order == ["mark_restarting", "close_all", "execv"]
+
+
+@pytest.mark.asyncio
+async def test_restart_aborts_before_close_all_on_handoff_failure(monkeypatch):
+    """A failed handoff write aborts the restart BEFORE sessions close: the
+    gateway keeps serving instead of ending up permanently closing with the
+    exec skipped."""
+    from kiro_crew.dashboard.handlers import updates
+
+    closed: list[str] = []
+
+    class FakeSessions:
+        async def close_all(self):  # pragma: no cover - must not be reached
+            closed.append("close_all")
+
+    class FakeState:
+        sessions = FakeSessions()
+
+        def push_update_progress(self, *a, **k):
+            pass
+
+    class FakeLease:
+        async def mark_restarting_async(self, **kw):
+            raise OSError("disk full")
+
+    execd: list[str] = []
+    monkeypatch.setattr(updates.os, "execv", lambda *a: execd.append("execv"))
+    monkeypatch.setattr("kiro_crew.dashboard.chat.save_all_slots_to_history", lambda s: None)
+    with pytest.raises(OSError):
+        await updates._restart_gateway(FakeState(), drain=False, lease=FakeLease())
+    assert not closed, "sessions must survive an aborted handoff"
+    assert not execd

--- a/test/test_update_venv_detection.py
+++ b/test/test_update_venv_detection.py
@@ -269,7 +269,7 @@ class TestApiUpdateApplyVenvDispatch:
             pip_called.append(True)
             return True
 
-        async def fake_restart(s):
+        async def fake_restart(s, *, drain=True):
             restart_called.append(True)
 
         monkeypatch.setattr(
@@ -318,7 +318,7 @@ class TestApiUpdateApplyVenvDispatch:
         async def fake_pip(p, s):
             return False  # pip install failed
 
-        async def fake_restart(s):
+        async def fake_restart(s, *, drain=True):
             restart_called.append(True)
 
         monkeypatch.setattr(


### PR DESCRIPTION
## Problem

Applying an update restarts the gateway with no regard for what it is running. Three paths restart after (or during) an update, and none of them waits for in-flight work:

- `_auto_apply_update` (boot auto-apply) `git reset --hard`s the running install, reinstalls, and `os.execv`s immediately — any active agent turn dies mid-prompt.
- `POST /api/update` does the same, and two concurrent POSTs race each other's `git pull` + `pip install` with nothing serializing them.
- The stale-asset watchdog does drain, but its in-flight counter only sees provider turns and Slack tasks. Executing cron jobs and running subagents — whose kiro-cli processes are children of the gateway — are invisible to it and get killed.

There is also no verification that a restart-for-update actually landed on new code: "update succeeded" means "we started something", not "the new version is serving". Issue #2324 documents the user-visible half of this (an update swaps `static/dist` under a live gateway, which then 404s new endpoints until something external restarts it).

## Why it matters

A gateway that runs long-lived autonomous work (multi-hour babysit loops, cron-driven agents, background subagents) cannot be updated without destroying that work. Users either disable `auto_update` and fall behind, or accept losing whatever was in flight. This is the gap between "auto-update exists" and "auto-update is safe to leave on".

The update-architecture RFC (`docs/request-for-change/rfc-update-architecture.md`, §5 "Drain-then-swap") already specifies the lifecycle: lease → stop new work → drain bounded → checkpoint → swap → restart → verify. This PR implements the shared drain-and-restart half of it (the RFC's Phase 3 orchestration seam) for the gateway's existing engines. Update-drain-or-loss is not unique to this project: OpenClaw tracks the same class of defects — stale in-memory module graphs after an in-place update (openclaw/openclaw#85844), and a requested drain + retry of unprocessed messages around gateway restarts (openclaw/openclaw#49692).

## Fix (symptoms → root cause → change)

Root cause: each restart-after-update path re-implements a subset of the §5 sequence, and the one existing drain helper is private to the watchdog with an under-counting in-flight predicate.

Change — one new module, `kiro_crew/update_drain.py`, three primitives, wired into all paths:

- **`UpdateLease`** — "one update in flight, ever" as a filesystem lease at `run/update-lease.json` (owner-only dir, same trust model as the run marker). It outlives the process on purpose: `os.execv` keeps the PID, so an in-memory flag can't distinguish "restarting into new code" from "still applying". Live holders always win; corrupt or dead-holder leases are reclaimed. `POST /api/update` now answers 409 while an update is in flight — which also closes the unguarded concurrent-apply race.
- **Boot verification handshake** (§5 step 9) — `verify_after_restart()` runs at the head of the boot update check: a lease left in `restarting` state means the previous process swapped and restarted into us, so we report whether the version actually changed (and flag a half-applied update if the lease was still `draining`), then consume the lease.
- **`drain_gate` + `drain_in_flight`** — a reference-counted quiesce flag plus the bounded drain generalized from the watchdog. While an apply is draining, `CronService._on_timer` defers claiming due jobs (they stay due; the relaunched gateway's first tick picks them up) and `AutoNudgeService._timer` re-arms instead of firing (no cycle consumed; loops survive restarts via `autonudge.json` anyway). Already-running work is never interrupted — the drain waits for it, bounded by a new `update_drain_timeout_secs` config (default 300s, 0 = restart immediately). A real shutdown (SIGTERM) always outranks a drain.
- **Widened in-flight counter** — `_count_in_flight_work` now also counts executing cron jobs (`CronService.executing_count()`) and running subagents (`SubagentManager.running_count`), with the same fail-idle defensive shape per surface so a broken accessor can never wedge a shutdown.
- **Wiring** — `_auto_apply_update` takes the lease and drains *before* `git reset --hard` (on the git engine, install and swap are the same step, so draining only before the restart is too late — this is the #2324 fix); `_restart_gateway` drains before its execv; the watchdog uses the shared drain and stands down when a vanish happens during a coordinated apply (the apply owns the restart; double-triggering would race the execv with a shutdown).

Deliberately out of scope: refusing *interactive* turn intake during a drain. Refusing inbound messages without a queue is the message-loss problem tracked in #2217, and the RFC sequences queue-and-replay as remaining Phase-3 work. Background intake (cron, autonudge) is deferred instead of refused precisely because deferral is lossless there.

## Tests

`test/test_update_drain.py` (26 tests):
- `DrainGate`: nested holders compose (dashboard apply + restart helper), unbalanced exit floors at zero.
- `drain_in_flight`: immediate return when idle, waits until work finishes, honest `False` on timeout, external shutdown interrupts within one poll, broken counter fails idle (never wedges), zero timeout skips.
- `UpdateLease`: acquire writes `draining` state; second acquire refused while the holder is alive (and the loser's `release()` can't clobber the winner); stale dead-holder and corrupt leases reclaimed; age alone never breaks a live holder's lease; `mark_restarting` records target.
- `verify_after_restart`: success on version change (with and without a recorded target), critical report when the version did NOT change, interrupted-mid-apply report for a `draining` lease at boot; every outcome consumes the lease.
- Quiesce wiring: a due cron job is not claimed mid-drain and no run task is created; an autonudge loop re-arms without firing and without consuming a cycle.

`test/test_slack_gateway.py` (+4 in `TestCountInFlightWork`): cron executions counted, subagents counted, all four surfaces sum, introspection failures on the new surfaces treated as idle.

Full touched-surface run: 881 passed, 5 skipped (update handlers, watchdog, autonudge, cron, config loader/baseline/API, slack gateway). isort/flake8/mypy clean on all changed files.

## Manual verification

N/A — unit coverage exercises the lease/drain/verify lifecycle directly, and the wired paths (`_auto_apply_update`, `POST /api/update`, `_restart_gateway`, watchdog) are covered by their existing suites plus the new counter tests. No UI change.
