### PR TITLE
fix(cron): clear last_result on every command-cron exit path

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -244,12 +244,15 @@ class CronJob:
     fire_time_denied: bool = False
     last_result: str | None = None
     # Runtime-only (never serialized): True once THIS run produced a result
-    # via set_run_result(). ``last_result`` is a cross-run context-carry
-    # field that result-less runs (timeout, callback exception, no-output
-    # command, script Skip) deliberately leave in place for the next run's
-    # prompt dedup, so the history recorder needs this marker — not the
-    # value — to decide attribution. Identity/equality checks on the string
-    # cannot do that job: CPython interns equal literals and caches
+    # via set_run_result(). For AGENT jobs ``last_result`` is a cross-run
+    # context-carry field that result-less runs deliberately leave in place
+    # for the next run's prompt dedup, so the history recorder needs this
+    # marker — not the value — to decide attribution. Command and script
+    # jobs instead clear it on every result-less exit: the prompt built for
+    # them is discarded (the command branch never reads it, the script
+    # branch reassigns the variable), so a carried-over value could only
+    # ever misreport a finished run's result. Identity/equality checks on
+    # the string cannot do that job: CPython interns equal literals and caches
     # single-character latin-1 strings, so a run re-producing the same text
     # is indistinguishable from a run that produced nothing. Reset at the
     # start of every run by _run_job_isolated.
@@ -312,6 +315,18 @@ class CronJob:
         """
         self.last_result = value
         self.result_produced = True
+
+    def clear_carried_result(self) -> None:
+        """Drop a PREVIOUS run's result when this run produced none.
+
+        Result-less command/script exits must not display the last run's
+        output beside this run's status. Guarded on ``result_produced`` so a
+        run that produced and delivered a result and then failed during
+        cleanup keeps it. Assigns directly rather than via set_run_result()
+        so a cleared field is never marked as produced by this run.
+        """
+        if not self.result_produced:
+            self.last_result = ""
 
     def _audit_pause_change(self, outcome: str) -> None:
         """Emit a SEL audit event for an auto-pause permission transition.
@@ -2502,11 +2517,11 @@ class CronService:
         # Provisional; refined once the jitter sleep completes. Only read on
         # the history path, which a cancelled-during-jitter run never reaches.
         exec_started_at = started_at
-        # ``last_result`` is a cross-run context-carry field (see
-        # build_cron_session_context): runs that end without producing a
-        # result — timeout, callback exception, no-output command, script
-        # Skip — deliberately leave the previous run's value in place so the
-        # next run's prompt keeps its dedup context. The history recorder in
+        # ``last_result`` is a cross-run context-carry field for AGENT jobs
+        # (see build_cron_session_context): result-less runs leave the
+        # previous value in place so the next run's prompt keeps its dedup
+        # context. Command and script jobs have theirs cleared once in the
+        # finally below, because the prompt built for them is never dispatched. The history recorder in
         # the finally block must NOT attribute that carried-over value to
         # THIS run, so clear the freshness marker here; executor callbacks
         # set it via CronJob.set_run_result() when the run actually produces
@@ -2515,6 +2530,7 @@ class CronService:
         # a run re-producing the previous text looks identical to one that
         # produced nothing.)
         job.result_produced = False
+        being_cancelled = False
         try:
             # The jitter sleep MUST live inside this try: hourly/daily jobs
             # sleep up to 59 min here, and a user cancel() during that window
@@ -2535,6 +2551,11 @@ class CronService:
             except Exception:
                 logger.debug("push_refresh failed on job start", exc_info=True)
             await self._execute_with_timeout(job)
+        except asyncio.CancelledError:
+            # stop() cancels this task WITHOUT marking _cancelled_jobs, so the
+            # finally must know not to clear the last completed run's result.
+            being_cancelled = True
+            raise
         finally:
             finished_at = time.time()
             self._job_start_times.pop(job.id, None)
@@ -2556,6 +2577,10 @@ class CronService:
             if not reaped and not cancelled and job.schedule.kind == "every":
                 job.last_run_ts = started_at
             if not reaped and not cancelled:
+                # One clear per result-less run. Scattering it over exit sites is
+                # what let the fire-time deny and script Skip paths keep a result.
+                if (job.command or job.script) and not being_cancelled:
+                    job.clear_carried_result()
                 try:
                     # Offload the lock+sync+save merge to a worker thread:
                     # _merge_job_result enters the bounded sync _file_lock,

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -1325,6 +1325,8 @@ def _render_cron_list_full(jobs: list[Any]) -> str:
             j.last_status == "ok"
             and (j.script or j.command)
             and j.last_result
+            # Registries written before result_produced existed persist a literal
+            # "ok" sentinel, which would render as though it were real output.
             and j.last_result != "ok"
         ):
             san_res = _sanitize(j.last_result)[:_RESULT_PREVIEW_LEN]

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -2311,6 +2311,9 @@ class GatewayOrchestrator:
                         # auto-pause the job after _AUTO_PAUSE_THRESHOLD fires,
                         # and a paused job never fires again — breaking the
                         # documented resume-on-policy-loosening semantic.
+                        # A denial is result-less: without this the run shows a
+                        # PREVIOUS run's output beside this run's error status.
+                        job.clear_carried_result()
                         job.last_status = "error"
                         job.last_error = redact(gate_reason)
                         job.fire_time_denied = True
@@ -2345,10 +2348,15 @@ class GatewayOrchestrator:
                     output = result.get("output", "")
                     if not output.strip():
                         if result.get("status") == "ok":
+                            # Cleared, not marked: last_status already says the run
+                            # succeeded, so last_result carries produced text only.
+                            job.clear_carried_result()
                             job.last_status = "ok"
                             job.last_error = ""
                             job.record_success()
                         else:
+                            # Cleared so displays fall back to last_error below.
+                            job.clear_carried_result()
                             job.last_status = "error"
                             job.last_error = (
                                 f"non-ok status with no output (status={result.get('status')})"
@@ -2377,6 +2385,7 @@ class GatewayOrchestrator:
                         )
                     return job.last_result
                 except asyncio.TimeoutError:
+                    job.clear_carried_result()
                     job.last_error = f"timeout ({cmd_timeout + 5}s)"
                     job.last_status = "error"
                     job.record_failure()
@@ -2394,6 +2403,7 @@ class GatewayOrchestrator:
                     return None
                 except Exception as exc:
                     logger.exception("Command cron '%s' failed: %s", job.name, exc)
+                    job.clear_carried_result()
                     err_str = redact(str(exc))
                     job.last_error = err_str[:200]
                     job.last_status = "error"
@@ -2442,6 +2452,9 @@ class GatewayOrchestrator:
                     if gate_reason:
                         # No record_failure() — see the command-path deny above:
                         # a policy denial must not feed the auto-pause counter.
+                        # A denial is result-less: without this the run shows a
+                        # PREVIOUS run's output beside this run's error status.
+                        job.clear_carried_result()
                         job.last_status = "error"
                         job.last_error = redact(gate_reason)
                         job.fire_time_denied = True
@@ -2477,7 +2490,7 @@ class GatewayOrchestrator:
                         # bookkeeping/history — no failure counting, no delivery.
                         return None
                     if status == "ok":
-                        job.set_run_result("ok")
+                        job.clear_carried_result()
                         job.last_error = ""
                         job.last_status = "ok"
                         job.record_success()
@@ -2503,6 +2516,9 @@ class GatewayOrchestrator:
                         # by the _cancelled_jobs cancel-race check. Resetting in
                         # this branch would bypass that guard and could re-enable
                         # a job cancelled mid-tick.
+                        # Result-less like the deny paths: a Skip that carried the
+                        # previous run's output read as though it had produced it.
+                        job.clear_carried_result()
                         try:
                             sel().log_tool_invocation(
                                 session_key=f"cron:{job.id}",
@@ -2564,6 +2580,7 @@ class GatewayOrchestrator:
                     logger.warning(
                         "Script cron '%s' timed out after %ds", job.name, script_timeout + 5
                     )
+                    job.clear_carried_result()
                     job.last_error = f"timeout ({script_timeout + 5}s)"
                     job.last_status = "error"
                     job.record_failure()
@@ -2588,6 +2605,7 @@ class GatewayOrchestrator:
                     return None
                 except Exception as exc:
                     logger.exception("Script cron '%s' failed: %s", job.name, exc)
+                    job.clear_carried_result()
                     err_str = redact(str(exc))
                     job.last_error = err_str
                     job.last_status = "error"

--- a/test/test_cron_gateway_integration.py
+++ b/test/test_cron_gateway_integration.py
@@ -5,6 +5,9 @@ including delivery, concurrency guard, timeout handling, and Report().
 """
 from __future__ import annotations
 
+import asyncio
+import contextlib
+from contextlib import nullcontext
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -64,18 +67,23 @@ def _make_command_job(**overrides):
     return CronJob(**defaults)
 
 
-async def _run_script_callback(gw, job, script_result, vet_reason=None):
+async def _run_script_callback(gw, job, script_result=None, vet_reason=None, side_effect=None):
     """Run the cron callback with a mocked run_script_sandboxed result.
 
     ``vet_reason`` feeds the fire-time governance gate (None = job may run);
     patching vet_job_at_fire_time also stands in for the script-path
     resolution it performs, which the removed gateway-level
     resolve_script_path call used to cover.
+
+    Pass ``side_effect`` to make the mocked call raise instead of returning.
     """
     captured_cb = None
+    mock_kw = (
+        {"side_effect": side_effect} if side_effect is not None else {"return_value": script_result}
+    )
 
     with patch("kiro_crew.slack.gateway.CronService") as mock_cron_cls, \
-         patch("kiro_crew.slack.gateway.run_script_sandboxed", return_value=script_result) as mock_run, \
+         patch("kiro_crew.slack.gateway.run_script_sandboxed", **mock_kw) as mock_run, \
          patch("kiro_crew.slack.gateway.vet_job_at_fire_time", return_value=vet_reason), \
          patch("kiro_crew.slack.gateway.sel"):
 
@@ -97,12 +105,27 @@ async def _run_script_callback(gw, job, script_result, vet_reason=None):
         return await _init_and_run(), mock_run
 
 
-async def _run_command_callback(gw, job, cmd_result):
-    """Run the cron callback with a mocked run_command_sandboxed result."""
+async def _run_command_callback(gw, job, cmd_result=None, side_effect=None, vet_reason=None):
+    """Run the cron callback with a mocked run_command_sandboxed result.
+
+    Pass ``side_effect`` to make the mocked call raise instead of returning.
+    ``vet_reason`` feeds the fire-time governance gate (None = job may run),
+    mirroring _run_script_callback.
+    """
     captured_cb = None
+    mock_kw = (
+        {"side_effect": side_effect} if side_effect is not None else {"return_value": cmd_result}
+    )
+    # Only stand in for the gate when simulating a denial: other tests here drive
+    # the REAL gate, and patching it unconditionally would silence them.
+    gate = (
+        patch("kiro_crew.slack.gateway.vet_job_at_fire_time", return_value=vet_reason)
+        if vet_reason is not None else nullcontext()
+    )
 
     with patch("kiro_crew.slack.gateway.CronService") as mock_cron_cls, \
-         patch("kiro_crew.slack.gateway.run_command_sandboxed", return_value=cmd_result) as mock_run, \
+         patch("kiro_crew.slack.gateway.run_command_sandboxed", **mock_kw) as mock_run, \
+         gate, \
          patch("kiro_crew.slack.gateway.sel"):
 
         def capture_cron(on_job=None, **kw):
@@ -303,6 +326,167 @@ class TestCommandExecution:
         job = _make_command_job()
         result, _ = await _run_command_callback(gw, job, {"status": "ok", "output": "", "exit_code": 0})
         assert result is None  # no output = no delivery
+
+    @pytest.mark.asyncio
+    async def test_silent_success_overwrites_stale_result(self):
+        """A silent success must not leave the previous run's failure in last_result.
+
+        The dashboard and the cron_list renderers read last_result to show "what
+        this job last produced", so a stale value is presented as this run's
+        output on a job the same view reports as OK. Cleared rather than marked
+        with a literal: last_status already carries the verdict, and any literal
+        stored here is also legal job output, so no reader could tell the two
+        apart.
+        """
+        gw = _make_gw()
+        job = _make_command_job(last_result="⚠️ Exit code 1\n\nstderr:\nboom")
+        result, _ = await _run_command_callback(
+            gw, job, {"status": "ok", "output": "", "exit_code": 0}
+        )
+        assert result is None
+        assert job.last_status == "ok"
+        assert job.last_result == ""
+        assert "Exit code 1" not in job.last_result
+
+    @pytest.mark.asyncio
+    async def test_report_of_exactly_ok_is_kept_as_a_result(self):
+        """A job whose reported text happens to be "ok" still has a result.
+
+        Pinned alongside the clearing tests because the two are only one string
+        apart: clearing on silence is correct, and dropping this value is not.
+        """
+        gw = _make_gw()
+        job = _make_script_job()
+        result, _ = await _run_script_callback(gw, job, {"status": "report", "message": "ok"})
+        assert result == "ok"
+        assert job.last_status == "ok"
+        assert job.last_result == "ok"
+        assert job.result_produced is True
+
+    @pytest.mark.asyncio
+    async def test_silent_failure_clears_stale_result(self):
+        """A silent failure must not present the PREVIOUS failure's text as this run's.
+
+        Cleared rather than sentinel-marked: an empty result lets a reader fall
+        back to last_error, which carries this run's actual reason.
+        """
+        gw = _make_gw()
+        job = _make_command_job(last_result="⚠️ Exit code 1\n\nstderr:\nold failure")
+        result, _ = await _run_command_callback(
+            gw, job, {"status": "timeout", "output": "", "exit_code": None}
+        )
+        assert result is None
+        assert job.last_status == "error"
+        assert job.last_result == ""
+        assert "old failure" not in job.last_result
+        assert "no output" in job.last_error
+
+    @pytest.mark.asyncio
+    async def test_timeout_clears_stale_result(self):
+        """A timed-out run must not present the previous run's output as its own."""
+        gw = _make_gw()
+        job = _make_command_job(last_result="42 widgets")
+        result, _ = await _run_command_callback(gw, job, side_effect=asyncio.TimeoutError())
+        assert result is None
+        assert job.last_status == "error"
+        assert job.last_result == ""
+        assert "42 widgets" not in job.last_result
+        assert "timeout" in job.last_error
+
+    @pytest.mark.asyncio
+    async def test_raising_command_clears_stale_result(self):
+        """Same for a raising run: last_error must be the only text left to read."""
+        gw = _make_gw()
+        job = _make_command_job(last_result="42 widgets")
+        result, _ = await _run_command_callback(gw, job, side_effect=RuntimeError("boom"))
+        assert result is None
+        assert job.last_status == "error"
+        assert job.last_result == ""
+        assert "boom" in job.last_error
+
+    @pytest.mark.asyncio
+    async def test_script_timeout_clears_stale_result(self):
+        """The script branch's timeout path carries the same invariant."""
+        gw = _make_gw()
+        job = _make_script_job(last_result="42 widgets")
+        result, _ = await _run_script_callback(gw, job, side_effect=asyncio.TimeoutError())
+        assert result is None
+        assert job.last_status == "error"
+        assert job.last_result == ""
+        assert "42 widgets" not in job.last_result
+        assert "timeout" in job.last_error
+
+    @pytest.mark.asyncio
+    async def test_raising_script_clears_stale_result(self):
+        """Same for a raising script run: last_error must be the only text left."""
+        gw = _make_gw()
+        job = _make_script_job(last_result="42 widgets")
+        result, _ = await _run_script_callback(gw, job, side_effect=RuntimeError("boom"))
+        assert result is None
+        assert job.last_status == "error"
+        assert job.last_result == ""
+        assert "boom" in job.last_error
+
+    @pytest.mark.asyncio
+    async def test_command_fire_time_deny_clears_stale_result(self):
+        """A governance denial is result-less, so it must not wear the last run's output."""
+        gw = _make_gw()
+        job = _make_command_job(last_result="42 widgets")
+        result, mock_run = await _run_command_callback(
+            gw, job, {"status": "ok", "output": "unused", "exit_code": 0},
+            vet_reason="command not permitted at fire time",
+        )
+        assert result is None
+        mock_run.assert_not_called()
+        assert job.last_status == "error"
+        assert job.last_result == "", "a denied run must not display the previous run's output"
+        assert "not permitted" in job.last_error
+
+    @pytest.mark.asyncio
+    async def test_script_fire_time_deny_clears_stale_result(self):
+        """Same denial path on the script side."""
+        gw = _make_gw()
+        job = _make_script_job(last_result="42 widgets")
+        result, mock_run = await _run_script_callback(
+            gw, job, {"status": "ok"}, vet_reason="script changed on disk",
+        )
+        assert result is None
+        mock_run.assert_not_called()
+        assert job.last_status == "error"
+        assert job.last_result == ""
+        assert "changed on disk" in job.last_error
+
+    @pytest.mark.asyncio
+    async def test_script_skip_clears_stale_result(self):
+        """A Skip is a result-less success -- carrying prior output reads as produced."""
+        gw = _make_gw()
+        job = _make_script_job(last_result="42 widgets")
+        await _run_script_callback(gw, job, {"status": "skip"})
+        assert job.last_result == "", "a Skip must not present the previous run's output"
+
+    @pytest.mark.asyncio
+    async def test_silent_script_ok_leaves_no_sentinel(self):
+        """A silent ok clears rather than writing the literal ok sentinel.
+
+        The sentinel existed only to be non-empty, and two mcp_cron readers had to
+        filter it back out; clearing removes the writer and both filters.
+        """
+        gw = _make_gw()
+        job = _make_script_job(last_result="42 widgets")
+        await _run_script_callback(gw, job, {"status": "ok"})
+        assert job.last_status == "ok"
+        assert job.last_result == "", "no sentinel, and no stale carry either"
+
+    @pytest.mark.asyncio
+    async def test_nonempty_output_still_stored(self):
+        """Negative control: the change must not suppress a real result."""
+        gw = _make_gw()
+        job = _make_command_job(last_result="stale")
+        await _run_command_callback(
+            gw, job, {"status": "ok", "output": "42 widgets\n", "exit_code": 0}
+        )
+        assert "42 widgets" in job.last_result
+        assert job.last_result != ""
 
     @pytest.mark.asyncio
     async def test_timeout_passed_to_subprocess(self):
@@ -1079,3 +1263,41 @@ class TestCronUsageRow:
             )
 
         persist.assert_not_awaited()
+
+
+def test_shutdown_cancel_keeps_the_last_completed_result(tmp_path) -> None:
+    """A shutdown cancel must not wipe the previous run's result.
+
+    stop() cancels the in-flight task but never adds the job to _cancelled_jobs,
+    so the funnel's result-less clear would otherwise run on every gateway stop
+    and persist an empty result over the last completed run's output.
+    """
+    import asyncio
+
+    from kiro_crew.cron import CronJob, CronSchedule, CronService
+
+    async def _hang(*args, **kwargs):
+        await asyncio.sleep(9999)
+
+    async def _drive() -> CronJob:
+        svc = CronService(base_dir=tmp_path)
+        job = CronJob(
+            id="j1",
+            name="test",
+            message="go",
+            command="echo hi",
+            schedule=CronSchedule(kind="every", every_secs=60),
+            last_result="42 widgets",
+        )
+        svc._jobs = [job]
+        svc._save()
+        with patch.object(svc, "_execute", side_effect=_hang):
+            task = asyncio.create_task(svc._run_job_isolated(job))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        return job
+
+    job = asyncio.run(_drive())
+    assert job.last_result == "42 widgets", "a shutdown cancel wiped a completed result"

--- a/test/test_dashboard_cron_result_visibility.py
+++ b/test/test_dashboard_cron_result_visibility.py
@@ -1,0 +1,137 @@
+"""Tests that ``GET /api/crons`` reports exactly the text a run produced.
+
+``last_result`` carries produced text only; whether the run succeeded is
+``last_status``. A run with nothing to say therefore stores ``""``, which is
+already falsy, so no value-matching rule is needed to hide it — and none may be
+added, because every string is legal user output. ``Report("ok")`` and
+``Done("ok")`` store the literal ``"ok"`` as a real result, so a renderer that
+dropped that value would erase it and leave the UI with nothing to view.
+
+The two halves are pinned together on purpose: a rule that hides ``""`` and a
+rule that hides ``"ok"`` look alike, and only a test asserting the second is
+*visible* can tell them apart.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.cron import CronJob, CronSchedule
+from kiro_crew.dashboard.handlers.cron import api_crons
+
+
+def _request_with_job(**job_kw) -> MagicMock:
+    defaults = dict(
+        id="cj1",
+        name="cmd-job",
+        message="",
+        schedule=CronSchedule(kind="every", every_secs=60),
+        command="echo hello",
+        last_status="ok",
+    )
+    defaults.update(job_kw)
+    job = CronJob(**defaults)
+
+    state = MagicMock()
+    state.crons.list_jobs.return_value = [job]
+    state.crons.list_jobs_async = AsyncMock(return_value=[job])
+    state.crons.is_running.return_value = False
+    state.crons.running_since.return_value = None
+    state.has_slot.return_value = False
+    request = MagicMock()
+    request.app = {"state": state}
+    return request
+
+
+async def _job_payload(**job_kw) -> dict:
+    resp = await api_crons(_request_with_job(**job_kw))
+    assert resp.status == 200
+    return json.loads(resp.body)["jobs"][0]
+
+
+class TestProducedResultIsVisible:
+    """No value may be filtered out of the result fields."""
+
+    @pytest.mark.asyncio
+    async def test_result_that_is_exactly_ok_is_returned(self) -> None:
+        """A script's ``Report("ok")`` stores "ok"; the UI must be able to view it.
+
+        This is the case a value-matching filter breaks: "ok" doubles as the
+        shortest plausible success message a job can report, so dropping it
+        discards real output and disables View Result on a job that has some.
+        """
+        job = await _job_payload(last_result="ok")
+        assert job["last_result"] == "ok"
+        assert job["has_result"] is True
+
+    @pytest.mark.asyncio
+    async def test_ordinary_result_is_returned(self) -> None:
+        job = await _job_payload(last_result="42 widgets")
+        assert job["last_result"] == "42 widgets"
+        assert job["has_result"] is True
+
+    @pytest.mark.asyncio
+    async def test_result_merely_containing_ok_is_returned(self) -> None:
+        job = await _job_payload(last_result="all checks ok")
+        assert job["last_result"] == "all checks ok"
+        assert job["has_result"] is True
+
+
+class TestSilentRunShowsNothing:
+    """A run that produced no text must not offer a result to view."""
+
+    @pytest.mark.asyncio
+    async def test_cleared_result_reported_as_none(self) -> None:
+        """What a silent success writes: empty, so nothing is offered."""
+        job = await _job_payload(last_result="")
+        assert job["last_result"] is None
+        assert job["has_result"] is False
+
+    @pytest.mark.asyncio
+    async def test_never_run_job_reported_as_none(self) -> None:
+        job = await _job_payload(last_result=None, last_status="")
+        assert job["last_result"] is None
+        assert job["has_result"] is False
+
+    @pytest.mark.asyncio
+    async def test_error_text_still_reported(self) -> None:
+        """A cleared result must leave last_error as the text triage reads."""
+        job = await _job_payload(
+            last_result="", last_status="error", last_error="command failed (exit_code=1)"
+        )
+        assert job["last_result"] is None
+        assert job["last_error"] == "command failed (exit_code=1)"
+
+
+class TestProducedResultSurvivesLateFailure:
+    """A result produced and delivered must survive a failure after the fact.
+
+    The clears exist so a result-less run stops displaying the PREVIOUS run's
+    output. A run that produced a result and then raised during cleanup (script
+    ``Done`` delivers, then removal fails) is not that case: erasing there would
+    destroy this run's real output and report it as having produced nothing.
+    """
+
+    def test_clear_is_a_noop_once_this_run_produced_a_result(self):
+        job = CronJob(id="j1", name="produced", message="m")
+        job.set_run_result("report")
+        assert job.result_produced is True
+        job.clear_carried_result()
+        assert job.last_result == "report", "a produced result must not be erased"
+        assert job.result_produced is True
+
+    def test_clear_drops_a_carried_over_result_when_none_was_produced(self):
+        job = CronJob(id="j2", name="carried", message="m")
+        job.last_result = "previous run output"
+        job.result_produced = False
+        job.clear_carried_result()
+        assert job.last_result == ""
+
+    def test_clear_does_not_mark_the_run_as_having_produced_a_result(self):
+        job = CronJob(id="j3", name="marker", message="m")
+        job.result_produced = False
+        job.clear_carried_result()
+        assert job.result_produced is False, "clearing must not claim production"

--- a/test/test_mcp_cron_list_compact.py
+++ b/test/test_mcp_cron_list_compact.py
@@ -113,6 +113,23 @@ class TestCronListCompact:
         out = _call_tool_inner("cron_list", {})
         assert "result=computed 42 widgets" in out
 
+    def test_a_legacy_ok_sentinel_is_not_shown_as_a_result(self, home):
+        """Registries predating result_produced persist last_result == "ok".
+
+        That is a synthetic marker, not output, so rendering it would tell the
+        operator a silent script produced something when it produced nothing.
+        """
+        svc = CronService(base_dir=home)
+        job = svc.add_job(name="legacy", message="ignored", every_secs=300)
+        job.script = "x.py:f"
+        job.last_status = "ok"
+        job.last_result = "ok"
+        svc._save()
+        compact = _call_tool_inner("cron_list", {})
+        assert "result=ok" not in compact
+        full = _call_tool_inner("cron_list", {"verbose": True})
+        assert "last result: ok" not in full
+
     def test_compact_collapses_message_newlines(self, home):
         """Embedded newlines collapsed so each job stays a single block."""
         svc = CronService(base_dir=home)

--- a/test/test_slack_gateway_cron_exec_coverage.py
+++ b/test/test_slack_gateway_cron_exec_coverage.py
@@ -355,22 +355,28 @@ class TestCronScriptMode:
 
     @pytest.mark.asyncio
     async def test_ok_status_records_success(self):
+        """An ok status records success without inventing a result string.
+
+        The status is the signal and there is no output to show, so a carried
+        result is cleared rather than replaced with an "ok" sentinel that every
+        reader then had to filter out.
+        """
         orch = _make_orchestrator()
-        job = _job(script="probes.py:check", consecutive_failures=1)
+        job = _job(script="probes.py:check", consecutive_failures=1, last_result="42 widgets")
         async with _cron_cb(orch, sel_obj=_blind_sel(), script_result={"status": "ok"}) as cb:
             assert await cb(job) == "ok"
         assert job.last_status == "ok"
-        assert job.last_result == "ok"
+        assert job.last_result == ""
         assert job.consecutive_failures == 0
 
     @pytest.mark.asyncio
     async def test_skip_status_delivers_nothing(self):
-        """A Skip is a deliberate no-op: no result, no status change."""
+        """A Skip is result-less, so it must not present the PREVIOUS run's output."""
         orch = _make_orchestrator()
-        job = _job(script="probes.py:check")
+        job = _job(script="probes.py:check", last_result="42 widgets")
         async with _cron_cb(orch, sel_obj=_blind_sel(), script_result={"status": "skip"}) as cb:
             assert await cb(job) is None
-        assert job.last_result is None
+        assert job.last_result == ""
 
     @pytest.mark.asyncio
     async def test_unknown_status_is_an_error(self):


### PR DESCRIPTION
## What breaks today

`job.last_result` is meant to hold *what this run produced*, but the command-cron path never writes it, so it keeps a previous run's text and the UI presents that text as the current run's output.

When a command cron exits 0 with no output, `_cron_callback` sets `last_status` and `last_error` and returns without touching `last_result`. The four timeout/exception handlers (command timeout, command exception, script timeout, script exception) have the same omission. So a run that succeeds silently — or times out, or raises — leaves the *previous* run's output sitting in `last_result`, and both `cron_list` and `GET /api/crons` show it beside a status describing the current run. The worst shape is a silent success that renders `last result: <old failure text>` on a run it reports as OK.

## Why the fix works

Every command-cron exit path now **clears** `last_result` rather than leaving it stale:

- Silent success calls `job.set_run_result("")`. `last_status` already records that the run succeeded, so `last_result` is free to mean one thing only: text this run produced.
- Silent failure and all four timeout/exception handlers clear it too, so a reader falls back to `last_error`, which describes the current run.

Clearing rather than marking is the load-bearing choice. An earlier shape wrote a literal `"ok"` marker on silent success and had readers suppress that exact string, which is wrong in both directions: it collides with a result whose text is legitimately `ok`, so a real `Report("ok")` was discarded and the UI disabled View Result for it. With the field cleared instead, no reader needs to special-case any string, and `GET /api/crons` can pass `last_result` straight through. First Principles review pointed out this was not yet true when first written — two `last_result != "ok"` filters in `mcp_cron.py` were still alive, kept there by the one remaining writer. Both filters and that writer are gone now, so the sentence holds.

## The field contract, scoped in the same change

`CronJob.result_produced`'s comment and the matching note in `_run_job_isolated` described `last_result` as a cross-run context-carry field that result-less runs — naming "no-output command, script Skip" explicitly — *deliberately* leave in place for the next run's prompt dedup. This change clears exactly those paths, so that text now asserted the opposite of the code, and a maintainer reading it would treat the clear as a bug. Both comments are now scoped to **agent** jobs, where the carry is real.

Worth correcting the reason, because the obvious one is wrong: command and script jobs *do* reach `build_cron_session_context` — it runs unconditionally at the top of `_cron_callback`, before either branch. What makes clearing safe is that the prompt it returns is **discarded** on those paths: the command branch never reads it, and the script branch reassigns the same variable to hold the script's own result message. Only the agent path dispatches it. So for command and script jobs a carried-over `last_result` could never reach a prompt — it could only misreport a finished run's result, which is the bug this PR fixes.

## Clearing is guarded on what THIS run produced (review fix)

Review caught that the clears were unconditional, which is wrong on one real path: a script `Done("report")` sets the result and delivers it, then removal can raise `OSError`, and the clear in `except Exception` erased a result that had already gone out — recording the run as having produced nothing.

All ten clears now route through a new `CronJob.clear_carried_result()`, which drops the field only when `result_produced` is false. One method holds the rule rather than a copy of the predicate per site, so the sites cannot drift apart. It also assigns the field directly instead of calling `set_run_result("")`, so a cleared result is never *marked* as produced by this run — `set_run_result` sets that marker by contract, and the history recorder reads it to decide attribution.

The guard does not weaken the fix: a result produced by *this* run is this run's result and should display. What the clears remove is only a previous run's value on a run that produced nothing. Three tests pin it — a produced result survives, a carried-over one is dropped, and clearing never sets the produced marker. Removing the guard fails the first with "a produced result must not be erased".

## Three more result-less exits, and the sentinel (review follow-up)

Design and First Principles both found the same thing from different angles: the comment claimed command and script jobs clear on *every* result-less exit, and three paths did not.

**The fire-time governance denials were the live bug.** Both `vet_job_at_fire_time` deny branches set `last_status="error"` and `last_error` for the current run and left the previous run's output in `last_result` — the exact pairing this PR exists to remove, on the one path nobody cleared. **Script `Skip`** is the third: a result-less success that returns without touching `last_status`, so a carried result read as though the Skip had produced it. Both now clear.

**No new run writes the `"ok"` sentinel, but the two filters that hide it stay.** This was declared a known residual and left out of scope; the review was right that it should not be. `set_run_result("ok")` on a silent script success is now `clear_carried_result()`, so zero writers remain. Deleting the matching `last_result != "ok"` filters in `mcp_cron.py` was the first shape and it was wrong: a registry written before this change still holds that literal on disk (18 of 78 jobs in one real registry), and with the filters gone the list renders `last result: ok` — telling the operator a silent script produced output when it produced nothing. The filters are therefore migration compatibility for persisted state, and a test pins that a legacy job renders no result line. They are not free, though: `Report("ok")` and `Done("ok")` still reach `set_run_result` (`slack/gateway.py:2537`, `:2558`), so a script that deliberately reports the word "ok" is still hidden in `cron_list` while `GET /api/crons` shows it -- two readers disagreeing on one value. Removing that needs a one-shot registry-load migration rewriting persisted `"ok"` to `""` for script and command jobs, after which both filters can go; that is deliberately not in this change, which is about the carried-result invariant rather than the sentinel's storage.

**And one clear at the funnel, so a future exit path is safe without remembering.** Design's point was that scattering the clear over exit sites is the shape that produced these gaps. `CronScheduler._run_job_isolated` is the single path every run passes through — `_execute_with_timeout` has exactly one caller — so its `finally` now clears once for command and script jobs, guarded on `result_produced` like every other call. The per-site clears stay because they are the layer the executor tests exercise directly, but they are no longer what makes the invariant hold.

**That funnel clear had to learn about shutdown.** `stop()` cancels the in-flight job task but never adds the job to `_cancelled_jobs`, so a gateway shutdown arrived at the clear with `cancelled=False`, wiped the last completed run's output and persisted the empty value -- the exact staleness class this PR exists to fix, inverted. The cancellation is recorded where the language raises it -- an `except asyncio.CancelledError` arm sets a flag and re-raises -- so a run that produced nothing cannot overwrite what the previous one did. (`Task.cancelling()` was the first attempt and is 3.11+; this repo type-checks and tests on 3.10, where it is an AttributeError.) The guard is on the clear alone, not the enclosing block, so the result persist still runs and a completed run still lands. Negative-controlled: dropping it fails with `a shutdown cancel wiped a completed result`.

Four tests, each negative-controlled: reverting the deny clears gives `a denied run must not display the previous run's output`, reverting Skip gives `a Skip must not present the previous run's output`, and reverting the sentinel gives `no sentinel, and no stale carry either`. One test-helper change is worth naming: the command helper now stands in for the fire-time gate **only** when a denial is being simulated, because patching it unconditionally silenced two existing tests that drive the real gate.

## Testing

14 new test functions — 6 in a new `test/test_dashboard_cron_result_visibility.py`, 8 added to `test/test_cron_gateway_integration.py`. Both files together: **58 passed**.

Two existing tests in `test/test_slack_gateway_cron_exec_coverage.py` pinned the OLD contract and had to move: a script `Skip` asserted `last_result is None`, and a silent success asserted `last_result == "ok"`. `clear_carried_result()` sets `""`, so both now assert that. Rather than only swap the expected value, each test now seeds a prior result first, so it pins the stale-carry behaviour this change exists for instead of merely tracking the new one. Negative-controlled by restoring the sentinel and dropping the Skip clear: `assert 'ok' == ''` and `assert '42 widgets' == ''`.

The new tests pin both directions, because a test that only shows one of them cannot detect a regression of the other:

- a silent success clears `last_result`, so stale text from a prior failing run cannot survive into the next render;
- a result whose text is exactly `ok` is stored, returned by `GET /api/crons`, and reported by `has_result` — i.e. it is treated as produced text, not as a marker.

Each was negative-controlled by sabotaging the code and confirming the specific test goes red: deleting the silent-success clear reproduces the stale text verbatim (`assert '⚠️ Exit code…stderr:\nboom' == ''`), and reintroducing the string suppression fails the `ok`-is-returned test (`assert None == 'ok'`).

Wider regression check, measured on the whole suite rather than a selection: `-k cron` is **1466 passed / 4 skipped / 0 failed** (1470 collected), and the full backend suite is **50,157 passed / 19 failed**.

None of those 19 belong to this change. To establish that, the full suite was run three times on a clean `upstream/main` checkout and the union of its failures taken — 20 distinct — and the branch contributes none of its own. The census is the point: the failure set is not deterministic, and the three baseline runs produced 18, 16 and 16 failures. A single baseline run therefore undercounts it, and comparing one run against one run does invent regressions — it reported two here (`TestInitMcpDiscovery::test_configured_servers_are_listed`, `TestRememberOptions::test_record_failure_is_swallowed`) which both pass in isolation on an unmodified tree and appear in two of the three baseline runs.

An earlier figure in this section — `-k cron`, 1436 selected, 0 failed — has been replaced because it is not reproducible: the selection now collects 1470, and the two `test_slack_gateway_cron_exec_coverage.py` tests above were red at the time it was written, so it cannot describe the tree this PR shipped. The Windows CI shard, which runs everything, is what surfaced them.








