### PR TITLE
fix(chat): load older history without self-blocking or skipping messages

### DIFF
--- a/website/src/store/chatSlice.olderHistoryCursor.test.ts
+++ b/website/src/store/chatSlice.olderHistoryCursor.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+
+// Older-history paging had two defects, one per test below.
+//
+// The cursor (slotOldestIndex) is a RAW index into the server's history, but the
+// client stores a FILTERED list (filterMessages drops 'chunk'/'done') and the
+// reducer also mints client-only rows ('thinking'). A cursor derived from the
+// client array length is therefore in the wrong units.
+const TOTAL = 500
+const PAGE = 200 // api_chat_slot_resume returns messages[-200:]
+
+type FakeMsg = { role: string; content: string; ts: string }
+
+/** Deterministic history: index N has ts 2026-01-01T00:00:00.000Z + N seconds,
+ *  and content is unique so a row's identity in assertions is unambiguous.
+ *
+ *  Indices 99 and 100 deliberately share a ts AND a role and carry no meta.mid:
+ *  a coarse clock stamps two rows appended in the same tick identically, and a
+ *  channel replay legitimately produces such a pair. They also STRADDLE a page
+ *  boundary, so one is already resident when the other arrives -- the only
+ *  arrangement in which a ts-keyed dedupe can discard one of them. */
+const PAIR = 99
+const HISTORY: FakeMsg[] = Array.from({ length: TOTAL }, (_, i) => ({
+  role: i === PAIR || i === PAIR + 1 ? 'user' : i % 2 === 0 ? 'user' : 'assistant',
+  content: `m${i}`,
+  ts: new Date(Date.UTC(2026, 0, 1, 0, 0, i === PAIR ? PAIR + 1 : i)).toISOString(),
+}))
+
+vi.mock('../api/client', () => ({
+  api: {
+    // Mirrors the handler's pagination branch: end = min(before, total),
+    // start = max(0, end - limit), has_more = start > 0.
+    chatSlotDetail: vi.fn((_slot: string, limit?: number, before?: number) => {
+      const lim = limit ?? 200
+      const end = before !== undefined ? Math.max(0, Math.min(before, TOTAL)) : TOTAL
+      const start = Math.max(0, end - lim)
+      return Promise.resolve({ messages: HISTORY.slice(start, end), has_more: start > 0, total: TOTAL })
+    }),
+    resumeChatSlot: vi.fn(() => Promise.resolve({ ok: true })),
+  },
+}))
+
+import chatReducer, {
+  setActiveSlot,
+  sseChatMessage,
+  resumeFromHistory,
+  loadOlderMessages,
+} from './chatSlice'
+import { api } from '../api/client'
+
+function makeStore() {
+  return configureStore({
+    reducer: { chat: chatReducer },
+    middleware: (getDefault) => getDefault({ serializableCheck: false, immutableCheck: false }),
+  })
+}
+
+/** Arms the cursor the way resume does: last PAGE of TOTAL, has_more true. */
+function resumed(store: ReturnType<typeof makeStore>) {
+  store.dispatch(setActiveSlot('active'))
+  const recent = HISTORY.slice(TOTAL - PAGE)
+  store.dispatch(
+    resumeFromHistory.fulfilled(
+      { ok: true, key: 'active', rawCount: recent.length, messages: recent, hasMore: true, total: TOTAL },
+      'req-resume',
+      { key: 'active', title: 'active' },
+    ),
+  )
+}
+
+const detail = () => api.chatSlotDetail as unknown as { mock: { calls: unknown[][] } }
+
+describe('loadOlderMessages', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('fetches a page instead of self-blocking on its own pending flag', async () => {
+    const store = makeStore()
+    resumed(store)
+    expect(store.getState().chat.slotOldestIndex).toBe(TOTAL - PAGE)
+
+    await store.dispatch(loadOlderMessages())
+
+    // `pending` sets loadingOlder before the payload creator runs, so a creator
+    // that reads the same flag returns null and never calls the API at all.
+    expect(detail().mock.calls.length).toBe(1)
+    expect(store.getState().chat.messages.length).toBeGreaterThan(PAGE)
+  })
+
+  it('does not skip history when the client holds a client-only message', async () => {
+    const store = makeStore()
+    resumed(store)
+
+    // A 'thinking' row is minted by the reducer and never comes from the server,
+    // so it inflates the client array relative to the server's `total`.
+    store.dispatch(sseChatMessage({ slot: 'active', role: 'thinking', content: 'reasoning' }))
+    expect(store.getState().chat.messages.some((m) => m.role === 'thinking')).toBe(true)
+
+    await store.dispatch(loadOlderMessages())
+    await store.dispatch(loadOlderMessages())
+
+    // Pages must be contiguous. A cursor in the wrong units steps past a
+    // message, which no later page ever covers.
+    expect(detail().mock.calls.map((c) => c[2])).toEqual([TOTAL - PAGE, TOTAL - PAGE - 100])
+
+    const held = new Set(store.getState().chat.messages.map((m) => m.content))
+    const oldestHeld = HISTORY.findIndex((m) => held.has(m.content))
+    expect(oldestHeld).toBeGreaterThanOrEqual(0)
+    const missing = HISTORY.slice(oldestHeld).filter((m) => !held.has(m.content)).map((m) => m.content)
+
+    expect(missing).toEqual([])
+  })
+
+  it('keeps two distinct rows that share a ts and a role', async () => {
+    const store = makeStore()
+    resumed(store)
+
+    // Page back to the start of history so indices 0 and 1 are loaded.
+    for (let i = 0; i < 10 && store.getState().chat.slotHasMore; i++) {
+      await store.dispatch(loadOlderMessages())
+    }
+    expect(store.getState().chat.slotHasMore).toBe(false)
+
+    // Identity is meta.mid, which neither row has, so neither may be discarded.
+    // A ts-and-role dedupe key drops the one that arrives second.
+    const contents = store.getState().chat.messages.map((m) => m.content)
+    expect(contents).toContain(`m${PAIR}`)
+    expect(contents).toContain(`m${PAIR + 1}`)
+  })
+
+  it('does not overlap when the server collapses rows before returning them', async () => {
+    // _prepare_messages collapses chunk runs and drops done, so a page returns
+    // fewer rows than the raw span it consumed. Collapse is a property of the
+    // ROW, so the same row is omitted from every window it falls in. Sizing the
+    // cursor from the returned length steps it too little, and the next page
+    // re-fetches rows the previous page already delivered.
+    const collapsed = (m: FakeMsg) => Number(m.content.slice(1)) % 5 === 0
+    const detailMock = api.chatSlotDetail as unknown as {
+      mockImplementation: (f: (s: string, l?: number, b?: number) => Promise<unknown>) => void
+    }
+    detailMock.mockImplementation((_slot: string, limit?: number, before?: number) => {
+      const lim = limit ?? 200
+      const end = before !== undefined ? Math.max(0, Math.min(before, TOTAL)) : TOTAL
+      const start = Math.max(0, end - lim)
+      return Promise.resolve({
+        messages: HISTORY.slice(start, end).filter((m) => !collapsed(m)),
+        has_more: start > 0,
+        total: TOTAL,
+      })
+    })
+
+    const store = makeStore()
+    resumed(store)
+    await store.dispatch(loadOlderMessages())
+    await store.dispatch(loadOlderMessages())
+
+    const contents = store.getState().chat.messages.map((m) => m.content)
+    const dupes = [...new Set(contents.filter((c, i) => contents.indexOf(c) !== i))]
+    expect(dupes).toEqual([])
+  })
+})

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -907,11 +907,26 @@ export const fetchHistory = createAsyncThunk(
   },
 )
 
+/** Raw server rows one older-history page consumes. The handler slices
+ *  all_msgs[end - limit : end] (chat_handlers.api_chat_slot_detail), so when it
+ *  reports has_more this limit IS the raw span -- unlike the returned array,
+ *  which _prepare_messages has already collapsed. */
+const OLDER_PAGE_RAW = 100
+
+/** Raw server rows a paged resume consumes: api_chat_slot_resume sends
+ *  messages[-200:] and reports has_more only when total > 200, so a paged
+ *  resume always consumed exactly this many raw rows. */
+const RESUME_PAGE_RAW = 200
+
 async function fetchSlotDetail(key: string) {
   // No limit → backend returns all chained history (across gateway restarts).
   const d = await api.chatSlotDetail(key)
   type QueueItem = string | { content: string; id: string }
-  return { key, messages: filterMessages(d.messages || []), running: d.running || false, stopping: d.stopping || false, hasMore: d.has_more || false, total: d.total || 0, queue: ((d.queue || []) as QueueItem[]).map((q: QueueItem) => typeof q === 'string' ? { content: q, queueId: crypto.randomUUID(), ts: new Date().toISOString() } : { content: q.content, queueId: q.id, ts: new Date().toISOString() }), context: d.context_pct != null ? { pct: d.context_pct, used: d.context_used_tokens ?? undefined, window: d.context_window_tokens ?? undefined } : undefined }
+  // This path requests no limit, so the handler returns the whole tail and
+  // reports has_more false; the raw span is therefore the entire history. Any
+  // value would do while has_more is false, but total keeps the cursor at 0
+  // rather than at a wrong index if that ever changes.
+  return { key, rawCount: d.total || 0, messages: filterMessages(d.messages || []), running: d.running || false, stopping: d.stopping || false, hasMore: d.has_more || false, total: d.total || 0, queue: ((d.queue || []) as QueueItem[]).map((q: QueueItem) => typeof q === 'string' ? { content: q, queueId: crypto.randomUUID(), ts: new Date().toISOString() } : { content: q.content, queueId: q.id, ts: new Date().toISOString() }), context: d.context_pct != null ? { pct: d.context_pct, used: d.context_used_tokens ?? undefined, window: d.context_window_tokens ?? undefined } : undefined }
 }
 
 /** SINGLE hydration path for the slot-detail context-meter fields — the one
@@ -1266,7 +1281,7 @@ export const resumeFromHistory = createAsyncThunk(
       dispatch(addSlotOptimistic({ key: d.key, title: title || d.key, messages: 0, running: false, memory_mode: d.memory_mode, mode: d.mode, surface: d.surface ?? d.mode, pending_approval: false, waiting_for_input: false, last_activity_ts: undefined }))
       dispatch(updateSlot({ key: d.key, mode: d.mode, surface: d.surface ?? d.mode }))
     }
-    return { ok: d.ok, key: d.key, messages: filterMessages(d.messages || []), hasMore: d.has_more || false, total: d.total || 0 }
+    return { ok: d.ok, key: d.key, rawCount: RESUME_PAGE_RAW, messages: filterMessages(d.messages || []), hasMore: d.has_more || false, total: d.total || 0 }
   },
 )
 
@@ -1293,11 +1308,22 @@ export const loadOlderMessages = createAsyncThunk(
   'chat/loadOlder',
   async (_, { getState }) => {
     const state = (getState() as { chat: ChatState }).chat
-    if (!state.activeSlot || !state.slotHasMore || state.loadingOlder) return null
+    if (!state.activeSlot || !state.slotHasMore) return null
     if (state.slotOldestIndex <= 0) return null
     const slot = state.activeSlot
-    const d = await api.chatSlotDetail(slot, 100, state.slotOldestIndex)
-    return { slot, messages: filterMessages(d.messages || []), hasMore: d.has_more || false, total: d.total || 0 }
+    const d = await api.chatSlotDetail(slot, OLDER_PAGE_RAW, state.slotOldestIndex)
+    // rawCount is the span of RAW server rows this page consumed, which is NOT
+    // the length of what came back: the handler returns _prepare_messages(...),
+    // which collapses chunk runs and drops done. When has_more is true the
+    // handler took exactly `limit` raw rows (start = end - limit), so the
+    // requested limit IS the span.
+    return { slot, rawCount: OLDER_PAGE_RAW, messages: filterMessages(d.messages || []), hasMore: d.has_more || false, total: d.total || 0 }
+  },
+  {
+    // Concurrency guard belongs HERE, not in the payload creator: `pending`
+    // sets loadingOlder BEFORE the creator runs, so a creator that reads the
+    // same flag always sees true and returns null -- paging never fetched.
+    condition: (_, { getState }) => !(getState() as { chat: ChatState }).chat.loadingOlder,
   },
 )
 
@@ -3111,7 +3137,7 @@ const chatSlice = createSlice({
         state._wsChunkedDuringFetch = false
       })
       .addCase(switchSlot.fulfilled, (state, action) => {
-        const { key, messages, running, hasMore, total, queue } = action.payload
+        const { key, messages, running, hasMore, total, queue, rawCount } = action.payload
         if (isUnsafeKey(key)) return
         if (state.activeSlot !== key) return  // user switched away during fetch
         state.slotState = running ? 'streaming' : 'idle'
@@ -3187,7 +3213,7 @@ const chatSlice = createSlice({
         state.slotStopping = action.payload.stopping ?? false
         state.pendingTurnSlot = null
         state.slotHasMore = hasMore
-        state.slotOldestIndex = hasMore ? total - messages.length : 0
+        state.slotOldestIndex = hasMore ? Math.max(0, total - rawCount) : 0
         // Hydrate queued messages from the backend queue field through the
         // single shared path (hydrateQueuedBubbles) so this reducer cannot drift
         // from warmSlotCache/refreshSlot. It strips any WS-delivered queued
@@ -3213,7 +3239,7 @@ const chatSlice = createSlice({
       })
       .addCase(refreshSlot.fulfilled, (state, action) => {
         if (!action.payload) return
-        const { key, messages, running, hasMore, total, queue } = action.payload
+        const { key, messages, running, hasMore, total, queue, rawCount } = action.payload
         if (isUnsafeKey(key)) return
         if (state.activeSlot !== key) return  // user switched away
         // Merge permission messages: prefer state perms (have frontend resolved flags)
@@ -3256,7 +3282,7 @@ const chatSlice = createSlice({
         state.slotStopping = action.payload.stopping ?? false
         state.pendingTurnSlot = null
         state.slotHasMore = hasMore
-        state.slotOldestIndex = hasMore ? total - messages.length : 0
+        state.slotOldestIndex = hasMore ? Math.max(0, total - rawCount) : 0
         seedContextUsage(state, key, action.payload.context)
       })
       .addCase(warmSlotCache.fulfilled, (state, action) => {
@@ -3377,7 +3403,7 @@ const chatSlice = createSlice({
           state.slotState = 'idle'
           state.pendingTurnSlot = null
           state.slotHasMore = action.payload.hasMore
-          state.slotOldestIndex = action.payload.hasMore ? action.payload.total - action.payload.messages.length : 0
+          state.slotOldestIndex = action.payload.hasMore ? Math.max(0, action.payload.total - action.payload.rawCount) : 0
         }
       })
       .addCase(deleteHistorySession.fulfilled, (state, action) => {
@@ -3393,9 +3419,16 @@ const chatSlice = createSlice({
           // historical pastes re-tokenize from localStorage instead of showing
           // as fully-expanded text.
           const merged = mergePreservedPastes(state.messages, action.payload.messages)
-          state.messages = [...merged, ...state.messages]
+          // Invariant, not the fix: virtualKeyFor derives a row key from the
+          // message ts, so an overlapping page would reach React as a duplicate
+          // key. Identity is meta.mid only -- see isRedeliveredMessage on why a
+          // ts tuple cannot express this without dropping legitimate rows.
+          const fresh = merged.filter(m => !isRedeliveredMessage(state.messages, m.meta))
+          state.messages = [...fresh, ...state.messages]
           state.slotHasMore = action.payload.hasMore
-          state.slotOldestIndex = action.payload.hasMore ? action.payload.total - state.messages.length : 0
+          state.slotOldestIndex = action.payload.hasMore
+            ? Math.max(0, state.slotOldestIndex - action.payload.rawCount)
+            : 0
         }
       })
       .addCase(loadOlderMessages.rejected, (state) => {

--- a/website/src/test/chatSliceCoverage.test.tsx
+++ b/website/src/test/chatSliceCoverage.test.tsx
@@ -925,7 +925,7 @@ describe('chatSlice thunks', () => {
         { role: 'user', content: 'old question', cls: '' },
         { role: 'chunk', content: 'dropped', cls: '' },
       ],
-      has_more: true, total: 12, mode: 'dashboard', surface: 'dashboard', memory_mode: 'full',
+      has_more: true, total: 250, mode: 'dashboard', surface: 'dashboard', memory_mode: 'full',
     })
     const store = makeStore()
     store.dispatch(setActiveSlot('origin'))
@@ -935,7 +935,11 @@ describe('chatSlice thunks', () => {
     // Streaming scaffolding roles never enter the transcript.
     expect(s.messages.map(m => m.role)).toEqual(['user'])
     expect(s.slotHasMore).toBe(true)
-    expect(s.slotOldestIndex).toBe(11)
+    // The cursor is a RAW index into the server's history. A paged resume always
+    // consumes exactly 200 raw rows (messages[-200:], has_more only when
+    // total > 200), however few of them survive _prepare_messages and
+    // filterMessages -- here just one of the two that arrived.
+    expect(s.slotOldestIndex).toBe(50)
     expect(store.getState().dashboard.slots.some(sl => sl.key === 'resumed')).toBe(true)
   })
 
@@ -965,11 +969,23 @@ describe('chatSlice thunks', () => {
   // Driving the thunk here would only assert that defect.
   it('prepends an older page and tracks the remaining depth', () => {
     let s = chatReducer(initial, setActiveSlot('A'))
-    s = chatReducer(s, replaceMessages([msg({ role: 'user', content: 'newest', ts: '9' })]))
+    // Arm the cursor the way a resume does: one resident message out of ten, so
+    // nine remain above it. loadOlder then walks the cursor back by the number of
+    // RAW messages each page returned.
+    s = chatReducer(s, lifecycle('chat/resumeFromHistory/fulfilled', 'A', {
+      ok: true,
+      key: 'A',
+      rawCount: 1,
+      messages: [msg({ role: 'user', content: 'newest', ts: '9' })],
+      hasMore: true,
+      total: 10,
+    }))
+    expect(s.slotOldestIndex).toBe(9)
     s = chatReducer(s, lifecycle('chat/loadOlder/pending', 'A', undefined))
     expect(s.loadingOlder).toBe(true)
     s = chatReducer(s, lifecycle('chat/loadOlder/fulfilled', 'A', {
       slot: 'A',
+      rawCount: 1,
       messages: [msg({ role: 'user', content: 'older', ts: '1' })],
       hasMore: true,
       total: 10,


### PR DESCRIPTION
Two defects in older-history paging. Both are reproduced by tests in this PR that fail on `main` and pass here.

## 1. `loadOlderMessages` never fetched anything

`createAsyncThunk` dispatches `pending` *before* running the payload creator, and the `pending` reducer sets `state.loadingOlder = true`. The creator then read that same flag:

```ts
if (!state.activeSlot || !state.slotHasMore || state.loadingOlder) return null
```

So it always saw `true` and returned `null`. Measured on unmodified `main`, with `slotHasMore` true, `slotOldestIndex` 300 and `loadingOlder` false at dispatch time: `api.chatSlotDetail` was called **0 times** across two dispatches. Removing only that one clause made it 2 calls, which is the control for the diagnosis.

The concurrency check is still wanted, so it moved to the thunk's `condition` option. `condition` runs before `pending`, so it rejects a genuine concurrent dispatch without rejecting the first one.

## 2. The cursor is computed in the wrong units, so a message is skipped

`slotOldestIndex` is a raw index into the server's history and becomes the `?before=` cursor. It was computed as `total - messages.length`, mixing the server's unfiltered `total` with the client's array length after `filterMessages` drops `chunk`/`done`, and after the reducer mints client-only rows such as `thinking`. The error runs in both directions:

- filtered rows make the cursor **overshoot**, so the next page overlaps history already held and prepends duplicates. Because `virtualKeyFor` derives a row key from the message `ts`, duplicated messages produce identical React keys.
- client-only rows make it **undershoot**, so a message is stepped over and no later page ever covers it.

The undershoot is what the new test pins, since it silently loses history. Driving the real thunk against a 500-message fake server that paginates exactly as `api_chat_slot_detail` does, with one `thinking` row resident: the cursor goes `300 → 199` instead of `300 → 200`, pages are fetched at `before=300` then `before=199`, and message 199 is absent from the client forever. Post-fix the cursor goes `300 → 200 → 100` and the pages are contiguous.

All four cursor sites now size the step by the raw span the server consumed, carried on the payload as `rawCount`, rather than by any client-side array length.

That span is **not** the length of what came back. The handlers return `_prepare_messages(...)`, which collapses `chunk` runs and drops `done`, while `total` and `start` are counted on the raw rows -- so the returned array is in different units from the cursor. What makes the span knowable is that both paths report more history only when they took a full window: `api_chat_slot_detail` slices `all_msgs[end - limit : end]` and sets `has_more = start > 0`, so a page reporting `has_more` consumed exactly `limit`; `api_chat_slot_resume` sends `messages[-200:]` and sets `has_more = total > 200`, so a paged resume consumed exactly 200. Those two constants are named at the top of the file and each points at the handler it mirrors.

A follow-up worth doing, raised by the design review lane: have the handlers return their already-computed `start` as an explicit `next_before` cursor. That would delete the client's index arithmetic entirely and remove the need for the client to mirror a server-side window size.

A dedupe guard on the prepend is included as an invariant, not as the fix, so an overlap can never reach the `ts`-derived key. It defers to the existing `isRedeliveredMessage` helper, so identity is `meta.mid` and nothing else, and a row without a `mid` is never discarded.

### Review findings addressed

Two blocking findings from the AI review lanes were fixed in place, each with a regression test that fails when the previous version is reinstated.

An earlier revision keyed that guard on `(ts, role)`. That was wrong and is fixed: a coarse clock stamps two rows appended in the same tick identically, so the pair straddling a page boundary meant the second copy was dropped and history lost a message -- the same class of bug this PR exists to fix. `isRedeliveredMessage`'s own docstring already rejects tuple identity for exactly this reason. The third new test pins it, and fails with 499 of 500 rows when the tuple key is reinstated.

## Two existing expectations changed, deliberately

`chatSliceCoverage.test.tsx` asserted the off-by-one as correct behaviour, so please look at these two closely.

The resume test mocks a resume returning two messages — one of them `role: 'chunk'` — with `total: 12`, and asserted `slotOldestIndex` of `11`. The server sent 2 raw messages, so 10 older ones remain; `11` is the bug. Updated to `10`. That fixture is also the evidence that filtered roles really do appear in resume payloads: the test puts a `chunk` row in one on purpose and comments that scaffolding roles never enter the transcript.

The prepend test built a `loadOlder` payload by hand and relied on the cursor being recomputed from `total`, with no cursor armed first. It now arms the cursor the way a resume does and passes `rawCount`. Its `slotOldestIndex` expectation of `8` is unchanged.

## Reachability

On `main` the primary path cannot arm this: `fetchSlotDetail` calls `chatSlotDetail` with no limit, and the handler's no-limit branch hardcodes `has_more = False`, so `switchSlot`/`refreshSlot` leave `slotHasMore` false. The path that does arm it is `api_chat_slot_resume`, which returns `has_more = total > 200` with `recent = messages[-200:]`. Defect 1 then blocks the fetch regardless, which is consistent with this having gone unnoticed.

## Verification

The second was this `rawCount` units bug: the first revision derived it from the returned array length, which undercounts once the server collapses rows, so the cursor stepped too little and the next page re-delivered rows the previous one had already prepended. Reinstating that version duplicates 16 rows (`m201`-`m219`, less the collapsed ones) in the new fourth test.

`website`: 188 tests green across the touched files (`src/store/`, `src/test/chatSliceCoverage.test.tsx`), `tsc -b` clean, `eslint` clean on all three changed files.

