### PR TITLE
fix(chat): retarget the panel to the pane a launch card was clicked in

### DIFF
--- a/website/src/pages/chat/SubagentRunCard.tsx
+++ b/website/src/pages/chat/SubagentRunCard.tsx
@@ -17,7 +17,7 @@ import { memo } from 'react'
 import { Bot, Loader2, CheckCircle2, AlertCircle, Clock, Square } from 'lucide-react'
 import { PanelRightSolid } from '../../components/icons/panels'
 import { useAppSelector, useAppDispatch } from '../../store'
-import { openActivityToTab, selectSubagent } from '../../store/chatSlice'
+import { openActivityToTab, selectSubagent, switchSlot } from '../../store/chatSlice'
 import { sanitizeLlmOutput } from '../../utils/sanitize'
 import type { ChatMessage, SubagentActivity } from '../../types'
 import { SPAWN_LAUNCH_MARKER } from './types'
@@ -150,6 +150,7 @@ const SubagentRunCard = memo(function SubagentRunCard({
   slot: string
 }) {
   const dispatch = useAppDispatch()
+  const activeSlot = useAppSelector(s => s.chat.activeSlot)
   const subagents = useAppSelector(s =>
     slot === s.chat.activeSlot ? s.chat.subagents : s.chat.slotActivity[slot]?.subagents ?? EMPTY_SUBAGENTS,
   )
@@ -203,6 +204,14 @@ const SubagentRunCard = memo(function SubagentRunCard({
         : `${total} agent${total === 1 ? '' : 's'}`
 
   const open = () => {
+    // The Subagents panel is mounted for `activeSlot`, and split view
+    // deliberately never moves `activeSlot` with pane focus. Opening from a
+    // background pane therefore has to make THIS card's session active first,
+    // or the panel that opens belongs to a different session and typically
+    // reads "No subagents running" — the card's own label promising otherwise.
+    // Safe inside split view: the auto-enter effect is gated on splitMode being
+    // off, so switching does not reseed or leave the grid.
+    if (slot && slot !== activeSlot) dispatch(switchSlot(slot))
     // Deep-link to the first agent of THIS wave so the panel lands on the
     // transcript the card refers to, not whatever was last selected.
     const first = launch.ids.find(id => subagents[id])

--- a/website/src/pages/chat/WorkflowRunCard.tsx
+++ b/website/src/pages/chat/WorkflowRunCard.tsx
@@ -17,7 +17,7 @@ import { memo } from 'react'
 import { Workflow, Loader2, CheckCircle2, AlertCircle } from 'lucide-react'
 import { PanelRightSolid } from '../../components/icons/panels'
 import { useAppSelector, useAppDispatch } from '../../store'
-import { openActivityToTab } from '../../store/chatSlice'
+import { openActivityToTab, switchSlot } from '../../store/chatSlice'
 import { sanitizeLlmOutput } from '../../utils/sanitize'
 import type { ChatMessage } from '../../types'
 
@@ -59,11 +59,17 @@ function parseLaunchLabel(message: ChatMessage): string {
 const WorkflowRunCard = memo(function WorkflowRunCard({
   runId,
   message,
+  slot,
 }: {
   runId: string
   message: ChatMessage
+  /** Session this card belongs to. Supplied by a surface that can render a
+   *  NON-active session (a split-view pane); omitted by single chat, which only
+   *  ever draws the active one. */
+  slot?: string
 }) {
   const dispatch = useAppDispatch()
+  const activeSlot = useAppSelector(s => s.chat.activeSlot)
   const run = useAppSelector(s => s.chat.workflowRuns?.[runId])
   const status = run?.status
 
@@ -72,7 +78,13 @@ const WorkflowRunCard = memo(function WorkflowRunCard({
   const lastLog = sanitizeLlmOutput((run?.lastLog || '').slice(0, 120))
   const errMsg = sanitizeLlmOutput((run?.error || '').slice(0, 120))
 
-  const open = () => dispatch(openActivityToTab('workflows'))
+  const open = () => {
+    // The Workflows panel is mounted for `activeSlot`, which split view never
+    // moves with pane focus — so opening from a background pane must make this
+    // card's session active first, or the panel belongs to another session.
+    if (slot && slot !== activeSlot) dispatch(switchSlot(slot))
+    dispatch(openActivityToTab('workflows'))
+  }
 
   return (
     <div className="px-5 mx-auto w-full py-0.5" style={{ maxWidth: 'var(--mc-content-width, 900px)' }}>

--- a/website/src/pages/chat/transcriptRenderers.tsx
+++ b/website/src/pages/chat/transcriptRenderers.tsx
@@ -37,26 +37,30 @@ import type { ChatMessage } from '../../types'
 export interface TranscriptRendererOptions {
   /** Slot these rows belong to. The tool line keys its per-slot log off it. */
   slot: string
-  /** Open a file in the host's side panel. */
+  /** Open a file in the host's side panel. Unwired from a pane until #3300:
+   *  the dock is `activeSlot`-keyed while pane focus deliberately is not. */
   onFileOpen?: (path: string, opts?: { line?: number; endLine?: number }) => void
-  /** Open a directory in the host's side panel. */
+  /** Open a directory in the host's side panel. Same #3300 blocker. */
   onFolderOpen?: (path: string) => void
-  /** "Show in side panel" on a sub-agent completion card. */
+  /** "Show in side panel" on a sub-agent completion card. Same #3300 blocker. */
   onOpenSubagentPanel?: (parsed: ParsedSubagentCompletion) => void
   /** Expanded-state map for tool rows, held ABOVE the row: a virtualised or
    *  remounted transcript unmounts the row and would otherwise forget it. */
   toolDisclosure?: Record<string, boolean>
   onToolDisclosureChange?: (key: string, expanded: boolean) => void
-  /** Whether an MCP app may be revealed in the panel, and how. */
+  /** Whether an MCP app may be revealed in the panel, and how. Unwired from a
+   *  pane for the same reason as `onFileOpen` — tracked in #3332. */
   appInPanel?: boolean
   onOpenApp?: (toolCallId: string) => void
   /** Id of the auto-nudge loop this surface can open, plus the opener. The
-   *  match rule stays here so a host never re-implements it. */
+   *  match rule stays here so a host never re-implements it. Unwired from a
+   *  pane until its composer can reach the popover — tracked in #3332. */
   activeNudgeLoopId?: string | null
   onOpenNudgeLoop?: () => void
   /** Turn-recovery state for the error row's Continue button. Omitted → the
    *  row renders without one, which is correct for a surface that cannot
-   *  continue a turn. */
+   *  continue a turn. A pane cannot supply these until `selectContinuable` /
+   *  `selectTurnInterrupted` are slot-aware — tracked in #3332. */
   continuable?: boolean
   interrupted?: boolean
   continuing?: boolean
@@ -130,7 +134,9 @@ export function createTranscriptRenderers(
         // The match already proved this, but a null here must draw the generic
         // line rather than crash the row.
         if (!runId) return toolLine(m, ctx)
-        return ctx.row(<WorkflowRunCard runId={runId} message={m} />)
+        // No ctx.row: this card lays out its own full-width row (it sets
+        // --mc-content-width itself), so wrapping it would double the padding.
+        return <WorkflowRunCard key={ctx.key} runId={runId} message={m} slot={o.slot} />
       },
     },
     {
@@ -140,7 +146,7 @@ export function createTranscriptRenderers(
       render: (m, ctx) => {
         const launch = extractSpawnRunLaunch(m)
         if (!launch) return toolLine(m, ctx)
-        return ctx.row(<SubagentRunCard launch={launch} slot={o.slot} />)
+        return <SubagentRunCard key={ctx.key} launch={launch} slot={o.slot} />
       },
     },
     {

--- a/website/src/test/SubagentRunCard.test.tsx
+++ b/website/src/test/SubagentRunCard.test.tsx
@@ -296,3 +296,61 @@ describe('SubagentRunCard rendering', () => {
     expect(screen.queryByTestId('subagent-card-queued')).toBeNull()
   })
 })
+
+describe('SubagentRunCard — opening from a background pane retargets the panel first', () => {
+  // The Subagents panel is mounted for `activeSlot`, and split view never moves
+  // activeSlot with pane focus. Without the retarget the click opens ANOTHER
+  // session's panel — usually "No subagents running" — while the card's own
+  // label promises this wave's detail.
+  const launch = { ids: ['a1'], announced: 1 }
+
+  it('activates the card\u2019s own session, then opens the panel on this wave', () => {
+    const store = createTestStore({
+      chat: {
+        activeSlot: 'some-other-slot',
+        subagents: {},
+        slotActivity: { [SLOT]: { subagents: { a1: agent('a1', 'running') } } },
+        subagentQueued: {},
+        // switchSlot.pending reads these, so a partial state would throw
+        // inside the reducer rather than exercise the retarget.
+        slotHistory: [], slotMessages: {}, messages: [], toolLog: [],
+      } as unknown as ChatState,
+    })
+    renderWithProviders(<SubagentRunCard launch={launch} slot={SLOT} />, { store })
+    fireEvent.click(screen.getByTestId('subagent-run-card'))
+    // switchSlot.pending assigns activeSlot synchronously as it is dispatched,
+    // so the panel is already pointed at this card's session by the time the
+    // tab opens.
+    expect(store.getState().chat.activeSlot).toBe(SLOT)
+    expect(store.getState().chat.activityOpen).toBe(true)
+    expect(store.getState().chat.activityTab).toBe('subagents')
+  })
+
+  it('keeps the affordance in a background pane rather than going quiet', () => {
+    // The alternative — dropping the button when the pane is not active — leaves
+    // a dead end in the one surface split view exists for: a failed wave with no
+    // route to its detail and no cue that one exists.
+    const store = createTestStore({
+      chat: {
+        activeSlot: 'some-other-slot',
+        subagents: {},
+        slotActivity: { [SLOT]: { subagents: { a1: agent('a1', 'failed') } } },
+        subagentQueued: {},
+      } as unknown as ChatState,
+    })
+    renderWithProviders(<SubagentRunCard launch={launch} slot={SLOT} />, { store })
+    const card = screen.getByTestId('subagent-run-card')
+    expect(card.tagName).toBe('BUTTON')
+    expect(card.getAttribute('title')).toBeTruthy()
+  })
+
+  it('does not retarget when the card already belongs to the active session', () => {
+    const store = createTestStore({
+      chat: { activeSlot: SLOT, subagents: { a1: agent('a1', 'running') }, subagentQueued: {} } as unknown as ChatState,
+    })
+    renderWithProviders(<SubagentRunCard launch={launch} slot={SLOT} />, { store })
+    fireEvent.click(screen.getByTestId('subagent-run-card'))
+    expect(store.getState().chat.activeSlot).toBe(SLOT)
+    expect(store.getState().chat.activityTab).toBe('subagents')
+  })
+})

--- a/website/src/test/WorkflowRunCard.test.tsx
+++ b/website/src/test/WorkflowRunCard.test.tsx
@@ -80,3 +80,42 @@ describe('WorkflowRunCard rendering', () => {
     expect(store.getState().chat.activityTab).toBe('workflows')
   })
 })
+
+describe('WorkflowRunCard — opening from a background pane retargets the panel first', () => {
+  // Same rule as SubagentRunCard: the Workflows panel is mounted for
+  // `activeSlot`, which split view never moves with pane focus.
+  const msg = wfToolMsg()
+
+  it('activates the card\u2019s own session, then opens the Workflows tab', () => {
+    const store = createTestStore({
+      chat: {
+        activeSlot: 'chat-9', workflowRuns: {},
+        // switchSlot.pending reads these; a partial state would throw instead.
+        slotHistory: [], slotMessages: {}, slotActivity: {}, messages: [], toolLog: [], subagents: {},
+      } as unknown as ChatState,
+    })
+    renderWithProviders(<WorkflowRunCard runId={RUN_ID} message={msg} slot="chat-1" />, { store })
+    fireEvent.click(screen.getByRole('button'))
+    expect(store.getState().chat.activeSlot).toBe('chat-1')
+    expect(store.getState().chat.activityTab).toBe('workflows')
+  })
+
+  it('does not retarget when no slot is supplied (single chat draws only the active session)', () => {
+    const store = createTestStore({
+      chat: { activeSlot: 'chat-1', workflowRuns: {} } as unknown as ChatState,
+    })
+    renderWithProviders(<WorkflowRunCard runId={RUN_ID} message={msg} />, { store })
+    fireEvent.click(screen.getByRole('button'))
+    expect(store.getState().chat.activeSlot).toBe('chat-1')
+    expect(store.getState().chat.activityTab).toBe('workflows')
+  })
+
+  it('keeps the affordance in a background pane rather than going quiet', () => {
+    const store = createTestStore({
+      chat: { activeSlot: 'chat-9', workflowRuns: {} } as unknown as ChatState,
+    })
+    renderWithProviders(<WorkflowRunCard runId={RUN_ID} message={msg} slot="chat-1" />, { store })
+    expect(screen.getByRole('button')).toBeTruthy()
+    expect(screen.getByText(new RegExp(RUN_ID))).toBeTruthy()
+  })
+})

--- a/website/src/test/transcriptRenderers.test.tsx
+++ b/website/src/test/transcriptRenderers.test.tsx
@@ -18,9 +18,11 @@
  * a stop event, which is exactly what these tests exist to catch.
  */
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import type { ReactElement } from 'react'
 import type { ChatMessage } from '../types'
-import { mergeRenderers, resolveRenderer, type MessageRenderContext } from '../app-sdk/messageRenderers'
+import { GROUPED_ROLES, mergeRenderers, resolveRenderer, type MessageRenderContext } from '../app-sdk/messageRenderers'
 import { createTranscriptRenderers } from '../pages/chat/transcriptRenderers'
 import { isWorkflowRunTool } from '../pages/chat/WorkflowRunCard'
 import { isSpawnRunTool } from '../pages/chat/SubagentRunCard'
@@ -188,5 +190,53 @@ describe('rows the defaults already draw correctly are left to them', () => {
     // Still deliberately undrawn, and still resolving to an ENTRY that says so.
     expect(idFor(msg('queued'))).toBe('undrawn')
     expect(idFor(msg('system'))).toBe('undrawn')
+  })
+})
+
+describe('drift guard against the single-chat row chain', () => {
+  // The single-chat surface still renders from its own inline role chain, so
+  // this module is a SECOND row set that has to agree with it. Nothing in the
+  // type system notices when they diverge: a branch added to ChatPage lands
+  // only there, and panes quietly regress to a reduced transcript again — the
+  // exact failure mode this PR exists to fix.
+  //
+  // So pin the agreement mechanically. Every role ChatPage dispatches on must
+  // be CLAIMED by some entry in the registry a pane renders through. This is
+  // deliberately a claim check, not a render check: several rows resolve only
+  // with a content guard (a tool row needs its 🔧 prefix), and what drift
+  // breaks is coverage, not the guard.
+  //
+  // Retire this guard when ChatPage consumes these entries directly and there
+  // is only one row set left to keep in sync.
+  const chatPageSrc = readFileSync(join(__dirname, '..', 'pages', 'ChatPage.tsx'), 'utf8')
+
+  const rolesInChatPage = [...new Set(
+    [...chatPageSrc.matchAll(/\.role === '([a-z_]+)'/g)].map(m => m[1]),
+  )].sort()
+
+  it('finds the role chain it is guarding (a rename must fail loudly, not silently pass)', () => {
+    // If ChatPage stops matching this shape the extraction returns nothing and
+    // every assertion below becomes vacuous, so assert the corpus itself.
+    expect(rolesInChatPage.length).toBeGreaterThan(8)
+    expect(rolesInChatPage).toContain('assistant')
+    expect(rolesInChatPage).toContain('user')
+    expect(rolesInChatPage).toContain('tool')
+  })
+
+  it('claims every role the single-chat chain dispatches on', () => {
+    const active = registry()
+    // A `'*'` entry carrying a `match` is SHAPE-matched (a stop event, a
+    // sub-agent completion) and claims no role — counting it would make this
+    // guard vacuous, since every role would look covered by it.
+    const claims = (role: string) =>
+      active.some(r => r.roles.includes(role) || (r.roles.includes('*') && !r.match))
+    // A grouped role is assembled into the collapsible group BEFORE per-row
+    // resolution, so no row entry is expected to claim it — the group owns its
+    // display. Read from the SDK's own export rather than hardcoded, so a
+    // change to what gets grouped moves this exclusion with it.
+    const unclaimed = rolesInChatPage
+      .filter(role => !GROUPED_ROLES.includes(role))
+      .filter(role => !claims(role))
+    expect(unclaimed).toEqual([])
   })
 })


### PR DESCRIPTION
Follow-up to #3302, answering the reviews it drew. Refs #3332.

## 1. What is the problem?

`WorkflowRunCard` and `SubagentRunCard` are whole-card buttons that deep-link into the Workflows / Subagents side panel (`openActivityToTab(...)`). That panel is mounted for `activeSlot`, and split view deliberately never moves `activeSlot` with pane focus.

#3302 started drawing both cards inside panes. So a pane that is not the active session got a click that opens **a different session's** panel — typically landing on "No subagents running". Split View exists to watch background sessions, which means most clicks in the surface #3302 targeted hit exactly that case, and the task fails silently every time.

Two smaller defects from the same change:

- Both cards lay out their own full-width row (they set `--mc-content-width` themselves), and the registry entries wrapped them in `ctx.row` as well — doubling the row padding.
- Design Review's concern that the new module is a second hand-maintained row set with no mechanical protection against drift.

## 2. Why this issue matters to the user

The card's label promises "Open Subagents panel" and shows a panel chevron. In a background pane that promise was false: the click opened an empty panel belonging to another session. A user cannot tell which pane a panel belongs to, so the natural read is that the feature is broken rather than that they clicked in the "wrong" pane.

## 3. How our fix solves it

**Make the click correct rather than remove it.** Opening from a pane whose session is not active now retargets first:

```ts
if (slot && slot !== activeSlot) dispatch(switchSlot(slot))
// …then select this wave's first agent and open the tab
```

- The panel that opens is the one the label promises, in every pane.
- Safe inside split view: `activeIsSplitAnchor` computes to `null` while `splitMode` is true, so the auto-enter effect cannot reseed the grid, and `SessionGridView`'s seeding is guarded by its own ref. `switchSlot` is the same action ChatPage already dispatches when a split collapses.
- `switchSlot.pending` assigns `activeSlot` synchronously as it is dispatched, so the panel is pointed at the right session before the tab opens.
- Single chat passes no `slot` and is unchanged. `WorkflowRunCard` gains an optional `slot`; `SubagentRunCard` already took one.
- **No new copy.** "Open in the Subagents panel" stays true, so nothing needed rewording across 14 locale catalogues.

**An earlier revision of this PR did the opposite** — it dropped the button, title, chevron and label in a background pane. UX Review was right that this trades a lying link for a dead end: a user seeing "1 agent failed" in the one surface split view exists for would have had no route to the detail and no cue that one existed, and the static card kept enough of its accent shell (`bg-accent/10`, `pi-morph group`) that a habituated click would read as broken rather than as not-applicable. Retargeting removes the class instead of hiding it. That review's alternative suggestion — "let the click activate the slot and then open the panel" — is what shipped here.

`ctx.row` is dropped for both launch entries, with a comment naming the reason so it is not re-added.

For the drift concern, the registry now carries a **guard** rather than a promise: `transcriptRenderers.test.tsx` extracts every role the single-chat chain dispatches on straight out of `ChatPage.tsx` and asserts each is claimed by the registry a pane renders through. A new row type added to ChatPage now fails a test instead of silently reducing the pane transcript. Grouped roles are excluded via the SDK's own `GROUPED_ROLES` export (a grouped role is displayed by the group, not by a row entry), so the exclusion moves if grouping does. The endgame — ChatPage consuming these entries so there is one row set — is #3332, and every option with no pane wiring yet now names its tracked consumer in the interface.

## 4. What tests we did

All new assertions are mutation-verified:

- **SubagentRunCard** — a click in a background pane leaves `activeSlot` on the card's own session and opens the Subagents tab on this wave; the card keeps its button and title there (the dead-end regression the earlier revision would have introduced is pinned against); and a card already in the active session does not retarget.
- **WorkflowRunCard** — same three, plus the no-`slot` single-chat path.
- **Drift guard** — every role ChatPage dispatches on is claimed, with a self-check that the extraction actually found the chain, so a rename in ChatPage fails loudly instead of making the guard vacuously pass.

Mutation results: deleting the `switchSlot` retarget line kills a test in each card. On the drift guard, breaking the `nudge` and `file` claims each fails it; breaking `thinking` does not, which is correct — `thinking` is a grouped role and excluded by design.

Worth recording two process notes. The drift guard was **vacuous on first write** — it counted `'*'` entries as claiming every role, so it passed while a claim was missing; mutation testing caught it, and a shape-matched `'*'` entry (which carries a `match`) now explicitly claims no role. And the retarget tests initially failed for the wrong reason: `switchSlot.pending` reads `slotHistory` / `slotMessages`, so a partial preloaded state threw inside the reducer rather than exercising the retarget.

Gates: `tsc --noEmit` 0 errors · `eslint` 0 errors · `npm run i18n:check` OK · `npm run i18n:render` OK · full `vitest` **1067 files / 17891 tests passed**.

## 5. Any other suggestions on the work

- **Screenshot Evidence is red until evidence lands.** The remaining visual delta is the padding fix; the retarget is a *sequence* (click in a background pane → panel opens for that session), which a still frame cannot prove, so the evidence should be a short recording rather than a screenshot. It follows in a revision rather than blocking review of the reasoning.
- Retargeting means clicking a launch card in a background pane also changes which session single chat would show on exit. That is the intended trade — the alternative is a panel that belongs to no visible pane — but it is the reason #3300 (file/folder open from a pane) is worth solving properly rather than by copying this pattern everywhere.
- Untouched here and still visible in #3302's screenshots: the empty `🔧 0 tool calls` boxes, which are permission-only groups that single chat drops outright. Not fixable from the registry — the group is assembled before per-row resolution (#2940) — and it belongs to the grouping convergence named in #3332.
