### PR TITLE
docs(rfc): perpetual agents — typed gates + spend-after-writeback (LoopX comparison)

### DIFF
--- a/docs/request-for-change/rfc-perpetual-agent.md
+++ b/docs/request-for-change/rfc-perpetual-agent.md
@@ -417,6 +417,23 @@ interacts with cron's auto-pause.
 ask_supervisor(wall, question, attempts[], options[])
 ```
 
+**Revision-3 addendum — an escalation is a durable STATE OBJECT, not a sent
+message** (convergent with LoopX's "concrete user gate", credited: the
+open-source loop-engineering kernel independently reached the same design).
+Phase 0's Finding 12 showed the send-shaped version failing exactly as a send
+fails: delivery degraded silently and a well-behaved agent waited politely for
+4.5 hours on a question that had never arrived. A gate object fixes the class,
+not the instance: `ask_supervisor` WRITES a pending gate into the job's state
+(question, wall, attempts, options, created_at), the dashboard renders every
+open gate — visibility no longer depends on any one channel delivering — and
+the "delivery receipt" Phase 1 asked for becomes trivial: the receipt is the
+gate existing in state. Two properties carry over from Phase 0 observations:
+a gate blocks only the lane that needs the answer (copywriting-warden's
+cycle 6 kept assessing while its PR lane was gated — that behaviour becomes
+the mechanism, matching LoopX's audited safe-fallback rule), and an unanswered
+gate past its SLA still triggers the file-publicly fallback rather than
+indefinite waiting.
+
 **`wall` classifies what stopped the agent, and it decides whether the attempts
 gate applies.** Revision 1 required two distinct prior attempts unconditionally.
 That is wrong for one of the two kinds of wall an agent can hit, and the two are
@@ -684,6 +701,20 @@ adds nothing but a different reset policy — accumulating instead of rolling �
 supervisor top-ups. That is a small, safe change with no behavioural theory
 attached, and it is the only part of revision 1's Phase 3 that is unambiguously
 worth building.
+
+**Revision-3 addendum — debit after validated writeback, not at wake**
+(convergent with LoopX's "quota spend only after a completed, validated slice";
+its complementary rule — quiet skips, preflight failures and dry-runs do not
+spend — independently reproduces this RFC's §4/§7 position that honest idle
+must never cost the agent anything). Debiting at wake makes the ceiling a tax
+on being scheduled; debiting after the wake's `agent_sleep` record lands makes
+it a tax on *claimed work*, which is the thing worth bounding. Concretely: a
+wake that dies to timeout or transient error consumes no budget (it already
+lost its work — Phase 0 lost two wakes this way); a wake that completes debits
+one slot when its `did` record persists. This also gives Phase 3a its audit
+hook for free: every debit points at a `did`, so the balance is a countable
+claim log rather than a wake counter, and Finding 7's audit view can render
+spend against evidence directly.
 
 Dormancy stays as revision 1 specified: **zero balance auto-pauses the job and
 leaves the life directory intact**, resumable only by a human. An agent that ran


### PR DESCRIPTION
## What this is

Two revision-3 addenda to the perpetual-agent RFC, from reviewing [huangruiteng/loopx](https://github.com/huangruiteng/loopx) (MIT, "loop engineering state kernel" — a provider-neutral control plane for long-running agents) against our design.

Three of LoopX's choices independently converge with Phase 0 conclusions — quiet skips don't spend quota (= our "honest idle is never punished"), reward memory is default-off experimental (= our Phase 3b posture), and judgment stays human (= our death-as-governance) — which is useful external validation. Two of its mechanisms are better than ours and are adopted:

## 1. §5 addendum — escalation is a durable state object, not a sent message

Finding 12's failure (delivery degraded silently, agent waited politely 4.5h) is a property of *sends*. LoopX's "concrete user gate" is the right shape: `ask_supervisor` writes a **typed gate into job state**; the dashboard renders every open gate, so visibility no longer depends on any channel delivering; Phase 1's "delivery receipt" becomes trivial — the receipt is the gate existing. A gate blocks only the lane that needs the answer (formalizing what copywriting-warden did on its own in cycle 6), and the unanswered-past-SLA → file-publicly fallback stays.

## 2. Phase 3a addendum — debit after validated writeback, never at wake

LoopX spends quota only after a completed, validated slice. Adopted: a wake that dies to timeout or transient error consumes no budget (Phase 0 lost two wakes exactly this way); a completed wake debits when its `agent_sleep` `did` record persists. Every debit then points at a `did`, so the balance is a countable claim log — which hands Finding 7's audit view its spend-against-evidence rendering for free.

Docs-only, +31 lines. What we deliberately did **not** adopt: LoopX's host-cooperative wake (its timer lives in the host runtime; ours is a disk-owned deadline that fires on recovery without agent cooperation) and its todo-driven work selection (Phase 0 Findings 14/15 showed pre-decomposed queues starving the goal — our §7 ranking step stands).
