### PR TITLE
fix(cron): call record_success on CronService success path (#3428)

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -2614,6 +2614,26 @@ class CronService:
             if job.last_status != "error":
                 job.last_status = "ok"
                 job.last_error = None
+                # Reset the auto-pause budget: without this, CronService-run
+                # jobs count failures monotonically (record_failure fires on
+                # the error/timeout paths but nothing ever reset the counter
+                # here), so any job accumulating _AUTO_PAUSE_THRESHOLD
+                # transient failures over its LIFETIME — successes in
+                # between notwithstanding — silently auto-paused. Guarded by
+                # the "error" check above so the deliberately-neutral paths
+                # (governance/fire-time denials, which set last_status =
+                # "error" without counting a failure) stay neutral: a policy
+                # denial neither spends nor refills the budget. Callback
+                # paths that already called record_success() are unaffected
+                # (resetting 0 to 0 is idempotent). The _cancelled_jobs
+                # check closes a cancel race: cancel() kills the sandboxed
+                # subprocess BEFORE task.cancel(), and the gateway's
+                # cancelled branch returns None without setting last_status,
+                # so a callback returning in that window would otherwise
+                # reach this branch — and cancel() documents that it leaves
+                # consecutive_failures untouched.
+                if job.id not in self._cancelled_jobs:
+                    job.record_success()
         except Exception as exc:
             job.last_status = "error"
             job.last_error = str(exc)

--- a/test/test_cron_autopause_persist.py
+++ b/test/test_cron_autopause_persist.py
@@ -12,6 +12,7 @@ whole round-trip.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import patch
@@ -152,3 +153,130 @@ class TestAutoPausePersistence:
         assert reloaded.enabled is False
         assert reloaded.user_paused is True
         assert reloaded.auto_paused is False
+
+
+class TestExecuteSuccessResetsCounter:
+    """CronService._execute must reset the auto-pause budget on success (#3428).
+
+    Before the fix, record_failure() fired on the error/timeout paths but
+    record_success() was only ever called from the gateway callback's own
+    branches — and callback shapes that return without touching bookkeeping
+    (e.g. a script cron's Skip outcome) left the counter monotonic. A healthy
+    cron accumulating _AUTO_PAUSE_THRESHOLD transient failures over its
+    lifetime, successes in between notwithstanding, silently auto-paused.
+    """
+
+    def _job(self) -> CronJob:
+        return CronJob(
+            id="j", name="n", message="m", schedule=CronSchedule(kind="every", every_secs=60)
+        )
+
+    def test_successful_run_resets_consecutive_failures(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        job = self._job()
+        job.consecutive_failures = _AUTO_PAUSE_THRESHOLD - 1
+
+        async def ok_callback(j: CronJob) -> None:
+            return None  # returns normally, no bookkeeping of its own (Skip-like)
+
+        svc._on_job = ok_callback
+        asyncio.run(svc._execute(job))
+        assert job.last_status == "ok"
+        assert job.consecutive_failures == 0, (
+            "a successful run must refill the auto-pause budget; a monotonic "
+            "counter silently pauses healthy jobs after 5 lifetime failures"
+        )
+
+    def test_fail_then_succeed_never_auto_pauses(self, tmp_path: Path) -> None:
+        # Alternating failure/success far past the threshold in TOTAL failures:
+        # with intervening successes the job must never auto-pause.
+        svc = CronService(base_dir=tmp_path)
+        job = self._job()
+
+        async def failing(j: CronJob) -> None:
+            # Faithful to the production contract: the gateway callback counts
+            # the failure itself, then re-raises for _execute to observe.
+            j.record_failure()
+            raise RuntimeError("transient")
+
+        async def succeeding(j: CronJob) -> None:
+            return None
+
+        for _ in range(_AUTO_PAUSE_THRESHOLD * 2):
+            svc._on_job = failing
+            asyncio.run(svc._execute(job))
+            svc._on_job = succeeding
+            asyncio.run(svc._execute(job))
+        assert job.auto_paused is False
+        assert job.enabled is True
+        assert job.consecutive_failures == 0
+
+    def test_callback_reported_error_does_not_reset(self, tmp_path: Path) -> None:
+        # A callback that signals failure by mutating the job (command/script
+        # contract) — and the deliberately-neutral governance-denial paths,
+        # which use the same last_status="error" shape — must NOT have the
+        # counter reset by _execute.
+        svc = CronService(base_dir=tmp_path)
+        job = self._job()
+        job.consecutive_failures = 3
+
+        async def mutating_error(j: CronJob) -> None:
+            j.last_status = "error"
+            j.last_error = "policy denial or command failure"
+
+        svc._on_job = mutating_error
+        asyncio.run(svc._execute(job))
+        assert job.last_status == "error"
+        assert job.consecutive_failures == 3
+
+    def test_raising_callback_does_not_reset(self, tmp_path: Path) -> None:
+        svc = CronService(base_dir=tmp_path)
+        job = self._job()
+        job.consecutive_failures = 4
+
+        async def raising(j: CronJob) -> None:
+            raise RuntimeError("boom")
+
+        svc._on_job = raising
+        asyncio.run(svc._execute(job))
+        assert job.last_status == "error"
+        assert job.consecutive_failures == 4
+
+    def test_success_lifts_auto_pause_via_execute(self, tmp_path: Path) -> None:
+        # Manual "Run Now" on an auto-paused job that then succeeds must lift
+        # the pause (record_success semantics reached from the _execute path).
+        svc = CronService(base_dir=tmp_path)
+        job = self._job()
+        for _ in range(_AUTO_PAUSE_THRESHOLD):
+            job.record_failure()
+        assert job.auto_paused is True
+
+        async def succeeding(j: CronJob) -> None:
+            return None
+
+        svc._on_job = succeeding
+        asyncio.run(svc._execute(job))
+        assert job.auto_paused is False
+        assert job.enabled is True
+        assert job.consecutive_failures == 0
+
+    def test_cancelled_run_does_not_reset_counter(self, tmp_path: Path) -> None:
+        # Cancel race: cancel() kills the sandboxed subprocess BEFORE
+        # task.cancel(), and the gateway's cancelled branch returns None
+        # without setting last_status — so the callback can return normally
+        # while the cancel marker is set. cancel() documents that it leaves
+        # consecutive_failures untouched; the ok-branch reset must not fire.
+        svc = CronService(base_dir=tmp_path)
+        job = self._job()
+        job.consecutive_failures = 3
+
+        async def cancelled_shape(j: CronJob) -> None:
+            return None  # gateway cancelled branch: no bookkeeping, no last_status
+
+        svc._on_job = cancelled_shape
+        svc._cancelled_jobs.add(job.id)
+        try:
+            asyncio.run(svc._execute(job))
+        finally:
+            svc._cancelled_jobs.discard(job.id)
+        assert job.consecutive_failures == 3


### PR DESCRIPTION
# fix(cron): call record_success on CronService success path

## Problem

`CronJob.consecutive_failures` never decreases for crons executed by `CronService`: the error and timeout paths call `record_failure()`, but nothing on the success path ever called `record_success()`. Callback shapes that do no bookkeeping of their own — most visibly a script cron's `Skip` outcome, which returns `None` without touching `last_status` — leave the counter monotonic. Any healthy cron that accumulates 5 transient failures over its **lifetime** (model 5xx, rate limits, ENOSPC), regardless of intervening successes, auto-pauses silently: it stops firing while still appearing in `cron_list` and the dashboard.

Live evidence from the issue: a dispatcher cron with 7 consecutive successful runs still carrying `consecutive_failures = 3`.

## Why it matters

Long-lived pipeline crons are on a one-way trip to being silently disabled. Transient failures are normal, so every perpetual cron eventually trips the threshold and quietly stops — with no alert and no workaround before it trips (pausing/resuming a healthy job does not reset the counter; `_enable_job_locked` only resets it when the job is *already* auto-paused).

## Fix (symptom → root cause → change)

- **Symptom**: healthy crons auto-pause after 5 lifetime transient failures.
- **Root cause**: `CronService._execute` owns part of the failure accounting (timeout path) but none of the success accounting; the reset lived only in `slack/gateway.py` callback branches, and not every callback shape reaches one (script `Skip` does not).
- **Change**: call `job.record_success()` on `_execute`'s ok branch, with two guards:
  - the existing `last_status != "error"` check keeps the **deliberately-neutral** governance/fire-time denial paths neutral (they set `last_status="error"` without counting a failure — a policy denial neither spends nor refills the budget, per `docs/system-specs/modules/learn-cron-dashboard.md`);
  - a `job.id not in self._cancelled_jobs` check closes a cancel race: `cancel()` kills the sandboxed subprocess *before* `task.cancel()`, and the gateway's cancelled branch returns `None` without setting `last_status`, so a callback returning in that window would otherwise reach the ok branch — while `cancel()` documents that it leaves `consecutive_failures` untouched.

Callback paths that already call `record_success()` are unaffected (resetting 0 to 0 is idempotent). The existing `record_success()` method correctly lifts auto-pause and re-derives `enabled`, and `_merge_job_result` already persists `consecutive_failures` + `auto_paused`.

## Tests

6 new tests in `test/test_cron_autopause_persist.py` (`TestExecuteSuccessResetsCounter`); 3 proven failing on base before the fix:

- `test_successful_run_resets_consecutive_failures` — a Skip-like no-bookkeeping callback resets the counter (fails on base)
- `test_fail_then_succeed_never_auto_pauses` — 10 total failures with intervening successes never auto-pause (fails on base)
- `test_success_lifts_auto_pause_via_execute` — manual Run-Now success on an auto-paused job lifts the pause via the `_execute` path (fails on base)
- `test_callback_reported_error_does_not_reset` — the `last_status="error"` shapes (command failure, policy denial) stay neutral
- `test_raising_callback_does_not_reset` — a raising callback does not reset
- `test_cancelled_run_does_not_reset_counter` — the cancel race does not reset the counter

Full local gates green: isort, flake8, mypy (941 files), and the cron-scoped suite (1433 passed). Full pytest run: only pre-existing environment failures (sandbox `CLONE_NEWUSER` EPERM on this host), reproduced identically on clean base; zero cron-related failures.

## Manual verification

N/A — unit coverage exercises the exact `_execute` paths (success, error-by-mutation, error-by-raise, cancel marker); no UI or cross-process behavior involved.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (cron bookkeeping); no rendered UI delta.

Closes #3428
