### PR TITLE
perf(dashboard): coalesce slot broadcasts so a burst of mutations emits one frame

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -132,6 +132,10 @@ NATIVE_SUBAGENT_DONE_TRUNC_MARKER = "…(earlier output truncated)\n"
 NATIVE_SUBAGENT_TERMINAL_KEEP = 50
 NATIVE_SUBAGENT_TERMINAL_TTL_SECS = 3600.0
 
+# Slot-list broadcast coalescing window. The sub-agent slots debouncer in
+# slack/gateway.py hardcodes the same value independently; the two are not shared.
+_SLOTS_BROADCAST_INTERVAL_S: float = 0.2
+
 
 def native_subagent_output_tail(chunks: list[str], limit: int = NATIVE_SUBAGENT_OUTPUT_TAIL) -> str:
     """Join only the trailing ``limit`` characters of native-card output."""
@@ -2210,6 +2214,15 @@ class DashboardState:
     _slots_push_suspend: int = 0
     _slots_push_pending: bool = False
     restoring_open_slots: bool = False
+    # push_slots_update() coalescing state, on that same read path. The lock
+    # defaults to None rather than to a shared Lock(): a None lock means "no
+    # coalescing", so a __new__-built state broadcasts straight through instead
+    # of every instance in the process contending on one class-level mutex.
+    # __init__ installs the real per-instance lock.
+    _slots_broadcast_lock: "threading.Lock | None" = None
+    _slots_broadcast_timer: "asyncio.TimerHandle | None" = None
+    _slots_broadcast_loop: "asyncio.AbstractEventLoop | None" = None
+    _slots_broadcast_last: float = 0.0
     # Keys the last open-tab restore could not read (not keys it proved absent).
     # _persist_open_slots folds these back into the snapshot so a transient read
     # failure cannot erase the reopen seed. The class-level baseline is an
@@ -2350,6 +2363,9 @@ class DashboardState:
         # Depth + pending flag for suspend_slots_push(); see that method.
         self._slots_push_suspend = 0
         self._slots_push_pending = False
+        # Time-based coalescing state for push_slots_update(). Guarded by a
+        # threading.Lock because callers are not all on the event loop.
+        self._slots_broadcast_lock = threading.Lock()
         # True while the startup open-tab restore is in flight. Suppresses the
         # open_slots.json snapshot so a periodic flush cannot overwrite the file
         # being restored from with a half-populated slot set — see
@@ -5055,16 +5071,99 @@ class DashboardState:
                 self.push_slots_update()
 
     def push_slots_update(self) -> None:
-        """Push slots, keeping provider status confined to owner websockets."""
-        from kiro_crew.dashboard.handlers.source_providers import (
-            gitlab_hosts_generation,
-        )
+        """Push slots, keeping provider status confined to owner websockets.
 
+        Coalesces on a leading plus trailing edge: the first call after an idle
+        period broadcasts immediately, further calls inside the window are
+        absorbed, and one trailing broadcast carries the final state. A single
+        chat turn fires several of these and each one re-serializes every slot,
+        so an uncoalesced burst redraws the whole sidebar once per mutation for
+        what the user sees as one change. The trailing flush re-serializes at
+        delivery time, so a coalesced frame is never a stale frame.
+        """
         if self._slots_push_suspend:
             # Inside suspend_slots_push(); remember that a push is owed and let the
             # outermost block emit a single coalesced broadcast on exit.
             self._slots_push_pending = True
             return
+
+        now = time.monotonic()
+        broadcast_now = False
+        lock = self._slots_broadcast_lock
+        if lock is None:
+            # Partially-constructed state (built via __new__): no coalescing.
+            self._do_slots_broadcast()
+            return
+
+        with lock:
+            if self._slots_broadcast_loop is None:
+                self._slots_broadcast_loop = self._running_loop()
+
+            elapsed = now - self._slots_broadcast_last
+            if elapsed >= _SLOTS_BROADCAST_INTERVAL_S:
+                self._slots_broadcast_last = now
+                if self._slots_broadcast_timer is not None:
+                    self._slots_broadcast_timer.cancel()
+                    self._slots_broadcast_timer = None
+                broadcast_now = True
+            elif self._slots_broadcast_timer is None:
+                # Scheduling onto the captured loop is preferred over broadcasting
+                # from a foreign thread; a closed loop falls back to an immediate send.
+                loop = self._slots_broadcast_loop
+                remaining = _SLOTS_BROADCAST_INTERVAL_S - elapsed
+                try:
+                    if loop is None:
+                        self._slots_broadcast_last = now
+                        broadcast_now = True
+                    elif loop is self._running_loop():
+                        self._slots_broadcast_timer = loop.call_later(
+                            remaining, self._trailing_slots_flush
+                        )
+                    else:
+                        loop.call_soon_threadsafe(self._schedule_trailing_flush, remaining)
+                except RuntimeError:
+                    self._slots_broadcast_last = now
+                    broadcast_now = True
+
+        # serialize_slots() and _broadcast() are the expensive half; running them
+        # outside the lock stops a cross-thread caller from blocking behind them.
+        if broadcast_now:
+            self._do_slots_broadcast()
+
+    @staticmethod
+    def _running_loop() -> asyncio.AbstractEventLoop | None:
+        """Return the running loop, or None when called off the event loop."""
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+
+    def _schedule_trailing_flush(self, delay: float) -> None:
+        """Arm the trailing flush. Must run ON the event loop."""
+        lock = self._slots_broadcast_lock
+        if lock is None:
+            return
+        with lock:
+            if self._slots_broadcast_timer is not None:
+                return
+            self._slots_broadcast_timer = asyncio.get_running_loop().call_later(
+                delay, self._trailing_slots_flush
+            )
+
+    def _trailing_slots_flush(self) -> None:
+        """Trailing-edge callback: broadcast whatever the state is now."""
+        lock = self._slots_broadcast_lock
+        if lock is not None:
+            with lock:
+                self._slots_broadcast_timer = None
+                self._slots_broadcast_last = time.monotonic()
+        self._do_slots_broadcast()
+
+    def _do_slots_broadcast(self) -> None:
+        """Serialize and broadcast the slot list. Bypasses coalescing."""
+        from kiro_crew.dashboard.handlers.source_providers import (
+            gitlab_hosts_generation,
+        )
 
         yolo_active = self.is_yolo_active()  # expire first if needed
         slots_data = self.serialize_slots()

--- a/test/test_chat_slot_create_folder.py
+++ b/test/test_chat_slot_create_folder.py
@@ -16,6 +16,7 @@ only the final state would pass even with the race reintroduced.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -28,7 +29,7 @@ from aiohttp.test_utils import TestClient, TestServer
 # resolves to the stdlib `test` and fails with ModuleNotFoundError on CI.
 from chat_test_helpers import _make_ready_kiro_prerequisite
 
-from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.state import _SLOTS_BROADCAST_INTERVAL_S, DashboardState
 from kiro_crew.history import ConversationLog
 
 FOLDER_ID = "f-design"
@@ -180,6 +181,10 @@ class TestCreateInFolder:
             )
             assert again.status == 200
             assert (await again.json())["folder_id"] == FOLDER_ID
+
+            # The first POST took the leading edge of the slot-broadcast
+            # coalescing window, so this frame arrives on the trailing edge.
+            await asyncio.sleep(_SLOTS_BROADCAST_INTERVAL_S + 0.05)
 
         assert seen, "re-filing an existing slot emitted no slots frame at all"
         entry = next((s for s in seen[-1] if s["key"] == "s1"), None)

--- a/test/test_slots_broadcast_coalesce.py
+++ b/test/test_slots_broadcast_coalesce.py
@@ -1,0 +1,181 @@
+"""Tests for push_slots_update leading+trailing edge coalescing."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.dashboard.state import (
+    _SLOTS_BROADCAST_INTERVAL_S,
+    DashboardState,
+    _ChatSlot,
+)
+
+
+@pytest.fixture
+def loop():
+    """A dedicated loop, so call_later handles are driven deterministically."""
+    new_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(new_loop)
+    yield new_loop
+    new_loop.close()
+    asyncio.set_event_loop(None)
+
+
+@pytest.fixture
+def state(monkeypatch, tmp_path, loop):
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    s = DashboardState(
+        sessions=MagicMock(count=0),
+        crons=MagicMock(list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})),
+        lessons=MagicMock(load_all=MagicMock(return_value=[])),
+        start_time=0.0,
+    )
+    s.is_yolo_active = lambda: False
+    # Production captures this on the first call from the loop thread; pinning it
+    # here keeps each test's timing independent of construction order.
+    s._slots_broadcast_loop = loop
+    return s
+
+
+class TestBurstCoalescing:
+    """A burst of N rapid calls produces exactly 1 leading + 1 trailing broadcast."""
+
+    def test_burst_produces_leading_plus_trailing(self, state, loop):
+        broadcasts: list[dict] = []
+        state._broadcast = lambda note: broadcasts.append(note)
+
+        async def _run_burst():
+            state.push_slots_update()
+            assert len(broadcasts) == 1, "Leading edge should broadcast immediately"
+
+            for _ in range(5):
+                state.push_slots_update()
+            assert len(broadcasts) == 1, "Burst within window should not add broadcasts"
+
+            await asyncio.sleep(_SLOTS_BROADCAST_INTERVAL_S + 0.05)
+            assert len(broadcasts) == 2, (
+                f"Expected exactly 1 trailing broadcast after timer, got {len(broadcasts)}"
+            )
+
+        loop.run_until_complete(_run_burst())
+
+
+class TestTrailingCarriesLatestState:
+    """The trailing broadcast carries the LATEST state, not a stale snapshot."""
+
+    def test_trailing_reflects_mutation(self, state, loop):
+        payloads: list[dict] = []
+        state._broadcast = lambda note: payloads.append(note)
+
+        slot = _ChatSlot("test-1-100", title="before")
+        state._slots["test-1-100"] = slot
+
+        async def _run():
+            state.push_slots_update()
+            assert len(payloads) == 1
+            assert any(s["title"] == "before" for s in payloads[0]["_slots_list"])
+
+            slot.title = "after"
+            state.push_slots_update()
+
+            await asyncio.sleep(_SLOTS_BROADCAST_INTERVAL_S + 0.05)
+            assert len(payloads) == 2
+            assert any(s["title"] == "after" for s in payloads[1]["_slots_list"]), (
+                "Trailing broadcast must carry the latest (mutated) state"
+            )
+
+        loop.run_until_complete(_run())
+
+
+class TestIsolatedCallImmediate:
+    """An isolated single call broadcasts immediately with no delay."""
+
+    def test_single_call_no_delay(self, state, loop):
+        broadcasts: list[float] = []
+        state._broadcast = lambda note: broadcasts.append(time.monotonic())
+
+        async def _run():
+            before = time.monotonic()
+            state.push_slots_update()
+            after = time.monotonic()
+
+            assert len(broadcasts) == 1
+            assert broadcasts[0] - before < 0.05, "Single call should broadcast instantly"
+            assert after - before < 0.05, "push_slots_update should return quickly"
+
+        loop.run_until_complete(_run())
+
+
+class TestSuspendTakesPriority:
+    """suspend_slots_push() still wins: nothing leaves the block until exit."""
+
+    def test_suspend_defers_then_emits_once(self, state, loop):
+        broadcasts: list[dict] = []
+        state._broadcast = lambda note: broadcasts.append(note)
+
+        async def _run():
+            with state.suspend_slots_push():
+                for _ in range(4):
+                    state.push_slots_update()
+                assert broadcasts == [], "Suspended block must not broadcast"
+            assert len(broadcasts) == 1, "Exiting suspension emits exactly one broadcast"
+
+        loop.run_until_complete(_run())
+
+
+class TestNonEventLoopThread:
+    """Calling from a non-event-loop thread does not raise and does not lose."""
+
+    def test_cross_thread_call(self, state, loop):
+        broadcasts: list[dict] = []
+        state._broadcast = lambda note: broadcasts.append(note)
+
+        # Prime the window: with a RECENT last-broadcast the worker thread cannot
+        # take the leading edge, so it must reach the threadsafe scheduling path.
+        state._slots_broadcast_last = time.monotonic()
+
+        errors: list[Exception] = []
+
+        def worker():
+            try:
+                state.push_slots_update()
+            except Exception as e:  # noqa: BLE001 - the assertion is "did not raise"
+                errors.append(e)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=2.0)
+
+        assert not errors, f"Cross-thread call raised: {errors}"
+        assert broadcasts == [], "In-window cross-thread call must not broadcast inline"
+
+        # Drive the loop so call_soon_threadsafe runs _schedule_trailing_flush.
+        loop.run_until_complete(asyncio.sleep(0.05))
+        assert state._slots_broadcast_timer is not None, (
+            "_schedule_trailing_flush must have armed the trailing timer"
+        )
+
+        loop.run_until_complete(asyncio.sleep(_SLOTS_BROADCAST_INTERVAL_S + 0.1))
+        assert len(broadcasts) == 1, "Update from non-loop thread must not be lost"
+
+    def test_dead_loop_falls_back_to_inline_broadcast(self, state):
+        """Negative control: with no usable loop the update is still delivered."""
+        broadcasts: list[dict] = []
+        state._broadcast = lambda note: broadcasts.append(note)
+
+        dead = asyncio.new_event_loop()
+        dead.close()
+        state._slots_broadcast_loop = dead
+        state._slots_broadcast_last = time.monotonic()
+
+        state.push_slots_update()
+
+        assert len(broadcasts) == 1, (
+            "A closed loop must degrade to an inline broadcast, not silently drop"
+        )
+        assert state._slots_broadcast_timer is None, "No timer can be armed on a closed loop"


### PR DESCRIPTION
## What breaks today

`DashboardState.push_slots_update()` serializes **every** slot and broadcasts the whole list on
each call. A single chat turn fires it several times — slot created, title set, status flipped,
message appended — so the sidebar is redrawn once per mutation for what the user experiences as
one change. There are 123 call sites of `push_slots_update` across `src/`, and the cost is paid
per call regardless of how little changed.

## What this does

Adds leading-plus-trailing-edge coalescing on a 0.2s window inside `push_slots_update()`:

- the first call after an idle period broadcasts **immediately**, so a single isolated mutation
  is as fast as it is today;
- further calls inside the window are absorbed;
- one trailing broadcast carries the final state.

The existing body moves verbatim into a new `_do_slots_broadcast()`; `push_slots_update()` becomes
the coalescing front door. **The trailing flush re-serializes at delivery time**, so a coalesced
frame is never a stale frame — it reflects the state at the moment it is sent, not at the moment
the burst started.

`suspend_slots_push()` keeps priority: its early return sits ahead of the coalescer, so an
explicit suspend block still collapses to exactly one push on exit.

### Two details worth a reviewer's eye

**The lock defaults to `None`, not to a class-level `Lock()`.** Several endpoint suites build the
state via `DashboardState.__new__(DashboardState)` and never run `__init__` — the class already
declares `_slots_push_suspend` / `_slots_push_pending` as class-level defaults for exactly that
reason, and `test_open_slots_persistence` exists to catch a new `__init__`-only attribute landing
on this read path. A shared class-level `Lock()` would make every instance in the process contend
on one mutex, so `None` is the default and means "no coalescing": a bare state broadcasts straight
through, preserving today's behaviour. `__init__` installs the real per-instance lock.

**Off-loop callers prefer `call_soon_threadsafe` and fall back inline only when the loop is
absent or closed.** An idle-but-live loop must *not* take the inline path, because `_broadcast`
touches asyncio queues and doing that from a foreign thread is the riskier branch. Every *fallback*
degrades to an immediate broadcast, so no fallback path drops a frame — it only ever sends one
earlier than the window would.

That is a claim about the fallbacks, and an earlier draft of this description overstated it as
"can never drop a frame", which is not true of the armed timer: a trailing flush scheduled with
`call_later` and still pending when the event loop stops is discarded, so the last mutation of a
burst that coincides with teardown never reaches clients. I have left the behaviour alone rather
than add a shutdown flush — it would mean editing teardown code this PR does not otherwise touch,
and at that point clients are disconnecting anyway — but the invariant as originally worded was
wrong and the comment in `state.py` that read "never drops" has been narrowed to match.

## How it was tested

- **6 new tests** (pytest collected count) in `test/test_slots_broadcast_coalesce.py` covering burst coalescing, the
  trailing edge carrying the latest state, cross-thread scheduling, and a dead loop falling back
  to an inline broadcast.
- **Negative control, so the suite is not vacuous:** setting the interval to `0.0` neutralises the
  coalescer and the suite goes to **2 failed / 4 passed**. Restored to `0.2` and re-read the line
  back out of the file.
- **Neighbourhood set:** every test file whose name mentions a slot, a broadcast, or dashboard
  state — 21 files, **436 passed, 0 failed**.
- **Full suite: CI is the witness, not this sandbox.** All four `Backend Tests` shards pass at
  this head on both 3.10 and 3.12 (47 checks green, 0 failing). A local whole-`test/` run is not
  a usable comparison here because this host cannot create user namespaces
  (`unshare(CLONE_NEWUSER)` returns `EPERM`), which fails a large block of sandbox and subagent
  tests irrespective of the change.
- **One unrelated test is unstable in that local environment and is not caused by this change.**
  `test_search_sessions_cost.py::TestAdmissionControlIsNotAOneWayRatchet::test_a_session_that_left_the_window_stops_holding_budget`
  fails **8 of 8 isolated runs at this branch's parent commit, without this change**, and 5 of 8
  with it; it passes in CI at this head. It pins a byte-exact cache-admission budget
  (`_folded_cache._max_bytes` is set to the live `stats()` value) and contains **zero** references
  to `push_slots_update`, `suspend_slots_push`, or `_do_slots_broadcast`, so there is no path from
  this change to it.

## Honest limitations

**1. This is the third coalescer on this general problem, and that makes it a judgment call.**
Two already exist upstream:

- `DashboardState.suspend_slots_push()` — *scope*-based, collapses pushes inside an explicit
  `with` block;
- the sub-agent lifecycle debouncer in `slack/gateway.py` — *time*-based, on
  `call_later(0.2, ...)`, i.e. **the same window** this change proposes — hardcoded there and
  declared here as `_SLOTS_BROADCAST_INTERVAL_S`, duplicated rather than shared, so nothing stops
  the two drifting apart.

Both existing ones are **caller-side**: they only help paths that opt in. This one is callee-side
and so covers the call sites that do neither, which is why I think it earns its place — but a
maintainer may reasonably prefer to extend one of the two rather than add a third, or to unify all
three behind one helper. I have not done that here because it would touch the gateway debouncer's
behaviour, which is out of scope for a perf change.

**2. One existing test needed adapting, and it is a real synchrony change, not a harness
artifact.** `test_chat_slot_create_folder::test_refiling_an_existing_slot_name_is_broadcast` sends
two POSTs inside one window, so the second POST's frame moves to the trailing edge and the test's
client block exited before it fired. In production the frame *is* delivered, 0.2s later. I adapted
it by awaiting the interval inside the client block and **kept both assertions** (a frame is
emitted; it carries the new `folder_id`), leaving the module's ordering thesis untouched. Worth
noting: that module's own docstring describes the bug it pins as a row painting at root and "only
~200ms later" moving into the folder — the same order of magnitude as this window, which is
precisely why it is the one test that notices.

**That relaxation is intentional and accepted.** Design review asked for a human to confirm it, so
to be explicit: a refile can now paint at root and move into the folder up to 200ms later, and the
test pins eventual delivery rather than synchrony. The trailing edge always corrects the row, the
window is bounded by `_SLOTS_BROADCAST_INTERVAL_S`, and the same 200ms is already the observed
behaviour on the sub-agent path via the gateway debouncer. If that intermediate render turns out to
matter for this interaction, the fix is to have the refile path bypass the window rather than to
shrink it globally.

**3. The off-loop branch is retained without proof that it is needed.** I could not cheaply
establish that all 123 call sites are on the event loop, and asserting that would be an unproven
universal. Keeping the branch is the smaller, more reversible option since every path in it
degrades to an immediate broadcast (subject to the teardown caveat noted above). If a maintainer knows the invariant holds, it can be deleted.





