### PR TITLE
docs(chat): point the unwired transcript options at the reason, not a closed issue

### DIFF
--- a/website/src/pages/chat/transcriptRenderers.tsx
+++ b/website/src/pages/chat/transcriptRenderers.tsx
@@ -49,18 +49,21 @@ export interface TranscriptRendererOptions {
   toolDisclosure?: Record<string, boolean>
   onToolDisclosureChange?: (key: string, expanded: boolean) => void
   /** Whether an MCP app may be revealed in the panel, and how. Unwired from a
-   *  pane for the same reason as `onFileOpen` — tracked in #3332. */
+   *  pane for the same reason as `onFileOpen` — the dock is `activeSlot`-keyed
+   *  while pane focus is not, tracked in #3300. */
   appInPanel?: boolean
   onOpenApp?: (toolCallId: string) => void
   /** Id of the auto-nudge loop this surface can open, plus the opener. The
    *  match rule stays here so a host never re-implements it. Unwired from a
-   *  pane until its composer can reach the popover — tracked in #3332. */
+   *  pane because a pane's composer cannot reach the auto-nudge popover yet;
+   *  wire it when that popover becomes reachable per pane. */
   activeNudgeLoopId?: string | null
   onOpenNudgeLoop?: () => void
   /** Turn-recovery state for the error row's Continue button. Omitted → the
    *  row renders without one, which is correct for a surface that cannot
    *  continue a turn. A pane cannot supply these until `selectContinuable` /
-   *  `selectTurnInterrupted` are slot-aware — tracked in #3332. */
+   *  `selectTurnInterrupted` become slot-aware — both read the active slot
+   *  today, so a pane cannot ask whether ITS turn was interrupted. */
   continuable?: boolean
   interrupted?: boolean
   continuing?: boolean

--- a/website/src/test/transcriptRenderers.test.tsx
+++ b/website/src/test/transcriptRenderers.test.tsx
@@ -206,8 +206,14 @@ describe('drift guard against the single-chat row chain', () => {
   // with a content guard (a tool row needs its 🔧 prefix), and what drift
   // breaks is coverage, not the guard.
   //
-  // Retire this guard when ChatPage consumes these entries directly and there
-  // is only one row set left to keep in sync.
+  // This guard is PERMANENT. Converging the two row sets by moving ChatPage
+  // onto this registry was considered and rejected (#3332, closed not-planned):
+  // the single-chat surface has no problem to fix, so migrating it is risk
+  // without payoff. The asymmetry is what makes the guard sufficient — ChatPage
+  // owns the policy, so drift can only ever degrade a DOWNSTREAM surface, never
+  // that one. If a row both sides draw ever diverges in component or props,
+  // strengthen this into a static comparison of what each side passes rather
+  // than migrating.
   const chatPageSrc = readFileSync(join(__dirname, '..', 'pages', 'ChatPage.tsx'), 'utf8')
 
   const rolesInChatPage = [...new Set(


### PR DESCRIPTION
## 1. What is the problem?

Comments in `website/src/pages/chat/transcriptRenderers.tsx` and its test point readers at **#3332**, which is now closed as not-planned. Three option groups say "tracked in #3332" for why they have no pane consumer, and the drift guard's comment tells the next reader to *retire* it "when ChatPage consumes these entries directly" — the migration that issue proposed and that was rejected.

## 2. Why this issue matters to the user

No runtime effect; this is a maintenance trap. A reader chasing #3332 lands on a closed issue and learns nothing about why the option is unwired, and the guard's comment actively invites someone to delete a check that is now permanent — which would re-open the exact regression #3302 fixed (a pane silently falling behind the single-chat row set).

## 3. How our fix solves it

Replace the pointers with the reason, so nothing has to be chased:

- `appInPanel` / `onOpenApp` — repointed to **#3300**, which is genuinely the same root cause (the dock is `activeSlot`-keyed while pane focus is not).
- `activeNudgeLoopId` / `onOpenNudgeLoop` and the `continuable` / `interrupted` / `continuing` / `onContinue` group — no issue invented for them; the comment now states the precondition inline (a pane's composer cannot reach the auto-nudge popover; `selectContinuable` / `selectTurnInterrupted` read the active slot, so a pane cannot ask whether ITS turn was interrupted).
- The drift guard's comment now says it is **permanent**, records that convergence was considered and rejected, and names the asymmetry that makes a guard sufficient: ChatPage owns the row policy, so drift can only degrade a downstream surface, never that one. If a row both sides draw ever diverges in component or props, the cheap answer is to strengthen this into a static comparison — not to migrate the healthy surface.

Comments only; no behaviour, no exported API, no test assertions changed.

## 4. What tests we did

`tsc --noEmit` 0 errors · `eslint` 0 errors · `vitest src/test/transcriptRenderers.test.tsx` 18/18 pass. No i18n gates needed — no strings and no JSX touched.

## 5. Any other suggestions on the work

The rejected direction is worth stating once here so it does not get re-proposed: converging the two row sets means editing a 7000-line surface that has no user-visible defect, and the failure mode it would prevent is one-directional and already guarded. Let a second real consumer of the rich row set drive convergence if one ever appears.
