### PR TITLE
fix(source): queue source fetches at the memory ceiling instead of refusing

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1404,
+    "missing_code": 1400,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 729,
+  "_compliant": 751,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -152,7 +152,7 @@
       "missing_code": 12
     },
     "dashboard/handlers/source_providers.py": {
-      "missing_code": 12,
+      "missing_code": 8,
       "opaque_body": 1
     },
     "dashboard/handlers/steering.py": {

--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -71,8 +71,20 @@ _PROVIDER_CONCURRENCY = 4
 # reservation until their underlying task actually completes.
 _DIRECT_FETCH_PENDING_MAX = 16
 _DIRECT_FETCH_MAX_RESERVED_BYTES = 128 * 1024 * 1024
+# Measured worst case for one full fetch -- every command in the fanout at its
+# declared output ceiling -- is a ~32MB allocation peak, and ~43MB projected if
+# every ceiling is filled exactly (decode amplifies wire bytes by ~4.3x). 64MB
+# is therefore a ~1.5x cover for raw bytes, decoded JSON, the normalized copy,
+# and object overhead while a complete fetch remains alive. Two of these
+# saturate the pool by design; a third caller WAITS for room rather than being
+# refused (see _wait_for_direct_fetch_capacity), so the ceiling bounds memory
+# without turning ordinary concurrent panel use into an error.
 _FULL_FETCH_RESERVATION_BYTES = 64 * 1024 * 1024
 _CHECKS_FETCH_RESERVATION_BYTES = 8 * 1024 * 1024
+# How long a caller waits for admission room before giving up. Sized under the
+# per-command timeout (_COMMAND_TIMEOUT_SECS) so a queued read cannot outlive the
+# fetch it is queued behind by more than one command's worth of work.
+_DIRECT_FETCH_WAIT_SECS = 20.0
 # An issue payload is metadata plus comments -- no diffs, no check rollup -- so
 # both its aggregate cache and its retained-memory lease sit well below the
 # pull-request figures. TTL and entry count are shared with the PR cache.
@@ -146,6 +158,10 @@ _ISSUE_CACHE_LOCK = asyncio.Lock()
 _ISSUE_FETCH_INFLIGHT: dict[str, asyncio.Task[dict[str, Any]]] = {}
 _ISSUE_FETCH_TASKS: dict[str, set[asyncio.Task[dict[str, Any]]]] = {}
 _DIRECT_FETCH_RESERVATIONS: dict[asyncio.Task[Any], int] = {}
+# Futures held by callers waiting for admission room. Woken when any reservation
+# is released, so a request that arrives at a full pool queues instead of
+# failing (see _wait_for_direct_fetch_capacity).
+_DIRECT_FETCH_WAITERS: list[asyncio.Future[None]] = []
 _provider_semaphore = asyncio.Semaphore(_PROVIDER_CONCURRENCY)
 _SAFE_ERROR_RE = re.compile(r"\s+")
 _PROVIDER_TOOL_NAME = "source_provider_cli"
@@ -154,6 +170,15 @@ logger = logging.getLogger(__name__)
 
 class SourceProviderError(RuntimeError):
     """A provider CLI could not return the requested source data."""
+
+
+class SourceCapacityError(SourceProviderError):
+    """Admission room did not free up within the wait budget.
+
+    Distinct from its parent so the HTTP layer can mark it retryable: nothing is
+    wrong with the request or the provider, the gateway was simply holding its
+    concurrent-fetch memory ceiling for longer than the caller agreed to wait.
+    """
 
 
 def _sel():
@@ -2190,20 +2215,62 @@ def _direct_fetch_tasks() -> set[asyncio.Task[Any]]:
     return tasks
 
 
-def _ensure_direct_fetch_capacity(reservation_bytes: int) -> None:
+def _direct_fetch_capacity_free(reservation_bytes: int) -> bool:
+    """Whether a lease of ``reservation_bytes`` fits under both ceilings now."""
     tasks = _direct_fetch_tasks()
     reserved = sum(
         amount
         for task, amount in _DIRECT_FETCH_RESERVATIONS.items()
         if task in tasks and not task.done()
     )
-    if (
-        len(tasks) >= _DIRECT_FETCH_PENDING_MAX
-        or reservation_bytes > _DIRECT_FETCH_MAX_RESERVED_BYTES - reserved
-    ):
-        raise SourceProviderError(
-            "Too many source requests are pending; retry shortly."
-        )
+    return (
+        len(tasks) < _DIRECT_FETCH_PENDING_MAX
+        and reservation_bytes <= _DIRECT_FETCH_MAX_RESERVED_BYTES - reserved
+    )
+
+
+async def _wait_for_direct_fetch_capacity(deadline: float) -> bool:
+    """Sleep until a reservation is released or ``deadline`` passes.
+
+    Returns True if a release was observed and the caller should re-check
+    capacity, False if the wait budget is spent.
+
+    MUST NOT be awaited while holding ``_CACHE_LOCK`` or ``_ISSUE_CACHE_LOCK``:
+    an in-flight fetch takes the same lock to write its result, so waiting for it
+    to finish while holding that lock would deadlock. Callers therefore release
+    the lock, wait here, then re-acquire and re-check.
+    """
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return False
+    waiter: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    _DIRECT_FETCH_WAITERS.append(waiter)
+    try:
+        await asyncio.wait_for(waiter, timeout=remaining)
+        return True
+    except asyncio.TimeoutError:
+        return False
+    finally:
+        if waiter in _DIRECT_FETCH_WAITERS:
+            _DIRECT_FETCH_WAITERS.remove(waiter)
+
+
+def _wake_direct_fetch_waiters() -> None:
+    """Wake every waiter after a release; each re-checks its own ceiling.
+
+    All waiters are woken rather than just the first: leases differ in size, so
+    the head of the queue is not necessarily the one that now fits, and a
+    freed lease that only satisfies a later waiter must not stall behind it.
+    """
+    waiters = list(_DIRECT_FETCH_WAITERS)
+    _DIRECT_FETCH_WAITERS.clear()
+    for waiter in waiters:
+        if not waiter.done():
+            waiter.set_result(None)
+
+
+def _capacity_exhausted_error() -> SourceCapacityError:
+    return SourceCapacityError("Too many source requests are pending; retry shortly.")
 
 
 def _reserve_direct_fetch(task: asyncio.Task[Any], reservation_bytes: int) -> None:
@@ -2212,6 +2279,11 @@ def _reserve_direct_fetch(task: asyncio.Task[Any], reservation_bytes: int) -> No
 
     def release(done: asyncio.Task[Any]) -> None:
         _DIRECT_FETCH_RESERVATIONS.pop(done, None)
+        # The lease is gone, so a queued caller may now fit. Scheduled on the loop
+        # rather than woken inline: this runs during task teardown, and deferring
+        # by one loop iteration means the waiter re-checks capacity after the task
+        # is fully settled rather than mid-completion.
+        asyncio.get_running_loop().call_soon(_wake_direct_fetch_waiters)
 
     task.add_done_callback(release)
 
@@ -2222,17 +2294,23 @@ async def fetch_pull_request_checks(raw_url: str) -> list[dict[str, Any]]:
     # URL validation reads the cached snapshot.
     await ensure_gitlab_hosts_loaded()
     ref = _require_change_ref(parse_source_url(raw_url))
-    task = _CHECKS_FETCH_INFLIGHT.get(ref.url)
-    if task is None:
-        _ensure_direct_fetch_capacity(_CHECKS_FETCH_RESERVATION_BYTES)
-        task = asyncio.create_task(_fetch_pull_request_checks_uncached(ref))
-        _CHECKS_FETCH_INFLIGHT[ref.url] = task
-        _reserve_direct_fetch(task, _CHECKS_FETCH_RESERVATION_BYTES)
+    deadline = time.monotonic() + _DIRECT_FETCH_WAIT_SECS
+    while True:
+        task = _CHECKS_FETCH_INFLIGHT.get(ref.url)
+        if task is not None:
+            break
+        if _direct_fetch_capacity_free(_CHECKS_FETCH_RESERVATION_BYTES):
+            task = asyncio.create_task(_fetch_pull_request_checks_uncached(ref))
+            _CHECKS_FETCH_INFLIGHT[ref.url] = task
+            _reserve_direct_fetch(task, _CHECKS_FETCH_RESERVATION_BYTES)
 
-        def finish_checks(done: asyncio.Task[list[dict[str, Any]]]) -> None:
-            _finish_inflight(_CHECKS_FETCH_INFLIGHT, ref.url, done)
+            def finish_checks(done: asyncio.Task[list[dict[str, Any]]]) -> None:
+                _finish_inflight(_CHECKS_FETCH_INFLIGHT, ref.url, done)
 
-        task.add_done_callback(finish_checks)
+            task.add_done_callback(finish_checks)
+            break
+        if not await _wait_for_direct_fetch_capacity(deadline):
+            raise _capacity_exhausted_error()
     return await asyncio.shield(task)
 
 
@@ -2285,30 +2363,40 @@ async def fetch_pull_request(raw_url: str, *, refresh: bool = False) -> dict[str
     await ensure_gitlab_hosts_loaded()
     ref = _require_change_ref(parse_source_url(raw_url))
     now = time.monotonic()
-    async with _CACHE_LOCK:
-        cached = _CACHE.get(ref.url)
-        if not refresh and cached and now - cached[0] < _CACHE_TTL_SECS:
-            return cached[2]
-        task = _FULL_FETCH_INFLIGHT.get(ref.url)
-        if task is None:
-            _ensure_direct_fetch_capacity(_FULL_FETCH_RESERVATION_BYTES)
-            generation = _FULL_FETCH_GENERATIONS.get(ref.url, 0)
-            task = asyncio.create_task(_fetch_pull_request_uncached(ref, generation))
-            _FULL_FETCH_INFLIGHT[ref.url] = task
-            _FULL_FETCH_TASKS.setdefault(ref.url, set()).add(task)
-            _reserve_direct_fetch(task, _FULL_FETCH_RESERVATION_BYTES)
+    deadline = now + _DIRECT_FETCH_WAIT_SECS
+    while True:
+        async with _CACHE_LOCK:
+            cached = _CACHE.get(ref.url)
+            if not refresh and cached and time.monotonic() - cached[0] < _CACHE_TTL_SECS:
+                return cached[2]
+            task = _FULL_FETCH_INFLIGHT.get(ref.url)
+            if task is not None:
+                break
+            if _direct_fetch_capacity_free(_FULL_FETCH_RESERVATION_BYTES):
+                generation = _FULL_FETCH_GENERATIONS.get(ref.url, 0)
+                task = asyncio.create_task(_fetch_pull_request_uncached(ref, generation))
+                _FULL_FETCH_INFLIGHT[ref.url] = task
+                _FULL_FETCH_TASKS.setdefault(ref.url, set()).add(task)
+                _reserve_direct_fetch(task, _FULL_FETCH_RESERVATION_BYTES)
 
-            def finish_full_fetch(done: asyncio.Task[dict[str, Any]]) -> None:
-                _finish_inflight(_FULL_FETCH_INFLIGHT, ref.url, done)
-                active = _FULL_FETCH_TASKS.get(ref.url)
-                if active is None:
-                    return
-                active.discard(done)
-                if not active:
-                    _FULL_FETCH_TASKS.pop(ref.url, None)
-                    _FULL_FETCH_GENERATIONS.pop(ref.url, None)
+                def finish_full_fetch(done: asyncio.Task[dict[str, Any]]) -> None:
+                    _finish_inflight(_FULL_FETCH_INFLIGHT, ref.url, done)
+                    active = _FULL_FETCH_TASKS.get(ref.url)
+                    if active is None:
+                        return
+                    active.discard(done)
+                    if not active:
+                        _FULL_FETCH_TASKS.pop(ref.url, None)
+                        _FULL_FETCH_GENERATIONS.pop(ref.url, None)
 
-            task.add_done_callback(finish_full_fetch)
+                task.add_done_callback(finish_full_fetch)
+                break
+        # Outside the lock on purpose: the fetches being waited on take
+        # _CACHE_LOCK themselves to write their result, so waiting under it would
+        # deadlock. Re-checks the cache and the inflight map on wake, since
+        # either may have been satisfied by whoever just finished.
+        if not await _wait_for_direct_fetch_capacity(deadline):
+            raise _capacity_exhausted_error()
     # Shield the shared fetch so one disconnected browser cannot cancel work
     # still awaited by another request for the same URL.
     return await asyncio.shield(task)
@@ -2362,31 +2450,63 @@ async def fetch_issue(raw_url: str, *, refresh: bool = False) -> dict[str, Any]:
     if ref.provider == "jira":
         raise ValueError("Jira issues open in the browser; there is no local fetch for them.")
     now = time.monotonic()
-    async with _ISSUE_CACHE_LOCK:
-        cached = _ISSUE_CACHE.get(ref.url)
-        if not refresh and cached and now - cached[0] < _CACHE_TTL_SECS:
-            return cached[2]
-        task = _ISSUE_FETCH_INFLIGHT.get(ref.url)
-        if task is None:
-            _ensure_direct_fetch_capacity(_ISSUE_FETCH_RESERVATION_BYTES)
-            task = asyncio.create_task(_fetch_issue_uncached(ref))
-            _ISSUE_FETCH_INFLIGHT[ref.url] = task
-            _ISSUE_FETCH_TASKS.setdefault(ref.url, set()).add(task)
-            _reserve_direct_fetch(task, _ISSUE_FETCH_RESERVATION_BYTES)
+    deadline = now + _DIRECT_FETCH_WAIT_SECS
+    while True:
+        async with _ISSUE_CACHE_LOCK:
+            cached = _ISSUE_CACHE.get(ref.url)
+            if not refresh and cached and time.monotonic() - cached[0] < _CACHE_TTL_SECS:
+                return cached[2]
+            task = _ISSUE_FETCH_INFLIGHT.get(ref.url)
+            if task is not None:
+                break
+            if _direct_fetch_capacity_free(_ISSUE_FETCH_RESERVATION_BYTES):
+                task = asyncio.create_task(_fetch_issue_uncached(ref))
+                _ISSUE_FETCH_INFLIGHT[ref.url] = task
+                _ISSUE_FETCH_TASKS.setdefault(ref.url, set()).add(task)
+                _reserve_direct_fetch(task, _ISSUE_FETCH_RESERVATION_BYTES)
 
-            def finish_issue_fetch(done: asyncio.Task[dict[str, Any]]) -> None:
-                _finish_inflight(_ISSUE_FETCH_INFLIGHT, ref.url, done)
-                active = _ISSUE_FETCH_TASKS.get(ref.url)
-                if active is None:
-                    return
-                active.discard(done)
-                if not active:
-                    _ISSUE_FETCH_TASKS.pop(ref.url, None)
+                def finish_issue_fetch(done: asyncio.Task[dict[str, Any]]) -> None:
+                    _finish_inflight(_ISSUE_FETCH_INFLIGHT, ref.url, done)
+                    active = _ISSUE_FETCH_TASKS.get(ref.url)
+                    if active is None:
+                        return
+                    active.discard(done)
+                    if not active:
+                        _ISSUE_FETCH_TASKS.pop(ref.url, None)
 
-            task.add_done_callback(finish_issue_fetch)
+                task.add_done_callback(finish_issue_fetch)
+                break
+        # Outside the lock: see the matching note in fetch_pull_request.
+        if not await _wait_for_direct_fetch_capacity(deadline):
+            raise _capacity_exhausted_error()
     # Shield the shared fetch so one disconnected browser cannot cancel work
     # still awaited by another request for the same URL.
     return await asyncio.shield(task)
+
+
+def _provider_error_response(
+    request: web.Request, operation: str, exc: SourceProviderError
+) -> web.Response:
+    """Audit and answer a failed provider read.
+
+    Capacity pressure is reported under its own code and audit reason rather than
+    as a generic provider error: nothing failed, the gateway was holding its
+    concurrent-fetch memory ceiling. The code is what lets the client retry this
+    one case instead of presenting it as a dead end, while a real provider error
+    (auth, missing PR, malformed payload) still fails immediately.
+
+    The audit event is emitted here rather than at the call sites so the reason
+    cannot drift from the code the caller receives -- the two are one decision.
+    Owning the ``json_response`` here also keeps the error-code contract scan
+    honest: a helper that returned only the body would leave every call site
+    passing an opaque variable (see test/test_error_code_contract.py).
+    """
+    if isinstance(exc, SourceCapacityError):
+        code, reason = "source_busy", "capacity_exhausted"
+    else:
+        code, reason = "provider_error", "provider_error"
+    _audit_source_api(request, operation, "failed", reason)
+    return web.json_response({"error": str(exc), "code": code}, status=503)
 
 
 async def api_pull_request_source(request: web.Request) -> web.Response:
@@ -2416,8 +2536,7 @@ async def api_pull_request_source(request: web.Request) -> web.Response:
         _audit_source_api(request, "source.pull_request.read", "failed", "invalid_request")
         return web.json_response({"error": str(exc)}, status=400)
     except SourceProviderError as exc:
-        _audit_source_api(request, "source.pull_request.read", "failed", "provider_error")
-        return web.json_response({"error": str(exc)}, status=503)
+        return _provider_error_response(request, "source.pull_request.read", exc)
     _audit_source_api(request, "source.pull_request.read", "completed")
     return web.json_response(data)
 
@@ -2450,8 +2569,7 @@ async def api_issue_source(request: web.Request) -> web.Response:
         _audit_source_api(request, "source.issue.read", "failed", "invalid_request")
         return web.json_response({"error": str(exc)}, status=400)
     except SourceProviderError as exc:
-        _audit_source_api(request, "source.issue.read", "failed", "provider_error")
-        return web.json_response({"error": str(exc)}, status=503)
+        return _provider_error_response(request, "source.issue.read", exc)
     _audit_source_api(request, "source.issue.read", "completed")
     return web.json_response(data)
 
@@ -2481,8 +2599,7 @@ async def api_pull_request_checks(request: web.Request) -> web.Response:
         _audit_source_api(request, "source.pull_request.checks", "failed", "invalid_request")
         return web.json_response({"error": str(exc)}, status=400)
     except SourceProviderError as exc:
-        _audit_source_api(request, "source.pull_request.checks", "failed", "provider_error")
-        return web.json_response({"error": str(exc)}, status=503)
+        return _provider_error_response(request, "source.pull_request.checks", exc)
     _audit_source_api(request, "source.pull_request.checks", "completed")
     return web.json_response({"checks": checks})
 
@@ -3712,8 +3829,7 @@ async def _owner_mutation_response(
             rejection["confirmationRequired"] = True
         return web.json_response(rejection, status=400)
     except SourceProviderError as exc:
-        _audit_source_api(request, operation, "failed", "provider_error")
-        return web.json_response({"error": str(exc)}, status=503)
+        return _provider_error_response(request, operation, exc)
     except Exception:
         _audit_source_api(request, operation, "failed", "internal_error")
         raise
@@ -3790,8 +3906,7 @@ async def api_pull_request_pending_review(request: web.Request) -> web.Response:
         _audit_source_api(request, operation, "failed", "invalid_request")
         return web.json_response({"error": str(exc), "code": "invalid_request"}, status=400)
     except SourceProviderError as exc:
-        _audit_source_api(request, operation, "failed", "provider_error")
-        return web.json_response({"error": str(exc), "code": "provider_error"}, status=503)
+        return _provider_error_response(request, operation, exc)
     _audit_source_api(request, operation, "completed")
     return web.json_response(data)
 

--- a/test/test_source_providers.py
+++ b/test/test_source_providers.py
@@ -2810,6 +2810,9 @@ async def test_direct_fetch_pending_bound_is_combined_and_coalesces(monkeypatch)
         return [{"name": "test", "bucket": "pending"}]
 
     monkeypatch.setattr(source, "_DIRECT_FETCH_PENDING_MAX", 16)
+    # Admission now WAITS for room before refusing, so a test asserting the
+    # ceiling has to shrink the budget or it would sit out the real one.
+    monkeypatch.setattr(source, "_DIRECT_FETCH_WAIT_SECS", 0.05)
     monkeypatch.setattr(
         source,
         "_DIRECT_FETCH_MAX_RESERVED_BYTES",
@@ -2927,6 +2930,7 @@ async def test_stale_and_fresh_full_fetches_fit_exact_reservation_ceiling(
         "_DIRECT_FETCH_MAX_RESERVED_BYTES",
         2 * source._FULL_FETCH_RESERVATION_BYTES,
     )
+    monkeypatch.setattr(source, "_DIRECT_FETCH_WAIT_SECS", 0.05)
     url = "https://github.com/acme/repo/pull/23"
     stale = source.asyncio.create_task(source.fetch_pull_request(url, refresh=True))
     await old_started.wait()
@@ -2984,6 +2988,7 @@ async def test_direct_fetch_bound_counts_detached_stale_full_task(monkeypatch) -
         return membership
 
     monkeypatch.setattr(source, "_DIRECT_FETCH_PENDING_MAX", 1)
+    monkeypatch.setattr(source, "_DIRECT_FETCH_WAIT_SECS", 0.05)
     monkeypatch.setattr(source, "_fetch_github", fetch)
     monkeypatch.setattr(source, "_run_json", run)
     url = "https://github.com/acme/repo/pull/23"
@@ -3011,6 +3016,198 @@ async def test_direct_fetch_bound_counts_detached_stale_full_task(monkeypatch) -
     assert not source._FULL_FETCH_TASKS
     assert not source._FULL_FETCH_GENERATIONS
     source._CACHE.clear()
+
+
+def _reset_direct_fetch_state() -> None:
+    source._CACHE.clear()
+    source._FULL_FETCH_INFLIGHT.clear()
+    source._FULL_FETCH_TASKS.clear()
+    source._FULL_FETCH_GENERATIONS.clear()
+    source._CHECKS_FETCH_INFLIGHT.clear()
+    source._ISSUE_CACHE.clear()
+    source._ISSUE_FETCH_INFLIGHT.clear()
+    source._ISSUE_FETCH_TASKS.clear()
+    source._DIRECT_FETCH_RESERVATIONS.clear()
+    source._DIRECT_FETCH_WAITERS.clear()
+
+
+def _reserved_bytes() -> int:
+    tasks = source._direct_fetch_tasks()
+    return sum(
+        amount
+        for task, amount in source._DIRECT_FETCH_RESERVATIONS.items()
+        if task in tasks and not task.done()
+    )
+
+
+@pytest.mark.asyncio
+async def test_saturated_pool_queues_the_next_fetch_instead_of_refusing(monkeypatch) -> None:
+    """A caller arriving at a full pool WAITS for room and then succeeds.
+
+    The panel's read is a user-facing load: refusing it outright turned ordinary
+    concurrent use (two windows on two PRs) into an error card with a manual
+    Retry. Waiting keeps the memory ceiling intact while removing the dead end.
+    """
+    _reset_direct_fetch_state()
+    release = source.asyncio.Event()
+    started = 0
+
+    async def fetch(ref):
+        nonlocal started
+        started += 1
+        await release.wait()
+        return {"provider": "github", "url": ref.url}
+
+    monkeypatch.setattr(source, "_fetch_github", fetch)
+    monkeypatch.setattr(
+        source,
+        "_DIRECT_FETCH_MAX_RESERVED_BYTES",
+        2 * source._FULL_FETCH_RESERVATION_BYTES,
+    )
+    first = source.asyncio.create_task(
+        source.fetch_pull_request("https://github.com/acme/repo/pull/1", refresh=True)
+    )
+    second = source.asyncio.create_task(
+        source.fetch_pull_request("https://github.com/acme/repo/pull/2", refresh=True)
+    )
+    while started < 2:
+        await source.asyncio.sleep(0)
+    assert _reserved_bytes() == source._DIRECT_FETCH_MAX_RESERVED_BYTES
+
+    queued = source.asyncio.create_task(
+        source.fetch_pull_request("https://github.com/acme/repo/pull/3", refresh=True)
+    )
+    for _ in range(10):
+        await source.asyncio.sleep(0)
+    # Queued, not resolved and not failed, and it did not breach the ceiling to
+    # get there.
+    assert not queued.done()
+    assert source._DIRECT_FETCH_WAITERS
+    assert _reserved_bytes() <= source._DIRECT_FETCH_MAX_RESERVED_BYTES
+
+    release.set()
+    assert (await source.asyncio.wait_for(queued, timeout=5))["url"] == (
+        "https://github.com/acme/repo/pull/3"
+    )
+    await first
+    await second
+    await source.asyncio.sleep(0)
+    assert not source._DIRECT_FETCH_RESERVATIONS
+    assert not source._DIRECT_FETCH_WAITERS
+    source._CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_queued_fetch_waits_outside_the_cache_lock(monkeypatch) -> None:
+    """The admission wait must not hold ``_CACHE_LOCK``.
+
+    An in-flight fetch takes the same lock to write its result, so waiting for
+    capacity while holding it would deadlock: the queued caller would block the
+    very completion that frees its room. This is the regression guard for that
+    shape -- move the wait back inside the lock and this test times out.
+    """
+    _reset_direct_fetch_state()
+    release = source.asyncio.Event()
+    started = 0
+
+    async def fetch(ref):
+        nonlocal started
+        started += 1
+        await release.wait()
+        return {"provider": "github", "url": ref.url}
+
+    monkeypatch.setattr(source, "_fetch_github", fetch)
+    monkeypatch.setattr(
+        source, "_DIRECT_FETCH_MAX_RESERVED_BYTES", source._FULL_FETCH_RESERVATION_BYTES
+    )
+    holder = source.asyncio.create_task(
+        source.fetch_pull_request("https://github.com/acme/repo/pull/4", refresh=True)
+    )
+    while started < 1:
+        await source.asyncio.sleep(0)
+    queued = source.asyncio.create_task(
+        source.fetch_pull_request("https://github.com/acme/repo/pull/5", refresh=True)
+    )
+    for _ in range(10):
+        await source.asyncio.sleep(0)
+    assert not queued.done()
+
+    release.set()
+    # Both complete: the holder could still take _CACHE_LOCK to write its cache
+    # entry while the queued caller was waiting.
+    assert await source.asyncio.wait_for(holder, timeout=5)
+    assert await source.asyncio.wait_for(queued, timeout=5)
+    source._CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_capacity_error_is_marked_retryable_for_the_client(monkeypatch) -> None:
+    """The wait-budget error carries ``code: source_busy``.
+
+    A generic provider error (auth, missing PR) must stay fail-fast in the UI, so
+    the retryable case needs its own machine-readable marker rather than the
+    client pattern-matching on prose.
+    """
+    _reset_direct_fetch_state()
+    monkeypatch.setattr(
+        source,
+        "fetch_pull_request",
+        AsyncMock(side_effect=source.SourceCapacityError("Too many source requests are pending.")),
+    )
+    async with TestClient(TestServer(_app())) as client:
+        response = await client.post(
+            "/api/source/pull-request", json={"url": "https://github.com/acme/repo/pull/9"}
+        )
+        assert response.status == 503
+        assert (await response.json())["code"] == "source_busy"
+
+
+@pytest.mark.asyncio
+async def test_provider_error_is_not_marked_retryable(monkeypatch) -> None:
+    """Revert guard for the marker: a real provider failure must NOT be busy."""
+    _reset_direct_fetch_state()
+    monkeypatch.setattr(
+        source,
+        "fetch_pull_request",
+        AsyncMock(side_effect=source.SourceProviderError("gh could not authenticate")),
+    )
+    async with TestClient(TestServer(_app())) as client:
+        response = await client.post(
+            "/api/source/pull-request", json={"url": "https://github.com/acme/repo/pull/9"}
+        )
+        assert response.status == 503
+        assert (await response.json())["code"] == "provider_error"
+
+
+@pytest.mark.asyncio
+async def test_capacity_error_audits_its_own_reason(monkeypatch, _mock_source_sel) -> None:
+    """The audit reason must match the code the caller receives.
+
+    Back-pressure recorded as ``provider_error`` would read, in the audit trail,
+    as the provider having failed. The pairing lives in one place so the two
+    cannot drift.
+    """
+    _reset_direct_fetch_state()
+    monkeypatch.setattr(
+        source,
+        "fetch_pull_request",
+        AsyncMock(side_effect=source.SourceCapacityError("Too many source requests are pending.")),
+    )
+    async with TestClient(TestServer(_app())) as client:
+        await client.post(
+            "/api/source/pull-request", json={"url": "https://github.com/acme/repo/pull/9"}
+        )
+    reasons = [
+        call.kwargs.get("error") for call in _mock_source_sel.log_api_access.call_args_list
+    ]
+    assert "capacity_exhausted" in reasons
+    assert "provider_error" not in reasons
+
+
+@pytest.mark.asyncio
+async def test_capacity_error_remains_a_source_provider_error() -> None:
+    """Every existing ``except SourceProviderError`` site must still catch it."""
+    assert issubclass(source.SourceCapacityError, source.SourceProviderError)
 
 
 @pytest.mark.asyncio
@@ -6560,6 +6757,7 @@ async def test_fetch_issue_reserves_direct_fetch_capacity(monkeypatch) -> None:
 
     monkeypatch.setattr(source, "_fetch_github_issue", fake_fetch)
     monkeypatch.setattr(source, "_DIRECT_FETCH_PENDING_MAX", 1)
+    monkeypatch.setattr(source, "_DIRECT_FETCH_WAIT_SECS", 0.05)
 
     inflight = asyncio.ensure_future(
         source.fetch_issue("https://github.com/acme/repo/issues/12")
@@ -6610,7 +6808,10 @@ async def test_issue_endpoint_maps_provider_error_to_503(monkeypatch) -> None:
     async with TestClient(TestServer(_app())) as client:
         response = await client.post("/api/source/issue", json={"url": _ISSUE_URL})
         assert response.status == 503
-        assert await response.json() == {"error": "gh timed out"}
+        # `code` distinguishes a real provider failure from admission pressure, so
+        # the client retries only the latter. Issues share the pull-request
+        # admission pool, so this endpoint can report either.
+        assert await response.json() == {"error": "gh timed out", "code": "provider_error"}
 
 
 @pytest.mark.asyncio

--- a/website/src/components/PullRequestPanel.tsx
+++ b/website/src/components/PullRequestPanel.tsx
@@ -62,6 +62,13 @@ const STATUS_FOLLOWUP_MS = 5_000
  *  STATUS_POLL_MAX_MS. Polling is never abandoned — a transient network or
  *  gateway blip must not freeze the strip's glyphs until the user intervenes. */
 const STATUS_ERROR_BACKOFF_MS = 30_000
+/** Retries allowed when the gateway reports it is at its concurrent-fetch
+ *  ceiling (`code: source_busy`). The server already waited its own admission
+ *  budget before answering, so these are spaced attempts at a ceiling that
+ *  clears as in-flight fetches complete — not a tight poll. Bounded so a
+ *  genuinely saturated gateway still surfaces the error instead of spinning. */
+const SOURCE_BUSY_RETRIES = 2
+const SOURCE_BUSY_RETRY_BASE_MS = 2_000
 /** Consecutive in-flight-refresh polls allowed at the fast interval before
  *  falling back to TTL pacing — bounds a provider that never settles. */
 export const STATUS_FOLLOWUP_MAX = 3
@@ -110,18 +117,26 @@ export function pullRequestErrorDetails(error: unknown): {
   loginCommand: 'gh auth login' | 'glab auth login' | ''
   /** The server refused pending an acknowledgement the client may now offer. */
   confirmationRequired: boolean
+  /** The gateway was at its concurrent-fetch ceiling; the same request may succeed later. */
+  sourceBusy: boolean
 } {
   let message = error instanceof Error ? error.message : String(error || '')
   let confirmationRequired = false
+  let sourceBusy = false
   // ApiError already unwraps the human message, which discards every other
   // field, so the structured marker is read from the raw body it preserves.
   const raw = typeof (error as { body?: unknown })?.body === 'string'
     ? (error as { body: string }).body
     : message
   try {
-    const payload = JSON.parse(raw) as { error?: unknown; confirmationRequired?: unknown }
+    const payload = JSON.parse(raw) as {
+      error?: unknown
+      confirmationRequired?: unknown
+      code?: unknown
+    }
     if (typeof payload.error === 'string') message = payload.error
     confirmationRequired = payload.confirmationRequired === true
+    sourceBusy = payload.code === 'source_busy'
   } catch {
     // Provider and network errors may already be plain text.
   }
@@ -131,11 +146,26 @@ export function pullRequestErrorDetails(error: unknown): {
     : authenticationFailure && /(?:`|\b)glab auth login(?:`|\b)/i.test(message)
       ? 'glab auth login'
       : ''
-  return { message, loginCommand, confirmationRequired }
+  return { message, loginCommand, confirmationRequired, sourceBusy }
 }
 
-function safeExternalUrl(value: string): string | undefined {
-  if (!value) return undefined
+/** Whether a failed source read is worth another attempt.
+ *
+ * Only admission pressure retries. A provider error (not authenticated, PR gone,
+ * malformed payload) is a message the user has to act on, so retrying it just
+ * delays that; `source_busy` instead means the gateway was at its
+ * concurrent-fetch memory ceiling, which clears on its own as in-flight fetches
+ * complete. */
+export function shouldRetrySourceRead(failureCount: number, error: unknown): boolean {
+  return pullRequestErrorDetails(error).sourceBusy && failureCount < SOURCE_BUSY_RETRIES
+}
+
+/** Backoff for a `source_busy` retry: 2s, then 4s. */
+export function sourceBusyRetryDelay(failureCount: number): number {
+  return SOURCE_BUSY_RETRY_BASE_MS * 2 ** failureCount
+}
+
+function safeExternalUrl(value: string): string | undefined {  if (!value) return undefined
   try {
     const url = new URL(value)
     return url.protocol === 'https:' || url.protocol === 'http:' ? url.href : undefined
@@ -801,7 +831,13 @@ export default function PullRequestPanel({
     },
     enabled: !!selected,
     staleTime: Infinity,
-    retry: false,
+    // Provider errors (auth, missing PR, bad payload) stay fail-fast: retrying
+    // them only delays a message the user has to act on. Capacity pressure is
+    // the one retryable case -- the gateway is holding its concurrent-fetch
+    // ceiling and already waited its own budget, so a couple of spaced attempts
+    // turn a dead-end error card into a slower load.
+    retry: shouldRetrySourceRead,
+    retryDelay: sourceBusyRetryDelay,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   })

--- a/website/src/test/PullRequestPanel.test.tsx
+++ b/website/src/test/PullRequestPanel.test.tsx
@@ -21,13 +21,53 @@ import PullRequestPanel, {
   CHECK_POLL_MAX_FAILURES,
   pullRequestCheckPollDelay,
   pullRequestCiSignal,
+  pullRequestErrorDetails,
   pullRequestIsLive,
   pullRequestLifecycleState,
   pullRequestMergeBlocker,
+  shouldRetrySourceRead,
+  sourceBusyRetryDelay,
   STATUS_FOLLOWUP_MAX,
   stateLabel,
   statusPollDelay,
 } from '../components/PullRequestPanel'
+
+/** An ApiError-shaped rejection: the human message plus the raw body the client
+ *  preserves, which is where the machine-readable code lives. */
+function apiError(body: Record<string, unknown>): Error & { body: string } {
+  const raw = JSON.stringify(body)
+  return Object.assign(new Error(String(body.error || '')), { body: raw })
+}
+
+describe('source read retry policy', () => {
+  it('retries a busy gateway, bounded', () => {
+    const busy = apiError({ error: 'Too many source requests are pending.', code: 'source_busy' })
+    expect(pullRequestErrorDetails(busy).sourceBusy).toBe(true)
+    expect(shouldRetrySourceRead(0, busy)).toBe(true)
+    expect(shouldRetrySourceRead(1, busy)).toBe(true)
+    // Bounded: a permanently saturated gateway surfaces the error instead of
+    // retrying forever.
+    expect(shouldRetrySourceRead(2, busy)).toBe(false)
+  })
+
+  it('does NOT retry a provider error', () => {
+    const provider = apiError({ error: 'gh could not authenticate', code: 'provider_error' })
+    expect(pullRequestErrorDetails(provider).sourceBusy).toBe(false)
+    expect(shouldRetrySourceRead(0, provider)).toBe(false)
+  })
+
+  it('does not treat an unlabelled error as retryable', () => {
+    // Pre-fix bodies and plain-text network errors carry no code; retrying them
+    // would delay a message the user must act on.
+    expect(shouldRetrySourceRead(0, apiError({ error: 'boom' }))).toBe(false)
+    expect(shouldRetrySourceRead(0, new Error('network down'))).toBe(false)
+  })
+
+  it('backs off between attempts', () => {
+    expect(sourceBusyRetryDelay(0)).toBe(2_000)
+    expect(sourceBusyRetryDelay(1)).toBe(4_000)
+  })
+})
 
 const github: PullRequestSource = {
   provider: 'github',


### PR DESCRIPTION
## Problem

Opening a pull request in the source panel could fail with:

> Could not load this pull request — Too many source requests are pending; retry shortly.

Nothing is wrong with the request, the PR, or the provider. This is the gateway's
own admission control refusing a read it could have simply delayed.

`_ensure_direct_fetch_capacity` enforced two ceilings:

| ceiling | value |
| --- | --- |
| `_DIRECT_FETCH_PENDING_MAX` | 16 tasks |
| `_DIRECT_FETCH_MAX_RESERVED_BYTES` | 128 MB |
| `_FULL_FETCH_RESERVATION_BYTES` | 64 MB per PR detail fetch |

128 / 64 means the byte pool admits **exactly two** concurrent full fetches, and
the 16-task ceiling can never fire. The third caller was refused instantly, and
since `PullRequestPanel`'s query used `retry: false`, that refusal became a
terminal error card requiring a manual Retry click.

Two ordinary situations reach it:

1. Two dashboard windows on two different pull requests, plus either one's checks
   poll (8 MB) or an issue panel (16 MB).
2. **A single URL.** When a mutation (resolve thread, comment, mark ready) or a
   cross-window `source_delta` invalidates the cache mid-fetch, the superseded
   generation keeps its 64 MB lease while the fresh generation is admitted —
   64 + 64 consumes the whole pool for one PR.

## Is the 64 MB lease wrong?

I measured before changing it, and it is **not** wrong. Feeding the GitHub fanout
synthetic payloads at every command's declared output ceiling, with the raw byte
copy and the JSON decode inside the traced region:

```
synthetic files    :  4.00 MB on the wire
synthetic comments :  2.00 MB on the wire
synthetic threads  :  0.34 MB on the wire
synthetic details  :  1.07 MB on the wire
tracemalloc PEAK during fetch  :   31.8 MB
retained after fetch (cached)  :    9.4 MB
```

Decode amplifies wire bytes by ~4.3x, so filling every ceiling exactly (10 MB
wire) projects to a ~43 MB peak. 64 MB is a ~1.5x cover, and it is left
unchanged. Comparing it against `_MAX_PAYLOAD_BYTES` (8 MB) — as an earlier read
of this code did — measures the wrong thing: that caps the *normalized* payload,
not the raw fanout that is alive while the fetch runs.

## Fix

The ceiling is correct; the **policy** is not. An admission ceiling on a
user-facing read should delay the read, not fail it.

- A caller that finds the pool full now **waits** for a lease to be released
  (`_DIRECT_FETCH_WAIT_SECS = 20s`) and proceeds when room appears. The byte
  ceiling is never exceeded to satisfy a waiter, so **worst-case memory is
  unchanged**.
- The wait happens **outside** `_CACHE_LOCK` / `_ISSUE_CACHE_LOCK` by
  construction. An in-flight fetch takes the same lock to write its result, so
  waiting under it would deadlock against the very completion that frees the
  room. Callers release the lock, wait, then re-acquire and re-check both the
  cache and the inflight map. There is a dedicated regression test for this
  shape.
- All waiters are woken on a release rather than just the head: leases differ in
  size, so the freed room may only fit a later waiter.
- If the budget does expire, the error is still raised — now as
  `SourceCapacityError`, a `SourceProviderError` subclass so every existing
  handler still catches it, carrying `code: "source_busy"` and its own audit
  reason (`capacity_exhausted` rather than `provider_error`).
- `PullRequestPanel` retries **only** that code, twice, with 2s/4s backoff. A real
  provider error (not authenticated, PR gone, malformed payload) stays fail-fast,
  because that is a message the user has to act on.

Deliberately **not** changed: the superseded generation still holds its own lease.
Its payload is real and is returned to callers already awaiting it, so charging
for it is honest accounting — with queueing, that case now costs a wait instead
of an error.

## Verification

**8 mutations revert-verified** (each patched out, matching test confirmed to
fail, source restored byte-identical):

| mutation | caught by |
| --- | --- |
| wait replaced by immediate refusal (old behaviour) | `test_saturated_pool_queues_the_next_fetch_instead_of_refusing` |
| waiters never woken on release | same |
| wait moved back **under** `_CACHE_LOCK` (deadlock shape) | `test_queued_fetch_waits_outside_the_cache_lock` |
| capacity error loses its retryable code | `test_capacity_error_is_marked_retryable_for_the_client` |
| `sourceBusy` marker never set | `source read retry policy` |
| retry bound removed (retries forever) | same |
| every error treated as retryable | same |
| backoff flattened to a constant | same |

Gates: 414 backend tests in the touched file, 726 dashboard tests, 433 tests
across the other source-touching suites, 18015 vitest, `tsc -b` clean, eslint 0
errors, isort/flake8 clean, `I18N_BASE_REF=origin/main npm run i18n:check` 16/16,
jscpd 0 clones.

The single mypy error (`vector_memory.py:1260`, faiss overload) is pre-existing —
A/B measured as identical with and without this branch's changes.

This was reported directly in a dashboard session rather than filed, so there is
no tracking issue to reference.

<!-- no-visual-delta -->

**Why no screenshot:** the frontend diff adds no markup, styling, or copy — it
adds a field to an error-parsing helper and swaps `retry: false` for a predicate,
so the only user-visible difference is that an existing error card appears less
often (verified by unit tests on the retry policy rather than pixels).
