### PR TITLE
ci(frontend): reduce vitest worker memory pressure

### DIFF
--- a/website/docs/testing.md
+++ b/website/docs/testing.md
@@ -85,6 +85,9 @@ match when you are debugging a CI-only failure: see
 - **jscpd** duplication check: copy-pasted code fails the build.
 - Coverage is emitted as cobertura XML from `test:website`.
 - `npx tsc -b` and eslint run as their own blocking steps.
+- Coverage runs use at most two fork workers with a 3072 MB old-space ceiling
+  per worker. The cap leaves room for the Vitest coordinator, coverage maps,
+  happy-dom state, and the operating system on a standard hosted runner.
 
 Backend-side test determinism and suite-speed rules (they apply to the same CI run)
 are in

--- a/website/src/test/vitestMemoryConfig.test.ts
+++ b/website/src/test/vitestMemoryConfig.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('vitest worker memory configuration', () => {
+  it('keeps coverage forks within the hosted runner memory budget', () => {
+    const config = readFileSync(resolve(process.cwd(), 'vite.config.ts'), 'utf8')
+
+    expect(config).toMatch(/maxWorkers:\s*2,/)
+    expect(config).toMatch(/execArgv:\s*\['--max-old-space-size=3072'\],/)
+  })
+})

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -488,8 +488,8 @@ export default defineConfig({
     // ceiling that fails a genuine leak loudly instead of dragging the host down.
     // (Vitest 4 pool rework: these are top-level, not poolOptions; minWorkers
     // was removed — only maxWorkers has effect.)
-    maxWorkers: 4,
-    execArgv: ['--max-old-space-size=4096'],
+    maxWorkers: 2,
+    execArgv: ['--max-old-space-size=3072'],
     // Default 5s is too tight for tests that ``await import(...)`` inside the
     // body: under a full concurrent forks run the collect phase can starve the
     // dynamic import past 5s and it times out. 15s gives headroom for


### PR DESCRIPTION
## Problem / Motivation

The frontend coverage job can exceed hosted-runner memory when four Vitest forks each receive a 4 GB heap ceiling.

## Why it matters

An operating-system OOM kill aborts the entire coverage run even though individual tests are healthy.

## What changed

Reduced coverage concurrency to two forks and lowered the per-worker old-space ceiling to 3072 MB. Added a structural regression test and documented the runner budget.

## Tests

- Focused configuration regression test passed.
- Full frontend coverage suite passed: 85.61% statements, 78.25% branches, 82.21% functions, 88.33% lines.
- ESLint, TypeScript build, docs lint, production build, and diff checks passed.

## Manual verification

Confirmed the full run launched no more than two workers, each with the 3072 MB ceiling.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** This only changes test-runner resource limits and testing documentation; production rendering and behavior are unchanged.

## Related Issues

Closes #3356

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added
- [x] Self-review completed
- [x] Documentation updated
- [x] No secrets, credentials, or internal references in the diff