### PR TITLE
fix(sandbox): drop inherited fds in the userns probe child

### DIFF
--- a/src/kiro_crew/gateway_lock.py
+++ b/src/kiro_crew/gateway_lock.py
@@ -25,12 +25,16 @@ The cost of that choice is the other half of the same property. ``fork()`` share
 one description between parent and child, so a forked child that inherits this fd
 keeps the lock alive after the parent dies. A child that wedges before ``exec``
 therefore pins the home: every later start is refused, and the pid recorded in
-the file names a process that no longer exists. This occurs when ``preexec_fn``
-forces a plain ``fork()`` of the multi-threaded gateway in
-:mod:`kiro_crew.kiro_prerequisite`.
+the file names a process that no longer exists.
 
-The remedy is to stop creating such children, not to weaken this guard;
-``_run_process`` therefore does not use ``preexec_fn``. What this
+The remedy is to stop creating such children, not to weaken this guard, so every
+plain ``fork()`` inside the gateway either avoids inheriting this fd or drops it
+before it can wedge. ``_run_process`` does not use ``preexec_fn`` (which would
+force a plain ``fork()`` of the multi-threaded gateway). The sandbox availability
+probe in :mod:`kiro_crew.sandbox` does fork a short-lived child to test
+``unshare``, but that child closes every inherited descriptor — this fd, and the
+dashboard listen socket, included — before it touches the namespace, so it can no
+longer pin the home even if it is orphaned. What this
 module owes the operator meanwhile is an honest refusal: it resolves the process
 that ACTUALLY holds the lock from ``/proc/*/fd`` rather than quoting the pid in
 the file, reports what that process looks like, and names the reclaim command


### PR DESCRIPTION
## What

The Linux user-namespace availability probe (`_probe_unshare_once`) forks a plain child that **never execs**, so `O_CLOEXEC` never fires and the child inherits a live copy of every descriptor the gateway held open at fork time — including the `gateway.lock` flock fd and the dashboard listen socket.

Because an `flock` lives on the open file *description*, an orphaned probe child that outlives a crashed parent keeps that description open and **pins `KIROCREW_HOME`**: every later `kirocrew gateway` start is refused, and the pid recorded in the lock file names a process that no longer exists. The retained socket copy likewise keeps the dashboard port bound.

Fixes #3150.

## Fix

`_probe_child_sequence` now calls a new `_close_inherited_fds_except(c2p_w, p2c_r)` before it touches libc/`unshare`: an async-signal-safe `os.closerange` sweep that drops every inherited descriptor except stdio and the two handshake pipes the child still needs. This severs both the lock-fd and listen-socket leaks — something `O_CLOEXEC` cannot do for a child that never execs. Only `os.closerange` runs in the child, so it is safe even when the fork happens on the multi-threaded gateway's background warm thread.

The parent-side `_close_probe_fds` cleanup is unchanged. The `gateway_lock.py` module docstring is updated to record that the probe child now drops these fds.

## Test

`test/test_sandbox_probe.py::TestProbeChildDropsInheritedLockFd` reproduces the leak: it acquires the home lock, forks a real probe child that (with `unshare` stubbed) runs past the fd-close and then blocks — genuinely outliving the parent — then simulates the holder crashing (closes the fd *without* `LOCK_UN`) and asserts a fresh `GatewayLock(home).acquire()` succeeds. The lock fd is deliberately a lower number than any probe pipe, so a fix that closed only pipe-adjacent fds would still fail this test.

- `python -m pytest test/test_sandbox_probe.py` → 33 passed
- `python -m pytest test/test_gateway_lock.py` → 9 passed