### PR TITLE
fix: remove forced npm registry pins

### DIFF
--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -200,12 +200,12 @@ bump one, bump the other and the root `version` fields in
 `packages[""].version`, NOT the dependency entries that coincidentally share a
 version), or `npm ci` will complain about a lock mismatch.
 
-> **npm registry pin (required):** both `website/.npmrc` *and*
-> `website/electron/.npmrc` pin `registry=https://registry.npmjs.org/`. The
-> electron pin is load-bearing — without it `npm ci` in `website/electron/`
-> inherits whatever registry the machine's global `~/.npmrc` sets and can fail
-> with an auth error on a non-public registry. Any new npm subproject needs its
-> own public-registry `.npmrc`.
+> **npm registry (system-configured):** the `.npmrc` files deliberately do NOT
+> pin a registry. `npm ci` inherits whatever registry the machine's `~/.npmrc`
+> or environment configures, so mirrors and private registries work for
+> builders who cannot reach `https://registry.npmjs.org/`. If your configured
+> registry lacks a public package or its auth token expired, fix your registry
+> config rather than adding a pin back.
 
 ## Build pipeline
 

--- a/site/.npmrc
+++ b/site/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/

--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,4 +1,10 @@
-registry=https://registry.npmjs.org/
+# No registry pin here on purpose: the npm registry is system-configured
+# (user/global .npmrc or environment), so mirrors and private registries work
+# for builders who cannot reach https://registry.npmjs.org/.
+
+# Wait before resolving newly published package versions: freshly released
+# packages are the main vector for supply-chain attacks and broken releases.
+min-release-age=7
 
 # Pin the V8 heap for every npm script instead of inheriting Node's default,
 # which is sized from the HOST's RAM. That made the bundle's memory headroom a

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -46,7 +46,9 @@ copy-paste before a single test executes. Commands and layers:
 ## This is a public OSS fork: don't reintroduce internal couplings
 
 - **Build/infra:** no `npm-pretty-much`, Brazil, AIM, or CodeArtifact registries.
-  The public build is plain npm + Vite; `.npmrc` pins the public registry.
+  The public build is plain npm + Vite; `.npmrc` deliberately does not pin a
+  registry -- the system-configured registry applies (see
+  `docs/build/desktop-app.md`).
 - **Identity/telemetry:** no live Cognito pools or RUM app ids (`src/rum.ts` is an
   inert no-op stub, keep it inert), no `aws-rum-web`.
 - **Removed product surfaces:** internal feature-app pages, tabs, API-client

--- a/website/electron/.npmrc
+++ b/website/electron/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/


### PR DESCRIPTION
# fix: remove forced npm registry pins

> Continuation of #2104 by @bbodenmiller — recreated on an org-owned branch to drive CI green. All credit for the change goes to the original author.

## Problem / Motivation

Not everyone can reach `https://registry.npmjs.org/`. The hardcoded `registry=` pins in `site/.npmrc`, `website/.npmrc`, and `website/electron/.npmrc` force that registry for every `npm` invocation in those trees, so builders behind corporate mirrors or private registries cannot build at all.

## Why it matters

The pins block contributors and internal builders whose environments require a mirror — `npm ci` fails outright instead of using their configured registry.

## Fix (symptoms → root cause → change)

- Symptom: `npm ci`/`npm install` fail for builders who cannot reach the public registry.
- Root cause: project-level `.npmrc` `registry=` pins override the system-configured registry.
- Change: remove the pins (delete `site/.npmrc` and `website/electron/.npmrc`, which contained only the pin; strip it from `website/.npmrc`). npm's built-in default is already `https://registry.npmjs.org/`, so environments with no custom registry — including all GitHub-hosted CI runners, which have no global `~/.npmrc` — resolve to the exact same registry as before; only builders who deliberately configure a mirror see a behavior change (their mirror now works).
- Follow-through: a comment in `website/.npmrc` records that the omission is intentional; `docs/build/desktop-app.md` and `website/AGENTS.md` are updated so no doc still calls the pin "required" (a stale doc would invite someone to restore it).
- Required by CI: `website/.npmrc` also gains `min-release-age=7` (wait 7 days before resolving newly published package versions). The blocking SAST (Semgrep) gate (`npm-missing-minimum-release-age`) fires on any modified `.npmrc` without it, so it cannot ship separately from this PR. It only applies to `website/` because that is the only `.npmrc` that still exists after this change (`site/` and `website/electron/` contained nothing but the pin and are deleted). Older npm (including the CI runner's npm 10.x) ignores the unknown key; npm ≥ 11.10 enforces it — the same partial-enforcement window as any adoption of this npm feature.

## Tests

N/A — config/docs-only change; no code path to unit-test. CI itself is the test: every `npm ci` lane exercises registry resolution.

## Manual verification

Verified no test, workflow, or script pins the content/existence of these `.npmrc` files (repo-wide grep). Runtime installers that deliberately pin the public registry (`src/kiro_crew/browser/setup.py`, `mcp_playwright_proxy.py`) use `--registry`/env mechanisms independent of these files and are untouched.

<!-- no-visual-delta -->
**Why no screenshot:** config and documentation change only; no rendered UI is affected.

no issue closed: continuation of PR #2104, which will be closed with credit once this merges.
