### PR TITLE
feat(registry): add agent-dashboard

### DIFF
--- a/src/kiro_crew/apps/app-registry.json
+++ b/src/kiro_crew/apps/app-registry.json
@@ -14,6 +14,7 @@
   {
     "name": "agent-dashboard",
     "gitUrl": "https://github.com/brunokktro/agent-dashboard",
+    "repo": "https://github.com/brunokktro/agent-dashboard",
     "branch": "main"
   }
 ]

--- a/src/kiro_crew/apps/app-registry.json
+++ b/src/kiro_crew/apps/app-registry.json
@@ -15,6 +15,6 @@
     "name": "agent-dashboard",
     "gitUrl": "https://github.com/brunokktro/agent-dashboard",
     "repo": "https://github.com/brunokktro/agent-dashboard",
-    "branch": "main"
+    "branch": "release"
   }
 ]

--- a/src/kiro_crew/apps/app-registry.json
+++ b/src/kiro_crew/apps/app-registry.json
@@ -10,5 +10,10 @@
     "gitUrl": "https://github.com/qihang-dai/todo-ledger",
     "repo": "https://github.com/qihang-dai/todo-ledger",
     "branch": "release"
+  },
+  {
+    "name": "agent-dashboard",
+    "gitUrl": "https://github.com/brunokktro/agent-dashboard",
+    "branch": "main"
   }
 ]


### PR DESCRIPTION
Adds **agent-dashboard** to the app registry.

**What it is:** local-first observability for AI agent fleets - run history and health scores, day-by-hour failure heatmap, P50/P95/P99 durations, failure diagnosis with probable-cause hints, work queue, scheduler view, live logs and real PTY terminals. FastAPI + React, MIT.

**Repo:** https://github.com/brunokktro/agent-dashboard

**Tested:** installed from a clean GitHub tarball on KiroCrew (gateway-managed asgi backend on an auto port, /health check, thin ESM shell page embedding the app same-origin so its WebSocket terminals and SSE streams keep working through the HTTP-only proxy). The built UI bundles (ui/dist and the app's own frontend/dist) are committed, so the install needs no Node on the target machine. Per-app settings honored via data/config.json (declared in configSchema).

**Permissions:** only `/apps/agent-dashboard/api`. All screenshots come from a deterministic demo ecosystem shipped in-repo (demo/seed-demo.py) - no real data.