### PR TITLE
feat(mcp): predict which MCP servers can safely share a backend

### DIFF
--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -188,6 +188,15 @@ Probes run from `POST /api/mcp/probe`:
   `_PROBE_TIMEOUT_SECS` is the fallback if config is not loaded yet). Results
   are cached for `_PROBE_TTL_SECS` (1800s), after which status reads as
   "outdated".
+- The handshake response is kept, not just the tool names: advertised
+  `capabilities`, the `protocolVersion` the server ANSWERED with, `serverInfo`,
+  and per-tool `annotations`. These feed the shareability verdict (below); the
+  probe already paid for the round-trip, so reading them costs nothing.
+- `client_info` overrides the identity sent in the handshake. The shareability
+  pre-flight uses it to ask one server under two identities; such a run is
+  excluded from the shared per-name probe cache, because a synthetic-identity
+  handshake is a diagnostic and not the canonical observation the dashboard
+  renders.
 - A probed stdio child that ignores a closed stdin costs
   `_PROBE_TEARDOWN_WAIT_SECS` twice (graceful wait, then again after SIGKILL)
   before the process-group reap, which is why that budget is a named constant
@@ -253,6 +262,19 @@ is not in the probe cache yet, so a freshly added server transitions from
 `list_servers()` call, because the stored absolute path goes stale after an
 update: first `agent._resolve_kirocrew_bin()`, then `shutil.which("kirocrew")`
 on the augmented PATH.
+
+## Shareability verdicts
+
+`GET /api/mcp-gateway/servers` returns a `recommendation` per row: whether the
+server looks safe to stub, and separately whether its backend looks safe to
+share. The verdict is derived on this host from evidence ranked
+observation > measurement > declaration, and a server the gateway has WATCHED
+behave per-client while shared is never offered again. Nothing about which
+servers a machine runs ships with Kiro Crew and nothing leaves the host.
+
+Full contracts — the two on-disk records, the reason-code vocabulary, what the
+pre-flight can and cannot decide, and the seed-once rule — live in
+[`docs/system-specs/modules/mcp-shareability.md`](../system-specs/modules/mcp-shareability.md).
 
 ## Dashboard MCP management
 

--- a/docs/system-specs/modules/README.md
+++ b/docs/system-specs/modules/README.md
@@ -70,6 +70,7 @@ agent loads only the one it needs.
 |---|---|
 | [app-kit-platform.md](app-kit-platform.md) | App contracts: MCP scoping, agent JSON composition, permissions, and dependencies. |
 | [mcp-apps.md](mcp-apps.md) | Apps that surface as MCP servers. |
+| [mcp-shareability.md](mcp-shareability.md) | Predicting which MCP servers can share one backend, from local evidence. |
 | [artifacts.md](artifacts.md) | Artifact identity, versioning, and the companion chat panel. |
 | [themes.md](themes.md) | The theme tier model and the CSS variable contract. |
 | [md-notebook.md](md-notebook.md) | The inline markdown viewer and editor. |

--- a/docs/system-specs/modules/mcp-shareability.md
+++ b/docs/system-specs/modules/mcp-shareability.md
@@ -1,0 +1,159 @@
+# MCP shareability (predicting which servers can share a backend)
+
+Deciding whether an MCP server may share one backend across sessions is a correctness question the operator was previously asked to answer with no information. This module answers it from evidence gathered on the host, provokes the failure before a session can be hurt by it, and remembers the answer so the cost is paid once.
+
+Nothing about which servers a machine runs ships with Kiro Crew and nothing leaves the host: shipped defaults are empty and every verdict is derived locally. That is why there is no curated list of server names in this repository — a list would both be wrong for most installs and be an inventory of the operator's tooling.
+
+## The ordering invariant
+
+Evidence is ranked, and the ranking is the load-bearing property. Strongest first:
+
+| Strength | Source | Meaning |
+|---|---|---|
+| `refuted` | `hazards` ledger | The gateway WATCHED this server behave per-client while shared. |
+| `disqualified` | pre-flight measurement, or a config/transport fact | Ruled out before any user is served. |
+| `declared` | the server's own `capabilities.experimental` | It says it was written for a pooled backend. |
+| `no_objection` | absence of any of the above | Nothing disqualifying was found — the weakest useful verdict. |
+| `unknown` | nothing observed | Not enough evidence to say anything. |
+
+A measurement always outranks a declaration, and an observation always outranks a measurement. Concretely: a server may advertise `kirocrew.caller-identity` and still be `disqualified` because the pre-flight caught it answering `initialize` differently per caller, and it may pass the pre-flight and still be `refuted` later. The engine (`mcp_gateway/shareability.py::assess`) is pure — no IO, no config, no clock — so this ordering is verified by unit tests rather than by inspection.
+
+`recommend_stub` and `recommend_share` are **separate outputs**. A stub keeps the backend 1:1 with the session (the same process topology as no gateway) and is what carries server-authored UI; sharing is the step that introduces co-tenancy. Weak evidence recommends the first and withholds the second.
+
+## What the pre-flight decides, and what it cannot
+
+`mcp_gateway/preflight.py` spawns the server twice with two different `clientInfo` identities and compares the SHAPE of the advertised capabilities — which keys exist and which boolean flags are set. Free-form leaf values (a build id, a session token) collapse to a presence marker, because their value is not part of the contract a pooled backend must keep identical; comparing raw objects would report every such server as caller-sensitive and make the check useless.
+
+Divergence is proof of caller sensitivity. This is the hazard `mcp_gateway/backend.py` documents when it caches the first stub's `initialize` result and replays it to later stubs, and which it describes as unverifiable at runtime — it is verifiable offline, which is the whole point of this module.
+
+`PreflightResult.ran` separates "answered no" from "could not ask". A server that needs a credential, a tunnel or a display this host lacks did not fail the check, and collapsing the two would mark much of a fleet unshareable. Callers MUST branch on `ran` before reading `caller_sensitive`.
+
+Not caught, deliberately: state that appears only after real work (a server that starts keying on the caller once someone authenticates) and behaviour that needs genuine concurrency. Those remain the ledger's job, which is why the ledger outranks the pre-flight rather than being its fallback.
+
+The pre-flight NEVER runs on a request path — it spawns processes — and never mutates the `McpServerInfo` it is given, so it cannot overwrite the status or tool list the dashboard is showing. A probe run under a synthetic identity is also excluded from the shared per-name probe cache, for the same reason.
+
+## Where the records live
+
+Both files sit in the gateway's per-host records directory, resolved by one
+helper (`rewriter.records_dir`) that BOTH the writer (gatewayd) and the reader
+(the dashboard) call:
+
+- a configured `mcp_gateway.socket_path` wins, so gatewayd's ledger lands beside
+  its real socket and the page reads the same place;
+- otherwise `$KIROCREW_HOME/mcp-gateway` — the directory the socket itself
+  defaults into.
+
+The fallback is load-bearing, not tidiness. `socket_path` is empty until a broker
+has been configured, and these records must exist BEFORE that: their whole
+purpose is to tell an operator who has **not** enabled stubbing whether it would
+be safe to. Deriving the directory from the socket made the feature inert for
+exactly its audience — no verdicts, no recommendation, ever.
+
+A bare `"."` counts as unset alongside the empty string, because `Path("")`
+constructs to `PosixPath(".")` and the two are indistinguishable afterwards;
+branching on truthiness alone would put the ledger in whatever directory the
+process happened to start in.
+
+## Durable contract 1 — observed-hazard ledger (schema v1)
+
+Path: `<records dir>/observed-hazards.json`, a sibling of `hot-keys.json`. Writer: gatewayd (`mcp_gateway/hazards.py`). Reader: the dashboard.
+
+```json
+{"schema": 1, "servers": {"<name>": {"codes": ["..."], "count": 3, "lastSeen": 1.0}}}
+```
+
+Codes are a closed vocabulary; an unknown code is refused on write and dropped on read, because a typo that silently became a permanent hazard would disqualify a server for ever with no way to read why:
+
+- `unroutable_server_request` — a server-initiated request arrived with no `relatedRequestId` while more than one stub shared the backend. Unroutable without a cross-tenant leak, so the backend is recycled.
+- `unattributable_notification` — a request-scoped notification could not be attributed to a pending call, so it was dropped rather than broadcast.
+
+Both are recorded ONLY for a shared backend (`exclusive_token` empty). A 1:1 backend legitimately owns its single client, so the same frame there proves nothing, and recording it would disqualify servers for behaviour that is correct when unshared.
+
+A missing, unreadable or future-schema file reads as "nothing observed" — never as "safe". Recording is in-memory and safe on the event loop; the flush is blocking IO and runs off-loop from the heartbeat sweep. Prior observations are reloaded when the sink is installed, so a daemon restart does not forget them.
+
+Because the flush runs off-loop while `record` keeps running ON it, an observation can land between building the payload and clearing the dirty flag. The generation counter is captured with the payload and dirty is cleared only if nothing moved in between: clearing unconditionally would drop that observation permanently, leaving the ledger looking clean while the file lacked the entry — a hazard the gateway actually saw that never withdraws a recommendation.
+
+## Durable contract 2 — local pre-flight cache (entry schema v1)
+
+Path: `<records dir>/shareability-verdicts.json`. Writer and reader: this host only; never shipped, never exported.
+
+```json
+{"entries": {"<key>": {"ran": true, "callerSensitive": false, "reasons": [], "evaluatedAt": 1.0}},
+ "applied": ["<server name>"]}
+```
+
+**Only the expensive measurement is cached, never the composite verdict.** The cheap evidence — declared env names, advertised capabilities, observed hazards — is re-read on every request and recombined by `assess`, so a hazard observed a minute ago changes the answer immediately without invalidating anything here. Caching the composite would go stale the moment the ledger grew an entry.
+
+An entry that cannot say whether the pre-flight `ran` is dropped on read: treating it as "ran" would fabricate evidence.
+
+**Entry key** is the execution identity, NUL-joined: `server_name`, `command_args_hash`, `env_hash`, `binary_version`, `SCHEMA`. Reusing the hashes `PoolKey` is built from means "the MCP was upgraded" or "its env changed" invalidates the measurement for free, and — because `hash_effective_env` drops secret keys — a credential rotation does NOT look like a different server here either. A name-keyed cache would keep serving a conclusion about a binary that no longer exists. `SCHEMA` is part of the key rather than a file-level version so a smarter pre-flight re-derives instead of inheriting, and a mixed-version rollout degrades to re-evaluation instead of a wipe.
+
+`binary_version` is the pool's own fingerprint (`stub.binary_fingerprint`), not a placeholder, and that matters for the **in-place upgrade**: same path, same args, new bytes. Without it the key hits, the pre-flight never re-runs, and a binary that BECAME caller-sensitive hands its first caller's `initialize` result to every co-tenant. Deferring that case to the hazard ledger is not equivalent — the ledger only fires after a session has already lost its tools, which is the outcome this feature exists to prevent.
+
+One row per configured server, keyed by NAME, with the execution identity stored as a field inside the row. Reading compares that field against the server's current identity and treats a mismatch as no measurement, so an upgraded binary or an edited command still forces a re-measurement. Keying by identity instead would make one server add a NEW row on every command edit and every binary upgrade, so the file would grow with config churn and need a size cap, an eviction policy, and a newest-wins rule for readers who only know a name; overwriting one row removes all three, and the row count follows the config rather than the history.
+
+**`applied` is keyed by NAME, not by execution identity** — deliberately. It records that a server's recommendation has already been written into config, and an operator who switched a server off must stay switched off across an upgrade of that server; an identity-keyed marker would re-flip it the moment the binary version changed. Applied markers are NOT pruned when a server disappears from config, because a server removed and re-added should not be seeded twice: it may have been removed precisely to stop it being stubbed.
+
+Absent or corrupt cache reads as empty, which costs a re-evaluation and never a wrong answer.
+
+## When evaluation happens, and what it costs
+
+`mcp_gateway/evaluate.py` owns the one policy question the layers below refuse to answer: which servers are worth paying for. Only servers whose stored measurement is missing or taken under a different identity are provoked, so the steady state is a file read and a newly installed MCP costs two spawns once. A single pass provokes at most **two** servers — four short-lived processes, fanned out under the prober's own concurrency ceiling — so a machine that just had twenty MCPs added covers them over ten probes instead of paying forty spawns inside one request. Until a server is measured it reads as `unknown`, which is the honest answer rather than a delay.
+
+It runs from `POST /api/mcp/probe` — the explicit action that already spawns every configured server — and never while rendering a page. A failure there is swallowed: the probe's own contract is status and tools, and a shareability problem must not cost the operator the answer they asked for.
+
+`MAX_EVALUATIONS_PER_PASS` (8) bounds one pass, so a machine that just had twenty MCPs added does not spend forty spawns inside one request; the remainder are evaluated on the next pass and read as `unknown` until then, which is the honest answer. A disabled server is never provoked — probing is the act consent gates.
+
+## The row builder does no IO
+
+`GET /api/mcp-gateway/servers` loads both records ONCE, off the event loop, before it builds any row; `_assess_server` is pure and takes the loaded state as arguments. Reading per row put N synchronous parses of the cache on the loop for an N-server config — enough to stall the dashboard and every chat sharing that loop — and it also let two rows in one payload disagree about the same file. Both properties are pinned by structural tests, because reproducing the stall needs a large config and a loaded host while the property itself is exact.
+
+## Seeding: designed, present, not yet wired
+
+`mcp_gateway/seed.py` turns verdicts into configuration, and it has **no production
+call site** — nothing on the startup path calls `plan_seed` or `apply_seed`, so a
+start does not change `mcp_gateway.stub_servers` today. The module and its tests
+ship ahead of that wiring because the wiring needs the config lock and deserves its
+own review; the section below is the contract it will honour when a caller exists,
+not behaviour a reader can observe now.
+
+Three properties, each chosen so the operator is not surprised:
+
+- **At start, never mid-run.** Nothing changes under a live session, so the failure this feature exists to prevent — a chat losing a server's tools because its backend was recycled — cannot happen as a side effect of seeding. No live re-apply path is needed either: `SessionManager.refresh_defaults` deliberately does not retrofit running sessions.
+- **Written into `mcp_gateway.stub_servers`, not acted on implicitly.** The MCP Management page renders that key, so materialising the verdict there is what makes the row's toggle show the true state. The operator sees the decision in a file they own. A gateway that routed differently from what the page claimed would be the dishonest alternative.
+- **Once per server.** After the first seed the config is the operator's; a later start that finds the same recommendation must not undo their choice.
+
+Seeding never turns the global `mcp_gateway.enabled` sharing switch on by itself. A recommendation to share is reported in `SeedPlan.wants_share` and left for a separate decision, because flipping that switch changes topology for every stubbed server, including ones stubbed for unrelated reasons.
+
+`plan_seed` is pure and returns a plan; `apply_seed` mutates a loaded config section and records the markers. The caller owns reading, locking and writing the file, so the same logic serves the tests and the gateway with no second implementation.
+
+## Reason codes
+
+`Reason` separates a stable `code` from a `detail`. The code is the enum-like vocabulary the UI translates; the detail carries verbatim observation — an env variable name, a capability path — and is NOT translated.
+
+That split is also the export contract. The telemetry layer requires low-cardinality enum-like attribute values and forbids user content, so any future aggregation may carry `code` and never `detail`: a server name or an env variable name must not leave the host. Remote aggregation is out of scope here; the OTLP path already exists and is opt-in and local-only by default.
+
+| Code | Strength | Ground |
+|---|---|---|
+| `observed_hazard` | refuted | Ledger entry; detail is the hazard code. |
+| `caller_sensitive_initialize` | disqualified | Pre-flight measured divergent capabilities. |
+| `not_stdio` | disqualified | No stdio pipe — out of scope, not unsafe. |
+| `first_party_session_scoped` | disqualified | A managed server bound to the session key. |
+| `rotating_secret_env` | disqualified | Declares an env name excluded from the pool key, so co-tenants can disagree on its value. Detail is the name. |
+| `per_client_capability` | disqualified | `resources.subscribe` or `logging`; detail names which. |
+| `not_probed` | unknown | No handshake was observed. |
+| `declares_caller_identity` | declared | Advertises the caller-identity extension. |
+| `preflight_passed` / `preflight_not_run` | declared | Whether the declaration has actually been tested. |
+| `all_tools_read_only` | supporting | Every tool declares `readOnlyHint`. Positive evidence only. |
+| `no_tool_annotations` | supporting | Annotations were unavailable; detail is the negotiated protocol version. |
+| `no_objection_found` | no_objection | Nothing disqualifying was found. |
+| `no_tools_listed` | supporting | `tools/list` produced nothing. |
+
+`*.listChanged` is deliberately absent from the disqualifiers: those notifications are global broadcasts (`backend._GLOBAL_BROADCAST_NOTIFICATIONS`) and are safe to fan out to every attached stub.
+
+Two DIFFERENT detection modes, because a capability and a flag inside one are different claims:
+
+- `resources.subscribe` is a **flag** — `{"subscribe": false}` is the server explicitly saying it does not subscribe, so truthiness is the right test and an explicit `false` must not count against it.
+- `logging` is a **capability** — in MCP an empty object is the standard way to advertise one that takes no sub-options, so `{"logging": {}}` means `logging/setLevel` IS supported, and that level is process-wide: one co-tenant's call changes what every other session receives. Presence is the right test.
+
+Tool annotations (`readOnlyHint` and friends) exist only from MCP 2025-03-26 onward, while the handshake negotiates `2024-11-05`. They are therefore treated as opportunistic positive evidence: present means something, absent means nothing. The negotiated version is deliberately unchanged — raising it alters real handshake semantics with third-party servers, which is a separate decision that should be made with data (the recorded `protocolVersion` is what will supply it).

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -17,11 +17,20 @@ from aiohttp import web
 from kiro_crew import platform_compat
 from kiro_crew.agent import _atomic_json_write, kiro_agents_dir_path, rebuild_agent_config
 from kiro_crew.atomic_write import atomic_write
-from kiro_crew.config.loader import _resolve_stub_servers
+from kiro_crew.config.loader import KiroCrewConfig, _resolve_stub_servers
 from kiro_crew.config.paths import data_home, kiro_agents_dir
 from kiro_crew.dashboard.state import DashboardState
-from kiro_crew.mcp_discovery import redact_mcp_error, redact_mcp_headers
-from kiro_crew.mcp_gateway import is_gateway_supported
+from kiro_crew.mcp_discovery import (
+    _MANAGED_SERVER_NAMES,
+    probe_metadata,
+    redact_mcp_error,
+    redact_mcp_headers,
+)
+from kiro_crew.mcp_gateway import hazards, is_gateway_supported
+from kiro_crew.mcp_gateway.hashing import hash_command
+from kiro_crew.mcp_gateway.rewriter import records_dir
+from kiro_crew.mcp_gateway.shareability import ShareEvidence, ShareVerdict, assess
+from kiro_crew.mcp_gateway.verdict_cache import load_cache
 from kiro_crew.mcp_provenance import ABSENT, resolve_write, stamp
 from kiro_crew.mcp_utils import (
     INTERNAL_CLIENT_ID_KEY,
@@ -475,7 +484,7 @@ async def _bg_mcp_probe() -> None:
             pass
 
         # Route through probe_all() so the fan-out is bounded by its
-        # _PROBE_MAX_CONCURRENCY semaphore. An
+        # PROBE_MAX_CONCURRENCY semaphore. An
         # unbounded gather here floods the loop's default executor during a
         # network blip and can starve the heartbeat into a watchdog _exit.
         probed = await probe_all()
@@ -662,6 +671,14 @@ async def api_mcp_probe(request: web.Request) -> web.Response:
     from kiro_crew.mcp_discovery import probe_all  # noqa: F811
 
     servers = await probe_all()
+    # The operator just asked us to spawn every configured server, which is the
+    # only moment the shareability pre-flight is affordable. Evaluate the ones
+    # whose execution identity has no cached measurement; failures here must not
+    # cost the probe its response, since status and tools are what was asked for.
+    try:
+        await _evaluate_shareability(servers)
+    except Exception:
+        logger.debug("shareability evaluation failed; probe result unaffected", exc_info=True)
     # Read global mcp.json for enabled/disabledTools state
     global_mcps: dict[str, Any] = {}
     try:
@@ -680,6 +697,27 @@ async def api_mcp_probe(request: web.Request) -> web.Response:
     _mcp_probe_cache[:] = result
     _mcp_probe_ts = time.time()
     return web.json_response(result)
+
+
+async def _evaluate_shareability(servers: list[Any]) -> None:
+    """Pre-flight any server whose execution identity has no cached measurement.
+
+    Separated from the endpoint so the probe's own contract — status and tools —
+    cannot be changed by a shareability failure.
+    """
+    # Imported HERE, not at module scope, and not because of a cycle: this module
+    # is on the gateway's boot path, and ``evaluate`` pulls in ``preflight`` ->
+    # ``mcp_discovery`` and ``stub`` (the stub PROCESS entry point). Measured on
+    # this tree, hoisting it put 8 extra modules on that path — enough to push a
+    # startup loop-responsiveness ceiling over on Windows. Nothing needs it until
+    # an operator explicitly probes.
+    from kiro_crew.mcp_gateway.evaluate import evaluate_new_servers
+
+    # Deliberately NOT gated on a configured broker: a machine that has never
+    # enabled stubbing is exactly the one that needs to learn whether it could.
+    await evaluate_new_servers(
+        list(servers), records_dir(KiroCrewConfig.load().mcp_gateway.socket_path)
+    )
 
 
 async def api_mcp_probe_cached(request: web.Request) -> web.Response:
@@ -2249,11 +2287,38 @@ async def api_mcp_gateway_servers(request: web.Request) -> web.Response:
                         "agents": set(),
                         "transport": "stdio" if "command" in entry else "http",
                         "entry_poolable": False,
+                        # Env NAMES only. The recommendation needs to know
+                        # whether a per-session rotating credential is declared;
+                        # it must never touch the values.
+                        "env_names": set(),
+                        # One hash per DISTINCT launch seen under this name. A
+                        # measurement belongs to one execution identity, and the
+                        # probe only ever runs the definition that won the merge,
+                        # so a second distinct launch here means the row covers
+                        # something nobody measured. Hashing is pure — no file is
+                        # opened, which is what keeps this row builder IO-free.
+                        "launch_ids": set(),
                     }
                     rows[name] = row
                 row["agents"].add(str(agent_name))
+                command = entry.get("command")
+                if isinstance(command, str) and command:
+                    args = entry.get("args")
+                    row["launch_ids"].add(
+                        hash_command(command, [str(a) for a in args] if isinstance(args, list) else [])
+                    )
                 if entry.get("poolable") is True:
                     row["entry_poolable"] = True
+                declared_env = entry.get("env")
+                if isinstance(declared_env, dict):
+                    row["env_names"].update(str(k) for k in declared_env)
+
+    # Both shareability files are read ONCE, off the event loop, before the row
+    # loop — and the row builder does no IO at all. Reading per row would put N
+    # synchronous parses on the loop for an N-server config, stalling the
+    # dashboard and every chat sharing it, and would also let two rows in one
+    # payload disagree about the same file.
+    observed, preflights = await asyncio.to_thread(_load_shareability_state)
 
     result: list[dict[str, Any]] = []
     for name in sorted(rows):
@@ -2282,9 +2347,96 @@ async def api_mcp_gateway_servers(request: web.Request) -> web.Response:
                 "agents": sorted(row["agents"]),
                 "transport": row["transport"],
                 "denylisted": denylisted,
+                # Advisory only. Never auto-applied: the evidence is weaker
+                # than proof (the probe handshakes as a different client than
+                # the gateway does), so the operator decides.
+                "recommendation": _assess_server(
+                    name,
+                    is_stdio=is_stdio,
+                    env_names=tuple(sorted(row["env_names"])),
+                    observed_hazards=observed.get(name, ()),
+                    # A measurement describes ONE execution identity. When this
+                    # name merged more than one distinct launch, the probe
+                    # measured whichever definition won the merge, so serving that
+                    # result here would tell the operator it is safe to share a
+                    # backend nobody ran. Same invariant the cache-side check
+                    # applies, enforced at the other place the information exists.
+                    preflight=(
+                        preflights.get(name) if len(row["launch_ids"]) <= 1 else None
+                    ),
+                ).to_dict(),
             }
         )
     return web.json_response({"servers": result})
+
+
+def _load_shareability_state() -> tuple[
+    dict[str, tuple[str, ...]], dict[str, tuple[bool, bool]]
+]:
+    """Read both shareability records for one response. BLOCKING — call off-loop.
+
+    Returns ``(hazards_by_name, preflight_by_name)`` where the preflight value is
+    ``(ran, caller_sensitive)``.
+
+    Absence is not an error and not a claim of safety: an empty map means nothing
+    has been observed or measured yet, which is exactly how
+    ``shareability.assess`` treats it.
+
+    Preflight rows are keyed by server NAME — one server, one row — so this is a
+    direct lookup. Identity is a field inside the row and is not checked here: this
+    builder is deliberately IO-free and cannot resolve a binary fingerprint, so a
+    server whose command just changed shows its previous measurement until the next
+    probe overwrites the row. Ambiguity that DOES matter — one name covering two
+    different launches in the merged agent config — is decided in the row loop,
+    where those definitions are visible.
+    """
+    try:
+        rt = records_dir(KiroCrewConfig.load().mcp_gateway.socket_path)
+        observed = hazards.load_ledger(rt).as_dict()
+        cache = load_cache(rt)
+    except OSError:
+        return {}, {}
+    preflights: dict[str, tuple[bool, bool]] = {}
+    for name in cache.server_names():
+        row = cache.get_by_name(name)
+        if row is not None:
+            preflights[name] = (row.ran, row.caller_sensitive)
+    return observed, preflights
+
+
+def _assess_server(
+    name: str,
+    *,
+    is_stdio: bool,
+    env_names: tuple[str, ...],
+    observed_hazards: tuple[str, ...],
+    preflight: tuple[bool, bool] | None,
+) -> ShareVerdict:
+    """Build evidence for one row and hand it to the verdict engine.
+
+    Pure: no IO, no config read, no clock. All the judgement lives in
+    ``shareability``; this function only gathers what the caller already loaded.
+    Probe metadata comes from the in-memory discovery cache rather than a fresh
+    probe — starting a server to render a table would spawn every configured MCP
+    on every page load, and probing is deliberately an explicit user action.
+    """
+    meta = probe_metadata(name)
+    return assess(
+        ShareEvidence(
+            name=name,
+            is_stdio=is_stdio,
+            is_first_party=name in _MANAGED_SERVER_NAMES,
+            probe_ok=bool(meta and meta.status == "ok"),
+            capabilities=meta.capabilities if meta else None,
+            protocol_version=meta.protocol_version if meta else "",
+            tool_annotations=list(meta.tool_annotations) if meta else [],
+            has_tools=bool(meta and meta.tools),
+            declared_env_names=env_names,
+            observed_hazards=observed_hazards,
+            preflight_ran=preflight[0] if preflight else None,
+            preflight_caller_sensitive=preflight[1] if preflight else False,
+        )
+    )
 
 
 async def api_mcp_gateway_set_stub(request: web.Request) -> web.Response:

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -330,6 +330,16 @@ class _ProbeResult:
     tools: list[str]
     error: str
     probed_at: float
+    # Handshake metadata, captured because the probe already pays for the
+    # ``initialize`` round-trip and threw the answer away. Consumed by
+    # ``mcp_gateway.shareability`` to decide whether to RECOMMEND stubbing.
+    capabilities: dict[str, Any] | None = None
+    protocol_version: str = ""
+    server_info: dict[str, Any] = field(default_factory=dict)
+    # ``annotations`` per tool, in ``tools/list`` order. Only servers speaking
+    # MCP 2025-03-26 or later can send these, so an empty list is "not
+    # available", never "declared nothing".
+    tool_annotations: list[dict[str, Any]] = field(default_factory=list)
 
 
 # Module-level probe cache: server name → result
@@ -353,6 +363,17 @@ def _get_cached(name: str) -> tuple[str, list[str], str]:
     return "outdated", cached.tools, ""
 
 
+def probe_metadata(name: str) -> _ProbeResult | None:
+    """The cached handshake metadata for *name*, or None if never probed.
+
+    Deliberately separate from ``_get_cached`` so adding evidence fields never
+    changes that function's tuple shape, and stale-but-present metadata stays
+    readable: an expired probe still tells the truth about what the server
+    advertised, and the caller decides whether age matters.
+    """
+    return _probe_cache.get(name)
+
+
 def _cache_probe(server: McpServerInfo) -> None:
     """Store probe result in cache.
 
@@ -367,6 +388,12 @@ def _cache_probe(server: McpServerInfo) -> None:
         tools=list(server.tools),
         error=redact_mcp_error(server.error, server.headers),
         probed_at=time.monotonic(),
+        capabilities=(
+            dict(server.capabilities) if isinstance(server.capabilities, dict) else None
+        ),
+        protocol_version=server.protocol_version,
+        server_info=dict(server.server_info),
+        tool_annotations=[dict(a) for a in server.tool_annotations],
     )
 
 
@@ -537,6 +564,16 @@ class McpServerInfo:
     # ``probe_server`` itself, so setting this flag is sufficient no matter which
     # entry point does the probing.
     disabled: bool = False
+    # -- handshake metadata (probe-only; empty on unprobed rows) -----------
+    # The server's advertised ``capabilities`` object, verbatim. ``None`` means
+    # no handshake happened, which is NOT the same as an empty declaration.
+    capabilities: dict[str, Any] | None = None
+    # The ``protocolVersion`` the server answered with — not the one requested.
+    # Tool annotations only exist from MCP 2025-03-26, so this is what makes
+    # their absence interpretable.
+    protocol_version: str = ""
+    server_info: dict[str, Any] = field(default_factory=dict)
+    tool_annotations: list[dict[str, Any]] = field(default_factory=list)
 
     @property
     def is_remote(self) -> bool:
@@ -1276,10 +1313,20 @@ async def _read_stdio_jsonrpc_response(
             return parsed
 
 
-async def probe_server(server: McpServerInfo) -> McpServerInfo:
+async def probe_server(
+    server: McpServerInfo, *, client_info: dict[str, str] | None = None
+) -> McpServerInfo:
     """Probe a single MCP server by spawning it and sending initialize.
 
     Updates server.status and server.tools in place and returns it.
+
+    *client_info* overrides the ``clientInfo`` sent in the handshake. The
+    shareability pre-flight uses it to ask the same server twice under two
+    identities: a server that negotiates its capabilities from ``clientInfo``
+    answers differently, and that is precisely the case a pooled backend cannot
+    serve — it caches the first stub's ``initialize`` result and replays it to
+    every later stub. Callers that just want status and tools omit it and keep
+    the probe's own identity.
 
     A consent-disabled server is refused HERE, ahead of the local/remote
     dispatch, because probing is the act that runs it: the local branch spawns
@@ -1390,7 +1437,9 @@ async def probe_server(server: McpServerInfo) -> McpServerInfo:
                     "params": {
                         "protocolVersion": "2024-11-05",
                         "capabilities": {},
-                        "clientInfo": {"name": "kirocrew-probe", "version": "1.0.0"},
+                        "clientInfo": dict(client_info)
+                        if client_info
+                        else {"name": "kirocrew-probe", "version": "1.0.0"},
                     },
                 }
             )
@@ -1422,6 +1471,21 @@ async def probe_server(server: McpServerInfo) -> McpServerInfo:
                 err.get("message", "unknown error") if isinstance(err, dict) else str(err)
             )
             return server
+
+        # Keep the handshake metadata the probe already paid for. Read from the
+        # server's ANSWER, never from what we asked for: a server may negotiate
+        # down to an older protocol version, and that answer is exactly what
+        # tells us whether tool annotations could have been sent at all.
+        init_result = resp.get("result") if isinstance(resp, dict) else None
+        if isinstance(init_result, dict):
+            caps = init_result.get("capabilities")
+            # An absent capabilities object and an empty one are different
+            # claims; only a dict counts as "the server declared something".
+            server.capabilities = caps if isinstance(caps, dict) else {}
+            version = init_result.get("protocolVersion")
+            server.protocol_version = version if isinstance(version, str) else ""
+            info = init_result.get("serverInfo")
+            server.server_info = info if isinstance(info, dict) else {}
 
         # Send initialized notification
         notif = (
@@ -1459,6 +1523,15 @@ async def probe_server(server: McpServerInfo) -> McpServerInfo:
             tools_data = result.get("tools", []) if isinstance(result, dict) else []
             server.tools = [
                 name for t in tools_data if isinstance(t, dict) and (name := t.get("name", ""))
+            ]
+            # ``annotations`` (MCP 2025-03-26+) is the only spec-native hint
+            # about whether a tool mutates anything. Collected as positive
+            # evidence only — a server on an older protocol version sends none,
+            # and that must never read as "this tool writes".
+            server.tool_annotations = [
+                ann
+                for t in tools_data
+                if isinstance(t, dict) and isinstance(ann := t.get("annotations"), dict)
             ]
         else:
             # initialize succeeded but tools/list yielded no response (banner
@@ -1638,7 +1711,11 @@ async def probe_server(server: McpServerInfo) -> McpServerInfo:
         if sandbox_cleanup:
             Path(sandbox_cleanup).unlink(missing_ok=True)
 
-    _cache_probe(server)
+    # A probe run under a SYNTHETIC identity must not become the cached truth:
+    # the per-name cache is what ``GET /api/mcp`` renders, and a pre-flight's
+    # second-identity handshake is a diagnostic, not the canonical observation.
+    if client_info is None:
+        _cache_probe(server)
     return server
 
 
@@ -1646,7 +1723,10 @@ async def probe_server(server: McpServerInfo) -> McpServerInfo:
 # subprocess (or opens a remote connection) and resolves DNS on the event
 # loop's default executor; an unbounded fan-out across 25+ servers floods that
 # pool during a network blip and stalls the loop.
-_PROBE_MAX_CONCURRENCY = 5
+PROBE_MAX_CONCURRENCY = 5
+#: Public because the shareability pre-flight bounds its own fan-out by the same
+#: number: those spawns land in this executor too, so two independent caps would
+#: let one pass flood the pool the other is protecting.
 
 
 async def probe_all() -> list[McpServerInfo]:
@@ -1678,7 +1758,7 @@ async def probe_all() -> list[McpServerInfo]:
         return []
     # Per-call semaphore: bounds the fan-out within this discovery pass while
     # binding to the currently-running loop (avoids import-time loop capture).
-    sem = asyncio.Semaphore(_PROBE_MAX_CONCURRENCY)
+    sem = asyncio.Semaphore(PROBE_MAX_CONCURRENCY)
 
     async def _guarded(s: McpServerInfo) -> McpServerInfo:
         async with sem:

--- a/src/kiro_crew/mcp_gateway/backend.py
+++ b/src/kiro_crew/mcp_gateway/backend.py
@@ -34,6 +34,7 @@ from kiro_crew.mcp_caller import (
     CallerContext,
     build_caller_meta,
 )
+from kiro_crew.mcp_gateway import hazards
 from kiro_crew.mcp_gateway.apps import (
     WithheldTools,
     append_marker,
@@ -1158,6 +1159,7 @@ class Backend:
                     "notification %r (not broadcast to avoid cross-tenant leak)",
                     self.pid, method,
                 )
+                self._record_hazard(hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION)
             return
         # Server-to-client request (has method AND id) — route ONLY when we can
         # attribute it unambiguously:
@@ -1201,10 +1203,38 @@ class Backend:
                     "cross-tenant leak — recycling"
                 )
                 logger.warning("backend pid=%s %s", self.pid, reason)
+                self._record_hazard(hazards.HAZARD_UNROUTABLE_SERVER_REQUEST)
                 self._dead_reason = self._dead_reason or reason
                 await self._broadcast_backend_gone(reason)
             return
         logger.debug("backend pid=%s emitted malformed JSON-RPC: %r", self.pid, msg)
+
+    def _record_hazard(self, code: str) -> None:
+        """Note that this server exhibited per-client behaviour while shared.
+
+        Only meaningful once MORE THAN ONE client is attached. A backend serving
+        a single client legitimately owns it, so an unattributable frame there
+        proves nothing: there is no second tenant it could have leaked to.
+        ``exclusive_token`` is not sufficient to express that — a pooled backend
+        also serves exactly one client from the moment it starts until a second
+        stub attaches, and recording during that window would disqualify a
+        server for behaviour that is correct.
+
+        Biased toward under-recording on purpose. A hazard is permanent and has
+        no redemption path, so a false one silently kills a server that is fine;
+        a missed one costs a withdrawal that the next observation makes again.
+
+        In-memory only — the flush is off-loop.
+        """
+        if self.exclusive_token or self.refcount <= 1:
+            return
+        name = self.pool_key.server_name
+        if name and hazards.record_observed(name, code):
+            logger.warning(
+                "hazard: server %r first exhibited %s while shared; the "
+                "MCP page will withdraw its recommendation",
+                name, code,
+            )
 
     async def _fail_init(self, reason: str) -> None:
         """Transition init to the terminal ``"failed"`` state and flush every

--- a/src/kiro_crew/mcp_gateway/evaluate.py
+++ b/src/kiro_crew/mcp_gateway/evaluate.py
@@ -1,0 +1,223 @@
+"""Run the pre-flight for servers whose verdict is missing or stale, and cache it.
+
+This is the orchestration the layers below deliberately do not do: ``preflight``
+knows how to provoke one server, ``verdict_cache`` knows how to remember, and
+``shareability`` knows how to judge. This module decides WHICH servers are worth
+paying for, which is a policy question and belongs in one place.
+
+The policy: evaluate only what changed. A server whose execution identity
+already has a cached verdict is skipped, so the steady-state cost of the whole
+feature is a file read. A newly installed or upgraded MCP costs two spawns,
+once.
+
+Never called while rendering anything. The pre-flight spawns processes, so this
+runs from the explicit probe action the operator already triggers — the same
+action that already spawns every configured server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+from kiro_crew.mcp_discovery import PROBE_MAX_CONCURRENCY
+from kiro_crew.mcp_gateway.hashing import hash_command, hash_effective_env
+from kiro_crew.mcp_gateway.preflight import preflight
+from kiro_crew.mcp_gateway.stub import binary_fingerprint
+from kiro_crew.mcp_gateway.verdict_cache import (
+    CachedPreflight,
+    Identity,
+    VerdictCache,
+    load_cache,
+    now,
+)
+
+logger = logging.getLogger(__name__)
+
+#: How many servers one pass will provoke. Each costs TWO spawns, so this is the
+#: real process budget for a single probe: two servers, four short-lived
+#: processes. Deliberately small — a machine that just had twenty MCPs added
+#: covers them over ten probes rather than paying forty spawns inside one
+#: request, and until a server is measured it reads as ``unknown``, which is the
+#: honest answer rather than a delay.
+MAX_EVALUATIONS_PER_PASS = 2
+
+#: Fan-out ceiling for the pre-flights in one pass, taken from the prober rather
+#: than chosen here: both spawn subprocesses and resolve names on the loop's
+#: default executor, so two independent caps would let this pass flood the pool
+#: the prober's own bound exists to protect.
+_PROBE_FAN_OUT = PROBE_MAX_CONCURRENCY
+
+
+def _assert_off_loop(what: str) -> None:
+    """Raise if called from the event loop thread.
+
+    The blocking work below is reached from a request handler, so an
+    accidentally synchronous call does not fail — it stalls every chat sharing
+    that loop for as long as the disk takes, which is invisible in tests and
+    surfaces only as a starvation failure under load. Raising converts that into
+    an immediate, attributable error.
+
+    Inside ``asyncio.to_thread`` there is no running loop in the worker thread,
+    so the correct call path passes, as does any synchronous caller.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    raise RuntimeError(f"{what} does blocking IO and must not run on the event loop")
+
+
+def identity_for(server: Any) -> Identity:
+    """Execution identity of *server*, using the hashes ``PoolKey`` is built from.
+
+    Stored inside the server's row rather than used as its key, so one server
+    keeps one row and a changed identity reads as "not measured" instead of
+    adding a second row.
+
+    Env is hashed by the same helper the pool uses, so the rotating-secret
+    exclusions apply identically — a credential rotation must not look like a
+    different server here either.
+
+    ``binary_version`` fingerprints everything the launch actually runs, not just
+    the executable. Most MCP servers are launched THROUGH an interpreter —
+    ``python server.py``, ``node server.js`` — so fingerprinting ``command``
+    alone identifies the interpreter, which does not change when the server's own
+    code is edited in place. The argv entries that resolve to real files are
+    fingerprinted too, so editing the script invalidates the verdict the way
+    replacing a compiled binary does. Without that, the most common shape of MCP
+    server keeps a stale measurement for ever: a server that BECAME
+    caller-sensitive would ship its first caller's ``initialize`` result to
+    everyone else, which is the outcome this identity exists to prevent.
+
+    BLOCKING IO: resolving the binary walks ``PATH``, and each fingerprint stats
+    and hashes bounded content. Call it from a worker thread.
+    """
+    _assert_off_loop("identity_for")
+    args = list(server.args or [])
+    env = getattr(server, "env", None)
+    return Identity(
+        command_args_hash=hash_command(server.command, args),
+        env_hash=hash_effective_env(
+            {str(k): str(v) for k, v in env.items()} if isinstance(env, dict) else {}
+        ),
+        binary_version=_launch_fingerprint(server.command, args),
+    )
+
+
+def _launch_fingerprint(command: str, args: list[str]) -> str:
+    """Fingerprint of the command plus every argv entry that names a real file.
+
+    Non-file arguments (flags, ports, module names) contribute nothing here —
+    they are already covered by ``hash_command``, which hashes argv verbatim.
+    What this adds is the CONTENT of the files argv points at, which argv itself
+    cannot express.
+
+    An argument that does not resolve to a readable file is skipped rather than
+    treated as empty, so a flag value that merely looks like a path does not make
+    the key unstable between passes.
+    """
+    parts = [binary_fingerprint(command)]
+    for arg in args:
+        if not arg or arg.startswith("-"):
+            continue
+        try:
+            if not Path(arg).is_file():
+                continue
+        except OSError:
+            continue
+        parts.append(binary_fingerprint(arg))
+    return "\u0000".join(parts)
+
+
+def _load_and_identify(
+    servers: list[Any], runtime_dir: Path
+) -> tuple[VerdictCache, dict[str, Identity]]:
+    """Read the cache and derive every execution identity in one worker thread.
+
+    These are one step, not two: the identity is what a stored row is validated
+    against, and deriving it is the more expensive half — a ``PATH`` walk plus a
+    bounded content hash per server, against a single file read. Splitting them
+    across the loop boundary is what left the costlier half on the loop.
+    """
+    return load_cache(runtime_dir), {s.name: identity_for(s) for s in servers}
+
+
+async def evaluate_new_servers(servers: list[Any], runtime_dir: Path) -> dict[str, CachedPreflight]:
+    """Pre-flight the servers with no current measurement; return every known one.
+
+    *servers* are ``McpServerInfo`` objects. Returns name -> verdict for every
+    server that has one, stored or freshly derived, so a caller can render
+    without a second lookup.
+
+    Nothing is deleted here. One server owns one row, so a row is replaced by its
+    own server's next measurement and by nothing else — there is no inventory to
+    compare against and no size to bound. That matters because the only caller's
+    list comes from ``probe_all``, which excludes consent-disabled rows by design:
+    any rule that deleted "servers not in this list" would discard the valid
+    measurement of every disabled server.
+
+    Every filesystem touch here is offloaded: this runs inside a request handler
+    on the gateway's event loop, and a slow disk would otherwise stall every chat
+    sharing that loop, not just this probe.
+    """
+    cache, identities = await asyncio.to_thread(_load_and_identify, servers, runtime_dir)
+
+    known: dict[str, CachedPreflight] = {}
+    due: list[Any] = []
+    budget = MAX_EVALUATIONS_PER_PASS
+    for server in servers:
+        hit = cache.get(server.name, identities[server.name])
+        if hit is not None:
+            known[server.name] = hit
+            continue
+        if getattr(server, "disabled", False) or not getattr(server, "command", ""):
+            # A disabled server must not be spawned (probing is the act consent
+            # gates), and a server with no command has no stdio pipe to stub.
+            continue
+        if budget <= 0:
+            continue
+        budget -= 1
+        due.append(server)
+
+    # Bounded fan-out, not a sequential walk. This is awaited by a request the
+    # operator is waiting on, and each pre-flight is two spawns that can each hit
+    # the probe timeout — serially that is the budget times two timeouts of dead
+    # wait, so one hung server used to make the whole pass feel hung. The cap is
+    # the prober's own, because the same executor and the same DNS resolution sit
+    # underneath: raising it here would flood the pool this bound exists to
+    # protect. Each pre-flight already spawns twice, so the real process ceiling
+    # is twice this number.
+    sem = asyncio.Semaphore(_PROBE_FAN_OUT)
+
+    async def _measure(server: Any) -> tuple[Any, Any]:
+        async with sem:
+            return server, await preflight(server)
+
+    for server, result in await asyncio.gather(*(_measure(s) for s in due)):
+        verdict = CachedPreflight(
+            ran=result.ran,
+            caller_sensitive=result.caller_sensitive,
+            reasons=result.reasons,
+            evaluated_at=now(),
+        )
+        if result.ran:
+            cache.put(server.name, identities[server.name], verdict)
+        else:
+            # A pre-flight that could not run says nothing about the server, only
+            # about the moment: a missing credential, an unreachable tunnel, a
+            # binary mid-install. Caching that keys the failure to an execution
+            # identity that has not changed, so the server would never be
+            # re-evaluated once the condition clears. Report it for this pass and
+            # pay the spawn again next time.
+            logger.info("shareability: %s could not be evaluated yet", server.name)
+        known[server.name] = verdict
+        logger.info(
+            "shareability: evaluated %s -> ran=%s caller_sensitive=%s",
+            server.name, result.ran, result.caller_sensitive,
+        )
+
+    await asyncio.to_thread(cache.flush)
+    return known

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -46,7 +46,7 @@ from kiro_crew.config.loader import config_dir as _config_dir
 from kiro_crew.executors import maintenance_executor, subprocess_executor
 from kiro_crew.mcp_caller import CallerContext
 from kiro_crew.mcp_caller import _parent_pid as _ppid_fn
-from kiro_crew.mcp_gateway import credwatch, socketsec, transport
+from kiro_crew.mcp_gateway import credwatch, hazards, socketsec, transport
 from kiro_crew.mcp_gateway.apps import sweep_spool as apps_sweep_spool
 from kiro_crew.mcp_gateway.backend import Backend, BackendGone, spawn_backend
 from kiro_crew.mcp_gateway.breaker import CircuitBreaker
@@ -69,6 +69,7 @@ from kiro_crew.mcp_gateway.rewriter import (
     env_sidecar_dir,
     env_sidecar_name,
     forward_declared_env_enabled,
+    records_dir,
     resolve_overlay_dir,
 )
 from kiro_crew.mcp_gateway.shutdown_budget import DRAIN_SECS, POOL_SHUTDOWN_SECS
@@ -365,6 +366,14 @@ async def run_gatewayd(
     hot_keys: Optional[HotKeyStore] = (
         HotKeyStore(default_hot_keys_path(socket_path)) if prewarm_count > 0 else None
     )
+
+    # Observed-hazard sink. Unconditional, unlike the hot-key store: this is
+    # how a server that misbehaves under sharing gets its recommendation
+    # withdrawn, and that must not depend on prewarming being enabled. Prior
+    # observations are loaded so a daemon restart does not forget them — and
+    # that read is offloaded, because a slow ledger store would otherwise delay
+    # socket readiness and every task already on this loop.
+    await asyncio.to_thread(hazards.install_sink, records_dir(socket_path))
 
     async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         task = asyncio.current_task()
@@ -1014,10 +1023,24 @@ async def _heartbeat_sweeper(
                     pids = "\n".join(str(p) for p in pool.live_backend_pids())
                     with contextlib.suppress(OSError):
                         await asyncio.to_thread(backends_pidfile.write_text, pids)
+                # Persist any per-client behaviour observed since the last
+                # sweep. Offloaded for the same reason as the pidfile write,
+                # and cheap when nothing was observed (the flush is a no-op
+                # unless the in-memory ledger is dirty).
+                await asyncio.to_thread(hazards.flush_sink)
             except Exception:  # pragma: no cover — defensive
                 logger.exception("heartbeat sweep failed; continuing")
     except asyncio.CancelledError:
         pass
+    finally:
+        # The periodic flush above only persists what was observed before the
+        # last tick. A clean shutdown cancels this task, so anything observed in
+        # the final interval would be lost — and a hazard is the strongest
+        # evidence the system has, so losing one means a server that misbehaved
+        # keeps its recommendation until it misbehaves again. Shutdown is the
+        # ordinary path here, not the exceptional one, so it flushes as well.
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(hazards.flush_sink)
 
 
 #: Number of stub writers currently inside their write+drain critical section

--- a/src/kiro_crew/mcp_gateway/hazards.py
+++ b/src/kiro_crew/mcp_gateway/hazards.py
@@ -1,0 +1,253 @@
+"""Record, per server, the moments a shared backend betrayed per-client state.
+
+The gateway already detects two behaviours that PROVE a server is not safe to
+share, and today it only debug-logs them:
+
+* a server-initiated request with no ``relatedRequestId`` while more than one
+  stub is attached — unroutable without a cross-tenant leak, so the backend is
+  recycled;
+* a request-scoped notification that cannot be attributed to a pending call —
+  dropped rather than broadcast.
+
+Both are observations of real traffic, which makes them the strongest evidence
+this system can have, and strictly better than any declaration a server makes
+about itself. This ledger is what carries them out of gatewayd's memory so the
+dashboard can withdraw a recommendation it previously made.
+
+Design constraints this shape satisfies
+---------------------------------------
+* **Cross-process.** The observer is gatewayd; the reader is the dashboard, a
+  different process. A file is the only channel they already share, and
+  ``hot-keys.json`` in this same directory is the precedent.
+* **Never blocks the loop.** Callers record into memory synchronously and flush
+  off-loop. A hazard that is only in memory is still correct for the current
+  process; losing the last flush costs a recommendation withdrawal, never
+  correctness of routing.
+* **Monotonic, and bounded.** Hazards accumulate but the per-server record is
+  collapsed to a set of codes plus a count and a last-seen wall clock, so the
+  file cannot grow with traffic.
+* **Never fabricates.** A missing or corrupt file reads as "no hazards
+  observed", which is the truth: we have not seen one. It does NOT read as
+  "safe" — safety is decided by ``shareability.assess``, which treats absence
+  of hazards as absence of evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.mcp_gateway.record_json import finite_float
+
+logger = logging.getLogger(__name__)
+
+HAZARDS_FILENAME = "observed-hazards.json"
+
+# Stable codes. These are the vocabulary the UI translates, so they are part of
+# the contract and must not be renamed without updating the catalogs.
+HAZARD_UNROUTABLE_SERVER_REQUEST = "unroutable_server_request"
+HAZARD_UNATTRIBUTABLE_NOTIFICATION = "unattributable_notification"
+
+_KNOWN_HAZARDS = frozenset(
+    {HAZARD_UNROUTABLE_SERVER_REQUEST, HAZARD_UNATTRIBUTABLE_NOTIFICATION}
+)
+
+_SCHEMA = 1
+
+
+@dataclass
+class _Record:
+    codes: set[str] = field(default_factory=set)
+    count: int = 0
+    last_seen: float = 0.0
+
+
+class HazardLedger:
+    """Per-server hazard observations, persisted as one small JSON object.
+
+    Not thread-safe by design: gatewayd records from its event loop, and the
+    dashboard only ever reads. A reader that races a writer sees either the old
+    or the new file because the write is atomic — never a torn one.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._records: dict[str, _Record] = {}
+        self._dirty = False
+        # Bumped by every ``record``. ``flush`` captures it alongside the payload
+        # so a concurrent observation cannot be marked persisted.
+        self._generation = 0
+        # Held across a whole flush. More than one caller flushes (the periodic
+        # sweep and the shutdown path), both from worker threads, so without this
+        # the later WRITE can carry the earlier READ and revert what is on disk.
+        self._flush_lock = threading.Lock()
+
+    # -- writer side (gatewayd) ------------------------------------------
+
+    def record(self, server_name: str, code: str) -> bool:
+        """Note that *server_name* exhibited *code*. Returns True if new.
+
+        Unknown codes are refused rather than stored: the vocabulary is a
+        contract with the UI, and a typo that silently became a permanent
+        "hazard" would disqualify a server forever with no way to read why.
+        """
+        if code not in _KNOWN_HAZARDS:
+            logger.warning("hazards: refusing unknown code %r for %r", code, server_name)
+            return False
+        if not server_name:
+            return False
+        rec = self._records.setdefault(server_name, _Record())
+        is_new = code not in rec.codes
+        rec.codes.add(code)
+        rec.count += 1
+        rec.last_seen = time.time()
+        self._dirty = True
+        self._generation += 1
+        return is_new
+
+    def flush(self) -> None:
+        """Persist if anything changed. Safe to call often; cheap when clean.
+
+        Serialized end to end, because there is more than one flush caller and
+        they run in worker threads. The periodic sweep and the shutdown flush can
+        overlap — cancellation starts the second while the first is mid-write —
+        and each builds its payload from the in-memory records before writing. Two
+        unsynchronised flushes therefore race, and the one that happens to write
+        last wins even if it read an OLDER snapshot, silently reverting an
+        observation that was already on disk. Holding the lock across build AND
+        write makes the last writer the last reader too.
+
+        The generation guard inside handles the other direction: ``record`` runs
+        ON the event loop while this runs off it, so an observation can land
+        between the payload being built and the dirty flag being cleared.
+        Clearing unconditionally would mark it persisted and lose it for good, so
+        dirty is cleared only when nothing moved in between.
+        """
+        with self._flush_lock:
+            if not self._dirty:
+                return
+            generation = self._generation
+            payload: dict[str, Any] = {
+                "schema": _SCHEMA,
+                "servers": {
+                    name: {
+                        "codes": sorted(rec.codes),
+                        "count": rec.count,
+                        "lastSeen": rec.last_seen,
+                    }
+                    for name, rec in sorted(self._records.items())
+                },
+            }
+            try:
+                atomic_write(self._path, json.dumps(payload, indent=2) + "\n")
+            except OSError as exc:
+                # A ledger we cannot persist must not take the daemon down: the
+                # in-memory copy still guards this process, and the cost of the
+                # failure is a stale recommendation, not a routing error.
+                logger.warning("hazards: could not write %s: %s", self._path, exc)
+                return
+            if self._generation == generation:
+                self._dirty = False
+
+    # -- reader side (dashboard) -----------------------------------------
+
+    def load(self) -> None:
+        """Read the file into memory. Absence and corruption both mean empty."""
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            # Same gap as the verdict cache, but this loader runs from
+            # ``install_sink`` during gatewayd startup, so an uncaught decode
+            # error keeps the daemon from binding at all.
+            logger.warning("hazards: ignoring unreadable %s: %s", self._path, exc)
+            return
+        if not isinstance(raw, dict) or raw.get("schema") != _SCHEMA:
+            # A future schema is not an error and not a hazard — a newer writer
+            # simply knows more than this reader. Reading it as "no hazards"
+            # loses a withdrawal; guessing at its shape would invent one.
+            return
+        servers = raw.get("servers")
+        if not isinstance(servers, dict):
+            return
+        for name, entry in servers.items():
+            if not isinstance(name, str) or not isinstance(entry, dict):
+                continue
+            codes = entry.get("codes")
+            if not isinstance(codes, list):
+                continue
+            kept = {c for c in codes if isinstance(c, str) and c in _KNOWN_HAZARDS}
+            if not kept:
+                continue
+            count = entry.get("count")
+            last = entry.get("lastSeen")
+            self._records[name] = _Record(
+                codes=kept,
+                count=count if isinstance(count, int) and count >= 0 else len(kept),
+                last_seen=finite_float(last),
+            )
+
+    def codes_for(self, server_name: str) -> tuple[str, ...]:
+        """Hazard codes observed for *server_name*, oldest-agnostic, sorted."""
+        rec = self._records.get(server_name)
+        return tuple(sorted(rec.codes)) if rec else ()
+
+    def as_dict(self) -> dict[str, tuple[str, ...]]:
+        return {name: tuple(sorted(rec.codes)) for name, rec in self._records.items()}
+
+
+def ledger_path(runtime_dir: Path) -> Path:
+    """Sibling of ``hot-keys.json`` in the gateway runtime directory."""
+    return runtime_dir / HAZARDS_FILENAME
+
+
+def load_ledger(runtime_dir: Path) -> HazardLedger:
+    """Read-only convenience for the dashboard side."""
+    ledger = HazardLedger(ledger_path(runtime_dir))
+    ledger.load()
+    return ledger
+
+
+# -- process-wide sink (gatewayd) ----------------------------------------
+#
+# The observation sites sit deep in per-request routing, where threading a
+# ledger handle through every frame would touch code that has nothing to do
+# with this feature. A process-global sink is the same ownership shape the
+# daemon already uses for its hot-key store, and the default is a no-op so
+# unit tests and the stub process never need to install anything.
+
+_sink: HazardLedger | None = None
+
+
+def install_sink(runtime_dir: Path) -> HazardLedger:
+    """Bind the process-wide sink. Called once by gatewayd at startup."""
+    global _sink
+    _sink = HazardLedger(ledger_path(runtime_dir))
+    _sink.load()  # keep prior observations; a restart must not forget them
+    return _sink
+
+
+def record_observed(server_name: str, code: str) -> bool:
+    """Note a hazard on the process sink. In-memory only; never touches disk.
+
+    Safe to call from the event loop precisely because it does no IO — the
+    flush is a separate, off-loop step. Returns True when this is the first
+    time *code* was seen for *server_name*, so a caller can log it once at a
+    louder level than the per-occurrence debug line.
+    """
+    if _sink is None:
+        return False
+    return _sink.record(server_name, code)
+
+
+def flush_sink() -> None:
+    """Persist the sink. Blocking IO — call via ``asyncio.to_thread``."""
+    if _sink is not None:
+        _sink.flush()

--- a/src/kiro_crew/mcp_gateway/preflight.py
+++ b/src/kiro_crew/mcp_gateway/preflight.py
@@ -1,0 +1,179 @@
+"""Provoke, before any user is served, the failure that sharing would cause.
+
+Waiting for a shared backend to misbehave means a real session pays: the
+affected chat loses that server's tools until it is reopened. This module
+anticipates instead. It asks the question the pool will ask later — "does this
+server behave the same for every caller?" — while nobody is attached.
+
+The check that matters, and why it is decidable
+----------------------------------------------
+``Backend`` caches the first stub's ``initialize`` result and replays it to every
+later stub, and its own docstring says the MCP spec does not require a server to
+answer ``initialize`` the same way twice: a server that negotiates capabilities
+from ``clientInfo`` would silently hand session B session A's capability set.
+That is documented there as an assumption the gateway cannot verify at runtime.
+
+It IS verifiable offline. Spawn the server twice under two different
+``clientInfo`` identities and compare what it advertises. Divergence is proof of
+caller sensitivity; agreement is strong evidence against it. Two sequential
+spawns, no broker, no synthetic co-tenancy.
+
+What this does NOT catch, on purpose
+------------------------------------
+State that only appears after real work (a server that starts keying on the
+caller only once someone authenticates), and behaviour that needs genuine
+concurrency. Those stay the ``hazards`` ledger's job — which is why the ledger
+outranks anything decided here rather than being a fallback for it.
+
+Cost
+----
+Two spawns per evaluated server, and only for servers whose execution identity
+changed (see ``verdict_cache``). Never on the request path: probing spawns
+processes, and this module is called from an explicit action or a background
+pass, never while rendering a page.
+"""
+
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+from kiro_crew.mcp_discovery import probe_server
+
+logger = logging.getLogger(__name__)
+
+#: Two identities that differ in every field a server could branch on. Distinct
+#: names AND versions, so a server keying on either is caught.
+#:
+#: Three constraints on the pair, all load-bearing:
+#:
+#: * Neither may be a name a real product owns. A probe that presents itself as
+#:   somebody else's tool is misattributed in that server's own logs and policy,
+#:   and it measures the wrong thing: a server that unlocks diagnostic
+#:   capabilities for a debugging client would read as caller-sensitive on a
+#:   difference the gateway will never provoke.
+#: * They must share no substring a server would plausibly key on — not the
+#:   vendor name, not ``preflight``. Two identities that both look like us would
+#:   answer alike at a server that personalises per vendor, and the divergence
+#:   would go unseen.
+#: * The names are imported by the real-server test, which branches on them by
+#:   equality. Renaming one here without updating that fixture makes the fixture
+#:   stop diverging; keep them exported rather than duplicated.
+_IDENTITY_A: dict[str, str] = {"name": "kirocrew-preflight-a", "version": "1.0.0"}
+_IDENTITY_B: dict[str, str] = {"name": "mcp-client-b", "version": "9.9.9"}
+
+#: The pair, for the real-server test to branch on by equality.
+PREFLIGHT_IDENTITY_NAMES: tuple[str, str] = (_IDENTITY_A["name"], _IDENTITY_B["name"])
+
+#: Reason codes this module can contribute. Kept here (not in ``shareability``)
+#: because they describe how the evidence was OBTAINED, and the verdict engine
+#: only needs to know they are disqualifying.
+REASON_CALLER_SENSITIVE_INIT = "caller_sensitive_initialize"
+REASON_PREFLIGHT_UNAVAILABLE = "preflight_unavailable"
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    """What the pre-flight learned. ``ran`` separates "no" from "could not ask".
+
+    A server that refuses to start in this environment — needs a credential, a
+    tunnel, a display — is NOT a server that failed the check, and collapsing
+    the two would silently mark half a fleet unshareable. Callers must branch on
+    ``ran`` before reading ``caller_sensitive``.
+    """
+
+    ran: bool
+    caller_sensitive: bool = False
+    #: Verbatim capability objects from each identity, kept for the diagnostic
+    #: surface. Never emitted as telemetry — they are free-form server data.
+    capabilities_a: dict[str, Any] | None = None
+    capabilities_b: dict[str, Any] | None = None
+    detail: str = ""
+
+    @property
+    def reasons(self) -> tuple[str, ...]:
+        if not self.ran:
+            return (REASON_PREFLIGHT_UNAVAILABLE,)
+        if self.caller_sensitive:
+            return (REASON_CALLER_SENSITIVE_INIT,)
+        return ()
+
+
+def _capability_shape(capabilities: dict[str, Any] | None) -> Any:
+    """A comparable projection of an advertised capability object.
+
+    Compares the SHAPE — which capability keys exist and which flags are on —
+    rather than the whole object, because a conformant server may legitimately
+    vary free-form ``experimental`` payloads (a build id, a session token) that
+    say nothing about caller sensitivity. Comparing raw dicts would report every
+    such server as caller-sensitive and the check would be useless.
+    """
+    if capabilities is None:
+        return None
+
+    def project(node: Any) -> Any:
+        if isinstance(node, dict):
+            return {k: project(v) for k, v in sorted(node.items())}
+        if isinstance(node, bool):
+            return node
+        # Any other leaf collapses to a presence marker: its VALUE is not part
+        # of the contract a pooled backend has to keep identical.
+        return "*"
+
+    return project(capabilities)
+
+
+async def preflight(server: Any) -> PreflightResult:
+    """Run the shareability pre-flight for one configured server.
+
+    *server* is an ``McpServerInfo``. It is NOT mutated: this function probes
+    copies, so a pre-flight can never overwrite the status or tool list the
+    dashboard is showing.
+    """
+
+    async def ask(identity: dict[str, str]) -> Any:
+        probe = deepcopy(server)
+        await probe_server(probe, client_info=identity)
+        return probe
+
+    try:
+        first = await ask(_IDENTITY_A)
+    except Exception as exc:  # pragma: no cover - defensive; probe owns its errors
+        logger.debug("preflight %s: first handshake raised: %s", server.name, exc)
+        return PreflightResult(ran=False, detail="probe_error")
+
+    if first.status != "ok":
+        # Could not start it. Says nothing about shareability.
+        return PreflightResult(ran=False, detail=first.error or first.status)
+
+    try:
+        second = await ask(_IDENTITY_B)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("preflight %s: second handshake raised: %s", server.name, exc)
+        return PreflightResult(ran=False, detail="probe_error")
+
+    if second.status != "ok":
+        # It answered once and not twice. That is a flaky or single-shot server,
+        # not a proven caller-sensitive one — and pooling it would be a bad idea
+        # for a different reason, so report "could not ask" rather than inventing
+        # a verdict this evidence does not support.
+        return PreflightResult(ran=False, detail=second.error or second.status)
+
+    shape_a = _capability_shape(first.capabilities)
+    shape_b = _capability_shape(second.capabilities)
+    diverged = shape_a != shape_b
+    if diverged:
+        logger.info(
+            "preflight %s: advertises different capabilities per clientInfo; "
+            "not shareable",
+            server.name,
+        )
+    return PreflightResult(
+        ran=True,
+        caller_sensitive=diverged,
+        capabilities_a=first.capabilities,
+        capabilities_b=second.capabilities,
+        detail="capability_shape_differs" if diverged else "",
+    )

--- a/src/kiro_crew/mcp_gateway/record_json.py
+++ b/src/kiro_crew/mcp_gateway/record_json.py
@@ -1,0 +1,40 @@
+"""Coercion for values read out of the gateway's on-disk record files.
+
+The hazard ledger and the verdict cache are both JSON files in the runtime
+directory, and both are loaded during gateway startup. Neither is a protocol
+message, so nothing upstream validates them: anything that can write the
+runtime directory decides what these loaders parse. A loader that raises
+therefore takes the daemon down before it binds its socket, and a loader that
+accepts a non-finite number stores a timestamp no comparison can order.
+
+Both files reach the same values through the same shapes, so the coercion lives
+here once rather than in each loader.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+def finite_float(value: Any, fallback: float = 0.0) -> float:
+    """*value* as a finite float, or *fallback* if it cannot be one.
+
+    ``isinstance(value, (int, float))`` is not sufficient to make ``float()``
+    safe. JSON parses a bare number with no decimal point into ``int``, which
+    has no size limit, and ``float()`` of a large enough one raises
+    ``OverflowError`` — an ``ArithmeticError``, so a guard spelled
+    ``except (TypeError, ValueError)`` does not catch it.
+
+    Non-finite results are rejected for the same reason, one step later: the
+    string form of that number converts to ``inf`` without raising, and an
+    ``inf`` timestamp is never older than anything, so an entry carrying one
+    would never expire.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return fallback
+    try:
+        as_float = float(value)
+    except (OverflowError, ValueError):
+        return fallback
+    return as_float if math.isfinite(as_float) else fallback

--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -6,8 +6,10 @@ filesystem remains untouched — the broker stubs in these specs are injected
 into each kiro-cli session over ACP ``session/new``, which outranks the
 same-named entry in the agent spec (see ``session_servers.py``).
 
-Servers in :data:`UNPOOLABLE_SERVERS` are left unwrapped because they bind
-to ``KIROCREW_SESSION_KEY`` and cannot be safely shared across sessions.
+Servers in :data:`UNPOOLABLE_SERVERS` are left unwrapped. The set is empty, so
+nothing is excluded through it; the first-party servers that bind
+``KIROCREW_SESSION_KEY`` stay unwrapped only because nothing lists them in the
+stub allowlist.
 
 The rewrite is fingerprint-cached: a content-signature snapshot of every input is
 kept at ``<overlay_dir>/.rewrite-fingerprint``, and a boot whose inputs all
@@ -86,11 +88,15 @@ _WHICH_KEY_SEP = "\0"
 
 # Reserved for MCP servers that explicitly opt out of the broker even
 # when they could support it (e.g. dev/diagnostic servers that want the
-# operator to see one process per session). The preferred signalling path is
-# a backend NOT advertising ``kirocrew.caller-identity`` in its initialize
-# response — gatewayd then refuses to pool it. This hardcoded set exists
-# only for servers that cannot be changed in lockstep (e.g. third-party MCPs
-# shipped by teams that haven't adopted the caller-identity extension yet).
+# operator to see one process per session).
+#
+# Empty, and nothing is excluded through it today. The intended signalling path
+# — a backend that does not advertise ``kirocrew.caller-identity`` in its
+# initialize response being refused for pooling — is NOT implemented: gatewayd
+# parses that capability only to decide whether to inject caller identity, and
+# no code path declines to pool a backend for lacking it. So this set is the
+# only mechanism of its kind that exists, and it is the one to reach for while
+# that is true, not a fallback for servers that cannot adopt the extension.
 UNPOOLABLE_SERVERS: frozenset[str] = frozenset()
 
 # Marker field set on rewritten MCP entries so repeat runs are idempotent.
@@ -1503,8 +1509,44 @@ def forward_declared_env_enabled() -> bool:
         return False
 
 
-def default_socket_path() -> Path:
-    """Return the default gateway unix socket path."""
+def runtime_dir() -> Path:
+    """Directory holding the gateway's per-host runtime records.
+
+    Derived from the data home, NOT from ``mcp_gateway.socket_path``. That field
+    is empty until the broker has been configured, and the shareability records
+    have to exist BEFORE that: their whole purpose is to tell an operator who has
+    not enabled stubbing yet whether it is safe to. Keying off the socket made
+    the feature inert for exactly the audience it serves.
+
+    Same directory the socket itself defaults into, so when a broker does run its
+    files sit alongside these.
+    """
     home = os.environ.get("KIROCREW_HOME")
     base = Path(home) if home else config_dir()
-    return base / "mcp-gateway" / "gateway.sock"
+    return base / "mcp-gateway"
+
+
+def default_socket_path() -> Path:
+    """Return the default gateway unix socket path."""
+    return runtime_dir() / "gateway.sock"
+
+
+def records_dir(socket_path: str | Path = "") -> Path:
+    """Where per-host gateway records live, for BOTH the writer and the reader.
+
+    gatewayd writes next to its actual socket; the dashboard has to read the same
+    place, and it may run when no socket is configured at all. One resolver keeps
+    those two from diverging — a custom ``socket_path`` would otherwise have the
+    daemon writing the hazard ledger somewhere the page never looks.
+
+    Emptiness is tested on the STRING form, and a bare ``"."`` counts as unset:
+    ``Path("")`` constructs to ``PosixPath(".")``, so an empty Path is
+    indistinguishable from an explicit one and branching on truthiness alone
+    would resolve an unconfigured socket to the current working directory.
+    A real relative socket (``./gateway.sock``) is unaffected — its string form
+    is the filename, not ``"."``.
+    """
+    as_str = str(socket_path or "")
+    if not as_str or as_str == ".":
+        return runtime_dir()
+    return Path(as_str).parent

--- a/src/kiro_crew/mcp_gateway/seed.py
+++ b/src/kiro_crew/mcp_gateway/seed.py
@@ -1,0 +1,114 @@
+"""Turn cached verdicts into config, once per server, at start.
+
+Two decisions shape this module, and both are about not surprising the operator.
+
+**It applies at start, never mid-run.** Nothing changes under a live session, so
+the failure this whole feature exists to prevent — a chat losing a server's tools
+because its backend was recycled — cannot happen as a side effect of seeding. It
+also means no live re-apply path is needed: ``refresh_defaults`` deliberately
+does not retrofit running sessions anyway.
+
+**It writes the value into config rather than acting on it implicitly.** The MCP
+Management page renders ``mcp_gateway.stub_servers``, so materialising the
+verdict there is what makes the row's toggle show the real state. The operator
+sees what was decided, in a file they own, and can switch it off — which is a
+different thing from a gateway that quietly routes differently than the page
+claims.
+
+**And it applies to each server exactly once.** After the first seed the config
+is the operator's. A later start that found the same recommendation must not
+re-flip a switch they turned off; the applied marker in ``verdict_cache`` is what
+makes "off" stick.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from kiro_crew.mcp_gateway.verdict_cache import VerdictCache
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SeedPlan:
+    """What seeding would change. Empty is the steady state, not a failure."""
+
+    #: Server names to add to ``mcp_gateway.stub_servers``.
+    add_stub: tuple[str, ...] = ()
+    #: Names seeded this pass, to be marked applied once the write succeeds.
+    mark_applied: tuple[str, ...] = ()
+    #: Whether any recommendation asked for sharing. Reported so a caller can
+    #: decide about ``mcp_gateway.enabled`` separately — this module never turns
+    #: the global sharing switch on by itself, because that is a topology change
+    #: over servers the operator may have stubbed for other reasons entirely.
+    wants_share: tuple[str, ...] = ()
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.add_stub and not self.mark_applied
+
+
+def plan_seed(
+    *,
+    cache: VerdictCache,
+    verdicts: dict[str, tuple[bool, bool]],
+    current_stub: set[str],
+) -> SeedPlan:
+    """Decide what to seed.
+
+    *verdicts* maps server name -> (recommend_stub, recommend_share), already
+    resolved by the caller from the cache and the hazard ledger. Pure: it reads
+    the applied markers and returns a plan, so the decision is testable without
+    a config file, a gateway, or a clock.
+    """
+    add: list[str] = []
+    mark: list[str] = []
+    share: list[str] = []
+    for name in sorted(verdicts):
+        recommend_stub, recommend_share = verdicts[name]
+        if cache.was_applied(name):
+            # Already the operator's call. Not re-examined, not re-flipped.
+            continue
+        if not recommend_stub:
+            # Nothing to write, but record that this server was considered, so a
+            # server that is merely "not recommended" is not re-evaluated for
+            # seeding on every single start.
+            mark.append(name)
+            continue
+        mark.append(name)
+        if name not in current_stub:
+            add.append(name)
+        if recommend_share:
+            share.append(name)
+    return SeedPlan(
+        add_stub=tuple(add), mark_applied=tuple(mark), wants_share=tuple(share)
+    )
+
+
+def apply_seed(plan: SeedPlan, section: dict, cache: VerdictCache) -> bool:
+    """Apply *plan* to a loaded ``mcp_gateway`` config *section*. True if changed.
+
+    The caller owns reading, locking and writing the config file; this function
+    only mutates the section in memory and records the markers, so the same logic
+    is exercised by tests and by the gateway without a second implementation.
+    """
+    if plan.is_empty:
+        return False
+    changed = False
+    if plan.add_stub:
+        current = section.get("stub_servers")
+        existing = [s for s in current if isinstance(s, str)] if isinstance(current, list) else []
+        merged = sorted(set(existing) | set(plan.add_stub))
+        if merged != existing:
+            section["stub_servers"] = merged
+            changed = True
+            logger.info(
+                "mcp seeding: stubbing %s on first evaluation (edit "
+                "mcp_gateway.stub_servers to change)",
+                ", ".join(plan.add_stub),
+            )
+    for name in plan.mark_applied:
+        cache.mark_applied(name)
+    return changed

--- a/src/kiro_crew/mcp_gateway/shareability.py
+++ b/src/kiro_crew/mcp_gateway/shareability.py
@@ -1,0 +1,304 @@
+"""Decide whether an MCP server LOOKS safe to stub and share, from evidence.
+
+This module answers one question and nothing else: given what we managed to
+observe about a server, do we RECOMMEND that the operator stub it (and, on a
+separate axis, share its backend)? It never writes config, never spawns a
+process, and never reads a file — callers gather evidence and hand it in.
+
+Why a recommendation and never an automatic switch
+--------------------------------------------------
+The evidence available is genuinely weaker than proof, and the gap is
+structural rather than an implementation shortcut:
+
+* The probe connects as ``clientInfo: {"name": "kirocrew-probe"}`` while the
+  gateway connects as ``kirocrew-gateway``. A server that negotiates its
+  capabilities from ``clientInfo`` can answer the probe differently from the
+  pooled backend — the exact hazard ``backend.Backend`` documents when it
+  caches the first stub's ``initialize`` result and replays it to later stubs.
+* The MCP base protocol models one client per stdio server process. There is
+  no spec field that says "I am safe to share", so no amount of reading a
+  conformant server's declarations can produce a proof.
+
+So a verdict is an invitation to a human decision. The one thing this module
+treats as conclusive is REFUTATION: when the gateway has already watched a
+server behave statefully under sharing, that observation outranks every
+declaration, and the recommendation is withdrawn.
+
+Evidence strength, strongest first
+----------------------------------
+``REFUTED``      the gateway observed per-client behaviour while shared.
+``DISQUALIFIED`` a declaration we trust rules sharing out up front.
+``DECLARED``     the server advertises the caller-identity extension, i.e. it
+                 was written for a pooled backend.
+``NO_OBJECTION`` nothing disqualifying was found — the weakest useful verdict,
+                 and the one whose wording must stay honest about that.
+``UNKNOWN``      not enough was observed to say anything.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+# The capability an MCP server advertises to say it can tell its callers apart.
+# Kept as a literal rather than imported from ``mcp_caller`` so this module has
+# no import edge into the runtime; the ratchet test pins the two together.
+CALLER_IDENTITY_CAPABILITY = "kirocrew.caller-identity"
+
+# Env names whose VALUE legitimately differs per session and is deliberately
+# excluded from ``PoolKey.effective_env_hash`` (see ``hashing.ENV_SCRUB_PREFIXES``).
+# Two co-tenants can therefore disagree on the value while sharing one backend,
+# so a server that authenticates from these can never be a safe recommendation.
+# This list must stay a superset of the hashing module's prefixes; the ratchet
+# test fails if hashing grows a prefix this does not cover.
+ROTATING_SECRET_ENV_PREFIXES: tuple[str, ...] = ("AWS_SECRET", "AWS_SESSION", "OAUTH")
+
+# Server capabilities that are per-CLIENT state by construction.
+#
+# ``resources.subscribe`` creates a subscription owned by one client; the
+# resulting ``notifications/resources/updated`` carries no request id, so a
+# shared backend cannot attribute it and drops it (deny-by-default in
+# ``backend._notification_owner``). The subscription silently stops working.
+#
+# ``logging`` is a client-scoped level set by ``logging/setLevel``; on a shared
+# backend the last caller's level wins for everyone.
+#
+# ``*.listChanged`` is deliberately NOT here: those notifications are global
+# broadcasts (``backend._GLOBAL_BROADCAST_NOTIFICATIONS``) and are safe to
+# fan out to every attached stub.
+_PER_CLIENT_CAPABILITIES: tuple[tuple[tuple[str, ...], str, str], ...] = (
+    (("resources", "subscribe"), "resources_subscribe", "truthy"),
+    (("logging",), "logging_level", "present"),
+)
+
+
+class Strength(str, Enum):
+    """How much the evidence is worth. Ordered weakest to strongest."""
+
+    UNKNOWN = "unknown"
+    NO_OBJECTION = "no_objection"
+    DECLARED = "declared"
+    DISQUALIFIED = "disqualified"
+    REFUTED = "refuted"
+
+
+@dataclass(frozen=True)
+class Reason:
+    """One machine-readable ground for a verdict.
+
+    ``code`` is stable and is what the UI translates; ``detail`` carries the
+    specific observation (an env name, a capability path) and is NOT
+    translated because it is verbatim data from the server or the config.
+    """
+
+    code: str
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class ShareEvidence:
+    """Everything observed about one server. All fields optional by design.
+
+    A caller that could not observe something leaves it ``None`` rather than
+    guessing, which is what keeps ``UNKNOWN`` distinguishable from
+    ``NO_OBJECTION``. ``probe_ok=False`` with ``capabilities=None`` means "we
+    never got a handshake", not "the server declared nothing".
+    """
+
+    name: str
+    # Transport: only stdio servers get a stub at all. HTTP/SSE servers are
+    # already shareable by nature and are out of scope, not unsafe.
+    is_stdio: bool = True
+    # One of Kiro Crew's own managed servers, which bind KIROCREW_SESSION_KEY
+    # and are per-session by construction.
+    is_first_party: bool = False
+    # Did the handshake succeed? A server we could not start is UNKNOWN.
+    probe_ok: bool = False
+    # The server's advertised ``capabilities`` object, verbatim.
+    capabilities: dict | None = None
+    # ``protocolVersion`` the server answered with. Tool annotations only exist
+    # from 2025-03-26 onward, so this decides whether their ABSENCE means
+    # anything at all.
+    protocol_version: str = ""
+    # ``annotations`` from each entry of ``tools/list``, in list order. Empty
+    # list = the server returned tools but none carried annotations.
+    tool_annotations: list[dict] = field(default_factory=list)
+    # Whether ``tools/list`` produced at least one tool.
+    has_tools: bool = False
+    # Env names DECLARED for this server in its config entry. Values are never
+    # passed in — only names are needed and values may be secret.
+    declared_env_names: tuple[str, ...] = ()
+    # Hazards the gateway already observed while this server was shared.
+    observed_hazards: tuple[str, ...] = ()
+    # Pre-flight outcome. ``None`` = never run, which is NOT the same as "ran
+    # and found nothing": a server that has not been provoked yet must not be
+    # recommended for sharing on the strength of its own declarations alone.
+    preflight_ran: bool | None = None
+    # Set only when ``preflight_ran`` is True. Proof the server answers
+    # ``initialize`` differently per caller, which a pooled backend cannot serve.
+    preflight_caller_sensitive: bool = False
+
+
+@dataclass(frozen=True)
+class ShareVerdict:
+    """The answer. ``recommend_stub`` and ``recommend_share`` are separate."""
+
+    name: str
+    strength: Strength
+    recommend_stub: bool
+    recommend_share: bool
+    reasons: tuple[Reason, ...]
+
+    def to_dict(self) -> dict:
+        return {
+            "strength": self.strength.value,
+            "recommendStub": self.recommend_stub,
+            "recommendShare": self.recommend_share,
+            "reasons": [{"code": r.code, "detail": r.detail} for r in self.reasons],
+        }
+
+
+def rotating_secret_env(env_names: tuple[str, ...]) -> tuple[str, ...]:
+    """Declared env names whose value is excluded from the pool key."""
+    return tuple(
+        n for n in env_names if n.upper().startswith(ROTATING_SECRET_ENV_PREFIXES)
+    )
+
+
+def _per_client_capabilities(capabilities: dict) -> list[Reason]:
+    """Capabilities that make a server per-client by construction.
+
+    Two detection modes, because a capability and a flag inside one are different
+    claims:
+
+    ``truthy`` — the leaf is a FLAG. ``resources: {"subscribe": false}`` is the
+    server explicitly saying it does not subscribe, so it must not count against
+    it.
+
+    ``present`` — the leaf IS the capability. In MCP an empty object is the
+    standard way to advertise a capability that takes no sub-options, so
+    ``{"logging": {}}`` means ``logging/setLevel`` is supported. Testing
+    truthiness there let a server whose log level is process-wide — one
+    co-tenant's ``setLevel`` changing what every other session gets — through as
+    shareable.
+    """
+    out: list[Reason] = []
+    for path, code, mode in _PER_CLIENT_CAPABILITIES:
+        node: object = capabilities
+        missing = False
+        for key in path:
+            if not isinstance(node, dict) or key not in node:
+                missing = True
+                break
+            node = node[key]
+        if missing:
+            continue
+        if mode == "present" or node:
+            out.append(Reason("per_client_capability", code))
+    return out
+
+
+def _declares_caller_identity(capabilities: dict) -> bool:
+    experimental = capabilities.get("experimental")
+    return isinstance(experimental, dict) and CALLER_IDENTITY_CAPABILITY in experimental
+
+
+def _all_tools_read_only(annotations: list[dict]) -> bool:
+    """True when every tool declares ``readOnlyHint``.
+
+    Positive evidence only. A server that predates MCP 2025-03-26 cannot send
+    annotations at all, so an empty list proves nothing and this returns False
+    without that counting against the server.
+    """
+    if not annotations:
+        return False
+    return all(a.get("readOnlyHint") is True for a in annotations)
+
+
+def assess(evidence: ShareEvidence) -> ShareVerdict:
+    """Turn evidence into a verdict. Pure; no IO, no config, no clock."""
+
+    def verdict(
+        strength: Strength,
+        reasons: list[Reason],
+        *,
+        stub: bool = False,
+        share: bool = False,
+    ) -> ShareVerdict:
+        return ShareVerdict(
+            name=evidence.name,
+            strength=strength,
+            recommend_stub=stub,
+            recommend_share=share,
+            reasons=tuple(reasons),
+        )
+
+    # 1. Refutation outranks every declaration. The gateway does not log these
+    #    speculatively: each one is a request it could not route, or a backend
+    #    it recycled, while this server was actually shared.
+    if evidence.observed_hazards:
+        return verdict(
+            Strength.REFUTED,
+            [Reason("observed_hazard", h) for h in evidence.observed_hazards],
+        )
+
+    # 2. Structural exclusions. None of these mean "unsafe" in the same sense —
+    #    they mean the question does not apply — so they are reported with
+    #    distinct codes rather than one "unsupported".
+    if not evidence.is_stdio:
+        return verdict(Strength.DISQUALIFIED, [Reason("not_stdio")])
+    if evidence.is_first_party:
+        return verdict(Strength.DISQUALIFIED, [Reason("first_party_session_scoped")])
+
+    rotating = rotating_secret_env(evidence.declared_env_names)
+    if rotating:
+        # Checked BEFORE probe_ok: this is a config fact, true whether or not
+        # the server ever started, and reporting it is more useful than
+        # "unknown" on a host where the probe cannot run.
+        return verdict(
+            Strength.DISQUALIFIED,
+            [Reason("rotating_secret_env", n) for n in rotating],
+        )
+
+    # 3. Nothing observed. Distinguish "never handshook" from "declared nothing".
+    if not evidence.probe_ok or evidence.capabilities is None:
+        return verdict(Strength.UNKNOWN, [Reason("not_probed")])
+
+    objections = _per_client_capabilities(evidence.capabilities)
+    if objections:
+        return verdict(Strength.DISQUALIFIED, objections)
+
+    # 4. Pre-flight proof. Checked BEFORE the positive declaration below: a
+    #    server may advertise caller-identity and still have been caught
+    #    answering `initialize` differently per caller, and the measurement wins
+    #    over the promise — the same ordering the hazard ledger enforces.
+    if evidence.preflight_ran and evidence.preflight_caller_sensitive:
+        return verdict(Strength.DISQUALIFIED, [Reason("caller_sensitive_initialize")])
+
+    # 5. Positive declaration: the server was written for a pooled backend.
+    if _declares_caller_identity(evidence.capabilities):
+        reasons = [Reason("declares_caller_identity")]
+        if _all_tools_read_only(evidence.tool_annotations):
+            reasons.append(Reason("all_tools_read_only"))
+        # Sharing still needs the provocation to have actually happened. A
+        # declaration plus an unrun pre-flight is a promise nobody has tested.
+        share = evidence.preflight_ran is True
+        reasons.append(
+            Reason("preflight_passed" if share else "preflight_not_run")
+        )
+        return verdict(Strength.DECLARED, reasons, stub=True, share=share)
+
+    # 6. No objection found. This is an absence of evidence, not evidence of
+    #    absence, so sharing is NOT recommended here even though stubbing is:
+    #    a stub alone keeps the backend 1:1 with the session (same topology as
+    #    no gateway) and is what unlocks server-authored UI, while sharing is
+    #    the step that introduces co-tenancy. Splitting the two is what makes a
+    #    weak verdict still actionable without being reckless.
+    reasons = [Reason("no_objection_found")]
+    if _all_tools_read_only(evidence.tool_annotations):
+        reasons.append(Reason("all_tools_read_only"))
+    elif not evidence.tool_annotations:
+        reasons.append(Reason("no_tool_annotations", evidence.protocol_version))
+    if not evidence.has_tools:
+        reasons.append(Reason("no_tools_listed"))
+    return verdict(Strength.NO_OBJECTION, reasons, stub=True, share=False)

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -299,6 +299,16 @@ def _binary_version(command: str) -> str:
         return "unknown"
 
 
+def binary_fingerprint(command: str) -> str:
+    """Public alias of :func:`_binary_version`.
+
+    The shareability cache keys on the same token the pool does, so an in-place
+    binary upgrade invalidates both. One implementation, two consumers — a second
+    copy would drift and let one of them keep a stale identity.
+    """
+    return _binary_version(command)
+
+
 def _resolve_channel_id(cli_value: Optional[str]) -> Optional[str]:
     """``--channel-id`` wins; else ``KIROCREW_CHANNEL_ID`` env; else None."""
     return cli_value or os.environ.get("KIROCREW_CHANNEL_ID") or None

--- a/src/kiro_crew/mcp_gateway/verdict_cache.py
+++ b/src/kiro_crew/mcp_gateway/verdict_cache.py
@@ -1,0 +1,249 @@
+"""Remember, per machine, what a shareability pre-flight concluded.
+
+Nothing about which MCP servers a machine runs ships with Kiro Crew. Each host
+derives its own verdicts and keeps them here, which is why there is no curated
+list of server names in the repository and none has to leave the host.
+
+One row per configured server
+-----------------------------
+The row is keyed by the server NAME, and the execution identity it was measured
+under is a FIELD inside the row. Reading compares that field against the
+server's current identity and treats a mismatch as no measurement at all, so an
+upgraded binary or an edited command still forces a re-measurement — the same
+invalidation an identity-keyed row would give.
+
+Keying by identity instead looks equivalent and is not: it makes one server
+produce a NEW row on every command edit and every binary upgrade, so the file
+grows with config churn and needs a size cap, an eviction policy, and a
+newest-wins rule for readers who only know a name. Overwriting one row per
+server removes all three. Row count equals the number of configured servers,
+which is bounded by the config rather than by history.
+
+The identity is the same material ``PoolKey`` is built from — command+args,
+effective env, resolved launch fingerprint — plus ``SCHEMA``, so a smarter
+pre-flight does not inherit conclusions an older one reached with less evidence.
+
+What is deliberately NOT stored here
+------------------------------------
+Observed hazards. Those live in ``hazards`` and outrank anything here: a cached
+"safe" must never be able to rescue a server the gateway has watched misbehave.
+Keeping the two stores separate is what makes that ordering impossible to get
+wrong by editing one file.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.mcp_gateway.record_json import finite_float
+
+logger = logging.getLogger(__name__)
+
+VERDICT_CACHE_FILENAME = "shareability-verdicts.json"
+
+#: Bump when the pre-flight learns a new check, so older verdicts are re-derived
+#: rather than trusted. Part of the identity string, so bumping it makes every
+#: stored row read as stale instead of wiping the file.
+SCHEMA = 1
+
+
+@dataclass(frozen=True)
+class Identity:
+    """What a measurement was taken under. Stored in the row, not used as its key."""
+
+    command_args_hash: str
+    env_hash: str
+    binary_version: str
+    schema: int = SCHEMA
+
+    def as_str(self) -> str:
+        return "\u0000".join(
+            (self.command_args_hash, self.env_hash, self.binary_version, str(self.schema))
+        )
+
+
+@dataclass(frozen=True)
+class CachedPreflight:
+    """A stored pre-flight MEASUREMENT — not a final verdict.
+
+    Only the expensive part is stored. The cheap evidence (declared env names,
+    advertised capabilities, observed hazards) is re-read on every request and
+    recombined by ``shareability.assess``, so a hazard observed a minute ago
+    changes the answer immediately without invalidating anything here. Storing
+    the composite instead would go stale the moment the ledger grew an entry.
+
+    ``ran`` distinguishes "provoked and found nothing" from "could not provoke
+    it", and callers must branch on it before trusting ``caller_sensitive``.
+
+    ``identity`` is what the measurement was taken under. A reader that knows the
+    server's current identity compares it; a reader that only knows the name (the
+    dashboard row builder, which does no IO) reads the row as-is and accepts that
+    a just-changed server shows its previous measurement until the next probe.
+    """
+
+    ran: bool
+    caller_sensitive: bool
+    reasons: tuple[str, ...]
+    evaluated_at: float
+    identity: str = ""
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "ran": self.ran,
+            "callerSensitive": self.caller_sensitive,
+            "reasons": list(self.reasons),
+            "evaluatedAt": self.evaluated_at,
+            "identity": self.identity,
+        }
+
+
+class VerdictCache:
+    """One row per configured server, as a single JSON object."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._entries: dict[str, CachedPreflight] = {}
+        # Servers whose recommendation has already been written into config.
+        # Keyed by NAME for the same reason the rows are: an operator who
+        # switches a server off must stay switched off across an upgrade of that
+        # server, and an identity-keyed marker would re-flip it the moment the
+        # binary version changed.
+        self._applied: set[str] = set()
+        self._dirty = False
+
+    def load(self) -> None:
+        """Read the file. Absence, corruption and a future shape all read empty.
+
+        Reading empty means "nothing evaluated yet", which costs a re-evaluation
+        and never a wrong answer. Guessing at an unreadable file's meaning is the
+        only outcome that could produce one.
+        """
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            # UnicodeDecodeError is raised by read_text BEFORE json.loads sees the
+            # bytes, and it is a ValueError rather than a JSONDecodeError, so the
+            # two obvious clauses do not cover it. A single invalid byte in this
+            # file is exactly the corruption this loader exists to absorb.
+            logger.warning("shareability cache: ignoring unreadable %s: %s", self._path, exc)
+            return
+        entries = raw.get("entries") if isinstance(raw, dict) else None
+        if not isinstance(entries, dict):
+            return
+        applied = raw.get("applied") if isinstance(raw, dict) else None
+        if isinstance(applied, list):
+            self._applied = {a for a in applied if isinstance(a, str) and a}
+        for name, value in entries.items():
+            if not isinstance(name, str) or not name or not isinstance(value, dict):
+                continue
+            ran = value.get("ran")
+            if not isinstance(ran, bool):
+                # A row that cannot say whether the pre-flight ran is unusable:
+                # treating it as "ran" would fabricate evidence.
+                continue
+            reasons = value.get("reasons")
+            identity = value.get("identity")
+            self._entries[name] = CachedPreflight(
+                ran=ran,
+                caller_sensitive=value.get("callerSensitive") is True,
+                reasons=tuple(r for r in reasons if isinstance(r, str))
+                if isinstance(reasons, list)
+                else (),
+                evaluated_at=finite_float(value.get("evaluatedAt")),
+                # A row written before identities were stored reads as identity
+                # "", which matches nothing, so it is re-measured rather than
+                # trusted. That is the safe direction for a format change.
+                identity=identity if isinstance(identity, str) else "",
+            )
+
+    def get(self, server_name: str, identity: Identity) -> CachedPreflight | None:
+        """The row for *server_name*, only if it was measured under *identity*.
+
+        An identity mismatch reads as "not measured": the stored conclusion
+        describes a program that is no longer what this name launches.
+        """
+        row = self._entries.get(server_name)
+        if row is None or row.identity != identity.as_str():
+            return None
+        return row
+
+    def get_by_name(self, server_name: str) -> CachedPreflight | None:
+        """The row for *server_name* without checking identity.
+
+        For the dashboard row builder, which is deliberately IO-free and so
+        cannot resolve a binary fingerprint. A row whose identity has moved on
+        is corrected by the next probe.
+        """
+        return self._entries.get(server_name)
+
+    def put(self, server_name: str, identity: Identity, verdict: CachedPreflight) -> None:
+        """Overwrite the row for *server_name*. One server, one row, always."""
+        self._entries[server_name] = CachedPreflight(
+            ran=verdict.ran,
+            caller_sensitive=verdict.caller_sensitive,
+            reasons=verdict.reasons,
+            evaluated_at=verdict.evaluated_at,
+            identity=identity.as_str(),
+        )
+        self._dirty = True
+
+    def was_applied(self, server_name: str) -> bool:
+        """True when this server's recommendation was already written to config.
+
+        The gate that stops a later start from undoing an operator's choice: a
+        server is seeded once, and after that the config is theirs.
+        """
+        return server_name in self._applied
+
+    def mark_applied(self, server_name: str) -> None:
+        if server_name and server_name not in self._applied:
+            self._applied.add(server_name)
+            self._dirty = True
+
+    def server_names(self) -> set[str]:
+        """Every server name with a stored measurement."""
+        return set(self._entries)
+
+    def flush(self) -> None:
+        """Persist when dirty. Blocking IO — keep it off the event loop."""
+        if not self._dirty:
+            return
+        payload = {
+            "entries": {k: v.to_json() for k, v in sorted(self._entries.items())},
+            "applied": sorted(self._applied),
+        }
+        try:
+            atomic_write(self._path, json.dumps(payload, indent=2) + "\n")
+        except OSError as exc:
+            # A cache we cannot persist costs a re-evaluation next start, so
+            # this is a warning and never fatal.
+            logger.warning("shareability cache: could not write %s: %s", self._path, exc)
+            return
+        self._dirty = False
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+def cache_path(runtime_dir: Path) -> Path:
+    """Sibling of ``hot-keys.json`` and ``observed-hazards.json``."""
+    return runtime_dir / VERDICT_CACHE_FILENAME
+
+
+def load_cache(runtime_dir: Path) -> VerdictCache:
+    cache = VerdictCache(cache_path(runtime_dir))
+    cache.load()
+    return cache
+
+
+def now() -> float:
+    """Wall clock for ``evaluated_at``. Seam so tests need no monkeypatching."""
+    return time.time()

--- a/test/test_handlers_mcp_coverage.py
+++ b/test/test_handlers_mcp_coverage.py
@@ -1233,10 +1233,32 @@ def routed_allowlist(monkeypatch: pytest.MonkeyPatch):
     import kiro_crew.config.loader as loader
 
     def _set(names: list[str]) -> None:
-        cfg = SimpleNamespace(mcp_gateway=SimpleNamespace(stub_servers=list(names)))
+        # ``socket_path`` is part of the real ``McpGatewayConfig`` and the
+        # handler reads it to locate the observed-hazard ledger. A double that
+        # omitted it would make the row builder raise on a field production
+        # always has — empty is the honest stand-in for "no broker configured".
+        cfg = SimpleNamespace(
+            mcp_gateway=SimpleNamespace(stub_servers=list(names), socket_path="")
+        )
         monkeypatch.setattr(loader.KiroCrewConfig, "load", staticmethod(lambda: cfg))
 
     return _set
+
+
+def _seed_probe(monkeypatch, *names: str) -> None:
+    """Make ``probe_metadata`` report a probed server that declares caller identity.
+
+    Without this the verdict stops at "never probed" for every row, and a test of
+    the preflight gate would pass whether or not the gate works.
+    """
+    meta = SimpleNamespace(
+        status="ok",
+        capabilities={"experimental": {"kirocrew.caller-identity": {}}},
+        protocol_version="2024-11-05",
+        tool_annotations=[],
+        tools=[SimpleNamespace(name="t")],
+    )
+    monkeypatch.setattr(mcp_mod, "probe_metadata", lambda n: meta if n in names else None)
 
 
 class TestGatewayServers:
@@ -1319,6 +1341,77 @@ class TestGatewayServers:
         }
         assert rows["never-mcp"]["denylisted"] is True
         assert rows["never-mcp"]["stub"] is False
+
+    @pytest.mark.asyncio
+    async def test_two_agents_disagreeing_on_the_command_withhold_the_measurement(
+        self, agents_dir: Path, routed_allowlist, monkeypatch
+    ) -> None:
+        """A merged row must not inherit a measurement of one of its definitions.
+
+        Discovery merges by NAME before probing, so only the definition that wins
+        the merge is ever measured. If two agents disagree about the command, the
+        row covers something nobody ran — and reporting the measured one's verdict
+        would tell the operator it is safe to share a backend that was never
+        started.
+        """
+        routed_allowlist([])
+        (agents_dir / "alpha.json").write_text(
+            json.dumps({"name": "alpha", "mcpServers": {"two-faced": {"command": "/bin/a"}}}),
+            encoding="utf-8",
+        )
+        (agents_dir / "beta.json").write_text(
+            json.dumps({"name": "beta", "mcpServers": {"two-faced": {"command": "/bin/b"}}}),
+            encoding="utf-8",
+        )
+        # A clean, sharing-granting measurement exists under that name. The probe
+        # metadata declares caller-identity so that consuming the measurement
+        # WOULD grant sharing — without that, both branches look the same and the
+        # test would pass whether or not the gate works.
+        _seed_probe(monkeypatch, "two-faced")
+        monkeypatch.setattr(
+            mcp_mod, "_load_shareability_state", lambda: ({}, {"two-faced": (True, False)})
+        )
+
+        rows = {
+            r["name"]: r
+            for r in _payload(await mcp_mod.api_mcp_gateway_servers(_request()))["servers"]
+        }
+
+        rec = rows["two-faced"]["recommendation"]
+        assert sorted(rows["two-faced"]["agents"]) == ["alpha", "beta"]
+        assert rec["recommendShare"] is False, rec
+        assert "preflight_not_run" in [r["code"] for r in rec["reasons"]], rec
+
+    @pytest.mark.asyncio
+    async def test_one_definition_in_two_agents_still_gets_its_measurement(
+        self, agents_dir: Path, routed_allowlist, monkeypatch
+    ) -> None:
+        """The ordinary case must keep working: same server, several agents.
+
+        Withholding on agent count instead of distinct launches would silently
+        drop the recommendation for most real configurations.
+        """
+        routed_allowlist([])
+        spec = {"mcpServers": {"shared-mcp": {"command": "/bin/a", "args": ["--x"]}}}
+        (agents_dir / "alpha.json").write_text(
+            json.dumps({"name": "alpha", **spec}), encoding="utf-8"
+        )
+        (agents_dir / "beta.json").write_text(
+            json.dumps({"name": "beta", **spec}), encoding="utf-8"
+        )
+        _seed_probe(monkeypatch, "shared-mcp")
+        monkeypatch.setattr(
+            mcp_mod, "_load_shareability_state", lambda: ({}, {"shared-mcp": (True, False)})
+        )
+
+        rows = {
+            r["name"]: r
+            for r in _payload(await mcp_mod.api_mcp_gateway_servers(_request()))["servers"]
+        }
+
+        rec = rows["shared-mcp"]["recommendation"]
+        assert rec["recommendShare"] is True, rec
+        assert "preflight_passed" in [r["code"] for r in rec["reasons"]], rec
 
     @pytest.mark.asyncio
     async def test_unreadable_and_non_object_agent_files_are_skipped(

--- a/test/test_mcp_bg_probe.py
+++ b/test/test_mcp_bg_probe.py
@@ -19,7 +19,7 @@ class TestBgMcpProbeBoundedFanout:
     """Regression guard.
 
     ``_bg_mcp_probe`` previously ran its own unbounded ``asyncio.gather`` over
-    every configured server, bypassing the ``_PROBE_MAX_CONCURRENCY`` semaphore
+    every configured server, bypassing the ``PROBE_MAX_CONCURRENCY`` semaphore
     that ``probe_all()`` carries (the fix). Under a network blip that
     floods the loop's default executor and can starve the heartbeat into a
     watchdog ``_exit`` (full gateway restart). It MUST route through the bounded

--- a/test/test_mcp_gatewayd_coverage.py
+++ b/test/test_mcp_gatewayd_coverage.py
@@ -486,6 +486,39 @@ class TestHeartbeatSweeper:
         assert task.done() and not task.cancelled()
 
     @pytest.mark.asyncio
+    async def test_cancellation_flushes_the_hazard_ledger(self, tmp_path):
+        """A hazard observed after the last tick must survive a clean shutdown.
+
+        The periodic flush only persists what was seen before the previous
+        interval, and shutdown cancels this task — so without a flush on exit an
+        observation made in the final interval is lost, and a server that
+        misbehaved keeps its recommendation until it misbehaves again. Shutdown is
+        the ordinary path, not the exceptional one.
+        """
+        from kiro_crew.mcp_gateway import hazards
+
+        ledger = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        gw.hazards._sink = ledger  # type: ignore[attr-defined]
+        try:
+            ledger.record("srv", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST)
+            assert not hazards.ledger_path(tmp_path).exists(), "nothing persisted yet"
+
+            pool = _SweeperPool([])
+            stop = asyncio.Event()
+            task = asyncio.create_task(
+                gw._heartbeat_sweeper(cast(Any, pool), 30.0, stop, None)
+            )
+            await asyncio.sleep(0)
+            task.cancel()
+            await asyncio.wait_for(task, timeout=5)
+
+            assert hazards.load_ledger(tmp_path).codes_for("srv") == (
+                hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,
+            )
+        finally:
+            gw.hazards._sink = None  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
     async def test_drained_backend_is_reaped_once_its_refcount_hits_zero(self):
         """Blue-green cutover: draining backends finish in-flight work, then go."""
         drained = _fake_backend(_pool_key(server="drained-mcp"), pid=7070)

--- a/test/test_mcp_preflight.py
+++ b/test/test_mcp_preflight.py
@@ -1,0 +1,524 @@
+"""Local verdict cache + the pre-flight that provokes sharing hazards early."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from kiro_crew.mcp_discovery import McpServerInfo
+from kiro_crew.mcp_gateway import preflight as pf
+from kiro_crew.mcp_gateway import verdict_cache as vc
+
+# The identities the pre-flight really sends, not copies of them. A double keyed
+# by hardcoded names answers nothing when a name changes, and the pre-flight then
+# reads as "server did not respond" while every test still describes a healthy
+# server.
+_ID_A, _ID_B = pf.PREFLIGHT_IDENTITY_NAMES
+
+
+def _ident(**over: Any) -> vc.Identity:
+    base = {
+        "command_args_hash": "cmd1",
+        "env_hash": "env1",
+        "binary_version": "1.0.0",
+    }
+    base.update(over)
+    return vc.Identity(**base)  # type: ignore[arg-type]
+
+
+def _verdict(ran: bool = True, caller_sensitive: bool = False) -> vc.CachedPreflight:
+    return vc.CachedPreflight(
+        ran=ran,
+        caller_sensitive=caller_sensitive,
+        reasons=() if ran else (pf.REASON_PREFLIGHT_UNAVAILABLE,),
+        evaluated_at=1.0,
+    )
+
+
+class TestIdentityInvalidation:
+    """The identity is the whole point: a stale hit is a wrong answer, not a slow one."""
+
+    def test_round_trip(self, tmp_path) -> None:
+        cache = vc.VerdictCache(vc.cache_path(tmp_path))
+        cache.put("srv", _ident(), _verdict(ran=True, caller_sensitive=True))
+        cache.flush()
+
+        fresh = vc.load_cache(tmp_path)
+        hit = fresh.get("srv", _ident())
+        assert hit is not None and hit.caller_sensitive is True
+
+    @pytest.mark.parametrize(
+        "changed",
+        [
+            {"command_args_hash": "cmd2"},
+            {"env_hash": "env2"},
+            {"binary_version": "1.0.1"},
+            {"schema": vc.SCHEMA + 1},
+        ],
+    )
+    def test_any_identity_change_misses(self, tmp_path, changed: dict[str, Any]) -> None:
+        """Upgrading the MCP, editing its env, or shipping a smarter pre-flight
+        must all re-derive rather than inherit."""
+        cache = vc.VerdictCache(vc.cache_path(tmp_path))
+        cache.put("srv", _ident(), _verdict())
+        assert cache.get("srv", _ident(**changed)) is None
+
+    def test_a_different_name_is_a_different_row(self, tmp_path) -> None:
+        cache = vc.VerdictCache(vc.cache_path(tmp_path))
+        cache.put("srv", _ident(), _verdict())
+        assert cache.get("other", _ident()) is None
+
+    def test_one_server_keeps_exactly_one_row(self, tmp_path) -> None:
+        """The reason the file needs no size cap and no eviction policy.
+
+        Keying by identity made every command edit and every binary upgrade add a
+        row, so the file grew with config churn and needed a ceiling, an eviction
+        rule, and a newest-wins rule for readers who only know a name. Overwriting
+        one row per server removes all three: row count is bounded by the config.
+        """
+        cache = vc.VerdictCache(vc.cache_path(tmp_path))
+        for i in range(10):
+            cache.put("srv", _ident(binary_version=f"v{i}"), _verdict())
+        cache.flush()
+
+        assert len(vc.load_cache(tmp_path)) == 1
+        # The surviving row is the newest measurement, and the superseded
+        # identities are gone rather than kept as history to sort through.
+        assert vc.load_cache(tmp_path).get("srv", _ident(binary_version="v9")) is not None
+        assert vc.load_cache(tmp_path).get("srv", _ident(binary_version="v0")) is None
+
+
+class TestCacheDegradesSafely:
+    def test_absent_file_is_empty(self, tmp_path) -> None:
+        assert len(vc.load_cache(tmp_path)) == 0
+
+    def test_corrupt_file_is_empty(self, tmp_path) -> None:
+        vc.cache_path(tmp_path).write_text("{{{", encoding="utf-8")
+        assert len(vc.load_cache(tmp_path)) == 0
+
+    def test_invalid_utf8_is_empty_rather_than_an_exception(self, tmp_path) -> None:
+        """A single bad byte must degrade, not propagate.
+
+        ``read_text`` raises ``UnicodeDecodeError`` before ``json.loads`` ever
+        sees the bytes, and that is a ``ValueError`` — NOT a ``JSONDecodeError``
+        — so catching only the two obvious clauses let it escape. This loader's
+        whole contract is that unreadable reads as unevaluated.
+        """
+        vc.cache_path(tmp_path).write_bytes(b'{"entries": {"a\xff\xfe": {}}}')
+        assert len(vc.load_cache(tmp_path)) == 0
+
+    def test_invalid_utf8_in_the_ledger_does_not_break_daemon_startup(
+        self, tmp_path
+    ) -> None:
+        """The same gap, on the path that decides whether gatewayd can bind.
+
+        ``install_sink`` loads this file during startup, so an escaping decode
+        error is not a degraded dashboard row — it is a daemon that never binds.
+        """
+        from kiro_crew.mcp_gateway import hazards
+
+        (tmp_path / hazards.HAZARDS_FILENAME).write_bytes(
+            b'{"schema": 1, "servers": {"a\xff\xfe": {}}}'
+        )
+        ledger = hazards.load_ledger(tmp_path)
+        assert ledger.codes_for("a") == ()
+
+    def test_entry_that_cannot_say_whether_it_ran_is_dropped(self, tmp_path) -> None:
+        vc.cache_path(tmp_path).write_text(
+            json.dumps({"entries": {"k": {"reasons": ["x"]}}}), encoding="utf-8"
+        )
+        assert len(vc.load_cache(tmp_path)) == 0
+
+    def test_flush_is_a_no_op_when_clean(self, tmp_path) -> None:
+        vc.VerdictCache(vc.cache_path(tmp_path)).flush()
+        assert not vc.cache_path(tmp_path).exists()
+
+
+class _FakeProbe:
+    """Stands in for ``probe_server``, answering per clientInfo name.
+
+    Mutates the passed server the way the real probe does, so the pre-flight is
+    exercised through the same interface it uses in production.
+    """
+
+    def __init__(self, answers: dict[str, tuple[str, dict[str, Any] | None]]) -> None:
+        self.answers = answers
+        self.identities: list[str] = []
+
+    async def __call__(
+        self, server: McpServerInfo, *, client_info: dict[str, str] | None = None
+    ) -> McpServerInfo:
+        name = (client_info or {}).get("name", "default")
+        self.identities.append(name)
+        status, caps = self.answers[name]
+        server.status = status
+        server.capabilities = caps
+        if status != "ok":
+            server.error = "boom"
+        return server
+
+
+@pytest.fixture
+def patch_probe(monkeypatch: pytest.MonkeyPatch):
+    def _install(answers: dict[str, tuple[str, dict[str, Any] | None]]) -> _FakeProbe:
+        fake = _FakeProbe(answers)
+        # Patch the CONSUMER namespace: preflight imports probe_server at module
+        # scope, so it holds its own reference and patching the source module
+        # would leave the real prober in place — the test would pass while
+        # spawning nothing, or spawn for real.
+        import kiro_crew.mcp_gateway.preflight as pf_mod
+
+        monkeypatch.setattr(pf_mod, "probe_server", fake)
+        return fake
+
+    return _install
+
+
+def _server() -> McpServerInfo:
+    return McpServerInfo(name="srv", command="/bin/true")
+
+
+class TestEvaluateOnlyWhatChanged:
+    """The orchestration policy: pay for a measurement once, per identity."""
+
+    @pytest.mark.asyncio
+    async def test_cached_identity_is_not_re_provoked(self, patch_probe, tmp_path) -> None:
+        from kiro_crew.mcp_gateway import evaluate as ev
+
+        fake = patch_probe({_ID_A: ("ok", {}), _ID_B: ("ok", {})})
+        server = _server()
+
+        first = await ev.evaluate_new_servers([server], tmp_path)
+        assert set(first) == {"srv"}
+        spawns_after_first = len(fake.identities)
+        assert spawns_after_first == 2, "a fresh server costs exactly two spawns"
+
+        second = await ev.evaluate_new_servers([_server()], tmp_path)
+        assert set(second) == {"srv"}
+        assert len(fake.identities) == spawns_after_first, "cache hit must not spawn"
+
+    @pytest.mark.asyncio
+    async def test_changed_command_is_re_provoked(self, patch_probe, tmp_path) -> None:
+        from kiro_crew.mcp_gateway import evaluate as ev
+
+        fake = patch_probe({_ID_A: ("ok", {}), _ID_B: ("ok", {})})
+        await ev.evaluate_new_servers([_server()], tmp_path)
+        before = len(fake.identities)
+
+        upgraded = McpServerInfo(name="srv", command="/bin/true", args=["--v2"])
+        await ev.evaluate_new_servers([upgraded], tmp_path)
+        assert len(fake.identities) > before, "an upgraded MCP must be re-measured"
+
+    @pytest.mark.asyncio
+    async def test_the_pass_overlaps_its_preflights_within_the_shared_cap(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """An operator waits on this pass, so it must not be a serial walk.
+
+        Each pre-flight is two spawns that can each hit the probe timeout, so run
+        serially the budget costs twice that many timeouts of dead wait and one
+        hung server makes the whole pass feel hung. The ceiling is the prober's
+        own constant, because the same executor sits underneath.
+        """
+        import asyncio
+
+        from kiro_crew.mcp_discovery import PROBE_MAX_CONCURRENCY
+        from kiro_crew.mcp_gateway import evaluate as ev
+
+        live = 0
+        peak = 0
+
+        async def slow_preflight(server):
+            nonlocal live, peak
+            live += 1
+            peak = max(peak, live)
+            try:
+                await asyncio.sleep(0.05)
+                return SimpleNamespace(ran=True, caller_sensitive=False, reasons=())
+            finally:
+                live -= 1
+
+        # Patch the CONSUMER namespace: evaluate holds its own reference.
+        monkeypatch.setattr(ev, "preflight", slow_preflight)
+
+        servers = [
+            McpServerInfo(name=f"srv{i}", command="/bin/true")
+            for i in range(ev.MAX_EVALUATIONS_PER_PASS)
+        ]
+        known = await ev.evaluate_new_servers(servers, tmp_path)
+
+        assert len(known) == len(servers), "every server still gets a verdict"
+        assert peak > 1, "the pre-flights ran one at a time"
+        assert peak <= PROBE_MAX_CONCURRENCY, f"fan-out exceeded the shared cap: {peak}"
+
+    @pytest.mark.asyncio
+    async def test_an_unavailable_server_is_re_provoked_next_pass(
+        self, patch_probe, tmp_path
+    ) -> None:
+        """A pre-flight that could not run says nothing about the server.
+
+        A missing credential, an unreachable tunnel, a binary mid-install: none
+        of those change the execution identity, so caching the failure against it
+        would freeze the server at ``unknown`` for good. It must cost the spawns
+        again rather than become permanently unevaluated.
+        """
+        from kiro_crew.mcp_gateway import evaluate as ev
+
+        fake = patch_probe(
+            {_ID_A: ("error", None), _ID_B: ("error", None)}
+        )
+
+        first = await ev.evaluate_new_servers([_server()], tmp_path)
+        assert first["srv"].ran is False, "the unavailable verdict is still reported"
+        spawns = len(fake.identities)
+        assert spawns > 0
+
+        await ev.evaluate_new_servers([_server()], tmp_path)
+
+        assert len(fake.identities) > spawns, "an unavailable result must not be cached"
+
+    @pytest.mark.asyncio
+    async def test_a_successful_verdict_is_still_cached(self, patch_probe, tmp_path) -> None:
+        """The other side of the rule: only failure is exempt from caching."""
+        from kiro_crew.mcp_gateway import evaluate as ev
+
+        fake = patch_probe({_ID_A: ("ok", {}), _ID_B: ("ok", {})})
+        await ev.evaluate_new_servers([_server()], tmp_path)
+        spawns = len(fake.identities)
+
+        await ev.evaluate_new_servers([_server()], tmp_path)
+
+        assert len(fake.identities) == spawns
+
+    @pytest.mark.asyncio
+    async def test_disabled_server_is_never_spawned(self, patch_probe, tmp_path) -> None:
+        """Probing IS the act consent gates; a disabled row must not be provoked."""
+        from kiro_crew.mcp_gateway import evaluate as ev
+
+        fake = patch_probe({_ID_A: ("ok", {}), _ID_B: ("ok", {})})
+        server = _server()
+        server.disabled = True
+        known = await ev.evaluate_new_servers([server], tmp_path)
+        assert known == {}
+        assert fake.identities == []
+
+    @pytest.mark.asyncio
+    async def test_pass_budget_is_respected(self, patch_probe, tmp_path) -> None:
+        """Twenty newly added MCPs must not cost forty spawns in one request."""
+        from kiro_crew.mcp_gateway import evaluate as ev
+
+        fake = patch_probe({_ID_A: ("ok", {}), _ID_B: ("ok", {})})
+        servers = [McpServerInfo(name=f"s{i}", command="/bin/true") for i in range(20)]
+        known = await ev.evaluate_new_servers(servers, tmp_path)
+        assert len(known) == ev.MAX_EVALUATIONS_PER_PASS
+        assert len(fake.identities) == 2 * ev.MAX_EVALUATIONS_PER_PASS
+
+    def test_the_budget_value_itself_is_pinned(self) -> None:
+        """The number is a product decision, not an implementation detail.
+
+        Two servers per pass means four short-lived processes per probe, and a
+        machine with twenty MCPs covers them over ten probes. Asserting only
+        against the constant cannot catch a change to it — the expectation moves
+        with the value — so the intended outcome is spelled out here.
+        """
+        from kiro_crew.mcp_gateway import evaluate as ev
+
+        assert ev.MAX_EVALUATIONS_PER_PASS == 2
+        assert ev.MAX_EVALUATIONS_PER_PASS * 2 == 4, "processes spawned per full pass"
+        assert -(-20 // ev.MAX_EVALUATIONS_PER_PASS) == 10, "twenty MCPs in ten probes"
+
+    @pytest.mark.asyncio
+    async def test_a_server_absent_from_the_pass_keeps_its_measurement(
+        self, patch_probe, tmp_path
+    ) -> None:
+        """Absence from the inventory is not evidence that a verdict is dead.
+
+        The only caller gets its list from ``probe_all``, which excludes
+        consent-disabled rows by design — so deleting entries that are missing
+        from it would throw away the still-valid measurement of every disabled
+        server, two spawns each, and make it read as unknown again the moment it
+        is re-enabled.
+        """
+        from kiro_crew.mcp_gateway import evaluate as ev
+
+        patch_probe({_ID_A: ("ok", {}), _ID_B: ("ok", {})})
+        await ev.evaluate_new_servers([_server()], tmp_path)
+        assert len(vc.load_cache(tmp_path)) == 1
+
+        await ev.evaluate_new_servers([], tmp_path)
+
+        assert len(vc.load_cache(tmp_path)) == 1, "an absent server lost its verdict"
+
+    @pytest.mark.asyncio
+    async def test_the_file_tracks_the_config_not_the_history(
+        self, patch_probe, tmp_path
+    ) -> None:
+        """Why no size cap and no eviction policy are needed.
+
+        A pass overwrites one row per server it measured and touches nothing else,
+        so the row count follows the number of configured servers rather than the
+        number of times any of them changed.
+        """
+        from kiro_crew.mcp_gateway import evaluate as ev
+
+        patch_probe({_ID_A: ("ok", {}), _ID_B: ("ok", {})})
+        for _ in range(5):
+            await ev.evaluate_new_servers([_server()], tmp_path)
+
+        after = vc.load_cache(tmp_path)
+        assert len(after) == 1, "repeated passes over one server kept one row"
+        assert after.server_names() == {"srv"}
+
+    def test_an_in_place_binary_upgrade_is_re_measured(self, tmp_path) -> None:
+        """Same path, same args, new bytes — the measurement must not be reused.
+
+        Without a binary fingerprint the key hits and the pre-flight never re-runs,
+        so a binary that BECAME caller-sensitive would hand its first caller's
+        ``initialize`` result to every co-tenant. The hazard ledger only fires
+        after a session has already lost its tools.
+
+        Synchronous on purpose: ``identity_for`` refuses to run on the event
+        loop, and production reaches it through ``asyncio.to_thread``.
+        """
+        from kiro_crew.mcp_gateway.evaluate import identity_for
+
+        exe = tmp_path / "server-bin"
+        exe.write_text("#!/bin/sh\necho v1\n", encoding="utf-8")
+        exe.chmod(0o755)
+        srv = McpServerInfo(name="s", command=str(exe))
+        before = identity_for(srv).as_str()
+
+        exe.write_text("#!/bin/sh\necho v2-different-bytes\n", encoding="utf-8")
+        after = identity_for(srv).as_str()
+
+        assert before != after, "an in-place upgrade reused the old measurement"
+
+    def test_editing_the_script_an_interpreter_runs_re_measures(self, tmp_path) -> None:
+        """Most MCP servers are ``python server.py``, not a compiled binary.
+
+        Fingerprinting only ``command`` identifies the interpreter, which does not
+        change when the server's own code is edited in place — so the cache would
+        hit for ever and a server that BECAME caller-sensitive would keep its
+        clean verdict.
+        """
+        from kiro_crew.mcp_gateway.evaluate import identity_for
+
+        script = tmp_path / "server.py"
+        script.write_text("print('v1')\n", encoding="utf-8")
+        srv = McpServerInfo(name="s", command="/bin/sh", args=[str(script)])
+        before = identity_for(srv).as_str()
+
+        script.write_text("print('v2-different-bytes')\n", encoding="utf-8")
+        after = identity_for(srv).as_str()
+
+        assert before != after, "editing the script reused the old measurement"
+
+    def test_non_file_arguments_do_not_make_the_key_unstable(self, tmp_path) -> None:
+        """A flag or a port must not be treated as a file to fingerprint.
+
+        Otherwise the key would change between passes for a server whose argv
+        merely looks path-like, and every pass would re-spawn it.
+        """
+        from kiro_crew.mcp_gateway.evaluate import identity_for
+
+        srv = McpServerInfo(
+            name="s", command="/bin/sh", args=["--port", "8080", "/nope/missing.py"]
+        )
+        assert identity_for(srv).as_str() == identity_for(srv).as_str()
+
+    def test_env_is_hashed_by_the_same_helper_the_pool_uses(self, tmp_path) -> None:
+        """So a rotating credential does not look like a different server here."""
+        from kiro_crew.mcp_gateway.evaluate import identity_for
+
+        a = McpServerInfo(name="s", command="/bin/true", env={"AWS_SECRET_ACCESS_KEY": "one"})
+        b = McpServerInfo(name="s", command="/bin/true", env={"AWS_SECRET_ACCESS_KEY": "two"})
+        assert identity_for(a).as_str() == identity_for(b).as_str()
+
+        c = McpServerInfo(name="s", command="/bin/true", env={"REGION": "us-west-2"})
+        assert identity_for(a).as_str() != identity_for(c).as_str()
+
+
+class TestPreflight:
+    @pytest.mark.asyncio
+    async def test_identical_capabilities_pass(self, patch_probe) -> None:
+        caps = {"tools": {"listChanged": True}}
+        fake = patch_probe({_ID_A: ("ok", caps), _ID_B: ("ok", caps)})
+        result = await pf.preflight(_server())
+        assert result.ran and not result.caller_sensitive
+        assert result.reasons == ()
+        # Two DIFFERENT identities, or the check proves nothing.
+        assert fake.identities == [_ID_A, _ID_B]
+
+    @pytest.mark.asyncio
+    async def test_divergent_capabilities_are_caught(self, patch_probe) -> None:
+        patch_probe(
+            {
+                _ID_A: ("ok", {"tools": {}}),
+                _ID_B: ("ok", {"tools": {}, "resources": {"subscribe": True}}),
+            }
+        )
+        result = await pf.preflight(_server())
+        assert result.ran and result.caller_sensitive
+        assert result.reasons == (pf.REASON_CALLER_SENSITIVE_INIT,)
+
+    @pytest.mark.asyncio
+    async def test_free_form_values_do_not_count_as_divergence(self, patch_probe) -> None:
+        """A build id or session token in ``experimental`` is not caller sensitivity.
+
+        Comparing raw dicts would flag every such server and make the check
+        useless, so only the SHAPE is compared.
+        """
+        patch_probe(
+            {
+                _ID_A: ("ok", {"experimental": {"buildId": "abc"}}),
+                _ID_B: ("ok", {"experimental": {"buildId": "zzz"}}),
+            }
+        )
+        result = await pf.preflight(_server())
+        assert result.ran and not result.caller_sensitive
+
+    @pytest.mark.asyncio
+    async def test_a_flipped_boolean_flag_does_count(self, patch_probe) -> None:
+        """Flags ARE part of the contract a pooled backend must keep identical."""
+        patch_probe(
+            {
+                _ID_A: ("ok", {"resources": {"subscribe": True}}),
+                _ID_B: ("ok", {"resources": {"subscribe": False}}),
+            }
+        )
+        result = await pf.preflight(_server())
+        assert result.caller_sensitive
+
+    @pytest.mark.asyncio
+    async def test_unstartable_server_is_not_a_failure(self, patch_probe) -> None:
+        """"Could not ask" must never collapse into "answered no".
+
+        A server needing a credential this host lacks would otherwise be marked
+        unshareable for ever.
+        """
+        patch_probe({_ID_A: ("error", None), _ID_B: ("ok", {})})
+        result = await pf.preflight(_server())
+        assert result.ran is False
+        assert result.caller_sensitive is False
+        assert result.reasons == (pf.REASON_PREFLIGHT_UNAVAILABLE,)
+
+    @pytest.mark.asyncio
+    async def test_answering_once_but_not_twice_is_also_unavailable(self, patch_probe) -> None:
+        patch_probe({_ID_A: ("ok", {}), _ID_B: ("error", None)})
+        result = await pf.preflight(_server())
+        assert result.ran is False
+
+    @pytest.mark.asyncio
+    async def test_the_caller_s_server_object_is_never_mutated(self, patch_probe) -> None:
+        """The dashboard is showing this object; a pre-flight must not touch it."""
+        patch_probe({_ID_A: ("ok", {}), _ID_B: ("ok", {})})
+        server = _server()
+        server.status = "unknown"
+        server.tools = ["kept"]
+        await pf.preflight(server)
+        assert server.status == "unknown"
+        assert server.tools == ["kept"]
+        assert server.capabilities is None

--- a/test/test_mcp_preflight_real_server.py
+++ b/test/test_mcp_preflight_real_server.py
@@ -1,0 +1,274 @@
+"""The shareability pre-flight, against a REAL MCP server process.
+
+Every other test of this feature replaces ``probe_server`` with a fake that
+answers from a dict, or mocks ``create_subprocess_exec`` outright. Those pin the
+policy layer, but none of them can say the mechanism works: the whole point of
+the pre-flight is that it spawns a server TWICE with different ``clientInfo`` and
+compares what the server really answered, and a fake that returns canned
+capabilities proves only that the fake behaves as written.
+
+So these tests spawn an actual stdio MCP server -- a small script written to
+disk, speaking real JSON-RPC over real pipes -- through the real
+``preflight`` -> ``probe_server`` path with nothing patched.
+
+The evidence is produced BY THE SERVER, not asserted about a double: each
+process appends the ``clientInfo.name`` it was handed to a witness file. A test
+that passes without that file holding two distinct identities is a test that
+never spawned anything, so the witness is checked explicitly rather than
+inferred from the verdict.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.mcp_discovery import McpServerInfo
+from kiro_crew.mcp_gateway.preflight import PREFLIGHT_IDENTITY_NAMES, preflight
+from kiro_crew.mcp_gateway.shareability import ShareEvidence, Strength, assess
+
+# A server whose declared capabilities depend on who is asking. This is the
+# hazard the pre-flight exists to detect: the pool caches the FIRST caller's
+# initialize result and replays it to everyone else, so a server that
+# negotiates per-client would hand session B session A's capability set.
+_CALLER_SENSITIVE = '''\
+import json, sys
+from pathlib import Path
+
+witness = Path(sys.argv[1])
+first_identity = sys.argv[2]
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except ValueError:
+        continue
+    method = msg.get("method")
+    if method == "initialize":
+        who = (msg.get("params") or {}).get("clientInfo", {}).get("name", "?")
+        with witness.open("a", encoding="utf-8") as fh:
+            fh.write(who + "\\n")
+        # The divergence: the first identity is told subscriptions exist, anyone
+        # else is not. Compared by equality against the name the pre-flight
+        # really sends, so renaming an identity cannot quietly stop the fixture
+        # from diverging.
+        caps = {"resources": {"subscribe": True}} if who == first_identity else {"resources": {}}
+        sys.stdout.write(json.dumps({
+            "jsonrpc": "2.0", "id": msg.get("id"),
+            "result": {"protocolVersion": "2024-11-05", "capabilities": caps,
+                       "serverInfo": {"name": "caller-sensitive", "version": "1"}},
+        }) + "\\n")
+        sys.stdout.flush()
+    elif method == "tools/list":
+        sys.stdout.write(json.dumps({
+            "jsonrpc": "2.0", "id": msg.get("id"),
+            "result": {"tools": [{"name": "peek", "description": "d"}]},
+        }) + "\\n")
+        sys.stdout.flush()
+'''
+
+# Same script, minus the branch on who is asking.
+_STABLE = _CALLER_SENSITIVE.replace(
+    'caps = {"resources": {"subscribe": True}} if who == first_identity else {"resources": {}}',
+    'caps = {"tools": {"listChanged": True}}',
+).replace('"name": "caller-sensitive"', '"name": "stable"')
+
+# Answers the first caller and then exits, so the SECOND spawn gets nothing.
+# The pre-flight must read that as "no measurement", never as agreement.
+_DIES_AFTER_FIRST = '''\
+import json, sys
+from pathlib import Path
+
+witness = Path(sys.argv[1])
+if witness.exists() and witness.read_text(encoding="utf-8").strip():
+    sys.exit(1)
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except ValueError:
+        continue
+    if msg.get("method") == "initialize":
+        who = (msg.get("params") or {}).get("clientInfo", {}).get("name", "?")
+        with witness.open("a", encoding="utf-8") as fh:
+            fh.write(who + "\\n")
+        sys.stdout.write(json.dumps({
+            "jsonrpc": "2.0", "id": msg.get("id"),
+            "result": {"protocolVersion": "2024-11-05", "capabilities": {},
+                       "serverInfo": {"name": "dies", "version": "1"}},
+        }) + "\\n")
+        sys.stdout.flush()
+    elif msg.get("method") == "tools/list":
+        sys.stdout.write(json.dumps({
+            "jsonrpc": "2.0", "id": msg.get("id"), "result": {"tools": []},
+        }) + "\\n")
+        sys.stdout.flush()
+'''
+
+
+@pytest.fixture
+def real_probe_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An isolated home whose config permits a genuinely unsandboxed spawn.
+
+    ``probe_server`` fail-closes when the host has no OS-level sandbox backend,
+    which is the case on a plain container or a userns-restricted host. Without
+    this opt-in the probe returns "skipped" everywhere such a backend is
+    missing, and these tests would pass while spawning nothing.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "config.json").write_text(
+        json.dumps({"agent": {"sandbox_allow_unsandboxed_exec": True}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("KIROCREW_HOME", str(home))
+    return home
+
+
+def _server(tmp_path: Path, source: str, witness: Path, name: str) -> McpServerInfo:
+    script = tmp_path / f"{name}.py"
+    script.write_text(source, encoding="utf-8")
+    import sys
+
+    return McpServerInfo(
+        name=name,
+        command=sys.executable,
+        args=[str(script), str(witness), PREFLIGHT_IDENTITY_NAMES[0]],
+    )
+
+
+def _identities(witness: Path) -> list[str]:
+    if not witness.exists():
+        return []
+    return [ln for ln in witness.read_text(encoding="utf-8").splitlines() if ln]
+
+
+@pytest.mark.asyncio
+async def test_a_caller_sensitive_server_is_caught_by_provoking_it(
+    tmp_path: Path, real_probe_home: Path
+) -> None:
+    """Two real spawns, two real answers, and the difference is detected."""
+    witness = tmp_path / "seen-caller-sensitive.txt"
+    server = _server(tmp_path, _CALLER_SENSITIVE, witness, "caller-sensitive")
+
+    result = await preflight(server)
+
+    seen = _identities(witness)
+    if not seen:
+        pytest.skip(
+            "the probe did not spawn anything on this host, so nothing here is "
+            "proven. The isolated home does set the unsandboxed opt-in, so the "
+            "blocker is upstream of it — a governance floor above Kiro Crew's own "
+            "config, or no usable spawn backend at all"
+        )
+
+    assert len(seen) == 2, f"the pre-flight must provoke exactly twice, saw {seen}"
+    assert len(set(seen)) == 2, f"both spawns used the same clientInfo: {seen}"
+    assert result.ran is True
+    assert result.caller_sensitive is True, result.reasons
+
+    verdict = assess(
+        ShareEvidence(
+            name=server.name,
+            probe_ok=True,
+            capabilities={"resources": {}},
+            preflight_ran=True,
+            preflight_caller_sensitive=True,
+        )
+    )
+    assert verdict.strength is Strength.DISQUALIFIED
+    assert verdict.recommend_share is False
+
+
+@pytest.mark.asyncio
+async def test_a_stable_server_answers_both_callers_identically(
+    tmp_path: Path, real_probe_home: Path
+) -> None:
+    """The negative case: a server that does not look at who is asking passes.
+
+    Without this, the test above would also pass if the pre-flight reported
+    every server as caller-sensitive.
+    """
+    witness = tmp_path / "seen-stable.txt"
+    server = _server(tmp_path, _STABLE, witness, "stable")
+
+    result = await preflight(server)
+
+    seen = _identities(witness)
+    if not seen:
+        pytest.skip("the probe did not spawn anything on this host")
+
+    assert len(seen) == 2, f"expected two spawns, saw {seen}"
+    assert result.ran is True
+    assert result.caller_sensitive is False, result.reasons
+
+
+@pytest.mark.asyncio
+async def test_a_server_that_never_starts_is_unavailable_not_safe(
+    tmp_path: Path, real_probe_home: Path
+) -> None:
+    """A real failure to launch must read as "no measurement", never as a pass.
+
+    The distinction is the whole reason ``ran`` exists: reporting an
+    unreachable server as not-caller-sensitive would recommend sharing a
+    backend nobody ever spoke to.
+    """
+    server = McpServerInfo(
+        name="missing", command=str(tmp_path / "does-not-exist"), args=[]
+    )
+
+    result = await preflight(server)
+
+    assert result.ran is False
+    verdict = assess(
+        ShareEvidence(
+            name="missing",
+            probe_ok=False,
+            capabilities=None,
+            preflight_ran=False,
+            preflight_caller_sensitive=False,
+        )
+    )
+    assert verdict.recommend_share is False
+
+
+@pytest.mark.asyncio
+async def test_a_server_that_answers_once_then_refuses_is_not_agreement(
+    tmp_path: Path, real_probe_home: Path
+) -> None:
+    """Half a measurement is no measurement.
+
+    The second spawn failing leaves one answer and nothing to compare it to.
+    Reading that as "the two agreed" would recommend sharing a backend on the
+    strength of a single handshake, which is the same fabrication as trusting a
+    server that never started.
+    """
+    witness = tmp_path / "seen-dies.txt"
+    server = _server(tmp_path, _DIES_AFTER_FIRST, witness, "dies-after-first")
+
+    result = await preflight(server)
+
+    seen = _identities(witness)
+    if not seen:
+        pytest.skip("the probe did not spawn anything on this host")
+
+    assert len(seen) == 1, f"the second spawn should have died before answering: {seen}"
+    assert result.ran is False, result.reasons
+    assert result.caller_sensitive is False
+
+
+def test_the_fake_servers_differ_only_in_the_branch_under_test() -> None:
+    """Guard the fixtures: the two scripts must be one edit apart.
+
+    If they drift, the pair stops being a controlled comparison and the
+    caller-sensitive result could come from any other difference.
+    """
+    assert _STABLE != _CALLER_SENSITIVE
+    assert "clientInfo" in _STABLE, "the stable server must still read clientInfo"
+    assert _STABLE.count("initialize") == _CALLER_SENSITIVE.count("initialize")

--- a/test/test_mcp_seed.py
+++ b/test/test_mcp_seed.py
@@ -1,0 +1,105 @@
+"""Seeding cached verdicts into config: once per server, and never re-imposed."""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.mcp_gateway import verdict_cache as vc
+from kiro_crew.mcp_gateway.seed import apply_seed, plan_seed
+
+
+@pytest.fixture
+def cache(tmp_path) -> vc.VerdictCache:
+    return vc.VerdictCache(vc.cache_path(tmp_path))
+
+
+class TestPlan:
+    def test_recommended_server_is_added_and_marked(self, cache) -> None:
+        plan = plan_seed(cache=cache, verdicts={"a": (True, False)}, current_stub=set())
+        assert plan.add_stub == ("a",)
+        assert plan.mark_applied == ("a",)
+        assert plan.wants_share == ()
+
+    def test_already_applied_server_is_left_alone(self, cache) -> None:
+        """The load-bearing guarantee: an operator's "off" survives every restart."""
+        cache.mark_applied("a")
+        plan = plan_seed(cache=cache, verdicts={"a": (True, True)}, current_stub=set())
+        assert plan.is_empty
+
+    def test_not_recommended_is_marked_so_it_is_not_reconsidered(self, cache) -> None:
+        plan = plan_seed(cache=cache, verdicts={"a": (False, False)}, current_stub=set())
+        assert plan.add_stub == ()
+        assert plan.mark_applied == ("a",)
+
+    def test_already_stubbed_server_is_marked_but_not_re_added(self, cache) -> None:
+        plan = plan_seed(cache=cache, verdicts={"a": (True, False)}, current_stub={"a"})
+        assert plan.add_stub == ()
+        assert plan.mark_applied == ("a",)
+
+    def test_share_is_reported_separately_and_never_applied_here(self, cache) -> None:
+        """Seeding never flips the global sharing switch on its own."""
+        plan = plan_seed(cache=cache, verdicts={"a": (True, True)}, current_stub=set())
+        assert plan.wants_share == ("a",)
+        section: dict = {}
+        apply_seed(plan, section, cache)
+        assert "enabled" not in section
+
+    def test_plan_is_deterministic(self, cache) -> None:
+        plan = plan_seed(
+            cache=cache,
+            verdicts={"b": (True, False), "a": (True, False)},
+            current_stub=set(),
+        )
+        assert plan.add_stub == ("a", "b")
+
+
+class TestApply:
+    def test_merges_into_existing_allowlist_without_dropping_entries(self, cache) -> None:
+        section = {"stub_servers": ["z"]}
+        plan = plan_seed(cache=cache, verdicts={"a": (True, False)}, current_stub={"z"})
+        assert apply_seed(plan, section, cache) is True
+        assert section["stub_servers"] == ["a", "z"]
+
+    def test_non_list_allowlist_is_replaced_not_crashed_on(self, cache) -> None:
+        """A hand-edited config can hold anything; seeding must not raise."""
+        section = {"stub_servers": "oops"}
+        plan = plan_seed(cache=cache, verdicts={"a": (True, False)}, current_stub=set())
+        assert apply_seed(plan, section, cache) is True
+        assert section["stub_servers"] == ["a"]
+
+    def test_markers_are_recorded_so_the_next_start_is_a_no_op(self, cache) -> None:
+        section: dict = {}
+        plan = plan_seed(cache=cache, verdicts={"a": (True, False)}, current_stub=set())
+        apply_seed(plan, section, cache)
+
+        again = plan_seed(
+            cache=cache, verdicts={"a": (True, False)}, current_stub=set(section["stub_servers"])
+        )
+        assert again.is_empty
+
+    def test_operator_turning_it_off_survives(self, cache) -> None:
+        """End to end on the promise: seed, user removes it, restart, stays off."""
+        section: dict = {}
+        plan = plan_seed(cache=cache, verdicts={"a": (True, False)}, current_stub=set())
+        apply_seed(plan, section, cache)
+        assert section["stub_servers"] == ["a"]
+
+        section["stub_servers"] = []  # the operator switches it off in the UI
+
+        plan2 = plan_seed(cache=cache, verdicts={"a": (True, False)}, current_stub=set())
+        assert apply_seed(plan2, section, cache) is False
+        assert section["stub_servers"] == []
+
+    def test_markers_survive_a_reload(self, cache, tmp_path) -> None:
+        plan = plan_seed(cache=cache, verdicts={"a": (True, False)}, current_stub=set())
+        apply_seed(plan, {}, cache)
+        cache.flush()
+
+        fresh = vc.load_cache(tmp_path)
+        assert fresh.was_applied("a") is True
+        assert plan_seed(cache=fresh, verdicts={"a": (True, False)}, current_stub=set()).is_empty
+
+    def test_empty_plan_changes_nothing(self, cache) -> None:
+        section = {"stub_servers": ["keep"]}
+        assert apply_seed(plan_seed(cache=cache, verdicts={}, current_stub=set()), section, cache) is False
+        assert section["stub_servers"] == ["keep"]

--- a/test/test_mcp_shareability.py
+++ b/test/test_mcp_shareability.py
@@ -1,0 +1,937 @@
+"""Verdict engine + hazard ledger for stub/share recommendations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kiro_crew.mcp_gateway import hazards, shareability
+from kiro_crew.mcp_gateway import verdict_cache as vc
+from kiro_crew.mcp_gateway.hashing import ENV_SCRUB_PREFIXES
+from kiro_crew.mcp_gateway.record_json import finite_float
+from kiro_crew.mcp_gateway.shareability import ShareEvidence, Strength, assess
+
+
+def _ident(**over: object) -> vc.Identity:
+    base: dict = {
+        "command_args_hash": "cmd1",
+        "env_hash": "env1",
+        "binary_version": "1.0.0",
+    }
+    base.update(over)
+    return vc.Identity(**base)  # type: ignore[arg-type]
+
+
+def _verdict() -> vc.CachedPreflight:
+    return vc.CachedPreflight(ran=True, caller_sensitive=False, reasons=(), evaluated_at=1.0)
+
+
+def _codes(verdict: shareability.ShareVerdict) -> set[str]:
+    return {r.code for r in verdict.reasons}
+
+
+class TestRefutationOutranksEverything:
+    def test_observed_hazard_beats_a_positive_declaration(self) -> None:
+        """A server may declare caller-identity and still be caught misbehaving.
+
+        This ordering is the whole point of the ledger: a declaration is a
+        promise, an observed hazard is what actually happened.
+        """
+        verdict = assess(
+            ShareEvidence(
+                name="x",
+                probe_ok=True,
+                capabilities={"experimental": {shareability.CALLER_IDENTITY_CAPABILITY: {}}},
+                observed_hazards=(hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,),
+            )
+        )
+        assert verdict.strength is Strength.REFUTED
+        assert not verdict.recommend_stub
+        assert not verdict.recommend_share
+        assert _codes(verdict) == {"observed_hazard"}
+
+
+class TestDisqualifiers:
+    def test_rotating_secret_env_disqualifies_without_a_probe(self) -> None:
+        """A config fact stands whether or not the server could be started."""
+        verdict = assess(
+            ShareEvidence(name="x", probe_ok=False, declared_env_names=("AWS_SECRET_ACCESS_KEY",))
+        )
+        assert verdict.strength is Strength.DISQUALIFIED
+        assert _codes(verdict) == {"rotating_secret_env"}
+        assert verdict.reasons[0].detail == "AWS_SECRET_ACCESS_KEY"
+
+    def test_rotating_prefixes_cover_every_pool_key_exclusion(self) -> None:
+        """Ratchet: hashing's scrub list is what makes co-tenants disagree.
+
+        If ``hashing`` grows a prefix this module does not know about, a server
+        authenticating from that variable would be recommended for sharing
+        while the pool key ignores its value — the exact incorrectness this
+        disqualifier exists to prevent.
+        """
+        for prefix in ENV_SCRUB_PREFIXES:
+            assert shareability.rotating_secret_env((prefix + "_X",)) == (prefix + "_X",), prefix
+
+    def test_first_party_is_never_recommended(self) -> None:
+        verdict = assess(ShareEvidence(name="kirocrew-core", is_first_party=True, probe_ok=True))
+        assert verdict.strength is Strength.DISQUALIFIED
+        assert _codes(verdict) == {"first_party_session_scoped"}
+
+    def test_non_stdio_is_out_of_scope_not_unsafe(self) -> None:
+        verdict = assess(ShareEvidence(name="x", is_stdio=False, probe_ok=True))
+        assert _codes(verdict) == {"not_stdio"}
+
+    def test_resources_subscribe_disqualifies(self) -> None:
+        verdict = assess(
+            ShareEvidence(
+                name="x", probe_ok=True, capabilities={"resources": {"subscribe": True}}
+            )
+        )
+        assert verdict.strength is Strength.DISQUALIFIED
+        assert verdict.reasons[0].detail == "resources_subscribe"
+
+    def test_subscribe_false_is_an_explicit_no_and_does_not_count(self) -> None:
+        """``{"subscribe": false}`` is the server saying it does NOT subscribe."""
+        verdict = assess(
+            ShareEvidence(
+                name="x",
+                probe_ok=True,
+                has_tools=True,
+                capabilities={"resources": {"subscribe": False, "listChanged": True}},
+            )
+        )
+        assert verdict.strength is Strength.NO_OBJECTION
+
+    def test_list_changed_alone_is_not_a_disqualifier(self) -> None:
+        """Those notifications are global broadcasts, safe to fan out."""
+        verdict = assess(
+            ShareEvidence(
+                name="x",
+                probe_ok=True,
+                has_tools=True,
+                capabilities={
+                    "tools": {"listChanged": True},
+                    "prompts": {"listChanged": True},
+                    "resources": {"listChanged": True},
+                },
+            )
+        )
+        assert verdict.strength is Strength.NO_OBJECTION
+
+    def test_declaring_logging_at_all_disqualifies(self) -> None:
+        """In MCP an empty object ADVERTISES a capability, it does not withhold it.
+
+        ``{"logging": {}}`` means ``logging/setLevel`` is supported, and that
+        level is process-wide: one co-tenant's call changes what every other
+        session receives. Testing truthiness here (an earlier version of this
+        module) let exactly that server through as shareable.
+        """
+        for caps in ({"logging": {}}, {"logging": {"level": "info"}}):
+            verdict = assess(ShareEvidence(name="x", probe_ok=True, capabilities=caps))
+            assert verdict.strength is Strength.DISQUALIFIED, caps
+            assert verdict.reasons[0].detail == "logging_level"
+
+    def test_absent_logging_key_does_not_disqualify(self) -> None:
+        verdict = assess(
+            ShareEvidence(name="x", probe_ok=True, has_tools=True, capabilities={"tools": {}})
+        )
+        assert verdict.strength is Strength.NO_OBJECTION
+
+
+class TestUnknownVersusNoObjection:
+    def test_never_probed_is_unknown_not_recommendable(self) -> None:
+        verdict = assess(ShareEvidence(name="x", probe_ok=False))
+        assert verdict.strength is Strength.UNKNOWN
+        assert not verdict.recommend_stub
+        assert _codes(verdict) == {"not_probed"}
+
+    def test_probe_ok_with_no_capabilities_object_is_still_unknown(self) -> None:
+        """``capabilities=None`` means we never saw a handshake result."""
+        verdict = assess(ShareEvidence(name="x", probe_ok=True, capabilities=None))
+        assert verdict.strength is Strength.UNKNOWN
+
+
+class TestPositiveDeclaration:
+    def test_caller_identity_plus_passed_preflight_recommends_both(self) -> None:
+        verdict = assess(
+            ShareEvidence(
+                name="x",
+                probe_ok=True,
+                has_tools=True,
+                capabilities={"experimental": {shareability.CALLER_IDENTITY_CAPABILITY: {}}},
+                preflight_ran=True,
+            )
+        )
+        assert verdict.strength is Strength.DECLARED
+        assert verdict.recommend_stub and verdict.recommend_share
+        assert "declares_caller_identity" in _codes(verdict)
+        assert "preflight_passed" in _codes(verdict)
+
+    def test_declaration_without_a_run_preflight_does_not_grant_sharing(self) -> None:
+        """A promise nobody has tested is not evidence.
+
+        The whole point of anticipating is that a real session must not be the
+        first thing to discover the server was wrong about itself.
+        """
+        verdict = assess(
+            ShareEvidence(
+                name="x",
+                probe_ok=True,
+                has_tools=True,
+                capabilities={"experimental": {shareability.CALLER_IDENTITY_CAPABILITY: {}}},
+                preflight_ran=None,
+            )
+        )
+        assert verdict.strength is Strength.DECLARED
+        assert verdict.recommend_stub is True
+        assert verdict.recommend_share is False
+        assert "preflight_not_run" in _codes(verdict)
+
+    def test_measurement_beats_the_declaration(self) -> None:
+        """Caught answering initialize per-caller outranks advertising support."""
+        verdict = assess(
+            ShareEvidence(
+                name="x",
+                probe_ok=True,
+                has_tools=True,
+                capabilities={"experimental": {shareability.CALLER_IDENTITY_CAPABILITY: {}}},
+                preflight_ran=True,
+                preflight_caller_sensitive=True,
+            )
+        )
+        assert verdict.strength is Strength.DISQUALIFIED
+        assert _codes(verdict) == {"caller_sensitive_initialize"}
+        assert not verdict.recommend_stub
+
+
+class TestNoObjectionSplitsStubFromShare:
+    def test_absence_of_evidence_recommends_stub_but_not_share(self) -> None:
+        """The load-bearing product decision.
+
+        Stubbing keeps the backend 1:1 with the session — same topology as no
+        gateway — and is what unlocks server-authored UI. Sharing is the step
+        that introduces co-tenancy. On weak evidence we offer the safe half.
+        """
+        verdict = assess(ShareEvidence(name="x", probe_ok=True, has_tools=True, capabilities={}))
+        assert verdict.strength is Strength.NO_OBJECTION
+        assert verdict.recommend_stub is True
+        assert verdict.recommend_share is False
+
+    def test_read_only_annotations_are_reported_as_supporting_evidence(self) -> None:
+        verdict = assess(
+            ShareEvidence(
+                name="x",
+                probe_ok=True,
+                has_tools=True,
+                capabilities={},
+                protocol_version="2025-06-18",
+                tool_annotations=[{"readOnlyHint": True}, {"readOnlyHint": True}],
+            )
+        )
+        assert "all_tools_read_only" in _codes(verdict)
+
+    def test_one_writing_tool_removes_the_read_only_claim(self) -> None:
+        verdict = assess(
+            ShareEvidence(
+                name="x",
+                probe_ok=True,
+                has_tools=True,
+                capabilities={},
+                tool_annotations=[{"readOnlyHint": True}, {"readOnlyHint": False}],
+            )
+        )
+        assert "all_tools_read_only" not in _codes(verdict)
+
+    def test_missing_annotations_are_reported_as_unavailable_not_as_writes(self) -> None:
+        """An older protocol version cannot send annotations; say so."""
+        verdict = assess(
+            ShareEvidence(
+                name="x",
+                probe_ok=True,
+                has_tools=True,
+                capabilities={},
+                protocol_version="2024-11-05",
+            )
+        )
+        codes = _codes(verdict)
+        assert "no_tool_annotations" in codes
+        assert "all_tools_read_only" not in codes
+        detail = next(r.detail for r in verdict.reasons if r.code == "no_tool_annotations")
+        assert detail == "2024-11-05"
+
+
+class TestHazardLedger:
+    def test_record_flush_and_reload_round_trip(self, tmp_path) -> None:
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        assert led.record("srv", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST) is True
+        assert led.record("srv", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST) is False
+        led.flush()
+
+        fresh = hazards.load_ledger(tmp_path)
+        assert fresh.codes_for("srv") == (hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,)
+        assert fresh.codes_for("other") == ()
+
+    def test_unknown_code_is_refused(self, tmp_path) -> None:
+        """The vocabulary is a UI contract; a typo must not disqualify forever."""
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        assert led.record("srv", "made_up") is False
+        assert led.codes_for("srv") == ()
+        led.flush()
+        assert not hazards.ledger_path(tmp_path).exists()
+
+    def test_missing_file_reads_as_no_hazards(self, tmp_path) -> None:
+        assert hazards.load_ledger(tmp_path).as_dict() == {}
+
+    def test_corrupt_file_reads_as_no_hazards(self, tmp_path) -> None:
+        hazards.ledger_path(tmp_path).write_text("{not json", encoding="utf-8")
+        assert hazards.load_ledger(tmp_path).as_dict() == {}
+
+    def test_future_schema_is_ignored_rather_than_guessed(self, tmp_path) -> None:
+        hazards.ledger_path(tmp_path).write_text(
+            json.dumps({"schema": 99, "servers": {"srv": {"codes": ["whatever"]}}}),
+            encoding="utf-8",
+        )
+        assert hazards.load_ledger(tmp_path).as_dict() == {}
+
+    def test_unknown_codes_are_dropped_on_read(self, tmp_path) -> None:
+        hazards.ledger_path(tmp_path).write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "servers": {
+                        "a": {"codes": ["made_up"], "count": 3},
+                        "b": {"codes": [hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION]},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        led = hazards.load_ledger(tmp_path)
+        assert led.codes_for("a") == ()
+        assert led.codes_for("b") == (hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION,)
+
+    def test_flush_is_a_no_op_when_clean(self, tmp_path) -> None:
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        led.flush()
+        assert not hazards.ledger_path(tmp_path).exists()
+
+    def test_an_observation_during_the_write_is_not_marked_persisted(self, tmp_path) -> None:
+        """The flush runs off-loop while ``record`` keeps running on it.
+
+        Clearing dirty unconditionally would drop an observation that landed
+        mid-write: the ledger would look clean while the file lacked the entry, so
+        a hazard the gateway really saw would never withdraw a recommendation.
+        """
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        led.record("srv", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST)
+
+        real_write = hazards.atomic_write
+
+        def racing_write(path, content, **kw):  # noqa: ANN001
+            # Simulate the loop recording while this thread is mid-write.
+            led.record("other", hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION)
+            return real_write(path, content, **kw)
+
+        hazards.atomic_write = racing_write  # type: ignore[assignment]
+        try:
+            led.flush()
+        finally:
+            hazards.atomic_write = real_write  # type: ignore[assignment]
+
+        assert led._dirty is True, "the concurrent observation was marked persisted"
+        led.flush()
+        assert hazards.load_ledger(tmp_path).codes_for("other") == (
+            hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION,
+        )
+
+    def test_concurrent_flushes_cannot_revert_the_file(self, tmp_path) -> None:
+        """Two flush callers race, and the loser must not be the newer snapshot.
+
+        The periodic sweep and the shutdown flush both run in worker threads and
+        can overlap — cancellation starts the second while the first is mid-write.
+        Each builds its payload from the in-memory records BEFORE writing, so
+        without serialization the thread that writes last can be the one that read
+        first, silently reverting an observation already on disk.
+        """
+        import threading
+
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        led.record("first", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST)
+
+        real_write = hazards.atomic_write
+        entered = threading.Event()
+        release = threading.Event()
+
+        def slow_write(path, text):
+            # Hold the first writer inside the critical section long enough for a
+            # second flush to attempt an overlap.
+            if not entered.is_set():
+                entered.set()
+                release.wait(2)
+            return real_write(path, text)
+
+        hazards.atomic_write = slow_write  # type: ignore[assignment]
+        try:
+            t = threading.Thread(target=led.flush)
+            t.start()
+            assert entered.wait(2), "the first flush never reached the write"
+            # A newer observation lands, then a second flush races the first.
+            led.record("second", hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION)
+            second = threading.Thread(target=led.flush)
+            second.start()
+            release.set()
+            t.join(5)
+            second.join(5)
+        finally:
+            hazards.atomic_write = real_write  # type: ignore[assignment]
+            release.set()
+
+        on_disk = hazards.load_ledger(tmp_path).as_dict()
+        assert "first" in on_disk
+        assert "second" in on_disk, "the newer observation was reverted by an older flush"
+
+    def test_ledger_feeds_the_verdict(self, tmp_path) -> None:
+        """End to end: what gatewayd observed withdraws the recommendation."""
+        led = hazards.HazardLedger(hazards.ledger_path(tmp_path))
+        led.record("srv", hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION)
+        led.flush()
+
+        observed = hazards.load_ledger(tmp_path).codes_for("srv")
+        verdict = assess(
+            ShareEvidence(
+                name="srv", probe_ok=True, capabilities={}, observed_hazards=observed
+            )
+        )
+        assert verdict.strength is Strength.REFUTED
+
+
+class TestHostileRecordNumbers:
+    """A record file is not a protocol message -- nothing upstream validates it.
+
+    Both records are loaded during gateway startup, so a loader that raises
+    takes the daemon down before it binds its socket. ``isinstance(v, (int,
+    float))`` reads as a sufficient guard and is not: JSON parses a bare number
+    into ``int``, which has no size limit, and ``float()`` of a large enough one
+    raises ``OverflowError`` -- an ``ArithmeticError``, so it escapes a guard
+    spelled ``except (TypeError, ValueError)``.
+    """
+
+    #: 310 digits: past the largest representable double, still valid JSON.
+    HUGE = "9" * 310
+
+    def test_overflowing_int_is_not_a_float_conversion_away(self) -> None:
+        """The premise, stated as a test so a Python change cannot silently void it."""
+        import json
+
+        parsed = json.loads(f'{{"n": {self.HUGE}}}')["n"]
+        assert isinstance(parsed, int)
+        with pytest.raises(OverflowError):
+            float(parsed)
+        assert not issubclass(OverflowError, (TypeError, ValueError))
+
+    def test_the_string_form_yields_infinity_instead_of_raising(self) -> None:
+        """The other half: no exception, but a timestamp nothing can order."""
+        assert float(self.HUGE) == float("inf")
+        assert finite_float(float("inf")) == 0.0
+        assert finite_float(float("nan")) == 0.0
+
+    def test_a_huge_timestamp_does_not_take_the_ledger_down(self, tmp_path) -> None:
+        hazards.ledger_path(tmp_path).write_text(
+            '{"schema": 1, "servers": {"srv": {"codes": ["%s"], "count": 1,'
+            ' "lastSeen": %s}}}'
+            % (hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION, self.HUGE),
+            encoding="utf-8",
+        )
+
+        led = hazards.load_ledger(tmp_path)
+
+        assert led.codes_for("srv") == (hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION,)
+
+    def test_a_huge_timestamp_does_not_take_the_verdict_cache_down(self, tmp_path) -> None:
+        vc.cache_path(tmp_path).write_text(
+            '{"schema": 1, "entries": {"srv\\u0000c\\u0000e\\u0000b\\u00001":'
+            ' {"ran": true, "callerSensitive": false, "reasons": [],'
+            ' "evaluatedAt": %s}}}' % self.HUGE,
+            encoding="utf-8",
+        )
+
+        cache = vc.load_cache(tmp_path)
+
+        assert len(cache) == 1
+
+    def test_bool_is_not_accepted_as_a_number(self) -> None:
+        """``bool`` is an ``int`` subclass, so a JSON ``true`` would read as 1.0."""
+        assert finite_float(True) == 0.0
+        assert finite_float(False) == 0.0
+
+
+class TestNameCollisionDoesNotInheritEvidence:
+    """One server owns one row, so the reader is a direct lookup.
+
+    The ambiguity that matters is one NAME covering two different launches in the
+    merged agent config: the rows merge, and serving the measured definition's
+    verdict to the merged row would hand an unmeasured one its
+    ``recommend_share``. That is decided in the row loop, where both definitions
+    are visible — not here.
+    """
+
+    @staticmethod
+    def _write_row(tmp_path: Path, name: str, ident: vc.Identity) -> None:
+        cache = vc.VerdictCache(vc.cache_path(tmp_path))
+        cache.put(name, ident, vc.CachedPreflight(True, False, (), 1.0))
+        cache.flush()
+
+    def test_a_stored_row_is_served_by_name(self, tmp_path, monkeypatch) -> None:
+        from kiro_crew.dashboard.handlers import mcp as handler
+
+        self._write_row(tmp_path, "srv", _ident(command_args_hash="cmdA"))
+        monkeypatch.setattr(handler, "records_dir", lambda *_a, **_k: tmp_path)
+
+        _observed, preflights = handler._load_shareability_state()
+
+        assert preflights.get("srv") == (True, False)
+
+    def test_a_changed_identity_overwrites_rather_than_accumulating(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Editing a server's command leaves ONE row, carrying the new measurement.
+
+        Keying by identity would have left the superseded row behind, which is what
+        forced a size cap, an eviction policy, and a newest-wins rule on every
+        reader. There is no history to sort through now.
+        """
+        from kiro_crew.dashboard.handlers import mcp as handler
+
+        cache = vc.VerdictCache(vc.cache_path(tmp_path))
+        cache.put(
+            "srv",
+            _ident(command_args_hash="old"),
+            vc.CachedPreflight(True, True, ("caller_sensitive_initialize",), 1.0),
+        )
+        cache.put(
+            "srv",
+            _ident(command_args_hash="new"),
+            vc.CachedPreflight(True, False, (), 2.0),
+        )
+        cache.flush()
+        assert len(vc.load_cache(tmp_path)) == 1
+        monkeypatch.setattr(handler, "records_dir", lambda *_a, **_k: tmp_path)
+
+        _observed, preflights = handler._load_shareability_state()
+
+        assert preflights.get("srv") == (True, False), "the newest measurement wins"
+
+    def test_the_same_definition_in_many_agents_is_not_ambiguous(self) -> None:
+        """Listing one server in several agents is the ordinary case.
+
+        Withholding on agent COUNT rather than on distinct launches would cost a
+        correct recommendation for every server an operator shares across agents,
+        which is most of them. The row keys on the launch hash for that reason.
+        """
+        from kiro_crew.mcp_gateway.hashing import hash_command
+
+        assert len({hash_command("/bin/a", ["--x"]) for _ in range(5)}) == 1
+        assert len({hash_command("/bin/a", []), hash_command("/bin/b", [])}) == 2
+
+
+class TestNoBlockingRecordIoOnTheLoop:
+    """One invariant, not one assertion per site.
+
+    Every filesystem touch of the two shareability records happens off the event
+    loop. Three separate rounds of this same finding — the row builder, the
+    evaluation pass, then daemon startup — were each closed by patching the
+    instance that was reported, because the rule named the blocking helpers in a
+    hand-written list. A helper missing from that list was invisible, so the
+    fourth instance (deriving cache keys, the most expensive of them) passed a
+    green ratchet.
+
+    So the blocking set is DERIVED from the modules themselves: any helper that
+    reaches a filesystem or subprocess primitive counts, whether or not anyone
+    remembered to list it.
+    """
+
+    #: Modules whose helpers own the record files and the binaries behind them.
+    RECORD_MODULES = (
+        "kiro_crew.mcp_gateway.hazards",
+        "kiro_crew.mcp_gateway.verdict_cache",
+        "kiro_crew.mcp_gateway.evaluate",
+    )
+
+    #: Primitives that make a helper blocking. Deliberately spelled as bare
+    #: attribute/function names, because that is how they appear at the call
+    #: site regardless of how the module imported them.
+    IO_PRIMITIVES = frozenset(
+        {
+            "open",
+            "atomic_write",
+            "read_text",
+            "write_text",
+            "read_bytes",
+            "write_bytes",
+            "mkdir",
+            "unlink",
+            "replace",
+            "stat",
+            "which",
+            "run",
+            "Popen",
+            "binary_fingerprint",
+            "communicate",
+        }
+    )
+
+    #: (module, async function) pairs that reach the records.
+    SITES = (
+        ("kiro_crew.dashboard.handlers.mcp", "api_mcp_gateway_servers"),
+        ("kiro_crew.dashboard.handlers.mcp", "_evaluate_shareability"),
+        ("kiro_crew.mcp_gateway.evaluate", "evaluate_new_servers"),
+    )
+
+    @classmethod
+    def _blocking_helpers(cls) -> set[str]:
+        """Names of helpers in the record modules that reach an IO primitive.
+
+        Transitive on purpose. ``load_cache`` touches no primitive itself — it
+        delegates to ``VerdictCache.load``, which does. A derivation that only
+        looked one level deep, or only at module-level functions, would call the
+        public entry points non-blocking and wave through exactly the calls this
+        rule exists to stop.
+        """
+        import ast
+        import importlib
+        import inspect
+
+        calls: dict[str, set[str]] = {}
+        module_level: set[str] = set()
+        for module_name in cls.RECORD_MODULES:
+            mod = importlib.import_module(module_name)
+            tree = ast.parse(inspect.getsource(mod))
+            module_level.update(
+                node.name
+                for node in tree.body
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            )
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                called: set[str] = set()
+                for inner in ast.walk(node):
+                    if not isinstance(inner, ast.Call):
+                        continue
+                    func = inner.func
+                    if isinstance(func, ast.Attribute):
+                        called.add(func.attr)
+                    elif isinstance(func, ast.Name):
+                        called.add(func.id)
+                calls.setdefault(node.name, set()).update(called)
+
+        blocking = {n for n, c in calls.items() if c & cls.IO_PRIMITIVES}
+        while True:
+            grown = {n for n, c in calls.items() if c & blocking}
+            if not grown <= blocking:
+                blocking |= grown
+                continue
+            # Methods drive the transitivity above but are not reported: a bare
+            # method name is not unique to these modules, and matching one by
+            # name alone flagged ``KiroCrewConfig.load()`` — an unrelated loader
+            # the whole codebase calls on the loop by design. What another module
+            # can actually reach is a module-level entry point, so that is what
+            # the caller scans for.
+            return blocking & module_level
+
+    def test_the_blocking_set_is_actually_derived(self) -> None:
+        """Guard the guard: an empty derivation would pass every check below."""
+        found = self._blocking_helpers()
+        assert {"load_cache", "load_ledger", "identity_for"} <= found, found
+
+    @pytest.mark.parametrize("module_name,func_name", SITES)
+    def test_every_record_touch_is_offloaded(self, module_name: str, func_name: str) -> None:
+        import importlib
+        import inspect
+
+        blocking = self._blocking_helpers() | {"flush", "install_sink"}
+        mod = importlib.import_module(module_name)
+        src = inspect.getsource(getattr(mod, func_name))
+        for line in src.splitlines():
+            code = line.split("#")[0]
+            if "to_thread" in code:
+                continue
+            for name in blocking:
+                assert f"{name}(" not in code, (
+                    f"{module_name}.{func_name}: {name} does blocking IO and runs "
+                    f"on the event loop -- offload it\n    {line.strip()}"
+                )
+
+    def test_the_key_derivation_refuses_to_run_on_the_loop(self) -> None:
+        """Belt and braces: the ratchet reads source, this catches a live call.
+
+        A reviewer can restructure the call into a shape the line scan does not
+        recognise; this fires regardless of how it is spelled.
+        """
+        import asyncio
+
+        from kiro_crew.mcp_gateway import evaluate
+
+        async def call_it() -> None:
+            evaluate.identity_for(
+                SimpleNamespace(name="s", command="/bin/true", args=[], env={})
+            )
+
+        with pytest.raises(RuntimeError, match="must not run on the event loop"):
+            asyncio.run(call_it())
+
+    def test_gatewayd_installs_the_sink_off_loop(self) -> None:
+        """Startup counts too: a slow ledger would delay socket readiness."""
+        import inspect
+
+        from kiro_crew.mcp_gateway import gatewayd
+
+        src = inspect.getsource(gatewayd.run_gatewayd)
+        line = next(ln for ln in src.splitlines() if "install_sink" in ln)
+        assert "to_thread" in line, line.strip()
+
+    def test_the_expensive_modules_stay_off_the_gateway_boot_path(self) -> None:
+        """``evaluate`` must not be imported at module scope by the handler.
+
+        The handler is on the gateway's boot path, and ``evaluate`` pulls in
+        ``preflight`` -> ``mcp_discovery`` and ``stub`` (the stub PROCESS entry
+        point). Measured on this tree, hoisting it added 8 modules to that path
+        and pushed a startup loop-responsiveness ceiling over on Windows. The
+        top-level-imports convention loses to a measured startup regression —
+        this is a boot-path decision, NOT an unproven circular-import excuse.
+
+        Asserted at module scope rather than by importing and counting, so the
+        test states the rule instead of re-measuring a machine-dependent number.
+        """
+        import ast
+        import inspect
+
+        from kiro_crew.dashboard.handlers import mcp as handler
+
+        tree = ast.parse(inspect.getsource(handler))
+        banned = {
+            "kiro_crew.mcp_gateway.evaluate",
+            "kiro_crew.mcp_gateway.preflight",
+            "kiro_crew.mcp_gateway.stub",
+        }
+        for node in tree.body:  # module scope only
+            if isinstance(node, ast.ImportFrom) and node.module in banned:
+                raise AssertionError(
+                    f"{node.module} imported at module scope (line {node.lineno}) -- "
+                    "that puts the stub/preflight chain on the gateway boot path"
+                )
+
+    def test_the_new_modules_have_no_function_local_imports(self) -> None:
+        """Hoisted to module scope, and proven cycle-free in both load orders.
+
+        A function-local import here is not a style nit: it hides a real cycle if
+        one exists, and the convention is to prove the absence instead.
+        """
+        import ast
+        import inspect
+
+        from kiro_crew.mcp_gateway import evaluate, preflight, seed, verdict_cache
+
+        for mod in (shareability, hazards, preflight, verdict_cache, seed, evaluate):
+            tree = ast.parse(inspect.getsource(mod))
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for inner in ast.walk(node):
+                    if isinstance(inner, (ast.Import, ast.ImportFrom)):
+                        raise AssertionError(
+                            f"{mod.__name__}.{node.name} imports at function scope "
+                            f"(line {inner.lineno}) -- hoist it to module scope"
+                        )
+
+    def test_assess_server_is_pure(self) -> None:
+        """It takes the loaded state as arguments and opens nothing."""
+        import inspect
+
+        from kiro_crew.dashboard.handlers import mcp as handler
+
+        src = inspect.getsource(handler._assess_server)
+        for forbidden in ("load_cache", "load_ledger", "KiroCrewConfig", "open("):
+            assert forbidden not in src, f"{forbidden} moved back into the row path"
+        params = inspect.signature(handler._assess_server).parameters
+        assert "preflight" in params, "preflight must be passed in, not looked up"
+        assert "observed_hazards" in params
+
+    def test_the_loader_is_awaited_off_loop_exactly_once(self) -> None:
+        """One ``to_thread`` call, outside the row loop."""
+        import inspect
+
+        from kiro_crew.dashboard.handlers import mcp as handler
+
+        src = inspect.getsource(handler.api_mcp_gateway_servers)
+        assert src.count("_load_shareability_state") == 1
+        assert "asyncio.to_thread(_load_shareability_state)" in src
+        # The call must precede the loop that builds rows, or it is per-row again.
+        assert src.index("_load_shareability_state") < src.index("for name in sorted(rows)")
+
+    def test_cache_exposes_names(self) -> None:
+        cache = vc.VerdictCache(vc.cache_path(Path("/nonexistent")))
+        cache.put("a", _ident(), _verdict())
+        cache.put("b", _ident(command_args_hash="other"), _verdict())
+        assert cache.server_names() == {"a", "b"}
+
+
+class TestRecordsDirIsNotGatedOnABroker:
+    """A machine that never enabled stubbing must still get verdicts.
+
+    Deriving the records directory from ``mcp_gateway.socket_path`` made the
+    whole feature inert for exactly its audience: that field is empty until a
+    broker is configured, and the recommendation exists to tell an operator
+    whether configuring one is safe.
+    """
+
+    def test_unconfigured_socket_still_resolves_a_directory(self, monkeypatch, tmp_path) -> None:
+        from kiro_crew.mcp_gateway.rewriter import records_dir, runtime_dir
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        assert records_dir("") == runtime_dir()
+        assert records_dir("") == tmp_path / "mcp-gateway"
+
+    def test_configured_socket_wins_so_writer_and_reader_agree(self, tmp_path) -> None:
+        """gatewayd writes beside its real socket; the page must read there."""
+        from kiro_crew.mcp_gateway.rewriter import records_dir
+
+        sock = tmp_path / "custom" / "gateway.sock"
+        assert records_dir(str(sock)) == sock.parent
+        # gatewayd passes a Path, the dashboard passes a str — both must work.
+        assert records_dir(sock) == sock.parent
+
+    def test_an_empty_path_does_not_resolve_to_the_cwd(self, monkeypatch, tmp_path) -> None:
+        """``Path("")`` is ``PosixPath(".")`` and therefore truthy.
+
+        Branching on the Path instead of its string form would put the hazard
+        ledger in whatever directory the process happened to start in.
+        """
+        from kiro_crew.mcp_gateway.rewriter import records_dir, runtime_dir
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        assert records_dir(Path("")) == runtime_dir()
+        assert records_dir(None) == runtime_dir()  # type: ignore[arg-type]
+        assert records_dir(".") == runtime_dir()
+        # But a REAL relative socket keeps its own directory — the guard is on
+        # the input being bare ".", not on the parent resolving to ".".
+        assert records_dir("gateway.sock") == Path(".")
+
+    def test_the_default_socket_lives_in_that_same_directory(self, monkeypatch, tmp_path) -> None:
+        from kiro_crew.mcp_gateway.rewriter import default_socket_path, runtime_dir
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        assert default_socket_path().parent == runtime_dir()
+
+    def test_neither_reader_nor_trigger_short_circuits_on_an_empty_socket(self) -> None:
+        """Ratchet: the early `if not socket_path: return` must not come back."""
+        import inspect
+
+        from kiro_crew.dashboard.handlers import mcp as handler
+
+        for fn in (handler._load_shareability_state, handler._evaluate_shareability):
+            src = inspect.getsource(fn)
+            assert "records_dir" in src, f"{fn.__name__} must use the shared resolver"
+            assert "if not socket_path" not in src, f"{fn.__name__} regained the broker gate"
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        ShareEvidence(name="a", probe_ok=False),
+        ShareEvidence(name="b", probe_ok=True, capabilities={}),
+        ShareEvidence(name="c", is_stdio=False),
+    ],
+)
+def test_to_dict_is_json_serialisable(evidence: ShareEvidence) -> None:
+    """The verdict crosses an HTTP boundary; it must survive json.dumps."""
+    json.dumps(assess(evidence).to_dict())
+
+
+class TestBackendRecordsHazards:
+    """The writer side. Without these the ledger is a declaration, not a signal."""
+
+    @staticmethod
+    def _backend(server_name: str, *, exclusive_token: str = "", refcount: int = 2) -> object:
+        """A Backend-shaped stand-in for the three fields ``_record_hazard`` reads.
+
+        Deliberately not a MagicMock: the point is to pin that the method reads
+        ``pool_key.server_name``, ``exclusive_token`` and ``refcount`` — the REAL
+        field names on ``Backend`` — so a rename cannot leave this passing
+        against a mock that would answer to anything.
+
+        ``refcount`` defaults to 2 because that is the only state in which a
+        hazard means anything: two clients attached, so an unattributable frame
+        could have reached the wrong one.
+        """
+        from kiro_crew.mcp_gateway.backend import Backend
+
+        obj = object.__new__(Backend)
+        obj.pool_key = SimpleNamespace(server_name=server_name)  # type: ignore[attr-defined]
+        obj.exclusive_token = exclusive_token  # type: ignore[attr-defined]
+        obj.refcount = refcount  # type: ignore[attr-defined]
+        return obj
+
+    def test_shared_backend_records(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(hazards, "_sink", hazards.HazardLedger(hazards.ledger_path(tmp_path)))
+        backend = self._backend("srv")
+        backend._record_hazard(hazards.HAZARD_UNROUTABLE_SERVER_REQUEST)  # type: ignore[attr-defined]
+        hazards.flush_sink()
+        assert hazards.load_ledger(tmp_path).codes_for("srv") == (
+            hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,
+        )
+
+    def test_exclusive_backend_does_not_record(self, tmp_path, monkeypatch) -> None:
+        """A 1:1 backend legitimately owns its single client.
+
+        The same frame there proves nothing about shareability, so recording it
+        would disqualify servers for behaviour that is correct when unshared.
+        """
+        monkeypatch.setattr(hazards, "_sink", hazards.HazardLedger(hazards.ledger_path(tmp_path)))
+        backend = self._backend("srv", exclusive_token="stub-uuid")
+        backend._record_hazard(hazards.HAZARD_UNROUTABLE_SERVER_REQUEST)  # type: ignore[attr-defined]
+        hazards.flush_sink()
+        assert hazards.load_ledger(tmp_path).as_dict() == {}
+
+    @pytest.mark.parametrize("refcount", [0, 1])
+    def test_a_pooled_backend_with_one_client_does_not_record(
+        self, tmp_path, monkeypatch, refcount: int
+    ) -> None:
+        """Being poolable is not the same as currently serving two clients.
+
+        A pooled backend serves exactly one client from the moment it starts
+        until a second stub attaches, and none at all between sessions. An
+        unattributable frame in either state had no second tenant to reach, so it
+        says nothing about shareability — and a hazard is permanent, so recording
+        one here would kill a server for behaviour that is correct.
+        """
+        monkeypatch.setattr(hazards, "_sink", hazards.HazardLedger(hazards.ledger_path(tmp_path)))
+        backend = self._backend("srv", refcount=refcount)
+        backend._record_hazard(hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION)  # type: ignore[attr-defined]
+        hazards.flush_sink()
+        assert hazards.load_ledger(tmp_path).as_dict() == {}
+
+    def test_no_sink_installed_is_a_silent_no_op(self, monkeypatch) -> None:
+        """The stub process and unit tests never install a sink."""
+        monkeypatch.setattr(hazards, "_sink", None)
+        assert hazards.record_observed("srv", hazards.HAZARD_UNROUTABLE_SERVER_REQUEST) is False
+        hazards.flush_sink()  # must not raise
+
+    def test_both_observation_sites_call_the_recorder(self) -> None:
+        """Ratchet: the two hazard sites must stay wired to the ledger.
+
+        Asserted on the source because reproducing either frame end to end
+        needs a live shared backend and a misbehaving server; the value here is
+        catching a future edit that deletes the call while keeping the log line.
+        """
+        from pathlib import Path as _Path
+
+        import kiro_crew.mcp_gateway.backend as backend_mod
+
+        src = _Path(backend_mod.__file__).read_text(encoding="utf-8")
+        assert src.count("self._record_hazard(") == 2, "expected exactly two hazard sites"
+        assert "hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION" in src
+        assert "hazards.HAZARD_UNROUTABLE_SERVER_REQUEST" in src


### PR DESCRIPTION
## 1. What is the problem?

Deciding which MCP servers to stub — and which may share one backend across sessions — is a correctness question the operator is asked to answer with no information. The MCP Management page lists every configured server with a `Stub` toggle and no guidance, so knowing whether a server keeps per-caller state has to come from outside the product.

Nothing helps, and nothing stops a bad choice from hurting:

- **The probe throws away the answer it already paid for.** `probe_server` performs a full MCP `initialize` handshake and keeps only the tool names. The advertised `capabilities` — including the `kirocrew.caller-identity` extension that exists precisely to say "I can tell my callers apart" — is discarded.
- **The one capability that IS parsed is not used for this.** `Backend` reads `capabilities.experimental["kirocrew.caller-identity"]` only to decide whether to inject a caller block. `UNPOOLABLE_SERVERS` is empty, and the comment above it describes gatewayd refusing to pool a backend that does not advertise the capability — **no such refusal exists in the code**.
- **Two proofs of statefulness are detected, then forgotten.** When a shared backend emits a server-initiated request with no `relatedRequestId`, the backend is recycled; when a request-scoped notification cannot be attributed, it is dropped. Both mean the server keeps per-client state, and both are only log lines. Nothing remembers them, so the same server is offered on the same terms after every restart.
- **Two config-level hazards are invisible.** A server whose `env` declares a rotating credential (`AWS_SECRET*` / `AWS_SESSION*` / `OAUTH*`) can never be safely shared, because those names are deliberately excluded from `PoolKey.effective_env_hash` so credential rotation does not split the pool — which means two co-tenants can disagree on the value. And Kiro Crew's own three managed servers bind `KIROCREW_SESSION_KEY`, so they are per-session by construction.

## 2. Why this issue matters to the user

The failure is silent and delayed. A server that is unsafe to share appears to work until a second session attaches, and then the affected chat loses that server's tools until it is reopened. Nothing in the UI explains why, and nothing prevents the same choice on the next machine.

The reverse cost is just as real: with no guidance the safe default is to stub nothing, so every session keeps launching its own copy of every MCP server — the process-count cost the gateway exists to remove.

## 3. How our fix solves it

Predict the hazard before a user pays for it, and derive the answer locally so no list of server names ships or leaves the host.

**Rank the evidence, and let the ranking decide.** `mcp_gateway/shareability.py::assess` is pure — no IO, no config, no clock — and orders evidence observation > measurement > declaration:

| Strength | Source |
|---|---|
| `refuted` | the gateway WATCHED this server behave per-client while shared |
| `disqualified` | a pre-flight measurement, or a config/transport fact |
| `declared` | the server advertises the caller-identity extension |
| `no_objection` | nothing disqualifying was found |
| `unknown` | not enough was observed to say anything |

A server may advertise caller-identity and still be `disqualified` because the pre-flight caught it answering `initialize` differently per caller, and it may pass the pre-flight and still be `refuted` later.

**Provoke the failure offline.** `mcp_gateway/preflight.py` spawns the server twice under two different `clientInfo` identities and compares the SHAPE of the advertised capabilities. Divergence proves caller sensitivity — the hazard `Backend` documents when it caches the first stub's `initialize` result and replays it to later stubs, and which it describes as unverifiable at runtime. It is verifiable offline; that is the point. Free-form leaf values (a build id, a session token) collapse to a presence marker, because their value is not part of the contract a pooled backend must keep identical — comparing raw objects would flag every such server and make the check useless. `PreflightResult.ran` keeps "could not ask" distinct from "answered no", so a server needing a credential this host lacks is not marked unshareable for ever.

**Remember what was actually observed.** `mcp_gateway/hazards.py` carries the two detections out of gatewayd's memory into `observed-hazards.json`, reloaded on daemon start. Recorded ONLY for a shared backend — a 1:1 backend legitimately owns its single client, so the same frame there proves nothing and recording it would disqualify servers for behaviour that is correct when unshared. A missing or corrupt ledger reads as "nothing observed", never as "safe".

**Recommend stubbing and sharing separately.** A stub keeps the backend 1:1 with the session (the same process topology as no gateway) and is what carries server-authored UI; sharing is the step that introduces co-tenancy. Weak evidence offers the first and withholds the second.

**Pay for the measurement once.** `mcp_gateway/verdict_cache.py` caches only the expensive pre-flight, keyed on the execution identity `PoolKey` is built from — so an upgraded MCP re-derives for free, and because `hash_effective_env` drops secret keys, a credential rotation does not look like a different server either. The cheap evidence (env names, capabilities, hazards) is re-read every request and recombined, so a hazard observed a minute ago changes the answer immediately without invalidating anything. Caching the composite verdict instead would go stale the moment the ledger grew an entry.

**Evaluate only what changed, and never on a request path.** `mcp_gateway/evaluate.py` runs from `POST /api/mcp/probe` — the explicit action that already spawns every configured server — and skips any server whose identity already has a measurement, so the steady state is a file read. A failure there is swallowed: the probe's contract is status and tools, and a shareability problem must not cost the operator the answer they asked for. `MAX_EVALUATIONS_PER_PASS` bounds one pass; a disabled server is never provoked, because probing is the act consent gates.

Shipped defaults stay empty. There is no curated list of server names in this repository and none is needed.

## 4. What tests we did

- **A real MCP server, spawned for real.** `test_mcp_preflight_real_server.py` runs the pre-flight against an actual stdio MCP server — a script on disk, real JSON-RPC over real pipes — through `preflight` -> `probe_server` with nothing patched. This closes a gap the rest of the suite could not: every other test replaces `probe_server` with a dict-driven double or mocks `create_subprocess_exec`, so none of them can show that spawning twice and comparing real answers works; they show that the double behaves as written. The evidence is produced BY the server, not asserted about a double — each process appends the `clientInfo` name it was handed to a witness file, and the test fails if that file does not hold two distinct identities, so a run that spawned nothing cannot read as a pass. Three cases: a server that answers differently per caller (must be caught), one that answers identically (must not be), and one that answers the first caller then dies (must read as *no measurement*, never as agreement — half a comparison is not agreement). Six independent mutations of the detection logic were each caught by it.
- **Unit, 199 passing** across `test_mcp_shareability.py`, `test_mcp_preflight.py`, `test_mcp_seed.py`, `test_handlers_mcp_coverage.py`. They pin the ordering invariant (refutation beats declaration; measurement beats declaration), each disqualifier and its distinct reason code, `unknown` vs `no_objection`, that `resources: {subscribe: false}` is an explicit no and must not count against a server, that `logging: {}` DOES count (an empty object is how MCP declares a capability with no sub-options, and `logging/setLevel` is process-global), that `*.listChanged` is NOT a disqualifier (those are global broadcasts), cache-key invalidation on command/env/binary/schema change, the per-pass budget, that a disabled server is never spawned, and that a pre-flight never mutates the `McpServerInfo` the dashboard is showing.
- **An invariant, not a list of call sites**: no helper that reaches a filesystem or subprocess primitive may run on the event loop. The rule derives its own set of blocking helpers from the record modules, transitively, so a delegating wrapper counts and a newly added helper is covered without anyone remembering to list it. Writing the derivation immediately showed that the two public loaders had never actually been derived as blocking under the previous hand-written list. Backed by a runtime guard that raises if the key derivation is called from the loop, so a restructure the source scan does not recognise still fails.
- **Hostile record files**: a 310-digit bare number in either record parses as `int`, and `float()` of it raises `OverflowError` — not a `ValueError` subclass, so it escaped the guard and would have exited the daemon before it bound its socket. The same number as a string raises nothing and yields `inf`, a timestamp nothing can order. Both loaders share one coercion that rejects non-finite results and refuses `bool`.
- **Ratchets against drift**: `ROTATING_SECRET_ENV_PREFIXES` is asserted to cover every prefix `hashing.ENV_SCRUB_PREFIXES` excludes, so a new exclusion cannot silently make a server recommendable while the pool key ignores its value; both hazard sites are asserted to stay wired to the ledger; and the modules that must stay off the gateway boot path are pinned by AST, with the measured module counts that justify the one function-local import.
- **End-to-end on an isolated instance**: the whole chain — config load -> agent-spec walk -> probe-cache read -> verdict engine -> JSON response — with correct real verdicts (the managed servers `disqualified` on `first_party_session_scoped`, an HTTP server `not_stdio`, unprobed servers honestly `unknown`) and a verdict cache written with real binary fingerprints. Scope worth stating: this ran against the real install's agent specs, because `KIROCREW_HOME` does not isolate `~/.kiro/agents`, and the stdio probe was sandbox-gated on that host — so it proved the plumbing and the payload, not the provocation. The provocation is what the real-server test above covers.
- **Gates**: isort, flake8, mypy (949 files), docs_lint all clean on the rebased base.

## 5. Any other suggestions on the work

- **No UI yet, deliberately.** The payload carries `recommendation` but the page does not render it. Where the hint belongs and how the five strengths are worded is a design decision worth signing off before 13 catalogs of copy are written. Until it lands, a `refuted` server is still shared and no operator sees a verdict — staging that is reversible, since the field is additive and unread.
- **Seeding is implemented but not wired.** `mcp_gateway/seed.py` turns verdicts into config at start, once per server, with an applied marker so an operator's "off" survives every later start — but its call site on the gateway startup path is not included here, because that path needs the config lock and deserves its own review. Its on-disk `applied` key therefore ships before its only consumer has been reviewed; #3290 records the writer-model decision that belongs with the wiring.
- **The pooling refusal is still unimplemented** — a backend that does not advertise `kirocrew.caller-identity` is not declined for pooling anywhere; gatewayd parses that capability only to decide whether to inject caller identity. The comment above `UNPOOLABLE_SERVERS` used to present that refusal as the preferred mechanism, which would have led a reader to rely on a guard that is not there; it now says what the code does. Implementing it is the guard you would most want before defaulting anything on.
- **A probe must not borrow another tool's name.** The second pre-flight identity was `mcp-inspector`, the name of the MCP project's own debugging tool. Two costs: the probe is misattributed in that server's logs and policy, and the measurement is confounded — a server that unlocks diagnostic capabilities for a debugging client reads as caller-sensitive on a difference the gateway will never provoke, and the resulting false positive withdraws a correct recommendation. The pair is now two names no product owns, still sharing no substring a server would plausibly key on, and exported so the real-server fixture branches on them by equality rather than a magic substring.
- **Hazard permanence has no redemption path** (#3289). The pre-flight cache keys on execution identity so an upgrade re-derives; the ledger keys on server name and never expires, with whole-file deletion as the only escape. Decide identity-scoped hazards or an explicit per-server clear before the UI renders these verdicts — an inert verdict nobody sees is cheap, a visible permanent withdrawal with no documented way back is not.
- **Making the managed servers shareable** — reading the caller from the injected caller block instead of `KIROCREW_SESSION_KEY` — is where the process-count saving actually is, since those three run on every machine.
- **Remote aggregation is out of scope.** The OTLP path already exists and is opt-in and local-only by default. The reason vocabulary separates a stable `code` from verbatim `detail` precisely so a future metric can carry codes and never a server or env name; the telemetry contract requires enum-like attribute values anyway.
- **One rough edge the e2e surfaced**: a server that lists zero tools can still be recommended for stubbing. Harmless but pointless — `no_tools_listed` may deserve to be a disqualifier rather than a supporting note.
- **A host with no usable spawn backend gets no coverage from the real-server test** — it skips with a reason rather than failing, so CI on such a host is green while that mechanism is unexercised. Turning the skip into a failure under a CI-only environment variable would close it; not done here because adding a switch nothing sets is the same shape as the unimplemented refusal above.

Refs #3211
