### PR TITLE
fix(queue): use theme text color in queued message edit input

### DIFF
--- a/website/src/components/QueueStack.tsx
+++ b/website/src/components/QueueStack.tsx
@@ -127,10 +127,10 @@ function EditInput({ initial, onCommit, onCancel }: {
           else if (e.key === 'Escape') { e.preventDefault(); cancel() }
         }}
         onBlur={commit}
-        className="flex-1 min-w-0 bg-white/20 text-warn-fg placeholder:text-warn-fg/50 rounded px-1.5 py-0.5 text-[13px] outline-none border border-white/30 focus:border-white/60"
+        className="flex-1 min-w-0 bg-[var(--bg)] text-[var(--text)] placeholder:text-[var(--muted)] rounded px-1.5 py-0.5 text-[13px] outline-none border border-[var(--border)] focus:border-[var(--accent)]"
         aria-label={i18nT('components.queueStack.edit_queued_message')}
       />
-      <button className="shrink-0 p-0.5 rounded hover:bg-white/20 transition-colors text-white"
+      <button className="shrink-0 p-0.5 rounded hover:bg-[var(--bg-hover)] transition-colors text-[var(--text)]"
         title={i18nT('components.queueStack.save')} aria-label={i18nT('components.queueStack.save_edit')}
         // mousedown commits before the input's blur can fire with the same value.
         onMouseDown={e => { e.preventDefault(); e.stopPropagation() }}
@@ -324,7 +324,7 @@ function QueueStackInner({ messages, onCancel, onInterrupt, onEdit, onReorder, f
                       {onReorder && expanded && messages.length > 1 && (
                         <>
                           <button
-                            className="shrink-0 p-0.5 rounded hover:bg-white/20 transition-colors disabled:opacity-30 disabled:hover:bg-transparent"
+                            className="shrink-0 p-0.5 rounded hover:bg-[var(--bg-hover)] transition-colors disabled:opacity-30 disabled:hover:bg-transparent"
                             title={i18nT('components.queueStack.run_sooner')}
                             aria-label={i18nT('components.queueStack.run_sooner')}
                             disabled={i === 0}
@@ -333,7 +333,7 @@ function QueueStackInner({ messages, onCancel, onInterrupt, onEdit, onReorder, f
                             <ArrowDown size={13} />
                           </button>
                           <button
-                            className="shrink-0 p-0.5 rounded hover:bg-white/20 transition-colors disabled:opacity-30 disabled:hover:bg-transparent"
+                            className="shrink-0 p-0.5 rounded hover:bg-[var(--bg-hover)] transition-colors disabled:opacity-30 disabled:hover:bg-transparent"
                             title={i18nT('components.queueStack.run_later')}
                             aria-label={i18nT('components.queueStack.run_later')}
                             disabled={i === messages.length - 1}
@@ -345,7 +345,7 @@ function QueueStackInner({ messages, onCancel, onInterrupt, onEdit, onReorder, f
                       )}
                       {onEdit && showActions && (
                         <button
-                          className="shrink-0 p-0.5 rounded hover:bg-white/20 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                          className="shrink-0 p-0.5 rounded hover:bg-[var(--bg-hover)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                           title={i18nT('components.queueStack.edit_queued_message')}
                           aria-label={i18nT('components.queueStack.edit_queued_message')}
                           disabled={isPending}
@@ -356,7 +356,7 @@ function QueueStackInner({ messages, onCancel, onInterrupt, onEdit, onReorder, f
                       )}
                       {onInterrupt && showActions && (
                         <button
-                          className="shrink-0 p-0.5 rounded hover:bg-white/20 transition-colors text-white disabled:opacity-40 disabled:cursor-not-allowed"
+                          className="shrink-0 p-0.5 rounded hover:bg-[var(--bg-hover)] transition-colors text-[var(--text)] disabled:opacity-40 disabled:cursor-not-allowed"
                           title={i18nT('components.queueStack.interrupt_current_turn_and_send_this_now')}
                           aria-label={i18nT('components.queueStack.send_now')}
                           disabled={isPending}
@@ -367,7 +367,7 @@ function QueueStackInner({ messages, onCancel, onInterrupt, onEdit, onReorder, f
                       )}
                       {onCancel && showActions && (
                         <button
-                          className="shrink-0 p-0.5 rounded hover:bg-white/20 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                          className="shrink-0 p-0.5 rounded hover:bg-[var(--bg-hover)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                           title={i18nT('components.queueStack.cancel_and_move_back_to_input')}
                           aria-label={i18nT('components.queueStack.cancel_queued_message')}
                           disabled={isPending}


### PR DESCRIPTION
# Problem

When editing a queued message in the chat input area, the text in the edit input is white (`text-warn-fg`) on a light warn-tinted background (`bg-white/20`). On the default light theme this renders as white-on-light-brown — completely unreadable.

# Why it matters

Users cannot see what they are typing when editing a queued instruction, making the edit feature unusable on light themes.

# Fix

Replace hardcoded `text-warn-fg` / `bg-white/20` / `border-white/30` with theme-aware variables:
- Input text: `var(--text)` (the standard dark foreground)
- Input background: `var(--bg)` (the standard page background)
- Input border: `var(--border)` / `var(--accent)` on focus
- Save button: `var(--text)` instead of `text-white`

This matches the contrast and color language used elsewhere (e.g. the merge-blocked banner in PullRequestPanel uses `text-muted` / `text-warn` on similar tinted backgrounds).

# Tests

TypeScript compiles with zero errors. No behavioral change — purely a visual/CSS fix.

# Manual verification

Needs visual verification on both light and dark themes: queue a message while the agent is busy, click the pencil to edit, confirm the text is readable."

# screen shots

here are screen shots of before:

<img width="1207" height="280" alt="Screenshot 2026-08-13 at 5 32 10 PM" src="https://github.com/user-attachments/assets/2d7f68f6-d6ff-4da8-b038-63e5a0102b6e" />

and after this change:

<img width="1115" height="280" alt="Screenshot 2026-08-13 at 5 29 19 PM" src="https://github.com/user-attachments/assets/2cf9be5b-78d5-4ff0-a725-846b10b40ac9" />

both UX Review and Design Review issues have been addressed.