### PR TITLE
test(mcp-gateway): pin rewrite_agents params to fingerprint

### DIFF
--- a/test/test_mcp_gateway_rewriter_fingerprint.py
+++ b/test/test_mcp_gateway_rewriter_fingerprint.py
@@ -10,6 +10,7 @@ strictly worse than the boot cost the cache removes.
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 from pathlib import Path
@@ -28,6 +29,20 @@ from kiro_crew.mcp_gateway.rewriter import (
 # ``shutil.which`` bare-name resolution path is never entered and the fixture
 # behaves identically on every CI platform.
 _CMD = "/usr/bin/env"
+
+
+def test_rewrite_agents_signature_is_pinned_to_fingerprint_inputs() -> None:
+    """Every rewrite parameter must stay classified as fingerprinted or output-neutral."""
+    assert set(inspect.signature(rewrite_agents).parameters) == {
+        "source_dir",
+        "overlay_dir",
+        "socket_path",
+        "work_dir",
+        "sandbox_mode",
+        "approval_mode",
+        "stub_servers",
+        "pooling_enabled",
+    }
 
 
 def _mk_tree(root: Path, *, n_agents: int = 2, with_env: bool = True) -> Path:


### PR DESCRIPTION
## Problem / Motivation

The overlay-rewrite fingerprint cache (#2521, shipped in #3170) hand-enumerates every input that can change `rewrite_agents()`'s output. Nothing forces a future contributor who adds a new `rewrite_agents` parameter to decide whether it belongs in `_rewrite_inputs_fingerprint` — a forgotten input means the stored fingerprint keeps matching while that input changes, and the gateway serves stale overlays with no error, no warning, and a normal-looking boot.

## Why it matters

Silently stale overlays are exactly the failure mode `test_mcp_gateway_rewriter_fingerprint.py`'s module docstring calls "strictly worse than the boot cost the cache removes": sessions would run against MCP stubs generated from old inputs, and nothing in the logs points at the cache.

## What changed (motivation → approach → change)

Goal: convert "forgot to think about the fingerprint" into a failing test.

Approach: pin the `rewrite_agents` parameter NAME SET with `inspect.signature`, following the repo's existing signature-pin precedent (`test_session_transfer.py`, `test_mcp_tool_registry.py`). 

## Tests

- New: `test_rewrite_agents_signature_is_pinned_to_fingerprint_inputs`
- `python -m pytest test/test_mcp_gateway_rewriter_fingerprint.py -n0`: all passed

## Manual verification

N/A

## Related Issues

Refs #3187

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no documented behavior changes
- [x] No secrets, credentials, or internal references in the diff