### PR TITLE
fix(test): reduce vitest fork workers to fit CI runner memory budget

### DIFF
--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -488,8 +488,22 @@ export default defineConfig({
     // ceiling that fails a genuine leak loudly instead of dragging the host down.
     // (Vitest 4 pool rework: these are top-level, not poolOptions; minWorkers
     // was removed — only maxWorkers has effect.)
-    maxWorkers: 4,
-    execArgv: ['--max-old-space-size=4096'],
+    //
+    // 4 x 4096MB (16GB heap alone) was still too high for ubuntu-latest: two
+    // workers peaking simultaneously exhausts the runner's RAM before either
+    // hits its own --max-old-space-size ceiling, so the OOM kill lands as a
+    // SIGKILL with no JS-level error at all -- the killed worker's file simply
+    // never finishes, and vitest's fork-manager marks it failed via
+    // hasFailed(), a path dangerouslyIgnoreUnhandledErrors does not gate (that
+    // flag only covers errors a live worker gets to report). This reproduces
+    // as shard-composition-dependent: only a diff that shifts memory-heavy
+    // (iframe/component) tests into the same shard as several others reliably
+    // trips it, which is why it hit some PRs' shard 2/3 but not main's own
+    // runs with a different file spread. 2 x 3072MB = 6GB leaves real headroom
+    // for the orchestrator process, coverage instrumentation, and OS overhead
+    // alongside the two workers. See issue #3356.
+    maxWorkers: 2,
+    execArgv: ['--max-old-space-size=3072'],
     // Default 5s is too tight for tests that ``await import(...)`` inside the
     // body: under a full concurrent forks run the collect phase can starve the
     // dynamic import past 5s and it times out. 15s gives headroom for


### PR DESCRIPTION
## Problem

Frontend Tests shards occasionally die mid-run with zero error output — the job log shows setup steps, then nothing until `blob report written` immediately followed by `Process completed with exit code 1`. Downloading the blob artifact shows only a handful of the shard's ~266 files made it into the report, all passing — no failing assertion anywhere.

Full investigation and evidence in #3356.

## Root cause

`maxWorkers: 4` x `--max-old-space-size=4096` requests 16GB of V8 heap alone across 4 concurrent fork workers, before accounting for V8's other memory regions, `--coverage`'s per-file instrumentation maps, happy-dom's DOM retention (heavier for component tests mounting iframes), and the orchestrator process — all sharing the same `ubuntu-latest` runner.

When two workers peak near their ceiling simultaneously, the OS OOM-kills a worker. This produces **no JS-level error** (SIGKILL leaves nothing for V8 to log), so:
- The killed file never finishes — it doesn't fail an assertion, it simply stops.
- vitest's fork-manager marks it failed via `hasFailed(modules)`, setting `process.exitCode = 1`.
- `dangerouslyIgnoreUnhandledErrors` does **not** gate this path — that flag only covers errors a *live* worker gets to report via `_checkUnhandledErrors()`.

This explains why the failure is shard-composition-dependent: only a diff that shifts several memory-heavy (iframe/component) tests into the same shard reliably trips it, while `main`'s own runs with a different file spread do not.

## Fix

```diff
- maxWorkers: 4,
- execArgv: ['--max-old-space-size=4096'],
+ maxWorkers: 2,
+ execArgv: ['--max-old-space-size=3072'],
```

2 x 3072MB = 6GB heap ceiling, leaving real headroom for the orchestrator, coverage instrumentation, and OS overhead.

## Verification

- Full suite locally with the new settings: **1072 files / 17990 tests pass**, unchanged from before.
- Single shard (`--shard 2/4 --coverage`) completes in **~7m15s** — well within the existing 25-minute per-shard timeout.
- TypeScript clean.

## Tradeoff

Slightly slower wall-clock per shard (2 workers instead of 4), but the shard timeout has ample headroom and the current behavior — a silent, non-deterministic worker death — is strictly worse than a modest speed cost.

---
Fixes #3356