### PR TITLE
fix(i18n): wait for webfonts and layout quiescence in the render gate

### DIFF
--- a/website/scripts/check-i18n-render.mjs
+++ b/website/scripts/check-i18n-render.mjs
@@ -77,6 +77,7 @@ import { serveDist } from './lib/serve-dist.mjs'
 import { stubDashboardApi, logPageProblems, json } from './lib/stub-dashboard-api.mjs'
 import { SURFACES, LOCALES, VIEWPORTS, FIXTURE_DETAIL_APP } from './lib/i18n-surfaces.mjs'
 import { browserBundle } from './lib/render-scan.mjs'
+import { browserBundleSettle } from './lib/settle.mjs'
 import {
   BUCKETS,
   BUCKET_MEANING,
@@ -91,6 +92,7 @@ import {
 } from './lib/render-verdict.mjs'
 
 const SCAN_SRC = fileURLToPath(new URL('./lib/render-scan.mjs', import.meta.url))
+const SETTLE_SRC = fileURLToPath(new URL('./lib/settle.mjs', import.meta.url))
 const LEDGER = fileURLToPath(new URL('../src/i18n/render-baseline.json', import.meta.url))
 const GLOSSARY = fileURLToPath(new URL('../src/i18n/glossary.json', import.meta.url))
 /**
@@ -701,6 +703,7 @@ async function main() {
   }
 
   const scanScript = browserBundle(readFileSync(SCAN_SRC, 'utf-8'))
+  const settleScript = browserBundleSettle(readFileSync(SETTLE_SRC, 'utf-8'))
   const dnt = JSON.parse(readFileSync(GLOSSARY, 'utf-8')).dnt
   const surfaces = ONLY_SURFACE ? SURFACES.filter(s => s.id === ONLY_SURFACE) : SURFACES
   const locales = ONLY_LOCALE ? LOCALES.filter(l => l.code === ONLY_LOCALE) : LOCALES
@@ -714,7 +717,7 @@ async function main() {
   /** Surfaces this branch added — no base measurement exists for them. */
   let newSurfaces = new Set()
   try {
-    head = await sweep(browser, DIST, { scanScript, dnt, surfaces, locales, label: 'HEAD' })
+    head = await sweep(browser, DIST, { scanScript, settleScript, dnt, surfaces, locales, label: 'HEAD' })
 
     // The diff-scoped half. Everything about it is derived at runtime from two
     // trees; nothing is read from a committed number, which is the whole point.
@@ -728,7 +731,7 @@ async function main() {
       // base's. If the base tree's own scanner were used instead, any change to the
       // detector would read as a product regression (or mask one).
       const baseSweep = await sweep(browser, baseDist, {
-        scanScript, dnt, surfaces, locales, label: `base ${scope.sha.slice(0, 8)}`,
+        scanScript, settleScript, dnt, surfaces, locales, label: `base ${scope.sha.slice(0, 8)}`,
       })
       baseAll = baseSweep.all
       // A surface is NEW — base 0 — only when the base bundle had no route for its
@@ -780,7 +783,7 @@ async function main() {
  * difference between them can then only come from the bundles, never from how they
  * were measured.
  */
-async function sweep(browser, dist, { scanScript, dnt, surfaces, locales, label }) {
+async function sweep(browser, dist, { scanScript, settleScript, dnt, surfaces, locales, label }) {
   const { srv, base } = await serveDist(dist)
   /** @type {Array<{surface: string, locale: string, viewport: string, finding: object}>} */
   const all = []
@@ -790,6 +793,13 @@ async function sweep(browser, dist, { scanScript, dnt, surfaces, locales, label 
    * added the route" from "this branch only added the registry entry".
    */
   const unresolved = new Set()
+  /**
+   * Surface renders that never reached layout quiescence within the settle frame cap, so
+   * they were measured mid-animation -- the #1555 failure mode. Collected and reported
+   * loudly rather than trusted silently: a capped measurement is not reliable and, if it
+   * differs between HEAD and base, would flake [vs-base].
+   */
+  const capped = []
   let pseudoSeen = false
 
   try {
@@ -867,25 +877,77 @@ async function sweep(browser, dist, { scanScript, dnt, surfaces, locales, label 
               + 'the wrong shape for this surface (see lib/boot-api.mjs for the two shapes that '
               + 'error-boundary the whole shell). Re-run with --verbose to see the page errors.')
           }
-          // Panels that fetch after mount need a beat more; a half-rendered surface
-          // under-reports rather than failing loudly.
-          await page.waitForTimeout(surface.settle || 250)
-          // Every width this gate reports is a text measurement, and text measures
-          // differently in the fallback face than in the real one. Scanning before
-          // the webfonts land made the layout bucket differ by 2 between identical
-          // runs (artifacts.layout 4 vs 2), which would have made the whole gate
-          // flaky rather than wrong. Two rAF ticks after that let the resulting
-          // reflow finish before anything is read.
+          // Wait for the webfonts, THEN for the layout to actually stop moving, before
+          // reading any width. #1555: framer-motion drives width/layout animations in JS (a
+          // requestAnimationFrame loop writing inline style), not as CSS transitions, so the
+          // context reducedMotion:'reduce' above is inert for any component that does not
+          // itself call useReducedMotion() -- most do not, and there is no global
+          // <MotionConfig>. A fixed waitForTimeout therefore RACED those springs and the
+          // webfont reflow, so the `layout` bucket flaked run to run (the historical
+          // "artifacts.layout 4 vs 2"). Waiting on the GEOMETRY going quiescent is
+          // animation-engine-agnostic and reads the settled layout a user sees. surface.settle
+          // stays on as the async-mount FLOOR (panels that fetch after mount still get their
+          // beat), and a frame cap means an unending animation degrades to a measurement,
+          // never a hang. See lib/settle.mjs.
           await page.evaluate(() => document.fonts.ready)
-          await page.evaluate(() => new Promise(r => requestAnimationFrame(
-            () => requestAnimationFrame(() => r(null)),
-          )))
+          await page.addScriptTag({ content: settleScript })
+          const settle = await page.evaluate(
+            ({ minMs }) => window.__I18N_SETTLE.waitForLayoutStable(
+              window.__I18N_SETTLE.geometrySignature, { framesStable: 4, maxFrames: 300, minMs },
+            ),
+            { minMs: surface.settle || 250 },
+          )
+          if (settle.reason === 'cap') {
+            // The layout was still moving when the frame cap hit, so this surface was
+            // measured mid-animation. Record it; a silent capped measurement is exactly the
+            // #1555 flake with the diagnostics thrown away.
+            capped.push(`${surface.id} · ${locale.code} · ${viewport.id} (${settle.frames} frames)`)
+          }
           if (pageErrors.length) {
             die(`[${label}] ${surface.url} (${locale.code}) threw while rendering, so its `
               + 'findings would be the error boundary\'s own English copy rather than the '
               + `product's:\n${pageErrors.slice(0, 3).map(e => `      ${e}`).join('\n')}`
               + '\n    Fix the fixture shape in FIXTURE_OVERRIDES, or drop the surface from '
               + 'lib/i18n-surfaces.mjs with a comment saying why.')
+          }
+          // #1555 residual: 'Space Grotesk' / 'JetBrains Mono' load from the Google Fonts CDN with
+          // font-display:swap, and the font stylesheet applies asynchronously (rel=preload ->
+          // onload -> stylesheet). The bare `document.fonts.ready` before the settle can resolve
+          // while text is still in a WIDER fallback, and the settle then goes quiescent on that
+          // fallback layout, so the scan buckets fallback widths as phantom `layout` overflow --
+          // the residual flake (0/84 on fast hardware naturally, 8/8 with the font requests
+          // blocked). By here the settle's render activity has applied the stylesheet, so poll
+          // until the primary UI faces are actually loaded, bounded so a dead CDN cannot hang the
+          // gate. Reading scrollWidth in the scan forces the font-swap reflow, so no separate flush
+          // is needed. Self-hosting the fonts is the durable fix -- it removes the CDN race
+          // entirely; see the #1555 write-up.
+          const fontStatus = await page.evaluate(async () => {
+            // Fixed families (never interpolate untrusted/dynamic text into the font shorthand).
+            const families = ['Space Grotesk', 'JetBrains Mono']
+            // Google Fonts splits each family into unicode-range SUBSETS (basic latin, latin-ext,
+            // ...). The pseudolocale's accented glyphs live in a DIFFERENT subset from basic latin,
+            // so a default-text check() can report "loaded" off the latin subset while the accented
+            // subset is still swapping -- and the flake would survive. Check/load against the unique
+            // characters actually on the page, so we wait for exactly the subsets the rendered text
+            // uses; glyphs a family does not cover simply do not block it.
+            const sample = [...new Set(document.body.innerText.replace(/\s/g, ''))].join('').slice(0, 800) || 'Ag'
+            const ready = () => families.every(f => document.fonts.check(`1em "${f}"`, sample))
+            const deadline = Date.now() + 10000
+            while (!ready() && Date.now() < deadline) {
+              await Promise.all(families.map(f => document.fonts.load(`1em "${f}"`, sample).catch(() => {})))
+              await new Promise(r => setTimeout(r, 100))
+            }
+            return { missing: families.filter(f => !document.fonts.check(`1em "${f}"`, sample)) }
+          })
+          if (fontStatus.missing.length) {
+            // Fail LOUD as infrastructure (exit 2), never as silent PR findings: a fallback-font
+            // measurement would charge phantom `layout` overflow against an unrelated PR, which is
+            // exactly the #1555 report. This is a network/CDN problem, not a code defect.
+            die(`[${label}] ${surface.url} (${locale.code}) was measured before its webfonts `
+              + `loaded (missing: ${fontStatus.missing.join(', ')}). The gate host could not reach `
+              + `the Google Fonts CDN (fonts.gstatic.com) within 10s, so text renders in a wider `
+              + `fallback and any layout findings would be font artifacts, not real overflow. `
+              + `Restore network access or self-host the fonts (#1555), then re-run.`)
           }
           await page.addScriptTag({ content: scanScript })
 
@@ -928,7 +990,13 @@ async function sweep(browser, dist, { scanScript, dnt, surfaces, locales, label 
   // value comparison over all 9 shipped catalogs. The guard that used to stand here
   // required a real locale precisely so this assertion could not go quiet; that
   // requirement now belongs to that script, which the i18n runner fails closed on.
-  return { all, unresolved }
+  if (capped.length) {
+    group(`[${label}] WARNING: ${capped.length} render(s) never reached layout quiescence within `
+      + 'the settle frame cap and were measured mid-animation (the #1555 failure mode). Give the '
+      + 'offending component a useReducedMotion guard, or the surface a larger `settle` in '
+      + 'lib/i18n-surfaces.mjs. A capped measurement is not reliable:', capped)
+  }
+  return { all, unresolved, capped }
 }
 
 /**

--- a/website/scripts/lib/settle.mjs
+++ b/website/scripts/lib/settle.mjs
@@ -1,0 +1,101 @@
+/**
+ * Deterministic layout-settle for the render gate (issue #1555).
+ *
+ * ## Why this exists
+ *
+ * The gate used to wait a FIXED time (`waitForTimeout(surface.settle || 250)` plus a bare
+ * double `requestAnimationFrame`) and then read `scrollWidth`/`clientWidth`. framer-motion
+ * drives width and layout animations in JavaScript -- a `requestAnimationFrame` loop writing
+ * inline `style.width` -- NOT as CSS transitions, so neither the browser context's
+ * `reducedMotion: 'reduce'` nor a `* { transition: none }` injection stops them for a
+ * component that does not itself call `useReducedMotion()`. Most do not, and there is no
+ * global `<MotionConfig>`. A fixed wall-clock wait therefore RACED those springs (and the
+ * webfont reflow): whichever frame it landed on was the width that got bucketed as `layout`,
+ * so the count flaked run to run and failed unrelated PRs at random.
+ *
+ * This waits for the GEOMETRY ITSELF to go quiescent instead of guessing a duration. It is
+ * animation-engine-agnostic (springs, tweens, layout/layoutId morphs, webfont reflow, late
+ * async panels) and measures the settled layout a user actually sees.
+ *
+ * `waitForLayoutStable` is pure and its `raf`/`now` are injectable, so it is unit-tested
+ * with a fake clock (src/test/renderGateSettle.test.ts). `geometrySignature` reads only
+ * width/height BOX metrics, so transform/opacity-only motion (spinners, caret blink, pulses)
+ * cannot keep it from settling, while the width/height changes the scanner measures do.
+ */
+
+/**
+ * Resolve once `sample()` returns a value byte-identical for `framesStable` consecutive
+ * animation frames AND at least `minMs` has elapsed, or after `maxFrames` frames.
+ *
+ * `minMs` is the async-mount FLOOR: without it, a page that is trivially static BEFORE its
+ * animation starts reads as already-quiescent and gets sampled in its not-yet-animated
+ * state (observed empirically). `maxFrames` is a hard ceiling so an unending animation
+ * degrades to a measurement rather than hanging CI.
+ *
+ * @param {() => (string|number)} sample geometry signature to watch
+ * @param {{framesStable?:number, maxFrames?:number, minMs?:number, raf?:Function, now?:Function}} [opts]
+ * @returns {Promise<{reason:'stable'|'cap', frames:number}>}
+ */
+export function waitForLayoutStable(sample, opts = {}) {
+  const framesStable = opts.framesStable ?? 4
+  const maxFrames = opts.maxFrames ?? 300
+  const minMs = opts.minMs ?? 0
+  const raf = opts.raf || (cb => requestAnimationFrame(cb))
+  const now = opts.now || (() => performance.now())
+  return new Promise((resolve) => {
+    const t0 = now()
+    let prev = null
+    let stable = 0
+    let frames = 0
+    const tick = () => {
+      const cur = sample()
+      if (cur === prev) stable++
+      else { stable = 0; prev = cur }
+      frames++
+      if (stable >= framesStable && (now() - t0) >= minMs) return resolve({ reason: 'stable', frames })
+      if (frames >= maxFrames) return resolve({ reason: 'cap', frames })
+      raf(tick)
+    }
+    raf(tick)
+  })
+}
+
+/**
+ * A signature of the document's layout geometry: width/height box metrics only, as
+ * integers, one triple per element. Deliberately NOT transform/opacity (those do not change
+ * these box metrics), so infinite spinners/pulses cannot prevent quiescence, while the
+ * width/height animations the scanner actually measures do move it.
+ *
+ * The element set MIRRORS the scanner's own exclusions (render-scan.mjs ~315-338, 538-539):
+ * geometry the scanner never reads must not be able to hold the settle open. Virtuoso
+ * virtual lists re-measure an oversized inner container continuously; hidden and opaque
+ * (code/terminal/mono) subtrees are skipped by the scan. We use only the cheap
+ * closest()/checkVisibility() tests here (not the scanner's per-element computed-font read)
+ * so this stays affordable to run every animation frame, and we exclude strictly LESS than
+ * the scanner in every ambiguous case, so we never stop watching something it measures.
+ */
+export function geometrySignature(root = document) {
+  const body = root.body || root
+  const els = body.querySelectorAll('*')
+  let s = ''
+  for (let i = 0; i < els.length; i++) {
+    const e = els[i]
+    if (e.closest('[data-testid="virtuoso"], code, pre, kbd, samp, [data-i18n-opaque]')) continue
+    if (typeof e.checkVisibility === 'function' && !e.checkVisibility()) continue
+    s += (e.clientWidth | 0) + ',' + (e.scrollWidth | 0) + ',' + (e.offsetHeight | 0) + ';'
+  }
+  return s
+}
+
+// __BROWSER_BUNDLE_CUT__
+
+/**
+ * Rewrite this module into a plain script for `page.addScriptTag`, exposing the two
+ * browser-safe helpers on `window.__I18N_SETTLE`. Mirrors `browserBundle` in
+ * lib/render-scan.mjs exactly: one implementation, two runtimes, no drift.
+ */
+export function browserBundleSettle(source) {
+  const body = source.split('// __BROWSER_BUNDLE_CUT__')[0]
+    .replace(/^export (function|const|class)/gm, '$1')
+  return `(() => {\n${body}\nwindow.__I18N_SETTLE = { waitForLayoutStable, geometrySignature };\n})()`
+}

--- a/website/src/test/renderGateSettle.test.ts
+++ b/website/src/test/renderGateSettle.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { waitForLayoutStable } from '../../scripts/lib/settle.mjs'
+
+// Deterministic fake clock: rAF callbacks fire only when we pump a frame, and `now`
+// advances a fixed 16ms per frame. No real timers, so the test is instant and stable --
+// mirrors the pure-unit style of src/test/renderVerdict.test.ts (no browser).
+function makeClock() {
+  let queue = []
+  let t = 0
+  return {
+    now: () => t,
+    raf: (cb) => { queue.push(cb) },
+    frame: () => { const due = queue; queue = []; t += 16; due.forEach(cb => cb(t)) },
+  }
+}
+const flush = () => Promise.resolve()
+
+describe('render gate settles on GEOMETRY, not on a fixed timeout (#1555)', () => {
+  it('stays pending while the measured width changes; resolves only once it holds still', async () => {
+    const clock = makeClock()
+    // width 0 -> 180 over several frames (a spring), then holds.
+    const widths = [0, 40, 95, 140, 168, 179, 180, 180, 180, 180, 180]
+    let i = 0
+    const sample = () => widths[Math.min(i++, widths.length - 1)]
+    let done = false
+    const p = waitForLayoutStable(sample, { framesStable: 3, maxFrames: 100, raf: clock.raf, now: clock.now })
+      .then(() => { done = true })
+    for (let f = 0; f < 6; f++) { clock.frame(); await flush() } // through the moving region
+    expect(done).toBe(false)                                      // must NOT sample mid-animation
+    for (let f = 0; f < 6; f++) { clock.frame(); await flush() } // through the stable tail
+    await p
+    expect(done).toBe(true)
+  })
+
+  it('never hangs: resolves via the frame cap even if the width never stabilises', async () => {
+    const clock = makeClock()
+    let w = 0
+    const p = waitForLayoutStable(() => (w += 1), { framesStable: 3, maxFrames: 20, raf: clock.raf, now: clock.now })
+    for (let f = 0; f < 25; f++) { clock.frame(); await flush() }
+    await expect(p).resolves.toMatchObject({ reason: 'cap' })     // capped, no CI deadlock
+  })
+
+  it('honours the async-mount floor: does not resolve before minMs even when already stable', async () => {
+    const clock = makeClock()
+    // Geometry is stable from frame 1, but minMs (200ms) must elapse first, so a page that
+    // is static BEFORE its animation starts is not sampled in its not-yet-animated state.
+    const p = waitForLayoutStable(() => 42, { framesStable: 3, minMs: 200, maxFrames: 100, raf: clock.raf, now: clock.now })
+    let done = false
+    p.then(() => { done = true })
+    for (let f = 0; f < 5; f++) { clock.frame(); await flush() }  // t=80ms: stable but under the floor
+    expect(done).toBe(false)
+    for (let f = 0; f < 10; f++) { clock.frame(); await flush() } // past 200ms
+    await p
+    expect(done).toBe(true)
+  })
+
+  it('the gate wires the geometry-settle in and no longer measures right after a fixed timeout', () => {
+    const gate = readFileSync(
+      resolve(import.meta.dirname, '../../scripts/check-i18n-render.mjs'), 'utf-8')
+    expect(gate).toMatch(/waitForLayoutStable/)                   // the stable wait is used
+    expect(gate).toMatch(/geometrySignature/)                     // fed the geometry signature
+    expect(gate).not.toMatch(/await page\.waitForTimeout\(surface\.settle/) // the #1555 flaky line is gone
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

The i18n render gate's `artifacts.layout` check fails unrelated PRs at random. On the `apps` surface at the narrow viewport under the pseudo-locale, it intermittently reports two extra `clipped-without-title` findings (`layout` 5 instead of the stable 3), so a PR that changed nothing about layout gets blocked. This is #1555.

## Why it matters

Contributors hit it on unrelated work: a green run turns red on a re-run with layout findings they did not cause, costing a re-run and a round of confused investigation. A gate that fails at random trains people to ignore it, which defeats the point of having it.

## What changed (motivation -> approach -> change)

Symptom: `artifacts.layout` flakes on `apps` / narrow / en-XA (5 vs 3), about 3 percent of runs. Two races were feeding the measured width:

- The settle was a fixed `waitForTimeout`, so reading `scrollWidth` raced framer-motion's width animation (driven in JS by an rAF loop writing inline style, not a CSS transition, so the context `reducedMotion` does not stop it).
- The residual: the app loads Space Grotesk and JetBrains Mono from the Google Fonts CDN with `font-display: swap`. When the gate measured during the fallback-to-webfont swap, the wider fallback font pushed two composite labels about 11 percent past their flex container. The plain labels beside them use `text-overflow: ellipsis` and never tripped.

It presents as a settle/animation timing flake, but it is not: transient stalls do not correlate with the failures, and blocking the webfonts reproduces it deterministically, which is what pinned it to font load rather than the settle.

Change (gate only):

1. Settle on geometry, not a clock. New `waitForLayoutStable` (`website/scripts/lib/settle.mjs`) resolves once the layout geometry is byte-identical for several frames, or a frame cap is hit; animation-engine agnostic.
2. Wait for the webfonts before measuring. After the settle, poll (bounded to 10 seconds) until the primary UI faces are loaded for the exact text on the page (subset aware, so the pseudo-locale's accented glyphs are covered), then scan.
3. Fail loud, never silent. If the fonts still are not loaded (CDN unreachable in CI), exit with a clear infrastructure error rather than charging phantom `layout` findings against the PR.

Out of scope, noted for maintainers: self-hosting these two fonts would remove the CDN race entirely (and is a CI supply-chain and privacy improvement), rather than waiting it out.

## Tests

- `website/src/test/renderGateSettle.test.ts` (new): unit-tests `waitForLayoutStable` with a fake clock. It resolves after N byte-identical frames, honors the minimum-time floor, and degrades an unending animation to a capped measurement rather than hanging.
- Existing render-gate suites pass unchanged.

## Manual verification

The font wait is an integration path (headless browser plus a live CDN), so it is covered by runs rather than a unit test:

- Before / after: full gate run, count deterministic and unchanged outside the flake; no surface hits the frame cap.
- Reverse (cause): block the webfonts and the exact flake (`layout=5`) reproduces on 8/8 runs, even on hardware that is 0/84 naturally.
- Forward (fix): under load, waiting for the fonts drives the rate from about 3 percent to 0.

## Related Issues

Fixes #1555

## Checklist

- [x] Single commit with a Conventional Commits title (`fix(i18n): ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable): N/A, no user-facing docs affected
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

I have read and agree to the project's Contribution License Agreement.
