### PR TITLE
feat(cron): perpetual agents — kind='self', agent_sleep, code-owned contract preamble

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -25,8 +25,10 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import random
 import re
+import stat
 import time
 import uuid
 from contextlib import contextmanager
@@ -35,6 +37,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterator
 from zoneinfo import ZoneInfo
+
+from kiro_crew.messaging.link import is_channel_session_key, is_legacy_slack_key
 
 if TYPE_CHECKING:
     from kiro_crew.session import SessionManager
@@ -110,6 +114,52 @@ def referenced_skill_names() -> set[str]:
 _STORE_VERSION = 2
 _MIN_INTERVAL_SECS = 60
 _JOB_TIMEOUT_SECS = 1800  # 30 min per job
+
+
+def is_operator_session_key(session_key: str) -> bool:
+    """True when ``session_key`` names a HUMAN operator surface.
+
+    GPT round-42: ``add_job`` previously took ``operator_authorized: bool`` — a
+    VERDICT computed by the caller. A boolean says nothing about provenance and any
+    in-process caller can pass ``True``, so the persistence layer was still
+    trusting its caller. It now takes the claimed session key and applies this
+    predicate ITSELF, using the same shared roster the MCP tool uses, so an
+    automation identity (``cron:``, ``subagent:``, ``webhook:``, ``heartbeat:``,
+    ``taskrunner:``, empty) is refused even when the caller claims it is fine.
+    GPT's prescription was to revert the parameter entirely; that would restore the
+    state its own round-23 finding called blocking (perpetual creation with NO gate
+    at this layer), so the answer is to make the layer verify rather than to remove
+    the check.
+
+    Stated plainly, because it is the honest limit: a caller running arbitrary
+    in-process Python can pass a forged operator key, and no check performed inside
+    that same process can prevent it. What this closes is the weaker hole — a
+    caller declaring its own authorization — and it puts the roster decision in the
+    layer that owns the write.
+    """
+    if not session_key:
+        return False
+    return bool(
+        session_key.startswith("dashboard:")
+        or is_channel_session_key(session_key)
+        or is_legacy_slack_key(session_key)
+    )
+
+
+#: Per-FIELD cap for an ``agent_sleep`` record. Applied to ``did`` and
+#: ``next_intent`` separately, and a caller exceeding it is refused rather than
+#: trimmed: the previous single 4,000-char cap on the JOINED string silently
+#: dropped ``next_intent`` whenever ``did`` filled the budget (GPT round-40).
+#: Half the old total each, so a well-behaved caller sees no change and the
+#: worst-case stored size is unchanged.
+_SLEEP_FIELD_MAX = 2000
+
+# §9 (RFC rev 3): perpetual agents get a separate, HIGHER auto-pause threshold.
+# Five failed wakes is an ordinary bad day for an agent mid-investigation
+# (Phase 0: throttling alone reached 2 in the first hour); silent death by
+# auto-pause is the exact failure the RFC names. A self job must never die
+# quietly — record_failure logs at the ordinary threshold and pauses only here.
+_AUTO_PAUSE_THRESHOLD_SELF = 10
 # Margin the per-wake budget must leave above a command/script subprocess
 # timeout: the wake deadline cancels only the executor FUTURE (threads are
 # not interruptible), so a budget shorter than the subprocess bound leaves
@@ -204,9 +254,17 @@ _JITTER_DAILY_MAX = 59 * 60  # 0–59 minutes for daily jobs
 
 @dataclass
 class CronSchedule:
-    """Schedule definition — ``every``, ``at``, or ``cron``."""
+    """Schedule definition — ``every``, ``at``, ``cron``, or ``self``.
 
-    kind: str  # "every" | "at" | "cron"
+    ``self`` is the perpetual-agent kind (RFC rev 3): the agent names its own
+    next deadline through the ``agent_sleep`` tool (persisted on the job as
+    ``next_wake_ts``), bounded above by the operator's ``every_secs`` ceiling —
+    a wake the agent did not choose falls back to that interval. Deadlines are
+    stored on disk, so a wake missed while the host was down fires on recovery
+    (the property that made cron the host over in-memory timers).
+    """
+
+    kind: str  # "every" | "at" | "cron" | "self"
     every_secs: int | None = None
     at_ts: float | None = None
     cron_expr: str | None = None  # "min hour dom month dow"
@@ -228,6 +286,23 @@ class CronJob:
         False  # True when paused by execution after repeated failures; cleared on re-enable/success
     )
     last_run_ts: float | None = None
+    # Perpetual agents (schedule.kind == "self") only: the agent-chosen next
+    # deadline, written by the agent_sleep tool and CONSUMED when the wake
+    # fires. None means "no choice made" — the operator's every_secs ceiling
+    # is the fallback. Persisted so an agent-chosen wake survives restarts.
+    next_wake_ts: float | None = None
+    # Perpetual agents only: the did/next_intent record written by agent_sleep.
+    # Deliberately NOT last_result — the turn-completion merge overwrites
+    # last_result with the turn's own text, which would clobber a record
+    # written mid-run. This field is never touched by _merge_job_result, so
+    # the agent's write survives (same ownership pattern as next_wake_ts).
+    last_sleep_record: str = ""
+    #: Runtime-only. GPT rounds 38/39/41/42 were all ONE consumed sleep record
+    #: being re-persisted from a different call site, so the value now lives here
+    #: instead of on ``last_sleep_record`` after consumption. ``_save`` serialises
+    #: an EXPLICIT field list, so this never reaches the store — a round-trip test
+    #: asserts that, rather than trusting the reader to notice.
+    consumed_sleep_record: str = ""
     last_status: str | None = None  # "ok" | "error"
     last_error: str | None = None
     created_ts: float = 0.0
@@ -343,7 +418,12 @@ class CronJob:
         """
         self.consecutive_failures += 1
         self.failure_recorded = True
-        if self.consecutive_failures >= _AUTO_PAUSE_THRESHOLD and not self.auto_paused:
+        _threshold = (
+            _AUTO_PAUSE_THRESHOLD_SELF
+            if self.schedule.kind == "self"
+            else _AUTO_PAUSE_THRESHOLD
+        )
+        if self.consecutive_failures >= _threshold and not self.auto_paused:
             self.enabled = False
             self.auto_paused = True
             self._audit_pause_change("auto_paused")
@@ -374,6 +454,247 @@ class CronJob:
 # ── Session-context helper ──
 
 
+# ── §7: perpetual-agent prompt assembly (kind == "self") ──
+
+# Caps keep an indefinitely-running agent's prompt bounded (§7: nothing in the
+# prompt may grow without a cap).
+_LIFE_MD_CAP_BYTES = 16_384
+_JOURNAL_TAIL_LINES = 20
+_JOURNAL_TAIL_CAP_BYTES = 6_144
+
+# The contract preamble is CODE-OWNED (not LIFE.md prose): Phase 0's strongest
+# result was that "what to do next" had no owner in either prompt or code, and
+# an operator-written delta trigger starved the goal for 8 straight cycles
+# (PHASE0-LOG Findings 14/15). The ranking step is therefore stated here, once,
+# for every perpetual agent. §7 also forbids claiming the agent will be
+# punished for an idle cycle — that instruction is what produces invented work.
+_SELF_CONTRACT_PREAMBLE = """[Perpetual agent contract]
+You are a perpetual agent: you hold a standing goal (LIFE.md below), and you
+own WHAT to do each wake. The scheduler owns WHEN.
+
+1. RANK FIRST. Assess your whole surface against the goal, name the largest
+   gap you can evidence, and work that. What changed since your last wake is
+   ONE INPUT to that assessment — never the trigger for it. A tool that only
+   reports changes will hide the largest static item; measure the whole.
+2. The assessment is never rate-limited; only filing is. If output is blocked
+   (e.g. a PR slot in review), the cycle's work is the next gap's evidence.
+3. Honest idle is a legitimate outcome, never punished: if the assessment
+   comes up empty, say what you assessed and what your largest standing gap
+   is, and sleep. Never invent work to fill a cycle.
+4. Escalate a permission wall immediately; a competence wall only after two
+   genuinely different attempts. If an escalation goes unanswered, file the
+   question publicly and return to the goal — do not wait politely forever.
+5. End the wake by calling the agent_sleep tool: report what you did (did),
+   what you intend next (next_intent), and when to wake you (next_wake_secs —
+   you may wake EARLIER than your schedule ceiling to continue work or catch
+   an event; you cannot sleep past it).
+[End of perpetual agent contract]"""
+
+
+def _agents_dir() -> Path:
+    """Root of per-agent life directories (~/.kiro/crew/agents by default)."""
+    return config_dir() / "agents"
+
+
+def _open_inside_nofollow(path: Path, root: Path) -> int | None:
+    """Open ``path`` read-only, refusing symlinks and escapes from ``root``.
+
+    Traverses from a pinned ``root`` descriptor and opens EVERY component with
+    ``O_NOFOLLOW``, so no symlink is ever followed and there is no window
+    between deciding a path is contained and using it. GPT round-15 found the
+    previous shape — ``realpath`` containment followed by a plain ``os.open`` —
+    raced: ``O_NOFOLLOW`` covers only the FINAL component, so swapping an
+    intermediate directory for a symlink between the two calls redirected the
+    read while the check had already passed. Walking component-by-component
+    removes the window rather than narrowing it: containment is now structural
+    (we start at the root fd and never traverse upward or through a link),
+    not a comparison that can go stale.
+
+    The relative segments are derived LEXICALLY from *root*; a path that is not
+    lexically under it, or that carries ``.``/``..``/empty segments, is refused
+    outright rather than normalised. Returns an fd, or None on any refusal.
+
+    Platforms without ``dir_fd`` support (Windows) fall back to the previous
+    ``realpath`` + ``O_NOFOLLOW`` form, whose residual race is documented there;
+    the perpetual-agent life directory is POSIX-only in practice because the
+    scheduler that reads it runs wherever the gateway runs.
+    """
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        logger.warning("life context refused: %s is not under the agents dir", path)
+        return None
+    segments = rel.parts
+    if not segments or any(s in ("", ".", "..") or "/" in s or "\\" in s for s in segments):
+        logger.warning("life context refused: %s has a non-literal segment", path)
+        return None
+
+    open_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    dir_flags = open_flags | getattr(os, "O_DIRECTORY", 0)
+    # O_NONBLOCK: a FIFO placed at this path must not block the open — with it
+    # the open returns immediately and the fstat check below refuses the
+    # non-regular file. Regular-file reads are unaffected by O_NONBLOCK.
+    leaf_flags = open_flags | getattr(os, "O_NONBLOCK", 0)
+
+    if os.open not in getattr(os, "supports_dir_fd", set()):
+        _life_context_unavailable_without_dirfd()
+        return None
+
+    root_fd: int | None = None
+    home_fd: int | None = None
+    cur: int | None = None
+    try:
+        # GPT round-18: the previous shape opened ``root`` (the AGENTS dir)
+        # without O_NOFOLLOW, on the claim that it is "product-created and not
+        # agent-writable". That claim was wrong — ``agents`` is not in the
+        # write-protected list, so an agent can move it aside and put a link
+        # there, and the walk then followed it and every component below was
+        # attacker-chosen. Split the two: the DATA HOME above it may
+        # legitimately be a link the operator made, so it is opened without
+        # O_NOFOLLOW; ``agents`` itself is opened FROM that descriptor WITH
+        # O_NOFOLLOW, so a replaced root is refused like any other component.
+        home_fd = os.open(root.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        root_fd = os.open(root.name, dir_flags, dir_fd=home_fd)
+        cur = root_fd
+        for seg in segments[:-1]:
+            nxt = os.open(seg, dir_flags, dir_fd=cur)
+            if cur != root_fd:
+                os.close(cur)
+            cur = nxt
+        fd = os.open(segments[-1], leaf_flags, dir_fd=cur)
+    except OSError:
+        return None
+    finally:
+        if home_fd is not None:
+            os.close(home_fd)
+        if cur is not None and cur != root_fd:
+            os.close(cur)
+        if root_fd is not None:
+            os.close(root_fd)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            os.close(fd)
+            logger.warning("life context refused: %s is not a regular file", path)
+            return None
+    except OSError:
+        os.close(fd)
+        return None
+    return fd
+
+
+def _life_context_unavailable_without_dirfd() -> None:
+    """Log the one-time reason life context is not ingested on this platform.
+
+    GPT round-19 retired the previous ``realpath``-containment fallback rather
+    than hardening it. That fallback could not refuse a link or junction whose
+    target resolves back INSIDE the agents root — the comparison passes, so one
+    agent's directory pointed at another's read the victim's goal file — and on
+    Windows a ``mklink /J`` junction reaches that state with no symlink
+    privilege at all. Round 16 pinned the gap as a documented residual; that was
+    the wrong call for a shipped default: silently ingesting a
+    possibly-attacker-chosen goal is worse than not ingesting one.
+
+    The alternative considered was a per-component reparse-point check before
+    the open. Rejected: it is still check-then-open, so it narrows the window
+    instead of closing it, and it adds platform-specific code to a security
+    path in exchange for a weaker guarantee than the ``openat`` walk gives
+    everywhere else.
+
+    Cost, stated plainly: on a platform without ``dir_fd`` a perpetual agent
+    gets its §7 contract preamble and its operator message but no LIFE.md or
+    JOURNAL.md section. The agent still runs; it runs without the goal file it
+    cannot be given safely.
+    """
+    logger.warning(
+        "life context not ingested: this platform has no dir_fd support, so the "
+        "per-component no-follow walk is unavailable and the reader fails closed"
+    )
+
+
+def _read_head_bytes(path: Path, cap: int, root: Path) -> str | None:
+    """Read at most ``cap`` bytes from the start of ``path`` (None if unreadable).
+
+    Bounded at the read() call itself — never a whole-file read_text — so a
+    pathologically large file cannot stall the caller for longer than the cap.
+    Opens via :func:`_open_inside_nofollow` (symlink + containment guards).
+    """
+    fd = _open_inside_nofollow(path, root)
+    if fd is None:
+        return None
+    try:
+        with os.fdopen(fd, "rb") as fh:
+            data = fh.read(cap + 1)
+    except OSError:
+        return None
+    truncated = len(data) > cap
+    text = data[:cap].decode("utf-8", "replace")
+    return text + "\n[truncated at cap]" if truncated else text
+
+
+def _read_tail_bytes(path: Path, cap: int, root: Path) -> str | None:
+    """Read at most ``cap`` bytes from the END of ``path`` (None if unreadable).
+
+    Opens via :func:`_open_inside_nofollow` (symlink + containment guards).
+    """
+    fd = _open_inside_nofollow(path, root)
+    if fd is None:
+        return None
+    try:
+        with os.fdopen(fd, "rb") as fh:
+            fh.seek(0, 2)
+            size = fh.tell()
+            fh.seek(max(0, size - cap))
+            data = fh.read(cap)
+    except OSError:
+        return None
+    return data.decode("utf-8", "replace")
+
+
+def _load_life_context(job: CronJob) -> str:
+    """Read the §6 life directory (LIFE.md + JOURNAL.md tail), capped.
+
+    Missing files degrade to empty sections — a fresh agent with no LIFE.md
+    yet still gets the contract preamble and its operator message. Read
+    errors are swallowed for the same reason: prompt assembly must never be
+    the thing that kills a wake.
+
+    The directory is keyed by the generated ``job.id`` — never the free-text
+    name: a name is choosable (any caller of cron_add), so keying by it would
+    let a job named after an EXISTING agent pull that agent's LIFE/JOURNAL
+    into its own prompt, besides ordinary collisions. The id is
+    machine-generated at creation and unique. The containment check below is
+    defense in depth on top of that. Reads are byte-bounded at the syscall
+    (never whole-file), so a huge journal cannot stall the caller beyond the
+    caps.
+    """
+    root = _agents_dir()
+    # NOT resolved: ``.resolve()`` here FOLLOWED a symlinked ``<job.id>``
+    # directory and handed the reader its target, so the per-component
+    # no-follow walk never saw the link and a containment comparison on the
+    # already-resolved path could only ask "did we land somewhere allowed?"
+    # rather than "did we traverse a link?". A link whose target sits inside
+    # the agents root — another agent's directory — passed that comparison and
+    # pulled the victim's goal file into this job's prompt (GPT round-15).
+    # Containment is now enforced structurally inside
+    # :func:`_open_inside_nofollow`, which starts at ``root`` and refuses every
+    # symlink and every non-literal segment, so the lexical path is what must
+    # be passed down.
+    base = root / job.id
+    if not job.id:
+        return ""
+    parts: list[str] = []
+    life = _read_head_bytes(base / "LIFE.md", _LIFE_MD_CAP_BYTES, root)
+    if life is not None:
+        parts.append(
+            f"[LIFE.md — your goal; owner: the human; read-only]\n{life}\n[End of LIFE.md]"
+        )
+    raw_tail = _read_tail_bytes(base / "JOURNAL.md", _JOURNAL_TAIL_CAP_BYTES, root)
+    if raw_tail is not None:
+        tail = "\n".join(raw_tail.splitlines()[-_JOURNAL_TAIL_LINES:])
+        parts.append(f"[JOURNAL.md tail — your own record]\n{tail}\n[End of JOURNAL.md tail]")
+    return "\n\n".join(parts)
+
+
 def build_cron_session_context(job: CronJob) -> tuple[str, str]:
     """Compute (session_key, prompt) for one cron run.
 
@@ -396,6 +717,31 @@ def build_cron_session_context(job: CronJob) -> tuple[str, str]:
     """
     if job.persistent_session:
         msg = job.message
+        self_head: str | None = None
+        if job.schedule.kind == "self":
+            head = _SELF_CONTRACT_PREAMBLE
+            life = _load_life_context(job)
+            if life:
+                head = f"{head}\n\n{life}"
+            # Round 42: prefer the TRANSIENT record set by the deadline consume.
+            # It is not a dataclass field, so it cannot be persisted by any save —
+            # which is what finally stopped a consumed record from reaching the
+            # NEXT wake. ``last_sleep_record`` is still read for the case where the
+            # deadline was not consumed on this run (an every_secs fallback wake).
+            _sleep_rec = getattr(job, "consumed_sleep_record", "") or job.last_sleep_record
+            if _sleep_rec:
+                head = (
+                    f"{head}\n\n[Your agent_sleep record from last wake]\n"
+                    f"{_sleep_rec}\n[End of agent_sleep record]"
+                )
+            # GPT round-24: this used to be prepended HERE, and the last_result
+            # block below then prefixed the whole thing — so for any agent that
+            # had already run once (i.e. every established perpetual agent, the
+            # majority case) the previous-run result sat ABOVE the contract, and
+            # §7's "preamble first" plus its RANK FIRST step were not first at
+            # all. Hold the head and prepend it after the result block is
+            # composed, so the contract leads unconditionally.
+            self_head = head
         if job.last_result:
             last = job.last_result
             if job.minimal_context and len(last) > 2000:
@@ -406,6 +752,8 @@ def build_cron_session_context(job: CronJob) -> tuple[str, str]:
                 "[End of previous run result]\n\n"
                 f"{msg}"
             )
+        if self_head is not None:
+            msg = f"{self_head}\n\n{msg}"
         return f"cron:{job.id}", msg
 
     # Stateless: fresh key, bare message.
@@ -481,6 +829,10 @@ def format_schedule(schedule: CronSchedule, tz_name: str = "") -> str:
             pass
     if schedule.kind == "cron" and schedule.cron_expr:
         return _humanize_cron(schedule.cron_expr, tz_name)
+    if schedule.kind == "self" and schedule.every_secs:
+        secs = schedule.every_secs
+        span = f"{secs // 3600}h" if secs >= 3600 else f"{secs}s"
+        return f"self-scheduled (ceiling {span})"
     if schedule.kind == "every" and schedule.every_secs:
         secs = schedule.every_secs
         if secs >= 3600:
@@ -570,6 +922,17 @@ def compute_next_run_ts(job: CronJob, now: float | None = None) -> float | None:
             return None
         sched = job.schedule
         now = now if now is not None else time.time()
+        if sched.kind == "self" and sched.every_secs is not None:
+            # Agent-chosen deadline wins; past-due fires immediately (missed
+            # wake fires on recovery, never one interval later). Fallback is
+            # the operator ceiling, same shape as "every".
+            if job.next_wake_ts is not None:
+                return job.next_wake_ts if job.next_wake_ts > now else now
+            last = job.last_run_ts if job.last_run_ts is not None else job.created_ts
+            if last is None:
+                return None
+            nxt = last + sched.every_secs
+            return nxt if nxt > now else now
         if sched.kind == "every" and sched.every_secs is not None:
             last = job.last_run_ts if job.last_run_ts is not None else job.created_ts
             if last is None:
@@ -1184,6 +1547,9 @@ class CronService:
         minimal_context: bool = False,
         timeout: int = 0,
         timeout_secs: int = 0,
+        perpetual: bool = False,
+        *,
+        operator_session_key: str = "",
     ) -> CronJob:
         """Add a new job. Provide one of ``every_secs``, ``at_ts``, or ``cron_expr``.
 
@@ -1243,6 +1609,8 @@ class CronService:
             minimal_context=minimal_context,
             timeout=timeout,
             timeout_secs=timeout_secs,
+            perpetual=perpetual,
+            operator_session_key=operator_session_key,
         )
         self._persist_add_locked(job)
         self._arm_timer()
@@ -1338,6 +1706,9 @@ class CronService:
         minimal_context: bool = False,
         timeout: int = 0,
         timeout_secs: int = 0,
+        perpetual: bool = False,
+        *,
+        operator_session_key: str = "",
     ) -> CronJob:
         """Validate inputs and construct the :class:`CronJob` (no I/O, no lock).
 
@@ -1379,7 +1750,55 @@ class CronService:
         for _d in skip_dates:
             if not is_valid_skip_date(_d):
                 raise ValueError(f"Invalid skip_date: {_d!r} (expected YYYY-MM-DD)")
-        if cron_expr:
+        if perpetual:
+            # §2/§9 (RFC rev 3): a perpetual agent is an "every"-shaped job
+            # whose deadline the agent may pull EARLIER via agent_sleep.
+            # every_secs is the operator ceiling (the fallback wake).
+            #
+            # GPT round-23: the operator-only rule (RFC Non-goals — only a human
+            # creates a perpetual agent) lived ONLY at the MCP tool. That left
+            # the invariant true by convention of a single caller rather than
+            # enforced by the owner of the write, so any other caller — a script,
+            # an app, a future code path — could author one silently. It is now
+            # checked HERE, where the job is built, and the MCP tool passes the
+            # flag after its own allowlist decides the caller is an operator
+            # surface. Keyword-only and default-false so every existing caller
+            # that does not opt in is refused rather than given legacy status.
+            #
+            # This does not pretend to stop an agent that can already execute
+            # arbitrary Python in-process; nothing at this layer can. What it
+            # stops is the invariant being enforced in exactly one place.
+            if not is_operator_session_key(operator_session_key):
+                raise ValueError(
+                    "perpetual=True requires an operator session key; it may only "
+                    "be created from an operator surface (RFC Non-goals). Got "
+                    f"{operator_session_key or '<empty>'!r}"
+                )
+            if not every_secs:
+                raise ValueError("perpetual=True requires every_secs (the operator ceiling)")
+            # GPT round-32: a command/script cron runs no model, so it can never
+            # call agent_sleep and never names its own next deadline — the whole
+            # point of kind="self". Accepting the combination produced a job
+            # LABELLED perpetual that behaved as a plain fixed interval, which is
+            # worse than refusing it: the §7 contract, the life context and the
+            # higher auto-pause threshold would all apply to something that
+            # cannot use them.
+            if command or script:
+                raise ValueError(
+                    "perpetual=True is exclusive with command/script jobs "
+                    "(they run no model and cannot call agent_sleep)"
+                )
+            if cron_expr or at_ts:
+                raise ValueError("perpetual=True is exclusive with cron_expr/at_ts")
+            if delete_after_run:
+                raise ValueError("delete_after_run is refused for perpetual jobs (§9)")
+            # Jitter off: the deadline is agent-chosen and often tied to an
+            # external event it reasoned about; noise corrupts the decision.
+            strict_schedule = True
+            # Continuity across wakes is load-bearing (Phase 0, need 3).
+            persistent_session = True
+            schedule = CronSchedule(kind="self", every_secs=max(every_secs, _MIN_INTERVAL_SECS))
+        elif cron_expr:
             if not validate_cron_expr(cron_expr):
                 raise ValueError(f"Invalid cron expression: {cron_expr}")
             schedule = CronSchedule(kind="cron", cron_expr=cron_expr)
@@ -1421,6 +1840,124 @@ class CronService:
             timeout=timeout,
             timeout_secs=int(timeout_secs) if timeout_secs else _JOB_TIMEOUT_SECS,
         )
+
+    def record_agent_sleep(
+        self,
+        job_id: str,
+        next_wake_secs: int,
+        did: str,
+        next_intent: str = "",
+    ) -> CronJob:
+        """Persist a perpetual agent's chosen next wake and its cycle record.
+
+        The agent_sleep MCP tool's disk core: under the cross-process
+        ``_file_lock``, validates the job is ``kind == "self"``, clamps the
+        requested wake into [_MIN_INTERVAL_SECS, every_secs] — the agent may
+        pull its wake EARLIER than the operator ceiling, never later (RFC rev
+        3: the sleep-longer half ships as §4 configuration, not agent-chosen
+        distant deadlines) — writes ``next_wake_ts``, and records ``did`` /
+        ``next_intent`` via :meth:`CronJob.set_run_result` so the §7 prompt
+        carries them into the next wake even if the turn's own result text is
+        lost. Raises ``ValueError`` on an unknown job or a non-self kind, and
+        :class:`CronStoreBusy` on sustained lock contention.
+
+        Runs in a genuinely loop-less process (the MCP server) per the
+        write-path audit table in :meth:`_save`; the gateway's scheduler picks
+        the new deadline up through the mtime+digest ``_sync`` on its next
+        tick, which is at most ``_TIMER_POLL_SECS`` away — the deadline is
+        disk-owned, so neither process needs the other alive at write time.
+        """
+        with self._file_lock():
+            self._sync()
+            for job in self._jobs:
+                if job.id != job_id:
+                    continue
+                if job.schedule.kind != "self":
+                    raise ValueError(
+                        f"agent_sleep is only valid for kind='self' jobs, got "
+                        f"{job.schedule.kind!r}"
+                    )
+                ceiling = job.schedule.every_secs or _MIN_INTERVAL_SECS
+                clamped = max(_MIN_INTERVAL_SECS, min(int(next_wake_secs), ceiling))
+                job.next_wake_ts = time.time() + clamped
+                # GPT round-40: a single ``record[:4000]`` truncation dropped the
+                # NEXT INTENT whenever ``did`` alone reached the cap — the agent's
+                # statement of what it plans to do next vanished with no error, and
+                # the next wake was simply never told. Silent loss of the more
+                # forward-looking half is the worst possible way to spend the
+                # budget.
+                #
+                # So the two fields are bounded SEPARATELY and an oversized record
+                # is REFUSED rather than trimmed. A caller that writes too much gets
+                # told; nothing is dropped behind its back.
+                _did = did.strip()
+                _intent = next_intent.strip()
+                if len(_did) > _SLEEP_FIELD_MAX or len(_intent) > _SLEEP_FIELD_MAX:
+                    raise ValueError(
+                        f"agent_sleep: 'did' and 'next_intent' are limited to "
+                        f"{_SLEEP_FIELD_MAX} characters each "
+                        f"(got {len(_did)} and {len(_intent)}); summarise instead"
+                    )
+                record = f"did: {_did}"
+                if _intent:
+                    record += f"\nnext: {_intent}"
+                job.last_sleep_record = record
+                self._save()
+                logger.info(
+                    "agent_sleep: job %s sleeping %ds (requested %ds, ceiling %ds)",
+                    job_id,
+                    clamped,
+                    next_wake_secs,
+                    ceiling,
+                )
+                return job
+        raise ValueError(f"Job not found: {job_id}")
+
+    def _consume_self_wake_locked(self, job: CronJob) -> None:
+        """Compare-and-clear the agent-chosen deadline at fire time.
+
+        Clears ``next_wake_ts`` on disk ONLY when it still equals the value
+        this fire consumed — an ``agent_sleep`` write landing during the run
+        (a NEWER choice) must survive. Degrades to the in-memory clear when
+        the store is contended; the next ``_sync`` reconciles.
+        """
+        fired = job.next_wake_ts
+        if fired is None:
+            return
+        # CronStoreBusy propagates: consuming only in memory while the disk
+        # keeps the past-due deadline would make every subsequent tick refire
+        # the job. The caller skips this wake and the next tick retries the
+        # locked consumption — contention is transient by construction.
+        with self._file_lock():
+            self._sync()
+            for j in self._jobs:
+                if j.id == job.id:
+                    # NB: when _sync did not reload, ``j`` IS ``job`` —
+                    # compare before any in-memory clear, or the guard
+                    # can never match its own object.
+                    if j.next_wake_ts == fired:
+                        j.next_wake_ts = None
+                        # GPT rounds 38/39/41/42 all landed on this one value, and
+                        # each of my fixes moved WHERE it was cleared instead of
+                        # removing the thing that kept re-persisting it. Round 42
+                        # ends the class: the consumed record is moved OFF the
+                        # persisted field and onto a TRANSIENT attribute.
+                        #
+                        # ``_save`` serialises an explicit field list (see the
+                        # ``data = {...}`` builder), so an attribute that is not a
+                        # dataclass field cannot reach the store by ANY path —
+                        # not the deadline consume, not ``_merge_job_result``, not
+                        # the run's own bookkeeping save, and not a future call
+                        # site nobody has written yet. That is what the three
+                        # previous placements could not guarantee.
+                        _consumed = j.last_sleep_record
+                        j.last_sleep_record = ""
+                        self._save()
+                        # the run about to start still needs it for its prompt
+                        job.last_sleep_record = ""
+                        job.consumed_sleep_record = _consumed
+                    break
+        job.next_wake_ts = None
 
     def _persist_add_locked(self, job: CronJob) -> None:
         """Lock/reload/append/save for a new job — the thread-safe disk core.
@@ -1465,6 +2002,9 @@ class CronService:
         minimal_context: bool = False,
         timeout: int = 0,
         timeout_secs: int = 0,
+        perpetual: bool = False,
+        *,
+        operator_session_key: str = "",
     ) -> CronJob:
         """Event-loop-safe :meth:`add_job`: the lock+save runs off the loop.
 
@@ -1512,6 +2052,8 @@ class CronService:
             minimal_context=minimal_context,
             timeout=timeout,
             timeout_secs=timeout_secs,
+            perpetual=perpetual,
+            operator_session_key=operator_session_key,
         )
         await asyncio.to_thread(self._persist_add_locked, job)
         self._arm_timer()
@@ -1584,6 +2126,59 @@ class CronService:
                         raise ValueError(f"Invalid interval: {kwargs['every_secs']}") from e
                     if val < _MIN_INTERVAL_SECS:
                         raise ValueError(f"Interval must be >= {_MIN_INTERVAL_SECS}s, got {val}")
+                # §9 invariants of a perpetual job, refused BEFORE any field is
+                # assigned so a rejected update leaves the job untouched (same
+                # posture as the timeout cross-field check below). GPT round-11:
+                # the generic path let an operator flip these off, and each one
+                # silently breaks the agent rather than erroring —
+                # persistent_session=False drops the cross-wake continuity that
+                # Phase 0 found load-bearing, strict_schedule=False re-enables
+                # the jitter §9 turns off (the deadline is agent-chosen and often
+                # tied to an external event), and delete_after_run removes the
+                # job on its first wake. Refuse instead of coercing: an operator
+                # who wants a plain job should create one, and a silent coercion
+                # would report success for an update that did not happen.
+                if job.schedule.kind == "self":
+                    # GPT round-12: cron_expr is the other route that converts
+                    # the job away from kind="self" — round-11 preserved the
+                    # kind across an INTERVAL change but the cron_expr branch
+                    # below still rebuilt it as kind="cron", with the same
+                    # consequence (contract context gone, agent_sleep refuses
+                    # it). A perpetual agent's cadence is a ceiling plus an
+                    # agent-chosen deadline; a calendar expression cannot
+                    # express that, so this is refused rather than coerced.
+                    if kwargs.get("cron_expr"):
+                        raise ValueError(
+                            "cron_expr cannot be set on a perpetual job (§9); "
+                            "adjust the every_secs ceiling instead"
+                        )
+                    # at_ts is refused for the same reason, and refused LOUDLY:
+                    # this path currently ignores it (verified — the schedule
+                    # section below has no at_ts branch, so update_job(at_ts=…)
+                    # reports success and changes nothing). A silent no-op on a
+                    # perpetual job is the same failure shape as a silent
+                    # conversion: the operator believes the cadence moved. A
+                    # one-shot deadline is also meaningless for a standing
+                    # condition that is never done. Raised by the Opus lane
+                    # alongside cron_expr; that half was already fixed in
+                    # round 12, this half was not.
+                    if kwargs.get("at_ts"):
+                        raise ValueError(
+                            "at_ts cannot be set on a perpetual job (§9); "
+                            "a perpetual agent has no one-shot deadline"
+                        )
+                    if "persistent_session" in kwargs and not kwargs["persistent_session"]:
+                        raise ValueError(
+                            "persistent_session cannot be disabled on a perpetual job (§9)"
+                        )
+                    if "strict_schedule" in kwargs and not kwargs["strict_schedule"]:
+                        raise ValueError(
+                            "strict_schedule cannot be disabled on a perpetual job (§9)"
+                        )
+                    if kwargs.get("delete_after_run"):
+                        raise ValueError(
+                            "delete_after_run is refused for perpetual jobs (§9)"
+                        )
                 # Calendar-validity of timezone / skip_dates, validated at the
                 # persistence owner so EVERY caller (MCP cron_add/cron_update,
                 # dashboard, CLI) is covered by one check rather than each
@@ -1693,7 +2288,32 @@ class CronService:
                 if "cron_expr" in kwargs and kwargs["cron_expr"]:
                     job.schedule = CronSchedule(kind="cron", cron_expr=kwargs["cron_expr"])
                 elif "every_secs" in kwargs and kwargs["every_secs"]:
-                    job.schedule = CronSchedule(kind="every", every_secs=int(kwargs["every_secs"]))
+                    # GPT round-11: a perpetual job keeps kind="self" across an
+                    # interval change. The generic path rebuilt the schedule as
+                    # kind="every", which silently retired the job's §7 contract
+                    # context and made agent_sleep reject it ("not a self job") —
+                    # an operator raising the wake ceiling would have un-made the
+                    # perpetual agent. The interval is still the operator's
+                    # ceiling either way. The floor is already enforced by the
+                    # pre-validation above; ``max`` here mirrors add_job so the
+                    # two construction sites read the same.
+                    _kind = "self" if job.schedule.kind == "self" else "every"
+                    _every = max(int(kwargs["every_secs"]), _MIN_INTERVAL_SECS)
+                    job.schedule = CronSchedule(kind=_kind, every_secs=_every)
+                    # GPT round-12: the agent-chosen deadline is bounded by the
+                    # operator's ceiling, so lowering the ceiling has to bound
+                    # an already-recorded deadline too. Without this, an agent
+                    # that slept 3500s under a 3600s ceiling kept waiting for
+                    # 3500s after the operator lowered the ceiling to 600s —
+                    # _is_due honours next_wake_ts first, so the lowered
+                    # ceiling had no effect until the stale deadline fired.
+                    # Clamped rather than cleared so a deadline EARLIER than the
+                    # new ceiling (the wake-sooner half this feature exists for)
+                    # survives an unrelated ceiling change.
+                    if _kind == "self" and job.next_wake_ts is not None:
+                        _cap = (job.last_run_ts or job.created_ts) + _every
+                        if job.next_wake_ts > _cap:
+                            job.next_wake_ts = _cap
                 self._save()
                 logger.info("Updated cron job %s", job_id)
                 return job
@@ -2424,6 +3044,37 @@ class CronService:
                 logger.debug("Cron: applying %.0fs jitter to job '%s'", jitter, job.name)
                 await asyncio.sleep(jitter)
             exec_started_at = time.time()
+            # Perpetual agents: consume the agent-chosen deadline NOW, on
+            # disk, so a crash mid-run cannot refire the same past-due wake
+            # forever. Offloaded — the compare-and-clear takes _file_lock.
+            #
+            # GPT round-35: the guard was only ``is not None``, so a run that did
+            # NOT arrive from that deadline — a manual cron_trigger, or a run_job
+            # call — consumed a deadline still in the FUTURE. The agent's choice
+            # was silently discarded, and if the manual run then failed before
+            # calling agent_sleep the next wake fell back to the every_secs
+            # ceiling: the agent asked for 20 minutes and got the fallback hours.
+            # Only a deadline this run actually reached is consumed.
+            if (
+                job.schedule.kind == "self"
+                and job.next_wake_ts is not None
+                and job.next_wake_ts <= exec_started_at
+            ):
+                try:
+                    await asyncio.to_thread(self._consume_self_wake_locked, job)
+                except CronStoreBusy:
+                    # Deadline not consumed on disk — running anyway would
+                    # let the persisted past-due value refire after this run.
+                    # Skip the wake; the next tick retries the consumption.
+                    # Marked CANCELLED so the finally block does not finalize
+                    # this non-run: without the marker it would advance
+                    # last_run_ts and record a phantom history row.
+                    self._cancelled_jobs.add(job.id)
+                    logger.warning(
+                        "Cron '%s': store busy consuming self deadline; skipping wake",
+                        job.name,
+                    )
+                    return
             # Notify dashboard that the job has started executing so the live
             # is_running badge appears without a manual reload.
             try:
@@ -2450,7 +3101,7 @@ class CronService:
             except Exception:
                 logger.debug("push_refresh failed on job end", exc_info=True)
             # For 'every' jobs, use started_at to prevent cumulative drift
-            if not reaped and not cancelled and job.schedule.kind == "every":
+            if not reaped and not cancelled and job.schedule.kind in ("every", "self"):
                 job.last_run_ts = started_at
             if not reaped and not cancelled:
                 try:
@@ -2538,7 +3189,16 @@ class CronService:
 
     @staticmethod
     def _is_due(job: CronJob, now: float) -> bool:
-        if job.schedule.kind == "every" and job.schedule.every_secs:
+        if job.schedule.kind == "self" and job.schedule.every_secs:
+            # Agent-chosen deadline wins; fallback is the operator ceiling.
+            if job.next_wake_ts is not None:
+                if now < job.next_wake_ts:
+                    return False
+            else:
+                last = job.last_run_ts or job.created_ts
+                if now < last + job.schedule.every_secs:
+                    return False
+        elif job.schedule.kind == "every" and job.schedule.every_secs:
             last = job.last_run_ts or job.created_ts
             if now < last + job.schedule.every_secs:
                 return False
@@ -2947,6 +3607,8 @@ class CronService:
                     user_paused=j.get("user_paused", not j.get("enabled", True)),
                     auto_paused=j.get("auto_paused", False),
                     last_run_ts=j.get("last_run_ts"),
+                    next_wake_ts=j.get("next_wake_ts"),
+                    last_sleep_record=j.get("last_sleep_record", ""),
                     last_status=j.get("last_status"),
                     last_error=j.get("last_error"),
                     created_ts=j.get("created_ts", 0.0),
@@ -3052,6 +3714,8 @@ class CronService:
                     "user_paused": j.user_paused,
                     "auto_paused": j.auto_paused,
                     "last_run_ts": j.last_run_ts,
+                    "next_wake_ts": j.next_wake_ts,
+                    "last_sleep_record": j.last_sleep_record,
                     "last_status": j.last_status,
                     "last_error": j.last_error,
                     "created_ts": j.created_ts,

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -548,7 +548,13 @@ class HookManager:
             if is_sensitive_path(target):
                 return ToolHookResult.deny(f"Blocked: access to sensitive path: {target}")
             # execute_bash (prefixed or bare) — check for reads of sensitive paths.
-            reason = is_sensitive_bash_command(target)
+            # session_key is passed so the perpetual-agent journal allowance can
+            # be scoped to the agent that OWNS that journal (GPT round-27): a
+            # journal is read back into its owner's next prompt, so a cross-agent
+            # write is a prompt-injection channel. Both real transports populate
+            # it (dashboard chat_runner and llm_helpers); a caller that does not
+            # gets no exemption rather than a shared one.
+            reason = is_sensitive_bash_command(target, session_key=session_key)
             if reason:
                 return ToolHookResult.deny(reason)
             # Data-exfiltration / reverse-shell command shapes.
@@ -595,7 +601,11 @@ class HookManager:
         # into a read regression, and the bash gate covers the shell surface.
         if tool_kind == _EDIT_TOOL_KIND and raw_params:
             wpath = raw_params.get("path") or raw_params.get("file_path")
-            if isinstance(wpath, str) and wpath and is_sensitive_write_path(wpath):
+            if (
+                isinstance(wpath, str)
+                and wpath
+                and is_sensitive_write_path(wpath, session_key=session_key)
+            ):
                 return ToolHookResult.deny(
                     f"Blocked: modification of write-protected config path: {wpath}"
                 )

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -37,8 +37,9 @@ from kiro_crew.cron import (
 )
 from kiro_crew.cron_script import resolve_script_path
 from kiro_crew.cron_trigger import trigger_cron_job
-from kiro_crew.mcp_core import _resolve_session_key
+from kiro_crew.mcp_core import _resolve_session_key, _resolve_session_key_strict
 from kiro_crew.mcp_shared import call_tool_with_logging, run_mcp_stdio_loop
+from kiro_crew.messaging.link import is_channel_session_key, is_legacy_slack_key
 from kiro_crew.platform import current_context
 from kiro_crew.platform import redact_via_context as redact
 from kiro_crew.sandbox import _AGENT_DENIED_ENV_KEYS
@@ -1119,8 +1120,46 @@ def _list_tools() -> list[dict[str, Any]]:
                         "bounds only script/command subprocesses. Raise it for "
                         "agents whose single wake legitimately outgrows 30 min.",
                     },
+                    "perpetual": {
+                        "type": "boolean",
+                        "description": "Create a perpetual agent (schedule "
+                        "kind='self'): the agent names its own next wake via "
+                        "the agent_sleep tool, bounded above by 'every' (the "
+                        "operator ceiling). Requires 'every'; forces "
+                        "strict_schedule and persistent_session; refuses "
+                        "delete_after_run.",
+                    },
                 },
                 "required": ["name"],
+            },
+        },
+        {
+            "name": "agent_sleep",
+            "description": "Perpetual agents only (cron kind='self'): end your "
+            "wake by recording what this cycle did, what you intend next, and "
+            "when to wake you. You may wake EARLIER than your schedule ceiling "
+            "(to continue work or catch an event); you cannot sleep past it. "
+            "Call this exactly once, at the END of your wake.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "next_wake_secs": {
+                        "type": "integer",
+                        "description": "Seconds until your next wake. Clamped "
+                        "into [60, your schedule ceiling].",
+                    },
+                    "did": {
+                        "type": "string",
+                        "description": "One-line record of what this wake "
+                        "actually produced (or an honest 'idle — assessed X, "
+                        "largest standing gap is Y').",
+                    },
+                    "next_intent": {
+                        "type": "string",
+                        "description": "What you intend to do next wake.",
+                    },
+                },
+                "required": ["next_wake_secs", "did"],
             },
         },
         {
@@ -1566,6 +1605,32 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         strict_schedule = args.get("strict_schedule")
         timeout_val = args.get("timeout", 0)
         timeout_secs_val = args.get("timeout_secs", 0)
+        perpetual_val = args.get("perpetual")
+        if perpetual_val is True:
+            # RFC rev 3, Non-goals / S8: only a HUMAN creates a perpetual
+            # agent. POSITIVE allowlist, fail closed: a denylist on "cron:"
+            # fell open for subagent:/webhook:/heartbeat:/empty identities —
+            # any automation with cron_add could mint autonomous successors.
+            # GPT round-7: a hand-rolled 4-prefix list rejected human Webex/
+            # WeCom/Teams/Weixin/unified-DM and legacy bare-Slack sessions, so
+            # the operator surface is now the SHARED predicates — dashboard:
+            # plus every messaging-channel namespace (is_channel_session_key
+            # covers the full roster and stays current when channels are
+            # added) plus the legacy un-namespaced Slack thread_ts shape.
+            # Automation identities (cron:/subagent:/webhook:/heartbeat:/
+            # taskrunner:/unresolved) match none of these and stay refused.
+            # Strict identity, no ancestor fallback.
+            _caller = _resolve_session_key_strict()
+            _is_operator = bool(_caller) and (
+                _caller.startswith("dashboard:")
+                or is_channel_session_key(_caller)
+                or is_legacy_slack_key(_caller)
+            )
+            if not _is_operator:
+                return (
+                    "Error: perpetual agents can only be created from an "
+                    "operator session (dashboard/chat), not from automation"
+                )
         try:
             job = svc.add_job(
                 name=n,
@@ -1593,6 +1658,14 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                 minimal_context=minimal_context if isinstance(minimal_context, bool) else False,
                 timeout=timeout_val or 0,
                 timeout_secs=timeout_secs_val or 0,
+                perpetual=perpetual_val if isinstance(perpetual_val, bool) else False,
+                # GPT round-42: pass the CLAIMED IDENTITY, not a boolean verdict —
+                # the persistence layer re-validates it against the same shared
+                # roster. Empty for a non-perpetual add, where ``_caller`` is not
+                # resolved at all: the allowlist block above runs only under
+                # ``perpetual_val is True``, and referencing it unconditionally
+                # raised NameError for every ordinary cron_add (38 tests).
+                operator_session_key=(_caller if perpetual_val is True else ""),
             )
         except CronStoreBusy:
             return "Error: cron store busy, please retry"
@@ -1607,6 +1680,59 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             resources=f"job_id={job.id}",
         )
         return f"Added job: {job.id} ({job.name}) [{sched_str}]. Tell the user: scheduled for {sched_str}."
+
+    if name == "agent_sleep":
+        # Resolve the calling cron job from the session key the gateway
+        # injected (cron:{job_id} or cron:{job_id}:{suffix}) — the tool works
+        # only from inside a perpetual agent's own wake, so an agent can
+        # never sleep another agent's job.
+        sk = _resolve_session_key_strict()
+        if not sk:
+            return (
+                "Error: agent_sleep requires direct session identity (a cron "
+                "subagent cannot sleep its parent job)"
+            )
+        _sk_match = re.match(r"^cron:([0-9a-f]{8})(?::|$)", sk)
+        if not _sk_match:
+            return (
+                "Error: agent_sleep must be called from a perpetual agent's "
+                "cron session (no cron job id in this session)"
+            )
+        jid = _sk_match.group(1)
+        # GPT round-10: the capability gate belongs here too. Writing
+        # next_wake_ts IS a cron mutation, and an operator who disables
+        # capabilities.cron mid-wake expects no further scheduling state to be
+        # authored — the fire-time gate stops the job from RUNNING, but without
+        # this the agent still persists a deadline on a surface that is no
+        # longer permitted to schedule. Keyed cron:<job.id> like
+        # vet_job_at_fire_time so the SEL deny trail names the job.
+        cap_err = _vet_cron_capability_governance(session_key=f"cron:{jid}")
+        if cap_err:
+            _log_cron_denial("agent_sleep", cap_err)
+            return cap_err
+        try:
+            job = svc.record_agent_sleep(
+                jid,
+                int(args["next_wake_secs"]),
+                str(args.get("did", "")),
+                str(args.get("next_intent", "") or ""),
+            )
+        except CronStoreBusy:
+            return "Error: cron store busy, please retry"
+        except (ValueError, TypeError) as e:
+            return f"Error: {e}"
+        sel().log_api_access(
+            caller="mcp",
+            operation="cron.agent_sleep",
+            outcome="allowed",
+            source="mcp",
+            resources=f"job_id={jid} next_wake_ts={job.next_wake_ts}",
+        )
+        _when = datetime.utcfromtimestamp(job.next_wake_ts or 0).strftime("%H:%M:%S UTC")
+        return (
+            f"Recorded. Next wake at {_when}. Your did/next_intent are saved "
+            "and will be in your next wake's prompt. End your turn now."
+        )
 
     if name == "cron_update":
         jid = args["job_id"]

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -4176,6 +4176,25 @@ _SENSITIVE_HOME_DIRS: list[str] = [
 # force-deletes ``~/.kirocrew`` once the move completes — there is no rollback
 # copy left behind to gate.
 _CREW_HOME_PREFIXES: tuple[str, ...] = (".kiro/crew", ".kirocrew")
+
+#: Trailing boundary for a path match in the command-text matchers: what can
+#: legitimately END a path token in a shell command. Whitespace, end-of-string
+#: and quotes were the original set; GPT round-14 added the shell CONTROL
+#: characters, because a command ending in a terminator
+#: (``> ~/.kiro/crew/crons.json;``, ``…|tee /tmp/x``, ``(…)``) puts a delimiter
+#: immediately after the leaf, and every branch carrying the old class then
+#: failed to match. That gap affected the PRE-EXISTING fences too — the
+#: credential directories and the data-home marker, not only the entries this PR
+#: added — so it is defined once here and shared, rather than patched per
+#: branch. ``}`` covers ``${VAR}``-adjacent spellings; ``,``/``:`` cover
+#: list-joined arguments; ``<``/``>`` were added in round 16 because a redirect
+#: can be attached with no space (``> …/crons.json>/tmp/out``), which puts an
+#: operator immediately after the leaf exactly like a terminator does.
+_PATH_END = r"(?:\s|$|['\";&|)},:<>])"
+#: Same, for a matcher whose path may legitimately continue with a separator
+#: (a directory match that must also fire on ``<dir>/<anything>``). POSIX form;
+#: the Windows branches build their own from ``win_sep``.
+_PATH_END_OR_SEP = r"(?:/|\s|$|['\";&|)},:<>])"
 _CREW_SECRET_LEAVES: list[str] = [
     ".env",
     # The Notes builtin stores a GitHub Personal Access Token here so it can
@@ -4381,7 +4400,20 @@ _WRITE_PROTECTED_HOME_PATHS: list[str] = [
     # would make the next boot skip migration and ignore the legacy home's
     # governance policy + secrets. The migration code writes it directly and
     # does NOT route through this gate, so legitimate stamping still works.
-    for leaf in ("config.json", "config.local.json", ".data-home-ready")
+    # crons.json: the scheduler STORE, and an input to an authorization
+    # decision in exactly the sense rotation.yaml is below. Every scheduling
+    # invariant the tools enforce — the operator-only gate on perpetual
+    # creation, agent_sleep's deadline clamp, the kind='self' inheritance
+    # overrides — is enforced at the TOOL boundary and then persisted here, so
+    # an agent tool that could rewrite this file would author a job the tools
+    # would have refused. It stays READABLE (the dashboard and `cron list`
+    # read it constantly); only the agent's own file/bash tools are refused.
+    # CronService writes it through its own file-lock + atomic-replace path,
+    # which does not route through this gate, so the product still writes it.
+    # Found by review on the perpetual-agent PR; the exposure predates it —
+    # an agent that could rewrite the store could already author a
+    # `command`-mode cron, i.e. arbitrary shell on the operator's schedule.
+    for leaf in ("config.json", "config.local.json", ".data-home-ready", "crons.json")
 ] + [
     # Ops Mission Control's on-call schedule. WRITE-protected, not read+write
     # sensitive: it holds no secret and every teammate's instance must READ it to
@@ -4488,8 +4520,24 @@ _WRITE_PROTECTED_HOME_PATHS += [
 # agent that rewrites it can have the gate approve one signal while the sink mutates another.
 # Reads stay allowed for the same reason as the schedule — it is the board every instance
 # renders, and it holds no secret.
+# ``crons.json`` is the fourth, and it meets the same bar one step further out: it is the
+# scheduler STORE, and every scheduling invariant lives at the TOOL boundary and is then
+# persisted here — the operator-only gate on perpetual creation, ``agent_sleep``'s deadline
+# clamp, the ``kind='self'`` inheritance overrides. An agent that rewrites it authors a job the
+# tools would have refused, and nothing downstream re-validates a job the loader reads back.
+# The exposure is not introduced by perpetual agents: an agent able to rewrite this file could
+# already author a ``command``-mode cron, i.e. arbitrary shell on the operator's own schedule,
+# which is strictly worse than any perpetual-scheduling knob. ``CronService`` writes it through
+# its own file-lock + atomic-replace path rather than this gate, so the product's own scheduling
+# is unaffected, and ``is_sensitive_path`` (the READ gate) still excludes it, so the CLI, the
+# dashboard and the read tool render it as before. Shell READS of it are blocked, like the
+# other entries here — this branch is verb-independent so that no write form can bypass it,
+# and that is acceptable for the same reason it is for the marker: the file holds no secret and
+# legitimate readers do not use shell ``cat``. Found by review on the perpetual-agent PR
+# (#3202).
 _WRITE_PROTECTED_BASH_LEAVES: tuple[str, ...] = (
     ".data-home-ready",
+    "crons.json",
     "apps/ops-mission-control/data/rotation.yaml",
     "apps/ops-mission-control/data/incidents/index.json",
 )
@@ -4526,6 +4574,23 @@ _WRITE_CMDS = (
 _SCRIPT_OPEN = r"(?:python|ruby|perl)\S*\s.*open\s*\("
 
 
+#: Shell "noise" a caller may splice between the characters of a filename without
+#: changing which file the shell opens: quotes, and — GPT round-42 — BACKSLASHES.
+#: ``printf x > c\rons.json`` writes ``crons.json`` because the shell strips the
+#: backslash, and the leaf matcher was built with a bare ``re.escape`` so it saw a
+#: different name. The quote-tolerant LIFE.md pattern had the same gap for
+#: backslashes.
+#:
+#: One builder is used for BOTH matchers on purpose: the recurring lesson in this
+#: module is that two hand-written spellings of one idea drift apart.
+_SHELL_NOISE = r"['\"\\]{0,8}"
+
+
+def _noise_tolerant(literal: str) -> str:
+    """A pattern matching ``literal`` with shell noise allowed between characters."""
+    return _SHELL_NOISE.join(re.escape(ch) for ch in literal)
+
+
 def _build_sensitive_regex() -> re.Pattern[str]:
     """Build a compiled regex matching bash reads OR writes of sensitive paths.
 
@@ -4552,18 +4617,99 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     home_alts = f"(?:{home}|{tilde}|{home_var}|{generic_home})"
     escaped_dirs = [re.escape(d) for d in _SENSITIVE_HOME_DIRS]
     dirs_pattern = "|".join(escaped_dirs)
-    sensitive_path = rf"{home_alts}/(?:{dirs_pattern})(?:/|\s|$|['\"])"
+    sensitive_path = rf"{home_alts}/(?:{dirs_pattern}){_PATH_END_OR_SEP}"
     # Write-protected leaves (e.g. the data-home marker): a full home-anchored
     # path to a specific leaf file, matched verb-INDEPENDENTLY (below) so no
     # write form can bypass it. See _WRITE_PROTECTED_BASH_LEAVES for why reads
     # are blocked too (harmless: no secret; legitimate readers use Python).
-    wp_prefixes = "|".join(re.escape(p) for p in _CREW_HOME_PREFIXES)
-    wp_leaves = "|".join(re.escape(leaf) for leaf in _WRITE_PROTECTED_BASH_LEAVES)
+    # GPT round-12: canonical no-op segments are accepted here too, the same way
+    # the agent-life branch below does it. Without this,
+    # ``> ~/.kiro/crew/./crons.json`` named a fenced leaf that this branch could
+    # not see — the same dot-segment class that was fixed for the goal file in
+    # round 6 but never applied to the leaf list. Entry-internal separators get
+    # the tolerance as well, so ``apps/./ops-mission-control/...`` matches.
+    _wp_gsep = r"(?:/(?:\.|[^/\s'\"]{1,64}/\.\.))*/"
+    wp_leaves = "|".join(
+        _wp_gsep.join(re.escape(part) for part in leaf.split("/"))
+        for leaf in _WRITE_PROTECTED_BASH_LEAVES
+    )
+    wp_prefixes_gsep = "|".join(
+        _wp_gsep.join(re.escape(part) for part in p.split("/"))
+        for p in _CREW_HOME_PREFIXES
+    )
     write_protected_path = (
         # trailing ``/`` is included so ``mkdir -p ~/.kiro/crew/.data-home-ready/x``
         # (which also MATERIALISES the marker as a directory, satisfying
         # ``marker.exists()``) is caught, not just the exact-leaf forms.
-        rf"{home_alts}/(?:{wp_prefixes})/(?:{wp_leaves})(?:/|\s|$|['\"])"
+        rf"(?:{home_alts}{_wp_gsep}(?:{wp_prefixes_gsep})"
+        # GPT round-40: the braced alternative only matched the BARE
+        # ``${KIROCREW_HOME}``, so every modified parameter expansion —
+        # ``${KIROCREW_HOME:0}``, ``:-default``, ``##*/``, ``%/``, ``/x/y`` — named
+        # the same directory and slipped past. The shell has a whole grammar of
+        # modifiers here; rather than enumerate them (the mistake this file has
+        # made repeatedly), the brace form now accepts ANY modifier text up to the
+        # closing brace. A modified expansion of this variable is refused whatever
+        # it does, which is the right default: the point of the fence is the
+        # variable, not the modifier.
+        rf"|\$KIROCREW_HOME|\$\{{KIROCREW_HOME[^}}]*\}}|%KIROCREW_HOME%)"
+        rf"{_wp_gsep}(?:{wp_leaves}){_PATH_END_OR_SEP}"
+    )
+    # Perpetual agents' LIFE.md: agents/<generated id>/LIFE.md — the id
+    # segment is dynamic, so this cannot live in the literal leaf list. Named
+    # verb-independently like the leaves above: writing one's own goal file
+    # is the self-modification the RFC hard-refuses (§6/Non-goals), and reads
+    # via bash are harmless (the prompt already carries the content).
+    #
+    # GPT round-6 hardening, both in this one branch:
+    #  * every separator is the POSIX ``gsep`` below (mirroring ``win_gsep``),
+    #    so canonical no-op spellings — ``agents/<id>/./LIFE.md``,
+    #    ``agents/x/../x/LIFE.md``, ``~/.kiro/./crew/...`` — still match;
+    #  * when ``KIROCREW_HOME`` re-anchors the data home, the live agents dir
+    #    is ``$KIROCREW_HOME/agents`` and carries NO home-anchored spelling,
+    #    so the resolved env root is added as an extra literal anchor (both
+    #    the expanded and realpath forms, matching the keystone-leaf duality
+    #    in ``_home_dir_targets_uncached``). The regex is process-cached, and
+    #    ``KIROCREW_HOME`` is fixed at process start, so build-time capture
+    #    is sound; tests that churn the env call ``_build_sensitive_regex``
+    #    directly, as the existing gate tests do.
+    gsep = r"(?:/(?:\.|[^/\s'\"]{1,64}/\.\.))*/"
+    # Separator-agnostic gsep for literal env-root forms: on a Windows host
+    # ``KIROCREW_HOME`` (and its realpath) is spelled with backslashes, so the
+    # env anchors must accept either separator plus the same no-op chains.
+    gsep_any = r"(?:[\\/](?:\.|[^\\/\s'\"]{1,64}[\\/]\.\.))*[\\/]"
+    # GPT round-19: the UNEXPANDED variable is an anchor in its own right.
+    # ``rm "$KIROCREW_HOME/crons.json"`` names the data home without any
+    # home-relative prefix and without the resolved literal, so every anchor
+    # built from the env VALUE missed it — the same way ``%USERPROFILE%`` is
+    # handled for the Windows branches rather than only the expanded path.
+    # Unconditional: the spelling means the data home whether or not this
+    # process has the variable set.
+    # Same round-40 widening as the write-protected anchor above: a MODIFIED
+    # parameter expansion names the same directory, so the brace form takes any
+    # modifier text. Both anchors are kept in step deliberately — the earlier
+    # rounds' lesson is that two spellings of one idea drift apart.
+    crew_home_var = r"(?:\$KIROCREW_HOME|\$\{KIROCREW_HOME[^}]*\}|%KIROCREW_HOME%)"
+    wp_prefixes_g = "|".join(re.escape(p).replace("/", gsep) for p in _CREW_HOME_PREFIXES)
+    life_anchor_alts = [
+        rf"{home_alts}{gsep}(?:{wp_prefixes_g})",
+        crew_home_var,
+    ]
+    _crew_env = os.environ.get("KIROCREW_HOME")
+    if _crew_env:
+        _env_forms = {os.path.abspath(os.path.expanduser(_crew_env))}
+        try:
+            _env_forms.add(os.path.realpath(os.path.expanduser(_crew_env)))
+        except (OSError, ValueError):
+            pass
+        for _form in sorted(_env_forms):
+            _parts = [p for p in re.split(r"[\\/]+", _form) if p]
+            _anchor = gsep_any.join(re.escape(p) for p in _parts)
+            if _form.startswith(("/", "\\")):
+                _anchor = gsep_any + _anchor
+            life_anchor_alts.append(_anchor)
+    agent_life_path = (
+        rf"(?:{'|'.join(life_anchor_alts)})"
+        rf"{gsep}agents{gsep}[^/\s'\"]+{gsep}LIFE\.md{_PATH_END}"
     )
     # Windows-native spellings of the same fenced dirs, matched in the RAW
     # command text. POSIX shlex consumes unquoted backslashes during
@@ -4616,7 +4762,7 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     # plain separator, so ``%APPDATA%\.\kiro-cli\data.sqlite3`` and
     # ``...\AppData\Roaming\..\Roaming\kiro-cli\...`` still name the store.
     win_sensitive_path = (
-        rf"{win_home_alts}{win_gsep}(?:{win_dirs_pattern})(?:{win_sep}|\s|$|['\"])"
+        rf"{win_home_alts}{win_gsep}(?:{win_dirs_pattern})(?:{win_sep}|\s|$|['\";&|)}},:<>])"
     )
     # ``%APPDATA%`` already points INTO ``AppData\Roaming``, so a spelling like
     # ``%APPDATA%\kiro-cli\data.sqlite3`` names a fenced store WITHOUT the
@@ -4637,7 +4783,93 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     # right after it is a canonical no-op specific to this anchor.
     appdata_sensitive_path = (
         rf"{appdata_var}(?:{win_sep}\.\.{win_sep}Roaming)*"
-        rf"{win_gsep}(?:{appdata_remainders})(?:{win_sep}|\s|$|['\"])"
+        rf"{win_gsep}(?:{appdata_remainders})(?:{win_sep}|\s|$|['\";&|)}},:<>])"
+    )
+    # GPT round-7 (BLOCKING): two spellings the round-6 branch still missed.
+    #
+    # (a) Windows-native direct spelling of the goal file — the POSIX branch
+    # above cannot see backslash separators or %USERPROFILE% anchors, exactly
+    # the gap ``win_sensitive_path`` closes for the fenced dirs. Same anchors,
+    # same ``win_gsep`` no-op chains, same crew prefixes.
+    crew_prefixes_win = "|".join(
+        win_gsep.join(re.escape(part) for part in p.split("/"))
+        for p in _CREW_HOME_PREFIXES
+    )
+    win_agent_life_path = (
+        rf"{win_home_alts}{win_gsep}(?:{crew_prefixes_win})"
+        rf"{win_gsep}agents{win_gsep}[^\\/\s'\"]+{win_gsep}LIFE\.md{_PATH_END}"
+    )
+    # (b) CHAINED RELATIVE writes: ``cd <crew agents dir> && echo x > LIFE.md``
+    # names the goal file only as a bare relative token, so no path-anchored
+    # branch can bind the two together. The two halves are compiled SEPARATELY
+    # and evaluated in :func:`is_sensitive_bash_command` behind a substring
+    # pre-guard, NOT as another alternation branch here: as two whole-command
+    # ``[\s\S]*`` lookaheads inside this pattern they re-scanned every command
+    # twice, and this matcher is already superlinear in command length
+    # (measured on main: 26ms at 1KB, 409ms at 4KB). Out here the check costs a
+    # C-speed ``in`` test on anything that does not name an agents directory.
+    #
+    # ``LIFE.md`` written with shell quote-splices (``LI''FE.md``,
+    # ``"LIFE".md``) is the same file, and this half matches RAW text no
+    # tokenizer has touched, so quote runs are tolerated inside the name with a
+    # bounded character class (GPT round-9). The path-anchored branches get the
+    # same coverage from the normalizer pass, which dequotes before checking.
+    global _AGENT_LIFE_DIR_RE, _AGENT_LIFE_LEAF_RE, _AGENT_LIFE_VAR_WRITE_RE
+    _AGENT_LIFE_DIR_RE = re.compile(
+        rf"(?:{'|'.join(life_anchor_alts)}){gsep}agents{_PATH_END_OR_SEP}"
+        rf"|{win_home_alts}{win_gsep}(?:{crew_prefixes_win})"
+        rf"{win_gsep}agents(?:{win_sep}|\s|$|['\";&|)}},:<>])",
+        re.IGNORECASE,
+    )
+    _AGENT_LIFE_LEAF_RE = re.compile(
+        _noise_tolerant("LIFE.md"),
+        re.IGNORECASE,
+    )
+    # GPT round-13: the same chained-relative shape, one directory up. After
+    # ``cd ~/.kiro/crew`` the fenced leaf is named as a BARE token
+    # (``printf … > crons.json``), so no path-anchored branch and no
+    # resolved-path check can bind the two — the normalizer resolves a relative
+    # token against the agent's cwd, not against a ``cd`` earlier in the same
+    # command line. Third appearance of this class in this file (the goal file
+    # in round 7, variable-derived targets in round 10), so it is handled the
+    # same way: a conjunction evaluated outside the big alternation, in write
+    # context only. The leaf half matches the final basename of each fenced
+    # entry, which is what a relative spelling leaves behind.
+    global _CREW_HOME_DIR_RE, _WP_LEAF_BASENAME_RE
+    _CREW_HOME_DIR_RE = re.compile(
+        rf"(?:{'|'.join(life_anchor_alts)})(?:{gsep}|{_PATH_END})"
+        rf"|{win_home_alts}{win_gsep}(?:{crew_prefixes_win})"
+        rf"(?:{win_sep}|{_PATH_END})",
+        re.IGNORECASE,
+    )
+    _WP_LEAF_BASENAME_RE = re.compile(
+        "(?:"
+        + "|".join(
+            _noise_tolerant(leaf.rsplit("/", 1)[-1])
+            for leaf in _WRITE_PROTECTED_BASH_LEAVES
+        )
+        + r")" + _PATH_END,
+        re.IGNORECASE,
+    )
+    # GPT round-10: variable indirection removes the literal entirely —
+    # ``cd <agents dir> && n=LIFE; echo hacked > "$n.md"`` names the goal file
+    # nowhere, and no static layer can resolve it (the value can come from the
+    # environment, a command substitution, or a read). Inside a command that
+    # ALREADY names a crew agents directory, a write whose target is
+    # variable-derived is therefore refused outright: the caller can always
+    # spell the path literally, and the alternative is a fence with a trivial
+    # bypass. Scoped to that conjunction, so ordinary variable-target writes
+    # elsewhere on the filesystem are untouched.
+    #
+    # Covers shell-level indirection: a redirect (with optional fd digits and
+    # quoting) or a write verb whose operand carries ``$`` / backtick / ``${``.
+    # It does NOT cover indirection built inside an embedded interpreter
+    # script (``python -c "open(f'{n}.md','w')"``) — that is unbounded static
+    # analysis, and the edit-tool gate plus the normalizer's resolved-path
+    # check remain the layers that catch those.
+    _AGENT_LIFE_VAR_WRITE_RE = re.compile(
+        r"(?:(?:^|[\s;&|(])\d*>>?\s*['\"]?[^\s;&|)]*[$`]"
+        r"|\b(?:tee|cp|mv|install|dd|truncate|ln|rsync)\b[^;&|]*[$`])",
     )
     return re.compile(
         # (1) verb/redirect-anchored, OR (2) verb-independent: the sensitive path
@@ -4654,6 +4886,8 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         rf"{sensitive_path}"
         rf"|(?:^|.*[\s'\"=:,;]){sensitive_path}"
         rf"|(?:^|.*[\s'\"=:,;]){write_protected_path}"
+        rf"|(?:^|.*[\s'\"=:,;]){agent_life_path}"
+        rf"|(?:^|.*[\s'\"=:,;]){win_agent_life_path}"
         # (4) Windows-native spelling, verb-independent (same token anchor):
         # covers quoted backslash paths AND embedded-script literals that the
         # tokenizing passes cannot see. (5) the %APPDATA% alias of the fenced
@@ -4665,6 +4899,17 @@ def _build_sensitive_regex() -> re.Pattern[str]:
 
 
 _SENSITIVE_RE: re.Pattern[str] | None = None
+# Halves of the chained-relative LIFE.md check, populated by
+# :func:`_build_sensitive_regex` (they share its anchor computation) and
+# evaluated by :func:`is_sensitive_bash_command`. Kept OUT of the big
+# alternation on purpose — see the comment at their assignment.
+_AGENT_LIFE_DIR_RE: re.Pattern[str] | None = None
+_AGENT_LIFE_LEAF_RE: re.Pattern[str] | None = None
+_AGENT_LIFE_VAR_WRITE_RE: re.Pattern[str] | None = None
+#: Halves of the chained-relative WRITE-PROTECTED-LEAF check (GPT round-13),
+#: same construction and rationale as the ``_AGENT_LIFE_*`` pair above.
+_CREW_HOME_DIR_RE: re.Pattern[str] | None = None
+_WP_LEAF_BASENAME_RE: re.Pattern[str] | None = None
 
 
 def _get_sensitive_re() -> re.Pattern[str]:
@@ -4989,7 +5234,26 @@ def path_contains_sensitive(dir_str: str, base_dir: str | None = None) -> bool:
     return False
 
 
-def is_sensitive_write_path(path_str: str, base_dir: str | None = None) -> bool:
+def _caller_agent_id(session_key: str | None) -> str | None:
+    """The perpetual-agent id owning ``session_key``, or None when unknown.
+
+    A perpetual agent runs under ``cron:<job.id>`` and its life directory is
+    ``agents/<job.id>`` (see ``cron._load_life_context``), so the session key is
+    what tells one agent's own journal from another's. Any other key shape — a
+    dashboard slot, a subagent, a webhook, an empty key — owns no life directory
+    and therefore owns no journal.
+    """
+    if not session_key:
+        return None
+    parts = session_key.split(":")
+    if len(parts) < 2 or parts[0] != "cron" or not parts[1]:
+        return None
+    return parts[1]
+
+
+def is_sensitive_write_path(
+    path_str: str, base_dir: str | None = None, session_key: str | None = None
+) -> bool:
     """Return True if the path must not be MODIFIED by an agent tool.
 
     Superset of :func:`is_sensitive_path`: everything that is read+write blocked
@@ -4999,9 +5263,149 @@ def is_sensitive_write_path(path_str: str, base_dir: str | None = None) -> bool:
     (``hooks.on_tool_call`` on the ACP ``edit`` kind) — see
     :data:`_WRITE_PROTECTED_HOME_PATHS` for the rationale.
     """
+    if _is_agent_life_md(path_str, base_dir):
+        return True
+    if _is_protected_agents_write(path_str, base_dir, session_key):
+        return True
     return _path_in_home_dirs(
         path_str, _SENSITIVE_HOME_DIRS + _WRITE_PROTECTED_HOME_PATHS, base_dir
     )
+
+
+def _is_protected_agents_write(
+    path_str: str, base_dir: str | None = None, session_key: str | None = None
+) -> bool:
+    """True for an agent WRITE anywhere under the perpetual-agent life root.
+
+    An ALLOWLIST, deliberately, and the sixth spelling of one class is why.
+    Every previous fence here keyed on the leaf NAME (``LIFE.md``), and each
+    round found another way to reach the same effect without writing that name:
+    quote splices, dot segments, variable composition, shell terminators, and
+    finally (GPT round-19) operating on the CONTAINER instead of the leaf —
+    ``mv <staged dir> agents/<id>``, ``mkdir agents/<id>``, or moving ``agents``
+    itself aside and rebuilding it. A denylist of spellings cannot converge on
+    that; an allowlist can, so the rule is inverted: under the agents root the
+    agent may write exactly ``JOURNAL.md`` and nothing else.
+
+    Scope notes:
+      * WRITE only. This is reached from :func:`is_sensitive_write_path` and
+        from the normalizer's write-context branch, never from the read gate —
+        ``ls`` of the directory and ``cat`` of a journal stay allowed, which is
+        what makes the rule affordable.
+      * ``JOURNAL.md`` is the one allowed leaf because the agent's own record
+        must stay appendable; that is the §6 split (goal read-only, journal
+        agent-owned).
+      * The root itself and every intermediate directory are covered, so
+        replacing or renaming the container is refused as well as writing into
+        it.
+      * The operator is unaffected: this gate applies to the agent's own file
+        and shell tools, not to the product's writers or a human editor.
+    """
+    try:
+        raw = Path(path_str).expanduser()
+        if not raw.is_absolute() and base_dir:
+            raw = Path(base_dir) / raw
+        resolved = Path(os.path.realpath(raw))
+    except (OSError, ValueError):
+        return True  # unresolvable path aimed at this subtree: fail closed
+    if resolved.name.casefold() == "journal.md":
+        # GPT round-27: this exemption was not OWNER-scoped, so agent A could
+        # overwrite agent B's JOURNAL.md — and the journal is read back into its
+        # owner's next prompt, making the write a cross-agent prompt-injection
+        # channel. This is the WRITE side of the same threat round 15 closed on
+        # the READ side (a symlinked <job.id> pulling a victim's LIFE.md into
+        # this job's prompt).
+        #
+        # The exemption now requires the journal to sit in the CALLER's own life
+        # directory. No identity means no exemption: the caller cannot prove it
+        # owns the file, so it is treated like any other write in this subtree.
+        # That is the positive form the round-24 lesson demands — never "allowed
+        # unless someone else's id is named".
+        owner = _caller_agent_id(session_key)
+        if owner is not None and resolved.parent.name == owner:
+            return False
+    roots: list[Path] = [Path.home() / prefix / "agents" for prefix in _CREW_HOME_PREFIXES]
+    crew_env = os.environ.get("KIROCREW_HOME")
+    if crew_env:
+        try:
+            roots.append(Path(crew_env).expanduser() / "agents")
+        except (OSError, ValueError):
+            pass
+    for root in roots:
+        try:
+            real_root = Path(os.path.realpath(root))
+        except (OSError, ValueError):
+            continue
+        if resolved == real_root or real_root in resolved.parents:
+            return True
+        # GPT round-41: the DATA HOME ITSELF was unprotected —
+        # ``mv ~/.kiro/crew ~/crew-stolen`` and ``rm -rf ~/.kiro/crew`` were both
+        # allowed. Relocating it defeats every fence in this module at once, since
+        # they all key on the canonical path: the relocated tree holds the same
+        # credentials, governance policy and store, now outside every anchor.
+        # Deleting it destroys the whole schedule and the agents' goal files.
+        #
+        # Only the root ITSELF is added. Writes to CHILDREN
+        # (``touch <home>/sessions.db``) name a child, not the root, so the pinned
+        # everyday behaviour is untouched — verified, not assumed.
+        #
+        # Cost: ``cp -r ~/.kiro/crew /tmp/copy`` is refused too, because a copy
+        # names the home as an argument of a write verb. That shape is
+        # exfiltration of the whole data home; ``kirocrew snapshot`` is the
+        # supported way to back it up.
+        if resolved == real_root.parent:
+            return True
+    return False
+
+
+def _is_agent_life_md(path_str: str, base_dir: str | None = None) -> bool:
+    """True when the path is a perpetual agent's ``LIFE.md``.
+
+    ``agents/<id>/LIFE.md`` under any crew home prefix is the agent's GOAL
+    file — §6 of the perpetual-agent RFC: owner is the human, the agent may
+    read it every wake and may never write it. An auto-approved perpetual
+    agent that could rewrite its own LIFE.md would self-modify its goal and
+    boundaries and ingest them on the very next wake. The middle segment is
+    the generated job id, so this cannot be expressed as a literal entry in
+    :data:`_WRITE_PROTECTED_HOME_PATHS`; the shape check lives here instead.
+    Reads stay allowed (the whole point of the file), and JOURNAL.md in the
+    same directory stays agent-writable.
+    """
+    try:
+        raw = Path(path_str).expanduser()
+        if not raw.is_absolute() and base_dir:
+            raw = Path(base_dir) / raw
+        resolved = Path(os.path.realpath(raw))
+    except (OSError, ValueError):
+        return True  # unresolvable path aimed at a guarded name: fail closed
+    if resolved.name.casefold() != "life.md":
+        return False
+    parent = resolved.parent
+    agents_roots = [Path.home() / prefix / "agents" for prefix in _CREW_HOME_PREFIXES]
+    # GPT round-6: when KIROCREW_HOME re-anchors the data home, the live
+    # agents directory is ``$KIROCREW_HOME/agents`` — NOT under either
+    # default crew prefix. Without this anchor both guards permit a write to
+    # the real goal file whenever the env override is set (the same gap the
+    # keystone leaves close in ``_home_dir_targets_uncached``). The default
+    # ``~``-rooted forms stay, so every location is always covered.
+    crew_env = os.environ.get("KIROCREW_HOME")
+    if crew_env:
+        try:
+            agents_roots.append(Path(crew_env).expanduser() / "agents")
+        except (OSError, ValueError):
+            pass
+    for root in agents_roots:
+        try:
+            # Casefolded comparison: on case-insensitive filesystems
+            # (macOS/Windows) a re-cased spelling still names the same
+            # directory. Over-matching on a case-SENSITIVE filesystem (two
+            # dirs differing only by case) is the documented fail-safe
+            # direction — the guarded name is machine-generated lowercase.
+            if str(parent.parent).casefold() == os.path.realpath(root).casefold():
+                return True
+        except (OSError, ValueError):
+            continue
+    return False
 
 
 def sensitive_home_dirs() -> tuple[str, ...]:
@@ -5052,7 +5456,7 @@ _EXTRACT_INTO_TRUST_ROOT_RE = re.compile(
     + re.escape(str(Path.home()))
     + r")(?:"
     + _CREW_HOME_ALT
-    + r")(?:/[^\s]*)?(?:\s|$|['\"])",
+    + r")(?:/[^\s]*)?" + _PATH_END + r"",
     re.IGNORECASE,
 )
 
@@ -5142,6 +5546,64 @@ _NORMALIZER_READ_VERBS: frozenset[str] = frozenset(
 # same fidelity as reading it. npm's own fs.link() never transits this gate.
 _LINK_CREATE_VERBS: frozenset[str] = frozenset({"ln", "link"})
 
+#: Write verbs the normalizer pass uses as COARSE write context for the
+#: write-protected check (GPT round-12), plus the token-level tests the
+#: conjunction checks share.
+#:
+#: GPT round-30: this used to be a hand-maintained frozenset with a comment
+#: asking the reader to "keep it in sync with ``_WRITE_CMDS``' verb list". That
+#: sync failed — ``chmod``, ``chown``, ``touch``, ``gzip``, ``cpio`` and
+#: ``patch`` were all in the regex and missing here, so ``cd ~/.kiro/crew &&
+#: chmod 000 crons.json`` read as no write context and the store could be made
+#: unreadable. Three separate rounds have now reported a verb this set was
+#: missing, which is what a "keep in sync" comment buys.
+#:
+#: So it is DERIVED from :data:`_WRITE_CMDS` instead: that regex is the single
+#: authority for "which commands mutate", and any verb added there is picked up
+#: here mechanically. Drift is no longer possible.
+#:
+#: Two deliberate deviations from the regex, both additive:
+#:   * ``cp``/``unlink``/``shred`` are token-only verbs the regex does not list;
+#:   * ``git <subcommand>`` alternatives are dropped, because a bare ``git`` word
+#:     is not a write and the subcommand words (``rm``, ``mv``, ``checkout``…)
+#:     are matched on their own anyway.
+
+
+def _verbs_from_write_cmds_regex(pattern: str) -> frozenset[str]:
+    """Extract the bare verb alternatives from the ``_WRITE_CMDS`` regex source.
+
+    Kept mechanical on purpose: the regex is the authority, and this reads it
+    rather than restating it. Alternatives carrying whitespace or nested groups
+    (the ``git <sub>`` form) are skipped — see the note above.
+    """
+    # Remove NESTED groups first. Without this the ``git (?:checkout|restore|…)``
+    # alternative is torn apart and its middle members leak in as standalone
+    # verbs while its first and last do not.
+    body = re.sub(r"\(\?:[^()]*\)", " ", pattern)
+    # Then drop the group decoration itself. Deliberately NOT a prefix/suffix
+    # strip: _WRITE_CMDS ends with ``)\s``, and a strip that assumed a bare
+    # trailing ``)`` silently left ``(?:tee`` as the first alternative, which is
+    # not alpha and so DROPPED ``tee`` — the set became weaker than the hand-
+    # written one it replaced. The test that pins regex ⊆ token-set caught it.
+    body = body.replace("(?:", " ").replace(")", " ")
+    out: set[str] = set()
+    for alt in body.split("|"):
+        alt = alt.strip()
+        # ``\s`` escapes are left intact on purpose: it is what makes ``git\s+``
+        # non-alpha, so a bare ``git`` (not a write on its own) stays out.
+        if not alt or not alt.isalpha():
+            continue
+        out.add(alt.casefold())
+    return frozenset(out)
+
+
+_NORMALIZER_WRITE_VERBS: frozenset[str] = _verbs_from_write_cmds_regex(_WRITE_CMDS) | {
+    # token-only verbs, not in the regex
+    "cp",
+    "unlink",
+    "shred",
+}
+
 # Shell redirection operators attached without a space (``>~/path``,
 # ``>>~/path``, ``2>~/path``, ``2>>~/path``, ``<~/path``).  shlex keeps these
 # as a single token; we strip the operator prefix to expose the path for
@@ -5150,8 +5612,653 @@ _LINK_CREATE_VERBS: frozenset[str] = frozenset({"ln", "link"})
 # since that takes a delimiter word, not a path.
 _REDIR_PREFIX_RE = re.compile(r"^\d*(?:>>?|<(?!<))")
 
+#: A token that is ONLY a redirect operator — the spaced form ``> path``, where
+#: shlex hands the operator and the path over as two tokens. Output redirects
+#: only (``>``/``>>``, optional fd digits): a ``<`` input redirect is a read and
+#: must not count as write context. Used by the normalizer pass to decide that
+#: the NEXT token is a write target.
+_REDIR_OP_ONLY_RE = re.compile(r"^\d*>>?$")
 
-def is_sensitive_bash_command(command: str) -> str | None:
+#: An OUTPUT redirect anywhere in the command (optional fd digits, ``>``/``>>``),
+#: excluding the ``2>&1``-style fd duplication that redirects no file. Used as
+#: the write-context signal; ``<`` is a read and is deliberately absent.
+#: An output redirect. GPT round-31: this used to require a whitespace/operator
+#: boundary BEFORE the operator, so ``echo -n>crons.json`` — a redirect glued to
+#: the preceding word — was not write context and the store could be truncated.
+#: The shell needs no separator there, so neither does this. Same root cause as
+#: round 25's ``&&rm``: a matcher that assumed spaces the shell does not require.
+#:
+#: ``>&`` (fd duplication) stays excluded, and ``<`` is a read.
+_WRITE_REDIR_RE = re.compile(r"\d*>>?(?!&)")
+
+#: A quoted span. Dropping the boundary requirement above means a ``>`` inside
+#: quoted DATA would read as an operator — ``grep 'a->b' crons.json`` would have
+#: become write context and a READ of a fenced leaf would be refused, which is
+#: the read-blocking failure this module must never commit. Quoted spans are
+#: therefore blanked before the redirect test: inside quotes ``>`` is text.
+_QUOTED_SPAN_RE = re.compile(r"'[^']*'|\"[^\"]*\"")
+
+
+def _blank_quoted_spans(command: str) -> str:
+    """Replace quoted spans with spaces, preserving length.
+
+    A redirect written OUTSIDE the quotes (``echo x >'crons.json'``) is
+    untouched, because only the span between the quotes is blanked.
+    """
+    return _QUOTED_SPAN_RE.sub(lambda m: " " * len(m.group(0)), command)
+
+
+#: A command whose ONLY write is a journal append. Used to keep the one allowed
+#: write under the agents root (the agent's own record) working while every
+#: other write there is refused.
+#:
+#: GPT round-24: the first cut of this asked "a journal is mentioned AND LIFE.md
+#: is not" — a denylist nested inside an allowlist, which is the exact shape this
+#: module has lost to repeatedly. ``rm -rf -- * && echo e >> JOURNAL.md`` names
+#: no fenced leaf at all, so it sailed through the allowance and deleted LIFE.md
+#: via a glob. The allowance now requires, positively:
+#:
+#:   1. no write VERB anywhere in the command (``_NORMALIZER_WRITE_VERBS`` already
+#:      covers rm/rmdir/mv/cp/mkdir/tee/dd/truncate/…), so nothing can mutate by
+#:      verb regardless of how the target is spelled or globbed; and
+#:   2. every redirect target is a journal basename.
+#:
+#: An append to the journal needs neither a verb nor a second target, so the one
+#: legitimate command satisfies both without an exception list.
+#: The id segment of an explicit agents path (``…/agents/<id>/JOURNAL.md`` or a
+#: chained ``cd …/agents/<id>``). Used to owner-scope the journal allowance
+#: whenever the command spells an id out. No trailing separator is required, so
+#: the ``cd`` form matches as well as the file form.
+#: A dot segment in a path (``/../``, ``/./``, or a trailing ``/..``). Any of these
+#: makes a text-level id comparison meaningless, so the journal allowance refuses
+#: rather than trying to canonicalise the text itself.
+#: A relative ``agents/<something>`` segment, for a command that names the crew
+#: home separately. GPT round-35: ``cd ~/.kiro/crew && echo x >> agents/job999/
+#: JOURNAL.md`` reaches the subtree without the anchored ``<crew home>/agents``
+#: spelling that :data:`_AGENT_LIFE_DIR_RE` requires, so the subtree conjunction
+#: never fired. Same chained-relative shape round 23 solved for the store leaf,
+#: one directory down.
+_RELATIVE_AGENTS_SEG_RE = re.compile(r"(?:^|[\s;&|(=])agents[\\/]", re.IGNORECASE)
+
+
+def _names_agents_subtree(command: str) -> bool:
+    """True when the command reaches the perpetual-agent subtree, anchored or not."""
+    if _AGENT_LIFE_DIR_RE is not None and _AGENT_LIFE_DIR_RE.search(command):
+        return True
+    return bool(
+        _CREW_HOME_DIR_RE is not None
+        and _CREW_HOME_DIR_RE.search(command)
+        and _RELATIVE_AGENTS_SEG_RE.search(command)
+    )
+
+
+#: An interpreter invoked with an INLINE payload (``-c``/``-e``/``-E``). Distinct
+#: from :data:`_INLINE_INTERPRETER_RE`, which matches any interpreter invocation:
+#: here the program text is inside the command, so its write target is opaque by
+#: construction and cannot be attributed even in principle.
+_INLINE_PAYLOAD_INTERPRETER_RE = re.compile(
+    r"(?:^|[\s;&|(/])"
+    r"(?:python[\d.]*|perl|ruby|node|deno|bun|php|sh|bash|zsh|ksh|dash|osascript|pwsh"
+    r"|powershell)"
+    r"(?:\.exe)?\s+(?:-\w*[ceE]\w*)(?:\s|$)",
+    re.IGNORECASE,
+)
+
+
+def _cd_target_is_crew_home(command: str) -> bool:
+    """True when a ``cd``/``pushd`` in the command targets the crew home.
+
+    The distinction that keeps the round-37 fence narrow: the crew home being the
+    WORKING DIRECTORY means any relative write lands in the store, whereas the
+    crew home merely appearing as an argument (``python3 <crew home>/crons/x.py``)
+    is the product's own supported shape.
+    """
+    if _CREW_HOME_DIR_RE is None:
+        return False
+    for m in re.finditer(r"(?:^|[\s;&|(])(?:cd|pushd)\s+([^\s;&|)]+)", command):
+        if _CREW_HOME_DIR_RE.search(m.group(1).replace("'", "").replace('"', "")):
+            return True
+    return False
+
+
+#: The Kiro root, matched WITHOUT the ``crew`` substring the crew-home anchors
+#: need. GPT round-43: composing the directory name from variables
+#: (``~/.kiro/$d$e/``) skipped the literal pre-guard that gates the crew-home
+#: conjunction, so the composed-leaf fence from round 16 never ran.
+_KIRO_ROOT_DIR_RE = re.compile(
+    r"(?:^|[\s;&|(=\"'])(?:~|\$HOME|\$\{HOME[^}]*\}|%USERPROFILE%)/\.kiro(?:/|\b)"
+    r"|(?:^|[\s;&|(=\"'])/(?:home|Users)/[^/\s]+/\.kiro(?:/|\b)",
+    re.IGNORECASE,
+)
+
+#: GPT round-44: both of these were written with ``/`` only, so on Windows —
+#: where the shell's separator is ``\`` — a foreign agent id (``agents\job999``)
+#: and a traversal (``job111\..\job999``) were invisible to the owner check. The
+#: platform difference is not a reason for a second pattern: both accept either
+#: separator.
+_PATH_SEP_CLS = r"[\\/]"
+_DOT_SEGMENT_RE = re.compile(rf"(?:^|{_PATH_SEP_CLS})\.\.?(?:{_PATH_SEP_CLS}|$)")
+
+_AGENTS_ID_IN_PATH_RE = re.compile(
+    rf"{_PATH_SEP_CLS}agents{_PATH_SEP_CLS}([^\\/\s;&|)<>]+)", re.IGNORECASE
+)
+
+_REDIR_TARGET_RE = re.compile(r"\d*>>?(?!&)\s*([^\s;&|)<>]+)")
+_JOURNAL_BASENAME_RE = re.compile(r"(?:^|[\\/])journal\.md$", re.IGNORECASE)
+
+
+def _is_journal_only_write(command: str, session_key: str | None = None) -> bool:
+    """True when the command's only write is an append to a journal.
+
+    GPT round-26: this asked only "no write VERB", so it missed the other signal
+    the module already counts as a write — an INTERPRETER invocation (round 22).
+    ``cd …/agents/<id> && python /tmp/wipe.py && echo e >> JOURNAL.md`` therefore
+    kept the allowance and deleted LIFE.md. The allowance was WIDER than the
+    module's own notion of a write, which is a drift bug, not a missing pattern.
+
+    So it is now expressed in terms of that notion rather than a list of signals:
+    strip the redirects out of the command, and if the REMAINDER still carries
+    write context, the command does more than append and the allowance does not
+    hold. Any future signal added to :func:`_command_has_write_context` is picked
+    up here automatically instead of having to be remembered a second time.
+
+    Consequence worth naming: an interpreter-wrapped append
+    (``bash -lc 'echo x >> JOURNAL.md'``) is refused inside the agents subtree. An
+    interpreter can do anything once running, so its redirect text cannot earn the
+    allowance — the plain and chained-``cd`` append forms are the supported ones.
+    """
+    targets = _REDIR_TARGET_RE.findall(command)
+    if not targets:
+        return False
+    # Quotes are stripped before the basename test for the reason the leaf
+    # matchers are quote-tolerant: ``JOUR''NAL.md`` is the same file to the
+    # shell, and an existing test pins it as an allowed append. Stripping them
+    # from the TARGET is narrower than making the pattern quote-tolerant — the
+    # comparison stays an exact basename match.
+    if not all(
+        _JOURNAL_BASENAME_RE.search(t.replace("'", "").replace('"', "").strip())
+        for t in targets
+    ):
+        return False
+    # GPT round-27, owner scoping. When the command names an agents directory id
+    # EXPLICITLY — in a redirect target OR in a chained ``cd`` — that id must be
+    # the caller's own, otherwise this writes into another agent's journal, which
+    # is read back into that agent's next prompt. Scanning the WHOLE command is
+    # what catches ``cd …/agents/<other> && echo … >> JOURNAL.md``, where the
+    # victim id never appears in the target itself. A command that names no id is
+    # left to the path-level check, which resolves it.
+    owner = _caller_agent_id(session_key)
+    unquoted = command.replace("'", "").replace('"', "")
+    # GPT round-32: a DOT SEGMENT defeats an id comparison made on text.
+    # ``cd ~/.kiro/crew/agents/job111/../job999 && echo … >> JOURNAL.md`` matched
+    # the owner's own id first and kept the allowance while landing in the
+    # victim's directory. The path level was never fooled — it resolves with
+    # ``os.path.realpath`` — but the chained-``cd`` form leaves a bare relative
+    # target that the path level never sees, so the text check has to hold here.
+    #
+    # Rather than trying to canonicalise text (the same losing game as matching
+    # leaf names), the allowance simply requires canonical paths: a journal
+    # append never needs ``.`` or ``..``, so any dot segment means no exemption.
+    if _DOT_SEGMENT_RE.search(unquoted):
+        return False
+    if any(m.group(1) != owner for m in _AGENTS_ID_IN_PATH_RE.finditer(unquoted)):
+        return False
+    # GPT round-35: a RELATIVE target carries the victim id without the
+    # ``/agents/`` prefix the scan above keys on —
+    # ``cd …/agents && echo injected >> job999/JOURNAL.md``. So each target's
+    # directory part must be either empty (a bare ``JOURNAL.md``, whose directory
+    # is whatever the command's own ``cd`` established and is covered by the id
+    # scan) or an explicit path that names the caller's own agents directory.
+    # Anything else — a relative subdirectory, an unrelated absolute path — cannot
+    # be attributed from the text, so the allowance does not hold.
+    for t in targets:
+        clean = t.replace("'", "").replace('"', "").strip()
+        # Split on EITHER separator (round 44): a Windows-style target carries the
+        # id after a backslash, which a ``/``-only split treats as one flat name.
+        _norm = clean.replace("\\", "/")
+        head, sep, _leaf = _norm.rpartition("/")
+        if not sep:
+            continue  # bare filename: no directory component to verify
+        if owner and _AGENTS_ID_IN_PATH_RE.search(f"{head}/"):
+            continue  # explicit …/agents/<owner>/ — already id-checked above
+        return False
+    return not _command_has_write_context(_REDIR_TARGET_RE.sub(" ", command))
+
+
+#: An INTERPRETER invocation of any shape. Used as write context.
+#:
+#: Round 21 matched only the inline ``-c``/``-e`` form and explicitly pinned
+#: ``python /tmp/script.py`` as NOT write context. Round 22 reverses that: a
+#: script file mutates exactly as well as an inline payload, and the argument
+#: naming the target sits in the command line either way
+#: (``cd ~/.kiro/crew && python /tmp/rewrite.py crons.json``). The earlier
+#: distinction was a distinction without a difference — where the program text
+#: lives says nothing about whether it writes — so the rule keys on "an
+#: interpreter is running" instead.
+#:
+#: This is liberal on purpose and affordable because of where it is consumed:
+#: the flag only GATES conjunctions that already require the command to name the
+#: crew home or the agents subtree, so an interpreter run anywhere else is
+#: untouched. ``sh``/``bash`` are included because ``sh -c '…>x'`` hides a
+#: redirect from the outer tokenizer as effectively as a Python payload.
+#:
+#: The name must be a complete word (the trailing lookahead), so ``node_modules``
+#: and similar path segments do not match.
+_INLINE_INTERPRETER_RE = re.compile(
+    r"(?:^|[\s;&|(/])"
+    r"(?:python[\d.]*|perl|ruby|node|deno|bun|php|sh|bash|zsh|ksh|dash|osascript|pwsh|powershell)"
+    r"(?:\.exe)?(?=\s|$)",
+    re.IGNORECASE,
+)
+
+
+#: Shell word separators for verb tokenization: whitespace plus the operators that
+#: end a command word without needing a space around them.
+_SHELL_WORD_SPLIT_RE = re.compile(r"[\s;&|()`\n<>]+")
+
+
+def _command_words(command: str) -> list[str]:
+    """Split a command into words and reduce each to its bare program name.
+
+    GPT round-25 reported ``cd ~/.kiro/crew && /bin/rm -f crons.json``: the verb
+    test was a substring membership check on a space-delimited string, so a
+    PATH-QUALIFIED verb never matched. Probing that finding turned up two more
+    spellings of the same root cause — ``cd ~/.kiro/crew&&rm …`` (an operator ends
+    a word without a space, so the ``" rm "`` window never forms) and ``'rm'``
+    (quotes break the window too).
+
+    All three are the same bug, so the fix is one shape change rather than three
+    patterns: split on whitespace AND the shell operators, strip quotes, and take
+    the path basename, then compare EXACTLY against the verb set. Exact matching
+    after basename is what keeps ``scp`` from reading as ``cp``.
+    """
+    words: list[str] = []
+    for raw in _SHELL_WORD_SPLIT_RE.split(command.lower()):
+        w = raw.replace("'", "").replace('"', "").strip()
+        if not w:
+            continue
+        # A trailing slash would empty the basename; rsplit handles both forms.
+        words.append(w.rsplit("/", 1)[-1] if "/" in w else w)
+        # GPT round-28: ``--output=crons.json`` is one shell word, so a flag
+        # compared whole never matched it. Emit the flag half as its own word so
+        # the conditional verb table sees ``--output`` in both spellings. The
+        # value half is deliberately NOT emitted as a word — it is a path, and
+        # paths are the normalizer's job, not the verb table's.
+        if w.startswith("-") and "=" in w:
+            words.append(w.split("=", 1)[0])
+    return words
+
+
+#: Programs that mutate only when given a particular flag, mapped to the flags
+#: that make them do so.
+#:
+#: GPT round-27: ``cd ~/.kiro/crew && find . -name crons.json -delete`` was
+#: allowed. ``find`` cannot go in :data:`_NORMALIZER_WRITE_VERBS` — it is
+#: overwhelmingly a READ, and making it unconditional write context would turn
+#: write-protection into read-blocking for ``find . -name '*.json'`` inside the
+#: crew home, which is the one thing these conjunctions must never do.
+#:
+#: So the verb set gains a second, conditional half rather than a looser first
+#: half. The ``-exec`` family is listed even though round 25's tokenizer already
+#: catches ``-exec rm`` through the inner verb: relying on the inner program
+#: being in the set makes this a denylist dependency, and ``-delete`` proved that
+#: dependency wrong once already.
+_CONDITIONAL_WRITE_VERBS: dict[str, frozenset[str]] = {
+    "find": frozenset(
+        {
+            "-delete",
+            "-exec",
+            "-execdir",
+            "-ok",
+            "-okdir",
+            # these predicates write a file directly
+            "-fprintf",
+            "-fprint",
+            "-fprint0",
+            "-fls",
+        }
+    ),
+    # GPT round-28: a FETCHER with an output flag writes a file just as surely as
+    # ``tee`` does — ``cd ~/.kiro/crew && curl -o crons.json file:///tmp/evil``
+    # replaces the store from attacker-controlled bytes. Same conditional shape
+    # as ``find``: the program alone is a read (a bare ``curl`` prints to stdout),
+    # the flag is what makes it a write.
+    #
+    # Flags are compared case-insensitively because :func:`_command_words`
+    # lowercases, which merges e.g. curl's ``-O`` into ``-o``. Both write, so the
+    # merge is conservative in the safe direction for every program listed here.
+    "curl": frozenset({"-o", "--output", "--output-dir", "--remote-name", "--create-dirs"}),
+    "wget": frozenset(
+        {"-o", "--output-file", "--output-document", "-p", "--directory-prefix"}
+    ),
+    "openssl": frozenset({"-out", "-keyout"}),
+    "gpg": frozenset({"-o", "--output"}),
+    # GPT named curl/wget/openssl/gpg; probing the same shape found sort, which
+    # writes in place with -o and is otherwise a read.
+    "sort": frozenset({"-o", "--output"}),
+    # sqlite3's writing dot-commands. Same mostly-read/flag-writes shape as find:
+    # `.tables`/`.schema`/`.dump` are reads, these name a file they will write.
+    "sqlite3": frozenset(
+        {".output", ".once", ".import", ".backup", ".clone", ".save", ".excel", ".log"}
+    ),
+    "gunzip": frozenset({"-o", "--output"}),
+    "xz": frozenset({"-o", "--output"}),
+    # GPT round-34 probe: ``git`` is a read for log/diff/status and a WRITE for
+    # these subcommands. The conditional table is the right home — the derived
+    # verb set cannot hold them, because round 30 drops the nested
+    # ``git (?:checkout|…)`` group whole so a bare ``checkout`` is not a verb.
+    "git": frozenset(
+        {
+            "checkout",
+            "switch",
+            "restore",
+            "reset",
+            "revert",
+            "apply",
+            "clean",
+            "rm",
+            "mv",
+            "stash",
+            "commit",
+            "merge",
+            "rebase",
+            "cherry-pick",
+            "gc",
+            "prune",
+            "worktree",
+            "init",
+            "clone",
+            "fetch",
+            "pull",
+        }
+    ),
+}
+
+
+#: Programs that only READ. Used to invert the write-context question inside the
+#: protected directories (GPT round-33).
+#:
+#: Every previous round enumerated things that WRITE — a verb set, a conditional
+#: flag table — and each time the report was another spelling the enumeration did
+#: not contain. ``cd ~/.kiro/crew && /tmp/rewrite crons.json`` ends that line of
+#: patching: an arbitrary executable cannot be enumerated, and I said as much in
+#: the round-29 disposition. So inside a command that already names a protected
+#: directory AND a fenced leaf, the question flips: write context is the DEFAULT,
+#: and only a command whose every program is known-read is treated as a read.
+#:
+#: Deliberately conservative membership:
+#:   * interpreters are NOT here — running one is write context (round 22);
+#:   * ``sed``/``awk`` are not here — they mutate (sed) or can redirect internally;
+#:   * anything that can EXECUTE another program is not here (``xargs``, ``env``):
+#:     the program-extraction step only sees the first word of a segment, so
+#:     ``echo crons.json | xargs /tmp/rewrite`` would otherwise read as ``xargs``;
+#:   * anything that writes a file WITHOUT a redirect is not here, even when its
+#:     common use is a read: ``xxd in out`` and ``xxd -r`` write by ARGUMENT
+#:     POSITION, which no flag table can express, and ``yq -i`` edits in place.
+#:     Cost, stated plainly: ``xxd crons.json`` and ``yq . crons.json`` — genuine
+#:     reads — are now refused inside the protected directories. Neither is in the
+#:     pinned everyday set, and a hex dump of the store is not worth a hole;
+#:   * ``tee`` is NOT here. It was, which was a straight contradiction: ``tee`` is
+#:     in the derived WRITE verb set. The verb half caught it anyway, so nothing
+#:     leaked, but a member that both halves disagree about is a latent bug;
+#:   * ``sqlite3`` IS here, but its WRITING dot-commands are in
+#:     :data:`_CONDITIONAL_WRITE_VERBS`. Round 33 kept it unconditionally and filed
+#:     its write ability under the sandbox class — wrong, because
+#:     ``sqlite3 … '.output crons.json' …`` NAMES the target. Round 35 removed it
+#:     outright, which round 37 then showed breaks
+#:     test_normal_crew_access_not_overblocked once the crew-home branch stopped
+#:     requiring a resolvable leaf. It belongs in the same mostly-read/flag-writes
+#:     shape as ``find`` and ``curl``. Raw SQL that mutates ``sessions.db`` itself
+#:     stays out of reach of text parsing — but that is not a fenced leaf, so the
+#:     store fence is unaffected;
+#:   * ``git`` IS here for ``log``/``diff``/``status``, but its mutating
+#:     subcommands are handled by :data:`_CONDITIONAL_WRITE_VERBS`. Round 33's
+#:     comment claimed the derived verb set already covered them — it did not:
+#:     round 30 drops the nested ``git (?:checkout|…)`` group WHOLE, so those
+#:     words are not verbs on their own. ``git checkout -- crons.json`` was
+#:     allowed. A comment asserting something the code does not do is the same
+#:     failure round 30 fixed, one level up.
+_KNOWN_READ_PROGRAMS: frozenset[str] = frozenset(
+    {
+        "cd",
+        "pushd",
+        "popd",
+        "ls",
+        "dir",
+        "cat",
+        "bat",
+        "head",
+        "tail",
+        "wc",
+        "less",
+        "more",
+        "grep",
+        "egrep",
+        "fgrep",
+        "zgrep",
+        "rg",
+        "cut",
+        "uniq",
+        "comm",
+        "diff",
+        "cmp",
+        "file",
+        "stat",
+        "du",
+        "df",
+        "basename",
+        "dirname",
+        "realpath",
+        "readlink",
+        "md5sum",
+        "sha1sum",
+        "sha256sum",
+        "cksum",
+        "jq",
+        "sqlite3",
+        "git",
+        # Programs whose DEFAULT is a read and whose write needs a flag: their
+        # flags live in _CONDITIONAL_WRITE_VERBS, so both halves agree.
+        # ``wget``, ``gunzip`` and ``xz`` are deliberately NOT here — each WRITES
+        # by default (wget saves to cwd, gunzip/xz replace the input file), so
+        # they are not mostly-read and must stay unrecognized.
+        "curl",
+        "openssl",
+        "gpg",
+        "echo",
+        "printf",
+        "true",
+        "false",
+        "test",
+        "date",
+        "pwd",
+        "which",
+        "type",
+        "find",
+        "sort",
+        "tr",
+        "column",
+        "od",
+        "strings",
+        "nl",
+    }
+)
+
+#: Wrappers that PREFIX another command; the program that matters is the next
+#: word, so these are stepped over rather than treated as the program.
+_COMMAND_WRAPPERS: frozenset[str] = frozenset(
+    {"sudo", "nohup", "time", "command", "nice", "ionice", "stdbuf", "timeout", "env"}
+)
+
+
+#: Directories a known-read program may legitimately come from. GPT round-33
+#: follow-up, found by probing: basenaming alone trusts the NAME, so
+#: ``cd ~/.kiro/crew && /tmp/x/cat crons.json`` — an attacker-placed binary named
+#: ``cat`` — was read as the real ``cat``. A path-qualified program is only
+#: trusted from a standard system bin; anything else is unrecognized whatever it
+#: is called. A bare name (resolved via PATH) is trusted only when the command
+#: does not rewrite its own resolution environment — see
+#: :data:`_RESOLUTION_VAR_ASSIGN_RE`. Round 33 asserted here that PATH control was
+#: "a different threat this text gate cannot see"; that was wrong for the case
+#: where the assignment sits in the command being judged, and round 36 corrects it.
+_TRUSTED_BIN_DIRS: frozenset[str] = frozenset(
+    {"/bin", "/usr/bin", "/usr/local/bin", "/sbin", "/usr/sbin", "/opt/homebrew/bin"}
+)
+
+
+def _program_words(command: str) -> list[str]:
+    """The program invoked by each segment of a compound command.
+
+    Only the FIRST word of each segment is a program; the rest are flags and
+    paths. Leading ``VAR=value`` assignments and wrapper programs are stepped
+    over. A program given with a path keeps a marker unless that path is a
+    trusted system bin, so ``/tmp/x/cat`` cannot masquerade as ``cat``.
+    """
+    progs: list[str] = []
+    # Strip redirect operators (including fd duplication) BEFORE splitting.
+    # Without this, ``cat x 2>&1`` splits on the ``&`` and leaves a segment whose
+    # first word is ``1``, which is not a known read — so an fd duplication would
+    # have read as an unrecognized program. Found by an existing unit assertion.
+    cleaned = re.sub(r"\d*>>?\s*&\s*\d*|\d*>>?|<", " ", command)
+    for seg in re.split(r"(?:\|\||&&|[;&|\n()`])+", cleaned):
+        for raw in seg.split():
+            w = raw.replace("'", "").replace('"', "").strip()
+            if not w or w.isdigit():
+                continue
+            if "=" in w and not w.startswith("-") and "/" not in w.split("=", 1)[0]:
+                continue  # VAR=value assignment prefix
+            if w.startswith("-"):
+                continue  # a stray flag: not a program name
+            if "/" in w:
+                head, _, leaf = w.rpartition("/")
+                name = leaf.casefold()
+                if head.casefold() not in _TRUSTED_BIN_DIRS:
+                    # untrusted location: report a name that cannot match the
+                    # read set, so it counts as unrecognized
+                    name = f"{name}@untrusted"
+            else:
+                name = w.casefold()
+            if name in _COMMAND_WRAPPERS:
+                continue  # step over the wrapper, take the next word
+            progs.append(name)
+            break
+    return progs
+
+
+#: An assignment to a variable that controls how a BARE program name resolves, or
+#: what a resolved program loads. GPT round-36: a bare name is trusted because it
+#: resolves via PATH — and round 33's comment claimed PATH control "is a different
+#: threat and one this text gate cannot see". That was false whenever the
+#: assignment is IN the command: ``PATH=/tmp:$PATH cat crons.json`` stages
+#: ``/tmp/cat`` and the gate can plainly see it. Same correction as the sqlite3
+#: reversal — if the text names the mechanism, it is a matching problem.
+#:
+#: ``LD_PRELOAD``/``LD_LIBRARY_PATH`` are here because they do not change WHICH
+#: file runs but do change what code executes inside it, which is the same
+#: outcome. Probing found those, plus the ``env PATH=…`` and ``PATH=…;`` forms,
+#: none of which the report named.
+_RESOLUTION_VAR_ASSIGN_RE = re.compile(
+    r"(?:^|[\s;&|(])(?:export\s+)?"
+    r"(?:PATH|LD_PRELOAD|LD_LIBRARY_PATH|DYLD_INSERT_LIBRARIES|DYLD_LIBRARY_PATH"
+    r"|BASH_ENV|ENV|SHELL|IFS)\s*=",
+    re.IGNORECASE,
+)
+
+
+def _has_unrecognized_program(command: str) -> bool:
+    """True when any program in the command is not a known read.
+
+    This is what makes an unknown executable write-capable by default inside the
+    protected directories, instead of relying on a list of writers that the next
+    round can always extend.
+    """
+    progs = _program_words(command)
+    if not progs:
+        return False
+    # A command that rewrites its own resolution environment forfeits the trust
+    # the read set grants: the NAME no longer identifies the program.
+    #
+    # Applied to every program in such a command, including a path-qualified one
+    # from a trusted bin. That is deliberate conservatism, not an oversight:
+    # `_program_words` normalises `/usr/bin/cat` to `cat`, so "bare" and
+    # "trusted-bin" are indistinguishable downstream, and threading a marker
+    # through to preserve a distinction only `PATH=/tmp /usr/bin/cat` would use is
+    # not worth the extra state. Refusing that shape costs nothing real.
+    if _RESOLUTION_VAR_ASSIGN_RE.search(command):
+        return True
+    return any(p not in _KNOWN_READ_PROGRAMS for p in progs)
+
+
+def _has_write_verb(command: str) -> bool:
+    """True when the command names a mutating verb from the shared verb set.
+
+    Split out of :func:`_command_has_write_context` in round 24 so the journal
+    allowance can ask the narrower question — "does this command mutate by verb?"
+    — against the SAME verb set, rather than growing a second list that would
+    drift out of step with it. Round 25 moved it from substring membership to
+    word/basename comparison; see :func:`_command_words`. Round 27 added the
+    conditional half (:data:`_CONDITIONAL_WRITE_VERBS`) so a program that mutates
+    only under a flag is caught without making its READ form write context.
+    """
+    words = _command_words(command)
+    if any(w in _NORMALIZER_WRITE_VERBS for w in words):
+        return True
+    wordset = set(words)
+    return any(
+        prog in wordset and not flags.isdisjoint(wordset)
+        for prog, flags in _CONDITIONAL_WRITE_VERBS.items()
+    )
+
+
+def _command_has_write_context(command: str) -> bool:
+    """True when the command carries an output redirect or a write verb.
+
+    Coarse, whole-command signal shared by the two conjunction checks that must
+    not turn write-protection into read-blocking: a command that only NAMES a
+    fenced leaf while reading it keeps whatever posture that leaf's own regex
+    branch defines. ``<`` is a read and does not count.
+    """
+    if _WRITE_REDIR_RE.search(_blank_quoted_spans(command)):
+        return True
+    # GPT round-21/22: an INTERPRETER RUNNING is write context. Round 21 closed
+    # ``cd ~/.kiro/crew && python -c 'open("crons.json","w")…'``; round 22
+    # widened it from the inline ``-c``/``-e`` form to any interpreter
+    # invocation, because ``python /tmp/rewrite.py crons.json`` mutates just as
+    # well and names its target the same way. Where the program text lives says
+    # nothing about whether it writes.
+    #
+    # Both are distinct from the interpreter-COMPOSED-path case that text
+    # parsing genuinely cannot reach (segments joined so the leaf name never
+    # appears anywhere): here the command says exactly which file it will touch,
+    # so refusing it is a matching problem, not a sandbox problem.
+    #
+    # Deliberately NOT keyed on mutation calls in the payload or the script: a
+    # write can be spelled unboundedly many ways there, and enumerating them is
+    # the same denylist this file has already lost to seven times. Keying on the
+    # SHAPE of the invocation converges.
+    #
+    # The consequence is that an interpreter-driven READ of a fenced leaf is
+    # refused too — which the absolute-path branch already does for these
+    # leaves, so the posture is consistent rather than newly strict. And it only
+    # bites where the command ALSO names the crew home or the agents subtree:
+    # ``cd /tmp && python x.py crons.json`` is untouched.
+    if _INLINE_INTERPRETER_RE.search(command):
+        return True
+    # GPT round-15/25: shell word separators are not just U+0020 — ``tee\tcrons.json``
+    # and ``&&rm`` are the same command with the same verb. Verb detection is
+    # tokenized and basename-compared in _has_write_verb rather than pattern-matched
+    # here, so every conjunction that consults write context gets all spellings.
+    # GPT round-33: an UNRECOGNIZED executable is write-capable. Every earlier
+    # round enumerated writers and each report was a spelling the enumeration
+    # lacked; `/tmp/rewrite crons.json` cannot be enumerated at all. Callers of
+    # this helper all require the command to name a protected directory first, so
+    # the inversion is scoped to exactly where GPT prescribed it.
+    if _has_unrecognized_program(command):
+        return True
+    return _has_write_verb(command)
+
+
+def is_sensitive_bash_command(command: str, session_key: str | None = None) -> str | None:
     """Check if a bash command reads sensitive paths, accesses IMDS, or leaks env creds.
 
     Uses a two-pass approach:
@@ -5168,6 +6275,129 @@ def is_sensitive_bash_command(command: str) -> str | None:
     # ── Pass 1: regex fast-path ──
     if _get_sensitive_re().search(command):
         return "Blocked: command accesses sensitive credential path"
+    # Chained-relative goal-file write (``cd <agents dir> && echo x > LIFE.md``).
+    # Evaluated here rather than as an alternation branch so the two
+    # whole-command scans only happen for a command that actually names an
+    # agents directory; ``"agents" in`` is a C-speed reject for everything else.
+    if (
+        "agents" in command.lower()
+        and _AGENT_LIFE_LEAF_RE is not None
+        and _AGENT_LIFE_DIR_RE is not None
+        and _AGENT_LIFE_DIR_RE.search(command)
+    ):
+        if _AGENT_LIFE_LEAF_RE.search(command):
+            return "Blocked: command writes a perpetual agent's LIFE.md"
+        if _AGENT_LIFE_VAR_WRITE_RE is not None and _AGENT_LIFE_VAR_WRITE_RE.search(command):
+            return (
+                "Blocked: variable-derived write target inside a perpetual "
+                "agent's directory (spell the path literally)"
+            )
+    # Chained-relative write ANYWHERE under the agents root
+    # (``cd ~/.kiro/crew/agents && rm -rf <id> && mv /tmp/staged <id>``). The
+    # round-19 allowlist works on RESOLVED paths, so it never saw this: after a
+    # chained ``cd`` the target is a bare relative token and the normalizer
+    # resolves it against the agent's cwd, not against the ``cd``. Ninth
+    # spelling of one class, so it goes in the conjunction that already exists
+    # rather than a tenth branch: the command names the agents root AND carries
+    # write context.
+    #
+    # The allowlist survives the move: if the ONLY fenced name in the command is
+    # a journal, it is a journal append and stays allowed. Anything else — a
+    # bare id, a staged directory, a rename, a delete — is refused, which is the
+    # same inversion round 19 applied to resolved paths.
+    if (
+        "agents" in command.lower()
+        and _AGENT_LIFE_DIR_RE is not None
+        and _command_has_write_context(command)
+        and _names_agents_subtree(command)
+        and not _is_journal_only_write(command, session_key)
+    ):
+        return (
+            "Blocked: write inside the perpetual-agent directory; only "
+            "JOURNAL.md is agent-writable there"
+        )
+    # Chained-relative write to a fenced leaf one directory up
+    # (``cd ~/.kiro/crew && printf … > crons.json``). Same conjunction shape as
+    # the goal-file check above, and gated on WRITE context so shell reads of
+    # those leaves keep the posture their own regex branch defines rather than
+    # gaining a second, wider block. Pre-guarded on the crew-prefix substring so
+    # the two whole-command scans never run for an unrelated command.
+    # GPT round-43: the conjunction above is pre-guarded on the literal substring
+    # ``crew``/``kirocrew`` for speed, so composing the DIRECTORY name from
+    # variables skipped it entirely — ``d=cr;e=ew;printf '{}' > ~/.kiro/$d$e/…``
+    # never contains the word. Round 16 closed the composed LEAF; the same trick
+    # one level up was still open.
+    #
+    # A variable-derived write anywhere beneath the Kiro root is therefore refused
+    # WITHOUT requiring that substring. Cost, accepted and narrow: a legitimate
+    # variable-built path under ``~/.kiro`` (``f=notes.md; echo x > ~/.kiro/$f``)
+    # is refused too. That directory is Kiro's own config root, the literal form
+    # stays available, and a static layer cannot tell which file a variable names.
+    if (
+        _KIRO_ROOT_DIR_RE.search(command)
+        and _command_has_write_context(command)
+        and _AGENT_LIFE_VAR_WRITE_RE is not None
+        and _AGENT_LIFE_VAR_WRITE_RE.search(command)
+    ):
+        return (
+            "Blocked: variable-derived write target beneath the Kiro root "
+            "(spell the path literally)"
+        )
+    _low_cmd = command.lower()
+    if (
+        ("crew" in _low_cmd or "kirocrew" in _low_cmd)
+        and _CREW_HOME_DIR_RE is not None
+        and _WP_LEAF_BASENAME_RE is not None
+        and _command_has_write_context(command)
+        and _CREW_HOME_DIR_RE.search(command)
+    ):
+        if _WP_LEAF_BASENAME_RE.search(command):
+            return "Blocked: command writes a write-protected path in the crew home"
+        # GPT round-16: the leaf name can be composed from a variable
+        # (``f=crons; : > "$f.json"``), so the basename half sees nothing. Same
+        # answer as the agents-directory case in round 10 and the SAME matcher:
+        # inside a command that already names the crew home, a variable-derived
+        # write target is refused, because no static layer can resolve it.
+        if _AGENT_LIFE_VAR_WRITE_RE is not None and _AGENT_LIFE_VAR_WRITE_RE.search(command):
+            return (
+                "Blocked: variable-derived write target in the crew home "
+                "(spell the path literally)"
+            )
+        # GPT round-37: the leaf name can also be COMPOSED at runtime
+        # (``python -c 'open("cr"+"ons.json","w")'``), where no static layer can
+        # resolve it — the class I rebutted three times as unreachable by text
+        # parsing. GPT's fix does not try to resolve the name: it refuses the
+        # CAPABILITY. My first cut refused any interpreter or unknown program
+        # whenever the crew home was NAMED, which broke two pinned behaviours:
+        # ``python3 ~/.kiro/crew/crons/report.py`` (the product's documented
+        # script-cron form) and ``touch <crew home>/sessions.db`` (pinned allowed).
+        # So it is narrowed to the two shapes where the target genuinely cannot be
+        # attributed:
+        #   * the crew home is the CWD (a ``cd`` into it) and the program is an
+        #     interpreter or unrecognized — any relative write lands in the store;
+        #   * an INLINE payload (``-c``/``-e``) with the crew home named anywhere —
+        #     the payload's target is opaque by construction.
+        # A named script FILE under the crew home stays allowed: it is the
+        # supported form, and its path is visible to every other check.
+        #
+        # Cost, pinned by tests: ``cd ~/.kiro/crew && python --version``,
+        # ``… && kirocrew status``, ``… && npm ls`` are refused. The crew home is
+        # Kiro Crew's data directory, not a workspace, and every CLI works from any
+        # cwd, so the workaround is not to cd into the store.
+        _cd_into_store = _cd_target_is_crew_home(command)
+        if (_cd_into_store and _has_unrecognized_program(command)) or (
+            _cd_into_store and _INLINE_INTERPRETER_RE.search(command)
+        ):
+            return (
+                "Blocked: interpreter or unrecognized program run with the crew "
+                "home as the working directory; its write target cannot be "
+                "resolved from the command text (run it from another directory)"
+            )
+        if _INLINE_PAYLOAD_INTERPRETER_RE.search(command):
+            return (
+                "Blocked: inline interpreter payload in a command naming the crew "
+                "home; its write target cannot be resolved (use a script file)"
+            )
     if _EXTRACT_INTO_TRUST_ROOT_RE.search(command):
         return "Blocked: command extracts into the governance trust-root directory"
     # Block ANY command referencing a sensitive path via relative traversal,
@@ -5178,7 +6408,7 @@ def is_sensitive_bash_command(command: str) -> str | None:
         return "Blocked: command references a sensitive credential path via relative traversal"
 
     # ── Pass 2: normalizer-based sensitive path detection ──
-    normalizer_result = _check_sensitive_via_normalizer(command)
+    normalizer_result = _check_sensitive_via_normalizer(command, session_key)
     if normalizer_result:
         return normalizer_result
 
@@ -5193,7 +6423,9 @@ def is_sensitive_bash_command(command: str) -> str | None:
     return None
 
 
-def _check_sensitive_via_normalizer(command: str) -> str | None:
+def _check_sensitive_via_normalizer(
+    command: str, session_key: str | None = None
+) -> str | None:
     """Normalizer second-pass: tokenize command and route paths through is_sensitive_path.
 
     Catches obfuscation the regex first-pass cannot:
@@ -5224,8 +6456,37 @@ def _check_sensitive_via_normalizer(command: str) -> str | None:
     if not tokens:
         return None
 
+    # Write context for the write-protected check below (see its comment for
+    # why it must not fire on a read). Delegated to the shared helper rather
+    # than re-implemented: GPT round-15 found the duplicate here recognised
+    # only U+0020 as a word separator, so ``tee\tcrons.json`` slipped past one
+    # copy while the other caught it. One definition, one behaviour.
+    # Named for what it holds: write CONTEXT (redirect, verb, or interpreter), not
+    # just a verb. It used to be called _has_write_verb, which both understated
+    # the value and shadowed the module function of that name inside this
+    # function — a trap for the next edit that wants to call the helper here.
+    _had_write_context = _command_has_write_context(command)
+
     # Route each path-like token through is_sensitive_path()
+    _prev_was_redir_op = False
+    _prev_was_nav_verb = False
     for token in tokens:
+        # A bare redirect operator is its own token when written with a space
+        # (``> path``), so the NEXT token is the write target. Tracked across
+        # iterations because the attached form (``>path``) is handled below and
+        # the spaced form is the common one — missing it left the write-context
+        # gate blind to ``echo x > <write-protected>``.
+        _redir_ctx = _prev_was_redir_op
+        _prev_was_redir_op = bool(_REDIR_OP_ONLY_RE.fullmatch(token or ""))
+        # A NAVIGATION argument is not a write target. ``cd <dir> && echo x >>
+        # JOURNAL.md`` carries a write verb, so the coarse write-context flag is
+        # true for every token in the command — including cd's operand, which
+        # made the round-19 agents-subtree rule refuse a legitimate journal
+        # append (the cd target IS the agents dir). Tracked positionally: only
+        # the token immediately after cd/pushd is exempt, so a real write target
+        # elsewhere in the same command is unaffected.
+        _nav_arg = _prev_was_nav_verb
+        _prev_was_nav_verb = (token or "").strip().lower() in ("cd", "pushd")
         if not token:
             continue
         # ``key=value`` operands carry the real path to the RIGHT of the first
@@ -5244,12 +6505,16 @@ def _check_sensitive_via_normalizer(command: str) -> str | None:
             # shlex.  Strip the leading operator so the path portion is
             # checked.  Pattern: optional fd digit(s), then ``>`` or ``>>``.
             stripped = _REDIR_PREFIX_RE.sub("", cand)
+            was_redirect = _redir_ctx
             if stripped != cand:
                 # The stripped form is the real path candidate; if empty
                 # after stripping, skip (bare ``>`` alone).
                 if not stripped:
                     continue
                 cand = stripped
+                # Remembered so the write-protected check below can require
+                # write context instead of firing on every named token.
+                was_redirect = True
             # Skip flags
             if cand.startswith("-"):
                 continue
@@ -5265,6 +6530,38 @@ def _check_sensitive_via_normalizer(command: str) -> str | None:
             if is_sensitive_path(cand):
                 return (
                     "Blocked: command accesses sensitive credential path "
+                    f"(resolved via normalizer: {cand[:80]})"
+                )
+            # The WRITE-protected set is not in is_sensitive_path's read set by
+            # design (those files stay readable), so this pass — the ONLY layer
+            # that can undo shell quoting and resolve dot segments — has to
+            # check it separately or every normalized spelling walks past.
+            #
+            # GPT round-9 added the perpetual-agent goal file here; round-12
+            # widened it to the whole write-protected set. The widening is
+            # gated on WRITE CONTEXT, which the reviewer's one-line version was
+            # not: this pass is verb-INDEPENDENT, so an ungated
+            # ``is_sensitive_write_path`` call turns write-protection into
+            # read-blocking and refuses ``cat ~/.kiro/crew/config.json`` — an
+            # invariant test_normal_crew_access_not_overblocked pins, and the
+            # deliberate asymmetry between the edit-tool list (which holds
+            # config.json) and the bash leaf list (which does not). Write
+            # context here = the token was a redirect target, or the command
+            # carries a write verb. ``_is_agent_life_md`` stays unconditional:
+            # the goal file is refused on naming alone, matching its regex
+            # branch.
+            if _is_agent_life_md(cand):
+                return (
+                    "Blocked: command writes a perpetual agent's LIFE.md "
+                    f"(resolved via normalizer: {cand[:80]})"
+                )
+            if (
+                (was_redirect or _had_write_context)
+                and not _nav_arg
+                and is_sensitive_write_path(cand, session_key=session_key)
+            ):
+                return (
+                    "Blocked: command writes a write-protected path "
                     f"(resolved via normalizer: {cand[:80]})"
                 )
     return None

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -2237,7 +2237,17 @@ class GatewayOrchestrator:
             _prompt_dispatched = False
             # helper picks stable vs ephemeral session key and
             # decides whether to prepend last_result, based on job.persistent_session.
-            session_key, msg = build_cron_session_context(job)
+            # Offloaded: for kind="self" jobs the context assembly reads the
+            # LIFE.md/JOURNAL.md files (bounded, but still disk I/O), which
+            # must not run on the gateway event loop.
+            session_key, msg = await asyncio.to_thread(build_cron_session_context, job)
+            # NB: the perpetual-agent sleep record is NOT cleared here. Round 39
+            # cleared it right after assembly, which GPT round-41 showed is before
+            # the dispatch authorization gate (vet_job_at_fire_time) and before the
+            # concurrent-execution guard — so a wake that was DENIED dispatch
+            # destroyed the record for the next permitted wake. The clear now
+            # happens after the prompt is actually handed to the provider; see the
+            # call site below.
 
             # ── Concurrent execution guard ──
             if (job.script or job.command) and job.id in self._running_script_ids:
@@ -2717,6 +2727,21 @@ class GatewayOrchestrator:
                             interactive=False,
                             agent=agent,
                         )
+                        # GPT round-43: clear the TRANSIENT record now that the
+                        # prompt has been handed over. Round 42 moved the value off
+                        # the persisted field and I deleted round 41's clear as
+                        # "redundant" — it was not. Persistence and in-memory reuse
+                        # are two different leaks: the service CACHES CronJob
+                        # objects, so a dispatched turn that omitted agent_sleep
+                        # left the value on the cached object and the next fallback
+                        # wake was told it was "your record from last wake".
+                        #
+                        # GPT round-44: the clear now waits for the PROVIDER to
+                        # accept the prompt. Round 43 cleared it here, before
+                        # stream_and_collect — so an ACP outage that failed before
+                        # the turn ran destroyed the record for the next wake. The
+                        # record has done its job only once a turn has actually run
+                        # with it; see after the call below.
                         # Wall clock for the cron agent turn: acp never assigns
                         # TurnUsage.duration_ms, so the row falls back to this.
                         # Brackets only the model turn — session acquisition and
@@ -2742,6 +2767,12 @@ class GatewayOrchestrator:
                         if not result_text:
                             result_text = "_No response._"
                         logger.info("Cron '%s': agent '%s' completed", job.name, agent)
+                        # Round 44: the turn RAN with the record, so the record is
+                        # spent. Reached only on a successful return — a provider
+                        # failure above propagates and leaves the value on the
+                        # cached job for the next wake, which is the point.
+                        if job.consumed_sleep_record:
+                            job.consumed_sleep_record = ""
 
                         # ── Per-turn usage row: background spend. ──
                         try:
@@ -2845,6 +2876,8 @@ class GatewayOrchestrator:
                     provider_type=_provider,
                     minimal_context=job.minimal_context,
                 )
+                # Round 44: the clear for this path also waits for the provider to
+                # accept — see after stream_and_collect returns below.
 
                 # Wall clock for the cron agent turn — see the sequential site
                 # above. acp reports no duration, so this is the row's fallback.
@@ -2871,6 +2904,12 @@ class GatewayOrchestrator:
 
                 if _model_downgraded:
                     result_text = _annotate_model_downgrade(result_text)
+
+                # Round 44: the turn ran with the record, so it is spent. Reached
+                # only on a successful return — a provider failure above leaves the
+                # value on the cached job for the next wake.
+                if job.consumed_sleep_record:
+                    job.consumed_sleep_record = ""
 
                 job.set_run_result(result_text)
 

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2101,6 +2101,7 @@ CRON_ADD_SCHEMA = ToolSchema(
         FieldSpec("command", str, max_len=5000, pattern=re.compile(r"^[^\x00-\x1f\x7f]*$")),
         FieldSpec("timeout", int, min_val=0, max_val=3600),
         FieldSpec("timeout_secs", int, min_val=1, max_val=86400),
+        FieldSpec("perpetual", bool),
     ],
     custom_validator=_validate_cron_add_requires_message_or_script,
 )
@@ -2419,6 +2420,14 @@ MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
 MCP_CRON_SCHEMAS: dict[str, ToolSchema] = {
     "cron_list": CRON_LIST_SCHEMA,
     "cron_add": CRON_ADD_SCHEMA,
+    "agent_sleep": ToolSchema(
+        tool_name="agent_sleep",
+        fields=[
+            FieldSpec("next_wake_secs", int, required=True, min_val=1, max_val=86400 * 30),
+            FieldSpec("did", str, required=True, max_len=MAX_MEDIUM_STRING),
+            FieldSpec("next_intent", str, max_len=MAX_MEDIUM_STRING),
+        ],
+    ),
     "cron_update": ToolSchema(
         tool_name="cron_update",
         fields=[

--- a/test/test_cron_kind_self.py
+++ b/test/test_cron_kind_self.py
@@ -1,0 +1,3226 @@
+"""Tests for perpetual agents: CronSchedule kind='self' + agent_sleep.
+
+RFC rev 3 Phase 1 floor items 1/4/5: the code-owned §7 contract preamble with
+the ranking step, agent_sleep's wake-sooner half, and the §9 inheritance
+decisions. Each §9 row pinned here is a path that would otherwise silently
+kill or distort an agent nobody is watching.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.cron import (
+    _AUTO_PAUSE_THRESHOLD,
+    _AUTO_PAUSE_THRESHOLD_SELF,
+    _MIN_INTERVAL_SECS,
+    _SELF_CONTRACT_PREAMBLE,
+    CronJob,
+    CronSchedule,
+    CronService,
+    build_cron_session_context,
+    compute_next_run_ts,
+    format_schedule,
+)
+
+
+def _svc(tmp_path: Path) -> CronService:
+    svc = CronService(base_dir=tmp_path)
+    svc._load()
+    return svc
+
+
+#: The agent id used throughout the shell-gate cases, and the session key of the
+#: agent that OWNS it. Round 27 owner-scoped the journal allowance, so both the
+#: allowed and the refused cases are asserted as that owner acting: a refusal
+#: proven only by the ABSENCE of identity would pass for the wrong reason.
+_OWNER_AGENT_ID = "ab12cd34"
+_OWNER_SESSION_KEY = f"cron:{_OWNER_AGENT_ID}"
+
+#: Whether this platform can open a file relative to a directory fd. Round 20
+#: retired the no-``dir_fd`` fallback and made the life-context reader FAIL
+#: CLOSED instead, because the fallback could not refuse a symlinked component.
+#: The documented cost is that a perpetual agent on such a platform (Windows)
+#: gets the §7 preamble and the operator message but no LIFE.md/JOURNAL.md.
+#:
+#: Tests that assert life-context CONTENT therefore cannot run there — the
+#: content is deliberately absent. They are gated on this flag, and
+#: :class:`TestLifeContextWithoutDirFd` asserts the fail-closed contract itself
+#: so the platform is covered by an assertion rather than merely skipped.
+_HAS_DIR_FD = os.open in getattr(os, "supports_dir_fd", set())
+_needs_dir_fd = pytest.mark.skipif(
+    not _HAS_DIR_FD, reason="life-context reads fail closed without dir_fd support (round 20)"
+)
+
+
+def _add_self(svc: CronService, name: str = "warden", every: int = 3600) -> CronJob:
+    # The operator session key mirrors what the MCP tool passes after its allowlist
+    # decides the caller is an operator surface (GPT round-23). A test that
+    # omitted it would be exercising a path the product refuses.
+    return svc.add_job(
+        name=name,
+        message="pursue the goal",
+        every_secs=every,
+        perpetual=True,
+        operator_session_key="dashboard:main",
+    )
+
+
+class TestSelfScheduleCreation:
+    def test_perpetual_requires_operator_authorization(self, tmp_path: Path) -> None:
+        """GPT round-23: the operator-only rule lived ONLY at the MCP tool, so
+        the invariant was true by convention of a single caller rather than
+        enforced by the owner of the write. Now checked where the job is built,
+        keyword-only and default-false so no existing caller keeps legacy status.
+
+        This does not pretend to stop an agent that can already run arbitrary
+        in-process Python; it stops the invariant living in exactly one place.
+        """
+        svc = _svc(tmp_path)
+        with pytest.raises(ValueError, match="operator session key"):
+            svc.add_job(name="w", message="m", every_secs=3600, perpetual=True)
+        # GPT round-42: the layer now VALIDATES a claimed identity instead of
+        # trusting a caller-computed boolean. An automation identity is refused
+        # even though the caller supplied one.
+        for forged in ("cron:job1", "subagent:x", "webhook:y", "heartbeat:z", "taskrunner:t"):
+            with pytest.raises(ValueError, match="operator session key"):
+                svc.add_job(
+                    name="w",
+                    message="m",
+                    every_secs=3600,
+                    perpetual=True,
+                    operator_session_key=forged,
+                )
+        # Non-perpetual jobs are unaffected — no caller has to opt in for those.
+        plain = svc.add_job(name="p", message="m", every_secs=3600)
+        assert plain.schedule.kind == "every"
+
+    def test_perpetual_creates_kind_self(self, tmp_path: Path) -> None:
+        job = _add_self(_svc(tmp_path))
+        assert job.schedule.kind == "self"
+        assert job.schedule.every_secs == 3600
+        assert job.next_wake_ts is None
+
+    def test_perpetual_requires_every(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="every_secs"):
+            _svc(tmp_path).add_job(
+                name="w",
+                message="m",
+                at_ts=time.time() + 60,
+                perpetual=True,
+                operator_session_key="dashboard:main",
+            )
+
+    def test_perpetual_refuses_delete_after_run(self, tmp_path: Path) -> None:
+        """§9: one-shot semantics are refused at validation."""
+        with pytest.raises(ValueError, match="delete_after_run"):
+            _svc(tmp_path).add_job(
+                name="w",
+                message="m",
+                every_secs=3600,
+                perpetual=True,
+                delete_after_run=True,
+                operator_session_key="dashboard:main",
+            )
+
+    def test_perpetual_forces_strict_schedule_and_persistence(self, tmp_path: Path) -> None:
+        """§9: jitter off (strict_schedule), continuity on (persistent_session)."""
+        job = _svc(tmp_path).add_job(
+            name="w", message="m", every_secs=3600, perpetual=True, operator_session_key="dashboard:main",
+            strict_schedule=False, persistent_session=False,
+        )
+        assert job.strict_schedule is True
+        assert job.persistent_session is True
+
+    def test_round_trips_through_store(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "did a thing", "next thing")
+        svc2 = _svc(tmp_path)
+        got = svc2.list_jobs()[0]
+        assert got.schedule.kind == "self"
+        assert got.next_wake_ts is not None
+        assert "did: did a thing" in got.last_sleep_record
+
+    def test_format_schedule(self) -> None:
+        assert "self-scheduled" in format_schedule(CronSchedule(kind="self", every_secs=3600))
+
+
+class TestSelfNextRun:
+    def test_fallback_is_operator_ceiling(self, tmp_path: Path) -> None:
+        """No agent choice -> behaves like 'every' (the ceiling)."""
+        job = _add_self(_svc(tmp_path))
+        job.last_run_ts = 1000.0
+        assert compute_next_run_ts(job, now=1100.0) == 1000.0 + 3600
+
+    def test_agent_choice_wins(self, tmp_path: Path) -> None:
+        job = _add_self(_svc(tmp_path))
+        job.last_run_ts = 1000.0
+        job.next_wake_ts = 1600.0
+        assert compute_next_run_ts(job, now=1100.0) == 1600.0
+
+    def test_missed_wake_fires_on_recovery(self, tmp_path: Path) -> None:
+        """A deadline that passed while the host was down fires NOW, not one
+        interval later — the property that made cron the host."""
+        job = _add_self(_svc(tmp_path))
+        job.next_wake_ts = 1000.0
+        assert compute_next_run_ts(job, now=5000.0) == 5000.0
+
+
+class TestAgentSleep:
+    def test_records_wake_and_result(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        t0 = time.time()
+        got = svc.record_agent_sleep(job.id, 600, "fixed the flake", "verify at population level")
+        assert got.next_wake_ts is not None
+        assert t0 + 595 <= got.next_wake_ts <= t0 + 605
+        assert "did: fixed the flake" in got.last_sleep_record
+        assert "next: verify at population level" in got.last_sleep_record
+
+    def test_wake_sooner_allowed_sleep_longer_clamped(self, tmp_path: Path) -> None:
+        """The wake-sooner half: earlier than the ceiling is allowed, past it
+        is clamped TO the ceiling (RFC rev 3: sleep-longer is §4 config, not
+        agent-chosen distant deadlines)."""
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        t0 = time.time()
+        got = svc.record_agent_sleep(job.id, 86400, "idle", "")
+        assert got.next_wake_ts is not None
+        assert got.next_wake_ts <= t0 + 3600 + 5
+
+    def test_floor_clamped(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        t0 = time.time()
+        got = svc.record_agent_sleep(job.id, 1, "quick continue", "")
+        assert got.next_wake_ts is not None
+        assert got.next_wake_ts >= t0 + _MIN_INTERVAL_SECS - 5
+
+    def test_rejected_for_non_self_jobs(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = svc.add_job(name="plain", message="m", every_secs=3600)
+        with pytest.raises(ValueError, match="kind='self'"):
+            svc.record_agent_sleep(job.id, 600, "did", "")
+
+    def test_unknown_job(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="not found"):
+            _svc(tmp_path).record_agent_sleep("deadbeef", 600, "did", "")
+
+
+class TestConsumeOnFire:
+    def test_consume_clears_matching_deadline(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "did", "")
+        target = svc.list_jobs()[0]
+        assert target.next_wake_ts is not None
+        svc._consume_self_wake_locked(target)
+        assert target.next_wake_ts is None
+        svc2 = _svc(tmp_path)
+        assert svc2.list_jobs()[0].next_wake_ts is None
+
+    def test_consume_preserves_newer_choice(self, tmp_path: Path) -> None:
+        """An agent_sleep landing during the run must survive the clear."""
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "did", "")
+        fired = svc.list_jobs()[0]
+        stale = CronJob(id=fired.id, name=fired.name, message=fired.message,
+                        schedule=fired.schedule)
+        stale.next_wake_ts = (fired.next_wake_ts or 0) - 100  # a DIFFERENT value
+        svc._consume_self_wake_locked(stale)
+        # Disk value differed from what this fire consumed -> preserved.
+        assert svc.list_jobs()[0].next_wake_ts is not None
+
+
+class TestSelfPromptAssembly:
+    def test_contract_preamble_prepended(self, tmp_path: Path) -> None:
+        job = _add_self(_svc(tmp_path))
+        with patch("kiro_crew.cron._agents_dir", return_value=tmp_path / "agents"):
+            key, prompt = build_cron_session_context(job)
+        assert key == f"cron:{job.id}"
+        assert prompt.startswith("[Perpetual agent contract]")
+        assert "RANK FIRST" in prompt
+        assert prompt.rstrip().endswith("pursue the goal")
+
+    @_needs_dir_fd
+    def test_life_and_journal_included_when_present(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc, name="warden")
+        base = tmp_path / "agents" / job.id
+        base.mkdir(parents=True)
+        (base / "LIFE.md").write_text("## 1. The goal\nKeep CI trustworthy.\n", encoding="utf-8")
+        (base / "JOURNAL.md").write_text(
+            "\n".join(f"line {i}" for i in range(50)) + "\n", encoding="utf-8"
+        )
+        with patch("kiro_crew.cron._agents_dir", return_value=tmp_path / "agents"):
+            _, prompt = build_cron_session_context(job)
+        assert "Keep CI trustworthy." in prompt
+        assert "line 49" in prompt
+        assert "line 0" not in prompt  # tail only
+
+    def test_missing_life_dir_degrades_gracefully(self, tmp_path: Path) -> None:
+        job = _add_self(_svc(tmp_path))
+        with patch("kiro_crew.cron._agents_dir", return_value=tmp_path / "nope"):
+            _, prompt = build_cron_session_context(job)
+        assert "[Perpetual agent contract]" in prompt
+
+    @_needs_dir_fd
+    def test_life_md_capped(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc, name="warden")
+        base = tmp_path / "agents" / job.id
+        base.mkdir(parents=True)
+        (base / "LIFE.md").write_text("x" * 50_000, encoding="utf-8")
+        with patch("kiro_crew.cron._agents_dir", return_value=tmp_path / "agents"):
+            _, prompt = build_cron_session_context(job)
+        assert "[truncated at cap]" in prompt
+        assert len(prompt) < 40_000
+
+    def test_no_idle_punishment_language(self) -> None:
+        """§7: the preamble must never claim idle will be refused/punished —
+        that instruction is what produces invented work."""
+        low = _SELF_CONTRACT_PREAMBLE.lower()
+        assert "honest idle is a legitimate outcome" in low
+        for banned in ("will be refused", "punish", "must produce"):
+            assert banned not in low.replace("never punished", "")
+
+    def test_plain_jobs_unchanged(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = svc.add_job(name="plain", message="hello", every_secs=3600)
+        _, prompt = build_cron_session_context(job)
+        assert "[Perpetual agent contract]" not in prompt
+
+
+class TestSelfAutoPause:
+    def test_higher_threshold_for_self(self, tmp_path: Path) -> None:
+        """§9: a self job survives the ordinary threshold and pauses only at
+        the raised one — it must never die quietly on an ordinary bad day."""
+        job = _add_self(_svc(tmp_path))
+        for _ in range(_AUTO_PAUSE_THRESHOLD):
+            job.record_failure()
+        assert job.auto_paused is False  # survived the ordinary threshold
+        for _ in range(_AUTO_PAUSE_THRESHOLD_SELF - _AUTO_PAUSE_THRESHOLD):
+            job.record_failure()
+        assert job.auto_paused is True
+
+    def test_plain_jobs_keep_ordinary_threshold(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = svc.add_job(name="plain", message="m", every_secs=3600)
+        for _ in range(_AUTO_PAUSE_THRESHOLD):
+            job.record_failure()
+        assert job.auto_paused is True
+
+
+class TestSelfIsDue:
+    """GPT round-1 F5: _is_due must support kind='self' or nothing ever fires."""
+
+    def test_due_when_agent_deadline_passed(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        job.next_wake_ts = 1000.0
+        assert CronService._is_due(job, now=1001.0) is True
+        assert CronService._is_due(job, now=999.0) is False
+
+    def test_fallback_ceiling_when_no_choice(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        job.last_run_ts = 1000.0
+        assert CronService._is_due(job, now=1000.0 + 3599) is False
+        assert CronService._is_due(job, now=1000.0 + 3601) is True
+
+
+class TestLifeContextSafety:
+    """GPT round-1 F1: the job name must not escape the agents directory."""
+
+    @pytest.mark.parametrize("bad", ["/tmp/private", "../outside", "a/../../b"])
+    def test_hostile_names_cannot_select_files(self, tmp_path: Path, bad: str) -> None:
+        """GPT round-4: the life dir is keyed by generated job.id, so a name
+        — hostile or colliding with an existing agent — selects nothing."""
+        svc = _svc(tmp_path)
+        job = svc.add_job(
+            name=bad,
+            message="m",
+            every_secs=3600,
+            perpetual=True,
+            operator_session_key="dashboard:main",
+        )
+        outside = tmp_path / "private"
+        outside.mkdir()
+        (outside / "LIFE.md").write_text("SECRET", encoding="utf-8")
+        with patch("kiro_crew.cron._agents_dir", return_value=tmp_path / "agents"):
+            _, prompt = build_cron_session_context(job)
+        assert "SECRET" not in prompt
+        assert "[Perpetual agent contract]" in prompt
+
+    def test_name_collision_cannot_steal_another_agents_life(self, tmp_path: Path) -> None:
+        """A job named after an existing agent must NOT read that agent's
+        LIFE.md — directories are keyed by id, not name."""
+        svc = _svc(tmp_path)
+        victim = _add_self(svc, name="warden")
+        base = tmp_path / "agents" / victim.id
+        base.mkdir(parents=True)
+        (base / "LIFE.md").write_text("VICTIM GOAL", encoding="utf-8")
+        impostor = _add_self(svc, name="warden")  # same NAME, different id
+        with patch("kiro_crew.cron._agents_dir", return_value=tmp_path / "agents"):
+            _, prompt = build_cron_session_context(impostor)
+        assert "VICTIM GOAL" not in prompt
+
+    @_needs_dir_fd
+    def test_reads_are_byte_bounded(self, tmp_path: Path) -> None:
+        """A huge journal must not be read whole — only the tail cap."""
+        from kiro_crew.cron import _JOURNAL_TAIL_CAP_BYTES, _read_tail_bytes
+
+        big = tmp_path / "JOURNAL.md"
+        big.write_text("x" * 5_000_000 + "\nlast line", encoding="utf-8")
+        tail = _read_tail_bytes(big, _JOURNAL_TAIL_CAP_BYTES, tmp_path)
+        assert tail is not None
+        assert len(tail.encode("utf-8")) <= _JOURNAL_TAIL_CAP_BYTES
+        assert tail.endswith("last line")
+
+
+class TestSleepRecordSurvivesTurnMerge:
+    """GPT round-1 F4: the sleep record must not be clobbered by the
+    turn-completion merge (last_result belongs to the turn)."""
+
+    def test_merge_preserves_sleep_record(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "the real record", "next step")
+        # Simulate the gateway's turn-completion merge with a stale in-memory
+        # snapshot whose last_result is the turn's own text.
+        snapshot = svc.list_jobs()[0]
+        snapshot.set_run_result("turn output text")
+        svc._merge_job_result(snapshot)
+        svc2 = _svc(tmp_path)
+        got = svc2.list_jobs()[0]
+        assert "the real record" in got.last_sleep_record
+        assert got.last_result == "turn output text"
+
+    def test_sleep_record_reaches_next_prompt(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "did the thing", "verify it")
+        target = svc.list_jobs()[0]
+        with patch("kiro_crew.cron._agents_dir", return_value=tmp_path / "agents"):
+            _, prompt = build_cron_session_context(target)
+        assert "did: did the thing" in prompt
+        assert "next: verify it" in prompt
+
+
+class TestLifeContextSymlinkGuard:
+    """GPT round-2: a symlinked LIFE.md must never pull outside bytes into
+    the prompt — O_NOFOLLOW at the open plus a realpath containment check."""
+
+    def test_symlinked_life_md_refused(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc, name="warden")
+        secret = tmp_path / "id_rsa"
+        secret.write_text("PRIVATE KEY BYTES", encoding="utf-8")
+        base = tmp_path / "agents" / "warden"
+        base.mkdir(parents=True)
+        (base / "LIFE.md").symlink_to(secret)
+        with patch("kiro_crew.cron._agents_dir", return_value=tmp_path / "agents"):
+            _, prompt = build_cron_session_context(job)
+        assert "PRIVATE KEY BYTES" not in prompt
+        assert "[Perpetual agent contract]" in prompt
+
+    def test_symlinked_parent_dir_refused(self, tmp_path: Path) -> None:
+        """A symlinked intermediate directory is refused because the walk opens
+        every component with O_NOFOLLOW — it is never traversed, rather than
+        being traversed and then compared (GPT round-15)."""
+        svc = _svc(tmp_path)
+        job = _add_self(svc, name="warden")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "LIFE.md").write_text("OUTSIDE BYTES", encoding="utf-8")
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / job.id).symlink_to(outside, target_is_directory=True)
+        with patch("kiro_crew.cron._agents_dir", return_value=agents):
+            _, prompt = build_cron_session_context(job)
+        assert "OUTSIDE BYTES" not in prompt
+
+    def test_intermediate_symlink_inside_root_is_still_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """The case a containment COMPARISON cannot catch: the link target is
+        itself inside the agents root, so realpath containment passes — only
+        refusing to traverse the link at all rejects it. This is what makes the
+        guard structural instead of a check that can go stale.
+
+        Requires ``dir_fd`` support: the per-component ``openat`` walk is what
+        refuses the traversal, and on a platform without it
+        (``_open_inside_nofollow_no_dirfd``, i.e. Windows) this exact case is the
+        documented residual rather than a regression — the fallback can only
+        compare the resolved path, which lands inside the root here. Confirmed
+        on CI: this assertion is the one that used to fail on the Windows shard.
+
+        No longer platform-gated: since round 19 the no-``dir_fd`` path fails
+        closed rather than falling back, so the refusal holds on EVERY platform
+        and the Windows shard runs this assertion for real.
+        """
+        svc = _svc(tmp_path)
+        job = _add_self(svc, name="warden")
+        agents = tmp_path / "agents"
+        victim = agents / "victim"
+        victim.mkdir(parents=True)
+        (victim / "LIFE.md").write_text("VICTIM GOAL BYTES", encoding="utf-8")
+        (agents / job.id).symlink_to(victim, target_is_directory=True)
+        with patch("kiro_crew.cron._agents_dir", return_value=agents):
+            _, prompt = build_cron_session_context(job)
+        assert "VICTIM GOAL BYTES" not in prompt
+
+    def test_no_dirfd_fails_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GPT round-19 retired the realpath fallback instead of hardening it.
+
+        Round 16 pinned its inability to refuse an inside-root link as a
+        documented residual; that was the wrong call for a shipped default,
+        because on Windows a ``mklink /J`` junction reaches the same state with
+        no symlink privilege. The reader now refuses to ingest at all when the
+        per-component walk is unavailable — an agent there runs with its
+        contract preamble and operator message but no goal file, which beats
+        ingesting a possibly-attacker-chosen one.
+        """
+        from kiro_crew.cron import _open_inside_nofollow
+
+        monkeypatch.setattr(os, "supports_dir_fd", set())
+        agents = tmp_path / "agents"
+        (agents / "warden").mkdir(parents=True)
+        (agents / "warden" / "LIFE.md").write_text("GOAL", encoding="utf-8")
+        # Even a perfectly ordinary, link-free path is refused: the guarantee is
+        # structural, so it cannot be granted selectively.
+        assert _open_inside_nofollow(agents / "warden" / "LIFE.md", agents) is None
+
+    def test_no_dirfd_degrades_the_prompt_without_killing_the_wake(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Failing closed must degrade, not raise: the contract preamble still
+        reaches the agent, only the LIFE/JOURNAL sections are absent."""
+        monkeypatch.setattr(os, "supports_dir_fd", set())
+        svc = _svc(tmp_path)
+        job = _add_self(svc, name="warden")
+        agents = tmp_path / "agents"
+        (agents / job.id).mkdir(parents=True)
+        (agents / job.id / "LIFE.md").write_text("GOAL BYTES", encoding="utf-8")
+        with patch("kiro_crew.cron._agents_dir", return_value=agents):
+            _, prompt = build_cron_session_context(job)
+        assert "GOAL BYTES" not in prompt
+        assert "[Perpetual agent contract]" in prompt
+
+    # ── GPT round-18 ─────────────────────────────────────────────────────
+
+    def test_replaced_agents_root_is_refused(self, tmp_path: Path) -> None:
+        """The root was the one component exempted from O_NOFOLLOW, on a claim
+        that turned out to be false: ``agents`` is NOT write-protected, so an
+        agent can move it aside and put a link there. Now the data home above it
+        keeps the exemption (an operator may legitimately link it) while
+        ``agents`` itself is opened with O_NOFOLLOW."""
+        from kiro_crew.cron import _open_inside_nofollow
+
+        home = tmp_path / "crew"
+        home.mkdir()
+        outside = tmp_path / "outside"
+        (outside / "warden").mkdir(parents=True)
+        (outside / "warden" / "LIFE.md").write_text("ATTACKER GOAL", encoding="utf-8")
+        agents = home / "agents"
+        agents.symlink_to(outside, target_is_directory=True)
+        assert _open_inside_nofollow(agents / "warden" / "LIFE.md", agents) is None
+
+    def test_replaced_agents_root_is_refused_end_to_end(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc, name="warden")
+        home = tmp_path / "crew"
+        home.mkdir()
+        outside = tmp_path / "outside"
+        (outside / job.id).mkdir(parents=True)
+        (outside / job.id / "LIFE.md").write_text("ATTACKER GOAL", encoding="utf-8")
+        agents = home / "agents"
+        agents.symlink_to(outside, target_is_directory=True)
+        with patch("kiro_crew.cron._agents_dir", return_value=agents):
+            _, prompt = build_cron_session_context(job)
+        assert "ATTACKER GOAL" not in prompt
+
+    def test_linked_root_refused_in_the_no_dirfd_path_too(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Trivially true now that the no-dir_fd path fails closed, but kept as
+        the regression anchor: if someone reintroduces a fallback, this case
+        (which a containment comparison cannot catch) must stay refused."""
+        from kiro_crew.cron import _open_inside_nofollow
+
+        monkeypatch.setattr(os, "supports_dir_fd", set())
+        home = tmp_path / "crew"
+        home.mkdir()
+        outside = tmp_path / "outside"
+        (outside / "warden").mkdir(parents=True)
+        (outside / "warden" / "LIFE.md").write_text("ATTACKER GOAL", encoding="utf-8")
+        agents = home / "agents"
+        agents.symlink_to(outside, target_is_directory=True)
+        assert _open_inside_nofollow(agents / "warden" / "LIFE.md", agents) is None
+
+    @_needs_dir_fd
+    def test_a_legitimately_linked_data_home_still_reads(self, tmp_path: Path) -> None:
+        """The exemption that survives: the operator may link the DATA HOME."""
+        from kiro_crew.cron import _open_inside_nofollow
+
+        real_home = tmp_path / "real-crew"
+        (real_home / "agents" / "warden").mkdir(parents=True)
+        (real_home / "agents" / "warden" / "LIFE.md").write_text("GOAL", encoding="utf-8")
+        linked_home = tmp_path / "crew"
+        linked_home.symlink_to(real_home, target_is_directory=True)
+        fd = _open_inside_nofollow(
+            linked_home / "agents" / "warden" / "LIFE.md", linked_home / "agents"
+        )
+        assert fd is not None
+        os.close(fd)
+
+    def test_dotdot_segment_in_the_life_path_is_refused(self, tmp_path: Path) -> None:
+        from kiro_crew.cron import _open_inside_nofollow
+        agents = tmp_path / "agents"
+        (agents / "warden").mkdir(parents=True)
+        (agents / "warden" / "LIFE.md").write_text("x", encoding="utf-8")
+        assert _open_inside_nofollow(agents / "warden" / ".." / "warden" / "LIFE.md", agents) is None
+        assert _open_inside_nofollow(tmp_path / "elsewhere" / "LIFE.md", agents) is None
+
+    @_needs_dir_fd
+    def test_regular_files_still_read(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc, name="warden")
+        base = tmp_path / "agents" / job.id
+        base.mkdir(parents=True)
+        (base / "LIFE.md").write_text("normal goal text", encoding="utf-8")
+        with patch("kiro_crew.cron._agents_dir", return_value=tmp_path / "agents"):
+            _, prompt = build_cron_session_context(job)
+        assert "normal goal text" in prompt
+
+
+class TestRound3Fixes:
+    """GPT round-3: FIFO refusal, contention propagation, last_run advance."""
+
+    def test_fifo_life_md_refused(self, tmp_path: Path) -> None:
+        """A FIFO at LIFE.md must not hang the open — refused via O_NONBLOCK
+        + regular-file check."""
+        import os as _os
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("mkfifo is POSIX-only")
+        svc = _svc(tmp_path)
+        job = _add_self(svc, name="warden")
+        base = tmp_path / "agents" / job.id
+        base.mkdir(parents=True)
+        _os.mkfifo(base / "LIFE.md")
+        with patch("kiro_crew.cron._agents_dir", return_value=tmp_path / "agents"):
+            _, prompt = build_cron_session_context(job)  # must return, not hang
+        assert "[Perpetual agent contract]" in prompt
+        assert "[LIFE.md" not in prompt.replace("[LIFE.md truncated", "")
+
+    def test_consume_propagates_store_busy(self, tmp_path: Path) -> None:
+        """Contention must propagate — an in-memory-only clear would leave the
+        past-due deadline live on disk and refire every tick."""
+        from kiro_crew.cron import CronStoreBusy
+
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "did", "")
+        target = svc.list_jobs()[0]
+        fired_value = target.next_wake_ts
+
+        class _Busy:
+            def __enter__(self):
+                raise CronStoreBusy("contended")
+
+            def __exit__(self, *a):
+                return False
+
+        with patch.object(svc, "_file_lock", return_value=_Busy()):
+            with pytest.raises(CronStoreBusy):
+                svc._consume_self_wake_locked(target)
+        # In-memory value untouched on the failure path too.
+        assert target.next_wake_ts == fired_value
+
+    def test_self_last_run_advances_like_every(self, tmp_path: Path) -> None:
+        """A completed self wake must advance last_run_ts so the fallback
+        deadline moves forward even when agent_sleep was never called."""
+        import asyncio as _aio
+
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        job.last_run_ts = None
+
+        async def _noop(_j: CronJob) -> None:
+            return None
+
+        svc._on_job = _noop
+        svc._job_run_meta[job.id] = (1234.5, "scheduled")
+        svc._executing.add(job.id)
+        _aio.run(svc._run_job_isolated(job))
+        assert job.last_run_ts == 1234.5
+
+
+class TestSkippedWakeNotFinalized:
+    """GPT round-4: a wake skipped on consumption contention must not be
+    finalized — no last_run_ts advance, no phantom history row."""
+
+    def test_contention_skip_leaves_run_state_untouched(self, tmp_path: Path) -> None:
+        import asyncio as _aio
+
+        from kiro_crew.cron import CronStoreBusy
+
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "did", "")
+        target = svc.list_jobs()[0]
+        target.last_run_ts = None
+        # GPT round-35: this scenario is a wake that FIRED and then hit
+        # contention while being consumed, so the deadline must be PAST DUE. The
+        # test previously left it 600s in the future and passed only because the
+        # consume path was entered unconditionally — i.e. it depended on the very
+        # bug round 35 fixed. A future deadline is no longer consumed at all.
+        target.next_wake_ts = time.time() - 1
+        ran = []
+
+        async def _mark(_j: CronJob) -> None:
+            ran.append(True)
+
+        svc._on_job = _mark
+        svc._job_run_meta[target.id] = (999.0, "scheduled")
+        svc._executing.add(target.id)
+        with patch.object(
+            svc, "_consume_self_wake_locked", side_effect=CronStoreBusy("busy")
+        ):
+            _aio.run(svc._run_job_isolated(target))
+        assert ran == []  # never executed
+        assert target.last_run_ts is None  # not finalized as a run
+
+
+class TestLifeMdWriteDeny:
+    """GPT round-5: LIFE.md is agent-read-only — both tool gates hard-deny
+    writes so a perpetual agent cannot self-modify its goal."""
+
+    def test_edit_gate_denies_agents_life_md(self, tmp_path: Path) -> None:
+        from pathlib import Path as _P
+
+        from kiro_crew.security import is_sensitive_write_path
+
+        home = _P.home()
+        life = home / ".kiro" / "crew" / "agents" / "abcd1234" / "LIFE.md"
+        assert is_sensitive_write_path(str(life)) is True
+
+    def test_edit_gate_allows_journal_md(self) -> None:
+        from pathlib import Path as _P
+
+        from kiro_crew.security import is_sensitive_write_path
+
+        home = _P.home()
+        journal = home / ".kiro" / "crew" / "agents" / "abcd1234" / "JOURNAL.md"
+        # Round 27: the journal exemption is owner-scoped, so it is asserted as
+        # the agent that owns THIS directory.
+        assert is_sensitive_write_path(str(journal), session_key="cron:abcd1234") is False
+        # and refused for anyone else, including an unidentified caller
+        assert is_sensitive_write_path(str(journal), session_key="cron:other") is True
+        assert is_sensitive_write_path(str(journal)) is True
+
+    def test_bash_gate_catches_life_md_write(self) -> None:
+        from kiro_crew.security import _build_sensitive_regex
+
+        rx = _build_sensitive_regex()
+        assert rx.search('echo hacked > ~/.kiro/crew/agents/ab12cd34/LIFE.md')
+        assert rx.search("tee $HOME/.kiro/crew/agents/x/LIFE.md")
+        # JOURNAL.md writes stay allowed.
+        assert not rx.search("echo entry >> ~/.kiro/crew/agents/ab12cd34/JOURNAL.md")
+
+    # ── GPT round-6 ──────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # single-dot segment right before the leaf (the reported bypass)
+            "echo hacked > ~/.kiro/crew/agents/ab12cd34/./LIFE.md",
+            # dot segment inside the crew prefix
+            "echo hacked > ~/.kiro/./crew/agents/ab12cd34/LIFE.md",
+            # same-level down-up excursion re-entering the id segment
+            "echo hacked > ~/.kiro/crew/agents/x/../x/LIFE.md",
+            # excursion through the agents dir itself
+            "tee $HOME/.kiro/crew/agents/./ab12cd34/LIFE.md",
+        ],
+    )
+    def test_bash_gate_catches_dot_segment_spellings(self, cmd: str) -> None:
+        from kiro_crew.security import _build_sensitive_regex
+
+        assert _build_sensitive_regex().search(cmd), cmd
+
+    def test_bash_gate_dot_segments_leave_journal_alone(self) -> None:
+        from kiro_crew.security import _build_sensitive_regex
+
+        rx = _build_sensitive_regex()
+        assert not rx.search("echo e >> ~/.kiro/crew/agents/ab12cd34/./JOURNAL.md")
+
+    def test_edit_gate_denies_life_md_under_kirocrew_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.security import is_sensitive_write_path
+
+        crew = tmp_path / "crew-home"
+        life = crew / "agents" / "ab12cd34" / "LIFE.md"
+        life.parent.mkdir(parents=True)
+        life.write_text("goal", encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_HOME", str(crew))
+        assert is_sensitive_write_path(str(life)) is True
+        # JOURNAL.md in the same env-anchored dir stays writable for its OWNER
+        # (round 27 owner-scoped the exemption).
+        journal = life.parent / "JOURNAL.md"
+        owner_key = f"cron:{life.parent.name}"
+        assert is_sensitive_write_path(str(journal), session_key=owner_key) is False
+        assert is_sensitive_write_path(str(journal)) is True
+
+    def test_bash_gate_catches_life_md_under_kirocrew_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.security import _build_sensitive_regex
+
+        crew = tmp_path / "crew-home"
+        (crew / "agents" / "ab12cd34").mkdir(parents=True)
+        monkeypatch.setenv("KIROCREW_HOME", str(crew))
+        rx = _build_sensitive_regex()
+        assert rx.search(f"echo hacked > {crew}/agents/ab12cd34/LIFE.md")
+        assert rx.search(f"echo hacked > {crew}/agents/ab12cd34/./LIFE.md")
+        assert not rx.search(f"echo e >> {crew}/agents/ab12cd34/JOURNAL.md")
+
+    def test_full_bash_gate_denies_env_anchored_write_via_normalizer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The live gate (regex pass may be process-cached from before the env
+        was set) still denies via the normalizer second-pass, because
+        ``_is_agent_life_md`` consults ``KIROCREW_HOME`` at call time."""
+        from kiro_crew.security import is_sensitive_write_path
+
+        crew = tmp_path / "crew-home"
+        life = crew / "agents" / "ab12cd34" / "LIFE.md"
+        life.parent.mkdir(parents=True)
+        life.write_text("goal", encoding="utf-8")
+        monkeypatch.setenv("KIROCREW_HOME", str(crew))
+        # dot-segment spelling resolves to the same guarded file
+        dotted = crew / "agents" / "ab12cd34" / "." / "LIFE.md"
+        assert is_sensitive_write_path(str(dotted)) is True
+
+    # ── GPT round-7 ──────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # the reported bypass: cd into the agents dir, write relatively
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo hacked > LIFE.md",
+            # other chained-relative verbs
+            "cd $HOME/.kiro/crew/agents/x; cp /tmp/evil LIFE.md",
+            "cd ~/.kirocrew/agents/ab12cd34 && tee LIFE.md < /tmp/evil",
+            # dot-segment spelling of the cd target
+            "cd ~/.kiro/crew/agents/./ab12cd34 && echo hacked > LIFE.md",
+        ],
+    )
+    def test_bash_gate_catches_chained_relative_write(self, cmd: str) -> None:
+        # The chain check lives in the gate function, not the compiled
+        # alternation (kept out to avoid two whole-command scans per call).
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            r"cmd /c echo hacked > C:\Users\u\.kiro\crew\agents\ab12\LIFE.md",
+            r"Set-Content $env:USERPROFILE\.kirocrew\agents\x\LIFE.md evil",
+            r"echo hacked > %USERPROFILE%\.kiro\crew\agents\ab12\LIFE.md",
+            # native cd + relative write chain
+            r"cd C:\Users\u\.kiro\crew\agents\ab12 && echo hacked > LIFE.md",
+        ],
+    )
+    def test_bash_gate_catches_windows_native_spellings(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    def test_chained_journal_work_stays_allowed(self) -> None:
+        from kiro_crew.security import _build_sensitive_regex
+
+        rx = _build_sensitive_regex()
+        assert not rx.search(
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo entry >> JOURNAL.md"
+        )
+
+    def test_env_anchored_chain_caught_when_regex_built_with_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.security import (
+            _build_sensitive_regex,
+            is_sensitive_bash_command,
+        )
+
+        crew = tmp_path / "crew-home"
+        crew.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(crew))
+        # Rebuild so the env-anchored halves are recomputed for this HOME.
+        _build_sensitive_regex()
+        cmd = f"cd {crew}/agents/ab12cd34 && echo hacked > LIFE.md"
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None
+
+    # ── GPT round-8 ──────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize("leaf", ["life.md", "Life.md", "LIFE.MD"])
+    def test_edit_gate_denies_recased_life_md(self, leaf: str) -> None:
+        """On case-insensitive filesystems (macOS/Windows) ``life.md`` names
+        the same goal file — the guard compares casefolded."""
+        from pathlib import Path as _P
+
+        from kiro_crew.security import is_sensitive_write_path
+
+        home = _P.home()
+        life = home / ".kiro" / "crew" / "agents" / "abcd1234" / leaf
+        assert is_sensitive_write_path(str(life)) is True
+
+    def test_edit_gate_recased_journal_stays_writable(self) -> None:
+        from pathlib import Path as _P
+
+        from kiro_crew.security import is_sensitive_write_path
+
+        home = _P.home()
+        journal = home / ".kiro" / "crew" / "agents" / "abcd1234" / "journal.md"
+        assert is_sensitive_write_path(str(journal), session_key="cron:abcd1234") is False
+
+    def test_bash_gate_recased_spelling_matches(self) -> None:
+        from kiro_crew.security import _build_sensitive_regex
+
+        # the bash regex already compiles with re.IGNORECASE — pin it
+        rx = _build_sensitive_regex()
+        assert rx.search("echo hacked > ~/.kiro/crew/agents/ab12cd34/life.md")
+
+    # ── GPT round-9 ──────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # quote-splice inside the leaf name (the reported bypass)
+            "echo hacked > ~/.kiro/crew/agents/ab12cd34/LI''FE.md",
+            'echo hacked > ~/.kiro/crew/agents/ab12cd34/"LIFE".md',
+            'echo hacked > ~/.kiro/crew/agents/ab12cd34/L"IF"E.md',
+            "tee ~/.kiro/crew/agents/x1/LI''FE.md < /tmp/x",
+            # quote-splice on the chained-relative form
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo hacked > LI''FE.md",
+            # unquoted forms must keep working
+            "echo hacked > ~/.kiro/crew/agents/ab12cd34/LIFE.md",
+        ],
+    )
+    def test_full_bash_gate_denies_quote_spliced_life_md(self, cmd: str) -> None:
+        """The FULL gate (regex pass 1 + normalizer pass 2) must deny every
+        shell-quoting spelling — the regex cannot see through quotes, so the
+        normalizer pass is the layer that has to check the write-protected
+        goal file, not only the read-blocked credential set."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "echo entry >> ~/.kiro/crew/agents/ab12cd34/JOURNAL.md",
+            "echo entry >> ~/.kiro/crew/agents/ab12cd34/JOUR''NAL.md",
+            "ls ~/.kiro/crew/agents",
+            "cat README.md",
+        ],
+    )
+    def test_full_bash_gate_leaves_journal_and_reads_alone(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    # ── GPT round-10 ─────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # variable indirection removes the literal entirely
+            'cd ~/.kiro/crew/agents/ab12cd34 && n=LIFE; echo hacked > "$n.md"',
+            "cd ~/.kiro/crew/agents/ab12cd34 && f=LIFE.md; echo hacked > $f",
+            'cd ~/.kiro/crew/agents/ab12cd34 && printf x > "${n}.md"',
+            "cd ~/.kiro/crew/agents/ab12cd34 && tee $f < /tmp/evil",
+            'echo hacked > ~/.kiro/crew/agents/ab12cd34/"$n".md',
+            # command substitution is the same class
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo x > `basename LIFE.md`",
+        ],
+    )
+    def test_variable_derived_write_in_agents_dir_is_refused(self, cmd: str) -> None:
+        """No static layer can resolve a variable-derived target, so a write
+        whose destination is variable-derived is refused when the command
+        already names a crew agents directory. Fail closed: the caller can
+        always spell the path literally."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # variable write targets ELSEWHERE stay allowed — the refusal is
+            # scoped to the agents-directory conjunction
+            "cd /tmp && f=out.txt; echo x > $f",
+            "cd ~/Repos/proj && echo x > $OUT",
+            "echo $HOME",
+            # literal JOURNAL.md work in the agents dir stays allowed
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo entry >> JOURNAL.md",
+        ],
+    )
+    def test_variable_write_scope_is_narrow(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+
+class TestSelfInvariantsSurviveUpdate:
+    """GPT round-11: the generic update path must not un-make a perpetual job.
+
+    Each field here silently BREAKS the agent rather than erroring, which is
+    why refusal beats coercion: a coerced update would report success for a
+    change that did not happen.
+    """
+
+    def test_interval_change_keeps_kind_self(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        got = svc.update_job(job.id, every_secs=7200)
+        assert got is not None
+        assert got.schedule.kind == "self"
+        assert got.schedule.every_secs == 7200
+
+    def test_interval_change_leaves_agent_sleep_usable(self, tmp_path: Path) -> None:
+        """The regression this guards: after an interval change the job used to
+        become kind='every', and agent_sleep then refused it outright."""
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        svc.update_job(job.id, every_secs=7200)
+        got = svc.record_agent_sleep(job.id, 600, "did", "next")
+        assert got.next_wake_ts is not None
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"persistent_session": False},
+            {"strict_schedule": False},
+            {"delete_after_run": True},
+        ],
+    )
+    def test_invariant_breaking_updates_are_refused(
+        self, tmp_path: Path, kwargs: dict
+    ) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        with pytest.raises(ValueError):
+            svc.update_job(job.id, **kwargs)
+
+    def test_refused_update_leaves_the_job_untouched(self, tmp_path: Path) -> None:
+        """Validation runs before ANY field assignment, so a rejected update
+        must not have applied the fields that came with it."""
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        with pytest.raises(ValueError):
+            svc.update_job(job.id, name="renamed", persistent_session=False)
+        got = svc.get_job(job.id)
+        assert got is not None
+        assert got.name == job.name
+        assert got.persistent_session is True
+
+    def test_enabling_the_invariants_is_still_allowed(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        got = svc.update_job(job.id, persistent_session=True, strict_schedule=True)
+        assert got is not None
+        assert got.persistent_session is True
+        assert got.strict_schedule is True
+
+    def test_plain_jobs_keep_generic_update_semantics(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = svc.add_job(name="plain", message="m", every_secs=3600)
+        got = svc.update_job(job.id, every_secs=7200, persistent_session=False)
+        assert got is not None
+        assert got.schedule.kind == "every"
+        assert got.persistent_session is False
+
+    # ── GPT round-12 ─────────────────────────────────────────────────────
+
+    def test_cron_expr_update_is_refused_on_self_job(self, tmp_path: Path) -> None:
+        """The other route that converted the job away from kind='self'."""
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        with pytest.raises(ValueError):
+            svc.update_job(job.id, cron_expr="0 9 * * MON-FRI")
+        got = svc.get_job(job.id)
+        assert got is not None
+        assert got.schedule.kind == "self"
+
+    def test_at_ts_update_is_refused_on_self_job(self, tmp_path: Path) -> None:
+        """Refused LOUDLY rather than left as a silent no-op: this path ignores
+        at_ts (no branch applies it), so update_job reported success while
+        changing nothing — the same "operator believes the cadence moved"
+        failure shape as a silent conversion."""
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        with pytest.raises(ValueError):
+            svc.update_job(job.id, at_ts=time.time() + 9999)
+        got = svc.get_job(job.id)
+        assert got is not None
+        assert got.schedule.kind == "self"
+        assert got.schedule.every_secs == 3600
+
+    def test_at_ts_still_works_on_plain_jobs(self, tmp_path: Path) -> None:
+        """The refusal is scoped to perpetual jobs — a plain job keeps whatever
+        generic semantics this path already had for at_ts."""
+        svc = _svc(tmp_path)
+        job = svc.add_job(name="plain", message="m", every_secs=3600)
+        got = svc.update_job(job.id, at_ts=time.time() + 9999)
+        assert got is not None
+
+    def test_lowering_the_ceiling_clamps_a_stale_deadline(self, tmp_path: Path) -> None:
+        """_is_due honours next_wake_ts first, so a deadline recorded under the
+        OLD ceiling would keep the lowered ceiling from taking effect."""
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        svc.record_agent_sleep(job.id, 3500, "did", "next")
+        before = svc.get_job(job.id)
+        assert before is not None and before.next_wake_ts is not None
+        base = before.last_run_ts or before.created_ts
+
+        got = svc.update_job(job.id, every_secs=600)
+        assert got is not None
+        assert got.next_wake_ts is not None
+        assert got.next_wake_ts <= base + 600 + 1
+
+    def test_lowering_the_ceiling_keeps_an_earlier_deadline(self, tmp_path: Path) -> None:
+        """The wake-sooner half must survive an unrelated ceiling change: a
+        deadline already EARLIER than the new ceiling is left alone."""
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        svc.record_agent_sleep(job.id, 120, "did", "next")
+        before = svc.get_job(job.id)
+        assert before is not None and before.next_wake_ts is not None
+        chosen = before.next_wake_ts
+
+        got = svc.update_job(job.id, every_secs=600)
+        assert got is not None
+        assert got.next_wake_ts == chosen
+
+    def test_raising_the_ceiling_leaves_the_deadline_alone(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc, every=3600)
+        svc.record_agent_sleep(job.id, 1800, "did", "next")
+        before = svc.get_job(job.id)
+        assert before is not None
+        chosen = before.next_wake_ts
+
+        got = svc.update_job(job.id, every_secs=7200)
+        assert got is not None
+        assert got.next_wake_ts == chosen
+
+
+class TestCronsStoreWriteProtected:
+    """GPT round-11: the scheduler store is an input to an authorization
+    decision — every scheduling invariant is enforced at the tool boundary and
+    then persisted there, so an agent tool that could rewrite it authors a job
+    the tools would have refused."""
+
+    def test_edit_gate_denies_store_write(self) -> None:
+        from pathlib import Path as _P
+
+        from kiro_crew.security import is_sensitive_write_path
+
+        assert is_sensitive_write_path(str(_P.home() / ".kiro" / "crew" / "crons.json")) is True
+
+    def test_store_stays_readable(self) -> None:
+        from pathlib import Path as _P
+
+        from kiro_crew.security import is_sensitive_path
+
+        # write-protected, NOT read-blocked: `cron list` and the dashboard
+        # render it constantly and it holds no secret.
+        assert is_sensitive_path(str(_P.home() / ".kiro" / "crew" / "crons.json")) is False
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "echo x > ~/.kiro/crew/crons.json",
+            "tee $HOME/.kiro/crew/crons.json < /tmp/evil",
+            "cp /tmp/evil ~/.kirocrew/crons.json",
+        ],
+    )
+    def test_bash_gate_denies_store_write(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    # ── GPT round-12 ─────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # dot segment: the write-protected-leaf regex branch carries no
+            # dot-segment tolerance, so the normalizer pass is what has to
+            # catch these
+            "echo x > ~/.kiro/crew/./crons.json",
+            "echo x > ~/.kiro/./crew/crons.json",
+            "tee ~/.kiro/crew/x/../crons.json < /tmp/evil",
+            # quote splice
+            "echo x > ~/.kiro/crew/crons''.json",
+            # the same normalized coverage must hold for the OTHER
+            # write-protected leaves, not just the store
+            "echo x > ~/.kiro/crew/./config.json",
+            "echo x > ~/.kiro/crew/apps/ops-mission-control/data/./rotation.yaml",
+        ],
+    )
+    def test_normalized_spellings_of_write_protected_paths_are_denied(
+        self, cmd: str
+    ) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # unrelated writes elsewhere are untouched
+            "echo x > /tmp/out.json",
+            "cd /tmp && f=out.json; echo x > $f",
+        ],
+    )
+    def test_write_protection_does_not_block_unrelated_writes(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    def test_shell_reads_of_the_store_are_blocked_like_the_other_leaves(self) -> None:
+        """Documented posture of _WRITE_PROTECTED_BASH_LEAVES: that branch is
+        matched verb-INDEPENDENTLY so no write form can bypass it, which blocks
+        shell READS of those leaves too. Harmless for this file (it holds no
+        secret) and consistent with .data-home-ready / rotation.yaml: legitimate
+        readers use the CLI or the read tool, not shell cat."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command("cat ~/.kiro/crew/crons.json") is not None
+
+    def test_python_api_reads_are_unaffected(self) -> None:
+        """is_sensitive_path is the READ gate — the store stays outside it, so
+        the CLI, the dashboard and the read tool are unaffected."""
+        from pathlib import Path as _P
+
+        from kiro_crew.security import is_sensitive_path
+
+        assert is_sensitive_path(str(_P.home() / ".kiro" / "crew" / "crons.json")) is False
+
+    # ── GPT round-13 ─────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && printf '{}' > crons.json",
+            "cd ~/.kiro/crew; echo x >> crons.json",
+            "cd ~/.kirocrew && tee crons.json < /tmp/evil",
+            "cd $HOME/.kiro/crew && cp /tmp/evil crons.json",
+            "cd ~/.kiro/crew/apps/ops-mission-control/data && echo x > rotation.yaml",
+            "cd ~/.kiro/crew && echo x > .data-home-ready",
+        ],
+    )
+    def test_chained_relative_write_to_fenced_leaf_is_denied(self, cmd: str) -> None:
+        """After a chained ``cd`` the leaf is a bare relative token, so neither
+        a path-anchored branch nor the normalizer's resolved-path check can bind
+        it to the crew home — the normalizer resolves against the agent's cwd,
+        not against a ``cd`` earlier on the same line."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # reads in the crew home keep the posture their own branch defines
+            "cd ~/.kiro/crew && cat config.json",
+            "cd ~/.kiro/crew && ls -la",
+            "cat ~/.kiro/crew/config.json",
+            "sqlite3 ~/.kiro/crew/sessions.db .tables",
+            # a same-named file elsewhere, and non-fenced writes in the crew home
+            "cd /tmp && echo x > crons.json",
+            "cd ~/.kiro/crew && echo x > /tmp/out.txt",
+            "cd ~/Repos/proj && echo x > notes.md",
+        ],
+    )
+    def test_chained_relative_check_stays_narrow(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    def test_write_context_ignores_fd_duplication_and_input_redirects(self) -> None:
+        """``2>&1`` redirects no file and ``<`` is a read, so neither may count
+        as write context and turn a read into a refusal."""
+        from kiro_crew.security import _command_has_write_context
+
+        assert _command_has_write_context("cd ~/.kiro/crew && cat crons.json 2>&1") is False
+        assert _command_has_write_context("wc -l < crons.json") is False
+        assert _command_has_write_context("echo x > crons.json") is True
+        assert _command_has_write_context("tee crons.json") is True
+
+    # ── GPT round-14 ─────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # shell terminators immediately after the leaf
+            'echo "{}" > ~/.kiro/crew/crons.json;',
+            'echo "{}" > ~/.kiro/crew/crons.json|tee /tmp/x',
+            '(echo "{}" > ~/.kiro/crew/crons.json)',
+            "echo x > ~/.kiro/crew/crons.json&",
+            # the PRE-EXISTING fences carried the same gap
+            "echo x > ~/.kiro/crew/.data-home-ready;",
+            "echo x > ~/.kiro/crew/agents/ab12cd34/LIFE.md;",
+            # and the chained-relative half
+            "cd ~/.kiro/crew && printf '{}' > crons.json;",
+            "cd ~/.kiro/crew && printf '{}' > crons.json)",
+        ],
+    )
+    def test_shell_terminators_do_not_end_the_fence(self, cmd: str) -> None:
+        """A path token can END at a shell control character, so the trailing
+        boundary has to admit them — otherwise a single ``;`` walks past every
+        branch that anchors on the leaf."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    def test_credential_paths_get_the_same_boundary(self) -> None:
+        """The boundary is shared, so the credential fences gain the fix too."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command("cat ~/.aws/credentials;") is not None
+        assert is_sensitive_bash_command("cat ~/.ssh/id_rsa|base64") is not None
+
+    # ── GPT round-15 ─────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize("ws", ["\t", "\n", "\x0b", "  "])
+    def test_write_verbs_are_recognised_after_any_shell_whitespace(self, ws: str) -> None:
+        """A shell word separator is not just U+0020, so the write-context test
+        must not key on the space character."""
+        from kiro_crew.security import _command_has_write_context
+
+        assert _command_has_write_context(f"tee{ws}crons.json") is True
+
+    def test_tab_separated_write_reaches_the_store_fence(self) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command("cd ~/.kiro/crew && tee\tcrons.json") is not None
+
+    # ── GPT round-16 ─────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # a redirect attached with no space ends the path token too
+            "echo x > ~/.kiro/crew/crons.json>/tmp/out",
+            "echo x > ~/.kiro/crew/crons.json<in",
+            "echo x > ~/.kiro/crew/agents/ab12/LIFE.md>/tmp/out",
+            # shared boundary, so the credential fences get it as well
+            "cat ~/.aws/credentials>/tmp/leak",
+        ],
+    )
+    def test_attached_redirect_does_not_end_the_fence(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            'cd ~/.kiro/crew && f=crons; : > "$f.json"',
+            'cd ~/.kiro/crew && n=data-home-ready; echo x > ".$n"',
+            "cd ~/.kirocrew && tee $f",
+        ],
+    )
+    def test_variable_composed_leaf_in_crew_home_is_refused(self, cmd: str) -> None:
+        """Same answer as the agents-directory case, through the same matcher:
+        a variable-derived write target cannot be resolved statically, so inside
+        a command that already names the crew home it is refused."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd /tmp && f=out; echo x > $f.json",
+            "echo x > /tmp/a.json>/tmp/b",
+            "cd ~/.kiro/crew && cat config.json",
+        ],
+    )
+    def test_round16_additions_stay_narrow(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    # ── GPT round-19 ─────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # operating on the CONTAINER instead of the leaf
+            "mv ~/.kiro/crew/agents ~/.kiro/crew/agents.bak",
+            "mkdir ~/.kiro/crew/agents/ab12cd34",
+            "mv /tmp/staged ~/.kiro/crew/agents/ab12cd34",
+            "rmdir ~/.kiro/crew/agents/ab12cd34",
+            # deletion is a write
+            "rm ~/.kiro/crew/crons.json",
+            "cd ~/.kiro/crew && rm crons.json",
+            # the UNEXPANDED data-home variable is an anchor too
+            'rm "$KIROCREW_HOME/crons.json"',
+            "echo x > ${KIROCREW_HOME}/crons.json",
+        ],
+    )
+    def test_container_and_deletion_spellings_are_refused(self, cmd: str) -> None:
+        """Sixth spelling of one class: every earlier fence keyed on the leaf
+        NAME, so operating on the directory that holds it reached the same
+        effect without ever writing that name. The agents subtree is now an
+        ALLOWLIST (JOURNAL.md only), which converges where a denylist of
+        spellings could not."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "path_leaf,denied",
+        [
+            ("LIFE.md", True),
+            ("life.md", True),
+            ("NOTES.md", True),
+            ("JOURNAL.md", False),
+            ("journal.md", False),
+        ],
+    )
+    def test_agents_subtree_allowlist_is_journal_only(
+        self, path_leaf: str, denied: bool
+    ) -> None:
+        from pathlib import Path as _P
+
+        from kiro_crew.security import is_sensitive_write_path
+
+        p = _P.home() / ".kiro" / "crew" / "agents" / "ab12cd34" / path_leaf
+        assert (
+            is_sensitive_write_path(str(p), session_key=_OWNER_SESSION_KEY) is denied
+        ), path_leaf
+
+    def test_agents_root_and_id_dir_are_write_protected(self) -> None:
+        from pathlib import Path as _P
+
+        from kiro_crew.security import is_sensitive_write_path
+
+        agents = _P.home() / ".kiro" / "crew" / "agents"
+        assert is_sensitive_write_path(str(agents)) is True
+        assert is_sensitive_write_path(str(agents / "ab12cd34")) is True
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # the journal must stay appendable, including through a chained cd —
+            # a navigation argument is not a write target
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo entry >> JOURNAL.md",
+            "echo entry >> ~/.kiro/crew/agents/ab12cd34/JOURNAL.md",
+            "ls ~/.kiro/crew/agents",
+            # deletions elsewhere are untouched
+            "rm /tmp/scratch.json",
+            "cd /tmp && rm crons.json",
+        ],
+    )
+    def test_round19_additions_stay_narrow(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    def test_navigation_argument_is_not_a_write_target(self) -> None:
+        """Positional, so a real write target later in the same command still
+        counts: only the token immediately after cd/pushd is exempt."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert (
+            is_sensitive_bash_command("cd /tmp && echo x > ~/.kiro/crew/crons.json")
+            is not None
+        )
+
+    # ── GPT round-21 ─────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            'cd ~/.kiro/crew && python -c \'open("crons.json","w").write("{}")\'',
+            'cd ~/.kiro/crew && python3 -c \'import pathlib;pathlib.Path("crons.json").write_text("{}")\'',
+            "cd ~/.kiro/crew && perl -e 'open(F,\">crons.json\")'",
+            'cd ~/.kiro/crew && node -e \'require("fs").writeFileSync("crons.json","{}")\'',
+            "cd ~/.kiro/crew && sh -c 'echo x > crons.json'",
+            'cd ~/.kiro/crew/agents/ab12cd34 && python -c \'open("LIFE.md","w").write("x")\'',
+            # round 22: a SCRIPT FILE is the same thing
+            "cd ~/.kiro/crew && python /tmp/rewrite.py crons.json",
+            "cd ~/.kiro/crew && python3 /tmp/x.py crons.json",
+            "cd ~/.kiro/crew && node /tmp/x.js crons.json",
+            "cd ~/.kiro/crew/agents/ab12cd34 && python /tmp/x.py LIFE.md",
+        ],
+    )
+    def test_inline_interpreter_counts_as_write_context(self, cmd: str) -> None:
+        """The leaf name and the crew home are both in the text here — only the
+        write-context classifier failed, because an interpreter is neither a
+        write verb nor a redirect. Deliberately NOT keyed on mutation calls
+        inside the payload: a write can be spelled unboundedly many ways there,
+        and enumerating them is the denylist this file has already lost to six
+        times."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # an interpreter alone is not a refusal — it only matters where the
+            # command also names the crew home or the agents subtree
+            "cd /tmp && python -c 'open(\"out.json\",\"w\").write(\"{}\")'",
+            "python -c 'print(1)'",
+            "python /tmp/probe.py",
+            "cd /tmp && python /tmp/x.py crons.json",
+            "node_modules/.bin/vite build",
+            "cd ~/Repos/proj && node -e 'require(\"fs\").writeFileSync(\"a.json\",\"1\")'",
+            # and the pinned crew-home reads stay readable
+            "cat ~/.kiro/crew/config.json",
+            "sqlite3 ~/.kiro/crew/sessions.db .tables",
+            # journal work is unaffected by the new write-context source
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo entry >> JOURNAL.md",
+        ],
+    )
+    def test_round21_addition_stays_narrow(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    def test_interpreter_write_context_covers_script_files_too(self) -> None:
+        """Round 21 pinned the opposite of this, and round 22 reversed it.
+        The earlier rule matched only the inline ``-c``/``-e`` form and asserted
+        ``python /tmp/script.py`` was NOT write context. That was a distinction
+        without a difference: a script file mutates exactly as well, and the
+        argument naming the target sits in the command line either way
+        (``cd ~/.kiro/crew && python /tmp/rewrite.py crons.json``). Where the
+        program text lives says nothing about whether it writes, so the rule now
+        keys on "an interpreter is running".
+        """
+        from kiro_crew.security import _command_has_write_context
+
+        assert _command_has_write_context("python /tmp/script.py") is True
+        assert _command_has_write_context("python -c 'x'") is True
+        assert _command_has_write_context("/usr/bin/python3 -c 'x'") is True
+        # A path segment that merely contains an interpreter name is not one.
+        # Asserted against the interpreter matcher itself rather than the whole
+        # helper: since round 33 an unrecognized executable IS write context, and
+        # `node_modules/.bin/vite` is unrecognized — so the helper returning True
+        # is correct for a DIFFERENT reason, and asserting False here would only
+        # re-pin the old semantics. The original intent — `node_modules` must not
+        # be mistaken for the `node` interpreter — is what is checked.
+        from kiro_crew.security import _INLINE_INTERPRETER_RE
+
+        assert _INLINE_INTERPRETER_RE.search("node_modules/.bin/vite build") is None
+        assert _command_has_write_context("ls -la") is False
+
+
+class TestAgentSleepGovernance:
+    """GPT round-10: writing next_wake_ts IS a cron mutation, so the    capabilities.cron gate applies to agent_sleep as it does to cron_add.
+
+    These go through the real ``_call_tool_inner``, which builds its OWN
+    ``CronService(base_dir=config_dir())`` — so the job has to be created in
+    that same store (conftest pins ``KIROCREW_HOME`` per test), not in a
+    separately-constructed service.
+    """
+
+    @staticmethod
+    def _handler_svc() -> Any:
+        from kiro_crew.config.loader import config_dir
+        from kiro_crew.cron import CronService
+
+        return CronService(base_dir=config_dir())
+
+    def test_denied_capability_refuses_and_leaves_deadline_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        import kiro_crew.mcp_cron as mc
+
+        svc = self._handler_svc()
+        job = _add_self(svc, every=3600)
+        assert job.next_wake_ts is None
+
+        with (
+            patch.object(mc, "_resolve_session_key_strict", return_value=f"cron:{job.id}"),
+            patch.object(
+                mc,
+                "_vet_cron_capability_governance",
+                return_value="Error: cron scheduling blocked by governance policy: off",
+            ),
+        ):
+            out = mc._call_tool_inner(
+                "agent_sleep", {"next_wake_secs": 600, "did": "x", "next_intent": "y"}
+            )
+
+        assert "governance policy" in out, out
+        # The refused call must not have persisted a deadline.
+        assert self._handler_svc().get_job(job.id).next_wake_ts is None
+
+    def test_permitted_capability_records_normally(self, tmp_path: Path) -> None:
+        import kiro_crew.mcp_cron as mc
+
+        svc = self._handler_svc()
+        job = _add_self(svc, every=3600)
+
+        with (
+            patch.object(mc, "_resolve_session_key_strict", return_value=f"cron:{job.id}"),
+            patch.object(mc, "_vet_cron_capability_governance", return_value=None),
+        ):
+            out = mc._call_tool_inner(
+                "agent_sleep", {"next_wake_secs": 600, "did": "x", "next_intent": "y"}
+            )
+
+        assert "Recorded" in out, out
+        assert self._handler_svc().get_job(job.id).next_wake_ts is not None
+
+    def test_gate_is_keyed_to_the_calling_job(self, tmp_path: Path) -> None:
+        """The SEL deny trail must name the job, not the generic vetting key."""
+        import kiro_crew.mcp_cron as mc
+
+        svc = self._handler_svc()
+        job = _add_self(svc, every=3600)
+        seen: list[str] = []
+
+        def _spy(session_key: str | None = None) -> str | None:
+            seen.append(session_key or "")
+            return None
+
+        with (
+            patch.object(mc, "_resolve_session_key_strict", return_value=f"cron:{job.id}"),
+            patch.object(mc, "_vet_cron_capability_governance", _spy),
+        ):
+            mc._call_tool_inner("agent_sleep", {"next_wake_secs": 600})
+
+        assert seen == [f"cron:{job.id}"], seen
+
+
+class TestPerpetualCreationAllowlist:
+    """GPT round-5: perpetual creation is a POSITIVE operator allowlist —
+    empty and automation identities are refused, not just cron:."""
+
+    @pytest.mark.parametrize(
+        "caller,allowed",
+        [
+            ("dashboard:abc123", True),
+            ("slack:C1:169.1", True),
+            # GPT round-7: every human messaging channel is an operator
+            # surface, via the shared is_channel_session_key predicate.
+            ("webex:room1", True),
+            ("wecom:u1", True),
+            ("teams:conv1", True),
+            ("weixin:u1", True),
+            ("whatsapp:u1", True),
+            ("unified:kirocrew:dm:u1", True),
+            ("discord:guild1:chan1", True),
+            ("telegram:chat1", True),
+            # legacy un-namespaced Slack thread_ts
+            ("1785370133.085469", True),
+            # automation identities stay refused
+            ("cron:ab12cd34", False),
+            ("subagent:xyz", False),
+            ("webhook:h1", False),
+            ("heartbeat:h1", False),
+            ("taskrunner:t1", False),
+            ("", False),
+        ],
+    )
+    def test_caller_gating(self, tmp_path: Path, caller: str, allowed: bool) -> None:
+        import kiro_crew.mcp_cron as mc
+
+        svc = _svc(tmp_path)
+        args = {
+            "name": "w",
+            "message": "goal",
+            "every": 3600,
+            "perpetual": True,
+        }
+        with (
+            patch.object(mc, "_resolve_session_key_strict", return_value=caller),
+            patch.object(mc, "_resolve_session_key", return_value=caller or "x"),
+            patch.object(mc, "get_service", return_value=svc, create=True),
+        ):
+            # Route through the real handler if its service accessor matches;
+            # otherwise call the inner tool with the svc patched in place.
+            with patch.object(mc, "svc", svc, create=True):
+                out = mc._call_tool_inner("cron_add", dict(args))
+        if allowed:
+            assert "Added job" in out, out
+        else:
+            assert "operator session" in out, out
+
+
+class TestAgentsSubtreeRelativeWrites:
+    """GPT round-23: the round-19 allowlist works on RESOLVED paths, so a bare
+    relative target after a chained ``cd`` never reached it — the normalizer
+    resolves it against the agent's cwd, not against the ``cd``. Ninth spelling
+    of one class, handled in the conjunction that already existed.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew/agents && rm -rf ab12cd34 && mv /tmp/staged ab12cd34",
+            "cd ~/.kiro/crew/agents && mkdir ab12cd34",
+            "cd ~/.kiro/crew/agents && mv ab12cd34 ab12cd34.bak",
+            "cd ~/.kiro/crew/agents && rmdir ab12cd34",
+            "cd ~/.kirocrew/agents && cp -r /tmp/staged ab12cd34",
+            "cd ~/.kiro/crew/agents/ab12cd34 && rm LIFE.md",
+        ],
+    )
+    def test_relative_writes_under_agents_are_refused(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # the ONE allowed write in that subtree survives the new rule
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo entry >> JOURNAL.md",
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo entry >> journal.md",
+            "echo entry >> ~/.kiro/crew/agents/ab12cd34/JOURNAL.md",
+            # reads keep the posture their own branches define
+            "ls ~/.kiro/crew/agents",
+            "cd ~/.kiro/crew/agents && ls -la",
+            # and an identically-named directory elsewhere is untouched
+            "cd /tmp/agents && mkdir ab12cd34",
+        ],
+    )
+    def test_journal_and_reads_survive(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    def test_journal_allowance_does_not_launder_a_second_target(self) -> None:
+        """Naming JOURNAL.md must not buy a write to something else in the same
+        command — the allowance requires the journal to be the only fenced name."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        cmd = (
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo x > LIFE.md && echo y >> JOURNAL.md"
+        )
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None
+
+
+class TestJournalAllowanceIsPositive:
+    """GPT round-24: the round-23 allowance asked "a journal is mentioned AND
+    LIFE.md is not" — a denylist nested inside an allowlist. A glob names no
+    fenced leaf at all, so ``rm -rf -- * && echo e >> JOURNAL.md`` sailed
+    through it. The allowance is now positive: no write verb anywhere, and every
+    redirect target is a journal.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # the finding, verbatim in shape
+            "cd ~/.kiro/crew/agents/ab12cd34 && rm -rf -- * && echo entry >> JOURNAL.md",
+            # a journal append does not launder a SECOND redirect target
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo e >> JOURNAL.md && echo z > state.json",
+            # nor a verb whose target is spelled some other way
+            "cd ~/.kiro/crew/agents/ab12cd34 && rm LIFE.md && echo e >> JOURNAL.md",
+            "cd ~/.kiro/crew/agents/ab12cd34 && cp /tmp/x LIFE.md && echo e >> JOURNAL.md",
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo x > LIFE.md && echo y >> JOURNAL.md",
+        ],
+    )
+    def test_journal_mention_cannot_launder_another_write(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo entry >> JOURNAL.md",
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo entry >> journal.md",
+            "echo entry >> ~/.kiro/crew/agents/ab12cd34/JOURNAL.md",
+            "cd ~/.kiro/crew/agents/ab12cd34 && printf '%s\\n' x >> JOURNAL.md",
+        ],
+    )
+    def test_the_one_allowed_write_still_works(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+
+class TestContractPreambleLeads:
+    """GPT round-24: the §7 preamble was prepended BEFORE the last_result block
+    was composed, so the previous-run result ended up above the contract for
+    every agent that had already run once — the majority case. §7 requires the
+    contract to lead, and its RANK FIRST step depends on that position.
+    """
+
+    def test_contract_leads_even_with_a_previous_result(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        job.last_result = "ranked three candidates last time"
+        _key, msg = build_cron_session_context(job)
+        contract_at = msg.index("You are a perpetual agent")
+        result_at = msg.index("[Previous run result")
+        assert contract_at < result_at, "contract must precede the previous result"
+        assert msg.startswith(_SELF_CONTRACT_PREAMBLE.split("\n")[0])
+
+    def test_previous_result_still_present_and_ordered_before_the_task(
+        self, tmp_path: Path
+    ) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        job.last_result = "prior work"
+        _key, msg = build_cron_session_context(job)
+        assert msg.index("[Previous run result") < msg.index("pursue the goal")
+
+
+class TestVerbSpellingIsTokenized:
+    """GPT round-25 reported ``/bin/rm``: the verb test was substring membership
+    on a space-delimited string, so a path-qualified verb never matched. Probing
+    it turned up two more spellings of the same root cause — ``&&rm`` (an
+    operator ends a word without a space) and ``'rm'`` (quotes break the window).
+    One shape change (split on operators, strip quotes, compare basenames) covers
+    all three, which is why they are pinned together here.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && /bin/rm -f crons.json",
+            "cd ~/.kiro/crew && /usr/bin/rm -f crons.json",
+            "cd ~/.kiro/crew&&rm -f crons.json",
+            "cd ~/.kiro/crew;rm -f crons.json",
+            "cd ~/.kiro/crew && 'rm' -f crons.json",
+            'cd ~/.kiro/crew && "rm" -f crons.json',
+            "cd ~/.kiro/crew && /usr/bin/tee crons.json",
+            "cd ~/.kiro/crew/agents && /bin/mkdir ab12cd34",
+            # the round-24 journal allowance must not be reopened by a
+            # path-qualified verb either
+            "cd ~/.kiro/crew/agents/ab12 && /bin/rm -rf -- * && echo e >> JOURNAL.md",
+        ],
+    )
+    def test_path_qualified_and_glued_verbs_are_caught(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # exact basename matching: scp is not cp, and naming a verb's path as
+            # a READ argument is not a write
+            "scp host:/a /tmp/b",
+            "ls /usr/bin/rm",
+            "cd ~/.kiro/crew && ls -la",
+            "cd ~/.kiro/crew && grep -c . config.json",
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo entry >> JOURNAL.md",
+            "node_modules/.bin/vite build",
+            "/bin/rm /tmp/scratch.txt",
+        ],
+    )
+    def test_tokenization_does_not_overblock(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+
+class TestJournalAllowanceConsultsWriteContext:
+    """GPT round-26: the allowance asked only "no write VERB", so it missed the
+    OTHER signal this module already counts as a write — an interpreter
+    invocation (round 22). The allowance was wider than the module's own notion
+    of a write, which is a drift bug rather than a missing pattern.
+
+    It now strips redirects and asks _command_has_write_context about the
+    remainder, so any future write-context signal is consulted automatically
+    instead of having to be remembered in a second place.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # script-file form: the leaf name never appears, which is exactly why
+            # round 22 made the interpreter itself the signal
+            "cd ~/.kiro/crew/agents/ab12 && python /tmp/wipe.py && echo e >> JOURNAL.md",
+            "cd ~/.kiro/crew && python /tmp/w.py && echo e >> ~/.kiro/crew/agents/ab12/JOURNAL.md",
+            "cd ~/.kiro/crew/agents/ab12 && node /tmp/wipe.js && echo e >> JOURNAL.md",
+            "cd ~/.kiro/crew/agents/ab12 && perl /tmp/wipe.pl && echo e >> JOURNAL.md",
+            # inline payload form
+            "cd ~/.kiro/crew/agents/ab12 && python -c 'import os' && echo e >> JOURNAL.md",
+            # an interpreter-wrapped append does not earn the allowance either:
+            # once running it can do anything, so its redirect text proves nothing
+            "cd ~/.kiro/crew/agents/ab12 && bash -lc 'echo x >> JOURNAL.md'",
+        ],
+    )
+    def test_interpreter_defeats_the_journal_allowance(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo entry >> JOURNAL.md",
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo entry >> journal.md",
+            "echo entry >> ~/.kiro/crew/agents/ab12cd34/JOURNAL.md",
+            "cd ~/.kiro/crew/agents/ab12cd34 && printf '%s\\n' x >> JOURNAL.md",
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo entry >> JOUR''NAL.md",
+        ],
+    )
+    def test_the_supported_append_forms_survive(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    def test_allowance_is_derived_not_duplicated(self) -> None:
+        """The allowance must consult the shared write-context helper, so a new
+        signal added there cannot silently reopen it."""
+        from kiro_crew import security
+
+        with patch.object(security, "_command_has_write_context", return_value=True):
+            assert security._is_journal_only_write("echo x >> JOURNAL.md") is False
+
+
+class TestConditionalWriteVerbs:
+    """GPT round-27: ``find . -name crons.json -delete`` was allowed. ``find``
+    cannot join the unconditional verb set — it is overwhelmingly a READ, and
+    making it write context would turn write-protection into read-blocking for
+    ``find . -name '*.json'`` in the crew home, the one thing these conjunctions
+    must never do. So the verb set gained a conditional half keyed on the flags
+    that make a program mutate.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && find . -name crons.json -delete",
+            "cd ~/.kiro/crew && find . -name x -fprintf crons.json '%p'",
+            "cd ~/.kiro/crew && find . -name x -fls crons.json",
+            # already caught via the inner verb, pinned so the conditional half
+            # is not silently relied upon alone
+            "cd ~/.kiro/crew && find . -name crons.json -exec rm {} ;",
+            "cd ~/.kiro/crew && find . -name crons.json -execdir rm {} ;",
+            "cd ~/.kiro/crew && find . -name crons.json | xargs rm",
+            "cd ~/.kiro/crew/agents && find . -name LIFE.md -delete",
+            "cd ~/.kiro/crew && /usr/bin/find . -name crons.json -delete",
+        ],
+    )
+    def test_conditional_mutators_are_write_context(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # THE point of the conditional half: find without a mutating flag is
+            # a read, even when it names a fenced leaf
+            "cd ~/.kiro/crew && find . -name '*.json'",
+            "cd ~/.kiro/crew && find . -name crons.json",
+            "cd ~/.kiro/crew && find . -type f -newer config.json",
+            "cd ~/.kiro/crew && find . -name crons.json -print",
+            # and a mutating find outside the crew home is not this gate's business
+            "find /tmp -name '*.log' -delete",
+        ],
+    )
+    def test_plain_find_stays_a_read(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+
+class TestJournalWritesAreOwnerScoped:
+    """GPT round-27: the journal exemption was not owner-scoped, so agent A could
+    write agent B's JOURNAL.md — and a journal is read back into its OWNER's next
+    prompt, making that write a cross-agent prompt-injection channel. This is the
+    WRITE side of the threat round 15 closed on the READ side (a symlinked
+    <job.id> pulling a victim's LIFE.md into this job's prompt).
+
+    Identity is available: both real transports pass session_key into
+    hooks.on_tool_call, and a perpetual agent runs as ``cron:<job.id>`` whose life
+    directory is ``agents/<job.id>``.
+    """
+
+    OWNER = "cron:job111"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "echo e >> ~/.kiro/crew/agents/job111/JOURNAL.md",
+            "cd ~/.kiro/crew/agents/job111 && echo e >> JOURNAL.md",
+            "cd ~/.kiro/crew/agents/job111 && echo e >> journal.md",
+        ],
+    )
+    def test_owner_may_append_its_own_journal(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=self.OWNER) is None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "echo pwned >> ~/.kiro/crew/agents/job999/JOURNAL.md",
+            # the victim id appears only in the cd, never in the redirect target
+            "cd ~/.kiro/crew/agents/job999 && echo pwned >> JOURNAL.md",
+            "echo pwned > ~/.kiro/crew/agents/job999/JOURNAL.md",
+            "cd ~/.kiro/crew/agents/job999 && echo pwned >> journal.md",
+        ],
+    )
+    def test_another_agents_journal_is_refused(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=self.OWNER) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "key", [None, "", "dashboard:main", "subagent:abc", "webhook:x", "cron:"]
+    )
+    def test_no_identity_means_no_exemption(self, key: str | None) -> None:
+        """Positive form (the round-24 lesson): a caller that cannot prove it owns
+        the journal does not get the exemption — rather than everyone getting it."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        cmd = "echo e >> ~/.kiro/crew/agents/job111/JOURNAL.md"
+        assert is_sensitive_bash_command(cmd, session_key=key) is not None
+
+    def test_edit_gate_is_owner_scoped_too(self) -> None:
+        from pathlib import Path as _P
+
+        from kiro_crew.security import is_sensitive_write_path
+
+        mine = _P.home() / ".kiro" / "crew" / "agents" / "job111" / "JOURNAL.md"
+        theirs = _P.home() / ".kiro" / "crew" / "agents" / "job999" / "JOURNAL.md"
+        assert is_sensitive_write_path(str(mine), session_key=self.OWNER) is False
+        assert is_sensitive_write_path(str(theirs), session_key=self.OWNER) is True
+        assert is_sensitive_write_path(str(mine)) is True
+
+    def test_caller_agent_id_only_trusts_a_cron_key(self) -> None:
+        from kiro_crew.security import _caller_agent_id
+
+        assert _caller_agent_id("cron:job111") == "job111"
+        # a per-run stateless suffix still identifies the same owner
+        assert _caller_agent_id("cron:job111:deadbeef") == "job111"
+        for key in [None, "", "cron:", "cron", "dashboard:job111", "subagent:job111"]:
+            assert _caller_agent_id(key) is None, key
+
+
+class TestOutputFlagsAreWriteContext:
+    """GPT round-28: a fetcher with an output flag writes a file as surely as
+    ``tee`` — ``curl -o crons.json file:///tmp/evil`` replaces the store from
+    attacker-controlled bytes. Same conditional shape round 27 built for ``find``:
+    the program alone is a read, the FLAG makes it a write.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && curl -o crons.json file:///tmp/evil.json",
+            "cd ~/.kiro/crew && curl --output crons.json file:///tmp/evil.json",
+            # --flag=value is one shell word; the tokenizer now emits the flag half
+            "cd ~/.kiro/crew && curl --output=crons.json file:///tmp/evil.json",
+            "cd ~/.kiro/crew && curl -O file:///tmp/crons.json",
+            "cd ~/.kiro/crew && wget -O crons.json file:///tmp/evil.json",
+            "cd ~/.kiro/crew && wget --output-document=crons.json http://x/y",
+            "cd ~/.kiro/crew && openssl enc -d -in /tmp/e -out crons.json",
+            "cd ~/.kiro/crew && gpg -o crons.json -d /tmp/evil.gpg",
+            # not named in the report; found by probing the same shape
+            "cd ~/.kiro/crew && sort -o crons.json /tmp/evil.json",
+            # path-qualified, to prove the round-25 basename step still applies
+            "cd ~/.kiro/crew && /usr/bin/curl -o crons.json file:///tmp/evil.json",
+        ],
+    )
+    def test_output_flags_are_caught(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # the program without its output flag stays a read
+            "cd ~/.kiro/crew && curl -s file:///tmp/x",
+            "cd ~/.kiro/crew && curl -I https://example.com",
+            # -o on a program NOT in the table is not an output flag
+            "cd ~/.kiro/crew && grep -o pattern config.json",
+            # and a real write outside the crew home is not this gate's business
+            "curl -o /tmp/x.json https://example.com/y",
+            "sort -o /tmp/out.txt /tmp/in.txt",
+        ],
+    )
+    def test_flagless_and_outside_forms_stay_allowed(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd) is None, cmd
+
+    def test_flag_value_split_does_not_leak_the_value_as_a_word(self) -> None:
+        """The value half of ``--output=x`` must not become a word: a path that
+        happens to equal a verb name would otherwise read as that verb."""
+        from kiro_crew.security import _command_words
+
+        words = _command_words("curl --output=rm https://x")
+        assert "--output" in words
+        assert "rm" not in words
+
+
+class TestWriteVerbsAreDerivedNotCopied:
+    """GPT round-30: chmod/chown/touch (plus gzip, cpio, patch) were in the
+    _WRITE_CMDS regex and missing from the token set, so `chmod 000 crons.json`
+    read as no write context and the store could be made unreadable. The set
+    carried a comment asking the reader to keep it in sync by hand; three rounds
+    each reported a verb it was missing. It is now DERIVED from the regex, so
+    drift is not possible.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && chmod 000 crons.json",
+            "cd ~/.kiro/crew && chown nobody crons.json",
+            "cd ~/.kiro/crew && touch crons.json",
+            "cd ~/.kiro/crew && gzip crons.json",
+            "cd ~/.kiro/crew && patch crons.json /tmp/evil.patch",
+            # NB: ``cpio -i < archive`` is deliberately NOT here. It extracts into
+            # the cwd without naming the leaf, so it belongs to the target-never-
+            # appears-in-text class, not to this verb-coverage fix.
+            # the round-25 tokenizer still applies to the newly derived verbs
+            "cd ~/.kiro/crew && /bin/chmod 000 crons.json",
+            "cd ~/.kiro/crew&&chmod 000 crons.json",
+            "cd ~/.kiro/crew/agents/ab12cd34 && chmod 000 LIFE.md",
+        ],
+    )
+    def test_permission_and_archive_mutators_are_write_context(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_token_set_covers_every_verb_in_the_authoritative_regex(self) -> None:
+        """The invariant the old 'keep in sync' comment could only ask for."""
+        from kiro_crew.security import (
+            _NORMALIZER_WRITE_VERBS,
+            _WRITE_CMDS,
+            _verbs_from_write_cmds_regex,
+        )
+
+        assert _verbs_from_write_cmds_regex(_WRITE_CMDS) <= _NORMALIZER_WRITE_VERBS
+        for verb in ("chmod", "chown", "touch", "rm", "mv", "tee", "sed", "patch"):
+            assert verb in _NORMALIZER_WRITE_VERBS, verb
+
+    def test_derivation_drops_nested_git_subcommands(self) -> None:
+        """A bare ``git`` is not a write, and the subcommand words inside the
+        nested group must not leak in as standalone verbs — tearing that group
+        apart would admit ``clean``/``reset``/``apply`` as verbs of their own."""
+        from kiro_crew.security import _NORMALIZER_WRITE_VERBS
+
+        for leaked in ("git", "checkout", "restore", "reset", "apply", "clean", "stash"):
+            assert leaked not in _NORMALIZER_WRITE_VERBS, leaked
+
+    def test_token_only_verbs_are_still_present(self) -> None:
+        """cp/unlink/shred are not in the regex and must survive the switch."""
+        from kiro_crew.security import _NORMALIZER_WRITE_VERBS
+
+        for verb in ("cp", "unlink", "shred"):
+            assert verb in _NORMALIZER_WRITE_VERBS, verb
+
+
+class TestAttachedRedirectsAreWriteContext:
+    """GPT round-31: the redirect matcher required a whitespace/operator boundary
+    BEFORE the operator, so `echo -n>crons.json` — glued to the preceding word —
+    was not write context and the store could be truncated. The shell needs no
+    separator there; same root cause as round 25's `&&rm`.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && echo -n>crons.json",
+            "cd ~/.kiro/crew && echo x>crons.json",
+            "cd ~/.kiro/crew && echo x>>crons.json",
+            "cd ~/.kiro/crew && cat /tmp/evil>crons.json",
+            "cd ~/.kiro/crew && :>crons.json",
+            "cd ~/.kiro/crew && echo x>'crons.json'",
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo x>LIFE.md",
+        ],
+    )
+    def test_attached_redirects_are_caught(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert (
+            is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None
+        ), cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # fd duplication is not an output redirect
+            "cd ~/.kiro/crew && cat config.json 2>&1",
+            # NB: the interpreter form of this case deliberately does NOT name the
+            # crew home. Round 37 refuses an interpreter whenever the crew home is
+            # named, so keeping `cd ~/.kiro/crew` here would test that rule rather
+            # than the `2>&1`-is-not-a-write rule this case exists for.
+            "python -c 'print(1)' 2>&1",
+            # a '>' inside QUOTED DATA is text, not an operator. Without the
+            # quote-blanking step, dropping the boundary requirement would make
+            # this a write and REFUSE A READ of a fenced leaf.
+            "cd ~/.kiro/crew && grep 'a->b' crons.json",
+            'cd ~/.kiro/crew && grep "x>y" crons.json',
+            "cd ~/.kiro/crew && grep -c . crons.json",
+        ],
+    )
+    def test_fd_dup_and_quoted_arrows_stay_reads(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    def test_quote_blanking_preserves_length_and_outside_operators(self) -> None:
+        from kiro_crew.security import _blank_quoted_spans
+
+        src = "echo 'a>b' > crons.json"
+        out = _blank_quoted_spans(src)
+        assert len(out) == len(src)
+        # the quoted arrow is gone, the real redirect survives
+        assert "a>b" not in out
+        assert "> crons.json" in out
+
+    def test_owner_scoping_survives_the_attached_form(self) -> None:
+        """The round-28 owner check must still apply when the redirect is glued."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        own = "cd ~/.kiro/crew/agents/job111 && echo x>>JOURNAL.md"
+        other = "cd ~/.kiro/crew/agents/job999 && echo x>>JOURNAL.md"
+        assert is_sensitive_bash_command(own, session_key="cron:job111") is None
+        assert is_sensitive_bash_command(other, session_key="cron:job111") is not None
+        # and an attached TRUNCATE of the agent's own goal file is still refused
+        life = "cd ~/.kiro/crew/agents/job111 && echo x>LIFE.md"
+        assert is_sensitive_bash_command(life, session_key="cron:job111") is not None
+
+
+class TestJournalAllowanceRequiresCanonicalPaths:
+    """GPT round-32: a DOT SEGMENT defeats an id comparison made on text.
+    ``cd ~/.kiro/crew/agents/job111/../job999 && echo … >> JOURNAL.md`` matched the
+    owner's own id first, kept the allowance, and landed in the victim's dir. The
+    path level was never fooled (it uses realpath) but the chained-``cd`` form
+    leaves a bare relative target the path level never sees.
+    """
+
+    OWNER = "cron:job111"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew/agents/job111/../job999 && echo pwned >> JOURNAL.md",
+            "cd ~/.kiro/crew/agents/job111/./../job999 && echo pwned >> JOURNAL.md",
+            "echo pwned >> ~/.kiro/crew/agents/job111/../job999/JOURNAL.md",
+            # even landing back in the OWNER's own directory is refused: the
+            # allowance requires canonical paths rather than trying to
+            # canonicalise text, which is the losing game
+            "cd ~/.kiro/crew/agents/./job111 && echo ok >> JOURNAL.md",
+            "cd ~/.kiro/crew/agents/job999/../job111 && echo ok >> JOURNAL.md",
+        ],
+    )
+    def test_dot_segments_forfeit_the_allowance(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=self.OWNER) is not None, cmd
+
+    def test_canonical_own_journal_still_allowed(self) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        for cmd in (
+            "cd ~/.kiro/crew/agents/job111 && echo ok >> JOURNAL.md",
+            "echo ok >> ~/.kiro/crew/agents/job111/JOURNAL.md",
+        ):
+            assert is_sensitive_bash_command(cmd, session_key=self.OWNER) is None, cmd
+
+    def test_path_level_resolves_traversal_independently(self) -> None:
+        """Defence in depth: the resolved-path gate catches the same traversal."""
+        from pathlib import Path as _P
+
+        from kiro_crew.security import is_sensitive_write_path
+
+        p = str(_P.home() / ".kiro/crew/agents/job111/../job999/JOURNAL.md")
+        assert is_sensitive_write_path(p, session_key=self.OWNER) is True
+
+
+class TestPerpetualRejectsNonModelJobs:
+    """GPT round-32 (non-blocking finding): a command/script cron runs no model,
+    so it can never call agent_sleep and never names its own deadline — the whole
+    point of kind="self". Accepting it produced a job LABELLED perpetual that
+    behaved as a plain fixed interval, while the §7 contract, life context and
+    higher auto-pause threshold all applied to something that cannot use them.
+    """
+
+    def test_command_job_cannot_be_perpetual(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        with pytest.raises(ValueError, match="exclusive with command/script"):
+            svc.add_job(
+                name="x",
+                message="m",
+                every_secs=3600,
+                perpetual=True,
+                operator_session_key="dashboard:main",
+                command="echo hi",
+            )
+
+    def test_script_job_cannot_be_perpetual(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        with pytest.raises(ValueError, match="exclusive with command/script"):
+            svc.add_job(
+                name="x",
+                message="m",
+                every_secs=3600,
+                perpetual=True,
+                operator_session_key="dashboard:main",
+                script="~/.kiro/crew/crons/x.py:f",
+            )
+
+    def test_plain_perpetual_is_unaffected(self, tmp_path: Path) -> None:
+        assert _add_self(_svc(tmp_path)).schedule.kind == "self"
+
+
+class TestLifeContextWithoutDirFd:
+    """Round 20 made the life-context reader FAIL CLOSED where ``dir_fd`` is
+    unavailable, because the fallback could not refuse a symlinked component.
+    Windows is that platform, so the content-asserting tests are skipped there —
+    this class asserts the CONTRACT instead, so the platform is covered by an
+    assertion rather than by an absence of tests.
+    """
+
+    def test_preamble_ships_without_life_context(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(os, "supports_dir_fd", set())
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        _key, msg = build_cron_session_context(job)
+        # the contract and the task survive; the life context does not appear
+        assert "[Perpetual agent contract]" in msg
+        assert "pursue the goal" in msg
+        assert "LIFE.md below" in msg  # the preamble's own words, not file content
+        assert "[Your LIFE.md]" not in msg
+        assert "[Your JOURNAL.md]" not in msg
+
+    def test_loader_returns_nothing_without_dir_fd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.cron import _load_life_context
+
+        monkeypatch.setattr(os, "supports_dir_fd", set())
+        job = _add_self(_svc(tmp_path))
+        assert not _load_life_context(job)
+
+
+class TestUnrecognizedExecutablesAreWriteCapable:
+    """GPT round-33 ended the enumeration. Every earlier round listed things that
+    WRITE (a verb set, then a conditional flag table) and each report was another
+    spelling the list lacked. `cd ~/.kiro/crew && /tmp/rewrite crons.json` cannot
+    be enumerated at all, so inside a command that already names a protected
+    directory the question is INVERTED: write context is the default, and only a
+    command whose every program is known-read counts as a read.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && /tmp/rewrite crons.json",
+            "cd ~/.kiro/crew && ./rewrite crons.json",
+            "cd ~/.kiro/crew && myhelper crons.json",
+            "cd ~/.kiro/crew && /home/me/bin/tool crons.json",
+            # a binary NAMED like a known read but living somewhere untrusted:
+            # basenaming alone trusted the name, which probing caught
+            "cd ~/.kiro/crew && /tmp/x/cat crons.json",
+            "cd ~/.kiro/crew && ./cat crons.json",
+            "cd ~/.kiro/crew/agents/ab12cd34 && /tmp/rewrite LIFE.md",
+        ],
+    )
+    def test_unknown_or_untrusted_programs_are_write_context(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert (
+            is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None
+        ), cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # reads of a fenced leaf must STAY reads — the inversion must not turn
+            # write-protection into read-blocking
+            "cd ~/.kiro/crew && cat crons.json",
+            "cd ~/.kiro/crew && /usr/bin/cat crons.json",
+            "cd ~/.kiro/crew && grep -c . crons.json",
+            "cd ~/.kiro/crew && cat crons.json 2>&1",
+            "cd ~/.kiro/crew && head -5 crons.json | grep x",
+            "cd ~/.kiro/crew && ls -la",
+            "cd ~/.kiro/crew && git diff --stat",
+            "cd ~/.kiro/crew && find . -name crons.json",
+            "cat ~/.kiro/crew/config.json",
+            "sqlite3 ~/.kiro/crew/sessions.db .tables",
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo e >> JOURNAL.md",
+        ],
+    )
+    def test_known_reads_stay_reads(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    def test_program_extraction_shape(self) -> None:
+        from kiro_crew.security import _program_words
+
+        # only the first word of each segment is a program
+        assert _program_words("cat a | grep b") == ["cat", "grep"]
+        # env assignments and wrappers are stepped over
+        assert _program_words("FOO=1 sudo /tmp/rewrite x") == ["rewrite@untrusted"]
+        # a trusted system bin keeps its plain name
+        assert _program_words("/usr/bin/cat x") == ["cat"]
+        # fd duplication is not a program named "1"
+        assert _program_words("cat x 2>&1") == ["cat"]
+        # a redirect target is not a program
+        assert _program_words("echo x > out.json") == ["echo"]
+
+    def test_interpreters_are_not_in_the_read_set(self) -> None:
+        """Round 22 made running an interpreter write context; the read set must
+        not quietly re-admit one."""
+        from kiro_crew.security import _KNOWN_READ_PROGRAMS
+
+        for interp in ("python", "python3", "node", "perl", "ruby", "sh", "bash", "sed"):
+            assert interp not in _KNOWN_READ_PROGRAMS, interp
+
+
+class TestReadSetExcludesWritersAndExecutors:
+    """GPT round-34 reported ``xxd -r``. Auditing the whole read set rather than
+    that one entry found three more, one of which was a comment of mine the code
+    never supported:
+
+      * ``xargs`` and ``env`` EXECUTE another program, and program extraction only
+        sees the first word of a segment — ``echo x | xargs /tmp/rewrite`` read as
+        ``xargs``;
+      * ``xxd in out`` / ``xxd -r`` and ``yq -i`` write without a redirect;
+      * ``git checkout -- crons.json`` was allowed, because round 33's comment
+        claimed the derived verb set covered git's mutating subcommands. It does
+        not: round 30 drops the nested ``git (?:checkout|…)`` group whole, so those
+        words are not verbs on their own. They are now in the conditional table.
+      * ``tee`` was in BOTH the read set and the write-verb set. The verb half
+        caught it so nothing leaked, but the contradiction was a latent bug.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && xxd -r /tmp/payload.hex crons.json",
+            "cd ~/.kiro/crew && xxd /tmp/in crons.json",
+            "cd ~/.kiro/crew && echo crons.json | xargs /tmp/rewrite",
+            "cd ~/.kiro/crew && echo x | xargs tee crons.json",
+            "cd ~/.kiro/crew && yq -i '.x=1' crons.json",
+            "cd ~/.kiro/crew && env /tmp/rewrite crons.json",
+            "cd ~/.kiro/crew && tee crons.json < /tmp/evil",
+        ],
+    )
+    def test_writers_and_executors_are_write_context(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert (
+            is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None
+        ), cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && git checkout -- crons.json",
+            "cd ~/.kiro/crew && git restore crons.json",
+            "cd ~/.kiro/crew && git rm crons.json",
+        ],
+    )
+    def test_git_mutating_subcommands_are_write_context(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert (
+            is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None
+        ), cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && git clean -fd",
+            "cd ~/.kiro/crew && git reset --hard",
+            "cd ~/.kiro/crew && git stash",
+            "cd ~/.kiro/crew && git apply /tmp/evil.patch",
+        ],
+    )
+    def test_git_forms_that_name_no_leaf_are_out_of_reach(self, cmd: str) -> None:
+        """These DO mutate, and they are NOT refused — deliberately documented
+        rather than papered over. The conjunction requires the command to name a
+        fenced leaf, and these destroy files without naming any: the same
+        target-never-appears-in-the-text class as a composed path. A text gate
+        cannot reach them; a read-only mount over the store can. Asserting the
+        real behaviour here keeps the gap visible instead of implying coverage.
+        """
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && git log --oneline -5",
+            "cd ~/.kiro/crew && git diff --stat",
+            "cd ~/.kiro/crew && git status",
+            "cd ~/.kiro/crew && git show HEAD",
+        ],
+    )
+    def test_git_reads_stay_reads(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    def test_read_set_and_verb_set_do_not_overlap(self) -> None:
+        """A program cannot be both a known read and a known write verb — that
+        contradiction is what put ``tee`` in both."""
+        from kiro_crew.security import _KNOWN_READ_PROGRAMS, _NORMALIZER_WRITE_VERBS
+
+        assert not (_KNOWN_READ_PROGRAMS & _NORMALIZER_WRITE_VERBS)
+
+    def test_read_set_excludes_program_executors(self) -> None:
+        from kiro_crew.security import _KNOWN_READ_PROGRAMS
+
+        for p in ("xargs", "env", "sudo", "nohup", "timeout", "xxd", "yq"):
+            assert p not in _KNOWN_READ_PROGRAMS, p
+
+
+class TestManualRunDoesNotEatAFutureWake:
+    """GPT round-35: the consume guard was only ``is not None``, so a run that did
+    NOT arrive from the agent-chosen deadline — a manual trigger — consumed a
+    deadline still in the FUTURE. The agent's choice was discarded, and a manual
+    run that then failed before calling agent_sleep fell back to the every_secs
+    ceiling: the agent asked for 20 minutes and got hours.
+    """
+
+    def test_future_deadline_survives_a_manual_run(self, tmp_path: Path) -> None:
+        import asyncio as _aio
+
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 6 * 3600, "chose +6h", "")
+        target = svc.list_jobs()[0]
+        chosen = target.next_wake_ts
+        assert chosen is not None and chosen > time.time()
+
+        consumed = []
+        svc._on_job = lambda _j: _aio.sleep(0)
+        with patch.object(
+            svc, "_consume_self_wake_locked", side_effect=lambda j: consumed.append(j.id)
+        ):
+            svc._job_run_meta[target.id] = (time.time(), "manual")
+            svc._executing.add(target.id)
+            _aio.run(svc._run_job_isolated(target))
+        assert consumed == [], "a future deadline must not be consumed by a manual run"
+        assert target.next_wake_ts == chosen
+
+    def test_due_deadline_is_still_consumed(self, tmp_path: Path) -> None:
+        import asyncio as _aio
+
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "chose +10m", "")
+        target = svc.list_jobs()[0]
+        target.next_wake_ts = time.time() - 1  # due
+
+        consumed = []
+        svc._on_job = lambda _j: _aio.sleep(0)
+        with patch.object(
+            svc, "_consume_self_wake_locked", side_effect=lambda j: consumed.append(j.id)
+        ):
+            svc._job_run_meta[target.id] = (time.time(), "scheduled")
+            svc._executing.add(target.id)
+            _aio.run(svc._run_job_isolated(target))
+        assert consumed == [target.id]
+
+
+class TestRelativeAgentPathsAreAttributed:
+    """GPT round-35: a RELATIVE target carries the victim id without the
+    ``/agents/`` prefix the owner scan keys on, and a relative ``agents/`` segment
+    reaches the subtree without the anchored spelling the subtree conjunction
+    required. Both are the chained-relative shape, one directory down.
+    """
+
+    OWNER = "cron:job111"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew/agents && echo injected >> job999/JOURNAL.md",
+            # even the OWNER's own id via a relative subdirectory is refused: the
+            # text cannot attribute it, so the allowance does not hold
+            "cd ~/.kiro/crew/agents && echo x >> job111/JOURNAL.md",
+            "cd ~/.kiro/crew && echo injected >> agents/job999/JOURNAL.md",
+            "cd ~/.kiro/crew && echo injected > agents/job999/LIFE.md",
+        ],
+    )
+    def test_relative_agent_targets_forfeit_the_allowance(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=self.OWNER) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew/agents/job111 && echo ok >> JOURNAL.md",
+            "echo ok >> ~/.kiro/crew/agents/job111/JOURNAL.md",
+        ],
+    )
+    def test_the_supported_owner_forms_still_work(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=self.OWNER) is None, cmd
+
+
+class TestSqlite3IsNotAKnownRead:
+    """GPT round-35: round 33 kept sqlite3 in the read set and filed its write
+    ability under the in-process/sandbox class. That was wrong — ``sqlite3 …
+    '.output crons.json' …`` NAMES the target in the command text, so by the
+    round-26 line it is a matching problem and gets fixed.
+    """
+
+    def test_output_redirection_via_sqlite3_is_write_context(self) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        for cmd in (
+            "cd ~/.kiro/crew && sqlite3 /tmp/x '.output crons.json' 'select 1'",
+            "cd ~/.kiro/crew && sqlite3 sessions.db '.output crons.json' 'select 1'",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_pinned_sessions_db_read_still_allowed(self) -> None:
+        """Removing sqlite3 must not break the pinned everyday access: sessions.db
+        is not a fenced bash leaf, so that command never reaches the conjunction."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command("sqlite3 ~/.kiro/crew/sessions.db .tables") is None
+        assert is_sensitive_bash_command("sqlite3 ~/.kirocrew/sessions.db .tables") is None
+
+    def test_sqlite3_writes_are_flag_conditional_not_excluded(self) -> None:
+        """Round 35 removed sqlite3 from the read set outright. Round 37 showed
+        that breaks test_normal_crew_access_not_overblocked once the crew-home
+        branch stops requiring a resolvable leaf, so it is back in the read set
+        with its WRITING dot-commands in the conditional table — the same
+        mostly-read/flag-writes shape as find, curl and sort."""
+        from kiro_crew.security import _CONDITIONAL_WRITE_VERBS, _KNOWN_READ_PROGRAMS
+
+        assert "sqlite3" in _KNOWN_READ_PROGRAMS
+        assert ".output" in _CONDITIONAL_WRITE_VERBS["sqlite3"]
+        assert ".import" in _CONDITIONAL_WRITE_VERBS["sqlite3"]
+
+    def test_default_writing_programs_stay_out_of_the_read_set(self) -> None:
+        """wget saves to cwd, gunzip/xz replace their input — they WRITE by
+        default, so unlike curl/openssl/gpg they must not be treated as reads."""
+        from kiro_crew.security import _KNOWN_READ_PROGRAMS
+
+        for p in ("wget", "gunzip", "xz", "tee", "xargs", "env", "xxd", "yq"):
+            assert p not in _KNOWN_READ_PROGRAMS, p
+
+
+class TestBareNamesUntrustedUnderResolutionControl:
+    """GPT round-36: a bare program name is trusted because it resolves via PATH.
+    Round 33's comment claimed PATH control was "a different threat this text gate
+    cannot see" — false whenever the assignment is IN the command being judged.
+    `PATH=/tmp:$PATH cat crons.json` stages /tmp/cat in plain sight. Same
+    correction as the sqlite3 reversal: if the text names the mechanism, it is a
+    matching problem, not an unreachable one.
+
+    Probing found four spellings the report did not name: LD_PRELOAD,
+    LD_LIBRARY_PATH, `env PATH=…`, and a `PATH=…;` statement ahead of the command.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && PATH=/tmp:$PATH cat crons.json",
+            "cd ~/.kiro/crew && PATH=/tmp cat crons.json",
+            "cd ~/.kiro/crew && export PATH=/tmp:$PATH; cat crons.json",
+            "cd ~/.kiro/crew && LD_PRELOAD=/tmp/evil.so cat crons.json",
+            "cd ~/.kiro/crew && LD_LIBRARY_PATH=/tmp cat crons.json",
+            "cd ~/.kiro/crew && env PATH=/tmp cat crons.json",
+            "PATH=/tmp:$PATH; cd ~/.kiro/crew && cat crons.json",
+            "cd ~/.kiro/crew && IFS=x cat crons.json",
+        ],
+    )
+    def test_resolution_control_forfeits_bare_name_trust(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert (
+            is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None
+        ), cmd
+
+    def test_path_qualified_form_is_also_refused_deliberately(self) -> None:
+        """`PATH=/tmp /usr/bin/cat` is refused too, and that is a chosen
+        conservatism rather than an oversight: _program_words normalises
+        /usr/bin/cat to `cat`, so a path-qualified program is indistinguishable
+        from a bare one downstream. Threading a marker through to rescue a shape
+        nobody writes is not worth the state. Asserted so the choice is explicit
+        and a future reader does not "fix" it by accident."""
+        from kiro_crew.security import _has_unrecognized_program
+
+        assert (
+            _has_unrecognized_program("cd ~/.kiro/crew && PATH=/tmp /usr/bin/cat crons.json")
+            is True
+        )
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && cat crons.json",
+            "cd ~/.kiro/crew && /usr/bin/cat crons.json",
+            "cd ~/.kiro/crew && grep -c . crons.json",
+            "cat ~/.kiro/crew/config.json",
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo e >> JOURNAL.md",
+            # an ordinary env assignment that does NOT affect resolution
+            "cd ~/.kiro/crew && FOO=1 cat crons.json",
+        ],
+    )
+    def test_ordinary_reads_unaffected(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+
+class TestComposedStoreWritesRefusedByCapability:
+    """GPT round-37 closed the class I rebutted three times — by a mechanism I had
+    not considered. My rebuttal was that a COMPOSED leaf name
+    (`python -c 'open("cr"+"ons.json","w")'`) cannot be matched by text parsing,
+    which is true and still true. GPT's fix does not match the name: inside a
+    command that already NAMES the crew home, an interpreter or an unrecognized
+    program can write anything, so the capability itself is refused whether or not
+    a fenced basename appears.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && python -c 'open(\"cr\"+\"ons.json\",\"w\").write(\"{}\")'",
+            "cd ~/.kiro/crew && perl -e 'open(F,\">cr\".\"ons.json\")'",
+            "cd ~/.kiro/crew && python /tmp/rewrite.py",
+            "cd ~/.kiro/crew && /tmp/rewrite",
+            "cd ~/.kiro/crew && ./helper",
+            "cd ~/.kirocrew && node /tmp/rewrite.js",
+        ],
+    )
+    def test_capability_is_refused_without_a_resolvable_leaf(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert (
+            is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None
+        ), cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd ~/.kiro/crew && python --version",
+            "cd ~/.kiro/crew && python -c 'print(1)'",
+            "cd ~/.kiro/crew && kirocrew status",
+            "cd ~/.kiro/crew && npm ls",
+            "cd ~/.kiro/crew && ./scripts/report.sh",
+        ],
+    )
+    def test_the_accepted_cost_is_pinned(self, cmd: str) -> None:
+        """These are HARMLESS and are now refused. Pinned deliberately so the cost
+        is visible in the test suite rather than discovered by a user: the crew home
+        is Kiro Crew's data directory, not a workspace, and every legitimate CLI runs
+        from any cwd — the workaround is not to cd into the store. If this trade is
+        ever judged wrong, this test is where the decision is recorded."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert (
+            is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is not None
+        ), cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # THE narrowing: a named script FILE under the crew home is the
+            # product's documented script-cron form and must stay allowed. My first
+            # cut refused any interpreter whenever the crew home was NAMED, which
+            # broke this and `touch <crew home>/sessions.db` — both pinned
+            # elsewhere in the suite, which is how the over-block was caught.
+            "python3 ~/.kiro/crew/crons/report.py",
+            "PYTHONUNBUFFERED=1 python3 ~/.kiro/crew/crons/report.py",
+            "touch ~/.kiro/crew/sessions.db",
+            "ls ~/.kiro/crew/",
+        ],
+    )
+    def test_named_script_files_and_non_interpreters_stay_allowed(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # reads inside the crew home must STILL be reads
+            "cd ~/.kiro/crew && cat crons.json",
+            "cd ~/.kiro/crew && ls -la",
+            "cd ~/.kiro/crew && grep -c . crons.json",
+            "cd ~/.kiro/crew && curl -s file:///tmp/x",
+            "cd ~/.kiro/crew && curl -I https://example.com",
+            "cd ~/.kiro/crew && git log --oneline -5",
+            "cd ~/.kiro/crew && find . -name crons.json",
+            "cat ~/.kiro/crew/config.json",
+            "sqlite3 ~/.kiro/crew/sessions.db .tables",
+            "cd ~/.kiro/crew/agents/ab12cd34 && echo e >> JOURNAL.md",
+            # and an interpreter OUTSIDE the crew home is untouched
+            "python -c 'print(1)'",
+            "cd /tmp && python /tmp/rewrite.py",
+        ],
+    )
+    def test_reads_and_outside_interpreters_unaffected(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=_OWNER_SESSION_KEY) is None, cmd
+
+
+class TestConsumedSleepRecordNotLeftOnDisk:
+    """GPT round-38: the deadline and the sleep record that produced it are ONE
+    fact. Consuming cleared only the deadline, so a wake that died before calling
+    agent_sleep again let the NEXT wake read a stale record and be told "this is
+    your record from last wake" about a decision two wakes old.
+    """
+
+    def test_record_is_cleared_on_disk_when_the_deadline_is_consumed(
+        self, tmp_path: Path
+    ) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "ranked A", "")
+        target = svc.list_jobs()[0]
+        assert target.last_sleep_record
+
+        target.next_wake_ts = time.time() - 1
+        svc._consume_self_wake_locked(target)
+
+        # the run being started still sees it — via the TRANSIENT attribute, which
+        # round 42 introduced precisely so no save can carry it forward
+        assert target.consumed_sleep_record, "the current run's prompt must keep it"
+        assert target.last_sleep_record == "", "the persisted field must be empty"
+        # a fresh reader (the next wake, or a restart) must not
+        fresh = _svc(tmp_path).list_jobs()[0]
+        assert fresh.next_wake_ts is None
+        assert fresh.last_sleep_record == ""
+
+    def test_a_newer_record_written_during_the_run_survives(self, tmp_path: Path) -> None:
+        """The round-4 compare-and-clear guard must still hold: an agent_sleep
+        landing DURING the run is a newer choice and must not be erased.
+
+        Modelled with two service objects on one directory, because that is the
+        real shape — the newer choice arrives on DISK while this run holds an
+        older in-memory deadline. My first draft called record_agent_sleep on the
+        same service, which mutates the very object consume reads `fired` from, so
+        it tested nothing.
+        """
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "ranked A", "")
+        target = svc.list_jobs()[0]
+        target.next_wake_ts = time.time() - 1  # the deadline this run fired on
+
+        # a NEWER choice lands on disk from elsewhere
+        other = _svc(tmp_path)
+        other.record_agent_sleep(job.id, 1800, "ranked B", "")
+
+        svc._consume_self_wake_locked(target)
+
+        fresh = _svc(tmp_path).list_jobs()[0]
+        assert fresh.next_wake_ts is not None, "newer deadline must survive"
+        assert "ranked B" in fresh.last_sleep_record
+
+
+class TestSleepRecordLifetimeEndsAtPromptAssembly:
+    """GPT round-39: round 38 cleared the record on disk but RESTORED it on the
+    in-memory job so the prompt could still show it. Any later save of that same
+    object — last_run_ts, last_result, the auto-pause counters — wrote it back, so
+    a wake that exited before calling agent_sleep still handed the next wake a
+    two-wakes-old record. The record's lifetime ends at prompt assembly, which is
+    the only point that needs it.
+    """
+
+    def test_the_runs_own_save_does_not_reinstate_the_record(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "ranked A", "")
+        target = svc.list_jobs()[0]
+        target.next_wake_ts = time.time() - 1
+
+        svc._consume_self_wake_locked(target)
+        # the prompt still carries it — that is what the in-memory value is for
+        _key, msg = build_cron_session_context(target)
+        assert "ranked A" in msg
+
+        # the gateway clears it right after assembly (the round-39 step)
+        if target.schedule.kind == "self" and target.last_sleep_record:
+            target.last_sleep_record = ""
+
+        # then the run's ordinary bookkeeping is persisted
+        target.last_run_ts = time.time()
+        target.last_result = "done"
+        svc._save()
+
+        fresh = _svc(tmp_path).list_jobs()[0]
+        assert fresh.last_sleep_record == "", "a later save must not reinstate it"
+        assert fresh.last_result == "done", "ordinary bookkeeping must still persist"
+
+    def test_gateway_clears_the_record_after_assembly(self) -> None:
+        """Round 42 superseded the gateway clear entirely. The invariant that
+        matters is no longer "where is it cleared" but "it cannot be persisted at
+        all": the consumed value lives on a TRANSIENT attribute and ``_save``
+        serialises an explicit field list. Asserted against that list, because a
+        future field added there would silently reopen rounds 38-42."""
+        import inspect
+
+        from kiro_crew import cron
+
+        src = inspect.getsource(cron._save_locked if hasattr(cron, "_save_locked") else cron)
+        assert '"last_sleep_record": j.last_sleep_record' in src
+        assert "consumed_sleep_record" not in src.split('data = {')[-1].split("}")[0]
+
+
+class TestModifiedParameterExpansionsAreAnchored:
+    """GPT round-40: the brace alternative matched only the BARE
+    ``${KIROCREW_HOME}``, so every MODIFIED parameter expansion named the same
+    directory and slipped past. The shell has a whole grammar of modifiers here;
+    the brace form now accepts any modifier text rather than enumerating them.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd /tmp && echo x > ${KIROCREW_HOME:0}/crons.json",
+            "echo x > ${KIROCREW_HOME:-/tmp}/crons.json",
+            "echo x > ${KIROCREW_HOME##*/}/crons.json",
+            "echo x > ${KIROCREW_HOME%/}/crons.json",
+            "echo x > ${KIROCREW_HOME/x/y}/crons.json",
+            "echo x > ${KIROCREW_HOME:?err}/crons.json",
+            # the bare forms that already worked must keep working
+            "echo x > $KIROCREW_HOME/crons.json",
+            "echo x > ${KIROCREW_HOME}/crons.json",
+        ],
+    )
+    def test_modified_expansions_are_refused(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_both_anchors_accept_modifiers(self) -> None:
+        """Two regexes spell this idea; earlier rounds' lesson is that two
+        spellings drift. Both must accept modifier text."""
+        from kiro_crew.security import _build_sensitive_regex
+
+        rx = _build_sensitive_regex()
+        assert rx.search("echo x > ${KIROCREW_HOME:0}/crons.json")
+
+
+class TestSleepRecordFieldsAreBoundedNotTruncated:
+    """GPT round-40: a single 4,000-char cap on the JOINED record dropped
+    ``next_intent`` whenever ``did`` alone filled the budget — the agent's
+    statement of what it plans to do next vanished with no error and the next wake
+    was never told. Fields are bounded separately and an oversized record is
+    REFUSED rather than trimmed.
+    """
+
+    def test_oversized_did_is_refused_not_silently_trimmed(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        with pytest.raises(ValueError, match="limited to"):
+            svc.record_agent_sleep(job.id, 600, "D" * 4000, "INTENT")
+
+    def test_oversized_intent_is_refused(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        with pytest.raises(ValueError, match="limited to"):
+            svc.record_agent_sleep(job.id, 600, "did", "I" * 4000)
+
+    def test_both_fields_survive_at_the_cap(self, tmp_path: Path) -> None:
+        from kiro_crew.cron import _SLEEP_FIELD_MAX
+
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        did = "D" * _SLEEP_FIELD_MAX
+        intent = "I" * _SLEEP_FIELD_MAX
+        svc.record_agent_sleep(job.id, 600, did, intent)
+        rec = svc.list_jobs()[0].last_sleep_record
+        assert did in rec, "did must survive intact"
+        assert intent in rec, "next_intent must NOT be dropped"
+
+    def test_ordinary_record_is_unchanged(self, tmp_path: Path) -> None:
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "ranked three PRs", "check CI at 09:00")
+        rec = svc.list_jobs()[0].last_sleep_record
+        assert "did: ranked three PRs" in rec
+        assert "next: check CI at 09:00" in rec
+
+
+class TestDataHomeItselfIsProtected:
+    """GPT round-41: the data home ITSELF was unprotected — `mv ~/.kiro/crew
+    ~/crew-stolen` and `rm -rf ~/.kiro/crew` were allowed. Relocating it defeats
+    every fence in the module at once, because they all key on the canonical path:
+    the moved tree holds the same credentials, governance policy and store, now
+    outside every anchor.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "mv ~/.kiro/crew ~/crew-stolen",
+            "mv ~/.kiro/crew /tmp/stolen",
+            "rm -rf ~/.kiro/crew",
+            "mv ~/.kirocrew ~/stolen",
+            # copying the whole home out is refused too — see the cost note
+            "cp -r ~/.kiro/crew /tmp/copy",
+        ],
+    )
+    def test_moving_or_deleting_the_home_is_refused(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_writes_to_children_are_unaffected(self) -> None:
+        """Only the root ITSELF is added; a write naming a CHILD is unchanged, so
+        the pinned everyday behaviour survives."""
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command("touch ~/.kiro/crew/sessions.db") is None
+        assert is_sensitive_bash_command("ls ~/.kiro/crew/") is None
+        assert is_sensitive_bash_command("cat ~/.kiro/crew/config.json") is None
+
+    def test_path_level_protects_root_agents_and_below(self) -> None:
+        from pathlib import Path as _P
+
+        from kiro_crew.security import is_sensitive_write_path
+
+        home = _P.home()
+        assert is_sensitive_write_path(str(home / ".kiro/crew")) is True
+        assert is_sensitive_write_path(str(home / ".kiro/crew/agents")) is True
+        assert is_sensitive_write_path(str(home / ".kiro/crew/agents/x")) is True
+
+
+class TestSleepRecordSurvivesDeniedDispatch:
+    """GPT round-41, third placement of one clear. Round 38 cleared it on disk but
+    restored it in memory (a later save wrote it back). Round 39 cleared it right
+    after prompt assembly — which is BEFORE vet_job_at_fire_time and before the
+    concurrent-execution guard, so a wake DENIED dispatch destroyed the record for
+    the next permitted wake. Every pre-dispatch exit must leave it intact, which is
+    only true if the clear sits after the prompt reaches the provider.
+    """
+
+    def test_clear_is_after_dispatch_not_after_assembly(self, tmp_path: Path) -> None:
+        """Round 42 removed the need for any placement at all: after consumption the
+        value lives on ``consumed_sleep_record``, which ``_save``'s explicit field
+        list does not serialise. So a wake DENIED dispatch cannot destroy the record
+        and a later merge cannot resurrect it. Asserted as a ROUND TRIP rather than
+        by source position — rounds 39 and 41 could only check where a line sat."""
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "ranked A", "")
+        target = svc.list_jobs()[0]
+        target.next_wake_ts = time.time() - 1
+        svc._consume_self_wake_locked(target)
+        assert target.consumed_sleep_record, "the run keeps it in memory"
+
+        # anything a later save writes must NOT carry the transient value
+        target.last_run_ts = time.time()
+        target.last_result = "done"
+        svc._save()
+        fresh = _svc(tmp_path).list_jobs()[0]
+        assert fresh.consumed_sleep_record == "", "the transient value must not persist"
+        assert fresh.last_sleep_record == ""
+        assert fresh.last_result == "done"
+
+    def test_assembly_region_does_not_clear(self) -> None:
+        """Guards the specific regression: no clear between assembly and the vet."""
+        import inspect
+
+        from kiro_crew.slack import gateway
+
+        src = inspect.getsource(gateway)
+        assembly = src.index("build_cron_session_context, job)")
+        vet = src.index("vet_job_at_fire_time,", assembly)
+        between = src[assembly:vet]
+        assert 'last_sleep_record = ""' not in between
+
+
+class TestComposedDirectoryNamesAreFenced:
+    """GPT round-43: the crew-home conjunction is pre-guarded on the literal
+    substring ``crew``/``kirocrew`` for speed, so composing the DIRECTORY name from
+    variables skipped it entirely — `d=cr;e=ew;printf '{}' > ~/.kiro/$d$e/…` never
+    contains the word. Round 16 closed the composed LEAF; the same trick one level
+    up was still open.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "d=cr;e=ew;f=cr;g=ons.json;printf '{}' > ~/.kiro/$d$e/$f$g",
+            "d=cr;e=ew;printf '{}' > ~/.kiro/$d$e/crons.json",
+            "d=cr;e=ew;printf '{}' > $HOME/.kiro/$d$e/crons.json",
+            # the composed-leaf form round 16 fixed must still be refused
+            "f=cr;g=ons.json;printf '{}' > ~/.kiro/crew/$f$g",
+        ],
+    )
+    def test_variable_derived_writes_under_the_kiro_root_are_refused(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # literal reads and writes outside the fence are unchanged
+            "cat ~/.kiro/crew/config.json",
+            "ls ~/.kiro",
+            "echo hi > /tmp/out.txt",
+            "f=notes.md; echo x > /tmp/$f",
+        ],
+    )
+    def test_literal_and_outside_forms_unaffected(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd) is None, cmd
+
+
+class TestConsumedRecordClearedAfterDispatch:
+    """GPT round-43, FIFTH round on one value — and this one was my own regression.
+    Round 42 moved the consumed record onto a transient field to stop it being
+    PERSISTED, and I deleted round 41's post-dispatch clear as "redundant". It was
+    not: persistence and in-memory reuse are two different leaks. The service CACHES
+    CronJob objects, so a dispatched turn that omitted agent_sleep left the value on
+    the cached job and the next fallback wake was told it was "your record from last
+    wake".
+
+    The clear sits AFTER dispatch, not at assembly: a wake denied dispatch must keep
+    it, because consume already cleared the disk copy and that wake never showed the
+    record to anyone.
+    """
+
+    def test_both_dispatch_paths_clear_the_transient(self) -> None:
+        import inspect
+
+        from kiro_crew.slack import gateway
+
+        src = inspect.getsource(gateway)
+        # both build_message call sites in the cron callback must be followed by a
+        # clear; count them rather than asserting one position
+        assert src.count('job.consumed_sleep_record = ""') >= 2, (
+            "each dispatch path must clear the transient record"
+        )
+
+    def test_clear_follows_dispatch_in_the_sequential_path(self) -> None:
+        import inspect
+
+        from kiro_crew.slack import gateway
+
+        src = inspect.getsource(gateway)
+        vet = src.index("vet_job_at_fire_time,")
+        clear = src.index('job.consumed_sleep_record = ""', vet)
+        assert clear > vet, "a denied wake must keep the record"
+
+    def test_transient_still_cannot_be_persisted(self, tmp_path: Path) -> None:
+        """Round 42's guarantee must survive round 43's change."""
+        svc = _svc(tmp_path)
+        job = _add_self(svc)
+        svc.record_agent_sleep(job.id, 600, "ranked A", "")
+        target = svc.list_jobs()[0]
+        target.next_wake_ts = time.time() - 1
+        svc._consume_self_wake_locked(target)
+        svc._save()
+        assert _svc(tmp_path).list_jobs()[0].consumed_sleep_record == ""
+
+
+class TestWindowsSeparatorsInAgentPaths:
+    """GPT round-44: the owner-scoping regexes were written with ``/`` only, so on
+    Windows — where the shell separator is ``\\`` — a foreign agent id
+    (``agents\\job999``) and a traversal (``job111\\..\\job999``) were invisible.
+    The platform difference is not a reason for a second pattern: one separator
+    class covers both.
+    """
+
+    OWNER = "cron:job111"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            r"cd $HOME\.kiro\crew\agents\job999; echo pwned >> JOURNAL.md",
+            r"cd %USERPROFILE%\.kiro\crew\agents\job999 && echo pwned >> JOURNAL.md",
+            r"echo pwned >> $HOME\.kiro\crew\agents\job999\JOURNAL.md",
+            r"cd $HOME\.kiro\crew\agents\job111\..\job999 && echo pwned >> JOURNAL.md",
+            # the posix forms must stay refused
+            "cd ~/.kiro/crew/agents/job999 && echo pwned >> JOURNAL.md",
+            "cd ~/.kiro/crew/agents/job111/../job999 && echo pwned >> JOURNAL.md",
+        ],
+    )
+    def test_foreign_ids_and_traversals_refused_on_both_separators(self, cmd: str) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        assert is_sensitive_bash_command(cmd, session_key=self.OWNER) is not None, cmd
+
+    def test_owner_forms_still_work(self) -> None:
+        from kiro_crew.security import is_sensitive_bash_command
+
+        for cmd in (
+            "cd ~/.kiro/crew/agents/job111 && echo ok >> JOURNAL.md",
+            "echo ok >> ~/.kiro/crew/agents/job111/JOURNAL.md",
+        ):
+            assert is_sensitive_bash_command(cmd, session_key=self.OWNER) is None, cmd
+
+    def test_both_regexes_accept_either_separator(self) -> None:
+        from kiro_crew.security import _AGENTS_ID_IN_PATH_RE, _DOT_SEGMENT_RE
+
+        assert _DOT_SEGMENT_RE.search("a/../b")
+        assert _DOT_SEGMENT_RE.search(r"a\..\b")
+        assert _AGENTS_ID_IN_PATH_RE.search("/agents/job1")
+        assert _AGENTS_ID_IN_PATH_RE.search(r"\agents\job1")
+
+
+class TestRecordClearedOnlyAfterProviderAccepts:
+    """GPT round-44, SIXTH round on one value. Round 43 cleared the transient right
+    after ``build_message`` — which only ASSEMBLES the prompt. A provider outage in
+    ``stream_and_collect`` then destroyed the record before any turn had run with
+    it. The record is spent only once a turn actually ran, so both clears now sit
+    after a successful return.
+    """
+
+    def test_both_clears_follow_stream_and_collect(self) -> None:
+        import inspect
+
+        from kiro_crew.slack import gateway
+
+        src = inspect.getsource(gateway)
+        # the two cron-callback dispatch sites, in order
+        first = src.index("result_text = await stream_and_collect(")
+        second = src.index("result_text = await stream_and_collect(", first + 1)
+        clear1 = src.index('job.consumed_sleep_record = ""', first)
+        clear2 = src.index('job.consumed_sleep_record = ""', second)
+        assert clear1 > first, "sequential path: clear must follow the provider call"
+        assert clear2 > second, "single-agent path: clear must follow the provider call"
+
+    def test_no_clear_between_assembly_and_dispatch(self) -> None:
+        """The specific regression: a clear before the provider call would destroy
+        the record on an outage that never ran a turn."""
+        import inspect
+
+        from kiro_crew.slack import gateway
+
+        src = inspect.getsource(gateway)
+        assembly = src.index("build_cron_session_context, job)")
+        first_call = src.index("result_text = await stream_and_collect(", assembly)
+        assert 'consumed_sleep_record = ""' not in src[assembly:first_call]


### PR DESCRIPTION
## What this is

The main Phase 1 PR for perpetual agents — RFC rev 3 ([merged](https://github.com/kirodotdev/KiroCrew/pull/3135)) floor items **1, 4, and 5**. Items 2/3 (transient retry + wake budget) landed in #3148. UI (Schedule-page create/inspect) is a separate follow-up.

## 1. `CronSchedule(kind="self")` — §2

An `every`-shaped job whose deadline the agent may pull **earlier** via `agent_sleep`; `every_secs` is the operator ceiling (the fallback wake when the agent made no choice). The agent-chosen deadline persists on the job (`next_wake_ts`), so a wake missed while the host was down **fires on recovery**, not one interval later — the property that made cron the host over in-memory timers. Consumed at fire time with a compare-and-clear so an `agent_sleep` write landing mid-run (a newer choice) survives.

## 2. `agent_sleep` MCP tool — §3, wake-sooner half only

Ends the wake by recording `did`/`next_intent` (via `set_run_result`, so the record reaches the next wake's prompt even if the turn's own result text is lost) plus the requested next wake, clamped into `[60s, ceiling]`. **Earlier than the ceiling is allowed; past it is clamped to it** — Phase 0 answered OQ6: both observed cadence failures pointed toward wake-sooner, none toward sleep-longer, so the sleep-longer half ships as §4 configuration, not agent-chosen distant deadlines. The job resolves from the calling session key (`cron:{id}`), so an agent can never sleep another agent's job.

## 3. The code-owned §7 contract preamble, ranking step first

Phase 0's strongest result (PHASE0-LOG Findings 14/15): "what to do next" had no owner in prompt or code, and an operator-written delta trigger starved an agent's goal for 8 straight cycles while a broken ranking instrument stayed invisible for 6. The preamble is code-owned so every perpetual agent gets it:

- **Rank the whole surface first** — the delta since last wake is one input, never the trigger
- The assessment is never rate-limited; only filing is
- **Honest idle is legitimate and never punished** — §7 forbids punishment language (it is precisely what produces invented work); pinned by test
- Permission walls escalate immediately; unanswered escalations file publicly and return to the goal
- Every wake ends with `agent_sleep`

`LIFE.md` (§6, agent-read-only) and the `JOURNAL.md` tail are read fresh each wake from the agents directory, size-capped (16KB / 20 lines), and degrade to empty when missing — prompt assembly must never be the thing that kills a wake.

## 4. §9 inheritance decisions, each with a test

| Inherited semantics | Decision |
|---|---|
| `delete_after_run` | Refused at validation |
| Jitter | Off — `strict_schedule` forced (the deadline is often tied to an external event the agent reasoned about) |
| `persistent_session` | Forced on (continuity is load-bearing, Phase 0 need 3) |
| Auto-pause | Threshold raised and **split**: `_AUTO_PAUSE_THRESHOLD_SELF = 10` vs 5 — five failed wakes is an ordinary bad day mid-investigation; Phase 0's first hour hit 2 on throttling alone |

## Creation surface

`add_job(..., perpetual=True)` + MCP `cron_add` `perpetual` flag (inputSchema + validation FieldSpec). Requires `every`; exclusive with `cron_expr`/`at_ts`.

## Verification

24 new tests in `test_cron_kind_self.py` (creation/validation/round-trip, next-run computation incl. missed-wake-on-recovery, sleep clamping both directions, consume-on-fire preserving newer choices, prompt assembly incl. caps and graceful degradation, split auto-pause). 1,198 cron+mcp+validation tests pass; isort/flake8/mypy clean.
