### PR TITLE
feat(acp): make the KAS backend able to serve a real session

### DIFF
--- a/docs/system-specs/modules/providers.md
+++ b/docs/system-specs/modules/providers.md
@@ -84,6 +84,90 @@ branch is unreachable in this build. Its binary-resolution + config-isolation
 details live in [`acp-client.md`](acp-client.md); do not re-add the registration
 glue or a provider selector (see the repo-root `CLAUDE.md`).
 
+**KAS backend authentication:** KAS launches with `--auth=acp-callback` and asks
+the host for an access token over ACP; `acp.kas_auth` answers by shelling out to
+kiro-cli's `chat _ get-kas-token`. Pointing KAS at a token file cannot work in
+general — credential resolution is stateful logic in kiro-cli (a cross-process
+refresh lock, a priority order across cached identities, OIDC refresh on expiry),
+and the default cache location holds only one of those identities, so on a host
+signed in another way KAS's own file provider correctly finds nothing. The refresh
+token never leaves kiro-cli; only short-lived access tokens pass through.
+
+Three details are load-bearing. `provider` must be forwarded when present or KAS
+infers enterprise status from `profileArn` presence and **fail-closes governance**
+for Builder ID and social sign-ins; `authMethod` selects the upstream `TokenType`
+header and is absent for those same identities, so it is omitted rather than sent
+empty. The reply uses `-32603`, not `-32601`: method-not-found would tell KAS the
+capability is absent and stop it asking again, turning a transient credential
+problem into a permanently unauthenticated session. And the callback is answered
+**on the runtime's reader loop**, not a session handle — it carries no `sessionId`
+and arrives *during* `session/new`, before any session queue exists, so deferring
+it deadlocks (KAS waits for the token, `create_session` waits for the id).
+
+**KAS backend agent selection:** KAS has no `--agent` flag, so the agent is named
+AND defined in `session/new`'s `_meta.kiro` — `modeId` selects, `customAgents`
+registers. Both are required, and omitting the definition fails **silently**: KAS
+binds `modeId` only to an agent already in its registry and ignores an
+unresolvable name rather than rejecting it, so `session/new` succeeds and the
+session runs KAS's own default mode with none of the agent's prompt, tool grants
+or MCP servers in effect. Measured against the KAS kiro-cli extracts: `modeId`
+alone returned `configOptions.currentValue == "vibe"`; with the definition it
+returned the requested agent.
+
+`acp.kas_agent` translates the on-disk config (kiro-cli's format) on the way out
+rather than migrating files — client-provided agents are the highest-precedence
+source in KAS's registry, above `~/.kiro/agents`, `.kiro/agents`, bundled and
+cloud profiles, so a stale file cannot shadow the live config. Two fields need
+real translation: `prompt` must be resolved content (KAS rejects a `file://` URI
+and makes resolution the client's job), and `tools` is `"*"`-or-list where
+kiro-cli splits the grant across `tools` and `allowedTools` — only `tools` maps,
+because `allowedTools` is an approval concern the host's own PreToolUse gate owns
+and forwarding it as tool ACCESS would widen real reach.
+
+Both KAS-specific behaviours reach the shared `AcpRuntime` as **capability
+membership**, never as a harness comparison on the shared path:
+`ACP_BACKENDS_HOST_MEDIATED_AUTH` decides who may be answered with a live access
+token, and `ACP_BACKENDS_CLIENT_DEFINED_AGENT` decides who needs the agent
+definition in `session/new`. Both are resolved once in `__init__` into a boolean,
+so the reader loop and `create_session` read a flag. A backend that never joins a
+set has no code path that reaches the behaviour — a stronger guarantee than a
+comparison evaluated per frame, and it keeps harness support additive
+(harness-parity H13).
+
+`resources` is deliberately **not** forwarded. KAS resolves those entries in its
+own process, so Kiro Crew's sensitive-path gate never sees the reads — an agent
+config carrying `resources: ["file://~/.aws/credentials"]` would put the file into
+model context. Validating them host-side would mean reimplementing KAS's resolver:
+an `AgentResource` is either a bare `file://`/`skill://` URI or a `knowledgeBase`
+object whose `include` carries glob patterns, and its schema states that scheme
+classification happens where the agent resolves them. A validator covering only
+the bare-URI form would read as a gate while the glob form walked through, so the
+capability is withheld until resources resolve through the sensitive-path check.
+A KAS agent losing its context files is a recoverable gap; a leaked credential is
+not.
+
+Every `file:` authority form is decided in one place (`_file_uri_to_path`), and a
+relative reference resolves against the **config's own directory** — never the
+gateway's working directory, which would inline an unrelated file into the system
+prompt. `.`/`..` are relative prefixes rather than hosts, `localhost` reads as an
+empty authority, a drive-shaped authority is a mis-parsed Windows drive, and any
+other authority stays a UNC host (dropping it would retarget the read at a
+same-named local path).
+
+Resolution is
+**fail-closed**: when the agent cannot be resolved, `create_session` raises BEFORE
+`session/new` rather than sending the request without a definition. That is
+deliberate — omitting the definition makes KAS fall back to its own default mode,
+which carries BROADER tool access than the configured agent, so "degrading
+politely" would be a silent privilege widening.
+
+Resolution is also delegated to `agent_discovery` in full — never a path this
+module builds, never a filename it compares. The declared `name` wins over the
+filename (that is what kiro-cli lists and accepts for `--agent`), and
+project-local wins over global. Three separate defects came from breaking that
+delegation three different ways, so the invariant is stated in the code rather
+than left implicit.
+
 **Key APIs:**
 - `start()` → `AcpClient.ensure_ready()` (spawns process, handshake, session/new)
 - `stream()` → maps events from `stream_events()`

--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -65,6 +65,7 @@ def build_session_new_params(
     *,
     mcp_servers: list[dict[str, Any]] | None = None,
     claude_meta: bool = False,
+    kas_agent: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the params for a ``session/new`` request.
 
@@ -72,6 +73,14 @@ def build_session_new_params(
     ``mcpServers`` field as malformed and exits cleanly (rc=0, no stderr) — so
     both backends must send it, even as an empty list. The ``claude_meta`` flag
     adds the SDK envelope the claude-agent-acp backend requires.
+
+    ``kas_agent`` carries a ClientCustomAgent definition for the KAS backend,
+    which has no ``--agent`` flag. It must be sent whenever a KAS session needs a
+    Kiro Crew agent: KAS binds ``modeId`` only to an agent already in its
+    registry and IGNORES an unresolvable one rather than rejecting it, so naming
+    the agent without also DEFINING it yields a fully successful ``session/new``
+    that quietly runs KAS's own default mode — with none of the agent's prompt,
+    tool grants or MCP servers in effect and every log line looking healthy.
     """
     params: dict[str, Any] = {
         "cwd": str(cwd),
@@ -79,6 +88,14 @@ def build_session_new_params(
     }
     if claude_meta:
         params["_meta"] = {"claudeCode": {"options": {}}}
+    elif kas_agent:
+        # Both keys in one namespace: the definition registers the agent and
+        # modeId selects it. Client-provided agents are the highest-precedence
+        # source in KAS's registry, above every file-based one, so nothing has to
+        # be written to disk and a stale file cannot shadow this.
+        params["_meta"] = {
+            "kiro": {"modeId": kas_agent["id"], "customAgents": [kas_agent]}
+        }
     return params
 
 

--- a/src/kiro_crew/acp/kas_agent.py
+++ b/src/kiro_crew/acp/kas_agent.py
@@ -1,0 +1,296 @@
+"""Translate a Kiro Crew agent config into KAS's injected-agent shape.
+
+The KAS backend has no ``--agent`` flag, so what that flag carries for kiro-cli
+has to travel in ``session/new`` instead. KAS accepts client-supplied agents in
+``_meta.kiro.customAgents``, and those are the HIGHEST-precedence source in its
+registry (above ``~/.kiro/agents``, ``.kiro/agents``, bundled and cloud profiles),
+so the config is translated on the way out rather than migrated on disk — nothing
+is written anywhere and a stale file cannot shadow the live config.
+
+Sending the definition is not optional. KAS binds ``modeId`` only to an agent
+already in its registry and **ignores an unresolvable name rather than rejecting
+it**, so selecting without defining produces a completely successful
+``session/new`` that runs KAS's own default mode. Measured: sending
+``modeId: "kirocrew"`` alone came back with ``configOptions.currentValue ==
+"vibe"``; sending it together with the definition came back ``"kirocrew"``. Every
+log line looks healthy either way, which is what makes the failure worth guarding
+in code rather than documenting.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+from urllib.request import url2pathname
+
+from kiro_crew.config.paths import kiro_agents_dir
+
+logger = logging.getLogger(__name__)
+
+#: Prompt references Kiro Crew may write into an agent config. KAS rejects these
+#: in its ``prompt`` field and documents resolution as the client's job, so they
+#: are read here rather than forwarded and silently dropped.
+_FILE_URI_SCHEME = "file://"
+
+#: A Windows drive letter that ``urlparse`` mistook for a host, e.g. the ``C:`` in
+#: ``file://C:\\Users\\...``. Matched rather than assumed so a genuine host in a
+#: ``file://host/share`` UNC reference is left alone.
+_DRIVE_NETLOC_RE = re.compile(r"[A-Za-z]:")
+
+#: Keys the two formats share, copied when present and non-empty. Absent differs
+#: from empty to KAS, so a falsy value is omitted rather than sent.
+# Keys forwarded verbatim, because KAS reads them the same way kiro-cli does.
+#
+# ``resources`` is deliberately NOT here. KAS resolves those entries in its OWN
+# process, so Kiro Crew's sensitive-path gate never sees the reads: an agent config
+# carrying ``resources: ["file://~/.aws/credentials"]`` would put the file into
+# model context. It cannot be validated host-side without reimplementing KAS's
+# resolver — ``AgentResource`` is heterogeneous (a bare ``file://`` or ``skill://``
+# URI, OR a ``knowledgeBase`` object whose ``include`` carries GLOB patterns), and
+# its own schema states that scheme classification happens where the agent resolves
+# them. A validator covering only the bare-URI form would read as a gate while the
+# glob and knowledge-base paths walked straight through, which is worse than having
+# no gate. So the capability is withheld until resources resolve through the
+# sensitive-path check; a KAS agent silently losing its context files is a
+# recoverable gap, a leaked credential is not.
+_PASSTHROUGH_KEYS: tuple[str, ...] = ("description", "model", "mcpServers")
+
+
+def _file_uri_to_path(uri: str, base_dir: Path | None) -> str | None:
+    """Decompose a ``file:`` URI into one filesystem path, or None if unresolvable.
+
+    THE INVARIANT: every authority form is decided EXACTLY ONCE, here, from the
+    exhaustive table below — and anything that comes out relative resolves against
+    *base_dir*, never against the process working directory. Deciding forms at the
+    read site produced two defects in a row, the second caused by the first's fix:
+    teaching the UNC branch to keep its host made ``.`` look like a host, so
+    ``file://./p.md`` became ``//./p.md`` — the filesystem root on POSIX and the
+    ``\\\\.\\`` DEVICE namespace on Windows.
+
+    ``urlparse`` puts whatever follows ``//`` into ``netloc``, so the authority is
+    the only part that varies:
+
+    - ``""`` — no authority; ``path`` as written.
+    - ``localhost`` — RFC 8089 spells "this machine" either way; same as empty.
+    - drive-shaped (``C:``) — a Windows drive letter mis-parsed as a host; the
+      drive is put back onto the path.
+    - ``.`` / ``..`` — a relative prefix, NOT a host; kept as the leading path
+      segment so the join below applies.
+    - anything else — a real remote host (UNC); preserved as the leading ``//``,
+      because dropping it retargets the read at a same-named LOCAL path.
+
+    A relative result may escape *base_dir* (``file://../shared/p.md``): the agent
+    config is the operator's own file, and the boundary that matters is the
+    caller's ``safe_read_file_bytes``, which canonicalizes and re-checks the
+    resolved target. Resolving against the gateway's working directory is the part
+    that is never acceptable — it silently reads an unrelated file.
+    """
+    try:
+        parsed = urlparse(uri)
+    except ValueError:
+        # urlparse RAISES on a bracket it reads as a malformed IPv6 authority
+        # ("file://[bad/path" -> "Invalid IPv6 URL"). The URI comes from an agent
+        # config the operator hand-writes, so a typo must degrade to "no prompt"
+        # like every other unreadable reference — not abort session creation.
+        logger.warning("KAS agent: prompt URI %s is malformed", uri)
+        return None
+    netloc, path = parsed.netloc, parsed.path
+    if netloc in ("", "localhost"):
+        raw = path
+    elif _DRIVE_NETLOC_RE.fullmatch(netloc):
+        raw = f"/{netloc}{path}"
+    elif netloc in (".", ".."):
+        raw = f"{netloc}{path}"
+    else:
+        raw = f"//{netloc}{path}"
+
+    target = Path(url2pathname(raw))
+    if target.is_absolute():
+        return str(target)
+    if base_dir is None:
+        # Refuse rather than fall back to the CWD: the prompt is inlined into the
+        # agent's system prompt, so reading the wrong file feeds the model content
+        # the operator never pointed at.
+        logger.warning("KAS agent: relative prompt URI %s has no base directory", uri)
+        return None
+    return str(base_dir / target)
+
+
+def _read_file_uri(uri: str, base_dir: Path | None = None) -> str | None:
+    """Resolve a ``file://`` prompt reference to its text, or None on failure.
+
+    Read through ``hooks.safe_read_file_bytes``, NOT ``Path.read_text``: the URI
+    comes from an agent config, so a value like ``file:///home/u/.aws/credentials``
+    would otherwise put credential contents into the agent's system prompt and
+    straight into the model. It canonicalizes first, re-checks the resolved target
+    against ``is_sensitive_path`` (so a symlink into a blocked directory is refused
+    through the link), and opens with ``O_NOFOLLOW``.
+
+    URI shapes — the Windows spelling, UNC, and relative references — are decided
+    by :func:`_file_uri_to_path`, never here.
+    """
+    resolved_path = _file_uri_to_path(uri, base_dir)
+    if resolved_path is None:
+        return None
+    # Function-local: hooks pulls in the security/policy surface, and acp modules
+    # are imported eagerly from acp/__init__, so a module-scope import here risks
+    # the same cycle config.loader already documents.
+    from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes
+
+    try:
+        blob = safe_read_file_bytes(resolved_path)
+    except FileTooLargeError:
+        # Size-capped on purpose: a prompt is inlined into session/new, so an
+        # oversized file would be read whole into the gateway before the request
+        # was even built. Refusing beats an OOM that takes every session with it.
+        logger.warning("KAS agent: prompt too large at %s", uri)
+        return None
+    except (OSError, ValueError, PermissionError):
+        logger.warning("KAS agent: prompt unreadable or refused at %s", uri, exc_info=True)
+        return None
+    if blob is None:
+        logger.warning("KAS agent: prompt rejected or unreadable at %s", uri)
+        return None
+    try:
+        return blob.decode("utf-8")
+    except UnicodeDecodeError:
+        logger.warning("KAS agent: prompt is not UTF-8 at %s", uri)
+        return None
+
+
+def client_custom_agent(agent_id: str, config: dict[str, Any]) -> dict[str, Any]:
+    """Shape one agent config as a KAS ClientCustomAgent.
+
+    Two fields need real translation rather than a copy:
+
+    ``prompt``
+        Must be resolved content; KAS rejects a ``file://`` URI here.
+    ``tools``
+        ``"*"``-or-list in KAS, while kiro-cli splits the grant across ``tools``
+        and ``allowedTools``. Only ``tools`` maps — ``allowedTools`` is an
+        approval concern Kiro Crew's own PreToolUse gate owns, and forwarding it
+        as tool ACCESS would widen what the agent can actually reach.
+    """
+    out: dict[str, Any] = {"id": agent_id, "prompt": str(config.get("prompt") or "")}
+    tools = config.get("tools")
+    # An EMPTY list is forwarded, not omitted: it means "no tools" and omitting it
+    # would let KAS apply its own broader default access — turning a deliberately
+    # narrow grant into a wider one. Only a missing/None value means "unspecified".
+    if tools == "*" or isinstance(tools, list):
+        out["tools"] = tools
+    for key in _PASSTHROUGH_KEYS:
+        value = config.get(key)
+        if value:
+            out[key] = value
+    return out
+
+
+def _resolve_agent_config(name: str, cwd: str | Path | None) -> Path | None:
+    """Locate the config declaring *name*, using dispatch's own precedence.
+
+    THE INVARIANT this function exists to hold: agent resolution is delegated to
+    ``agent_discovery`` in full — never a path this module builds, never a
+    filename this module compares. Three separate defects came from breaking it in
+    three different ways (an unguarded open, a global-only lookup, and a stem
+    comparison), and each point-fix left the next one reachable.
+
+    Two consequences of the delegation:
+
+    * The DECLARED name wins over the filename. ``project_agent_name`` is what
+      kiro-cli itself lists and accepts for ``--agent``, so a renamed or
+      package-prefixed agent has a filename that matches nothing.
+    * Project-local wins over global, matching ``project_agent_files`` — which
+      documents ``<project>/.kiro/agents/*.json`` as the only project location
+      kiro-cli resolves ``--agent`` against.
+
+    Precision matters more than it looks: a missing config now REFUSES the session
+    rather than silently widening it, so a lookup that misses a legitimate agent
+    turns a working setup into a hard failure.
+    """
+    from kiro_crew.agent_discovery import project_agent_files, project_agent_name
+
+    if cwd:
+        for spec in project_agent_files(cwd):
+            if project_agent_name(spec) == name:
+                return spec
+    for spec in sorted(kiro_agents_dir().glob("*.json")):
+        if project_agent_name(spec) == name:
+            return spec
+    return None
+
+
+def load_client_custom_agent(
+    agent: str, cwd: str | Path | None = None
+) -> dict[str, Any] | None:
+    """Read *agent*'s config and shape it for KAS, or None when unusable.
+
+    Blocking (filesystem + JSON), so callers run it off the event loop.
+
+    Returning None is FAIL-CLOSED at the caller: ``create_session`` raises before
+    ``session/new`` rather than sending a request with no definition. Omitting it
+    would make KAS fall back to its own default mode, which carries BROADER tool
+    access than the configured agent — so "degrading politely" here would be a
+    silent privilege widening, not resilience.
+    """
+    name = (agent or "").strip()
+    if not name:
+        return None
+    path = _resolve_agent_config(name, cwd)
+    if path is None:
+        logger.warning("KAS agent: no config found for %r", name)
+        return None
+    # Read through hooks' hardened gate rather than opening the path here: the
+    # agents directory is user-writable and shared with other tools, so a config
+    # can be a symlink whose RESOLVED target is sensitive (`evil.json` ->
+    # `~/.aws/credentials`) or a file large enough to matter. This is the same
+    # reader agent_discovery._read_agent_spec uses for the identical reason; the
+    # resolve+sensitive check is repeated here because that function is private
+    # and has no cross-module callers to follow.
+    from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes
+    from kiro_crew.security import is_sensitive_path
+
+    try:
+        real = path.resolve(strict=True)
+    except (OSError, RuntimeError):
+        # OSError: broken link or permission. RuntimeError: pathlib's signal for a
+        # symlink LOOP, one `ln -s` away in a user-writable directory.
+        logger.warning("KAS agent: config for %r is not a readable path", name)
+        return None
+    if is_sensitive_path(str(real)):
+        logger.warning("KAS agent: config for %r resolves to a protected path", name)
+        return None
+    try:
+        blob = safe_read_file_bytes(str(real))
+    except FileTooLargeError:
+        logger.warning("KAS agent: config for %r is oversized", name)
+        return None
+    except (OSError, ValueError, PermissionError):
+        logger.warning("KAS agent: config unreadable for %r", name, exc_info=True)
+        return None
+    if blob is None:
+        logger.warning("KAS agent: config for %r rejected or unreadable", name)
+        return None
+    try:
+        raw = json.loads(blob.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError):
+        logger.warning("KAS agent: config for %r is not readable JSON", name)
+        return None
+    if not isinstance(raw, dict):
+        logger.warning("KAS agent: config for %r is not an object", name)
+        return None
+    prompt = raw.get("prompt")
+    if isinstance(prompt, str) and prompt.startswith(_FILE_URI_SCHEME):
+        # base_dir is the config's OWN directory, so a relative prompt reference
+        # tracks the config it is written in rather than the gateway's cwd.
+        resolved = _read_file_uri(prompt, real.parent)
+        if resolved is None:
+            return None
+        raw["prompt"] = resolved
+    if not str(raw.get("prompt") or "").strip():
+        logger.warning("KAS agent: config for %r carries no prompt", name)
+        return None
+    return client_custom_agent(name, raw)

--- a/src/kiro_crew/acp/kas_assets.py
+++ b/src/kiro_crew/acp/kas_assets.py
@@ -142,12 +142,28 @@ def resolve_kas_entry() -> tuple[Path, Path]:
     )
 
 
-def build_kas_argv(node: Path, server_script: Path) -> list[str]:
-    """argv for a KAS stdio session.
+#: Host-mediated auth. KAS asks this process for an access token over ACP
+#: (``_kiro/auth/getAccessToken``) instead of reading a token file, and
+#: ``acp.kas_auth`` answers by shelling out to kiro-cli.
+#:
+#: Pointing KAS at a file cannot work in general: credential resolution is
+#: stateful logic living in kiro-cli — a cross-process refresh lock, a priority
+#: order across cached identities, and OIDC refresh on expiry. A file read
+#: reproduces none of that, and the default cache location holds only one of those
+#: identities, so on a host signed in another way KAS's own file provider
+#: correctly finds nothing.
+#:
+#: ``KIRO_API_KEY`` still outranks this flag inside KAS, so an operator with an
+#: API key keeps that path and never reaches the callback.
+KAS_AUTH_ARG = "--auth=acp-callback"
 
-    ``--auth`` is deliberately absent: without it KAS selects its file auth
-    provider and reads/refreshes the token itself, so Kiro Crew never handles a
-    credential. Passing ``--auth=acp-callback`` would force this process to
-    implement ``_kiro/auth/getAccessToken`` instead.
-    """
-    return [str(node), *KAS_NODE_FLAGS, str(server_script), KAS_TRANSPORT_ARG]
+
+def build_kas_argv(node: Path, server_script: Path) -> list[str]:
+    """argv for a KAS stdio session."""
+    return [
+        str(node),
+        *KAS_NODE_FLAGS,
+        str(server_script),
+        KAS_TRANSPORT_ARG,
+        KAS_AUTH_ARG,
+    ]

--- a/src/kiro_crew/acp/kas_auth.py
+++ b/src/kiro_crew/acp/kas_auth.py
@@ -1,0 +1,169 @@
+"""Host side of KAS's ``_kiro/auth/getAccessToken`` callback.
+
+A KAS spawn cannot resolve Kiro credentials on its own, and pointing it at a token
+file does not work in general: credential resolution is stateful logic that lives
+in kiro-cli, not a file KAS could read. Its hidden ``chat _ get-kas-token``
+subcommand
+
+* takes a CROSS-PROCESS refresh lock, so concurrent hosts cannot race,
+* picks the highest-priority cached identity (External -> Builder -> Social),
+* refreshes it over OIDC when it has crossed expiry,
+* reports which auth method and sign-in provider produced it.
+
+None of that is reproducible by reading a path, and the default cache location
+holds only the Social variant — so on a host signed in any other way KAS's own
+``FileAuthProvider`` correctly finds nothing. The absent file is the right answer,
+not a misconfiguration.
+
+Kiro Crew therefore does what kiro-cli's own ACP host does: shell out for an
+ACCESS token each time KAS asks. The refresh token stays with kiro-cli and is
+never seen here, so this module moves a short-lived credential and stores none.
+
+Two forwarded fields are easy to drop and both change behaviour when missing:
+
+``authMethod``
+    Selects KAS's upstream ``TokenType`` header. Absent for Builder ID / IdC /
+    Social, where the subcommand deliberately sends nothing.
+``provider``
+    Lets KAS's governance service decide enterprise status. Without it KAS infers
+    from ``profileArn`` presence and misclassifies Builder ID and social sign-ins
+    as enterprise, which FAIL-CLOSES governance for them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Agent -> client extension method KAS calls. Must match the name KAS sends.
+GET_ACCESS_TOKEN_METHOD = "_kiro/auth/getAccessToken"
+
+#: Hidden kiro-cli subcommand that owns credential resolution and refresh.
+GET_KAS_TOKEN_ARGV: tuple[str, ...] = ("chat", "_", "get-kas-token")
+
+#: Envelope kind the subcommand emits on success.
+_OK_KIND = "getKasToken"
+
+#: One user-facing string for every failure path. A token failure has many causes,
+#: none of them actionable in a chat surface, and the detail can name paths and
+#: account identifiers. Diagnostics go to the log instead.
+AUTH_ERROR_USER_FACING = "Failed to verify authentication. Please log in again to continue."
+
+#: Matches kiro-cli's own budget for this subcommand. It can perform an OIDC round
+#: trip, so it is not instant, and KAS holds a turn open while it waits.
+GET_TOKEN_TIMEOUT_SECS = 30.0
+
+#: Forwarded verbatim when present, omitted when not: KAS distinguishes an absent
+#: key from an empty one for both of these.
+_OPTIONAL_FIELDS: tuple[str, ...] = ("authMethod", "provider")
+
+
+class KasTokenError(Exception):
+    """No access token could be obtained. Carries only the user-facing string."""
+
+
+def parse_last_json_line(stdout: str) -> dict[str, Any]:
+    """Return the LAST JSON object printed on stdout.
+
+    The subcommand may emit progress lines before its result, so the envelope is
+    the last parseable line rather than the whole stream. Mirrors kiro-cli's own
+    ``parseLastJsonLine`` so both hosts tolerate the same output shape.
+    """
+    for line in reversed([ln for ln in stdout.splitlines() if ln.strip()]):
+        try:
+            parsed = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    raise KasTokenError(AUTH_ERROR_USER_FACING)
+
+
+def response_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Convert the subcommand's envelope into KAS's GetAccessTokenResponse.
+
+    Validated here rather than forwarded partially: KAS rejects a response without
+    ``accessToken`` or with an unparseable ``expiresAt``, and its refusal surfaces
+    as an opaque protocol error far from this cause.
+    """
+    kind = envelope.get("kind")
+    if kind == "error":
+        logger.warning("KAS auth: error envelope from kiro-cli: %s", envelope.get("data"))
+        raise KasTokenError(AUTH_ERROR_USER_FACING)
+    if kind != _OK_KIND:
+        logger.error("KAS auth: unexpected envelope kind %r", kind)
+        raise KasTokenError(AUTH_ERROR_USER_FACING)
+
+    data = envelope.get("data")
+    if not isinstance(data, dict):
+        logger.error("KAS auth: envelope carried no data object")
+        raise KasTokenError(AUTH_ERROR_USER_FACING)
+
+    secret = data.get("accessToken")
+    expiry = data.get("expiresAt")
+    if not secret or not expiry:
+        # Nothing sensitive is interpolated: both arguments are bool() presence
+        # flags, never the values. Semgrep matches on the credential WORD in the
+        # message string rather than on the argument, so any phrasing that names
+        # what is missing trips it — and the presence pair IS the whole diagnosis
+        # a reader needs here. The marker must sit on the line IMMEDIATELY above
+        # the call; separating it from the call by explanation silently voids it.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
+        logger.error(
+            "KAS auth: payload incomplete (has_secret=%s, has_expiry=%s)",
+            bool(secret),
+            bool(expiry),
+        )
+        raise KasTokenError(AUTH_ERROR_USER_FACING)
+
+    response: dict[str, Any] = {
+        "accessToken": secret,
+        "expiresAt": expiry,
+        "profileArn": data.get("profileArn"),
+    }
+    for field in _OPTIONAL_FIELDS:
+        value = data.get(field)
+        if value:
+            response[field] = value
+    has_profile = bool(response["profileArn"])
+    # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
+    # Interpolates an expiry timestamp and a bool, never the token itself.
+    logger.debug("KAS auth: acquired (expiry=%s, has_profile=%s)", expiry, has_profile)
+    return response
+
+
+async def fetch_access_token(kiro_bin: str) -> dict[str, Any]:
+    """Ask kiro-cli for an access token and shape it for KAS.
+
+    Raises ``KasTokenError`` for every failure, so callers have one thing to catch.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            kiro_bin,
+            *GET_KAS_TOKEN_ARGV,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError:
+        logger.warning("KAS auth: could not spawn %s", kiro_bin, exc_info=True)
+        raise KasTokenError(AUTH_ERROR_USER_FACING) from None
+
+    try:
+        stdout, _ = await asyncio.wait_for(
+            proc.communicate(), timeout=GET_TOKEN_TIMEOUT_SECS
+        )
+    except asyncio.TimeoutError:
+        # Leaving the child running would hold the cross-process refresh lock and
+        # wedge every other host waiting on it.
+        proc.kill()
+        await proc.wait()
+        logger.warning("KAS auth: token subcommand timed out")
+        raise KasTokenError(AUTH_ERROR_USER_FACING) from None
+
+    return response_from_envelope(
+        parse_last_json_line(stdout.decode("utf-8", errors="replace"))
+    )

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any, Callable, TypeVar
 
 from kiro_crew import platform_compat
+from kiro_crew.acp import kas_auth
 from kiro_crew.acp._dispatch import (
     build_session_new_params,
     parse_session_modes,
@@ -40,6 +41,7 @@ from kiro_crew.acp.client import (
     _KiroExecutableTrustError,
     _resolve_kiro_bin_for_spawn,
 )
+from kiro_crew.acp.kas_agent import load_client_custom_agent
 from kiro_crew.acp.kas_assets import (
     KasAssetsMissing,
     build_kas_argv,
@@ -54,6 +56,8 @@ from kiro_crew.acp.session_handle import (
 from kiro_crew.acp.types import (
     ACP_BACKEND_KAS,
     ACP_BACKEND_KIRO,
+    ACP_BACKENDS_CLIENT_DEFINED_AGENT,
+    ACP_BACKENDS_HOST_MEDIATED_AUTH,
     ACP_BACKENDS_INTERNAL_SANDBOX,
     ACP_CLIENT_CAPABILITIES,
     KAS_CLIENT_CAPABILITIES,
@@ -92,6 +96,12 @@ from kiro_crew.session_pid import (
 from kiro_crew.validation import MODEL_ID_RE
 
 logger = logging.getLogger(__name__)
+
+#: Reply code when Kiro Crew implements a method but cannot fulfil it this time (a
+#: failed token acquisition). Deliberately not -32601: method-not-found would tell
+#: the agent the capability is absent and stop it asking again, turning a transient
+#: credential problem into a permanently unauthenticated session.
+_JSONRPC_INTERNAL_ERROR = -32603
 
 __all__ = [
     "AcpRuntime",
@@ -515,6 +525,13 @@ class AcpRuntime:
             self._work_dir = config_dir() / "workspace"
         self._agent = agent
         self._acp_backend = acp_backend
+        # Capability membership resolved ONCE here, so the shared reader and
+        # create-session paths read a boolean instead of naming a harness. A
+        # backend that never joins the set has no code path that can reach the
+        # behaviour, which is a stronger guarantee than a comparison evaluated
+        # per frame — and it keeps harness support additive (harness-parity H13).
+        self._answers_auth_callback = acp_backend in ACP_BACKENDS_HOST_MEDIATED_AUTH
+        self._defines_agent_client_side = acp_backend in ACP_BACKENDS_CLIENT_DEFINED_AGENT
         if model is not None:
             if not MODEL_ID_RE.match(model):
                 raise ValueError(
@@ -558,6 +575,10 @@ class AcpRuntime:
 
         # Demux routing
         self._pending_requests: dict[int, asyncio.Future[dict[str, Any]]] = {}
+        # Strong refs for the fire-and-forget KAS auth-callback tasks. Without
+        # them a task can be garbage-collected mid-flight, and an unretrieved
+        # exception on one makes crash_guard log a spurious ASYNCIO UNHANDLED.
+        self._kas_auth_tasks: set[asyncio.Task[None]] = set()
         # Maps req_id → sessionId for responses that should be routed to a session queue
         # (e.g. session/prompt response signals turn completion and must reach the session)
         self._routed_requests: dict[int, str] = {}
@@ -1231,6 +1252,34 @@ class AcpRuntime:
 
                 # Route notifications by sessionId
                 session_id = (msg.params or {}).get("sessionId")
+
+                # KAS's auth callback carries NO sessionId and arrives DURING
+                # session/new — before any session queue exists to route it to. It
+                # must be answered on this loop: the session-handle reader that
+                # serves other inbound requests only starts once create_session
+                # returns, so deferring would deadlock (KAS waits for a token,
+                # create_session waits for the sessionId).
+                # Gated on a CAPABILITY, not a harness comparison: membership in
+                # ACP_BACKENDS_HOST_MEDIATED_AUTH decides who may receive a live
+                # access token, so a backend outside the set falls through to the
+                # unknown-method refusal below. Any ACP child can emit this
+                # request; answering it for one that was never supposed to hold a
+                # token is the failure this gate exists to prevent.
+                if (
+                    self._answers_auth_callback
+                    and msg.is_method(kas_auth.GET_ACCESS_TOKEN_METHOD)
+                    and msg.id is not None
+                ):
+                    # Not awaited inline: the subcommand can take an OIDC round
+                    # trip, and blocking this loop would stall every other
+                    # session's frames behind it. RETAINED in a set — an
+                    # unreferenced task whose exception is never retrieved makes
+                    # crash_guard write a spurious ASYNCIO UNHANDLED record.
+                    task = asyncio.create_task(self._answer_kas_access_token(msg))
+                    self._kas_auth_tasks.add(task)
+                    task.add_done_callback(self._kas_auth_tasks.discard)
+                    continue
+
                 if session_id:
                     # A frame tagged with a sessionId belongs to exactly one
                     # session. Route to it if registered; otherwise DROP it.
@@ -1544,9 +1593,33 @@ class AcpRuntime:
             mcp_servers = await asyncio.to_thread(
                 pooled_session_servers, self._mcp_gateway_overlay, agent or self._agent
             )
+        # A backend with no --agent flag carries the agent's DEFINITION here
+        # instead. Capability membership, not a harness test, so the shared path
+        # asks "does this backend define its agent client-side" rather than naming
+        # one. Read off the loop (filesystem + JSON) alongside the overlay above.
+        kas_agent: dict[str, Any] | None = None
+        if self._defines_agent_client_side:
+            kas_agent = await asyncio.to_thread(
+                load_client_custom_agent,
+                agent or self._agent,
+                cwd if cwd else self._work_dir,
+            )
+            if kas_agent is None:
+                # Refuse rather than continue. Sending session/new without the
+                # definition does NOT degrade politely: KAS falls back to its own
+                # default mode, which carries BROADER tool access than the agent
+                # the operator configured — a silent privilege widening dressed as
+                # resilience. Failing here names the cause instead.
+                raise AcpRuntimeError(
+                    f"KAS backend: agent {agent or self._agent!r} could not be "
+                    f"loaded, so its tools and prompt cannot be sent. Refusing to "
+                    f"start a session on the agent server's default mode. Run "
+                    f"`kirocrew setup --agent-only` to materialize the config."
+                )
         params = build_session_new_params(
             cwd if cwd else self._work_dir,
             mcp_servers=mcp_servers,
+            kas_agent=kas_agent,
         )
 
         self._session_inits_in_flight += 1
@@ -1760,6 +1833,66 @@ class AcpRuntime:
         return handle
 
     # ── Internal Helpers ──
+
+    async def _reply_kas_auth(
+        self, request_id: str | int, *, result: dict[str, Any] | None, message: str = ""
+    ) -> None:
+        """Answer the auth callback, tolerating a runtime that died meanwhile.
+
+        The token fetch can take up to 30s, so the process may be gone by the time
+        there is something to send. ``send_response``/``send_error`` raise
+        ``AcpRuntimeDead`` then, and this runs in a fire-and-forget task — an
+        exception escaping it would make ``crash_guard`` record a spurious
+        ASYNCIO UNHANDLED entry, the same false-crash noise other spawn paths
+        already guard against. A dead runtime needs no reply: KAS died with it.
+        """
+        try:
+            if result is not None:
+                await self.send_response(request_id, result)
+            else:
+                await self.send_error(request_id, _JSONRPC_INTERNAL_ERROR, message)
+        except (AcpRuntimeDead, BrokenPipeError, ConnectionResetError) as exc:
+            logger.debug("KAS auth: runtime gone before the reply landed (%s)", exc)
+
+    async def _answer_kas_access_token(self, msg: JsonRpcMessage) -> None:
+        """Serve KAS's ``_kiro/auth/getAccessToken`` by asking kiro-cli.
+
+        KAS blocks on this request, so it always gets an answer: a token, or a
+        JSON-RPC error carrying one user-facing sentence. ``-32603`` rather than
+        ``-32601`` — method-not-found would tell KAS the capability is absent and
+        stop it asking again, turning a transient credential problem into a
+        permanently unauthenticated session.
+
+        Kiro Crew stays a pipe: kiro-cli owns the refresh token and the
+        cross-process refresh lock, and only short-lived access tokens pass here.
+        """
+        if msg.id is None:
+            return
+        try:
+            kiro_bin = await _resolve_kiro_bin_for_spawn()
+        except _KiroExecutableTrustError as exc:
+            logger.error("KAS auth: kiro-cli is untrusted: %s", exc)
+            kiro_bin = ""
+        if not kiro_bin:
+            # A KAS session does not otherwise need kiro-cli at prompt time, so
+            # this is reachable on a host with the extracted server but no CLI.
+            logger.error("KAS auth: kiro-cli unavailable for token acquisition")
+            await self._reply_kas_auth(
+                msg.id, result=None, message=kas_auth.AUTH_ERROR_USER_FACING
+            )
+            return
+        try:
+            result = await kas_auth.fetch_access_token(kiro_bin)
+        except kas_auth.KasTokenError as exc:
+            await self._reply_kas_auth(msg.id, result=None, message=str(exc))
+            return
+        except Exception:
+            logger.warning("KAS auth: token acquisition failed", exc_info=True)
+            await self._reply_kas_auth(
+                msg.id, result=None, message=kas_auth.AUTH_ERROR_USER_FACING
+            )
+            return
+        await self._reply_kas_auth(msg.id, result=result)
 
     async def _send_and_await(
         self, method: str, params: dict[str, Any], timeout: float = _REQUEST_TIMEOUT

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -101,6 +101,7 @@ from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
 
+
 # ── Constants ──
 
 

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -7,6 +7,8 @@ import re as _re
 from dataclasses import dataclass, field
 from typing import Any
 
+from kiro_crew.constants import env_flag_enabled
+
 # ── ACP Event Kinds ──
 
 EVENT_TEXT_CHUNK = "text_chunk"
@@ -110,13 +112,45 @@ ACP_BACKENDS_KNOWN = frozenset(
     }
 )
 # What an operator may actually persist in ``agent.acp_backend``, which is a
-# narrower question than what the code understands. KAS is plumbed and tested but
-# cannot serve a session yet: production names an agent on every session, KAS
-# advertises only its own built-in modes, and Crew's agent reaches it through
-# ``_meta.kiro.customAgents`` on ``session/new`` — not wired up yet. Config
-# resolution degrades an unselectable value to the default so the refusal lands
-# at startup with a reason instead of on the operator's first message.
+# narrower question than what the code understands: the claude backend is a
+# dormant seam with no public registration glue, so it stays out, and KAS is
+# still under test.
+#
+# KAS's remaining gap is no longer the agent wiring — Crew now names AND defines
+# the configured agent on ``session/new`` (``acp.kas_agent``) — nor credentials,
+# which the host mediates over the ``_kiro/auth/getAccessToken`` callback rather
+# than requiring a token in KAS's own cache location (``acp.kas_auth``). What
+# keeps it out of this set is exposure alone: the backend has not been exercised
+# widely enough to offer to every install, so it stays behind
+# :data:`ENV_KAS_PREVIEW`.
+# Config resolution degrades an unselectable value to the default so the refusal
+# lands at startup with a reason instead of on the operator's first message.
 ACP_BACKENDS_SELECTABLE = frozenset({ACP_BACKEND_KIRO})
+
+#: Opt-in that adds KAS to the selectable set for a single process, so the
+#: backend can be exercised end to end while it stays hidden from ordinary
+#: installs. Read at call time, never persisted — there is deliberately no config
+#: key, because a config key IS the exposure this gate exists to avoid.
+ENV_KAS_PREVIEW = "KIROCREW_KAS_PREVIEW"
+
+
+def selectable_backends() -> frozenset[str]:
+    """Backends an operator may select in this process.
+
+    A function rather than a constant because the preview gate is an environment
+    variable: a module-level snapshot would bake in whatever was set at import
+    time, which for a long-lived gateway is the wrong answer and for tests is an
+    ordering dependency.
+
+    Gated on the shared ``env_flag_enabled`` predicate, never on "the variable is
+    non-empty": an operator who writes ``KIROCREW_KAS_PREVIEW=0`` is turning the
+    preview OFF, and admitting that value would launch an under-test backend — and
+    hand it an access token — with no positive opt-in.
+    """
+    if env_flag_enabled(ENV_KAS_PREVIEW):
+        return ACP_BACKENDS_SELECTABLE | {ACP_BACKEND_KAS}
+    return ACP_BACKENDS_SELECTABLE
+
 
 # ── Capability membership (harness-parity H6, H7) ──
 # Every capability a backend may claim is an OPT-IN set here, never a negation at
@@ -142,6 +176,19 @@ ACP_BACKENDS_STEER = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
 # that never starts and leaves the agent process unconfined. Only kiro-cli
 # qualifies; a Node or Python harness does not, however it is spawned.
 ACP_BACKENDS_INTERNAL_SANDBOX = frozenset({ACP_BACKEND_KIRO})
+
+# Backends that obtain credentials by calling BACK into the host
+# (``_kiro/auth/getAccessToken``) instead of resolving their own. The answer is a
+# live access token, so this membership is what decides who may receive one — a
+# harness outside the set has its request treated as an unknown method. kiro-cli
+# resolves its own credentials and is not a member.
+ACP_BACKENDS_HOST_MEDIATED_AUTH = frozenset({ACP_BACKEND_KAS})
+
+# Backends with no ``--agent`` flag, which therefore need the agent DEFINITION
+# carried in ``session/new``. kiro-cli takes ``--agent`` and materializes the
+# agent pre-spawn, so it is not a member.
+ACP_BACKENDS_CLIENT_DEFINED_AGENT = frozenset({ACP_BACKEND_KAS})
+
 
 # ── Provider labels ──
 # The backend identity key persisted in the session map. It indexes three

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1169,8 +1169,15 @@ class AgentConfig:
         metadata=_meta(
             "ACP Backend",
             "Which ACP agent to drive. Only '' (kiro-cli) is selectable; the "
-            "'kas' plumbing is present but not yet usable.",
-            enum=[""],
+            "'kas' backend is wired but still under test.",
+            # This enum is the JSON-Schema domain, and validate_config_data
+            # REMOVES a value outside it before the loader ever sees the key. So
+            # 'kas' has to be listed or the preview opt-in could never take
+            # effect — the value would be stripped, not degraded. Selectability is
+            # enforced separately by acp.types.selectable_backends(), which is
+            # what actually keeps KAS off ordinary installs. No settings surface
+            # reads this field, so listing it here exposes nothing in the UI.
+            enum=["", "kas"],
         ),
     )
     default_agent: str = field(
@@ -3751,10 +3758,15 @@ def _normalize_acp_backend(value: object) -> str:
     from kiro_crew.acp.types import (
         ACP_BACKEND_KIRO,
         ACP_BACKENDS_KNOWN,
-        ACP_BACKENDS_SELECTABLE,
+        selectable_backends,
     )
 
-    if isinstance(value, str) and value in ACP_BACKENDS_SELECTABLE:
+    # Resolved per call, not from a module constant: the preview gate is an env
+    # var, so a snapshot taken at import time would be stale for a gateway and
+    # order-dependent for tests.
+    selectable = selectable_backends()
+
+    if isinstance(value, str) and value in selectable:
         return value
     if value not in (None, ""):
         known_but_unusable = isinstance(value, str) and value in ACP_BACKENDS_KNOWN
@@ -3763,7 +3775,7 @@ def _normalize_acp_backend(value: object) -> str:
             "Selectable values: %s",
             value,
             "not usable yet" if known_but_unusable else "unknown",
-            ", ".join(repr(b) for b in sorted(ACP_BACKENDS_SELECTABLE)),
+            ", ".join(repr(b) for b in sorted(selectable)),
         )
     return ACP_BACKEND_KIRO
 

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -47,16 +47,23 @@ provider.
 
 | Value | Agent | Status |
 |-------|-------|--------|
-| `""` (default) | kiro-cli | the only supported value |
-| `kas` | kiro-agent (KAS) | plumbed, **not yet usable** |
+| `""` (default) | kiro-cli | the only selectable value |
+| `kas` | kiro-agent (KAS) | wired, **still under test** |
 
-**Leave this unset.** The KAS backend's spawn and session plumbing is in place,
-but Kiro Crew does not yet send your configured agent to KAS, so every session
-would fail to activate it. Setting `kas` is refused at startup with that reason
-rather than failing on your first message.
+**Leave this unset.** The KAS backend is now complete enough to run a session —
+your configured agent is sent to KAS on each new session (KAS has no equivalent of
+kiro-cli's `--agent` flag), and Kiro Crew answers KAS's token callback by asking
+kiro-cli, so any Kiro sign-in kiro-cli itself can use works here too. What keeps
+it unlisted is that it has not been exercised widely enough to offer, and it
+depends on kiro-cli for credentials as well as for the agent server. Setting `kas`
+degrades to the default with that reason in the log rather than failing on your
+first message.
 
-An unrecognized value logs a warning and falls back to the default backend, so a
-typo costs you a line in the log rather than a gateway that will not start.
+To exercise it deliberately, set `KIROCREW_KAS_PREVIEW=1` for that process — a
+per-process opt-in, never persisted, so nothing changes for an ordinary install.
+
+An unrecognized value degrades the same way, so a typo costs you a line in the
+log rather than a gateway that will not start.
 
 ## Key Settings
 

--- a/test/test_acp_backend_kas.py
+++ b/test/test_acp_backend_kas.py
@@ -215,14 +215,42 @@ class TestConfigRoundTrip:
     def test_kas_is_not_selectable_yet(self, tmp_path):
         """Degraded at the boundary, so the refusal is a log line at startup.
 
-        KAS cannot serve a session until Crew sends the configured agent over
-        ``session/new``; letting the value through would instead fail on the
-        operator's first message.
+        The agent wiring KAS was waiting on now exists (``acp.kas_agent`` sends
+        the configured agent on ``session/new``), but the backend stays hidden
+        while it is under test — it needs kiro-cli for credentials as well as for
+        the server. ``KIROCREW_KAS_PREVIEW`` opts a single process in.
         """
         cfg = _load_agent_config({"acp_backend": ACP_BACKEND_KAS}, tmp_path)
         assert cfg.agent.acp_backend == ACP_BACKEND_KIRO
         provider = cfg.create_provider_factory()(session_key="test:rt", agent="")
         assert provider.is_kiro_backend is True
+
+    def test_preview_env_makes_kas_selectable(self, tmp_path, monkeypatch):
+        """The gate must reach config resolution, not just the set.
+
+        Resolution calls ``selectable_backends()`` per invocation rather than
+        reading a module constant, so this also pins that the answer is not
+        cached at import time.
+        """
+        from kiro_crew.acp.types import ENV_KAS_PREVIEW
+
+        monkeypatch.setenv(ENV_KAS_PREVIEW, "1")
+
+        cfg = _load_agent_config({"acp_backend": ACP_BACKEND_KAS}, tmp_path)
+
+        assert cfg.agent.acp_backend == ACP_BACKEND_KAS
+        provider = cfg.create_provider_factory()(session_key="test:rt", agent="")
+        assert provider.is_kas_backend is True
+
+    def test_preview_env_does_not_admit_an_unknown_backend(self, tmp_path, monkeypatch):
+        """The gate opens KAS specifically, not validation in general."""
+        from kiro_crew.acp.types import ENV_KAS_PREVIEW
+
+        monkeypatch.setenv(ENV_KAS_PREVIEW, "1")
+
+        cfg = _load_agent_config({"acp_backend": "kass"}, tmp_path)
+
+        assert cfg.agent.acp_backend == ACP_BACKEND_KIRO
 
     @pytest.mark.parametrize("bad", ["kiro-cli", "KAS", "claude_code", 7, None, []])
     def test_unselectable_values_degrade_to_the_default(self, bad, tmp_path):

--- a/test/test_kas_agent_selection.py
+++ b/test/test_kas_agent_selection.py
@@ -1,0 +1,668 @@
+"""Tests for carrying a Kiro Crew agent onto a KAS session.
+
+KAS has no ``--agent`` flag, so the agent has to be named AND defined in
+``session/new``. The failure this guards is silent: KAS binds ``modeId`` only to
+an agent already in its registry and ignores an unresolvable name rather than
+rejecting it, so selecting without defining yields a completely successful
+``session/new`` that runs KAS's own default mode -- with none of the agent's
+prompt, tool grants or MCP servers in effect and every log line looking healthy.
+
+Measured against the real KAS that kiro-cli extracts: ``modeId`` alone came back
+with ``configOptions.currentValue == "vibe"``; sending the definition alongside it
+came back ``"kirocrew"``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.acp import kas_agent, kas_auth
+from kiro_crew.acp._dispatch import build_session_new_params
+
+
+class TestTokenEnvelopeParsing:
+    """The host mediates KAS's token, so every malformed reply must be caught here.
+
+    KAS rejects a response without ``accessToken`` or with an unparseable
+    ``expiresAt``, and its refusal surfaces as an opaque protocol error far from
+    the cause — so the shaping is validated on this side.
+    """
+
+    def test_last_json_object_wins_over_progress_lines(self) -> None:
+        """The subcommand may print progress before its result envelope."""
+        out = 'refreshing...\nnot json\n{"kind":"x","data":{"a":1}}\n'
+
+        assert kas_auth.parse_last_json_line(out) == {"kind": "x", "data": {"a": 1}}
+
+    def test_no_json_object_raises_the_user_facing_error(self) -> None:
+        for out in ("", "   \n", "plain text\n", "[1, 2]\n"):
+            with pytest.raises(kas_auth.KasTokenError):
+                kas_auth.parse_last_json_line(out)
+
+    def test_complete_envelope_is_shaped_for_kas(self) -> None:
+        """``provider`` must be forwarded: KAS otherwise infers enterprise status
+        from ``profileArn`` presence and fail-closes governance."""
+        resp = kas_auth.response_from_envelope(
+            {
+                "kind": kas_auth._OK_KIND,
+                "data": {
+                    "accessToken": "tok",
+                    "expiresAt": "2026-08-13T18:07:11Z",
+                    "profileArn": "arn:aws:x",
+                    "provider": "Internal",
+                },
+            }
+        )
+
+        assert resp["accessToken"] == "tok"
+        assert resp["expiresAt"] == "2026-08-13T18:07:11Z"
+        assert resp["profileArn"] == "arn:aws:x"
+        assert resp["provider"] == "Internal"
+        # Omitted-not-empty: Builder ID / IdC / Social send no authMethod at all.
+        assert "authMethod" not in resp
+
+    def test_incomplete_or_bad_envelopes_all_raise(self) -> None:
+        bad: list[dict[str, object]] = [
+            {"kind": "error", "data": "no credentials"},
+            {"kind": "surprise", "data": {}},
+            {"kind": kas_auth._OK_KIND, "data": "not-an-object"},
+            {"kind": kas_auth._OK_KIND, "data": {"expiresAt": "2026-01-01T00:00:00Z"}},
+            {"kind": kas_auth._OK_KIND, "data": {"accessToken": "tok"}},
+        ]
+        for envelope in bad:
+            with pytest.raises(kas_auth.KasTokenError):
+                kas_auth.response_from_envelope(envelope)
+
+
+class TestFetchAccessToken:
+    @pytest.mark.asyncio
+    async def test_unspawnable_binary_raises_token_error(self) -> None:
+        """Every failure mode raises KasTokenError so callers catch one thing."""
+        with pytest.raises(kas_auth.KasTokenError):
+            await kas_auth.fetch_access_token("/nonexistent/kiro-cli-binary")
+
+    @pytest.mark.asyncio
+    async def test_successful_run_returns_the_shaped_response(self, monkeypatch) -> None:
+        envelope = '{"kind":"getKasToken","data":{"accessToken":"tok","expiresAt":"2026-08-13T18:07:11Z"}}'
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return envelope.encode("utf-8"), b""
+
+        async def _exec(*_a, **_k):
+            return _Proc()
+
+        monkeypatch.setattr(kas_auth.asyncio, "create_subprocess_exec", _exec)
+
+        resp = await kas_auth.fetch_access_token("kiro-cli")
+
+        assert resp["accessToken"] == "tok"
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_the_child_before_raising(self, monkeypatch) -> None:
+        """A live child would hold the cross-process refresh lock and wedge every
+        other host waiting on it."""
+        killed: list[bool] = []
+
+        class _Hang:
+            async def communicate(self):
+                raise AssertionError("communicate should be cancelled by wait_for")
+
+            def kill(self):
+                killed.append(True)
+
+            async def wait(self):
+                return 0
+
+        async def _exec(*_a, **_k):
+            return _Hang()
+
+        async def _timeout(awaitable, *_a, **_k):
+            # Close the coroutine we are refusing to await, or Python reports it as
+            # a never-awaited coroutine and the warning outlives this test.
+            awaitable.close()
+            # kas_auth.asyncio.TimeoutError, NOT the builtin: they are the same
+            # class only from 3.11 on. On 3.10 asyncio.TimeoutError is
+            # concurrent.futures.TimeoutError, so raising the builtin escapes the
+            # source's ``except asyncio.TimeoutError`` and fails that shard alone.
+            raise kas_auth.asyncio.TimeoutError
+
+        monkeypatch.setattr(kas_auth.asyncio, "create_subprocess_exec", _exec)
+        monkeypatch.setattr(kas_auth.asyncio, "wait_for", _timeout)
+
+        with pytest.raises(kas_auth.KasTokenError):
+            await kas_auth.fetch_access_token("kiro-cli")
+
+        assert killed == [True], "the timed-out child must be killed"
+
+
+class TestTokenCallbackIsBackendGated:
+    """Only a KAS runtime may answer the credential callback.
+
+    The method name alone is not authorization: any ACP child can emit it, and
+    answering would hand a live access token to a process that was never meant to
+    have one. The classifier deliberately has NO case for it, so on a non-KAS
+    transport it falls through to the unknown-request path and is refused there.
+    """
+
+    def test_classifier_has_no_case_for_the_auth_method(self) -> None:
+        from kiro_crew.acp import kas_auth
+        from kiro_crew.acp._dispatch import classify_notification
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        msg = JsonRpcMessage(
+            method=kas_auth.GET_ACCESS_TOKEN_METHOD, params={}, id="req-1", result=None
+        )
+
+        # Unknown => answered with -32601 by the dispatch sites, never served.
+        assert classify_notification(msg) == "server_request_unknown"
+
+    def test_capability_membership_decides_who_may_be_answered(self) -> None:
+        """kiro-cli must NOT be a member: it resolves its own credentials.
+
+        Membership is the authorization. A backend outside the set has no code
+        path that reaches the handler, which is stronger than a comparison
+        evaluated per frame — and it keeps the shared runtime harness-agnostic
+        (harness-parity H13).
+        """
+        from kiro_crew.acp.types import (
+            ACP_BACKEND_KAS,
+            ACP_BACKEND_KIRO,
+            ACP_BACKENDS_HOST_MEDIATED_AUTH,
+        )
+
+        assert ACP_BACKEND_KAS in ACP_BACKENDS_HOST_MEDIATED_AUTH
+        assert ACP_BACKEND_KIRO not in ACP_BACKENDS_HOST_MEDIATED_AUTH
+
+    def test_reader_loop_gates_on_the_capability_not_a_harness_name(self) -> None:
+        """The shared loop reads a capability flag, never a backend comparison.
+
+        Pinned on the source because the security property and the parity rule
+        pull the same way here: an inline ``== ACP_BACKEND_KAS`` would both name a
+        harness on the shared Kiro path and re-derive authorization at the call
+        site instead of reading the one set that owns it.
+        """
+        import inspect
+
+        from kiro_crew.acp import runtime
+
+        src = inspect.getsource(runtime.AcpRuntime._reader_loop)
+        idx = src.find("GET_ACCESS_TOKEN_METHOD")
+        assert idx > 0, "the auth-callback branch moved; re-point this guard"
+        window = src[max(0, idx - 400) : idx]
+        assert "_answers_auth_callback" in window, "callback branch is not gated"
+        assert "ACP_BACKEND_KAS" not in window, "shared loop must not name a harness"
+
+    def test_the_flags_are_resolved_from_the_named_sets(self) -> None:
+        """A flag hand-set to True would bypass the set that owns the decision."""
+        import inspect
+
+        from kiro_crew.acp import runtime
+
+        src = inspect.getsource(runtime.AcpRuntime.__init__)
+        assert "ACP_BACKENDS_HOST_MEDIATED_AUTH" in src
+        assert "ACP_BACKENDS_CLIENT_DEFINED_AGENT" in src
+
+
+class TestUnresolvableAgentRefusesTheSession:
+    """An unresolvable agent must RAISE, never fall through to session/new.
+
+    Sending session/new without the definition does not degrade politely: KAS
+    binds no mode and runs its own default, which carries BROADER tool access than
+    the configured agent. The raise is the only thing standing between a config
+    typo and a silent privilege widening, so it is pinned rather than left to the
+    reader loop's error path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_session_raises_when_the_agent_cannot_be_resolved(
+        self, monkeypatch
+    ) -> None:
+        from kiro_crew.acp import runtime as runtime_mod
+        from kiro_crew.acp.runtime import AcpRuntime, AcpRuntimeError
+        from kiro_crew.acp.types import ACP_BACKEND_KAS
+
+        rt = AcpRuntime(work_dir="/tmp", acp_backend=ACP_BACKEND_KAS)
+        rt._initialized = True
+        rt._process = object()  # only truthiness is checked before the refusal
+        assert rt._defines_agent_client_side, "precondition: KAS defines its agent"
+
+        # The definition cannot be loaded — the case a config typo produces.
+        monkeypatch.setattr(runtime_mod, "load_client_custom_agent", lambda *a, **k: None)
+        sent: list[str] = []
+
+        async def _record(method, params, timeout=None):
+            sent.append(method)
+            return {"sessionId": "sid"}
+
+        monkeypatch.setattr(rt, "_send_and_await", _record)
+
+        with pytest.raises(AcpRuntimeError):
+            await rt.create_session(cwd="/w", agent="missing-agent")
+
+        assert sent == [], "session/new must NOT be sent without the definition"
+
+
+class TestBackendStaysHiddenWhileUnderTest:
+    """The wiring lands; the exposure does not.
+
+    Worth pinning separately because the two are independent: with the agent
+    wiring in place it is tempting to widen the selectable set in the same change,
+    and that is the line between "ready to test" and "shipped".
+    """
+
+    def test_kas_is_not_offered_by_default(self) -> None:
+        from kiro_crew.acp.types import ACP_BACKEND_KAS, selectable_backends
+
+        assert ACP_BACKEND_KAS not in selectable_backends()
+
+    def test_only_a_truthy_optin_opens_the_gate(self, monkeypatch) -> None:
+        """A falsy value is an operator turning the preview OFF, not setting it.
+
+        Gating on "the variable is non-empty" admits ``=0`` and ``=false``, which
+        would launch an under-test backend — and hand it an access token — for
+        someone who explicitly disabled it. Routed through the shared
+        ``env_flag_enabled`` predicate rather than a hand-rolled check so this
+        agrees with every other flag in the codebase.
+        """
+        from kiro_crew.acp.types import ACP_BACKEND_KAS, ENV_KAS_PREVIEW, selectable_backends
+
+        for off in ("0", "false", "False", "no", "off", "", "  "):
+            monkeypatch.setenv(ENV_KAS_PREVIEW, off)
+            assert ACP_BACKEND_KAS not in selectable_backends(), off
+        for on in ("1", "true", "TRUE", "yes", "on", " 1 "):
+            monkeypatch.setenv(ENV_KAS_PREVIEW, on)
+            assert ACP_BACKEND_KAS in selectable_backends(), on
+
+    def test_kas_is_listed_in_the_schema_domain(self) -> None:
+        """The enum is the JSON-Schema domain, NOT the exposure surface.
+
+        ``validate_config_data`` REMOVES a value outside this enum before the
+        loader sees the key, so listing 'kas' is what lets the preview opt-in take
+        effect at all — without it the value is stripped, not degraded, and the
+        degrade log never even fires. Exposure is controlled by
+        ``selectable_backends()`` above, and no settings surface reads this field.
+        """
+        from kiro_crew.config.loader import AgentConfig
+
+        meta = AgentConfig.__dataclass_fields__["acp_backend"].metadata
+        assert "kas" in (meta.get("enum") or [])
+
+    def test_no_settings_surface_reads_the_field(self) -> None:
+        """Pins the reason listing 'kas' in the enum exposes nothing.
+
+        If a frontend panel ever starts rendering this field, the enum stops being
+        purely a schema domain and this test is the reminder to gate it there too.
+        """
+        import subprocess
+
+        repo = Path(__file__).resolve().parents[1]
+        hits = subprocess.run(
+            ["grep", "-rl", "acp_backend", str(repo / "website" / "src")],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert hits.stdout.strip() == "", f"frontend now reads acp_backend: {hits.stdout}"
+
+    def test_preview_env_opens_the_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from kiro_crew.acp.types import ACP_BACKEND_KAS, ENV_KAS_PREVIEW, selectable_backends
+
+        monkeypatch.setenv(ENV_KAS_PREVIEW, "1")
+
+        assert ACP_BACKEND_KAS in selectable_backends()
+
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_blank_preview_value_does_not_open_the_set(
+        self, value: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An exported-but-empty variable is the shell's idea of unset."""
+        from kiro_crew.acp.types import ACP_BACKEND_KAS, ENV_KAS_PREVIEW, selectable_backends
+
+        monkeypatch.setenv(ENV_KAS_PREVIEW, value)
+
+        assert ACP_BACKEND_KAS not in selectable_backends()
+
+    def test_claude_stays_unselectable_either_way(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The gate opens KAS specifically, not the dormant claude seam."""
+        from kiro_crew.acp.types import ACP_BACKEND_CLAUDE, ENV_KAS_PREVIEW, selectable_backends
+
+        monkeypatch.setenv(ENV_KAS_PREVIEW, "1")
+
+        assert ACP_BACKEND_CLAUDE not in selectable_backends()
+
+
+class TestAgentConfigResolution:
+    """Resolution follows dispatch's own precedence, not a filename guess.
+
+    Load matters more now that a missing config REFUSES the session: a lookup that
+    misses a legitimate project-local agent turns a working setup into a hard
+    failure rather than a silent widening.
+    """
+
+    def test_project_local_config_wins(self, tmp_path: Path, monkeypatch) -> None:
+        proj = tmp_path / "proj" / ".kiro" / "agents"
+        proj.mkdir(parents=True)
+        (proj / "a.json").write_text(json.dumps({"prompt": "from project"}))
+        globals_dir = tmp_path / "global"
+        globals_dir.mkdir()
+        (globals_dir / "a.json").write_text(json.dumps({"prompt": "from global"}))
+        monkeypatch.setattr(kas_agent, "kiro_agents_dir", lambda: globals_dir)
+
+        out = kas_agent.load_client_custom_agent("a", cwd=tmp_path / "proj")
+
+        assert out is not None
+        assert out["prompt"] == "from project"
+
+    def test_global_config_is_the_fallback(self, tmp_path: Path, monkeypatch) -> None:
+        globals_dir = tmp_path / "global"
+        globals_dir.mkdir()
+        (globals_dir / "a.json").write_text(json.dumps({"prompt": "from global"}))
+        monkeypatch.setattr(kas_agent, "kiro_agents_dir", lambda: globals_dir)
+
+        out = kas_agent.load_client_custom_agent("a", cwd=tmp_path / "empty")
+
+        assert out is not None
+        assert out["prompt"] == "from global"
+
+    def test_declared_name_wins_over_filename(self, tmp_path: Path, monkeypatch) -> None:
+        """kiro-cli dispatches on the spec's `name`, not its stem.
+
+        A renamed or package-prefixed agent has a filename matching nothing, so a
+        stem comparison accepts exactly the files whose author happened not to
+        rename them — and since resolution is fail-closed, the rest break outright.
+        """
+        globals_dir = tmp_path / "global"
+        globals_dir.mkdir()
+        (globals_dir / "some-file-name.json").write_text(
+            json.dumps({"name": "declared-agent", "prompt": "p"})
+        )
+        monkeypatch.setattr(kas_agent, "kiro_agents_dir", lambda: globals_dir)
+
+        assert kas_agent.load_client_custom_agent("declared-agent") is not None
+        # The stem must NOT resolve: it is not a dispatchable name.
+        assert kas_agent.load_client_custom_agent("some-file-name") is None
+
+    def test_absent_everywhere_returns_none(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(kas_agent, "kiro_agents_dir", lambda: tmp_path)
+
+        assert kas_agent.load_client_custom_agent("nope", cwd=tmp_path) is None
+
+
+class TestSessionNewParams:
+    def test_kas_agent_is_selected_and_defined_together(self) -> None:
+        """Both keys, one namespace: the definition registers, modeId selects."""
+        definition = {"id": "kirocrew", "prompt": "p"}
+
+        params = build_session_new_params("/w", mcp_servers=[], kas_agent=definition)
+
+        assert params["_meta"] == {
+            "kiro": {"modeId": "kirocrew", "customAgents": [definition]}
+        }
+
+    def test_mode_id_is_taken_from_the_definition_not_a_second_argument(self) -> None:
+        """One source for the name, so selection cannot disagree with definition."""
+        params = build_session_new_params(
+            "/w", mcp_servers=[], kas_agent={"id": "other", "prompt": "p"}
+        )
+
+        assert params["_meta"]["kiro"]["modeId"] == "other"
+
+    def test_absent_kas_agent_sends_no_meta(self) -> None:
+        """kiro-cli gets its agent from --agent; an empty _meta would be noise."""
+        params = build_session_new_params("/w", mcp_servers=[])
+
+        assert "_meta" not in params
+
+    def test_cwd_and_mcp_servers_are_still_always_present(self) -> None:
+        """kiro-cli treats a missing mcpServers as malformed and exits rc=0."""
+        params = build_session_new_params("/w", kas_agent={"id": "a", "prompt": "p"})
+
+        assert params["cwd"] == "/w"
+        assert params["mcpServers"] == []
+
+    def test_claude_meta_wins_over_kas_agent(self) -> None:
+        """The two backends are mutually exclusive; one _meta slot, no merging."""
+        params = build_session_new_params(
+            "/w", mcp_servers=[], claude_meta=True, kas_agent={"id": "a", "prompt": "p"}
+        )
+
+        assert params["_meta"] == {"claudeCode": {"options": {}}}
+
+
+class TestClientCustomAgent:
+    def test_id_and_prompt_are_the_required_core(self) -> None:
+        out = kas_agent.client_custom_agent("kirocrew", {"prompt": "be helpful"})
+
+        assert out == {"id": "kirocrew", "prompt": "be helpful"}
+
+    def test_star_tools_stay_the_wildcard(self) -> None:
+        """KAS accepts "*" or a list; the wildcard must not become ["*"]."""
+        out = kas_agent.client_custom_agent("a", {"prompt": "p", "tools": "*"})
+
+        assert out["tools"] == "*"
+
+    def test_tool_list_is_passed_through(self) -> None:
+        out = kas_agent.client_custom_agent("a", {"prompt": "p", "tools": ["fs_read"]})
+
+        assert out["tools"] == ["fs_read"]
+
+    def test_empty_tool_list_is_forwarded_not_omitted(self) -> None:
+        """An empty list means "no tools" — omitting it WIDENS the grant.
+
+        KAS applies its own broader default access when the key is absent, so
+        dropping a deliberately empty list turns a narrow grant into a wide one.
+        Only a missing value means "unspecified".
+        """
+        out = kas_agent.client_custom_agent("a", {"prompt": "p", "tools": []})
+
+        assert out["tools"] == []
+
+    def test_absent_tools_key_is_omitted(self) -> None:
+        out = kas_agent.client_custom_agent("a", {"prompt": "p"})
+
+        assert "tools" not in out
+
+    def test_allowed_tools_is_never_forwarded(self) -> None:
+        """allowedTools is an approval concern Kiro Crew's own gate owns.
+
+        Forwarding it as tool ACCESS would widen what the agent can reach beyond
+        what its `tools` grant says.
+        """
+        out = kas_agent.client_custom_agent(
+            "a", {"prompt": "p", "tools": ["fs_read"], "allowedTools": ["execute_bash"]}
+        )
+
+        assert out["tools"] == ["fs_read"]
+        assert "allowedTools" not in out
+
+    @pytest.mark.parametrize("key", ["description", "model", "mcpServers"])
+    def test_shared_keys_pass_through(self, key: str) -> None:
+        out = kas_agent.client_custom_agent("a", {"prompt": "p", key: {"x": 1}})
+
+        assert out[key] == {"x": 1}
+
+    def test_resources_are_never_forwarded(self) -> None:
+        """KAS resolves ``resources`` in its OWN process, past Crew's path gate.
+
+        Forwarding them lets an agent config carrying
+        ``resources: ["file://~/.aws/credentials"]`` pull the file into model
+        context. It cannot be validated here without reimplementing KAS's resolver
+        — an entry is either a bare ``file://``/``skill://`` URI or a
+        ``knowledgeBase`` object whose ``include`` holds GLOB patterns — and a
+        validator covering only the bare-URI form would read as a gate while the
+        glob form walked through.
+        """
+        out = kas_agent.client_custom_agent(
+            "a",
+            {
+                "prompt": "p",
+                "resources": [
+                    "file://~/.aws/credentials",
+                    {"type": "knowledgeBase", "source": "/etc", "include": ["**/*"]},
+                ],
+            },
+        )
+
+        assert "resources" not in out
+        assert "resources" not in kas_agent._PASSTHROUGH_KEYS
+
+    def test_falsy_optional_values_are_omitted(self) -> None:
+        """KAS reads its own defaults for an absent key, not for an empty one."""
+        out = kas_agent.client_custom_agent("a", {"prompt": "p", "model": ""})
+
+        assert set(out) == {"id", "prompt"}
+
+
+class TestLoadClientCustomAgent:
+    """Reading the config is best-effort: an unusable one degrades, never raises.
+
+    Raising would fail session/new outright and take down a surface over a
+    configuration problem the operator can fix without a restart.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _agents_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        d = tmp_path / "agents"
+        d.mkdir()
+        monkeypatch.setattr(kas_agent, "kiro_agents_dir", lambda: d)
+        return d
+
+    def test_reads_and_shapes_a_config(self, _agents_dir: Path) -> None:
+        (_agents_dir / "kirocrew.json").write_text(
+            json.dumps({"prompt": "hello", "tools": "*", "description": "d"})
+        )
+
+        out = kas_agent.load_client_custom_agent("kirocrew")
+
+        assert out == {"id": "kirocrew", "prompt": "hello", "tools": "*", "description": "d"}
+
+    def test_resolves_a_file_uri_prompt(self, _agents_dir: Path, tmp_path: Path) -> None:
+        """KAS rejects a file:// URI here and makes resolution the client's job."""
+        prompt_file = tmp_path / "p.md"
+        prompt_file.write_text("from a file")
+        (_agents_dir / "a.json").write_text(
+            json.dumps({"prompt": f"file://{prompt_file}"})
+        )
+
+        out = kas_agent.load_client_custom_agent("a")
+
+        assert out is not None
+        assert out["prompt"] == "from a file"
+
+    def test_a_sensitive_prompt_path_is_refused(self, _agents_dir: Path) -> None:
+        """A prompt URI is agent-config data, so it must not bypass path controls.
+
+        Without ``safe_read_file`` a config carrying
+        ``file:///home/u/.aws/credentials`` would put credential contents into the
+        agent's system prompt and straight into the model. Asserted through the
+        real gate rather than a mock, so a future refactor that drops it fails.
+        """
+        blocked = Path.home() / ".aws" / "credentials"
+        (_agents_dir / "a.json").write_text(json.dumps({"prompt": f"file://{blocked}"}))
+
+        assert kas_agent.load_client_custom_agent("a") is None
+
+    def test_unresolvable_file_uri_degrades(self, _agents_dir: Path) -> None:
+        (_agents_dir / "a.json").write_text(json.dumps({"prompt": "file:///nope/x.md"}))
+
+        assert kas_agent.load_client_custom_agent("a") is None
+
+    def test_every_authority_form_resolves(self, tmp_path: Path) -> None:
+        """One assertion per row of ``_file_uri_to_path``'s authority table.
+
+        Asserted against the real function rather than a reconstruction
+        expression: the earlier tests re-implemented the concatenation they were
+        checking, so they stayed green while the function mishandled ``.``.
+        Properties rather than exact strings, because ``url2pathname`` uses the
+        host separator and CI runs a Windows shard.
+        """
+        base = tmp_path / "cfgdir"
+        base.mkdir()
+        f = kas_agent._file_uri_to_path
+
+        # No authority, and the localhost spelling RFC 8089 treats as identical.
+        # Asserted on PARTS, not on a rebuilt string: on Windows url2pathname
+        # anchors a POSIX-style absolute path to the current DRIVE, so
+        # "file:///abs/p.md" yields "C:\\abs\\p.md" while str(Path("/abs/p.md"))
+        # yields "\\abs\\p.md". Comparing parts covers both hosts without this
+        # test re-implementing the transform it is checking.
+        for uri in ("file:///abs/p.md", "file://localhost/abs/p.md"):
+            got = Path(f(uri, base) or "")
+            assert got.is_absolute(), uri
+            assert got.parts[-2:] == ("abs", "p.md"), uri
+        # A Windows drive mis-parsed as a host: the drive must survive.
+        assert "C:" in (f("file://C:/proj/p.md", base) or "")
+        # A real remote host stays UNC instead of becoming the local /share/p.md.
+        unc = f("file://server/share/p.md", base) or ""
+        assert "server" in unc and unc.startswith(("//", "\\\\"))
+        # Relative forms resolve against the config's directory, never the cwd.
+        for uri in ("file://./p.md", "file:p.md"):
+            assert f(uri, base) == str(base / "p.md"), uri
+        assert Path(f("file://../p.md", base) or "").name == "p.md"
+
+    def test_malformed_uri_degrades_instead_of_raising(self, tmp_path: Path) -> None:
+        """``urlparse`` RAISES on a bracket it reads as a bad IPv6 authority.
+
+        The URI is hand-written in an agent config, so a typo must degrade to "no
+        prompt" like any other unreadable reference. An uncaught ValueError here
+        aborts session creation instead.
+        """
+        for bad in ("file://[bad/path", "file://a]b/p.md"):
+            assert kas_agent._file_uri_to_path(bad, tmp_path) is None, bad
+
+    def test_relative_uri_never_falls_back_to_the_cwd(self) -> None:
+        """With no base directory a relative reference is REFUSED, not guessed.
+
+        Resolving against the gateway's working directory would inline whatever
+        file happens to sit there into the agent's system prompt.
+        """
+        assert kas_agent._file_uri_to_path("file://./p.md", None) is None
+        assert kas_agent._file_uri_to_path("file:p.md", None) is None
+
+    def test_relative_prompt_resolves_beside_its_config(self, _agents_dir: Path) -> None:
+        """End to end: the prompt file sits next to the config that names it."""
+        (_agents_dir / "prompt.md").write_text("beside-config", encoding="utf-8")
+        (_agents_dir / "a.json").write_text(json.dumps({"prompt": "file://./prompt.md"}))
+
+        agent = kas_agent.load_client_custom_agent("a")
+
+        assert agent is not None
+        assert agent["prompt"] == "beside-config"
+
+    def test_posix_file_uri_is_read(self, tmp_path: Path) -> None:
+        target = tmp_path / "p.md"
+        target.write_text("posix-form", encoding="utf-8")
+
+        assert kas_agent._read_file_uri(f"file://{target}") == "posix-form"
+
+    def test_missing_config_degrades(self) -> None:
+        assert kas_agent.load_client_custom_agent("absent") is None
+
+    def test_malformed_json_degrades(self, _agents_dir: Path) -> None:
+        (_agents_dir / "a.json").write_text("{not json")
+
+        assert kas_agent.load_client_custom_agent("a") is None
+
+    def test_non_object_config_degrades(self, _agents_dir: Path) -> None:
+        (_agents_dir / "a.json").write_text("[1, 2]")
+
+        assert kas_agent.load_client_custom_agent("a") is None
+
+    @pytest.mark.parametrize("prompt", ["", "   ", None])
+    def test_promptless_config_degrades(self, _agents_dir: Path, prompt: object) -> None:
+        """KAS requires prompt; sending an empty one would define a mute agent."""
+        (_agents_dir / "a.json").write_text(json.dumps({"prompt": prompt, "tools": "*"}))
+
+        assert kas_agent.load_client_custom_agent("a") is None
+
+    @pytest.mark.parametrize("name", ["", "   "])
+    def test_blank_agent_name_needs_no_filesystem_hit(self, name: str) -> None:
+        assert kas_agent.load_client_custom_agent(name) is None

--- a/test/test_kas_spawn.py
+++ b/test/test_kas_spawn.py
@@ -121,19 +121,23 @@ class TestArgv:
     def test_shape(self, tmp_path):
         argv = build_kas_argv(tmp_path / "node", tmp_path / "acp-server.js")
         assert argv[0].endswith("node")
-        assert argv[-1] == KAS_TRANSPORT_ARG
+        assert KAS_TRANSPORT_ARG in argv
         for flag in KAS_NODE_FLAGS:
             assert flag in argv
 
-    def test_no_auth_flag_is_passed(self, tmp_path):
-        """Omitting --auth is what keeps token handling out of this codebase.
+    def test_auth_is_host_mediated(self, tmp_path):
+        """KAS must ask this host for a token rather than read a file.
 
-        With no --auth, KAS selects its file auth provider and reads/refreshes
-        the token itself. Passing --auth=acp-callback would instead force this
-        process to implement ``_kiro/auth/getAccessToken``.
+        A token file cannot work in general: credential resolution is stateful
+        logic in kiro-cli (cross-process refresh lock, priority order across
+        cached identities, OIDC refresh on expiry), and the default cache location
+        holds only one of those identities — so on a host signed in another way
+        KAS's file provider correctly finds nothing. ``acp.kas_auth`` answers the
+        callback by shelling out to kiro-cli, which keeps resolution in one place.
         """
         argv = build_kas_argv(tmp_path / "node", tmp_path / "acp-server.js")
-        assert not any(a.startswith("--auth") for a in argv)
+        assert "--auth=acp-callback" in argv
+        assert not any(a.startswith("--token-path") for a in argv)
 
     def test_no_agent_flag_is_passed(self, tmp_path):
         argv = build_kas_argv(tmp_path / "node", tmp_path / "acp-server.js")

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -137,6 +137,17 @@ PREEXEC_EXEMPT: frozenset[str] = frozenset(
 # category breakdown and follow-up hardening candidates.
 BENIGN_SPAWNS: frozenset[str] = frozenset(
     {
+        # Kiro credential acquisition for a KAS session. Nothing about this spawn
+        # is agent-influenced: the argv is the module constant
+        # ``("chat", "_", "get-kas-token")`` with no interpolation, no shell, no
+        # cwd, and the binary comes from ``_resolve_kiro_bin_for_spawn`` (the same
+        # trust-checked resolution the kiro-cli backend spawn uses) rather than
+        # bare PATH. Deliberately NOT routed through the sandbox chokepoint: the
+        # subcommand's whole job is to read the user's credential store and take a
+        # cross-process refresh lock, both of which the sandbox exists to hide —
+        # routing it would break auth rather than harden it, and the agent cannot
+        # reach the token because only the shaped response crosses back.
+        "acp/kas_auth.py::fetch_access_token",
         "acp/runtime.py::_get_rss_mb",
         # _get_rss_tree_mb is deliberately NOT listed: its own spawn moved into
         # _ps_process_table below, so an entry for it would be stale and would


### PR DESCRIPTION
## What

Wires the two pieces the KAS backend was missing, so a session on it runs the configured Kiro Crew agent and can complete a real turn.

**Still not offered to ordinary installs.** Selectability stays gated behind `KIROCREW_KAS_PREVIEW` while the backend is under test, and no frontend surface reads the field.

## Agent selection, and why omitting it fails silently

KAS has no `--agent` flag, so the agent is named AND defined in `session/new`'s `_meta.kiro`. Both are required:

| sent | `configOptions.currentValue` came back as |
|---|---|
| `modeId` alone | `vibe` — KAS's own default |
| `modeId` + `customAgents` | the requested agent |

KAS binds `modeId` only to an agent already in its registry and **ignores an unresolvable name rather than rejecting it**, so `session/new` succeeds either way. Without the definition the session runs KAS's default mode with none of the agent's prompt, tool grants or MCP servers in effect — and every log line looks healthy. Invisible to a source read and to any test asserting on the request rather than the response.

Nothing is migrated on disk: the config is translated on the way out, and client-provided agents outrank every file-based source in KAS's registry, so a stale file cannot shadow the live config. `prompt` is resolved client-side because KAS rejects a `file://` URI there. `allowedTools` is deliberately **not** forwarded — it is an approval concern this codebase's own PreToolUse gate owns, and sending it as tool ACCESS would widen what the agent can reach.

## Authentication, and why a token file cannot work

Credential resolution is stateful logic living in kiro-cli — a cross-process refresh lock, a priority order across cached identities, OIDC refresh on expiry — not a file KAS could read. The default cache location holds only one of those identities, so on a host signed in another way KAS's own file provider **correctly finds nothing**; the absent file is the right answer, not a misconfiguration.

KAS now launches with `--auth=acp-callback` and the host answers by shelling out to the same subcommand kiro-cli's own ACP host uses. Resolution stays in one place and only short-lived access tokens pass through; the refresh token never leaves kiro-cli.

Three details are load-bearing:

- **The callback is answered on the runtime's reader loop, not a session handle.** It carries no `sessionId` and arrives *during* `session/new`, before any session queue exists — deferring it deadlocks, KAS waiting for the token and `create_session` waiting for the id. That deadlock was a real 90s `session/new` timeout this change also fixes.
- **`provider` must be forwarded.** Without it KAS infers enterprise status from `profileArn` presence and fail-closes governance for Builder ID and social sign-ins. Observed on this host: `profileArn=True` while `provider=Internal`, so dropping it misclassifies the session.
- **The reply uses `-32603`, not `-32601`.** Method-not-found would tell KAS the capability is absent and stop it asking again, turning a transient credential problem into a permanently unauthenticated session.

`authMethod` is omitted rather than sent empty (KAS distinguishes absent from empty) and was observed absent here, matching kiro-cli's note that Builder ID / IdC / Social send nothing.

## The enum is a schema domain, not an exposure surface

Worth naming because it cost real time. `validate_config_data` **removes** a value outside the field's JSON-Schema enum before the loader sees the key — so with `kas` omitted there, the preview opt-in was unreachable: the value was *stripped*, not degraded, and the degrade log never even fired (it only logs a non-empty value).

So the enum lists `kas`, `selectable_backends()` decides selectability, and a test pins that no frontend reads the field — if one ever does, that test is the reminder to gate it there too.

## Verification

End to end on the real server kiro-cli extracts: `kirocrew chat` on the KAS backend returns the requested reply.

- 278 tests pass across the KAS + runtime files; five gates green (flake8, isort, mypy, docs-lint, brand)
- Full suite: same-file-set baseline **28 failed** vs this branch **28 failed** — no new regressions. Those are pre-existing environment-sensitive failures on this host (nested user namespaces denied, `AF_UNIX path too long`)
- The spawn audit is satisfied by registering the token subcommand as benign with its justification rather than routing it: the sandbox exists to hide exactly the credential store this subcommand must read, so routing it would break auth rather than harden it

## Not covered

Product-level E2E through the gateway could not be exercised on this host — nested user namespaces are denied, so no OS sandbox backend is available and every agent spawn is refused. Verified by control that this blocks the **default kiro-cli backend identically**, so it is an environment limit rather than anything this branch introduces.
