### PR TITLE
fix(crew): resolve crew name to its agent template

### DIFF
--- a/src/kiro_crew/crew_chat.py
+++ b/src/kiro_crew/crew_chat.py
@@ -29,6 +29,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from kiro_crew.config.loader import KiroCrewConfig, resolve_agent_bindings
 from kiro_crew.config.paths import data_home
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_utils import effective_session_key
@@ -993,6 +994,68 @@ class CrewOrchestrator:
         except Exception:
             logger.debug("crew: agent-cache warm failed", exc_info=True)
 
+    async def _dispatch_agent(self, slot: Any) -> str:
+        """The kiro-cli agent TEMPLATE this slot's crew dispatches as.
+
+        ``slot.agent`` holds a CREW name — a key of the config's ``agents``
+        mapping — while ``spawn()`` validates its ``agent=`` against the kiro-cli
+        TEMPLATE names ``list_agents()`` reports. The two coincide for every crew
+        whose ``kiro_agent`` repeats its own name, which is all of them except
+        the default crew: ``default`` binds the template ``kirocrew``. Passing the
+        crew name straight through therefore worked by coincidence everywhere
+        except the crew every session starts on, where ``_validate_agent`` refused
+        the dispatch and the user saw "Couldn't start that one".
+
+        Resolution is deliberately per dispatch rather than cached on the slot: a
+        config edit must take effect on the next message, and the crew name stays
+        the durable identity.
+
+        The warm is kept and runs first — the resolved template may itself be a
+        project agent, which ``_validate_agent`` only ever sees through the warmed
+        cache. Falls back to the crew name on any resolution failure, so a broken
+        config degrades to the previous behaviour instead of losing the dispatch.
+
+        An UNKNOWN crew name (``requested_resolved`` False) also returns the raw
+        crew name rather than the default binding the resolver fell back to:
+        dispatching that binding would silently run the default agent under a
+        stale name, whereas the crew name is refused by ``_validate_agent`` —
+        the unknown-name path stays fail-closed.
+
+        An EMPTY crew also resolves (as ``None``, i.e. the default binding)
+        rather than passing ``""`` through: ``spawn()``'s governance agent-scope
+        check (``capabilities.spawn.scopes.agents``) only vets a NAMED agent, so
+        ``agent=""`` would run the default agent without the administrator's
+        allowlist ever seeing it. Resolving pins the concrete template name the
+        dispatch will run, keeping it inside the governance check.
+        """
+        await self._warm_agent_cache(slot)
+        crew = str(getattr(slot, "agent", "") or "")
+
+        def _resolve() -> str:
+            cfg = KiroCrewConfig.load()
+            bindings = resolve_agent_bindings(cfg, crew or None, self._slot_cwd(slot) or None)
+            if crew and not getattr(bindings, "requested_resolved", True):
+                # The crew name matched neither an alias nor a materialized
+                # agent, so the resolver fell back to the DEFAULT binding.
+                # Dispatching that binding would silently run the default
+                # agent under an unknown/stale crew name — return the raw
+                # crew name instead so _validate_agent refuses it, keeping
+                # the unknown-name path fail-closed.
+                logger.warning(
+                    "crew: crew %r is unknown; refusing default-agent fallback",
+                    crew,
+                )
+                return crew
+            return str(bindings.kiro_agent or crew)
+
+        try:
+            # KiroCrewConfig.load() reads and parses from disk; this runs on the
+            # event loop, so it goes to a worker thread.
+            return await asyncio.to_thread(_resolve)
+        except Exception:
+            logger.warning("crew: could not resolve crew %r to a template", crew, exc_info=True)
+            return crew
+
     async def _post_durable(self, slot: Any, content: str, kind: str = "crew") -> bool:
         """`_post`, then wait for the durable transcript row to actually land.
 
@@ -1389,7 +1452,7 @@ class CrewOrchestrator:
                 # the same flag on the main path. Without it, a temporary crew slot
                 # leaked stored memory and lessons into every subagent it spawned.
                 no_reads = bool(getattr(slot, "blocks_reads", False))
-                await self._warm_agent_cache(slot)
+                dispatch_agent = await self._dispatch_agent(slot)
             except Exception:
                 e["state"] = prior_state or "pending"
                 e.pop("dispatch_id", None)
@@ -1414,7 +1477,7 @@ class CrewOrchestrator:
                 # subagent edits files, and without this it edited ANOTHER
                 # project's tree. Same value the warm above validated.
                 cwd=self._slot_cwd(slot),
-                agent=getattr(slot, "agent", "") or "",
+                agent=dispatch_agent,
                 keep=True,
                 _preassigned_id=dispatch_id,
                 include_memory=not no_reads,
@@ -1540,13 +1603,14 @@ class CrewOrchestrator:
         # id rather than a guess. Without this the continuation minted its id
         # inside the call, and a restart could neither adopt the started run nor
         # safely reopen the entry.
+        dispatch_agent = await self._dispatch_agent(slot)
         info = self._subagents.continue_conversation(
             t["topic_id"], e["text"] + _SUB_TASK_SUFFIX,
             # Same governance key as the spawn path: a continuation re-enters the
             # capability check, so keying it to the tab would let a resumed topic
             # run under a surface the linked session never granted.
             parent_session_key=effective_session_key(slot),
-            agent=getattr(slot, "agent", "") or "",
+            agent=dispatch_agent,
             # Same cwd as the spawn path. `spawn` resolves an empty cwd to the
             # pool project BEFORE validating the agent, so a project-local agent
             # was rejected here and the rejection fell through to a digest-only
@@ -1590,12 +1654,12 @@ class CrewOrchestrator:
                     )
                     raise
                 no_reads = bool(getattr(slot, "blocks_reads", False))
-                await self._warm_agent_cache(slot)
+                dispatch_agent = await self._dispatch_agent(slot)
                 fresh = self._subagents.spawn(
                     seed + _SUB_TASK_SUFFIX,
                     parent_session_key=effective_session_key(slot),
                     cwd=self._slot_cwd(slot),
-                    agent=getattr(slot, "agent", "") or "", keep=True,
+                    agent=dispatch_agent, keep=True,
                     _preassigned_id=respawn_id,
                     include_memory=not no_reads,
                     include_lessons=not no_reads,

--- a/test/test_crew_chat.py
+++ b/test/test_crew_chat.py
@@ -2722,3 +2722,217 @@ class TestGptRoundSixteen:
             "ingest returned without forcing the slot to disk — the echoed user "
             "message and the acknowledgement were memory-only"
         )
+
+
+def _crew_config(mapping: dict[str, str]) -> MagicMock:
+    """A config whose `agents` maps crew name -> kiro_agent template."""
+    cfg = MagicMock()
+    cfg.agents = {
+        name: MagicMock(kiro_agent=template) for name, template in mapping.items()
+    }
+    return cfg
+
+
+def _bindings(mapping: dict[str, str]):
+    """`resolve_agent_bindings` stand-in honouring *mapping*, else passthrough."""
+
+    def _resolve(_cfg, agent_name=None, project_dir=None):  # type: ignore[no-untyped-def]
+        del project_dir
+        return MagicMock(kiro_agent=mapping.get(agent_name or "", agent_name or ""))
+
+    return _resolve
+
+
+class TestCrewNameResolvesToTemplate:
+    """`slot.agent` is a CREW name; `spawn(agent=)` validates TEMPLATE names.
+
+    They coincide for every crew whose `kiro_agent` repeats its own name, so the
+    defect only ever showed on the default crew (`default` -> `kirocrew`) — which
+    is the crew every session starts on, making crew mode unusable by default.
+    """
+
+    def _patches(self, mapping: dict[str, str]):
+        return (
+            patch.object(crew_mod.KiroCrewConfig, "load", staticmethod(
+                lambda: _crew_config(mapping))),
+            patch.object(crew_mod, "resolve_agent_bindings", _bindings(mapping)),
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_crew_dispatches_as_its_template(self) -> None:
+        cfg_patch, bind_patch = self._patches({"default": "kirocrew"})
+        subagents = MagicMock()
+        subagents.spawn = MagicMock(return_value=_spawn_info("r1"))
+        orch = _orch(subagents=subagents)
+        slot = _slot(agent="default")
+        st = orch._store("s1")
+        e = st.add_msg("build X")
+        with cfg_patch, bind_patch, patch.object(orch, "_post"):
+            await orch._apply(slot, st, {"do": "spawn", "msg_id": e["msg_id"], "title": "X"})
+        # The crew name would be refused by _validate_agent: no template is named
+        # "default".
+        assert subagents.spawn.call_args.kwargs["agent"] == "kirocrew"
+
+    @pytest.mark.asyncio
+    async def test_crew_whose_name_matches_its_template_is_unchanged(self) -> None:
+        cfg_patch, bind_patch = self._patches({"cr-analyst": "cr-analyst"})
+        subagents = MagicMock()
+        subagents.spawn = MagicMock(return_value=_spawn_info("r1"))
+        orch = _orch(subagents=subagents)
+        st = orch._store("s1")
+        e = st.add_msg("review this")
+        with cfg_patch, bind_patch, patch.object(orch, "_post"):
+            await orch._apply(_slot(agent="cr-analyst"), st,
+                              {"do": "spawn", "msg_id": e["msg_id"], "title": "X"})
+        assert subagents.spawn.call_args.kwargs["agent"] == "cr-analyst"
+
+    @pytest.mark.asyncio
+    async def test_empty_agent_resolves_to_the_default_binding(self) -> None:
+        # Empty must NOT pass "" through to spawn(): the governance agent-scope
+        # check (capabilities.spawn.scopes.agents) only vets a NAMED agent, so
+        # agent="" would run the default agent outside the administrator's
+        # allowlist. Resolving as None pins the default binding's template.
+        def _resolve(_cfg, agent_name=None, project_dir=None):  # type: ignore[no-untyped-def]
+            del project_dir
+            assert agent_name is None  # empty crew resolves as the default
+            return MagicMock(kiro_agent="kirocrew", requested_resolved=True)
+
+        cfg_patch = patch.object(crew_mod.KiroCrewConfig, "load", staticmethod(
+            lambda: _crew_config({"default": "kirocrew"})))
+        bind_patch = patch.object(crew_mod, "resolve_agent_bindings", _resolve)
+        subagents = MagicMock()
+        subagents.spawn = MagicMock(return_value=_spawn_info("r1"))
+        orch = _orch(subagents=subagents)
+        st = orch._store("s1")
+        e = st.add_msg("build X")
+        with cfg_patch, bind_patch, patch.object(orch, "_post"):
+            await orch._apply(_slot(agent=""), st,
+                              {"do": "spawn", "msg_id": e["msg_id"], "title": "X"})
+        assert subagents.spawn.call_args.kwargs["agent"] == "kirocrew"
+
+    @pytest.mark.asyncio
+    async def test_resolution_failure_falls_back_to_the_crew_name(self) -> None:
+        # A broken config must degrade to the previous behaviour, not lose the
+        # dispatch: the crew name still resolves for the 40 crews where name ==
+        # template.
+        subagents = MagicMock()
+        subagents.spawn = MagicMock(return_value=_spawn_info("r1"))
+        orch = _orch(subagents=subagents)
+        st = orch._store("s1")
+        e = st.add_msg("build X")
+        boom = patch.object(crew_mod.KiroCrewConfig, "load", staticmethod(
+            MagicMock(side_effect=RuntimeError("unreadable config"))))
+        with boom, patch.object(orch, "_post"):
+            await orch._apply(_slot(agent="cr-analyst"), st,
+                              {"do": "spawn", "msg_id": e["msg_id"], "title": "X"})
+        assert subagents.spawn.call_args.kwargs["agent"] == "cr-analyst"
+
+    @pytest.mark.asyncio
+    async def test_warm_still_runs_before_resolution(self) -> None:
+        # The resolved template may itself be a project agent, which
+        # _validate_agent only ever sees through the warmed cache.
+        cfg_patch, bind_patch = self._patches({"default": "kirocrew"})
+        orch = _orch()
+        with cfg_patch, bind_patch, patch.object(
+            orch, "_warm_agent_cache", new=AsyncMock()
+        ) as warm:
+            resolved = await orch._dispatch_agent(_slot(agent="default"))
+        assert resolved == "kirocrew"
+        warm.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_continuation_dispatches_as_the_template(self) -> None:
+        cfg_patch, bind_patch = self._patches({"default": "kirocrew"})
+        orch = _orch()
+        st = orch._store("s1")
+        slot = _slot(agent="default")
+        e = st.add_msg("first")
+        info0 = _spawn_info("r1")
+        orch._subagents.spawn = MagicMock(return_value=info0)
+        with cfg_patch, bind_patch, patch.object(orch, "_post"):
+            await orch._apply(slot, st, {"do": "spawn", "msg_id": e["msg_id"], "title": "T"})
+        t = st.topic("r1")
+        t["status"] = "idle"
+        follow = st.add_msg("follow up")
+        orch._subagents.continue_conversation = MagicMock(return_value=_spawn_info("r2"))
+        with cfg_patch, bind_patch, patch.object(orch, "_post"):
+            await orch._apply(slot, st, {"do": "route", "msg_id": follow["msg_id"],
+                                         "topic_id": t["topic_id"]})
+        kwargs = orch._subagents.continue_conversation.call_args.kwargs
+        assert kwargs["agent"] == "kirocrew"
+
+
+class TestUnknownCrewNameStaysFailClosed:
+    """An UNKNOWN crew name must not dispatch as the default agent.
+
+    `resolve_agent_bindings` answers an unknown name with the DEFAULT binding
+    and signals it via `requested_resolved=False`. Dispatching that binding
+    would silently run the default agent under a stale/unknown crew name —
+    `_dispatch_agent` must return the raw crew name instead, which
+    `_validate_agent` refuses because no template carries it.
+    """
+
+    @staticmethod
+    def _unknown_bindings(default_template: str):
+        """Resolver stub: unknown names fall back to the default binding."""
+
+        def _resolve(_cfg, agent_name=None, project_dir=None):  # type: ignore[no-untyped-def]
+            del project_dir
+            return MagicMock(
+                kiro_agent=default_template,
+                requested_resolved=False,
+            )
+
+        return _resolve
+
+    @pytest.mark.asyncio
+    async def test_unknown_crew_returns_the_raw_name_not_the_default(self) -> None:
+        cfg_patch = patch.object(
+            crew_mod.KiroCrewConfig, "load",
+            staticmethod(lambda: _crew_config({"default": "kirocrew"})))
+        bind_patch = patch.object(
+            crew_mod, "resolve_agent_bindings", self._unknown_bindings("kirocrew"))
+        orch = _orch()
+        with cfg_patch, bind_patch:
+            resolved = await orch._dispatch_agent(_slot(agent="ghost-crew"))
+        # NOT "kirocrew": the default binding must not be dispatched under an
+        # unknown name. The raw name is what _validate_agent refuses.
+        assert resolved == "ghost-crew"
+
+    @pytest.mark.asyncio
+    async def test_unknown_crew_spawn_is_refused_downstream(self) -> None:
+        # End-to-end through _apply: the unknown name reaches spawn(agent=)
+        # unchanged, so _validate_agent (which only accepts real template
+        # names) refuses the dispatch instead of silently running the default
+        # agent.
+        cfg_patch = patch.object(
+            crew_mod.KiroCrewConfig, "load",
+            staticmethod(lambda: _crew_config({"default": "kirocrew"})))
+        bind_patch = patch.object(
+            crew_mod, "resolve_agent_bindings", self._unknown_bindings("kirocrew"))
+        subagents = MagicMock()
+        subagents.spawn = MagicMock(return_value=_spawn_info("r1"))
+        orch = _orch(subagents=subagents)
+        st = orch._store("s1")
+        e = st.add_msg("build X")
+        with cfg_patch, bind_patch, patch.object(orch, "_post"):
+            await orch._apply(_slot(agent="ghost-crew"), st,
+                              {"do": "spawn", "msg_id": e["msg_id"], "title": "X"})
+        assert subagents.spawn.call_args.kwargs["agent"] == "ghost-crew"
+
+    @pytest.mark.asyncio
+    async def test_known_crew_is_unaffected_by_the_guard(self) -> None:
+        # requested_resolved defaults True for constructions predating the
+        # field; a known crew keeps resolving to its template.
+        def _resolve(_cfg, agent_name=None, project_dir=None):  # type: ignore[no-untyped-def]
+            del project_dir
+            return MagicMock(kiro_agent="kirocrew", requested_resolved=True)
+
+        cfg_patch = patch.object(
+            crew_mod.KiroCrewConfig, "load",
+            staticmethod(lambda: _crew_config({"default": "kirocrew"})))
+        bind_patch = patch.object(crew_mod, "resolve_agent_bindings", _resolve)
+        orch = _orch()
+        with cfg_patch, bind_patch:
+            resolved = await orch._dispatch_agent(_slot(agent="default"))
+        assert resolved == "kirocrew"


### PR DESCRIPTION
## Problem

Crew mode is unusable on a default-crew session. Every dispatch fails, and the
chat shows:

```
Couldn't start that one — say the word and I'll retry.
Couldn't start that one — say the word and I'll retry.
Couldn't start that one — say the word and I'll retry.
I could not work out how to route this request after several attempts, so
nothing was started. Please rephrase and send again.
```

The gateway log names the cause on every attempt:

```
WARNING kiro_crew.subagent: Agent 'default' not found; refusing spawn.
Available: ['amzn-builder', 'apollo-deployment-assistant', 'cr-analyst', ...]
```

## Why it matters

`default` is the crew every chat session starts on, so crew mode is broken out
of the box: the user has to know to pick a *named* crew from the picker before
the feature works at all. The retry text also reads as a transient failure, so
the natural response is to try again — which fails identically.

## Fix (symptom → root cause → change)

**Symptom.** `_validate_agent` refuses the spawn, and the refusal's "Available"
list does not contain the requested name.

**Root cause.** Two namespaces that look alike:

| | what it is | where it lives |
|---|---|---|
| **crew** | a key of the config's `agents` mapping | `agents.<name>` in `config.json` |
| **template** | the kiro-cli agent `list_agents()` reports | `agents.<name>.kiro_agent` |

`spawn(agent=)` validates **template** names. `crew_chat` passed
`getattr(slot, "agent", "")` — a **crew** name — straight through. The two
coincide for every crew whose `kiro_agent` repeats its own name, which is all of
them except the default crew, where `default` binds the template `kirocrew`. So
the mismatch was invisible for 40 of 41 crews and fatal for the one that ships
as the default.

**Change.** One `_dispatch_agent` accessor that warms the project agent cache
and then resolves the crew via `resolve_agent_bindings(...).kiro_agent`, with all
three dispatch paths routed through it (spawn, continue, respawn) so they cannot
drift apart. Resolution is per dispatch rather than cached on the slot: a config
edit takes effect on the next message, and the crew name stays the durable
identity.

Two things deliberately unchanged, because both looked like cleanup targets and
are not:

- **`_warm_agent_cache` stays, and still runs first.** The resolved template may
  itself be a project agent, and `_validate_agent` only ever sees those through
  the warmed cache — so removing the warm would trade this bug for a
  project-agent version of it.
- **`_agent_prevalidated` is NOT set.** Resolving an alias proves nothing about
  the template existing, so setting it would restore the silent-fallback
  privilege escalation the refusal exists to prevent, and would additionally
  bypass the spawn queue.

Resolution failure falls back to the crew name, so a broken config degrades to
today's behaviour instead of losing the dispatch.

## Tests

Six cases in `test/test_crew_chat.py::TestCrewNameResolvesToTemplate`:

| test | locks in |
|---|---|
| `test_default_crew_dispatches_as_its_template` | the reported bug: crew `default` reaches `spawn()` as `kirocrew` |
| `test_crew_whose_name_matches_its_template_is_unchanged` | the 40 coincidental crews keep working |
| `test_empty_agent_stays_empty` | `""` still means "use the host default" and is not substituted with a named agent |
| `test_resolution_failure_falls_back_to_the_crew_name` | a config read failure degrades instead of dropping the dispatch |
| `test_warm_still_runs_before_resolution` | the warm ordering that keeps project agents resolvable |
| `test_continuation_dispatches_as_the_template` | the continuation path, which had no warm at all before this change |

**Proven red pre-fix.** With the resolution stripped (returning the crew name
verbatim), 3 of the 6 fail; restored, all 6 pass. The existing suite is 155
passing, and note that `_slot()`'s default of `agent="kirocrew"` is what hid this
defect — that default is a *template* name where production passes a *crew* name.

## Manual verification

N/A — unit coverage is the right shape here. The failure is a pure
name-resolution mismatch at one call boundary, and the three dispatch paths are
each asserted on the `spawn` / `continue_conversation` kwargs they actually emit.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change in `src/kiro_crew/crew_chat.py`; no
frontend path is touched and nothing renders differently.

## Follow-up (not in this PR)

`src/kiro_crew/dashboard/chat_orchestrator.py` carries the identical
crew-name-into-`spawn(agent=)` pattern at 11 autopilot sites. Same defect class,
same one-line remedy, but a different surface — kept out to keep this diff
reviewable. Worth its own PR.

no issue closed: reported in chat, no tracking issue filed.
