### PR TITLE
fix(mochi): guard native Settings close against unsaved edits (#3326)

### DIFF
--- a/website/electron/mochi/pet-preload.js
+++ b/website/electron/mochi/pet-preload.js
@@ -162,6 +162,22 @@ exposePetApi({
   // dismiss any more).
   closeSettings: () => ipcRenderer.send("mochi-settings:close"),
   /**
+   * Main -> renderer: the native close button was clicked; run the Unsaved
+   * Changes guard instead of dying. The acknowledgement goes back AFTER the
+   * subscriber returns, so a subscriber that throws never acks and the shell's
+   * bounded fallback destroys the window rather than leaving it unclosable.
+   * The shell verifies the ack came from the window it asked, so one Settings
+   * window cannot acknowledge another's request.
+   */
+  onSettingsCloseRequested: (cb) => {
+    const handler = () => {
+      cb();
+      ipcRenderer.send("mochi-settings:close-request-ack");
+    };
+    ipcRenderer.on("mochi-settings:close-request", handler);
+    return () => ipcRenderer.removeListener("mochi-settings:close-request", handler);
+  },
+  /**
    * Hide/show every Mochi window — the same toggle the hideAll accelerator
    * drives. The pet's context menu "Hide" means THIS, not disabling the app:
    * disabling tears the app down through the app manager and takes seconds.

--- a/website/electron/mochi/settingsWindow.js
+++ b/website/electron/mochi/settingsWindow.js
@@ -10,11 +10,15 @@
  * conversation and squeezed a form the original gave 420px into the 320px panel.
  * Settings is a utility window in the original and is one here again.
  *
- * WHY NO CLOSE INTERCEPTOR
- * The original intercepted `close` to ask its renderer about unsaved edits (with
- * a 2s force-close fallback for a wedged renderer). Our panel persists every
- * control on change — there is no staged, unsaved state to lose — so a plain
- * close is correct and the interceptor would only add a way to get stuck.
+ * WHY THE CLOSE INTERCEPTOR EXISTS
+ * The Settings renderer stages every control locally until Save, so destroying
+ * the window on the native close button would silently drop pending edits. The
+ * `close` handler therefore asks the renderer first (it runs the Unsaved
+ * Changes guard) and only destroys once the renderer decides — with a bounded
+ * force-close fallback so a wedged or absent renderer can never leave an
+ * unclosable always-on-top window. The explicit teardown paths (Save/Discard,
+ * disable, shutdown, instance switching) call closeSettingsWindow(), whose
+ * destroy() never emits `close`, so they bypass the guard by construction.
  *
  * The open channel is registered at MODULE LOAD, not on first open: registering
  * lazily inside the open function is what silently broke the Avatars window
@@ -36,9 +40,23 @@ const WIN_MIN_H = 420;
 // First-paint title; the renderer refines it per language via document.title,
 // which Electron mirrors onto the window.
 const SETTINGS_TITLE = "⚙️ Settings";
+// How long the shell waits for the renderer to acknowledge a close request
+// before force-destroying the window. Long enough for a healthy renderer's
+// event loop to run the subscriber; short enough that a wedged renderer does
+// not read as a window that refuses to close. Matches the original's fallback.
+const CLOSE_ACK_TIMEOUT_MS = 2000;
 
 /** @type {BrowserWindow|null} */
 let settingsWindow = null;
+/**
+ * Force-close timer for the ONE close request that may be in flight. Doubles as
+ * the pending marker: non-null means a request was sent and not yet
+ * acknowledged, so repeated clicks on the native close button cannot queue
+ * duplicate requests or stack timers. Cleared on acknowledgement and when the
+ * window goes away.
+ * @type {ReturnType<typeof setTimeout>|null}
+ */
+let closeAckTimer = null;
 let lastBaseUrl = "";
 /** First-load token for a REMOTE instance; "" for the local gateway. */
 let lastToken = "";
@@ -85,15 +103,57 @@ function openSettingsWindow(baseUrl, token = "") {
   const reveal = () => {
     if (!win.isDestroyed() && !win.isVisible()) win.show();
   };
+  // The close guard only makes sense once the renderer has a frame: before
+  // did-finish-load nothing is staged and there is no subscriber, and a
+  // webContents.send to a frameless renderer is dropped SILENTLY (not thrown),
+  // which would stall the close for the full ack timeout instead of closing.
+  let rendererLoaded = false;
   win.once("ready-to-show", reveal);
-  win.webContents.once("did-finish-load", reveal);
+  win.webContents.once("did-finish-load", () => {
+    rendererLoaded = true;
+    reveal();
+  });
+
+  // Native close (the red x) asks the renderer first — see the module
+  // docstring. The acknowledgement means "a subscriber ran the close guard";
+  // until it arrives, the bounded timer is the only thing standing between a
+  // wedged renderer and an unclosable always-on-top window.
+  win.on("close", (event) => {
+    // Pre-load there are no edits to guard — let the default close destroy.
+    if (!rendererLoaded) return;
+    event.preventDefault();
+    // At most one request in flight: a second click while the renderer is
+    // still deciding must not re-fire the guard or stack force-close timers.
+    if (closeAckTimer !== null) return;
+    try {
+      win.webContents.send("mochi-settings:close-request");
+    } catch {
+      // The renderer is gone (webContents destroyed mid-close); there is
+      // nobody to guard the edits, so an unclosable window is the only thing
+      // left to prevent.
+      win.destroy();
+      return;
+    }
+    closeAckTimer = setTimeout(() => {
+      closeAckTimer = null;
+      if (!win.isDestroyed()) win.destroy();
+    }, CLOSE_ACK_TIMEOUT_MS);
+  });
 
   win.on("closed", () => {
+    clearPendingCloseRequest();
     settingsWindow = null;
   });
 
   win.loadURL(mochiPageUrl(lastBaseUrl, "settings.html", lastToken));
   return win;
+}
+
+function clearPendingCloseRequest() {
+  if (closeAckTimer !== null) {
+    clearTimeout(closeAckTimer);
+    closeAckTimer = null;
+  }
 }
 
 function closeSettingsWindow() {
@@ -108,6 +168,18 @@ function isSettingsWindowOpen() {
 // Eager registration — see the module docstring.
 ipcMain.on("mochi-pet:open-settings", () => openSettingsWindow(lastBaseUrl));
 ipcMain.on("mochi-settings:close", () => closeSettingsWindow());
+// The acknowledgement is bound to the CURRENT Settings window's own renderer:
+// a stale window's late ack (destroyed and replaced while a request was in
+// flight) must not clear a request that belongs to its successor.
+ipcMain.on("mochi-settings:close-request-ack", (event) => {
+  if (
+    settingsWindow &&
+    !settingsWindow.isDestroyed() &&
+    event.sender === settingsWindow.webContents
+  ) {
+    clearPendingCloseRequest();
+  }
+});
 
 module.exports = {
   openSettingsWindow,
@@ -116,4 +188,5 @@ module.exports = {
   setSettingsBaseUrl,
   WIN_W,
   WIN_H,
+  CLOSE_ACK_TIMEOUT_MS,
 };

--- a/website/electron/mochi/test/pet-preload.test.js
+++ b/website/electron/mochi/test/pet-preload.test.js
@@ -188,3 +188,47 @@ test("never exposes credential getters, tunnel controls, or a generic relay", ()
     assert.strictEqual(api[name], undefined, `pet-preload must not expose ${name}`);
   }
 });
+
+// ── Settings native-close guard (preload side) ──────────────────────────────
+//
+// The shell intercepts the Settings BrowserWindow `close` and asks the
+// renderer; this seam is the renderer's half. The acknowledgement contract is
+// exact: sent AFTER the subscriber returns, never when it throws — the shell's
+// bounded fallback force-closes a renderer that fails to ack, which is the
+// only thing standing between a wedged renderer and an unclosable window.
+
+test("onSettingsCloseRequested subscribes, acks after the callback, unsubscribes", () => {
+  const { api, sent, listeners } = loadPreload();
+  assert.strictEqual(typeof api.onSettingsCloseRequested, "function");
+
+  let fired = 0;
+  const off = api.onSettingsCloseRequested(() => { fired += 1; });
+  assert.strictEqual((listeners["mochi-settings:close-request"] || []).length, 1);
+
+  sent.length = 0;
+  listeners["mochi-settings:close-request"][0]();
+  assert.strictEqual(fired, 1);
+  assert.deepStrictEqual(
+    sent.map((s) => s.channel),
+    ["mochi-settings:close-request-ack"],
+    "the ack must go back after the subscriber runs",
+  );
+
+  off();
+  assert.strictEqual(
+    (listeners["mochi-settings:close-request"] || []).length,
+    0,
+    "must remove its listener",
+  );
+});
+
+test("a throwing close subscriber never acks, so the shell fallback can fire", () => {
+  const { api, sent, listeners } = loadPreload();
+  api.onSettingsCloseRequested(() => {
+    throw new Error("renderer wedged");
+  });
+
+  sent.length = 0;
+  assert.throws(() => listeners["mochi-settings:close-request"][0]());
+  assert.deepStrictEqual(sent, [], "no ack may be sent when the subscriber throws");
+});

--- a/website/electron/mochi/test/settingsWindow.test.js
+++ b/website/electron/mochi/test/settingsWindow.test.js
@@ -26,9 +26,11 @@ function stubElectron() {
       this.focused = false;
       this.loadedUrl = null;
       this.events = {};
+      this.wcSent = [];
       this.webContents = {
         once: (name, fn) => { this.events[`wc:${name}`] = fn; },
         on: (name, fn) => { this.events[`wc:${name}`] = fn; },
+        send: (channel, ...args) => { this.wcSent.push({ channel, args }); },
       };
       created.push(this);
     }
@@ -40,7 +42,9 @@ function stubElectron() {
     focus() { this.focused = true; }
     isVisible() { return this.visible; }
     isDestroyed() { return this.destroyed; }
-    destroy() { this.destroyed = true; }
+    // Real Electron emits `closed` after destroy(); the module's pending-state
+    // cleanup hangs off that event, so the fake must be faithful here.
+    destroy() { this.destroyed = true; this.events["closed"]?.(); }
     emit(name, ...args) { this.events[name]?.(...args); }
   }
 
@@ -140,4 +144,168 @@ test("reveals itself on did-finish-load even if ready-to-show never fires", () =
   assert.strictEqual(win.visible, false);
   win.events["wc:did-finish-load"]();
   assert.strictEqual(win.visible, true);
+});
+
+// ── Native close guard ──────────────────────────────────────────────────────
+//
+// The Settings renderer stages every control until Save, so the native close
+// button must run the same Unsaved Changes guard as the in-panel Cancel. These
+// pin the seam: intercept-and-ask instead of destroy, one pending request at a
+// time, a sender-bound acknowledgement, and a bounded force-close fallback so
+// a wedged renderer can never leave an unclosable always-on-top window.
+
+function fakeCloseEvent() {
+  return {
+    prevented: false,
+    preventDefault() { this.prevented = true; },
+  };
+}
+
+/** Open the settings window and simulate the renderer finishing its load —
+ *  the precondition for the close guard to be armed. */
+function openLoadedWindow(mod, created) {
+  mod.openSettingsWindow("http://127.0.0.1:5476");
+  const win = created[created.length - 1];
+  win.events["wc:did-finish-load"]();
+  return win;
+}
+
+test("a close before the renderer has loaded is NOT intercepted", () => {
+  // Pre-load there is no subscriber and nothing staged; a send to a frameless
+  // renderer is dropped silently, so intercepting here would stall the close
+  // for the full ack timeout. The default (destroy) must proceed instead.
+  const { mod, created } = loadModule();
+  mod.openSettingsWindow("http://127.0.0.1:5476");
+  const win = created[0];
+
+  const event = fakeCloseEvent();
+  win.emit("close", event);
+
+  assert.strictEqual(event.prevented, false);
+  assert.strictEqual(win.wcSent.length, 0);
+});
+
+test("native close asks the renderer instead of destroying", () => {
+  const { mod, created } = loadModule();
+  const win = openLoadedWindow(mod, created);
+
+  const event = fakeCloseEvent();
+  win.emit("close", event);
+
+  assert.strictEqual(event.prevented, true);
+  assert.strictEqual(win.destroyed, false);
+  assert.deepStrictEqual(
+    win.wcSent.map((s) => s.channel),
+    ["mochi-settings:close-request"],
+  );
+});
+
+test("repeated native close clicks do not queue duplicate requests", () => {
+  const { mod, created } = loadModule();
+  const win = openLoadedWindow(mod, created);
+
+  win.emit("close", fakeCloseEvent());
+  const second = fakeCloseEvent();
+  win.emit("close", second);
+
+  // Still intercepted (the window must not die), but only ONE request went out.
+  assert.strictEqual(second.prevented, true);
+  assert.strictEqual(win.wcSent.length, 1);
+});
+
+test("an acknowledged request disarms the force-close fallback", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const { mod, created, ipcHandlers } = loadModule();
+  const win = openLoadedWindow(mod, created);
+
+  win.emit("close", fakeCloseEvent());
+  ipcHandlers["mochi-settings:close-request-ack"]({ sender: win.webContents });
+  t.mock.timers.tick(mod.CLOSE_ACK_TIMEOUT_MS + 1);
+
+  // The renderer took over (it shows the dialog or closes itself); the shell
+  // must not yank the window out from under it.
+  assert.strictEqual(win.destroyed, false);
+});
+
+test("after an acknowledgement, the next close click sends a fresh request", () => {
+  const { mod, created, ipcHandlers } = loadModule();
+  const win = openLoadedWindow(mod, created);
+
+  win.emit("close", fakeCloseEvent());
+  ipcHandlers["mochi-settings:close-request-ack"]({ sender: win.webContents });
+  win.emit("close", fakeCloseEvent());
+
+  assert.strictEqual(win.wcSent.length, 2);
+});
+
+test("the acknowledgement is sender-bound: another webContents cannot clear it", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const { mod, created, ipcHandlers } = loadModule();
+  const win = openLoadedWindow(mod, created);
+
+  win.emit("close", fakeCloseEvent());
+  // An ack from some OTHER window's renderer must not disarm the fallback.
+  ipcHandlers["mochi-settings:close-request-ack"]({ sender: { not: "ours" } });
+  t.mock.timers.tick(mod.CLOSE_ACK_TIMEOUT_MS + 1);
+
+  assert.strictEqual(win.destroyed, true);
+});
+
+test("a silent renderer is force-closed after the timeout", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const { mod, created } = loadModule();
+  const win = openLoadedWindow(mod, created);
+
+  win.emit("close", fakeCloseEvent());
+  assert.strictEqual(win.destroyed, false);
+  t.mock.timers.tick(mod.CLOSE_ACK_TIMEOUT_MS + 1);
+
+  assert.strictEqual(win.destroyed, true);
+  assert.strictEqual(mod.isSettingsWindowOpen(), false);
+});
+
+test("a renderer that cannot be reached is force-closed immediately", () => {
+  const { mod, created } = loadModule();
+  const win = openLoadedWindow(mod, created);
+  win.webContents.send = () => {
+    throw new Error("webContents destroyed");
+  };
+
+  win.emit("close", fakeCloseEvent());
+
+  assert.strictEqual(win.destroyed, true);
+  assert.strictEqual(mod.isSettingsWindowOpen(), false);
+});
+
+test("the renderer's own close channel still destroys during a pending request", () => {
+  // Save/Discard resolve the guard by closing through mochi-settings:close;
+  // that path must stay an unconditional destroy, never re-enter the guard.
+  const { mod, created, ipcHandlers } = loadModule();
+  const win = openLoadedWindow(mod, created);
+
+  win.emit("close", fakeCloseEvent());
+  ipcHandlers["mochi-settings:close"]();
+
+  assert.strictEqual(win.destroyed, true);
+  assert.strictEqual(mod.isSettingsWindowOpen(), false);
+});
+
+test("a pending request from a destroyed window cannot leak into its successor", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const { mod, created, ipcHandlers } = loadModule();
+  const first = openLoadedWindow(mod, created);
+
+  // Request in flight on the first window, then it is torn down explicitly.
+  first.emit("close", fakeCloseEvent());
+  ipcHandlers["mochi-settings:close"]();
+
+  // A new window's close must send its own request (pending state was cleared).
+  const second = openLoadedWindow(mod, created);
+  second.emit("close", fakeCloseEvent());
+  assert.strictEqual(second.wcSent.length, 1);
+
+  // And the FIRST window's late ack must not disarm the second's fallback.
+  ipcHandlers["mochi-settings:close-request-ack"]({ sender: first.webContents });
+  t.mock.timers.tick(mod.CLOSE_ACK_TIMEOUT_MS + 1);
+  assert.strictEqual(second.destroyed, true);
 });

--- a/website/src/apps/mochi/src/mochiApi.ts
+++ b/website/src/apps/mochi/src/mochiApi.ts
@@ -70,6 +70,13 @@ import type { PetdexInstalled, PetdexPet } from '../petdexImport'
  */
 interface ShellChannels {
   closeSettings?: () => void
+  /**
+   * The native close button was clicked on the Settings window. The shell
+   * intercepts the BrowserWindow `close` and asks the renderer, so the same
+   * Unsaved Changes guard that covers the in-panel Cancel covers the red x;
+   * with no shell there is no native chrome, so the member is simply absent.
+   */
+  onSettingsCloseRequested?: (cb: () => void) => () => void
   // Field names match the shell's own hit test (petWindow.js inRect reads w/h).
   setMenuHitbox?: (rect: { x: number; y: number; w: number; h: number } | null) => void
   menuOpened?: () => void
@@ -160,7 +167,6 @@ interface UnimplementedUpstream {
   sendCaptureRegion?: (region: unknown) => void
   /** In-panel navigation — Settings and Avatars are separate windows here. */
   onNavigate?: (cb: (route: string) => void) => () => void
-  onSettingsCloseRequested?: (cb: () => void) => () => void
   /** A generic IPC relay is on the preload's never-expose list. */
   send?: never
 }

--- a/website/src/apps/mochi/src/renderer/SettingsPanel.tsx
+++ b/website/src/apps/mochi/src/renderer/SettingsPanel.tsx
@@ -121,7 +121,14 @@ export const SettingsPanel: React.FC<{ onClose: () => void }> = ({ onClose }) =>
 
   // Listen for native window close (red × button)
   useEffect(() => {
-    const off = api?.onSettingsCloseRequested?.(() => handleClose())
+    const off = api?.onSettingsCloseRequested?.(() => {
+      // Before the config loads nothing is staged, so a native close may
+      // proceed immediately — and must not touch handleClose, whose const
+      // binding sits below the loading early-return and is still in TDZ on
+      // this render's closure.
+      if (!config || !original) { onClose(); return }
+      handleClose()
+    })
     return () => { off?.() }
   })
 


### PR DESCRIPTION
## Problem

Mochi's Settings window stages every control locally until Save, and the renderer already treats Cancel as a guarded close by subscribing to `api.onSettingsCloseRequested` — but production never supplied that subscription. `pet-preload.js` exposed only `closeSettings`, the Mochi API type listed `onSettingsCloseRequested` under `UnimplementedUpstream`, and `settingsWindow.js` never intercepted the Settings BrowserWindow `close` event. Clicking the native window close button therefore destroyed the window directly, bypassing the existing Unsaved Changes dialog and silently dropping pending edits. Renderer tests passed because they mock a subscription production did not have.

Closes #3326

## Why it matters

Losing staged edits with no warning is silent data loss in a settings surface: a user who fills in several sections and closes the window with the red × gets no dialog, no error, and a form that quietly reverted. The in-panel Cancel button and the native close button behaved differently for no visible reason.

## Fix

Symptoms → root cause → change:

- **Root cause:** the main-to-renderer close-request seam was never wired; the renderer's guard was subscribed to an event nothing sends.
- **`website/electron/mochi/settingsWindow.js`** — intercept the BrowserWindow `close` event once the renderer has finished loading: `preventDefault`, send one `mochi-settings:close-request` to the window's own webContents, and track at most one pending request (repeated clicks cannot queue duplicates or stack timers). A bounded fallback (`CLOSE_ACK_TIMEOUT_MS`, 2s, matching upstream) destroys the window when the renderer is unreachable, throws, or never acknowledges — a wedged renderer must never leave an unclosable always-on-top window. Before `did-finish-load` the guard is deliberately not armed: nothing is staged yet, there is no subscriber, and a send to a frameless renderer is dropped silently, so the default destroy is both correct and instant. `closeSettingsWindow()` (used by Save/Discard, disable, shutdown, and instance switching) still calls `destroy()`, which never emits `close`, so those paths bypass the guard by construction.
- **`website/electron/mochi/pet-preload.js`** — expose the `onSettingsCloseRequested` subscribe/unsubscribe pair. The acknowledgement is sent back only after the subscriber returns, so a throwing subscriber never acks and the fallback fires. The main process verifies `event.sender` against the current Settings window's webContents, so one Settings window cannot acknowledge another's request.
- **`website/src/apps/mochi/src/mochiApi.ts`** — promote `onSettingsCloseRequested` out of `UnimplementedUpstream` into `ShellChannels`, making the existing `SettingsPanel` subscription live.
- **`website/src/apps/mochi/src/renderer/SettingsPanel.tsx`** — guard the close callback during the loading render: before the config resolves nothing is staged, so a native close proceeds immediately instead of touching `handleClose`, whose `const` binding sits below the loading early-return (TDZ on that render's closure).

Known tradeoff, stated deliberately: if the renderer's event loop is blocked for longer than the 2-second acknowledgement window when the request arrives, the fallback destroys the window and any staged edits with it. An unclosable always-on-top window was judged worse than this narrow loss, matching the original app's 2s fallback; the ack is sent synchronously after the subscriber runs, so only a genuinely wedged renderer reaches the timeout.

## Tests

Electron suite (`website/electron/mochi/test/`), all stub-driven `node --test`:

- `settingsWindow.test.js` (+10): close interception fires the request instead of destroying; a pre-load close is not intercepted; repeated clicks send one request; an ack disarms the fallback and re-arms on the next click; the ack is sender-bound (a foreign webContents cannot disarm it, and a destroyed predecessor's late ack cannot leak into a successor); a silent renderer is force-closed after the timeout; an unreachable renderer is force-closed immediately; the renderer's own close channel still destroys during a pending request.
- `pet-preload.test.js` (+2): subscribe registers/unsubscribes the channel listener and acks after the callback; a throwing subscriber never acks.

Non-vacuity proven: with the production change reverted, 10 of the new tests fail.

Full local gates: `npx tsc -b` clean; touched vitest suites (MochiSettingsPanel.coverage, mochiSettingsSaveReveal, mochiApiSeam) 93 tests pass; Electron mochi suites 29/29; backend isort/flake8 clean (no backend files changed).

## Manual verification

Verified via the stubbed Electron test harness rather than a packaged app (the fix is in the main-process seam, which the stubs exercise directly). The full renderer path — subscription in `SettingsPanel`, dialog on dirty state, `closeSettings` destroy on Save/Discard — is covered by the existing renderer tests that previously mocked this seam and now describe production behavior.

## Screenshots

<!-- no-visual-delta -->
**Why no screenshot:** No UI pixels change — the fix wires a main↔renderer IPC seam (a non-rendering Electron close-event interception); the Unsaved Changes dialog it makes reachable already exists and is unchanged.

## Review notes

Two model-pinned pre-push reviewers ran: GPT 5.6 Sol (zero findings) and Opus 5 (zero blocking, 4 advisories — the TDZ guard and the pre-load close handling above were adopted from them; the bounded-fallback tradeoff is stated in the Fix section).

