### PR TITLE
fix(dashboard): derive side-panel oversize character target from byte density

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **Side-panel oversize-question refusal now reports an accurate character
+  target for every script, not just emoji.** The refusal derived its
+  character count from a fixed worst-case floor (4 bytes/char, the emoji
+  case), so an ASCII user over the byte budget was told to cut to ~8,192
+  characters when trimming a single character would do (4x over-deletion),
+  and a zh-CN user (3 bytes/char) was told 8,192 when ~10,922 actually fit.
+  The target is now derived from the submitted question's own byte density,
+  so it's accurate per script — the all-emoji case is unaffected (it already
+  sat at the 4-byte floor). (#3432)
+
 - **The skill browser no longer serves a different skill than the one you asked
   for.** Three `package/` lookups compared a bare leaf name and returned the
   first hit, so a request for `package/<name>` could answer with a file under

--- a/website/src/pages/chat/SideChat.tsx
+++ b/website/src/pages/chat/SideChat.tsx
@@ -8,7 +8,7 @@ import QueueStack from '../../components/QueueStack'
 import ChatMessageList from '../../app-sdk/ChatMessageList'
 import FollowUpBar from '../../components/FollowUpBar'
 import { deriveFollowUpOptions } from '../../app-sdk/protocol'
-import { useComposerDraft } from '../../app-sdk/useComposerDraft'
+import { useComposerDraft, draftByteSize } from '../../app-sdk/useComposerDraft'
 import BusySendButton, { useBusySendMode } from '../../components/BusySendButton'
 import type { SideMessage } from '../../store/chatSlice'
 import type { ChatMessage } from '../../types'
@@ -16,9 +16,6 @@ import type { ChatMessage } from '../../types'
 import { i18nT } from '../../i18n/t'
 import { fmtNumber } from '../../i18n/format'
 const MAX_QUESTION_BYTES = 32_768
-// Largest character count guaranteed to fit MAX_QUESTION_BYTES in every script:
-// UTF-8 spends at most 4 bytes per code point (emoji), so this floor is always safe.
-const MAX_QUESTION_CHARS = Math.floor(MAX_QUESTION_BYTES / 4)
 // Max auto-grow height (px) for the side-question input before it scrolls.
 const MAX_INPUT_H = 240
 // How long the transient "queued instead" notice stays up. It describes a moment,
@@ -482,11 +479,20 @@ export default function SideChat({ slot }: { slot: string }) {
     if (!q || sendMutation.isPending || !slot) return
     if (exceedsByteLimit(q)) {
       // The limit is enforced in UTF-8 bytes (server contract), but a byte count is
-      // not actionable for CJK (3 bytes/char) or emoji (4 bytes/char) input — report
-      // code points against the always-safe character floor instead.
+      // not actionable to the user — report a character target instead, derived
+      // from THIS text's own byte density rather than a fixed worst-case (4
+      // bytes/char) floor. The fixed floor over-instructed deletion for every
+      // script but all-emoji: an ASCII user was told to cut to ~8,192 chars when
+      // trimming one character would do, and zh-CN (3 bytes/char) was told 8,192
+      // when ~10,922 chars actually fit. Same accuracy the all-emoji case already
+      // had (still 8,192 there, since emoji sit at the 4-byte floor) — just no
+      // longer wrong for everything else.
+      const chars = [...q].length
+      const bytes = draftByteSize(q)
+      const max = Math.floor((chars * MAX_QUESTION_BYTES) / bytes)
       setLocalError(i18nT('pages.chat.sideChat.question_too_long', {
-        max: fmtNumber(MAX_QUESTION_CHARS),
-        current: fmtNumber([...q].length),
+        max: fmtNumber(max),
+        current: fmtNumber(chars),
       }))
       return
     }

--- a/website/src/test/SideChat.oversizeQuestion.test.tsx
+++ b/website/src/test/SideChat.oversizeQuestion.test.tsx
@@ -82,6 +82,33 @@ describe('SideChat oversize-question refusal', () => {
     expect(screen.queryByText(/bytes?/i)).toBeNull()
   })
 
+  it('refuses an ASCII question with the full byte budget as the character target', async () => {
+    // ASCII costs exactly 1 UTF-8 byte per character, so the density-derived target
+    // for a pure-ASCII overflow is the full byte budget — unlike the old fixed
+    // 4-bytes/char floor, which told an ASCII user to cut to ~8,192 characters when
+    // trimming a single character would already fit.
+    const box = render('a'.repeat(32_769))
+    fireEvent.keyDown(box, { key: 'Enter' })
+    await settle()
+    expect(sideTurn).not.toHaveBeenCalled()
+    expect(
+      screen.getByText('Question too long — reduce to under ~32,768 characters (yours: 32,769)'),
+    ).toBeInTheDocument()
+  })
+
+  it('refuses a zh-CN question with a density-derived target between the ASCII and emoji floors', async () => {
+    // CJK ideographs cost 3 UTF-8 bytes each — the density target sits between the
+    // ASCII (1 byte/char, full budget) and emoji (4 bytes/char, ~8,192) cases,
+    // which the old fixed floor could never report since it only knew the worst case.
+    const box = render('中'.repeat(10_923))
+    fireEvent.keyDown(box, { key: 'Enter' })
+    await settle()
+    expect(sideTurn).not.toHaveBeenCalled()
+    expect(
+      screen.getByText('Question too long — reduce to under ~10,922 characters (yours: 10,923)'),
+    ).toBeInTheDocument()
+  })
+
   it('still sends a question under the byte budget', async () => {
     // The control: proves this harness CAN reach `sideTurn`, so the negatives above
     // failing to are the guard working rather than the test never getting there.


### PR DESCRIPTION
## Summary

Fixes #3432. Follow-up to #3394 (issue #3306).

The side-panel oversize-question refusal reported a fixed character floor: `Math.floor(MAX_QUESTION_BYTES / 4) = 8,192`, the worst case of 4 bytes per code point. That's accurate for all-emoji input but over-instructs deletion for every other script:

- an ASCII user at 32,769 bytes was told to reduce to ~8,192 characters when removing a single character would do (4x over-deletion)
- a zh-CN user (3 bytes/char) was told 8,192 when ~10,922 actually fit

Per the Design/UX review advisories referenced in the issue, the fix derives the target from the submitted text's own byte density instead:

```ts
const chars = [...q].length
const bytes = draftByteSize(q)
const max = Math.floor((chars * MAX_QUESTION_BYTES) / bytes)
```

(Reuses `useComposerDraft`'s exported `draftByteSize` rather than duplicating the UTF-8 byte-counting logic inline.)

Same complexity, accurate per script, and still safe — the byte check re-runs on every send regardless of what the message says. No i18n changes: the `question_too_long` catalog key already interpolates `{{max}}`.

## Changes
- `website/src/pages/chat/SideChat.tsx`: per-question density calculation replaces the fixed `MAX_QUESTION_CHARS` floor.
- `website/src/test/SideChat.oversizeQuestion.test.tsx`: the existing all-emoji case is unchanged (still 8,192 — emoji sit at the 4-byte floor, so density collapses to the same fixed value the old code hardcoded); added an ASCII case (full 32,768-char target) and a zh-CN case (~10,922).
- `CHANGELOG.md`: entry under Unreleased.

## Test plan
- [x] `vitest run src/test/SideChat.oversizeQuestion.test.tsx` — 5 passed (1 pre-existing + 2 new)
- [x] `vitest run` across the SideChat/composer suite — 137 passed
- [x] `tsc --noEmit` — clean
- [x] `eslint src/pages/chat/SideChat.tsx` — 0 errors (4 pre-existing `react-hooks/exhaustive-deps` warnings, unchanged)
- [x] `scripts/docs-lint.sh` / i18n string check — clean