### PR TITLE
fix(crew-companion): open the session a waiting-on-you bubble is about

### DIFF
--- a/website/electron/crew-companion/index.js
+++ b/website/electron/crew-companion/index.js
@@ -89,6 +89,15 @@ async function tokenForProbe(forceMint) {
 }
 
 /**
+ * Resolve the dashboard window a notification should be opened in.
+ *
+ * Supplied by main.js, which owns window lifecycle; the same shape `initMochi`
+ * takes its `getMainWindow` in. Absent when the companion is initialised without
+ * it, in which case the CTA reports that it could not act rather than pretending.
+ */
+let getDashboardWindow = null;
+
+/**
  * Ask the gateway whether the app is enabled.
  *
  * ``unauthorized`` is split out from ``unknown`` so a cached token that the
@@ -130,6 +139,142 @@ function probeEnabled(token) {
     });
     req.on("error", () => resolve("unknown"));
   });
+}
+
+/**
+ * True when *wc* currently hosts the dashboard itself.
+ *
+ * The `navigate` message is only listened for by the dashboard SPA. Every other
+ * page this view can hold drops it silently: the boot and recovery splashes
+ * (`loading.html`, loaded as `file://`), an error page, or a view still blank
+ * mid-load. Sending into one of those and returning true would tell the overlay
+ * the session had been opened, and the caller dismisses a sticky notification on
+ * that word — so the notification is lost and the session never opens.
+ *
+ * Matched on ORIGIN rather than on a full URL, because the dashboard's address
+ * carries a `?token=` and any in-app route: same origin is exactly the property
+ * that decides whether the SPA — and therefore the listener — is loaded.
+ *
+ * @param {object} wc the view's webContents.
+ * @returns {boolean} true only for a page served from the dashboard's origin.
+ */
+function hostsDashboard(wc) {
+  if (!backendUrl) return false;
+  let current = "";
+  try {
+    current = (wc.getURL && wc.getURL()) || "";
+  } catch {
+    return false; // torn down between the isDestroyed() check and here
+  }
+  try {
+    return new URL(current).origin === new URL(backendUrl).origin;
+  } catch {
+    return false; // "", about:blank, or a file:// splash — not the dashboard
+  }
+}
+
+/**
+ * True when the view holds a page from some OTHER web origin.
+ *
+ * The complement of :func:`hostsDashboard` is not one state but two, and only
+ * one of them is a security problem:
+ *
+ * * the app's own local shell -- "", `about:blank`, or the `file://` splash --
+ *   is this window on its way to becoming the dashboard. Nothing foreign is
+ *   displayed and nothing has been navigated away from.
+ * * an `http(s)` origin that is not the backend's is a page the dashboard
+ *   window is not supposed to be showing at all.
+ *
+ * `hostsDashboard` answers false for both, which is right for ROUTING (neither
+ * can receive a `navigate`) and wrong for AUTHORIZATION (only the second means
+ * the caller must be refused). This predicate isolates the second.
+ *
+ * @param {object} wc the view's webContents.
+ * @returns {boolean} true only for a committed non-backend web origin.
+ */
+function showsForeignOrigin(wc) {
+  let current = "";
+  try {
+    current = (wc.getURL && wc.getURL()) || "";
+  } catch {
+    return false; // torn down; the isDestroyed() check owns that case
+  }
+  let url;
+  try {
+    url = new URL(current);
+  } catch {
+    return false; // "", about:blank, or a relative shell path — not foreign
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  if (!backendUrl) return true; // a web page with no backend to compare against
+  try {
+    return url.origin !== new URL(backendUrl).origin;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Surface the dashboard for a notification's session.
+ *
+ * The overlay cannot do this itself: it is a full-display, non-focusable window
+ * that knows nothing about the dashboard's windows, so — exactly like the panel's
+ * `crew-companion:panel-open` — it asks the main process to raise the right one.
+ * The route is the dashboard's own session deep link, the same `?sid=` the System
+ * page's session rows and the app SDK build.
+ *
+ * An empty *slotKey* means the notification names no session (an approval raised
+ * with no owning conversation carries `slot: ""`). The dashboard is still
+ * surfaced — that is where the approvals surface lives — but nothing is routed,
+ * because navigating away from whatever the user had open would claim to have
+ * opened a session that was never identified.
+ *
+ * @param {string} slotKey dashboard slot key, or "" when there is no session.
+ * @returns {boolean} true when the dashboard was surfaced; false when there was
+ *   no window able to receive the request, so the caller can KEEP a notification
+ *   it could not act on instead of dismissing it.
+ */
+function openDashboardSession(slotKey) {
+  const win = getDashboardWindow && getDashboardWindow();
+  if (!win || win.isDestroyed()) return false;
+  // Resolved BEFORE the window is raised: a routing request that cannot be
+  // delivered must fail whole, not leave the dashboard focused on the wrong
+  // session while the overlay is told the session was opened.
+  const view = win._mcView;
+  const wc = view && view.webContents;
+  // Caller authorization and slot routing are SEPARATE questions, and only the
+  // second one depends on naming a session.
+  //
+  // Unconditional: a missing or destroyed view, and a view showing a foreign web
+  // origin, are both refusals whether or not a slot was named. Gating the whole
+  // check on a non-empty slotKey let a slot-less approval land on whatever a
+  // focused secondary window happened to be showing and still answer true — so
+  // the overlay dismissed a sticky notification it had never acted on while the
+  // gateway stayed blocked. `getDashboardWindow` cannot prevent this on its own:
+  // it takes the focused window whenever it merely HAS an `_mcView`.
+  if (!wc || wc.isDestroyed() || showsForeignOrigin(wc)) return false;
+  // Is the SPA — and therefore the approvals surface and the navigate listener —
+  // actually there? The local shell ("", about:blank, the file:// splash) is
+  // this window on its way to the dashboard, so it is ours to raise but has
+  // nothing loaded yet.
+  const ready = hostsDashboard(wc);
+  // A request that NAMES a session must fail whole, before the window moves: a
+  // route that cannot be delivered must not leave the dashboard focused while
+  // the overlay is told the session was opened.
+  if (slotKey && !ready) return false;
+  if (win.isMinimized()) win.restore();
+  win.show();
+  win.focus();
+  // SURFACING and ACKNOWLEDGING are different answers, and the return value is
+  // the second one — the overlay dismisses a sticky notification on true.
+  // Raising a loading window is honest and useful; claiming the approval has
+  // somewhere to be acted on is not, because the surface that would show it has
+  // not loaded. Answering true here dropped the user's only pointer to work the
+  // gateway is still blocked on. So the window comes forward and the
+  // notification STAYS.
+  if (!ready) return false;
+  if (slotKey) wc.send("navigate", `/chat?sid=${encodeURIComponent(slotKey)}`);
+  return true;
 }
 
 async function reconcileOnce() {
@@ -186,12 +331,14 @@ async function reconcileOnce() {
 /**
  * Start following the app's enabled state.
  *
- * @param {{backendUrl: string, fetchLocalToken: () => Promise<string>, glog: (m: string) => void}} deps
+ * @param {{backendUrl: string, fetchLocalToken: () => Promise<string>, glog: (m: string) => void,
+ *   getDashboardWindow?: () => (object | null)}} deps
  */
 function initCrewCompanion(deps) {
   backendUrl = (deps && deps.backendUrl) || "";
   fetchLocalToken = deps && deps.fetchLocalToken;
   log = (deps && deps.glog) || (() => {});
+  getDashboardWindow = (deps && deps.getDashboardWindow) || null;
   setOverlayLogger(log);
   setPanelLogger(log);
   setGalleryLogger(log);
@@ -232,6 +379,18 @@ function initCrewCompanion(deps) {
     if (focusable) win.focus();
   });
 
+  /**
+   * "Open session" on a waiting-on-you bubble.
+   *
+   * `handle`, not `on`, because the answer is what makes the CTA honest: the
+   * overlay clears the notification only once the dashboard has actually been
+   * surfaced, and a sticky approval bubble is the only pointer the user has back
+   * to the blocked session. `removeHandler` first so a second init cannot throw
+   * on the duplicate registration.
+   */
+  ipcMain.removeHandler("crew-companion:open-session");
+  ipcMain.handle("crew-companion:open-session", (_event, slotKey) =>
+    openDashboardSession(typeof slotKey === "string" ? slotKey : ""));
 
   if (timer) clearInterval(timer);
   timer = setInterval(() => void reconcileOnce(), TICK_MS);
@@ -264,4 +423,5 @@ module.exports = {
   // Exported for tests: they drive the tick directly rather than waiting 5s.
   reconcileOnce,
   probeEnabled,
+  openDashboardSession,
 };

--- a/website/electron/crew-companion/pet-preload.js
+++ b/website/electron/crew-companion/pet-preload.js
@@ -103,6 +103,26 @@ contextBridge.exposeInMainWorld("crewCompanion", {
   },
 
   /**
+   * Open the session a waiting-on-you notification is about.
+   *
+   * Must go through the main process for the same reason `panelOpen` does: this
+   * overlay is a non-focusable full-display window with no handle on the
+   * dashboard, so raising and routing the dashboard is not something it can do
+   * for itself.
+   *
+   * `invoke`, not `send`, because the renderer needs the ANSWER: the CTA is the
+   * only exit a sticky approval bubble has, so it clears the notification only
+   * once the dashboard has actually been surfaced.
+   *
+   * @param {string} slotKey dashboard slot key, or "" when the notification
+   *   names no session — the dashboard is raised, nothing is routed.
+   * @returns {Promise<boolean>} whether the dashboard was surfaced.
+   */
+  openSession(slotKey) {
+    return ipcRenderer.invoke("crew-companion:open-session", String(slotKey || ""));
+  },
+
+  /**
    * Open a link in the user's real browser.
    *
    * Must go through the main process: `window.open` from here opens another Electron

--- a/website/electron/crew-companion/test/petOverlay.test.js
+++ b/website/electron/crew-companion/test/petOverlay.test.js
@@ -16,6 +16,8 @@ const Module = require("module");
 function stubElectron() {
   const created = [];
   const ipcHandlers = {};
+  /** `ipcMain.handle` channels — the ones that answer, kept apart from `on`. */
+  const ipcInvokers = {};
 
   class FakeWindow {
     constructor(opts) {
@@ -55,7 +57,16 @@ function stubElectron() {
         { id: 2, bounds: { x: 1440, y: 0, width: 1920, height: 1080 } },
       ],
     },
-    ipcMain: { on: (ch, cb) => { ipcHandlers[ch] = cb; } },
+    ipcMain: {
+      on: (ch, cb) => { ipcHandlers[ch] = cb; },
+      // Electron throws on a second `handle` for one channel, so the real
+      // registration removes first; the stub mirrors both halves.
+      handle: (ch, cb) => {
+        if (ipcInvokers[ch]) throw new Error(`second handler for '${ch}'`);
+        ipcInvokers[ch] = cb;
+      },
+      removeHandler: (ch) => { delete ipcInvokers[ch]; },
+    },
     contextBridge: { exposeInMainWorld: () => {} },
     ipcRenderer: { send: () => {} },
   };
@@ -72,6 +83,7 @@ function stubElectron() {
     created,
     ipcHandlers,
     dockCalls,
+    ipcInvokers,
     restore() {
       Module._resolveFilename = realResolve;
       delete require.cache.electron;
@@ -418,6 +430,412 @@ test("showing an overlay re-asserts the host's Dock presence on macOS", () => {
       "activation policy re-asserted to regular after showing the overlay",
     );
     assert.ok(stub.dockCalls.dockShow >= 1, "app.dock.show() called after showing the overlay");
+  } finally {
+    stub.restore();
+  }
+});
+
+// ── "Open session" ──────────────────────────────────────────────────────────
+//
+// The overlay is a non-focusable full-display window with no handle on the
+// dashboard, so its waiting-on-you CTA can only ASK the main process to surface
+// the right window. What is pinned here is the answer as much as the action: the
+// CTA is the only exit a sticky approval bubble has, and it clears that bubble
+// only when this reports the dashboard was actually surfaced.
+
+/** A dashboard window as `main.js` hands it over, with its SPA view attached. */
+function fakeDashboard({
+  minimized = false,
+  viewGone = false,
+  // Defaults to the dashboard's own origin: every case that is not about WHICH
+  // page the view holds should read as "the dashboard is loaded".
+  url = "http://127.0.0.1:9/?token=t",
+} = {}) {
+  const sent = [];
+  return {
+    sent,
+    restored: false,
+    shown: false,
+    focused: false,
+    isDestroyed: () => false,
+    isMinimized() { return minimized; },
+    restore() { this.restored = true; },
+    show() { this.shown = true; },
+    focus() { this.focused = true; },
+    _mcView: {
+      webContents: {
+        isDestroyed: () => viewGone,
+        getURL: () => url,
+        send: (channel, arg) => sent.push([channel, arg]),
+      },
+    },
+  };
+}
+
+test("open-session surfaces the dashboard and routes it to that session", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    const win = fakeDashboard({ minimized: true });
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    assert.strictEqual(index.openDashboardSession("chat-7-1785905004"), true);
+    // Minimised to the taskbar is the case that makes plain focus() insufficient.
+    assert.ok(win.restored && win.shown && win.focused, "window must be surfaced");
+    assert.deepStrictEqual(win.sent, [["navigate", "/chat?sid=chat-7-1785905004"]]);
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("open-session encodes the slot key rather than splicing it into the query", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    const win = fakeDashboard();
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    // Slot keys carry user-chosen names; an unencoded `&` would silently drop the
+    // rest of the key and open a different session.
+    index.openDashboardSession("chat a&b");
+    assert.deepStrictEqual(win.sent, [["navigate", "/chat?sid=chat%20a%26b"]]);
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("an approval with no owning session raises the dashboard but routes nowhere", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    const win = fakeDashboard();
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    // Unowned approvals are broadcast with slot:"" and live on the dashboard's own
+    // approvals surface. Navigating anyway would claim to have opened a session
+    // that was never identified — and throw away whatever the user had open.
+    assert.strictEqual(index.openDashboardSession(""), true);
+    assert.ok(win.shown && win.focused, "the dashboard is still surfaced");
+    assert.deepStrictEqual(win.sent, [], "nothing is routed");
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("open-session refuses when there is no dashboard window to surface", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => null,
+    });
+
+    // False is what keeps the notification: the overlay leaves a sticky bubble up
+    // rather than dismissing the user's only pointer to blocked work.
+    assert.strictEqual(index.openDashboardSession("chat-7"), false);
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a routing request that cannot be delivered fails whole, without raising", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    const win = fakeDashboard({ viewGone: true });
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    // A window mid-teardown can be raised but not routed. Raising it anyway would
+    // leave the dashboard focused on the WRONG session while the overlay was told
+    // the right one had been opened.
+    assert.strictEqual(index.openDashboardSession("chat-7"), false);
+    assert.ok(!win.shown && !win.focused, "no half-done surface");
+    assert.deepStrictEqual(win.sent, []);
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("the renderer's open-session channel answers rather than fires and forgets", async () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    const win = fakeDashboard();
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    // `handle`, not `on`: the overlay needs the outcome before it clears a bubble.
+    const handler = stub.ipcInvokers["crew-companion:open-session"];
+    assert.ok(handler, "open-session must be registered as an invokable channel");
+    assert.strictEqual(await handler({}, "chat-7"), true);
+    assert.deepStrictEqual(win.sent, [["navigate", "/chat?sid=chat-7"]]);
+
+    // A renderer that sends something that is not a string must not reach
+    // encodeURIComponent with it; it is read as "no session named".
+    win.sent.length = 0;
+    assert.strictEqual(await handler({}, { slot: "chat-7" }), true);
+    assert.deepStrictEqual(win.sent, []);
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("re-initialising does not throw on the already-registered channel", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    const deps = {
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => null,
+    };
+    index.initCrewCompanion(deps);
+    index.initCrewCompanion(deps);
+    assert.ok(stub.ipcInvokers["crew-companion:open-session"]);
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("open-session refuses while the view shows the boot/recovery splash", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    // What the gateway-recovery and boot paths put on screen: loading.html,
+    // loaded from disk. It has no `navigate` listener, so the message would be
+    // dropped — and the caller dismisses the sticky notification on a `true`.
+    const win = fakeDashboard({ url: "file:///C:/app/electron/loading.html" });
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    assert.strictEqual(
+      index.openDashboardSession("chat-7"),
+      false,
+      "acknowledged a navigation the splash cannot perform",
+    );
+    assert.deepStrictEqual(win.sent, [], "navigate must not be sent to the splash");
+    assert.ok(!win.shown && !win.focused, "no half-done surface");
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("open-session refuses while the view is still blank", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    // A view created but not yet navigated reports an empty URL.
+    const win = fakeDashboard({ url: "" });
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    assert.strictEqual(index.openDashboardSession("chat-7"), false);
+    assert.deepStrictEqual(win.sent, []);
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("open-session refuses when the view holds a foreign origin", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    const win = fakeDashboard({ url: "https://example.com/chat?sid=chat-7" });
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    assert.strictEqual(index.openDashboardSession("chat-7"), false);
+    assert.deepStrictEqual(
+      win.sent,
+      [],
+      "a session key must never be sent to a page that is not the dashboard",
+    );
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("open-session still routes when the dashboard is on an in-app route", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    // Preservation: the guard matches on ORIGIN, so a dashboard already deep in
+    // the SPA (its own route, its own token query) must still be routable.
+    const win = fakeDashboard({ url: "http://127.0.0.1:9/system?token=abc123" });
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    assert.strictEqual(index.openDashboardSession("chat-9"), true);
+    assert.deepStrictEqual(win.sent, [["navigate", "/chat?sid=chat-9"]]);
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("open-session with no session key surfaces a splash window but does NOT acknowledge", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    // The empty-key contract still holds where it was right: this window is the
+    // app's own, so raising it is useful and safe even mid-load.
+    //
+    // What changed is the ANSWER. The return value is what the overlay reads to
+    // dismiss a sticky notification, and a loading window has no approvals
+    // surface yet -- so reporting success threw away the user's only pointer to
+    // work the gateway is still blocked on. Surfacing and acknowledging are now
+    // separate: the window comes forward, and the notification stays.
+    const win = fakeDashboard({ url: "file:///C:/app/electron/loading.html" });
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    assert.strictEqual(
+      index.openDashboardSession(""),
+      false,
+      "a loading window acknowledged an approval it cannot yet surface",
+    );
+    assert.ok(win.shown && win.focused, "the dashboard window must still be raised");
+    assert.deepStrictEqual(win.sent, []);
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a slot-less approval is refused when the window shows a foreign origin", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    // `getDashboardWindow` is `focusedDashboardWindow()`, which returns the
+    // focused window whenever it merely HAS an `_mcView` -- it never checks what
+    // that view is showing. So a focused secondary window on another origin does
+    // reach here.
+    const win = fakeDashboard({ url: "https://example.invalid/other" });
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    // Caller authorization does not depend on naming a session. Answering true
+    // here told the overlay to dismiss a sticky notification it had not acted
+    // on, while the gateway stayed blocked on the approval.
+    assert.strictEqual(
+      index.openDashboardSession(""),
+      false,
+      "a slot-less approval bypassed the origin check",
+    );
+    assert.ok(!win.shown, "the window was raised before the check refused");
+    assert.ok(!win.focused, "the window was focused before the check refused");
+    assert.deepStrictEqual(win.sent, [], "nothing is routed");
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a slot-less approval is refused when the view is gone", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    const win = fakeDashboard({ viewGone: true });
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    assert.strictEqual(
+      index.openDashboardSession(""),
+      false,
+      "a slot-less approval was accepted by a destroyed view",
+    );
+    assert.ok(!win.shown, "the window was raised before the check refused");
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a ROUTED approval is still refused on the splash it cannot deliver to", () => {
+  const stub = stubElectron();
+  try {
+    const { index } = loadModules();
+    // The other side of the split: the local shell is not foreign, so it passes
+    // authorization -- but it cannot receive a `navigate`, so a request that
+    // names a slot must still fail whole rather than raise the window and lie.
+    const win = fakeDashboard({ url: "file:///C:/app/electron/loading.html" });
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "",
+      glog: () => {},
+      getDashboardWindow: () => win,
+    });
+
+    assert.strictEqual(index.openDashboardSession("chat-7"), false);
+    assert.ok(!win.shown, "the window was raised for a route it cannot deliver");
+    assert.deepStrictEqual(win.sent, []);
+    index.shutdownCrewCompanion();
   } finally {
     stub.restore();
   }

--- a/website/electron/crew-companion/test/tokenReuse.test.js
+++ b/website/electron/crew-companion/test/tokenReuse.test.js
@@ -34,7 +34,7 @@ function loadCompanion(wiring) {
   const originalLoad = Module._load;
   const stubs = {
     electron: {
-      ipcMain: { on() {}, handle() {} },
+      ipcMain: { on() {}, handle() {}, removeHandler() {} },
       BrowserWindow: { fromWebContents: () => null },
     },
   };

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -4283,7 +4283,15 @@ app.whenReady().then(async () => {
   // Same shape and the same best-effort contract: the companion's windows follow
   // the app's enabled state, and a failure here must never block the dashboard.
   try {
-    initCrewCompanion({ backendUrl: BACKEND_URL, fetchLocalToken, glog });
+    // `getDashboardWindow` is what lets the companion's "Open session" CTA reach a
+    // dashboard route: the same window the app menu's Settings…/About items target,
+    // resolved here because main.js owns window lifecycle.
+    initCrewCompanion({
+      backendUrl: BACKEND_URL,
+      fetchLocalToken,
+      glog,
+      getDashboardWindow: () => focusedDashboardWindow() || null,
+    });
   } catch (err) {
     glog(`crew-companion: init failed — ${err && err.message}`);
   }

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -13,7 +13,7 @@ import { getBuiltinSurfaces, getBuiltinSurface, selectSurfaceBadgeCount, selectS
 import { createSlot, appendSlotMessage, setAgentSwitchNotice, setSlotRunning, switchSlot, selectActiveSlotProject } from './store/chatSlice'
 import { queryComposer } from './pages/chat/composerFocus'
 import { setNavIntentHandler as setArtifactNavIntentHandler } from './utils/artifactPopout'
-import { applyNavIntentInMain } from './utils/navIntent'
+import { applyNavIntentInMain, chatDeepLinkSlot } from './utils/navIntent'
 import { installSoftNavigate } from './utils/errorReport'
 import { agentSwitchFailureMessage } from './utils/agentSwitchFeedback'
 import { readSendReceipt } from './utils/sendDelivery'
@@ -2013,16 +2013,35 @@ export default function App() {
     const electronAPI = (window as Window & { electronAPI?: { setDevMode?: (v: boolean) => void } }).electronAPI
     electronAPI?.setDevMode?.(devMode)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
-  // Native app-menu navigation (Settings…, About): the Electron main process
-  // sends an in-app path; route to it. Accept only plain absolute app paths —
-  // rejects protocol-relative ("//host") and external URLs by construction.
+  // Native app-menu navigation (Settings…, About) and the Crew Companion's "Open
+  // session" CTA: the Electron main process sends an in-app path; route to it.
+  // Accept only plain absolute app paths — rejects protocol-relative ("//host")
+  // and external URLs by construction.
+  //
+  // A session deep link takes the same route a popout's nav intent does — select
+  // the session, then navigate — rather than a bare navigate. `?sid=` is read by
+  // ChatPage only while it MOUNTS, so from an already-open /chat a bare navigate
+  // would surface the dashboard with the previous session still on screen: the
+  // window comes forward and the notification appears to have opened nothing.
   useEffect(() => {
     const electronAPI = (window as Window & { electronAPI?: { onNavigate?: (cb: (path: string) => void) => () => void } }).electronAPI
     if (!electronAPI?.onNavigate) return
     return electronAPI.onNavigate(path => {
-      if (typeof path === 'string' && /^\/(?!\/)/.test(path)) navigate(path)
+      if (typeof path !== 'string' || !/^\/(?!\/)/.test(path)) return
+      const slotKey = chatDeepLinkSlot(path)
+      if (slotKey) {
+        applyNavIntentInMain(
+          // `path` is deliberately dropped in favour of the bare route: a
+          // NavIntent carries no query string, and ChatPage writes `?sid=` back
+          // into the URL itself once the session is active.
+          { path: '/chat', slotKey },
+          { navigate, switchSlot: (key) => { dispatch(switchSlot(key)) } },
+        )
+        return
+      }
+      navigate(path)
     })
-  }, [navigate])
+  }, [navigate, dispatch])
   // Dismiss the dev-page notification dot once the user visits /developer
   useEffect(() => {
     if (location.pathname === '/developer') setDevPageSeen(true)

--- a/website/src/apps/crew-companion/Bubble.tsx
+++ b/website/src/apps/crew-companion/Bubble.tsx
@@ -15,19 +15,36 @@ import { ArrowRight, X } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import './bubble.css'
 import { i18nT } from '../../i18n/t'
-import { policyFor, isSticky, type NotifKind } from './notificationPolicy'
+import { policyFor, isSticky, type BubbleAction, type NotifKind } from './notificationPolicy'
 
 export interface BubbleProps {
   text: string
   kind: NotifKind
   /** Dismiss it. Called by the ✕, by a click on the body, and by the timer. */
   onDismiss: () => void
-  /** Run the bubble's call to action, when its policy offers one. */
-  onAction?: (action: 'breathe' | 'open-session') => void
+  /**
+   * Run the bubble's call to action, when its policy offers one.
+   *
+   * The RESULT decides whether the bubble then leaves. Returning nothing means
+   * "done" — the handler acted locally and there is nothing to fail — while
+   * `false`, or a promise resolving to `false`, says the action could not be
+   * carried out and the notification must stay.
+   *
+   * That distinction is the whole point of the contract: a sticky bubble has no ✕
+   * and ignores body clicks, so its CTA is the only exit. Clearing it regardless
+   * of what the handler managed to do destroys the user's only pointer back to
+   * work that is still blocked on them.
+   */
+  onAction?: (action: BubbleAction) => boolean | void | Promise<boolean | void>
 }
 
 /** Exit animation duration; the unmount waits exactly this long. */
 const EXIT_MS = 300
+
+/** True for a value that reports its outcome later. */
+function isThenable(v: unknown): v is Promise<boolean | void> {
+  return typeof (v as Promise<unknown> | undefined)?.then === 'function'
+}
 
 export function Bubble({ text, kind, onDismiss, onAction }: BubbleProps) {
   const policy = policyFor(kind)
@@ -182,8 +199,27 @@ export function Bubble({ text, kind, onDismiss, onAction }: BubbleProps) {
             className="cc-bubble-cta"
             onClick={(e) => {
               e.stopPropagation()
-              if (policy.action) onAction?.(policy.action)
-              setLeaving(true)
+              if (!policy.action) {
+                setLeaving(true)
+                return
+              }
+              const outcome = onAction?.(policy.action)
+              // A handler that answers synchronously keeps the exit synchronous —
+              // deferring every CTA through a microtask would change the timing of
+              // the ones that never fail (the breathing nudge opens the panel and
+              // is done). Only a handler that reports asynchronously waits.
+              if (isThenable(outcome)) {
+                void outcome.then(
+                  (ok) => { if (ok !== false) setLeaving(true) },
+                  // A handler that threw did not act, so the bubble stays for the
+                  // same reason an explicit `false` keeps it. Handled here rather
+                  // than left to reject: an unhandled rejection in a window with
+                  // no console open is a failure nobody ever sees.
+                  () => {},
+                )
+                return
+              }
+              if (outcome !== false) setLeaving(true)
             }}
           >
             <span>{i18nT(policy.ctaKey as Parameters<typeof i18nT>[0])}</span>

--- a/website/src/apps/crew-companion/pet.tsx
+++ b/website/src/apps/crew-companion/pet.tsx
@@ -109,6 +109,13 @@ declare global {
        *  hold still while the user is browsing it. */
       onGalleryOpened?(cb: () => void): () => void
       onGalleryClosed?(cb: () => void): () => void
+      /**
+       * Surface the dashboard on a notification's session, answering whether it
+       * managed to. Optional for the same reason the rest of this bridge is: in a
+       * plain browser tab there is no main process, and then there is no dashboard
+       * window to raise — which is a refusal, not a silent success.
+       */
+      openSession?(slotKey: string): Promise<boolean>
     }
   }
 }
@@ -125,6 +132,15 @@ interface Bubble {
   seq: number
   kind: NotifKind
   text: string
+  /**
+   * The session this notification is about, when it names one.
+   *
+   * Carried so the "Open session" CTA has somewhere to go. Only the gateway
+   * socket supplies it — a fire drained from the companion's own backend
+   * describes a reminder or a break nudge, neither of which belongs to a
+   * session — so it is absent rather than empty-by-default on purpose.
+   */
+  slot?: string
 }
 
 /**
@@ -441,6 +457,31 @@ function Companion() {
   openPanelRef.current = openPanel
 
   /**
+   * Take the user to the work a waiting-on-you notification is about.
+   *
+   * Handed to the main process rather than done here, for the reason `openPanel`
+   * is: this overlay is a non-focusable full-display window with no handle on the
+   * dashboard, so raising and routing it is not something the renderer can do.
+   *
+   * The answer is returned to the bubble, which clears itself only on a success —
+   * an approval bubble has no ✕ and ignores body clicks, so a CTA that dismissed
+   * on a failed open would destroy the user's only pointer back to the blocked
+   * session. No bridge means no main process to ask (this page also opens in an
+   * ordinary browser), which is a refusal, not a quiet success.
+   */
+  const openSession = useCallback(async (slot?: string): Promise<boolean> => {
+    const bridge = window.crewCompanion
+    if (!bridge?.openSession) return false
+    try {
+      return await bridge.openSession(slot ?? '')
+    } catch {
+      // A rejected invoke is a main process that could not answer. Same verdict:
+      // the notification stays rather than being lost to an exception.
+      return false
+    }
+  }, [])
+
+  /**
    * Follow the panel window's own lifecycle.
    *
    * It closes on click-away, Escape and its ✕ without going through `closePanel`, so
@@ -581,7 +622,7 @@ function Companion() {
     isSilent: () => sessionAlertsRef.current === false,
     // The backend rang: drain now rather than at the next tick of the poll.
     onFireQueued: () => pollNowRef.current?.(),
-    onDone: ({ title, failed }) => {
+    onDone: ({ slot, title, failed }) => {
       /*
        * A failure is a DIFFERENT notification, not a finish with sad wording.
        *
@@ -622,6 +663,10 @@ function Companion() {
         seq: localSeqRef.current,
         kind: result.pending?.kind ?? kind,
         text: result.show,
+        // The session that just ended. When several completions collapse into one
+        // count the text stops naming a single session, but the CTA still has to
+        // lead somewhere, so it leads to the most recent one.
+        slot,
       })
       if (failed) {
         react('error', 2_000)
@@ -655,7 +700,7 @@ function Companion() {
      * own title is the body, reusing the existing state.approval_pending string so no
      * new copy is minted; an untitled session shows the label alone.
      */
-    onApproval: ({ title }) => {
+    onApproval: ({ slot, title }) => {
       const kind: NotifKind = 'approval'
       const label = i18nT('apps.crewCompanion.state.approval_pending')
       const named = title.trim()
@@ -677,6 +722,10 @@ function Companion() {
         seq: localSeqRef.current,
         kind: result.pending?.kind ?? kind,
         text: result.show,
+        // The blocked session, so the CTA can take the user to the tool call that
+        // is waiting on them. An approval raised with no owning conversation
+        // carries '' here and is surfaced on the dashboard's own approvals feed.
+        slot,
       })
       // Curious, not alarmed: activeAnimFor turns a curious mood into the head-cock.
       bumpReaction()
@@ -1057,6 +1106,15 @@ function Companion() {
           }
         >
           <Bubble
+            // Keyed by seq so a REPLACEMENT bubble is a new component instance
+            // rather than the same one re-rendered with new props. Without it a
+            // CTA whose handler resolves late — a session-error retry, say —
+            // still holds the shared instance's `setLeaving`, so when it lands
+            // after the bubble was replaced it dismisses the REPLACEMENT the
+            // user never acted on, and clears its slot. Every bubble carries a
+            // distinct seq (negative for the local ones, so they cannot collide
+            // with a backend fire), which makes it the identity to key on.
+            key={bubble.seq}
             text={bubble.text}
             kind={bubble.kind}
             onDismiss={dismiss}
@@ -1065,7 +1123,11 @@ function Companion() {
               // reason that bubble carries one.
               // The exercise lives in the panel window, so the CTA opens the panel
               // and the window starts it from there.
-              if (action === 'breathe') openPanel()
+              if (action === 'breathe') {
+                openPanel()
+                return
+              }
+              return openSession(bubble.slot)
             }}
           />
         </div>

--- a/website/src/test/AppRootCoverage.test.tsx
+++ b/website/src/test/AppRootCoverage.test.tsx
@@ -408,6 +408,24 @@ describe('App — Electron bridges', () => {
     act(() => navigateFromMenu?.('//example.com/steal'))
     expect(screen.getByTestId('logs-page')).toBeInTheDocument()
   })
+
+  it('a session deep link SELECTS the session, not just the route', async () => {
+    // The Crew Companion's "Open session" CTA arrives on this same channel. A
+    // bare navigate would be enough only from another page: ChatPage reads `?sid`
+    // while it MOUNTS, so from an already-open /chat the window would come
+    // forward with the previous session still on screen — the notification would
+    // appear to have opened nothing, which is the bug the CTA is meant to fix.
+    let navigateFromMain: ((path: string) => void) | undefined
+    setElectronBridge({ onNavigate: cb => { navigateFromMain = cb; return () => { navigateFromMain = undefined } } })
+    const { store } = renderWithProviders(<App />, { route: '/chat' })
+    await screen.findByTestId('chat-page')
+    expect(store.getState().chat.activeSlot).not.toBe('chat-2-200')
+
+    act(() => navigateFromMain?.('/chat?sid=chat-2-200'))
+
+    expect(store.getState().chat.activeSlot).toBe('chat-2-200')
+    expect(screen.getByTestId('chat-page')).toBeInTheDocument()
+  })
 })
 
 describe('App — developer mode', () => {

--- a/website/src/test/CrewCompanionBubbleClose.test.tsx
+++ b/website/src/test/CrewCompanionBubbleClose.test.tsx
@@ -9,7 +9,7 @@
  * bubble still will not close on screen, the fault is in the hitbox, not here.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { act, render, screen, fireEvent, cleanup } from '@testing-library/react'
 
 import { Bubble } from '../apps/crew-companion/Bubble'
 
@@ -25,6 +25,17 @@ afterEach(() => {
 /** The exit animation runs before onDismiss fires, so tests must step past it. */
 function flushExit() {
   vi.advanceTimersByTime(400)
+}
+
+/**
+ * Let a CTA whose handler reports asynchronously finish reporting.
+ *
+ * The verdict arrives in a microtask, and the state it drives has to be applied
+ * before the exit timer is stepped — otherwise the timer is advanced past a
+ * dismissal that has not been scheduled yet, and the test reads a pass as a fail.
+ */
+async function settleAction() {
+  await act(async () => {})
 }
 
 describe('closing a bubble', () => {
@@ -122,6 +133,54 @@ describe('closing a bubble', () => {
     fireEvent.click(cta!)
     flushExit()
     expect(onAction).toHaveBeenCalledWith('open-session')
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('a CTA whose action could not be carried out does NOT clear the bubble', async () => {
+    // The dismissal used to be unconditional, which is worst exactly where it
+    // matters: an approval has no ✕ and ignores body clicks, so clearing it on a
+    // failed open destroys the only pointer back to the blocked session.
+    const onDismiss = vi.fn()
+    const { container } = render(
+      <Bubble
+        text="needs your OK"
+        kind="approval"
+        onDismiss={onDismiss}
+        onAction={() => Promise.resolve(false)}
+      />,
+    )
+    fireEvent.click(container.querySelector('.cc-bubble-cta')!)
+    await settleAction()
+    flushExit()
+    expect(onDismiss).not.toHaveBeenCalled()
+    expect(container.querySelector('.cc-bubble-wrap')?.className).not.toContain('cc-bubble-out')
+  })
+
+  it('a CTA that reports success clears the bubble once the action lands', async () => {
+    const onDismiss = vi.fn()
+    const { container } = render(
+      <Bubble
+        text="needs your OK"
+        kind="approval"
+        onDismiss={onDismiss}
+        onAction={() => Promise.resolve(true)}
+      />,
+    )
+    fireEvent.click(container.querySelector('.cc-bubble-cta')!)
+    await settleAction()
+    flushExit()
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('a synchronous CTA still clears the bubble synchronously', () => {
+    // The breathing nudge's handler opens the panel and returns nothing; routing
+    // every CTA through a promise would delay an exit that cannot fail.
+    const onDismiss = vi.fn()
+    const { container } = render(
+      <Bubble text="Try a breath" kind="break-breathe" onDismiss={onDismiss} onAction={() => {}} />,
+    )
+    fireEvent.click(container.querySelector('.cc-bubble-cta')!)
+    flushExit()
     expect(onDismiss).toHaveBeenCalledTimes(1)
   })
 

--- a/website/src/test/CrewCompanionPet.coverage.test.tsx
+++ b/website/src/test/CrewCompanionPet.coverage.test.tsx
@@ -125,6 +125,21 @@ let galleryOpenedCbs: Array<() => void> = []
 let galleryClosedCbs: Array<() => void> = []
 /** When true, the `since=0` re-read after a backend restart answers not-ok. */
 let sinceZeroFails = false
+/**
+ * What the main process answers when asked to surface the dashboard.
+ *
+ * False is the real refusal case — no dashboard window to raise — and it is the
+ * one the sticky bubble's survival depends on.
+ */
+let openSessionSucceeds = true
+/**
+ * When set, `openSession` waits on this before reporting.
+ *
+ * The replacement race needs a CTA that is still in flight while the next
+ * notification arrives, which is only observable if the handler can be held
+ * open deliberately rather than by timing.
+ */
+let openSessionGate: Promise<void> | null = null
 
 /** The window-level preload bridge the overlay toggles window input through. */
 function installCrewCompanion() {
@@ -138,6 +153,10 @@ function installCrewCompanion() {
       return () => {}
     }),
     galleryOpen: vi.fn(),
+    openSession: vi.fn(async () => {
+      if (openSessionGate) await openSessionGate
+      return openSessionSucceeds
+    }),
     onGalleryOpened: vi.fn((cb: () => void) => {
       galleryOpenedCbs.push(cb)
       return () => {}
@@ -196,6 +215,8 @@ beforeEach(() => {
   galleryOpenedCbs = []
   galleryClosedCbs = []
   sinceZeroFails = false
+  openSessionSucceeds = true
+  openSessionGate = null
   packDetail = null
   savedPos = { x: 300, y: 200 }
   config = { activeAppearance: 'kiro-ghost', sessionNotificationsEnabled: true }
@@ -486,6 +507,154 @@ describe('session signals from the gateway socket', () => {
     await mountPet()
     await waitFor(() => expect(watch).not.toBeNull())
     await waitFor(() => expect(watch!.isSilent()).toBe(true))
+  })
+})
+
+/**
+ * The "Open session" CTA — the one button a sticky bubble has.
+ *
+ * `approval` and `session-input` bubbles render no ✕ and ignore body clicks, so
+ * this button is their only exit. Two properties therefore have to hold together,
+ * and they pull in opposite directions: the click must actually take the user to
+ * the blocked session, and it must NOT clear the notification when it could not.
+ */
+describe('the "Open session" call to action', () => {
+  /** The CTA, which is the only button inside the bubble for a sticky kind. */
+  function cta(): HTMLElement | null {
+    return document.querySelector('.cc-bubble-cta')
+  }
+
+  it('opens the session an approval is about, then clears the notification', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    watch!.onApproval!({ slot: 'chat-7-1785905004', title: 'Run the migration' })
+    await waitFor(() => expect(cta()).not.toBeNull())
+
+    fireEvent.click(cta()!)
+
+    // The slot the gateway's approval frame named — not a title, not a guess.
+    await waitFor(() => expect(api.openSession).toHaveBeenCalledWith('chat-7-1785905004'))
+    // And only then does the bubble go: the block has somewhere to be resolved.
+    await waitFor(() => expect(document.querySelector('.cc-bubble-text')).toBeNull())
+  })
+
+  it('keeps a sticky approval on screen when the dashboard could not be surfaced', async () => {
+    openSessionSucceeds = false
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    watch!.onApproval!({ slot: 'chat-7-1785905004', title: 'Run the migration' })
+    await waitFor(() => expect(cta()).not.toBeNull())
+
+    fireEvent.click(cta()!)
+    // Longer than the 300ms exit animation, so a bubble still on screen after
+    // this was never asked to leave rather than being caught mid-animation.
+    await new Promise((r) => setTimeout(r, 500))
+
+    expect(document.querySelector('.cc-bubble-body')?.textContent).toBe('Run the migration')
+    expect(document.querySelector('.cc-bubble-wrap')?.className).not.toContain('cc-bubble-out')
+    // Still no ✕ — so had the CTA dismissed it, the only pointer to a session
+    // that is still blocked on the user would be gone for good.
+    expect(document.querySelector('.cc-bubble-x')).toBeNull()
+    expect(api.openSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('a late CTA result must not dismiss the notification that replaced it', async () => {
+    // The overlay renders ONE bubble slot. Without a per-notification identity on
+    // the rendered element, React keeps a single <Bubble> instance across
+    // replacements -- so a CTA whose handler is still in flight holds that
+    // instance's dismissal, and when it finally reports it dismisses whatever
+    // bubble is on screen NOW. The user never acted on that one.
+    //
+    // Driven through `session-error` deliberately: `isSticky` excludes it, so it
+    // is a CTA-bearing bubble that a later notification can actually replace. An
+    // approval cannot reproduce this -- it is sticky, so it holds the slot and
+    // suppresses the replacement instead.
+    let release: () => void = () => {}
+    openSessionGate = new Promise<void>((res) => {
+      release = res
+    })
+
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+
+    // A: a failed turn, clicked, with its handler held open.
+    watch!.onDone({ slot: 'a', title: 'Fix the parser', elapsedMs: 10, failed: true })
+    await waitFor(() => expect(cta()).not.toBeNull())
+    fireEvent.click(cta()!)
+    await waitFor(() => expect(api.openSession).toHaveBeenCalledTimes(1))
+
+    // B replaces A while A's handler is still pending. Asserted as "the text
+    // changed", not as B's title: two rapid completions coalesce into a count
+    // ("2 jobs finished"), which is still a different notification occupying the
+    // slot -- the replacement this test is about.
+    const aText = document.querySelector('.cc-bubble-text')?.textContent
+    watch!.onDone({ slot: 'b', title: 'Ship the release', elapsedMs: 10, failed: true })
+    await waitFor(() =>
+      expect(document.querySelector('.cc-bubble-text')?.textContent).not.toBe(aText),
+    )
+    const bText = document.querySelector('.cc-bubble-text')?.textContent
+    expect(bText).toBeTruthy()
+
+    // A now reports success -- for a notification that is no longer on screen.
+    release()
+    // Longer than the 300ms exit animation, so a bubble still up after this was
+    // never asked to leave rather than being caught mid-animation.
+    await new Promise((r) => setTimeout(r, 500))
+
+    expect(document.querySelector('.cc-bubble-text')?.textContent).toBe(bText)
+    expect(document.querySelector('.cc-bubble-wrap')?.className).not.toContain('cc-bubble-out')
+  })
+
+  it('raises the dashboard without routing when the approval owns no session', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    // An approval with no owning conversation is broadcast with slot: "" and is
+    // surfaced on the dashboard's approvals feed instead.
+    watch!.onApproval!({ slot: '', title: 'Run the migration' })
+    await waitFor(() => expect(cta()).not.toBeNull())
+
+    fireEvent.click(cta()!)
+
+    await waitFor(() => expect(api.openSession).toHaveBeenCalledWith(''))
+    await waitFor(() => expect(document.querySelector('.cc-bubble-text')).toBeNull())
+  })
+
+  it('opens the session a failed turn belongs to', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    watch!.onDone({ slot: 'chat-9-42', title: 'Fix the parser', elapsedMs: 10, failed: true })
+    await waitFor(() => expect(cta()).not.toBeNull())
+
+    fireEvent.click(cta()!)
+
+    await waitFor(() => expect(api.openSession).toHaveBeenCalledWith('chat-9-42'))
+  })
+
+  it('a queued approval names no session, so its CTA still leads to the dashboard', async () => {
+    // Fires drained from the companion's own backend carry a nudge key, never a
+    // slot. The CTA must not become a dead button on them — a sticky bubble whose
+    // only exit refuses is a notification that can never be cleared.
+    queue([fire({ seq: 1, kind: 'approval', text: 'needs your OK' })])
+    await mountPet()
+    await waitFor(() => expect(cta()).not.toBeNull())
+
+    fireEvent.click(cta()!)
+
+    await waitFor(() => expect(api.openSession).toHaveBeenCalledWith(''))
+    await waitFor(() => expect(document.querySelector('.cc-bubble-text')).toBeNull())
+  })
+
+  it('leaves the breathing nudge alone — its CTA opens the panel, not a session', async () => {
+    queue([fire({ seq: 1, kind: 'break-breathe', text: 'Try a breath' })])
+    await mountPet()
+    await waitFor(() => expect(cta()).not.toBeNull())
+
+    fireEvent.click(cta()!)
+
+    await waitFor(() => expect(api.panelOpen).toHaveBeenCalled())
+    expect(api.openSession).not.toHaveBeenCalled()
+    // A local action cannot fail, so it clears the bubble exactly as it always has.
+    await waitFor(() => expect(document.querySelector('.cc-bubble-text')).toBeNull())
   })
 })
 

--- a/website/src/test/popoutNavForwarding.test.ts
+++ b/website/src/test/popoutNavForwarding.test.ts
@@ -6,7 +6,7 @@ import {
   type PopoutMsg,
   type NavIntent,
 } from '../utils/popoutController'
-import { applyNavIntentInMain, writePrefill, PREFILL_STORAGE_KEY } from '../utils/navIntent'
+import { applyNavIntentInMain, chatDeepLinkSlot, writePrefill, PREFILL_STORAGE_KEY } from '../utils/navIntent'
 
 /**
  * Navigation-intent forwarding tests (popout navigation containment).
@@ -224,6 +224,27 @@ describe('applyNavIntentInMain', () => {
     applyNavIntentInMain({ path: '/artifacts' }, { navigate, switchSlot })
     expect(switchSlot).not.toHaveBeenCalled()
     expect(navigate).toHaveBeenCalledWith('/artifacts')
+  })
+})
+
+describe('chatDeepLinkSlot', () => {
+  it('reads the session out of the dashboard session deep link', () => {
+    expect(chatDeepLinkSlot('/chat?sid=chat-69-1785905004')).toBe('chat-69-1785905004')
+    // The slug is decorative — ChatPage writes it from the session title.
+    expect(chatDeepLinkSlot('/chat/fix-the-parser?sid=chat-1')).toBe('chat-1')
+    // `?slot=` is the legacy spelling ChatPage still accepts.
+    expect(chatDeepLinkSlot('/chat?slot=chat-2')).toBe('chat-2')
+    expect(chatDeepLinkSlot('/chat?sid=chat%20a%2Fb')).toBe('chat a/b')
+  })
+
+  it('names no session for a path that is not one', () => {
+    // Each of these must fall through to a plain navigate: routing them as a
+    // session link would dispatch a switchSlot for a session that was never named.
+    expect(chatDeepLinkSlot('/chat')).toBe('')
+    expect(chatDeepLinkSlot('/settings?tab=about')).toBe('')
+    expect(chatDeepLinkSlot('/chats?sid=chat-1')).toBe('')
+    expect(chatDeepLinkSlot('/logs?sid=chat-1')).toBe('')
+    expect(chatDeepLinkSlot('')).toBe('')
   })
 })
 

--- a/website/src/utils/navIntent.ts
+++ b/website/src/utils/navIntent.ts
@@ -18,6 +18,33 @@ export function writePrefill(slotKey: string, prompt: string): boolean {
 }
 
 /**
+ * The chat session a dashboard path names, or `''` when it names none.
+ *
+ * `/chat?sid=<slotKey>` is the dashboard's session deep link — the System page's
+ * session rows, Telemetry's conversation links and the app SDK all build it — and
+ * `?slot=` is the legacy spelling ChatPage still reads. A `/chat/<slug>` prefix is
+ * decorative (ChatPage writes it from the session title), so it is accepted too.
+ *
+ * Used to tell a session deep link apart from an ordinary route, because the two
+ * cannot be honoured the same way: `navigate()` alone only selects a session while
+ * ChatPage is MOUNTING, so a link followed while /chat is already open lands on
+ * the page with the previous session still selected.
+ */
+export function chatDeepLinkSlot(path: string): string {
+  let url: URL
+  try {
+    // A relative path needs some base to parse against; only the path and query
+    // are ever read back off it.
+    url = new URL(path, 'http://dashboard.invalid')
+  } catch {
+    return ''
+  }
+  const onChat = url.pathname === '/chat' || url.pathname.startsWith('/chat/')
+  if (!onChat) return ''
+  return url.searchParams.get('sid') || url.searchParams.get('slot') || ''
+}
+
+/**
  * Perform a navigation intent forwarded from a popout window, in THIS main
  * dashboard window. Order matters: the prefill must be in sessionStorage
  * before the slot switch + route change so ChatPage's slot-restore effect


### PR DESCRIPTION
## Problem / Motivation

A Crew Companion notification bubble that is waiting on the user carries an **Open session** call to action. Clicking it opens nothing — the bubble just fades out.

For an `approval` or `session-input` bubble that is the worst outcome available. Those kinds are sticky: `isSticky()` is true, so the bubble deliberately renders no ✕ and ignores a click on its body, and the CTA is its only exit. The one button on the notification destroys the user's only pointer back to the blocked session instead of taking them there.

## Why it matters

The companion's promise is that anything waiting on you always notifies. Today the notification arrives, says a tool needs approving, and then the only control on it throws itself away. The turn stays blocked, the user has to hunt for the session by hand, and they have lost the one thing that told them which session it was. Reported on stable, not platform-specific.

## What changed (motivation → approach → change)

**Root cause — three gaps, all of which have to close for the button to work:**

1. **The CTA has no handler.** `notificationPolicy.policyFor()` gives `approval`, `session-input` and `session-error` a CTA with `action: 'open-session'`, but the only consumer — `pet.tsx`'s `onAction` — branches on `'breathe'` and nothing else. `'open-session'` falls straight through. It type-checks, so nothing failed.
2. **The bubble has no session identity.** `watchSessions` already carries `slot` on both `onDone` and `onApproval`, but `pet.tsx` destructured only `{ title }` and the bubble state was `{seq, kind, text}`. The identity was available and dropped one line from where it was needed.
3. **The dismissal is unconditional.** `Bubble.tsx` ran `onAction?.(…)` and then `setLeaving(true)` regardless of what the handler managed to do.

**The fix, end to end:**

- `pet.tsx` keeps the `slot` the gateway already sent on the bubble it raised from it, and adds the missing `'open-session'` branch.
- The overlay cannot open a dashboard route itself — it is a non-focusable full-display window with no handle on the dashboard — so it asks the main process, the same way `'breathe'` asks it to raise the panel window (`crew-companion:panel-open`). New channel: `crew-companion:open-session`.
- `handle`/`invoke` rather than `send`, because the renderer needs the **answer**: the main process reports whether it actually surfaced a dashboard window, and the bubble clears only then.
- In the main process the shape is the one `openSettingsPage(tab)` already uses for the app menu's Settings…/About items: resolve the dashboard window, `restore()`/`show()`/`focus()`, then `wc.send("navigate", path)`. `main.js` supplies the resolver as an `initCrewCompanion` dep (`getDashboardWindow`), mirroring `initMochi`'s `getMainWindow`, so the routing itself lives in the companion module where it is testable.
- The route is the dashboard's **existing** session deep link, `/chat?sid=<slot>` — what the System page's session rows, Telemetry's conversation links and the app SDK all build. No new route is added.
- `Bubble.tsx`'s CTA clears the bubble only when the handler did not report a refusal. A handler that returns nothing still clears synchronously, so the breathing nudge's CTA is unchanged in behaviour *and* in timing.

**The half that would otherwise have been silently missing.** `navigate('/chat?sid=…')` alone is enough only from another page: ChatPage reads `?sid` while it is **mounting**, and its post-mount reader is deliberately gated on a genuine Back/Forward POP (the comments there enumerate the `activeSlot`↔URL ping-pong that gate exists to prevent). From an already-open `/chat` — the likely state when a tool blocks on approval — a bare navigate would bring the window forward with the *previous* session still on screen, and the notification would once again appear to have opened nothing. So `App.tsx` honours a session deep link through `applyNavIntentInMain` — select the session, then navigate — which is the contract the artifact popout's session links already use for exactly this problem.

**Missing / dead target.** An approval raised with no owning conversation is broadcast with `slot: ""` (see the "NO heuristic fallback" reasoning in `slack/gateway.py`), and a fire drained from the companion's own backend carries a nudge key rather than a slot. Those still surface the dashboard — that is where the approvals feed lives — but route nowhere, because navigating away from whatever the user had open would claim to have opened a session that was never identified. They are deliberately **not** refused: a sticky bubble whose only exit refuses is a notification that can never be cleared, which is a worse version of the bug being fixed. Refusal is reserved for "there is no dashboard window to surface", where keeping the notification is the right answer.

**Refusal also covers a window whose view is not the dashboard (review-driven).** The acknowledgement is what dismisses a sticky notification, so a `true` that did not actually route loses the notification *and* never opens the session — the same failure this PR exists to fix, reached a different way. `wc.send("navigate", …)` is only listened for by the dashboard SPA; every other page that view can hold drops it silently: the boot and gateway-recovery splashes (`loading.html`, loaded as `file://`), an error page, or a view still blank mid-load. The routing branch therefore now also requires the view to be on the dashboard's own origin.

Matched on **origin**, not on a full URL: the dashboard's address carries a `?token=` and whatever in-app route the user is on, and same-origin is exactly the property that decides whether the SPA — and therefore the listener — is loaded. A dashboard already deep in the SPA stays routable, which is pinned by its own test.

Scope note, stated because the reviewer's chain and the fix do not match exactly: the reported path was gateway recovery replacing the live view. Tracing it, `loading.html` is only ever loaded into `win.webContents` (`showLoadingThenConnect`, `reconnectExternalGateway`, `reconnectOrRespawnAdoptedGateway`), never into `win._mcView.webContents`, which is what this routing sends to — so that exact interleaving is not reachable today. The guard is kept anyway because the property it enforces is the one the acknowledgement contract actually needs ("this view can receive a navigation"), and nothing else in the module was checking it; the empty-key path is left outside it, since there is nothing to deliver there.

## Tests

Behavioural, and each fail-before below fails on the PR base *for the reported reason*, not because a new symbol is missing:

| Test | Locks in | On the base |
|---|---|---|
| `CrewCompanionPet.coverage` — opens the session an approval is about | the slot from the gateway's approval frame reaches the bridge, then the bubble clears | `Number of calls: 0` — the CTA opened nothing |
| `CrewCompanionPet.coverage` — keeps a sticky approval on screen when the dashboard could not be surfaced | the reported bug's worst case | `expected undefined to be 'Run the migration'` — the sticky bubble was destroyed |
| `CrewCompanionPet.coverage` — raises the dashboard without routing when the approval owns no session | the `slot: ""` case still has an exit | 0 calls |
| `CrewCompanionPet.coverage` — opens the session a failed turn belongs to | `session-error` carries its slot too | 0 calls |
| `CrewCompanionPet.coverage` — a queued approval names no session | a backend-fired bubble's CTA is not a dead button | 0 calls |
| `CrewCompanionPet.coverage` — leaves the breathing nudge alone | preservation: `'breathe'` opens the panel, never `openSession`, and still clears | passes on the base |
| `CrewCompanionBubbleClose` — a CTA whose action could not be carried out does NOT clear the bubble | the dismissal contract | `onDismiss` was called |
| `CrewCompanionBubbleClose` — a synchronous CTA still clears synchronously | the async gate did not change timing for handlers that cannot fail | passes on the base |
| `AppRootCoverage` — a session deep link SELECTS the session | the already-open-`/chat` half | `activeSlot` never becomes the linked session |
| `popoutNavForwarding` — `chatDeepLinkSlot` | `?sid=` / legacy `?slot=` / slug tolerance, and that `/chats`, `/logs` and `/settings` are not session links | the helper does not exist — a symbol test, listed for completeness rather than as evidence |
| `petOverlay.test.js` ×7 | surfacing + routing, slot-key encoding, the no-slot case, both refusal cases, `handle`-not-`send`, a non-string argument, re-init | same: these are symbol tests on the base |
| `petOverlay.test.js` — refuses while the view shows the boot/recovery splash | a `file://` splash cannot receive `navigate`, so the CTA must not report success | **fails on the previous head `8f06d1875`**: `acknowledged a navigation the splash cannot perform` |
| `petOverlay.test.js` — refuses while the view is still blank | a view created but not yet navigated reports `""` | **fails on `8f06d1875`** |
| `petOverlay.test.js` — refuses when the view holds a foreign origin | a session key is never sent to a page that is not the dashboard | **fails on `8f06d1875`** |
| `petOverlay.test.js` — still routes when the dashboard is on an in-app route | preservation: origin-matching keeps `/system?token=abc123` routable | passes on both |
| `petOverlay.test.js` — no session key still surfaces a splash-showing window | preservation: the `slot: ""` contract stays outside the guard | passes on both |


### Review-driven changes (second commit)

Two exact-head blockers, both reproduced before changing anything.

**Caller authorization no longer depends on naming a session.** `openDashboardSession` checked `hostsDashboard(wc)` only `if (slotKey)`, so a slot-less approval raised and focused whatever window it was handed and answered `true` — and `getDashboardWindow` cannot prevent that, being `focusedDashboardWindow()`, which takes the focused window whenever it merely *has* an `_mcView`.

Checking `hostsDashboard` unconditionally would have broken the pinned splash contract (`open-session with no session key still surfaces a splash-showing window`), because that helper is false for the app's own `file://` shell and for a foreign origin alike. So the predicate is split: new `showsForeignOrigin` isolates a committed `http(s)` origin that is not the backend's and is checked unconditionally, while `hostsDashboard` stays conditional on `slotKey` — only a request that routes needs the SPA loaded. No existing test was deleted or weakened.

**The bubble is keyed by `bubble.seq`.** The overlay renders one slot and the element carried no key, so React kept one `<Bubble>` instance across replacements and an in-flight CTA applied its dismissal to whichever notification was on screen when it reported.

| Test | Behavior locked in |
|---|---|
| `a slot-less approval is refused when the window shows a foreign origin` | authorization does not depend on `slotKey`; the window is not raised before the refusal |
| `a slot-less approval is refused when the view is gone` | a destroyed view refuses whether or not a slot was named |
| `a ROUTED approval is still refused on the splash it cannot deliver to` | the other side of the split: local shell passes authorization but cannot receive a `navigate` |
| `a late CTA result must not dismiss the notification that replaced it` | driven through `session-error`, which `isSticky` excludes so it can actually be replaced — an approval is sticky and suppresses the replacement, so it cannot reproduce the bug |

Red-before on `ed08cf0d2`: the two authorization regressions fail, and the replacement case fails with `expected undefined to be '2 jobs finished'` — the replacement bubble was simply gone once the late result landed.

Gates for this commit: `node --test website/electron/crew-companion/test/*.test.js` — 36 passed, 0 failed; `npx vitest run` on `CrewCompanionPet.coverage`, `CrewCompanionBubbleClose`, `CrewCompanionBubbleVisuals` — 90 passed; `npx tsc -b` clean; `npx eslint` clean on all five changed files.

## Manual verification

Not performed, and worth being precise about why: exercising the real path needs the packaged Electron shell, a running gateway, and a tool call actually blocking on approval. What that leaves unproven is only the two ends of the wire — that `ipcRenderer.invoke` reaches `ipcMain.handle`, and that `wc.send("navigate", …)` reaches the SPA — and both are the same primitives `crew-companion:panel-open` and `openSettingsPage(tab)` already ship. Everything between them is covered above, on both sides of the process boundary.

Local gates (Node 22.23.2, Windows 11):

- `npx tsc -b` — clean.
- `npx eslint` on every changed frontend file — 0 errors (3 warnings, all on lines this PR does not touch).
- `npm run jscpd` (the `pretest` duplication gate) — 0 clones.
- `scripts/check_brand_name.py` against `origin/main` — clean.
- Full `npx vitest run`: **17664 passed, 11 failed**. Every one of the 11 was reproduced with the changed sources reverted to `origin/main`: 3 `Kiro credits` focus/format assertions, and 8 known-environmental ones (`MeetingsSessionLogic`, `PapyrusCloseProject` — no gateway on this box — plus `terminalSurfaceParity` and `chatProtocolBoundary`, which compare `components\X.tsx` against `components/X.tsx` and fail on Windows path separators). Branch-only failures: none.
- `node --test website/electron/crew-companion/test/petOverlay.test.js` at the current head — **25 passed**. With `index.js` reverted to `8f06d1875` and the tests kept: **3 failed, 22 passed**, the three failures being exactly the new refusal cases and the two new preservation cases passing on both sides.
- `npx eslint` on both changed files at the current head — 0 errors.
- Electron `npm test` (890 tests): failing-node sets compared base vs branch with the test indices stripped — **identical, 17 both sides**. Branch-only failures: none. (They are the electron-updater library contracts and the POSIX-only process/token tests.)

No i18n work: the CTA label key `apps.crewCompanion.notif.open_session` already exists in every locale, and this PR adds no user-facing string.

### Rejected alternatives

- **Handling `'open-session'` inside the overlay** (e.g. `window.open`). The overlay is `setFocusable(false)` and covers the whole display; the existing `'breathe'` branch already establishes that raising a destination window is the main process's job.
- **A new dashboard session route.** `/chat?sid=` already is that contract and has four callers; a second spelling would be the change needing justification.
- **Making `onAction` unconditionally async.** It would defer every CTA — including the breathing nudge's, which cannot fail — through a microtask for no reason.
- **Refusing the CTA when the notification names no session.** Correct-looking and wrong: a sticky bubble has no other exit, so refusing turns "opens nothing" into "can never be cleared".
- **Widening ChatPage's post-mount `?sid` reader to honour a PUSH.** That gate is load-bearing against the `activeSlot`↔URL ping-pong its comments describe, and `applyNavIntentInMain` already solves the same problem the same way for popout windows.
- **Guarding the switch on the session still existing.** Left out deliberately: `applyNavIntentInMain`'s existing callers do not guard, and a notification's session is essentially always still live seconds later. A session that has since gone lands on an empty conversation for that key — the same outcome as any other stale session link in the dashboard.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** the diff adds no markup, copy, or styles — the bubble and
its CTA render exactly as before, and the change is entirely in what the button
*does*.

Being precise rather than blanket about that, since one behavioural difference is
in principle observable: when the open cannot be carried out, the bubble now
stays instead of fading. Everything else the change produces happens in another
window — the Electron main process restores/shows/focuses the dashboard and the
SPA selects the session — so the outcome a recording would need to show is a
cross-window state change, not a repaint of the surface this PR touches.

Both halves are covered behaviourally instead, on both sides of the process
boundary: `CrewCompanionPet.coverage` drives the real overlay through its own
entry path and clicks the rendered CTA (bubble cleared on success; bubble, its
missing ✕ and its text all still present on a refusal), and
`petOverlay.test.js` asserts the main process restores, shows and focuses the
dashboard window and sends `navigate` with the session's own deep link.

A real end-to-end capture would need the packaged Electron shell, a running
gateway and a live tool call blocking on approval; a mocked stand-in would show
a bubble that looks identical to the one on `main` and would be evidence of
nothing.

## Related Issues

Fixes #3032.

Adjacent but distinct: #3016 / #3012 (macOS `acceptFirstMouse`, where the click never reaches the handler at all). That is a different root cause in the same component and shares no file with this change.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no spec under `docs/system-specs/` covers the companion
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

