### PR TITLE
fix(dashboard): make voice auto-speak independent of the enabled switch

### DIFF
--- a/docs/system-specs/features/voice-streaming.md
+++ b/docs/system-specs/features/voice-streaming.md
@@ -64,7 +64,8 @@ Stored in `~/.kiro/crew/config.json` under `voice_reply`:
 | `engine` | generative | generative, neural, long-form, standard (Polly only) |
 | `rate` | 100% | 50%–200% (Polly only) |
 | `pitch` | +0% | -20% to +20% (Polly only) |
-| `enabled` | true | Controls auto-speak and Slack voice replies |
+| `enabled` | true | Primary voice switch; gates Slack voice replies. Independent of `auto_speak` |
+| `auto_speak` | false | Dashboard auto-speak: speak each assistant reply automatically. Independent of `enabled` — the manual 🔊 Speak button works regardless of either flag |
 | `aws_profile` | _(empty)_ | AWS CLI profile name for Polly calls. Empty = use default credentials |
 | `region` | _(empty)_ | AWS region for Polly. Empty = use CLI default |
 | `piper_model` | _(empty)_ | Path to a Piper `.onnx` voice model. Required for Piper |
@@ -113,7 +114,7 @@ instruction for two of the three kinds.
 
 ### API
 
-- `GET /api/voice/config` — returns current settings + `autoSpeak` flag
+- `GET /api/voice/config` — returns current settings + `autoSpeak` flag (mirrors `auto_speak`, not `enabled`)
 - `PUT /api/voice/config` — update settings (partial patch), persists to config.json
 - `POST /api/voice/synthesize` — `{ slot, text, voice?, engine?, rate?, pitch? }`
 - `GET /api/voice/voices` — list available Polly voices via `aws polly

--- a/src/kiro_crew/dashboard/chat_voice.py
+++ b/src/kiro_crew/dashboard/chat_voice.py
@@ -50,7 +50,7 @@ async def api_voice_config(request: web.Request) -> web.Response:
                 "engine": _vc.default_engine,
                 "rate": _vc.default_rate,
                 "pitch": _vc.default_pitch,
-                "autoSpeak": _vc.global_enabled,
+                "autoSpeak": _vc.auto_speak,
                 "aws_profile": _vc.aws_profile,
                 "region": _vc.region,
                 "piper_binary": _vc.piper_binary,
@@ -84,7 +84,7 @@ async def api_voice_config(request: web.Request) -> web.Response:
     if "enabled" in body:
         _vc.global_enabled = bool(body["enabled"])
     if "autoSpeak" in body:
-        _vc.global_enabled = bool(body["autoSpeak"])
+        _vc.auto_speak = bool(body["autoSpeak"])
     if "aws_profile" in body:
         _vc.aws_profile = str(body["aws_profile"]).strip()
     if "region" in body:
@@ -115,6 +115,7 @@ async def api_voice_config(request: web.Request) -> web.Response:
         vr.update(
             {
                 "enabled": _vc.global_enabled,
+                "auto_speak": _vc.auto_speak,
                 "provider": _vc.provider,
                 "voice_id": _vc.default_voice,
                 "engine": _vc.default_engine,

--- a/test/test_chat_voice.py
+++ b/test/test_chat_voice.py
@@ -27,10 +27,19 @@ class TestVoiceConfig:
     async def test_get_config(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         mock_vc = MagicMock(
-            global_enabled=True, provider="polly", default_voice="Joanna",
-            default_engine="neural", default_rate="100%", default_pitch="0%",
-            aws_profile="", region="us-east-1", piper_binary="", piper_model="",
-            piper_model_config="", piper_length_scale=1.0,
+            global_enabled=True,
+            auto_speak=False,
+            provider="polly",
+            default_voice="Joanna",
+            default_engine="neural",
+            default_rate="100%",
+            default_pitch="0%",
+            aws_profile="",
+            region="us-east-1",
+            piper_binary="",
+            piper_model="",
+            piper_model_config="",
+            piper_length_scale=1.0,
         )
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
         state = _make_state(tmp_path)
@@ -41,13 +50,51 @@ class TestVoiceConfig:
             assert data["voice"] == "Joanna"
             assert data["engine"] == "neural"
             assert data["enabled"] is True
+            # autoSpeak reflects the dedicated auto_speak field, not `enabled` —
+            # they're independent toggles in the Settings UI.
+            assert data["autoSpeak"] is False
+
+    @pytest.mark.asyncio
+    async def test_get_config_auto_speak_independent_of_enabled(self, tmp_path, monkeypatch):
+        # Regression test: `autoSpeak` used to alias `global_enabled`, so a user
+        # with voice enabled but auto-speak off would still get auto-spoken
+        # replies (and vice versa). The two must be reported independently.
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        mock_vc = MagicMock(
+            global_enabled=True,
+            auto_speak=False,
+            provider="piper",
+            default_voice="Ruth",
+            default_engine="generative",
+            default_rate="100%",
+            default_pitch="0%",
+            aws_profile="",
+            region="",
+            piper_binary="",
+            piper_model="",
+            piper_model_config="",
+            piper_length_scale=1.0,
+        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
+        state = _make_state(tmp_path)
+        async with TestClient(TestServer(_make_voice_app(state))) as client:
+            resp = await client.get("/api/voice/config")
+            data = await resp.json()
+            assert data["enabled"] is True
+            assert data["autoSpeak"] is False
 
     @pytest.mark.asyncio
     async def test_put_config_updates_voice(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         mock_vc = MagicMock(
-            global_enabled=False, default_voice="Joanna", default_engine="neural",
-            default_rate="100%", default_pitch="0%", aws_profile="", region="us-east-1",
+            global_enabled=False,
+            auto_speak=False,
+            default_voice="Joanna",
+            default_engine="neural",
+            default_rate="100%",
+            default_pitch="0%",
+            aws_profile="",
+            region="us-east-1",
         )
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
         # Write a config file so PUT can persist
@@ -62,13 +109,60 @@ class TestVoiceConfig:
             assert mock_vc.global_enabled is True
 
     @pytest.mark.asyncio
+    async def test_put_config_updates_auto_speak_independently_of_enabled(
+        self, tmp_path, monkeypatch
+    ):
+        # Regression test: PUT {"autoSpeak": ...} used to flip `global_enabled`
+        # (the primary voice switch) instead of the dedicated `auto_speak` field —
+        # so unchecking "Auto-speak responses" in Settings silently disabled
+        # voice entirely, including the manual speak button.
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        mock_vc = MagicMock(
+            global_enabled=True,
+            auto_speak=True,
+            provider="piper",
+            default_voice="Ruth",
+            default_engine="generative",
+            default_rate="100%",
+            default_pitch="0%",
+            aws_profile="",
+            region="",
+            piper_binary="",
+            piper_model="",
+            piper_model_config="",
+            piper_length_scale=1.0,
+        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({}))
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice.config_path", lambda: cfg_path)
+        state = _make_state(tmp_path)
+        async with TestClient(TestServer(_make_voice_app(state))) as client:
+            resp = await client.put("/api/voice/config", json={"autoSpeak": False})
+            assert resp.status == 200
+            assert mock_vc.auto_speak is False
+            # Turning auto-speak off must NOT also disable voice globally.
+            assert mock_vc.global_enabled is True
+        persisted = json.loads(cfg_path.read_text(encoding="utf-8"))["voice_reply"]
+        assert persisted["auto_speak"] is False
+
+    @pytest.mark.asyncio
     async def test_get_config_exposes_provider_and_piper(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         mock_vc = MagicMock(
-            global_enabled=True, provider="piper", default_voice="Ruth",
-            default_engine="generative", default_rate="100%", default_pitch="0%",
-            aws_profile="", region="", piper_binary="/usr/bin/piper",
-            piper_model="~/m.onnx", piper_model_config="", piper_length_scale=1.0,
+            global_enabled=True,
+            auto_speak=False,
+            provider="piper",
+            default_voice="Ruth",
+            default_engine="generative",
+            default_rate="100%",
+            default_pitch="0%",
+            aws_profile="",
+            region="",
+            piper_binary="/usr/bin/piper",
+            piper_model="~/m.onnx",
+            piper_model_config="",
+            piper_length_scale=1.0,
         )
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
         state = _make_state(tmp_path)
@@ -85,10 +179,19 @@ class TestVoiceConfig:
     async def test_put_config_updates_provider_and_piper(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         mock_vc = MagicMock(
-            global_enabled=False, provider="polly", default_voice="Joanna",
-            default_engine="neural", default_rate="100%", default_pitch="0%",
-            aws_profile="", region="", piper_binary="", piper_model="",
-            piper_model_config="", piper_length_scale=1.0,
+            global_enabled=False,
+            auto_speak=False,
+            provider="polly",
+            default_voice="Joanna",
+            default_engine="neural",
+            default_rate="100%",
+            default_pitch="0%",
+            aws_profile="",
+            region="",
+            piper_binary="",
+            piper_model="",
+            piper_model_config="",
+            piper_length_scale=1.0,
         )
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
         cfg_path = tmp_path / "config.json"
@@ -96,10 +199,14 @@ class TestVoiceConfig:
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice.config_path", lambda: cfg_path)
         state = _make_state(tmp_path)
         async with TestClient(TestServer(_make_voice_app(state))) as client:
-            resp = await client.put("/api/voice/config", json={
-                "provider": "piper", "piper_model": " ~/voices/en.onnx ",
-                "piper_length_scale": 1.5,
-            })
+            resp = await client.put(
+                "/api/voice/config",
+                json={
+                    "provider": "piper",
+                    "piper_model": " ~/voices/en.onnx ",
+                    "piper_length_scale": 1.5,
+                },
+            )
             assert resp.status == 200
             assert mock_vc.provider == "piper"
             assert mock_vc.piper_model == "~/voices/en.onnx"  # stripped
@@ -113,10 +220,19 @@ class TestVoiceConfig:
     async def test_put_config_rejects_invalid_provider(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         mock_vc = MagicMock(
-            global_enabled=False, provider="piper", default_voice="Ruth",
-            default_engine="generative", default_rate="100%", default_pitch="0%",
-            aws_profile="", region="", piper_binary="", piper_model="",
-            piper_model_config="", piper_length_scale=1.0,
+            global_enabled=False,
+            auto_speak=False,
+            provider="piper",
+            default_voice="Ruth",
+            default_engine="generative",
+            default_rate="100%",
+            default_pitch="0%",
+            aws_profile="",
+            region="",
+            piper_binary="",
+            piper_model="",
+            piper_model_config="",
+            piper_length_scale=1.0,
         )
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
         cfg_path = tmp_path / "config.json"
@@ -136,10 +252,19 @@ class TestVoiceConfig:
         # The provider check above was already guarded; engine was missed.
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         mock_vc = MagicMock(
-            global_enabled=False, provider="piper", default_voice="Ruth",
-            default_engine="generative", default_rate="100%", default_pitch="0%",
-            aws_profile="", region="", piper_binary="", piper_model="",
-            piper_model_config="", piper_length_scale=1.0,
+            global_enabled=False,
+            auto_speak=False,
+            provider="piper",
+            default_voice="Ruth",
+            default_engine="generative",
+            default_rate="100%",
+            default_pitch="0%",
+            aws_profile="",
+            region="",
+            piper_binary="",
+            piper_model="",
+            piper_model_config="",
+            piper_length_scale=1.0,
         )
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
         cfg_path = tmp_path / "config.json"
@@ -157,10 +282,19 @@ class TestVoiceConfig:
     async def test_put_config_ignores_invalid_length_scale(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         mock_vc = MagicMock(
-            global_enabled=False, provider="piper", default_voice="Ruth",
-            default_engine="generative", default_rate="100%", default_pitch="0%",
-            aws_profile="", region="", piper_binary="", piper_model="",
-            piper_model_config="", piper_length_scale=1.0,
+            global_enabled=False,
+            auto_speak=False,
+            provider="piper",
+            default_voice="Ruth",
+            default_engine="generative",
+            default_rate="100%",
+            default_pitch="0%",
+            aws_profile="",
+            region="",
+            piper_binary="",
+            piper_model="",
+            piper_model_config="",
+            piper_length_scale=1.0,
         )
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
         cfg_path = tmp_path / "config.json"
@@ -184,10 +318,19 @@ class TestVoiceConfig:
         # unhashable JSON value (list/dict); the isinstance(str) guard prevents it.
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         mock_vc = MagicMock(
-            global_enabled=False, provider="piper", default_voice="Ruth",
-            default_engine="generative", default_rate="100%", default_pitch="0%",
-            aws_profile="", region="", piper_binary="", piper_model="",
-            piper_model_config="", piper_length_scale=1.0,
+            global_enabled=False,
+            auto_speak=False,
+            provider="piper",
+            default_voice="Ruth",
+            default_engine="generative",
+            default_rate="100%",
+            default_pitch="0%",
+            aws_profile="",
+            region="",
+            piper_binary="",
+            piper_model="",
+            piper_model_config="",
+            piper_length_scale=1.0,
         )
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
         cfg_path = tmp_path / "config.json"
@@ -201,30 +344,44 @@ class TestVoiceConfig:
 
     @pytest.mark.asyncio
     async def test_put_config_preserves_unmanaged_voice_reply_keys(self, tmp_path, monkeypatch):
-        # The PUT persists a fixed key set but the loader also reads auto_speak /
+        # The PUT persists a fixed key set but the loader also reads
         # auto_reply_to_voice from voice_reply — a wholesale rewrite would drop
-        # them. Merge must preserve keys this handler doesn't manage.
+        # it. Merge must preserve keys this handler doesn't manage.
+        # (auto_speak IS managed by this handler — see
+        # test_put_config_updates_auto_speak_independently_of_enabled — so it's
+        # written from the live `_vc.auto_speak`, not merely carried over.)
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         mock_vc = MagicMock(
-            global_enabled=True, provider="polly", default_voice="Joanna",
-            default_engine="neural", default_rate="100%", default_pitch="0%",
-            aws_profile="", region="", piper_binary="", piper_model="",
-            piper_model_config="", piper_length_scale=1.0,
+            global_enabled=True,
+            auto_speak=True,
+            provider="polly",
+            default_voice="Joanna",
+            default_engine="neural",
+            default_rate="100%",
+            default_pitch="0%",
+            aws_profile="",
+            region="",
+            piper_binary="",
+            piper_model="",
+            piper_model_config="",
+            piper_length_scale=1.0,
         )
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
         cfg_path = tmp_path / "config.json"
-        cfg_path.write_text(json.dumps({
-            "voice_reply": {"enabled": True, "auto_reply_to_voice": False, "auto_speak": True}
-        }))
+        cfg_path.write_text(
+            json.dumps(
+                {"voice_reply": {"enabled": True, "auto_reply_to_voice": False, "auto_speak": True}}
+            )
+        )
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice.config_path", lambda: cfg_path)
         state = _make_state(tmp_path)
         async with TestClient(TestServer(_make_voice_app(state))) as client:
             resp = await client.put("/api/voice/config", json={"voice": "Matthew"})
             assert resp.status == 200
         persisted = json.loads(cfg_path.read_text(encoding="utf-8"))["voice_reply"]
-        assert persisted["voice_id"] == "Matthew"       # updated
+        assert persisted["voice_id"] == "Matthew"  # updated
         assert persisted["auto_reply_to_voice"] is False  # preserved (not dropped)
-        assert persisted["auto_speak"] is True            # preserved
+        assert persisted["auto_speak"] is True  # written from _vc.auto_speak
 
     @pytest.mark.asyncio
     async def test_synthesize_routes_piper_through_nonstreaming(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem / Motivation

Fixes #3331. `GET/PUT /api/voice/config` aliased the `autoSpeak` field to
`_vc.global_enabled` (the primary voice on/off switch) instead of the dedicated
`_vc.auto_speak` field, so the two settings could never differ. What a user
observes:

- Turning **Auto-speak Responses** off in Settings silently disabled voice
  entirely (including the manual 🔊 Speak button), because the PUT handler wrote
  the toggle's value into `global_enabled`.
- A config with `enabled: false, auto_speak: true` never auto-spoke replies,
  since GET always reported `autoSpeak == enabled`.
- PUT never persisted `auto_speak` to `config.json` at all, so any change made
  through the Settings UI was lost on restart.

## Why it matters

The dashboard's two voice settings are advertised as independent — the frontend
(`useWebSocket.ts`, `VoicePanel.tsx`) already treats `enabled` and `autoSpeak`
that way, and `voice_reply.auto_speak` is a documented `config.json` key. Anyone
who touches the Auto-speak toggle loses voice output altogether and cannot get
it back from that screen, and anyone who sets `auto_speak` in `config.json`
finds it silently ignored by the dashboard. Both are trust-eroding, silent
failures in a user-facing setting.

## What changed (motivation → approach → change)

Observed symptom: the Auto-speak toggle disables all voice, and `auto_speak`
never persists. Root cause: `chat_voice.py` used `_vc.global_enabled` as the
backing field for the `autoSpeak` wire field on both the read and the write
path, and the persistence block never wrote `auto_speak` at all.

`_vc.auto_speak` already exists and is already loaded from `config.json`'s
`voice_reply.auto_speak` at startup (`slack/handler.py:set_orch_cfg`), with its
own coverage in `test/test_set_orch_cfg_voice.py` — the dashboard endpoint was
the only place that ignored it. So the fix is to point the endpoint at the field
that already exists rather than introduce new state:

- `src/kiro_crew/dashboard/chat_voice.py`: GET returns `_vc.auto_speak`; PUT
  writes `_vc.auto_speak`; PUT persists `auto_speak` into the `voice_reply`
  block of `config.json` alongside `enabled`.
- `docs/system-specs/features/voice-streaming.md`: the config table documented
  `enabled` as controlling auto-speak. It now describes `enabled` as the primary
  switch gating Slack voice replies, adds the missing `auto_speak` row, and
  notes on the API line that `autoSpeak` mirrors `auto_speak`, not `enabled`.

## Tests

`test/test_chat_voice.py` — two new regression tests, plus mock updates so the
existing cases reflect the now-independent fields:

- GET reports `autoSpeak` from `auto_speak`, and reports it independently of
  `enabled` (locks in that `enabled: false, auto_speak: true` is reported
  faithfully instead of collapsing to `false`).
- PUT writes `autoSpeak` into `auto_speak` without touching `global_enabled`,
  and the persisted `config.json` carries `voice_reply.auto_speak` (locks in
  both the aliasing bug and the missing persistence).

Local run: `pytest test/test_chat_voice.py test/test_set_orch_cfg_voice.py -q` —
40 passed. `flake8`, `isort --check`, `mypy` on the changed files, the black
baseline gate, and `scripts/docs-lint.sh` are all clean.

## Manual verification

N/A — unit coverage is sufficient: both the wire contract (GET/PUT payloads) and
the persisted `config.json` shape are asserted directly by the new tests, and
the frontend already consumed `autoSpeak` as an independent flag before this
change.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** backend handler plus spec-doc change only — no frontend
file is touched and the Settings UI renders identically; only the value the
existing Auto-speak toggle reads and writes changes.

## Related Issues

Fixes #3331

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Notes

This fixes the auto-speak flag bug directly, but does not fully explain the
*other* symptom described in #3331 (manual speak-button clicks producing zero
network requests) — `ChatPage.tsx`'s `handleSpeak` calls `api.voiceSynthesize`
unconditionally with no gating, which looks correct on `main`. That symptom is
more consistent with the maintainer's own triage hypothesis of a stale bundled
asset in the packaged macOS app, and is left out of scope here.
