### PR TITLE
test: settle prune deselect before clicking Remove selected (#3179)

### DIFF
--- a/website/src/test/DevFleetPageCoverage.test.tsx
+++ b/website/src/test/DevFleetPageCoverage.test.tsx
@@ -739,6 +739,11 @@ describe('DevFleetPage prune failures', () => {
     fireEvent.click(screen.getByText('Prune merged'))
     await waitFor(() => expect(screen.getByText('Prune worktrees')).toBeInTheDocument())
     fireEvent.click(screen.getByLabelText('Select wt-a'))
+    // The footer's "Remove selected" filters by the pruneSelected state, so the
+    // deselection must COMMIT (checkbox re-rendered unchecked) before the next
+    // click — otherwise, on a loaded runner, the click captures the stale
+    // still-selected closure and the run fires instead of "Nothing selected".
+    await waitFor(() => expect(screen.getByLabelText('Select wt-a')).not.toBeChecked())
     fireEvent.click(screen.getByText('Remove selected'))
     await waitFor(() => expect(screen.getByText('Nothing selected')).toBeInTheDocument())
     expect(runCalls).toBe(0)


### PR DESCRIPTION
## Problem

`DevFleetPageCoverage.test.tsx > DevFleetPage prune failures > refuses to run with every candidate deselected` fails consistently on 2-core CI runners (3/3 attempts across two heads on PR #1636's frontend lane) while passing locally under every condition tried — plain run, CI env vars, Node 24, and CI's exact shard compositions. It contributes a persistent red to Frontend Tests on full-frontend-lane PR runs.

## Why it matters

A deterministic red on constrained runners blocks unrelated PRs' frontend lanes and trains contributors to ignore a failing required check.

## Fix (symptom → root cause → change)

- **Symptom:** `waitFor(getByText('Nothing selected'))` times out — the "Nothing selected" notice never renders.
- **Root cause:** the test fires `fireEvent.click` on the "Select wt-a" checkbox (deselect) and immediately fires `fireEvent.click` on "Remove selected". The modal footer's button (`DevFleetPage.tsx`, `pruneReviewDialog`) filters candidates by the `pruneSelected` state captured in its **render closure**. If the second click lands before React commits the deselection re-render, the handler still sees `wt-a` selected, `pruneExecute` proceeds with a non-empty list, the run POST fires, and the "Nothing selected" branch is never taken. On a loaded 2-core runner this stale-closure window is consistently hit; on fast local machines it never is.
- **Change:** insert `await waitFor(() => expect(screen.getByLabelText('Select wt-a')).not.toBeChecked())` between the two clicks. `Checkbox` is a controlled native input (`ui.tsx`), so the unchecked DOM state is proof the deselection re-render committed — and with it a fresh footer closure. This is the "poll instead of sleep" fix class from `docs/system-specs/common/testing-conventions.md` § Determinism: no arbitrary timeout, no weakened assertion, and the test still fails if deselection ever stops working.

## Tests

The change is itself a test fix. `DevFleetPageCoverage.test.tsx` passes 54/54 with it; the guarded assertion (`runCalls === 0` + "Nothing selected" rendered) is unchanged, so the covered product behavior (refusing an empty prune run) is still locked in.

## Manual verification

N/A — unit coverage sufficient; the change adds one deterministic intermediate assertion to an existing test and touches no product code.

## Screenshots

N/A — no UI change.

Closes #3179
