### PR TITLE
fix: pair settings captions with controls via label htmlFor (#3283)

### DIFF
--- a/website/src/components/SimpleSelect.tsx
+++ b/website/src/components/SimpleSelect.tsx
@@ -33,6 +33,10 @@ export interface SimpleSelectProps {
   triggerFallback?: string
   disabled?: boolean
   style?: React.CSSProperties
+  /** Forwarded to the trigger so a caption's `<label htmlFor>` can name it
+   *  (SettingsField pairs this with its label association). Optional: the
+   *  standalone dropdowns keep naming themselves via aria-label. */
+  id?: string
   /** Extra classes for the TRIGGER. For a caller whose surrounding rows are
    *  denser than the default `px-3 py-2 text-sm` — the dev config table runs at
    *  `h-7 text-[13px]`, and a taller control there would change every row's
@@ -41,7 +45,7 @@ export interface SimpleSelectProps {
   'aria-label'?: string
 }
 
-export default function SimpleSelect({ options, optionLabels, value, onChange, action, clearLabel, triggerFallback, disabled, style, className, 'aria-label': ariaLabel }: SimpleSelectProps) {
+export default function SimpleSelect({ options, optionLabels, value, onChange, action, clearLabel, triggerFallback, disabled, style, id, className, 'aria-label': ariaLabel }: SimpleSelectProps) {
   const toRadix = (v: string) => (v === '' ? EMPTY_VALUE_SENTINEL : v)
   const fromRadix = (v: string) => (v === EMPTY_VALUE_SENTINEL ? '' : v)
   // '' is selectable only when the options include it or a clearLabel row exists;
@@ -58,7 +62,7 @@ export default function SimpleSelect({ options, optionLabels, value, onChange, a
         }}
         disabled={disabled}
       >
-        <SelectTrigger aria-label={ariaLabel} className={className}>
+        <SelectTrigger id={id} aria-label={ariaLabel} className={className}>
           <SelectValue placeholder={triggerFallback ?? clearLabel ?? (value || '—')} />
         </SelectTrigger>
         <SelectContent>

--- a/website/src/components/settings.tsx
+++ b/website/src/components/settings.tsx
@@ -57,12 +57,22 @@ export function SettingsToggle({ label, description, checked, onChange, disabled
 
 /* ── Select ── */
 
-/** Shared field wrapper: label + optional hint + optional description */
-function SettingsField({ label, description, hint, configKey, children }: { label: string; description?: string; hint?: string; configKey?: string; children: React.ReactNode }) {
+/** Shared field wrapper: label + optional hint + optional description.
+ *
+ * `controlId` is the id of the labelable control rendered inside `children`.
+ * When provided, the caption renders as `<label htmlFor>` so the visible text
+ * becomes the control's programmatic name (unlocking screen-reader
+ * announcement and `getByLabelText` in tests). Without it the caption stays a
+ * `<span>` — a `<label>` with a dangling `htmlFor`, or one wrapping a group of
+ * buttons (SettingsStepper / SettingsButtonGroup), would be wrong. Optional so
+ * the wrappers without a single labelable control keep compiling unchanged. */
+function SettingsField({ label, description, hint, configKey, controlId, children }: { label: string; description?: string; hint?: string; configKey?: string; controlId?: string; children: React.ReactNode }) {
   return (
     <div data-setting-label={label} {...(configKey ? { 'data-setting-key': configKey } : {})} className="flex flex-col gap-1.5 py-1.5">
       <div className="flex items-center gap-1.5">
-        <span className="text-[13px] font-semibold text-text">{label}</span>
+        {controlId
+          ? <label htmlFor={controlId} className="text-[13px] font-semibold text-text">{label}</label>
+          : <span className="text-[13px] font-semibold text-text">{label}</span>}
         {hint && <InfoTip text={hint} />}
       </div>
       {description && <div className="text-[12px] text-muted">{description}</div>}
@@ -88,9 +98,15 @@ interface SettingsSelectProps {
 }
 
 export function SettingsSelect({ label, description, hint, value, options, optionLabels, onChange, action, disabled, configKey }: SettingsSelectProps) {
+  // Per-instance id pairing the caption's htmlFor with the select trigger, so
+  // the visible caption is the control's programmatic label. The aria-label
+  // below stays as a fallback: it wins the accessible-name computation and
+  // carries the same string, so nothing double-announces.
+  const controlId = React.useId()
   return (
-    <SettingsField label={label} description={description} hint={hint} configKey={configKey}>
+    <SettingsField label={label} description={description} hint={hint} configKey={configKey} controlId={controlId}>
       <SimpleSelect
+        id={controlId}
         options={options}
         optionLabels={optionLabels}
         value={value}
@@ -126,10 +142,18 @@ interface SettingsInputProps {
 }
 
 export function SettingsInput({ label, description, hint, value, onChange, onBlur, placeholder, type = 'text', min, max, step, disabled, multiline, 'aria-label': ariaLabel, configKey }: SettingsInputProps) {
+  // Per-instance id pairing the caption's htmlFor with the control. This is
+  // what gives the single-line branch an accessible name by DEFAULT: it used
+  // to render aria-label={ariaLabel} with ariaLabel undefined unless a caller
+  // duplicated the caption, leaving the input nameless to screen readers.
+  // An explicit aria-label still wins the name computation, so deliberate
+  // overrides keep working.
+  const controlId = React.useId()
   return (
-    <SettingsField label={label} description={description} hint={hint} configKey={configKey}>
+    <SettingsField label={label} description={description} hint={hint} configKey={configKey} controlId={controlId}>
       {multiline ? (
         <textarea
+          id={controlId}
           value={value}
           onChange={e => onChange(e.target.value)}
           onBlur={onBlur}
@@ -141,6 +165,7 @@ export function SettingsInput({ label, description, hint, value, onChange, onBlu
         />
       ) : (
         <Input
+          id={controlId}
           type={type}
           value={value}
           onChange={e => onChange(e.target.value)}

--- a/website/src/test/SettingsField.labelAssociation.test.tsx
+++ b/website/src/test/SettingsField.labelAssociation.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { SettingsButtonGroup, SettingsInput, SettingsSelect, SettingsStepper } from '../components/settings'
+
+/**
+ * SettingsField label association (issue #3283).
+ *
+ * The bug this locks: SettingsField rendered its caption as a plain <span>,
+ * so the visible caption was never programmatically associated with the
+ * control it captions. The single-line branch of SettingsInput passed
+ * `aria-label={ariaLabel}` where ariaLabel is undefined unless a caller
+ * explicitly duplicated the caption — so those inputs had NO accessible name
+ * at all (screen readers fell back to placeholder text or nothing).
+ *
+ * The fix generates a per-instance id (React.useId) in each field component,
+ * renders the caption as <label htmlFor={id}>, and threads the id onto the
+ * wrapped control. getByLabelText(<caption>) is therefore the assertion of
+ * record here: it resolves only through a real accessible-name channel
+ * (htmlFor/id association or aria-label), never through visual adjacency.
+ */
+describe('SettingsField label association', () => {
+  it('single-line input: caption resolves the control via htmlFor/id with no aria-label passed', () => {
+    render(<SettingsInput label="API key" value="" onChange={() => {}} placeholder="sk-..." />)
+
+    // Fail-before case: on main this throws — the caption is a <span> and the
+    // input has aria-label={undefined}, so the input has no accessible name.
+    const input = screen.getByLabelText('API key')
+    expect(input.tagName).toBe('INPUT')
+
+    // Prove the channel is a REAL label association, not an aria-label
+    // default: the caption element must be a <label> whose htmlFor points at
+    // the input's id.
+    const label = screen.getByText('API key')
+    expect(label.tagName).toBe('LABEL')
+    expect(input.id).toBeTruthy()
+    expect(label).toHaveAttribute('for', input.id)
+    // No aria-label was passed and none may be invented: the association IS
+    // the name. Inventing one would mask a future htmlFor regression.
+    expect(input).not.toHaveAttribute('aria-label')
+  })
+
+  it('multiline textarea: caption is a <label> associated with the textarea, aria-label fallback kept', () => {
+    render(<SettingsInput label="System prompt" value="" onChange={() => {}} multiline />)
+
+    const textarea = screen.getByLabelText('System prompt')
+    expect(textarea.tagName).toBe('TEXTAREA')
+
+    // The pre-existing aria-label fallback must survive. NOTE: this is a
+    // deliberate contract lock on the fallback the spec says to keep, not an
+    // a11y requirement — it wins over the label element and carries the same
+    // string, so nothing double-announces.
+    expect(textarea).toHaveAttribute('aria-label', 'System prompt')
+
+    // And the label association must exist underneath it.
+    const label = screen.getByText('System prompt')
+    expect(label.tagName).toBe('LABEL')
+    expect(textarea.id).toBeTruthy()
+    expect(label).toHaveAttribute('for', textarea.id)
+  })
+
+  it('select: caption is a <label> associated with the Radix trigger, aria-label fallback kept', () => {
+    render(
+      <SettingsSelect
+        label="Theme"
+        value="dark"
+        options={['light', 'dark']}
+        onChange={() => {}}
+      />
+    )
+
+    const trigger = screen.getByLabelText('Theme')
+    // The actual contract is that the trigger is a labelable element (<label
+    // htmlFor> only names form-associated elements); its ARIA role is Radix's
+    // business and may change across versions.
+    expect(trigger.tagName).toBe('BUTTON')
+
+    // Pre-existing aria-label path must survive as the fallback. NOTE: this is
+    // a deliberate contract lock on the fallback the spec says to keep (an
+    // explicit override channel), not an a11y requirement — the htmlFor
+    // association below would name the trigger by itself.
+    expect(trigger).toHaveAttribute('aria-label', 'Theme')
+
+    // And the trigger must now carry the id the caption's htmlFor points at.
+    const label = screen.getByText('Theme')
+    expect(label.tagName).toBe('LABEL')
+    expect(trigger.id).toBeTruthy()
+    expect(label).toHaveAttribute('for', trigger.id)
+  })
+
+  it('explicit aria-label override still wins over the label association', () => {
+    render(
+      <SettingsInput
+        label="Visible caption"
+        aria-label="Announced name"
+        value=""
+        onChange={() => {}}
+      />
+    )
+
+    // Query by COMPUTED accessible name: getByRole implements accname
+    // precedence, so this fails if the htmlFor association ever outranks the
+    // explicit aria-label (getByLabelText alone would pass through either
+    // channel and could not catch a precedence regression).
+    const input = screen.getByRole('textbox', { name: 'Announced name' })
+    expect(input).toHaveAttribute('aria-label', 'Announced name')
+
+    // The caption text must NOT be the computed name once overridden…
+    expect(screen.queryByRole('textbox', { name: 'Visible caption' })).toBeNull()
+
+    // …but it still renders visually (the override changes the announced
+    // name, not the visual caption).
+    expect(screen.getByText('Visible caption')).toBeInTheDocument()
+  })
+
+  it('keeps the data-setting-label / data-setting-key query hooks intact', () => {
+    const { container } = render(
+      <SettingsInput label="Poll interval" configKey="poll.interval" value="30" onChange={() => {}} />
+    )
+
+    const field = container.querySelector('[data-setting-label="Poll interval"]')
+    expect(field).not.toBeNull()
+    expect(field).toHaveAttribute('data-setting-key', 'poll.interval')
+  })
+
+  it('generates distinct ids for sibling fields with the same caption', () => {
+    render(
+      <>
+        <SettingsInput label="Token" value="a" onChange={() => {}} />
+        <SettingsInput label="Token" value="b" onChange={() => {}} />
+      </>
+    )
+
+    const inputs = screen.getAllByLabelText('Token')
+    expect(inputs).toHaveLength(2)
+    expect(inputs[0].id).not.toBe(inputs[1].id)
+  })
+
+  it('stepper and button-group captions stay a <span> — no single labelable control', () => {
+    // Locks the deliberate no-controlId decision: a <label htmlFor> pointing
+    // at a button group (or at nothing) is itself an a11y defect. If a later
+    // refactor threads controlId into these wrappers, this fails.
+    render(
+      <>
+        <SettingsStepper label="Retries" value={3} onIncrement={() => {}} onDecrement={() => {}} />
+        <SettingsButtonGroup
+          label="Density"
+          value="cozy"
+          options={[{ value: 'cozy', label: 'Cozy' }, { value: 'compact', label: 'Compact' }]}
+          onChange={() => {}}
+        />
+      </>
+    )
+
+    expect(screen.getByText('Retries').tagName).toBe('SPAN')
+    expect(screen.getByText('Density').tagName).toBe('SPAN')
+    // The group keeps its own naming channel (role=group + aria-label).
+    expect(screen.getByRole('group', { name: 'Density' })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** The caption element changes from `<span>` to `<label>` with byte-identical typography classes (`text-[13px] font-semibold text-text`) and identical layout; the only deltas are accessibility-tree wiring (`htmlFor`/`id` pairing) with zero rendered-pixel change.

## What

`SettingsField` rendered its caption as a plain `<span>`, so the visible caption was never programmatically associated with the control it captions. The single-line branch of `SettingsInput` passed `aria-label={ariaLabel}` where `ariaLabel` is `undefined` unless a caller duplicated the caption — those inputs (~23 call sites) had **no accessible name at all**; screen readers fell back to placeholder text or nothing.

## How

Fixed the primitive once so every caller gains a correct accessible name with no call-site change:

- `SettingsField` accepts an optional `controlId` and renders the caption as `<label htmlFor={controlId}>` when provided. Typography classes and the `data-setting-label` / `data-setting-key` query hooks (Search Everywhere / SettingRef) are unchanged.
- `SettingsInput` and `SettingsSelect` generate a per-instance `React.useId()` and thread it both directions: onto the caption's `htmlFor` and onto the wrapped control (`Input id`, `textarea id`, and `SimpleSelect`'s new optional `id` forwarded to the Radix `SelectTrigger`).
- Existing `aria-label` fallbacks are deliberately kept: an explicit `aria-label` on `SettingsInput` still wins the accessible-name computation, and the textarea/select fallbacks carry the same string as the label so nothing double-announces.
- `SettingsStepper` / `SettingsButtonGroup` intentionally do **not** pass `controlId` (no single labelable control; a `<label>` around a button group would itself be an a11y defect). A test locks this decision.

This also unlocks `getByLabelText(<caption>)` in tests for all three field shapes.

## Tests

New `website/src/test/SettingsField.labelAssociation.test.tsx` (7 tests):
- label association resolves the control for single-line input, multiline textarea, and select trigger (fail-before verified on the single-line case: 4/6 initial tests failed on main);
- explicit `aria-label` override wins, asserted via computed accessible name (`getByRole(…, { name })`) so a precedence regression is actually caught;
- `data-setting-*` hooks intact; distinct ids for same-caption siblings; Stepper/ButtonGroup captions stay `<span>`.

Gates: `npx tsc -b` clean; frontend vitest 1066 files / 17,867 passed; backend isort/flake8/mypy clean; backend pytest 50,665 passed (77 failures all pre-existing environmental on this host — sandbox backend unavailable, live-gateway port collisions — backend source untouched).

Out of scope per issue triage: `WeixinPanel.tsx` per-caller `aria-label` cleanup (PR #3279 is open on that file), restyles, migrating existing tests off `getByPlaceholderText`.

Closes #3283
