### PR TITLE
fix: keep Restart & Update disabled after install is dispatched

### DIFF
--- a/website/src/components/UpdateModal.tsx
+++ b/website/src/components/UpdateModal.tsx
@@ -50,7 +50,12 @@ export default function UpdateModal() {
   }
 
   const installMutation = useMutation({ mutationFn: () => getUpdateApi()!.install() })
-  const installing = installMutation.isPending
+  // install() resolves as soon as the install is DISPATCHED — on macOS the
+  // platform installer then works for several seconds before the app quits.
+  // Keying `disabled` on `isPending` alone lets the button re-arm during that
+  // window, so the user sees a clickable "Restart & Update" followed by an
+  // unexplained quit — which reads as a crash.
+  const installing = installMutation.isPending || installMutation.isSuccess
 
   const open = !!update && update.state === 'downloaded' && !dismissed
 


### PR DESCRIPTION
# fix: keep Restart & Update disabled after install is dispatched

> **Credit:** This change was originally authored by @welikoiwanenko in #2027. That PR went stale with CI failures caused purely by base drift (Windows backend + macOS Gateway lanes). This PR recreates the same fix on a fresh base per the drive-to-green process — the design, approach, and scope are unchanged from the original. Thank you @welikoiwanenko!

## Problem

After clicking "Restart & Update" in the update modal, the button briefly re-enables before the app actually quits and relaunches. The user sees a clickable button again and thinks the click did nothing.

## Why it matters

On macOS, the platform installer works for several seconds after the IPC call resolves. During that window the user sees an active button, clicks it again, and interprets the subsequent quit as a crash rather than a successful update.

## Fix (symptoms → root cause → change)

`update:install` resolves as soon as the install is **dispatched** — not when the app actually quits. Keying `disabled` on `isPending` alone lets the button re-arm during that window.

Fix: key on `isPending || isSuccess` so the button stays disabled once the install is dispatched.

This is the exact pattern already used in `AboutPanel.tsx` (see its explicit "Install is a ONE-WAY door" comment documenting this same problem). `UpdateModal` was written later and missed it.

```tsx
// before
const installing = installMutation.isPending

// after
const installing = installMutation.isPending || installMutation.isSuccess
```

Failure paths verified: on `isError`, `isPending` clears and `isSuccess` never sets, so the button (and dismiss/Escape handlers) correctly re-enable — no regression on the retry path.

## Tests

No automated tests added — this is a one-line fix mirroring an established pattern in the same codebase. `AboutPanel.tsx` has the same logic and no test for it either. Local gates: `tsc -b` clean, full vitest suite 18001 passed, eslint 0 errors.

## Manual verification

Verified by the original author: reproduced locally using a mock `window.updateAPI` that resolves after 2 seconds (simulating the dispatch-to-quit window). With the fix, the button remains disabled through `isSuccess` until the app would quit.

<!-- no-visual-delta -->
**Why no screenshot:** the only rendered delta is a transient disabled-button state during a live update install (the seconds between install dispatch and app quit); the modal's resting appearance is unchanged and the state is not reachable in a static build without a real signed update in flight.

Supersedes #2027 (no issue closed: the original PR is the tracking item and will be closed with credit once this is green).
