### PR TITLE
fix(knowledge): take ingested item ids from the commit callback

### DIFF
--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -908,10 +908,90 @@ class FolderWatcher:
             now = datetime.now().isoformat()
             self._update_state(source_id, file_path, "", 0, json.dumps(old_item_ids), now, "failed", "sensitive path blocked")
             return None, "failed"
-        try:
-            before_ids = {r["id"] for r in self.store.db.execute(
-                "SELECT id FROM items WHERE source_id = ?", (source_id,)).fetchall()}
 
+        # The pipeline reports the items it created through `on_committed`, which
+        # it invokes INSIDE its own `run_to_completion` finalize hop -- the same
+        # uncancellable unit that commits them (see `_finalize` in ingestion.py).
+        # Taking the ids from there, instead of reading them back afterwards, is
+        # what makes two separate hazards unreachable:
+        #
+        # * No query. The previous before/after diff read the source's ENTIRE
+        #   item-id set twice per file. `idx_items_source_id` keeps that an index
+        #   scan, but it still materializes one row per item in the SOURCE --
+        #   ~20k rows apiece on a large folder source, measured at >1s each --
+        #   synchronously on the event loop, which trips the loop-stall watchdog
+        #   and crash-loops the gateway.
+        # * No await after the commit. ANY await between the pipeline's commit
+        #   and this function's return is an orphan window: a shutdown cancelling
+        #   there leaves committed items that no `folder_file_state` row names,
+        #   so the next scan re-ingests the file and duplicates them while the
+        #   first group stays untracked and undeletable. Offloading the reads
+        #   would have introduced exactly that window; not needing them removes
+        #   it. `test_knowledge_ingest_scan_off_loop.py` ratchets both properties.
+        #
+        # `on_committed` fires only on the fully-successful branch, so it also
+        # replaces the `sources.sync_status` read that used to detect a partial
+        # rollback -- and it does so per call, rather than reading a column a
+        # concurrent ingest on the same source can flip.
+        committed: list[str] | None = None
+
+        def _record_committed(item_ids: list[str]) -> None:
+            # Runs INSIDE the pipeline's finalize hop, on its worker thread --
+            # the same uncancellable unit that commits the group. Persisting the
+            # row HERE, not just capturing the ids in memory, is what closes the
+            # remaining orphan window: the pipeline awaits again after the
+            # finalize hop (`generate_source_summary`), so a shutdown cancelling
+            # there would otherwise leave a committed group that only this
+            # closure remembers -- the caller's own state write never runs, the
+            # 'scanning' marker survives, and the next sweep re-ingests the file
+            # alongside the untracked first group.
+            #
+            # A targeted UPDATE, not `_write_state_row`: the 'scanning' marker
+            # the caller wrote before invoking us already carries the file's
+            # content hash and mtime, which this frame does not have. Every call
+            # site writes that marker first, so the row is always there to hit.
+            # `status='done'` also clears the retry budget, matching every other
+            # terminal write. The caller's own 'done' write (same values) still
+            # lands afterwards on the uncancelled path, which keeps this order-
+            # independent. `store.db` is per-thread and, on this worker,
+            # autocommit -- no separate commit hop, no transaction to interleave.
+            nonlocal committed
+            committed = list(item_ids)
+            # Fail-safe, never fail-closed: the write below is a durability
+            # UPGRADE over the in-memory capture, not a precondition. Before it
+            # existed this callback could not raise; letting a raise escape now
+            # would poison the finalize hop AFTER the group has committed and
+            # the superseded items are deleted -- the pipeline would report the
+            # whole ingest failed, the caller would write a terminal 'failed'
+            # row, and the next sweep would re-ingest alongside the committed
+            # group: exactly the duplication this write exists to prevent. On
+            # a swallowed error the memory path still stands and the caller's
+            # own 'done' write persists the group on the uncancelled path; the
+            # exposure shrinks back to the cancellation window, never past the
+            # pre-write behavior. Writer-lock contention past busy_timeout
+            # (e.g. a large concurrent import_bundle) is the realistic raiser.
+            try:
+                text_hash: str | None = None
+                if committed:
+                    row = self.store.db.execute(
+                        "SELECT content_hash FROM items WHERE id = ?",
+                        (committed[0],)).fetchone()
+                    if row:
+                        text_hash = row["content_hash"]
+                self.store.db.execute(
+                    "UPDATE folder_file_state SET item_ids = ?, text_hash = ?, "
+                    "status = 'done', error_message = NULL, attempts = 0, "
+                    "last_seen = ? WHERE source_id = ? AND file_path = ?",
+                    (json.dumps(committed), text_hash,
+                     datetime.now().isoformat(), source_id, file_path))
+                self.store.db.commit()
+            except Exception:
+                logger.warning(
+                    "could not persist committed group for %s inside the "
+                    "commit callback; deferring to the caller's state write",
+                    file_path, exc_info=True)
+
+        try:
             # Hand the pipeline the path that was just validated, not the one that
             # was validated a moment earlier -- re-deriving it there would reopen the
             # window this check closed. The display name still comes from the logical
@@ -920,24 +1000,22 @@ class FolderWatcher:
                 resolved, source_id=source_id, namespace=namespace,
                 original_name=Path(file_path).name,
                 old_item_ids=old_item_ids,
+                on_committed=_record_committed,
                 on_duplicate=on_duplicate)
 
             if job_id and (self.pipeline.get_job_status(job_id) or {}).get(
                     "status") == DUPLICATE_JOB_STATUS:
                 return [], "deduped"
 
-            # Detect partial failure (pipeline rolls back but doesn't raise)
-            row = self.store.db.execute(
-                "SELECT sync_status FROM sources WHERE id = ?", (source_id,)).fetchone()
-            if row and row["sync_status"] == "error":
+            # Detect partial failure (pipeline rolls back but doesn't raise): the
+            # finalize hop reports a committed group only on the branch that
+            # commits one, so an unset `committed` IS the rollback signal.
+            if committed is None:
                 now = datetime.now().isoformat()
                 self._update_state(source_id, file_path, "", 0, json.dumps(old_item_ids), now, "failed", "partial ingestion failure")
                 return None, "failed"
 
-            after_ids = {r["id"] for r in self.store.db.execute(
-                "SELECT id FROM items WHERE source_id = ?", (source_id,)).fetchall()}
-
-            return list(after_ids - before_ids), "done"
+            return committed, "done"
         except Exception as e:
             logger.exception("Failed to ingest %s", file_path)
             now = datetime.now().isoformat()

--- a/test/test_folder_watcher.py
+++ b/test/test_folder_watcher.py
@@ -261,8 +261,10 @@ class TestFolderWatcherScan:
         source = {"id": source_id, "uri": str(vault), "source_type": "local_folder", "properties": "{}"}
 
         # Mock ingest to create items
-        async def fake_ingest(path, **kwargs):
-            store.add_item("title", "content", "doc", source_id=source_id)
+        async def fake_ingest(path, *, on_committed=None, **kwargs):
+            item_id = store.add_item("title", "content", "doc", source_id=source_id)
+            if on_committed is not None:
+                on_committed([item_id])
             return "job1"
         pipeline.ingest_file = fake_ingest
 
@@ -320,6 +322,15 @@ class TestFolderWatcherScan:
         source_id = store.add_source("test", "local_folder", str(vault))
         source = {"id": source_id, "uri": str(vault), "source_type": "local_folder", "properties": "{}"}
 
+        # Honor the pipeline contract: on_committed fires on the committing
+        # branch. A mock that ingests without reporting reads as a rollback.
+        async def fake_ingest(path, *, on_committed=None, **kwargs):
+            item_id = store.add_item("title", "content", "doc", source_id=source_id)
+            if on_committed is not None:
+                on_committed([item_id])
+            return "job1"
+        pipeline.ingest_file = fake_ingest
+
         await fw.scan_source(source)
 
         # Modify a file with explicit future mtime (avoids 1s granularity flakiness)
@@ -345,8 +356,10 @@ class TestFolderWatcherScan:
         source_id = store.add_source("test", "local_folder", str(vault))
         source = {"id": source_id, "uri": str(vault), "source_type": "local_folder", "properties": "{}"}
 
-        async def fake_ingest(path, **kwargs):
-            store.add_item("title", "content", "doc", source_id=source_id)
+        async def fake_ingest(path, *, on_committed=None, **kwargs):
+            item_id = store.add_item("title", "content", "doc", source_id=source_id)
+            if on_committed is not None:
+                on_committed([item_id])
             return "job1"
         pipeline.ingest_file = fake_ingest
 
@@ -709,8 +722,10 @@ class TestAsyncToThread:
         source = {"id": source_id, "uri": str(vault),
                   "source_type": "local_folder", "properties": "{}"}
 
-        async def fake_ingest(path, **kwargs):
-            store.add_item("title", "content", "doc", source_id=source_id)
+        async def fake_ingest(path, *, on_committed=None, **kwargs):
+            item_id = store.add_item("title", "content", "doc", source_id=source_id)
+            if on_committed is not None:
+                on_committed([item_id])
             return "job1"
         pipeline.ingest_file = fake_ingest
 
@@ -1036,8 +1051,10 @@ class TestInterruptedScanRetryCap:
         source = {"id": source_id, "uri": str(vault), "source_type": "local_folder",
                   "properties": "{}"}
 
-        async def fake_ingest(path, **kw):
-            store.add_item("title", "content", "doc", source_id=source_id)
+        async def fake_ingest(path, *, on_committed=None, **kw):
+            item_id = store.add_item("title", "content", "doc", source_id=source_id)
+            if on_committed is not None:
+                on_committed([item_id])
             return "job1"
         pipeline.ingest_file = fake_ingest
 
@@ -1087,8 +1104,10 @@ class TestInterruptedScanRetryCap:
         doc.write_text("# Rewritten after the cap was spent")
         os.utime(doc, (9999999999, 9999999999))
 
-        async def fake_ingest(path, **kw):
-            store.add_item("title", "content", "doc", source_id=source_id)
+        async def fake_ingest(path, *, on_committed=None, **kw):
+            item_id = store.add_item("title", "content", "doc", source_id=source_id)
+            if on_committed is not None:
+                on_committed([item_id])
             return "job1"
         pipeline.ingest_file = fake_ingest
 

--- a/test/test_knowledge_ingest_scan_off_loop.py
+++ b/test/test_knowledge_ingest_scan_off_loop.py
@@ -1,0 +1,713 @@
+"""``_ingest_file`` must neither query per file nor await after the commit.
+
+Two defects meet in this one function, and the fix for the first used to create
+the second -- so both are ratcheted here together.
+
+**The query.** The scan used to learn which items a file produced by reading the
+source's entire item-id set BEFORE and AFTER every single file and diffing the two.
+``idx_items_source_id`` keeps each read an index scan rather than a table scan, but
+it still materializes one row per item in the SOURCE -- about 20k rows on a large
+folder source, measured at over a second per call -- twice per file, synchronously
+on the event loop. That trips the loop-stall watchdog, which exits the process; the
+supervisor respawns it, the boot scan re-enters the same reads, and the gateway
+crash-loops. Observed against a 2709-file source: four watchdog exits inside 17
+minutes, with 7-9s of loop lag still reported between them.
+
+**The orphan window.** Merely moving those reads to a worker thread introduces a
+DIFFERENT bug, which is why this file also ratchets awaits. The pipeline commits
+the new items inside its own uncancellable ``run_to_completion`` finalize hop, and
+the caller (``_do_scan``) writes the ``folder_file_state`` row that NAMES them only
+after ``_ingest_file`` returns. Any await between that commit and this function's
+return is therefore a window where a gateway shutdown cancels the coroutine,
+committed items end up named by no state row, and the next scan re-ingests the file
+-- duplicating them while the first group stays untracked and undeletable.
+
+Both are closed by the same change: the pipeline already reports its created ids
+through ``on_committed``, invoked INSIDE the finalize hop that commits them. Taking
+the ids from there means no read to offload and no post-commit await to cancel.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import pathlib
+import sqlite3
+
+import pytest
+
+from kiro_crew.knowledge.folder_watcher import FolderWatcher
+from kiro_crew.knowledge.store import KnowledgeStore
+
+# A nested def / lambda is a separate execution frame -- a sync helper or a thread
+# target -- so a call inside one is not running on the loop.
+_NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+
+_WATCHER_SRC = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "src"
+    / "kiro_crew"
+    / "knowledge"
+    / "folder_watcher.py"
+)
+
+# Names that only ever appear as a synchronous sqlite round-trip.
+_DB_CALLS = {"execute", "executemany", "fetchall", "fetchone", "executescript"}
+
+
+def _direct_calls(body: list[ast.stmt]) -> set[tuple[str, int]]:
+    """Every name called directly in *body*, paired with its line number.
+
+    Nested scopes are skipped: a call inside a nested ``def``/``lambda`` runs in
+    that frame -- a sync helper, or a thread target -- not in the enclosing one.
+    """
+    out: set[tuple[str, int]] = set()
+    stack = list(body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, _NESTED_SCOPES):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        called = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if called:
+            out.add((called, node.lineno))
+    return out
+
+
+def _async_def(tree: ast.Module, name: str) -> ast.AsyncFunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name:
+            return node
+    raise AssertionError(
+        f"async def {name} no longer exists in folder_watcher.py -- this ratchet "
+        "is guarding nothing and must be repointed at whatever replaced it"
+    )
+
+
+def _awaits(fn: ast.AsyncFunctionDef) -> list[tuple[int, str]]:
+    """``(lineno, callee)`` for every await in *fn*'s own frame, in source order."""
+    out: list[tuple[int, str]] = []
+    stack = list(fn.body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, _NESTED_SCOPES):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+        if not isinstance(node, ast.Await):
+            continue
+        value = node.value
+        callee = "<expr>"
+        if isinstance(value, ast.Call):
+            func = value.func
+            callee = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "<expr>")
+        out.append((node.lineno, callee))
+    return sorted(out)
+
+
+def test_ingest_file_issues_no_sqlite_call_on_the_event_loop():
+    """Ratchet: the coroutine body runs no synchronous sqlite round-trip.
+
+    Scoped to this one coroutine on purpose. A repo-wide ban on synchronous
+    ``execute`` would light up hundreds of pre-existing sites and say nothing about
+    this defect; this function is the one that ran a full per-source id read twice
+    for every file in a scan, so it is the one that must stay clean.
+    """
+    tree = ast.parse(_WATCHER_SRC.read_text(errors="replace"))
+    fn = _async_def(tree, "_ingest_file")
+    offenders = sorted(
+        f"folder_watcher.py:{lineno} calls {called}() directly"
+        for called, lineno in _direct_calls(fn.body)
+        if called in _DB_CALLS
+    )
+    assert offenders == [], (
+        "_ingest_file runs sqlite on the event loop at:\n  "
+        + "\n  ".join(offenders)
+        + "\nIt does not need to: the pipeline reports the ids it created through "
+        "the on_committed callback, from inside the finalize hop that commits "
+        "them. Reading them back costs ~20k rows twice per file and, after the "
+        "commit, opens the orphan window the next test guards."
+    )
+
+
+def test_ingest_file_never_awaits_after_the_pipeline_commits():
+    """Ratchet: exactly one await, the pipeline call itself.
+
+    This is the invariant that makes the orphan window unreachable rather than
+    merely unlikely. The caller writes the ``folder_file_state`` row naming the new
+    items only after this function RETURNS, so a second await -- however cheap, and
+    including an ``asyncio.to_thread`` hop added in good faith to get a query off
+    the loop -- lets a shutdown cancel the coroutine after the pipeline has already
+    committed. The items survive, nothing names them, and the next scan re-ingests
+    the file alongside them.
+    """
+    tree = ast.parse(_WATCHER_SRC.read_text(errors="replace"))
+    fn = _async_def(tree, "_ingest_file")
+    awaits = _awaits(fn)
+    rendered = ", ".join(f"line {ln}: await {name}(...)" for ln, name in awaits)
+    assert [name for _, name in awaits] == ["ingest_file"], (
+        f"_ingest_file has awaits other than the pipeline call ({rendered}).\n"
+        "Every await after the pipeline's commit is an orphan window: a shutdown "
+        "cancelling there leaves committed items that no folder_file_state row "
+        "names, so the next scan duplicates them and the first group is "
+        "undeletable. If you need data the pipeline holds, take it through a "
+        "callback that runs inside its finalize hop -- do not read it back."
+    )
+
+
+def test_ingest_file_takes_its_item_ids_from_the_commit_callback():
+    """The ids come from ``on_committed``, not from a read-back.
+
+    Guards the two ratchets above against passing because the bookkeeping was
+    simply deleted: a scan that reports no item ids silently stops attributing
+    items to files, which breaks deletion and re-ingest detection.
+    """
+    source = _WATCHER_SRC.read_text(errors="replace")
+    assert "on_committed=" in source, (
+        "folder_watcher no longer passes on_committed to the pipeline, so it has "
+        "no way to learn which items a file produced"
+    )
+    tree = ast.parse(source)
+    fn = _async_def(tree, "_ingest_file")
+    body = ast.get_source_segment(source, fn) or ""
+    assert (
+        "SELECT id FROM items" not in body
+    ), "_ingest_file still reads the source's item-id set back"
+    assert "on_committed=_record_committed" in body, (
+        "_ingest_file does not hand its own recorder to the pipeline, so the "
+        "committed ids never reach it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ingest_file_reports_the_committed_ids_without_touching_sqlite(tmp_path):
+    """Behavioural: the right ids come back, and the loop's connection stays idle.
+
+    Asserted by tracing the LOOP THREAD's own sqlite connection rather than by
+    patching a method. ``store.db`` is per-thread, so that connection sees a
+    statement only if it was executed on the loop thread -- the exact property
+    under test, and one a lexical check cannot fake.
+    """
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    try:
+        doc = tmp_path / "doc.md"
+        doc.write_text("body", encoding="utf-8")
+        source_id = store.add_source("folder", "local_folder", str(tmp_path))
+        created: list[str] = []
+
+        class _Pipeline:
+            """Stand-in that really inserts, then reports through on_committed."""
+
+            async def ingest_file(
+                self,
+                path,
+                *,
+                source_id,
+                namespace,
+                original_name,
+                old_item_ids,
+                on_committed=None,
+                on_duplicate=None,
+            ):
+                def _insert_and_report() -> None:
+                    # Mirrors the real finalize hop: insert, then hand the ids to
+                    # the callback inside the same uncancellable unit.
+                    created.append(store.add_item("T", "body", "document", source_id=source_id))
+                    if on_committed is not None:
+                        on_committed(list(created))
+
+                await asyncio.to_thread(_insert_and_report)
+                return "job-1"
+
+            def get_job_status(self, job_id):
+                return {"status": "completed"}
+
+        watcher = FolderWatcher(store, _Pipeline())
+
+        # Touch `db` on the loop thread first so the traced connection is the one
+        # the loop would reuse, then record every statement it executes.
+        loop_conn = store.db
+        traced: list[str] = []
+        loop_conn.set_trace_callback(traced.append)
+        try:
+            item_ids, outcome = await watcher._ingest_file(str(doc), source_id, "default", {}, [])
+        finally:
+            loop_conn.set_trace_callback(None)
+
+        assert outcome == "done", (
+            f"the ingest did not take the success path (outcome={outcome!r}), so "
+            "this test would prove nothing about it"
+        )
+        assert created, "the stand-in pipeline inserted nothing"
+        assert item_ids == created, (
+            f"reported {item_ids} but the pipeline created {created} -- the scan "
+            "no longer attributes items to files"
+        )
+
+        on_loop = [s for s in traced if "FROM items" in s or "sync_status" in s]
+        assert on_loop == [], (
+            "these ingest queries ran on the event-loop thread's connection:\n  "
+            + "\n  ".join(on_loop)
+            + "\nOn a real source each is ~20k rows, per file; on the loop they "
+            "trip the stall watchdog and crash-loop the gateway."
+        )
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_ingest_file_reports_failure_when_the_pipeline_never_commits(tmp_path):
+    """A silent rollback is still detected, without reading ``sync_status``.
+
+    The pipeline invokes ``on_committed`` only on the branch that actually commits
+    a group, so an unset callback IS the rollback signal. Losing this would make a
+    partial failure look like a successful ingest that produced no items: the file
+    would be recorded ``done`` and never retried.
+    """
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    try:
+        doc = tmp_path / "doc.md"
+        doc.write_text("body", encoding="utf-8")
+        source_id = store.add_source("folder", "local_folder", str(tmp_path))
+
+        class _RollingBackPipeline:
+            async def ingest_file(
+                self,
+                path,
+                *,
+                source_id,
+                namespace,
+                original_name,
+                old_item_ids,
+                on_committed=None,
+                on_duplicate=None,
+            ):
+                # Rolls back internally and does NOT raise -- exactly the shape
+                # the old sync_status read existed to catch.
+                return "job-1"
+
+            def get_job_status(self, job_id):
+                return {"status": "error"}
+
+        watcher = FolderWatcher(store, _RollingBackPipeline())
+        item_ids, outcome = await watcher._ingest_file(str(doc), source_id, "default", {}, [])
+
+        assert outcome == "failed", (
+            f"a silent rollback was reported as {outcome!r}; the file would be "
+            "recorded terminal and never retried"
+        )
+        assert item_ids is None, f"a failed ingest reported item ids: {item_ids!r}"
+        row = store.db.execute(
+            "SELECT status, error_message FROM folder_file_state "
+            "WHERE source_id = ? AND file_path = ?",
+            (source_id, str(doc)),
+        ).fetchone()
+        assert (
+            row is not None and row["status"] == "failed"
+        ), f"no 'failed' state row was written for the rollback (row={row and dict(row)})"
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_ingest_file_still_reports_a_refused_duplicate_as_deduped(tmp_path):
+    """The duplicate branch is unaffected by sourcing ids from the callback.
+
+    The pre-ingest gate refuses the write and never commits a group, so
+    ``on_committed`` does not fire there either -- the same condition as a
+    rollback. The duplicate check must therefore keep winning, or a legitimately
+    refused file would be recorded ``failed`` and retried on every scan.
+    """
+    from kiro_crew.knowledge.ingestion import DUPLICATE_JOB_STATUS
+
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    try:
+        doc = tmp_path / "doc.md"
+        doc.write_text("body", encoding="utf-8")
+        source_id = store.add_source("folder", "local_folder", str(tmp_path))
+
+        class _RefusingPipeline:
+            async def ingest_file(
+                self,
+                path,
+                *,
+                source_id,
+                namespace,
+                original_name,
+                old_item_ids,
+                on_committed=None,
+                on_duplicate=None,
+            ):
+                return "job-dupe"
+
+            def get_job_status(self, job_id):
+                return {"status": DUPLICATE_JOB_STATUS}
+
+        watcher = FolderWatcher(store, _RefusingPipeline())
+        item_ids, outcome = await watcher._ingest_file(str(doc), source_id, "default", {}, [])
+
+        assert outcome == "deduped", (
+            f"a refused duplicate was reported as {outcome!r} -- 'failed' would "
+            "make every scan retry a write the gate will refuse again"
+        )
+        assert item_ids == [], f"a deduped file claimed ownership of {item_ids!r}"
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_ingest_file_lets_cancellation_through_without_a_failed_state_row(tmp_path):
+    """A cancelled ingest must not be recorded as an ingest failure.
+
+    ``CancelledError`` is a ``BaseException``, so the function's ``except
+    Exception`` does not catch it and the file keeps its retryable ``scanning``
+    marker. Widening that handler would write a terminal ``failed`` row on every
+    gateway shutdown, and the next scan would skip a file that was never broken.
+    """
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    try:
+        doc = tmp_path / "doc.md"
+        doc.write_text("body", encoding="utf-8")
+        source_id = store.add_source("folder", "local_folder", str(tmp_path))
+        started = asyncio.Event()
+
+        class _HangingPipeline:
+            async def ingest_file(self, path, **kwargs):
+                started.set()
+                await asyncio.Event().wait()  # never completes
+
+            def get_job_status(self, job_id):  # pragma: no cover - not reached
+                return {}
+
+        watcher = FolderWatcher(store, _HangingPipeline())
+        task = asyncio.ensure_future(watcher._ingest_file(str(doc), source_id, "default", {}, []))
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        row = store.db.execute(
+            "SELECT status FROM folder_file_state WHERE source_id = ? " "AND file_path = ?",
+            (source_id, str(doc)),
+        ).fetchone()
+        assert row is None or row["status"] != "failed", (
+            "a cancellation was recorded as a terminal 'failed' state row; a "
+            "shutdown mid-scan would make the next scan skip a healthy file"
+        )
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_commit_callback_persists_the_state_row_before_returning(tmp_path):
+    """The committed group reaches the state row INSIDE the callback.
+
+    Capturing the ids in memory is not enough: the pipeline awaits again after
+    its finalize hop (``generate_source_summary``), so a shutdown cancelling
+    there strands a committed group the caller never gets to record -- the
+    'scanning' marker survives and the next sweep re-ingests the file alongside
+    the untracked first group. This asserts the row is already terminal, and
+    names the group, at the moment ``on_committed`` returns -- observed from
+    inside the stand-in pipeline, before ``_ingest_file`` has a chance to run
+    any code after its await.
+    """
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    try:
+        doc = tmp_path / "doc.md"
+        doc.write_text("body", encoding="utf-8")
+        source_id = store.add_source("folder", "local_folder", str(tmp_path))
+        seen_inside: dict = {}
+
+        class _Pipeline:
+            """Really inserts, fires the callback, then reads the row back --
+            all inside the same worker hop, mirroring the real finalize."""
+
+            async def ingest_file(
+                self,
+                path,
+                *,
+                source_id,
+                namespace,
+                original_name,
+                old_item_ids,
+                on_committed=None,
+                on_duplicate=None,
+            ):
+                def _insert_report_and_observe() -> None:
+                    item_id = store.add_item("T", "body", "document", source_id=source_id)
+                    if on_committed is not None:
+                        on_committed([item_id])
+                    row = store.db.execute(
+                        "SELECT item_ids, status FROM folder_file_state "
+                        "WHERE source_id = ? AND file_path = ?",
+                        (source_id, str(doc)),
+                    ).fetchone()
+                    seen_inside["row"] = dict(row) if row else None
+                    seen_inside["item_id"] = item_id
+
+                await asyncio.to_thread(_insert_report_and_observe)
+                return "job-1"
+
+            def get_job_status(self, job_id):
+                return {"status": "completed"}
+
+        watcher = FolderWatcher(store, _Pipeline())
+        # The scan always writes a 'scanning' marker before invoking
+        # _ingest_file; the callback's targeted UPDATE lands on that row.
+        watcher._update_state(
+            source_id, str(doc), "hash", 1.0, "[]", "2026-01-01T00:00:00", "scanning", attempts=1
+        )
+
+        item_ids, outcome = await watcher._ingest_file(str(doc), source_id, "default", {}, [])
+
+        assert outcome == "done" and item_ids == [seen_inside["item_id"]]
+        row = seen_inside["row"]
+        assert row is not None, "no state row existed when the commit callback returned"
+        assert row["status"] == "done", (
+            f"the callback left status={row['status']!r}; a cancellation landing "
+            "after the finalize hop would leave the 'scanning' marker in place "
+            "and the next sweep would re-ingest the file alongside the "
+            "committed group"
+        )
+        assert json.loads(row["item_ids"] or "[]") == [seen_inside["item_id"]], (
+            f"the callback persisted {row['item_ids']} instead of the committed "
+            "group -- the items would be unreachable by the deleted-file path"
+        )
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_callback_persistence_does_not_poison_the_ingest(tmp_path):
+    """The callback's state write is a durability upgrade, never a precondition.
+
+    It runs inside the pipeline's finalize hop, AFTER the group has committed
+    and the superseded items are deleted. If a writer-lock timeout (a large
+    concurrent import_bundle) made it raise, the exception would poison that
+    hop: the pipeline reports the whole ingest failed, the caller writes a
+    terminal 'failed' row, and the next sweep re-ingests alongside the
+    committed group -- exactly the duplication the write exists to prevent. So
+    a failed write must be swallowed: the ids still travel through memory and
+    the caller's own 'done' write persists them on the uncancelled path.
+    """
+
+    class _LockedConn:
+        """Real connection, except folder_file_state writes hit a locked DB."""
+
+        def __init__(self, real):
+            self._real = real
+
+        def execute(self, sql, *args):
+            if sql.lstrip().startswith("UPDATE folder_file_state"):
+                raise sqlite3.OperationalError("database is locked")
+            return self._real.execute(sql, *args)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    class _Store:
+        def __init__(self, real):
+            self._real = real
+
+        @property
+        def db(self):
+            return _LockedConn(self._real.db)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    try:
+        doc = tmp_path / "doc.md"
+        doc.write_text("body", encoding="utf-8")
+        source_id = store.add_source("folder", "local_folder", str(tmp_path))
+        created: list[str] = []
+
+        class _Pipeline:
+            async def ingest_file(
+                self,
+                path,
+                *,
+                source_id,
+                namespace,
+                original_name,
+                old_item_ids,
+                on_committed=None,
+                on_duplicate=None,
+            ):
+                def _insert_and_report() -> None:
+                    created.append(store.add_item("T", "body", "document", source_id=source_id))
+                    if on_committed is not None:
+                        # Must not raise: a raise here poisons the finalize
+                        # hop after the commit (see docstring).
+                        on_committed(list(created))
+
+                await asyncio.to_thread(_insert_and_report)
+                return "job-1"
+
+            def get_job_status(self, job_id):
+                return {"status": "completed"}
+
+        watcher = FolderWatcher(_Store(store), _Pipeline())
+        item_ids, outcome = await watcher._ingest_file(str(doc), source_id, "default", {}, [])
+
+        assert outcome == "done", (
+            f"a failed best-effort persistence turned the ingest into "
+            f"{outcome!r}; the committed group would be rolled up as a partial "
+            "failure and re-ingested (duplicated) by the next sweep"
+        )
+        assert item_ids == created, (
+            "the in-memory path must still deliver the committed ids when the "
+            "durability write fails"
+        )
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_scan_records_the_committed_group_on_the_state_row(tmp_path):
+    """End to end: the ids the pipeline committed are what the state row names.
+
+    The unit tests above assert the value ``_ingest_file`` returns; this asserts
+    the value the SCAN persists, which is what the deleted-file path and re-ingest
+    detection actually read. A callback wired up but dropped on the way out would
+    pass every test above and still strand every ingested file.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from kiro_crew.knowledge.ingestion import IngestionPipeline
+
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    try:
+        folder = tmp_path / "folder"
+        folder.mkdir()
+        (folder / "doc.md").write_text("some body", encoding="utf-8")
+
+        extractor = MagicMock()
+        extractor._pool = None
+        extractor.extract_batch = AsyncMock(
+            return_value=[{"category": "document", "summary": "s", "entities": []}]
+        )
+        chunker = MagicMock()
+        # A .md file dispatches to chunk_markdown (see _run_chunker); a bare
+        # MagicMock would answer it with len()==0 and the scan would commit an
+        # empty group, passing this test vacuously in the other direction.
+        _one_chunk = lambda text, **kw: [  # noqa: E731
+            {
+                "content": text,
+                "chunk_index": 0,
+                "section_title": None,
+                "line_start": 0,
+                "line_end": 0,
+            }
+        ]
+        chunker.chunk.side_effect = _one_chunk
+        chunker.chunk_markdown.side_effect = _one_chunk
+        reader = MagicMock()
+        reader.read.return_value = ("some body", {})
+        pipeline = IngestionPipeline(
+            store=store, extractor=extractor, chunker=chunker, reader=reader, embedder=None
+        )
+
+        source_id = store.add_source("folder", "local_folder", str(folder))
+        watcher = FolderWatcher(store, pipeline)
+        await watcher.scan_source(
+            {"id": source_id, "uri": str(folder), "source_type": "local_folder", "properties": "{}"}
+        )
+
+        owned = sorted(
+            r["id"]
+            for r in store.db.execute(
+                "SELECT id FROM items WHERE source_id = ?", (source_id,)
+            ).fetchall()
+        )
+        assert owned, (
+            "the scan ingested nothing, so there is no group to name and this "
+            "test would pass vacuously"
+        )
+        row = store.db.execute(
+            "SELECT item_ids, status FROM folder_file_state WHERE source_id = ?", (source_id,)
+        ).fetchone()
+        assert row is not None, "the scan recorded no state row for the file"
+        assert sorted(json.loads(row["item_ids"] or "[]")) == owned, (
+            f"the state row names {row['item_ids']} but the source owns {owned} -- "
+            "the committed group was not carried out of the callback, so those "
+            "items are unreachable by the deleted-file path "
+            f"(status={row['status']!r})"
+        )
+    finally:
+        store.close()
+
+
+def test_await_ratchet_would_catch_a_reintroduced_post_commit_hop():
+    """Negative control: the await detector fires on the shape just removed.
+
+    Without this, a detector bug that reports nothing would make the ratchet pass
+    forever. Feeds it the exact code the GPT reviewer flagged.
+    """
+    pre_fix = ast.parse(
+        "class W:\n"
+        "    async def _ingest_file(self):\n"
+        "        job = await self.pipeline.ingest_file(p)\n"
+        "        if await asyncio.to_thread(_sync_status) == 'error':\n"
+        "            return None, 'failed'\n"
+        "        after = await asyncio.to_thread(_owned_item_ids)\n"
+        "        return after, 'done'\n"
+    )
+    names = [name for _, name in _awaits(_async_def(pre_fix, "_ingest_file"))]
+    assert names.count("to_thread") == 2, f"the detector missed the post-commit hops (saw {names})"
+
+
+def test_await_ratchet_ignores_awaits_inside_nested_helpers():
+    """Negative control: an await in a nested frame is not this frame's await.
+
+    A detector that flagged those would make the correct shape unlandable and push
+    the next author back onto the loop.
+    """
+    post_fix = ast.parse(
+        "class W:\n"
+        "    async def _ingest_file(self):\n"
+        "        async def _later():\n"
+        "            return await asyncio.sleep(0)\n"
+        "        return await self.pipeline.ingest_file(p)\n"
+    )
+    names = [name for _, name in _awaits(_async_def(post_fix, "_ingest_file"))]
+    assert names == [
+        "ingest_file"
+    ], f"the detector counted a nested frame's await as this frame's: {names}"
+
+
+def test_db_ratchet_would_catch_a_reintroduced_on_loop_query():
+    """Negative control for the sqlite detector, on the original pre-fix shape."""
+    pre_fix = ast.parse(
+        "class W:\n"
+        "    async def _ingest_file(self):\n"
+        "        before = {r['id'] for r in self.store.db.execute(\n"
+        "            'SELECT id FROM items WHERE source_id = ?', (1,)).fetchall()}\n"
+        "        return before\n"
+    )
+    fn = _async_def(pre_fix, "_ingest_file")
+    hits = {called for called, _ in _direct_calls(fn.body) if called in _DB_CALLS}
+    assert {
+        "execute",
+        "fetchall",
+    } <= hits, f"the detector missed part of the pre-fix shape (found {sorted(hits)})"
+
+
+def test_db_ratchet_ignores_queries_inside_nested_helpers():
+    """Negative control: a query in a nested sync helper is a thread target."""
+    nested = ast.parse(
+        "class W:\n"
+        "    async def _ingest_file(self):\n"
+        "        def _ids():\n"
+        "            return self.store.db.execute('SELECT 1').fetchall()\n"
+        "        return _ids\n"
+    )
+    fn = _async_def(nested, "_ingest_file")
+    hits = {called for called, _ in _direct_calls(fn.body) if called in _DB_CALLS}
+    assert (
+        hits == set()
+    ), f"the detector flagged a query that lives in a nested helper: {sorted(hits)}"


### PR DESCRIPTION
## Problem

A folder source large enough to matter crash-loops the gateway. On a 2709-file
source this reproduced as **four loop-stall watchdog exits inside 17 minutes**,
with the surviving process still reporting 7-9s of event-loop lag between them:

```
13:39:05 folder_watcher: Source 80b88169-…: capped at 2000 files (709 skipped)
13:44:22 event-loop heartbeat: lag 9.1s (loop was blocked)
13:45:55 event-loop heartbeat: lag 9.2s (loop was blocked)
```

Dumps land in `~/.kiro/crew/logs/crash-dumps/loopstall-*.txt`; the last one in a
loop is usually truncated because the watchdog loses the race to the supervisor's
kill.

## Why it matters

Every exit takes the whole gateway with it — live chat sessions, crons and
channels all die — and the respawned process re-enters the identical boot scan,
so the loop is self-sustaining rather than self-healing. Anyone whose Knowledge
Library holds one large folder source is affected, and the auto-registered
project-docs source made that the default rather than the exception.

## Fix (symptoms → root cause → change)

`_ingest_file` learned which items a file produced by reading the source's
**entire item-id set before and after** handing the file to the pipeline, and
diffing the two. Both reads ran synchronously on the event loop.

`idx_items_source_id` keeps each read an index scan, so this is not a
missing-index bug. The cost is *result size*: one row per item in the **source**
— ~20k rows on a large source, measured at >1s per call — twice for every file in
the scan. That is well past the watchdog's budget.

Neither read is necessary. The pipeline already reports the ids it created
through its `on_committed` callback, which it invokes **inside** its own
`run_to_completion` finalize hop (`ingestion.py`) — the same uncancellable unit
that commits them. Passing a recorder there removes both reads outright, and
removes the `sources.sync_status` read as well: `on_committed` fires only on the
branch that actually commits a group, so an unset recorder *is* the
silent-rollback signal — evaluated per call, rather than reading a column a
concurrent ingest on the same source can flip.

### Why eliminate rather than offload

The first revision of this PR moved the reads to a worker thread with
`asyncio.to_thread`. The GPT reviewer correctly blocked that on SHA `307263fac`,
and the finding was legitimate: offloading adds `await` points **after** the
pipeline commits, and the caller (`_do_scan`) writes the `folder_file_state` row
that NAMES the new items only once `_ingest_file` returns. A shutdown cancelling
at such an await leaves committed items that no state row names — the next scan
re-ingests the file and duplicates them, while the first group stays untracked
and undeletable.

Sourcing the ids from the callback means there is no post-commit await to cancel.
The cost problem and the atomicity problem are closed by the same change instead
of being traded against each other.

### The callback also persists, fail-safe

Capturing the ids in memory alone left one window open: the pipeline awaits
again **after** its finalize hop (`generate_source_summary`), and the caller's
state write only runs once `_ingest_file` returns. A shutdown cancelling in that
gap strands a committed group nothing names. So the recorder also writes the
`folder_file_state` row from inside the finalize hop itself — a targeted UPDATE
onto the `scanning` marker the scan wrote before the call (committed ids,
terminal `done`, derived `text_hash`, cleared retry budget). The caller's own
`done` write still lands with the same values on the uncancelled path, so the
two writers are order-independent; the caller's `_write_state_row` remains the
authoritative spelling and the callback's UPDATE must stay field-consistent
with it (`attempts=0`, `error_message=NULL`, `text_hash` derivation).

The write is **fail-safe, never fail-closed**: it runs after the group has
committed and the superseded items are deleted, so an escaping exception there
(writer-lock contention past `busy_timeout`, e.g. a large concurrent
`import_bundle`) would poison the finalize hop and convert a successful ingest
into a terminal `failed` row — causing the exact duplication it exists to
prevent. Errors are swallowed and logged; the memory path and the caller's
write still stand, and the exposure shrinks back to the cancellation window,
never past pre-fix behavior.

### Why this wasn't already fixed

This is the site that **survived** #2175, #2336 and #2507. Each of those moved a
*different* call off the loop — `dedup_document`, `delete_items_batch`, the
duplicate-skip gate — and none touched this one, which is why crash loops kept
being reported on builds carrying all three.

## Tests

`test/test_knowledge_ingest_scan_off_loop.py`, following the two-kinds shape of
the existing `test_knowledge_delete_off_loop.py`. Both invariants are ratcheted,
because the fix for the first defect is what created the second:

| Test | Locks in |
|---|---|
| `test_ingest_file_issues_no_sqlite_call_on_the_event_loop` | AST ratchet: no `execute`/`fetchall`/`fetchone` called directly from the coroutine body (nested scopes excluded — those are thread targets) |
| `test_ingest_file_never_awaits_after_the_pipeline_commits` | AST ratchet: **exactly one await**, the pipeline call. This is what makes the orphan window unreachable rather than merely absent — it fails on any future `to_thread` hop added in good faith to get a query off the loop |
| `test_ingest_file_takes_its_item_ids_from_the_commit_callback` | Guards both ratchets against passing because the bookkeeping was *deleted* rather than rewired |
| `test_ingest_file_reports_the_committed_ids_without_touching_sqlite` | Behavioural, not lexical: traces the **loop thread's own** sqlite connection via `set_trace_callback` (`store.db` is per-thread), and asserts the reported ids equal what the pipeline created |
| `test_ingest_file_reports_failure_when_the_pipeline_never_commits` | A silent rollback is still detected without reading `sync_status`; losing this would record a partial failure as `done` and never retry it |
| `test_ingest_file_still_reports_a_refused_duplicate_as_deduped` | The dedupe branch must keep winning over the rollback branch — both leave `on_committed` unfired |
| `test_ingest_file_lets_cancellation_through_without_a_failed_state_row` | `CancelledError` is a `BaseException`, so a shutdown keeps the retryable `scanning` marker instead of a terminal `failed` row |
| `test_commit_callback_persists_the_state_row_before_returning` | The committed group reaches the state row **inside** the callback, observed from the stand-in pipeline's worker hop — before `_ingest_file` can run any post-await code |
| `test_a_failed_callback_persistence_does_not_poison_the_ingest` | A locked-DB UPDATE inside the callback is swallowed: the ingest still returns `(ids, 'done')` through the memory path instead of rolling a committed group up as a partial failure |
| `test_scan_records_the_committed_group_on_the_state_row` | End to end through `scan_source`: a callback wired up but dropped on the way out would satisfy every unit assertion above and still strand every file |
| 4 negative controls | Each ratchet fires on the pre-fix shape **and** ignores nested-frame awaits/queries — so neither can pass vacuously, and neither can push the next author back onto the loop |

## Manual verification

Static gates run locally on the rebased tree: `flake8` and `isort --check-only`
clean; `mypy` reports nothing in `folder_watcher.py` (the 3 `hooks.py` xattr
errors are pre-existing on `main` and Linux-only). AST invariants confirmed
directly against the file: zero sqlite calls in the coroutine body, one await
(`ingest_file`).

**The suite itself was deliberately not run locally by the original author** (see rationale below); the drive-to-green pass later ran the full suite on a separate host: 56623 passed, 0 failed.

Original rationale: A local `pytest -n auto`
on this host saturates the CPU and starves the very gateway event loop this PR is
about, which is one of the documented ways it gets killed. CI is the gate for the
tests — and the previous revision's run confirms the shape works there: all four
`Backend Tests (3.12, N)` shards passed, 53 lanes green, with GPT the only real
failure.

Runtime confirmation is left to CI plus observation: the reproducing condition is
a >2000-file source, and the observable is the absence of new `loopstall-*.txt`
dumps across a boot scan.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change under `src/kiro_crew/knowledge/`; no
frontend path is touched and nothing renders differently.

no issue closed: the crash loop was diagnosed from local gateway logs across
several sessions and never filed as a tracked issue.

