### PR TITLE
fix: defer session-map disk writes to a snapshot flush off the event loop (#2405)

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -365,8 +365,22 @@ stored and new provider names for observability.
 
 **Atomic write:** tmp file + `os.replace()` prevents corruption on crash.
 
+**Deferred flush (event loop only):** a mutation made on the event loop marks
+the map dirty and schedules a debounced flush task; the task serializes the map
+under `_MAP_LOCK` into an immutable JSON payload, then performs the tmp+rename
+in a worker thread — the loop never pays the file write inline, and `_data`
+never crosses the thread boundary. Coalescing never drops a trailing mutation
+(the task loops until it observes a clean map), and a per-snapshot ticket keeps
+a slow in-flight write from landing an older map over a newer forced one.
+`SessionMap.flush()` (sync contexts) and `SessionMap.aflush()` (awaited, for
+loop-side shutdown paths — `SessionManager.close_all()` uses it) are the
+deterministic durability points; off the loop (CLI, tests, worker threads)
+every mutation still writes inline. Losing a pending
+flush on a crash leaves a well-formed older map, never a truncated file.
+
 **Auto-prune:** `SessionMap.get()` auto-removes entries whose `.json` file
-no longer exists. `SessionMap.prune()` bulk-removes all stale entries at
+no longer exists (the entry drops from memory immediately; the file write rides
+the deferred flush). `SessionMap.prune()` bulk-removes all stale entries at
 startup.
 
 **Mapped-session enumeration:** `SessionMap.mapped_sids_by_key()` returns session

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -3791,6 +3791,18 @@ class SessionManager:
                     ):
                         self._session_map.set(key, sid, provider="claude_code", cwd=_cwd_str)
 
+            # The set() calls above run on the loop and therefore DEFER their
+            # disk write; the gateway exits via os._exit, which never cancels
+            # tasks, so nothing downstream would ever land them. This is the
+            # shutdown durability point: await the off-loop flush so a wedged
+            # filesystem cannot hold the loop past the shutdown deadline.
+            try:
+                await self._session_map.aflush()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug("close_all: session map flush failed", exc_info=True)
+
             sessions = dict(self._sessions)
             self._sessions.clear()
             self._compact_cooldown_until.clear()

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -7,6 +7,7 @@ generic ChannelLink mirror map) for bidirectional sync.
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import json
 import logging
@@ -62,6 +63,14 @@ MIRROR_OPT_OUT_FLAG = "mirror_opt_out"
 # describing one session (Slack's ``temporary`` / ``incognito`` threads) must
 # stay collectable — one leaked row per such thread would grow without bound.
 _DURABLE_FLAGS = frozenset({MIRROR_OPT_OUT_FLAG})
+
+# How long a deferred flush waits before serializing, so a burst of mutations
+# (a subagent wave calling ``set`` once per spawn) collapses into one write
+# instead of one write per mutation. Small on purpose: the window is also how
+# much recent state a crash can lose (the file stays a well-formed OLDER map —
+# see ``_write_payload``'s tmp+rename), and durability-critical points force
+# the write through :meth:`SessionMap.flush` rather than waiting it out.
+_FLUSH_DEBOUNCE_SECS = 0.05
 
 
 def _has_durable_flag(entry: dict) -> bool:
@@ -183,11 +192,17 @@ class SessionMap:
        stale snapshot. A throwaway ``SessionMap()`` is therefore READ-ONLY —
        see ``session_transfer._join_layer_b`` for what a detached write costs.
 
-    Writes still happen synchronously on the caller's thread, which on the event
-    loop is a stall every task shares (~0.8 ms at today's map sizes, growing
-    linearly with entry count). Moving them off the loop is issue #2405, and the
-    lock is what makes that possible to attempt at all — before it, offloading a
-    single write made the map racy instead of non-blocking.
+    On the event loop, a mutation does not pay the disk write inline: it marks
+    the map dirty and a debounced flush task serializes UNDER the lock into an
+    immutable payload, then writes tmp+rename in a worker thread — ``_data``
+    never crosses the thread boundary, and the lock is never held across the
+    await (the ratchet in ``test_session_map_locking.py`` checks that). Off the
+    loop (CLI, tests, worker threads) writes stay inline and synchronous.
+    :meth:`flush` (sync) and :meth:`aflush` (awaited) are the deterministic
+    durability points; losing a pending flush leaves a well-formed OLDER file,
+    never a truncated one. The lock is what
+    makes the offload safe at all — before it, offloading a single write made
+    the map racy instead of non-blocking.
 
     SCOPE: the lock is in-PROCESS. Two gateways writing one map file would still
     lose updates, and nothing here changes that — the data-home singleton is what
@@ -201,6 +216,22 @@ class SessionMap:
         self._thread_to_session: dict[str, str] = {}  # slack_thread_ts → session_key
         self._batch_depth = 0
         self._batch_dirty = False
+        # Deferred-flush state (all mutated under _MAP_LOCK). ``_dirty`` records
+        # that in-memory state is ahead of the file; ``_flush_task`` is the one
+        # loop task owed for it. ``_snapshot_seq`` tickets each serialized
+        # snapshot and ``_written_seq`` (guarded by ``_io_lock``, not _MAP_LOCK)
+        # refuses a STALE payload: an in-flight thread write racing a forced
+        # inline write must not land an older map over a newer one. Keeping the
+        # worker's write off _MAP_LOCK is what keeps loop-side MUTATIONS from
+        # waiting on its disk I/O; the inline write paths (batch exit, flush,
+        # load-time migration) do queue behind it on _io_lock — they already
+        # paid an inline write before deferral existed, so that wait replaces
+        # like with like.
+        self._dirty = False
+        self._flush_task: asyncio.Task[None] | None = None
+        self._snapshot_seq = 0
+        self._written_seq = 0
+        self._io_lock = threading.Lock()
         self._load()
 
     @contextmanager
@@ -233,6 +264,11 @@ class SessionMap:
                 self._batch_depth -= 1
                 if self._batch_depth == 0 and self._batch_dirty:
                     self._batch_dirty = False
+                    # The batch's inline write below IS the flush for anything
+                    # deferred before the block started, so consume the dirty
+                    # mark too — otherwise an already-scheduled flush task would
+                    # wake and rewrite the identical state.
+                    self._dirty = False
                     self._write()
 
     def _load(self) -> None:
@@ -246,7 +282,7 @@ class SessionMap:
         ``asyncio.to_thread``) would hold the lock across it, so a loop-side
         ``set_slack_link`` would block on a worker's disk read and stall every
         gateway task with it. The two shared effects it does have —
-        ``_rebuild_thread_index`` and the migration ``_save`` — take the lock
+        ``_rebuild_thread_index`` and the migration ``_write`` — take the lock
         themselves, and both are bounded (see the class threading contract).
         """
         self._thread_to_session = {}
@@ -321,7 +357,13 @@ class SessionMap:
             self._data = new_data
             self._rebuild_thread_index()
             if migrated:
-                self._save()
+                # Inline, not deferred: this is a one-time legacy-format repair
+                # running from __init__ on an instance no task should capture,
+                # and readers of the FILE (a fresh instance, a cotenant scan)
+                # rely on the migrated shape being durable once construction
+                # returns. It costs nothing on the steady state — an already
+                # migrated map never takes this branch.
+                self._write()
         else:
             self._data = {}
 
@@ -371,25 +413,206 @@ class SessionMap:
 
     @_guarded
     def _save(self) -> None:
+        """Record that the file is owed a write, and arrange for one.
+
+        Three contexts, three behaviours:
+
+        - inside a :meth:`batched_save` block: mark the batch dirty; the block
+          exit writes once for the whole sequence (unchanged).
+        - on a thread running an event loop: mark dirty and schedule ONE
+          debounced flush task. The task serializes under the lock and does the
+          disk write in a worker thread, so the loop never pays the write
+          inline (issue #2405). A mutation landing while a flush is in flight
+          re-marks dirty, and the task loops until it observes a clean map, so
+          a trailing mutation is never dropped.
+        - no running loop (CLI, tests, worker threads): write inline on the
+          caller's thread. Worker threads may block on disk; the loop is the
+          only caller that must not.
+        """
         if self._batch_depth:
             self._batch_dirty = True
             return
-        self._write()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._write()
+            return
+        self._dirty = True
+        task = self._flush_task
+        # ``done()`` covers a task that exited exceptionally without clearing
+        # itself; the loop-identity check covers a stale task bound to a loop
+        # that no longer runs (tests create a loop per test) — such a task can
+        # never wake, so it must not suppress scheduling on the live loop.
+        if task is None or task.done() or task.get_loop() is not loop:
+            self._flush_task = loop.create_task(self._flush_async())
+
+    @_guarded
+    def _take_pending_snapshot(self) -> tuple[str, int] | None:
+        """Atomically claim the pending flush: serialize now, or report clean.
+
+        Returns ``(payload, seq)`` when a write is owed, consuming the dirty
+        mark. Returns ``None`` — and retires ``_flush_task`` in the SAME
+        critical section — when the map is clean: clearing the task while still
+        holding the lock is what makes "task exists" a reliable reason for
+        :meth:`_save` to skip scheduling, with no window where a new mutation
+        sees a task that has already decided to exit. Retirement is
+        identity-checked so a superseded task (one whose loop went stale and
+        was replaced by :meth:`_save`) cannot un-register its replacement.
+        """
+        if not self._dirty:
+            if self._flush_task is asyncio.current_task():
+                self._flush_task = None
+            return None
+        self._dirty = False
+        return self._serialize()
+
+    @_guarded
+    def _serialize(self) -> tuple[str, int]:
+        """Snapshot ``_data`` as an immutable JSON string with a ticket.
+
+        The string is the ONLY thing that crosses the thread boundary —
+        ``_data`` itself never does. The ticket orders this snapshot against
+        every other snapshot so :meth:`_write_payload` can refuse to land a
+        stale one over a newer one.
+        """
+        self._snapshot_seq += 1
+        return json.dumps(self._data), self._snapshot_seq
+
+    async def _flush_async(self) -> None:
+        """Debounce, serialize under the lock, write off the loop; repeat.
+
+        Loops because coalescing must not lose the last write: a mutation that
+        lands while ``to_thread`` is writing re-marks dirty, and the next
+        iteration picks it up. Exits only via :meth:`_take_pending_snapshot`
+        observing a clean map (which retires the task under the lock).
+
+        The lock is NEVER held across an await — serialization happens inside
+        the guarded helpers, the write happens off-lock in a worker thread.
+        Cancellation re-owes any claimed-but-unwritten snapshot and does NOT
+        write (a cancellation handler that did disk I/O on the loop would hold
+        up the very teardown that cancelled it): pending state is landed by the
+        shutdown path awaiting :meth:`aflush`, or rescheduled by the next
+        mutation. A task cancelled before its first step never runs this body
+        at all — the same two nets cover it, because nothing here consumed the
+        dirty mark. A write failure restores the mark and retires the task so
+        a later mutation retries.
+        """
+        try:
+            while True:
+                await asyncio.sleep(_FLUSH_DEBOUNCE_SECS)
+                snapshot = self._take_pending_snapshot()
+                if snapshot is None:
+                    return
+                payload, seq = snapshot
+                await asyncio.to_thread(self._write_payload, payload, seq)
+        except asyncio.CancelledError:
+            self._restore_dirty()
+            raise
+        except Exception:
+            logger.exception("Deferred session-map flush failed; will retry on next mutation")
+            self._restore_dirty()
+
+    @_guarded
+    def _restore_dirty(self) -> None:
+        """A claimed snapshot never landed: re-owe the flush, retire the task."""
+        self._dirty = True
+        if self._flush_task is asyncio.current_task():
+            self._flush_task = None
+
+    @_guarded
+    def _claim_for_flush(self) -> tuple[str, int] | None:
+        """Claim pending state for a durability write, or report nothing owed.
+
+        The shared predicate behind :meth:`flush` and :meth:`aflush`. Progress-
+        based, not just the dirty mark: a flush task that has already CLAIMED a
+        snapshot (consuming the mark) but whose worker-thread write has not
+        landed leaves ``_snapshot_seq`` ahead of ``_written_seq``, and treating
+        that as clean would hand the caller a stale file. A stale read of
+        ``_written_seq`` (it advances under ``_io_lock``, not this lock) only
+        errs toward one redundant write, never toward skipping a needed one.
+        """
+        if self._batch_depth:
+            return None
+        if not self._dirty and self._snapshot_seq <= self._written_seq:
+            return None
+        self._dirty = False
+        return self._serialize()
+
+    @_guarded
+    def flush(self) -> None:
+        """Force any pending deferred write to disk, synchronously.
+
+        The deterministic durability point for SYNC contexts (no running loop,
+        worker threads, tests): after this returns, the file reflects every
+        mutation made so far (a no-op inside a :meth:`batched_save` block,
+        whose exit already writes). The write queues behind any in-flight
+        worker write on ``_io_lock`` and lands with a newer ticket, so an
+        in-flight payload can never regress it. On the event loop prefer
+        :meth:`aflush`: this method blocks its calling thread on disk I/O.
+        """
+        snapshot = self._claim_for_flush()
+        if snapshot is None:
+            return
+        payload, seq = snapshot
+        self._write_payload(payload, seq)
+
+    async def aflush(self) -> None:
+        """Awaitable durability point: land pending state without blocking the loop.
+
+        Same progress-based contract as :meth:`flush`, but the disk write runs
+        in a worker thread, so a shutdown path awaiting this stays cancellable
+        and a wedged filesystem cannot hold the loop. Cancellation mid-write
+        re-owes the state (erring toward one redundant write — the orphaned
+        thread write may still land, ordered by its ticket) and re-raises so
+        the caller's deadline stays honest.
+        """
+        snapshot = self._claim_for_flush()
+        if snapshot is None:
+            return
+        payload, seq = snapshot
+        try:
+            await asyncio.to_thread(self._write_payload, payload, seq)
+        except asyncio.CancelledError:
+            self._restore_dirty()
+            raise
 
     @_guarded
     def _write(self) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_fd, tmp_path = tempfile.mkstemp(dir=str(self._path.parent), suffix=".tmp")
-        try:
-            with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
-                json.dump(self._data, f)
-            os.replace(tmp_path, str(self._path))
-        except Exception:
+        payload, seq = self._serialize()
+        self._write_payload(payload, seq)
+
+    def _write_payload(self, payload: str, seq: int) -> None:
+        """Land one serialized snapshot atomically; refuse to regress.
+
+        Runs on whatever thread the caller chose — the loop-side inline path
+        under ``_MAP_LOCK``, or a worker thread WITHOUT it (holding the map
+        lock across disk I/O in a thread would make a loop-side mutation wait
+        on the disk, the very stall the deferral removes). ``_io_lock`` orders
+        concurrent writers, and the ticket check drops a payload older than one
+        already on disk, so a slow in-flight flush cannot overwrite a newer
+        forced write. Both are PER-INSTANCE: they order this instance's own
+        writers against each other, not two instances sharing the file — that
+        remains covered by the class contract's rule 3 (a throwaway
+        ``SessionMap()`` is read-only, only the live map writes). tmp+rename
+        keeps a crash from ever leaving a truncated file: the worst case is a
+        well-formed OLDER map.
+        """
+        with self._io_lock:
+            if seq <= self._written_seq:
+                return
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_fd, tmp_path = tempfile.mkstemp(dir=str(self._path.parent), suffix=".tmp")
             try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+                with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                    f.write(payload)
+                os.replace(tmp_path, str(self._path))
+            except Exception:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+            self._written_seq = seq
 
     def _resolve_alias(self, key: str) -> "tuple[str, dict | None]":
         """Resolve *key* through the map's alias folds; return (matched_key, entry).

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -9901,6 +9901,9 @@ class TestForkSlot:
         monkeypatch.setattr("kiro_crew.session_map.config_dir", lambda: tmp_path)
         session_map = SessionMap()
         session_map.set("dashboard:src", "parent-kiro-sid-abc123")
+        # A loop-side mutation defers its disk write; the fresh-instance
+        # readback below needs the file current NOW.
+        session_map.flush()
 
         state = _make_state(tmp_path)
         slot = state.get_or_create_slot("src")

--- a/test/test_ephemeral_sessions.py
+++ b/test/test_ephemeral_sessions.py
@@ -1690,6 +1690,9 @@ class TestDurableSlackFlagsAtHttpGate:
 
         sm = SessionMap()
         sm.set_flag(self.SLACK_KEY, flag, True)
+        # A loop-side mutation defers its disk write; the fresh-instance
+        # precondition below reads the FILE, so force it current first.
+        sm.flush()
         # Preconditions: durable on disk, absent from this process's maps.
         assert SessionMap().get_flag(self.SLACK_KEY, flag) is True
         assert _h.is_thread_incognito(self.SLACK_KEY) is False

--- a/test/test_session_map_flush.py
+++ b/test/test_session_map_flush.py
@@ -1,0 +1,361 @@
+"""SessionMap's deferred snapshot flush: off-loop writes that lose nothing.
+
+Issue #2405. On the event loop a mutation marks the map dirty and a debounced
+flush task hands an ALREADY SERIALIZED snapshot to a worker thread; ``_data``
+never crosses the thread boundary and ``_MAP_LOCK`` is never held across the
+await (ratcheted in ``test_session_map_locking.py``). Off the loop, writes stay
+inline. Pinned here:
+
+1. a burst of loop-side mutations pays ZERO inline writes and coalesces to one
+   file write (this is the fails-before test: pre-deferral, every mutation
+   called ``os.replace`` synchronously on the loop);
+2. a mutation landing while a flush is in flight is still on disk after the
+   map settles — coalescing never drops the trailing write;
+3. the payload handed to the worker thread is an immutable snapshot, not
+   ``_data``;
+4. sync contexts (no running loop) keep writing immediately;
+5. ``get()``'s stale-entry prune returns ``None`` immediately and reaches disk
+   after the flush, not inline;
+6. ``flush()`` is deterministic, and a stale in-flight payload can never land
+   over a newer forced write.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.session_map import SESSION_MAP_FILENAME, SessionMap
+
+
+@pytest.fixture
+def session_map(tmp_path):
+    with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+        yield SessionMap()
+
+
+def _map_file(tmp_path) -> dict:
+    return json.loads((tmp_path / SESSION_MAP_FILENAME).read_text(encoding="utf-8"))
+
+
+async def _settle(sm: SessionMap) -> None:
+    """Wait until every scheduled flush has retired (deterministic, no sleeps)."""
+    while True:
+        task = sm._flush_task
+        if task is None:
+            return
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+async def _await_event(event: threading.Event, what: str) -> None:
+    """Await a thread-side event with a deadline, failing on the point at issue.
+
+    An unbounded spin would hang until the repo-wide ``--timeout`` fires with
+    an unhelpful stack instead of failing on the assertion the test makes.
+    """
+
+    async def _poll() -> None:
+        while not event.is_set():
+            await asyncio.sleep(0.005)
+
+    try:
+        await asyncio.wait_for(_poll(), timeout=10)
+    except asyncio.TimeoutError:
+        pytest.fail(f"timed out waiting for {what}")
+
+
+class TestDeferredFlush:
+    @pytest.mark.asyncio
+    async def test_burst_pays_no_inline_write_and_coalesces_to_one(self, session_map, tmp_path):
+        """The win, proven not asserted: pre-deferral this counts one
+        ``os.replace`` per mutation, all synchronous on the loop thread; now the
+        burst itself performs ZERO renames and the settle performs exactly one,
+        off the loop thread.
+        """
+        import kiro_crew.session_map as mod
+
+        loop_thread = threading.current_thread()
+        renames: list[threading.Thread] = []
+        # NOTE: mod.os IS the os module, so this patch is process-global, not
+        # module-local. Harmless under xdist process isolation; do not widen.
+        real_replace = mod.os.replace
+
+        def counting_replace(src, dst):
+            renames.append(threading.current_thread())
+            return real_replace(src, dst)
+
+        with patch.object(mod.os, "replace", counting_replace):
+            for i in range(20):
+                session_map.set(f"dashboard:burst-{i}", f"sid-{i}")
+            inline_renames = len(renames)
+            await _settle(session_map)
+
+        assert inline_renames == 0, "a loop-side mutation still paid the file write inline"
+        assert len(renames) == 1, "one debounce window must produce exactly one write"
+        assert renames[0] is not loop_thread, "the write ran on the event-loop thread"
+        persisted = _map_file(tmp_path)
+        assert {k: v["sid"] for k, v in persisted.items()} == {
+            f"dashboard:burst-{i}": f"sid-{i}" for i in range(20)
+        }
+
+    @pytest.mark.asyncio
+    async def test_trailing_mutation_survives_inflight_flush(self, session_map, tmp_path):
+        """A mutation arriving while a flush is writing is not dropped."""
+        entered = threading.Event()
+        release = threading.Event()
+        real = SessionMap._write_payload
+
+        def gated(self, payload, seq):
+            entered.set()
+            assert release.wait(timeout=10)
+            return real(self, payload, seq)
+
+        with patch.object(SessionMap, "_write_payload", gated):
+            session_map.set("dashboard:first", "sid-first")
+            await _await_event(entered, "the gated flush write to start")
+            # The flush thread is mid-write with a snapshot that predates this:
+            session_map.set("dashboard:trailing", "sid-trailing")
+            release.set()
+            await _settle(session_map)
+
+        persisted = _map_file(tmp_path)
+        assert persisted["dashboard:trailing"]["sid"] == "sid-trailing"
+        assert persisted["dashboard:first"]["sid"] == "sid-first"
+
+    @pytest.mark.asyncio
+    async def test_payload_is_a_snapshot_not_data(self, session_map, tmp_path):
+        """Mutating ``_data`` after the handoff must not change what lands."""
+        entered = threading.Event()
+        release = threading.Event()
+        handed: list[object] = []
+        real = SessionMap._write_payload
+
+        def gated(self, payload, seq):
+            handed.append(payload)
+            entered.set()
+            assert release.wait(timeout=10)
+            return real(self, payload, seq)
+
+        with patch.object(SessionMap, "_write_payload", gated):
+            session_map.set("dashboard:snap", "sid-original")
+            await _await_event(entered, "the gated flush write to start")
+            # Serialization already happened; poke the live structure directly
+            # (bypassing _save so no second flush is owed).
+            session_map._data["dashboard:snap"]["sid"] = "MUTATED-AFTER-HANDOFF"
+            release.set()
+            await _settle(session_map)
+
+        assert handed and not isinstance(
+            handed[0], dict
+        ), "the executor was handed a live structure, not a serialized payload"
+        assert json.loads(handed[0])["dashboard:snap"]["sid"] == "sid-original"
+        assert _map_file(tmp_path)["dashboard:snap"]["sid"] == "sid-original"
+
+    def test_no_running_loop_writes_immediately(self, session_map, tmp_path):
+        """Sync contexts (CLI, worker threads, plain tests) keep inline writes."""
+        session_map.set("dashboard:sync", "sid-sync")
+        assert _map_file(tmp_path)["dashboard:sync"]["sid"] == "sid-sync"
+
+    @pytest.mark.asyncio
+    async def test_get_defers_the_prune_write(self, session_map, tmp_path, monkeypatch):
+        """A stale entry: ``None`` now, removal in memory now, on disk after."""
+        sessions_dir = tmp_path / "kiro-sessions"
+        sessions_dir.mkdir()
+        monkeypatch.setattr("kiro_crew.session_map._KIRO_SESSIONS_DIR", sessions_dir)
+        session_map.set("dashboard:stale", "sid-gone")
+        session_map.flush()
+        assert _map_file(tmp_path)["dashboard:stale"]["sid"] == "sid-gone"
+
+        entered = threading.Event()
+        release = threading.Event()
+        real = SessionMap._write_payload
+
+        def gated(self, payload, seq):
+            entered.set()
+            assert release.wait(timeout=10)
+            return real(self, payload, seq)
+
+        with patch.object(SessionMap, "_write_payload", gated):
+            # sid-gone has no session file → get prunes. The return and the
+            # in-memory removal are immediate; the write is not.
+            assert session_map.get("dashboard:stale") is None
+            assert "dashboard:stale" not in session_map._data
+            assert (
+                _map_file(tmp_path)["dashboard:stale"]["sid"] == "sid-gone"
+            ), "the prune paid its file write inline on the loop"
+            release.set()
+            await _settle(session_map)
+        assert "dashboard:stale" not in _map_file(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_flush_is_deterministic_durability(self, session_map, tmp_path):
+        """After ``flush()`` returns, the file is current — no awaiting needed."""
+        session_map.set("dashboard:durable", "sid-durable")
+        session_map.flush()
+        assert _map_file(tmp_path)["dashboard:durable"]["sid"] == "sid-durable"
+        await _settle(session_map)  # the scheduled task finds a clean map and retires
+        assert session_map._flush_task is None
+
+    def test_stale_inflight_payload_cannot_regress_a_newer_write(self, session_map, tmp_path):
+        """The ticket check: an older snapshot landing late is dropped."""
+        newer, newer_seq = session_map._serialize()
+        session_map._data["dashboard:late"] = {"sid": "sid-late"}
+        older = json.dumps(session_map._data)
+        session_map._data.pop("dashboard:late")
+        session_map._write_payload(newer, newer_seq)
+        # A slow in-flight flush delivering an OLDER ticket after the newer
+        # write must be refused, not land last-writer-wins.
+        session_map._write_payload(older, newer_seq - 1)
+        assert "dashboard:late" not in _map_file(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_write_failure_restores_dirty_and_retries(self, session_map, tmp_path):
+        """A failed flush re-owes the write; the next mutation lands both."""
+        real = SessionMap._write_payload
+        boom = {"armed": True}
+
+        def flaky(self, payload, seq):
+            if boom.pop("armed", False):
+                raise OSError("disk full")
+            return real(self, payload, seq)
+
+        with patch.object(SessionMap, "_write_payload", flaky):
+            session_map.set("dashboard:one", "sid-one")
+            await _settle(session_map)  # first flush fails, dirty restored
+            session_map.set("dashboard:two", "sid-two")
+            await _settle(session_map)
+
+        persisted = _map_file(tmp_path)
+        assert persisted["dashboard:one"]["sid"] == "sid-one"
+        assert persisted["dashboard:two"]["sid"] == "sid-two"
+
+    @pytest.mark.asyncio
+    async def test_cancellation_reowes_and_aflush_lands_it(self, session_map, tmp_path):
+        """A cancelled flush task must not lose state — and must not write.
+
+        Writing from a cancellation path would block the loop mid-teardown, so
+        the contract is re-owe: the state stays pending and the shutdown path's
+        awaited ``aflush`` lands it off-loop.
+        """
+        session_map.set("dashboard:shutdown", "sid-shutdown")
+        task = session_map._flush_task
+        assert task is not None
+        # Park the task in its debounce sleep, then cancel mid-flight.
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert session_map._dirty, "cancellation must re-owe the pending write"
+        await session_map.aflush()
+        assert _map_file(tmp_path)["dashboard:shutdown"]["sid"] == "sid-shutdown"
+
+    @pytest.mark.asyncio
+    async def test_cancel_before_first_step_reowes_and_aflush_lands_it(self, session_map, tmp_path):
+        """A task cancelled before EVER running must not strand pending state.
+
+        A cancelled-before-start coroutine body never executes, so nothing has
+        consumed the dirty mark: the state is still owed, the next mutation
+        would reschedule (the task is done), and the shutdown ``aflush`` lands
+        it. This is the loop-shutdown shape: create_task, then teardown
+        cancels everything before the debounce elapses.
+        """
+        session_map.set("dashboard:early", "sid-early")
+        task = session_map._flush_task
+        assert task is not None
+        task.cancel()  # deliberately NO yield first — the body never runs
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert session_map._dirty, "an unstarted task must leave the write owed"
+        await session_map.aflush()
+        assert _map_file(tmp_path)["dashboard:early"]["sid"] == "sid-early"
+
+    @pytest.mark.asyncio
+    async def test_aflush_covers_a_claimed_but_unwritten_snapshot(self, session_map, tmp_path):
+        """aflush() must not report clean while a claimed snapshot is unwritten."""
+        entered = threading.Event()
+        release = threading.Event()
+        calls: list[int] = []
+        real = SessionMap._write_payload
+
+        def gated(self, payload, seq):
+            calls.append(seq)
+            if len(calls) == 1:
+                entered.set()
+                assert release.wait(timeout=10)
+            return real(self, payload, seq)
+
+        with patch.object(SessionMap, "_write_payload", gated):
+            session_map.set("dashboard:aclaimed", "sid-aclaimed")
+            await _await_event(entered, "the flush task to claim the snapshot")
+            release.set()  # aflush's own write queues behind this on _io_lock
+            await session_map.aflush()
+            assert _map_file(tmp_path)["dashboard:aclaimed"]["sid"] == "sid-aclaimed"
+            await _settle(session_map)
+
+    @pytest.mark.asyncio
+    async def test_flush_covers_a_claimed_but_unwritten_snapshot(self, session_map, tmp_path):
+        """flush() during an in-flight claimed snapshot must still write.
+
+        The flush task consumes the dirty mark when it CLAIMS a snapshot, so a
+        dirty-only predicate would let flush() return while the worker thread
+        has not landed anything — a stale file behind a "deterministic
+        durability point". The file must be current before flush() returns,
+        with the gated task write still unreleased.
+        """
+        entered = threading.Event()
+        release = threading.Event()
+        calls: list[int] = []
+        real = SessionMap._write_payload
+
+        def gated(self, payload, seq):
+            calls.append(seq)
+            if len(calls) == 1:
+                # Only the task's write blocks; flush()'s inline write passes.
+                entered.set()
+                assert release.wait(timeout=10)
+            return real(self, payload, seq)
+
+        with patch.object(SessionMap, "_write_payload", gated):
+            session_map.set("dashboard:claimed", "sid-claimed")
+            await _await_event(entered, "the flush task to claim the snapshot")
+            # Dirty is consumed, nothing is on disk yet. flush() must not no-op.
+            session_map.flush()
+            assert (
+                _map_file(tmp_path)["dashboard:claimed"]["sid"] == "sid-claimed"
+            ), "flush() returned while the claimed snapshot was still unwritten"
+            release.set()
+            await _settle(session_map)
+        # The task's older ticket must not have regressed the forced write.
+        assert _map_file(tmp_path)["dashboard:claimed"]["sid"] == "sid-claimed"
+
+    @pytest.mark.asyncio
+    async def test_batched_save_still_writes_once_on_exit(self, session_map, tmp_path):
+        """A batch on the loop stays one inline write; no redundant flush after."""
+        renames: list[int] = []
+        import kiro_crew.session_map as mod
+
+        # Process-global patch, same caveat as above.
+        real_replace = mod.os.replace
+
+        def counting_replace(src, dst):
+            renames.append(1)
+            return real_replace(src, dst)
+
+        with patch.object(mod.os, "replace", counting_replace):
+            with session_map.batched_save():
+                session_map.set("dashboard:a", "sid-a")
+                session_map.set("dashboard:b", "sid-b")
+            batch_renames = len(renames)
+            await _settle(session_map)
+        assert batch_renames == 1
+        assert len(renames) == 1, "a flush task rewrote state the batch exit already landed"
+        persisted = _map_file(tmp_path)
+        assert persisted["dashboard:a"]["sid"] == "sid-a"
+        assert persisted["dashboard:b"]["sid"] == "sid-b"

--- a/test/test_session_map_locking.py
+++ b/test/test_session_map_locking.py
@@ -413,6 +413,80 @@ class TestLockRatchet:
         assert not _touches_map_structure(scan)
 
 
+class TestNoLockAcrossFlushAwait:
+    """The deferred flush must never hold ``_MAP_LOCK`` across its await.
+
+    Extends property 4b to the flush path: serialization happens inside the
+    guarded sync helpers, and only the already-serialized payload crosses into
+    ``asyncio.to_thread``. Two shapes would break that, and both are ratcheted
+    structurally: an ``async def`` in the module decorated ``@_guarded`` (the
+    wrapper would take the lock only to build the coroutine object — a no-op
+    that reads as protection), and a ``with _MAP_LOCK`` block inside an
+    ``async def`` whose body awaits.
+    """
+
+    @staticmethod
+    def _async_defs(tree: ast.AST):
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef):
+                yield node
+
+    def test_no_async_def_is_guarded(self):
+        offenders = []
+        tree = ast.parse((SRC / "session_map.py").read_text(encoding="utf-8"))
+        for fn in self._async_defs(tree):
+            decorators = {d.id for d in fn.decorator_list if isinstance(d, ast.Name)}
+            if "_guarded" in decorators:
+                offenders.append(fn.name)
+        assert offenders == [], (
+            f"async functions decorated @_guarded: {offenders}. The wrapper "
+            "releases the lock as soon as the coroutine OBJECT is built, so the "
+            "decoration is not protection — and making it real would hold the "
+            "lock across an await."
+        )
+
+    def test_no_map_lock_block_awaits(self):
+        offenders: list[str] = []
+        tree = ast.parse((SRC / "session_map.py").read_text(encoding="utf-8"))
+        for fn in self._async_defs(tree):
+            for node in ast.walk(fn):
+                if not isinstance(node, (ast.With, ast.AsyncWith)):
+                    continue
+                holds_map_lock = any(
+                    isinstance(item.context_expr, ast.Name)
+                    and item.context_expr.id == "_MAP_LOCK"
+                    for item in node.items
+                )
+                if not holds_map_lock:
+                    continue
+                for inner in ast.walk(node):
+                    if isinstance(inner, (ast.Await, ast.AsyncFor, ast.AsyncWith)):
+                        offenders.append(f"{fn.name}:{inner.lineno}")
+        assert offenders == [], (
+            f"_MAP_LOCK is held across an await at: {offenders}. Serialize "
+            "under the lock, write off-lock — a lock held across the flush "
+            "await lets a coroutine interleave while worker threads stall."
+        )
+
+    def test_ratchet_detects_a_lock_held_across_await(self):
+        tree = ast.parse(
+            "async def f(s):\n"
+            "    with _MAP_LOCK:\n"
+            "        payload = s._serialize()\n"
+            "        await asyncio.to_thread(s._write_payload, payload)\n"
+        )
+        fns = list(self._async_defs(tree))
+        assert len(fns) == 1
+        found = False
+        for node in ast.walk(fns[0]):
+            if isinstance(node, ast.With) and any(
+                isinstance(i.context_expr, ast.Name) and i.context_expr.id == "_MAP_LOCK"
+                for i in node.items
+            ):
+                found = found or any(isinstance(n, ast.Await) for n in ast.walk(node))
+        assert found
+
+
 class TestNoAwaitInsideBatch:
     """Property 4b: no ``batched_save`` block anywhere in the tree awaits."""
 

--- a/test/test_slack_handler_coverage.py
+++ b/test/test_slack_handler_coverage.py
@@ -1123,7 +1123,9 @@ class TestPrivacyModifiers:
         await h._apply_incognito_modifier("t1", "U1", "C1", slack, sessions, "t1")
         # Assert real durability rather than that set_flag was called: a FRESH
         # map must read both flags back off disk, which is the property the
-        # restart path actually depends on.
+        # restart path actually depends on. Loop-side mutations defer their
+        # disk write, so force the flush — the deterministic durability point.
+        sessions._session_map.flush()
         fresh = SessionMap()
         assert fresh.get_flag("t1", "temporary") is True
         assert fresh.get_flag("t1", "incognito") is True


### PR DESCRIPTION
## What

`SessionMap` persisted by rewriting the whole map file synchronously on the caller's thread, so every mutation made on the event loop — each session creation's `get()`, each subagent spawn's `set()` — paid a full-file disk write inline, scaling with map size.

This change defers loop-side writes to a debounced snapshot flush:

- `_save()` on the loop marks the map dirty and schedules ONE flush task; off the loop (CLI, tests, worker threads) writes stay inline exactly as before.
- The flush task serializes under `_MAP_LOCK` into an immutable JSON payload, then does the tmp+rename in a worker thread via `asyncio.to_thread`. `_data` never crosses the thread boundary, and the lock is never held across the await (structurally ratcheted in `test_session_map_locking.py`).
- Coalescing never drops the trailing write: the task loops until it observes a clean map, and a per-snapshot ticket in `_write_payload` keeps a slow in-flight payload from landing an older map over a newer forced write.
- `flush()` (sync contexts) and `aflush()` (awaited) are the deterministic durability points, sharing a progress-based claim (dirty OR claimed-but-unwritten snapshot), so neither can no-op while a worker write is in flight.
- Flush-task cancellation **re-owes** the pending state without writing (a cancellation-path write would block the very teardown that cancelled it). `SessionManager.close_all()` awaits `aflush()` — the awaited, off-loop durability point — after saving mappings, because the gateway exits via `os._exit`, which never cancels tasks. This covers a task cancelled before its first step too: nothing consumed the dirty mark, so the state is still owed.
- `get()`'s stale-entry prune returns `None` immediately and drops the entry from memory immediately; only its disk write rides the deferred flush. `has_hint()` is untouched. Crash consistency stays "well-formed older map, never truncated" (tmp+rename preserved).

## Note for reviewers reading issue #2405

The issue's premise that the map is *unlocked* ("a worker thread cannot be used because it is unlocked") predates `_MAP_LOCK` (#2989). The lock exists now and is exactly what makes this offload safe; the fix is scoped to what remained: the single-mutation case and the write happening on the loop.

## Tested

- 12 new tests in `test/test_session_map_flush.py`: burst pays zero inline loop writes and coalesces to one off-thread write (fails before this change: one inline `os.replace` per mutation), trailing-mutation durability through an in-flight flush, snapshot immutability across the thread boundary, no-loop inline path, `get()` prune-defer, deterministic `flush()` (including during a claimed-but-unwritten snapshot), stale-ticket regression guard, write-failure retry, cancellation both mid-flight and before-first-step (re-owe + `aflush` lands it), `aflush` during a claimed-but-unwritten snapshot, batched exit still one write.
- 3 new ratchets in `test_session_map_locking.py`: no async def is `@_guarded`, no `_MAP_LOCK` block awaits, plus a detector self-check.
- Full local gates: isort, flake8, mypy clean; full pytest 49,866 passed with the failure set byte-identical to pristine main on the same host (19 pre-existing environment failures, verified apples-to-apples on the same file set).
- Three existing tests that asserted immediate durability after a loop-side mutation now force it via `flush()`; the one-time legacy migration in `_load()` writes inline so fresh-instance readbacks of migrated maps stay exact.

## Pre-push review

Two model-pinned reviewers (GPT 5.6 Sol, Opus 5) each raised the same two blocking findings — the `flush()` claimed-snapshot gap and the unreachable cancellation net under `os._exit` — both fixed and test-pinned here. Opus advisories on comment accuracy, ratchet accumulation, bounded test waits, and patch-scope comments applied; two Low advisories accepted as-is (the prune-defer window is what #2405 specifies; a failed flush retries on the next mutation and is now also covered by the shutdown flush).

Closes #2405

