### PR TITLE
test: fix lost-click race in DevFleet prune deselect test (#3179)

### DIFF
--- a/website/src/test/DevFleetPageCoverage.test.tsx
+++ b/website/src/test/DevFleetPageCoverage.test.tsx
@@ -9,7 +9,7 @@
  * being called (or starts being called with the wrong shape) fails here.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { screen, waitFor, fireEvent, within, act } from '@testing-library/react'
 import { renderWithProviders } from './helpers'
 
 import DevFleetPage from '../pages/DevFleetPage'
@@ -738,7 +738,17 @@ describe('DevFleetPage prune failures', () => {
     await waitForRow('wt-a')
     fireEvent.click(screen.getByText('Prune merged'))
     await waitFor(() => expect(screen.getByText('Prune worktrees')).toBeInTheDocument())
-    fireEvent.click(screen.getByLabelText('Select wt-a'))
+    // The dialog is opened by an async handler (pruneShipped awaits the
+    // candidates fetch before committing setPruneSelected + setPruneDialog).
+    // A click dispatched while that commit's work is still pending is lost:
+    // the controlled checkbox's change never reaches React, its DOM state is
+    // reverted on the next commit, and the run fires with the row still
+    // selected. Drain the pending work first, then assert the deselect
+    // actually landed before acting on it.
+    await act(async () => {})
+    const checkbox = screen.getByLabelText('Select wt-a') as HTMLInputElement
+    fireEvent.click(checkbox)
+    await waitFor(() => expect(checkbox).not.toBeChecked())
     fireEvent.click(screen.getByText('Remove selected'))
     await waitFor(() => expect(screen.getByText('Nothing selected')).toBeInTheDocument())
     expect(runCalls).toBe(0)


### PR DESCRIPTION
# What is the problem?

`DevFleetPageCoverage.test.tsx > DevFleetPage prune failures > refuses to run with every candidate deselected` fails consistently on hosted CI runners (3/3 attempts on PR #1636's CI, 2/2 attempts on PR #3189's CI) while passing in local full-file runs. The failure is `Unable to find an element with the text: Nothing selected`.

# Why this issue matters to the user

It contributes a persistent red to Frontend Tests / Frontend Coverage Merge / Coverage Gate on full-frontend-lane PR runs, blocking unrelated PRs (currently blocking the #3174 fix in PR #3189, and previously PR #1636). A gate that is red for everyone trains people to ignore it.

# How our fix solves it

Reproduced deterministically (not just under load): the test fails 5/5 when run in isolation pinned to 2 CPUs (`taskset -c 0,1 npx vitest run ... -t "refuses to run..."`) — and instrumentation pins the mechanism:

- The prune dialog is committed from an **async handler** (`pruneShipped` awaits the candidates fetch before `setPruneSelected` + `setPruneDialog`).
- The test's `fireEvent.click` on the **controlled** checkbox is dispatched while that commit's work is still pending. The change event never reaches React: instrumentation shows `checked` stays `true` immediately after the click **and never becomes false within a 1s poll** — the click is swallowed, not delayed.
- The run therefore starts with `wt-a` still selected (`runCalls` observed = 1, progress checklist mounted), so the `Nothing selected` toast never renders. A longer `waitFor` timeout (4s) does not help — confirming this is not a slow-render timeout.

Fix (test-only, two parts):
1. `await act(async () => {})` after the dialog appears — drains the pending commit so the subsequent click is delivered to a settled tree. With this, the same pinned isolated run passes 5/5 (was 0/5).
2. `await waitFor(() => expect(checkbox).not.toBeChecked())` before clicking Remove selected — a guard that makes any future recurrence fail **at the deselect step** with a precise message, instead of the misleading downstream toast miss.

# What tests we did

- Repro before fix: 0/5 isolated runs pinned to 2 CPUs; also fails isolated **unpinned**.
- After fix: 5/5 isolated pinned runs green; full file 54/54 pinned to 2 CPUs green.
- `npx tsc -b` green.
- Mutation direction: the unfixed base fails the exact repro command, so the fix is what flips it.

# Any other suggestions on the work

The underlying pattern (interacting immediately after an async-handler-opened dialog) exists in the neighboring prune tests too, but they click buttons (uncontrolled targets) whose handlers read fresh state, so they are not exposed to the lost-controlled-change failure. Scope stays on the one failing test.

Closes #3179
