### PR TITLE
perf(embeddings): pin llama.cpp threads and prioritize interactive embeds

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1609,6 +1609,18 @@ class MemoryConfig:
         default=1024,
         metadata=_meta("Embedding Dimension", "Dimensionality of embedding vectors."),
     )
+    embedding_threads: int = field(
+        default=4,
+        metadata=_meta(
+            "Embedding Threads",
+            "CPU threads llama.cpp may use per embedding call. Left unset, llama.cpp "
+            "sizes its batch pool from the host core count, so even a few-token embed "
+            "fans out across every core and competes with the rest of the gateway. "
+            "Embedding a short query does not need many threads; raise this only if "
+            "bulk re-embedding throughput matters more than interactive latency. "
+            "Clamped to the machine's core count.",
+        ),
+    )
     embed_model_url: str = field(
         default="",
         metadata=_meta(
@@ -5597,6 +5609,7 @@ class KiroCrewConfig:
                     memory_data.get("embedding_provider", "llama_cpp")
                 ),
                 embedding_dim=memory_data.get("embedding_dim", 1024),
+                embedding_threads=_safe_int(memory_data.get("embedding_threads", 4), 4, 1, 256),
                 embed_model_url=memory_data.get("embed_model_url", ""),
                 embed_model_path=memory_data.get("embed_model_path", ""),
                 embed_model_id=memory_data.get("embed_model_id", ""),

--- a/src/kiro_crew/embeddings.py
+++ b/src/kiro_crew/embeddings.py
@@ -50,6 +50,7 @@ from typing import Callable, NamedTuple, Protocol
 
 from kiro_crew.config.loader import config_path
 from kiro_crew.config.paths import config_dir
+from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.security import is_sensitive_path
 
 logger = logging.getLogger(__name__)
@@ -108,6 +109,28 @@ _LLM_LOAD_RETRY_SECS = 300.0  # re-attempt a failed model load after this long
 # exit. Bounded so an unload never wedges a shutdown; the thread is a daemon, so
 # a straggler cannot hold the interpreter open either.
 _INFER_STOP_TIMEOUT_SECS = 30.0
+# llama.cpp sizes its compute pools from the HOST CPU COUNT when the caller does
+# not pass them: n_threads = cpu//2 and n_threads_batch = cpu (see the vendored
+# llama.py). Embedding is prompt processing, so it runs on the BATCH pool — on a
+# 16-core host EVERY embed, even an 8-character one, fanned out across all 16
+# cores and measured ~4.5 cores sustained inside the gateway. A 0.6B model over
+# short text does not need that, and oversubscribing the box makes the pool both
+# suffer and cause contention. Pinned low here, overridable via
+# memory.embedding_threads.
+_DEFAULT_EMBED_THREADS = 4
+# Only log an embed's queue wait at INFO once it is long enough for a waiting
+# caller to notice; below this it stays DEBUG so ordinary memory writes do not
+# emit a line each.
+_EMBED_WAIT_LOG_MS = 250.0
+# Scheduling classes for the shared inference queue. The whole process shares ONE
+# model on ONE thread, so a bulk corpus sweep and a user's query compete for the
+# same single slot: without ordering, a short interactive embed waits behind
+# however much background work happens to be queued. Lower value wins.
+PRIORITY_INTERACTIVE = 0  # a human is blocked on this (prompt build, search box)
+PRIORITY_NORMAL = 1  # bounded explicit write (one lesson, one preference)
+PRIORITY_BULK = 2  # corpus loops: backfill, migration, ingestion, consolidation
+# Shutdown outranks everything so close() is not stuck behind a queued sweep.
+_PRIORITY_SENTINEL = -1
 
 # ── Download constants ──
 
@@ -382,6 +405,86 @@ def _read_memory_config() -> dict:
     except Exception:
         logger.debug("Could not read the memory config section", exc_info=True)
     return {}
+
+
+def _embed_threads() -> int:
+    """Thread count for llama.cpp's embedding compute pools.
+
+    Read from the RAW ``memory`` config section for the same reason the rest of
+    this module does: the download thread and the backend factory must not pull
+    in the full config dataclass import graph. Clamped to ``[1, cpu_count]`` so a
+    typo cannot hand llama.cpp a zero, a negative, or a count far above the
+    machine's cores.
+    """
+    raw = _read_memory_config().get("embedding_threads")
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+        raw = _DEFAULT_EMBED_THREADS
+    return max(1, min(raw, os.cpu_count() or _DEFAULT_EMBED_THREADS))
+
+
+def _chars_bucket(chars: int) -> str:
+    """Low-cardinality size band for the inference metric.
+
+    Bucketed rather than raw so the metric can separate a short interactive query
+    from a bulk consolidation block without an unbounded attribute domain.
+    """
+    for bound in (128, 512, 2000, 6000):
+        if chars <= bound:
+            return f"<={bound}"
+    return ">6000"
+
+
+def _emit_embed_timing(
+    t0: float,
+    t_started: float,
+    texts: "list[str]",
+    *,
+    priority: int = PRIORITY_NORMAL,
+    failed: bool = False,
+) -> None:
+    """Report queue wait and model time separately for one embed call.
+
+    The split is the point. ``infer_ms`` is the model's own cost. ``wait_ms`` is
+    this call blocked on the queue while ANOTHER caller's embed ran, because the
+    whole process is serialized onto one model on one inference thread. A short
+    interactive embed reporting a large ``wait_ms`` is therefore not slow, it is
+    queued behind bulk background work — and that is a different defect with a
+    different fix than slow inference.
+    """
+    now = time.monotonic()
+    # Clamped: monotonic makes a negative value impossible on the real path, but a
+    # negative sample is silently REJECTED by the recorder (losing the datapoint)
+    # and logs a warning, so a clock edge case must not cost us the measurement.
+    wait_ms = max(0.0, (t_started - t0) * 1000.0)
+    infer_ms = max(0.0, (now - t_started) * 1000.0)
+    chars = sum(len(t) for t in texts)
+    # BULK stays at DEBUG however long it waited. Being preempted is the DESIGNED
+    # outcome for a corpus sweep, not news, and a migration preempted row-by-row
+    # would otherwise emit thousands of INFO lines and bury the interactive ones
+    # this log exists to surface.
+    reportable = wait_ms >= _EMBED_WAIT_LOG_MS and priority != PRIORITY_BULK
+    level = logging.INFO if reportable else logging.DEBUG
+    logger.log(
+        level,
+        "Embed timing: wait=%.0fms infer=%.0fms n=%d chars=%d prio=%d%s",
+        wait_ms,
+        infer_ms,
+        len(texts),
+        chars,
+        priority,
+        " FAILED" if failed else "",
+    )
+    try:
+        recorder = get_recorder()
+        recorder.histogram("kirocrew.embed.queue_wait", wait_ms, unit="ms")
+        recorder.histogram(
+            "kirocrew.embed.inference",
+            infer_ms,
+            unit="ms",
+            attrs={"chars_bucket": _chars_bucket(chars)},
+        )
+    except Exception:
+        logger.debug("Embed timing metric emission failed", exc_info=True)
 
 
 class CustomModelSpec(NamedTuple):
@@ -880,12 +983,18 @@ class EmbeddingBackend(abc.ABC):
         """True when the backend can produce vectors right now (model loaded)."""
 
     @abc.abstractmethod
-    def embed(self, text: str) -> "list[float] | None":
-        """Embed a single text. Returns None on any failure."""
+    def embed(self, text: str, *, priority: int = PRIORITY_NORMAL) -> "list[float] | None":
+        """Embed one text, or None when unavailable.
+
+        *priority* orders competing callers on the shared model (``PRIORITY_*``).
+        Implementations that do not queue may ignore it.
+        """
 
     @abc.abstractmethod
-    def embed_batch(self, texts: "list[str]") -> "list[list[float]] | None":
-        """Embed multiple texts. Returns None on any failure."""
+    def embed_batch(
+        self, texts: "list[str]", *, priority: int = PRIORITY_NORMAL
+    ) -> "list[list[float]] | None":
+        """Embed several texts, or None when unavailable. See :meth:`embed`."""
 
     @abc.abstractmethod
     def close(self) -> None:
@@ -898,7 +1007,7 @@ class EmbeddingBackend(abc.ABC):
 class _InferJob:
     """One ``create_embedding`` call handed to the embedder's worker thread."""
 
-    __slots__ = ("llm", "texts", "result", "error", "done")
+    __slots__ = ("llm", "texts", "result", "error", "done", "started")
 
     def __init__(self, llm: object, texts: "list[str]") -> None:
         self.llm = llm
@@ -906,6 +1015,9 @@ class _InferJob:
         self.result: object | None = None
         self.error: BaseException | None = None
         self.done = threading.Event()
+        # Set by the worker once it actually begins inference, so the caller can
+        # separate time spent QUEUED from time spent in the model.
+        self.started: float = 0.0
 
 
 class LlamaCppEmbedder(EmbeddingBackend):
@@ -953,9 +1065,28 @@ class LlamaCppEmbedder(EmbeddingBackend):
         self._lock = threading.Lock()  # serializes inference (Llama is not thread-safe)
         self._load_lock = threading.Lock()  # guards loader-thread spawn state
         self._load_thread: threading.Thread | None = None
-        # Single owned inference thread + its job queue (see the class docstring).
-        self._jobs: "queue.SimpleQueue[_InferJob | None]" = queue.SimpleQueue()
+        # Single owned inference thread + its PRIORITY job queue (see the class
+        # docstring). Items are ``(priority, seq, job)``. ``seq`` is a strictly
+        # increasing tiebreaker, which makes the ordering stable — equal
+        # priorities stay FIFO — and also means the heap never has to compare two
+        # _InferJob objects, which are not orderable.
+        self._jobs: "queue.PriorityQueue[tuple[int, int, _InferJob | None]]" = queue.PriorityQueue()
+        self._seq = 0
+        self._seq_lock = threading.Lock()
+        # Guards the DISPATCH state — (_infer_thread, _jobs) selection, worker
+        # spawn, and the enqueue — as one atomic step. Deliberately NOT _lock:
+        # the worker holds _lock across inference, so enqueueing under it would
+        # block every submitter behind the in-flight embed and put at most one
+        # job in the queue, which is exactly the condition that made priority
+        # meaningless before. Held only for a heap push, never across inference,
+        # a join, or a model load.
+        self._dispatch_lock = threading.Lock()
         self._infer_thread: threading.Thread | None = None
+
+    def _next_seq(self) -> int:
+        with self._seq_lock:
+            self._seq += 1
+            return self._seq
 
     @property
     def model_path(self) -> Path:
@@ -1044,6 +1175,7 @@ class LlamaCppEmbedder(EmbeddingBackend):
             return
         try:
             started = time.monotonic()
+            threads = _embed_threads()
             llm = llama_cls(
                 model_path=str(self._model_path),
                 embedding=True,
@@ -1051,6 +1183,12 @@ class LlamaCppEmbedder(EmbeddingBackend):
                 n_ctx=_N_CTX,
                 n_batch=_N_CTX,
                 n_ubatch=_N_CTX,
+                # Both pools are pinned. Embedding is prompt processing, so the
+                # BATCH pool is the one that actually runs, but leaving the
+                # generation pool at llama.cpp's cpu//2 default would still size
+                # a second oversubscribed pool on this thread.
+                n_threads=threads,
+                n_threads_batch=threads,
                 verbose=False,
             )
             # Validate the model's REAL output width against the configured dim
@@ -1138,7 +1276,7 @@ class LlamaCppEmbedder(EmbeddingBackend):
             logger.debug("Could not probe embedding dim", exc_info=True)
             return None
 
-    def _infer_loop(self, jobs: "queue.SimpleQueue[_InferJob | None]") -> None:
+    def _infer_loop(self, jobs: "queue.PriorityQueue[tuple[int, int, _InferJob | None]]") -> None:
         """Worker body: run queued ``create_embedding`` calls, one at a time.
 
         ``jobs`` is passed in rather than read from ``self`` so this worker is
@@ -1150,55 +1288,120 @@ class LlamaCppEmbedder(EmbeddingBackend):
         waiting on ``job.done``. ``None`` is the shutdown sentinel from
         :meth:`close`; exiting the thread is what releases llama.cpp's compute
         pool.
+
+        This worker — NOT the caller — holds ``_lock`` across inference. That is
+        what lets the queue's priority mean anything: while the caller held it,
+        every other caller blocked *before* it could enqueue, so at most one job
+        was ever queued and there was nothing to order. Serialization is
+        unchanged, because a single owner thread running under ``_lock`` is
+        strictly no more concurrent than a single caller holding it was.
         """
         while True:
-            job = jobs.get()
+            _prio, _seq, job = jobs.get()
             if job is None:
+                # close() has already dropped the model. Anything queued behind
+                # the sentinel would otherwise wait on job.done forever, since
+                # no worker will serve this queue again — fail them explicitly.
+                self._drain_orphans(jobs)
                 return
             try:
-                job.result = job.llm.create_embedding(job.texts)  # type: ignore[attr-defined]
+                with self._lock:
+                    job.started = time.monotonic()
+                    job.result = job.llm.create_embedding(job.texts)  # type: ignore[attr-defined]
             except BaseException as exc:  # noqa: BLE001 - relayed to the caller verbatim
                 job.error = exc
             finally:
                 job.done.set()
 
-    def _create_embedding(self, llm: object, texts: "list[str]") -> object:
-        """Run one ``create_embedding`` on the owned thread; re-raise its error.
+    @staticmethod
+    def _drain_orphans(
+        jobs: "queue.PriorityQueue[tuple[int, int, _InferJob | None]]",
+    ) -> None:
+        """Fail every job left on a retired queue so no caller waits forever."""
+        while True:
+            try:
+                _prio, _seq, job = jobs.get_nowait()
+            except queue.Empty:
+                return
+            if job is None:
+                continue
+            job.error = RuntimeError("embedding backend closed before this job ran")
+            job.done.set()
 
-        Caller must hold ``_lock``, which keeps at most one job in flight.
-        The wait is unbounded, matching the previous inline call — a wedged
-        native inference blocked the caller then too.
+    def _submit_infer(
+        self, llm: object, texts: "list[str]", priority: int = PRIORITY_NORMAL
+    ) -> "_InferJob":
+        """Queue one inference for the owned thread and wait for the job to finish.
+
+        Returns the completed job rather than its result, so the caller can read
+        ``job.started`` and tell queue wait apart from model time. Errors are
+        left ON the job; :meth:`_create_embedding` is the raising wrapper.
+
+        The caller does NOT hold ``_lock`` — the worker takes it around the
+        actual inference — so several callers can have work queued at once and
+        *priority* decides who the single model serves next. The wait is
+        unbounded, matching the previous inline call: a wedged native inference
+        blocked the caller then too.
         """
-        thread = self._infer_thread
-        if thread is None or not thread.is_alive():
-            # New worker, new queue. A straggler left behind by a timed-out
-            # close() join keeps draining its OWN queue, so it can neither
-            # consume this worker's jobs nor eat this worker's future sentinel.
-            self._jobs = queue.SimpleQueue()
-            thread = threading.Thread(
-                target=self._infer_loop, args=(self._jobs,), name="kc-embed-infer", daemon=True
-            )
-            self._infer_thread = thread
-            thread.start()
-        jobs = self._jobs
         job = _InferJob(llm, texts)
-        jobs.put(job)
+        with self._dispatch_lock:
+            # Retirement check, worker selection/spawn and the enqueue are ONE
+            # atomic step. Split, they lose two ways: two callers racing an
+            # absent worker each spawn one and orphan the loser's thread, and a
+            # close() landing between the worker check and the enqueue puts the
+            # job on a queue no worker will ever serve, so job.done is never set
+            # and the caller blocks forever on an unbounded wait.
+            if self._closed or not self._serving or llm is not self._llm:
+                # The backend was retired or swapped while this call was in
+                # flight. Fail the job here rather than queueing it into a space
+                # nothing will drain; embed_batch turns this into None, which is
+                # the ABC's documented "no embedding available".
+                job.error = RuntimeError("embedding backend retired before this job was queued")
+                job.done.set()
+                return job
+            thread = self._infer_thread
+            if thread is None or not thread.is_alive():
+                # New worker, new queue. A straggler left behind by a timed-out
+                # close() join keeps draining its OWN queue, so it can neither
+                # consume this worker's jobs nor eat this worker's future sentinel.
+                self._jobs = queue.PriorityQueue()
+                thread = threading.Thread(
+                    target=self._infer_loop,
+                    args=(self._jobs,),
+                    name="kc-embed-infer",
+                    daemon=True,
+                )
+                self._infer_thread = thread
+                thread.start()
+            self._jobs.put((priority, self._next_seq(), job))
+        # Wait OUTSIDE the lock: the wait is unbounded, and holding the dispatch
+        # lock across it would serialize every submitter behind this one job.
         job.done.wait()
+        return job
+
+    def _create_embedding(
+        self, llm: object, texts: "list[str]", priority: int = PRIORITY_NORMAL
+    ) -> object:
+        """Run one ``create_embedding`` on the owned thread; re-raise its error."""
+        job = self._submit_infer(llm, texts, priority)
         if job.error is not None:
             raise job.error
         return job.result
 
-    def embed(self, text: str) -> list[float] | None:
+    def embed(self, text: str, *, priority: int = PRIORITY_NORMAL) -> list[float] | None:
         """Embed a single text. Returns None on any failure."""
-        result = self.embed_batch([text])
+        result = self.embed_batch([text], priority=priority)
         return result[0] if result else None
 
-    def embed_batch(self, texts: list[str]) -> list[list[float]] | None:
+    def embed_batch(
+        self, texts: list[str], *, priority: int = PRIORITY_NORMAL
+    ) -> list[list[float]] | None:
         """Embed multiple texts. Returns None on any failure (incl. model not loaded yet).
 
         Never blocks on the model load: when the model isn't in memory yet this
-        kicks a background load and returns ``None`` immediately. Inference on a
-        loaded model is serialized behind ``_lock`` (tens of ms per short text).
+        kicks a background load and returns ``None`` immediately. Inference is
+        serialized onto one owned thread; *priority* decides the order that
+        single model serves competing callers (see ``PRIORITY_*``).
         """
         if not texts or not any(t.strip() for t in texts):
             return None
@@ -1216,13 +1419,26 @@ class LlamaCppEmbedder(EmbeddingBackend):
                 logger.debug("Truncating embed input %d -> %d chars", len(t), _MAX_EMBED_CHARS)
                 t = t[:_MAX_EMBED_CHARS]
             clipped.append(t)
-        with self._lock:
-            try:
-                resp = self._create_embedding(llm, clipped)
-                vectors = [item["embedding"] for item in resp["data"]]  # type: ignore[index]
-            except Exception:
-                logger.debug("In-process embed failed", exc_info=True)
-                return None
+        _t0 = time.monotonic()
+        job = self._submit_infer(llm, clipped, priority)
+        # started==0 means the worker never reached inference (drained orphan).
+        _started = job.started or time.monotonic()
+        if job.error is not None:
+            if not isinstance(job.error, Exception):
+                # BaseException (KeyboardInterrupt/SystemExit) is relayed to the
+                # caller verbatim, as it was when the call ran inline.
+                _emit_embed_timing(_t0, _started, clipped, priority=priority, failed=True)
+                raise job.error
+            logger.debug("In-process embed failed", exc_info=job.error)
+            _emit_embed_timing(_t0, _started, clipped, priority=priority, failed=True)
+            return None
+        try:
+            vectors = [item["embedding"] for item in job.result["data"]]  # type: ignore[index]
+        except Exception:
+            logger.debug("In-process embed failed", exc_info=True)
+            _emit_embed_timing(_t0, _started, clipped, priority=priority, failed=True)
+            return None
+        _emit_embed_timing(_t0, _started, clipped, priority=priority)
         if len(vectors) != len(clipped) or not vectors or not vectors[0]:
             logger.warning(
                 "Unexpected embedding response (got %d vectors for %d texts)",
@@ -1281,15 +1497,25 @@ class LlamaCppEmbedder(EmbeddingBackend):
             self._llm = None
             self._load_failed_at = 0.0
             self._load_thread = None
-            thread, self._infer_thread = self._infer_thread, None
-            if thread is not None and thread.is_alive():
-                # Holding _lock means no job can be queued behind this sentinel.
-                # If the join times out, the straggler stays parked on THIS
-                # queue, which the next worker will not share (see
-                # _create_embedding), so the sentinel it eventually consumes is
-                # still its own.
-                self._jobs.put(None)
-                thread.join(_INFER_STOP_TIMEOUT_SECS)
+            # Same lock the submitters use, so a retirement can never interleave
+            # with a dispatch: a caller either enqueues onto a live worker before
+            # this runs, or sees the retired state and fails fast.
+            with self._dispatch_lock:
+                thread, self._infer_thread = self._infer_thread, None
+                # Retire the queue at the same time as the thread, so a late caller
+                # cannot enqueue onto a queue that is shutting down.
+                jobs, self._jobs = self._jobs, queue.PriorityQueue()
+                if thread is not None and thread.is_alive():
+                    # The sentinel outranks queued work, so a large sweep already
+                    # in the queue cannot delay shutdown. The worker fails
+                    # anything still queued on its way out (_drain_orphans)
+                    # rather than leaving a caller waiting on job.done.
+                    jobs.put((_PRIORITY_SENTINEL, self._next_seq(), None))
+        # Join OUTSIDE _lock. The WORKER now holds _lock around inference, so
+        # joining while holding it would deadlock against a job that was dequeued
+        # just before the sentinel until the timeout expired.
+        if thread is not None and thread.is_alive():
+            thread.join(_INFER_STOP_TIMEOUT_SECS)
 
 
 _shared_embedder: EmbeddingBackend | None = None
@@ -1770,6 +1996,13 @@ def make_sync_embed_fn() -> Callable[[str], "list[float] | None"]:
     ``None`` until the model is resident.
     """
 
+    # Priority travels OUT OF BAND rather than as a cached argument: adding it to
+    # the lru_cache key would re-embed the same text once per priority, losing the
+    # reuse that currently lets episodic recall ride on the lessons embed of the
+    # identical query. Thread-local is safe because embed() blocks on the calling
+    # thread — the hand-off to kc-embed-infer happens inside it.
+    _call_priority = threading.local()
+
     @functools.lru_cache(maxsize=_EMBED_CACHE_MAX)
     def _cached_embed(text: str, model_id: str) -> tuple[float, ...]:
         del model_id  # cache-key only — routes stale entries away after a backend swap
@@ -1782,15 +2015,24 @@ def make_sync_embed_fn() -> Callable[[str], "list[float] | None"]:
                 info.currsize,
                 info.maxsize,
             )
-        vec = get_shared_embedder().embed(text)
+        vec = get_shared_embedder().embed(
+            text, priority=getattr(_call_priority, "value", PRIORITY_NORMAL)
+        )
         if vec is None:
             raise _EmbedFailed
         return tuple(vec)
 
-    def _embed(text: str) -> list[float] | None:
+    def _embed(text: str, *, priority: int = PRIORITY_NORMAL) -> list[float] | None:
+        _call_priority.value = priority
         try:
             return list(_cached_embed(text, get_shared_embedder().model_id))
         except _EmbedFailed:
             return None
+        finally:
+            _call_priority.value = PRIORITY_NORMAL
 
+    # Explicit capability flag rather than a TypeError probe: a TypeError raised
+    # from INSIDE a custom embed_fn must not be misread as "does not take a
+    # priority", which would silently downgrade every call to the default.
+    _embed.accepts_priority = True  # type: ignore[attr-defined]
     return _embed

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -30,6 +30,13 @@ from uuid import uuid4
 
 from snowballstemmer import stemmer as _snowball_stemmer
 
+# Scheduling classes for the shared embedding queue. This module stays decoupled
+# from the embedding BACKEND (it takes an injected ``embed_fn``); these are three
+# int constants, imported rather than duplicated so the two cannot drift. Safe
+# direction: ``embeddings`` reaches the store only through a Protocol, so it does
+# not import this module and there is no cycle.
+from kiro_crew.embeddings import PRIORITY_BULK, PRIORITY_INTERACTIVE, PRIORITY_NORMAL
+
 try:
     import pysqlite3 as sqlite3
 
@@ -999,7 +1006,9 @@ class VectorMemoryStore:
         # Query-aware filtering: hybrid vector + keyword scoring
         if query_text:
             query_words = _stem_words(set(re.findall(r"\w+", query_text.lower())))
-            query_embedding = self._try_embed(query_text) if self.embed_fn else None
+            query_embedding = (
+                self._try_embed(query_text, PRIORITY_INTERACTIVE) if self.embed_fn else None
+            )
 
             # Context assembly runs on executor threads (subagent context builds,
             # run_in_embed_pool) concurrent with writers on worker threads, and
@@ -1029,7 +1038,11 @@ class VectorMemoryStore:
                 vec_score = 0.0
                 if query_embedding is not None:
                     entry_text = f"{r['key']} {r['value_json']}"
-                    entry_emb = self._try_embed(entry_text)
+                    # BULK: this is an unbounded per-row loop over the whole
+                    # semantic table, recomputed on every call because non-lesson
+                    # rows never persist a vector. It must never outrank the
+                    # interactive query embed that started this same request.
+                    entry_emb = self._try_embed(entry_text, PRIORITY_BULK)
                     if entry_emb:
                         vec_score = max(0.0, self._cosine_sim(query_embedding, entry_emb))
 
@@ -1750,7 +1763,7 @@ class VectorMemoryStore:
         relevant-but-old memory is admitted rather than ordered out by recency.
         """
         if query_embedding is None and query_text and self.embed_fn is not None:
-            query_embedding = self._try_embed(query_text)
+            query_embedding = self._try_embed(query_text, PRIORITY_INTERACTIVE)
         results = self.search_episodic(
             query_embedding=query_embedding,
             query_text=query_text,
@@ -2145,7 +2158,7 @@ class VectorMemoryStore:
                     # Sampling after it returns would tag an old blob with the new
                     # generation and the flush check would wave it through.
                     backfill_generation = self._space_generation
-                    existing_emb = self._try_embed(existing_val)
+                    existing_emb = self._try_embed(existing_val, PRIORITY_BULK)
                     if existing_emb:
                         blob = struct.pack(f"{len(existing_emb)}f", *existing_emb)
                         pending_backfills.append(
@@ -2369,7 +2382,7 @@ class VectorMemoryStore:
         that matches nothing degrades to plain recency.
         """
         query_words = _stem_words(set(re.findall(r"\w+", query_text.lower())))
-        query_emb = self._try_embed(query_text) if self.embed_fn else None
+        query_emb = self._try_embed(query_text, PRIORITY_INTERACTIVE) if self.embed_fn else None
         similarity = self._stored_similarity_scorer(query_emb)
         scored: list[tuple[float, tuple[dict, str]]] = []
         for entry in entries:
@@ -2470,7 +2483,7 @@ class VectorMemoryStore:
             return ("pref.general", match.group(1).strip())
         return None
 
-    def _try_embed(self, text: str) -> list[float] | None:
+    def _try_embed(self, text: str, priority: int = PRIORITY_NORMAL) -> list[float] | None:
         """Embed text using embed_fn if available.
 
         If embed_fn is None but embed_fn_factory is set, attempt to lazily
@@ -2527,7 +2540,12 @@ class VectorMemoryStore:
         if self.embed_fn is not None:
             try:
                 generation_before = self._space_generation
-                result = self.embed_fn(text)
+                # Only forward to an embed_fn that advertises the kwarg. A custom
+                # or legacy embed_fn keeps its single-argument contract.
+                if getattr(self.embed_fn, "accepts_priority", False):
+                    result = self.embed_fn(text, priority=priority)  # type: ignore[call-arg]
+                else:
+                    result = self.embed_fn(text)
                 if self._space_generation != generation_before:
                     # A model swap landed while this text was in flight. The
                     # vector belongs to the previous space; committing it would
@@ -2792,7 +2810,7 @@ class VectorMemoryStore:
             # spin, and this loop can run for minutes on a large corpus.
             progress(0, total)
         for row in rows:
-            vec = self._try_embed(row["text"])
+            vec = self._try_embed(row["text"], PRIORITY_BULK)
             if not vec:
                 if progress is not None:
                     progress(embedded, total)
@@ -2873,7 +2891,7 @@ class VectorMemoryStore:
             except (ValueError, TypeError):
                 logger.debug("Skipping lesson %s with unparseable value", row["key"])
                 continue
-            vec = self._try_embed(text)
+            vec = self._try_embed(text, PRIORITY_BULK)
             if not vec:
                 continue
             # Stored un-normalized to match write_lesson(): _cosine_sim()

--- a/test/test_embedding_model_apply.py
+++ b/test/test_embedding_model_apply.py
@@ -704,7 +704,7 @@ class TestCommitTimeGenerationCheck:
 
         src = inspect.getsource(VectorMemoryStore.write_lesson)
         sample = src.find("backfill_generation = self._space_generation")
-        embed = src.find("existing_emb = self._try_embed(existing_val)")
+        embed = src.find("existing_emb = self._try_embed(existing_val")
         assert -1 not in (sample, embed), "lazy-backfill sampling not found"
         assert sample < embed, (
             "the generation must be sampled BEFORE the embed, or a swap in the "

--- a/test/test_embeddings.py
+++ b/test/test_embeddings.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import threading
+import time
 import urllib.error
 from pathlib import Path
 from types import SimpleNamespace
@@ -688,9 +689,11 @@ class _FakeSharedEmbedder:
     def __init__(self) -> None:
         self.calls = 0
         self.fail = False
+        self.priorities: list[int] = []
 
-    def embed(self, text: str) -> list[float] | None:
+    def embed(self, text: str, *, priority: int = embeddings_mod.PRIORITY_NORMAL):
         self.calls += 1
+        self.priorities.append(priority)
         if self.fail:
             return None
         return [0.5] * _DIM
@@ -711,6 +714,20 @@ class TestMakeSyncEmbedFn:
         vec = embed("hello")
         assert isinstance(vec, list)
         assert len(vec) == _DIM
+
+    def test_priority_reaches_the_backend_but_not_the_cache_key(self, fake_embedder) -> None:
+        """Priority is forwarded, but is NOT part of the cache key.
+
+        Keying the cache on priority would re-embed identical text once per
+        class, losing the reuse that lets episodic recall ride on the lessons
+        embed of the very same query.
+        """
+        embed = make_sync_embed_fn()
+        assert getattr(embed, "accepts_priority", False) is True
+        embed("shared text", priority=embeddings_mod.PRIORITY_BULK)
+        assert fake_embedder.priorities == [embeddings_mod.PRIORITY_BULK]
+        embed("shared text", priority=embeddings_mod.PRIORITY_INTERACTIVE)
+        assert fake_embedder.calls == 1, "cache key must ignore priority"
 
     def test_caches_successful_result(self, fake_embedder) -> None:
         embed = make_sync_embed_fn()
@@ -803,3 +820,311 @@ class TestSingletons:
         first = model_download_manager()
         reset_download_manager()
         assert model_download_manager() is not first
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Embedding thread pinning (memory.embedding_threads)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestEmbedThreads:
+    """llama.cpp must not size its compute pools from the host core count.
+
+    Left unset, ``n_threads_batch`` defaults to the CPU count, so even a
+    few-token embed fans out across every core and competes with the rest of the
+    gateway for CPU. These lock the resolver's clamping and prove the resolved
+    value actually reaches the ``Llama`` constructor.
+    """
+
+    def test_default_when_unset(self, monkeypatch) -> None:
+        monkeypatch.setattr(embeddings_mod, "_read_memory_config", lambda: {})
+        assert embeddings_mod._embed_threads() == embeddings_mod._DEFAULT_EMBED_THREADS
+
+    def test_configured_value_is_used(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            embeddings_mod, "_read_memory_config", lambda: {"embedding_threads": 2}
+        )
+        assert embeddings_mod._embed_threads() == 2
+
+    @pytest.mark.parametrize("bad", [0, -1, True, False, "4", 2.5, None])
+    def test_invalid_values_fall_back_to_the_default(self, monkeypatch, bad) -> None:
+        """Booleans are rejected explicitly: ``True`` would coerce to 1 thread."""
+        monkeypatch.setattr(
+            embeddings_mod, "_read_memory_config", lambda: {"embedding_threads": bad}
+        )
+        assert embeddings_mod._embed_threads() == embeddings_mod._DEFAULT_EMBED_THREADS
+
+    def test_clamped_to_the_core_count(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            embeddings_mod, "_read_memory_config", lambda: {"embedding_threads": 9999}
+        )
+        monkeypatch.setattr("os.cpu_count", lambda: 8)
+        assert embeddings_mod._embed_threads() == 8
+
+    def test_threads_reach_the_llama_constructor(self, tmp_path: Path, monkeypatch) -> None:
+        """BOTH pools are pinned, not only the batch pool that runs inference."""
+        fake_cls = _make_fake_llama_class()
+        monkeypatch.setattr("kiro_crew.embeddings._load_llama_class", lambda: fake_cls)
+        monkeypatch.setattr(
+            embeddings_mod, "_read_memory_config", lambda: {"embedding_threads": 3}
+        )
+        emb = LlamaCppEmbedder(model_path=_write_model_file(tmp_path / "model.gguf"))
+        assert emb.wait_ready(timeout=5)
+        kwargs = fake_cls.instances[0].kwargs
+        assert kwargs["n_threads"] == 3
+        assert kwargs["n_threads_batch"] == 3
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Embed timing + inference queue priority
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestEmbedQueueTiming:
+    """Queue wait must be reported separately from the model's own cost.
+
+    The process shares ONE model on ONE thread, so a short embed can be slow
+    purely because it queued behind a long one. That is a different defect from
+    slow inference, with a different fix, and these assert the instrumentation
+    tells the two apart.
+    """
+
+    def test_a_queued_embed_reports_wait_not_inference(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        fake_cls = _make_fake_llama_class()
+        monkeypatch.setattr("kiro_crew.embeddings._load_llama_class", lambda: fake_cls)
+        emb = LlamaCppEmbedder(model_path=_write_model_file(tmp_path / "model.gguf"))
+        assert emb.wait_ready(timeout=5)
+
+        emitted: list[tuple[float, float, int]] = []
+        real_emit = embeddings_mod._emit_embed_timing
+
+        def _spy(t0, t_started, texts, *, priority=embeddings_mod.PRIORITY_NORMAL, failed=False):
+            emitted.append(
+                (
+                    (t_started - t0) * 1000.0,
+                    (time.monotonic() - t_started) * 1000.0,
+                    sum(len(t) for t in texts),
+                )
+            )
+            real_emit(t0, t_started, texts, priority=priority, failed=failed)
+
+        monkeypatch.setattr(embeddings_mod, "_emit_embed_timing", _spy)
+
+        holding = threading.Event()
+        release = threading.Event()
+
+        def _create(texts):
+            if sum(len(t) for t in texts) > 100:
+                holding.set()
+                release.wait(timeout=5)
+            return {"data": [{"embedding": [0.1] * _DIM} for _ in texts]}
+
+        fake_cls.instances[0].create_embedding = _create
+
+        bulk = threading.Thread(target=lambda: emb.embed("x" * 4000))
+        bulk.start()
+        assert holding.wait(timeout=5), "bulk embed never started"
+
+        # Patch the queue only NOW: the first submission REPLACES self._jobs with
+        # a fresh PriorityQueue when it spawns the worker, so a wrapper installed
+        # before that point lands on the discarded original and never fires.
+        # Deterministic barrier: a fixed sleep here would race a loaded CI runner,
+        # releasing before the short embed enqueued and collapsing its wait.
+        queued = threading.Event()
+        real_put = emb._jobs.put
+
+        def _put(item):
+            real_put(item)
+            _prio, _seq, job = item
+            if job is not None and sum(len(t) for t in job.texts) == 2:
+                queued.set()
+
+        monkeypatch.setattr(emb._jobs, "put", _put)
+
+        short = threading.Thread(target=lambda: emb.embed("hi"))
+        short.start()
+        assert queued.wait(timeout=5), "short embed never reached the queue"
+        # Hold deliberately, so the measured wait is this duration rather than a
+        # scheduling artifact.
+        time.sleep(0.5)
+        release.set()
+        bulk.join(timeout=10)
+        short.join(timeout=10)
+
+        big = [e for e in emitted if e[2] == 4000]
+        small = [e for e in emitted if e[2] == 2]
+        assert len(big) == 1 and len(small) == 1
+        assert big[0][0] < 200, f"bulk should not have queued: {big[0]}"
+        assert small[0][0] >= 300, f"queued embed should report wait: {small[0]}"
+        assert small[0][1] < 200, f"queued embed's own inference was fast: {small[0]}"
+
+    def test_chars_bucket_is_low_cardinality(self) -> None:
+        assert embeddings_mod._chars_bucket(2) == "<=128"
+        assert embeddings_mod._chars_bucket(400) == "<=512"
+        assert embeddings_mod._chars_bucket(4000) == "<=6000"
+        assert embeddings_mod._chars_bucket(99_999) == ">6000"
+
+
+class TestEmbedPriority:
+    """A short interactive embed must not wait behind a queued bulk sweep.
+
+    This used to be impossible: the CALLER held ``_lock`` across submit+wait, so
+    every other caller blocked before it could enqueue and at most one job was
+    ever queued. The lock moved to the worker precisely so ordering can exist.
+    """
+
+    def _gated(self, tmp_path: Path, monkeypatch):
+        """Start a gated worker and return (emb, order, release, queued, threads).
+
+        The gate job is already RUNNING on return, which matters for two reasons:
+        the first submission replaces ``self._jobs`` with a fresh queue when it
+        spawns the worker (so the recording wrapper has to be installed after
+        that, not before), and ``queued`` then counts only the submissions a test
+        actually cares about. ``queued`` is what lets a test release on a
+        deterministic barrier instead of a fixed sleep: on a loaded runner a sleep
+        can release before every submitter has enqueued, and the ordering
+        assertion would then measure scheduling rather than priority.
+        """
+        fake_cls = _make_fake_llama_class()
+        monkeypatch.setattr("kiro_crew.embeddings._load_llama_class", lambda: fake_cls)
+        emb = LlamaCppEmbedder(model_path=_write_model_file(tmp_path / "model.gguf"))
+        assert emb.wait_ready(timeout=5)
+        order: list[str] = []
+        holding = threading.Event()
+        release = threading.Event()
+
+        def _create(texts):
+            label = texts[0]
+            if label == "gate":
+                holding.set()
+                release.wait(timeout=5)
+            order.append(label)
+            return {"data": [{"embedding": [0.1] * _DIM} for _ in texts]}
+
+        fake_cls.instances[0].create_embedding = _create
+
+        threads = [threading.Thread(target=lambda: emb.embed("gate"))]
+        threads[0].start()
+        assert holding.wait(timeout=5), "worker never entered the gate job"
+
+        queued: list[str] = []
+        queued_lock = threading.Lock()
+        real_put = emb._jobs.put
+
+        def _put(item):
+            real_put(item)
+            _prio, _seq, job = item
+            if job is not None:
+                with queued_lock:
+                    queued.append(job.texts[0])
+
+        monkeypatch.setattr(emb._jobs, "put", _put)
+        return emb, order, release, queued, threads
+
+    @staticmethod
+    def _await_queued(queued: list, expected: int, timeout: float = 5.0) -> None:
+        """Block until *expected* submissions have reached the queue."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if len(queued) >= expected:
+                return
+            time.sleep(0.01)
+        raise AssertionError(f"only {len(queued)} of {expected} enqueued: {queued}")
+
+    def test_interactive_preempts_queued_bulk(self, tmp_path: Path, monkeypatch) -> None:
+        emb, order, release, queued, threads = self._gated(tmp_path, monkeypatch)
+
+        # Bulk is submitted FIRST and still must lose to the later query.
+        for i in range(3):
+            t = threading.Thread(
+                target=lambda i=i: emb.embed(f"bulk{i}", priority=embeddings_mod.PRIORITY_BULK)
+            )
+            t.start()
+            threads.append(t)
+        self._await_queued(queued, 3)
+        q = threading.Thread(
+            target=lambda: emb.embed("query", priority=embeddings_mod.PRIORITY_INTERACTIVE)
+        )
+        q.start()
+        threads.append(q)
+        self._await_queued(queued, 4)
+        release.set()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert order[0] == "gate"
+        assert order[1] == "query", f"interactive must preempt queued bulk: {order}"
+        assert set(order[2:]) == {"bulk0", "bulk1", "bulk2"}
+
+    def test_equal_priority_stays_fifo(self, tmp_path: Path, monkeypatch) -> None:
+        """The seq tiebreaker keeps ordering stable, so priority is not a lottery."""
+        emb, order, release, queued, threads = self._gated(tmp_path, monkeypatch)
+        for i in range(4):
+            t = threading.Thread(target=lambda i=i: emb.embed(f"n{i}"))
+            t.start()
+            threads.append(t)
+            # Confirm each submission is enqueued before starting the next, so
+            # FIFO order is well-defined: with all four racing, any interleaving
+            # is a legal seq order and the assertion would be testing the
+            # scheduler rather than the tiebreaker.
+            self._await_queued(queued, i + 1)
+        release.set()
+        for t in threads:
+            t.join(timeout=10)
+        assert order == ["gate", "n0", "n1", "n2", "n3"], order
+
+    def test_close_does_not_abandon_a_queued_caller(self, tmp_path: Path, monkeypatch) -> None:
+        """A job already queued when the sentinel arrives is failed, not hung.
+
+        Retirement and dispatch now share a lock, so a LATE submission fails fast
+        instead of queueing. This covers the other half: a job legally enqueued
+        before ``close()`` still has to be failed by the drain.
+        """
+        emb, _order, release, queued, threads = self._gated(tmp_path, monkeypatch)
+        results: list[object] = []
+        late = threading.Thread(target=lambda: results.append(emb.embed("late")))
+        late.start()
+        self._await_queued(queued, 1)  # 'late' is genuinely on the queue now
+
+        release.set()
+        closer = threading.Thread(target=emb.close)
+        closer.start()
+        closer.join(timeout=15)
+        assert not closer.is_alive(), "close() must not block on the in-flight job"
+        late.join(timeout=10)
+        assert not late.is_alive(), "a queued caller must never wait forever"
+        for t in threads:
+            t.join(timeout=10)
+        assert len(results) == 1
+
+    def test_a_retired_backend_fails_fast_instead_of_hanging(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A submission after close() must not queue into a space nothing drains.
+
+        This is the hang the dispatch lock exists to prevent: close() swaps BOTH
+        the worker and the queue, so a caller that passed the liveness check and
+        then enqueued would wait on ``job.done`` forever.
+        """
+        fake_cls = _make_fake_llama_class()
+        monkeypatch.setattr("kiro_crew.embeddings._load_llama_class", lambda: fake_cls)
+        emb = LlamaCppEmbedder(model_path=_write_model_file(tmp_path / "model.gguf"))
+        assert emb.wait_ready(timeout=5)
+        llm = fake_cls.instances[0]
+        emb.close()
+
+        # Submitting the STALE llm handle is exactly what a caller holding a
+        # pre-close reference does; it must fail, not block.
+        done = threading.Event()
+        out: list = []
+
+        def _submit():
+            out.append(emb._submit_infer(llm, ["stale"]))
+            done.set()
+
+        threading.Thread(target=_submit, daemon=True).start()
+        assert done.wait(timeout=5), "_submit_infer hung on a retired backend"
+        assert out[0].error is not None
+        assert "retired" in str(out[0].error)


### PR DESCRIPTION
## Problem

Every first turn in a session paid roughly **7 seconds** building the `lessons` context block. The eager-spawn work that was supposed to hide cold starts did not help, because this cost was not startup: it was paid on the first real turn, every time.

Instrumentation from #3175 localised it to the embedder rather than to SQLite, FAISS, or the MCP fleet. `llama_cpp` sizes its compute pool from the host core count, so an 8-character query like `"how do I run tests"` fanned out across all 16 cores. On a box already running the gateway plus MCP servers, those threads oversubscribed the CPU and spent their time in ggml's barrier synchronisation instead of doing work. Measured during a lessons embed: **1035-1384% CPU** across **49 threads**, 17 of them llama's.

A single embed is far too small to amortise that. The parallelism was pure overhead.

## Change

**Thread pinning (this is where the win comes from).** Embedding backends now default to `4` threads instead of the host core count, clamped to the machine's cores at the point of use and configurable via `embedding_threads`.

**Priority queue (insurance, not the fix).** Embed jobs now carry `PRIORITY_INTERACTIVE` / `PRIORITY_NORMAL` / `PRIORITY_BULK`. Interactive queries jump ahead of corpus sweeps and backfills. Priority travels through a `threading.local` deliberately so it stays **out** of the `lru_cache` key, otherwise identical text would be re-embedded once per priority and episodic context would lose the reuse that currently lets it ride on the lessons embed.

To make ordering possible at all, the inference lock had to move off the caller and onto the worker. Previously each caller held `_lock` across submit-and-wait, so every other caller blocked before it could even enqueue and at most one job was ever in the queue, which made any priority scheme meaningless.

**Split timing.** `_InferJob` gained a `started` timestamp so `embed_batch` can separate queue wait from inference time. Without it, a slow embed and a queued embed look identical in the logs.

## Measured effect

Before and after on a live gateway, syncing only `embeddings.py`:

| Metric | Before | After |
|---|---|---|
| `lessons` first-turn context | 7338 / 8029 / 7436 ms | **350 / 222 / 320 ms** |
| Embed inference | not separable | 204-252 ms |
| Embed queue wait | unmeasured | **0 ms** |
| CPU during embed burst | 1035-1384% | **352-409%** |
| Process threads | 49 (17 llama) | 21 (4 llama) |

**A correction worth stating plainly:** `wait=0ms` means the queueing hypothesis was *not* what got fixed. The entire win is thread pinning. The priority queue earns its place only when bulk work is genuinely concurrent with an interactive query, which is a real scenario during migrations and backfills but is not what these numbers demonstrate. It is unproven here, not disproven.

## Testing

- **621 tests pass** across the embedding, vector-memory and context suites.
- New coverage for priority ordering, FIFO stability within a priority, and the retirement race.
- Deterministic enqueue barriers replace fixed `sleep()` calls in the concurrency tests, so they do not flake on a loaded CI runner.
- Falsification-checked the retirement guard: neutering it makes the new test fail, because a submission after `close()` then silently resurrects the retired model and succeeds.
- Static gates clean: `isort`, `flake8`, `mypy` (939 files), `check_brand_name.py`, `docs_lint.py`, `verify_vendor_manifest.py`, `scrub-lint.sh`.

**Deviation to declare:** I ran targeted suites rather than the full `pytest` run, which is expensive on this host. CI is the backstop for the rest. Three pre-existing environmental failures (`_is_trusted_dir('/usr/bin')` and two `ssh -G` cases) were confirmed unrelated by reproducing them on a pristine tree.

`black` was deliberately not run: this venv is Python 3.10 while the repo was formatted under 3.14, so it reformats already-committed code and fails `black --check` on an untouched tree.

## Risk

The lock restructure is the sharp edge, so it got a dedicated review pass. Two reviewers independently landed on the same span in `_submit_infer`, which read and mutated shared lifecycle state with no lock: one found a caller that could hang forever, the other a leaked daemon thread per lost spawn race. Both were two symptoms of one missing invariant, and both are closed by a single `_dispatch_lock` that makes the retirement check, worker spawn and enqueue atomic.

Lock ordering, verified acyclic: `_submit_infer` takes `_dispatch_lock` (then `_seq_lock`), the worker takes only `_lock`, and `close()` takes `_lock` then `_load_lock` then `_dispatch_lock`. A submitter never waits on `_lock` while holding `_dispatch_lock`, and `_dispatch_lock` is never held across inference, a join, or a model load.

Behaviour is unchanged when embeddings are disabled or a remote backend is in use. `embedding_threads` defaults preserve existing behaviour for anyone who has set it explicitly.

## Screenshots

**N/A**, no user-visible UI change. The change is backend embedding scheduling; the only observable difference is latency and log output.

## Issue

**No issue closed:** this came out of live profiling rather than a filed report, and I did not find an existing tracked issue for first-turn context latency. Happy to file one retroactively if that is the convention here.

Follow-up worth its own PR, deliberately not widened into this one: `get_semantic_context` recomputes roughly 422 embeddings per call and never persists them, even though the `embedding` column exists to hold them.
