### PR TITLE
fix: recover the composer IME guard from an abandoned composition (#3345)

### DIFF
--- a/website/src/app-sdk/useComposerDraft.ts
+++ b/website/src/app-sdk/useComposerDraft.ts
@@ -42,6 +42,7 @@ import {
   useRef,
   useState,
   type Dispatch,
+  type FocusEvent,
   type KeyboardEvent,
   type MutableRefObject,
   type SetStateAction,
@@ -130,8 +131,19 @@ export interface ComposerDraft {
   setDraft: Dispatch<SetStateAction<string>>
   /** Attach to the textarea so it grows with content up to `maxHeight`. */
   textareaRef: MutableRefObject<HTMLTextAreaElement | null>
-  /** Spread onto the input so the IME guard can see composition start/end. */
-  composition: { onCompositionStart: () => void; onCompositionEnd: () => void }
+  /**
+   * Spread onto the input so the IME guard can see composition start/end, and so
+   * an abandoned composition recovers on blur. A composition abandoned WITHOUT a
+   * `compositionend` (focus moves away mid-composition, an OS-level IME cancel)
+   * leaves the guard latched; the `onBlur` half clears it, so Enter works again
+   * when focus returns. A surface with its own blur behaviour composes the two —
+   * spreading this AFTER an own `onBlur` would silently drop that handler.
+   */
+  composition: {
+    onCompositionStart: () => void
+    onCompositionEnd: () => void
+    onBlur: <T extends HTMLElement>(e: FocusEvent<T>) => void
+  }
   /**
    * Whether this key event is an IME committing a candidate rather than a real
    * keypress. Exposed for a surface whose key handler is too rich to delegate to
@@ -303,6 +315,15 @@ export function useComposerDraft(opts: ComposerDraftOptions = {}): ComposerDraft
     e: KeyboardEvent<T>,
     submit: () => void,
   ) => {
+    // Escape while a composition is latched means the user cancelled the IME, and
+    // some IME/browser pairs deliver no `compositionend` for that cancel. Clear the
+    // latch and fall through untouched — no submit, no preventDefault — so the
+    // surface's own Escape behaviour (closing a panel, dismissing a picker) still
+    // runs.
+    if (e.key === 'Escape') {
+      ime.reset()
+      return
+    }
     if (e.key !== 'Enter' || e.shiftKey) return
     // An IME sends a final Enter to COMMIT the candidate the user just chose. Reading
     // that as a submit sends a half-written question and is unrecoverable — the text is
@@ -317,7 +338,12 @@ export function useComposerDraft(opts: ComposerDraftOptions = {}): ComposerDraft
     draft,
     setDraft,
     textareaRef,
-    composition: ime.composition,
+    composition: {
+      ...ime.composition,
+      // Focus leaving the box mid-composition means no `compositionend` is coming.
+      // Clear the latch, or the guard eats every Enter for the component's life.
+      onBlur: () => { ime.reset() },
+    },
     isComposing,
     mergeIntoDraft,
     picked,

--- a/website/src/hooks/useImeGuard.ts
+++ b/website/src/hooks/useImeGuard.ts
@@ -22,8 +22,10 @@ import { useRef, useEffect, type KeyboardEvent, type FocusEvent } from 'react'
  * component unmounts an input mid-composition (e.g. Escape cancels a rename
  * and removes the input from the tree), `compositionEnd` will never fire and
  * `composingRef` would stay true forever, blocking Enter on other inputs that
- * share this hook. `bindEnter` and `composition` auto-`reset()` on blur/Escape
- * to avoid that.
+ * share this hook. `bindEnter` auto-`reset()`s on blur/Escape to avoid that.
+ * The bare `composition` binding does NOT: a consumer wiring its own
+ * `onKeyDown` must call `reset()` on blur/Escape itself (`useComposerDraft`
+ * does this for composer surfaces).
  *
  * Usage (simple Enter/Escape inputs):
  *   const ime = useImeGuard()

--- a/website/src/test/SideChat.imeEnter.test.tsx
+++ b/website/src/test/SideChat.imeEnter.test.tsx
@@ -105,4 +105,29 @@ describe('SideChat Enter key', () => {
     await settle()
     expect(sideTurn).not.toHaveBeenCalled()
   })
+
+  /**
+   * Recovery: a composition abandoned without a compositionEnd (focus moved away,
+   * an OS-level IME cancel) must not latch the guard forever. Before the recovery
+   * wiring, this panel could never send again until it remounted — the guard that
+   * exists to save one message ate all of them.
+   */
+  it('sends again after a composition abandoned by blur', async () => {
+    const box = render()
+    fireEvent.compositionStart(box)
+    // No compositionEnd — focus just leaves the box mid-composition.
+    fireEvent.blur(box)
+    fireEvent.keyDown(box, { key: 'Enter' })
+    await waitFor(() => expect(sideTurn).toHaveBeenCalledTimes(1))
+    expect(sideTurn.mock.calls[0][1]).toBe('a question')
+  })
+
+  it('sends again after a composition abandoned by Escape', async () => {
+    const box = render()
+    fireEvent.compositionStart(box)
+    fireEvent.keyDown(box, { key: 'Escape' })
+    fireEvent.keyDown(box, { key: 'Enter' })
+    await waitFor(() => expect(sideTurn).toHaveBeenCalledTimes(1))
+    expect(sideTurn.mock.calls[0][1]).toBe('a question')
+  })
 })

--- a/website/src/test/useComposerDraft.test.tsx
+++ b/website/src/test/useComposerDraft.test.tsx
@@ -8,7 +8,7 @@
  * reimplementation gets wrong — not the code shape.
  */
 import { describe, it, expect, vi } from 'vitest'
-import { StrictMode, type KeyboardEvent } from 'react'
+import { StrictMode, type FocusEvent, type KeyboardEvent } from 'react'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { renderHook, act } from '@testing-library/react'
@@ -439,6 +439,60 @@ describe('useComposerDraft', () => {
       } finally {
         vi.useRealTimers()
       }
+    })
+
+    /**
+     * The recovery half of the guard's contract. A composition abandoned WITHOUT a
+     * `compositionend` (focus moves away mid-composition, an OS-level IME cancel,
+     * Escape in some IME/browser pairs) leaves the latch set. Without a recovery
+     * path every later Enter takes the composing early-return — which neither
+     * submits nor prevents default — so the surface silently inserts newlines and
+     * can never send again until it remounts.
+     */
+    describe('abandoned-composition recovery', () => {
+      const blurEvent = () =>
+        ({} as unknown as FocusEvent<HTMLTextAreaElement>)
+
+      it('submits again after a composition abandoned by blur', () => {
+        const { result } = setup()
+        const submit = vi.fn()
+        act(() => result.current.composition.onCompositionStart())
+        // No compositionEnd — focus just leaves the box mid-composition.
+        act(() => result.current.composition.onBlur(blurEvent()))
+        act(() => result.current.submitOnEnter(keyEvent(), submit))
+        expect(submit).toHaveBeenCalledTimes(1)
+      })
+
+      it('submits again after a composition abandoned by Escape', () => {
+        const { result } = setup()
+        const submit = vi.fn()
+        act(() => result.current.composition.onCompositionStart())
+        act(() => result.current.submitOnEnter(keyEvent({ key: 'Escape', keyCode: 27 }), submit))
+        expect(submit).not.toHaveBeenCalled()
+        act(() => result.current.submitOnEnter(keyEvent(), submit))
+        expect(submit).toHaveBeenCalledTimes(1)
+      })
+
+      it('leaves Escape itself to the surface: no submit, no preventDefault', () => {
+        // A surface's own Escape behaviour (closing the panel, dismissing a picker)
+        // must still run — the reset is a side effect, not a claim on the key.
+        const { result } = setup()
+        const submit = vi.fn()
+        const e = keyEvent({ key: 'Escape', keyCode: 27 })
+        act(() => result.current.submitOnEnter(e, submit))
+        expect(submit).not.toHaveBeenCalled()
+        expect(e.preventDefault).not.toHaveBeenCalled()
+      })
+
+      it('still blocks a genuine composition Enter after recovery is wired', () => {
+        // Recovery must not loosen the guard: between compositionStart and blur or
+        // Escape, an Enter is an IME commit and must not send.
+        const { result } = setup()
+        const submit = vi.fn()
+        act(() => result.current.composition.onCompositionStart())
+        act(() => result.current.submitOnEnter(keyEvent(), submit))
+        expect(submit).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/website/src/test/useImeGuard.test.ts
+++ b/website/src/test/useImeGuard.test.ts
@@ -69,6 +69,17 @@ describe('useImeGuard', () => {
     expect(result.current.isComposing(key())).toBe(false)
   })
 
+  it('the bare composition binding carries ONLY the composition handlers', () => {
+    // Pins the docblock's claim: `composition` does not auto-reset. A consumer that
+    // needs abandoned-composition recovery wires `reset()` itself, or consumes
+    // `useComposerDraft`, whose composition binding adds the blur reset. Adding a
+    // handler here changes every `{...ime.composition}` spread in the tree — do it
+    // deliberately, with the consumer audit, not by accident.
+    const { result } = renderHook(() => useImeGuard())
+    expect(Object.keys(result.current.composition).sort())
+      .toEqual(['onCompositionEnd', 'onCompositionStart'])
+  })
+
   it('clears pending timer on unmount (no stale timer callbacks after teardown)', () => {
     vi.useFakeTimers()
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')


### PR DESCRIPTION
## Problem

`useImeGuard`'s `composingRef` is latched true by `compositionstart` and cleared only by `compositionend` (via a 50ms timer) or an explicit `reset()`. `useComposerDraft` returned `composition: ime.composition` unchanged, and that bare binding wires neither a blur nor an Escape reset.

So a composition abandoned **without** a `compositionend` (focus moves away mid-composition, an OS-level IME cancel, Escape in some IME/browser pairs) left the latch set for the life of the component. From then on every Enter took the `isComposing` early-return in `submitOnEnter`, which neither submits nor calls `preventDefault()`. The side chat composer silently inserted newlines and could never send again until it remounted. The guard that exists to save one message ate all of them.

Reproduction, component level: `compositionStart(textarea)`, `blur(textarea)`, then `keyDown(textarea, { key: 'Enter' })` with a non-empty draft. The submit never fires on main.

## Change

Fixed inside the shared hook, so every present and future consumer inherits the recovery half of the contract rather than each surface re-wiring it.

`website/src/app-sdk/useComposerDraft.ts`
- The returned `composition` binding now carries `onBlur`, which calls `ime.reset()`. A surface that spreads the binding onto its input gets blur recovery with no wiring of its own.
- `ComposerDraft.composition` is widened to declare the handler, typed generically as `FocusEvent<T>` in the same style as `submitOnEnter`, and still spreads onto a `<textarea>` without a cast.
- `submitOnEnter` clears the latch on Escape and falls through untouched: no submit, no `preventDefault`, so a surface's own Escape behaviour (closing a panel, dismissing a picker) still runs. Escape is not swallowed.
- The composition-Enter guard itself is unchanged. An Enter that really is an IME commit still does not submit. This is a recovery fix, not a loosening.

`website/src/hooks/useImeGuard.ts`
- Docblock corrected. It claimed `bindEnter` **and** `composition` auto-reset on blur/Escape; only `bindEnter` ever did.

### Route chosen, and why

The bare `composition` binding at the `useImeGuard` level stays bare. The spec offered adding the reset there instead, so here is the audit behind the choice: `website/src/` has ten `{...ime.composition}` spread sites across `ChatInput`, `ChannelPage`, `FolderConfigModal`, `CommentsSidebar` (three), `CommentThreadPopover`, and `CommentOverlay` (two). Several pass their own `onBlur` that a hook-level handler would shadow or be shadowed by depending on spread order, and `CommentOverlay`'s `CommentRow` in particular relies on `onBlur={commitEdit}` for its commit path. Adding a handler to the shared bare binding would change all ten call sites at once for the benefit of one. The recovery belongs in the composer hook that owns the Enter path, which is where the wedge is reachable. A new test pins the bare binding's shape so the decision is not undone by accident.

`SideChat.tsx` needs no change: its textarea declares no `onBlur` and spreads `{...composition}` ahead of its other props, so the new handler takes effect and shadows nothing.

## Verification

- Fail-before verified. With the source reverted and the new tests in place, exactly the four recovery cases fail (two hook, two component) and every regression pin passes. With the fix applied all 62 tests in the three suites pass.
- New tests: abandoned-composition-then-blur-then-Enter submits; `compositionStart`-then-Escape-then-Enter submits; Escape alone neither submits nor prevents default; a genuine composition Enter still does not submit. Component-level equivalents drive the real SideChat textarea and assert against the `sideTurn` API call.
- Regression pins kept green: Shift+Enter inserts a newline, `compositionEnd` followed by an Enter inside the 50ms window still does not submit, the native-flag and keyCode-229 paths still block.
- `npx tsc -b` clean. Full frontend suite green: 1072 files, 17975 passed, 2 expected fail, 3 skipped.
- No Python files changed, so the backend gate result is identical to `main` by construction.
- No i18n keys, no new user-facing strings, no rendered-output or geometry change, so no screenshots.

## Known limits

The hook takes no `onBlur` option, so a future surface wanting both its own blur behaviour and the recovery composes the two itself. The type's doc comment says so. That keeps the surface minimal until a second consumer actually needs it.

Closes #3345
