### PR TITLE
fix(sidebar): persist reveal filter clearing, harden the flash path (#912)

### DIFF
--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1659,10 +1659,15 @@ button:hover .app-icon{--ico-a:var(--accent);--ico-b:var(--text)}
 /* Reveal-in-sidebar confirmation: an accent outline the reveal handler holds
    briefly and then fades (ChatSidebar reveal effect, issue #912). Outline, not
    background, because the revealed row is usually the active one and already
-   carries the accent-subtle background. The fade is a color transition (not an
-   animation) so the global reduced-motion animation kill-switch above leaves
-   the confirmation visible. */
-.session-row.session-reveal-flash{outline:2px solid var(--accent);outline-offset:-2px;transition:outline-color .4s ease}
+   carries the accent-subtle background. No transition declared here on
+   purpose: the row's own Tailwind transition-all animates outline-color, and
+   declaring any transition longhand/shorthand at this higher specificity
+   would strip transition-all while the flash is up, making hover styles snap
+   on exactly the row the reveal highlighted. The fade is a color transition
+   (not an animation), so the global reduced-motion animation kill-switch
+   above leaves the confirmation visible. JS removes the classes after the
+   fade completes (REVEAL_FLASH_FADE_MS in ChatSidebar.tsx covers it). */
+.session-row.session-reveal-flash{outline:2px solid var(--accent);outline-offset:-2px}
 .session-row.session-reveal-flash-fade{outline-color:transparent}
 .session-row.session-colored{position:relative}
 .session-row.session-colored::before{

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -6159,13 +6159,16 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 <ChatHeaderMenu
                   activeSlot={activeSlot}
                   agent={currentSlot?.agent}
-                  onReveal={activeSlot ? () => {
+                  onReveal={activeSlot && embedMode !== 'chat' ? () => {
                     // The request rides the store, not a window event: with the
                     // drawer collapsed ChatSidebar is unmounted, so an event
                     // dispatched here (before the mount that setSidebarPinned
                     // schedules commits) had no listener and was dropped —
                     // the store entry survives until the sidebar consumes it
-                    // (#912). Mobile drives its own drawer state.
+                    // (#912). Mobile drives its own drawer state. Embed-chat
+                    // never mounts a sidebar, so the item is not offered there:
+                    // a stored request would outlive the view and fire on
+                    // whichever sidebar mounts next.
                     sidebarAutoHidden.current = null
                     if (isMobile) setMobileSessions(true)
                     else if (!sidebarPinned) setSidebarPinned(true)

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -694,6 +694,8 @@ const SORT_LS_KEY = 'mc-session-sort'
 const FLAT_VIEW_LS_KEY = 'mc-sidebar-flat-view'
 
 export const SIDEBAR_MIN = 180
+export const SIDEBAR_MAX = 1400
+const SIDEBAR_LS_KEY = 'mc-sidebar-width'
 /** Reveal-in-sidebar retry budget: ancestor expansion and filter resets land
  *  through mutations and re-renders, so the target row can enter the DOM
  *  several frames after the request is consumed. 20 × 100 ms ≈ 2 s, then the
@@ -703,8 +705,10 @@ const REVEAL_RETRY_MS = 100
 const REVEAL_MAX_ATTEMPTS = 20
 /** How long the reveal confirmation outline holds before fading out. */
 const REVEAL_FLASH_HOLD_MS = 1600
-export const SIDEBAR_MAX = 1400
-const SIDEBAR_LS_KEY = 'mc-sidebar-width'
+/** Must cover the CSS fade on .session-reveal-flash-fade in index.css (.4s):
+ *  the classes are removed at HOLD + FADE + slack, so shortening this below
+ *  the CSS duration snaps the outline off mid-fade. */
+const REVEAL_FLASH_FADE_MS = 500
 
 function ChatSidebar({
   slots, activeSlot, unreadSlots, history, historyHasMore,
@@ -1811,13 +1815,26 @@ function ChatSidebar({
     // Consume immediately: the request must not survive to a later remount.
     dispatch(clearSlotReveal())
     const slot = slots.find(s => s.key === key)
-    if (!slot) return
+    if (!slot) {
+      // Stale key or a session outside this surface's slot list. Not user-visible
+      // (there is nothing to highlight), so leave a trace for bug reports.
+      console.debug('reveal-in-sidebar: no session for key', key)
+      return
+    }
     // A live sidebar search or status filter can exclude the target row from
     // the list entirely (#912 D5) — reveal is an explicit "show me this row",
     // so drop the filters that hide it rather than scrolling to nothing.
     if (!filteredSlots.some(s => s.key === key)) {
       if (slotFilter) setSlotFilter('')
-      if (activeFilters.size > 0) setActiveFilters(new Set())
+      if (activeFilters.size > 0) {
+        // Persisted like toggleFilter: state alone is not enough — the sidebar
+        // unmounts whenever the drawer collapses, and remount re-reads the
+        // stored '1', silently restoring the filter that hides this row.
+        for (const filterDef of SESSION_FILTERS) {
+          if (activeFilters.has(filterDef.key)) safeSetItem(filterDef.storageKey, '0')
+        }
+        setActiveFilters(new Set())
+      }
     }
     if (slot.folder_id) {
       // The folder filter hides whole subtrees in the flat and tree lanes —
@@ -1867,6 +1884,9 @@ function ChatSidebar({
       if (!el) {
         attempt += 1
         if (attempt <= REVEAL_MAX_ATTEMPTS) run.timer = window.setTimeout(tryScroll, REVEAL_RETRY_MS)
+        // Row never appeared (e.g. board lane with no matching column). Not
+        // user-visible, so leave a trace for bug reports instead of vanishing.
+        else console.debug('reveal-in-sidebar: row never rendered for', key)
         return
       }
       const reduce = !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
@@ -1883,7 +1903,7 @@ function ChatSidebar({
       revealFlashTimersRef.current.forEach(clearTimeout)
       setRevealFlash({ key, fading: false })
       const t1 = window.setTimeout(() => setRevealFlash(f => (f && f.key === key ? { key, fading: true } : f)), REVEAL_FLASH_HOLD_MS)
-      const t2 = window.setTimeout(() => setRevealFlash(f => (f && f.key === key ? null : f)), REVEAL_FLASH_HOLD_MS + 500)
+      const t2 = window.setTimeout(() => setRevealFlash(f => (f && f.key === key ? null : f)), REVEAL_FLASH_HOLD_MS + REVEAL_FLASH_FADE_MS)
       revealFlashTimersRef.current = [t1, t2]
     }
     tryScroll()

--- a/website/src/test/ChatSidebarCoverage.test.tsx
+++ b/website/src/test/ChatSidebarCoverage.test.tsx
@@ -573,6 +573,7 @@ describe('ChatSidebar — reveal request (store-driven, issue #912)', () => {
   })
 
   it('clears the sidebar search filter when it hides the target row', async () => {
+    localStorage.setItem('mc-session-pinned-only', '1')
     const { store } = renderSidebar({
       slots: [
         { key: 'k-a', title: 'Alpha', running: false },
@@ -588,6 +589,9 @@ describe('ChatSidebar — reveal request (store-driven, issue #912)', () => {
     // reveal has something to land on.
     await waitFor(() => expect((search as HTMLInputElement).value).toBe(''))
     await waitFor(() => expect(scrollIntoView).toHaveBeenCalled())
+    // The status-filter clearing must ALSO clear the persisted key — the
+    // sidebar unmounts when the drawer collapses, and remount re-reads it.
+    expect(localStorage.getItem('mc-session-pinned-only')).toBe('0')
   })
 
   it('ignores a request for an unknown session key but still consumes it', async () => {


### PR DESCRIPTION
# Problem

PR #3215 (reveal-in-sidebar rework for #912) auto-merged while two pre-push review findings from its own reviewer pass were still local. The merged code has one real defect and four hardening gaps: clearing a persisted status filter during a reveal writes React state only, so collapsing and reopening the drawer re-reads the stored `'1'` and silently restores the filter that hides the just-revealed row.

# Why it matters

The filter resurrection undoes the reveal the user just performed — the exact "click, nothing happens" experience #912 was filed about, resurfacing through a different door. The remaining gaps make future regressions likelier (silent failure paths, an unnamed timing coupling) and leave a dead menu item that plants a time bomb (embed views).

# Fix (symptoms -> root cause -> change)

- **Persisted filter resurrection (the defect).** `ChatSidebar` seeds `activeFilters` from each filter's localStorage key on every mount, and the sidebar unmounts whenever the drawer collapses. The reveal's filter clearing now writes each active filter's storage key to `'0'` (mirroring `toggleFilter`) before clearing state, so a remount cannot resurrect it.
- **Embed-chat leak.** `/embed/chat` offers the Reveal menu item but never mounts a sidebar, so a stored request would persist for the tab's lifetime and fire an unrequested scroll+flash on whichever sidebar mounts later in that store. The item is no longer offered in embed-chat mode.
- **Silent failure paths.** The two ways a reveal can produce nothing (stale/foreign session key; row never renders within the retry budget, e.g. a board lane with no matching column) now leave a `console.debug` trace, so the next bug report carries evidence instead of "nothing happened".
- **Flash timing coupling.** The class-removal delay was `HOLD + 500` with a bare literal that had to outlive the CSS fade; it's now a named `REVEAL_FLASH_FADE_MS` with cross-references in both files. The CSS classes also no longer declare `transition` at all — any transition declaration at that specificity resets `transition-property` and strips the row's own Tailwind `transition-all` while the flash is up (hover styles would snap on exactly the highlighted row); the row's existing transition animates the outline fade instead.
- **Constant placement.** The reveal constants no longer split the `SIDEBAR_MIN`/`SIDEBAR_MAX` pair.

# Tests

`ChatSidebarCoverage.test.tsx` — the filter-clearing test now seeds `mc-session-pinned-only='1'` in localStorage and asserts the reveal writes it to `'0'`, pinning the persistence half of the clear (fails on the state-only implementation).

# Manual verification

N/A — unit coverage sufficient: the filter-persistence path is asserted directly, and the remaining changes are non-rendering (log lines, constant naming/placement, a menu item removed from a surface that had no sidebar to act on).

# Screenshots

<!-- no-visual-delta -->
**Why no screenshot:** the outline flash renders identically to the frames in #3215; the only rendered difference is the fade-out easing now coming from the row's own `transition-all`, which a still frame cannot show.

no issue closed: follow-up to #912, which PR #3215 already closed.
