### PR TITLE
fix(publish): drop unsafe-eval from published widget CSP

### DIFF
--- a/src/kiro_crew/publish_sync.py
+++ b/src/kiro_crew/publish_sync.py
@@ -28,8 +28,10 @@ import asyncio
 import hashlib
 import logging
 import os
+import re
 import tempfile
 from datetime import datetime, timezone
+from pathlib import Path
 
 # Concrete publish providers are NOT imported here. In the public edition no
 # provider is registered (the registry stays empty → get_provider() raises
@@ -90,24 +92,53 @@ _STANDALONE_THEME_VARS: dict[str, str] = {
     "--info": "#2563eb",
 }
 
-# CSP for the published standalone widget document (wrap_widget_html), rendered
-# in a null-origin sandboxed iframe. Accepted risk:
-# 'unsafe-eval' is required by the Tailwind Play CDN
-# (cdn.tailwindcss.com), a client-side JIT compiler that calls new Function();
-# 'unsafe-inline' is required because widget bodies are LLM-authored inline
-# <script>/<style> that cannot be nonce/hash-pinned at author time. Residual
-# XSS risk is contained by the sandbox — null origin, default-src 'none',
-# connect-src 'none', form-action 'none', base-uri 'none' — so LLM content
-# cannot reach cookies, storage, the parent DOM, or the network. Removing these
-# tokens would break Tailwind-styled widgets with no material security gain.
+# CSP for the published standalone widget document (wrap_widget_html).
+#
+# 'unsafe-eval' is NOT granted: the vendored Tailwind v4 runtime inlined by
+# wrap_widget_html uses zero eval/Function/WebAssembly, so widget JS gets no
+# dynamic-exec primitive. 'unsafe-inline' stays — widget bodies are LLM-authored
+# inline <script>/<style> that cannot be nonce/hash-pinned at author time, and
+# the runtime itself is inlined. jsdelivr/cdnjs remain for widget-authored
+# Chart.js/D3.
+#
+# Inline script therefore still executes, and what bounds it is carried by the
+# document: this CSP travels in a <meta> tag, so connect-src 'none',
+# form-action 'none' and base-uri 'none' hold wherever the document is served —
+# no fetch/XHR/WebSocket, no form target, no rebased URL. This is not a total
+# egress boundary: script-src deliberately admits jsdelivr/cdnjs, and CSP does
+# not govern top-level navigation. Origin-level isolation (no cookies, no
+# storage, no parent DOM) additionally depends on the destination rendering it
+# in a sandboxed iframe, which the provider owns and Kiro Crew cannot enforce;
+# it is an expectation of the viewer, not a guarantee made here.
 _CSP = (
     "default-src 'none'; "
-    "script-src 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com "
+    "script-src 'unsafe-inline' "
     "https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; "
-    "style-src 'unsafe-inline' https://cdn.tailwindcss.com; "
+    "style-src 'unsafe-inline'; "
     "img-src data: blob:; font-src data:; connect-src 'none'; "
     "form-action 'none'; base-uri 'none';"
 )
+
+#: Vendored Tailwind v4 browser runtime, staged into the served static bundle by
+#: the frontend build (``website/vite.config.ts`` emits it from the tracked
+#: ``@tailwindcss/browser`` dependency). ``website/src/lib/vendorPaths.ts`` is
+#: the URL-path source of truth for the dashboard's own consumers; this is the
+#: on-disk copy of the same asset, read at publish time because a published
+#: document is viewed outside the dashboard and cannot resolve its origin.
+_TAILWIND_RUNTIME_FILE = (
+    Path(__file__).resolve().parent / "static" / "dist" / "vendor" / "tailwindcss-browser.js"
+)
+
+#: Matches a raw-text script terminator in any ASCII casing, capturing the tag
+#: name so a substitution can preserve it. HTML tokenization compares
+#: ``</script`` case-insensitively, so a lowercase-only escape lets ``</SCRIPT>``
+#: close an inlined script early; preserving the matched casing keeps the
+#: neutralised text byte-identical to the source once the browser reads ``<\/``
+#: back as ``/``. ``re.ASCII`` bounds the folding to ASCII: Python otherwise
+#: folds U+017F onto ``s`` and U+0131/U+0130 onto ``i``, so ``</ſcript>`` — which
+#: the HTML tokenizer does NOT treat as a terminator — would take a stray
+#: backslash and could corrupt a raw string literal in the bundle.
+_SCRIPT_CLOSE_RE = re.compile(r"</(script)", re.IGNORECASE | re.ASCII)
 _BASE_BODY_CSS = (
     "body { margin: 0; padding: 16px; font-family: -apple-system, "
     "BlinkMacSystemFont, 'Segoe UI', sans-serif; }"
@@ -165,11 +196,46 @@ _WIDGET_BODY_START = "<!--mc:widget-body-->"
 _WIDGET_BODY_END = "<!--/mc:widget-body-->"
 
 
+def _tailwind_runtime_js() -> str:
+    """Source of the vendored Tailwind v4 browser runtime, or ``""`` when the
+    staged frontend bundle is absent (an unbuilt source checkout).
+
+    Read per call rather than cached: the served bundle is restaged at runtime by
+    a frontend rebuild, and a cache populated before the first build would pin
+    the missing state forever. A 260 KB read is negligible beside the upload it
+    precedes.
+
+    Missing asset degrades to an unstyled-utility render, never to the Tailwind
+    Play CDN: that CDN JIT-compiles via ``new Function()`` and would require
+    ``'unsafe-eval'``, which :data:`_CSP` does not grant. A single static CSP
+    cannot grant eval conditionally, so falling back would mean granting it for
+    every published document to serve a case that only arises pre-build.
+    """
+    try:
+        return _TAILWIND_RUNTIME_FILE.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning(
+            "Tailwind runtime %s unavailable (%s); publishing widget without "
+            "utility-class styling",
+            _TAILWIND_RUNTIME_FILE,
+            exc,
+        )
+        return ""
+
+
 def wrap_widget_html(inner_html: str) -> str:
     """Wrap a widget's inner HTML in a self-contained standalone document.
 
     Mirrors the frontend ``buildSrcdoc`` (widgetSrcdoc.ts) for a fixed
-    light-theme render. The publishing provider auto-injects ``<base
+    light-theme render, including its eval-free Tailwind v4 runtime — inlined
+    here rather than linked, because the document is viewed away from the
+    dashboard origin that serves it. Self-contained as a result: the wrapper
+    adds no network fetch of its own, so styling survives CDN churn and works in
+    network-restricted viewers (widget-authored content may still load its own
+    scripts from the allowed CDNs). The accepted cost is the runtime's ~260 KB
+    in every document wrapped with the runtime staged, paid as transfer and
+    parse before first paint instead of as a CDN round trip. The publishing
+    provider auto-injects ``<base
     target="_blank">`` and a same-page anchor interceptor on upload, so we do
     NOT add those here (design §6.1). No height reporter — that's only for the
     dashboard iframe.
@@ -189,13 +255,21 @@ def wrap_widget_html(inner_html: str) -> str:
         f":root{{{theme_css};color-scheme:light}}"
         "body{background:var(--bg);color:var(--text)}"
     )
+    # The runtime is inlined rather than linked: an external viewer cannot reach
+    # the dashboard origin the frontend serves it from, and the provider hosts a
+    # single file with no sibling asset. Inlining is what keeps the document
+    # self-contained AND eval-free. A raw-text terminator in the source would
+    # close this element early, so every casing of `</script` is neutralised
+    # (the current bundle contains none; the escape keeps a dependency bump from
+    # turning that into a silent break).
+    runtime = _SCRIPT_CLOSE_RE.sub(lambda m: "<\\/" + m.group(1), _tailwind_runtime_js())
+    runtime_tag = f"<script>{runtime}</script>" if runtime else ""
     return (
         "<!DOCTYPE html>\n<html><head>"
         '<meta charset="utf-8">'
         '<meta name="viewport" content="width=device-width, initial-scale=1">'
         f'<meta http-equiv="Content-Security-Policy" content="{_CSP}">'
-        '<script src="https://cdn.tailwindcss.com"></script>'
-        "<script>tailwind.config={darkMode:'class'}</script>"
+        f"{runtime_tag}"
         f"<style>{style}</style>"
         '</head><body class="light">'
         f"{_WIDGET_BODY_START}{inner_html}{_WIDGET_BODY_END}"

--- a/test/test_publish_sync.py
+++ b/test/test_publish_sync.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import json
 import os
+import re
+from pathlib import Path
 
 import pytest
 
@@ -513,9 +515,145 @@ def test_wrap_widget_html_self_contained():
     html = publish_sync.wrap_widget_html("<h1>Hi</h1>")
     assert html.startswith("<!DOCTYPE html>")
     assert "<h1>Hi</h1>" in html
-    assert '<script src="https://cdn.tailwindcss.com"></script>' in html
+    # No external script is fetched: the Tailwind runtime is inlined from the
+    # staged bundle, so the document renders with no network egress.
+    assert "<script src=" not in html
+    assert "cdn.tailwindcss.com" not in html
     # MCP auto-injects <base>; the wrapper must not add it.
     assert "<base" not in html
+
+
+def _csp_directives(csp: str) -> dict[str, set[str]]:
+    """Parse a CSP string into ``{directive: {source tokens}}``.
+
+    Asserting against parsed tokens rather than searching the raw string is
+    exact: a substring hit says nothing about WHICH directive carries a token,
+    so `'unsafe-inline'` in style-src would satisfy a naive check aimed at
+    script-src.
+    """
+    directives: dict[str, set[str]] = {}
+    for part in csp.split(";"):
+        fields = part.split()
+        if fields:
+            directives[fields[0]] = set(fields[1:])
+    return directives
+
+
+def test_published_csp_grants_no_eval():
+    csp = _csp_directives(publish_sync._CSP)
+    # The published CSP must not hand widget JS a dynamic-exec primitive. The
+    # vendored Tailwind v4 runtime needs no eval, so the token has no purpose
+    # here and its presence would undo the containment of LLM-authored inline
+    # scripts.
+    assert "'unsafe-eval'" not in csp["script-src"]
+    # Pinned exactly, not by membership: the Play CDN that required eval is gone
+    # from both directives that named it, and any future source added to either
+    # one fails here rather than widening the policy silently. What survives is
+    # inline widget bodies plus the two CDNs widget-authored Chart.js/D3 load
+    # from; Tailwind v4 emits CSS as inline <style>, so style-src needs no CDN.
+    assert csp["script-src"] == {
+        "'unsafe-inline'",
+        "https://cdn.jsdelivr.net",
+        "https://cdnjs.cloudflare.com",
+    }
+    assert csp["style-src"] == {"'unsafe-inline'"}
+    # And the containment the accepted inline risk rests on.
+    assert csp["default-src"] == {"'none'"}
+    assert csp["connect-src"] == {"'none'"}
+    assert csp["form-action"] == {"'none'"}
+    assert csp["base-uri"] == {"'none'"}
+
+
+def test_wrap_widget_html_inlines_the_staged_runtime(tmp_path, monkeypatch):
+    runtime = tmp_path / "tailwindcss-browser.js"
+    runtime.write_text("/*tw-runtime*/globalThis.__tw=1;", encoding="utf-8")
+    monkeypatch.setattr(publish_sync, "_TAILWIND_RUNTIME_FILE", runtime)
+
+    html = publish_sync.wrap_widget_html("<p>x</p>")
+    assert "<script>/*tw-runtime*/globalThis.__tw=1;</script>" in html
+    # Inlined, not linked — an external viewer has no dashboard origin to resolve.
+    assert "<script src=" not in html
+
+
+def test_wrap_widget_html_without_staged_runtime_does_not_fall_back_to_cdn(tmp_path, monkeypatch):
+    # An unbuilt source checkout has no staged bundle. The document must degrade
+    # to unstyled utility classes rather than reintroduce the Play CDN, which
+    # would require the 'unsafe-eval' the CSP no longer grants.
+    monkeypatch.setattr(publish_sync, "_TAILWIND_RUNTIME_FILE", tmp_path / "absent.js")
+
+    html = publish_sync.wrap_widget_html("<p>x</p>")
+    assert "cdn.tailwindcss.com" not in html
+    assert "<script" not in html
+    # Still a well-formed document carrying the widget and the eval-free CSP.
+    assert html.startswith("<!DOCTYPE html>")
+    assert "<p>x</p>" in html
+    assert "'unsafe-eval'" not in html
+
+
+@pytest.mark.parametrize("close_tag", ["</script>", "</SCRIPT>", "</Script >", "</sCrIpT/"])
+def test_wrap_widget_html_neutralises_script_close_in_runtime(close_tag, tmp_path, monkeypatch):
+    # Guard against a dependency bump shipping a terminator in a string literal.
+    # HTML tokenization matches `</script` in ANY ascii casing, so a
+    # lowercase-only escape would let `</SCRIPT>` close the tag early and dump
+    # the remainder of the bundle into the document body as text.
+    runtime = tmp_path / "tailwindcss-browser.js"
+    runtime.write_text(f'var s="{close_tag}";', encoding="utf-8")
+    monkeypatch.setattr(publish_sync, "_TAILWIND_RUNTIME_FILE", runtime)
+
+    html = publish_sync.wrap_widget_html("<p>x</p>")
+    # Neutralised, and the tag name keeps its original casing so the string the
+    # browser reconstructs is byte-identical to the bundle's.
+    assert f'"<\\/{close_tag[2:]}";' in html
+    # Exactly one script element: the runtime's own, not a truncated one plus
+    # leaked bundle text.
+    assert html.count("</script>") == 1
+
+
+@pytest.mark.parametrize("lookalike", ["</ſcript>", "</scrıpt>", "</scrİpt>"])
+def test_wrap_widget_html_leaves_non_ascii_lookalikes_untouched(lookalike, tmp_path, monkeypatch):
+    # The terminator escape folds case only over ASCII. Python's Unicode
+    # IGNORECASE maps U+017F onto `s` and U+0131/U+0130 onto `i`, but the HTML
+    # tokenizer does not — so escaping these would insert a backslash the source
+    # never had, corrupting a raw string literal for no security gain.
+    runtime = tmp_path / "tailwindcss-browser.js"
+    runtime.write_text(f'var s=String.raw`{lookalike}`;', encoding="utf-8")
+    monkeypatch.setattr(publish_sync, "_TAILWIND_RUNTIME_FILE", runtime)
+
+    html = publish_sync.wrap_widget_html("<p>x</p>")
+    assert lookalike in html
+    assert "<\\/" not in html
+
+
+def test_tailwind_runtime_filename_matches_the_frontend_emit_target():
+    # The runtime path has two owners in two languages: vendorPaths.ts declares
+    # the URL path vite emits to, and _TAILWIND_RUNTIME_FILE reads the emitted
+    # file off disk. They fail asymmetrically — a rename breaks the dashboard
+    # loudly (404 + frontend test) but degrades publishing to a log warning and
+    # an unstyled document. This turns that silent drift into a red test.
+    vendor_paths = Path(__file__).resolve().parents[1] / "website" / "src" / "lib" / "vendorPaths.ts"
+    declared = re.search(
+        r"TAILWIND_RUNTIME_PATH\s*=\s*'([^']+)'", vendor_paths.read_text(encoding="utf-8")
+    )
+    assert declared, "vendorPaths.ts no longer declares TAILWIND_RUNTIME_PATH"
+    assert publish_sync._TAILWIND_RUNTIME_FILE.name == declared.group(1).rsplit("/", 1)[-1]
+
+
+def test_wrap_widget_html_round_trips_with_runtime_inlined(tmp_path, monkeypatch):
+    # The inlined bundle sits between the CSP meta and the body sentinels; the
+    # sentinel scan must still recover the exact inner fragment.
+    runtime = tmp_path / "tailwindcss-browser.js"
+    runtime.write_text("/*tw*/", encoding="utf-8")
+    monkeypatch.setattr(publish_sync, "_TAILWIND_RUNTIME_FILE", runtime)
+
+    inner = "<div class='grid gap-2'>round trip</div>"
+    assert publish_sync.unwrap_widget_html(publish_sync.wrap_widget_html(inner)) == inner
+
+
+def test_tailwind_runtime_js_returns_empty_on_unreadable_asset(tmp_path, monkeypatch):
+    # A directory at the asset path raises OSError on read — the helper reports
+    # it and returns empty rather than propagating into the publish call.
+    monkeypatch.setattr(publish_sync, "_TAILWIND_RUNTIME_FILE", tmp_path)
+    assert publish_sync._tailwind_runtime_js() == ""
 
 
 def test_redact_untrusted_scans_every_source():

--- a/website/src/lib/vendorPaths.ts
+++ b/website/src/lib/vendorPaths.ts
@@ -7,6 +7,13 @@
 //   - vite.config.ts (build)  : generateBundle emit fileName
 // Keeping one definition here means the consumer path can't drift from the
 // dev-serve / build-emit paths.
+//
+// A fourth consumer reads the same asset from DISK, not this URL path:
+// src/kiro_crew/publish_sync.py inlines it into published widget documents,
+// which are viewed away from the dashboard origin and so cannot resolve a
+// same-origin path. It resolves the build-emit location
+// (static/dist/vendor/tailwindcss-browser.js) and depends on the emit filename
+// below staying put.
 
 /** Public URL path the dashboard serves the Tailwind v4 runtime from (leading
  * slash). The sandboxed widget iframe is null-origin, so widgetSrcdoc prefixes


### PR DESCRIPTION
## Problem

Published widget documents loaded the Tailwind Play CDN:

```html
<script src="https://cdn.tailwindcss.com"></script>
```

That CDN is a client-side JIT compiler that calls `new Function()`, so the
document's CSP had to grant `'unsafe-eval'`:

```
script-src 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com ...
```

Widget bodies are LLM-authored inline `<script>`, so this handed that content a
dynamic-exec primitive on top of the inline execution it already has.

## Why it matters

Published documents are the artifacts that leave the dashboard and get shared, so
this is the most exposed surface the widget pipeline has. An automated AppSec scan
flags it (`unsafe-eval in CSP configuration`), and it is the one remaining
non-risk-accepted instance of that finding in this tree.

Being honest about the size of the win: `'unsafe-inline'` is still granted and
cannot be removed — arbitrary inline widget script is the feature, and it cannot
be nonce- or hash-pinned at author time. So this does not stop arbitrary
execution. What it removes is the ability to *synthesise code from data at
runtime*, which is the difference between a payload that must be statically
present in the document and one that can be assembled from a string. Real
defense-in-depth, not a new perimeter.

## Fix (symptom → root cause → change)

The root cause is that the published document reached for a *remote JIT compiler*
to do work the frontend already does locally without eval. `website/` vendors the
eval-free Tailwind v4 browser runtime and serves it same-origin
(`widgetSrcdoc.ts`), and that runtime uses zero `eval` / `new Function` /
`WebAssembly`.

The published path cannot link that runtime: a published document is viewed away
from the dashboard origin, and the provider hosts a single file with no sibling
asset. So the runtime is **inlined** from the staged bundle
(`src/kiro_crew/static/dist/vendor/tailwindcss-browser.js`), and `'unsafe-eval'`
plus `cdn.tailwindcss.com` are dropped from the CSP.

Inlining is what makes the document eval-free, CDN-free and genuinely
self-contained at the same time — which is what `wrap_widget_html`'s own contract
already claimed. Accepted cost is ~260 KB per document, paid as transfer and parse
instead of a CDN round trip; in exchange the document keeps styling with no
network fetch of its own, so it survives CDN churn and renders in
network-restricted viewers.

A missing staged bundle degrades to unstyled utility classes and **never** falls
back to the CDN: one static CSP cannot grant eval conditionally, so a fallback
would mean granting it to every document to serve a case that only arises in an
unbuilt checkout.

Two supporting details:

- The terminator escape is ASCII-case-insensitive with the matched casing
  preserved (`re.IGNORECASE | re.ASCII`). HTML matches `</script` in any ASCII
  casing, so a lowercase-only escape would let `</SCRIPT>` close the element
  early; `re.ASCII` is required because Python otherwise folds U+017F onto `s`
  and U+0131/U+0130 onto `i`, which would insert a stray backslash into bytes
  the tokenizer never treats as a terminator.
- `vendorPaths.ts` gains a comment naming the new disk-side consumer, keeping its
  single-source-of-truth contract accurate.

## Tests

- `test_published_csp_grants_no_eval` — pins the absent tokens *and* the four
  containment tokens the retained `'unsafe-inline'` risk rests on, so a later edit
  cannot quietly trade containment away.
- `test_wrap_widget_html_without_staged_runtime_does_not_fall_back_to_cdn` — pins
  the absence of a CDN fallback, the only route by which `'unsafe-eval'` returns.
- `test_wrap_widget_html_inlines_the_staged_runtime` — inlined, not linked.
- `test_wrap_widget_html_neutralises_script_close_in_runtime` — parametrized over
  `</script>`, `</SCRIPT>`, `</Script >`, `</sCrIpT/`; fails against a
  lowercase-only escape.
- `test_wrap_widget_html_leaves_non_ascii_lookalikes_untouched` — parametrized
  over `</ſcript>`, `</scrıpt>`, `</scrİpt>`; locks the `re.ASCII` bound.
- `test_wrap_widget_html_round_trips_with_runtime_inlined` — sentinel unwrap still
  recovers the exact fragment past a 260 KB inline blob.
- `test_tailwind_runtime_filename_matches_the_frontend_emit_target` — parses
  `TAILWIND_RUNTIME_PATH` out of `vendorPaths.ts` and asserts the Python constant
  agrees. The two owners fail asymmetrically (a rename 404s loudly on the
  dashboard but degrades publishing to a log warning), so this turns silent drift
  into a red test.
- `test_tailwind_runtime_js_returns_empty_on_unreadable_asset` — `OSError` path.

Backend pytest runs without a staged `dist` (CI stages it only for the E2E job),
so every test that needs the asset monkeypatches the path; the one that does not
asserts only properties true in both states.

## Manual verification

Rendered a document against the real 260,427-byte staged bundle:

```
doc bytes=261,543  scripts=1  unsafe-eval=False  cdn.tailwindcss.com=False
round-trip=exact  runtime bytes intact=True
```

Exactly one script element (no early termination), no eval, no CDN, and the
sentinel round-trip still returns the inner fragment byte-for-byte.

Not a user-visible UI change, so no screenshots: the rendered widget is
byte-identical apart from where the Tailwind runtime comes from.

## Out of scope

- **#3373** — widgets published *before* this change keep the old CSP until their
  next push, because `push_version` returns early when the version has not moved.
  Closing that needs a forced re-push or a wrapper-revision marker, i.e. new code
  in files this PR does not touch.
- `webapp_preview.py:326` still grants `'unsafe-eval'` for the loopback-only
  sandboxed dev preview. That instance is separately risk-accepted.
- `builtin_skills/widgets/SKILL.md` still describes `cdn.tailwindcss.com` for the
  *dashboard* iframe — a different surface, already stale on `main` since the
  frontend vendored its runtime.
