### PR TITLE
fix(gateway): clear headless run marker on shutdown

### DIFF
--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -55,7 +55,9 @@ Starts the Socket Mode listener. Blocks until SIGINT/SIGTERM. When `no_crons=Tru
 1. First Ctrl+C sets `shutdown_event` → graceful shutdown begins (10s deadline)
 2. Second Ctrl+C calls `os._exit(0)` immediately (force exit)
 3. `_shutdown()` **first disarms the loop-stall watchdog** (`dashboard_state._loop_watchdog.stop()` + cancels `_loop_heartbeat`), then saves active chat slots, cancels handler tasks, stops cron/heartbeat, closes sessions. The watchdog MUST be disarmed before `close_all()`/`cancel_all()` because that teardown deliberately kills every kiro-cli child — the same `os.waitpid` reaping burst the watchdog guards against — and a slow teardown would otherwise let the armed `faulthandler.dump_traceback_later(exit=True)` timer `_exit(1)` the process mid-shutdown (a clean quit would look like a crash). The watchdog's own `on_cleanup` hook fires too late (inside `AppRunner.cleanup()`, gathered concurrently with the reaping).
-4. Before `os._exit(0)`, `cleanup_orphaned_sessions()` kills any kiro-cli PIDs tracked in the PID file
+4. The gateway clears its port-keyed run marker in both dashboard and API-only
+   modes, then `cleanup_orphaned_sessions()` kills any kiro-cli PIDs tracked in
+   the PID file before `os._exit(0)`.
 
 ### Event-loop stall watchdog & blocking-work executors
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -351,6 +351,11 @@ _MAX_INJECT_ATTEMPTS = 2
 # _JOB_TIMEOUT_SECS: no human is present, so the turn MUST be bounded.
 _NUDGE_TURN_TIMEOUT = 1800.0  # 30 min
 
+# Budget for awaiting the in-flight run-marker write during shutdown. Bounded
+# so a stalled write can never eat into GRACEFUL_SHUTDOWN_SECS (which saves
+# active slots) — the marker is best-effort, the slot save is not.
+_MARKER_WRITE_WAIT_SECS = 5.0
+
 # Approval sources that run UNATTENDED (no human responder). These deny-fast on a
 # short window instead of burning the full 2h human-approval window. Subagent
 # approvals are NOT background: they route to the dashboard where the spawning
@@ -1096,6 +1101,11 @@ class GatewayOrchestrator:
         self.channel_history: ChannelHistory | None = None
         self.dashboard_state: DashboardState | None = None
         self._background_tasks: set[asyncio.Task] = set()  # prevent GC of fire-and-forget tasks
+        self._marker_write_task: "asyncio.Task[None] | None" = None
+        # Set by the shutdown path when the marker write is still in flight:
+        # tells the writer thread to self-clear after publishing, closing the
+        # write-after-clear race without any event-loop dependency.
+        self._marker_clear_pending = threading.Event()
         self._dashboard_runner: web.AppRunner | None = None
         self._handler_tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
         self._session_tasks: dict[str, asyncio.Task] = {}  # type: ignore[type-arg]
@@ -7297,6 +7307,28 @@ class GatewayOrchestrator:
             )
             return False
 
+    def _write_marker_worker(self, run_marker: Any, port: int) -> None:
+        """Write the run marker; self-clear if shutdown flagged a clear.
+
+        ``run_marker`` is the :mod:`kiro_crew.instances.run_marker` module,
+        passed in by ``run()`` (which already imports it lazily) so this
+        worker adds no import of its own. Runs on a ``to_thread`` worker.
+        If graceful shutdown timed out waiting for this write, it sets
+        ``_marker_clear_pending`` BEFORE clearing the marker itself — so
+        whichever order the write and the shutdown-side clear land in, this
+        thread re-clears its own late write. The clear lives in the same
+        thread as the write (not an event-loop callback) because
+        ``os._exit`` can beat any callback still queued on the loop.
+        """
+        try:
+            run_marker.write_marker(port)
+        finally:
+            if self._marker_clear_pending.is_set():
+                try:
+                    run_marker.clear_marker(port)
+                except Exception:
+                    logger.debug("Late run-marker self-clear skipped", exc_info=True)
+
     async def run(self) -> None:
         """Start all services and block until shutdown signal."""
         # ── Crash guard (D1/D2 of Lorikeets-3929) ──
@@ -7426,8 +7458,11 @@ class GatewayOrchestrator:
 
             if self._dashboard_port:
                 _marker_task = asyncio.create_task(
-                    asyncio.to_thread(run_marker.write_marker, self._dashboard_port)
+                    asyncio.to_thread(
+                        self._write_marker_worker, run_marker, self._dashboard_port
+                    )
                 )
+                self._marker_write_task = _marker_task
                 self._background_tasks.add(_marker_task)
                 _marker_task.add_done_callback(self._background_tasks.discard)
         except Exception:
@@ -7644,14 +7679,44 @@ class GatewayOrchestrator:
         await shutdown_event.wait()
         print("👻 Shutting down…")
 
-        # Drop this gateway's run-marker so a mint never execs a launcher for a
-        # port we no longer serve (best-effort; a stale marker is harmless — the
-        # next startup overwrites it, and mint would just fail to reach the down
-        # dashboard exactly as it does today).
+        # Drop this gateway's run-marker BEFORE _shutdown() releases the
+        # listener: once the port is free a replacement gateway can bind it
+        # and publish its own marker + credential, which this clear would
+        # then delete (clear_marker is unconditional — consumers verify
+        # ownership on read, but deleting the successor's credential 403s
+        # its clients). The clear itself is best-effort; a stale marker is
+        # harmless — the next startup overwrites it. The wait for the
+        # in-flight write is bounded so a stalled write cannot eat into the
+        # graceful-shutdown deadline below (which saves active slots). On
+        # timeout the detached writer thread may still republish the marker
+        # after the clear, so _marker_clear_pending is set FIRST: the
+        # writer thread (see _write_marker_worker) then re-clears its own
+        # late write in the same thread, with no event-loop callback that
+        # os._exit could beat. TimeoutError and a failed write are both
+        # caught HERE (not by the outer except) so they still fall through
+        # to the clear.
         try:
             from kiro_crew.instances import run_marker
 
-            if not self._no_dashboard and self._dashboard_port:
+            if self._dashboard_port:
+                if self._marker_write_task is not None:
+                    try:
+                        await asyncio.wait_for(
+                            self._marker_write_task,
+                            timeout=_MARKER_WRITE_WAIT_SECS,
+                        )
+                    except asyncio.TimeoutError:
+                        self._marker_clear_pending.set()
+                        logger.warning(
+                            "Run-marker write did not finish within %ss; "
+                            "clearing marker without waiting",
+                            _MARKER_WRITE_WAIT_SECS,
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Run-marker write failed; clearing anyway",
+                            exc_info=True,
+                        )
                 run_marker.clear_marker(self._dashboard_port)
         except Exception:
             logger.debug("Gateway run-marker clear skipped", exc_info=True)

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -2456,11 +2457,37 @@ class TestRunMethod:
         orch._shutdown.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_run_no_dashboard_uses_api_server(self):
-        """--no-dashboard uses _init_api_server."""
+    async def test_run_no_dashboard_uses_api_server(self, tmp_path, monkeypatch):
+        """--no-dashboard waits for and then clears its run marker."""
         import kiro_crew
+        from kiro_crew.instances import run_marker
 
         orch = _make_orchestrator(no_dashboard=True)
+        orch._dashboard_port = 5476
+
+        monkeypatch.setattr(run_marker, "config_dir", lambda: tmp_path)
+        run_marker.write_marker(orch._dashboard_port)
+        original_write_marker = run_marker.write_marker
+        events = []
+
+        def slow_write_marker(port):
+            events.append("write-start")
+            time.sleep(0.05)
+            original_write_marker(port)
+            events.append("write-end")
+
+        original_clear_marker = run_marker.clear_marker
+
+        def recording_clear_marker(port):
+            events.append("clear")
+            original_clear_marker(port)
+
+        monkeypatch.setattr(run_marker, "write_marker", slow_write_marker)
+        monkeypatch.setattr(run_marker, "clear_marker", recording_clear_marker)
+        marker = run_marker.marker_path(orch._dashboard_port)
+        pid_marker = run_marker.pid_path(orch._dashboard_port)
+        assert marker.exists()
+        assert pid_marker.exists()
 
         orch._init_services = AsyncMock()
         orch._start_embeddings = AsyncMock()
@@ -2487,9 +2514,14 @@ class TestRunMethod:
                     with patch("kiro_crew.slack.interactions.init"):
                         with patch("kiro_crew.slack.events.SeenCache"):
                             with patch("kiro_crew.session.cleanup_orphaned_sessions"):
-                                with patch("kiro_crew.dashboard.handlers._bg_mcp_probe", new_callable=AsyncMock):
+                                with patch(
+                                    "kiro_crew.dashboard.handlers._bg_mcp_probe",
+                                    new_callable=AsyncMock,
+                                ):
                                     with patch("os._exit"):
-                                        with patch("resource.getrlimit", return_value=(256, 10240)):
+                                        with patch(
+                                            "resource.getrlimit", return_value=(256, 10240)
+                                        ):
                                             with patch("resource.setrlimit"):
                                                 await orch.run()
         finally:
@@ -2497,6 +2529,173 @@ class TestRunMethod:
 
         orch._init_dashboard.assert_not_awaited()
         orch._init_api_server.assert_awaited_once()
+        assert events == ["write-start", "write-end", "clear"]
+        assert not marker.exists()
+        assert not pid_marker.exists()
+
+    @pytest.mark.asyncio
+    async def test_run_stalled_marker_write_does_not_block_shutdown(
+        self, tmp_path, monkeypatch
+    ):
+        """A hung marker write times out; the marker is cleared and _shutdown runs.
+
+        Regression: an unbounded ``await self._marker_write_task`` sat before
+        the bounded ``_shutdown()`` call, so a stalled write consumed the
+        graceful-shutdown deadline and active slots were SIGKILLed unsaved.
+        """
+        import kiro_crew
+        from kiro_crew.instances import run_marker
+        from kiro_crew.slack import gateway as gateway_mod
+
+        orch = _make_orchestrator(no_dashboard=True)
+        orch._dashboard_port = 5477
+
+        monkeypatch.setattr(run_marker, "config_dir", lambda: tmp_path)
+        run_marker.write_marker(orch._dashboard_port)
+        # Shrink the wait budget so the timeout path runs fast in tests.
+        monkeypatch.setattr(gateway_mod, "_MARKER_WRITE_WAIT_SECS", 0.05)
+
+        events = []
+        stall = threading.Event()
+        original_write_marker = run_marker.write_marker
+        original_clear_marker = run_marker.clear_marker
+
+        def stalled_write_marker(port):
+            events.append("write-start")
+            stall.wait(5.0)  # far longer than the shrunk 0.05s budget
+            original_write_marker(port)  # late write republishes the marker
+            events.append("write-end")
+
+        def recording_clear_marker(port):
+            events.append("clear")
+            original_clear_marker(port)
+
+        monkeypatch.setattr(run_marker, "write_marker", stalled_write_marker)
+        monkeypatch.setattr(run_marker, "clear_marker", recording_clear_marker)
+        marker = run_marker.marker_path(orch._dashboard_port)
+        pid_marker = run_marker.pid_path(orch._dashboard_port)
+        assert marker.exists()
+
+        orch._init_services = AsyncMock()
+        orch._start_embeddings = AsyncMock()
+        orch._auto_migrate_memory = AsyncMock()
+        orch._init_cron = AsyncMock()
+        orch._init_heartbeat = AsyncMock()
+        orch._init_mcp_discovery = MagicMock()
+        orch._init_subagents = MagicMock()
+        orch._init_task_runner = MagicMock()
+        orch._init_dashboard = AsyncMock()
+        orch._init_api_server = AsyncMock()
+        orch._init_autonudge = AsyncMock()
+        orch._check_for_updates = AsyncMock()
+        orch._shutdown = AsyncMock()
+
+        kiro_crew.shutdown_event.set()
+        loop = asyncio.get_running_loop()
+        try:
+            with patch.object(loop, "add_signal_handler"):
+                with patch("kiro_crew.slack.events.init_socket_mode"):
+                    with patch("kiro_crew.slack.interactions.init"):
+                        with patch("kiro_crew.slack.events.SeenCache"):
+                            with patch("kiro_crew.session.cleanup_orphaned_sessions"):
+                                with patch(
+                                    "kiro_crew.dashboard.handlers._bg_mcp_probe",
+                                    new_callable=AsyncMock,
+                                ):
+                                    with patch("os._exit"):
+                                        with patch(
+                                            "resource.getrlimit", return_value=(256, 10240)
+                                        ):
+                                            with patch("resource.setrlimit"):
+                                                await orch.run()
+        finally:
+            kiro_crew.shutdown_event.clear()
+            # Release AND drain the stalled writer inside this finally: if an
+            # assertion below failed with the worker still parked, monkeypatch
+            # teardown would restore the real config_dir/write_marker and the
+            # worker would wake later and write markers OUTSIDE tmp_path.
+            stall.set()
+            for _ in range(200):  # up to ~10s; normally a few ms
+                if "write-start" not in events or events.count("clear") >= 2:
+                    break
+                await asyncio.sleep(0.05)
+
+        # The stalled write did not complete before the bounded wait expired,
+        # yet the marker was cleared and graceful shutdown still ran — the
+        # timeout kept the deadline intact.
+        assert events[:2] == ["write-start", "clear"]
+        orch._shutdown.assert_awaited_once()
+
+        # The released writer republished the marker files after the
+        # timed-out clear. The writer thread must then self-clear them
+        # (same thread, no event-loop callback os._exit could beat),
+        # otherwise a stopped gateway leaves stale runtime state behind.
+        assert "write-end" in events
+        assert events.index("write-end") > events.index("clear")
+        assert events.count("clear") == 2  # timed-out clear + writer self-clear
+        assert not marker.exists()
+        assert not pid_marker.exists()
+
+    @pytest.mark.asyncio
+    async def test_run_failed_marker_write_still_clears(self, tmp_path, monkeypatch):
+        """A marker write that raises must not skip the shutdown clear."""
+        import kiro_crew
+        from kiro_crew.instances import run_marker
+
+        orch = _make_orchestrator(no_dashboard=True)
+        orch._dashboard_port = 5478
+
+        monkeypatch.setattr(run_marker, "config_dir", lambda: tmp_path)
+        run_marker.write_marker(orch._dashboard_port)  # pre-existing marker
+
+        def failing_write_marker(port):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(run_marker, "write_marker", failing_write_marker)
+        marker = run_marker.marker_path(orch._dashboard_port)
+        pid_marker = run_marker.pid_path(orch._dashboard_port)
+        assert marker.exists()
+
+        orch._init_services = AsyncMock()
+        orch._start_embeddings = AsyncMock()
+        orch._auto_migrate_memory = AsyncMock()
+        orch._init_cron = AsyncMock()
+        orch._init_heartbeat = AsyncMock()
+        orch._init_mcp_discovery = MagicMock()
+        orch._init_subagents = MagicMock()
+        orch._init_task_runner = MagicMock()
+        orch._init_dashboard = AsyncMock()
+        orch._init_api_server = AsyncMock()
+        orch._init_autonudge = AsyncMock()
+        orch._check_for_updates = AsyncMock()
+        orch._shutdown = AsyncMock()
+
+        kiro_crew.shutdown_event.set()
+        loop = asyncio.get_running_loop()
+        try:
+            with patch.object(loop, "add_signal_handler"):
+                with patch("kiro_crew.slack.events.init_socket_mode"):
+                    with patch("kiro_crew.slack.interactions.init"):
+                        with patch("kiro_crew.slack.events.SeenCache"):
+                            with patch("kiro_crew.session.cleanup_orphaned_sessions"):
+                                with patch(
+                                    "kiro_crew.dashboard.handlers._bg_mcp_probe",
+                                    new_callable=AsyncMock,
+                                ):
+                                    with patch("os._exit"):
+                                        with patch(
+                                            "resource.getrlimit", return_value=(256, 10240)
+                                        ):
+                                            with patch("resource.setrlimit"):
+                                                await orch.run()
+        finally:
+            kiro_crew.shutdown_event.clear()
+
+        # The failed write must not divert control past the clear: the
+        # pre-existing marker files are removed and shutdown completed.
+        assert not marker.exists()
+        assert not pid_marker.exists()
+        orch._shutdown.assert_awaited_once()
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/test/windows-expected-failures.txt
+++ b/test/windows-expected-failures.txt
@@ -222,8 +222,10 @@ test/test_session_pid_sig.py::TestNoNofollowPlatform::test_symlink_present_at_ls
 test/test_slack_config_handlers.py::test_write_env_updates_adds_and_preserves
 test/test_slack_config_handlers.py::test_write_env_updates_is_atomic_and_owner_only
 test/test_slack_gateway.py::TestBgSessionDashboardBranch::test_bg_session_prints_dashboard_url
+test/test_slack_gateway.py::TestRunMethod::test_run_failed_marker_write_still_clears
 test/test_slack_gateway.py::TestRunMethod::test_run_no_dashboard_uses_api_server
 test/test_slack_gateway.py::TestRunMethod::test_run_raises_on_shutdown
+test/test_slack_gateway.py::TestRunMethod::test_run_stalled_marker_write_does_not_block_shutdown
 test/test_slack_gateway.py::TestRunSignalAndBgSession::test_run_with_ollama_config
 test/test_subagent_cwd.py::TestValidateCwd::test_tilde_expanded_in_allowed_roots
 test/test_subagent_cwd.py::TestValidateCwd::test_tilde_expanded_in_cwd


### PR DESCRIPTION
## Problem / Motivation

Graceful shutdown clears the port-keyed run marker only when the dashboard is enabled. An API-only (`--no-dashboard`) gateway therefore leaves stale runtime markers behind after it exits.

## Why it matters

Stale markers make later startup and instance discovery treat a stopped headless gateway as still present (issue #2975): stale runtime state survives every clean exit of an API-only gateway, so consumers must rely on prune/ownership fallbacks instead of the marker lifecycle being symmetric.

## What changed (motivation → approach → change)

Symptom: stale `.bin`/`.pid` markers after an API-only gateway exits. Root cause: the shutdown clear was gated on `not self._no_dashboard`, while the boot-path write runs for any resolved port. Change: track the async marker write (`_marker_write_task`), and clear the marker for both dashboard and API-only gateways.

Ordering and hardening around that clear:

- The clear runs **after** the bounded `_shutdown()` (which saves active slots), and the wait for the in-flight write is itself bounded (`_MARKER_WRITE_WAIT_SECS`, 5s) — a stalled write can neither eat the graceful-shutdown deadline nor hold up process exit.
- On timeout, the detached `to_thread` writer survives cancellation and could republish the marker after the clear. A thread-safe `_marker_clear_pending` flag makes the writer thread self-clear its own late write in the same thread (an event-loop callback could be beaten by `os._exit`).
- `TimeoutError` and write failures are caught inside the clear block, so both still fall through to `clear_marker()` instead of being swallowed by the outer `except` and skipping the clear on exactly the path this PR fixes.

## Tests

- `test_run_no_dashboard_uses_api_server` — extended with a delayed marker writer: verifies write-before-clear ordering and both marker files removed.
- `test_run_stalled_marker_write_does_not_block_shutdown` — a hung write times out, the marker is cleared, `_shutdown()` still runs; the released writer's late republish is re-cleared by the self-clear path.
- `test_run_failed_marker_write_still_clears` — a raising write does not skip the clear.
- Full module: `pytest test/test_slack_gateway.py` — 223 passed.

## Manual verification

N/A — the regression tests exercise the real marker filesystem helpers, delayed/stalled/failing write ordering, and the complete orchestrator shutdown path.

<!-- no-visual-delta -->
**Why no screenshot:** backend shutdown cleanup only; rendered UI is unchanged.

## Related Issues

Closes #2975

