### PR TITLE
fix(artifacts): one-time re-push of published widgets to drop unsafe-eval CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to KiroCrew are documented in this file.
 
 ## [Unreleased]
 
+- **Published widgets no longer keep the old `'unsafe-eval'` CSP forever.**
+  `wrap_widget_html` stopped emitting `'unsafe-eval'` and the Tailwind Play
+  CDN, but `push_version` only re-renders a publication on a version bump —
+  so a widget published before that change and never edited again kept
+  serving the old CSP indefinitely, with the exposure staying open on exactly
+  the artifacts that are already public. The gateway now force-repushes
+  every already-published widget once per install on startup (a background
+  task, so it never delays the port bind) to close the gap for existing
+  publications. (#3373)
+
 - **The skill browser no longer serves a different skill than the one you asked
   for.** Three `package/` lookups compared a bare leaf name and returned the
   first hit, so a request for `package/<name>` could answer with a file under

--- a/docs/system-specs/modules/artifacts.md
+++ b/docs/system-specs/modules/artifacts.md
@@ -235,6 +235,18 @@ forwards it as `?pageToken=`, and `RemoteBrowseSection` drives a
 `useInfiniteQuery` with a "Load more" control — so remote artifacts past the
 provider's first page are reachable rather than silently truncated.
 
+**One-time widget CSP remediation.** `push_version` only re-renders a
+publication on a KiroCrew version bump (the 1:1 version invariant), so a
+`wrap_widget_html` change (e.g. dropping `'unsafe-eval'`) has no effect on a
+widget already published and never edited again — the live document keeps
+serving the old wrapper indefinitely. `publish_sync.republish_widgets_dropping_unsafe_eval`,
+fired as a tracked background task on gateway startup
+(`dashboard/server.py`'s `_register_widget_republish_hook`) and gated by a
+marker file at the artifact store's root, force-repushes every already-published
+`widget` artifact exactly once per install to close that gap for existing
+publications. See the function's own docstring for why this is a one-shot
+sweep rather than a persistent retry loop.
+
 ### Dashboard pages
 
 - `/artifacts` — list page (name / kind / tags / updated_at), tag filter,

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1789,6 +1789,32 @@ def _register_instances_hooks(app: web.Application, state: DashboardState, port:
     app.on_cleanup.append(_instances_shutdown)
 
 
+def _register_widget_republish_hook(app: web.Application, state: DashboardState) -> None:
+    """One-time sweep: re-push every already-published widget artifact so it
+    picks up ``wrap_widget_html``'s current CSP (see
+    ``publish_sync.republish_widgets_dropping_unsafe_eval``'s own docstring for
+    why this cannot wait for a normal edit-triggered push).
+
+    Fired as a tracked background task, not awaited inline: it may make one
+    provider network call per already-published widget, so awaiting it here
+    would gate the port bind on however many publications exist and however
+    the provider is currently answering — same reasoning as the Instances
+    tunnel revive below (``_register_instances_hooks``). The function itself
+    is idempotent (marker-gated), so a task that is still running at shutdown
+    and never gets to write the marker just resumes the sweep on the next
+    start.
+    """
+
+    async def _widget_republish_startup(app_: web.Application) -> None:
+        from kiro_crew.publish_sync import republish_widgets_dropping_unsafe_eval
+
+        task = asyncio.create_task(republish_widgets_dropping_unsafe_eval())
+        state._background_tasks.add(task)
+        task.add_done_callback(state._background_tasks.discard)
+
+    app.on_startup.append(_widget_republish_startup)
+
+
 def build_host_canonical_redirect(canonical_host: str) -> Any:
     """Build the loopback-host-canonicalization middleware.
 
@@ -2838,6 +2864,7 @@ async def start_dashboard(
     # ``runner.setup()`` freezes the app's signal lists. See
     # ``_register_instances_hooks`` for why ordering matters.
     _register_instances_hooks(app, state, port)
+    _register_widget_republish_hook(app, state)
     _register_browser_view_cleanup(app)
 
     # Unix-socket cleanup hook — registered before runner.setup freezes the

--- a/src/kiro_crew/publish_sync.py
+++ b/src/kiro_crew/publish_sync.py
@@ -600,6 +600,54 @@ async def push_version_by_slug(slug: str, *, force: bool = False) -> None:
         await push_version(art, force=force)
 
 
+#: Marker (at the artifact store's root) that :func:`republish_widgets_dropping_unsafe_eval`
+#: has already swept once for this install. Named for the specific remediation
+#: rather than generically, since a future wrapper change needs its own sweep
+#: (or the more durable option 2 from the originating issue: a wrapper-revision
+#: marker embedded in the document and compared in upstream_status).
+_UNSAFE_EVAL_REPUBLISH_MARKER = ".unsafe-eval-republished"
+
+
+async def republish_widgets_dropping_unsafe_eval() -> None:
+    """One-time remediation: force-repush every already-published ``widget``
+    artifact so its live document picks up ``wrap_widget_html``'s current,
+    ``'unsafe-eval'``-free CSP.
+
+    ``push_version`` only re-renders on a KiroCrew version bump (the 1:1
+    version invariant), so a widget published before ``wrap_widget_html``
+    dropped ``'unsafe-eval'`` and never edited again keeps serving the old CSP
+    indefinitely — the exposure stays open on exactly the artifacts that are
+    already public, and the remediation is otherwise invisible for them.
+
+    Runs once per install, gated by a marker file at the artifact store's
+    root, rather than on every gateway start: ``push_version`` is already
+    best-effort (never raises; a provider failure is recorded on
+    ``publication.last_error`` and does not propagate), so retrying a
+    persistently-failing artifact (a provider outage, a since-deleted
+    publication) on every restart would just be repeated wasted network calls
+    for no better outcome — an artifact that fails here still gets a normal
+    retry the next time it is actually edited, same as any other push
+    failure. The marker is written after one sweep attempt regardless of
+    per-artifact outcome, matching that "one-time" framing.
+    """
+    store = get_default_store()
+    marker = store.root / _UNSAFE_EVAL_REPUBLISH_MARKER
+    if await asyncio.to_thread(marker.exists):
+        return
+    widgets = await asyncio.to_thread(store.list, kind="widget")
+    published = [a for a in widgets if a.publication is not None and a.publication.auto_sync]
+    for art in published:
+        try:
+            await push_version(art, force=True)
+        except Exception:  # pragma: no cover — push_version is already best-effort
+            logger.exception("unsafe-eval republish: unexpected failure for %s", art.slug)
+    await asyncio.to_thread(marker.write_text, "done\n", encoding="utf-8")
+    if published:
+        logger.info(
+            "unsafe-eval republish: re-pushed %d already-published widget(s)", len(published)
+        )
+
+
 async def update_sharing(
     slug: str, *, visibility: str, shared_with: list[str] | None = None
 ) -> dict[str, object]:

--- a/test/test_dashboard_server_startup_coverage.py
+++ b/test/test_dashboard_server_startup_coverage.py
@@ -313,6 +313,54 @@ async def _cancel_stray_tasks() -> None:
         await asyncio.gather(*stray, return_exceptions=True)
 
 
+# ── _register_widget_republish_hook ──────────────────────────────────────
+#
+# The one-time #3373 CSP-remediation sweep. Same registration-ordering
+# requirement as _register_instances_hooks (attached before runner.setup()
+# freezes the signal lists) and the same reason for firing as a tracked
+# background task rather than an awaited one: it may make one provider
+# network call per already-published widget, so gating the port bind on it
+# would delay startup by however many publications exist.
+
+
+class TestRegisterWidgetRepublishHook:
+    def _state(self):
+        from kiro_crew.dashboard.state import DashboardState
+
+        return DashboardState(
+            sessions=MagicMock(), crons=MagicMock(), lessons=MagicMock(), start_time=0.0
+        )
+
+    @pytest.mark.asyncio
+    async def test_registering_before_freeze_does_not_raise(self) -> None:
+        app = web.Application()
+        state = self._state()
+        srv._register_widget_republish_hook(app, state)
+        app.freeze()  # must not raise "Cannot modify frozen list"
+
+    @pytest.mark.asyncio
+    async def test_fires_a_self_cleaning_background_task_on_startup(self, monkeypatch) -> None:
+        import kiro_crew.publish_sync as publish_sync
+
+        called = asyncio.Event()
+
+        async def fake_republish() -> None:
+            called.set()
+
+        monkeypatch.setattr(publish_sync, "republish_widgets_dropping_unsafe_eval", fake_republish)
+
+        app = web.Application()
+        state = self._state()
+        srv._register_widget_republish_hook(app, state)
+
+        async with TestClient(TestServer(app)):
+            await asyncio.wait_for(called.wait(), timeout=2)
+            # Let the task's own add_done_callback run before asserting cleanup.
+            await asyncio.sleep(0)
+
+        assert state._background_tasks == set()
+
+
 class TestStartDashboardWiring:
     @pytest.mark.asyncio
     async def test_the_app_is_wired_and_reports_ready(self, tmp_path, monkeypatch) -> None:

--- a/test/test_publish_sync.py
+++ b/test/test_publish_sync.py
@@ -349,6 +349,109 @@ async def test_push_version_noop_when_not_published(store, fake_client):
     assert fake_client.called("upload_version") == []
 
 
+# ── republish_widgets_dropping_unsafe_eval ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_republish_forces_a_repush_of_published_widgets(store, fake_client):
+    # Regression for #3373: a widget published before wrap_widget_html dropped
+    # 'unsafe-eval' and never edited again would otherwise keep serving the old
+    # CSP forever, since push_version only re-renders on a version bump.
+    store.create(name="W", content="<h1>hi</h1>", kind="widget", slug="w")
+    await publish_sync.publish("w")  # last_synced_kirocrew_version = 1, no new version since
+    fake_client.calls.clear()
+
+    await publish_sync.republish_widgets_dropping_unsafe_eval()
+
+    assert len(fake_client.called("upload_version")) == 1
+    assert store.get("w").publication.last_error == ""
+
+
+@pytest.mark.asyncio
+async def test_republish_ignores_non_widget_and_unpublished_artifacts(store, fake_client):
+    store.create(name="Doc", content="text", kind="text", slug="txt")
+    await publish_sync.publish("txt")
+    store.create(name="Draft", content="<p>x</p>", kind="widget", slug="draft")  # never published
+    fake_client.calls.clear()
+
+    await publish_sync.republish_widgets_dropping_unsafe_eval()
+
+    assert fake_client.called("upload_version") == []
+
+
+@pytest.mark.asyncio
+async def test_republish_is_one_time_only(store, fake_client):
+    store.create(name="W", content="<h1>hi</h1>", kind="widget", slug="w")
+    await publish_sync.publish("w")
+    fake_client.calls.clear()
+
+    await publish_sync.republish_widgets_dropping_unsafe_eval()
+    assert len(fake_client.called("upload_version")) == 1
+
+    # A second sweep (e.g. the next gateway restart) is a no-op: the marker
+    # from the first sweep is already on disk.
+    await publish_sync.republish_widgets_dropping_unsafe_eval()
+    assert len(fake_client.called("upload_version")) == 1
+
+    # A widget published AFTER the first sweep is also never swept again --
+    # this is a one-time remediation, not an ongoing marker check (that's the
+    # "more durable" option the originating issue deferred).
+    store.create(name="W2", content="<h1>hi 2</h1>", kind="widget", slug="w2")
+    await publish_sync.publish("w2")
+    fake_client.calls.clear()
+    await publish_sync.republish_widgets_dropping_unsafe_eval()
+    assert fake_client.called("upload_version") == []
+
+
+@pytest.mark.asyncio
+async def test_republish_writes_a_marker_at_the_store_root(store, fake_client):
+    store.create(name="W", content="<h1>hi</h1>", kind="widget", slug="w")
+    await publish_sync.publish("w")
+
+    marker = store.root / publish_sync._UNSAFE_EVAL_REPUBLISH_MARKER
+    assert not marker.exists()
+    await publish_sync.republish_widgets_dropping_unsafe_eval()
+    assert marker.exists()
+
+
+@pytest.mark.asyncio
+async def test_republish_writes_marker_even_with_no_published_widgets(store, fake_client):
+    # No widgets at all -- still marks the sweep done so an empty install
+    # doesn't re-scan its (empty) artifact store on every future restart.
+    await publish_sync.republish_widgets_dropping_unsafe_eval()
+    assert (store.root / publish_sync._UNSAFE_EVAL_REPUBLISH_MARKER).exists()
+    assert fake_client.called("upload_version") == []
+
+
+@pytest.mark.asyncio
+async def test_republish_continues_past_an_unexpected_push_failure(store, fake_client, monkeypatch):
+    # push_version itself is already best-effort against ordinary provider
+    # errors (records last_error, never raises) -- what this guards is an
+    # UNEXPECTED exception from push_version, which must still not abort the
+    # sweep before it reaches the remaining artifacts or writes the marker.
+    store.create(name="Bad", content="<p>bad</p>", kind="widget", slug="bad")
+    await publish_sync.publish("bad")
+    store.create(name="Good", content="<p>good</p>", kind="widget", slug="good")
+    await publish_sync.publish("good")
+    fake_client.calls.clear()
+
+    real_push_version = publish_sync.push_version
+
+    async def flaky_push_version(art, *, force=False):
+        if art.slug == "bad":
+            raise RuntimeError("boom")
+        return await real_push_version(art, force=force)
+
+    monkeypatch.setattr(publish_sync, "push_version", flaky_push_version)
+
+    await publish_sync.republish_widgets_dropping_unsafe_eval()
+
+    # "good" was still reached and pushed despite "bad" raising.
+    assert len(fake_client.called("upload_version")) == 1
+    # And the sweep still completed (didn't abort before the marker write).
+    assert (store.root / publish_sync._UNSAFE_EVAL_REPUBLISH_MARKER).exists()
+
+
 # ── sharing ────────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #3373.

`wrap_widget_html` no longer emits `'unsafe-eval'` or the Tailwind Play CDN in published widget documents, but that fix only takes effect the next time a widget is pushed. `push_version` returns early when the artifact's KiroCrew version hasn't moved (the 1:1 version invariant):

```python
if not force and fresh.version == pub.last_synced_kirocrew_version:
    return
```

So a widget published before the CSP change and never edited again is never re-rendered — its live document keeps `script-src ... 'unsafe-eval' https://cdn.tailwindcss.com` indefinitely. The exposure stays open on exactly the artifacts that are already public.

## Approach

Implements **Option 1** from the issue (the smaller of the two proposed remediations — Option 2, a wrapper-revision marker compared in `upstream_status`, generalises to every future wrapper change but costs a marker in every document, and is left for a follow-up):

> A one-time forced re-push over published widget artifacts (`force=True`), which re-renders each document with the current wrapper.

- `publish_sync.republish_widgets_dropping_unsafe_eval()`: lists published `widget` artifacts and force-repushes each via the existing `push_version(art, force=True)`. `push_version` is already best-effort (never raises for provider failures, records `last_error`), so a failing artifact doesn't abort the sweep — it just isn't retried *by this sweep* specifically, the same as any other push failure.
- Gated by a marker file at the artifact store's root (`ArtifactStore.root`) so it runs exactly once per install, not on every restart — a provider outage or a since-deleted publication shouldn't cost repeated wasted network calls forever; an artifact that fails here still gets a normal retry the next time it's actually edited.
- Fired as a tracked background task on gateway startup (`dashboard/server.py`'s new `_register_widget_republish_hook`, registered right next to `_register_instances_hooks`), not awaited inline — it may make one provider network call per already-published widget, so awaiting it would gate the port bind on however many publications exist, same reasoning as the Instances tunnel-revive task it sits beside.

## Changes
- `src/kiro_crew/publish_sync.py`: `republish_widgets_dropping_unsafe_eval()`.
- `src/kiro_crew/dashboard/server.py`: `_register_widget_republish_hook()`, wired into `start_dashboard`.
- `test/test_publish_sync.py`: 6 new tests (force-repush happens, non-widget/unpublished artifacts skipped, one-time-only via the marker, marker written at the store root, marker written even with nothing to push, sweep continues past an unexpected per-artifact failure and still writes the marker).
- `test/test_dashboard_server_startup_coverage.py`: 2 new tests (hook registers before `app.freeze()` without raising; on_startup fires a self-cleaning tracked background task).
- `docs/system-specs/modules/artifacts.md`: new paragraph documenting the sweep.
- `CHANGELOG.md`: entry under Unreleased.

## Test plan
- [x] `pytest test/test_publish_sync.py test/test_dashboard_server_startup_coverage.py test/test_dashboard_server_coverage.py test/test_artifacts.py -q` — 379 passed, 6 skipped (pre-existing platform skips)
- [x] `flake8` / `isort --check` on changed files — clean
- [x] `mypy` on changed files — no new errors
- [x] `scripts/docs-lint.sh` — clean