### PR TITLE
test(dashboard): assert strict and mixed internal-API buckets cannot overlap

### DIFF
--- a/test/test_internal_path_bucket_disjointness.py
+++ b/test/test_internal_path_bucket_disjointness.py
@@ -1,0 +1,66 @@
+"""The strict and mixed internal-API buckets must not overlap.
+
+``_STRICT_INTERNAL_API_PATHS`` and ``_MIXED_INTERNAL_API_PATHS`` carry OPPOSITE auth
+policy for a caller that is not on loopback: a strict path is hard-denied, a mixed path
+falls through to ordinary cookie auth so a dashboard page can call it. ``token_auth``'s
+middleware resolves the two independently, each by prefix-or-exact match against its own
+set, so an entry satisfying both leaves the request's policy decided by the order the two
+checks happen to run in rather than by anything a reader can see at the definition site.
+
+An overlap does not merely make membership ambiguous, it silently changes which branch a
+request takes. The remote-access promotion that widens strict paths to mixed is guarded on
+"matches strict AND NOT mixed", so an overlapping entry skips that promotion and stays
+strict even once the operator has opted into remote access.
+
+Exact duplication is the obvious form. The form that reads as deliberate and still
+collides is a prefix-nested split -- putting ``/api/artifacts`` in one bucket and a
+hypothetical ``/api/artifacts/detail`` in the other -- because the middleware extends
+every entry by ``/`` when matching. ``_collides`` mirrors that matcher, and the two
+predicate tests below exist so a wrong mirror cannot pass unnoticed; if the middleware's
+matching shape changes, this file has to follow it.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.dashboard.server import (
+    _MIXED_INTERNAL_API_PATHS,
+    _STRICT_INTERNAL_API_PATHS,
+)
+
+
+def _collides(a: str, b: str) -> bool:
+    """Mirror of the middleware's prefix-or-exact match, applied across buckets."""
+    return a == b or a.startswith(b + "/") or b.startswith(a + "/")
+
+
+class TestInternalPathBucketDisjointness:
+    def test_buckets_do_not_collide(self):
+        """A path in both buckets has two contradictory auth policies."""
+        clashes = sorted(
+            (strict, mixed)
+            for strict in _STRICT_INTERNAL_API_PATHS
+            for mixed in _MIXED_INTERNAL_API_PATHS
+            if _collides(strict, mixed)
+        )
+        assert not clashes, f"strict/mixed entries collide (prefix or exact): {clashes}"
+
+    def test_neither_bucket_is_empty(self):
+        """The collision check is a cross product, so an empty set passes it for free."""
+        assert _STRICT_INTERNAL_API_PATHS
+        assert _MIXED_INTERNAL_API_PATHS
+
+    def test_collision_predicate_fires_on_exact_and_nested_paths(self):
+        """Both collision shapes, in both nesting directions."""
+        assert _collides("/api/example", "/api/example")
+        assert _collides("/api/example/detail", "/api/example")
+        assert _collides("/api/example", "/api/example/detail")
+
+    def test_collision_predicate_ignores_sibling_prefixes(self):
+        """A shared string prefix is not a shared path prefix -- the ``/`` matters.
+
+        Each pair is a real neighbour inside one bucket, and each is a raw string prefix of
+        the other, so dropping the ``/`` turns the check into a false positive on names
+        that merely start alike.
+        """
+        assert not _collides("/api/browser/command", "/api/browser/command-drain")
+        assert not _collides("/api/browser/command", "/api/browser/command-result")


### PR DESCRIPTION
## What this guards

`kiro_crew.dashboard.server` keeps two allowlists of internal API paths, and they carry **opposite** auth policy for a caller that is not on loopback:

- `_STRICT_INTERNAL_API_PATHS` — hard-denied for a non-loopback caller.
- `_MIXED_INTERNAL_API_PATHS` — falls through to ordinary cookie auth, so a dashboard page can call it.

`token_auth_middleware` resolves the two **independently**, each by prefix-or-exact match against its own set:

```python
_matches_strict = internal_paths and (
    path in internal_paths or any(path.startswith(p + "/") for p in internal_paths)
)
_matches_mixed = mixed_internal_paths and (
    path in mixed_internal_paths
    or any(path.startswith(p + "/") for p in mixed_internal_paths)
)
```

Nothing today asserts the two sets are disjoint. If an entry ever satisfies both, a request's auth policy stops being decided by anything a reader can see at the definition site.

It is worse than ambiguous. The promotion that widens strict paths to mixed once the operator has opted into remote access is guarded on *matches strict and **not** mixed*:

```python
if not local_only and _matches_strict and not _matches_mixed:
    _matches_mixed = True
    _matches_strict = False
```

So an overlapping entry skips that promotion and silently stays strict — the overlap changes which branch the request takes, it does not merely make membership unclear.

Exact duplication is the obvious collision. The one that reads as deliberate and still collides is a **prefix-nested split**: `/api/artifacts` in one bucket and `/api/artifacts/detail` in the other looks like a narrowing, but the matcher extends every entry by `/`, so a request for the child matches both.

## What the test does

One new test file, no production change:

| test | what it pins |
| --- | --- |
| `test_buckets_do_not_collide` | no cross-bucket pair is exact-equal or path-nested; the failure message names the offending pair |
| `test_neither_bucket_is_empty` | the collision check is a cross product, so it would pass for free if a refactor emptied either set |
| `test_collision_predicate_fires_on_exact_and_nested_paths` | the collision predicate actually fires, in both nesting directions |
| `test_collision_predicate_ignores_sibling_prefixes` | a shared *string* prefix is not a shared *path* prefix — the `/` is load-bearing |

## How it was tested

Green as-is: 4 passed. The two buckets are disjoint today (21 strict entries, 26 mixed, zero exact intersection, zero prefix collisions), so **this adds a guard rather than fixing a live defect** — worth saying plainly.

Because a check that can only ever pass is worth nothing, each assertion was mutation-tested and each one fails for its own intended reason, hitting only its own test (`1 failed, 3 passed` every time):

| mutation | test that failed |
| --- | --- |
| inject `/api/artifacts/injected` into the strict set | `test_buckets_do_not_collide` |
| set `_MIXED_INTERNAL_API_PATHS = frozenset()` | `test_neither_bucket_is_empty` |
| drop the `+ "/"` from the predicate | `test_collision_predicate_ignores_sibling_prefixes` |
| reduce the predicate to `a == b` | `test_collision_predicate_fires_on_exact_and_nested_paths` |

The first mutation reports `strict/mixed entries collide (prefix or exact): [('/api/artifacts/injected', '/api/artifacts')]`, so a real future failure is self-diagnosing.

Also ran the 11 existing test files that import either set, plus `test_token_auth.py` and `test_webhooks_auth_surface.py`: **683 passed**, no conflict with the assertions those files already make about these sets.

## Honest limitations

1. **The predicate is a mirror, not the real matcher.** The middleware's match is inline inside the middleware closure, so there is no function to import. `_collides` restates it, and the two predicate self-tests exist so a wrong restatement cannot pass silently — but if the matcher's *shape* changes, this file has to be updated to follow it. Extracting the matcher into an importable helper would remove the duplication; that is a production refactor on the auth path and deliberately out of scope for a test-only change.
2. **The sibling-prefix fixtures come from within one bucket.** Across the two buckets there is currently no pair that is a raw string prefix without also being a path prefix, so the trailing slash is not *presently* load-bearing cross-bucket. The two fixtures (`/api/browser/command` against `/api/browser/command-drain` and `/api/browser/command-result`) are real neighbours inside the strict set, where sharing a policy makes them harmless. They are used because they are the only live pairs in either set with the shape that discriminates a correct predicate from a sloppy one.
3. This is a static assertion over two module-level constants. It cannot catch a path that becomes ambiguous through route registration or a wildcard route rather than through these two sets.
