### PR TITLE
feat: add pod prune and orphan-HOME age to pod ls (#2567)

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1393,7 +1393,7 @@ Examples:
     )
     pod_sub = pod_parser.add_subparsers(
         dest="pod_action",
-        metavar="{up,down,ls,status,token,url,logs,exec,provision,install}",
+        metavar="{up,down,ls,prune,status,token,url,logs,exec,provision,install}",
     )
     pod_up = pod_sub.add_parser("up", help="Schedule an isolated pod for a worktree")
     pod_up.add_argument("name", help="Worktree name")
@@ -1432,6 +1432,35 @@ Examples:
     pod_down.add_argument("name", help="Worktree name")
     pod_ls = pod_sub.add_parser("ls", help="List running pods")
     pod_ls.add_argument("--json", action="store_true", help="Emit rows as JSON")
+    pod_prune = pod_sub.add_parser(
+        "prune", help="Reclaim orphaned pod HOMEs in bulk (the N-at-once `pod down`)"
+    )
+    pod_prune.add_argument(
+        "--older-than",
+        dest="older_than",
+        default="3d",
+        help=(
+            "Only reclaim orphans whose last activity is older than this "
+            "(e.g. 3d, 12h, 30m, 45s). Default: 3d, so a freshly-crashed HOME "
+            "an operator may still be debugging is kept. Use --all to reclaim "
+            "regardless of age."
+        ),
+    )
+    pod_prune.add_argument(
+        "--all",
+        dest="prune_all",
+        action="store_true",
+        help="Reclaim ALL orphans regardless of age (overrides --older-than)",
+    )
+    pod_prune.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        help="Classify and print what would be reclaimed without deleting anything",
+    )
+    pod_prune.add_argument(
+        "--json", action="store_true", help="Emit per-name results as JSON"
+    )
     pod_status = pod_sub.add_parser("status", help="Up/down + health for one pod")
     pod_status.add_argument("name", help="Worktree name")
     pod_status.add_argument("--json", action="store_true", help="Emit status as JSON")

--- a/src/kiro_crew/pod/README.md
+++ b/src/kiro_crew/pod/README.md
@@ -20,7 +20,8 @@ kirocrew pod up   <wt> [--json]   # bring up an isolated pod → {base_url, toke
 kirocrew pod up   <wt> --provision# provision (if needed) then bring it up
 kirocrew pod up   <wt> --approval reads  # boot its gateway in an approval mode
 kirocrew pod up   <wt> --crons          # boot its gateway with the cron scheduler on
-kirocrew pod ls                   # what's running (≈ kubectl get pods) + orphaned HOMEs
+kirocrew pod ls                   # what's running (≈ kubectl get pods) + orphaned HOMEs (with age)
+kirocrew pod prune [--all] [--dry-run]  # bulk-reclaim orphaned HOMEs (default: older than 3d; --all for every age)
 kirocrew pod status <wt>          # up/down + health
 kirocrew pod token  <wt> [--ttl]  # (re)mint a dashboard token for a running pod
 kirocrew pod url    <wt>          # print its base_url
@@ -81,7 +82,10 @@ HOME through `runtime.cleanup_home` (which re-validates the name and refuses
 semantics), then VERIFIES the directory is gone and fails loudly if it is not.
 The trade is that a pod which goes away without a `down` — a crash, a raw
 `systemctl --user stop`, a reboot — leaves its HOME behind; `pod ls` reports
-those, and `pod down <wt>` reclaims one.
+those with their age, `pod down <wt>` reclaims one, and `pod prune` reclaims
+them in bulk — by default only HOMEs whose last activity is older than 3 days
+(`--all` sweeps every age; each delete still routes through the same
+stop-drain-verify path `down` uses, with liveness re-checked per name).
 
 ### Port derivation
 

--- a/src/kiro_crew/pod/cli.py
+++ b/src/kiro_crew/pod/cli.py
@@ -7,8 +7,11 @@ Dispatched from :func:`kiro_crew.cli_commands._pod`.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
 import logging
+import re
 import subprocess
 import sys
 import time
@@ -305,12 +308,275 @@ def _print_orphans(cfg: PodConfig, orphans: list[str]) -> None:
     """Human-readable report of pod HOMEs with no live pod behind them."""
     if not orphans:
         return
+    now = time.time()
     print(
         f"\n{len(orphans)} orphaned pod HOME(s) — left by a pod that went away "
         "without an explicit `down` (a crash, a raw service stop, a reboot):"
     )
     for n in orphans:
-        print(f"  {n:<26} reclaim: kirocrew pod down {n}")
+        # Best-effort "last alive" hint. A HOME that vanished or cannot be
+        # statted between the enumeration and this loop still gets its row —
+        # age is a hint, never a gate, on the read path.
+        try:
+            age = _relative_age(now - _orphan_last_alive(cfg, n))
+        except OSError:
+            age = "age unknown"
+        print(f"  {n:<26} {age:<12} reclaim: kirocrew pod down {n}")
+    print("  bulk reclaim: kirocrew pod prune [--all] [--dry-run] (default keeps the last 3d)")
+
+
+def _orphan_last_alive(cfg: PodConfig, name: str) -> float:
+    """Best-effort "last alive" timestamp for an orphaned HOME.
+
+    The HOME directory's own mtime freezes once the top-level layout exists —
+    a gateway writes into ``logs/``, ``sessions/``, ``workspace/`` — so it
+    measures creation, not activity, and would age a freshly-crashed pod as its
+    boot date (making the crash being debugged the first thing ``--older-than``
+    reclaims). Scan two levels down and take the newest mtime: log appends and
+    db writes land on level-1/2 files, so this tracks real activity without an
+    unbounded walk. Raises OSError only when the HOME itself cannot be statted;
+    unreadable children are skipped.
+    """
+    home = cfg.pod_root / name
+    newest = home.stat().st_mtime
+    try:
+        for child in home.iterdir():
+            try:
+                newest = max(newest, child.stat().st_mtime)
+                if child.is_dir() and not child.is_symlink():
+                    for grand in child.iterdir():
+                        try:
+                            newest = max(newest, grand.stat().st_mtime)
+                        except OSError:
+                            continue
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return newest
+
+
+def _relative_age(seconds: float) -> str:
+    """Coarse relative age ("3d ago"): largest whole unit, floored, never negative.
+
+    A clock skew or a just-touched directory can put the mtime in the future;
+    clamping to 0 keeps the report readable instead of printing a negative age.
+    """
+    s = max(0, int(seconds))
+    if s >= 86400:
+        return f"{s // 86400}d ago"
+    if s >= 3600:
+        return f"{s // 3600}h ago"
+    if s >= 60:
+        return f"{s // 60}m ago"
+    return f"{s}s ago"
+
+
+# ``prune --older-than`` accepts a single count+unit token. Deliberately a tiny
+# local grammar (no dependency): days/hours/minutes/seconds cover every horizon
+# an orphan sweep needs. The digit cap bounds the arithmetic: an unbounded
+# count over ~1e308 would overflow the float timestamp subtraction; 9 digits of
+# days is ~2.7 million years, ample and safely finite.
+_OLDER_THAN_RE = re.compile(r"^(\d{1,9})([dhms])$")
+_OLDER_THAN_UNIT_SECS = {"d": 86400, "h": 3600, "m": 60, "s": 1}
+
+
+def _parse_older_than(spec: str) -> float:
+    """``"3d"`` → seconds. Raises :class:`rt.PodError` for anything else, so the
+    caller can audit the refusal and the dispatch layer still renders the
+    documented one-line ``pod: …`` message."""
+    m = _OLDER_THAN_RE.match(spec.strip())
+    if not m:
+        raise rt.PodError(
+            f"invalid --older-than {spec!r} "
+            f"(expected <N>d, <N>h, <N>m or <N>s with at most 9 digits, e.g. 3d)"
+        )
+    return int(m.group(1)) * _OLDER_THAN_UNIT_SECS[m.group(2)]
+
+
+def _prune(cfg: PodConfig, args: argparse.Namespace) -> None:
+    """Bulk-reclaim orphaned pod HOMEs (the N-at-once form of `pod down <name>`).
+
+    Enumerates the same orphan set ``ls`` reports, optionally keeps anything
+    whose last activity is younger than ``--older-than``, and reclaims each
+    survivor through the same safe delete path ``down`` uses. Per-name results,
+    because a prune where three of nine names succeeded must say which three —
+    one aggregate "done" line would hide partial failure.
+    """
+    # An unusable backend is ONE refusal, not N per-name failures — and a
+    # refused bulk-destructive invocation must still reach the audit trail, so
+    # every refusal path out of this verb (dead backend, malformed duration,
+    # failed orphan enumeration) is recorded as denied before the dispatch
+    # layer renders the documented one-line error.
+    try:
+        rt.require_backend()
+        # Age-gated by DEFAULT (3d): a bare `prune` must not sweep the
+        # minutes-old crash HOME an operator is still debugging — its logs and
+        # sessions are the only postmortem evidence, and the delete is
+        # unrecoverable. `--all` is the explicit opt-in for a full sweep.
+        threshold: float | None = None
+        if not getattr(args, "prune_all", False):
+            threshold = time.time() - _parse_older_than(args.older_than)
+        orphans = rt.orphan_homes(cfg)
+    except rt.PodError as exc:
+        _audit("pod.prune", "denied", f"older_than={args.older_than or 'all'}", error=str(exc)[:120])
+        raise
+    dry_run = bool(getattr(args, "dry_run", False))
+    results: list[dict[str, str]] = []
+    for name in orphans:
+        if threshold is not None:
+            # A HOME that cannot be statted cannot be proven old enough —
+            # skip it and keep going rather than abort the whole prune.
+            try:
+                last_alive = _orphan_last_alive(cfg, name)
+            except OSError as exc:
+                results.append({"name": name, "status": "skipped", "detail": f"stat failed: {exc}"})
+                continue
+            if last_alive > threshold:
+                results.append(
+                    {"name": name, "status": "kept", "detail": "younger than --older-than"}
+                )
+                continue
+        if dry_run:
+            # Apply the DETERMINISTIC classification so the preview matches a
+            # real run: an invalid name is skipped either way. The liveness
+            # rechecks are moment-in-time and stay out of the preview.
+            try:
+                rt.validate_name(name)
+            except rt.PodError:
+                results.append(
+                    {"name": name, "status": "skipped", "detail": "not a valid pod name"}
+                )
+                continue
+            results.append({"name": name, "status": "would-reclaim", "detail": ""})
+            continue
+        if args.json:
+            # The delete path underneath (stop_pod -> cleanup_home) prints its
+            # diagnostics to stdout; interleaved with the machine output they
+            # would corrupt the JSON document. Reroute them to stderr — kept
+            # visible, never parsed.
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                row = _prune_one(cfg, name)
+            if buf.getvalue():
+                print(buf.getvalue(), file=sys.stderr, end="")
+            results.append(row)
+        else:
+            results.append(_prune_one(cfg, name))
+    failed = sum(1 for r in results if r["status"] == "failed")
+    counts = {
+        s: sum(1 for r in results if r["status"] == s)
+        for s in ("reclaimed", "would-reclaim", "kept", "skipped", "failed")
+    }
+    # Invocation-level audit: the per-name events say what each delete decided,
+    # but a bulk destructive verb must be visible in the trail even when it
+    # touched nothing (empty set, all kept, dry run).
+    _audit(
+        "pod.prune",
+        "allowed",
+        f"total={len(results)} reclaimed={counts['reclaimed']} kept={counts['kept']} "
+        f"skipped={counts['skipped']} failed={failed} dry_run={int(dry_run)}",
+    )
+    if args.json:
+        # prune owns its machine shape; `ls --json` stays live-pods-only.
+        print(json.dumps(results))
+    elif not results:
+        print("no orphaned pod HOMEs to prune")
+    else:
+        for r in results:
+            detail = f"  {r['detail']}" if r["detail"] else ""
+            print(f"  {r['name']:<26} {r['status']}{detail}")
+        if dry_run:
+            print(
+                f"dry run: {counts['would-reclaim']} would be reclaimed, "
+                f"{counts['kept']} kept, {counts['skipped']} skipped"
+            )
+        else:
+            print(
+                f"pruned: {counts['reclaimed']} reclaimed, {counts['kept']} kept, "
+                f"{counts['skipped']} skipped, {counts['failed']} failed"
+            )
+    if failed:
+        sys.exit(1)
+
+
+def _prune_one(cfg: PodConfig, name: str) -> dict[str, str]:
+    """Reclaim ONE orphaned HOME through the safe delete path; never raises.
+
+    Structured so the SEL audit CANNOT be skipped: every decision path returns
+    through :func:`_prune_one_decide`, and the single audit call here is the
+    only exit. A per-name permission decision on a bulk-destructive verb that
+    does not reach the trail is invisible to the operator — adding a new
+    return path to the decide helper keeps this property by construction.
+    """
+    status, detail, outcome, err = _prune_one_decide(cfg, name)
+    _audit("pod.prune", outcome, f"name={name}", error=err)
+    return {"name": name, "status": status, "detail": detail}
+
+
+def _prune_one_decide(cfg: PodConfig, name: str) -> tuple[str, str, str, str]:
+    """The decision half of :func:`_prune_one`: ``(status, detail, outcome, error)``.
+
+    Every delete routes through :func:`rt.stop_pod` — the path that drains the
+    unit's processes and verifies the HOME is really gone — NEVER through
+    ``cleanup_home`` directly, which would race the pod's own surviving
+    processes (the exact defect the hook-based teardown removal fixed).
+
+    Liveness is re-checked HERE, under the per-name mutex, and it must be
+    STRICTER than the enumeration's ``--state=active`` filter: a unit in the
+    ``Restart=on-failure`` backoff window reports ``activating`` (not active),
+    so both the orphan scan and a bare ``is_active`` call miss it — and a
+    ``systemctl stop`` would cancel the pending restart and delete a pod the
+    operator considers running. Only a terminal state (``inactive``/``failed``
+    with no restart pending) may proceed; anything else is refused, the same
+    fail-closed reading the macOS plist recheck gives mid-``up`` names. A
+    failure on one name is reported and the prune continues — partial progress
+    beats an aborted sweep.
+    """
+    try:
+        # A stray directory that is not a valid pod name (spaces, over-long)
+        # can never have a unit or be reclaimed by `down`; refuse it by name
+        # rather than shelling a bogus systemctl stop and reporting a failure
+        # that would make every future prune exit nonzero.
+        try:
+            rt.validate_name(name)
+        except rt.PodError as exc:
+            return "skipped", "not a valid pod name", "denied", str(exc)[:120]
+        with rt.pod_name_mutex(cfg, name):
+            if rt.is_active(cfg, name):
+                return "skipped", "pod is now active", "denied", "pod is now active"
+            state, restarts = rt.unit_state(cfg, name)
+            if state not in ("inactive", "failed") or restarts > 0:
+                return (
+                    "skipped",
+                    f"unit is {state} (mid-transition or restarting, not orphaned)",
+                    "denied",
+                    f"unit state {state} restarts={restarts}",
+                )
+            # macOS: a per-pod plist means "installed" (a name mid-`up`), not
+            # orphaned — same predicate orphan_homes applies, re-checked at
+            # delete time for writers that bypass the mutex.
+            if rt.IS_MACOS and rt.launchd.plist_path(cfg, name).exists():
+                return "skipped", "pod is now installed", "denied", "pod is now installed"
+            cp = rt.stop_pod(cfg, name)
+            if cp.returncode != 0:
+                err = (cp.stderr or "").strip() or f"stop rc={cp.returncode}"
+                return "failed", err, "failure", err[:120]
+            if rt.RECLAIMED_MARKER in (cp.stdout or ""):
+                # The name was claimed by a new pod mid-teardown; its env file
+                # now pins the NEW pod's checkout — leave it alone.
+                return "skipped", "name claimed by a new pod", "allowed", ""
+            # Clear the pinned CHECKOUT= / SEED= so a later `up` re-resolves
+            # cleanly — the same post-reclaim step `down` performs. missing_ok:
+            # exists()-then-unlink is a TOCTOU against a concurrent `down`.
+            cfg.env_file(name).unlink(missing_ok=True)
+    except (rt.PodError, OSError, subprocess.SubprocessError) as exc:
+        # One name must never abort the sweep: containment covers the pod
+        # error type AND the raw filesystem/subprocess failures underneath it
+        # (an unwritable env dir, a timed-out systemctl) — an escaped exception
+        # here would hide every result already earned and strand the tail.
+        return "failed", str(exc), "failure", str(exc)[:120]
+    return "reclaimed", "", "allowed", ""
 
 
 def _status(cfg: PodConfig, args: argparse.Namespace) -> None:
@@ -444,6 +710,7 @@ _VERBS: dict[str, PodHandler] = {
     "up": _up,
     "down": _down,
     "ls": _ls,
+    "prune": _prune,
     "status": _status,
     "token": _token,
     "url": _url,
@@ -461,7 +728,7 @@ def dispatch(args: argparse.Namespace) -> None:
     if not action:
         print(
             "Usage: kirocrew pod "
-            "{up|down|ls|status|token|url|logs|exec|install|provision} …"
+            "{up|down|ls|prune|status|token|url|logs|exec|install|provision} …"
         )
         sys.exit(2)
     cfg = PodConfig.load()

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -829,7 +829,11 @@ def orphan_homes(cfg: PodConfig) -> list[str]:
     :func:`cleanup_home`'s re-validation via ``kirocrew pod down <name>``.
     """
     try:
-        entries = [p for p in cfg.pod_root.iterdir() if p.is_dir()]
+        # never follow a symlink: a link under pod_root can point at a LIVE
+        # pod's HOME (or anywhere), and everything downstream of this
+        # enumeration treats the NAME as the directory it will judge and
+        # delete. A real pod HOME is always created as a plain directory.
+        entries = [p for p in cfg.pod_root.iterdir() if p.is_dir() and not p.is_symlink()]
     except OSError:
         return []
     live = active_names(cfg)
@@ -1095,13 +1099,41 @@ def cleanup_home(cfg: PodConfig, name: str) -> int:
         print(f"refusing pod cleanup for invalid instance name {name!r}")
         return 2
     root = cfg.pod_root.resolve()
-    target = (cfg.pod_root / name).resolve()
+    unresolved = cfg.pod_root / name
+    # Refuse to delete THROUGH a symlink: resolving first lets a link planted
+    # under pod_root pass the containment check below while the tree it names
+    # lives elsewhere — including another, live pod's HOME. A real pod HOME is
+    # always created as a plain directory, so a link here is never ours to follow.
+    if unresolved.is_symlink():
+        print(f"refusing pod cleanup: {unresolved} is a symlink, not a pod HOME")
+        return 2
+    target = unresolved.resolve()
     if target == root or target.parent != root:
         print(f"refusing pod cleanup: {target} is not a pod dir under {root}")
         return 2
-    shutil.rmtree(target, ignore_errors=True)
-    if not target.exists():
+    # Delete by the UNRESOLVED name, never the resolved target: between the
+    # symlink pre-check above and this call the entry can be swapped for a
+    # symlink (check-to-use race), and rmtree on the RESOLVED path would then
+    # delete the live sibling the link points at. rmtree itself refuses a
+    # top-level symlink, so deleting by name makes the swap harmless — nothing
+    # is removed and the survivor check below reports the failure.
+    shutil.rmtree(unresolved, ignore_errors=True)
+    # Verify by the ENTRY itself, never the resolved target: an entry swapped
+    # to a DANGLING symlink during the delete makes rmtree refuse silently
+    # (suppressed by ignore_errors), and the resolved target of a dangling
+    # link does not exist — so a target-existence check would report a clean
+    # reclaim while the link remains as residue that orphan_homes (which
+    # skips symlinks) can never surface again.
+    if not os.path.lexists(unresolved):
         return 0
+    if unresolved.is_symlink():
+        # Swapped to a symlink mid-delete: rmtree refused it (correctly), and
+        # the link itself is the residue — name it rather than the target.
+        print(
+            f"pod cleanup did not remove {unresolved}: the entry is now a "
+            "symlink, which teardown refuses to follow — remove it by hand"
+        )
+        return 1
     survivors = _surviving_entries(target)
     print(
         f"pod cleanup did not fully remove {target}: still present "

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -10,6 +10,7 @@ import stat
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1187,6 +1188,506 @@ class TestOrphanHomes:
         monkeypatch.setattr(rt, "health", lambda port, timeout=3: 200)
         pod_cli._ls(c, argparse.Namespace(json=True))
         assert [r["name"] for r in json.loads(capsys.readouterr().out)] == ["running"]
+
+    def test_ls_shows_each_orphans_age(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """An orphan left 5 minutes ago and one left 3 weeks ago need different
+        handling; the HOME's mtime is the signal the report was missing."""
+        c = self._plane(tmp_path, monkeypatch)
+        monkeypatch.setattr(rt, "health", lambda port, timeout=3: 200)
+        three_days = time.time() - 3 * 86400
+        os.utime(c.pod_root / "orphan", (three_days, three_days))
+        pod_cli._ls(c, argparse.Namespace(json=False))
+        assert "3d ago" in capsys.readouterr().out
+
+    def test_an_unstattable_orphan_still_gets_its_row(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A HOME that vanished between enumeration and the report must not
+        crash the listing — age is a hint, never a gate, on the read path."""
+        c = self._plane(tmp_path, monkeypatch)
+        pod_cli._print_orphans(c, ["ghost"])
+        out = capsys.readouterr().out
+        assert "ghost" in out
+        assert "age unknown" in out
+
+
+class TestRelativeAge:
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (0, "0s ago"),
+            (59, "59s ago"),
+            (60, "1m ago"),
+            (3600, "1h ago"),
+            (86400 * 3 + 3600, "3d ago"),
+            (-10, "0s ago"),  # future mtime (clock skew) clamps, never negative
+        ],
+    )
+    def test_largest_whole_unit(self, seconds: float, expected: str) -> None:
+        assert pod_cli._relative_age(seconds) == expected
+
+
+class TestParseOlderThan:
+    @pytest.mark.parametrize(
+        "spec,expected",
+        [("3d", 3 * 86400.0), ("12h", 12 * 3600.0), ("30m", 1800.0), ("45s", 45.0)],
+    )
+    def test_accepted_forms(self, spec: str, expected: float) -> None:
+        assert pod_cli._parse_older_than(spec) == expected
+
+    @pytest.mark.parametrize("spec", ["", "3", "d", "3w", "1.5h", "3d12h", "-3d", "9" * 400 + "d"])
+    def test_rejects_anything_else(self, spec: str) -> None:
+        with pytest.raises(rt.PodError, match="invalid --older-than"):
+            pod_cli._parse_older_than(spec)
+
+    def test_the_digit_cap_keeps_the_timestamp_arithmetic_finite(self) -> None:
+        """An unbounded count (a 400-digit day value) survives int arithmetic
+        but overflows the float timestamp subtraction in _prune with an
+        uncaught OverflowError; the largest accepted count must stay finite."""
+        biggest = pod_cli._parse_older_than("999999999d")
+        assert time.time() - biggest == pytest.approx(time.time() - biggest)  # no OverflowError
+
+
+class TestPrune:
+    """`prune` is the N-at-once `down` for orphans: every delete routes through
+    stop_pod (drain + verify), liveness is re-checked per name at delete time,
+    and one bad name never aborts the sweep."""
+
+    def _plane(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, orphans: tuple[str, ...]
+    ) -> PodConfig:
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "env"))
+        c = PodConfig.load()
+        for n in orphans:
+            (c.pod_root / n).mkdir(parents=True)
+        monkeypatch.setattr(rt, "require_backend", lambda: None)
+        monkeypatch.setattr(rt, "active_names", lambda cc: set())
+        monkeypatch.setattr(rt, "is_active", lambda cc, n: False)
+        monkeypatch.setattr(rt, "unit_state", lambda cc, n: ("inactive", 0))
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+        # cleanup_home directly from prune would BE the race stop_pod exists to
+        # close — any call that does not come through stop_pod is a regression.
+        monkeypatch.setattr(
+            rt, "cleanup_home", lambda *a, **k: pytest.fail("prune bypassed stop_pod")
+        )
+        return c
+
+    def _ns(self, **kw) -> argparse.Namespace:
+        # prune_all=True keeps the reclaim-behavior tests on a full sweep; the
+        # age-gate default is covered by its own dedicated tests below.
+        base = {"older_than": "3d", "json": False, "dry_run": False, "prune_all": True}
+        base.update(kw)
+        return argparse.Namespace(**base)
+
+    def test_reclaims_every_orphan_through_stop_pod(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        c = self._plane(tmp_path, monkeypatch, ("a", "b"))
+        stopped: list[str] = []
+        monkeypatch.setattr(rt, "stop_pod", lambda cc, n: stopped.append(n) or _cp())
+        rt.pin_checkout(c, "a", tmp_path / "co")
+        pod_cli._prune(c, self._ns())
+        out = capsys.readouterr().out
+        assert stopped == ["a", "b"]
+        assert not c.env_file("a").exists(), "the stale checkout pin must be cleared"
+        assert "pruned: 2 reclaimed, 0 kept, 0 skipped, 0 failed" in out
+
+    def test_older_than_keeps_the_young_orphan(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        c = self._plane(tmp_path, monkeypatch, ("old", "young"))
+        five_days = time.time() - 5 * 86400
+        os.utime(c.pod_root / "old", (five_days, five_days))
+        stopped: list[str] = []
+        monkeypatch.setattr(rt, "stop_pod", lambda cc, n: stopped.append(n) or _cp())
+        pod_cli._prune(c, self._ns(older_than="3d", prune_all=False))
+        out = capsys.readouterr().out
+        assert stopped == ["old"]
+        assert "1 reclaimed, 1 kept" in out
+
+    def test_liveness_is_rechecked_at_delete_time(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A name can go active between enumeration and its turn in the loop —
+        deleting under a live unit is the one unrecoverable outcome."""
+        c = self._plane(tmp_path, monkeypatch, ("woke-up",))
+        monkeypatch.setattr(rt, "is_active", lambda cc, n: True)
+        monkeypatch.setattr(
+            rt, "stop_pod", lambda cc, n: pytest.fail("stopped a live pod during prune")
+        )
+        pod_cli._prune(c, self._ns())
+        assert "pod is now active" in capsys.readouterr().out
+
+    def test_one_failure_does_not_abort_the_sweep(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Per-name results: a prune where one of two succeeded must say which,
+        keep going, and exit nonzero."""
+        c = self._plane(tmp_path, monkeypatch, ("bad", "good"))
+        monkeypatch.setattr(
+            rt,
+            "stop_pod",
+            lambda cc, n: _cp(returncode=1, stderr="still writing") if n == "bad" else _cp(),
+        )
+        with pytest.raises(SystemExit) as exc:
+            pod_cli._prune(c, self._ns())
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "still writing" in out
+        assert "1 reclaimed" in out and "1 failed" in out
+
+    def test_a_pod_error_on_one_name_is_contained(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        c = self._plane(tmp_path, monkeypatch, ("erroring", "fine"))
+
+        def _stop(cc: PodConfig, n: str) -> subprocess.CompletedProcess:
+            if n == "erroring":
+                raise rt.PodError("launchctl cannot answer")
+            return _cp()
+
+        monkeypatch.setattr(rt, "stop_pod", _stop)
+        with pytest.raises(SystemExit):
+            pod_cli._prune(c, self._ns())
+        out = capsys.readouterr().out
+        assert "launchctl cannot answer" in out
+        assert "1 reclaimed" in out
+
+    def test_a_name_reclaimed_by_a_new_pod_keeps_its_pin(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """RECLAIMED_MARKER means the env file now pins the NEW pod's checkout."""
+        c = self._plane(tmp_path, monkeypatch, ("handover",))
+        rt.pin_checkout(c, "handover", tmp_path / "co")
+        monkeypatch.setattr(rt, "stop_pod", lambda cc, n: _cp(stdout=rt.RECLAIMED_MARKER))
+        pod_cli._prune(c, self._ns())
+        assert c.env_file("handover").exists(), "a live pod's checkout pin must survive"
+        assert "claimed by a new pod" in capsys.readouterr().out
+
+    def test_macos_installed_plist_is_refused_at_delete_time(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The plist can be written by an `up` AFTER the orphan enumeration (which
+        already excludes installed names) — the delete-time recheck is what
+        stands between that pod and a bootout of its live service."""
+        c = self._plane(tmp_path, monkeypatch, ("mid-up",))
+        monkeypatch.setattr(rt, "IS_MACOS", True)
+        plist = tmp_path / "mid-up.plist"
+        plist.write_text("")
+        monkeypatch.setattr(rt.launchd, "plist_path", lambda cc, n: plist)
+        monkeypatch.setattr(
+            rt, "stop_pod", lambda cc, n: pytest.fail("booted-out an installed pod")
+        )
+        res = pod_cli._prune_one(c, "mid-up")
+        assert res["status"] == "skipped"
+        assert "pod is now installed" in res["detail"]
+
+    def test_json_shape_is_per_name_results(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        c = self._plane(tmp_path, monkeypatch, ("a",))
+        monkeypatch.setattr(rt, "stop_pod", lambda cc, n: _cp())
+        pod_cli._prune(c, self._ns(json=True))
+        rows = json.loads(capsys.readouterr().out)
+        assert rows == [{"name": "a", "status": "reclaimed", "detail": ""}]
+
+    def test_json_stays_valid_when_the_delete_path_prints(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """stop_pod/cleanup_home print diagnostics to stdout; interleaved with
+        the machine output they would corrupt the JSON document. They must be
+        rerouted to stderr, not swallowed."""
+        c = self._plane(tmp_path, monkeypatch, ("noisy",))
+
+        def _stop(cc: PodConfig, n: str) -> subprocess.CompletedProcess:
+            print("pod cleanup did not fully remove /x: still present")
+            return _cp(returncode=1, stderr="teardown incomplete")
+
+        monkeypatch.setattr(rt, "stop_pod", _stop)
+        with pytest.raises(SystemExit):
+            pod_cli._prune(c, self._ns(json=True))
+        captured = capsys.readouterr()
+        rows = json.loads(captured.out)  # the whole stdout must parse
+        assert rows[0]["status"] == "failed"
+        assert "still present" in captured.err
+
+    def test_a_refused_invocation_is_still_audited(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bulk-destructive verb that exits on a refusal (dead backend, bad
+        duration) must reach the audit trail — an unrecorded refused prune is
+        invisible to the log."""
+        c = self._plane(tmp_path, monkeypatch, ())
+        events: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            pod_cli, "_audit", lambda op, outcome, res="", error="": events.append((op, outcome))
+        )
+        with pytest.raises(rt.PodError):
+            pod_cli._prune(c, self._ns(older_than="banana", prune_all=False))
+        assert ("pod.prune", "denied") in events
+
+    def test_a_failed_enumeration_is_audited_before_the_refusal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        c = self._plane(tmp_path, monkeypatch, ())
+        events: list[str] = []
+        monkeypatch.setattr(
+            pod_cli, "_audit", lambda op, outcome, res="", error="": events.append(outcome)
+        )
+
+        def _boom(cc: PodConfig) -> list[str]:
+            raise rt.PodError("launchctl cannot enumerate")
+
+        monkeypatch.setattr(rt, "orphan_homes", _boom)
+        with pytest.raises(rt.PodError):
+            pod_cli._prune(c, self._ns())
+        assert "denied" in events
+
+    def test_every_prune_one_path_emits_exactly_one_audit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The audit is the single exit chokepoint of _prune_one: no decision
+        path — including the invalid-name refusal — may return without a SEL
+        event, and none may double-audit."""
+        c = self._plane(tmp_path, monkeypatch, ("plain",))
+        events: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            pod_cli, "_audit", lambda op, outcome, res="", error="": events.append((outcome, res))
+        )
+        scenarios: list[tuple[str, dict, str]] = [
+            ("invalid name", {}, "denied"),
+            ("active", {"is_active": lambda cc, n: True}, "denied"),
+            ("mid-restart", {"unit_state": lambda cc, n: ("activating", 1)}, "denied"),
+            ("stop fails", {"stop_pod": lambda cc, n: _cp(returncode=1, stderr="x")}, "failure"),
+            ("reclaimed", {"stop_pod": lambda cc, n: _cp()}, "allowed"),
+            (
+                "handover",
+                {"stop_pod": lambda cc, n: _cp(stdout=rt.RECLAIMED_MARKER)},
+                "allowed",
+            ),
+        ]
+        for label, patches, expected in scenarios:
+            # Re-pin the baseline before layering the scenario's patch, so a
+            # previous scenario's monkeypatch cannot leak forward.
+            monkeypatch.setattr(rt, "is_active", lambda cc, n: False)
+            monkeypatch.setattr(rt, "unit_state", lambda cc, n: ("inactive", 0))
+            for attr, fn in patches.items():
+                monkeypatch.setattr(rt, attr, fn)
+            events.clear()
+            name = "not a pod" if label == "invalid name" else "plain"
+            pod_cli._prune_one(c, name)
+            assert len(events) == 1, f"{label}: expected exactly one audit, got {events}"
+            assert events[0][0] == expected, f"{label}: outcome {events[0][0]} != {expected}"
+
+    def test_nothing_to_prune_says_so(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        c = self._plane(tmp_path, monkeypatch, ())
+        pod_cli._prune(c, self._ns())
+        assert "no orphaned pod HOMEs to prune" in capsys.readouterr().out
+
+    def test_prune_is_dispatchable(self) -> None:
+        assert pod_cli._VERBS["prune"] is pod_cli._prune
+
+    def test_a_bare_prune_keeps_a_fresh_crash_by_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """The CLI default is --older-than 3d: a bare `pod prune` must not
+        sweep the minutes-old crash HOME an operator is still debugging — its
+        logs are the only postmortem evidence. --all is the explicit opt-in."""
+        c = self._plane(tmp_path, monkeypatch, ("fresh",))
+        monkeypatch.setattr(rt, "stop_pod", lambda cc, n: pytest.fail("swept a fresh crash"))
+        pod_cli._prune(c, self._ns(prune_all=False))  # CLI defaults
+        assert "kept" in capsys.readouterr().out
+
+    def test_a_restarting_unit_is_refused_at_delete_time(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """During the Restart=on-failure backoff the unit is `activating` — not
+        active — so both the orphan scan and is_active miss it, and a stop here
+        would cancel the pending restart and delete a running pod's HOME."""
+        c = self._plane(tmp_path, monkeypatch, ("mid-backoff",))
+        monkeypatch.setattr(rt, "unit_state", lambda cc, n: ("activating", 1))
+        monkeypatch.setattr(
+            rt, "stop_pod", lambda cc, n: pytest.fail("cancelled a pending restart")
+        )
+        pod_cli._prune(c, self._ns())
+        assert "mid-transition or restarting" in capsys.readouterr().out
+
+    def test_a_crash_looping_unit_is_refused_even_when_terminal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """restarts>0 means the service manager is still involved with this
+        name — fail closed and leave it to an explicit `pod down`."""
+        c = self._plane(tmp_path, monkeypatch, ("crashy",))
+        monkeypatch.setattr(rt, "unit_state", lambda cc, n: ("failed", 2))
+        monkeypatch.setattr(rt, "stop_pod", lambda cc, n: pytest.fail("reclaimed a managed unit"))
+        pod_cli._prune(c, self._ns())
+        assert "not orphaned" in capsys.readouterr().out
+
+    def test_an_unknown_unit_state_fails_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        c = self._plane(tmp_path, monkeypatch, ("murky",))
+        monkeypatch.setattr(rt, "unit_state", lambda cc, n: ("unknown", 0))
+        monkeypatch.setattr(rt, "stop_pod", lambda cc, n: pytest.fail("deleted on no evidence"))
+        pod_cli._prune(c, self._ns())
+        assert "skipped" in capsys.readouterr().out
+
+    def test_an_os_error_on_one_name_is_contained(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Raw filesystem/subprocess failures (not just PodError) must become a
+        per-name failed row — an escaped exception would hide every result
+        already earned and strand the remaining orphans unprocessed."""
+        c = self._plane(tmp_path, monkeypatch, ("cursed", "fine"))
+
+        def _stop(cc: PodConfig, n: str) -> subprocess.CompletedProcess:
+            if n == "cursed":
+                raise PermissionError("env dir is read-only")
+            return _cp()
+
+        monkeypatch.setattr(rt, "stop_pod", _stop)
+        with pytest.raises(SystemExit):
+            pod_cli._prune(c, self._ns())
+        out = capsys.readouterr().out
+        assert "env dir is read-only" in out
+        assert "1 reclaimed" in out
+
+    def test_dry_run_classifies_without_deleting(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        c = self._plane(tmp_path, monkeypatch, ("a", "b"))
+        (c.pod_root / "not a pod").mkdir()  # invalid name: same verdict as a real run
+        monkeypatch.setattr(rt, "stop_pod", lambda cc, n: pytest.fail("dry run deleted"))
+        pod_cli._prune(c, self._ns(dry_run=True))
+        out = capsys.readouterr().out
+        assert "would-reclaim" in out
+        assert "not a valid pod name" in out, "preview must match the real run's classification"
+        assert "dry run: 2 would be reclaimed" in out
+        assert (c.pod_root / "a").exists() and (c.pod_root / "b").exists()
+
+    def test_a_stray_non_pod_directory_is_skipped_by_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A directory that fails validate_name can never have a unit and can
+        never be reclaimed by `down`; shelling a bogus systemctl stop for it
+        would report failed and pin every future prune's exit at 1."""
+        c = self._plane(tmp_path, monkeypatch, ())
+        (c.pod_root / "not a pod").mkdir(parents=True)
+        monkeypatch.setattr(rt, "stop_pod", lambda cc, n: pytest.fail("stopped a bogus unit"))
+        pod_cli._prune(c, self._ns())
+        assert "not a valid pod name" in capsys.readouterr().out
+
+    def test_backend_absent_is_one_refusal_not_n_failures(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without a usable service manager the sweep must refuse once (the
+        documented one-line `pod:` error), not report N stuck HOMEs."""
+        c = self._plane(tmp_path, monkeypatch, ("a", "b"))
+
+        def _absent() -> None:
+            raise rt.PodBackendAbsent("no session bus")
+
+        monkeypatch.setattr(rt, "require_backend", _absent)
+        with pytest.raises(rt.PodError):
+            pod_cli._prune(c, self._ns())
+
+    def test_older_than_measures_activity_not_creation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A pod created 5 days ago that crashed 10 minutes ago is the orphan
+        being debugged — its fresh log write must keep it, even though the HOME
+        directory's own mtime froze at creation."""
+        c = self._plane(tmp_path, monkeypatch, ("fresh-crash",))
+        home = c.pod_root / "fresh-crash"
+        (home / "logs").mkdir()
+        (home / "logs" / "gateway.log").write_text("boom")  # fresh mtime (now)
+        five_days = time.time() - 5 * 86400
+        os.utime(home / "logs", (five_days, five_days))
+        os.utime(home, (five_days, five_days))
+        monkeypatch.setattr(rt, "stop_pod", lambda cc, n: pytest.fail("reclaimed a fresh crash"))
+        pod_cli._prune(c, self._ns(older_than="3d", prune_all=False))
+        assert "kept" in capsys.readouterr().out
+
+
+class TestOrphanSymlinkSafety:
+    """A symlink under pod_root can point at a LIVE pod's HOME (or anywhere);
+    following it — in the enumeration or at the delete chokepoint — turns a
+    bulk reclaim into deleting a directory that was never an orphan."""
+
+    def test_orphan_homes_never_lists_a_symlink(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        c = PodConfig.load()
+        (c.pod_root / "live").mkdir(parents=True)
+        (c.pod_root / "alias").symlink_to(c.pod_root / "live")
+        monkeypatch.setattr(rt, "active_names", lambda cc: {"live"})
+        assert rt.orphan_homes(c) == []
+
+    def test_cleanup_home_refuses_to_follow_a_symlink(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        c = PodConfig.load()
+        victim = c.pod_root / "live"
+        victim.mkdir(parents=True)
+        (victim / "sessions.db").write_text("precious")
+        (c.pod_root / "alias").symlink_to(victim)
+        assert rt.cleanup_home(c, "alias") == 2
+        assert (victim / "sessions.db").exists(), "followed the link and deleted the target"
+        assert "symlink" in capsys.readouterr().out
+
+    def test_cleanup_home_deletes_by_name_never_by_resolved_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The symlink pre-check can be raced (entry swapped to a symlink
+        between check and delete). What makes that race harmless is that
+        rmtree receives the UNRESOLVED name — stdlib rmtree refuses a
+        top-level symlink — never the resolved path, which at swap time is
+        the live sibling the link points at. Pin the argument."""
+        real = tmp_path / "real-pods"
+        real.mkdir()
+        (tmp_path / "pods").symlink_to(real)  # unresolved != resolved spelling
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        c = PodConfig.load()
+        (c.pod_root / "demo").mkdir()
+        seen: list[Path] = []
+        monkeypatch.setattr(
+            rt.shutil, "rmtree", lambda p, ignore_errors=False: seen.append(Path(p))
+        )
+        rt.cleanup_home(c, "demo")
+        assert seen == [c.pod_root / "demo"], "rmtree must get the unresolved name"
+        assert seen[0] != (c.pod_root / "demo").resolve(), "test setup lost the distinction"
+
+    def test_a_dangling_symlink_swap_is_reported_not_swallowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """rmtree refuses a symlink SILENTLY under ignore_errors, and a
+        DANGLING link's resolved target does not exist — so verifying by
+        target existence would report a clean reclaim while the link remains
+        as residue the orphan scan (which skips symlinks) can never surface
+        again. The verification must be lexists on the entry itself."""
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        c = PodConfig.load()
+        entry = c.pod_root / "swapped"
+        entry.mkdir(parents=True)  # a real dir at pre-check time
+
+        def _swap_then_refuse(p, ignore_errors=False):
+            # Net effect of the worst-case interleaving: by the time rmtree
+            # runs, the entry is a dangling symlink, which rmtree refuses
+            # (silently, under ignore_errors).
+            entry.rmdir()
+            entry.symlink_to(c.pod_root / "gone")
+
+        monkeypatch.setattr(rt.shutil, "rmtree", _swap_then_refuse)
+        rc = rt.cleanup_home(c, "swapped")
+        assert rc == 1, "a surviving entry must be a reported failure, never rc 0"
+        assert "symlink" in capsys.readouterr().out
 
 
 class TestDownSamplesStateUnderTheLock:


### PR DESCRIPTION
# What is the problem?

`pod ls` reports orphaned pod HOMEs — directories left under the pod root by a pod that went away without an explicit `down` (a crash, a raw service stop, a reboot) — but gives the operator nothing to act on them at scale. There is no age on each orphan (a HOME abandoned five minutes ago looks identical to one abandoned three weeks ago), and no bulk reclaim: cleaning N orphans means hand-typing N `pod down` commands.

# Why this issue matters to the user

Nothing bounds orphan growth. Each HOME carries a full isolated gateway state (venv-adjacent data, sessions, logs), so on an active dev machine they silently accumulate into gigabytes. The operator either ignores them or does tedious one-by-one reclaims — and has no signal for distinguishing a stale HOME from a crash they are actively debugging.

# How our fix solves it

Symptom → root cause → change:

- **No age signal** → `_print_orphans` printed only names → `pod ls` now shows a relative age per orphan ("3d ago"). The age comes from a bounded two-level newest-mtime scan (`_orphan_last_alive`), not the HOME directory's own mtime — a directory's mtime freezes at creation, which would have aged a freshly-crashed pod as its boot date.
- **No bulk reclaim** → no verb existed → new `kirocrew pod prune [--older-than Nd|Nh|Nm|Ns] [--dry-run] [--json]`. Every delete routes through `stop_pod` (the established stop → drain → delete → verify path), never `cleanup_home` directly, preserving the teardown-safety property that removing the post-stop hook established. Results are per-name (a prune where 3 of 9 succeeded says which 3), one bad name never aborts the sweep, and the exit code is nonzero only on real failures.
- **Deleting under a live unit** (the one unrecoverable outcome) is closed at delete time, under the per-name lifecycle mutex, with checks stricter than the enumeration: a unit in the `Restart=on-failure` backoff window reports `activating` — invisible to both the orphan scan and `is-active` — so `_prune_one` requires a terminal `unit_state` (`inactive`/`failed`, zero restarts) and fails closed on anything else, including `unknown`. On macOS the plist-presence recheck covers a name mid-`up`.
- **Symlinks under the pod root** are refused end-to-end: `orphan_homes` never enumerates one, `cleanup_home` refuses a symlinked name outright, and the final `rmtree` receives the unresolved name (stdlib `rmtree` refuses a top-level symlink), so even an entry swapped to a symlink between check and delete deletes nothing.
- `pod ls --json` stays byte-identical (three external callers); `prune --json` has its own per-name result shape. Every per-name delete decision and each prune invocation emits a SEL audit event.

# What tests we did

- 25 new tests in `test/test_pod.py`: prune-through-`stop_pod`-only (a direct `cleanup_home` call fails the test), `--older-than` filtering by activity (a 5-day-old HOME with a 10-minute-old log write is kept), delete-time refusals (active, `activating` backoff, crash-looping, `unknown` state, macOS plist, `RECLAIMED_MARKER` keeps the new pod's env pin), per-name containment for `PodError`/`OSError` with the sweep continuing and exiting 1, `--dry-run` deletes nothing, stray non-pod names skipped, backend-absent is one refusal not N failures, symlink enumeration/refusal/delete-by-name ratchet, duration parser accept/reject table, relative-age table, JSON shapes (`ls --json` unchanged, `prune --json` per-name rows).
- Full local gates green at pinned CI versions (isort 6.0.0, flake8 7.1.0, mypy 1.14.1): pytest full suite delta vs an unmodified-main baseline is empty after isolated reruns (remaining failures reproduced identically on base; a mid-run `ENOSPC` storm on the shared host was ruled out by a clean re-run).
- Two model-pinned pre-push reviews (GPT + Opus contracts) found 2 blocking + 5 advisory findings; all fixed, then a focused verifier confirmed each closed, including a residual check-to-use race it caught in the first symlink fix.

# Any other suggestions on the work

- `unit_state`-based liveness could also harden `pod down` against the same `activating` window; left out to keep this PR scoped to the new verb (down is an explicit, single-name operator action).
- Manual verification beyond unit tests: N/A — pod units are Linux `systemd --user`; every safety decision point is exercised by tests through the same seams the runtime uses, and this host's live pods were not touched.

Closes #2567
