### PR TITLE
ci(security): add supply-chain attack detection Semgrep rules

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -267,6 +267,7 @@ jobs:
             --config p/security-audit \
             --config p/secrets \
             --config p/owasp-top-ten \
+            --config .semgrep/ \
             --baseline-commit "$SEMGREP_BASELINE_REF" \
             --error
 

--- a/.semgrep/supply-chain.yaml
+++ b/.semgrep/supply-chain.yaml
@@ -1,0 +1,118 @@
+rules:
+  # ─── Supply Chain: Download + Execute ──────────────────────────────
+  # Inspired by COE-358507 / AWS-2025-015: attacker modified build
+  # process to download external payload and execute it at startup.
+
+  - id: kirocrew.download-and-exec-subprocess
+    patterns:
+      - pattern-either:
+          - pattern: |
+              subprocess.run(["curl", ...], ...)
+          - pattern: |
+              subprocess.run(["wget", ...], ...)
+          - pattern: |
+              subprocess.Popen(["curl", ...], ...)
+          - pattern: |
+              subprocess.Popen(["wget", ...], ...)
+    paths:
+      exclude:
+        - test/*
+        - src/kiro_crew/_vendor/*
+    message: >
+      Subprocess call downloads from an external URL (curl/wget).
+      Supply-chain risk: build-time download of external payload can
+      introduce malicious code. Pin the dependency or vendor it instead.
+    severity: WARNING
+    languages: [python]
+    metadata:
+      category: security
+      subcategory: supply-chain
+      cwe: "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      references:
+        - https://aws.amazon.com/security/security-bulletins/AWS-2025-015/
+
+  - id: kirocrew.download-and-exec-urlretrieve
+    patterns:
+      - pattern-either:
+          - pattern: urllib.request.urlretrieve($URL, ...)
+          - pattern: urlretrieve($URL, ...)
+    paths:
+      exclude:
+        - test/*
+        - src/kiro_crew/_vendor/*
+    message: >
+      urlretrieve downloads a file from an external URL at runtime.
+      If this runs during build or startup, it is a supply-chain risk.
+      Prefer vendored dependencies with integrity checks.
+    severity: WARNING
+    languages: [python]
+    metadata:
+      category: security
+      subcategory: supply-chain
+      cwe: "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+
+  - id: kirocrew.download-then-exec
+    patterns:
+      - pattern: |
+          $RESP = requests.get($URL, ...)
+          ...
+          exec($RESP. ...)
+      - pattern-not-inside: |
+          # nosemgrep: kirocrew.download-then-exec
+          ...
+    paths:
+      exclude:
+        - test/*
+    message: >
+      HTTP response content passed directly to exec(). This is the
+      canonical supply-chain attack pattern (download + execute).
+    severity: ERROR
+    languages: [python]
+    metadata:
+      category: security
+      subcategory: supply-chain
+      cwe: "CWE-94: Code Injection"
+
+  - id: kirocrew.download-then-subprocess
+    patterns:
+      - pattern: |
+          $PATH = ...
+          ...
+          subprocess.run([$PATH, ...], ...)
+      - metavariable-regex:
+          metavariable: $PATH
+          regex: ".*download.*|.*tmp.*|.*temp.*"
+    paths:
+      exclude:
+        - test/*
+        - src/kiro_crew/_vendor/*
+    message: >
+      Downloaded file path passed to subprocess execution. Ensure
+      the file has verified integrity (SHA-256 check) before execution.
+    severity: WARNING
+    languages: [python]
+    metadata:
+      category: security
+      subcategory: supply-chain
+      cwe: "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+
+  # ─── Frontend: script injection via external URL ───────────────────
+
+  - id: kirocrew.frontend-external-script-inject
+    pattern: |
+      $EL.src = $URL
+    paths:
+      include:
+        - website/src/**
+      exclude:
+        - website/src/**/*.test.*
+    message: >
+      Dynamic script src assignment. If URL is externally controlled,
+      this enables supply-chain code injection (similar to the
+      aws-toolkit-vscode build process modification attack).
+    severity: WARNING
+    languages: [typescript, javascript]
+    metadata:
+      category: security
+      subcategory: supply-chain
+      cwe: "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"


### PR DESCRIPTION
## Summary

Add supply-chain attack detection rules to Semgrep, inspired by [COE-358507](https://www.coe.a2z.com/coe/358507/content) / [AWS-2025-015](https://aws.amazon.com/security/security-bulletins/AWS-2025-015/) (Amazon Q VSCode extension compromise).

## Motivation

The COE attack pattern was:
1. Attacker obtains admin token via CI memory dump
2. Pushes malicious commit directly to main
3. Commit modifies build process to **download external payload and execute it at startup**

Our existing Semgrep rules (`p/security-audit`, `p/owasp-top-ten`) don't specifically target the download+execute pattern that is the hallmark of supply-chain attacks.

## Rules Added (`.semgrep/supply-chain.yaml`)

| Rule | Severity | Pattern |
|------|----------|---------|
| `download-and-exec-subprocess` | WARNING | `subprocess.run(["curl"/"wget", ...])` |
| `download-and-exec-urlretrieve` | WARNING | `urllib.request.urlretrieve(url, ...)` |
| `download-then-exec` | ERROR | HTTP response → `exec()` |
| `download-then-subprocess` | WARNING | Downloaded file path → `subprocess.run()` |
| `frontend-external-script-inject` | WARNING | Dynamic `script.src = url` in frontend |

## Why this is different from the previous attempt

PR #3097's custom rules were correctly blocked by Design Review because they referenced nonexistent functions (`verify_internal_secret`) and wrong paths (`src/kiro_crew/handlers/*`). These rules:
- Target **unambiguous** patterns (curl/wget/urlretrieve + exec/subprocess)
- Don't reference project-specific functions or paths
- Have inherently low false-positive risk (KiroCrew vendors dependencies, so legitimate download+execute in production code is unexpected)
- Exclude test/ and _vendor/ directories

## Integration

Also adds `--config .semgrep/` to the SAST job in `code-review.yml` so custom rules are picked up automatically.

## Risk

Low — scan is diff-only (`--baseline-commit`), so only new code triggering these patterns will be flagged. Existing code is untouched.
