### PR TITLE
refactor(chat): send the older-history cursor from the server

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -925,6 +925,9 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
             messages = mem_msgs
         total = len(messages)
         has_more = False
+        # This branch returns the whole corpus, so there is no older page to ask
+        # for. Sent anyway so the field is present on every response shape.
+        next_before = 0
     else:
         # Legacy pagination path (retained for programmatic callers).
         # Always reads from chained disk history; no in-memory offset math.
@@ -957,6 +960,11 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
         start = max(0, end - limit)
         messages = all_msgs[start:end]
         has_more = start > 0
+        # The cursor the client should send next, in the RAW index space this
+        # slice was taken in. The client cannot derive it from the response: the
+        # returned rows are _prepare_messages output, which collapses chunk runs
+        # and drops done, so their count is not the span consumed here.
+        next_before = start
 
     prepared = _prepare_messages(messages, slot.running)
 
@@ -975,6 +983,7 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
             ],
             "total": total,
             "has_more": has_more,
+            "next_before": next_before,
             # Seeds the context meter on open. Turn-scoped WS frames alone leave
             # it empty for a session reopened in a new tab; omitted entirely
             # (not zeroed) when genuinely unknown, so the frontend can tell
@@ -3462,6 +3471,12 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
         total = len(existing.messages)
         recent = existing.messages[-200:] if total > 200 else existing.messages
         prepared = _prepare_messages(recent, existing.running)
+        # Raw index this window starts at: the frozen on-disk prefix plus the
+        # in-memory rows it skipped. has_more is derived from the same number so
+        # the flag cannot contradict the cursor -- counting only the in-memory
+        # window said "no more" for a slot with a prefix, and the client drops a
+        # cursor it was told not to use.
+        next_before = (getattr(existing, "_disk_older_count", 0) or 0) + (total - len(recent))
         return web.json_response(
             {
                 "ok": True,
@@ -3472,7 +3487,8 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
                     for q in existing._queue
                 ],
                 "total": total,
-                "has_more": total > 200,
+                "has_more": next_before > 0,
+                "next_before": next_before,
                 "memory_mode": existing.memory_mode,
                 # Return the slot's mode (and its `surface` alias) so the
                 # frontend can render the recovered slot in the correct mode
@@ -3636,6 +3652,9 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
         {
             "ok": True,
             "key": slot.key,
+            # `total` is the full on-disk length here, so this already is the
+            # raw index the next older page starts from.
+            "next_before": total - len(recent),
             "messages": _prepare_messages(recent, slot.running),
             "queue": [
                 {"id": q["id"], "content": _redact_for_display(q["content"])} for q in slot._queue

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -948,11 +948,16 @@ class TestSlotDetailPagination:
             assert data["has_more"] is True
             assert len(data["messages"]) == 200
             assert data["total"] == 300
+            # The cursor for the next page, in the raw index space this slice was
+            # taken in. The client cannot derive it from the response body, whose
+            # rows have already been collapsed by _prepare_messages.
+            assert data["next_before"] == 100
 
-            resp = await client.get("/api/chat/slots/test?limit=200&before=100")
+            resp = await client.get(f"/api/chat/slots/test?limit=200&before={data['next_before']}")
             data = await resp.json()
             assert len(data["messages"]) == 100
             assert data["has_more"] is False
+            assert data["next_before"] == 0
             assert data["messages"][0]["content"] == "msg 0"
 
     @pytest.mark.asyncio
@@ -1863,6 +1868,60 @@ class TestResumeDedupe:
         assert r["surface"] == "orchestrator"
         # The live slot must also carry the restored mode.
         assert state._slots["orchhist"].mode == "orchestrator"
+
+    @pytest.mark.asyncio
+    async def test_resume_from_disk_sends_the_older_history_cursor(self, tmp_path, monkeypatch):
+        """A fresh resume must send next_before. The client pages by that field
+        and treats its absence as 'no older history', so omitting it strands
+        every row outside the returned window."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        for i in range(250):
+            log.append("dashboard:deep", "user", f"m{i}")
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            r = await (
+                await client.post(
+                    "/api/chat/slots/deep/resume", json={"key": "dashboard:deep"}
+                )
+            ).json()
+
+        assert r["ok"] is True
+        assert r["has_more"] is True, "250 rows past a 200-row page must report more"
+        assert "next_before" in r, "resume omitted the cursor the client pages by"
+        assert r["next_before"] == 250 - 200
+
+    @pytest.mark.asyncio
+    async def test_resume_existing_slot_cursor_counts_the_frozen_prefix(
+        self, tmp_path, monkeypatch
+    ):
+        """`total` on this branch counts only the in-memory window, so the cursor
+        has to add the frozen on-disk prefix back. Without that it points inside
+        the range it is meant to skip past, and paging silently loses rows."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.conversation_log.append("dashboard:s1", "user", "hello")
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            await client.post("/api/chat/slots/s1/resume", json={"key": "dashboard:s1"})
+            # A restored slot keeps its older on-disk rows outside slot.messages.
+            state._slots["s1"]._disk_older_count = 300
+            r = await (
+                await client.post("/api/chat/slots/s1/resume", json={"key": "dashboard:s1"})
+            ).json()
+
+        assert r["ok"] is True
+        # window is 1 row and is entirely returned, so the cursor is the prefix.
+        assert r["next_before"] == 300, (
+            "cursor ignored _disk_older_count; it would page from inside the prefix"
+        )
+        # A cursor the client is told not to use is dead: every reducer does
+        # `hasMore ? nextBefore : 0`, so asserting the value alone would pass
+        # while the fix stayed inert for exactly the slot shape it targets.
+        assert r["has_more"] is True, (
+            "has_more counted only the in-memory window, so the client discards the cursor"
+        )
 
     @pytest.mark.asyncio
     async def test_resume_existing_slot_returns_it(self, tmp_path, monkeypatch):

--- a/website/src/store/chatSlice.olderHistoryCursor.test.ts
+++ b/website/src/store/chatSlice.olderHistoryCursor.test.ts
@@ -35,7 +35,7 @@ vi.mock('../api/client', () => ({
       const lim = limit ?? 200
       const end = before !== undefined ? Math.max(0, Math.min(before, TOTAL)) : TOTAL
       const start = Math.max(0, end - lim)
-      return Promise.resolve({ messages: HISTORY.slice(start, end), has_more: start > 0, total: TOTAL })
+      return Promise.resolve({ messages: HISTORY.slice(start, end), has_more: start > 0, total: TOTAL, next_before: start })
     }),
     resumeChatSlot: vi.fn(() => Promise.resolve({ ok: true })),
   },
@@ -62,7 +62,7 @@ function resumed(store: ReturnType<typeof makeStore>) {
   const recent = HISTORY.slice(TOTAL - PAGE)
   store.dispatch(
     resumeFromHistory.fulfilled(
-      { ok: true, key: 'active', rawCount: recent.length, messages: recent, hasMore: true, total: TOTAL },
+      { ok: true, key: 'active', nextBefore: TOTAL - PAGE, messages: recent, hasMore: true, total: TOTAL },
       'req-resume',
       { key: 'active', title: 'active' },
     ),
@@ -129,11 +129,8 @@ describe('loadOlderMessages', () => {
   })
 
   it('does not overlap when the server collapses rows before returning them', async () => {
-    // _prepare_messages collapses chunk runs and drops done, so a page returns
-    // fewer rows than the raw span it consumed. Collapse is a property of the
-    // ROW, so the same row is omitted from every window it falls in. Sizing the
-    // cursor from the returned length steps it too little, and the next page
-    // re-fetches rows the previous page already delivered.
+    // A page returns fewer rows than the raw span it consumed, so only the
+    // server's cursor steps far enough to avoid re-delivering rows.
     const collapsed = (m: FakeMsg) => Number(m.content.slice(1)) % 5 === 0
     const detailMock = api.chatSlotDetail as unknown as {
       mockImplementation: (f: (s: string, l?: number, b?: number) => Promise<unknown>) => void
@@ -146,6 +143,7 @@ describe('loadOlderMessages', () => {
         messages: HISTORY.slice(start, end).filter((m) => !collapsed(m)),
         has_more: start > 0,
         total: TOTAL,
+        next_before: start,
       })
     })
 
@@ -157,5 +155,33 @@ describe('loadOlderMessages', () => {
     const contents = store.getState().chat.messages.map((m) => m.content)
     const dupes = [...new Set(contents.filter((c, i) => contents.indexOf(c) !== i))]
     expect(dupes).toEqual([])
+  })
+})
+
+describe('resume cursor', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  // Both directions: without the positive case, a thrown thunk would leave
+  // hasMore false and the guard assertion would pass for the wrong reason.
+  it('advertises older history when the server sends a cursor', async () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('active'))
+    ;(api.resumeChatSlot as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true, key: 'active', messages: [], has_more: true, total: TOTAL, next_before: TOTAL - PAGE,
+    })
+    await store.dispatch(resumeFromHistory({ key: 'active', title: 'active' }) as never)
+    expect(store.getState().chat.slotHasMore).toBe(true)
+    expect(store.getState().chat.slotOldestIndex).toBe(TOTAL - PAGE)
+  })
+
+  it('does not advertise older history when the server omits the cursor', async () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('active'))
+    ;(api.resumeChatSlot as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true, key: 'active', messages: [], has_more: true, total: TOTAL,
+    })
+    await store.dispatch(resumeFromHistory({ key: 'active', title: 'active' }) as never)
+    expect(store.getState().chat.slotHasMore).toBe(false)
+    expect(store.getState().chat.slotOldestIndex).toBe(0)
   })
 })

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -907,26 +907,14 @@ export const fetchHistory = createAsyncThunk(
   },
 )
 
-/** Raw server rows one older-history page consumes. The handler slices
- *  all_msgs[end - limit : end] (chat_handlers.api_chat_slot_detail), so when it
- *  reports has_more this limit IS the raw span -- unlike the returned array,
- *  which _prepare_messages has already collapsed. */
-const OLDER_PAGE_RAW = 100
-
-/** Raw server rows a paged resume consumes: api_chat_slot_resume sends
- *  messages[-200:] and reports has_more only when total > 200, so a paged
- *  resume always consumed exactly this many raw rows. */
-const RESUME_PAGE_RAW = 200
+/** Rows to request per older-history page. */
+const OLDER_PAGE_LIMIT = 100
 
 async function fetchSlotDetail(key: string) {
   // No limit → backend returns all chained history (across gateway restarts).
   const d = await api.chatSlotDetail(key)
   type QueueItem = string | { content: string; id: string }
-  // This path requests no limit, so the handler returns the whole tail and
-  // reports has_more false; the raw span is therefore the entire history. Any
-  // value would do while has_more is false, but total keeps the cursor at 0
-  // rather than at a wrong index if that ever changes.
-  return { key, rawCount: d.total || 0, messages: filterMessages(d.messages || []), running: d.running || false, stopping: d.stopping || false, hasMore: d.has_more || false, total: d.total || 0, queue: ((d.queue || []) as QueueItem[]).map((q: QueueItem) => typeof q === 'string' ? { content: q, queueId: crypto.randomUUID(), ts: new Date().toISOString() } : { content: q.content, queueId: q.id, ts: new Date().toISOString() }), context: d.context_pct != null ? { pct: d.context_pct, used: d.context_used_tokens ?? undefined, window: d.context_window_tokens ?? undefined } : undefined }
+  return { key, nextBefore: d.next_before || 0, messages: filterMessages(d.messages || []), running: d.running || false, stopping: d.stopping || false, hasMore: d.has_more || false, total: d.total || 0, queue: ((d.queue || []) as QueueItem[]).map((q: QueueItem) => typeof q === 'string' ? { content: q, queueId: crypto.randomUUID(), ts: new Date().toISOString() } : { content: q.content, queueId: q.id, ts: new Date().toISOString() }), context: d.context_pct != null ? { pct: d.context_pct, used: d.context_used_tokens ?? undefined, window: d.context_window_tokens ?? undefined } : undefined }
 }
 
 /** SINGLE hydration path for the slot-detail context-meter fields — the one
@@ -1281,7 +1269,10 @@ export const resumeFromHistory = createAsyncThunk(
       dispatch(addSlotOptimistic({ key: d.key, title: title || d.key, messages: 0, running: false, memory_mode: d.memory_mode, mode: d.mode, surface: d.surface ?? d.mode, pending_approval: false, waiting_for_input: false, last_activity_ts: undefined }))
       dispatch(updateSlot({ key: d.key, mode: d.mode, surface: d.surface ?? d.mode }))
     }
-    return { ok: d.ok, key: d.key, rawCount: RESUME_PAGE_RAW, messages: filterMessages(d.messages || []), hasMore: d.has_more || false, total: d.total || 0 }
+    // Without a cursor this response cannot be paged, so do not advertise more:
+    // a zero cursor beside hasMore renders an affordance that loads nothing.
+    const cursor = typeof d.next_before === 'number' ? d.next_before : null
+    return { ok: d.ok, key: d.key, nextBefore: cursor ?? 0, messages: filterMessages(d.messages || []), hasMore: cursor !== null && (d.has_more || false), total: d.total || 0 }
   },
 )
 
@@ -1311,13 +1302,8 @@ export const loadOlderMessages = createAsyncThunk(
     if (!state.activeSlot || !state.slotHasMore) return null
     if (state.slotOldestIndex <= 0) return null
     const slot = state.activeSlot
-    const d = await api.chatSlotDetail(slot, OLDER_PAGE_RAW, state.slotOldestIndex)
-    // rawCount is the span of RAW server rows this page consumed, which is NOT
-    // the length of what came back: the handler returns _prepare_messages(...),
-    // which collapses chunk runs and drops done. When has_more is true the
-    // handler took exactly `limit` raw rows (start = end - limit), so the
-    // requested limit IS the span.
-    return { slot, rawCount: OLDER_PAGE_RAW, messages: filterMessages(d.messages || []), hasMore: d.has_more || false, total: d.total || 0 }
+    const d = await api.chatSlotDetail(slot, OLDER_PAGE_LIMIT, state.slotOldestIndex)
+    return { slot, nextBefore: d.next_before || 0, messages: filterMessages(d.messages || []), hasMore: d.has_more || false, total: d.total || 0 }
   },
   {
     // Concurrency guard belongs HERE, not in the payload creator: `pending`
@@ -3165,7 +3151,7 @@ const chatSlice = createSlice({
         state._wsChunkedDuringFetch = false
       })
       .addCase(switchSlot.fulfilled, (state, action) => {
-        const { key, messages, running, hasMore, total, queue, rawCount } = action.payload
+        const { key, messages, running, hasMore, queue, nextBefore } = action.payload
         if (isUnsafeKey(key)) return
         if (state.activeSlot !== key) return  // user switched away during fetch
         state.slotState = running ? 'streaming' : 'idle'
@@ -3241,7 +3227,7 @@ const chatSlice = createSlice({
         state.slotStopping = action.payload.stopping ?? false
         state.pendingTurnSlot = null
         state.slotHasMore = hasMore
-        state.slotOldestIndex = hasMore ? Math.max(0, total - rawCount) : 0
+        state.slotOldestIndex = hasMore ? nextBefore : 0
         // Hydrate queued messages from the backend queue field through the
         // single shared path (hydrateQueuedBubbles) so this reducer cannot drift
         // from warmSlotCache/refreshSlot. It strips any WS-delivered queued
@@ -3267,7 +3253,7 @@ const chatSlice = createSlice({
       })
       .addCase(refreshSlot.fulfilled, (state, action) => {
         if (!action.payload) return
-        const { key, messages, running, hasMore, total, queue, rawCount } = action.payload
+        const { key, messages, running, hasMore, queue, nextBefore } = action.payload
         if (isUnsafeKey(key)) return
         if (state.activeSlot !== key) return  // user switched away
         // Merge permission messages: prefer state perms (have frontend resolved flags)
@@ -3310,7 +3296,7 @@ const chatSlice = createSlice({
         state.slotStopping = action.payload.stopping ?? false
         state.pendingTurnSlot = null
         state.slotHasMore = hasMore
-        state.slotOldestIndex = hasMore ? Math.max(0, total - rawCount) : 0
+        state.slotOldestIndex = hasMore ? nextBefore : 0
         seedContextUsage(state, key, action.payload.context)
       })
       .addCase(warmSlotCache.fulfilled, (state, action) => {
@@ -3431,7 +3417,7 @@ const chatSlice = createSlice({
           state.slotState = 'idle'
           state.pendingTurnSlot = null
           state.slotHasMore = action.payload.hasMore
-          state.slotOldestIndex = action.payload.hasMore ? Math.max(0, action.payload.total - action.payload.rawCount) : 0
+          state.slotOldestIndex = action.payload.hasMore ? action.payload.nextBefore : 0
         }
       })
       .addCase(deleteHistorySession.fulfilled, (state, action) => {
@@ -3454,9 +3440,7 @@ const chatSlice = createSlice({
           const fresh = merged.filter(m => !isRedeliveredMessage(state.messages, m.meta))
           state.messages = [...fresh, ...state.messages]
           state.slotHasMore = action.payload.hasMore
-          state.slotOldestIndex = action.payload.hasMore
-            ? Math.max(0, state.slotOldestIndex - action.payload.rawCount)
-            : 0
+          state.slotOldestIndex = action.payload.hasMore ? action.payload.nextBefore : 0
         }
       })
       .addCase(loadOlderMessages.rejected, (state) => {

--- a/website/src/test/ChatSliceCoverageSecondPass.test.tsx
+++ b/website/src/test/ChatSliceCoverageSecondPass.test.tsx
@@ -925,7 +925,7 @@ describe('chatSlice thunks', () => {
         { role: 'user', content: 'old question', cls: '' },
         { role: 'chunk', content: 'dropped', cls: '' },
       ],
-      has_more: true, total: 250, mode: 'dashboard', surface: 'dashboard', memory_mode: 'full',
+      has_more: true, total: 250, next_before: 50, mode: 'dashboard', surface: 'dashboard', memory_mode: 'full',
     })
     const store = makeStore()
     store.dispatch(setActiveSlot('origin'))
@@ -935,10 +935,8 @@ describe('chatSlice thunks', () => {
     // Streaming scaffolding roles never enter the transcript.
     expect(s.messages.map(m => m.role)).toEqual(['user'])
     expect(s.slotHasMore).toBe(true)
-    // The cursor is a RAW index into the server's history. A paged resume always
-    // consumes exactly 200 raw rows (messages[-200:], has_more only when
-    // total > 200), however few of them survive _prepare_messages and
-    // filterMessages -- here just one of the two that arrived.
+    // The cursor is the server's raw index: only one of the two arrived rows
+    // survived filterMessages, and neither count bears on it.
     expect(s.slotOldestIndex).toBe(50)
     expect(store.getState().dashboard.slots.some(sl => sl.key === 'resumed')).toBe(true)
   })
@@ -970,12 +968,11 @@ describe('chatSlice thunks', () => {
   it('prepends an older page and tracks the remaining depth', () => {
     let s = chatReducer(initial, setActiveSlot('A'))
     // Arm the cursor the way a resume does: one resident message out of ten, so
-    // nine remain above it. loadOlder then walks the cursor back by the number of
-    // RAW messages each page returned.
+    // nine remain above it. Each page then carries the next cursor itself.
     s = chatReducer(s, lifecycle('chat/resumeFromHistory/fulfilled', 'A', {
       ok: true,
       key: 'A',
-      rawCount: 1,
+      nextBefore: 9,
       messages: [msg({ role: 'user', content: 'newest', ts: '9' })],
       hasMore: true,
       total: 10,
@@ -985,7 +982,7 @@ describe('chatSlice thunks', () => {
     expect(s.loadingOlder).toBe(true)
     s = chatReducer(s, lifecycle('chat/loadOlder/fulfilled', 'A', {
       slot: 'A',
-      rawCount: 1,
+      nextBefore: 8,
       messages: [msg({ role: 'user', content: 'older', ts: '1' })],
       hasMore: true,
       total: 10,


### PR DESCRIPTION
Follow-up to #3339 (merged 2026-08-13), whose design review proposed it: *"the true fix is a follow-up where the handler returns its already-computed `start` as a `next_before` cursor, eliminating all client-side index arithmetic."*

## Why the client could not compute this

`slotOldestIndex` is a `?before=` cursor: a raw index into the server's history. Both handlers already know it and were throwing it away.

- `api_chat_slot_detail` computes `start = max(0, end - limit)` and returns `all_msgs[start:end]`.
- `api_chat_slot_resume` sends `messages[-200:]`, so the window begins at `total - len(recent)`.

Both then return `_prepare_messages(...)`, which collapses `chunk` runs and drops `done`, while `total` and `start` are counted on the raw rows. So the response body is in different units from the cursor, and no count taken from it reconstructs the index. #3339 worked around that by having the client mirror each handler's window size — `100` for a page, `200` for a resume — which is correct only for as long as those two numbers stay in sync across a process boundary.

## What changes

Each handler returns the index it already had:

```python
next_before = start                       # api_chat_slot_detail, paged branch
next_before = 0                           # no-limit branch: whole corpus, nothing older
"next_before": total - len(recent)        # api_chat_slot_resume, disk-load branch
next_before = _disk_older_count + (total - len(recent))   # ... existing-slot branch
```

All four client cursor sites collapse to the same shape:

```ts
state.slotOldestIndex = hasMore ? nextBefore : 0
```

That deletes `rawCount`, both mirrored window-size constants, the `Math.max(0, ...)` clamps that existed to contain arithmetic that no longer happens, and the accumulate-versus-recompute distinction between the `loadOlder` site and the other three. `total` is no longer read by any cursor site.

## Two behaviour changes on the existing-slot resume branch, not just a refactor

Both are on `api_chat_slot_resume`'s already-active-slot path, where `total` counts only the **in-memory** window while the slot may also hold a frozen on-disk prefix:

1. **The cursor now adds that prefix.** The old `total - len(recent)` pointed *inside* the prefix, so paging skipped the rows it was meant to step over. For a 1000-row slot with a 500-row window it asked for `before=300` while the resident rows started at raw 800.
2. **`has_more` is now derived from the cursor** (`next_before > 0`) instead of `total > 200`. Counting only the in-memory window reported `has_more: false` for a slot with a prefix and ≤200 resident rows — and every reducer does `hasMore ? nextBefore : 0`, so the client discarded the very cursor fix 1 computes. Deriving both from one number means the flag cannot contradict the cursor. For a slot with no prefix the value is unchanged.

Fix 2 came from the First Principles review lane, which spotted that fix 1 was inert in exactly the slot shape it targets.

## Verification

The `loadOlder` reducer no longer touches the response body, so the guard is that it must not regress to inferring one. Reinstating `slotOldestIndex - messages.length` at that site duplicates 16 rows (`m201`-`m219`, less the collapsed ones) in the collapsing-server test, which is how that test earns its place.

- `test/`: 559 passed in `test_dashboard_chat.py`, 582 with `test_dashboard.py` alongside.
- `website`: 155 passed across `chatSlice.olderHistoryCursor.test.ts`, `ChatSliceCoverageSecondPass.test.tsx` and `chatSliceCoverage.test.tsx`; `tsc -b` clean.
- The frozen-prefix test asserts **both** `next_before == 300` and `has_more is True`. Asserting the value alone passed while the cursor stayed unusable, which is what hid fix 2.
- Reverting `has_more` to `total > 200` fails that test and only that test; reverting the prefix term fails the cursor assertion.
- `flake8`, `isort` and the comment-length lint clean.

`next_before` is additive, so an older client ignoring it is unaffected.
