### PR TITLE
test: fix the two frontend tests broken on main (#3174, #3179)

### DIFF
--- a/website/src/test/AppRootCoverage.test.tsx
+++ b/website/src/test/AppRootCoverage.test.tsx
@@ -297,13 +297,12 @@ describe('App — system metrics segment', () => {
 })
 
 describe('App — Kiro credits modal', () => {
-  const usageWithBonus = (startUrl: string) => ({
+  const usageWithBonus = (startUrl: string, accountType = 'Social') => ({
     usage: {
       credits_used: 8000, credits_plan: 10000, credits_overage: 0,
-      bonus_limit: 2000, bonus_used: 500, bonus_label: 'Welcome credits',
-      bonus_expires_label: 'expires 2026-09-01',
+      bonus_credits: [{ name: 'Welcome credits', used: 500, total: 2000, days_left: 19 }],
       plan: 'KIRO POWER', resets: '2026-09-01', overage_rate: '0.04', cost_usd: 1.5,
-      account_type: 'Social', email: 'builder@example.com', start_url: startUrl,
+      account_type: accountType, email: 'builder@example.com', start_url: startUrl,
     },
   })
 
@@ -313,27 +312,29 @@ describe('App — Kiro credits modal', () => {
     vi.mocked(api.sessionsUsage).mockResolvedValue(usageWithBonus('https://example.awsapps.com/start') as never)
     renderWithProviders(<App />, { route: '/chat' })
 
-    fireEvent.click(await screen.findByRole('button', { name: /^Kiro credits:/ }))
+    fireEvent.click(await screen.findByTitle(/Kiro credit usage/))
     const dialog = await screen.findByRole('dialog')
-    expect(within(dialog).getByText('Breakdown')).toBeInTheDocument()
-    expect(within(dialog).getByText('Welcome credits')).toBeInTheDocument()
-    expect(within(dialog).getByText('expires 2026-09-01')).toBeInTheDocument()
+    // Plan pool: the progressbar tracks the plan only, not bonus grants.
     expect(within(dialog).getByText('KIRO POWER')).toBeInTheDocument()
-    expect(within(dialog).getByText('Resets 2026-09-01')).toBeInTheDocument()
-    // Bonus present, so the total is pooled and labelled as a total.
-    expect(within(dialog).getByText('8,500')).toBeInTheDocument()
-    expect(within(dialog).getByText('/ 12,000 credits total')).toBeInTheDocument()
-    expect(within(dialog).getByText('$1.50 USD')).toBeInTheDocument()
-    expect(within(dialog).getByText('Signed in with Social login · example.awsapps.com')).toBeInTheDocument()
+    expect(within(dialog).getByText('8,000')).toBeInTheDocument()
+    expect(within(dialog).getByText(/\/\s*10,000\s*credits/)).toBeInTheDocument()
+    expect(within(dialog).getByText(/Resets\s*Sep 1/)).toBeInTheDocument()
+    // Bonus pool: its own section with per-grant balance and expiry.
+    expect(within(dialog).getByText('Bonus credits')).toBeInTheDocument()
+    expect(within(dialog).getByText('Welcome credits')).toBeInTheDocument()
+    expect(within(dialog).getByText('Remaining credit balance: 1,500')).toBeInTheDocument()
+    expect(within(dialog).getByText('Days until expiration: 19')).toBeInTheDocument()
+    expect(within(dialog).getByText('$1.50')).toBeInTheDocument()
+    expect(within(dialog).getByText('Signed in with Social login')).toBeInTheDocument()
   })
 
   it('drops the issuer host when the start URL will not parse', async () => {
-    vi.mocked(api.sessionsUsage).mockResolvedValue(usageWithBonus('not-a-url') as never)
+    vi.mocked(api.sessionsUsage).mockResolvedValue(usageWithBonus('not-a-url', 'IamIdentityCenter') as never)
     renderWithProviders(<App />, { route: '/chat' })
 
-    fireEvent.click(await screen.findByRole('button', { name: /^Kiro credits:/ }))
+    fireEvent.click(await screen.findByTitle(/Kiro credit usage/))
     const dialog = await screen.findByRole('dialog')
-    expect(within(dialog).getByText('Signed in with Social login')).toBeInTheDocument()
+    expect(within(dialog).getByText('Signed in with IAM Identity Center')).toBeInTheDocument()
   })
 })
 

--- a/website/src/test/DevFleetPageCoverage.test.tsx
+++ b/website/src/test/DevFleetPageCoverage.test.tsx
@@ -9,7 +9,7 @@
  * being called (or starts being called with the wrong shape) fails here.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { screen, waitFor, fireEvent, within, act } from '@testing-library/react'
 import { renderWithProviders } from './helpers'
 
 import DevFleetPage from '../pages/DevFleetPage'
@@ -738,7 +738,17 @@ describe('DevFleetPage prune failures', () => {
     await waitForRow('wt-a')
     fireEvent.click(screen.getByText('Prune merged'))
     await waitFor(() => expect(screen.getByText('Prune worktrees')).toBeInTheDocument())
-    fireEvent.click(screen.getByLabelText('Select wt-a'))
+    // The dialog is opened by an async handler (pruneShipped awaits the
+    // candidates fetch before committing setPruneSelected + setPruneDialog).
+    // A click dispatched while that commit's work is still pending is lost:
+    // the controlled checkbox's change never reaches React, its DOM state is
+    // reverted on the next commit, and the run fires with the row still
+    // selected. Drain the pending work first, then assert the deselect
+    // actually landed before acting on it.
+    await act(async () => {})
+    const checkbox = screen.getByLabelText('Select wt-a') as HTMLInputElement
+    fireEvent.click(checkbox)
+    await waitFor(() => expect(checkbox).not.toBeChecked())
     fireEvent.click(screen.getByText('Remove selected'))
     await waitFor(() => expect(screen.getByText('Nothing selected')).toBeInTheDocument())
     expect(runCalls).toBe(0)


### PR DESCRIPTION
# What is the problem?

Two tests in `website/src/test/AppRootCoverage.test.tsx` ("App — Kiro credits modal") fail deterministically on main. PR #3147 redesigned the credits usage card and account modal:

- The credits pill's accessible name changed from the literal `Kiro credits: X/Y` format to the i18n key `components.kiroAccountModal.kiro_credit_usage` ("Kiro credit usage"), so `findByRole('button', { name: /^Kiro credits:/ })` matches nothing.
- The modal no longer renders the pooled "Breakdown" view (pooled `8,500 / 12,000 credits total`, `$1.50 USD`, `expires 2026-09-01`); it now shows a plan-only progress section plus a separate bonus-grants section.
- Social logins no longer append the issuer host to the provider pill.
- The wire payload dropped `bonus_limit` / `bonus_used` / `bonus_label` / `bonus_expires_label` in favor of `bonus_credits[]`.

# Why this issue matters to the user

Every PR rebased onto current main inherits the red: Frontend Tests and Coverage Merge fail regardless of what the PR changes. That blocks the whole review pipeline and trains people to ignore a red gate.

# How our fix solves it

Symptom → the locator finds no button → because the accessible name now comes from the i18n title → so the locators switch to `findByTitle(/Kiro credit usage/)`, the exact pattern the passing neighbor suite `App.test.tsx` already uses. From there the tests still failed on stale content assertions, so the tests are updated to pin the redesigned modal rather than the deleted one:

- The fixture migrates to the current `bonus_credits: [{ name, used, total, days_left }]` wire shape (`KiroBonusCreditGrantPayload`), which the App.tsx normalizer validates and maps to `daysLeft`.
- Test 1 now asserts the redesign's actual split: the plan pool (`8,000` / `10,000 credits`, `Resets Sep 1`, `KIRO POWER`, `$1.50` estimated overage cost) and the bonus section (`Bonus credits`, grant name, `Remaining credit balance: 1,500`, `Days until expiration: 19`) — preserving the test's intent ("breaks the total into a bonus pool and a plan pool") against the current UI.
- Test 2 (issuer-host drop on unparseable start URL) switches the fixture to `IamIdentityCenter`: Social returns early and never appends a host, so only a non-Social account type keeps the URL-parse branch meaningful.

Test-only change; no production code is touched.

# What tests we did

- `npx tsc -b` — green.
- `npx vitest run src/test/AppRootCoverage.test.tsx` — 22/22 pass (was 21 pass / 1 fail at the first assertion before the content rewrite).
- Two model-pinned local reviewers (GPT mirror of codex-review, Opus mirror of claude-review + AUTOSDE) — both PASS with no findings; Opus verified the fixture matches `KiroBonusCreditGrantPayload` and that the `IamIdentityCenter` switch is what keeps the host-drop branch exercised.

# Any other suggestions on the work

None — the remaining risk is the usual one for text-pinned tests: the next modal copy change re-breaks them. The assertions use i18n-derived strings and partial regexes (`/Resets\s*Sep 1/`) to keep them as robust as the design allows.

Closes #3174


---

# Update: this PR now also carries the DevFleet prune-deselect fix (#3179)

CI exposed a circular deadlock between this PR and #3190 that neither could escape alone:

- `main` currently carries **two** broken frontend tests: the credits-modal tests in `AppRootCoverage.test.tsx` (broken by the #3147 redesign — this PR's fix, issue #3174) and the deterministic-on-CI-runners `DevFleetPageCoverage` prune-deselect race (issue #3179).
- CI tests `refs/pull/N/merge` (main + the PR's diff), so each PR went red on exactly the test the *other* one fixes: this PR failed `DevFleetPageCoverage` (fixed by #3190), and #3190 failed the two `AppRootCoverage` credits tests (fixed here). Verified in #3190's Frontend Tests (1) log: its only 2 failures are `App — Kiro credits modal` with the pre-#3147 locator.
- Consequence: every frontend PR inherits at least one red until both fixes land together.

Resolution: #3190's single test-only commit is cherry-picked here unchanged (`8da7533`, +12/−2 in `DevFleetPageCoverage.test.tsx` — drain the async dialog commit's pending React work, then assert the deselect landed before acting on it). Merging this PR unbreaks both tests on `main` at once; #3190 is then redundant and will be closed.

Gates re-run on the combined head: `npx tsc -b` green; `AppRootCoverage.test.tsx` 22/22; `DevFleetPageCoverage.test.tsx` 54/54 under the pinned-2-CPU repro condition (`taskset -c 0,1`) that reproduced the original failure 5/5.

Closes #3179
