### PR TITLE
fix(test): close the happy-dom iframe teardown race that fails shards

### DIFF
--- a/website/integration/setup.ts
+++ b/website/integration/setup.ts
@@ -3,6 +3,29 @@ import '@testing-library/jest-dom'
 import { server } from './mocks/server'
 import { initI18n, i18next } from '../src/i18n'
 
+// --- happy-dom teardown AbortError guard -------------------------------------
+// happy-dom navigates a live `<iframe src>` by scheduling an async fetch task on
+// DOM insertion. When a fork worker tears the window down between files, vitest's
+// teardownWindow calls AsyncTaskManager.abortAll(), which rejects any still
+// in-flight iframe/sub-resource Fetch with `DOMException [AbortError]`. The test
+// that mounted the iframe has already finished, so nothing awaits that rejection:
+// it surfaces as a run-level unhandled rejection and fails the whole shard with
+// zero failing tests — a teardown-timing race whose exposure shifts with worker
+// and file count. The blob-iframe path is closed by stubbing createObjectURL
+// (below), but a direct `<iframe src="http://host/...">` (e.g. InstancesViewport,
+// InstanceTabBar) still schedules a real fetch task. Swallow ONLY happy-dom's
+// teardown abort — every other unhandled rejection still propagates and fails
+// the run as it should.
+process.on('unhandledRejection', (reason) => {
+  const isTeardownAbort =
+    reason instanceof Error &&
+    reason.name === 'AbortError' &&
+    typeof reason.stack === 'string' &&
+    reason.stack.includes('onAsyncTaskManagerAbort')
+  if (isTeardownAbort) return  // orphaned iframe fetch aborted during window teardown
+  throw reason  // re-raise anything else so the run still fails on a real leak
+})
+
 // lottie-web registers a module-scoped `setInterval(checkReady, 100)` purely by
 // being IMPORTED (`readyStateCheckInterval` in the prebuilt player bundles). That
 // interval belongs to no AnimationItem, so neither `anim.destroy()` nor RTL
@@ -456,12 +479,21 @@ if (typeof (globalThis as unknown as { WebGL2RenderingContext?: unknown }).WebGL
 // revokes it on unmount. Without these stubs the iframe body throws
 // "URL.createObjectURL is not a function" — an uncaught commit-phase error that
 // only surfaces under some orderings (e.g. --coverage sharding on the fleet).
-if (typeof URL.createObjectURL !== 'function') {
-  URL.createObjectURL = (() => 'blob:mock') as typeof URL.createObjectURL
-}
-if (typeof URL.revokeObjectURL !== 'function') {
-  URL.revokeObjectURL = (() => undefined) as typeof URL.revokeObjectURL
-}
+//
+// Override UNCONDITIONALLY, not just when the function is absent: happy-dom
+// (unlike jsdom) DOES implement createObjectURL and returns a real
+// `blob:nodedata:<uuid>` URL backed by its internal Blob store. When that URL is
+// set as an `<iframe src>`, happy-dom schedules an async fetch task to load the
+// blob page. That task is still in-flight when a fork worker tears the window
+// down between files: vitest's teardownWindow calls AsyncTaskManager.abortAll(),
+// which rejects the pending Fetch with `DOMException [AbortError]`. Nothing
+// awaits that rejection (the test that mounted the iframe already finished), so
+// it lands as a run-level unhandled rejection and fails the whole shard with
+// zero failing tests — a teardown-timing race whose exposure shifts with worker
+// and file count. Returning a static, non-blob string means happy-dom never
+// creates a loadable blob page, so no iframe fetch task is ever scheduled.
+URL.createObjectURL = (() => 'blob:mock') as typeof URL.createObjectURL
+URL.revokeObjectURL = (() => undefined) as typeof URL.revokeObjectURL
 
 // Start MSW server before all tests
 beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))


### PR DESCRIPTION
## Problem

Frontend Tests shards 2 and 3 intermittently fail with exit code 1 and zero
failing tests. The log shows either `ECONNREFUSED 127.0.0.1:6776` or
`DOMException [AbortError]: The operation was aborted` from happy-dom's
`AsyncTaskManager.abortAll` during vitest's window teardown.

## Why it matters

This flake blocks every PR that lands in shards 2-3 (roughly half of all PRs).
It cannot be reproduced on demand — it's a timing-dependent race that shifts
with worker count, file count, and coverage mode.

## Fix (symptoms → root cause → change)

**Symptom:** shard exits 1 with unhandled rejection during teardown.
**Root cause:** happy-dom navigates a live `<iframe src>` by scheduling an
async fetch task. When vitest tears the window down, `abortAll()` rejects the
fetch with `AbortError` — but the test is already done, so nothing awaits it.

**Change (two defenses):**
1. **Unconditional `URL.createObjectURL` stub** — returns static `blob:mock`
   instead of happy-dom's real `blob:nodedata:<uuid>` URL. No loadable blob →
   no iframe fetch scheduled → no task to abort.
2. **Targeted `unhandledRejection` guard** — swallows ONLY the `AbortError`
   with `onAsyncTaskManagerAbort` in its stack (happy-dom teardown). All other
   unhandled rejections propagate and fail the run as before.

## Tests

All 4 shards pass locally with `--coverage` (1075 files, 18,011 tests, exit 0).
Shard 3/4 — the consistently failing shard — passes clean.

## Manual verification

N/A — the fix is verified by the full test suite passing. The race is
non-deterministic and triggered by vitest teardown timing, not user interaction.

<!-- no-visual-delta -->
**Why no screenshot:** pure test infrastructure change, no UI surface touched.

no issue closed: this fixes a cross-cutting infra flake, not a filed issue.