### PR TITLE
fix(snapshot): refuse malformed cron JSON during merge

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -122,7 +122,7 @@ This allows `kirocrew` to find project-level agent config and skills from any di
 | `kirocrew snapshot --keep N` | Auto-prune to N most recent snapshots (default 7) |
 | `kirocrew snapshot --list` | List existing snapshots |
 | `kirocrew restore <file>` | Restore from a snapshot (auto-detects replace vs merge) |
-| `kirocrew restore <file> --mode replace\|merge` | Force restore mode |
+| `kirocrew restore <file> --mode replace\|merge` | Force restore mode; merge skips malformed incoming or local cron JSON with a file-specific warning |
 | `kirocrew restore <file> --components X,Y` | Selective component restore |
 | `kirocrew restore <file> --dry-run` | Preview restore without writing |
 | `kirocrew restore --list-components` | Show available component names |

--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -492,8 +492,16 @@ def _merge_memory(src_db: Path, dst_db: Path) -> None:
 
 
 def _merge_crons(src_path: Path, dst_path: Path) -> None:
-    src = json.loads(src_path.read_text())
-    dst = json.loads(dst_path.read_text())
+    try:
+        src = json.loads(src_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"  ⚠️  Could not read {src_path}: {exc} — skipping cron merge")
+        return
+    try:
+        dst = json.loads(dst_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"  ⚠️  Could not read {dst_path}: {exc} — skipping cron merge")
+        return
     existing = {j.get("name") for j in dst.get("jobs", [])}
     imported = 0
     for job in src.get("jobs", []):

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -339,6 +339,43 @@ class TestRestoreMerge:
         count = len(json.loads((dst / "crons.json").read_text(encoding="utf-8"))["jobs"])
         assert count == 2
 
+    def test_merge_malformed_snapshot_crons_skips_without_changing_local_file(
+        self, env, capsys, monkeypatch
+    ):
+        src, _, _, tmp_path = env
+        (src / "crons.json").write_text("{malformed", encoding="utf-8")
+        tarball = _make_snapshot(src, tmp_path / "malformed-snapshot-out")
+        dst = tmp_path / "dst_malformed_snapshot_crons"
+        _setup_fake_kirocrew(dst)
+        before = (dst / "crons.json").read_bytes()
+
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(tarball), "--mode", "merge", "--components", "crons", "--force"])
+
+        assert ret == 0
+        assert (dst / "crons.json").read_bytes() == before
+        output = capsys.readouterr().out
+        assert "crons.json" in output
+        assert "skipping cron merge" in output
+
+    def test_merge_malformed_local_crons_skips_without_changing_local_file(
+        self, env, capsys, monkeypatch
+    ):
+        _, _, tarball, tmp_path = env
+        dst = tmp_path / "dst_malformed_local_crons"
+        _setup_fake_kirocrew(dst)
+        malformed = b"{malformed"
+        (dst / "crons.json").write_bytes(malformed)
+
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(tarball), "--mode", "merge", "--components", "crons", "--force"])
+
+        assert ret == 0
+        assert (dst / "crons.json").read_bytes() == malformed
+        output = capsys.readouterr().out
+        assert str(dst / "crons.json") in output
+        assert "skipping cron merge" in output
+
     def test_merge_workspace_no_overwrite(self, env, monkeypatch):
         """TEST 10"""
         _, _, tarball, tmp_path = env


### PR DESCRIPTION
## Problem

`kirocrew restore --mode merge` raises an uncaught JSON decoding traceback when either the snapshot or receiving machine has a malformed `crons.json` and both files exist.

## Why it matters

Restore should degrade per component and explain what it skipped. A traceback makes a recoverable cron-file problem look like a failed restore and obscures which file needs attention.

## Fix

Guard each cron JSON read independently at the merge boundary. If either file is unreadable or invalid JSON, report the exact path, skip only the cron merge, and leave the receiving file untouched. The neighboring notification merge already handles malformed JSON records per line, so no parallel change is needed there.

## Tests

- Add coverage for malformed snapshot cron JSON.
- Add coverage for malformed local cron JSON.
- In both cases, verify restore returns normally, names the file, and preserves the local file byte-for-byte.
- Run the complete snapshot test module: 49 passed.

## Manual verification

N/A — unit coverage exercises complete snapshot creation/extraction and merge-mode restore using real files.

## Screenshots

<!-- no-visual-delta -->
**Why no screenshot:** This changes CLI error handling only; rendered UI is unchanged.

Closes #3070
