### PR TITLE
fix: stop filtering bundled hooks + add wrapper-revision staleness (#3362, #3373)

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -897,13 +897,35 @@ def _sel_hook_rejected(event: str, command: str, reason: str) -> None:
         logger.debug("SEL audit for rejected hook failed", exc_info=True)
 
 
+# Kiro Crew-internal hook keys that must NOT appear in generated kiro-cli agent  # brand-ok
+# specs (kiro-cli rejects unknown keys). Excluded when deriving _VALID_HOOK_EVENTS
+# from bundled defaults below, so an internal key never round-trips as an event.
+_INTERNAL_HOOK_KEYS = frozenset(
+    {"auto_approve_tools", "auto_deny_tools", "auto_replies", "transforms"}
+)
+
+# Valid kiro-cli hook event names — the UNION of the hardcoded baseline (kiro-cli's
+# known schema) and any event key present in bundled defaults. Used as the single
+# filter on both the generation path (bundled defaults -> generated spec) and the
+# repair/validation path (on-disk repair, user-input) — a new event added to
+# defaults.json is automatically accepted on both without a matching allowlist
+# update (#3362).
 _VALID_HOOK_EVENTS = frozenset(
     {"preToolUse", "postToolUse", "userPromptSubmit", "agentSpawn", "stop"}
+) | frozenset(
+    k
+    for k in (_load_json(_BUNDLED_CFG_DIR / "defaults.json") or {}).get("hooks", {})
+    if k not in _INTERNAL_HOOK_KEYS
 )
 
 
 def _kiro_hooks_only(hooks: dict) -> dict:
-    """Return only kiro-cli valid hook keys, stripping KiroCrew-internal ones."""
+    """Return only kiro-cli valid hook keys, stripping everything else.
+
+    Used on both the generation path (trusted bundled defaults) and the
+    repair/validation path (on-disk repair, user-supplied config) — screens
+    unknown keys that kiro-cli would reject.
+    """
     return {k: v for k, v in hooks.items() if k in _VALID_HOOK_EVENTS}
 
 
@@ -1497,6 +1519,9 @@ def build_agent_config() -> dict:
     bundled_hooks = bundled.get("hooks")
     if not bundled_hooks:
         raise RuntimeError("Cannot build agent config: hooks missing from bundled defaults")
+    # Strip Kiro Crew-internal keys (auto_approve_tools etc.) that kiro-cli  # brand-ok
+    # rejects. _VALID_HOOK_EVENTS already unions in every non-internal bundled
+    # event key, so this never drops a new event added to bundled defaults (#3362).
     config["hooks"] = _kiro_hooks_only(bundled_hooks)
 
     # Strip the retired deniedCommands/autoAllowReadonly injection so a config

--- a/src/kiro_crew/artifacts.py
+++ b/src/kiro_crew/artifacts.py
@@ -252,6 +252,9 @@ class ArtifactPublication:
     collab_mode: str = "mirror"
     last_pushed_sha256: str = ""  # concurrency guard for the next version push
     last_synced_kirocrew_version: int = 0
+    #: Wrapper envelope revision at the time of the last push — compared against
+    #: ``publish_sync.WRAPPER_REVISION`` to detect wrapper-only staleness (#3373).
+    wrapper_revision: int = 0
     # Maps str(kirocrew_version) -> remote_version_number.
     version_map: dict[str, int] = field(default_factory=dict)
     published_at: str = ""
@@ -3298,6 +3301,10 @@ class ArtifactStore:
             last_synced = int(raw_pub.get("last_synced_kirocrew_version", 0) or 0)
         except (TypeError, ValueError):
             last_synced = 0
+        try:
+            wrapper_rev = int(raw_pub.get("wrapper_revision", 0) or 0)
+        except (TypeError, ValueError):
+            wrapper_rev = 0
         return ArtifactPublication(
             artifact_id=str(artifact_id),
             view_url=str(raw_pub.get("view_url") or ""),
@@ -3308,6 +3315,7 @@ class ArtifactStore:
             collab_mode=("live" if raw_pub.get("collab_mode") == "live" else "mirror"),
             last_pushed_sha256=str(raw_pub.get("last_pushed_sha256") or ""),
             last_synced_kirocrew_version=last_synced,
+            wrapper_revision=wrapper_rev,
             version_map=version_map,
             published_at=str(raw_pub.get("published_at") or ""),
             published_by=str(raw_pub.get("published_by") or ""),

--- a/src/kiro_crew/publish_sync.py
+++ b/src/kiro_crew/publish_sync.py
@@ -92,6 +92,11 @@ _STANDALONE_THEME_VARS: dict[str, str] = {
     "--info": "#2563eb",
 }
 
+# Monotonically increasing revision counter for the wrap_widget_html envelope.
+# Bump this whenever the wrapper's CSP, scripts, or structural HTML changes so
+# that already-published widgets are detected as stale and re-pushed (#3373).
+WRAPPER_REVISION: int = 2
+
 # CSP for the published standalone widget document (wrap_widget_html).
 #
 # 'unsafe-eval' is NOT granted: the vendored Tailwind v4 runtime inlined by
@@ -467,6 +472,7 @@ async def publish(
         collab_mode=_collab_mode_for(provider),
         last_pushed_sha256=res.concurrency_token,
         last_synced_kirocrew_version=art.version,
+        wrapper_revision=WRAPPER_REVISION if art.kind == "widget" else 0,
         version_map={str(art.version): res.version_number},
         published_at=_now_iso(),
         published_by=res.owner,
@@ -527,7 +533,13 @@ async def push_version(art: Artifact, *, force: bool = False) -> None:
     # NOT dedupe on content — the 1:1 mapping is intentional, and a provider's
     # stored bytes (e.g. the provider's HTML auto-injection) won't match a
     # locally-computed hash anyway.
-    if not force and fresh.version == pub.last_synced_kirocrew_version:
+    # Also re-push when the wrapper envelope has changed (CSP, CDN scripts) even
+    # if the artifact content version hasn't moved (#3373).
+    wrapper_stale = (
+        fresh.kind == "widget"
+        and WRAPPER_REVISION > (pub.wrapper_revision or 0)
+    )
+    if not force and fresh.version == pub.last_synced_kirocrew_version and not wrapper_stale:
         return
 
     provider = _resolve_provider(pub.provider)
@@ -579,6 +591,7 @@ async def push_version(art: Artifact, *, force: bool = False) -> None:
             art.slug,
             last_pushed_sha256=res.concurrency_token or pub.last_pushed_sha256,
             last_synced_kirocrew_version=fresh.version,
+            wrapper_revision=WRAPPER_REVISION if fresh.kind == "widget" else pub.wrapper_revision,
             version_map=version_map,
             last_error="",
             **extra_pub,
@@ -913,10 +926,15 @@ async def upstream_status(slug: str) -> dict[str, object]:
         remote_hash = await _live_remote_hash(provider, ext_id)
         baseline = pub.last_synced_remote_hash
         upstream_ahead = bool(baseline) and bool(remote_hash) and remote_hash != baseline
+        local_ahead_live = (
+            art.version > pub.last_synced_kirocrew_version
+            # Wrapper envelope changed since last push — widget needs re-render (#3373).
+            or (art.kind == "widget" and WRAPPER_REVISION > (pub.wrapper_revision or 0))
+        )
         base.update(
             {
                 "upstream_ahead": bool(upstream_ahead),
-                "local_ahead": bool(art.version > pub.last_synced_kirocrew_version),
+                "local_ahead": bool(local_ahead_live),
                 "conflict": False,
                 "cloud_version": cur_v if isinstance(cur_v, int) else None,
             }
@@ -926,7 +944,11 @@ async def upstream_status(slug: str) -> dict[str, object]:
     local_ahead = (
         is_pub
         and art.publication is not None
-        and art.version > art.publication.last_synced_kirocrew_version
+        and (
+            art.version > art.publication.last_synced_kirocrew_version
+            # Wrapper envelope changed since last push — widget needs re-render (#3373).
+            or (art.kind == "widget" and WRAPPER_REVISION > (art.publication.wrapper_revision or 0))
+        )
     )
     base.update(
         {

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -1451,6 +1451,26 @@ class TestKiroHooksFiltering:
         result = _kiro_hooks_only(hooks)
         assert set(result.keys()) == _VALID_HOOK_EVENTS
 
+    def test_bundled_defaults_hook_keys_are_classified(self):
+        """Pins the exact set of hook keys in bundled defaults.json.
+
+        _VALID_HOOK_EVENTS derives from bundled keys minus _INTERNAL_HOOK_KEYS, so
+        a new key is auto-accepted as an event by construction -- silent if it was
+        actually meant to be internal (kiro-cli would then reject the whole spec at
+        runtime). This ratchet forces an explicit choice: adding a bundled hook key
+        means updating either this set (a real event) or _INTERNAL_HOOK_KEYS
+        (Kiro-Crew-internal), never neither (#3362 fail-loud guard)."""
+        from kiro_crew.agent import _BUNDLED_CFG_DIR, _load_json
+
+        bundled = _load_json(_BUNDLED_CFG_DIR / "defaults.json")
+        bundled_hook_keys = set((bundled or {}).get("hooks", {}).keys())
+        assert bundled_hook_keys == {"auto_approve_tools", "postToolUse"}, (
+            f"bundled defaults.json hooks keys changed to {bundled_hook_keys} -- "
+            "classify any new key as a real kiro-cli event (covered automatically "
+            "via _VALID_HOOK_EVENTS) or Kiro-Crew-internal (add to "
+            "_INTERNAL_HOOK_KEYS), then update this pinned set."
+        )
+
     def test_sanitize_agent_hooks_repairs_existing_file(self, tmp_path: Path):
         """_sanitize_agent_hooks removes invalid hook keys from existing configs."""
         from kiro_crew.agent import _hooks_sanitized_mtimes, _sanitize_agent_hooks

--- a/test/test_publish_sync.py
+++ b/test/test_publish_sync.py
@@ -331,6 +331,40 @@ async def test_push_version_skips_already_synced_version(store, fake_client):
 
 
 @pytest.mark.asyncio
+async def test_push_version_re_pushes_widget_on_wrapper_revision_bump(store, fake_client, monkeypatch):
+    """A widget with stale wrapper_revision is re-pushed even if content version matches (#3373)."""
+    store.create(name="Widget", content="<p>hi</p>", kind="widget", slug="w")
+    await publish_sync.publish("w")
+    art = store.get("w")
+    assert art.publication.last_synced_kirocrew_version == 1
+    assert art.publication.wrapper_revision == publish_sync.WRAPPER_REVISION
+
+    # Simulate a wrapper bump (CSP tightened) — revision goes up by 1.
+    monkeypatch.setattr(publish_sync, "WRAPPER_REVISION", publish_sync.WRAPPER_REVISION + 1)
+    fake_client.calls.clear()
+
+    # Same artifact version, but wrapper is stale → should re-push.
+    await publish_sync.push_version(store.get("w"))
+    assert len(fake_client.called("upload_version")) == 1
+    # After push, wrapper_revision is updated.
+    art = store.get("w")
+    assert art.publication.wrapper_revision == publish_sync.WRAPPER_REVISION
+
+
+@pytest.mark.asyncio
+async def test_push_version_skips_non_widget_on_wrapper_revision_bump(store, fake_client, monkeypatch):
+    """Non-widget artifacts ignore wrapper_revision — only widgets wrap with CSP (#3373)."""
+    store.create(name="Doc", content="hello", kind="text", slug="t")
+    await publish_sync.publish("t")
+    monkeypatch.setattr(publish_sync, "WRAPPER_REVISION", publish_sync.WRAPPER_REVISION + 1)
+    fake_client.calls.clear()
+
+    await publish_sync.push_version(store.get("t"))
+    # Text artifact → no wrapper staleness → skip.
+    assert fake_client.called("upload_version") == []
+
+
+@pytest.mark.asyncio
 async def test_push_version_conflict_sets_last_error(store, fake_client):
     store.create(name="Doc", content="v1", kind="text", slug="d")
     await publish_sync.publish("d")
@@ -1134,6 +1168,18 @@ async def test_upstream_status_reports_ahead(store, fake_client, tmp_path):
     assert status["cloud_version"] == 5
     assert status["source"] == "publication"
     assert status["live_dirty"] is False
+
+
+@pytest.mark.asyncio
+async def test_upstream_status_reports_local_ahead_on_wrapper_revision_bump(store, fake_client, tmp_path, monkeypatch):
+    """Widget with stale wrapper_revision shows local_ahead even if content hasn't changed (#3373)."""
+    art = store.create(name="W", content="<p>x</p>", kind="widget")
+    _track_publication(store, art.slug)
+    # Simulate wrapper bump.
+    monkeypatch.setattr(publish_sync, "WRAPPER_REVISION", publish_sync.WRAPPER_REVISION + 1)
+    fake_client.get_response = _remote_get(tmp_path, "ignored", version=1, sha="sha-v1")
+    status = await publish_sync.upstream_status(art.slug)
+    assert status["local_ahead"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two must-fix-before-stable issues resolved in one commit:

### #3362 — Generated agent specs silently drop hook events outside hardcoded v2 allowlist

**Root cause:** `build_agent_config()` and `_refresh_dynamic_fields()` used `_kiro_hooks_only()` — a hardcoded 5-event allowlist — to filter bundled `defaults.json` hooks. Any new hook event in bundled defaults was silently dropped until the allowlist was updated.

**Fix (shipped design):** Widen `_VALID_HOOK_EVENTS` itself into a computed UNION of the hardcoded baseline (kiro-cli's known event schema) and every non-internal key present in bundled `defaults.json` (`_INTERNAL_HOOK_KEYS` — `auto_approve_tools`, `auto_deny_tools`, `auto_replies`, `transforms` — is excluded from the union). `_kiro_hooks_only()` stays the single filter, now used identically on **both** the generation path (bundled defaults → generated spec) and the existing repair/validation path (on-disk repair, user-supplied config). A new event added to bundled defaults is now accepted on both paths automatically, with no separate allowlist update. A ratchet test (`test_bundled_defaults_hook_keys_are_classified`) pins the current bundled key set so any future key forces an explicit classification (real event vs. internal) instead of silently falling through either way.

*(An earlier iteration of this PR shipped a separate denylist function, `_strip_internal_hook_keys`, only on the generation path. Removed after review — the widened `_VALID_HOOK_EVENTS` already makes that function's output identical to `_kiro_hooks_only`'s, so keeping both was a redundant second filter.)*

### #3373 — Published widgets keep unsafe-eval CSP until their next push

**Root cause:** `push_version` returns early when `fresh.version == pub.last_synced_kirocrew_version`. A wrapper-only change (CSP tightening) never bumps the artifact version, so already-published widgets are never re-rendered.

**Fix:** Add a `WRAPPER_REVISION` counter (bump when the envelope changes). Store the revision at push time in `ArtifactPublication.wrapper_revision` (persisted via `_parse_publication`). On push, detect staleness and re-render. In `upstream_status`, report `local_ahead=True` for stale wrappers in both the mirror and live (CRDT) publication branches.

**Known limitation (accepted for this PR):** `WRAPPER_REVISION` is a hand-bumped counter — the next engineer who changes `wrap_widget_html`'s envelope and forgets to bump it silently reproduces the staleness bug. A hash-based self-detecting alternative was investigated but rejected for now: `wrap_widget_html` reads the vendored Tailwind runtime via `_tailwind_runtime_js()`, which is present in a built checkout and absent (degrades gracefully) in an unbuilt source checkout — a hash pin would flake exactly in dev/CI environments without a built frontend. Staleness detection is also lazy (only checked inside `push_version`/`upstream_status`, not swept proactively), so an idle published widget keeps the old CSP until acted on. Both are flagged for follow-up rather than blocking this fix.

## Changes

| File | What |
|------|------|
| `src/kiro_crew/agent.py` | Widen `_VALID_HOOK_EVENTS` to union in non-internal bundled-defaults keys; both generation-path call sites now use `_kiro_hooks_only` (same function as the repair path) |
| `src/kiro_crew/artifacts.py` | Add `wrapper_revision: int = 0` field to `ArtifactPublication`; persist it in `_parse_publication` |
| `src/kiro_crew/publish_sync.py` | Add `WRAPPER_REVISION` constant, staleness check in `push_version` guard, store revision on success, detect in both mirror AND live branches of `upstream_status` |
| `test/test_agent.py` | Ratchet test pinning bundled defaults' hook key classification |
| `test/test_publish_sync.py` | 3 new tests: widget re-push on revision bump, non-widget skips, upstream_status reports local_ahead |

## Testing

- All changed files compile clean (`py_compile`)
- 4 targeted tests added covering the new behavior
- Full CI green (58/58 checks, GPT/Opus/Design reviews all passed with only advisory findings, all answered in PR comments)

<!-- no-visual-delta -->
**Why no screenshot:** Pure backend logic change — no UI components affected.

Closes #3362
Closes #3373
