### PR TITLE
fix: fold block-scalar frontmatter values instead of storing the indicator (#3182)

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -596,7 +596,7 @@ truncated to 300 chars.
 
 ## Skills (`skills.py`)
 
-Markdown files at `~/.kiro/crew/skills/{name}/SKILL.md` with optional YAML frontmatter (`name`, `description`, `always`).
+Markdown files at `~/.kiro/crew/skills/{name}/SKILL.md` with optional YAML frontmatter (`name`, `description`, `always`). Values may be single-line scalars or block scalars: a `>` folded / `|` literal value folds its indented continuation lines into the field (`parse_frontmatter_block`, shared by the loader and the Discover reader — the loader strips surrounding quotes on single-line values, Discover keeps them; a bare indicator with no indented body keeps the literal character), so a multi-line `description` reaches the router (catalog lines still pass through `_short_desc`, which collapses whitespace and caps at 300 chars). Only a key at column 0 is a field — an indented `key: value` inside a block scalar becomes part of that block's text, never a field.
 
 Supports nested directories (e.g. `skills/utils/tiny-url/SKILL.md`). The skill name is the relative path from the skills root (e.g. `utils/tiny-url`).
 

--- a/src/kiro_crew/dashboard/handlers/discover.py
+++ b/src/kiro_crew/dashboard/handlers/discover.py
@@ -22,6 +22,7 @@ from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel as _sel
 from kiro_crew.skill_providers.base import ProviderRegistry
 from kiro_crew.skill_providers.skillsh import SkillsShConfig, SkillsShProvider
+from kiro_crew.skills import parse_frontmatter_block
 from kiro_crew.skills import skills_dir as _skills_dir
 
 logger = logging.getLogger(__name__)
@@ -602,11 +603,23 @@ async def api_skills_discover_preview(request: web.Request) -> web.Response:
     max_preview = 64 * 1024
     # Provider-sourced fields (including the full SKILL.md body) are
     # attacker-controllable -- redact before returning to the dashboard.
+    # Frontmatter fields are length-capped too: a block-scalar value now folds
+    # to its whole indented body (issue #3182) instead of one physical line,
+    # so an attacker-chosen field must not scale the response unboundedly.
+    # Redaction runs BEFORE the cap: a truncation cut can split a credential
+    # pattern so the matcher misses it, while cutting already-redacted text
+    # can only shorten safe output. Field size is bounded upstream by the
+    # provider fetch cap.
+    max_field = 4096
+
+    def _safe_field(key: str) -> str:
+        return _redact_external(meta.get(key, ""))[:max_field]
+
     return web.json_response({
-        "description": _redact_external(meta.get("description", "")),
-        "name": _redact_external(meta.get("name", "")),
-        "license": _redact_external(meta.get("license", "")),
-        "author": _redact_external(meta.get("author", "")),
+        "description": _safe_field("description"),
+        "name": _safe_field("name"),
+        "license": _safe_field("license"),
+        "author": _safe_field("author"),
         "content": _redact_external(content[:max_preview]),
         "files": [_redact_external(f) for f in files[:200]],
         "file_count": len(files),
@@ -614,16 +627,16 @@ async def api_skills_discover_preview(request: web.Request) -> web.Response:
 
 
 def _parse_frontmatter(content: str) -> dict:
-    """Extract YAML frontmatter key-value pairs from a SKILL.md."""
+    """Extract YAML frontmatter key-value pairs from a SKILL.md.
+
+    Delegates to :func:`kiro_crew.skills.parse_frontmatter_block` so a
+    block-scalar ``description:`` folds here exactly as in the loader
+    (issue #3182) instead of showing ``>`` in the Discover preview. Quotes
+    are kept on single-line values, as this reader always did.
+    """
     if not content.startswith("---"):
         return {}
     end = content.find("\n---", 3)
     if end == -1:
         return {}
-    frontmatter = content[4:end]
-    result: dict = {}
-    for line in frontmatter.split("\n"):
-        if ":" in line and not line.startswith(" "):
-            key, _, value = line.partition(":")
-            result[key.strip()] = value.strip()
-    return result
+    return parse_frontmatter_block(content[4:end], strip_quotes=False)

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -340,6 +340,149 @@ def _project_skills_dir() -> Path | None:
     return None
 
 
+# A YAML block-scalar header: the style character (``>`` folded / ``|``
+# literal), optionally followed by a chomping indicator (``+`` / ``-``) and/or
+# an explicit indentation digit, in either order (``>-``, ``|+``, ``|2``,
+# ``>2-``…), optionally followed by a comment (``> # note``) — group 1 is the
+# indicator itself. Anything else after the colon is an ordinary scalar value.
+_BLOCK_SCALAR_INDICATOR = re.compile(
+    r"^([>|](?:[1-9][+-]?|[+-][1-9]?)?)(?:[ \t]+#.*)?$"
+)
+
+
+def _fold_block_scalar(indicator: str, body: list[str]) -> str:
+    """Fold the indented *body* of a block scalar into a single value.
+
+    *indicator* is the full header (``>``, ``|``, ``>-``, ``|2``…): the first
+    character picks the style, and an explicit indentation digit, when
+    present, sets exactly how many leading spaces to strip (YAML's indentation
+    indicator); otherwise the first non-blank line's indentation is inferred.
+
+    ``>`` folds per YAML for the shapes skills actually use: single newlines
+    between lines become spaces, a blank line becomes a newline, and a
+    more-indented line stays literal on its own line. ``|`` keeps every
+    newline. Leading/trailing blank lines are always trimmed and no trailing
+    newline is kept, regardless of chomping modifier — the value feeds
+    description/trigger fields where stray whitespace is never wanted, which
+    satisfies ``-`` chomping without modeling ``+`` (keep) separately.
+
+    Returns ``""`` when *body* holds no text, so the caller can fall back to
+    the pre-fold behavior for a bare indicator with nothing under it.
+    """
+    start, end = 0, len(body)
+    while start < end and not body[start].strip():
+        start += 1
+    while end > start and not body[end - 1].strip():
+        end -= 1
+    body = body[start:end]
+    if not body:
+        return ""
+    digit = next((c for c in indicator[1:] if c.isdigit()), "")
+    if digit:
+        prefix = " " * int(digit)
+    else:
+        # Spaces only: YAML indentation is never tabs, so a tab after the
+        # indent is CONTENT (a code line) and must survive the dedent.
+        prefix = body[0][: len(body[0]) - len(body[0].lstrip(" "))]
+    dedented = [
+        ""
+        if not ln.strip()
+        else (ln[len(prefix) :] if ln.startswith(prefix) else ln.lstrip(" "))
+        for ln in body
+    ]
+    if indicator[0] == "|":
+        return "\n".join(dedented)
+    # Folded (>): consecutive text lines join with spaces; a run of k blank
+    # lines between text lines becomes k newlines (a double blank keeps its
+    # wider paragraph gap); a more-indented line stays literal on its own
+    # line per YAML (nested lists, code), and because no fold happens around
+    # a literal line, a blank run adjacent to one keeps ALL its newlines
+    # (k blanks -> k+1 newlines). Verified against PyYAML on these shapes.
+    out_parts: list[str] = []
+    blanks = 0
+    prev_literal: bool | None = None  # None = nothing emitted yet
+    for ln in dedented:
+        if not ln:
+            if prev_literal is not None:
+                blanks += 1
+            continue
+        literal = ln[:1].isspace()
+        if prev_literal is None:
+            sep = ""
+        elif blanks:
+            sep = "\n" * (blanks + 1 if (literal or prev_literal) else blanks)
+        elif literal or prev_literal:
+            sep = "\n"
+        else:
+            sep = " "
+        out_parts.append(sep + ln)
+        blanks = 0
+        prev_literal = literal
+    return "".join(out_parts)
+
+
+def parse_frontmatter_block(block: str, *, strip_quotes: bool = True) -> dict[str, str]:
+    """Parse the inner lines of a YAML frontmatter block (simple key: value).
+
+    Only a key at column 0 is a field. An indented ``key: value`` belongs to
+    the enclosing block scalar — a description that documents a setting, for
+    instance — and reading it as the setting made the writer and the reader
+    disagree: ``set_inject_on_trigger`` deliberately leaves an indented
+    occurrence alone (deleting it would rewrite the author's prose), so
+    honoring it here meant the opt-in could never take effect. Ignoring
+    indented lines also drops the junk keys a prose line like ``  Steps: do x``
+    used to invent.
+
+    A column-0 value that is exactly a block-scalar indicator (``>`` / ``|``,
+    with optional chomping/indent modifiers) folds the following more-indented
+    lines into that key's value instead of storing the indicator character
+    (issue #3182 — the router matches on ``description``, so a block-scalar
+    description previously left the skill unroutable). This strengthens both
+    invariants above: an indented ``key: value`` inside the block becomes part
+    of that block's TEXT and still never becomes a field.
+
+    *strip_quotes* preserves each caller's historical single-line behavior:
+    the loader has always stripped surrounding quotes; the dashboard Discover
+    reader never did. A tab-indented ``key: value`` is treated as indented
+    (not a field) for both callers — tabs are not legal YAML indentation, and
+    the loader always read them that way.
+    """
+    meta: dict[str, str] = {}
+    # Normalize CRLF per line: Path.read_text gets universal-newline
+    # translation, but provider-fetched content (the Discover path) arrives
+    # raw — and its block extraction can also leave a dangling final "\r"
+    # when the closing delimiter split a "\r\n" pair.
+    lines = [ln[:-1] if ln.endswith("\r") else ln for ln in block.split("\n")]
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        i += 1
+        if ":" not in line or line[:1].isspace():
+            continue
+        key, raw_value = line.split(":", 1)
+        value = raw_value.strip()
+        header = _BLOCK_SCALAR_INDICATOR.match(value)
+        if header:
+            body: list[str] = []
+            while i < len(lines) and (
+                not lines[i].strip() or lines[i][:1].isspace()
+            ):
+                body.append(lines[i])
+                i += 1
+            folded = _fold_block_scalar(header.group(1), body)
+            if folded or body:
+                # Any consumed body — even one that folds to empty (a
+                # whitespace-only block) — means the value IS the folded
+                # text: storing the indicator for it would corrupt the field.
+                meta[key.strip()] = folded
+                continue
+            # A bare indicator with no body lines at all: keep the literal
+            # value exactly as this parser stored it before it learned block
+            # scalars.
+        meta[key.strip()] = value.strip("\"'") if strip_quotes else value
+    return meta
+
+
 def _trusted_skill_roots() -> tuple[str, ...]:
     """Resolved roots a symlink inside the skills tree may legitimately point into.
 
@@ -3258,16 +3401,11 @@ class SkillsLoader:
 
     @staticmethod
     def _parse_frontmatter(path: Path) -> dict[str, str]:
-        """Parse YAML frontmatter from a markdown file (simple key: value).
+        """Parse YAML frontmatter from a markdown file.
 
-        Only a key at column 0 is a field. An indented ``key: value`` belongs to
-        the enclosing block scalar — a description that documents a setting, for
-        instance — and reading it as the setting made the writer and the reader
-        disagree: ``set_inject_on_trigger`` deliberately leaves an indented
-        occurrence alone (deleting it would rewrite the author's prose), so
-        honoring it here meant the opt-in could never take effect. Ignoring
-        indented lines also drops the junk keys a prose line like
-        ``  Steps: do x`` used to invent.
+        Extracts the ``--- ... ---`` block and delegates the key/value parsing
+        (including block-scalar folding) to :func:`parse_frontmatter_block`,
+        which carries the column-0 invariants this reader has always enforced.
         """
         content = path.read_text(encoding="utf-8")
         if not content.startswith("---"):
@@ -3275,12 +3413,7 @@ class SkillsLoader:
         match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
         if not match:
             return {}
-        meta: dict[str, str] = {}
-        for line in match.group(1).split("\n"):
-            if ":" in line and not line[:1].isspace():
-                key, value = line.split(":", 1)
-                meta[key.strip()] = value.strip().strip("\"'")
-        return meta
+        return parse_frontmatter_block(match.group(1))
 
     @staticmethod
     def strip_frontmatter(content: str) -> str:

--- a/test/test_skill_frontmatter_block_scalar.py
+++ b/test/test_skill_frontmatter_block_scalar.py
@@ -1,0 +1,380 @@
+"""Block-scalar frontmatter values must fold instead of collapsing to ``>``.
+
+Regression tests for https://github.com/kirodotdev/KiroCrew/issues/3182: a
+skill whose ``description:`` uses a YAML block scalar (``>`` folded or ``|``
+literal) previously stored the indicator character alone, leaving the skill
+unroutable (the catalog the router matches on showed ``>`` as the whole
+description).
+
+The two invariants the original column-0 rule protected are pinned here too:
+an indented ``key: value`` never becomes a top-level field, and a prose line
+like ``  Steps: do x`` never invents a ``Steps`` key. Folding strengthens
+both — inside a block scalar those lines become part of the block's TEXT.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.config.loader import KiroCrewConfig, SkillsConfig
+from kiro_crew.dashboard.handlers.discover import _parse_frontmatter as discover_parse
+from kiro_crew.skills import SkillsLoader, parse_frontmatter_block
+
+
+@pytest.fixture(autouse=True)
+def _isolate_extra_paths(monkeypatch):
+    """Keep loader tests hermetic (same rationale as test_skills.py)."""
+    from kiro_crew.platform.defaults import DefaultMcpToolingProvider
+
+    monkeypatch.setattr(
+        KiroCrewConfig,
+        "load",
+        classmethod(lambda cls: KiroCrewConfig(skills=SkillsConfig(extra_paths=[]))),
+    )
+    monkeypatch.setattr(DefaultMcpToolingProvider, "extra_skills", lambda self: [])
+
+
+def _skill_file(tmp_path: Path, name: str, content: str) -> Path:
+    skill_dir = tmp_path / "skills" / name
+    skill_dir.mkdir(parents=True)
+    path = skill_dir / "SKILL.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# Reporter's exact repro shape from issue #3182.
+_FOLDED_SKILL = """---
+name: my-skill
+description: >
+  Audit a drafted document against the writing-style rules. Use when a draft
+  needs a wording pass, or the user asks for a style check.
+---
+
+# my-skill
+"""
+
+_FOLDED_DESCRIPTION = (
+    "Audit a drafted document against the writing-style rules. Use when a draft "
+    "needs a wording pass, or the user asks for a style check."
+)
+
+
+class TestFoldedScalar:
+    def test_folded_description_space_joins(self, tmp_path):
+        path = _skill_file(tmp_path, "my-skill", _FOLDED_SKILL)
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert meta["description"] == _FOLDED_DESCRIPTION
+        assert meta["description"] != ">"
+        assert meta["description"] == meta["description"].strip()
+        assert meta["name"] == "my-skill"
+
+    def test_blank_line_becomes_newline(self, tmp_path):
+        path = _skill_file(
+            tmp_path,
+            "para",
+            "---\nname: para\ndescription: >\n  First paragraph line one\n"
+            "  line two.\n\n  Second paragraph.\n---\nbody\n",
+        )
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert meta["description"] == (
+            "First paragraph line one line two.\nSecond paragraph."
+        )
+
+    def test_folded_with_chomping_modifier(self, tmp_path):
+        path = _skill_file(
+            tmp_path,
+            "chomp",
+            "---\nname: chomp\ndescription: >-\n  Keep this text.\n---\nbody\n",
+        )
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert meta["description"] == "Keep this text."
+        assert meta["description"] != ">-"
+
+
+class TestLiteralScalar:
+    def test_literal_preserves_newlines(self, tmp_path):
+        path = _skill_file(
+            tmp_path,
+            "lit",
+            "---\nname: lit\ndescription: |\n  line one\n  line two\n---\nbody\n",
+        )
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert meta["description"] == "line one\nline two"
+        assert meta["description"] != "|"
+
+    def test_literal_with_chomping_modifier(self, tmp_path):
+        path = _skill_file(
+            tmp_path,
+            "litchomp",
+            "---\nname: litchomp\ndescription: |-\n  only line\n---\nbody\n",
+        )
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert meta["description"] == "only line"
+        assert meta["description"] != "|-"
+
+
+class TestInvariantsPreserved:
+    """The docstring guards: pinned so a refactor cannot silently undo them."""
+
+    def test_indented_key_value_in_block_is_text_not_field(self, tmp_path):
+        path = _skill_file(
+            tmp_path,
+            "guard",
+            "---\nname: guard\ndescription: >\n  Documents the flag\n"
+            "  inject_on_trigger: false\n  and more prose.\n---\nbody\n",
+        )
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert "inject_on_trigger" not in meta
+        assert "inject_on_trigger: false" in meta["description"]
+
+    def test_prose_steps_line_invents_no_key(self, tmp_path):
+        path = _skill_file(
+            tmp_path,
+            "steps",
+            "---\nname: steps\ndescription: >\n  How to do it.\n"
+            "  Steps: do x\n---\nbody\n",
+        )
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert "Steps" not in meta
+        assert "Steps: do x" in meta["description"]
+
+    def test_indented_line_outside_block_still_ignored(self, tmp_path):
+        path = _skill_file(
+            tmp_path,
+            "stray",
+            "---\nname: stray\ndescription: plain\n  orphan: value\n---\nbody\n",
+        )
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert meta == {"name": "stray", "description": "plain"}
+
+
+class TestSingleLineRegression:
+    """Values that are already single-line must parse byte-identically."""
+
+    def test_plain_and_quoted_values_unchanged(self, tmp_path):
+        path = _skill_file(
+            tmp_path,
+            "plain",
+            '---\nname: plain\ndescription: "A quoted description"\n'
+            "triggers: alpha, beta\nalways: true\n---\nbody\n",
+        )
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert meta == {
+            "name": "plain",
+            "description": "A quoted description",
+            "triggers": "alpha, beta",
+            "always": "true",
+        }
+
+    def test_indicator_with_no_body_keeps_old_value(self, tmp_path):
+        # A bare `>` with no indented content has nothing to fold; the parse
+        # must not crash and must keep the pre-fix literal value.
+        path = _skill_file(
+            tmp_path,
+            "bare",
+            "---\nname: bare\ndescription: >\nalways: true\n---\nbody\n",
+        )
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert meta["description"] == ">"
+        assert meta["always"] == "true"
+
+    def test_indicator_with_whitespace_only_body_is_empty(self, tmp_path):
+        # A block whose body was consumed but folds to nothing (whitespace-
+        # only) is an EMPTY value, never the indicator character: storing
+        # `|-` for it would recreate the corruption this fix removes.
+        path = _skill_file(
+            tmp_path,
+            "wsbody",
+            "---\nname: wsbody\ndescription: |-\n   \nalways: true\n---\nbody\n",
+        )
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert meta["description"] == ""
+        assert meta["always"] == "true"
+
+    def test_value_starting_with_gt_but_not_indicator(self, tmp_path):
+        path = _skill_file(
+            tmp_path,
+            "gtword",
+            "---\nname: gtword\ndescription: >prompt marker\n---\nbody\n",
+        )
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert meta["description"] == ">prompt marker"
+
+
+class TestDiscoverReader:
+    """The dashboard Discover view's reader has the same defect; same fix."""
+
+    def test_folded_description(self):
+        meta = discover_parse(_FOLDED_SKILL)
+        assert meta["description"] == _FOLDED_DESCRIPTION
+        assert meta["description"] != ">"
+
+    def test_single_line_values_byte_identical(self):
+        # This reader never stripped quotes; pin that it still does not.
+        meta = discover_parse(
+            '---\nname: q\ndescription: "quoted stays quoted"\n---\nbody\n'
+        )
+        assert meta["description"] == '"quoted stays quoted"'
+        assert meta["name"] == "q"
+
+
+class TestWriterReaderAgreement:
+    """Round-trip: what the writer emits, the reader returns unchanged."""
+
+    def test_to_frontmatter_lines_round_trip(self, tmp_path):
+        from kiro_crew.skills import AutoSkillProvenance, _build_auto_skill_content
+
+        prov = AutoSkillProvenance(
+            session_key="sess-1", created_at=AutoSkillProvenance.now_iso()
+        )
+        content = _build_auto_skill_content(
+            slug="round-trip",
+            description="A single line description",
+            triggers="alpha, beta",
+            procedure_md="# body",
+            provenance=prov,
+        )
+        path = _skill_file(tmp_path, "round-trip", content)
+        meta = SkillsLoader._parse_frontmatter(path)
+        assert meta["description"] == "A single line description"
+        assert meta["triggers"] == "alpha, beta"
+        assert meta["session_key"] == "sess-1"
+        assert meta["created_at"] == prov.created_at
+
+    def test_set_inject_on_trigger_takes_effect_on_block_scalar_skill(
+        self, tmp_path
+    ):
+        _skill_file(tmp_path, "toggle", _FOLDED_SKILL)
+        loader = SkillsLoader(
+            skills_path=tmp_path / "skills", install_builtins=False
+        )
+        assert loader.set_inject_on_trigger("toggle", False) is True
+        meta = SkillsLoader._parse_frontmatter(
+            tmp_path / "skills" / "toggle" / "SKILL.md"
+        )
+        # The toggle landed as a real field AND the description survived.
+        assert meta["inject_on_trigger"] == "false"
+        assert meta["description"] == _FOLDED_DESCRIPTION
+
+
+class TestRouterSurface:
+    """The catalog the router matches on must carry the real description."""
+
+    def test_list_skills_surfaces_folded_description(self, tmp_path):
+        _skill_file(tmp_path, "my-skill", _FOLDED_SKILL)
+        loader = SkillsLoader(
+            skills_path=tmp_path / "skills", install_builtins=False
+        )
+        rows = loader.list_skills()
+        assert len(rows) == 1
+        assert rows[0]["description"] == _FOLDED_DESCRIPTION
+
+    def test_get_context_catalog_shows_folded_description(self, tmp_path):
+        _skill_file(tmp_path, "my-skill", _FOLDED_SKILL)
+        loader = SkillsLoader(
+            skills_path=tmp_path / "skills", install_builtins=False
+        )
+        context = loader.get_context()
+        assert "Audit a drafted document against the writing-style rules" in context
+        assert "**my-skill**: >" not in context
+
+
+class TestParseFrontmatterBlockHelper:
+    """Direct coverage of the shared helper's edge shapes."""
+
+    def test_indent_indicator_digit_accepted(self):
+        meta = parse_frontmatter_block("description: |2\n  text here")
+        assert meta["description"] == "text here"
+
+    def test_indent_indicator_digit_honored(self):
+        # |2 declares a 2-space block indent, so a 4-space body keeps 2 spaces.
+        meta = parse_frontmatter_block("description: |2\n    kept indent")
+        assert meta["description"] == "  kept indent"
+
+    def test_deeper_indent_kept_in_literal(self):
+        meta = parse_frontmatter_block(
+            "description: |\n  outer\n    inner extra indent"
+        )
+        assert meta["description"] == "outer\n  inner extra indent"
+
+    def test_deeper_indent_stays_literal_in_folded(self):
+        # YAML keeps more-indented lines literal inside a `>` block: a nested
+        # list must not be space-mashed into the surrounding paragraph.
+        meta = parse_frontmatter_block(
+            "description: >\n  Use when:\n    - alpha\n    - beta\n  tail line"
+        )
+        assert meta["description"] == "Use when:\n  - alpha\n  - beta\ntail line"
+
+    def test_block_ends_at_column_zero_key(self):
+        meta = parse_frontmatter_block(
+            "description: >\n  folded text\nalways: true"
+        )
+        assert meta["description"] == "folded text"
+        assert meta["always"] == "true"
+
+    def test_trailing_blank_lines_chomped(self):
+        meta = parse_frontmatter_block(
+            "description: >\n  text\n\nalways: true"
+        )
+        assert meta["description"] == "text"
+        assert meta["always"] == "true"
+
+    def test_crlf_input_normalized(self):
+        # Provider-fetched content (the Discover path) is not read through
+        # Path.read_text, so it can carry CRLF; no \r may leak into values.
+        meta = parse_frontmatter_block(
+            "name: crlf\r\ndescription: >\r\n  line one\r\n  line two\r\n"
+        )
+        assert meta["description"] == "line one line two"
+        assert "\r" not in meta["description"]
+        assert meta["name"] == "crlf"
+
+    def test_tab_indented_key_is_not_a_field(self):
+        # Tabs are not legal YAML indentation; a tab-indented `key: value`
+        # line is treated as indented block content, never as a field. This
+        # deliberately aligns the Discover reader with the loader. The tab
+        # itself is content and survives (spaces-only dedent).
+        meta = parse_frontmatter_block(
+            "name: tabs\ndescription: >\n\ttab-indented body\nalways: true"
+        )
+        assert meta["description"] == "\ttab-indented body"
+        assert meta["always"] == "true"
+
+    def test_mixed_indentation_falls_back_to_lstrip(self):
+        # A body line that does not share the first line's exact whitespace
+        # prefix is lstripped rather than dropped or kept mis-indented.
+        meta = parse_frontmatter_block(
+            "description: >\n    four spaces\n  two spaces"
+        )
+        assert meta["description"] == "four spaces two spaces"
+
+    def test_consecutive_blank_lines_keep_their_count(self):
+        # YAML folded: a run of k blank lines between text lines becomes k
+        # newlines; a double blank must not collapse into one break.
+        meta = parse_frontmatter_block(
+            "description: >\n  para one\n\n\n  para two"
+        )
+        assert meta["description"] == "para one\n\npara two"
+
+    def test_blank_line_next_to_indented_line_keeps_all_newlines(self):
+        # No fold happens around a more-indented (literal) line, so a blank
+        # run adjacent to one yields k+1 newlines (matches PyYAML:
+        # 'para\n\n  indented').
+        meta = parse_frontmatter_block(
+            "description: >\n  para\n\n    indented"
+        )
+        assert meta["description"] == "para\n\n  indented"
+
+    def test_comment_after_indicator_still_folds(self):
+        # YAML allows a comment after the block header: `> # note` is a valid
+        # folded block (verified against PyYAML), so the body must fold.
+        meta = parse_frontmatter_block("description: > # note\n  folded text")
+        assert meta["description"] == "folded text"
+
+    def test_content_leading_tab_survives_dedent(self):
+        # YAML indentation is spaces-only, so a tab after the indent is
+        # CONTENT (verified against PyYAML: '|\n  \tcode' -> '\tcode').
+        meta = parse_frontmatter_block("description: |\n  \tcode line")
+        assert meta["description"] == "\tcode line"


### PR DESCRIPTION
## What broke

A skill whose frontmatter `description:` uses a YAML block scalar (`>` folded or `|` literal) stored the indicator character alone: the line parser took everything after the first `:` as the value and skipped every indented continuation line. `description` is what skill auto-routing matches on, so the skill appeared in the "Available Skills" catalog with `>` as its whole description — installed and healthy-looking, but dead to the router. The reporter measured 10 of 25 skills in one imported directory affected. Deterministic for both `>` and `|`.

## What changed

- **`src/kiro_crew/skills.py`** — new module-level `parse_frontmatter_block()` (+ `_fold_block_scalar`, `_BLOCK_SCALAR_INDICATOR`). When a column-0 key's value is exactly a block indicator (`>`, `|`, with optional chomping/indent modifiers such as `>-`, `|2`), the following more-indented lines fold into that key's value: single newlines become spaces for `>` (blank line = paragraph break, more-indented lines stay literal), newlines are preserved for `|`. An explicit indent digit (`|2`) is honored. Leading/trailing whitespace is trimmed, so `-` chomping is satisfied. CRLF is normalized per line (the Discover path reads provider bytes, not `Path.read_text`). `SkillsLoader._parse_frontmatter` delegates to the helper. **No YAML library added.**
- **`src/kiro_crew/dashboard/handlers/discover.py`** — the second reader with the identical defect now imports the shared helper (`strip_quotes=False` preserves its historical no-quote-stripping on single-line values). Provider-sourced frontmatter fields are now length-capped at 4096 before redaction, since a folded value is attacker-sizable where one physical line was not.
- **`docs/system-specs/modules/memory-skills-hooks.md`** — one sentence documenting block-scalar folding and the preserved column-0 invariant.
- **`test/test_skill_frontmatter_block_scalar.py`** — 27 new tests.

## Invariants preserved (the deliberate column-0 rule)

The old docstring's guards are kept and pinned by tests: an indented `key: value` still never becomes a top-level field (inside a block scalar it becomes part of that block's TEXT; outside one it is ignored exactly as before), and a prose line like `  Steps: do x` still invents no `Steps` key. Writer/reader agreement holds: `set_inject_on_trigger` edits raw lines at column 0, so the toggle takes effect on a skill whose description is a block scalar without corrupting it (round-trip test included). Single-line and quoted values parse byte-identically to before for BOTH readers (regression-pinned). A bare indicator with no indented body keeps the literal `>` — behavior preservation, pinned.

Behavior note: the Discover reader previously accepted a *tab*-indented `key: value` as a field (`startswith(" ")` check); it now treats it as indented, matching the loader. Tabs are not legal YAML indentation; pinned by test.

## Readers surveyed

- `SkillsLoader._parse_frontmatter` (skills.py) — **fixed** (the routing-path reader; also serves prompts.py and skill_budget.py via `_cached_frontmatter`).
- `dashboard/handlers/discover.py::_parse_frontmatter` — **fixed** (Discover preview showed `>` too).
- `onboarding_import.py::_frontmatter` — **left alone**: import-time exclusion check that only tests key *presence* (`always`, `triggers`); a block-scalar value doesn't change presence, and it is not on the routing path.
- `history.py::_frontmatter_value` — **left alone**: reads live *auto*-skill bodies during consolidation, and those are written by `_build_auto_skill_content`, which single-lines every value by construction; block scalars cannot occur on that path.
- `md_notebook parse_frontmatter` — out of scope per the issue (different subsystem).

## Verification

- Bug reproduced on unmodified main with the reporter's exact repro shape (`description` parsed as `'>'`), fails before / passes after.
- 27 new tests: folded/literal/chomping/indent-digit variants, both invariant guards, single-line + quoted regression pins, Discover reader parity, writer/reader round-trip, router-level catalog surfacing (`list_skills` + `get_context`), CRLF, tab-indent, mixed indentation, comment-after-indicator.
- Full local gates green: isort, flake8, mypy (no findings in changed files), `python -m pytest` (50028 passed; 73 failures are a pre-existing local-sandbox environment class, none skill-related).
- Pre-push review fleet: GPT 5.6 Sol (3 findings: quadratic blank-line trim on untrusted input, ignored `|2` indent digit, CRLF leakage — all fixed) and Opus 5 (PASS, 0 blocking; advisories applied: provider field cap, literal more-indented lines in `>` folds, tab-behavior documentation + pin, doc precision, extra edge tests).

Closes #3182
