### PR TITLE
fix(mochi): bind native settings close after handleClose exists

### DIFF
--- a/website/src/apps/mochi/src/renderer/SettingsPanel.tsx
+++ b/website/src/apps/mochi/src/renderer/SettingsPanel.tsx
@@ -3,7 +3,7 @@
  * All changes are staged locally. Only applied on Save.
  * Closing without saving prompts the user and reverts if discarded.
  */
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import type { AppConfig } from '../shared/config'
 import { ELECTRON_MAP, MODIFIER_GLYPHS, MODIFIER_ORDER } from '../shared/config'
 import type { CompanionStats, McpServerInfo } from '../shared/types'
@@ -119,11 +119,18 @@ export const SettingsPanel: React.FC<{ onClose: () => void }> = ({ onClose }) =>
     return JSON.stringify(config) !== JSON.stringify(original)
   })()
 
-  // Listen for native window close (red × button)
+  // Declared before the native-close subscription: an early fire during subscribe
+  // would otherwise read handleClose while it is still in the temporal dead zone.
+  // The effect deps include handleClose so a dirty-state change replaces the
+  // listener; an empty list would keep the first (always-clean) closure forever.
+  const handleClose = useCallback(() => {
+    if (isDirty) { setShowUnsaved(true) } else { onClose() }
+  }, [isDirty, onClose])
+
   useEffect(() => {
     const off = api?.onSettingsCloseRequested?.(() => handleClose())
     return () => { off?.() }
-  })
+  }, [handleClose])
 
   useEffect(() => {
     api?.getConfig?.().then((c: AppConfig) => {
@@ -265,10 +272,6 @@ export const SettingsPanel: React.FC<{ onClose: () => void }> = ({ onClose }) =>
       applyTheme(original.mochi.theme as ThemeId)
     }
     onClose()
-  }
-
-  const handleClose = () => {
-    if (isDirty) { setShowUnsaved(true) } else { onClose() }
   }
 
   return (

--- a/website/src/test/MochiSettingsPanel.coverage.test.tsx
+++ b/website/src/test/MochiSettingsPanel.coverage.test.tsx
@@ -33,6 +33,11 @@ import type { CompanionStats, McpServerInfo } from '../apps/mochi/src/shared/typ
 const mocks = vi.hoisted(() => {
   /** `onSettingsCloseRequested` subscribers, so a native close can be replayed. */
   const closeRequested = new Set<() => void>()
+  /** Default subscribe: register only. Restored after any test that replaces it. */
+  const subscribeClose = (cb: () => void) => {
+    closeRequested.add(cb)
+    return () => { closeRequested.delete(cb) }
+  }
   const api = {
     hasShell: true,
     getConfig: vi.fn<() => Promise<unknown>>(),
@@ -48,13 +53,11 @@ const mocks = vi.hoisted(() => {
     setModel: vi.fn<(m: string) => Promise<boolean>>(),
     galleryOpen: vi.fn(),
     openExternal: vi.fn(),
-    onSettingsCloseRequested: (cb: () => void) => {
-      closeRequested.add(cb)
-      return () => { closeRequested.delete(cb) }
-    },
+    onSettingsCloseRequested: subscribeClose,
   }
   return {
     api,
+    subscribeClose,
     /** Replay the native window-close request the shell sends on the red ×. */
     requestClose: () => { for (const cb of [...closeRequested]) cb() },
     clearCloseRequested: () => closeRequested.clear(),
@@ -198,6 +201,9 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  // Tests may replace this to fire during subscribe; put the register-only
+  // default back so the next case does not inherit an early-fire mock.
+  api.onSettingsCloseRequested = mocks.subscribeClose
 })
 
 /* ── loading gate ─────────────────────────────────────────────── */
@@ -1117,5 +1123,30 @@ describe('SettingsPanel close', () => {
     mocks.requestClose()
 
     await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+  })
+
+  it('survives a native close that fires during subscribe', () => {
+    // Pins the TDZ: subscribe used to close over handleClose declared later in
+    // the component body, so an early fire threw ReferenceError.
+    api.onSettingsCloseRequested = (cb: () => void) => {
+      cb()
+      return mocks.subscribeClose(cb)
+    }
+
+    expect(() => render(<SettingsPanel onClose={onClose} />)).not.toThrow()
+  })
+
+  it('keeps the native-close handler current after re-renders', async () => {
+    // Pins the empty-deps stale-closure case: the first handleClose always saw
+    // isDirty false (config not landed yet), so a later close skipped the prompt.
+    await mount()
+    openSection('Appearance')
+    openSection('Behavior')
+    openSection('General')
+    fireEvent.change(screen.getByDisplayValue('Mochi'), { target: { value: 'Tofu' } })
+
+    mocks.requestClose()
+    expect(await screen.findByText('Unsaved Changes')).toBeTruthy()
+    expect(onClose).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Declare handleClose before the native-close subscription and give the effect a real dependency list so an early fire cannot hit the temporal dead zone and dirty-state changes replace the listener instead of stacking one per render.

Closes #3309

<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

<!-- Bug fix: the concrete symptom — what is broken or missing, ideally what the
     user observes.
     New feature / enhancement: the gap, use case, or opportunity this addresses
     — what a user cannot do (or does awkwardly) today. -->

## Why it matters

<!-- Impact if this is left undone: for a fix, who is hit by the bug and how
     badly; for a feature, the user/business value it unlocks. -->

## What changed (motivation → approach → change)

<!-- A short chain of thought so the reader sees *why this is the right change*,
     not just what changed:
     - Bug fix: observed symptom → underlying root cause → the specific change
       that addresses that cause.
     - New feature / enhancement: goal → the approach/design you chose (and why,
       over the alternatives you considered) → what you actually built. -->

## Tests

<!-- Automated tests added/updated and the behavior each one locks in. -->

## Manual verification

<!-- Manual steps performed or still required where unit tests fall short
     (integration paths, UI, external services). State "N/A — unit coverage
     sufficient" only when genuinely true, with a one-line why. -->

## Screenshots / video

<!-- MANDATORY for any user-visible UI change (new/changed panels, components,
     layouts, themes); delete this section otherwise.

     - Show each affected surface in its meaningful variants (e.g. desktop vs
       browser, empty vs populated, light vs dark).
     - Prefer a short video/GIF when the change involves motion or a multi-step
       flow (animations, transitions, interactions) — a still image cannot
       prove those.
     - Commit media to the PR branch under a top-level, ephemeral, never-packaged
       dir `temp-screenshots/<feature>/` (never under docs/ or src/kiro_crew/**)
       and embed with commit-SHA-pinned URLs so they survive branch deletion on
       merge and periodic cleanup:
       ![alt](https://github.com/<owner>/<repo>/raw/<sha>/temp-screenshots/<feature>/<name>.png)
     - Put the two or three most telling shots inline; fold full-page context
       into a <details> block. -->

## Related Issues

<!-- Link to relevant issues, e.g. Fixes #123 -->

## Checklist

- [ ] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality
- [ ] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
