### PR TITLE
fix: allow Asana MCP OAuth authorization

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -5343,6 +5343,7 @@ _OAUTH_AUTHORIZATION_ENDPOINTS: frozenset[tuple[str, str]] = frozenset(
     {
         ("accounts.google.com", "/o/oauth2/v2/auth"),
         ("api.notion.com", "/v1/oauth/authorize"),
+        ("app.asana.com", "/-/oauth_authorize"),
         ("auth.atlassian.com", "/authorize"),
         ("github.com", "/login/oauth/authorize"),
         ("linear.app", "/oauth/authorize"),

--- a/test/oauth_url_corpus.py
+++ b/test/oauth_url_corpus.py
@@ -26,6 +26,19 @@ from __future__ import annotations
 
 # Each item: (provider_label, authorization_url)
 LEGIT_OAUTH_URLS: list[tuple[str, str]] = [
+    # Asana V2 MCP OAuth authorization + PKCE.
+    # developers.asana.com/docs/integrating-with-asanas-mcp-server
+    (
+        "asana-mcp-v2",
+        "https://app.asana.com/-/oauth_authorize"
+        "?client_id=1234567890123456"
+        "&redirect_uri=http%3A%2F%2F127.0.0.1%3A33418%2Fcallback"
+        "&response_type=code"
+        "&resource=https%3A%2F%2Fmcp.asana.com%2Fv2"
+        "&state=af0ifjsldkj"
+        "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        "&code_challenge_method=S256",
+    ),
     # GitHub OAuth apps + PKCE.
     # docs.github.com/.../authorizing-oauth-apps
     (


### PR DESCRIPTION
## Problem / Motivation

Kiro Crew rejects Asana MCP OAuth authorization URLs instead of recognizing
them as legitimate OAuth URLs. This prevents the Asana MCP authentication flow
from being surfaced correctly.

## Why it matters

Users connecting Asana's V2 MCP server cannot complete OAuth authorization
through Kiro Crew. The authorization URL is treated as containing credentials
because Asana's documented endpoint is missing from the endpoint-aware security
allowlist.

## What changed (motivation → approach → change)

Asana uses the documented authorization endpoint
`https://app.asana.com/-/oauth_authorize`. The centralized OAuth security gate
already recognizes the required OAuth query parameters, including `resource`,
but did not recognize this endpoint.

This change:

- adds `app.asana.com/-/oauth_authorize` to the exact OAuth authorization
  endpoint allowlist;
- adds an Asana V2 MCP OAuth and PKCE URL to the legitimate OAuth regression
  corpus, including `resource`, `state`, and an S256 `code_challenge`.

## Tests

- Added the Asana V2 MCP authorization URL to the shared legitimate OAuth URL
  corpus.
- `test/test_mcp_oauth_banner.py test/test_display_time_redaction.py`: 94 passed.
- `test/test_security.py::TestOAuthAuthorizationUrlRedaction`: 27 passed.
- `isort --check-only src/kiro_crew/security.py test/oauth_url_corpus.py`: passed.
- `flake8 src/kiro_crew/security.py test/oauth_url_corpus.py`: passed.
- Black check for `test/oauth_url_corpus.py`: passed.
- `git diff --check`: passed.

Black cannot safely parse the repository's Python 3.14-targeted
`security.py` under the available Python 3.12 runtime. The same failure
reproduces against the unchanged `main` version of that file.

## Manual verification

N/A — the affected behavior is the centralized OAuth URL classification path,
which is covered by the OAuth security, banner, and display-time redaction
tests.

## Related Issues

N/A — no related issue identified.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality
      (targeted affected suites pass; the complete repository suite was not run)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable; no documentation change required)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->