### PR TITLE
test(frontend): normalize widget blob URL fixture

### DIFF
--- a/website/docs/testing.md
+++ b/website/docs/testing.md
@@ -57,6 +57,11 @@ a component under test talks to a realistic API without a gateway running.
 When a test fails with an unhandled request, the fix is almost always a missing
 handler rather than a change to the component: add the endpoint to the mock server.
 
+Mocks for `URL.createObjectURL()` that feed an iframe must return a well-formed
+`blob:<origin>/<id>` URL rooted at the configured happy-dom origin. Short forms
+such as `blob:test` can be reinterpreted during deferred iframe cleanup and escape
+the MSW boundary after the test file has finished.
+
 ## Playwright: how it actually runs
 
 The config is `playwright.config.ts`, and several of its choices surprise people:

--- a/website/src/test/ArtifactDetailPage.companionChat.test.tsx
+++ b/website/src/test/ArtifactDetailPage.companionChat.test.tsx
@@ -95,7 +95,7 @@ describe('ArtifactDetailPage companion chat', () => {
     sessionStorage.clear()
     if (!URL.createObjectURL) {
       // @ts-expect-error stub
-      URL.createObjectURL = vi.fn().mockReturnValue('blob:test')
+      URL.createObjectURL = vi.fn().mockReturnValue('blob:http://localhost:6776/artifact-detail-companion-chat')
       // @ts-expect-error stub
       URL.revokeObjectURL = vi.fn()
     }

--- a/website/src/test/ArtifactDetailPage.stickyHeader.test.tsx
+++ b/website/src/test/ArtifactDetailPage.stickyHeader.test.tsx
@@ -39,7 +39,7 @@ function renderRoute() {
 describe('ArtifactDetailPage — sticky header', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost:6776/artifact-detail-sticky-header')
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     vi.mocked(api).artifactEvents = vi.fn().mockResolvedValue({ slug: 'cr-queue', events: [] })
     vi.mocked(api).artifactComments = vi.fn().mockResolvedValue({ comments: [] })

--- a/website/src/test/ArtifactDetailPage.test.tsx
+++ b/website/src/test/ArtifactDetailPage.test.tsx
@@ -66,7 +66,7 @@ describe('ArtifactDetailPage', () => {
     vi.clearAllMocks()
     // Spy rather than assign: only a spy lands in the registry that
     // vi.restoreAllMocks() can undo. The env provides both natively.
-    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost:6776/artifact-detail-test')
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     // Default events response so the events query never throws "undefined".
     // Individual tests can override this with .mockResolvedValueOnce when

--- a/website/src/test/ArtifactDetailPageCoverage.test.tsx
+++ b/website/src/test/ArtifactDetailPageCoverage.test.tsx
@@ -178,7 +178,7 @@ describe('ArtifactDetailPage — mutation paths', () => {
     sessionStorage.clear()
     if (!URL.createObjectURL) {
       // @ts-expect-error jsdom lacks blob URLs
-      URL.createObjectURL = vi.fn().mockReturnValue('blob:test')
+      URL.createObjectURL = vi.fn().mockReturnValue('blob:http://localhost:6776/artifact-detail-coverage')
       // @ts-expect-error jsdom lacks blob URLs
       URL.revokeObjectURL = vi.fn()
     }

--- a/website/src/test/RemoteArtifactDetailPageCoverage.test.tsx
+++ b/website/src/test/RemoteArtifactDetailPageCoverage.test.tsx
@@ -166,7 +166,7 @@ describe('RemoteArtifactDetailPage', () => {
     vi.clearAllMocks()
     // happy-dom has no object-URL support, which the HTML render path needs.
     // @ts-expect-error assigning a test stub onto the URL global
-    globalThis.URL.createObjectURL = vi.fn().mockReturnValue('blob:remote-test')
+    globalThis.URL.createObjectURL = vi.fn().mockReturnValue('blob:http://localhost:6776/remote-artifact-detail-test')
     // @ts-expect-error assigning a test stub onto the URL global
     globalThis.URL.revokeObjectURL = vi.fn()
     // clearAllMocks resets call history only, so re-establish the defaults every
@@ -264,7 +264,7 @@ describe('RemoteArtifactDetailPage', () => {
       )
       renderPage()
       const frame = await screen.findByTitle(`Remote artifact: ${EXT_ID}`)
-      expect(frame).toHaveAttribute('src', 'blob:remote-test')
+      expect(frame).toHaveAttribute('src', 'blob:http://localhost:6776/remote-artifact-detail-test')
       expect(frame).toHaveAttribute('sandbox', expect.stringContaining('allow-scripts'))
       expect(URL.createObjectURL).toHaveBeenCalled()
     })

--- a/website/src/test/WidgetFrame.test.tsx
+++ b/website/src/test/WidgetFrame.test.tsx
@@ -9,6 +9,8 @@ import { effectiveWidgetSlug } from '../lib/widgetSlug'
 import { i18nT } from '../i18n/t'
 import { TAILWIND_COMPLEXITY_THRESHOLD } from '../lib/widgetComplexity'
 
+const WIDGET_BLOB_URL = 'blob:http://localhost:6776/widget-frame-test'
+
 // WidgetFrame consumes useTheme(), which requires a ThemeProvider, and now
 // useQuery, which requires a QueryClient. Wrap every render here to mirror the
 // production setup (main.tsx wraps App in both).
@@ -61,7 +63,7 @@ beforeEach(() => {
       }
     }
   } as typeof Blob
-  vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test-widget')
+  vi.spyOn(URL, 'createObjectURL').mockReturnValue(WIDGET_BLOB_URL)
   vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
 
   // Jest-dom inherits the real CSSOM, so spy on getComputedStyle to inject a
@@ -166,6 +168,14 @@ describe('WidgetFrame theme passthrough', () => {
     const iframe = container.querySelector('iframe')!
     expect(iframe.className).toMatch(/\bbg-card\b/)
     expect(iframe.className).not.toMatch(/\bbg-white\b/)
+  })
+
+  it('uses a well-formed blob URL rooted at the test document origin', () => {
+    const { container } = wrap(<WidgetFrame html="<p>hi</p>" title="T" />)
+    const iframe = container.querySelector('iframe')!
+
+    expect(iframe.src).toBe(WIDGET_BLOB_URL)
+    expect(new URL(iframe.src).origin).toBe(window.location.origin)
   })
 
   it('preserves the CSP meta and loads the Tailwind runtime same-origin', () => {
@@ -285,7 +295,7 @@ describe('WidgetFrame openInNewTab', () => {
       if (typeof parts[0] === 'string') wrapper = parts[0] as string
       return new realBlob(parts, opts)
     })
-    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue(WIDGET_BLOB_URL)
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     vi.spyOn(window, 'open').mockReturnValue(null)
 
@@ -304,7 +314,7 @@ describe('WidgetFrame openInNewTab', () => {
       mimeType = opts?.type ?? ''
       return new realBlob(args[0] as BlobPart[], opts)
     })
-    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue(WIDGET_BLOB_URL)
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     vi.spyOn(window, 'open').mockReturnValue(null)
 


### PR DESCRIPTION
## Problem

Several iframe tests return shortened blob values such as blob:test. Happy-dom can revisit an iframe resource during deferred cleanup, reinterpret the malformed URL, and terminate an otherwise passing Vitest shard.

## Why it matters

The deferred failure can crash a worker with no assertion failure, so unrelated pull requests fail depending on file-to-shard placement.

## Fix

Use well-formed blob URLs rooted at the configured happy-dom origin across WidgetFrame and the directly related local and remote artifact iframe fixtures. Document the same rule for future iframe tests.

## Tests

- Add a regression assertion that the WidgetFrame iframe blob URL parses back to the test document origin.
- Run the six affected iframe suites together: 230 passed.
- Run ESLint, TypeScript build, docs lint, and diff checks.

## Manual verification

Inspected the failed CI log from the first revision, identified the remaining blob:test iframe fixture, and normalized every directly related artifact iframe mock.

## Screenshots

<!-- no-visual-delta -->
**Why no screenshot:** Production UI is unchanged; only test URL fixtures and testing documentation changed.

Closes #3359