### PR TITLE
fix: resolve block-scalar values in skill frontmatter (#3182)

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -598,6 +598,8 @@ truncated to 300 chars.
 
 Markdown files at `~/.kiro/crew/skills/{name}/SKILL.md` with optional YAML frontmatter (`name`, `description`, `always`).
 
+Frontmatter is parsed line-by-line (`_parse_frontmatter`): only a column-0 `key: value` line is a field. A value that is a bare block-scalar indicator (`>`, `|`, optionally chomped with `-`/`+`) is resolved from the indented lines that follow — folded (`>`) folds single breaks to spaces while preserving blank-line counts and more-indented line breaks, literal (`|`) preserves newlines — so a multi-line `description` still routes. Explicit indentation indicators (`>2`) are not supported. The other frontmatter readers stay reconciled with this resolution: the onboarding import gate treats a bare indicator as an activating `always` value (fail-closed), and the auto-skill update path's `history._frontmatter_value` resolves block scalars the same way, so a live skill's block-scalar `description`/`triggers` survive the staged-candidate round-trip instead of collapsing to the indicator character.
+
 Supports nested directories (e.g. `skills/utils/tiny-url/SKILL.md`). The skill name is the relative path from the skills root (e.g. `utils/tiny-url`).
 
 **Source precedence** (project-level wins): `$KIROCREW_PROJECT_DIR/skills/` → `builtin_skills/` (bundled). Auto-copied to `~/.kiro/crew/skills/` on first run. Copies entire skill directories (scripts, assets, etc.).

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -33,7 +33,12 @@ from kiro_crew.preview_text import strip_markdown_preview
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.session import BACKGROUND_KEY
-from kiro_crew.skills import AUTO_SKILL_MAX_PROCEDURE_CHARS, AutoSkillProvenance
+from kiro_crew.skills import (
+    _BLOCK_SCALAR_INDICATORS,
+    AUTO_SKILL_MAX_PROCEDURE_CHARS,
+    AutoSkillProvenance,
+    _fold_block_scalar,
+)
 from kiro_crew.skills_dedupe import (
     VERDICT_DUP,
     VERDICT_NEW,
@@ -4069,15 +4074,40 @@ _TOOL_ROLES: frozenset[str] = frozenset({"tool", "tool_call", "tool_result"})
 
 
 def _frontmatter_value(text: str | None, key: str) -> str:
-    """Return a single-line frontmatter value from a SKILL.md body, or ""."""
+    """Return *key*'s frontmatter value from a SKILL.md body, or "".
+
+    Values resolve the way ``SkillsLoader._parse_frontmatter`` resolves them:
+    only a column-0 key is a field, and a bare block-scalar indicator
+    (``>``/``|``, optionally chomped) folds the indented lines that follow.
+    The auto-skill update path carries the live skill's ``description`` and
+    ``triggers`` through this reader into a staged candidate that overwrites
+    the live skill on approval — reading the indicator verbatim would collapse
+    a block-scalar description to ``""`` and inject a bogus ``>`` trigger on
+    that round-trip.
+    """
     if not text:
         return ""
     m = re.match(r"^\s*---\n(.*?)\n---", text, re.DOTALL)
     if not m:
         return ""
-    for ln in m.group(1).split("\n"):
-        if ":" in ln and ln.split(":", 1)[0].strip() == key:
-            return ln.split(":", 1)[1].strip()
+    lines = m.group(1).split("\n")
+    i = 0
+    while i < len(lines):
+        ln = lines[i]
+        i += 1
+        if ":" not in ln or ln[:1].isspace():
+            continue
+        k, raw = ln.split(":", 1)
+        if k.strip() != key:
+            continue
+        value = raw.strip()
+        if value in _BLOCK_SCALAR_INDICATORS:
+            block: list[str] = []
+            while i < len(lines) and (not lines[i].strip() or lines[i][:1].isspace()):
+                block.append(lines[i])
+                i += 1
+            return _fold_block_scalar(value, block)
+        return value
     return ""
 
 

--- a/src/kiro_crew/onboarding_import.py
+++ b/src/kiro_crew/onboarding_import.py
@@ -47,6 +47,7 @@ from kiro_crew.security import (
     redact_credentials,
     redact_exfiltration_urls,
 )
+from kiro_crew.skills import _BLOCK_SCALAR_INDICATORS
 from kiro_crew.vector_memory import VectorMemoryStore
 
 logger = logging.getLogger(__name__)
@@ -1212,8 +1213,15 @@ def _skill_package(
             return None
         if path.name == "SKILL.md":
             metadata, _ = _frontmatter(text)
-            always = metadata.get("always", "").casefold() in {"1", "true", "yes"}
-            if always or "triggers" in metadata:
+            # ``_frontmatter`` maps ANY ``key:`` line (indented prose included,
+            # last write wins) and stops at an indented ``---``, while the
+            # loader honors only column-0 keys and closes only at a column-0
+            # ``---`` — so its collapsed map must not decide activation.
+            # ``_column0_activation_declared`` mirrors the loader's region and
+            # key rules; the ``triggers`` presence check on the map is kept as
+            # an extra conservative layer (an indented mention only ever makes
+            # the gate stricter).
+            if _column0_activation_declared(text) or "triggers" in metadata:
                 scan.diagnostic(
                     "skills",
                     "automatic_activation_excluded",
@@ -1895,6 +1903,41 @@ def _frontmatter(text: str) -> tuple[dict[str, str], str]:
     if not end:
         return {}, text
     return metadata, "\n".join(lines[end + 1 :]).strip()
+
+
+def _column0_activation_declared(text: str) -> bool:
+    """True if any column-0 auto-activation declaration is in the frontmatter.
+
+    The activation decision must mirror what ``SkillsLoader._parse_frontmatter``
+    can conclude after install, not ``_frontmatter``'s collapsed map (where an
+    indented prose line like ``  always: false`` overwrites the real value, and
+    an indented ``---`` inside a block scalar truncates the scan). Region and
+    key rules therefore match the loader exactly: the frontmatter closes at the
+    first line that STARTS with ``---`` (the loader's ``\\n---`` regex), and
+    only column-0 keys count. A column-0 ``always`` activates on a truthy plain
+    value or a bare block-scalar indicator (fail-closed: this parser cannot see
+    the continuation lines the loader resolves); a column-0 ``triggers`` key
+    activates by presence. ANY activating declaration rejects — stricter than
+    the loader's last-wins on duplicate keys, which only ever diverges in the
+    conservative direction.
+    """
+    if not text.startswith("---"):
+        return False
+    for line in text.splitlines()[1:]:
+        if line.startswith("---"):
+            break
+        if ":" not in line or line[:1].isspace():
+            continue
+        key, raw = line.split(":", 1)
+        key = key.strip()
+        if key == "triggers":
+            return True
+        if key != "always":
+            continue
+        value = raw.strip().strip("\"'").casefold()
+        if value in {"1", "true", "yes"} or value in _BLOCK_SCALAR_INDICATORS:
+            return True
+    return False
 
 
 def _parse_configs(

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -36,6 +36,69 @@ logger = logging.getLogger(__name__)
 SKILLS_DIR_NAME = "skills"
 _MIN_TRIGGER_OVERLAP = 0.7
 
+# YAML block-scalar indicators recognized as frontmatter values: folded (>) or
+# literal (|), each with an optional chomping modifier. Explicit indentation
+# indicators (e.g. ">2") are not supported by this minimal parser.
+_BLOCK_SCALAR_INDICATORS = frozenset({">", "|", ">-", "|-", ">+", "|+"})
+
+
+def _fold_block_scalar(indicator: str, block: list[str]) -> str:
+    """Resolve a YAML block scalar's indented lines into a single value.
+
+    ``indicator`` is one of ``_BLOCK_SCALAR_INDICATORS``; ``block`` holds the
+    raw continuation lines (still carrying their indentation). Literal (``|``)
+    scalars keep one line per newline. Folded (``>``) scalars fold a single
+    break between plain lines to a space and keep blank lines as newlines
+    (k blanks -> k newlines plain-to-plain, k+1 next to a more-indented line,
+    where the separator break stays literal), and never fold a break adjacent
+    to a more-indented line, so nested indentation survives. Indentation is
+    stripped relative to the first non-blank line, and the result is trimmed,
+    so the chomping modifier (``-``/``+``) has no residual effect on the
+    stored value.
+    """
+    # Trim trailing blank lines without mutating the caller's list and
+    # without per-iteration copies (a pathological blank run stays linear).
+    end = len(block)
+    while end and not block[end - 1].strip():
+        end -= 1
+    if not end:
+        return ""
+    block = block[:end]
+    first = next(ln for ln in block if ln.strip())
+    indent = len(first) - len(first.lstrip())
+    dedented = [
+        ln[indent:] if ln[:indent].isspace() or not ln.strip() else ln.lstrip() for ln in block
+    ]
+    if indicator.startswith("|"):
+        return "\n".join(dedented).strip()
+    # Folded: a single line break between two plain lines becomes a space;
+    # blank lines are preserved as line breaks (k blanks -> k newlines); and
+    # breaks adjacent to a more-indented line are kept, so indented structure
+    # (nested lists, code-ish content) survives the fold.
+    parts: list[str] = []
+    pending_blanks = 0
+    prev_more_indented = False
+    for ln in dedented:
+        if not ln.strip():
+            pending_blanks += 1
+            continue
+        more_indented = ln[:1].isspace()
+        if parts:
+            if pending_blanks:
+                # The separator break folds to nothing between plain lines,
+                # but stays literal next to a more-indented line: k blanks
+                # yield k newlines plain-to-plain, k+1 otherwise.
+                extra = 1 if (more_indented or prev_more_indented) else 0
+                parts.append("\n" * (pending_blanks + extra))
+            elif more_indented or prev_more_indented:
+                parts.append("\n")
+            else:
+                parts.append(" ")
+        parts.append(ln.rstrip() if more_indented else ln.strip())
+        prev_more_indented = more_indented
+        pending_blanks = 0
+    return "".join(parts)
+
 
 def _matches_any(path: str, globs: list[str]) -> bool:
     """True if *path* matches any fnmatch glob in *globs*.
@@ -3268,6 +3331,14 @@ class SkillsLoader:
         honoring it here meant the opt-in could never take effect. Ignoring
         indented lines also drops the junk keys a prose line like
         ``  Steps: do x`` used to invent.
+
+        A value that is a YAML block-scalar indicator (``>``, ``|``, with an
+        optional chomping ``-``/``+``) is resolved from the indented lines that
+        follow it: folded (``>``) folds single breaks to spaces while keeping
+        blank-line and more-indented structure, literal (``|``) preserves
+        newlines. Without this, the stored value would be the indicator
+        character itself and the real content — a multi-line ``description``
+        used for routing — would be dropped, leaving the skill unroutable.
         """
         content = path.read_text(encoding="utf-8")
         if not content.startswith("---"):
@@ -3276,10 +3347,26 @@ class SkillsLoader:
         if not match:
             return {}
         meta: dict[str, str] = {}
-        for line in match.group(1).split("\n"):
-            if ":" in line and not line[:1].isspace():
-                key, value = line.split(":", 1)
-                meta[key.strip()] = value.strip().strip("\"'")
+        lines = match.group(1).split("\n")
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            i += 1
+            if ":" not in line or line[:1].isspace():
+                continue
+            key, raw = line.split(":", 1)
+            value = raw.strip()
+            if value in _BLOCK_SCALAR_INDICATORS:
+                # Indented (or blank) lines up to the next column-0 key are the
+                # scalar's content; trailing blanks between fields are trimmed
+                # by the folder.
+                block: list[str] = []
+                while i < len(lines) and (not lines[i].strip() or lines[i][:1].isspace()):
+                    block.append(lines[i])
+                    i += 1
+                meta[key.strip()] = _fold_block_scalar(value, block)
+            else:
+                meta[key.strip()] = value.strip("\"'")
         return meta
 
     @staticmethod

--- a/test/test_onboarding_import_coverage.py
+++ b/test/test_onboarding_import_coverage.py
@@ -2948,6 +2948,74 @@ class TestSkillPackaging:
 
         assert api._skill_package(scan, scan.root, manifest) is None
 
+    def test_a_block_scalar_always_value_is_rejected_fail_closed(self, tmp_path: Path) -> None:
+        # The gate's verbatim parser sees only the indicator; the loader that
+        # runs after install resolves the indented `true`. The gate must treat
+        # the unresolvable value as activating, or the package would slip past
+        # here and become always-injected once installed.
+        api = _api()
+        scan = _scan(tmp_path, "codex")
+        manifest = self._skill(scan.root, "demo", "---\nalways: >\n  true\n---\nBody\n")
+
+        assert api._skill_package(scan, scan.root, manifest) is None
+        assert "automatic_activation_excluded" in _reasons(scan)
+
+    def test_a_literal_block_scalar_always_value_is_rejected(self, tmp_path: Path) -> None:
+        api = _api()
+        scan = _scan(tmp_path, "codex")
+        manifest = self._skill(scan.root, "demo", "---\nalways: |-\n  true\n---\nBody\n")
+
+        assert api._skill_package(scan, scan.root, manifest) is None
+        assert "automatic_activation_excluded" in _reasons(scan)
+
+    def test_an_indented_always_line_cannot_mask_a_real_declaration(self, tmp_path: Path) -> None:
+        # _frontmatter's collapsed map takes the last ``key:`` line it sees,
+        # indented prose included — so ``always: false`` inside a block scalar
+        # would overwrite the real column-0 ``always: true``. The gate must
+        # decide from column-0 declarations only, like the loader does.
+        body = "---\nalways: true\ndescription: >\n  always: false\n---\nBody\n"
+        api = _api()
+        scan = _scan(tmp_path, "codex")
+        manifest = self._skill(scan.root, "demo", body)
+
+        assert api._skill_package(scan, scan.root, manifest) is None
+        assert "automatic_activation_excluded" in _reasons(scan)
+
+    def test_an_indented_always_line_alone_does_not_reject(self, tmp_path: Path) -> None:
+        # Prose that merely mentions ``always:`` inside a block scalar is not
+        # a declaration; the loader ignores it, and so must the gate.
+        body = "---\nname: demo\ndescription: >\n  always: true\n---\nBody\n"
+        api = _api()
+        scan = _scan(tmp_path, "codex")
+        manifest = self._skill(scan.root, "demo", body)
+
+        assert api._skill_package(scan, scan.root, manifest) is not None
+
+    def test_an_indented_delimiter_cannot_truncate_the_always_scan(self, tmp_path: Path) -> None:
+        # An indented ``---`` inside a block scalar is prose; the loader's
+        # frontmatter regex closes only at a column-0 ``---``, so a column-0
+        # ``always: true`` after the indented line is a real declaration the
+        # gate must still see.
+        body = "---\ndescription: >\n  ---\nalways: true\n---\nBody\n"
+        api = _api()
+        scan = _scan(tmp_path, "codex")
+        manifest = self._skill(scan.root, "demo", body)
+
+        assert api._skill_package(scan, scan.root, manifest) is None
+        assert "automatic_activation_excluded" in _reasons(scan)
+
+    def test_an_indented_delimiter_cannot_truncate_the_triggers_scan(self, tmp_path: Path) -> None:
+        # Same truncation shape through the ``triggers`` presence check, which
+        # reads _frontmatter's map — the map stops at the indented ``---`` and
+        # would drop the key.
+        body = "---\ndescription: >\n  ---\ntriggers: build\n---\nBody\n"
+        api = _api()
+        scan = _scan(tmp_path, "codex")
+        manifest = self._skill(scan.root, "demo", body)
+
+        assert api._skill_package(scan, scan.root, manifest) is None
+        assert "automatic_activation_excluded" in _reasons(scan)
+
     def test_an_over_large_package_is_diagnosed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/test/test_skill_update_flow.py
+++ b/test/test_skill_update_flow.py
@@ -800,6 +800,31 @@ def test_frontmatter_value_reads_fields_and_tolerates_missing():
     assert H._frontmatter_value(None, "description") == ""
 
 
+def test_frontmatter_value_resolves_block_scalars():
+    # A live skill authored with block-scalar frontmatter must round-trip
+    # through the update path: the staged candidate overwrites the live skill
+    # on approval, so reading the indicator verbatim would collapse the
+    # description to ">" (resolved to "" by the loader) and inject a bogus
+    # ">" entry into the merged trigger list.
+    body = (
+        "---\n"
+        "name: auto/x\n"
+        "description: >\n"
+        "  Retry a deploy\n"
+        "  after checking the logs.\n"
+        "triggers: |-\n"
+        "  a, b\n"
+        "---\n\n## Steps\n"
+    )
+    assert H._frontmatter_value(body, "description") == "Retry a deploy after checking the logs."
+    assert H._frontmatter_value(body, "triggers") == "a, b"
+    # An empty block resolves to "" rather than the indicator character.
+    assert H._frontmatter_value("---\ndescription: >\nname: x\n---\nbody", "description") == ""
+    # An indented occurrence of the key is prose inside a block, not a field.
+    nested = "---\ndescription: >\n  triggers: not real\ntriggers: real\n---\nbody"
+    assert H._frontmatter_value(nested, "triggers") == "real"
+
+
 @pytest.mark.asyncio
 async def test_stage_update_merges_live_triggers_not_replaces_them():
     """Approval writes the candidate's frontmatter over live, so the candidate

--- a/test/test_skills_frontmatter.py
+++ b/test/test_skills_frontmatter.py
@@ -1,0 +1,208 @@
+"""Frontmatter block-scalar parsing in ``SkillsLoader._parse_frontmatter``.
+
+A skill's ``description`` drives auto-routing; when it is authored as a YAML
+block scalar (``>``/``|``), the parser must resolve the indented continuation
+lines into the value instead of storing the indicator character. These tests
+lock in both block-scalar forms alongside the existing simple-value behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kiro_crew.skills import SkillsLoader
+
+
+def _write(tmp_path: Path, frontmatter: str) -> Path:
+    path = tmp_path / "SKILL.md"
+    path.write_text(f"---\n{frontmatter}\n---\n\n# Body\n", encoding="utf-8")
+    return path
+
+
+class TestSimpleValues:
+    """Existing single-line behavior must be preserved."""
+
+    def test_plain_key_value(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "name: my-skill\ndescription: does a thing")
+        )
+        assert meta == {"name": "my-skill", "description": "does a thing"}
+
+    def test_quoted_value_unquoted(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(_write(tmp_path, 'description: "quoted text"'))
+        assert meta["description"] == "quoted text"
+
+    def test_indented_key_value_ignored(self, tmp_path):
+        # An indented ``key: value`` is prose inside an enclosing scalar, not a
+        # field; honoring it invented junk keys and flipped real settings.
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "name: my-skill\n  inject_on_trigger: false")
+        )
+        assert meta == {"name": "my-skill"}
+
+    def test_no_frontmatter(self, tmp_path):
+        path = tmp_path / "SKILL.md"
+        path.write_text("# Just a body\n", encoding="utf-8")
+        assert SkillsLoader._parse_frontmatter(path) == {}
+
+
+class TestFoldedBlockScalar:
+    def test_folded_joins_with_spaces(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(
+            _write(
+                tmp_path,
+                "name: my-skill\n"
+                "description: >\n"
+                "  Render rich HTML inline via mcwidget tags\n"
+                "  with theme-aware styling.\n"
+                "triggers: widget",
+            )
+        )
+        assert meta["description"] == (
+            "Render rich HTML inline via mcwidget tags with theme-aware styling."
+        )
+        # Surrounding keys still parse normally.
+        assert meta["name"] == "my-skill"
+        assert meta["triggers"] == "widget"
+
+    def test_folded_with_chomping_strip(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "description: >-\n  first line\n  second line")
+        )
+        assert meta["description"] == "first line second line"
+
+    def test_folded_with_chomping_keep(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "description: >+\n  first line\n  second line")
+        )
+        assert meta["description"] == "first line second line"
+
+    def test_folded_blank_line_is_paragraph_break(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "description: >\n  para one\n\n  para two")
+        )
+        assert meta["description"] == "para one\npara two"
+
+    def test_folded_preserves_consecutive_blank_count(self, tmp_path):
+        # k blank lines fold to k newlines, not to a single separator.
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "description: >\n  para one\n\n\n  para two")
+        )
+        assert meta["description"] == "para one\n\npara two"
+
+    def test_folded_keeps_more_indented_line_breaks(self, tmp_path):
+        # Breaks adjacent to a more-indented line are not folded, so nested
+        # structure (a list inside a folded description) keeps its shape.
+        meta = SkillsLoader._parse_frontmatter(
+            _write(
+                tmp_path,
+                "description: >\n"
+                "  intro line\n"
+                "    - item one\n"
+                "    - item two\n"
+                "  outro line",
+            )
+        )
+        assert meta["description"] == "intro line\n  - item one\n  - item two\noutro line"
+
+    def test_folded_blank_next_to_more_indented_keeps_separator_break(self, tmp_path):
+        # Between plain lines the separator break folds away (k blanks -> k
+        # newlines); next to a more-indented line it stays literal, so k
+        # blanks yield k+1 newlines.
+        meta = SkillsLoader._parse_frontmatter(
+            _write(
+                tmp_path,
+                "description: >\n"
+                "  plain intro\n"
+                "\n"
+                "    indented detail\n"
+                "\n"
+                "  plain outro",
+            )
+        )
+        assert meta["description"] == "plain intro\n\n  indented detail\n\nplain outro"
+
+    def test_folded_at_end_of_frontmatter(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "name: my-skill\ndescription: >\n  trailing block value")
+        )
+        assert meta["description"] == "trailing block value"
+
+    def test_empty_folded_block_is_empty_string(self, tmp_path):
+        # An indicator with no continuation lines resolves to "", never ">".
+        meta = SkillsLoader._parse_frontmatter(_write(tmp_path, "description: >\nname: x"))
+        assert meta["description"] == ""
+        assert meta["name"] == "x"
+
+
+class TestLiteralBlockScalar:
+    def test_literal_preserves_newlines(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "description: |\n  line one\n  line two")
+        )
+        assert meta["description"] == "line one\nline two"
+
+    def test_literal_with_chomping_strip(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "description: |-\n  line one\n  line two")
+        )
+        assert meta["description"] == "line one\nline two"
+
+    def test_literal_with_chomping_keep(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "description: |+\n  line one\n  line two")
+        )
+        assert meta["description"] == "line one\nline two"
+
+    def test_literal_keeps_relative_indentation(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "description: |\n  outer\n    nested detail")
+        )
+        assert meta["description"] == "outer\n  nested detail"
+
+    def test_literal_leading_blank_line_keeps_relative_indentation(self, tmp_path):
+        # Indent is derived from the first NON-BLANK line, so a blank line
+        # right after the indicator must not flatten nested indentation.
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "description: |\n\n  outer\n    nested detail")
+        )
+        assert meta["description"] == "outer\n  nested detail"
+
+
+class TestBlockScalarBoundaries:
+    def test_colon_inside_block_is_not_a_key(self, tmp_path):
+        # A continuation line containing ``:`` stays part of the scalar and
+        # must not invent a frontmatter field.
+        meta = SkillsLoader._parse_frontmatter(
+            _write(
+                tmp_path,
+                "description: >\n  Steps: do x then y\nname: my-skill",
+            )
+        )
+        assert meta["description"] == "Steps: do x then y"
+        assert "Steps" not in meta
+        assert meta["name"] == "my-skill"
+
+    def test_next_unindented_key_ends_block(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(
+            _write(
+                tmp_path,
+                "description: >\n  the description\nalways: true\ntriggers: a, b",
+            )
+        )
+        assert meta["description"] == "the description"
+        assert meta["always"] == "true"
+        assert meta["triggers"] == "a, b"
+
+    def test_blank_lines_between_block_and_next_key(self, tmp_path):
+        meta = SkillsLoader._parse_frontmatter(
+            _write(tmp_path, "description: >\n  the description\n\nname: my-skill")
+        )
+        assert meta["description"] == "the description"
+        assert meta["name"] == "my-skill"
+
+    def test_indicator_like_prose_value_kept_verbatim(self, tmp_path):
+        # Only a bare indicator triggers block collection; a value merely
+        # starting with one of the characters is an ordinary scalar.
+        meta = SkillsLoader._parse_frontmatter(_write(tmp_path, "description: >prompt marker"))
+        assert meta["description"] == ">prompt marker"


### PR DESCRIPTION
## Problem

A skill whose frontmatter field is authored as a YAML block scalar — e.g.

```yaml
description: >
  Render rich HTML inline via mcwidget tags
  with theme-aware styling.
```

parses to `description == ">"`. `SkillsLoader._parse_frontmatter` splits each line on the first `:` and stores the stripped remainder, so the block-scalar indicator itself becomes the value and the indented continuation lines are discarded.

## Why it matters

`description` drives auto-routing. A skill whose description collapses to `>` or `|` never matches anything — the skill is silently unroutable, and block scalars are the natural way to author the long multi-line descriptions real skills carry.

Closes #3182

## Fix (symptoms → root cause → change)

- **Symptom:** block-scalar descriptions stored as a single indicator character; continuation lines dropped.
- **Root cause:** the line parser has no concept of a value spanning lines; the existing indented-line skip (which is correct for prose inside a block scalar) discards the content that should have become the value.
- **Change:** when a value strips to a bare indicator (`>`, `|`, `>-`, `|-`, `>+`, `|+`), collect the following indented/blank lines up to the next column-0 key and resolve them per YAML semantics — folded (`>`) joins with spaces with blank lines as paragraph breaks; literal (`|`) preserves newlines (`_fold_block_scalar`). Indented lines outside a block scalar are still ignored, preserving the documented column-0 contract that `set_inject_on_trigger` relies on.
- **Security hardening (found in pre-push review):** the onboarding import gate reads `always` through its own verbatim parser, so with the loader now resolving block scalars, a foreign skill declaring `always: >` + indented `true` would have passed the gate yet become always-injected after install — a fail-open parser divergence. The gate now treats a bare block-scalar indicator as an activating value (fail-closed, shared `_BLOCK_SCALAR_INDICATORS` constant), so the two parsers can never disagree in the permissive direction.
- The `memory-skills-hooks` spec is updated in the same commit per the spec-management rule.

Known limitation (deliberate, documented in code + spec): explicit indentation indicators (`>2`) and indicator-plus-comment (`> # note`) are not resolved — they keep the previous verbatim behavior.

## Tests

- `test/test_skills_frontmatter.py` (new, 19 tests): folded/literal each with all three chomping forms, paragraph breaks, relative indentation (incl. leading-blank-line regression), block boundaries (next key ends block, blank lines between fields, `:` inside a block does not invent a key), empty block → `""`, indicator-like prose values kept verbatim, and existing simple-value/quoted/indented-key behavior locked in.
- `test/test_onboarding_import_coverage.py` (+2): a block-scalar `always` value (`>` and `|-`) is rejected fail-closed with `automatic_activation_excluded`.

## Manual verification

N/A — unit coverage is sufficient: the parser is a pure function over file text, and both consumer paths (routing description, import gate) are exercised by the added tests.

## Screenshots

N/A — backend-only change, no UI surface.
