### PR TITLE
feat(kas): enable KAS as a working chat backend

### DIFF
--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -65,6 +65,7 @@ def build_session_new_params(
     *,
     mcp_servers: list[dict[str, Any]] | None = None,
     claude_meta: bool = False,
+    kas_custom_agents: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build the params for a ``session/new`` request.
 
@@ -72,6 +73,12 @@ def build_session_new_params(
     ``mcpServers`` field as malformed and exits cleanly (rc=0, no stderr) — so
     both backends must send it, even as an empty list. The ``claude_meta`` flag
     adds the SDK envelope the claude-agent-acp backend requires.
+
+    ``kas_custom_agents`` carries agent definitions to KAS, which has no
+    ``--agent`` flag and advertises only its own built-in modes: an injected
+    agent is registered, surfaces as a mode, and can then be activated by the
+    ordinary ``session/set_mode``. The two ``_meta`` envelopes belong to
+    different backends, so they never both apply.
     """
     params: dict[str, Any] = {
         "cwd": str(cwd),
@@ -79,6 +86,8 @@ def build_session_new_params(
     }
     if claude_meta:
         params["_meta"] = {"claudeCode": {"options": {}}}
+    if kas_custom_agents:
+        params["_meta"] = {"kiro": {"customAgents": kas_custom_agents}}
     return params
 
 

--- a/src/kiro_crew/acp/kas_agents.py
+++ b/src/kiro_crew/acp/kas_agents.py
@@ -1,0 +1,234 @@
+"""Project a Crew agent spec onto KAS's ``ClientCustomAgent`` shape.
+
+kiro-cli reads agent definitions from ``~/.kiro/agents/*.json`` and selects one
+with a ``--agent`` flag. KAS has no such flag: it advertises only its own
+built-in modes and takes client agents over the wire, as
+``_meta.kiro.customAgents`` on ``session/new``. Each injected agent is
+registered and then surfaces as a switchable mode, which is what lets the
+ordinary ``session/set_mode`` activation work afterwards.
+
+Two properties of KAS's schema drive the mapping and are easy to get wrong:
+
+* ``prompt`` must be resolved content. A ``file://`` URI is the client's job to
+  read, so a spec that points at a prompt file has to be inlined here.
+* ``tools`` absent means NO tool access, not "all tools" — KAS resolves it as
+  ``agent.tools ?? []``. The list is therefore always emitted explicitly, and an
+  ambiguous spec fails closed rather than guessing ``*``.
+
+Deliberately NOT projected, each for a reason a reader would otherwise have to
+rediscover:
+
+* ``mcpServers`` — Crew injects broker stubs as the session-level ``mcpServers``
+  param, and a session-injected server outranks an agent-declared one. Carrying
+  them twice risks a double registration. ``@server`` entries in ``tools`` still
+  resolve, because KAS tags every MCP tool with ``@<server>`` from the server's
+  name regardless of where it was declared.
+* ``model`` — the model is set through its own protocol verb, so it has exactly
+  one owner rather than being pinned in two places that can disagree.
+* ``permissions`` — KAS's inline policy is keyed by ITS capability vocabulary,
+  not by tool names, so translating Crew's auto-approve list would mean guessing
+  identifiers. A wrong guess either no-ops or over-allows, and over-allowing is
+  not a risk worth taking for a convenience feature; omitting the field leaves
+  KAS's own default policy in force. Auto-approval parity is a follow-up.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from kiro_crew.security import is_sensitive_path
+
+logger = logging.getLogger(__name__)
+
+#: Cap KAS enforces on ``_meta.kiro.customAgents`` (``z.array(...).max(50)``).
+KAS_MAX_CUSTOM_AGENTS = 50
+
+_PROMPT_FILE_SCHEME = "file://"
+
+#: Pseudo-filesystems whose contents are process/kernel state, not documents.
+_PSEUDO_FS_ROOTS = ("/proc", "/sys", "/dev")
+
+#: Spec keys Crew writes that KAS's ``ClientCustomAgent`` has no home for.
+#: Dropped with a named warning so a lost capability shows up in the log instead
+#: of being discovered as missing behaviour later.
+UNSUPPORTED_SPEC_KEYS = frozenset(
+    {
+        "allowedTools",
+        "hooks",
+        "slashCommand",
+        "toolsSettings",
+    }
+)
+
+
+class KasAgentTranslationError(ValueError):
+    """A spec cannot be projected onto KAS's schema at all."""
+
+
+def _is_unsafe_prompt_path(path: Path) -> bool:
+    """True if *path* must not be read and inlined into a KAS agent prompt.
+
+    The prompt content is shipped to KAS over the wire, so a spec pointing at a
+    credential store or a pseudo-filesystem would exfiltrate it. Blocks the
+    credential/governance locations ``is_sensitive_path`` knows, plus ``/proc``,
+    ``/sys`` and ``/dev`` (which it does not cover) — ``/proc/<pid>/environ`` is
+    the sharp edge, exposing the gateway's own environment.
+    """
+    if is_sensitive_path(str(path)):
+        return True
+    posix = path.as_posix()
+    return any(posix == root or posix.startswith(root + "/") for root in _PSEUDO_FS_ROOTS)
+
+
+def resolve_prompt(spec: dict[str, Any], *, agent_id: str, agents_dir: Path) -> str:
+    """Return the spec's prompt as literal text, reading a ``file://`` URI.
+
+    Separated from :func:`to_client_custom_agent` so the projection itself stays
+    pure. Because the resolved content is shipped to KAS over the wire, two
+    safety rules apply to a ``file://`` URI:
+
+    * A RELATIVE path is anchored to *agents_dir* (where the agent config lives,
+      the documented base for ``file://./prompts/x.md``), never the gateway cwd,
+      and may not escape it via ``..``.
+    * The resolved path must not be a credential/governance location or a
+      pseudo-filesystem (see :func:`_is_unsafe_prompt_path`).
+    """
+    raw = spec.get("prompt")
+    if not isinstance(raw, str) or not raw.strip():
+        raise KasAgentTranslationError(f"agent {agent_id!r} has no prompt; KAS requires one")
+    if not raw.startswith(_PROMPT_FILE_SCHEME):
+        return raw
+    ref = raw[len(_PROMPT_FILE_SCHEME) :]
+    candidate = Path(ref).expanduser()
+    if candidate.is_absolute():
+        path = candidate.resolve()
+    else:
+        base = agents_dir.resolve()
+        path = (base / ref).resolve()
+        if path != base and base not in path.parents:
+            raise KasAgentTranslationError(
+                f"agent {agent_id!r} relative prompt {ref!r} escapes the agent directory"
+            )
+    if _is_unsafe_prompt_path(path):
+        raise KasAgentTranslationError(
+            f"agent {agent_id!r} prompt path {path} is not an allowed location; refusing to inline it"
+        )
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise KasAgentTranslationError(
+            f"agent {agent_id!r} prompt file {path} is unreadable: {exc}"
+        ) from exc
+    if not text.strip():
+        raise KasAgentTranslationError(f"agent {agent_id!r} prompt file {path} is empty")
+    return text
+
+
+def _project_tools(spec: dict[str, Any], agent_id: str) -> str | list[str]:
+    """Resolve the tool allowlist, failing closed when the spec is silent.
+
+    ``"*"`` anywhere in the list is KAS's all-tools literal, which is a
+    different type from a list, so it cannot simply be passed through.
+    """
+    raw = spec.get("tools")
+    if raw == "*":
+        return "*"
+    if isinstance(raw, list):
+        entries = [t for t in raw if isinstance(t, str) and t]
+        if "*" in entries:
+            return "*"
+        return entries
+    # Absent or malformed: KAS would resolve this to zero tools anyway. Emit that
+    # explicitly and say so, rather than inferring an allowlist nobody wrote.
+    logger.warning(
+        "agent %r declares no usable 'tools' list; sending an empty allowlist, so "
+        "it will run with no tool access on KAS",
+        agent_id,
+    )
+    return []
+
+
+def to_client_custom_agent(
+    agent_id: str,
+    spec: dict[str, Any],
+    prompt: str,
+) -> dict[str, Any]:
+    """Project one Crew agent spec onto a KAS ``ClientCustomAgent`` descriptor.
+
+    Pure: *prompt* is already-resolved content (see :func:`resolve_prompt`).
+    """
+    if not agent_id:
+        raise KasAgentTranslationError("agent id must be non-empty")
+    if not prompt.strip():
+        raise KasAgentTranslationError(f"agent {agent_id!r} prompt is empty")
+
+    dropped = sorted(k for k in UNSUPPORTED_SPEC_KEYS if spec.get(k))
+    if dropped:
+        logger.warning(
+            "agent %r: dropping spec keys with no KAS equivalent: %s",
+            agent_id,
+            ", ".join(dropped),
+        )
+
+    out: dict[str, Any] = {
+        "id": agent_id,
+        "prompt": prompt,
+        "tools": _project_tools(spec, agent_id),
+    }
+
+    description = spec.get("description")
+    if isinstance(description, str) and description:
+        out["description"] = description
+
+    excluded = spec.get("excludedTools")
+    if isinstance(excluded, list):
+        entries = [t for t in excluded if isinstance(t, str) and t]
+        if entries:
+            out["excludedTools"] = entries
+
+    include_mcp = spec.get("includeMcpJson")
+    if isinstance(include_mcp, bool):
+        out["includeMcpJson"] = include_mcp
+
+    resources = spec.get("resources")
+    if isinstance(resources, list):
+        entries = [r for r in resources if isinstance(r, str) and r]
+        if entries:
+            out["resources"] = entries
+
+    return out
+
+
+def load_agent_spec(agents_dir: Path, agent_id: str) -> dict[str, Any]:
+    """Read a materialized agent spec.
+
+    Takes the directory explicitly rather than resolving it here so this module
+    stays free of :mod:`kiro_crew.agent`, which imports the config loader and
+    would form an import cycle.
+    """
+    path = agents_dir / f"{agent_id}.json"
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise KasAgentTranslationError(f"agent spec {path} is unreadable: {exc}") from exc
+    except ValueError as exc:
+        raise KasAgentTranslationError(f"agent spec {path} is not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise KasAgentTranslationError(f"agent spec {path} is not an object")
+    return raw
+
+
+def build_kas_custom_agents(agents_dir: Path, agent_id: str) -> list[dict[str, Any]]:
+    """Build the ``_meta.kiro.customAgents`` batch that binds *agent_id* on KAS.
+
+    One entry: KAS registers the injected agent, it then surfaces as a mode, and
+    the ordinary ``session/set_mode`` activation can select it. Without this the
+    session stays on KAS's own default mode and the operator's prompt and tool
+    configuration have no effect.
+    """
+    spec = load_agent_spec(agents_dir, agent_id)
+    prompt = resolve_prompt(spec, agent_id=agent_id, agents_dir=agents_dir)
+    return [to_client_custom_agent(agent_id, spec, prompt)]

--- a/src/kiro_crew/acp/kas_assets.py
+++ b/src/kiro_crew/acp/kas_assets.py
@@ -35,6 +35,14 @@ KAS_NODE_FLAGS = ("--experimental-wasm-modules",)
 #: KAS defaults to stdio, but state it so the transport is visible in ps output.
 KAS_TRANSPORT_ARG = "--transport=stdio"
 
+#: Auth mode: KAS keeps no refresh token and calls back over ACP
+#: (``_kiro/auth/getAccessToken``) whenever it needs an access token. The
+#: runtime answers that callback by shelling out to kiro-cli (see
+#: :mod:`kas_auth`). The alternative -- omitting ``--auth`` -- makes KAS use its
+#: file auth provider, which reads a ``~/.aws/sso/cache`` token that
+#: ``kiro-cli login`` does NOT write, so a cli-only machine has no token there.
+KAS_AUTH_ACP_CALLBACK_ARG = "--auth=acp-callback"
+
 #: Where the entry script sits inside a version directory. Checked before any
 #: recursive walk, because the staged tree holds hundreds of packages.
 _SCRIPT_RELATIVE_PATHS = (
@@ -145,9 +153,20 @@ def resolve_kas_entry() -> tuple[Path, Path]:
 def build_kas_argv(node: Path, server_script: Path) -> list[str]:
     """argv for a KAS stdio session.
 
-    ``--auth`` is deliberately absent: without it KAS selects its file auth
-    provider and reads/refreshes the token itself, so Kiro Crew never handles a
-    credential. Passing ``--auth=acp-callback`` would force this process to
-    implement ``_kiro/auth/getAccessToken`` instead.
+    Launched with ``--auth=acp-callback``: KAS keeps no refresh token and asks
+    this host for an access token over ACP whenever it needs one. The runtime
+    fulfils that ``_kiro/auth/getAccessToken`` callback by shelling out to
+    ``kiro-cli chat _ get-kas-token`` (see :mod:`kas_auth`), so the refresh token
+    never leaves kiro-cli's own store and this process only ever handles a
+    short-lived access token in transit. This works on any machine where
+    ``kiro-cli login`` succeeded -- unlike the file auth provider (omit
+    ``--auth``), which needs a ``~/.aws/sso/cache`` token that the cli does not
+    write.
     """
-    return [str(node), *KAS_NODE_FLAGS, str(server_script), KAS_TRANSPORT_ARG]
+    return [
+        str(node),
+        *KAS_NODE_FLAGS,
+        str(server_script),
+        KAS_TRANSPORT_ARG,
+        KAS_AUTH_ACP_CALLBACK_ARG,
+    ]

--- a/src/kiro_crew/acp/kas_auth.py
+++ b/src/kiro_crew/acp/kas_auth.py
@@ -1,0 +1,149 @@
+"""Thin, leak-safe resolver for KAS's ``_kiro/auth/getAccessToken`` callback.
+
+When KAS is launched with ``--auth=acp-callback`` (see :mod:`kas_assets`), it
+keeps NO refresh token of its own: whenever it needs an access token it calls
+back to this host over ACP. kiro-cli already owns the OIDC refresh token and
+exposes a hidden subcommand -- ``kiro-cli chat _ get-kas-token`` -- that
+resolves-and-refreshes the token and prints it as one JSON line. So this host's
+entire auth job is a passthrough: shell out to that command and hand the result
+back to KAS. No OIDC, no refresh logic, no token custody lives here.
+
+Security (no credential in logs, no information disclosure via errors):
+
+* The access token exists only as a transient local for the duration of one
+  callback -- it is never cached, persisted, or written to a log.
+* Failure paths raise :class:`KasAuthCallbackError` whose message is a fixed
+  human string, NEVER the subprocess output -- a malformed line could itself be
+  a live token with trailing junk, so it must not travel in an exception or a
+  traceback.
+* The one place upstream text is surfaced (kiro-cli's own ``kind: "error"``
+  message, which carries no token) is still run through ``redact_credentials``
+  defensively before it leaves this module.
+* The command is spawned with an argv LIST and no shell, so there is no command
+  injection surface, and a timeout guarantees a hung kiro-cli cannot wedge the
+  auth callback (and with it every prompt on the connection).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import Any
+
+from kiro_crew.kiro_cli import resolve_kiro_cli
+
+#: Subcommand that resolves + refreshes the KAS access token and prints one
+#: JSON line. Hidden kiro-cli IPC surface; may change without notice.
+_GET_KAS_TOKEN_ARGV_TAIL = ("chat", "_", "get-kas-token")
+
+#: Hard cap on the callback subprocess. A refresh is a network round-trip, so
+#: allow room, but never let a hung process block the connection forever.
+_CALLBACK_TIMEOUT_SECS = 20.0
+
+#: The only keys forwarded to KAS, matching ``GetAccessTokenResponse`` in the
+#: ACP type covenant. Filtering (rather than forwarding ``data`` wholesale)
+#: keeps any future kiro-cli field from leaking onto the wire unreviewed.
+_COVENANT_KEYS = ("accessToken", "expiresAt", "profileArn", "authMethod", "provider")
+
+
+class KasAuthCallbackError(RuntimeError):
+    """A KAS auth callback could not be fulfilled.
+
+    Its ``str`` is always a fixed, token-free description -- safe to log and to
+    send back as a JSON-RPC error message.
+    """
+
+
+async def resolve_kas_access_token(
+    *,
+    timeout: float = _CALLBACK_TIMEOUT_SECS,
+) -> dict[str, Any]:
+    """Resolve a fresh KAS access token via kiro-cli, as the ACP response dict.
+
+    Returns the ``GetAccessTokenResponse`` body KAS expects
+    (``accessToken`` + ``expiresAt`` always, ``profileArn`` / ``authMethod`` /
+    ``provider`` when kiro-cli supplies them). Raises :class:`KasAuthCallbackError`
+    on any failure, with a message that never contains token bytes.
+    """
+    binary = await asyncio.to_thread(resolve_kiro_cli)
+    if not binary:
+        raise KasAuthCallbackError("kiro-cli not found; cannot obtain a KAS token")
+
+    argv = [binary, *_GET_KAS_TOKEN_ARGV_TAIL]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError as exc:
+        # Spawn failure carries no token; the OSError text is a path/errno.
+        raise KasAuthCallbackError(f"could not launch kiro-cli: {exc}") from None
+
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(ProcessLookupError, asyncio.TimeoutError):
+            await asyncio.wait_for(proc.wait(), timeout=2.0)
+        raise KasAuthCallbackError("kiro-cli token callback timed out") from None
+    except asyncio.CancelledError:
+        # Runtime/loop teardown cancelled this callback task mid-flight. SIGKILL
+        # the credential subprocess synchronously so it cannot linger detached;
+        # do NOT await here (we are unwinding a cancellation) — the loop's child
+        # watcher reaps the killed process.
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        raise
+
+    return _parse_token_output(stdout_b, stderr_b)
+
+
+def _parse_token_output(stdout_b: bytes, stderr_b: bytes) -> dict[str, Any]:
+    """Parse the subprocess output into the ACP response, leaking nothing.
+
+    Split out from the spawn so it can be unit-tested without a real process.
+    """
+    stdout = stdout_b.decode("utf-8", "replace").strip()
+    if not stdout:
+        # No JSON at all. Deliberately do NOT echo stderr: it is untrusted
+        # subprocess output and credential redaction is best-effort, so the only
+        # way to GUARANTEE no token leaks here is to never surface it. The raw
+        # stderr is dropped rather than logged for the same reason.
+        raise KasAuthCallbackError("kiro-cli returned no token output")
+
+    # Use only the last line: kiro-cli emits exactly one JSON line, but a stray
+    # leading log line must not derail the parse.
+    last = stdout.splitlines()[-1]
+    try:
+        obj = json.loads(last)
+    except (ValueError, TypeError):
+        # DO NOT put `last`/`stdout` in the message -- it may be a live token.
+        raise KasAuthCallbackError("could not parse kiro-cli token output") from None
+
+    if not isinstance(obj, dict):
+        raise KasAuthCallbackError("kiro-cli token output was not a JSON object")
+
+    kind = obj.get("kind")
+    data = obj.get("data")
+    if not isinstance(data, dict):
+        raise KasAuthCallbackError("kiro-cli token output had no data object")
+
+    if kind == "error":
+        # Do NOT surface the subprocess-provided message: it is untrusted and
+        # could in principle carry sensitive text, and this module is not an
+        # egress boundary (so it must not call a redactor either — the
+        # test_security_posture contract). Raise a fixed, generic, actionable
+        # message; the specific cause stays in kiro-cli's own logs.
+        raise KasAuthCallbackError("kiro-cli authentication failed; run `kiro-cli login`")
+
+    if kind != "getKasToken":
+        raise KasAuthCallbackError(f"unexpected kiro-cli token output kind: {kind!r}")
+
+    if not data.get("accessToken"):
+        raise KasAuthCallbackError("kiro-cli token output missing accessToken")
+
+    # Forward ONLY the covenant keys that are present. Never log this dict.
+    return {k: data[k] for k in _COVENANT_KEYS if k in data}

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -40,10 +40,18 @@ from kiro_crew.acp.client import (
     _KiroExecutableTrustError,
     _resolve_kiro_bin_for_spawn,
 )
+from kiro_crew.acp.kas_agents import (
+    KasAgentTranslationError,
+    build_kas_custom_agents,
+)
 from kiro_crew.acp.kas_assets import (
     KasAssetsMissing,
     build_kas_argv,
     resolve_kas_entry,
+)
+from kiro_crew.acp.kas_auth import (
+    KasAuthCallbackError,
+    resolve_kas_access_token,
 )
 from kiro_crew.acp.session_handle import (
     AcpRuntimeDead,
@@ -56,7 +64,10 @@ from kiro_crew.acp.types import (
     ACP_BACKEND_KIRO,
     ACP_BACKENDS_INTERNAL_SANDBOX,
     ACP_CLIENT_CAPABILITIES,
+    KAS_AUTH_CALLBACK_ERROR_CODE,
     KAS_CLIENT_CAPABILITIES,
+    METHOD_KAS_AUTH_GET_ACCESS_TOKEN,
+    METHOD_KAS_SESSION_DELETE,
     METHOD_MCP_OAUTH_REQUEST,
     METHOD_MCP_SERVER_INIT_FAILURE,
     METHOD_MCP_SERVER_INITIALIZED,
@@ -1229,6 +1240,24 @@ class AcpRuntime:
                     logger.debug("Unmatched response id=%d", req_id)
                     continue
 
+                # Inbound server→client REQUEST (method + id, no result/error).
+                # The KAS auth callback is connection-level: it carries NO
+                # sessionId, so it cannot be routed to a session and must be
+                # answered by the runtime itself. Handle it OFF this loop —
+                # shelling out to kiro-cli for a token must not block stdout
+                # demux for every other multiplexed session. Everything else
+                # (e.g. session/request_permission, which IS session-scoped and
+                # carries a sessionId) falls through to the routing below
+                # unchanged.
+                if (
+                    msg.id is not None
+                    and msg.result is None
+                    and msg.error is None
+                    and msg.is_method(METHOD_KAS_AUTH_GET_ACCESS_TOKEN)
+                ):
+                    asyncio.ensure_future(self._answer_get_access_token(msg.id))
+                    continue
+
                 # Route notifications by sessionId
                 session_id = (msg.params or {}).get("sessionId")
                 if session_id:
@@ -1284,6 +1313,65 @@ class AcpRuntime:
             # crash) so a trickle that never reached the interval is still
             # accounted for instead of vanishing with the task.
             self._flush_dropped_frames()
+
+    async def _answer_get_access_token(self, request_id: int | str) -> None:
+        """Answer KAS's ``_kiro/auth/getAccessToken`` callback (see :mod:`kas_auth`).
+
+        Runs OFF the reader loop. Resolves a fresh access token by shelling out
+        to kiro-cli and hands it straight back to KAS. The token is a transient
+        local here — never cached, never logged. On any failure KAS is sent a
+        JSON-RPC error (which it treats as an expired token, prompting re-login)
+        rather than being left to hang on the callback.
+        """
+        # Defensive: only KAS is spawned with --auth=acp-callback, so no other
+        # backend ever sends this. Deliver on the KAS path; refuse elsewhere
+        # rather than shell out for a credential.
+        if self._acp_backend == ACP_BACKEND_KAS:
+            await self._deliver_kas_access_token(request_id)
+            return
+        try:
+            await self.send_error(
+                request_id, KAS_AUTH_CALLBACK_ERROR_CODE, "Method not found"
+            )
+        except AcpRuntimeDead:
+            pass
+
+    async def _deliver_kas_access_token(self, request_id: int | str) -> None:
+        """Resolve a KAS token via kiro-cli and hand it back, leak-safe.
+
+        Split from :meth:`_answer_get_access_token` so backend dispatch stays a
+        positive ``== ACP_BACKEND_KAS`` check (harness-parity H5); this body is
+        only ever reached on the KAS path.
+        """
+        try:
+            result = await resolve_kas_access_token()
+        except KasAuthCallbackError as exc:
+            # str(exc) is token-free by construction (see kas_auth), so it is
+            # safe to log and to return as the error reason.
+            logger.warning("KAS auth callback failed: %s", exc)
+            try:
+                await self.send_error(request_id, KAS_AUTH_CALLBACK_ERROR_CODE, str(exc))
+            except AcpRuntimeDead:
+                pass
+            return
+        except Exception as exc:  # noqa: BLE001
+            # An UNEXPECTED exception's message could carry unredacted bytes, so
+            # log only its type and return a generic reason — never str(exc).
+            # Also: a token task must never crash the single-owner runtime.
+            logger.warning("KAS auth callback error: %s", type(exc).__name__)
+            try:
+                await self.send_error(
+                    request_id, KAS_AUTH_CALLBACK_ERROR_CODE, "auth callback failed"
+                )
+            except AcpRuntimeDead:
+                pass
+            return
+
+        try:
+            await self.send_response(request_id, result)
+        except AcpRuntimeDead:
+            # Process gone before we could answer; nothing to do.
+            pass
 
     def saw_not_logged_in(self) -> bool:
         """True if kiro-cli's 'not logged in' auth-failure appeared on stderr.
@@ -1473,19 +1561,39 @@ class AcpRuntime:
             if not self._dead and self._process is not None:
                 try:
                     await self._send_and_await(
-                        METHOD_SESSION_TERMINATE,
+                        self._session_teardown_method(),
                         {"sessionId": session_id},
                         timeout=_TERMINATE_TIMEOUT,
                     )
                 except Exception:
                     logger.debug(
-                        "session/terminate failed for %s (runtime dead/slow); "
+                        "session teardown failed for %s (runtime dead/slow); "
                         "proceeding with local unregister",
                         session_id,
                         exc_info=True,
                     )
         finally:
             self.unregister_session(session_id)
+
+    def _session_teardown_method(self) -> str:
+        """The verb that frees one session on this backend.
+
+        kiro-cli's terminate evicts the session from the process and leaves the
+        transcript on disk for the caller to deal with. KAS offers no evict-only
+        equivalent, so its delete does both at once.
+
+        That difference is invisible here but matters to the caller: on KAS the
+        local ``AcpSessionHandle._cleanup_transcript`` is a NO-OP, because it
+        unlinks from kiro-cli's sessions dir and KAS keeps its own store. So the
+        ``keep_transcript`` guard does not protect anything on KAS — a KAS
+        session's record is gone once this verb returns. The only capability that
+        loses is opportunistic ``spawn_continue`` on a shared subagent, which
+        degrades to a typed ``conversation_gone`` and a re-spawn; explicitly
+        continuable runs are dedicated sessions that never reach this path.
+        """
+        if self._acp_backend == ACP_BACKEND_KAS:
+            return METHOD_KAS_SESSION_DELETE
+        return METHOD_SESSION_TERMINATE
 
     # ── Session Management ──
 
@@ -1524,6 +1632,39 @@ class AcpRuntime:
             return True
         return agent in ids
 
+    async def _kas_custom_agents(self, agent: str) -> list[dict[str, Any]] | None:
+        """Agent definitions to carry on ``session/new``, or None for kiro-cli.
+
+        kiro-cli takes its agent from the ``--agent`` spawn flag and reads the
+        spec off disk itself; KAS has neither, so the definition has to travel
+        over the wire or the session silently stays on KAS's default mode.
+
+        Materializes first for the same reason the kiro spawn path does: the
+        managed default spec may not exist yet, and reading it is what the
+        projection needs. File I/O is offloaded — this runs on the loop.
+        """
+        if self._acp_backend == ACP_BACKEND_KAS and agent:
+
+            def _build() -> list[dict[str, Any]]:
+                try:
+                    ensure_agent_materialized(agent)
+                except Exception:
+                    logger.warning(
+                        "pre-session agent materialization failed for %r", agent, exc_info=True
+                    )
+                return build_kas_custom_agents(kiro_agents_dir(), agent)
+
+            try:
+                return await asyncio.to_thread(_build)
+            except KasAgentTranslationError as exc:
+                # Fail loud: continuing would create a session on KAS's own default
+                # mode, which for a restricted agent means running a BROADER agent
+                # than the caller asked for.
+                raise AcpRuntimeError(
+                    f"cannot project agent {agent!r} onto KAS: {exc}"
+                ) from exc
+        return None
+
     async def create_session(
         self,
         cwd: str | Path | None = None,
@@ -1544,9 +1685,19 @@ class AcpRuntime:
             mcp_servers = await asyncio.to_thread(
                 pooled_session_servers, self._mcp_gateway_overlay, agent or self._agent
             )
+        # The agent to run: an explicit request, else the runtime default. KAS
+        # has no --agent spawn flag, so its default must be BOTH injected (below)
+        # and activated (via set_mode after session/new); the kiro default is
+        # already active from the --agent spawn.
+        active_agent = agent or self._agent
+        # Adapter-only seam: _kas_custom_agents returns None on the kiro backend,
+        # so the kiro construction path gains no conditional, no new required
+        # argument, and no new failure mode (harness-parity H13).
+        kas_agents = await self._kas_custom_agents(active_agent)
         params = build_session_new_params(
             cwd if cwd else self._work_dir,
             mcp_servers=mcp_servers,
+            kas_custom_agents=kas_agents,
         )
 
         self._session_inits_in_flight += 1
@@ -1592,11 +1743,19 @@ class AcpRuntime:
         # rather than silently leaving the session on kiro-cli's default mode: for
         # a restricted/app agent that would run a BROADER agent than requested (a
         # privilege escalation), so we terminate and raise an actionable error.
-        if agent and self._mode_available(agent, resp):
+        # The agent to ACTIVATE. An explicit request always applies. When a KAS
+        # custom agent was injected (``kas_agents`` non-empty) the runtime
+        # default must be activated too: KAS has no --agent flag, so an injected
+        # default that is not set here stays registered-but-inactive and the
+        # session silently runs KAS's own default mode. On kiro ``kas_agents`` is
+        # None and the --agent spawn already selected the default, so only an
+        # explicit override reaches set_mode here.
+        mode_agent = agent or (self._agent if kas_agents else None)
+        if mode_agent and self._mode_available(mode_agent, resp):
             try:
                 await self._send_and_await(
                     METHOD_SET_MODE,
-                    set_mode_params(session_id, agent),
+                    set_mode_params(session_id, mode_agent),
                 )
             except Exception:
                 await self.terminate_session(session_id)
@@ -1608,14 +1767,14 @@ class AcpRuntime:
             # must not arm the drain's idle shortcut while the switched-to
             # agent's own servers may still be booting.
             _ids, _current, _adv = parse_session_modes(resp)
-            mode_switched = bool(_current) and agent != _current
-        elif agent:
+            mode_switched = bool(_current) and mode_agent != _current
+        elif mode_agent:
             _ids, _current, _adv = parse_session_modes(resp)
             await self.terminate_session(session_id)
             raise AcpRuntimeError(
-                f"Agent mode {agent!r} is not available on this session "
+                f"Agent mode {mode_agent!r} is not available on this session "
                 f"(advertised modes: {_ids or 'none'}); its "
-                f"~/.kiro/agents/{agent}.json is likely missing. Refusing to run "
+                f"~/.kiro/agents/{mode_agent}.json is likely missing. Refusing to run "
                 f"the backend default mode {_current or '(unknown)'} in its place. "
                 f"Run `kirocrew setup --agent-only` to materialize the agent config."
             )

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -60,6 +60,7 @@ from kiro_crew.acp.liveness import (
 )
 from kiro_crew.acp.prompt_blocks import build_prompt_blocks
 from kiro_crew.acp.types import (
+    ACP_BACKEND_KAS,
     EVENT_AGENT_SWITCHED,
     EVENT_CLEAR_STATUS,
     EVENT_COMPACTION_STATUS,
@@ -81,6 +82,7 @@ from kiro_crew.acp.types import (
     METHOD_SET_CONFIG_OPTION,
     METHOD_SET_MODE,
     METHOD_SET_MODEL,
+    MODEL_CONFIG_ID,
     OPTION_ALLOW_ALWAYS,
     OPTION_ALLOW_ONCE,
     OUTCOME_CANCELLED,
@@ -289,6 +291,16 @@ class AcpRuntimeProtocol(Protocol):
     def pid(self) -> int | None:
         """Subprocess pid (sandbox launcher parent under the Linux namespace
         sandbox) — the liveness oracle scans its descendant tree for evidence."""
+        ...
+
+    @property
+    def acp_backend(self) -> str:
+        """Which ACP backend the process speaks.
+
+        The handle needs it because the backends disagree on verbs, not just on
+        payloads — the model, for one, is a ``session/set_model`` request on
+        kiro-cli and a session config option on KAS.
+        """
         ...
 
     @property
@@ -794,10 +806,16 @@ class AcpSessionHandle:
             # Inherit the backend default — nothing to send. For the ephemeral
             # _bg session the current model IS session/new's served default.
             return
-        await self._runtime.send_request(
-            METHOD_SET_MODEL,
-            set_model_params(self._session_id, resolved),
-        )
+        if self._runtime.acp_backend == ACP_BACKEND_KAS:
+            # KAS implements no ``session/set_model``; the model is one of its
+            # session config options instead. Same effect, different verb — so
+            # the bookkeeping below is shared rather than duplicated.
+            await self.set_config_option(MODEL_CONFIG_ID, resolved)
+        else:
+            await self._runtime.send_request(
+                METHOD_SET_MODEL,
+                set_model_params(self._session_id, resolved),
+            )
         self._model = resolved
         # Parity with AcpClient.set_model: keep _resolved_model_id in sync so
         # _backfill_context_window looks up the NEW model's window after a switch
@@ -1238,7 +1256,13 @@ class AcpSessionHandle:
             self._cleanup_transcript()
 
     def _cleanup_transcript(self) -> None:
-        """Best-effort delete of this session's kiro-cli transcript files."""
+        """Best-effort delete of this session's kiro-cli transcript files.
+
+        A NO-OP on the KAS backend: this unlinks from kiro-cli's sessions dir and
+        KAS keeps its own store, so nothing here matches. The ``keep_transcript``
+        guard therefore protects nothing on KAS — that backend's session record is
+        already gone, removed by the same verb that freed the session.
+        """
         sid = self._session_id
         if not sid:
             return

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -50,6 +50,12 @@ METHOD_SESSION_LOAD = "session/load"
 # grows without bound as sessions accumulate. Handler: acp_agent.rs -> Session
 # ManagerRequestData::TerminateSession (self.sessions.remove + handle.shutdown).
 METHOD_SESSION_TERMINATE = "_kiro.dev/session/terminate"
+#: KAS's equivalent. Its extension namespace is ``_kiro/`` (no ``.dev``), and it
+#: has no evict-only verb: this disposes the resident session AND removes its
+#: persisted record. Both are wanted here — the disposal is the memory reclaim
+#: ``terminate`` exists for, and the record is what would otherwise accumulate.
+#: Takes the same ``{"sessionId": ...}`` params and is idempotent.
+METHOD_KAS_SESSION_DELETE = "_kiro/session/delete"
 METHOD_COMPACTION_STATUS = "_kiro.dev/compaction/status"
 METHOD_CLEAR_STATUS = "_kiro.dev/clear/status"
 METHOD_AGENT_SWITCHED = "_kiro.dev/agent/switched"
@@ -59,6 +65,19 @@ METHOD_MCP_SERVER_INIT_FAILURE = "_kiro.dev/mcp/server_init_failure"
 METHOD_SUBAGENT_LIST_UPDATE = "_kiro.dev/subagent/list_update"
 METHOD_KIRO_SESSION_UPDATE = "_kiro.dev/session/update"
 METHOD_SET_CONFIG_OPTION = "session/set_config_option"
+#: ``configId`` under which KAS exposes the session model. KAS implements no
+#: ``session/set_model``, so this is the only way to switch a model on it.
+MODEL_CONFIG_ID = "model"
+
+#: KAS→client auth callback (server-initiated REQUEST) sent when KAS is launched
+#: with ``--auth=acp-callback``. Connection-level: it carries NO sessionId, so
+#: the runtime answers it directly rather than routing it to a session. Note the
+#: single-underscore ``_kiro/`` namespace, distinct from the ``_kiro.dev/`` ones.
+METHOD_KAS_AUTH_GET_ACCESS_TOKEN = "_kiro/auth/getAccessToken"
+#: JSON-RPC error code returned when the auth callback cannot be fulfilled. KAS
+#: treats any rejection as an expired-token signal, so the exact code is not
+#: load-bearing; -32000 is the ACP server-error range.
+KAS_AUTH_CALLBACK_ERROR_CODE = -32000
 
 # kiro-cli exposes its task/TODO list as an ordinary tool call whose real name
 # arrives in `_meta.kiro.toolName` (the visible `title` is a prose sentence like
@@ -110,13 +129,11 @@ ACP_BACKENDS_KNOWN = frozenset(
     }
 )
 # What an operator may actually persist in ``agent.acp_backend``, which is a
-# narrower question than what the code understands. KAS is plumbed and tested but
-# cannot serve a session yet: production names an agent on every session, KAS
-# advertises only its own built-in modes, and Crew's agent reaches it through
-# ``_meta.kiro.customAgents`` on ``session/new`` — not wired up yet. Config
-# resolution degrades an unselectable value to the default so the refusal lands
-# at startup with a reason instead of on the operator's first message.
-ACP_BACKENDS_SELECTABLE = frozenset({ACP_BACKEND_KIRO})
+# narrower question than what the code understands: ``ACP_BACKEND_CLAUDE`` is a
+# dormant seam reached by its own provider, not something to select here. Config
+# resolution degrades an unselectable value to the default, so a typo costs a log
+# line rather than a gateway that will not start.
+ACP_BACKENDS_SELECTABLE = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
 
 # ── Capability membership (harness-parity H6, H7) ──
 # Every capability a backend may claim is an OPT-IN set here, never a negation at
@@ -128,9 +145,14 @@ ACP_BACKENDS_SELECTABLE = frozenset({ACP_BACKEND_KIRO})
 # docs/system-specs/modules/harness-parity.md.
 
 # Backends whose single process can host N concurrent ACP sessions (AcpRuntime
-# demux), which is what subagent session sharing requires. claude-agent-acp runs
-# through AcpClient (one process per session) and is not a member.
-ACP_BACKENDS_SESSION_SHARING = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
+# demux) AND can persist a SHARED subagent session across teardown. KAS runs on
+# AcpRuntime (multi-session), but its teardown maps to _kiro/session/delete,
+# which removes the persisted session — so a shared subagent would strand
+# spawn_continue (conversation_gone). KAS therefore opts in only once a
+# keep-aware teardown lands (native subagent work); until then its subagents get
+# dedicated sessions. claude-agent-acp runs through AcpClient (one process per
+# session) and is not a member.
+ACP_BACKENDS_SESSION_SHARING = frozenset({ACP_BACKEND_KIRO})
 
 # Backends implementing the ``_session/steer`` extension (mid-turn steer).
 ACP_BACKENDS_STEER = frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1184,9 +1184,9 @@ class AgentConfig:
         default="",
         metadata=_meta(
             "ACP Backend",
-            "Which ACP agent to drive. Only '' (kiro-cli) is selectable; the "
-            "'kas' plumbing is present but not yet usable.",
-            enum=[""],
+            "Which ACP agent to drive: '' = kiro-cli (default), 'kas' = kiro-agent. "
+            "KAS runs chat but has no native subagent progress reporting yet.",
+            enum=["", "kas"],
         ),
     )
     default_agent: str = field(

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -47,16 +47,45 @@ provider.
 
 | Value | Agent | Status |
 |-------|-------|--------|
-| `""` (default) | kiro-cli | the only supported value |
-| `kas` | kiro-agent (KAS) | plumbed, **not yet usable** |
+| `""` (default) | kiro-cli | full support |
+| `kas` | kiro-agent (KAS) | runs chat; some surfaces still missing |
 
-**Leave this unset.** The KAS backend's spawn and session plumbing is in place,
-but Kiro Crew does not yet send your configured agent to KAS, so every session
-would fail to activate it. Setting `kas` is refused at startup with that reason
-rather than failing on your first message.
+**What works on `kas`:** normal chat — your configured agent, its prompt, its tool
+allowlist, and session resume.
+
+**What does not, yet:**
+
+- Native subagent progress reporting (subagents run; their live progress does not
+  surface in the UI).
+- Context-usage percentage, compaction status, and agent-switch echoes — KAS
+  reports these differently and the mapping is not wired up.
+- Slash-command execution.
+- Auto-approve (`allowedTools`) is not carried over, so KAS applies its own
+  default approval policy.
+- `spawn_continue` works for runs started with an explicit keep, but not for
+  opportunistically-retained shared subagents.
+- Model selection is unverified: KAS advertises no model list on an
+  unauthenticated session, and Kiro Crew only sends a model the session
+  advertised, so a session may simply run KAS's own default model.
+
+**KAS gets its token from kiro-cli.** Kiro Crew launches KAS with
+`--auth=acp-callback`, so KAS keeps no credential of its own: whenever it needs
+an access token it calls back over ACP (`_kiro/auth/getAccessToken`) and Kiro
+Crew answers by shelling out to `kiro-cli chat _ get-kas-token`, which
+resolves-and-refreshes the token. The refresh token never leaves kiro-cli's own
+store, and this process only ever holds a short-lived access token in transit —
+never cached, never logged. This works on any machine where `kiro-cli login` has
+succeeded; a machine that is not signed in gets an auth error on the first
+prompt (the session still starts cleanly). Sign in with kiro-cli before
+switching.
+
+It also needs a KAS bundle already extracted on the machine by kiro-cli; set
+`KIROCREW_KAS_NODE` / `KIROCREW_KAS_SCRIPT` to point elsewhere.
 
 An unrecognized value logs a warning and falls back to the default backend, so a
 typo costs you a line in the log rather than a gateway that will not start.
+
+Set via `kirocrew config set agent.acp_backend kas`.
 
 ## Key Settings
 

--- a/test/test_acp_backend_kas.py
+++ b/test/test_acp_backend_kas.py
@@ -212,17 +212,18 @@ class TestConfigRoundTrip:
     def test_absent_key_loads_as_the_default(self, tmp_path):
         assert _load_agent_config({}, tmp_path).agent.acp_backend == ACP_BACKEND_KIRO
 
-    def test_kas_is_not_selectable_yet(self, tmp_path):
-        """Degraded at the boundary, so the refusal is a log line at startup.
+    def test_kas_survives_a_load_from_disk(self, tmp_path):
+        """The selectable value must reach the provider, not degrade.
 
-        KAS cannot serve a session until Crew sends the configured agent over
-        ``session/new``; letting the value through would instead fail on the
-        operator's first message.
+        This is the round trip the field exists for: ``load()`` lists every
+        field explicitly, so one it forgets is dropped to the default and the
+        next ``save()`` writes that default back over the operator's setting.
         """
         cfg = _load_agent_config({"acp_backend": ACP_BACKEND_KAS}, tmp_path)
-        assert cfg.agent.acp_backend == ACP_BACKEND_KIRO
+        assert cfg.agent.acp_backend == ACP_BACKEND_KAS
+        assert cfg.to_dict()["agent"]["acp_backend"] == ACP_BACKEND_KAS
         provider = cfg.create_provider_factory()(session_key="test:rt", agent="")
-        assert provider.is_kiro_backend is True
+        assert provider.is_kas_backend is True
 
     @pytest.mark.parametrize("bad", ["kiro-cli", "KAS", "claude_code", 7, None, []])
     def test_unselectable_values_degrade_to_the_default(self, bad, tmp_path):

--- a/test/test_kas_agents.py
+++ b/test/test_kas_agents.py
@@ -1,0 +1,247 @@
+"""Crew agent spec -> KAS ``ClientCustomAgent`` projection.
+
+Each assertion here pins a constraint read off KAS's own zod schema
+(``resolve-client-agents.ts``), not a preference: getting ``tools`` or ``prompt``
+wrong produces an agent that registers successfully and then behaves nothing like
+the one the operator configured.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import config as kiro_crew_config
+from kiro_crew.acp.kas_agents import (
+    KAS_MAX_CUSTOM_AGENTS,
+    KasAgentTranslationError,
+    resolve_prompt,
+    to_client_custom_agent,
+)
+
+
+def _spec(**over):
+    base = {
+        "name": "kirocrew",
+        "description": "the crew agent",
+        "prompt": "You are Kiro.",
+        "tools": ["fs_read", "fs_write", "@kirocrew-core"],
+        "mcpServers": {"kirocrew-core": {"command": "x"}},
+        "model": "auto",
+        "includeMcpJson": False,
+    }
+    base.update(over)
+    return base
+
+
+class TestRequiredFields:
+    """``id`` and ``prompt`` are the schema's only required members."""
+
+    def test_id_and_prompt_are_emitted(self):
+        out = to_client_custom_agent("kirocrew", _spec(), "You are Kiro.")
+        assert out["id"] == "kirocrew"
+        assert out["prompt"] == "You are Kiro."
+
+    def test_empty_id_is_refused(self):
+        with pytest.raises(KasAgentTranslationError):
+            to_client_custom_agent("", _spec(), "p")
+
+    def test_empty_prompt_is_refused(self):
+        with pytest.raises(KasAgentTranslationError):
+            to_client_custom_agent("kirocrew", _spec(), "   ")
+
+
+class TestToolsFailClosed:
+    """``tools`` absent means NO tools on KAS (``agent.tools ?? []``).
+
+    So the list must always be emitted, and a spec that does not state one must
+    not be widened into an allowlist nobody wrote.
+    """
+
+    def test_list_is_passed_through(self):
+        out = to_client_custom_agent("a", _spec(), "p")
+        assert out["tools"] == ["fs_read", "fs_write", "@kirocrew-core"]
+
+    def test_mcp_server_shorthand_survives(self):
+        """KAS tags every MCP tool ``@<server>``, so Crew's existing syntax works."""
+        out = to_client_custom_agent("a", _spec(tools=["@kirocrew-cron"]), "p")
+        assert out["tools"] == ["@kirocrew-cron"]
+
+    def test_star_becomes_the_all_tools_literal(self):
+        """``"*"`` is a distinct type in the schema, not a list member."""
+        assert to_client_custom_agent("a", _spec(tools=["*"]), "p")["tools"] == "*"
+        assert to_client_custom_agent("a", _spec(tools="*"), "p")["tools"] == "*"
+
+    @pytest.mark.parametrize("bad", [None, {}, 7, "fs_read"])
+    def test_absent_or_malformed_yields_an_empty_allowlist(self, bad):
+        spec = _spec()
+        spec["tools"] = bad
+        if bad is None:
+            del spec["tools"]
+        assert to_client_custom_agent("a", spec, "p")["tools"] == []
+
+    def test_non_string_entries_are_discarded(self):
+        out = to_client_custom_agent("a", _spec(tools=["fs_read", 3, "", None]), "p")
+        assert out["tools"] == ["fs_read"]
+
+
+class TestDeliberateOmissions:
+    """Fields left out on purpose; each would misbehave if projected.
+
+    ``mcpServers`` would double-register against the session-level injection,
+    ``model`` would compete with the dedicated model verb, and ``permissions``
+    would require guessing KAS's capability identifiers.
+    """
+
+    @pytest.mark.parametrize("key", ["mcpServers", "model", "permissions", "welcomeMessage"])
+    def test_key_is_not_projected(self, key):
+        assert key not in to_client_custom_agent("a", _spec(), "p")
+
+
+class TestOptionalPassThrough:
+    def test_description_when_present(self):
+        assert to_client_custom_agent("a", _spec(), "p")["description"] == "the crew agent"
+
+    def test_description_omitted_when_blank(self):
+        assert "description" not in to_client_custom_agent("a", _spec(description=""), "p")
+
+    def test_include_mcp_json_is_a_bool_passthrough(self):
+        assert to_client_custom_agent("a", _spec(), "p")["includeMcpJson"] is False
+        assert "includeMcpJson" not in to_client_custom_agent(
+            "a", _spec(includeMcpJson="no"), "p"
+        )
+
+    def test_resources_and_excluded_tools_when_non_empty(self):
+        out = to_client_custom_agent(
+            "a", _spec(resources=["file:///x.md"], excludedTools=["execute_bash"]), "p"
+        )
+        assert out["resources"] == ["file:///x.md"]
+        assert out["excludedTools"] == ["execute_bash"]
+
+    def test_empty_lists_are_omitted_rather_than_sent(self):
+        out = to_client_custom_agent("a", _spec(resources=[], excludedTools=[]), "p")
+        assert "resources" not in out
+        assert "excludedTools" not in out
+
+
+class TestUnsupportedKeysAreLoud:
+    """A dropped capability must be visible in the log, not silent."""
+
+    def test_dropped_keys_are_named(self, caplog):
+        spec = _spec(allowedTools=["fs_read"], toolsSettings={"x": 1})
+        with caplog.at_level("WARNING"):
+            to_client_custom_agent("kirocrew", spec, "p")
+        msg = caplog.text
+        assert "allowedTools" in msg and "toolsSettings" in msg
+
+    def test_nothing_logged_when_the_spec_has_none(self, caplog):
+        with caplog.at_level("WARNING"):
+            to_client_custom_agent("kirocrew", _spec(), "p")
+        assert "no KAS equivalent" not in caplog.text
+
+
+class TestPromptResolution:
+    """KAS requires resolved content; a ``file://`` prompt is ours to read."""
+
+    def test_inline_prompt_is_returned_as_is(self, tmp_path):
+        assert resolve_prompt({"prompt": "hello"}, agent_id="a", agents_dir=tmp_path) == "hello"
+
+    def test_file_uri_is_inlined(self, tmp_path):
+        p = tmp_path / "prompt.md"
+        p.write_text("from disk", encoding="utf-8")
+        assert (
+            resolve_prompt({"prompt": f"file://{p}"}, agent_id="a", agents_dir=tmp_path)
+            == "from disk"
+        )
+
+    def test_missing_file_is_an_error_not_a_silent_empty_prompt(self, tmp_path):
+        with pytest.raises(KasAgentTranslationError):
+            resolve_prompt(
+                {"prompt": f"file://{tmp_path / 'nope.md'}"}, agent_id="a", agents_dir=tmp_path
+            )
+
+    def test_empty_file_is_refused(self, tmp_path):
+        p = tmp_path / "empty.md"
+        p.write_text("   ", encoding="utf-8")
+        with pytest.raises(KasAgentTranslationError):
+            resolve_prompt({"prompt": f"file://{p}"}, agent_id="a", agents_dir=tmp_path)
+
+    def test_sensitive_prompt_path_is_refused_before_any_read(self, tmp_path):
+        # A spec whose prompt points at a credential file must NOT be inlined and
+        # shipped to KAS. The guard fires on the path, before read_text, so it
+        # holds even if the file does not exist.
+        for target in ("file://~/.aws/credentials", "file://~/.ssh/id_rsa"):
+            with pytest.raises(KasAgentTranslationError, match="not an allowed location"):
+                resolve_prompt({"prompt": target}, agent_id="a", agents_dir=tmp_path)
+
+    def test_proc_environ_prompt_is_refused(self, tmp_path):
+        # /proc/self/environ would leak the gateway's own environment. It must be
+        # refused either way: on POSIX it is absolute and caught by the pseudo-fs
+        # denylist ("not an allowed location"); on Windows it is not absolute (no
+        # drive letter), so it is treated as a relative prompt and rejected for
+        # escaping the agent directory. Both are fail-closed rejections.
+        with pytest.raises(
+            KasAgentTranslationError, match="not an allowed location|escapes the agent directory"
+        ):
+            resolve_prompt(
+                {"prompt": "file:///proc/self/environ"}, agent_id="a", agents_dir=tmp_path
+            )
+
+    def test_relative_prompt_anchors_to_agents_dir_not_cwd(self, tmp_path):
+        sub = tmp_path / "prompts"
+        sub.mkdir()
+        (sub / "expert.md").write_text("expert prompt", encoding="utf-8")
+        out = resolve_prompt(
+            {"prompt": "file://./prompts/expert.md"}, agent_id="a", agents_dir=tmp_path
+        )
+        assert out == "expert prompt"
+
+    def test_relative_prompt_escaping_the_agents_dir_is_refused(self, tmp_path):
+        with pytest.raises(KasAgentTranslationError, match="escapes"):
+            resolve_prompt(
+                {"prompt": "file://../../etc/passwd"}, agent_id="a", agents_dir=tmp_path
+            )
+
+    @pytest.mark.parametrize("bad", [None, "", "   ", 7])
+    def test_absent_prompt_is_refused(self, bad, tmp_path):
+        with pytest.raises(KasAgentTranslationError):
+            resolve_prompt({"prompt": bad}, agent_id="a", agents_dir=tmp_path)
+
+
+def test_the_batch_cap_matches_the_schema():
+    """KAS declares ``customAgents: z.array(z.unknown()).max(50)``."""
+    assert KAS_MAX_CUSTOM_AGENTS == 50
+
+
+class TestAgainstTheRealBundledSpec:
+    """Translate the spec Crew actually ships, not a hand-written stand-in.
+
+    The fixtures above encode what the schema allows; this one catches the case
+    where the real spec's shape has drifted away from them.
+    """
+
+    @staticmethod
+    def _bundled() -> dict:
+        path = Path(kiro_crew_config.__file__).resolve().parent / "defaults.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def test_the_crew_agent_projects_with_its_tools_intact(self):
+        spec = self._bundled()
+        out = to_client_custom_agent(spec["name"], spec, "resolved prompt text")
+
+        assert out["id"] == "kirocrew"
+        assert out["prompt"] == "resolved prompt text"
+        # The MCP shorthand is most of Crew's tool surface; losing it would leave
+        # the agent nominally configured but unable to reach its own tools.
+        assert any(t.startswith("@") for t in out["tools"])
+        assert "fs_read" in out["tools"]
+
+    def test_the_real_spec_carries_keys_KAS_cannot_take(self):
+        """Guards the drop path against the actual spec, not a synthetic one."""
+        spec = self._bundled()
+        assert spec.get("allowedTools"), "expected the real spec to still carry allowedTools"
+        out = to_client_custom_agent(spec["name"], spec, "p")
+        assert "allowedTools" not in out
+        assert "mcpServers" not in out

--- a/test/test_kas_auth.py
+++ b/test/test_kas_auth.py
@@ -1,0 +1,190 @@
+"""Tests for the KAS auth callback helper.
+
+The security-critical property under test is negative: a token must NEVER appear
+in an exception message, a log, or the forwarded dict beyond the covenant keys.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from kiro_crew.acp import kas_auth
+from kiro_crew.acp.kas_auth import (
+    KasAuthCallbackError,
+    _parse_token_output,
+    resolve_kas_access_token,
+)
+
+# A realistic-looking token value. Every failure-path test asserts this string
+# never escapes into an exception message.
+_FAKE_TOKEN = "aoaAbc123." + "X" * 200
+
+
+def _line(kind: str, data: dict) -> bytes:
+    return (json.dumps({"kind": kind, "data": data}) + "\n").encode()
+
+
+class TestParsingHappyPath:
+    def test_returns_all_present_covenant_keys(self):
+        out = _line(
+            "getKasToken",
+            {
+                "accessToken": _FAKE_TOKEN,
+                "expiresAt": "2026-08-14T00:12:59Z",
+                "profileArn": "arn:aws:codewhisperer:us-east-1:123:profile/X",
+                "authMethod": "external_idp",
+                "provider": "ExternalIdp",
+            },
+        )
+        result = _parse_token_output(out, b"")
+        assert result == {
+            "accessToken": _FAKE_TOKEN,
+            "expiresAt": "2026-08-14T00:12:59Z",
+            "profileArn": "arn:aws:codewhisperer:us-east-1:123:profile/X",
+            "authMethod": "external_idp",
+            "provider": "ExternalIdp",
+        }
+
+    def test_omits_absent_optional_keys(self):
+        # Mirrors the real observed output: authMethod null → absent on the wire.
+        out = _line(
+            "getKasToken",
+            {
+                "accessToken": _FAKE_TOKEN,
+                "expiresAt": "2026-08-14T00:12:59Z",
+                "profileArn": "arn:aws:codewhisperer:us-east-1:123:profile/X",
+                "provider": "Internal",
+            },
+        )
+        result = _parse_token_output(out, b"")
+        assert set(result) == {"accessToken", "expiresAt", "profileArn", "provider"}
+        assert "authMethod" not in result
+
+    def test_drops_unexpected_keys(self):
+        out = _line(
+            "getKasToken",
+            {
+                "accessToken": _FAKE_TOKEN,
+                "expiresAt": "2026-08-14T00:12:59Z",
+                "refreshToken": "SHOULD-NOT-FORWARD",
+                "surprise": "nope",
+            },
+        )
+        result = _parse_token_output(out, b"")
+        assert set(result) == {"accessToken", "expiresAt"}
+
+    def test_uses_last_line_only(self):
+        out = b"some leading log noise\n" + _line(
+            "getKasToken", {"accessToken": _FAKE_TOKEN, "expiresAt": "2026-08-14T00:12:59Z"}
+        )
+        result = _parse_token_output(out, b"")
+        assert result["accessToken"] == _FAKE_TOKEN
+
+
+class TestFailurePathsDoNotLeak:
+    def test_non_json_output_is_not_echoed(self):
+        # A malformed line could itself be a live token with trailing junk.
+        junk = _FAKE_TOKEN + " <not json>"
+        with pytest.raises(KasAuthCallbackError) as ei:
+            _parse_token_output(junk.encode(), b"")
+        assert _FAKE_TOKEN not in str(ei.value)
+
+    def test_missing_access_token_raises(self):
+        out = _line("getKasToken", {"expiresAt": "2026-08-14T00:12:59Z"})
+        with pytest.raises(KasAuthCallbackError, match="missing accessToken"):
+            _parse_token_output(out, b"")
+
+    def test_unexpected_kind_raises(self):
+        out = _line("somethingElse", {"accessToken": _FAKE_TOKEN})
+        with pytest.raises(KasAuthCallbackError) as ei:
+            _parse_token_output(out, b"")
+        assert _FAKE_TOKEN not in str(ei.value)
+
+    def test_error_kind_uses_a_fixed_generic_message(self):
+        # The subprocess-provided error text is NOT surfaced (it is untrusted
+        # and could carry sensitive content); a fixed, actionable message is
+        # raised instead.
+        out = _line("error", {"message": f"boom token={_FAKE_TOKEN}"})
+        with pytest.raises(KasAuthCallbackError, match="kiro-cli login") as ei:
+            _parse_token_output(out, b"")
+        assert _FAKE_TOKEN not in str(ei.value)
+        assert "boom" not in str(ei.value)
+
+    def test_empty_output_raises(self):
+        with pytest.raises(KasAuthCallbackError, match="no token output"):
+            _parse_token_output(b"", b"")
+
+    def test_non_object_json_raises(self):
+        with pytest.raises(KasAuthCallbackError):
+            _parse_token_output(b"[1,2,3]\n", b"")
+
+    def test_stderr_is_not_echoed_when_no_stdout(self):
+        # stderr is untrusted; it must not be echoed at all (redaction is
+        # best-effort, so suppression is the only guarantee).
+        stderr = f"token={_FAKE_TOKEN}".encode()
+        with pytest.raises(KasAuthCallbackError) as ei:
+            _parse_token_output(b"", stderr)
+        assert _FAKE_TOKEN not in str(ei.value)
+        assert "token=" not in str(ei.value)
+
+
+class TestResolveBinaryMissing:
+    @pytest.mark.asyncio
+    async def test_missing_binary_raises(self, monkeypatch):
+        monkeypatch.setattr(kas_auth, "resolve_kiro_cli", lambda: None)
+        with pytest.raises(KasAuthCallbackError, match="kiro-cli not found"):
+            await resolve_kas_access_token()
+
+
+class _HangingProc:
+    """A fake subprocess whose communicate() never returns on its own."""
+
+    def __init__(self):
+        self.returncode = None
+        self.killed = False
+
+    async def communicate(self):
+        await asyncio.sleep(3600)  # never completes; caller must kill
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self):
+        return self.returncode
+
+
+class TestSubprocessNeverOrphaned:
+    """The get-kas-token subprocess must not outlive the callback."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_the_subprocess(self, monkeypatch):
+        proc = _HangingProc()
+        monkeypatch.setattr(kas_auth, "resolve_kiro_cli", lambda: "kiro-cli")
+
+        async def _fake_exec(*a, **k):
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+        with pytest.raises(KasAuthCallbackError, match="timed out"):
+            await resolve_kas_access_token(timeout=0.05)
+        assert proc.killed is True
+
+    @pytest.mark.asyncio
+    async def test_cancellation_kills_the_subprocess(self, monkeypatch):
+        proc = _HangingProc()
+        monkeypatch.setattr(kas_auth, "resolve_kiro_cli", lambda: "kiro-cli")
+
+        async def _fake_exec(*a, **k):
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+        task = asyncio.ensure_future(resolve_kas_access_token(timeout=100))
+        await asyncio.sleep(0.05)  # let it reach communicate()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert proc.killed is True

--- a/test/test_kas_auth_callback.py
+++ b/test/test_kas_auth_callback.py
@@ -1,0 +1,102 @@
+"""Runtime wiring for KAS's auth callback.
+
+KAS sends ``_kiro/auth/getAccessToken`` as a connection-level request (no
+sessionId), so the runtime answers it directly. These tests pin: a resolved
+token is sent straight back; every failure becomes a JSON-RPC error (KAS never
+hangs); an UNEXPECTED error's text never reaches the wire; and a non-KAS backend
+refuses outright.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.acp import runtime as runtime_mod
+from kiro_crew.acp.kas_assets import build_kas_argv
+from kiro_crew.acp.kas_auth import KasAuthCallbackError
+from kiro_crew.acp.runtime import AcpRuntime
+from kiro_crew.acp.types import ACP_BACKEND_KAS, ACP_BACKEND_KIRO
+
+_FAKE_TOKEN = "aoaAbc123." + "X" * 200
+_RESULT = {"accessToken": _FAKE_TOKEN, "expiresAt": "2026-08-14T00:12:59Z"}
+
+
+def _fake_runtime(backend: str = ACP_BACKEND_KAS) -> MagicMock:
+    """A stand-in carrying only what _answer_get_access_token touches."""
+    fake = MagicMock()
+    fake._acp_backend = backend
+    fake.send_response = AsyncMock()
+    fake.send_error = AsyncMock()
+    return fake
+
+
+class TestAnswerGetAccessToken:
+    @pytest.mark.asyncio
+    async def test_answers_with_the_resolved_token(self, monkeypatch):
+        monkeypatch.setattr(
+            runtime_mod, "resolve_kas_access_token", AsyncMock(return_value=_RESULT)
+        )
+        fake = _fake_runtime()
+        await AcpRuntime._deliver_kas_access_token(fake, 7)
+        fake.send_response.assert_awaited_once_with(7, _RESULT)
+        fake.send_error.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_callback_error_is_returned_as_reason(self, monkeypatch):
+        monkeypatch.setattr(
+            runtime_mod,
+            "resolve_kas_access_token",
+            AsyncMock(side_effect=KasAuthCallbackError("not logged in")),
+        )
+        fake = _fake_runtime()
+        await AcpRuntime._deliver_kas_access_token(fake, 7)
+        fake.send_response.assert_not_awaited()
+        fake.send_error.assert_awaited_once()
+        args = fake.send_error.await_args.args
+        assert args[0] == 7
+        assert "not logged in" in args[2]
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_message_is_generic(self, monkeypatch):
+        # An unexpected exception could carry token bytes in its text; the wire
+        # error must be generic, never str(exc).
+        monkeypatch.setattr(
+            runtime_mod,
+            "resolve_kas_access_token",
+            AsyncMock(side_effect=ValueError(_FAKE_TOKEN)),
+        )
+        fake = _fake_runtime()
+        await AcpRuntime._deliver_kas_access_token(fake, 7)
+        fake.send_response.assert_not_awaited()
+        fake.send_error.assert_awaited_once()
+        msg = fake.send_error.await_args.args[2]
+        assert _FAKE_TOKEN not in msg
+        assert msg == "auth callback failed"
+
+    @pytest.mark.asyncio
+    async def test_kas_backend_dispatches_to_delivery(self):
+        # Positive backend dispatch (harness-parity H5): KAS → deliver.
+        fake = _fake_runtime()
+        fake._deliver_kas_access_token = AsyncMock()
+        await AcpRuntime._answer_get_access_token(fake, 7)
+        fake._deliver_kas_access_token.assert_awaited_once_with(7)
+        fake.send_error.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_kas_backend_refuses_without_delivering(self):
+        fake = _fake_runtime(backend=ACP_BACKEND_KIRO)
+        fake._deliver_kas_access_token = AsyncMock()
+        await AcpRuntime._answer_get_access_token(fake, 7)
+        fake._deliver_kas_access_token.assert_not_awaited()
+        fake.send_response.assert_not_awaited()
+        fake.send_error.assert_awaited_once()
+
+
+class TestLaunchFlag:
+    def test_kas_argv_requests_acp_callback(self, tmp_path):
+        node = tmp_path / "node"
+        script = tmp_path / "acp-server.js"
+        argv = build_kas_argv(node, script)
+        assert "--auth=acp-callback" in argv

--- a/test/test_kas_mode_binding.py
+++ b/test/test_kas_mode_binding.py
@@ -1,0 +1,239 @@
+"""Agent binding on KAS: inject the definition, then activate it as a mode.
+
+KAS has no ``--agent`` flag and advertises only its own built-in modes, so a
+``session/set_mode`` naming Crew's agent fails against a stock KAS. The agent has
+to travel on ``session/new`` as ``_meta.kiro.customAgents``; KAS registers it, it
+surfaces as a mode, and the ordinary activation then works.
+
+The stub here mirrors that mechanism rather than accepting everything: it
+advertises only its built-ins plus whatever the client injected, and rejects a
+``set_mode`` for an unknown mode. A test that passes against a permissive stub
+would prove nothing about the binding.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from kiro_crew.acp.kas_assets import ENV_KAS_NODE, ENV_KAS_SCRIPT
+from kiro_crew.acp.runtime import AcpRuntime
+from kiro_crew.acp.types import ACP_BACKEND_KAS
+
+#: Records what the client injected so a test can read it back, and gates
+#: ``session/set_mode`` on the resulting mode list the way KAS does.
+_MODE_STUB = '''
+import json, os, sys
+
+BUILTIN = ["vibe", "spec", "plan"]
+state = {"modes": list(BUILTIN), "injected": [], "set_mode": None}
+RECORD = os.environ["KAS_STUB_RECORD"]
+
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\\n")
+    sys.stdout.flush()
+
+def record():
+    with open(RECORD, "w", encoding="utf-8") as fh:
+        json.dump(state, fh)
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method, mid, params = msg.get("method"), msg.get("id"), msg.get("params") or {}
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": mid, "result": {
+            "protocolVersion": params.get("protocolVersion"),
+            "agentCapabilities": {"loadSession": True},
+        }})
+    elif method == "session/new":
+        agents = ((params.get("_meta") or {}).get("kiro") or {}).get("customAgents") or []
+        state["injected"] = agents
+        state["modes"] = list(BUILTIN) + [a.get("id") for a in agents if a.get("id")]
+        record()
+        send({"jsonrpc": "2.0", "id": mid, "result": {
+            "sessionId": "kas-mode-session",
+            "modes": {
+                "currentModeId": "vibe",
+                "availableModes": [{"id": m, "name": m} for m in state["modes"]],
+            },
+        }})
+    elif method == "session/set_mode":
+        requested = params.get("modeId")
+        state["set_mode"] = requested
+        record()
+        if requested in state["modes"]:
+            send({"jsonrpc": "2.0", "id": mid, "result": {}})
+        else:
+            send({"jsonrpc": "2.0", "id": mid, "error": {
+                "code": -32603, "message": "Mode '%s' not found" % requested}})
+    elif mid is not None:
+        send({"jsonrpc": "2.0", "id": mid, "result": {}})
+'''
+
+
+@pytest.fixture
+def mode_stub(tmp_path, monkeypatch):
+    """A KAS-shaped agent that only accepts modes it actually advertises."""
+    script = tmp_path / "kas_mode_stub.py"
+    script.write_text(_MODE_STUB)
+    record = tmp_path / "stub-record.json"
+    launcher = tmp_path / "node-stub"
+    launcher.write_text(f'#!/bin/sh\nexec "{sys.executable}" "{script}"\n')
+    launcher.chmod(0o755)
+    monkeypatch.setenv(ENV_KAS_NODE, str(launcher))
+    monkeypatch.setenv(ENV_KAS_SCRIPT, str(script))
+    monkeypatch.setenv("KAS_STUB_RECORD", str(record))
+    return record
+
+
+@pytest.fixture
+def crew_agent(tmp_path, monkeypatch):
+    """A materialized agent spec the projection can read, in an isolated dir."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    (agents_dir / "kirocrew.json").write_text(
+        json.dumps(
+            {
+                "name": "kirocrew",
+                "description": "test crew agent",
+                "prompt": "You are Kiro.",
+                "tools": ["fs_read", "@kirocrew-core"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("kiro_crew.acp.runtime.kiro_agents_dir", lambda: agents_dir)
+    monkeypatch.setattr("kiro_crew.acp.runtime.ensure_agent_materialized", lambda _a: True)
+    return agents_dir
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="the stub launcher is a POSIX shell script")
+class TestModeBinding:
+    @pytest.mark.asyncio
+    async def test_injected_agent_becomes_the_active_mode(
+        self, mode_stub, crew_agent, tmp_path
+    ):
+        """The whole chain: inject -> advertised as a mode -> activated."""
+        runtime = AcpRuntime(
+            work_dir=tmp_path / "ws",
+            agent="kirocrew",
+            sandbox_mode="off",
+            acp_backend=ACP_BACKEND_KAS,
+        )
+        try:
+            await runtime.spawn()
+            handle = await runtime.create_session(cwd=tmp_path / "ws", agent="kirocrew")
+            assert handle is not None
+        finally:
+            await runtime.kill()
+
+        seen = json.loads(mode_stub.read_text(encoding="utf-8"))
+        assert [a["id"] for a in seen["injected"]] == ["kirocrew"]
+        assert seen["injected"][0]["prompt"] == "You are Kiro."
+        assert seen["injected"][0]["tools"] == ["fs_read", "@kirocrew-core"]
+        # Activation had to happen, and had to name the injected agent — not a
+        # built-in that KAS would have run in its place.
+        assert seen["set_mode"] == "kirocrew"
+
+    @pytest.mark.asyncio
+    async def test_runtime_default_agent_is_activated_without_explicit_request(
+        self, mode_stub, crew_agent, tmp_path
+    ):
+        """A KAS session created with no explicit agent must still ACTIVATE the
+        runtime default. KAS has no --agent flag, so injecting the default via
+        customAgents without a following set_mode would leave the session on
+        KAS's own default mode — the injection would be inert. Injection and
+        activation must resolve the SAME agent.
+        """
+        runtime = AcpRuntime(
+            work_dir=tmp_path / "wsd",
+            agent="kirocrew",
+            sandbox_mode="off",
+            acp_backend=ACP_BACKEND_KAS,
+        )
+        try:
+            await runtime.spawn()
+            # No agent= passed: both injection and activation must fall back to
+            # the runtime default.
+            await runtime.create_session(cwd=tmp_path / "wsd")
+        finally:
+            await runtime.kill()
+
+        seen = json.loads(mode_stub.read_text(encoding="utf-8"))
+        assert [a["id"] for a in seen["injected"]] == ["kirocrew"]
+        assert seen["set_mode"] == "kirocrew"
+
+    @pytest.mark.asyncio
+    async def test_prompt_is_inlined_not_sent_as_a_file_uri(
+        self, mode_stub, crew_agent, tmp_path
+    ):
+        """KAS rejects ``file://`` here; the client owns the read."""
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("inlined from disk", encoding="utf-8")
+        (crew_agent / "kirocrew.json").write_text(
+            json.dumps(
+                {"name": "kirocrew", "prompt": f"file://{prompt_file}", "tools": ["fs_read"]}
+            ),
+            encoding="utf-8",
+        )
+        runtime = AcpRuntime(
+            work_dir=tmp_path / "ws2",
+            agent="kirocrew",
+            sandbox_mode="off",
+            acp_backend=ACP_BACKEND_KAS,
+        )
+        try:
+            await runtime.spawn()
+            await runtime.create_session(cwd=tmp_path / "ws2", agent="kirocrew")
+        finally:
+            await runtime.kill()
+
+        seen = json.loads(mode_stub.read_text(encoding="utf-8"))
+        assert seen["injected"][0]["prompt"] == "inlined from disk"
+
+    @pytest.mark.asyncio
+    async def test_an_unprojectable_agent_fails_loud(self, mode_stub, crew_agent, tmp_path):
+        """Silently continuing would run KAS's default mode instead.
+
+        For a restricted app or subagent agent that means a BROADER agent than
+        the caller asked for, so this must raise rather than degrade.
+        """
+        (crew_agent / "kirocrew.json").write_text(
+            json.dumps({"name": "kirocrew", "tools": ["fs_read"]}), encoding="utf-8"
+        )
+        runtime = AcpRuntime(
+            work_dir=tmp_path / "ws3",
+            agent="kirocrew",
+            sandbox_mode="off",
+            acp_backend=ACP_BACKEND_KAS,
+        )
+        try:
+            await runtime.spawn()
+            with pytest.raises(Exception) as exc:
+                await runtime.create_session(cwd=tmp_path / "ws3", agent="kirocrew")
+            assert "onto KAS" in str(exc.value)
+        finally:
+            await runtime.kill()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="the stub launcher is a POSIX shell script")
+class TestKiroPathUntouched:
+    """The kiro backend must not gain a customAgents payload.
+
+    kiro-cli reads its agent from disk via ``--agent``; injecting definitions
+    would be a second, competing source of truth.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_custom_agents_for_the_kiro_backend(self, mode_stub, crew_agent, tmp_path):
+        runtime = AcpRuntime(
+            work_dir=tmp_path / "ws4",
+            agent="kirocrew",
+            sandbox_mode="off",
+        )
+        assert await runtime._kas_custom_agents("kirocrew") is None

--- a/test/test_kas_model_verb.py
+++ b/test/test_kas_model_verb.py
@@ -1,0 +1,105 @@
+"""The model is set by a different VERB on each backend.
+
+kiro-cli takes ``session/set_model``. KAS implements no such method — the model is
+one of its session config options — so a session on KAS would error on every
+model assignment if the kiro verb were reused. The bookkeeping either verb
+triggers (resolved id, context-window rebase) is identical and stays shared.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.acp.session_handle import AcpSessionHandle
+from kiro_crew.acp.types import (
+    ACP_BACKEND_KAS,
+    ACP_BACKEND_KIRO,
+    METHOD_SET_CONFIG_OPTION,
+    METHOD_SET_MODEL,
+    MODEL_CONFIG_ID,
+)
+
+_MODEL = "claude-sonnet-4.5"
+
+
+def _handle(backend: str) -> tuple[AcpSessionHandle, MagicMock]:
+    runtime = MagicMock()
+    runtime.acp_backend = backend
+    # send_request returns a request id the caller may then await a response for.
+    runtime.send_request = AsyncMock(return_value=1)
+    handle = AcpSessionHandle("sess-1", asyncio.Queue(), runtime)
+    # Response plumbing is not what these tests are about; the wire call is.
+    handle._wait_for_response = AsyncMock(return_value={})  # type: ignore[method-assign]
+    # The gate in set_model only sends a model the session advertised, so the
+    # advertisement has to exist for either verb to be reached at all.
+    handle._available_models = [{"modelId": _MODEL}]
+    return handle, runtime
+
+
+def _sent_methods(runtime: MagicMock) -> list[str]:
+    return [call.args[0] for call in runtime.send_request.await_args_list]
+
+
+class TestModelVerbPerBackend:
+    @pytest.mark.asyncio
+    async def test_kas_uses_a_session_config_option(self):
+        handle, runtime = _handle(ACP_BACKEND_KAS)
+        await handle.set_model(_MODEL)
+        methods = _sent_methods(runtime)
+        assert METHOD_SET_CONFIG_OPTION in methods
+        # Reusing the kiro verb here is the defect this pins: KAS has no handler
+        # for it, so the assignment would fail on every switch.
+        assert METHOD_SET_MODEL not in methods
+
+    @pytest.mark.asyncio
+    async def test_kas_names_the_model_config_id(self):
+        handle, runtime = _handle(ACP_BACKEND_KAS)
+        await handle.set_model(_MODEL)
+        params = next(
+            c.args[1]
+            for c in runtime.send_request.await_args_list
+            if c.args[0] == METHOD_SET_CONFIG_OPTION
+        )
+        assert params["configId"] == MODEL_CONFIG_ID
+        assert params["value"] == _MODEL
+        assert params["sessionId"] == "sess-1"
+
+    @pytest.mark.asyncio
+    async def test_kiro_still_uses_set_model(self):
+        handle, runtime = _handle(ACP_BACKEND_KIRO)
+        await handle.set_model(_MODEL)
+        methods = _sent_methods(runtime)
+        assert METHOD_SET_MODEL in methods
+        assert METHOD_SET_CONFIG_OPTION not in methods
+
+
+class TestSharedBookkeeping:
+    """Whichever verb carried it, the handle's own state must agree.
+
+    The context meter converts percentages against the resolved model's window,
+    so a backend that updated the wire but not this state would report usage
+    against the previous model.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("backend", [ACP_BACKEND_KAS, ACP_BACKEND_KIRO])
+    async def test_resolved_model_is_recorded(self, backend):
+        handle, _ = _handle(backend)
+        await handle.set_model(_MODEL)
+        assert handle._model == _MODEL
+        assert handle._resolved_model_id == _MODEL
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("backend", [ACP_BACKEND_KAS, ACP_BACKEND_KIRO])
+    async def test_an_unserved_model_sends_nothing_on_either_backend(self, backend):
+        """The advertised-model gate is backend-independent.
+
+        It can only run after ``session/new`` returns the served list, which is
+        why the model is not carried in the session/new payload instead.
+        """
+        handle, runtime = _handle(backend)
+        await handle.set_model("some-model-nobody-serves")
+        assert runtime.send_request.await_args_list == []

--- a/test/test_kas_session_teardown.py
+++ b/test/test_kas_session_teardown.py
@@ -1,0 +1,77 @@
+"""Freeing one session uses a different VERB on each backend.
+
+kiro-cli's terminate evicts the session from the multiplexed process and leaves
+the transcript for the caller to unlink. KAS's extension namespace is ``_kiro/``
+(no ``.dev``) and it offers no evict-only verb, so its delete disposes the
+resident AND removes the persisted record. Reusing the kiro verb against KAS
+returns ``-32603``, so the session would never be freed and RSS would grow with
+every background task.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.acp.runtime import AcpRuntime
+from kiro_crew.acp.types import (
+    ACP_BACKEND_KAS,
+    METHOD_KAS_SESSION_DELETE,
+    METHOD_SESSION_TERMINATE,
+)
+
+
+def _runtime(tmp_path, backend: str) -> AcpRuntime:
+    return AcpRuntime(
+        work_dir=tmp_path / f"ws-{backend or 'kiro'}",
+        sandbox_mode="off",
+        acp_backend=backend,
+    )
+
+
+class TestTeardownVerbPerBackend:
+    def test_kas_uses_the_kiro_slash_delete_verb(self, tmp_path):
+        assert _runtime(tmp_path, ACP_BACKEND_KAS)._session_teardown_method() == (
+            METHOD_KAS_SESSION_DELETE
+        )
+
+    def test_kiro_still_uses_terminate(self, tmp_path):
+        assert _runtime(tmp_path, "")._session_teardown_method() == METHOD_SESSION_TERMINATE
+
+    def test_the_two_verbs_are_not_the_same_namespace(self):
+        """A regression here would send the wrong extension namespace."""
+        assert METHOD_KAS_SESSION_DELETE == "_kiro/session/delete"
+        assert METHOD_SESSION_TERMINATE == "_kiro.dev/session/terminate"
+
+
+class TestTeardownIsStillBestEffort:
+    """Teardown must neither hang nor raise, on either backend.
+
+    The local unregister has to run even when the request cannot be delivered, or
+    the reader loop keeps routing frames to an abandoned queue.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("backend", [ACP_BACKEND_KAS, ""])
+    async def test_a_dead_runtime_skips_the_round_trip(self, tmp_path, backend):
+        runtime = _runtime(tmp_path, backend)
+        runtime._dead = True
+        # Never spawned, so a round-trip would raise rather than no-op.
+        await runtime.terminate_session("sess-1")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("backend", [ACP_BACKEND_KAS, ""])
+    async def test_the_queue_is_unregistered_even_when_the_send_fails(
+        self, tmp_path, backend, monkeypatch
+    ):
+        import asyncio
+
+        runtime = _runtime(tmp_path, backend)
+        runtime._session_queues["sess-1"] = asyncio.Queue()
+        runtime._process = object()  # type: ignore[assignment]
+
+        async def boom(*_a, **_k):
+            raise RuntimeError("backend refused")
+
+        monkeypatch.setattr(runtime, "_send_and_await", boom)
+        await runtime.terminate_session("sess-1")
+        assert "sess-1" not in runtime._session_queues

--- a/test/test_kas_spawn.py
+++ b/test/test_kas_spawn.py
@@ -7,13 +7,13 @@ KAS's dialect, and completes ``initialize`` -> ``session/new`` -> ``session/prom
 not exercise the real KAS build, which is not present on a machine whose kiro-cli
 has never unpacked it.
 
-Driving the REAL build is deliberately NOT a test here. KAS authenticates itself
-through its file auth provider, so it reads and may rewrite the operator's token —
-state no ``tmp_path`` contains — and an env-var opt-in is not enough protection
-when that variable can be set in a shell profile or a CI matrix and then reached
-by an ordinary ``pytest`` run. Pointing KAS at a synthetic token dir is not an
-option either: it would select a provider with no credentials and so prove nothing
-about the auth path being verified.
+Driving the REAL build is deliberately NOT a test here. KAS is launched with
+``--auth=acp-callback``, so a real prompt makes it call back for a token, which
+the runtime answers by shelling out to ``kiro-cli chat _ get-kas-token`` — that
+touches the operator's live credential store, state no ``tmp_path`` contains, and
+an env-var opt-in is not enough protection when that variable can be set in a
+shell profile or a CI matrix and then reached by an ordinary ``pytest`` run.
+Faking the callback proves nothing about the real auth path either.
 
 When working on the backend, run it by hand instead::
 
@@ -32,11 +32,10 @@ When working on the backend, run it by hand instead::
     asyncio.run(main())
     EOF
 
-That last call is the current blocker: KAS advertises only its own built-in modes
-(``vibe``, ``spec``, ``plan``, ...), and Crew's agent reaches it through
-``_meta.kiro.customAgents`` on ``session/new``, which is not wired up — so the mode
-guard refuses rather than running a broader agent than the caller asked for. This
-is why ``agent.acp_backend`` does not accept ``kas`` yet.
+That call now succeeds: Crew injects its agent through ``_meta.kiro.customAgents``
+on ``session/new`` and activates it with ``session/set_mode``, and with
+``--auth=acp-callback`` a real prompt round-trip completes (the host answers KAS's
+token callback by shelling out to kiro-cli). ``agent.acp_backend`` accepts ``kas``.
 """
 
 from __future__ import annotations
@@ -121,19 +120,21 @@ class TestArgv:
     def test_shape(self, tmp_path):
         argv = build_kas_argv(tmp_path / "node", tmp_path / "acp-server.js")
         assert argv[0].endswith("node")
-        assert argv[-1] == KAS_TRANSPORT_ARG
+        assert KAS_TRANSPORT_ARG in argv
         for flag in KAS_NODE_FLAGS:
             assert flag in argv
 
-    def test_no_auth_flag_is_passed(self, tmp_path):
-        """Omitting --auth is what keeps token handling out of this codebase.
+    def test_auth_acp_callback_is_passed(self, tmp_path):
+        """We now launch KAS with --auth=acp-callback.
 
-        With no --auth, KAS selects its file auth provider and reads/refreshes
-        the token itself. Passing --auth=acp-callback would instead force this
-        process to implement ``_kiro/auth/getAccessToken``.
+        KAS then keeps no refresh token and asks this host for an access token
+        over ACP (``_kiro/auth/getAccessToken``), which the runtime answers by
+        shelling out to kiro-cli. This works on a cli-only machine, unlike the
+        file auth provider (omit --auth) whose SSO-cache token ``kiro-cli login``
+        does not write.
         """
         argv = build_kas_argv(tmp_path / "node", tmp_path / "acp-server.js")
-        assert not any(a.startswith("--auth") for a in argv)
+        assert "--auth=acp-callback" in argv
 
     def test_no_agent_flag_is_passed(self, tmp_path):
         argv = build_kas_argv(tmp_path / "node", tmp_path / "acp-server.js")

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -172,6 +172,16 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # version into versions.txt. The binary name is a module constant; a
         # resource ceiling / sandbox adds nothing to a `--version` call.
         "diagnostics.py::_kiro_cli_version",
+        # KAS auth callback token fetch (--auth=acp-callback): a single fixed
+        # argv ``[<kiro-cli>, "chat", "_", "get-kas-token"]`` with a 20s timeout,
+        # no shell and no agent-influenced arguments — the subcommand tail is a
+        # module constant and the binary is the same kiro-cli Crew already spawns
+        # as its agent runtime (``resolve_kiro_cli``). Deliberately NOT
+        # sandbox-routed: kiro-cli must reach its OWN auth/token store to mint the
+        # KAS access token (same reason ``gh`` is not routed), which a sandbox
+        # would hide and break the callback. The child is SIGKILLed on timeout or
+        # task cancellation, so it never orphans.
+        "acp/kas_auth.py::resolve_kas_access_token",
         # Tailnet origin derivation + forwarded-peer whois (RFC:
         # rfc-tailnet-dashboard-access): one fixed argv — ``["<tailscale>",
         # "status", "--json"]`` or ``["<tailscale>", "whois", "--json",


### PR DESCRIPTION
## Summary

Makes the **KAS (kiro-agent) ACP backend** usable as a real chat backend, end to
end. Builds on the merged KAS spawn/asset work; this adds the four things that
stood between "session starts" and "prompt works", plus the unlock.

### What changed

- **Custom-agent injection** (`kas_agents.py`) — KAS has no `--agent` flag, so a
  Crew agent spec is projected onto KAS's `ClientCustomAgent` and carried on
  `session/new` via `_meta.kiro.customAgents`, then activated with
  `session/set_mode`. Prompt is inlined (no `file://`), tools **fail closed**
  (empty = no tool access, never a guessed `*`), and unprojectable specs **fail
  loud** rather than silently running a broader agent. `@server` tool syntax
  works unchanged (KAS tags each MCP tool `@<server>`).
- **Model verb** — KAS implements no `session/set_model`; model changes route
  through `session/set_config_option{configId:"model"}`. The kiro path is
  untouched. Deliberately does **not** send `_meta.kiro.modelId` on
  `session/new` (that precedes the served-model safety gate).
- **Session teardown** — `_kiro.dev/session/terminate` maps to
  `_kiro/session/delete` unconditionally. The local transcript cleanup is a
  no-op on KAS (it targets kiro-cli's dir), documented so the `keep_transcript`
  guard is not mistaken for live protection.
- **Auth via acp-callback** (`kas_auth.py`) — KAS is launched with
  `--auth=acp-callback` and keeps no refresh token; whenever it needs an access
  token it calls back over ACP (`_kiro/auth/getAccessToken`), which the runtime
  answers by shelling out to `kiro-cli chat _ get-kas-token`. This works on any
  machine where `kiro-cli login` succeeded — no dependency on an
  IDE/SSO-written token file.
- **Unlock** — `kas` is now selectable via `agent.acp_backend`.

### Security (credential handling)

Security-sensitive credential handling — no secret in logs, no information
disclosure via errors:

- The access token is a **transient local** for one callback — never cached,
  persisted, or logged. The OIDC **refresh token never leaves kiro-cli**.
- Failure paths raise a fixed, **token-free** message; subprocess stdout/stderr
  is **never echoed** (redaction is best-effort, so suppression is the
  guarantee). An unexpected exception returns a generic `"auth callback failed"`,
  never `str(exc)`.
- The subprocess is an **argv list, no shell** (no injection surface) with a
  **timeout** so a hung kiro-cli cannot wedge the connection's auth.
- Only the covenant keys (`accessToken`/`expiresAt`/`profileArn`/`authMethod`/
  `provider`) are forwarded; only the KAS backend ever shells out (defensive
  backend guard).

## Tests

Automated (new): agent translation (`test_kas_agents.py`), mode binding
(`test_kas_mode_binding.py`), model verb (`test_kas_model_verb.py`), session
teardown (`test_kas_session_teardown.py`), and the auth path
(`test_kas_auth.py`, `test_kas_auth_callback.py`). The auth tests pin the
leak-safety invariants directly: a token-shaped string never appears in an
exception message, stderr is never echoed on the no-token path, and an
unexpected exception yields a generic reason — each verified by a mutation
(flip the guard → the test goes red).

## Manual verification (real KAS 0.38.7)

Run against the real KAS bundle on a cli-logged-in machine, outside the test
suite (the callback touches the live credential store). No token was surfaced in
any run.

**1. Auth + prompt round-trip** — the exact step that failed with
`No auth token found` before this change:

```
[1] spawn+initialize ok; loadSession: True
[2] session/new ok
[3] set_mode(kirocrew) ok
[4] prompt round-trip ok=True stop_reason='end_turn' reply='PONG'
```

KAS's own log confirms the path:
`Auth: --auth=acp-callback (host-mediated refresh via _kiro/auth/getAccessToken)`.

**2. Proof-of-KAS + multi-turn reasoning** — four independent signals that the
session is served by KAS, then a 3-turn conversation an echo could not produce:

- Bundle spawned: `…/kas/2.18.0-…/@kiro/agent/dist/server/acp-server.js`
- KAS self-identifies on stderr:
  `kas.server.starting {"product":"KAS (Kiro Agent Server)","version":"0.38.7"}`
- KAS runtime generated each turn: `[KRS] GenerateAssistantResponseCommand done`
- `set_mode(kirocrew)` succeeds — that mode exists only because KAS accepted the
  injected `_meta.kiro.customAgents` (a KAS-only mechanism)

Conversation (same session, cross-turn memory + reasoning):
- Turn 1: given name=Zebra, favorite=7, city=Berlin → acknowledged
- Turn 2: `7×6=42`, "Zebra"=5 letters, `42−5=37` → correct
- Turn 3: recalled Berlin (set two turns earlier, not repeated since) and used it
  in a one-sentence travel tip

## Gates

flake8 / isort / mypy (946 files) / docs-lint green. Backend suite passes with
zero kiro-path regression — the reader-loop interception for the auth callback is
inert on kiro, which never sends that request (a dedicated test pins the kiro
path to `None`).

## Blocked / follow-ups (not this PR)

- Protocol renames — context-usage %, compaction status, agent-switch echo, slash
  commands (Group A). Display-only degradation, does not block chat.
- **Model list not advertised** — even with auth working, KAS's `session/new`
  did not advertise a model list in testing, so the session runs KAS's default
  model. Belongs with the Group A `session_info_update` work; the
  "model selection unverified" note in `configuration.md` stays honest.
- Native subagent progress (`_native_subagent_sync`) rewrite — subagent cards do
  not render on KAS yet (Group B).

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (ACP runtime + auth callback) plus a
docs edit; no frontend/UI surface is touched.
