### PR TITLE
fix(test_dashboard_server_startup_coverage): adopt short_sock_dir in dashboard startup coverage socket tests

### DIFF
--- a/test/test_dashboard_server_startup_coverage.py
+++ b/test/test_dashboard_server_startup_coverage.py
@@ -86,14 +86,14 @@ class TestRemoveStaleUnixSocket:
         assert victim.is_dir()
 
     @requires_unix_socket
-    def test_a_real_stale_socket_is_unlinked(self, tmp_path: Path) -> None:
+    def test_a_real_stale_socket_is_unlinked(self, short_sock_dir: Path) -> None:
         """The arm that lets a restart rebind: a real socket inode is removed.
 
         Asserted against a real ``AF_UNIX`` inode rather than a mocked
         ``os.stat``, because the whole decision is ``S_ISSOCK`` on the real
         mode bits.
         """
-        path = tmp_path / "stale.sock"
+        path = short_sock_dir / "stale.sock"
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
             sock.bind(str(path))
@@ -107,7 +107,7 @@ class TestRemoveStaleUnixSocket:
 
     @requires_unix_socket
     def test_an_unlink_failure_is_logged_and_swallowed(
-        self, tmp_path: Path, monkeypatch, caplog
+        self, short_sock_dir: Path, monkeypatch, caplog
     ) -> None:
         """A refused unlink must degrade to TCP-only, not abort startup.
 
@@ -115,7 +115,7 @@ class TestRemoveStaleUnixSocket:
         raising here would take the whole gateway down over an optional
         transport.
         """
-        path = tmp_path / "stale.sock"
+        path = short_sock_dir / "stale.sock"
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
             sock.bind(str(path))
@@ -162,7 +162,7 @@ class TestRegisterUnixSocketCleanup:
     @requires_unix_socket
     @pytest.mark.asyncio
     async def test_the_socket_named_after_registration_is_removed(
-        self, tmp_path: Path
+        self, short_sock_dir: Path
     ) -> None:
         """A clean shutdown must not leave a socket file behind.
 
@@ -170,7 +170,7 @@ class TestRegisterUnixSocketCleanup:
         fallback, so this is the difference between a clean restart and one that
         looks broken to every internal caller.
         """
-        path = tmp_path / "dash.sock"
+        path = short_sock_dir / "dash.sock"
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.bind(str(path))
         sock.close()
@@ -366,9 +366,7 @@ class TestStartDashboardWiring:
         ``_audit_denied`` exists at all).
         """
         async with _dashboard(tmp_path, monkeypatch) as (runner, _state, _spies):
-            names = [
-                getattr(mw, "__name__", type(mw).__name__) for mw in runner.app.middlewares
-            ]
+            names = [getattr(mw, "__name__", type(mw).__name__) for mw in runner.app.middlewares]
 
         assert "host_validation_middleware" in names
         assert "sel_audit_middleware" in names
@@ -409,9 +407,7 @@ class TestStartDashboardWiring:
                 assert resp.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
 
     @pytest.mark.asyncio
-    async def test_lifecycle_hooks_are_registered_by_name(
-        self, tmp_path, monkeypatch
-    ) -> None:
+    async def test_lifecycle_hooks_are_registered_by_name(self, tmp_path, monkeypatch) -> None:
         """Every long-lived subsystem must have a teardown hook.
 
         Selected BY NAME: the lists are appended to as subsystems are added, so a
@@ -465,9 +461,7 @@ class TestStartDashboardWiring:
                 assert resp.status == 403
 
     @pytest.mark.asyncio
-    async def test_a_configured_url_joins_the_csrf_origin_set(
-        self, tmp_path, monkeypatch
-    ) -> None:
+    async def test_a_configured_url_joins_the_csrf_origin_set(self, tmp_path, monkeypatch) -> None:
         """A published URL widens the CSRF allowlist — but only behind token auth.
 
         The widening is guarded by an explicit re-check that the token-auth
@@ -477,9 +471,11 @@ class TestStartDashboardWiring:
         origin unauthenticated.
         """
         url = "http://dash.example.com:5476"
-        async with _dashboard(
-            tmp_path, monkeypatch, dashboard_url=url, local_only=False
-        ) as (runner, _state, _spies):
+        async with _dashboard(tmp_path, monkeypatch, dashboard_url=url, local_only=False) as (
+            runner,
+            _state,
+            _spies,
+        ):
             assert any(getattr(mw, "_is_token_auth", False) for mw in runner.app.middlewares)
             assert url in runner.app["allowed_origins"]
 
@@ -527,9 +523,7 @@ class TestStartDashboardWiring:
             lambda: SimpleNamespace(
                 tunnel=provider,
                 telemetry=SimpleNamespace(record_event=lambda *_a, **_k: None),
-                dashboard=SimpleNamespace(
-                    start_services=AsyncMock(), stop_services=AsyncMock()
-                ),
+                dashboard=SimpleNamespace(start_services=AsyncMock(), stop_services=AsyncMock()),
             ),
         )
 


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 1 related change:
- **Adopt short_sock_dir in dashboard startup coverage socket tests**

## Changes and rationale

### Adopt short_sock_dir in dashboard startup coverage socket tests
**Problem:** Three tests in test/test_dashboard_server_startup_coverage.py (TestRegisterUnixSocketCleanup::test_the_socket_named_after_registration_is_removed, TestRemoveStaleUnixSocket::test_a_real_stale_socket_is_unlinked, TestRemoveStaleUnixSocket::test_an_unlink_failure_is_logged_and_swallowed) bind real AF_UNIX sockets at paths derived from pytest tmp_path (verified on upstream/main: sockets bound at tmp_path/"stale.sock" etc. around lines 89-174). When the pytest temp base resolves under a deep directory (observed in…
**Why it matters:** Deterministic full-suite failure on any deep checkout. It contributed to dead-lettering file-path-menu-component on 2026-08-12 (gate-pytest run run-290f70, 3 failed / 338 passed in the file's shard). The tests are temporarily deselected in the local gate-pytest HOST_ENV_DESELECTS (entry 6) — remove that entry when this fix merges upstream.
**Fix (symptoms → root cause → change):** Switch the socket-BINDING paths in the three tests from tmp_path to the existing short_sock_dir conftest fixture. Keep tmp_path for anything that is not a bound socket (e.g. the "never-existed.sock" nonexistent-path probe and the "not-a-socket" plain file at lines ~61-70 never bind, and may stay on tmp_path). No behavior change, no skips — the tests must actually run.
**Tests:** Run the three tests with a deliberately long --basetemp (>90 chars): all pass. Control: they fail with OSError on pre-fix code under the same basetemp. Normal full-file run stays green; no leaked temp dirs (short_sock_dir cleans up). .venv/bin/python -m pytest test/test_dashboard_server_startup_coverage.py -o addopts="" -p no:cacheprovider
**Review focus:** backend

## Review map

| Change | Primary files |
|---|---|
| Adopt short_sock_dir in dashboard startup coverage socket tests | `test/test_dashboard_server_startup_coverage.py` |

## Commits
- [`f2a9314`](https://github.com/kirodotdev/KiroCrew/pull/3319/commits/f2a9314c4adc0864424763e13826f17eeb8d9d09) fix(test_dashboard_server_startup_coverage): adopt short_sock_dir in …

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (1 files, +15/-21)</summary>

- `test/test_dashboard_server_startup_coverage.py` (+15/-21)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->