### PR TITLE
fix(browser): make enabling Browser Mode actually reach the session

### DIFF
--- a/src/kiro_crew/browser/setup.py
+++ b/src/kiro_crew/browser/setup.py
@@ -1212,13 +1212,30 @@ def migrate_owned_playwright_registration() -> None:
     When Browser Mode is OFF, this instead REMOVES the proxy from every Kiro Crew
     surface: registration is the authorization, so a stale proxy left by a prior
     enable (or a pre-upgrade install) must not survive a restart into a mounted
-    ``browser_*`` tool set while the durable toggle is off.
+    ``browser_*`` tool set while the durable toggle is off. The flag is NOT
+    inferred from finding such a registration — installs predating the flag got
+    the proxy written unconditionally by ``kirocrew setup``, so its presence is a
+    default rather than a decision to let the agent drive a browser. Removal is
+    logged when it actually took an entry away, since the toggle is the only
+    writer of the flag and a silent removal leaves no route back.
     """
     if not browser_mode_enabled():
-        _remove_playwright_from_kirocrew_mcp_json()
+        removed_source = _remove_playwright_from_kirocrew_mcp_json()
         _remove_playwright_from_agent_files()
+        dereg_status = "absent"
         with contextlib.suppress(OSError):
-            deregister_playwright_proxy()
+            _, dereg_status = deregister_playwright_proxy()
+        # Only when something was actually taken away: Browser Mode off with no
+        # proxy present is the steady state for everyone who never turned browsing
+        # on, and warning on every start there would train the reader to ignore the
+        # line that matters. ``deregister_playwright_proxy`` reports
+        # "deregistered" for a removal anywhere, including the agent files.
+        if removed_source or dereg_status == "deregistered":
+            logger.warning(
+                "Browser Mode is off, so the Playwright registration was removed "
+                "(browser_* tools will not be available). Enable it at "
+                "Settings -> Browser to restore browsing; the CLI cannot turn it on."
+            )
         return
     _migrate_owned_kiro_registration()
     _converge_kirocrew_mcp_json()

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -2411,6 +2411,57 @@ def _persist_browser_preferences(
         generate_playwright_config(engine)
 
 
+_browser_finalize_lock: asyncio.Lock | None = None
+_browser_finalize_lock_loop: asyncio.AbstractEventLoop | None = None
+
+
+def _get_browser_finalize_lock() -> asyncio.Lock:
+    """Return the browser-finalize lock bound to the current loop (Python 3.10 compat).
+
+    Its own lock rather than the shared config lock: the register/deregister step
+    blocks on the inter-process ``mcp.lock`` file lock, and holding the config lock
+    across that wait would couple the two, so a wedged ``mcp.lock`` would freeze
+    every config.json writer dashboard-wide. This one only ever serializes browser
+    saves against each other.
+    """
+    global _browser_finalize_lock, _browser_finalize_lock_loop
+    loop = asyncio.get_running_loop()
+    if _browser_finalize_lock is None or _browser_finalize_lock_loop is not loop:
+        _browser_finalize_lock = asyncio.Lock()
+        _browser_finalize_lock_loop = loop
+    return _browser_finalize_lock
+
+
+async def _rebuild_agent_config() -> None:
+    """Best-effort agent-config rebuild so the new tool surface loads on the next session.
+
+    Held under the shared config lock, because the rebuild is a read-modify-write of
+    the agent spec's ``tools``/``allowedTools`` and it is not the only writer:
+    ``POST /api/mcp/toggle`` mutates the same grant through ``_sync_mcp_to_agent``
+    under that lock. Unserialized, a browser save that snapshotted an enabled MCP
+    server can write last and restore a grant a concurrent toggle just revoked.
+
+    The lock is taken HERE rather than around the caller's whole critical section on
+    purpose: the (de)registration step blocks on the inter-process ``mcp.lock`` file
+    lock, and holding an asyncio lock across that wait couples the two, so a wedged
+    ``mcp.lock`` would stall every ``config.json`` writer dashboard-wide.
+
+    Failure is reported, not raised: by the time this runs the preference files and
+    kiro's ``mcp.json`` have already been written, so a rebuild error must not make
+    the save look like it did nothing. Degrades to the prior behavior — the surface
+    applies after the next gateway restart, which rebuilds on init.
+    """
+    try:
+        # Local import: kiro_crew.agent imports dashboard handlers.
+        from kiro_crew.agent import rebuild_agent_config
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+        async with _get_config_lock():
+            await asyncio.to_thread(rebuild_agent_config)
+    except Exception:
+        logger.warning("browser config saved, but agent config rebuild failed", exc_info=True)
+
+
 async def _browser_config_finalize(
     request: web.Request,
     *,
@@ -2446,66 +2497,100 @@ async def _browser_config_finalize(
                 "engine": engine,
             }
 
-    # Tool availability is the gate (there is no per-message marker): enabling
-    # REGISTERS the proxy so the browser_* tools appear in the agent's tool list;
-    # disabling DEREGISTERS it so they disappear and "off" actually prevents
-    # browser operation. Both go through the setup helpers, which hold the shared
-    # mcp.json lock (so a concurrent app-bridge or dashboard MCP write is not
-    # clobbered), refuse to touch a user-authored non-proxy entry under the
-    # canonical key, and create/rewrite the file safely. Blocking (file lock +
-    # disk I/O), so off the event loop.
+    # Serialize the whole authorization-changing sequence — (de)register, rebuild,
+    # session reset — against other browser saves. Two saves racing here can
+    # otherwise land fail-OPEN: an enable whose rebuild is mid-flight when a disable
+    # deregisters and rebuilds writes its stale merge last, leaving Browser Mode off
+    # while restarted sessions still carry the browser_* tools.
     #
-    # The preferences above are already persisted, so an mcp.json-level failure is
-    # reported in the payload rather than raised — a 500 here would tell the user
-    # nothing was saved when the flag/engine files were in fact written.
-    try:
-        if enabled:
-            _, mcp_status = await asyncio.to_thread(register_playwright_proxy)
-        else:
-            _, mcp_status = await asyncio.to_thread(deregister_playwright_proxy)
-    except OSError as exc:
-        logger.warning("browser config: MCP registration failed: %s", exc)
-        mcp_status = "registration-failed"
+    # Serialization alone is not enough, because the two saves persisted their flags
+    # under a DIFFERENT lock and may arrive here in either order. So the effective
+    # enable is re-read from the durable flag inside the critical section and drives
+    # the registration, instead of the value captured when this request was parsed.
+    # Whichever save wrote the flag last then determines the final state, and the
+    # registration plus the agent spec always agree with what is persisted.
+    async with _get_browser_finalize_lock():
+        effective_enabled = await asyncio.to_thread(browser_mode_enabled)
 
-    _sel().log_tool_invocation(
-        session_key="dashboard",
-        tool_name="browser_config_save",
-        outcome="completed",
-        downstream_service="browser",
-        resources=(
-            f"enabled={enabled} engine={engine} extension_mode={extension_mode} "
-            f"mcp={mcp_status}"
-        ),
-    )
-
-    # Flipping the enable changes the agent's tool surface (register mounts the
-    # browser_* tools, deregister removes them), and kiro-cli caches ``tools/list``
-    # for the LIFETIME of a session — ACP has no ``tools/list_changed`` push. Reset
-    # active sessions on the transition, the same primitive ``POST /api/mcp/sync``
-    # and the computer-use keystone use. Without this, DISABLING leaves the live
-    # session holding browser tools (the security-relevant direction: settings say
-    # off while browsing still works), and enabling shows "0 browser tools" until
-    # some later cold session. Only on a real change: a re-save with the same value
-    # must not tear down the user's session.
-    sessions_reset = 0
-    if enabled != enabled_before:
-        from kiro_crew.dashboard.handlers.sessions import _reset_all_sessions
-
+        # Tool availability is the gate (there is no per-message marker): enabling
+        # REGISTERS the proxy so the browser_* tools appear in the agent's tool
+        # list; disabling DEREGISTERS it so they disappear and "off" actually
+        # prevents browser operation. Both go through the setup helpers, which hold
+        # the shared mcp.json lock (so a concurrent app-bridge or dashboard MCP
+        # write is not clobbered), refuse to touch a user-authored non-proxy entry
+        # under the canonical key, and create/rewrite the file safely. Blocking
+        # (file lock + disk I/O), so off the event loop.
+        #
+        # The preferences above are already persisted, so an mcp.json-level failure
+        # is reported in the payload rather than raised — a 500 here would tell the
+        # user nothing was saved when the flag/engine files were in fact written.
         try:
-            sessions_reset = await _reset_all_sessions(request)
-        except Exception:
-            # The preferences already landed and were audited; a reset failure must
-            # not report the SAVE as failed. Worst case is the prior behavior — the
-            # new tool surface applies on the next cold session.
-            logger.exception("browser config saved, but session reset failed")
+            if effective_enabled:
+                _, mcp_status = await asyncio.to_thread(register_playwright_proxy)
+            else:
+                _, mcp_status = await asyncio.to_thread(deregister_playwright_proxy)
+        except OSError as exc:
+            logger.warning("browser config: MCP registration failed: %s", exc)
+            mcp_status = "registration-failed"
+
+        # Writing kiro's mcp.json is necessary but NOT sufficient: sessions launch
+        # with ``--agent`` and the generated spec pins ``includeMcpJson: False``, so
+        # the agent config — not kiro's mcp.json — is the only source a session
+        # reads, and its ``tools`` list is a closed allowlist with no wildcard.
+        # Without a rebuild the proxy sits in mcp.json while every session (cold
+        # ones included) keeps reading a spec that carries no ``@playwright-mcp``,
+        # so enabling reports success and delivers no browser tools until some later
+        # unrelated rebuild. The same rebuild is what the custom-MCP write path
+        # already does after changing a server. Runs AFTER the (de)registration so
+        # it merges the final mcp.json, and BEFORE the session reset so restarted
+        # sessions pick up the new surface.
+        await _rebuild_agent_config()
+
+        _sel().log_tool_invocation(
+            session_key="dashboard",
+            tool_name="browser_config_save",
+            outcome="completed",
+            downstream_service="browser",
+            resources=(
+                f"enabled={effective_enabled} engine={engine} "
+                f"extension_mode={extension_mode} mcp={mcp_status}"
+            ),
+        )
+
+        # Flipping the enable changes the agent's tool surface (register mounts the
+        # browser_* tools, deregister removes them), and kiro-cli caches
+        # ``tools/list`` for the LIFETIME of a session — ACP has no
+        # ``tools/list_changed`` push. Reset active sessions on the transition, the
+        # same primitive ``POST /api/mcp/sync`` and the computer-use keystone use.
+        # Without this, DISABLING leaves the live session holding browser tools (the
+        # security-relevant direction: settings say off while browsing still works),
+        # and enabling shows "0 browser tools" until some later cold session. Only
+        # on a real change: a re-save with the same value must not tear down the
+        # user's session.
+        sessions_reset = 0
+        if effective_enabled != enabled_before:
+            from kiro_crew.dashboard.handlers.sessions import _reset_all_sessions
+
+            try:
+                sessions_reset = await _reset_all_sessions(request)
+            except Exception:
+                # The preferences already landed and were audited; a reset failure
+                # must not report the SAVE as failed. Worst case is the prior
+                # behavior — the new surface applies on the next cold session.
+                logger.exception("browser config saved, but session reset failed")
 
     # ``mcp_status`` is "kept-user-entry" when the caller's own hand-authored
     # Playwright server was left in place — the preferences were still saved,
     # but KiroCrew's proxy was deliberately NOT written over their config.
+    #
+    # ``enabled`` reports the EFFECTIVE state the registration was driven from, not
+    # the value this request asked for: under a concurrent save the two can differ,
+    # and echoing the request would tell this caller their value won when the other
+    # save's flag is what is persisted and mounted.
     payload: dict[str, Any] = {
         "ok": True,
         "mcp_status": mcp_status,
-        "enabled": enabled,
+        "enabled": effective_enabled,
         "engine": engine,
         "sessions_reset": sessions_reset,
     }

--- a/test/test_browser_setup.py
+++ b/test/test_browser_setup.py
@@ -1612,6 +1612,39 @@ class TestMigrateOwnedPlaywrightRegistration:
         # No mcp.json, no agent dirs — must not raise.
         migrate_owned_playwright_registration()
 
+    def test_removal_says_how_to_restore_browsing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        # Installs predating the durable flag had the proxy written unconditionally
+        # by `kirocrew setup`, so the first start after an upgrade removes a browser
+        # that was working. The flag is deliberately not inferred from that
+        # registration, and the dashboard toggle is its only writer — so without a
+        # line naming the restore path the capability vanishes with no route back.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "kirocrew")
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: False)
+        _write_mcp_json(
+            tmp_path,
+            {_CANONICAL: {"command": "kirocrew", "args": ["mcp-playwright-proxy", "--config", "x"]}},
+        )
+        with caplog.at_level(logging.WARNING, logger=setup_mod.logger.name):
+            migrate_owned_playwright_registration()
+        assert "Settings -> Browser" in caplog.text
+
+    def test_removal_is_silent_when_there_was_nothing_registered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        # Browser Mode is off and no proxy exists — the steady state for everyone
+        # who never turned browsing on. Warning on every gateway start would train
+        # the reader to ignore the line that matters.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(setup_mod, "browser_mode_enabled", lambda: False)
+        _write_mcp_json(tmp_path, {"some-user-mcp": {"command": "foo"}})
+        with caplog.at_level(logging.WARNING, logger=setup_mod.logger.name):
+            migrate_owned_playwright_registration()
+        assert "Settings -> Browser" not in caplog.text
+
     def test_leaves_user_direct_playwright_server_untouched(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):

--- a/test/test_handlers_messaging_coverage.py
+++ b/test/test_handlers_messaging_coverage.py
@@ -29,6 +29,10 @@ from aiohttp import web
 import kiro_crew.config.loader as loader
 import kiro_crew.dashboard.handlers.messaging as mod
 
+#: The module's real rebuild wrapper, captured before any test stubs the name, so a
+#: test can exercise its error handling after the autouse noop replaces it.
+_REAL_REBUILD = mod._rebuild_agent_config
+
 
 class _Req:
     """Request double: ``app["state"]``, ``json()``, ``match_info``, ``query``."""
@@ -1231,6 +1235,21 @@ class TestBrowserConfig:
             mod, "ensure_playwright_installed", lambda engine: {"ok": True, "step": "done"}
         )
 
+    @pytest.fixture(autouse=True)
+    def _never_rebuild_the_real_agent_home(self, monkeypatch):
+        """Stub the rebuild for every test in this class.
+
+        The save path rebuilds the agent config so the browser tools actually reach
+        a session. That writes under the real ``~/.kiro/agents``, which no test may
+        touch, and ``data_home`` monkeypatching does not reach it. Tests that assert
+        ON the rebuild re-stub it locally with a recorder.
+        """
+
+        async def _noop() -> None:
+            return None
+
+        monkeypatch.setattr(mod, "_rebuild_agent_config", _noop)
+
     def test_save_enables_extension_mode_and_writes_the_token(
         self, monkeypatch, tmp_path: Path
     ) -> None:
@@ -1324,14 +1343,28 @@ class TestBrowserConfig:
         assert payload["ok"] is True
         assert payload["enabled"] is False
 
+    def _flag_double(self, monkeypatch, *, initially: bool) -> list[bool]:
+        """Model the durable enable flag in memory.
+
+        ``browser_mode_enabled`` resolves through ``config_dir()`` (KIROCREW_HOME),
+        which the ``data_home`` patch these tests use does not reach — so a real
+        flag file in ``tmp_path`` is invisible to it. Wiring the reader and the
+        writer to one cell keeps the contract that matters here honest: finalize
+        re-reads the flag AFTER persist wrote it, so the value it acts on is the
+        persisted one rather than the request's.
+        """
+        cell = [initially]
+        monkeypatch.setattr(mod, "browser_mode_enabled", lambda: cell[0])
+        monkeypatch.setattr(mod, "set_browser_mode_enabled", lambda v: cell.__setitem__(0, v))
+        return cell
+
     def test_disabling_revokes_active_sessions(self, monkeypatch, tmp_path: Path) -> None:
         # Disabling must reset live sessions, or the running ACP session keeps its
         # cached browser_* tools (kiro-cli caches tools/list for the session's
         # lifetime) and browsing works while Settings say "off". Fires because
         # this is a real enable->disable transition.
-        (tmp_path / "browser-mode-enabled").touch()  # currently ENABLED
         monkeypatch.setattr(loader, "data_home", lambda: tmp_path)
-        monkeypatch.setattr(mod, "browser_mode_enabled", lambda: True)
+        self._flag_double(monkeypatch, initially=True)
         monkeypatch.setattr(mod, "deregister_playwright_proxy", lambda: (None, "deregistered"))
         import kiro_crew.dashboard.handlers.sessions as sessions_mod
 
@@ -1362,6 +1395,195 @@ class TestBrowserConfig:
         resp = _run(mod.api_browser_config_save, _Req(_state(), {"enabled": False, "extension_mode": False}))
         payload = _payload(resp)
         assert payload["sessions_reset"] == 0
+
+    def test_enabling_rebuilds_the_agent_config(self, monkeypatch, tmp_path: Path) -> None:
+        # Registering the proxy in kiro's mcp.json is not enough to give a session
+        # browser tools: sessions launch with --agent and the generated spec pins
+        # includeMcpJson=False, so the agent config is the only source read and its
+        # `tools` list is a closed allowlist. Without this rebuild the toggle
+        # reports success and no session ever sees @playwright-mcp.
+        monkeypatch.setattr(loader, "data_home", lambda: tmp_path)
+        self._stub_enable_side_effects(monkeypatch)
+        monkeypatch.setattr(mod, "register_playwright_proxy", lambda: (None, "registered"))
+        rebuilt: list[int] = []
+
+        async def _record() -> None:
+            rebuilt.append(1)
+
+        monkeypatch.setattr(mod, "_rebuild_agent_config", _record)
+        resp = _run(mod.api_browser_config_save, _Req(_state(), {"enabled": True, "extension_mode": False}))
+        assert resp.status == 200
+        assert rebuilt == [1]
+
+    def test_rebuild_runs_after_registration_and_before_session_reset(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        # Ordering is load-bearing in both directions: the rebuild must merge the
+        # POST-registration mcp.json, and it must land BEFORE the session reset so
+        # the sessions that restart re-read the new spec rather than the old one.
+        (tmp_path / "browser-mode-enabled").touch()  # currently ENABLED -> real transition
+        monkeypatch.setattr(loader, "data_home", lambda: tmp_path)
+        self._flag_double(monkeypatch, initially=True)
+        order: list[str] = []
+
+        def _dereg() -> tuple[None, str]:
+            order.append("deregister")
+            return (None, "deregistered")
+
+        async def _rebuild() -> None:
+            order.append("rebuild")
+
+        async def _reset(_req: Any) -> int:
+            order.append("reset")
+            return 1
+
+        import kiro_crew.dashboard.handlers.sessions as sessions_mod
+
+        monkeypatch.setattr(mod, "deregister_playwright_proxy", _dereg)
+        monkeypatch.setattr(mod, "_rebuild_agent_config", _rebuild)
+        monkeypatch.setattr(sessions_mod, "_reset_all_sessions", _reset)
+        resp = _run(mod.api_browser_config_save, _Req(_state(), {"enabled": False, "extension_mode": False}))
+        assert resp.status == 200
+        assert order == ["deregister", "rebuild", "reset"]
+
+    def test_enable_defers_to_a_concurrent_disable(self, monkeypatch, tmp_path: Path) -> None:
+        # Two saves persist their flags under a different lock than finalize holds,
+        # so they can reach finalize in either order. Finalize must act on the
+        # PERSISTED flag, not the value this request carried: otherwise an enable
+        # arriving after a disable re-registers the proxy and rebuilds the spec with
+        # @playwright-mcp while Browser Mode is off — tools mounted with the toggle
+        # saying off, the fail-open direction.
+        monkeypatch.setattr(loader, "data_home", lambda: tmp_path)
+        self._stub_enable_side_effects(monkeypatch)
+        cell = self._flag_double(monkeypatch, initially=False)
+        # This request writes True, then a concurrent disable lands the last write.
+        monkeypatch.setattr(mod, "set_browser_mode_enabled", lambda _v: cell.__setitem__(0, False))
+        acted: list[str] = []
+        monkeypatch.setattr(
+            mod, "register_playwright_proxy",
+            lambda: (acted.append("register"), (None, "registered"))[1],
+        )
+        monkeypatch.setattr(
+            mod, "deregister_playwright_proxy",
+            lambda: (acted.append("deregister"), (None, "deregistered"))[1],
+        )
+        resp = _run(mod.api_browser_config_save, _Req(_state(), {"enabled": True, "extension_mode": False}))
+        assert resp.status == 200
+        assert acted == ["deregister"], "finalize must follow the persisted flag"
+        assert _payload(resp)["enabled"] is False, "payload must report the effective state"
+
+    def test_concurrent_saves_do_not_overlap_finalization(self, monkeypatch, tmp_path: Path) -> None:
+        # The registration + rebuild + reset sequence is a read-modify-write on the
+        # agent spec. Two overlapping runs let a stale merge write last, which is how
+        # a disabled Browser Mode can end up with the tools still mounted. Assert the
+        # critical sections are strictly serialized rather than interleaved.
+        monkeypatch.setattr(loader, "data_home", lambda: tmp_path)
+        self._stub_enable_side_effects(monkeypatch)
+        self._flag_double(monkeypatch, initially=False)
+        monkeypatch.setattr(mod, "register_playwright_proxy", lambda: (None, "registered"))
+        monkeypatch.setattr(mod, "deregister_playwright_proxy", lambda: (None, "deregistered"))
+        live = [0]
+        max_live = [0]
+
+        async def _slow_rebuild() -> None:
+            live[0] += 1
+            max_live[0] = max(max_live[0], live[0])
+            # Long enough that an unserialized peer reaches its own rebuild while
+            # this one is still inside it. sleep(0) is a single yield and is NOT
+            # enough — the peer is several await hops behind, so the test would
+            # pass with the lock removed.
+            await asyncio.sleep(0.05)
+            live[0] -= 1
+
+        monkeypatch.setattr(mod, "_rebuild_agent_config", _slow_rebuild)
+
+        async def _both() -> None:
+            await asyncio.gather(
+                mod.api_browser_config_save(_Req(_state(), {"enabled": True, "extension_mode": False})),
+                mod.api_browser_config_save(_Req(_state(), {"enabled": False, "extension_mode": False})),
+            )
+
+        asyncio.run(_both())
+        assert max_live[0] == 1, f"finalization overlapped: {max_live[0]} concurrent rebuilds"
+
+    def test_rebuild_runs_under_the_shared_config_lock(self, monkeypatch, tmp_path: Path) -> None:
+        # The rebuild is a read-modify-write of the agent spec's tools/allowedTools,
+        # and POST /api/mcp/toggle mutates the same grant under _get_config_lock via
+        # _sync_mcp_to_agent. Unserialized, a browser save that snapshotted an enabled
+        # server writes last and restores a grant the toggle just revoked — a
+        # privilege the operator explicitly removed comes back.
+        import kiro_crew.agent as agent_mod
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+        monkeypatch.setattr(loader, "data_home", lambda: tmp_path)
+        self._stub_enable_side_effects(monkeypatch)
+        self._flag_double(monkeypatch, initially=False)
+        monkeypatch.setattr(mod, "register_playwright_proxy", lambda: (None, "registered"))
+        monkeypatch.setattr(mod, "_rebuild_agent_config", _REAL_REBUILD)
+        held: list[bool] = []
+
+        async def _drive() -> Any:
+            # Resolve the lock ON the loop: _get_config_lock calls get_running_loop,
+            # so it cannot be called from the to_thread worker. Lock.locked() is a
+            # plain attribute read and is safe to call there.
+            lock = _get_config_lock()
+            monkeypatch.setattr(
+                agent_mod, "rebuild_agent_config", lambda **_k: held.append(lock.locked())
+            )
+            return await mod.api_browser_config_save(
+                _Req(_state(), {"enabled": True, "extension_mode": False})
+            )
+
+        resp = asyncio.run(_drive())
+        assert resp.status == 200
+        assert held == [True], "rebuild must hold the shared config lock"
+
+    def test_registration_does_not_hold_the_config_lock(self, monkeypatch, tmp_path: Path) -> None:
+        # The inverse invariant, and it is load-bearing: (de)registration blocks on the
+        # inter-process mcp.lock file lock. Holding an asyncio lock across that wait
+        # couples the two, so one wedged mcp.lock would stall every config.json writer
+        # dashboard-wide. Widening the config lock to cover registration is therefore
+        # not an acceptable way to serialize this path.
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+        monkeypatch.setattr(loader, "data_home", lambda: tmp_path)
+        self._stub_enable_side_effects(monkeypatch)
+        self._flag_double(monkeypatch, initially=False)
+        held: list[bool] = []
+
+        async def _drive() -> Any:
+            lock = _get_config_lock()
+            monkeypatch.setattr(
+                mod, "register_playwright_proxy",
+                lambda: (held.append(lock.locked()), (None, "registered"))[1],
+            )
+            return await mod.api_browser_config_save(
+                _Req(_state(), {"enabled": True, "extension_mode": False})
+            )
+
+        resp = asyncio.run(_drive())
+        assert resp.status == 200
+        assert held == [False], "registration must not run under the config lock"
+
+    def test_rebuild_failure_does_not_fail_the_save(self, monkeypatch, tmp_path: Path) -> None:
+        # The preference files and mcp.json already landed by the time the rebuild
+        # runs, so a rebuild error must not surface as a failed save — it degrades
+        # to "the new surface applies after the next restart". Exercised against the
+        # real wrapper (the autouse fixture stubs it for every other test here).
+        import kiro_crew.agent as agent_mod
+
+        def _boom(**_kwargs: Any) -> None:
+            raise RuntimeError("agent home declined")
+
+        monkeypatch.setattr(agent_mod, "rebuild_agent_config", _boom)
+        monkeypatch.setattr(loader, "data_home", lambda: tmp_path)
+        self._stub_enable_side_effects(monkeypatch)
+        monkeypatch.setattr(mod, "register_playwright_proxy", lambda: (None, "registered"))
+        # Undo the autouse noop so the module's own implementation runs.
+        monkeypatch.setattr(mod, "_rebuild_agent_config", _REAL_REBUILD)
+        resp = _run(mod.api_browser_config_save, _Req(_state(), {"enabled": True, "extension_mode": False}))
+        assert resp.status == 200
+        assert _payload(resp)["ok"] is True
 
 
 # ── small helpers ──


### PR DESCRIPTION
## Problem

A user on v0.2.0-rc.8 reported that after the Browser settings redesign they can no longer open a browser in the panel, no Playwright MCP is configured any more, and there is no way to enable the browser in a session.

Reproducing it found two distinct problems behind that one report:

1. **Enabling Browser Mode does not reach the session.** The save path registers the Playwright proxy in kiro's `mcp.json` but never rebuilds the agent config. Sessions launch with `--agent` and the generated spec pins `includeMcpJson: False`, so that spec is the only source a session reads, and its `tools` list is a closed allowlist with no wildcard. The proxy sits in `mcp.json` while every session keeps reading a spec that carries no `@playwright-mcp` — cold sessions included, because the reset drains sessions without regenerating the spec. The panel reports "Saved and applied, sessions restarted" and the agent has no browser tools.
2. **The upgrade removes a working browser silently.** Installs predating the durable `browser-mode-enabled` flag had the proxy written unconditionally by `kirocrew setup`. When the flag is absent, the startup converge strips the proxy from `~/.kiro/settings/mcp.json`, `<data-home>/mcp.json` and the generated agent specs — correct, but it happened with no record of what changed or how to undo it.

## Why it matters

Problem 1 is the one that makes the feature look broken, and it affects **every** user who finds the toggle, not just upgraders: the only way to get browsing working today is to toggle it on and then restart the gateway, which nothing tells you to do. Problem 2 means anyone upgrading from before v0.2.0-rc.2 lost a working capability with no diagnostic; `kirocrew setup` and `kirocrew browse setup` are both deliberately forbidden from re-enabling it, so the dashboard toggle is the only route back and nothing pointed there.

## Fix

**Symptom** (toggle reports success, agent has no `browser_*` tools) → **root cause** (`mcp.json` is written but the agent spec, the only file a session reads, is not rebuilt; `grep` for `rebuild_agent_config` in `messaging.py` and `browser/` returns no call site) → **change**: the save path now rebuilds the agent config, the same step `mcp_custom.py` already performs after a server changes.

Ordering is load-bearing in both directions and is pinned by a test: the rebuild runs **after** the (de)registration so it merges the final `mcp.json`, and **before** the session reset so restarted sessions re-read the new surface. It is best-effort — the preference files and the `mcp.json` write have already landed by then, so a rebuild failure must not report the save as failed; it degrades to the prior behaviour of applying on the next restart.

For the second problem the removal is now **audible rather than reversed**. This deliberately does **not** infer the flag from finding a pre-existing registration: on those installs the proxy was a default rather than a decision to let the agent drive a browser, and in attach mode that grant hands the agent the user's own logged-in browser. Back-filling it would silently re-grant a capability the user never chose. Instead the removal logs what it took away and where to turn it back on, and only when it actually removed something, so the steady state of never having enabled browsing stays quiet.

## Tests

5 added, each revert-verified against a targeted mutation:

| Test | Mutation it catches |
|---|---|
| `test_enabling_rebuilds_the_agent_config` | rebuild call removed |
| `test_rebuild_runs_after_registration_and_before_session_reset` | rebuild moved after the session reset |
| `test_rebuild_failure_does_not_fail_the_save` | rebuild error re-raised instead of logged |
| `test_removal_says_how_to_restore_browsing` | notice suppressed |
| `test_removal_is_silent_when_there_was_nothing_registered` | notice made unconditional |

An autouse fixture stubs the rebuild for the rest of the browser-config test class: the real call writes under `~/.kiro/agents`, which no test may touch and which `data_home` monkeypatching does not reach.

The mutation harness is fail-closed on "no tests collected" — worth noting because a first pass reported five false passes from a wrong class name, where pytest exited non-zero on collecting nothing rather than on a failure.

## Manual verification

N/A — the defect is which files the save path writes, which the ordering and call-site tests assert directly. No UI change, so no screenshots.

## Notes

Both defects trace to #2101 (`7363a5d07`, shipped in v0.2.0-rc.2). No issue was filed for either; I searched open and closed issues before writing this (#2491 is the storage-state break, #1634 the extension token).

no issue closed: neither defect had a tracked issue — found while investigating a user report.
