### PR TITLE
refactor: consolidate the four SKILL.md frontmatter parsers (#3201)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/discover.py
+++ b/src/kiro_crew/dashboard/handlers/discover.py
@@ -18,6 +18,7 @@ import shutil
 from aiohttp import web
 
 from kiro_crew.dashboard.handlers._shared import _get_skills
+from kiro_crew.frontmatter import PROVIDER_PREVIEW, parse_frontmatter
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel as _sel
 from kiro_crew.skill_providers.base import ProviderRegistry
@@ -588,7 +589,7 @@ async def api_skills_discover_preview(request: web.Request) -> web.Response:
         return web.json_response(_empty)
 
     # Parse YAML frontmatter to extract description
-    meta = _parse_frontmatter(content)
+    meta = parse_frontmatter(content, PROVIDER_PREVIEW)
     _sel().log_tool_invocation(
         session_key=request.get("session_key", "dashboard"),
         tool_name="preview_skill_from_provider",
@@ -611,19 +612,3 @@ async def api_skills_discover_preview(request: web.Request) -> web.Response:
         "files": [_redact_external(f) for f in files[:200]],
         "file_count": len(files),
     })
-
-
-def _parse_frontmatter(content: str) -> dict:
-    """Extract YAML frontmatter key-value pairs from a SKILL.md."""
-    if not content.startswith("---"):
-        return {}
-    end = content.find("\n---", 3)
-    if end == -1:
-        return {}
-    frontmatter = content[4:end]
-    result: dict = {}
-    for line in frontmatter.split("\n"):
-        if ":" in line and not line.startswith(" "):
-            key, _, value = line.partition(":")
-            result[key.strip()] = value.strip()
-    return result

--- a/src/kiro_crew/frontmatter.py
+++ b/src/kiro_crew/frontmatter.py
@@ -1,0 +1,309 @@
+"""Single home for hand-rolled SKILL.md frontmatter parsing.
+
+Four backend callers parse ``key: value`` frontmatter from markdown, and each
+historically carried its own copy of the scanner. The copies drifted: they
+disagree on whether the opening fence may carry trailing text or leading
+whitespace, whether an indented ``key: value`` line is a field or prose,
+whether surrounding quotes are stripped from values, which of two duplicate
+keys wins, and whether a YAML block-scalar value is resolved from its
+indented continuation lines. Those disagreements are load-bearing — the
+skills loader MUST keep rejecting indented keys (an indented occurrence
+belongs to a block scalar, and honoring it once broke
+``set_inject_on_trigger``), while the onboarding import screen MUST keep its
+leniency (it is a fail-closed gate, and narrowing what it reads as
+``always:``/``triggers:`` would turn refusals into acceptances). So the
+scanner logic lives here exactly once, and each caller names its accepted
+grammar explicitly via a :class:`FrontmatterDialect`.
+
+This is deliberately NOT a YAML parser and must not grow into one: values are
+single-line strings apart from the minimal block-scalar folding below, and no
+YAML library is involved. Swapping the parsing technology would change every
+caller's accepted-input surface at once and needs its own review.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+# YAML block-scalar indicators recognized as frontmatter values: folded (>) or
+# literal (|), each with an optional chomping modifier. Explicit indentation
+# indicators (e.g. ">2") are not supported by this minimal parser.
+BLOCK_SCALAR_INDICATORS = frozenset({">", "|", ">-", "|-", ">+", "|+"})
+
+# Fence extraction for the "column0_fence" dialect: the opener must be exactly
+# ``---`` at position 0 followed by a newline; the closer is the next line
+# that *starts with* ``---`` (trailing text after the closer is tolerated).
+_COLUMN0_BLOCK_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+
+# Fence extraction for the "leading_ws_fence" dialect: identical, except any
+# whitespace (including blank lines) may precede the opening fence.
+_LEADING_WS_BLOCK_RE = re.compile(r"^\s*---\n(.*?)\n---", re.DOTALL)
+
+# How the frontmatter block is located within the document. Each mode
+# reproduces one caller's historical fence-matching behavior byte for byte;
+# they are not interchangeable (e.g. "prefix_find" slices the block at a
+# fixed offset of 4, so an opener with trailing text bleeds into the block).
+Extraction = Literal["column0_fence", "line_scan", "leading_ws_fence", "prefix_find"]
+
+# Whether an indented ``key: value`` line is a field or prose.
+# - "reject_indented": any leading whitespace (space or tab) makes the line
+#   prose. The skills loader depends on this: an indented occurrence belongs
+#   to the enclosing block scalar, not the frontmatter.
+# - "reject_space_indented": only a leading space disqualifies; a tab-indented
+#   key is (historically) accepted.
+# - "accept_indented": indentation is ignored; the key is stripped and used.
+IndentPolicy = Literal["reject_indented", "reject_space_indented", "accept_indented"]
+
+
+@dataclass(frozen=True)
+class FrontmatterDialect:
+    """One caller's accepted frontmatter grammar, named explicitly.
+
+    A dialect is a contract, not a tuning knob: changing a field changes what
+    an existing caller accepts or rejects, which is a behavior change with its
+    own review surface (see the snapshot corpus in ``test/test_frontmatter.py``).
+    """
+
+    extraction: Extraction
+    indent_policy: IndentPolicy
+    # Strip surrounding double/single quote characters from plain values.
+    # This is str.strip("\"'"), i.e. it removes *runs* of quote characters
+    # from both ends and tolerates mismatched pairs — preserved from the
+    # originals. Never applied to a resolved block scalar.
+    strip_quotes: bool
+    # True: the first occurrence of a duplicate key wins (single-value lookup
+    # semantics). False: the last occurrence wins (dict-overwrite semantics).
+    first_key_wins: bool = False
+    # Resolve a bare block-scalar indicator value (see
+    # BLOCK_SCALAR_INDICATORS) from the blank-or-indented lines that follow
+    # it, via fold_block_scalar. Dialects without this store the indicator
+    # character verbatim and leave the continuation lines to the indent
+    # policy.
+    resolve_block_scalars: bool = False
+
+
+# ``SkillsLoader._parse_frontmatter`` — the skills catalog reader. Strict
+# opener, indented lines are prose, quotes stripped from plain values, block
+# scalars resolved, last duplicate wins.
+SKILL_LOADER = FrontmatterDialect(
+    extraction="column0_fence",
+    indent_policy="reject_indented",
+    strip_quotes=True,
+    resolve_block_scalars=True,
+)
+
+# ``onboarding_import._frontmatter`` — the import screen's collapsed map.
+# Lenient on the opener (trailing text tolerated), the closer indentation,
+# and indented keys; quotes stripped; no block-scalar resolution. The
+# activation DECISION does not ride on this map alone:
+# ``onboarding_import._column0_activation_declared`` mirrors the loader's
+# region and key rules separately, precisely because this grammar diverges
+# from the loader's (indented prose can overwrite a real value here, and a
+# ``---``-prefixed closer line does not close this fence).
+ONBOARDING_IMPORT = FrontmatterDialect(
+    extraction="line_scan",
+    indent_policy="accept_indented",
+    strip_quotes=True,
+)
+
+# ``history._frontmatter_value`` — single-key lookup used by the skill-update
+# merge. Tolerates leading whitespace before the opener; otherwise mirrors
+# the loader's field rules (column-0 keys only, block scalars resolved) so a
+# value survives the read-stage-approve round-trip, but keeps plain values
+# verbatim (no quote stripping) and returns the first duplicate.
+SKILL_UPDATE = FrontmatterDialect(
+    extraction="leading_ws_fence",
+    indent_policy="reject_indented",
+    strip_quotes=False,
+    first_key_wins=True,
+    resolve_block_scalars=True,
+)
+
+# ``dashboard/handlers/discover.py`` skill-provider preview. Opener located by
+# prefix + fixed offset, tab-indented keys accepted, values kept verbatim,
+# no block-scalar resolution.
+PROVIDER_PREVIEW = FrontmatterDialect(
+    extraction="prefix_find",
+    indent_policy="reject_space_indented",
+    strip_quotes=False,
+)
+
+
+def fold_block_scalar(indicator: str, block: list[str]) -> str:
+    """Resolve a YAML block scalar's indented lines into a single value.
+
+    ``indicator`` is one of ``BLOCK_SCALAR_INDICATORS``; ``block`` holds the
+    raw continuation lines (still carrying their indentation). Literal (``|``)
+    scalars keep one line per newline. Folded (``>``) scalars fold a single
+    break between plain lines to a space and keep blank lines as newlines
+    (k blanks -> k newlines plain-to-plain, k+1 next to a more-indented line,
+    where the separator break stays literal), and never fold a break adjacent
+    to a more-indented line, so nested indentation survives. Indentation is
+    stripped relative to the first non-blank line, and the result is trimmed,
+    so the chomping modifier (``-``/``+``) has no residual effect on the
+    stored value.
+    """
+    # Trim trailing blank lines without mutating the caller's list and
+    # without per-iteration copies (a pathological blank run stays linear).
+    end = len(block)
+    while end and not block[end - 1].strip():
+        end -= 1
+    if not end:
+        return ""
+    block = block[:end]
+    first = next(ln for ln in block if ln.strip())
+    indent = len(first) - len(first.lstrip())
+    dedented = [
+        ln[indent:] if ln[:indent].isspace() or not ln.strip() else ln.lstrip() for ln in block
+    ]
+    if indicator.startswith("|"):
+        return "\n".join(dedented).strip()
+    # Folded: a single line break between two plain lines becomes a space;
+    # blank lines are preserved as line breaks (k blanks -> k newlines); and
+    # breaks adjacent to a more-indented line are kept, so indented structure
+    # (nested lists, code-ish content) survives the fold.
+    parts: list[str] = []
+    pending_blanks = 0
+    prev_more_indented = False
+    for ln in dedented:
+        if not ln.strip():
+            pending_blanks += 1
+            continue
+        more_indented = ln[:1].isspace()
+        if parts:
+            if pending_blanks:
+                # The separator break folds to nothing between plain lines,
+                # but stays literal next to a more-indented line: k blanks
+                # yield k newlines plain-to-plain, k+1 otherwise.
+                extra = 1 if (more_indented or prev_more_indented) else 0
+                parts.append("\n" * (pending_blanks + extra))
+            elif more_indented or prev_more_indented:
+                parts.append("\n")
+            else:
+                parts.append(" ")
+        parts.append(ln.rstrip() if more_indented else ln.strip())
+        prev_more_indented = more_indented
+        pending_blanks = 0
+    return "".join(parts)
+
+
+def parse_frontmatter(text: str, dialect: FrontmatterDialect) -> dict[str, str]:
+    """Parse frontmatter fields from *text* under *dialect*; ``{}`` if absent."""
+    # Field-only path: skip the body slice entirely — the skills catalog
+    # calls this per SKILL.md on load, and the body would be a dead
+    # allocation the size of the document.
+    lines, _ = _extract_block(text, dialect.extraction, want_body=False)
+    if lines is None:
+        return {}
+    return _parse_block_lines(lines, dialect)
+
+
+def frontmatter_value(text: str, key: str, dialect: FrontmatterDialect) -> str:
+    """Return one frontmatter field's value, or ``""`` when absent."""
+    return parse_frontmatter(text, dialect).get(key, "")
+
+
+def split_frontmatter(text: str, dialect: FrontmatterDialect) -> tuple[dict[str, str], str]:
+    """Parse frontmatter and split off the body under *dialect*.
+
+    Returns ``(fields, body)``. When no complete frontmatter block is found
+    the fields are ``{}`` and the body is *text* unchanged. The body is only
+    contractually meaningful for the ``line_scan`` extraction (the one caller
+    that consumes it: the stripped text after the closing fence line). The
+    other modes return an arbitrary unconsumed remainder — ``column0_fence``
+    and ``leading_ws_fence`` cut immediately after the ``---`` closer token
+    (mid-line when the closer carries trailing text), and ``prefix_find``'s
+    remainder still BEGINS with the ``\\n---`` closer — so do not render it
+    as a document body.
+    """
+    lines, body = _extract_block(text, dialect.extraction)
+    if lines is None:
+        return {}, body
+    return _parse_block_lines(lines, dialect), body
+
+
+def _extract_block(
+    text: str, extraction: Extraction, *, want_body: bool = True
+) -> tuple[list[str] | None, str]:
+    """Locate the frontmatter block; ``(None, text)`` when there isn't one.
+
+    With ``want_body=False`` the second element is ``""`` whenever a block
+    was found (the caller promises not to read it); the no-block case still
+    returns *text* so ``({}, text)`` stays uniform.
+    """
+    if extraction == "column0_fence" or extraction == "leading_ws_fence":
+        pattern = _COLUMN0_BLOCK_RE if extraction == "column0_fence" else _LEADING_WS_BLOCK_RE
+        match = pattern.match(text)
+        if not match:
+            return None, text
+        return match.group(1).split("\n"), (text[match.end() :] if want_body else "")
+    if extraction == "line_scan":
+        if not text.startswith("---"):
+            return None, text
+        # splitlines() preserved from the original: the closer test's
+        # .strip() already absorbs a trailing \r, so the visible differences
+        # vs split("\n") are the wider line-boundary set (\r, \v, \f,
+        # \x1c-\x1e, \x85, \u2028, \u2029 also split) and interior \r removal
+        # in the joined body. The opener line itself is skipped, tolerating
+        # trailing text.
+        lines = text.splitlines()
+        for index, line in enumerate(lines[1:], start=1):
+            if line.strip() == "---":
+                body = "\n".join(lines[index + 1 :]).strip() if want_body else ""
+                return lines[1:index], body
+        return None, text
+    if extraction == "prefix_find":
+        # Opener by prefix, block sliced at the fixed offset of 4. When the
+        # opener line carries trailing text the slice starts mid-line —
+        # preserved verbatim from the original (the junk becomes a prose
+        # line, or a degenerate key when it contains a colon).
+        if not text.startswith("---"):
+            return None, text
+        end = text.find("\n---", 3)
+        if end == -1:
+            return None, text
+        return text[4:end].split("\n"), (text[end:] if want_body else "")
+    # A new Extraction literal must get its own branch: falling through to
+    # any existing mode would silently hand it that mode's grammar.
+    raise ValueError(f"unknown frontmatter extraction mode: {extraction!r}")
+
+
+def _parse_block_lines(lines: list[str], dialect: FrontmatterDialect) -> dict[str, str]:
+    """Scan block lines into a field dict under *dialect*'s line rules."""
+    fields: dict[str, str] = {}
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        i += 1
+        if ":" not in line:
+            continue
+        # line[:1] is "" for an empty line and "".isspace() is False, so the
+        # guards only fire on genuinely indented lines.
+        if dialect.indent_policy == "reject_indented" and line[:1].isspace():
+            continue
+        if dialect.indent_policy == "reject_space_indented" and line.startswith(" "):
+            continue
+        key, _, raw = line.partition(":")
+        key = key.strip()
+        value = raw.strip()
+        if dialect.resolve_block_scalars and value in BLOCK_SCALAR_INDICATORS:
+            # Blank or indented lines up to the next column-0 line are the
+            # scalar's content; trailing blanks between fields are trimmed by
+            # the folder. Under a reject_indented dialect (every preset that
+            # resolves scalars) consuming them hides no key — those lines
+            # could not have been fields anyway. A custom dialect combining
+            # resolution with accept_indented trades indented-key visibility
+            # for scalar content, which is what the indicator means in YAML.
+            block: list[str] = []
+            while i < len(lines) and (not lines[i].strip() or lines[i][:1].isspace()):
+                block.append(lines[i])
+                i += 1
+            value = fold_block_scalar(value, block)
+        elif dialect.strip_quotes:
+            value = value.strip("\"'")
+        if dialect.first_key_wins and key in fields:
+            continue
+        fields[key] = value
+    return fields

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -27,18 +27,14 @@ from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.executors import run_in_embed_pool
+from kiro_crew.frontmatter import SKILL_UPDATE, frontmatter_value
 from kiro_crew.llm_helpers import ToolApprovalPolicy, stream_and_collect, stream_and_collect_json
 from kiro_crew.messaging.link import legacy_key
 from kiro_crew.preview_text import strip_markdown_preview
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.session import BACKGROUND_KEY
-from kiro_crew.skills import (
-    _BLOCK_SCALAR_INDICATORS,
-    AUTO_SKILL_MAX_PROCEDURE_CHARS,
-    AutoSkillProvenance,
-    _fold_block_scalar,
-)
+from kiro_crew.skills import AUTO_SKILL_MAX_PROCEDURE_CHARS, AutoSkillProvenance
 from kiro_crew.skills_dedupe import (
     VERDICT_DUP,
     VERDICT_NEW,
@@ -4083,32 +4079,13 @@ def _frontmatter_value(text: str | None, key: str) -> str:
     ``triggers`` through this reader into a staged candidate that overwrites
     the live skill on approval — reading the indicator verbatim would collapse
     a block-scalar description to ``""`` and inject a bogus ``>`` trigger on
-    that round-trip.
+    that round-trip. The grammar (plus the leading-whitespace opener
+    tolerance, verbatim plain values, and first-duplicate-wins lookup) is
+    pinned as ``frontmatter.SKILL_UPDATE``.
     """
     if not text:
         return ""
-    m = re.match(r"^\s*---\n(.*?)\n---", text, re.DOTALL)
-    if not m:
-        return ""
-    lines = m.group(1).split("\n")
-    i = 0
-    while i < len(lines):
-        ln = lines[i]
-        i += 1
-        if ":" not in ln or ln[:1].isspace():
-            continue
-        k, raw = ln.split(":", 1)
-        if k.strip() != key:
-            continue
-        value = raw.strip()
-        if value in _BLOCK_SCALAR_INDICATORS:
-            block: list[str] = []
-            while i < len(lines) and (not lines[i].strip() or lines[i][:1].isspace()):
-                block.append(lines[i])
-                i += 1
-            return _fold_block_scalar(value, block)
-        return value
-    return ""
+    return frontmatter_value(text, key, SKILL_UPDATE)
 
 
 def _merge_trigger_lists(live: str, candidate: str, *, cap: int = 12) -> str:
@@ -4143,7 +4120,9 @@ def _strip_skill_frontmatter(text: str | None) -> str:
     A skill body read off disk carries its frontmatter header; only the prose
     below it may be fed to (or accepted from) the update-merge turn, because
     ``stage_skill_candidate`` re-emits frontmatter of its own. Text without a
-    leading block is returned unchanged (stripped).
+    leading block is returned unchanged (stripped). A fence LOCATOR, not a
+    field parser — deliberately outside ``kiro_crew.frontmatter``; editing
+    its grammar means revisiting ``_frontmatter_value``'s dialect too.
     """
     if not text:
         return ""

--- a/src/kiro_crew/onboarding_import.py
+++ b/src/kiro_crew/onboarding_import.py
@@ -38,6 +38,7 @@ from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 from kiro_crew.embeddings import make_sync_embed_fn
+from kiro_crew.frontmatter import BLOCK_SCALAR_INDICATORS, ONBOARDING_IMPORT, split_frontmatter
 from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes_nolink
 from kiro_crew.learn import _MAX_LESSONS_TOTAL, Lesson, LessonStore
 from kiro_crew.mcp_utils import mcp_server_alias
@@ -47,7 +48,6 @@ from kiro_crew.security import (
     redact_credentials,
     redact_exfiltration_urls,
 )
-from kiro_crew.skills import _BLOCK_SCALAR_INDICATORS
 from kiro_crew.vector_memory import VectorMemoryStore
 
 logger = logging.getLogger(__name__)
@@ -1888,21 +1888,17 @@ def _add_hermes_json_schedules(
 
 
 def _frontmatter(text: str) -> tuple[dict[str, str], str]:
-    if not text.startswith("---"):
-        return {}, text
-    lines = text.splitlines()
-    metadata: dict[str, str] = {}
-    end = 0
-    for index, line in enumerate(lines[1:], start=1):
-        if line.strip() == "---":
-            end = index
-            break
-        if ":" in line:
-            key, value = line.split(":", 1)
-            metadata[key.strip()] = value.strip().strip("\"'")
-    if not end:
-        return {}, text
-    return metadata, "\n".join(lines[end + 1 :]).strip()
+    """Split frontmatter for the import screen (``frontmatter.ONBOARDING_IMPORT``).
+
+    Deliberately lenient on the opener and on indented keys — narrowing what
+    this map reads would weaken the diagnostics built on it. Its grammar
+    diverges from the loader's (indented prose can overwrite a real value,
+    and the closer must be an exact ``---`` line, not a ``---`` prefix), so
+    the activation DECISION does not ride on this map alone:
+    ``_column0_activation_declared`` mirrors the loader's region and key
+    rules separately.
+    """
+    return split_frontmatter(text, ONBOARDING_IMPORT)
 
 
 def _column0_activation_declared(text: str) -> bool:
@@ -1935,7 +1931,7 @@ def _column0_activation_declared(text: str) -> bool:
         if key != "always":
             continue
         value = raw.strip().strip("\"'").casefold()
-        if value in {"1", "true", "yes"} or value in _BLOCK_SCALAR_INDICATORS:
+        if value in {"1", "true", "yes"} or value in BLOCK_SCALAR_INDICATORS:
             return True
     return False
 

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -19,6 +19,7 @@ from typing import Callable
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.cron import referenced_skill_names
+from kiro_crew.frontmatter import SKILL_LOADER, parse_frontmatter
 from kiro_crew.hooks import safe_read_file, validate_file_path
 from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.security import (
@@ -35,69 +36,6 @@ logger = logging.getLogger(__name__)
 
 SKILLS_DIR_NAME = "skills"
 _MIN_TRIGGER_OVERLAP = 0.7
-
-# YAML block-scalar indicators recognized as frontmatter values: folded (>) or
-# literal (|), each with an optional chomping modifier. Explicit indentation
-# indicators (e.g. ">2") are not supported by this minimal parser.
-_BLOCK_SCALAR_INDICATORS = frozenset({">", "|", ">-", "|-", ">+", "|+"})
-
-
-def _fold_block_scalar(indicator: str, block: list[str]) -> str:
-    """Resolve a YAML block scalar's indented lines into a single value.
-
-    ``indicator`` is one of ``_BLOCK_SCALAR_INDICATORS``; ``block`` holds the
-    raw continuation lines (still carrying their indentation). Literal (``|``)
-    scalars keep one line per newline. Folded (``>``) scalars fold a single
-    break between plain lines to a space and keep blank lines as newlines
-    (k blanks -> k newlines plain-to-plain, k+1 next to a more-indented line,
-    where the separator break stays literal), and never fold a break adjacent
-    to a more-indented line, so nested indentation survives. Indentation is
-    stripped relative to the first non-blank line, and the result is trimmed,
-    so the chomping modifier (``-``/``+``) has no residual effect on the
-    stored value.
-    """
-    # Trim trailing blank lines without mutating the caller's list and
-    # without per-iteration copies (a pathological blank run stays linear).
-    end = len(block)
-    while end and not block[end - 1].strip():
-        end -= 1
-    if not end:
-        return ""
-    block = block[:end]
-    first = next(ln for ln in block if ln.strip())
-    indent = len(first) - len(first.lstrip())
-    dedented = [
-        ln[indent:] if ln[:indent].isspace() or not ln.strip() else ln.lstrip() for ln in block
-    ]
-    if indicator.startswith("|"):
-        return "\n".join(dedented).strip()
-    # Folded: a single line break between two plain lines becomes a space;
-    # blank lines are preserved as line breaks (k blanks -> k newlines); and
-    # breaks adjacent to a more-indented line are kept, so indented structure
-    # (nested lists, code-ish content) survives the fold.
-    parts: list[str] = []
-    pending_blanks = 0
-    prev_more_indented = False
-    for ln in dedented:
-        if not ln.strip():
-            pending_blanks += 1
-            continue
-        more_indented = ln[:1].isspace()
-        if parts:
-            if pending_blanks:
-                # The separator break folds to nothing between plain lines,
-                # but stays literal next to a more-indented line: k blanks
-                # yield k newlines plain-to-plain, k+1 otherwise.
-                extra = 1 if (more_indented or prev_more_indented) else 0
-                parts.append("\n" * (pending_blanks + extra))
-            elif more_indented or prev_more_indented:
-                parts.append("\n")
-            else:
-                parts.append(" ")
-        parts.append(ln.rstrip() if more_indented else ln.strip())
-        prev_more_indented = more_indented
-        pending_blanks = 0
-    return "".join(parts)
 
 
 def _matches_any(path: str, globs: list[str]) -> bool:
@@ -3339,39 +3277,21 @@ class SkillsLoader:
         newlines. Without this, the stored value would be the indicator
         character itself and the real content — a multi-line ``description``
         used for routing — would be dropped, leaving the skill unroutable.
+        That grammar is pinned as ``frontmatter.SKILL_LOADER``.
         """
         content = path.read_text(encoding="utf-8")
-        if not content.startswith("---"):
-            return {}
-        match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
-        if not match:
-            return {}
-        meta: dict[str, str] = {}
-        lines = match.group(1).split("\n")
-        i = 0
-        while i < len(lines):
-            line = lines[i]
-            i += 1
-            if ":" not in line or line[:1].isspace():
-                continue
-            key, raw = line.split(":", 1)
-            value = raw.strip()
-            if value in _BLOCK_SCALAR_INDICATORS:
-                # Indented (or blank) lines up to the next column-0 key are the
-                # scalar's content; trailing blanks between fields are trimmed
-                # by the folder.
-                block: list[str] = []
-                while i < len(lines) and (not lines[i].strip() or lines[i][:1].isspace()):
-                    block.append(lines[i])
-                    i += 1
-                meta[key.strip()] = _fold_block_scalar(value, block)
-            else:
-                meta[key.strip()] = value.strip("\"'")
-        return meta
+        return parse_frontmatter(content, SKILL_LOADER)
 
     @staticmethod
     def strip_frontmatter(content: str) -> str:
-        """Remove YAML frontmatter from markdown."""
+        """Remove YAML frontmatter from markdown.
+
+        A fence LOCATOR, not a field parser — deliberately outside
+        ``kiro_crew.frontmatter``. Its closer grammar is stricter than
+        ``_parse_frontmatter``'s (``---`` must be followed by a newline), so
+        a ``---junk`` closer parses fields yet strips nothing; editing either
+        grammar means revisiting the other.
+        """
         if content.startswith("---"):
             match = re.match(r"^---\n.*?\n---\n", content, re.DOTALL)
             if match:

--- a/test/test_frontmatter.py
+++ b/test/test_frontmatter.py
@@ -1,0 +1,416 @@
+"""Snapshot tests pinning the consolidated frontmatter parser to the four
+grammars its call sites historically accepted.
+
+The expected values below were captured by running the four pre-consolidation
+parsers (``SkillsLoader._parse_frontmatter``, ``onboarding_import._frontmatter``,
+``history._frontmatter_value``, and the ``discover.py`` handler copy) against
+this corpus. They are the oracle for the refactor: a change in any expectation
+means a caller's accepted-input surface moved, which is a behavior change with
+its own review — not a refactor.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import history
+from kiro_crew.frontmatter import (
+    ONBOARDING_IMPORT,
+    PROVIDER_PREVIEW,
+    SKILL_LOADER,
+    SKILL_UPDATE,
+    FrontmatterDialect,
+    frontmatter_value,
+    parse_frontmatter,
+    split_frontmatter,
+)
+from kiro_crew.onboarding_import import _column0_activation_declared, _frontmatter
+from kiro_crew.skills import SkillsLoader
+
+# Inputs chosen to hit every axis the four grammars disagree on: opener
+# strictness, closer form, indent policy, quote stripping, duplicate-key
+# resolution, block-scalar resolution, and line-ending handling.
+CORPUS: dict[str, str] = {
+    "simple": "---\nname: x\ndescription: hello\n---\nbody\n",
+    "space_indented_key": "---\nname: x\n  steps: do x\n---\n",
+    "tab_indented_key": "---\nname: x\n\tsteps: tabbed\n---\n",
+    "quoted_values": "---\nname: \"quoted\"\ndesc: 'single'\nmulti: \"\"double\"\"\n---\n",
+    "mismatched_quotes": "---\nk: \"a'\n---\n",
+    "leading_ws_before_opener": "\n  ---\nname: x\n---\n",
+    "opener_trailing_junk": "---junk\nname: x\n---\n",
+    "opener_junk_with_colon": "---x: y\nname: x\n---\n",
+    "no_closer": "---\nname: x\n",
+    "closer_trailing_junk": "---\nname: x\n---junk\nbody\n",
+    "closer_indented": "---\nname: x\n  ---\nbody\n",
+    "duplicate_keys": "---\nk: first\nk: second\n---\n",
+    "crlf": "---\r\nname: x\r\n---\r\nbody\r\n",
+    "empty_block": "---\n---\nbody\n",
+    "colon_in_value": "---\nurl: http://example.com:8080\n---\n",
+    "empty_value": "---\nkey:\n---\n",
+    "block_scalar_folded": "---\ndescription: >\n  first line\n  second line\n---\n",
+    "block_scalar_literal": "---\ndescription: |\n  line one\n  line two\n---\n",
+    "block_scalar_chomped": "---\ndescription: >-\n  folded text\nname: x\n---\n",
+    "block_scalar_blank_fold": "---\ndescription: >\n  para one\n\n  para two\n---\n",
+    "block_scalar_junk_keys": "---\ndescription: |\n  Steps: do x\n  more: prose\n---\n",
+    "block_scalar_quoted_inside": "---\nk: |\n  \"quoted\"\n---\n",
+    "no_colon_line": "---\nnoise\nname: x\n---\n",
+    "four_dash_fences": "----\nkey: v\n----\nbody\n",
+    "bare_open_fence": "---",
+    "empty_text": "",
+    "plain_prose": "no frontmatter here\nkey: value\n",
+    "value_whitespace": "---\nk:    padded value   \n---\n",
+    "body_padding": "---\nk: v\n---\n\n  body  \n\n",
+    # An indented duplicate BEFORE the column-0 key: separates the indent
+    # policies from duplicate-key resolution.
+    "indented_shadow_before": "---\n  k: shadow\nk: real\n---\n",
+    # A resolved scalar followed by a plain duplicate: separates first-wins
+    # (scalar survives) from last-wins (plain overwrites).
+    "duplicate_scalar_then_plain": "---\nk: |\n  from scalar\nk: plain\n---\n",
+    # The reverse — plain first, scalar second — is the one shape where the
+    # shared scanner's mechanics differ from history's original (which
+    # returned on first match and never consumed the second scalar's lines);
+    # pinned to prove the lookup result is unchanged anyway.
+    "duplicate_plain_then_scalar": "---\nk: plain\nk: |\n  from scalar\n---\n",
+}
+
+# ``SkillsLoader._parse_frontmatter`` reads files with ``Path.read_text``,
+# whose universal-newline mode collapses CRLF to LF before parsing — so the
+# SKILL_LOADER dialect is exercised on normalized text, like the real caller.
+SKILL_LOADER_EXPECTED: dict[str, dict[str, str]] = {
+    "bare_open_fence": {},
+    "block_scalar_blank_fold": {"description": "para one\npara two"},
+    "block_scalar_chomped": {"description": "folded text", "name": "x"},
+    "block_scalar_folded": {"description": "first line second line"},
+    "block_scalar_junk_keys": {"description": "Steps: do x\nmore: prose"},
+    "block_scalar_literal": {"description": "line one\nline two"},
+    "block_scalar_quoted_inside": {"k": '"quoted"'},
+    "body_padding": {"k": "v"},
+    "closer_indented": {},
+    "closer_trailing_junk": {"name": "x"},
+    "colon_in_value": {"url": "http://example.com:8080"},
+    "crlf": {"name": "x"},
+    "duplicate_keys": {"k": "second"},
+    "duplicate_plain_then_scalar": {"k": "from scalar"},
+    "duplicate_scalar_then_plain": {"k": "plain"},
+    "empty_block": {},
+    "empty_text": {},
+    "empty_value": {"key": ""},
+    "four_dash_fences": {},
+    "indented_shadow_before": {"k": "real"},
+    "leading_ws_before_opener": {},
+    "mismatched_quotes": {"k": "a"},
+    "no_closer": {},
+    "no_colon_line": {"name": "x"},
+    "opener_junk_with_colon": {},
+    "opener_trailing_junk": {},
+    "plain_prose": {},
+    "quoted_values": {"desc": "single", "multi": "double", "name": "quoted"},
+    "simple": {"description": "hello", "name": "x"},
+    "space_indented_key": {"name": "x"},
+    "tab_indented_key": {"name": "x"},
+    "value_whitespace": {"k": "padded value"},
+}
+
+ONBOARDING_EXPECTED: dict[str, tuple[dict[str, str], str]] = {
+    "bare_open_fence": ({}, "---"),
+    # This collapsed map stores a block-scalar indicator verbatim; activation
+    # never rides on that, because ``_column0_activation_declared`` treats a
+    # bare indicator as activating (fail-closed).
+    "block_scalar_blank_fold": ({"description": ">"}, ""),
+    "block_scalar_chomped": ({"description": ">-", "name": "x"}, ""),
+    "block_scalar_folded": ({"description": ">"}, ""),
+    "block_scalar_junk_keys": ({"Steps": "do x", "description": "|", "more": "prose"}, ""),
+    "block_scalar_literal": ({"description": "|"}, ""),
+    "block_scalar_quoted_inside": ({"k": "|"}, ""),
+    "body_padding": ({"k": "v"}, "body"),
+    "closer_indented": ({"name": "x"}, "body"),
+    # KNOWN DIVERGENCE from SKILL_LOADER: this dialect's closer must be an
+    # exact "---" line, so a "---junk" closer means no frontmatter here —
+    # while the skills loader parses {"name": "x"} from the same bytes. The
+    # activation gate is immune (see TestOnboardingImportDialect::
+    # test_closer_divergence_cannot_bypass_the_activation_gate); issue #3231
+    # documents the history.
+    "closer_trailing_junk": ({}, "---\nname: x\n---junk\nbody\n"),
+    "colon_in_value": ({"url": "http://example.com:8080"}, ""),
+    "crlf": ({"name": "x"}, "body"),
+    "duplicate_keys": ({"k": "second"}, ""),
+    "duplicate_plain_then_scalar": ({"k": "|"}, ""),
+    "duplicate_scalar_then_plain": ({"k": "plain"}, ""),
+    "empty_block": ({}, "body"),
+    "empty_text": ({}, ""),
+    "empty_value": ({"key": ""}, ""),
+    "four_dash_fences": ({}, "----\nkey: v\n----\nbody\n"),
+    "indented_shadow_before": ({"k": "real"}, ""),
+    "leading_ws_before_opener": ({}, "\n  ---\nname: x\n---\n"),
+    "mismatched_quotes": ({"k": "a"}, ""),
+    "no_closer": ({}, "---\nname: x\n"),
+    "no_colon_line": ({"name": "x"}, ""),
+    "opener_junk_with_colon": ({"name": "x"}, ""),
+    "opener_trailing_junk": ({"name": "x"}, ""),
+    "plain_prose": ({}, "no frontmatter here\nkey: value\n"),
+    "quoted_values": ({"desc": "single", "multi": "double", "name": "quoted"}, ""),
+    "simple": ({"description": "hello", "name": "x"}, "body"),
+    "space_indented_key": ({"name": "x", "steps": "do x"}, ""),
+    "tab_indented_key": ({"name": "x", "steps": "tabbed"}, ""),
+    "value_whitespace": ({"k": "padded value"}, ""),
+}
+
+# Non-empty single-key lookups only; every probed key absent from a case's
+# dict was verified to return "" from the pre-consolidation
+# ``_frontmatter_value``.
+HISTORY_EXPECTED: dict[str, dict[str, str]] = {
+    "bare_open_fence": {},
+    "block_scalar_blank_fold": {"description": "para one\npara two"},
+    "block_scalar_chomped": {"description": "folded text", "name": "x"},
+    "block_scalar_folded": {"description": "first line second line"},
+    "block_scalar_junk_keys": {"description": "Steps: do x\nmore: prose"},
+    "block_scalar_literal": {"description": "line one\nline two"},
+    "block_scalar_quoted_inside": {"k": '"quoted"'},
+    "body_padding": {"k": "v"},
+    "closer_indented": {},
+    "closer_trailing_junk": {"name": "x"},
+    "colon_in_value": {"url": "http://example.com:8080"},
+    "crlf": {},
+    "duplicate_keys": {"k": "first"},
+    # first_key_wins both ways: the plain value survives a later scalar
+    # duplicate (whose lines the shared scanner consumes but the original
+    # never even read — the lookup result is identical), and a resolved
+    # scalar survives a later plain duplicate.
+    "duplicate_plain_then_scalar": {"k": "plain"},
+    "duplicate_scalar_then_plain": {"k": "from scalar"},
+    "empty_block": {},
+    "empty_text": {},
+    "empty_value": {},
+    "four_dash_fences": {},
+    "indented_shadow_before": {"k": "real"},
+    "leading_ws_before_opener": {"name": "x"},
+    "mismatched_quotes": {"k": "\"a'"},
+    "no_closer": {},
+    "no_colon_line": {"name": "x"},
+    "opener_junk_with_colon": {},
+    "opener_trailing_junk": {},
+    "plain_prose": {},
+    "quoted_values": {"multi": '""double""', "name": '"quoted"'},
+    "simple": {"description": "hello", "name": "x"},
+    "space_indented_key": {"name": "x"},
+    "tab_indented_key": {"name": "x"},
+    "value_whitespace": {"k": "padded value"},
+}
+
+DISCOVER_EXPECTED: dict[str, dict[str, str]] = {
+    "bare_open_fence": {},
+    "block_scalar_blank_fold": {"description": ">"},
+    "block_scalar_chomped": {"description": ">-", "name": "x"},
+    "block_scalar_folded": {"description": ">"},
+    "block_scalar_junk_keys": {"description": "|"},
+    "block_scalar_literal": {"description": "|"},
+    "block_scalar_quoted_inside": {"k": "|"},
+    "body_padding": {"k": "v"},
+    "closer_indented": {},
+    "closer_trailing_junk": {"name": "x"},
+    "colon_in_value": {"url": "http://example.com:8080"},
+    "crlf": {"name": "x"},
+    "duplicate_keys": {"k": "second"},
+    "duplicate_plain_then_scalar": {"k": "|"},
+    "duplicate_scalar_then_plain": {"k": "plain"},
+    "empty_block": {},
+    "empty_text": {},
+    "empty_value": {"key": ""},
+    "four_dash_fences": {"key": "v"},
+    "indented_shadow_before": {"k": "real"},
+    "leading_ws_before_opener": {},
+    "mismatched_quotes": {"k": "\"a'"},
+    "no_closer": {},
+    "no_colon_line": {"name": "x"},
+    "opener_junk_with_colon": {"": "y", "name": "x"},
+    "opener_trailing_junk": {"name": "x"},
+    "plain_prose": {},
+    "quoted_values": {"desc": "'single'", "multi": '""double""', "name": '"quoted"'},
+    "simple": {"description": "hello", "name": "x"},
+    "space_indented_key": {"name": "x"},
+    "tab_indented_key": {"name": "x", "steps": "tabbed"},
+    "value_whitespace": {"k": "padded value"},
+}
+
+HISTORY_PROBE_KEYS = ("name", "description", "k", "key", "steps", "url", "multi", "more", "Steps", "")
+
+
+def _write_corpus_file(tmp_path: Path, case_id: str) -> Path:
+    path = tmp_path / f"{case_id}.md"
+    # newline="" so CRLF corpus bytes reach the parser's read_text unmangled
+    # by the platform's default newline translation on write.
+    with path.open("w", encoding="utf-8", newline="") as f:
+        f.write(CORPUS[case_id])
+    return path
+
+
+class TestSkillLoaderDialect:
+    """The skills-catalog grammar, exercised through the real caller."""
+
+    @pytest.mark.parametrize("case_id", sorted(CORPUS))
+    def test_snapshot(self, case_id: str, tmp_path: Path) -> None:
+        path = _write_corpus_file(tmp_path, case_id)
+        assert SkillsLoader._parse_frontmatter(path) == SKILL_LOADER_EXPECTED[case_id]
+
+    def test_rejects_indented_keys_including_tabs(self) -> None:
+        # The column-0 gate is load-bearing: an indented occurrence belongs to
+        # a block scalar, and honoring it broke set_inject_on_trigger.
+        text = "---\nname: x\n  inject_on_trigger: false\n\tinject_on_trigger: false\n---\n"
+        assert parse_frontmatter(text, SKILL_LOADER) == {"name": "x"}
+
+
+class TestOnboardingImportDialect:
+    """The import screen's collapsed map, exercised through the real caller."""
+
+    @pytest.mark.parametrize("case_id", sorted(CORPUS))
+    def test_snapshot(self, case_id: str) -> None:
+        assert _frontmatter(CORPUS[case_id]) == ONBOARDING_EXPECTED[case_id]
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Spellings the map has always read — indented, quoted,
+            # junk-opener, and whitespace-closed variants. These pin the
+            # map's LENIENT axes; completeness of the activation decision is
+            # ``_column0_activation_declared``'s job, tested below.
+            "---\nalways: true\n---\nbody",
+            "---\n  always: 'true'\n---\nbody",
+            "---junk\nalways: \"yes\"\n---\nbody",
+            "---\ntriggers: a, b\n  ---\nbody",
+            "---\n\ttriggers: x\n---\nbody",
+        ],
+    )
+    def test_lenient_map_inputs_still_read(self, text: str) -> None:
+        metadata, _ = _frontmatter(text)
+        assert ("always" in metadata) or ("triggers" in metadata)
+
+    def test_closer_divergence_cannot_bypass_the_activation_gate(self) -> None:
+        # The map's exact-"---" closer misses a "---junk"-closed block that
+        # the loader parses (see the KNOWN DIVERGENCE pin above; issue #3231
+        # documents the history) — but the activation decision mirrors the
+        # loader's region rules, so the divergence cannot re-admit an
+        # auto-activating skill.
+        text = "---\nalways: true\n---junk\nbody"
+        map_metadata, _ = _frontmatter(text)
+        assert map_metadata == {}
+        assert parse_frontmatter(text, SKILL_LOADER) == {"always": "true"}
+        assert _column0_activation_declared(text) is True
+
+    def test_indent_shadow_cannot_bypass_the_activation_gate(self) -> None:
+        # The other divergence the separate gate exists for: the map accepts
+        # indented keys with last-wins, so indented prose overwrites the real
+        # column-0 value — while the loader (and the gate) honor only the
+        # column-0 line. A "column-0 beats indented" special case added to
+        # the shared scanner would silently erase this divergence; this pin
+        # makes that a conscious decision.
+        text = "---\nalways: true\n  always: false\n---\nbody"
+        map_metadata, _ = _frontmatter(text)
+        assert map_metadata == {"always": "false"}
+        assert parse_frontmatter(text, SKILL_LOADER) == {"always": "true"}
+        assert _column0_activation_declared(text) is True
+
+
+class TestSkillUpdateDialect:
+    """The single-key lookup grammar, exercised through the real caller."""
+
+    @pytest.mark.parametrize("case_id", sorted(CORPUS))
+    def test_snapshot(self, case_id: str) -> None:
+        text = CORPUS[case_id]
+        expected = HISTORY_EXPECTED[case_id]
+        for key in HISTORY_PROBE_KEYS:
+            assert history._frontmatter_value(text, key) == expected.get(key, "")
+
+    def test_none_and_empty(self) -> None:
+        assert history._frontmatter_value(None, "description") == ""
+        assert history._frontmatter_value("", "description") == ""
+
+
+class TestProviderPreviewDialect:
+    @pytest.mark.parametrize("case_id", sorted(CORPUS))
+    def test_snapshot(self, case_id: str) -> None:
+        assert parse_frontmatter(CORPUS[case_id], PROVIDER_PREVIEW) == DISCOVER_EXPECTED[case_id]
+
+
+class TestDialectContracts:
+    """The four dialects stay distinct — collapsing any two axes silently
+    changes some caller's accepted-input surface."""
+
+    def test_presets_are_distinct(self) -> None:
+        presets = [SKILL_LOADER, ONBOARDING_IMPORT, SKILL_UPDATE, PROVIDER_PREVIEW]
+        keys = {
+            (p.extraction, p.indent_policy, p.strip_quotes, p.first_key_wins,
+             p.resolve_block_scalars)
+            for p in presets
+        }
+        assert len(keys) == len(presets)
+
+    def test_presets_are_frozen(self) -> None:
+        with pytest.raises(AttributeError):
+            SKILL_LOADER.strip_quotes = False  # type: ignore[misc]
+
+    def test_first_key_wins_vs_last(self) -> None:
+        text = "---\nk: first\nk: second\n---\n"
+        assert frontmatter_value(text, "k", SKILL_UPDATE) == "first"
+        assert parse_frontmatter(text, SKILL_LOADER)["k"] == "second"
+
+    def test_quote_stripping_is_per_dialect(self) -> None:
+        text = '---\nk: "v"\n---\n'
+        assert parse_frontmatter(text, SKILL_LOADER)["k"] == "v"
+        assert parse_frontmatter(text, PROVIDER_PREVIEW)["k"] == '"v"'
+
+    def test_block_scalar_resolution_is_per_dialect(self) -> None:
+        text = "---\nk: |\n  content\n---\n"
+        assert parse_frontmatter(text, SKILL_LOADER)["k"] == "content"
+        assert parse_frontmatter(text, SKILL_UPDATE)["k"] == "content"
+        assert parse_frontmatter(text, PROVIDER_PREVIEW)["k"] == "|"
+        assert parse_frontmatter(text, ONBOARDING_IMPORT)["k"] == "|"
+
+    def test_quote_strip_never_applies_to_a_resolved_scalar(self) -> None:
+        # SKILL_LOADER strips quotes from plain values but a resolved block
+        # scalar keeps its content verbatim, quotes included.
+        text = '---\nk: |\n  "quoted"\n---\n'
+        assert parse_frontmatter(text, SKILL_LOADER)["k"] == '"quoted"'
+
+    def test_split_returns_text_unchanged_without_block(self) -> None:
+        for dialect in (SKILL_LOADER, ONBOARDING_IMPORT, SKILL_UPDATE, PROVIDER_PREVIEW):
+            assert split_frontmatter("plain prose", dialect) == ({}, "plain prose")
+
+    def test_custom_dialect_axes_compose(self) -> None:
+        # The parameterization is real, not four hardcoded paths: a novel
+        # combination behaves per its axes.
+        dialect = FrontmatterDialect(
+            extraction="column0_fence",
+            indent_policy="accept_indented",
+            strip_quotes=False,
+            first_key_wins=True,
+        )
+        text = "---\nk: 'a'\n  k: b\n---\n"
+        assert parse_frontmatter(text, dialect) == {"k": "'a'"}
+
+    def test_unknown_extraction_mode_fails_loud(self) -> None:
+        # A new Extraction literal without its own branch must raise, never
+        # silently inherit another mode's grammar.
+        bogus = FrontmatterDialect(
+            extraction="nonsense",  # type: ignore[arg-type]
+            indent_policy="accept_indented",
+            strip_quotes=False,
+        )
+        with pytest.raises(ValueError, match="unknown frontmatter extraction mode"):
+            parse_frontmatter("---\nk: v\n---\n", bogus)
+
+    def test_line_scan_body_is_the_only_renderable_body(self) -> None:
+        # line_scan's body contract: stripped text after the closer line.
+        # The other three modes' remainders are pinned here as NOT renderable:
+        # prefix_find's still begins with the closer token, and the two fence
+        # modes cut immediately after "---" — mid-line when the closer
+        # carries trailing text.
+        text = "---\nk: v\n---\nbody\n"
+        assert split_frontmatter(text, ONBOARDING_IMPORT)[1] == "body"
+        assert split_frontmatter(text, PROVIDER_PREVIEW)[1].startswith("\n---")
+        assert split_frontmatter(text, SKILL_LOADER)[1] == "\nbody\n"
+        assert split_frontmatter(text, SKILL_UPDATE)[1] == "\nbody\n"
+        junk_closer = "---\nk: v\n---junk\nbody\n"
+        assert split_frontmatter(junk_closer, SKILL_LOADER)[1] == "junk\nbody\n"
+        assert split_frontmatter(junk_closer, SKILL_UPDATE)[1] == "junk\nbody\n"


### PR DESCRIPTION
## What is the problem?

SKILL.md frontmatter is parsed by **four** hand-rolled scanners that have drifted apart — one more than the issue title counts:

1. `SkillsLoader._parse_frontmatter` — `src/kiro_crew/skills.py`
2. `onboarding_import._frontmatter` — `src/kiro_crew/onboarding_import.py`
3. `history._frontmatter_value` — `src/kiro_crew/history.py`
4. `dashboard/handlers/discover.py`'s provider-preview copy

Verified disagreements on current `main` (this supersedes the table in the issue — PR #3194 landed mid-flight and moved two rows):

| Aspect | skills.py | onboarding_import.py | history.py | discover.py |
|---|---|---|---|---|
| Opener | exact `---\n` at col 0 | `---` prefix (trailing text tolerated) | leading whitespace tolerated | `---` prefix + fixed offset-4 slice |
| Closer | line **starting with** `---` | **exact** `---` line (whitespace tolerated) | line starting with `---` | `\n---` prefix search |
| Indented `key:` lines | rejected (space and tab) | **accepted** | rejected | space rejected, **tab accepted** |
| Quote stripping | yes (`strip("\"'")`) | yes | no | no |
| Duplicate keys | last wins | last wins | **first wins** | last wins |
| Block scalars (`>`/`\|`) | resolved | indicator kept verbatim | resolved | indicator kept verbatim |

Every one of these differences is silently load-bearing somewhere, and nothing pinned them: an edit to one copy could not know what the other three depended on.

## Why this issue matters to the user

The four scanners guard user-facing behavior that must stay consistent: which skills the catalog routes on (`description`), whether an imported third-party skill can auto-activate (`always:`/`triggers:` — a fail-closed security screen), and what value a skill-update round-trip writes back over a live skill. Drift between copies is exactly how bugs like #3182 (block-scalar descriptions collapsing to `>`, making skills unroutable) appear in one reader and not another — and how a divergence can go unnoticed until it has a security consequence.

## How our fix solves it

Symptom → root cause → change: the scanners disagree because the *same logic* was re-implemented four times with no shared home and no oracle pinning any copy's grammar. The fix gives the logic exactly one home — `src/kiro_crew/frontmatter.py` — parameterized by an explicit, frozen `FrontmatterDialect` per caller (extraction mode, indent policy, quote stripping, duplicate-key resolution, block-scalar resolution). Each divergent behavior is now a **named axis**, not an accident:

- The four call sites become thin wrappers around `parse_frontmatter` / `split_frontmatter` / `frontmatter_value` with their historical signatures intact.
- `fold_block_scalar` and `BLOCK_SCALAR_INDICATORS` (added by #3194) move into the shared module **byte-identically**; `history.py` and `onboarding_import.py` import them from there instead of from `skills.py`.
- Each caller's accepted-input surface is preserved **byte for byte** — this is a refactor, not a behavior change. Deliberately unchanged: the loader keeps rejecting indented keys, the import screen keeps its leniency (both are load-bearing, per the dialect docstrings), and the import screen's stricter exact-`---` closer stays (a residual map-level divergence with no security consequence since #3194's `_column0_activation_declared` decides activation with the loader's region rules — see #3231, closed as fixed by #3194; the divergence is pinned in the corpus so any future change to it is a conscious decision).
- Deliberately NOT consolidated: `_column0_activation_declared` (an activation-decision mirror, not a general parser), and the two fence *locators* (`strip_frontmatter` / `_strip_skill_frontmatter`), which now carry cross-reference docstrings naming the coupling.
- No YAML library — the scope is collapsing four copies of hand-rolled logic; swapping parsing technology is #1825's conversation.
- An unknown extraction mode raises `ValueError` instead of falling through to the loosest grammar, and the field-only parse path skips the dead body allocation.

**Scope note:** #1825 (`SkillForm.tsx` frontend round-trip) is deliberately NOT in this PR — different language and runtime; this PR establishes the canonical backend contract the frontend can later adopt. It stays open as the follow-up.

## What tests we did

- **Snapshot oracle** (`test/test_frontmatter.py`, 147 tests): a 32-case corpus × 4 dialects, with every expectation **captured by executing the pre-consolidation parsers from `origin/main`** — including the discriminating cases for each axis (junk openers/closers, indented shadows, duplicate-key orderings crossed with block scalars, CRLF, 4-dash fences, the offset-4 slice quirks). Byte-identical output per caller is asserted through the real call sites, not just the shared module.
- **Mutation verification**: 16 hand-written dialect/scanner mutants (flip each preset axis, break key-stripping, un-strip the body, break literal folding, break scalar blank-line consumption) — 16/16 killed by the snapshot suite.
- **Divergence pins**: the two map-vs-loader divergences that justify the separate activation gate (`---junk` closer; indented-shadow overwrite) each get a three-way assertion (map result, loader result, `_column0_activation_declared` verdict) so erasing either divergence — or weakening the gate — fails a named test.
- **Full local gates**: isort / flake8 / mypy clean; full pytest run with the only failures (17) proven byte-identical on base `main` in isolated runs (host-environment: subagent/git/terminal sandboxing), zero in any touched module; #3194's new suites (`test_skills_frontmatter`, `test_onboarding_import_coverage`, `test_skill_update_flow`) all green.
- **Model-pinned pre-push review**: GPT (gpt-5.6-sol) mirror of the codex gate — no findings, per-call-site equivalence confirmed; Opus (claude-opus-5) mirror of the claude gate — no blocking, 4 advisories all adopted (the divergence pins, the reverse-duplicate corpus case, the dead body allocation, the fence-mode body pins), plus a focused verifier confirming closure.

## Manual verification

N/A — unit coverage sufficient: the snapshot corpus exercises the four real call sites end-to-end on the exact byte shapes that discriminate every grammar axis, and the gate interaction is pinned three ways.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only refactor; no frontend file is touched and no rendered surface changes.

Closes #3201
