### PR TITLE
fix(lessons): apply the create route's session gate to lesson deletes

### DIFF
--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -7,6 +7,7 @@ import json
 import logging
 import time
 import uuid
+from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 
@@ -666,6 +667,172 @@ async def api_cron_history_all(request: web.Request) -> web.Response:
     return web.json_response({"runs": runs, "total": total})
 
 
+# Delete-route policy for the archived-session recovery path: only a temporary
+# session is blocked from deleting; incognito may delete (an active user
+# action), mirroring the live-slot ``_blocks_reads_session`` policy. The create
+# route blocks every private mode via the canonical
+# ``history.is_incognito_transcript`` classifier instead.
+def _is_temporary_transcript(persisted_mode: str) -> bool:
+    return persisted_mode == "temporary"
+
+
+async def _recognize_session(
+    state: DashboardState,
+    sk: str,
+    operation: str,
+    *,
+    blocks_persisted_mode: Callable[[str], bool],
+    error_codes: bool = False,
+) -> web.Response | None:
+    """Session-recognition gate shared by the lessons routes.
+
+    Applies one slot / restricted-key / channel-namespace / persisted-JSONL
+    cascade to every caller so the create and delete routes cannot diverge.
+    Returns a refusal :class:`web.Response`, or ``None`` when the session is
+    recognised. Every decision — allow or deny — emits a SEL audit event
+    under *operation*.
+
+    ``blocks_persisted_mode`` is the per-route policy for the
+    archived-session recovery path: create blocks every private mode (the
+    canonical ``history.is_incognito_transcript`` classifier); delete blocks
+    only ``temporary``. A ``None``
+    (unreadable or ambiguous) persisted mode always fails closed regardless
+    of policy. ``error_codes`` controls whether the 400 refusal bodies carry
+    the machine-readable ``code`` field (the delete route's error contract;
+    the create route's 400 responses predate it and stay code-less); the 403
+    refusal carries ``restricted_session`` on both routes.
+    """
+    if not sk:
+        _sel().log_api_access(
+            caller="anonymous", operation=operation, outcome="denied",
+            source="dashboard", resources="missing_session_key",
+        )
+        if error_codes:
+            return web.json_response(
+                {"error": "missing X-Session-Key", "code": "missing_session_key"},
+                status=400,
+            )
+        return web.json_response({"error": "missing X-Session-Key"}, status=400)
+    if sk == "dashboard:ui":
+        # Browser UI's static key — implicitly trusted, but the allow
+        # decision itself is still an authorization outcome and must be
+        # audited (every permission decision emits a SEL event).
+        _sel().log_api_access(
+            caller=sk, operation=operation, outcome="allowed",
+            source="dashboard", resources="dashboard_ui",
+        )
+        return None
+    slot_name = sk.split(":", 1)[-1] if ":" in sk else sk
+    in_slots = slot_name in state._slots
+    in_restricted = sk in state._restricted_keys
+    # A channel-originated session (Slack, Telegram, Discord, Webex,
+    # WeCom, …) is a legitimate established session: its key is namespaced
+    # ``{channel}:{conversation_id}`` and the transport publishes
+    # ``session_pid`` so the gateway resolves this X-Session-Key (#232).
+    # Recognise the WHOLE channel-namespace family via the canonical
+    # ``is_channel_session_key`` — not just Slack. Two reasons this is the
+    # right gate, both already true for Slack:
+    #   * the first memory call in a fresh channel thread races the JSONL
+    #     flush (which only lands after the LLM turn completes), so a
+    #     namespace fast-path avoids a spurious HTTP 400 until the
+    #     transcript is on disk; and
+    #   * the ``_probe_persisted_session`` fallback below cannot
+    #     rescue a channel key anyway — ``slot_name`` is
+    #     ``sk.split(":", 1)[-1]`` (inner colons kept, channel prefix
+    #     dropped) while the file is ``dashboard_<safe_key>.jsonl`` with
+    #     colons folded to ``_``, so no probed name ever matches (and a
+    #     colon is now rejected outright by ``_persisted_session_path``).
+    # Before this, only ``slack:`` was accepted, so learn_add failed with
+    # HTTP 400 "unknown session" from every OTHER channel (Telegram /
+    # Discord / Webex / WeCom) even though the session is fully identified
+    # (#1268). The bare Slack thread_ts shim stays for legacy native-Slack
+    # keys. Incognito/temporary sessions are still blocked by each route's
+    # live-slot policy check (Slack is the only channel with that concept),
+    # so widening the namespace does not widen memory writes to ephemeral
+    # sessions.
+    is_channel_ns = is_channel_session_key(sk) or bool(SLACK_THREAD_TS_RE.match(sk))
+    # Only consult the on-disk JSONL when the cheaper in-memory checks all
+    # fail. ``_probe_persisted_session()`` performs synchronous filesystem
+    # I/O (path resolution plus a bounded metadata head read), so it runs
+    # via ``asyncio.to_thread`` — never on the event loop (AUTOSDE
+    # ``no-blocking-call-on-event-loop``) — and only on this rare recovery
+    # path, leaving the common live-slot path free of both I/O and a thread
+    # hop. One composed call answers BOTH questions (does the session
+    # exist, and may it touch memory) from a single path resolution, so the
+    # two decisions can never be made about different files.
+    if not (in_slots or in_restricted or is_channel_ns):
+        exists, persisted_mode = await asyncio.to_thread(
+            _probe_persisted_session, slot_name
+        )
+        if not exists:
+            # Slot may have been evicted from memory (idle sweep,
+            # gateway restart) while the MCP subprocess keeps its
+            # original KIROCREW_SESSION_KEY. No session JSONL means
+            # the key genuinely does not belong to any established
+            # session. (Presence does NOT imply the session is
+            # non-ephemeral — every memory_mode writes a transcript —
+            # which is what ``persisted_mode`` below settles.)
+            _sel().log_api_access(
+                caller=sk, operation=operation, outcome="denied",
+                source="dashboard", resources="unknown_session",
+            )
+            if error_codes:
+                return web.json_response(
+                    {"error": "unknown session", "code": "unknown_session"},
+                    status=400,
+                )
+            return web.json_response({"error": "unknown session"}, status=400)
+        if persisted_mode is None or blocks_persisted_mode(persisted_mode):
+            # Archiving a tab drops the slot AND discards its
+            # ``_restricted_keys`` entry while leaving the transcript —
+            # and its ``memory_mode`` marker — on disk, so the two
+            # in-memory checks above cannot see that this session is
+            # ephemeral. The persisted mode is the only remaining
+            # evidence. ``None`` means the header was unreadable, which
+            # is NOT evidence that the call is allowed: append() writes
+            # the metadata line at file creation, so a normal session
+            # always has one. Fail closed.
+            _sel().log_api_access(
+                caller=sk, operation=operation, outcome="denied",
+                source="dashboard", resources="restricted_session_block",
+            )
+            return web.json_response(
+                {
+                    "error": "Memory writes are not allowed in this session mode.",
+                    # Machine-readable per the error-code contract; matches
+                    # the code already used for this condition at
+                    # handlers/memory.py's restricted-session refusal.
+                    "code": "restricted_session",
+                },
+                status=403,
+            )
+        # JSONL-fallback is the sole reason the call is permitted.
+        # Audit it as an allow decision so session-recovery
+        # authorization is traceable alongside the deny path above.
+        _sel().log_api_access(
+            caller=sk, operation=operation, outcome="allowed",
+            source="dashboard", resources="jsonl_fallback_recovery",
+        )
+    elif in_slots:
+        # Live in-memory slot — the common happy path. Audit so that
+        # every permission decision on this branch is traceable.
+        _sel().log_api_access(
+            caller=sk, operation=operation, outcome="allowed",
+            source="dashboard", resources="live_slot",
+        )
+    elif in_restricted:
+        _sel().log_api_access(
+            caller=sk, operation=operation, outcome="allowed",
+            source="dashboard", resources="restricted_key",
+        )
+    else:  # is_channel_ns
+        _sel().log_api_access(
+            caller=sk, operation=operation, outcome="allowed",
+            source="dashboard", resources="channel_namespace",
+        )
+    return None
+
+
 async def api_lessons_create(request: web.Request) -> web.Response:
     """POST /api/lessons — add a lesson (vector store or JSONL fallback)."""
     from kiro_crew.learn import Lesson  # noqa: F811
@@ -679,125 +846,12 @@ async def api_lessons_create(request: web.Request) -> web.Response:
         return web.json_response({"error": "request body must be a JSON object"}, status=400)
     # Block lesson writes from restricted (incognito/temporary/guest) sessions.
     sk = request.headers.get("X-Session-Key", "")
-    if not sk:
-        _sel().log_api_access(
-            caller="anonymous", operation="learn_add", outcome="denied",
-            source="dashboard", resources="missing_session_key",
-        )
-        return web.json_response({"error": "missing X-Session-Key"}, status=400)
-    if sk != "dashboard:ui":
-        slot_name = sk.split(":", 1)[-1] if ":" in sk else sk
-        in_slots = slot_name in state._slots
-        in_restricted = sk in state._restricted_keys
-        # A channel-originated session (Slack, Telegram, Discord, Webex,
-        # WeCom, …) is a legitimate established session: its key is namespaced
-        # ``{channel}:{conversation_id}`` and the transport publishes
-        # ``session_pid`` so the gateway resolves this X-Session-Key (#232).
-        # Recognise the WHOLE channel-namespace family via the canonical
-        # ``is_channel_session_key`` — not just Slack. Two reasons this is the
-        # right gate, both already true for Slack:
-        #   * the first learn_add in a fresh channel thread races the JSONL
-        #     flush (which only lands after the LLM turn completes), so a
-        #     namespace fast-path avoids a spurious HTTP 400 until the
-        #     transcript is on disk; and
-        #   * the ``_probe_persisted_session`` fallback below cannot
-        #     rescue a channel key anyway — ``slot_name`` is
-        #     ``sk.split(":", 1)[-1]`` (inner colons kept, channel prefix
-        #     dropped) while the file is ``dashboard_<safe_key>.jsonl`` with
-        #     colons folded to ``_``, so no probed name ever matches (and a
-        #     colon is now rejected outright by ``_persisted_session_path``).
-        # Before this, only ``slack:`` was accepted, so learn_add failed with
-        # HTTP 400 "unknown session" from every OTHER channel (Telegram /
-        # Discord / Webex / WeCom) even though the session is fully identified
-        # (#1268). The bare Slack thread_ts shim stays for legacy native-Slack
-        # keys. Incognito/temporary sessions are still blocked below by
-        # ``_is_restricted_session`` (Slack is the only channel with that
-        # concept), so widening the namespace does not widen memory writes to
-        # ephemeral sessions.
-        is_channel_ns = is_channel_session_key(sk) or bool(SLACK_THREAD_TS_RE.match(sk))
-        # Only consult the on-disk JSONL when the cheaper in-memory checks all
-        # fail. ``_probe_persisted_session()`` performs synchronous filesystem
-        # I/O (path resolution plus a bounded metadata head read), so it runs
-        # via ``asyncio.to_thread`` — never on the event loop (AUTOSDE
-        # ``no-blocking-call-on-event-loop``) — and only on this rare recovery
-        # path, leaving the common live-slot path free of both I/O and a thread
-        # hop. One composed call answers BOTH questions (does the session
-        # exist, and may it write memory) from a single path resolution, so the
-        # two decisions can never be made about different files.
-        if not (in_slots or in_restricted or is_channel_ns):
-            exists, persisted_mode = await asyncio.to_thread(
-                _probe_persisted_session, slot_name
-            )
-            if not exists:
-                # Slot may have been evicted from memory (idle sweep,
-                # gateway restart) while the MCP subprocess keeps its
-                # original KIROCREW_SESSION_KEY. No session JSONL means
-                # the key genuinely does not belong to any established
-                # session. (Presence does NOT imply the session is
-                # non-ephemeral — every memory_mode writes a transcript —
-                # which is what ``persisted_mode`` below settles.)
-                _sel().log_api_access(
-                    caller=sk, operation="learn_add", outcome="denied",
-                    source="dashboard", resources="unknown_session",
-                )
-                return web.json_response({"error": "unknown session"}, status=400)
-            if persisted_mode is None or is_incognito_transcript(persisted_mode):
-                # Archiving a tab drops the slot AND discards its
-                # ``_restricted_keys`` entry while leaving the transcript —
-                # and its ``memory_mode`` marker — on disk, so the two
-                # in-memory checks above cannot see that this session is
-                # ephemeral. The persisted mode is the only remaining
-                # evidence. ``None`` means the header was unreadable, which
-                # is NOT evidence that writes are allowed: append() writes
-                # the metadata line at file creation, so a normal session
-                # always has one. Fail closed.
-                _sel().log_api_access(
-                    caller=sk, operation="learn_add", outcome="denied",
-                    source="dashboard", resources="restricted_session_block",
-                )
-                return web.json_response(
-                    {
-                        "error": "Memory writes are not allowed in this session mode.",
-                        # Machine-readable per the error-code contract; matches
-                        # the code already used for this condition at
-                        # handlers/memory.py's restricted-session refusal.
-                        "code": "restricted_session",
-                    },
-                    status=403,
-                )
-            # JSONL-fallback is the sole reason the call is permitted.
-            # Audit it as an allow decision so session-recovery
-            # authorization is traceable alongside the deny path above.
-            _sel().log_api_access(
-                caller=sk, operation="learn_add", outcome="allowed",
-                source="dashboard", resources="jsonl_fallback_recovery",
-            )
-        elif in_slots:
-            # Live in-memory slot — the common happy path. Audit so that
-            # every ``learn_add`` permission decision on this branch is
-            # traceable.
-            _sel().log_api_access(
-                caller=sk, operation="learn_add", outcome="allowed",
-                source="dashboard", resources="live_slot",
-            )
-        elif in_restricted:
-            _sel().log_api_access(
-                caller=sk, operation="learn_add", outcome="allowed",
-                source="dashboard", resources="restricted_key",
-            )
-        else:  # is_channel_ns
-            _sel().log_api_access(
-                caller=sk, operation="learn_add", outcome="allowed",
-                source="dashboard", resources="channel_namespace",
-            )
-    else:
-        # Browser UI's static key — implicitly trusted, but the allow
-        # decision itself is still an authorization outcome and must be
-        # audited (every permission decision emits a SEL event).
-        _sel().log_api_access(
-            caller=sk, operation="learn_add", outcome="allowed",
-            source="dashboard", resources="dashboard_ui",
-        )
+    refusal = await _recognize_session(
+        state, sk, "learn_add",
+        blocks_persisted_mode=is_incognito_transcript,
+    )
+    if refusal is not None:
+        return refusal
     if _is_restricted_session(state, request):
         sk = request.headers.get("X-Session-Key", "")
         logger.warning("Blocked learn_add from restricted session %s", sk)
@@ -913,10 +967,32 @@ async def api_lessons_create(request: web.Request) -> web.Response:
 async def api_lessons_delete(request: web.Request) -> web.Response:
     """DELETE /api/lessons — remove lessons by substring."""
     state: DashboardState = request.app["state"]
-    # Block lesson deletes from temporary sessions only.
+    # Require the SAME session recognition as ``api_lessons_create``, via the
+    # shared ``_recognize_session`` gate. Before this gate, deleting a lesson
+    # was LESS protected than adding one: a key that create rejects with HTTP
+    # 400 "unknown session" (forged, or a fresh background session whose
+    # transcript hasn't flushed yet) could still substring-delete any durable
+    # lesson. That asymmetry also breaks the remove-then-re-add consolidation
+    # pattern non-atomically — the destructive remove succeeds, then the
+    # re-add is refused, and the lesson is lost. Gating delete the same way
+    # makes the pattern fail closed at step one.
+    #
+    # Policy differences from create are carried by the gate's parameters:
+    # incognito sessions MAY delete (an active user action), only temporary
+    # sessions are blocked — both for live slots (``_blocks_reads_session``
+    # below) and, on the archived-session recovery path, via the persisted
+    # memory-mode probe.
+    sk = request.headers.get("X-Session-Key", "")
+    refusal = await _recognize_session(
+        state, sk, "lessons.delete",
+        blocks_persisted_mode=_is_temporary_transcript,
+        error_codes=True,
+    )
+    if refusal is not None:
+        return refusal
+    # Block lesson deletes from live temporary sessions only.
     # Incognito allows learn_remove (active user action).
     if _blocks_reads_session(state, request):
-        sk = request.headers.get("X-Session-Key", "")
         _sel().log_api_access(
             caller=sk,
             operation="lessons.delete",

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -887,6 +887,7 @@ def _http_error_body(exc: urllib.error.HTTPError) -> dict:
         raw = ""
     message = raw or str(exc)
     counted = False
+    code = ""
     if raw:
         try:
             parsed = json.loads(raw)
@@ -897,6 +898,17 @@ def _http_error_body(exc: urllib.error.HTTPError) -> dict:
                 # error-body flattening or spawn_run would double-reconcile
                 # in-process rejections and close waves early.
                 counted = bool(parsed.get("counted"))
+                # Preserve the backend's machine-readable error code (e.g.
+                # ``unknown_session`` from DELETE /api/lessons) so callers can
+                # dispatch on the stable code instead of matching the
+                # human-readable wording. The body is untrusted external
+                # content, so only a short identifier-shaped value survives —
+                # anything else is dropped rather than echoed onward.
+                raw_code = parsed.get("code")
+                if isinstance(raw_code, str) and _re.fullmatch(
+                    r"[a-z0-9_.-]{1,64}", raw_code
+                ):
+                    code = raw_code
         except Exception:
             pass
     message, _ = redact_exfiltration_urls(message)
@@ -904,6 +916,8 @@ def _http_error_body(exc: urllib.error.HTTPError) -> dict:
     out: dict = {"error": message}
     if counted:
         out["counted"] = True
+    if code:
+        out["code"] = code
     return out
 
 

--- a/src/kiro_crew/mcp_tools/learn.py
+++ b/src/kiro_crew/mcp_tools/learn.py
@@ -182,8 +182,23 @@ def learn_list(name: str, args: dict[str, Any]) -> str:
 def learn_remove(name: str, args: dict[str, Any]) -> str:
     query = args["query"]
     d = mcp_core._delete("/api/lessons", {"rule": query})
-    if d.get("error"):
-        return f"Error: {d['error']}"
+    err_val = d.get("error")
+    if err_val:
+        # Same session-scope mapping as ``learn_add``, but dispatched on the
+        # machine-readable ``code`` the delete route emits (and ``_delete``
+        # preserves) rather than the error wording, so a rephrased message
+        # cannot break the mapping. Make explicit that NOTHING was deleted, so
+        # a remove-then-re-add consolidation knows it failed closed at step
+        # one instead of assuming the destructive half went through.
+        if d.get("code") == "unknown_session":
+            return (
+                "No lessons were removed: this session is not recognised "
+                "by the gateway (no active slot, restricted key, or "
+                "persisted history found for this session key). Retry "
+                "from an established session (dashboard tab or Slack "
+                "thread), or use `kirocrew learn remove` from a shell."
+            )
+        return f"Error: {err_val}"
     return f"Removed lessons matching: {query}"
 
 

--- a/test/test_ephemeral_sessions.py
+++ b/test/test_ephemeral_sessions.py
@@ -46,7 +46,7 @@ def _make_app(state):
         api_chat_slot_resume,
         api_chat_slots,
     )
-    from kiro_crew.dashboard.handlers import api_lessons_create
+    from kiro_crew.dashboard.handlers import api_lessons_create, api_lessons_delete
 
     app = web.Application()
     app["state"] = state
@@ -55,6 +55,7 @@ def _make_app(state):
     app.router.add_delete("/api/chat/slots/{slot}", api_chat_slot_delete)
     app.router.add_post("/api/chat/slots/{slot}/resume", api_chat_slot_resume)
     app.router.add_post("/api/lessons", api_lessons_create)
+    app.router.add_delete("/api/lessons", api_lessons_delete)
     return app
 
 
@@ -1729,3 +1730,337 @@ class TestDurableSlackFlagsAtHttpGate:
                     headers={"X-Session-Key": self.SLACK_KEY},
                 )
                 assert resp.status == 200, await resp.text()
+
+
+# ── API: lessons DELETE session-recognition gate ──
+
+
+class TestLessonsDeleteGate:
+    """DELETE /api/lessons must apply the SAME session recognition as the
+    create route. Before the gate, deleting was LESS protected than adding: a
+    key that create rejects with 400 ``unknown session`` could still
+    substring-delete any durable lesson, and a remove-then-re-add
+    consolidation from such a session lost the lesson (destructive half
+    succeeded, re-add refused). Delete-specific policy is preserved: incognito
+    may delete (active user action); only temporary is blocked.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _persisted_history_dir_tracks_patched_home(self, monkeypatch):
+        """Same redirect as TestSessionSlotRecovery: keep the seeded
+        ``<home>/.kirocrew/sessions`` layout authoritative for the probe."""
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers._shared.config_dir",
+            lambda: Path.home() / ".kirocrew",
+        )
+
+    def _write_sessions_jsonl(self, tmp_path, stem: str, *, memory_mode=None) -> None:
+        sess_dir = tmp_path / ".kirocrew" / "sessions"
+        sess_dir.mkdir(parents=True, exist_ok=True)
+        meta = {"_type": "metadata", "created_at": "2026-01-01T00:00:00"}
+        if memory_mode:
+            meta["memory_mode"] = memory_mode
+        (sess_dir / f"{stem}.jsonl").write_text(
+            _json.dumps(meta) + "\n", encoding="utf-8"
+        )
+
+    def _deletable_state(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        # Route reads the vector store through cron.py's own binding.
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.cron._get_memory",
+            MagicMock(return_value=MagicMock(vector_store=None)),
+        )
+        state = _make_state(tmp_path)
+        state.lessons.remove = MagicMock(return_value=True)
+        return state
+
+    @pytest.mark.asyncio
+    async def test_delete_rejected_without_session_header(self, tmp_path, monkeypatch):
+        state = self._deletable_state(tmp_path, monkeypatch)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete("/api/lessons", json={"rule": "x"})
+            assert resp.status == 400
+            data = await resp.json()
+            assert "X-Session-Key" in data["error"]
+        state.lessons.remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_rejected_for_unknown_session(self, tmp_path, monkeypatch):
+        """Core regression: a forged/unknown key must NOT delete lessons."""
+        state = self._deletable_state(tmp_path, monkeypatch)
+        (tmp_path / ".kirocrew" / "sessions").mkdir(parents=True, exist_ok=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete(
+                "/api/lessons",
+                json={"rule": "x"},
+                headers={"X-Session-Key": "dashboard:deleted-slot"},
+            )
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"] == "unknown session"
+        state.lessons.remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_rejects_forged_cron_key_without_jsonl(self, tmp_path, monkeypatch):
+        state = self._deletable_state(tmp_path, monkeypatch)
+        (tmp_path / ".kirocrew" / "sessions").mkdir(parents=True, exist_ok=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete(
+                "/api/lessons",
+                json={"rule": "x"},
+                headers={"X-Session-Key": "cron:forged123"},
+            )
+            assert resp.status == 400
+        state.lessons.remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_allowed_for_browser_ui(self, tmp_path, monkeypatch):
+        state = self._deletable_state(tmp_path, monkeypatch)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete(
+                "/api/lessons",
+                json={"rule": "x"},
+                headers={"X-Session-Key": "dashboard:ui"},
+            )
+            assert resp.status == 200
+        state.lessons.remove.assert_called_once_with("x")
+
+    @pytest.mark.asyncio
+    async def test_delete_allowed_for_live_persistent_slot(self, tmp_path, monkeypatch):
+        state = self._deletable_state(tmp_path, monkeypatch)
+        state.get_or_create_slot("n1")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete(
+                "/api/lessons",
+                json={"rule": "x"},
+                headers={"X-Session-Key": "dashboard:n1"},
+            )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_delete_allowed_for_live_incognito_slot(self, tmp_path, monkeypatch):
+        """Incognito deletes stay allowed — an active user action (unchanged
+        from the pre-gate behavior; create blocks incognito, delete doesn't)."""
+        state = self._deletable_state(tmp_path, monkeypatch)
+        state.get_or_create_slot("e1", memory_mode="incognito")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete(
+                "/api/lessons",
+                json={"rule": "x"},
+                headers={"X-Session-Key": "dashboard:e1"},
+            )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_delete_blocked_for_live_temporary_slot(self, tmp_path, monkeypatch):
+        state = self._deletable_state(tmp_path, monkeypatch)
+        state.get_or_create_slot("t1", memory_mode="temporary")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete(
+                "/api/lessons",
+                json={"rule": "x"},
+                headers={"X-Session-Key": "dashboard:t1"},
+            )
+            assert resp.status == 403
+        state.lessons.remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_allowed_for_channel_namespace(self, tmp_path, monkeypatch):
+        state = self._deletable_state(tmp_path, monkeypatch)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete(
+                "/api/lessons",
+                json={"rule": "x"},
+                headers={"X-Session-Key": "telegram:kirocrew:forum:-1004326574849:18:gen3"},
+            )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_delete_allowed_for_evicted_session_with_persistent_jsonl(
+        self, tmp_path, monkeypatch
+    ):
+        """Evicted-but-real session recovers via the persisted-JSONL probe —
+        same as create — so a cron whose transcript has flushed can still
+        remove lessons after a gateway restart."""
+        state = self._deletable_state(tmp_path, monkeypatch)
+        self._write_sessions_jsonl(tmp_path, "cron_abc123")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete(
+                "/api/lessons",
+                json={"rule": "x"},
+                headers={"X-Session-Key": "cron:abc123"},
+            )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_delete_blocked_for_evicted_temporary_session_jsonl(
+        self, tmp_path, monkeypatch
+    ):
+        """Archived temporary session: the persisted memory_mode is the only
+        remaining evidence; deletes are blocked to mirror the live-slot
+        ``blocks_reads`` policy."""
+        state = self._deletable_state(tmp_path, monkeypatch)
+        self._write_sessions_jsonl(tmp_path, "dashboard_t9", memory_mode="temporary")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete(
+                "/api/lessons",
+                json={"rule": "x"},
+                headers={"X-Session-Key": "dashboard:t9"},
+            )
+            assert resp.status == 403
+        state.lessons.remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_allowed_for_evicted_incognito_session_jsonl(
+        self, tmp_path, monkeypatch
+    ):
+        """Archived incognito session may still delete — consistent with the
+        live-slot policy (delete differs from create here by design)."""
+        state = self._deletable_state(tmp_path, monkeypatch)
+        self._write_sessions_jsonl(tmp_path, "dashboard_e9", memory_mode="incognito")
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.delete(
+                "/api/lessons",
+                json={"rule": "x"},
+                headers={"X-Session-Key": "dashboard:e9"},
+            )
+            assert resp.status == 200
+
+
+class TestSharedRecognitionGate:
+    """Create and delete must run through ONE shared recognition gate.
+
+    ``_recognize_session`` is the single implementation of the slot /
+    restricted-key / channel-namespace / persisted-JSONL cascade; these tests
+    pin that both routes actually call it (so the cascades cannot silently
+    diverge again) and that each passes its own policy: create blocks every
+    incognito mode and stays code-less on its 400s, delete blocks only
+    temporary and emits machine-readable codes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_and_delete_call_the_same_gate(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.handlers import cron as cron_handlers
+        from kiro_crew.history import is_incognito_transcript
+
+        calls: dict[str, dict] = {}
+
+        async def _spy(state, sk, operation, **kwargs):
+            calls[operation] = kwargs
+            return web.json_response({"error": "gate refusal"}, status=400)
+
+        monkeypatch.setattr(cron_handlers, "_recognize_session", _spy)
+        state = _make_state(tmp_path)
+        state.lessons.remove = MagicMock(return_value=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            create = await client.post(
+                "/api/lessons",
+                json={"rule": "x", "category": "knowledge"},
+                headers={"X-Session-Key": "dashboard:whatever"},
+            )
+            delete = await client.delete(
+                "/api/lessons",
+                json={"rule": "x"},
+                headers={"X-Session-Key": "dashboard:whatever"},
+            )
+        # Both routes were refused by the gate's response — proof they route
+        # every request through the shared cascade, not a private copy.
+        assert create.status == 400
+        assert delete.status == 400
+        state.lessons.remove.assert_not_called()
+        assert set(calls) == {"learn_add", "lessons.delete"}
+        # Per-route policy rides on the parameters, not on divergent code:
+        # create blocks every private mode via the canonical classifier,
+        # delete blocks only temporary (incognito may delete).
+        assert calls["learn_add"]["blocks_persisted_mode"] is is_incognito_transcript
+        delete_blocks = calls["lessons.delete"]["blocks_persisted_mode"]
+        assert delete_blocks("temporary") is True
+        assert delete_blocks("incognito") is False
+        assert delete_blocks("persistent") is False
+        assert calls["lessons.delete"]["error_codes"] is True
+        assert calls["learn_add"].get("error_codes", False) is False
+
+    @pytest.mark.asyncio
+    async def test_delete_unknown_session_carries_machine_code(
+        self, tmp_path, monkeypatch
+    ):
+        """The delete route's 400 carries ``code: unknown_session`` (the
+        contract learn_remove dispatches on); create's equivalent stays
+        code-less (its pre-existing response shape)."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers._shared.config_dir", lambda: tmp_path
+        )
+        (tmp_path / "sessions").mkdir(parents=True, exist_ok=True)
+        state = _make_state(tmp_path)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            delete = await client.delete(
+                "/api/lessons",
+                json={"rule": "x"},
+                headers={"X-Session-Key": "dashboard:deleted-slot"},
+            )
+            assert delete.status == 400
+            data = await delete.json()
+            assert data["error"] == "unknown session"
+            assert data["code"] == "unknown_session"
+            create = await client.post(
+                "/api/lessons",
+                json={"rule": "x", "category": "knowledge"},
+                headers={"X-Session-Key": "dashboard:deleted-slot"},
+            )
+            assert create.status == 400
+            data = await create.json()
+            assert data["error"] == "unknown session"
+            assert "code" not in data
+
+    def test_http_error_body_preserves_machine_code(self):
+        """``_http_error_body`` must carry the backend's ``code`` through the
+        error-body flattening — learn_remove dispatches on it."""
+        import io
+        import urllib.error
+
+        from kiro_crew.mcp_core import _http_error_body
+
+        err = urllib.error.HTTPError(
+            url="http://x/api/lessons", code=400, msg="Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(b'{"error": "unknown session", "code": "unknown_session"}'),
+        )
+        assert _http_error_body(err) == {
+            "error": "unknown session",
+            "code": "unknown_session",
+        }
+        # A non-identifier code is untrusted content and must be dropped, not
+        # echoed onward.
+        err = urllib.error.HTTPError(
+            url="http://x/api/lessons", code=400, msg="Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(b'{"error": "x", "code": "https://evil.example/exfil"}'),
+        )
+        assert _http_error_body(err) == {"error": "x"}
+
+    def test_learn_remove_dispatches_on_code_not_wording(self, monkeypatch):
+        """A rephrased error message must not break the fail-closed mapping:
+        the dispatch key is ``code == "unknown_session"``, not the wording."""
+        from kiro_crew.mcp_tools.learn import learn_remove
+
+        monkeypatch.setattr(
+            "kiro_crew.mcp_core._delete",
+            lambda path, body=None: {
+                "error": "session not recognised (reworded)",
+                "code": "unknown_session",
+            },
+        )
+        out = learn_remove("learn_remove", {"query": "x"})
+        assert "No lessons were removed" in out
+
+    def test_learn_remove_surfaces_other_errors_verbatim(self, monkeypatch):
+        from kiro_crew.mcp_tools.learn import learn_remove
+
+        monkeypatch.setattr(
+            "kiro_crew.mcp_core._delete",
+            lambda path, body=None: {"error": "boom"},
+        )
+        assert learn_remove("learn_remove", {"query": "x"}) == "Error: boom"


### PR DESCRIPTION
## Problem

`DELETE /api/lessons` accepted any `X-Session-Key`. A key that `api_lessons_create` rejects with HTTP 400 `unknown session` — a forged key, or a fresh background session whose transcript hasn't flushed to disk yet — could still substring-delete any durable lesson. The destructive operation was **less** protected than the additive one.

This breaks the remove-then-re-add consolidation pattern non-atomically. Observed on a live gateway (2026-08-13, sanitized):

```
learn_remove("Babysit ALL of ...")   → Removed lessons matching: ...   # succeeded
learn_add(<merged replacement>)      → Lesson was NOT saved: this session is not
                                       recognised by the gateway (...)  # refused
```

The same session that was refused a write had just been allowed a delete. Without a fallback path, the lesson would have been permanently lost.

## Fix

`api_lessons_delete` now applies the same session-recognition gate as `api_lessons_create`: `dashboard:ui`, live slot, restricted key, channel namespace (`is_channel_session_key` + legacy Slack ts), or the off-loop persisted-JSONL probe (`_probe_persisted_session`).

Delete-specific policy is preserved:
- **Incognito may delete** (an active user action) — unchanged from the existing live-slot behavior, and now consistent on the archived-session recovery path.
- **Only temporary is blocked** — live slots via the existing `_blocks_reads_session` check, archived sessions via the persisted `memory_mode`.
- Ambiguous or unreadable persisted metadata **fails closed** (same as create).

Every authorization decision emits a SEL audit event under `lessons.delete`, matching the create route's per-branch auditing.

The `learn_remove` MCP wrapper maps the new `unknown session` refusal to an actionable message that states explicitly that **nothing was deleted**, so an agent running a consolidation knows it failed closed at step one.

Unaffected callers: the CLI (`kirocrew learn remove`) operates on the store directly and never hits this route; the dashboard UI sends the trusted `dashboard:ui` key.

## Tests

- 11 new regression tests in `test_ephemeral_sessions.py` (`TestLessonsDeleteGate`): missing header, unknown session, forged cron key, browser UI, live persistent/incognito/temporary slots, channel namespace, and the persisted-JSONL recovery path for persistent/temporary/incognito modes.
- 4 fail pre-fix (mutation-verified: forged and unknown keys got HTTP 200 deletes).
- Full `test_ephemeral_sessions.py` + `test_mcp_core_coverage.py`: 257 passed. `-k "lesson or learn"` across the suite: 330 passed, 1 skipped.
- isort / flake8 / mypy clean on touched files.