### PR TITLE
test(website): close two shard races and document the barrier rule

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -17,7 +17,7 @@ them.
 | shared components, a11y, URL sanitization, data fetching | [frontend-conventions](docs/frontend-conventions.md) |
 | any user-facing string, date, number, or sort order | [i18n-catalog](docs/i18n-catalog.md) + [i18n gates](../docs/ci/i18n-gates.md) |
 | `src/extensions.ts`, edition composition, registries | [extension-seams](docs/extension-seams.md) |
-| tests (vitest, MSW, Playwright, Electron) | [testing](docs/testing.md) |
+| tests (vitest, MSW, Playwright, Electron), or a test that fails only in CI | [testing](docs/testing.md) |
 | the Electron desktop shell | [electron/README.md](electron/README.md) |
 | anything backend, or a whole-system question | [`../AGENTS.md`](../AGENTS.md) |
 

--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -10,7 +10,7 @@ Backend and whole-system docs are in [`../../docs/`](../../docs/README.md).
 | [theming-contract.md](theming-contract.md) | The CSS variable contract, the stable class hooks a theme may target, and what is deliberately not customizable. |
 | [frontend-conventions.md](frontend-conventions.md) | Shared components, accessibility, URL sanitization, data fetching, animation, and styling. |
 | [i18n-catalog.md](i18n-catalog.md) | Catalog structure, key naming, plurals, and the formatting seam. |
-| [testing.md](testing.md) | The three test layers, which to use when, how Playwright really runs, and the manual procedures. |
+| [testing.md](testing.md) | The three test layers, which to use when, how Playwright really runs, how to keep a test deterministic under a loaded shard, and the manual procedures. |
 | [extension-seams.md](extension-seams.md) | The registry seams a downstream edition composes against, and the fail-closed edition opt-in. |
 
 Related, outside this directory:

--- a/website/docs/testing.md
+++ b/website/docs/testing.md
@@ -92,6 +92,61 @@ are in
 The short version holds here too: never fix a flake with a rerun, a longer timeout,
 or a weakened assertion. Poll for the condition you actually care about.
 
+## Determinism: establish the state you assert on
+
+Every CI-only failure this suite has produced so far reduces to one mistake: **the
+test asserted against a state it did not establish**, and got away with it locally
+because the component happened to be slower than the assertion. The shard runs four
+workers under coverage, so "happened to be" stops holding. Two concrete shapes to
+recognize — both have shipped as red shards.
+
+**A mounted element is not a settled state.** `findBy*` proves a node rendered, not
+that the async work behind it finished. A component that renders against a fallback
+prop mounts *before* the effect that sets the real value, so its query has not even
+been issued yet:
+
+```tsx
+// WRONG: the editor renders against `mainFile` before the open-main effect sets
+// `currentFile`, so the read query is still disabled — `mockClear` clears nothing
+// and the mount-time read lands afterwards, credited to the click.
+await screen.findByLabelText('editor')
+api.readFile.mockClear()
+await user.click(fileRow)
+expect(api.readFile).not.toHaveBeenCalled()
+
+// RIGHT: wait for the thing the assertion is actually about.
+await screen.findByLabelText('editor')
+await waitFor(() => expect(api.readFile).toHaveBeenCalled())
+api.readFile.mockClear()
+```
+
+Put that wait in the file's shared `…Ready()` helper rather than in the one test
+that tripped over it: the barrier is wrong for every test using it, and the next
+one to notice will be another red shard.
+
+**A default DOM value the component overwrites is not a fixture.** If production
+code writes `scrollTop`, `value`, or `open` on a timer or in an effect, a test that
+relies on the initial value is racing it — and losing the race is silent, because
+the state just reads as "already correct" and the branch under test never runs:
+
+```tsx
+// WRONG: the panel re-pins the scroller on 50/150/300ms timers after history
+// lands. Once one has fired, this scroll reads as "already at the bottom" and the
+// pill never renders — a 1000ms `findByRole` timeout with no hint why.
+fireEvent.scroll(scroller)
+
+// RIGHT: park it where the test needs it, so the event means one thing.
+scroller.scrollTop = 0
+fireEvent.scroll(scroller)
+```
+
+**Reproduce before you fix.** Both examples above were confirmed by *forcing* the
+race locally — an `await new Promise(r => setTimeout(r, 400))` before the assertion,
+or a `mockImplementation` that resolves on a timer — which turns a CI-only flake
+into a deterministic local failure. Keep the forced delay in place while you verify
+the fix, then remove it: a fix that only passes once the delay is gone has not been
+shown to fix anything.
+
 ## Manual procedures
 
 A few flows are deliberately not automated. They are documented rather than

--- a/website/src/test/MochiChatPanelCoverage.test.tsx
+++ b/website/src/test/MochiChatPanelCoverage.test.tsx
@@ -283,6 +283,13 @@ describe('ChatPanel scroll position pill', () => {
     scroller.scrollTo = scrollTo as unknown as typeof scroller.scrollTo
 
     expect(screen.queryByRole('button', { name: 'Scroll to Latest' })).not.toBeInTheDocument()
+    // The panel re-pins the scroller to the end on 50/150/300ms timers once the
+    // history lands, so the initial `scrollTop` of 0 is not a state this test can
+    // rely on: whichever timer has already run leaves the scroller AT the bottom,
+    // the scroll below reads as "still at the latest turn" and the pill never
+    // renders. Park the scroller away from the end explicitly, so the reported
+    // scroll means the same thing regardless of which timers have fired.
+    scroller.scrollTop = 0
     fireEvent.scroll(scroller)
     const pill = await screen.findByRole('button', { name: 'Scroll to Latest' })
 

--- a/website/src/test/PapyrusPageCoverage.test.tsx
+++ b/website/src/test/PapyrusPageCoverage.test.tsx
@@ -158,6 +158,12 @@ function openWorkspace(store = createTestStore()) {
 async function workspaceReady() {
   await screen.findByTestId('papyrus-workspace')
   await screen.findByLabelText('editor')
+  // The editor mounts against `mainFile` BEFORE the open-main effect sets
+  // `currentFile`, so a mounted editor does not mean the first read has been
+  // issued — the read query is still disabled until then. Wait for that read,
+  // or a test that takes this barrier as "settled" (clearing `readFile`, or
+  // counting saves) credits the mount-time read to whatever it does next.
+  await waitFor(() => expect(api.readFile).toHaveBeenCalled())
 }
 
 function makeDirty(text: string) {


### PR DESCRIPTION
<!-- no-visual-delta -->

## What

Fixes two vitest tests that fail only on a loaded CI shard, and writes the rule
they violated into `website/docs/testing.md`.

Surfaced on the CI run for #3143, which touches none of this code — those two
red shards were unrelated to that PR and would keep tripping other branches.

## Root cause

Both tests asserted against a state they did not establish, and passed locally
because the component happened to be slower than the assertion. Under four
workers with coverage, that stops holding.

**`PapyrusPageCoverage`** — `PapyrusEditor` renders against
`path={currentFile || mainFile || DEFAULT_MAIN_FILE}`, so the editor mounts
*before* the open-main effect sets `currentFile`, while the read query is still
`enabled: false`. `workspaceReady()` returned at that point, so
`api.readFile.mockClear()` cleared nothing and the mount-time read landed
afterwards — credited to the click under test (`called 1 times`).

Fixed in the shared `workspaceReady()` helper rather than the single test: the
barrier was unsound for all 51 tests using it.

**`MochiChatPanelCoverage`** — `ChatPanel` re-pins the scroller with
`setTimeout(scrollToEnd, 50/150/300)` once history loads. The test relied on
`scrollTop` still being 0; once any of those timers had fired, `onScroll`
computed `atBottom = true`, the "Scroll to Latest" pill never rendered, and
`findByRole` timed out at 1000ms (the CI run shows the test at 1156ms). The
scroller is now parked explicitly before the scroll is reported.

## Verification

Both failures were reproduced **deterministically** before being fixed, by
forcing the race locally — a `setTimeout` delay before the assertion for the
scroller, and a timer-resolving `getProject` mock for Papyrus. The Mochi repro
produced the identical CI error string (`Unable to find role="button" and name
"Scroll to Latest"`). Each fix was then re-verified **with the forced delay
still in place**, so it is the barrier that closed the race and not the delay
being removed.

- `PapyrusPageCoverage` 51 + `MochiChatPanelCoverage` 39 + `PapyrusCloseProject`
  42 pass
- `npx tsc -b`, `eslint` on both files, `./scripts/docs-lint.sh` clean

## Audited but not changed

The same "`mockClear()` on a `findBy*` barrier" shape appears at seven other
sites. Each was checked against the production code **and** run under a forced
race; all seven are sound, so they are left alone:

| Site | Why it holds |
|---|---|
| `McpBrowserModal` (`invalidateSpy`) | `invalidateQueries` has exactly two callers — the mount effect (fully executed before the Install button can render) and `installMutation.onSuccess` (after the click) |
| `PapyrusPageCoverage` ~778 (`api.compile`) | compile is user-initiated only; the conflict path never calls it |
| `PapyrusPageCoverage` ~840 (`api.readFile`) | neutralized by the `workspaceReady()` fix above; the dirty-buffer conflict path returns before any read |
| `MdNotebookPageCoverage` (`api.listNotes`) | the note buttons are rendered *from* the `listNotes` response, so the barrier implies it settled; the 4s changes poll cannot fire and short-circuits on an unchanged `rev` anyway |
| `MdNotebookPageCoverage` (`api.readNote`) | `mountDirty()` awaits the rendered body; the sync-rejection path never reads |
| `ProjectPicker` (`browseSpy`) | the 250ms auto-drill effect short-circuits on `target === browsePath`, and the assertion checks a specific argument rather than "was called" |
| `ArtifactPanelCoverage` (`copyToClipboard`) | user-gesture-only, no mount-time caller |

## Docs

`website/docs/testing.md` gains a **Determinism: establish the state you assert
on** section carrying the rule, both concrete shapes with WRONG/RIGHT snippets,
and the force-the-race-first method. `website/AGENTS.md` stays a router — only
its testing row was widened to also route "a test that fails only in CI".
