### PR TITLE
test: stabilize flaky widget-tag streaming assertion (#3314)

### DIFF
--- a/website/src/test/MochiChatPanel.coverage.test.tsx
+++ b/website/src/test/MochiChatPanel.coverage.test.tsx
@@ -795,7 +795,9 @@ describe('ChatPanel streaming footer', () => {
     await renderPanel()
     stream('Building it now <mcwidget title="Half')
     expect(await screen.findByText('Building it now')).toBeInTheDocument()
-    expect(screen.queryByText(/mcwidget/)).not.toBeInTheDocument()
+    // The stream commit is async; wait for React to flush before asserting the
+    // negative, or a slow runner still sees the pre-strip markup and fails.
+    await waitFor(() => expect(screen.queryByText(/mcwidget/)).not.toBeInTheDocument())
   })
 
   it('replaces the streamed text with the committed message', async () => {


### PR DESCRIPTION
# test: stabilize flaky widget-tag streaming assertion

## Problem
`MochiChatPanel.coverage.test.tsx > ChatPanel streaming footer > drops a half-arrived widget tag rather than showing its markup` fails intermittently in CI while passing locally. Observed on PR #3302, run [31710742636](https://github.com/kirodotdev/KiroCrew/actions/runs/31710742636), shard `Frontend Tests (4)` at head `cba9e9778` — a PR whose diff cannot reach this test's code paths.

## Why it matters
A shard that fails on a file the diff cannot reach costs every unrelated PR a re-run and trains reviewers to distrust red CI.

## Fix (symptom → root cause → change)
- **Symptom:** the test fails only on loaded 2-core CI runners, never locally.
- **Root cause:** after the stream mock emits content containing a partial `<mcwidget` tag, the test awaits the positive assertion (`findByText('Building it now')`, which waits) but then immediately fires the negative assertion with a synchronous `queryByText(/mcwidget/)`. The streamed-state commit that strips the partial tag is asynchronous; on a slow runner the assertion runs before React flushes, still sees the pre-strip markup, and fails.
- **Change:** wrap the negative assertion in `waitFor` — `await waitFor(() => expect(screen.queryByText(/mcwidget/)).not.toBeInTheDocument())` — so the assertion polls until React commits. This is the determinism-conventions remedy for this flake class (poll, never sleep/rerun/relax) and the same pattern this file already uses for its other post-async negative assertion ("replaces the streamed text with the committed message").

The assertion semantics are unchanged: if the panel ever rendered the partial widget markup persistently, `waitFor` times out and the test still fails.

## Tests
This PR is itself a test change. `MochiChatPanel.coverage.test.tsx` passes 82/82; full frontend suite 17990 passed / 0 failed on the branch; `npx tsc -b` clean.

## Manual verification
N/A — unit coverage sufficient; the change is confined to one test assertion.

## Screenshots
N/A — no user-visible UI change.

Closes #3314
