### PR TITLE
fix(slack): warn when a tracked channel is unreadable by the installed token

### DIFF
--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -26,6 +26,7 @@ Slack Socket Mode → events.py (dispatch) → handler.py → SessionManager →
 | `slack/interactions.py` | Block Kit button routing — tool approval, OPTIONS choices, cron/subagent ack, allowlist approve/deny, track channel approve/deny |
 | `slack/blocks.py` | Reusable Block Kit dict builders for slash command UIs (session list, send-to-slack). Action IDs: `mc_<command>_<action>[_<id>]` |
 | `slack/allowlist.py` | Tracking-channel allowlist prompts (`prompt_allowlist`, `prompt_track_channel`) + config persistence (`persist_allowed_user`, `persist_tracking_channel`) |
+| `slack/scope_probe.py` | Tracked-channel history-readability probe (`warn_unreadable_tracked_channels`) — warns when the installed token cannot read a tracked channel (e.g. a private channel on an install predating `groups:history`) |
 | `slack/enterprise.py` | Enterprise Grid workspace validation — `validate_enterprise()` (startup auth.test + cache) + `check_message_origin()` (per-message team_id check). SEL audit on all outcomes. See V2160269460 |
 
 ## APIs
@@ -228,6 +229,7 @@ Available to all allowed users.
 - When a user joins a monitored channel, `prompt_allowlist()` sends Allow/Deny to the owner
 - Users already on the allowlist are silently skipped
 - If `tracking_channels` is empty, no monitoring occurs
+- Tracked channels are capability-probed (`slack/scope_probe.py`, one `conversations.history` call with `limit=1`) after the socket connects at startup and whenever a channel is added to tracking. A `missing_scope`/`channel_not_found` result logs a warning and pushes a dashboard notification — a private channel tracked under an install predating `groups:history` would otherwise fail silently. Deferred (`asyncio.create_task`), best-effort: transient network errors report nothing
 - `/<command> @user` still works as a manual trigger (command name configurable via `slack.command` in config, default: `kirocrew`)
 - `/<command> #channel` adds a tracking channel via owner approval
 

--- a/src/kiro_crew/slack/client.py
+++ b/src/kiro_crew/slack/client.py
@@ -182,6 +182,19 @@ class SlackClientOps(ABC):
         """
         return None
 
+    async def probe_channel_history(self, channel: str) -> str | None:
+        """Probe whether the bot token can read *channel*'s history.
+
+        Returns the Slack API error code when the read fails with a definite
+        API error (e.g. ``missing_scope`` on an install that predates the
+        ``groups:history`` scope, or ``channel_not_found`` when the token
+        cannot see the channel), or None when the channel is readable or the
+        outcome is undeterminable (transient network failure). Never raises.
+
+        Default returns None (readable) — subclasses override to hit Slack.
+        """
+        return None
+
     async def fetch_thread_replies(self, channel: str, thread_ts: str, limit: int = 200, warn_on_pagination: bool = True) -> list[dict]:
         """Fetch thread replies. Returns list of message dicts with 'user'/'bot_id' and 'text'."""
         return []
@@ -594,6 +607,31 @@ class RealSlackClient(SlackClientOps):
             elif inline_type == "usergroup":
                 texts.append(f'<!subteam^{element.get("usergroup_id", "")}>')
         return [t for t in texts if t]
+
+    async def probe_channel_history(self, channel: str) -> str | None:
+        """Capability probe: one ``conversations.history`` call with limit=1.
+
+        The lightest way to prove the installed token's grant can actually
+        read the channel — ``conversations.info`` is not a substitute because
+        reading a private channel's info needs ``groups:read``, which the same
+        stale install may also lack.
+        """
+        kwargs: dict[str, Any] = {"channel": channel, "limit": 1}
+        self._inject_team(channel, kwargs)
+        try:
+            await self._web.conversations_history(**kwargs)
+        except (SlackClientError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            resp = getattr(exc, "response", None)
+            error = ""
+            if resp is not None:
+                try:
+                    error = str(resp.get("error", "") or "")
+                except Exception:
+                    error = ""
+            if error:
+                return error
+            logger.debug("history probe failed for %s", channel, exc_info=True)
+        return None
 
     async def fetch_message(self, channel: str, ts: str) -> str | None:
         """Fetch a single message's text by channel and timestamp.

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -209,6 +209,7 @@ from kiro_crew.slack.handler import (
 )
 from kiro_crew.slack.outbound import PostedOptions
 from kiro_crew.slack.retry import open_dm_with_retry
+from kiro_crew.slack.scope_probe import warn_unreadable_tracked_channels
 from kiro_crew.subagent import (
     DIGEST_HOLD_SECS,
     INJECTION_TIMEOUT,
@@ -7134,6 +7135,22 @@ class GatewayOrchestrator:
         if self.dashboard_state:
             self.dashboard_state.slack_socket_connected = connected
             self.dashboard_state.slack_connect_error = getattr(self, "_slack_connect_error", "")
+
+        # Deferred tracked-channel capability probe (fire-and-forget, never
+        # awaited — boot latency is unaffected). A Slack install created before
+        # the manifest gained groups:history keeps its old grant, so a tracked
+        # private channel delivers no events and nothing logs; the probe turns
+        # that silent-dead state into a warning + dashboard notification.
+        if connected and self.slack is not None and self._tracking_channels:
+            _scope_task = asyncio.create_task(
+                warn_unreadable_tracked_channels(
+                    self.slack,
+                    set(self._tracking_channels),
+                    notify=self.dashboard_state.notify if self.dashboard_state else None,
+                )
+            )
+            self._background_tasks.add(_scope_task)
+            _scope_task.add_done_callback(self._background_tasks.discard)
 
         # Block until shutdown
         await shutdown_event.wait()

--- a/src/kiro_crew/slack/interactions.py
+++ b/src/kiro_crew/slack/interactions.py
@@ -82,6 +82,7 @@ from kiro_crew.slack.renderer import (
     TOOL_TRUST_ACTION_PREFIX,
     SlackApprovalDecider,
 )
+from kiro_crew.slack.scope_probe import warn_unreadable_tracked_channels
 
 if TYPE_CHECKING:
     from kiro_crew.slack.gateway import GatewayOrchestrator
@@ -123,6 +124,28 @@ def init(orchestrator: GatewayOrchestrator) -> None:
     fwd_cb = _get_forward_callback()
     if fwd_cb:
         register_view_handler(fwd_cb, _handle_shortcut_submission)
+
+
+def _probe_tracked_channel_scope(channel_ids: set[str]) -> None:
+    """Fire a deferred history-readability probe for newly tracked channels.
+
+    A private channel tracked under a Slack install that predates the
+    ``groups:history`` scope delivers no message events and nothing logs —
+    the probe (see :mod:`kiro_crew.slack.scope_probe`) turns that silent-dead
+    state into a warning + dashboard notification. Fire-and-forget so the
+    interaction ack is never delayed by a Slack API round-trip.
+    """
+    if not channel_ids or not _orch or _orch.slack is None:
+        return
+    t = asyncio.create_task(
+        warn_unreadable_tracked_channels(
+            _orch.slack,
+            channel_ids,
+            notify=_orch.dashboard_state.notify if _orch.dashboard_state else None,
+        )
+    )
+    _orch._handler_tasks.add(t)
+    t.add_done_callback(_orch._handler_tasks.discard)
 
 
 # ---------------------------------------------------------------------------
@@ -220,8 +243,10 @@ async def _handle_config_submission(payload: dict) -> None:
         return
 
     if _orch:
+        added = new_channels - _orch._tracking_channels
         _orch._tracking_channels = new_channels
         set_tracking_channels(new_channels)
+        _probe_tracked_channel_scope(added)
 
     logger.info("Config updated via modal: channels=%d", len(new_channels))
     sel().log_api_access(
@@ -1137,6 +1162,7 @@ async def _handle_ch_add(payload: dict, action: dict) -> None:
 
     _orch._tracking_channels.add(cid)
     set_tracking_channels(_orch._tracking_channels)
+    _probe_tracked_channel_scope({cid})
     await run_config_write(persist_tracking_channel, cid)
     logger.info("Channel %s added to tracking", cid)
     sel().log_api_access(
@@ -2163,6 +2189,7 @@ async def _handle_track_channel(
             return
         _orch._tracking_channels.add(target_channel_id)
         set_tracking_channels(_orch._tracking_channels)
+        _probe_tracked_channel_scope({target_channel_id})
         await run_config_write(
             persist_tracking_channel, target_channel_id, name=channel_name
         )
@@ -2339,8 +2366,10 @@ async def _handle_channels_select(
         return
 
     if _orch:
+        added = new_channels - _orch._tracking_channels
         _orch._tracking_channels = new_channels
         set_tracking_channels(new_channels)
+        _probe_tracked_channel_scope(added)
 
     logger.info("Tracked channels updated via select: %d channels", len(new_channels))
     sel().log_api_access(

--- a/src/kiro_crew/slack/scope_probe.py
+++ b/src/kiro_crew/slack/scope_probe.py
@@ -1,0 +1,88 @@
+"""Tracked-channel history-readability probe.
+
+Slack grants OAuth scopes only at install time: an install created before the
+app manifest gained ``groups:history``/``message.groups`` keeps its old grant
+set even after the manifest is fixed, so a tracked private channel delivers no
+message events and the silence is indistinguishable from "nobody wrote
+anything". This probe gives that dead state a trace: one cheap
+``conversations.history(limit=1)`` capability check per tracked channel,
+emitting a log warning (and a dashboard notification) for every channel the
+bot token cannot read.
+
+Callers dispatch :func:`warn_unreadable_tracked_channels` as a deferred task
+(``asyncio.create_task``) — never on the gateway boot path — at gateway
+startup after the Slack socket connects, and whenever a channel is added to
+tracking dynamically. Best-effort by design: only definitive Slack error
+codes are reported; transient network failures stay silent so a flaky link
+never produces a false "reinstall your app" alarm.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Callable, Iterable
+
+if TYPE_CHECKING:
+    from kiro_crew.slack.client import SlackClientOps
+
+logger = logging.getLogger(__name__)
+
+# Slack error codes that definitively mean the bot token cannot read the
+# channel's history under its current OAuth grant:
+# - ``missing_scope``: the install predates a required scope (for a private
+#   channel that is ``groups:history`` on a pre-manifest-fix install).
+# - ``channel_not_found``: the token cannot see the channel at all (a private
+#   channel outside the grant's visibility looks nonexistent to the API).
+UNREADABLE_ERRORS = frozenset({"missing_scope", "channel_not_found"})
+
+_REINSTALL_HINT = (
+    "the Slack app install likely predates the current OAuth scopes "
+    "(groups:history / message.groups) — reinstall the Slack app from the "
+    "bundled manifest to restore private-channel message delivery."
+)
+
+
+async def warn_unreadable_tracked_channels(
+    slack: "SlackClientOps",
+    channel_ids: Iterable[str],
+    notify: Callable[..., None] | None = None,
+) -> dict[str, str]:
+    """Probe each tracked channel's history readability; warn on failures.
+
+    Returns ``{channel_id: error_code}`` for every channel the bot token
+    cannot read. When *notify* (``DashboardState.notify``-compatible) is
+    given and at least one channel is unreadable, one aggregated dashboard
+    notification is pushed. Never raises — safe to run fire-and-forget.
+    """
+    unreadable: dict[str, str] = {}
+    for cid in sorted({c for c in channel_ids if c}):
+        err = await slack.probe_channel_history(cid)
+        if err in UNREADABLE_ERRORS:
+            unreadable[cid] = err
+            # The rule keys on the word "token" in the format string; the call
+            # logs only a channel ID, a Slack error code, and a static hint —
+            # no credential is in scope here.
+            logger.warning(  # nosemgrep: python-logger-credential-disclosure
+                "Tracked Slack channel %s is not readable by the bot token (%s) "
+                "— messages there will NOT be delivered. If this is a private "
+                "channel, %s",
+                cid,
+                err,
+                _REINSTALL_HINT,
+            )
+    if unreadable and notify is not None:
+        channels = ", ".join(sorted(unreadable))
+        try:
+            notify(
+                "agent",
+                "Slack: tracked channel(s) unreadable",
+                (
+                    f"The Slack bot token cannot read tracked channel(s) "
+                    f"{channels} — messages there will NOT be delivered. "
+                    f"If these are private channels, {_REINSTALL_HINT}"
+                ),
+                meta={"channels": sorted(unreadable)},
+            )
+        except Exception:
+            logger.debug("scope-probe notification failed", exc_info=True)
+    return unreadable

--- a/test/test_slack_scope_probe.py
+++ b/test/test_slack_scope_probe.py
@@ -1,0 +1,247 @@
+"""Tests for the tracked-channel history-readability probe (issue #3225).
+
+A Slack install created before the manifest gained ``groups:history`` keeps
+its old OAuth grant, so tracked private channels deliver no message events
+and nothing logs. These tests lock in the probe's warning path: unreadable
+channels produce a log warning + dashboard notification; readable channels
+and transient failures stay silent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import aiohttp
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from kiro_crew.slack.client import RealSlackClient, SlackClientOps
+from kiro_crew.slack.scope_probe import (
+    UNREADABLE_ERRORS,
+    warn_unreadable_tracked_channels,
+)
+
+
+class ProbeStubClient(SlackClientOps):
+    """Minimal SlackClientOps stub with a scripted probe outcome per channel."""
+
+    def __init__(self, outcomes: dict[str, str | None]):
+        self._outcomes = outcomes
+        self.probed: list[str] = []
+
+    async def probe_channel_history(self, channel: str) -> str | None:
+        self.probed.append(channel)
+        return self._outcomes.get(channel)
+
+    # Abstract members not exercised by the probe.
+    async def post_message(self, channel, text, thread_ts=None, unfurl_links=None, unfurl_media=None):
+        raise NotImplementedError
+
+    async def post_blocks(self, channel, blocks, text, thread_ts=None, unfurl_links=None, unfurl_media=None):
+        raise NotImplementedError
+
+    async def update_message(self, channel, ts, text="", blocks=None):
+        raise NotImplementedError
+
+    async def delete_message(self, channel, ts):
+        raise NotImplementedError
+
+    async def add_reaction(self, channel, ts, emoji, raise_on_error=False):
+        raise NotImplementedError
+
+    async def remove_reaction(self, channel, ts, emoji, raise_on_error=False):
+        raise NotImplementedError
+
+    async def upload_file(self, channel, thread_ts, file, filename, title):
+        raise NotImplementedError
+
+    async def open_dm(self, user_id):
+        raise NotImplementedError
+
+    async def post_ephemeral(self, channel, user_id, text, blocks=None, thread_ts=None):
+        raise NotImplementedError
+
+    async def views_publish(self, user_id, view):
+        raise NotImplementedError
+
+
+class TestWarnUnreadableTrackedChannels:
+    @pytest.mark.asyncio
+    async def test_missing_scope_warns_and_notifies(self, caplog):
+        slack = ProbeStubClient({"C_PRIV": "missing_scope"})
+        notes: list[tuple] = []
+
+        def notify(kind, title, body, **kwargs):
+            notes.append((kind, title, body, kwargs))
+
+        with caplog.at_level("WARNING", logger="kiro_crew.slack.scope_probe"):
+            result = await warn_unreadable_tracked_channels(slack, {"C_PRIV"}, notify=notify)
+
+        assert result == {"C_PRIV": "missing_scope"}
+        assert any(
+            "C_PRIV" in rec.getMessage() and "missing_scope" in rec.getMessage()
+            for rec in caplog.records
+        )
+        assert len(notes) == 1
+        kind, title, body, kwargs = notes[0]
+        assert kind == "agent"
+        assert "C_PRIV" in body
+        assert kwargs["meta"] == {"channels": ["C_PRIV"]}
+
+    @pytest.mark.asyncio
+    async def test_channel_not_found_warns(self, caplog):
+        slack = ProbeStubClient({"C_GONE": "channel_not_found"})
+        with caplog.at_level("WARNING", logger="kiro_crew.slack.scope_probe"):
+            result = await warn_unreadable_tracked_channels(slack, {"C_GONE"})
+        assert result == {"C_GONE": "channel_not_found"}
+        assert any("channel_not_found" in rec.getMessage() for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_readable_channel_is_silent(self, caplog):
+        slack = ProbeStubClient({"C_OK": None})
+        notes: list[tuple] = []
+        with caplog.at_level("WARNING", logger="kiro_crew.slack.scope_probe"):
+            result = await warn_unreadable_tracked_channels(
+                slack, {"C_OK"}, notify=lambda *a, **k: notes.append(a)
+            )
+        assert result == {}
+        assert not notes
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+    @pytest.mark.asyncio
+    async def test_non_definitive_error_codes_do_not_warn(self, caplog):
+        # ratelimited / not_in_channel etc. are not proof of a stale grant.
+        slack = ProbeStubClient({"C_RATE": "ratelimited", "C_MEM": "not_in_channel"})
+        with caplog.at_level("WARNING", logger="kiro_crew.slack.scope_probe"):
+            result = await warn_unreadable_tracked_channels(slack, {"C_RATE", "C_MEM"})
+        assert result == {}
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+    @pytest.mark.asyncio
+    async def test_mixed_set_probes_all_and_aggregates_one_note(self):
+        slack = ProbeStubClient(
+            {"C_A": "missing_scope", "C_B": None, "C_C": "channel_not_found"}
+        )
+        notes: list[tuple] = []
+        result = await warn_unreadable_tracked_channels(
+            slack,
+            {"C_A", "C_B", "C_C", ""},  # empty id is skipped
+            notify=lambda *a, **k: notes.append((a, k)),
+        )
+        assert sorted(slack.probed) == ["C_A", "C_B", "C_C"]
+        assert result == {"C_A": "missing_scope", "C_C": "channel_not_found"}
+        assert len(notes) == 1
+        assert notes[0][1]["meta"] == {"channels": ["C_A", "C_C"]}
+
+    @pytest.mark.asyncio
+    async def test_notify_failure_is_swallowed(self, caplog):
+        slack = ProbeStubClient({"C_PRIV": "missing_scope"})
+
+        def bad_notify(*a, **k):
+            raise RuntimeError("bus down")
+
+        # Must not raise — the probe is fire-and-forget.
+        result = await warn_unreadable_tracked_channels(slack, {"C_PRIV"}, notify=bad_notify)
+        assert result == {"C_PRIV": "missing_scope"}
+
+
+class TestSlackClientOpsDefault:
+    @pytest.mark.asyncio
+    async def test_base_default_returns_none(self):
+        from conftest import MockSlackClient
+
+        client = MockSlackClient()
+        assert await client.probe_channel_history("C1") is None
+
+
+class TestRealSlackClientProbe:
+    def _client(self, web) -> RealSlackClient:
+        client = RealSlackClient.__new__(RealSlackClient)
+        client._web = web
+        return client
+
+    @pytest.mark.asyncio
+    async def test_readable_returns_none(self):
+        web = AsyncMock()
+        web.conversations_history = AsyncMock(return_value={"ok": True, "messages": []})
+        client = self._client(web)
+        assert await client.probe_channel_history("C1") is None
+        web.conversations_history.assert_called_once_with(channel="C1", limit=1)
+
+    @pytest.mark.asyncio
+    async def test_missing_scope_returns_error_code(self):
+        web = AsyncMock()
+        web.conversations_history = AsyncMock(
+            side_effect=SlackApiError("nope", {"ok": False, "error": "missing_scope"})
+        )
+        client = self._client(web)
+        assert await client.probe_channel_history("C1") == "missing_scope"
+
+    @pytest.mark.asyncio
+    async def test_channel_not_found_returns_error_code(self):
+        web = AsyncMock()
+        web.conversations_history = AsyncMock(
+            side_effect=SlackApiError("nope", {"ok": False, "error": "channel_not_found"})
+        )
+        client = self._client(web)
+        assert await client.probe_channel_history("C1") == "channel_not_found"
+
+    @pytest.mark.asyncio
+    async def test_network_error_returns_none(self):
+        web = AsyncMock()
+        web.conversations_history = AsyncMock(side_effect=aiohttp.ClientError("boom"))
+        client = self._client(web)
+        assert await client.probe_channel_history("C1") is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_none(self):
+        web = AsyncMock()
+        web.conversations_history = AsyncMock(side_effect=asyncio.TimeoutError())
+        client = self._client(web)
+        assert await client.probe_channel_history("C1") is None
+
+
+class TestInteractionsProbeHook:
+    @pytest.mark.asyncio
+    async def test_probe_helper_schedules_task(self, monkeypatch):
+        from kiro_crew.slack import interactions
+
+        slack = ProbeStubClient({"C_NEW": "missing_scope"})
+        tasks: set = set()
+        orch = SimpleNamespace(slack=slack, dashboard_state=None, _handler_tasks=tasks)
+        monkeypatch.setattr(interactions, "_orch", orch)
+
+        interactions._probe_tracked_channel_scope({"C_NEW"})
+        assert len(tasks) == 1
+        await asyncio.gather(*tasks)
+        assert slack.probed == ["C_NEW"]
+
+    @pytest.mark.asyncio
+    async def test_probe_helper_noop_without_slack(self, monkeypatch):
+        from kiro_crew.slack import interactions
+
+        tasks: set = set()
+        orch = SimpleNamespace(slack=None, dashboard_state=None, _handler_tasks=tasks)
+        monkeypatch.setattr(interactions, "_orch", orch)
+        interactions._probe_tracked_channel_scope({"C_NEW"})
+        assert not tasks
+
+    @pytest.mark.asyncio
+    async def test_probe_helper_noop_on_empty_set(self, monkeypatch):
+        from kiro_crew.slack import interactions
+
+        tasks: set = set()
+        orch = SimpleNamespace(
+            slack=ProbeStubClient({}), dashboard_state=None, _handler_tasks=tasks
+        )
+        monkeypatch.setattr(interactions, "_orch", orch)
+        interactions._probe_tracked_channel_scope(set())
+        assert not tasks
+
+
+def test_unreadable_errors_are_the_definitive_codes():
+    # The contract the warning path is built on: only codes that prove the
+    # grant cannot read the channel, never transient or membership errors.
+    assert UNREADABLE_ERRORS == frozenset({"missing_scope", "channel_not_found"})


### PR DESCRIPTION
## Problem

Slack grants OAuth scopes only at install time. An install created before the app manifest gained `groups:history`/`message.groups` (#3206, PR #3224) keeps its old grant set: tracked private channels deliver no message events, the handler never runs, and nothing logs. The degraded state is byte-for-byte indistinguishable from "nobody sent a message" — the same silent symptom #3206 fixed for new installs persists for upgraded ones.

Closes #3225 (advisory A2 from the Opus review of PR #3224, accepted-and-deferred there).

## Why it matters

A user who tracked a private channel before upgrading gets permanent silent failure with zero trace. The CHANGELOG reinstall note is only read *before* someone notices the silence — the product gives no runtime signal at all.

## Fix (symptoms → root cause → change)

Symptom: tracked private channel receives nothing, no log line. Root cause: the installed token's grant predates `groups:history`, and no code path ever exercises the token against the tracked channel outside of event delivery — which is exactly what's dead. Change: probe the token's actual read capability where it matters.

- **`src/kiro_crew/slack/scope_probe.py`** (new): `warn_unreadable_tracked_channels()` — probes each tracked channel and, on a definitive `missing_scope`/`channel_not_found`, logs a warning naming the reinstall requirement and pushes one aggregated dashboard notification. Never raises; transient network errors report nothing (no false "reinstall" alarms).
- **`src/kiro_crew/slack/client.py`**: `SlackClientOps.probe_channel_history()` (default: readable) + `RealSlackClient` impl — one `conversations.history(limit=1)` call. `conversations.info` is deliberately not used: reading a private channel's info needs `groups:read`, which the same stale install may also lack, so probing history directly is the only truthful capability check.
- **`src/kiro_crew/slack/gateway.py`**: startup hook after the socket connects — fire-and-forget `asyncio.create_task`, registered in `_background_tasks`. Runs ~180 lines after the `KIROCREW_READY` print, so per AUTOSDE `no-new-work-on-gateway-boot-path` it adds zero boot-path work.
- **`src/kiro_crew/slack/interactions.py`**: `_probe_tracked_channel_scope()` fired from all four dynamic-add paths (modal picker, track-approve button, and both whole-set select handlers, which probe only the added delta).
- **`docs/system-specs/modules/slack-gateway.md`**: module-table row + Channel Monitoring bullet (same-commit doc rule).

All probes are deferred (`create_task`) and async end-to-end (aiohttp-backed slack_sdk) — no blocking syscall reaches the event loop.

## Tests

`test/test_slack_scope_probe.py` (16 new tests):
- Warning path: `missing_scope` and `channel_not_found` produce the log warning + one aggregated dashboard notification with the affected channel list.
- Silence guarantees: readable channels, non-definitive codes (`ratelimited`, `not_in_channel`), transient network errors, and a raising notify callback all stay quiet / never raise.
- `RealSlackClient.probe_channel_history`: returns the Slack error code on API error, `None` on success/network failure/timeout; calls `conversations.history` with `limit=1`.
- Interactions hook: schedules a task parented to `_handler_tasks`; no-ops without a Slack client or with an empty add-set.
- Contract pin: `UNREADABLE_ERRORS` is exactly `{missing_scope, channel_not_found}`.

Full local gates green: pytest (42k+ passed; residual failures reproduced identically on clean `main` — pre-existing host-env issues), isort, flake8, mypy (943 files).

## Manual verification

N/A — unit coverage sufficient: the probe's only external effect is a Slack Web API read plus log/notification, both locked by tests; exercising a real pre-#3206 install would require an actual stale OAuth grant.

## Screenshots

N/A — no user-visible UI change (dashboard notification uses the existing bell feed).
