### PR TITLE
fix(mcp-gateway): gatewayd self-exits when its socket path disappears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **MCP gateway daemons no longer leak when their launcher dies.** A `gatewayd`
+  whose launcher exited without signalling it (a torn-down `pytest` run, for
+  example) used to stay resident forever — invisible to every sweep, ~27 MB
+  each, accumulating without bound. The daemon now watches its own listening
+  socket path and gracefully self-exits once the path is gone (three
+  consecutive checks, POSIX only), and the untracked-orphan sweep reaps any
+  gatewayd whose `--socket` path no longer exists on disk, TERM-first so
+  pooled backends drain cleanly. (#3315)
+
 - **Slack manifest: private channels now work out of the box.** The shipped app
   manifest adds the `groups:history` and `users:read` bot scopes and subscribes
   to the `message.groups` event, so a tracked private channel actually delivers

--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -678,6 +678,39 @@ parent PID explicitly avoids this.
 - **Periodic**: `_cleanup_loop()` calls it alongside idle session expiry (~60s)
 - **At shutdown**: `cleanup_orphaned_sessions()` on signal/exit
 
+### Unreachable gatewayd reclamation
+
+`mcp_gateway.gatewayd` daemons are their own session/process-group leaders
+(`start_new_session=True`), so a launcher that dies without signalling one
+(pytest teardown is the common case) leaves it resident forever — `killpg`
+from the launcher's tree cannot reach it, and the marker-based orphan sweep
+excludes gateway entrypoints (`_GATEWAY_MARKERS`) because a cmdline alone
+cannot distinguish a live dev pod's daemon from a dead launcher's. Two layers
+close the leak, both keyed on the one reachability signal that IS observable:
+the daemon's `--socket` path. gatewayd creates that socket at bind, so once
+the path is absent from disk no stub can ever connect again — the process is
+provably unreachable regardless of who launched it.
+
+- **Self-exit (primary, in-daemon)**: `gatewayd._socket_liveness_sweeper`
+  stats its own socket path on the idle-sweep cadence, armed only after a
+  successful bind. Three CONSECUTIVE `ENOENT` observations set `stop_event`,
+  taking the same graceful drain as SIGTERM (backends drained and reaped).
+  Any other stat failure (EACCES/EIO) is inconclusive and never counts.
+  POSIX-only — a Windows named pipe has no directory entry to observe.
+- **Sweep-side reap (defense in depth)**: `_is_sweepable_orphan_gatewayd` is
+  a fourth positive-identity path in the untracked orphan sweep. It overrides
+  the `_GATEWAY_MARKERS` exclusion only for a structural
+  `-m kiro_crew.mcp_gateway.gatewayd` argv whose `--socket` path is gone
+  (NUL-separated argv only — the space-joined `ps` fallback cannot delimit
+  paths safely and fails closed, so the path is effectively Linux-only).
+  `kiro_crew.cli` / `kiro_crew.__main__` stay unconditionally excluded. The
+  kill is TERM-first (`_kill_orphan_gatewayd`) so the daemon drains its own
+  pooled backends, escalating to `killpg` SIGKILL only after the daemon's full
+  `TOTAL_SHUTDOWN_BUDGET_SECS` (shared with the supervisor's SIGTERM→SIGKILL
+  grace, so a correctly-draining daemon is never killed mid-drain), with a
+  cmdline re-verify guarding PID recycling. Same-uid + reparented-to-init
+  candidacy, the age floor, and the kill budget all still apply.
+
 ### session_pid sidecar contract (`session_pid_sig.py`)
 
 The gateway maps its direct child pid to a session key by publishing

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -75,6 +75,7 @@ from kiro_crew.mcp_gateway.shutdown_budget import DRAIN_SECS, POOL_SHUTDOWN_SECS
 from kiro_crew.mcp_gateway.spill import cleanup_old_spill_files
 from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.peer_resolve import resolve_peer_identity
+from kiro_crew.platform_compat import IS_WINDOWS
 from kiro_crew.platform_compat import get_process_start_id as _get_process_start_id
 from kiro_crew.sandbox import warm_backend
 from kiro_crew.sel import SecurityEventLog
@@ -412,6 +413,7 @@ async def run_gatewayd(
     # a dangling socket that confuses the next startup probe.
     server: Optional[transport.TransportServer] = None
     sweeper: Optional[asyncio.Task[None]] = None
+    socket_liveness: Optional[asyncio.Task[None]] = None
     diagnostic: Optional[asyncio.Task[None]] = None
     heartbeat: Optional[asyncio.Task[None]] = None
     flush_sweeper: Optional[asyncio.Task[None]] = None
@@ -459,6 +461,22 @@ async def run_gatewayd(
             _idle_sweeper(pool, idle_timeout_secs, sweep_interval, stop_event),
             name="mcp-gateway-idle-sweeper",
         )
+
+        # Socket-liveness self-exit: the daemon is its own session/group
+        # leader, so a launcher that dies without signalling it (pytest
+        # teardown is the common case) leaves it resident forever — and the
+        # tracked-PID and orphan sweeps both exclude gateway entrypoints by
+        # design. The one unreachability signal observable from inside is the
+        # listening socket path this daemon created: once it is gone, no stub
+        # can ever connect again. Armed HERE, only after ``transport.serve``
+        # bound the endpoint — before bind, an absent path is a startup race,
+        # not unreachability. POSIX-only: a Windows named pipe has no
+        # directory entry to observe.
+        if not IS_WINDOWS:
+            socket_liveness = asyncio.create_task(
+                _socket_liveness_sweeper(socket_path, sweep_interval, stop_event),
+                name="mcp-gateway-socket-liveness",
+            )
 
         # Zombie diagnostic: probes
         # ``server.is_serving()`` every 30 s and dumps a post-mortem JSONL on
@@ -652,6 +670,11 @@ async def run_gatewayd(
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await sweeper
 
+        if socket_liveness is not None:
+            socket_liveness.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await socket_liveness
+
         if diagnostic is not None:
             diagnostic.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -735,6 +758,75 @@ async def _idle_sweeper(
                     logger.debug("idle sweep evicted %d backends", evicted)
             except Exception:  # pragma: no cover — defensive
                 logger.exception("idle sweep failed; continuing")
+    except asyncio.CancelledError:
+        pass
+
+
+#: Consecutive missing-socket observations required before the daemon
+#: self-exits. A single stat is not trusted: a transient tmpfs/NFS hiccup
+#: must not kill a healthy daemon, so only an uninterrupted run of misses
+#: counts as proof of unreachability.
+_SOCKET_LIVENESS_MISSES = 3
+
+
+async def _socket_liveness_sweeper(
+    socket_path: Path,
+    interval: float,
+    stop_event: asyncio.Event,
+) -> None:
+    """Self-exit when the daemon's own listening socket path disappears.
+
+    The daemon is spawned with ``start_new_session=True``, making it a
+    session and process-group leader: when its launcher dies without
+    signalling it, no ``killpg`` from the launcher's tree can reach it and it
+    stays resident forever. The one unreachability signal observable from
+    inside is the listening socket path this daemon created at bind — once
+    that path is gone, no stub can ever connect again, so the process is
+    provably useless regardless of who launched it. Exiting through
+    ``stop_event`` takes exactly the graceful drain path SIGTERM takes:
+    in-flight work drains and every pooled backend is shut down.
+
+    Fail-closed rules:
+
+    * The caller arms this task only AFTER a successful bind — before that,
+      an absent path is a startup race, not unreachability.
+    * Only ``FileNotFoundError`` (ENOENT) counts as a miss. Any other stat
+      failure (EACCES, EIO, …) is inconclusive: it neither counts toward
+      exit nor resets an in-progress miss streak.
+    * :data:`_SOCKET_LIVENESS_MISSES` CONSECUTIVE misses are required; a
+      successful stat resets the streak.
+    * POSIX-only — a Windows named pipe has no directory entry to observe,
+      so the caller never creates this task there.
+    """
+    misses = 0
+    try:
+        while not stop_event.is_set():
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval)
+                break  # stop_event fired — exit cleanly
+            except asyncio.TimeoutError:
+                pass
+            try:
+                await asyncio.to_thread(os.stat, socket_path)
+                misses = 0
+            except FileNotFoundError:
+                misses += 1
+                if misses >= _SOCKET_LIVENESS_MISSES:
+                    logger.warning(
+                        "gatewayd socket %s missing for %d consecutive checks — "
+                        "no stub can reach this daemon again; initiating "
+                        "graceful self-shutdown",
+                        socket_path,
+                        misses,
+                    )
+                    stop_event.set()
+                    break
+            except OSError:
+                logger.debug(
+                    "socket liveness probe inconclusive for %s",
+                    socket_path,
+                    exc_info=True,
+                )
     except asyncio.CancelledError:
         pass
 
@@ -3195,7 +3287,10 @@ def _build_argparser() -> argparse.ArgumentParser:
         dest="idle_timeout_secs",
         type=int,
         default=300,
-        help="Seconds an unattached backend is kept before the idle sweeper drains it.",
+        help="Seconds an unattached POOLED BACKEND is kept before the idle "
+        "sweeper evicts it. Bounds pool-entry lifetime only, never the "
+        "daemon's own — the daemon exits on SIGTERM/SIGINT or when its own "
+        "socket path disappears.",
     )
     p.add_argument(
         "--prewarm-count",

--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -24,6 +24,7 @@ from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 from kiro_crew.constants import KIROCREW_SPAWNED_ENV, KIROCREW_SPAWNED_VALUE
+from kiro_crew.mcp_gateway.shutdown_budget import TOTAL_SHUTDOWN_BUDGET_SECS
 from kiro_crew.providers.base import LLMProvider
 
 logger = logging.getLogger(__name__)
@@ -1090,8 +1091,9 @@ _MCP_ENTRYPOINT_MARKERS = (
 
 # Gateway/CLI entrypoints — these are peer gateways, never orphan MCP targets.
 # Checked BEFORE _MCP_ENTRYPOINT_MARKERS to prevent prefix overlap.
+_GATEWAYD_MODULE = b"kiro_crew.mcp_gateway.gatewayd"
 _GATEWAY_MARKERS = (
-    b"kiro_crew.mcp_gateway.gatewayd",
+    _GATEWAYD_MODULE,
     b"kiro_crew.cli",
     b"kiro_crew.__main__",
 )
@@ -1255,6 +1257,130 @@ def _is_sweepable_orphan_mcp(pid: int, cmdline: bytes) -> bool:
     return _is_marked_mcp_launcher(cmdline) and _env_has_kirocrew_marker(pid)
 
 
+# Grace given to a TERMed unreachable gatewayd before killpg SIGKILL. TERM is
+# sent first, deliberately: gatewayd's signal handler routes into the same
+# graceful stop path a supervised shutdown takes, so the daemon drains
+# in-flight work and reaps its own pooled backend subprocesses — a direct
+# SIGKILL would orphan them for a later sweep instead. Derived from the
+# daemon's own total shutdown budget (the same discipline the supervisor's
+# SIGTERM→SIGKILL grace follows) so the escalation can never fire while a
+# correctly-draining daemon is still inside its drain window.
+_GATEWAYD_TERM_GRACE_SECONDS = float(TOTAL_SHUTDOWN_BUDGET_SECS)
+
+
+def _gatewayd_socket_arg(cmdline: bytes) -> bytes | None:
+    """Extract the ``--socket`` argument from a gatewayd cmdline, or ``None``.
+
+    Accepts the two-token ``--socket <path>`` form (the shape every Kiro Crew
+    spawn site produces) and the argparse-equivalent ``--socket=<path>``.
+    NUL-separated argv ONLY: the space-joined ``ps`` fallback (macOS) cannot
+    delimit a path containing spaces, and statting a truncated path would
+    read as ENOENT — a wrong-kill — so anything without NULs fails closed.
+    ABSOLUTE paths only, for the same reason: a relative path would be
+    resolved against the SWEEPER's working directory, not the daemon's, so
+    a reachable daemon bound to ``gw.sock`` in another cwd would read as
+    ENOENT here. When the flag repeats, the LAST occurrence is returned —
+    argparse binds last-wins, so that is the path the daemon actually
+    created.
+    """
+    args = [a for a in cmdline.split(b"\x00") if a]
+    if len(args) <= 1:
+        return None
+    candidate: bytes | None = None
+    for i, arg in enumerate(args):
+        if arg == b"--socket" and i + 1 < len(args):
+            candidate = args[i + 1]
+        elif arg.startswith(b"--socket="):
+            candidate = arg[len(b"--socket=") :]
+    if candidate is not None and os.path.isabs(os.fsdecode(candidate)):
+        return candidate
+    return None
+
+
+def _is_sweepable_orphan_gatewayd(cmdline: bytes) -> bool:
+    """Fourth positive-identity path: a gatewayd whose listening socket is gone.
+
+    :data:`_GATEWAY_MARKERS` excludes gateway entrypoints from every other
+    sweep path because the cmdline alone cannot distinguish a live dev pod's
+    daemon from a dead launcher's. This path supplies the missing
+    information: gatewayd creates the socket it is invoked with, and once
+    that path is absent from disk no stub can ever connect to the daemon
+    again — it is provably unreachable regardless of who launched it.
+
+    Positive identity is the conjunction of:
+
+    1. a structural ``-m kiro_crew.mcp_gateway.gatewayd`` argv pair — never
+       ``kiro_crew.cli`` / ``kiro_crew.__main__``, which stay unconditionally
+       excluded (they carry no socket argument and no equivalent
+       reachability predicate);
+    2. a ``--socket`` path in argv (:func:`_gatewayd_socket_arg`, NUL-argv
+       only, fail-closed);
+    3. that path absent from disk — ``ENOENT`` only; any other stat failure
+       is inconclusive and fails closed.
+
+    The callers preserve the rest of the sweep discipline: same-uid +
+    reparented-to-init candidacy, the age floor, the kill budget, and
+    re-verification immediately before signalling.
+    """
+    args = [a for a in cmdline.split(b"\x00") if a]
+    is_gatewayd = any(
+        args[i] == b"-m" and args[i + 1] == _GATEWAYD_MODULE for i in range(len(args) - 1)
+    )
+    if not is_gatewayd:
+        return False
+    sock = _gatewayd_socket_arg(cmdline)
+    if sock is None:
+        return False
+    try:
+        os.stat(os.fsdecode(sock))
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False  # inconclusive (EACCES, EIO, …) — fail closed
+    return False
+
+
+def _kill_orphan_gatewayd(pid: int, cmdline: bytes) -> int:
+    """SIGTERM an unreachable gatewayd; escalate to killpg SIGKILL if wedged.
+
+    TERM first so the daemon's graceful stop path drains and reaps its own
+    pooled backends. If the process is still alive after
+    :data:`_GATEWAYD_TERM_GRACE_SECONDS`, its identity is re-verified (PID
+    recycling) and the whole group is SIGKILLed — the daemon is its own
+    group leader (``start_new_session=True``), so ``killpg`` cannot reach
+    any foreign process.
+    """
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return 0
+    deadline = time.monotonic() + _GATEWAYD_TERM_GRACE_SECONDS
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            _sel_orphan_kill(pid, pid, cmdline, "sigterm")
+            return 1
+        time.sleep(0.1)
+    # Still alive past the grace: re-verify identity before force-kill so a
+    # recycled PID is never SIGKILLed.
+    try:
+        if sys.platform == "linux":
+            current = Path(f"/proc/{pid}/cmdline").read_bytes()
+            if current != cmdline:
+                _sel_orphan_kill(pid, pid, cmdline, "sigterm")
+                return 1
+        pgid = os.getpgid(pid)
+        if pgid == pid and pgid != os.getpgrp() and pgid > 1:
+            os.killpg(pgid, signal.SIGKILL)
+        else:
+            os.kill(pid, signal.SIGKILL)
+    except (ProcessLookupError, OSError):
+        pass
+    _sel_orphan_kill(pid, pid, cmdline, "sigterm+sigkill")
+    return 1
+
+
 def _work_orphan_basename(cmdline: bytes) -> bytes:
     """argv0 basename from a raw cmdline (NUL-separated Linux, space macOS)."""
     args = cmdline.split(b"\x00")
@@ -1397,6 +1523,7 @@ def find_orphan_mcp_candidates(active_pids: set[int]) -> list[int]:
             continue
         if not (
             _is_sweepable_orphan_mcp(pid, cmdline)
+            or _is_sweepable_orphan_gatewayd(cmdline)
             or _is_sweepable_orphan_work(pid, cmdline, pid_age)
         ):
             continue
@@ -1506,6 +1633,17 @@ def kill_orphan_mcps(pids: list[int]) -> int:
                     os.kill(pid, signal.SIGKILL)
                     killed += 1
                     _sel_orphan_kill(pid, pgid, cmdline, "kill")
+                continue
+            # Unreachable-gatewayd orphan: re-verify the FULL identity —
+            # the socket-path stat AND the age floor — right before
+            # signalling. The age recheck matters: a candidate that exited
+            # after the find phase can have its PID recycled by a brand-new
+            # gatewayd that has not bound its socket yet, and without the
+            # floor that pre-bind daemon would read as "socket absent" and
+            # be TERMed. TERM-first so the daemon drains its own backends.
+            gw_age = _linux_pid_age(pid, time.time()) if sys.platform == "linux" else 0.0
+            if gw_age >= _ORPHAN_MIN_AGE_SECONDS and _is_sweepable_orphan_gatewayd(cmdline):
+                killed += _kill_orphan_gatewayd(pid, cmdline)
                 continue
             # Work-class orphan (KIROCREW_SPAWNED marker, no launcher shape).
             # Re-verify the full identity — including the age floor — right

--- a/test/test_gatewayd_self_exit.py
+++ b/test/test_gatewayd_self_exit.py
@@ -1,0 +1,518 @@
+"""Unreachable-gatewayd reclamation (issue #3315).
+
+Two layers under test:
+
+* ``gatewayd._socket_liveness_sweeper`` — the daemon self-exits when its own
+  listening socket path disappears (three consecutive ENOENT observations),
+  and never exits on inconclusive stat failures or non-consecutive misses.
+* ``session_pid._is_sweepable_orphan_gatewayd`` + ``_kill_orphan_gatewayd`` —
+  the untracked orphan sweep reaps a gatewayd whose ``--socket`` path is gone
+  from disk, TERM-first, while ``kiro_crew.cli`` / ``kiro_crew.__main__`` and
+  live-socket daemons stay excluded.
+
+The ``run_gatewayd`` tests bind a real local socket under ``tmp_path``; no
+subprocesses are spawned and no sandbox is touched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew import session_pid as sp
+from kiro_crew.mcp_gateway import gatewayd as gw
+
+# POSIX process/socket semantics: ``os.killpg`` does not exist on Windows
+# (even patching it fails with AttributeError), and the daemon's endpoint
+# there is a named pipe with no directory entry to observe or unlink.
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX socket-file and killpg semantics"
+)
+
+# ── gatewayd._socket_liveness_sweeper ──────────────────────────────
+
+
+class TestSocketLivenessSweeper:
+    @pytest.mark.asyncio
+    async def test_exits_after_consecutive_misses(self, tmp_path: Path) -> None:
+        """Socket unlinked -> three consecutive misses -> stop_event set."""
+        sock = tmp_path / "gw.sock"
+        sock.write_text("")  # stand-in for the bound endpoint
+        stop = asyncio.Event()
+        task = asyncio.create_task(gw._socket_liveness_sweeper(sock, 0.01, stop))
+        try:
+            await asyncio.sleep(0.05)
+            assert not stop.is_set(), "must not exit while the path exists"
+            sock.unlink()
+            await asyncio.wait_for(stop.wait(), timeout=5)
+            # stop_event fired by the sweeper itself — the task finishes
+            # cleanly on its own.
+            await asyncio.wait_for(task, timeout=5)
+        finally:
+            if not task.done():
+                task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_does_not_exit_while_path_exists(self, tmp_path: Path) -> None:
+        sock = tmp_path / "gw.sock"
+        sock.write_text("")
+        stop = asyncio.Event()
+        task = asyncio.create_task(gw._socket_liveness_sweeper(sock, 0.01, stop))
+        await asyncio.sleep(0.2)  # ~20 intervals, all hits
+        assert not stop.is_set()
+        stop.set()
+        await asyncio.wait_for(task, timeout=5)
+
+    @pytest.mark.asyncio
+    async def test_inconclusive_stat_failure_never_triggers_exit(
+        self, tmp_path: Path
+    ) -> None:
+        """EACCES-style failures are not misses — the daemon must stay up."""
+        sock = tmp_path / "gw.sock"
+        sock.write_text("")
+        real_stat = os.stat
+
+        def denied(path, *args, **kwargs):
+            if str(path) == str(sock):
+                raise PermissionError(13, "denied", str(sock))
+            return real_stat(path, *args, **kwargs)
+
+        stop = asyncio.Event()
+        with patch("kiro_crew.mcp_gateway.gatewayd.os.stat", side_effect=denied):
+            task = asyncio.create_task(gw._socket_liveness_sweeper(sock, 0.01, stop))
+            await asyncio.sleep(0.2)  # far more than 3 intervals of EACCES
+            assert not stop.is_set()
+            stop.set()
+            await asyncio.wait_for(task, timeout=5)
+
+    @pytest.mark.asyncio
+    async def test_non_consecutive_misses_never_trigger_exit(
+        self, tmp_path: Path
+    ) -> None:
+        """Misses interleaved with hits must never exit.
+
+        Mutation guard for the CONSECUTIVE requirement: both removing the
+        ``misses = 0`` reset (cumulative counting) and lowering the threshold
+        (exit on any miss) make this pattern — miss, miss, hit, repeated —
+        set ``stop_event``, failing the assertion.
+        """
+        sock = tmp_path / "gw.sock"
+        sock.write_text("")
+        real_stat = os.stat
+        calls = {"n": 0}
+
+        def flaky(path, *args, **kwargs):
+            if str(path) == str(sock):
+                calls["n"] += 1
+                if calls["n"] % 3 != 0:  # two misses, then one hit, repeating
+                    raise FileNotFoundError(2, "gone", str(sock))
+            return real_stat(path, *args, **kwargs)
+
+        stop = asyncio.Event()
+        with patch("kiro_crew.mcp_gateway.gatewayd.os.stat", side_effect=flaky):
+            task = asyncio.create_task(gw._socket_liveness_sweeper(sock, 0.01, stop))
+            # Wait for enough probes that a cumulative counter would have
+            # fired many times over.
+            for _ in range(500):
+                if calls["n"] >= 12:
+                    break
+                await asyncio.sleep(0.01)
+            assert calls["n"] >= 12, "sweeper did not probe enough to prove anything"
+            assert not stop.is_set()
+            stop.set()
+            await asyncio.wait_for(task, timeout=5)
+
+    def test_armed_only_after_bind(self) -> None:
+        """Structural ratchet: the liveness task is created after the bind.
+
+        Before ``transport.serve`` returns, an absent socket path is a
+        startup race, not unreachability — so the create_task for the
+        liveness sweeper must appear AFTER the serve call in
+        ``run_gatewayd``'s body.
+        """
+        import inspect
+
+        src = inspect.getsource(gw.run_gatewayd)
+        bind_at = src.index("transport.serve(")
+        armed_at = src.index("_socket_liveness_sweeper(")
+        assert bind_at < armed_at
+
+
+@_POSIX_ONLY
+class TestRunGatewaydSelfExit:
+    @pytest.mark.asyncio
+    async def test_daemon_self_exits_when_socket_is_unlinked(
+        self, tmp_path: Path
+    ) -> None:
+        """End to end: bind a real endpoint, unlink it, daemon exits cleanly."""
+        socket_path = tmp_path / "gw-selfexit.sock"
+        stop_event = asyncio.Event()
+
+        def _resolver(pool_key):  # never invoked — no stub connects
+            raise AssertionError("no backend should be spawned")
+
+        daemon = asyncio.create_task(
+            gw.run_gatewayd(
+                socket_path,
+                max_backends=1,
+                idle_timeout_secs=1,  # sweep interval clamps to 0.5s
+                stop_event=stop_event,
+                target_resolver=_resolver,
+            )
+        )
+        try:
+            for _ in range(500):
+                if socket_path.exists():
+                    break
+                await asyncio.sleep(0.02)
+            assert socket_path.exists(), "the daemon never bound its endpoint"
+            socket_path.unlink()
+            # 3 consecutive misses at 0.5s intervals ≈ 1.5–2s, then the
+            # graceful drain. Generous ceiling for loaded CI hosts.
+            await asyncio.wait_for(daemon, timeout=30)
+            assert stop_event.is_set()
+        finally:
+            if not daemon.done():
+                stop_event.set()
+                await asyncio.wait_for(daemon, timeout=15)
+
+    @pytest.mark.asyncio
+    async def test_windows_never_arms_the_liveness_sweeper(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With IS_WINDOWS=True the sweeper is not created: unlinking the
+        endpoint path must NOT terminate the daemon (named pipes have no
+        directory entry, so the probe would be meaningless there)."""
+        monkeypatch.setattr(gw, "IS_WINDOWS", True)
+        socket_path = tmp_path / "gw-win.sock"
+        stop_event = asyncio.Event()
+
+        def _resolver(pool_key):
+            raise AssertionError("no backend should be spawned")
+
+        daemon = asyncio.create_task(
+            gw.run_gatewayd(
+                socket_path,
+                max_backends=1,
+                idle_timeout_secs=1,
+                stop_event=stop_event,
+                target_resolver=_resolver,
+            )
+        )
+        try:
+            for _ in range(500):
+                if socket_path.exists():
+                    break
+                await asyncio.sleep(0.02)
+            assert socket_path.exists(), "the daemon never bound its endpoint"
+            socket_path.unlink()
+            await asyncio.sleep(2.5)  # > 3 sweep intervals + margin
+            assert not daemon.done(), "daemon must keep serving without the probe"
+            assert not stop_event.is_set()
+        finally:
+            stop_event.set()
+            await asyncio.wait_for(daemon, timeout=15)
+
+
+# ── session_pid gatewayd sweep predicate ───────────────────────────
+
+
+def _gatewayd_cmdline(sock: Path | str, socket_form: str = "pair") -> bytes:
+    parts = [b"/usr/bin/python3", b"-m", b"kiro_crew.mcp_gateway.gatewayd"]
+    if socket_form == "pair":
+        parts += [b"--socket", os.fsencode(str(sock))]
+    elif socket_form == "equals":
+        parts += [b"--socket=" + os.fsencode(str(sock))]
+    parts += [b"--idle-timeout-secs", b"300", b"--max-backends", b"20"]
+    return b"\x00".join(parts)
+
+
+class TestIsSweepableOrphanGatewayd:
+    def test_gatewayd_with_gone_socket_is_sweepable(self, tmp_path: Path) -> None:
+        gone = tmp_path / "vanished.sock"
+        assert sp._is_sweepable_orphan_gatewayd(_gatewayd_cmdline(gone)) is True
+
+    def test_gatewayd_with_live_socket_is_not_sweepable(self, tmp_path: Path) -> None:
+        live = tmp_path / "live.sock"
+        live.write_text("")
+        assert sp._is_sweepable_orphan_gatewayd(_gatewayd_cmdline(live)) is False
+
+    def test_socket_equals_form_is_recognized(self, tmp_path: Path) -> None:
+        gone = tmp_path / "vanished.sock"
+        cmdline = _gatewayd_cmdline(gone, socket_form="equals")
+        assert sp._is_sweepable_orphan_gatewayd(cmdline) is True
+
+    def test_gatewayd_without_socket_arg_fails_closed(self) -> None:
+        cmdline = _gatewayd_cmdline("", socket_form="none")
+        assert sp._is_sweepable_orphan_gatewayd(cmdline) is False
+
+    def test_relative_socket_path_fails_closed(self) -> None:
+        """A relative --socket would be resolved against the SWEEPER's cwd,
+        not the daemon's — a reachable daemon bound to gw.sock elsewhere
+        would read as ENOENT here and be wrongly killed. Must never match."""
+        for form in ("pair", "equals"):
+            cmdline = _gatewayd_cmdline("gw.sock", socket_form=form)
+            assert sp._is_sweepable_orphan_gatewayd(cmdline) is False
+        # Control: the same name as an absolute path (nonexistent) matches.
+        cmdline = _gatewayd_cmdline("/nonexistent-dir-3315/gw.sock")
+        assert sp._is_sweepable_orphan_gatewayd(cmdline) is True
+
+    def test_duplicate_socket_flags_use_the_last_occurrence(
+        self, tmp_path: Path
+    ) -> None:
+        """argparse binds last-wins, so the LAST --socket is the path the
+        daemon actually created. Statting the first would terminate a
+        reachable daemon whose live socket is named later in argv."""
+        live = tmp_path / "live.sock"
+        live.write_text("")
+        gone = tmp_path / "gone.sock"
+        base = [b"/usr/bin/python3", b"-m", b"kiro_crew.mcp_gateway.gatewayd"]
+        # gone first, live last -> daemon is reachable -> NOT sweepable.
+        cmdline = b"\x00".join(
+            base
+            + [b"--socket", os.fsencode(str(gone)), b"--socket", os.fsencode(str(live))]
+        )
+        assert sp._is_sweepable_orphan_gatewayd(cmdline) is False
+        # live first, gone last -> daemon bound the gone path -> sweepable.
+        cmdline = b"\x00".join(
+            base
+            + [b"--socket", os.fsencode(str(live)), b"--socket", os.fsencode(str(gone))]
+        )
+        assert sp._is_sweepable_orphan_gatewayd(cmdline) is True
+        # last occurrence relative -> unresolvable -> fail closed.
+        cmdline = b"\x00".join(
+            base + [b"--socket", os.fsencode(str(gone)), b"--socket", b"gw.sock"]
+        )
+        assert sp._is_sweepable_orphan_gatewayd(cmdline) is False
+
+    def test_cli_and_main_entrypoints_are_never_sweepable(self, tmp_path: Path) -> None:
+        gone = tmp_path / "vanished.sock"
+        for module in (b"kiro_crew.cli", b"kiro_crew.__main__"):
+            cmdline = b"\x00".join(
+                [b"/usr/bin/python3", b"-m", module, b"--socket", os.fsencode(str(gone))]
+            )
+            assert sp._is_sweepable_orphan_gatewayd(cmdline) is False
+
+    def test_space_joined_ps_cmdline_fails_closed(self, tmp_path: Path) -> None:
+        """The macOS ps fallback cannot delimit paths — must never match."""
+        gone = tmp_path / "vanished.sock"
+        cmdline = _gatewayd_cmdline(gone).replace(b"\x00", b" ")
+        assert sp._is_sweepable_orphan_gatewayd(cmdline) is False
+
+    def test_marker_as_path_fragment_does_not_match(self, tmp_path: Path) -> None:
+        """`vim kiro_crew.mcp_gateway.gatewayd` shapes are structural misses."""
+        gone = tmp_path / "vanished.sock"
+        cmdline = b"\x00".join(
+            [
+                b"vim",
+                b"kiro_crew.mcp_gateway.gatewayd",
+                b"--socket",
+                os.fsencode(str(gone)),
+            ]
+        )
+        assert sp._is_sweepable_orphan_gatewayd(cmdline) is False
+
+    def test_inconclusive_stat_failure_fails_closed(self, tmp_path: Path) -> None:
+        sock = tmp_path / "denied.sock"
+        real_stat = os.stat
+
+        def denied(path, *args, **kwargs):
+            if str(path) == str(sock):
+                raise PermissionError(13, "denied", str(sock))
+            return real_stat(path, *args, **kwargs)
+
+        with patch("kiro_crew.session_pid.os.stat", side_effect=denied):
+            assert sp._is_sweepable_orphan_gatewayd(_gatewayd_cmdline(sock)) is False
+
+
+class TestFindOrphanGatewaydCandidates:
+    def test_gone_socket_gatewayd_becomes_a_candidate(self, tmp_path: Path) -> None:
+        """The _GATEWAY_MARKERS exclusion is overridden by the reachability path."""
+        gone = tmp_path / "vanished.sock"
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[700]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_gatewayd_cmdline(gone)),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=300.0),
+        ):
+            mock_sys.platform = "linux"
+            result = sp.find_orphan_mcp_candidates(active_pids=set())
+        assert result == [700]
+
+    def test_live_socket_gatewayd_is_excluded(self, tmp_path: Path) -> None:
+        live = tmp_path / "live.sock"
+        live.write_text("")
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[701]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_gatewayd_cmdline(live)),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=300.0),
+        ):
+            mock_sys.platform = "linux"
+            result = sp.find_orphan_mcp_candidates(active_pids=set())
+        assert result == []
+
+    def test_age_floor_still_applies(self, tmp_path: Path) -> None:
+        gone = tmp_path / "vanished.sock"
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[702]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_gatewayd_cmdline(gone)),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=10.0),
+        ):
+            mock_sys.platform = "linux"
+            result = sp.find_orphan_mcp_candidates(active_pids=set())
+        assert result == []
+
+
+class TestKillOrphanGatewayd:
+    def test_term_grace_covers_the_daemon_shutdown_budget(self) -> None:
+        """The escalation grace must never truncate gatewayd's own graceful
+        shutdown: an inverted pair (grace < drain budget) would SIGKILL a
+        correctly-draining daemon mid-drain, losing in-flight responses and
+        orphaning pooled backends — the exact failure TERM-first exists to
+        avoid. Derivation from the shared budget makes the inversion
+        unrepresentable; this pins it."""
+        from kiro_crew.mcp_gateway.shutdown_budget import TOTAL_SHUTDOWN_BUDGET_SECS
+
+        assert sp._GATEWAYD_TERM_GRACE_SECONDS >= TOTAL_SHUTDOWN_BUDGET_SECS
+
+    @_POSIX_ONLY
+    def test_term_suffices_when_the_daemon_exits(self, tmp_path: Path) -> None:
+        """SIGTERM delivered, process gone on first liveness poll -> 1 kill,
+        no SIGKILL escalation."""
+        gone = tmp_path / "vanished.sock"
+        cmdline = _gatewayd_cmdline(gone)
+        sent: list[tuple[int, int]] = []
+
+        def fake_kill(pid: int, sig: int) -> None:
+            sent.append((pid, sig))
+            if sig == 0:
+                raise ProcessLookupError  # already exited
+            if sig == signal.SIGKILL:
+                raise AssertionError("must not escalate when TERM worked")
+
+        with (
+            patch("kiro_crew.session_pid.os.kill", side_effect=fake_kill),
+            patch("kiro_crew.session_pid.os.killpg") as killpg,
+        ):
+            assert sp._kill_orphan_gatewayd(900, cmdline) == 1
+        assert (900, signal.SIGTERM) in sent
+        killpg.assert_not_called()
+
+    @_POSIX_ONLY
+    def test_wedged_daemon_is_escalated_to_killpg(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        gone = tmp_path / "vanished.sock"
+        cmdline = _gatewayd_cmdline(gone)
+        monkeypatch.setattr(sp, "_GATEWAYD_TERM_GRACE_SECONDS", 0.2)
+
+        def fake_kill(pid: int, sig: int) -> None:
+            return None  # alive forever, TERM ignored
+
+        with (
+            patch("kiro_crew.session_pid.os.kill", side_effect=fake_kill),
+            patch("kiro_crew.session_pid.os.killpg") as killpg,
+            patch("kiro_crew.session_pid.os.getpgid", return_value=901),
+            patch("kiro_crew.session_pid.os.getpgrp", return_value=1234),
+            patch.object(Path, "read_bytes", return_value=cmdline),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+        ):
+            mock_sys.platform = "linux"
+            assert sp._kill_orphan_gatewayd(901, cmdline) == 1
+        killpg.assert_called_once_with(901, signal.SIGKILL)
+
+    @_POSIX_ONLY
+    def test_recycled_pid_is_never_sigkilled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """cmdline changed between TERM and escalation -> no force-kill."""
+        gone = tmp_path / "vanished.sock"
+        cmdline = _gatewayd_cmdline(gone)
+        monkeypatch.setattr(sp, "_GATEWAYD_TERM_GRACE_SECONDS", 0.2)
+
+        def fake_kill(pid: int, sig: int) -> None:
+            if sig == signal.SIGKILL:
+                raise AssertionError("recycled PID must not be SIGKILLed")
+            return None
+
+        with (
+            patch("kiro_crew.session_pid.os.kill", side_effect=fake_kill),
+            patch("kiro_crew.session_pid.os.killpg") as killpg,
+            patch.object(Path, "read_bytes", return_value=b"some\x00other\x00proc"),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+        ):
+            mock_sys.platform = "linux"
+            sp._kill_orphan_gatewayd(902, cmdline)
+        killpg.assert_not_called()
+
+    @_POSIX_ONLY
+    def test_kill_orphan_mcps_routes_gatewayd_through_term_first(
+        self, tmp_path: Path
+    ) -> None:
+        """End to end through kill_orphan_mcps: fresh-cmdline re-verify picks
+        the gatewayd branch and TERMs (not SIGKILLs) the daemon."""
+        gone = tmp_path / "vanished.sock"
+        cmdline = _gatewayd_cmdline(gone)
+        sent: list[tuple[int, int]] = []
+
+        def fake_kill(pid: int, sig: int) -> None:
+            sent.append((pid, sig))
+            if sig == 0:
+                raise ProcessLookupError
+
+        with (
+            patch("kiro_crew.session_pid.platform_compat") as pc,
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=cmdline),
+            patch("kiro_crew.session_pid.os.kill", side_effect=fake_kill),
+            patch("kiro_crew.session_pid.os.killpg") as killpg,
+            patch("kiro_crew.session_pid.os.getpgrp", return_value=1234),
+            patch("kiro_crew.session_pid.os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=300.0),
+        ):
+            pc.IS_WINDOWS = False
+            mock_sys.platform = "linux"
+            killed = sp.kill_orphan_mcps([903])
+        assert killed == 1
+        assert (903, signal.SIGTERM) in sent
+        assert (903, signal.SIGKILL) not in sent
+        killpg.assert_not_called()
+
+    @_POSIX_ONLY
+    def test_kill_phase_age_floor_protects_a_recycled_pid(
+        self, tmp_path: Path
+    ) -> None:
+        """A candidate that exits after the find phase can have its PID
+        recycled by a brand-new gatewayd that has not bound its socket yet.
+        The kill-phase age recheck must skip such a young process — without
+        it, the pre-bind daemon reads as 'socket absent' and gets TERMed."""
+        gone = tmp_path / "vanished.sock"
+        cmdline = _gatewayd_cmdline(gone)
+
+        with (
+            patch("kiro_crew.session_pid.platform_compat") as pc,
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=cmdline),
+            patch("kiro_crew.session_pid.os.kill") as kill,
+            patch("kiro_crew.session_pid.os.killpg") as killpg,
+            patch("kiro_crew.session_pid.os.getpgrp", return_value=1234),
+            patch("kiro_crew.session_pid.os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=3.0),
+        ):
+            pc.IS_WINDOWS = False
+            mock_sys.platform = "linux"
+            killed = sp.kill_orphan_mcps([904])
+        assert killed == 0
+        kill.assert_not_called()
+        killpg.assert_not_called()

--- a/test/test_pid_lifecycle.py
+++ b/test/test_pid_lifecycle.py
@@ -526,26 +526,27 @@ class TestFindOrphanMcpCandidates:
 
         assert result == []
 
-    def test_excludes_peer_gateway(self) -> None:
-        """Peer gateways (gatewayd processes) are never candidates.
+    def test_excludes_peer_gateway(self, tmp_path: Path) -> None:
+        """Peer gateways with a LIVE socket path are never candidates.
 
         Age is patched above the min-age floor so the assertion depends on the
         _GATEWAY_MARKERS exclusion in _is_orphan_mcp, not on the age guard
-        short-circuiting before the exclusion logic ever runs.
+        short-circuiting before the exclusion logic ever runs. The socket path
+        must exist on disk: a gatewayd whose socket is GONE is deliberately
+        sweepable via the reachability path (_is_sweepable_orphan_gatewayd).
         """
         from kiro_crew.session_pid import find_orphan_mcp_candidates
 
+        live_sock = tmp_path / "gw.sock"
+        live_sock.write_text("")
+        cmdline = (
+            b"python3\x00-m\x00kiro_crew.mcp_gateway.gatewayd"
+            b"\x00--socket\x00" + os.fsencode(str(live_sock))
+        )
         with (
             patch("kiro_crew.session_pid._our_orphan_pids", return_value=[360]),
             patch("kiro_crew.session_pid.sys") as mock_sys,
-            patch.object(
-                Path,
-                "read_bytes",
-                return_value=(
-                    b"python3\x00-m\x00kiro_crew.mcp_gateway.gatewayd"
-                    b"\x00--socket\x00/tmp/gw.sock"
-                ),
-            ),
+            patch.object(Path, "read_bytes", return_value=cmdline),
             patch("os.getpid", return_value=1),
             patch("kiro_crew.session_pid._linux_pid_age", return_value=300.0),
         ):


### PR DESCRIPTION
## What is the problem?

`mcp_gateway.gatewayd` has no self-termination path. Once started it runs until someone signals it — and when its launcher dies without doing so (the common case: a `pytest` run whose xdist workers are torn down), the daemon reparents to init and stays resident forever. Measured on one developer host: **187 orphaned daemons, 4.7 GB resident, oldest 3.27 days**.

Four layers each miss this process class:
1. Process groups don't help — the daemon is its own session/group leader (`start_new_session=True`), so a launcher's `killpg` cannot reach it.
2. There is no self-exit — `run_gatewayd` ends at `await stop_event.wait()`, and `--idle-timeout-secs` only drives pool-backend eviction, never the daemon's lifetime.
3. The tracked-PID sweep excludes it by type (`_MANAGED_AGENT_MARKERS`).
4. The orphan scan excludes it deliberately (`_GATEWAY_MARKERS`) — correctly, because a cmdline alone cannot distinguish a live dev pod's daemon from a dead launcher's.

## Why this issue matters to the user

Every test run on a developer machine permanently leaks ~5 × 27 MB with no reclaim mechanism anywhere in the product. The loss is monotonic: the host degrades run over run until an operator kills processes by hand, and because the daemons are invisible to every sweep, no log line or metric reports the growth.

## How our fix solves it — chain from symptom to root cause

The missing information is the **listening socket path**. gatewayd is always invoked with `--socket <path>` and *creates* that socket at bind — so once the path is absent from disk, no stub can ever connect to that daemon again. It is provably unreachable regardless of who launched it. Verified against all 187 orphans on the measured host: 187/187 had their socket path gone; the 5 legitimately-parented daemons all had a live path.

Two independent layers keyed on that signal:

**(a) Self-exit inside gatewayd (primary).** A `_socket_liveness_sweeper` task runs alongside the idle sweeper (same `idle_timeout_secs / 4` cadence), armed only **after a successful bind** — before that, an absent path is a startup race, not unreachability. Three **consecutive** `FileNotFoundError` (ENOENT) observations set `stop_event`, taking exactly the graceful drain SIGTERM takes (in-flight work drains, every pooled backend shut down). Any other stat failure (EACCES/EIO) is inconclusive — it neither counts toward exit nor resets an in-progress streak. POSIX-only: a Windows named pipe has no directory entry to observe, so the task is never created there. This is self-healing — it needs no gateway running and no sweeper cooperating.

**(b) Sweep-side reap (defense in depth).** `_is_sweepable_orphan_gatewayd` is a fourth positive-identity path in the untracked orphan sweep, overriding the `_GATEWAY_MARKERS` exclusion only when all of: a structural `-m kiro_crew.mcp_gateway.gatewayd` argv pair, a `--socket` path in argv (NUL-separated argv only — the space-joined `ps` fallback cannot delimit paths safely and fails closed), and that path absent from disk (ENOENT only, anything else fails closed). `kiro_crew.cli` / `kiro_crew.__main__` remain unconditionally excluded. The kill is **TERM-first** (`_kill_orphan_gatewayd`) so the daemon drains its own pooled backends — evidence from the field reap: 187/187 exited on SIGTERM alone — escalating to `killpg` SIGKILL only after the daemon's full `TOTAL_SHUTDOWN_BUDGET_SECS` (the same shared budget the supervisor's SIGTERM→SIGKILL grace derives from, so a correctly-draining daemon is never killed mid-drain; pinned by a ratchet test) with a cmdline re-verify guarding PID recycling. Same-uid + reparented-to-init candidacy, the age floor, the kill budget, and pre-kill re-verification all still apply.

Also fixed per the issue's suggestion: the `--idle-timeout-secs` help text read as though it bounded the daemon's own lifetime; it now states it bounds pool-entry lifetime only.

## What tests we did

- **22 new tests** in `test/test_gatewayd_self_exit.py`: sweeper exits after 3 consecutive misses / never while the path exists / never on EACCES-style failures / never on non-consecutive misses; a structural ratchet pinning the arm-after-bind ordering; end-to-end `run_gatewayd` self-exit on a real bound socket plus a Windows-flag control proving the sweeper is not armed there; predicate coverage (gone/live socket, `--socket=` form, missing flag, cli/`__main__` exclusion, space-joined ps fail-close, path-fragment non-match, EACCES fail-close); candidate-scan wiring incl. age floor; kill path (TERM suffices / wedged→killpg / recycled-PID guard / routing through `kill_orphan_mcps`).
- **Mutation checks** (the issue's explicit ask): lowering the consecutive-miss threshold to 1 and removing the `misses = 0` reset each make `test_non_consecutive_misses_never_trigger_exit` fail.
- **One existing test updated** (`test_excludes_peer_gateway`): its fixture used a nonexistent `/tmp/gw.sock`, which is now precisely the sweepable case — it now pins the refined invariant (live-socket peer gateway stays excluded).
- **Real-process QA** (isolated, no mocks): daemon self-exited within ~1s of socket removal with the expected log lines; a control daemon stayed alive 15s (~30 sweep intervals) with the socket present and shut down cleanly on SIGTERM; the predicate evaluated `False` against the live daemon's `/proc` cmdline and `True` after SIGKILL + socket removal; help text verified via `--help`.
- **Gates**: full backend suite (50,708 passed; the 81 reds are pre-existing tool-sandbox userns / network-dependent failures, reproduced identically on clean `main`, zero overlap with this diff), isort, flake8, mypy (CI-parity venv, 942 files), inclusive-language diff scan.

## Any other suggestions on the work

- The sweep-side TERM grace (derived: `TOTAL_SHUTDOWN_BUDGET_SECS`, 20s) briefly blocks the maintenance-executor thread per wedged daemon; the poll exits the moment the process dies (0.1s steps), it is bounded by the existing 30-kill budget, and it is only reachable when a daemon ignores SIGTERM, which the field evidence suggests is rare (0/187).
- Overlap note: open PR #3250 also touches `gatewayd.py` (startup wiring for MCP shareability); the regions are disjoint, whichever lands second rebases trivially.

Fixes #3315
