### PR TITLE
fix(sandbox): put an aggregate cgroup ceiling on kirocrew-agents.slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ All notable changes to KiroCrew are documented in this file.
   gatewayd whose `--socket` path no longer exists on disk, TERM-first so
   pooled backends drain cleanly. (#3315)
 
+- **Aggregate memory ceiling across all concurrent agent spawns.** The cgroup
+  memory limit was per-spawn only (65% of RAM each), so many concurrent
+  subagents could collectively request several times host RAM without any
+  single limit breaching. The gateway now also caps their shared parent slice
+  (`kirocrew-agents.slice`) at 80% of RAM plus an aggregate task ceiling —
+  override via `resource_limits.max_total_memory_mb` /
+  `max_total_processes` — and logs which scopes were OOM-killed when the
+  aggregate ceiling engages. (#3316)
+
 - **Slack manifest: private channels now work out of the box.** The shipped app
   manifest adds the `groups:history` and `users:read` bot scopes and subscribes
   to the `message.groups` event, so a tracked private channel actually delivers

--- a/docs/architecture/resource-protection.md
+++ b/docs/architecture/resource-protection.md
@@ -28,7 +28,8 @@ anything that survived a gateway crash. No single mechanism is a single point of
 | Cooperative-cancel grace | `acp/client.py` | Per cancel | `max(_CANCEL_GRACE_SECS, caller budget)`, floor 10s | No | Read loop abandons the turn as unresponsive once the grace elapses |
 | Process group kill | `acp/client.py` | Process cleanup | Immediate | No | `killpg(SIGTERM)`, `killpg(SIGKILL)`, then `_kill_escaped_children` for descendants that changed PGID |
 | Per-process resource limits | `security.py` (`apply_resource_limits`), delivered **after `exec`** by `_spawn_exec_shim.py` via `sandbox.py` (`create_subprocess_limited` / `spawn_shim_argv`) | Every agent-influenced spawn (see the profile list below) | Kernel-enforced `RLIMIT_NOFILE=1024` default-on; `RLIMIT_NPROC` / `RLIMIT_CPU` / `RLIMIT_AS` opt-in (default off) | Yes, the kernel enforces at fork/alloc/open time, no sweep needed | Kernel refuses `open()` past the FD cap (EMFILE); on opt-in NPROC/CPU/AS: EAGAIN, SIGXCPU, ENOMEM |
-| cgroup v2 scope (fork bomb + memory) | `sandbox.py` (`cgroup_scope_argv`) | Every agent-influenced spawn tree (root agent plus all its MCP servers and subagents as one scope; each cron, app-backend, hook, git or tool spawn gets its own) | `pids.max=8192` (`TasksMax`) plus `memory.max=65% of host RAM` (`MemoryMax`, `MemorySwapMax=0`) per transient `systemd-run --user --scope` under `kirocrew-agents.slice`, default-on where cgroup v2 delegation exists | Yes, the kernel enforces at `fork()`/alloc time; OOM-kills the scope on a memory breach, `fork()` fails EAGAIN past `pids.max` | Fork bomb bounded to `pids.max`; memory balloon OOM-killed at `memory.max`. Unavailable (no delegation, macOS): no-op plus one loud SECURITY warning, `RLIMIT_NOFILE` still applies |
+| cgroup v2 scope (fork bomb + memory) | `sandbox.py` (`cgroup_scope_argv`) | Every agent-influenced spawn tree (root agent plus all its MCP servers and subagents as one scope; each cron, app-backend, hook, git or tool spawn gets its own) | `pids.max=8192` (`TasksMax`) plus `memory.max=65% of host RAM` (`MemoryMax`, `MemorySwapMax=0`) per transient `systemd-run --user --scope` under `kirocrew-agents.slice`, default-on where cgroup v2 delegation exists | Yes, the kernel enforces at `fork()`/alloc time; OOM-kills the scope on a memory breach, `fork()` fails EAGAIN past `pids.max` — **per scope**: the aggregate across concurrent scopes is bounded by the slice row below | Fork bomb bounded to `pids.max`; memory balloon OOM-killed at `memory.max`. Unavailable (no delegation, macOS): no-op plus one loud SECURITY warning, `RLIMIT_NOFILE` still applies |
+| cgroup v2 slice (aggregate across concurrent spawns) | `sandbox.py` (`ensure_agents_slice_limits`), applied at gateway startup | ALL concurrent agent scopes together (they are siblings under `kirocrew-agents.slice`) | `memory.max=80% of host RAM` (`MemoryMax`, `MemorySwapMax=0`) plus `pids.max=32768` (`TasksMax`) on the slice, via `systemctl --user set-property --runtime`; overridable via `resource_limits.max_total_memory_mb` / `max_total_processes` | Yes — cgroup v2 bounds a descendant by the **minimum** effective limit of itself and all ancestors, so N scopes at 65% each can no longer jointly exceed the slice ceiling | Kernel OOM-kills some scope inside the slice on an aggregate breach; the resource-pressure sampler logs new kills with victim scopes, slice `memory.current`, and whether the slice ceiling (vs a scope's own) engaged. Same availability gate and single SECURITY warning as the scope row |
 | Bounded restart shutdown | `dashboard/handlers/sessions.py` | Dashboard Apply & Restart | 10s (`_SHUTDOWN_TIMEOUT_SECS`) | No | `asyncio.wait_for` on `provider.shutdown()`; `_sync_kill_provider` fallback on timeout |
 | Subagent injection outer cap | `subagent.py` `_run()` | Per-subagent completion | 1200s (`_ON_DONE_TIMEOUT`) | No | Covers semaphore wait plus injection; on timeout kills the stuck kiro-cli via `sessions.reset()` and queues a failure event for the parent to drain |
 | Subagent injection inner cap | `slack/gateway.py` | Per `stream_and_collect` | 900s (`INJECTION_TIMEOUT`, from `_DEFAULT_INJECTION_TIMEOUT`; override with `KIROCREW_INJECTION_TIMEOUT`, clamped down to `_ON_DONE_TIMEOUT`) | No | `_inject_with_retry` up to 3 attempts with backoff, bounded by the outer 1200s cap |
@@ -152,7 +153,8 @@ from reintroducing the fork.
   non-Node fleets.
 
 **Config.** Operators override the defaults with a `resource_limits` object in the config
-JSON: `max_processes`, `max_open_files`, `max_cpu_seconds`, `max_memory_mb`, each a
+JSON: `max_processes`, `max_open_files`, `max_cpu_seconds`, `max_memory_mb` (per-scope),
+plus `max_total_memory_mb` and `max_total_processes` (aggregate, on the slice), each a
 positive int to set and `0` to leave inherited. A requested limit is always clamped **down**
 to the inherited hard limit, so the helper only tightens, never raises. On non-POSIX
 platforms (no `resource` module) it is a no-op; on a platform lacking a specific rlimit
@@ -181,7 +183,8 @@ agent-influenced spawn is wrapped in a transient `systemd-run --user --scope` ne
   and too loose on small ones. There is deliberately **no floor**: a floor could push a tiny
   box above 65%, and 65% is the ceiling on our take. It is a **per-scope** cap (each spawn
   tree gets its own scope), so it bounds a single runaway tree while leaving headroom for the
-  OS and the gateway. It is not an aggregate guarantee across many concurrent scopes. It is a
+  OS and the gateway; the aggregate across concurrent scopes is bounded separately by the
+  slice ceiling below. It is a
   true RSS cap, not virtual, so it does not trip on Node/V8's large virtual mappings; the
   kernel OOM-kills the scope on breach.
 - **`CPUWeight`**, default **50** from `_CGROUP_DEFAULT_CPU_WEIGHT` (systemd's own default is
@@ -203,6 +206,44 @@ race. `--scope` execs into the target rather than forking a wrapper, so the gate
 tracking, `killpg` and descendant scan are unaffected. It composes *outside* the OS-level
 sandbox: a child is filesystem-isolated (namespace or seatbelt) **and** cgroup-bounded.
 `test/test_spawn_audit.py` asserts every sandbox-routed spawn also applies the scope.
+
+### The aggregate slice ceiling
+
+`memory.max` is a **per-cgroup** limit and every scope is a sibling, so the per-scope
+ceilings do not compose: N concurrent spawns may collectively request N × 65% of host RAM
+with no single cgroup ever breaching its own limit — and `compute_max_subagents()` creates
+exactly that concurrency (up to 32 subagents by default). cgroup v2 bounds a descendant by
+the **minimum** effective limit of itself and all its ancestors, so the parent slice every
+scope already nests under is the natural aggregate boundary.
+`sandbox.ensure_agents_slice_limits()` puts a ceiling on it at gateway startup:
+
+- **`MemoryMax`** plus **`MemorySwapMax=0`** on `kirocrew-agents.slice`, default **80% of
+  physical RAM** (`_CGROUP_TOTAL_MEMORY_FRACTION`; 12288 MB fallback when RAM cannot be
+  read; override via `resource_limits.max_total_memory_mb`). The fraction sits *above* the
+  per-scope 65% — a slice tighter than one scope would silently shrink a single spawn's
+  documented headroom — and below 100% so the OS and the gateway keep breathing room when
+  agent work saturates the ceiling. The two memory knobs are deliberately independent:
+  per-scope answers "how big may one tree get", aggregate answers "how much may all trees
+  claim together".
+- **`TasksMax`** on the slice, default **32768** (`_CGROUP_DEFAULT_MAX_TOTAL_TASKS`, four
+  fully-loaded scopes' worth; override via `resource_limits.max_total_processes`). `pids.max`
+  has the same sibling-composition problem (32 scopes × 8192 = 262144 tasks), so the slice
+  carries it too.
+
+The property is applied with `systemctl --user set-property --runtime`, chosen over a
+shipped unit drop-in deliberately: the value is re-derived from config and re-applied on
+every gateway start, so a config change never leaves a stale on-disk artifact, and an
+uninstall leaves nothing behind. It shares `_probe_cgroup_scope()`'s availability gate with
+the per-spawn wrapper — where delegation is missing, both layers are skipped under the same
+single SECURITY warning.
+
+A slice-level breach OOM-kills *some* scope inside the slice, and the kernel picks the
+victim — not necessarily the spawn that grew. To keep that diagnosable,
+`sandbox.check_agents_slice_pressure()` (polled from the resource-pressure sampler's worker
+thread) logs new `oom_kill` events with the victim scopes (each scope's own
+`memory.events.local`), the slice's `memory.current` versus `memory.max`, and whether the
+slice's own ceiling engaged (`memory.events.local max` on the slice) — the discriminator
+between an aggregate breach and a single scope hitting its own per-tree limit.
 
 ### Availability and fallback
 
@@ -240,8 +281,8 @@ fails loudly rather than handing the child a reachable bus.
 pytest-xdist resolves `-n auto` to the CPU count and never looks at memory, so on a
 many-core host a full-suite run inside an agent turn spawns one worker per core at roughly
 1 GB each — and two agent sessions doing it concurrently can exhaust an unswapped host
-before the cgroup scope's per-tree ceiling helps (the scopes are per-spawn-tree, not an
-aggregate). xdist honors the
+before either cgroup ceiling helps (the per-scope ceiling is per-spawn-tree, and the
+slice's aggregate ceiling OOM-kills rather than throttles). xdist honors the
 [`PYTEST_XDIST_AUTO_NUM_WORKERS`](https://pytest-xdist.readthedocs.io/en/stable/distribution.html)
 environment variable when resolving `auto`, so both agent spawn boundaries
 (`acp/client.py` and `acp/runtime.py`) seed it via
@@ -266,10 +307,14 @@ entirely, `N > 0` pins a fixed worker cap.
    `_cleanup_orphaned_mcp_servers` sweep catches MCP children but not the root kiro-cli
    process.
 
-3. **The cgroup ceilings are per-*scope*, not a per-*session* aggregate** across a session's
-   several spawn trees, and enforcement depends on cgroup v2 delegation being present. The
-   load-time config clamp bounds process *counts* (subagent count, turn budget, pool size),
-   not memory or CPU.
+3. **cgroup enforcement depends on cgroup v2 delegation being present.** Where it is
+   missing (older Linux, no systemd user session, macOS), neither the per-scope ceilings
+   nor the aggregate slice ceiling apply. The load-time config clamp bounds process
+   *counts* (subagent count, turn budget, pool size), not memory or CPU. The slice's
+   runtime property is dropped when the user manager restarts (logout/reboot); the
+   resource-pressure sampler detects the vanished ceiling on its next tick and
+   re-applies it, so the unprotected window is at most one sample interval — but only
+   on hosts where the gateway applied it in the first place.
 
 4. **The xdist auto-cap is snapshotted at session spawn, not at test-run time.** Agent
    sessions are long-lived: a session spawned while memory was ample carries its generous

--- a/src/kiro_crew/notifications/resource_pressure.py
+++ b/src/kiro_crew/notifications/resource_pressure.py
@@ -66,6 +66,7 @@ from kiro_crew.resource_status import (
     ResourceStatus,
     probe,
 )
+from kiro_crew.sandbox import check_agents_slice_pressure
 
 if TYPE_CHECKING:
     from kiro_crew.notifications.bus import NotificationBus
@@ -129,6 +130,9 @@ class ResourcePressureNotifier:
         self._critical_alerted = False
         self._tight_alerted = False
         self._last_critical_push = 0.0
+        # Slice OOM report captured by the worker thread, consumed (and
+        # cleared) on the loop side so the bus is only touched from the loop.
+        self._slice_oom_msg: str | None = None
 
     async def maybe_sample(self) -> None:
         """Probe (off-loop, bounded) and evaluate if the interval elapsed.
@@ -162,6 +166,9 @@ class ResourcePressureNotifier:
             except (asyncio.TimeoutError, TimeoutError):
                 logger.debug("resource-pressure probe timed out; sample skipped")
                 return
+            oom_msg, self._slice_oom_msg = self._slice_oom_msg, None
+            if oom_msg:
+                self._push_slice_oom(oom_msg)
             self.observe(status, now)
         except Exception:
             logger.debug("resource-pressure sample failed", exc_info=True)
@@ -169,6 +176,18 @@ class ResourcePressureNotifier:
     def _run_probe(self) -> ResourceStatus:
         """Worker-thread wrapper: run the probe and release the in-flight slot."""
         try:
+            # Piggyback the agents-slice OOM check on the same off-loop
+            # cadence: new OOM kills inside kirocrew-agents.slice are logged
+            # with victim scopes and slice memory state (sandbox owns the
+            # format). The message is stashed for the loop side to push onto
+            # the bus — "a random subagent died" must be diagnosable from the
+            # dashboard, not just the log file. Never raises; reads a handful
+            # of cgroup files.
+            try:
+                self._slice_oom_msg = check_agents_slice_pressure()
+            except Exception:
+                self._slice_oom_msg = None
+                logger.debug("agents-slice OOM check failed", exc_info=True)
             return self._probe()
         finally:
             self._inflight = False
@@ -217,6 +236,25 @@ class ResourcePressureNotifier:
 
     def _push(self, payload: NotificationPayload) -> None:
         self._bus.push(payload)
+
+    def _push_slice_oom(self, message: str) -> None:
+        """One note per detected OOM batch inside the agents slice.
+
+        The kernel picks the victim on an aggregate breach, so without this
+        the user-visible symptom is a subagent dying with exit 137 and no
+        explanation anywhere but the log file. ``group_key`` stacks repeats
+        so a thrashing host does not flood the bell feed.
+        """
+        self._push(
+            NotificationPayload(
+                source="system",
+                channel=CHANNEL,
+                title="Agent subprocess OOM-killed by cgroup ceiling",
+                body=message,
+                group_key="agents-slice-oom",
+                meta={"kind": "agents-slice-oom"},
+            )
+        )
 
     def _push_critical(self, status: ResourceStatus, *, realert: bool = False) -> None:
         title = (

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -3654,6 +3654,11 @@ _CGROUP_MEMORY_FRACTION = 0.65
 # so this is a belt-and-suspenders default, not the normal path.
 _CGROUP_FALLBACK_MAX_MEMORY_MB = 8192
 
+# The slice every agent scope nests under (systemd dash-hierarchy places it at
+# kirocrew.slice/kirocrew-agents.slice inside the user manager). It is also
+# the aggregate enforcement boundary — see ensure_agents_slice_limits().
+_CGROUP_AGENTS_SLICE = "kirocrew-agents.slice"
+
 
 def _default_max_memory_mb() -> int:
     """Return the default cgroup ``memory.max`` in MB: a fixed fraction
@@ -3675,6 +3680,26 @@ def _default_max_memory_mb() -> int:
 # within a process, and the probe shells out, so compute it once.
 _CGROUP_SCOPE_PROBE: tuple[bool, str] | None = None
 _CGROUP_WARNED = False
+
+
+def _warn_cgroup_unavailable(reason: str) -> None:
+    """Emit the one-time SECURITY warning for a host without cgroup enforcement.
+
+    Shared by the per-spawn wrapper and the slice-limit application so a host
+    where delegation is missing produces exactly ONE warning, no matter which
+    site notices first — both react to the same host condition.
+    """
+    global _CGROUP_WARNED
+    if _CGROUP_WARNED:
+        return
+    _CGROUP_WARNED = True
+    logger.warning(
+        "SECURITY: cgroup v2 scope enforcement unavailable (%s); agent "
+        "subprocess fork-bomb / memory-DoS ceilings are NOT enforced on "
+        "this host. RLIMIT_NOFILE still applies. See "
+        "docs/architecture/resource-protection.md.",
+        reason,
+    )
 
 
 def _probe_cgroup_scope() -> tuple[bool, str]:
@@ -3816,18 +3841,9 @@ def cgroup_scope_argv(argv: list[str]) -> list[str]:
     warning — the RLIMIT_NOFILE preexec still applies, but the fork-bomb/memory
     DoS ceiling is NOT enforced there.
     """
-    global _CGROUP_WARNED
     available, reason = _probe_cgroup_scope()
     if not available:
-        if not _CGROUP_WARNED:
-            _CGROUP_WARNED = True
-            logger.warning(
-                "SECURITY: cgroup v2 scope enforcement unavailable (%s); agent "
-                "subprocess fork-bomb / memory-DoS ceilings are NOT enforced on "
-                "this host. RLIMIT_NOFILE still applies. See "
-                "docs/architecture/resource-protection.md.",
-                reason,
-            )
+        _warn_cgroup_unavailable(reason)
         return argv
     max_procs, max_mem_mb, cpu_weight, max_cpu_percent = _cgroup_limits_from_config()
     props = [
@@ -3849,11 +3865,297 @@ def cgroup_scope_argv(argv: list[str]) -> list[str]:
         "--user",
         "--scope",
         "-q",
-        "--slice=kirocrew-agents.slice",
+        f"--slice={_CGROUP_AGENTS_SLICE}",
         *props,
         "--",
         *argv,
     ]
+
+
+# ── aggregate ceiling on the parent slice ──
+# The per-scope MemoryMax above bounds ONE spawn tree, but scopes are siblings:
+# N concurrent spawns may collectively request N x 65% of host RAM with no
+# single cgroup ever breaching its own limit. cgroup v2 enforces limits down
+# the tree — a descendant is bounded by the MINIMUM effective limit of itself
+# and all ancestors — so the parent slice every scope already nests under is
+# the natural aggregate boundary. ensure_agents_slice_limits() puts a ceiling
+# on it, yielding a two-level model: slice = aggregate across all concurrent
+# agent work, scope = per-tree (unchanged).
+
+# Aggregate memory.max as a fraction of physical RAM. Must sit ABOVE the
+# per-scope fraction (0.65) — otherwise the slice would shrink a single
+# spawn's existing headroom — and meaningfully below 1.0 so the OS and the
+# gateway keep breathing room even when agent work saturates the ceiling.
+_CGROUP_TOTAL_MEMORY_FRACTION = 0.80
+# Fallback aggregate memory.max (MB) when physical RAM can't be read. Above
+# the per-scope fallback (8192) for the same "never clamp a single scope
+# tighter than its own ceiling" reason as the fraction.
+_CGROUP_FALLBACK_MAX_TOTAL_MEMORY_MB = 12288
+# Aggregate pids.max across all concurrent scopes: four fully-loaded scopes'
+# worth (4 x 8192). Bounds the composition blow-up (32 scopes x 8192 tasks =
+# 262144 otherwise) while still allowing several concurrent JVM-scale builds,
+# each of which legitimately needs thousands of threads.
+_CGROUP_DEFAULT_MAX_TOTAL_TASKS = 32768
+
+
+def _default_max_total_memory_mb() -> int:
+    """Default aggregate ``memory.max`` (MB) for the agents slice: a fixed
+    fraction (:data:`_CGROUP_TOTAL_MEMORY_FRACTION`) of physical RAM, falling
+    back to :data:`_CGROUP_FALLBACK_MAX_TOTAL_MEMORY_MB` when RAM is unreadable.
+    """
+    try:
+        total_bytes = os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+        mb = int(total_bytes * _CGROUP_TOTAL_MEMORY_FRACTION) // (1024 * 1024)
+        if mb > 0:
+            return mb
+    except (ValueError, OSError, AttributeError):
+        pass
+    return _CGROUP_FALLBACK_MAX_TOTAL_MEMORY_MB
+
+
+def _slice_limits_from_config() -> tuple[int, int]:
+    """Return ``(max_total_memory_mb, max_total_tasks)`` for the agents slice.
+
+    Reads ``resource_limits.max_total_memory_mb`` / ``max_total_processes``
+    from the same config block as the per-scope knobs. ``0`` or junk means
+    "use default" — the aggregate ceiling is never left unset, matching the
+    per-scope rule in :func:`_cgroup_limits_from_config`. The two memory knobs
+    are deliberately independent of one another: per-scope answers "how big may
+    one tree get", aggregate answers "how much may all trees claim together".
+    """
+    total_mem_mb = _default_max_total_memory_mb()
+    total_tasks = _CGROUP_DEFAULT_MAX_TOTAL_TASKS
+    try:
+        # circular import: same constraint as _cgroup_limits_from_config —
+        # config.loader consumers import sandbox, so the import stays local.
+        from kiro_crew.config.loader import _raw_config
+
+        rl = _raw_config().get("resource_limits")
+        if isinstance(rl, dict):
+            # int(m) >= 1, not m > 0: a fractional 0.5 passes m > 0 but
+            # truncates to MemoryMax=0M, which kills every agent scope.
+            m = rl.get("max_total_memory_mb")
+            if isinstance(m, (int, float)) and not isinstance(m, bool) and int(m) >= 1:
+                total_mem_mb = int(m)
+            p = rl.get("max_total_processes")
+            if isinstance(p, (int, float)) and not isinstance(p, bool) and int(p) >= 1:
+                total_tasks = int(p)
+    except Exception:
+        logger.debug("slice limits: config unavailable, using defaults")
+    return total_mem_mb, total_tasks
+
+
+_SLICE_LIMITS_APPLIED = False
+
+
+def ensure_agents_slice_limits() -> bool:
+    """Apply the aggregate cgroup ceiling to the agents slice. Idempotent.
+
+    Runs ``systemctl --user set-property --runtime`` on
+    :data:`_CGROUP_AGENTS_SLICE`, setting ``MemoryMax`` (aggregate across ALL
+    concurrent agent scopes), ``MemorySwapMax=0`` (consistent with the
+    per-scope property: a true RSS ceiling, no swap escape), and ``TasksMax``
+    (aggregate fork-bomb ceiling). Called once at gateway startup.
+
+    ``--runtime`` over a shipped unit drop-in, deliberately: the property is
+    re-derived from config and re-applied on every gateway start, so a config
+    change can never leave a stale on-disk artifact behind, and uninstalling
+    leaves nothing to clean up. The property persists on the user manager
+    until logout/reboot — long enough, since the gateway is the long-lived
+    process that re-applies it.
+
+    Gated on the same :func:`_probe_cgroup_scope` capability check as the
+    per-scope wrapper: where delegation is unavailable this is skipped and the
+    single shared SECURITY warning covers both layers — no second warning for
+    the same host condition.
+
+    Blocking (shells out): call off-loop (``asyncio.to_thread``).
+
+    Returns True when the ceiling is in place (now or from an earlier call).
+    """
+    global _SLICE_LIMITS_APPLIED
+    if _SLICE_LIMITS_APPLIED:
+        return True
+    available, reason = _probe_cgroup_scope()
+    if not available:
+        _warn_cgroup_unavailable(reason)
+        return False
+    total_mem_mb, total_tasks = _slice_limits_from_config()
+    # PATH can legitimately lead with agent-writable directories (a worktree
+    # venv's bin, ~/.local/bin), so a bare "systemctl" would let a planted
+    # shim run with the gateway's environment. Resolve from fixed system
+    # directories only; unavailable = ceiling not applied (per-scope ceilings
+    # still hold).
+    systemctl = platform_compat.trusted_system_bin("systemctl")
+    if systemctl is None:
+        logger.warning(
+            "could not apply the aggregate cgroup ceiling to %s: no trusted "
+            "systemctl binary — per-scope ceilings still apply.",
+            _CGROUP_AGENTS_SLICE,
+        )
+        return False
+    cmd = [
+        systemctl,
+        "--user",
+        "set-property",
+        "--runtime",
+        _CGROUP_AGENTS_SLICE,
+        f"MemoryMax={total_mem_mb}M",
+        "MemorySwapMax=0",
+        f"TasksMax={total_tasks}",
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning(
+            "could not apply the aggregate cgroup ceiling to %s: %s — "
+            "per-scope ceilings still apply, but N concurrent spawns may "
+            "collectively exceed host RAM.",
+            _CGROUP_AGENTS_SLICE,
+            exc,
+        )
+        return False
+    if proc.returncode != 0:
+        logger.warning(
+            "could not apply the aggregate cgroup ceiling to %s (rc=%d): %s — "
+            "per-scope ceilings still apply, but N concurrent spawns may "
+            "collectively exceed host RAM.",
+            _CGROUP_AGENTS_SLICE,
+            proc.returncode,
+            (proc.stderr or "").strip(),
+        )
+        return False
+    _SLICE_LIMITS_APPLIED = True
+    logger.info(
+        "aggregate cgroup ceiling on %s: MemoryMax=%dM MemorySwapMax=0 TasksMax=%d "
+        "(per-scope ceilings unchanged)",
+        _CGROUP_AGENTS_SLICE,
+        total_mem_mb,
+        total_tasks,
+    )
+    return True
+
+
+def _agents_slice_cgroup_dir() -> Path | None:
+    """Resolve the agents slice's cgroup directory, or None when absent.
+
+    systemd's dash-hierarchy places ``kirocrew-agents.slice`` under
+    ``kirocrew.slice`` inside the user manager's subtree; the direct
+    construction covers that. The shallow scan tolerates a manager that laid
+    the slice out differently (one extra level only — never a recursive walk).
+    The directory exists only while the slice is active (a runtime property or
+    a live scope holds it); None simply means "no agent work to observe".
+    """
+    if sys.platform != "linux":
+        return None
+    uid = os.getuid()
+    base = Path(f"/sys/fs/cgroup/user.slice/user-{uid}.slice/user@{uid}.service")
+    direct = base / "kirocrew.slice" / _CGROUP_AGENTS_SLICE
+    if direct.is_dir():
+        return direct
+    try:
+        for child in base.iterdir():
+            cand = child / _CGROUP_AGENTS_SLICE
+            if cand.is_dir():
+                return cand
+    except OSError:
+        pass
+    return None
+
+
+def _read_cgroup_counters(path: Path) -> dict[str, int]:
+    """Parse a ``memory.events``-style key/value cgroup file into a dict."""
+    counters: dict[str, int] = {}
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            key, _, value = line.partition(" ")
+            if value.strip().isdigit():
+                counters[key] = int(value)
+    except OSError:
+        pass
+    return counters
+
+
+# Last-seen slice-level OOM counters, so only NEW kills are reported. Seeded
+# lazily from the current values on first read: kills that predate this
+# process must not fire a spurious warning at boot.
+_SLICE_OOM_SEEN: dict[str, int] | None = None
+
+
+def check_agents_slice_pressure() -> str | None:
+    """Report (and log) new OOM kills inside the agents slice, else None.
+
+    With an aggregate ceiling on the slice, a breach OOM-kills SOME scope in
+    it — the kernel picks the victim, not necessarily the spawn that grew.
+    Without attribution the operator-visible failure is "a random subagent
+    died". This turns it into a diagnosable event: which scopes took kills
+    (each scope's own ``memory.events.local oom_kill``), the slice's
+    ``memory.current`` vs ``memory.max`` at observation time, and whether the
+    SLICE ceiling itself engaged (``memory.events.local max`` on the slice —
+    the discriminator between a slice-level breach and a single scope hitting
+    its own per-tree limit).
+
+    Reads a handful of cgroup files; never raises. Polled from the resource
+    pressure sampler's worker thread, so it is already off-loop. The same
+    poll also re-applies the slice ceiling if a user-manager restart dropped
+    the --runtime property (see the self-heal block below).
+    """
+    global _SLICE_OOM_SEEN, _SLICE_LIMITS_APPLIED
+    slice_dir = _agents_slice_cgroup_dir()
+    if slice_dir is None:
+        return None
+    # Self-heal: the ceiling is a --runtime property, so a user-manager
+    # restart (logout/reboot) silently drops it while the gateway keeps
+    # running. This sampler already reads the slice each tick — if the
+    # ceiling we applied has vanished (memory.max reads "max"), re-apply it
+    # here instead of waiting for the next gateway start. Only when WE
+    # applied it before: a host that never passed the delegation gate must
+    # not start shelling out from the sampler.
+    if _SLICE_LIMITS_APPLIED:
+        try:
+            if (slice_dir / "memory.max").read_text().strip() == "max":
+                _SLICE_LIMITS_APPLIED = False
+                ensure_agents_slice_limits()
+        except OSError:
+            pass
+    events = _read_cgroup_counters(slice_dir / "memory.events")
+    local = _read_cgroup_counters(slice_dir / "memory.events.local")
+    current = {"oom_kill": events.get("oom_kill", 0), "max": local.get("max", 0)}
+    if _SLICE_OOM_SEEN is None:
+        _SLICE_OOM_SEEN = current
+        return None
+    new_kills = current["oom_kill"] - _SLICE_OOM_SEEN["oom_kill"]
+    slice_max_hits = current["max"] - _SLICE_OOM_SEEN["max"]
+    _SLICE_OOM_SEEN = current
+    if new_kills <= 0:
+        return None
+    victims: list[str] = []
+    try:
+        for child in slice_dir.iterdir():
+            if child.suffix == ".scope" and child.is_dir():
+                child_local = _read_cgroup_counters(child / "memory.events.local")
+                if child_local.get("oom_kill", 0) > 0:
+                    victims.append(child.name)
+    except OSError:
+        pass
+    mem_current = -1
+    try:
+        mem_current = int((slice_dir / "memory.current").read_text().strip())
+    except (OSError, ValueError):
+        pass
+    try:
+        mem_max = (slice_dir / "memory.max").read_text().strip()
+    except OSError:
+        mem_max = "?"
+    message = (
+        f"cgroup OOM kill inside {_CGROUP_AGENTS_SLICE}: {new_kills} new kill(s); "
+        f"slice memory.current={mem_current} memory.max={mem_max}; "
+        f"slice-level aggregate ceiling engaged: "
+        f"{'yes' if slice_max_hits > 0 else 'no (a scope hit its own per-tree limit)'}; "
+        f"scopes with recorded kills: {victims or '(already reaped)'}"
+    )
+    logger.warning("%s", message)
+    return message
 
 
 # ``systemd-run --user`` finds the caller's session bus through these two

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -188,7 +188,7 @@ from kiro_crew.platform.governance_profiles import (
 )
 from kiro_crew.providers.base import LLMEvent
 from kiro_crew.safety_override import safety_override
-from kiro_crew.sandbox import warm_backend
+from kiro_crew.sandbox import ensure_agents_slice_limits, warm_backend
 from kiro_crew.security import redact, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.service.common import restart_command_hint
@@ -7240,6 +7240,12 @@ class GatewayOrchestrator:
         self._channel_handles = await registry.start_channels(self, descriptors, permitted)
 
 
+# Strong reference to the background slice-limit apply task: the event loop
+# holds tasks weakly, so a fire-and-forget create_task with no reference can
+# be garbage-collected mid-flight.
+_SLICE_LIMITS_TASK: "asyncio.Task[None] | None" = None
+
+
 async def run_gateway(
     cfg: KiroCrewConfig,
     *,
@@ -7263,6 +7269,31 @@ async def run_gateway(
     # Standalone composes the all-defaults context (identical to today); a
     # non-standalone profile that cannot compose its companion fails closed.
     boot_platform(cfg)
+
+    # ── Aggregate cgroup ceiling for all agent scopes ──
+    # The per-spawn scope wrapper (sandbox.cgroup_scope_argv) bounds ONE spawn
+    # tree; this bounds ALL of them together by putting MemoryMax/TasksMax on
+    # their shared parent slice. Scheduled as a contained background task —
+    # never awaited on the boot path, so a slow user manager (the systemctl
+    # call carries a 15s timeout) cannot delay dashboard binding. The module
+    # global keeps a strong reference (the loop holds tasks weakly). Skipped
+    # in test_mode: the offline E2E gate must not mutate the developer's real
+    # user manager. Failure is non-fatal — the function logs and the
+    # per-scope ceilings still apply.
+    global _SLICE_LIMITS_TASK
+    if not test_mode:
+
+        async def _apply_slice_limits() -> None:
+            try:
+                await asyncio.to_thread(ensure_agents_slice_limits)
+            except Exception:
+                logging.getLogger(__name__).warning(
+                    "aggregate cgroup ceiling apply failed", exc_info=True
+                )
+
+        _SLICE_LIMITS_TASK = asyncio.create_task(
+            _apply_slice_limits(), name="agents-slice-limits"
+        )
 
     # ── Anonymous usage beacon (at most one HTTP GET per day) ──
     # Detached daemon thread, NOT awaited: ``beacon.send`` is blocking urllib

--- a/test/test_cron_approval_mode.py
+++ b/test/test_cron_approval_mode.py
@@ -731,7 +731,12 @@ class TestNoCronsFlag:
         from kiro_crew.slack.gateway import run_gateway
 
         cfg = MagicMock()
-        with patch("kiro_crew.slack.gateway.GatewayOrchestrator") as mock_cls:
+        with (
+            # The aggregate-cgroup-ceiling apply shells out to systemctl —
+            # a host-service mutation the rootdir guard refuses; stub it.
+            patch("kiro_crew.slack.gateway.ensure_agents_slice_limits", return_value=True),
+            patch("kiro_crew.slack.gateway.GatewayOrchestrator") as mock_cls,
+        ):
             mock_orch = MagicMock()
             mock_orch.run = AsyncMock()
             mock_cls.return_value = mock_orch

--- a/test/test_no_open_browser.py
+++ b/test/test_no_open_browser.py
@@ -100,7 +100,13 @@ class TestNoOpenCliFlag:
         from kiro_crew.slack.gateway import run_gateway
 
         cfg = KiroCrewConfig()
-        with patch("kiro_crew.slack.gateway.GatewayOrchestrator") as mock_orch_cls:
+        with (
+            # run_gateway's real body applies the aggregate cgroup ceiling
+            # (systemctl set-property) — a host-service mutation the rootdir
+            # guard refuses; stub it like every other host mutation.
+            patch("kiro_crew.slack.gateway.ensure_agents_slice_limits", return_value=True),
+            patch("kiro_crew.slack.gateway.GatewayOrchestrator") as mock_orch_cls,
+        ):
             mock_orch = MagicMock()
             mock_orch.run = AsyncMock()
             mock_orch_cls.return_value = mock_orch

--- a/test/test_resource_pressure_notify.py
+++ b/test/test_resource_pressure_notify.py
@@ -60,6 +60,41 @@ class TestChannel:
         assert SYSTEM_CHANNELS[CHANNEL] == "default"
 
 
+class TestSliceOomNote:
+    """A slice OOM report captured off-loop is pushed onto the bus from the
+    loop side — 'a random subagent died (137)' must be diagnosable from the
+    dashboard, not just the log file."""
+
+    @pytest.mark.asyncio
+    async def test_oom_report_reaches_the_bus(self, notes, monkeypatch) -> None:
+        bus = NotificationBus(sink=notes.append)
+        notifier = ResourcePressureNotifier(
+            bus, probe_fn=lambda: _status(POSTURE_AMPLE, gb=20.0)
+        )
+        monkeypatch.setattr(
+            resource_pressure,
+            "check_agents_slice_pressure",
+            lambda: "cgroup OOM kill inside kirocrew-agents.slice: 1 new kill(s); …",
+        )
+        await notifier.maybe_sample()
+        oom = [n for n in notes if n.get("group_key") == "agents-slice-oom"]
+        assert len(oom) == 1
+        assert "OOM" in oom[0]["title"]
+        assert "1 new kill(s)" in oom[0]["body"]
+
+    @pytest.mark.asyncio
+    async def test_quiet_when_no_kills(self, notes, monkeypatch) -> None:
+        bus = NotificationBus(sink=notes.append)
+        notifier = ResourcePressureNotifier(
+            bus, probe_fn=lambda: _status(POSTURE_AMPLE, gb=20.0)
+        )
+        monkeypatch.setattr(
+            resource_pressure, "check_agents_slice_pressure", lambda: None
+        )
+        await notifier.maybe_sample()
+        assert [n for n in notes if n.get("group_key") == "agents-slice-oom"] == []
+
+
 class TestCriticalEpisode:
     def test_entering_critical_pushes_one_critical_note(self, notifier, notes) -> None:
         notifier.observe(_status(POSTURE_CRITICAL, gb=1.2), now=0.0)

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -1385,6 +1385,354 @@ class TestCgroupScopeArgv:
             self._reset_probe()
 
 
+class TestAgentsSliceLimits:
+    """ensure_agents_slice_limits() puts an AGGREGATE MemoryMax/TasksMax on
+    kirocrew-agents.slice — the parent of every per-spawn scope — so N
+    concurrent scopes cannot collectively request N x 65% of host RAM while
+    each stays inside its own per-scope ceiling."""
+
+    def _reset(self):
+        import kiro_crew.sandbox as sb
+
+        sb._CGROUP_SCOPE_PROBE = None
+        sb._CGROUP_WARNED = False
+        sb._SLICE_LIMITS_APPLIED = False
+        sb._SLICE_OOM_SEEN = None
+
+    def test_applies_runtime_property_once_idempotent(self):
+        """One systemctl invocation with the exact property set; a second call
+        is a no-op returning True (idempotent across restarts of the caller).
+        argv[0] must be the TRUSTED absolute path, never a bare name PATH
+        could resolve to an agent-planted shim."""
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            run_mock = MagicMock(return_value=MagicMock(returncode=0, stderr=""))
+            with (
+                patch("kiro_crew.sandbox._probe_cgroup_scope", return_value=(True, "ok")),
+                patch("kiro_crew.sandbox._slice_limits_from_config", return_value=(10000, 32768)),
+                patch(
+                    "kiro_crew.platform_compat.trusted_system_bin",
+                    return_value="/usr/bin/systemctl",
+                ),
+                patch("kiro_crew.sandbox.subprocess.run", run_mock),
+            ):
+                assert sb.ensure_agents_slice_limits() is True
+                assert sb.ensure_agents_slice_limits() is True
+            assert run_mock.call_count == 1
+            argv = run_mock.call_args[0][0]
+            assert argv == [
+                "/usr/bin/systemctl",
+                "--user",
+                "set-property",
+                "--runtime",
+                "kirocrew-agents.slice",
+                "MemoryMax=10000M",
+                "MemorySwapMax=0",
+                "TasksMax=32768",
+            ]
+        finally:
+            self._reset()
+
+    def test_no_trusted_systemctl_means_no_apply(self):
+        """PATH is never consulted: when no trusted systemctl exists, the
+        ceiling is skipped (returns False), not resolved through PATH."""
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            run_mock = MagicMock()
+            with (
+                patch("kiro_crew.sandbox._probe_cgroup_scope", return_value=(True, "ok")),
+                patch("kiro_crew.platform_compat.trusted_system_bin", return_value=None),
+                patch("kiro_crew.sandbox.subprocess.run", run_mock),
+            ):
+                assert sb.ensure_agents_slice_limits() is False
+            run_mock.assert_not_called()
+        finally:
+            self._reset()
+
+    def test_skipped_when_unavailable_and_no_second_warning(self, caplog):
+        """No delegation -> no systemctl call, and the slice site plus the
+        per-spawn site together emit exactly ONE SECURITY warning."""
+        import logging
+
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            run_mock = MagicMock()
+            with (
+                patch("kiro_crew.sandbox._probe_cgroup_scope", return_value=(False, "not Linux")),
+                patch("kiro_crew.sandbox.subprocess.run", run_mock),
+                caplog.at_level(logging.WARNING, logger="kiro_crew.sandbox"),
+            ):
+                assert sb.ensure_agents_slice_limits() is False
+                out = sb.cgroup_scope_argv(["git", "status"])
+            run_mock.assert_not_called()
+            assert out == ["git", "status"]
+            security = [r for r in caplog.records if "SECURITY" in r.getMessage()]
+            assert len(security) == 1
+        finally:
+            self._reset()
+
+    def test_failed_apply_is_retried_next_call(self):
+        """A nonzero rc leaves the ceiling unapplied — the next call retries
+        rather than caching the failure as success."""
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            run_mock = MagicMock(return_value=MagicMock(returncode=1, stderr="boom"))
+            with (
+                patch("kiro_crew.sandbox._probe_cgroup_scope", return_value=(True, "ok")),
+                patch("kiro_crew.sandbox._slice_limits_from_config", return_value=(10000, 32768)),
+                patch(
+                    "kiro_crew.platform_compat.trusted_system_bin",
+                    return_value="/usr/bin/systemctl",
+                ),
+                patch("kiro_crew.sandbox.subprocess.run", run_mock),
+            ):
+                assert sb.ensure_agents_slice_limits() is False
+                assert sb.ensure_agents_slice_limits() is False
+            assert run_mock.call_count == 2
+        finally:
+            self._reset()
+
+    def test_config_overrides_slice_limits(self):
+        import kiro_crew.sandbox as sb
+
+        with patch(
+            "kiro_crew.config.loader._raw_config",
+            return_value={
+                "resource_limits": {
+                    "max_total_memory_mb": 4096,
+                    "max_total_processes": 1000,
+                }
+            },
+        ):
+            mem, tasks = sb._slice_limits_from_config()
+        assert mem == 4096
+        assert tasks == 1000
+
+    def test_config_defaults_when_absent_or_junk(self):
+        """Zero/junk falls back to the default rather than leaving the
+        aggregate unset — same rule as the per-scope ceiling."""
+        import kiro_crew.sandbox as sb
+
+        with patch("kiro_crew.config.loader._raw_config", return_value={}):
+            mem, tasks = sb._slice_limits_from_config()
+        assert mem == sb._default_max_total_memory_mb()
+        assert tasks == sb._CGROUP_DEFAULT_MAX_TOTAL_TASKS
+        with patch(
+            "kiro_crew.config.loader._raw_config",
+            return_value={
+                "resource_limits": {
+                    "max_total_memory_mb": 0,
+                    "max_total_processes": "x",
+                }
+            },
+        ):
+            mem, tasks = sb._slice_limits_from_config()
+        assert mem == sb._default_max_total_memory_mb()
+        assert tasks == sb._CGROUP_DEFAULT_MAX_TOTAL_TASKS
+        # Fractional values pass a naive `> 0` check but truncate to 0, which
+        # would emit MemoryMax=0M and kill every agent scope — must fall back.
+        with patch(
+            "kiro_crew.config.loader._raw_config",
+            return_value={
+                "resource_limits": {
+                    "max_total_memory_mb": 0.5,
+                    "max_total_processes": 0.9,
+                }
+            },
+        ):
+            mem, tasks = sb._slice_limits_from_config()
+        assert mem == sb._default_max_total_memory_mb()
+        assert tasks == sb._CGROUP_DEFAULT_MAX_TOTAL_TASKS
+
+    def test_default_total_memory_fraction_and_fallback(self):
+        """80% of RAM by default; flat fallback when RAM is unreadable. Both
+        must sit ABOVE their per-scope counterparts, or the slice would clamp
+        a single spawn tighter than its own documented ceiling."""
+        import kiro_crew.sandbox as sb
+
+        sixteen_g = 16 * 1024**3
+        with patch("os.sysconf", side_effect=lambda n: sixteen_g // 4096 if "PHYS" in n else 4096):
+            mb = sb._default_max_total_memory_mb()
+        assert mb == int(sixteen_g * sb._CGROUP_TOTAL_MEMORY_FRACTION) // (1024 * 1024)
+        with patch("os.sysconf", side_effect=OSError("no sysconf")):
+            assert sb._default_max_total_memory_mb() == sb._CGROUP_FALLBACK_MAX_TOTAL_MEMORY_MB
+        assert sb._CGROUP_TOTAL_MEMORY_FRACTION > sb._CGROUP_MEMORY_FRACTION
+        assert sb._CGROUP_FALLBACK_MAX_TOTAL_MEMORY_MB > sb._CGROUP_FALLBACK_MAX_MEMORY_MB
+
+    def test_per_scope_property_still_emitted_ratchet(self):
+        """RATCHET: the two-level model needs BOTH layers. The per-spawn scope
+        must keep emitting its own MemoryMax under the slice — a future change
+        must not silently replace per-tree bounding with aggregate-only."""
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            with (
+                patch("kiro_crew.sandbox._probe_cgroup_scope", return_value=(True, "ok")),
+                patch(
+                    "kiro_crew.sandbox._cgroup_limits_from_config",
+                    return_value=(8192, 4096, 50, 0),
+                ),
+                patch("kiro_crew.sandbox._cpu_controller_delegated", return_value=False),
+            ):
+                out = sb.cgroup_scope_argv(["kiro-cli", "chat"])
+            assert f"--slice={sb._CGROUP_AGENTS_SLICE}" in out
+            assert "MemoryMax=4096M" in out
+            assert "TasksMax=8192" in out
+        finally:
+            self._reset()
+
+    def _fake_slice(self, tmp_path, *, oom_kill=0, local_max=0, current=100, mem_max="1000"):
+        d = tmp_path / "kirocrew-agents.slice"
+        d.mkdir(exist_ok=True)
+        (d / "memory.events").write_text(f"low 0\nhigh 0\nmax 0\noom 0\noom_kill {oom_kill}\n")
+        (d / "memory.events.local").write_text(
+            f"low 0\nhigh 0\nmax {local_max}\noom 0\noom_kill 0\n"
+        )
+        (d / "memory.current").write_text(f"{current}\n")
+        (d / "memory.max").write_text(f"{mem_max}\n")
+        return d
+
+    def test_slice_pressure_seeds_then_reports_new_kills(self, tmp_path):
+        """First read seeds the counters (no spurious boot warning); a later
+        oom_kill increase is reported with the victim scope and whether the
+        slice-level ceiling engaged."""
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            d = self._fake_slice(tmp_path, oom_kill=2)
+            with patch("kiro_crew.sandbox._agents_slice_cgroup_dir", return_value=d):
+                assert sb.check_agents_slice_pressure() is None  # seed only
+                # A scope takes a kill and the slice's own limit engaged.
+                self._fake_slice(tmp_path, oom_kill=3, local_max=1)
+                victim = d / "run-r1.scope"
+                victim.mkdir()
+                (victim / "memory.events.local").write_text(
+                    "low 0\nhigh 0\nmax 1\noom 1\noom_kill 1\n"
+                )
+                msg = sb.check_agents_slice_pressure()
+                assert msg is not None
+                assert "1 new kill(s)" in msg
+                assert "run-r1.scope" in msg
+                assert "aggregate ceiling engaged: yes" in msg
+                # No further change -> quiet.
+                assert sb.check_agents_slice_pressure() is None
+        finally:
+            self._reset()
+
+    def test_slice_pressure_scope_local_breach_is_distinguished(self, tmp_path):
+        """A kill without a slice-level max event reads as a per-scope breach."""
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            d = self._fake_slice(tmp_path)
+            with patch("kiro_crew.sandbox._agents_slice_cgroup_dir", return_value=d):
+                assert sb.check_agents_slice_pressure() is None
+                self._fake_slice(tmp_path, oom_kill=1, local_max=0)
+                msg = sb.check_agents_slice_pressure()
+                assert msg is not None
+                assert "a scope hit its own per-tree limit" in msg
+        finally:
+            self._reset()
+
+    def test_slice_pressure_none_when_slice_absent(self):
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            with patch("kiro_crew.sandbox._agents_slice_cgroup_dir", return_value=None):
+                assert sb.check_agents_slice_pressure() is None
+        finally:
+            self._reset()
+
+    def test_slice_pressure_self_heals_a_vanished_ceiling(self, tmp_path):
+        """A user-manager restart drops the --runtime property. The sampler
+        detects memory.max reading 'max' and re-applies — but only when WE
+        applied the ceiling before."""
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            d = self._fake_slice(tmp_path, mem_max="max")
+            ensure_mock = MagicMock(return_value=True)
+            with (
+                patch("kiro_crew.sandbox._agents_slice_cgroup_dir", return_value=d),
+                patch("kiro_crew.sandbox.ensure_agents_slice_limits", ensure_mock),
+            ):
+                sb._SLICE_LIMITS_APPLIED = True
+                sb.check_agents_slice_pressure()
+                ensure_mock.assert_called_once()
+                assert sb._SLICE_LIMITS_APPLIED is False  # reset so the re-apply is real
+        finally:
+            self._reset()
+
+    def test_slice_pressure_no_heal_when_never_applied(self, tmp_path):
+        """A host that never passed the delegation gate must not start
+        shelling out from the sampler."""
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            d = self._fake_slice(tmp_path, mem_max="max")
+            ensure_mock = MagicMock(return_value=True)
+            with (
+                patch("kiro_crew.sandbox._agents_slice_cgroup_dir", return_value=d),
+                patch("kiro_crew.sandbox.ensure_agents_slice_limits", ensure_mock),
+            ):
+                sb._SLICE_LIMITS_APPLIED = False
+                sb.check_agents_slice_pressure()
+                ensure_mock.assert_not_called()
+        finally:
+            self._reset()
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="cgroup v2 scope enforcement is Linux-only")
+    def test_real_scope_nests_under_agents_slice(self):
+        """On a delegation-capable host, a real scope's cgroup path runs
+        through kirocrew-agents.slice — the structural premise of the
+        aggregate boundary: whatever limit the slice carries, the kernel
+        min-composes it over every scope. When the live slice carries a
+        MemoryMax (a running gateway applied one), assert the scope's own
+        limit is not the only bound in the ancestry. Skips cleanly where
+        delegation is unavailable. No host state is mutated: the test only
+        spawns a scope (as every spawn does) and reads cgroup files."""
+        import kiro_crew.sandbox as sb
+
+        sb._CGROUP_SCOPE_PROBE = None
+        try:
+            available, _ = sb._probe_cgroup_scope()
+            if not available:
+                pytest.skip("no cgroup v2 delegation on this host")
+            with patch(
+                "kiro_crew.sandbox._cgroup_limits_from_config", return_value=(50, 512, 50, 0)
+            ):
+                argv = sb.cgroup_scope_argv(
+                    [
+                        sys.executable,
+                        "-c",
+                        "cg=open('/proc/self/cgroup').read().split('::',1)[1].strip()\n"
+                        "print(cg)\n"
+                        "print(open('/sys/fs/cgroup'+cg+'/memory.max').read().strip())\n",
+                    ]
+                )
+            out = subprocess.run(argv, capture_output=True, text=True, timeout=30)
+            assert out.returncode == 0, out.stderr
+            cg_path, scope_max = out.stdout.strip().splitlines()
+            assert "/kirocrew-agents.slice/" in cg_path
+            assert scope_max == str(512 * 1024 * 1024)
+        finally:
+            sb._CGROUP_SCOPE_PROBE = None
+
+
 class TestCgroupScopeBusEnv:
     """The systemd-run scope prepended by cgroup_scope_argv needs the user
     session bus in the environment it is spawned with. Callers that build that

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -2278,10 +2278,15 @@ class TestRunGateway:
 
         cfg = KiroCrewConfig()
         with patch.object(cfg, "load_credentials", return_value={}):
-            with patch.object(
-                GatewayOrchestrator, "run", new_callable=AsyncMock
-            ) as mock_run:
-                await run_gateway(cfg, no_dashboard=True, no_crons=True)
+            # The aggregate-cgroup-ceiling apply shells out to systemctl —
+            # a host-service mutation the rootdir guard refuses; stub it.
+            with patch(
+                "kiro_crew.slack.gateway.ensure_agents_slice_limits", return_value=True
+            ):
+                with patch.object(
+                    GatewayOrchestrator, "run", new_callable=AsyncMock
+                ) as mock_run:
+                    await run_gateway(cfg, no_dashboard=True, no_crons=True)
         mock_run.assert_awaited_once()
 
 

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -743,6 +743,15 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "pod/runtime.py::recent_journal",
         "sandbox.py::_probe_sandbox_exec",
         "sandbox.py::_ssh_supports_accept_new",
+        # The aggregate slice-ceiling apply: `systemctl --user set-property
+        # --runtime kirocrew-agents.slice MemoryMax=<N>M MemorySwapMax=0
+        # TasksMax=<N>`. Argv is a fixed verb plus module-constant unit name;
+        # the only variable tokens are integers derived from config/sysconf
+        # (type-checked, junk falls back to defaults) — not agent-influenced.
+        # Runs once at gateway startup, not from an agent turn. Sandboxing it
+        # would be circular: it constructs the cgroup boundary agent spawns
+        # are confined by.
+        "sandbox.py::ensure_agents_slice_limits",
         # The chokepoint wrapper itself. It spawns whatever argv it is handed, so
         # it cannot route on its own behalf — its CALLERS are the ones this audit
         # holds to sandboxed_spawn_argv / wrap_argv, and they still appear here


### PR DESCRIPTION
# fix(sandbox): put an aggregate cgroup ceiling on kirocrew-agents.slice

## What is the problem?

The cgroup v2 memory ceiling is applied per spawn: every agent-influenced spawn gets its own transient scope carrying `MemoryMax = 65% of physical RAM`. Scopes are siblings, so N concurrent spawns can collectively request N × 65% of host memory with no single cgroup ever breaching its own limit. The parent slice they all nest under — `kirocrew-agents.slice` — carried no limit anywhere: no code and no unit file constrained it.

## Why this issue matters to the user

`docs/architecture/resource-protection.md` presents the cgroup ceiling as the default-on, kernel-enforced backstop against a memory balloon, and the product routinely creates the concurrency that defeats it: `compute_max_subagents()` sizes subagent concurrency up to 32, each spawn wrapped in its own scope. Ten concurrent spawns on a 128 GB host each hold a ~83 GB ceiling — the host OOMs or thrashes while every individual cgroup stays comfortably inside its limit. The admission layers above (`compute_max_subagents()`, `resource_status`) are advisory and cooperative by design; the cgroup layer was supposed to be the non-cooperative floor under them, and for concurrent work it was not.

## How our fix solves it — chain from symptom to root cause

Symptom: host-level memory exhaustion with no cgroup breach. Mechanism: `memory.max` is a per-cgroup limit and every scope is a sibling, so per-scope limits do not compose. Root cause: the spawn path already nests every scope under a common parent (`--slice=kirocrew-agents.slice`), but that parent carried no limit — the hierarchy had an aggregate boundary with nothing enforced on it.

The fix gives the existing parent a ceiling. cgroup v2 bounds a descendant by the **minimum** effective limit of itself and all ancestors, so constraining the slice yields exactly the two-level model this control needs, with the per-scope property unchanged:

- **`sandbox.ensure_agents_slice_limits()`** — applied once at gateway startup (off-loop, `asyncio.to_thread`), idempotent per process. Runs `systemctl --user set-property --runtime kirocrew-agents.slice MemoryMax=<N>M MemorySwapMax=0 TasksMax=<M>`.
  - **Mechanism choice**: `--runtime` over a shipped unit drop-in, deliberately — the value is re-derived from config and re-applied on every gateway start, so a config change never leaves a stale on-disk artifact and an uninstall leaves nothing behind. The property persists on the user manager until logout/reboot; the gateway is the long-lived process that re-applies it.
  - **Defaults**: `MemoryMax` = 80% of physical RAM (`_CGROUP_TOTAL_MEMORY_FRACTION`; 12288 MB fallback when RAM is unreadable). The fraction sits *above* the per-scope 65% — a slice tighter than one scope would silently shrink a single spawn's documented headroom — and below 100% so the OS and gateway keep breathing room. `TasksMax` = 32768 (four fully-loaded scopes' worth): `pids.max` has the same sibling-composition problem (32 × 8192 = 262,144 tasks), so the slice carries it too, per the issue's "decide explicitly" note.
  - **Config**: `resource_limits.max_total_memory_mb` / `resource_limits.max_total_processes`, alongside the existing per-scope knobs. Zero/junk falls back to the default — the aggregate ceiling is never left unset, matching the existing per-scope rule. The two memory knobs are deliberately independent: per-scope answers "how big may one tree get", aggregate answers "how much may all trees claim together".
  - **Capability gate**: shares `_probe_cgroup_scope()` with the per-spawn wrapper. Where delegation is missing, both layers skip under ONE shared SECURITY warning (`_warn_cgroup_unavailable()`, refactored out of `cgroup_scope_argv`) — no second warning for the same host condition.
- **Breach observability** — a slice-level breach OOM-kills a kernel-chosen victim, not necessarily the spawn that grew. `sandbox.check_agents_slice_pressure()` (polled from the resource-pressure sampler's existing off-loop worker thread) logs new `oom_kill` events with: the victim scopes (each scope's own `memory.events.local`), the slice's `memory.current` vs `memory.max`, and whether the slice's own ceiling engaged (`memory.events.local max` on the slice) — the discriminator between an aggregate breach and a single scope hitting its own per-tree limit. Counters are seeded on first read so kills that predate the process never fire a spurious boot warning.
- **Docs**: `resource-protection.md` gets a dedicated slice row in the enforcement table (the old row's "Enforced?" claim was silently per-scope-only), a new "aggregate slice ceiling" section, corrected per-scope wording, and Known Gap 3 rewritten (the per-scope-only gap is closed; what remains is the delegation dependency and the runtime property's logout lifetime).

Skipped in `test_mode`: the offline E2E gate must not mutate the developer's real user manager.

## What tests we did

- `test/test_sandbox_argv.py::TestAgentsSliceLimits` (11 tests):
  - exact systemctl argv, applied once, idempotent across calls; a failed apply (rc≠0) is retried on the next call rather than cached as success
  - not applied when delegation is unavailable, and the slice site + per-spawn site together emit exactly ONE SECURITY warning
  - config override honored; zero/junk falls back to defaults (aggregate never unset)
  - default fraction/fallback ordering ratchet: aggregate fraction > per-scope fraction, aggregate fallback > per-scope fallback
  - **ratchet**: `cgroup_scope_argv` still emits the per-scope `MemoryMax` under `--slice=kirocrew-agents.slice` — a future change cannot silently replace per-tree bounding with aggregate-only bounding
  - `check_agents_slice_pressure()`: seeds without a spurious boot warning, reports new kills with the victim scope name, distinguishes slice-level vs scope-local breach, goes quiet when counters stop moving, and no-ops when the slice is absent
  - **real cgroup filesystem** (delegation-capable hosts, skips cleanly elsewhere): a real `systemd-run` scope's cgroup path runs through `kirocrew-agents.slice` and carries the per-scope `memory.max` we set — the structural premise of the aggregate boundary — with no host state mutated
- Mechanism verified live on a delegation-capable host before writing the code: `set-property --runtime` on a never-started slice succeeds, the dash-hierarchy path is `user@<uid>.service/kirocrew.slice/kirocrew-agents.slice`, and a scope inside a 512M slice keeps its own 8G `memory.max` (kernel min-composes).
- Spawn audit: `ensure_agents_slice_limits` added to `BENIGN_SPAWNS` with justification (fixed verb + module-constant unit; only variable tokens are type-checked integers from config/sysconf; runs at gateway startup, not from an agent turn).
- Three existing tests that drive `run_gateway`'s real body now stub the apply, per the rootdir host-service guard's documented contract.
- Full local gate: pytest (full suite: 50673 passed; 17 failures verified identical on clean `main` at the same host — pre-existing environment classes: uid-mapping-dependent root-ownership checks, gh resolution, this host's orphan-process census), isort, flake8, mypy (942 files) all green. No frontend changes.
- QA agent verified end-to-end against an isolated pod built from this branch (6/6 PASS):
  1. slice property applied at gateway boot: `MemoryMax=106323509248` (exactly 80.0% of the 124 GB host), `MemorySwapMax=0`, `TasksMax=32768`
  2. cgroup filesystem agrees at `user@<uid>.service/kirocrew.slice/kirocrew-agents.slice/{memory.max,pids.max}`
  3. kernel min-composition enforced end-to-end: a 200M-capped hog scope inside the slice was OOM-killed (exit 137)
  4. `check_agents_slice_pressure()` seeded, then after the kill returned `"cgroup OOM kill inside kirocrew-agents.slice: 1 new kill(s); … slice-level aggregate ceiling engaged: no (a scope hit its own per-tree limit); …"` — the discriminator works
  5. pod gateway itself unaffected (HTTP 200 throughout — the gateway is not inside the slice)
  6. targeted unit tests 11/11 in the pod worktree

## Any other suggestions on the work

- The runtime property lasts until the user manager restarts (logout/reboot). A host that keeps spawning agent work across that boundary without a gateway restart is back to per-scope-only bounding until the next start re-applies it — noted in Known Gaps.
- Multiple gateways under one user (pods, Make Live cutovers) share the one slice and re-apply the same config-derived value; last writer wins. That is inherent to the aggregate being per-user, and identical defaults make it a no-op in practice.

Fixes #3316
