### PR TITLE
fix: stop auto-speak repeating the whole reply after a segment reset

### DIFF
--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -189,6 +189,11 @@ export function useWebSocket() {
   const activeAudioRef = useRef<HTMLAudioElement | null>(null)
   const autoSpeakRef = useRef(false)
   const spokenLenRef = useRef(0)  // chars already sent to TTS during streaming
+  // Whether the streaming path synthesized anything this turn. chat_segment
+  // resets spokenLenRef to 0, so the completion pass cannot tell "nothing
+  // spoken yet" (speak the whole reply) from "spoken, then segment-reset"
+  // (speaking from 0 repeats the entire reply) without this.
+  const spokeThisTurnRef = useRef(false)
   const voiceMutedRef = useRef(false)  // suppress incoming chunks after interrupt
   const synthChainRef = useRef<Promise<unknown>>(Promise.resolve())  // serialize TTS calls
   // #1 streaming-chunk coalescing: accumulate per-slot chunk text and flush
@@ -404,6 +409,11 @@ export function useWebSocket() {
       const streaming = [...msgs].reverse().find(m => m.role === 'streaming')
       if (streaming) {
         const full = streaming.content
+        // The counter is 0 with the spoke-flag still set only right after a
+        // chat_segment reset. New streaming content in that state is a fresh
+        // post-segment block — the trailing message is no longer the
+        // already-spoken one, so the completion pass must not skip it.
+        if (spokenLenRef.current === 0 && full.length > 0) spokeThisTurnRef.current = false
         let lastBound = -1
         const re = /[.!?](?:\s|$)/g
         let match
@@ -414,6 +424,7 @@ export function useWebSocket() {
           const newText = full.slice(spokenLenRef.current, lastBound).trim()
           if (newText.length >= 10) {
             spokenLenRef.current = lastBound
+            spokeThisTurnRef.current = true
             synthChainRef.current = synthChainRef.current
               .then(() => api.voiceSynthesize(activeSlot, newText))
               .catch(() => {})
@@ -821,7 +832,7 @@ export function useWebSocket() {
             // trigger (no-op unless an L2 theme with that manifest sound is
             // active + unmuted). User/tool messages don't chime.
             if (data.role === 'assistant') emitThemeSound('message-received')
-            if (data.role === 'user' || data.role === 'inject' || data.role === 'subagent') { stopVoice(); spokenLenRef.current = 0; synthChainRef.current = Promise.resolve() }
+            if (data.role === 'user' || data.role === 'inject' || data.role === 'subagent') { stopVoice(); spokenLenRef.current = 0; spokeThisTurnRef.current = false; synthChainRef.current = Promise.resolve() }
             if (data.slot && (data.role === 'user' || data.role === 'inject' || data.role === 'subagent')) {
               dispatch(setSlotStatusDetail({ slot: data.slot, kind: 'thinking', text: 'Thinking…', ts: Date.now() }))
             }
@@ -1164,13 +1175,18 @@ export function useWebSocket() {
               const last = [...msgs].reverse().find(m => m.role === 'assistant')
               if (last) {
                 const remaining = last.content.slice(spokenLenRef.current).trim()
-                if (remaining.length >= 10) {
+                // spokenLen 0 after streaming spoke means chat_segment reset
+                // the counter — "remaining" would then be the whole reply,
+                // repeating everything already spoken.
+                const segmentReset = spokeThisTurnRef.current && spokenLenRef.current === 0
+                if (remaining.length >= 10 && !segmentReset) {
                   synthChainRef.current = synthChainRef.current
                     .then(() => api.voiceSynthesize(data.slot, remaining))
                     .catch(() => {})
                 }
               }
               spokenLenRef.current = 0
+              spokeThisTurnRef.current = false
             } else if (data.slot === store.getState().chat.activeSlot) {
               // Re-check config in case it changed
               api.voiceConfig().then(c => { autoSpeakRef.current = !!c.autoSpeak }).catch(() => {})

--- a/website/src/test/useWebSocket.autoSpeakSegmentReset.test.ts
+++ b/website/src/test/useWebSocket.autoSpeakSegmentReset.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Auto-speak's turn-completion pass exists to speak only the tail the
+ * sentence-boundary streamer never reached. `chat_segment` resets the
+ * spoken-length counter to 0, so after a segment the completion pass would
+ * slice the finished reply from 0 and speak EVERYTHING a second time.
+ *
+ * These tests pin both sides: a segment-reset turn is not re-spoken, and a
+ * reply that never streamed through the sentence path is still spoken in full.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useWebSocket } from '../hooks/useWebSocket'
+import { store } from '../store'
+import { setActiveSlot, clearMessages } from '../store/chatSlice'
+import { api } from '../api/client'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: true }),
+    voiceSynthesize: vi.fn().mockResolvedValue({}),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() { WS_INSTANCES.push(this) }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+const SENTENCE = 'This is the first spoken sentence. '
+
+describe('useWebSocket auto-speak after a segment reset', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    // The hook reads streamed messages and the active slot off the singleton
+    // store, so the Provider must hand it that same store.
+    store.dispatch(setActiveSlot('slot-1'))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    store.dispatch(clearMessages())
+    store.dispatch(setActiveSlot(null))
+  })
+
+  async function mount() {
+    function wrapper({ children }: { children: React.ReactNode }) {
+      return createElement(Provider, { store },
+        createElement(QueryClientProvider, { client: queryClient }, children))
+    }
+    const hook = renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    // Let the onopen voiceConfig() promise resolve so autoSpeak is cached.
+    await act(async () => {})
+    return { hook, ws }
+  }
+
+  it('does not re-speak the whole reply when chat_segment reset the counter', async () => {
+    const { hook, ws } = await mount()
+
+    // Stream a full sentence, then a segment boundary: the flush speaks the
+    // sentence, the segment finalizes it and resets the spoken counter.
+    act(() => {
+      ws.simulateMessage({ type: 'chat_chunk', data: { slot: 'slot-1', content: SENTENCE, seq: 1 } })
+      ws.simulateMessage({ type: 'chat_segment', data: { slot: 'slot-1' } })
+    })
+    await act(async () => {})
+    expect(api.voiceSynthesize).toHaveBeenCalledTimes(1)
+    expect(api.voiceSynthesize).toHaveBeenCalledWith('slot-1', SENTENCE.trim())
+
+    // Turn completion: everything streamed was already spoken, so nothing may
+    // be synthesized again — slicing from the reset counter would repeat the
+    // entire reply.
+    act(() => { ws.simulateMessage({ type: 'chat_done', data: { slot: 'slot-1' } }) })
+    await act(async () => {})
+    expect(api.voiceSynthesize).toHaveBeenCalledTimes(1)
+
+    hook.unmount()
+  })
+
+  it('still speaks a reply that never went through the streaming path', async () => {
+    const { hook, ws } = await mount()
+
+    // A short or non-streamed reply arrives as a plain assistant message: the
+    // completion pass is its only chance to be spoken, and the counter is 0
+    // because nothing streamed — that must not be mistaken for a segment reset.
+    act(() => {
+      ws.simulateMessage({ type: 'chat_message', data: { slot: 'slot-1', role: 'assistant', content: 'A reply that never streamed at all.', ts: '10.0' } })
+      ws.simulateMessage({ type: 'chat_done', data: { slot: 'slot-1' } })
+    })
+    await act(async () => {})
+
+    expect(api.voiceSynthesize).toHaveBeenCalledTimes(1)
+    expect(api.voiceSynthesize).toHaveBeenCalledWith('slot-1', 'A reply that never streamed at all.')
+
+    hook.unmount()
+  })
+
+  it('speaks an unspoken post-segment tail that never crossed a sentence boundary', async () => {
+    const { hook, ws } = await mount()
+
+    // First segment: a full sentence streams and is spoken, then the segment
+    // finalizes it and resets the counter.
+    act(() => {
+      ws.simulateMessage({ type: 'chat_chunk', data: { slot: 'slot-1', content: SENTENCE, seq: 1 } })
+      ws.simulateMessage({ type: 'chat_segment', data: { slot: 'slot-1' } })
+    })
+    await act(async () => {})
+    expect(api.voiceSynthesize).toHaveBeenCalledTimes(1)
+
+    // Second segment: a NEW block streams but never crosses the sentence
+    // boundary regex (no terminal punctuation — a list item, code fence, or
+    // bare URL ending). The completion pass is its only chance to be spoken;
+    // the segment-reset skip must not swallow it.
+    const TAIL = 'a final unpunctuated tail block'
+    act(() => {
+      ws.simulateMessage({ type: 'chat_chunk', data: { slot: 'slot-1', content: TAIL, seq: 2 } })
+    })
+    await act(async () => {})
+    act(() => { ws.simulateMessage({ type: 'chat_done', data: { slot: 'slot-1' } }) })
+    await act(async () => {})
+
+    expect(api.voiceSynthesize).toHaveBeenCalledTimes(2)
+    expect(api.voiceSynthesize).toHaveBeenLastCalledWith('slot-1', TAIL)
+
+    hook.unmount()
+  })
+})


### PR DESCRIPTION
## Problem

With auto-speak enabled, any reply containing a segment boundary is spoken twice: streaming speaks each finished sentence, then at turn completion the entire reply is synthesized again from the start.

## Why it matters

Voice replies become unusable on longer answers — everything already heard replays from the beginning — and every double-spoken reply is double TTS cost.

## Fix (symptoms → root cause → change)

`chat_segment` resets the spoken-length counter (`spokenLenRef`) to 0, so the completion pass — which exists to speak only the tail the sentence-boundary streamer never reached — sliced the finished reply from 0 and re-spoke everything. A turn-scoped `spokeThisTurnRef` flag distinguishes "nothing spoken yet" (short or non-streamed replies are still spoken in full at completion) from "spoken, then segment-reset" (skip).

On top of the original fix, one edge the flag alone missed is handled: after a segment, a **new** post-segment block that never crosses the sentence-boundary regex (a list item, code fence, or bare URL ending) would present the same `spokenLen === 0 && spokeThisTurn` signature and be silently dropped. New streaming content arriving while the counter is 0 clears the flag — at that point the trailing message is by construction a fresh unspoken block, so the completion pass speaks it.

## Tests

`website/src/test/useWebSocket.autoSpeakSegmentReset.test.ts` (new) drives the WebSocket frames three ways:

- a streamed sentence followed by `chat_segment` + `chat_done` synthesizes exactly once (the double-speak regression)
- a reply that never streamed is still spoken in full at completion
- an unpunctuated post-segment tail is still spoken (mutation-checked: fails without the hook fix)

`npx tsc -b` clean; targeted vitest (all `useWebSocket*` + `UseWebSocketCoverage`, 178 tests) and the full frontend suite pass locally (one unrelated `CliPanelCoverage` flake, passes in isolation).

## Manual verification

N/A — the WebSocket-frame tests drive the exact prod paths (flush, segment, done); no rendered surface changes.

<!-- no-visual-delta -->
**Why no screenshot:** audio-only behavior change in a hook; no pixel changes.

## Credit

This recreates **PR #1893 by @Premshay** on an org-owned branch — the original's CI failures were pure base drift. The design, mechanism, and test approach are the original author's; this PR adds only the post-segment-tail edge fix + its regression test found during local review. Full credit to @Premshay.

no issue closed: upstream PR #1893 describes the defect; no separate issue exists.
