### PR TITLE
fix: take auto_research campaigns DB off the event loop (#3050)

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -41,6 +41,7 @@ from kiro_crew.config.paths import data_home
 from kiro_crew.dashboard.chat_utils import (
     slot_history_key,
 )
+from kiro_crew.history import on_loop_persist_strict
 from kiro_crew.knowledge.llm_pool import LLMPool
 from kiro_crew.platform_compat import is_link_or_junction, unlink_link_or_junction
 
@@ -200,7 +201,48 @@ def _safe_campaign_dir(campaign_id: str) -> Path | None:
 # --- Database ---
 
 
+class OnLoopDBError(RuntimeError):
+    """A campaigns-DB connection was opened on the event loop under strict mode."""
+
+
+_ON_LOOP_DB_WARN_INTERVAL_S = 60.0
+_on_loop_db_warn_last = 0.0
+
+
+def _check_on_loop_db_discipline() -> None:
+    """Enforce (strict) or diagnose (production) an on-loop ``_get_db`` entry.
+
+    Called at the top of :func:`_get_db`. No running event loop means the
+    caller is already off-loop (worker thread / executor / CLI) — the common,
+    correct case — and this is a no-op.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return  # off-loop: the sanctioned path — nothing to flag
+    if on_loop_persist_strict():
+        raise OnLoopDBError(
+            "auto_research campaigns DB opened on the event loop; the 30s "
+            "busy timeout means one lock wait can stall the loop past the "
+            "watchdog budget and kill the gateway. Offload the DB section "
+            "(asyncio.to_thread / run_in_executor) like the surrounding "
+            "handlers do."
+        )
+    global _on_loop_db_warn_last
+    now = time.monotonic()
+    if now - _on_loop_db_warn_last >= _ON_LOOP_DB_WARN_INTERVAL_S:
+        _on_loop_db_warn_last = now
+        logger.warning(
+            "auto_research: _get_db() ran ON the event loop without "
+            "offloading; a contended write here blocks every task (including "
+            "the watchdog heartbeat) for up to 30s. Route it through "
+            "asyncio.to_thread / run_in_executor.",
+            stack_info=True,
+        )
+
+
 def _get_db() -> sqlite3.Connection:
+    _check_on_loop_db_discipline()
     dbp = db_path()
     dbp.parent.mkdir(parents=True, exist_ok=True)
     # Explicit 30s busy timeout (vs the 5s driver default). The research worker
@@ -837,6 +879,143 @@ def _campaign_transition_lock(campaign_id: str) -> asyncio.Lock:
     return lock
 
 
+def _guarded_txn(
+    cid: str,
+    new_status: str,
+    allowed_current: tuple[str, ...],
+    expected_started_at: float | None,
+    **kwargs: Any,
+) -> dict | None:
+    """The fence check + write of :func:`_guarded_transition`, WITHOUT the lock.
+
+    Runs off-loop. Callers must already hold the campaign's transition lock
+    (directly, or via :func:`_guarded_transition`).
+    """
+    db = _get_db()
+    try:
+        row = db.execute(
+            "SELECT status, started_at FROM campaigns WHERE id = ?", (cid,)
+        ).fetchone()
+        if row is None or row["status"] not in allowed_current:
+            return None
+        if expected_started_at is not None and row["started_at"] != expected_started_at:
+            return None  # stale generation: a replacement run took over
+    finally:
+        db.close()
+    return update_campaign_status(cid, new_status, **kwargs)
+
+
+def _sse_from_thread(loop: asyncio.AbstractEventLoop, event: dict) -> None:
+    """Deliver an SSE event from a worker thread (``_emit_sse`` is loop-affine)."""
+    loop.call_soon_threadsafe(_emit_sse, event)
+
+
+async def _guarded_transition(
+    cid: str,
+    new_status: str,
+    *,
+    allowed_current: tuple[str, ...],
+    expected_started_at: float | None = None,
+    on_commit: Any = None,
+    **kwargs: Any,
+) -> dict | None:
+    """Serialize a background status transition against user actions.
+
+    A background observer (watchdog / nudge / workflow poller) decides on a
+    transition from state it read BEFORE a thread hop, so a user Stop/Pause
+    that commits during the hop must win. This takes the same per-campaign
+    lock ``_handle_action`` holds, re-reads the current status, and writes
+    only while it is still one of ``allowed_current`` — refusing stale
+    observations instead of resurrecting or overwriting the newer state.
+
+    ``expected_started_at`` is the generation fence: ``started_at`` is minted
+    on every RUNNING transition, so a Pause→Resume that recreates RUNNING
+    yields a NEW generation and a status-only check would let the OLD run's
+    verdict (COMPLETE/STAGNANT/NEEDS_INPUT) terminate the replacement run
+    (ABA). Callers that observed a RUNNING row pass the ``started_at`` they
+    read; the write then also requires the persisted generation to match
+    (same equality contract as :func:`_campaign_run_has_status`).
+
+    Returns the update result, or ``None`` when the transition was refused.
+    The caller must NOT already hold the campaign's transition lock
+    (``asyncio.Lock`` is not reentrant) — a frame that holds it offloads
+    :func:`_guarded_txn` directly.
+
+    ``on_commit`` (optional) runs IN THE WORKER THREAD immediately after the
+    transition persists, before this coroutine resumes. Side effects that must
+    accompany a persisted transition (SSE via :func:`_sse_from_thread`, audit,
+    marker files) belong here: the awaiting frame can be CANCELLED at the
+    ``to_thread`` suspension point AFTER the commit already landed, and a
+    success-branch after ``await`` is silently skipped in that window (the
+    watchdog's shutdown cancel made a persisted COMPLETE lose its SSE).
+    """
+    async with _campaign_transition_lock(cid):
+
+        def _txn_and_notify() -> dict | None:
+            result = _guarded_txn(
+                cid, new_status, allowed_current, expected_started_at, **kwargs
+            )
+            if result and on_commit is not None:
+                on_commit(result)
+            return result
+
+        return await asyncio.to_thread(_txn_and_notify)
+
+
+async def _expire_trust(cid: str, observed_started_at: float | None) -> None:
+    """24h auto-approve expiry: park the campaign for re-authorization.
+
+    Transition FIRST, then write the synthetic question only if it persisted:
+    a refused transition (a user Stop committed during the hop) must not leave
+    a stale question file behind — it would drag a later Resume straight back
+    into NEEDS_INPUT with an expiry prompt that no longer applies.
+    ``observed_started_at`` fences the write to the run generation whose age
+    was actually measured — a Pause→Resume replacement run must not be parked
+    by the previous run's expiry verdict.
+    """
+    event_loop = asyncio.get_running_loop()
+
+    def _on_parked(_result: dict) -> None:
+        # Runs in the txn thread right after the transition persists — survives
+        # a cancellation of the awaiting watchdog frame (see _guarded_transition).
+        qpath = _questions_path(cid)
+        if qpath:
+            try:
+                # The path lives in the agent-writable research dir: clear a
+                # link/junction or directory squatting on it before writing, and
+                # never let a write failure suppress the audit/SSE for a
+                # transition that already persisted.
+                if is_link_or_junction(qpath):
+                    unlink_link_or_junction(qpath)
+                elif qpath.is_dir():
+                    shutil.rmtree(qpath)
+                qpath.write_text(
+                    json.dumps(
+                        {
+                            "question": "Auto-approval expired after 24h. Resume to "
+                            "re-authorize and continue."
+                        }
+                    )
+                )
+            except OSError:
+                logger.warning(
+                    "auto_research: could not publish the expiry prompt for %s "
+                    "(campaign is parked NEEDS_INPUT; Resume still works)",
+                    cid,
+                    exc_info=True,
+                )
+        _audit("campaign_trust_expired", cid)
+        _sse_from_thread(event_loop, {"type": "needs_input", "campaign_id": cid})
+
+    await _guarded_transition(
+        cid,
+        CampaignStatus.NEEDS_INPUT,
+        allowed_current=(CampaignStatus.RUNNING,),
+        expected_started_at=observed_started_at,
+        on_commit=_on_parked,
+    )
+
+
 def _emit_sse(event: dict) -> None:
     for q in _sse_queues:
         try:
@@ -1045,15 +1224,24 @@ async def _record_new_cycle_from_watchdog(
     last_counts: dict[str, int],
     last_ts: dict[str, float],
 ) -> dict:
-    """Record a newly observed cycle without blocking the gateway event loop."""
-    latest = await asyncio.to_thread(
-        _persist_new_cycle_bookkeeping,
-        campaign_id,
-        cycle_files,
-    )
+    """Record a newly observed cycle without blocking the gateway event loop.
+
+    The SSE fires from the worker thread right after the bookkeeping persists
+    (same cancellation contract as ``_guarded_transition``'s ``on_commit``).
+    """
+    event_loop = asyncio.get_running_loop()
+
+    def _persist_and_notify() -> dict:
+        latest = _persist_new_cycle_bookkeeping(campaign_id, cycle_files)
+        _sse_from_thread(
+            event_loop,
+            {"type": "new_finding", "campaign_id": campaign_id, "finding": latest},
+        )
+        return latest
+
+    latest = await asyncio.to_thread(_persist_and_notify)
     last_counts[campaign_id] = len(cycle_files)
     last_ts[campaign_id] = time.time()
-    _emit_sse({"type": "new_finding", "campaign_id": campaign_id, "finding": latest})
     return latest
 
 
@@ -1220,6 +1408,7 @@ async def _settle_campaign_from_watchdog(
 
 
 async def _watchdog_loop(app: web.Application | None = None) -> None:
+    event_loop = asyncio.get_running_loop()  # for _sse_from_thread in on_commit hooks
     state = app.get("state") if app is not None else None
     last_counts: dict[str, int] = {}
     last_ts: dict[str, float] = {}
@@ -1243,20 +1432,26 @@ async def _watchdog_loop(app: web.Application | None = None) -> None:
                 # re-establishes trust and re-arms the loop in the per-campaign body.
                 await _suspend_research_loops_while_disabled(state)
                 continue
-            db = _get_db()
-            active = db.execute(
-                "SELECT id, idle_secs, max_cycles, started_at, auto_approve, execution_mode "
-                "FROM campaigns WHERE status = ?",
-                (CampaignStatus.RUNNING,),
-            ).fetchall()
-            db.close()
+
+            def _read_active_campaigns() -> list[sqlite3.Row]:
+                db = _get_db()
+                try:
+                    return db.execute(
+                        "SELECT id, idle_secs, max_cycles, started_at, auto_approve, execution_mode "
+                        "FROM campaigns WHERE status = ?",
+                        (CampaignStatus.RUNNING,),
+                    ).fetchall()
+                finally:
+                    db.close()
+
+            active = await asyncio.to_thread(_read_active_campaigns)
             for row in active:
                 cid = row["id"]
                 # Workflow-mode campaigns are driven by a Dynamic Workflow run;
                 # the adapter translates its events/result into the RL file+SSE
                 # model. The agent-mode body below does not apply to them.
                 if row["execution_mode"] == "workflow":
-                    await _poll_workflow_campaign(cid, state)
+                    await _poll_workflow_campaign(cid, state, row["started_at"])
                     continue
                 slot_key = research_slot_key(cid)
                 slot = state._slots.get(slot_key) if state is not None else None
@@ -1299,19 +1494,7 @@ async def _watchdog_loop(app: web.Application | None = None) -> None:
                 if started and time.time() - started > _TRUST_TTL_SECS:
                     if slot is not None:
                         slot._trust = False
-                    qpath = _questions_path(cid)
-                    if qpath:
-                        qpath.write_text(
-                            json.dumps(
-                                {
-                                    "question": "Auto-approval expired after 24h. Resume to "
-                                    "re-authorize and continue."
-                                }
-                            )
-                        )
-                    update_campaign_status(cid, CampaignStatus.NEEDS_INPUT)
-                    _audit("campaign_trust_expired", cid)
-                    _emit_sse({"type": "needs_input", "campaign_id": cid})
+                    await _expire_trust(cid, started)
                     continue
                 # Re-establish worker trust each cycle (restart-durable; bounded above).
                 if slot is not None and not slot._trust:
@@ -1324,8 +1507,15 @@ async def _watchdog_loop(app: web.Application | None = None) -> None:
                 # Attended: pause for the user. Unattended: discard the stray
                 # question + keep running (code-enforced; see helper).
                 if _should_pause_for_question(cid, bool(row["auto_approve"])):
-                    update_campaign_status(cid, CampaignStatus.NEEDS_INPUT)
-                    _emit_sse({"type": "needs_input", "campaign_id": cid})
+                    await _guarded_transition(
+                        cid,
+                        CampaignStatus.NEEDS_INPUT,
+                        allowed_current=(CampaignStatus.RUNNING,),
+                        expected_started_at=started,
+                        on_commit=lambda _r, cid=cid: _sse_from_thread(
+                            event_loop, {"type": "needs_input", "campaign_id": cid}
+                        ),
+                    )
                     continue
                 # Lightweight: count files without reading them all. Only parse
                 # the latest finding when count advances (avoids re-reading 50+
@@ -1346,14 +1536,35 @@ async def _watchdog_loop(app: web.Application | None = None) -> None:
                     )
                     verified = latest.get("verification")
                     if isinstance(verified, dict) and verified.get("passed") is True:
-                        update_campaign_status(cid, CampaignStatus.COMPLETE)
-                        _emit_sse({"type": "complete", "campaign_id": cid})
+                        await _guarded_transition(
+                            cid,
+                            CampaignStatus.COMPLETE,
+                            allowed_current=(CampaignStatus.RUNNING,),
+                            expected_started_at=started,
+                            on_commit=lambda _r, cid=cid: _sse_from_thread(
+                                event_loop, {"type": "complete", "campaign_id": cid}
+                            ),
+                        )
                     elif count >= row["max_cycles"]:
-                        update_campaign_status(cid, CampaignStatus.COMPLETE)
-                        _emit_sse({"type": "complete", "campaign_id": cid})
+                        await _guarded_transition(
+                            cid,
+                            CampaignStatus.COMPLETE,
+                            allowed_current=(CampaignStatus.RUNNING,),
+                            expected_started_at=started,
+                            on_commit=lambda _r, cid=cid: _sse_from_thread(
+                                event_loop, {"type": "complete", "campaign_id": cid}
+                            ),
+                        )
                     elif check_stagnation(cid):
-                        update_campaign_status(cid, CampaignStatus.STAGNANT)
-                        _emit_sse({"type": "stagnant", "campaign_id": cid})
+                        await _guarded_transition(
+                            cid,
+                            CampaignStatus.STAGNANT,
+                            allowed_current=(CampaignStatus.RUNNING,),
+                            expected_started_at=started,
+                            on_commit=lambda _r, cid=cid: _sse_from_thread(
+                                event_loop, {"type": "stagnant", "campaign_id": cid}
+                            ),
+                        )
                 elif cid in last_ts:
                     if slot is not None and slot.running:
                         # Agent is actively working this cycle (deep research can
@@ -1443,16 +1654,40 @@ async def _launch_loop(request: web.Request, cid: str, *, prepared: bool = False
             "auto_research: cannot launch loop for %s (autonudge/state unavailable)", cid
         )
         return
-    db = _get_db()
-    row = db.execute(
-        "SELECT name, question, sub_questions, sources, scope_constraints, max_cycles, idle_secs, "
-        "success_criteria, auto_approve, parallel_workers, model FROM campaigns WHERE id = ?",
-        (cid,),
-    ).fetchone()
-    db.close()
+
+    def _read_launch_row_and_write_brief() -> sqlite3.Row | None:
+        """Row read + brief render in ONE write transaction.
+
+        ``BEGIN IMMEDIATE`` serializes this against ``_append_question``'s
+        transaction: a concurrent Add Question either commits before (this
+        brief includes it) or waits until after (its own in-transaction brief
+        write lands last, from the fresher row). Two separate hops here would
+        let a stale snapshot overwrite a just-committed question's brief.
+        """
+        with _brief_publish_lock(cid):
+            db = _get_db()
+            try:
+                db.execute("BEGIN IMMEDIATE")
+                row = db.execute(
+                    "SELECT name, question, sub_questions, sources, scope_constraints, max_cycles, idle_secs, "
+                    "success_criteria, auto_approve, parallel_workers, model FROM campaigns WHERE id = ?",
+                    (cid,),
+                ).fetchone()
+                if row is None:
+                    db.execute("ROLLBACK")
+                    return None
+                db.commit()
+            finally:
+                db.close()
+            # Publish AFTER commit (a rollback must never leave a brief that
+            # describes phantom state); the publish lock spans commit+write so
+            # publish order matches commit order.
+            _write_brief(cid, row)
+            return row
+
+    row = await asyncio.to_thread(_read_launch_row_and_write_brief)
     if row is None:
         return
-    _write_brief(cid, row)
     # Pin the campaign's explicit model pick on the worker slot ('' = inherit
     # the research agent's / backend's default resolution — never a hardcoded
     # id here). If a concrete pick is not served for this account, the session
@@ -1522,6 +1757,25 @@ async def _launch_loop(request: web.Request, cid: str, *, prepared: bool = False
         max_cycles=int(row["max_cycles"] or 0),
         stop_sentinel_path=str(_campaign_dir(cid) / "STOP"),
     )
+
+
+_brief_publish_locks: dict[str, threading.Lock] = {}
+_brief_publish_locks_guard = threading.Lock()
+
+
+def _brief_publish_lock(campaign_id: str) -> threading.Lock:
+    """Serialize one campaign's commit→brief-publish sequences (off-loop).
+
+    ``brief.md`` must be published only AFTER the row it renders committed
+    (a rollback must never leave a brief describing phantom state), and the
+    publish order must match the commit order (a stale snapshot must never
+    overwrite a newer brief). Holding this process-wide lock across
+    ``BEGIN IMMEDIATE`` → ``commit()`` → ``_write_brief`` gives both: the DB
+    write lock alone cannot, because it is released at commit, before the
+    file write.
+    """
+    with _brief_publish_locks_guard:
+        return _brief_publish_locks.setdefault(campaign_id, threading.Lock())
 
 
 def _write_brief(cid: str, row: Any) -> None:
@@ -1747,51 +2001,66 @@ def _activate_emergent(campaign_id: str) -> list[dict]:
     queue = _sq.load_queue(d)
     if _sq.pending_count(queue) == 0:
         return []
-    db = _get_db()
-    row = db.execute(
-        "SELECT execution_mode, max_subquestions_per_round, sub_questions, total_cycles "
-        "FROM campaigns WHERE id = ?",
-        (campaign_id,),
-    ).fetchone()
-    if row is None or row["execution_mode"] != DEFAULT_EXECUTION_MODE:
+    with _brief_publish_lock(campaign_id):
+        db = _get_db()
+        # Write lock BEFORE the read: this is a read-modify-write on sub_questions
+        # (same shape as _append_question), so two concurrent writers must
+        # serialize instead of both reading the same base list.
+        db.execute("BEGIN IMMEDIATE")
+        row = db.execute(
+            "SELECT execution_mode, max_subquestions_per_round, sub_questions, total_cycles "
+            "FROM campaigns WHERE id = ?",
+            (campaign_id,),
+        ).fetchone()
+        if row is None or row["execution_mode"] != DEFAULT_EXECUTION_MODE:
+            db.execute("ROLLBACK")
+            db.close()
+            return []
+        subs = json.loads(row["sub_questions"] or "[]")
+        initial = [
+            s for s in subs if isinstance(s, dict) and s.get("origin") in ("grill", "manual", None, "")
+        ]
+        initial_open = [s for s in initial if s.get("status") != "answered"]
+        if initial_open and int(row["total_cycles"] or 0) < len(initial):
+            db.execute("ROLLBACK")
+            db.close()
+            return []  # still working the initial questions — hold emergent ones
+        k = int(
+            row["max_subquestions_per_round"]
+            if row["max_subquestions_per_round"] is not None
+            else DEFAULT_MAX_SUBQUESTIONS_PER_ROUND
+        )
+        activated = _sq.dequeue_top_k(queue, k)
+        if not activated:
+            db.execute("ROLLBACK")
+            db.close()
+            return []
+        for a in activated:
+            subs.append({"text": a["text"], "origin": "emergent", "status": "open"})
+        db.execute(
+            "UPDATE campaigns SET sub_questions = ? WHERE id = ?",
+            (json.dumps(subs), campaign_id),
+        )
+        # Re-read inside the transaction; publish AFTER commit under the publish
+        # lock (mirrors _append_question / the launch path): the brief on disk
+        # always reflects a COMMITTED row, publish order matches commit order, and
+        # a rollback can never leave a brief describing phantom state.
+        full = db.execute(
+            "SELECT question, sub_questions, sources, scope_constraints, max_cycles, "
+            "idle_secs, success_criteria, auto_approve, parallel_workers "
+            "FROM campaigns WHERE id = ?",
+            (campaign_id,),
+        ).fetchone()
+        db.commit()
         db.close()
-        return []
-    subs = json.loads(row["sub_questions"] or "[]")
-    initial = [
-        s for s in subs if isinstance(s, dict) and s.get("origin") in ("grill", "manual", None, "")
-    ]
-    initial_open = [s for s in initial if s.get("status") != "answered"]
-    if initial_open and int(row["total_cycles"] or 0) < len(initial):
-        db.close()
-        return []  # still working the initial questions — hold emergent ones
-    k = int(
-        row["max_subquestions_per_round"]
-        if row["max_subquestions_per_round"] is not None
-        else DEFAULT_MAX_SUBQUESTIONS_PER_ROUND
-    )
-    activated = _sq.dequeue_top_k(queue, k)
-    if not activated:
-        db.close()
-        return []
-    for a in activated:
-        subs.append({"text": a["text"], "origin": "emergent", "status": "open"})
-    db.execute("BEGIN")
-    db.execute(
-        "UPDATE campaigns SET sub_questions = ? WHERE id = ?",
-        (json.dumps(subs), campaign_id),
-    )
-    db.commit()
-    _sq.mark_analyzed(queue, activated)  # dedup ledger: never re-admit/re-activate
-    _sq.save_queue(d, queue)
-    full = db.execute(
-        "SELECT question, sub_questions, sources, scope_constraints, max_cycles, "
-        "idle_secs, success_criteria, auto_approve, parallel_workers "
-        "FROM campaigns WHERE id = ?",
-        (campaign_id,),
-    ).fetchone()
-    db.close()
-    if full is not None:
-        _write_brief(campaign_id, full)  # surface the new emergent items next cycle
+        # Ledger BEFORE the brief publish (both inside the publish lock): the
+        # dedup ledger must record the activation even if the brief write then
+        # fails — otherwise the items stay pending and are re-activated
+        # (duplicated) on the next cycle.
+        _sq.mark_analyzed(queue, activated)  # dedup ledger: never re-admit/re-activate
+        _sq.save_queue(d, queue)
+        if full is not None:
+            _write_brief(campaign_id, full)  # surface the new emergent items next cycle
     _audit("campaign_emergent_activated", campaign_id)
     return activated
 
@@ -1936,16 +2205,23 @@ async def _launch_workflow(request: web.Request, cid: str) -> None:
         logger.warning(
             "auto_research: workflow_service unavailable; cannot launch workflow for %s", cid
         )
-        update_campaign_status(
+        await asyncio.to_thread(
+            update_campaign_status,
             cid,
             CampaignStatus.FAILED,
             error_message="Dynamic Workflow engine unavailable — cannot start workflow mode.",
         )
         _emit_sse({"type": "failed", "campaign_id": cid})
         return
-    db = _get_db()
-    row = db.execute("SELECT * FROM campaigns WHERE id = ?", (cid,)).fetchone()
-    db.close()
+
+    def _read_workflow_row() -> sqlite3.Row | None:
+        db = _get_db()
+        try:
+            return db.execute("SELECT * FROM campaigns WHERE id = ?", (cid,)).fetchone()
+        finally:
+            db.close()
+
+    row = await asyncio.to_thread(_read_workflow_row)
     if row is None:
         return
     args = build_workflow_args(dict(row))
@@ -1953,7 +2229,8 @@ async def _launch_workflow(request: web.Request, cid: str) -> None:
         res = await svc.start(RESEARCH_WORKFLOW_SOURCE, name=research_slot_key(cid), args=args)
     except Exception:
         logger.exception("auto_research: workflow start failed for %s", cid)
-        update_campaign_status(
+        await asyncio.to_thread(
+            update_campaign_status,
             cid,
             CampaignStatus.FAILED,
             error_message="Workflow start failed — see gateway logs for details.",
@@ -1966,8 +2243,11 @@ async def _launch_workflow(request: web.Request, cid: str) -> None:
         _audit("campaign_workflow_started", cid)
     else:
         logger.warning("auto_research: workflow start returned no run_id for %s: %s", cid, res)
-        update_campaign_status(
-            cid, CampaignStatus.FAILED, error_message="Workflow start returned no run ID."
+        await asyncio.to_thread(
+            update_campaign_status,
+            cid,
+            CampaignStatus.FAILED,
+            error_message="Workflow start returned no run ID.",
         )
         _emit_sse({"type": "failed", "campaign_id": cid})
 
@@ -1984,14 +2264,18 @@ async def _stop_workflow(request: web.Request, cid: str) -> None:
             logger.exception("auto_research: workflow cancel failed for %s", cid)
 
 
-async def _poll_workflow_campaign(campaign_id: str, state: Any) -> None:
+async def _poll_workflow_campaign(
+    campaign_id: str, state: Any, observed_started_at: float | None
+) -> None:
     """Adapter: translate a Dynamic Workflow run's events/result into the RL
     file + SSE model the existing UI consumes. Each `investigate:` agent that
     finishes becomes a cycle finding; on terminal the run's report is written to
     FINDINGS.md and the campaign is marked COMPLETE/FAILED. Best-effort — never
-    raises into the watchdog.
+    raises into the watchdog. ``observed_started_at`` fences every terminal
+    write to the run generation this poll actually observed.
     """
     try:
+        event_loop = asyncio.get_running_loop()
 
         def _redact_llm(s: Any) -> str:
             text = str(s or "")
@@ -2023,89 +2307,142 @@ async def _poll_workflow_campaign(campaign_id: str, state: Any) -> None:
                     run_meta = json.loads(run_file.read_text())
                     started_ts = float(run_meta.get("ts", 0))
                     if started_ts and (time.time() - started_ts) > 3600:
-                        update_campaign_status(
+                        await _guarded_transition(
                             campaign_id,
                             CampaignStatus.FAILED,
+                            allowed_current=(CampaignStatus.RUNNING,),
+                            expected_started_at=observed_started_at,
+                            on_commit=lambda _r: _sse_from_thread(
+                                event_loop,
+                                {"type": "failed", "campaign_id": campaign_id},
+                            ),
                             error_message="Workflow run snapshot lost after 1h — run likely evicted or crashed.",
                         )
-                        _emit_sse({"type": "failed", "campaign_id": campaign_id})
                 except (json.JSONDecodeError, OSError, ValueError, TypeError):
                     pass
             return
-        d = _campaign_dir(campaign_id)
-        events = snap.get("events") or []
-        # Correlate agent_started (carries label/phase) -> agent_finished by id.
-        started: dict = {}
-        for e in events:
-            if e.get("type") == "agent_started":
-                data = e.get("data") or {}
-                started[data.get("agent_id")] = data
-        investigate: list = []
-        for e in events:
-            if e.get("type") == "agent_finished":
-                data = e.get("data") or {}
-                meta = started.get(data.get("agent_id"), {})
-                if str(meta.get("label", "")).startswith("investigate") and data.get("ok"):
-                    investigate.append((meta, data))
-        cycle_offset = _read_workflow_cycle_offset(campaign_id)
-        wrote = False
-        # Each investigation maps to one cycle file (intentional: the UI shows
-        # per-investigation progress, and total_cycles is a UI counter, not the
-        # DW round count. The DW script's max_rounds caps exploration rounds;
-        # per_round is already bounded by parallel_workers to limit fan-out).
-        for i in range(len(investigate)):
-            cycle_no = cycle_offset + i + 1
-            fpath = d.joinpath("findings", "cycle_%03d.json" % cycle_no)
-            if fpath.exists():
-                continue  # already written by an earlier poll (idempotent)
-            meta, fin = investigate[i]
-            label = str(meta.get("label", ""))
-            insight = label[len("investigate: ") :] if label.startswith("investigate: ") else label
-            finding = {
-                "cycle": cycle_no,
-                "summary": _redact_llm(fin.get("result_summary", "")),
-                "key_insight": _redact_llm(insight),
-                "sources_checked": [],
-                "sources_empty": [],
-                "new_findings_count": 1,
-                "evidence_strength": "moderate",
-            }
-            fpath.parent.mkdir(parents=True, exist_ok=True)
-            fpath.write_text(json.dumps(finding, indent=2))
-            wrote = True
-        if wrote:
-            count = len(_list_cycle_files(campaign_id))
-            db = _get_db()
-            db.execute("BEGIN")
-            db.execute("UPDATE campaigns SET total_cycles=? WHERE id=?", (count, campaign_id))
-            db.commit()
-            db.close()
-            _emit_sse(
-                {
-                    "type": "new_finding",
-                    "campaign_id": campaign_id,
-                    "finding": _read_finding_file(_list_cycle_files(campaign_id)[-1]),
+        # ALL snapshot processing runs under the campaign's transition lock:
+        # the slow snapshot read above happens outside it, so a user Pause →
+        # Resume may have replaced the run generation while we were reading.
+        # Re-verify the generation at lock entry and abort processing entirely
+        # when stale — a stale poll must not write cycle files, bookkeeping, or
+        # terminal state into the REPLACEMENT run. The lock also excludes
+        # _handle_action mid-processing, so check-then-write below is atomic
+        # with respect to user actions.
+        async with _campaign_transition_lock(campaign_id):
+            if not await asyncio.to_thread(
+                _campaign_run_is_current, campaign_id, observed_started_at
+            ):
+                return  # replacement run took over while we read the snapshot
+            d = _campaign_dir(campaign_id)
+            events = snap.get("events") or []
+            # Correlate agent_started (carries label/phase) -> agent_finished by id.
+            started: dict = {}
+            for e in events:
+                if e.get("type") == "agent_started":
+                    data = e.get("data") or {}
+                    started[data.get("agent_id")] = data
+            investigate: list = []
+            for e in events:
+                if e.get("type") == "agent_finished":
+                    data = e.get("data") or {}
+                    meta = started.get(data.get("agent_id"), {})
+                    if str(meta.get("label", "")).startswith("investigate") and data.get("ok"):
+                        investigate.append((meta, data))
+            cycle_offset = _read_workflow_cycle_offset(campaign_id)
+            wrote = False
+            # Each investigation maps to one cycle file (intentional: the UI shows
+            # per-investigation progress, and total_cycles is a UI counter, not the
+            # DW round count. The DW script's max_rounds caps exploration rounds;
+            # per_round is already bounded by parallel_workers to limit fan-out).
+            for i in range(len(investigate)):
+                cycle_no = cycle_offset + i + 1
+                fpath = d.joinpath("findings", "cycle_%03d.json" % cycle_no)
+                if fpath.exists():
+                    continue  # already written by an earlier poll (idempotent)
+                meta, fin = investigate[i]
+                label = str(meta.get("label", ""))
+                insight = label[len("investigate: ") :] if label.startswith("investigate: ") else label
+                finding = {
+                    "cycle": cycle_no,
+                    "summary": _redact_llm(fin.get("result_summary", "")),
+                    "key_insight": _redact_llm(insight),
+                    "sources_checked": [],
+                    "sources_empty": [],
+                    "new_findings_count": 1,
+                    "evidence_strength": "moderate",
                 }
-            )
-        status = snap.get("status")
-        if status == "finished":
-            result = snap.get("result") if isinstance(snap.get("result"), dict) else {}
-            report = str((result or {}).get("report") or "")
-            if not report:
-                fs = (result or {}).get("findings") or []
-                report = "\n\n".join(str(x) for x in fs) if isinstance(fs, list) else ""
-            d.joinpath("FINDINGS.md").write_text(_redact_llm(report) or "(no findings gathered)")
-            update_campaign_status(campaign_id, CampaignStatus.COMPLETE)
-            _emit_sse({"type": "complete", "campaign_id": campaign_id})
-        elif status in ("failed", "cancelled"):
-            update_campaign_status(
-                campaign_id,
-                CampaignStatus.FAILED,
-                error_message=_redact_llm(
-                    snap.get("error") or "workflow run ended without completing"
-                ),
-            )
-            _emit_sse({"type": "failed", "campaign_id": campaign_id})
+                fpath.parent.mkdir(parents=True, exist_ok=True)
+                fpath.write_text(json.dumps(finding, indent=2))
+                wrote = True
+            if wrote:
+                count = len(_list_cycle_files(campaign_id))
+
+                def _persist_cycle_count() -> None:
+                    db = _get_db()
+                    try:
+                        db.execute("BEGIN")
+                        # Predicated on the observed generation: even a poll that
+                        # somehow raced past the entry check cannot write counts
+                        # into a replacement run's row.
+                        db.execute(
+                            "UPDATE campaigns SET total_cycles=? "
+                            "WHERE id=? AND started_at IS ?",
+                            (count, campaign_id, observed_started_at),
+                        )
+                        db.commit()
+                    finally:
+                        db.close()
+
+                await asyncio.to_thread(_persist_cycle_count)
+                _emit_sse(
+                    {
+                        "type": "new_finding",
+                        "campaign_id": campaign_id,
+                        "finding": _read_finding_file(_list_cycle_files(campaign_id)[-1]),
+                    }
+                )
+            status = snap.get("status")
+            if status == "finished":
+                result = snap.get("result") if isinstance(snap.get("result"), dict) else {}
+                report = str((result or {}).get("report") or "")
+                if not report:
+                    fs = (result or {}).get("findings") or []
+                    report = "\n\n".join(str(x) for x in fs) if isinstance(fs, list) else ""
+                d.joinpath("FINDINGS.md").write_text(_redact_llm(report) or "(no findings gathered)")
+
+                def _complete_and_notify() -> dict | None:
+                    r = _guarded_txn(
+                        campaign_id,
+                        CampaignStatus.COMPLETE,
+                        (CampaignStatus.RUNNING,),
+                        observed_started_at,
+                    )
+                    if r:
+                        _sse_from_thread(
+                            event_loop, {"type": "complete", "campaign_id": campaign_id}
+                        )
+                    return r
+
+                await asyncio.to_thread(_complete_and_notify)
+            elif status in ("failed", "cancelled"):
+                def _fail_and_notify() -> dict | None:
+                    r = _guarded_txn(
+                        campaign_id,
+                        CampaignStatus.FAILED,
+                        (CampaignStatus.RUNNING,),
+                        observed_started_at,
+                        error_message=_redact_llm(
+                            snap.get("error") or "workflow run ended without completing"
+                        ),
+                    )
+                    if r:
+                        _sse_from_thread(
+                            event_loop, {"type": "failed", "campaign_id": campaign_id}
+                        )
+                    return r
+
+                await asyncio.to_thread(_fail_and_notify)
     except Exception:
         logger.exception("auto_research: workflow poll failed for %s", campaign_id)
 
@@ -2390,12 +2727,18 @@ async def _handle_action(request: web.Request) -> web.Response:
 
     # Fork: creates a new child campaign from a completed parent.
     if action == "fork":
-        db = _get_db()
-        parent = db.execute(
-            "SELECT id, question, sources, status, model FROM campaigns WHERE id = ?",
-            (cid,),
-        ).fetchone()
-        db.close()
+
+        def _read_fork_parent() -> sqlite3.Row | None:
+            db = _get_db()
+            try:
+                return db.execute(
+                    "SELECT id, question, sources, status, model FROM campaigns WHERE id = ?",
+                    (cid,),
+                ).fetchone()
+            finally:
+                db.close()
+
+        parent = await asyncio.to_thread(_read_fork_parent)
         if parent is None:
             return web.json_response({"error": "Not found"}, status=404)
         if parent["status"] not in (CampaignStatus.COMPLETE, CampaignStatus.STOPPED):
@@ -2458,22 +2801,28 @@ async def _handle_action(request: web.Request) -> web.Response:
         },
     }
     async with _campaign_transition_lock(cid):
-        db = _get_db()
-        srow = db.execute("SELECT status FROM campaigns WHERE id = ?", (cid,)).fetchone()
-        db.close()
+
+        def _read_status_row() -> sqlite3.Row | None:
+            db = _get_db()
+            try:
+                return db.execute("SELECT status FROM campaigns WHERE id = ?", (cid,)).fetchone()
+            finally:
+                db.close()
+
+        srow = await asyncio.to_thread(_read_status_row)
         if srow is None:
             return web.json_response({"error": "Not found"}, status=404)
         if srow["status"] not in allowed[action]:
             return web.json_response(
                 {"error": f"Cannot {action} a campaign in '{srow['status']}' state"}, status=409
             )
-        mode = _campaign_execution_mode(cid)
+        mode = await asyncio.to_thread(_campaign_execution_mode, cid)
         if action in ("start", "resume") and mode != "workflow":
             # Publish RUNNING only after old stop evidence is gone. The watchdog
             # selects RUNNING campaigns, so reversing this order exposes a partial
             # resume while marker cleanup or tombstone persistence is still pending.
             await _prepare_loop_launch(cid)
-        result = update_campaign_status(cid, status_map[action])
+        result = await asyncio.to_thread(update_campaign_status, cid, status_map[action])
         if "error" in result:
             return web.json_response(result, status=404)
         if action in ("start", "resume"):
@@ -2502,12 +2851,12 @@ async def _handle_delete(request: web.Request) -> web.Response:
         return web.json_response({"error": "Invalid campaign ID"}, status=400)
     async with _campaign_transition_lock(cid):
         # Tear down any running worker (agent loop or workflow run) first.
-        mode = _campaign_execution_mode(cid)
+        mode = await asyncio.to_thread(_campaign_execution_mode, cid)
         if mode == "workflow":
             await _stop_workflow(request, cid)
         else:
             await _stop_loop(cid, remove=True)
-        result = delete_campaign(cid)
+        result = await asyncio.to_thread(delete_campaign, cid)
         if "error" in result:
             return web.json_response(result, status=404)
         _audit("campaign_deleted", cid)
@@ -2522,7 +2871,7 @@ async def _handle_nudge(request: web.Request) -> web.Response:
         return web.json_response({"error": "Invalid campaign ID"}, status=400)
     # Workflow-mode campaigns are driven by a deterministic DW script; guidance
     # injected mid-run has no effect (the script doesn't read guidance.txt).
-    if _campaign_execution_mode(cid) == "workflow":
+    if await asyncio.to_thread(_campaign_execution_mode, cid) == "workflow":
         return web.json_response(
             {
                 "error": "Nudge/guidance not supported in workflow mode — the script "
@@ -2538,10 +2887,14 @@ async def _handle_nudge(request: web.Request) -> web.Response:
         return web.json_response({"error": "text required"}, status=400)
     write_guidance(cid, text)
     # If the agent paused awaiting input, clear the question and resume.
+    # Guarded: a Stop/Pause that committed while this handler ran must win —
+    # restoring RUNNING over it would resurrect a campaign with no worker.
     qp = _questions_path(cid)
     if qp and qp.exists():
         qp.unlink()
-        update_campaign_status(cid, CampaignStatus.RUNNING)
+        await _guarded_transition(
+            cid, CampaignStatus.RUNNING, allowed_current=(CampaignStatus.NEEDS_INPUT,)
+        )
     _audit("campaign_nudge", cid)
     return web.json_response({"ok": True})
 
@@ -2596,9 +2949,17 @@ async def _handle_report_status(request: web.Request) -> web.Response:
         return web.json_response({"error": "Invalid campaign ID"}, status=400)
     if not _HAS_ARTIFACTS:
         return web.json_response({"slug": None})
-    db = _get_db()
-    row = db.execute("SELECT report_artifact_slug FROM campaigns WHERE id = ?", (cid,)).fetchone()
-    db.close()
+
+    def _read_slug_row() -> sqlite3.Row | None:
+        db = _get_db()
+        try:
+            return db.execute(
+                "SELECT report_artifact_slug FROM campaigns WHERE id = ?", (cid,)
+            ).fetchone()
+        finally:
+            db.close()
+
+    row = await asyncio.to_thread(_read_slug_row)
     if row is None:
         return web.json_response({"error": "Not found"}, status=404)
     slug = row["report_artifact_slug"]
@@ -2636,13 +2997,19 @@ async def _handle_to_artifact(request: web.Request) -> web.Response:
     findings_path = d / "FINDINGS.md"
     if not findings_path.exists():
         return web.json_response({"error": "No findings yet"}, status=404)
-    db = _get_db()
-    row = db.execute(
-        "SELECT question, sub_questions, total_cycles, status, report_artifact_slug "
-        "FROM campaigns WHERE id = ?",
-        (cid,),
-    ).fetchone()
-    db.close()
+
+    def _read_export_row() -> sqlite3.Row | None:
+        db = _get_db()
+        try:
+            return db.execute(
+                "SELECT question, sub_questions, total_cycles, status, report_artifact_slug "
+                "FROM campaigns WHERE id = ?",
+                (cid,),
+            ).fetchone()
+        finally:
+            db.close()
+
+    row = await asyncio.to_thread(_read_export_row)
     if row is None:
         return web.json_response({"error": "Not found"}, status=404)
     question = row["question"]
@@ -2711,10 +3078,18 @@ async def _handle_to_artifact(request: web.Request) -> web.Response:
     # Persist the slug so the next export regenerates this same artifact and
     # the UI can show "View report" upfront.
     if art.slug != existing_slug:
-        db = _get_db()
-        db.execute("UPDATE campaigns SET report_artifact_slug = ? WHERE id = ?", (art.slug, cid))
-        db.commit()
-        db.close()
+
+        def _persist_slug() -> None:
+            db = _get_db()
+            try:
+                db.execute(
+                    "UPDATE campaigns SET report_artifact_slug = ? WHERE id = ?", (art.slug, cid)
+                )
+                db.commit()
+            finally:
+                db.close()
+
+        await asyncio.to_thread(_persist_slug)
     _audit("campaign_to_artifact", cid, slug=art.slug)
     return web.json_response(
         {"slug": art.slug, "name": name, "regenerated": regenerated},
@@ -2828,9 +3203,15 @@ async def _handle_to_knowledge(request: web.Request) -> web.Response:
             {"error": "Already in Knowledge Library", "id": existing["id"]}, status=409
         )
     # Add source and trigger ingestion
-    db = _get_db()
-    row = db.execute("SELECT question FROM campaigns WHERE id = ?", (cid,)).fetchone()
-    db.close()
+
+    def _read_question_row() -> sqlite3.Row | None:
+        db = _get_db()
+        try:
+            return db.execute("SELECT question FROM campaigns WHERE id = ?", (cid,)).fetchone()
+        finally:
+            db.close()
+
+    row = await asyncio.to_thread(_read_question_row)
     # The Knowledge Library is an external surface (RAG/search), so even the
     # source name metadata must be redacted before ingestion — matching the
     # treatment _handle_to_artifact applies to its artifact name.
@@ -2870,7 +3251,7 @@ async def _handle_add_question(request: web.Request) -> web.Response:
         return web.json_response({"error": "Invalid campaign ID"}, status=400)
     # Workflow-mode campaigns plan sub-questions at launch (the DW script
     # decomposes them internally); adding questions mid-run has no effect.
-    if _campaign_execution_mode(cid) == "workflow":
+    if await asyncio.to_thread(_campaign_execution_mode, cid) == "workflow":
         return web.json_response(
             {
                 "error": "Adding questions mid-run not supported in workflow mode — "
@@ -2885,32 +3266,55 @@ async def _handle_add_question(request: web.Request) -> web.Response:
     text = (body.get("text") or "").strip()
     if not text:
         return web.json_response({"error": "text required"}, status=400)
-    db = _get_db()
-    row = db.execute(
-        "SELECT sub_questions, question, sources, scope_constraints, max_cycles, "
-        "idle_secs, success_criteria, auto_approve FROM campaigns WHERE id = ?",
-        (cid,),
-    ).fetchone()
-    if row is None:
-        db.close()
+
+    def _append_question() -> list | None:
+        """Read-modify-write under one write transaction, publish after commit.
+
+        ``BEGIN IMMEDIATE`` takes the write lock BEFORE the read, so two
+        concurrent appends serialize instead of both reading the same base
+        list and one overwriting the other's question. The publish lock spans
+        commit→``_write_brief`` so the brief on disk always reflects a
+        COMMITTED row and publish order matches commit order.
+        """
+        with _brief_publish_lock(cid):
+            db = _get_db()
+            try:
+                db.execute("BEGIN IMMEDIATE")
+                row = db.execute(
+                    "SELECT sub_questions, question, sources, scope_constraints, max_cycles, "
+                    "idle_secs, success_criteria, auto_approve FROM campaigns WHERE id = ?",
+                    (cid,),
+                ).fetchone()
+                if row is None:
+                    db.execute("ROLLBACK")
+                    return None
+                subs = json.loads(row["sub_questions"] or "[]")
+                subs.append({"text": text, "origin": "manual", "status": "open"})
+                db.execute(
+                    "UPDATE campaigns SET sub_questions = ? WHERE id = ?",
+                    (json.dumps(subs), cid),
+                )
+                # Re-read the row so _write_brief sees the updated sub_questions.
+                # parallel_workers MUST be included — _write_brief defaults it to 1
+                # when absent, which would silently drop the parallel instruction
+                # from the brief.
+                fresh = db.execute(
+                    "SELECT question, sub_questions, sources, scope_constraints, max_cycles, "
+                    "idle_secs, success_criteria, auto_approve, parallel_workers "
+                    "FROM campaigns WHERE id = ?",
+                    (cid,),
+                ).fetchone()
+                db.commit()
+            finally:
+                db.close()
+            # Publish AFTER commit (rollback can never leave a phantom brief):
+            # regenerate brief.md so the agent sees the new question next cycle.
+            _write_brief(cid, fresh)
+            return subs
+
+    subs = await asyncio.to_thread(_append_question)
+    if subs is None:
         return web.json_response({"error": "Not found"}, status=404)
-    subs = json.loads(row["sub_questions"] or "[]")
-    subs.append({"text": text, "origin": "manual", "status": "open"})
-    db.execute("BEGIN")
-    db.execute("UPDATE campaigns SET sub_questions = ? WHERE id = ?", (json.dumps(subs), cid))
-    db.commit()
-    # Re-read the row so _write_brief sees the updated sub_questions.
-    # parallel_workers MUST be included — _write_brief defaults it to 1 when
-    # absent, which would silently drop the parallel instruction from the brief.
-    row = db.execute(
-        "SELECT question, sub_questions, sources, scope_constraints, max_cycles, "
-        "idle_secs, success_criteria, auto_approve, parallel_workers "
-        "FROM campaigns WHERE id = ?",
-        (cid,),
-    ).fetchone()
-    db.close()
-    # Regenerate brief.md so the agent sees the new question next cycle.
-    _write_brief(cid, row)
     _audit("campaign_add_question", cid)
     _emit_sse({"type": "question_added", "campaign_id": cid})
     return web.json_response({"ok": True, "sub_questions": subs})

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -388,6 +388,19 @@ _ON_LOOP_TRUTHY = frozenset({"1", "true", "yes", "on"})
 _ON_LOOP_FALSY = frozenset({"0", "false", "no", "off"})
 
 
+def on_loop_persist_strict() -> bool:
+    """Public alias of :func:`_on_loop_persist_strict` for other modules.
+
+    The strictness knob (``KIROCREW_STRICT_ON_LOOP_PERSIST`` /
+    ``KIROCREW_DEV_MODE``) governs the on-loop persistence discipline for every
+    store, not just this module's conversation log; consumers that enforce the
+    same offload rule on their own SQLite databases (e.g. the auto_research
+    campaigns DB) read the shared setting through this alias instead of
+    importing a private name.
+    """
+    return _on_loop_persist_strict()
+
+
 def _check_on_loop_persist_discipline(key: str) -> None:
     """Enforce (strict) or diagnose (production) an on-loop ``_locked`` entry.
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -552,6 +552,14 @@ def _isolate_kirocrew_home(_isolation_dirs, monkeypatch):
     # would leak into every later test's port resolution. Clear it per test;
     # a test that wants it sets it via monkeypatch (which still wins).
     monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+    # Match CI on a dev box for the off-loop-IO strictness knob too: a developer
+    # with KIROCREW_DEV_MODE=1 (or KIROCREW_STRICT_ON_LOOP_PERSIST=1) exported
+    # would otherwise flip history's _locked guard AND the auto_research
+    # campaigns-DB guard strict for the whole suite, failing tests that call
+    # sync helpers directly on the loop as harness convenience. Tests that
+    # exercise strict mode set the env themselves via monkeypatch (which wins).
+    monkeypatch.delenv("KIROCREW_DEV_MODE", raising=False)
+    monkeypatch.delenv("KIROCREW_STRICT_ON_LOOP_PERSIST", raising=False)
     monkeypatch.setattr("kiro_crew.config.paths._resolved_home", None)
 
 

--- a/test/test_auto_research_handlers_coverage.py
+++ b/test/test_auto_research_handlers_coverage.py
@@ -415,8 +415,8 @@ class TestPollWorkflowCampaign:
     @pytest.mark.asyncio
     async def test_absent_service_or_run_id_is_a_no_op(self, _isolate: Path, sse):
         cid = _campaign(execution_mode="workflow")
-        await h._poll_workflow_campaign(cid, None)
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock()))
+        await h._poll_workflow_campaign(cid, None, h.get_campaign(cid)["started_at"])
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock()), h.get_campaign(cid)["started_at"])
         assert sse.events == []
 
     @pytest.mark.asyncio
@@ -424,7 +424,7 @@ class TestPollWorkflowCampaign:
         cid = _campaign(execution_mode="workflow")
         _running(cid)
         h._write_workflow_run_id(cid, "run-1")
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=None)))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=None)), h.get_campaign(cid)["started_at"])
         assert _status(cid) == h.CampaignStatus.RUNNING
         assert sse.events == []
 
@@ -434,7 +434,7 @@ class TestPollWorkflowCampaign:
         _running(cid)
         run_file = h._campaign_dir(cid) / h._WORKFLOW_RUN_FILE
         run_file.write_text(json.dumps({"run_id": "run-1", "ts": time.time() - 7200}))
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=None)))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=None)), h.get_campaign(cid)["started_at"])
         assert _status(cid) == h.CampaignStatus.FAILED
         assert "snapshot lost" in (h.get_campaign(cid) or {})["error_message"]
         assert sse.types() == ["failed"]
@@ -445,7 +445,7 @@ class TestPollWorkflowCampaign:
         _running(cid)
         d = h._campaign_dir(cid)
         (d / h._WORKFLOW_RUN_FILE).write_text(json.dumps({"run_id": "r", "ts": "yesterday"}))
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=None)))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=None)), h.get_campaign(cid)["started_at"])
         assert _status(cid) == h.CampaignStatus.RUNNING
         assert sse.events == []
 
@@ -458,7 +458,7 @@ class TestPollWorkflowCampaign:
             events=_investigate_events("investigate: how is it rate limited", "plan: outline")
         )
         state = _workflow_state(result=MagicMock(return_value=snap))
-        await h._poll_workflow_campaign(cid, state)
+        await h._poll_workflow_campaign(cid, state, h.get_campaign(cid)["started_at"])
         files = h._list_cycle_files(cid)
         assert len(files) == 1  # only the investigate agent produced a cycle
         finding = json.loads(files[0].read_text())
@@ -474,7 +474,7 @@ class TestPollWorkflowCampaign:
         _running(cid)
         h._write_workflow_run_id(cid, "run-1")
         snap = _snapshot(events=_investigate_events("investigate: nope", ok=False))
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)), h.get_campaign(cid)["started_at"])
         assert h._list_cycle_files(cid) == []
         assert sse.events == []
 
@@ -485,9 +485,9 @@ class TestPollWorkflowCampaign:
         h._write_workflow_run_id(cid, "run-1")
         snap = _snapshot(events=_investigate_events("investigate: a"))
         state = _workflow_state(result=MagicMock(return_value=snap))
-        await h._poll_workflow_campaign(cid, state)
+        await h._poll_workflow_campaign(cid, state, h.get_campaign(cid)["started_at"])
         first = h._list_cycle_files(cid)[0].read_text()
-        await h._poll_workflow_campaign(cid, state)
+        await h._poll_workflow_campaign(cid, state, h.get_campaign(cid)["started_at"])
         assert len(h._list_cycle_files(cid)) == 1
         assert h._list_cycle_files(cid)[0].read_text() == first
         assert sse.types() == ["new_finding"]  # no duplicate event
@@ -500,7 +500,7 @@ class TestPollWorkflowCampaign:
         _write_finding(cid, 2)
         h._write_workflow_run_id(cid, "run-2")  # records offset 2
         snap = _snapshot(events=_investigate_events("investigate: resumed"))
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)), h.get_campaign(cid)["started_at"])
         cycles = [json.loads(p.read_text())["cycle"] for p in h._list_cycle_files(cid)]
         assert cycles == [1, 2, 3]
 
@@ -510,7 +510,7 @@ class TestPollWorkflowCampaign:
         _running(cid)
         h._write_workflow_run_id(cid, "run-1")
         snap = _snapshot(events=_investigate_events("investigate-no-colon"))
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)), h.get_campaign(cid)["started_at"])
         finding = json.loads(h._list_cycle_files(cid)[0].read_text())
         assert finding["key_insight"] == "investigate-no-colon"
 
@@ -520,7 +520,7 @@ class TestPollWorkflowCampaign:
         _running(cid)
         h._write_workflow_run_id(cid, "run-1")
         snap = _snapshot(status="finished", result={"report": "# Report\nAll done."})
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)), h.get_campaign(cid)["started_at"])
         assert (h._campaign_dir(cid) / "FINDINGS.md").read_text() == "# Report\nAll done."
         assert _status(cid) == h.CampaignStatus.COMPLETE
         assert sse.types() == ["complete"]
@@ -531,7 +531,7 @@ class TestPollWorkflowCampaign:
         _running(cid)
         h._write_workflow_run_id(cid, "run-1")
         snap = _snapshot(status="finished", result={"findings": ["one", "two"]})
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)), h.get_campaign(cid)["started_at"])
         assert (h._campaign_dir(cid) / "FINDINGS.md").read_text() == "one\n\ntwo"
 
     @pytest.mark.asyncio
@@ -540,7 +540,7 @@ class TestPollWorkflowCampaign:
         _running(cid)
         h._write_workflow_run_id(cid, "run-1")
         snap = _snapshot(status="finished", result="not-a-dict")
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)), h.get_campaign(cid)["started_at"])
         assert (h._campaign_dir(cid) / "FINDINGS.md").read_text() == "(no findings gathered)"
         assert _status(cid) == h.CampaignStatus.COMPLETE
 
@@ -551,7 +551,7 @@ class TestPollWorkflowCampaign:
         _running(cid)
         h._write_workflow_run_id(cid, "run-1")
         snap = _snapshot(status=status, error="engine exploded")
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)), h.get_campaign(cid)["started_at"])
         assert _status(cid) == h.CampaignStatus.FAILED
         assert (h.get_campaign(cid) or {})["error_message"] == "engine exploded"
         assert sse.types() == ["failed"]
@@ -564,7 +564,7 @@ class TestPollWorkflowCampaign:
         _running(cid)
         h._write_workflow_run_id(cid, "run-1")
         snap = _snapshot(status="failed")
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)), h.get_campaign(cid)["started_at"])
         assert "without completing" in (h.get_campaign(cid) or {})["error_message"]
 
     @pytest.mark.asyncio
@@ -577,7 +577,7 @@ class TestPollWorkflowCampaign:
         _running(cid)
         h._write_workflow_run_id(cid, "run-1")
         snap = _snapshot(status="finished", result={"report": "token=hunter2"})
-        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=MagicMock(return_value=snap)), h.get_campaign(cid)["started_at"])
         written = (h._campaign_dir(cid) / "FINDINGS.md").read_text()
         assert "hunter2" not in written
         assert written == "[REDACTED]"
@@ -588,7 +588,7 @@ class TestPollWorkflowCampaign:
         _running(cid)
         h._write_workflow_run_id(cid, "run-1")
         boom = MagicMock(side_effect=RuntimeError("snapshot store on fire"))
-        await h._poll_workflow_campaign(cid, _workflow_state(result=boom))
+        await h._poll_workflow_campaign(cid, _workflow_state(result=boom), h.get_campaign(cid)["started_at"])
         assert _status(cid) == h.CampaignStatus.RUNNING
 
 

--- a/test/test_auto_research_onloop_db.py
+++ b/test/test_auto_research_onloop_db.py
@@ -1,0 +1,668 @@
+"""Off-loop DB discipline for the auto_research campaigns DB.
+
+Every connection from ``_get_db()`` carries a 30s busy timeout, and the
+watchdog writes the campaigns table every cycle while HTTP handlers read and
+write the same rows — so a single ``_get_db()`` entered directly on the
+asyncio event loop can freeze the whole gateway past the loop-stall watchdog
+budget (25s) and hard-exit the process. These tests pin the discipline from
+three directions:
+
+1. the runtime chokepoint guard in ``_get_db()`` (strict raise / production
+   warn / off-loop no-op),
+2. a static AST ratchet: no ``async def`` in handlers.py calls a DB-touching
+   function directly (the offload pattern is ``asyncio.to_thread`` /
+   ``run_in_executor``, optionally via a nested sync helper),
+3. an end-to-end contention proof: a held write lock on the campaigns DB
+   stalls the affected handler, not the event loop's heartbeat.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import sqlite3
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.apps.builtins.auto_research import handlers as h
+from kiro_crew.apps.builtins.auto_research.handlers import (
+    CampaignStatus,
+    OnLoopDBError,
+    _get_db,
+    create_campaign,
+    get_campaign,
+    register_routes,
+    update_campaign_status,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path):
+    """Isolate DB and research dir per test (same shape as test_auto_research)."""
+    with (
+        patch(
+            "kiro_crew.apps.builtins.auto_research.handlers.DB_PATH",
+            tmp_path / "test.db",
+        ),
+        patch(
+            "kiro_crew.apps.builtins.auto_research.handlers.RESEARCH_DIR",
+            tmp_path / "research",
+        ),
+    ):
+        yield tmp_path
+
+
+class TestOnLoopGuard:
+    """The runtime chokepoint: ``_get_db()`` flags on-loop entry."""
+
+    @pytest.mark.asyncio
+    async def test_on_loop_get_db_raises_under_strict(self, monkeypatch):
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "1")
+        with pytest.raises(OnLoopDBError):
+            _get_db()
+
+    def test_off_loop_get_db_allowed_under_strict(self, monkeypatch):
+        """No running loop (worker thread / executor / CLI) is the sanctioned
+        path — strict mode must not flag it."""
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "1")
+        conn = _get_db()
+        try:
+            assert conn.execute("SELECT 1").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+    @pytest.mark.asyncio
+    async def test_on_loop_get_db_warns_in_production_mode(self, monkeypatch, caplog):
+        """Strict off (production): the on-loop entry proceeds but logs loudly,
+        so a mis-wired call-site is never silent."""
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "0")
+        monkeypatch.setattr(h, "_on_loop_db_warn_last", 0.0)  # reset throttle window
+        with caplog.at_level("WARNING", logger=h.logger.name):
+            conn = _get_db()
+            conn.close()
+        assert any("event loop" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_on_loop_warning_is_throttled(self, monkeypatch, caplog):
+        monkeypatch.setenv("KIROCREW_STRICT_ON_LOOP_PERSIST", "0")
+        monkeypatch.setattr(h, "_on_loop_db_warn_last", 0.0)
+        with caplog.at_level("WARNING", logger=h.logger.name):
+            for _ in range(3):
+                conn = _get_db()
+                conn.close()
+        assert sum("event loop" in r.message for r in caplog.records) == 1
+
+    def test_get_db_enters_the_guard(self):
+        """Mutation guard: removing the discipline check from ``_get_db``
+        silently disarms every other protection here — pin the call."""
+        tree = ast.parse(inspect.getsource(h._get_db))
+        fn = tree.body[0]
+        calls = [
+            n.func.id
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        ]
+        assert "_check_on_loop_db_discipline" in calls
+
+
+# Functions that open (or transitively open) the campaigns DB. A direct call
+# to any of these inside an ``async def`` in handlers.py runs the 30s busy
+# timeout on the event loop. Kept honest by test_db_touching_set_is_current
+# below, which recomputes the closure from the AST.
+_DB_TOUCHING_FNS = frozenset(
+    {
+        "_get_db",
+        "_guarded_txn",
+        "update_campaign_status",
+        "delete_campaign",
+        "create_campaign",
+        "get_campaign",
+        "list_campaigns",
+        "validate_campaign",
+        "_campaign_execution_mode",
+        "_campaign_run_has_status",
+        "_campaign_run_is_current",
+        "_persist_new_cycle_bookkeeping",
+        "_should_finalize",
+        "_ingest_emergent_questions",
+        "_activate_emergent",
+        "_advance_exploration",
+    }
+)
+
+
+def _module_tree() -> ast.Module:
+    src = Path(inspect.getsourcefile(h)).read_text(encoding="utf-8")
+    return ast.parse(src)
+
+
+class TestStaticRatchet:
+    def test_db_touching_set_is_current(self):
+        """Drift guard: ``_DB_TOUCHING_FNS`` must equal the transitive closure
+        of top-level sync functions that reach ``_get_db``. A new sync DB
+        helper added to handlers.py without extending the set would make the
+        main ratchet below scan with a blind spot — fail loudly instead."""
+        tree = _module_tree()
+        calls: dict[str, set[str]] = {}
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef):
+                calls[node.name] = {
+                    n.func.id
+                    for n in ast.walk(node)
+                    if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+                }
+        touching = {"_get_db"}
+        changed = True
+        while changed:
+            changed = False
+            for name, called in calls.items():
+                if name not in touching and called & touching:
+                    touching.add(name)
+                    changed = True
+        assert touching == set(_DB_TOUCHING_FNS), (
+            "sync DB-helper closure drifted from _DB_TOUCHING_FNS — update the "
+            f"set. computed-only: {sorted(touching - set(_DB_TOUCHING_FNS))}, "
+            f"set-only: {sorted(set(_DB_TOUCHING_FNS) - touching)}"
+        )
+
+    def test_no_async_def_calls_db_functions_directly(self):
+        """AST ratchet: every DB touch from async code must be offloaded.
+
+        Enforced shape: inside an ``async def``, a DB-touching function may
+        only appear as an ARGUMENT to ``asyncio.to_thread`` /
+        ``run_in_executor`` — never called directly. A nested sync ``def``
+        whose body touches the DB is the other offload pattern; it must
+        itself be passed to ``to_thread``/``run_in_executor`` in the
+        enclosing async def, and a direct in-line call to it (``row =
+        _read_row()``) is flagged, since that re-runs the 30s busy wait on
+        the loop while staying invisible to a name-based scan.
+        """
+        tree = _module_tree()
+        violations: list[str] = []
+
+        def _body_touches_db(fn: ast.FunctionDef) -> bool:
+            for n in ast.walk(fn):
+                if (
+                    isinstance(n, ast.Call)
+                    and isinstance(n.func, ast.Name)
+                    and n.func.id in _DB_TOUCHING_FNS
+                ):
+                    return True
+            return False
+
+        def _is_offload_call(n: ast.Call) -> bool:
+            return isinstance(n.func, ast.Attribute) and n.func.attr in (
+                "to_thread",
+                "run_in_executor",
+            )
+
+        def scan(node: ast.AsyncFunctionDef) -> None:
+            db_closures = {
+                child.name
+                for child in ast.walk(node)
+                if isinstance(child, ast.FunctionDef) and _body_touches_db(child)
+            }
+            offloaded: set[str] = set()
+            flagged = _DB_TOUCHING_FNS | db_closures
+            stack = list(ast.iter_child_nodes(node))
+            while stack:
+                n = stack.pop()
+                if isinstance(n, ast.FunctionDef):
+                    continue  # nested sync helper body runs off-loop when offloaded
+                if isinstance(n, ast.Call):
+                    if _is_offload_call(n):
+                        offloaded.update(
+                            a.id for a in n.args if isinstance(a, ast.Name) and a.id in flagged
+                        )
+                    elif isinstance(n.func, ast.Name) and n.func.id in flagged:
+                        violations.append(f"{node.name}:{n.lineno} calls {n.func.id}() on the loop")
+                stack.extend(ast.iter_child_nodes(n))
+            for name in sorted(db_closures - offloaded):
+                violations.append(
+                    f"{node.name}: nested DB helper {name}() is defined but never "
+                    "passed to asyncio.to_thread / run_in_executor"
+                )
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef):
+                scan(node)
+        assert not violations, (
+            "direct campaigns-DB call(s) on the event loop (offload via "
+            "asyncio.to_thread / run_in_executor):\n" + "\n".join(violations)
+        )
+
+
+class TestContention:
+    @pytest.fixture
+    def app(self, tmp_path: Path):
+        @web.middleware
+        async def _inject_user(request, handler):
+            request["user"] = "test-user"
+            return await handler(request)
+
+        a = web.Application(middlewares=[_inject_user])
+        register_routes(a)
+        return a
+
+    @pytest.mark.asyncio
+    async def test_held_write_lock_stalls_handler_not_heartbeat(self, app, tmp_path: Path):
+        """A write lock held on the campaigns DB must stall only the request
+        that needs the lock — never the event loop. This is the production
+        failure shape: the watchdog writes every cycle, a user clicks Pause
+        mid-write, and before the fix the handler's 30s busy wait ran ON the
+        loop, silencing the gateway heartbeat past the watchdog kill budget.
+        """
+        async with TestClient(TestServer(app)) as c:
+            cr = await c.post(
+                "/api/apps/auto-research/campaigns",
+                json={"question": "How do teams handle rate limiting?", "sources": ["web"]},
+            )
+            assert cr.status == 201
+            cid = (await cr.json())["id"]
+            # Pause is only legal from RUNNING.
+            await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+
+            # Hold the campaigns-DB write lock like a mid-write watchdog cycle.
+            blocker = sqlite3.connect(str(tmp_path / "test.db"))
+            blocker.execute("BEGIN IMMEDIATE")
+
+            ticks = 0
+
+            async def heartbeat() -> None:
+                nonlocal ticks
+                while True:
+                    ticks += 1
+                    await asyncio.sleep(0.02)
+
+            hb = asyncio.create_task(heartbeat())
+            req = asyncio.create_task(
+                c.patch(f"/api/apps/auto-research/campaigns/{cid}", json={"action": "pause"})
+            )
+            try:
+                await asyncio.sleep(0.6)
+                # The handler is genuinely blocked on the contended write...
+                assert not req.done(), "handler finished despite a held write lock"
+                # ...while the event loop stayed live (~30 ticks expected; >=5
+                # is a generous slow-CI floor — an on-loop 30s busy wait yields
+                # 0-1 because this sleep itself cannot run either).
+                assert ticks >= 5, f"event loop starved during contended DB write (ticks={ticks})"
+            finally:
+                blocker.rollback()
+                blocker.close()
+                hb.cancel()
+            resp = await req
+            assert resp.status == 200
+            assert (await resp.json())["status"] == CampaignStatus.PAUSED
+
+
+class TestAddQuestionAtomicity:
+    """The one read-modify-write among the offloaded sites: concurrent appends
+    must serialize (write lock before read), never lose a question."""
+
+    @pytest.fixture
+    def app(self, tmp_path: Path):
+        @web.middleware
+        async def _inject_user(request, handler):
+            request["user"] = "test-user"
+            return await handler(request)
+
+        a = web.Application(middlewares=[_inject_user])
+        register_routes(a)
+        return a
+
+    @pytest.mark.asyncio
+    async def test_concurrent_add_question_loses_nothing(self, app):
+        async with TestClient(TestServer(app)) as c:
+            cr = await c.post(
+                "/api/apps/auto-research/campaigns",
+                json={"question": "What drives adoption of edge computing?", "sources": ["web"]},
+            )
+            assert cr.status == 201
+            cid = (await cr.json())["id"]
+            n = 8
+            resps = await asyncio.gather(
+                *(
+                    c.post(
+                        f"/api/apps/auto-research/campaigns/{cid}/questions",
+                        json={"text": f"q-{i}"},
+                    )
+                    for i in range(n)
+                )
+            )
+            assert all(r.status == 200 for r in resps)
+
+            def _read_subs() -> list:
+                import json as _json
+
+                db = _get_db()
+                try:
+                    row = db.execute(
+                        "SELECT sub_questions FROM campaigns WHERE id = ?", (cid,)
+                    ).fetchone()
+                    return _json.loads(row["sub_questions"] or "[]")
+                finally:
+                    db.close()
+
+            subs = await asyncio.to_thread(_read_subs)
+            manual = {s["text"] for s in subs if s.get("origin") == "manual"}
+            assert manual == {f"q-{i}" for i in range(n)}, (
+                f"lost questions under concurrency: {sorted(manual)}"
+            )
+
+
+class TestGuardedTransition:
+    """Background transitions must not overwrite a user action that committed
+    during the thread hop (Stop wins over a stale watchdog/nudge observation)."""
+
+    @pytest.mark.asyncio
+    async def test_stale_observation_is_refused(self):
+        cid = create_campaign({"question": "Does edge caching reduce latency?", "sources": ["web"]})["id"]
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+        # User Stop commits between the observer's read and its write.
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.STOPPED)
+        result = await h._guarded_transition(
+            cid, CampaignStatus.NEEDS_INPUT, allowed_current=(CampaignStatus.RUNNING,)
+        )
+        assert result is None, "stale transition must be refused"
+        row = await asyncio.to_thread(get_campaign, cid)
+        assert row["status"] == CampaignStatus.STOPPED
+
+    @pytest.mark.asyncio
+    async def test_current_observation_proceeds(self):
+        cid = create_campaign({"question": "Does edge caching reduce latency?", "sources": ["web"]})["id"]
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+        result = await h._guarded_transition(
+            cid, CampaignStatus.NEEDS_INPUT, allowed_current=(CampaignStatus.RUNNING,)
+        )
+        assert result is not None and result["status"] == CampaignStatus.NEEDS_INPUT
+
+    @pytest.mark.asyncio
+    async def test_nudge_does_not_resurrect_a_stopped_campaign(self, monkeypatch):
+        """GPT scenario end-to-end: Stop committed, then a nudge whose question
+        file still exists tries to restore RUNNING — the campaign stays STOPPED
+        (a RUNNING row with no worker would be a zombie the watchdog re-adopts)."""
+        cid = create_campaign({"question": "Does edge caching reduce latency?", "sources": ["web"]})["id"]
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.STOPPED)
+        result = await h._guarded_transition(
+            cid, CampaignStatus.RUNNING, allowed_current=(CampaignStatus.NEEDS_INPUT,)
+        )
+        assert result is None
+        row = await asyncio.to_thread(get_campaign, cid)
+        assert row["status"] == CampaignStatus.STOPPED
+
+    @pytest.mark.asyncio
+    async def test_refused_expiry_leaves_no_question_file(self, tmp_path):
+        """GPT round-2 scenario: 24h expiry races a user Stop. When the guarded
+        transition is refused, no synthetic question file may remain — it would
+        drag a later Resume straight back into NEEDS_INPUT."""
+        cid = create_campaign({"question": "Does edge caching reduce latency?", "sources": ["web"]})["id"]
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+        row = await asyncio.to_thread(get_campaign, cid)
+        observed = row["started_at"]
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.STOPPED)
+        await h._expire_trust(cid, observed)
+        qp = h._questions_path(cid)
+        assert qp is None or not qp.exists(), "refused expiry left a stale question file"
+        row = await asyncio.to_thread(get_campaign, cid)
+        assert row["status"] == CampaignStatus.STOPPED
+
+    @pytest.mark.asyncio
+    async def test_successful_expiry_writes_question_and_parks(self, tmp_path):
+        cid = create_campaign({"question": "Does edge caching reduce latency?", "sources": ["web"]})["id"]
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+        row = await asyncio.to_thread(get_campaign, cid)
+        await h._expire_trust(cid, row["started_at"])
+        row = await asyncio.to_thread(get_campaign, cid)
+        assert row["status"] == CampaignStatus.NEEDS_INPUT
+        qp = h._questions_path(cid)
+        assert qp is not None and qp.exists()
+        assert "re-authorize" in qp.read_text()
+
+    @pytest.mark.asyncio
+    async def test_expiry_prompt_survives_a_directory_squatting_on_its_path(self, tmp_path):
+        """GPT round-7: the agent controls the research dir and can leave a
+        directory (or link) at questions.json. The expiry write must clear it
+        and publish the prompt — and even if the write fails, the audit + SSE
+        for the already-persisted NEEDS_INPUT must not be suppressed."""
+        cid = create_campaign({"question": "Does edge caching reduce latency?", "sources": ["web"]})["id"]
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+        row = await asyncio.to_thread(get_campaign, cid)
+        qp = h._questions_path(cid)
+        assert qp is not None
+        qp.mkdir(parents=True)  # squat a directory on the prompt path
+        await h._expire_trust(cid, row["started_at"])
+        row = await asyncio.to_thread(get_campaign, cid)
+        assert row["status"] == CampaignStatus.NEEDS_INPUT
+        assert qp.is_file(), "expiry prompt was not published over the squatting dir"
+        assert "re-authorize" in qp.read_text()
+
+    @pytest.mark.asyncio
+    async def test_commit_side_effects_survive_cancellation(self):
+        """CI-repro (cycle-cap test flake): the awaiting frame can be CANCELLED
+        at the ``to_thread`` suspension point AFTER the transition committed —
+        a success-branch after the await is then silently skipped and the SSE
+        for a persisted transition is lost. ``on_commit`` runs in the txn
+        thread, so the side effect survives the cancel deterministically."""
+        import threading
+
+        cid = create_campaign({"question": "Does edge caching reduce latency?", "sources": ["web"]})["id"]
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+        row = await asyncio.to_thread(get_campaign, cid)
+
+        committed = threading.Event()
+        release = threading.Event()
+        emitted: list[dict] = []
+
+        def _on_commit(_result: dict) -> None:
+            emitted.append({"type": "complete", "campaign_id": cid})
+            committed.set()
+            release.wait(timeout=5)  # hold the txn thread so the cancel lands first
+
+        task = asyncio.ensure_future(
+            h._guarded_transition(
+                cid,
+                CampaignStatus.COMPLETE,
+                allowed_current=(CampaignStatus.RUNNING,),
+                expected_started_at=row["started_at"],
+                on_commit=_on_commit,
+            )
+        )
+        # Wait (off-loop) until the commit + side effect ran in the txn thread.
+        assert await asyncio.to_thread(committed.wait, 5), "txn never committed"
+        task.cancel()  # cancel the awaiting frame at its suspension point
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        row = await asyncio.to_thread(get_campaign, cid)
+        assert row["status"] == CampaignStatus.COMPLETE, "commit was lost"
+        assert emitted, "commit-time side effect was lost to the cancellation"
+
+    @pytest.mark.asyncio
+    async def test_stale_workflow_poll_writes_nothing_into_a_replacement_run(self):
+        """GPT round-5 F1: a poll that read its snapshot against generation A
+        must abort at lock entry when generation B replaced it — no cycle
+        files, no bookkeeping, no terminal state may land in the new run."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        cid = create_campaign(
+            {
+                "question": "Does edge caching reduce latency?",
+                "sources": ["web"],
+                "execution_mode": "workflow",
+            }
+        )["id"]
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+        row = await asyncio.to_thread(get_campaign, cid)
+        old_generation = row["started_at"]
+        h._write_workflow_run_id(cid, "run-1")
+        # Pause → Resume replaces the run generation.
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.PAUSED)
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+        snap = {
+            "status": "finished",
+            "result": {"report": "# stale report"},
+            "events": [],
+        }
+        state = SimpleNamespace(
+            workflow_service=SimpleNamespace(result=MagicMock(return_value=snap))
+        )
+        await h._poll_workflow_campaign(cid, state, old_generation)
+        row = await asyncio.to_thread(get_campaign, cid)
+        assert row["status"] == CampaignStatus.RUNNING, (
+            "stale poll terminated the replacement run"
+        )
+        findings = h._campaign_dir(cid) / "FINDINGS.md"
+        assert not findings.exists(), "stale poll wrote FINDINGS.md into the replacement run"
+
+    @pytest.mark.asyncio
+    async def test_stale_generation_is_refused_even_when_status_matches(self):
+        """GPT round-4 ABA scenario: a Pause→Resume mints a NEW started_at, so
+        the status is RUNNING again — but an old run's verdict carrying the OLD
+        generation must not terminate the replacement run."""
+        cid = create_campaign({"question": "Does edge caching reduce latency?", "sources": ["web"]})["id"]
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+        row = await asyncio.to_thread(get_campaign, cid)
+        old_generation = row["started_at"]
+        # Pause → Resume: RUNNING again, but a NEW generation.
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.PAUSED)
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+        row = await asyncio.to_thread(get_campaign, cid)
+        assert row["started_at"] != old_generation, "resume must mint a new generation"
+        result = await h._guarded_transition(
+            cid,
+            CampaignStatus.COMPLETE,
+            allowed_current=(CampaignStatus.RUNNING,),
+            expected_started_at=old_generation,
+        )
+        assert result is None, "stale-generation verdict terminated the replacement run"
+        row = await asyncio.to_thread(get_campaign, cid)
+        assert row["status"] == CampaignStatus.RUNNING
+
+    @pytest.mark.asyncio
+    async def test_current_generation_proceeds(self):
+        cid = create_campaign({"question": "Does edge caching reduce latency?", "sources": ["web"]})["id"]
+        await asyncio.to_thread(update_campaign_status, cid, CampaignStatus.RUNNING)
+        row = await asyncio.to_thread(get_campaign, cid)
+        result = await h._guarded_transition(
+            cid,
+            CampaignStatus.COMPLETE,
+            allowed_current=(CampaignStatus.RUNNING,),
+            expected_started_at=row["started_at"],
+        )
+        assert result is not None and result["status"] == CampaignStatus.COMPLETE
+
+    def test_background_transitions_route_through_the_guard(self):
+        """Ratchet: the watchdog / nudge / workflow-poll frames must not call
+        ``update_campaign_status`` directly (even offloaded) — a raw offloaded
+        write skips the lock + allowed_current re-check and reintroduces the
+        lost-serialization race. ``_launch_workflow`` runs under
+        ``_handle_action``'s transition lock, so its direct writes are exempt
+        (the lock is not reentrant)."""
+        tree = _module_tree()
+        background = {
+            "_watchdog_loop",
+            "_handle_nudge",
+            "_poll_workflow_campaign",
+            "_record_new_cycle_from_watchdog",
+        }
+        offenders: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name in background:
+                for n in ast.walk(node):
+                    if (
+                        isinstance(n, ast.Name)
+                        and n.id == "update_campaign_status"
+                        and isinstance(n.ctx, ast.Load)
+                    ):
+                        offenders.append(f"{node.name}:{n.lineno}")
+        assert not offenders, (
+            "background frame references update_campaign_status directly "
+            f"(use _guarded_transition): {offenders}"
+        )
+
+
+class TestBriefTransactionality:
+    """brief.md publication invariant (two failure modes, both pinned):
+
+    1. Never publish BEFORE commit — a rollback/crash after the file write
+       would leave a brief describing phantom (uncommitted) state.
+    2. Publish order must match commit order — a stale snapshot must not
+       overwrite a newer brief. The per-campaign ``_brief_publish_lock`` spans
+       commit→publish in every producer, giving both properties at once.
+    """
+
+    def _producer_source(self, fn) -> str:
+        import textwrap
+
+        return textwrap.dedent(inspect.getsource(fn))
+
+    def test_launch_publishes_after_commit_under_the_lock(self):
+        src = self._producer_source(h._launch_loop)
+        assert "_brief_publish_lock" in src, "launch producer lost the publish lock"
+        closure = src[src.index("_brief_publish_lock") :]
+        assert closure.index("db.commit()") < closure.index("_write_brief("), (
+            "launch publishes the brief before its transaction commits"
+        )
+
+    def test_append_question_publishes_after_commit_under_the_lock(self):
+        src = self._producer_source(h._handle_add_question)
+        assert "_brief_publish_lock" in src, "append producer lost the publish lock"
+        assert src.index("db.commit()") < src.index("_write_brief("), (
+            "_handle_add_question publishes the brief before commit"
+        )
+
+    def test_activate_emergent_publishes_after_commit_under_the_lock(self):
+        src = self._producer_source(h._activate_emergent)
+        assert "_brief_publish_lock" in src, "emergent producer lost the publish lock"
+        assert src.index("db.commit()") < src.index("_write_brief("), (
+            "_activate_emergent publishes the brief before commit"
+        )
+
+    def test_emergent_ledger_persists_before_the_brief_publish(self):
+        """GPT round-6: the dedup ledger (mark_analyzed + save_queue) must be
+        persisted BEFORE the brief write — a failing brief write must not lose
+        the activation record, or the same items are re-activated (duplicated)
+        next cycle. Pinned structurally: source order within _activate_emergent
+        is commit → mark_analyzed → save_queue → _write_brief."""
+        src = inspect.getsource(h._activate_emergent)
+        i_commit = src.index("db.commit()")
+        i_mark = src.index("_sq.mark_analyzed(")
+        i_save = src.index("_sq.save_queue(")
+        i_brief = src.index("_write_brief(")
+        assert i_commit < i_mark < i_save < i_brief, (
+            "emergent activation order must be commit -> ledger -> brief publish"
+        )
+
+    def test_every_write_brief_producer_holds_the_publish_lock(self):
+        """Drift guard: any function that calls _write_brief must also acquire
+        _brief_publish_lock (rendering helpers and the lock factory exempt)."""
+        tree = _module_tree()
+        offenders = []
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name in ("_write_brief", "_brief_publish_lock"):
+                    continue
+                names = {
+                    n.func.id
+                    for n in ast.walk(node)
+                    if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+                }
+                if "_write_brief" in names and "_brief_publish_lock" not in names:
+                    offenders.append(node.name)
+        assert not offenders, f"_write_brief called without the publish lock in: {offenders}"
+
+
+class TestWarnThrottleClock:
+    def test_throttle_uses_monotonic_clock(self):
+        """The warn throttle must use time.monotonic (wall-clock jumps must not
+        re-open or permanently close the throttle window)."""
+        src = inspect.getsource(h._check_on_loop_db_discipline)
+        assert "time.monotonic()" in src
+        assert time.monotonic  # imported and real


### PR DESCRIPTION
## What is the problem?

The auto_research campaigns SQLite database is opened directly on the asyncio event loop. Every connection carries a 30-second busy timeout (`_get_db()` sets it via both the connect kwarg and `PRAGMA busy_timeout`), and the research worker writes findings/status every cycle while HTTP handlers read and write the same rows. One contended write entered on the loop therefore blocks **every** task — including the gateway's loop-stall watchdog heartbeat, whose kill budget (25s) is shorter than the busy timeout. A single lock wait can hard-exit the whole gateway.

An AST scan of main found 29 DB entries still executing inside `async def` frames in `handlers.py`: 11 direct `_get_db()` sites plus 18 calls to sync helpers that open the DB transitively (`update_campaign_status`, `_campaign_execution_mode`, `delete_campaign`) — in the watchdog loop, both launch paths, the workflow poller, and six HTTP handlers.

## Why does this issue matter to the user?

A user running a research campaign can freeze their entire gateway — chat, dashboard, every other app — by clicking Pause while the watchdog is mid-write, or simply by having two campaigns write concurrently. The watchdog then kills the process, dropping all in-flight sessions. This is the highest-blast-radius failure shape an app can have: one feature's disk contention takes down the whole product.

## How does our fix solve the problem?

Chain from symptom to root cause: gateway hard-exit → watchdog missed heartbeats → event loop starved → a 30s SQLite busy wait running ON the loop → DB connections opened inside `async def` frames.

The fix removes the root cause and pins it shut:

- **Every DB section in an async frame is offloaded** via `asyncio.to_thread` — either wrapping the sync helper call directly or extracting the read/write into a nested sync closure that is passed to `to_thread` (the style PR #2450 already established in this file).
- **`_handle_add_question` — the one read-modify-write among the sites — becomes a single `BEGIN IMMEDIATE` transaction** (write lock before read), so two concurrent appends serialize instead of one overwriting the other's question, and `_write_brief` runs inside the transaction so the on-disk brief always reflects the committed row it was rendered from. Note: the offload is what makes this race *reachable* (the loop's run-to-completion previously serialized the section), so the atomicity ships in the same commit.
- **A runtime chokepoint guard in `_get_db()`** raises under strict mode (`KIROCREW_STRICT_ON_LOOP_PERSIST` / `KIROCREW_DEV_MODE`, read through a new public `on_loop_persist_strict()` alias in `history.py` — same knob the conversation-log discipline uses) and logs a throttled warning in production, so a future un-offloaded call-site is loud, never silent.
- **A static AST ratchet test** forbids any `async def` in `handlers.py` from calling a DB-touching function outside a `to_thread`/`run_in_executor` argument position, including inline calls to nested DB closures. A companion drift test recomputes the transitive closure of sync DB helpers from the AST, so the ratchet's function list cannot silently go stale.

Background writers integrate with PR #2450's tombstone + `_campaign_transition_lock` mechanism rather than replacing it: every background transition (watchdog, nudge, workflow poller) goes through `_guarded_transition`, which holds the same per-campaign lock `_handle_action` uses, re-checks the current status (`allowed_current`), and — added during review — fences on the observed `started_at` generation so a Pause→Resume replacement run can never be terminated by a stale verdict (ABA). Commit-coupled side effects (SSE, audit, the expiry prompt) run via the `on_commit` hook in the transaction thread, so a cancellation of the awaiting frame cannot skip them after the commit landed. `brief.md` is published only after its row's transaction commits, under a per-campaign publish lock that keeps publish order equal to commit order.

## What tests did we do?

- `test/test_auto_research_onloop_db.py` (new, 10 tests): strict-raise / production-warn / off-loop-no-op / throttle for the guard; the AST ratchet + its drift guard; an end-to-end contention proof (a held `BEGIN IMMEDIATE` write lock stalls only the Pause request while an event-loop heartbeat keeps ticking); concurrent add-question losing zero of 8 parallel appends.
- Mutation verification: 3/3 mutants caught (un-offload a direct call → ratchet red; call a nested closure inline → ratchet red; drop the guard from `_get_db` → pin test red). Restore verified by content comparison.
- Timing-sensitive tests repeated 5× — stable.
- 411 auto_research tests + 198 history tests green; isort/flake8/mypy clean on changed files.

## Any other suggestions on the work?

The same 30s-busy-timeout-on-loop pattern is worth a repo-wide sweep — other builtin apps with their own SQLite stores can reproduce this failure shape; the guard + ratchet here are copyable as-is.

Closes #3050

