### PR TITLE
test: normalize mocked createObjectURL to a well-formed blob: URI

### DIFF
--- a/website/src/test/ArtifactDetailPage.companionChat.test.tsx
+++ b/website/src/test/ArtifactDetailPage.companionChat.test.tsx
@@ -94,8 +94,11 @@ describe('ArtifactDetailPage companion chat', () => {
     vi.clearAllMocks()
     sessionStorage.clear()
     if (!URL.createObjectURL) {
+      // Well-formed blob: URI, not a bare 'blob:test' literal — see the note in
+      // WidgetFrame.test.tsx's beforeEach for why a malformed mock value here
+      // risks a deferred ECONNREFUSED crashing an unrelated shard.
       // @ts-expect-error stub
-      URL.createObjectURL = vi.fn().mockReturnValue('blob:test')
+      URL.createObjectURL = vi.fn().mockReturnValue('blob:http://localhost:6776/test')
       // @ts-expect-error stub
       URL.revokeObjectURL = vi.fn()
     }

--- a/website/src/test/ArtifactDetailPage.stickyHeader.test.tsx
+++ b/website/src/test/ArtifactDetailPage.stickyHeader.test.tsx
@@ -39,7 +39,10 @@ function renderRoute() {
 describe('ArtifactDetailPage — sticky header', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    // Well-formed blob: URI, not a bare 'blob:test' literal — see the note in
+    // WidgetFrame.test.tsx's beforeEach for why a malformed mock value here
+    // risks a deferred ECONNREFUSED crashing an unrelated shard.
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost:6776/test')
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     vi.mocked(api).artifactEvents = vi.fn().mockResolvedValue({ slug: 'cr-queue', events: [] })
     vi.mocked(api).artifactComments = vi.fn().mockResolvedValue({ comments: [] })

--- a/website/src/test/ArtifactDetailPage.test.tsx
+++ b/website/src/test/ArtifactDetailPage.test.tsx
@@ -66,7 +66,10 @@ describe('ArtifactDetailPage', () => {
     vi.clearAllMocks()
     // Spy rather than assign: only a spy lands in the registry that
     // vi.restoreAllMocks() can undo. The env provides both natively.
-    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    // Well-formed blob: URI, not a bare 'blob:test' literal — see the note in
+    // WidgetFrame.test.tsx's beforeEach for why a malformed mock value here
+    // risks a deferred ECONNREFUSED crashing an unrelated shard.
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost:6776/test')
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     // Default events response so the events query never throws "undefined".
     // Individual tests can override this with .mockResolvedValueOnce when

--- a/website/src/test/ArtifactDetailPageCoverage.test.tsx
+++ b/website/src/test/ArtifactDetailPageCoverage.test.tsx
@@ -177,8 +177,11 @@ describe('ArtifactDetailPage — mutation paths', () => {
     localStorage.clear()
     sessionStorage.clear()
     if (!URL.createObjectURL) {
+      // Well-formed blob: URI, not a bare 'blob:test' literal — see the note in
+      // WidgetFrame.test.tsx's beforeEach for why a malformed mock value here
+      // risks a deferred ECONNREFUSED crashing an unrelated shard.
       // @ts-expect-error jsdom lacks blob URLs
-      URL.createObjectURL = vi.fn().mockReturnValue('blob:test')
+      URL.createObjectURL = vi.fn().mockReturnValue('blob:http://localhost:6776/test')
       // @ts-expect-error jsdom lacks blob URLs
       URL.revokeObjectURL = vi.fn()
     }

--- a/website/src/test/RemoteArtifactDetailPageCoverage.test.tsx
+++ b/website/src/test/RemoteArtifactDetailPageCoverage.test.tsx
@@ -165,8 +165,19 @@ describe('RemoteArtifactDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // happy-dom has no object-URL support, which the HTML render path needs.
+    // Well-formed blob: URI, not a bare 'blob:remote-test' literal: this
+    // component renders a real <iframe src={blobUrl}>, and disableIframePageLoading's
+    // synchronous refusal doesn't end the story — happy-dom's AsyncTaskManager
+    // can retry the SAME request later, off this test's call stack. A malformed
+    // value survives that retry looking like a same-origin PATH once the scheme
+    // is gone, missing both the msw catch-all's blob:/data: fast path and its
+    // DOM_DRIVEN_LOAD_RE allowlist, landing on the 501 fallback — which surfaces
+    // as a deferred ECONNREFUSED during fork-worker teardown and can crash the
+    // whole shard. Anchoring to the real test origin keeps the blob: scheme
+    // intact through the retry either way. See WidgetFrame.test.tsx (the
+    // original report) for the full mechanism.
     // @ts-expect-error assigning a test stub onto the URL global
-    globalThis.URL.createObjectURL = vi.fn().mockReturnValue('blob:remote-test')
+    globalThis.URL.createObjectURL = vi.fn().mockReturnValue('blob:http://localhost:6776/remote-test')
     // @ts-expect-error assigning a test stub onto the URL global
     globalThis.URL.revokeObjectURL = vi.fn()
     // clearAllMocks resets call history only, so re-establish the defaults every
@@ -264,7 +275,7 @@ describe('RemoteArtifactDetailPage', () => {
       )
       renderPage()
       const frame = await screen.findByTitle(`Remote artifact: ${EXT_ID}`)
-      expect(frame).toHaveAttribute('src', 'blob:remote-test')
+      expect(frame).toHaveAttribute('src', 'blob:http://localhost:6776/remote-test')
       expect(frame).toHaveAttribute('sandbox', expect.stringContaining('allow-scripts'))
       expect(URL.createObjectURL).toHaveBeenCalled()
     })

--- a/website/src/test/WidgetFrame.test.tsx
+++ b/website/src/test/WidgetFrame.test.tsx
@@ -61,7 +61,17 @@ beforeEach(() => {
       }
     }
   } as typeof Blob
-  vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test-widget')
+  // Well-formed blob: URI (scheme + real origin + opaque path), not a bare
+  // 'blob:test-widget' literal. happy-dom's disableIframePageLoading refuses
+  // the iframe navigation synchronously, but its AsyncTaskManager can retry
+  // the SAME request later, off this test's call stack. A malformed value
+  // survives that retry looking like a same-origin PATH once the scheme is
+  // gone, missing the msw catch-all's blob:/data: fast path and its
+  // DOM_DRIVEN_LOAD_RE allowlist alike — landing on the 501 fallback, which
+  // surfaces as a deferred ECONNREFUSED during fork-worker teardown and can
+  // crash the whole shard (not just this test). Anchoring to the real test
+  // origin keeps the blob: scheme intact through the retry either way.
+  vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost:6776/test-widget')
   vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
 
   // Jest-dom inherits the real CSSOM, so spy on getComputedStyle to inject a
@@ -285,7 +295,9 @@ describe('WidgetFrame openInNewTab', () => {
       if (typeof parts[0] === 'string') wrapper = parts[0] as string
       return new realBlob(parts, opts)
     })
-    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    // Well-formed blob: URI — see the beforeEach mock above for why a bare
+    // 'blob:test' literal risks a deferred ECONNREFUSED crashing the shard.
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost:6776/test')
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     vi.spyOn(window, 'open').mockReturnValue(null)
 
@@ -304,7 +316,9 @@ describe('WidgetFrame openInNewTab', () => {
       mimeType = opts?.type ?? ''
       return new realBlob(args[0] as BlobPart[], opts)
     })
-    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    // Well-formed blob: URI — see the beforeEach mock above for why a bare
+    // 'blob:test' literal risks a deferred ECONNREFUSED crashing the shard.
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost:6776/test')
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     vi.spyOn(window, 'open').mockReturnValue(null)
 


### PR DESCRIPTION
## Summary

Fixes #3359.

`WidgetFrame.test.tsx` mocks `URL.createObjectURL` to return the literal string `'blob:test-widget'` — not a well-formed `blob:` URI (normally `blob:<origin>/<uuid>`). `WidgetFrame` renders a real `<iframe src={blobUrl}>`; `vite.config.ts` sets `happyDOM.settings.disableIframePageLoading: true`, so happy-dom refuses the navigation synchronously with a loud-but-harmless `NotSupportedError` — except that refusal isn't the end of the story. happy-dom's `AsyncTaskManager` still tracks the underlying fetch task and can retry/resolve it later, off the DOM-connect call stack, well after the test that triggered it has finished. With no matching mock, that stray retry falls through to msw's catch-all fallback's 501, which surfaces as a genuine `ECONNREFUSED` socket dial seconds later — landing during vitest's fork-worker teardown, where it can crash the whole worker (failing every test in that shard, not just this one).

Per the issue, this was confirmed empirically across PR #3312 and its predecessor #3043: every CI run that places `WidgetFrame.test.tsx` in the same vitest shard as `widgetSrcdoc.test.ts` and its neighbors reproducibly failed that shard with the ECONNREFUSED signature, while `WidgetFrame.test.tsx` in isolation always passed.

## Fix

Normalizes the mocked `createObjectURL` return value to a well-formed `blob:` URI anchored to the real test origin — `blob:http://localhost:6776/<id>`, matching `TEST_ORIGIN` in `integration/mocks/server.ts` and `environmentOptions.happyDOM.url` in `vite.config.ts` — in `WidgetFrame.test.tsx` and every sibling file using the same malformed-literal pattern:

- `WidgetFrame.test.tsx` and `RemoteArtifactDetailPageCoverage.test.tsx` (updated its dependent `toHaveAttribute('src', ...)` assertion too) — both components render a real `<iframe src={blobUrl}>`, so both share the actual crash risk.
- `ArtifactDetailPage.stickyHeader.test.tsx`, `ArtifactDetailPage.companionChat.test.tsx`, `ArtifactDetailPageCoverage.test.tsx`, `ArtifactDetailPage.test.tsx` — `ArtifactDetailPage.tsx` only uses `createObjectURL` for a download `<a href>` (never navigated by happy-dom), so these are lower-risk, but normalized too per the issue's "ideally the sibling files using the same pattern" — a malformed `blob:` URL isn't a realistic mock regardless of current risk, and it's a zero-cost change.

## Test plan
- [x] `vitest run` across all 6 changed files — 229 passed (the `NotSupportedError` DOMException console noise is expected/harmless per the issue — happy-dom's synchronous refusal, not the deferred retry)
- [x] `tsc --noEmit` — clean
- [x] `eslint` on the 6 changed files — 0 errors (3 pre-existing, unrelated `no-explicit-any` warnings in `ArtifactDetailPage.test.tsx`)
- [ ] I did not reproduce the original ECONNREFUSED crash locally — it's a CI-shard-specific timing race the issue itself notes only reproduces via a specific multi-file shard co-location under real CI (not `WidgetFrame.test.tsx` in isolation), which isn't practical to force deterministically outside that environment. I applied the issue's exact suggested fix, which is based on a detailed root-cause analysis empirically confirmed across two real merged-repo PRs (#3312, #3043). Flagging this rather than claiming a local repro I didn't do.