### PR TITLE
fix(sandbox): sweep inherited fds in the probe child before unshare (#3150)

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -397,6 +397,76 @@ def _close_probe_fds(*fds: int) -> None:
             pass
 
 
+_PROBE_CHILD_FD_SWEEP_CAP = 4096
+"""Fallback bound for the probe child's inherited-fd close sweep.
+
+Used only when ``SC_OPEN_MAX`` cannot be read or answers nonsense. When
+sysconf answers, its value (the soft ``RLIMIT_NOFILE``) is trusted as the
+bound: ``os.closerange`` delegates to ``close_range(2)`` on Linux >= 5.9, so
+a wide span costs one syscall rather than a walk, and silently clamping the
+bound would leave a high-numbered lock fd open with no diagnostic that the
+sweep came up short.
+"""
+
+
+def _fd_sweep_ranges(
+    keep: frozenset[int], limit: int | None = None
+) -> tuple[tuple[int, int], ...]:
+    """Precompute the ``os.closerange`` spans covering ``[0, bound)`` minus *keep*.
+
+    Runs in the PARENT, before ``os.fork()``. The probe child of a threaded
+    process must not allocate or take locks — another thread may own the
+    allocator lock at fork time and vanish, leaving it held forever in the
+    child — so everything that sorts, boxes, or asks ``sysconf`` happens here,
+    and the child is left executing bare ``closerange`` syscalls over the
+    returned pairs (:func:`_close_fd_ranges`).
+
+    The bound is ``SC_OPEN_MAX`` (the soft ``RLIMIT_NOFILE``);
+    :data:`_PROBE_CHILD_FD_SWEEP_CAP` applies only when sysconf cannot answer.
+    ``limit`` exists for tests. Never raises.
+    """
+    if limit is None:
+        try:
+            limit = int(os.sysconf("SC_OPEN_MAX"))
+        except (AttributeError, OSError, ValueError):
+            # AttributeError: os.sysconf does not exist off-POSIX (Windows);
+            # the sweep only runs on Linux, but this helper must keep its
+            # never-raises contract everywhere the tests exercise it.
+            limit = _PROBE_CHILD_FD_SWEEP_CAP
+    if limit <= 0:
+        limit = _PROBE_CHILD_FD_SWEEP_CAP
+    ranges: list[tuple[int, int]] = []
+    low = 0
+    for fd in sorted(k for k in keep if k >= 0):
+        if fd >= limit:
+            break
+        if fd > low:
+            ranges.append((low, fd))
+        low = fd + 1
+    if low < limit:
+        ranges.append((low, limit))
+    return tuple(ranges)
+
+
+def _close_fd_ranges(ranges: tuple[tuple[int, int], ...]) -> None:
+    """Close the precomputed fd spans: the probe child's half of the sweep.
+
+    Runs between ``os.fork()`` and ``os._exit`` in a child that never execs,
+    so ``O_CLOEXEC`` never fires and every inherited descriptor — the
+    ``gateway.lock`` flock fd and the dashboard listen socket included — is
+    still open. Without the sweep, a probe child orphaned by its parent's
+    death (gateway OOM-killed between fork and reap) keeps the lock fd open
+    and pins the data home until someone reclaims it.
+
+    Only ``os.closerange`` is invoked here: the spans were computed pre-fork
+    by :func:`_fd_sweep_ranges` precisely so this post-fork path does no
+    allocation-bearing work beyond iterating a ready tuple. ``closerange``
+    ignores bad fds, so this never raises.
+    """
+    for low, high in ranges:
+        os.closerange(low, high)
+
+
 def _probe_failure(label: str, err: int) -> tuple[bool, bool, str, str]:
     """Shape one failed probe step into ``(ok, transient, reason)``.
 
@@ -556,15 +626,27 @@ def _probe_reap(pid: int) -> None:
 
 
 def _probe_child_sequence(
-    libc: ctypes.CDLL, c2p_r: int, c2p_w: int, p2c_r: int, p2c_w: int
+    libc: ctypes.CDLL,
+    c2p_r: int,
+    c2p_w: int,
+    p2c_r: int,
+    p2c_w: int,
+    sweep_ranges: tuple[tuple[int, int], ...],
 ) -> None:
     """Probe child: run the launcher's two unshare steps, reporting each on the pipe.
 
     Never returns. It reports raw errnos and classifies nothing, so the entire
     verdict lives in the parent where a test can drive it without forking.
+    ``sweep_ranges`` was computed pre-fork by :func:`_fd_sweep_ranges` so this
+    path performs no allocation-bearing bookkeeping of its own.
     """
     try:
         _close_probe_fds(c2p_r, p2c_w)
+        # Drop every other inherited descriptor before touching namespaces:
+        # an orphaned probe child must not keep the gateway.lock fd (or the
+        # dashboard listen socket) open and pin the home. Only the handshake
+        # ends and the standard streams survive. (#3150)
+        _close_fd_ranges(sweep_ranges)
         err = _probe_child_unshare(libc, _CLONE_NEWUSER)
         os.write(c2p_w, b"U:%d\n" % err)
         if err:
@@ -659,6 +741,11 @@ def _probe_unshare_once() -> tuple[bool, bool, str, str]:
         _close_probe_fds(c2p_r, c2p_w)
         return _probe_failure("probe pipe", exc.errno or 0)
 
+    # Compute the child's fd sweep BEFORE forking: sorting, sysconf, and tuple
+    # building all allocate, and post-fork the allocator lock may be held by a
+    # thread that no longer exists in the child. (#3150)
+    sweep_ranges = _fd_sweep_ranges(frozenset({0, 1, 2, c2p_w, p2c_r}))
+
     try:
         pid = os.fork()
     except OSError as exc:
@@ -666,7 +753,7 @@ def _probe_unshare_once() -> tuple[bool, bool, str, str]:
         return _probe_failure("fork", exc.errno or 0)
 
     if pid == 0:
-        _probe_child_sequence(libc, c2p_r, c2p_w, p2c_r, p2c_w)  # never returns
+        _probe_child_sequence(libc, c2p_r, c2p_w, p2c_r, p2c_w, sweep_ranges)  # never returns
         os._exit(1)  # pragma: no cover - defensive
 
     _close_probe_fds(c2p_w, p2c_r)

--- a/test/test_sandbox_probe.py
+++ b/test/test_sandbox_probe.py
@@ -452,3 +452,179 @@ class TestProbeScaffolding:
 
         assert sb._probe_unshare() is False
         assert sb._last_unshare_failure == (False, "not Linux", "")
+
+
+def _fd_open(fd: int) -> bool:
+    """Whether *fd* refers to an open descriptor in THIS process."""
+    try:
+        os.fstat(fd)
+        return True
+    except OSError:
+        return False
+
+
+class TestProbeChildFdSweep:
+    """The probe child must drop inherited descriptors before its first unshare.
+
+    Regression cover for #3150: ``fork()`` copies every open descriptor — the
+    ``gateway.lock`` flock fd and the dashboard listen socket included — and the
+    probe child never execs, so ``O_CLOEXEC`` never fires. A child orphaned by
+    its parent's death (gateway OOM-killed between fork and reap) used to keep
+    the lock fd open and pin the data home.
+
+    The range-arithmetic tests are platform-neutral; only the two tests that
+    actually ``fork()`` carry the Linux gate.
+    """
+
+    def test_sweep_ranges_skip_exactly_the_keep_set(self):
+        """The precomputed spans cover everything below the limit but keep."""
+        ranges = sb._fd_sweep_ranges(frozenset({0, 1, 2, 5, 7}), limit=10)
+
+        assert ranges == ((3, 5), (6, 7), (8, 10))
+        covered = {fd for lo, hi in ranges for fd in range(lo, hi)}
+        assert covered == set(range(10)) - {0, 1, 2, 5, 7}
+
+    def test_sweep_ignores_keep_fds_at_or_above_the_limit(self):
+        """A keep fd beyond the sweep bound must not truncate the sweep below it."""
+        assert sb._fd_sweep_ranges(frozenset({0, 1, 2, 5000, -1}), limit=10) == ((3, 10),)
+
+    def test_sweep_trusts_a_large_open_max(self, monkeypatch):
+        """A big SC_OPEN_MAX is the bound, not clamped: high lock fds must close.
+
+        ``os.closerange`` is one ``close_range(2)`` syscall on Linux >= 5.9, so
+        a wide span is cheap — and silently clamping it would leave an fd at,
+        say, 60000 open on a ``LimitNOFILE=65536`` host with no diagnostic.
+        ``raising=False`` because ``os.sysconf`` does not exist on Windows.
+        """
+        monkeypatch.setattr(sb.os, "sysconf", lambda _name: 65536, raising=False)
+
+        assert sb._fd_sweep_ranges(frozenset({0, 1, 2})) == ((3, 65536),)
+
+    def test_sweep_falls_back_when_sysconf_is_unhelpful(self, monkeypatch):
+        """Unreadable, nonsense, or absent SC_OPEN_MAX gets the fallback cap.
+
+        The absent case is real: ``os.sysconf`` does not exist off-POSIX, and
+        the helper's never-raises contract must hold everywhere it can run.
+        """
+
+        def unavailable(_name):
+            raise ValueError("unrecognized configuration name")
+
+        monkeypatch.setattr(sb.os, "sysconf", unavailable, raising=False)
+        first = sb._fd_sweep_ranges(frozenset({0, 1, 2}))
+
+        monkeypatch.setattr(sb.os, "sysconf", lambda _name: -1, raising=False)
+        second = sb._fd_sweep_ranges(frozenset({0, 1, 2}))
+
+        monkeypatch.delattr(sb.os, "sysconf", raising=False)
+        third = sb._fd_sweep_ranges(frozenset({0, 1, 2}))
+
+        assert first == second == third == ((3, sb._PROBE_CHILD_FD_SWEEP_CAP),)
+
+    def test_close_fd_ranges_replays_exactly_the_given_spans(self, monkeypatch):
+        """The child half only replays the precomputed spans, in order."""
+        calls: list[tuple[int, int]] = []
+        monkeypatch.setattr(sb.os, "closerange", lambda lo, hi: calls.append((lo, hi)))
+
+        sb._close_fd_ranges(((3, 5), (8, 20)))
+
+        assert calls == [(3, 5), (8, 20)]
+
+    @_linux_only
+    def test_child_sweeps_before_first_unshare_and_keeps_handshake_ends(self, monkeypatch):
+        """``_probe_child_sequence`` runs the sweep BEFORE touching namespaces.
+
+        Order matters: a sweep after the first unshare leaves the window where
+        an orphaned child parked in the handshake still holds the lock fd. The
+        sweep must replay exactly the ranges the parent precomputed — dropping
+        either handshake end deadlocks the parent's read.
+        """
+        calls: list[tuple[str, object]] = []
+        monkeypatch.setattr(
+            sb,
+            "_close_fd_ranges",
+            lambda ranges: calls.append(("sweep", tuple(ranges))),
+        )
+
+        def fake_unshare(_libc, flags):
+            calls.append(("unshare", flags))
+            return 0
+
+        class _ChildExit(BaseException):
+            """Raised by the patched ``os._exit`` so nothing runs past an exit."""
+
+        exits: list[int] = []
+        test_pid = os.getpid()
+        real_exit = os._exit  # captured pre-patch; the guard must not recurse
+
+        def fake_exit(code):
+            if os.getpid() != test_pid:  # a real fork must still exit for real
+                real_exit(code)  # pragma: no cover - only on an escaped fork
+            exits.append(code)
+            raise _ChildExit(code)
+
+        monkeypatch.setattr(sb, "_probe_child_unshare", fake_unshare)
+        monkeypatch.setattr(sb.os, "_exit", fake_exit)
+
+        c2p_r, c2p_w = os.pipe()
+        p2c_r, p2c_w = os.pipe()
+        # The child closes the parent's ends (c2p_r, p2c_w); in production the
+        # parent process still holds them. Without a surviving reader for c2p
+        # in this single-process harness, the child's report write gets EPIPE.
+        parent_c2p_r = os.dup(c2p_r)
+        sweep = ((3, c2p_w), (c2p_w + 1, 64),)
+        try:
+            os.write(p2c_w, b"x")  # pre-release the maps handshake
+            with pytest.raises(_ChildExit):
+                sb._probe_child_sequence(None, c2p_r, c2p_w, p2c_r, p2c_w, sweep)
+        finally:
+            # _probe_child_sequence already closed c2p_r and p2c_w as its first
+            # statement; re-closing them here could tear down an unrelated fd
+            # that was allocated into the freed numbers meanwhile.
+            for fd in (c2p_w, p2c_r, parent_c2p_r):
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+        # The success path exits 0; a failure after the second unshare would
+        # first record a nonzero exit before the BaseException handler re-exits,
+        # so the FIRST recorded code is the real verdict.
+        assert exits[0] == 0
+        assert calls[0] == ("sweep", sweep)
+        assert calls[1] == ("unshare", sb._CLONE_NEWUSER)
+        assert ("unshare", sb._CLONE_NEWNS) in calls
+
+    @_linux_only
+    def test_forked_child_really_drops_a_lock_shaped_fd(self, tmp_path):
+        """End to end: a fd held open in the parent is closed in the swept child.
+
+        Mirrors the leak shape exactly — a plain ``os.open`` on a lock file,
+        inherited across ``fork()`` — and asserts the sweep drops it while the
+        report pipe named in the keep-set survives to carry the verdict out.
+        The ranges are precomputed pre-fork, as production does.
+        """
+        sentinel = os.open(str(tmp_path / "gateway.lock"), os.O_RDWR | os.O_CREAT)
+        report_r, report_w = os.pipe()
+        sweep = sb._fd_sweep_ranges(frozenset({0, 1, 2, report_w}))
+        pid = os.fork()
+        if pid == 0:  # pragma: no cover - forked child, exits below
+            try:
+                sb._close_fd_ranges(sweep)
+                payload = (b"1" if _fd_open(sentinel) else b"0") + (
+                    b"1" if _fd_open(report_w) else b"0"
+                )
+                os.write(report_w, payload)
+                os._exit(0)
+            except BaseException:
+                os._exit(1)
+        os.close(report_w)
+        try:
+            data = os.read(report_r, 2)
+        finally:
+            os.close(report_r)
+            os.close(sentinel)
+            _, status = os.waitpid(pid, 0)
+
+        assert os.waitstatus_to_exitcode(status) == 0
+        assert data == b"01", "sentinel lock fd must close; kept report pipe must survive"


### PR DESCRIPTION
## Problem

The sandbox capability probe forks a child that runs the launcher's two `unshare(2)` steps. `fork()` copies every open descriptor — including the `gateway.lock` flock fd and the dashboard listen socket — and the probe child never execs, so `O_CLOEXEC` never fires. A probe child orphaned by its parent's death (gateway OOM-killed between fork and reap) kept those descriptors open: the stale lock pinned the data home so a restarted gateway could not take it over, and the held listen socket blocked rebinding the dashboard port.

Closes #3150

## Why it matters

The exact moment this bites is the moment the gateway most needs a clean restart: it just died. On a memory-pressured host an OOM kill between the probe's fork and reap leaves an invisible child holding the home hostage — the operator sees "another instance is running" with no such instance in the process list, and the only remedies are hunting the orphan or waiting for it to die.

## Fix

The probe child now drops every inherited descriptor before touching namespaces, keeping only the standard streams and its two live handshake pipe ends.

Post-fork safety is load-bearing here: the gateway is multithreaded, and a child forked while another thread owns an allocator lock inherits that lock permanently held. So the sweep is split in two:

- `_fd_sweep_ranges()` runs in the **parent, before `os.fork()`** — reads `SC_OPEN_MAX`, sorts the keep-set, and precomputes the `(low, high)` closerange spans. All allocation happens here.
- `_close_fd_ranges()` runs in the **child** — replays the ready tuple with bare `os.closerange` syscalls, which ignore bad fds and never raise.

`SC_OPEN_MAX` (the soft `RLIMIT_NOFILE`) is trusted as the sweep bound — `os.closerange` delegates to `close_range(2)` on Linux ≥ 5.9, so a wide span costs one syscall — with a 4096 fallback only when `sysconf` cannot answer. Silently clamping would leave a high-numbered lock fd open with no diagnostic.

## Tests

Seven tests in `test/test_sandbox_probe.py::TestProbeChildFdSweep`:

- Range arithmetic (platform-neutral, runs on all OS lanes): interleave covers exactly `[0, limit) − keep`; keep fds at/above the bound don't truncate the sweep; a large `SC_OPEN_MAX` is trusted as the bound; sysconf failure falls back to the cap; the child half replays exactly the given spans in order.
- Wiring (Linux-only): `_probe_child_sequence` sweeps before the first `unshare`, with the success exit code asserted (`exits[0] == 0`, not just exception type); the `os._exit` patch is pid-guarded so an escaped fork still exits for real.
- End to end (Linux-only): a real `fork()` proves a lock-shaped fd inherited from the parent is closed in the swept child while the kept report pipe survives.

Non-vacuity proven by mutation: with the child's sweep call disabled, the wiring test fails.

## Manual verification

Ran the full targeted file locally (39 passed, 1 pre-existing skip) plus isort/flake8/mypy across all 925 source files, all clean. Mutation probe (sweep disabled → test fails → restored → green) run under the memory-safe pytest wrapper.

## Screenshots

N/A — backend-only change to the sandbox probe's fork path; no UI surface.
