### PR TITLE
refactor(electron): track gateway ownership as one state, not three booleans (#2282)

### DIFF
--- a/website/electron/gateway-recovery.js
+++ b/website/electron/gateway-recovery.js
@@ -15,26 +15,52 @@
 // a terminal error dialog that QUIT the app on any button — including Retry (the
 // perceived "crash on Retry" on network change).
 //
-// This helper is the single source of truth for that fork: given whether we own
-// the gateway, return which recovery strategy to run. Keeping it pure means the
-// ownership rule is covered by tests independently of the Electron plumbing.
+// This helper is the single source of truth for that fork: given how the
+// gateway was obtained (the launcher's single ownership state), return which
+// recovery strategy to run. Keeping it pure means the ownership rule is covered
+// by tests independently of the Electron plumbing.
+
+// The launcher's gateway-ownership vocabulary (main.js keeps exactly one of
+// these in a single module-level state; see GATEWAY_OWNERSHIP_STATES):
+//   "none"           — no gateway yet, or an adopted holder that could NOT be
+//                      positively identified as local (tunnel / external).
+//   "spawned"        — this app spawned the bundled backend on this port.
+//   "reused-local"   — adopted a local same-family Kiro Crew process.
+//   "reused-service" — like reused-local, but the holder was SERVICE-classified.
+const GATEWAY_OWNERSHIP_STATES = Object.freeze(["none", "spawned", "reused-local", "reused-service"]);
+
+/**
+ * Classify an adopted (reuse-path) gateway into the ownership vocabulary.
+ * Positive identification requires BOTH a same-family health answer and a
+ * local LISTEN owner ("kirocrew"/"service"); anything less (tunnel, no visible
+ * owner, probe failure) stays "none" — the never-kill/never-respawn external
+ * classification. Pure so the classification rule is unit-testable without
+ * Electron.
+ *
+ * @param {object} o
+ * @param {string} o.reason      the reuse decision's reason (from
+ *                               decideGatewayAction); only "same-family" is a
+ *                               positive family identification.
+ * @param {string} o.localOwner  the LISTEN-owner classification for the port
+ *                               ("kirocrew" | "service" | "other" | "none" | …).
+ * @returns {"reused-service" | "reused-local" | "none"}
+ */
+function classifyAdoptedGateway({ reason, localOwner }) {
+  const local = reason === "same-family" && (localOwner === "kirocrew" || localOwner === "service");
+  if (!local) return "none";
+  return localOwner === "service" ? "reused-service" : "reused-local";
+}
 
 /**
  * Decide how to recover an unresponsive gateway.
  *
  * @param {object} o
- * @param {boolean} o.weSpawnedGateway  true only when this app spawned the
- *                                       bundled backend on this port (spawn
- *                                       path). false on the reuse path — a
- *                                       gateway was already answering at boot
- *                                       (remote tunnel or external gateway).
- * @param {boolean} [o.reusedLocalGateway=false]  true only when the reuse
- *                                       decision positively identified the
- *                                       port-holder as a LOCAL same-family
- *                                       Kiro Crew process (localOwner
- *                                       "kirocrew"/"service" + same-family
- *                                       health). A tunnel or an unidentified
- *                                       holder never sets this.
+ * @param {string} o.gatewayOwnership  one of GATEWAY_OWNERSHIP_STATES: how the
+ *                                     gateway on this port was obtained.
+ *                                     "spawned" is the only owned state; the
+ *                                     reused-* states are adopted local
+ *                                     gateways; "none" (or anything
+ *                                     unrecognized) is external/unknown.
  * @returns {"respawn" | "reconnect-bounded" | "reconnect"}
  *   "respawn"   — we own the child: kill the wedged tree, free the port, spawn a
  *                 fresh backend, re-run the boot flow.
@@ -50,9 +76,12 @@
  *                 tunnel heals, then reconnect (re-fetching a token, since the
  *                 drop likely invalidated the old one).
  */
-function chooseRecoveryStrategy({ weSpawnedGateway, reusedLocalGateway = false }) {
-  if (weSpawnedGateway) return "respawn";
-  if (reusedLocalGateway) return "reconnect-bounded";
+function chooseRecoveryStrategy({ gatewayOwnership }) {
+  if (gatewayOwnership === "spawned") return "respawn";
+  if (gatewayOwnership === "reused-local" || gatewayOwnership === "reused-service") return "reconnect-bounded";
+  // "none", undefined, or anything unrecognized: ownership defaults to "not
+  // ours" — the safe strategy is the non-destructive reconnect, never a
+  // port-kill.
   return "reconnect";
 }
 
@@ -118,6 +147,8 @@ async function waitForProcessExit({ pids, isAlive, sleep, timeoutMs = INCUMBENT_
 
 module.exports = {
   chooseRecoveryStrategy,
+  classifyAdoptedGateway,
+  GATEWAY_OWNERSHIP_STATES,
   waitForServiceRebind,
   waitForProcessExit,
   SERVICE_REBIND_GRACE_MS,

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -39,7 +39,7 @@ const {
   setGlobalHotkeyLogger,
 } = require("./global-hotkey");
 const { createLivenessMonitor } = require("./gateway-liveness");
-const { chooseRecoveryStrategy, waitForServiceRebind, waitForProcessExit } = require("./gateway-recovery");
+const { chooseRecoveryStrategy, classifyAdoptedGateway, waitForServiceRebind, waitForProcessExit } = require("./gateway-recovery");
 const { capturePySpyDump } = require("./pyspy-dump");
 const { createMetricsRecorder } = require("./perf-metrics");
 const { identityFamily, decideGatewayAction, classifyGatewayReadiness, FAMILY_META, HEALTH_IDENTITY_PATH, READY_PATH } = require("./instance-guard");
@@ -217,34 +217,42 @@ if (!app.requestSingleInstanceLock()) {
 let mainWindow = null;
 let tray = null;
 let gatewayProcess = null;
-// True only when WE spawned the bundled backend on this flavor's port. False on
-// the reuse path — i.e. a gateway was already answering when we booted, which is
-// exactly the remote-tunnel setup (localhost:<port> is an SSH forward to a
-// remote gateway) and also the "dev ran `kirocrew gateway` in a terminal" case.
-// Recovery must NEVER kill or respawn a gateway we did not spawn: the port-holder
-// is someone else's process (our SSH tunnel, a manual gateway), and the correct
-// fix on a dropped tunnel is to re-probe and reconnect once it heals, not to
-// force-stop the port or spawn a (nonexistent, in remote mode) local backend.
-let weSpawnedGateway = false;
-// True only on the reuse path when the port-holder was POSITIVELY identified as
-// a local same-family Kiro Crew process (same-family /api/health + a "kirocrew"
-// or "service" LISTEN owner). Distinguishes "we adopted a local gateway" from
-// "we connected to a tunnel / external gateway" for recovery: an adopted local
-// gateway that dies will never come back on its own, so recovery must wait
-// BOUNDED and then respawn — never the indefinite tunnel-heal wait, which
-// leaves the shell dead until the user manually relaunches.
+// How the gateway on this flavor's port was obtained — ONE mutually-exclusive
+// state (previously three module-level booleans that encoded it redundantly and
+// could drift out of sync). Vocabulary + the recovery-strategy mapping live in
+// gateway-recovery.js (chooseRecoveryStrategy / classifyAdoptedGateway); assign
+// at exactly one place per outcome.
+//   "none"           — no gateway yet, or the reuse path could NOT positively
+//                      identify the port-holder as a local Kiro Crew process
+//                      (remote SSH tunnel, manual/external gateway, probe
+//                      failure). Recovery must NEVER kill or respawn it: the
+//                      port-holder is someone else's process, and the correct
+//                      fix on a dropped tunnel is to re-probe and reconnect
+//                      once it heals, not to force-stop the port or spawn a
+//                      (nonexistent, in remote mode) local backend.
+//   "spawned"        — WE spawned the bundled backend on this flavor's port;
+//                      recovery may kill + respawn it.
+//   "reused-local"   — reuse path, holder POSITIVELY identified as a local
+//                      same-family Kiro Crew process (same-family /api/health
+//                      + a "kirocrew" LISTEN owner). An adopted local gateway
+//                      that dies will never come back on its own, so recovery
+//                      must wait BOUNDED and then respawn — never the
+//                      indefinite tunnel-heal wait, which leaves the shell
+//                      dead until the user manually relaunches.
+//   "reused-service" — like "reused-local", but the holder was SERVICE-
+//                      classified (PPID = init: a real launchd/systemd unit —
+//                      or an orphan, which reparents to init and is
+//                      indistinguishable at classify time). If that gateway
+//                      later releases the port, a real service manager may be
+//                      about to respawn it, so recovery must offer a bounded
+//                      rebind grace before spawning locally — spawning
+//                      immediately races the manager for the bind and one side
+//                      dies with EADDRINUSE.
 // KNOWN RESIDUAL (Windows): classifyPortOwner cannot positively identify
-// owners there (no lsof/ps), so this flag never sets and an adopted draining
-// gateway still falls into the indefinite "reconnect" wait — deliberately
-// conservative until the Windows-native owner probe lands.
-let reusedLocalGateway = false;
-// True when the adopted holder was specifically SERVICE-classified (PPID = init:
-// a real launchd/systemd unit — or an orphan, which reparents to init and is
-// indistinguishable at classify time). If that gateway later releases the port,
-// a real service manager may be about to respawn it, so recovery must offer a
-// bounded rebind grace before spawning locally — spawning immediately races the
-// manager for the bind and one side dies with EADDRINUSE.
-let reusedServiceGateway = false;
+// owners there (no lsof/ps), so the reused-* states never set and an adopted
+// draining gateway still falls into the indefinite "reconnect" wait —
+// deliberately conservative until the Windows-native owner probe lands.
+let gatewayOwnership = "none";
 // Post-handoff backend liveness monitor (primary window only). Detects a wedged
 // gateway — alive TCP socket, frozen event loop — that the spawn 'exit' watcher
 // can't, since the process never exits. See gateway-liveness.js.
@@ -512,15 +520,13 @@ async function resolveGatewayConflict(rebindDepth = 0) {
       adoptedDraining = true;
     }
     glog(`reusing existing gateway on :${PORT} (${decision.reason}) — bundled backend NOT spawned`);
-    weSpawnedGateway = false; // reuse path — recovery must not kill/respawn a gateway we don't own
-    // A same-family gateway held by a local Kiro Crew process is OURS in spirit
+    // Reuse path — recovery must not kill/respawn a gateway we don't own. A
+    // same-family gateway held by a local Kiro Crew process is OURS in spirit
     // even though we didn't spawn it: if it dies, no tunnel will resurrect it,
     // so recovery may respawn after a bounded wait. Anything less positively
     // identified (tunnel, no visible owner, probe failure) keeps the
-    // never-respawn external classification.
-    reusedLocalGateway = decision.reason === "same-family"
-      && (localOwner === "kirocrew" || localOwner === "service");
-    reusedServiceGateway = reusedLocalGateway && localOwner === "service";
+    // never-respawn external classification ("none").
+    gatewayOwnership = classifyAdoptedGateway({ reason: decision.reason, localOwner });
     // A gateway we adopted mid-drain is not a success to celebrate: recovery
     // may immediately retract it. Keep the status neutral for that case.
     sendStatus(adoptedDraining ? "Connecting to the existing gateway…" : "Gateway already running ✓");
@@ -816,9 +822,10 @@ function spawnGateway(resolve) {
           },
         });
         gatewayProcess = child;
-        weSpawnedGateway = true; // we own this child — recovery may kill+respawn it
-        reusedLocalGateway = false; // ownership transitioned: no longer on an adopted gateway
-        reusedServiceGateway = false; // ditto — stale service classification must not outlive the adoption
+        // We own this child — recovery may kill+respawn it. Ownership
+        // transitioned: any stale adopted/service classification must not
+        // outlive the spawn.
+        gatewayOwnership = "spawned";
         // The child inherits its own dup of the fd; close our copy so it doesn't leak.
         if (typeof childOut === "number") { try { fs.closeSync(childOut); } catch { /* ignore */ } }
 
@@ -2113,7 +2120,7 @@ async function recoverWedgedGateway(win) {
   // fell through to showUnrecoverableGatewayError, which QUIT the app on any
   // button (that was the "crash on Retry"). Instead: leave the tunnel alone and
   // re-probe until it heals, then reconnect.
-  const strategy = chooseRecoveryStrategy({ weSpawnedGateway, reusedLocalGateway });
+  const strategy = chooseRecoveryStrategy({ gatewayOwnership });
   if (strategy === "reconnect") {
     glog("liveness: backend unresponsive on a gateway we did not spawn (remote tunnel / external gateway) — waiting for it to recover instead of killing the port");
     if (!win || win.isDestroyed() || isQuitting) return;
@@ -2247,7 +2254,7 @@ async function reconnectOrRespawnAdoptedGateway(win) {
     return showUnrecoverableGatewayError(win, PORT, "held");
   }
   if (!win || win.isDestroyed() || isQuitting) return;
-  if (reusedServiceGateway) {
+  if (gatewayOwnership === "reused-service") {
     // The dead gateway was SERVICE-classified: a real launchd/systemd unit is
     // (or may be) about to respawn it, and spawning immediately races that
     // rebind for the port. Orphans classify as service too but nothing rebinds
@@ -2270,8 +2277,7 @@ async function reconnectOrRespawnAdoptedGateway(win) {
       const readiness = await fetchGatewayReadiness();
       if (decision.action === "reuse" && readiness !== "shutting-down") {
         glog(`liveness: service manager re-bound :${PORT} (owner=${owner}, reason=${decision.reason}, readiness=${readiness}) — reconnecting to the restarted gateway`);
-        reusedLocalGateway = decision.reason === "same-family" && (owner === "kirocrew" || owner === "service");
-        reusedServiceGateway = reusedLocalGateway && owner === "service";
+        gatewayOwnership = classifyAdoptedGateway({ reason: decision.reason, localOwner: owner });
         gatewayStartFailure = null;
         return showLoadingThenConnect(win, BACKEND_URL);
       }

--- a/website/electron/test/gateway-recovery.test.js
+++ b/website/electron/test/gateway-recovery.test.js
@@ -1,10 +1,16 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
-const { chooseRecoveryStrategy, waitForServiceRebind, waitForProcessExit } = require("../gateway-recovery");
+const {
+  chooseRecoveryStrategy,
+  classifyAdoptedGateway,
+  GATEWAY_OWNERSHIP_STATES,
+  waitForServiceRebind,
+  waitForProcessExit,
+} = require("../gateway-recovery");
 
 describe("chooseRecoveryStrategy", () => {
   it("respawns when we own the spawned gateway", () => {
-    assert.equal(chooseRecoveryStrategy({ weSpawnedGateway: true }), "respawn");
+    assert.equal(chooseRecoveryStrategy({ gatewayOwnership: "spawned" }), "respawn");
   });
 
   // Regression guard for the lid-close / network-switch crash: on the reuse
@@ -14,15 +20,16 @@ describe("chooseRecoveryStrategy", () => {
   // "respawn" here is exactly the bug that force-killed the tunnel and then quit
   // the app on Retry.
   it("reconnects (never respawns) for a gateway we did not spawn", () => {
-    assert.equal(chooseRecoveryStrategy({ weSpawnedGateway: false }), "reconnect");
+    assert.equal(chooseRecoveryStrategy({ gatewayOwnership: "none" }), "reconnect");
   });
 
   // Ownership defaults to "not ours" when unknown: the safe strategy is the
   // non-destructive reconnect, never a port-kill.
   it("defaults to reconnect when ownership is falsy/unknown", () => {
     assert.equal(chooseRecoveryStrategy({}), "reconnect");
-    assert.equal(chooseRecoveryStrategy({ weSpawnedGateway: undefined }), "reconnect");
-    assert.equal(chooseRecoveryStrategy({ weSpawnedGateway: null }), "reconnect");
+    assert.equal(chooseRecoveryStrategy({ gatewayOwnership: undefined }), "reconnect");
+    assert.equal(chooseRecoveryStrategy({ gatewayOwnership: null }), "reconnect");
+    assert.equal(chooseRecoveryStrategy({ gatewayOwnership: "garbage" }), "reconnect");
   });
 
   // Regression guard for the adopted-gateway dead window: a relaunch adopted
@@ -31,30 +38,57 @@ describe("chooseRecoveryStrategy", () => {
   // a comeback that a local process can never make on its own. An adopted
   // LOCAL gateway must get the bounded wait-then-respawn strategy instead.
   it("bounded reconnect-then-respawn for an adopted local same-family gateway", () => {
-    assert.equal(
-      chooseRecoveryStrategy({ weSpawnedGateway: false, reusedLocalGateway: true }),
-      "reconnect-bounded",
-    );
+    assert.equal(chooseRecoveryStrategy({ gatewayOwnership: "reused-local" }), "reconnect-bounded");
   });
 
-  // The never-evict/never-respawn behavior is preserved ONLY for genuinely
-  // external gateways: reuse without the positive local-family identification
-  // stays on the indefinite tunnel-heal wait.
-  it("keeps the indefinite reconnect for external/tunnel gateways", () => {
-    assert.equal(
-      chooseRecoveryStrategy({ weSpawnedGateway: false, reusedLocalGateway: false }),
-      "reconnect",
-    );
-    assert.equal(chooseRecoveryStrategy({ weSpawnedGateway: false }), "reconnect");
+  // A service-classified adoption is still an adopted LOCAL gateway for the
+  // wedged-recovery fork (the rebind grace lives further down the respawn
+  // path); it must never fall into the indefinite external wait.
+  it("bounded reconnect-then-respawn for an adopted service-managed gateway", () => {
+    assert.equal(chooseRecoveryStrategy({ gatewayOwnership: "reused-service" }), "reconnect-bounded");
   });
 
-  // Owning the spawned child always wins: the kill+respawn path is safe (and
-  // correct) for a process we created, regardless of any stale adoption flag.
-  it("respawn takes precedence over the adopted-local classification", () => {
-    assert.equal(
-      chooseRecoveryStrategy({ weSpawnedGateway: true, reusedLocalGateway: true }),
-      "respawn",
-    );
+  it("covers every declared ownership state (vocabulary is closed)", () => {
+    for (const state of GATEWAY_OWNERSHIP_STATES) {
+      const strategy = chooseRecoveryStrategy({ gatewayOwnership: state });
+      assert.ok(
+        ["respawn", "reconnect-bounded", "reconnect"].includes(strategy),
+        `state ${state} produced unknown strategy ${strategy}`,
+      );
+    }
+  });
+});
+
+describe("classifyAdoptedGateway", () => {
+  // Positive identification requires BOTH same-family health AND a local
+  // LISTEN owner — anything less stays "none" (never-kill/never-respawn).
+  it("classifies a same-family kirocrew-owned holder as reused-local", () => {
+    assert.equal(classifyAdoptedGateway({ reason: "same-family", localOwner: "kirocrew" }), "reused-local");
+  });
+
+  it("classifies a same-family service-owned holder as reused-service", () => {
+    assert.equal(classifyAdoptedGateway({ reason: "same-family", localOwner: "service" }), "reused-service");
+  });
+
+  it("stays none for a tunnel / unidentified holder (no positive owner)", () => {
+    assert.equal(classifyAdoptedGateway({ reason: "same-family", localOwner: "none" }), "none");
+    assert.equal(classifyAdoptedGateway({ reason: "same-family", localOwner: "other" }), "none");
+    assert.equal(classifyAdoptedGateway({ reason: "same-family", localOwner: undefined }), "none");
+  });
+
+  it("stays none without the same-family health identification", () => {
+    assert.equal(classifyAdoptedGateway({ reason: "healthy", localOwner: "kirocrew" }), "none");
+    assert.equal(classifyAdoptedGateway({ reason: undefined, localOwner: "service" }), "none");
+  });
+
+  // The classifier's output must feed chooseRecoveryStrategy losslessly: a
+  // positively-identified local adoption gets the bounded strategy, an
+  // unidentified one keeps the indefinite external reconnect.
+  it("composes with chooseRecoveryStrategy end to end", () => {
+    const local = classifyAdoptedGateway({ reason: "same-family", localOwner: "kirocrew" });
+    assert.equal(chooseRecoveryStrategy({ gatewayOwnership: local }), "reconnect-bounded");
+    const external = classifyAdoptedGateway({ reason: "same-family", localOwner: "none" });
+    assert.equal(chooseRecoveryStrategy({ gatewayOwnership: external }), "reconnect");
   });
 });
 


### PR DESCRIPTION
## Problem

The Electron launcher tracked how the gateway on this flavor's port was obtained
using three separate module-level booleans -- `weSpawnedGateway`,
`reusedLocalGateway`, `reusedServiceGateway` -- that together encode ONE
mutually-exclusive state. Nothing in the type system or the code shape held them
consistent, so each of the three assignment sites had to remember to clear the
other two flags by hand.

## Why it matters

The invariant they encode is load-bearing for teardown and recovery safety: the
launcher may only kill and respawn a gateway it spawned itself. Every write site
carried a hand-maintained clear of its siblings (the spawn path wrote all three
in a row purely to avoid a stale adoption flag outliving the adoption). A future
edit that adds a fourth outcome, or forgets one of those clears, produces an
impossible combination -- e.g. `weSpawnedGateway && reusedServiceGateway` -- and
the recovery fork silently reads the wrong branch. That class of drift is a
correctness bug in the path that decides whether to SIGKILL a process the app
does not own.

## Fix (symptoms -> root cause -> change)

Symptom: three booleans, six write sites, and per-site sibling clears.
Root cause: a single mutually-exclusive state modelled as independent flags.
Change: replace them with one `gatewayOwnership` state whose vocabulary is
declared in `gateway-recovery.js`:

- `"none"` -- no gateway yet, or an adopted holder that could NOT be positively
  identified as local (remote SSH tunnel, external gateway, probe failure).
- `"spawned"` -- we spawned the bundled backend on this port.
- `"reused-local"` -- adopted a local same-family Kiro Crew process.
- `"reused-service"` -- as above, but the holder was SERVICE-classified.

Each outcome is now assigned at exactly one place, and assigning any state
implicitly retires every other -- the sibling clears become structurally
unnecessary rather than a convention:

- boot reuse path and the service-rebind reconnect path both go through the new
  pure `classifyAdoptedGateway({ reason, localOwner })`, which was previously two
  duplicated inline expressions that had to agree with each other.
- the spawn path assigns `"spawned"` (was three writes).
- `chooseRecoveryStrategy` takes `{ gatewayOwnership }` and maps the state to
  `respawn` / `reconnect-bounded` / `reconnect`.
- the service rebind-grace read becomes `gatewayOwnership === "reused-service"`.

Behaviour is unchanged, including the fail-safe default: an unrecognized or
absent state still yields the non-destructive `"reconnect"`, never a port-kill.

Teardown was re-verified: `stopGatewayGracefully` keys off `gatewayProcess`,
which is only ever set on the spawn path, so it still stops only a gateway this
process spawned. The refactored state is not consulted there.

## Tests

`website/electron/test/gateway-recovery.test.js` -- rewritten for the enum and
extended (11 assertions in the two affected describes, all passing):

- every prior `chooseRecoveryStrategy` case, restated against the state values,
  including the falsy/unknown default and a new explicit garbage-state case.
- `"reused-service"` gets the bounded strategy (previously only reachable
  implicitly, via `reusedLocalGateway` being true whenever the service flag was).
- a closed-vocabulary test that drives every declared state and asserts the
  mapping never returns an unknown strategy, so adding a state without a mapping
  fails here instead of at runtime.
- new `classifyAdoptedGateway` describe: positive identification requires BOTH
  same-family health and a local LISTEN owner; a tunnel, an unidentified owner,
  or a non-same-family reason all stay `"none"`; plus an end-to-end composition
  test proving the classifier feeds the strategy fork losslessly.

## Manual verification

N/A -- unit coverage sufficient. This is a pure refactor of launcher state with
no rendered surface; the two pure helpers are fully covered, and the Electron
suite (922 tests) passes.

<!-- no-visual-delta -->
**Why no screenshot:** launcher process-ownership bookkeeping in
`website/electron/main.js`; no dashboard surface, component, or string changes,
so nothing renders differently.

Closes #2282
