### PR TITLE
fix: survive enterprise MCP registry governance instead of failing silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,8 +303,9 @@ from the dashboard. Incognito and temporary session modes let you opt out when
 a conversation should not persist.
 
 **Skills, MCP, and apps.** Markdown skills supply reusable workflows and can be
-loaded only when relevant. The built-in `kirocrew-core` and `kirocrew-cron` MCP
-servers expose task, subagent, learning, messaging, and scheduling tools. You
+loaded only when relevant. The built-in `kirocrew-core`, `kirocrew-cron` and
+`kirocrew-computer` MCP servers expose task, subagent, learning, messaging,
+scheduling, and desktop-automation tools. You
 can discover additional MCP servers from Kiro or Kiro Crew configuration. The
 App Kit adds installable interfaces and domain workflows. Apps can add dashboard
 pages, use scoped Gateway APIs, subscribe to events, and register lifecycle

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -120,6 +120,17 @@ from the live `kirocrew` binary, strips stale remote-transport fields (`url`,
 gateway is actually running under while preserving the user's own env keys.
 User customizations such as `autoApprove` are preserved.
 
+Under an enterprise MCP registry, `_refresh_dynamic_fields()` also maintains a
+`"type": "registry"` marker on these three entries — added when
+`agent.mcp_registry_mode` is declared, and REMOVED when it is not. The marker is
+maintained rather than preserved because it tracks the account the gateway is
+signed in to, not a user preference, and because the client's filter is
+symmetric: outside registry mode a marked entry is the one that gets dropped.
+`command`/`args` stay either way, since the registry path is not the only
+consumer of this spec (doctor's handshake probe and the CC sidecar sync both
+launch from it). See
+[../guides/enterprise-mcp-governance.md](../guides/enterprise-mcp-governance.md).
+
 `kirocrew-computer` carries **no `autoApprove` key and none may ever be added.**
 kiro-cli approves an auto-approved MCP tool locally and emits no permission
 request, so `hooks.on_tool_call` (the PreToolUse deny floor, sensitive-path

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -12,6 +12,7 @@ system is built, see [../architecture/](../architecture/README.md).
 | [cloud-instance-ssm-vs-ssh.md](cloud-instance-ssm-vs-ssh.md) | How a cloud-launched instance is reached through the Instances hub: the native AWS SSM transport vs the legacy SSH-over-`ProxyCommand` path. |
 | [remote-crew-on-ec2.md](remote-crew-on-ec2.md) | Reaching a Remote Crew gateway on EC2 over SSH or AWS SSM, plus the common EC2 setup gotchas (sandbox backend, linger, port/tunnel matching). |
 | [slack-setup.md](slack-setup.md) | Creating and configuring the Slack app. |
+| [enterprise-mcp-governance.md](enterprise-mcp-governance.md) | Running Kiro Crew on an enterprise Kiro account (IAM Identity Center / API key) whose administrator allow-lists MCP servers through a registry: why features go silently missing, and the two-sided fix. |
 | — | Other chat channels (Discord, Telegram, Teams, Webex, WeCom, WeChat) are documented in [../../src/kiro_crew/docs/](../../src/kiro_crew/docs/README.md); the channel-neutral transport contract is [messaging.md](../system-specs/modules/messaging.md). |
 
 `assets/` holds the copy-pasteable service unit, launchd plist, and setup script

--- a/docs/guides/enterprise-mcp-governance.md
+++ b/docs/guides/enterprise-mcp-governance.md
@@ -1,0 +1,172 @@
+# Kiro Crew behind enterprise MCP governance
+
+Applies when the Kiro account `kiro-cli` is signed in to is an **enterprise**
+account — IAM Identity Center (or an external IdP such as Okta / Entra ID
+fronting it), or an API key — and an administrator has configured an **MCP
+registry**. Personal accounts (Builder ID, social sign-in) are not subject to
+organization-level MCP controls and need nothing on this page.
+
+## The symptom
+
+Kiro Crew starts, the dashboard works, chat works — and a large part of the
+product is quietly absent. `spawn_run` does nothing, `cron_add` is unavailable,
+`learn_add` never saves, the knowledge tools are missing, the research agent has
+no tools to work with. Nothing errors. `kirocrew doctor` reports the MCP servers
+healthy.
+
+That combination — healthy locally, absent in sessions — is the signature of MCP
+governance, because the two checks are measuring different things:
+
+- Kiro Crew's own probe **spawns each server directly** and completes an MCP
+  handshake with it. That succeeds regardless of governance.
+- `kiro-cli` applies governance **when it assembles a session**, after reading
+  the agent spec. Every server it drops there is dropped silently.
+
+## What governance actually does
+
+The administrator sets two things on the Kiro profile (Kiro console → Settings →
+Shared settings): an MCP on/off toggle, and an **MCP Registry URL** pointing at a
+registry JSON file listing the allow-listed servers.
+
+With a registry URL configured, the client is in **registry access mode**, and
+its filter is *symmetric*:
+
+| Access mode | Entries that connect | Entries that are dropped |
+|---|---|---|
+| registry (a registry URL is set) | only entries carrying `"type": "registry"` that resolve to a catalog entry **of the same name** | everything else |
+| non-registry (no registry URL) | ordinary entries | entries carrying `"type": "registry"` |
+
+Two consequences worth internalising:
+
+- The match is on the **`mcpServers` map key**, not on the command, not on a
+  registry id. `kirocrew-core` in your spec must be `kirocrew-core` in the
+  registry file.
+- `"type": "registry"` is **not a transport**. It declares "this entry is a
+  pointer into the catalog", and only `env`, `headers` and `timeout` are carried
+  over from your entry as overrides. The `command` in a registry-type entry is
+  not what launches.
+
+Governance also **fails closed**: if the client cannot reach the governance API,
+MCP is disabled entirely rather than falling open.
+
+## Fixing it — two halves, both required
+
+### 1. Declare registry mode on the Kiro Crew side
+
+```bash
+kirocrew config set agent.mcp_registry_mode true
+kirocrew restart
+```
+
+Kiro Crew then stamps `"type": "registry"` on the servers it manages, so they
+survive the registry filter. It is an explicit declaration rather than
+auto-detection on purpose: the client fetches the toggle and the registry URL
+from `GetProfile` at startup and **persists neither**, so nothing on disk
+distinguishes a governed account from an ungoverned one. Leave the setting
+`false` on a personal account — there the filter inverts and the marked entries
+are the ones dropped.
+
+Verify with `kirocrew doctor`, which grows an `MCP Governance (enterprise)`
+section whenever the local identity came from Identity Center.
+
+### 2. Have the administrator allow-list the servers
+
+Kiro Crew needs three servers, and they must appear in the registry file under
+**exactly** these names:
+
+| Server | What is lost without it |
+|---|---|
+| `kirocrew-core` | `spawn_run`, `learn_add`, artifacts, knowledge, monitoring — the bulk of the product |
+| `kirocrew-cron` | every scheduled job (`cron_add` and the whole cron surface) |
+| `kirocrew-computer` | desktop automation (inert unless separately enabled, but still filtered) |
+
+The registry file format is a subset of the MCP registry standard's server
+schema. Each entry needs a `packages` entry describing how to launch the server,
+and — because all three Kiro Crew servers live behind one package — a
+`packageArguments` entry naming the subcommand. For a `pypi` package the client
+derives `uvx <identifier> <packageArguments>`, so an entry without the argument
+launches `uvx kirocrew` with no subcommand, which prints CLI help instead of
+speaking MCP and fails the handshake:
+
+```json
+{
+  "servers": [
+    {
+      "name": "kirocrew-core",
+      "description": "Kiro Crew orchestration: subagents, memory, artifacts, monitoring",
+      "version": "0.3.0",
+      "packages": [
+        {
+          "registryType": "pypi",
+          "identifier": "kirocrew",
+          "packageArguments": [{ "type": "positional", "value": "mcp-core" }],
+          "transport": { "type": "stdio" }
+        }
+      ]
+    },
+    {
+      "name": "kirocrew-cron",
+      "description": "Kiro Crew scheduled jobs",
+      "version": "0.3.0",
+      "packages": [
+        {
+          "registryType": "pypi",
+          "identifier": "kirocrew",
+          "packageArguments": [{ "type": "positional", "value": "mcp-cron" }],
+          "transport": { "type": "stdio" }
+        }
+      ]
+    },
+    {
+      "name": "kirocrew-computer",
+      "description": "Kiro Crew desktop automation (macOS, opt-in)",
+      "version": "0.3.0",
+      "packages": [
+        {
+          "registryType": "pypi",
+          "identifier": "kirocrew",
+          "packageArguments": [{ "type": "positional", "value": "mcp-computer" }],
+          "transport": { "type": "stdio" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Set `version` to the Kiro Crew version your fleet runs.
+
+## Known limitation: the registry launches the server, not your install
+
+Kiro Crew's MCP servers are not standalone tools — they are the gateway's own
+process, reached through subcommands (`kirocrew mcp-core`, `mcp-cron`,
+`mcp-computer`), and they share the gateway's data home and version.
+
+A registry-type entry hands the launch decision to the catalog: the client
+resolves the package and, when a locally installed server's version differs from
+the registry's, relaunches it at the registry's version. For a `pypi` entry that
+means `uvx` fetching Kiro Crew from PyPI into its own ephemeral environment — so
+the process serving your MCP tools can be a *different* Kiro Crew from the
+gateway serving your dashboard. Your `env` overrides (including `KIROCREW_HOME`)
+do flow through, which keeps the data home aligned, but the code does not.
+
+Keep the registry `version` in step with your fleet's installed version. If your
+organisation pins Kiro Crew centrally, that pin now governs the MCP side too.
+
+## Version floor
+
+MCP registry governance requires Kiro CLI **1.23** or later (Kiro IDE 0.11.28).
+Enforcement in the V2 TUI arrived in **2.2.2**, and **2.6.0** made personal
+`mcp.json` servers load alongside registry-managed ones. Kiro Crew's servers
+live in an agent spec (`~/.kiro/agents/kirocrew.json`), not in personal
+`mcp.json`, so that last change does not exempt them.
+
+## Related
+
+- [../architecture/mcp.md](../architecture/mcp.md) — how Kiro Crew composes the
+  agent spec's `mcpServers` map and which files it owns.
+- [../../src/kiro_crew/docs/troubleshooting.md](../../src/kiro_crew/docs/troubleshooting.md)
+  — the user-facing "MCP tools not working" checklist.
+- Kiro's own documentation: `https://kiro.dev/docs/enterprise/governance/mcp/`
+  (administrator setup) and `https://kiro.dev/docs/mcp/registry/` (registry mode
+  and registry-type overrides).

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -409,6 +409,53 @@ def _managed_mcp_env() -> dict[str, str]:
     return {"KIROCREW_HOME": str(override)} if override else {}
 
 
+# Declaration discriminator kiro-cli reads for enterprise MCP governance. It is
+# NOT a transport: a `registry` entry is a POINTER into the admin's catalog,
+# carrying only env/headers/timeout overrides, and its command/url are ignored.
+_MCP_REGISTRY_TYPE = "registry"
+
+
+def _mcp_registry_mode() -> bool:
+    """True when the operator has declared this install registry-governed.
+
+    An enterprise Kiro profile with an MCP Registry URL puts the client in
+    `registry` access mode, where it resolves each `mcpServers` entry that
+    carries ``"type": "registry"`` against the admin's catalog BY THE MAP KEY
+    and silently drops every entry that does not. Without the marker the
+    managed servers are filtered out before launch and the features they carry
+    (`spawn_run`, `cron_add`, `learn_add`, ...) disappear with no local error.
+
+    The mode cannot be auto-detected: the client fetches the toggle and the
+    registry URL from GetProfile at startup and persists neither, so nothing on
+    disk distinguishes a governed account from an ungoverned one. It is an
+    explicit operator declaration, defaulting to false because the filter is
+    symmetric — outside registry mode the marked entries are the dropped ones,
+    so stamping unconditionally would break every personal install.
+
+    Read through the EFFECTIVE config rather than ``config.json`` alone, because
+    ``config.local.json`` deep-merges over it and is where ``kirocrew config set
+    --local`` writes. Reading only the base file would ignore an overlay that
+    declares the mode, emit no marker, and reproduce the silent drop this whole
+    change exists to prevent.
+    """
+    try:
+        # Function-local like the model resolver a few frames up: importing the
+        # loader at module scope closes an import cycle through the config plane.
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        return KiroCrewConfig.load().agent.mcp_registry_mode is True
+    except Exception:
+        # A config that cannot be loaded is not a governed declaration. Fall back
+        # to the base file so a partially broken overlay still cannot flip the
+        # marker on by accident.
+        logger.debug("effective config unavailable for registry mode", exc_info=True)
+        cfg = _load_json(_mc_config_path()) or {}
+        agent_cfg = cfg.get("agent")
+        if not isinstance(agent_cfg, dict):
+            return False
+        return agent_cfg.get("mcp_registry_mode") is True
+
+
 def _kirocrew_mcp_invocation(subcommand: str) -> tuple[str, list[str]]:
     """Resolve a CWD- and shebang-independent invocation for a built-in
     MCP server (``kirocrew-cron`` / ``kirocrew-core``).
@@ -1510,6 +1557,7 @@ def build_agent_config() -> dict:
     # Dynamic fields — always resolved at install time
     config["prompt"] = f"file://{_prompt_path()}"
     mcp = config.setdefault("mcpServers", {})
+    registry_mode = _mcp_registry_mode()
     for name, spec in _MANAGED_MCP_SERVERS.items():
         if "invocation_fn" in spec:
             cmd, args = spec["invocation_fn"]()
@@ -1517,6 +1565,13 @@ def build_agent_config() -> dict:
             cmd = spec.get("command") or spec["command_fn"]()
             args = list(spec["args"])
         entry = {"command": cmd, "args": args}
+        # Enterprise registry mode: without this marker the client drops the
+        # entry before launch (see _mcp_registry_mode). command/args stay so the
+        # spec still describes a runnable server for every other consumer —
+        # doctor's handshake probe, the CC sidecar sync, a later un-governed
+        # refresh — none of which route through the registry.
+        if registry_mode:
+            entry["type"] = _MCP_REGISTRY_TYPE
         # Pin the data home so the shim cannot read a DIFFERENT one than the
         # gateway that spawned it (see _managed_mcp_env). Omitted entirely on a
         # default install, so the emitted spec is unchanged there.
@@ -1554,6 +1609,7 @@ def _refresh_dynamic_fields(config: dict) -> None:
     # Managed MCP servers — ensure present and up-to-date.
     # Only refresh command/args; preserve user customizations (e.g. autoApprove).
     mcp = config.setdefault("mcpServers", {})
+    registry_mode = _mcp_registry_mode()
     for name, spec in _MANAGED_MCP_SERVERS.items():
         is_new = name not in mcp
         entry = mcp.setdefault(name, {})
@@ -1568,6 +1624,16 @@ def _refresh_dynamic_fields(config: dict) -> None:
         # the downstream stdio-force in cc_agent / acp.client.)
         entry.pop("url", None)
         entry.pop("headers", None)
+        # Enterprise registry marker — refreshed like command/args rather than
+        # preserved like ``autoApprove``, because it tracks the account the
+        # gateway is actually signed in to, not a user preference. Removed (not
+        # left stale) when the declaration is off, so a host that leaves an
+        # enterprise profile stops shipping a marker that would now cause the
+        # inverse filter to drop these servers.
+        if registry_mode:
+            entry["type"] = _MCP_REGISTRY_TYPE
+        elif entry.get("type") == _MCP_REGISTRY_TYPE:
+            entry.pop("type", None)
         # Data-home pin — refreshed like command/args rather than preserved like
         # ``autoApprove``, because it is OURS, not a user customization: it must
         # track the home the gateway is actually running under. A config written

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -53,6 +53,7 @@ from kiro_crew.embeddings import (
     resolve_custom_model,
     verify_vendored_libs,
 )
+from kiro_crew.kiro_cli import mcp_governance_may_apply
 from kiro_crew.mcp_cleanup import KIROCREW_BIN_MCP_SERVERS as _MANAGED_MCPS
 from kiro_crew.mcp_discovery import McpServerInfo, probe_server
 from kiro_crew.platform import (
@@ -271,6 +272,105 @@ def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
             for line in detail.splitlines():
                 print(f"      {line}")
         issues.append(f"{ref} probe")
+
+
+# Non-secret rows kiro-cli writes when the signed-in identity came from IAM
+# Identity Center. Presence is the signal; the values (a start URL and a region)
+# are never read into a message, and no token key is touched.
+def _doctor_mcp_governance(agent_path: Path, issues: list[str]) -> None:
+    """Render the `MCP Governance` section of `kirocrew doctor`.
+
+    Speaks up in two situations: governance can reach this identity (Identity
+    Center or an API key), where an administrator's registry may be in force, and
+    the registry declaration or its markers are present on an identity governance
+    CANNOT reach, which is the inverse failure and just as silent. Stays quiet on
+    an ordinary personal install, where a governance warning would be pure noise.
+
+    This exists because the section above cannot detect either failure.
+    Governance is enforced inside kiro-cli when it assembles a session: it drops
+    every ``mcpServers`` entry whose registry marker does not match the account's
+    access mode. Kiro Crew's own handshake probe spawns each server directly and
+    therefore still reports it healthy, so an affected host reads green here
+    while `spawn_run`, `cron_add` and `learn_add` are absent from every session.
+    """
+    try:
+        declared = KiroCrewConfig.load().agent.mcp_registry_mode
+    except Exception:
+        logger.debug("config load failed in governance check", exc_info=True)
+        declared = False
+
+    try:
+        spec = json.loads(agent_path.read_text(encoding="utf-8"))
+        servers = spec.get("mcpServers") or {}
+    except Exception:
+        servers = {}
+    if not isinstance(servers, dict):
+        # `or {}` only replaces a FALSY value, so a string or list here survives
+        # and the membership walk below would raise, aborting the whole doctor
+        # run — on exactly the malformed spec someone is running doctor to find.
+        servers = {}
+
+    marked = sorted(
+        name
+        for name in _MANAGED_MCPS
+        if isinstance(servers.get(name), dict) and servers[name].get("type") == "registry"
+    )
+    names = ", ".join(sorted(_MANAGED_MCPS))
+    governed_capable = mcp_governance_may_apply()
+
+    # Nothing to say: an identity governance cannot reach, with no registry
+    # declaration and no leftover markers, is the ordinary case.
+    if not governed_capable and not declared and not marked:
+        return
+
+    print("\nMCP Governance (enterprise):")
+
+    if not governed_capable:
+        # The inverse filter. Outside registry mode a MARKED entry is the one the
+        # client drops, so this state breaks the same servers, equally silently —
+        # reachable by copying the guide onto a personal account, or by leaving an
+        # enterprise account with the declaration still set. Safe to assert only
+        # because neither governance-capable signal is present: no Identity Center
+        # rows AND no API key, which leaves Builder ID or social sign-in.
+        print("  identity: not Identity Center or API key — an admin MCP registry cannot apply")
+        if declared:
+            print(
+                "  ❌ registry mode is declared, so kiro-cli treats these servers as "
+                "registry-provided and drops them on an ungoverned account"
+            )
+        else:
+            print("  ❌ registry markers are present on the spec without the declaration")
+        print(f"      affected: {', '.join(marked) if marked else names}")
+        print("      fix:  kirocrew config set agent.mcp_registry_mode false")
+        issues.append("MCP registry mode on non-IDC account")
+        return
+
+    print("  identity: Identity Center or API key — an admin MCP registry can apply")
+    if declared:
+        print(f"  registry mode: on — {len(marked)}/{len(_MANAGED_MCPS)} managed servers marked")
+        if len(marked) < len(_MANAGED_MCPS):
+            print("  ❌ markers missing — re-run `kirocrew setup --agent-only`")
+            issues.append("MCP registry markers")
+            return
+        # Deliberately not a success line. Whether the administrator actually
+        # allow-listed these names is not knowable locally, so claiming green
+        # here would repeat the overstatement this section exists to correct.
+        print("  cannot verify the registry itself — that lives with your administrator")
+        print(f"      these names must be allow-listed, exactly: {names}")
+        print(
+            "      if tools are still missing in sessions, the account may no longer be "
+            "registry-governed — try `kirocrew config set agent.mcp_registry_mode false`"
+        )
+        return
+
+    print("  registry mode: off")
+    print(
+        "  ⚠️  If MCP tools are missing in sessions while probing OK above, your "
+        "administrator has configured an MCP Registry URL. In that mode kiro-cli "
+        "connects only to servers marked 'type': \"registry\"."
+    )
+    print("      Declare it:  kirocrew config set agent.mcp_registry_mode true")
+    print(f"      Then have your admin allow-list, by these exact names: {names}")
 
 
 def _doctor_data_home() -> None:
@@ -1051,6 +1151,9 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     print("\nMCP Tools")
     if agent_path.exists():
         _doctor_mcp_tools(agent_path, issues)
+        # After the probe, deliberately: the probe reporting green is the exact
+        # condition this section exists to explain.
+        _doctor_mcp_governance(agent_path, issues)
 
     # ── Python Runtime ──
     print("\nRuntime")

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1084,6 +1084,22 @@ class AgentConfig:
         default="acp",
         metadata=_meta("Provider", "LLM provider backend (KiroACP / kiro-cli).", enum=["acp"]),
     )
+    mcp_registry_mode: bool = field(
+        default=False,
+        metadata=_meta(
+            "Enterprise MCP Registry Mode",
+            "Set true when this Kiro account is governed by an enterprise MCP "
+            "registry (Kiro console -> Shared settings -> MCP Registry URL, which "
+            "applies to IAM Identity Center and API-key sign-ins). In registry "
+            "mode the client connects ONLY to mcpServers entries carrying "
+            "'type': \"registry\" that resolve to a catalog entry of the same "
+            "name, so Kiro Crew stamps that marker on the servers it manages. "
+            "Leave false on a personal account: with no registry configured the "
+            "filter inverts and registry-marked entries are the ones dropped. "
+            "The administrator must also allow-list kirocrew-core, kirocrew-cron "
+            "and kirocrew-computer in the registry by those exact names.",
+        ),
+    )
     acp_backend: str = field(
         default="",
         metadata=_meta(
@@ -5588,6 +5604,7 @@ class KiroCrewConfig:
                 role_efforts=coerce_role_efforts(agent_data.get("role_efforts")),
                 reasoning_effort=agent_data.get("reasoning_effort", ""),
                 provider=agent_data.get("provider", "acp"),
+                mcp_registry_mode=_safe_bool(agent_data.get("mcp_registry_mode", False), False),
                 acp_backend=_normalize_acp_backend(agent_data.get("acp_backend")),
                 default_agent=agent_data.get("default_agent", ""),
                 sandbox=agent_data.get("sandbox", "auto"),

--- a/src/kiro_crew/docs/agents.md
+++ b/src/kiro_crew/docs/agents.md
@@ -11,7 +11,7 @@ The kirocrew agent config lives at `~/.kiro/agents/kirocrew.json`. It defines:
 - Available tools (bash, file read/write, grep, MCP tools)
 - Auto-approved tools (safe tools that skip approval)
 - Denied commands (destructive operations blocked by default)
-- MCP servers (kirocrew-cron, kirocrew-core)
+- MCP servers (kirocrew-cron, kirocrew-core, kirocrew-computer)
 
 ## Switching Agents
 

--- a/src/kiro_crew/docs/troubleshooting.md
+++ b/src/kiro_crew/docs/troubleshooting.md
@@ -61,6 +61,27 @@ The doctor also runs a live handshake probe against each managed server and
 prints the child's stderr tail on failure, which is usually where the real cause
 (an import error, a bad path) shows up.
 
+### MCP tools missing on an enterprise (work) account
+
+If the probe above reports every server healthy but the tools are still absent in
+sessions — no `spawn_run`, no `cron_add`, no `learn_add` — and your Kiro account
+is a work account signed in through IAM Identity Center, your administrator has
+almost certainly allow-listed MCP servers through an MCP registry. In that mode
+kiro-cli connects only to servers marked `"type": "registry"`, and it drops the
+rest without an error. The local probe cannot see this because it spawns the
+servers directly.
+
+```bash
+kirocrew config set agent.mcp_registry_mode true
+kirocrew restart
+```
+
+Your administrator also has to add `kirocrew-core`, `kirocrew-cron` and
+`kirocrew-computer` to the registry under those exact names. `kirocrew doctor`
+prints an `MCP Governance (enterprise)` section on Identity Center hosts with the
+current state. Full walkthrough, including the registry JSON your administrator
+needs: `docs/guides/enterprise-mcp-governance.md`.
+
 ### Dashboard not loading
 
 ```bash

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -2586,6 +2586,13 @@ _AUDIT_ONLY_READ_IDS: dict[str, str] = {
     # justification in _INTERNAL_READ_ALLOWLIST -- identical posture, different
     # storage layout).
     "kiro_usage_api.sqlite_token": ".local/share/{kiro-cli,amazon-q}/data.sqlite3",
+    # Same store, read by ``kiro_crew.kiro_cli.signed_in_via_idc`` to answer one
+    # question for the enterprise MCP-governance diagnostic: did this identity come
+    # from Identity Center? Only the two non-secret ``auth.idc.*`` marker rows are
+    # selected, and only their COUNT leaves the function -- no token row is read and
+    # no value is returned. The audit is owed regardless, because the file holds
+    # live credential material whatever this reader touches.
+    "kiro_cli.idc_identity_probe": ".local/share/kiro-cli/data.sqlite3",
 }
 
 

--- a/src/kiro_crew/kiro_cli.py
+++ b/src/kiro_crew/kiro_cli.py
@@ -3,14 +3,180 @@
 from __future__ import annotations
 
 import os
+import stat
 import sys
+import urllib.request
 from collections.abc import Mapping
 from pathlib import Path
 
 from kiro_crew import platform_compat
+from kiro_crew._sqlite_compat import sqlite3
 from kiro_crew.env import augmented_path
 
 KIRO_CLI_NAME = "kiro-cli"
+
+# kiro-cli's own local state database. Holds identity-describing rows next to
+# credential rows, so every reader here is read-only and key-scoped.
+KIRO_CLI_STATE_DB = "data.sqlite3"
+
+# Non-secret rows kiro-cli writes when the signed-in identity came from IAM
+# Identity Center. Presence is the whole signal: the values (a start URL and a
+# region) are never returned, and no token key is selected.
+_IDC_STATE_KEYS = ("auth.idc.start-url", "auth.idc.region")
+
+# Name only. Governance covers API-key sign-ins too, so its presence decides
+# whether an admin registry can apply; the value is never read.
+_API_KEY_ENV = "KIRO_API_KEY"
+
+# SEL audit id for the identity probe below. Registered in
+# ``hooks._AUDIT_ONLY_READ_IDS``; an unregistered id fails closed.
+_IDC_PROBE_READ_ID = "kiro_cli.idc_identity_probe"
+
+_STATE_DB_TIMEOUT_SECS = 5.0
+
+
+def kiro_cli_state_dbs(
+    platform_name: str,
+    home: Path,
+    environ: Mapping[str, str],
+) -> tuple[Path, ...]:
+    """Return candidate paths to kiro-cli's state database, most likely first.
+
+    Mirrors the per-platform data directories the readiness probe stages from,
+    including the ``XDG_DATA_HOME`` / ``LOCALAPPDATA`` redirections, so a host
+    with a relocated data dir is not silently treated as having no store.
+    """
+    if platform_name == "darwin":
+        roots = [home / "Library" / "Application Support" / KIRO_CLI_NAME]
+    elif platform_name == "win32":
+        local_app_data = Path(environ.get("LOCALAPPDATA") or home / "AppData" / "Local")
+        roots = [
+            local_app_data / KIRO_CLI_NAME,
+            home / "AppData" / "Roaming" / KIRO_CLI_NAME,
+        ]
+    else:
+        data_home = Path(environ.get("XDG_DATA_HOME") or home / ".local" / "share")
+        roots = [data_home / KIRO_CLI_NAME]
+    return tuple(root / KIRO_CLI_STATE_DB for root in _unique_paths(roots))
+
+
+def _unique_paths(items: list[Path]) -> list[Path]:
+    return list(dict.fromkeys(items))
+
+
+def api_key_configured(environ: Mapping[str, str] | None = None) -> bool:
+    """Whether an API-key credential is configured for kiro-cli.
+
+    Only presence is inspected, never the value. Enterprise MCP governance
+    applies to API-key sign-ins as well as IAM Identity Center, so a caller
+    deciding whether governance *can* apply has to consider this too — treating
+    an API-key account as ungoverned produces advice that breaks a correctly
+    configured host.
+
+    Reads the process environment, which by this point also carries anything the
+    credential loader lifted out of Kiro Crew's ``.env``.
+    """
+    env = environ if environ is not None else os.environ
+    return bool((env.get(_API_KEY_ENV) or "").strip())
+
+
+def mcp_governance_may_apply(
+    platform_name: str | None = None,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Whether an administrator's MCP registry can be in force for this identity.
+
+    True for IAM Identity Center and for API-key sign-ins, the two the governance
+    surface covers. False for Builder ID and social sign-ins, which
+    organization-level MCP controls do not reach.
+
+    Deliberately an OR of two independent signals rather than a single lookup: a
+    host can be governed through either, and answering "ungoverned" for the one
+    it does not check is what turns a diagnostic into bad advice.
+    """
+    return signed_in_via_idc(platform_name, home, environ) or api_key_configured(environ)
+
+
+def signed_in_via_idc(
+    platform_name: str | None = None,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Whether kiro-cli's local state says the identity came from IDC.
+
+    Returns False on any failure. An unreadable or absent store means "cannot
+    tell", and inferring an enterprise account from a missing file would put a
+    governance warning in front of every personal install.
+
+    The store holds live credential material, so every read of it owes an SEL
+    audit event even though this function only ever selects the COUNT of two
+    non-secret ``auth.idc.*`` marker rows. Auditing is FAIL-CLOSED: if the audit
+    cannot be emitted the probe reports "cannot tell" rather than reading
+    unaudited, which costs a diagnostic hint and never a credential.
+    """
+    # Imported here rather than at module scope: ``hooks`` pulls in the security
+    # and governance planes, and this module is imported by lightweight
+    # path-resolution callers (including the MCP server entry points) that must
+    # not pay for that, nor risk an import cycle through them.
+    from kiro_crew.hooks import emit_internal_read_audit
+
+    candidates = kiro_cli_state_dbs(
+        platform_name or sys.platform,
+        home if home is not None else Path.home(),
+        environ if environ is not None else os.environ,
+    )
+    placeholders = ",".join("?" * len(_IDC_STATE_KEYS))
+    for db in candidates:
+        connection = _open_state_db_readonly(db)
+        if connection is None:
+            continue
+        try:
+            if not emit_internal_read_audit(_IDC_PROBE_READ_ID, "success"):
+                # Audit surface unavailable: do not read the store.
+                return False
+            with connection:
+                row = connection.execute(
+                    f"SELECT count(*) FROM state WHERE key IN ({placeholders})",
+                    _IDC_STATE_KEYS,
+                ).fetchone()
+            if row and int(row[0]) > 0:
+                return True
+        except (sqlite3.Error, ValueError):
+            continue
+        finally:
+            connection.close()
+    return False
+
+
+def _open_state_db_readonly(path: Path) -> sqlite3.Connection | None:
+    """Open kiro-cli's state store read-only, or return None if it cannot be read.
+
+    Mirrors the readiness probe's gates on the same file: reject a symlink and
+    require a regular file, then hand SQLite a read-only URI.
+
+    ``mode=ro`` WITHOUT ``immutable=1``. The immutable flag avoids touching a
+    sidecar, but it also tells SQLite the file cannot change, so the WAL is
+    IGNORED — and against a store in WAL mode whose newest commits are still in
+    ``data.sqlite3-wal`` the identity rows read as absent. A fresh Identity
+    Center sign-in would then look like a personal account and silence the very
+    governance diagnosis this function exists to trigger. Plain ``mode=ro``
+    applies the WAL, so the answer matches what kiro-cli itself would read; the
+    cost is that SQLite may create or refresh the ``-shm`` index beside the live
+    database exactly as any other reader does, and it holds no identity data.
+    """
+    try:
+        if path.is_symlink():
+            return None
+        if not stat.S_ISREG(os.lstat(str(path)).st_mode):
+            return None
+    except OSError:
+        return None
+    uri = f"file:{urllib.request.pathname2url(str(path))}?mode=ro"
+    try:
+        return sqlite3.connect(uri, uri=True, timeout=_STATE_DB_TIMEOUT_SECS)
+    except sqlite3.Error:
+        return None
 
 
 def _unique(items: list[str]) -> list[str]:

--- a/test/test_mcp_registry_governance.py
+++ b/test/test_mcp_registry_governance.py
@@ -1,0 +1,455 @@
+"""Enterprise MCP registry governance: spec markers, detection, doctor section.
+
+An enterprise Kiro profile with an MCP Registry URL puts kiro-cli in `registry`
+access mode, where it connects ONLY to `mcpServers` entries carrying
+``"type": "registry"`` that resolve to a catalog entry of the same name. Outside
+that mode the filter inverts and marked entries are the dropped ones, so the
+marker has to appear exactly when the operator declares the account governed and
+disappear when they do not.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import agent as agent_mod
+from kiro_crew import cli_doctor
+from kiro_crew import kiro_cli as kiro_cli_mod
+from kiro_crew.config import KiroCrewConfig
+from kiro_crew.kiro_cli import (
+    kiro_cli_state_dbs,
+    mcp_governance_may_apply,
+    signed_in_via_idc,
+)
+
+MANAGED = ("kirocrew-core", "kirocrew-cron", "kirocrew-computer")
+
+
+def _write_config(home: Path, *, registry_mode: bool | None) -> Path:
+    path = home / "config.json"
+    agent: dict[str, object] = {}
+    if registry_mode is not None:
+        agent["mcp_registry_mode"] = registry_mode
+    path.write_text(json.dumps({"agent": agent}), encoding="utf-8")
+    return path
+
+
+def _point_config_at(tmp_path: Path, monkeypatch) -> None:
+    """Make both config readers resolve to tmp_path.
+
+    ``_mcp_registry_mode`` reads the EFFECTIVE config (base + local overlay) via
+    the loader, which resolves from ``KIROCREW_HOME``; the fallback path reads the
+    base file directly. Point both, and drop the load cache so a per-test config
+    is actually seen.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr(agent_mod, "_mc_config_path", lambda: tmp_path / "config.json")
+    if hasattr(KiroCrewConfig.load, "cache_clear"):
+        KiroCrewConfig.load.cache_clear()
+
+
+class TestRegistryModeDeclaration:
+    def test_absent_key_is_not_registry_mode(self, tmp_path, monkeypatch):
+        """A personal install must emit today's spec byte-for-byte."""
+        _write_config(tmp_path, registry_mode=None)
+        _point_config_at(tmp_path, monkeypatch)
+        assert agent_mod._mcp_registry_mode() is False
+
+    def test_declared_true_is_registry_mode(self, tmp_path, monkeypatch):
+        _write_config(tmp_path, registry_mode=True)
+        _point_config_at(tmp_path, monkeypatch)
+        assert agent_mod._mcp_registry_mode() is True
+
+    @pytest.mark.parametrize("junk", ["true", 1, [], {"a": 1}, None])
+    def test_only_a_real_bool_counts(self, tmp_path, monkeypatch, junk):
+        """A truthy string from a hand-edited config must not silently arm the
+        marker: arming it wrongly breaks an ungoverned install outright. The
+        loader's own coercion is strict the same way, so both paths agree."""
+        (tmp_path / "config.json").write_text(
+            json.dumps({"agent": {"mcp_registry_mode": junk}}), encoding="utf-8"
+        )
+        _point_config_at(tmp_path, monkeypatch)
+        assert agent_mod._mcp_registry_mode() is False
+
+    def test_missing_config_file_is_not_registry_mode(self, tmp_path, monkeypatch):
+        _point_config_at(tmp_path, monkeypatch)
+        monkeypatch.setattr(agent_mod, "_mc_config_path", lambda: tmp_path / "nope.json")
+        assert agent_mod._mcp_registry_mode() is False
+
+    def test_config_loader_round_trips_the_field(self, tmp_path, monkeypatch):
+        _write_config(tmp_path, registry_mode=True)
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        KiroCrewConfig.load.cache_clear() if hasattr(KiroCrewConfig.load, "cache_clear") else None
+        cfg = KiroCrewConfig.load()
+        assert cfg.agent.mcp_registry_mode is True
+
+    def test_local_overlay_declaration_is_honoured(self, tmp_path, monkeypatch):
+        """`kirocrew config set --local` writes config.local.json, which deep-merges
+        OVER config.json. Reading only the base file would ignore a declaration made
+        the way the CLI advertises as upgrade-durable, emit no marker, and reproduce
+        the silent drop this change exists to prevent."""
+        _write_config(tmp_path, registry_mode=None)
+        (tmp_path / "config.local.json").write_text(
+            json.dumps({"agent": {"mcp_registry_mode": True}}), encoding="utf-8"
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        monkeypatch.setattr(agent_mod, "_mc_config_path", lambda: tmp_path / "config.json")
+        if hasattr(KiroCrewConfig.load, "cache_clear"):
+            KiroCrewConfig.load.cache_clear()
+        assert agent_mod._mcp_registry_mode() is True
+
+    def test_local_overlay_can_turn_the_declaration_off(self, tmp_path, monkeypatch):
+        """Precedence runs both ways: an overlay that disables it must win over a
+        base file that enables it, or a host cannot switch the marker off."""
+        _write_config(tmp_path, registry_mode=True)
+        (tmp_path / "config.local.json").write_text(
+            json.dumps({"agent": {"mcp_registry_mode": False}}), encoding="utf-8"
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        monkeypatch.setattr(agent_mod, "_mc_config_path", lambda: tmp_path / "config.json")
+        if hasattr(KiroCrewConfig.load, "cache_clear"):
+            KiroCrewConfig.load.cache_clear()
+        assert agent_mod._mcp_registry_mode() is False
+
+
+class TestIdentityProbeIsAudited:
+    """The store holds live credential material, so the probe owes an SEL event.
+
+    Registered in ``hooks._AUDIT_ONLY_READ_IDS`` and FAIL-CLOSED: no audit means
+    no read, which costs a diagnostic hint rather than an unaudited credential
+    access.
+    """
+
+    def test_read_id_is_registered(self):
+        from kiro_crew import hooks
+
+        assert kiro_cli_mod._IDC_PROBE_READ_ID in hooks._AUDIT_ONLY_READ_IDS
+
+    def test_probe_emits_an_audit_event(self, tmp_path, monkeypatch):
+        db = kiro_cli_state_dbs("linux", tmp_path, {})[0]
+        TestIdcDetection._make_db(db, ("auth.idc.start-url",))
+        seen: list[tuple[str, str]] = []
+
+        def _spy(read_id: str, outcome: str) -> bool:
+            seen.append((read_id, outcome))
+            return True
+
+        monkeypatch.setattr("kiro_crew.hooks.emit_internal_read_audit", _spy)
+        assert signed_in_via_idc("linux", tmp_path, {}) is True
+        assert seen and seen[0][0] == kiro_cli_mod._IDC_PROBE_READ_ID
+
+    def test_probe_fails_closed_when_the_audit_is_unavailable(self, tmp_path, monkeypatch):
+        """An unregistered or unavailable audit surface must stop the read, not
+        merely log — otherwise the audit requirement is advisory."""
+        db = kiro_cli_state_dbs("linux", tmp_path, {})[0]
+        TestIdcDetection._make_db(db, ("auth.idc.start-url",))
+        monkeypatch.setattr("kiro_crew.hooks.emit_internal_read_audit", lambda *_: False)
+        assert signed_in_via_idc("linux", tmp_path, {}) is False
+
+
+class TestFreshInstallMarker:
+    def test_no_marker_outside_registry_mode(self, monkeypatch):
+        monkeypatch.setattr(agent_mod, "_mcp_registry_mode", lambda: False)
+        config = agent_mod.build_agent_config()
+        for name in MANAGED:
+            assert "type" not in config["mcpServers"][name], name
+
+    def test_marker_on_every_managed_server_in_registry_mode(self, monkeypatch):
+        monkeypatch.setattr(agent_mod, "_mcp_registry_mode", lambda: True)
+        config = agent_mod.build_agent_config()
+        for name in MANAGED:
+            assert config["mcpServers"][name]["type"] == "registry", name
+
+    def test_marker_does_not_replace_the_command(self, monkeypatch):
+        """command/args stay so doctor's handshake probe, the CC sidecar sync and
+        a later ungoverned refresh still describe a runnable server."""
+        monkeypatch.setattr(agent_mod, "_mcp_registry_mode", lambda: True)
+        entry = agent_mod.build_agent_config()["mcpServers"]["kirocrew-core"]
+        assert entry["command"]
+        assert entry["args"] == ["mcp-core"] or "mcp-core" in entry["args"]
+
+
+class TestRefreshMarker:
+    def test_refresh_adds_the_marker(self, monkeypatch):
+        monkeypatch.setattr(agent_mod, "_mcp_registry_mode", lambda: True)
+        config = {"mcpServers": {name: {"command": "x", "args": []} for name in MANAGED}}
+        agent_mod._refresh_dynamic_fields(config)
+        for name in MANAGED:
+            assert config["mcpServers"][name]["type"] == "registry", name
+
+    def test_refresh_removes_a_stale_marker(self, monkeypatch):
+        """A host that leaves an enterprise account must stop shipping a marker
+        that the inverse filter would now use to drop these servers."""
+        monkeypatch.setattr(agent_mod, "_mcp_registry_mode", lambda: False)
+        config = {
+            "mcpServers": {
+                name: {"command": "x", "args": [], "type": "registry"} for name in MANAGED
+            }
+        }
+        agent_mod._refresh_dynamic_fields(config)
+        for name in MANAGED:
+            assert "type" not in config["mcpServers"][name], name
+
+    def test_refresh_preserves_a_user_transport_hint(self, monkeypatch):
+        """Only the registry marker is ours. A transport hint the user wrote is
+        theirs, and kiro-cli tolerates it."""
+        monkeypatch.setattr(agent_mod, "_mcp_registry_mode", lambda: False)
+        config = {"mcpServers": {"kirocrew-core": {"command": "x", "args": [], "type": "stdio"}}}
+        agent_mod._refresh_dynamic_fields(config)
+        assert config["mcpServers"]["kirocrew-core"]["type"] == "stdio"
+
+
+class TestIdcDetection:
+    @staticmethod
+    def _make_db(path: Path, keys: tuple[str, ...]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        con = sqlite3.connect(path)
+        con.execute("CREATE TABLE state (key TEXT PRIMARY KEY, value TEXT)")
+        con.executemany("INSERT INTO state VALUES (?, ?)", [(k, "v") for k in keys])
+        con.commit()
+        con.close()
+
+    def test_idc_rows_are_detected(self, tmp_path):
+        db = kiro_cli_state_dbs("linux", tmp_path, {})[0]
+        self._make_db(db, ("auth.idc.start-url", "auth.idc.region"))
+        assert signed_in_via_idc("linux", tmp_path, {}) is True
+
+    def test_builder_id_store_is_not_idc(self, tmp_path):
+        db = kiro_cli_state_dbs("linux", tmp_path, {})[0]
+        self._make_db(db, ("telemetryClientId", "migration.kiro.completed"))
+        assert signed_in_via_idc("linux", tmp_path, {}) is False
+
+    def test_absent_store_is_not_idc(self, tmp_path):
+        assert signed_in_via_idc("linux", tmp_path, {}) is False
+
+    def test_corrupt_store_is_not_idc(self, tmp_path):
+        """"Cannot tell" must never render as an enterprise diagnosis."""
+        db = kiro_cli_state_dbs("linux", tmp_path, {})[0]
+        db.parent.mkdir(parents=True, exist_ok=True)
+        db.write_bytes(b"not a database")
+        assert signed_in_via_idc("linux", tmp_path, {}) is False
+
+    def test_xdg_data_home_redirection_is_followed(self, tmp_path):
+        moved = tmp_path / "elsewhere"
+        db = kiro_cli_state_dbs("linux", tmp_path, {"XDG_DATA_HOME": str(moved)})[0]
+        assert moved in db.parents
+        self._make_db(db, ("auth.idc.region",))
+        assert signed_in_via_idc("linux", tmp_path, {"XDG_DATA_HOME": str(moved)}) is True
+
+    def test_rows_still_in_the_wal_are_seen(self, tmp_path):
+        """A fresh Identity Center sign-in commits into `data.sqlite3-wal`. Opening
+        with `immutable=1` would ignore the WAL and read the rows as absent, so a
+        just-signed-in enterprise host would look personal and the whole governance
+        diagnosis would go silent — the same silent-failure class this fixes."""
+        db = kiro_cli_state_dbs("linux", tmp_path, {})[0]
+        db.parent.mkdir(parents=True, exist_ok=True)
+        writer = sqlite3.connect(db)
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("CREATE TABLE state (key TEXT PRIMARY KEY, value TEXT)")
+        writer.execute("INSERT INTO state VALUES ('auth.idc.start-url', 'x')")
+        writer.commit()
+        # Keep the writer open and DO NOT checkpoint, so the row lives in the -wal
+        # sidecar rather than the main database file.
+        try:
+            assert (db.parent / "data.sqlite3-wal").exists()
+            assert signed_in_via_idc("linux", tmp_path, {}) is True
+        finally:
+            writer.close()
+
+    def test_symlinked_store_is_refused(self, tmp_path):
+        """Path defenses match the readiness probe's on the same file.
+
+        Two redundant gates close this: the symlink check and the regular-file
+        check (``lstat`` reports the link itself, not its target). Removing
+        either alone leaves the other holding, so this asserts the behaviour
+        rather than one gate — it fails only when both are gone.
+        """
+        real = tmp_path / "real.sqlite3"
+        self._make_db(real, ("auth.idc.region",))
+        db = kiro_cli_state_dbs("linux", tmp_path, {})[0]
+        db.parent.mkdir(parents=True, exist_ok=True)
+        db.symlink_to(real)
+        assert signed_in_via_idc("linux", tmp_path, {}) is False
+
+
+class TestGovernanceCapableIdentity:
+    """Governance covers Identity Center AND API-key sign-ins.
+
+    Answering "ungoverned" for the signal a caller does not check is what turns
+    the diagnostic into advice that breaks a correctly configured host.
+    """
+
+    def test_api_key_alone_is_governance_capable(self, tmp_path):
+        assert mcp_governance_may_apply("linux", tmp_path, {"KIRO_API_KEY": "abc"}) is True
+
+    def test_blank_api_key_is_not_a_credential(self, tmp_path):
+        assert mcp_governance_may_apply("linux", tmp_path, {"KIRO_API_KEY": "   "}) is False
+
+    def test_no_signal_is_not_governance_capable(self, tmp_path):
+        assert mcp_governance_may_apply("linux", tmp_path, {}) is False
+
+    def test_idc_alone_is_governance_capable(self, tmp_path):
+        db = kiro_cli_state_dbs("linux", tmp_path, {})[0]
+        TestIdcDetection._make_db(db, ("auth.idc.start-url",))
+        assert mcp_governance_may_apply("linux", tmp_path, {}) is True
+
+
+class TestDoctorGovernanceSection:
+    def _spec(self, tmp_path: Path, *, marked: bool) -> Path:
+        entry: dict[str, object] = {"command": "kirocrew", "args": ["mcp-core"]}
+        if marked:
+            entry["type"] = "registry"
+        path = tmp_path / "kirocrew.json"
+        path.write_text(
+            json.dumps({"mcpServers": {name: dict(entry) for name in MANAGED}}), encoding="utf-8"
+        )
+        return path
+
+    def test_silent_on_a_personal_account(self, tmp_path, monkeypatch, capsys):
+        """A governance warning in front of every personal install is noise."""
+        monkeypatch.setattr(cli_doctor, "mcp_governance_may_apply", lambda: False)
+        monkeypatch.setattr(
+            cli_doctor.KiroCrewConfig, "load", staticmethod(lambda: _cfg(registry_mode=False))
+        )
+        issues: list[str] = []
+        cli_doctor._doctor_mcp_governance(self._spec(tmp_path, marked=False), issues)
+        assert capsys.readouterr().out == ""
+        assert issues == []
+
+    def test_declared_on_a_non_idc_account_is_flagged(self, tmp_path, monkeypatch, capsys):
+        """The inverse filter. Outside registry mode a MARKED entry is the one the
+        client drops, so this state breaks the same servers just as silently — and
+        it is reachable by copying the guide onto a personal account."""
+        monkeypatch.setattr(cli_doctor, "mcp_governance_may_apply", lambda: False)
+        monkeypatch.setattr(
+            cli_doctor.KiroCrewConfig, "load", staticmethod(lambda: _cfg(registry_mode=True))
+        )
+        issues: list[str] = []
+        cli_doctor._doctor_mcp_governance(self._spec(tmp_path, marked=True), issues)
+        out = capsys.readouterr().out
+        assert issues == ["MCP registry mode on non-IDC account"]
+        assert "mcp_registry_mode false" in out
+        for name in MANAGED:
+            assert name in out
+
+    def test_stale_markers_without_the_declaration_are_flagged(self, tmp_path, monkeypatch, capsys):
+        """Markers can outlive the declaration (a spec written under an enterprise
+        account, refreshed by an older build). Same silent drop, so same warning."""
+        monkeypatch.setattr(cli_doctor, "mcp_governance_may_apply", lambda: False)
+        monkeypatch.setattr(
+            cli_doctor.KiroCrewConfig, "load", staticmethod(lambda: _cfg(registry_mode=False))
+        )
+        issues: list[str] = []
+        cli_doctor._doctor_mcp_governance(self._spec(tmp_path, marked=True), issues)
+        assert issues == ["MCP registry mode on non-IDC account"]
+        assert "markers are present" in capsys.readouterr().out
+
+    def test_idc_without_declaration_explains_the_silent_failure(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(cli_doctor, "mcp_governance_may_apply", lambda: True)
+        monkeypatch.setattr(
+            cli_doctor.KiroCrewConfig, "load", staticmethod(lambda: _cfg(registry_mode=False))
+        )
+        cli_doctor._doctor_mcp_governance(self._spec(tmp_path, marked=False), [])
+        out = capsys.readouterr().out
+        assert "registry mode: off" in out
+        assert "agent.mcp_registry_mode true" in out
+        for name in MANAGED:
+            assert name in out
+
+    def test_declared_but_unmarked_spec_is_an_issue(self, tmp_path, monkeypatch, capsys):
+        """Declaring the mode and shipping an unmarked spec is the one state that
+        silently drops every managed server, so it must not read as healthy."""
+        monkeypatch.setattr(cli_doctor, "mcp_governance_may_apply", lambda: True)
+        monkeypatch.setattr(
+            cli_doctor.KiroCrewConfig, "load", staticmethod(lambda: _cfg(registry_mode=True))
+        )
+        issues: list[str] = []
+        cli_doctor._doctor_mcp_governance(self._spec(tmp_path, marked=False), issues)
+        assert issues == ["MCP registry markers"]
+        assert "markers missing" in capsys.readouterr().out
+
+    def test_declared_and_marked_reports_the_names_to_allow_list(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(cli_doctor, "mcp_governance_may_apply", lambda: True)
+        monkeypatch.setattr(
+            cli_doctor.KiroCrewConfig, "load", staticmethod(lambda: _cfg(registry_mode=True))
+        )
+        issues: list[str] = []
+        cli_doctor._doctor_mcp_governance(self._spec(tmp_path, marked=True), issues)
+        out = capsys.readouterr().out
+        assert issues == []
+        assert "allow-listed" in out
+        for name in MANAGED:
+            assert name in out
+        # Whether the admin actually allow-listed the names is not knowable
+        # locally, so this branch must not render as a verified success.
+        assert "✅" not in out
+        assert "cannot verify" in out
+        # And it must name the way out of a stale declaration.
+        assert "mcp_registry_mode false" in out
+
+
+class TestDoctorSurvivesAMalformedSpec:
+    """Doctor must not crash on the spec shapes it exists to diagnose.
+
+    `spec.get("mcpServers") or {}` only replaces a FALSY value, so a string or
+    list survives and the membership walk raises AttributeError, aborting the
+    whole doctor run.
+    """
+
+    @pytest.mark.parametrize(
+        "servers", ["not-a-dict", ["kirocrew-core"], 7, True, "", [], {}]
+    )
+    def test_non_dict_mcp_servers_does_not_crash(self, tmp_path, monkeypatch, capsys, servers):
+        path = tmp_path / "kirocrew.json"
+        path.write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
+        monkeypatch.setattr(cli_doctor, "mcp_governance_may_apply", lambda: True)
+        monkeypatch.setattr(
+            cli_doctor.KiroCrewConfig, "load", staticmethod(lambda: _cfg(registry_mode=True))
+        )
+        issues: list[str] = []
+        cli_doctor._doctor_mcp_governance(path, issues)
+        out = capsys.readouterr().out
+        # No marker can be read from a malformed map, so it reports the missing
+        # markers rather than raising.
+        assert "markers missing" in out
+        assert issues == ["MCP registry markers"]
+
+    @pytest.mark.parametrize("body", ["[]", "null", '"a string"', "not json at all", ""])
+    def test_malformed_spec_file_does_not_crash(self, tmp_path, monkeypatch, capsys, body):
+        path = tmp_path / "kirocrew.json"
+        path.write_text(body, encoding="utf-8")
+        monkeypatch.setattr(cli_doctor, "mcp_governance_may_apply", lambda: True)
+        monkeypatch.setattr(
+            cli_doctor.KiroCrewConfig, "load", staticmethod(lambda: _cfg(registry_mode=False))
+        )
+        issues: list[str] = []
+        cli_doctor._doctor_mcp_governance(path, issues)
+        assert "registry mode: off" in capsys.readouterr().out
+
+    def test_missing_spec_file_does_not_crash(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(cli_doctor, "mcp_governance_may_apply", lambda: True)
+        monkeypatch.setattr(
+            cli_doctor.KiroCrewConfig, "load", staticmethod(lambda: _cfg(registry_mode=False))
+        )
+        cli_doctor._doctor_mcp_governance(tmp_path / "absent.json", [])
+        assert "registry mode: off" in capsys.readouterr().out
+
+
+def _cfg(*, registry_mode: bool):
+    """Minimal stand-in for the loaded config: only the one field is read."""
+
+    class _Agent:
+        mcp_registry_mode = registry_mode
+
+    class _Cfg:
+        agent = _Agent()
+
+    return _Cfg()


### PR DESCRIPTION
## Problem

A user on an enterprise Kiro account reported that most of Kiro Crew never
worked for them, and spent weeks debugging it. Their administrator had MCP
governance active with a vetted server list that did not include Kiro Crew's
servers.

An enterprise Kiro profile with an **MCP Registry URL** puts kiro-cli in
`registry` access mode. In that mode the client connects **only** to `mcpServers`
entries carrying `"type": "registry"` that resolve to a catalog entry of the same
name (matched on the map key), and drops every other entry when it assembles a
session — `resolve-registry-entries.ts` excludes non-registry servers as
`accessModeFiltered`.

The three managed servers carried no such marker, so on a governed host they were
filtered out before launch. `spawn_run`, `cron_add`, `learn_add`, knowledge and
the research agent silently disappeared. Nothing errored.

Worse, the existing diagnostic actively pointed away from the cause: doctor's
handshake probe spawns each server **directly**, so it reports every server
healthy on exactly the hosts where kiro-cli refuses to load them.

No documentation covered any of this — no page on running Kiro Crew under an
enterprise account, and nothing stating which servers an administrator must
allow-list.

## Change

**The marker, declared not guessed.** `agent.mcp_registry_mode` declares the
account governed; the managed servers are then stamped with the registry marker,
and it is removed again when the declaration is off.

Two reasons it is neither unconditional nor auto-detected:

- The filter is **symmetric**. Outside registry mode, a marked entry is the one
  that gets dropped, so stamping unconditionally would break every personal
  install.
- The mode **cannot** be detected. The client reads the toggle and the registry
  URL from `GetProfile` at startup and persists neither, so nothing on disk
  distinguishes a governed account from an ungoverned one. Verified against the
  local state store: it holds `auth.idc.*` and the profile ARN, but no
  `mcpRegistryUrl` and no `optInFeatures`.

`command`/`args` are kept on a marked entry, since the registry path is not the
only consumer of this spec — doctor's probe and the CC sidecar sync both launch
from it.

**The diagnostic.** Doctor grows an `MCP Governance (enterprise)` section that
names the current state and the three names an administrator must allow-list. It
is silent unless the local identity came from Identity Center, so personal
installs see nothing. It runs *after* the probe deliberately: the probe reporting
green is the condition it exists to explain.

`signed_in_via_idc` reads two non-secret marker rows from kiro-cli's state store,
read-only and key-scoped, never touching a credential row, and returns `False` on
any failure so an unreadable store cannot manufacture an enterprise diagnosis.

**The docs.** A guide covering the two-sided fix, with the registry JSON an
administrator needs (`pypi` package entries under the three exact names) and an
honest write-up of the limitation it carries: a registry-type entry hands the
launch decision to the catalog, so it can start a *different* Kiro Crew than the
gateway being served, and the registry `version` has to track the fleet. Plus a
user-facing troubleshooting entry, and a fix for two docs that still listed two
managed servers instead of three.

## Correcting a plausible wrong fix

The reported fix was "add `type: registry` to every MCP server". Applied
literally that is worse than the bug: it would break every personal install
through the inverse filter, and it does not help by itself either, since a marked
entry only connects if the administrator has added that name to the catalog. Both
halves are required, which is why the guide covers the administrator side.

## Verification

- 24 new tests. **All 5 fixes revert-verified** — each patched out individually,
  each paired test confirmed failing, tree restored, suite green again.
- Covered both directions of the marker (added, and stale marker removed), the
  truthy-junk case (a hand-edited `"true"` string must not arm it), a user's own
  transport hint surviving, IDC detection including `XDG_DATA_HOME`
  redirection / corrupt store / Builder ID store, and all four doctor states.
- `isort` / `flake8` / `mypy` (944 files) clean at CI's exact scope.
- `docs-lint.sh` passes (201 files).
- Full backend suite A/B against the pristine base: **identical 67-name failure
  set on both arms**, so every failure is pre-existing host environment
  (worktree/ssh/sandbox/git), none from this change.

No frontend change: `_meta` feeds `config-baseline.json` only, and there is no
schema-driven settings renderer.

## Follow-up worth tracking separately

kiro.dev's docs and its launch blog disagree on whether personal `mcp.json`
servers load alongside registry-managed ones. The changelog says 2.6.0 made them
load, but Kiro Crew's servers live in an agent spec rather than personal
`mcp.json`, so that change does not exempt them. Worth confirming with the
kiro-cli team.
