### PR TITLE
refactor: share one incognito-transcript classifier (#2464)

### DIFF
--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -61,7 +61,7 @@ from typing import TYPE_CHECKING, Any
 
 from kiro_crew.dashboard.channel_folders import lookup_channel_folder
 from kiro_crew.dashboard.state import _normalize_slot_key
-from kiro_crew.history import carry_provenance
+from kiro_crew.history import carry_provenance, is_incognito_transcript
 from kiro_crew.messaging.link import channel_namespace_of, is_channel_session_key
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -74,9 +74,6 @@ logger = logging.getLogger(__name__)
 #: bounds how stale the sidebar can be for a channel conversation started while
 #: the dashboard is already open, and each pass is a cheap metadata scan.
 RECONCILE_INTERVAL_SECS = 30
-
-#: Memory modes whose sessions must never be surfaced as a durable slot.
-_EPHEMERAL_MEMORY_MODES = frozenset({"incognito", "temporary"})
 
 #: Human-facing label per channel namespace, used only when a session has no
 #: title of its own yet (first turn still in flight).
@@ -204,11 +201,11 @@ def eligible_channel_sessions(
         # clears the stale flag — see reconcile_channel_slots).
         if _close_stands(s, meta, mtimes or {}):
             continue
-        modes = (
-            str(meta.get("memory_mode", "")).lower(),
-            str(s.get("memory_mode", "")).lower(),
-        )
-        if any(m in _EPHEMERAL_MEMORY_MODES for m in modes):
+        # An ephemeral (incognito/temporary) session must never be surfaced as
+        # a durable slot; either the metadata line or the listing row can carry
+        # the mode, so both are classified.
+        modes = (meta.get("memory_mode"), s.get("memory_mode"))
+        if any(is_incognito_transcript(m) for m in modes):
             continue
         exempt = bool(meta.get("pinned")) or bool(meta.get("folder_id"))
         if not exempt and cutoff is not None and float(s.get("modified", 0) or 0) < cutoff:

--- a/src/kiro_crew/dashboard/chat_folder_suggest.py
+++ b/src/kiro_crew/dashboard/chat_folder_suggest.py
@@ -31,7 +31,7 @@ from typing import Any
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot
 from kiro_crew.executors import subprocess_executor
-from kiro_crew.history import INCOGNITO_MEMORY_MODES
+from kiro_crew.history import is_incognito_transcript
 from kiro_crew.llm_helpers import run_bg_oneliner
 
 logger = logging.getLogger(__name__)
@@ -118,7 +118,7 @@ def _folder_sample_titles(state: DashboardState) -> dict[str, list[str]]:
         # A temporary session CAN be filed (api_chat_slot_folder does not gate on
         # memory_mode, and the folder id is persisted to its metadata line), so
         # the folder filter below is not enough on its own.
-        if str(session.get("memory_mode") or "persistent") in INCOGNITO_MEMORY_MODES:
+        if is_incognito_transcript(session.get("memory_mode")):
             continue
         fid = str(session.get("folder_id") or "")
         if not fid:
@@ -145,7 +145,7 @@ def _live_slot_titles(state: DashboardState, exclude_key: str) -> dict[str, list
             continue
         # Same privacy rule as the archived scan: a LIVE temporary/incognito slot
         # can be filed too, and its title must not reach the prompt either.
-        if slot.memory_mode in INCOGNITO_MEMORY_MODES:
+        if is_incognito_transcript(slot.memory_mode):
             continue
         title = " ".join(str(slot.title or "").split())[:_MAX_SAMPLE_CHARS]
         if not title:

--- a/src/kiro_crew/dashboard/chat_summary.py
+++ b/src/kiro_crew/dashboard/chat_summary.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 from kiro_crew.acp.types import STOP_REASON_END_TURN
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.dashboard.chat_utils import slot_history_key
+from kiro_crew.history import is_incognito_transcript
 from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.session_summary import (
     count_user_turns,
@@ -41,12 +42,6 @@ logger = logging.getLogger(__name__)
 # Role used to pick the model. Summarization is unattended background work, so
 # it must not ride the interactive chat flagship on every turn.
 _SUMMARY_ROLE = "background"
-
-# Memory modes that forbid deriving durable artifacts from the conversation.
-# Mirrors history.INCOGNITO_MEMORY_MODES: a temporary session's transcript is
-# discarded, so persisting a summary of it to the .intents sidecar would leave
-# conversation content on disk after the conversation itself is gone.
-_NO_DERIVED_ARTIFACT_MODES = frozenset({"incognito", "temporary"})
 
 _PROMPT = """\
 Summarize this chat session by INTENT, for a panel whose only job is to make \
@@ -153,7 +148,10 @@ def _should_summarize(cfg: KiroCrewConfig, slot: Any, user_turns: int | None) ->
         return "disabled"
     if getattr(slot, "_summary_in_flight", False):
         return "in_flight"
-    if getattr(slot, "memory_mode", "") in _NO_DERIVED_ARTIFACT_MODES:
+    # An incognito/temporary session forbids deriving durable artifacts: its
+    # transcript is discarded, so persisting a summary to the .intents sidecar
+    # would leave conversation content on disk after the conversation is gone.
+    if is_incognito_transcript(getattr(slot, "memory_mode", "")):
         return "memory_mode"
     # Require EXACTLY a clean end_turn. The marker is cleared at turn start,
     # so an empty value means the turn never reached EVENT_COMPLETE (ACP

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -19,7 +19,7 @@ from kiro_crew.dashboard.cron_inject import (
     inject_cron_result_to_dashboard,
 )
 from kiro_crew.dashboard.state import DashboardState
-from kiro_crew.history import INCOGNITO_MEMORY_MODES
+from kiro_crew.history import is_incognito_transcript
 from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.messaging.link import is_channel_session_key
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -741,7 +741,7 @@ async def api_lessons_create(request: web.Request) -> web.Response:
                     source="dashboard", resources="unknown_session",
                 )
                 return web.json_response({"error": "unknown session"}, status=400)
-            if persisted_mode is None or persisted_mode in INCOGNITO_MEMORY_MODES:
+            if persisted_mode is None or is_incognito_transcript(persisted_mode):
                 # Archiving a tab drops the slot AND discards its
                 # ``_restricted_keys`` entry while leaving the transcript —
                 # and its ``memory_mode`` marker — on disk, so the two

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -29,7 +29,7 @@ from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
 from kiro_crew.dashboard.session_memory import SessionMemorySampler
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.executors import subprocess_executor
-from kiro_crew.history import INCOGNITO_MEMORY_MODES, SEARCH_MIN_CHARS, _archive_dir
+from kiro_crew.history import SEARCH_MIN_CHARS, _archive_dir, is_incognito_transcript
 from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.mcp_discovery import (
     discover_servers_to_sync,
@@ -1042,7 +1042,7 @@ async def _summarize_one(state: DashboardState, key: str) -> str:
     meta = await loop.run_in_executor(None, log.get_metadata, key)
     # Defense in depth: never summarize an incognito/temporary session even if a
     # caller somehow passes its key.
-    if str(meta.get("memory_mode", "")).lower() in INCOGNITO_MEMORY_MODES:
+    if is_incognito_transcript(meta.get("memory_mode")):
         return ""
     # Cache: a summary persisted in a sidecar file is reusable as long as the
     # session file hasn't changed since it was generated. session_mtime advances

--- a/src/kiro_crew/discord/session_resume.py
+++ b/src/kiro_crew/discord/session_resume.py
@@ -9,7 +9,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from kiro_crew.history import INCOGNITO_MEMORY_MODES
+from kiro_crew.history import is_incognito_transcript
 from kiro_crew.messaging.driver import sanitize_channel_replay_text
 from kiro_crew.messaging.link import ChannelLink
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -246,7 +246,7 @@ class DiscordSessionResume:
         for row in rows:
             if not isinstance(row, dict):
                 continue
-            if str(row.get("memory_mode", "persistent")).lower() in INCOGNITO_MEMORY_MODES:
+            if is_incognito_transcript(row.get("memory_mode")):
                 continue
             key = _history_dashboard_key(row.get("key"))
             if key is None:

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -675,6 +675,27 @@ _SEARCH_SNIPPET_BUDGET_BYTES = 64 * 1024 * 1024
 # can't silently diverge between surfaces.
 INCOGNITO_MEMORY_MODES = frozenset({"incognito", "temporary"})
 
+
+def is_incognito_transcript(memory_mode: object) -> bool:
+    """True when *memory_mode* marks a transcript private (incognito/temporary).
+
+    The single shared predicate for :data:`INCOGNITO_MEMORY_MODES` membership,
+    so the normalization cannot drift between the surfaces that must agree on
+    what "private" means (history scans, MCP history tools, dashboard session
+    handlers, Discord resume, summary/folder/channel-slot derivations).
+
+    Normalization is ``str()`` + ``lower()`` — exactly what the call sites
+    apply: ``None``/absent reads as persistent (not private), and comparison is
+    case-insensitive because the set holds lowercase members while a
+    hand-edited transcript header is not bound by the API's validation.
+    Whitespace is deliberately NOT stripped and unrecognized values read as
+    not-private: callers that must fail closed on an unreadable or junk header
+    (e.g. the restricted-session write gate) resolve the mode through an
+    allowlist first and deny on ``None`` before this membership test applies.
+    """
+    return str(memory_mode or "").lower() in INCOGNITO_MEMORY_MODES
+
+
 # The fields that record where a message came from: the session key it arrived
 # on (``source_thread``, e.g. ``slack:1785861252.833429``) and the platform user
 # who sent it (``source_user``). Written by :meth:`ConversationLog.append`, read
@@ -3083,10 +3104,8 @@ class ConversationLog:
                             d = json.loads(line.strip())
                         except (json.JSONDecodeError, ValueError):
                             continue
-                        if (
-                            d.get("_type") == "metadata"
-                            and str(d.get("memory_mode", "")).lower()
-                            in INCOGNITO_MEMORY_MODES
+                        if d.get("_type") == "metadata" and is_incognito_transcript(
+                            d.get("memory_mode")
                         ):
                             is_restricted = True
                             break

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -44,7 +44,7 @@ from kiro_crew.config.loader import (
 from kiro_crew.context_management import summarize_result
 from kiro_crew.dashboard.origin import dashboard_socket_path
 from kiro_crew.history import _SEARCH_SCAN_WINDOW as SEARCH_SCAN_WINDOW
-from kiro_crew.history import INCOGNITO_MEMORY_MODES, ConversationLog, search_query_tokens
+from kiro_crew.history import ConversationLog, is_incognito_transcript, search_query_tokens
 from kiro_crew.knowledge.dedup import dedup_sweep
 from kiro_crew.knowledge.embedder import create_embedder_from_config
 from kiro_crew.knowledge.retrieval import HybridRetriever
@@ -1246,7 +1246,6 @@ def _call_tool(name: str, raw_args: dict[str, Any]) -> str:
 
 # ── Chat-history search helpers (Phase 1: search_chat_history / get_chat_session) ──
 
-_HISTORY_INCOGNITO_MODES = INCOGNITO_MEMORY_MODES  # canonical set (single source of truth in history.py)
 _SNIPPET_RADIUS = 120  # chars of context kept on each side of a match
 _SNIPPET_MAX_LEN = 320  # hard cap on a returned snippet
 # Upper bound on ranked candidates pulled from the backend per search. Bound to
@@ -1257,8 +1256,12 @@ _SEARCH_HISTORY_SCAN = SEARCH_SCAN_WINDOW
 
 
 def _history_is_incognito(meta: dict) -> bool:
-    """True if a session's memory_mode marks it private (never searchable)."""
-    return str(meta.get("memory_mode", "")).lower() in _HISTORY_INCOGNITO_MODES
+    """True if a session's memory_mode marks it private (never searchable).
+
+    Dict-shaped convenience over :func:`kiro_crew.history.is_incognito_transcript`,
+    the shared classifier — the predicate itself lives in history.py.
+    """
+    return is_incognito_transcript(meta.get("memory_mode"))
 
 
 def _redact_history_output(text: str) -> str:

--- a/test/test_chat_folder_suggest.py
+++ b/test/test_chat_folder_suggest.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from kiro_crew.dashboard import chat_folder_suggest as fs
+from kiro_crew.history import INCOGNITO_MEMORY_MODES
 
 # ── _parse_choice ───────────────────────────────────────────────────────────
 
@@ -126,7 +127,7 @@ def test_folder_sample_titles_without_conversation_log() -> None:
     assert fs._folder_sample_titles(_state([], log=None)) == {}
 
 
-@pytest.mark.parametrize("mode", sorted(fs.INCOGNITO_MEMORY_MODES))
+@pytest.mark.parametrize("mode", sorted(INCOGNITO_MEMORY_MODES) + ["Incognito"])
 def test_archived_scan_excludes_private_sessions(mode: str) -> None:
     """A filed temporary/incognito session's title must never ground the prompt.
 
@@ -151,7 +152,7 @@ def test_archived_scan_treats_missing_memory_mode_as_persistent() -> None:
     assert fs._folder_sample_titles(state) == {"a": ["Legacy"]}
 
 
-@pytest.mark.parametrize("mode", sorted(fs.INCOGNITO_MEMORY_MODES))
+@pytest.mark.parametrize("mode", sorted(INCOGNITO_MEMORY_MODES) + ["Incognito"])
 def test_live_slot_titles_exclude_private_slots(mode: str) -> None:
     """A LIVE private slot can be filed too — same rule as the archived scan."""
     slots = {

--- a/test/test_history_coverage.py
+++ b/test/test_history_coverage.py
@@ -1376,3 +1376,29 @@ class TestReadMessagesSkipsBlankLines:
             + _jsonl({"role": "user", "content": "only"}),
         )
         assert [m["content"] for m in log._read_messages("k")] == ["only"]
+
+
+class TestIsIncognitoTranscript:
+    """Lock the shared classifier's normalization so call sites can rely on it."""
+
+    @pytest.mark.parametrize("mode", sorted(H.INCOGNITO_MEMORY_MODES))
+    def test_private_modes_classify_true(self, mode: str) -> None:
+        assert H.is_incognito_transcript(mode) is True
+
+    @pytest.mark.parametrize("mode", ["Incognito", "TEMPORARY", "Temporary"])
+    def test_case_insensitive(self, mode: str) -> None:
+        """The set holds lowercase members; a hand-edited header is not bound
+        by API validation, so comparison must be case-insensitive."""
+        assert H.is_incognito_transcript(mode) is True
+
+    @pytest.mark.parametrize("mode", [None, "", "persistent", "unknown", 42, False])
+    def test_absent_or_unrecognized_reads_persistent(self, mode: object) -> None:
+        """None/absent means a legacy persistent session; junk stays
+        not-private — fail-closed callers allowlist BEFORE this predicate."""
+        assert H.is_incognito_transcript(mode) is False
+
+    def test_whitespace_not_stripped(self) -> None:
+        """`"incognito "` deliberately misses the set: the restricted-session
+        write gate normalizes via its own allowlist and denies on None, so
+        stripping here would silently change which callers fail closed."""
+        assert H.is_incognito_transcript("incognito ") is False

--- a/test/test_mcp_core_coverage.py
+++ b/test/test_mcp_core_coverage.py
@@ -31,6 +31,7 @@ from unittest.mock import patch
 import pytest
 
 from kiro_crew import mcp_core
+from kiro_crew.history import INCOGNITO_MEMORY_MODES
 from kiro_crew.mcp_core import (
     _call_tool,
     _casefold_match_span,
@@ -288,7 +289,7 @@ class TestPostTransportClassification:
 
 class TestHistoryScalarHelpers:
     def test_incognito_detection_is_case_insensitive(self):
-        mode = sorted(mcp_core._HISTORY_INCOGNITO_MODES)[0]
+        mode = sorted(INCOGNITO_MEMORY_MODES)[0]
         assert _history_is_incognito({"memory_mode": mode.upper()}) is True
         assert _history_is_incognito({"memory_mode": "persistent"}) is False
         assert _history_is_incognito({}) is False

--- a/test/test_session_summary_generate.py
+++ b/test/test_session_summary_generate.py
@@ -144,6 +144,16 @@ class TestGating:
         assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is False
         assert called == []
 
+    async def test_mixed_case_incognito_is_refused_too(self, env, monkeypatch):
+        """A hand-edited transcript header is not bound by the API's
+        validation, so the privacy refusal must be case-insensitive."""
+        state, slot = env
+        slot.memory_mode = "Incognito"
+        called = []
+        _stub_llm(monkeypatch, _GOOD_REPLY, called)
+        assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is False
+        assert called == []
+
     async def test_temporary_is_refused_before_any_model_call(self, env, monkeypatch):
         """A temporary session's transcript is discarded; persisting a summary
         of it would leave conversation content on disk after the conversation


### PR DESCRIPTION
## Problem

The predicate deciding whether a transcript is private (incognito/temporary) was re-derived independently in eight modules. A change to the rule had to be found and applied in every copy, and one copy had already drifted: `chat_folder_suggest.py`'s archived-session scan compared **case-sensitively**, unlike every other site.

## Why it matters

This predicate is a privacy control — it decides whether a session may be searched, listed, summarized, sampled into remote-model prompts, or surfaced as a durable slot. Divergent copies mean divergent privacy behavior: the drifted case-sensitive copy would ship a `memory_mode: "Incognito"` session's title to a remote model that every other surface refuses to touch.

## Fix (symptoms → root cause → change)

Symptom: eight hand-rolled membership checks against `INCOGNITO_MEMORY_MODES` (or locally mirrored copies of it). Root cause: the constant was shared but the *check* was not, so each module re-derived the normalization. Change: add one shared helper next to the constant it interprets —

```python
# src/kiro_crew/history.py
def is_incognito_transcript(memory_mode: object) -> bool:
    return str(memory_mode or "").lower() in INCOGNITO_MEMORY_MODES
```

— and route every call site through it. The helper preserves the dominant existing semantics exactly (`str()` + `lower()`, `None`/absent reads persistent, whitespace **not** stripped, unrecognized values not private; fail-closed callers allowlist before this predicate — that contract is spelled out in the docstring and locked by tests).

### Call sites routed (grep-verified complete; reviewers can re-check with `grep -rn INCOGNITO_MEMORY_MODES src/`)

| Site | Before | Notes |
|---|---|---|
| `src/kiro_crew/history.py` `_recent_across_sessions` scan | inline `str(...).lower() in SET` | equivalent |
| `src/kiro_crew/mcp_core.py` `_history_is_incognito` | duplicate predicate + `_HISTORY_INCOGNITO_MODES` alias | now delegates; alias deleted so the next `mcp_core` edit finds the helper, not the raw set |
| `src/kiro_crew/discord/session_resume.py` | `str(row.get(..., "persistent")).lower() in SET` | equivalent |
| `src/kiro_crew/dashboard/handlers/sessions.py` `_summarize_one` | `str(...).lower() in SET` | equivalent |
| `src/kiro_crew/dashboard/handlers/cron.py` `api_lessons_create` | `persisted_mode is None or persisted_mode in SET` | `None` fail-closed branch kept at the site (`is_incognito_transcript(None)` is `False`, so the explicit deny is still load-bearing) |
| `src/kiro_crew/dashboard/chat_folder_suggest.py` archived scan | `str(... or "persistent") in SET` — **case-sensitive (drifted)** | gains case-insensitivity: strictly more privacy-restrictive |
| `src/kiro_crew/dashboard/chat_folder_suggest.py` live slots | `slot.memory_mode in SET` | gains case-insensitivity (more restrictive) |
| `src/kiro_crew/dashboard/chat_summary.py` | mirrored `_NO_DERIVED_ARTIFACT_MODES` frozenset | mirror deleted; rationale comment kept at the site |
| `src/kiro_crew/dashboard/channel_slots.py` | mirrored `_EPHEMERAL_MEMORY_MODES` frozenset | mirror deleted; two-source (meta + row) check preserved |

No site becomes less restrictive. The only behavior deltas are the case-insensitivity gains noted above, all in the privacy-safe direction.

Sites deliberately **not** routed: `chat_utils._apply_incognito_prefix` (distinguishes the two modes for different prompt prefixes — not this predicate), `chat_handlers`/`state.VALID_MEMORY_MODES` (validity allowlist, a different question), `state.py is_temporary` (temporary-only semantics), `handlers/_shared.py` mode resolver (allowlist normalization feeding the fail-closed caller above).

## Tests

- `test_history_coverage.py::TestIsIncognitoTranscript` (new): locks the helper's normalization — both private modes true, case-insensitive true, `None`/`""`/`"persistent"`/junk/non-str false, `"incognito "` (whitespace) deliberately false.
- `test_chat_folder_suggest.py`: parametrizations now include `"Incognito"` so the call-site case-insensitivity gain cannot silently regress.
- `test_session_summary_generate.py::test_mixed_case_incognito_is_refused_too` (new): a mixed-case header still blocks summary persistence before any model call.
- Existing suites for all touched surfaces pass unchanged (sessions, cron, discord resume, channel slots, MCP history tools).

## Manual verification

N/A — pure refactor with unit coverage on every touched predicate; no user-visible surface changes.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only refactor, no frontend files touched, no rendered delta.

Closes #2464
