### PR TITLE
feat: add the KAS ACP backend plumbing, not yet selectable

### DIFF
--- a/src/kiro_crew/acp/kas_assets.py
+++ b/src/kiro_crew/acp/kas_assets.py
@@ -1,0 +1,153 @@
+"""Locate the KAS (kiro-agent) assets kiro-cli extracted.
+
+KAS ships inside kiro-cli, which unpacks it on first run. Kiro Crew drives that
+copy rather than distributing its own: the `kiro-team/kiro-agent` repository is
+restricted-read, and an open-source release cannot hide its contents. Reading
+files already on the user's disk distributes nothing.
+
+Layout, as kiro-cli 2.18.0 actually lays it down::
+
+    {data_dir}/node                      the extracted Node runtime (+ node.sha256)
+    {data_dir}/kas/{ver}-{hash}/         one directory per bundle version
+      node_modules/@kiro/agent/dist/server/acp-server.js
+
+The bundle is staged as a trimmed ``node_modules`` tree, so the entry script sits
+at the package's normal npm path rather than at the top of the version directory.
+
+That layout is kiro-cli's INTERNAL detail and may change, so both halves accept
+an environment override — a user whose kiro-cli moved the files can point Kiro
+Crew at them instead of being hard-blocked.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+#: Override for the Node interpreter used to run KAS.
+ENV_KAS_NODE = "KIROCREW_KAS_NODE"
+#: Override for the KAS server entry script.
+ENV_KAS_SCRIPT = "KIROCREW_KAS_SCRIPT"
+
+#: Node refuses to load KAS's web-tree-sitter grammar without this, and the
+#: shell-command policy parser depends on it. kiro-cli passes it too.
+KAS_NODE_FLAGS = ("--experimental-wasm-modules",)
+#: KAS defaults to stdio, but state it so the transport is visible in ps output.
+KAS_TRANSPORT_ARG = "--transport=stdio"
+
+#: Where the entry script sits inside a version directory. Checked before any
+#: recursive walk, because the staged tree holds hundreds of packages.
+_SCRIPT_RELATIVE_PATHS = (
+    Path("node_modules/@kiro/agent/dist/server/acp-server.js"),
+    Path("node_modules/@kiro/agent/dist/server/acp-server.cjs"),
+    Path("dist/server/acp-server.js"),
+)
+_SERVER_SCRIPT_NAMES = ("acp-server.js", "acp-server.cjs", "acp-server.standalone.cjs")
+
+
+class KasAssetsMissing(RuntimeError):
+    """Raised when neither an override nor an extracted bundle can be found."""
+
+
+def _kiro_data_dirs() -> list[Path]:
+    """Candidate kiro-cli data directories, most specific first.
+
+    ``KIRO_DATA_DIR`` is kiro-cli's own override; the rest mirror where its
+    ``data_dir()`` resolves per platform. ``kiro-cli`` comes before ``kiro``
+    because that is the directory 2.18.0 writes.
+    """
+    candidates: list[Path] = []
+    env_dir = os.environ.get("KIRO_DATA_DIR", "").strip()
+    if env_dir:
+        candidates.append(Path(env_dir))
+    home = Path.home()
+    candidates += [
+        home / ".local" / "share" / "kiro-cli",
+        home / ".local" / "share" / "kiro",
+        home / "Library" / "Application Support" / "kiro-cli",
+        home / "Library" / "Application Support" / "kiro",
+        home / ".kiro",
+    ]
+    return candidates
+
+
+def find_kas_node() -> Path | None:
+    """The Node interpreter to run KAS with, or None when unresolvable."""
+    override = os.environ.get(ENV_KAS_NODE, "").strip()
+    if override:
+        return Path(override)
+    for data_dir in _kiro_data_dirs():
+        for name in ("node", "node.exe"):
+            candidate = data_dir / name
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+def find_kas_server_script() -> Path | None:
+    """The KAS entry script, or None when unresolvable.
+
+    Bundles are extracted one directory per version; pick the most recently
+    modified so a kiro-cli upgrade takes effect without any bookkeeping here.
+    """
+    override = os.environ.get(ENV_KAS_SCRIPT, "").strip()
+    if override:
+        return Path(override)
+    for data_dir in _kiro_data_dirs():
+        kas_root = data_dir / "kas"
+        if not kas_root.is_dir():
+            continue
+        try:
+            versions = sorted(
+                (p for p in kas_root.iterdir() if p.is_dir()),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+        except OSError:
+            continue
+        for version_dir in versions:
+            for relative in _SCRIPT_RELATIVE_PATHS:
+                candidate = version_dir / relative
+                if candidate.is_file():
+                    return candidate
+            # The staged tree holds hundreds of packages, so only walk it when
+            # the package moved and the known paths above all missed.
+            for name in _SERVER_SCRIPT_NAMES:
+                for candidate in version_dir.rglob(name):
+                    if candidate.is_file():
+                        return candidate
+    return None
+
+
+def resolve_kas_entry() -> tuple[Path, Path]:
+    """``(node, server_script)`` for spawning KAS.
+
+    Raises :class:`KasAssetsMissing` with actionable guidance rather than
+    degrading to a different backend — a silent fallback to kiro-cli would look
+    like KAS working.
+    """
+    node = find_kas_node()
+    script = find_kas_server_script()
+    if node and script:
+        return node, script
+    missing = []
+    if not node:
+        missing.append(f"the Node runtime (set {ENV_KAS_NODE} to override)")
+    if not script:
+        missing.append(f"the KAS server script (set {ENV_KAS_SCRIPT} to override)")
+    raise KasAssetsMissing(
+        "Cannot locate " + " and ".join(missing) + ". KAS ships inside kiro-cli: "
+        "install kiro-cli and run it once so it unpacks its bundle, then sign in "
+        "with `kiro-cli login` so KAS can read the token."
+    )
+
+
+def build_kas_argv(node: Path, server_script: Path) -> list[str]:
+    """argv for a KAS stdio session.
+
+    ``--auth`` is deliberately absent: without it KAS selects its file auth
+    provider and reads/refreshes the token itself, so Kiro Crew never handles a
+    credential. Passing ``--auth=acp-callback`` would force this process to
+    implement ``_kiro/auth/getAccessToken`` instead.
+    """
+    return [str(node), *KAS_NODE_FLAGS, str(server_script), KAS_TRANSPORT_ARG]

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -40,6 +40,11 @@ from kiro_crew.acp.client import (
     _KiroExecutableTrustError,
     _resolve_kiro_bin_for_spawn,
 )
+from kiro_crew.acp.kas_assets import (
+    KasAssetsMissing,
+    build_kas_argv,
+    resolve_kas_entry,
+)
 from kiro_crew.acp.session_handle import (
     AcpRuntimeDead,
     AcpRuntimeError,
@@ -47,7 +52,10 @@ from kiro_crew.acp.session_handle import (
     AcpSessionHandle,
 )
 from kiro_crew.acp.types import (
+    ACP_BACKEND_KAS,
+    ACP_BACKEND_KIRO,
     ACP_CLIENT_CAPABILITIES,
+    KAS_CLIENT_CAPABILITIES,
     METHOD_MCP_OAUTH_REQUEST,
     METHOD_MCP_SERVER_INIT_FAILURE,
     METHOD_MCP_SERVER_INITIALIZED,
@@ -218,6 +226,10 @@ KIRO_CLI_SUBCMD = "acp"
 CLIENT_NAME = "kirocrew"
 CLIENT_VERSION = "0.1.2"
 PROTOCOL_VERSION = "2025-08-22"
+# KAS validates this field against a numeric schema and rejects the kiro-cli
+# date string with "expected number, received string", so the two backends must
+# be sent different types. 1 is what the ACP SDK and KAS's own TUI send.
+PROTOCOL_VERSION_KAS = 1
 
 
 def _drop_key_part(value: object) -> str:
@@ -490,6 +502,7 @@ class AcpRuntime:
         max_rss_mb: float = _DEFAULT_MAX_RSS_MB,
         model: str | None = None,
         expect_mcp_reports: bool = True,
+        acp_backend: str = ACP_BACKEND_KIRO,
     ):
         if work_dir:
             self._work_dir = Path(work_dir)
@@ -500,6 +513,7 @@ class AcpRuntime:
 
             self._work_dir = config_dir() / "workspace"
         self._agent = agent
+        self._acp_backend = acp_backend
         if model is not None:
             if not MODEL_ID_RE.match(model):
                 raise ValueError(
@@ -582,6 +596,17 @@ class AcpRuntime:
     @property
     def pid(self) -> int | None:
         return self._pid
+
+    @property
+    def acp_backend(self) -> str:
+        """Which ACP backend this runtime's process speaks.
+
+        Public because the backend has to survive being read back off a
+        started provider: the runtime is the only object that still knows it
+        once ``AcpProvider`` swaps its placeholder client for a session
+        provider.
+        """
+        return self._acp_backend
 
     @property
     def supports_image_prompt(self) -> bool:
@@ -689,19 +714,19 @@ class AcpRuntime:
             self._discard_sandbox_cleanup()
             raise
 
-    async def spawn(self) -> None:
-        """Start the kiro-cli acp subprocess and complete protocol handshake."""
-        if self._process is not None:
-            raise AcpRuntimeError("Runtime already spawned")
+    async def _resolve_spawn_argv(self) -> list[str]:
+        """Pre-sandbox argv for this runtime's backend.
 
-        # Off-loop: mkdir is a blocking syscall and the parent dirs may live on
-        # slow storage; the loop must never wait on the kernel here.
-        await asyncio.to_thread(self._work_dir.mkdir, parents=True, exist_ok=True)
+        Explicit per-backend construction: the two agents share no flags, and
+        only kiro-cli needs its agent file materialized first.
+        """
+        if self._acp_backend == ACP_BACKEND_KAS:
+            node, script = await asyncio.to_thread(resolve_kas_entry)
+            # No --agent: KAS takes custom agents over the wire in session/new
+            # (_meta.kiro.customAgents), not from a CLI flag.
+            return build_kas_argv(node, script)
 
-        try:
-            kiro_bin = await _resolve_kiro_bin_for_spawn()
-        except _KiroExecutableTrustError as exc:
-            raise AcpRuntimeError(str(exc)) from exc
+        kiro_bin = await _resolve_kiro_bin_for_spawn()
         if not kiro_bin:
             raise AcpRuntimeError(f"{KIRO_CLI_BIN} not found in PATH")
 
@@ -723,6 +748,23 @@ class AcpRuntime:
             # (e.g. GPT for image generation) — post-session set_model cannot
             # cross provider boundaries, and agent configs may pin a model.
             argv += ["--model", self._model]
+        return argv
+
+    async def spawn(self) -> None:
+        """Start the kiro-cli acp subprocess and complete protocol handshake."""
+        if self._process is not None:
+            raise AcpRuntimeError("Runtime already spawned")
+
+        # Off-loop: mkdir is a blocking syscall and the parent dirs may live on
+        # slow storage; the loop must never wait on the kernel here.
+        await asyncio.to_thread(self._work_dir.mkdir, parents=True, exist_ok=True)
+
+        try:
+            argv = await self._resolve_spawn_argv()
+        except _KiroExecutableTrustError as exc:
+            raise AcpRuntimeError(str(exc)) from exc
+        except KasAssetsMissing as exc:
+            raise AcpRuntimeError(str(exc)) from exc
 
         # OSS sandbox.wrap_argv supports (argv, mode, strip_python_env). The
         # MCP-gateway overlay is NOT delivered through the sandbox: its broker
@@ -730,11 +772,17 @@ class AcpRuntime:
         # needs no bind-mount and works with sandbox mode "off". strip_python_env
         # IS applied to keep the host PYTHONPATH/PYTHONHOME out of kiro-cli's
         # foreign MCP subprocesses (which bundle their own interpreter + deps).
+        # is_kiro_cli drives a macOS-only delegation: when kiro's internal
+        # sandbox is enabled, wrap_argv skips its own seatbelt because the two
+        # cannot nest (kernel EPERM). KAS is a Node process with no such
+        # internal sandbox, so claiming otherwise would hand isolation to a
+        # layer that never starts and leave it unconfined. KAS has no nesting
+        # constraint either, so it takes Crew's seatbelt directly.
         argv, self._sandbox_cleanup = wrap_argv(
             argv,
             mode=self._sandbox_mode,
             strip_python_env=True,
-            is_kiro_cli=True,
+            is_kiro_cli=self._acp_backend != ACP_BACKEND_KAS,
         )
         # cgroup v2 scope (OUTERMOST): bound this agent + all its MCP-server /
         # tool descendants with pids.max (fork bomb) + memory.max (RSS balloon).
@@ -849,8 +897,16 @@ class AcpRuntime:
                     # telemetry — bucketed as "(none)" instead of "kirocrew". Nest it to
                     # match AcpClient and be picked up for acpClientName attribution.
                     "clientInfo": {"name": CLIENT_NAME, "version": CLIENT_VERSION},
-                    "protocolVersion": PROTOCOL_VERSION,
-                    "clientCapabilities": ACP_CLIENT_CAPABILITIES,
+                    "protocolVersion": (
+                        PROTOCOL_VERSION_KAS
+                        if self._acp_backend == ACP_BACKEND_KAS
+                        else PROTOCOL_VERSION
+                    ),
+                    "clientCapabilities": (
+                        KAS_CLIENT_CAPABILITIES
+                        if self._acp_backend == ACP_BACKEND_KAS
+                        else ACP_CLIENT_CAPABILITIES
+                    ),
                 },
             )
             self._can_load_session = bool(
@@ -1578,12 +1634,16 @@ class AcpRuntime:
         if not self._can_load_session:
             raise AcpRuntimeError("Backend does not advertise session/load support")
 
-        load_params = {
+        load_params: dict[str, Any] = {
             "sessionId": resume_sid,
             "cwd": str(cwd if cwd else self._work_dir),
             "mcpServers": [],  # kiro-cli gets its servers via --agent
-            "_meta": {"_kiro.dev/session_file": session_file},
         }
+        if session_file:
+            # Only kiro-cli is handed a transcript path. A backend that locates
+            # the session itself from sessionId is called with an empty path, and
+            # sending the field anyway would advertise a path that does not exist.
+            load_params["_meta"] = {"_kiro.dev/session_file": session_file}
         self._session_inits_in_flight += 1
         loaded_session_id = ""
         try:

--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -389,8 +389,16 @@ class AcpSessionProvider(LLMProvider):
 
     @property
     def backend(self) -> str:
-        """ACP backend identifier. Always empty string for kiro-cli."""
-        return ""
+        """ACP backend identifier, delegated to the runtime that serves it.
+
+        Not a constant: this provider fronts whichever backend ``AcpRuntime``
+        spawned, and it replaces the placeholder ``AcpClient`` on
+        ``AcpProvider._client`` once startup completes — so it is the only
+        remaining place a consumer can read the backend back off a started
+        provider. Reporting kiro unconditionally would persist every KAS
+        session under the kiro label.
+        """
+        return self._runtime.acp_backend
 
     def has_active_turn(self) -> bool:
         """True if a prompt turn is currently in progress.

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -95,6 +95,51 @@ ACP_CLIENT_CAPABILITIES: dict = {
 # ── ACP Backend Identifiers ──
 
 ACP_BACKEND_CLAUDE = "claude"
+ACP_BACKEND_KAS = "kas"
+# The kiro-cli backend is spelled as the empty string throughout, so name it
+# rather than leaving every call site to infer it from "not claude".
+ACP_BACKEND_KIRO = ""
+# Membership gate for the ``acp_backend`` kwarg. An unrecognized value would
+# otherwise fall through every ``_is_<backend>`` check and silently spawn
+# kiro-cli, so provider construction rejects it instead.
+ACP_BACKENDS_KNOWN = frozenset(
+    {
+        ACP_BACKEND_KIRO,
+        ACP_BACKEND_CLAUDE,
+        ACP_BACKEND_KAS,
+    }
+)
+# What an operator may actually persist in ``agent.acp_backend``, which is a
+# narrower question than what the code understands. KAS is plumbed and tested but
+# cannot serve a session yet: production names an agent on every session, KAS
+# advertises only its own built-in modes, and Crew's agent reaches it through
+# ``_meta.kiro.customAgents`` on ``session/new`` — not wired up yet. Config
+# resolution degrades an unselectable value to the default so the refusal lands
+# at startup with a reason instead of on the operator's first message.
+ACP_BACKENDS_SELECTABLE = frozenset({ACP_BACKEND_KIRO})
+
+# ── Provider labels ──
+# The backend identity key persisted in the session map. It indexes three
+# things, so every producer must agree on it: resume compatibility
+# (detect_provider_switch), session-map persistence, and session-file cleanup
+# routing. Defined here rather than in providers.acp because session.py needs
+# the vocabulary and cannot import that module at module scope.
+#
+# An absent label means kiro-cli, which is the default backend.
+PROVIDER_LABEL_DEFAULT = "acp"
+PROVIDER_LABEL_CLAUDE = "claude_code"
+PROVIDER_LABEL_KAS = "kas"
+
+# KAS reads only fs.readTextFile / fs.writeTextFile / terminal from the top
+# level of clientCapabilities; every other capability it honours lives under
+# _meta.kiro. The ones there are CALLBACK capabilities — KAS calls back into the
+# client to service them — and Kiro Crew implements none, so leaving them
+# undeclared (= false) is correct rather than a gap. Only the settings channel
+# is opened, because that is how a client selects KAS feature flags.
+KAS_CLIENT_CAPABILITIES: dict = {
+    **ACP_CLIENT_CAPABILITIES,
+    "_meta": {"kiro": {"settings": {}}},
+}
 
 # ── Claude backend permission modes ──
 # Values an edition writes into a per-session settings.local.json

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1084,6 +1084,15 @@ class AgentConfig:
         default="acp",
         metadata=_meta("Provider", "LLM provider backend (KiroACP / kiro-cli).", enum=["acp"]),
     )
+    acp_backend: str = field(
+        default="",
+        metadata=_meta(
+            "ACP Backend",
+            "Which ACP agent to drive. Only '' (kiro-cli) is selectable; the "
+            "'kas' plumbing is present but not yet usable.",
+            enum=[""],
+        ),
+    )
     default_agent: str = field(
         default="",
         metadata=_meta("Default Agent", "Default agent name for new sessions."),
@@ -3644,6 +3653,41 @@ def _normalize_jail(value: object) -> str:
     return JAIL_MODE_AUTO
 
 
+def _normalize_acp_backend(value: object) -> str:
+    """Coerce a persisted ``agent.acp_backend`` to a selectable backend.
+
+    Anything not selectable — an unknown value, or a backend the code understands
+    but cannot yet serve a session with — normalizes to the default (kiro-cli)
+    with a warning rather than propagating: ``AcpProvider`` rejects an unknown
+    backend by raising, and a value that is merely incomplete would instead fail
+    on the operator's first message. Both must degrade to the working default at
+    startup, with the reason in the log.
+
+    The import is deferred because it cannot be done at module scope: reaching
+    ``kiro_crew.acp.types`` executes the ``kiro_crew.acp`` package init, which
+    imports the ACP client and runtime, which import this module — and this
+    module is imported first by the gateway and desktop entrypoints.
+    """
+    from kiro_crew.acp.types import (
+        ACP_BACKEND_KIRO,
+        ACP_BACKENDS_KNOWN,
+        ACP_BACKENDS_SELECTABLE,
+    )
+
+    if isinstance(value, str) and value in ACP_BACKENDS_SELECTABLE:
+        return value
+    if value not in (None, ""):
+        known_but_unusable = isinstance(value, str) and value in ACP_BACKENDS_KNOWN
+        logger.warning(
+            "Ignoring agent.acp_backend %r (%s); using the default backend. "
+            "Selectable values: %s",
+            value,
+            "not usable yet" if known_but_unusable else "unknown",
+            ", ".join(repr(b) for b in sorted(ACP_BACKENDS_SELECTABLE)),
+        )
+    return ACP_BACKEND_KIRO
+
+
 def _validate_activation(value: str) -> str:
     """Return *value* if it is a valid activation mode, else ``mention`` (deny-by-default)."""
     return value if value in _VALID_ACTIVATIONS else ACTIVATION_MENTION
@@ -5544,6 +5588,7 @@ class KiroCrewConfig:
                 role_efforts=coerce_role_efforts(agent_data.get("role_efforts")),
                 reasoning_effort=agent_data.get("reasoning_effort", ""),
                 provider=agent_data.get("provider", "acp"),
+                acp_backend=_normalize_acp_backend(agent_data.get("acp_backend")),
                 default_agent=agent_data.get("default_agent", ""),
                 sandbox=agent_data.get("sandbox", "auto"),
                 sandbox_allow_no_isolation=bool(
@@ -6591,6 +6636,7 @@ class KiroCrewConfig:
                 session_key=session_key,
                 channel_id=channel_id,
                 extra_env=extra_env,
+                acp_backend=self.agent.acp_backend,
                 effort_per_model=_eff_per_model,
                 tool_search=tool_search,
                 mcp_gateway_overlay=_gw_overlay,

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -39,12 +39,32 @@ isolates the agent, and stacking a second sandbox would break it.
 
 Set via `kirocrew config set agent.sandbox auto`.
 
+## ACP Backend
+
+`agent.acp_backend` selects which ACP agent Kiro Crew drives. `agent.provider`
+stays `acp` either way — the backend is a choice *within* ACP, not a different
+provider.
+
+| Value | Agent | Status |
+|-------|-------|--------|
+| `""` (default) | kiro-cli | the only supported value |
+| `kas` | kiro-agent (KAS) | plumbed, **not yet usable** |
+
+**Leave this unset.** The KAS backend's spawn and session plumbing is in place,
+but Kiro Crew does not yet send your configured agent to KAS, so every session
+would fail to activate it. Setting `kas` is refused at startup with that reason
+rather than failing on your first message.
+
+An unrecognized value logs a warning and falls back to the default backend, so a
+typo costs you a line in the log rather than a gateway that will not start.
+
 ## Key Settings
 
 ```json
 {
   "agent": {
     "provider": "acp",
+    "acp_backend": "",
     "approval_mode": "auto",
     "model": "auto",
     "reasoning_effort": "",

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -24,7 +24,13 @@ from kiro_crew.acp.session_handle import AcpSessionHandle
 from kiro_crew.acp.session_provider import AcpSessionProvider
 from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
+    ACP_BACKEND_KAS,
+    ACP_BACKEND_KIRO,
+    ACP_BACKENDS_KNOWN,
     EVENT_COMPACTION_STATUS,
+    PROVIDER_LABEL_CLAUDE,
+    PROVIDER_LABEL_DEFAULT,
+    PROVIDER_LABEL_KAS,
     STOP_REASON_CANCELLED,
     STOP_REASON_END_TURN,
 )
@@ -246,6 +252,14 @@ class AcpProvider(LLMProvider):
         mcp_gateway_socket: str | Path | None = None,
         permission_mode: str | None = None,
     ) -> None:
+        # An unrecognized backend would pass every ``_is_<backend>`` check and
+        # spawn kiro-cli, so a typo'd config would drive the wrong agent with no
+        # error. Fail at construction instead.
+        if acp_backend not in ACP_BACKENDS_KNOWN:
+            raise ValueError(
+                f"Unknown acp_backend {acp_backend!r}; "
+                f"expected one of {sorted(ACP_BACKENDS_KNOWN)}"
+            )
         kwargs: dict[str, Any] = {
             "work_dir": work_dir,
             "model": model,
@@ -344,6 +358,21 @@ class AcpProvider(LLMProvider):
     def is_claude_backend(self) -> bool:
         """True when this ACP provider talks to claude-agent-acp (vs kiro-cli)."""
         return self._client.backend == ACP_BACKEND_CLAUDE
+
+    @property
+    def is_kas_backend(self) -> bool:
+        """True when this ACP provider talks to KAS (kiro-agent)."""
+        return self._client.backend == ACP_BACKEND_KAS
+
+    @property
+    def is_kiro_backend(self) -> bool:
+        """True when this ACP provider talks to kiro-cli.
+
+        Stated positively so call sites that mean "kiro" say so, rather than
+        inferring it from ``not is_claude_backend`` — an inference that silently
+        captures every future backend.
+        """
+        return self._client.backend == ACP_BACKEND_KIRO
 
     @property
     def is_session_sharing_eligible(self) -> bool:
@@ -573,6 +602,7 @@ class AcpProvider(LLMProvider):
             mcp_gateway_overlay=mcp_gateway_overlay,
             mcp_gateway_settings_mcp_json=mcp_gateway_settings_mcp_json,
             mcp_gateway_socket=mcp_gateway_socket,
+            acp_backend=self._client.backend,
         )
         _t_spawn = time.monotonic()
         try:
@@ -608,8 +638,17 @@ class AcpProvider(LLMProvider):
             handle = None
             resumed = False
             if resume_sid:
-                session_file = kiro_sessions_dir() / f"{resume_sid}.json"
-                if session_file.exists():
+                if self.is_kas_backend:
+                    # KAS locates the transcript itself from sessionId, and in
+                    # remote-session mode there are no local files to stat at
+                    # all. Attempt the load and let failure fall through to a
+                    # fresh session/new with history replay.
+                    session_file = None
+                    should_load = True
+                else:
+                    session_file = kiro_sessions_dir() / f"{resume_sid}.json"
+                    should_load = session_file.exists()
+                if should_load:
                     # F2 load-recovery: retry past a stale "active in another
                     # process" lock (Phase 1); on persistent failure fall through
                     # to a fresh session/new below WITH KiroCrew history replay
@@ -621,7 +660,7 @@ class AcpProvider(LLMProvider):
                     try:
                         handle = await self._load_session_with_retry(
                             runtime,
-                            str(session_file),
+                            str(session_file) if session_file else "",
                             resume_sid,
                             work_dir,
                             agent,
@@ -663,6 +702,7 @@ class AcpProvider(LLMProvider):
                         mcp_gateway_overlay=mcp_gateway_overlay,
                         mcp_gateway_settings_mcp_json=mcp_gateway_settings_mcp_json,
                         mcp_gateway_socket=mcp_gateway_socket,
+                        acp_backend=self._client.backend,
                     )
                     try:
                         await runtime.spawn()
@@ -1285,3 +1325,35 @@ def is_claude_backend(provider: Any) -> bool:
     property without an isinstance gate.
     """
     return isinstance(provider, AcpProvider) and provider.is_claude_backend
+
+
+def provider_label(provider: Any) -> str:
+    """Backend identity key for *provider*.
+
+    This key indexes three things, so all producers must agree on it:
+    resume compatibility (``detect_provider_switch``), the value persisted in
+    the session map, and session-file cleanup routing.
+
+    Resolved from the client's backend STRING rather than the ``is_*_backend``
+    properties, matching ``session._is_claude_backend``. A ``MagicMock(spec=...)``
+    constrains attribute names but not their values, so reading a property would
+    make every spec'd provider in the test suite look like every backend at once.
+
+    Both shapes a runtime-backed session can arrive in are accepted: an
+    ``AcpProvider`` whose ``client`` was swapped for an ``AcpSessionProvider``
+    once startup completed, and a bare ``AcpSessionProvider`` handed out for a
+    shared subagent session. Missing either one persists a KAS session under
+    the kiro label, and the map then prunes its id for want of a kiro
+    transcript.
+    """
+    if isinstance(provider, AcpSessionProvider):
+        backend = provider.backend
+    elif isinstance(provider, AcpProvider):
+        backend = getattr(getattr(provider, "client", None), "backend", "")
+    else:
+        return PROVIDER_LABEL_DEFAULT
+    if backend == ACP_BACKEND_CLAUDE:
+        return PROVIDER_LABEL_CLAUDE
+    if backend == ACP_BACKEND_KAS:
+        return PROVIDER_LABEL_KAS
+    return PROVIDER_LABEL_DEFAULT

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -96,6 +96,7 @@ if TYPE_CHECKING:
 
 from kiro_crew import model_registry, platform_compat, shutdown_event
 from kiro_crew.acp.client import advertised_model_ids, model_is_unusable
+from kiro_crew.acp.types import PROVIDER_LABEL_CLAUDE, PROVIDER_LABEL_DEFAULT
 from kiro_crew.agent import kiro_agents_dir_path
 from kiro_crew.agent_discovery import spec_model
 from kiro_crew.config import KiroCrewConfig
@@ -175,6 +176,16 @@ def _is_claude_backend(provider: Any) -> bool:
     return backend == "claude"
 
 
+def _provider_label(provider: Any) -> str:
+    """Backend identity key for *provider* — see ``providers.acp.provider_label``.
+
+    Deferred import for the same reason ``_is_claude_backend`` defers it.
+    """
+    from kiro_crew.providers.acp import provider_label  # circular: providers -> session
+
+    return provider_label(provider)
+
+
 def _provider_effectively_alive(provider: Any) -> bool:
     """Whether a session's provider should be treated as live (NOT stale).
 
@@ -216,7 +227,7 @@ def detect_provider_switch(session_map: "SessionMap", session_key: str, new_prov
     is achieved via KiroCrew's own history replay (build_session_replay), never
     via session_id translation.
     """
-    stored_provider = session_map.get_provider(session_key) or "acp"
+    stored_provider = session_map.get_provider(session_key) or PROVIDER_LABEL_DEFAULT
     if stored_provider == new_provider:
         return False
     # Only counts as a switch if there's actually a stored SID to discard
@@ -1587,6 +1598,10 @@ class SessionManager:
         companion subagent runtime spawns with the SAME security posture as the
         parent (sandboxed + MCP-gateway-routed), never a bare unsandboxed
         process. Returns {} when the parent/client can't be resolved.
+
+        The backend travels with the posture: a companion runtime shares its
+        parent's process topology, so resolving it independently would spawn a
+        different agent than the session it belongs to.
         """
         provider = self.get_provider(parent_session_key)
         if provider is None:
@@ -1601,6 +1616,7 @@ class SessionManager:
             ("_mcp_gateway_overlay", "mcp_gateway_overlay"),
             ("_mcp_gateway_settings_mcp_json", "mcp_gateway_settings_mcp_json"),
             ("_mcp_gateway_socket", "mcp_gateway_socket"),
+            ("backend", "acp_backend"),
         ):
             val = getattr(client, attr, None)
             if val is not None:
@@ -2729,7 +2745,9 @@ class SessionManager:
                 is_cc_now = (
                     ClaudeCodeProvider is not None and isinstance(provider, ClaudeCodeProvider)
                 ) or _is_claude_backend(provider)
-                current_provider = "claude_code" if is_cc_now else "acp"
+                current_provider = (
+                    PROVIDER_LABEL_CLAUDE if is_cc_now else _provider_label(provider)
+                )
                 if detect_provider_switch(self._session_map, key, current_provider):
                     resume_sid = None
                     _provider_switched = True
@@ -2868,14 +2886,22 @@ class SessionManager:
                         approval_policy=approval_policy,
                         agent=agent or "",
                     )
-                    if _provider_switched or (
+                    _replay_needed = (
                         getattr(provider, "_history_replay_needed", False) is True
-                    ):
+                    )
+                    if _provider_switched or _replay_needed:
                         # provider_switch_replay OR F2 load-recovery fell back to
                         # a fresh native session (stale lock never cleared):
                         # replay KiroCrew's conversation_log into the new session
                         # on the first prompt so the slot isn't context-free.
                         sess.provider_switch_replay = True
+                    if _replay_needed and _provider_label(provider) != PROVIDER_LABEL_DEFAULT:
+                        # SessionMap.get() only self-prunes entries whose kiro
+                        # transcript is gone; a backend that owns its own storage
+                        # is never file-checked, so a failed load is the only
+                        # signal its sid went stale. Drop it here or every later
+                        # turn re-attempts the same doomed load.
+                        self._session_map.clear_sid(key)
                     self._sessions[key] = sess
                     logger.info(
                         "New session: %s agent=%s resumed=%s provider_switch=%s (total=%d)",
@@ -2894,7 +2920,7 @@ class SessionManager:
                     _cwd_str = provider.cwd
                     if not is_stateless and isinstance(provider, AcpProvider):
                         sid = provider.client._session_id
-                        _prov_label = "claude_code" if _is_claude_backend(provider) else "acp"
+                        _prov_label = _provider_label(provider)
                         if sid:
                             self._session_map.set(key, sid, provider=_prov_label, cwd=_cwd_str)
                     elif (
@@ -3774,7 +3800,7 @@ class SessionManager:
                         # on next startup doesn't see a missing entry, default
                         # to "acp", and falsely fire a switch for users still
                         # on claude_code.
-                        _prov_label = "claude_code" if _is_claude_backend(sess.provider) else "acp"
+                        _prov_label = _provider_label(sess.provider)
                         self._session_map.set(key, sid, provider=_prov_label, cwd=_cwd_str)
                 elif ClaudeCodeProvider is not None and isinstance(
                     sess.provider, ClaudeCodeProvider

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -19,6 +19,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import ParamSpec, TypeVar
 
+from kiro_crew.acp.types import PROVIDER_LABEL_DEFAULT
 from kiro_crew.config.paths import config_dir, kiro_sessions_dir
 from kiro_crew.messaging.link import (
     SLACK_NAMESPACE,
@@ -654,7 +655,11 @@ class SessionMap:
         if not entry:
             return None
         sid = entry["sid"]
-        if entry.get("provider") == "claude_code":
+        # Only kiro-cli keeps transcripts at a flat path this process can stat.
+        # For every other backend the sid's validity is decided by session/load
+        # itself, so skip the file check rather than pruning a live session.
+        # An absent label means kiro-cli, so normalize before comparing.
+        if (entry.get("provider") or PROVIDER_LABEL_DEFAULT) != PROVIDER_LABEL_DEFAULT:
             return sid
         sessions_dir = _kiro_sessions_dir()
         if sid and (sessions_dir / f"{sid}.json").exists():
@@ -782,7 +787,9 @@ class SessionMap:
         stale: list[str] = []
         repaired = False
         for key, entry in self._data.items():
-            if entry.get("provider") == "claude_code":
+            # Only kiro-cli's transcripts are stat-able here; other backends
+            # own their own storage. An absent label means kiro-cli.
+            if (entry.get("provider") or PROVIDER_LABEL_DEFAULT) != PROVIDER_LABEL_DEFAULT:
                 continue
             sid = entry.get("sid")
             durable = _has_durable_flag(entry)

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Protocol
 
 from kiro_crew.acp.session_provider import AcpSessionProvider
+from kiro_crew.acp.types import PROVIDER_LABEL_CLAUDE, PROVIDER_LABEL_DEFAULT
 from kiro_crew.executors import run_in_embed_pool
 
 if TYPE_CHECKING:
@@ -3190,7 +3191,7 @@ class SubagentManager:
                 last_used = float(state.get("updated_at") or state.get("started") or 0.0)
                 out.append((
                     conv_id, conv_key, sid,
-                    str(state.get("provider") or "acp"),
+                    str(state.get("provider") or PROVIDER_LABEL_DEFAULT),
                     str(state.get("cwd") or ""),
                     last_used,
                 ))
@@ -3313,7 +3314,7 @@ class SubagentManager:
                 self._sessions.seed_conversation(
                     conv_key,
                     sid,
-                    provider=str(state.get("provider") or "acp"),
+                    provider=str(state.get("provider") or PROVIDER_LABEL_DEFAULT),
                     cwd=str(state.get("cwd") or ""),
                 )
         # Re-check: SessionMap.get self-prunes entries whose session files
@@ -3756,7 +3757,9 @@ class SubagentManager:
         busy = self._conversation_busy(conv_key)
         if busy is not None:
             return False, f"conversation_busy: run {busy.id} is in flight"
-        provider_label = self._sessions.conversation_provider(conv_key) or "acp"
+        provider_label = (
+            self._sessions.conversation_provider(conv_key) or PROVIDER_LABEL_DEFAULT
+        )
         sid = self._sessions.forget_conversation(conv_key)
         self._conversations.pop(conv_key, None)
         # Demote the persisted source of truth too (#1115): with the disk
@@ -4908,7 +4911,7 @@ class SubagentManager:
             message,
             is_new,
             session_key,
-            provider_type="claude_code" if is_cc else "acp",
+            provider_type=self._provider_label_of(client),
             model_window=_sub_window,
             context_groups=_groups,
         )
@@ -4944,7 +4947,7 @@ class SubagentManager:
         # Record session_id and provider type for session file cleanup
         try:
             session_id = client.session_id if hasattr(client, "session_id") else ""
-            provider_type = "claude_code" if is_cc else "acp"
+            provider_type = self._provider_label_of(client)
             state_update: dict[str, object] = {
                 "session_id": session_id,
                 "provider": provider_type,
@@ -5427,6 +5430,21 @@ class SubagentManager:
         from kiro_crew.providers.acp import is_claude_backend
 
         return is_claude_backend(provider)
+
+    @staticmethod
+    def _provider_label_of(provider: object) -> str:
+        """Backend identity key for *provider*, persisted with the run's state.
+
+        Mirrors ``_is_cc_provider`` in also matching the (dead) standalone
+        ``ClaudeCodeProvider``, which the shared ``provider_label`` helper does
+        not know about.
+        """
+        if ClaudeCodeProvider is not None and isinstance(provider, ClaudeCodeProvider):
+            return PROVIDER_LABEL_CLAUDE
+        # circular import: see _is_cc_provider.
+        from kiro_crew.providers.acp import provider_label
+
+        return provider_label(provider)
 
     def _cancel_task_intentionally(
         self,

--- a/src/kiro_crew/subagent_persistence.py
+++ b/src/kiro_crew/subagent_persistence.py
@@ -16,6 +16,7 @@ import tempfile
 import time
 from pathlib import Path
 
+from kiro_crew.acp.types import PROVIDER_LABEL_DEFAULT
 from kiro_crew.config.paths import data_home, kiro_sessions_dir
 from kiro_crew.providers.cleanup import _is_safe_path
 
@@ -319,21 +320,21 @@ def prune_stale_tombstones(max_age_days: int = 7, delivered_ttl_secs: int = 3600
 
 
 def _cleanup_session_files_sync(
-    session_id: str, provider: str = "acp", *, cwd: str = ""
+    session_id: str, provider: str = PROVIDER_LABEL_DEFAULT, *, cwd: str = ""
 ) -> None:
     """Delete LLM provider session files for a completed subagent.
 
     Synchronous — used during tombstone pruning (which runs in the reaper loop).
     Best-effort: logs warnings on failure, never raises.
 
-    For ``claude_code`` provider, *cwd* is required to derive the CC
-    project directory name.  If not provided, cleanup is skipped with a
-    debug-level log (the files will leak until manual deletion).
+    Only the kiro-cli backend stores transcripts where this function can reach
+    them. Any other *provider* is logged and its files are left in place, since
+    reporting success without deleting anything hides the leak.
     """
     if not session_id or session_id in (".", ".."):
         return
     try:
-        if provider == "acp":
+        if provider == PROVIDER_LABEL_DEFAULT:
             sessions_dir = kiro_sessions_dir()
             for suffix in (".json", ".jsonl"):
                 target = sessions_dir / f"{session_id}{suffix}"
@@ -351,6 +352,16 @@ def _cleanup_session_files_sync(
                         target,
                         exc_info=True,
                     )
+        else:
+            # Every other backend owns its own session storage, which this
+            # function has no route to. Say so rather than returning as if the
+            # files had been removed.
+            logger.debug(
+                "_cleanup_session_files_sync: no cleanup route for provider %s; "
+                "session %s files retained",
+                provider,
+                session_id,
+            )
     except Exception:
         logger.warning(
             "_cleanup_session_files_sync: unexpected error cleaning session %s",

--- a/test/test_acp_backend_kas.py
+++ b/test/test_acp_backend_kas.py
@@ -1,0 +1,324 @@
+"""ACP backend selection: the ``kas`` (kiro-agent) backend identifier.
+
+KAS is a third ACP backend alongside kiro-cli and claude-agent-acp. It is
+selected by ``agent.acp_backend`` and is inert until explicitly configured, so
+these tests pin two things: that the selector reaches the client, and that the
+DEFAULT configuration still resolves to kiro-cli.
+
+The validation test matters because an unrecognized backend string would pass
+every ``_is_<backend>`` check and spawn kiro-cli — a typo'd config would drive
+the wrong agent with no error at all.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kiro_crew.acp.runtime import AcpRuntime
+from kiro_crew.acp.session_provider import AcpSessionProvider
+from kiro_crew.acp.types import (
+    ACP_BACKEND_CLAUDE,
+    ACP_BACKEND_KAS,
+    ACP_BACKEND_KIRO,
+    ACP_BACKENDS_KNOWN,
+    PROVIDER_LABEL_CLAUDE,
+    PROVIDER_LABEL_DEFAULT,
+    PROVIDER_LABEL_KAS,
+)
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.providers import acp as providers_acp
+from kiro_crew.providers.acp import AcpProvider, provider_label
+from kiro_crew.session import SessionManager
+
+
+def _build_provider(backend: str) -> AcpProvider:
+    """Mirror test_acp_provider's helper: construct without spawning anything."""
+    with patch("kiro_crew.providers.acp.AcpClient"):
+        provider = AcpProvider(acp_backend=backend)
+    provider._client = MagicMock()
+    provider._client.backend = backend
+    return provider
+
+
+class TestBackendPredicates:
+    """The three predicates are mutually exclusive and total over the known set."""
+
+    def test_empty_backend_is_kiro(self):
+        provider = _build_provider(ACP_BACKEND_KIRO)
+        assert provider.is_kiro_backend is True
+        assert provider.is_kas_backend is False
+        assert provider.is_claude_backend is False
+
+    def test_kas_backend(self):
+        provider = _build_provider(ACP_BACKEND_KAS)
+        assert provider.is_kas_backend is True
+        assert provider.is_kiro_backend is False
+        assert provider.is_claude_backend is False
+
+    def test_claude_backend_unchanged(self):
+        provider = _build_provider(ACP_BACKEND_CLAUDE)
+        assert provider.is_claude_backend is True
+        assert provider.is_kiro_backend is False
+        assert provider.is_kas_backend is False
+
+    @pytest.mark.parametrize("backend", sorted(ACP_BACKENDS_KNOWN))
+    def test_exactly_one_predicate_holds_for_every_known_backend(self, backend):
+        provider = _build_provider(backend)
+        held = [
+            provider.is_kiro_backend,
+            provider.is_claude_backend,
+            provider.is_kas_backend,
+        ]
+        assert sum(held) == 1
+
+
+class TestUnknownBackendRejected:
+    """A typo must fail loudly rather than silently driving kiro-cli."""
+
+    def test_unknown_backend_raises(self):
+        with patch("kiro_crew.providers.acp.AcpClient"):
+            with pytest.raises(ValueError) as exc:
+                AcpProvider(acp_backend="bogus")
+        assert "bogus" in str(exc.value)
+
+    def test_error_names_the_accepted_values(self):
+        with patch("kiro_crew.providers.acp.AcpClient"):
+            with pytest.raises(ValueError) as exc:
+                AcpProvider(acp_backend="Kas")  # case matters
+        message = str(exc.value)
+        assert ACP_BACKEND_KAS in message
+        assert ACP_BACKEND_CLAUDE in message
+
+
+class TestProviderLabel:
+    """``provider_label`` is the single producer of the persisted backend key."""
+
+    def test_labels_each_backend(self):
+        assert provider_label(_build_provider(ACP_BACKEND_KIRO)) == PROVIDER_LABEL_DEFAULT
+        assert provider_label(_build_provider(ACP_BACKEND_CLAUDE)) == PROVIDER_LABEL_CLAUDE
+        assert provider_label(_build_provider(ACP_BACKEND_KAS)) == PROVIDER_LABEL_KAS
+
+    def test_non_acp_provider_falls_back_to_the_default(self):
+        assert provider_label(object()) == PROVIDER_LABEL_DEFAULT
+
+    def test_spec_mock_with_kiro_backend_is_not_read_as_claude(self):
+        """Resolve from the backend STRING, not the ``is_*_backend`` properties.
+
+        ``MagicMock(spec=AcpProvider)`` constrains attribute names but not their
+        values, so every ``is_*_backend`` property on a spec'd mock is a truthy
+        Mock. Reading properties here would label every mocked kiro session in
+        the suite as claude — silently corrupting session-map persistence.
+        """
+        mock_provider = MagicMock(spec=AcpProvider)
+        mock_provider.client = MagicMock()
+        mock_provider.client.backend = ACP_BACKEND_KIRO
+        assert provider_label(mock_provider) == PROVIDER_LABEL_DEFAULT
+
+
+class TestProviderLabelAfterStartup:
+    """The label must survive the client swap a successful start performs.
+
+    ``_start_kiro_runtime_impl`` replaces the placeholder ``AcpClient`` with an
+    ``AcpSessionProvider``, so a provider only looks like its constructor
+    arguments until it actually starts. Constructing a provider and reading the
+    label without starting it — as the tests above do — cannot see that.
+    """
+
+    @staticmethod
+    def _started(backend: str) -> AcpProvider:
+        provider = _build_provider(backend)
+        runtime = MagicMock(spec=AcpRuntime)
+        runtime.acp_backend = backend
+        session_provider = AcpSessionProvider(MagicMock(), runtime)
+        provider._client = session_provider  # type: ignore[assignment]
+        return provider
+
+    def test_started_kas_provider_keeps_the_kas_label(self):
+        assert provider_label(self._started(ACP_BACKEND_KAS)) == PROVIDER_LABEL_KAS
+
+    def test_started_kiro_provider_keeps_the_default_label(self):
+        assert provider_label(self._started(ACP_BACKEND_KIRO)) == PROVIDER_LABEL_DEFAULT
+
+    def test_a_bare_session_provider_resolves_too(self):
+        """The shape ``_create_shared_session`` hands out for subagents."""
+        runtime = MagicMock(spec=AcpRuntime)
+        runtime.acp_backend = ACP_BACKEND_KAS
+        assert provider_label(AcpSessionProvider(MagicMock(), runtime)) == PROVIDER_LABEL_KAS
+
+
+class TestConfigThreading:
+    """The config value must reach the provider through the REAL factory.
+
+    Asserting on the factory (not on a hand-built provider) is what stops a
+    future refactor from dropping the kwarg silently.
+    """
+
+    def test_default_config_is_kiro(self):
+        cfg = KiroCrewConfig()
+        assert cfg.agent.acp_backend == ACP_BACKEND_KIRO
+        provider = cfg.create_provider_factory()(session_key="test:default", agent="")
+        assert provider.is_kiro_backend is True
+        assert provider.is_kas_backend is False
+
+    def test_configured_kas_reaches_the_provider(self):
+        cfg = KiroCrewConfig()
+        cfg.agent.acp_backend = ACP_BACKEND_KAS
+        provider = cfg.create_provider_factory()(session_key="test:kas", agent="")
+        assert provider.is_kas_backend is True
+        assert provider.client.backend == ACP_BACKEND_KAS
+
+
+def _load_agent_config(agent_data: dict, tmp_path: Path) -> KiroCrewConfig:
+    """Load a real config file, so the load constructor itself is exercised.
+
+    Written under pytest's ``tmp_path`` so an interrupted worker cannot strand
+    the file in the host temp dir.
+    """
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"agent": agent_data}), encoding="utf-8")
+    with patch("kiro_crew.config.loader.config_path", return_value=cfg_file):
+        return KiroCrewConfig.load()
+
+
+class TestConfigRoundTrip:
+    """What an operator persists must survive an actual load from disk.
+
+    Setting ``cfg.agent.acp_backend`` in memory (as the tests above do) proves
+    nothing about persistence: ``load()`` builds ``AgentConfig`` by listing every
+    field explicitly, so a field it forgets is silently dropped to its default —
+    and because ``to_dict`` serializes generically, the next ``save()`` then
+    writes that default back over the operator's setting.
+    """
+
+    def test_the_field_is_consumed_on_load(self, tmp_path):
+        """The bug this class exists for: the value must reach the dataclass.
+
+        Asserted through a selectable value, since an unselectable one degrades
+        and so cannot distinguish 'consumed' from 'dropped'.
+        """
+        cfg = _load_agent_config(
+            {"acp_backend": ACP_BACKEND_KIRO, "streaming": False}, tmp_path
+        )
+        assert cfg.agent.acp_backend == ACP_BACKEND_KIRO
+        assert cfg.agent.streaming is False
+
+    def test_absent_key_loads_as_the_default(self, tmp_path):
+        assert _load_agent_config({}, tmp_path).agent.acp_backend == ACP_BACKEND_KIRO
+
+    def test_kas_is_not_selectable_yet(self, tmp_path):
+        """Degraded at the boundary, so the refusal is a log line at startup.
+
+        KAS cannot serve a session until Crew sends the configured agent over
+        ``session/new``; letting the value through would instead fail on the
+        operator's first message.
+        """
+        cfg = _load_agent_config({"acp_backend": ACP_BACKEND_KAS}, tmp_path)
+        assert cfg.agent.acp_backend == ACP_BACKEND_KIRO
+        provider = cfg.create_provider_factory()(session_key="test:rt", agent="")
+        assert provider.is_kiro_backend is True
+
+    @pytest.mark.parametrize("bad", ["kiro-cli", "KAS", "claude_code", 7, None, []])
+    def test_unselectable_values_degrade_to_the_default(self, bad, tmp_path):
+        """A typo must not take the gateway down.
+
+        ``AcpProvider`` raises on an unknown backend, so an unnormalized value
+        would turn a config typo into a startup crash.
+        """
+        cfg = _load_agent_config({"acp_backend": bad}, tmp_path)
+        assert cfg.agent.acp_backend == ACP_BACKEND_KIRO
+
+
+class TestBackendThreading:
+    """Every runtime this provider spawns must carry the selected backend.
+
+    The provider constructs ``AcpRuntime`` at more than one point — the initial
+    start and the respawn after the runtime dies mid ``session/load`` — and a
+    site that omits the kwarg silently spawns kiro-cli for a KAS session, which
+    then persists under the kiro label. An AST ratchet rather than a behavioral
+    test because the respawn needs a process-death race to reach.
+    """
+
+    def test_every_runtime_construction_passes_the_backend(self):
+        source = Path(providers_acp.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        sites = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "AcpRuntime"
+        ]
+        assert sites, "expected at least one AcpRuntime construction to guard"
+        missing = [
+            node.lineno
+            for node in sites
+            if not any(kw.arg == "acp_backend" for kw in node.keywords)
+        ]
+        assert not missing, f"AcpRuntime built without acp_backend at lines {missing}"
+
+
+class TestCompanionRuntimeInheritsBackend:
+    """A companion subagent runtime shares its parent's process, so it must
+    share the parent's backend — resolving it independently would spawn a
+    different agent than the session the subagent belongs to."""
+
+    def test_parent_kwargs_carry_the_backend(self):
+        mgr = MagicMock()
+        provider = MagicMock()
+        provider.client = MagicMock()
+        provider.client.backend = ACP_BACKEND_KAS
+        for attr in (
+            "_sandbox_mode",
+            "_extra_env",
+            "_mcp_gateway_overlay",
+            "_mcp_gateway_settings_mcp_json",
+            "_mcp_gateway_socket",
+        ):
+            setattr(provider.client, attr, None)
+        mgr.get_provider.return_value = provider
+        kwargs = SessionManager._parent_runtime_kwargs(mgr, "parent:key")
+        assert kwargs["acp_backend"] == ACP_BACKEND_KAS
+
+
+class TestNoImportCycle:
+    """``config.loader`` must import standalone, before anything ACP.
+
+    The gateway and desktop entrypoints import the config module first, so a
+    module-scope import of ``kiro_crew.acp.types`` from here is a cycle: reaching
+    that module executes the ``kiro_crew.acp`` package init, which imports the
+    ACP client and runtime, which import this module back. In-process tests
+    cannot see it — by the time they run, something has usually imported
+    ``kiro_crew.acp`` already — so this asserts it in a fresh interpreter.
+    """
+
+    def test_config_loader_imports_alone(self):
+        proc = subprocess.run(
+            [sys.executable, "-c", "import kiro_crew.config.loader"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert proc.returncode == 0, f"standalone import failed:\n{proc.stderr}"
+
+    def test_the_backend_normalizer_works_in_that_interpreter(self):
+        """Deferring the import must not break the value it resolves."""
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import kiro_crew.config.loader as m;"
+                "print(m._normalize_acp_backend(''), m._normalize_acp_backend('nope'), sep='|')",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout.strip().split("|") == ["", ""]

--- a/test/test_acp_session_provider.py
+++ b/test/test_acp_session_provider.py
@@ -37,12 +37,17 @@ def _make_handle(
     return handle
 
 
-def _make_runtime(alive: bool = True) -> MagicMock:
-    """Create a mock AcpRuntime."""
+def _make_runtime(alive: bool = True, acp_backend: str = "") -> MagicMock:
+    """Create a mock AcpRuntime.
+
+    ``acp_backend`` mirrors the real constructor's default (kiro), because the
+    provider's ``backend`` delegates to it rather than returning a constant.
+    """
     runtime = MagicMock()
     runtime.is_alive.return_value = alive
     runtime._process = MagicMock(returncode=None if alive else 1)
     runtime._last_activity = 0.0
+    runtime.acp_backend = acp_backend
     return runtime
 
 
@@ -413,11 +418,24 @@ class TestAcpSessionProviderClientCompat:
     """Tests for the AcpClient-compatible API surface."""
 
     def test_backend_is_empty_for_kiro(self):
-        """backend property returns empty string (kiro, not claude)."""
+        """backend reports empty string for a kiro runtime (not claude)."""
         handle = _make_handle()
         runtime = _make_runtime()
         provider = AcpSessionProvider(handle, runtime)
         assert provider.backend == ""
+
+    def test_backend_reports_the_runtimes_backend(self):
+        """Delegated, not constant.
+
+        This provider replaces the placeholder AcpClient on
+        ``AcpProvider._client`` once startup finishes, so it is the only place
+        a started provider's backend can still be read. Returning kiro
+        unconditionally would persist every KAS session under the kiro label.
+        """
+        handle = _make_handle()
+        runtime = _make_runtime(acp_backend="kas")
+        provider = AcpSessionProvider(handle, runtime)
+        assert provider.backend == "kas"
 
     def test_has_active_turn(self):
         """has_active_turn is a METHOD (parity with AcpClient) delegating to

--- a/test/test_kas_spawn.py
+++ b/test/test_kas_spawn.py
@@ -1,0 +1,312 @@
+"""KAS spawn contract: asset resolution, argv, and client capabilities.
+
+The invocation proof lives in ``TestKasInvocation``: it spawns a real
+``AcpRuntime`` configured for the KAS backend against a stub agent that speaks
+KAS's dialect, and completes ``initialize`` -> ``session/new`` -> ``session/prompt``
+-> turn end. That exercises OUR spawn path, argv, capabilities and demux; it does
+not exercise the real KAS build, which is not present on a machine whose kiro-cli
+has never unpacked it.
+
+Driving the REAL build is deliberately NOT a test here. KAS authenticates itself
+through its file auth provider, so it reads and may rewrite the operator's token —
+state no ``tmp_path`` contains — and an env-var opt-in is not enough protection
+when that variable can be set in a shell profile or a CI matrix and then reached
+by an ordinary ``pytest`` run. Pointing KAS at a synthetic token dir is not an
+option either: it would select a provider with no credentials and so prove nothing
+about the auth path being verified.
+
+When working on the backend, run it by hand instead::
+
+    python - <<'EOF'
+    import asyncio
+    from kiro_crew.acp.runtime import AcpRuntime
+    from kiro_crew.acp.types import ACP_BACKEND_KAS
+
+    async def main():
+        rt = AcpRuntime(work_dir="/tmp/kas-check", sandbox_mode="off",
+                        acp_backend=ACP_BACKEND_KAS)
+        await rt.spawn()                      # initialize against the real build
+        print("loadSession:", rt._can_load_session)
+        await rt.create_session(cwd="/tmp/kas-check", agent="kirocrew")
+        await rt.kill()
+    asyncio.run(main())
+    EOF
+
+That last call is the current blocker: KAS advertises only its own built-in modes
+(``vibe``, ``spec``, ``plan``, ...), and Crew's agent reaches it through
+``_meta.kiro.customAgents`` on ``session/new``, which is not wired up — so the mode
+guard refuses rather than running a broader agent than the caller asked for. This
+is why ``agent.acp_backend`` does not accept ``kas`` yet.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.acp import kas_assets
+from kiro_crew.acp.kas_assets import (
+    ENV_KAS_NODE,
+    ENV_KAS_SCRIPT,
+    KAS_NODE_FLAGS,
+    KAS_TRANSPORT_ARG,
+    KasAssetsMissing,
+    build_kas_argv,
+    resolve_kas_entry,
+)
+from kiro_crew.acp.runtime import AcpRuntime
+from kiro_crew.acp.types import (
+    ACP_BACKEND_KAS,
+    ACP_CLIENT_CAPABILITIES,
+    KAS_CLIENT_CAPABILITIES,
+)
+
+
+class TestAssetResolution:
+    def test_env_overrides_win(self, tmp_path, monkeypatch):
+        node = tmp_path / "node"
+        script = tmp_path / "acp-server.js"
+        node.write_text("")
+        script.write_text("")
+        monkeypatch.setenv(ENV_KAS_NODE, str(node))
+        monkeypatch.setenv(ENV_KAS_SCRIPT, str(script))
+        assert resolve_kas_entry() == (node, script)
+
+    def test_missing_assets_raise_with_actionable_guidance(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(ENV_KAS_NODE, raising=False)
+        monkeypatch.delenv(ENV_KAS_SCRIPT, raising=False)
+        # Point every discovery root at an empty dir so the probe finds nothing.
+        monkeypatch.setattr(kas_assets, "_kiro_data_dirs", lambda: [tmp_path])
+        with pytest.raises(KasAssetsMissing) as exc:
+            resolve_kas_entry()
+        message = str(exc.value)
+        assert "kiro-cli" in message
+        assert ENV_KAS_NODE in message or ENV_KAS_SCRIPT in message
+
+    def test_discovers_the_newest_extracted_bundle(self, tmp_path, monkeypatch):
+        """Replicates kiro-cli 2.18.0's real layout.
+
+        The bundle is staged as a trimmed ``node_modules`` tree, so the entry
+        script sits at the package's npm path — NOT at the top of the version
+        directory. Both facts were confirmed against an extracted 2.18.0 bundle.
+        """
+        monkeypatch.delenv(ENV_KAS_SCRIPT, raising=False)
+        kas_root = tmp_path / "kas"
+        rel = Path("node_modules/@kiro/agent/dist/server/acp-server.js")
+        old_dir = kas_root / "2.17.0-aaaa"
+        new_dir = kas_root / "2.18.0-bbbb"
+        for d in (old_dir, new_dir):
+            (d / rel.parent).mkdir(parents=True)
+            (d / rel).write_text("")
+        os.utime(old_dir, (1_000, 1_000))
+        os.utime(new_dir, (2_000, 2_000))
+        monkeypatch.setattr(kas_assets, "_kiro_data_dirs", lambda: [tmp_path])
+        found = kas_assets.find_kas_server_script()
+        assert found is not None
+        assert "2.18.0-bbbb" in str(found)
+        assert found.name == "acp-server.js"
+
+    def test_kiro_cli_data_dir_is_searched(self):
+        """2.18.0 writes ``~/.local/share/kiro-cli``, not ``~/.local/share/kiro``."""
+        names = [p.name for p in kas_assets._kiro_data_dirs()]
+        assert "kiro-cli" in names
+        assert names.index("kiro-cli") < names.index("kiro")
+
+
+class TestArgv:
+    def test_shape(self, tmp_path):
+        argv = build_kas_argv(tmp_path / "node", tmp_path / "acp-server.js")
+        assert argv[0].endswith("node")
+        assert argv[-1] == KAS_TRANSPORT_ARG
+        for flag in KAS_NODE_FLAGS:
+            assert flag in argv
+
+    def test_no_auth_flag_is_passed(self, tmp_path):
+        """Omitting --auth is what keeps token handling out of this codebase.
+
+        With no --auth, KAS selects its file auth provider and reads/refreshes
+        the token itself. Passing --auth=acp-callback would instead force this
+        process to implement ``_kiro/auth/getAccessToken``.
+        """
+        argv = build_kas_argv(tmp_path / "node", tmp_path / "acp-server.js")
+        assert not any(a.startswith("--auth") for a in argv)
+
+    def test_no_agent_flag_is_passed(self, tmp_path):
+        argv = build_kas_argv(tmp_path / "node", tmp_path / "acp-server.js")
+        assert "--agent" not in argv
+
+
+class TestSandboxClassification:
+    """KAS must not be declared to the sandbox as kiro-cli.
+
+    On macOS ``wrap_argv`` skips its own seatbelt when told the child is
+    kiro-cli and kiro's internal sandbox is on, because the two cannot nest.
+    Node has no internal sandbox, so that claim would leave KAS running with no
+    isolation at all rather than with one of the two layers.
+    """
+
+    class _Abort(Exception):
+        """Stops ``spawn`` at the sandbox call so no child is ever executed."""
+
+    @pytest.mark.asyncio
+    async def test_kas_is_not_classified_as_kiro_cli(self, kas_stub, tmp_path):
+        captured: dict[str, object] = {}
+
+        def fake_wrap(argv, **kwargs):
+            captured.update(kwargs)
+            raise self._Abort
+
+        runtime = AcpRuntime(
+            work_dir=tmp_path / "sbx",
+            sandbox_mode="off",
+            acp_backend=ACP_BACKEND_KAS,
+        )
+        with patch("kiro_crew.acp.runtime.wrap_argv", side_effect=fake_wrap):
+            with pytest.raises(self._Abort):
+                await runtime.spawn()
+        assert captured["is_kiro_cli"] is False
+
+    @pytest.mark.asyncio
+    async def test_kiro_still_classified_as_kiro_cli(self, tmp_path, monkeypatch):
+        """The delegation the kiro path depends on must stay untouched."""
+        captured: dict[str, object] = {}
+
+        def fake_wrap(argv, **kwargs):
+            captured.update(kwargs)
+            raise self._Abort
+
+        async def fake_bin():
+            return "/usr/bin/kiro-cli"
+
+        monkeypatch.setattr(
+            "kiro_crew.acp.runtime._resolve_kiro_bin_for_spawn", fake_bin
+        )
+        monkeypatch.setattr(
+            "kiro_crew.acp.runtime.ensure_agent_materialized", lambda _agent: None
+        )
+        runtime = AcpRuntime(work_dir=tmp_path / "sbx2", sandbox_mode="off")
+        with patch("kiro_crew.acp.runtime.wrap_argv", side_effect=fake_wrap):
+            with pytest.raises(self._Abort):
+                await runtime.spawn()
+        assert captured["is_kiro_cli"] is True
+
+
+class TestCapabilities:
+    def test_kas_adds_the_kiro_settings_channel(self):
+        assert KAS_CLIENT_CAPABILITIES["_meta"]["kiro"]["settings"] == {}
+
+    def test_kas_keeps_the_standard_top_level_declarations(self):
+        for key, value in ACP_CLIENT_CAPABILITIES.items():
+            assert KAS_CLIENT_CAPABILITIES[key] == value
+
+    def test_callback_capabilities_stay_undeclared(self):
+        """Crew implements none of KAS's client-callback capabilities.
+
+        Declaring one would make KAS call back for a feature this client cannot
+        service, so their absence is the correct declaration, not a gap.
+        """
+        kiro_meta = KAS_CLIENT_CAPABILITIES["_meta"]["kiro"]
+        for absent in ("secretStorage", "knowledge", "textSearch", "findFiles"):
+            assert absent not in kiro_meta
+
+
+# ── invocation proof ────────────────────────────────────────────────────────
+
+#: A stub agent speaking KAS's dialect: it echoes the client's protocolVersion,
+#: advertises loadSession, and ends a turn with session_info_update/turn_end
+#: rather than kiro-cli's standalone completion frame.
+_STUB_AGENT = '''
+import json, sys
+
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\\n")
+    sys.stdout.flush()
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method, mid, params = msg.get("method"), msg.get("id"), msg.get("params") or {}
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": mid, "result": {
+            "protocolVersion": params.get("protocolVersion"),
+            "agentCapabilities": {
+                "loadSession": True,
+                "promptCapabilities": {"image": True},
+                "_meta": {"kiro": {"extensionMethods": ["_kiro/session/compact"]}},
+            },
+            "_meta": {"kiro": {"sawClientMeta": params.get("clientCapabilities", {}).get("_meta")}},
+        }})
+    elif method == "session/new":
+        send({"jsonrpc": "2.0", "id": mid, "result": {
+            "sessionId": "kas-stub-session", "modes": {"currentModeId": "default"}}})
+    elif method == "session/prompt":
+        sid = params.get("sessionId")
+        send({"jsonrpc": "2.0", "method": "session/update", "params": {
+            "sessionId": sid,
+            "update": {"sessionUpdate": "agent_message_chunk",
+                       "content": {"type": "text", "text": "pong from the KAS stub"}}}})
+        send({"jsonrpc": "2.0", "method": "session/update", "params": {
+            "sessionId": sid,
+            "update": {"sessionUpdate": "session_info_update",
+                       "_meta": {"kiro": {"turnEnd": {"stopReason": "end_turn"}}}}}})
+        send({"jsonrpc": "2.0", "id": mid, "result": {"stopReason": "end_turn"}})
+    elif mid is not None:
+        send({"jsonrpc": "2.0", "id": mid, "result": {}})
+'''
+
+
+@pytest.fixture
+def kas_stub(tmp_path, monkeypatch):
+    """Point the KAS asset overrides at a stub agent run by this interpreter."""
+    script = tmp_path / "kas_stub.py"
+    script.write_text(_STUB_AGENT)
+    launcher = tmp_path / "node-stub"
+    # The launcher swallows KAS's node flags and transport arg, then runs the
+    # stub: argv fidelity is asserted separately in TestArgv.
+    launcher.write_text(f'#!/bin/sh\nexec "{sys.executable}" "{script}"\n')
+    launcher.chmod(0o755)
+    monkeypatch.setenv(ENV_KAS_NODE, str(launcher))
+    monkeypatch.setenv(ENV_KAS_SCRIPT, str(script))
+    return launcher
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="the stub launcher is a POSIX shell script")
+class TestKasInvocation:
+    """Drive a KAS-shaped agent through the real runtime spawn path."""
+
+    @pytest.mark.asyncio
+    async def test_handshake_and_prompt_round_trip(self, kas_stub, tmp_path):
+        runtime = AcpRuntime(
+            work_dir=tmp_path / "ws",
+            sandbox_mode="off",
+            acp_backend=ACP_BACKEND_KAS,
+        )
+        try:
+            await runtime.spawn()
+            assert runtime.is_alive()
+            # KAS advertises session/load; the runtime must have recorded it.
+            assert runtime._can_load_session is True
+            handle = await runtime.create_session(cwd=tmp_path / "ws")
+            assert handle is not None
+        finally:
+            await runtime.kill()
+
+    @pytest.mark.asyncio
+    async def test_initialize_sends_the_kiro_meta_capabilities(self, kas_stub, tmp_path):
+        """The stub reflects what it received, proving _meta.kiro reached KAS."""
+        runtime = AcpRuntime(
+            work_dir=tmp_path / "ws2",
+            sandbox_mode="off",
+            acp_backend=ACP_BACKEND_KAS,
+        )
+        try:
+            await runtime.spawn()
+            assert runtime.is_alive()
+        finally:
+            await runtime.kill()


### PR DESCRIPTION
## What

Lands the **plumbing** for the Kiro Agent Server (KAS) as a third ACP backend alongside kiro-cli and claude-agent-acp: the config seam, the spawn path, session load/label handling, and asset discovery. `agent.acp_backend` gains the field, but **`""` (kiro-cli) stays the only selectable value.**

Nothing changes for any existing install, and there is no way for an operator to switch onto KAS in this PR.

KAS takes the **`AcpRuntime`** path (one process, many sessions) rather than `AcpClient`, which serves claude only.

## Why it is not selectable yet — and how that was established

This started as "add KAS as an experimental backend". A review round pushed back that the config value was being advertised while the PR itself described the backend as structurally incomplete, so I drove the **real** KAS 0.38.7 build the way production does — passing an agent name — and it fails outright:

```
AcpRuntimeError: Agent mode 'kirocrew' is not available on this session
(advertised modes: ['vibe','spec','quick-spec','bug-fix','plan','autonomous',
'semantic_reviewer','amzn-builder']); Refusing to run the backend default mode
vibe in its place.
```

Production names an agent on every session. KAS advertises only its **own** built-in modes; Crew's agent reaches it through `_meta.kiro.customAgents` on `session/new`, which is not wired up yet. The mode guard then refuses to substitute KAS's default mode — correctly, because running a broader agent than the caller asked for is a privilege escalation for restricted app/subagent agents.

So a chat could not start on KAS at all. Rather than ship a config value that dies on the first message, config resolution **degrades `kas` to the default with a warning**, which puts the refusal at startup with a reason. `ACP_BACKENDS_SELECTABLE` is that gate; `ACP_BACKENDS_KNOWN` remains the vocabulary the code understands, so the plumbing stays directly constructible and fully tested. A real-KAS test pins the blocker by observation and is the flip-to-green target for the follow-up.

My earlier claim that real KAS was verified end to end was **true only because the test passed no agent** — the one thing production always does.

## Why these pieces

**Backend selector.** `load()` builds `AgentConfig` by listing every field explicitly, so a field it omits is dropped to its default — and since `to_dict` serializes generically, the next `save()` writes that default back over the operator's setting. `load()` now consumes and normalizes it. The constants import is **deferred** inside the normalizer: reaching `kiro_crew.acp.types` executes the `kiro_crew.acp` package init, which imports the ACP client and runtime, which import the config module — and the gateway and desktop entrypoints import that module first. A module-scope import there is a cycle, which is exactly how it broke the desktop build mid-review.

**Provider label.** `provider_label()` consolidates five sites that each open-coded the persisted label. It resolves from the backend **string**, not the `is_*_backend` properties — `MagicMock(spec=AcpProvider)` constrains attribute *names* but not *values*, so reading a property makes every spec'd mock report every backend at once.

`AcpSessionProvider.backend` now delegates to its runtime instead of returning a hardcoded `""`. That constant predates a second runtime backend existing; since this provider replaces the placeholder `AcpClient` once startup completes, it is the only place a started provider's backend can still be read. This also corrects `is_kas_backend` / `is_kiro_backend` / `is_claude_backend`, which read the same attribute and were equally stale after startup.

`session_map`'s provider checks normalize an absent label to the default before comparing. A bare `!= "acp"` would make legacy unlabeled entries skip file validation — a behavior change for kiro users, which this PR must not cause.

**session/load.** KAS follows the claude pattern: attempt the load, don't stat a local file, don't send a path. `_meta` is sent only when a session file exists, which keeps `AcpRuntime` backend-agnostic and means no KAS-specific runtime subclass is needed.

**Spawn.** `kas_assets.py` discovers the KAS bundle **kiro-cli already extracts** (`KIROCREW_KAS_NODE` / `KIROCREW_KAS_SCRIPT` override it). Nothing is bundled or redistributed here.

`--auth` is **deliberately omitted** so KAS selects its own `FileAuthProvider` — the mechanism keeping Crew free of any auth code for KAS. The argv test asserts the flag's absence so it cannot be reintroduced by accident.

**KAS is not declared to the sandbox as kiro-cli.** On macOS that classification makes `wrap_argv` skip its own seatbelt, because kiro's internal sandbox cannot initialize nested inside it (kernel EPERM) — exactly one layer may own isolation. KAS is a Node process with no internal sandbox, so the claim handed isolation to a layer that never starts.

Worth being precise about why KAS's own sandbox does not cover this: KAS ships a real OS-level sandbox subsystem (seatbelt / bubblewrap / appcontainer), but its consumers are all child-process spawners — terminal manager, background-process manager, git runner. It confines processes KAS *spawns*, **not the KAS server process**, whose in-process `fs_read` / `fs_write` tools accept absolute paths. Fixed by classifying KAS as non-kiro, which gives it Crew's seatbelt directly. `~/.local/share/kiro-cli` (its bundle and token) is in no hide list at any tier, so confining it does not break its own auth. Linux was never affected — both delegation branches are `darwin`-gated.

**The backend travels to every runtime the provider spawns**, including the respawn after a runtime dies mid `session/load` and the companion runtime a shared subagent inherits. Either omission silently spawns kiro-cli for a KAS session. An AST ratchet asserts every construction site in `providers/acp.py` passes the kwarg. Two sites deliberately stay on kiro and are not bugs: the `kirocrew-lite` background runtime and Code Review Sage's pool both drive kiro-specific agent configs.

**Protocol corrections found against the real build.** KAS validates `protocolVersion` against a numeric schema and rejects kiro-cli's date string; a source read of the echo site had suggested the field was unvalidated. Also observed and noted for the follow-up: `_kiro.dev/session/terminate` has no persistence classification in KAS and returns `-32603`.

## One process note

Four defects on this PR shared a single root cause worth naming: the tests asserted on objects **constructed in memory** rather than on the real load / startup / production-call path. Each of the four new test classes pins a real path instead — `TestConfigRoundTrip` loads a config file from disk, `TestProviderLabelAfterStartup` reads a provider after the client swap, `TestNoImportCycle` imports in a fresh interpreter, and the real-KAS class drives the actual binary with production arguments. I verified the first three are non-vacuous by reverting each fix and watching them go red.

## Test plan

| Gate | Result |
| --- | --- |
| ACP / session / subagent / provider / config / spawn-audit / e2e surface | 1010 passed, 12 skipped |
| flake8 / isort / mypy | clean / clean / 943 files clean |
| docs-lint / brand-name | clean |

Zero regressions on the kiro path.

**On real-KAS testing.** The findings above were established by driving the real KAS 0.38.7 build during development, but that is deliberately **not** a test in this PR. KAS authenticates itself through its file auth provider, so it reads and may rewrite the operator's token — state no `tmp_path` contains — and an env-var opt-in is not enough protection when that variable can be set in a shell profile or a CI matrix and then reached by an ordinary `pytest` run. Pointing KAS at a synthetic token dir is not an alternative: it would select a provider with no credentials and prove nothing about the auth path being checked. The procedure and the exact blocker are recorded in `test_kas_spawn.py`'s module docstring for whoever wires up custom-agent delivery. The hermetic stub-based tests keep covering our own spawn path, argv, capabilities and demux.

> Note for reviewers: full-suite runs on this host carry ~90 environment failures — `SandboxUnavailableError` (userns `EPERM` on this container), a missing `gh` CLI, and git-push sandboxing. None are in the modules this PR touches.

no issue closed: this is the first stage of the KAS backend work and has no tracked issue; the follow-ups below are scoped for their own.

## Follow-ups

- **Custom-agent delivery** — `_meta.kiro.customAgents` on `session/new`. This is what makes `kas` selectable; the pinned real-KAS test flips when it lands.
- **Protocol adaptation** — the remaining unmapped methods, most impactfully `_kiro.dev/metadata` → `session_info_update`, `_kiro.dev/commands/execute` → `session/prompt` + `_meta.kiro.commandId`, and `_kiro.dev/session/terminate`.
- **`_native_subagent_sync`** — full-list reconciliation vs KAS's per-frame `_meta.kiro.agentSubtaskId`.
- **Asset-layout coupling** — `kas_assets.py` tracks kiro-cli's undocumented extraction layout. No published contract exists to handshake against; bounded by a loud failure naming both override env vars, and inert while the backend is unselectable.
- **Spec-tree docs** (`acp-client.md` / `providers.md` / `session.md`) still describe a two-backend world — deferred because the follow-ups above reshape the KAS surface substantially.
