### PR TITLE
ci(electron): stop the shell tests fetching Electron at require time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1069,6 +1069,21 @@ jobs:
     name: Electron Shell Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # electron 43 resolves the binary LAZILY, at require() time: index.js ends in
+    # `module.exports = getElectronPath()`, which on a missing path.txt logs
+    # "Downloading Electron binary..." and shells out to install.js. `npm ci`
+    # really does fetch nothing (the package declares no scripts at all), so the
+    # download lands in `npm test` instead — every green run of this job has been
+    # pulling ~120MB (313MB extracted), and when that fetch fails the first test
+    # file to require() a main-process module dies at load, failing the job with
+    # no assertion failure. ELECTRON_SKIP_BINARY_DOWNLOAD is honored nowhere in
+    # electron 43; ELECTRON_OVERRIDE_DIST_PATH is, and it returns a path without
+    # fetching. Job-scoped so a version that moves the download back to
+    # postinstall is covered too. The suite never launches the binary, so this
+    # path deliberately does not exist — anything that did launch it fails loudly
+    # rather than silently downloading.
+    env:
+      ELECTRON_OVERRIDE_DIST_PATH: /nonexistent/electron-dist
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -1083,9 +1098,10 @@ jobs:
         # Belt-and-braces: this pin currently downloads no Electron binary
         # anyway (electron 43's package ships no install script), so the var is
         # inert today — it is set so a future version that reintroduces the
-        # ~100MB postinstall download cannot silently slow this job down. The
-        # tests require() only main-process modules and the stdlib test runner,
-        # so the binary is never needed.
+        # ~100MB postinstall download cannot silently slow this job down. It does
+        # NOT cover the test step: main-process modules are precisely the ones
+        # that require("electron"), which resolves the binary lazily, so the
+        # binary IS needed there. See ELECTRON_OVERRIDE_DIST_PATH on the job.
         env:
           ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
         run: npm ci --no-audit --no-fund


### PR DESCRIPTION
## Problem / Motivation

`Electron Shell Tests` is documented as *"deliberately tiny and fast — pure unit tests, no Electron binary download, no packaging."* It does download the Electron binary, on every run, and that download is on the critical path of `npm test`.

electron 43 declares **no `scripts` field at all**, so `npm ci` genuinely fetches nothing and never writes `path.txt`. But the download did not go away — it moved to **require time**. `node_modules/electron/index.js` ends in:

```js
module.exports = getElectronPath();
// → path.txt absent → downloadElectron()
//   → console.log('Downloading Electron binary...')
//   → spawnSync(node install.js)          // ~120MB, 313MB extracted
//   → on failure: throw 'Electron failed to install correctly'
```

`npm test` runs `node --test`, i.e. plain Node, and the suite requires main-process modules — which are precisely the modules that do a top-level `require("electron")`. So the fetch happens in the **Unit tests** step, where nothing guards it.

## Why it matters

The job's whole justification is that it is cheap: it is documented as deliberately tiny and fast, with no Electron binary download. If it downloads the binary on every run, that promise is false and the cost lands on the critical path of `npm test`, where it is paid by every contributor on every push. It is also a correctness risk rather than just a slow lane — a job that reaches the network at require time can fail for reasons unrelated to the code under test, which turns an infrastructure hiccup into a red gate that looks like a real failure.

## Why the job usually passes anyway

Because the download normally succeeds. A green run is in fact *proof* that it happened: after `npm ci` there is no `path.txt`, no override var is set, so the only way `require("electron")` can avoid throwing is a successful download.

When the fetch fails, the first test file to require a main-process module dies at module load. That surfaces as a red job with **no assertion failure** — in the run that led me here, 847 of 848 subtests passed and the "1 failure" was the dead file. It failed on three consecutive pushes inside about a 40-minute window (the third run retried the download 7 times), while `main` happened to run either side of that window and went green.

Because `node --test` gives each file its own process, one suite run logs **3 separate download attempts**, so the exposure is per-process, not per-run.

## Why `ELECTRON_SKIP_BINARY_DOWNLOAD` does not cover it

Two independent reasons, both measured:

1. It is set on **Install dependencies**, but the download happens in **Unit tests**.
2. It is honored by **no code in electron 43**. `grep -rl ELECTRON_SKIP_BINARY_DOWNLOAD node_modules/` returns nothing. Positive control: the same grep for `ELECTRON_OVERRIDE_DIST_PATH` returns `electron/index.js` and `electron/install.js`.

So merely moving the existing var to the test step does not work — I tried it, and it still downloaded.

## What changed (motivation → approach → change)

Set `ELECTRON_OVERRIDE_DIST_PATH` at job scope. `getElectronPath()` checks it **before** any download and returns a path immediately. Job-scoped rather than step-scoped so that a future version which moves the download back to postinstall is also covered. The path deliberately does not exist: the suite never launches the binary, so anything that started to would fail loudly instead of silently fetching 120MB.

The existing `ELECTRON_SKIP_BINARY_DOWNLOAD` is left in place — its forward-looking rationale still stands — but its comment no longer claims the binary is never needed.

## Tests

Full suite, `website/electron`, from a state with `path.txt` and `dist/` removed:

| | tests | pass | fail | download attempts | `node_modules/electron` |
|---|---|---|---|---|---|
| Without the override (today) | 898 | 892 | 6 | **3** | **313 MB** |
| With the override | 898 | 892 | 6 | **0** | **1.2 MB** |

**The failure sets are byte-identical**, so the change neither introduces nor masks a failure. The 6 failures are artifacts of the isolated copy I ran in (they include `pane constants agree across backend`, which reads files outside `website/electron`); they are present in both arms and are not related to this change.

Caveats: measured on Node v22, whereas CI pins Node 24. This does not fix a currently-red lane — the lane is green on `main` — so the value is removing ~120MB per run from a job billed as tiny, and deleting a failure mode rather than waiting for the next bad window.

## Prior art

I checked the tracker before writing this. The two other flakes I hit are already filed and fixed — #3078 (happy-dom `ECONNREFUSED :6776` in shard 2) and #1555 (the i18n render gate sampling an animated width). #3142 is this same lane but a different cause. I found nothing covering the require-time download: no results for `ELECTRON_SKIP_BINARY_DOWNLOAD`, `ELECTRON_OVERRIDE_DIST_PATH`, or `electron binary download`.

## Note for maintainers

This touches `.github/workflows/ci.yml`, so **Fork workflow-change guard will block it by design** and needs the `allow-fork-workflow-change` label after review. That is the guard working correctly — flagging it here rather than working around it. Since `strip-stale-override` clears the label on any new push, I have kept this to a single commit and will not push again unless review asks for a change.

