### PR TITLE
refactor: hoist function-local kiro_crew.agent imports to module scope (#1050)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -17,6 +17,7 @@ from aiohttp import web
 
 from kiro_crew import agent_state, model_registry
 from kiro_crew.acp.client import advertised_model_ids, model_is_unusable
+from kiro_crew.agent import AGENT_FILENAME, get_shipped_tools, install_agent, kiro_agents_dir_path
 from kiro_crew.agent_discovery import (
     clear_list_agents_cache,
     list_agents,
@@ -82,8 +83,6 @@ def _namespaced_agent_file_exists(agent_name: str) -> bool:
     # Resolved per call, not read from a module constant: the agents dir tracks
     # the live data home (see config.md "Data Home"), and a frozen constant would
     # glob the real ~/.kiro from an isolated run.
-    from kiro_crew.agent import kiro_agents_dir_path
-
     try:
         for path in kiro_agents_dir_path().glob(f"*--{agent_name}.json"):
             try:
@@ -122,8 +121,6 @@ def _sel():
 def _auto_install_agent() -> None:
     """Re-install agent config to kiro-cli so changes take effect immediately."""
     try:
-        from kiro_crew.agent import install_agent  # noqa: F811
-
         install_agent()
         logger.info("Auto-applied agent config via dashboard")
     except Exception:
@@ -141,8 +138,6 @@ def _installed_agent_config() -> Path:
     This is the live config that kiro-cli reads.  Dashboard MCP toggle
     and sync operations write here — NOT to agents/defaults.json.
     """
-    from kiro_crew.agent import AGENT_FILENAME, kiro_agents_dir_path  # noqa: F811
-
     return kiro_agents_dir_path() / AGENT_FILENAME
 
 
@@ -173,8 +168,6 @@ async def api_agent_config(request: web.Request) -> web.Response:
             # so they don't reappear on upgrade.  Stored in ~/.kiro/crew/config.json
             # (NOT kirocrew.json — kiro-cli rejects unknown fields).
             # Per-key dict so removing from allowedTools only doesn't affect tools.
-            from kiro_crew.agent import get_shipped_tools  # noqa: F811
-
             shipped = get_shipped_tools()
             removed_per_key: dict[str, list[str]] = {}
             for key in ("tools", "allowedTools"):
@@ -479,8 +472,6 @@ async def api_capability_skills_install(request: web.Request) -> web.Response:
         # Regenerate agent config to pick up new skill paths. install_agent()
         # does filesystem-heavy config rebuilding — offload it so it never
         # blocks the asyncio event loop (chat/heartbeat) under a slow FS.
-        from kiro_crew.agent import install_agent  # noqa: F811
-
         await asyncio.to_thread(install_agent)
         state: DashboardState = request.app["state"]
         state.push_refresh("agents")
@@ -507,8 +498,6 @@ async def api_capability_skills_uninstall(request: web.Request) -> web.Response:
             return web.json_response(
                 {"error": (res.message or "uninstall failed")[:500]}, status=500
             )
-        from kiro_crew.agent import install_agent  # noqa: F811
-
         await asyncio.to_thread(install_agent)
         state: DashboardState = request.app["state"]
         state.push_refresh("agents")
@@ -564,8 +553,6 @@ async def _mutate_agent_package(request: web.Request, *, install: bool) -> web.R
             return web.json_response({"error": _redact_external(message)}, status=500)
         # Filesystem-heavy config rebuild — offload so it never blocks the asyncio
         # event loop (chat turn + liveness heartbeat) on a slow FS.
-        from kiro_crew.agent import install_agent  # noqa: F811
-
         await asyncio.to_thread(install_agent)
         # list_agents() caches on a (count, newest-mtime-ns) signature, so a
         # mutation landing inside one mtime tick would otherwise serve a stale
@@ -1168,8 +1155,6 @@ async def api_slash_commands(request: web.Request) -> web.Response:
 async def api_agent_detail(request: web.Request) -> web.Response:
     """GET/DELETE/PATCH /api/agents/detail/{name} — view, delete, or update agent config."""
     name = request.match_info["name"]
-    from kiro_crew.agent import kiro_agents_dir_path  # noqa: F811
-
     # Parse body early so JSONDecodeError returns 400, not 404 from the file loop.
     patch_body = None
     if request.method == "PATCH":
@@ -1514,8 +1499,6 @@ async def _do_agents_sync(request: web.Request) -> web.Response:
         discovered_names = {a.name for a in discovered_agents}
 
         # Add new agents
-        from kiro_crew.agent import kiro_agents_dir_path  # noqa: F811
-
         mc_kiro_agents = {a.kiro_agent for a in cfg.agents.values()}
         for disc in discovered_agents:
             if (

--- a/src/kiro_crew/dashboard/handlers/hooks.py
+++ b/src/kiro_crew/dashboard/handlers/hooks.py
@@ -14,6 +14,7 @@ import aiohttp
 from aiohttp import web
 
 from kiro_crew import webhooks
+from kiro_crew.agent import _VALID_HOOK_EVENTS, _shipped_defaults, kiro_agents_dir_path
 from kiro_crew.config.loader import KiroCrewConfig, data_home
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.executors import run_in_embed_pool
@@ -95,7 +96,6 @@ async def api_hooks(request: web.Request) -> web.Response:
 @_store_failure_guard
 async def api_kiro_hooks(request: web.Request) -> web.Response:
     """GET /api/kiro-hooks — read-only view of kiro-cli agent hooks from kirocrew.json."""
-    from kiro_crew.agent import _VALID_HOOK_EVENTS, _shipped_defaults, kiro_agents_dir_path
     from kiro_crew.platform import redact_via_context as redact
 
     agent_cfg = kiro_agents_dir_path() / "kirocrew.json"

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -14,6 +14,7 @@ from typing import Any
 from aiohttp import web
 
 from kiro_crew import platform_compat
+from kiro_crew.agent import _atomic_json_write, kiro_agents_dir_path, rebuild_agent_config
 from kiro_crew.config.loader import _resolve_stub_servers
 from kiro_crew.config.paths import data_home, kiro_agents_dir
 from kiro_crew.dashboard.state import DashboardState
@@ -193,10 +194,6 @@ def _get_apply_lock() -> asyncio.Lock:
 
 def _write_mcp_json(data: dict) -> None:
     """Atomically write global mcp.json to prevent partial reads."""
-    from kiro_crew.agent import (  # noqa: F811  # circular import: agent imports handlers
-        _atomic_json_write,
-    )
-
     _GLOBAL_MCP_JSON.parent.mkdir(parents=True, exist_ok=True)
     _atomic_json_write(_GLOBAL_MCP_JSON, data)
 
@@ -335,10 +332,6 @@ def _sync_mcp_to_agent_unlocked(name: str, enabled: bool, *, remove: bool = Fals
         cfg.get("mcpServers", {}).pop(alias, None)
         cfg.get("mcpServers", {}).pop(name, None)
     try:
-        from kiro_crew.agent import (  # noqa: F811 circular: agent imports handlers
-            _atomic_json_write,
-        )
-
         _atomic_json_write(path, cfg)
     except OSError as exc:
         logger.warning("Cannot write agent config %s: %s", path, exc)
@@ -457,10 +450,6 @@ def _sync_mcp_to_agent_batch_unlocked(names: list[str], enabled: bool) -> None:
     if not changed:
         return
     try:
-        from kiro_crew.agent import (  # noqa: F811 circular: agent imports handlers
-            _atomic_json_write,
-        )
-
         _atomic_json_write(path, cfg)
     except OSError as exc:
         logger.warning("Cannot write agent config %s: %s", path, exc)
@@ -607,8 +596,6 @@ async def api_mcp_active(request: web.Request) -> web.Response:
     when ``--agent <name>`` is passed.  For kirocrew (or no agent),
     reads from global ``~/.kiro/settings/mcp.json`` as before.
     """
-    from kiro_crew.agent import kiro_agents_dir_path  # noqa: F811
-
     agent = request.query.get("agent", "")
 
     # Resolve KiroCrew agent name → kiro agent name so "default" → "kirocrew"
@@ -1264,10 +1251,6 @@ def _load_json_or_empty(path: Path) -> dict[str, Any]:
 
 def _atomic_write(path: Path, data: dict) -> None:
     """Atomic JSON write; reuses the agent helper."""
-    from kiro_crew.agent import (  # noqa: F811  # circular: agent imports dashboard handlers
-        _atomic_json_write,
-    )
-
     path.parent.mkdir(parents=True, exist_ok=True)
     _atomic_json_write(path, data)
 
@@ -1910,10 +1893,6 @@ async def _do_mcp_apply(request: web.Request) -> web.Response:
     rebuild_ok = False
     rebuild_error: str | None = None
     try:
-        # circular import: kiro_crew.agent imports dashboard handlers, so
-        # this is delayed to runtime to break the cycle at module load.
-        from kiro_crew.agent import rebuild_agent_config  # noqa: F811
-
         await asyncio.to_thread(rebuild_agent_config)
         rebuild_ok = True
     except Exception as exc:
@@ -2090,7 +2069,6 @@ async def api_mcp_gateway_enable(request: web.Request) -> web.Response:
     so the dashboard session stays authenticated.  Returns the verified state
     ``{ok, enabled, running, ping_ok}``.
     """
-    from kiro_crew.agent import _atomic_json_write  # circular import
     from kiro_crew.config.loader import config_path  # circular import
     from kiro_crew.dashboard.handlers.agents import _get_config_lock  # circular import
 
@@ -2197,7 +2175,6 @@ async def api_mcp_gateway_servers(request: web.Request) -> web.Response:
     Whether a stubbed server SHARES its backend is not per-row: that is the one
     global switch (``mcp_gateway.enabled``), reported by the status endpoint.
     """
-    from kiro_crew.agent import kiro_agents_dir_path
     from kiro_crew.config.loader import KiroCrewConfig  # noqa: F811
     from kiro_crew.mcp_gateway.rewriter import UNPOOLABLE_SERVERS
 
@@ -2283,7 +2260,6 @@ async def api_mcp_gateway_set_stub(request: web.Request) -> web.Response:
     Returns ``{ok, name, stub, ...}`` for the single form and
     ``{ok, names, stub, ...}`` for the batch form.
     """
-    from kiro_crew.agent import _atomic_json_write
     from kiro_crew.config.loader import config_path  # noqa: F811
     from kiro_crew.dashboard.handlers.agents import _get_config_lock  # circular: agents imports mcp
 

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -96,6 +96,7 @@ if TYPE_CHECKING:
 
 from kiro_crew import model_registry, platform_compat, shutdown_event
 from kiro_crew.acp.client import advertised_model_ids, model_is_unusable
+from kiro_crew.agent import kiro_agents_dir_path
 from kiro_crew.agent_discovery import spec_model
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
@@ -2155,8 +2156,6 @@ class SessionManager:
           mtime, so entries also expire after ``_AGENT_MODEL_CACHE_TTL`` seconds
           and are re-resolved.
         """
-        from kiro_crew.agent import kiro_agents_dir_path
-
         try:
             dir_mtime = kiro_agents_dir_path().stat().st_mtime
         except OSError:

--- a/test/test_agent_import_hoist.py
+++ b/test/test_agent_import_hoist.py
@@ -1,0 +1,93 @@
+"""Regression guard for issue #1050: module-scope ``kiro_crew.agent`` imports.
+
+The four modules below historically used function-local
+``from kiro_crew.agent import ...`` statements, several justified by
+``# circular import`` comments that misstated the real import graph
+(``kiro_crew.agent`` imports nothing from ``kiro_crew.dashboard.*`` or
+``kiro_crew.session``).  The imports were hoisted to module scope; these
+tests keep them there and prove no cycle exists in either load order.
+
+Order-dependent cycles only surface in a fresh interpreter, not under a
+bare import in an already-warm test process — hence the subprocess runs.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+
+_HOISTED_MODULES = (
+    "kiro_crew.dashboard.handlers.agents",
+    "kiro_crew.dashboard.handlers.mcp",
+    "kiro_crew.dashboard.handlers.hooks",
+    "kiro_crew.session",
+)
+
+_HOISTED_FILES = (
+    "kiro_crew/dashboard/handlers/agents.py",
+    "kiro_crew/dashboard/handlers/mcp.py",
+    "kiro_crew/dashboard/handlers/hooks.py",
+    "kiro_crew/session.py",
+)
+
+
+def _fresh_import(statements: str) -> None:
+    """Run import statements in a fresh child interpreter; fail on any error."""
+    res = subprocess.run(
+        [sys.executable, "-c", statements],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert res.returncode == 0, (
+        f"fresh-interpreter import failed (a hoisted import created a cycle?):\n"
+        f"{res.stderr}"
+    )
+
+
+def test_hoisted_modules_import_together_fresh() -> None:
+    """All four hoisted modules import together in a cold interpreter."""
+    _fresh_import("; ".join(f"import {m}" for m in _HOISTED_MODULES))
+
+
+def test_hoisted_modules_import_agent_first_fresh() -> None:
+    """Loading kiro_crew.agent BEFORE the handlers must also be cycle-free.
+
+    A cycle between ``agent`` and these modules would be order-dependent:
+    it can pass in one load order and raise ImportError in the other.
+    """
+    _fresh_import(
+        "; ".join(["import kiro_crew.agent"] + [f"import {m}" for m in _HOISTED_MODULES])
+    )
+
+
+def test_no_function_local_agent_imports_remain() -> None:
+    """Ratchet: no function-local ``from kiro_crew.agent import`` in the four files.
+
+    A reintroduced local import would silently undo the hoist and eventually
+    re-grow the false ``# circular import`` folklore this fixed.  All three
+    repo spellings are covered: ``from kiro_crew.agent import X``,
+    ``import kiro_crew.agent``, and ``from kiro_crew import agent`` (the
+    last matched on the bare ``agent`` name so sibling imports like
+    ``agent_state`` don't trip it; comments are excluded from the match).
+    """
+    local_import = re.compile(
+        r"^[ \t]+(?:"
+        r"from kiro_crew\.agent import"
+        r"|import kiro_crew\.agent\b"
+        r"|from kiro_crew import [^#\n]*\bagent\b"
+        r")",
+        re.MULTILINE,
+    )
+    offenders = {}
+    for rel in _HOISTED_FILES:
+        text = (_SRC / rel).read_text(encoding="utf-8")
+        hits = local_import.findall(text)
+        if hits:
+            offenders[rel] = len(hits)
+    assert not offenders, (
+        f"function-local kiro_crew.agent imports reintroduced: {offenders}; "
+        f"import at module scope instead (no cycle exists — see issue #1050)"
+    )

--- a/test/test_api_agent_config_put_succeeds.py
+++ b/test/test_api_agent_config_put_succeeds.py
@@ -41,7 +41,7 @@ async def test_api_agent_config_put_succeeds(tmp_path):
             return_value={"toolsSettings": {"execute_bash": {"deniedCommands": ["rm -rf"]}}},
         ),
         patch(
-            "kiro_crew.agent.get_shipped_tools",
+            "kiro_crew.dashboard.handlers.agents.get_shipped_tools",
             return_value={"tools": ["a", "c"], "allowedTools": ["b"]},
         ),
     ):
@@ -97,7 +97,7 @@ async def test_api_agent_config_put_strips_governed_grants(tmp_path, monkeypatch
         patch("kiro_crew.dashboard.handlers._find_agent_config", return_value=defaults),
         patch("kiro_crew.dashboard.handlers._reset_all_sessions", new_callable=AsyncMock),
         patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
-        patch("kiro_crew.agent.get_shipped_tools", return_value={"tools": [], "allowedTools": []}),
+        patch("kiro_crew.dashboard.handlers.agents.get_shipped_tools", return_value={"tools": [], "allowedTools": []}),
     ):
         response = await api_agent_config(request)
 

--- a/test/test_api_kiro_hooks.py
+++ b/test/test_api_kiro_hooks.py
@@ -20,11 +20,14 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from kiro_crew.dashboard.handlers.hooks import api_kiro_hooks
 
-# Handler does `from kiro_crew.agent import KIRO_AGENTS_DIR, _shipped_defaults`
-# and `from kiro_crew.security import redact` inside the function body each call,
-# so we patch at the source module where the names are defined.
+# The handler imports `_shipped_defaults` at module scope (hoisted, #1050), so
+# it is patched in the handler's namespace.  `KIRO_AGENTS_DIR` stays patched at
+# the SOURCE module on purpose: `kiro_agents_dir_path()` reads it from `agent`'s
+# globals at call time, so the source-module patch is unaffected by the hoist —
+# do NOT retarget it to the handler namespace (the name does not exist there).
+# `redact` is likewise patched where it is defined.
 _P_AGENTS_DIR = "kiro_crew.agent.KIRO_AGENTS_DIR"
-_P_DEFAULTS = "kiro_crew.agent._shipped_defaults"
+_P_DEFAULTS = "kiro_crew.dashboard.handlers.hooks._shipped_defaults"
 _P_REDACT = "kiro_crew.security.redact"
 
 

--- a/test/test_capability_agents_plugins.py
+++ b/test/test_capability_agents_plugins.py
@@ -178,7 +178,7 @@ def no_agent_rebuild(monkeypatch):
     """Stub the agent-config rebuild — it is filesystem-heavy and not under test."""
     rebuilds: List[bool] = []
     monkeypatch.setattr(
-        "kiro_crew.agent.install_agent", lambda *a, **k: rebuilds.append(True)
+        "kiro_crew.dashboard.handlers.agents.install_agent", lambda *a, **k: rebuilds.append(True)
     )
     cleared: List[bool] = []
     monkeypatch.setattr(

--- a/test/test_mcp_apply.py
+++ b/test/test_mcp_apply.py
@@ -173,9 +173,7 @@ class TestApplyEndpoint:
             ),
         )
         # Stub rebuild_agent_config — we only care about file writes here.
-        import kiro_crew.agent
-
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", lambda: None)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", lambda: None)
 
         # No-op the lock to simplify testing.
         class _NoLock:
@@ -232,9 +230,7 @@ class TestApplyEndpoint:
         # the subprocess.run call entirely.
         monkeypatch.setattr("kiro_crew.dashboard.handlers._shared._capability_manager", lambda: MagicMock(**{"available.return_value": False}))
 
-        import kiro_crew.agent
-
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", lambda: None)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", lambda: None)
 
         class _NoLock:
             async def __aenter__(self):
@@ -268,10 +264,8 @@ class TestApplyEndpoint:
         # Return None from shutil.which to short-circuit that path.
         monkeypatch.setattr("kiro_crew.dashboard.handlers._shared._capability_manager", lambda: MagicMock(**{"available.return_value": False}))
 
-        import kiro_crew.agent
-
         rebuild = MagicMock()
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", rebuild)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", rebuild)
 
         class _NoLock:
             async def __aenter__(self):
@@ -348,10 +342,8 @@ class TestHostileNameRejection:
             lambda: pytest.fail("_capability_manager must not be reached for invalid name"),
         )
 
-        import kiro_crew.agent
-
         rebuild = MagicMock()
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", rebuild)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", rebuild)
 
         class _NoLock:
             async def __aenter__(self):
@@ -398,9 +390,7 @@ class TestHostileNameRejection:
         )
         monkeypatch.setattr("kiro_crew.dashboard.handlers._shared._capability_manager", lambda: MagicMock(**{"available.return_value": False}))
 
-        import kiro_crew.agent
-
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", lambda: None)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", lambda: None)
 
         class _NoLock:
             async def __aenter__(self):
@@ -493,13 +483,12 @@ class TestApplyBatchCap:
     @pytest.mark.asyncio
     async def test_accepts_batch_at_cap(self, monkeypatch, tmp_path) -> None:
         """A batch exactly at the cap is not rejected by the size guard."""
-        import kiro_crew.agent
         from kiro_crew.dashboard.handlers import mcp as mcp_mod
 
         monkeypatch.setattr(mcp_mod, "_KIROCREW_MCP_JSON", tmp_path / "kc.json")
         monkeypatch.setattr(mcp_mod, "_GLOBAL_MCP_JSON", tmp_path / "kiro.json")
         monkeypatch.setattr(mcp_mod, "_extra_mcp_scopes", lambda: [])
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", lambda: None)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", lambda: None)
 
         class _NoLock:
             async def __aenter__(self):
@@ -581,14 +570,13 @@ class TestBoundedCapabilityManager:
         (in the phase BEFORE the MCP file lock is taken) and records it."""
         from unittest.mock import AsyncMock
 
-        import kiro_crew.agent
         from kiro_crew.dashboard.handlers import _shared
         from kiro_crew.dashboard.handlers import mcp as mcp_mod
 
         monkeypatch.setattr(mcp_mod, "_KIROCREW_MCP_JSON", tmp_path / "kc.json")
         monkeypatch.setattr(mcp_mod, "_GLOBAL_MCP_JSON", tmp_path / "kiro.json")
         monkeypatch.setattr(mcp_mod, "_extra_mcp_scopes", lambda: [])
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", lambda: None)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", lambda: None)
 
         class _NoLock:
             async def __aenter__(self):
@@ -622,14 +610,13 @@ class TestBoundedCapabilityManager:
         import asyncio as _asyncio
         from unittest.mock import AsyncMock
 
-        import kiro_crew.agent
         from kiro_crew.dashboard.handlers import _shared
         from kiro_crew.dashboard.handlers import mcp as mcp_mod
 
         monkeypatch.setattr(mcp_mod, "_KIROCREW_MCP_JSON", tmp_path / "kc.json")
         monkeypatch.setattr(mcp_mod, "_GLOBAL_MCP_JSON", tmp_path / "kiro.json")
         monkeypatch.setattr(mcp_mod, "_extra_mcp_scopes", lambda: [])
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", lambda: None)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", lambda: None)
         # Tiny budget so the hanging op blows the phase deadline immediately.
         from kiro_crew.platform import capability_bound
 
@@ -673,7 +660,6 @@ class TestUninstallCrashWindowCleanup:
         uninstall's config removal runs — the finally sweep still purges it."""
         from unittest.mock import AsyncMock
 
-        import kiro_crew.agent
         from kiro_crew.dashboard.handlers import _shared
         from kiro_crew.dashboard.handlers import mcp as mcp_mod
 
@@ -686,7 +672,7 @@ class TestUninstallCrashWindowCleanup:
         monkeypatch.setattr(mcp_mod, "_KIROCREW_MCP_JSON", tmp_path / "kc.json")
         monkeypatch.setattr(mcp_mod, "_GLOBAL_MCP_JSON", kiro_path)
         monkeypatch.setattr(mcp_mod, "_extra_mcp_scopes", lambda: [])
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", lambda: None)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", lambda: None)
 
         class _NoLock:
             async def __aenter__(self):
@@ -740,7 +726,6 @@ class TestUninstallCrashWindowCleanup:
         import asyncio as _asyncio
         from unittest.mock import AsyncMock
 
-        import kiro_crew.agent
         from kiro_crew.dashboard.handlers import _shared
         from kiro_crew.dashboard.handlers import mcp as mcp_mod
         from kiro_crew.platform import capability_bound
@@ -752,7 +737,7 @@ class TestUninstallCrashWindowCleanup:
         monkeypatch.setattr(mcp_mod, "_KIROCREW_MCP_JSON", tmp_path / "kc.json")
         monkeypatch.setattr(mcp_mod, "_GLOBAL_MCP_JSON", kiro_path)
         monkeypatch.setattr(mcp_mod, "_extra_mcp_scopes", lambda: [])
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", lambda: None)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", lambda: None)
         monkeypatch.setattr(capability_bound, "CAPABILITY_UNINSTALL_TIMEOUT", 0.01)
 
         class _NoLock:
@@ -804,7 +789,6 @@ class TestUninstallCrashWindowCleanup:
         import asyncio as _asyncio
         from unittest.mock import AsyncMock
 
-        import kiro_crew.agent
         from kiro_crew.dashboard.handlers import _shared
         from kiro_crew.dashboard.handlers import mcp as mcp_mod
 
@@ -817,7 +801,7 @@ class TestUninstallCrashWindowCleanup:
         monkeypatch.setattr(mcp_mod, "_KIROCREW_MCP_JSON", tmp_path / "kc.json")
         monkeypatch.setattr(mcp_mod, "_GLOBAL_MCP_JSON", kiro_path)
         monkeypatch.setattr(mcp_mod, "_extra_mcp_scopes", lambda: [])
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", lambda: None)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", lambda: None)
 
         class _NoLock:
             async def __aenter__(self):
@@ -876,7 +860,6 @@ class TestUninstallCrashWindowCleanup:
         import threading
         from unittest.mock import AsyncMock
 
-        import kiro_crew.agent
         from kiro_crew.dashboard.handlers import _shared
         from kiro_crew.dashboard.handlers import mcp as mcp_mod
 
@@ -885,7 +868,7 @@ class TestUninstallCrashWindowCleanup:
         monkeypatch.setattr(mcp_mod, "_KIROCREW_MCP_JSON", tmp_path / "kc.json")
         monkeypatch.setattr(mcp_mod, "_GLOBAL_MCP_JSON", kiro_path)
         monkeypatch.setattr(mcp_mod, "_extra_mcp_scopes", lambda: [])
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", lambda: None)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", lambda: None)
 
         class _NoLock:
             async def __aenter__(self):
@@ -939,14 +922,13 @@ class TestApplyMutex:
         import asyncio as _asyncio
         from unittest.mock import AsyncMock
 
-        import kiro_crew.agent
         from kiro_crew.dashboard.handlers import _shared
         from kiro_crew.dashboard.handlers import mcp as mcp_mod
 
         monkeypatch.setattr(mcp_mod, "_KIROCREW_MCP_JSON", tmp_path / "kc.json")
         monkeypatch.setattr(mcp_mod, "_GLOBAL_MCP_JSON", tmp_path / "kiro.json")
         monkeypatch.setattr(mcp_mod, "_extra_mcp_scopes", lambda: [])
-        monkeypatch.setattr(kiro_crew.agent, "rebuild_agent_config", lambda: None)
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.mcp.rebuild_agent_config", lambda: None)
         # Reset the module-global apply lock so a stale loop binding from an
         # earlier test can't leak in.
         monkeypatch.setattr(mcp_mod, "_apply_lock", None)

--- a/test/test_session_more_coverage.py
+++ b/test/test_session_more_coverage.py
@@ -279,7 +279,7 @@ class TestResolveAgentModel:
         """``stat()`` on an absent dir raises OSError; mtime 0.0 must be used as
         the cache stamp rather than the lookup blowing up."""
         missing = tmp_path / "nope"
-        with patch("kiro_crew.agent.kiro_agents_dir_path", return_value=missing):
+        with patch("kiro_crew.session.kiro_agents_dir_path", return_value=missing):
             assert SessionManager._resolve_agent_model("researcher") == "auto"
         assert SessionManager._agent_model_cache["researcher"][1] == 0.0
 
@@ -289,7 +289,7 @@ class TestResolveAgentModel:
         agents = tmp_path / "agents"
         agents.mkdir()
         (agents / "researcher.json").write_text("{not json", encoding="utf-8")
-        with patch("kiro_crew.agent.kiro_agents_dir_path", return_value=agents):
+        with patch("kiro_crew.session.kiro_agents_dir_path", return_value=agents):
             assert SessionManager._resolve_agent_model("researcher") == "auto"
 
     def test_a_readable_agent_file_supplies_its_pinned_model(self, tmp_path) -> None:
@@ -298,14 +298,14 @@ class TestResolveAgentModel:
         (agents / "researcher.json").write_text(
             '{"name": "researcher", "model": "sonnet-9"}', encoding="utf-8"
         )
-        with patch("kiro_crew.agent.kiro_agents_dir_path", return_value=agents):
+        with patch("kiro_crew.session.kiro_agents_dir_path", return_value=agents):
             assert SessionManager._resolve_agent_model("researcher") == "sonnet-9"
 
     def test_a_raising_spec_reader_falls_back_to_auto(self, tmp_path) -> None:
         agents = tmp_path / "agents"
         agents.mkdir()
         (agents / "researcher.json").write_text('{"name": "researcher"}', encoding="utf-8")
-        with patch("kiro_crew.agent.kiro_agents_dir_path", return_value=agents), patch(
+        with patch("kiro_crew.session.kiro_agents_dir_path", return_value=agents), patch(
             "kiro_crew.session.spec_model", side_effect=RuntimeError("bad spec")
         ):
             assert SessionManager._resolve_agent_model("researcher") == "auto"


### PR DESCRIPTION
## Problem

20 function-local `from kiro_crew.agent import ...` statements are scattered through four modules — 9 in `dashboard/handlers/agents.py`, 9 in `dashboard/handlers/mcp.py`, 1 in `dashboard/handlers/hooks.py`, 1 in `session.py`. Five of the `mcp.py` sites carry a `# circular import: agent imports handlers` comment that misstates the real import graph, and every site carries a `# noqa: F811` marker to suppress the redefinition warnings the repetition causes.

## Why it matters

In-function imports hide dependencies, break IDE navigation, and make monkeypatch targets ambiguous (AUTOSDE `top-level-imports`). Worse, the false `# circular import` comments actively discouraged the hoist — the folklore is what kept this unfixed and is copyable into new call sites.

## Fix (symptoms → root cause → change)

Symptom: repeated local imports justified by cycle comments. Root cause: **the claimed cycle does not exist** — `kiro_crew.agent`'s module-scope import set expanded to fixpoint (35 modules) reaches nothing in `kiro_crew.dashboard.*` or `kiro_crew.session`, in either load order. Change:

- Hoist all 20 sites to module scope in the four files (count re-derived against main, matches the issue's corrected count of 20, not the title's "four").
- Delete the five false `# circular import` comments in `mcp.py` and the now-moot `# noqa: F811` markers. Removing the misinformation is part of the fix, not cleanup noise.
- Retarget test monkeypatches from the `kiro_crew.agent` namespace to the consumer namespaces where the hoist changes binding time (`test_session_more_coverage.py`, `test_mcp_apply.py` ×13, `test_api_kiro_hooks.py`, `test_api_agent_config_put_succeeds.py`, `test_capability_agents_plugins.py`). `KIRO_AGENTS_DIR` deliberately stays patched at the source module — `kiro_agents_dir_path()` reads it from `agent`'s globals at call time — and the comment now says why.
- `_atomic_json_write` is hoisted between internal handler modules only; it is not re-exported and its visibility is unchanged.

**Boot-path check** (AUTOSDE `no-new-work-on-gateway-boot-path` matches these files): the hoist adds zero new transitive load. `kiro_crew.agent` is already imported at module scope by `acp/client.py`, `context.py`, `dashboard/chat_persistence.py`, and `cli_doctor.py`, all of which load before these handlers on the gateway boot path — verified by both pre-push reviewers and by a real gateway boot.

**Scope boundary (deliberate):** 30 function-local `kiro_crew.agent` imports remain elsewhere in `src/kiro_crew/` (e.g. `handlers/core.py`, `cli_setup.py`, `mcp_discovery.py`, `slack/gateway.py`), some with the same unverified `# circular import` notes. Each needs its own cycle/boot-path derivation, so they are out of scope here; the ratchet test pins exactly the four files this PR fixes. Follow-up tracked in the issue comment.

## Tests

- New `test/test_agent_import_hoist.py`:
  - `test_hoisted_modules_import_together_fresh` — all four modules import together in a cold interpreter (a cycle would raise `ImportError`).
  - `test_hoisted_modules_import_agent_first_fresh` — same with `kiro_crew.agent` loaded first, catching order-dependent cycles.
  - `test_no_function_local_agent_imports_remain` — ratchet covering all three local-import spellings (`from kiro_crew.agent import`, `import kiro_crew.agent`, `from kiro_crew import agent`), mutation-verified against 8 spelling cases.
- Retargeted patches keep their original assertions; the previously-dead stubs now genuinely intercept (e.g. `test_calls_rebuild_agent_config_once` failed before retargeting because the real `rebuild_agent_config` ran).

## Manual verification

Real gateway boot from the branch venv with isolated `KIROCREW_HOME`: socket bound and `/api/status` answered (403 auth-gated, as expected without a token). Full pytest: 50211 passed; the 143 failures are environment-caused (no OS sandbox on host, subagent spawn paths) and reproduce identically on `origin/main` (verified with an A/B run — identical failure sets).

<!-- no-visual-delta -->
**Why no screenshot:** backend-only import reorganization; no frontend paths touched, no rendered change.

Closes #1050
