### PR TITLE
fix(telegram): only send a table as a Rich Message when it parses as one

### DIFF
--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -248,24 +248,88 @@ _FENCE_LINE_RE = re.compile(r"^[ \t]*(?:`{3,}|~{3,})", re.MULTILINE)
 
 
 def _is_table_separator(line: str) -> bool:
-    """True if *line* is a GFM separator row (``| --- |``, ``---|---``)."""
+    """True if *line* is a GFM separator row (``| --- |``, ``---|---``).
+
+    Every cell must be non-empty and carry a dash. Both halves are what the
+    server was observed to do, not what a spec reading predicts: ``| --- | |``
+    comes back as a ``paragraph`` (so an empty cell must be rejected, or the
+    block ships flattened), while ``| - - | --- |`` comes back as a ``table``
+    (so a broken dash run must be ACCEPTED -- demanding a contiguous run here
+    would degrade a table the server renders fine into a monospace block).
+    """
     stripped = line.strip()
     if not stripped or not set(stripped) <= _TABLE_SEP_CHARS:
         return False
-    return "-" in stripped and "|" in stripped
+    if "-" not in stripped or "|" not in stripped:
+        return False
+    cells = _row_cells(stripped)
+    if len(cells) > 1 and cells[0].strip() == "":
+        cells = cells[1:]
+    if len(cells) > 1 and cells[-1].strip() == "":
+        cells = cells[:-1]
+    return bool(cells) and all("-" in cell for cell in cells)
+
+
+def _row_cells(row: str) -> list[str]:
+    """Split a table row on its UNESCAPED cell boundaries.
+
+    Escaping is decided by walking the row, not by a lookbehind: ``\\|`` is cell
+    content, but ``\\\\`` is a literal backslash that leaves a following ``|`` as
+    a real boundary. A fixed-width lookbehind cannot express that -- it reads the
+    second backslash of an even run as an escape and merges two cells, which
+    under-counts the row and can make a malformed header match its delimiter.
+    """
+    cells: list[str] = []
+    buf: list[str] = []
+    escaped = False
+    for ch in row:
+        if escaped:
+            buf.append(ch)
+            escaped = False
+        elif ch == "\\":
+            buf.append(ch)
+            escaped = True
+        elif ch == "|":
+            cells.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    cells.append("".join(buf))
+    return cells
+
+
+def _row_cell_count(row: str) -> int:
+    """Number of cells in a GFM table row.
+
+    Outer pipes are optional, so a single leading and a single trailing boundary
+    -- which show up as empty first/last cells -- are dropped.
+    """
+    cells = _row_cells(row.strip())
+    if len(cells) > 1 and cells[0] == "":
+        cells = cells[1:]
+    if len(cells) > 1 and cells[-1] == "":
+        cells = cells[:-1]
+    return len(cells)
 
 
 def _has_table(text: str) -> bool:
     """True if *text* contains a GFM pipe table.
 
-    A table is a line holding at least one ``|`` immediately followed by a
-    separator row. Outer pipes are optional on BOTH rows, because GFM accepts
-    ``a | b`` / ``--- | ---`` with no leading or trailing pipe -- anchoring on a
-    leading ``|`` silently missed those and rendered them as literal pipes.
+    A table is a pipe-bearing line immediately followed by a separator row whose
+    cell count MATCHES it. The count check is what GFM (and therefore Telegram's
+    Rich Markdown) uses to decide a table exists at all, so skipping it sends
+    content down the rich path that the server then renders as a plain paragraph
+    -- newlines collapsed, pipes literal, worse than the monospace fallback.
+
+    Outer pipes are optional on BOTH rows, because GFM accepts ``a | b`` /
+    ``--- | ---`` with no leading or trailing pipe -- anchoring on a leading
+    ``|`` silently missed those and rendered them as literal pipes.
 
     The separator row must contain a dash (so it is a separator, not more data)
     and a pipe (so a bare ``-----`` horizontal rule under a pipe-bearing
-    sentence is not mistaken for a table).
+    sentence is not mistaken for a table). The header must contain a pipe for
+    the same reason: a one-cell separator would otherwise promote any ordinary
+    sentence above it to a table.
 
     Deliberately does NOT exclude fenced code blocks. Table markup inside a
     fence only means one extra rich send, not wrong output: Rich Markdown parses
@@ -277,12 +341,24 @@ def _has_table(text: str) -> bool:
     """
     lines = text.split("\n")
     return any(
-        "|" in header and _is_table_separator(sep) for header, sep in zip(lines, lines[1:])
+        "|" in header
+        and _is_table_separator(sep)
+        and _row_cell_count(header) == _row_cell_count(sep)
+        for header, sep in zip(lines, lines[1:])
     )
 
 
 def _seal_table_fallback(text: str) -> str:
     """Render *text* for the no-Rich-Messages path: tables monospace, prose rich.
+
+    Run detection here is deliberately LOOSER than ``_has_table``: a pipe-bearing
+    line above a separator row is monospaced whatever the two rows' cell counts
+    are. The two predicates answer different questions and must not be unified.
+    ``_has_table`` decides a TRANSPORT and so must agree with the server's own
+    GFM cell-count rule -- claiming a table the server will not parse is what
+    ships a flattened paragraph. This one only decides a RENDERING, and ``<pre>``
+    reproduces its input verbatim, so widening it costs nothing and covers the
+    malformed markup ``_has_table`` correctly refuses.
 
     Reached only when ``sendRichMessage`` failed, which -- if this server never
     supports it -- is the PERMANENT path for every table-bearing reply, so it
@@ -869,6 +945,40 @@ class TelegramRenderer(Renderer):
         else:
             await self._client.edit_message(self._chat_id, self._stream_mid, text)
 
+    async def _seal_without_rich(self, text: str) -> tuple[str, str]:
+        """HTML for a seal that cannot use Rich Messages, plus the tail segment.
+
+        Pipe blocks are wrapped in ``<pre>`` so a block Rich Markdown would
+        reflow keeps its columns and loses no cell; prose around them keeps its
+        normal formatting.
+
+        ``<pre>`` only ADDS characters, and the segment was sized against the
+        RICH budget, so the result can overflow ``_rendered_limit()`` twice over
+        -- first the wrapped form, then the plain render. When even the plain
+        render spills, the segment is re-split against the HTML budget and every
+        chunk but the last is shipped here: header repetition keeps each chunk
+        detected as a table, so the whole thing degrades uniformly to ``<pre>``
+        rather than half aligned and half ragged. Letting the client's truncation
+        backstop cap it instead would drop content silently.
+
+        Returns the HTML to seal with and the tail segment it renders, which the
+        caller seals through its normal path so the keyboard lands on the final
+        message.
+        """
+        html_text = _seal_table_fallback(text)
+        if len(html_text) > self._rendered_limit():
+            html_text = _md_to_telegram_html(text)
+            if len(html_text) > self._rendered_limit():
+                chunks = self._degraded_table_chunks(text)
+                for ch in chunks[:-1]:
+                    await self._seal_chunk_html(ch)
+                if chunks:
+                    text = chunks[-1]
+                html_text = _seal_table_fallback(text)
+                if len(html_text) > self._rendered_limit():
+                    html_text = _md_to_telegram_html(text)
+        return html_text, text
+
     async def _seal_current(self, *, keyboard: dict | None = None) -> None:
         """Finalize the current segment: replace its live plaintext with the
         formatted HTML (and optional keyboard). Edits the streamed message in
@@ -915,36 +1025,15 @@ class TelegramRenderer(Renderer):
             # fall through and seal it the legacy way. Only the table runs are
             # wrapped in <pre>; prose around them keeps its normal formatting,
             # so this path never renders worse than the plain HTML seal.
-            #
-            # The segment was already sized against the plain HTML render, and
-            # <pre> wrapping only ADDS characters, so on a near-limit reply the
-            # wrapped form can overflow _rendered_limit() and have its tail cut
-            # by _cap_text(). Losing the end of the answer is worse than losing
-            # column alignment, so fall back to the plain render when it spills.
             logger.debug("sendRichMessage failed for chat %s, falling back to HTML", self._chat_id)
-            html_text = _seal_table_fallback(text)
-            if len(html_text) > self._rendered_limit():
-                html_text = _md_to_telegram_html(text)
-                if len(html_text) > self._rendered_limit():
-                    # The segment was sized against the RICH budget, so it can
-                    # be several HTML messages long -- letting the client's
-                    # truncation backstop cap it would drop content. Re-split
-                    # against the HTML budget instead: header repetition keeps
-                    # every chunk of the table detected, so the whole table
-                    # degrades uniformly to <pre> rather than half-rich,
-                    # half-pipes. All chunks but the last ship here; the last
-                    # flows into the normal seal below so the keyboard lands on
-                    # the final message.
-                    chunks = self._degraded_table_chunks(text)
-                    for ch in chunks[:-1]:
-                        await self._seal_chunk_html(ch)
-                    if chunks:
-                        text = chunks[-1]
-                    html_text = _seal_table_fallback(text)
-                    if len(html_text) > self._rendered_limit():
-                        html_text = _md_to_telegram_html(text)
+            html_text, text = await self._seal_without_rich(text)
         else:
-            html_text = _md_to_telegram_html(text)
+            # No conforming table, which includes pipe markup GFM rejects -- a
+            # header row whose cell count disagrees with its delimiter. Rich
+            # Markdown renders that as one paragraph with the newlines collapsed,
+            # so it must not take the rich path; the monospace seal shows every
+            # row verbatim on its own line instead.
+            html_text, text = await self._seal_without_rich(text)
         if self._stream_mid is not None:
             ok = await self._client.edit_message(
                 self._chat_id,

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -57,6 +57,7 @@ from kiro_crew.telegram.renderer import (
     _may_exceed_rendered,
     _md_to_telegram_html,
     _rendered_len,
+    _row_cell_count,
     _seal_table_fallback,
     _split_markdown,
     _split_markdown_bounded,
@@ -1169,6 +1170,70 @@ class TestRenderer:
         # A pipe-bearing sentence above a horizontal rule is NOT a table: the
         # separator row has no pipe, so it stays on the ordinary HTML path.
         assert not _has_table("cost | benefit analysis\n---------------------")
+
+    def test_table_detection_requires_matching_cell_counts(self) -> None:
+        # THE bug: a header row glued to leading prose has one cell too many, so
+        # no GFM parser sees a table. Claiming one anyway sends the block down
+        # the rich path, where the server renders it as a single paragraph --
+        # newlines collapsed, every pipe literal. Counting cells is what keeps
+        # that content on the monospace path instead.
+        assert not _has_table("Here you go:| a | b |\n| --- | --- |\n| 1 | 2 |")
+        assert not _has_table("a | b | c\n--- | ---\n1 | 2")  # malformed, 3 vs 2
+        assert _has_table("| a |\n| --- |\n| 1 |")  # single column is still a table
+        assert _has_table("| a\\|b | c |\n| --- | --- |\n| 1 | 2 |")  # escaped pipe
+        # A one-cell separator must not promote the sentence above it to a table.
+        assert not _has_table("just prose\n|---|")
+
+    def test_table_detection_counts_cells_by_escape_parity(self) -> None:
+        # `\|` is cell content, but `\\` is a literal backslash that leaves the
+        # NEXT pipe a real boundary. A fixed-width lookbehind cannot tell those
+        # apart: it reads the second backslash of an even run as an escape, merges
+        # two cells, and can make a malformed header match its delimiter -- which
+        # would route it to the rich path and flatten it.
+        assert _row_cell_count(r"| a\|b | c |") == 2, "escaped pipe stays inside its cell"
+        assert _row_cell_count("| a\\\\ | b |") == 2, "even backslash run does not escape"
+        assert _row_cell_count(r"| a\\\|b | c |") == 2, "odd run after a pair escapes again"
+        # The header below is 3 cells against a 2-cell delimiter once parity is
+        # honoured, so it must NOT be claimed as a table.
+        assert not _has_table("a\\\\ | b | c\n| --- | --- |\n| 1 | 2 |")
+
+    def test_delimiter_cells_follow_the_observed_server_rule(self) -> None:
+        # Every case here was checked against the live API by reading the echoed
+        # `rich_message.blocks`, because a spec reading and the server disagree.
+        # An EMPTY delimiter cell is rejected by the server (`paragraph`), so it
+        # must not take the rich path.
+        assert not _has_table("| a | b |\n| --- | |\n| 1 | 2 |")
+        # A BROKEN dash run is accepted by the server (`table`), so demanding a
+        # contiguous run would degrade a table it renders fine into monospace.
+        assert _has_table("| a | b |\n| - - | --- |\n| 1 | 2 |")
+        # Ordinary spellings, also confirmed as `table`.
+        assert _has_table("| a | b |\n| --- | --- |\n| 1 | 2 |")
+        assert _has_table("| a | b |\n| - | - |\n| 1 | 2 |")
+
+    def test_a_glued_table_is_sealed_verbatim_instead_of_reflowed(self) -> None:
+        # A header row sharing a line with prose has one cell too many, so no GFM
+        # parser sees a table. Sending it as rich would render one paragraph with
+        # every newline collapsed. Whether the extra cell is prose or a delimiter
+        # the author got wrong is NOT decidable from the text, so nothing is
+        # rewritten: the monospace seal reproduces the block as written.
+        glued = "Here is the table you asked for:| a | b |\n| --- | --- |\n| 1 | 2 |"
+        cli = FakeClient()
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0")  # type: ignore[arg-type]
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk(glued)
+            await r._stream_live(force=True)
+            await r._seal_current()
+
+        asyncio.run(_go())
+
+        assert cli.rich_sent == [], "non-conforming pipe markup must not take the rich path"
+        assert not cli.deleted, "the streamed bubble is edited, not replaced"
+        sealed = cli.edits[-1][1]
+        assert "<pre>" in sealed and "</pre>" in sealed, "the pipe block is sealed monospace"
+        for row in ("| a | b |", "| --- | --- |", "| 1 | 2 |"):
+            assert row in sealed, f"{row} must survive verbatim"
 
     def test_a_degraded_table_is_sealed_monospace_not_as_ragged_pipes(self) -> None:
         # When rich is unavailable the table still has to go out, but sealing it


### PR DESCRIPTION
## 1. What is the problem?

A Telegram reply carrying a pipe table can arrive as one flattened paragraph of
literal `|` characters — every row squashed onto a single line, no columns — even
though the Rich Messages path (`sendRichMessage`) is enabled and the send succeeds.

It happens whenever the header row's cell count disagrees with its delimiter row, for
example when the header shares a line with preceding prose:

```
Here is the table you asked for:| a | b |
| --- | --- |
| 1 | 2 |
```

## 2. Why this issue matters to the user

Tables are the entire reason the Rich Messages path exists, and in this shape the
output is **worse** than the legacy HTML seal it replaced. Telegram parses the block
as a `paragraph`, and paragraph rendering collapses newlines, so the rows lose even
their line breaks. Nothing recovers: the API call itself returns `ok: true`, so the
existing `<pre>` fallback — which keeps the columns aligned — is never reached.

## 3. How our fix solves it

Chain from symptom to root cause:

- **Symptom:** flattened literal pipes in the chat.
- **Server behaviour:** GFM (and therefore Telegram's Rich Markdown) recognizes a
  table only when the header row and the delimiter row have the **same cell count**.
  In the example the header has 3 cells and the delimiter has 2, so no table exists
  and the block degrades to a paragraph.
- **Root cause:** `_has_table` never implemented that rule. It accepted any line
  containing a `|` whose successor was a separator row, so the renderer committed to
  `sendRichMessage` for markdown the server cannot render as a table — and because
  the send succeeded, no fallback ran.

Two changes in `src/kiro_crew/telegram/renderer.py`:

1. **`_has_table` is now GFM-correct** — it compares cell counts, splitting on
   unescaped `|` only, with outer pipes optional on both rows. Content that would not
   parse as a table no longer takes the rich path.
2. **The non-rich seal keeps the block verbatim.** The `else` branch previously sealed
   through `_md_to_telegram_html`, which reflows a pipe block into ragged escaped
   pipes. It now shares the `<pre>` seal the rich-failure path already used, so a
   block Rich Markdown would flatten keeps its columns and every cell. This is a
   rendering choice, not an interpretation — no character is moved or dropped.

Both non-rich branches route through one new `_seal_without_rich` helper, which also
carries the degraded-table chunk splitting that landed on main while this PR was open.
Oversize segments therefore behave identically on both paths rather than only on the
failure one.

**Deliberately not attempted: rewriting the reply to recover a table.** An earlier
revision inserted the missing line break so the glued case would render as a real
table. Three review rounds established that the class is undecidable: prose glued to a
header and a header whose delimiter row is short produce identical text — header
`want + k`, delimiter `want`, body `want`. Every predicate added to tell them apart
closed one instance and left the class open, and guessing wrong demotes a real header
cell to prose while GFM drops the overflowing body cell. Rendering the block verbatim
is sound; guessing at intent is not.

Scope is Telegram-only: `_has_table` / `_is_table_separator` exist nowhere else in the
tree, because no other channel has a rich-table transport and therefore no such
decision point.

## 4. What tests we did

- New tests in `test/test_telegram.py`: the cell-count rule (glued header rejected,
  malformed 3-vs-2 rejected, single-column tables and escaped pipes still detected, a
  one-cell separator not promoting an ordinary sentence), and an end-to-end seal
  asserting a glued table never takes the rich path and reaches the client inside
  `<pre>` with every row byte-identical.
- **Mutation-verified.** Dropping the cell-count comparison fails both the detection
  test and the verbatim-seal test; reverting the `else` branch to the plain HTML seal
  fails the verbatim-seal test. No mutant survives.
- Gates green on the rebased head: 273 tests in `test/test_telegram.py`,
  `isort --check-only`, `flake8`, and `mypy src/kiro_crew/` (942 files).

## 5. Manual verification

Probed the live Bot API to establish the server-side rule rather than inferring it
from docs. The echoed `rich_message` payload is decisive: a header glued to prose
comes back as a single `paragraph` block whose text is the flattened pipe run, while
the same table with the header on its own line comes back as a `table` block with its
cells. That is the behaviour the cell-count check now mirrors, and the reason
non-conforming markup must not be sent as rich.

## 6. Screenshots

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change in the Telegram renderer; no dashboard
surface is touched.

Fixes #3209
