### PR TITLE
feat(app-store): consume the editorial document for rail order

### DIFF
--- a/src/kiro_crew/apps/official_catalog.py
+++ b/src/kiro_crew/apps/official_catalog.py
@@ -169,23 +169,27 @@ def _https_request(url: str) -> urllib.request.Request:
     scheme = urllib.parse.urlsplit(url).scheme
     if scheme != "https":
         raise ValueError(f"the catalog URL must be https, not {scheme!r}")
-    return urllib.request.Request(
-        url, method="GET", headers={"Accept": "application/json"}
-    )
+    return urllib.request.Request(url, method="GET", headers={"Accept": "application/json"})
 
 
-def _download() -> dict[str, Any] | None:
-    """GET the catalog document. Returns None on any failure.
+def fetch_document(url: str) -> dict[str, Any] | None:
+    """GET one JSON document from the catalog origin. Returns None on any failure.
 
-    Fetching the catalog is an enhancement to a store that already works from
-    the seed index, so every failure here is a degradation rather than an error:
-    the caller renders the seed.
+    Takes the URL because a second document (``editorial.json``) is served from
+    the same origin under the same trust basis, and the guards below -- https
+    only, redirects refused, a byte cap before decode, and the exception family
+    that a narrower tuple lets escape -- are security behaviour that must not
+    drift into a second copy. The scheme guard is what keeps this general form
+    from becoming a file read if a caller ever passes something configurable.
+
+    Every failure is a degradation rather than an error: each caller has a
+    working answer without the document.
     """
     try:
-        req = _https_request(OFFICIAL_CATALOG_URL)
+        req = _https_request(url)
         with _open_catalog(req) as resp:
             if resp.status != 200:
-                logger.info("official catalog returned HTTP %s", resp.status)
+                logger.info("%s returned HTTP %s", url, resp.status)
                 return None
             raw = resp.read(MAX_BYTES + 1)
     # `HTTPException` is the family, not a courtesy addition to the tuple. It is
@@ -201,17 +205,22 @@ def _download() -> dict[str, Any] | None:
         OSError,
         ValueError,
     ) as exc:
-        logger.info("could not fetch the official catalog: %s", exc)
+        logger.info("could not fetch %s: %s", url, exc)
         return None
     if len(raw) > MAX_BYTES:
-        logger.warning("official catalog exceeds %d bytes; ignoring it", MAX_BYTES)
+        logger.warning("%s exceeds %d bytes; ignoring it", url, MAX_BYTES)
         return None
     try:
         doc = json.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        logger.warning("official catalog is not valid JSON: %s", exc)
+        logger.warning("%s is not valid JSON: %s", url, exc)
         return None
     return doc if isinstance(doc, dict) else None
+
+
+def _download() -> dict[str, Any] | None:
+    """Fetch THIS module's document. The registry's own call into the seam."""
+    return fetch_document(OFFICIAL_CATALOG_URL)
 
 
 def load_official_catalog(fetcher: Any = None) -> list[dict[str, Any]]:

--- a/src/kiro_crew/apps/official_editorial.py
+++ b/src/kiro_crew/apps/official_editorial.py
@@ -1,0 +1,186 @@
+"""The editorial document: presentation the curator controls without a release.
+
+WHAT THIS IS. ``editorial.json`` is published beside ``official-registry.json``
+and carries PRESENTATION only -- which categories the Discover rail shows and in
+what order. The registry says what exists; this says how it is arranged. Keeping
+them apart is what lets a curator reorder the rail without touching the list of
+apps, and lets the client refuse one document while still rendering the other.
+
+WHAT THIS DOES NOT DO, YET.
+
+- **No sections.** ``sections`` carries spotlight / rail / banner entries, and
+  the live document publishes an empty list. Nothing here reads it: a spotlight
+  names an app plus a blurb, which is INVENTORY-adjacent presentation, and
+  wiring it before the registry can add inventory would render a spotlight for
+  an app the client cannot show. The field is left alone rather than half-read.
+
+- **No labels from the document.** A category's ``label`` is published in
+  English only, while the rail is translated into 11 languages, so honouring it
+  would replace localised copy with English for every user. The client therefore
+  takes ``id`` and ``order`` and resolves copy through its own catalog; an id the
+  client has no copy for is DROPPED rather than shown raw. Consequence, stated
+  plainly: a genuinely new category needs a release, and until then it is
+  invisible instead of appearing as a slug.
+
+- **No signature verification.** Same basis as the registry: TLS to our own
+  domain. Presentation is a lower-stakes payload than inventory -- the worst a
+  hostile document achieves here is a reordered or shortened rail -- but the
+  omission is named here rather than left for a reader to infer from silence.
+
+Every failure degrades to the client's built-in order, which is what the rail
+used before this module existed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+from kiro_crew.apps.official_catalog import (
+    MAX_BYTES,
+    OFFICIAL_CATALOG_BASE,
+    SUPPORTED_SCHEMA_VERSION,
+    fetch_document,
+)
+from kiro_crew.config.loader import config_dir
+
+logger = logging.getLogger(__name__)
+
+OFFICIAL_EDITORIAL_URL = f"{OFFICIAL_CATALOG_BASE}editorial.json"
+
+#: Same TTLs as the registry: the two documents are published together by one
+#: workflow run, so caching them for different lengths would show a rail ordered
+#: by one revision beside apps listed by another.
+CACHE_TTL = 3600
+FAILURE_TTL = 60
+
+#: The schema's own ceiling. A document above it is malformed, not merely large,
+#: and the cap is applied here so a bad document cannot make the rail unbounded.
+MAX_CATEGORIES = 30
+
+_FAILED_KEY = "_fetchFailedAt"
+
+
+def _cache_path() -> Path:
+    return config_dir() / "cache" / "official-editorial.json"
+
+
+def _read_cache() -> dict[str, Any] | None:
+    """Return the cached document, or None when there is nothing usable.
+
+    A cached FAILURE returns the sentinel rather than None: the caller must tell
+    "no cache, go fetch" apart from "the fetch just failed, do not hammer it".
+    """
+    path = _cache_path()
+    try:
+        if not path.is_file():
+            return None
+        age = time.time() - path.stat().st_mtime
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    if _FAILED_KEY in data:
+        return data if age <= FAILURE_TTL else None
+    return data if age <= CACHE_TTL else None
+
+
+def _write_cache(doc: dict[str, Any]) -> None:
+    path = _cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(doc), encoding="utf-8")
+    except OSError:
+        logger.debug("could not cache the editorial document", exc_info=True)
+
+
+def _write_failure() -> None:
+    _write_cache({_FAILED_KEY: time.time()})
+
+
+def _download() -> dict[str, Any] | None:
+    """GET the editorial document through the registry module's fetch seam.
+
+    Deliberately NOT a second copy of the fetch: the https-only guard, the
+    refuse-redirects opener, the byte cap and the exception family are security
+    behaviour that must not drift between two documents served from one origin.
+    """
+    return fetch_document(OFFICIAL_EDITORIAL_URL)
+
+
+def _coerce_order(value: Any) -> int | None:
+    """An ``order`` that is not a real int is missing, not zero.
+
+    ``type(...) is int`` rather than ``isinstance``: ``bool`` subclasses ``int``,
+    so ``True`` would otherwise sort as 1 and quietly place a category first.
+    """
+    return value if type(value) is int else None
+
+
+def load_category_order(fetcher: Any = None) -> list[str]:
+    """Return published category ids in rail order, or ``[]`` to use the default.
+
+    Empty is always a safe answer -- the rail falls back to the order compiled
+    into the client, which is what it showed before this module existed. Nothing
+    read here may raise: a malformed field degrades that field only.
+
+    *fetcher* is injected by tests.
+    """
+    doc = _read_cache()
+    if doc is not None and _FAILED_KEY in doc:
+        # A recent fetch failed. Answer from the default WITHOUT another attempt.
+        return []
+    if doc is None:
+        doc = (fetcher or _download)()
+        if doc is None:
+            _write_failure()
+        else:
+            _write_cache(doc)
+    if doc is None:
+        return []
+
+    version = doc.get("schemaVersion")
+    # Identical gate to the registry's, for the identical reason: `1.0 == 1` and
+    # `True == 1` both hold, so a looser test accepts a version field that is not
+    # an integer and acts on a contract it cannot name.
+    if type(version) is not int or version != SUPPORTED_SCHEMA_VERSION:
+        logger.warning(
+            "editorial document declares schemaVersion %r, expected %r; ignoring it",
+            version,
+            SUPPORTED_SCHEMA_VERSION,
+        )
+        return []
+
+    raw = doc.get("categories")
+    if not isinstance(raw, list):
+        return []
+
+    ranked: list[tuple[int, int, str]] = []
+    for position, item in enumerate(raw[:MAX_CATEGORIES]):
+        if not isinstance(item, dict):
+            continue
+        cid = item.get("id")
+        if not isinstance(cid, str) or not cid.strip():
+            continue
+        order = _coerce_order(item.get("order"))
+        if order is None:
+            continue
+        # Document position breaks an `order` tie, so a duplicated order is
+        # stable rather than dependent on sort implementation details.
+        ranked.append((order, position, cid.strip()))
+
+    ranked.sort()
+    seen: set[str] = set()
+    out: list[str] = []
+    for _, _, cid in ranked:
+        if cid not in seen:
+            seen.add(cid)
+            out.append(cid)
+    return out
+
+
+__all__ = ["load_category_order", "MAX_BYTES", "OFFICIAL_EDITORIAL_URL"]

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -71,6 +71,7 @@ from kiro_crew.apps.manager import (
     update_app,
 )
 from kiro_crew.apps.manifest import Dependencies, PlatformConfig
+from kiro_crew.apps.official_editorial import load_category_order
 from kiro_crew.apps.registry import (
     _git_url_host,
     get_registry_app_by_repo,
@@ -1311,8 +1312,7 @@ async def handle_disable_app(request: web.Request) -> web.Response:
         module_name = name.replace("-", "_")
         if module_name in BUILTIN_NAMES:
             try:
-                mod = importlib.import_module(
-                    f"kiro_crew.apps.builtins.{module_name}")
+                mod = importlib.import_module(f"kiro_crew.apps.builtins.{module_name}")
                 if hasattr(mod, "on_disable"):
                     mod.on_disable(request.app)
             except Exception as exc:
@@ -1438,10 +1438,21 @@ async def handle_open_app(request: web.Request) -> web.Response:
 async def handle_registry(request: web.Request) -> web.Response:
     """GET /api/apps/registry — list all apps available for installation."""
     apps = await list_registry()
+    # Published rail order rides along on the response the store already makes,
+    # rather than a second endpoint the page would have to wait on separately.
+    # Off the event loop: the first call after a cache expiry does network I/O.
+    # A failure degrades to the client's built-in order, so it must never 500 the
+    # store -- the same contract the catalog annotation above already keeps.
+    try:
+        category_order = await asyncio.to_thread(load_category_order)
+    except Exception:  # noqa: BLE001 - presentation is never worth a failed store
+        logger.warning("ignoring the editorial category order", exc_info=True)
+        category_order = []
     return web.json_response(
         {
             "apps": apps,
             "serverPlatform": get_server_platform(),
+            "categoryOrder": category_order,
         }
     )
 

--- a/test/test_official_editorial.py
+++ b/test/test_official_editorial.py
@@ -1,0 +1,182 @@
+"""Tests for the editorial consumer.
+
+The shape mirrors ``test_official_catalog.py``: every refusal path is asserted
+with the DEFAULT as the expected answer, because "degrade to the built-in order"
+is the promise this module makes and an empty list is how it keeps it.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import pytest
+
+from kiro_crew.apps import official_editorial as oe
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache(tmp_path, monkeypatch):
+    """Point the cache at a scratch dir so tests never read the real one."""
+    monkeypatch.setattr(oe, "_cache_path", lambda: tmp_path / "editorial.json")
+    return tmp_path
+
+
+def _doc(categories: Any, version: int | Any = 1) -> dict[str, Any]:
+    return {"schemaVersion": version, "categories": categories}
+
+
+def _cat(cid: str, order: int) -> dict[str, Any]:
+    # `label` is present because the live document carries it; these tests assert
+    # it is IGNORED rather than absent.
+    return {"id": cid, "label": cid.replace("-", " ").title(), "order": order}
+
+
+class TestOrdering:
+    def test_categories_come_back_in_order_not_document_sequence(self):
+        doc = _doc([_cat("b", 20), _cat("a", 10), _cat("c", 30)])
+        assert oe.load_category_order(fetcher=lambda: doc) == ["a", "b", "c"]
+
+    def test_a_tie_on_order_falls_back_to_document_position(self):
+        # Both order=10: the one written first must stay first, so a duplicated
+        # order is stable instead of depending on sort internals.
+        doc = _doc([_cat("first", 10), _cat("second", 10)])
+        assert oe.load_category_order(fetcher=lambda: doc) == ["first", "second"]
+
+    def test_a_duplicate_id_is_collapsed_to_its_best_position(self):
+        doc = _doc([_cat("dup", 30), _cat("other", 20), _cat("dup", 10)])
+        assert oe.load_category_order(fetcher=lambda: doc) == ["dup", "other"]
+
+
+class TestFieldLevelDegradation:
+    """A bad field degrades THAT field. Nothing here may raise."""
+
+    @pytest.mark.parametrize(
+        "order",
+        [None, "10", 1.5, True, False, [], {}],
+        ids=["none", "str", "float", "true", "false", "list", "dict"],
+    )
+    def test_an_order_that_is_not_a_real_int_drops_that_category(self, order):
+        # `True`/`False` matter specifically: bool subclasses int, so a loose
+        # check would sort True as 1 and place the category first.
+        doc = _doc([{"id": "bad", "label": "Bad", "order": order}, _cat("good", 5)])
+        assert oe.load_category_order(fetcher=lambda: doc) == ["good"]
+
+    @pytest.mark.parametrize(
+        "cid", [None, "", "   ", 5, [], {}], ids=["none", "empty", "blank", "int", "list", "dict"]
+    )
+    def test_a_missing_or_non_string_id_drops_that_category(self, cid):
+        doc = _doc([{"id": cid, "order": 1}, _cat("good", 5)])
+        assert oe.load_category_order(fetcher=lambda: doc) == ["good"]
+
+    def test_a_non_dict_item_is_skipped_not_fatal(self):
+        doc = _doc(["nope", 5, None, _cat("good", 1)])
+        assert oe.load_category_order(fetcher=lambda: doc) == ["good"]
+
+    def test_an_id_is_stripped_of_surrounding_whitespace(self):
+        doc = _doc([{"id": "  spaced  ", "order": 1}])
+        assert oe.load_category_order(fetcher=lambda: doc) == ["spaced"]
+
+    def test_the_published_label_is_never_returned(self):
+        # The rail resolves copy through its own i18n catalog; honouring an
+        # English label here would replace localised copy for every user.
+        doc = _doc([{"id": "developer-tools", "label": "ZZZ Custom", "order": 1}])
+        assert oe.load_category_order(fetcher=lambda: doc) == ["developer-tools"]
+
+
+class TestRefusals:
+    @pytest.mark.parametrize(
+        "version",
+        [None, "1", 1.0, True, 2, 0, -1],
+        ids=["none", "str", "float", "true", "2", "0", "neg"],
+    )
+    def test_an_unsupported_schema_version_refuses_the_document(self, version):
+        doc = _doc([_cat("a", 1)], version=version)
+        assert oe.load_category_order(fetcher=lambda: doc) == []
+
+    @pytest.mark.parametrize(
+        "categories", ["nope", 5, None, {}], ids=["str", "int", "none", "dict"]
+    )
+    def test_a_non_list_categories_field_yields_the_default(self, categories):
+        assert oe.load_category_order(fetcher=lambda: _doc(categories)) == []
+
+    def test_a_failed_fetch_yields_the_default(self):
+        assert oe.load_category_order(fetcher=lambda: None) == []
+
+    def test_more_than_the_cap_is_truncated_not_refused(self):
+        many = [_cat(f"c{i:03d}", i) for i in range(oe.MAX_CATEGORIES + 10)]
+        got = oe.load_category_order(fetcher=lambda: _doc(many))
+        assert len(got) == oe.MAX_CATEGORIES
+
+
+class TestCaching:
+    def test_a_success_is_cached_and_the_fetcher_is_not_called_again(self):
+        calls: list[int] = []
+
+        def fetcher():
+            calls.append(1)
+            return _doc([_cat("a", 1)])
+
+        assert oe.load_category_order(fetcher=fetcher) == ["a"]
+        assert oe.load_category_order(fetcher=fetcher) == ["a"]
+        assert len(calls) == 1, "the second call must be served from cache"
+
+    def test_a_failure_is_cached_so_the_next_caller_does_not_wait_again(self):
+        calls: list[int] = []
+
+        def fetcher():
+            calls.append(1)
+            return None
+
+        assert oe.load_category_order(fetcher=fetcher) == []
+        assert oe.load_category_order(fetcher=fetcher) == []
+        assert len(calls) == 1, "a remembered failure must not be retried"
+
+    def test_the_failure_ttl_is_far_shorter_than_the_success_ttl(self):
+        # Forgetting too early costs one retry; remembering too long keeps the
+        # rail stale after the CDN is back.
+        assert oe.FAILURE_TTL < oe.CACHE_TTL / 10
+
+    def test_an_expired_failure_is_retried(self, _isolated_cache, monkeypatch):
+        oe._write_failure()
+        # Age the cache past FAILURE_TTL without sleeping.
+        path = oe._cache_path()
+        old = time.time() - (oe.FAILURE_TTL + 5)
+        import os
+
+        os.utime(path, (old, old))
+        assert oe.load_category_order(fetcher=lambda: _doc([_cat("a", 1)])) == ["a"]
+
+    def test_a_corrupt_cache_file_is_ignored_not_fatal(self, _isolated_cache):
+        path = oe._cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+        assert oe.load_category_order(fetcher=lambda: _doc([_cat("a", 1)])) == ["a"]
+
+    def test_a_cached_non_dict_is_ignored(self, _isolated_cache):
+        path = oe._cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(["a", "list"]), encoding="utf-8")
+        assert oe.load_category_order(fetcher=lambda: _doc([_cat("a", 1)])) == ["a"]
+
+
+class TestFetchSeam:
+    def test_the_url_is_the_editorial_document_beside_the_registry(self):
+        from kiro_crew.apps import official_catalog as oc
+
+        assert oe.OFFICIAL_EDITORIAL_URL.startswith(oc.OFFICIAL_CATALOG_BASE)
+        assert oe.OFFICIAL_EDITORIAL_URL.endswith("editorial.json")
+
+    def test_the_download_goes_through_the_shared_fetch_seam(self, monkeypatch):
+        # The guards (https-only, refuse redirects, byte cap, exception family)
+        # live in that seam; a second copy of the fetch would let them drift.
+        seen: list[str] = []
+
+        def fake(url: str):
+            seen.append(url)
+            return _doc([_cat("a", 1)])
+
+        monkeypatch.setattr(oe, "fetch_document", fake)
+        assert oe._download() is not None
+        assert seen == [oe.OFFICIAL_EDITORIAL_URL]

--- a/test/test_registry_endpoint_category_order.py
+++ b/test/test_registry_endpoint_category_order.py
@@ -1,0 +1,70 @@
+"""The registry endpoint carries the published rail order, and never fails for it.
+
+Presentation is an enhancement to a store that already works. So the contract
+asserted here is not "the order is present" but "a broken order costs the order
+and nothing else" -- the store still answers 200 with its apps.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from kiro_crew.apps import routes
+
+
+class _FakeRequest:
+    """Minimal stand-in: handle_registry reads nothing off the request."""
+
+
+async def _call() -> tuple[int, dict[str, Any]]:
+    import json
+
+    resp = await routes.handle_registry(_FakeRequest())  # type: ignore[arg-type]
+    return resp.status, json.loads(resp.body.decode("utf-8"))
+
+
+@pytest.fixture(autouse=True)
+def _quiet_registry(monkeypatch):
+    """Keep the test about the editorial half: the app list is stubbed."""
+
+    async def _apps():
+        return [{"name": "demo", "tags": ["git"]}]
+
+    monkeypatch.setattr(routes, "list_registry", _apps)
+    monkeypatch.setattr(routes, "get_server_platform", lambda: {"os": "linux", "arch": "x86_64"})
+
+
+@pytest.mark.asyncio
+class TestCategoryOrderOnTheRegistryEndpoint:
+    async def test_the_published_order_is_included(self, monkeypatch):
+        monkeypatch.setattr(routes, "load_category_order", lambda: ["other", "developer-tools"])
+        status, body = await _call()
+        assert status == 200
+        assert body["categoryOrder"] == ["other", "developer-tools"]
+
+    async def test_an_empty_order_is_still_a_list_not_a_missing_key(self, monkeypatch):
+        # The client narrows with `Array.isArray`, so a null would be discarded
+        # anyway -- but an absent key would make the field's absence ambiguous
+        # between "nothing published" and "an older server".
+        monkeypatch.setattr(routes, "load_category_order", lambda: [])
+        status, body = await _call()
+        assert status == 200
+        assert body["categoryOrder"] == []
+
+    async def test_a_raising_loader_costs_the_order_not_the_store(self, monkeypatch):
+        def boom():
+            raise RuntimeError("editorial exploded")
+
+        monkeypatch.setattr(routes, "load_category_order", boom)
+        status, body = await _call()
+        assert status == 200, "presentation must never take down the store"
+        assert body["categoryOrder"] == []
+        assert body["apps"], "the apps must still be served"
+
+    async def test_the_apps_payload_is_unchanged_by_this_addition(self, monkeypatch):
+        monkeypatch.setattr(routes, "load_category_order", lambda: ["other"])
+        _, body = await _call()
+        assert [a["name"] for a in body["apps"]] == ["demo"]
+        assert body["serverPlatform"] == {"os": "linux", "arch": "x86_64"}

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -2125,7 +2125,7 @@ export const api = {
   // narrows it to its own local RegistryApp shape at the call site. Typing it as
   // unknown[] here would break those structural assignments across files.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  listRegistry: () => fetch('/api/apps/registry').then(j) as Promise<{ apps: any[]; serverPlatform: { os: string; arch: string } }>,
+  listRegistry: () => fetch('/api/apps/registry').then(j) as Promise<{ apps: any[]; serverPlatform: { os: string; arch: string }; categoryOrder?: string[] }>,
   listRegistries: () => fetch('/api/apps/registries').then(j) as Promise<{ registries: { name: string; repo: string; branch: string }[] }>,
   updateRegistries: (registries: { name: string; repo: string; branch: string }[]) => put('/api/apps/registries', { registries }).then(j) as Promise<{ ok: boolean; registries: { name: string; repo: string; branch: string }[]; newlyTrustedHosts: string[] }>,
   refreshRegistries: (repo?: string) => post('/api/apps/registries/refresh', repo ? { repo } : {}).then(j) as Promise<{ ok: boolean; refreshed: string[]; failed: string[]; results: { name: string; ok: boolean }[]; apps: number; lastSyncedAt: string }>,

--- a/website/src/components/appstore/categories.ts
+++ b/website/src/components/appstore/categories.ts
@@ -101,14 +101,94 @@ export function categoryFor(tags?: unknown): Category {
   return 'Other'
 }
 
+/**
+ * Published category id (catalog slug) → this client's category id.
+ *
+ * Written out rather than derived: the catalog publishes `oncall-ops` while this
+ * client's id is `On-call & Ops`, which no mechanical slugify produces
+ * (`on-call-ops`). A table fails loudly when a new published id has no home
+ * here; a transform would silently invent one.
+ *
+ * Values are INDEXES into `CATEGORY_ORDER` rather than repeated string
+ * literals. Spelling an id twice invites the two spellings to drift, and these
+ * ids are compared byte-for-byte (`categoryFor(...) !== category`, `Map` keys),
+ * so a drifted copy would not fail loudly -- it would quietly match nothing.
+ *
+ * The mapping is deliberately NOT total in either direction. `Designer Tools`
+ * has no published counterpart, and a published id absent from this table is
+ * DROPPED rather than shown -- the rail's copy comes from this client's i18n
+ * catalog, so an unknown id could only render as a raw slug.
+ */
+export const PUBLISHED_CATEGORY_ID: Record<string, Category> = {
+  'developer-tools': CATEGORY_ORDER[0],
+  'designer-tools': CATEGORY_ORDER[1],
+  'oncall-ops': CATEGORY_ORDER[2],
+  'productivity': CATEGORY_ORDER[3],
+  'agents-automation': CATEGORY_ORDER[4],
+  'research-writing': CATEGORY_ORDER[5],
+  'other': CATEGORY_ORDER[6],
+}
+
+/**
+ * Merge a published rail order into the client's canonical order.
+ *
+ * The published document decides the relative order of the categories it NAMES.
+ * A category it does not name keeps its position relative to its local
+ * neighbours instead of being flushed to the end — otherwise a document that
+ * simply forgot `Designer Tools` would silently demote it, which is a
+ * presentation change nobody authored.
+ *
+ * Concretely: published ids are laid down in published order, and each unnamed
+ * category is re-inserted after the last named category that precedes it
+ * locally. An empty or unusable list returns the canonical order unchanged,
+ * which is the answer the rail used before the document existed.
+ */
+export function mergeCategoryOrder(publishedIds: readonly string[]): Category[] {
+  // `hasOwnProperty`, not `in`: a published id of `toString` would otherwise
+  // resolve to an inherited Object.prototype member.
+  const mapped: Category[] = []
+  for (const id of publishedIds) {
+    if (!Object.prototype.hasOwnProperty.call(PUBLISHED_CATEGORY_ID, id)) continue
+    const category = PUBLISHED_CATEGORY_ID[id]
+    if (!mapped.includes(category)) mapped.push(category)
+  }
+  if (mapped.length === 0) return [...CATEGORY_ORDER]
+
+  const named = new Set(mapped)
+  // Walk the canonical order once, collecting each unnamed category under the
+  // named one it currently follows. `null` holds those that precede every named
+  // category, so they stay at the front rather than jumping to the back.
+  const trailing = new Map<Category | null, Category[]>()
+  let anchor: Category | null = null
+  for (const category of CATEGORY_ORDER) {
+    if (named.has(category)) {
+      anchor = category
+      continue
+    }
+    const bucket = trailing.get(anchor)
+    if (bucket) bucket.push(category)
+    else trailing.set(anchor, [category])
+  }
+
+  const out: Category[] = [...(trailing.get(null) || [])]
+  for (const category of mapped) {
+    out.push(category)
+    for (const extra of trailing.get(category) || []) out.push(extra)
+  }
+  return out
+}
+
 /** Count apps per category, omitting empty categories, in canonical order. */
-export function categoryCounts(apps: { tags?: unknown }[]): { category: Category; count: number }[] {
+export function categoryCounts(
+  apps: { tags?: unknown }[],
+  order: readonly Category[] = CATEGORY_ORDER,
+): { category: Category; count: number }[] {
   const counts = new Map<Category, number>()
   for (const app of apps) {
     const c = categoryFor(app.tags)
     counts.set(c, (counts.get(c) || 0) + 1)
   }
-  return CATEGORY_ORDER
+  return order
     .filter(c => counts.has(c))
     .map(c => ({ category: c, count: counts.get(c)! }))
 }

--- a/website/src/pages/AppsPage.tsx
+++ b/website/src/pages/AppsPage.tsx
@@ -32,7 +32,7 @@ import AppListRow from '../components/appstore/AppListRow'
 import InstalledAppCard from '../components/appstore/InstalledAppCard'
 import TrustAppModal, { isTrustDeniedError, useTrustGate, type TrustAppTarget } from '../components/appstore/TrustAppModal'
 import SourcesPopover from '../components/appstore/SourcesPopover'
-import { categoryFor, categoryCounts, type Category } from '../components/appstore/categories'
+import { categoryFor, categoryCounts, mergeCategoryOrder, type Category } from '../components/appstore/categories'
 import { hasHeroArt } from '../components/appstore/useHeroArt'
 import { isVerified, normalizeRegistryApp, type InstalledApp, type RegistryApp } from '../components/appstore/types'
 
@@ -110,7 +110,10 @@ export default function AppsPage() {
     queryFn: () => api.listApps(),
   })
 
-  const { data: registryData, isLoading: registryLoading, error: registryError } = useQuery<{ apps: RegistryApp[] }>({
+  const { data: registryData, isLoading: registryLoading, error: registryError } = useQuery<{
+    apps: RegistryApp[]
+    categoryOrder: string[]
+  }>({
     queryKey: ['registry'],
     // api.listRegistry() types `apps` as unknown[]; the backend payload matches
     // RegistryApp, so narrow it here at the single fetch boundary.
@@ -119,7 +122,18 @@ export default function AppsPage() {
       // Normalize at the single fetch boundary: registry.py yields minimal
       // rows when an app.json fetch fails, and external registries are
       // user-supplied JSON, so display fields may be missing or mistyped.
-      return { apps: (res.apps as RegistryApp[]).map(normalizeRegistryApp) }
+      //
+      // `categoryOrder` is published presentation, so it gets the same
+      // treatment: a non-array, or a member that is not a string, collapses to
+      // an empty list, which `mergeCategoryOrder` reads as "use the canonical
+      // order".
+      const publishedOrder = Array.isArray(res.categoryOrder)
+        ? res.categoryOrder.filter((id): id is string => typeof id === 'string')
+        : []
+      return {
+        apps: (res.apps as RegistryApp[]).map(normalizeRegistryApp),
+        categoryOrder: publishedOrder,
+      }
     },
     staleTime: 5 * 60_000, // cache for 5min to avoid re-fetching on tab switch
   })
@@ -188,7 +202,18 @@ export default function AppsPage() {
   const featured = useMemo(() => pickFeatured(browseApps), [browseApps])
   const [spotlight, ...secondary] = featured
 
-  const categories = useMemo(() => categoryCounts(browseApps), [browseApps])
+  // The published rail order decides the sequence of the categories it names;
+  // anything it omits keeps its canonical position. An absent or unusable
+  // document leaves the order exactly as it was before the editorial document
+  // existed.
+  const categoryOrder = useMemo(
+    () => mergeCategoryOrder(registryData?.categoryOrder || []),
+    [registryData],
+  )
+  const categories = useMemo(
+    () => categoryCounts(browseApps, categoryOrder),
+    [browseApps, categoryOrder],
+  )
 
   const sources: SourceRow[] = useMemo(() => {
     // Count built-ins from browseApps so the SOURCES totals describe the same

--- a/website/src/test/categoryOrderMerge.test.ts
+++ b/website/src/test/categoryOrderMerge.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for merging the published rail order into the client's canonical order.
+ *
+ * The rule under test is deliberately not "published wins, rest to the back":
+ * a category the document omits keeps its LOCAL position, so a document that
+ * simply forgot one does not silently demote it.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  CATEGORY_ORDER,
+  PUBLISHED_CATEGORY_ID,
+  mergeCategoryOrder,
+  categoryCounts,
+  type Category,
+} from '../components/appstore/categories'
+
+describe('mergeCategoryOrder', () => {
+  it('returns the canonical order when nothing is published', () => {
+    expect(mergeCategoryOrder([])).toEqual([...CATEGORY_ORDER])
+  })
+
+  it('returns the canonical order when no published id is recognised', () => {
+    expect(mergeCategoryOrder(['nope', 'also-nope'])).toEqual([...CATEGORY_ORDER])
+  })
+
+  it('maps each published slug to the category it names', () => {
+    // The table's values are CATEGORY_ORDER indexes, so a reorder of that array
+    // would silently rewire every slug. This pins the pairs by value.
+    expect(PUBLISHED_CATEGORY_ID).toEqual({
+      'developer-tools': 'Developer Tools',
+      'designer-tools': 'Designer Tools',
+      'oncall-ops': 'On-call & Ops',
+      'productivity': 'Productivity',
+      'agents-automation': 'Agents & Automation',
+      'research-writing': 'Research & Writing',
+      'other': 'Other',
+    })
+  })
+
+  it('covers every canonical category, so none can become unreachable', () => {
+    expect(new Set(Object.values(PUBLISHED_CATEGORY_ID))).toEqual(new Set(CATEGORY_ORDER))
+  })
+
+  it('maps the published slug that no slugify would produce', () => {
+    // The catalog publishes `oncall-ops`; a mechanical transform of the client
+    // id `On-call & Ops` yields `on-call-ops`, which would silently miss.
+    expect(PUBLISHED_CATEGORY_ID['oncall-ops']).toBe('On-call & Ops')
+    // Naming ONE category does not promote it to the front: the two categories
+    // that canonically precede it keep their places, which is the whole point of
+    // not flushing omitted categories to the back.
+    const got = mergeCategoryOrder(['oncall-ops'])
+    expect(got).toContain('On-call & Ops')
+    expect(got.indexOf('On-call & Ops')).toBe(CATEGORY_ORDER.indexOf('On-call & Ops'))
+    expect(got).toEqual([...CATEGORY_ORDER])
+  })
+
+  it('honours the published sequence for the categories it names', () => {
+    const got = mergeCategoryOrder(['other', 'developer-tools'])
+    expect(got.indexOf('Other')).toBeLessThan(got.indexOf('Developer Tools'))
+  })
+
+  it('keeps an omitted category next to its canonical neighbour, not at the end', () => {
+    // `designer-tools` is absent from the live document. It must stay adjacent to
+    // Developer Tools (its canonical predecessor), NOT be flushed to the back.
+    const live = [
+      'developer-tools',
+      'oncall-ops',
+      'productivity',
+      'agents-automation',
+      'research-writing',
+      'other',
+    ]
+    const got = mergeCategoryOrder(live)
+    expect(got).toContain('Designer Tools')
+    expect(got.indexOf('Designer Tools')).toBe(got.indexOf('Developer Tools') + 1)
+    expect(got.indexOf('Designer Tools')).toBeLessThan(got.length - 1)
+  })
+
+  it('reproduces the canonical order when the live document is published as authored', () => {
+    // Guards the actual deployed data: today's editorial.json must not reorder
+    // the rail, so shipping this consumer is a no-op until a curator changes it.
+    const live = [
+      'developer-tools',
+      'oncall-ops',
+      'productivity',
+      'agents-automation',
+      'research-writing',
+      'other',
+    ]
+    expect(mergeCategoryOrder(live)).toEqual([...CATEGORY_ORDER])
+  })
+
+  it('keeps every category exactly once', () => {
+    const got = mergeCategoryOrder(['other', 'other', 'developer-tools'])
+    expect(new Set(got).size).toBe(got.length)
+    expect(got.length).toBe(CATEGORY_ORDER.length)
+  })
+
+  it('never loses a category, whatever subset is published', () => {
+    for (const subset of [
+      ['other'],
+      ['productivity', 'developer-tools'],
+      ['research-writing', 'oncall-ops', 'other'],
+    ]) {
+      const got = mergeCategoryOrder(subset)
+      expect([...got].sort()).toEqual([...CATEGORY_ORDER].sort())
+    }
+  })
+
+  it('ignores an inherited Object.prototype key published as an id', () => {
+    // A published id of `toString` must not resolve to Object.prototype.toString
+    // and push a function into the rail.
+    const got = mergeCategoryOrder(['toString', 'constructor'])
+    expect(got).toEqual([...CATEGORY_ORDER])
+    for (const c of got) expect(typeof c).toBe('string')
+  })
+})
+
+describe('categoryCounts with an explicit order', () => {
+  const apps = [
+    { tags: ['git'] }, // Developer Tools
+    { tags: ['oncall'] }, // On-call & Ops
+    { tags: ['research'] }, // Research & Writing
+  ]
+
+  it('defaults to the canonical order when no order is passed', () => {
+    const got = categoryCounts(apps).map(c => c.category)
+    expect(got).toEqual(['Developer Tools', 'On-call & Ops', 'Research & Writing'])
+  })
+
+  it('follows a supplied order', () => {
+    const order: Category[] = ['Research & Writing', 'On-call & Ops', 'Developer Tools']
+    const got = categoryCounts(apps, order).map(c => c.category)
+    expect(got).toEqual(['Research & Writing', 'On-call & Ops', 'Developer Tools'])
+  })
+
+  it('still omits categories with no apps', () => {
+    const got = categoryCounts(apps, [...CATEGORY_ORDER]).map(c => c.category)
+    expect(got).not.toContain('Productivity')
+    expect(got).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
## What

`editorial.json` has been published beside `official-registry.json` since the
store started fetching a catalog, and nothing read it. This wires the second
half: the registry says what exists, the editorial document says how it is
arranged, and a curator can now reorder the Discover rail by publishing instead
of shipping a client.

- `src/kiro_crew/apps/official_editorial.py` — fetch the document, take each
  category's `id` + `order`, return rail order. 1h success cache, 60s negative
  cache, schema-version gate, field-level degradation.
- `GET /api/apps/registry` grows `categoryOrder`, riding the response the store
  already makes rather than adding an endpoint the page waits on.
- `mergeCategoryOrder()` folds the published order into the client's canonical
  one.

## The fetch is not duplicated

`official_catalog._download` became `fetch_document(url)`. The https-only
guard, the refuse-redirects opener, the byte cap before decode, and the
exception family a narrower tuple lets escape (`HTTPException` is the family —
`IncompleteRead`, `BadStatusLine`, `LineTooLong`, `InvalidURL` all escape a
tuple listing only `URLError`/`OSError`) now serve both documents from one
place. The registry's own 104 tests pass unchanged, which is what says the
extraction did not move behaviour.

## Two deliberate omissions, named in the module

**`sections` is not read.** It carries spotlight / rail / banner entries and the
live document publishes `[]`. A spotlight names an app plus a blurb — that is
inventory-adjacent presentation, and the registry cannot add inventory yet
(a published `git` source is pinned to a commit; the install path clones with
`--branch`). Wiring it now would spotlight an app the client cannot show.

**The published `label` is not used.** It is English-only while the rail is
translated into 11 languages, so honouring it would replace localised copy with
English for every user. The client takes `id` and resolves copy through its own
catalog; an id it has no copy for is **dropped** rather than rendered as a raw
slug. The consequence, stated plainly: a genuinely new category still needs a
release, and until then it is invisible instead of appearing as
`developer-tools`.

## Order merging

The published document decides the order of the categories it **names**. A
category it omits keeps its position relative to its local neighbours instead of
being flushed to the end — otherwise a document that simply forgot
`Designer Tools` (which has no published counterpart today) would silently
demote it, a presentation change nobody authored.

`PUBLISHED_CATEGORY_ID` maps `oncall-ops` → `On-call & Ops` by hand: no
mechanical slugify produces that pair (it yields `on-call-ops`), so a transform
would miss silently. Its values index `CATEGORY_ORDER` rather than repeating the
id as a literal, because these ids are compared byte-for-byte (`categoryFor(...)
!== category`, `Map` keys, `localeCompare`) and a drifted second spelling would
quietly match nothing. A test pins the pairs by value so a reorder of
`CATEGORY_ORDER` cannot rewire the table unnoticed.

## Failure behaviour

Everything degrades to the order compiled into the client — no document, an
unreadable one, an unknown `schemaVersion`, a malformed field, or a loader that
raises. The endpoint keeps the same contract the catalog annotation already
keeps: presentation is never worth a failed storefront, so a raising loader
costs the order and returns 200 with the apps.

## Testing

- `test/test_official_editorial.py` — 40 tests: ordering, tie-breaking by
  document position, dedup, field-level degradation (`bool` is a subclass of
  `int`, so `order: true` must not sort as 1), refusals, caching, the fetch seam.
- `test/test_registry_endpoint_category_order.py` — 4 tests, including that a
  raising loader still answers 200 with the apps.
- `website/src/test/categoryOrderMerge.test.ts` — 14 tests, including that the
  live document reproduces the canonical order exactly (so shipping this is a
  no-op until a curator changes something), that no category is ever lost for
  any published subset, and that a published id of `toString` cannot resolve to
  `Object.prototype.toString`.

Every claim above was mutation-verified: reverting each guard fails a **named**
test. The `bool` guard, the schema gate, the sort, the dedup, the cap, the
label-never-leaks rule, the negative cache, and the endpoint's try/except were
each broken in turn and each produced a specific failure.

Gates: `pytest` (222 on the touched files) · `isort` · `flake8` · `mypy` ·
`docs-lint` · brand · `tsc -b` · `eslint` · `jscpd` · `i18n:check` — all exit 0.

## Not in scope

Signature verification, tombstone resolution, and catalog-provided inventory
remain the three fail-closed gates documented in `official_catalog.py`. This
change adds a fourth document consumer with the same discipline; it does not
open any of them.
