### PR TITLE
test: stabilize flaky Scroll to Latest pill assertion (#3288)

### DIFF
--- a/website/docs/testing.md
+++ b/website/docs/testing.md
@@ -135,11 +135,20 @@ the state just reads as "already correct" and the branch under test never runs:
 ```tsx
 // WRONG: the panel re-pins the scroller on 50/150/300ms timers after history
 // lands. Once one has fired, this scroll reads as "already at the bottom" and the
-// pill never renders — a 1000ms `findByRole` timeout with no hint why.
+// pill never renders — a `findByRole` timeout with no hint why.
 fireEvent.scroll(scroller)
 
-// RIGHT: park it where the test needs it, so the event means one thing.
+// STILL WRONG: a plain write is itself racing the same timers — one that runs
+// after it puts the value right back.
 scroller.scrollTop = 0
+fireEvent.scroll(scroller)
+
+// RIGHT: park it with an own accessor, so every read reports the parked value
+// and the component's own writes are swallowed. The setter must exist: a
+// getter-only property makes the component's strict-mode write throw instead.
+Object.defineProperty(scroller, 'scrollTop', {
+  configurable: true, get: () => 500, set: () => {},
+})
 fireEvent.scroll(scroller)
 ```
 

--- a/website/src/test/MochiChatPanelCoverage.test.tsx
+++ b/website/src/test/MochiChatPanelCoverage.test.tsx
@@ -284,14 +284,28 @@ describe('ChatPanel scroll position pill', () => {
 
     expect(screen.queryByRole('button', { name: 'Scroll to Latest' })).not.toBeInTheDocument()
     // The panel re-pins the scroller to the end on 50/150/300ms timers once the
-    // history lands, so the initial `scrollTop` of 0 is not a state this test can
-    // rely on: whichever timer has already run leaves the scroller AT the bottom,
-    // the scroll below reads as "still at the latest turn" and the pill never
-    // renders. Park the scroller away from the end explicitly, so the reported
-    // scroll means the same thing regardless of which timers have fired.
-    scroller.scrollTop = 0
+    // history lands, so a plain `scrollTop` write is not a state this test can
+    // rely on: a timer that runs after the write puts the scroller back AT the
+    // bottom, the scroll below reads as "still at the latest turn" and the pill
+    // never renders. Park the scroller away from the end with an own accessor —
+    // the getter pins the reported position mid-scroll and the setter swallows
+    // the panel's re-pin writes (a plain no-setter property would make those
+    // strict-mode writes throw inside the panel's timers). The element is
+    // per-test, so the override dies with it and needs no restore.
+    Object.defineProperty(scroller, 'scrollTop', {
+      configurable: true,
+      get: () => 500,
+      set: () => {},
+    })
     fireEvent.scroll(scroller)
-    const pill = await screen.findByRole('button', { name: 'Scroll to Latest' })
+    // React handles scroll at continuous (non-sync) priority, so the pill's
+    // commit is scheduled rather than flushed inside `fireEvent`. On a loaded
+    // CI runner that scheduling can outlive the default 1s query budget; give
+    // the appearance the same generous ceiling the file's other timing-driven
+    // assertions use.
+    const pill = await screen.findByRole(
+      'button', { name: 'Scroll to Latest' }, { timeout: 5000 },
+    )
 
     // The pill dims under the pointer, which is how it reads as pressable.
     await userEvent.hover(pill)


### PR DESCRIPTION
## Problem

`MochiChatPanelCoverage.test.tsx` → *"offers a way back to the latest turn once the user scrolls away from it"* fails intermittently in CI's Frontend Tests shard 2 (`Unable to find role="button" and name "Scroll to Latest"`), hitting PRs that touch no chat code (runs 31694293073, 31700487886, 31734370604). It does not reproduce locally, including under the same shard split, coverage, 2-core pinning, and background CPU load.

## Why it matters

Unrelated PRs go red, and the failing shard's own log names no test (only the coverage-merge job prints the failure), so each occurrence costs a manual dig through the merge job's aggregated output.

## Fix (symptoms → root cause → change)

The failure DOM dump shows the pill never mounted and no activity guard (stop capsule) was rendered, so `isAtBottom` stayed `true` for the query's full budget. Two race legs, both closed:

1. **The parked scroll position is not stable.** The test parked the scroller with a plain `scroller.scrollTop = 0` write, but the panel re-pins the scroller to the end on 50/150/300ms timers after history lands (`scrollToEnd`: `el.scrollTop = el.scrollHeight`). happy-dom persists assignments (probed: values round-trip, no scroll events fire), so a timer that runs after the test's write puts the position right back at the bottom — the plain write *is itself racing the timers it was added to defeat*. The fix parks the position with an own accessor property: the getter pins `scrollTop` at 500 on every read (`1000 − 500 − 0 ≥ 150` → not at bottom, deterministically), and the no-op setter swallows the panel's re-pin writes. The setter must exist — a getter-only property would make the panel's strict-mode timer writes throw. The override is on a per-test element, so nothing outlives the test.
2. **The query budget races React's scheduling.** React handles `scroll` at continuous (non-sync) priority, so the pill's commit is scheduled rather than flushed inside `fireEvent`; on a loaded 4-shard runner that scheduling can outlive `findByRole`'s default 1000ms budget. The assertion now polls with the same 5000ms ceiling the file's other timing-driven assertions use — per the repo's determinism conventions this is the sanctioned shape (poll for the condition with a generous deadline), not a lengthened sleep, and it stays under the 15s test timeout.

`website/docs/testing.md` presented the plain-write park as the RIGHT pattern, in a snippet describing this exact panel and symptom; it now teaches the accessor park and marks the plain write as still racing (docs updated in the same commit per repo convention).

## Tests

The change is itself a test-determinism fix; the assertion is strictly stronger (same condition, pinned precondition, larger polling deadline — it still fails if the pill logic breaks, verified by the unchanged negative assertion before the scroll and the unchanged hover/click behavior assertions after it). Full file passes 39/39 across repeated runs including 2-core + coverage + background-load stress.

## Manual verification

N/A — unit coverage sufficient: the flake does not reproduce locally under any attempted amplification (12 isolated runs, 6 full-file coverage runs under CPU starvation), so CI shard 2 over the coming runs is the real signal.

## Screenshots

N/A — test-only + docs change, no UI surface touched.

Closes #3288
