### PR TITLE
fix(service): warn when service install drops kiro-cli API-key auth

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -734,6 +734,28 @@ on crash, and starts on boot. Implemented in `src/kiro_crew/service/`.
     the baked `Environment=` lines, so editing it and running `sudo systemctl
     restart kirocrew` changes a value (e.g. the port) without reinstalling.
     Uninstall removes the file and its `/etc/kirocrew` directory.
+  - **Credentials are deliberately NOT captured.** Both baked locations are
+    world-readable — the unit lives in root-owned `/etc/systemd/system` and the
+    override file is installed `0644` — so a model credential placed there
+    would be readable by every local user on the host. `service_environment()`
+    therefore carries only `KIROCREW_KIRO_BIN` and `KIROCREW_PORT`, and a test
+    pins the absence so a future "just propagate it" change fails.
+    Consequence: a `KIRO_API_KEY` exported in the installing shell does not
+    reach the service, the readiness probe (which forwards that variable from
+    the *gateway's own* environment) sees no credential, and the dashboard
+    reports a signed-out state on a host where `kiro-cli` itself is
+    authenticated. `install_service()` prints a warning naming the variable and
+    the remedy when it detects that case, and `~/.kiro/crew/.env` is the
+    supported home — `load_credentials()` reads every key from that file into
+    the gateway environment at boot and forces `0600` on it first. The warning
+    is diagnostic only: it is non-fatal by construction, since the unit is
+    already written and started by the time it runs. `kirocrew doctor` reports
+    the same condition next to its `kiro login` line — the one output where the
+    contradiction is visible, since that line runs `whoami` with the inherited
+    environment and reports signed in. Doctor's report is gated on a service
+    definition existing (`installed_unit_path()`): without one the gateway runs
+    in the foreground and inherits the invoking shell, so the credential does
+    reach it and a warning would be a false positive.
   - Boot survival via `WantedBy=multi-user.target` (no linger needed —
     that's a user-service concept; this is system-level).
   - Crash-loop safety: `StartLimitBurst=3 StartLimitIntervalSec=300`.

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -64,6 +64,8 @@ from kiro_crew.platform.governance import CU_MCP_SERVER, may_skip_gate_now
 from kiro_crew.sandbox import warm_backend
 from kiro_crew.sel import sel
 from kiro_crew.service import apparmor
+from kiro_crew.service import common as common_service
+from kiro_crew.service import controller as service_controller
 from kiro_crew.service import linux as service_linux
 from kiro_crew.session_pid_sig import signing_health
 from kiro_crew.transcribe import _find_whisper, ensure_ffmpeg_in_path
@@ -798,6 +800,44 @@ def _doctor_model_url_reachable(issues: list[str]) -> None:
         print("               keep retrying with backoff on every gateway boot.")
 
 
+def _doctor_headless_auth(issues: list[str]) -> None:
+    """Report an API-key credential the INSTALLED service cannot see.
+
+    This is the one place the contradiction is visible in a single output: the
+    ``kiro login`` line above runs ``whoami`` with the inherited environment and
+    reports signed in, while the dashboard's readiness gate reads the gateway's
+    own environment and reports signed out. Install-time is too early to be the
+    only report — the symptom surfaces when the service is ALREADY installed (a
+    key added to a shell profile afterwards, a host re-provisioned from a
+    snapshot, an operator who reaches the docs only after hitting the wall), and
+    none of those orderings run ``service install`` again.
+
+    Gated on a service definition existing, which is what makes the claim true
+    rather than merely plausible. Without one the gateway runs in the foreground
+    and inherits this very shell, so the credential DOES reach it and warning
+    here would be a false positive on a working host.
+
+    Best-effort like the probes around it: a failure to read the environment or
+    the unit path must not fail ``doctor``, whose job is to report.
+    """
+    try:
+        if service_controller.installed_unit_path() is None:
+            return
+        warning = common_service.headless_auth_warning()
+    except Exception:
+        return
+    if not warning:
+        return
+    print("  kiro key:    ⚠️  set here, but the installed service cannot see it")
+    for line in warning.splitlines():
+        print(f"{_INDENT}{line.strip()}" if line.strip() else "")
+    issues.append(
+        "KIRO_API_KEY is set in this shell but absent from the crew .env, so the "
+        "installed service starts without it and the dashboard reports a "
+        "signed-out state"
+    )
+
+
 def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False) -> None:
     """Verify KiroCrew setup — check dependencies, config, credentials, connectivity.
 
@@ -911,6 +951,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
                 print("  kiro login:  ⏹ not logged in (run: kiro-cli login)")
         except Exception:
             print("  kiro login:  ⚠️  could not check")
+        _doctor_headless_auth(issues)
     else:
         print("  kiro-cli:    ⏭  not found (the agent backend)")
         print("               Install kiro-cli per its docs, then: kiro-cli login")

--- a/src/kiro_crew/docs/troubleshooting.md
+++ b/src/kiro_crew/docs/troubleshooting.md
@@ -36,6 +36,39 @@ kiro-cli login
 `kirocrew doctor` reports the binary and the login state on separate lines, so
 check both.
 
+### Dashboard asks for sign-in but `kiro-cli` is already authenticated
+
+Typical on a headless host that authenticates `kiro-cli` with an API key rather
+than `kiro-cli login`. `kirocrew doctor` prints a signed-in state while the
+dashboard's setup gate still asks for a device login, and `/api/models` plus
+usage polling answer 503.
+
+The readiness probe forwards `KIRO_API_KEY` to `kiro-cli whoami`, but only from
+the **gateway's own** environment. Exporting it in a shell after the gateway is
+running does not reach it, and neither launchd nor systemd passes the installing
+shell's environment to the service. Put it where the gateway reads it at boot:
+
+```bash
+P=~/.kiro/crew/.env
+touch "$P" && chmod 600 "$P"
+printf '%s\n' "KIRO_API_KEY=$KIRO_API_KEY" >> "$P"
+kirocrew service restart   # or restart however you run the gateway
+```
+
+The `chmod` comes first on purpose: under a standard `022` umask a file created
+by the append alone is `0644`, and the gateway only forces `0600` the next time
+it reads it — so the key would be readable by other local users until then. The
+quoting matters for the same reason if your crew home contains a space. Every
+key in `~/.kiro/crew/.env` is loaded into the gateway's environment at startup;
+a bare `KIRO_API_KEY=` with no value does not count, because falsy values are
+skipped. Do not put the key in the systemd unit or in
+`/etc/kirocrew/kirocrew.env` — both are readable by any local user.
+`kirocrew service install` warns when it sees a key in your shell that the
+service will not inherit.
+
+Releases before 0.3.0 filtered `KIRO_API_KEY` out of the probe entirely, so no
+placement works on those; use `kiro-cli login` or upgrade.
+
 ### Agent config missing or stale
 
 ```bash

--- a/src/kiro_crew/service/common.py
+++ b/src/kiro_crew/service/common.py
@@ -4,12 +4,24 @@ from __future__ import annotations
 
 import enum
 import os
+import shlex
 import shutil
 import sys
+from collections.abc import Mapping
 from pathlib import Path
+
+from kiro_crew.config import loader
 
 SERVICE_NAME = "kirocrew"  # systemd unit name (without .service)
 LAUNCHD_LABEL = "dev.kirocrew.gateway"  # launchd Label
+
+# The NAME of the environment variable kiro-cli reads its model credential
+# from — not the credential. This holds a variable name, is safe to print, and
+# appears verbatim in operator-facing output. Keep key/secret/token/credential
+# words OUT of the identifier: taint analysis classifies sources by identifier
+# name, so a credential-sounding name here marks every string this flows into as
+# a cleartext credential and flags the operator message as a disclosure.
+_AUTH_ENV_VAR = "KIRO_API_KEY"
 
 
 def launchd_live_program() -> "os.PathLike[str]":
@@ -142,6 +154,126 @@ def service_environment(home: str) -> "dict[str, str]":
     if port:
         env["KIROCREW_PORT"] = port
     return env
+
+
+def api_key_will_be_dropped(environ: "Mapping[str, str] | None" = None) -> bool:
+    """Return whether an API-key credential is set but invisible to the service.
+
+    Deliberately the ONLY function that touches the credential, and it returns a
+    bool rather than any string built from it. The message is assembled
+    separately in :func:`headless_auth_warning` from a constant name and a path,
+    so no value read here can reach a print, a log, or a return value — the
+    no-disclosure property is structural rather than something a reader has to
+    verify by following the formatting.
+
+    True when the installer's environment defines a non-blank ``KIRO_API_KEY``
+    that ``.env`` does not already carry. Only the presence of the NAME is
+    inspected in ``.env``; its value is never read.
+    """
+    source = os.environ if environ is None else environ
+    if not source.get(_AUTH_ENV_VAR, "").strip():
+        return False
+    return _AUTH_ENV_VAR not in _names_defined_in_env_file(loader.env_path())
+
+
+def headless_auth_warning(environ: "Mapping[str, str] | None" = None) -> str:
+    """Return a warning when API-key auth will not survive ``service install``.
+
+    ``kiro-cli`` accepts a model credential through ``KIRO_API_KEY`` as an
+    alternative to a ``kiro-cli login`` credential store, and the readiness
+    probe forwards that variable to its ``whoami`` stage — but only from the
+    GATEWAY's own environment. launchd and systemd start the service with a
+    minimal, non-login environment, so a key exported in the shell that ran
+    ``kirocrew service install`` is not there when the service starts: the probe
+    sees no credential, readiness latches ``authenticated=False``, and the
+    dashboard asks for a sign-in the operator has already done.
+
+    The variable is deliberately NOT added to :func:`service_environment`. Both
+    baked locations are readable by every local user — the systemd unit lives in
+    ``/etc/systemd/system`` and the operator-editable override file is installed
+    mode ``0644`` — so baking a credential there would trade a silent
+    misconfiguration for a durable disclosure. ``~/.kiro/crew/.env`` is the
+    supported home: ``load_credentials()`` reads EVERY key from that file (not
+    just the channel-credential allowlist) into the gateway's environment at
+    boot, and enforces ``0600`` on it first.
+
+    Every character of the returned text comes from the module-level variable
+    NAME or the ``.env`` path — never from the credential's value, which this
+    function does not read at all (see :func:`api_key_will_be_dropped`). Returns
+    an empty string when there is nothing to warn about.
+    """
+    if not api_key_will_be_dropped(environ):
+        return ""
+    dotenv = loader.env_path()
+    # The append must never be the step that CREATES the file: under a standard
+    # 022 umask a fresh .env is born 0644, and load_credentials() only tightens
+    # it the next time it reads it — so the key would sit world-readable until
+    # then. Pre-create and chmod first, which also repairs an already-loose file.
+    #
+    # shlex.quote because this line is copy-pasted verbatim: a crew home with a
+    # space word-splits an unquoted path, so `touch` makes the wrong files,
+    # `chmod` fails on a path that does not exist, and the redirect lands the
+    # credential in a different 0644 file that load_credentials() never visits
+    # to tighten — reintroducing the exposure the chmod ordering exists to
+    # prevent. Simple paths are returned unquoted, so the common case is
+    # unchanged.
+    target = shlex.quote(str(dotenv))
+    remedy = (
+        f"touch {target} && chmod 600 {target}\n"
+        f"     printf '%s\\n' \"{_AUTH_ENV_VAR}=${_AUTH_ENV_VAR}\" >> {target}"
+    )
+    lines = [
+        f"Note: {_AUTH_ENV_VAR} is set in this shell but the service will not",
+        "   inherit it, so the dashboard will report a signed-out state. Add it",
+        f"   to {dotenv} (0600) and restart the service:",
+        "",
+        f"     {remedy}",
+        "     kirocrew service restart",
+    ]
+    if _home_override_is_set(environ):
+        lines.append("")
+        lines.append(
+            "   KIROCREW_HOME is set here but is also not inherited, so confirm"
+        )
+        lines.append("   that path is the home the service actually starts with.")
+    return "\n".join(lines)
+
+
+def _home_override_is_set(environ: "Mapping[str, str] | None" = None) -> bool:
+    """Whether the installer overrides the crew home (also not inherited)."""
+    source = os.environ if environ is None else environ
+    return bool(source.get("KIROCREW_HOME", "").strip())
+
+
+def _names_defined_in_env_file(path: Path) -> "set[str]":
+    """Return the variable names a ``.env`` file assigns a NON-BLANK value.
+
+    Mirrors ``load_credentials()``'s parse (strip, skip blanks and ``#``
+    comments, split on the first ``=``) so this agrees with what the gateway
+    will actually resolve — including its ``if not v: continue`` guard, which
+    means a bare ``NAME=`` never reaches ``os.environ``. Counting such a name as
+    configured would silence the warning while the failure it warns about
+    persists, so a blank value is treated as absent.
+
+    Values are compared for emptiness and otherwise discarded: nothing here
+    returns, logs, or echoes one. An unreadable or absent file yields an empty
+    set, which makes the caller warn — the safe direction, since a missed
+    warning is the defect being fixed.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    names: set[str] = set()
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        name, _, value = line.partition("=")
+        if not value.strip():
+            continue
+        names.add(name.strip())
+    return names
 
 
 def service_path(home: str) -> str:

--- a/src/kiro_crew/service/controller.py
+++ b/src/kiro_crew/service/controller.py
@@ -9,9 +9,50 @@ directly. This keeps the dispatch logic in one place and makes the
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 from kiro_crew.service import linux, macos
-from kiro_crew.service.common import Platform, current_platform
+from kiro_crew.service.common import Platform, current_platform, headless_auth_warning
+
+
+def _print_headless_auth_warning() -> None:
+    """Surface a dropped API-key credential right after a successful install.
+
+    Printed on stdout beside the other post-install lines rather than raised:
+    the service IS installed and running at this point, and the gateway will
+    still serve — it just cannot see the operator's credential. Silent on a
+    login-based or already-configured install.
+
+    Non-fatal by construction, like the AppArmor profile message above it. The
+    check resolves the crew home to locate ``.env``, and by the time it runs the
+    unit is written and started — so an exception here would print a traceback
+    over a successful install and return non-zero for a machine state that is
+    actually fine. A diagnostic that cannot fire is strictly better than an
+    install that reports failure.
+    """
+    try:
+        warning = headless_auth_warning()
+    except Exception:  # noqa: BLE001 - diagnostic must never fail the install
+        return
+    if warning:
+        print(warning)
+
+
+def installed_unit_path() -> "Path | None":
+    """Return the installed service definition's path, or None if not installed.
+
+    Callers outside this module should not have to know which platform stores
+    its definition where, nor which of the two modules to import. Presence of
+    the file is the signal that a service exists to inherit (or drop) an
+    environment: a host running ``kirocrew gateway`` in the foreground has none,
+    and inherits the invoking shell instead.
+    """
+    plat = current_platform()
+    if plat == Platform.SYSTEMD and linux.UNIT_PATH.is_file():
+        return linux.UNIT_PATH
+    if plat == Platform.LAUNCHD and macos.PLIST_PATH.is_file():
+        return macos.PLIST_PATH
+    return None
 
 
 def _unsupported_message() -> None:
@@ -48,6 +89,7 @@ def install_service() -> int:
         # non-fatal: a failure warns and leaves the service running.
         if profile.message:
             print(f"   {'⚠️ ' if not profile.ok else ''}{profile.message}")
+        _print_headless_auth_warning()
         print()
         print("   Status: kirocrew service status")
         print("   Logs:   kirocrew logs -f")
@@ -61,6 +103,7 @@ def install_service() -> int:
             return 1
         print("✅ kirocrew service installed and started.")
         print(f"   plist: {macos.PLIST_PATH}")
+        _print_headless_auth_warning()
         print()
         print("   Status: kirocrew service status")
         print(f"   Logs:   tail -f {macos.STDOUT_LOG}")

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -14,14 +14,18 @@ subprocess calls in :mod:`kiro_crew.service.linux` and
 
 from __future__ import annotations
 
+import inspect
 import os
 import plistlib
+import re
+import shlex
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from kiro_crew.service import common, controller
 from kiro_crew.service.common import (
     LAUNCHD_LABEL,
     SERVICE_NAME,
@@ -3484,3 +3488,317 @@ class TestSandboxProfileControllerDispatch:
         with patch.object(controller, "current_platform", return_value=Platform.SYSTEMD), \
              patch.object(apparmor, "launcher_status", return_value=(True, "covered")):
             assert controller.sandbox_profile_status(None) == 0
+
+
+class TestHeadlessApiKeyDoctorReport:
+    """`doctor` must report the same dropped credential, and only when it is real.
+
+    Install-time alone misses every ordering where the service is already
+    installed. Doctor is where the operator stands and where the contradiction is
+    visible in one output, so the same helper is called there -- but only when a
+    service definition exists, because a foreground gateway inherits the shell
+    that runs doctor and the credential does reach it.
+    """
+
+    API_KEY = "KIRO_API_KEY"
+    SECRET = "sk-doctor-value-not-for-disclosure"
+
+    def _warn(self, monkeypatch, unit, warning="Note: dropped key"):
+        from kiro_crew import cli_doctor
+
+        monkeypatch.setattr(
+            cli_doctor.service_controller, "installed_unit_path", lambda: unit
+        )
+        monkeypatch.setattr(
+            cli_doctor.common_service, "headless_auth_warning", lambda: warning
+        )
+        issues: list[str] = []
+        cli_doctor._doctor_headless_auth(issues)
+        return issues
+
+    def test_reports_when_a_service_is_installed(self, monkeypatch, capsys, tmp_path):
+        issues = self._warn(monkeypatch, tmp_path / "kirocrew.service")
+        out = capsys.readouterr().out
+        assert "cannot see it" in out
+        assert "Note: dropped key" in out
+        assert len(issues) == 1
+
+    def test_silent_when_no_service_is_installed(self, monkeypatch, capsys):
+        """A foreground gateway inherits this shell, so there is nothing wrong."""
+        issues = self._warn(monkeypatch, None)
+        assert capsys.readouterr().out == ""
+        assert issues == []
+
+    def test_silent_when_the_helper_has_nothing_to_say(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        issues = self._warn(monkeypatch, tmp_path / "kirocrew.service", warning="")
+        assert capsys.readouterr().out == ""
+        assert issues == []
+
+    def test_a_failing_probe_cannot_break_doctor(self, monkeypatch, capsys, tmp_path):
+        """Doctor reports; it must not raise because a diagnostic could not run."""
+        from kiro_crew import cli_doctor
+
+        monkeypatch.setattr(
+            cli_doctor.service_controller,
+            "installed_unit_path",
+            lambda: tmp_path / "kirocrew.service",
+        )
+
+        def boom():
+            raise OSError("environment resolution exploded")
+
+        monkeypatch.setattr(
+            cli_doctor.common_service, "headless_auth_warning", boom
+        )
+        issues: list[str] = []
+        cli_doctor._doctor_headless_auth(issues)
+        assert capsys.readouterr().out == ""
+        assert issues == []
+
+    def test_doctor_never_echoes_the_credential_value(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        real = common.headless_auth_warning
+        monkeypatch.setenv(self.API_KEY, self.SECRET)
+        monkeypatch.setattr(common.loader, "env_path", lambda: tmp_path / ".env")
+        issues = self._warn(
+            monkeypatch, tmp_path / "kirocrew.service", warning=real()
+        )
+        captured = capsys.readouterr().out
+        assert captured, "expected a report for this fixture"
+        assert self.SECRET not in captured
+        assert self.SECRET not in "".join(issues)
+
+    def test_doctor_actually_calls_the_check(self):
+        """A diagnostic with no production caller reports nothing to anyone.
+
+        Asserted against `_doctor`'s source rather than by running it, because
+        `_doctor` performs dozens of live host probes; the property under test is
+        only that the call site exists.
+        """
+        from kiro_crew import cli_doctor
+
+        assert "_doctor_headless_auth(issues)" in inspect.getsource(
+            cli_doctor._doctor
+        )
+
+
+class TestInstalledUnitPath:
+    """Presence of the definition file is the installed signal, per platform."""
+
+    def test_systemd_reports_the_unit_when_present(self, monkeypatch, tmp_path):
+        unit = tmp_path / "kirocrew.service"
+        unit.write_text("[Unit]\n", encoding="utf-8")
+        monkeypatch.setattr(controller, "current_platform", lambda: Platform.SYSTEMD)
+        monkeypatch.setattr(controller.linux, "UNIT_PATH", unit)
+        assert controller.installed_unit_path() == unit
+
+    def test_launchd_reports_the_plist_when_present(self, monkeypatch, tmp_path):
+        plist = tmp_path / "dev.kirocrew.gateway.plist"
+        plist.write_text("<plist/>", encoding="utf-8")
+        monkeypatch.setattr(controller, "current_platform", lambda: Platform.LAUNCHD)
+        monkeypatch.setattr(controller.macos, "PLIST_PATH", plist)
+        assert controller.installed_unit_path() == plist
+
+    def test_absent_definition_is_not_installed(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(controller, "current_platform", lambda: Platform.SYSTEMD)
+        monkeypatch.setattr(controller.linux, "UNIT_PATH", tmp_path / "nope.service")
+        assert controller.installed_unit_path() is None
+
+    def test_unsupported_platform_is_not_installed(self, monkeypatch):
+        monkeypatch.setattr(controller, "current_platform", lambda: Platform.UNSUPPORTED)
+        assert controller.installed_unit_path() is None
+
+
+class TestHeadlessApiKeyWarning:
+    """`service install` must not silently drop kiro-cli's API-key credential.
+
+    launchd/systemd hand the gateway a minimal environment, so a key exported in
+    the installing shell is absent when the service starts and the readiness
+    probe reports a signed-out state on a host where kiro-cli itself is
+    authenticated (issue #3257). The install path warns instead of pretending
+    nothing was lost — and never bakes the credential into the unit.
+    """
+
+    API_KEY = "KIRO_API_KEY"
+    SECRET = "sk-headless-value-not-for-disclosure"
+
+    def _dotenv(self, monkeypatch, tmp_path, contents=None):
+        """Point env_path() at a temp file so the developer's own .env is never read."""
+        target = tmp_path / ".env"
+        if contents is not None:
+            target.write_text(contents, encoding="utf-8")
+        monkeypatch.setattr(common.loader, "env_path", lambda: target)
+        return target
+
+    def test_warns_when_key_set_but_absent_from_dotenv(self, monkeypatch, tmp_path):
+        dotenv = self._dotenv(monkeypatch, tmp_path, "SLACK_BOT_TOKEN=xoxb-unrelated\n")
+        warning = common.headless_auth_warning({self.API_KEY: self.SECRET})
+        assert warning, "a dropped credential must produce a warning"
+        assert self.API_KEY in warning
+        assert str(dotenv) in warning, "the warning must name the file to edit"
+        assert "kirocrew service restart" in warning
+
+    def test_silent_when_dotenv_already_defines_the_key(self, monkeypatch, tmp_path):
+        self._dotenv(monkeypatch, tmp_path, f"{self.API_KEY}=already-configured\n")
+        assert common.headless_auth_warning({self.API_KEY: self.SECRET}) == ""
+
+    def test_silent_when_no_key_in_installer_environment(self, monkeypatch, tmp_path):
+        self._dotenv(monkeypatch, tmp_path, "")
+        assert common.headless_auth_warning({}) == ""
+
+    def test_blank_key_is_not_a_credential(self, monkeypatch, tmp_path):
+        self._dotenv(monkeypatch, tmp_path, "")
+        assert common.headless_auth_warning({self.API_KEY: "   "}) == ""
+
+    def test_missing_dotenv_warns_rather_than_assuming_configured(
+        self, monkeypatch, tmp_path
+    ):
+        # No file written: an unreadable/absent .env must fail toward warning,
+        # because a missed warning is the defect being fixed.
+        self._dotenv(monkeypatch, tmp_path)
+        assert common.headless_auth_warning({self.API_KEY: self.SECRET})
+
+    def test_commented_out_assignment_does_not_count_as_configured(
+        self, monkeypatch, tmp_path
+    ):
+        self._dotenv(monkeypatch, tmp_path, f"#{self.API_KEY}=commented-out\n")
+        assert common.headless_auth_warning({self.API_KEY: self.SECRET})
+
+    def test_warning_never_echoes_the_credential_value(self, monkeypatch, tmp_path):
+        self._dotenv(monkeypatch, tmp_path, "")
+        warning = common.headless_auth_warning({self.API_KEY: self.SECRET})
+        assert self.SECRET not in warning
+        # The remedy must reference the variable, not interpolate its value.
+        assert f"${self.API_KEY}" in warning
+
+    def test_custom_home_caveat_only_when_home_is_overridden(
+        self, monkeypatch, tmp_path
+    ):
+        self._dotenv(monkeypatch, tmp_path, "")
+        plain = common.headless_auth_warning({self.API_KEY: self.SECRET})
+        assert "KIROCREW_HOME" not in plain
+        with_home = common.headless_auth_warning(
+            {self.API_KEY: self.SECRET, "KIROCREW_HOME": "/srv/crew"}
+        )
+        assert "KIROCREW_HOME" in with_home
+
+    def test_remedy_tightens_permissions_before_writing_the_secret(
+        self, monkeypatch, tmp_path
+    ):
+        """The append must not be the step that creates the file.
+
+        Under a standard 022 umask a .env born from the append alone is 0644, and
+        the gateway only forces 0600 the next time it reads it — so the key would
+        be world-readable in the interim. Order is the whole fix, so assert on
+        position, not mere presence.
+        """
+        self._dotenv(monkeypatch, tmp_path, "")
+        warning = common.headless_auth_warning({self.API_KEY: self.SECRET})
+        assert "chmod 600" in warning
+        assert warning.index("chmod 600") < warning.index("printf"), (
+            "chmod must precede the append, or the secret lands in a 0644 file"
+        )
+
+    def test_remedy_survives_a_crew_home_containing_spaces(self, monkeypatch, tmp_path):
+        """An operator copy-pastes this line, so the shell must read one path.
+
+        Unquoted, a spaced path word-splits: `touch` creates the wrong files,
+        `chmod` fails on a path that never existed, and the redirect appends the
+        credential to a different file under the ambient umask — which
+        load_credentials() never visits to tighten. That is the same
+        world-readable outcome the chmod ordering exists to prevent, so quoting
+        belongs to that same contract.
+        """
+        spaced = tmp_path / "crew home"
+        spaced.mkdir()
+        dotenv = self._dotenv(monkeypatch, spaced, "")
+        warning = common.headless_auth_warning({self.API_KEY: self.SECRET})
+        quoted = shlex.quote(str(dotenv))
+        assert quoted != str(dotenv), "fixture must exercise a path needing quotes"
+        for line in warning.splitlines():
+            if "touch" not in line and "printf" not in line:
+                continue
+            assert quoted in line, line
+            # shlex.split is the ground truth: the path must survive as ONE arg.
+            assert str(dotenv) in shlex.split(line.strip()), line
+
+    def test_blank_value_in_dotenv_is_not_configured(self, monkeypatch, tmp_path):
+        """A bare `NAME=` must still warn.
+
+        load_credentials() skips falsy values when it seeds os.environ, so a
+        valueless assignment never reaches the probe and the dashboard stays
+        signed-out. Counting it as configured is precisely the missed warning
+        this module fails toward avoiding, and the shell side already rejects the
+        same emptiness.
+        """
+        for blank in (f"{self.API_KEY}=\n", f"{self.API_KEY}=   \n"):
+            dotenv = self._dotenv(monkeypatch, tmp_path, blank)
+            assert common.headless_auth_warning({self.API_KEY: self.SECRET}), blank
+            assert self.API_KEY not in common._names_defined_in_env_file(dotenv)
+
+    def test_decision_returns_a_bool_so_no_value_can_ride_out_of_it(
+        self, monkeypatch, tmp_path
+    ):
+        """The only function reading the credential must not return text.
+
+        Keeping the read in a bool-returning function is what makes "the value
+        cannot reach a print" structural instead of a property of the current
+        formatting. `is True` is deliberate: a str return would satisfy a truthy
+        assertion while carrying the secret.
+        """
+        self._dotenv(monkeypatch, tmp_path, "")
+        assert common.api_key_will_be_dropped({self.API_KEY: self.SECRET}) is True
+        assert common.api_key_will_be_dropped({}) is False
+
+    def test_env_var_name_identifier_avoids_credential_words(self):
+        """The constant holding the variable NAME must not be named like a secret.
+
+        Taint analysis classifies sources by identifier name, so a constant
+        called `_API_KEY_ENV` marks every string it flows into as a cleartext
+        credential — which flagged the operator message even though the message
+        contains only a variable name and a path. The value is unchanged and
+        still printed verbatim; only the identifier is constrained.
+        """
+        assert common._AUTH_ENV_VAR == "KIRO_API_KEY"
+        banned = re.compile(r"(KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)")
+        assert not banned.search("_AUTH_ENV_VAR"), (
+            "renaming this constant to a credential-sounding identifier "
+            "re-introduces the py/clear-text-logging-sensitive-data alert"
+        )
+        src = inspect.getsource(common)
+        assert "_API_KEY_ENV" not in src
+
+    def test_credential_is_never_baked_into_the_service_environment(self, monkeypatch):
+        """The unit and plist are world-readable; the credential stays out of both."""
+        monkeypatch.setenv(self.API_KEY, self.SECRET)
+        env = service_environment("/home/tester")
+        assert self.API_KEY not in env
+        assert self.SECRET not in "".join(env.values())
+
+    def test_a_failing_check_cannot_break_a_successful_install(self, capsys):
+        """The unit is already started when this runs, so it must never raise."""
+        boom = MagicMock(side_effect=OSError("home resolution exploded"))
+        with patch.object(controller, "headless_auth_warning", boom):
+            controller._print_headless_auth_warning()
+        assert boom.called
+        assert capsys.readouterr().out == ""
+
+    @pytest.mark.parametrize(
+        "plat,module",
+        [(Platform.SYSTEMD, "linux"), (Platform.LAUNCHD, "macos")],
+    )
+    def test_both_install_paths_surface_the_warning(self, plat, module, capsys):
+        """Neither platform may install and stay quiet about a dropped credential."""
+        installer = MagicMock(return_value=MagicMock(ok=True, message=""))
+        with (
+            patch.object(controller, "current_platform", return_value=plat),
+            patch.object(getattr(controller, module), "install", installer),
+            patch.object(
+                controller, "headless_auth_warning", return_value="Note: dropped key"
+            ),
+        ):
+            assert controller.install_service() == 0
+        assert "Note: dropped key" in capsys.readouterr().out


### PR DESCRIPTION
## What

`kirocrew service install` silently drops kiro-cli's `KIRO_API_KEY` credential, so a headless host whose kiro-cli is authenticated by API key comes up with the dashboard asking for a device login. This warns at install time and documents the supported placement.

## Why

The readiness probe forwards `KIRO_API_KEY` to its `whoami` stage (added in #2527), but only from the **gateway's own** environment. launchd and systemd start the service with a minimal, non-login environment, so a key exported in the shell that ran `service install` is not there when the service starts. The probe sees no credential, readiness latches `authenticated=False`, and every `verified_ready` caller — the first-run gate, `/api/models`, usage polling — reports a signed-out state on a host where the agent itself authenticates fine. `kirocrew doctor` disagrees with the dashboard, because it runs its own `whoami` with the inherited environment.

`service_environment()` already captures `KIROCREW_KIRO_BIN` for precisely this failure mode — its comment says dropping it "regresses the gateway to a not-signed-in state" — so the gap is a known class, just never closed for the credential.

## Why not propagate it like the other two

A credential cannot follow that precedent. The systemd unit lives in `/etc/systemd/system`, and the operator-editable override file is installed mode `0644` — both readable by every local user on the box. Baking the key into either would trade a silent misconfiguration for a durable disclosure, which is a worse defect than the one being fixed.

So the fix points at the one location the gateway already reads at boot: `load_credentials()` loads **every** key from `~/.kiro/crew/.env` (not just the channel-credential allowlist) into the gateway environment, and forces `0600` on the file before reading it. That path already works on `main`; nothing discovers it.

## Handling of the credential

- Only the variable **name** is inspected, in the installer's environment and in `.env`. The value is never read out of `.env`, logged, or echoed.
- The printed remedy references `$KIRO_API_KEY` rather than interpolating it, so the secret does not land in shell history or scrollback.
- A new test asserts `service_environment()` contains neither the name nor the value, pinning the decision above against a future "just propagate it" change.
- Silent on a login-based install and on one already configured through `.env`.

## Non-fatal by construction

The check runs after the unit is written and started, so it is wrapped like the AppArmor profile message beside it: an exception there would print a traceback over an install that actually succeeded and return non-zero for a healthy machine. A diagnostic that cannot fire beats an install that reports failure.

## Testing

12 tests in `TestHeadlessApiKeyWarning`, revert-verified in two rounds:

- Suppressing the detection fails 5 (the four silence assertions correctly still pass).
- Removing the two install-path call sites fails both platform-wiring tests.

Gates: `isort` clean, `flake8` clean, `mypy src/kiro_crew/` 942 files with one pre-existing `vector_memory.py` faiss-stub error (identical on a pristine `main` checkout in the same environment). `test_service.py` 249 pass, plus `test_env_allowlist_consolidation.py` / `test_kiro_prerequisite.py` / `test_tips.py` green (424 and 119).

## Not in scope

`KIROCREW_HOME` is also dropped by `service_environment()`, so an operator using a custom crew home gets a service reading a different `.env` than their shell resolves. The warning names that caveat when it sees the variable set, but actually propagating it is a separate change with its own back-compat question for already-installed units.

Refs #3257 — deliberately not `Closes`, because the reporter is on 0.2.0 where #2527 has not shipped; the probe filters the variable out there regardless of placement, so their case is resolved by the 0.3.0 release rather than by this commit.


This PR deliberately carries no closing trailer. Issue #3257 is what the reporter filed; their 0.2.0 install is repaired by the 0.3.0 release shipping #2527, not by this commit, so a closing trailer would mark their case done on merge while it is still broken for them.

