### PR TITLE
fix: clear leaked Node timers before happy-dom teardown (#3090)

### DIFF
--- a/website/integration/setup.ts
+++ b/website/integration/setup.ts
@@ -1,7 +1,164 @@
-import { afterEach } from 'vitest'
+import { afterEach, vi } from 'vitest'
 import '@testing-library/jest-dom'
 import { server } from './mocks/server'
 import { initI18n, i18next } from '../src/i18n'
+
+// lottie-web registers a module-scoped `setInterval(checkReady, 100)` purely by
+// being IMPORTED (`readyStateCheckInterval` in the prebuilt player bundles). That
+// interval belongs to no AnimationItem, so neither `anim.destroy()` nor RTL
+// `cleanup()` can clear it, and it self-clears only on its first tick ~100ms
+// after import. A vitest worker that tears happy-dom down inside that window
+// leaves the tick to fire with no `document`; the resulting
+// `ReferenceError: document is not defined` is counted as an unhandled error and
+// fails the run with 0 failing tests -- a race whose exposure shifts with worker
+// count and file count. Mock BOTH runtime specifiers (the light player and the
+// full build are separate modules, each creating its own interval) so the real
+// bundle never loads under test. Components only use `loadAnimation` and the
+// returned item's destroy/addEventListener/removeEventListener; a test that
+// needs richer behavior can install its own per-test mock, which overrides this.
+// Declared as a hoisted `function` so the hoisted vi.mock calls can reach it.
+function lottiePlayerMock() {
+  return {
+    default: {
+      loadAnimation: vi.fn(() => ({
+        destroy: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        play: () => {},
+        pause: () => {},
+        stop: () => {},
+      })),
+      destroy: () => {},
+      setQuality: () => {},
+    },
+  }
+}
+vi.mock('lottie-web', lottiePlayerMock)
+vi.mock('lottie-web/build/player/lottie_light', lottiePlayerMock)
+
+// --- Node-timer leak guard ---------------------------------------------------
+// The mock above removes the known lottie instance; this guard covers the wider
+// hazard: a timer registered through the global `setTimeout` / `setInterval` /
+// `setImmediate` that dereferences DOM globals after environment teardown.
+// (Not the full class: `node:timers/promises` and `AbortSignal.timeout()`
+// schedule through Node internals the wrappers never see -- a leak through
+// those still needs its own fix.)
+//
+// Why `happyDOM.abort()` (which vitest's own environment teardown already calls)
+// cannot do it: vitest's happy-dom environment copies window properties onto
+// `globalThis` from a fixed key list, and the timer functions are not in it --
+// Node's raw implementations stay. So a timer registered by test-loaded code is
+// a plain Node `Timeout`, invisible to happy-dom's async task manager (the CI
+// trace shows `Timeout.checkReady`, Node's class). The only teardown that can
+// reach such timers is one that tracked their handles at creation.
+//
+// Wrap the global timer functions to record live handles; `clearLeakedTimers()`
+// clears whatever is still pending and flips the wrappers into teardown mode,
+// where a late registration (e.g. an un-awaited promise continuation scheduling
+// a timer after the last afterAll) is cancelled on the spot. One-shot callbacks
+// self-evict from the ledger when they fire, so the Set tracks live timers, not
+// total creations. `vi.useFakeTimers()` composes cleanly: it replaces the
+// globals with fakes (fake timers never leak into teardown) and restores these
+// wrappers on `useRealTimers()`.
+// Each handle is stored with ITS OWN clear function: Node's clearImmediate is
+// not a safe no-op on a Timeout (both types carry the internal fields it
+// mutates), so cross-type clearing is never attempted.
+const liveTimerHandles = new Map<unknown, (handle: never) => void>()
+let timersTearingDown = false
+const realSetTimeout = globalThis.setTimeout
+const realSetInterval = globalThis.setInterval
+const realSetImmediate = globalThis.setImmediate
+const realClearTimeout = globalThis.clearTimeout
+const realClearInterval = globalThis.clearInterval
+const realClearImmediate = globalThis.clearImmediate
+
+type AnyTimerFn = (...args: never[]) => unknown
+
+function wrapTimerCreate<T extends AnyTimerFn>(
+  real: T,
+  clear: (handle: never) => void,
+  options: { oneShot: boolean },
+): T {
+  const wrapped = ((...args: unknown[]) => {
+    let callArgs = args
+    if (options.oneShot && typeof args[0] === 'function') {
+      // A fired one-shot Timeout still pins its callback closure (and whatever
+      // it captured) until cleared, so keeping fired handles in the ledger
+      // would grow it with TOTAL creations -- thousands in userEvent-heavy
+      // files. Self-evict on fire instead, so the Set holds only live timers.
+      const original = args[0] as (...cb: unknown[]) => unknown
+      const selfEvicting = (...cbArgs: unknown[]) => {
+        liveTimerHandles.delete(handle)
+        return original(...cbArgs)
+      }
+      callArgs = [selfEvicting, ...args.slice(1)]
+    }
+    const handle = (real as (...a: unknown[]) => unknown)(...callArgs)
+    if (timersTearingDown) {
+      // Registration after the teardown sweep: nothing will sweep again, so
+      // letting it live re-opens the fire-into-torn-down-document window.
+      clear(handle as never)
+      return handle
+    }
+    liveTimerHandles.set(handle, clear)
+    return handle
+  }) as unknown as T
+  // Preserve the callable's extra own properties (e.g. Node's
+  // `util.promisify.custom` symbol on setTimeout) so `promisify(setTimeout)`
+  // keeps working through the wrapper.
+  for (const key of Reflect.ownKeys(real)) {
+    if (key === 'length' || key === 'name' || key === 'prototype') continue
+    const desc = Object.getOwnPropertyDescriptor(real, key)
+    if (desc) Object.defineProperty(wrapped, key, desc)
+  }
+  return wrapped
+}
+
+function wrapTimerClear<T extends AnyTimerFn>(real: T): T {
+  return ((handle: unknown) => {
+    if (handle !== undefined && handle !== null) liveTimerHandles.delete(handle)
+    return (real as (h: unknown) => unknown)(handle)
+  }) as unknown as T
+}
+
+globalThis.setTimeout = wrapTimerCreate(realSetTimeout, realClearTimeout, { oneShot: true })
+globalThis.setInterval = wrapTimerCreate(realSetInterval, realClearInterval, { oneShot: false })
+globalThis.setImmediate = wrapTimerCreate(realSetImmediate, realClearImmediate, { oneShot: true })
+globalThis.clearTimeout = wrapTimerClear(realClearTimeout)
+globalThis.clearInterval = wrapTimerClear(realClearInterval)
+globalThis.clearImmediate = wrapTimerClear(realClearImmediate)
+
+/**
+ * Clear every live Node timer created through the test globals. Returns how
+ * many pending handles were cleared. Safe to call mid-file (does not flip
+ * teardown mode). Exported so the regression test can exercise the exact sweep
+ * the teardown relies on.
+ */
+export function clearLeakedTimers(): number {
+  const count = liveTimerHandles.size
+  for (const [handle, clear] of liveTimerHandles) clear(handle as never)
+  liveTimerHandles.clear()
+  return count
+}
+
+/**
+ * The teardown entry point: sweep pending timers AND flip the wrappers into
+ * teardown mode, so a late registration (an un-awaited promise continuation
+ * scheduling a timer after the last afterAll) is cancelled on the spot instead
+ * of surviving into environment teardown.
+ */
+export function beginTimerTeardown(): number {
+  timersTearingDown = true
+  return clearLeakedTimers()
+}
+
+// Registered FIRST on purpose: vitest runs after-hooks in reverse registration
+// order, so this executes after the msw `server.close()` below -- immediately
+// before environment teardown, when anything still pending is by definition a
+// leak about to fire into a torn-down document.
+afterAll(() => {
+  beginTimerTeardown()
+})
 
 // Initialize i18n for EVERY test file, pinned to English.
 //

--- a/website/src/test/lottieTeardownGuard.test.ts
+++ b/website/src/test/lottieTeardownGuard.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Guards for the lottie-web / happy-dom teardown interaction.
+ *
+ * lottie-web's prebuilt player bundles register a module-scoped
+ * `setInterval(checkReady, 100)` purely by being imported. The interval belongs
+ * to no AnimationItem, so no component cleanup can clear it; it self-clears only
+ * on its first tick ~100ms after import, and only while `document` still exists.
+ * A vitest worker that tears happy-dom down inside that window leaves the tick
+ * to fire with no `document`, and the resulting
+ * `ReferenceError: document is not defined` is counted by vitest as an unhandled
+ * error -- the job goes red with 0 failing tests.
+ *
+ * `happyDOM.abort()` cannot close this: vitest's happy-dom environment does not
+ * install happy-dom's task-managed timers on `globalThis` (the timer keys are
+ * absent from its copy list), so such intervals are raw Node `Timeout`s that
+ * happy-dom's async task manager never sees.
+ *
+ * Two layers defend against the failure, both wired in integration/setup.ts;
+ * these tests pin each layer independently.
+ *   1. `vi.mock` for both runtime specifiers, so the real bundle (and its
+ *      import-time interval) never loads under test.
+ *   2. A tracking wrapper on the global timer functions plus a sweep at file
+ *      teardown, cancelling any still-pending Node timer before the
+ *      environment goes away.
+ *
+ * NOTE: the last test arms teardown mode (late registrations get cancelled),
+ * so it must stay LAST in this file.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { clearLeakedTimers, beginTimerTeardown } from '../../integration/setup'
+
+describe('lottie-web import-time timer neutralization', () => {
+  it('serves the setup mock for BOTH runtime specifiers, so the real bundle never registers its interval', async () => {
+    // Each specifier is a separate module with its own module-scoped interval,
+    // so covering only one would leave the race open through the other.
+    const full = (await import('lottie-web')).default
+    const light = (await import('lottie-web/build/player/lottie_light')).default
+    expect(vi.isMockFunction(full.loadAnimation)).toBe(true)
+    expect(vi.isMockFunction(light.loadAnimation)).toBe(true)
+  })
+
+  it('sweeps a pending module-scoped interval before it can fire into a torn-down document', async () => {
+    // Same shape as lottie's readyStateCheckInterval: an interval that
+    // dereferences `document` on each tick. No await between registration and
+    // the sweep, so the tick cannot run first -- the assertion is deterministic.
+    const tick = vi.fn(() => document.readyState)
+    setInterval(tick, 100)
+    expect(clearLeakedTimers()).toBeGreaterThan(0)
+
+    // Wait past the interval period on a raw Node timer imported directly from
+    // node:timers/promises (independent of the wrapped globals). If the sweep
+    // failed, the tick fires within 100ms and this catches it.
+    await sleep(250)
+    expect(tick).not.toHaveBeenCalled()
+  })
+
+  it('sweeps a pending setImmediate as well', async () => {
+    const soon = vi.fn(() => document.readyState)
+    setImmediate(soon)
+    clearLeakedTimers()
+    await sleep(20)
+    expect(soon).not.toHaveBeenCalled()
+  })
+
+  it('clearTimeout/clearInterval through the wrappers stay functional', async () => {
+    const late = vi.fn()
+    const handle = setTimeout(late, 100)
+    clearTimeout(handle)
+    await sleep(150)
+    expect(late).not.toHaveBeenCalled()
+  })
+
+  it('a fired one-shot self-evicts from the ledger (the Set tracks live timers, not total creations)', async () => {
+    clearLeakedTimers() // drain anything earlier tests or React left pending
+    const ran = vi.fn()
+    setTimeout(ran, 1)
+    await sleep(30)
+    expect(ran).toHaveBeenCalledTimes(1)
+    // The fired handle must be gone from the ledger; only timers created by
+    // OTHER code between the drain and here could remain, and none were.
+    expect(clearLeakedTimers()).toBe(0)
+  })
+
+  it('setup.ts wires the sweep into an afterAll (structural pin)', async () => {
+    // The behavioral tests above exercise the sweep directly; this pins that it
+    // is actually REGISTERED to run at file teardown. A refactor that keeps the
+    // function but drops the hook re-opens the race silently -- the leak only
+    // fires under specific worker/file-count timing.
+    const { readFile } = await import('node:fs/promises')
+    const { resolve } = await import('node:path')
+    // Resolved from cwd (vitest runs with cwd at the website root, where
+    // vite.config.ts lives). import.meta.url is NOT usable here: under this
+    // suite's happy-dom environment it carries the environment's http URL,
+    // not a file: URL, so fileURLToPath throws.
+    const source = await readFile(resolve(process.cwd(), 'integration/setup.ts'), 'utf8')
+    expect(source).toMatch(/afterAll\([\s\S]{0,120}?beginTimerTeardown\(/)
+  })
+
+  it('after teardown begins, a late registration is cancelled on the spot (MUST BE LAST)', async () => {
+    beginTimerTeardown()
+    const straggler = vi.fn(() => document.readyState)
+    setTimeout(straggler, 1)
+    setInterval(straggler, 10)
+    await sleep(80)
+    expect(straggler).not.toHaveBeenCalled()
+    // The file's own afterAll calls beginTimerTeardown() again -- idempotent.
+  })
+})


### PR DESCRIPTION
## What is the problem?

`Frontend Tests` can exit non-zero while **every test passes**. `lottie-web` registers a module-scoped `setInterval(checkReady, 100)` purely by being imported; when a vitest worker tears down happy-dom inside that 100ms window, the tick fires with no `document` and throws `ReferenceError: document is not defined`. vitest counts the unhandled error as a run failure — a red job with 0 failing tests (CI evidence on PR #2703: `955 passed (955), Errors 1 error`).

## Why this issue matters to the user

It is a race whose exposure shifts with worker count and file count, so it lands on whichever PR happens to add a test file — the author sees a red job, every test green, and no connection to their change. Sharding currently masks it rather than fixing it, and every re-shuffle of the suite can resurface it.

## How our fix solves it

Symptom → root cause chain, with one correction to the issue's suggested fix:

1. The interval belongs to no `AnimationItem`, so neither `anim.destroy()` nor RTL `cleanup()` can clear it. It self-clears only ~100ms after import.
2. The issue's Option A (`happyDOM.cancelAsync()` in an `afterAll`) **cannot work, and I verified this empirically before finding why**: a test registering a lottie-shaped interval then calling `abort()` still saw the tick fire. The reason: vitest's happy-dom environment copies window properties onto `globalThis` from a fixed key list that does **not** include the timer functions — Node's raw implementations stay (`node_modules/vitest/dist/chunks/index.DC7d2Pf8.js`, `getWindowKeys`). Every timer registered by test-loaded code is a raw Node `Timeout` (the CI trace even shows `Timeout.checkReady`, Node's class), invisible to happy-dom's async task manager. vitest's own environment teardown *already* calls `happyDOM.abort()` — which is exactly why the bug exists despite it.
3. The fix therefore tracks timers where they are actually created. `website/integration/setup.ts` wraps the global `setTimeout` / `setInterval` / `setImmediate` (+ their clears) with a handle ledger; an `afterAll` — registered first so it runs *after* `server.close()`, immediately before environment teardown — sweeps every still-pending handle and arms teardown mode, in which any late registration (e.g. an un-awaited promise continuation scheduling a timer after the last hook) is cancelled on the spot. One-shot callbacks self-evict from the ledger when they fire, so it holds live timers only, not total creations. Each handle is cleared by its own type's clear function. `vi.useFakeTimers()` composes cleanly (fakes replace the wrappers; `useRealTimers()` restores them), and vitest's internal timeout timers bypass the wrappers entirely (`getSafeTimers()` is snapshotted before setup files run — verified in the installed vitest).
4. Defense-in-depth: `vi.mock` for **both** runtime specifiers (`lottie-web` and `lottie-web/build/player/lottie_light` are separate modules, each creating its own interval) so the real bundle never loads under test at all.

Honest scope note: the wrapper covers the global timer functions, not the entire class — `node:timers/promises` and `AbortSignal.timeout()` schedule through Node internals the wrappers never see. The setup comment says so explicitly rather than overclaiming.

## What tests we did

- New `website/src/test/lottieTeardownGuard.test.ts` (7 tests): both lottie specifiers resolve to the mock; a pending lottie-shaped interval is swept before it can fire into a torn-down document; `setImmediate` swept; clear wrappers stay functional; one-shot self-eviction keeps the ledger live-only; a structural pin that the sweep is actually wired into an `afterAll`; late post-teardown registrations are cancelled.
- Mutation verification, 5/5 killed: mock removed → red; sweep loop gutted → red; `afterAll` wiring removed → red; teardown flag never set → red; self-eviction removed → red.
- The failure mechanism reproduced standalone (raw Node interval + deleted `document` → the exact CI `ReferenceError`).
- Full local gates: `npx tsc -b` clean; full vitest 17,748 passed with only the 2 pre-existing `AppRootCoverage` credits-modal failures (#3174 — proven byte-identical on unmodified base `setup.ts` via A/B); both i18n gates and the brand gate green.
- Two model-pinned local reviewers: GPT PASS (zero findings), Opus PASS + 6 advisories — 4 adopted (one-shot self-eviction, `setImmediate` coverage + honest class comment, post-sweep registration window, loosened pin regex), 2 dispositioned below.

## Any other suggestions on the work

- Opus advisory (accepted-and-deferred): the suite-wide lottie mock means the real player contract is exercised nowhere under test; a follow-up could add one `vi.unmock` smoke test loading a real clip through `LottieRenderer`.
- Opus advisory (disclosed): neither changed file is covered by `npx tsc -b` (`tsconfig.app.json` excludes `src/test` and doesn't reference `integration/`), so the wrapper's casts are unvetted by the type gate — stated here so no reader assumes otherwise. A `tsconfig.test.json` project reference would close that gap repo-wide.
- The structural-pin test resolves `setup.ts` from `process.cwd()` because `import.meta.url` carries the happy-dom environment URL (http scheme), not a file URL — documented in the test.

Closes #3090
