### PR TITLE
fix: complete Slack OAuth scopes in app manifest

### DIFF
--- a/docs/guides/slack-setup.md
+++ b/docs/guides/slack-setup.md
@@ -15,7 +15,7 @@ There are **two independent paths** to create a Slack app. Pick one, and do not 
 | Path | Steps | Best for |
 |------|-------|----------|
 | **[Path A: Manifest](#path-a-create-via-manifest-recommended)** (recommended) | 6 steps | Most users; auto-configures all scopes, events, and permissions in one shot |
-| **[Path B: Manual](#path-b-manual-setup)** | 10 steps | If you need to customize scopes or understand each setting individually |
+| **[Path B: Manual](#path-b-manual-setup)** | 11 steps | If you need to customize scopes or understand each setting individually |
 
 Both paths require a Slack workspace where you can install apps (see [Prerequisites](#prerequisites)).
 
@@ -139,6 +139,7 @@ Go to **Features → OAuth & Permissions → Bot Token Scopes** and add:
 | `chat:write` | Send, update, and delete messages |
 | `channels:history` | Read channel messages (for @mentions) |
 | `channels:read` | List public channels (the channel picker) and read channel metadata |
+| `groups:history` | Read private-channel messages and thread context |
 | `groups:read` | Same, for private channels the bot is in |
 | `im:history` | Read DM history |
 | `im:read` | View DM metadata |
@@ -147,28 +148,38 @@ Go to **Features → OAuth & Permissions → Bot Token Scopes** and add:
 | `files:read` | Read uploaded files |
 | `files:write` | Upload screenshots |
 | `commands` | Slash commands |
+| `users:read` | Resolve Slack member IDs to profile and display names |
 
-Two scopes are deliberately **not** in the shipped manifest, so Path B should
-leave them out unless you want the extra behavior:
+The `emoji:read` bot scope is deliberately **not** in the shipped manifest.
+Add it only if you want custom workspace emojis to appear in the emoji picker.
 
-| Scope | What adding it buys |
-|-------|---------------------|
-| `emoji:read` | Custom workspace emojis appear in the emoji picker |
-| `users:read` | Profile lookups (`users.info`) resolve a sender's real name. Without it those calls fail and are caught: the display name falls back to the matching `slack.allowed_users` entry, then to the raw Slack member ID |
+### Step 4. Add User Scopes
 
-### Step 4. Subscribe to Events
+Under **User Token Scopes**, add:
+
+`channels:history`, `channels:read`, `groups:history`, `groups:read`,
+`im:history`, `im:read`, `mpim:history`, `mpim:read`, `search:read`, and
+`users:read`.
+
+These scopes belong to the installing user's `xoxp-...` token. The Kiro Crew
+gateway itself uses the bot token; the user token is for a separately configured
+Slack MCP/search integration that lets an agent search Slack as that user. Store
+and configure that token only in the integration that consumes it.
+
+### Step 5. Subscribe to Events
 
 1. **Features → Event Subscriptions** → Toggle **ON**
 2. Under **Subscribe to bot events**, add all of these:
    - `message.im`
    - `message.channels`
+   - `message.groups`
    - `app_mention`
    - `app_home_opened`
    - `file_change`
    - `member_joined_channel`
 3. Click **Save Changes**
 
-### Step 5. Add Slash Commands
+### Step 6. Add Slash Commands
 
 **Features → Slash Commands** → **Create New Command**:
 
@@ -190,7 +201,7 @@ The command name you choose here must match the `slack.command` value in `~/.kir
 
 When creating the command, check **Escape channels, users, and links sent to your app** so mentions resolve to `<@U1234|user>` format.
 
-### Step 6. Enable Interactivity
+### Step 7. Enable Interactivity
 
 **Features → Interactivity & Shortcuts** → Toggle **ON**
 
@@ -199,7 +210,7 @@ buttons work, including tool approval (approve / trust / reject), the
 multiple-choice option buttons, the cron and subagent acknowledge buttons, and
 the session Resume / End buttons.
 
-### Step 7. Enable App Home
+### Step 8. Enable App Home
 
 **Features → App Home**:
 
@@ -207,20 +218,24 @@ the session Resume / End buttons.
 - Enable **Chat Tab**
 - Check **"Allow users to send Slash commands and messages from the chat tab"**
 
-### Step 8. Install to Workspace & Get Bot Token
+### Step 9. Install to Workspace & Get Bot Token
 
 1. **Features → OAuth & Permissions** → **Install to Workspace** → Approve
 2. Copy the `xoxb-...` token. This is your **Bot Token**
 
 > **"Install App" button greyed out?** Use **Features → OAuth & Permissions → Install to Workspace** instead (known Slack UI bug).
 
-### Step 9. Configure Kiro Crew
+### Step 10. Configure Kiro Crew
 
 Same as [Path A, Step 5](#step-5-configure-kirocrew).
 
-### Step 10. Verify & Run
+### Step 11. Verify & Run
 
 Same as [Path A, Step 6](#step-6-verify--run).
+
+If you add scopes to an existing app, reinstall it from **OAuth &
+Permissions** before testing. Slack does not grant newly declared scopes to
+tokens from an older installation.
 
 ---
 
@@ -505,4 +520,3 @@ to end just one browser's session, sign out in that browser
 - [Slack API Docs](https://api.slack.com/)
 - [Slack Socket Mode](https://api.slack.com/apis/socket-mode)
 - [Create a free Slack workspace](https://slack.com/get-started)
-

--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -30,6 +30,22 @@ Slack Socket Mode → events.py (dispatch) → handler.py → SessionManager →
 
 ## APIs
 
+### Slack App OAuth Contract
+
+The bundled `slack-manifest.yaml` is the setup source of truth. Its bot scopes
+are `app_mentions:read`, `channels:history`, `channels:read`, `chat:write`,
+`commands`, `files:read`, `files:write`, `groups:history`, `groups:read`,
+`im:history`, `im:read`, `im:write`, `reactions:write`, and `users:read`.
+`message.groups` is subscribed alongside `message.channels` so private-channel
+turns and thread continuation are delivered.
+
+The manifest also requests user scopes `channels:history`, `channels:read`,
+`groups:history`, `groups:read`, `im:history`, `im:read`, `mpim:history`,
+`mpim:read`, `search:read`, and `users:read`. These scopes apply only to a
+separately configured Slack MCP/search integration's `xoxp-...` token. The
+gateway constructs every Slack client with `SLACK_BOT_TOKEN`; it does not read
+or store the user token.
+
 ### `run_gateway(cfg: KiroCrewConfig, *, no_dashboard=False, no_crons=False) -> None`
 Starts the Socket Mode listener. Blocks until SIGINT/SIGTERM. When `no_crons=True`, the `CronService` is instantiated but not started — cron jobs are visible in the dashboard but not executed. Use for multi-instance setups where a single primary instance handles cron execution. On shutdown, calls `dashboard_state.close_all_ws()` before `AppRunner.cleanup()` to prevent 30s hang from blocked WebSocket `async for msg` loops.
 

--- a/src/kiro_crew/docs/slack-integration.md
+++ b/src/kiro_crew/docs/slack-integration.md
@@ -156,12 +156,22 @@ your own workspace.
 1. **Create a Slack app** at https://api.slack.com/apps and enable **Socket
    Mode**. Generate an app-level token (`xapp-`) with the `connections:write`
    scope.
-2. **Add a bot user** and OAuth scopes for the features you use (e.g.
-   `chat:write`, `im:history`, `app_mentions:read`, `reactions:write`). Install
-   the app to your workspace to get the bot token (`xoxb-`).
-3. **Set credentials** in `~/.kiro/crew/.env` (`SLACK_APP_TOKEN`,
+2. **Add a bot user** with these Bot Token Scopes:
+   `app_mentions:read`, `channels:history`, `channels:read`, `chat:write`,
+   `commands`, `files:read`, `files:write`, `groups:history`, `groups:read`,
+   `im:history`, `im:read`, `im:write`, `reactions:write`, and `users:read`.
+3. **Add User Token Scopes** if the same app supplies a user token to a
+   separately configured Slack MCP/search integration: `channels:history`,
+   `channels:read`, `groups:history`, `groups:read`, `im:history`, `im:read`,
+   `mpim:history`, `mpim:read`, `search:read`, and `users:read`. The gateway
+   does not consume this `xoxp-...` token.
+4. **Subscribe to bot events**: `message.im`, `message.channels`,
+   `message.groups`, `app_mention`, `app_home_opened`, `file_change`, and
+   `member_joined_channel`. Install or reinstall the app to grant the scopes and
+   get the bot token (`xoxb-`).
+5. **Set credentials** in `~/.kiro/crew/.env` (`SLACK_APP_TOKEN`,
    `SLACK_BOT_TOKEN`, `KIROCREW_OWNER_ID`).
-4. **Slash command** (optional) — the command name is configurable via
+6. **Slash command** (optional) — the command name is configurable via
    `slack.command` in config.json (default: `kirocrew`). Each app instance
    should use a unique name.
 

--- a/src/kiro_crew/slack-manifest.yaml
+++ b/src/kiro_crew/slack-manifest.yaml
@@ -38,19 +38,33 @@ oauth_config:
       - commands
       - files:read
       - files:write
+      - groups:history
       - groups:read
       - im:history
       - im:read
       - im:write
       - reactions:write
+      - users:read
       # Optional: uncomment for custom workspace emojis in Secretary emoji picker
       # - emoji:read
+    user:
+      - channels:history
+      - channels:read
+      - groups:history
+      - groups:read
+      - im:history
+      - im:read
+      - mpim:history
+      - mpim:read
+      - search:read
+      - users:read
 
 settings:
   event_subscriptions:
     bot_events:
       - message.im
       - message.channels
+      - message.groups
       - app_mention
       - app_home_opened
       - file_change

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1414,6 +1414,45 @@ class TestGetAlias:
 class TestManifest:
     """Tests for _manifest."""
 
+    def test_packaged_manifest_declares_complete_oauth_scopes(self):
+        import yaml
+
+        from kiro_crew import slack_manifest
+
+        manifest = yaml.safe_load(slack_manifest.render("scope-test"))
+        assert manifest["oauth_config"]["scopes"] == {
+            "bot": [
+                "app_mentions:read",
+                "channels:history",
+                "channels:read",
+                "chat:write",
+                "commands",
+                "files:read",
+                "files:write",
+                "groups:history",
+                "groups:read",
+                "im:history",
+                "im:read",
+                "im:write",
+                "reactions:write",
+                "users:read",
+            ],
+            "user": [
+                "channels:history",
+                "channels:read",
+                "groups:history",
+                "groups:read",
+                "im:history",
+                "im:read",
+                "mpim:history",
+                "mpim:read",
+                "search:read",
+                "users:read",
+            ],
+        }
+        bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
+        assert "message.groups" in bot_events
+
     def _patch_template(
         self, content="name: KiroCrew-{{ALIAS}}\ndisplay_name: KiroCrew-{{ALIAS}}\n"
     ):


### PR DESCRIPTION
# fix: complete Slack OAuth scopes in app manifest

Add the required bot and user token scopes so generated Slack apps support private channels, user lookups, and separately configured Slack search. Document the token boundaries and pin the manifest scope contract in tests.

## Problem / Motivation

The generated Slack app manifest omitted scopes and event subscriptions required for private-channel messages, user profile lookups, and Slack search through a separately configured user token.

## Why it matters

Apps created from the manifest could miss private-channel events, fail to resolve user details, or lack the permissions needed by a Slack MCP/search integration. Users then had to diagnose and add these permissions manually.

## What changed (motivation -> approach -> change)

The manifest is the Slack setup source of truth, so the missing permissions are declared there rather than handled as runtime fallbacks.

- Added `groups:history` and `users:read` bot scopes.
- Added the user token scopes required for channel, DM, user, and search access.
- Subscribed the bot to `message.groups` for private-channel events.
- Documented the distinction between the gateway's `xoxb-...` bot token and the separately configured integration's `xoxp-...` user token.
- Updated the manual and packaged Slack setup documentation.

## Tests

Added `TestManifest::test_packaged_manifest_declares_complete_oauth_scopes`, which renders and parses the packaged manifest and pins the exact bot scopes, user scopes, and `message.groups` event subscription.

Focused CLI suite: 251 passed, 2 skipped.

## Manual verification

Not performed - requires a Slack workspace. Follow-up verification should create or reinstall an app from the manifest, confirm the granted scopes, and test a private-channel turn, user lookup, and separately configured Slack search.

## Related Issues

N/A - no related issue.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text - it will be added here once Legal provides it. -->